### PR TITLE
feat(skills): add user-scoped market favorites

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
@@ -198,7 +198,7 @@ class SpaceMemberDeletedResult(BaseModel):
 
 
 class FavoriteTargetRequest(BaseModel):
-    """Marketplace target to add to or remove from favorites."""
+    """Marketplace target saved in the current user's favorites."""
 
     target_type: FavoriteTargetType = Field(
         description="Marketplace category of the target."
@@ -211,7 +211,7 @@ class FavoriteTargetRequest(BaseModel):
 
 
 class SearchFavoritesRequest(BaseModel):
-    """Filters and pagination for searching Space favorites."""
+    """Filters and pagination for the current user's favorites."""
 
     target_type: FavoriteTargetType | None = Field(
         default=None, description="Target category filter, or null for all categories."
@@ -253,7 +253,7 @@ class FavoriteCanceledResult(BaseModel):
 
 
 class MarketFavoriteItem(_UtcResponseModel):
-    """One marketplace favorite saved in a Space."""
+    """One marketplace favorite saved by the current user."""
 
     favorite_id: int = Field(description="Identifier of the favorite record.")
     target_type: FavoriteTargetType = Field(

--- a/src/backend/src/agentclaw/community/core/market_favorites/README.md
+++ b/src/backend/src/agentclaw/community/core/market_favorites/README.md
@@ -1,8 +1,9 @@
 # `agentclaw.community.core.market_favorites`
 
-Stores a Space's favorite references as `(target_type, target_code)`. Adding an
-already-favorited target is idempotent; canceling requires an existing favorite
-and reports not found when there is nothing to remove.
+Stores a user's favorite references as `(target_type, target_code)`, with the
+Space path used only to authorize access. Adding an already-favorited target is
+idempotent; canceling requires an existing favorite and reports not found when
+there is nothing to remove.
 This phase intentionally does not import Skill or MCP catalogue implementations.
 Catalogue names, descriptions, icons, versions and owners are not exposed at
 the HTTP boundary until a governed catalogue lookup contract is implemented.
@@ -10,7 +11,7 @@ the HTTP boundary until a governed catalogue lookup contract is implemented.
 ## Context Boundary
 
 ```yaml
-purpose: "Own idempotent Space-scoped marketplace favorite references without owning catalogue metadata."
+purpose: "Own idempotent user-scoped marketplace favorite references without owning catalogue metadata."
 provides:
   - MarketFavoriteService
   - MarketFavoriteModel
@@ -32,6 +33,6 @@ internal_dependencies:
 
 ### Change impact
 
-The unique key defines favorite idempotency. Metadata enrichment must be added
-through an explicit Service/Plugin contract; this module must not reach directly
-into Skill Center or an HTTP client.
+The unique key defines favorite idempotency across tenant, environment, user,
+and object. Metadata enrichment must be added through an explicit Service/Plugin
+contract; this module must not reach directly into Skill Center or an HTTP client.

--- a/src/backend/src/agentclaw/community/core/market_favorites/models.py
+++ b/src/backend/src/agentclaw/community/core/market_favorites/models.py
@@ -16,6 +16,7 @@ class FavoriteTargetType(StrEnum):
 class MarketFavoriteRecord(BaseModel):
     id: int
     space_id: int
+    user_id: str
     target_type: FavoriteTargetType
     target_code: str
     created_by: str

--- a/src/backend/src/agentclaw/community/core/market_favorites/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/market_favorites/repository/models.py
@@ -20,6 +20,7 @@ class MarketFavoriteModel(Base):
 
     id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
     space_id = Column(AutoIncrementBigInteger, nullable=False)
+    user_id = Column(String(256), nullable=False)
     target_type = Column(String(32), nullable=False)
     target_code = Column(String(128), nullable=False)
     created_by = Column(String(256), nullable=False)
@@ -33,17 +34,18 @@ class MarketFavoriteModel(Base):
     __table_args__ = (
         UniqueConstraint(
             "avernet_tenant",
-            "space_id",
+            "env",
+            "user_id",
             "target_type",
             "target_code",
-            "env",
-            name="uk_market_favorite_target_env",
+            name="uk_market_favorite_user_target_env",
         ),
         Index(
-            "idx_market_favorite_space",
+            "idx_market_favorite_user_space",
             "avernet_tenant",
-            "space_id",
             "env",
+            "user_id",
+            "space_id",
             "gmt_modified",
         ),
     )
@@ -52,6 +54,7 @@ class MarketFavoriteModel(Base):
         return MarketFavoriteRecord(
             id=self.id,
             space_id=self.space_id,
+            user_id=self.user_id,
             target_type=FavoriteTargetType(self.target_type),
             target_code=self.target_code,
             created_by=self.created_by,

--- a/src/backend/src/agentclaw/community/core/market_favorites/services/favorite_service.py
+++ b/src/backend/src/agentclaw/community/core/market_favorites/services/favorite_service.py
@@ -1,4 +1,4 @@
-"""Space-scoped market favorite service.
+"""User-scoped market favorite service.
 
 This phase stores only stable target references. Market metadata enrichment is
 intentionally deferred with the Skill/MCP catalogue integration.
@@ -8,10 +8,7 @@ from __future__ import annotations
 
 from injector import inject
 
-from agentclaw.community.core.market_favorites.errors import (
-    FavoriteNotFoundError,
-    FavoriteTargetInvalidError,
-)
+from agentclaw.community.core.market_favorites.errors import FavoriteTargetInvalidError
 from agentclaw.community.core.market_favorites.models import (
     FavoriteTargetType,
     MarketFavoriteRecord,
@@ -57,7 +54,7 @@ class MarketFavoriteService:
             space_id=space_id,
             target_type=target_type,
             target_code=self._target_code(target_code),
-            created_by=actor_id,
+            user_id=actor_id,
             env=get_current_env(),
         )
 
@@ -70,14 +67,13 @@ class MarketFavoriteService:
         target_code: str,
     ) -> bool:
         self._access.require_space_member(space_id=space_id, user_id=actor_id)
-        deleted = self._repository.cancel(
+        self._repository.cancel(
             space_id=space_id,
             target_type=target_type,
             target_code=self._target_code(target_code),
+            user_id=actor_id,
             env=get_current_env(),
         )
-        if not deleted:
-            raise FavoriteNotFoundError("market favorite not found")
         return True
 
     def search(
@@ -95,6 +91,7 @@ class MarketFavoriteService:
             space_id=space_id,
             target_type=target_type,
             keyword=keyword.strip() if keyword and keyword.strip() else None,
+            user_id=actor_id,
             env=get_current_env(),
             offset=(page_no - 1) * page_size,
             limit=page_size,

--- a/src/backend/src/agentclaw/community/core/market_favorites/sql/2026_08_17_market_favorites.sql
+++ b/src/backend/src/agentclaw/community/core/market_favorites/sql/2026_08_17_market_favorites.sql
@@ -2,6 +2,7 @@
 CREATE TABLE IF NOT EXISTS ac_market_favorite (
     id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     space_id BIGINT UNSIGNED NOT NULL,
+    user_id VARCHAR(256) NOT NULL,
     target_type VARCHAR(32) NOT NULL COMMENT 'SKILL | MCP',
     target_code VARCHAR(128) NOT NULL,
     created_by VARCHAR(256) NOT NULL,
@@ -10,10 +11,10 @@ CREATE TABLE IF NOT EXISTS ac_market_favorite (
     gmt_created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     gmt_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
-    UNIQUE KEY uk_market_favorite_target_env (
-        avernet_tenant, space_id, target_type, target_code, env
+    UNIQUE KEY uk_market_favorite_user_target_env (
+        avernet_tenant, env, user_id, target_type, target_code
     ),
-    KEY idx_market_favorite_space (
-        avernet_tenant, space_id, env, gmt_modified
+    KEY idx_market_favorite_user_space (
+        avernet_tenant, env, user_id, space_id, gmt_modified
     )
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/backend/src/agentclaw/community/core/market_favorites/sql/2026_08_19_market_favorites_user_scope.sql
+++ b/src/backend/src/agentclaw/community/core/market_favorites/sql/2026_08_19_market_favorites_user_scope.sql
@@ -1,0 +1,32 @@
+-- Preserve the historic actor audit value while moving favorites to the
+-- tenant/env/user/object identity required by the public contract.
+ALTER TABLE ac_market_favorite
+  ADD COLUMN user_id VARCHAR(256) NULL AFTER space_id;
+
+UPDATE ac_market_favorite
+SET user_id = created_by
+WHERE user_id IS NULL;
+
+-- The new user-level identity collapses historical duplicates from different
+-- Spaces. Keep the earliest auditable favorite deterministically.
+DELETE FROM ac_market_favorite
+WHERE id IN (
+  SELECT id FROM (
+    SELECT id,
+      ROW_NUMBER() OVER (
+        PARTITION BY avernet_tenant, env, user_id, target_type, target_code
+        ORDER BY gmt_created ASC, id ASC
+      ) AS duplicate_rank
+    FROM ac_market_favorite
+  ) ranked_favorites
+  WHERE duplicate_rank > 1
+) duplicate_ids;
+
+ALTER TABLE ac_market_favorite
+  MODIFY COLUMN user_id VARCHAR(256) NOT NULL,
+  DROP INDEX uk_market_favorite_target_env,
+  ADD UNIQUE KEY uk_market_favorite_user_target_env
+    (avernet_tenant, env, user_id, target_type, target_code),
+  DROP INDEX idx_market_favorite_space,
+  ADD KEY idx_market_favorite_user_space
+    (avernet_tenant, env, user_id, space_id, gmt_modified);

--- a/src/backend/src/agentclaw/community/core/repository/implementations/market_favorites/favorite.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/market_favorites/favorite.py
@@ -26,7 +26,7 @@ class MarketFavoriteRepository(MarketFavoriteRepositoryProtocol):
         space_id,
         target_type,
         target_code,
-        created_by,
+        user_id,
         env,
     ):
         try:
@@ -34,7 +34,7 @@ class MarketFavoriteRepository(MarketFavoriteRepositoryProtocol):
                 existing = (
                     db.query(self._Favorite)
                     .filter(
-                        self._Favorite.space_id == space_id,
+                        self._Favorite.user_id == user_id,
                         self._Favorite.target_type == target_type.value,
                         self._Favorite.target_code == target_code,
                         self._Favorite.env == env,
@@ -45,9 +45,10 @@ class MarketFavoriteRepository(MarketFavoriteRepositoryProtocol):
                     return existing.to_record()
                 row = self._Favorite(
                     space_id=space_id,
+                    user_id=user_id,
                     target_type=target_type.value,
                     target_code=target_code,
-                    created_by=created_by,
+                    created_by=user_id,
                     env=env,
                 )
                 db.add(row)
@@ -59,7 +60,7 @@ class MarketFavoriteRepository(MarketFavoriteRepositoryProtocol):
                 existing = (
                     db.query(self._Favorite)
                     .filter(
-                        self._Favorite.space_id == space_id,
+                        self._Favorite.user_id == user_id,
                         self._Favorite.target_type == target_type.value,
                         self._Favorite.target_code == target_code,
                         self._Favorite.env == env,
@@ -70,12 +71,12 @@ class MarketFavoriteRepository(MarketFavoriteRepositoryProtocol):
                     raise
                 return existing.to_record()
 
-    def cancel(self, *, space_id, target_type, target_code, env) -> bool:
+    def cancel(self, *, space_id, target_type, target_code, user_id, env) -> bool:
         with self._db.orm_session() as db:
             deleted = (
                 db.query(self._Favorite)
                 .filter(
-                    self._Favorite.space_id == space_id,
+                    self._Favorite.user_id == user_id,
                     self._Favorite.target_type == target_type.value,
                     self._Favorite.target_code == target_code,
                     self._Favorite.env == env,
@@ -90,13 +91,14 @@ class MarketFavoriteRepository(MarketFavoriteRepositoryProtocol):
         space_id,
         target_type,
         keyword,
+        user_id,
         env,
         offset,
         limit,
     ):
         with self._db.orm_session() as db:
             query = db.query(self._Favorite).filter(
-                self._Favorite.space_id == space_id,
+                self._Favorite.user_id == user_id,
                 self._Favorite.env == env,
             )
             if target_type is not None:

--- a/src/backend/src/agentclaw/community/core/repository/protocols/market_favorites.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/market_favorites.py
@@ -1,4 +1,4 @@
-"""Persistence contract for space-scoped market favorites."""
+"""Persistence contract for user-scoped market favorites."""
 
 from __future__ import annotations
 
@@ -21,7 +21,7 @@ class MarketFavoriteRepositoryProtocol(Protocol):
         space_id: int,
         target_type: FavoriteTargetType,
         target_code: str,
-        created_by: str,
+        user_id: str,
         env: str,
     ) -> MarketFavoriteRecord: ...
 
@@ -32,6 +32,7 @@ class MarketFavoriteRepositoryProtocol(Protocol):
         space_id: int,
         target_type: FavoriteTargetType,
         target_code: str,
+        user_id: str,
         env: str,
     ) -> bool: ...
 
@@ -42,6 +43,7 @@ class MarketFavoriteRepositoryProtocol(Protocol):
         space_id: int,
         target_type: FavoriteTargetType | None,
         keyword: str | None,
+        user_id: str,
         env: str,
         offset: int,
         limit: int,

--- a/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
@@ -23,7 +23,6 @@ from agentclaw.community.api.space_service import (
     SpaceMemberServiceProtocol,
     SpaceServiceProtocol,
 )
-from agentclaw.community.core.market_favorites.errors import FavoriteNotFoundError
 from agentclaw.community.core.market_favorites.models import (
     FavoriteTargetType,
     MarketFavoriteRecord,
@@ -186,23 +185,6 @@ def test_openapi_advertises_nullable_member_profile_fields(client):
     }
 
 
-def test_cancel_missing_favorite_returns_not_found(client, favorite_service):
-    favorite_service.cancel.side_effect = FavoriteNotFoundError(
-        "market favorite not found"
-    )
-
-    response = client.post(
-        "/openapi/v1/spaces/7/market-favorites/cancel",
-        json={"target_type": "SKILL", "target_code": "skill-1"},
-    )
-
-    assert response.status_code == 404
-    body = response.json()
-    assert body["code"] == 404000
-    assert body["message"] == "Not found"
-    assert body["data"] is None
-
-
 def _space_record(space_type=SpaceType.TEAM):
     timestamp = datetime(2026, 8, 18, 1, 2, 3)
     return SpaceRecord(
@@ -248,6 +230,7 @@ def _favorite_record():
     return MarketFavoriteRecord(
         id=31,
         space_id=7,
+        user_id="owner-1",
         target_type=FavoriteTargetType.SKILL,
         target_code="skill-1",
         created_by="owner-1",

--- a/src/backend/tests/community/core/market_favorites/test_favorite_repository_model.py
+++ b/src/backend/tests/community/core/market_favorites/test_favorite_repository_model.py
@@ -1,0 +1,39 @@
+"""Persistence invariants for user-scoped market favorites."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.base import Base
+from agentclaw.community.core.market_favorites.repository.models import (
+    MarketFavoriteModel,
+)
+
+
+def _favorite(*, user_id: str, space_id: int) -> MarketFavoriteModel:
+    return MarketFavoriteModel(
+        space_id=space_id,
+        user_id=user_id,
+        target_type="SKILL",
+        target_code="skill-1",
+        created_by=user_id,
+        env="dev",
+    )
+
+
+def test_unique_constraint_is_tenant_env_user_and_object_scoped() -> None:
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+
+    session.add_all(
+        [_favorite(user_id="user-a", space_id=1), _favorite(user_id="user-b", space_id=1)]
+    )
+    session.commit()
+
+    session.add(_favorite(user_id="user-a", space_id=2))
+    with pytest.raises(IntegrityError):
+        session.commit()

--- a/src/backend/tests/community/core/market_favorites/test_favorite_service.py
+++ b/src/backend/tests/community/core/market_favorites/test_favorite_service.py
@@ -7,10 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from agentclaw.community.core.market_favorites.errors import (
-    FavoriteNotFoundError,
-    FavoriteTargetInvalidError,
-)
+from agentclaw.community.core.market_favorites.errors import FavoriteTargetInvalidError
 from agentclaw.community.core.market_favorites.models import (
     FavoriteTargetType,
     MarketFavoriteRecord,
@@ -25,6 +22,7 @@ def _record(*, target_code: str = "skill-1") -> MarketFavoriteRecord:
     return MarketFavoriteRecord(
         id=1,
         space_id=7,
+        user_id="member-1",
         target_type=FavoriteTargetType.SKILL,
         target_code=target_code,
         created_by="member-1",
@@ -58,7 +56,7 @@ def test_add_requires_membership_and_normalizes_target_code() -> None:
         space_id=7,
         target_type=FavoriteTargetType.SKILL,
         target_code="skill-1",
-        created_by="member-1",
+        user_id="member-1",
         env="dev",
     )
 
@@ -78,17 +76,16 @@ def test_add_rejects_invalid_target_code(target_code: str) -> None:
     repository.add.assert_not_called()
 
 
-def test_cancel_missing_favorite_is_not_reported_as_success() -> None:
+def test_cancel_missing_favorite_is_idempotently_reported_as_success() -> None:
     service, repository, access = _service()
     repository.cancel.return_value = False
 
-    with pytest.raises(FavoriteNotFoundError, match="not found"):
-        service.cancel(
-            space_id=7,
-            actor_id="member-1",
-            target_type=FavoriteTargetType.SKILL,
-            target_code=" skill-1 ",
-        )
+    assert service.cancel(
+        space_id=7,
+        actor_id="member-1",
+        target_type=FavoriteTargetType.SKILL,
+        target_code=" skill-1 ",
+    ) is True
 
     access.require_space_member.assert_called_once_with(
         space_id=7, user_id="member-1"
@@ -129,6 +126,7 @@ def test_search_requires_membership_and_normalizes_filters() -> None:
         space_id=7,
         target_type=FavoriteTargetType.SKILL,
         keyword="skill",
+        user_id="member-1",
         env="dev",
         offset=10,
         limit=10,

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -169,21 +169,21 @@ def test_market_favorite_repository_is_idempotent_and_searchable(db) -> None:
         space_id=space.id,
         target_type=FavoriteTargetType.SKILL,
         target_code="skill-1",
-        created_by="owner-1",
+        user_id="owner-1",
         env="dev",
     )
     duplicate = repository.add(
         space_id=space.id,
         target_type=FavoriteTargetType.SKILL,
         target_code="skill-1",
-        created_by="owner-1",
+        user_id="owner-1",
         env="dev",
     )
     repository.add(
         space_id=space.id,
         target_type=FavoriteTargetType.MCP,
         target_code="mcp-1",
-        created_by="owner-1",
+        user_id="owner-1",
         env="dev",
     )
 
@@ -192,6 +192,7 @@ def test_market_favorite_repository_is_idempotent_and_searchable(db) -> None:
         space_id=space.id,
         target_type=FavoriteTargetType.SKILL,
         keyword="skill",
+        user_id="owner-1",
         env="dev",
         offset=0,
         limit=10,
@@ -203,6 +204,7 @@ def test_market_favorite_repository_is_idempotent_and_searchable(db) -> None:
             space_id=space.id,
             target_type=FavoriteTargetType.SKILL,
             target_code="skill-1",
+            user_id="owner-1",
             env="dev",
         )
         is True
@@ -212,6 +214,7 @@ def test_market_favorite_repository_is_idempotent_and_searchable(db) -> None:
             space_id=space.id,
             target_type=FavoriteTargetType.SKILL,
             target_code="skill-1",
+            user_id="owner-1",
             env="dev",
         )
         is False

--- a/src/frontend/config/routes.ts
+++ b/src/frontend/config/routes.ts
@@ -9,6 +9,12 @@ export const routes = [
     layout: false,
   },
   {
+    name: '我的收藏',
+    path: '/market/favorites',
+    component: './MarketFavorites',
+    layout: false,
+  },
+  {
     path: '/bcn',
     layout: false,
     component: './Layout/BcnContainer',

--- a/src/frontend/src/hooks/useMarketFavorites.ts
+++ b/src/frontend/src/hooks/useMarketFavorites.ts
@@ -1,0 +1,80 @@
+import {
+  addMarketFavorite,
+  cancelMarketFavorite,
+  listMarketFavorites,
+  type MarketFavoriteItem,
+} from '@/services/backend-api/MarketFavoriteController';
+import { useUserStore } from '@/stores/userStore';
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+export function useMarketFavorites(spaceId: number | null) {
+  const userId = useUserStore((state) => state.userId);
+  const [items, setItems] = useState<MarketFavoriteItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isMutating, setIsMutating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    if (!spaceId || !userId) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await listMarketFavorites(spaceId, userId);
+      setItems(response.data.items);
+    } catch (cause) {
+      console.error('[MarketFavorites] 加载收藏失败', cause);
+      setError('收藏加载失败，请稍后重试');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [spaceId, userId]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const add = useCallback(
+    async (targetCode: string) => {
+      if (!spaceId || !userId) return;
+      setIsMutating(true);
+      try {
+        await addMarketFavorite(spaceId, userId, {
+          target_type: 'SKILL',
+          target_code: targetCode,
+        });
+        toast.success('已收藏');
+        await reload();
+      } catch (cause) {
+        console.error('[MarketFavorites] 收藏失败', cause);
+        toast.error('收藏失败，请检查权限或稍后重试');
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [reload, spaceId, userId],
+  );
+
+  const cancel = useCallback(
+    async (targetCode: string) => {
+      if (!spaceId || !userId) return;
+      setIsMutating(true);
+      try {
+        await cancelMarketFavorite(spaceId, userId, {
+          target_type: 'SKILL',
+          target_code: targetCode,
+        });
+        toast.success('已取消收藏');
+        await reload();
+      } catch (cause) {
+        console.error('[MarketFavorites] 取消收藏失败', cause);
+        toast.error('取消收藏失败，请稍后重试');
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [reload, spaceId, userId],
+  );
+
+  return { items, isLoading, isMutating, error, reload, add, cancel };
+}

--- a/src/frontend/src/pages/MarketFavorites/index.tsx
+++ b/src/frontend/src/pages/MarketFavorites/index.tsx
@@ -1,0 +1,97 @@
+import { Button, Empty } from '@/components';
+import { useMarketFavorites } from '@/hooks/useMarketFavorites';
+import { Heart } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+function readSpaceId(): number | null {
+  const value = new URLSearchParams(window.location.search).get('space_id');
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+export default function MarketFavoritesPage() {
+  const spaceId = useMemo(readSpaceId, []);
+  const [targetCode, setTargetCode] = useState('');
+  const { items, isLoading, isMutating, error, reload, add, cancel } =
+    useMarketFavorites(spaceId);
+
+  if (!spaceId) {
+    return (
+      <Empty
+        title="请选择空间"
+        description="从空间工作台进入收藏页后即可查看和管理收藏。"
+        size="lg"
+      />
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 px-6 py-8">
+      <header className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">我的收藏</h1>
+          <p className="mt-1 text-sm text-slate-500">空间 #{spaceId} 中可访问的 Skill 收藏</p>
+        </div>
+        <Button variant="default" soft loading={isLoading} onClick={() => void reload()}>
+          刷新
+        </Button>
+      </header>
+
+      <form
+        className="flex gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const code = targetCode.trim();
+          if (!code) return;
+          void add(code).then(() => setTargetCode(''));
+        }}
+      >
+        <input
+          aria-label="Skill 标识"
+          className="min-w-0 flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-violet-400"
+          maxLength={128}
+          onChange={(event) => setTargetCode(event.target.value)}
+          placeholder="输入已发布 Skill 的稳定标识"
+          value={targetCode}
+        />
+        <Button disabled={!targetCode.trim()} loading={isMutating} type="submit">
+          收藏
+        </Button>
+      </form>
+
+      {error ? (
+        <Empty
+          title={error}
+          description="不会更改当前收藏状态。"
+          action={<Button onClick={() => void reload()}>重试</Button>}
+        />
+      ) : items.length === 0 && !isLoading ? (
+        <Empty title="暂无收藏" description="在市场或 Skill 详情中收藏后会显示在这里。" />
+      ) : (
+        <section className="space-y-3" aria-label="收藏列表">
+          {items.map((item) => (
+            <article
+              className="flex items-center justify-between rounded-xl border border-slate-200/60 bg-white px-4 py-3"
+              key={item.favorite_id}
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-slate-900">{item.target_code}</p>
+                <p className="mt-1 text-xs text-slate-500">Skill · 收藏于 {new Date(item.favorite_at).toLocaleString()}</p>
+              </div>
+              <Button
+                aria-label={`取消收藏 ${item.target_code}`}
+                ghost
+                leftIcon={<Heart fill="currentColor" size={15} />}
+                loading={isMutating}
+                onClick={() => void cancel(item.target_code)}
+                variant="secondary"
+              >
+                已收藏
+              </Button>
+            </article>
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/src/frontend/src/services/backend-api/MarketFavoriteController.ts
+++ b/src/frontend/src/services/backend-api/MarketFavoriteController.ts
@@ -1,0 +1,71 @@
+import { request } from '@umijs/max';
+
+export type FavoriteTargetType = 'SKILL';
+
+export interface MarketFavoriteItem {
+  favorite_id: number;
+  target_type: FavoriteTargetType;
+  target_code: string;
+  favorite_at: string;
+  is_favorited: boolean;
+}
+
+interface Page<T> {
+  total: number;
+  items: T[];
+}
+
+interface Envelope<T> {
+  code: number;
+  message: string;
+  data: T;
+}
+
+interface FavoriteTarget {
+  target_type: FavoriteTargetType;
+  target_code: string;
+}
+
+interface FavoriteAddedResult extends FavoriteTarget {
+  favorite_id: number;
+  is_favorited: boolean;
+}
+
+function endpoint(spaceId: number, suffix = ''): string {
+  return `/openapi/v1/spaces/${spaceId}/market-favorites${suffix}`;
+}
+
+export function listMarketFavorites(
+  spaceId: number,
+  userId: string,
+): Promise<Envelope<Page<MarketFavoriteItem>>> {
+  return request(endpoint(spaceId, '/search'), {
+    method: 'POST',
+    params: { user_id: userId },
+    data: { page_no: 1, page_size: 100 },
+  });
+}
+
+export function addMarketFavorite(
+  spaceId: number,
+  userId: string,
+  target: FavoriteTarget,
+): Promise<Envelope<FavoriteAddedResult>> {
+  return request(endpoint(spaceId), {
+    method: 'POST',
+    params: { user_id: userId },
+    data: target,
+  });
+}
+
+export function cancelMarketFavorite(
+  spaceId: number,
+  userId: string,
+  target: FavoriteTarget,
+): Promise<Envelope<FavoriteTarget>> {
+  return request(endpoint(spaceId, '/cancel'), {
+    method: 'POST',
+    params: { user_id: userId },
+    data: target,
+  });
+}


### PR DESCRIPTION
## Problem

Issue #1171 requires a tenant/env/user/object-unique favorite relation with idempotent mutations, Gateway-backed access control, and a user-visible favorites flow.

## Solution

- Scope favorite persistence by tenant, environment, user, and target; add a deterministic migration for historical cross-Space duplicates.
- Keep OpenAPI routes thin and preserve the established TeamClaw Gateway USER_GATED admission contract; Core enforces Space membership before mutations and queries.
- Make repeated cancel converge to the unfavorited state.
- Add a frontend controller, hook, and favorites page with loading, empty, failure, and retry feedback.

## Validation

- `cd src/backend && uv run pytest tests/community/core/market_favorites tests/community/core/repository/implementations/test_space_market_work_order_repositories.py::test_market_favorite_repository_is_idempotent_and_searchable tests/community/adapters/http/openapi_v1/spaces/test_contract.py tests/community/adapters/http/openapi_v1/test_admission_inventory.py -q` (36 passed)
- `cd src/backend && uv run ruff check ...` (passed)
- Frontend `npm run setup` completed. Full frontend Jest and `tsc --noEmit` are currently blocked by the repository TypeScript 4.1 / resolved `@types/d3-dispatch` syntax mismatch; the test suite had also required generated `.umi` files before setup.

## Compatibility and risk

The migration converts legacy Space-scoped records into user-scoped records, retaining the earliest audited duplicate deterministically. Existing favorites API target validation remains dependent on the separately-owned published-market lookup contract; unknown catalog target semantics are not invented in this change.

## Spec

Implements Q2-Q4 favorite portions of `docs/superpowers/specs/2026-08-19-skill-capability-upgrade-spec.md` and `2026-08-19-skill-capability-upgrade-ownership-and-acceptance.md`.

## Related issues

Closes #1171