### PR TITLE
fix(skills): harden mapping v3 center consumers

### DIFF
--- a/src/engine/src/engine/community/core/adapters/claude_code/skills.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/skills.py
@@ -341,7 +341,13 @@ class ClaudeCodeSkillsAdapter(SkillsService):
         auth: AuthContext | None = None,
     ) -> CenterEnsureResult:
         token = auth.token if auth is not None else None
-        raw = await self._port.skills_ensure_center(token=token)
+        raw = await self._port.skills_ensure_center(
+            token=token,
+            items=[
+                {"skill_uuid": item.skill_uuid, "version": item.version}
+                for item in request.items
+            ],
+        )
         ok = [
             CenterEnsureItem(
                 skill_uuid=d.get("skill_uuid", ""), version=str(d.get("version", ""))

--- a/src/engine/src/engine/community/core/adapters/claude_code/tests/test_adapters.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/tests/test_adapters.py
@@ -641,7 +641,8 @@ class _FakeSkillsPort:
     async def skills_clean_symlinks(self, token=None) -> dict:
         return {"directories_scanned": 2, "removed": ["x"]}
 
-    async def skills_ensure_center(self, token=None) -> dict:
+    async def skills_ensure_center(self, items, token=None) -> dict:
+        self.calls.append({"method": "skills_ensure_center", "items": items, "token": token})
         return {"ok": [{"skill_uuid": "u1", "version": "1.0"}],
                 "failed": [{"skill_uuid": "u2", "version": "2.0", "reason": "missing"}]}
 
@@ -708,7 +709,8 @@ class TestSkillsAdapter:
         assert result.removed == ["x"]
 
     async def test_ensure_center_builds_result(self):
-        adapter = ClaudeCodeSkillsAdapter(_FakeSkillsPort())
+        port = _FakeSkillsPort()
+        adapter = ClaudeCodeSkillsAdapter(port)
         result = await adapter.ensure_center_skills(
             CenterEnsureRequest(items=[CenterEnsureItem(skill_uuid="u1", version="1.0")]),
             auth=_auth("t"),
@@ -717,6 +719,13 @@ class TestSkillsAdapter:
         assert result.ok[0].skill_uuid == "u1"
         assert len(result.failed) == 1
         assert result.failed[0].reason == "missing"
+        assert port.calls == [
+            {
+                "method": "skills_ensure_center",
+                "items": [{"skill_uuid": "u1", "version": "1.0"}],
+                "token": "t",
+            }
+        ]
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/src/engine/src/engine/community/core/adapters/claude_code/tests/test_adapters_coverage.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/tests/test_adapters_coverage.py
@@ -1585,7 +1585,7 @@ class TestSkillsAdapterCoverage:
     async def test_ensure_center_filters_non_dict(self):
         port = _SkillsPort()
 
-        async def ensure(token=None):
+        async def ensure(items=None, token=None):
             return {"ok": [{"skill_uuid": "ok1"}, "bad", None],
                     "failed": [{"skill_uuid": "f1", "reason": "x"}, 5, None]}
         port.skills_ensure_center = ensure  # type: ignore[assignment]

--- a/src/engine/src/engine/community/local/claude_code/plugin_impl.py
+++ b/src/engine/src/engine/community/local/claude_code/plugin_impl.py
@@ -481,8 +481,11 @@ class LocalClaudeCodePluginImpl(ClaudeCodePlugin):
     async def skills_ensure_center(
         self,
         token: str | None = None,
+        items: list[dict[str, str]] | None = None,
     ) -> dict:
-        return {"ok": True, "ensured": []}
+        if items is None:
+            return {"ok": True, "ensured": []}
+        return {"ok": items, "failed": []}
 
     # ----------------------------------------------------------------- cron
 

--- a/src/engine/src/engine/community/plugin_api/claude_code/skills.py
+++ b/src/engine/src/engine/community/plugin_api/claude_code/skills.py
@@ -216,11 +216,14 @@ class ClaudeCodeSkillsPort(Protocol):
     async def skills_ensure_center(
         self,
         token: str | None = None,
+        items: list[dict[str, str]] | None = None,
     ) -> dict:
-        """Call ``skills.ensure_center`` to ensure center skills are present.
+        """Call ``skills.ensure_center`` for exact Center skill versions.
 
         Args:
             token: MCP token for per-token pool routing; None -> default client.
+            items: Exact ``skill_uuid`` / ``version`` dependencies to ensure.
+                ``None`` preserves the historical no-op request shape.
         """
         ...
 

--- a/src/engine/src/engine/community/plugins/claude_code/_skills.py
+++ b/src/engine/src/engine/community/plugins/claude_code/_skills.py
@@ -307,5 +307,12 @@ class _SkillsPortMixin:
     async def skills_clean_symlinks(self, token: str | None = None) -> dict:
         return await self._skills_passthrough("skills.clean_symlinks", {})
 
-    async def skills_ensure_center(self, token: str | None = None) -> dict:
-        return await self._skills_passthrough("skills.ensure_center", {})
+    async def skills_ensure_center(
+        self,
+        token: str | None = None,
+        items: list[dict[str, str]] | None = None,
+    ) -> dict:
+        return await self._skills_passthrough(
+            "skills.ensure_center",
+            {} if items is None else {"items": items},
+        )

--- a/src/engine/src/engine/community/plugins/claude_code/tests/test_mixins_coverage.py
+++ b/src/engine/src/engine/community/plugins/claude_code/tests/test_mixins_coverage.py
@@ -928,7 +928,22 @@ class TestSkillsMixin:
         c = _FakeRelayClient()
         c.set_response("skills.ensure_center", _ok({"ensured": True}))
         impl, _ = _impl(c)
+        assert await impl.skills_ensure_center(
+            items=[{"skill_uuid": "u1", "version": "1.0"}]
+        ) == {"ensured": True}
+        _, args, kw = _last_call(c)
+        assert args[0] == "skills.ensure_center"
+        assert kw["params"] == {"items": [{"skill_uuid": "u1", "version": "1.0"}]}
+
+    async def test_ensure_center_without_items_preserves_legacy_payload(self):
+        c = _FakeRelayClient()
+        c.set_response("skills.ensure_center", _ok({"ensured": True}))
+        impl, _ = _impl(c)
+
         assert await impl.skills_ensure_center() == {"ensured": True}
+        _, args, kw = _last_call(c)
+        assert args[0] == "skills.ensure_center"
+        assert kw["params"] == {}
 
 
 # ── _session.py ──────────────────────────────────────────────────────────────

--- a/src/engine/src/engine/community/plugins/openclaw/_skills.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_skills.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from pathlib import Path
+import shutil
+from pathlib import Path, PurePosixPath
 from typing import Any
+from uuid import UUID, uuid4
 
 from engine.community.core.skills.layout_planner import (
     MAPPING_CONTRACT_VERSION,
@@ -282,22 +284,6 @@ class _SkillsPortMixin:
                 f"rsync exit {result.returncode}: {result.stderr.strip()[:200]}"
             )
 
-    @staticmethod
-    def _skills_ensure_current_symlink(uuid_dir: Path, version_dir_name: str) -> None:
-        """Atomically update the ``current`` symlink under ``uuid_dir``.
-
-        Relocated intact from
-        ``engines/openclaw/skills.py:OpenClawSkillsService._ensure_current_symlink``.
-        """
-        current = uuid_dir / "current"
-        if current.is_symlink() and os.readlink(current) == version_dir_name:
-            return
-        tmp = uuid_dir / f".current.tmp.{os.getpid()}"
-        if tmp.is_symlink() or tmp.exists():
-            tmp.unlink()
-        tmp.symlink_to(version_dir_name)
-        os.replace(tmp, current)
-
     async def _skills_ensure_one(
         self,
         item: dict[str, Any],
@@ -313,28 +299,67 @@ class _SkillsPortMixin:
         """
         import asyncio as _asyncio
 
-        skill_uuid = item["skill_uuid"]
-        version_dir_name = str(item["version"])
+        skill_uuid = item.get("skill_uuid")
+        version_dir_name = item.get("version")
+        if not isinstance(skill_uuid, str):
+            raise _SkillsEnsureError("skill_uuid must be a UUIDv4")
+        try:
+            parsed_uuid = UUID(skill_uuid)
+        except ValueError as error:
+            raise _SkillsEnsureError("skill_uuid must be a UUIDv4") from error
+        if parsed_uuid.version != 4:
+            raise _SkillsEnsureError("skill_uuid must be a UUIDv4")
+        if (
+            not isinstance(version_dir_name, str)
+            or not version_dir_name
+            or version_dir_name.strip() != version_dir_name
+            or len(PurePosixPath(version_dir_name).parts) != 1
+            or PurePosixPath(version_dir_name).parts[0] in {".", ".."}
+        ):
+            raise _SkillsEnsureError("version must be one normalized path segment")
         local_uuid_dir = local_root / skill_uuid
         local_version_dir = local_uuid_dir / version_dir_name
 
-        if local_version_dir.exists() and any(local_version_dir.iterdir()):
+        if (local_version_dir / "SKILL.md").is_file():
             return
+        if local_version_dir.exists() or local_version_dir.is_symlink():
+            raise _SkillsEnsureError("existing center version incomplete")
 
         lock_key = f"{skill_uuid}/{version_dir_name}"
         lock = self._get_ensure_lock(lock_key)
         async with lock:
-            if local_version_dir.exists() and any(local_version_dir.iterdir()):
+            if (local_version_dir / "SKILL.md").is_file():
                 return
+            if local_version_dir.exists() or local_version_dir.is_symlink():
+                raise _SkillsEnsureError("existing center version incomplete")
 
             nas_version_dir = nas_root / skill_uuid / version_dir_name
-            if not nas_version_dir.exists():
-                raise _SkillsEnsureError(f"NAS source missing: {nas_version_dir}")
+            if (
+                nas_version_dir.is_symlink()
+                or not (nas_version_dir / "SKILL.md").is_file()
+                or (nas_version_dir / "SKILL.md").is_symlink()
+            ):
+                raise _SkillsEnsureError(
+                    f"NAS source missing SKILL.md: {nas_version_dir}"
+                )
 
             local_version_dir.parent.mkdir(parents=True, exist_ok=True)
-            await _asyncio.to_thread(
-                self._skills_rsync_dir, nas_version_dir, local_version_dir
-            )
+            temporary = local_uuid_dir / f".{version_dir_name}.tmp.{uuid4().hex}"
+            temporary.mkdir()
+            try:
+                await _asyncio.to_thread(
+                    self._skills_rsync_dir, nas_version_dir, temporary
+                )
+                if not (temporary / "SKILL.md").is_file():
+                    raise _SkillsEnsureError(
+                        f"center skill missing SKILL.md: {nas_version_dir}"
+                    )
+                if local_version_dir.exists():
+                    shutil.rmtree(local_version_dir)
+                os.replace(temporary, local_version_dir)
+            except Exception:
+                shutil.rmtree(temporary, ignore_errors=True)
+                raise
 
     async def ensure_center_skills(self, params: dict[str, Any]) -> dict[str, Any]:
         """Ensure each (skill_uuid, version) from ``params["items"]`` is present locally.

--- a/src/engine/src/engine/community/plugins/openclaw/_skills.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_skills.py
@@ -354,8 +354,8 @@ class _SkillsPortMixin:
                     raise _SkillsEnsureError(
                         f"center skill missing SKILL.md: {nas_version_dir}"
                     )
-                if local_version_dir.exists():
-                    shutil.rmtree(local_version_dir)
+                if local_version_dir.exists() or local_version_dir.is_symlink():
+                    raise _SkillsEnsureError("existing center version incomplete")
                 os.replace(temporary, local_version_dir)
             except Exception:
                 shutil.rmtree(temporary, ignore_errors=True)

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_center_ensure.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_center_ensure.py
@@ -10,6 +10,9 @@ from engine.community.plugins.openclaw._skills import (
     _SkillsPortMixin,
 )
 
+_SKILL_UUID = "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a"
+_VERSION = "2026.8.19"
+
 
 @pytest.mark.asyncio
 async def test_center_ensure_rejects_incomplete_version_before_publication(
@@ -18,7 +21,7 @@ async def test_center_ensure_rejects_incomplete_version_before_publication(
 ) -> None:
     source = tmp_path / "nas"
     destination = tmp_path / "pool"
-    version = source / "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a" / "2026.8.19"
+    version = source / _SKILL_UUID / _VERSION
     version.mkdir(parents=True)
     (version / "partial.txt").write_text("not a skill")
 
@@ -32,14 +35,14 @@ async def test_center_ensure_rejects_incomplete_version_before_publication(
     with pytest.raises(_SkillsEnsureError, match="SKILL.md"):
         await port._skills_ensure_one(
             {
-                "skill_uuid": "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a",
-                "version": "2026.8.19",
+                "skill_uuid": _SKILL_UUID,
+                "version": _VERSION,
             },
             source,
             destination,
         )
 
-    assert not (destination / "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a").exists()
+    assert not (destination / _SKILL_UUID).exists()
 
 
 @pytest.mark.asyncio
@@ -62,20 +65,131 @@ async def test_center_ensure_rejects_untrusted_identity_before_path_resolution(
 async def test_center_ensure_preserves_existing_incomplete_version(
     tmp_path: Path,
 ) -> None:
-    skill_uuid = "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a"
-    version = "2026.8.19"
-    source_version = tmp_path / "nas" / skill_uuid / version
+    source_version = tmp_path / "nas" / _SKILL_UUID / _VERSION
     source_version.mkdir(parents=True)
     (source_version / "SKILL.md").write_text("valid")
-    destination_version = tmp_path / "pool" / skill_uuid / version
+    destination_version = tmp_path / "pool" / _SKILL_UUID / _VERSION
     destination_version.mkdir(parents=True)
     (destination_version / "partial.txt").write_text("preserve for repair")
 
     with pytest.raises(_SkillsEnsureError, match="existing center version incomplete"):
         await _SkillsPortMixin()._skills_ensure_one(
-            {"skill_uuid": skill_uuid, "version": version},
+            {"skill_uuid": _SKILL_UUID, "version": _VERSION},
             tmp_path / "nas",
             tmp_path / "pool",
         )
 
     assert (destination_version / "partial.txt").read_text() == "preserve for repair"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("item", "message"),
+    [
+        ({"skill_uuid": None, "version": _VERSION}, "skill_uuid"),
+        (
+            {
+                "skill_uuid": "00000000-0000-1000-8000-000000000000",
+                "version": _VERSION,
+            },
+            "skill_uuid",
+        ),
+        ({"skill_uuid": _SKILL_UUID, "version": "../escape"}, "version"),
+    ],
+)
+async def test_center_ensure_rejects_invalid_identity_fields(
+    tmp_path: Path,
+    item: dict[str, str | None],
+    message: str,
+) -> None:
+    with pytest.raises(_SkillsEnsureError, match=message):
+        await _SkillsPortMixin()._skills_ensure_one(
+            item,
+            tmp_path / "nas",
+            tmp_path / "pool",
+        )
+
+
+@pytest.mark.asyncio
+async def test_center_ensure_materializes_a_complete_exact_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "nas"
+    destination = tmp_path / "pool"
+    source_version = source / _SKILL_UUID / _VERSION
+    source_version.mkdir(parents=True)
+    (source_version / "SKILL.md").write_text("complete")
+    port = _SkillsPortMixin()
+    monkeypatch.setattr(
+        port,
+        "_skills_rsync_dir",
+        lambda src, dst: shutil.copytree(src, dst, dirs_exist_ok=True),
+    )
+
+    await port._skills_ensure_one(
+        {"skill_uuid": _SKILL_UUID, "version": _VERSION},
+        source,
+        destination,
+    )
+
+    assert (destination / _SKILL_UUID / _VERSION / "SKILL.md").read_text() == "complete"
+    assert not (destination / _SKILL_UUID / "current").exists()
+
+
+@pytest.mark.asyncio
+async def test_center_ensure_refuses_a_destination_created_during_materialization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "nas"
+    destination = tmp_path / "pool"
+    source_version = source / _SKILL_UUID / _VERSION
+    source_version.mkdir(parents=True)
+    (source_version / "SKILL.md").write_text("complete")
+    destination_version = destination / _SKILL_UUID / _VERSION
+    port = _SkillsPortMixin()
+
+    def materialize_then_race(src: Path, temporary: Path) -> None:
+        shutil.copytree(src, temporary, dirs_exist_ok=True)
+        destination_version.mkdir(parents=True)
+        (destination_version / "other.txt").write_text("concurrent")
+
+    monkeypatch.setattr(port, "_skills_rsync_dir", materialize_then_race)
+
+    with pytest.raises(_SkillsEnsureError, match="existing center version incomplete"):
+        await port._skills_ensure_one(
+            {"skill_uuid": _SKILL_UUID, "version": _VERSION},
+            source,
+            destination,
+        )
+
+    assert (destination_version / "other.txt").read_text() == "concurrent"
+    assert not list((destination / _SKILL_UUID).glob(f".{_VERSION}.tmp.*"))
+
+
+@pytest.mark.asyncio
+async def test_center_ensure_cleans_temporary_directory_after_copy_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "nas"
+    destination = tmp_path / "pool"
+    source_version = source / _SKILL_UUID / _VERSION
+    source_version.mkdir(parents=True)
+    (source_version / "SKILL.md").write_text("complete")
+    port = _SkillsPortMixin()
+
+    def fail_copy(_src: Path, _temporary: Path) -> None:
+        raise RuntimeError("rsync failed")
+
+    monkeypatch.setattr(port, "_skills_rsync_dir", fail_copy)
+
+    with pytest.raises(RuntimeError, match="rsync failed"):
+        await port._skills_ensure_one(
+            {"skill_uuid": _SKILL_UUID, "version": _VERSION},
+            source,
+            destination,
+        )
+
+    assert not list((destination / _SKILL_UUID).glob(f".{_VERSION}.tmp.*"))

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_center_ensure.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_center_ensure.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from engine.community.plugins.openclaw._skills import (
+    _SkillsEnsureError,
+    _SkillsPortMixin,
+)
+
+
+@pytest.mark.asyncio
+async def test_center_ensure_rejects_incomplete_version_before_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "nas"
+    destination = tmp_path / "pool"
+    version = source / "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a" / "2026.8.19"
+    version.mkdir(parents=True)
+    (version / "partial.txt").write_text("not a skill")
+
+    port = _SkillsPortMixin()
+    monkeypatch.setattr(
+        port,
+        "_skills_rsync_dir",
+        lambda src, dst: shutil.copytree(src, dst, dirs_exist_ok=True),
+    )
+
+    with pytest.raises(_SkillsEnsureError, match="SKILL.md"):
+        await port._skills_ensure_one(
+            {
+                "skill_uuid": "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a",
+                "version": "2026.8.19",
+            },
+            source,
+            destination,
+        )
+
+    assert not (destination / "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a").exists()
+
+
+@pytest.mark.asyncio
+async def test_center_ensure_rejects_untrusted_identity_before_path_resolution(
+    tmp_path: Path,
+) -> None:
+    port = _SkillsPortMixin()
+
+    with pytest.raises(_SkillsEnsureError, match="skill_uuid"):
+        await port._skills_ensure_one(
+            {"skill_uuid": "../escape", "version": "2026.8.19"},
+            tmp_path / "nas",
+            tmp_path / "pool",
+        )
+
+    assert not (tmp_path / "pool").exists()
+
+
+@pytest.mark.asyncio
+async def test_center_ensure_preserves_existing_incomplete_version(
+    tmp_path: Path,
+) -> None:
+    skill_uuid = "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a"
+    version = "2026.8.19"
+    source_version = tmp_path / "nas" / skill_uuid / version
+    source_version.mkdir(parents=True)
+    (source_version / "SKILL.md").write_text("valid")
+    destination_version = tmp_path / "pool" / skill_uuid / version
+    destination_version.mkdir(parents=True)
+    (destination_version / "partial.txt").write_text("preserve for repair")
+
+    with pytest.raises(_SkillsEnsureError, match="existing center version incomplete"):
+        await _SkillsPortMixin()._skills_ensure_one(
+            {"skill_uuid": skill_uuid, "version": version},
+            tmp_path / "nas",
+            tmp_path / "pool",
+        )
+
+    assert (destination_version / "partial.txt").read_text() == "preserve for repair"

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_activation.py
@@ -65,6 +65,15 @@ def test_mapping_source_classifier_selects_one_managed_layout(
     legacy_source = (
         home / ".openclaw" / "workspace" / "skills" / "skills-local" / "legacy-skill"
     )
+    center_source = (
+        home
+        / ".openclaw"
+        / "workspace"
+        / "skills-pool"
+        / "skill-center"
+        / "2e0f2a89-5f8e-4df2-bc3e-797f5f02d26a"
+        / "2026.8.19"
+    )
     external_source = home / "external-skills" / "external"
 
     assert mapping_sources_use_pool(
@@ -75,6 +84,16 @@ def test_mapping_source_classifier_selects_one_managed_layout(
     assert not mapping_sources_use_pool(
         engine="openclaw",
         sources=[legacy_source, external_source],
+        home=home,
+    )
+    assert not mapping_sources_use_pool(
+        engine="openclaw",
+        sources=[legacy_source, center_source],
+        home=home,
+    )
+    assert mapping_sources_use_pool(
+        engine="openclaw",
+        sources=[pool_source, center_source],
         home=home,
     )
     with pytest.raises(ValueError, match="mix Legacy and Pool"):

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -141,7 +141,7 @@ def mapping_sources_use_pool(
     layout = _Layout.for_engine(engine, Path(home))
     pool_roots = tuple(
         Path(os.path.abspath(root))
-        for root in (layout.pool_local, layout.pool_repo, layout.pool_center)
+        for root in (layout.pool_local, layout.pool_repo)
     )
     legacy_roots = tuple(
         Path(os.path.abspath(root))
@@ -166,6 +166,10 @@ def mapping_sources_use_pool(
         normalized = Path(os.path.abspath(source))
         if any(normalized.is_relative_to(root) for root in pool_roots):
             has_pool = True
+        elif normalized.is_relative_to(Path(os.path.abspath(layout.pool_center))):
+            # Center has one canonical root in both Legacy and Pool layouts.
+            # It must therefore never select, or conflict with, either layout.
+            continue
         elif stable_repo_root is not None and normalized.is_relative_to(
             stable_repo_root
         ):

--- a/src/engine/src/engine/community/tests/contracts/test_claude_code_local_plugin.py
+++ b/src/engine/src/engine/community/tests/contracts/test_claude_code_local_plugin.py
@@ -9,8 +9,8 @@ local plugin, no ``world`` fixture.
 from __future__ import annotations
 
 from engine.community.kernel.frames import EventFrame
-from engine.community.plugin_api.claude_code.plugin import ClaudeCodePlugin
 from engine.community.local.claude_code import LocalClaudeCodePluginImpl
+from engine.community.plugin_api.claude_code.plugin import ClaudeCodePlugin
 
 
 def test_local_claude_code_plugin_satisfies_runtime_protocol_shape():
@@ -196,6 +196,11 @@ async def test_local_claude_code_plugin_stateful_ports_and_error_branches():
     assert (await plugin.skills_sync_bindpaths())["ok"] is True
     assert (await plugin.skills_clean_symlinks())["ok"] is True
     assert (await plugin.skills_ensure_center())["ok"] is True
+    center_items = [{"skill_uuid": "u1", "version": "1.0.0"}]
+    assert (await plugin.skills_ensure_center(items=center_items)) == {
+        "ok": center_items,
+        "failed": [],
+    }
     assert await plugin.skills_uninstall("sk1") is True
     assert await plugin.skills_uninstall("sk1") is False
     assert await plugin.skills_get("sk1") is None

--- a/src/engine/src/engine/community/tests/core/skills/test_logical_mapping_planner.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_logical_mapping_planner.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 from engine.community.core.skills.layout_planner import (
     LAYOUT_CONTRACT_VERSION,
     LayoutIdentity,

--- a/src/engine/src/engine/community/tests/core/skills/test_mapping_contract.py
+++ b/src/engine/src/engine/community/tests/core/skills/test_mapping_contract.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 from engine.community.core.skills.exceptions import (
     InvalidPoolMappingRequestError,
 )


### PR DESCRIPTION
## Problem

Mapping v3 Center consumers could misclassify canonical Center paths during Legacy reconciliation, omit exact dependencies on the Claude relay, and accept incomplete or unsafe Center materialization.

## Solution

- Keep `pool_center` layout-neutral while preserving it in mapping lifecycle operations.
- Forward structured UUID/version dependencies through the Claude Code Plugin API while preserving the legacy empty request shape.
- Fail closed on untrusted Center identities and incomplete existing/source versions; materialize verified content through a temporary directory without `current`.

## Validation

- `uv run --with pytest --with pytest-asyncio pytest -q` (Engine): 2381 passed, 5 skipped.
- `uv run pytest -q` (Backend): 12307 passed, 1 skipped.
- Targeted TDD/contract tests: 13 passed.
- Relevant Ruff checks and `git diff --check`: passed.
- Mypy was run on changed Engine sources; it reports 15 pre-existing mixin/layout typing errors and no new issue from this change.

## Compatibility and risk

Mapping v2 and the historical empty Claude ensure payload remain unchanged. Center requests now require UUIDv4 and a normalized single-segment exact version; incomplete local versions fail closed rather than being replaced. Runtime relay implementations must accept the additive `items` payload before declaring v3 support.

## Related issues

Closes #1167