### PR TITLE
feat(backend): add read-only Space detail API

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -446,6 +446,7 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     # work-order recipient checks. Space ownership initialization, team/member
     # administration, and work-order review remain human-only.
     ("GET", "/openapi/v1/spaces"): AdmissionMode.USER_GATED,
+    ("GET", "/openapi/v1/spaces/{space_id}"): AdmissionMode.REFUSED,
     ("POST", "/openapi/v1/spaces/personal/initialize"): AdmissionMode.REFUSED,
     ("POST", "/openapi/v1/spaces/create"): AdmissionMode.REFUSED,
     ("GET", "/openapi/v1/spaces/{space_id}/members"): AdmissionMode.USER_GATED,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/router.py
@@ -35,6 +35,7 @@ from agentclaw.community.adapters.http.openapi_v1.spaces.schemas import (
     PersonalSpaceInitialized,
     SearchFavoritesRequest,
     SpaceCreated,
+    SpaceMembershipRole,
     SpaceRole,
     SpaceType,
     SpaceItem,
@@ -87,9 +88,14 @@ def _space_item(record: SpaceSummaryRecord) -> SpaceItem:
         space_code=record.space.space_code,
         space_name=record.space.name,
         space_type=record.space.space_type,
-        current_user_role=record.current_user_role,
+        current_user_role=(
+            _membership_role(record.current_user_role)
+            if record.current_user_role is not None
+            else None
+        ),
         join_status=record.join_status,
         member_count=record.member_count,
+        administrator_count=record.owner_count,
         owner_count=record.owner_count,
         gmt_modified=record.space.gmt_modified,
     )
@@ -115,9 +121,17 @@ def _member_item(record: SpaceMemberSummaryRecord) -> SpaceMemberItem:
         user_id=record.member.user_id,
         user_name=record.user_name,
         display_name=record.display_name,
-        role=record.member.role,
+        role=_membership_role(record.member.role),
         is_creator=record.is_creator,
         gmt_modified=record.member.gmt_modified,
+    )
+
+
+def _membership_role(role: DomainSpaceRole) -> SpaceMembershipRole:
+    return (
+        SpaceMembershipRole.ADMINISTRATOR
+        if role is DomainSpaceRole.OWNER
+        else SpaceMembershipRole.MEMBER
     )
 
 
@@ -155,6 +169,22 @@ async def list_spaces(
         page_size=page_size,
     )
     return page(total, [_space_item(record) for record in records], request)
+
+
+@router.get(
+    "/{space_id}", response_model=Envelope[SpaceItem], dependencies=_REFUSES_APP_ONLY
+)
+@envelope_errors
+async def get_space(
+    space_id: SpaceIdPath,
+    request: Request,
+    caller: ActingCallerDep,
+    service: SpaceServiceProtocol = Injected(SpaceServiceProtocol),
+) -> Envelope[SpaceItem]:
+    actor_id = _require_user_delegation(caller)
+    return envelope(
+        _space_item(service.get_space(space_id=space_id, user_id=actor_id)), request
+    )
 
 
 @router.post(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
@@ -33,6 +33,18 @@ class SpaceRole(_DocumentedEnum):
     }
 
 
+class SpaceMembershipRole(_DocumentedEnum):
+    """Governance role held by a member of a Space."""
+
+    ADMINISTRATOR = "ADMINISTRATOR"
+    MEMBER = "MEMBER"
+
+    __descriptions__ = {
+        "ADMINISTRATOR": "May administer the Space and its membership.",
+        "MEMBER": "May use the Space without administering it.",
+    }
+
+
 class SpaceJoinStatus(_DocumentedEnum):
     """Current user's membership state for a Space."""
 
@@ -87,14 +99,27 @@ class SpaceItem(_UtcResponseModel):
     space_code: str = Field(description="Stable external code of the Space.")
     space_name: str = Field(description="Display name of the Space.")
     space_type: SpaceType = Field(description="Ownership model of the Space.")
