### PR TITLE
fix(skill-center): use null global defaults for aicoding fallback

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/default_skill_set_selection.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/default_skill_set_selection.py
@@ -1,4 +1,4 @@
-"""Default SkillSet compatibility contributed by the aicoding engine."""
+"""aicoding default SkillSet selection compatibility."""
 
 from __future__ import annotations
 
@@ -12,11 +12,10 @@ from .strategy import AICODING_ENGINE_TYPE, CLAUDE_CODE_ENGINE_TYPE
 class AicodingDefaultSkillSetSelectionResolver:
     """Route non-normal Claude Code default SkillSet reads to aicoding rows.
 
-    Routed Claude Code should first use the current bot-scoped persisted
-    default, then fall back to the existing online global default SkillSet rows
-    created under the aicoding runtime engine and ``bolt_id='default'``.  Only
-    this engine relationship needs the compatibility lookup; all unclaimed
-    inputs fall back to the persisted engine in the neutral policy.
+    Routed Claude Code first uses the current bot-scoped persisted default, then
+    falls back to the legacy global default SkillSet rows. In current data these
+    global defaults are stored with ``bolt_id IS NULL`` for both aicoding and
+    claude_code; there is no ``aicoding + bolt_id='default'`` row to query.
     """
 
     _GLOBAL_DEFAULT_BOLT_ID = "default"
@@ -46,11 +45,11 @@ class AicodingDefaultSkillSetSelectionResolver:
                 (
                     DefaultSkillSetSelection(
                         engine_type=runtime_engine_type,
-                        bolt_id=self._GLOBAL_DEFAULT_BOLT_ID,
+                        bolt_id=None,
                     ),
                     DefaultSkillSetSelection(
                         engine_type=persisted_engine_type,
-                        bolt_id=self._GLOBAL_DEFAULT_BOLT_ID,
+                        bolt_id=None,
                     ),
                 )
             )

--- a/src/backend/tests/community/core/skill_center/test_default_skill_set_selection_policy.py
+++ b/src/backend/tests/community/core/skill_center/test_default_skill_set_selection_policy.py
@@ -36,14 +36,14 @@ def test_default_policy_has_no_engine_specific_runtime_routing():
     assert selection.bolt_id is None
 
 
-def test_registered_policy_uses_aicoding_global_default_for_routed_claude_code():
+def test_registered_policy_uses_aicoding_null_global_default_for_routed_claude_code():
     selection = get_default_skill_set_selection_policy().resolve(
         persisted_engine_type="claude_code",
         runtime_engine_type="aicoding",
     )
 
     assert selection.engine_type == "aicoding"
-    assert selection.bolt_id == "default"
+    assert selection.bolt_id is None
 
 
 def test_registered_policy_keeps_openclaw_unchanged():
@@ -63,8 +63,8 @@ def test_registered_policy_orders_routed_claude_code_global_default_fallbacks():
     )
 
     assert [(item.engine_type, item.bolt_id) for item in plan] == [
-        ("aicoding", "default"),
-        ("claude_code", "default"),
+        ("aicoding", None),
+        ("claude_code", None),
     ]
 
 
@@ -77,8 +77,8 @@ def test_registered_policy_orders_routed_claude_code_bot_then_global_fallbacks()
 
     assert [(item.engine_type, item.bolt_id) for item in plan] == [
         ("claude_code", "bot-1"),
-        ("aicoding", "default"),
-        ("claude_code", "default"),
+        ("aicoding", None),
+        ("claude_code", None),
     ]
 
 
@@ -90,8 +90,8 @@ def test_registered_policy_does_not_duplicate_global_default_bolt_id():
     )
 
     assert [(item.engine_type, item.bolt_id) for item in plan] == [
-        ("aicoding", "default"),
-        ("claude_code", "default"),
+        ("aicoding", None),
+        ("claude_code", None),
     ]
 
 

