### PR TITLE
fix(backend): resolve publish provider from the bot, not the record's ext

### DIFF
--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_instance_service.py
@@ -104,15 +104,25 @@ class ExpertChatInstanceService:
         self._common_config_service = common_config_service
         self._image_policy_resolver = PublishImagePolicyResolver(
             publish_repository=bot_publish_repo,
-            binding_repository=binding_repo,
             common_config_service=common_config_service,
         )
 
-    def _resolve_publish_image_pin(
-        self, publish_record, *, bot_id: str | None = None, owner_id: str | None = None
-    ):
-        """Resolve through the shared seam; legacy caller args are ignored."""
-        return self._image_policy_resolver.resolve(publish_record)
+    def _resolve_publish_image_pin(self, publish_record, *, bot_id: str, owner_id: str):
+        """Resolve through the shared seam.
+
+        The image policy follows the bot's container, so the provider is resolved
+        from the bot here rather than sniffed out of the publish record's ``ext``.
+        """
+        bot_info = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
+        if not bot_info:
+            raise ConnectionError(
+                f"Bot not found: bot_id={bot_id} owner_id={owner_id}",
+                error_code="5001",
+            )
+        return self._image_policy_resolver.resolve(
+            publish_record,
+            device_provider=self._baas.resolve_container_provider(bot_info),
+        )
 
     # ------------------------------------------------------------------
     # Public entry
@@ -152,7 +162,9 @@ class ExpertChatInstanceService:
             bot_id, owner_id
         )
         version = publish_record.version or 1
-        image_pin = self._resolve_publish_image_pin(publish_record)
+        image_pin = self._resolve_publish_image_pin(
+            publish_record, bot_id=bot_id, owner_id=owner_id
+        )
 
         # --- Step 1: look up / create instance row ---
         instance = self._instance_repo.get_instance(user_id, bot_id, owner_id)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/arca_image_pin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/arca_image_pin.py
@@ -1,9 +1,16 @@
 """ARCA service-bot image policy helpers.
 
 New bots and successful draft restarts explicitly opt into the BaaS/ARCA
-default image. Published operations are reproducible: they read only the target
-publish record. Records created before the policy existed are lazily protected
-by the environment common-config and snapshot the configured image once.
+default image. The *image* a published operation ships is reproducible: it is
+read only from the target publish record. Records created before the policy
+existed are lazily protected by the environment common-config and snapshot the
+configured image once.
+
+Which *provider* a bot runs on is deliberately NOT a publish-record fact. The
+container follows the bot (``resolve_container_provider``) and its device
+binding; callers pass the resolved ``device_provider`` in rather than having it
+sniffed back out of the record's ``ext`` blob, so the image policy can never
+disagree with the container the build and release stages actually target.
 """
 from __future__ import annotations
 
@@ -13,6 +20,9 @@ from typing import Any, Callable
 
 from agentclaw.community.core.common_config.service import CommonConfigService
 from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
+from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
+    TECLAW_DEVICE_PROVIDER,
+)
 from agentclaw.community.log import get_logger
 
 logger = get_logger()
@@ -27,12 +37,6 @@ IMAGE_POLICY_KEYS = (
     IMAGE_PIN_ENABLED_KEY,
     IMAGE_PIN_VALUE_KEY,
 )
-SERVICE_BOT_RUNTIME_KIND_KEY = "sbot_runtime_kind"
-RUNTIME_KIND_ARCA = "arca"
-RUNTIME_KIND_TECLAW = "teclaw"
-_RUNTIME_KINDS = {RUNTIME_KIND_ARCA, RUNTIME_KIND_TECLAW}
-_LEGACY_RUNTIME_KIND_TYPO = "arka"
-
 
 
 class ImagePolicyState(str, Enum):
@@ -90,64 +94,6 @@ def resolve_current_arca_image(
     if isinstance(image, str) and image.strip():
         return image.strip()
     return None
-
-
-def runtime_kind_from_provider(device_provider: str | None) -> str | None:
-    if device_provider == RUNTIME_KIND_TECLAW:
-        return RUNTIME_KIND_TECLAW
-    if device_provider in {"arca", "baas"}:
-        return RUNTIME_KIND_ARCA
-    return None
-
-
-def apply_runtime_kind_to_ext(
-    ext: dict[str, Any] | None, runtime_kind: str | None
-) -> dict[str, Any] | None:
-    updated = dict(ext or {})
-    if runtime_kind in _RUNTIME_KINDS:
-        updated[SERVICE_BOT_RUNTIME_KIND_KEY] = runtime_kind
-    return updated or None
-
-
-def resolve_publish_runtime_kind(
-    publish_record: BotPublishRecord,
-    *,
-    binding_repository: Any | None = None,
-) -> str:
-    """Resolve runtime only from immutable publish-owned facts.
-
-    New records carry ``sbot_runtime_kind``. Historical TeClaw records are
-    recognized from their config artifact or stage bindings; the final fallback
-    is ARCA because ARCA predates the external-runtime publish format.
-    """
-    ext = publish_record.ext or {}
-    explicit = ext.get(SERVICE_BOT_RUNTIME_KIND_KEY)
-    if explicit == _LEGACY_RUNTIME_KIND_TYPO:
-        return RUNTIME_KIND_ARCA
-    if explicit in _RUNTIME_KINDS:
-        return explicit
-
-    artifact = ext.get("config_artifact")
-    if isinstance(artifact, dict) and artifact.get("engine_type") == RUNTIME_KIND_TECLAW:
-        return RUNTIME_KIND_TECLAW
-
-    binding_ids = (ext.get("binding") or {}).values() if isinstance(ext.get("binding"), dict) else ()
-    if binding_repository is not None:
-        for binding_id in binding_ids:
-            try:
-                resolved_binding_id = int(binding_id)
-            except (TypeError, ValueError):
-                continue
-            binding = binding_repository.get_by_id(resolved_binding_id)
-            kind = runtime_kind_from_provider(getattr(binding, "device_provider", None))
-            if kind is not None:
-                return kind
-
-    logger.warning(
-        "[arca_image_pin] publish runtime kind missing; using legacy ARCA fallback: publish_id=%s",
-        publish_record.id,
-    )
-    return RUNTIME_KIND_ARCA
 
 
 def has_explicit_image_policy(ext: dict[str, Any] | None) -> bool:
@@ -344,26 +290,35 @@ class PublishImagePolicyResolver:
         self,
         *,
         publish_repository: Any,
-        binding_repository: Any,
         common_config_service: CommonConfigService | None,
         max_cas_attempts: int = 3,
     ) -> None:
         self._publish_repository = publish_repository
-        self._binding_repository = binding_repository
         self._common_config_service = common_config_service
         self._max_cas_attempts = max_cas_attempts
 
-    def resolve(self, publish_record: BotPublishRecord) -> ServiceBotImagePin:
-        """Return only an explicit policy or a legacy decision persisted by CAS."""
+    def resolve(
+        self,
+        publish_record: BotPublishRecord,
+        *,
+        device_provider: str,
+    ) -> ServiceBotImagePin:
+        """Return only an explicit policy or a legacy decision persisted by CAS.
+
+        ``device_provider`` is the caller's already-resolved container token (the
+        same value that selects the build producer and the provider behavior). It
+        is required rather than re-derived here so the image policy and the
+        deployed container can never disagree.
+        """
         for _attempt in range(self._max_cas_attempts):
             latest = self._publish_repository.get_by_id(publish_record.id)
             if latest is None:
                 raise ImagePinPersistenceError(
                     f"Publish record disappeared while resolving image policy: {publish_record.id}"
                 )
-            if resolve_publish_runtime_kind(
-                latest, binding_repository=self._binding_repository
-            ) == RUNTIME_KIND_TECLAW:
+            # The teclaw container owns its own image; the ARCA policy — including
+            # the lazy legacy snapshot below — never applies to it.
+            if device_provider == TECLAW_DEVICE_PROVIDER:
                 publish_record.ext = latest.ext
                 return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/arca_image_pin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/arca_image_pin.py
@@ -6,6 +6,11 @@ read only from the target publish record. Records created before the policy
 existed are lazily protected by the environment common-config and snapshot the
 configured image once.
 
+:class:`PublishImagePolicyResolver` is the single entry point for that: it owns
+the repository read and the CAS write. ``image_policy_from_ext`` beside it is
+only the pure decoder it uses internally — it reads a record's existing policy
+and never acquires one, so it is not a second way to "resolve" the policy.
+
 Which *provider* a bot runs on is deliberately NOT a publish-record fact. The
 container follows the bot (``resolve_container_provider``) and its device
 binding; callers pass the resolved ``device_provider`` in rather than having it
@@ -16,7 +21,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable
+from typing import Any
 
 from agentclaw.community.core.common_config.service import CommonConfigService
 from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
@@ -64,9 +69,6 @@ class ServiceBotImagePin:
     def enabled(self) -> bool:
         """Backward-compatible pinned predicate."""
         return self.state == ImagePolicyState.PINNED