-    current_user_role: SpaceRole | None = Field(
+    current_user_role: SpaceMembershipRole | None = Field(
         description="Current user's role, or null when the user has not joined."
     )
     join_status: SpaceJoinStatus = Field(
         description="Current user's membership or application state."
     )
     member_count: int = Field(description="Number of members in the Space.")
-    owner_count: int = Field(description="Number of owners in the Space.")
+    administrator_count: int | None = Field(
+        default=None,
+        description=(
+            "Number of active Space Administrators. Null is reserved for "
+            "backwards-compatible callers."
+        ),
+    )
+    owner_count: int = Field(
+        description=(
+            "Deprecated compatibility alias for administrator_count; it never "
+            "represents a Skill Owner or Skill Grant."
+        ),
+        json_schema_extra={"deprecated": True},
+    )
     gmt_modified: datetime = Field(
         description="UTC time when the Space metadata was last modified.",
         json_schema_extra={"format": "date-time"},
@@ -148,7 +173,9 @@ class SpaceMemberItem(_UtcResponseModel):
     display_name: str | None = Field(
         default=None, description="Display name of the member, when available."
     )
-    role: SpaceRole = Field(description="Role currently held by the member.")
+    role: SpaceMembershipRole = Field(
+        description="Governance role currently held by the member."
+    )
     is_creator: bool = Field(
         description="Whether this member originally created the Space."
     )

--- a/src/backend/src/agentclaw/community/api/space_service.py
+++ b/src/backend/src/agentclaw/community/api/space_service.py
@@ -41,6 +41,9 @@ class SpaceServiceProtocol(Protocol):
         page_size: int,
     ) -> tuple[int, list[SpaceSummaryRecord]]: ...
 
+    @abstractmethod
+    def get_space(self, *, space_id: int, user_id: str) -> SpaceSummaryRecord: ...
+
 
 @runtime_checkable
 class SpaceMemberServiceProtocol(Protocol):

--- a/src/backend/src/agentclaw/community/core/repository/implementations/spaces/space.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/spaces/space.py
@@ -149,6 +149,66 @@ class SpaceRepository(SpaceRepositoryProtocol):
             )
             return row.to_record() if row is not None else None
 
+    def _space_summary(self, db, *, space, user_id: str, env: str):
+        current = (
+            db.query(self._Member)
+            .filter(
+                self._Member.space_id == space.id,
+                self._Member.user_id == user_id,
+                self._Member.env == env,
+                self._Member.status == "ACTIVE",
+            )
+            .one_or_none()
+        )
+        member_count = (
+            db.query(func.count(self._Member.id))
+            .filter(
+                self._Member.space_id == space.id,
+                self._Member.env == env,
+                self._Member.status == "ACTIVE",
+            )
+            .scalar()
+            or 0
+        )
+        owner_count = (
+            db.query(func.count(self._Member.id))
+            .filter(
+                self._Member.space_id == space.id,
+                self._Member.role == self._stored_role(SpaceRole.OWNER),
+                self._Member.env == env,
+                self._Member.status == "ACTIVE",
+            )
+            .scalar()
+            or 0
+        )
+        role = current.to_record().role if current is not None else None
+        return SpaceSummaryRecord(
+            space=space.to_record(),
+            current_user_role=role,
+            join_status=(
+                SpaceJoinStatus.JOINED
+                if current is not None
+                else SpaceJoinStatus.NOT_JOINED
+            ),
+            member_count=member_count,
+            owner_count=owner_count,
+        )
+
+    def get_space_summary(self, *, space_id: int, user_id: str, env: str):
+        with self._db.orm_session() as db:
+            space = (
+                db.query(self._Space)
+                .filter(
+                    self._Space.id == space_id,
+                    self._Space.env == env,
+                    self._Space.deleted_at.is_(None),
+                )
+                .one_or_none()
+            )
+            if space is None:
+                return None
+            return self._space_summary(db, space=space, user_id=user_id, env=env)
+
     def batch_query_personal(
         self, *, user_ids: list[str], env: str
     ) -> list[PersonalSpaceLookupRecord]:
