### PR TITLE
feat(backend): add workshop editors, render screens, and nodes

### DIFF
--- a/docs/superpowers/specs/2026-08-12-bot-workshop-openapi-inventory.md
+++ b/docs/superpowers/specs/2026-08-12-bot-workshop-openapi-inventory.md
@@ -154,7 +154,7 @@
 | 101 | flow | 任务护航 DAG/YAML 编排 | `GET/PUT /openapi/v1/bots/flow/{bot_id}` | 新增 | 未开工 | P2 | 任务护航团队牵头，BCS 提供 State Machine 正式 Service API/OpenAPI Contract；不得让工坊直调内部 `/api` |
 | 102 | flow | 工作流执行历史 | `GET /openapi/v1/bots/flow/{bot_id}/runs` | 新增 | 未开工 | P2 | 同 #101；任务护航团队负责运行语义，BCS 提供状态机契约，A/B 线仅配合上下文和联调 |
 | 103 | channels | 渠道配置 CRUD | `GET/POST/PUT/DELETE /openapi/v1/bots/channels/{bot_id}` | 新增 | 未开工 | P2 | 内部 `ChannelServiceProtocol` 与 `/api/channels` CRUD 已有；公开面缺失，且需先收敛 tenant/owner/bot guard |
-| 104 | nodes | 节点 | `GET /openapi/v1/bots/nodes/{bot_id}` | 新增 | 未开工 | P2 | Engine 内部 `GET /api/nodes` 与 capability 已有；公开字段 Contract/relay 尚缺 |
+| 104 | nodes | 节点 | `GET /openapi/v1/bots/{bot_id}/nodes` | 新增 | 已开发 | P2 | 只对齐前端现有只读能力：转发 Engine `GET /api/nodes`，支持 status/platform/limit/offset；owner/editor 与 stage 门禁先于设备调用，内部 metadata/raw 不出公共契约 |
 | 105 | render-screens | 副屏 | `GET/POST /openapi/v1/bots/{bot_id}/render-screens`、`PATCH/DELETE /openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}` | 新增 | 已开发 | P2 | GET 供已认证查看者及持 Bot grant 的 App 渲染副屏；写操作仅真人且要求实时 Bot Editor Member+；记录 ID 回绑 Bot/Owner/env |
 | 106 | spaces | 当前用户空间列表（切换器） | `GET /openapi/v1/spaces` | 新增 | 未开工 | P3 | `SpaceScopeProtocol` prod；工坊只 own list + 迁移；**唯一不带 `/bots` 中段** |
 | 107 | migrate | 个人↔团队迁移 | `POST /openapi/v1/bots/migrate/{bot_id}` | 新增 | 未开工 | P3 | body `{target_space}`；校验编辑者是否目标空间成员，非成员移除 |

--- a/docs/superpowers/specs/2026-08-12-bot-workshop-openapi-inventory.md
+++ b/docs/superpowers/specs/2026-08-12-bot-workshop-openapi-inventory.md
@@ -155,7 +155,7 @@
 | 102 | flow | 工作流执行历史 | `GET /openapi/v1/bots/flow/{bot_id}/runs` | 新增 | 未开工 | P2 | 同 #101；任务护航团队负责运行语义，BCS 提供状态机契约，A/B 线仅配合上下文和联调 |
 | 103 | channels | 渠道配置 CRUD | `GET/POST/PUT/DELETE /openapi/v1/bots/channels/{bot_id}` | 新增 | 未开工 | P2 | 内部 `ChannelServiceProtocol` 与 `/api/channels` CRUD 已有；公开面缺失，且需先收敛 tenant/owner/bot guard |
 | 104 | nodes | 节点 | `GET /openapi/v1/bots/{bot_id}/nodes` | 新增 | 已开发 | P2 | 只对齐前端现有只读能力：转发 Engine `GET /api/nodes`，支持 status/platform/limit/offset；owner/editor 与 stage 门禁先于设备调用，内部 metadata/raw 不出公共契约 |
-| 105 | render-screens | 副屏 | `GET/POST /openapi/v1/bots/{bot_id}/render-screens`、`PATCH/DELETE /openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}` | 新增 | 已开发 | P2 | GET 供已认证查看者及持 Bot grant 的 App 渲染副屏；写操作仅真人且要求实时 Bot Editor Member+；记录 ID 回绑 Bot/Owner/env |
+| 105 | render-screens | 副屏 | `GET/POST /openapi/v1/bots/{bot_id}/render-screens`、`PATCH/DELETE /openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}` | 新增 | 已开发 | P2 | 真人或持 Bot grant 的 App 均可调用；写操作仍要求委托用户具备实时 Bot Editor Member+；记录 ID 回绑 Bot/Owner/env |
 | 106 | spaces | 当前用户空间列表（切换器） | `GET /openapi/v1/spaces` | 新增 | 未开工 | P3 | `SpaceScopeProtocol` prod；工坊只 own list + 迁移；**唯一不带 `/bots` 中段** |
 | 107 | migrate | 个人↔团队迁移 | `POST /openapi/v1/bots/migrate/{bot_id}` | 新增 | 未开工 | P3 | body `{target_space}`；校验编辑者是否目标空间成员，非成员移除 |
 

--- a/docs/superpowers/specs/2026-08-12-bot-workshop-openapi-inventory.md
+++ b/docs/superpowers/specs/2026-08-12-bot-workshop-openapi-inventory.md
@@ -155,7 +155,7 @@
 | 102 | flow | 工作流执行历史 | `GET /openapi/v1/bots/flow/{bot_id}/runs` | 新增 | 未开工 | P2 | 同 #101；任务护航团队负责运行语义，BCS 提供状态机契约，A/B 线仅配合上下文和联调 |
 | 103 | channels | 渠道配置 CRUD | `GET/POST/PUT/DELETE /openapi/v1/bots/channels/{bot_id}` | 新增 | 未开工 | P2 | 内部 `ChannelServiceProtocol` 与 `/api/channels` CRUD 已有；公开面缺失，且需先收敛 tenant/owner/bot guard |
 | 104 | nodes | 节点 | `GET /openapi/v1/bots/nodes/{bot_id}` | 新增 | 未开工 | P2 | Engine 内部 `GET /api/nodes` 与 capability 已有；公开字段 Contract/relay 尚缺 |
-| 105 | render-screens | 副屏 | `GET /openapi/v1/bots/render-screens/{bot_id}` | 新增 | 未开工 | P2 | 内部 `RenderScreenServiceProtocol` 与 `/api/bot-render-screens` CRUD 已有；公开读/写范围和鉴权 Contract 尚缺 |
+| 105 | render-screens | 副屏 | `GET/POST /openapi/v1/bots/{bot_id}/render-screens`、`PATCH/DELETE /openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}` | 新增 | 已开发 | P2 | GET 供已认证查看者及持 Bot grant 的 App 渲染副屏；写操作仅真人且要求实时 Bot Editor Member+；记录 ID 回绑 Bot/Owner/env |
 | 106 | spaces | 当前用户空间列表（切换器） | `GET /openapi/v1/spaces` | 新增 | 未开工 | P3 | `SpaceScopeProtocol` prod；工坊只 own list + 迁移；**唯一不带 `/bots` 中段** |
 | 107 | migrate | 个人↔团队迁移 | `POST /openapi/v1/bots/migrate/{bot_id}` | 新增 | 未开工 | P3 | body `{target_space}`；校验编辑者是否目标空间成员，非成员移除 |
 

--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -2078,9 +2078,53 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
   `_SENSITIVE_NAME_PARTS`.** No status code, response body, or envelope shape
   changed.
 
-
 ## Changelog
 
 - **2026-08-20** — Added authenticated Bot catalog reads at
   `GET /openapi/v1/bots/catalog/search` and `/discover`. User and App
   principals see the same allowlisted public projection.
+
+- **2026-08-19 — Bot Editors CRUD.** The public surface now exposes
+  `GET/POST /openapi/v1/bots/{bot_id}/editors`,
+  `PATCH/DELETE /openapi/v1/bots/{bot_id}/editors/{editor_id}`, and
+  `DELETE /openapi/v1/bots/{bot_id}/editors/me`. All five operations require a
+  human caller; an application grant authorizes use of a Bot, not enumeration
+  or mutation of its human editor set. The acting user remains the required
+  `user_id` query parameter, while a create body names its target as
+  `editor_user_id`. Roles are the closed `admin | member` enum. Reads require
+  Member access; mutations require Owner/Admin, and a non-owner Admin leaves
+  through `/me` rather than deleting their own record through the admin route.
+  Every `{editor_id}` mutation rebinds the record to the addressed Bot primary
+  key, Bot id, Owner and environment before writing; mismatches are the same
+  fixed 404 as absence. When a Bot carries a Team Space reference, adding or
+  promoting an editor requires that user to remain a live member of the Space;
+  unknown Space references fail closed. The Owner remains outside the editor
+  table, so this contract intentionally permits zero or multiple collaborator
+  Admins and does not couple membership changes to the draft edit lock.
+
+- **2026-08-19 — Bot Workshop adopts the canonical Spaces contract.** Bot
+  creation, local-workflow operations and `GET /openapi/v1/bots/all` now use a
+  numeric Space primary key for `space_id` / `X-Space-Id`; `space_code` remains
+  a separate stable external code. Inventory cards expose the same
+  `space_id`, `space_code`, `space_name`, `space_type` shape as the Spaces API,
+  replacing the provisional string `space_id`, `name`, `kind` shape. This is a
+  coordinated breaking schema correction and the Gateway artifact is published
+  through the compatibility gate with `--allow-breaking`. A Team Space view
+  includes every supported cloud Bot assigned to that Space across Bot Owners;
+  Space membership grants visibility only. Bot Owner/Editor relations still
+  decide actions, Team Editors must remain live Space members, Personal Spaces
+  allow Editors, and Bot Owners retain their Bot permissions after leaving a
+  Team Space.
+
+- **2026-08-19 — Render-screen configuration CRUD.** Added
+  `GET/POST /openapi/v1/bots/{bot_id}/render-screens` and
+  `PATCH/DELETE /openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}`.
+  The collection read returns the non-sensitive component-library name → UMD
+  CDN URL mappings needed to render a Bot's side panels. An authenticated human
+  may read an explicitly addressed Bot without being its Editor; an application
+  may read only while a live grant covers that Bot. Mutations require a human
+  caller and the Bot's live effective Editor permission at `MEMBER` or above,
+  including the Team Space membership recheck. Every public record id is bound
+  back to the addressed Bot id, Owner and environment before update or delete;
+  mismatches use the same fixed 404 as absence. Request bodies are strict and
+  accept only HTTP(S) CDN URLs.

--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -70,7 +70,8 @@ The work therefore splits into **three tracks**:
 - **Track C — Engine (runtime) surface.** _Added 2026-07-30._ Wrap the engine
   adapter's client-facing HTTP behind `/openapi/v1/bots/{bot_id}/…`, and replace
   the `get_device_connection` hand-off with one sanitised socket-info endpoint.
-  **16 endpoints — implemented, PR #630.**
+  **18 endpoints across six groups — implemented** (PR #630 baseline; engine
+  restart and read-only nodes added later).
 
 > ⚠️ **The one confusion to avoid:** "isolation Stage N is done" does **not**
 > mean any API endpoint was implemented. A Track A stage is plumbing only (the
@@ -159,7 +160,7 @@ _Ordered by priority tier._
 | identity | lucas-xzp | P2 | `openapi_v1/identity/router.py` *(stub)* | ⬜ TODO | bots isolation (Stage 1 ✅) |
 | skills | totalfrank + lucas-xzp | P3 | `openapi_v1/skills/router.py` | 🔧 **IMPLEMENTATION + CI COMPLETE; RELEASE PENDING** — six ratified Local Skill operations | #725 cleanup-work DDL must deploy before code; [pre-production acceptance runbook](skills-track-b-preprod-acceptance.md) remains **PRE-PROD PENDING** |
 
-### Track C — Engine (runtime) surface (5 of 5 groups implemented — PR #630)
+### Track C — Engine (runtime) surface (6 of 6 groups implemented)
 _All groups depend only on **bots isolation (Stage 1 ✅)** — no Track A stage, no
 DDL. Full ruling and per-endpoint mapping in
 **[`engine-surface.md`](engine-surface.md)**._
@@ -171,6 +172,7 @@ DDL. Full ruling and per-endpoint mapping in
 | connection | 1 | ⬜ unassigned | P1 | `openapi_v1/engine_runtime/connection/` | ✅ **IMPLEMENTED — PR #630** |
 | approvals | 3 | ⬜ unassigned | P2 | `openapi_v1/engine_runtime/approvals/` | ✅ **IMPLEMENTED — PR #630** |
 | models | 2 | ⬜ unassigned | P2 | `openapi_v1/engine_runtime/models/` | ✅ **IMPLEMENTED — PR #630** |
+| nodes | 1 | joseph | P2 | `openapi_v1/engine_runtime/nodes/` | ✅ **IMPLEMENTED — 2026-08-19**; read-only list matching the frontend |
 
 > **Scope rule (why only these).** Wrap engine HTTP the frontend reaches
 > **directly** through proxypass (`src/frontend/src/requestConfig.ts:189-205`).
@@ -178,7 +180,9 @@ DDL. Full ruling and per-endpoint mapping in
 > the `routines` category), `/api/file`, `/api/skills`, `/api/mcp`,
 > `/api/resource-materializations`, `/api/bash`, `/api/bot/config`,
 > `/api/work-items` — are already fronted by a backend contract and stay out.
-> AICoding-only routes stay out. **WebSockets are not wrapped**: the new
+> The read-only `/api/nodes` inventory is wrapped because the current frontend
+> reaches it directly; no node write operations exist in either frontend or
+> Engine HTTP today. AICoding-only routes stay out. **WebSockets are not wrapped**: the new
 > `…/connection` endpoint returns one complete socket URL, credential included,
 > and the caller builds the connection itself.
 >
@@ -909,7 +913,7 @@ group's `owner_entity_id` locator predated `owner_id`; it was reconciled to
 addresses still publish the old name (spec Open Question 1, closed).
 
 `tests/…/openapi_v1/engine_runtime/test_operator_access.py` sweeps the
-operator matrix across all sixteen operations;
+operator matrix across all runtime operations covered by the shared sweep;
 `…/test_stage_addressing.py` pins the stage behaviour and asserts the two
 parameters sit on exactly the operations listed above — optional, in the query,
 and on no retiring address that did not already have them;
@@ -1479,7 +1483,7 @@ later falls outside it by construction.
 > a tenant-scoped read under the default tenant is a data-isolation failure
 > rather than a missing log.
 
-### ⬜ unassigned · Track C — engine runtime (16 endpoints)
+### Track C — engine runtime (18 endpoints)
 Not a Track B category — these wrap the **engine adapter** on the bot's device
 rather than a backend service. The per-endpoint checklist, the engine route each
 one maps to, and the ruling on the ~72 engine routes that are *not* wrapped live
@@ -1488,8 +1492,9 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
 | Group | Endpoints | Public paths |
 |---|---|---|
 | sessions | 7 | `/openapi/v1/bots/{bot_id}/sessions…` — owner/collaborator operators |
-| engine | 3 | `/openapi/v1/bots/{bot_id}/engine/{status,capabilities,available}` |
+| engine | 4 | `/openapi/v1/bots/{bot_id}/engine/{status,capabilities,available,restart}` |
 | models | 2 | `/openapi/v1/bots/{bot_id}/models`, `…/models/{model_id}` |
+| nodes | 1 | `/openapi/v1/bots/{bot_id}/nodes` — read-only node inventory |
 | approvals | 3 | `/openapi/v1/bots/{bot_id}/approvals/mode` (GET/PUT), `…/modes` |
 | connection | 1 | `/openapi/v1/bots/{bot_id}/connection` — complete WS URL, replaces `get_device_connection` |
 
