### PR TITLE
feat(bcs): configure provider chat run timeout

### DIFF
--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -11,6 +11,10 @@ max_history_per_session = 1000
 store_messages = false
 strict_container_validation = true
 
+# Default HTTP Provider chat.send run deadline when the frame has no explicit
+# timeout_ms. Configuration changes take effect after BCS restarts.
+provider_chat_run_timeout_ms = 10800000
+
 # Deprecated compatibility setting. Provider 2.0 chat.send is always SSE-first;
 # this value is retained for config/API compatibility and has no effect.
 provider_stream_gray_enabled = false

--- a/src/bcs/configs/bcs-config-local.toml
+++ b/src/bcs/configs/bcs-config-local.toml
@@ -11,6 +11,10 @@ max_history_per_session = 1000
 store_messages = false
 strict_container_validation = false
 
+# Default HTTP Provider chat.send run deadline when the frame has no explicit
+# timeout_ms. Configuration changes take effect after BCS restarts.
+provider_chat_run_timeout_ms = 10800000
+
 # Deprecated compatibility setting. Provider 2.0 chat.send is always SSE-first;
 # this value is retained for config/API compatibility and has no effect.
 provider_stream_gray_enabled = false

--- a/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
@@ -46,6 +46,9 @@ const SSE_RESPONSE_HEADER_TIMEOUT_MS: u64 = 125_000;
 /// Maximum time to read the finite JSON acknowledgement when an SSE-preferred
 /// request falls back to `application/json`.
 const JSON_FALLBACK_BODY_TIMEOUT_MS: u64 = SSE_RESPONSE_HEADER_TIMEOUT_MS;
+/// Existing provider execution budget for the non-streaming interaction
+/// resolution request. This is intentionally independent from chat runs.
+const INTERACTION_RESOLVE_TIMEOUT_MS: u64 = 60 * 60 * 1_000;
 /// Bounded retry for resolving run context after `deliver()` returns but before
 /// `put_context` lands (#2 put_context race): ~50ms * 20 ≈ 1s.
 const SSE_CTX_RETRY_INTERVAL_MS: u64 = 50;
@@ -141,6 +144,7 @@ pub struct HttpProviderTransport {
     /// a long-lived stream. HTTP/1.1 remains enabled for JSON callback fallback.
     sse_client: reqwest::Client,
     url_guard: OutboundUrlGuard,
+    chat_run_timeout_ms: u64,
     event_ingest: std::sync::RwLock<Option<Arc<dyn ProviderEventIngestService>>>,
     bot_run_context: std::sync::RwLock<Option<Arc<dyn BotRunContextPort>>>,
     interactions: std::sync::RwLock<Option<std::sync::Weak<dyn InteractionService>>>,
@@ -177,10 +181,18 @@ impl HttpProviderTransport {
                 .build()
                 .expect("build provider sse client"),
             url_guard,
+            chat_run_timeout_ms: DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS,
             event_ingest: std::sync::RwLock::new(None),
             bot_run_context: std::sync::RwLock::new(None),
             interactions: std::sync::RwLock::new(None),
         }
+    }
+
+    /// Override the fallback deadline for `chat.send` frames that do not
+    /// provide an explicit `params.timeout_ms`.
+    pub fn with_chat_run_timeout_ms(mut self, timeout_ms: u64) -> Self {
+        self.chat_run_timeout_ms = timeout_ms;
+        self
     }
 
     /// Inject the ingest dependencies needed by the 2.0 SSE branch after