@@ -203,54 +263,10 @@ class SpaceRepository(SpaceRepositoryProtocol):
                 .limit(limit)
                 .all()
             )
-            items = []
-            for row in rows:
-                current = (
-                    db.query(self._Member)
-                    .filter(
-                        self._Member.space_id == row.id,
-                        self._Member.user_id == user_id,
-                        self._Member.env == env,
-                        self._Member.status == "ACTIVE",
-                    )
-                    .one_or_none()
-                )
-                member_count = (
-                    db.query(func.count(self._Member.id))
-                    .filter(
-                        self._Member.space_id == row.id,
-                        self._Member.env == env,
-                        self._Member.status == "ACTIVE",
-                    )
-                    .scalar()
-                    or 0
-                )
-                owner_count = (
-                    db.query(func.count(self._Member.id))
-                    .filter(
-                        self._Member.space_id == row.id,
-                        self._Member.role == self._stored_role(SpaceRole.OWNER),
-                        self._Member.env == env,
-                        self._Member.status == "ACTIVE",
-                    )
-                    .scalar()
-                    or 0
-                )
-                role = current.to_record().role if current is not None else None
-                items.append(
-                    SpaceSummaryRecord(
-                        space=row.to_record(),
-                        current_user_role=role,
-                        join_status=(
-                            SpaceJoinStatus.JOINED
-                            if current is not None
-                            else SpaceJoinStatus.NOT_JOINED
-                        ),
-                        member_count=member_count,
-                        owner_count=owner_count,
-                    )
-                )
-            return total, items
+            return total, [
+                self._space_summary(db, space=row, user_id=user_id, env=env)
+                for row in rows
+            ]
 
     def get_member(self, *, space_id: int, user_id: str, env: str):
         with self._db.orm_session() as db:

--- a/src/backend/src/agentclaw/community/core/repository/protocols/spaces.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/spaces.py
@@ -32,6 +32,11 @@ class SpaceRepositoryProtocol(Protocol):
     def get_space(self, *, space_id: int, env: str) -> SpaceRecord | None: ...
 
     @abstractmethod
+    def get_space_summary(
+        self, *, space_id: int, user_id: str, env: str
+    ) -> SpaceSummaryRecord | None: ...
+
+    @abstractmethod
     def batch_query_personal(
         self, *, user_ids: list[str], env: str
     ) -> list[PersonalSpaceLookupRecord]: ...

--- a/src/backend/src/agentclaw/community/core/spaces/services/space_service.py
+++ b/src/backend/src/agentclaw/community/core/spaces/services/space_service.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 from injector import inject
 
 from agentclaw.community.core.repository.protocols.spaces import SpaceRepositoryProtocol
-from agentclaw.community.core.spaces.errors import SpaceNameInvalidError
+from agentclaw.community.core.spaces.errors import (
+    SpaceAccessDeniedError,
+    SpaceNameInvalidError,
+    SpaceNotFoundError,
+)
 from agentclaw.community.core.spaces.models import (
     PersonalSpaceLookupRecord,
     SpaceRecord,
     SpaceSummaryRecord,
     SpaceType,
+)
+from agentclaw.community.core.spaces.services.space_access_service import (
+    SpaceAccessService,
 )
 from agentclaw.community.plugin_api.skill_center_client import (
     SkillCenterClient,
@@ -25,9 +32,11 @@ class SpaceService:
         self,
         repository: SpaceRepositoryProtocol,
         skill_center_client: SkillCenterClient,
+        access: SpaceAccessService,
     ) -> None:
         self._repository = repository
         self._skill_center_client = skill_center_client
+        self._access = access
 
     def initialize_personal(self, *, user_id: str) -> tuple[SpaceRecord, bool]:
         return self._repository.initialize_personal(
@@ -88,3 +97,14 @@ class SpaceService:
             offset=(page_no - 1) * page_size,
             limit=page_size,
         )
