### PR TITLE
fix(skill-center): scope routed default skillsets by bot

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/default_skill_set_selection.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/default_skill_set_selection.py
@@ -12,7 +12,8 @@ from .strategy import AICODING_ENGINE_TYPE, CLAUDE_CODE_ENGINE_TYPE
 class AicodingDefaultSkillSetSelectionResolver:
     """Route non-normal Claude Code default SkillSet reads to aicoding rows.
 
-    Existing online global default SkillSet rows for routed Claude Code were
+    Routed Claude Code should first use the current bot-scoped persisted
+    default, then fall back to the existing online global default SkillSet rows
     created under the aicoding runtime engine and ``bolt_id='default'``.  Only
     this engine relationship needs the compatibility lookup; all unclaimed
     inputs fall back to the persisted engine in the neutral policy.
@@ -27,21 +28,33 @@ class AicodingDefaultSkillSetSelectionResolver:
         runtime_engine_type: str | None,
         normalized_persisted_engine_type: str,
         normalized_runtime_engine_type: str,
+        bolt_id: str | None = None,
     ) -> tuple[DefaultSkillSetSelection, ...] | None:
         if (
             normalized_persisted_engine_type == CLAUDE_CODE_ENGINE_TYPE
             and normalized_runtime_engine_type == AICODING_ENGINE_TYPE
         ):
-            return (
-                DefaultSkillSetSelection(
-                    engine_type=runtime_engine_type,
-                    bolt_id=self._GLOBAL_DEFAULT_BOLT_ID,
-                ),
-                DefaultSkillSetSelection(
-                    engine_type=persisted_engine_type,
-                    bolt_id=self._GLOBAL_DEFAULT_BOLT_ID,
-                ),
+            candidates: list[DefaultSkillSetSelection] = []
+            if bolt_id and bolt_id != self._GLOBAL_DEFAULT_BOLT_ID:
+                candidates.append(
+                    DefaultSkillSetSelection(
+                        engine_type=persisted_engine_type,
+                        bolt_id=bolt_id,
+                    )
+                )
+            candidates.extend(
+                (
+                    DefaultSkillSetSelection(
+                        engine_type=runtime_engine_type,
+                        bolt_id=self._GLOBAL_DEFAULT_BOLT_ID,
+                    ),
+                    DefaultSkillSetSelection(
+                        engine_type=persisted_engine_type,
+                        bolt_id=self._GLOBAL_DEFAULT_BOLT_ID,
+                    ),
+                )
             )
+            return tuple(candidates)
         return None
 
 

--- a/src/backend/src/agentclaw/community/core/skill_center/policies/default_skill_set_selection.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/policies/default_skill_set_selection.py
@@ -40,6 +40,7 @@ class DefaultSkillSetSelectionResolver(Protocol):
         runtime_engine_type: str | None,
         normalized_persisted_engine_type: str,
         normalized_runtime_engine_type: str,
+        bolt_id: str | None = None,
     ) -> tuple[DefaultSkillSetSelection, ...] | DefaultSkillSetSelection | None:
         """Return default SkillSet lookup candidates, or ``None``."""
 
@@ -58,10 +59,12 @@ class DefaultSkillSetSelectionPolicy:
         *,
         persisted_engine_type: str | None,
         runtime_engine_type: str | None,
+        bolt_id: str | None = None,
     ) -> DefaultSkillSetSelection:
         return self.resolve_candidates(
             persisted_engine_type=persisted_engine_type,
             runtime_engine_type=runtime_engine_type,
+            bolt_id=bolt_id,
         )[0]
 
     def resolve_candidates(
@@ -69,6 +72,7 @@ class DefaultSkillSetSelectionPolicy:
         *,
         persisted_engine_type: str | None,
         runtime_engine_type: str | None,
+        bolt_id: str | None = None,
     ) -> tuple[DefaultSkillSetSelection, ...]:
         normalized_persisted_engine = normalize_engine_for_default_skill_set(
             persisted_engine_type
@@ -82,6 +86,7 @@ class DefaultSkillSetSelectionPolicy:
                 runtime_engine_type=runtime_engine_type,
                 normalized_persisted_engine_type=normalized_persisted_engine,
                 normalized_runtime_engine_type=normalized_runtime_engine,
+                bolt_id=bolt_id,
             )
             if isinstance(selection, DefaultSkillSetSelection):
                 return (selection,)

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -278,11 +278,12 @@ class SkillSetService:
         return self._default_skill_set_selection_candidates(engine_type)[0]
 
     def _default_skill_set_selection_candidates(
-        self, engine_type: str | None = None
+        self, engine_type: str | None = None, bolt_id: str | None = None
     ) -> tuple[DefaultSkillSetSelection, ...]:
         return self._default_skill_set_selection_policy.resolve_candidates(
             persisted_engine_type=self.engine_type if engine_type is None else engine_type,
             runtime_engine_type=self.runtime_engine_type,
+            bolt_id=bolt_id,
         )
 
     def _default_skill_set_query_kwargs(
@@ -315,7 +316,9 @@ class SkillSetService:
     def _ordered_active_default_selections(
         self, *, bolt_id: str | None, engine_type: str | None
     ) -> tuple[DefaultSkillSetSelection, ...] | None:
-        candidates = self._default_skill_set_selection_candidates(engine_type)
+        candidates = self._default_skill_set_selection_candidates(
+            engine_type, bolt_id=bolt_id
+        )
         if (
             len(candidates) == 1
             and candidates[0].bolt_id is None
@@ -324,12 +327,9 @@ class SkillSetService:
             return None
 
         # Compatibility-only path. Keep the generic repository query primitive
-        # unchanged, and express the lookup order in the service layer:
-        # bot-scoped persisted default -> resolver-provided global fallbacks.
-        return (
-            DefaultSkillSetSelection(engine_type=engine_type, bolt_id=bolt_id),
-            *candidates,
-        )
+        # unchanged, and let engine-specific resolvers contribute the lookup
+        # order (for example: bot-scoped default -> global fallbacks).
+        return candidates
 
     def _get_all_active_skill_sets_with_default_fallback(
         self,
@@ -619,11 +619,29 @@ class SkillSetService:
             List of SkillSet dicts
         """
         effective_bolt_id = bolt_id if bolt_id else self.bot_id