@@ -281,7 +293,7 @@ impl InteractionProviderPort for HttpProviderTransport {
             before: None,
             after: None,
             limit: None,
-            timeout_ms: DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS,
+            timeout_ms: INTERACTION_RESOLVE_TIMEOUT_MS,
             extensions: None,
         };
         let ack = post_provider::<ProviderAckResponse>(
@@ -339,7 +351,7 @@ impl BotDeliveryPort for HttpProviderTransport {
         let body = provider_request_from_frame(
             &cmd.target,
             &cmd.frame,
-            DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS,
+            self.chat_run_timeout_ms,
         )?;
         let provider_id = body.to_bot.provider_id.clone();
         let provider_bot_ref = body.to_bot.provider_bot_ref.clone();

--- a/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
@@ -46,9 +46,9 @@ const SSE_RESPONSE_HEADER_TIMEOUT_MS: u64 = 125_000;
 /// Maximum time to read the finite JSON acknowledgement when an SSE-preferred
 /// request falls back to `application/json`.
 const JSON_FALLBACK_BODY_TIMEOUT_MS: u64 = SSE_RESPONSE_HEADER_TIMEOUT_MS;
-/// Existing provider execution budget for the non-streaming interaction
-/// resolution request. This is intentionally independent from chat runs.
-const INTERACTION_RESOLVE_TIMEOUT_MS: u64 = 60 * 60 * 1_000;
+/// Existing provider execution budget for methods other than `chat.send`.
+/// This is intentionally independent from configurable chat runs.
+const NON_CHAT_PROVIDER_REQUEST_TIMEOUT_MS: u64 = 60 * 60 * 1_000;
 /// Bounded retry for resolving run context after `deliver()` returns but before
 /// `put_context` lands (#2 put_context race): ~50ms * 20 ≈ 1s.
 const SSE_CTX_RETRY_INTERVAL_MS: u64 = 50;
@@ -293,7 +293,7 @@ impl InteractionProviderPort for HttpProviderTransport {
             before: None,
             after: None,
             limit: None,
-            timeout_ms: INTERACTION_RESOLVE_TIMEOUT_MS,
+            timeout_ms: NON_CHAT_PROVIDER_REQUEST_TIMEOUT_MS,
             extensions: None,
         };
         let ack = post_provider::<ProviderAckResponse>(
@@ -799,7 +799,7 @@ fn provider_request_from_frame(
             .and_then(Value::as_u64)
             .unwrap_or(timeout_ms)
     } else {
-        timeout_ms
+        NON_CHAT_PROVIDER_REQUEST_TIMEOUT_MS
     };
     let attachments = params
         .get("attachments")

--- a/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
@@ -24,7 +24,6 @@ use bcs_service_api::{
     GroupCallbackOutcome, GroupHistoryBotRequestPort, MessageFlowService,
     ProviderEventIngestCommand, ProviderEventIngestService, ProviderEventSource,
     ProviderRunTransport, ProviderTransportPreference, ServiceResult,
-    DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS,
     TaskCompleteCommand, TaskCompleteOutcome, TaskDispatchCommand, TaskDispatchOutcome,
     TaskRunAliasRegistration, WebSendCommand, WebSendOutcome,
 };
@@ -38,7 +37,8 @@ async fn interaction_resolve_reuses_provider_route_and_expects_json_ack() {
         .with_state(captured.clone());
     let (webhook_url, server) = spawn_server(app).await;
     let target = provider_target_v2(webhook_url);
-    let transport = HttpProviderTransport::allowing_private_networks_for_tests();
+    let transport = HttpProviderTransport::allowing_private_networks_for_tests()
+        .with_chat_run_timeout_ms(42_000);
 
     let ack = transport
         .resolve_interaction(InteractionProviderCommand {
@@ -80,6 +80,7 @@ async fn interaction_resolve_reuses_provider_route_and_expects_json_ack() {
     assert_eq!(request.body["params"]["kind"], "exec");
     assert_eq!(request.body["params"]["idempotencyKey"], "idem-1");
     assert_eq!(request.body["params"]["decision"], "allow_once");
+    assert_eq!(request.body["timeout_ms"], 3_600_000);
     server.abort();
 }
 use serde_json::{Value, json};
@@ -342,7 +343,8 @@ async fn provider_delivery_posts_bearer_token_and_chat_send_body() {
         .with_state(captured.clone());
     let (webhook_url, server) = spawn_server(app).await;
 
-    let transport = HttpProviderTransport::allowing_private_networks_for_tests();
+    let transport = HttpProviderTransport::allowing_private_networks_for_tests()
+        .with_chat_run_timeout_ms(42_000);
     let result = transport
         .deliver(BotDeliveryCommand {
             target: provider_target(webhook_url),
@@ -701,7 +703,8 @@ async fn provider_delivery_falls_back_to_actor_id_for_sender_name() {
         .with_state(captured.clone());
     let (webhook_url, server) = spawn_server(app).await;
 
-    let transport = HttpProviderTransport::allowing_private_networks_for_tests();
+    let transport = HttpProviderTransport::allowing_private_networks_for_tests()
+        .with_chat_run_timeout_ms(7_200_000);
     let result = transport
         .deliver(BotDeliveryCommand {
             target: provider_target(webhook_url),
@@ -740,10 +743,7 @@ async fn provider_delivery_falls_back_to_actor_id_for_sender_name() {
     assert_eq!(request.body["from"]["kind"], "bot");
     assert_eq!(request.body["from"]["name"], "sender-bot-id");
     assert_eq!(request.body["from"]["actor_id"], "sender-bot-id");
-    assert_eq!(
-        request.body["timeout_ms"],
-        DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS
-    );
+    assert_eq!(request.body["timeout_ms"], 7_200_000);
 
     server.abort();
 }

--- a/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
@@ -903,7 +903,8 @@ async fn provider_delivery_posts_chat_inject_body_with_bcn_group_id() {
         .with_state(captured.clone());
     let (webhook_url, server) = spawn_server(app).await;
 
-    let transport = HttpProviderTransport::allowing_private_networks_for_tests();
+    let transport = HttpProviderTransport::allowing_private_networks_for_tests()
+        .with_chat_run_timeout_ms(42_000);
     let result = transport
         .deliver(BotDeliveryCommand {
             target: provider_target(webhook_url),
@@ -954,6 +955,7 @@ async fn provider_delivery_posts_chat_inject_body_with_bcn_group_id() {
     assert_eq!(request.body["from"]["name"], "Sender Bot");
     assert_eq!(request.body["message"]["text"], "observe");
     assert_eq!(request.body["attachments"][0]["attachment_id"], "att-1");
+    assert_eq!(request.body["timeout_ms"], 3_600_000);
 
     server.abort();
 }

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -1423,6 +1423,12 @@ impl BcsConfig {
 }
 
 fn validate_loaded_config(config: &BcsConfig) -> Result<(), Box<dyn std::error::Error>> {
+    if config.provider_chat_run_timeout_ms == 0 {
+        return Err(Box::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "provider_chat_run_timeout_ms must be greater than zero",
+        )));
+    }
     config.gateway_principal.validate().map_err(|e| {
         Box::new(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
             as Box<dyn std::error::Error>
@@ -1511,6 +1517,23 @@ mod tests {
         let config: BcsConfig = toml::from_str(toml).expect("parse provider chat run timeout");
 
         assert_eq!(config.provider_chat_run_timeout_ms, 14_400_000);
+    }
+
+    #[test]
+    fn provider_chat_run_timeout_rejects_zero() {
+        let toml = r#"
+            bots_base_dir = "/bots"
+            provider_chat_run_timeout_ms = 0
+        "#;
+
+        let config: BcsConfig = toml::from_str(toml).expect("parse provider chat run timeout");
+        let error = validate_loaded_config(&config).expect_err("zero timeout must be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("provider_chat_run_timeout_ms must be greater than zero")
+        );
     }
 
     #[test]

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -683,6 +683,11 @@ pub struct BcsConfig {
     #[serde(default)]
     pub group_logger: Option<ding_logger::GroupLoggerConfig>,
 
+    /// Default execution deadline for HTTP Provider `chat.send` runs that do
+    /// not provide an explicit `timeout_ms`. Applied at process startup.
+    #[serde(default = "default_provider_chat_run_timeout_ms")]
+    pub provider_chat_run_timeout_ms: u64,
+
     /// Async chat run (bcs-cli chat-async) — max wall-clock a single run may
     /// be pending/running before the cleanup task marks it failed("timeout").
     /// Default 2 h 5 min, configurable up to 24 h.
@@ -798,6 +803,10 @@ fn default_max_group_messages() -> i64 {
 
 fn default_register_path() -> String {
     "/bcn/register".to_string()
+}
+
+fn default_provider_chat_run_timeout_ms() -> u64 {
+    bcs_service_api::DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS
 }
 
 fn default_async_chat_run_timeout_ms() -> u64 {
@@ -1018,6 +1027,7 @@ impl Default for BcsConfig {
             auth: AuthChainConfig::default(),
             cors: CorsConfig::default(),
             group_logger: None,
+            provider_chat_run_timeout_ms: default_provider_chat_run_timeout_ms(),
             async_chat_run_timeout_ms: default_async_chat_run_timeout_ms(),
             async_chat_run_retention_ms: default_async_chat_run_retention_ms(),
             async_chat_poll_wait_max_ms: default_async_chat_poll_wait_max_ms(),
@@ -1481,6 +1491,7 @@ mod tests {
         assert_eq!(config.bots_base_dir, PathBuf::from("/bots"));
         assert!(config.fusion_provider.is_none());
         assert_eq!(config.max_history_per_session, 1000);
+        assert_eq!(config.provider_chat_run_timeout_ms, 10_800_000);
         assert_eq!(config.async_chat_run_timeout_ms, 7_500_000);
         assert!(config.security.outbound_url.block_private_networks);
         assert!(!config.security.outbound_url.allow_loopback);
@@ -1488,6 +1499,18 @@ mod tests {
             config.group_session_ws.signing_key_secret,
             "bcn-group-session-ws-jwt"
         );
+    }
+
+    #[test]
+    fn provider_chat_run_timeout_can_be_configured() {
+        let toml = r#"
+            bots_base_dir = "/bots"
+            provider_chat_run_timeout_ms = 14_400_000
+        "#;
+
+        let config: BcsConfig = toml::from_str(toml).expect("parse provider chat run timeout");
+
+        assert_eq!(config.provider_chat_run_timeout_ms, 14_400_000);
     }
 
     #[test]

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1766,7 +1766,8 @@ impl Default for BcsServerState {
         let frontend_run_channels = run_channels.clone();
         let ws_bot_delivery: Arc<dyn BotDeliveryPort> = bot_connections.clone();
         let provider_transport = Arc::new(
-            bcs_provider_http::HttpProviderTransport::with_url_guard(outbound_url_guard.clone()),
+            bcs_provider_http::HttpProviderTransport::with_url_guard(outbound_url_guard.clone())
+                .with_chat_run_timeout_ms(config.provider_chat_run_timeout_ms),
         );
         let provider_stream_gray_list = create_provider_stream_gray_list(&config);
         let raw_bot_delivery: Arc<dyn BotDeliveryPort> = Arc::new(
@@ -1854,6 +1855,7 @@ impl Default for BcsServerState {
                 .with_delivery(bot_delivery.clone())
                 .with_frontend_delivery(frontend_delivery.clone())
                 .with_bot_run_context(bot_run_context.clone())
+                .with_provider_chat_run_timeout_ms(config.provider_chat_run_timeout_ms)
                 .with_message_repo(message_repo.clone())
                 .with_provider_stream_gray_list(provider_stream_gray_list.clone())
                 .register(BotJoinedMessageProducer::new(group_message_history.clone()))
@@ -1896,6 +1898,7 @@ impl Default for BcsServerState {
             Some(message_repo.clone()),
             provider_stream_gray_list.clone(),
             state_machine_terminal_observer.clone(),
+            config.provider_chat_run_timeout_ms,
         );
         let group_management_impl = Arc::new(GroupManagement::new(
             sessions.clone(),
@@ -1955,6 +1958,7 @@ impl Default for BcsServerState {
             )
             .with_bot_registry(bot_registry.clone())
             .with_bot_run_context(bot_run_context.clone())
+            .with_provider_chat_run_timeout_ms(config.provider_chat_run_timeout_ms)
             .with_callback_url_guard(outbound_url_guard.clone())
             .with_session_channel_outbound(session_channel_outbound)
             .with_result_publisher(Arc::new(
@@ -2410,6 +2414,7 @@ fn build_use_case_bundle(
             .with_delivery(bot_delivery.clone())
             .with_frontend_delivery(frontend_delivery.clone())
             .with_bot_run_context(bot_run_context)
+            .with_provider_chat_run_timeout_ms(config.provider_chat_run_timeout_ms)
             .with_provider_stream_gray_list(provider_stream_gray_list.clone())
             .register(BotJoinedMessageProducer::new(group_message_history.clone()))
             .register(HumanJoinedMessageProducer::new())
@@ -2598,6 +2603,7 @@ fn create_message_flow_services(
     message_repo: Option<Arc<dyn MessageRepoPort>>,
     provider_stream_gray_list: Arc<ProviderStreamGrayList>,
     bot_terminal_observer: Arc<dyn BotTerminalObserverPort>,
+    provider_chat_run_timeout_ms: u64,
 ) -> (Arc<dyn MessageFlowService>, ChannelSlot) {
     let mut message_flow = BcsMessageFlow::new(
         group,
@@ -2610,6 +2616,7 @@ fn create_message_flow_services(
     .with_interceptors(interceptors)
     .with_session_management(session_management)
     .with_bot_run_context(bot_run_context)
+    .with_provider_chat_run_timeout_ms(provider_chat_run_timeout_ms)
     .with_system_message(system_message)
     .with_provider_stream_gray_list(provider_stream_gray_list)
     .with_bot_terminal_observer(bot_terminal_observer);
@@ -3223,7 +3230,8 @@ impl BcsServer {
         let frontend_run_channels = run_channels.clone();
         let ws_bot_delivery: Arc<dyn BotDeliveryPort> = bot_connections.clone();
         let provider_transport = Arc::new(
-            bcs_provider_http::HttpProviderTransport::with_url_guard(provider_request_url_guard),
+            bcs_provider_http::HttpProviderTransport::with_url_guard(provider_request_url_guard)
+                .with_chat_run_timeout_ms(config.provider_chat_run_timeout_ms),
         );
         let provider_stream_gray_list = create_provider_stream_gray_list(&config);
         let raw_bot_delivery: Arc<dyn BotDeliveryPort> = Arc::new(
@@ -3351,6 +3359,7 @@ impl BcsServer {
             Some(message_repo.clone()),
             provider_stream_gray_list.clone(),
             state_machine_terminal_observer.clone(),
+            config.provider_chat_run_timeout_ms,
         );
 
         let collaboration_store = Arc::new(MemoryCollaborationStore::new());
@@ -3378,6 +3387,7 @@ impl BcsServer {
             )
             .with_bot_registry(bot_registry.clone())
             .with_bot_run_context(bot_run_context.clone())
+            .with_provider_chat_run_timeout_ms(config.provider_chat_run_timeout_ms)
             .with_callback_url_guard(callback_url_guard.clone())
             .with_session_channel_outbound(session_channel_outbound)
             .with_result_publisher(Arc::new(
@@ -3809,7 +3819,8 @@ impl BcsServer {
         let frontend_run_channels = run_channels.clone();
         let ws_bot_delivery: Arc<dyn BotDeliveryPort> = bot_connections.clone();
         let provider_transport = Arc::new(
-            bcs_provider_http::HttpProviderTransport::with_url_guard(outbound_url_guard.clone()),
+            bcs_provider_http::HttpProviderTransport::with_url_guard(outbound_url_guard.clone())
+                .with_chat_run_timeout_ms(config.provider_chat_run_timeout_ms),
         );
         let provider_stream_gray_list = create_provider_stream_gray_list(&config);
         let raw_bot_delivery: Arc<dyn BotDeliveryPort> = Arc::new(
@@ -3973,6 +3984,7 @@ impl BcsServer {
             Some(message_repo.clone()),
             provider_stream_gray_list.clone(),
             state_machine_terminal_observer.clone(),
+            config.provider_chat_run_timeout_ms,
         );
         frontend_connections
             .set_bot_query(use_cases.bot_query.clone())
@@ -4011,6 +4023,7 @@ impl BcsServer {
                 )
                 .with_bot_registry(bot_registry.clone())
                 .with_bot_run_context(bot_run_context.clone())
+                .with_provider_chat_run_timeout_ms(config.provider_chat_run_timeout_ms)
                 .with_callback_url_guard(outbound_url_guard.clone())
                 .with_session_channel_outbound(session_channel_outbound)
                 .with_result_publisher(Arc::new(

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/provider.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/provider.rs
@@ -10,7 +10,7 @@ use crate::ServiceResult;
 use super::message_flow::{BotEventOutcome, ChatEventState, ProviderEventIngestCommand};
 
 /// Default lifetime for an HTTP Provider `chat.send` callback correlation.
-pub const DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS: u64 = 60 * 60 * 1_000;
+pub const DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS: u64 = 3 * 60 * 60 * 1_000;
 
 #[derive(Clone)]
 pub enum ProviderBotEventCredential {

--- a/src/bcs/crates/service-api/bcs-service-api/tests/provider_callback_timeout_contract.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/provider_callback_timeout_contract.rs
@@ -1,6 +1,6 @@
 use bcs_service_api::DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS;
 
 #[test]
-fn default_provider_callback_timeout_is_one_hour() {
-    assert_eq!(DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS, 3_600_000);
+fn default_provider_callback_timeout_is_three_hours() {
+    assert_eq!(DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS, 10_800_000);
 }

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -82,6 +82,7 @@ pub struct CollaborationRuntime {
     bot_delivery: Arc<dyn BotDeliveryPort>,
     bot_registry: Option<Arc<dyn BotRegistryCoreService>>,
     bot_run_context: Option<Arc<dyn BotRunContextPort>>,
+    provider_chat_run_timeout_ms: u64,
     frontend_delivery: Option<Arc<dyn FrontendDeliveryPort>>,
     message_repo: Option<Arc<dyn MessageRepoPort>>,
     session_channel_outbound: Option<Arc<dyn SessionChannelOutboundPort>>,
@@ -122,6 +123,7 @@ impl CollaborationRuntime {
             bot_delivery,
             bot_registry: None,
             bot_run_context: None,
+            provider_chat_run_timeout_ms: bcs_service_api::DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS,
             judge,
             frontend_delivery: None,
             message_repo: None,
@@ -138,6 +140,11 @@ impl CollaborationRuntime {
 
     pub fn with_bot_run_context(mut self, bot_run_context: Arc<dyn BotRunContextPort>) -> Self {
         self.bot_run_context = Some(bot_run_context);
+        self
+    }
+
+    pub fn with_provider_chat_run_timeout_ms(mut self, timeout_ms: u64) -> Self {
+        self.provider_chat_run_timeout_ms = timeout_ms;
         self
     }
 
@@ -591,7 +598,7 @@ impl CollaborationRuntime {
                 .and_then(|node| node.timeout_deadline_ms)
                 .unwrap_or_else(|| {
                     bcs_protocol::now_ms()
-                        .saturating_add(bcs_service_api::DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS)
+                        .saturating_add(self.provider_chat_run_timeout_ms)
                 });
             bot_run_context
                 .put_context(BotRunContext {
@@ -628,7 +635,7 @@ impl CollaborationRuntime {
             delivery_request_id = %delivery_request_id,
             "state_machine: node dispatch started"
         );
-        let frame = build_chat_send_frame(
+        let mut frame = build_chat_send_frame(
             &delivery_request_id,
             &group.id,
             &group_context,
@@ -645,6 +652,13 @@ impl CollaborationRuntime {
             Some("state_machine".to_string()),
             Some(&run.session_id),
         );
+        if let Some(timeout_ms) = node_run.node_timeout_ms {
+            if let BcsFrame::Request(request) = &mut frame {
+                if let Some(params) = request.params.as_mut().and_then(Value::as_object_mut) {
+                    params.insert("timeout_ms".to_string(), Value::from(timeout_ms));
+                }
+            }
+        }
         let target = if let Some(registry) = self.bot_registry.as_ref() {
             registry.resolve_delivery_target(&assignee_bot_id).await?
         } else {

--- a/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
@@ -2230,6 +2230,8 @@ async fn single_node_run_completes_session_with_bot_final_text() {
 
 #[tokio::test]
 async fn state_machine_bot_delivery_registers_message_flow_run_context() {
+    const CONFIGURED_TIMEOUT_MS: u64 = 7_200_000;
+
     let group = Arc::new(GroupStore::new());
     group.upsert(test_group()).await.expect("seed group");
     let store = Arc::new(MemoryCollaborationStore::new());
@@ -2245,7 +2247,67 @@ async fn state_machine_bot_delivery_registers_message_flow_run_context() {
         delivery.clone(),
         noop_judge(),
     )
+    .with_provider_chat_run_timeout_ms(CONFIGURED_TIMEOUT_MS)
     .with_bot_run_context(run_context.clone());
+
+    let definition_yaml = single_node_yaml()
+        .replace("      node_timeout_ms: 120000\n", "")
+        .replace("        node_timeout_ms: 60000\n", "");
+    let before_start_ms = bcs_protocol::now_ms();
+    runtime
+        .start_state_machine_run(StartStateMachineRunCommand {
+            group_id: "group-1".to_string(),
+            session_id: None,
+            definition_yaml: Some(definition_yaml),
+            definition: None,
+            definition_ref: None,
+            participant_bindings: None,
+            input: json!({"question": "stream this"}),
+            caller_id: None,
+            authenticated_human: None,
+        })
+        .await
+        .expect("start run");
+    let after_start_ms = bcs_protocol::now_ms();
+
+    let delivery_run_id = delivery.commands.lock().await[0].run_id.clone();
+    let context = run_context
+        .get_context(&delivery_run_id)
+        .await
+        .expect("state-machine delivery run context");
+    assert_eq!(context.bot_id, "driver-bot");
+    assert!(context.group_id.is_empty());
+    assert!(context.bcs_session_id.is_none());
+    assert!(!context.terminal);
+    assert!(
+        context.deadline_ms
+            >= before_start_ms.saturating_add(CONFIGURED_TIMEOUT_MS)
+    );
+    assert!(
+        context.deadline_ms
+            <= after_start_ms.saturating_add(CONFIGURED_TIMEOUT_MS)
+    );
+}
+
+#[tokio::test]
+async fn state_machine_explicit_node_timeout_overrides_provider_chat_default() {
+    const CONFIGURED_TIMEOUT_MS: u64 = 7_200_000;
+
+    let group = Arc::new(GroupStore::new());
+    group.upsert(test_group()).await.expect("seed group");
+    let store = Arc::new(MemoryCollaborationStore::new());
+    let delivery = Arc::new(RecordingDelivery::default());
+    let runtime = CollaborationRuntime::new(
+        store.clone(),
+        store.clone(),
+        store.clone(),
+        store,
+        group,
+        test_sessions(),
+        delivery.clone(),
+        noop_judge(),
+    )
+    .with_provider_chat_run_timeout_ms(CONFIGURED_TIMEOUT_MS);
 
     runtime
         .start_state_machine_run(StartStateMachineRunCommand {
@@ -2262,16 +2324,19 @@ async fn state_machine_bot_delivery_registers_message_flow_run_context() {
         .await
         .expect("start run");
 
-    let delivery_run_id = delivery.commands.lock().await[0].run_id.clone();
-    let context = run_context
-        .get_context(&delivery_run_id)
-        .await
-        .expect("state-machine delivery run context");
-    assert_eq!(context.bot_id, "driver-bot");
-    assert!(context.group_id.is_empty());
-    assert!(context.bcs_session_id.is_none());
-    assert!(!context.terminal);
-    assert!(context.deadline_ms > bcs_protocol::now_ms());
+    let commands = delivery.commands.lock().await;
+    let BcsFrame::Request(request) = &commands[0].frame else {
+        panic!("state-machine bot delivery must use a request frame");
+    };
+    let timeout_ms = request
+        .params
+        .as_ref()
+        .and_then(|params| params.get("timeout_ms"))
+        .and_then(Value::as_u64)
+        .expect("explicit node timeout must reach Provider chat.send");
+    assert!(timeout_ms > 0);
+    assert!(timeout_ms <= 60_000);
+    assert_ne!(timeout_ms, CONFIGURED_TIMEOUT_MS);
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -52,6 +52,7 @@ pub struct BcsMessageFlow {
     pub interceptors: Arc<InterceptorChain>,
     pub session_management: Option<Arc<dyn SessionManagementService>>,
     pub bot_run_context: Option<Arc<dyn BotRunContextPort>>,
+    pub provider_chat_run_timeout_ms: u64,
     pub system_message: Option<Arc<dyn SystemMessageService>>,
     pub message_repo: Option<Arc<dyn MessageRepoPort>>,
     pub message_tracker: Arc<crate::message_tracker::MessageTracker>,
@@ -81,6 +82,7 @@ impl BcsMessageFlow {
             interceptors: Arc::new(InterceptorChain::new()),
             session_management: None,
             bot_run_context: None,
+            provider_chat_run_timeout_ms: DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS,
             system_message: None,
             message_repo: None,
             message_tracker: Arc::new(crate::message_tracker::MessageTracker::new()),
@@ -122,6 +124,11 @@ impl BcsMessageFlow {
 
     pub fn with_bot_run_context(mut self, run_context: Arc<dyn BotRunContextPort>) -> Self {
         self.bot_run_context = Some(run_context);
+        self
+    }
+
+    pub fn with_provider_chat_run_timeout_ms(mut self, timeout_ms: u64) -> Self {
+        self.provider_chat_run_timeout_ms = timeout_ms;
         self
     }
 
@@ -177,8 +184,7 @@ impl BcsMessageFlow {
                     bot_id: bot_id.to_string(),
                     group_id: group_id.to_string(),
                     bcs_session_id: bcs_session_id.map(str::to_string),
-                    deadline_ms: now_ms()
-                        .saturating_add(DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS),
+                    deadline_ms: now_ms().saturating_add(self.provider_chat_run_timeout_ms),
                     terminal: false,
                 })
                 .await;

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -4654,6 +4654,8 @@ fn manager_worker_flow_with_provider_stream(
     ])))
 }
 
+const CONFIGURED_TASK_RUN_TIMEOUT_MS: u64 = 7_200_000;
+
 async fn manager_worker_flow_with_blocking_repo() -> (
     support::FlowTestSupport,
     Arc<BlockingMessageRepo>,
@@ -4680,6 +4682,7 @@ async fn manager_worker_flow_with_blocking_repo() -> (
         support.bot_delivery.clone(),
         support.frontend_delivery.clone(),
     )
+    .with_provider_chat_run_timeout_ms(CONFIGURED_TASK_RUN_TIMEOUT_MS)
     .with_message_repo(repo.clone())
     .with_bot_run_context(run_context.clone());
     (support, repo, run_context, flow)
@@ -4829,6 +4832,7 @@ async fn manager_worker_task_dispatch_persists_dispatch_to_worker_history_after_
 async fn manager_worker_task_dispatch_records_context_before_history_persistence() {
     let (support, repo, run_context, flow) = manager_worker_flow_with_blocking_repo().await;
 
+    let before_dispatch_ms = bcs_protocol::now_ms();
     let handle = tokio::spawn(async move {
         flow.handle_task_dispatch(TaskDispatchCommand {
             driver_bot_id: "bot-manager".to_string(),
@@ -4847,6 +4851,7 @@ async fn manager_worker_task_dispatch_records_context_before_history_persistence
     let frames = support.bot_delivery.frames().await;
     let run_id = request_id(frames.first().expect("expected task.dispatch frame"));
     let context_before_append_finished = run_context.get_context(&run_id).await;
+    let after_context_ms = bcs_protocol::now_ms();
     repo.release_append();
     let outcome = handle
         .await
@@ -4859,6 +4864,14 @@ async fn manager_worker_task_dispatch_records_context_before_history_persistence
     assert_eq!(context.bot_id, "bot-worker");
     assert_eq!(context.group_id, "group-1");
     assert_eq!(context.bcs_session_id.as_deref(), Some("group-1:abcdef12"));
+    assert!(
+        context.deadline_ms
+            >= before_dispatch_ms.saturating_add(CONFIGURED_TASK_RUN_TIMEOUT_MS)
+    );
+    assert!(
+        context.deadline_ms
+            <= after_context_ms.saturating_add(CONFIGURED_TASK_RUN_TIMEOUT_MS)
+    );
     assert_eq!(repo.appended().await.len(), 1);
 }
 

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -8,7 +8,6 @@ use bcs_service_api::{
     GroupCoreService, GroupStatus, GroupStrategy, HumanActor, MessageFlowService, MessageRole, Participant,
     ParticipantMode, ParticipantRole, PersistentGroupSendCommand, ProviderStreamGrayList,
     RedactedToken, ServiceError, WebSendCommand,
-    DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS,
     ServiceResult, Session, SessionHistoryCommand, SessionKind, SessionManagementService,
     SessionStatus, SessionUseCaseError,
     interceptor::{BlockReason, InterceptorDecision, MessageInterceptor, OutboundMessage},
@@ -1318,6 +1317,8 @@ async fn web_send_persists_public_human_owner_for_manager_worker() {
 
 #[tokio::test]
 async fn accepted_chat_send_records_run_context_for_callback() {
+    const CONFIGURED_TIMEOUT_MS: u64 = 7_200_000;
+
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
     let run_context = Arc::new(MemoryBotRunContextStore::new());
     let flow = BcsMessageFlow::new(
@@ -1327,6 +1328,7 @@ async fn accepted_chat_send_records_run_context_for_callback() {
         support.bot_delivery.clone(),
         support.frontend_delivery.clone(),
     )
+    .with_provider_chat_run_timeout_ms(CONFIGURED_TIMEOUT_MS)
     .with_bot_run_context(run_context.clone());
 
     let before_send_ms = bcs_protocol::now_ms();
@@ -1370,11 +1372,11 @@ async fn accepted_chat_send_records_run_context_for_callback() {
     );
     assert!(
         context.deadline_ms
-            >= before_send_ms.saturating_add(DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS)
+            >= before_send_ms.saturating_add(CONFIGURED_TIMEOUT_MS)
     );
     assert!(
         context.deadline_ms
-            <= after_send_ms.saturating_add(DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS)
+            <= after_send_ms.saturating_add(CONFIGURED_TIMEOUT_MS)
     );
 }
 

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher.rs
@@ -35,6 +35,8 @@ pub struct SystemMessageDispatcherImpl {
     frontend_delivery: Arc<dyn FrontendDeliveryPort>,
     /// Optional run-context registry for HTTP-provider final callbacks.
     bot_run_context: Option<Arc<dyn BotRunContextPort>>,
+    /// Fallback deadline for Provider `chat.send` runs without an explicit timeout.
+    provider_chat_run_timeout_ms: u64,
     /// Optional message repo for persisting system messages to history.
     message_repo: Option<Arc<dyn MessageRepoPort>>,
     /// Deprecated compatibility setting. Provider 2.0 `chat.send` is always
@@ -58,6 +60,7 @@ pub struct SystemMessageDispatcherBuilder {
     delivery: Option<Arc<dyn BotDeliveryPort>>,
     frontend_delivery: Option<Arc<dyn FrontendDeliveryPort>>,
     bot_run_context: Option<Arc<dyn BotRunContextPort>>,
+    provider_chat_run_timeout_ms: Option<u64>,
     message_repo: Option<Arc<dyn MessageRepoPort>>,
     provider_stream_gray_list: Option<Arc<ProviderStreamGrayList>>,
 }
@@ -84,6 +87,12 @@ impl SystemMessageDispatcherBuilder {
     /// Set the run-context registry used by HTTP provider callbacks.
     pub fn with_bot_run_context(mut self, bot_run_context: Arc<dyn BotRunContextPort>) -> Self {
         self.bot_run_context = Some(bot_run_context);
+        self
+    }
+
+    /// Set the fallback deadline for Provider `chat.send` run contexts.
+    pub fn with_provider_chat_run_timeout_ms(mut self, timeout_ms: u64) -> Self {
+        self.provider_chat_run_timeout_ms = Some(timeout_ms);
         self
     }
 
@@ -118,6 +127,9 @@ impl SystemMessageDispatcherBuilder {
             delivery: self.delivery.ok_or("delivery required")?,
             frontend_delivery: self.frontend_delivery.ok_or("frontend_delivery required")?,
             bot_run_context: self.bot_run_context,
+            provider_chat_run_timeout_ms: self
+                .provider_chat_run_timeout_ms
+                .unwrap_or(DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS),
             message_repo: self.message_repo,
             _provider_stream_gray_list: self.provider_stream_gray_list,
         })
@@ -292,6 +304,7 @@ impl SystemMessageDispatcherService for SystemMessageDispatcherImpl {
 
         let delivery = self.delivery.clone();
         let bot_run_context = self.bot_run_context.clone();
+        let provider_chat_run_timeout_ms = self.provider_chat_run_timeout_ms;
         results.extend(join_all(commands.into_iter().map(|cmd| {
             let recipient = cmd.recipient_id.clone();
             let delivery = delivery.clone();
@@ -313,7 +326,7 @@ impl SystemMessageDispatcherService for SystemMessageDispatcherImpl {
                                 group_id: cmd.group_id,
                                 bcs_session_id: cmd.bcs_session_id,
                                 deadline_ms: now_ms()
-                                    .saturating_add(DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS),
+                                    .saturating_add(provider_chat_run_timeout_ms),
                                 terminal: false,
                             })
                             .await;

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
@@ -13,7 +13,7 @@ use bcs_domain::{
 use bcs_service_api::{
     ActorStatus, AgentCredentials, BotCapabilities, BotDeliveryCommand, BotDeliveryKind, BotDeliveryPort,
     BotDeliveryResult, BotDeliveryTarget, BotDynamicStatus, BotRegistryCoreService,
-    BotRunContext, BotRunContextPort, DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS,
+    BotRunContext, BotRunContextPort,
     EnsureHumanResult, ProviderRunTransport, ProviderStreamGrayList, RegisteredBot,
     ServiceError, ServiceResult, SystemMessageDispatcherService, SystemMessageProducerService,
 };
@@ -804,6 +804,8 @@ async fn dispatch_session_context_uses_at_mention_when_group_has_provider_downli
 
 #[tokio::test]
 async fn dispatch_send_system_message_records_run_context_for_provider_callback() {
+    const CONFIGURED_TIMEOUT_MS: u64 = 7_200_000;
+
     let group = Group {
         id: "group-provider".into(),
         label: None,
@@ -849,6 +851,7 @@ async fn dispatch_send_system_message_records_run_context_for_provider_callback(
         .with_delivery(delivery.clone())
         .with_frontend_delivery(frontend_delivery)
         .with_bot_run_context(run_context.clone())
+        .with_provider_chat_run_timeout_ms(CONFIGURED_TIMEOUT_MS)
         .register(FixedSendProducer)
         .build()
         .expect("build dispatcher");
@@ -874,11 +877,11 @@ async fn dispatch_send_system_message_records_run_context_for_provider_callback(
     assert!(!context.terminal);
     assert!(
         context.deadline_ms
-            >= before_dispatch_ms.saturating_add(DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS)
+            >= before_dispatch_ms.saturating_add(CONFIGURED_TIMEOUT_MS)
     );
     assert!(
         context.deadline_ms
-            <= after_dispatch_ms.saturating_add(DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS)
+            <= after_dispatch_ms.saturating_add(CONFIGURED_TIMEOUT_MS)
     );
 }
 

--- a/src/bcs/docs/plans/2026-08-19-provider-chat-run-timeout-design.md
+++ b/src/bcs/docs/plans/2026-08-19-provider-chat-run-timeout-design.md
@@ -1,0 +1,107 @@
+# Configurable Provider Chat Run Timeout Design
+
+- **Date:** 2026-08-19
+- **Status:** Approved
+- **Scope:** HTTP Provider `chat.send` default run deadline
+
+## Problem
+
+HTTP Provider `chat.send` currently falls back to the hard-coded
+`DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS` value of one hour when a delivery frame
+does not contain `params.timeout_ms`. The same hard-coded value is used by the
+message-flow, system-message, and collaboration-runtime run contexts that
+govern callback acceptance and Provider 2.0 SSE reading.
+
+Manager-to-worker task dispatch does not provide an explicit timeout, so a
+worker that legitimately runs for two hours reaches the one-hour Provider run
+deadline. The manager-worker task ledger TTL is a separate concern and does not
+keep the SSE run open.
+
+Operations also needs to change the default deadline through deployment
+configuration. Runtime hot reload is not required; a BCS restart may be used
+to apply an emergency change.
+
+## Decision
+
+Add the top-level BCS setting:
+
+```toml
+provider_chat_run_timeout_ms = 10800000
+```
+
+The default is three hours. It is the fallback execution deadline for HTTP
+Provider `chat.send` only. Existing frames with an explicit
+`params.timeout_ms` retain that value:
+
+```text
+effective timeout = explicit frame timeout
+                    or provider_chat_run_timeout_ms
+```
+
+The configured value is not a cap. An explicit timeout may be shorter or
+longer. This preserves entry-point-specific budgets such as the existing A2A
+Provider execution timeout.
+
+## Runtime Consistency
+
+The same configured fallback must be applied at every point that owns an
+implicit Provider chat deadline:
+
+- `HttpProviderTransport` uses it in the Provider webhook request body when
+  `chat.send` has no explicit timeout.
+- `BcsMessageFlow` uses it for group-chat and manager-worker run contexts.
+- `SystemMessageDispatcherImpl` uses it for system-message run contexts.
+- `CollaborationRuntime` uses it when a Bot task node has no explicit node
+  deadline.
+
+This keeps the value advertised to the Provider aligned with the BCS callback
+and SSE deadline. Constructors retain the public default so isolated tests and
+non-bootstrap consumers remain backward compatible; bootstrap injects the
+configured value into every production composition profile.
+
+The Provider event service's missing-context retention fallback follows the
+new three-hour public default, but it does not create or control an SSE run.
+
+## Interaction with Existing Timeouts
+
+| Path | Effective Provider execution deadline | Other deadline |
+| --- | --- | --- |
+| Manager assigns worker task | New setting, default 3 h | Task ledger TTL remains unchanged |
+| Group/system `chat.send` without explicit timeout | New setting, default 3 h | SSE idle timeout remains 15 min |
+| `chat-async` to HTTP Provider | Existing explicit 2 h | Async lifecycle remains 2 h 5 min by default |
+| Any `chat.send` with explicit `timeout_ms` | Explicit value | Entry-point lifecycle may still impose its own limit |
+
+`async_chat_run_timeout_ms` is not reused or changed. It owns the outer
+`chat-async` lifecycle rather than the default Provider execution budget.
+
+The 15-minute SSE idle timeout is also unchanged. A run may live for up to the
+effective run deadline only while the stream continues producing bytes often
+enough to avoid the independent idle timeout.
+
+## Configuration Lifecycle
+
+The setting is deserialized with the rest of `BcsConfig` and is immutable for
+the process lifetime. Updating the configuration requires restarting BCS. No
+environment-variable read or runtime watcher is introduced.
+
+## Compatibility and Risk
+
+The default changes from one hour to three hours for Provider `chat.send`
+deliveries without an explicit timeout. Explicit timeouts, non-`chat.send`
+Provider methods, interaction resolution, manager-worker task ledger TTL, and
+SSE idle/header timeouts do not change.
+
+The main risk is deadline drift between the outbound request and the internal
+run context. Tests therefore cover the three-hour public default, config
+override parsing, transport fallback and explicit precedence, message-flow and
+system-message run contexts, collaboration-runtime fallback, and bootstrap
+wiring. An A2A regression test retains its explicit two-hour downstream
+timeout.
+
+## Validation
+
+- Focused configuration and Provider transport tests.
+- Message-flow, system-message, and collaboration-runtime deadline tests.
+- Bootstrap compile/tests for all production composition profiles.
+- A2A explicit-timeout regression coverage.
+- Affected Cargo package tests, `cargo check -p bcs`, and `git diff --check`.

--- a/src/bcs/docs/plans/2026-08-19-provider-chat-run-timeout.md
+++ b/src/bcs/docs/plans/2026-08-19-provider-chat-run-timeout.md
@@ -1,0 +1,109 @@
+# Configurable Provider Chat Run Timeout Implementation Plan
+
+> **For Codex:** Implement each task test-first and keep explicit `timeout_ms`
+> precedence intact.
+
+**Goal:** Make the default HTTP Provider `chat.send` run deadline configurable,
+default it to three hours, and keep all explicit per-delivery timeouts unchanged.
+
+**Architecture:** `BcsConfig` owns one process-lifetime default. Bootstrap
+injects it into the HTTP Provider adapter and the application services that
+create implicit Provider run contexts. Core/application services retain the
+public default in constructors for compatibility. The transport computes the
+effective timeout as explicit frame value or configured fallback.
+
+**Tech Stack:** Rust, serde/TOML configuration, async traits, Tokio, Reqwest,
+Cargo tests.
+
+---
+
+### Task 1: Change and parse the public default
+
+**Files:**
+- Modify: `src/bcs/crates/service-api/bcs-service-api/src/application/provider.rs`
+- Modify: `src/bcs/crates/service-api/bcs-service-api/tests/provider_callback_timeout_contract.rs`
+- Modify: `src/bcs/crates/bootstrap/bcs/src/config.rs`
+
+**Steps:**
+
+1. Change the service API contract test to expect `10_800_000` and add config
+   tests for the three-hour default and an explicit override.
+2. Run the focused tests and confirm they fail against the one-hour constant
+   and missing config field.
+3. Change `DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS` to three hours and add
+   `provider_chat_run_timeout_ms` to `BcsConfig`, defaulted from that constant.
+4. Run the focused tests and `cargo check -p bcs-service-api`.
+
+### Task 2: Apply fallback and explicit precedence in the HTTP Provider adapter
+
+**Files:**
+- Modify: `src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs`
+- Modify: `src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs`
+
+**Steps:**
+
+1. Add tests proving an injected Provider chat default is sent when the frame
+   omits `timeout_ms`, and an explicit frame value wins over that injected
+   default.
+2. Run the focused tests and confirm the injected-default test fails.
+3. Store the default on `HttpProviderTransport`, add a builder method, and pass
+   it only to `provider_request_from_frame` for ordinary delivery. Leave
+   `interaction.resolve` and explicit frame parsing unchanged.
+4. Run the Provider transport contract tests.
+
+### Task 3: Align application run contexts
+
+**Files:**
+- Modify: `src/bcs/crates/services/bcs-message-flow/src/group_flow.rs`
+- Modify: `src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs`
+- Modify: `src/bcs/crates/services/bcs-system-message/src/dispatcher.rs`
+- Modify: `src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs`
+- Modify: `src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs`
+- Modify: `src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs`
+
+**Steps:**
+
+1. Add focused tests that inject a non-default timeout and assert the created
+   `BotRunContext.deadline_ms` uses it for message-flow, system-message, and a
+   state-machine Bot node without an explicit node deadline.
+2. Run each focused test and confirm it fails against the hard-coded default.
+3. Add defaulted builder fields/methods to the three services and replace only
+   implicit Provider callback deadlines. Preserve explicit state-machine node
+   deadlines.
+4. Run the three affected package test suites.
+
+### Task 4: Wire the setting through production bootstrap
+
+**Files:**
+- Modify: `src/bcs/crates/bootstrap/bcs/src/server.rs`
+- Modify bootstrap tests in: `src/bcs/crates/bootstrap/bcs/src/server.rs`
+
+**Steps:**
+
+1. Add or extend a bootstrap construction test so the configured value must be
+   accepted through every production profile.
+2. Run `cargo check -p bcs` and use constructor/test failures to identify any
+   missed composition path.
+3. Inject `config.provider_chat_run_timeout_ms` into each
+   `HttpProviderTransport`, `BcsMessageFlow`, `SystemMessageDispatcherImpl`,
+   and `CollaborationRuntime` construction path.
+4. Do not change the A2A construction or its explicit two-hour Provider frame
+   timeout.
+5. Run bootstrap tests and `cargo check -p bcs`.
+
+### Task 5: Regression verification and review
+
+**Files:**
+- Verify all files changed from the design commit.
+
+**Steps:**
+
+1. Run the service-api, Provider adapter, message-flow, system-message,
+   collaboration-runtime, and bootstrap tests affected above.
+2. Run the A2A test that asserts `A2A_DOWNSTREAM_EXECUTION_TIMEOUT_MS` is sent
+   explicitly; add a narrow assertion if current coverage is insufficient.
+3. Search all production uses of `DEFAULT_PROVIDER_CALLBACK_TIMEOUT_MS` and all
+   `BotRunContext` creation sites to confirm no implicit Provider run context
+   remains disconnected from configuration.
+4. Run `git diff --check` and inspect the complete diff for unrelated changes.
+5. Apply the verification-before-completion checklist before reporting success.


### PR DESCRIPTION
## Problem

Provider-backed `chat.send` runs used a fixed one-hour execution deadline. Manager-worker subtasks that legitimately run for up to two hours could therefore lose their Provider SSE run before the worker produced its terminal result. The existing async-chat lifecycle timeout and manager-worker task ledger TTL cover different concerns and should not be reused for this deadline.

## Solution

- Add the top-level `provider_chat_run_timeout_ms` BCS setting with a three-hour default (`10_800_000` ms).
- Thread the configured deadline through every production construction profile used by Provider transport, message flow, system-message dispatch, and collaboration runtime.
- Preserve request-level precedence: an explicit `chat.send.params.timeout_ms` overrides the configured fallback.
- Forward explicit state-machine node timeouts to Provider `chat.send` requests.
- Keep non-chat Provider methods (`chat.inject`, `chat.abort`, and `interaction.resolve`) on their existing one-hour budget.
- Keep the A2A Provider execution timeout explicitly at two hours and its outer async lifecycle at two hours plus five minutes.
- Reject a zero timeout during startup configuration validation.
- Document that changing the setting requires a BCS restart.

## Validation

The following checks were completed before publishing this branch:

- `cargo test -p bcs-service-api -p bcs-provider-http -p bcs-message-flow -p bcs-system-message -p bcs-collaboration-runtime`
- `cargo test -p bcs --lib` — 167 passed, 5 pre-existing ignored
- `cargo check -p bcs`
- Independent code review found no blocking issues.

No additional verification or Git hooks were run during the publish step, as requested.

## Compatibility and risk

- Existing configurations remain valid; omitting the new setting selects the three-hour default.
- The change increases only the fallback deadline for Provider `chat.send` runs. Explicit per-request timeouts continue to win.
- The manager-worker task ledger TTL and the 15-minute SSE idle timeout are unchanged. Long-running Providers must continue to emit SSE heartbeat or progress data within the idle window.
- Applying a changed value requires restarting BCS. Setting the value back to `3_600_000` restores the previous one-hour chat-run behavior.