+
+    def get_space(self, *, space_id: int, user_id: str) -> SpaceSummaryRecord:
+        self._access.require_space_member(space_id=space_id, user_id=user_id)
+        summary = self._repository.get_space_summary(
+            space_id=space_id, user_id=user_id, env=get_current_env()
+        )
+        if summary is None:
+            raise SpaceNotFoundError("space not found")
+        if summary.current_user_role is None:
+            raise SpaceAccessDeniedError("space membership required")
+        return summary

--- a/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
@@ -15,6 +15,7 @@ from agentclaw.community.adapters.http.openapi_v1.spaces.router import router
 from agentclaw.community.adapters.http.openapi_v1.spaces.schemas import (
     MarketFavoriteItem,
     SpaceMemberItem,
+    SpaceMembershipRole,
 )
 from agentclaw.community.api.market_favorite_service import (
     MarketFavoriteServiceProtocol,
@@ -24,6 +25,10 @@ from agentclaw.community.api.space_service import (
     SpaceServiceProtocol,
 )
 from agentclaw.community.core.market_favorites.errors import FavoriteNotFoundError
+from agentclaw.community.core.spaces.errors import (
+    SpaceAccessDeniedError,
+    SpaceNotFoundError,
+)
 from agentclaw.community.core.market_favorites.models import (
     FavoriteTargetType,
     MarketFavoriteRecord,
@@ -122,7 +127,7 @@ def test_naive_persisted_datetime_is_serialized_as_explicit_utc():
         user_id="member-1",
         user_name=None,
         display_name=None,
-        role=SpaceRole.MEMBER,
+        role=SpaceMembershipRole.MEMBER,
         is_creator=False,
         gmt_modified=datetime(2026, 8, 17, 7, 50, 45),
     )
@@ -169,6 +174,13 @@ def test_add_member_accepts_an_optional_role(
 
 def test_openapi_advertises_nullable_member_profile_fields(client):
     schemas = client.get("/openapi.json").json()["components"]["schemas"]
+
+    space_properties = schemas["SpaceItem"]["properties"]
+    assert "administrator_count" in space_properties
+    assert space_properties["owner_count"]["deprecated"] is True
+    assert "never represents a Skill Owner" in space_properties["owner_count"][
+        "description"
+    ]
 
     member_properties = schemas["SpaceMemberItem"]["properties"]
     assert "user_name" in member_properties
@@ -286,6 +298,49 @@ def test_list_spaces_forwards_filters_and_maps_page(client, space_service):
         page_no=2,
         page_size=5,
     )
+
+
+def test_get_space_returns_member_visible_space_detail(client, space_service):
+    space_service.get_space.return_value = SpaceSummaryRecord(
+        space=_space_record(),
+        current_user_role=SpaceRole.OWNER,
+        join_status=SpaceJoinStatus.JOINED,
+        member_count=3,
+        owner_count=1,
+    )
+
+    response = client.get("/openapi/v1/spaces/7")
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {
+        "space_id": 7,
+        "space_code": "spc-7",
+        "space_name": "Team",
+        "space_type": "TEAM",
+        "current_user_role": "ADMINISTRATOR",
+        "join_status": "JOINED",
+        "member_count": 3,
+        "administrator_count": 1,
+        "owner_count": 1,
+        "gmt_modified": "2026-08-18T01:02:03Z",
+    }
+    space_service.get_space.assert_called_once_with(space_id=7, user_id="owner-1")
+
+
+@pytest.mark.parametrize(
+    ("error", "status"),
+    [
+        (SpaceAccessDeniedError("space membership required"), 403),
+        (SpaceNotFoundError("space not found"), 404),
+    ],
+)
+def test_get_space_maps_access_and_missing_errors(client, space_service, error, status):
+    space_service.get_space.side_effect = error
+
+    response = client.get("/openapi/v1/spaces/7")
+
+    assert response.status_code == status
+    assert response.json()["data"] is None
 
 
 @pytest.mark.parametrize("was_created", [True, False])

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -335,7 +335,7 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: and five account-level operations. The trace filter remains the sole query
 #: placement. Together with the caller-identity read, the combined contract is
 #: 83/1/41.
-_BOT_ID_PLACEMENT = {"path": 83, "query": 1, "none": 41}
+_BOT_ID_PLACEMENT = {"path": 83, "query": 1, "none": 42}
 
 
 def _schema() -> dict:
@@ -420,8 +420,8 @@ def test_the_pinned_number_of_operations_take_it():
     # recipient-notification operations added by the collaboration API, then +2
     # for the Bot Chats operations. The combined Bot Workshop surface adds a
     # further net 32 user-scoped operations (27 bot-addressed and five
-    # account-level operations).
-    assert len(taking) == 114
+    # account-level operations), and the Space detail read adds one more.
+    assert len(taking) == 115
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -1,6 +1,7 @@
 """SQLite-backed unit tests for the new unified ORM repositories."""
 
 import asyncio
+from datetime import datetime
 
 import pytest
 
@@ -158,6 +159,37 @@ def test_space_repository_full_member_lifecycle(db) -> None:
         repository.delete_member(space_id=team.id, user_id="member-1", env="dev")
         is False
     )