--- a/src/backend/tests/community/services/test_skill_set_service_engine_type.py
+++ b/src/backend/tests/community/services/test_skill_set_service_engine_type.py
@@ -230,7 +230,7 @@ def test_default_skill_set_query_kwargs_keeps_normal_claude_code_query_shape(tmp
     assert service._default_skill_set_query_kwargs() == {}
 
 
-def test_default_skill_set_query_kwargs_routes_claude_code_default_to_aicoding(tmp_path):
+def test_default_skill_set_query_kwargs_routes_claude_code_null_default_to_aicoding(tmp_path):
     from agentclaw.community.core.bot_management.engines.registry import (
         get_default_skill_set_selection_policy,
     )
@@ -243,12 +243,12 @@ def test_default_skill_set_query_kwargs_routes_claude_code_default_to_aicoding(t
     )
 
     assert service._default_skill_set_query_kwargs() == {
-        "default_skill_set_bolt_id": "default",
+        "default_skill_set_bolt_id": None,
         "default_skill_set_engine_type": "aicoding",
     }
 
 
-def test_active_skill_sets_falls_back_from_bot_default_to_aicoding_then_claude_code_default(tmp_path):
+def test_active_skill_sets_falls_back_to_aicoding_legacy_null_then_claude_code_default(tmp_path):
     from agentclaw.community.core.bot_management.engines.registry import (
         get_default_skill_set_selection_policy,
     )
@@ -275,10 +275,10 @@ def test_active_skill_sets_falls_back_from_bot_default_to_aicoding_then_claude_c
     third_kwargs = repo.get_all_active_skill_sets.call_args_list[2].kwargs
     assert first_kwargs["default_skill_set_bolt_id"] == "bot"
     assert first_kwargs["default_skill_set_engine_type"] == "claude_code"
-    assert second_kwargs["default_skill_set_bolt_id"] == "default"
+    assert second_kwargs["default_skill_set_bolt_id"] is None
     assert second_kwargs["default_skill_set_engine_type"] == "aicoding"
-    assert third_kwargs["default_skill_set_bolt_id"] == "default"
-    assert third_kwargs["default_skill_set_engine_type"] == "claude_code"
+    assert "default_skill_set_bolt_id" not in third_kwargs
+    assert "default_skill_set_engine_type" not in third_kwargs
 
 
 def test_active_skill_sets_stops_when_bot_default_exists(tmp_path):
@@ -356,7 +356,7 @@ def test_list_skill_sets_uses_aicoding_scoped_default_candidates(tmp_path):
     assert first_kwargs["default_skill_set_engine_type"] == "claude_code"
     assert second_kwargs["bolt_id"] == "bot"
     assert second_kwargs["engine_type"] == "claude_code"
-    assert second_kwargs["default_skill_set_bolt_id"] == "default"
+    assert second_kwargs["default_skill_set_bolt_id"] is None
     assert second_kwargs["default_skill_set_engine_type"] == "aicoding"
 
 
@@ -465,7 +465,7 @@ def test_env_active_skill_sets_fallback_stops_when_default_exists(tmp_path):
     assert first_kwargs["default_skill_set_bolt_id"] == "bot"
     assert first_kwargs["default_skill_set_engine_type"] == "claude_code"
     assert first_kwargs["env"] == "pre"
-    assert second_kwargs["default_skill_set_bolt_id"] == "default"
+    assert second_kwargs["default_skill_set_bolt_id"] is None
     assert second_kwargs["default_skill_set_engine_type"] == "aicoding"
     assert second_kwargs["env"] == "pre"
 


### PR DESCRIPTION
## Summary
- Update aicoding routed Claude Code default SkillSet fallback to use legacy global rows with bolt_id IS NULL
- Keep fallback order as bot-scoped claude_code first, then aicoding NULL, then claude_code NULL
- Update tests for the NULL global default fallback behavior

## Tests
- cd src/backend && uv run pytest tests/community/core/skill_center/test_default_skill_set_selection_policy.py tests/community/services/test_skill_set_service_engine_type.py -q --tb=short