-        return self.skill_set_repo.list_all(
-            user_id,
-            bolt_id=effective_bolt_id,
-            engine_type=self.engine_type,
+        selections = self._ordered_active_default_selections(
+            bolt_id=effective_bolt_id, engine_type=self.engine_type
         )
+        if selections is None:
+            return self.skill_set_repo.list_all(
+                user_id,
+                bolt_id=effective_bolt_id,
+                engine_type=self.engine_type,
+            )
+
+        first_result: list[dict] | None = None
+        for selection in selections:
+            result = self.skill_set_repo.list_all(
+                user_id=user_id,
+                bolt_id=effective_bolt_id,
+                engine_type=self.engine_type,
+                **self._default_skill_set_query_kwargs(self.engine_type, selection),
+            )
+            if first_result is None:
+                first_result = result
+            if self._has_default_skill_set(result):
+                return result
+        return first_result or []
 
     def update_skill_set(
         self,

--- a/src/backend/tests/community/core/skill_center/test_default_skill_set_selection_policy.py
+++ b/src/backend/tests/community/core/skill_center/test_default_skill_set_selection_policy.py
@@ -68,6 +68,33 @@ def test_registered_policy_orders_routed_claude_code_global_default_fallbacks():
     ]
 
 
+def test_registered_policy_orders_routed_claude_code_bot_then_global_fallbacks():
+    plan = get_default_skill_set_selection_policy().resolve_candidates(
+        persisted_engine_type="claude_code",
+        runtime_engine_type="aicoding",
+        bolt_id="bot-1",
+    )
+
+    assert [(item.engine_type, item.bolt_id) for item in plan] == [
+        ("claude_code", "bot-1"),
+        ("aicoding", "default"),
+        ("claude_code", "default"),
+    ]
+
+
+def test_registered_policy_does_not_duplicate_global_default_bolt_id():
+    plan = get_default_skill_set_selection_policy().resolve_candidates(
+        persisted_engine_type="claude_code",
+        runtime_engine_type="aicoding",
+        bolt_id="default",
+    )
+
+    assert [(item.engine_type, item.bolt_id) for item in plan] == [
+        ("aicoding", "default"),
+        ("claude_code", "default"),
+    ]
+
+
 def test_policy_accepts_single_selection_resolver_result():
     from agentclaw.community.core.skill_center.policies.default_skill_set_selection import (
         DefaultSkillSetSelection,

--- a/src/backend/tests/community/services/test_skill_set_service_engine_type.py
+++ b/src/backend/tests/community/services/test_skill_set_service_engine_type.py
@@ -326,6 +326,114 @@ def test_active_skill_sets_returns_first_result_when_no_default_candidate_exists
     assert repo.get_all_active_skill_sets.call_count == 3
 
 
+
+def test_list_skill_sets_uses_aicoding_scoped_default_candidates(tmp_path):
+    from agentclaw.community.core.bot_management.engines.registry import (
+        get_default_skill_set_selection_policy,
+    )
+
+    service = _make_skill_set_service_for_default_selection(
+        tmp_path,
+        engine_type="claude_code",
+        runtime_engine_type="aicoding",
+        default_skill_set_selection_policy=get_default_skill_set_selection_policy(),
+    )
+    repo = service.skill_set_repo
+    repo.list_all.side_effect = [
+        [{"id": "custom-1", "is_default": False}],
+        [{"id": "global-aicoding", "is_default": True}],
+    ]
+
+    result = service.list_skill_sets(user_id="owner", bolt_id="bot")
+
+    assert result == [{"id": "global-aicoding", "is_default": True}]
+    assert repo.list_all.call_count == 2
+    first_kwargs = repo.list_all.call_args_list[0].kwargs
+    second_kwargs = repo.list_all.call_args_list[1].kwargs
+    assert first_kwargs["bolt_id"] == "bot"
+    assert first_kwargs["engine_type"] == "claude_code"
+    assert first_kwargs["default_skill_set_bolt_id"] == "bot"
+    assert first_kwargs["default_skill_set_engine_type"] == "claude_code"
+    assert second_kwargs["bolt_id"] == "bot"
+    assert second_kwargs["engine_type"] == "claude_code"
+    assert second_kwargs["default_skill_set_bolt_id"] == "default"
+    assert second_kwargs["default_skill_set_engine_type"] == "aicoding"
+
+
+
+def test_list_skill_sets_keeps_normal_claude_code_query_shape_with_bot_id(tmp_path):
+    service = _make_skill_set_service_for_default_selection(
+        tmp_path,
+        engine_type="claude_code",
+        runtime_engine_type="claude_code",
+    )
+    repo = service.skill_set_repo
+    repo.list_all.return_value = []
+
+    assert service.list_skill_sets(user_id="owner", bolt_id="bot") == []
+
+    repo.list_all.assert_called_once()
+    call_args = repo.list_all.call_args.args
+    call_kwargs = repo.list_all.call_args.kwargs
+    assert call_args == ("owner",)
+    assert call_kwargs["bolt_id"] == "bot"
+    assert call_kwargs["engine_type"] == "claude_code"
+    assert "default_skill_set_bolt_id" not in call_kwargs
+    assert "default_skill_set_engine_type" not in call_kwargs
+
+
+def test_list_skill_sets_keeps_openclaw_query_shape_with_bot_id(tmp_path):
+    service = _make_skill_set_service_for_default_selection(
+        tmp_path,
+        engine_type="openclaw",
+        runtime_engine_type="openclaw",
+    )
+    repo = service.skill_set_repo
+    repo.list_all.return_value = []
+
+    assert service.list_skill_sets(user_id="owner", bolt_id="bot") == []
+
+    repo.list_all.assert_called_once()
+    call_args = repo.list_all.call_args.args
+    call_kwargs = repo.list_all.call_args.kwargs
+    assert call_args == ("owner",)
+    assert call_kwargs["bolt_id"] == "bot"
+    assert call_kwargs["engine_type"] == "openclaw"
+    assert "default_skill_set_bolt_id" not in call_kwargs
+    assert "default_skill_set_engine_type" not in call_kwargs
+
+
+def test_get_all_skill_sets_with_mcps_keeps_direct_list_all_for_routed_aicoding(tmp_path):
+    from agentclaw.community.core.bot_management.engines.registry import (
+        get_default_skill_set_selection_policy,
+    )
+
+    service = _make_skill_set_service_for_default_selection(
+        tmp_path,
+        engine_type="claude_code",
+        runtime_engine_type="aicoding",
+        default_skill_set_selection_policy=get_default_skill_set_selection_policy(),
+    )
+    service.entity_id = "owner"
+    repo = service.skill_set_repo
+    repo.list_all.return_value = [
+        {"id": "1", "is_default": False, "gmt_created": "2026-01-01"}
+    ]
+    repo.get_by_id.return_value = {"id": "1", "is_default": False}
+    repo.get_mcp_servers_in_set.return_value = []
+
+    result = service.get_all_skill_sets_with_mcps(user_id="owner", bolt_id="bot")
+
+    assert [item["id"] for item in result] == ["1"]
+    repo.list_all.assert_called_once()
+    call_kwargs = repo.list_all.call_args.kwargs
+    assert call_kwargs["user_id"] == "owner"
+    assert call_kwargs["bolt_id"] == "bot"
+    assert call_kwargs["engine_type"] == "claude_code"
+    assert "default_skill_set_bolt_id" not in call_kwargs
+    assert "default_skill_set_engine_type" not in call_kwargs
+    repo.get_mcp_servers_in_set.assert_called_once_with("1")
+
 def test_env_active_skill_sets_fallback_stops_when_default_exists(tmp_path):
     from agentclaw.community.core.bot_management.engines.registry import (
         get_default_skill_set_selection_policy,


### PR DESCRIPTION
## Summary
- Scope routed Claude Code default SkillSet fallback by the current bot_id/bolt_id before global defaults.
- Keep aicoding-specific fallback ordering inside the aicoding default SkillSet resolver.
- Keep openclaw and normal claude_code query shape unchanged.
- Minimal scope: only the /api/skillsets list path uses this bot-scoped list fallback; get_all_skill_sets_with_skills/get_all_skill_sets_with_mcps remain direct list_all calls.

## Compatibility and risk
- Affects routed Claude Code callers where persisted engine_type is claude_code and runtime_engine_type is aicoding.
- For a non-default bot_id, default lookup order becomes: claude_code + current bot_id, then aicoding + default, then claude_code + default.
- For bolt_id=default, duplicate default candidates are avoided.
- OpenClaw and normal Claude Code continue to call repositories without default_skill_set_bolt_id/default_skill_set_engine_type compatibility kwargs.
- with-skills and with-mcps service helpers are intentionally not widened in this PR to keep behavior change minimal.

## Tests
- uv run pytest tests/community/core/skill_center/test_default_skill_set_selection_policy.py tests/community/services/test_skill_set_service_engine_type.py -q --tb=short