+
+
+def test_space_summary_is_env_isolated_and_excludes_soft_deleted_spaces(db) -> None:
+    repository = SpaceRepository(db)
+    team = _team(repository)
+    repository.add_member(
+        space_id=team.id,
+        user_id="member-1",
+        role=SpaceRole.MEMBER,
+        creator_id="owner-1",
+        env="dev",
+    )
+
+    summary = repository.get_space_summary(
+        space_id=team.id, user_id="member-1", env="dev"
+    )
+
+    assert summary is not None
+    assert summary.current_user_role is SpaceRole.MEMBER
+    assert summary.member_count == 2
+    assert repository.get_space_summary(
+        space_id=team.id, user_id="member-1", env="pre"
+    ) is None
+
+    with db.orm_session() as session:
+        row = session.query(SpaceModel).filter(SpaceModel.id == team.id).one()
+        row.deleted_at = datetime(2026, 8, 19, 12, 0, 0)
+
+    assert repository.get_space_summary(
+        space_id=team.id, user_id="member-1", env="dev"
+    ) is None
 
 
 def test_market_favorite_repository_is_idempotent_and_searchable(db) -> None:

--- a/src/backend/tests/community/core/spaces/test_space_service.py
+++ b/src/backend/tests/community/core/spaces/test_space_service.py
@@ -12,7 +12,14 @@ import pytest
 from agentclaw.community.core.repository.implementations.spaces.space import (
     SpaceRepository,
 )