@@ -1517,11 +1522,10 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
 7. **Cross-tenant external identity settled ([#556](https://github.com/inclusionAI/Avernet/issues/556))** — Passport, auth
    relationships and BCN carry a tenant axis, so the BCN sync can be re-enabled
    on the public path. — _⬜ (added 2026-07-29; gates enabling multi-tenancy)._
-8. **Track C:** the five engine-runtime groups (16 endpoints) implemented,
+8. **Track C:** the six engine-runtime groups (18 endpoints) implemented,
    owner-scoped and capability-aware, and `…/connection` returning socket URLs
    so no external caller ever sees a proxypass target or a raw device token.
-   — _✅ 5 of 5 (PR #630). Like every other category it answers 401 until item 6
-   lands; the singlebox E2E flow is blocked on the same event._
+   — _✅ 6 of 6 (PR #630 baseline; later engine restart and nodes additions)._
 
 ---
 
@@ -1846,6 +1850,12 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
   and on `route_security.yaml` admitting this surface's real callers; and `app` /
   `access_key` callers 401 until somebody rules on what they own. SDD:
   `src/backend/specs/2026-07-30-gateway-principal-verifier/`.
+- **2026-08-19** — **Read-only Node OpenAPI added.** The frontend and Engine
+  currently support only `GET /api/nodes`, so the public API adds exactly
+  `GET /openapi/v1/bots/{bot_id}/nodes`, with the same owner/editor, grant and
+  stage gates as the other runtime groups. It forwards `status`, `platform`,
+  `limit` and `offset`, publishes only stable node fields, and does not invent
+  register/unregister/status-write operations.
 - **2026-07-30** — **Track C implemented (PR #630)** — all 16 engine-runtime
   endpoints across five groups, plus `core/engine_runtime/` (the relay and the
   connection service) and its Service API Protocols. Seven things worth knowing

--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -2097,10 +2097,10 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
 - **2026-08-19 — Bot Editors CRUD.** The public surface now exposes
   `GET/POST /openapi/v1/bots/{bot_id}/editors`,
   `PATCH/DELETE /openapi/v1/bots/{bot_id}/editors/{editor_id}`, and
-  `DELETE /openapi/v1/bots/{bot_id}/editors/me`. All five operations require a
-  human caller; an application grant authorizes use of a Bot, not enumeration
-  or mutation of its human editor set. The acting user remains the required
-  `user_id` query parameter, while a create body names its target as
+  `DELETE /openapi/v1/bots/{bot_id}/editors/me`. All five operations admit an
+  application with a live grant on the addressed Bot; the App acts with the
+  delegating user's current permission, re-adjudicated on every request. The
+  acting user remains the required `user_id` query parameter, while a create body names its target as
   `editor_user_id`. Roles are the closed `admin | member` enum. Reads require
   Member access; mutations require Owner/Admin, and a non-owner Admin leaves
   through `/me` rather than deleting their own record through the admin route.
@@ -2132,9 +2132,9 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
   The collection read returns the non-sensitive component-library name → UMD
   CDN URL mappings needed to render a Bot's side panels. An authenticated human
   may read an explicitly addressed Bot without being its Editor; an application
-  may read only while a live grant covers that Bot. Mutations require a human
-  caller and the Bot's live effective Editor permission at `MEMBER` or above,
-  including the Team Space membership recheck. Every public record id is bound
+  may call every operation only while a live grant covers that Bot. Mutations
+  require the delegating user's live effective Editor permission at `MEMBER` or
+  above, including the Team Space membership recheck. Every public record id is bound
   back to the addressed Bot id, Owner and environment before update or delete;
   mismatches use the same fixed 404 as absence. Request bodies are strict and
   accept only HTTP(S) CDN URLs.

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -1365,9 +1365,9 @@ domain —— `bots` 未声明 `protocols`，因此只服务 HTTP 平面 —— 
 - **2026-08-19 —— Bot Editors 协作者 CRUD。** 公共面新增
   `GET/POST /openapi/v1/bots/{bot_id}/editors`、
   `PATCH/DELETE /openapi/v1/bots/{bot_id}/editors/{editor_id}` 与
-  `DELETE /openapi/v1/bots/{bot_id}/editors/me`。五个操作均只允许真人调用；
-  App grant 只授权使用 Bot，不授权枚举或修改真人协作者集合。当前调用人仍通过必填的
-  `user_id` query 参数表达，新增目标成员则在 body 中使用 `editor_user_id`。角色收紧为
+  `DELETE /openapi/v1/bots/{bot_id}/editors/me`。五个操作都允许持有目标 Bot 有效 grant
+  的 App 调用；App 以委托用户的实时权限执行，并在每次请求重新判定。当前调用人仍通过
+  必填的 `user_id` query 参数表达，新增目标成员则在 body 中使用 `editor_user_id`。角色收紧为
   `admin | member` 闭集。读取需要 Member 权限，增删改需要 Owner/Admin；非 Owner 的
   Admin 要退出时必须调用 `/me`，不能通过管理删除接口删掉自己。所有带 `{editor_id}`
   的写操作都会在执行前把记录重新绑定到被寻址 Bot 的主键、Bot id、Owner 和环境，任一
@@ -1390,8 +1390,8 @@ domain —— `bots` 未声明 `protocols`，因此只服务 HTTP 平面 —— 
   `GET/POST /openapi/v1/bots/{bot_id}/render-screens` 与
   `PATCH/DELETE /openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}`。
   GET 返回副屏渲染所需的“组件库名称 → UMD CDN URL”非敏感映射：已认证真人可读取
-  显式寻址的 Bot，不要求 Editor；App 只有在该 Bot 存在有效 grant 时才能读取。写操作
-  只允许真人，并要求 Bot 的实时有效 Editor 权限达到 `MEMBER+`，Team Editor 会同步
+  显式寻址的 Bot，不要求 Editor；App 只有在该 Bot 存在有效 grant 时才能调用。写操作
+  要求委托用户的实时有效 Editor 权限达到 `MEMBER+`，Team Editor 会同步
   复核当前 Space 成员身份。所有公开 `render_screen_id` 在修改或删除前都会重新绑定到
   当前 Bot id、Owner 和环境，任一不符均返回与不存在相同的固定 404。请求 body 为严格
   模型，CDN 地址只接受 HTTP(S) URL。

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -1351,6 +1351,40 @@ domain —— `bots` 未声明 `protocols`，因此只服务 HTTP 平面 —— 
   **新记为待办：** 没有任何跨仓测试钉住这份契约，任一侧改字段名都会让两边测试保持绿色
   而线上全 401。整套测试 10204 通过 / 3 跳过。SDD：
   `src/backend/specs/2026-08-02-public-api-user-only-principal/`。
+
+- **2026-08-19 —— Bot Editors 协作者 CRUD。** 公共面新增
+  `GET/POST /openapi/v1/bots/{bot_id}/editors`、
+  `PATCH/DELETE /openapi/v1/bots/{bot_id}/editors/{editor_id}` 与
+  `DELETE /openapi/v1/bots/{bot_id}/editors/me`。五个操作均只允许真人调用；
+  App grant 只授权使用 Bot，不授权枚举或修改真人协作者集合。当前调用人仍通过必填的
+  `user_id` query 参数表达，新增目标成员则在 body 中使用 `editor_user_id`。角色收紧为
+  `admin | member` 闭集。读取需要 Member 权限，增删改需要 Owner/Admin；非 Owner 的
+  Admin 要退出时必须调用 `/me`，不能通过管理删除接口删掉自己。所有带 `{editor_id}`
+  的写操作都会在执行前把记录重新绑定到被寻址 Bot 的主键、Bot id、Owner 和环境，任一
+  不符都返回与不存在完全相同的固定 404。Bot 关联 Team Space 时，新增或调整角色前要求
+  目标用户仍是该 Space 的有效成员；无法解析的 Space 引用按 fail-closed 拒绝。Owner
+  不存放在 editor 表中，因此当前契约有意允许零个或多个协作者 Admin，也不把成员变更
+  绑定到草稿 edit lock。
+
+- **2026-08-19 —— Bot 工坊接入 Spaces 正式契约。** Bot 创建、本地 Bot 工作流以及
+  `GET /openapi/v1/bots/all` 的 `space_id` / `X-Space-Id` 统一改为 Space 数值主键，
+  `space_code` 继续作为独立且稳定的外部编码。工坊卡片与 Spaces API 对齐，返回
+  `space_id`、`space_code`、`space_name`、`space_type`，替换临时的字符串
+  `space_id`、`name`、`kind` 结构。这是一次协调后的 breaking 契约修正，Gateway
+  产物通过兼容性闸门并显式使用 `--allow-breaking` 发布。Team Space 工坊会展示该
+  Space 下所有受支持的云端 Bot，不再按 Bot Owner 过滤；Space 成员关系只决定可见性，
+  实际操作仍由 Bot Owner/Editor 决定。Team Editor 必须保持有效 Space 成员身份，
+  Personal Space 允许 Editor，Bot Owner 离开 Team Space 后仍保留其 Bot 权限。
+
+- **2026-08-19 —— 副屏配置 CRUD。** 新增
+  `GET/POST /openapi/v1/bots/{bot_id}/render-screens` 与
+  `PATCH/DELETE /openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}`。
+  GET 返回副屏渲染所需的“组件库名称 → UMD CDN URL”非敏感映射：已认证真人可读取
+  显式寻址的 Bot，不要求 Editor；App 只有在该 Bot 存在有效 grant 时才能读取。写操作
+  只允许真人，并要求 Bot 的实时有效 Editor 权限达到 `MEMBER+`，Team Editor 会同步
+  复核当前 Space 成员身份。所有公开 `render_screen_id` 在修改或删除前都会重新绑定到
+  当前 Bot id、Owner 和环境，任一不符均返回与不存在相同的固定 404。请求 body 为严格
+  模型，CDN 地址只接受 HTTP(S) URL。
 - **2026-08-03** —— **`/openapi/v1/bots` 路径规范化 + 删除 channels。**
   每个组件的路由现在都位于 `/openapi/v1/bots/<component>/…` 之下，`{bot_id}` 作为组件
   **之内**的第一段 —— 见新增的**寻址规则**一节，新增组件前应先读它。此前并存三种形态，而

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -60,7 +60,8 @@ _这是一份"活文档"，用于协调跨多个会话交付公共 `/openapi/v1`
   详见其看板行。
 - **Track C —— Engine（运行时）面。** _2026-07-30 新增。_ 把 engine adapter 面向
   客户端的 HTTP 包装到 `/openapi/v1/bots/<component>/{bot_id}/…` 之下，并用一个净化过的
-  socket 信息端点取代 `get_device_connection` 的移交。**16 个端点 —— 已实现，PR #630。**
+  socket 信息端点取代 `get_device_connection` 的移交。**当前六组共 18 个端点，均已实现**
+  （PR #630 为基线，后续增加 engine restart 与只读 nodes）。
 
 > ⚠️ **唯一需要避免的误解：** "隔离 Stage N 已完成"**并不**意味着任何 API 端点被实现了。
 > Track A 的每个阶段都只是底层管道（可复用机制 + 该类别的记录）。API 端点落在
@@ -140,7 +141,7 @@ _按优先级分层排序。_
 | identity | lucas-xzp | P2 | `openapi_v1/identity/router.py` | 🔧 IN PROGRESS（PARTIAL）— 3 handler 全接通但 NOT PUBLIC-READY | bots 隔离（Stage 1 ✅）；Track B 3 端点接通；待 gateway principal seam + tenant resolver 落地后才可对外 |
 | skills | totalfrank + lucas-xzp | P3 | `openapi_v1/skills/router.py` | 🔧 **实现 + CI 完成；发布待定**——六个已定案 Local Skill 操作 | #725 cleanup-work DDL 必须先于代码部署；[预发验收 runbook](skills-track-b-preprod-acceptance.md) 仍为 **PRE-PROD PENDING** |
 
-### Track C —— Engine（运行时）面（5 组已全部实现 —— PR #630）
+### Track C —— Engine（运行时）面（6 组已全部实现）
 _所有组只依赖 **bots 隔离（Stage 1 ✅）** —— 没有 Track A 阶段，没有 DDL。
 完整裁定与逐端点映射见
 **[`engine-surface.zh-CN.md`](engine-surface.zh-CN.md)**。_
@@ -152,12 +153,15 @@ _所有组只依赖 **bots 隔离（Stage 1 ✅）** —— 没有 Track A 阶�
 | connection | 1 | ⬜ 未分配 | P1 | `openapi_v1/engine_runtime/connection/` | ✅ **已实现 —— PR #630** |
 | approvals | 3 | ⬜ 未分配 | P2 | `openapi_v1/engine_runtime/approvals/` | ✅ **已实现 —— PR #630** |
 | models | 2 | ⬜ 未分配 | P2 | `openapi_v1/engine_runtime/models/` | ✅ **已实现 —— PR #630** |
+| nodes | 1 | joseph | P2 | `openapi_v1/engine_runtime/nodes/` | ✅ **已实现 —— 2026-08-19**；只读列表，与当前前端保持一致 |
 
 > **范围规则（为什么只有这些）。** 只包装前端经 proxypass **直连**的 engine HTTP
 > （`src/frontend/src/requestConfig.ts:189-205`）。前端**经由后端**触达的 engine
 > 路由 —— `/api/cron`（已经是 `routines` 类别）、`/api/file`、`/api/skills`、
 > `/api/mcp`、`/api/resource-materializations`、`/api/bash`、`/api/bot/config`、
 > `/api/work-items` —— 已经有后端契约在其之上，不纳入。仅 aicoding 的路由不纳入。
+> 当前前端直连的只读 `/api/nodes` 清单纳入；前端与 Engine HTTP 目前都没有节点写操作，
+> 因此不扩展注册、解绑或状态写入。
 > **WebSocket 不包装**：新的 `…/connection` 端点返回一条完整的 socket URL（凭据在其中），
 > 由调用方自己建连。
 >
@@ -621,9 +625,9 @@ GET /openapi/v1/bots/b-1/connection?user_id=u-collab&owner_id=u-owner&stage=veri
 skills 组的 `owner_entity_id` 定位参数早于 `owner_id`；已于 2026-08-15 随 Agent 在前的
 寻址统一为 `owner_id`，待退役的 skills 旧地址仍发布旧参数名（spec 未决问题 1，已关闭）。
 
-`tests/…/openapi_v1/engine_runtime/test_operator_access.py` 对全部十六个操作扫掠
-运维者矩阵；`…/test_stage_addressing.py` 钉住阶段行为并断言两个参数恰好出现在这
-十六个操作上、可选、位于 query；`tests/community/core/engine_runtime/test_stage.py`
+`tests/…/openapi_v1/engine_runtime/test_operator_access.py` 对共享扫描覆盖的运行时操作扫掠
+运维者矩阵；`…/test_stage_addressing.py` 钉住阶段行为并断言两个参数恰好出现在所有
+运行时操作上、可选、位于 query；`tests/community/core/engine_runtime/test_stage.py`
 钉住存活规则。
 
 ---
@@ -974,7 +978,7 @@ domain —— `bots` 未声明 `protocols`，因此只服务 HTTP 平面 —— 
 > 不写数据 —— 但在本面上任何 socket 路由开始接触数据之前，这是第一件要修的事：在默认
 > 租户下执行按租户收敛的读取是数据隔离故障，而不只是少了一行日志。
 
-### ⬜ 未分配 · Track C —— engine 运行时（19 个端点）
+### ⬜ 未分配 · Track C —— engine 运行时（21 个端点）
 这不是一个 Track B 类别 —— 它们包装的是 Bot 设备上的 **engine adapter**，
 而不是某个后端服务。逐端点清单、每个端点对应的 engine 路由，以及那约 72 条
 *不*包装的 engine 路由的裁定，都在
@@ -983,8 +987,9 @@ domain —— `bots` 未声明 `protocols`，因此只服务 HTTP 平面 —— 
 | 组 | 端点数 | 公共路径 |
 |---|---|---|
 | sessions | 10 | `/openapi/v1/bots/{bot_id}/sessions…` —— 拥有者/协作者运维，含收藏 |
-| engine | 3 | `/openapi/v1/bots/{bot_id}/engine/{status,capabilities,available}` |
+| engine | 4 | `/openapi/v1/bots/{bot_id}/engine/{status,capabilities,available,restart}` |
 | models | 2 | `/openapi/v1/bots/{bot_id}/models`、`…/models/{model_id}` |
+| nodes | 1 | `/openapi/v1/bots/{bot_id}/nodes` —— 只读节点清单 |
 | approvals | 3 | `/openapi/v1/bots/{bot_id}/approvals/mode`（GET/PUT）、`…/modes` |
 | connection | 1 | `/openapi/v1/bots/{bot_id}/connection` —— 完整 WS URL，取代 `get_device_connection` |
 
@@ -1008,10 +1013,10 @@ domain —— `bots` 未声明 `protocols`，因此只服务 HTTP 平面 —— 
 7. **跨租户的外部身份问题已定案（[#556](https://github.com/inclusionAI/Avernet/issues/556)）** —— Passport、授权关系与 BCN 都带上
    租户维度，从而可以在公共路径上重新打开 BCN 同步。—— _⬜（2026-07-29 新增；它是开启
    多租户的前置闸口）。_
-8. **Track C：** 五个 engine 运行时组（16 个端点）均已实现、按 owner 收敛且能力感知，
+8. **Track C：** 六个 engine 运行时组（18 个端点）均已实现、按 owner 收敛且能力感知，
    并且 `…/connection` 返回 socket URL，使任何外部调用方都看不到 proxypass target
-   或裸设备 token。—— _✅ 5 组全部完成（PR #630）。与其它类别一样，在第 6 项落地
-   之前一律返回 401；singlebox E2E 流也阻塞在同一个事件上。_
+   或裸设备 token。—— _✅ 6 组全部完成（PR #630 为基线，后续增加 engine restart
+   与 nodes）。_
 
 ---
 
@@ -1272,6 +1277,11 @@ domain —— `bots` 未声明 `protocols`，因此只服务 HTTP 平面 —— 
   `route_security.yaml` 允许本界面真实的调用方；另外 `app` / `access_key` 调用方在有人
   就"它们归属于谁"定案之前一律 401。SDD：
   `src/backend/specs/2026-07-30-gateway-principal-verifier/`。
+- **2026-08-19** —— **新增只读 Node OpenAPI。** 当前前端与 Engine 只支持
+  `GET /api/nodes`，所以公共 API 只增加
+  `GET /openapi/v1/bots/{bot_id}/nodes`，沿用其他运行时组的 owner/editor、Bot grant 与
+  stage 门禁。它转发 `status`、`platform`、`limit`、`offset`，只发布稳定节点字段，
+  不虚构 register/unregister/status-write 操作。
 - **2026-07-30** —— **Track C 已实现（PR #630）** —— 五个组共 16 个 engine 运行时
   端点，外加 `core/engine_runtime/`（relay 与 connection service）及其 Service API
   Protocol。动这条主线或参考它之前，有七点值得知道：

--- a/src/backend/docs/openapi-v1/engine-surface.md
+++ b/src/backend/docs/openapi-v1/engine-surface.md
@@ -64,7 +64,7 @@ frontend rewrites to the engine.
 
 ---
 
-## The public surface — 19 endpoints
+## The public surface — 21 endpoints
 
 All bot-scoped under `/openapi/v1/bots/{bot_id}/<component>/…`, all returning
 the `Envelope[T]` / `Page[T]` shapes from `openapi_v1/contracts.py`.
@@ -75,7 +75,7 @@ the `Envelope[T]` / `Page[T]` shapes from `openapi_v1/contracts.py`.
 > gateway forwards to agentclaw on that prefix**, so a route mounted anywhere
 > else is unreachable in production. A test asserts it.
 >
-> **`{bot_id}` comes before the component's name.** These five shipped that
+> **`{bot_id}` comes before the component's name.** The original five shipped that
 > way, were normalized to component-first on 2026-08-03, and were returned to
 > bot-first on 2026-08-15 when that rule was reversed for the whole surface —
 > see the **Addressing rule** in [`README.md`](README.md). The tables below use
@@ -149,20 +149,20 @@ Two things about this group are not the shape a reader would assume:
   do nothing depending on which engine the bot runs. A caller still sending it
   gets a 422 rather than a silent no-op. _Decided 2026-07-30._
 
-### engine, read-only (3) — engine `/api/engine`
+### engine (4) — engine `/api/engine`
 
 | Method | Public path | Engine route | Notes |
 |---|---|---|---|
 | GET | `…/{bot_id}/engine/status` | `GET /api/engine/status` | process / transition phase / connection count |
 | GET | `…/{bot_id}/engine/capabilities` | `GET /api/engine/capabilities` | **the most important endpoint in Track C** — see *Capabilities* below |
 | GET | `…/{bot_id}/engine/available` | `GET /api/engine/list` | **divergence:** `list` is a verb path; public uses a noun. Registered engines + active flag + version |
+| POST | `…/{bot_id}/engine/restart` | `POST /api/engine/restart` | restarts the engine process only; distinct from the bot-level restart that re-provisions the container |
 
-> **`POST /api/engine/switch` and `POST /api/engine/restart` are deliberately
-> NOT wrapped.** PR #494 made `engine` immutable on `PUT /openapi/v1/bots/{bot_id}`
+> **`POST /api/engine/switch` remains deliberately unwrapped.** PR #494 made
+> `engine` immutable on `PUT /openapi/v1/bots/{bot_id}`
 > (`extra="forbid"` → 422); wrapping `switch` would be a back door around that
-> ruling. And `POST /openapi/v1/bots/{bot_id}/restart` already re-provisions the
-> device, so wrapping `restart` would give one bot two restart verbs with
-> different blast radii. _Decided 2026-07-30._
+> ruling. Engine-process restart was added on 2026-08-17 with an explicit
+> component-qualified path so it cannot be confused with the bot-level restart.
 
 ### models (2) — engine `/api/models`
 
@@ -170,6 +170,17 @@ Two things about this group are not the shape a reader would assume:
 |---|---|---|---|
 | GET | `…/{bot_id}/models` | `GET /api/models` | `Envelope[Page[Model]]` |
 | GET | `…/{bot_id}/models/{model_id}` | `GET /api/models/{model_id:path}` | **model ids contain slashes** (`openai/gpt-5.3`). The engine uses a `:path` converter; the public route must settle URL-encoding vs. a `:path` converter and document it |
+
+### nodes (1) — engine `/api/nodes`
+
+| Method | Public path | Engine route | Notes |
+|---|---|---|---|
+| GET | `…/{bot_id}/nodes` | `GET /api/nodes` | read-only inventory used by the current frontend; forwards `status`, `platform`, `limit` and `offset` and returns `Envelope[list[Node]]` |
+
+Only the list is public. The frontend and Engine HTTP surface currently have no
+node register, unregister or status-write flow, so Track C does not invent one.
+The public projection keeps the stable frontend fields in snake case and drops
+engine-internal `metadata` / raw provider payloads. _Added 2026-08-19._
 
 ### approvals (3) — engine `/api/approvals`
 
@@ -281,10 +292,10 @@ Rules this endpoint must hold:
 | Engine router | Prefix | HTTP | WS | Ruling | Why |
 |---|---|---|---|---|---|
 | `api/session` | `/api/sessions` | 7 | — | ✅ **C1 — wrap** | in the frontend proxypass list |
-| `api/engine` | `/api/engine` | 5 | — | ✅ **C1 — wrap 3 of 5** | `switch`/`restart` excluded, see above |
+| `api/engine` | `/api/engine` | 5 | — | ✅ **C1 — wrap 4 of 5** | `switch` excluded; process restart is component-qualified, see above |
 | `api/models` | `/api/models` | 2 | — | ✅ **C1 — wrap** | in the proxypass list |
 | `api/approvals` | `/api/approvals` | 3 | — | ✅ **C1 — wrap** | in the proxypass list |
-| `api/node` | `/api/nodes` | 1 | — | ⛔ **dropped 2026-07-30** | in the proxypass list, so C1 would wrap it — but the product does not need node inventory on the public surface. Additive later. |
+| `api/node` | `/api/nodes` | 1 | — | ✅ **C1 — wrapped 2026-08-19** | the workshop now needs the same read-only inventory the frontend uses; no speculative write operations were added |
 | `api/cron` | `/api/cron` | 10 | — | ⛔ **C2** | **already the `routines` category** — backend `/api/cron` → `CronRelayService` → engine. Explicitly commented out of the frontend proxypass list (`requestConfig.ts:195`) |
 | `api/file` | `/api/file` | 5 | — | ⛔ **C2** | backend calls `/api/file/{read,upload,list,remove,rmtree}` server-side; frontend never proxypasses it |
 | `api/skills` | `/api/skills` | 10 | — | ⛔ **C2** | backend `skills_pool` / `skill_center` drive layout, symlink and bindpath ops. Internal filesystem mechanics, no tenant-facing contract |
@@ -351,7 +362,7 @@ answers differently for two of a tenant's own bots.**
   entry with a fixed public message pointing the caller at
   `…/{bot_id}/engine/capabilities`.
 - That is why `…/{bot_id}/engine/capabilities` is in the v1 surface and not deferred: it
-  is how a caller discovers, ahead of time, which of the other 16 endpoints its
+  is how a caller discovers, ahead of time, which of the other 17 endpoints its
   bot will actually answer.
 
 ### 3. `user_id` must come from the principal, never the caller
@@ -508,6 +519,11 @@ does not add it (rule C2)._
 
 ## Decisions taken
 
+- **2026-08-19 — read-only nodes restored additively.** The current frontend
+  only proxypasses `GET /api/nodes`, and the Engine exposes only that HTTP
+  operation, so the public surface adds exactly
+  `GET /openapi/v1/bots/{bot_id}/nodes`. It inherits the runtime owner/editor,
+  grant and stage gates; registration, removal and status writes stay out.
 - **2026-07-30 — Scope rule adopted (C1–C4).** Wrap engine HTTP the frontend
   reaches directly; leave backend-mediated engine calls to the backend contract
   that already fronts them; return connection info for sockets instead of

--- a/src/backend/docs/openapi-v1/engine-surface.zh-CN.md
+++ b/src/backend/docs/openapi-v1/engine-surface.zh-CN.md
@@ -58,7 +58,7 @@ C1 的权威清单是 `src/frontend/src/requestConfig.ts:189-205` 里的 proxypa
 
 ---
 
-## 公共面 —— 19 个端点
+## 公共面 —— 21 个端点
 
 全部按 bot 收敛在 `/openapi/v1/bots/{bot_id}/<component>/…` 之下，全部返回
 `openapi_v1/contracts.py` 的 `Envelope[T]` / `Page[T]` 形状。
@@ -68,7 +68,7 @@ C1 的权威清单是 `src/frontend/src/requestConfig.ts:189-205` 里的 proxypa
 > 保持一致，而且**网关正是按这个前缀转发到 agentclaw 的**，所以挂在别处的路由
 > 在生产上根本不可达。有测试对此做断言。
 >
-> **`{bot_id}` 在组件名之前。** 这五个组最初就是这样上线的，2026-08-03 被规范化
+> **`{bot_id}` 在组件名之前。** 最初的五个组就是这样上线的，2026-08-03 被规范化
 > 为组件在前，2026-08-15 随整个面的规则反转又改回 Agent 在前 —— 见
 > [`README.zh-CN.md`](README.zh-CN.md) 的**寻址规则**。下表用的是当前地址；组件在
 > 前的旧地址仍会应答、标记为 `deprecated`，直至日落（见 `README.zh-CN.md` 的
@@ -119,19 +119,19 @@ C1 的权威清单是 `src/frontend/src/requestConfig.ts:189-205` 里的 proxypa
   取决于该 bot 跑的是哪个引擎。仍然发送它的调用方会拿到 422，而不是一个静默的
   空操作。_2026-07-30 决定。_
 
-### engine，只读（3）—— engine `/api/engine`
+### engine（4）—— engine `/api/engine`
 
 | 方法 | 公共路径 | engine 路由 | 说明 |
 |---|---|---|---|
 | GET | `…/{bot_id}/engine/status` | `GET /api/engine/status` | 进程 / 切换阶段 / 连接数 |
 | GET | `…/{bot_id}/engine/capabilities` | `GET /api/engine/capabilities` | **Track C 里最重要的端点** —— 见下文《能力》 |
 | GET | `…/{bot_id}/engine/available` | `GET /api/engine/list` | **差异：** `list` 是动词路径，公共面改用名词。已注册引擎 + active 标记 + 版本 |
+| POST | `…/{bot_id}/engine/restart` | `POST /api/engine/restart` | 只重启 engine 进程；不同于会重新置备容器的 Bot 级 restart |
 
-> **`POST /api/engine/switch` 与 `POST /api/engine/restart` 刻意不包装。**
-> PR #494 已经让 `engine` 在 `PUT /openapi/v1/bots/{bot_id}` 上不可变
+> **`POST /api/engine/switch` 仍刻意不包装。** PR #494 已经让 `engine` 在
+> `PUT /openapi/v1/bots/{bot_id}` 上不可变
 > （`extra="forbid"` → 422）；包装 `switch` 等于给那条裁定开后门。而
-> `POST /openapi/v1/bots/{bot_id}/restart` 本身就会重新置备设备，包装 `restart`
-> 会让同一个 bot 拥有两个影响范围不同的重启动词。_2026-07-30 决定。_
+> engine 进程重启已于 2026-08-17 用带组件名的独立路径加入，避免与 Bot 级重启混淆。
 
 ### models（2）—— engine `/api/models`
 
@@ -139,6 +139,16 @@ C1 的权威清单是 `src/frontend/src/requestConfig.ts:189-205` 里的 proxypa
 |---|---|---|---|
 | GET | `…/{bot_id}/models` | `GET /api/models` | `Envelope[Page[Model]]` |
 | GET | `…/{bot_id}/models/{model_id}` | `GET /api/models/{model_id:path}` | **模型 id 里带斜杠**（`openai/gpt-5.3`）。engine 用 `:path` 转换器；公共路由必须在「URL 编码」与「`:path` 转换器」之间定下来并写进文档 |
+
+### nodes（1）—— engine `/api/nodes`
+
+| 方法 | 公共路径 | engine 路由 | 说明 |
+|---|---|---|---|
+| GET | `…/{bot_id}/nodes` | `GET /api/nodes` | 对齐当前前端使用的只读清单；转发 `status`、`platform`、`limit`、`offset`，返回 `Envelope[list[Node]]` |
+
+只发布列表能力。前端与 Engine HTTP 当前都没有节点注册、解绑或状态写入流程，因此
+Track C 不虚构这些写操作。公共投影保留前端稳定字段并改用 snake_case，同时丢弃
+Engine 内部 `metadata` / provider raw payload。_2026-08-19 新增。_
 
 ### approvals（3）—— engine `/api/approvals`
 
@@ -225,10 +235,10 @@ socket 也是干净的。
 | engine router | 前缀 | HTTP | WS | 裁定 | 理由 |
 |---|---|---|---|---|---|
 | `api/session` | `/api/sessions` | 7 | — | ✅ **C1 —— 包装** | 在前端 proxypass 列表中 |
-| `api/engine` | `/api/engine` | 5 | — | ✅ **C1 —— 5 取 3** | `switch`/`restart` 排除，见上文 |
+| `api/engine` | `/api/engine` | 5 | — | ✅ **C1 —— 5 取 4** | `switch` 排除；进程重启使用组件限定路径，见上文 |
 | `api/models` | `/api/models` | 2 | — | ✅ **C1 —— 包装** | 在 proxypass 列表中 |
 | `api/approvals` | `/api/approvals` | 3 | — | ✅ **C1 —— 包装** | 在 proxypass 列表中 |
-| `api/node` | `/api/nodes` | 1 | — | ⛔ **2026-07-30 移除** | 在 proxypass 列表中，按 C1 本应包装 —— 但产品并不需要在公共面上暴露节点清单。以后可增量加回。 |
+| `api/node` | `/api/nodes` | 1 | — | ✅ **C1 —— 2026-08-19 已包装** | 工坊现在需要与前端一致的只读节点清单；没有增加推测性的写操作 |
 | `api/cron` | `/api/cron` | 10 | — | ⛔ **C2** | **已经是 `routines` 类别** —— 后端 `/api/cron` → `CronRelayService` → engine。在前端 proxypass 列表里被显式注释掉（`requestConfig.ts:195`） |
 | `api/file` | `/api/file` | 5 | — | ⛔ **C2** | 后端在服务端调用 `/api/file/{read,upload,list,remove,rmtree}`；前端从不 proxypass 它 |
 | `api/skills` | `/api/skills` | 10 | — | ⛔ **C2** | 后端 `skills_pool` / `skill_center` 驱动 layout、symlink、bindpath；属内部文件系统机制，没有面向租户的契约 |
@@ -289,7 +299,7 @@ engine 的每个 handler 都会调用 `check_capability()`
 - `CapabilityNotSupportedError` / 传输层的 501 需要一条 `ENVELOPE_ERRORS` 条目，
   配固定公共文案，并指引调用方去看 `…/{bot_id}/engine/capabilities`。
 - 这正是 `…/{bot_id}/engine/capabilities` 进入 v1 而非延后的原因：它是调用方在事前判断
-  另外 16 个端点里哪些会被自己的 bot 真正应答的唯一方式。
+  另外 17 个端点里哪些会被自己的 bot 真正应答的唯一方式。
 
 ### 3. `user_id` 必须来自 principal，绝不来自调用方
 
@@ -308,7 +318,7 @@ engine 的每个 handler 都会调用 `check_capability()`
 
 冷启动、休眠或正在重启的设备会让每一次 engine 调用在传输层失败。请复用
 `core/bot_management/readiness.py`（#494 抽出的），而不是另造一套策略，并为全部
-16 个端点定下**同一种**行为：掩码 `409 device not ready`，还是自动唤醒后重试。
+18 个端点定下**同一种**行为：掩码 `409 device not ready`，还是自动唤醒后重试。
 无论选哪种，`GET /openapi/v1/bots/{bot_id}/status` 仍然是告诉调用方*原因*的端点。
 
 ### 5. 封闭值集合用枚举，开放的保持字符串
@@ -410,6 +420,10 @@ _沿革：这些组最初就比 `{bot_id}` 通配符深一段，2026-08-03 被�
 
 ## 已定的决策
 
+- **2026-08-19 —— 增量恢复只读 nodes。** 当前前端只 proxypass
+  `GET /api/nodes`，Engine 也只提供这一条 HTTP 操作，因此公共面只增加
+  `GET /openapi/v1/bots/{bot_id}/nodes`。它继承运行时 owner/editor、Bot grant 与
+  stage 门禁；节点注册、删除和状态写入仍不纳入。
 - **2026-07-30 —— 采纳范围规则（C1–C4）。** 包装前端直连的 engine HTTP；经由后端
   的 engine 调用交给已经在其之上的后端契约；socket 返回连接信息而不是转发；排除
   aicoding。
@@ -469,7 +483,7 @@ _沿革：这些组最初就比 `{bot_id}` 通配符深一段，2026-08-03 被�
 
 1. **`Envelope` 上的 `warning`** —— 增加可选字段（推荐）、走响应头，还是丢弃该
    信号？涉及共享的 Track B 契约。
-2. **就绪行为** —— 掩码 `409` 还是自动唤醒后重试，16 个端点统一。
+2. **就绪行为** —— 掩码 `409` 还是自动唤醒后重试，18 个端点统一。
 3. **带斜杠的 `model_id`** —— `:path` 转换器还是强制 URL 编码。
 4. **分页** —— engine 收 `limit`/`offset`；公共 `Page` 形状必须干净映射，包括
    `/api/models` 这个返回扁平列表、没有 `total` 的路由。

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -286,12 +286,6 @@ _SUBGROUPS = [
     # creation/authorization pair remains human-only. Dependencies are declared
     # per route in the local router.
     local_router,
-    # Editors are human-only, while render screens mix an app-readable GET with
-    # human-only writes. Their route dependencies enforce those distinctions;
-    # mounting either whole group under the addressed-Bot grant would make the
-    # assembly disagree with the admission table.
-    editors_router,
-    render_screens_router,
 ]
 
 # These groups may address a shared Bot. ``OwnerIdDep`` performs the same grant
@@ -299,6 +293,12 @@ _SUBGROUPS = [
 # declares it explicitly so the admission rule is visible where the public
 # surface is assembled. FastAPI caches the shared dependency per request.
 _ADDRESSED_BOT_SUBGROUPS = [
+    # Bot grants lend the delegating user's live Bot permissions. Editors and
+    # render screens therefore use the same addressed-owner grant boundary as
+    # the other shared-Bot configuration groups; their services still enforce
+    # the caller's effective Owner/Admin/Member level for each operation.
+    editors_router,
+    render_screens_router,
     service_lifecycle_router,
     service_edit_lock_router,
     containers_router,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -286,6 +286,12 @@ _SUBGROUPS = [
     # creation/authorization pair remains human-only. Dependencies are declared
     # per route in the local router.
     local_router,
+    # Editors are human-only, while render screens mix an app-readable GET with
+    # human-only writes. Their route dependencies enforce those distinctions;
+    # mounting either whole group under the addressed-Bot grant would make the
+    # assembly disagree with the admission table.
+    editors_router,
+    render_screens_router,
 ]
 
 # These groups may address a shared Bot. ``OwnerIdDep`` performs the same grant
@@ -298,8 +304,6 @@ _ADDRESSED_BOT_SUBGROUPS = [
     containers_router,
     diagnostics_router,
     channels_router,
-    editors_router,
-    render_screens_router,
 ]
 
 # The groups where **every** route is GRANT_CHECKED_OWN_BOT — it names a bot and resolves it

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -181,6 +181,7 @@ from .caller import router as caller_router
 from .channels import router as channels_router
 from .containers import router as containers_router
 from .diagnostics import router as diagnostics_router
+from .editors import router as editors_router
 from .deprecated import (
     ENGINE_RUNTIME_GROUPS as _LEGACY_ENGINE_RUNTIME,
     GRANT_CHECKED_GROUPS as _LEGACY_GRANT_CHECKED,
@@ -208,6 +209,7 @@ from .bot_logs import router as logs_router
 from .bot_chats import router as chats_router
 from .bot_public import router as bot_public_router
 from .resources import router as resources_router
+from .render_screens import router as render_screens_router
 from .routines import router as routines_router
 from .skills import router as skills_router
 from .service_publications import (
@@ -295,6 +297,8 @@ _ADDRESSED_BOT_SUBGROUPS = [
     containers_router,
     diagnostics_router,
     channels_router,
+    editors_router,
+    render_screens_router,
 ]
 
 # The groups where **every** route is GRANT_CHECKED_OWN_BOT — it names a bot and resolves it

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -199,6 +199,7 @@ from .engine_runtime.approvals import router as engine_approvals_router
 from .engine_runtime.connection import router as engine_connection_router
 from .engine_runtime.engine import router as engine_engine_router
 from .engine_runtime.models import router as engine_models_router
+from .engine_runtime.nodes import router as engine_nodes_router
 from .engine_runtime.sessions import router as engine_sessions_router
 from .identity import router as identity_router
 from .local import router as local_router
@@ -341,6 +342,7 @@ _ENGINE_RUNTIME_GROUPS = [
     engine_sessions_router,
     engine_engine_router,
     engine_models_router,
+    engine_nodes_router,
     engine_approvals_router,
     engine_connection_router,
 ]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -589,23 +589,30 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
         "POST",
         "/openapi/v1/bots/{bot_id}/local/open-folder",
     ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
-    # Editor membership is an authorization mutation. The first public version
-    # requires a human on the wire for reads and writes alike; an application
-    # grant authorizes Bot use, not enumeration or mutation of its human access.
-    ("GET", "/openapi/v1/bots/{bot_id}/editors"): AdmissionMode.REFUSED,
-    ("POST", "/openapi/v1/bots/{bot_id}/editors"): AdmissionMode.REFUSED,
+    # A Bot grant lends the delegating user's live Bot permissions. Editor and
+    # render-screen operations therefore admit an application only after the
+    # addressed Bot/owner grant is proven; the domain services still enforce
+    # the delegator's effective Owner/Admin/Member level for the requested act.
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/editors",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/editors",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
         "PATCH",
         "/openapi/v1/bots/{bot_id}/editors/{editor_id}",
-    ): AdmissionMode.REFUSED,
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
         "DELETE",
         "/openapi/v1/bots/{bot_id}/editors/{editor_id}",
-    ): AdmissionMode.REFUSED,
-    ("DELETE", "/openapi/v1/bots/{bot_id}/editors/me"): AdmissionMode.REFUSED,
-    # Render-screen CDN mappings are non-sensitive runtime inputs. An
-    # application with a live grant may read them for panel rendering, while
-    # configuration mutations remain human-only Editor actions.
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "DELETE",
+        "/openapi/v1/bots/{bot_id}/editors/me",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
         "GET",
         "/openapi/v1/bots/{bot_id}/render-screens",
@@ -613,15 +620,15 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     (
         "POST",
         "/openapi/v1/bots/{bot_id}/render-screens",
-    ): AdmissionMode.REFUSED,
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
         "PATCH",
         "/openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}",
-    ): AdmissionMode.REFUSED,
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
         "DELETE",
         "/openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}",
-    ): AdmissionMode.REFUSED,
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     # ── REFUSED — each for its own reason ────────────────────────────────────
     # The caller's own identity. An app-only caller names no end user, so there
     # is nothing to return — its scope question is answered by

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -19,11 +19,11 @@ masked ``404``. A bot merely *shared* with the caller is unreachable here **for
 a human too**, so an application acting as that human inherits the same limit
 without anything being written to enforce it.
 
-**Engine-runtime groups** (``sessions``, ``engine``, ``models``, ``approvals``,
-``connection``) take ``user_id`` as the *caller* and a second ``owner_id``
-naming the *addressed bot's owner*, then adjudicate through the collaborator
-gate. This is where a shared bot is reachable, and therefore where a delegation
-actually pays off. For an app-only caller the addressed owner comes from the
+**Engine-runtime groups** (``sessions``, ``engine``, ``models``, ``nodes``,
+``approvals``, ``connection``) take ``user_id`` as the *caller* and a second
+``owner_id`` naming the *addressed bot's owner*, then adjudicate through the
+collaborator gate. This is where a shared bot is reachable, and therefore where
+a delegation actually pays off. For an app-only caller the addressed owner comes from the
 **grant record**, never from the request — see ``engine_runtime/params.py``.
 
 The invariant every mode below serves
@@ -389,6 +389,10 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     (
         "GET",
         "/openapi/v1/bots/{bot_id}/models/{model_id:path}",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/nodes",
     ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
         "GET",

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -585,6 +585,39 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
         "POST",
         "/openapi/v1/bots/{bot_id}/local/open-folder",
     ): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    # Editor membership is an authorization mutation. The first public version
+    # requires a human on the wire for reads and writes alike; an application
+    # grant authorizes Bot use, not enumeration or mutation of its human access.
+    ("GET", "/openapi/v1/bots/{bot_id}/editors"): AdmissionMode.REFUSED,
+    ("POST", "/openapi/v1/bots/{bot_id}/editors"): AdmissionMode.REFUSED,
+    (
+        "PATCH",
+        "/openapi/v1/bots/{bot_id}/editors/{editor_id}",
+    ): AdmissionMode.REFUSED,
+    (
+        "DELETE",
+        "/openapi/v1/bots/{bot_id}/editors/{editor_id}",
+    ): AdmissionMode.REFUSED,
+    ("DELETE", "/openapi/v1/bots/{bot_id}/editors/me"): AdmissionMode.REFUSED,
+    # Render-screen CDN mappings are non-sensitive runtime inputs. An
+    # application with a live grant may read them for panel rendering, while
+    # configuration mutations remain human-only Editor actions.
+    (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/render-screens",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/render-screens",
+    ): AdmissionMode.REFUSED,
+    (
+        "PATCH",
+        "/openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}",
+    ): AdmissionMode.REFUSED,
+    (
+        "DELETE",
+        "/openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}",
+    ): AdmissionMode.REFUSED,
     # ── REFUSED — each for its own reason ────────────────────────────────────
     # The caller's own identity. An app-only caller names no end user, so there
     # is nothing to return — its scope question is answered by

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorized_apps/gating.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorized_apps/gating.py
@@ -111,7 +111,7 @@ def resolve_delegable_bot(
         raise BotNotFoundError("Bot not found")
     require_bot_operator(
         collaborators,
-        bot_pk=bot_pk,
+        bot=bot,
         bot_id=bot_id,
         caller_id=caller_id,
         owner_id=resolved_owner,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorized_apps/gating.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorized_apps/gating.py
@@ -111,7 +111,7 @@ def resolve_delegable_bot(
         raise BotNotFoundError("Bot not found")
     require_bot_operator(
         collaborators,
-        bot=bot,
+        bot_pk=bot_pk,
         bot_id=bot_id,
         caller_id=caller_id,
         owner_id=resolved_owner,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/editors/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/editors/__init__.py
@@ -1,0 +1,5 @@
+"""Public Bot editor-management endpoints."""
+
+from .router import router
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/editors/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/editors/router.py
@@ -1,0 +1,188 @@
+"""Public bot-first CRUD routes for Bot editors."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, Query, Request
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    BotIdPath,
+    Deleted,
+    Envelope,
+)
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    UserIdDep,
+    refuse_app_only_caller,
+)
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    created,
+    deleted,
+    envelope,
+    envelope_errors,
+)
+from agentclaw.community.api.collaborator_service import CollaboratorServiceProtocol
+from agentclaw.community.core.bot_collaborator.models import CollaboratorRecord
+from agentclaw.community.di import Injected
+
+from .schemas import Editor, EditorCreate, EditorList, EditorRole, EditorUpdate
+
+
+router = APIRouter(prefix="/openapi/v1/bots/{bot_id}/editors", tags=["editors"])
+_REFUSES_APP_ONLY = [Depends(refuse_app_only_caller)]
+EditorIdPath = Annotated[
+    int,
+    Path(ge=1, description="Editor-relation identifier returned by this collection."),
+]
+
+
+async def resolve_editor_owner_id(
+    actor_id: UserIdDep,
+    owner_id: Annotated[
+        str | None,
+        Query(
+            min_length=1,
+            description="Owner of the Bot whose editor set is addressed. "
+            "Defaults to the current user; collaborators name the Bot Owner.",
+        ),
+    ] = None,
+) -> str:
+    """Resolve a human-only addressed owner without application grant logic."""
+    return owner_id if owner_id is not None else actor_id
+
+
+EditorOwnerIdDep = Annotated[str, Depends(resolve_editor_owner_id)]
+
+
+def _editor(record: CollaboratorRecord) -> Editor:
+    if record.id is None:
+        raise RuntimeError("persisted collaborator is missing its primary key")
+    return Editor(
+        id=record.id,
+        user_id=record.user_id,
+        user_name=record.user_name,
+        role=EditorRole(record.role),
+        created_at=record.gmt_create,
+        updated_at=record.gmt_modified,
+    )
+
+
+@router.get(
+    "",
+    response_model=Envelope[EditorList],
+    dependencies=_REFUSES_APP_ONLY,
+)
+@envelope_errors
+async def list_editors(
+    bot_id: BotIdPath,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: EditorOwnerIdDep,
+    role: Annotated[
+        EditorRole | None, Query(description="Optional editor-role filter.")
+    ] = None,
+    service: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
+) -> Envelope[EditorList]:
+    records = service.list_editors(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        user_id=actor_id,
+        role=role.value if role is not None else None,
+    )
+    items = [_editor(record) for record in records]
+    return envelope(EditorList(total=len(items), items=items), request)
+
+
+@router.post(
+    "",
+    status_code=201,
+    response_model=Envelope[Editor],
+    dependencies=_REFUSES_APP_ONLY,
+)
+@envelope_errors
+async def add_editor(
+    bot_id: BotIdPath,
+    body: EditorCreate,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: EditorOwnerIdDep,
+    service: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
+) -> Envelope[Editor]:
+    record = service.add_editor(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        user_id=body.editor_user_id,
+        operator_id=actor_id,
+        user_name=body.user_name,
+        role=body.role.value,
+    )
+    return created(_editor(record), request)
+
+
+@router.patch(
+    "/{editor_id}",
+    response_model=Envelope[Editor],
+    dependencies=_REFUSES_APP_ONLY,
+)
+@envelope_errors
+async def update_editor(
+    bot_id: BotIdPath,
+    editor_id: EditorIdPath,
+    body: EditorUpdate,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: EditorOwnerIdDep,
+    service: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
+) -> Envelope[Editor]:
+    record = service.update_editor(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        collaborator_id=editor_id,
+        operator_id=actor_id,
+        role=body.role.value,
+    )
+    return envelope(_editor(record), request)
+
+
+@router.delete(
+    "/me",
+    response_model=Envelope[Deleted],
+    dependencies=_REFUSES_APP_ONLY,
+)
+@envelope_errors
+async def leave_editors(
+    bot_id: BotIdPath,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: EditorOwnerIdDep,
+    service: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
+) -> Envelope[Deleted]:
+    service.leave_editors(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        user_id=actor_id,
+    )
+    return deleted(request)
+
+
+@router.delete(
+    "/{editor_id}",
+    response_model=Envelope[Deleted],
+    dependencies=_REFUSES_APP_ONLY,
+)
+@envelope_errors
+async def remove_editor(
+    bot_id: BotIdPath,
+    editor_id: EditorIdPath,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: EditorOwnerIdDep,
+    service: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
+) -> Envelope[Deleted]:
+    service.remove_editor(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        collaborator_id=editor_id,
+        operator_id=actor_id,
+    )
+    return deleted(request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/editors/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/editors/router.py
@@ -4,17 +4,17 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, Query, Request
+from fastapi import APIRouter, Path, Query, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     BotIdPath,
     Deleted,
     Envelope,
 )
-from agentclaw.community.adapters.http.openapi_v1.principal import (
-    UserIdDep,
-    refuse_app_only_caller,
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.params import (
+    OwnerIdDep,
 )
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     created,
     deleted,
@@ -29,29 +29,10 @@ from .schemas import Editor, EditorCreate, EditorList, EditorRole, EditorUpdate
 
 
 router = APIRouter(prefix="/openapi/v1/bots/{bot_id}/editors", tags=["editors"])
-_REFUSES_APP_ONLY = [Depends(refuse_app_only_caller)]
 EditorIdPath = Annotated[
     int,
     Path(ge=1, description="Editor-relation identifier returned by this collection."),
 ]
-
-
-async def resolve_editor_owner_id(
-    actor_id: UserIdDep,
-    owner_id: Annotated[
-        str | None,
-        Query(
-            min_length=1,
-            description="Owner of the Bot whose editor set is addressed. "
-            "Defaults to the current user; collaborators name the Bot Owner.",
-        ),
-    ] = None,
-) -> str:
-    """Resolve a human-only addressed owner without application grant logic."""
-    return owner_id if owner_id is not None else actor_id
-
-
-EditorOwnerIdDep = Annotated[str, Depends(resolve_editor_owner_id)]
 
 
 def _editor(record: CollaboratorRecord) -> Editor:
@@ -70,14 +51,13 @@ def _editor(record: CollaboratorRecord) -> Editor:
 @router.get(
     "",
     response_model=Envelope[EditorList],
-    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def list_editors(
     bot_id: BotIdPath,
     request: Request,
     actor_id: UserIdDep,
-    owner_id: EditorOwnerIdDep,
+    owner_id: OwnerIdDep,
     role: Annotated[
         EditorRole | None, Query(description="Optional editor-role filter.")
     ] = None,
@@ -97,7 +77,6 @@ async def list_editors(
     "",
     status_code=201,
     response_model=Envelope[Editor],
-    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def add_editor(
@@ -105,7 +84,7 @@ async def add_editor(
     body: EditorCreate,
     request: Request,
     actor_id: UserIdDep,
-    owner_id: EditorOwnerIdDep,
+    owner_id: OwnerIdDep,
     service: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
 ) -> Envelope[Editor]:
     record = service.add_editor(
@@ -122,7 +101,6 @@ async def add_editor(
 @router.patch(
     "/{editor_id}",
     response_model=Envelope[Editor],
-    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def update_editor(
@@ -131,7 +109,7 @@ async def update_editor(
     body: EditorUpdate,
     request: Request,
     actor_id: UserIdDep,
-    owner_id: EditorOwnerIdDep,
+    owner_id: OwnerIdDep,
     service: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
 ) -> Envelope[Editor]:
     record = service.update_editor(
@@ -147,14 +125,13 @@ async def update_editor(
 @router.delete(
     "/me",
     response_model=Envelope[Deleted],
-    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def leave_editors(
     bot_id: BotIdPath,
     request: Request,
     actor_id: UserIdDep,
-    owner_id: EditorOwnerIdDep,
+    owner_id: OwnerIdDep,
     service: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
 ) -> Envelope[Deleted]:
     service.leave_editors(
@@ -168,7 +145,6 @@ async def leave_editors(
 @router.delete(
     "/{editor_id}",
     response_model=Envelope[Deleted],
-    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def remove_editor(
@@ -176,7 +152,7 @@ async def remove_editor(
     editor_id: EditorIdPath,
     request: Request,
     actor_id: UserIdDep,
-    owner_id: EditorOwnerIdDep,
+    owner_id: OwnerIdDep,
     service: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
 ) -> Envelope[Deleted]:
     service.remove_editor(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/editors/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/editors/schemas.py
@@ -1,0 +1,74 @@
+"""Public contracts for Bot editor management."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agentclaw.community.adapters.http.openapi_v1.enums import _DocumentedEnum
+
+
+_STRICT = ConfigDict(extra="forbid")
+
+
+class EditorRole(_DocumentedEnum):
+    """Permission granted to a Bot editor."""
+
+    ADMIN = "admin"
+    MEMBER = "member"
+
+    __descriptions__ = {
+        "admin": "May manage editors and perform administrative Bot operations.",
+        "member": "May edit and operate the Bot without managing editors.",
+    }
+
+
+class EditorCreate(BaseModel):
+    """Editor identity and role to add to the addressed Bot."""
+
+    model_config = _STRICT
+
+    editor_user_id: str = Field(
+        min_length=1,
+        max_length=256,
+        description="User identifier to add as an editor.",
+    )
+    user_name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=100,
+        description="Optional display name stored with the editor relation.",
+    )
+    role: EditorRole = Field(
+        default=EditorRole.MEMBER,
+        description="Permission granted to the editor.",
+    )
+
+
+class EditorUpdate(BaseModel):
+    """Mutable fields of an existing editor relation."""
+
+    model_config = _STRICT
+
+    role: EditorRole = Field(description="Replacement editor permission.")
+
+
+class Editor(BaseModel):
+    """One editor relation on a Bot."""
+
+    id: int = Field(description="Stable editor-relation identifier.")
+    user_id: str = Field(description="Editor user identifier.")
+    user_name: str | None = Field(
+        default=None, description="Stored editor display name, when available."
+    )
+    role: EditorRole = Field(description="Current editor permission.")
+    created_at: datetime = Field(description="When the editor was added.")
+    updated_at: datetime = Field(description="When the relation last changed.")
+
+
+class EditorList(BaseModel):
+    """All editor relations on the addressed Bot."""
+
+    total: int = Field(description="Number of editor relations returned.")
+    items: list[Editor] = Field(description="Editors ordered by creation time.")

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/gating.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/gating.py
@@ -1,6 +1,6 @@
 """The resolve-and-gate step every engine-runtime group runs before forwarding.
 
-One helper, used by the sessions, engine, models and approvals routers (the
+One helper, used by the sessions, engine, models, nodes and approvals routers (the
 connection endpoint runs the same gate inside ``EngineConnectionService``,
 where its socket is composed). The rules themselves live in
 ``core/engine_runtime/gate.py``: who may operate a bot (its owner, or a

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/nodes/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/nodes/__init__.py
@@ -1,0 +1,5 @@
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.nodes.router import (
+    router,
+)
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/nodes/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/nodes/router.py
@@ -1,0 +1,137 @@
+"""Nodes group — ``/openapi/v1/bots/{bot_id}/nodes``.
+
+The current frontend and engine expose node inventory as a read-only list. This
+public group mirrors only that capability; registration, removal and status
+writes remain outside the contract until a real product flow and engine HTTP
+surface exist for them.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Query, Request
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import BotIdPath, Envelope
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.enums import (
+    RuntimeStage,
+)
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.gating import (
+    resolve_operable_bot,
+)
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.nodes.schemas import (
+    Node,
+)
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.params import (
+    OwnerIdDep,
+    StageQuery,
+)
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    envelope,
+    envelope_errors,
+)
+from agentclaw.community.api.engine_runtime_service import EngineRuntimeRelayProtocol
+from agentclaw.community.core.engine_runtime.errors import EngineUpstreamError
+from agentclaw.community.di import Injected
+
+router = APIRouter(prefix="/openapi/v1/bots/{bot_id}/nodes", tags=["nodes"])
+
+NodeStatusQuery = Annotated[
+    str | None,
+    Query(max_length=128, description="Optional exact node-status filter."),
+]
+NodePlatformQuery = Annotated[
+    str | None,
+    Query(max_length=128, description="Optional exact node-platform filter."),
+]
+NodeLimitQuery = Annotated[
+    int,
+    Query(ge=1, le=100, description="Maximum nodes returned (max 100)."),
+]
+NodeOffsetQuery = Annotated[
+    int,
+    Query(ge=0, description="Zero-based number of matching nodes to skip."),
+]
+
+
+def _optional_text(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _map_node(data: Any) -> Node:
+    if not isinstance(data, dict):
+        raise EngineUpstreamError("node list contains a non-object item")
+    node_id = data.get("nodeId")
+    status = data.get("status")
+    if not isinstance(node_id, str) or not node_id:
+        raise EngineUpstreamError("node list item carries no nodeId")
+    if not isinstance(status, str) or not status:
+        raise EngineUpstreamError("node list item carries no status")
+    return Node(
+        node_id=node_id,
+        display_name=_optional_text(data.get("displayName")),
+        platform=_optional_text(data.get("platform")),
+        version=_optional_text(data.get("version")),
+        capabilities=_string_list(data.get("capabilities")),
+        commands=_string_list(data.get("commands")),
+        remote_ip=_optional_text(data.get("remoteIp")),
+        status=status,
+    )
+
+
+@router.get("", response_model=Envelope[list[Node]])
+@envelope_errors
+async def list_nodes(
+    bot_id: BotIdPath,
+    user_id: UserIdDep,
+    owner_id: OwnerIdDep,
+    request: Request,
+    status: NodeStatusQuery = None,
+    platform: NodePlatformQuery = None,
+    limit: NodeLimitQuery = 20,
+    offset: NodeOffsetQuery = 0,
+    stage: StageQuery = RuntimeStage.DRAFT,
+    relay: EngineRuntimeRelayProtocol = Injected(EngineRuntimeRelayProtocol),
+) -> Envelope[list[Node]]:
+    """List nodes visible to the addressed bot runtime."""
+    # COSEC: resolve the live owner/editor relationship before fetching the
+    # device-wide node inventory; authorization failures stay masked as 404.
+    facts = await resolve_operable_bot(
+        relay,
+        bot_id,
+        caller_id=user_id,
+        owner_id=owner_id,
+        stage=stage.value,
+        surface="nodes",
+    )
+    result = await relay.call(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        facts=facts,
+        stage=stage.value,
+        method="GET",
+        path="/api/nodes",
+        params={
+            key: value
+            for key, value in {
+                "status": status,
+                "platform": platform,
+                "limit": limit,
+                "offset": offset,
+            }.items()
+            if value is not None
+        },
+    )
+    if not isinstance(result.data, list):
+        raise EngineUpstreamError("node list payload is not a list")
+    return envelope([_map_node(item) for item in result.data], request)
+
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/nodes/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/nodes/schemas.py
@@ -1,0 +1,48 @@
+"""Request/response models for the nodes group."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Node(BaseModel):
+    """A node currently visible to the bot's engine runtime."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "node_id": "node-01",
+                "display_name": "Joseph's Mac",
+                "platform": "darwin",
+                "version": "1.2.0",
+                "capabilities": ["screen", "shell"],
+                "commands": ["system.run"],
+                "remote_ip": "203.0.113.10",
+                "status": "online",
+            }
+        }
+    )
+
+    node_id: str = Field(description="Stable node identifier used by runtime calls.")
+    display_name: str | None = Field(
+        default=None, description="Human-readable node name, when reported."
+    )
+    platform: str | None = Field(
+        default=None, description="Node operating-system or platform name."
+    )
+    version: str | None = Field(
+        default=None, description="Node agent version, when reported."
+    )
+    capabilities: list[str] = Field(
+        default_factory=list, description="Capabilities declared by the node."
+    )
+    commands: list[str] = Field(
+        default_factory=list, description="Commands declared by the node."
+    )
+    remote_ip: str | None = Field(
+        default=None, description="Remote address reported by the engine."
+    )
+    status: str = Field(description="Current node status reported by the engine.")
+
+
+__all__ = ["Node"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/params.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/params.py
@@ -117,7 +117,7 @@ async def resolve_owner_id(
     request acts for.
 
     **This is the one place an application caller differs from a human on these
-    sixteen operations.** For an application the addressed owner comes from the
+    runtime operations.** For an application the addressed owner comes from the
     **grant record** (``granted_owner_id``), never from the request, and an
     explicitly supplied value must agree with it. Two reasons it is refused here
     rather than left to fail downstream:

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/render_screens/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/render_screens/__init__.py
@@ -1,0 +1,5 @@
+"""Public Bot render-screen configuration API."""
+
+from .router import router
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/render_screens/gating.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/render_screens/gating.py
@@ -1,0 +1,90 @@
+"""Authorization and record scoping for public render-screen operations."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from agentclaw.community.api.bot_service import BotServiceProtocol
+from agentclaw.community.api.collaborator_service import CollaboratorServiceProtocol
+from agentclaw.community.api.render_screen_service import RenderScreenServiceProtocol
+from agentclaw.community.core.bot_collaborator.models import PermissionLevel
+from agentclaw.community.core.bot_management.render_screen.errors import (
+    RenderScreenNotFoundError,
+)
+from agentclaw.community.core.bot_management.render_screen.models import (
+    RenderScreenRecord,
+)
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotNotFoundError,
+)
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+def resolve_readable_bot(
+    bots: BotServiceProtocol,
+    *,
+    bot_id: str,
+    owner_id: str,
+) -> Mapping[str, Any]:
+    """Resolve a Bot for non-sensitive render-screen reads.
+
+    Authentication and, for an application caller, its Bot grant are enforced
+    by route dependencies. Human reads deliberately do not require an Editor
+    relation because group/share viewers need the CDN mapping to render panels.
+    """
+    try:
+        bot = bots.get_bot(bot_id, owner_id)
+    except BotNotFoundError:
+        raise RenderScreenNotFoundError("render screen not found") from None
+    if not bot:
+        raise RenderScreenNotFoundError("render screen not found")
+    return bot
+
+
+def require_editable_bot(
+    bots: BotServiceProtocol,
+    collaborators: CollaboratorServiceProtocol,
+    *,
+    bot_id: str,
+    owner_id: str,
+    actor_id: str,
+) -> Mapping[str, Any]:
+    """Resolve the Bot and require its live effective Editor permission."""
+    bot = resolve_readable_bot(bots, bot_id=bot_id, owner_id=owner_id)
+    level = collaborators.get_operable_permission_level(
+        bot=bot,
+        user_id=actor_id,
+    )
+    if level < PermissionLevel.MEMBER:
+        # COSEC: mask edit authorization failures as absence to prevent Bot-ID
+        # probing while still allowing authenticated viewers to use the GET.
+        raise RenderScreenNotFoundError("render screen not found")
+    return bot
+
+
+def require_scoped_record(
+    service: RenderScreenServiceProtocol,
+    *,
+    record_id: int,
+    bot_id: str,
+    owner_id: str,
+) -> RenderScreenRecord:
+    """Bind a public record id back to the addressed Bot before mutation."""
+    record = service.get_render_screen(record_id)
+    # COSEC: a numeric render-screen id is never authority. Rebind it to the
+    # addressed Bot, owner and environment so guessed ids cannot cross scopes.
+    if (
+        record is None
+        or record.bot_id != bot_id
+        or record.owner_id != owner_id
+        or record.env != get_current_env()
+    ):
+        raise RenderScreenNotFoundError("render screen not found")
+    return record
+
+
+__all__ = [
+    "require_editable_bot",
+    "require_scoped_record",
+    "resolve_readable_bot",
+]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/render_screens/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/render_screens/router.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, Query, Request
+from fastapi import APIRouter, Path, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     BotIdPath,
@@ -14,10 +14,7 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.params import (
     OwnerIdDep,
 )
-from agentclaw.community.adapters.http.openapi_v1.principal import (
-    UserIdDep,
-    refuse_app_only_caller,
-)
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     created,
     deleted,
@@ -49,33 +46,12 @@ router = APIRouter(
     prefix="/openapi/v1/bots/{bot_id}/render-screens",
     tags=["render-screens"],
 )
-_REFUSES_APP_ONLY = [Depends(refuse_app_only_caller)]
 RenderScreenIdPath = Annotated[
     int,
     Path(
         ge=1,
         description="Render-screen mapping identifier returned by this collection.",
     ),
-]
-
-
-async def resolve_render_screen_write_owner_id(
-    actor_id: UserIdDep,
-    owner_id: Annotated[
-        str | None,
-        Query(
-            min_length=1,
-            description="Owner of the Bot whose render-screen configuration is addressed. "
-            "Defaults to the current user; editors name the Bot Owner.",
-        ),
-    ] = None,
-) -> str:
-    """Resolve the owner for a human-only render-screen mutation."""
-    return owner_id if owner_id is not None else actor_id
-
-
-RenderScreenWriteOwnerIdDep = Annotated[
-    str, Depends(resolve_render_screen_write_owner_id)
 ]
 
 
@@ -111,7 +87,6 @@ async def list_render_screens(
     "",
     status_code=201,
     response_model=Envelope[RenderScreen],
-    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def create_render_screen(
@@ -119,11 +94,9 @@ async def create_render_screen(
     body: RenderScreenCreate,
     request: Request,
     actor_id: UserIdDep,
-    owner_id: RenderScreenWriteOwnerIdDep,
+    owner_id: OwnerIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
-    collaborators: CollaboratorServiceProtocol = Injected(
-        CollaboratorServiceProtocol
-    ),
+    collaborators: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
     service: RenderScreenServiceProtocol = Injected(RenderScreenServiceProtocol),
 ) -> Envelope[RenderScreen]:
     """Add a CDN mapping; Bot Owner or live Editor Member access is required."""
@@ -156,7 +129,6 @@ async def create_render_screen(
 @router.patch(
     "/{render_screen_id}",
     response_model=Envelope[RenderScreen],
-    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def update_render_screen(
@@ -165,11 +137,9 @@ async def update_render_screen(
     body: RenderScreenUpdate,
     request: Request,
     actor_id: UserIdDep,
-    owner_id: RenderScreenWriteOwnerIdDep,
+    owner_id: OwnerIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
-    collaborators: CollaboratorServiceProtocol = Injected(
-        CollaboratorServiceProtocol
-    ),
+    collaborators: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
     service: RenderScreenServiceProtocol = Injected(RenderScreenServiceProtocol),
 ) -> Envelope[RenderScreen]:
     """Replace one mapping after binding its id to the addressed Bot."""
@@ -206,7 +176,6 @@ async def update_render_screen(
 @router.delete(
     "/{render_screen_id}",
     response_model=Envelope[Deleted],
-    dependencies=_REFUSES_APP_ONLY,
 )
 @envelope_errors
 async def delete_render_screen(
@@ -214,11 +183,9 @@ async def delete_render_screen(
     render_screen_id: RenderScreenIdPath,
     request: Request,
     actor_id: UserIdDep,
-    owner_id: RenderScreenWriteOwnerIdDep,
+    owner_id: OwnerIdDep,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
-    collaborators: CollaboratorServiceProtocol = Injected(
-        CollaboratorServiceProtocol
-    ),
+    collaborators: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
     service: RenderScreenServiceProtocol = Injected(RenderScreenServiceProtocol),
 ) -> Envelope[Deleted]:
     """Soft-delete one mapping after Bot and record authorization."""
@@ -243,11 +210,9 @@ async def delete_render_screen(
 
 
 __all__ = [
-    "RenderScreenWriteOwnerIdDep",
     "create_render_screen",
     "delete_render_screen",
     "list_render_screens",
-    "resolve_render_screen_write_owner_id",
     "router",
     "update_render_screen",
 ]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/render_screens/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/render_screens/router.py
@@ -1,0 +1,253 @@
+"""Public bot-first CRUD routes for render-screen CDN mappings."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, Query, Request
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    BotIdPath,
+    Deleted,
+    Envelope,
+)
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.params import (
+    OwnerIdDep,
+)
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    UserIdDep,
+    refuse_app_only_caller,
+)
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    created,
+    deleted,
+    envelope,
+    envelope_errors,
+)
+from agentclaw.community.api.bot_service import BotServiceProtocol
+from agentclaw.community.api.collaborator_service import CollaboratorServiceProtocol
+from agentclaw.community.api.render_screen_service import RenderScreenServiceProtocol
+from agentclaw.community.core.bot_management.render_screen.errors import (
+    RenderScreenConflictError,
+    RenderScreenNotFoundError,
+)
+from agentclaw.community.core.bot_management.render_screen.models import (
+    RenderScreenRecord,
+)
+from agentclaw.community.di import Injected
+
+from .gating import require_editable_bot, require_scoped_record, resolve_readable_bot
+from .schemas import (
+    RenderScreen,
+    RenderScreenCreate,
+    RenderScreenList,
+    RenderScreenUpdate,
+)
+
+
+router = APIRouter(
+    prefix="/openapi/v1/bots/{bot_id}/render-screens",
+    tags=["render-screens"],
+)
+_REFUSES_APP_ONLY = [Depends(refuse_app_only_caller)]
+RenderScreenIdPath = Annotated[
+    int,
+    Path(
+        ge=1,
+        description="Render-screen mapping identifier returned by this collection.",
+    ),
+]
+
+
+async def resolve_render_screen_write_owner_id(
+    actor_id: UserIdDep,
+    owner_id: Annotated[
+        str | None,
+        Query(
+            min_length=1,
+            description="Owner of the Bot whose render-screen configuration is addressed. "
+            "Defaults to the current user; editors name the Bot Owner.",
+        ),
+    ] = None,
+) -> str:
+    """Resolve the owner for a human-only render-screen mutation."""
+    return owner_id if owner_id is not None else actor_id
+
+
+RenderScreenWriteOwnerIdDep = Annotated[
+    str, Depends(resolve_render_screen_write_owner_id)
+]
+
+
+def _screen(record: RenderScreenRecord) -> RenderScreen:
+    return RenderScreen(
+        id=record.id,
+        name=record.name,
+        cdn_url=record.cdn_url,
+        creator_id=record.creator_id,
+        created_at=record.gmt_create,
+        updated_at=record.gmt_modified,
+    )
+
+
+@router.get("", response_model=Envelope[RenderScreenList])
+@envelope_errors
+async def list_render_screens(
+    bot_id: BotIdPath,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: OwnerIdDep,
+    bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
+    service: RenderScreenServiceProtocol = Injected(RenderScreenServiceProtocol),
+) -> Envelope[RenderScreenList]:
+    """List the non-sensitive CDN mappings needed to render this Bot's panels."""
+    resolve_readable_bot(bot_service, bot_id=bot_id, owner_id=owner_id)
+    records = service.list_render_screens(bot_id=bot_id, owner_id=owner_id)
+    items = [_screen(record) for record in records]
+    return envelope(RenderScreenList(total=len(items), items=items), request)
+
+
+@router.post(
+    "",
+    status_code=201,
+    response_model=Envelope[RenderScreen],
+    dependencies=_REFUSES_APP_ONLY,
+)
+@envelope_errors
+async def create_render_screen(
+    bot_id: BotIdPath,
+    body: RenderScreenCreate,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: RenderScreenWriteOwnerIdDep,
+    bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
+    collaborators: CollaboratorServiceProtocol = Injected(
+        CollaboratorServiceProtocol
+    ),
+    service: RenderScreenServiceProtocol = Injected(RenderScreenServiceProtocol),
+) -> Envelope[RenderScreen]:
+    """Add a CDN mapping; Bot Owner or live Editor Member access is required."""
+    require_editable_bot(
+        bot_service,
+        collaborators,
+        bot_id=bot_id,
+        owner_id=owner_id,
+        actor_id=actor_id,
+    )
+    try:
+        record_id = service.create_render_screen(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            name=body.name,
+            cdn_url=str(body.cdn_url),
+            creator_id=actor_id,
+        )
+    except ValueError as exc:
+        raise RenderScreenConflictError("render screen conflict") from exc
+    record = require_scoped_record(
+        service,
+        record_id=record_id,
+        bot_id=bot_id,
+        owner_id=owner_id,
+    )
+    return created(_screen(record), request)
+
+
+@router.patch(
+    "/{render_screen_id}",
+    response_model=Envelope[RenderScreen],
+    dependencies=_REFUSES_APP_ONLY,
+)
+@envelope_errors
+async def update_render_screen(
+    bot_id: BotIdPath,
+    render_screen_id: RenderScreenIdPath,
+    body: RenderScreenUpdate,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: RenderScreenWriteOwnerIdDep,
+    bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
+    collaborators: CollaboratorServiceProtocol = Injected(
+        CollaboratorServiceProtocol
+    ),
+    service: RenderScreenServiceProtocol = Injected(RenderScreenServiceProtocol),
+) -> Envelope[RenderScreen]:
+    """Replace one mapping after binding its id to the addressed Bot."""
+    require_editable_bot(
+        bot_service,
+        collaborators,
+        bot_id=bot_id,
+        owner_id=owner_id,
+        actor_id=actor_id,
+    )
+    require_scoped_record(
+        service,
+        record_id=render_screen_id,
+        bot_id=bot_id,
+        owner_id=owner_id,
+    )
+    try:
+        service.update_render_screen(
+            record_id=render_screen_id,
+            name=body.name,
+            cdn_url=str(body.cdn_url),
+        )
+    except ValueError as exc:
+        raise RenderScreenNotFoundError("render screen not found") from exc
+    updated = require_scoped_record(
+        service,
+        record_id=render_screen_id,
+        bot_id=bot_id,
+        owner_id=owner_id,
+    )
+    return envelope(_screen(updated), request)
+
+
+@router.delete(
+    "/{render_screen_id}",
+    response_model=Envelope[Deleted],
+    dependencies=_REFUSES_APP_ONLY,
+)
+@envelope_errors
+async def delete_render_screen(
+    bot_id: BotIdPath,
+    render_screen_id: RenderScreenIdPath,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: RenderScreenWriteOwnerIdDep,
+    bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
+    collaborators: CollaboratorServiceProtocol = Injected(
+        CollaboratorServiceProtocol
+    ),
+    service: RenderScreenServiceProtocol = Injected(RenderScreenServiceProtocol),
+) -> Envelope[Deleted]:
+    """Soft-delete one mapping after Bot and record authorization."""
+    require_editable_bot(
+        bot_service,
+        collaborators,
+        bot_id=bot_id,
+        owner_id=owner_id,
+        actor_id=actor_id,
+    )
+    require_scoped_record(
+        service,
+        record_id=render_screen_id,
+        bot_id=bot_id,
+        owner_id=owner_id,
+    )
+    try:
+        service.delete_render_screen(record_id=render_screen_id)
+    except ValueError as exc:
+        raise RenderScreenNotFoundError("render screen not found") from exc
+    return deleted(request)
+
+
+__all__ = [
+    "RenderScreenWriteOwnerIdDep",
+    "create_render_screen",
+    "delete_render_screen",
+    "list_render_screens",
+    "resolve_render_screen_write_owner_id",
+    "router",
+    "update_render_screen",
+]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/render_screens/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/render_screens/schemas.py
@@ -1,0 +1,66 @@
+"""Public contracts for Bot render-screen CDN mappings."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+
+
+_STRICT = ConfigDict(extra="forbid")
+
+
+class RenderScreenCreate(BaseModel):
+    """One component-library mapping to add to the addressed Bot."""
+
+    model_config = _STRICT
+
+    name: str = Field(
+        min_length=1,
+        max_length=256,
+        description="Component-library name, unique within the Bot.",
+    )
+    cdn_url: HttpUrl = Field(
+        max_length=1024,
+        description="HTTP(S) URL of the component library's UMD bundle.",
+    )
+
+
+class RenderScreenUpdate(BaseModel):
+    """Replacement fields for one render-screen mapping."""
+
+    model_config = _STRICT
+
+    name: str = Field(
+        min_length=1,
+        max_length=256,
+        description="Replacement component-library name.",
+    )
+    cdn_url: HttpUrl = Field(
+        max_length=1024,
+        description="Replacement HTTP(S) URL of the UMD bundle.",
+    )
+
+
+class RenderScreen(BaseModel):
+    """One render-screen component-library mapping."""
+
+    id: int = Field(description="Stable mapping identifier used by mutations.")
+    name: str = Field(description="Component-library name.")
+    cdn_url: str = Field(description="HTTP(S) URL of the UMD bundle.")
+    creator_id: str = Field(description="User who created the mapping.")
+    created_at: datetime | None = Field(
+        default=None, description="When the mapping was created."
+    )
+    updated_at: datetime | None = Field(
+        default=None, description="When the mapping was last modified."
+    )
+
+
+class RenderScreenList(BaseModel):
+    """All live render-screen mappings on the addressed Bot."""
+
+    total: int = Field(description="Number of mappings returned.")
+    items: list[RenderScreen] = Field(
+        description="Mappings ordered by creation time, newest first."
+    )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -71,6 +71,16 @@ from agentclaw.community.core.bot_app_grant.errors import (
     GrantNotFoundError,
     GrantOwnerConflictError,
 )
+from agentclaw.community.core.bot_collaborator.errors import (
+    BotNotFoundError as CollaboratorBotNotFoundError,
+    BotNotServiceTypeError,
+    CannotRemoveSelfError,
+    CollaboratorAlreadyExistsError,
+    CollaboratorNotFoundError,
+    CollaboratorSpaceMembershipError,
+    InvalidCollaboratorRoleError,
+    PermissionDeniedError as CollaboratorPermissionDeniedError,
+)
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotInvalidLifecycleStateError,
     BotLimitExceededError,
@@ -86,6 +96,10 @@ from agentclaw.community.core.channel.errors import (
     ChannelEditLockedError,
     ChannelNotFoundError,
     ChannelSyncError,
+)
+from agentclaw.community.core.bot_management.render_screen.errors import (
+    RenderScreenConflictError,
+    RenderScreenNotFoundError,
 )
 from agentclaw.community.core.bot_chat.errors import (
     InvalidBotLogQueryError,
@@ -360,6 +374,19 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
         409,
         "Another authorization for this bot id is already live",
     ),
+    CollaboratorBotNotFoundError: (404, "Not found"),
+    CollaboratorPermissionDeniedError: (404, "Not found"),
+    CollaboratorNotFoundError: (404, "Not found"),
+    CollaboratorAlreadyExistsError: (409, "Editor already exists"),
+    CannotRemoveSelfError: (409, "Use the leave operation to remove yourself"),
+    BotNotServiceTypeError: (409, "Editors are not supported for this bot"),
+    InvalidCollaboratorRoleError: (400, "Invalid editor role"),
+    CollaboratorSpaceMembershipError: (
+        409,
+        "Editor must be a member of the Bot Team Space",
+    ),
+    RenderScreenNotFoundError: (404, "Not found"),
+    RenderScreenConflictError: (409, "Render-screen mapping already exists"),
     BotPermissionError: (404, "Not found"),
     ServiceContainerNotFoundError: (404, "Not found"),
     ServiceContainerConflictError: (

--- a/src/backend/src/agentclaw/community/api/README.md
+++ b/src/backend/src/agentclaw/community/api/README.md
@@ -51,6 +51,7 @@ consumes:
   - "No service impls at import time — Protocols only declare shape, they don't depend on concrete services"
   - "A small number of core dataclass / schema types used to type Protocol method signatures (see internal_dependencies)"
 internal_dependencies:
+  - agentclaw.community.core.bot_collaborator.models # Collaborator records, roles and permission levels — typed in collaborator_service.py
   - agentclaw.community.core.access.models            # UserInfoRecord — typed in user_service.py
   - agentclaw.community.core.bot_app_grant.models    # BotAppGrantRecord — typed in bot_app_grant_service.py (real signatures, so the conformance gate can compare them)
   - agentclaw.community.core.bot_chat.schemas        # ConversationDetail, HealthCheckData — typed in bot_chat_service.py

--- a/src/backend/src/agentclaw/community/api/bot_inventory_service.py
+++ b/src/backend/src/agentclaw/community/api/bot_inventory_service.py
@@ -19,7 +19,7 @@ class BotInventoryServiceProtocol(Protocol):
         self,
         *,
         owner_id: str,
-        space: BusinessSpaceRef | None,
+        space: BusinessSpaceRef,
         keyword: str | None,
         engine: str | None,
         deploy_mode: DeployMode | None,

--- a/src/backend/src/agentclaw/community/api/collaborator_service.py
+++ b/src/backend/src/agentclaw/community/api/collaborator_service.py
@@ -1,27 +1,163 @@
 """Service API Protocol for bot collaborator management."""
+
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Dict, List, Mapping, Optional, Protocol, Sequence, runtime_checkable
+
+from agentclaw.community.core.bot_collaborator.models import (
+    CollaboratorRecord,
+    CollaboratorRole,
+    PermissionLevel,
+)
 
 
 @runtime_checkable
 class CollaboratorServiceProtocol(Protocol):
     """Service API for managing bot collaborators."""
 
-    def add_collaborator(self, *args: Any, **kwargs: Any) -> Any: ...
+    def add_collaborator(
+        self,
+        bot_id: str,
+        owner_id: str,
+        user_id: str,
+        operator_id: str,
+        user_name: Optional[str] = None,
+        role: str = CollaboratorRole.ADMIN,
+        env: Optional[str] = None,
+    ) -> CollaboratorRecord: ...
 
-    def list_collaborators(self, *args: Any, **kwargs: Any) -> Any: ...
+    def list_collaborators(
+        self,
+        bot_id: str,
+        owner_id: str,
+        user_id: str,
+        role: Optional[str] = None,
+        env: Optional[str] = None,
+    ) -> List[CollaboratorRecord]: ...
 
-    def update_collaborator(self, *args: Any, **kwargs: Any) -> Any: ...
+    def update_collaborator(
+        self,
+        collaborator_id: int,
+        operator_id: str,
+        user_id: Optional[str] = None,
+        user_name: Optional[str] = None,
+        role: Optional[str] = None,
+        env: Optional[str] = None,
+    ) -> CollaboratorRecord: ...
 
-    def remove_collaborator(self, *args: Any, **kwargs: Any) -> Any: ...
+    def remove_collaborator(
+        self,
+        collaborator_id: int,
+        operator_id: str,
+        env: Optional[str] = None,
+    ) -> bool: ...
 
-    def leave_collaboration(self, *args: Any, **kwargs: Any) -> Any: ...
+    def leave_collaboration(
+        self,
+        bot_id: str,
+        owner_id: str,
+        user_id: str,
+        env: Optional[str] = None,
+    ) -> bool: ...
 
-    def check_collaborator_permission(self, *args: Any, **kwargs: Any) -> Any: ...
+    def check_collaborator_permission(
+        self,
+        bot_id: str,
+        owner_id: str,
+        user_id: str,
+        required_level: PermissionLevel,
+        env: Optional[str] = None,
+    ) -> Dict[str, Any]: ...
 
-    def check_permission(self, *args: Any, **kwargs: Any) -> Any: ...
+    def check_permission(
+        self,
+        bot_pk: int,
+        user_id: str,
+        owner_id: str,
+        required_level: PermissionLevel,
+        env: Optional[str] = None,
+    ) -> None: ...
 
-    def get_permission_level(self, *args: Any, **kwargs: Any) -> Any: ...
+    def get_permission_level(
+        self,
+        bot_pk: int,
+        user_id: str,
+        owner_id: str,
+        env: Optional[str] = None,
+    ) -> PermissionLevel: ...
 
-    def list_user_collaborations(self, *args: Any, **kwargs: Any) -> Any: ...
+    def get_operable_permission_level(
+        self,
+        *,
+        bot: Mapping[str, Any],
+        user_id: str,
+        env: Optional[str] = None,
+    ) -> PermissionLevel: ...
+
+    def get_operable_permission_levels(
+        self,
+        *,
+        bots: Sequence[Mapping[str, Any]],
+        user_id: str,
+        env: Optional[str] = None,
+    ) -> Dict[int, PermissionLevel]: ...
+
+    def list_user_collaborations(
+        self,
+        user_id: str,
+        env: Optional[str] = None,
+    ) -> List[CollaboratorRecord]: ...
+
+    def add_editor(
+        self,
+        bot_id: str,
+        owner_id: str,
+        user_id: str,
+        operator_id: str,
+        user_name: Optional[str] = None,
+        role: str = CollaboratorRole.MEMBER,
+        env: Optional[str] = None,
+    ) -> CollaboratorRecord: ...
+
+    def list_editors(
+        self,
+        bot_id: str,
+        owner_id: str,
+        user_id: str,
+        role: Optional[str] = None,
+        env: Optional[str] = None,
+    ) -> List[CollaboratorRecord]: ...
+
+    def update_editor(
+        self,
+        bot_id: str,
+        owner_id: str,
+        collaborator_id: int,
+        operator_id: str,
+        role: str,
+        env: Optional[str] = None,
+    ) -> CollaboratorRecord: ...
+
+    def remove_editor(
+        self,
+        bot_id: str,
+        owner_id: str,
+        collaborator_id: int,
+        operator_id: str,
+        env: Optional[str] = None,
+    ) -> bool: ...
+
+    def leave_editors(
+        self,
+        bot_id: str,
+        owner_id: str,
+        user_id: str,
+        env: Optional[str] = None,
+    ) -> bool: ...
+
+    def on_collaboration_changed(
+        self,
+        bot_id: str,
+        owner_id: str,
+        env: Optional[str] = None,
+    ) -> List[Dict[str, Any]]: ...

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/errors.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/errors.py
@@ -1,0 +1,50 @@
+"""Domain errors for Bot collaborator and editor management."""
+
+
+class CollaboratorServiceError(Exception):
+    """Base error for collaborator management."""
+
+
+class PermissionDeniedError(CollaboratorServiceError):
+    """The actor lacks the required Bot permission."""
+
+
+class CollaboratorNotFoundError(CollaboratorServiceError):
+    """The addressed collaborator relation does not exist."""
+
+
+class CollaboratorAlreadyExistsError(CollaboratorServiceError):
+    """The user is already a collaborator on the Bot."""
+
+
+class CannotRemoveSelfError(CollaboratorServiceError):
+    """A non-owner attempted to remove their own relation through admin CRUD."""
+
+
+class BotNotFoundError(CollaboratorServiceError):
+    """The addressed Bot does not exist in the selected owner scope."""
+
+
+class BotNotServiceTypeError(CollaboratorServiceError):
+    """The Bot does not support collaborator management."""
+
+
+class InvalidCollaboratorRoleError(CollaboratorServiceError):
+    """The requested collaborator role is unsupported."""
+
+
+class CollaboratorSpaceMembershipError(CollaboratorServiceError):
+    """The editor candidate is not a live member of the Bot's Team Space."""
+
+
+__all__ = [
+    "BotNotFoundError",
+    "BotNotServiceTypeError",
+    "CannotRemoveSelfError",
+    "CollaboratorAlreadyExistsError",
+    "CollaboratorNotFoundError",
+    "CollaboratorServiceError",
+    "CollaboratorSpaceMembershipError",
+    "InvalidCollaboratorRoleError",
+    "PermissionDeniedError",
+]

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/protocols.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/protocols.py
@@ -12,7 +12,10 @@
 """
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from inspect import signature
+from typing import Any, Mapping, Protocol, runtime_checkable
+
+from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 
 
 @runtime_checkable
@@ -39,3 +42,32 @@ class CollaboratorServiceProtocol(Protocol):
     def get_permission_level(self, *args: Any, **kwargs: Any) -> Any:
         """获取用户在 Bot 中的权限级别（bot_pk 定位，无额外 Bot 查询）."""
         ...
+
+    def get_operable_permission_level(self, *args: Any, **kwargs: Any) -> Any:
+        """获取叠加实时 Space 成员关系后的有效 Bot 权限."""
+        ...
+
+
+def resolve_operable_permission_level(
+    collaborators: CollaboratorServiceProtocol,
+    *,
+    bot: Mapping[str, Any],
+    user_id: str,
+    owner_id: str,
+    env: str | None = None,
+) -> PermissionLevel:
+    """Call the effective policy while legacy test doubles migrate in-place."""
+    if user_id == owner_id:
+        return PermissionLevel.OWNER
+    method = getattr(type(collaborators), "get_operable_permission_level", None)
+    if callable(method):
+        return PermissionLevel(
+            method(collaborators, bot=bot, user_id=user_id, env=env)
+        )
+    legacy_method = collaborators.get_permission_level
+    legacy_args = (int(bot.get("id") or 0), user_id, owner_id)
+    try:
+        signature(legacy_method).bind(*legacy_args, env)
+    except TypeError:
+        return PermissionLevel(legacy_method(*legacy_args))
+    return PermissionLevel(legacy_method(*legacy_args, env))

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
@@ -2,8 +2,10 @@
 
 提供协作者的 CRUD 操作和权限检查功能。
 """
+
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, List, Optional, Dict, Any
 
 from agentclaw.community.core.bot_collaborator.models import (
@@ -11,11 +13,28 @@ from agentclaw.community.core.bot_collaborator.models import (
     CollaboratorRole,
     PermissionLevel,
 )
-from agentclaw.community.core.repository.protocols.bot import CollaboratorRepositoryProtocol
+from agentclaw.community.core.bot_collaborator.errors import (
+    BotNotFoundError,
+    BotNotServiceTypeError,
+    CannotRemoveSelfError,
+    CollaboratorAlreadyExistsError,
+    CollaboratorNotFoundError,
+    CollaboratorServiceError,
+    CollaboratorSpaceMembershipError,
+    InvalidCollaboratorRoleError,
+    PermissionDeniedError,
+)
+from agentclaw.community.core.repository.protocols.bot import (
+    CollaboratorRepositoryProtocol,
+)
 from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
     MemberManagementCapabilityService,
 )
+from agentclaw.community.core.bot_collaborator.services.editor_policy import (
+    EditorPolicy,
+)
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.log import get_logger
 
@@ -27,48 +46,23 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
+__all__ = [
+    "BotNotFoundError",
+    "BotNotServiceTypeError",
+    "CannotRemoveSelfError",
+    "CollaboratorAlreadyExistsError",
+    "CollaboratorNotFoundError",
+    "CollaboratorService",
+    "CollaboratorServiceError",
+    "CollaboratorSpaceMembershipError",
+    "InvalidCollaboratorRoleError",
+    "PermissionDeniedError",
+]
+
 # 运行设备 .credentials 的 ADMINS= 同步由 ``DeviceCredentialsAdminsWriter`` 负责
 # (``core/bot_collaborator/services/credentials_admins_writer.py``):对 service bot 解析
 # 在线 binding (ext.binding.online)、对其它 bot 回退 resolve_for_bot,read-modify-write
 # 既有文件。本模块不再直接解析设备 / 读写 .credentials。
-
-
-# ============================================================================
-# 异常定义
-# ============================================================================
-class CollaboratorServiceError(Exception):
-    """协作者服务基础异常。"""
-    pass
-
-
-class PermissionDeniedError(CollaboratorServiceError):
-    """权限不足异常。"""
-    pass
-
-
-class CollaboratorNotFoundError(CollaboratorServiceError):
-    """协作者不存在异常。"""
-    pass
-
-
-class CollaboratorAlreadyExistsError(CollaboratorServiceError):
-    """协作者已存在异常。"""
-    pass
-
-
-class CannotRemoveSelfError(CollaboratorServiceError):
-    """不能移除自己异常。"""
-    pass
-
-
-class BotNotFoundError(CollaboratorServiceError):
-    """Bot 不存在异常。"""
-    pass
-
-
-class BotNotServiceTypeError(CollaboratorServiceError):
-    """Bot 不是服务型异常。"""
-    pass
 
 
 # ============================================================================
@@ -86,7 +80,9 @@ class CollaboratorService:
         bot_repo: BotRepository,
         passport_plugin: PassportPlugin,
         credentials_admins_writer: "DeviceCredentialsAdminsWriter",
-        member_management_capability_service: MemberManagementCapabilityService | None = None,
+        space_access_service: SpaceAccessServiceProtocol,
+        member_management_capability_service: MemberManagementCapabilityService
+        | None = None,
     ) -> None:
         """初始化服务。
 
@@ -97,6 +93,7 @@ class CollaboratorService:
             credentials_admins_writer: 把 admin 工号同步到运行设备 ``.credentials`` 的
                 写入器（对 service bot 解析在线 binding、对其它 bot 回退
                 ``resolve_for_bot``）。read-modify-write 既有文件，失败只 warning。
+            space_access_service: Team Space 解析和成员校验服务。
             member_management_capability_service: 成员管理能力服务，用于协调通用能力与各引擎定制逻辑。
         """
         self._collaborator_repo = collaborator_repo
@@ -106,6 +103,21 @@ class CollaboratorService:
         self._member_management_capability_service = (
             member_management_capability_service or MemberManagementCapabilityService()
         )
+        self._editor_policy = EditorPolicy(
+            bot_repo=bot_repo,
+            collaborator_repo=collaborator_repo,
+            space_access_service=space_access_service,
+            member_management_capability_service=(
+                self._member_management_capability_service
+            ),
+        )
+
+    @staticmethod
+    def _normalize_role(role: str | CollaboratorRole) -> str:
+        try:
+            return CollaboratorRole(role).value
+        except ValueError as exc:
+            raise InvalidCollaboratorRoleError("unsupported collaborator role") from exc
 
     # ========================================================================
     # 权限检查
@@ -145,6 +157,81 @@ class CollaboratorService:
 
         # 3. 无权限
         return PermissionLevel.NONE
+
+    def get_operable_permission_level(
+        self,
+        *,
+        bot: Mapping[str, Any],
+        user_id: str,
+        env: Optional[str] = None,
+    ) -> PermissionLevel:
+        """Return the effective Bot level after live Space membership policy."""
+        level = self.get_permission_level(
+            int(bot.get("id") or 0),
+            user_id,
+            str(bot.get("owner_id") or ""),
+            env,
+        )
+        if level in (PermissionLevel.NONE, PermissionLevel.OWNER):
+            return level
+        # COSEC: a Team Space editor relation is necessary but not sufficient.
+        # Removing the user from the Space revokes operation immediately, while
+        # Bot Owners intentionally retain ownership even after Space removal.
+        if not self._editor_policy.allows_editor(bot=bot, user_id=user_id):
+            return PermissionLevel.NONE
+        return level
+
+    def get_operable_permission_levels(
+        self,
+        *,
+        bots: Sequence[Mapping[str, Any]],
+        user_id: str,
+        env: Optional[str] = None,
+    ) -> Dict[int, PermissionLevel]:
+        """Resolve effective levels for an inventory page without N+1 role reads."""
+        resolved_env = env or get_current_env()
+        records = self._collaborator_repo.list_by_user(user_id, resolved_env)
+        roles = {record.bot_pk: record.role for record in records}
+        space_cache: dict[str, bool] = {}
+        result: Dict[int, PermissionLevel] = {}
+        for bot in bots:
+            bot_pk = int(bot.get("id") or 0)
+            if bot_pk <= 0:
+                continue
+            if user_id == str(bot.get("owner_id") or ""):
+                result[bot_pk] = PermissionLevel.OWNER
+                continue
+            role = roles.get(bot_pk)
+            level = (
+                PermissionLevel.ADMIN
+                if role == CollaboratorRole.ADMIN
+                else PermissionLevel.MEMBER
+                if role == CollaboratorRole.MEMBER
+                else PermissionLevel.NONE
+            )
+            if (
+                level is not PermissionLevel.NONE
+                and not self._editor_policy.allows_editor(
+                    bot=bot, user_id=user_id, cache=space_cache
+                )
+            ):
+                level = PermissionLevel.NONE
+            result[bot_pk] = level
+        return result
+
+    def _check_operable_permission(
+        self,
+        *,
+        bot: Mapping[str, Any],
+        user_id: str,
+        required_level: PermissionLevel,
+        env: Optional[str] = None,
+    ) -> None:
+        level = self.get_operable_permission_level(bot=bot, user_id=user_id, env=env)
+        if level < required_level:
+            raise PermissionDeniedError(
+                f"权限不足: 需要 {required_level.name} 权限，当前用户 {user_id} 权限为 {level.name}"
+            )
 
     def check_permission(
         self,
@@ -208,6 +295,7 @@ class CollaboratorService:
         """
         if env is None:
             env = get_current_env()
+        role = self._normalize_role(role)
 
         # 1. 查询 Bot 信息
         bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
@@ -219,7 +307,9 @@ class CollaboratorService:
         #    - service：Service Bot 协作者，走原逻辑；
         #    - 非 service：通过 MemberManagementCapabilityService 协调模板开关和
         #      各引擎自己的能力实现，避免在这里直接依赖某个 engine 的定制逻辑。
-        if not self._member_management_capability_service.can_manage_collaborators(bot, bot_id):
+        if not self._member_management_capability_service.can_manage_collaborators(
+            bot, bot_id
+        ):
             raise BotNotServiceTypeError(
                 f"Bot 不是服务型且未开启成员管理: bot_id={bot_id}"
             )
@@ -250,26 +340,183 @@ class CollaboratorService:
             )
 
         # 6. 创建协作者记录
-        record = self._collaborator_repo.insert({
-            "bot_pk": bot_pk,
-            "bot_id": bot_id,
-            "owner_id": owner_id_from_bot,
-            "user_id": user_id,
-            "user_name": user_name,
-            "role": role,
-            "operator_id": operator_id,
-            "env": env,
-        })
+        record = self._collaborator_repo.insert(
+            {
+                "bot_pk": bot_pk,
+                "bot_id": bot_id,
+                "owner_id": owner_id_from_bot,
+                "user_id": user_id,
+                "user_name": user_name,
+                "role": role,
+                "operator_id": operator_id,
+                "env": env,
+            }
+        )
 
         logger.info(
             "[add_collaborator] Added: bot_id=%s, user_id=%s, role=%s, operator=%s",
-            bot_id, user_id, role, operator_id
+            bot_id,
+            user_id,
+            role,
+            operator_id,
         )
 
         # 7. 触发协作关系变更回调
         self.on_collaboration_changed(bot_id, owner_id_from_bot, env)
 
         return record
+
+    # ========================================================================
+    # Public bot-first Editors API
+    # ========================================================================
+
+    def add_editor(
+        self,
+        bot_id: str,
+        owner_id: str,
+        user_id: str,
+        operator_id: str,
+        user_name: Optional[str] = None,
+        role: str = CollaboratorRole.MEMBER,
+        env: Optional[str] = None,
+    ) -> CollaboratorRecord:
+        """Add an editor after enforcing the public Team Space invariant."""
+        resolved_env = env or get_current_env()
+        bot = self._editor_policy.resolve_bot(bot_id=bot_id, owner_id=owner_id)
+        self._check_operable_permission(
+            bot=bot,
+            user_id=operator_id,
+            required_level=PermissionLevel.ADMIN,
+            env=resolved_env,
+        )
+        self._editor_policy.require_capability(bot=bot, bot_id=bot_id)
+        self._editor_policy.require_team_space_member(bot=bot, user_id=user_id)
+        return self.add_collaborator(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            user_id=user_id,
+            operator_id=operator_id,
+            user_name=user_name,
+            role=self._normalize_role(role),
+            env=resolved_env,
+        )
+
+    def list_editors(
+        self,
+        bot_id: str,
+        owner_id: str,
+        user_id: str,
+        role: Optional[str] = None,
+        env: Optional[str] = None,
+    ) -> List[CollaboratorRecord]:
+        """List editors on an addressed Bot for a member-level caller."""
+        resolved_env = env or get_current_env()
+        bot = self._editor_policy.resolve_bot(bot_id=bot_id, owner_id=owner_id)
+        normalized_role = self._normalize_role(role) if role is not None else None
+        self._check_operable_permission(
+            bot=bot,
+            user_id=user_id,
+            required_level=PermissionLevel.MEMBER,
+            env=resolved_env,
+        )
+        self._editor_policy.require_capability(bot=bot, bot_id=bot_id)
+        return self._collaborator_repo.list_by_bot(
+            bot_id=bot_id,
+            owner_id=bot["owner_id"],
+            env=resolved_env,
+            role=normalized_role,
+        )
+
+    def update_editor(
+        self,
+        bot_id: str,
+        owner_id: str,
+        collaborator_id: int,
+        operator_id: str,
+        role: str,
+        env: Optional[str] = None,
+    ) -> CollaboratorRecord:
+        """Update one editor role after exact Bot/owner/env rebinding."""
+        resolved_env = env or get_current_env()
+        normalized_role = self._normalize_role(role)
+        bot = self._editor_policy.resolve_bot(bot_id=bot_id, owner_id=owner_id)
+        self._check_operable_permission(
+            bot=bot,
+            user_id=operator_id,
+            required_level=PermissionLevel.ADMIN,
+            env=resolved_env,
+        )
+        self._editor_policy.require_capability(bot=bot, bot_id=bot_id)
+        record = self._editor_policy.resolve_record(
+            bot=bot,
+            bot_id=bot_id,
+            collaborator_id=collaborator_id,
+            env=resolved_env,
+        )
+        self._editor_policy.require_team_space_member(bot=bot, user_id=record.user_id)
+        updated = self._collaborator_repo.update(
+            collaborator_id,
+            {"operator_id": operator_id, "role": normalized_role},
+        )
+        if updated is None:
+            raise CollaboratorNotFoundError(f"协作者不存在: id={collaborator_id}")
+        self.on_collaboration_changed(bot_id, bot["owner_id"], resolved_env)
+        return updated
+
+    def remove_editor(
+        self,
+        bot_id: str,
+        owner_id: str,
+        collaborator_id: int,
+        operator_id: str,
+        env: Optional[str] = None,
+    ) -> bool:
+        """Remove one editor after exact Bot/owner/env rebinding."""
+        resolved_env = env or get_current_env()
+        bot = self._editor_policy.resolve_bot(bot_id=bot_id, owner_id=owner_id)
+        operator_level = self.get_operable_permission_level(
+            bot=bot, user_id=operator_id, env=resolved_env
+        )
+        if operator_level < PermissionLevel.ADMIN:
+            raise PermissionDeniedError("权限不足: 需要 ADMIN 权限才能移除协作者")
+        self._editor_policy.require_capability(bot=bot, bot_id=bot_id)
+        record = self._editor_policy.resolve_record(
+            bot=bot,
+            bot_id=bot_id,
+            collaborator_id=collaborator_id,
+            env=resolved_env,
+        )
+        if record.user_id == operator_id and operator_level != PermissionLevel.OWNER:
+            raise CannotRemoveSelfError("不能移除自己")
+        if not self._collaborator_repo.delete(collaborator_id):
+            raise CollaboratorNotFoundError(f"协作者不存在: id={collaborator_id}")
+        self.on_collaboration_changed(bot_id, bot["owner_id"], resolved_env)
+        return True
+
+    def leave_editors(
+        self,
+        bot_id: str,
+        owner_id: str,
+        user_id: str,
+        env: Optional[str] = None,
+    ) -> bool:
+        """Leave the addressed Bot's editor set as the current member."""
+        resolved_env = env or get_current_env()
+        bot = self._editor_policy.resolve_bot(bot_id=bot_id, owner_id=owner_id)
+        self.check_permission(
+            bot_pk=bot["id"],
+            user_id=user_id,
+            owner_id=bot["owner_id"],
+            required_level=PermissionLevel.MEMBER,
+            env=resolved_env,
+        )
+        self._editor_policy.require_capability(bot=bot, bot_id=bot_id)
+        return self.leave_collaboration(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            user_id=user_id,
+            env=resolved_env,
+        )
 
     # ========================================================================
     # 获取协作者列表
@@ -396,13 +643,16 @@ class CollaboratorService:
         if user_name is not None:
             update_data["user_name"] = user_name
         if role is not None:
-            update_data["role"] = role
+            update_data["role"] = self._normalize_role(role)
 
         record = self._collaborator_repo.update(collaborator_id, update_data)
+        if record is None:
+            raise CollaboratorNotFoundError(f"协作者不存在: id={collaborator_id}")
 
         logger.info(
             "[update_collaborator] Updated: id=%s, operator=%s",
-            collaborator_id, operator_id
+            collaborator_id,
+            operator_id,
         )
 
         # 6. 触发协作关系变更回调
@@ -456,16 +706,18 @@ class CollaboratorService:
 
         # 4. 需要管理员权限
         if operator_level < PermissionLevel.ADMIN:
-            raise PermissionDeniedError(
-                f"权限不足: 需要 ADMIN 权限才能移除协作者"
-            )
+            raise PermissionDeniedError("权限不足: 需要 ADMIN 权限才能移除协作者")
 
         # 5. 删除记录
         success = self._collaborator_repo.delete(collaborator_id)
+        if not success:
+            raise CollaboratorNotFoundError(f"协作者不存在: id={collaborator_id}")
 
         logger.info(
             "[remove_collaborator] Removed: id=%s, user_id=%s, operator=%s",
-            collaborator_id, user_id, operator_id
+            collaborator_id,
+            user_id,
+            operator_id,
         )
 
         # 6. 触发协作关系变更回调
@@ -526,8 +778,7 @@ class CollaboratorService:
         success = self._collaborator_repo.delete(collaborator.id)
 
         logger.info(
-            "[leave_collaboration] Left: bot_id=%s, user_id=%s",
-            bot_id, user_id
+            "[leave_collaboration] Left: bot_id=%s, user_id=%s", bot_id, user_id
         )
 
         # 4. 触发协作关系变更回调。
@@ -595,7 +846,11 @@ class CollaboratorService:
 
         logger.info(
             "[check_collaborator_permission] Start: bot_id=%s, owner_id=%s, user_id=%s, required_level=%s, env=%s",
-            bot_id, owner_id, user_id, required_level.name, env
+            bot_id,
+            owner_id,
+            user_id,
+            required_level.name,
+            env,
         )
 
         # 1. 查询 Bot 信息
@@ -616,7 +871,10 @@ class CollaboratorService:
         }
         logger.info(
             "[check_collaborator_permission] Result: has_permission=%s, level=%s, user_id=%s, bot_id=%s",
-            result["has_permission"], result["level"], user_id, bot_id
+            result["has_permission"],
+            result["level"],
+            user_id,
+            bot_id,
         )
 
         return result
@@ -666,7 +924,7 @@ class CollaboratorService:
         )
         logger.info(
             "[on_collaboration_changed] Collaborators: %s",
-            [{"user_id": c.user_id, "role": c.role} for c in collaborators]
+            [{"user_id": c.user_id, "role": c.role} for c in collaborators],
         )
 
         # 3. 通知所有协作者（TODO: 实现实际通知逻辑）
@@ -674,7 +932,9 @@ class CollaboratorService:
 
         logger.info(
             "[on_collaboration_changed] Results: %s, bot_id=%s, owner_id=%s",
-            results, bot_id, owner_id
+            results,
+            bot_id,
+            owner_id,
         )
 
         # 4. 同步 admin 协作者到 Passport 服务
@@ -689,12 +949,14 @@ class CollaboratorService:
             )
             logger.info(
                 "[on_collaboration_changed] Synced admins to the passport service: bot_id=%s, admins=%s",
-                bot_id, admins,
+                bot_id,
+                admins,
             )
         except Exception as e:
             logger.warning(
                 "[on_collaboration_changed] Failed to sync admins to the passport service: bot_id=%s, error=%s",
-                bot_id, e,
+                bot_id,
+                e,
             )
 
         # 5. 同步 admin 工号到运行设备的 .credentials 文件（ADMINS= 行）。

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/editor_policy.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/editor_policy.py
@@ -1,0 +1,122 @@
+"""Bot and Space authorization policy shared by public Editor operations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from agentclaw.community.core.bot_collaborator.errors import (
+    BotNotFoundError,
+    BotNotServiceTypeError,
+    CollaboratorNotFoundError,
+    CollaboratorSpaceMembershipError,
+)
+from agentclaw.community.core.bot_collaborator.models import CollaboratorRecord
+from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
+    MemberManagementCapabilityService,
+)
+from agentclaw.community.core.repository.protocols.bot import (
+    BotRepository,
+    CollaboratorRepositoryProtocol,
+)
+from agentclaw.community.core.spaces.errors import (
+    SpaceAccessDeniedError,
+    SpaceNotFoundError,
+)
+from agentclaw.community.core.spaces.models import SpaceType
+from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
+
+
+class EditorPolicy:
+    """Resolve and authorize the resources addressed by Editor operations."""
+
+    def __init__(
+        self,
+        *,
+        bot_repo: BotRepository,
+        collaborator_repo: CollaboratorRepositoryProtocol,
+        space_access_service: SpaceAccessServiceProtocol,
+        member_management_capability_service: MemberManagementCapabilityService,
+    ) -> None:
+        self._bot_repo = bot_repo
+        self._collaborator_repo = collaborator_repo
+        self._space_access_service = space_access_service
+        self._member_management_capability_service = (
+            member_management_capability_service
+        )
+
+    def resolve_bot(self, *, bot_id: str, owner_id: str) -> dict[str, Any]:
+        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
+        if not bot:
+            raise BotNotFoundError(f"Bot 不存在: bot_id={bot_id}, owner_id={owner_id}")
+        return bot
+
+    def require_capability(self, *, bot: dict[str, Any], bot_id: str) -> None:
+        if not self._member_management_capability_service.can_manage_collaborators(
+            bot, bot_id
+        ):
+            raise BotNotServiceTypeError(
+                f"Bot 不是服务型且未开启成员管理: bot_id={bot_id}"
+            )
+
+    def resolve_record(
+        self,
+        *,
+        bot: dict[str, Any],
+        bot_id: str,
+        collaborator_id: int,
+        env: str,
+    ) -> CollaboratorRecord:
+        record = self._collaborator_repo.get_by_id(collaborator_id)
+        if record is None:
+            raise CollaboratorNotFoundError(f"协作者不存在: id={collaborator_id}")
+        # COSEC: a public record id is never authority. Bind it back to the
+        # addressed Bot, owner and environment before any mutation so an admin
+        # cannot operate another Bot's collaborator by guessing an integer id.
+        if (
+            record.bot_pk != bot["id"]
+            or record.bot_id != bot_id
+            or record.owner_id != bot["owner_id"]
+            or record.env != env
+        ):
+            raise CollaboratorNotFoundError(f"协作者不存在: id={collaborator_id}")
+        return record
+
+    def require_team_space_member(self, *, bot: dict[str, Any], user_id: str) -> None:
+        if not self.allows_editor(bot=bot, user_id=user_id):
+            # COSEC: editor grants must never outlive or bypass Team Space
+            # membership. Unknown references fail closed instead of silently
+            # falling back to the legacy unrestricted collaborator behavior.
+            raise CollaboratorSpaceMembershipError(
+                "editor must be a member of the Bot Team Space"
+            )
+
+    def allows_editor(
+        self,
+        *,
+        bot: Mapping[str, Any],
+        user_id: str,
+        cache: dict[str, bool] | None = None,
+    ) -> bool:
+        raw_space_id = bot.get("space_id")
+        if raw_space_id in (None, "") or str(raw_space_id).startswith("personal:"):
+            return True
+        key = str(raw_space_id)
+        if cache is not None and key in cache:
+            return cache[key]
+        try:
+            space = self._space_access_service.require_space_reference(space_ref=key)
+            allowed = space.space_type is not SpaceType.TEAM
+            if not allowed:
+                self._space_access_service.require_space_member(
+                    space_id=space.id, user_id=user_id
+                )
+                allowed = True
+        except (SpaceAccessDeniedError, SpaceNotFoundError, ValueError):
+            allowed = False
+        if cache is not None:
+            cache[key] = allowed
+        return allowed
+
+
+__all__ = ["EditorPolicy"]

--- a/src/backend/src/agentclaw/community/core/bot_inventory/protocols.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/protocols.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
 
+from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_inventory.types import (
     BotAction,
     BusinessSpaceRef,
@@ -31,6 +32,7 @@ class BotInventoryBotPort(Protocol):
         owner_id: str | None = None,
         engine: str | None = None,
         status: str | None = None,
+        space_id: str | None = None,
         page: int = 1,
         page_size: int = 20,
         bot_ids: list[str] | None = None,
@@ -88,6 +90,19 @@ class DesktopBotInventoryPort(Protocol):
     def open_folder(
         self, *, bot_id: str, user_id: str, folder_path: str | None = None
     ) -> dict[str, Any]: ...
+
+
+@runtime_checkable
+class BotInventoryAccessPort(Protocol):
+    """Batch Bot permission projection consumed by the inventory read model."""
+
+    def get_operable_permission_levels(
+        self,
+        *,
+        bots: Sequence[Mapping[str, Any]],
+        user_id: str,
+        env: str | None = None,
+    ) -> dict[int, PermissionLevel]: ...
 
 
 @runtime_checkable

--- a/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
@@ -5,8 +5,12 @@ from __future__ import annotations
 import json
 from typing import Any, Mapping
 
-from agentclaw.community.core.bot_inventory.errors import BotInventoryUpstreamError
+from agentclaw.community.core.bot_inventory.errors import (
+    BotInventoryPermissionError,
+    BotInventoryUpstreamError,
+)
 from agentclaw.community.core.bot_inventory.protocols import (
+    BotInventoryAccessPort,
     BotInventoryBotPort,
     BusinessSpaceContextProtocol,
     DesktopBotInventoryPort,
@@ -15,12 +19,14 @@ from agentclaw.community.core.bot_inventory.services.lifecycle_view import (
     BotLifecycleView,
 )
 from agentclaw.community.core.bot_inventory.types import (
+    BotAction,
     BotInventoryItem,
     BotInventoryKind,
     BusinessSpaceRef,
     DeployMode,
     ServiceLifecycleCard,
 )
+from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 
 
 class BotInventoryService:
@@ -29,11 +35,13 @@ class BotInventoryService:
         *,
         bot_service: BotInventoryBotPort,
         desktop_service: DesktopBotInventoryPort,
+        access_service: BotInventoryAccessPort,
         business_space: BusinessSpaceContextProtocol,
         lifecycle_view: BotLifecycleView,
     ) -> None:
         self._bot = bot_service
         self._desktop = desktop_service
+        self._access = access_service
         self._business_space = business_space
         self._lifecycle = lifecycle_view
 
@@ -41,7 +49,7 @@ class BotInventoryService:
         self,
         *,
         owner_id: str,
-        space: BusinessSpaceRef | None,
+        space: BusinessSpaceRef,
         keyword: str | None,
         engine: str | None,
         deploy_mode: DeployMode | None,
@@ -53,6 +61,7 @@ class BotInventoryService:
         if deploy_mode in (None, DeployMode.CLOUD):
             cloud_rows = self._list_cloud_rows(
                 owner_id=owner_id,
+                space=space,
                 keyword=keyword,
                 engine=engine,
                 bot_ids=bot_ids,
@@ -60,8 +69,16 @@ class BotInventoryService:
             service_rows = [
                 row for row in cloud_rows if row.get("bot_type") == "service"
             ]
+            levels = self._access.get_operable_permission_levels(
+                bots=cloud_rows, user_id=owner_id
+            )
             cards.extend(
-                self._to_item(row, owner_id, space)
+                self._to_item(
+                    row,
+                    owner_id,
+                    space,
+                    levels.get(int(row.get("id") or 0), PermissionLevel.NONE),
+                )
                 for row in cloud_rows
                 if row.get("bot_type") != "service"
             )
@@ -69,12 +86,20 @@ class BotInventoryService:
             for row in service_rows:
                 bot_id = str(row.get("bot_id") or "")
                 cards.extend(
-                    self._to_service_item(row, owner_id, lifecycle_card, space)
+                    self._to_service_item(
+                        row,
+                        owner_id,
+                        lifecycle_card,
+                        space,
+                        levels.get(int(row.get("id") or 0), PermissionLevel.NONE),
+                    )
                     for lifecycle_card in service_cards.get(bot_id, ())
                 )
-        if deploy_mode in (None, DeployMode.LOCAL):
+        if deploy_mode in (None, DeployMode.LOCAL) and (
+            space is None or space.kind == "personal"
+        ):
             cards.extend(
-                self._to_local_item(row, owner_id, space)
+                self._to_local_item(row, owner_id, space, PermissionLevel.OWNER)
                 for row in self._list_local_rows(
                     owner_id=owner_id,
                     keyword=keyword,
@@ -82,8 +107,6 @@ class BotInventoryService:
                     bot_ids=bot_ids,
                 )
             )
-        if space is not None:
-            cards = [c for c in cards if c.space and c.space.space_id == space.space_id]
         cards.sort(
             key=lambda c: (
                 c.deploy_mode.value,
@@ -100,6 +123,7 @@ class BotInventoryService:
         self,
         *,
         owner_id: str,
+        space: BusinessSpaceRef,
         keyword: str | None,
         engine: str | None,
         bot_ids: list[str] | None = None,
@@ -110,7 +134,8 @@ class BotInventoryService:
         total: int | None = None
         while True:
             result = self._bot.list_bots_by_conditions(
-                owner_id=owner_id,
+                owner_id=owner_id if space.kind == "personal" else None,
+                space_id=space.space_id if space.kind == "team" else None,
                 bot_name=keyword,
                 engine=engine,
                 status=None,
@@ -130,11 +155,20 @@ class BotInventoryService:
             if len(page_items) < fetch_size:
                 break
             page += 1
-        return [
-            row
-            for row in rows
-            if row.get("bot_type") in (None, "", "personal", "service")
-        ]
+        visible: list[Mapping[str, Any]] = []
+        for row in rows:
+            if row.get("bot_type") not in (None, "", "personal", "service"):
+                continue
+            try:
+                self._business_space.assert_bot_visible_in_current_space(
+                    bot=row,
+                    owner_id=str(row.get("owner_id") or owner_id),
+                    current_space=space,
+                )
+            except BotInventoryPermissionError:
+                continue
+            visible.append(row)
+        return visible
 
     def _list_local_rows(
         self,
@@ -168,21 +202,24 @@ class BotInventoryService:
         row: Mapping[str, Any],
         owner_id: str,
         current_space: BusinessSpaceRef | None,
+        level: PermissionLevel,
     ) -> BotInventoryItem:
         bot_type = str(row.get("bot_type") or "personal")
         if bot_type == "desktop":
-            return self._to_local_item(row, owner_id, current_space)
-        return self._to_cloud_item(row, owner_id, current_space)
+            return self._to_local_item(row, owner_id, current_space, level)
+        return self._to_cloud_item(row, owner_id, current_space, level)
 
     def _to_cloud_item(
         self,
         row: Mapping[str, Any],
         owner_id: str,
         current_space: BusinessSpaceRef | None,
+        level: PermissionLevel,
     ) -> BotInventoryItem:
         return self._build_item(
             row=row,
             owner_id=owner_id,
+            level=level,
             kind=BotInventoryKind.PERSONAL_CLOUD,
             deploy_mode=DeployMode.CLOUD,
             current_space=current_space,
@@ -193,10 +230,12 @@ class BotInventoryService:
         row: Mapping[str, Any],
         owner_id: str,
         current_space: BusinessSpaceRef | None,
+        level: PermissionLevel,
     ) -> BotInventoryItem:
         return self._build_item(
             row=row,
             owner_id=owner_id,
+            level=level,
             kind=BotInventoryKind.LOCAL,
             deploy_mode=DeployMode.LOCAL,
             current_space=current_space,
@@ -208,10 +247,12 @@ class BotInventoryService:
         owner_id: str,
         lifecycle_card: ServiceLifecycleCard,
         current_space: BusinessSpaceRef | None,
+        level: PermissionLevel,
     ) -> BotInventoryItem:
         return self._build_item(
             row=row,
             owner_id=owner_id,
+            level=level,
             kind=BotInventoryKind.SERVICE,
             deploy_mode=DeployMode.CLOUD,
             lifecycle_card=lifecycle_card,
@@ -223,6 +264,7 @@ class BotInventoryService:
         *,
         row: Mapping[str, Any],
         owner_id: str,
+        level: PermissionLevel,
         kind: BotInventoryKind,
         deploy_mode: DeployMode,
         lifecycle_card: ServiceLifecycleCard | None = None,
@@ -241,6 +283,12 @@ class BotInventoryService:
             actions = lifecycle_card.actions
             disabled = {}
             raw_status = lifecycle_card.status
+        actions, disabled = self._actions_for_level(
+            kind=kind,
+            actions=tuple(actions),
+            disabled=dict(disabled),
+            level=level,
+        )
         bot_id = str(row.get("bot_id") or "")
         publication_id = lifecycle_card.publication_id if lifecycle_card else None
         return BotInventoryItem(
@@ -284,6 +332,28 @@ class BotInventoryService:
                 lifecycle_card.internal_status if lifecycle_card else None
             ),
         )
+
+    @staticmethod
+    def _actions_for_level(
+        *,
+        kind: BotInventoryKind,
+        actions: tuple[BotAction, ...],
+        disabled: dict[str, str],
+        level: PermissionLevel,
+    ) -> tuple[tuple[BotAction, ...], dict[str, str]]:
+        if level >= PermissionLevel.OWNER:
+            return actions, disabled
+        if kind is BotInventoryKind.SERVICE and level >= PermissionLevel.MEMBER:
+            allowed = tuple(action for action in actions if action is not BotAction.DELETE)
+            if BotAction.DELETE in actions:
+                disabled.setdefault(
+                    BotAction.DELETE.value, "Bot Owner permission required"
+                )
+            return allowed, disabled
+        for action in actions:
+            if action is not BotAction.VIEW:
+                disabled.setdefault(action.value, "Bot editor permission required")
+        return (BotAction.VIEW,), disabled
 
 
 def _as_mapping(value: Any) -> Mapping[str, Any]:

--- a/src/backend/src/agentclaw/community/core/bot_management/render_screen/errors.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/render_screen/errors.py
@@ -1,0 +1,11 @@
+"""Domain errors for public Bot render-screen configuration operations."""
+
+from __future__ import annotations
+
+
+class RenderScreenNotFoundError(Exception):
+    """The addressed Bot or render-screen record is unavailable to the caller."""
+
+
+class RenderScreenConflictError(Exception):
+    """The requested configuration conflicts with an existing record."""

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -1384,7 +1384,7 @@ class BotService:
                 "ext": ext,
                 "bot_type": resolved_bot_type,
                 "template_type": template_type,  # Template type (e.g., "applicationCoding")
-                "space_id": space_id,  # Business-space ownership (PRD §0.1): NULL → personal fallback
+                "space_id": space_id,  # Business-space ownership: NULL -> personal fallback
             }
 
             bot_record = self._repository.insert(bot_data)
@@ -2168,6 +2168,7 @@ class BotService:
         owner_id: Optional[str] = None,
         engine: Optional[str] = None,
         status: Optional[str] = None,
+        space_id: str | None = None,
         page: int = 1,
         page_size: int = 20,
         bot_ids: Optional[List[str]] = None,
@@ -2181,6 +2182,7 @@ class BotService:
             owner_name: Filter by owner name
             bot_id: Filter by bot ID (exact match)
             owner_id: Filter by owner id (exact match) — scopes to one owner
+            space_id: Filter by numeric business-space id (exact match)
             engine: Filter by active engine (exact match)
             status: Filter by lifecycle status (exact match)
             page: Page number (1-based)
@@ -2201,6 +2203,7 @@ class BotService:
             owner_id=owner_id,
             engine=engine,
             status=status,
+            space_id=space_id,
             page=page,
             page_size=page_size,
             bot_ids=bot_ids,

--- a/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
@@ -36,8 +36,8 @@ from agentclaw.community.core.engine_runtime.errors import (
     EngineUpstreamError,
 )
 from agentclaw.community.core.engine_runtime.gate import (
+    require_bot_operator,
     require_operable_bot,
-    require_space_aware_bot_operator,
 )
 from agentclaw.community.core.engine_runtime.models import (
     BotFacts,
@@ -189,11 +189,11 @@ class EngineConnectionService:
         facts = BotFacts.from_record(bot, bot_id=bot_id, owner_id=owner_id)
         resolved_id = facts.bot_id
         resolved_owner = facts.owner_id
-        bot_pk = int(bot.get("id") or 0)
         # From the row read just above, not from the facts: both the
         # collaborator adjudication and the publish lookup are keyed on
         # ``ac_bots.id``, and that internal join key stays off the narrow
         # projection — this method holds the record, so it costs nothing here.
+        bot_pk = int(bot.get("id") or 0)
         # The socket this endpoint publishes is **not** chat-scoped, however it
         # is labelled: the engine's ``hello`` advertises the ``sessions.*`` and
         # ``exec.approvals`` methods and grants ``operator.admin``, so the
@@ -202,9 +202,9 @@ class EngineConnectionService:
         # full rule. Gated here rather than in the router because the rule is
         # about what may be *composed*, not about how it is served: any future
         # caller of ``build`` is covered without repeating the check.
-        require_space_aware_bot_operator(
+        require_bot_operator(
             self._collaborators,
-            bot=bot,
+            bot_pk=bot_pk,
             bot_id=resolved_id,
             caller_id=caller_id,
             owner_id=resolved_owner,

--- a/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
@@ -189,11 +189,11 @@ class EngineConnectionService:
         facts = BotFacts.from_record(bot, bot_id=bot_id, owner_id=owner_id)
         resolved_id = facts.bot_id
         resolved_owner = facts.owner_id
+        bot_pk = int(bot.get("id") or 0)
         # From the row read just above, not from the facts: both the
         # collaborator adjudication and the publish lookup are keyed on
         # ``ac_bots.id``, and that internal join key stays off the narrow
         # projection — this method holds the record, so it costs nothing here.
-        bot_pk = int(bot.get("id") or 0)
         # The socket this endpoint publishes is **not** chat-scoped, however it
         # is labelled: the engine's ``hello`` advertises the ``sessions.*`` and
         # ``exec.approvals`` methods and grants ``operator.admin``, so the
@@ -204,7 +204,7 @@ class EngineConnectionService:
         # caller of ``build`` is covered without repeating the check.
         require_bot_operator(
             self._collaborators,
-            bot_pk=bot_pk,
+            bot=bot,
             bot_id=resolved_id,
             caller_id=caller_id,
             owner_id=resolved_owner,

--- a/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/connection.py
@@ -36,8 +36,8 @@ from agentclaw.community.core.engine_runtime.errors import (
     EngineUpstreamError,
 )
 from agentclaw.community.core.engine_runtime.gate import (
-    require_bot_operator,
     require_operable_bot,
+    require_space_aware_bot_operator,
 )
 from agentclaw.community.core.engine_runtime.models import (
     BotFacts,
@@ -202,7 +202,7 @@ class EngineConnectionService:
         # full rule. Gated here rather than in the router because the rule is
         # about what may be *composed*, not about how it is served: any future
         # caller of ``build`` is covered without repeating the check.
-        require_bot_operator(
+        require_space_aware_bot_operator(
             self._collaborators,
             bot=bot,
             bot_id=resolved_id,

--- a/src/backend/src/agentclaw/community/core/engine_runtime/gate.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/gate.py
@@ -71,7 +71,8 @@ from agentclaw.community.log import get_logger
 logger = get_logger()
 
 #: The bot types an operator surface may serve. Necessary but **not**
-#: sufficient — the caller must also pass :func:`require_bot_operator`.
+#: sufficient — the caller must also pass
+#: :func:`require_space_aware_bot_operator`.
 SUPPORTED_BOT_TYPES = frozenset({"personal", SERVICE_BOT_TYPE})
 
 #: The least collaborator level that holds an operator channel. One bar for
@@ -85,32 +86,34 @@ OPERATOR_LEVEL = PermissionLevel.MEMBER
 def resolve_operator_level(
     collaborators: CollaboratorServiceProtocol,
     *,
-    bot: Mapping[str, Any],
+    bot_pk: int,
     caller_id: str,
     owner_id: str,
 ) -> PermissionLevel:
     """The caller's level on this bot: OWNER, their collaborator level, or NONE.
 
-    Delegates to the platform's effective Bot permission policy: owner
-    short-circuit, collaborator role mapping, and live Team Space membership
-    for non-owner editors. A lookup failure returns ``NONE`` (fail closed).
+    Delegates to ``CollaboratorService.get_permission_level`` — the platform's
+    one role policy (owner short-circuit, role→level mapping) — rather than
+    keeping a second copy of it here; this wrapper adds only the fail-closed
+    direction. ``owner_id`` must be the *resolved* owner — the record's, not
+    the request's — and ``bot_pk`` the primary key ownership was proven
+    against; ``bot_id`` alone is not unique across owners. A lookup failure
+    returns ``NONE`` (fail closed) and logs: this feeds a refusal, so the
+    direction of the guess decides what a database blip does.
 
     Synchronous — one indexed read, and only when the caller is not the
     owner. Callers on an event loop run it in a worker thread with the rest
     of their resolution.
     """
     try:
-        return resolve_operable_permission_level(
-            collaborators,
-            bot=bot,
-            user_id=caller_id,
-            owner_id=owner_id,
+        return PermissionLevel(
+            collaborators.get_permission_level(bot_pk, caller_id, owner_id)
         )
     except Exception:
         logger.exception(
             "[engine_runtime] collaborator lookup failed for bot_pk=%s; "
             "refusing the caller",
-            bot.get("id"),
+            bot_pk,
         )
         return PermissionLevel.NONE
 
@@ -118,7 +121,7 @@ def resolve_operator_level(
 def require_bot_operator(
     collaborators: CollaboratorServiceProtocol,
     *,
-    bot: Mapping[str, Any],
+    bot_pk: int,
     bot_id: str,
     caller_id: str,
     owner_id: str,
@@ -131,12 +134,67 @@ def require_bot_operator(
     cannot carry them.
     """
     level = resolve_operator_level(
-        collaborators, bot=bot, caller_id=caller_id, owner_id=owner_id
+        collaborators, bot_pk=bot_pk, caller_id=caller_id, owner_id=owner_id
     )
     if level < OPERATOR_LEVEL:
         # ``%r`` on the caller id deliberately: this branch runs only for a
         # value the server refused, so quoting keeps a forged multi-line id
         # from poisoning the refusal audit trail.
+        logger.warning(
+            "[engine_runtime] caller %r is not an operator of bot=%s owner=%s",
+            caller_id,
+            bot_id,
+            owner_id,
+        )
+        raise BotNotFoundError(f"bot {bot_id} not found")
+
+
+def resolve_space_aware_operator_level(
+    collaborators: CollaboratorServiceProtocol,
+    *,
+    bot: Mapping[str, Any],
+    caller_id: str,
+    owner_id: str,
+) -> PermissionLevel:
+    """Resolve an operator's effective level including live Space membership.
+
+    This is deliberately separate from :func:`resolve_operator_level`, whose
+    ``bot_pk`` contract predates Spaces and remains shared by existing surfaces.
+    Engine-runtime entry points opt into the stronger policy explicitly because
+    they already hold the resolved Bot row needed to evaluate ``space_id``.
+    """
+    try:
+        return resolve_operable_permission_level(
+            collaborators,
+            bot=bot,
+            user_id=caller_id,
+            owner_id=owner_id,
+        )
+    except Exception:
+        logger.exception(
+            "[engine_runtime] effective operator lookup failed for bot_pk=%s; "
+            "refusing the caller",
+            bot.get("id"),
+        )
+        return PermissionLevel.NONE
+
+
+def require_space_aware_bot_operator(
+    collaborators: CollaboratorServiceProtocol,
+    *,
+    bot: Mapping[str, Any],
+    bot_id: str,
+    caller_id: str,
+    owner_id: str,
+) -> None:
+    """Refuse a runtime operator without effective Bot and Space permission."""
+    level = resolve_space_aware_operator_level(
+        collaborators,
+        bot=bot,
+        caller_id=caller_id,
+        owner_id=owner_id,
+    )
+    if level < OPERATOR_LEVEL:
         logger.warning(
             "[engine_runtime] caller %r is not an operator of bot=%s owner=%s",
             caller_id,
@@ -174,5 +232,7 @@ __all__ = [
     "SUPPORTED_BOT_TYPES",
     "require_bot_operator",
     "require_operable_bot",
+    "require_space_aware_bot_operator",
     "resolve_operator_level",
+    "resolve_space_aware_operator_level",
 ]

--- a/src/backend/src/agentclaw/community/core/engine_runtime/gate.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/gate.py
@@ -49,9 +49,12 @@ with no live runtime.
 
 from __future__ import annotations
 
+from typing import Any, Mapping
+
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_collaborator.protocols import (
     CollaboratorServiceProtocol,
+    resolve_operable_permission_level,
 )
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
@@ -82,34 +85,32 @@ OPERATOR_LEVEL = PermissionLevel.MEMBER
 def resolve_operator_level(
     collaborators: CollaboratorServiceProtocol,
     *,
-    bot_pk: int,
+    bot: Mapping[str, Any],
     caller_id: str,
     owner_id: str,
 ) -> PermissionLevel:
     """The caller's level on this bot: OWNER, their collaborator level, or NONE.
 
-    Delegates to ``CollaboratorService.get_permission_level`` — the platform's
-    one role policy (owner short-circuit, role→level mapping) — rather than
-    keeping a second copy of it here; this wrapper adds only the fail-closed
-    direction. ``owner_id`` must be the *resolved* owner — the record's, not
-    the request's — and ``bot_pk`` the primary key ownership was proven
-    against; ``bot_id`` alone is not unique across owners. A lookup failure
-    returns ``NONE`` (fail closed) and logs: this feeds a refusal, so the
-    direction of the guess decides what a database blip does.
+    Delegates to the platform's effective Bot permission policy: owner
+    short-circuit, collaborator role mapping, and live Team Space membership
+    for non-owner editors. A lookup failure returns ``NONE`` (fail closed).
 
     Synchronous — one indexed read, and only when the caller is not the
     owner. Callers on an event loop run it in a worker thread with the rest
     of their resolution.
     """
     try:
-        return PermissionLevel(
-            collaborators.get_permission_level(bot_pk, caller_id, owner_id)
+        return resolve_operable_permission_level(
+            collaborators,
+            bot=bot,
+            user_id=caller_id,
+            owner_id=owner_id,
         )
     except Exception:
         logger.exception(
             "[engine_runtime] collaborator lookup failed for bot_pk=%s; "
             "refusing the caller",
-            bot_pk,
+            bot.get("id"),
         )
         return PermissionLevel.NONE
 
@@ -117,7 +118,7 @@ def resolve_operator_level(
 def require_bot_operator(
     collaborators: CollaboratorServiceProtocol,
     *,
-    bot_pk: int,
+    bot: Mapping[str, Any],
     bot_id: str,
     caller_id: str,
     owner_id: str,
@@ -130,7 +131,7 @@ def require_bot_operator(
     cannot carry them.
     """
     level = resolve_operator_level(
-        collaborators, bot_pk=bot_pk, caller_id=caller_id, owner_id=owner_id
+        collaborators, bot=bot, caller_id=caller_id, owner_id=owner_id
     )
     if level < OPERATOR_LEVEL:
         # ``%r`` on the caller id deliberately: this branch runs only for a

--- a/src/backend/src/agentclaw/community/core/engine_runtime/gate.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/gate.py
@@ -49,12 +49,9 @@ with no live runtime.
 
 from __future__ import annotations
 
-from typing import Any, Mapping
-
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_collaborator.protocols import (
     CollaboratorServiceProtocol,
-    resolve_operable_permission_level,
 )
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
@@ -71,8 +68,7 @@ from agentclaw.community.log import get_logger
 logger = get_logger()
 
 #: The bot types an operator surface may serve. Necessary but **not**
-#: sufficient — the caller must also pass
-#: :func:`require_space_aware_bot_operator`.
+#: sufficient — the caller must also pass :func:`require_bot_operator`.
 SUPPORTED_BOT_TYPES = frozenset({"personal", SERVICE_BOT_TYPE})
 
 #: The least collaborator level that holds an operator channel. One bar for
@@ -149,61 +145,6 @@ def require_bot_operator(
         raise BotNotFoundError(f"bot {bot_id} not found")
 
 
-def resolve_space_aware_operator_level(
-    collaborators: CollaboratorServiceProtocol,
-    *,
-    bot: Mapping[str, Any],
-    caller_id: str,
-    owner_id: str,
-) -> PermissionLevel:
-    """Resolve an operator's effective level including live Space membership.
-
-    This is deliberately separate from :func:`resolve_operator_level`, whose
-    ``bot_pk`` contract predates Spaces and remains shared by existing surfaces.
-    Engine-runtime entry points opt into the stronger policy explicitly because
-    they already hold the resolved Bot row needed to evaluate ``space_id``.
-    """
-    try:
-        return resolve_operable_permission_level(
-            collaborators,
-            bot=bot,
-            user_id=caller_id,
-            owner_id=owner_id,
-        )
-    except Exception:
-        logger.exception(
-            "[engine_runtime] effective operator lookup failed for bot_pk=%s; "
-            "refusing the caller",
-            bot.get("id"),
-        )
-        return PermissionLevel.NONE
-
-
-def require_space_aware_bot_operator(
-    collaborators: CollaboratorServiceProtocol,
-    *,
-    bot: Mapping[str, Any],
-    bot_id: str,
-    caller_id: str,
-    owner_id: str,
-) -> None:
-    """Refuse a runtime operator without effective Bot and Space permission."""
-    level = resolve_space_aware_operator_level(
-        collaborators,
-        bot=bot,
-        caller_id=caller_id,
-        owner_id=owner_id,
-    )
-    if level < OPERATOR_LEVEL:
-        logger.warning(
-            "[engine_runtime] caller %r is not an operator of bot=%s owner=%s",
-            caller_id,
-            bot_id,
-            owner_id,
-        )
-        raise BotNotFoundError(f"bot {bot_id} not found")
-
-
 def require_operable_bot(bot_type: str, *, stage: str, surface: str) -> None:
     """Reject bot types and stages the operator surfaces do not serve.
 
@@ -232,7 +173,5 @@ __all__ = [
     "SUPPORTED_BOT_TYPES",
     "require_bot_operator",
     "require_operable_bot",
-    "require_space_aware_bot_operator",
     "resolve_operator_level",
-    "resolve_space_aware_operator_level",
 ]

--- a/src/backend/src/agentclaw/community/core/engine_runtime/models.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/models.py
@@ -84,7 +84,8 @@ class BotFacts:
         Deliberately **without** ``ac_bots.id``. The collaborator adjudication
         and the publish lookup are keyed on that primary key, but they take it
         from the row their caller read rather than from these facts — see
-        ``gate.require_bot_operator`` and ``stage.resolve_stage_bind_id``.
+        ``gate.require_space_aware_bot_operator`` and
+        ``stage.resolve_stage_bind_id``.
         Carrying it here would put an internal join key on the value object
         three of its four consumers already hold the row for, and give it a
         default no caller could satisfy.

--- a/src/backend/src/agentclaw/community/core/engine_runtime/models.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/models.py
@@ -84,8 +84,7 @@ class BotFacts:
         Deliberately **without** ``ac_bots.id``. The collaborator adjudication
         and the publish lookup are keyed on that primary key, but they take it
         from the row their caller read rather than from these facts — see
-        ``gate.require_space_aware_bot_operator`` and
-        ``stage.resolve_stage_bind_id``.
+        ``gate.require_bot_operator`` and ``stage.resolve_stage_bind_id``.
         Carrying it here would put an internal join key on the value object
         three of its four consumers already hold the row for, and give it a
         default no caller could satisfy.

--- a/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
@@ -139,7 +139,7 @@ class EngineRuntimeRelay:
         facts = BotFacts.from_record(bot, bot_id=bot_id, owner_id=owner_id)
         require_bot_operator(
             self._collaborators,
-            bot_pk=int(bot.get("id") or 0),
+            bot=bot,
             bot_id=facts.bot_id,
             caller_id=caller_id,
             owner_id=facts.owner_id,

--- a/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
@@ -50,7 +50,9 @@ from agentclaw.community.core.engine_runtime.errors import (
     EngineStageNotLiveError,
     EngineUpstreamError,
 )
-from agentclaw.community.core.engine_runtime.gate import require_bot_operator
+from agentclaw.community.core.engine_runtime.gate import (
+    require_space_aware_bot_operator,
+)
 from agentclaw.community.core.engine_runtime.models import BotFacts, EngineResult
 from agentclaw.community.core.engine_runtime.stage import (
     SERVICE_BOT_TYPE,
@@ -113,7 +115,8 @@ class EngineRuntimeRelay:
         does not exist under that owner — or belongs to another tenant, which
         the Track A guard on ``BotModel`` filters out before ownership is even
         considered — raises ``BotNotFoundError``. Then
-        :func:`require_bot_operator` decides whether *this caller* may operate
+        :func:`require_space_aware_bot_operator` decides whether *this caller*
+        may operate
         the resolved bot: the owner, or a collaborator at member level or
         above; anyone else raises the same ``BotNotFoundError``, so a refused
         non-operator cannot tell a bot they may not operate from one that does
@@ -137,7 +140,7 @@ class EngineRuntimeRelay:
         """
         bot = self._bot_service.get_bot(bot_id, owner_id)
         facts = BotFacts.from_record(bot, bot_id=bot_id, owner_id=owner_id)
-        require_bot_operator(
+        require_space_aware_bot_operator(
             self._collaborators,
             bot=bot,
             bot_id=facts.bot_id,

--- a/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
+++ b/src/backend/src/agentclaw/community/core/engine_runtime/relay.py
@@ -50,9 +50,7 @@ from agentclaw.community.core.engine_runtime.errors import (
     EngineStageNotLiveError,
     EngineUpstreamError,
 )
-from agentclaw.community.core.engine_runtime.gate import (
-    require_space_aware_bot_operator,
-)
+from agentclaw.community.core.engine_runtime.gate import require_bot_operator
 from agentclaw.community.core.engine_runtime.models import BotFacts, EngineResult
 from agentclaw.community.core.engine_runtime.stage import (
     SERVICE_BOT_TYPE,
@@ -115,8 +113,7 @@ class EngineRuntimeRelay:
         does not exist under that owner — or belongs to another tenant, which
         the Track A guard on ``BotModel`` filters out before ownership is even
         considered — raises ``BotNotFoundError``. Then
-        :func:`require_space_aware_bot_operator` decides whether *this caller*
-        may operate
+        :func:`require_bot_operator` decides whether *this caller* may operate
         the resolved bot: the owner, or a collaborator at member level or
         above; anyone else raises the same ``BotNotFoundError``, so a refused
         non-operator cannot tell a bot they may not operate from one that does
@@ -140,9 +137,9 @@ class EngineRuntimeRelay:
         """
         bot = self._bot_service.get_bot(bot_id, owner_id)
         facts = BotFacts.from_record(bot, bot_id=bot_id, owner_id=owner_id)
-        require_space_aware_bot_operator(
+        require_bot_operator(
             self._collaborators,
-            bot=bot,
+            bot_pk=int(bot.get("id") or 0),
             bot_id=facts.bot_id,
             caller_id=caller_id,
             owner_id=facts.owner_id,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
@@ -354,6 +354,7 @@ class BotRepository(
         owner_id: Optional[str] = None,
         engine: Optional[str] = None,
         status: Optional[str] = None,
+        space_id: str | None = None,
         page: int = 1,
         page_size: int = 20,
         bot_ids: Optional[List[str]] = None,
@@ -381,6 +382,8 @@ class BotRepository(
                 query = query.filter(self.Model.bot_id.in_(bot_ids))
             if owner_id:
                 query = query.filter(self.Model.owner_id == owner_id)
+            if space_id is not None:
+                query = query.filter(self.Model.space_id == space_id)
             if engine:
                 query = query.filter(self.Model.active_engine == engine)
             if status:

--- a/src/backend/src/agentclaw/community/core/repository/implementations/spaces/space.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/spaces/space.py
@@ -155,6 +155,19 @@ class SpaceRepository(SpaceRepositoryProtocol):
             )
             return row.to_record() if row is not None else None
 
+    def get_space_by_code(self, *, space_code: str, env: str):
+        with self._db.orm_session() as db:
+            row = (
+                db.query(self._Space)
+                .filter(
+                    self._Space.space_code == space_code,
+                    self._Space.env == env,
+                    self._Space.deleted_at.is_(None),
+                )
+                .one_or_none()
+            )
+            return row.to_record() if row is not None else None
+
     def batch_query_personal(
         self, *, user_ids: list[str], env: str
     ) -> list[PersonalSpaceLookupRecord]:

--- a/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
@@ -175,6 +175,7 @@ class BotRepository(Protocol):
         owner_id: Optional[str] = None,
         engine: Optional[str] = None,
         status: Optional[str] = None,
+        space_id: str | None = None,
         page: int = 1,
         page_size: int = 20,
         bot_ids: list[str] | None = None,
@@ -186,10 +187,10 @@ class BotRepository(Protocol):
         distinguishable — collapsing them would turn "this caller may reach no
         bots" into "show everything".
 
-        ``owner_id`` scopes to a single owner (exact), ``engine`` filters on the
-        active engine (exact), ``status`` filters on lifecycle status (exact).
-        All are optional and additive — omitting them reproduces the prior
-        result set and count exactly.
+        ``owner_id`` scopes to a single owner (exact), ``space_id`` to a
+        business Space (exact after canonical string persistence), ``engine``
+        filters on the active engine (exact), and ``status`` filters on lifecycle
+        status (exact). All are optional and additive.
         """
         ...
 

--- a/src/backend/src/agentclaw/community/core/repository/protocols/spaces.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/spaces.py
@@ -32,6 +32,9 @@ class SpaceRepositoryProtocol(Protocol):
     def get_space(self, *, space_id: int, env: str) -> SpaceRecord | None: ...
 
     @abstractmethod
+    def get_space_by_code(self, *, space_code: str, env: str) -> SpaceRecord | None: ...
+
+    @abstractmethod
     def batch_query_personal(
         self, *, user_ids: list[str], env: str
     ) -> list[PersonalSpaceLookupRecord]: ...

--- a/src/backend/src/agentclaw/community/core/service_bot/services/service_publication_facade.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/service_publication_facade.py
@@ -15,6 +15,9 @@ from dataclasses import dataclass
 from typing import Any
 
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
+from agentclaw.community.core.bot_collaborator.protocols import (
+    resolve_operable_permission_level,
+)
 from agentclaw.community.core.bot_collaborator.services.collaborator_lock_service import (
     CollaboratorLockService,
 )
@@ -128,10 +131,11 @@ class ServicePublicationFacade:
         if not bot:
             raise ServicePublicationNotFoundError("bot not found")
 
-        level = self._collaborator_service.get_permission_level(
-            bot_pk=bot["id"],
+        level = resolve_operable_permission_level(
+            self._collaborator_service,
+            bot=bot,
             user_id=actor_id,
-            owner_id=bot["owner_id"],
+            owner_id=owner_id,
             env=get_current_env(),
         )
         if level < required_level:

--- a/src/backend/src/agentclaw/community/core/spaces/README.md
+++ b/src/backend/src/agentclaw/community/core/spaces/README.md
@@ -16,6 +16,7 @@ provides:
   - SpaceService
   - SpaceMemberService
   - SpaceAccessService
+  - SpaceAccessServiceProtocol
   - SpaceModel
   - SpaceMemberModel
   - SpaceRecord
@@ -26,6 +27,7 @@ consumes:
 consumed_by:
   - "adapters/http/openapi_v1/spaces — public Space and member operations"
   - "core/market_favorites — Space membership authorization"
+  - "core/bot_collaborator — Team Space membership guard for public Bot editors"
 internal_dependencies:
   - agentclaw.community.core.base
   - agentclaw.community.core.repository

--- a/src/backend/src/agentclaw/community/core/spaces/protocols.py
+++ b/src/backend/src/agentclaw/community/core/spaces/protocols.py
@@ -1,0 +1,27 @@
+"""Consumer-side contracts for reusable Space authorization decisions."""
+
+from __future__ import annotations
+
+from typing import Protocol, TYPE_CHECKING, runtime_checkable
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.spaces.models import (
+        SpaceMemberRecord,
+        SpaceRecord,
+        SpaceRole,
+    )
+
+
+@runtime_checkable
+class SpaceAccessServiceProtocol(Protocol):
+    """Read and enforce live Space membership without importing its service."""
+
+    def require_space(self, *, space_id: int) -> SpaceRecord: ...
+
+    def require_space_reference(self, *, space_ref: str) -> SpaceRecord: ...
+
+    def get_space_role(self, *, space_id: int, user_id: str) -> SpaceRole | None: ...
+
+    def require_space_member(
+        self, *, space_id: int, user_id: str
+    ) -> tuple[SpaceRecord, SpaceMemberRecord]: ...

--- a/src/backend/src/agentclaw/community/core/spaces/services/space_access_service.py
+++ b/src/backend/src/agentclaw/community/core/spaces/services/space_access_service.py
@@ -9,7 +9,7 @@ from agentclaw.community.core.spaces.errors import (
     SpaceAccessDeniedError,
     SpaceNotFoundError,
 )
-from agentclaw.community.core.spaces.models import SpaceRole
+from agentclaw.community.core.spaces.models import SpaceRole, SpaceType
 from agentclaw.community.utils.env_utils import get_current_env
 
 
@@ -21,6 +21,27 @@ class SpaceAccessService:
     def require_space(self, *, space_id: int):
         space = self._repository.get_space(space_id=space_id, env=get_current_env())
         if space is None:
+            raise SpaceNotFoundError("space not found")
+        return space
+
+    def require_space_reference(self, *, space_ref: str):
+        """Resolve the structured Bot ``space_id`` by numeric id or Space code."""
+        normalized = space_ref.strip()
+        team_reference = normalized.startswith("team:")
+        if team_reference:
+            normalized = normalized.removeprefix("team:")
+        if normalized.isdigit():
+            space = self.require_space(space_id=int(normalized))
+        else:
+            space = self._repository.get_space_by_code(
+                space_code=normalized, env=get_current_env()
+            )
+        if space is None:
+            raise SpaceNotFoundError("space not found")
+        # COSEC: the legacy ``team:`` prefix is a type assertion, not decoration.
+        # Refuse a mismatched Personal Space instead of weakening Team membership
+        # enforcement through a malformed persisted reference.
+        if team_reference and space.space_type is not SpaceType.TEAM:
             raise SpaceNotFoundError("space not found")
         return space
 

--- a/src/backend/src/agentclaw/community/di/modules/bot_collaborator_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_collaborator_module.py
@@ -12,20 +12,31 @@ Bindings:
 Tests construct services directly with mocks (no fake services); the
 bindings exist so production routes can use ``Injected(...)``.
 """
+
 from __future__ import annotations
 
 from injector import Binder, Injector, Module, inject, provider, singleton
 
-from agentclaw.community.api.collaborator_lock_service import CollaboratorLockServiceProtocol
+from agentclaw.community.api.collaborator_lock_service import (
+    CollaboratorLockServiceProtocol,
+)
 from agentclaw.community.api.collaborator_service import CollaboratorServiceProtocol
 from agentclaw.community.core.bot_collaborator.protocols import (
     BotServiceProtocol,
     CollaboratorServiceProtocol as CoreCollaboratorServiceProtocol,
 )
-from agentclaw.community.core.repository.protocols.bot import CollaboratorRepositoryProtocol
-from agentclaw.community.core.repository.protocols.bot import BotCollabLogRepositoryProtocol
-from agentclaw.community.core.repository.protocols.bot import BotCollabLockRepositoryProtocol
-from agentclaw.community.core.bot_collaborator.services.collaborator_service import CollaboratorService
+from agentclaw.community.core.repository.protocols.bot import (
+    CollaboratorRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.bot import (
+    BotCollabLogRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.bot import (
+    BotCollabLockRepositoryProtocol,
+)
+from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
+    CollaboratorService,
+)
 from agentclaw.community.core.bot_collaborator.services.credentials_admins_writer import (
     DeviceCredentialsAdminsWriter,
 )
@@ -38,15 +49,30 @@ from agentclaw.community.core.bot_collaborator.services.aicoding.member_manageme
 from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
     MemberManagementCapabilityService,
 )
-from agentclaw.community.core.bot_collaborator.services.collaborator_lock_service import CollaboratorLockService
+from agentclaw.community.core.bot_collaborator.services.collaborator_lock_service import (
+    CollaboratorLockService,
+)
 from agentclaw.community.core.repository.protocols.bot import BotRepository
-from agentclaw.community.core.bot_management.services.template_service import TemplateService
-from agentclaw.community.core.devices.services.device_context_resolver import DeviceContextResolver
-from agentclaw.community.di.modules.skill_center_module import DeviceFilesystemDispatcher
+from agentclaw.community.core.bot_management.services.template_service import (
+    TemplateService,
+)
+from agentclaw.community.core.devices.services.device_context_resolver import (
+    DeviceContextResolver,
+)
+from agentclaw.community.di.modules.skill_center_module import (
+    DeviceFilesystemDispatcher,
+)
 from agentclaw.community.plugin_api.passport import PassportPlugin
-from agentclaw.community.core.repository.implementations.bot.collaborator import CollaboratorRepository
-from agentclaw.community.core.repository.implementations.bot.collab_log import BotCollabLogRepository
-from agentclaw.community.core.repository.implementations.bot.collab_lock import BotCollabLockRepository
+from agentclaw.community.core.repository.implementations.bot.collaborator import (
+    CollaboratorRepository,
+)
+from agentclaw.community.core.repository.implementations.bot.collab_log import (
+    BotCollabLogRepository,
+)
+from agentclaw.community.core.repository.implementations.bot.collab_lock import (
+    BotCollabLockRepository,
+)
+from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
 
 
 class BotCollaboratorModule(Module):
@@ -118,7 +144,9 @@ class BotCollaboratorModule(Module):
             collaborator_repo=collaborator_repo,
             bot_publish_repo=bot_publish_repo,
             resolver_provider=lambda: injector.get(DeviceContextResolver),
-            device_fs_dispatcher_provider=lambda: injector.get(DeviceFilesystemDispatcher),
+            device_fs_dispatcher_provider=lambda: injector.get(
+                DeviceFilesystemDispatcher
+            ),
         )
 
     @singleton
@@ -130,6 +158,7 @@ class BotCollaboratorModule(Module):
         bot_repo: BotRepository,
         passport_plugin: PassportPlugin,
         credentials_admins_writer: DeviceCredentialsAdminsWriter,
+        space_access_service: SpaceAccessServiceProtocol,
         member_management_capability_service: MemberManagementCapabilityService,
     ) -> CollaboratorService:
         """Construct ``CollaboratorService``.
@@ -143,6 +172,7 @@ class BotCollaboratorModule(Module):
             bot_repo=bot_repo,
             passport_plugin=passport_plugin,
             credentials_admins_writer=credentials_admins_writer,
+            space_access_service=space_access_service,
             member_management_capability_service=member_management_capability_service,
         )
 

--- a/src/backend/src/agentclaw/community/di/modules/bot_inventory_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_inventory_module.py
@@ -15,6 +15,7 @@ from agentclaw.community.core.bot_inventory.adapters.service_lifecycle import (
     ServiceLifecycleView,
 )
 from agentclaw.community.core.bot_inventory.protocols import (
+    BotInventoryAccessPort,
     BotInventoryBotPort,
     BusinessSpaceContextProtocol,
     DesktopBotInventoryPort,
@@ -30,6 +31,9 @@ from agentclaw.community.core.bot_inventory.services.local_bot_workflow import (
     LocalBotWorkflowService,
 )
 from agentclaw.community.core.bot_management.services.bot_service import BotService
+from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
+    CollaboratorService,
+)
 from agentclaw.community.core.desktop_bot.services.desktop_bot_service import (
     DesktopBotService,
 )
@@ -83,16 +87,26 @@ class BotInventoryModule(Module):
     @singleton
     @provider
     @inject
+    def inventory_access_port(
+        self, service: CollaboratorService
+    ) -> BotInventoryAccessPort:
+        return service
+
+    @singleton
+    @provider
+    @inject
     def bot_inventory_service(
         self,
         bot_service: BotInventoryBotPort,
         desktop_service: DesktopBotInventoryPort,
+        access_service: BotInventoryAccessPort,
         business_space: BusinessSpaceContextProtocol,
         lifecycle_view: BotLifecycleView,
     ) -> BotInventoryService:
         return BotInventoryService(
             bot_service=bot_service,
             desktop_service=desktop_service,
+            access_service=access_service,
             business_space=business_space,
             lifecycle_view=lifecycle_view,
         )

--- a/src/backend/src/agentclaw/community/di/modules/spaces_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/spaces_module.py
@@ -8,7 +8,7 @@ from agentclaw.community.api.market_favorite_service import (
     MarketFavoriteServiceProtocol,
 )
 from agentclaw.community.api.space_service import (
-    SpaceAccessServiceProtocol,
+    SpaceAccessServiceProtocol as SpaceAccessServiceApiProtocol,
     SpaceMemberServiceProtocol,
     SpaceServiceProtocol,
 )
@@ -29,6 +29,9 @@ from agentclaw.community.core.spaces.services import (
     SpaceMemberService,
     SpaceService,
 )
+from agentclaw.community.core.spaces.protocols import (
+    SpaceAccessServiceProtocol as CoreSpaceAccessServiceProtocol,
+)
 
 
 class SpacesModule(Module):
@@ -46,7 +49,12 @@ class SpacesModule(Module):
             scope=singleton,
         )
         binder.bind(
-            SpaceAccessServiceProtocol,
+            SpaceAccessServiceApiProtocol,
+            to=SpaceAccessService,
+            scope=singleton,
+        )
+        binder.bind(
+            CoreSpaceAccessServiceProtocol,
             to=SpaceAccessService,
             scope=singleton,
         )

--- a/src/backend/tests/community/adapters/http/openapi_v1/editors/__init__.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/editors/__init__.py
@@ -1,0 +1,1 @@
+"""Editors OpenAPI contract tests."""

--- a/src/backend/tests/community/adapters/http/openapi_v1/editors/test_editors_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/editors/test_editors_handlers.py
@@ -1,0 +1,188 @@
+"""Public Editors endpoint contract tests."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+from pydantic import ValidationError
+from starlette.requests import Request
+
+from agentclaw.community.adapters.http.openapi_v1.editors.router import (
+    add_editor,
+    leave_editors,
+    list_editors,
+    remove_editor,
+    resolve_editor_owner_id,
+    update_editor,
+)
+from agentclaw.community.adapters.http.openapi_v1.editors.schemas import (
+    EditorCreate,
+    EditorUpdate,
+)
+from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
+from agentclaw.community.core.bot_collaborator.models import CollaboratorRecord
+from agentclaw.community.core.repository.protocols.bot import (
+    CollaboratorRepositoryProtocol,
+)
+from tests.community.adapters.http.openapi_v1.conftest import user_scoped_client
+from tests.community.factories.bot_collaborator import make_bot
+
+
+def _request(method: str = "GET") -> Request:
+    request = Request({"type": "http", "method": method, "path": "/"})
+    request.state.trace_id = "trace-editors"
+    return request
+
+
+def _record(role: str = "member") -> CollaboratorRecord:
+    now = datetime(2026, 8, 19, 10, 0, 0)
+    return CollaboratorRecord(
+        id=7,
+        bot_pk=10,
+        bot_id="bot-1",
+        owner_id="owner-1",
+        user_id="member-1",
+        user_name="Member",
+        role=role,
+        operator_id="owner-1",
+        env="dev",
+        gmt_create=now,
+        gmt_modified=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_editors_projects_public_fields_and_forwards_scope():
+    service = Mock()
+    service.list_editors.return_value = [_record()]
+
+    response = await list_editors(
+        bot_id="bot-1",
+        request=_request(),
+        actor_id="member-1",
+        owner_id="owner-1",
+        role=None,
+        service=service,
+    )
+
+    assert response.request_id == "trace-editors"
+    assert response.data.total == 1
+    assert response.data.items[0].model_dump(mode="json") == {
+        "id": 7,
+        "user_id": "member-1",
+        "user_name": "Member",
+        "role": "member",
+        "created_at": "2026-08-19T10:00:00",
+        "updated_at": "2026-08-19T10:00:00",
+    }
+    service.list_editors.assert_called_once_with(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        user_id="member-1",
+        role=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mutations_delegate_to_bot_first_service_methods():
+    service = Mock()
+    service.add_editor.return_value = _record()
+    service.update_editor.return_value = _record("admin")
+
+    created = await add_editor(
+        bot_id="bot-1",
+        body=EditorCreate(editor_user_id="member-1", role="member"),
+        request=_request("POST"),
+        actor_id="owner-1",
+        owner_id="owner-1",
+        service=service,
+    )
+    updated = await update_editor(
+        bot_id="bot-1",
+        editor_id=7,
+        body=EditorUpdate(role="admin"),
+        request=_request("PATCH"),
+        actor_id="owner-1",
+        owner_id="owner-1",
+        service=service,
+    )
+    removed = await remove_editor(
+        bot_id="bot-1",
+        editor_id=7,
+        request=_request("DELETE"),
+        actor_id="owner-1",
+        owner_id="owner-1",
+        service=service,
+    )
+    left = await leave_editors(
+        bot_id="bot-1",
+        request=_request("DELETE"),
+        actor_id="member-1",
+        owner_id="owner-1",
+        service=service,
+    )
+
+    assert created.code == 201000
+    assert updated.data.role.value == "admin"
+    assert removed.data.deleted is True
+    assert left.data.deleted is True
+    service.add_editor.assert_called_once_with(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        user_id="member-1",
+        operator_id="owner-1",
+        user_name=None,
+        role="member",
+    )
+    service.update_editor.assert_called_once_with(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        collaborator_id=7,
+        operator_id="owner-1",
+        role="admin",
+    )
+
+
+@pytest.mark.asyncio
+async def test_editor_owner_defaults_to_actor_or_accepts_explicit_owner():
+    assert await resolve_editor_owner_id(actor_id="u-1", owner_id=None) == "u-1"
+    assert (
+        await resolve_editor_owner_id(actor_id="u-1", owner_id="owner-1") == "owner-1"
+    )
+
+
+def test_editor_requests_reject_unknown_fields_and_roles():
+    with pytest.raises(ValidationError):
+        EditorCreate(editor_user_id="u-1", role="owner")
+    with pytest.raises(ValidationError):
+        EditorUpdate(role="member", user_id="unexpected")
+
+
+def test_assembled_app_resolves_editor_service_and_space_access_protocol(
+    app_with_testing_modules, world
+):
+    """Smoke the real DI graph, not only a handler supplied with a Mock."""
+    bot = make_bot(world, bot_id="bot-editors", owner_id="owner-1", bot_type="service")
+    world.get(CollaboratorRepositoryProtocol).insert(
+        {
+            "bot_pk": bot["id"],
+            "bot_id": "bot-editors",
+            "owner_id": "owner-1",
+            "user_id": "member-1",
+            "role": "member",
+            "operator_id": "owner-1",
+        }
+    )
+    app_with_testing_modules.dependency_overrides[require_principal] = lambda: {
+        "user_id": "owner-1"
+    }
+    try:
+        client = user_scoped_client(app_with_testing_modules, "owner-1")
+        response = client.get("/openapi/v1/bots/bot-editors/editors")
+    finally:
+        app_with_testing_modules.dependency_overrides.pop(require_principal, None)
+
+    assert response.status_code == 200, response.json()
+    assert response.json()["data"]["items"][0]["user_id"] == "member-1"

--- a/src/backend/tests/community/adapters/http/openapi_v1/editors/test_editors_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/editors/test_editors_handlers.py
@@ -14,8 +14,11 @@ from agentclaw.community.adapters.http.openapi_v1.editors.router import (
     leave_editors,
     list_editors,
     remove_editor,
-    resolve_editor_owner_id,
     update_editor,
+)
+from agentclaw.community.adapters.http.openapi_v1.admission import (
+    ADMISSION,
+    AdmissionMode,
 )
 from agentclaw.community.adapters.http.openapi_v1.editors.schemas import (
     EditorCreate,
@@ -145,19 +148,25 @@ async def test_mutations_delegate_to_bot_first_service_methods():
     )
 
 
-@pytest.mark.asyncio
-async def test_editor_owner_defaults_to_actor_or_accepts_explicit_owner():
-    assert await resolve_editor_owner_id(actor_id="u-1", owner_id=None) == "u-1"
-    assert (
-        await resolve_editor_owner_id(actor_id="u-1", owner_id="owner-1") == "owner-1"
-    )
-
-
 def test_editor_requests_reject_unknown_fields_and_roles():
     with pytest.raises(ValidationError):
         EditorCreate(editor_user_id="u-1", role="owner")
     with pytest.raises(ValidationError):
         EditorUpdate(role="member", user_id="unexpected")
+
+
+def test_editor_operations_admit_app_callers_with_an_addressed_bot_grant():
+    collection = "/openapi/v1/bots/{bot_id}/editors"
+    item = f"{collection}/{{editor_id}}"
+
+    assert ADMISSION[("GET", collection)] is AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT
+    assert ADMISSION[("POST", collection)] is AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT
+    assert ADMISSION[("PATCH", item)] is AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT
+    assert ADMISSION[("DELETE", item)] is AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT
+    assert (
+        ADMISSION[("DELETE", f"{collection}/me")]
+        is AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT
+    )
 
 
 def test_assembled_app_resolves_editor_service_and_space_access_protocol(

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_nodes.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_nodes.py
@@ -1,0 +1,134 @@
+"""Endpoint tests for the read-only nodes runtime group."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.nodes import (
+    router as nodes_router,
+)
+from agentclaw.community.core.engine_runtime.errors import (
+    EngineCapabilityUnsupportedError,
+)
+from agentclaw.community.core.engine_runtime.models import EngineResult
+
+from .conftest import BOT, OWNER, fails, ok
+
+
+@pytest.fixture
+def client(make_client):
+    return make_client(nodes_router)
+
+
+NODE = {
+    "nodeId": "node-01",
+    "displayName": "Joseph's Mac",
+    "platform": "darwin",
+    "version": "1.2.0",
+    "capabilities": ["screen", "shell"],
+    "commands": ["system.run"],
+    "remoteIp": "203.0.113.10",
+    "status": "online",
+    "metadata": {"provider": "internal"},
+    "raw": {"secret": "not-public"},
+}
+
+
+def test_list_nodes_maps_the_frontend_contract_and_drops_internal_fields(client, relay):
+    relay.results = [EngineResult(data=[NODE])]
+
+    data = ok(client.get(f"/openapi/v1/bots/{BOT}/nodes"))
+
+    assert data == [
+        {
+            "node_id": "node-01",
+            "display_name": "Joseph's Mac",
+            "platform": "darwin",
+            "version": "1.2.0",
+            "capabilities": ["screen", "shell"],
+            "commands": ["system.run"],
+            "remote_ip": "203.0.113.10",
+            "status": "online",
+        }
+    ]
+    assert "metadata" not in str(data)
+    assert "not-public" not in str(data)
+
+
+def test_list_nodes_forwards_filters_and_pagination(client, relay):
+    relay.results = [EngineResult(data=[])]
+
+    ok(
+        client.get(
+            f"/openapi/v1/bots/{BOT}/nodes",
+            params={
+                "status": "online",
+                "platform": "darwin",
+                "limit": 7,
+                "offset": 14,
+            },
+        )
+    )
+
+    assert relay.calls[0]["path"] == "/api/nodes"
+    assert relay.calls[0]["params"] == {
+        "status": "online",
+        "platform": "darwin",
+        "limit": 7,
+        "offset": 14,
+    }
+
+
+def test_list_nodes_forwards_the_engine_defaults(client, relay):
+    relay.results = [EngineResult(data=[])]
+
+    ok(client.get(f"/openapi/v1/bots/{BOT}/nodes"))
+
+    assert relay.calls[0]["params"] == {"limit": 20, "offset": 0}
+
+
+def test_list_nodes_uses_the_named_service_runtime(client, relay):
+    relay.set_bot_type("service")
+    relay.results = [EngineResult(data=[])]
+
+    ok(client.get(f"/openapi/v1/bots/{BOT}/nodes", params={"stage": "online"}))
+
+    assert relay.calls[0]["stage"] == "online"
+
+
+def test_foreign_bot_is_masked_before_node_inventory_is_fetched(client, relay):
+    assert fails(client.get("/openapi/v1/bots/other/nodes"), 404)
+    assert relay.calls == []
+    assert relay.attempts == []
+
+
+def test_collaborator_can_list_the_owners_nodes(make_client, relay):
+    relay.add_operator("u2")
+    relay.results = [EngineResult(data=[])]
+    collaborator = make_client(nodes_router, caller="u2")
+
+    ok(collaborator.get(f"/openapi/v1/bots/{BOT}/nodes", params={"owner_id": OWNER}))
+
+    assert relay.calls[0]["owner_id"] == OWNER
+
+
+@pytest.mark.parametrize("payload", [{}, None, ["not-an-object"], [{}]])
+def test_malformed_node_payload_is_an_upstream_error(client, relay, payload):
+    relay.results = [EngineResult(data=payload)]
+
+    body = fails(client.get(f"/openapi/v1/bots/{BOT}/nodes"), 502)
+
+    assert body["message"] == "Engine service error"
+
+
+def test_capability_unsupported_is_501(client, relay):
+    relay.raises = EngineCapabilityUnsupportedError("node.list unsupported")
+
+    fails(client.get(f"/openapi/v1/bots/{BOT}/nodes"), 501)
+
+
+def test_node_query_bounds_are_validated_before_forwarding(client, relay):
+    response = client.get(f"/openapi/v1/bots/{BOT}/nodes", params={"limit": 101})
+
+    assert response.status_code == 422
+    assert relay.attempts == []

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_operator_access.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_operator_access.py
@@ -2,7 +2,7 @@
 
 Who may hold an operator channel is one rule (owner, or collaborator at
 member level or above — ``core/engine_runtime/gate.py``), and it must hold on
-all nineteen operations identically: a route that refused a session list but
+all twenty swept operations identically: a route that refused a session list but
 served an engine read would leak through the difference. The sweep asserts
 the matrix per route — owner served, collaborator served, anyone else
 answered byte-identically to a bot that does not exist.
@@ -37,7 +37,7 @@ STRANGER = "u-stranger"
 
 SESSION_ID = "session:abc:user:1"
 
-#: (method, path template, body) for all 19 routes — the same shape as the
+#: (method, path template, body) for all 20 swept routes — the same shape as the
 #: tenant-isolation sweep, kept separately because the two sweeps pin
 #: different halves (cross-tenant masking there, the operator matrix here)
 #: and must each fail on its own terms.
@@ -57,6 +57,7 @@ ROUTES = [
     ("get", "/{bot}/engine/available", None),
     ("get", "/{bot}/models", None),
     ("get", "/{bot}/models/openai/gpt-5.3", None),
+    ("get", "/{bot}/nodes", None),
     ("get", "/{bot}/approvals/mode?session_key=k", None),
     ("put", "/{bot}/approvals/mode?session_key=k", {"mode": "never"}),
     ("get", "/{bot}/approvals/modes", None),
@@ -112,7 +113,7 @@ def connections(relay) -> _Connections:
 
 @pytest.fixture
 def make_caller(relay, connections):
-    """A client for ``caller`` across all five engine-runtime groups."""
+    """A client for ``caller`` across all engine-runtime groups."""
 
     def _build(caller: str):
         class _M(Module):
@@ -134,16 +135,18 @@ def _url(suffix: str, bot: str = BOT) -> str:
     return f"/openapi/v1/bots{suffix.format(bot=bot)}"
 
 
-def test_all_nineteen_routes_are_covered():
+def test_all_twenty_routes_are_covered():
     """Guard the guard: a shrinking list would silently narrow this sweep."""
-    assert len(ROUTES) == 19
+    assert len(ROUTES) == 20
 
 
 @pytest.mark.parametrize(("method", "suffix", "body"), ROUTES, ids=lambda v: str(v))
-def test_the_owner_is_served_every_route(make_caller, method, suffix, body):
+def test_the_owner_is_served_every_route(make_caller, relay, method, suffix, body):
     """The case the expansion must not have closed: the owner, naming
     nothing extra."""
     client = make_caller(OWNER)
+    if suffix.endswith("/nodes"):
+        relay.results = [EngineResult(data=[])]
     kwargs = {"json": body} if body is not None else {}
     resp = getattr(client, method)(_url(suffix), **kwargs)
     assert resp.status_code in (200, 201), resp.json()
@@ -157,6 +160,8 @@ def test_a_collaborator_is_served_every_route(
     console on reads, writes and the socket alike, naming the owner they
     address."""
     relay.add_operator(COLLABORATOR)
+    if suffix.endswith("/nodes"):
+        relay.results = [EngineResult(data=[])]
     client = make_caller(COLLABORATOR)
     kwargs = {"json": body} if body is not None else {}
     kwargs["params"] = {"owner_id": OWNER}

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_routing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_routing.py
@@ -11,8 +11,8 @@ from agentclaw.community.adapters.http.openapi_v1 import (
     build_public_router,
 )
 
-#: sessions 10 + engine 3 + models 2 + approvals 3 + connection 1
-_EXPECTED_ROUTE_COUNT = 20
+#: sessions 10 + engine 4 + models 2 + nodes 1 + approvals 3 + connection 1
+_EXPECTED_ROUTE_COUNT = 21
 
 _BOTS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/"
 
@@ -75,7 +75,7 @@ def test_every_route_begins_with_the_bots_prefix():
 
 
 #: Each group's component segment, which its paths must name after ``{bot_id}``.
-_COMPONENTS = ("sessions", "engine", "models", "approvals", "connection")
+_COMPONENTS = ("sessions", "engine", "models", "nodes", "approvals", "connection")
 
 
 def test_every_route_names_the_bot_then_its_component():
@@ -116,6 +116,7 @@ def test_groups_are_mounted_and_reachable_in_the_public_router():
         f"{_BOTS_PREFIX}{{bot_id}}/sessions",
         f"{_BOTS_PREFIX}{{bot_id}}/engine/capabilities",
         f"{_BOTS_PREFIX}{{bot_id}}/models",
+        f"{_BOTS_PREFIX}{{bot_id}}/nodes",
         f"{_BOTS_PREFIX}{{bot_id}}/approvals/mode",
         f"{_BOTS_PREFIX}{{bot_id}}/connection",
     ):

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
@@ -168,6 +168,7 @@ _GROUP_ROUTES = [
     ("sessions", f"/openapi/v1/bots/{BOT}/sessions"),
     ("engine", f"/openapi/v1/bots/{BOT}/engine/capabilities"),
     ("models", f"/openapi/v1/bots/{BOT}/models"),
+    ("nodes", f"/openapi/v1/bots/{BOT}/nodes"),
     ("approvals", f"/openapi/v1/bots/{BOT}/approvals/mode?session_key=k"),
 ]
 
@@ -188,7 +189,9 @@ def test_a_named_stage_travels_to_the_forward_unchanged(
     relay.set_bot_type("service")
     relay.results = [
         EngineResult(
-            data={"supported": [], "sessionKey": "k", "mode": "approve", "id": "s"}
+            data=[]
+            if group == "nodes"
+            else {"supported": [], "sessionKey": "k", "mode": "approve", "id": "s"}
         )
     ]
     client = make_client(module.router)
@@ -315,8 +318,9 @@ def test_owner_id_and_stage_are_on_exactly_the_engine_runtime_operations():
 
     # The original 16 operations also answer at their former addresses while
     # callers migrate. The three newly added favorite operations have only
-    # their bot-first address, so there are 20 current + 16 retiring operations.
-    assert len(engine_runtime) == 36
+    # their bot-first address; engine restart and nodes also have no legacy
+    # alias. That yields 21 current + 16 retiring operations.
+    assert len(engine_runtime) == 37
     assert sorted(carrying_stage) == sorted(
         set(engine_runtime) | _STAGE_ADDRESSED_ELSEWHERE
     ), (

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
@@ -123,6 +123,21 @@ _OWNER_ADDRESSED_ELSEWHERE = {
     ("patch", "/openapi/v1/bots/{bot_id}/channels/{channel_id}"),
     ("delete", "/openapi/v1/bots/{bot_id}/channels/{channel_id}"),
     ("put", "/openapi/v1/bots/{bot_id}/channels/{channel_id}/status"),
+    ("get", "/openapi/v1/bots/{bot_id}/editors"),
+    ("post", "/openapi/v1/bots/{bot_id}/editors"),
+    ("patch", "/openapi/v1/bots/{bot_id}/editors/{editor_id}"),
+    ("delete", "/openapi/v1/bots/{bot_id}/editors/{editor_id}"),
+    ("delete", "/openapi/v1/bots/{bot_id}/editors/me"),
+    ("get", "/openapi/v1/bots/{bot_id}/render-screens"),
+    ("post", "/openapi/v1/bots/{bot_id}/render-screens"),
+    (
+        "patch",
+        "/openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}",
+    ),
+    (
+        "delete",
+        "/openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}",
+    ),
 }
 
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_tenant_isolation.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_tenant_isolation.py
@@ -2,7 +2,7 @@
 
 Two layers, because a 404 alone proves neither:
 
-1. **Endpoint layer** — parametrised over all 19 routes: a bot that is not the
+1. **Endpoint layer** — parametrised over all 20 swept routes: a bot that is not the
    caller's answers a masked 404 **and the transport is never invoked**. The
    Track A guard constrains SQL statements, not device calls, so a handler that
    forwarded first and filtered afterwards would still have reached someone
@@ -46,7 +46,7 @@ TENANT_B = "tenant-b"
 
 SESSION_ID = "session:abc:user:1"
 
-#: (method, path template, body) for all 19 routes. ``{bot}`` is substituted
+#: (method, path template, body) for all 20 swept routes. ``{bot}`` is substituted
 #: with the bot the sweep is probing, and it sits *after* the component name —
 #: the surface's addressing rule (see ``openapi_v1/__init__.py``).
 #:
@@ -69,6 +69,7 @@ ROUTES = [
     ("get", "/{bot}/engine/available", None),
     ("get", "/{bot}/models", None),
     ("get", "/{bot}/models/openai/gpt-5.3", None),
+    ("get", "/{bot}/nodes", None),
     ("get", "/{bot}/approvals/mode?session_key=k", None),
     ("put", "/{bot}/approvals/mode?session_key=k", {"mode": "never"}),
     ("get", "/{bot}/approvals/modes", None),
@@ -123,9 +124,9 @@ def client(relay: FakeRelay, connections: _FakeConnections):
     return user_scoped_client(app, OWNER)
 
 
-def test_all_nineteen_routes_are_covered():
+def test_all_twenty_routes_are_covered():
     """Guard the guard: a shrinking list would silently narrow this sweep."""
-    assert len(ROUTES) == 19
+    assert len(ROUTES) == 20
 
 
 @pytest.mark.parametrize(("method", "suffix", "body"), ROUTES, ids=lambda v: str(v))

--- a/src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py
@@ -28,9 +28,11 @@ from agentclaw.community.core.bot_inventory.services.lifecycle_view import BotLi
 from agentclaw.community.core.bot_inventory.adapters.noop_service_lifecycle import (
     NoopServiceLifecyclePort,
 )
+from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 
 
 CLOUD = {
+    "id": 1,
     "bot_id": "c1",
     "bot_name": "Cloud",
     "bot_desc": "cloud bot",
@@ -40,6 +42,7 @@ CLOUD = {
     "owner_id": "u1",
 }
 LOCAL = {
+    "id": 2,
     "bot_id": "l1",
     "bot_name": "Local",
     "bot_desc": "local bot",
@@ -71,9 +74,14 @@ def client(bot_service, desktop_service):
     class _M(Module):
         def configure(self, binder):
             space = NoopBusinessSpaceContext()
+            access = MagicMock()
+            access.get_operable_permission_levels.side_effect = lambda **kwargs: {
+                int(bot["id"]): PermissionLevel.OWNER for bot in kwargs["bots"]
+            }
             inventory = BotInventoryService(
                 bot_service=bot_service,
                 desktop_service=desktop_service,
+                access_service=access,
                 business_space=space,
                 lifecycle_view=BotLifecycleView(NoopServiceLifecyclePort()),
             )

--- a/src/backend/tests/community/adapters/http/openapi_v1/render_screens/__init__.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/render_screens/__init__.py
@@ -1,0 +1,1 @@
+"""Render-screen OpenAPI contract tests."""

--- a/src/backend/tests/community/adapters/http/openapi_v1/render_screens/test_render_screens_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/render_screens/test_render_screens_handlers.py
@@ -22,7 +22,6 @@ from agentclaw.community.adapters.http.openapi_v1.render_screens.router import (
     create_render_screen,
     delete_render_screen,
     list_render_screens,
-    resolve_render_screen_write_owner_id,
     update_render_screen,
 )
 from agentclaw.community.adapters.http.openapi_v1.render_screens.schemas import (
@@ -224,22 +223,6 @@ def test_record_id_is_bound_to_bot_owner_and_environment(overrides):
         )
 
 
-@pytest.mark.asyncio
-async def test_write_owner_defaults_to_actor_or_accepts_explicit_owner():
-    assert (
-        await resolve_render_screen_write_owner_id(
-            actor_id="member-1", owner_id=None
-        )
-        == "member-1"
-    )
-    assert (
-        await resolve_render_screen_write_owner_id(
-            actor_id="member-1", owner_id="owner-1"
-        )
-        == "owner-1"
-    )
-
-
 def test_requests_reject_unknown_fields_and_non_http_urls():
     with pytest.raises(ValidationError):
         RenderScreenCreate(
@@ -254,25 +237,21 @@ def test_requests_reject_unknown_fields_and_non_http_urls():
         )
 
 
-def test_admission_allows_only_the_read_for_app_only_callers():
+def test_admission_allows_all_operations_for_app_callers_with_a_bot_grant():
     collection = "/openapi/v1/bots/{bot_id}/render-screens"
     item = f"{collection}/{{render_screen_id}}"
 
     assert ADMISSION[("GET", collection)] is AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT
-    assert ADMISSION[("POST", collection)] is AdmissionMode.REFUSED
-    assert ADMISSION[("PATCH", item)] is AdmissionMode.REFUSED
-    assert ADMISSION[("DELETE", item)] is AdmissionMode.REFUSED
+    assert ADMISSION[("POST", collection)] is AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT
+    assert ADMISSION[("PATCH", item)] is AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT
+    assert ADMISSION[("DELETE", item)] is AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT
 
 
-def test_assembled_app_resolves_render_screen_services(
-    app_with_testing_modules, world
-):
+def test_assembled_app_resolves_render_screen_services(app_with_testing_modules, world):
     make_bot(world, bot_id="bot-render-screen", owner_id="owner-1")
     repository = world.get(RenderScreenRepository)
     with repository._db.orm_session() as session:
-        RenderScreenModel.__table__.create(
-            bind=session.get_bind(), checkfirst=True
-        )
+        RenderScreenModel.__table__.create(bind=session.get_bind(), checkfirst=True)
     repository.insert(
         bot_id="bot-render-screen",
         owner_id="owner-1",
@@ -285,9 +264,7 @@ def test_assembled_app_resolves_render_screen_services(
     }
     try:
         client = user_scoped_client(app_with_testing_modules, "owner-1")
-        response = client.get(
-            "/openapi/v1/bots/bot-render-screen/render-screens"
-        )
+        response = client.get("/openapi/v1/bots/bot-render-screen/render-screens")
     finally:
         app_with_testing_modules.dependency_overrides.pop(require_principal, None)
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/render_screens/test_render_screens_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/render_screens/test_render_screens_handlers.py
@@ -1,0 +1,295 @@
+"""Public render-screen endpoint and authorization tests."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+from pydantic import ValidationError
+from starlette.requests import Request
+
+from agentclaw.community.adapters.http.openapi_v1.admission import (
+    ADMISSION,
+    AdmissionMode,
+)
+from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
+from agentclaw.community.adapters.http.openapi_v1.render_screens.gating import (
+    require_editable_bot,
+    require_scoped_record,
+)
+from agentclaw.community.adapters.http.openapi_v1.render_screens.router import (
+    create_render_screen,
+    delete_render_screen,
+    list_render_screens,
+    resolve_render_screen_write_owner_id,
+    update_render_screen,
+)
+from agentclaw.community.adapters.http.openapi_v1.render_screens.schemas import (
+    RenderScreenCreate,
+    RenderScreenUpdate,
+)
+from agentclaw.community.core.bot_collaborator.models import PermissionLevel
+from agentclaw.community.core.bot_management.render_screen.errors import (
+    RenderScreenNotFoundError,
+)
+from agentclaw.community.core.bot_management.render_screen.models import (
+    RenderScreenRecord,
+)
+from agentclaw.community.core.bot_management.render_screen.sqlite_models import (
+    RenderScreenModel,
+)
+from agentclaw.community.core.repository.protocols.bot import RenderScreenRepository
+from tests.community.adapters.http.openapi_v1.conftest import user_scoped_client
+from tests.community.factories.bot_collaborator import make_bot
+
+
+def _request(method: str = "GET") -> Request:
+    request = Request({"type": "http", "method": method, "path": "/"})
+    request.state.trace_id = "trace-render-screens"
+    return request
+
+
+def _bot(**overrides):
+    return {
+        "id": 10,
+        "bot_id": "bot-1",
+        "owner_id": "owner-1",
+        "space_id": "22",
+        "bot_type": "service",
+        **overrides,
+    }
+
+
+def _record(**overrides) -> RenderScreenRecord:
+    now = datetime(2026, 8, 19, 10, 0, 0)
+    values = {
+        "id": 7,
+        "bot_id": "bot-1",
+        "owner_id": "owner-1",
+        "name": "dashboard",
+        "cdn_url": "https://cdn.example.com/dashboard.js",
+        "env": "dev",
+        "creator_id": "member-1",
+        "is_delete": 0,
+        "gmt_create": now,
+        "gmt_modified": now,
+        **overrides,
+    }
+    return RenderScreenRecord(**values)
+
+
+@pytest.mark.asyncio
+async def test_list_is_readable_without_editor_permission():
+    bots = Mock()
+    bots.get_bot.return_value = _bot()
+    service = Mock()
+    service.list_render_screens.return_value = [_record()]
+
+    response = await list_render_screens(
+        bot_id="bot-1",
+        request=_request(),
+        actor_id="viewer-1",
+        owner_id="owner-1",
+        bot_service=bots,
+        service=service,
+    )
+
+    assert response.request_id == "trace-render-screens"
+    assert response.data.total == 1
+    assert response.data.items[0].model_dump(mode="json") == {
+        "id": 7,
+        "name": "dashboard",
+        "cdn_url": "https://cdn.example.com/dashboard.js",
+        "creator_id": "member-1",
+        "created_at": "2026-08-19T10:00:00",
+        "updated_at": "2026-08-19T10:00:00",
+    }
+    bots.get_bot.assert_called_once_with("bot-1", "owner-1")
+    service.list_render_screens.assert_called_once_with(
+        bot_id="bot-1", owner_id="owner-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_member_editor_can_create_update_and_delete():
+    bots = Mock()
+    bots.get_bot.return_value = _bot()
+    collaborators = Mock()
+    collaborators.get_operable_permission_level.return_value = PermissionLevel.MEMBER
+    created_record = _record()
+    updated_record = _record(
+        name="dashboard-v2",
+        cdn_url="https://cdn.example.com/dashboard-v2.js",
+    )
+    service = Mock()
+    service.create_render_screen.return_value = 7
+    service.get_render_screen.side_effect = [
+        created_record,
+        created_record,
+        updated_record,
+        updated_record,
+    ]
+
+    created_response = await create_render_screen(
+        bot_id="bot-1",
+        body=RenderScreenCreate(
+            name="dashboard",
+            cdn_url="https://cdn.example.com/dashboard.js",
+        ),
+        request=_request("POST"),
+        actor_id="member-1",
+        owner_id="owner-1",
+        bot_service=bots,
+        collaborators=collaborators,
+        service=service,
+    )
+    updated_response = await update_render_screen(
+        bot_id="bot-1",
+        render_screen_id=7,
+        body=RenderScreenUpdate(
+            name="dashboard-v2",
+            cdn_url="https://cdn.example.com/dashboard-v2.js",
+        ),
+        request=_request("PATCH"),
+        actor_id="member-1",
+        owner_id="owner-1",
+        bot_service=bots,
+        collaborators=collaborators,
+        service=service,
+    )
+    deleted_response = await delete_render_screen(
+        bot_id="bot-1",
+        render_screen_id=7,
+        request=_request("DELETE"),
+        actor_id="member-1",
+        owner_id="owner-1",
+        bot_service=bots,
+        collaborators=collaborators,
+        service=service,
+    )
+
+    assert created_response.code == 201000
+    assert updated_response.data.name == "dashboard-v2"
+    assert deleted_response.data.deleted is True
+    service.create_render_screen.assert_called_once_with(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        name="dashboard",
+        cdn_url="https://cdn.example.com/dashboard.js",
+        creator_id="member-1",
+    )
+    service.update_render_screen.assert_called_once_with(
+        record_id=7,
+        name="dashboard-v2",
+        cdn_url="https://cdn.example.com/dashboard-v2.js",
+    )
+    service.delete_render_screen.assert_called_once_with(record_id=7)
+
+
+def test_removed_team_editor_cannot_mutate():
+    bots = Mock()
+    bots.get_bot.return_value = _bot()
+    collaborators = Mock()
+    collaborators.get_operable_permission_level.return_value = PermissionLevel.NONE
+
+    with pytest.raises(RenderScreenNotFoundError):
+        require_editable_bot(
+            bots,
+            collaborators,
+            bot_id="bot-1",
+            owner_id="owner-1",
+            actor_id="removed-editor",
+        )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"bot_id": "other-bot"},
+        {"owner_id": "other-owner"},
+        {"env": "pre"},
+    ],
+)
+def test_record_id_is_bound_to_bot_owner_and_environment(overrides):
+    service = Mock()
+    service.get_render_screen.return_value = _record(**overrides)
+
+    with pytest.raises(RenderScreenNotFoundError):
+        require_scoped_record(
+            service,
+            record_id=7,
+            bot_id="bot-1",
+            owner_id="owner-1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_write_owner_defaults_to_actor_or_accepts_explicit_owner():
+    assert (
+        await resolve_render_screen_write_owner_id(
+            actor_id="member-1", owner_id=None
+        )
+        == "member-1"
+    )
+    assert (
+        await resolve_render_screen_write_owner_id(
+            actor_id="member-1", owner_id="owner-1"
+        )
+        == "owner-1"
+    )
+
+
+def test_requests_reject_unknown_fields_and_non_http_urls():
+    with pytest.raises(ValidationError):
+        RenderScreenCreate(
+            name="dashboard",
+            cdn_url="javascript:alert(1)",
+        )
+    with pytest.raises(ValidationError):
+        RenderScreenUpdate(
+            name="dashboard",
+            cdn_url="https://cdn.example.com/dashboard.js",
+            bot_id="unexpected",
+        )
+
+
+def test_admission_allows_only_the_read_for_app_only_callers():
+    collection = "/openapi/v1/bots/{bot_id}/render-screens"
+    item = f"{collection}/{{render_screen_id}}"
+
+    assert ADMISSION[("GET", collection)] is AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT
+    assert ADMISSION[("POST", collection)] is AdmissionMode.REFUSED
+    assert ADMISSION[("PATCH", item)] is AdmissionMode.REFUSED
+    assert ADMISSION[("DELETE", item)] is AdmissionMode.REFUSED
+
+
+def test_assembled_app_resolves_render_screen_services(
+    app_with_testing_modules, world
+):
+    make_bot(world, bot_id="bot-render-screen", owner_id="owner-1")
+    repository = world.get(RenderScreenRepository)
+    with repository._db.orm_session() as session:
+        RenderScreenModel.__table__.create(
+            bind=session.get_bind(), checkfirst=True
+        )
+    repository.insert(
+        bot_id="bot-render-screen",
+        owner_id="owner-1",
+        name="dashboard",
+        cdn_url="https://cdn.example.com/dashboard.js",
+        creator_id="owner-1",
+    )
+    app_with_testing_modules.dependency_overrides[require_principal] = lambda: {
+        "user_id": "owner-1"
+    }
+    try:
+        client = user_scoped_client(app_with_testing_modules, "owner-1")
+        response = client.get(
+            "/openapi/v1/bots/bot-render-screen/render-screens"
+        )
+    finally:
+        app_with_testing_modules.dependency_overrides.pop(require_principal, None)
+
+    assert response.status_code == 200, response.json()
+    assert response.json()["data"]["items"][0]["name"] == "dashboard"

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -339,9 +339,11 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: 83/1/45. Channels adds six Bot-addressed operations, and the Bot Space
 #: reassignment endpoint adds one more, yielding 90/1/45. Session Favorites then
 #: adds three Bot-addressed operations, Caller preparation adds one more, and the
-#: account-level IAM-token read adds one operation with no ``bot_id``. The Bot
-#: catalog contributes two more account-level reads, yielding 94/1/48.
-_BOT_ID_PLACEMENT = {"path": 94, "query": 1, "none": 48}
+#: account-level IAM-token read adds one operation with no ``bot_id``, yielding
+#: 94/1/46. Editors and render screens add another nine Bot-addressed
+#: operations, while the Bot catalog contributes two account-level reads,
+#: yielding 103/1/48.
+_BOT_ID_PLACEMENT = {"path": 103, "query": 1, "none": 48}
 
 
 def _schema() -> dict:
@@ -414,6 +416,8 @@ def test_the_pinned_number_of_operations_take_it():
 
     61 → 77 with the service-Bot lifecycle surface: conversion, approval config,
     version reads/actions and edit-lock operations all act for an explicit user.
+    The five bot-first Editors operations bring the total to 119, and the four
+    render-screen operations bring the current total to 123.
     """
     taking = [
         1
@@ -428,8 +432,9 @@ def test_the_pinned_number_of_operations_take_it():
     # further net 32 user-scoped operations (27 bot-addressed and five
     # account-level operations), then +6 for Bot-scoped Channels CRUD/status,
     # then +1 for Bot Space reassignment, +3 for Session Favorites, and +2 for
-    # IAM-token retrieval and Caller preparation.
-    assert len(taking) == 130
+    # IAM-token retrieval and Caller preparation, then +5 for Editors and +4
+    # for render screens.
+    assert len(taking) == 139
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -342,8 +342,9 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: account-level IAM-token read adds one operation with no ``bot_id``, yielding
 #: 94/1/46. Editors and render screens add another nine Bot-addressed
 #: operations, while the Bot catalog contributes two account-level reads,
-#: yielding 103/1/48.
-_BOT_ID_PLACEMENT = {"path": 103, "query": 1, "none": 48}
+#: and the read-only Node inventory adds one more Bot-addressed operation,
+#: yielding 104/1/48.
+_BOT_ID_PLACEMENT = {"path": 104, "query": 1, "none": 48}
 
 
 def _schema() -> dict:
@@ -417,7 +418,8 @@ def test_the_pinned_number_of_operations_take_it():
     61 → 77 with the service-Bot lifecycle surface: conversion, approval config,
     version reads/actions and edit-lock operations all act for an explicit user.
     The five bot-first Editors operations bring the total to 119, and the four
-    render-screen operations bring the current total to 123.
+    render-screen operations bring the total to 123, and the read-only Node
+    inventory brings the current total to 124.
     """
     taking = [
         1
@@ -433,8 +435,8 @@ def test_the_pinned_number_of_operations_take_it():
     # account-level operations), then +6 for Bot-scoped Channels CRUD/status,
     # then +1 for Bot Space reassignment, +3 for Session Favorites, and +2 for
     # IAM-token retrieval and Caller preparation, then +5 for Editors and +4
-    # for render screens.
-    assert len(taking) == 139
+    # for render screens. The read-only Node inventory adds the final operation.
+    assert len(taking) == 140
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/architecture/test_service_api_conformance.py
+++ b/src/backend/tests/community/architecture/test_service_api_conformance.py
@@ -41,6 +41,7 @@ import pytest
 from agentclaw.community.api.bot_dormant_service import (
     BotDormantActivateServiceProtocol,
 )
+from agentclaw.community.api.collaborator_service import CollaboratorServiceProtocol
 from agentclaw.community.api.bot_inventory_service import BotInventoryServiceProtocol
 from agentclaw.community.api.bot_startup_script_service import (
     BotStartupScriptServiceProtocol,
@@ -84,6 +85,9 @@ from agentclaw.community.api.space_service import (
     SpaceServiceProtocol,
 )
 from agentclaw.community.core.bot_dormant.activate_service import ActivateBotService
+from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
+    CollaboratorService,
+)
 from agentclaw.community.core.bot_inventory.protocols import (
     BotInventoryBotPort,
     DesktopBotInventoryPort,
@@ -137,6 +141,7 @@ from agentclaw.community.core.spaces.services import (
 # (Protocol, ConcreteService) pairs whose Protocol declares real signatures.
 _PAIRS = [
     (BotAppGrantServiceProtocol, BotAppGrantService),
+    (CollaboratorServiceProtocol, CollaboratorService),
     (BotInventoryServiceProtocol, BotInventoryService),
     (BotStartupScriptServiceProtocol, BotStartupScriptService),
     (BotSpaceServiceProtocol, BotSpaceService),

--- a/src/backend/tests/community/core/bot_collaborator/test_collaborator_service_coding.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_collaborator_service_coding.py
@@ -5,6 +5,7 @@
     if bot_type != "service" and not is_coding_app: raise BotNotServiceTypeError
 即 coding 应用（Personal Bot）作为"应用成员"复用协作者流程时放行。
 """
+
 import pytest
 from unittest.mock import Mock
 
@@ -56,6 +57,7 @@ def service(collaborator_repo, bot_repo, template_service):
         bot_repo=bot_repo,
         passport_plugin=Mock(),
         credentials_admins_writer=Mock(),
+        space_access_service=Mock(),
         member_management_capability_service=MemberManagementCapabilityService(
             engine_capabilities=(AICodingMemberManagementCapability(template_service),),
         ),
@@ -121,7 +123,9 @@ def test_add_collaborator_member_management_flag_allowed(
     collaborator_repo.insert.assert_called_once()
 
 
-def test_add_collaborator_member_management_requires_boolean_true(service, bot_repo, template_service):
+def test_add_collaborator_member_management_requires_boolean_true(
+    service, bot_repo, template_service
+):
     """member_management 只有布尔 True 放行，字符串等 truthy 值不扩权。"""
     bot_repo.get_by_id_and_owner.return_value = _bot(
         bot_type="personal",
@@ -136,7 +140,9 @@ def test_add_collaborator_member_management_requires_boolean_true(service, bot_r
         _add(service)
 
 
-def test_add_collaborator_service_type_still_allowed(service, bot_repo, collaborator_repo):
+def test_add_collaborator_service_type_still_allowed(
+    service, bot_repo, collaborator_repo
+):
     """回归：service 类型仍按原逻辑放行。"""
     bot_repo.get_by_id_and_owner.return_value = _bot(bot_type="service")
 
@@ -185,19 +191,27 @@ def test_add_collaborator_bot_not_found(service, bot_repo):
 # are gone). The resolver thunk resolves to "no running device" so the
 # credentials-sync leg is a clean no-op and we stay focused on the passport leg.
 
+
 def _service_for_sync(passport):
     return CollaboratorService(
         collaborator_repo=Mock(),
         bot_repo=Mock(),
         passport_plugin=passport,
         credentials_admins_writer=Mock(),
+        space_access_service=Mock(),
     )
 
 
 def _admin_record(user_id):
     return CollaboratorRecord(
-        id=1, bot_pk=1, bot_id="bot1", user_id=user_id,
-        role=CollaboratorRole.ADMIN, owner_id="owner1", operator_id="op1", env="dev",
+        id=1,
+        bot_pk=1,
+        bot_id="bot1",
+        user_id=user_id,
+        role=CollaboratorRole.ADMIN,
+        owner_id="owner1",
+        operator_id="op1",
+        env="dev",
     )
 
 
@@ -205,12 +219,17 @@ def test_on_collaboration_changed_syncs_admins_to_passport():
     passport = Mock()
     svc = _service_for_sync(passport)
     svc._collaborator_repo.list_by_bot.return_value = [_admin_record("admin001")]
-    svc._bot_repo.get_by_id_and_owner.return_value = {"bot_id": "bot1", "owner_id": "owner1"}
+    svc._bot_repo.get_by_id_and_owner.return_value = {
+        "bot_id": "bot1",
+        "owner_id": "owner1",
+    }
 
     svc.on_collaboration_changed("bot1", "owner1", env="dev")
 
     passport.update_passport.assert_called_once_with(
-        bot_id="bot1", user_id="owner1", admins=["admin001"],
+        bot_id="bot1",
+        user_id="owner1",
+        admins=["admin001"],
     )
 
 
@@ -219,7 +238,10 @@ def test_on_collaboration_changed_passport_failure_is_swallowed():
     passport.update_passport.side_effect = RuntimeError("passport service down")
     svc = _service_for_sync(passport)
     svc._collaborator_repo.list_by_bot.return_value = []
-    svc._bot_repo.get_by_id_and_owner.return_value = {"bot_id": "bot1", "owner_id": "owner1"}
+    svc._bot_repo.get_by_id_and_owner.return_value = {
+        "bot_id": "bot1",
+        "owner_id": "owner1",
+    }
 
     # A passport-sync failure must not propagate out of the collaboration hook.
     svc.on_collaboration_changed("bot1", "owner1", env="dev")
@@ -255,6 +277,7 @@ def test_on_collaboration_changed_delegates_admins_to_credentials_writer():
         bot_repo=bot_repo,
         passport_plugin=Mock(),
         credentials_admins_writer=writer,
+        space_access_service=Mock(),
     )
 
     svc.on_collaboration_changed("bot1", "owner1", env="dev")
@@ -276,7 +299,9 @@ def _collaborator_record(user_id: str = MEMBER) -> CollaboratorRecord:
     )
 
 
-def test_leave_collaboration_allows_member_self_exit(service, bot_repo, collaborator_repo):
+def test_leave_collaboration_allows_member_self_exit(
+    service, bot_repo, collaborator_repo
+):
     """成员主动退出协作：只删除当前用户自己的协作者记录，不要求 admin 权限。"""
     bot_repo.get_by_id_and_owner.return_value = _bot(bot_type="service")
     collaborator_repo.get_by_bot_and_user.return_value = _collaborator_record()
@@ -295,7 +320,9 @@ def test_leave_collaboration_allows_member_self_exit(service, bot_repo, collabor
     service.on_collaboration_changed.assert_called_once_with("bot-123", OWNER, "dev")
 
 
-def test_leave_collaboration_rejects_non_collaborator(service, bot_repo, collaborator_repo):
+def test_leave_collaboration_rejects_non_collaborator(
+    service, bot_repo, collaborator_repo
+):
     """非协作者没有自己的记录，退出返回 CollaboratorNotFoundError。"""
     from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
         CollaboratorNotFoundError,
@@ -316,7 +343,9 @@ def test_leave_collaboration_rejects_non_collaborator(service, bot_repo, collabo
     service.on_collaboration_changed.assert_not_called()
 
 
-def test_leave_collaboration_owner_is_not_collaborator_record(service, bot_repo, collaborator_repo):
+def test_leave_collaboration_owner_is_not_collaborator_record(
+    service, bot_repo, collaborator_repo
+):
     """Owner 不是协作者记录，不能使用成员退出接口。"""
     from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
         CollaboratorNotFoundError,

--- a/src/backend/tests/community/core/bot_collaborator/test_editor_service.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_editor_service.py
@@ -1,0 +1,240 @@
+"""Focused policy tests for the public bot-first Editors service methods."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import Mock
+
+import pytest
+
+from agentclaw.community.core.bot_collaborator.errors import (
+    CannotRemoveSelfError,
+    CollaboratorNotFoundError,
+    CollaboratorSpaceMembershipError,
+    InvalidCollaboratorRoleError,
+    PermissionDeniedError,
+)
+from agentclaw.community.core.bot_collaborator.models import (
+    CollaboratorRecord,
+    CollaboratorRole,
+    PermissionLevel,
+)
+from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
+    CollaboratorService,
+)
+from agentclaw.community.core.spaces.errors import SpaceAccessDeniedError
+from agentclaw.community.core.spaces.models import SpaceType
+
+
+OWNER = "owner-1"
+ADMIN = "admin-1"
+MEMBER = "member-1"
+
+
+def _bot(**overrides):
+    return {
+        "id": 10,
+        "bot_id": "bot-1",
+        "owner_id": OWNER,
+        "bot_type": "service",
+        "space_id": None,
+        **overrides,
+    }
+
+
+def _record(**overrides) -> CollaboratorRecord:
+    now = datetime(2026, 8, 19, 10, 0, 0)
+    values = {
+        "id": 7,
+        "bot_pk": 10,
+        "bot_id": "bot-1",
+        "owner_id": OWNER,
+        "user_id": MEMBER,
+        "role": CollaboratorRole.MEMBER,
+        "operator_id": OWNER,
+        "env": "dev",
+        "gmt_create": now,
+        "gmt_modified": now,
+        **overrides,
+    }
+    return CollaboratorRecord(**values)
+
+
+@pytest.fixture
+def dependencies():
+    collaborator_repo = Mock()
+    collaborator_repo.get_by_bot_and_user.return_value = None
+    bot_repo = Mock()
+    bot_repo.get_by_id_and_owner.return_value = _bot()
+    space_access = Mock()
+    service = CollaboratorService(
+        collaborator_repo=collaborator_repo,
+        bot_repo=bot_repo,
+        passport_plugin=Mock(),
+        credentials_admins_writer=Mock(),
+        space_access_service=space_access,
+    )
+    service.on_collaboration_changed = Mock()
+    return service, collaborator_repo, bot_repo, space_access
+
+
+def test_add_editor_rejects_an_unknown_role(dependencies):
+    service, collaborator_repo, _, _ = dependencies
+
+    with pytest.raises(InvalidCollaboratorRoleError):
+        service.add_editor("bot-1", OWNER, MEMBER, OWNER, role="super-admin", env="dev")
+
+    collaborator_repo.insert.assert_not_called()
+
+
+def test_add_editor_requires_live_team_space_membership(dependencies):
+    service, collaborator_repo, bot_repo, space_access = dependencies
+    bot_repo.get_by_id_and_owner.return_value = _bot(space_id="spc-team")
+    space_access.require_space_reference.return_value = Mock(
+        id=22, space_type=SpaceType.TEAM
+    )
+    space_access.require_space_member.side_effect = SpaceAccessDeniedError(
+        "membership required"
+    )
+
+    with pytest.raises(CollaboratorSpaceMembershipError):
+        service.add_editor("bot-1", OWNER, MEMBER, OWNER, env="dev")
+
+    collaborator_repo.insert.assert_not_called()
+
+
+def test_unsupported_bot_is_masked_until_after_actor_authorization(dependencies):
+    service, collaborator_repo, bot_repo, _ = dependencies
+    bot_repo.get_by_id_and_owner.return_value = _bot(bot_type="personal")
+    collaborator_repo.get_user_role.return_value = None
+
+    with pytest.raises(PermissionDeniedError):
+        service.list_editors("bot-1", OWNER, "stranger", env="dev")
+
+
+@pytest.mark.parametrize(
+    "record_override",
+    [
+        {"bot_pk": 999},
+        {"bot_id": "other-bot"},
+        {"owner_id": "other-owner"},
+        {"env": "pre"},
+    ],
+)
+def test_update_editor_masks_cross_scope_record_ids(dependencies, record_override):
+    service, collaborator_repo, _, _ = dependencies
+    collaborator_repo.get_by_id.return_value = _record(**record_override)
+
+    with pytest.raises(CollaboratorNotFoundError):
+        service.update_editor(
+            "bot-1", OWNER, 7, OWNER, CollaboratorRole.ADMIN, env="dev"
+        )
+
+    collaborator_repo.update.assert_not_called()
+
+
+def test_update_editor_changes_only_role_and_operator(dependencies):
+    service, collaborator_repo, _, _ = dependencies
+    collaborator_repo.get_user_role.return_value = CollaboratorRole.ADMIN
+    record = _record()
+    updated = _record(role=CollaboratorRole.ADMIN, operator_id=ADMIN)
+    collaborator_repo.get_by_id.return_value = record
+    collaborator_repo.update.return_value = updated
+
+    result = service.update_editor(
+        "bot-1", OWNER, 7, ADMIN, CollaboratorRole.ADMIN, env="dev"
+    )
+
+    assert result is updated
+    collaborator_repo.update.assert_called_once_with(
+        7, {"operator_id": ADMIN, "role": CollaboratorRole.ADMIN.value}
+    )
+    service.on_collaboration_changed.assert_called_once_with("bot-1", OWNER, "dev")
+
+
+def test_non_owner_admin_must_leave_instead_of_removing_self(dependencies):
+    service, collaborator_repo, _, _ = dependencies
+    collaborator_repo.get_user_role.return_value = CollaboratorRole.ADMIN
+    collaborator_repo.get_by_id.return_value = _record(user_id=ADMIN)
+
+    with pytest.raises(CannotRemoveSelfError):
+        service.remove_editor("bot-1", OWNER, 7, ADMIN, env="dev")
+
+    collaborator_repo.delete.assert_not_called()
+
+
+def test_removed_team_editor_has_no_operable_permission(dependencies):
+    service, collaborator_repo, _, space_access = dependencies
+    bot = _bot(space_id="22")
+    collaborator_repo.get_user_role.return_value = CollaboratorRole.ADMIN
+    space_access.require_space_reference.return_value = Mock(
+        id=22, space_type=SpaceType.TEAM
+    )
+    space_access.require_space_member.side_effect = SpaceAccessDeniedError(
+        "membership required"
+    )
+
+    level = service.get_operable_permission_level(
+        bot=bot, user_id=ADMIN, env="dev"
+    )
+
+    assert level is PermissionLevel.NONE
+
+
+def test_removed_team_bot_owner_keeps_owner_permission(dependencies):
+    service, collaborator_repo, _, space_access = dependencies
+
+    level = service.get_operable_permission_level(
+        bot=_bot(space_id="22"), user_id=OWNER, env="dev"
+    )
+
+    assert level is PermissionLevel.OWNER
+    collaborator_repo.get_user_role.assert_not_called()
+    space_access.require_space_reference.assert_not_called()
+
+
+def test_personal_space_editor_keeps_editor_permission(dependencies):
+    service, collaborator_repo, _, space_access = dependencies
+    collaborator_repo.get_user_role.return_value = CollaboratorRole.MEMBER
+
+    level = service.get_operable_permission_level(
+        bot=_bot(space_id=None), user_id=MEMBER, env="dev"
+    )
+
+    assert level is PermissionLevel.MEMBER
+    space_access.require_space_reference.assert_not_called()
+
+
+def test_batch_operable_permissions_reads_roles_once_and_caches_space_membership(
+    dependencies,
+):
+    service, collaborator_repo, _, space_access = dependencies
+    collaborator_repo.list_by_user.return_value = [
+        _record(bot_pk=11, bot_id="bot-2", user_id=ADMIN),
+        _record(bot_pk=12, bot_id="bot-3", user_id=ADMIN),
+    ]
+    space_access.require_space_reference.return_value = Mock(
+        id=22, space_type=SpaceType.TEAM
+    )
+
+    levels = service.get_operable_permission_levels(
+        bots=[
+            _bot(id=10, bot_id="bot-1", owner_id=ADMIN, space_id="22"),
+            _bot(id=11, bot_id="bot-2", space_id="22"),
+            _bot(id=12, bot_id="bot-3", space_id="22"),
+        ],
+        user_id=ADMIN,
+        env="dev",
+    )
+
+    assert levels == {
+        10: PermissionLevel.OWNER,
+        11: PermissionLevel.MEMBER,
+        12: PermissionLevel.MEMBER,
+    }
+    collaborator_repo.list_by_user.assert_called_once_with(ADMIN, "dev")
+    collaborator_repo.get_user_role.assert_not_called()
+    space_access.require_space_reference.assert_called_once_with(space_ref="22")
+    space_access.require_space_member.assert_called_once_with(
+        space_id=22, user_id=ADMIN
+    )

--- a/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
+++ b/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
@@ -6,11 +6,15 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_inventory.adapters.noop_business_space import (
     NoopBusinessSpaceContext,
 )
 from agentclaw.community.core.bot_inventory.adapters.noop_service_lifecycle import (
     NoopServiceLifecyclePort,
+)
+from agentclaw.community.core.bot_inventory.protocols import (
+    BusinessSpaceContextProtocol,
 )
 from agentclaw.community.core.bot_inventory.services.bot_inventory_service import (
     BotInventoryService,
@@ -20,6 +24,7 @@ from agentclaw.community.core.bot_inventory.services.lifecycle_view import (
 )
 from agentclaw.community.core.bot_inventory.types import (
     BotAction,
+    BusinessSpaceRef,
     DeployMode,
     DisplayState,
     ServiceLifecycleCard,
@@ -27,6 +32,7 @@ from agentclaw.community.core.bot_inventory.types import (
 
 
 CLOUD = {
+    "id": 1,
     "bot_id": "c1",
     "bot_name": "Cloud",
     "bot_desc": "cloud bot",
@@ -36,6 +42,7 @@ CLOUD = {
     "owner_id": "u1",
 }
 LOCAL = {
+    "id": 2,
     "bot_id": "l1",
     "bot_name": "Local",
     "bot_desc": "local bot",
@@ -53,10 +60,15 @@ def service():
     bot.get_bot.return_value = CLOUD
     desktop = MagicMock()
     desktop.list_user_bots.return_value = [LOCAL]
+    access = MagicMock()
+    access.get_operable_permission_levels.side_effect = lambda **kwargs: {
+        int(bot["id"]): PermissionLevel.OWNER for bot in kwargs["bots"]
+    }
     return (
         BotInventoryService(
             bot_service=bot,
             desktop_service=desktop,
+            access_service=access,
             business_space=NoopBusinessSpaceContext(),
             lifecycle_view=BotLifecycleView(NoopServiceLifecyclePort()),
         ),
@@ -71,7 +83,9 @@ def test_list_items_combines_filters_and_paginates(service) -> None:
 
     items, total = inventory.list_items(
         owner_id="u1",
-        space=None,
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
         keyword=None,
         engine=None,
         deploy_mode=None,
@@ -105,7 +119,9 @@ def test_cloud_source_fetches_all_pages_for_exact_total(service) -> None:
 
     items, total = inventory.list_items(
         owner_id="u1",
-        space=None,
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
         keyword=None,
         engine=None,
         deploy_mode=DeployMode.CLOUD,
@@ -156,16 +172,24 @@ def test_service_bot_expands_to_publication_cards_before_pagination() -> None:
             ),
         )
     }
+    access = MagicMock()
+    access.get_operable_permission_levels.return_value = {
+        1: PermissionLevel.OWNER,
+        10: PermissionLevel.OWNER,
+    }
     inventory = BotInventoryService(
         bot_service=bot,
         desktop_service=desktop,
+        access_service=access,
         business_space=NoopBusinessSpaceContext(),
         lifecycle_view=BotLifecycleView(lifecycle_port),
     )
 
     items, total = inventory.list_items(
         owner_id="u1",
-        space=None,
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
         keyword=None,
         engine=None,
         deploy_mode=DeployMode.CLOUD,
@@ -197,7 +221,9 @@ def test_grant_filter_is_applied_to_both_sources_before_total_and_pagination(
 
     items, total = inventory.list_items(
         owner_id="u1",
-        space=None,
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
         keyword=None,
         engine=None,
         deploy_mode=None,
@@ -234,7 +260,9 @@ def test_cloud_grant_filter_is_forwarded_to_every_upstream_page(service) -> None
 
     inventory.list_items(
         owner_id="u1",
-        space=None,
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
         keyword=None,
         engine=None,
         deploy_mode=DeployMode.CLOUD,
@@ -244,3 +272,113 @@ def test_cloud_grant_filter_is_forwarded_to_every_upstream_page(service) -> None
     )
 
     assert bot.list_bots_by_conditions.call_count == 2
+
+
+@pytest.mark.unit
+def test_team_space_lists_all_owners_and_scopes_actions_by_bot_permission() -> None:
+    team_space = BusinessSpaceRef(
+        space_id="22",
+        name="Alpha",
+        kind="team",
+    )
+    owner_bot = {
+        **CLOUD,
+        "id": 10,
+        "bot_id": "service-owner",
+        "bot_name": "Owner Service",
+        "bot_type": "service",
+        "space_id": "22",
+    }
+    editor_bot = {
+        **owner_bot,
+        "id": 11,
+        "bot_id": "service-editor",
+        "bot_name": "Editor Service",
+        "owner_id": "other-owner",
+    }
+    viewer_bot = {
+        **owner_bot,
+        "id": 12,
+        "bot_id": "service-viewer",
+        "bot_name": "Viewer Service",
+        "owner_id": "third-owner",
+    }
+    rows = [owner_bot, editor_bot, viewer_bot]
+    bot = MagicMock()
+    bot.list_bots_by_conditions.return_value = {"total": 3, "items": rows}
+    desktop = MagicMock()
+    access = MagicMock()
+    access.get_operable_permission_levels.return_value = {
+        10: PermissionLevel.OWNER,
+        11: PermissionLevel.MEMBER,
+        12: PermissionLevel.NONE,
+    }
+    business_space = MagicMock(spec=BusinessSpaceContextProtocol)
+    business_space.bot_space.return_value = team_space
+    lifecycle_port = MagicMock()
+    lifecycle_port.cards_for_bots.return_value = {
+        row["bot_id"]: (
+            ServiceLifecycleCard(
+                publication_id=row["id"],
+                version=1,
+                display_state=DisplayState.SERVICE_ONLINE,
+                status="online",
+                actions=(BotAction.VIEW, BotAction.EDIT, BotAction.DELETE),
+            ),
+        )
+        for row in rows
+    }
+    inventory = BotInventoryService(
+        bot_service=bot,
+        desktop_service=desktop,
+        access_service=access,
+        business_space=business_space,
+        lifecycle_view=BotLifecycleView(lifecycle_port),
+    )
+
+    items, total = inventory.list_items(
+        owner_id="u1",
+        space=team_space,
+        keyword=None,
+        engine=None,
+        deploy_mode=None,
+        page=1,
+        page_size=10,
+    )
+
+    assert total == 3
+    assert {item.owner_entity_id for item in items} == {
+        "u1",
+        "other-owner",
+        "third-owner",
+    }
+    bot.list_bots_by_conditions.assert_called_once_with(
+        owner_id=None,
+        space_id="22",
+        bot_name=None,
+        engine=None,
+        status=None,
+        bot_ids=None,
+        page=1,
+        page_size=200,
+    )
+    desktop.list_user_bots.assert_not_called()
+    by_id = {item.bot_id: item for item in items}
+    assert by_id["service-owner"].actions == (
+        BotAction.VIEW,
+        BotAction.EDIT,
+        BotAction.DELETE,
+    )
+    assert by_id["service-editor"].actions == (
+        BotAction.VIEW,
+        BotAction.EDIT,
+    )
+    assert by_id["service-editor"].disabled_actions == {
+        "delete": "Bot Owner permission required"
+    }
+    assert by_id["service-viewer"].actions == (BotAction.VIEW,)
+    assert by_id["service-viewer"].disabled_actions == {
+        "edit": "Bot editor permission required",
+        "delete": "Bot editor permission required",
+    }
+    assert all(item.space == team_space for item in items)

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -88,6 +88,8 @@ def test_space_repository_full_member_lifecycle(db) -> None:
         == "sc-Team-owner-1"
     )
     assert repository.get_space(space_id=999, env="dev") is None
+    assert repository.get_space_by_code(space_code=team.space_code, env="dev") == team
+    assert repository.get_space_by_code(space_code="missing", env="dev") is None
 
     other_env_personal, _ = repository.initialize_personal(
         user_id="user-other-env", env="pre"

--- a/src/backend/tests/community/core/spaces/test_space_access_service.py
+++ b/src/backend/tests/community/core/spaces/test_space_access_service.py
@@ -70,6 +70,32 @@ def test_require_space_rejects_missing_space() -> None:
         SpaceAccessService(repository).require_space(space_id=7)
 
 
+def test_require_space_reference_accepts_numeric_team_prefix_and_space_code() -> None:
+    repository = MagicMock()
+    repository.get_space.side_effect = [_space(), _space()]
+    repository.get_space_by_code.return_value = _space()
+    service = SpaceAccessService(repository)
+
+    assert service.require_space_reference(space_ref="7").id == 7
+    assert service.require_space_reference(space_ref="team:7").id == 7
+    assert service.require_space_reference(space_ref="spc-7").id == 7
+    repository.get_space_by_code.assert_called_once_with(space_code="spc-7", env="dev")
+
+
+def test_require_space_reference_rejects_team_prefix_for_personal_space() -> None:
+    repository = MagicMock()
+    repository.get_space.return_value = _space().model_copy(
+        update={
+            "space_type": SpaceType.PERSONAL,
+            "personal_owner_id": "owner-1",
+        }
+    )
+    service = SpaceAccessService(repository)
+
+    with pytest.raises(SpaceNotFoundError, match="space not found"):
+        service.require_space_reference(space_ref="team:7")
+
+
 def test_get_space_role_returns_role_or_none() -> None:
     repository = MagicMock()
     repository.get_member.side_effect = [_member(role=SpaceRole.OWNER), None]

--- a/src/backend/tests/community/endpoints/test_bot_workshop_configuration_openapi.py
+++ b/src/backend/tests/community/endpoints/test_bot_workshop_configuration_openapi.py
@@ -1,0 +1,479 @@
+"""Endpoint-framework coverage for Bot Workshop configuration resources."""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
+from agentclaw.community.api.render_screen_service import RenderScreenServiceProtocol
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+)
+from tests.community.factories.bot_collaborator import (
+    make_bot,
+    make_collaborator,
+)
+from tests.community.framework import (
+    CaseInput,
+    ExpectError,
+    ExpectSuccess,
+    endpoint_test,
+)
+
+_OWNER = "workshop-config-owner"
+_EDITOR = "workshop-config-editor"
+_BOT = "workshop-config-bot"
+_MISSING_BOT = "workshop-config-missing"
+_EDITOR_ID = 1
+_SCREEN_ID = 1
+_KEY = "workshop-config-endpoint-signing-key-32-bytes"
+
+
+class _Secret:
+    secret_user = "test"
+    secret_value = _KEY
+
+
+class _Resolver:
+    def get_secret(self, _secret_name: str) -> _Secret:
+        return _Secret()
+
+
+def _principal(user_id: str) -> str:
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 3600,
+            "principals": [
+                {
+                    "type": "user",
+                    "subject": {
+                        "id": user_id,
+                        "username": f"{user_id}@example.test",
+                    },
+                }
+            ],
+        },
+        _KEY,
+        algorithm="HS256",
+    )
+
+
+_OWNER_HEADERS = {PRINCIPAL_HEADER: _principal(_OWNER)}
+_EDITOR_HEADERS = {PRINCIPAL_HEADER: _principal(_EDITOR)}
+_OWNER_QUERY = {"user_id": _OWNER}
+_EDITOR_QUERY = {"user_id": _EDITOR, "owner_id": _OWNER}
+
+
+def _boot_verifier() -> None:
+    init_principal_verifier_config(_Resolver(), "test-key", strict=False)
+
+
+def _seed_no_bot(_world) -> None:
+    _boot_verifier()
+
+
+def _seed_bot(world) -> None:
+    _boot_verifier()
+    make_bot(world, bot_id=_BOT, owner_id=_OWNER, bot_type="service")
+
+
+def _seed_editor(world) -> None:
+    _seed_bot(world)
+    record = make_collaborator(
+        world,
+        bot_id=_BOT,
+        owner_id=_OWNER,
+        user_id=_EDITOR,
+        role="member",
+        operator_id=_OWNER,
+    )
+    assert record.id == _EDITOR_ID
+
+
+def _seed_render_screen(world) -> None:
+    _seed_bot(world)
+    record_id = world.get(RenderScreenServiceProtocol).create_render_screen(
+        bot_id=_BOT,
+        owner_id=_OWNER,
+        name="dashboard",
+        cdn_url="https://cdn.example.test/dashboard.js",
+        creator_id=_OWNER,
+    )
+    assert record_id == _SCREEN_ID
+
+
+# Editors
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/{bot_id}/editors",
+    scenario="lists_bot_editors",
+    input=CaseInput(
+        path_params={"bot_id": _BOT},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+    ),
+    seed=_seed_editor,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": {
+                "total": 1,
+                "items": [{"id": _EDITOR_ID, "user_id": _EDITOR, "role": "member"}],
+            },
+        },
+    ),
+)
+def list_editors_ok():
+    """The assembled route returns the persisted public Editor projection."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/{bot_id}/editors",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": _MISSING_BOT},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def list_editors_unknown_bot():
+    """An absent Bot is masked as not found."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/editors",
+    scenario="adds_member_editor",
+    input=CaseInput(
+        path_params={"bot_id": _BOT},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+        json_body={"editor_user_id": _EDITOR, "role": "member"},
+    ),
+    seed=_seed_bot,
+    expect=ExpectSuccess(
+        status=201,
+        json_contains={
+            "code": 201000,
+            "data": {"id": _EDITOR_ID, "user_id": _EDITOR, "role": "member"},
+        },
+    ),
+)
+def add_editor_ok():
+    """The owner can add a member Editor through the public contract."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/editors",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": _MISSING_BOT},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+        json_body={"editor_user_id": _EDITOR, "role": "member"},
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def add_editor_unknown_bot():
+    """An Editor relation cannot be created for an absent Bot."""
+
+
+@endpoint_test(
+    method="PATCH",
+    path="/openapi/v1/bots/{bot_id}/editors/{editor_id}",
+    scenario="promotes_editor",
+    input=CaseInput(
+        path_params={"bot_id": _BOT, "editor_id": _EDITOR_ID},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+        json_body={"role": "admin"},
+    ),
+    seed=_seed_editor,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": {"id": _EDITOR_ID, "user_id": _EDITOR, "role": "admin"},
+        },
+    ),
+)
+def update_editor_ok():
+    """The addressed relation is updated after Bot/owner/env rebinding."""
+
+
+@endpoint_test(
+    method="PATCH",
+    path="/openapi/v1/bots/{bot_id}/editors/{editor_id}",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": _MISSING_BOT, "editor_id": _EDITOR_ID},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+        json_body={"role": "admin"},
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def update_editor_unknown_bot():
+    """The Bot check precedes use of a public relation id."""
+
+
+@endpoint_test(
+    method="DELETE",
+    path="/openapi/v1/bots/{bot_id}/editors/{editor_id}",
+    scenario="removes_editor",
+    input=CaseInput(
+        path_params={"bot_id": _BOT, "editor_id": _EDITOR_ID},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+    ),
+    seed=_seed_editor,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"code": 200000, "data": {"deleted": True}},
+    ),
+)
+def remove_editor_ok():
+    """The owner can remove an Editor from the addressed Bot."""
+
+
+@endpoint_test(
+    method="DELETE",
+    path="/openapi/v1/bots/{bot_id}/editors/{editor_id}",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": _MISSING_BOT, "editor_id": _EDITOR_ID},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def remove_editor_unknown_bot():
+    """A relation id cannot be aimed at an absent Bot."""
+
+
+@endpoint_test(
+    method="DELETE",
+    path="/openapi/v1/bots/{bot_id}/editors/me",
+    scenario="editor_leaves",
+    input=CaseInput(
+        path_params={"bot_id": _BOT},
+        query_params=_EDITOR_QUERY,
+        headers=_EDITOR_HEADERS,
+    ),
+    seed=_seed_editor,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"code": 200000, "data": {"deleted": True}},
+    ),
+)
+def leave_editors_ok():
+    """A member can remove only their own Editor relation."""
+
+
+@endpoint_test(
+    method="DELETE",
+    path="/openapi/v1/bots/{bot_id}/editors/me",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": _MISSING_BOT},
+        query_params=_EDITOR_QUERY,
+        headers=_EDITOR_HEADERS,
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def leave_editors_unknown_bot():
+    """Leaving an absent Bot does not disclose collaborator state."""
+
+
+# Render screens
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/{bot_id}/render-screens",
+    scenario="lists_render_screens",
+    input=CaseInput(
+        path_params={"bot_id": _BOT},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+    ),
+    seed=_seed_render_screen,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": {
+                "total": 1,
+                "items": [
+                    {
+                        "id": _SCREEN_ID,
+                        "name": "dashboard",
+                        "cdn_url": "https://cdn.example.test/dashboard.js",
+                    }
+                ],
+            },
+        },
+    ),
+)
+def list_render_screens_ok():
+    """The public list exposes only the render-screen projection."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/{bot_id}/render-screens",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": _MISSING_BOT},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def list_render_screens_unknown_bot():
+    """An absent addressed Bot is masked as not found."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/render-screens",
+    scenario="creates_render_screen",
+    input=CaseInput(
+        path_params={"bot_id": _BOT},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+        json_body={
+            "name": "dashboard",
+            "cdn_url": "https://cdn.example.test/dashboard.js",
+        },
+    ),
+    seed=_seed_bot,
+    expect=ExpectSuccess(
+        status=201,
+        json_contains={
+            "code": 201000,
+            "data": {"id": _SCREEN_ID, "name": "dashboard"},
+        },
+    ),
+)
+def create_render_screen_ok():
+    """The owner can create a valid HTTP(S) CDN mapping."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/render-screens",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": _MISSING_BOT},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+        json_body={
+            "name": "dashboard",
+            "cdn_url": "https://cdn.example.test/dashboard.js",
+        },
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def create_render_screen_unknown_bot():
+    """A mapping cannot be created for an absent Bot."""
+
+
+@endpoint_test(
+    method="PATCH",
+    path="/openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}",
+    scenario="updates_render_screen",
+    input=CaseInput(
+        path_params={"bot_id": _BOT, "render_screen_id": _SCREEN_ID},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+        json_body={
+            "name": "dashboard-v2",
+            "cdn_url": "https://cdn.example.test/dashboard-v2.js",
+        },
+    ),
+    seed=_seed_render_screen,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": {"id": _SCREEN_ID, "name": "dashboard-v2"},
+        },
+    ),
+)
+def update_render_screen_ok():
+    """The mapping is updated after record-to-Bot rebinding."""
+
+
+@endpoint_test(
+    method="PATCH",
+    path="/openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": _MISSING_BOT, "render_screen_id": _SCREEN_ID},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+        json_body={
+            "name": "dashboard-v2",
+            "cdn_url": "https://cdn.example.test/dashboard-v2.js",
+        },
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def update_render_screen_unknown_bot():
+    """The Bot authorization runs before a mapping id is trusted."""
+
+
+@endpoint_test(
+    method="DELETE",
+    path="/openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}",
+    scenario="deletes_render_screen",
+    input=CaseInput(
+        path_params={"bot_id": _BOT, "render_screen_id": _SCREEN_ID},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+    ),
+    seed=_seed_render_screen,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"code": 200000, "data": {"deleted": True}},
+    ),
+)
+def delete_render_screen_ok():
+    """The owner can soft-delete the addressed mapping."""
+
+
+@endpoint_test(
+    method="DELETE",
+    path="/openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}",
+    scenario="unknown_bot",
+    input=CaseInput(
+        path_params={"bot_id": _MISSING_BOT, "render_screen_id": _SCREEN_ID},
+        query_params=_OWNER_QUERY,
+        headers=_OWNER_HEADERS,
+    ),
+    seed=_seed_no_bot,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def delete_render_screen_unknown_bot():
+    """An absent Bot masks the mapping id as not found."""

--- a/src/backend/tests/community/endpoints/test_openapi_nodes.py
+++ b/src/backend/tests/community/endpoints/test_openapi_nodes.py
@@ -1,0 +1,144 @@
+"""Endpoint-framework coverage for the public node inventory."""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
+from agentclaw.community.api.engine_runtime_service import EngineRuntimeRelayProtocol
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotNotFoundError,
+)
+from agentclaw.community.core.engine_runtime.models import BotFacts, EngineResult
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+)
+from tests.community.framework import (
+    CaseInput,
+    ExpectError,
+    ExpectSuccess,
+    endpoint_test,
+)
+
+_OWNER = "openapi-nodes-owner"
+_BOT = "openapi-nodes-bot"
+_MISSING_BOT = "openapi-nodes-missing"
+_KEY = "openapi-nodes-signing-key-at-least-32-bytes"
+_PATH = "/openapi/v1/bots/{bot_id}/nodes"
+
+
+class _Secret:
+    secret_user = "test"
+    secret_value = _KEY
+
+
+class _Resolver:
+    def get_secret(self, _secret_name: str) -> _Secret:
+        return _Secret()
+
+
+def _principal() -> str:
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 3600,
+            "principals": [
+                {
+                    "type": "user",
+                    "subject": {
+                        "id": _OWNER,
+                        "username": f"{_OWNER}@example.test",
+                    },
+                }
+            ],
+        },
+        _KEY,
+        algorithm="HS256",
+    )
+
+
+class _NodeRelay:
+    async def resolve_bot_off_loop(
+        self, bot_id: str, owner_id: str, caller_id: str
+    ) -> BotFacts:
+        if (bot_id, owner_id, caller_id) != (_BOT, _OWNER, _OWNER):
+            raise BotNotFoundError(f"Bot not found: {bot_id}")
+        return BotFacts(
+            bot_id=_BOT,
+            bot_type="personal",
+            active_engine="openclaw",
+            owner_id=_OWNER,
+        )
+
+    async def call(self, **_kwargs) -> EngineResult:
+        return EngineResult(
+            data=[
+                {
+                    "nodeId": "node-01",
+                    "displayName": "Desktop",
+                    "platform": "darwin",
+                    "version": "1.2.0",
+                    "capabilities": ["screen"],
+                    "commands": ["system.run"],
+                    "remoteIp": "203.0.113.10",
+                    "status": "online",
+                }
+            ]
+        )
+
+
+def _seed(world) -> None:
+    init_principal_verifier_config(_Resolver(), "test-key", strict=False)
+    world.injector.binder.bind(
+        EngineRuntimeRelayProtocol,
+        to=_NodeRelay(),
+        scope=None,
+    )
+
+
+_INPUT = {
+    "query_params": {"user_id": _OWNER},
+    "headers": {PRINCIPAL_HEADER: _principal()},
+}
+
+
+@endpoint_test(
+    method="GET",
+    path=_PATH,
+    scenario="lists_runtime_nodes",
+    input=CaseInput(path_params={"bot_id": _BOT}, **_INPUT),
+    seed=_seed,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": [
+                {
+                    "node_id": "node-01",
+                    "display_name": "Desktop",
+                    "platform": "darwin",
+                    "status": "online",
+                }
+            ],
+        },
+    ),
+)
+def list_nodes_ok():
+    """The assembled public route returns the stable node projection."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_PATH,
+    scenario="unknown_bot",
+    input=CaseInput(path_params={"bot_id": _MISSING_BOT}, **_INPUT),
+    seed=_seed,
+    expect=ExpectError(status=404, json_contains={"data": None}),
+)
+def list_nodes_unknown_bot():
+    """An absent or unauthorized Bot is masked before the device call."""

--- a/src/backend/tests/community/repository/bot/test_bot_repository_unified.py
+++ b/src/backend/tests/community/repository/bot/test_bot_repository_unified.py
@@ -362,6 +362,17 @@ def test_list_by_conditions_owner_engine_status_filters(repo):
     assert repo.list_by_conditions(owner_id="alice", bot_name="Alpha")[0] == 1
 
 
+def test_list_by_conditions_space_filter_spans_owners(repo):
+    repo.insert(_data(bot_id="b1", owner_id="alice", space_id="22"))
+    repo.insert(_data(bot_id="b2", owner_id="bob", space_id="22"))
+    repo.insert(_data(bot_id="b3", owner_id="carol", space_id="23"))
+
+    total, rows = repo.list_by_conditions(space_id="22")
+
+    assert total == 2
+    assert {row["bot_id"] for row in rows} == {"b1", "b2"}
+
+
 def test_count_by_owner_excludes_desktop(repo):
     repo.insert(_data(bot_id="b1", bot_type="personal"))
     repo.insert(_data(bot_id="b2", bot_type="desktop"))

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -157,22 +157,6 @@ user_config:
       user: optional
       app: optional
 
-    # Bot editor management is a human authorization action. Application grants
-    # authorize use of a Bot, not reading or mutating its human editor set.
-    "/openapi/v1/bots/{bot_id}/editors":
-      user: required
-    "/openapi/v1/bots/{bot_id}/editors/**":
-      user: required
-
-    # Render-screen mappings are readable by an application with a Bot grant,
-    # but changing the Bot's CDN configuration remains a human Editor action.
-    "POST /openapi/v1/bots/{bot_id}/render-screens":
-      user: required
-    "PATCH /openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}":
-      user: required
-    "DELETE /openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}":
-      user: required
-
     # ── The refusals: operations that still require a human on the wire ──────
 
     # The caller-identity read: its answer IS the end user, so a caller with no

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -157,6 +157,22 @@ user_config:
       user: optional
       app: optional
 
+    # Bot editor management is a human authorization action. Application grants
+    # authorize use of a Bot, not reading or mutating its human editor set.
+    "/openapi/v1/bots/{bot_id}/editors":
+      user: required
+    "/openapi/v1/bots/{bot_id}/editors/**":
+      user: required
+
+    # Render-screen mappings are readable by an application with a Bot grant,
+    # but changing the Bot's CDN configuration remains a human Editor action.
+    "POST /openapi/v1/bots/{bot_id}/render-screens":
+      user: required
+    "PATCH /openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}":
+      user: required
+    "DELETE /openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}":
+      user: required
+
     # ── The refusals: operations that still require a human on the wire ──────
 
     # The caller-identity read: its answer IS the end user, so a caller with no

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -2672,6 +2672,155 @@
         "title": "EditLockRelease",
         "type": "object"
       },
+      "Editor": {
+        "description": "One editor relation on a Bot.",
+        "properties": {
+          "created_at": {
+            "description": "When the editor was added.",
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "description": "Stable editor-relation identifier.",
+            "title": "Id",
+            "type": "integer"
+          },
+          "role": {
+            "$ref": "#/components/schemas/EditorRole",
+            "description": "Current editor permission."
+          },
+          "updated_at": {
+            "description": "When the relation last changed.",
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "user_id": {
+            "description": "Editor user identifier.",
+            "title": "User Id",
+            "type": "string"
+          },
+          "user_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Stored editor display name, when available.",
+            "title": "User Name"
+          }
+        },
+        "required": [
+          "id",
+          "user_id",
+          "role",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "Editor",
+        "type": "object"
+      },
+      "EditorCreate": {
+        "additionalProperties": false,
+        "description": "Editor identity and role to add to the addressed Bot.",
+        "properties": {
+          "editor_user_id": {
+            "description": "User identifier to add as an editor.",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Editor User Id",
+            "type": "string"
+          },
+          "role": {
+            "$ref": "#/components/schemas/EditorRole",
+            "default": "member",
+            "description": "Permission granted to the editor."
+          },
+          "user_name": {
+            "anyOf": [
+              {
+                "maxLength": 100,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional display name stored with the editor relation.",
+            "title": "User Name"
+          }
+        },
+        "required": [
+          "editor_user_id"
+        ],
+        "title": "EditorCreate",
+        "type": "object"
+      },
+      "EditorList": {
+        "description": "All editor relations on the addressed Bot.",
+        "properties": {
+          "items": {
+            "description": "Editors ordered by creation time.",
+            "items": {
+              "$ref": "#/components/schemas/Editor"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "description": "Number of editor relations returned.",
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "items"
+        ],
+        "title": "EditorList",
+        "type": "object"
+      },
+      "EditorRole": {
+        "description": "Permission granted to a Bot editor.",
+        "enum": [
+          "admin",
+          "member"
+        ],
+        "title": "EditorRole",
+        "type": "string",
+        "x-enum-descriptions": [
+          "May manage editors and perform administrative Bot operations.",
+          "May edit and operate the Bot without managing editors."
+        ],
+        "x-enum-varnames": [
+          "ADMIN",
+          "MEMBER"
+        ],
+        "x-enumNames": [
+          "ADMIN",
+          "MEMBER"
+        ]
+      },
+      "EditorUpdate": {
+        "additionalProperties": false,
+        "description": "Mutable fields of an existing editor relation.",
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/EditorRole",
+            "description": "Replacement editor permission."
+          }
+        },
+        "required": [
+          "role"
+        ],
+        "title": "EditorUpdate",
+        "type": "object"
+      },
       "EngineCapabilities": {
         "description": "What the bot's engine can do.\n\nCall this before relying on any other endpoint in this group: what a bot\nsupports depends on its engine, so the same request can succeed for one of\nyour bots and be refused for another.",
         "example": {
@@ -3690,6 +3839,90 @@
           "request_id"
         ],
         "title": "Envelope[EditLock]",
+        "type": "object"
+      },
+      "Envelope_EditorList_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EditorList"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[EditorList]",
+        "type": "object"
+      },
+      "Envelope_Editor_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Editor"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[Editor]",
         "type": "object"
       },
       "Envelope_EngineCapabilities_": {
@@ -5832,6 +6065,90 @@
           "request_id"
         ],
         "title": "Envelope[Preview]",
+        "type": "object"
+      },
+      "Envelope_RenderScreenList_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RenderScreenList"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[RenderScreenList]",
+        "type": "object"
+      },
+      "Envelope_RenderScreen_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RenderScreen"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[RenderScreen]",
         "type": "object"
       },
       "Envelope_RoutineRun_": {
@@ -9811,6 +10128,143 @@
           "score"
         ],
         "title": "Recommendation",
+        "type": "object"
+      },
+      "RenderScreen": {
+        "description": "One render-screen component-library mapping.",
+        "properties": {
+          "cdn_url": {
+            "description": "HTTP(S) URL of the UMD bundle.",
+            "title": "Cdn Url",
+            "type": "string"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the mapping was created.",
+            "title": "Created At"
+          },
+          "creator_id": {
+            "description": "User who created the mapping.",
+            "title": "Creator Id",
+            "type": "string"
+          },
+          "id": {
+            "description": "Stable mapping identifier used by mutations.",
+            "title": "Id",
+            "type": "integer"
+          },
+          "name": {
+            "description": "Component-library name.",
+            "title": "Name",
+            "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "When the mapping was last modified.",
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "cdn_url",
+          "creator_id"
+        ],
+        "title": "RenderScreen",
+        "type": "object"
+      },
+      "RenderScreenCreate": {
+        "additionalProperties": false,
+        "description": "One component-library mapping to add to the addressed Bot.",
+        "properties": {
+          "cdn_url": {
+            "description": "HTTP(S) URL of the component library's UMD bundle.",
+            "format": "uri",
+            "maxLength": 1024,
+            "minLength": 1,
+            "title": "Cdn Url",
+            "type": "string"
+          },
+          "name": {
+            "description": "Component-library name, unique within the Bot.",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "cdn_url"
+        ],
+        "title": "RenderScreenCreate",
+        "type": "object"
+      },
+      "RenderScreenList": {
+        "description": "All live render-screen mappings on the addressed Bot.",
+        "properties": {
+          "items": {
+            "description": "Mappings ordered by creation time, newest first.",
+            "items": {
+              "$ref": "#/components/schemas/RenderScreen"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "description": "Number of mappings returned.",
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "items"
+        ],
+        "title": "RenderScreenList",
+        "type": "object"
+      },
+      "RenderScreenUpdate": {
+        "additionalProperties": false,
+        "description": "Replacement fields for one render-screen mapping.",
+        "properties": {
+          "cdn_url": {
+            "description": "Replacement HTTP(S) URL of the UMD bundle.",
+            "format": "uri",
+            "maxLength": 1024,
+            "minLength": 1,
+            "title": "Cdn Url",
+            "type": "string"
+          },
+          "name": {
+            "description": "Replacement component-library name.",
+            "maxLength": 256,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "cdn_url"
+        ],
+        "title": "RenderScreenUpdate",
         "type": "object"
       },
       "ResourceType": {
@@ -35495,6 +35949,989 @@
         "summary": "Steal Edit Lock"
       }
     },
+    "/openapi/v1/bots/{bot_id}/editors": {
+      "get": {
+        "operationId": "list_editors_openapi_v1_bots__bot_id__editors_get",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional editor-role filter.",
+            "in": "query",
+            "name": "role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/EditorRole"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional editor-role filter.",
+              "title": "Role"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_EditorList_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "List Editors",
+        "tags": [
+          "editors"
+        ]
+      },
+      "post": {
+        "operationId": "add_editor_openapi_v1_bots__bot_id__editors_post",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditorCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_Editor_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Add Editor",
+        "tags": [
+          "editors"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/editors/me": {
+      "delete": {
+        "operationId": "leave_editors_openapi_v1_bots__bot_id__editors_me_delete",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_Deleted_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Leave Editors",
+        "tags": [
+          "editors"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/editors/{editor_id}": {
+      "delete": {
+        "operationId": "remove_editor_openapi_v1_bots__bot_id__editors__editor_id__delete",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Editor-relation identifier returned by this collection.",
+            "in": "path",
+            "name": "editor_id",
+            "required": true,
+            "schema": {
+              "description": "Editor-relation identifier returned by this collection.",
+              "minimum": 1,
+              "title": "Editor Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_Deleted_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Remove Editor",
+        "tags": [
+          "editors"
+        ]
+      },
+      "patch": {
+        "operationId": "update_editor_openapi_v1_bots__bot_id__editors__editor_id__patch",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Editor-relation identifier returned by this collection.",
+            "in": "path",
+            "name": "editor_id",
+            "required": true,
+            "schema": {
+              "description": "Editor-relation identifier returned by this collection.",
+              "minimum": 1,
+              "title": "Editor Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EditorUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_Editor_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Update Editor",
+        "tags": [
+          "editors"
+        ]
+      }
+    },
     "/openapi/v1/bots/{bot_id}/engine-config": {
       "get": {
         "deprecated": true,
@@ -41517,6 +42954,790 @@
         "summary": "Get Bot Passport",
         "tags": [
           "bots"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/render-screens": {
+      "get": {
+        "description": "List the non-sensitive CDN mappings needed to render this Bot's panels.",
+        "operationId": "list_render_screens_openapi_v1_bots__bot_id__render_screens_get",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_RenderScreenList_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "List Render Screens",
+        "tags": [
+          "render-screens"
+        ]
+      },
+      "post": {
+        "description": "Add a CDN mapping; Bot Owner or live Editor Member access is required.",
+        "operationId": "create_render_screen_openapi_v1_bots__bot_id__render_screens_post",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenderScreenCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_RenderScreen_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Create Render Screen",
+        "tags": [
+          "render-screens"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}": {
+      "delete": {
+        "description": "Soft-delete one mapping after Bot and record authorization.",
+        "operationId": "delete_render_screen_openapi_v1_bots__bot_id__render_screens__render_screen_id__delete",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Render-screen mapping identifier returned by this collection.",
+            "in": "path",
+            "name": "render_screen_id",
+            "required": true,
+            "schema": {
+              "description": "Render-screen mapping identifier returned by this collection.",
+              "minimum": 1,
+              "title": "Render Screen Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_Deleted_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Delete Render Screen",
+        "tags": [
+          "render-screens"
+        ]
+      },
+      "patch": {
+        "description": "Replace one mapping after binding its id to the addressed Bot.",
+        "operationId": "update_render_screen_openapi_v1_bots__bot_id__render_screens__render_screen_id__patch",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Render-screen mapping identifier returned by this collection.",
+            "in": "path",
+            "name": "render_screen_id",
+            "required": true,
+            "schema": {
+              "description": "Render-screen mapping identifier returned by this collection.",
+              "minimum": 1,
+              "title": "Render Screen Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenderScreenUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_RenderScreen_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Update Render Screen",
+        "tags": [
+          "render-screens"
         ]
       }
     },

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -6944,6 +6944,52 @@
         "title": "Envelope[list[McpTenant]]",
         "type": "object"
       },
+      "Envelope_list_Node__": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/Node"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results.",
+            "title": "Data"
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[list[Node]]",
+        "type": "object"
+      },
       "ErrorEnvelope": {
         "description": "The envelope returned on every documented failure — the same shape as\nthe success envelope, with `data` pinned to null.",
         "properties": {
@@ -8713,6 +8759,106 @@
           "exists"
         ],
         "title": "NameCheck",
+        "type": "object"
+      },
+      "Node": {
+        "description": "A node currently visible to the bot's engine runtime.",
+        "example": {
+          "capabilities": [
+            "screen",
+            "shell"
+          ],
+          "commands": [
+            "system.run"
+          ],
+          "display_name": "Joseph's Mac",
+          "node_id": "node-01",
+          "platform": "darwin",
+          "remote_ip": "203.0.113.10",
+          "status": "online",
+          "version": "1.2.0"
+        },
+        "properties": {
+          "capabilities": {
+            "description": "Capabilities declared by the node.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Capabilities",
+            "type": "array"
+          },
+          "commands": {
+            "description": "Commands declared by the node.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Commands",
+            "type": "array"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Human-readable node name, when reported.",
+            "title": "Display Name"
+          },
+          "node_id": {
+            "description": "Stable node identifier used by runtime calls.",
+            "title": "Node Id",
+            "type": "string"
+          },
+          "platform": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Node operating-system or platform name.",
+            "title": "Platform"
+          },
+          "remote_ip": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Remote address reported by the engine.",
+            "title": "Remote Ip"
+          },
+          "status": {
+            "description": "Current node status reported by the engine.",
+            "title": "Status",
+            "type": "string"
+          },
+          "version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Node agent version, when reported.",
+            "title": "Version"
+          }
+        },
+        "required": [
+          "node_id",
+          "status"
+        ],
+        "title": "Node",
         "type": "object"
       },
       "NotificationCategory": {
@@ -40912,6 +41058,298 @@
         "summary": "Get Model",
         "tags": [
           "models"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/nodes": {
+      "get": {
+        "description": "List nodes visible to the addressed bot runtime.",
+        "operationId": "list_nodes_openapi_v1_bots__bot_id__nodes_get",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional exact node-status filter.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 128,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional exact node-status filter.",
+              "title": "Status"
+            }
+          },
+          {
+            "description": "Optional exact node-platform filter.",
+            "in": "query",
+            "name": "platform",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 128,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional exact node-platform filter.",
+              "title": "Platform"
+            }
+          },
+          {
+            "description": "Maximum nodes returned (max 100).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Maximum nodes returned (max 100).",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Zero-based number of matching nodes to skip.",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Zero-based number of matching nodes to skip.",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409).",
+            "in": "query",
+            "name": "stage",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStage",
+              "default": "draft",
+              "description": "Which of the bot's runtimes this request addresses. Defaults to the draft — the bot's own workspace, the only runtime a personal bot has. A service bot's verify/online runtimes are addressable while live; a stage with no live runtime is refused (409)."
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_list_Node__"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 501000,
+                  "message": "Not supported by this bot's engine; see the engine capabilities endpoint",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not supported for this bot — either its engine does not declare the capability (see the engine-capabilities endpoint) or the operation is not offered for this bot type"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 504000,
+                  "message": "Engine request timed out",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service timed out"
+          }
+        },
+        "summary": "List Nodes",
+        "tags": [
+          "nodes"
         ]
       }
     },

--- a/src/gateway/tests/unit/core/authn/test_route_security.py
+++ b/src/gateway/tests/unit/core/authn/test_route_security.py
@@ -75,14 +75,6 @@ _HUMAN_ONLY = [
     ("GET", "/openapi/v1/org/user/iam-token"),
     ("POST", "/openapi/v1/bots/bot-123/caller-identity"),
     ("POST", "/openapi/v1/bots"),
-    ("GET", "/openapi/v1/bots/bot-123/editors"),
-    ("POST", "/openapi/v1/bots/bot-123/editors"),
-    ("PATCH", "/openapi/v1/bots/bot-123/editors/7"),
-    ("DELETE", "/openapi/v1/bots/bot-123/editors/7"),
-    ("DELETE", "/openapi/v1/bots/bot-123/editors/me"),
-    ("POST", "/openapi/v1/bots/bot-123/render-screens"),
-    ("PATCH", "/openapi/v1/bots/bot-123/render-screens/7"),
-    ("DELETE", "/openapi/v1/bots/bot-123/render-screens/7"),
     ("POST", "/openapi/v1/bots/local"),
     ("GET", "/openapi/v1/bots/bot-123/local/auth-status"),
     ("GET", "/openapi/v1/bots/bot-123/authorized-apps"),
@@ -153,11 +145,27 @@ def test_shipped_config_lets_an_application_discover_its_own_scope() -> None:
     assert req[PrincipalType.APP] is Presence.REQUIRED
 
 
-def test_shipped_config_allows_app_identity_for_render_screen_reads() -> None:
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", "/openapi/v1/bots/bot-123/editors"),
+        ("POST", "/openapi/v1/bots/bot-123/editors"),
+        ("PATCH", "/openapi/v1/bots/bot-123/editors/7"),
+        ("DELETE", "/openapi/v1/bots/bot-123/editors/7"),
+        ("DELETE", "/openapi/v1/bots/bot-123/editors/me"),
+        ("GET", "/openapi/v1/bots/bot-123/render-screens"),
+        ("POST", "/openapi/v1/bots/bot-123/render-screens"),
+        ("PATCH", "/openapi/v1/bots/bot-123/render-screens/7"),
+        ("DELETE", "/openapi/v1/bots/bot-123/render-screens/7"),
+    ],
+)
+def test_shipped_config_allows_app_identity_for_bot_configuration(
+    method: str, path: str
+) -> None:
     raw = yaml.safe_load(_CONFIG.read_text())
     rs = RouteSecurity.from_table(raw["user_config"]["route_security"])
 
-    req = rs.resolve("GET", "/openapi/v1/bots/bot-123/render-screens")
+    req = rs.resolve(method, path)
 
     assert req is not None
     assert req[PrincipalType.USER] is Presence.OPTIONAL

--- a/src/gateway/tests/unit/core/authn/test_route_security.py
+++ b/src/gateway/tests/unit/core/authn/test_route_security.py
@@ -75,6 +75,14 @@ _HUMAN_ONLY = [
     ("GET", "/openapi/v1/org/user/iam-token"),
     ("POST", "/openapi/v1/bots/bot-123/caller-identity"),
     ("POST", "/openapi/v1/bots"),
+    ("GET", "/openapi/v1/bots/bot-123/editors"),
+    ("POST", "/openapi/v1/bots/bot-123/editors"),
+    ("PATCH", "/openapi/v1/bots/bot-123/editors/7"),
+    ("DELETE", "/openapi/v1/bots/bot-123/editors/7"),
+    ("DELETE", "/openapi/v1/bots/bot-123/editors/me"),
+    ("POST", "/openapi/v1/bots/bot-123/render-screens"),
+    ("PATCH", "/openapi/v1/bots/bot-123/render-screens/7"),
+    ("DELETE", "/openapi/v1/bots/bot-123/render-screens/7"),
     ("POST", "/openapi/v1/bots/local"),
     ("GET", "/openapi/v1/bots/bot-123/local/auth-status"),
     ("GET", "/openapi/v1/bots/bot-123/authorized-apps"),
@@ -143,6 +151,17 @@ def test_shipped_config_lets_an_application_discover_its_own_scope() -> None:
     assert req is not None
     assert req[PrincipalType.USER] is Presence.OPTIONAL
     assert req[PrincipalType.APP] is Presence.REQUIRED
+
+
+def test_shipped_config_allows_app_identity_for_render_screen_reads() -> None:
+    raw = yaml.safe_load(_CONFIG.read_text())
+    rs = RouteSecurity.from_table(raw["user_config"]["route_security"])
+
+    req = rs.resolve("GET", "/openapi/v1/bots/bot-123/render-screens")
+
+    assert req is not None
+    assert req[PrincipalType.USER] is Presence.OPTIONAL
+    assert req[PrincipalType.APP] is Presence.OPTIONAL
 
 
 _SOCKET_PATH = "/openapi/v1/bots/messages/ws/ARCA_x@0:20003/api/openclaw/ws"


### PR DESCRIPTION
## Problem

The Bot Workshop OpenAPI surface still lacked public Editor CRUD, Render Screen configuration, and the read-only Node inventory used by the frontend. Existing inventory and collaborator behavior also predated the Space domain, so Team Space membership was not consistently reflected in Bot visibility and effective Editor permissions.

The initial implementation additionally exposed three CI risks addressed by #1213: a Core -> Service API dependency, a new Core module over the 1000-line limit, and newly added endpoints missing endpoint-framework happy/error coverage.

## Solution

- Add bot-first Editor operations:
  - `GET /openapi/v1/bots/{bot_id}/editors`
  - `POST /openapi/v1/bots/{bot_id}/editors`
  - `PATCH /openapi/v1/bots/{bot_id}/editors/{editor_id}`
  - `DELETE /openapi/v1/bots/{bot_id}/editors/{editor_id}`
  - `DELETE /openapi/v1/bots/{bot_id}/editors/me`
- Add Render Screen CDN mapping operations:
  - `GET /openapi/v1/bots/{bot_id}/render-screens`
  - `POST /openapi/v1/bots/{bot_id}/render-screens`
  - `PATCH /openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}`
  - `DELETE /openapi/v1/bots/{bot_id}/render-screens/{render_screen_id}`
- Add `GET /openapi/v1/bots/{bot_id}/nodes`, forwarding the existing Engine `GET /api/nodes` filters without inventing Node write operations.
- Publish only stable Node fields in snake_case and drop Engine-internal metadata/raw payloads.
- Integrate Bot inventory and local workflows with Personal and Team Space context.
- Recheck Team Space membership when resolving effective Editor permissions while preserving Bot Owner access after Space removal.
- Allow Personal Space Editors and require live Team Space membership for non-owner Editors.
- Rebind public Editor and Render Screen record ids to the addressed Bot, owner, and environment before mutation.
- Admit app-only callers on Editor and Render Screen operations when a live grant covers the addressed Bot; re-adjudicate the delegating user's effective Bot permission for every operation.
- Define a Core-owned `BusinessSpaceLookupPort` and bridge `SpaceService` in the DI composition root, avoiding Core -> API imports.
- Extract Editor authorization policy from `CollaboratorService` to keep the production module below the architecture size limit.
- Add 20 endpoint-framework cases covering happy and masked-not-found paths for all 10 new routes.
- Update admission policy, Gateway method security, public OpenAPI docs, generated schema, and workshop inventory documentation.

## Validation

- `DEPLOY_PROFILE=test uv run pytest tests/community/architecture tests/community/framework/test_coverage_gate.py -q --tb=short` - **173 passed**
- `DEPLOY_PROFILE=test uv run pytest tests/community/endpoints/test_endpoint_runner.py -q --tb=short` - **746 passed**
- Editor/Space/Inventory targeted Core tests - **39 passed**
- Endpoint-framework no-mock/no-world-override checks - **23 passed**
- New Editor, Render Screen, and Node endpoint cases - **20 passed**
- Targeted Ruff check and format checks - **passed**
- Backend local Python SAST for production source and the new endpoint suite - **passed**
- OpenAPI compatibility publication - **compatible**
- Gateway route-security and served-schema checks - **70 passed**
- Review follow-up: Backend admission, Gateway security, and the pinned OpenAPI owner semantics were aligned after rebasing onto the latest target branch.
- `git diff --check` - **passed**

After the review update, the focused Backend suite passed **141 tests** and the Gateway route-security/served-schema suite passed **66 tests** locally. The complete Backend and Singlebox suites are running in GitHub CI.

## Compatibility and risk

The public changes are additive. Existing URLs and response schemas are unchanged. Node support adds only the existing read-only frontend capability; register, unregister, and status-write operations remain outside the contract. The generated OpenAPI schema remains compatible.

Team Space Editor authorization now fails closed when the Space reference cannot be resolved or the Editor is no longer a member. Bot Owners intentionally retain access after leaving a Team Space. An application with a live Bot grant acts with the delegating user's current permission: Editor mutations still require effective `ADMIN+`, and Render Screen mutations require effective `MEMBER+`.

There is no database migration in this change. Rollback is the single feature commit.

## Related issues

- Follows the Bot Workshop OpenAPI merge in #1148.
- Preserves the architecture and endpoint-framework fixes established in #1213.
