### PR TITLE
feat: allow coding bots to ensure DIMA workspace

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/aicoding/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/aicoding/router.py
@@ -307,7 +307,9 @@ async def create_bot_dima_workspace(
     ctx: RequestContext = Depends(get_request_context),
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
 ) -> DimaWorkspaceResponse:
-    """为 applicationCoding bot 创建 DIMA 工作空间（幂等）。
+    """为 Coding bot 创建 DIMA 工作空间（幂等）。
+
+    支持 legacy applicationCoding，或 active_engine 为 claude_code/aicoding 的 Bot。
 
     使用场景：bot 创建时 DIMA 调用失败，前端检测到 template_config 中
     缺少 ``dima_space_id``，可调用本接口手动触发创建。

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -23,6 +23,7 @@ from agentclaw.community.core.bot_management.capabilities import (
 )
 from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
     AICODING_ENGINE_TYPE,
+    CLAUDE_CODE_ENGINE_TYPE,
 )
 from agentclaw.community.core.bot_management.engines.registry import (
     normalize_engine_type,
@@ -5667,7 +5668,7 @@ class BotService:
         return self._workspace_hosting_service
 
     def ensure_hosted_workspace(self, bot_id: str, user_id: str) -> Optional[str]:
-        """为 applicationCoding bot 确保 DIMA workspace 存在（幂等）。
+        """为 Coding bot 确保 DIMA workspace 存在（幂等）。
 
         创建 bot 时若 DIMA 调用失败，bot 仍会成功落库但 template_config 缺少
         ``dima_space_id``。此方法暴露给前端做手动补救：
@@ -5685,16 +5686,23 @@ class BotService:
 
         Raises:
             BotNotFoundError: bot 不存在或当前用户无权访问
-            BotServiceError: bot 不是 applicationCoding 模板
+            BotServiceError: bot 不是可托管 DIMA 工作空间的 Coding Bot
         """
         bot = self._repository.get_by_id_and_owner(bot_id, user_id)
         if not bot:
             raise BotNotFoundError(f"Bot not found: {bot_id}")
 
         template_type = bot.get("template_type")
-        if template_type != "applicationCoding":
+        active_engine = normalize_engine_type(
+            bot.get("active_engine") or bot.get("engine_type"),
+            default="",
+        )
+        is_legacy_application_coding = template_type == "applicationCoding"
+        is_coding_engine = active_engine in {AICODING_ENGINE_TYPE, CLAUDE_CODE_ENGINE_TYPE}
+        if not (is_legacy_application_coding or is_coding_engine):
             raise BotServiceError(
-                f"Bot {bot_id} 不是 applicationCoding 模板（template_type={template_type}），"
+                f"Bot {bot_id} 不是可创建 DIMA 工作空间的 Coding Bot"
+                f"（template_type={template_type}, active_engine={active_engine or None}），"
                 "无法创建 DIMA 工作空间"
             )
 

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_ensure_hosted_workspace.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_ensure_hosted_workspace.py
@@ -4,7 +4,7 @@ Covers:
 - 幂等：template_config 已有 dima_space_id → 直接返回不调 DIMA
 - 创建成功 → 调 DIMA + 持久化 template + 返回 workspace_id
 - bot 不存在 → BotNotFoundError
-- 非 applicationCoding → BotServiceError
+- 非 Coding Bot → BotServiceError
 - DIMA 报错 → 异常透出（不吞）
 - template_service 持久化失败 → workspace_id 仍返回（让前端可重试持久化）
 """
@@ -29,14 +29,23 @@ def _make_service():
     return svc
 
 
-def _make_app_coding_bot(bot_id: str = "bot-001", owner_id: str = "owner-1"):
-    return {
+def _make_app_coding_bot(
+    bot_id: str = "bot-001",
+    owner_id: str = "owner-1",
+    template_type: str = "applicationCoding",
+    active_engine: str | None = None,
+):
+    bot = {
         "id": 1,
         "bot_id": bot_id,
         "bot_name": "TestApp",
         "owner_id": owner_id,
-        "template_type": "applicationCoding",
+        "template_type": template_type,
     }
+    if active_engine is not None:
+        bot["active_engine"] = active_engine
+    return bot
+
 
 
 class TestEnsureDimaWorkspace:
@@ -125,22 +134,62 @@ class TestEnsureDimaWorkspace:
 
         svc._workspace_hosting_service.create_workspace_for_bot.assert_not_called()
 
-    def test_raises_for_non_application_coding_bot(self):
-        """template_type 不是 applicationCoding → BotServiceError。"""
+    def test_allows_non_application_coding_claude_code_bot(self):
+        """template_type 非 applicationCoding 但 active_engine=claude_code → 允许创建。"""
+        from agentclaw.community.core.bot_management.services.bot_service import BotService
+
+        svc = _make_service()
+        svc._repository.get_by_id_and_owner.return_value = _make_app_coding_bot(
+            template_type="normalCC",
+            active_engine="claude_code",
+        )
+        svc._template_service.get_template_config.return_value = {"foo": "bar"}
+
+        def fake_create(staff_id, bot_id, bot_name, template_config, raise_on_failure):
+            template_config["dima_space_id"] = "W_CC"
+            return "W_CC"
+
+        svc._workspace_hosting_service.create_workspace_for_bot.side_effect = fake_create
+
+        result = BotService.ensure_hosted_workspace(svc, "bot-001", "owner-1")
+
+        assert result == "W_CC"
+        svc._workspace_hosting_service.create_workspace_for_bot.assert_called_once()
+
+    def test_allows_non_application_coding_aicoding_bot(self):
+        """template_type 非 applicationCoding 但 active_engine=aicoding → 允许创建。"""
+        from agentclaw.community.core.bot_management.services.bot_service import BotService
+
+        svc = _make_service()
+        svc._repository.get_by_id_and_owner.return_value = _make_app_coding_bot(
+            template_type="personalCoding",
+            active_engine="aicoding",
+        )
+        svc._template_service.get_template_config.return_value = {}
+        svc._workspace_hosting_service.create_workspace_for_bot.return_value = "W_AI"
+
+        result = BotService.ensure_hosted_workspace(svc, "bot-001", "owner-1")
+
+        assert result == "W_AI"
+        svc._workspace_hosting_service.create_workspace_for_bot.assert_called_once()
+
+    def test_raises_for_non_coding_bot(self):
+        """既不是 legacy applicationCoding，也不是 claude_code/aicoding engine → BotServiceError。"""
         from agentclaw.community.core.bot_management.services.bot_service import (
             BotServiceError,
             BotService,
         )
 
         svc = _make_service()
-        bot = _make_app_coding_bot()
-        bot["template_type"] = "personal"
-        svc._repository.get_by_id_and_owner.return_value = bot
+        svc._repository.get_by_id_and_owner.return_value = _make_app_coding_bot(
+            template_type="personal",
+            active_engine="openclaw",
+        )
 
         with pytest.raises(BotServiceError) as exc_info:
             BotService.ensure_hosted_workspace(svc, "bot-001", "owner-1")
 
-        assert "applicationCoding" in str(exc_info.value)
+        assert "Coding Bot" in str(exc_info.value)
         svc._workspace_hosting_service.create_workspace_for_bot.assert_not_called()
 
     def test_propagates_dima_error(self):

--- a/src/backend/tests/community/endpoints/test_aicoding_hosted_workspace.py
+++ b/src/backend/tests/community/endpoints/test_aicoding_hosted_workspace.py
@@ -2,7 +2,7 @@
 
 Covers happy path (workspace created via the stub WorkspaceHostingService that
 DI binds under the test/singlebox profile → synthetic ``W_STUB_<bot_id>``) and
-error path (non-applicationCoding bot → 400 in app envelope).
+error path (non-coding bot → 400 in app envelope).
 """
 from __future__ import annotations
 
@@ -46,7 +46,7 @@ def _seed_app_coding_bot_without_dima(world):
 
 
 def _seed_non_app_coding_bot(world):
-    """personal bot (not applicationCoding) → ensure_hosted_workspace should reject."""
+    """personal openclaw bot (not Coding Bot) → ensure_hosted_workspace should reject."""
     make_staff_user(world, user_id="u_owner")
     bot_repo = world.get(BotRepository)
     bot_repo.insert({
@@ -59,8 +59,30 @@ def _seed_non_app_coding_bot(world):
         "entity_type": "staff",
         "creator_id": "u_owner",
         "template_type": "personal",
+        "active_engine": "openclaw",
     })
 
+
+
+def _seed_claude_code_bot_without_dima(world):
+    """Non-applicationCoding coding-engine bot should be allowed to create DIMA workspace."""
+    make_staff_user(world, user_id="u_owner")
+    bot_repo = world.get(BotRepository)
+    bot_repo.insert({
+        "bot_id": "bot_claude_code",
+        "bot_name": "ClaudeCodeBot",
+        "owner_id": "u_owner",
+        "bot_type": "personal",
+        "status": "ACTIVE",
+        "entity_id": "u_owner",
+        "entity_type": "staff",
+        "creator_id": "u_owner",
+        "template_type": "normalCC",
+        "active_engine": "claude_code",
+    })
+
+    template_svc = world.get(TemplateService)
+    template_svc.create_template(bot_id="bot_claude_code", template_config={"foo": "bar"})
 
 # ── Cases ──────────────────────────────────────────────────────────────────
 
@@ -90,7 +112,29 @@ def create_dima_workspace_ok():
 @endpoint_test(
     method="POST",
     path="/api/aicoding/bot/{bot_id}/dima-workspace",
-    scenario="error_non_app_coding",
+    scenario="ok_claude_code_non_app_coding",
+    input=CaseInput(
+        path_params={"bot_id": "bot_claude_code"},
+        query_params={"user_id": "u_owner"},
+        headers={"x-user-id": "u_owner"},
+    ),
+    seed=_seed_claude_code_bot_without_dima,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "success": True,
+            "data": {"dima_space_id": "W_STUB_bot_claude_code"},
+        },
+    ),
+)
+def create_dima_workspace_ok_for_claude_code_non_app_coding():
+    """Happy path: non-applicationCoding claude_code bot can create DIMA workspace."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/aicoding/bot/{bot_id}/dima-workspace",
+    scenario="error_non_coding",
     input=CaseInput(
         path_params={"bot_id": "bot_personal"},
         query_params={"user_id": "u_owner"},
@@ -103,4 +147,4 @@ def create_dima_workspace_ok():
     ),
 )
 def create_dima_workspace_error():
-    """Error: non-applicationCoding bot returns 400 in app envelope."""
+    """Error: non-coding bot returns 400 in app envelope."""


### PR DESCRIPTION
## Problem

The existing DIMA workspace ensure API only allows bots with `template_type=applicationCoding`.

This blocks newly introduced Coding Bot templates, such as `claude_code` / `aicoding` based template-factory bots, from creating or reusing a DIMA workspace through the existing frontend flow after bot creation.

As a result, the frontend cannot reliably call the existing DIMA workspace API for arbitrary Coding Bots unless they are legacy applicationCoding bots.

## Solution

Relax the backend guard in `BotService.ensure_hosted_workspace`.

Instead of only allowing `template_type=applicationCoding`, the API now allows:

- legacy `template_type=applicationCoding`
- bots with `active_engine=aicoding`
- bots with `active_engine=claude_code`
- normalized engine aliases such as `claude-code`

Non-Coding Bots are still rejected.

The existing API path remains unchanged:

```http
POST /api/aicoding/bot/{bot_id}/dima-workspace
```

This keeps the change minimal and avoids requiring frontend API migration in this step.

## Validation

Ran service-level tests:

```bash
cd /Users/tianxun/2024code/aix-coding-new/Avernet/src/backend
PYENV_VERSION=system uv run pytest tests/community/core/bot_management/services/test_bot_service_ensure_hosted_workspace.py -q
```

Result:

```text
12 passed, 17 warnings
```

Added / updated test coverage for:

- legacy applicationCoding bot DIMA workspace creation
- non-applicationCoding `claude_code` bot DIMA workspace creation
- non-applicationCoding `aicoding` bot DIMA workspace creation
- non-Coding Bot rejection

Endpoint-level test definitions were also updated to reflect the new allowed and rejected cases.

## Compatibility and risk

Backward compatible for existing applicationCoding bots.

No API path, request body, or response schema changes are introduced.

Risk is limited to broadening DIMA workspace creation eligibility from applicationCoding-only to Coding-engine bots. Non-Coding Bots continue to be rejected by backend validation.

Rollback path: restore the previous `template_type == "applicationCoding"` guard in `BotService.ensure_hosted_workspace`.

## Spec

This is the minimal backend step toward capability-driven DIMA workspace orchestration.

It enables the frontend to call the existing DIMA workspace creation API after creating any `claude_code` / `aicoding` Coding Bo