-from agentclaw.community.core.spaces.models import SpaceRecord, SpaceType
+from agentclaw.community.core.spaces.models import (
+    SpaceJoinStatus,
+    SpaceRecord,
+    SpaceRole,
+    SpaceSummaryRecord,
+    SpaceType,
+)
+from agentclaw.community.core.spaces.errors import SpaceAccessDeniedError
 from agentclaw.community.core.spaces.services.space_service import SpaceService
 from agentclaw.community.plugin_api.skill_center_client import (
     SkillCenterTeamCreateError,
@@ -62,7 +69,7 @@ def test_create_team_pushes_to_sc_before_transaction_commit() -> None:
     skill_center.create_team.return_value = SkillCenterTeamCreateResult(
         team_id="sc-team-9001"
     )
-    service = SpaceService(repository, skill_center)
+    service = SpaceService(repository, skill_center, MagicMock())
 
     record = service.create_team(name="  Demo Team  ", creator_id="owner-1")
 
@@ -88,7 +95,7 @@ def test_create_team_rolls_back_when_sc_creation_fails() -> None:
     repository = _TransactionRepository(_space())
     skill_center = MagicMock()
     skill_center.create_team.side_effect = SkillCenterTeamCreateError("SC failed")
-    service = SpaceService(repository, skill_center)
+    service = SpaceService(repository, skill_center, MagicMock())
 
     with pytest.raises(SkillCenterTeamCreateError, match="SC failed"):
         service.create_team(name="Demo Team", creator_id="owner-1")
@@ -108,7 +115,7 @@ def test_generated_space_code_matches_sc_format() -> None:
 def test_create_team_rejects_invalid_name(name: str) -> None:
     repository = MagicMock()
     skill_center = MagicMock()
-    service = SpaceService(repository, skill_center)
+    service = SpaceService(repository, skill_center, MagicMock())
 
     from agentclaw.community.core.spaces.errors import SpaceNameInvalidError
 
@@ -122,7 +129,7 @@ def test_create_team_rejects_invalid_name(name: str) -> None:
 def test_initialize_personal_delegates_to_repository() -> None:
     repository = MagicMock()
     repository.initialize_personal.return_value = (_space(), True)
-    service = SpaceService(repository, MagicMock())
+    service = SpaceService(repository, MagicMock(), MagicMock())
 
     assert service.initialize_personal(user_id="owner-1") == (_space(), True)
     repository.initialize_personal.assert_called_once_with(user_id="owner-1", env="dev")
@@ -131,7 +138,7 @@ def test_initialize_personal_delegates_to_repository() -> None:
 def test_list_spaces_normalizes_filters_and_pagination() -> None:
     repository = MagicMock()
     repository.list_spaces.return_value = (0, [])
-    service = SpaceService(repository, MagicMock())
+    service = SpaceService(repository, MagicMock(), MagicMock())
 
     assert service.list_spaces(
         user_id="owner-1",
@@ -153,7 +160,7 @@ def test_list_spaces_normalizes_filters_and_pagination() -> None:
 def test_list_spaces_turns_blank_optional_filters_into_none() -> None:
     repository = MagicMock()
     repository.list_spaces.return_value = (0, [])
-    service = SpaceService(repository, MagicMock())
+    service = SpaceService(repository, MagicMock(), MagicMock())
 
     service.list_spaces(
         user_id="owner-1",
@@ -167,10 +174,46 @@ def test_list_spaces_turns_blank_optional_filters_into_none() -> None:
     assert repository.list_spaces.call_args.kwargs["space_type"] is None
 
 
+def test_get_space_requires_membership_and_returns_space_summary() -> None:
+    repository = MagicMock()
+    access = MagicMock()
+    expected = SpaceSummaryRecord(
+        space=_space(),
+        current_user_role=SpaceRole.OWNER,
+        join_status=SpaceJoinStatus.JOINED,
+        member_count=3,
+        owner_count=1,
+    )
+    repository.get_space_summary.return_value = expected
+    service = SpaceService(repository, MagicMock(), access)
+
+    assert service.get_space(space_id=7, user_id="member-1") == expected
+    access.require_space_member.assert_called_once_with(
+        space_id=7, user_id="member-1"
+    )
+    repository.get_space_summary.assert_called_once_with(
+        space_id=7, user_id="member-1", env="dev"
+    )
+
+
+def test_get_space_does_not_read_when_membership_is_denied() -> None:
+    repository = MagicMock()
+    access = MagicMock()
+    access.require_space_member.side_effect = SpaceAccessDeniedError(
+        "space membership required"
+    )
+    service = SpaceService(repository, MagicMock(), access)
+
+    with pytest.raises(SpaceAccessDeniedError, match="membership required"):
+        service.get_space(space_id=7, user_id="non-member")
+
+    repository.get_space_summary.assert_not_called()
+
+
 def test_batch_query_personal_deduplicates_and_preserves_first_occurrence() -> None:
     repository = MagicMock()
     repository.batch_query_personal.return_value = []
-    service = SpaceService(repository, MagicMock())
+    service = SpaceService(repository, MagicMock(), MagicMock())
 
     assert service.batch_query_personal(user_ids=[" user-2 ", "user-1", "user-2"]) == []
     repository.batch_query_personal.assert_called_once_with(
@@ -181,7 +224,7 @@ def test_batch_query_personal_deduplicates_and_preserves_first_occurrence() -> N
 @pytest.mark.parametrize("user_ids", [[], ["  "], [str(index) for index in range(501)]])
 def test_batch_query_personal_rejects_invalid_ids(user_ids: list[str]) -> None:
     repository = MagicMock()
-    service = SpaceService(repository, MagicMock())
+    service = SpaceService(repository, MagicMock(), MagicMock())
 
     with pytest.raises(ValueError, match="user_id"):
         service.batch_query_personal(user_ids=user_ids)

--- a/src/backend/tests/community/endpoints/test_spaces_router.py
+++ b/src/backend/tests/community/endpoints/test_spaces_router.py
@@ -48,7 +48,7 @@ class _Resolver:
         return _Secret()
 
 
-def _principal_headers() -> dict[str, str]:
+def _principal_headers(user_id: str = _USER_ID) -> dict[str, str]:
     now = int(time.time())
     token = jwt.encode(
         {
@@ -61,8 +61,8 @@ def _principal_headers() -> dict[str, str]:
                     "type": "user",
                     "tenant": "spaces-endpoint-test",
                     "subject": {
-                        "id": _USER_ID,
-                        "username": "spaces-endpoint-user@example.com",
+                        "id": user_id,
+                        "username": f"{user_id}@example.com",
                     },
                 }
             ],
@@ -147,6 +147,87 @@ def list_spaces_happy():
     expect=ExpectError(status=403),
 )
 def list_spaces_wrong_user():
+    """The framework owns invocation."""
+
+
+# ── GET /openapi/v1/spaces/{space_id} ──────────────────────────────────────
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/spaces/{space_id}",
+    scenario="happy",
+    seed=_seed_team_space,
+    input=CaseInput(
+        path_params={"space_id": 1},
+        query_params={"user_id": _USER_ID},
+        headers=_principal_headers(),
+    ),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": {
+                "space_name": "Endpoint Team",
+                "current_user_role": "ADMINISTRATOR",
+            },
+        },
+    ),
+)
+def get_space_happy():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/spaces/{space_id}",
+    scenario="wrong_user",
+    seed=_enable_public_auth,
+    input=_mismatched_user(path_params={"space_id": 1}),
+    expect=ExpectError(status=403),
+)
+def get_space_wrong_user():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/spaces/{space_id}",
+    scenario="non_member",
+    seed=_seed_team_space,
+    input=CaseInput(
+        path_params={"space_id": 1},
+        query_params={"user_id": _MEMBER_ID},
+        headers=_principal_headers(_MEMBER_ID),
+    ),
+    expect=ExpectError(status=403),
+)
+def get_space_non_member():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/spaces/{space_id}",
+    scenario="personal_happy",
+    seed=_seed_personal_space,
+    input=CaseInput(
+        path_params={"space_id": 1},
+        query_params={"user_id": _USER_ID},
+        headers=_principal_headers(),
+    ),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": {
+                "space_type": "PERSONAL",
+                "current_user_role": "ADMINISTRATOR",
+            },
+        },
+    ),
+)
+def get_personal_space_happy():
     """The framework owns invocation."""
 
 

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -5280,6 +5280,48 @@
         "title": "Envelope[SpaceCreated]",
         "type": "object"
       },