-
-
-PublishExtWriter = Callable[[dict[str, Any]], None]
 
 
 def resolve_current_arca_image(
@@ -159,27 +161,20 @@ def copy_image_policy_to_ext(
     return target or None
 
 
-def resolve_publish_image_pin(
-    publish_record: BotPublishRecord,
-    *,
-    common_config_service: CommonConfigService | None = None,
-    env: str | None = None,
-    persist_ext: PublishExtWriter | None = None,
-) -> ServiceBotImagePin:
-    """Resolve default/pinned/legacy policy from the target publish record.
+def image_policy_from_ext(publish_record: BotPublishRecord) -> ServiceBotImagePin:
+    """Decode the policy a publish record already carries on its ``ext``.
 
-    Explicit publish snapshots never consult common-config. A legacy record
-    consults it once; when enabled, the selected image is appended to ``ext``
-    through ``persist_ext`` before being used. Disabled/missing config leaves the
-    record legacy and uses the provider default for this operation.
+    Pure: no repository, no common-config, no writes. A record with no explicit
+    policy is LEGACY — deciding whether such a record should *acquire* one is the
+    persisted, CAS-backed job of :class:`PublishImagePolicyResolver`, which is the
+    only thing callers outside this module should use.
     """
     ext = dict(publish_record.ext or {})
     if ext.get(IMAGE_DEFAULT_KEY) is True:
         return ServiceBotImagePin(ImagePolicyState.DEFAULT, None)
 
-    pin_enabled = ext.get(IMAGE_PIN_ENABLED_KEY) is True
     image = read_image_pin_from_ext(ext)
-    if pin_enabled:
+    if ext.get(IMAGE_PIN_ENABLED_KEY) is True:
         if image is None:
             raise ImagePinConfigError(
                 f"Publish {publish_record.id} enables image Pin without a valid image"
@@ -192,24 +187,7 @@ def resolve_publish_image_pin(
             f"Publish {publish_record.id} has an inconsistent image policy snapshot"
         )
 
-    image = resolve_current_arca_image(
-        common_config_service,
-        env=env or publish_record.env,
-    )
-    if image is None:
-        return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
-
-    pinned_ext = apply_image_pin_to_ext(ext, image)
-    if persist_ext is not None:
-        persist_ext(pinned_ext)
-    publish_record.ext = pinned_ext
-    logger.info(
-        "[arca_image_pin] snapshotted legacy publish image: publish_id=%s env=%s image=%s",
-        publish_record.id,
-        env or publish_record.env,
-        image,
-    )
-    return ServiceBotImagePin(ImagePolicyState.PINNED, image)
+    return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
 
 
 def persist_default_image_policy(
@@ -324,7 +302,7 @@ class PublishImagePolicyResolver:
 
             if has_explicit_image_policy(latest.ext):
                 publish_record.ext = latest.ext
-                return resolve_publish_image_pin(latest)
+                return image_policy_from_ext(latest)
 
             image = resolve_current_arca_image(
                 self._common_config_service, env=latest.env
@@ -348,7 +326,7 @@ class PublishImagePolicyResolver:
                     updated.env,
                     image,
                 )
-                return resolve_publish_image_pin(updated)
+                return image_policy_from_ext(updated)
 
         raise ImagePinPersistenceError(
             f"Publish image policy CAS conflicted repeatedly: publish_id={publish_record.id}"

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -30,13 +30,8 @@ from agentclaw.community.core.service_bot.services.arca_image_pin import (
     copy_image_policy_to_ext,
     has_explicit_image_policy,
     resolve_current_arca_image,
-    apply_runtime_kind_to_ext,
-    runtime_kind_from_provider,
-    RUNTIME_KIND_ARCA,
-    RUNTIME_KIND_TECLAW,
     PublishImagePolicyResolver,
     ServiceBotImagePin,
-    resolve_publish_runtime_kind,
 )
 from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
 from agentclaw.community.core.service_bot.types import PublishStage
@@ -84,7 +79,6 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         self._common_config_service = common_config_service
         self._image_policy_resolver = PublishImagePolicyResolver(
             publish_repository=bot_publish_repo,
-            binding_repository=device_binding_repo,
             common_config_service=common_config_service,
         )
         self._env = get_current_env()
@@ -236,23 +230,17 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
             source_bot.get("ext") if isinstance(source_bot, dict) else None
         )
         ext = copy_image_policy_to_ext(source_bot_ext, ext)
+        # The provider is NOT snapshotted onto the record: the container follows
+        # the bot's engine, and every later stage re-asks the bot. Only the
+        # resolved ARCA *image* is frozen here.
+        is_arca_service = (
+            isinstance(source_bot, dict)
+            and source_bot.get("bot_type") == "service"
+            and not self._bot_service.is_teclaw_bot(source_bot.get("active_engine"))
+        )
         image_policy_image: str | None = None
         if isinstance(source_bot, dict) and source_bot.get("bot_type") == "service":
-            runtime_kind = None
-            binding_id = source_bot.get("binding_id")
-            if isinstance(binding_id, int):
-                binding = self._device_binding_repo.get_by_id(binding_id)
-                runtime_kind = runtime_kind_from_provider(
-                    getattr(binding, "device_provider", None)
-                )
-            if runtime_kind is None:
-                runtime_kind = (
-                    RUNTIME_KIND_TECLAW
-                    if self._bot_service.is_teclaw_bot(source_bot.get("active_engine"))
-                    else RUNTIME_KIND_ARCA
-                )
-            ext = apply_runtime_kind_to_ext(ext, runtime_kind)
-            if runtime_kind == RUNTIME_KIND_ARCA:
+            if is_arca_service:
                 image_policy_image = resolve_current_arca_image(
                     self._common_config_service, env=self._env
                 )
@@ -264,10 +252,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         # protection is enabled, freeze the configured image on the new publish
         # record so all published operations remain reproducible.
         is_legacy_arca_service = (
-            isinstance(source_bot, dict)
-            and source_bot.get("bot_type") == "service"
-            and not self._bot_service.is_teclaw_bot(source_bot.get("active_engine"))
-            and not has_explicit_image_policy(source_bot_ext)
+            is_arca_service and not has_explicit_image_policy(source_bot_ext)
         )
         if is_legacy_arca_service and image_policy_image:
             ext = apply_image_pin_to_ext(ext, image_policy_image)
@@ -441,16 +426,18 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         )
 
     def resolve_publish_image_pin(
-        self, publish_record: BotPublishRecord
+        self,
+        publish_record: BotPublishRecord,
+        *,
+        device_provider: str,
     ) -> ServiceBotImagePin:
-        """Resolve image policy through the shared persisted-CAS seam."""
-        return self._image_policy_resolver.resolve(publish_record)
+        """Resolve image policy through the shared persisted-CAS seam.
 
-    def resolve_publish_runtime_kind(self, publish_record: BotPublishRecord) -> str:
-        """Resolve provider identity only from Publish-owned persisted facts."""
-        return resolve_publish_runtime_kind(
-            publish_record,
-            binding_repository=self._device_binding_repo,
+        ``device_provider`` is the caller's resolved container token; the policy
+        never re-derives the provider from the record's ``ext``.
+        """
+        return self._image_policy_resolver.resolve(
+            publish_record, device_provider=device_provider
         )
 
     def record_draft_artifact(

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -431,7 +431,12 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         *,
         device_provider: str,
     ) -> ServiceBotImagePin:
-        """Resolve image policy through the shared persisted-CAS seam.
+        """Resolve image policy through :class:`PublishImagePolicyResolver`.
+
+        This is *the* image-policy operation: it re-reads the record, may
+        lazily snapshot the configured ARCA image under CAS, and returns the
+        resulting policy. (``arca_image_pin.image_policy_from_ext`` is only the
+        pure decoder the resolver uses internally.)
 
         ``device_provider`` is the caller's resolved container token; the policy
         never re-derives the provider from the record's ``ext``.

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_draft_restore_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_draft_restore_mixin.py
@@ -13,10 +13,6 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishStatus,
 )
 from agentclaw.community.core.repository.protocols.publishing import PublishOperationRepository
-from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
-    TECLAW_DEVICE_PROVIDER,
-    resolve_device_provider,
-)
 from agentclaw.community.core.service_bot.services.publish_exceptions import (
     BotPublishServiceError,
     PublishNotFoundError,
@@ -124,19 +120,13 @@ class PublishDraftRestoreMixin:
         if bot is None:
             return draft, target, f"Bot不存在: {draft.source_bot_id}"
 
-        target_ext = target.ext or {}
-        device_provider = resolve_device_provider(
-            bot.get("active_engine") if isinstance(bot, dict) else None
-        )
-        is_teclaw = device_provider == TECLAW_DEVICE_PROVIDER
-        if is_teclaw:
-            config_artifact = target_ext.get("config_artifact")
-            if not isinstance(config_artifact, dict):
-                return draft, target, "上一版本没有可用的 config_artifact 构造物"
-            if config_artifact.get("engine_type") != TECLAW_DEVICE_PROVIDER:
-                return draft, target, "上一版本的 config_artifact 不是 teclaw 构造物"
-        elif not target_ext.get("migration_path"):
-            return draft, target, "上一版本没有可用的 migration_path 构造物"
+        # Same artifact rule the executing restore applies, through the same
+        # provider seam — the preflight must never answer for a different
+        # provider than ``execute_restore_draft`` will actually use.
+        behavior = self._publish_flow_service_provider().provider_behavior(bot)
+        invalid_reason = behavior.validate_draft_restore_artifact(target.ext or {})
+        if invalid_reason:
+            return draft, target, invalid_reason
         return draft, target, "可以恢复草稿"
 
     def can_restore_draft(self, publish_id: int) -> tuple[bool, str, dict | None]:

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/draft_restore_ops_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/draft_restore_ops_mixin.py
@@ -157,7 +157,7 @@ class DraftRestoreOpsMixin:
                     f"草稿容器未就绪: binding_id={binding_id}, status={binding.status}"
                 )
 
-            behavior = self._provider_behavior(bot)
+            behavior = self.provider_behavior(bot)
             invalid_reason = behavior.validate_draft_restore_artifact(source_ext)
             if invalid_reason:
                 raise PublishFlowServiceError(invalid_reason)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/eval_publish_mixin.py
@@ -71,7 +71,9 @@ class EvalPublishMixin:
         # config_artifact read above is only the build-artifact presence guard. Eval
         # does not persist, so the applied overrides are discarded.
         delivery, _ = self._ext_state.compose_live(publish_record, publish_stage)
-        image_pin = self.resolve_publish_image_pin(publish_record)
+        image_pin = self.resolve_publish_image_pin(
+            publish_record, device_provider=self.device_provider(bot)
+        )
 
         ext_info = {}
         if biz_id:
@@ -100,7 +102,6 @@ class EvalPublishMixin:
                 delivery=delivery,
                 ext_info=ext_info,
                 docker_image=image_pin.docker_image,
-                runtime_kind=self.resolve_publish_runtime_kind(publish_record),
                 template_config=service_publish_template_config(bot),
             )
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/image_policy_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/image_policy_mixin.py
@@ -1,35 +1,41 @@
-"""Publish-record ARCA image-policy resolution."""
+"""Publish-record ARCA image-policy resolution + the provider seam it shares.
+
+Provider identity is a fact about the *bot's container*, not about the publish
+record: it is resolved through ``BaasService.resolve_container_provider`` — the
+same call the build stage makes to pick the artifact producer — so build and
+every later deploy stage can never disagree. The publish record's ``ext`` holds
+the frozen build artifact and the frozen image, never the provider.
+"""
 
 from __future__ import annotations
 
 from agentclaw.community.core.service_bot.repository.models import BotPublishRecord
 from agentclaw.community.core.service_bot.services.arca_image_pin import (
-    RUNTIME_KIND_TECLAW,
     ServiceBotImagePin,
 )
-from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
-    DEFAULT_DEVICE_PROVIDER,
-    TECLAW_DEVICE_PROVIDER,
+from agentclaw.community.core.service_bot.services.publish_flow.provider_behavior import (
+    ProviderBehavior,
 )
 
 
 class PublishImagePolicyMixin:
-    """Delegate every publish path to the shared persisted policy resolver."""
+    """Provider resolution + the shared persisted image-policy resolver."""
+
+    def device_provider(self, bot: dict) -> str:
+        """``bot``'s container token — the single provider question in the flow."""
+        return self._baas_service.resolve_container_provider(bot)
+
+    def provider_behavior(self, bot: dict) -> ProviderBehavior:
+        """The :class:`ProviderBehavior` for ``bot``'s container, resolved via the
+        same ``resolve_container_provider`` mapping used for producer selection."""
+        return self._provider_behaviors.resolve(self.device_provider(bot))
 
     def resolve_publish_image_pin(
-        self, publish_record: BotPublishRecord
+        self,
+        publish_record: BotPublishRecord,
+        *,
+        device_provider: str,
     ) -> ServiceBotImagePin:
-        return self._publish_service.resolve_publish_image_pin(publish_record)
-
-    def resolve_publish_runtime_kind(self, publish_record: BotPublishRecord) -> str:
-        return self._publish_service.resolve_publish_runtime_kind(publish_record)
-
-    def _publish_provider_behavior(self, publish_record: BotPublishRecord):
-        """Resolve behavior from immutable Publish metadata/bindings."""
-        runtime_kind = self.resolve_publish_runtime_kind(publish_record)
-        provider = (
-            TECLAW_DEVICE_PROVIDER
-            if runtime_kind == RUNTIME_KIND_TECLAW
-            else DEFAULT_DEVICE_PROVIDER
+        return self._publish_service.resolve_publish_image_pin(
+            publish_record, device_provider=device_provider
         )
-        return self._provider_behaviors.resolve(provider)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/progress_sync_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/progress_sync_mixin.py
@@ -172,7 +172,7 @@ class ProgressSyncMixin:
         if not bot:
             return
         try:
-            self._publish_provider_behavior(publish_record).refresh_after_upgrade(
+            self.provider_behavior(bot).refresh_after_upgrade(
                 bot_uuid=binding.device_id, bot=bot
             )
         except Exception as e:
@@ -259,7 +259,7 @@ class ProgressSyncMixin:
                 f"Bot does not exist: {publish_record.source_bot_id}"
             )
 
-        if not self._publish_provider_behavior(publish_record).destroys_verify_bot_on_online:
+        if not self.provider_behavior(bot).destroys_verify_bot_on_online:
             logger.info(
                 "[PublishFlowService._destroy_verify_bot_after_online_success] "
                 "Skip destroying verify BaaS bot for this provider: "

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/provider_behavior.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/provider_behavior.py
@@ -10,7 +10,8 @@ This is deliberately distinct from the artifact *producer* seam
 (``deploy/producer.py``): the producer *builds* the artifact for a
 ``(bot, version)`` at build time; this owns the *deploy-time* steps that differ
 by container — post-build file staging, post-upgrade MCP-rule refresh, whether
-scale is supported, and whether the verify bot is destroyed on online success.
+scale is supported, whether an upgrade can revive a not-live bot, and whether the
+verify bot is destroyed on online success.
 """
 from __future__ import annotations
 
@@ -114,6 +115,16 @@ class ProviderBehavior(ABC):
 
     @property
     @abstractmethod
+    def upgrade_recovers_not_live_bot(self) -> bool:
+        """Whether an upgrade can revive a candidate BaaS bot that is no longer
+        live (``FAILED`` / ``STOPPED``). ``True`` when the provider's UPDATE
+        destroys and recreates the device in place; ``False`` when it cannot
+        rebuild a gone container, so the online deploy must retire the candidate
+        and release a fresh one instead."""
+        ...
+
+    @property
+    @abstractmethod
     def destroys_verify_bot_on_online(self) -> bool:
         """Whether the verify-stage BaaS bot is torn down after online success."""
         ...
@@ -123,8 +134,9 @@ class DefaultProviderBehavior(ProviderBehavior):
     """ARCA / baas container behavior — the historical default (no teclaw steps).
 
     Files already mirror to storage (no snapshot needed), an ARCA upgrade rebuilds
-    the container and refreshes MCP auth via its startup callback, scale is
-    supported, and the verify bot is destroyed once online succeeds.
+    the container and refreshes MCP auth via its startup callback (so an upgrade
+    also revives a FAILED/STOPPED bot), scale is supported, and the verify bot is
+    destroyed once online succeeds.
     """
 
     async def stage_build_files(
@@ -177,6 +189,12 @@ class DefaultProviderBehavior(ProviderBehavior):
         return True
 
     @property
+    def upgrade_recovers_not_live_bot(self) -> bool:
+        # The ARCA/baas UPDATE destroys + recreates the device in place, so a
+        # FAILED/STOPPED candidate is recovered by upgrading it.
+        return True
+
+    @property
     def destroys_verify_bot_on_online(self) -> bool:
         return True
 
@@ -188,8 +206,9 @@ class TeclawProviderBehavior(ProviderBehavior):
     of them), so a build snapshots ``/workspace`` + identity files into OSS and
     embeds the refs;
     a teclaw upgrade has no startup callback, so the MCP outbound rule is refreshed
-    explicitly; teclaw service bots do not support scale; and the verify bot is
-    kept (not destroyed) when online succeeds.
+    explicitly; its UPDATE cannot rebuild a gone container, so a not-live bot is
+    retired rather than upgraded; teclaw service bots do not support scale; and the
+    verify bot is kept (not destroyed) when online succeeds.
     """
 
     def __init__(
@@ -284,6 +303,13 @@ class TeclawProviderBehavior(ProviderBehavior):
 
     @property
     def supports_scale(self) -> bool:
+        return False
+
+    @property
+    def upgrade_recovers_not_live_bot(self) -> bool:
+        # A teclaw UPDATE cannot rebuild a gone container — it would just fail the
+        # publish and strand the record, so a not-live candidate is retired and
+        # replaced by a fresh first release.
         return False
 
     @property

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/publish_ext_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/publish_ext_mixin.py
@@ -12,9 +12,6 @@ from __future__ import annotations
 import copy
 
 from agentclaw.community.core.service_bot.repository.models import PublishStatus
-from agentclaw.community.core.service_bot.services.publish_flow.errors import (
-    PublishFlowServiceError,
-)
 from agentclaw.community.core.service_bot.types import PublishStage
 from agentclaw.community.log import get_logger
 
@@ -46,12 +43,7 @@ class PublishExtMixin:
         expected_ext = copy.deepcopy(ext)
         ext.setdefault("binding", {})[stage.value] = binding_id
         ext.setdefault("publish", {})[stage.value] = baas_publish_id
-        publish_record = self.get_publish_record(publish_id)
-        if publish_record is None:
-            raise PublishFlowServiceError(
-                f"Publish record not found: publish_id={publish_id}"
-            )
-        self._publish_provider_behavior(publish_record).persist_stage_promotion(
+        self.provider_behavior(bot).persist_stage_promotion(
             ext=ext, stage=stage, engine_overrides=engine_overrides
         )
         self._update_publish_status(

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/release_stage.py
@@ -27,7 +27,6 @@ from agentclaw.community.core.service_bot.repository.models import (
 from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.service_bot.services.arca_image_pin import (
-    RUNTIME_KIND_TECLAW,
     ServiceBotImagePin,
 )
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
@@ -37,9 +36,6 @@ from agentclaw.community.core.service_bot.services.publish_flow.ext_state import
 from agentclaw.community.core.service_bot.services.publish_flow.provider_behavior import (
     ProviderBehavior,
     ProviderBehaviorRouter,
-)
-from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
-    TECLAW_DEVICE_PROVIDER,
 )
 from agentclaw.community.core.service_bot.services.publish_flow.operation_runner import (
     PublishOperationRunner,
@@ -91,10 +87,9 @@ class ReleaseRecordOps(Protocol):
     def resolve_publish_image_pin(
         self,
         publish_record: BotPublishRecord,
+        *,
+        device_provider: str,
     ) -> ServiceBotImagePin: ...
-
-    def resolve_publish_runtime_kind(self, publish_record: BotPublishRecord) -> str: ...
-
 
 
 @dataclass(frozen=True)
@@ -158,14 +153,13 @@ class ReleaseStageRunner:
         self._ops = ops
         self._operation_runner = operation_runner
 
-    def _provider_behavior(self, publish_record: BotPublishRecord) -> ProviderBehavior:
-        """Provider behavior frozen by the target Publish contract."""
-        runtime_kind = self._ops.resolve_publish_runtime_kind(publish_record)
-        return self._provider_behaviors.resolve(
-            TECLAW_DEVICE_PROVIDER
-            if runtime_kind == RUNTIME_KIND_TECLAW
-            else "baas"
-        )
+    def _device_provider(self, bot: dict) -> str:
+        """``bot``'s container token — the same ``resolve_container_provider``
+        mapping the build stage uses to pick the artifact producer."""
+        return self._baas_service.resolve_container_provider(bot)
+
+    def _provider_behavior(self, device_provider: str) -> ProviderBehavior:
+        return self._provider_behaviors.resolve(device_provider)
 
     async def first_release(
         self,
@@ -183,7 +177,9 @@ class ReleaseStageRunner:
         publish_id = publish_record.id
         owner_id = self._ext_state.owner_id(publish_record)
         skills_env = service_publish_extra_envs(publish_record.ext, bot)
-        image_pin = self._ops.resolve_publish_image_pin(publish_record)
+        image_pin = self._ops.resolve_publish_image_pin(
+            publish_record, device_provider=self._device_provider(bot)
+        )
 
         # Compose through the single delivery seam (LIVE overrides re-fetch); the raw
         # ext['config_artifact'] is never handed to BaaS. ``overrides`` is the applied
@@ -208,7 +204,6 @@ class ReleaseStageRunner:
                 delivery=delivery,
                 extra_envs=skills_env,
                 docker_image=image_pin.docker_image,
-                runtime_kind=self._ops.resolve_publish_runtime_kind(publish_record),
                 template_config=service_publish_template_config(bot),
             )
             if spec.first_release_passes_version:
@@ -285,7 +280,10 @@ class ReleaseStageRunner:
         version = f"{publish_record.version}"
         owner_id = self._ext_state.owner_id(publish_record)
         skills_env = service_publish_extra_envs(publish_record.ext, bot)
-        image_pin = self._ops.resolve_publish_image_pin(publish_record)
+        device_provider = self._device_provider(bot)
+        image_pin = self._ops.resolve_publish_image_pin(
+            publish_record, device_provider=device_provider
+        )
 
         # Compose through the single delivery seam (LIVE overrides re-fetch); the raw
         # ext['config_artifact'] is never handed to BaaS. ``overrides`` is the applied
@@ -309,7 +307,6 @@ class ReleaseStageRunner:
                 delivery=delivery,
                 extra_envs=skills_env,
                 docker_image=image_pin.docker_image,
-                runtime_kind=self._ops.resolve_publish_runtime_kind(publish_record),
                 template_config=service_publish_template_config(bot),
             )
 
@@ -360,7 +357,7 @@ class ReleaseStageRunner:
         ext, expected_ext = self._ext_state.get_latest_ext_snapshot(publish_id)
         ext.setdefault("binding", {})[spec.stage.value] = existing_binding_id
         ext.setdefault("publish", {})[spec.stage.value] = baas_publish_id
-        self._provider_behavior(publish_record).persist_stage_promotion(
+        self._provider_behavior(device_provider).persist_stage_promotion(
             ext=ext, stage=spec.stage, engine_overrides=overrides
         )
         self._ops.refresh_publish_handle(existing_binding_id, baas_publish_id)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/restart_mixin.py
@@ -304,7 +304,9 @@ class RestartMixin:
         # so restarting a non-latest stage never delivers another stage's channels.
         delivery = self._ext_state.compose_stored(publish_record.ext or {}, stage_enum)
         skills_env = service_publish_extra_envs(publish_record.ext, bot)
-        image_pin = self.resolve_publish_image_pin(publish_record)
+        image_pin = self.resolve_publish_image_pin(
+            publish_record, device_provider=self.device_provider(bot)
+        )
 
         # A prior recreate that crashed between its ext write and its
         # complete_operation left a dangling op. That crashed leg IS this restart
@@ -402,7 +404,6 @@ class RestartMixin:
                 delivery=delivery,
                 extra_envs=skills_env,
                 docker_image=image_pin.docker_image,
-                runtime_kind=self.resolve_publish_runtime_kind(publish_record),
                 template_config=service_publish_template_config(bot),
             )
         # NOTE: transient errors out of the atom are NOT caught + failed here. A
@@ -583,7 +584,6 @@ class RestartMixin:
                 delivery=delivery,
                 extra_envs=skills_env,
                 docker_image=docker_image,
-                runtime_kind=self.resolve_publish_runtime_kind(publish_record),
                 template_config=service_publish_template_config(bot),
             )
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/rollback_ops_mixin.py
@@ -116,7 +116,9 @@ class RollbackOpsMixin:
         version = f"{target_record.version}"
         delivery = self._ext_state.compose_stored(target_ext, PublishStage.ONLINE)
         skills_env = service_publish_extra_envs(target_ext, bot)
-        image_pin = self.resolve_publish_image_pin(target_record)
+        image_pin = self.resolve_publish_image_pin(
+            target_record, device_provider=self.device_provider(bot)
+        )
 
         # (#197) Crash-safe issuance via the operation runner (existing bot →
         # adopt-by-query on resume, never a second rollback deploy).
@@ -140,7 +142,6 @@ class RollbackOpsMixin:
                 delivery=delivery,
                 extra_envs=skills_env,
                 docker_image=image_pin.docker_image,
-                runtime_kind=self.resolve_publish_runtime_kind(target_record),
                 template_config=service_publish_template_config(bot),
             )
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/scale_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/scale_mixin.py
@@ -59,13 +59,13 @@ class ScaleMixin:
         if not bot:
             raise PublishFlowServiceError(f"Bot does not exist: {publish_record.source_bot_id}")
 
-        publish_runtime_kind = self.resolve_publish_runtime_kind(publish_record)
-        if not self._publish_provider_behavior(publish_record).supports_scale:
+        device_provider = self.device_provider(bot)
+        if not self._provider_behaviors.resolve(device_provider).supports_scale:
             return {
                 "success": True,
                 "message": "Service bots on the teclaw engine do not support scaling",
                 "publish_id": publish_id,
-                "engine": publish_runtime_kind,
+                "engine": device_provider,
                 "supported": True,
             }
 
@@ -90,7 +90,9 @@ class ScaleMixin:
 
         bot_uuid = binding.device_id
         target_count = self._resolve_scale_target_count(publish_record)
-        image_pin = self.resolve_publish_image_pin(publish_record)
+        image_pin = self.resolve_publish_image_pin(
+            publish_record, device_provider=device_provider
+        )
         pinned_image = image_pin.docker_image
         scale_config = (
             {"deploy_config": {"docker_image": pinned_image}}

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/upgrade_resolution_mixin.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/upgrade_resolution_mixin.py
@@ -18,9 +18,6 @@ from __future__ import annotations
 from agentclaw.community.core.service_bot.repository.models import (
     BotPublishRecord,
 )
-from agentclaw.community.core.service_bot.services.arca_image_pin import (
-    RUNTIME_KIND_TECLAW,
-)
 from agentclaw.community.core.service_bot.services.publish_flow.errors import (
     PublishFlowServiceError,
 )
@@ -183,10 +180,12 @@ class UpgradeResolutionMixin:
           rejects any new publish of a different type while it runs, so neither an
           UPGRADE nor a retire could land — the durable task retries until it
           settles to ``STOPPED``.
-        - ``FAILED`` / ``STOPPED`` → ``UPGRADE`` for ``baas``/ARCA (the UPDATE
-          destroys+recreates the device in place and recovers it), but
-          ``RETIRE_THEN_FIRST_RELEASE`` for teclaw (its UPDATE cannot rebuild a
-          gone container — it would just fail the publish and strand the record).
+        - ``FAILED`` / ``STOPPED`` → decided by the container's
+          ``ProviderBehavior.upgrade_recovers_not_live_bot``: ``UPGRADE`` for
+          ``baas``/ARCA (the UPDATE destroys+recreates the device in place and
+          recovers it), ``RETIRE_THEN_FIRST_RELEASE`` for teclaw (its UPDATE
+          cannot rebuild a gone container — it would just fail the publish and
+          strand the record).
         - anything else (``PENDING``/unknown) → ``UPGRADE`` (optimistic; the deploy
           atom / progress poll settles a still-provisioning bot).
 
@@ -232,19 +231,17 @@ class UpgradeResolutionMixin:
             )
 
         if status in _ONLINE_NOT_LIVE_BAAS_STATUSES:
-            is_teclaw = (
-                self.resolve_publish_runtime_kind(publish_record)
-                == RUNTIME_KIND_TECLAW
-            )
+            device_provider = self.device_provider(bot)
+            behavior = self._provider_behaviors.resolve(device_provider)
             decision = (
-                OnlineDeployDecision.RETIRE_THEN_FIRST_RELEASE
-                if is_teclaw
-                else OnlineDeployDecision.UPGRADE
+                OnlineDeployDecision.UPGRADE
+                if behavior.upgrade_recovers_not_live_bot
+                else OnlineDeployDecision.RETIRE_THEN_FIRST_RELEASE
             )
             logger.info(
                 f"[PublishFlowService._decide_online_deploy] "
                 f"candidate not live: bot_uuid={bot_uuid}, status={status}, "
-                f"is_teclaw={is_teclaw} -> {decision.value}"
+                f"provider={device_provider} -> {decision.value}"
             )
             return decision
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
@@ -486,13 +486,6 @@ class PublishFlowService(
             action="process",
         )
 
-    def _provider_behavior(self, bot: dict):
-        """The :class:`ProviderBehavior` for ``bot``'s container, resolved via the
-        same ``resolve_container_provider`` mapping used for producer selection."""
-        return self._provider_behaviors.resolve(
-            self._baas_service.resolve_container_provider(bot)
-        )
-
     # ── phase entry points for the durable task handlers ─────────────────────
     # Public: the task handlers (publish_flow/tasks.py) are an external consumer
     # (queue-adapter layer, own lifecycle) — these three phase methods ARE the

--- a/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
+++ b/src/backend/tests/community/core/expert_chat/services/test_expert_chat_instance_service.py
@@ -152,11 +152,12 @@ def _wire_bot_build_service_async(bot_build_service, create_result=None, upgrade
 class TestResolvePublishImagePin:
     def test_teclaw_skips_arca_policy_resolution(self):
         svc, _, baas, _, bot_repo, *_ = _make_service()
-        record = MockPublishRecord(
-            ext={"migration_path": "/nas/path", "sbot_runtime_kind": "teclaw"}
-        )
+        record = MockPublishRecord(ext={"migration_path": "/nas/path"})
         publish_repo = svc._publish_repo
         publish_repo.get_by_id.return_value = record
+        # The container follows the bot, not anything cached on the record.
+        bot_repo.get_by_id_and_owner.return_value = {"active_engine": "teclaw"}
+        baas.resolve_container_provider.return_value = "teclaw"
 
         resolved = svc._resolve_publish_image_pin(
             record,

--- a/src/backend/tests/community/core/service_bot/services/test_arca_image_pin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_arca_image_pin.py
@@ -17,7 +17,7 @@ from agentclaw.community.core.service_bot.services.arca_image_pin import (
     overlay_image_pin_on_template_config,
     persist_default_image_policy,
     resolve_current_arca_image,
-    resolve_publish_image_pin,
+    image_policy_from_ext,
 )
 
 
@@ -144,80 +144,44 @@ def test_publish_copy_supports_default_and_clears_stale_target_policy():
     }
 
 
-def test_resolve_publish_image_pin_reads_only_publish_ext():
+def test_image_policy_from_ext_reads_a_pin_snapshot():
     record = _record({"sbot_pin_image": True, "sbot_docker_image": "arca:v2"})
-    common_config = MagicMock()
 
-    resolved = resolve_publish_image_pin(
-        record, common_config_service=common_config
-    )
+    resolved = image_policy_from_ext(record)
 
     assert resolved.enabled is True
     assert resolved.state == ImagePolicyState.PINNED
     assert resolved.docker_image == "arca:v2"
-    common_config.get_value.assert_not_called()
 
 
-def test_resolve_default_publish_does_not_read_common_config():
-    common_config = MagicMock()
-
-    resolved = resolve_publish_image_pin(
-        _record({"sbot_use_default_image": True, "other": 1}),
-        common_config_service=common_config,
+def test_image_policy_from_ext_reads_a_default_marker():
+    resolved = image_policy_from_ext(
+        _record({"sbot_use_default_image": True, "other": 1})
     )
 
     assert resolved.state == ImagePolicyState.DEFAULT
     assert resolved.docker_image is None
-    common_config.get_value.assert_not_called()
 
 
-def test_resolve_legacy_publish_with_disabled_config_keeps_platform_default():
-    common_config = MagicMock()
-    common_config.get_value.return_value = None
-    persist = MagicMock()
+def test_image_policy_from_ext_is_legacy_without_an_explicit_policy():
+    """Acquiring a policy is PublishImagePolicyResolver's job, not this decoder's."""
+    record = _record({"migration_path": "/build/v1"})
 
-    resolved = resolve_publish_image_pin(
-        _record({"migration_path": "/build/v1"}),
-        common_config_service=common_config,
-        persist_ext=persist,
-    )
+    resolved = image_policy_from_ext(record)
 
     assert resolved.state == ImagePolicyState.LEGACY
     assert resolved.docker_image is None
-    persist.assert_not_called()
-
-
-def test_resolve_legacy_publish_snapshots_pin_before_use():
-    common_config = MagicMock()
-    common_config.get_value.return_value = {"image": "registry/arca:v2"}
-    persist = MagicMock()
-    record = _record({"migration_path": "/build/v1"})
-
-    resolved = resolve_publish_image_pin(
-        record,
-        common_config_service=common_config,
-        persist_ext=persist,
-    )
-
-    expected_ext = {
-        "migration_path": "/build/v1",
-        "sbot_pin_image": True,
-        "sbot_docker_image": "registry/arca:v2",
-    }
-    assert resolved.state == ImagePolicyState.PINNED
-    assert resolved.docker_image == "registry/arca:v2"
-    persist.assert_called_once_with(expected_ext)
-    assert record.ext == expected_ext
+    assert record.ext == {"migration_path": "/build/v1"}
 
 
 def test_resolve_rejects_pin_without_image():
     with pytest.raises(ImagePinConfigError, match="without a valid image"):
-        resolve_publish_image_pin(_record({"sbot_pin_image": True}))
+        image_policy_from_ext(_record({"sbot_pin_image": True}))
 
 
 def test_resolve_rejects_dangling_image_policy_field():
     with pytest.raises(ImagePinConfigError, match="inconsistent image policy"):
-        resolve_publish_image_pin(_record({"sbot_docker_image": "arca:v2"}))
+        image_policy_from_ext(_record({"sbot_docker_image": "arca:v2"}))
 
 
 def test_persisted_resolver_returns_successful_cas_snapshot():

--- a/src/backend/tests/community/core/service_bot/services/test_arca_image_pin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_arca_image_pin.py
@@ -10,19 +10,14 @@ from agentclaw.community.core.service_bot.services.arca_image_pin import (
     ImagePinConfigError,
     ImagePolicyState,
     PublishImagePolicyResolver,
-    RUNTIME_KIND_ARCA,
-    RUNTIME_KIND_TECLAW,
     apply_default_image_to_ext,
     apply_image_pin_to_ext,
     clear_image_policy_from_ext,
-    apply_runtime_kind_to_ext,
     copy_image_policy_to_ext,
     overlay_image_pin_on_template_config,
     persist_default_image_policy,
     resolve_current_arca_image,
     resolve_publish_image_pin,
-    resolve_publish_runtime_kind,
-    runtime_kind_from_provider,
 )
 
 
@@ -225,53 +220,6 @@ def test_resolve_rejects_dangling_image_policy_field():
         resolve_publish_image_pin(_record({"sbot_docker_image": "arca:v2"}))
 
 
-def test_runtime_kind_prefers_publish_snapshot():
-    record = _record({"sbot_runtime_kind": RUNTIME_KIND_TECLAW})
-    binding_repo = MagicMock()
-
-    assert (
-        resolve_publish_runtime_kind(record, binding_repository=binding_repo)
-        == RUNTIME_KIND_TECLAW
-    )
-    binding_repo.get_by_id.assert_not_called()
-
-
-def test_runtime_kind_reads_teclaw_artifact_for_historical_publish():
-    record = _record({"config_artifact": {"engine_type": "teclaw"}})
-
-    assert resolve_publish_runtime_kind(record) == RUNTIME_KIND_TECLAW
-
-
-def test_runtime_kind_reads_string_stage_binding_provider():
-    record = _record({"binding": {"online": "42"}})
-    binding_repo = MagicMock()
-    binding_repo.get_by_id.return_value = SimpleNamespace(device_provider="baas")
-
-    assert (
-        resolve_publish_runtime_kind(record, binding_repository=binding_repo)
-        == RUNTIME_KIND_ARCA
-    )
-    binding_repo.get_by_id.assert_called_once_with(42)
-
-
-@pytest.mark.parametrize("provider", ["arca", "baas"])
-def test_runtime_kind_from_arca_provider_uses_canonical_spelling(provider):
-    assert runtime_kind_from_provider(provider) == "arca"
-
-
-def test_runtime_kind_normalizes_legacy_arka_publish_snapshot():
-    record = _record({"sbot_runtime_kind": "arka"})
-
-    assert resolve_publish_runtime_kind(record) == "arca"
-
-
-def test_apply_runtime_kind_preserves_unrelated_ext():
-    assert apply_runtime_kind_to_ext({"migration_path": "/build/v1"}, "arca") == {
-        "migration_path": "/build/v1",
-        "sbot_runtime_kind": "arca",
-    }
-
-
 def test_persisted_resolver_returns_successful_cas_snapshot():
     legacy = _record({"migration_path": "/build/v1", "unrelated": "keep"})
     persisted = _record(
@@ -289,12 +237,11 @@ def test_persisted_resolver_returns_successful_cas_snapshot():
     common_config.get_value.return_value = {"image": "registry/arca:v2"}
     resolver = PublishImagePolicyResolver(
         publish_repository=publish_repo,
-        binding_repository=MagicMock(),
         common_config_service=common_config,
     )
     original = _record()
 
-    resolved = resolver.resolve(original)
+    resolved = resolver.resolve(original, device_provider="baas")
 
     assert resolved.state == ImagePolicyState.PINNED
     assert resolved.docker_image == "registry/arca:v2"
@@ -314,12 +261,11 @@ def test_persisted_resolver_keeps_legacy_when_switch_disabled():
     common_config.get_value.return_value = None
     resolver = PublishImagePolicyResolver(
         publish_repository=publish_repo,
-        binding_repository=MagicMock(),
         common_config_service=common_config,
     )
     original = _record()
 
-    resolved = resolver.resolve(original)
+    resolved = resolver.resolve(original, device_provider="baas")
 
     assert resolved.state == ImagePolicyState.LEGACY
     assert resolved.docker_image is None
@@ -339,12 +285,11 @@ def test_persisted_resolver_reloads_concurrent_default_after_cas_conflict():
     common_config.get_value.return_value = {"image": "registry/arca:v2"}
     resolver = PublishImagePolicyResolver(
         publish_repository=publish_repo,
-        binding_repository=MagicMock(),
         common_config_service=common_config,
     )
     original = _record()
 
-    resolved = resolver.resolve(original)
+    resolved = resolver.resolve(original, device_provider="baas")
 
     assert resolved.state == ImagePolicyState.DEFAULT
     assert resolved.docker_image is None
@@ -360,29 +305,27 @@ def test_persisted_resolver_fails_closed_after_repeated_cas_conflicts():
     common_config.get_value.return_value = {"image": "registry/arca:v2"}
     resolver = PublishImagePolicyResolver(
         publish_repository=publish_repo,
-        binding_repository=MagicMock(),
         common_config_service=common_config,
         max_cas_attempts=2,
     )
 
     with pytest.raises(ImagePinPersistenceError, match="CAS conflicted repeatedly"):
-        resolver.resolve(_record())
+        resolver.resolve(_record(), device_provider="baas")
 
     assert publish_repo.compare_and_set_ext.call_count == 2
 
 
 def test_persisted_resolver_skips_common_config_for_teclaw_publish():
-    latest = _record({"sbot_runtime_kind": "teclaw"})
+    latest = _record({"migration_path": "/build/v1"})
     publish_repo = MagicMock()
     publish_repo.get_by_id.return_value = latest
     common_config = MagicMock()
     resolver = PublishImagePolicyResolver(
         publish_repository=publish_repo,
-        binding_repository=MagicMock(),
         common_config_service=common_config,
     )
 
-    resolved = resolver.resolve(_record())
+    resolved = resolver.resolve(_record(), device_provider="teclaw")
 
     assert resolved.state == ImagePolicyState.LEGACY
     assert resolved.docker_image is None

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -24,7 +24,44 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishOperationState,
     PublishStatus,
 )
+from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
+    TECLAW_DEVICE_PROVIDER,
+    resolve_device_provider,
+)
+from agentclaw.community.core.service_bot.services.publish_flow.provider_behavior import (
+    DefaultProviderBehavior,
+    ProviderBehaviorRouter,
+    TeclawProviderBehavior,
+)
 from agentclaw.community.core.service_bot.types import PublishStage
+
+
+def _flow_service_with_real_provider_seam() -> MagicMock:
+    """A ``PublishFlowService`` stub whose provider seam is the real router.
+
+    The draft-restore preflight asks the flow service for the bot's
+    ``ProviderBehavior``, so these tests keep exercising the real per-provider
+    artifact rule (and the real engine → device_provider mapping) instead of
+    asserting against a mock.
+    """
+    router = ProviderBehaviorRouter(
+        {
+            TECLAW_DEVICE_PROVIDER: TeclawProviderBehavior(
+                build_service=MagicMock(),
+                resolver=MagicMock(),
+                device_fs_dispatcher=MagicMock(),
+                teclaw_file_promotion=MagicMock(),
+            ),
+            "arca": DefaultProviderBehavior(),
+            "baas": DefaultProviderBehavior(),
+        },
+        default_provider_key="baas",
+    )
+    flow_service = MagicMock()
+    flow_service.provider_behavior.side_effect = lambda bot: router.resolve(
+        resolve_device_provider((bot or {}).get("active_engine"))
+    )
+    return flow_service
 
 
 def _make_service(
@@ -63,7 +100,10 @@ def _make_service(
     return BotPublishService(
         bot_publish_repo=bot_publish_repo,
         bot_repo=bot_repo or MagicMock(),
-        publish_flow_service_provider=publish_flow_service_provider or (lambda: MagicMock()),
+        publish_flow_service_provider=(
+            publish_flow_service_provider
+            or (lambda flow=_flow_service_with_real_provider_seam(): flow)
+        ),
         bot_service=bot_service or MagicMock(),
         device_binding_repo=device_binding_repo or MagicMock(),
         bcn_service=bcn_service or MagicMock(),
@@ -145,7 +185,6 @@ class TestCreatePublishImagePolicy:
         assert ext == {
             "migration_path": "/build/v1",
             "sbot_use_default_image": True,
-            "sbot_runtime_kind": "arca",
         }
         common_config.get_value.assert_called_once()
 
@@ -170,10 +209,7 @@ class TestCreatePublishImagePolicy:
             common_config_value=config_value,
         )
 
-        assert ext == {
-            "migration_path": "/build/v1",
-            "sbot_runtime_kind": "arca",
-        }
+        assert ext == {"migration_path": "/build/v1"}
         common_config.get_value.assert_called_once()
 
     def test_legacy_arca_bot_snapshots_enabled_common_config_image(self):
@@ -190,7 +226,6 @@ class TestCreatePublishImagePolicy:
             "migration_path": "/build/v1",
             "sbot_pin_image": True,
             "sbot_docker_image": "registry/arca:v2",
-            "sbot_runtime_kind": "arca",
         }
         common_config.get_value.assert_called_once()
 
@@ -204,10 +239,7 @@ class TestCreatePublishImagePolicy:
             common_config_value=None,
         )
 
-        assert ext == {
-            "migration_path": "/build/v1",
-            "sbot_runtime_kind": "arca",
-        }
+        assert ext == {"migration_path": "/build/v1"}
         common_config.get_value.assert_called_once()
 
     def test_teclaw_publish_does_not_consume_arca_common_config(self):
@@ -221,10 +253,9 @@ class TestCreatePublishImagePolicy:
             is_teclaw=True,
         )
 
-        assert ext == {
-            "migration_path": "/build/v1",
-            "sbot_runtime_kind": "teclaw",
-        }
+        # The provider is not snapshotted onto the record any more — the publish
+        # record carries only the image policy (here: none, teclaw owns its image).
+        assert ext == {"migration_path": "/build/v1"}
         common_config.get_value.assert_not_called()
 
 

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -16,7 +16,8 @@ from agentclaw.community.core.service_bot.services.bot_build_service import BotB
 from agentclaw.community.core.service_bot.services.arca_image_pin import (
     ImagePolicyState,
     ServiceBotImagePin,
-    resolve_publish_image_pin as resolve_publish_image_pin_policy,
+    has_explicit_image_policy,
+    image_policy_from_ext,
 )
 from agentclaw.community.core.service_bot.services.publish_flow_service import (
     PublishFlowService,
@@ -125,25 +126,15 @@ def _pf(*args, **kw):
     publish_service = args[0] if args else kw.get("bot_publish_service")
     if isinstance(publish_service, Mock):
         def _resolve_image_policy(record, *, device_provider):
-            if device_provider == "teclaw":
+            # Stands in for PublishImagePolicyResolver.resolve: teclaw carries no
+            # ARCA policy, an explicit snapshot decodes as-is, and a record with no
+            # policy stays legacy. These flow tests predate runtime-pin
+            # configuration and focus on orchestration, so the resolver's lazy
+            # common-config snapshot is deliberately not modelled here — dedicated
+            # image-policy tests cover it.
+            if device_provider == "teclaw" or not has_explicit_image_policy(record.ext):
                 return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
-            if not any(
-                key in (record.ext or {})
-                for key in (
-                    "sbot_pin_image",
-                    "sbot_docker_image",
-                    "sbot_use_default_image",
-                )
-            ):
-                # These flow tests predate runtime-pin configuration and focus
-                # on orchestration. Dedicated image-policy tests cover the
-                # production resolver's fail-closed behavior.
-                return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
-            return resolve_publish_image_pin_policy(
-                record,
-                common_config_service=kw["common_config_service"],
-                env=record.env,
-            )
+            return image_policy_from_ext(record)
 
         publish_service.resolve_publish_image_pin.side_effect = _resolve_image_policy
     if "channel_overrides_reader" not in kw:

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -124,9 +124,8 @@ def _pf(*args, **kw):
         baas.list_bot_publishes.return_value = []
     publish_service = args[0] if args else kw.get("bot_publish_service")
     if isinstance(publish_service, Mock):
-        def _resolve_image_policy(record):
-            artifact = (record.ext or {}).get("config_artifact")
-            if isinstance(artifact, dict) and artifact.get("engine_type") == "teclaw":
+        def _resolve_image_policy(record, *, device_provider):
+            if device_provider == "teclaw":
                 return ServiceBotImagePin(ImagePolicyState.LEGACY, None)
             if not any(
                 key in (record.ext or {})
@@ -147,26 +146,6 @@ def _pf(*args, **kw):
             )
 
         publish_service.resolve_publish_image_pin.side_effect = _resolve_image_policy
-        def _resolve_runtime_kind(record):
-            ext = record.ext or {}
-            explicit = ext.get("sbot_runtime_kind")
-            if explicit == "arka":
-                return "arca"
-            if explicit in {"arca", "teclaw"}:
-                return explicit
-            artifact = ext.get("config_artifact")
-            if isinstance(artifact, dict) and artifact.get("engine_type") == "teclaw":
-                return "teclaw"
-            # Old flow fixtures express their historical binding through the
-            # BaaS provider mock. Production uses Publish ext/bindings only.
-            provider = (
-                baas.resolve_container_provider.return_value
-                if isinstance(baas, Mock)
-                else None
-            )
-            return "teclaw" if provider == "teclaw" else "arca"
-
-        publish_service.resolve_publish_runtime_kind.side_effect = _resolve_runtime_kind
     if "channel_overrides_reader" not in kw:
         # Default to "no channels for this stage" ({}), so promotion delivers the
         # base artifact with channels cleared — tests that care about channels pass
@@ -1828,6 +1807,56 @@ async def test_verify_first_release_stamps_canary_delivered_and_persisted():
 
 
 @pytest.mark.asyncio
+async def test_release_provider_follows_the_bot_not_a_stale_publish_ext():
+    """A stale provider hint on ``ext`` must not decide the container.
+
+    The build stage picks its producer from ``resolve_container_provider(bot)``.
+    The release stage must reach the same answer, or a teclaw build is shipped to
+    an ARCA create (and vice versa). Here the record still carries the ARCA mount
+    chain plus an ARCA image pin from an earlier life, while the bot now runs in a
+    teclaw container: the bot wins, and the ARCA image pin is not consumed.
+    """
+    publish_service = Mock()
+    publish_service.create_device_binding.return_value = 55
+    build_service = Mock()
+    build_service.release_async = AsyncMock(
+        return_value={"bot_uuid": "BOT-1", "publish_id": 9}
+    )
+    build_service.generate_request_id = Mock(return_value="rid")
+    baas_service = Mock()
+    baas_service.resolve_container_provider.return_value = "teclaw"
+    svc = _pf(
+        publish_service, build_service, baas_service, Mock(), _arca_router(build_service)
+    )
+    svc._ext_state.get_latest_ext = Mock(return_value=_artifact_ext("draft"))
+    svc._ext_state.update_status = Mock()
+    svc.approve_baas_publish = Mock()
+
+    record = _make_publish_record(
+        status=PublishStatus.BUILT.value,
+        ext={
+            **_artifact_ext("draft"),
+            "migration_path": "/build/v1",
+            "sbot_pin_image": True,
+            "sbot_docker_image": "registry/arca:v2",
+        },
+    )
+    await svc._execute_verify_first_release(
+        publish_record=record,
+        operator="op",
+        migration_path="/build/v1",
+        bot={"bot_id": "b2", "owner_id": "u1"},
+    )
+
+    baas_service.resolve_container_provider.assert_called_with(
+        {"bot_id": "b2", "owner_id": "u1"}
+    )
+    # The ARCA image policy is skipped for a teclaw container even though the
+    # record still carries a pin.
+    assert build_service.release_async.await_args.kwargs["docker_image"] is None
+
+
+@pytest.mark.asyncio
 async def test_verify_upgrade_stamps_canary_delivered_and_persisted():
     publish_service = Mock()
     build_service = Mock()
@@ -2833,14 +2862,15 @@ async def test_scale_bot_teclaw_returns_supported_message_without_baas_call():
         return_value=_make_publish_record(
             id=15,
             status=PublishStatus.SUCCESS.value,
-            ext={"sbot_runtime_kind": "teclaw"},
+            ext={"migration_path": "/build/v1"},
         )
     )
     bot_service.get_bot = Mock(
-        return_value={"bot_id": "bot-source", "active_engine": "openclaw", "ext": {}}
+        return_value={"bot_id": "bot-source", "active_engine": "teclaw", "ext": {}}
     )
-    # The current Draft is ARCA, but the immutable Publish is TeClaw-owned.
-    baas_service.resolve_container_provider.return_value = "baas"
+    # Scale support follows the bot's container, not anything cached on the
+    # publish record's ext.
+    baas_service.resolve_container_provider.return_value = "teclaw"
 
     result = await svc.scale_bot(publish_id=15, operator="u1")
 

--- a/src/backend/tests/community/core/service_bot/services/test_publish_image_policy_mixin.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_image_policy_mixin.py
@@ -9,6 +9,10 @@ from agentclaw.community.core.service_bot.services.arca_image_pin import (
 from agentclaw.community.core.service_bot.services.publish_flow.image_policy_mixin import (
     PublishImagePolicyMixin,
 )
+from agentclaw.community.core.service_bot.services.publish_flow.provider_behavior import (
+    DefaultProviderBehavior,
+    ProviderBehaviorRouter,
+)
 
 
 def _record(ext=None) -> BotPublishRecord:
@@ -32,6 +36,10 @@ def _record(ext=None) -> BotPublishRecord:
 class _ImagePolicyHarness(PublishImagePolicyMixin):
     def __init__(self) -> None:
         self._publish_service = MagicMock()
+        self._baas_service = MagicMock()
+        self._provider_behaviors = ProviderBehaviorRouter(
+            {"baas": DefaultProviderBehavior()}, default_provider_key="baas"
+        )
 
 
 def test_resolve_publish_image_pin_delegates_to_shared_publish_service_resolver():
@@ -40,7 +48,20 @@ def test_resolve_publish_image_pin_delegates_to_shared_publish_service_resolver(
     svc = _ImagePolicyHarness()
     svc._publish_service.resolve_publish_image_pin.return_value = expected
 
-    resolved = svc.resolve_publish_image_pin(record)
+    resolved = svc.resolve_publish_image_pin(record, device_provider="baas")
 
     assert resolved is expected
-    svc._publish_service.resolve_publish_image_pin.assert_called_once_with(record)
+    svc._publish_service.resolve_publish_image_pin.assert_called_once_with(
+        record, device_provider="baas"
+    )
+
+
+def test_device_provider_asks_the_bot_not_the_publish_record():
+    """Provider identity comes from the bot's container, never from ``ext``."""
+    svc = _ImagePolicyHarness()
+    svc._baas_service.resolve_container_provider.return_value = "baas"
+    bot = {"bot_id": "bot-1", "active_engine": "openclaw"}
+
+    assert svc.device_provider(bot) == "baas"
+    assert isinstance(svc.provider_behavior(bot), DefaultProviderBehavior)
+    svc._baas_service.resolve_container_provider.assert_called_with(bot)


### PR DESCRIPTION
## Problem

`resolve_publish_runtime_kind` was the single decision point for whether a deploy
issues `create_teclaw_bot` or `create_bot` (`bot_build_service.py:536`, `:1176`).
It also selected the `ProviderBehavior` in two places, gated the ARCA image pin,
and decided retire-vs-upgrade for a not-live online candidate.

It derived all of that from `publish_record.ext`, in this precedence:

1. `ext["sbot_runtime_kind"]` — a *copy* of the answer, stamped once at `create_publish`
2. `ext["config_artifact"]["engine_type"] == "teclaw"` — the *build output*, used as an identity oracle
3. `ext["binding"][stage] → binding.device_provider` — the only authoritative signal, reached last, and only when a repository was passed
4. a silent `return "arca"` behind a log warning

The build stage of the same flow already resolves the container correctly, from
the bot (`build_stage.py:90-92`):

```python
device_provider = self._baas_service.resolve_container_provider(bot)
producer = self._producer_router.resolve(device_provider)
behavior = self._provider_behaviors.resolve(device_provider)
```

So build asked the bot and release asked a JSON blob, and the two halves of one
publish could disagree.

They diverge in practice. `active_engine` and `binding_id` are both in the bot
repository's update allowlist (`bot.py:62-75`), so the stamp taken at draft
creation goes stale while still outranking every fresher signal: a record stamped
`arca` whose bot later became teclaw builds a teclaw `config_artifact`, stages its
files to OSS, and then hands the whole thing to an ARCA `create_bot` with an ARCA
image pin applied. Step 2 fails in the opposite direction — `upgrade_publish`
deliberately seeds a new draft with the previous version's `config_artifact`
(`bot_publish_service.py:816-819`), so an unstamped ARCA record can inherit a
teclaw artifact and be read as teclaw. Step 4 turns any unresolved case into a
silent ARCA guess rather than an error.

Separately, three provider rules were reimplemented instead of going through the
existing `ProviderBehavior` seam:

- `publish_draft_restore_mixin.py:127-139` duplicated
  `ProviderBehavior.validate_draft_restore_artifact` verbatim, same user-facing
  strings, while `draft_restore_ops_mixin.py:161` used the seam — so the
  preflight and the executing restore could answer differently.
- `_decide_online_deploy(publish_record, bot)` documented "reads … the bot's
  container provider" but ignored its `bot` argument and branched on the ext-derived
  runtime kind instead.
- `ReleaseStageRunner._provider_behavior` and
  `PublishImagePolicyMixin._publish_provider_behavior` were two copies of the same
  runtime_kind → provider-token → behavior mapping, one using a literal `"baas"`
  and the other `DEFAULT_DEVICE_PROVIDER`.

## Solution

Provider identity now comes from the bot's container everywhere in the publish flow.

- Deleted `resolve_publish_runtime_kind`, `apply_runtime_kind_to_ext`,
  `runtime_kind_from_provider`, and the `RUNTIME_KIND_*` / `sbot_runtime_kind`
  vocabulary. The flow speaks one provider dialect (`device_provider`), the same
  one the producer and behavior routers already key on.
- `PublishImagePolicyMixin` owns the single seam: `device_provider(bot)` and
  `provider_behavior(bot)`, both delegating to `resolve_container_provider`.
  `PublishFlowService._provider_behavior` folded into it as a public method so the
  draft-restore preflight on `BotPublishService` can consume it.
- `PublishImagePolicyResolver.resolve` takes `device_provider` as a required
  keyword argument instead of re-deriving it, so the image policy and the deployed
  container cannot disagree. `binding_repository` is no longer needed on it.
- Dropped the six `runtime_kind=` overrides at the deploy call sites;
  `release_async` / `upgrade_async` already resolve the container from `bot`, which
  is now the source of truth, so passing a second opinion was the bug's carrier.
- `create_publish` no longer stamps `sbot_runtime_kind`. It still freezes the ARCA
  *image*, which genuinely is a record-owned, reproducible fact.
- The retire-vs-upgrade rule became
  `ProviderBehavior.upgrade_recovers_not_live_bot` (Default `True`, Teclaw `False`),
  which makes `_decide_online_deploy` actually use the `bot` its docstring claimed.
- The draft-restore preflight calls `validate_draft_restore_artifact` rather than
  reimplementing it.
- `expert_chat_instance_service` resolves the provider from the bot for its caller
  containers, the same way — it shares `PublishImagePolicyResolver`.

Rejected alternative: keeping `ext` as the pinned snapshot and only hardening it
(drop the artifact heuristic, raise instead of defaulting to ARCA, reconcile the
stamp at build time). That preserves "reproducible from the publish record alone",
but the container a bot runs in is owned by the bot and its binding, not by a
publish row, and it leaves two sources of truth to keep in sync forever.

`bot_build_service` was left alone by design, so its `runtime_kind` parameter is
now always `None` — dead weight worth removing in a follow-up, together with the
`runtime_kind` vs `device_provider` vocabulary split it still straddles
(`resolved_runtime_kind == TECLAW_DEVICE_PROVIDER` compares across two vocabularies
that agree only because both spell teclaw the same).

## Validation

Full backend suite, `python -m pytest tests/community -n auto --dist loadfile`:
**12228 passed, 36 skipped, 2 failed in 206s**.

The 2 failures are
`test_bot_build_service_skill_artifact.py::test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_write_nfs[openclaw|claude_code]`,
which shell out to `rsync`; `rsync` is not installed in this container
(`rsync: not found`). They are unrelated to this change.

One other test, `test_endpoint_runner.py::test_endpoint_injection[PATCH …/call-type :: happy]`,
failed on a serial run; it was confirmed to fail identically on a clean tree with
these changes stashed, and passes under the parallel run. Pre-existing, not caused here.

Test changes:

- `test_arca_image_pin.py` — dropped the runtime-kind sniffing suite; the resolver
  tests pass `device_provider` explicitly, and the teclaw skip is now driven by the
  passed provider.
- `test_bot_publish_service.py` — the draft-restore tests now run against the real
  `ProviderBehaviorRouter` (helper `_flow_service_with_real_provider_seam`), so they
  still exercise the real per-provider artifact rule and the real engine →
  `device_provider` mapping rather than a mock. Image-policy assertions no longer
  expect the `sbot_runtime_kind` stamp.
- `test_publish_flow_service.py` — the `_pf` harness lost its `_resolve_runtime_kind`
  stub (which was itself papering over the divergence: its comment read "Old flow
  fixtures express their historical binding through the BaaS provider mock.
  Production uses Publish ext/bindings only."). Added
  `test_release_provider_follows_the_bot_not_a_stale_publish_ext` as a regression
  test for the reported bug. `test_scale_bot_teclaw_returns_supported_message_without_baas_call`
  previously asserted the old behavior explicitly ("The current Draft is ARCA, but
  the immutable Publish is TeClaw-owned") and was rewritten to the new contract.
- `test_publish_image_policy_mixin.py` — covers the new `device_provider` /
  `provider_behavior` seam.

`test_decide_online_deploy_matrix` already drove `resolve_container_provider` across
both providers, so it now covers the new `ProviderBehavior` property with no edit.

Not run: `ruff` is not a CI gate here (`scripts/ci_test.sh` runs pytest + coverage
only) and reports ~9964 pre-existing findings across the tree, so a repo-wide lint
result would carry no signal. The coverage gate in `ci_test.sh` was not run locally
because it needs a resolved base ref and the full report pipeline.

## Compatibility and risk

`ext["sbot_runtime_kind"]` is no longer written or read. Existing rows keep the key
as inert data; nothing needs migrating, and no API or frontend surface exposes it
(it appears only in backend code and tests).

Behavioral change worth calling out: a publish record no longer pins its provider.
If a bot's engine changes between a build and a later restart/rollback of an older
record, that operation now targets the bot's *current* container instead of the one
recorded at publish time. That is the intended fix — it is what makes build and
release agree — but it does mean a rollback to an old version follows the bot rather
than reproducing the old container type.

Rollback path: revert the commit. The deleted helpers and the `sbot_runtime_kind`
writer come back together, and no persisted state has to be undone.


---
_Generated by [Claude Code](https://claude.ai/code/session_017MieWstr2j2E66qJAjCE14)_