+      "Envelope_SpaceItem_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SpaceItem"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[SpaceItem]",
+        "type": "object"
+      },
       "Envelope_SpaceJoinRequestCreated_": {
         "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
@@ -9361,10 +9403,22 @@
       "SpaceItem": {
         "description": "Summary of a Space visible to the current user.",
         "properties": {
+          "administrator_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Number of active Space Administrators. Null is reserved for backwards-compatible callers.",
+            "title": "Administrator Count"
+          },
           "current_user_role": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/SpaceRole"
+                "$ref": "#/components/schemas/SpaceMembershipRole"
               },
               {
                 "type": "null"
@@ -9388,7 +9442,8 @@
             "type": "integer"
           },
           "owner_count": {
-            "description": "Number of owners in the Space.",
+            "deprecated": true,
+            "description": "Deprecated compatibility alias for administrator_count; it never represents a Skill Owner or Skill Grant.",
             "title": "Owner Count",
             "type": "integer"
           },
@@ -9531,8 +9586,8 @@
             "type": "boolean"
           },
           "role": {
-            "$ref": "#/components/schemas/SpaceRole",
-            "description": "Role currently held by the member."
+            "$ref": "#/components/schemas/SpaceMembershipRole",
+            "description": "Governance role currently held by the member."
           },
           "user_id": {
             "description": "Identifier of the member user.",
@@ -9586,6 +9641,27 @@
         ],
         "title": "SpaceMemberMutationResult",
         "type": "object"
+      },
+      "SpaceMembershipRole": {
+        "description": "Governance role held by a member of a Space.",
+        "enum": [
+          "ADMINISTRATOR",
+          "MEMBER"
+        ],
+        "title": "SpaceMembershipRole",
+        "type": "string",
+        "x-enum-descriptions": [
+          "May administer the Space and its membership.",
+          "May use the Space without administering it."
+        ],
+        "x-enum-varnames": [
+          "ADMINISTRATOR",
+          "MEMBER"
+        ],
+        "x-enumNames": [
+          "ADMINISTRATOR",
+          "MEMBER"
+        ]
       },
       "SpaceRole": {
         "description": "Role held by a user in a Space.",
@@ -40252,6 +40328,173 @@
           }
         },
         "summary": "Initialize Personal Space",
+        "tags": [
+          "spaces"
+        ]
+      }
+    },
+    "/openapi/v1/spaces/{space_id}": {
+      "get": {
+        "operationId": "get_space_openapi_v1_spaces__space_id__get",
+        "parameters": [
+          {
+            "description": "Space primary identifier.",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "description": "Space primary identifier.",
+              "minimum": 1,
+              "title": "Space Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SpaceItem_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Get Space",
         "tags": [
           "spaces"
         ]

--- a/src/gateway/tests/unit/core/authn/test_route_security.py
+++ b/src/gateway/tests/unit/core/authn/test_route_security.py
@@ -41,6 +41,7 @@ def test_shipped_config_admits_a_machine_caller_on_the_public_api() -> None:
 _HUMAN_ONLY = [
     ("GET", "/openapi/v1/caller"),
     ("GET", "/openapi/v1/spaces"),
+    ("GET", "/openapi/v1/spaces/1"),
     ("POST", "/openapi/v1/spaces/personal/initialize"),
     ("POST", "/openapi/v1/spaces/create"),
     ("GET", "/openapi/v1/spaces/1/members"),


### PR DESCRIPTION
## Problem

The Space workbench lacks a member-protected detail read through the published Gateway contract.

## Solution

Add `GET /openapi/v1/spaces/{space_id}` through the OpenAPI adapter, Service API Protocol, Core, and Repository. Enforce active Space membership, tenant/env filtering, soft-delete masking, and human-only Gateway admission. Read projections use `ADMINISTRATOR`/`MEMBER`; `administrator_count` is additive and `owner_count` remains a deprecated compatibility alias. Regenerate the Gateway OpenAPI artifact through its compatibility gate.

## Validation

- `uv run pytest tests/community -q --tb=short` — 12,318 passed, 1 skipped
- Gateway CI — 924 unit passed, 27 E2E passed; 95.37% line coverage
- OpenAPI dump/publish compatibility gate — passed
- `scripts/ci/python_sast_local.sh src/backend 1 --base origin/dev_refactory_collaboration --head HEAD` — passed
- Dual-axis code review — no remaining findings

## Compatibility and risk

The new detail path and `administrator_count` are additive. Existing `owner_count` stays available as a deprecated compatibility alias and is documented as unrelated to Skill Owner/Grant. The route is human-only at both Gateway and Backend boundaries. Rollback is the single commit.

## Spec

Implements Skill Capability Upgrade final spec §§3, 6.2, 9, 16, 18 and Q2 in the ownership-and-acceptance document.

## Related issues

Closes #1172