### PR TITLE
feat(baas): support BCN interaction SSE and resolution

### DIFF
--- a/src/baas/docs/2026-08-19-baas-bcn-interaction-sse-design.md
+++ b/src/baas/docs/2026-08-19-baas-bcn-interaction-sse-design.md
@@ -1,0 +1,324 @@
+# BaaS 到 BCN 的 Interaction SSE 转换设计
+
+## 背景
+
+Engine 通过 WebSocket 发送 `interaction.requested` 和
+`interaction.resolved` 事件。BaaS 当前把 Engine envelope 基本原样放入 SSE
+`data`，并使用 Engine 事件名作为 SSE `event`：
+
+```text
+id: 1
+event: interaction.requested
+data: {"type":"event","event":"interaction.requested","payload":{...},"runId":"<BCN request id>","seq":1,"ts":...}
+```
+
+BCN Provider 2.0 协议只识别顶层 `event: interaction`，并要求
+`interactionId`、`kind`、`phase` 等字段直接位于 `data` 根部。当前格式有两处
+协议级不兼容：事件名无法被 BCN interaction parser 识别，以及业务字段被
+Engine envelope 嵌套在 `data.payload` 中。即使只修改事件名，BCN 仍无法在
+`data` 根部找到必需字段。
+
+## 目标
+
+- 在 BaaS SSE converter 边界将 Engine interaction 转为 BCN Provider 2.0
+  的扁平 `interaction` 事件。
+- 支持 `ask_user`、`exec`、`mode_switch` 三类 requested interaction。
+- 保留 resolved interaction 的现有能力，并统一输出为 BCN 格式。
+- 对实际 Engine 消息和旧格式做有限兼容，避免单条异常 interaction 终止
+  整条聊天流。
+- 更新 BCN SSE 协议，允许 mode switch 的目标模式和推荐选项。
+
+## 非目标
+
+- 不改变 Engine WebSocket 协议。
+- 不改变 BaaS 中用于 interaction resolve 的完整 Engine envelope 持久化。
+- 不把 Engine 私有状态、生命周期或 UI 元数据暴露到 BCN 公共协议。
+- 不为未知 interaction kind 推测协议结构。
+
+## 设计选择
+
+转换位于 BaaS SSE converter 边界，并按 kind 使用独立的纯转换函数：
+
+```text
+_transform_interaction
+├── _transform_ask_user_requested
+├── _transform_exec_requested
+└── _transform_mode_switch_requested
+```
+
+converter 从已保存的 Engine envelope 中读取 `payload`，创建新的 BCN 数据
+对象，不修改原对象。输出采用字段白名单，防止 Engine 新增内部字段后被自动
+泄露。Engine 回调仍保存完整 envelope，供 interaction resolve 使用。
+
+不在 Engine 回调处直接归一化，因为该层同时承担 Engine 原始事件持久化；过早
+转换会混淆 Engine 合约和 BCN 合约。也不采用通用字段表驱动的深层映射，因为
+三类 interaction 的兼容规则不同，显式的 kind converter 更易审查和测试。
+
+## SSE envelope 与序列语义
+
+转换后的事件形式为：
+
+```text
+id: <BaaS stream sequence>
+event: interaction
+data: {"runId":"<BCN chat.send request id>","seq":<BaaS stream sequence>,"ts":..., ...}
+```
+
+- SSE `id` 是 BaaS 当前连接内生成的递增序号的字符串形式。
+- `data.seq` 使用同一个 BaaS 连接内序号；BCN 使用它做顺序处理和去重。
+- `data.runId` 使用 BCN 发起 `chat.send` 时请求中的 `id`，代表当前 Bot 响应
+  生命周期；不使用 Engine payload 中的 `runId`。
+- `data.ts` 由 BaaS SSE converter 生成。
+- Engine payload 中的 `runId`、`seq`、`ts` 不进入 BCN 输出。
+
+该规则让 interaction 与同一 SSE 流中的 `agent`、`chat` 事件共享统一序列。
+
+## 公共字段
+
+三类 requested interaction 均输出以下公共字段：
+
+| Engine 来源 | BCN `data` 字段 | 规则 |
+| --- | --- | --- |
+| `payload.interactionId`，fallback `payload.id` | `interactionId` | 必需 |
+| `payload.kind` | `kind` | 必需 |
+| `payload.phase` | `phase` | 缺失时根据源事件名推导；与源事件名冲突时以源事件名为准并记录 warning |
+| `payload.title` | `title` | 缺失时不输出 |
+| `payload.description` | `description` | 缺失时不输出 |
+| `payload.toolCallId`，fallback `payload.subject.toolCallId` | `toolCallId` | 缺失时不输出 |
+
+可选字段缺失时直接省略，不输出 `null`。
+
+## `ask_user` requested 映射
+
+除公共字段外：
+
+| Engine 来源 | BCN `data` 字段 | 规则 |
+| --- | --- | --- |
+| `questions[].question` | `questions[].question` | 保留问题正文 |
+| `questions[].header` | `questions[].header` | 存在时保留 |
+| `questions[].header` | `questions[].questionId` | 作为回答键 |
+| `questions[].allowOther` | `questions[].allowOther` | 仅 options 问题可选，且只转发 bool |
+| `questions[].multiSelect` | `questions[].multiSelect` | 可选，只转发 bool |
+| `questions[].options[].decision`，fallback `.value`，旧格式再 fallback `.label` | `questions[].options[].value` | 使用 label fallback 时记录脱敏 warning |
+| `questions[].options[].label` | `questions[].options[].label` | 必需 |
+| `questions[].options[].description` | `questions[].options[].description` | 可选 |
+
+Engine 当前不提供独立 `questionId`。正常情况下使用 `header`。如果 header 缺失
+或为空，BaaS 按问题位置生成稳定 fallback：`question_1`、`question_2`，依次类推，
+并记录 warning。header 和 fallback ID 进入同一个唯一键集合；出现重复
+`questionId` 时，转换阶段由后一题覆盖前一题，只输出一个问题并保留该 key 首次
+出现的位置，同时记录 warning。
+
+当前 Engine orchestrator bridge 的旧 `InteractionQuestion` options 只有
+`label`、可选 `description/preview`，没有 `decision/value`。BaaS 因此按非空
+`decision` > 非空 `value` > 非空 `label` 的优先级生成 BCN option value；只有
+最后一级属于旧格式兼容，并记录不包含 label 或 question 正文的
+`legacy_label_fallback` warning。唯一性、1..4 上限和后写覆盖均基于最终生成的
+option value，因此重复 label-only 选项也在原位置稳定覆盖。
+
+BCN 每个 `ask_user` interaction 要求 1..4 个唯一问题；每个显式 options 问题
+要求 1..4 个唯一 option value。超过上限的唯一项记录 warning 后跳过，重复
+option value 同样采用后写覆盖且保留首次位置。只有源 question 完全没有 options
+key 时才按自由文本问题处理并省略 options；这种情况下也必须省略 `allowOther`。
+只要 options key 存在（包括值为 `null`），其值就必须是数组且转换后包含 1..4
+个有效 option，否则跳过该 question；全部 question 均无效时跳过当前
+interaction，但不终止后续 SSE。
+
+示例：
+
+```text
+event: interaction
+data: {
+  "runId": "bcn-run-1",
+  "seq": 7,
+  "interactionId": "int-ask-1",
+  "kind": "ask_user",
+  "phase": "requested",
+  "title": "Choose deployment",
+  "questions": [{
+    "header": "Region",
+    "questionId": "Region",
+    "question": "Which region should be used?",
+    "multiSelect": false,
+    "options": [{
+      "value": "cn-hangzhou",
+      "label": "Hangzhou",
+      "description": "Lowest latency"
+    }]
+  }],
+  "ts": 1787043219471
+}
+```
+
+## `exec` requested 映射
+
+除公共字段外：
+
+| Engine 来源 | BCN `data` 字段 | 规则 |
+| --- | --- | --- |
+| `payload.cwd` | `cwd` | 可选 |
+| `payload.command` | `command` | 必需，必须为非空字符串 |
+| `payload.options[].label` | `options[].label` | 必需 |
+| `payload.options[].decision`，fallback `.value` | `options[].decision` | 两者都缺失时跳过该选项并 warning |
+
+旧 Engine 类型定义中的 exec 可能没有顶层 `options`；BaaS 接受这种输入并合成
+BCN 可执行的 `allow-once`、`allow-always`、`deny` 三个标准选项。显式提供
+`options` 时必须是非空数组；非法子项被过滤，重复 decision 由后一项覆盖前一项，
+过滤后没有有效选项则跳过当前 interaction。显式 `null` 不触发默认选项合成。
+
+```text
+event: interaction
+data: {
+  "runId": "bcn-run-1",
+  "seq": 8,
+  "interactionId": "int-exec-1",
+  "kind": "exec",
+  "phase": "requested",
+  "title": "Command approval required",
+  "cwd": "/workspace",
+  "command": "npm run deploy",
+  "options": [{"label":"Proceed","decision":"proceed"}],
+  "ts": 1787043219472
+}
+```
+
+## `mode_switch` requested 映射
+
+除公共字段外：
+
+| Engine 来源 | BCN `data` 字段 | 规则 |
+| --- | --- | --- |
+| `payload.fromMode`，fallback `payload.subject.fromMode` | `fromMode` | 可选 |
+| `payload.toMode`，fallback `payload.subject.toMode` | `targetMode` | 可选 |
+| `payload.options[].label` | `options[].label` | 必需 |
+| `payload.options[].decision`，fallback `.value` | `options[].decision` | 两者都缺失时跳过该选项并 warning |
+| `payload.options[].targetMode` | `options[].targetMode` | 可选 |
+| `payload.options[].recommended` | `options[].recommended` | 可选 bool |
+
+实际 Engine 消息在 payload 顶层同时提供 `fromMode`、`toMode`，并在 option 中
+同时提供 `decision`、`value`。转换优先使用顶层模式字段和 `decision`；
+`subject` 与 `value` 仅用于兼容旧格式。
+
+BCN Provider 2.0 SSE 协议同步增加：
+
+- 与 `fromMode` 平级的可选 `targetMode: string`；
+- 明确 `options[].targetMode: string` 为可选；
+- 新增可选 `options[].recommended: bool`。
+
+```text
+event: interaction
+data: {
+  "runId": "bcn-run-1",
+  "seq": 9,
+  "interactionId": "int-mode-1",
+  "kind": "mode_switch",
+  "phase": "requested",
+  "title": "Plan mode transition",
+  "description": "Transition from plan to execute",
+  "toolCallId": "fc-1",
+  "fromMode": "plan",
+  "targetMode": "execute",
+  "options": [
+    {"label":"Continue to execution","decision":"proceed","recommended":true},
+    {"label":"Stay in planning","decision":"stay"}
+  ],
+  "ts": 1787043219473
+}
+```
+
+## 字段白名单
+
+除了以上定义的公共和 kind 专有字段，Engine 内部字段不进入 BCN 数据，包括但
+不限于重复 `id`、`interactionType`、`status`、`subject`、`toolName`、option
+中的 `value` 与 `optionId`、`inputSchema`、`uiHints`、时间和生命周期状态、
+持久化状态、Engine `runId`、Engine `seq` 与 Engine `ts`。
+
+## Resolved 事件
+
+Engine 的 `interaction.resolved` 和 `mode_transition.resolved` 都转换为
+`event: interaction` 和扁平 `data`，phase 为 `resolved`。BaaS 在内部 envelope
+保留原始 Engine 事件名；converter 以事件名映射 BCN phase，因此
+`mode_transition.resolved` payload 中的 Engine lifecycle phase（例如
+`proceeded`）不会泄漏为 BCN phase。公共身份字段及 BCN 已有 resolved 字段按
+白名单输出。这样 requested 和 resolved 共享一个协议入口，不保留
+`event: interaction.resolved` 或 `event: mode_transition.resolved` 的不兼容 SSE
+形式。
+
+mode-switch requested chunk 在活跃 stream 上暴露后，其 interactionId 会进入该
+stream 的有界 pending 集合。对应 `mode_transition.resolved` 到达时只投递一次
+resolved SSE，即使更早的成功 RPC response 已将 DB record 兜底标记为 resolved。
+未暴露 requested chunk、非法 kind 或重复 terminal event 不进入这一兼容投递
+路径。
+
+## 容错与日志
+
+单条 interaction 的转换错误不能冒泡到 SSE 流级错误处理，也不能关闭聊天流。
+
+- 缺少或非法 `interactionId`、`kind`：跳过该 interaction 并 warning。
+- 未知 kind：跳过该 interaction 并 warning。
+- phase 缺失：从 Engine 事件名推导；冲突时使用事件名语义并 warning。
+- 单个 question 或 option 结构非法：只跳过该子项；显式 options 过滤后为空时
+  跳过所属 question。
+- exec/mode_switch option 同时缺少 `decision` 和 `value` 时跳过；ask_user 在 label
+  有效时使用上述旧格式 fallback，并记录脱敏 warning。
+- header 缺失、为空或重复：使用上述 fallback/后写覆盖策略并 warning。
+- 任一 ask_user question 包含 `secret` 或 `isSecret` key 时，无论其值为何都跳过
+  整个 interaction 并 warning，避免 BCN 暴露 secret 输入。
+- questions 缺失、非数组或过滤后为空：跳过当前 interaction 并 warning；后续
+  SSE 和序号不受影响。
+- questions 和每题 options 均限制为 1..4 个唯一键；超限项跳过，重复键后写覆盖，
+  均记录 warning。
+- kind converter 的意外异常在 interaction 转换边界捕获，跳过当前 interaction，
+  不中断后续 SSE。
+
+warning 使用结构化上下文，仅记录 BCN runId、interactionId、kind、字段路径或
+数组索引、错误类型；不记录 question、command、description、answer 等业务敏感
+内容。
+
+## 测试策略
+
+### BaaS converter 单元测试
+
+- 三类 requested 均输出 `event: interaction` 和扁平数据。
+- `runId` 来自 BCN `chat.send` request id；Engine runId/seq/ts 不泄露。
+- SSE `id` 与 `data.seq` 相同，interaction 与相邻 agent/chat 共享递增序列。
+- 公共字段、可选字段省略和 toolCallId 顶层/subject fallback。
+- ask_user 的 question 正文、header 派生 questionId、缺失 fallback、重复后写覆盖、
+  1..4/唯一性限制、bool-only `multiSelect`/`allowOther`、自由文本约束，以及 option
+  decision/value/legacy-label fallback；用真实 Engine label+description-only shape
+  验证输出仍满足 BCN 合约且 warning 不泄露业务文本。
+- exec 的必需 command、无 options 默认选项、显式非法 options 拒绝、option
+  fallback 与重复 decision 后写覆盖。
+- 使用实际抓包形状作为 mode_switch fixture，验证顶层 toMode 到 targetMode、
+  subject fallback、decision/value fallback、recommended 和 option targetMode。
+- 验证 Engine 私有字段不会进入 BCN 数据。
+- 缺少必需身份、未知 kind、非法子项和转换异常只跳过当前 interaction，后续
+  chat/agent 事件仍可输出。
+- phase 缺失和冲突行为。
+- resolved 事件也输出统一的 BCN interaction 形式。
+
+### BCN 合约测试
+
+- 更新 Provider 2.0 SSE 协议示例和字段说明。
+- 增加 mode_switch fixture，覆盖顶层 `targetMode`、可选
+  `options[].targetMode` 和 `options[].recommended`。
+- 验证 parser 接受事件且 raw 数据完整保留新增字段。现有 parser 对 kind 专有
+  字段采用 raw 保留，预期无需修改核心解析逻辑。
+
+## 兼容性与风险
+
+这是 BaaS 对外 SSE wire format 的有意修正：旧消费者如果依赖
+`event: interaction.requested` 或 `data.payload` 将不再兼容；BCN Provider 2.0
+消费者则从无法解析变为可解析。功能继续受现有 BaaS interaction process 配置门控。
+
+主要风险是 Engine 实际消息随版本变化。字段白名单、顶层优先加旧结构 fallback、
+子项级容错和结构化 warning 用于限制风险。回滚可恢复旧 converter 输出；完整
+Engine envelope 的持久化格式不变。
+
+interaction 状态 payload 对允许决策采用显式三态兼容历史 pending 数据：旧记录
+缺少 `allowedDecisions` 时解码为 `None`，仅这种状态按 legacy unrestricted 处理；
+新记录显式写入决策数组，空数组解码为 `()` 并 fail-closed，非空 tuple 按白名单
+校验。序列化时 `None` 继续省略字段，而 `()` 必须保留为 `allowedDecisions: []`，
+因此既不会把新无效 interaction 误当 unrestricted，也不会阻断升级前已经持久化、
+尚待 resolve 的 pending interaction。ask_user 新记录固定允许 `submit`、`cancel`，
+并忽略其协议不支持的顶层 options；exec/mode_switch 只持久化可实际展示的选项。

--- a/src/baas/docs/2026-08-19-baas-bcn-interaction-sse-implementation.md
+++ b/src/baas/docs/2026-08-19-baas-bcn-interaction-sse-implementation.md
@@ -1,0 +1,943 @@
+# BaaS to BCN Interaction SSE Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Convert Engine `interaction.requested` and `interaction.resolved` envelopes into flat BCN Provider 2.0 `event: interaction` SSE frames without allowing a malformed interaction to terminate the chat stream.
+
+**Architecture:** Keep the complete Engine envelope unchanged in the interaction persistence path, and normalize only at the BaaS `DefaultStreamConverter` delivery boundary. Use explicit kind-specific allowlist functions for `ask_user`, `exec`, and `mode_switch`; the generic SSE builder remains the sole owner of BCN run ID, sequence, event ID, and timestamp. BCS already preserves kind-specific fields in `InteractionEvent.raw`, so its production parser remains unchanged while its contract test and protocol documentation are extended.
+
+**Tech Stack:** Python 3.12, pytest, BaaS `StreamChunk`/`SseEvent`, Rust 2024, serde_json, Cargo tests, Markdown Provider 2.0 protocol.
+
+---
+
+Implementation must follow @superpowers:test-driven-development. Before claiming completion, use @superpowers:verification-before-completion. Do not run `cargo fmt`; `src/bcs/CLAUDE.md` explicitly forbids global formatting.
+
+Reference design: `src/baas/docs/2026-08-19-baas-bcn-interaction-sse-design.md`.
+
+### Task 1: Replace passthrough with the BCN interaction envelope and exec mapping
+
+**Files:**
+
+- Modify: `src/baas/tests/unit/core/service/sse/test_default_converter.py:419`
+- Modify: `src/baas/src/secbaas/community/core/service/sse/_default_converter.py:1-168`
+
+**Step 1: Add a test helper that builds the real BaaS chunk shape**
+
+Add below `_data` in the test module:
+
+```python
+def _interaction_chunk(event: str, payload: dict) -> StreamChunk:
+    envelope = {
+        "type": "event",
+        "event": event,
+        "payload": payload,
+    }
+    if "seq" in payload:
+        envelope["seq"] = payload["seq"]
+    return StreamChunk(
+        type="interaction",
+        metadata={"event": event, "payload": envelope},
+    )
+```
+
+Replace the two passthrough assertions in `TestInteractionBranch` with focused tests:
+
+```python
+def test_exec_requested_is_flat_bcn_interaction(self):
+    converter = DefaultStreamConverter()
+    event = converter.convert(
+        _interaction_chunk(
+            "interaction.requested",
+            {
+                "interactionId": "int-1",
+                "runId": "engine-run-7",
+                "seq": 7279,
+                "ts": 1787043219471,
+                "kind": "exec",
+                "phase": "requested",
+                "title": "Command approval required",
+                "description": "Deploy current build",
+                "toolCallId": "tc-1",
+                "cwd": "/workspace",
+                "command": "npm run deploy",
+                "options": [
+                    {"label": "Proceed", "decision": "proceed", "value": "legacy"},
+                    {"label": "Deny", "value": "deny"},
+                ],
+                "status": "pending",
+            },
+        ),
+        run_id="bcn-run-1",
+    )
+
+    assert event is not None
+    assert event.event == "interaction"
+    assert event.id == "1"
+    assert _data(event) == {
+        "runId": "bcn-run-1",
+        "seq": 1,
+        "interactionId": "int-1",
+        "kind": "exec",
+        "phase": "requested",
+        "title": "Command approval required",
+        "description": "Deploy current build",
+        "toolCallId": "tc-1",
+        "cwd": "/workspace",
+        "command": "npm run deploy",
+        "options": [
+            {"label": "Proceed", "decision": "proceed"},
+            {"label": "Deny", "decision": "deny"},
+        ],
+    }
+
+def test_resolved_is_flat_bcn_interaction(self):
+    converter = DefaultStreamConverter()
+    event = converter.convert(
+        _interaction_chunk(
+            "interaction.resolved",
+            {
+                "interactionId": "int-1",
+                "kind": "exec",
+                "phase": "resolved",
+                "decision": "proceed",
+                "idempotencyKey": "idem-1",
+            },
+        ),
+        run_id="bcn-run-1",
+    )
+
+    assert event is not None
+    assert event.event == "interaction"
+    assert _data(event) == {
+        "runId": "bcn-run-1",
+        "seq": 1,
+        "interactionId": "int-1",
+        "kind": "exec",
+        "phase": "resolved",
+        "decision": "proceed",
+        "idempotencyKey": "idem-1",
+    }
+```
+
+The first test intentionally proves that Engine `runId/seq/ts/status/value` do not leak and that `decision` wins over `value`.
+
+Add one resolved ask-user test asserting `action` and `answers` are copied by the
+resolved allowlist, and one exec test without source `options` asserting the target
+synthesizes the BCN-compatible `allow-once`, `allow-always`, and `deny` options.
+These protect the existing resolved capability and the old Engine exec shape.
+
+**Step 2: Run the tests and verify the old passthrough fails**
+
+Run from `src/baas`:
+
+```bash
+uv run pytest tests/unit/core/service/sse/test_default_converter.py::TestInteractionBranch -q
+```
+
+Expected: FAIL because the current event is `interaction.requested` or `interaction.resolved`, and data still contains the Engine envelope.
+
+**Step 3: Add safe dispatch, common fields, resolved fields, and exec conversion**
+
+In `_default_converter.py`:
+
+- Change the module description to say interaction chunks produce `event: interaction`.
+- Import `get_logger` and define `logger = get_logger("core-service")`.
+- Pass `run_id` into `_transform_chunk`, so warnings can identify the BCN run without logging business content.
+- Replace `_transform_interaction` with explicit envelope unwrapping and allowlist construction.
+
+The dispatch signature change is limited to this private call chain:
+
+```python
+def convert(self, chunk: StreamChunk, *, run_id: str) -> SseEvent | None:
+    converted = _transform_chunk(chunk, _engine_name(chunk), run_id=run_id)
+    # Keep the existing heartbeat and _build_event logic unchanged below.
+
+
+def _transform_chunk(
+    chunk: StreamChunk,
+    engine: str,
+    *,
+    run_id: str,
+) -> dict[str, Any] | None:
+    # Keep all existing chat/agent branches unchanged.
+    if chunk.type == "interaction":
+        return _transform_interaction(chunk, run_id=run_id)
+```
+
+Use these function responsibilities and shapes:
+
+```python
+_INTERACTION_PHASES = {
+    "interaction.requested": "requested",
+    "interaction.resolved": "resolved",
+}
+
+
+def _transform_interaction(
+    chunk: StreamChunk,
+    *,
+    run_id: str,
+) -> dict[str, Any] | None:
+    metadata = chunk.metadata or {}
+    source_event = metadata.get("event")
+    expected_phase = _INTERACTION_PHASES.get(source_event)
+    envelope = metadata.get("payload")
+    payload = envelope.get("payload") if isinstance(envelope, dict) else None
+    if expected_phase is None or not isinstance(payload, dict):
+        _warn_interaction(run_id=run_id, error_type="invalid_envelope")
+        return None
+
+    interaction_id = _non_empty_str(payload.get("interactionId"))
+    if interaction_id is None:
+        interaction_id = _non_empty_str(payload.get("id"))
+    kind = _non_empty_str(payload.get("kind"))
+    if interaction_id is None or kind is None:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path="interactionId" if interaction_id is None else "kind",
+            error_type="missing_required_field",
+        )
+        return None
+
+    data = _common_interaction_data(
+        payload,
+        interaction_id=interaction_id,
+        kind=kind,
+        expected_phase=expected_phase,
+        run_id=run_id,
+    )
+    if expected_phase == "resolved":
+        _copy_present(payload, data, ("decision", "action", "answers", "idempotencyKey"))
+        return {"event": "interaction", "data": data}
+
+    if kind == "exec":
+        converter = _transform_exec_requested
+    elif kind == "ask_user":
+        converter = _transform_ask_user_requested
+    elif kind == "mode_switch":
+        converter = _transform_mode_switch_requested
+    else:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path="kind",
+            error_type="unknown_kind",
+        )
+        return None
+
+    try:
+        converter(payload, data, run_id=run_id)
+    except Exception as exc:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            error_type=type(exc).__name__,
+        )
+        return None
+    return {"event": "interaction", "data": data}
+```
+
+`_common_interaction_data` must:
+
+- always set `interactionId`, `kind`, and the phase derived from the source event;
+- warn when payload phase is present and differs from the derived phase;
+- copy only `title` and `description` when present;
+- copy `toolCallId` from payload first, otherwise from a dict-valued `subject`;
+- never copy Engine `runId`, `seq`, `ts`, or the envelope.
+
+Implement those rules explicitly:
+
+```python
+def _common_interaction_data(
+    payload: dict[str, Any],
+    *,
+    interaction_id: str,
+    kind: str,
+    expected_phase: str,
+    run_id: str,
+) -> dict[str, Any]:
+    payload_phase = payload.get("phase")
+    if payload_phase is not None and payload_phase != expected_phase:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path="phase",
+            error_type="phase_conflict",
+        )
+    data: dict[str, Any] = {
+        "interactionId": interaction_id,
+        "kind": kind,
+        "phase": expected_phase,
+    }
+    _copy_present(payload, data, ("title", "description"))
+    subject = payload.get("subject")
+    subject = subject if isinstance(subject, dict) else {}
+    _copy_first_present(payload, subject, data, "toolCallId", "toolCallId")
+    return data
+
+
+def _copy_first_present(
+    source: dict[str, Any],
+    fallback: dict[str, Any],
+    target: dict[str, Any],
+    source_key: str,
+    target_key: str,
+) -> None:
+    value = source.get(source_key)
+    if value is None:
+        value = fallback.get(source_key)
+    if value is not None:
+        target[target_key] = value
+
+
+def _non_empty_str(value: Any) -> str | None:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _warn_interaction(
+    *,
+    run_id: str,
+    interaction_id: str | None = None,
+    kind: str | None = None,
+    field_path: str | None = None,
+    error_type: str,
+) -> None:
+    logger.warning(
+        "interaction SSE conversion warning: run_id=%s interaction_id=%s "
+        "kind=%s field_path=%s error_type=%s",
+        run_id,
+        interaction_id or "",
+        kind or "",
+        field_path or "",
+        error_type,
+    )
+```
+
+Add this exec-specific implementation. BCN requires a non-empty command and a
+non-empty, unique decision option list. The old Engine shape without an
+`options` key is normalized to the three standard decisions; an explicitly
+present invalid/empty/null `options` value is rejected rather than defaulted:
+
+```python
+def _transform_exec_requested(
+    payload: dict[str, Any],
+    data: dict[str, Any],
+    *,
+    run_id: str,
+) -> bool:
+    command = _non_empty_str(payload.get("command"))
+    if command is None:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=data["interactionId"],
+            kind=data["kind"],
+            field_path="payload.command",
+            error_type="missing_required_field",
+        )
+        return False
+    data["command"] = command
+    _copy_present(payload, data, ("cwd",))
+
+    if "options" not in payload:
+        data["options"] = [dict(option) for option in _DEFAULT_EXEC_OPTIONS]
+        return True
+
+    options = _convert_decision_options(
+        payload.get("options"),
+        run_id=run_id,
+        interaction_id=data["interactionId"],
+        kind=data["kind"],
+    )
+    if not options:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=data["interactionId"],
+            kind=data["kind"],
+            field_path="payload.options",
+            error_type="no_valid_options",
+        )
+        return False
+    data["options"] = options
+    return True
+```
+
+`_convert_decision_options` always returns a list. It contains only valid
+`label` and `decision` fields, prefers a non-empty `decision`, falls back to a
+non-empty `value`, skips malformed children, and applies stable last-write-wins
+deduplication by decision. The exec caller rejects an empty result.
+
+```python
+def _convert_decision_options(
+    value: Any,
+    *,
+    run_id: str,
+    interaction_id: str,
+    kind: str,
+) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path="payload.options",
+            error_type="invalid_type",
+        )
+        return []
+
+    options: list[dict[str, str]] = []
+    decision_positions: dict[str, int] = {}
+    for index, source in enumerate(value):
+        field_path = f"payload.options[{index}]"
+        if not isinstance(source, dict):
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=field_path,
+                error_type="invalid_type",
+            )
+            continue
+        label = _non_empty_str(source.get("label"))
+        decision = _non_empty_str(source.get("decision")) or _non_empty_str(
+            source.get("value")
+        )
+        if label is None or decision is None:
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=field_path,
+                error_type="missing_required_field",
+            )
+            continue
+        option = {"label": label, "decision": decision}
+        existing_position = decision_positions.get(decision)
+        if existing_position is not None:
+            options[existing_position] = option
+            continue
+        decision_positions[decision] = len(options)
+        options.append(option)
+    return options
+```
+
+The producer-side `_allowed_decisions` is kind-aware. `ask_user` always records
+`("submit", "cancel")` and ignores unsupported top-level options. `exec` and
+`mode_switch` accept only options whose label and decision/value are non-empty
+strings, skip malformed children, and deduplicate without mutating the Engine
+envelope. Missing exec options yield the same three defaults; missing or wholly
+invalid mode-switch options, plus unknown/missing kinds, yield an explicit empty
+tuple.
+
+Persisted allowed decisions use three states so the stricter validation remains
+compatible with historical pending rows:
+
+- `None` means a legacy JSON payload had no `allowedDecisions` field. Only this
+  state retains unrestricted resolve behavior.
+- `()` means a new record explicitly has no valid decisions and is fail-closed.
+- A non-empty tuple is the exact resolve whitelist.
+
+`BotRunInteractionPayload.from_dict` maps a missing field to `None` and an
+explicit `[]` to `()`. `to_dict` omits `None` but must preserve `()` as
+`allowedDecisions: []`. `BotInteractionService.resolve` performs membership
+validation for every tuple, including the empty tuple, and bypasses it only for
+legacy `None`; it never reconstructs policy from the opaque Engine envelope.
+
+`_warn_interaction` must use parameterized logging and only these values: `run_id`, `interaction_id`, `kind`, `field_path`, and `error_type`. Do not log payloads, exception messages, question text, command, description, or answers.
+
+**Step 4: Run the focused tests**
+
+```bash
+uv run pytest tests/unit/core/service/sse/test_default_converter.py::TestInteractionBranch -q
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/baas/src/secbaas/community/core/service/sse/_default_converter.py src/baas/tests/unit/core/service/sse/test_default_converter.py
+git commit -m "feat(baas): normalize exec interaction SSE events"
+```
+
+### Task 2: Add ask_user field mapping and tolerant question IDs
+
+**Files:**
+
+- Modify: `src/baas/tests/unit/core/service/sse/test_default_converter.py`
+- Modify: `src/baas/src/secbaas/community/core/service/sse/_default_converter.py`
+
+**Step 1: Write failing ask_user mapping tests**
+
+Add a `TestAskUserInteraction` class covering one complete event:
+
+```python
+def test_maps_questions_and_derives_question_ids(self):
+    converter = DefaultStreamConverter()
+    event = converter.convert(
+        _interaction_chunk(
+            "interaction.requested",
+            {
+                "interactionId": "int-ask-1",
+                "kind": "ask_user",
+                "phase": "requested",
+                "title": "Deployment settings",
+                "questions": [
+                    {
+                        "header": "Environment",
+                        "question": "Where should this be deployed?",
+                        "allowOther": True,
+                        "multiSelect": False,
+                        "options": [
+                            {
+                                "decision": "staging",
+                                "value": "legacy-staging",
+                                "label": "Staging",
+                                "description": "Staging environment",
+                            },
+                            {"value": "production", "label": "Production"},
+                        ],
+                    }
+                ],
+            },
+        ),
+        run_id="bcn-run-1",
+    )
+
+    assert event is not None
+    assert _data(event)["questions"] == [
+        {
+            "questionId": "Environment",
+            "header": "Environment",
+            "question": "Where should this be deployed?",
+            "allowOther": True,
+            "multiSelect": False,
+            "options": [
+                {
+                    "value": "staging",
+                    "label": "Staging",
+                    "description": "Staging environment",
+                },
+                {"value": "production", "label": "Production"},
+            ],
+        }
+    ]
+```
+
+Add separate tests for:
+
+- absent optional `allowOther`, `multiSelect`, `description`, and `options` are omitted;
+- missing/empty header produces `question_1`, `question_2` and emits a warning;
+- duplicate header/fallback IDs use last-write-wins, keep the key's first position, and emit a warning;
+- missing/non-array/all-invalid questions drop only the interaction without consuming sequence;
+- explicit options that are non-array, empty, or all-invalid drop their question;
+- questions and per-question options enforce BCN's 1..4 and unique-key constraints;
+- non-object children and missing required fields are skipped locally when a valid parent remains;
+- real Engine label/description-only options use label as the legacy value fallback and emit a sanitized warning;
+- mixed options preserve the priority `decision` > `value` > legacy `label`, with duplicate handling based on the final value;
+- `allowOther`/`multiSelect` accept only bool, and free-text questions omit `allowOther`.
+
+Use `caplog` to assert the warning contains the field path/error type but not the question text or option label.
+
+**Step 2: Run and verify failure**
+
+```bash
+uv run pytest tests/unit/core/service/sse/test_default_converter.py::TestAskUserInteraction -q
+```
+
+Expected: FAIL because `_transform_ask_user_requested` has not populated questions.
+
+**Step 3: Implement ask_user conversion**
+
+Implement `_transform_ask_user_requested` and helpers with these exact output rules:
+
+- The kind helper returns `True` only after producing 1..4 valid questions. The caller
+  returns `None` when it returns `False`, so the rejected interaction consumes no SSE seq.
+- Treat whitespace-only required strings as missing while preserving valid source strings.
+- Derive `questionId` from non-empty `header`, otherwise from the source array's 1-based
+  index. Store converted questions by `questionId`: a duplicate replaces the prior value
+  in its original position and emits a warning. Limit unique questions to four.
+- A missing/non-array questions value or a list with no valid question rejects the current
+  interaction with a warning, without terminating the stream.
+- Only a source question with no `options` key means free text. If the key exists, including
+  with a `None` value, it must be an array yielding 1..4 valid, unique values or the question
+  is skipped. Duplicate values replace the prior option in its original position; excess
+  unique options are skipped.
+- Copy the first non-empty `decision`, `value`, or legacy `label` to option
+  `value`, plus required `label` and optional `description`. The label fallback
+  exists for the real Engine `InteractionQuestion` shape whose options contain
+  only label/description; emit `legacy_label_fallback` with structural context
+  only. Do not emit Engine-only option fields.
+- Apply duplicate last-write-wins and the 1..4 limit to the final option value,
+  including label-only legacy options.
+- Copy `multiSelect` only when it is bool. Copy `allowOther` only when it is bool and the
+  question has valid options; warn and omit it for free-text questions.
+- Requested helpers return a success bool: `exec` requires a valid command and
+  valid/default options, `ask_user` requires valid questions, and `mode_switch`
+  requires valid options. Keep the existing kind-converter exception boundary.
+
+Do not use question text, header, option label/description, payload, or exception messages as
+log context. Malformed children may be skipped locally, but never emit a BCN-invalid empty
+questions/options collection.
+
+**Step 4: Run ask_user and existing converter tests**
+
+```bash
+uv run pytest tests/unit/core/service/sse/test_default_converter.py::TestAskUserInteraction tests/unit/core/service/sse/test_default_converter.py::TestInteractionBranch -q
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/baas/src/secbaas/community/core/service/sse/_default_converter.py src/baas/tests/unit/core/service/sse/test_default_converter.py
+git commit -m "feat(baas): map ask-user interaction questions"
+```
+
+### Task 3: Add actual Engine mode_switch compatibility
+
+**Files:**
+
+- Modify: `src/baas/tests/unit/core/service/sse/test_default_converter.py`
+- Modify: `src/baas/src/secbaas/community/core/service/sse/_default_converter.py`
+
+**Step 1: Write the failing captured-shape test**
+
+Add a pytest fixture or module constant representing the captured Engine payload. It must include:
+
+```python
+{
+    "interactionId": "int:14136f21-01a0-42ed-8000-14136f2102ed",
+    "id": "int:14136f21-01a0-42ed-8000-14136f2102ed",
+    "runId": "engine-run-1",
+    "sessionKey": "engine-session-1",
+    "kind": "mode_switch",
+    "interactionType": "mode_switch",
+    "phase": "requested",
+    "status": "pending",
+    "title": "Plan mode transition",
+    "description": "Transition from plan to execute",
+    "subject": {
+        "type": "mode",
+        "toolCallId": "subject-tool-call",
+        "fromMode": "subject-plan",
+        "toMode": "subject-execute",
+    },
+    "toolCallId": "top-level-tool-call",
+    "options": [
+        {
+            "value": "legacy-proceed",
+            "decision": "proceed",
+            "label": "Continue to execution",
+            "recommended": True,
+            "optionId": "opt-0",
+        },
+        {"value": "stay", "label": "Stay in planning", "targetMode": "plan"},
+    ],
+    "fromMode": "plan",
+    "toMode": "execute",
+    "inputSchema": {"type": "choices", "multiSelect": False},
+    "uiHints": {"variant": "plan", "severity": "info"},
+    "schemaVersion": 2,
+    "seq": 7279,
+    "ts": 1787043219471,
+}
+```
+
+Assert the flat result uses top-level `toolCallId/fromMode/toMode`, renames `toMode` to `targetMode`, prefers option `decision`, falls back to option `value`, retains optional `recommended/targetMode`, and contains none of the Engine internal keys.
+
+Add a second test with only `subject.toolCallId/fromMode/toMode` to verify the old Engine fallback.
+
+**Step 2: Run and verify failure**
+
+```bash
+uv run pytest tests/unit/core/service/sse/test_default_converter.py::TestModeSwitchInteraction -q
+```
+
+Expected: FAIL because mode-switch fields are not yet populated.
+
+**Step 3: Implement mode_switch conversion**
+
+```python
+def _transform_mode_switch_requested(
+    payload: dict[str, Any],
+    data: dict[str, Any],
+    *,
+    run_id: str,
+) -> bool:
+    subject = payload.get("subject")
+    subject = subject if isinstance(subject, dict) else {}
+    _copy_first_present(
+        data,
+        "fromMode",
+        _non_empty_str(payload.get("fromMode")),
+        _non_empty_str(subject.get("fromMode")),
+    )
+    _copy_first_present(
+        data,
+        "targetMode",
+        _non_empty_str(payload.get("toMode")),
+        _non_empty_str(subject.get("toMode")),
+    )
+    options = _convert_mode_switch_options(
+        payload.get("options"),
+        run_id=run_id,
+        interaction_id=data["interactionId"],
+        kind=data["kind"],
+    )
+    if not options:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=data["interactionId"],
+            kind=data["kind"],
+            field_path="payload.options",
+            error_type="no_valid_options",
+        )
+        return False
+    data["options"] = options
+    return True
+```
+
+`_convert_mode_switch_options` requires a non-empty source array and at least one
+valid option. It uses decision/value fallback and stable last-write-wins
+deduplication, copies non-empty optional `targetMode`, and copies
+`recommended` only when it is bool (preserving explicit `False`).
+
+**Step 4: Run all interaction converter tests**
+
+```bash
+uv run pytest tests/unit/core/service/sse/test_default_converter.py -q
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/baas/src/secbaas/community/core/service/sse/_default_converter.py src/baas/tests/unit/core/service/sse/test_default_converter.py
+git commit -m "feat(baas): map mode-switch interaction events"
+```
+
+### Task 4: Prove failure isolation, phase normalization, and shared sequencing
+
+**Files:**
+
+- Modify: `src/baas/tests/unit/core/service/sse/test_default_converter.py`
+- Modify if tests expose a gap: `src/baas/src/secbaas/community/core/service/sse/_default_converter.py`
+
+**Step 1: Add failure-isolation tests**
+
+Add tests that assert:
+
+```python
+def test_invalid_interaction_does_not_consume_seq_or_stop_following_chat(caplog):
+    converter = DefaultStreamConverter()
+    first = converter.convert(StreamChunk(type="delta", content="a"), run_id="bcn-run-1")
+    dropped = converter.convert(
+        _interaction_chunk(
+            "interaction.requested",
+            {"interactionId": "int-secret", "kind": "unknown", "title": "secret-title"},
+        ),
+        run_id="bcn-run-1",
+    )
+    following = converter.convert(StreamChunk(type="delta", content="b"), run_id="bcn-run-1")
+
+    assert first.id == "1"
+    assert dropped is None
+    assert following.id == "2"
+    assert "secret-title" not in caplog.text
+```
+
+Also cover:
+
+- missing `interactionId` and missing `kind` return `None` with warning;
+- `interactionId` falls back to payload `id`;
+- missing phase is derived from the source event;
+- conflicting phase warns and the source event phase wins;
+- malformed envelope returns `None`;
+- monkeypatching a kind converter to raise proves unexpected errors return `None` and only log the exception class, not its message;
+- optional `False` values survive, while absent optional fields are omitted;
+- one valid interaction between an agent/chat event pair uses the same converter-wide sequence and has `event.id == str(data["seq"])`.
+
+**Step 2: Run and verify any uncovered case fails**
+
+```bash
+uv run pytest tests/unit/core/service/sse/test_default_converter.py -q
+```
+
+Expected before the final hardening: at least the phase conflict or forced-exception test fails if Task 1 did not fully isolate it.
+
+**Step 3: Make the minimum hardening changes**
+
+Ensure all interaction-specific failures are caught inside `_transform_interaction`. Do not add a broad catch around chat/agent conversion, because unrelated converter bugs must retain their current behavior. Make warning values structural and parameterized; never include `repr(payload)` or `str(exc)`.
+
+**Step 4: Run BaaS focused tests and lint**
+
+From `src/baas`:
+
+```bash
+uv run pytest tests/unit/core/service/sse/test_default_converter.py -q
+uv run ruff check src/secbaas/community/core/service/sse/_default_converter.py tests/unit/core/service/sse/test_default_converter.py
+```
+
+Expected: both commands PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/baas/src/secbaas/community/core/service/sse/_default_converter.py src/baas/tests/unit/core/service/sse/test_default_converter.py
+git commit -m "test(baas): cover interaction SSE failure isolation"
+```
+
+### Task 5: Extend the BCN Provider 2.0 mode-switch contract
+
+**Files:**
+
+- Modify: `src/bcs/crates/contracts/bcs-protocol/src/stream/parse.rs:266-290`
+- Modify: `src/bcs/docs/bcs-provider-2.0-sse-protocol.md:480-518`
+
+**Step 1: Add a parser compatibility test for the new optional fields**
+
+Add beside the existing interaction parser tests:
+
+```rust
+#[test]
+fn preserves_requested_mode_switch_target_and_recommendation() {
+    let data = json!({
+        "runId": "provider-run-1",
+        "seq": 9,
+        "phase": "requested",
+        "interactionId": "interaction-3",
+        "kind": "mode_switch",
+        "fromMode": "plan",
+        "targetMode": "execute",
+        "options": [
+            {
+                "decision": "proceed",
+                "label": "Continue to execution",
+                "targetMode": "execute",
+                "recommended": true
+            },
+            {"decision": "stay", "label": "Stay in planning"}
+        ]
+    });
+
+    match parse_stream_event("interaction", data.clone()) {
+        StreamEvent::Interaction(interaction) => {
+            assert_eq!(interaction.kind, InteractionKind::ModeSwitch);
+            assert_eq!(interaction.raw["targetMode"], json!("execute"));
+            assert_eq!(interaction.raw["options"][0]["targetMode"], json!("execute"));
+            assert_eq!(interaction.raw["options"][0]["recommended"], json!(true));
+            assert_eq!(interaction.raw, data);
+        }
+        other => panic!("expected interaction, got {other:?}"),
+    }
+}
+```
+
+**Step 2: Run the contract test**
+
+From `src/bcs`:
+
+```bash
+cargo test -p bcs-protocol stream::parse::tests::preserves_requested_mode_switch_target_and_recommendation -- --exact
+```
+
+Expected: PASS without production parser changes. This is a characterization test: the parser intentionally validates common interaction fields and preserves all kind-specific fields in `raw`.
+
+**Step 3: Update the Provider 2.0 protocol**
+
+In the mode-switch requested example:
+
+- add top-level `"targetMode": "execute"` next to `fromMode`;
+- keep option `targetMode` optional;
+- mark the preferred option with `"recommended": true`.
+
+Update the constraints to state explicitly:
+
+```markdown
+- `fromMode/targetMode` are optional Provider opaque strings; BCS does not maintain a mode enum.
+- Option `targetMode` is optional. An option entering a known mode should provide it; stay/deny options may omit it.
+- Option `recommended` is an optional boolean UI hint; omission means no recommendation.
+```
+
+Do not add typed Rust fields or validation for these extensions; doing so would duplicate the raw kind-specific protocol and broaden the code change unnecessarily.
+
+**Step 4: Run the bcs-protocol tests**
+
+```bash
+cargo test -p bcs-protocol
+```
+
+Expected: PASS. Do not run `cargo fmt`.
+
+**Step 5: Commit**
+
+```bash
+git add src/bcs/crates/contracts/bcs-protocol/src/stream/parse.rs src/bcs/docs/bcs-provider-2.0-sse-protocol.md
+git commit -m "docs(bcs): extend mode-switch interaction SSE contract"
+```
+
+### Task 6: Run affected-module verification
+
+**Files:**
+
+- Verify only; no planned production edits.
+
+**Step 1: Install this worktree's repository hooks if not already installed**
+
+From the repository root:
+
+```bash
+scripts/install_git_hooks.sh
+```
+
+Expected: hooks are installed for this worktree.
+
+**Step 2: Run the complete BaaS unit suite**
+
+From `src/baas`:
+
+```bash
+just test-ut
+```
+
+Expected: PASS. If unrelated pre-existing failures occur, record the exact tests and rerun the focused converter suite to separate regression evidence.
+
+**Step 3: Run the BaaS architecture suite**
+
+```bash
+just test-arch
+```
+
+Expected: PASS, including layer and exception-handling rules.
+
+**Step 4: Re-run the affected BCS crate**
+
+From `src/bcs`:
+
+```bash
+cargo test -p bcs-protocol
+```
+
+Expected: PASS.
+
+**Step 5: Check the final diff**
+
+From the repository root:
+
+```bash
+git diff --check origin/dev...HEAD
+git status --short
+```
+
+Expected: no whitespace errors and no uncommitted implementation files. Review `git diff --stat origin/dev...HEAD` to confirm only the requested BaaS converter/tests and BCN protocol/test files were added beyond the pre-existing feature work.
+
+**Step 6: Record validation evidence**
+
+Use the exact command results in the final handoff or PR `## Validation` section. Do not claim the full BaaS or BCS suites passed unless those commands actually completed successfully.

--- a/src/baas/docs/2026-08-20-bcn-answer-header-design.md
+++ b/src/baas/docs/2026-08-20-bcn-answer-header-design.md
@@ -1,0 +1,174 @@
+# BCN Ask-User Answer Header Design
+
+- Date: 2026-08-20
+- Status: Approved
+- Scope: BaaS Engine-to-BCN requested conversion, BCS `interaction.resolve`
+  enrichment, and BaaS BCN-to-Engine normalization
+
+## Problem
+
+An ask-user resolve currently uses the `answers` object key (`questionId`) as
+the display header when BaaS builds the Engine resolution:
+
+```json
+{
+  "answers": {
+    "deploy_target": {
+      "question": "What's your deploy target?",
+      "values": ["staging"]
+    }
+  }
+}
+```
+
+This conflates two independent protocol concepts. `questionId` is a stable
+question identity, while `header` is Provider-owned display text. BCN permits
+Providers to assign different values and does not define `questionId` as a
+fallback header.
+
+## Goals
+
+- Preserve `questionId` only as the outer answer identity.
+- Give every BaaS-produced question an independent deterministic identity and
+  carry `header` only as Provider-owned display text.
+- Forward the trusted requested `header` in each answer sent from BCS to the
+  Provider.
+- Require a non-empty answer `header` at the BaaS Provider boundary.
+- Use `answer.header`, rather than `questionId`, for the Engine `answer`,
+  `message`, and `values` projections.
+- Keep Frontend resolve submissions values-only.
+- Keep Engine request formats unchanged.
+
+## Non-goals
+
+- Making `header` globally required for every BCN Provider.
+- Falling back from a missing answer header to `questionId`, `question`, or a
+  Frontend-supplied field.
+- Changing exec or mode-switch resolution.
+- Changing how custom ask-user values are represented.
+
+## Contract
+
+Frontend continues to submit only values:
+
+```json
+{
+  "action": "submit",
+  "answers": {
+    "deploy_target": {"values": ["staging"]}
+  }
+}
+```
+
+BCS uses the outer `questionId` to locate the authoritative stored requested
+question. It forwards the stored `question` and, when present, the stored
+`header`:
+
+```json
+{
+  "action": "submit",
+  "answers": {
+    "deploy_target": {
+      "header": "部署环境",
+      "question": "What's your deploy target?",
+      "values": ["staging"]
+    }
+  }
+}
+```
+
+The outer key remains `questionId`; it has no display fallback semantics.
+
+## BCS Behavior
+
+BCS keeps `header` optional in the global requested SSE contract. During
+ask-user submit augmentation it:
+
+1. Finds each stored requested question by `questionId`.
+2. Overwrites any Frontend-supplied `question` with the stored question text.
+3. Removes any Frontend-supplied `header`.
+4. Inserts the stored header only when it is a non-empty string.
+5. Does not synthesize a header when the stored question omits it.
+
+The canonical augmented resolution is used for both the idempotency
+fingerprint and the Provider request. Therefore untrusted presentation fields
+cannot change retry identity or reach the Provider.
+
+## BaaS Behavior
+
+BaaS treats answer `header` as required because BaaS-produced ask-user
+requested events always carry one. Its BCN request model and internal domain
+answer require non-empty `header`, `question`, and `values`.
+
+On Engine-to-BCN requested conversion, BaaS requires every Engine question to
+contain a non-empty header. A missing or whitespace-only header drops the
+whole unusable interaction through the existing sanitized warning path; BaaS
+does not synthesize a header. BaaS assigns the independent deterministic
+identity `question_<source position>` and ignores any Engine questionId for
+BCN identity. Repeated headers remain separate questions with distinct IDs
+and produce a content-free warning.
+
+For answers in JSON object order, BaaS builds:
+
+```json
+{
+  "decision": "submit",
+  "answer": "部署环境: staging",
+  "message": "部署环境: staging",
+  "values": {"部署环境": "staging"},
+  "answers": {"What's your deploy target?": "staging"},
+  "selectedOptions": [["staging"]]
+}
+```
+
+`answer` and `message` join question summaries with `；`. Values within one
+answer are joined with `，`. `answers` remains keyed by the full question text,
+and `selectedOptions` remains an ordered two-dimensional array.
+
+If headers repeat, normalization does not reject or stall the interaction.
+The textual summary retains every answer, while the Engine `values` object
+uses stable last-write-wins behavior and BaaS emits a structured warning that
+contains no question, header, or answer content.
+
+## Validation and Errors
+
+- BCS does not reject a globally valid Provider interaction merely because its
+  requested question omitted optional `header`.
+- BCS forwards no header for such a question and performs no fallback.
+- BaaS rejects an ask-user submit whose answer omits `header`, supplies a
+  non-string header, or supplies a whitespace-only header.
+- BaaS does not publish an ask-user requested event if any Engine question
+  omits a non-empty header; the rejected event does not consume an SSE
+  sequence number.
+- The existing finite Provider ACK maps this BaaS validation failure to
+  `ok=false`, `retryable=false`; no malformed Engine request is queued.
+- Cancel, exec, and mode-switch requests are unaffected.
+
+## Compatibility and Deployment
+
+This is an intentional tightening of the BaaS Provider contract. A new BaaS
+does not accept legacy BCS ask-user answers without `header`. Deploy BCS before
+BaaS so BaaS-originated interactions are enriched before strict validation is
+enabled. Old BaaS deployments may ignore the additional field until upgraded.
+
+## Tests
+
+BCS contract and service tests cover:
+
+- Frontend values-only input becomes Provider answers containing stored
+  `question` and stored `header`.
+- Frontend-supplied `question/header` cannot override stored values.
+- Missing stored header is omitted without fallback.
+- Provider transport receives the enriched JSON unchanged.
+
+BaaS adapter and service tests cover:
+
+- Engine-to-BCN conversion uses indexed question IDs independent of header.
+- Missing/empty requested headers drop the interaction without consuming seq.
+- Duplicate requested headers remain distinct and warnings contain no content.
+- Request parsing and domain mapping preserve required header.
+- Missing, empty, whitespace-only, and non-string headers are rejected.
+- Engine summary and `values` use header while `answers` uses question.
+- `questionId` differs from header without leaking into Engine display fields.
+- Duplicate headers use last-write-wins and emit a content-free warning.
+- Cancel, exec, and mode-switch regression behavior remains unchanged.

--- a/src/baas/docs/2026-08-20-bcn-answer-header-implementation.md
+++ b/src/baas/docs/2026-08-20-bcn-answer-header-implementation.md
@@ -1,0 +1,550 @@
+# BCN Ask-User Answer Header Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Carry the authoritative requested question header through BCS ask-user resolution and require BaaS to use that header, rather than `questionId`, when building the Engine resolution.
+
+**Architecture:** BaaS emits only ask-user requested questions with required headers and independent indexed question IDs. Frontend continues to send values-only answers. BCS canonicalizes each answer from its stored requested payload and forwards trusted `question` plus optional trusted `header`; BaaS applies its stricter Provider contract, requiring `header`, then produces the unchanged Engine request shape using header-based display keys.
+
+**Tech Stack:** Rust 2024, Serde/serde_json, Tokio/Cargo tests, Python 3.12, Pydantic v2, dataclasses, pytest, Ruff.
+
+**Spec:** `src/baas/docs/2026-08-20-bcn-answer-header-design.md`
+
+## Global Constraints
+
+- Do not modify Engine source or Engine wire contracts.
+- Do not derive `header` from `questionId`, `question`, or Frontend input.
+- BaaS requested conversion must reject missing headers and must not use header
+  as question identity; use deterministic source-position IDs instead.
+- Keep `header` optional in the global BCN requested protocol.
+- Require a non-empty `header` at the BaaS Provider resolve boundary.
+- Frontend `interaction.resolve` remains values-only.
+- BCS must canonicalize `question/header` before fingerprinting and Provider delivery.
+- Duplicate BaaS headers use stable last-write-wins plus a content-free warning.
+- Do not run global `cargo fmt`; format only changed Rust files if required.
+- Preserve unrelated worktree changes, including the untracked live-verification document.
+
+---
+
+### Task 1: Canonicalize ask-user answer headers in BCS
+
+**Files:**
+- Modify: `src/bcs/crates/services/bcs-interaction/src/management.rs`
+- Test: `src/bcs/crates/services/bcs-interaction/src/management.rs`
+
+**Interfaces:**
+- Consumes: stored `InteractionRecord.requested_payload.questions[]` with required `questionId/question` and optional `header`.
+- Produces: canonical `InteractionProviderCommand.resolution.answers[questionId]` containing `values`, stored `question`, and stored `header` only when present and non-empty.
+
+- [ ] **Step 1: Extend the existing augmentation test and add a missing-header test**
+
+Change `ask_user_submit_augments_answers_with_origin_question` so stored
+questions contain headers that differ from their IDs, while Frontend answers
+contain malicious `question/header` fields:
+
+```rust
+{
+    "questionId": "target",
+    "header": "Deployment environment",
+    "question": "Where should this be deployed?",
+    "options": [{"value": "staging", "label": "Staging"}]
+}
+{
+    "questionId": "components",
+    "header": "Components",
+    "question": "Which components?",
+    "multiSelect": true,
+    "options": [{"value": "web", "label": "Web"}]
+}
+```
+
+```rust
+"answers": {
+    "target": {
+        "values": ["staging"],
+        "question": "frontend question",
+        "header": "frontend header"
+    },
+    "components": {"values": ["web", "worker"]}
+}
+```
+
+Assert the Provider call contains stored values only:
+
+```rust
+assert_eq!(resolution["answers"]["target"]["header"], "Deployment environment");
+assert_eq!(
+    resolution["answers"]["target"]["question"],
+    "Where should this be deployed?"
+);
+assert_eq!(resolution["answers"]["components"]["header"], "Components");
+```
+
+Add `ask_user_submit_omits_header_when_requested_header_is_absent`. Give the
+Frontend answer `"header":"untrusted"`, omit stored header, resolve, and
+assert:
+
+```rust
+assert!(resolution["answers"]["target"].get("header").is_none());
+assert_eq!(resolution["answers"]["target"]["question"], "Where?");
+```
+
+- [ ] **Step 2: Run focused BCS tests and verify RED**
+
+Run from `src/bcs`:
+
+```bash
+cargo test -p bcs-interaction ask_user_submit_augments_answers_with_origin_question -- --exact
+cargo test -p bcs-interaction ask_user_submit_omits_header_when_requested_header_is_absent -- --exact
+```
+
+Expected: the first test fails because stored header is not added; the second
+fails because the Frontend-supplied header survives canonicalization.
+
+- [ ] **Step 3: Implement minimal canonical augmentation**
+
+Inside `augment_ask_user_resolution`, remove any incoming presentation fields
+before inserting stored values:
+
+```rust
+if let Some(answer) = answers.get_mut(question_id).and_then(Value::as_object_mut) {
+    answer.remove("question");
+    answer.remove("header");
+    answer.insert(
+        "question".to_string(),
+        Value::String(question_text.to_string()),
+    );
+    if let Some(header) = question
+        .get("header")
+        .and_then(Value::as_str)
+        .filter(|header| !header.trim().is_empty())
+    {
+        answer.insert("header".to_string(), Value::String(header.to_string()));
+    }
+}
+```
+
+Update the function comment to state that BCS canonicalizes both fields, never
+synthesizes header, and uses the result for fingerprinting and delivery.
+
+- [ ] **Step 4: Run BCS interaction tests and verify GREEN**
+
+```bash
+cargo test -p bcs-interaction ask_user_submit_
+cargo test -p bcs-interaction
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit the BCS canonicalization**
+
+```bash
+git add src/bcs/crates/services/bcs-interaction/src/management.rs
+git commit -m "feat(bcs): forward canonical ask-user headers"
+```
+
+### Task 2: Lock the BCS Provider wire contract and documentation
+
+**Files:**
+- Modify: `src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs`
+- Modify: `src/bcs/docs/bcs-provider-2.0-sse-protocol.md`
+
+**Interfaces:**
+- Consumes: canonical resolution produced by Task 1.
+- Produces: documented Provider 2.0 `interaction.resolve` body with outer `questionId` keys and inner `header/question/values`.
+
+- [ ] **Step 1: Add a Provider transport contract test**
+
+Add a test that sends an ask-user `InteractionProviderCommand` with:
+
+```rust
+kind: InteractionKind::AskUser,
+resolution: json!({
+    "action": "submit",
+    "answers": {
+        "deploy_target": {
+            "header": "Deployment environment",
+            "question": "Where should this be deployed?",
+            "values": ["staging"]
+        }
+    }
+}),
+```
+
+Assert the captured Provider request preserves all three answer fields and the
+outer identity:
+
+```rust
+assert_eq!(
+    request.body["params"]["answers"]["deploy_target"],
+    json!({
+        "header": "Deployment environment",
+        "question": "Where should this be deployed?",
+        "values": ["staging"]
+    })
+);
+```
+
+- [ ] **Step 2: Run the transport contract test**
+
+```bash
+cargo test -p bcs-provider-http --test provider_transport_contract interaction_resolve_forwards_ask_user_header -- --exact
+```
+
+Expected: PASS if the generic resolution flattening already preserves the
+field. This is a characterization test for an unchanged transport adapter; if
+it fails, make only the smallest serialization fix in
+`src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs` and rerun.
+
+- [ ] **Step 3: Update the Provider 2.0 protocol document**
+
+In section 6.2:
+
+- keep Frontend submit values-only;
+- show BCS-to-Provider answers with `header/question/values`;
+- state that `question` and `header` come from stored requested data;
+- state that BCS strips same-named Frontend fields;
+- state that missing requested header remains absent and is never synthesized;
+- state that a specific Provider may impose a stricter required-header
+  contract, as BaaS does.
+
+- [ ] **Step 4: Run BCS protocol and transport regression tests**
+
+```bash
+cargo test -p bcs-provider-http --test provider_transport_contract
+cargo test -p bcs-ws --test web_frame_compat interaction_resolve
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit the BCS contract evidence**
+
+```bash
+git add src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs \
+  src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs \
+  src/bcs/docs/bcs-provider-2.0-sse-protocol.md
+git commit -m "docs(bcs): define ask-user answer headers"
+```
+
+Only add `src/lib.rs` when Step 2 required a production change.
+
+### Task 3: Require and preserve answer header at the BaaS boundary
+
+**Files:**
+- Modify: `src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_model.py`
+- Modify: `src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py`
+- Modify: `src/baas/src/secbaas/community/api/bcn/_models.py`
+- Test: `src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py`
+
+**Interfaces:**
+- Consumes: BCS Provider resolve answer `{header, question, values}`.
+- Produces: `BcnInteractionAnswer(values: tuple[str, ...], question: str, header: str)`.
+
+- [ ] **Step 1: Write strict request and mapping tests**
+
+Update `_interaction_resolve_body` so each answer has a header different from
+its outer question ID:
+
+```python
+"deploy_target": {
+    "header": "Deployment environment",
+    "values": ["staging"],
+    "question": "what's your deploy target?",
+}
+```
+
+Assert parsing and dispatch preserve it:
+
+```python
+assert request.params.answers["deploy_target"].header == "Deployment environment"
+assert resolve_input.answers["deploy_target"].header == "Deployment environment"
+```
+
+Extend invalid-answer cases with:
+
+```python
+{"answers": {"question-1": {"values": ["value"], "question": "Question?"}}}
+{"answers": {"question-1": {"header": "", "values": ["value"], "question": "Question?"}}}
+{"answers": {"question-1": {"header": "   ", "values": ["value"], "question": "Question?"}}}
+{"answers": {"question-1": {"header": 7, "values": ["value"], "question": "Question?"}}}
+```
+
+- [ ] **Step 2: Run BaaS adapter tests and verify RED**
+
+Run from `src/baas`:
+
+```bash
+.venv/bin/pytest tests/unit/adapters/web/open_api/test_bcn_router.py -q
+```
+
+Expected: header attribute/mapping assertions fail and missing header is still
+accepted.
+
+- [ ] **Step 3: Add the strict typed field**
+
+Add to the Pydantic model:
+
+```python
+class InteractionResolveAnswer(BaseModel):
+    values: list[str] = Field(..., min_length=1)
+    question: str
+    header: str
+
+    @field_validator("question", "header")
+    @classmethod
+    def _text_fields_must_be_non_empty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("interaction answer text fields must be non-empty")
+        return value
+```
+
+Add the required domain field:
+
+```python
+@dataclass(slots=True, frozen=True)
+class BcnInteractionAnswer:
+    values: tuple[str, ...]
+    question: str
+    header: str
+```
+
+Map `header=answer.header` in `_dispatch_interaction_resolve`. Do not add a
+default or fallback in any layer.
+
+- [ ] **Step 4: Run BaaS adapter tests and verify GREEN**
+
+```bash
+.venv/bin/pytest tests/unit/adapters/web/open_api/test_bcn_router.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit the BaaS boundary contract**
+
+```bash
+git add src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink \
+  src/baas/src/secbaas/community/api/bcn/_models.py \
+  src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
+git commit -m "feat(baas): require ask-user answer headers"
+```
+
+### Task 4: Normalize BaaS Engine answers from header
+
+**Files:**
+- Modify: `src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py`
+- Test: `src/baas/tests/unit/core/service/bcn/test_bcn_service.py`
+
+**Interfaces:**
+- Consumes: strict `BcnInteractionAnswer.header/question/values` from Task 3.
+- Produces: `InteractionResolution` whose summary and `values` use header, whose `answers` use question, and whose `selected_options` preserve answer order.
+
+- [ ] **Step 1: Write header projection and duplicate-header tests**
+
+Change `_make_interaction_resolve_input` answers to include headers that differ
+from their IDs. Update the main expected resolution to:
+
+```python
+InteractionResolution(
+    kind="ask_user",
+    decision="submit",
+    answer="Deployment environment: staging；Components: web，worker，custom raw value",
+    message="Deployment environment: staging；Components: web，worker，custom raw value",
+    values={
+        "Deployment environment": "staging",
+        "Components": "web，worker，custom raw value",
+    },
+    answers={
+        "what's your deploy target?": "staging",
+        "whats' the components?": "web，worker，custom raw value",
+    },
+    selected_options=(("staging",), ("web", "worker", "custom raw value")),
+)
+```
+
+Add a duplicate-header test with two different question IDs and questions.
+Assert both summaries and selected option groups remain ordered, the `values`
+entry contains the second answer, and one `duplicate_answer_header` warning is
+emitted without header, question, or answer text.
+
+- [ ] **Step 2: Run BaaS normalization tests and verify RED**
+
+```bash
+.venv/bin/pytest tests/unit/core/service/bcn/test_bcn_service.py -q
+```
+
+Expected: existing output still uses outer question IDs, and no duplicate
+header warning exists.
+
+- [ ] **Step 3: Implement header-based normalization**
+
+In `_normalize_interaction_resolution` validate and use source header:
+
+```python
+if not source_answer.header.strip() or not source_answer.question.strip():
+    raise ValueError("ask_user answer identity must be non-empty")
+joined_values = "，".join(source_answer.values)
+summaries.append(f"{source_answer.header}: {joined_values}")
+if source_answer.header in values:
+    logger.warning(
+        "Interaction resolution warning: interaction_id=%s "
+        "field_path=answers.header error_type=duplicate_answer_header",
+        resolve_input.interaction_id,
+    )
+values[source_answer.header] = joined_values
+answers[source_answer.question] = joined_values
+selected_options.append(tuple(source_answer.values))
+```
+
+Do not log the question ID, header, question text, or selected values.
+
+- [ ] **Step 4: Run BaaS service and Engine-frame regression tests**
+
+```bash
+.venv/bin/pytest tests/unit/core/service/bcn/test_bcn_service.py -q
+.venv/bin/pytest \
+  tests/unit/core/service/bot_run/test_interaction_protocol.py \
+  tests/unit/core/service/bot_run/test_bot_websocket_client.py -q
+```
+
+Expected: all tests pass and the unchanged Engine builder emits the new
+header-based normalized values exactly.
+
+- [ ] **Step 5: Commit the BaaS normalization**
+
+```bash
+git add src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py \
+  src/baas/tests/unit/core/service/bcn/test_bcn_service.py
+git commit -m "feat(baas): normalize ask-user answers by header"
+```
+
+### Task 5: Enforce BaaS requested headers and independent question identity
+
+**Files:**
+- Modify: `src/baas/src/secbaas/community/core/service/sse/_default_converter.py`
+- Test: `src/baas/tests/unit/core/service/sse/test_default_converter.py`
+- Modify: `src/baas/docs/2026-08-20-bcn-answer-header-design.md`
+- Modify: `src/baas/docs/2026-08-20-bcn-answer-header-implementation.md`
+
+**Interfaces:**
+- Consumes: Engine ask-user `questions[]` with required BaaS `header` and
+  `question` fields.
+- Produces: BCN questions with `questionId=question_<source position>` and a
+  separate non-empty header.
+
+- [ ] **Step 1: Add RED tests for required header and independent identity**
+
+Cover missing and whitespace-only header dropping the entire interaction
+without consuming seq. Cover two questions with the same header remaining
+distinct as `question_1` and `question_2`, with a sanitized duplicate warning.
+Also prove an Engine-supplied questionId does not override BaaS identity.
+
+- [ ] **Step 2: Implement the minimal requested conversion change**
+
+Return no questions as soon as a missing/empty header is encountered. Always
+derive questionId from the source array position. Track headers only to emit a
+content-free duplicate warning; never replace a previously converted question.
+
+- [ ] **Step 3: Run the complete converter regression and static checks**
+
+```bash
+cd src/baas
+.venv/bin/pytest tests/unit/core/service/sse/test_default_converter.py -q
+.venv/bin/ruff check \
+  src/secbaas/community/core/service/sse/_default_converter.py \
+  tests/unit/core/service/sse/test_default_converter.py
+.venv/bin/ruff format --check \
+  src/secbaas/community/core/service/sse/_default_converter.py \
+  tests/unit/core/service/sse/test_default_converter.py
+```
+
+Expected: all commands exit zero.
+
+### Task 6: Cross-module verification and documentation consistency
+
+**Files:**
+- Verify: `src/bcs/crates/services/bcs-interaction/src/management.rs`
+- Verify: `src/bcs/crates/adapters/http/bcs-provider-http/`
+- Verify: `src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/`
+- Verify: `src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py`
+- Verify: `src/baas/src/secbaas/community/core/service/sse/_default_converter.py`
+- Verify: `src/baas/docs/2026-08-20-bcn-answer-header-design.md`
+- Verify: `src/baas/docs/2026-08-20-bcn-answer-header-implementation.md`
+
+**Interfaces:**
+- Consumes: all Task 1-5 deliverables.
+- Produces: verified BCS-to-BaaS-to-Engine contract evidence with no Engine modification.
+
+- [ ] **Step 1: Run complete affected BCS tests**
+
+```bash
+cd src/bcs
+cargo test -p bcs-interaction
+cargo test -p bcs-provider-http
+cargo test -p bcs-ws --test web_frame_compat interaction_resolve
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Run complete affected BaaS tests**
+
+```bash
+cd src/baas
+.venv/bin/pytest \
+  tests/unit/adapters/web/open_api/test_bcn_router.py \
+  tests/unit/core/service/bcn/test_bcn_service.py \
+  tests/unit/core/service/bot_run/test_interaction_protocol.py \
+  tests/unit/core/service/bot_run/test_bot_websocket_client.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run changed-file static checks**
+
+```bash
+cd src/baas
+.venv/bin/ruff check \
+  src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_model.py \
+  src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py \
+  src/secbaas/community/api/bcn/_models.py \
+  src/secbaas/community/core/service/bcn/_bcn_service.py \
+  tests/unit/adapters/web/open_api/test_bcn_router.py \
+  tests/unit/core/service/bcn/test_bcn_service.py
+.venv/bin/ruff format --check \
+  src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_model.py \
+  src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py \
+  src/secbaas/community/api/bcn/_models.py \
+  src/secbaas/community/core/service/bcn/_bcn_service.py \
+  tests/unit/adapters/web/open_api/test_bcn_router.py \
+  tests/unit/core/service/bcn/test_bcn_service.py
+```
+
+Expected: both commands exit zero.
+
+- [ ] **Step 4: Audit the final contract and diff**
+
+```bash
+rg -n 'questionId.*header|header.*questionId|fallback' \
+  src/bcs/crates/services/bcs-interaction/src/management.rs \
+  src/bcs/docs/bcs-provider-2.0-sse-protocol.md \
+  src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink \
+  src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py
+git diff --check
+git status --short
+```
+
+Confirm there is no production fallback, no Engine file change, and no
+unrelated file staged or committed.
+
+- [ ] **Step 5: Commit final documentation-only corrections if required**
+
+If verification exposed wording drift, update only the two answer-header docs
+and the BCS Provider protocol, then commit:
+
+```bash
+git add src/baas/docs/2026-08-20-bcn-answer-header-design.md \
+  src/baas/docs/2026-08-20-bcn-answer-header-implementation.md \
+  src/bcs/docs/bcs-provider-2.0-sse-protocol.md
+git commit -m "docs(baas): align answer header contract"
+```
+
+If no correction is required, do not create an empty commit.

--- a/src/baas/docs/2026-08-20-bcn-interaction-resolve-design.md
+++ b/src/baas/docs/2026-08-20-bcn-interaction-resolve-design.md
@@ -1,0 +1,238 @@
+# BaaS BCN Interaction Resolve Design
+
+## Context
+
+BCS sends every Provider 2.0 human-interaction answer to the Provider webhook
+as `POST /bcn/downlink` with `method = interaction.resolve`. BaaS already
+persists Engine `interaction.requested` events and has an owner-worker queue
+that delivers a decision to the Engine WebSocket. The downlink router does not
+currently register `interaction.resolve`, and the persisted dispatch command
+currently carries only a decision, so `ask_user` answer data cannot survive the
+HTTP-to-owner-worker boundary.
+
+This change adds the missing BaaS adapter without changing Engine source or
+Engine behavior.
+
+## Goals
+
+- Register `interaction.resolve` on `POST /bcn/downlink` for JSON transport.
+- Accept the full BCS Provider webhook envelope and validate kind-specific
+  resolution data.
+- Persist a normalized, transport-independent resolution with the existing
+  interaction state machine before acknowledging BCS.
+- Deliver the normalized resolution through the existing owner worker and
+  build the Engine-native request for `ask_user`, `exec`, and `mode_switch`.
+- Preserve Provider idempotency across HTTP retries.
+
+## Non-goals
+
+- Do not change any file under `src/engine`.
+- Do not add `interaction.resolve` to SSE transport; it is a finite JSON
+  request returning a JSON acknowledgement.
+- Do not infer whether an `ask_user` value is a predefined option or a custom
+  value. Every value is treated as an ordinary value in this version.
+- Do not synthesize or forward `fromMode`, `targetMode`, BCS run IDs, or BCS
+  idempotency metadata to Engine.
+
+## Chosen architecture
+
+The BCN adapter normalizes the request before persistence. A typed interaction
+resolution is stored with the existing interaction record and returned by
+`claim_for_dispatch`. The owner `AsyncChatClient` passes it to the existing
+Engine WebSocket client, which selects the Engine method and builds the exact
+wire frame.
+
+This preserves the current durable owner-worker flow. Parsing the raw BCN
+envelope in the owner worker was rejected because it would leak a transport
+contract into Engine delivery. Sending directly from the router was rejected
+because the HTTP worker may not own the Engine WebSocket and because it would
+bypass the interaction state machine.
+
+## BCN request contract
+
+The outer request is the existing BCS Provider webhook envelope:
+
+```json
+{
+  "type": "req",
+  "id": "bcn-resolve-1",
+  "method": "interaction.resolve",
+  "session_id": "session-1",
+  "bcn_group_id": "group-1",
+  "to_bot": {
+    "provider_id": "provider-1",
+    "provider_bot_ref": "bot-1"
+  },
+  "params": {
+    "bcsRunId": "bcs-run-1",
+    "runId": "provider-run-1",
+    "interactionId": "interaction-1",
+    "kind": "ask_user",
+    "idempotencyKey": "idem-1",
+    "action": "submit",
+    "answers": {}
+  },
+  "timeout_ms": 3600000
+}
+```
+
+The BaaS lookup key is the trusted outer `session_id` together with
+`params.interactionId`. The stored interaction remains authoritative; the
+Engine request uses the interaction ID returned by that state machine.
+
+## Kind-specific normalization
+
+### `ask_user`
+
+BCN requires `action = submit | cancel`. A submit requires one or more answers.
+Each answer is keyed by `questionId` and contains a non-empty `question` plus a
+non-empty ordered list of string `values`.
+
+Given:
+
+```json
+{
+  "action": "submit",
+  "answers": {
+    "deploy_target": {
+      "values": ["staging"],
+      "question": "what's your deploy target?"
+    },
+    "components": {
+      "values": ["web", "worker"],
+      "question": "whats' the components?"
+    }
+  }
+}
+```
+
+the normalized Engine fields are:
+
+```json
+{
+  "decision": "submit",
+  "answer": "deploy_target: staging；components: web，worker",
+  "message": "deploy_target: staging；components: web，worker",
+  "values": {
+    "deploy_target": "staging",
+    "components": "web，worker"
+  },
+  "answers": {
+    "what's your deploy target?": "staging",
+    "whats' the components?": "web，worker"
+  },
+  "selectedOptions": [
+    ["staging"],
+    ["web", "worker"]
+  ]
+}
+```
+
+Within one question, values are joined with the Chinese comma `，`. Question
+summaries are joined with the Chinese semicolon `；`. JSON object and array
+order follows the incoming answer order. `selectedOptions` is a two-dimensional
+array: each inner array is an unchanged copy of one answer's `values`.
+
+No option lookup or `other` substitution occurs. Cancel produces only
+`decision = cancel`.
+
+### `exec`
+
+BCN supplies a non-empty `decision` that BCS has already checked against the
+offered options. BaaS still validates it against the decision set persisted
+with the requested interaction. The Engine request is:
+
+```json
+{
+  "type": "req",
+  "id": "<BaaS-generated request ID>",
+  "method": "interaction.resolve",
+  "params": {
+    "interactionId": "interaction-exec-1",
+    "decision": "allow-once"
+  }
+}
+```
+
+The same shape supports `allow-always` and `deny` when offered.
+
+### `mode_switch`
+
+BCN also supplies a non-empty `decision`, normally `proceed` or `stay`. Unlike
+the other kinds, Engine uses its mode transition RPC and transition identity:
+
+```json
+{
+  "type": "req",
+  "id": "<BaaS-generated request ID>",
+  "method": "mode_transition.resolve",
+  "params": {
+    "transitionId": "interaction-mode-1",
+    "decision": "stay"
+  }
+}
+```
+
+## Persistence and idempotency
+
+The interaction payload stores both the original BCN request envelope and the
+normalized resolution. `decision` remains explicit for state validation and
+backward compatibility. Older queued records without a normalized resolution
+continue to dispatch as decision-only interaction requests.
+
+For Provider requests, BaaS persists `idempotencyKey` with the accepted
+resolution. A retry with the same key and identical normalized resolution
+returns success without a second state transition or Engine dispatch, including
+after the accepted record reaches a terminal `failed` or `expired` state. If a
+concurrent request wins the `requested -> queued` transition, the loser rereads
+the record before deciding whether the request is an identical replay. Reusing
+the same key for different content, or resolving the same interaction with a
+different key after it has left `requested`, is a conflict.
+
+Engine emits a top-level `interaction.resolved` event for `ask_user` and `exec`,
+and current Engine versions emit `mode_transition.resolved` for `mode_switch`.
+BaaS preserves the raw mode-transition envelope and converts it to the common
+BCN `interaction` event with `phase = resolved`. Because the terminal event can
+arrive after the accepted RPC response, its one-time SSE delivery is gated by
+the active stream's previously exposed mode-switch request rather than by a
+second database state transition.
+
+BaaS still persists the mode RPC exchange first and marks the record resolved
+from an accepted response. This remains a database-terminalization fallback for
+older Engine versions that do not emit `mode_transition.resolved`; the response
+itself does not synthesize a terminal SSE.
+
+## Response and errors
+
+After the record is durably moved to `queued`, `/bcn/downlink` returns the BCS
+Provider acknowledgement:
+
+```json
+{"ok": true}
+```
+
+An interaction validation, lookup, expiry, or conflict failure returns a
+finite acknowledgement with `ok = false`, `retryable = false`, and a sanitized
+error string. Unexpected infrastructure failures remain server errors so BCS
+can treat them as retryable transport failures. Answer content must never be
+written to logs at any level. Pydantic failures for `interaction.resolve` are
+caught inside the downlink route so rejected `input_value` data never reaches
+the global validation logger or a non-2xx transport response.
+
+## Verification
+
+Tests cover:
+
+- Pydantic validation for all three kinds;
+- router registration and exact domain handoff;
+- the exact `ask_user`, `exec`, and `mode_switch` Engine frames;
+- two-dimensional `selectedOptions` and ordered ordinary-value conversion;
+- persistence and claim across the HTTP-to-owner-worker boundary;
+- same-key idempotent retries and conflicting retries;
+- idempotent replay after terminal failure/expiry and concurrent transition
+  races;
+- sanitized invalid-request ACKs and interaction logs;
+- mode-switch terminalization from the accepted Engine RPC;
+- decision-only backward compatibility for existing queued records;
+- focused BaaS router, service, protocol, interaction, and async client suites;
+- Ruff formatting/checking and `git diff --check`.

--- a/src/baas/docs/2026-08-20-bcn-interaction-resolve-implementation.md
+++ b/src/baas/docs/2026-08-20-bcn-interaction-resolve-implementation.md
@@ -1,0 +1,478 @@
+# BCN Interaction Resolve Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Register `interaction.resolve` on BaaS `/bcn/downlink`, durably normalize BCS resolutions, and deliver the exact kind-specific request to the existing Engine WebSocket without changing Engine source.
+
+**Architecture:** The BCN HTTP adapter validates the Provider webhook and converts it to a typed, transport-independent `InteractionResolution`. The existing bot-interaction state service persists that resolution and idempotency key, the owner worker claims it, and the BaaS Engine adapter selects `interaction.resolve` or `mode_transition.resolve` and serializes the exact wire params. Existing decision-only queued records remain compatible.
+
+**Tech Stack:** Python 3.12, FastAPI, Pydantic v2, dependency-injector, dataclasses, pytest, Ruff.
+
+---
+
+### Task 1: Add the typed interaction resolution contract
+
+**Files:**
+- Modify: `src/baas/src/secbaas/community/api/bot_interaction/_models.py`
+- Modify: `src/baas/src/secbaas/community/api/bot_interaction/__init__.py`
+- Test: `src/baas/tests/unit/core/service/test_bot_interaction_service.py`
+
+**Step 1: Write the failing model test**
+
+Add a test that constructs a normalized ask-user resolution with ordered
+values, question-text answers, and two-dimensional selected options, then
+asserts `to_dict()` and `from_dict()` preserve the exact JSON-safe shape.
+
+The public model is:
+
+```python
+@dataclass(frozen=True, slots=True)
+class InteractionResolution:
+    decision: str
+    kind: Literal["ask_user", "exec", "mode_switch"] | None = None
+    answer: str | None = None
+    message: str | None = None
+    values: dict[str, str] | None = None
+    answers: dict[str, str] | None = None
+    selected_options: tuple[tuple[str, ...], ...] | None = None
+
+    def to_dict(self) -> dict[str, object]: ...
+
+    @classmethod
+    def from_dict(cls, value: dict[str, object]) -> "InteractionResolution": ...
+```
+
+`kind=None` is intentional for real legacy queued records that predate the
+normalized payload and must continue to use `interaction.resolve`.
+
+**Step 2: Run the focused test and verify RED**
+
+Run from `src/baas`:
+
+```bash
+.venv/bin/pytest tests/unit/core/service/test_bot_interaction_service.py -q
+```
+
+Expected: collection/import failure because `InteractionResolution` does not
+exist.
+
+**Step 3: Implement strict serialization**
+
+Validate non-empty `decision`, the optional kind enum, string maps, and nested
+string arrays. Serialize with Engine wire key `selectedOptions`, omitting every
+`None` field. Export the model from `api.bot_interaction`.
+
+**Step 4: Run the focused test and verify GREEN**
+
+Run the command from Step 2. Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/baas/src/secbaas/community/api/bot_interaction \
+  src/baas/tests/unit/core/service/test_bot_interaction_service.py
+git commit -m "feat(baas): model normalized interaction resolutions"
+```
+
+### Task 2: Persist normalized resolutions and Provider idempotency
+
+**Files:**
+- Modify: `src/baas/src/secbaas/community/api/bot_interaction/_models.py`
+- Modify: `src/baas/src/secbaas/community/api/bot_interaction/_protocols.py`
+- Modify: `src/baas/src/secbaas/community/core/repository/bot_run_interaction/_record.py`
+- Modify: `src/baas/src/secbaas/community/core/service/bot_interaction/_service.py`
+- Test: `src/baas/tests/unit/core/service/test_bot_interaction_service.py`
+- Test: `src/baas/tests/unit/core/repository/bot_run_interaction/test_orm_repository.py`
+
+**Step 1: Write failing state-machine tests**
+
+Cover:
+
+- a requested record transitions to queued with `decision`, normalized
+  `resolution`, original `clientReq`, and `idempotencyKey` persisted;
+- `claim_for_dispatch` returns the complete `InteractionResolution`;
+- the same idempotency key plus identical resolution deduplicates without a
+  second transition, including after accepted terminal states;
+- a lost `requested -> queued` transition race rereads and recognizes an
+  identical concurrent winner;
+- the same key with different content conflicts;
+- a different key after the record left requested conflicts;
+- a legacy queued record without `resolution` returns a decision-only
+  resolution with `kind=None`.
+
+Change the service contract to:
+
+```python
+def resolve(
+    self,
+    *,
+    session_key: str,
+    interaction_id: str,
+    resolution: InteractionResolution,
+    request_envelope: dict[str, Any],
+    idempotency_key: str | None = None,
+) -> InteractionResolveResult: ...
+```
+
+and make `InteractionDispatch` carry `resolution` instead of only `decision`.
+
+**Step 2: Run tests and verify RED**
+
+```bash
+.venv/bin/pytest \
+  tests/unit/core/service/test_bot_interaction_service.py \
+  tests/unit/core/repository/bot_run_interaction/test_orm_repository.py -q
+```
+
+Expected: failures because payload and service do not persist or claim the new
+fields.
+
+**Step 3: Implement the minimal persistence changes**
+
+Add optional JSON fields `resolution` and `idempotencyKey` to
+`BotRunInteractionPayload` and its patch. The state service serializes the
+typed resolution on transition and reconstructs it on claim. It compares the
+persisted normalized resolution for idempotent retries and never compares or
+logs raw answer text.
+
+Update the existing OpenAPI resolve adapter to construct a decision-only
+`InteractionResolution`; its external request and response remain unchanged.
+
+**Step 4: Run tests and verify GREEN**
+
+Run the command from Step 2 plus:
+
+```bash
+.venv/bin/pytest tests/unit/adapters/web/open_api -q
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/baas/src/secbaas/community/api/bot_interaction \
+  src/baas/src/secbaas/community/core/repository/bot_run_interaction \
+  src/baas/src/secbaas/community/core/service/bot_interaction \
+  src/baas/src/secbaas/community/adapters/web/routers/open_api \
+  src/baas/tests/unit/core/service/test_bot_interaction_service.py \
+  src/baas/tests/unit/core/repository/bot_run_interaction/test_orm_repository.py \
+  src/baas/tests/unit/adapters/web/open_api
+git commit -m "feat(baas): persist interaction resolution payloads"
+```
+
+### Task 3: Build exact Engine resolve frames
+
+**Files:**
+- Modify: `src/baas/src/secbaas/community/core/service/bot_run/_interaction_protocol.py`
+- Modify: `src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py`
+- Test: `src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py`
+- Test: `src/baas/tests/unit/core/service/bot_run/test_bot_websocket_client.py`
+
+**Step 1: Write failing protocol tests**
+
+Assert exact frames for:
+
+- ask-user submit with `answer`, `message`, `values`, question-text `answers`,
+  and two-dimensional `selectedOptions`;
+- ask-user cancel with only `interactionId` and `decision`;
+- exec `allow-once` and `deny` using `interaction.resolve`;
+- mode switch `stay` and `proceed` using `mode_transition.resolve` and
+  `transitionId`;
+- legacy `kind=None` using decision-only `interaction.resolve`.
+
+**Step 2: Run tests and verify RED**
+
+```bash
+.venv/bin/pytest \
+  tests/unit/core/service/bot_run/test_interaction_protocol.py \
+  tests/unit/core/service/bot_run/test_bot_websocket_client.py -q
+```
+
+Expected: failures because the builder accepts only a decision and always
+creates `interaction.resolve`.
+
+**Step 3: Implement the builder and client handoff**
+
+Change `build_interaction_resolve_request` and
+`BotWebSocketClient.interaction_resolve` to accept `InteractionResolution`.
+For `mode_switch`, emit `mode_transition.resolve` with `transitionId`; otherwise
+emit `interaction.resolve` with `interactionId`. Copy only the normalized
+optional fields produced by the BaaS adapter.
+
+**Step 4: Run tests and verify GREEN**
+
+Run the command from Step 2. Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/baas/src/secbaas/community/core/service/bot_run \
+  src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py \
+  src/baas/tests/unit/core/service/bot_run/test_bot_websocket_client.py
+git commit -m "feat(baas): build kind-specific engine resolve frames"
+```
+
+### Task 4: Carry the resolution through the owner worker
+
+**Files:**
+- Modify: `src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py`
+- Test: `src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py`
+- Test: `src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py`
+- Test: `src/baas/tests/unit/core/service/bot_run/test_engine_dispatch_integration.py`
+
+**Step 1: Write a failing persistence-to-Engine test**
+
+Use the real interaction service with a fake repository, persist an ask-user
+resolution, allow `AsyncChatClient` to claim it, and assert the fake Engine
+client receives the complete typed resolution. Also retain an existing
+decision-only case.
+
+**Step 2: Run tests and verify RED**
+
+```bash
+.venv/bin/pytest \
+  tests/unit/core/service/bot_run/test_async_chat_client.py \
+  tests/unit/core/service/bot_run/test_async_chat_client_coverage.py \
+  tests/unit/core/service/bot_run/test_engine_dispatch_integration.py -q
+```
+
+Expected: failures because the owner worker passes only `command.decision`.
+
+**Step 3: Pass the typed resolution**
+
+Replace the decision-only call with
+`client.interaction_resolve(interaction_id=..., resolution=command.resolution)`.
+Do not parse the stored BCN envelope in this layer.
+
+**Step 4: Run tests and verify GREEN**
+
+Run the command from Step 2. Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py \
+  src/baas/tests/unit/core/service/bot_run
+git commit -m "feat(baas): dispatch complete interaction resolutions"
+```
+
+### Task 5: Add the BCN request/domain contract and normalization
+
+**Files:**
+- Modify: `src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_model.py`
+- Modify: `src/baas/src/secbaas/community/api/bcn/_models.py`
+- Modify: `src/baas/src/secbaas/community/api/bcn/_protocols.py`
+- Modify: `src/baas/src/secbaas/community/api/bcn/__init__.py`
+- Modify: `src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py`
+- Test: `src/baas/tests/unit/core/service/bcn/test_bcn_service.py`
+- Test: `src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py`
+
+**Step 1: Write failing request and normalization tests**
+
+Add BCS-shaped fixtures for ask-user submit/cancel, exec allow/deny, and mode
+switch proceed/stay. The ask-user assertion must exactly match:
+
+```json
+{
+  "decision": "submit",
+  "answer": "deploy_target: staging；components: web，worker",
+  "message": "deploy_target: staging；components: web，worker",
+  "values": {
+    "deploy_target": "staging",
+    "components": "web，worker"
+  },
+  "answers": {
+    "what's your deploy target?": "staging",
+    "whats' the components?": "web，worker"
+  },
+  "selectedOptions": [["staging"], ["web", "worker"]]
+}
+```
+
+Also test empty values, missing question, invalid kind-specific decision/action,
+and that ordinary values are never rewritten to `other`.
+
+**Step 2: Run tests and verify RED**
+
+```bash
+.venv/bin/pytest \
+  tests/unit/core/service/bcn/test_bcn_service.py \
+  tests/unit/adapters/web/open_api/test_bcn_router.py -q
+```
+
+Expected: import and assertion failures because the BCN resolve models and
+service method do not exist.
+
+**Step 3: Implement models and normalization**
+
+Add Pydantic transport models with aliases for `bcsRunId`, `runId`,
+`interactionId`, and `idempotencyKey`. Add API dataclasses for the domain
+input/result. `DefaultBcnDownlinkService.handle_interaction_resolve` performs
+the ordinary-value conversion, builds `InteractionResolution`, and calls the
+bot-interaction service with outer `session_id` and the original request
+envelope.
+
+Do not inspect requested options or create `other`.
+
+**Step 4: Run tests and verify GREEN**
+
+Run the command from Step 2. Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_model.py \
+  src/baas/src/secbaas/community/api/bcn \
+  src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py \
+  src/baas/tests/unit/core/service/bcn/test_bcn_service.py \
+  src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
+git commit -m "feat(baas): normalize BCN interaction resolutions"
+```
+
+### Task 6: Register `/bcn/downlink` and wire composition
+
+**Files:**
+- Modify: `src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py`
+- Modify: `src/baas/src/secbaas/community/bootstrap/_core_services.py`
+- Modify: `src/baas/tests/architecture/check_protocols/api/bcn/check_bcn_downlink_service.py`
+- Test: `src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py`
+- Test: `src/baas/tests/e2e/asgi/baseline/test_bcn_downlink_extended.py`
+
+**Step 1: Write a failing route test**
+
+POST a full BCS Provider request with `method=interaction.resolve` and JSON
+transport. Assert it is registered, calls the service once, and returns the
+Provider acknowledgement `{"ok": true}`. Add a service-error case returning
+`{"ok": false, "retryable": false, "error": ...}` without exposing answers.
+Assert SSE transport continues to reject this finite method.
+
+**Step 2: Run tests and verify RED**
+
+```bash
+.venv/bin/pytest \
+  tests/unit/adapters/web/open_api/test_bcn_router.py \
+  tests/e2e/asgi/baseline/test_bcn_downlink_extended.py -q
+```
+
+Expected: HTTP 501 / missing dispatcher.
+
+**Step 3: Register and wire the service**
+
+Register `interaction.resolve` in `_METHOD_DISPATCH`, update router docs and
+response union, and inject `bot_interaction_service` into
+`DefaultBcnDownlinkService` at the composition root. Update the architecture
+protocol construction fixture.
+
+**Step 4: Run tests and verify GREEN**
+
+Run the command from Step 2 plus:
+
+```bash
+.venv/bin/pytest tests/architecture/check_protocols/api/bcn -q
+```
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py \
+  src/baas/src/secbaas/community/bootstrap/_core_services.py \
+  src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py \
+  src/baas/tests/e2e/asgi/baseline/test_bcn_downlink_extended.py \
+  src/baas/tests/architecture/check_protocols/api/bcn/check_bcn_downlink_service.py
+git commit -m "feat(baas): register BCN interaction resolve downlink"
+```
+
+### Task 7: Regression and boundary verification
+
+**Files:**
+- Modify only files required by failures caused by this feature.
+
+**Step 1: Run focused interaction and BCN suites**
+
+```bash
+cd src/baas
+.venv/bin/pytest \
+  tests/unit/core/service/test_bot_interaction_service.py \
+  tests/unit/core/repository/bot_run_interaction \
+  tests/unit/core/service/bot_run/test_interaction_protocol.py \
+  tests/unit/core/service/bot_run/test_bot_websocket_client.py \
+  tests/unit/core/service/bot_run/test_async_chat_client.py \
+  tests/unit/core/service/bot_run/test_async_chat_client_coverage.py \
+  tests/unit/core/service/bot_run/test_engine_dispatch_integration.py \
+  tests/unit/core/service/bcn \
+  tests/unit/adapters/web/open_api/test_bcn_router.py \
+  tests/e2e/asgi/baseline/test_bcn_downlink.py \
+  tests/e2e/asgi/baseline/test_bcn_downlink_extended.py -q
+```
+
+Expected: PASS.
+
+**Step 2: Run formatting and lint**
+
+```bash
+.venv/bin/ruff format --check \
+  src/secbaas/community/api/bot_interaction \
+  src/secbaas/community/api/bcn \
+  src/secbaas/community/core/repository/bot_run_interaction \
+  src/secbaas/community/core/service/bot_interaction \
+  src/secbaas/community/core/service/bot_run \
+  src/secbaas/community/core/service/bcn \
+  src/secbaas/community/adapters/web/routers/bcn_downlink \
+  tests/unit/core/service/test_bot_interaction_service.py \
+  tests/unit/core/service/bot_run \
+  tests/unit/core/service/bcn \
+  tests/unit/adapters/web/open_api/test_bcn_router.py
+
+.venv/bin/ruff check <the same changed Python paths>
+```
+
+Expected: PASS.
+
+**Step 3: Check repository boundaries**
+
+```bash
+cd ../..
+git diff --check origin/dev...HEAD
+git diff --name-only 113cc1b04...HEAD | rg '^src/engine/'
+git status --short
+```
+
+Expected: no whitespace errors, no Engine paths, and a clean worktree after
+the final commit.
+
+**Step 4: Commit any test-only cleanup**
+
+```bash
+git add <only files required by the verified feature>
+git commit -m "test(baas): cover BCN interaction resolve delivery"
+```
+
+### Task 8: Harden validation, logging, terminalization, and retries
+
+**Files:**
+- Modify: `src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py`
+- Modify: `src/baas/src/secbaas/community/core/service/bot_interaction/_service.py`
+- Modify: `src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py`
+- Modify: `src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py`
+- Test the corresponding router, state-service, and websocket paths.
+
+**Step 1: Add RED regressions**
+
+Cover four review findings: malformed Provider answers must receive a sanitized
+finite ACK; interaction answer content must not appear in raw-frame or wildcard
+logs; an accepted `mode_transition.resolve` response must terminalize its row;
+and identical idempotent retries must survive terminal states and a concurrent
+transition winner.
+
+**Step 2: Implement the boundary fixes**
+
+Catch `InteractionResolveRequest` validation errors inside `/bcn/downlink`, log
+only structural interaction metadata, mark an accepted mode-switch RPC resolved
+after recording its exchange, and reread a failed queue transition before
+returning a conflict. Compare only the normalized resolution for idempotency;
+never log raw answers.
+
+**Step 3: Re-run the focused and complete verification from Task 7**

--- a/src/baas/docs/2026-08-20-mode-transition-resolved-sse-design.md
+++ b/src/baas/docs/2026-08-20-mode-transition-resolved-sse-design.md
@@ -1,0 +1,119 @@
+# Mode Transition Resolved SSE Design
+
+## Problem
+
+BaaS currently subscribes to Engine `interaction.requested` and
+`interaction.resolved` events. A mode-switch request is exposed correctly, but
+the Engine completes it with a distinct top-level event:
+`mode_transition.resolved`.
+
+The accepted `mode_transition.resolve` RPC is already used as a compatibility
+fallback to terminalize the persisted interaction. Therefore, merely routing
+the newly observed event through the existing `interaction.resolved` handler
+is insufficient: by the time the event arrives, the database transition can
+legitimately return `False`, and the resolved SSE would still be dropped.
+
+## Goal
+
+Expose one BCN-compatible resolved interaction SSE for an Engine
+`mode_transition.resolved` event without changing the Engine protocol or
+regressing the accepted-RPC fallback used by older Engine versions.
+
+The public SSE shape is:
+
+```text
+event: interaction
+data: {
+  "interactionId": "int:...",
+  "kind": "mode_switch",
+  "phase": "resolved",
+  "decision": "proceed",
+  "runId": "provider-run-id",
+  "seq": 1
+}
+```
+
+The Engine's raw `phase`, such as `proceeded`, is not exposed. The event name
+defines the canonical BCN phase `resolved`.
+
+## Boundary mapping
+
+BaaS subscribes to all three Engine interaction events:
+
+- `interaction.requested`
+- `interaction.resolved`
+- `mode_transition.resolved`
+
+The typed Engine boundary preserves the original event name in its envelope.
+It does not relabel `mode_transition.resolved` as `interaction.resolved`.
+
+The SSE converter accepts the original event names and maps them explicitly:
+
+| Engine event | BCN SSE event | BCN phase |
+| --- | --- | --- |
+| `interaction.requested` | `interaction` | `requested` |
+| `interaction.resolved` | `interaction` | `resolved` |
+| `mode_transition.resolved` | `interaction` | `resolved` |
+
+For the mode-transition alias, the converter uses the existing resolved-field
+allowlist. It exposes `interactionId`, `kind`, and `decision`, plus the normal
+BaaS `runId`, `seq`, and timestamp fields. It does not expose Engine lifecycle,
+status, options, or reconciliation fields.
+
+## Single-delivery rule
+
+Each active stream keeps a bounded set of mode-switch interaction IDs whose
+requested chunks were emitted to that stream.
+
+1. When a newly persisted `mode_switch` requested event emits an interaction
+   chunk, its interaction ID is added to the stream-local set.
+2. When `mode_transition.resolved` arrives, BaaS validates that it is a
+   `mode_switch` terminal event and attempts the normal database terminal
+   transition with the original envelope.
+3. BaaS emits the resolved chunk only when the interaction ID is present in
+   the same stream-local set, then removes it before emission.
+4. A replayed terminal event cannot emit twice because the ID has already been
+   removed.
+5. An unsolicited or non-mode event cannot enter this compatibility path.
+
+The stream-local set is released with the existing `SessionState`; it does not
+create process-lifetime interaction state. The database keeps its existing
+first-terminal-write semantics. If the accepted RPC fallback terminalized the
+record first, the later Engine event may return `False` from `mark_resolved`,
+but it still supplies the one terminal SSE for the exposed active stream.
+
+## Backward compatibility
+
+The accepted `mode_transition.resolve` RPC continues to mark a mode-switch
+record resolved. Older Engine versions that do not emit
+`mode_transition.resolved` therefore do not remain indefinitely in
+`dispatching`.
+
+The new event is additive. Existing `interaction.resolved` behavior for
+`ask_user` and `exec` remains gated by the database transition and is not
+changed to stream-local delivery.
+
+## Logging and safety
+
+`mode_transition.resolved` uses the same structured log allowlist as the other
+interaction events. Logs may include structural identity and lifecycle fields,
+but must not dump the raw payload or option labels.
+
+Malformed payloads fail at the typed Engine boundary and do not emit SSE.
+Converter warnings remain structural and do not include business content.
+
+## Verification
+
+Tests cover:
+
+- the actual Engine `mode_transition.resolved` payload shape, including raw
+  `phase = proceeded`, converts to BCN `phase = resolved` with
+  `decision = proceed`;
+- connect and reconnect both register the event handler;
+- a mode request followed by an RPC fallback and then the Engine event emits
+  one resolved chunk even when the database transition returns `False`;
+- replayed terminal events do not emit duplicate chunks;
+- an unexposed interaction, a non-mode kind, or an invalid payload does not use
+  the compatibility delivery path;
+- the existing accepted-RPC fallback remains covered for older Engines; and
+- interaction logging remains sanitized.

--- a/src/baas/docs/2026-08-20-mode-transition-resolved-sse-implementation.md
+++ b/src/baas/docs/2026-08-20-mode-transition-resolved-sse-implementation.md
@@ -1,0 +1,422 @@
+# Mode Transition Resolved SSE Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Convert the Engine's top-level `mode_transition.resolved` event into one BCN-compatible resolved interaction SSE while retaining the legacy accepted-RPC terminalization fallback.
+
+**Architecture:** Extend the typed BaaS Engine boundary and SSE converter with an additive raw event alias. Track exposed mode-switch requests in the existing stream-local `SessionState`, so a late terminal Engine event is delivered once even when the database was already terminalized by the RPC fallback.
+
+**Tech Stack:** Python 3.12, dataclasses, asyncio, pytest, unittest.mock, Ruff
+
+**Spec:** `src/baas/docs/2026-08-20-mode-transition-resolved-sse-design.md`
+
+## Global Constraints
+
+- Change only BaaS; do not modify Engine behavior or Engine protocol frames.
+- Preserve the raw Engine event name `mode_transition.resolved` in the typed envelope and stream chunk.
+- Canonicalize the public BCN phase from the event name to `resolved`; never expose Engine `phase = proceeded` as the BCN phase.
+- Deliver the terminal mode-switch SSE only for a mode-switch requested chunk exposed on the same active stream, and deliver it at most once.
+- Keep the accepted `mode_transition.resolve` RPC response fallback for older Engine versions.
+- Do not overwrite an already terminal database record with a late Engine event.
+- Do not log raw interaction payloads, decision labels, questions, commands, answers, or selected options.
+
+---
+
+### Task 1: Type and convert the raw mode-transition event
+
+**Files:**
+- Modify: `src/baas/src/secbaas/community/core/service/bot_run/_interaction_protocol.py`
+- Modify: `src/baas/src/secbaas/community/core/service/sse/_default_converter.py`
+- Test: `src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py`
+- Test: `src/baas/tests/unit/core/service/sse/test_default_converter.py`
+
+**Interfaces:**
+- Consumes: Engine payloads with `interactionId`, `kind = mode_switch`, `decision`, and raw lifecycle fields.
+- Produces: `EngineInteractionResolvedEvent.from_mode_transition_payload(*, session_key: str, payload: JsonObject) -> EngineInteractionResolvedEvent` and a converter result with `event = interaction`, `phase = resolved`.
+
+- [x] **Step 1: Write failing typed-boundary tests**
+
+Add a real-payload characterization test and fail-closed kind validation:
+
+```python
+def test_mode_transition_resolved_preserves_raw_event_name() -> None:
+    payload = {
+        "sessionKey": "payload-session",
+        "interactionId": "int-mode",
+        "transitionId": "int-mode",
+        "kind": "mode_switch",
+        "phase": "proceeded",
+        "decision": "proceed",
+        "seq": 131,
+    }
+
+    event = EngineInteractionResolvedEvent.from_mode_transition_payload(
+        session_key="trusted-session",
+        payload=payload,
+    )
+
+    assert event.session_key == "trusted-session"
+    assert event.interaction_id == "int-mode"
+    assert event.envelope == {
+        "type": "event",
+        "event": "mode_transition.resolved",
+        "payload": payload,
+        "seq": 131,
+    }
+
+
+def test_mode_transition_resolved_rejects_non_mode_kind() -> None:
+    with pytest.raises(ValueError, match="kind must be mode_switch"):
+        EngineInteractionResolvedEvent.from_mode_transition_payload(
+            session_key="s-1",
+            payload={"interactionId": "int-1", "kind": "exec"},
+        )
+```
+
+- [x] **Step 2: Write the failing converter test**
+
+Use the observed Engine lifecycle phase and assert the public canonical data:
+
+```python
+def test_mode_transition_resolved_maps_actual_engine_event_to_common_path(self):
+    converter = DefaultStreamConverter()
+    event = converter.convert(
+        _interaction_chunk(
+            "mode_transition.resolved",
+            {
+                "interactionId": "int-mode",
+                "kind": "mode_switch",
+                "phase": "proceeded",
+                "decision": "proceed",
+                "status": "resolved",
+                "options": [{"label": "Continue", "decision": "proceed"}],
+            },
+        ),
+        run_id="bcn-run",
+    )
+
+    assert event is not None
+    assert event.event == "interaction"
+    assert _data(event) == {
+        "runId": "bcn-run",
+        "seq": 1,
+        "interactionId": "int-mode",
+        "kind": "mode_switch",
+        "phase": "resolved",
+        "decision": "proceed",
+    }
+```
+
+- [x] **Step 3: Run the tests to verify RED**
+
+Run:
+
+```bash
+cd src/baas
+.venv/bin/pytest tests/unit/core/service/bot_run/test_interaction_protocol.py -k mode_transition_resolved -q
+.venv/bin/pytest tests/unit/core/service/sse/test_default_converter.py -k mode_transition_resolved -q
+```
+
+Expected: failures because the typed constructor does not exist and the converter rejects the event name.
+
+- [x] **Step 4: Implement the minimal typed boundary and converter alias**
+
+Extend the event literal and add a dedicated constructor that validates the mode kind while retaining the original envelope:
+
+```python
+InteractionEventName = Literal[
+    "interaction.requested",
+    "interaction.resolved",
+    "mode_transition.resolved",
+]
+
+@classmethod
+def from_mode_transition_payload(
+    cls,
+    *,
+    session_key: str,
+    payload: JsonObject,
+) -> EngineInteractionResolvedEvent:
+    if payload.get("kind") != "mode_switch":
+        raise ValueError("mode transition resolved kind must be mode_switch")
+    return cls(
+        session_key=_required_identity(session_key, "sessionKey"),
+        interaction_id=_interaction_id(payload),
+        envelope=_event_envelope("mode_transition.resolved", payload),
+    )
+```
+
+Replace implicit phase inference with an explicit event-to-phase map:
+
+```python
+_INTERACTION_EVENT_PHASES = {
+    "interaction.requested": "requested",
+    "interaction.resolved": "resolved",
+    "mode_transition.resolved": "resolved",
+}
+
+phase = _INTERACTION_EVENT_PHASES[event]
+```
+
+- [x] **Step 5: Run focused tests to verify GREEN**
+
+Run the two commands from Step 3. Expected: all selected tests pass.
+
+- [x] **Step 6: Commit the boundary mapping**
+
+```bash
+git add src/baas/src/secbaas/community/core/service/bot_run/_interaction_protocol.py src/baas/src/secbaas/community/core/service/sse/_default_converter.py src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py src/baas/tests/unit/core/service/sse/test_default_converter.py
+git commit -m "feat(baas): map mode transition resolved events"
+```
+
+---
+
+### Task 2: Subscribe and deliver the terminal mode-switch event once
+
+**Files:**
+- Modify: `src/baas/src/secbaas/community/core/service/bot_run/_session_state.py`
+- Modify: `src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py`
+- Test: `src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py`
+
+**Interfaces:**
+- Consumes: `EngineInteractionResolvedEvent.from_mode_transition_payload` from Task 1 and existing `BotInteractionService.mark_resolved`.
+- Produces: `AsyncChatClient._on_mode_transition_resolved` and stream-local `SessionState.pending_mode_transition_ids: set[str]`.
+
+- [x] **Step 1: Write failing connect and reconnect registration tests**
+
+Extend the existing callback-registration assertions so both initial connect and reconstructed reconnect clients contain:
+
+```python
+mock_client.on_event.assert_any_call(
+    "mode_transition.resolved",
+    client._on_mode_transition_resolved,
+)
+```
+
+Use the same mocked `BotWebSocketClient` instances already used by the connect and reconnect tests; do not introduce a second fake websocket stack.
+
+- [x] **Step 2: Write failing stream-delivery tests**
+
+Cover the RPC-won race, replay suppression, and exposure gate:
+
+```python
+def test_mode_transition_resolved_emits_after_rpc_terminalized_record(self, mock_bot_ws):
+    service = MagicMock()
+    service.record_requested.return_value = True
+    service.mark_resolved.return_value = False
+    client = AsyncChatClient(
+        uri="ws://host/ws", max_retries=0, interaction_service=service
+    )
+    state = _setup_session_state(client, "sk1")
+    state.stream_queue = asyncio.Queue()
+    requested = {
+        "sessionKey": "sk1",
+        "interactionId": "int-mode",
+        "kind": "mode_switch",
+        "options": [{"label": "Continue", "decision": "proceed"}],
+    }
+
+    client._on_interaction_requested(requested)
+    state.stream_queue.get_nowait()
+    resolved = {
+        "sessionKey": "sk1",
+        "interactionId": "int-mode",
+        "kind": "mode_switch",
+        "phase": "proceeded",
+        "decision": "proceed",
+    }
+    client._on_mode_transition_resolved(resolved)
+    client._on_mode_transition_resolved(resolved)
+
+    assert state.stream_queue.qsize() == 1
+    chunk = state.stream_queue.get_nowait()
+    assert chunk.metadata["event"] == "mode_transition.resolved"
+    assert chunk.metadata["payload"]["event"] == "mode_transition.resolved"
+```
+
+Add separate tests proving a terminal event without a previously emitted mode
+request does not emit, and that a non-mode kind raises before persistence or
+delivery.
+
+- [x] **Step 3: Write the failing sanitized-log test**
+
+Call `_log_event("mode_transition.resolved", payload)` with an option label
+sentinel and assert the log contains structural identity but not the sentinel.
+
+- [x] **Step 4: Run the tests to verify RED**
+
+Run:
+
+```bash
+cd src/baas
+.venv/bin/pytest tests/unit/core/service/bot_run/test_async_chat_client_coverage.py -k 'mode_transition_resolved or callback_registration or reconnect' -q
+```
+
+Expected: failures for the missing callback, missing stream-local field, and unsanitized log alias.
+
+- [x] **Step 5: Implement stream-local tracking and initial/reconnect subscriptions**
+
+Add the bounded field:
+
+```python
+pending_mode_transition_ids: set[str] = field(default_factory=set)
+```
+
+When a newly created requested event emits a chunk, track only mode switches:
+
+```python
+if payload.get("kind") == "mode_switch":
+    state.pending_mode_transition_ids.add(event.interaction_id)
+```
+
+Register the same dedicated handler in `connect` and `_reconnect_loop`:
+
+```python
+client.on_event(
+    "mode_transition.resolved",
+    self._on_mode_transition_resolved,
+)
+```
+
+- [x] **Step 6: Implement the dedicated handler and log alias**
+
+The handler always attempts persistence, but its SSE delivery is independently
+gated by the active stream's pending set:
+
+```python
+@_with_session_trace("_on_mode_transition_resolved")
+def _on_mode_transition_resolved(
+    self,
+    payload: JsonObject,
+    *,
+    session_key: str,
+    state: SessionState | None,
+) -> None:
+    if self._interaction_service is None:
+        return
+    event = EngineInteractionResolvedEvent.from_mode_transition_payload(
+        session_key=session_key,
+        payload=payload,
+    )
+    self._interaction_service.mark_resolved(
+        session_key=event.session_key,
+        interaction_id=event.interaction_id,
+        envelope=event.envelope,
+    )
+    if state is None:
+        return
+    if event.interaction_id not in state.pending_mode_transition_ids:
+        return
+    state.pending_mode_transition_ids.remove(event.interaction_id)
+    self._emit_stream_chunk(
+        state,
+        StreamChunk(
+            type="interaction",
+            content="",
+            metadata={
+                "event": "mode_transition.resolved",
+                "payload": event.envelope,
+            },
+        ),
+    )
+```
+
+Add `mode_transition.resolved` to the interaction-event structured logging
+allowlist. Do not add `options`, `decision` labels, or arbitrary payload fields
+to the logged metadata.
+
+- [x] **Step 7: Run focused tests to verify GREEN**
+
+Run the command from Step 4 and the existing RPC fallback test:
+
+```bash
+cd src/baas
+.venv/bin/pytest tests/unit/core/service/bot_run/test_async_chat_client_coverage.py -k 'mode_transition_resolved or mode_switch_dispatch or callback_registration or reconnect' -q
+```
+
+Expected: all selected tests pass, including the unchanged accepted-RPC fallback.
+
+- [x] **Step 8: Commit the client delivery path**
+
+```bash
+git add src/baas/src/secbaas/community/core/service/bot_run/_session_state.py src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
+git commit -m "feat(baas): deliver mode transition terminal SSE"
+```
+
+---
+
+### Task 3: Align compatibility documentation and run affected gates
+
+**Files:**
+- Modify: `src/baas/docs/2026-08-19-baas-bcn-interaction-sse-design.md`
+- Modify: `src/baas/docs/2026-08-20-bcn-interaction-resolve-design.md`
+- Modify: `src/baas/docs/2026-08-20-mode-transition-resolved-sse-implementation.md`
+
+**Interfaces:**
+- Consumes: completed behavior from Tasks 1 and 2.
+- Produces: design documentation that no longer states that mode transitions lack a top-level resolved event, plus fresh verification evidence.
+
+- [x] **Step 1: Update stale compatibility statements**
+
+Document that current Engines emit `mode_transition.resolved`, that BaaS
+preserves that raw envelope and maps it to the common resolved SSE, and that
+the accepted RPC remains the fallback for older Engines. Do not claim that the
+RPC response itself emits a terminal SSE.
+
+- [x] **Step 2: Run the focused affected suites**
+
+```bash
+cd src/baas
+.venv/bin/pytest tests/unit/core/service/bot_run/test_interaction_protocol.py tests/unit/core/service/bot_run/test_async_chat_client_coverage.py tests/unit/core/service/sse/test_default_converter.py -q
+```
+
+Expected: all tests pass.
+
+- [x] **Step 3: Run the broader SSE and bot-run regression suites**
+
+```bash
+cd src/baas
+.venv/bin/pytest tests/unit/core/service/sse tests/unit/core/service/bot_run -q
+```
+
+Expected: all collected tests pass.
+
+- [x] **Step 4: Run formatting, lint, and whitespace gates**
+
+```bash
+cd src/baas
+.venv/bin/ruff format --check src/secbaas/community/core/service/bot_run/_interaction_protocol.py src/secbaas/community/core/service/bot_run/_session_state.py src/secbaas/community/core/service/bot_run/_async_chat_client.py src/secbaas/community/core/service/sse/_default_converter.py tests/unit/core/service/bot_run/test_interaction_protocol.py tests/unit/core/service/bot_run/test_async_chat_client_coverage.py tests/unit/core/service/sse/test_default_converter.py
+.venv/bin/ruff check src/secbaas/community/core/service/bot_run/_interaction_protocol.py src/secbaas/community/core/service/bot_run/_session_state.py src/secbaas/community/core/service/bot_run/_async_chat_client.py src/secbaas/community/core/service/sse/_default_converter.py tests/unit/core/service/bot_run/test_interaction_protocol.py tests/unit/core/service/bot_run/test_async_chat_client_coverage.py tests/unit/core/service/sse/test_default_converter.py
+cd ../..
+git diff --check
+```
+
+Expected: every command exits zero.
+
+- [x] **Step 5: Record actual validation results and commit documentation**
+
+Replace this plan's checkbox states only with commands actually completed, then
+commit the compatibility documentation:
+
+```bash
+git add src/baas/docs/2026-08-19-baas-bcn-interaction-sse-design.md src/baas/docs/2026-08-20-bcn-interaction-resolve-design.md src/baas/docs/2026-08-20-mode-transition-resolved-sse-implementation.md
+git commit -m "docs(baas): document mode transition terminal events"
+```
+
+## Execution evidence
+
+- Typed-boundary and converter RED: 3 expected failures for the missing raw
+  event constructor and unsupported converter event.
+- Async-client RED: 6 expected failures for missing initial/reconnect
+  subscriptions, missing one-time delivery, missing exposure gating, and raw
+  payload logging.
+- Non-stream exposure RED: 1 expected failure proving that a `SessionState`
+  without a stream queue must not qualify for terminal SSE delivery.
+- Focused GREEN: 205 passed across the complete interaction protocol,
+  AsyncChatClient coverage, and default converter test files.
+- Broader regression: 1003 passed, 8 xpassed, and 0 failed across the complete
+  BaaS `sse` and `bot_run` unit-test directories. The xpasses come from tests
+  already marked expected-failure; they did not fail the suite.
+- Ruff format check: 7 changed Python files already formatted.
+- Ruff lint: all checks passed.
+- `git diff --check`: passed.

--- a/src/baas/sqls/migrate_baas_bot_run_interaction.sql
+++ b/src/baas/sqls/migrate_baas_bot_run_interaction.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS `baas_bot_run_interaction` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT COMMENT '主键',
+  `session_key` varchar(512) NOT NULL COMMENT 'engine sessionKey',
+  `interaction_id` varchar(160) NOT NULL COMMENT 'engine interactionId',
+  `state` varchar(32) NOT NULL COMMENT 'requested/queued/dispatching/resolved/expired/failed',
+  `payload` JSON NOT NULL COMMENT '完整 interaction 协议快照 JSON',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_session_interaction` (`session_key`, `interaction_id`),
+  KEY `idx_session_state` (`session_key`, `state`)
+) AUTO_INCREMENT = 1 DEFAULT CHARSET = utf8mb4 COMMENT = 'Bot run human interaction state';

--- a/src/baas/sqls/migrate_baas_bot_run_interaction.sql
+++ b/src/baas/sqls/migrate_baas_bot_run_interaction.sql
@@ -4,8 +4,8 @@ CREATE TABLE IF NOT EXISTS `baas_bot_run_interaction` (
   `interaction_id` varchar(160) NOT NULL COMMENT 'engine interactionId',
   `state` varchar(32) NOT NULL COMMENT 'requested/queued/dispatching/resolved/expired/failed',
   `payload` JSON NOT NULL COMMENT '完整 interaction 协议快照 JSON',
-  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
-  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+  `gmt_create` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uk_session_interaction` (`session_key`, `interaction_id`),
   KEY `idx_session_state` (`session_key`, `state`)

--- a/src/baas/sqls/migrate_baas_bot_run_queue_chunk.sql
+++ b/src/baas/sqls/migrate_baas_bot_run_queue_chunk.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS `baas_bot_run_queue_chunk` (
    `gmt_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
   `run_id`      varchar(128) NOT NULL COMMENT '关联 baas_bot_run.run_id',
   `seq`         int(11) NOT NULL COMMENT 'chunk 序号，严格递增',
-  `chunk_type`  varchar(16) NOT NULL COMMENT 'delta / final / error / usage / agent',
+  `chunk_type`  varchar(16) NOT NULL COMMENT 'delta / final / error / usage / agent / interaction',
   `content`     mediumtext DEFAULT NULL COMMENT 'chunk 内容 (JSON 或纯文本)',
   `metadata`    text DEFAULT NULL COMMENT 'chunk 元数据 JSON (engine_frame 等)',
   PRIMARY KEY (`id`),

--- a/src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_model.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_model.py
@@ -5,7 +5,7 @@
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from secbaas.community.api.bcn import (
     Attachment as DomainAttachment,
@@ -221,6 +221,80 @@ class ChatHistoryRequest(BaseModel):
         if self.before is not None and self.after is not None:
             raise ValueError("before 和 after 互斥，不能同时传入")
         return self
+
+
+class InteractionResolveAnswer(BaseModel):
+    """One ask-user answer forwarded by BCS."""
+
+    values: list[str] = Field(..., min_length=1)
+    question: str
+    header: str
+
+    @field_validator("question", "header")
+    @classmethod
+    def _text_fields_must_be_non_empty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("interaction answer text fields must be non-empty")
+        return value
+
+    @field_validator("values")
+    @classmethod
+    def _values_must_be_non_empty(cls, values: list[str]) -> list[str]:
+        if any(not value.strip() for value in values):
+            raise ValueError("interaction answer values must be non-empty strings")
+        return values
+
+
+class InteractionResolveParams(BaseModel):
+    """BCS Provider 2.0 kind-specific interaction resolution."""
+
+    bcs_run_id: str = Field(..., alias="bcsRunId")
+    run_id: str = Field(..., alias="runId")
+    interaction_id: str = Field(..., alias="interactionId")
+    kind: Literal["ask_user", "exec", "mode_switch"]
+    idempotency_key: str = Field(..., alias="idempotencyKey")
+    action: Literal["submit", "cancel"] | None = None
+    decision: str | None = None
+    answers: dict[str, InteractionResolveAnswer] | None = None
+
+    model_config = {"populate_by_name": True}
+
+    @model_validator(mode="after")
+    def _validate_kind_specific_fields(self) -> "InteractionResolveParams":
+        if self.kind == "ask_user":
+            if self.action is None:
+                raise ValueError("ask_user interaction resolve requires action")
+            if self.action == "submit" and not self.answers:
+                raise ValueError("ask_user submit requires answers")
+            if self.answers is not None and any(
+                not question_id.strip() for question_id in self.answers
+            ):
+                raise ValueError("ask_user answer questionId must be non-empty")
+            return self
+        if self.decision is None or not self.decision.strip():
+            raise ValueError(f"{self.kind} interaction resolve requires decision")
+        return self
+
+
+class InteractionResolveRequest(BaseModel):
+    """Full BCS Provider webhook for `interaction.resolve`."""
+
+    type: Literal["req"] = "req"
+    id: str
+    method: Literal["interaction.resolve"] = "interaction.resolve"
+    session_id: str
+    bcn_group_id: str
+    to_bot: BotRef
+    params: InteractionResolveParams
+    timeout_ms: int = 3_600_000
+
+
+class InteractionResolveAckResponse(BaseModel):
+    """Finite acknowledgement decoded by BCS `ProviderAckResponse`."""
+
+    ok: bool
+    retryable: bool | None = None
+    error: str | None = None
 
 
 # ─────────────────────────── Response ───────────────────────────

--- a/src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py
@@ -1,7 +1,8 @@
 """BCN 下行协议路由
 
 提供 BCN -> Provider 的下行接口:
-  - POST /bcn/v1/downlink  (chat.send / chat.inject / chat.history)
+  - POST /bcn/downlink
+    (chat.send / chat.inject / chat.history / interaction.resolve)
 
 本文件只负责:
   1. HTTP 认证与协议版本校验
@@ -28,7 +29,7 @@ from typing import Any
 from dependency_injector.wiring import Provide, inject
 from fastapi import APIRouter, Depends, Header, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from secbaas.community.adapters.web.routers.bcn_downlink.bcn_model import (
     BcnErrorDetail,
@@ -39,6 +40,8 @@ from secbaas.community.adapters.web.routers.bcn_downlink.bcn_model import (
     ChatInjectSuccessResponse,
     ChatSendRequest,
     ChatSendSuccessResponse,
+    InteractionResolveAckResponse,
+    InteractionResolveRequest,
 )
 from secbaas.community.adapters.web.routers.bcn_downlink.bcn_model import (
     HistoryMessage as BcnHistoryMessage,
@@ -47,6 +50,8 @@ from secbaas.community.api.bcn import (
     BcnBotNotFoundError,
     BcnDownlinkService,
     BcnError,
+    BcnInteractionAnswer,
+    BcnInteractionResolveInput,
     BcnInvalidRequestError,
     BcnUnauthorizedError,
     BcnUnsupportedMethodError,
@@ -54,6 +59,7 @@ from secbaas.community.api.bcn import (
     ChatInjectInput,
     ChatSendInput,
 )
+from secbaas.community.api.bot_interaction import InteractionServiceError
 from secbaas.community.api.bot_runtime import BotBindingNotFoundError
 from secbaas.community.api.sse import (
     SseConverterFactory,
@@ -178,7 +184,11 @@ def _register_stream(method: str, req_model: type[BaseModel]):
 @router.post(
     "/downlink",
     summary="BCN 下行统一入口",
-    description="接收 BCN 下行请求 (chat.send / chat.inject / chat.history)，根据 body.method 分发",
+    description=(
+        "接收 BCN 下行请求 "
+        "(chat.send / chat.inject / chat.history / interaction.resolve)，"
+        "根据 body.method 分发"
+    ),
     response_model=None,
     responses={
         200: {"description": "请求处理成功"},
@@ -207,6 +217,7 @@ async def bcn_downlink(
     ChatSendSuccessResponse
     | ChatInjectSuccessResponse
     | ChatHistorySuccessResponse
+    | InteractionResolveAckResponse
     | StreamingResponse
 ):
     """BCN 下行统一入口
@@ -217,6 +228,7 @@ async def bcn_downlink(
       - 否则快速返回 200 OK，异步执行后通过 uplink 回调
     - chat.inject: 向 Bot 注入消息（不触发推理）
     - chat.history: 查询聊天历史
+    - interaction.resolve: 持久化并排队 Engine interaction resolution
     """
     body = await request.json()
     method = body.get("method", "")
@@ -247,7 +259,17 @@ async def bcn_downlink(
         raise BcnUnsupportedMethodError(method)
 
     req_model, dispatcher = entry
-    req = req_model.model_validate(body)
+    try:
+        req = req_model.model_validate(body)
+    except ValidationError:
+        if method != "interaction.resolve":
+            raise
+        logger.warning("[interaction.resolve] invalid request structure")
+        return InteractionResolveAckResponse(
+            ok=False,
+            retryable=False,
+            error="invalid interaction.resolve request",
+        )
     return await dispatcher(req, service)
 
 
@@ -408,6 +430,51 @@ async def _dispatch_chat_history(
         next_before=result.next_before,
         next_after=result.next_after,
     )
+
+
+# ───────────────────────── interaction.resolve ─────────────────────────
+
+
+@_register("interaction.resolve", InteractionResolveRequest)
+async def _dispatch_interaction_resolve(
+    req: InteractionResolveRequest,
+    service: BcnDownlinkService,
+) -> InteractionResolveAckResponse:
+    """Translate the BCN webhook and return a finite Provider ACK."""
+    answers = None
+    if req.params.answers is not None:
+        answers = {
+            question_id: BcnInteractionAnswer(
+                values=tuple(answer.values),
+                question=answer.question,
+                header=answer.header,
+            )
+            for question_id, answer in req.params.answers.items()
+        }
+
+    resolve_input = BcnInteractionResolveInput(
+        id=req.id,
+        session_id=req.session_id,
+        bcn_group_id=req.bcn_group_id,
+        interaction_id=req.params.interaction_id,
+        kind=req.params.kind,
+        idempotency_key=req.params.idempotency_key,
+        action=req.params.action,
+        decision=req.params.decision,
+        answers=answers,
+        request_envelope=req.model_dump(by_alias=True, exclude_none=True),
+    )
+
+    try:
+        result = await service.handle_interaction_resolve(resolve_input)
+    except InteractionServiceError as exc:
+        return InteractionResolveAckResponse(
+            ok=False,
+            retryable=False,
+            error=str(exc),
+        )
+
+    return InteractionResolveAckResponse(ok=result.ok)
 
 
 # ─────────────────────────── 内部辅助 ───────────────────────────

--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/message_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/message_router.py
@@ -18,6 +18,12 @@ from secbaas.community.adapters.web.routers.open_api.dependencies import (
 )
 from secbaas.community.adapters.web.routers.open_api.model import (
     ExtraInfo,
+    InteractionResolveAcceptedPayload,
+    InteractionResolveEnvelope,
+    InteractionResolveError,
+    InteractionResolveErrorEnvelope,
+    InteractionResolveResponse,
+    InteractionResolveSuccessEnvelope,
     MessageRequest,
     MessageResponse,
     MessageResponseData,
@@ -43,6 +49,10 @@ from secbaas.community.api.sse import (
     with_sse_heartbeat,
 )
 from secbaas.community.bootstrap import ApplicationContainer
+from secbaas.community.core.service.bot_interaction import (
+    BotInteractionService,
+    InteractionServiceError,
+)
 from secbaas.community.logger import get_logger
 
 logger = get_logger("router-open-api")
@@ -311,6 +321,64 @@ async def deliver_message_stream(
             "Connection": "keep-alive",
             "X-Accel-Buffering": "no",
         },
+    )
+
+
+@router.post(
+    "/messages/interactions/resolve",
+    summary="Resolve an interaction requested on a message stream",
+    response_model=InteractionResolveResponse,
+    responses={
+        200: {
+            "description": "Resolve request accepted or rejected as RPC res envelope"
+        },
+        401: {"description": "Authentication failed"},
+        403: {"description": "Forbidden"},
+    },
+)
+@inject
+async def resolve_message_interaction(
+    request: InteractionResolveEnvelope,
+    api_key_record: APIKeyRecord = Depends(validate_api_key),
+    interaction_service: BotInteractionService = Depends(
+        Provide[ApplicationContainer.services.bot_interaction_service]
+    ),
+) -> InteractionResolveResponse:
+    """HTTP uplink for SSE stream interactions.
+
+    The HTTP response is the protocol ``res`` envelope. ``ok=true`` means the
+    answer was persisted and queued for the owner worker; final application is
+    later pushed on the same SSE stream as ``interaction.resolve``.
+    """
+    if api_key_record.app_type not in ("system", "app"):
+        logger.warning(
+            "resolve_message_interaction forbidden: app_type=%s",
+            api_key_record.app_type,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "code": OpenAPICode.FORBIDDEN,
+                "message": get_code_message(OpenAPICode.FORBIDDEN),
+            },
+        )
+
+    envelope = request.model_dump(by_alias=True)
+    try:
+        result = interaction_service.resolve(
+            session_key=request.params.session_key,
+            interaction_id=request.params.interaction_id,
+            decision=request.params.decision,
+            request_envelope=envelope,
+        )
+    except InteractionServiceError as exc:
+        return InteractionResolveErrorEnvelope(
+            id=request.id,
+            error=InteractionResolveError(code=exc.code, message=str(exc)),
+        )
+    return InteractionResolveSuccessEnvelope(
+        id=request.id,
+        payload=InteractionResolveAcceptedPayload(interaction_id=result.interaction_id),
     )
 
 

--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/message_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/message_router.py
@@ -348,7 +348,7 @@ async def resolve_message_interaction(
 
     The HTTP response is the protocol ``res`` envelope. ``ok=true`` means the
     answer was persisted and queued for the owner worker; final application is
-    later pushed on the same SSE stream as ``interaction.resolve``.
+    later pushed on the same SSE stream as ``interaction.resolved``.
     """
     if api_key_record.app_type not in ("system", "app"):
         logger.warning(

--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/message_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/message_router.py
@@ -33,6 +33,11 @@ from secbaas.community.adapters.web.routers.open_api.model import (
     StreamMessageRequest,
 )
 from secbaas.community.api.api_gateway import APIKeyRecord
+from secbaas.community.api.bot_interaction import (
+    BotInteractionService,
+    InteractionResolution,
+    InteractionServiceError,
+)
 from secbaas.community.api.bot_runtime import (
     BotChatContext,
     BotNotAvailableError,
@@ -49,10 +54,6 @@ from secbaas.community.api.sse import (
     with_sse_heartbeat,
 )
 from secbaas.community.bootstrap import ApplicationContainer
-from secbaas.community.core.service.bot_interaction import (
-    BotInteractionService,
-    InteractionServiceError,
-)
 from secbaas.community.logger import get_logger
 
 logger = get_logger("router-open-api")
@@ -368,7 +369,7 @@ async def resolve_message_interaction(
         result = interaction_service.resolve(
             session_key=request.params.session_key,
             interaction_id=request.params.interaction_id,
-            decision=request.params.decision,
+            resolution=InteractionResolution(decision=request.params.decision),
             request_envelope=envelope,
         )
     except InteractionServiceError as exc:

--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
@@ -1,7 +1,7 @@
 """Open API request/response model definitions"""
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -107,6 +107,59 @@ class StreamMessageRequest(BaseModel):
             "biz_scene (str, optional): Business scene/category tag. Defaults to 'default' when absent."
         ),
     )
+
+
+class InteractionResolveParams(BaseModel):
+    """Validated parameters for ``interaction.resolve``."""
+
+    session_key: str = Field(..., alias="sessionKey", min_length=1)
+    interaction_id: str = Field(..., alias="interactionId", min_length=1)
+    decision: str = Field(..., min_length=1)
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+
+class InteractionResolveEnvelope(BaseModel):
+    """HTTP uplink envelope for ``interaction.resolve``."""
+
+    type: Literal["req"]
+    id: str = Field(..., min_length=1, description="Client request id")
+    method: Literal["interaction.resolve"]
+    params: InteractionResolveParams
+
+    model_config = {"extra": "forbid"}
+
+
+class InteractionResolveAcceptedPayload(BaseModel):
+    interaction_id: str = Field(..., alias="interactionId")
+    accepted: Literal[True] = True
+    delivery_status: Literal["queued"] = Field(default="queued", alias="deliveryStatus")
+
+    model_config = {"populate_by_name": True, "extra": "forbid"}
+
+
+class InteractionResolveError(BaseModel):
+    code: str
+    message: str
+
+
+class InteractionResolveSuccessEnvelope(BaseModel):
+    type: Literal["res"] = "res"
+    id: str
+    ok: Literal[True] = True
+    payload: InteractionResolveAcceptedPayload
+
+
+class InteractionResolveErrorEnvelope(BaseModel):
+    type: Literal["res"] = "res"
+    id: str
+    ok: Literal[False] = False
+    error: InteractionResolveError
+
+
+InteractionResolveResponse = (
+    InteractionResolveSuccessEnvelope | InteractionResolveErrorEnvelope
+)
 
 
 class MessageResponseData(BaseModel):

--- a/src/baas/src/secbaas/community/api/bcn/__init__.py
+++ b/src/baas/src/secbaas/community/api/bcn/__init__.py
@@ -16,6 +16,9 @@ from ._exceptions import (
 )
 from ._models import (
     Attachment,
+    BcnInteractionAnswer,
+    BcnInteractionResolveInput,
+    BcnInteractionResolveResult,
     BotRef,
     ChatEvent,
     ChatHistoryInput,
@@ -45,6 +48,9 @@ __all__ = [
     # Models - 下行
     "Attachment",
     "BotRef",
+    "BcnInteractionAnswer",
+    "BcnInteractionResolveInput",
+    "BcnInteractionResolveResult",
     "ChatHistoryInput",
     "ChatHistoryResult",
     "ChatInjectInput",

--- a/src/baas/src/secbaas/community/api/bcn/_models.py
+++ b/src/baas/src/secbaas/community/api/bcn/_models.py
@@ -5,7 +5,7 @@
 """
 
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 
 @dataclass(slots=True, frozen=True)
@@ -182,6 +182,41 @@ class ChatHistoryResult:
     has_more: bool = False
     next_before: int | None = None
     next_after: int | None = None
+
+
+# ─────────────────────────── interaction.resolve ───────────────────────────
+
+
+@dataclass(slots=True, frozen=True)
+class BcnInteractionAnswer:
+    """One BCS ask-user answer in incoming question order."""
+
+    values: tuple[str, ...]
+    question: str
+    header: str
+
+
+@dataclass(slots=True, frozen=True)
+class BcnInteractionResolveInput:
+    """Validated BCN Provider resolution ready for normalization."""
+
+    id: str
+    session_id: str
+    bcn_group_id: str
+    interaction_id: str
+    kind: Literal["ask_user", "exec", "mode_switch"]
+    idempotency_key: str
+    action: Literal["submit", "cancel"] | None
+    decision: str | None
+    answers: dict[str, BcnInteractionAnswer] | None
+    request_envelope: dict[str, Any]
+
+
+@dataclass(slots=True, frozen=True)
+class BcnInteractionResolveResult:
+    """Provider acknowledgement after a resolution is durably queued."""
+
+    ok: bool = True
 
 
 # ─────────────────────────── 上行协议模型 ───────────────────────────

--- a/src/baas/src/secbaas/community/api/bcn/_protocols.py
+++ b/src/baas/src/secbaas/community/api/bcn/_protocols.py
@@ -9,6 +9,8 @@ from typing import Protocol, runtime_checkable
 from secbaas.community.api.sse import StreamChunk
 
 from ._models import (
+    BcnInteractionResolveInput,
+    BcnInteractionResolveResult,
     ChatHistoryInput,
     ChatHistoryResult,
     ChatInjectInput,
@@ -113,4 +115,10 @@ class BcnDownlinkService(Protocol):
             BcnSessionNotFoundError: 会话不存在
             BcnInvalidRequestError: 请求参数错误
         """
+        ...
+
+    async def handle_interaction_resolve(
+        self, resolve_input: BcnInteractionResolveInput
+    ) -> BcnInteractionResolveResult:
+        """Persist a BCN interaction answer for the Engine websocket owner."""
         ...

--- a/src/baas/src/secbaas/community/api/bot_interaction/__init__.py
+++ b/src/baas/src/secbaas/community/api/bot_interaction/__init__.py
@@ -1,0 +1,27 @@
+"""Bot interaction API contract definitions."""
+
+from __future__ import annotations
+
+from ._exceptions import (
+    InteractionBadRequestError,
+    InteractionConflictError,
+    InteractionNotFoundError,
+    InteractionServiceError,
+)
+from ._models import (
+    InteractionDispatch,
+    InteractionResolution,
+    InteractionResolveResult,
+)
+from ._protocols import BotInteractionService
+
+__all__ = [
+    "BotInteractionService",
+    "InteractionBadRequestError",
+    "InteractionConflictError",
+    "InteractionDispatch",
+    "InteractionNotFoundError",
+    "InteractionResolution",
+    "InteractionResolveResult",
+    "InteractionServiceError",
+]

--- a/src/baas/src/secbaas/community/api/bot_interaction/_exceptions.py
+++ b/src/baas/src/secbaas/community/api/bot_interaction/_exceptions.py
@@ -1,0 +1,31 @@
+"""Interaction service error hierarchy (transport-agnostic contract).
+
+Defined in the ``api`` layer so adapters can raise/catch them without
+importing the concrete ``core.service`` implementation.
+"""
+
+from __future__ import annotations
+
+
+class InteractionServiceError(Exception):
+    """Base interaction service error."""
+
+    code = "INTERACTION_ERROR"
+
+
+class InteractionBadRequestError(InteractionServiceError):
+    """Caller supplied an invalid/unsupported resolution."""
+
+    code = "BAD_REQUEST"
+
+
+class InteractionNotFoundError(InteractionServiceError):
+    """No interaction row matched the supplied identity."""
+
+    code = "NOT_FOUND"
+
+
+class InteractionConflictError(InteractionServiceError):
+    """Interaction is in a state that rejects the requested transition."""
+
+    code = "CONFLICT"

--- a/src/baas/src/secbaas/community/api/bot_interaction/_models.py
+++ b/src/baas/src/secbaas/community/api/bot_interaction/_models.py
@@ -1,0 +1,163 @@
+"""Result dataclasses returned by the interaction service contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+InteractionKind = Literal["ask_user", "exec", "mode_switch"]
+
+
+@dataclass(frozen=True, slots=True)
+class InteractionResolution:
+    """Transport-independent answer queued for the Engine websocket owner."""
+
+    decision: str
+    kind: InteractionKind | None = None
+    answer: str | None = None
+    message: str | None = None
+    values: dict[str, str] | None = None
+    answers: dict[str, str] | None = None
+    selected_options: tuple[tuple[str, ...], ...] | None = None
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.decision, "decision")
+        if self.kind not in {None, "ask_user", "exec", "mode_switch"}:
+            raise ValueError("interaction resolution kind is invalid")
+        _validate_optional_string(self.answer, "answer")
+        _validate_optional_string(self.message, "message")
+        _validate_optional_string_map(self.values, "values")
+        _validate_optional_string_map(self.answers, "answers")
+        if self.selected_options is not None:
+            if not self.selected_options:
+                raise ValueError(
+                    "interaction resolution selectedOptions cannot be empty"
+                )
+            for options in self.selected_options:
+                if not options:
+                    raise ValueError(
+                        "interaction resolution selectedOptions entries cannot be empty"
+                    )
+                for option in options:
+                    _require_non_empty_string(option, "selectedOptions value")
+
+    def to_dict(self) -> dict[str, object]:
+        """Encode the durable JSON shape, omitting absent optional fields."""
+        result: dict[str, object] = {"decision": self.decision}
+        if self.kind is not None:
+            result["kind"] = self.kind
+        if self.answer is not None:
+            result["answer"] = self.answer
+        if self.message is not None:
+            result["message"] = self.message
+        if self.values is not None:
+            result["values"] = dict(self.values)
+        if self.answers is not None:
+            result["answers"] = dict(self.answers)
+        if self.selected_options is not None:
+            result["selectedOptions"] = [
+                list(options) for options in self.selected_options
+            ]
+        return result
+
+    @classmethod
+    def from_dict(cls, value: dict[str, object]) -> InteractionResolution:
+        """Decode a persisted resolution without accepting malformed rows."""
+        kind = value.get("kind")
+        if kind is not None and not isinstance(kind, str):
+            raise ValueError("interaction resolution kind must be a string")
+        return cls(
+            decision=_required_string_field(value, "decision"),
+            kind=kind,  # type: ignore[arg-type]
+            answer=_optional_string_field(value, "answer"),
+            message=_optional_string_field(value, "message"),
+            values=_optional_string_map_field(value, "values"),
+            answers=_optional_string_map_field(value, "answers"),
+            selected_options=_optional_selected_options(value),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class InteractionDispatch:
+    """Validated command claimed by the websocket owner."""
+
+    session_key: str
+    interaction_id: str
+    resolution: InteractionResolution
+
+
+@dataclass(frozen=True, slots=True)
+class InteractionResolveResult:
+    """Successful state transition returned to an uplink adapter."""
+
+    interaction_id: str
+
+
+def _required_string_field(value: dict[str, object], key: str) -> str:
+    item = value.get(key)
+    _require_non_empty_string(item, key)
+    return item
+
+
+def _optional_string_field(value: dict[str, object], key: str) -> str | None:
+    if key not in value:
+        return None
+    item = value[key]
+    _require_non_empty_string(item, key)
+    return item
+
+
+def _optional_string_map_field(
+    value: dict[str, object], key: str
+) -> dict[str, str] | None:
+    if key not in value:
+        return None
+    item = value[key]
+    if not isinstance(item, dict):
+        raise ValueError(f"interaction resolution {key} must be an object")
+    result: dict[str, str] = {}
+    for map_key, map_value in item.items():
+        _require_non_empty_string(map_key, f"{key} key")
+        _require_non_empty_string(map_value, f"{key} value")
+        result[map_key] = map_value
+    if not result:
+        raise ValueError(f"interaction resolution {key} cannot be empty")
+    return result
+
+
+def _optional_selected_options(
+    value: dict[str, object],
+) -> tuple[tuple[str, ...], ...] | None:
+    if "selectedOptions" not in value:
+        return None
+    item = value["selectedOptions"]
+    if not isinstance(item, list):
+        raise ValueError("interaction resolution selectedOptions must be an array")
+    groups: list[tuple[str, ...]] = []
+    for group in item:
+        if not isinstance(group, list):
+            raise ValueError(
+                "interaction resolution selectedOptions entries must be arrays"
+            )
+        groups.append(tuple(group))
+    return tuple(groups)
+
+
+def _validate_optional_string(value: str | None, name: str) -> None:
+    if value is not None:
+        _require_non_empty_string(value, name)
+
+
+def _validate_optional_string_map(value: dict[str, str] | None, name: str) -> None:
+    if value is None:
+        return
+    if not value:
+        raise ValueError(f"interaction resolution {name} cannot be empty")
+    for map_key, map_value in value.items():
+        _require_non_empty_string(map_key, f"{name} key")
+        _require_non_empty_string(map_value, f"{name} value")
+
+
+def _require_non_empty_string(value: object, name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"interaction resolution {name} must be a non-empty string")

--- a/src/baas/src/secbaas/community/api/bot_interaction/_protocols.py
+++ b/src/baas/src/secbaas/community/api/bot_interaction/_protocols.py
@@ -1,0 +1,70 @@
+"""Bot interaction service contract.
+
+Adapters depend on this ``api``-layer base class instead of the concrete
+``core.service`` implementation, keeping the web delivery layer thin
+(architecture Rule 7). The concrete ``DefaultBotInteractionService`` in
+``core.service.bot_interaction`` subclasses this contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._models import (
+    InteractionDispatch,
+    InteractionResolution,
+    InteractionResolveResult,
+)
+
+
+class BotInteractionService:
+    """Transport-agnostic interaction state service contract."""
+
+    def record_requested(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        envelope: dict[str, Any],
+        allowed_decisions: tuple[str, ...],
+        expires_at_ms: int | None,
+    ) -> bool: ...
+
+    def resolve(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        resolution: InteractionResolution,
+        request_envelope: dict[str, Any],
+        idempotency_key: str | None = None,
+    ) -> InteractionResolveResult: ...
+
+    def claim_for_dispatch(
+        self, *, session_key: str, interaction_id: str
+    ) -> InteractionDispatch | None: ...
+
+    def should_poll(self, *, session_key: str, interaction_id: str) -> bool: ...
+
+    def record_engine_exchange(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        engine_req: dict[str, Any],
+        engine_res: dict[str, Any],
+    ) -> bool: ...
+
+    def mark_resolved(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        envelope: dict[str, Any],
+    ) -> bool: ...
+
+    def mark_expired(self, *, session_key: str, interaction_id: str) -> bool: ...
+
+    def mark_failed(
+        self, *, session_key: str, interaction_id: str, error: str
+    ) -> bool: ...

--- a/src/baas/src/secbaas/community/bootstrap/_container.py
+++ b/src/baas/src/secbaas/community/bootstrap/_container.py
@@ -168,6 +168,7 @@ class ApplicationContainer(containers.DeclarativeContainer):
         local_user_machine_repo=repository.local_user_machine_repository,
         bot_run_repository=repository.bot_run_repository,
         bot_run_queue_repository=repository.bot_run_queue_repository,
+        bot_run_interaction_repository=repository.bot_run_interaction_repository,
         bot_run_queue_chunk_repository=repository.bot_run_queue_chunk_repository,
         bot_qpm_repository=repository.bot_qpm_repository,
         distributed_lock_repository=repository.distributed_lock_repository,

--- a/src/baas/src/secbaas/community/bootstrap/_core_repository.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_repository.py
@@ -8,6 +8,9 @@ from secbaas.community.core.repository.bot import OrmBotRepository
 from secbaas.community.core.repository.bot_device_rel import OrmBotDeviceRelRepository
 from secbaas.community.core.repository.bot_qpm import OrmBotQpmRepository
 from secbaas.community.core.repository.bot_run import OrmBotRunRepository
+from secbaas.community.core.repository.bot_run_interaction import (
+    OrmBotRunInteractionRepository,
+)
 from secbaas.community.core.repository.bot_run_queue import OrmBotRunQueueRepository
 from secbaas.community.core.repository.bot_run_queue_chunk import (
     OrmBotRunQueueChunkRepository,
@@ -101,6 +104,11 @@ class CoreRepositoryContainer(containers.DeclarativeContainer):
         ZDAS_ORM=_orm_repo(OrmBotRunQueueRepository),
         SQLITE_ORM=_orm_repo(OrmBotRunQueueRepository),
         MARIADB_ORM=_orm_repo(OrmBotRunQueueRepository),
+    )
+    bot_run_interaction_repository = providers.Selector(
+        config.plugins.database.plugin_database,
+        ZDAS_ORM=_orm_repo(OrmBotRunInteractionRepository),
+        SQLITE_ORM=_orm_repo(OrmBotRunInteractionRepository),
     )
     bot_run_queue_chunk_repository = providers.Selector(
         config.plugins.database.plugin_database,

--- a/src/baas/src/secbaas/community/bootstrap/_core_services.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_services.py
@@ -12,6 +12,7 @@ from secbaas.community.core.service.bcn.uplink import (
     BcnUplinkClient,
     BcnUplinkConfig,
 )
+from secbaas.community.core.service.bot_interaction import BotInteractionService
 from secbaas.community.core.service.bot_manage import (
     DefaultBotCrudService,
     DefaultBotManagementService,
@@ -193,6 +194,7 @@ class CoreServiceContainer(containers.DeclarativeContainer):
     local_user_machine_repo = providers.Dependency()
     bot_run_repository = providers.Dependency()
     bot_run_queue_repository = providers.Dependency()
+    bot_run_interaction_repository = providers.Dependency()
     bot_run_queue_chunk_repository = providers.Dependency()
     bot_qpm_repository = providers.Dependency()
     distributed_lock_repository = providers.Dependency()
@@ -216,6 +218,11 @@ class CoreServiceContainer(containers.DeclarativeContainer):
         repository=system_config_repo,
     )
 
+    bot_interaction_service = providers.Singleton(
+        BotInteractionService,
+        repository=bot_run_interaction_repository,
+    )
+
     chat_client_pool = providers.Singleton(
         AsyncChatClientPool,
         max_size=config.chat_client_pool.max_size,
@@ -225,6 +232,7 @@ class CoreServiceContainer(containers.DeclarativeContainer):
         max_retries=config.chat_client_pool.max_retries,
         retry_base_backoff=config.chat_client_pool.retry_base_backoff,
         system_config_service=system_config_service,
+        interaction_service=bot_interaction_service,
     )
 
     tenant_service = providers.Singleton(

--- a/src/baas/src/secbaas/community/bootstrap/_core_services.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_services.py
@@ -12,7 +12,7 @@ from secbaas.community.core.service.bcn.uplink import (
     BcnUplinkClient,
     BcnUplinkConfig,
 )
-from secbaas.community.core.service.bot_interaction import BotInteractionService
+from secbaas.community.core.service.bot_interaction import DefaultBotInteractionService
 from secbaas.community.core.service.bot_manage import (
     DefaultBotCrudService,
     DefaultBotManagementService,
@@ -219,7 +219,7 @@ class CoreServiceContainer(containers.DeclarativeContainer):
     )
 
     bot_interaction_service = providers.Singleton(
-        BotInteractionService,
+        DefaultBotInteractionService,
         repository=bot_run_interaction_repository,
     )
 
@@ -644,6 +644,7 @@ class CoreServiceContainer(containers.DeclarativeContainer):
         bcn_api_key_prefix=config.bcn.api_key.prefix,
         uplink_client=bcn_uplink_client,
         run_repository=bot_run_repository,
+        interaction_service=bot_interaction_service,
     )
 
     # ── SSE stream converter factory ────────────────────────────────────────

--- a/src/baas/src/secbaas/community/core/repository/bot_run_interaction/__init__.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_interaction/__init__.py
@@ -1,0 +1,25 @@
+"""Public exports for bot_run_interaction repository."""
+
+from ._orm_model import BotRunInteractionModel
+from ._orm_repository import OrmBotRunInteractionRepository
+from ._protocol import BotRunInteractionRepository
+from ._record import (
+    BotRunInteractionCreateResult,
+    BotRunInteractionPayload,
+    BotRunInteractionPayloadPatch,
+    BotRunInteractionRecord,
+    InteractionState,
+    JsonObject,
+)
+
+__all__ = [
+    "BotRunInteractionCreateResult",
+    "BotRunInteractionModel",
+    "BotRunInteractionPayload",
+    "BotRunInteractionPayloadPatch",
+    "BotRunInteractionRecord",
+    "BotRunInteractionRepository",
+    "InteractionState",
+    "JsonObject",
+    "OrmBotRunInteractionRepository",
+]

--- a/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_orm_model.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_orm_model.py
@@ -1,0 +1,78 @@
+"""ORM model for baas_bot_run_interaction."""
+
+from __future__ import annotations
+
+import json
+from typing import cast
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    Column,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+
+from secbaas.community.spi.database import Base
+
+from ._record import (
+    BotRunInteractionPayload,
+    BotRunInteractionRecord,
+    InteractionState,
+)
+
+
+class BotRunInteractionModel(Base):
+    """Minimal interaction state table.
+
+    ``payload`` stores the complete protocol snapshot as JSON text for maximum
+    DB compatibility; the migration uses JSON where available.
+    """
+
+    __tablename__ = "baas_bot_run_interaction"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    session_key = Column(String(512), nullable=False)
+    interaction_id = Column(String(160), nullable=False)
+    state = Column(String(32), nullable=False)
+    payload = Column(Text, nullable=False)
+    created_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+    updated_at = Column(
+        TIMESTAMP, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "session_key", "interaction_id", name="uk_session_interaction"
+        ),
+        Index("idx_session_state", "session_key", "state"),
+    )
+
+    def to_record(self) -> BotRunInteractionRecord:
+        try:
+            decoded = json.loads(self.payload)
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise ValueError("invalid interaction payload JSON") from exc
+        if not isinstance(decoded, dict):
+            raise ValueError("interaction payload must be a JSON object")
+        if self.state not in {
+            "requested",
+            "queued",
+            "dispatching",
+            "resolved",
+            "expired",
+            "failed",
+        }:
+            raise ValueError(f"invalid interaction state: {self.state}")
+        return BotRunInteractionRecord(
+            id=self.id,
+            session_key=self.session_key,
+            interaction_id=self.interaction_id,
+            state=cast(InteractionState, self.state),
+            payload=BotRunInteractionPayload.from_dict(decoded),
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )

--- a/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_orm_model.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_orm_model.py
@@ -39,8 +39,8 @@ class BotRunInteractionModel(Base):
     interaction_id = Column(String(160), nullable=False)
     state = Column(String(32), nullable=False)
     payload = Column(Text, nullable=False)
-    created_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
-    updated_at = Column(
+    gmt_create = Column(TIMESTAMP, nullable=False, server_default=func.now())
+    gmt_modified = Column(
         TIMESTAMP, nullable=False, server_default=func.now(), onupdate=func.now()
     )
 
@@ -73,6 +73,6 @@ class BotRunInteractionModel(Base):
             interaction_id=self.interaction_id,
             state=cast(InteractionState, self.state),
             payload=BotRunInteractionPayload.from_dict(decoded),
-            created_at=self.created_at,
-            updated_at=self.updated_at,
+            created_at=self.gmt_create,
+            updated_at=self.gmt_modified,
         )

--- a/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_orm_repository.py
@@ -1,0 +1,164 @@
+"""ORM repository for ``baas_bot_run_interaction``."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+from sqlalchemy.exc import IntegrityError
+
+from secbaas.community.core.repository import OrmConnectionMixin, with_orm_session
+
+from ._orm_model import BotRunInteractionModel
+from ._record import (
+    BotRunInteractionCreateResult,
+    BotRunInteractionPayload,
+    BotRunInteractionPayloadPatch,
+    BotRunInteractionRecord,
+    InteractionState,
+)
+
+
+def _dump(payload: BotRunInteractionPayload) -> str:
+    return json.dumps(payload.to_dict(), ensure_ascii=False, separators=(",", ":"))
+
+
+class OrmBotRunInteractionRepository(OrmConnectionMixin):
+    def __init__(self, database) -> None:
+        self._database = database
+
+    @with_orm_session
+    def create_requested(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        payload: BotRunInteractionPayload,
+    ) -> BotRunInteractionCreateResult:
+        # Engine may redeliver an event. The unique key owns idempotency and an
+        # existing row must never be rolled back to requested.
+        row = self._get_row(session_key=session_key, interaction_id=interaction_id)
+        if row is not None:
+            return BotRunInteractionCreateResult(record=row.to_record(), created=False)
+
+        row = BotRunInteractionModel(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            state="requested",
+            payload=_dump(payload),
+        )
+        self._session.add(row)
+        try:
+            self._session.flush()
+        except IntegrityError:
+            self._session.rollback()
+            row = self._get_row(session_key=session_key, interaction_id=interaction_id)
+            if row is None:
+                raise
+            return BotRunInteractionCreateResult(record=row.to_record(), created=False)
+        return BotRunInteractionCreateResult(record=row.to_record(), created=True)
+
+    @with_orm_session
+    def get(
+        self, *, session_key: str, interaction_id: str
+    ) -> BotRunInteractionRecord | None:
+        row = self._get_row(session_key=session_key, interaction_id=interaction_id)
+        return row.to_record() if row is not None else None
+
+    @with_orm_session
+    def transition(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        from_states: frozenset[InteractionState],
+        to_state: InteractionState,
+        patch: BotRunInteractionPayloadPatch,
+    ) -> BotRunInteractionRecord | None:
+        return self._atomic_update(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            allowed_states=from_states,
+            to_state=to_state,
+            patch=patch,
+        )
+
+    @with_orm_session
+    def merge_payload(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        allowed_states: frozenset[InteractionState],
+        patch: BotRunInteractionPayloadPatch,
+    ) -> BotRunInteractionRecord | None:
+        return self._atomic_update(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            allowed_states=allowed_states,
+            to_state=None,
+            patch=patch,
+        )
+
+    def _atomic_update(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        allowed_states: frozenset[InteractionState],
+        to_state: InteractionState | None,
+        patch: BotRunInteractionPayloadPatch,
+    ) -> BotRunInteractionRecord | None:
+        """Lock, validate state, and merge the JSON payload in one transaction.
+
+        The row lock serializes payload read/merge/write on production MySQL.
+        The UPDATE still carries the allowed-state predicate, so state-machine
+        races are rejected without a separate version column. SQLAlchemy omits
+        ``FOR UPDATE`` on SQLite, while the conditional UPDATE preserves the
+        unit-test/runtime fallback behavior.
+        """
+        row = self._get_row(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            for_update=True,
+        )
+        if row is None or row.state not in allowed_states:
+            return None
+
+        current = row.to_record()
+        next_payload = current.payload.merge(patch)
+        values = {"payload": _dump(next_payload)}
+        if to_state is not None:
+            values["state"] = to_state
+
+        count = (
+            self._session.query(BotRunInteractionModel)
+            .filter(
+                BotRunInteractionModel.session_key == session_key,
+                BotRunInteractionModel.interaction_id == interaction_id,
+                BotRunInteractionModel.state.in_(allowed_states),
+            )
+            .update(values, synchronize_session=False)
+        )
+        if count != 1:
+            return None
+        return replace(
+            current,
+            state=to_state or current.state,
+            payload=next_payload,
+        )
+
+    def _get_row(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        for_update: bool = False,
+    ) -> BotRunInteractionModel | None:
+        query = self._session.query(BotRunInteractionModel).filter(
+            BotRunInteractionModel.session_key == session_key,
+            BotRunInteractionModel.interaction_id == interaction_id,
+        )
+        if for_update:
+            query = query.with_for_update()
+        return query.one_or_none()

--- a/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_protocol.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_protocol.py
@@ -1,0 +1,47 @@
+"""Repository protocol for bot run interactions."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from ._record import (
+    BotRunInteractionCreateResult,
+    BotRunInteractionPayload,
+    BotRunInteractionPayloadPatch,
+    BotRunInteractionRecord,
+    InteractionState,
+)
+
+
+@runtime_checkable
+class BotRunInteractionRepository(Protocol):
+    def create_requested(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        payload: BotRunInteractionPayload,
+    ) -> BotRunInteractionCreateResult: ...
+
+    def get(
+        self, *, session_key: str, interaction_id: str
+    ) -> BotRunInteractionRecord | None: ...
+
+    def transition(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        from_states: frozenset[InteractionState],
+        to_state: InteractionState,
+        patch: BotRunInteractionPayloadPatch,
+    ) -> BotRunInteractionRecord | None: ...
+
+    def merge_payload(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        allowed_states: frozenset[InteractionState],
+        patch: BotRunInteractionPayloadPatch,
+    ) -> BotRunInteractionRecord | None: ...

--- a/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_record.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_record.py
@@ -1,0 +1,171 @@
+"""Bot run interaction records and persisted payload contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Literal
+
+InteractionState = Literal[
+    "requested",
+    "queued",
+    "dispatching",
+    "resolved",
+    "expired",
+    "failed",
+]
+JsonObject = dict[str, object]
+
+
+@dataclass(frozen=True, slots=True)
+class BotRunInteractionPayloadPatch:
+    """Fields that may be appended after the requested row is created.
+
+    Initial request metadata is intentionally absent: a later transition must
+    never replace the original requested snapshot, allowed decisions, or
+    deadline.
+    """
+
+    decision: str | None = None
+    client_req: JsonObject | None = None
+    engine_req: JsonObject | None = None
+    engine_res: JsonObject | None = None
+    resolved: JsonObject | None = None
+    dispatch_error: str | None = None
+    expire_reason: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BotRunInteractionPayload:
+    """Validated representation of the interaction table's ``payload`` JSON.
+
+    Protocol frames are opaque snapshots. Only the few fields used by the
+    state machine are represented explicitly, so callers never inspect nested
+    request/response dictionaries to recover identity or dispatch input.
+    """
+
+    requested: JsonObject
+    allowed_decisions: tuple[str, ...] = ()
+    expires_at_ms: int | None = None
+    decision: str | None = None
+    client_req: JsonObject | None = None
+    engine_req: JsonObject | None = None
+    engine_res: JsonObject | None = None
+    resolved: JsonObject | None = None
+    dispatch_error: str | None = None
+    expire_reason: str | None = None
+
+    @classmethod
+    def from_dict(cls, value: JsonObject) -> BotRunInteractionPayload:
+        """Decode persisted JSON strictly instead of hiding corrupt rows."""
+        return cls(
+            requested=_required_object(value, "requested"),
+            allowed_decisions=_optional_str_tuple(value, "allowedDecisions"),
+            expires_at_ms=_optional_int(value, "expiresAtMs"),
+            decision=_optional_str(value, "decision"),
+            client_req=_optional_object(value, "clientReq"),
+            engine_req=_optional_object(value, "engineReq"),
+            engine_res=_optional_object(value, "engineRes"),
+            resolved=_optional_object(value, "resolved"),
+            dispatch_error=_optional_str(value, "dispatchError"),
+            expire_reason=_optional_str(value, "expireReason"),
+        )
+
+    def to_dict(self) -> JsonObject:
+        values: JsonObject = {
+            "requested": self.requested,
+            "allowedDecisions": (
+                list(self.allowed_decisions) if self.allowed_decisions else None
+            ),
+            "expiresAtMs": self.expires_at_ms,
+            "decision": self.decision,
+            "clientReq": self.client_req,
+            "engineReq": self.engine_req,
+            "engineRes": self.engine_res,
+            "resolved": self.resolved,
+            "dispatchError": self.dispatch_error,
+            "expireReason": self.expire_reason,
+        }
+        return {key: item for key, item in values.items() if item is not None}
+
+    def merge(self, patch: BotRunInteractionPayloadPatch) -> BotRunInteractionPayload:
+        changes = {
+            field: item
+            for field, item in (
+                ("decision", patch.decision),
+                ("client_req", patch.client_req),
+                ("engine_req", patch.engine_req),
+                ("engine_res", patch.engine_res),
+                ("resolved", patch.resolved),
+                ("dispatch_error", patch.dispatch_error),
+                ("expire_reason", patch.expire_reason),
+            )
+            if item is not None
+        }
+        return replace(self, **changes)
+
+
+@dataclass(frozen=True, slots=True)
+class BotRunInteractionRecord:
+    """``baas_bot_run_interaction`` row."""
+
+    id: int
+    session_key: str
+    interaction_id: str
+    state: InteractionState
+    payload: BotRunInteractionPayload
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BotRunInteractionCreateResult:
+    record: BotRunInteractionRecord
+    created: bool
+
+
+def _required_object(value: JsonObject, key: str) -> JsonObject:
+    item = value.get(key)
+    if not isinstance(item, dict):
+        raise ValueError(f"interaction payload {key} must be an object")
+    return item
+
+
+def _optional_object(value: JsonObject, key: str) -> JsonObject | None:
+    if key not in value:
+        return None
+    item = value[key]
+    if not isinstance(item, dict):
+        raise ValueError(f"interaction payload {key} must be an object")
+    return item
+
+
+def _optional_str(value: JsonObject, key: str) -> str | None:
+    if key not in value:
+        return None
+    item = value[key]
+    if not isinstance(item, str) or not item:
+        raise ValueError(f"interaction payload {key} must be a non-empty string")
+    return item
+
+
+def _optional_int(value: JsonObject, key: str) -> int | None:
+    if key not in value:
+        return None
+    item = value[key]
+    if not isinstance(item, int) or isinstance(item, bool):
+        raise ValueError(f"interaction payload {key} must be an integer")
+    return item
+
+
+def _optional_str_tuple(value: JsonObject, key: str) -> tuple[str, ...]:
+    if key not in value:
+        return ()
+    item = value[key]
+    if not isinstance(item, list) or any(
+        not isinstance(decision, str) or not decision for decision in item
+    ):
+        raise ValueError(
+            f"interaction payload {key} must be an array of non-empty strings"
+        )
+    return tuple(item)

--- a/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_record.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_interaction/_record.py
@@ -28,6 +28,8 @@ class BotRunInteractionPayloadPatch:
 
     decision: str | None = None
     client_req: JsonObject | None = None
+    resolution: JsonObject | None = None
+    idempotency_key: str | None = None
     engine_req: JsonObject | None = None
     engine_res: JsonObject | None = None
     resolved: JsonObject | None = None
@@ -45,10 +47,12 @@ class BotRunInteractionPayload:
     """
 
     requested: JsonObject
-    allowed_decisions: tuple[str, ...] = ()
+    allowed_decisions: tuple[str, ...] | None = None
     expires_at_ms: int | None = None
     decision: str | None = None
     client_req: JsonObject | None = None
+    resolution: JsonObject | None = None
+    idempotency_key: str | None = None
     engine_req: JsonObject | None = None
     engine_res: JsonObject | None = None
     resolved: JsonObject | None = None
@@ -64,6 +68,8 @@ class BotRunInteractionPayload:
             expires_at_ms=_optional_int(value, "expiresAtMs"),
             decision=_optional_str(value, "decision"),
             client_req=_optional_object(value, "clientReq"),
+            resolution=_optional_object(value, "resolution"),
+            idempotency_key=_optional_str(value, "idempotencyKey"),
             engine_req=_optional_object(value, "engineReq"),
             engine_res=_optional_object(value, "engineRes"),
             resolved=_optional_object(value, "resolved"),
@@ -75,11 +81,15 @@ class BotRunInteractionPayload:
         values: JsonObject = {
             "requested": self.requested,
             "allowedDecisions": (
-                list(self.allowed_decisions) if self.allowed_decisions else None
+                list(self.allowed_decisions)
+                if self.allowed_decisions is not None
+                else None
             ),
             "expiresAtMs": self.expires_at_ms,
             "decision": self.decision,
             "clientReq": self.client_req,
+            "resolution": self.resolution,
+            "idempotencyKey": self.idempotency_key,
             "engineReq": self.engine_req,
             "engineRes": self.engine_res,
             "resolved": self.resolved,
@@ -94,6 +104,8 @@ class BotRunInteractionPayload:
             for field, item in (
                 ("decision", patch.decision),
                 ("client_req", patch.client_req),
+                ("resolution", patch.resolution),
+                ("idempotency_key", patch.idempotency_key),
                 ("engine_req", patch.engine_req),
                 ("engine_res", patch.engine_res),
                 ("resolved", patch.resolved),
@@ -158,9 +170,9 @@ def _optional_int(value: JsonObject, key: str) -> int | None:
     return item
 
 
-def _optional_str_tuple(value: JsonObject, key: str) -> tuple[str, ...]:
+def _optional_str_tuple(value: JsonObject, key: str) -> tuple[str, ...] | None:
     if key not in value:
-        return ()
+        return None
     item = value[key]
     if not isinstance(item, list) or any(
         not isinstance(decision, str) or not decision for decision in item

--- a/src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py
+++ b/src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py
@@ -14,6 +14,8 @@ from typing import Any
 
 from secbaas.community.api.bcn import (
     BcnDownlinkService,
+    BcnInteractionResolveInput,
+    BcnInteractionResolveResult,
     ChatHistoryInput,
     ChatHistoryResult,
     ChatInjectInput,
@@ -21,6 +23,10 @@ from secbaas.community.api.bcn import (
     ChatSendInput,
     ChatSendResult,
     DownlinkMessage,
+)
+from secbaas.community.api.bot_interaction import (
+    BotInteractionService,
+    InteractionResolution,
 )
 from secbaas.community.api.bot_runtime import BotChatContext, BotRunner
 from secbaas.community.api.sse import StreamChunk
@@ -52,6 +58,70 @@ def _extract_message_text(message: DownlinkMessage) -> str:
     return "\n".join(parts)
 
 
+def _normalize_interaction_resolution(
+    resolve_input: BcnInteractionResolveInput,
+) -> InteractionResolution:
+    """Convert BCN fields to the Engine-neutral durable resolution."""
+    if resolve_input.kind != "ask_user":
+        decision = resolve_input.decision
+        if decision is None or not decision.strip():
+            raise ValueError(
+                f"{resolve_input.kind} interaction resolve requires decision"
+            )
+        return InteractionResolution(
+            kind=resolve_input.kind,
+            decision=decision,
+        )
+
+    action = resolve_input.action
+    if action not in {"submit", "cancel"}:
+        raise ValueError("ask_user interaction resolve requires action")
+    if action == "cancel":
+        return InteractionResolution(kind="ask_user", decision="cancel")
+
+    source_answers = resolve_input.answers
+    if not source_answers:
+        raise ValueError("ask_user submit requires answers")
+
+    summaries: list[str] = []
+    values: dict[str, str] = {}
+    answers: dict[str, str] = {}
+    selected_options: list[tuple[str, ...]] = []
+    for question_id, source_answer in source_answers.items():
+        if (
+            not question_id.strip()
+            or not source_answer.header.strip()
+            or not source_answer.question.strip()
+        ):
+            raise ValueError("ask_user answer identity must be non-empty")
+        if not source_answer.values or any(
+            not value.strip() for value in source_answer.values
+        ):
+            raise ValueError("ask_user answer values must be non-empty")
+        joined_values = "，".join(source_answer.values)
+        summaries.append(f"{source_answer.header}: {joined_values}")
+        if source_answer.header in values:
+            logger.warning(
+                "Interaction resolution warning: interaction_id=%s "
+                "field_path=answers.header error_type=duplicate_answer_header",
+                resolve_input.interaction_id,
+            )
+        values[source_answer.header] = joined_values
+        answers[source_answer.question] = joined_values
+        selected_options.append(tuple(source_answer.values))
+
+    summary = "；".join(summaries)
+    return InteractionResolution(
+        kind="ask_user",
+        decision="submit",
+        answer=summary,
+        message=summary,
+        values=values,
+        answers=answers,
+        selected_options=tuple(selected_options),
+    )
+
+
 class DefaultBcnDownlinkService(BcnDownlinkService):
     """BCN 下行协议服务默认实现
 
@@ -68,13 +138,29 @@ class DefaultBcnDownlinkService(BcnDownlinkService):
         bcn_api_key_prefix: str,
         uplink_client: UplinkClient,
         run_repository: BotRunRepository,
+        interaction_service: BotInteractionService,
     ):
         self._bot_runner = bot_runner
         self._api_key_repository = api_key_repository
         self._bcn_api_key_prefix = bcn_api_key_prefix
         self._uplink_client = uplink_client
         self._run_repository = run_repository
+        self._interaction_service = interaction_service
         self._uplink_callback = BcnUplinkCallback(uplink_client, run_repository)
+
+    async def handle_interaction_resolve(
+        self, resolve_input: BcnInteractionResolveInput
+    ) -> BcnInteractionResolveResult:
+        """Normalize and durably queue one BCS interaction resolution."""
+        resolution = _normalize_interaction_resolution(resolve_input)
+        self._interaction_service.resolve(
+            session_key=resolve_input.session_id,
+            interaction_id=resolve_input.interaction_id,
+            resolution=resolution,
+            request_envelope=resolve_input.request_envelope,
+            idempotency_key=resolve_input.idempotency_key,
+        )
+        return BcnInteractionResolveResult(ok=True)
 
     async def handle_chat_send(self, chat_send_input: ChatSendInput) -> ChatSendResult:
         """处理 chat.send 请求

--- a/src/baas/src/secbaas/community/core/service/bot_interaction/__init__.py
+++ b/src/baas/src/secbaas/community/core/service/bot_interaction/__init__.py
@@ -1,6 +1,11 @@
-"""Bot interaction core service."""
+"""Bot interaction core service.
 
-from ._service import (
+The transport-agnostic contract lives in ``community.api.bot_interaction``;
+this module provides the concrete ``DefaultBotInteractionService`` that
+``core`` wires into the application container.
+"""
+
+from secbaas.community.api.bot_interaction import (
     BotInteractionService,
     InteractionBadRequestError,
     InteractionConflictError,
@@ -10,8 +15,11 @@ from ._service import (
     InteractionServiceError,
 )
 
+from ._service import DefaultBotInteractionService
+
 __all__ = [
     "BotInteractionService",
+    "DefaultBotInteractionService",
     "InteractionBadRequestError",
     "InteractionConflictError",
     "InteractionDispatch",

--- a/src/baas/src/secbaas/community/core/service/bot_interaction/__init__.py
+++ b/src/baas/src/secbaas/community/core/service/bot_interaction/__init__.py
@@ -1,0 +1,21 @@
+"""Bot interaction core service."""
+
+from ._service import (
+    BotInteractionService,
+    InteractionBadRequestError,
+    InteractionConflictError,
+    InteractionDispatch,
+    InteractionNotFoundError,
+    InteractionResolveResult,
+    InteractionServiceError,
+)
+
+__all__ = [
+    "BotInteractionService",
+    "InteractionBadRequestError",
+    "InteractionConflictError",
+    "InteractionDispatch",
+    "InteractionNotFoundError",
+    "InteractionResolveResult",
+    "InteractionServiceError",
+]

--- a/src/baas/src/secbaas/community/core/service/bot_interaction/_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_interaction/_service.py
@@ -3,8 +3,17 @@
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
 
+from secbaas.community.api.bot_interaction import (
+    BotInteractionService,
+    InteractionBadRequestError,
+    InteractionConflictError,
+    InteractionDispatch,
+    InteractionNotFoundError,
+    InteractionResolution,
+    InteractionResolveResult,
+    InteractionServiceError,
+)
 from secbaas.community.core.repository.bot_run_interaction import (
     BotRunInteractionPayload,
     BotRunInteractionPayloadPatch,
@@ -12,42 +21,18 @@ from secbaas.community.core.repository.bot_run_interaction import (
     JsonObject,
 )
 
-
-class InteractionServiceError(Exception):
-    """Base interaction service error."""
-
-    code = "INTERACTION_ERROR"
-
-
-class InteractionBadRequestError(InteractionServiceError):
-    code = "BAD_REQUEST"
-
-
-class InteractionNotFoundError(InteractionServiceError):
-    code = "NOT_FOUND"
+# Re-export the contract types so existing ``core.service.bot_interaction``
+# importers keep resolving them without touching the delivery layer.
+__all__ = [
+    "BotInteractionService",
+    "DefaultBotInteractionService",
+    "InteractionDispatch",
+    "InteractionResolveResult",
+    "InteractionServiceError",
+]
 
 
-class InteractionConflictError(InteractionServiceError):
-    code = "CONFLICT"
-
-
-@dataclass(frozen=True, slots=True)
-class InteractionDispatch:
-    """Validated command claimed by the websocket owner."""
-
-    session_key: str
-    interaction_id: str
-    decision: str
-
-
-@dataclass(frozen=True, slots=True)
-class InteractionResolveResult:
-    """Successful state transition returned to an uplink adapter."""
-
-    interaction_id: str
-
-
-class BotInteractionService:
+class DefaultBotInteractionService(BotInteractionService):
     """Transport-agnostic interaction state service.
 
     Transport adapters validate protocol shapes and pass identity explicitly.
@@ -83,20 +68,29 @@ class BotInteractionService:
         *,
         session_key: str,
         interaction_id: str,
-        decision: str,
+        resolution: InteractionResolution,
         request_envelope: JsonObject,
+        idempotency_key: str | None = None,
     ) -> InteractionResolveResult:
         record = self._repo.get(session_key=session_key, interaction_id=interaction_id)
         if record is None:
             raise InteractionNotFoundError("interaction not found")
+        resolution_payload = resolution.to_dict()
         if record.state != "requested":
+            if self._is_idempotent_replay(
+                record.payload,
+                idempotency_key=idempotency_key,
+                resolution_payload=resolution_payload,
+            ):
+                return InteractionResolveResult(interaction_id=interaction_id)
             raise InteractionConflictError(f"interaction state is {record.state}")
         if self._is_expired(record.payload.expires_at_ms):
             self.mark_expired(session_key=session_key, interaction_id=interaction_id)
             raise InteractionConflictError("interaction expired")
+        allowed_decisions = record.payload.allowed_decisions
         if (
-            record.payload.allowed_decisions
-            and decision not in record.payload.allowed_decisions
+            allowed_decisions is not None
+            and resolution.decision not in allowed_decisions
         ):
             raise InteractionBadRequestError(
                 "decision is not allowed by interaction options"
@@ -108,11 +102,23 @@ class BotInteractionService:
             from_states=frozenset({"requested"}),
             to_state="queued",
             patch=BotRunInteractionPayloadPatch(
-                decision=decision,
+                decision=resolution.decision,
                 client_req=request_envelope,
+                resolution=resolution_payload,
+                idempotency_key=idempotency_key,
             ),
         )
         if updated is None:
+            latest = self._repo.get(
+                session_key=session_key,
+                interaction_id=interaction_id,
+            )
+            if latest is not None and self._is_idempotent_replay(
+                latest.payload,
+                idempotency_key=idempotency_key,
+                resolution_payload=resolution_payload,
+            ):
+                return InteractionResolveResult(interaction_id=interaction_id)
             raise InteractionConflictError("interaction already resolved or queued")
         return InteractionResolveResult(interaction_id=interaction_id)
 
@@ -130,6 +136,26 @@ class BotInteractionService:
                 error="queued interaction has no decision",
             )
             return None
+        try:
+            resolution = (
+                InteractionResolution.from_dict(record.payload.resolution)
+                if record.payload.resolution is not None
+                else InteractionResolution(decision=decision)
+            )
+        except ValueError:
+            self.mark_failed(
+                session_key=session_key,
+                interaction_id=interaction_id,
+                error="queued interaction has invalid resolution",
+            )
+            return None
+        if resolution.decision != decision:
+            self.mark_failed(
+                session_key=session_key,
+                interaction_id=interaction_id,
+                error="queued interaction resolution decision does not match",
+            )
+            return None
         claimed = self._repo.transition(
             session_key=session_key,
             interaction_id=interaction_id,
@@ -142,7 +168,7 @@ class BotInteractionService:
         return InteractionDispatch(
             session_key=session_key,
             interaction_id=interaction_id,
-            decision=decision,
+            resolution=resolution,
         )
 
     def should_poll(self, *, session_key: str, interaction_id: str) -> bool:
@@ -213,6 +239,21 @@ class BotInteractionService:
             )
             is not None
         )
+
+    @staticmethod
+    def _is_idempotent_replay(
+        payload: BotRunInteractionPayload,
+        *,
+        idempotency_key: str | None,
+        resolution_payload: JsonObject,
+    ) -> bool:
+        if idempotency_key is None or payload.idempotency_key != idempotency_key:
+            return False
+        if payload.resolution != resolution_payload:
+            raise InteractionConflictError(
+                "idempotency key was reused with a different resolution"
+            )
+        return True
 
     @staticmethod
     def _is_expired(expires_at_ms: int | None) -> bool:

--- a/src/baas/src/secbaas/community/core/service/bot_interaction/_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_interaction/_service.py
@@ -1,0 +1,219 @@
+"""Core service for SSE + HTTP human interaction answers."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from secbaas.community.core.repository.bot_run_interaction import (
+    BotRunInteractionPayload,
+    BotRunInteractionPayloadPatch,
+    BotRunInteractionRepository,
+    JsonObject,
+)
+
+
+class InteractionServiceError(Exception):
+    """Base interaction service error."""
+
+    code = "INTERACTION_ERROR"
+
+
+class InteractionBadRequestError(InteractionServiceError):
+    code = "BAD_REQUEST"
+
+
+class InteractionNotFoundError(InteractionServiceError):
+    code = "NOT_FOUND"
+
+
+class InteractionConflictError(InteractionServiceError):
+    code = "CONFLICT"
+
+
+@dataclass(frozen=True, slots=True)
+class InteractionDispatch:
+    """Validated command claimed by the websocket owner."""
+
+    session_key: str
+    interaction_id: str
+    decision: str
+
+
+@dataclass(frozen=True, slots=True)
+class InteractionResolveResult:
+    """Successful state transition returned to an uplink adapter."""
+
+    interaction_id: str
+
+
+class BotInteractionService:
+    """Transport-agnostic interaction state service.
+
+    Transport adapters validate protocol shapes and pass identity explicitly.
+    The service never rediscovers ``session_key`` or ``interaction_id`` inside
+    opaque protocol snapshots.
+    """
+
+    def __init__(self, repository: BotRunInteractionRepository) -> None:
+        self._repo = repository
+
+    def record_requested(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        envelope: JsonObject,
+        allowed_decisions: tuple[str, ...],
+        expires_at_ms: int | None,
+    ) -> bool:
+        result = self._repo.create_requested(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            payload=BotRunInteractionPayload(
+                requested=envelope,
+                allowed_decisions=allowed_decisions,
+                expires_at_ms=expires_at_ms,
+            ),
+        )
+        return result.created
+
+    def resolve(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        decision: str,
+        request_envelope: JsonObject,
+    ) -> InteractionResolveResult:
+        record = self._repo.get(session_key=session_key, interaction_id=interaction_id)
+        if record is None:
+            raise InteractionNotFoundError("interaction not found")
+        if record.state != "requested":
+            raise InteractionConflictError(f"interaction state is {record.state}")
+        if self._is_expired(record.payload.expires_at_ms):
+            self.mark_expired(session_key=session_key, interaction_id=interaction_id)
+            raise InteractionConflictError("interaction expired")
+        if (
+            record.payload.allowed_decisions
+            and decision not in record.payload.allowed_decisions
+        ):
+            raise InteractionBadRequestError(
+                "decision is not allowed by interaction options"
+            )
+
+        updated = self._repo.transition(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            from_states=frozenset({"requested"}),
+            to_state="queued",
+            patch=BotRunInteractionPayloadPatch(
+                decision=decision,
+                client_req=request_envelope,
+            ),
+        )
+        if updated is None:
+            raise InteractionConflictError("interaction already resolved or queued")
+        return InteractionResolveResult(interaction_id=interaction_id)
+
+    def claim_for_dispatch(
+        self, *, session_key: str, interaction_id: str
+    ) -> InteractionDispatch | None:
+        record = self._repo.get(session_key=session_key, interaction_id=interaction_id)
+        if record is None or record.state != "queued":
+            return None
+        decision = record.payload.decision
+        if decision is None:
+            self.mark_failed(
+                session_key=session_key,
+                interaction_id=interaction_id,
+                error="queued interaction has no decision",
+            )
+            return None
+        claimed = self._repo.transition(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            from_states=frozenset({"queued"}),
+            to_state="dispatching",
+            patch=BotRunInteractionPayloadPatch(),
+        )
+        if claimed is None:
+            return None
+        return InteractionDispatch(
+            session_key=session_key,
+            interaction_id=interaction_id,
+            decision=decision,
+        )
+
+    def should_poll(self, *, session_key: str, interaction_id: str) -> bool:
+        record = self._repo.get(session_key=session_key, interaction_id=interaction_id)
+        return record is not None and record.state in {"requested", "queued"}
+
+    def record_engine_exchange(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        engine_req: JsonObject,
+        engine_res: JsonObject,
+    ) -> bool:
+        return (
+            self._repo.merge_payload(
+                session_key=session_key,
+                interaction_id=interaction_id,
+                allowed_states=frozenset({"dispatching"}),
+                patch=BotRunInteractionPayloadPatch(
+                    engine_req=engine_req,
+                    engine_res=engine_res,
+                ),
+            )
+            is not None
+        )
+
+    def mark_resolved(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        envelope: JsonObject,
+    ) -> bool:
+        return (
+            self._repo.transition(
+                session_key=session_key,
+                interaction_id=interaction_id,
+                from_states=frozenset({"requested", "queued", "dispatching"}),
+                to_state="resolved",
+                patch=BotRunInteractionPayloadPatch(resolved=envelope),
+            )
+            is not None
+        )
+
+    def mark_expired(self, *, session_key: str, interaction_id: str) -> bool:
+        return (
+            self._repo.transition(
+                session_key=session_key,
+                interaction_id=interaction_id,
+                from_states=frozenset({"requested", "queued"}),
+                to_state="expired",
+                patch=BotRunInteractionPayloadPatch(
+                    expire_reason="interaction deadline elapsed"
+                ),
+            )
+            is not None
+        )
+
+    def mark_failed(self, *, session_key: str, interaction_id: str, error: str) -> bool:
+        return (
+            self._repo.transition(
+                session_key=session_key,
+                interaction_id=interaction_id,
+                from_states=frozenset({"queued", "dispatching"}),
+                to_state="failed",
+                patch=BotRunInteractionPayloadPatch(dispatch_error=error),
+            )
+            is not None
+        )
+
+    @staticmethod
+    def _is_expired(expires_at_ms: int | None) -> bool:
+        return expires_at_ms is not None and int(time.time() * 1000) > expires_at_ms

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import Any
@@ -25,7 +26,13 @@ from secbaas.community.api.sse import StreamChunk
 from secbaas.community.logger import get_logger
 from secbaas.community.tracer import get_tracer_plugin
 
+from ..bot_interaction import BotInteractionService
 from ._bot_websocket_client import BotWebSocketClient, ChatRequestError
+from ._interaction_protocol import (
+    EngineInteractionRequestedEvent,
+    EngineInteractionResolvedEvent,
+    JsonObject,
+)
 from ._session_key_matcher import SessionKeyMatcher
 from ._session_state import _SessionState
 
@@ -150,6 +157,7 @@ class AsyncChatClient:
         max_retries: int = 1,
         retry_base_backoff: float = 0.5,
         ignore_case: bool = False,
+        interaction_service: BotInteractionService | None = None,
     ):
         """初始化客户端
 
@@ -176,6 +184,8 @@ class AsyncChatClient:
         self._max_retries = max_retries
         self._retry_base_backoff = retry_base_backoff
         self._ignore_case = ignore_case
+        self._interaction_service = interaction_service
+        self._interaction_tasks: dict[tuple[str, str], asyncio.Task[None]] = {}
 
         # 并发信号量：限制单连接总并发会话数，提供背压
         self._concurrency_sem: asyncio.Semaphore | None = (
@@ -252,6 +262,9 @@ class AsyncChatClient:
 
         _client.on_event("chat", self._on_chat)
         _client.on_event("agent", self._on_agent)
+        _client.on_event("interaction.requested", self._on_interaction_requested)
+        _client.on_event("interaction.resolved", self._on_interaction_resolved)
+        _client.on_event("interaction.resolve", self._on_interaction_resolved)
         _client.on_event("error", self._on_error)
         _client.on_event("*", self._log_event)
         _client.on_disconnect(self._on_disconnect)
@@ -604,6 +617,13 @@ class AsyncChatClient:
             await self._client.close()
             self._client = None
 
+        interaction_tasks = list(self._interaction_tasks.values())
+        for task in interaction_tasks:
+            task.cancel()
+        if interaction_tasks:
+            await asyncio.gather(*interaction_tasks, return_exceptions=True)
+        self._interaction_tasks.clear()
+
         # 清理所有 session state，并唤醒等待中的协程
         async with self._condition:
             self._sessions.clear()
@@ -840,6 +860,188 @@ class AsyncChatClient:
         else:
             state.last_stream_is_assistant = False
 
+    @_with_session_trace("_on_interaction_requested")
+    def _on_interaction_requested(
+        self,
+        payload: JsonObject,
+        *,
+        session_key: str,
+        state: _SessionState | None,
+    ) -> None:
+        """Persist and expose a validated engine interaction request."""
+        event = EngineInteractionRequestedEvent.from_payload(
+            session_key=session_key,
+            payload=payload,
+        )
+        created = True
+        if self._interaction_service is not None:
+            created = self._interaction_service.record_requested(
+                session_key=event.session_key,
+                interaction_id=event.interaction_id,
+                envelope=event.envelope,
+                allowed_decisions=event.allowed_decisions,
+                expires_at_ms=event.expires_at_ms,
+            )
+        if created and state is not None:
+            self._emit_stream_chunk(
+                state,
+                StreamChunk(
+                    type="interaction",
+                    content="",
+                    metadata={
+                        "event": "interaction.requested",
+                        "payload": event.envelope,
+                    },
+                ),
+            )
+
+        if self._interaction_service is None or self._client is None:
+            return
+        task_key = (event.session_key, event.interaction_id)
+        if task_key in self._interaction_tasks:
+            return
+        task = asyncio.create_task(
+            self._dispatch_interaction_answer(
+                session_key=event.session_key,
+                interaction_id=event.interaction_id,
+                deadline_ms=event.expires_at_ms,
+            )
+        )
+        self._interaction_tasks[task_key] = task
+        task.add_done_callback(
+            lambda completed, key=task_key: self._discard_interaction_task(
+                key, completed
+            )
+        )
+
+    @_with_session_trace("_on_interaction_resolved")
+    def _on_interaction_resolved(
+        self,
+        payload: JsonObject,
+        *,
+        session_key: str,
+        state: _SessionState | None,
+    ) -> None:
+        """Persist one terminal event and expose it as interaction.resolve."""
+        event = EngineInteractionResolvedEvent.from_payload(
+            session_key=session_key,
+            payload=payload,
+        )
+        applied = True
+        if self._interaction_service is not None:
+            applied = self._interaction_service.mark_resolved(
+                session_key=event.session_key,
+                interaction_id=event.interaction_id,
+                envelope=event.envelope,
+            )
+        if not applied:
+            return
+
+        if state is not None:
+            self._emit_stream_chunk(
+                state,
+                StreamChunk(
+                    type="interaction",
+                    content="",
+                    metadata={
+                        "event": "interaction.resolve",
+                        "payload": event.envelope,
+                    },
+                ),
+            )
+
+    def _discard_interaction_task(
+        self,
+        key: tuple[str, str],
+        completed: asyncio.Task[None],
+    ) -> None:
+        if self._interaction_tasks.get(key) is completed:
+            self._interaction_tasks.pop(key, None)
+        if completed.cancelled():
+            return
+        error = completed.exception()
+        if error is not None:
+            logger.error(
+                "[interaction] dispatch task failed: sessionKey=%s interactionId=%s",
+                key[0],
+                key[1],
+                exc_info=(type(error), error, error.__traceback__),
+            )
+
+    async def _dispatch_interaction_answer(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        deadline_ms: int | None,
+    ) -> None:
+        """Poll the DB, claim one queued answer, and send it to the engine."""
+        interaction_service = self._interaction_service
+        if interaction_service is None:
+            return
+        if deadline_ms is None:
+            deadline_ms = int(time.time() * 1000) + 300_000
+
+        while int(time.time() * 1000) <= deadline_ms:
+            command = interaction_service.claim_for_dispatch(
+                session_key=session_key,
+                interaction_id=interaction_id,
+            )
+            if command is not None:
+                client = self._client
+                if client is None:
+                    interaction_service.mark_failed(
+                        session_key=session_key,
+                        interaction_id=interaction_id,
+                        error="engine websocket is disconnected",
+                    )
+                    return
+                try:
+                    exchange = await client.interaction_resolve(
+                        interaction_id=command.interaction_id,
+                        decision=command.decision,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "[interaction] dispatch failed: sessionKey=%s interactionId=%s",
+                        session_key,
+                        interaction_id,
+                        exc_info=True,
+                    )
+                    interaction_service.mark_failed(
+                        session_key=session_key,
+                        interaction_id=interaction_id,
+                        error=str(exc),
+                    )
+                    return
+
+                interaction_service.record_engine_exchange(
+                    session_key=session_key,
+                    interaction_id=interaction_id,
+                    engine_req=exchange.request,
+                    engine_res=exchange.response,
+                )
+                if not exchange.accepted:
+                    interaction_service.mark_failed(
+                        session_key=session_key,
+                        interaction_id=interaction_id,
+                        error=exchange.error_message
+                        or "engine rejected interaction.resolve",
+                    )
+                return
+
+            if not interaction_service.should_poll(
+                session_key=session_key,
+                interaction_id=interaction_id,
+            ):
+                return
+            await asyncio.sleep(0.2)
+
+        interaction_service.mark_expired(
+            session_key=session_key,
+            interaction_id=interaction_id,
+        )
+
     @_with_session_trace("_on_error")
     def _on_error(
         self,
@@ -995,6 +1197,15 @@ class AsyncChatClient:
                     )
                     new_client.on_event("chat", self._on_chat)
                     new_client.on_event("agent", self._on_agent)
+                    new_client.on_event(
+                        "interaction.requested", self._on_interaction_requested
+                    )
+                    new_client.on_event(
+                        "interaction.resolved", self._on_interaction_resolved
+                    )
+                    new_client.on_event(
+                        "interaction.resolve", self._on_interaction_resolved
+                    )
                     new_client.on_event("error", self._on_error)
                     new_client.on_event("*", self._log_event)
                     new_client.on_disconnect(self._on_disconnect)

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -264,6 +264,7 @@ class AsyncChatClient:
         _client.on_event("agent", self._on_agent)
         _client.on_event("interaction.requested", self._on_interaction_requested)
         _client.on_event("interaction.resolved", self._on_interaction_resolved)
+        _client.on_event("mode_transition.resolved", self._on_mode_transition_resolved)
         _client.on_event("error", self._on_error)
         _client.on_event("*", self._log_event)
         _client.on_disconnect(self._on_disconnect)
@@ -901,6 +902,8 @@ class AsyncChatClient:
                     },
                 ),
             )
+            if state.stream_queue is not None and payload.get("kind") == "mode_switch":
+                state.pending_mode_transition_ids.add(event.interaction_id)
 
         # Engine events normally arrive only on an active client. Keep persistence
         # and SSE delivery above, but do not start a dispatcher without an uplink.
@@ -962,6 +965,49 @@ class AsyncChatClient:
                 ),
             )
 
+    @_with_session_trace("_on_mode_transition_resolved")
+    def _on_mode_transition_resolved(
+        self,
+        payload: JsonObject,
+        *,
+        session_key: str,
+        state: SessionState | None,
+    ) -> None:
+        """Persist a raw mode terminal event and expose it once to its stream."""
+        if self._interaction_service is None:
+            logger.debug(
+                "interaction processing is disabled; skip mode transition event"
+            )
+            return
+
+        event = EngineInteractionResolvedEvent.from_mode_transition_payload(
+            session_key=session_key,
+            payload=payload,
+        )
+        self._interaction_service.mark_resolved(
+            session_key=event.session_key,
+            interaction_id=event.interaction_id,
+            envelope=event.envelope,
+        )
+        if (
+            state is None
+            or event.interaction_id not in state.pending_mode_transition_ids
+        ):
+            return
+
+        state.pending_mode_transition_ids.remove(event.interaction_id)
+        self._emit_stream_chunk(
+            state,
+            StreamChunk(
+                type="interaction",
+                content="",
+                metadata={
+                    "event": "mode_transition.resolved",
+                    "payload": event.envelope,
+                },
+            ),
+        )
+
     def _discard_interaction_task(
         self,
         key: tuple[str, str],
@@ -1011,7 +1057,7 @@ class AsyncChatClient:
                 try:
                     exchange = await client.interaction_resolve(
                         interaction_id=command.interaction_id,
-                        decision=command.decision,
+                        resolution=command.resolution,
                     )
                 except Exception as exc:
                     logger.warning(
@@ -1039,6 +1085,15 @@ class AsyncChatClient:
                         interaction_id=interaction_id,
                         error=exchange.error_message
                         or "engine rejected interaction.resolve",
+                    )
+                elif command.resolution.kind == "mode_switch":
+                    # The Engine resolves mode transitions through the RPC response
+                    # and a compatibility agent stream; it does not emit the
+                    # top-level interaction.resolved event used by other kinds.
+                    interaction_service.mark_resolved(
+                        session_key=session_key,
+                        interaction_id=interaction_id,
+                        envelope=exchange.response,
                     )
                 return
 
@@ -1110,12 +1165,32 @@ class AsyncChatClient:
             "chat": ("message", "deltaText", "delta"),
             "agent": ("data",),
         }
-        sensitive_keys = _sensitive_keys.get(event_name)
-        if sensitive_keys:
+        if event_name in {
+            "interaction.requested",
+            "interaction.resolved",
+            "mode_transition.resolved",
+        }:
+            metadata_keys = (
+                "interactionId",
+                "id",
+                "runId",
+                "sessionKey",
+                "kind",
+                "phase",
+                "status",
+                "toolCallId",
+                "seq",
+                "ts",
+            )
+            safe_payload = {
+                key: payload[key] for key in metadata_keys if key in payload
+            }
+            logger.info("[log_event] event=%s, payload=%s", event_name, safe_payload)
+        elif sensitive_keys := _sensitive_keys.get(event_name):
             safe_payload = {k: v for k, v in payload.items() if k not in sensitive_keys}
-            logger.info(f"[log_event] event={event_name}, payload={safe_payload}")
+            logger.info("[log_event] event=%s, payload=%s", event_name, safe_payload)
         else:
-            logger.info(f"[log_event] event={event_name}, payload={payload}")
+            logger.info("[log_event] event=%s, payload=%s", event_name, payload)
 
     def _on_disconnect(self, event_name: str, payload: dict[str, Any]) -> None:
         """断连回调：通知 _reconnect_loop 立即感知断连。
@@ -1214,6 +1289,10 @@ class AsyncChatClient:
                     )
                     new_client.on_event(
                         "interaction.resolved", self._on_interaction_resolved
+                    )
+                    new_client.on_event(
+                        "mode_transition.resolved",
+                        self._on_mode_transition_resolved,
                     )
                     new_client.on_event("error", self._on_error)
                     new_client.on_event("*", self._log_event)

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -34,7 +34,7 @@ from ._interaction_protocol import (
     JsonObject,
 )
 from ._session_key_matcher import SessionKeyMatcher
-from ._session_state import _SessionState
+from ._session_state import SessionState
 
 logger = get_logger("core-bot-run")
 
@@ -201,7 +201,7 @@ class AsyncChatClient:
         self._condition = asyncio.Condition()
 
         # sessionKey → _SessionState 分流表
-        self._sessions: dict[str, _SessionState] = {}
+        self._sessions: dict[str, SessionState] = {}
 
         # sessionKey 模糊匹配器：服务端返回的 sessionKey 可能比客户端注册的长，
         # 通过 contains 匹配从 store 中回溯查找客户端注册的原始 key
@@ -264,7 +264,6 @@ class AsyncChatClient:
         _client.on_event("agent", self._on_agent)
         _client.on_event("interaction.requested", self._on_interaction_requested)
         _client.on_event("interaction.resolved", self._on_interaction_resolved)
-        _client.on_event("interaction.resolve", self._on_interaction_resolved)
         _client.on_event("error", self._on_error)
         _client.on_event("*", self._log_event)
         _client.on_disconnect(self._on_disconnect)
@@ -273,7 +272,12 @@ class AsyncChatClient:
             logger.info("Connecting...")
 
         # 直接 await 异步连接，不再需要 run_in_executor
-        hello = await _client.connect()
+        hello: dict[str, Any] | None = None
+        try:
+            hello = await _client.connect()
+        except Exception as e:
+            logger.error(f"Connect failed: {e}")
+            raise e
         self._client = _client
         # 启动后台重连监控（仅在 max_retries > 0 时）
         if self._max_retries > 0 and self._reconnect_monitor is None:
@@ -367,7 +371,7 @@ class AsyncChatClient:
                     state.agent_complete.clear()
                     state.trace_context = trace_ctx
                 else:
-                    state = _SessionState(trace_context=trace_ctx)
+                    state = SessionState(trace_context=trace_ctx)
                     self._sessions[session_key] = state
 
             try:
@@ -494,7 +498,7 @@ class AsyncChatClient:
                     state.agent_complete.clear()
                     state.trace_context = trace_ctx
                 else:
-                    state = _SessionState(trace_context=trace_ctx)
+                    state = SessionState(trace_context=trace_ctx)
                     self._sessions[session_key] = state
 
                 # 流式模式：创建 queue 并绑定到 state
@@ -569,6 +573,7 @@ class AsyncChatClient:
             message: 要注入的消息内容
             session_key: 会话 key，不传则自动生成
             auth_token: 认证令牌，为空时传 OPEN_API:NOT_PROVIDED
+            chat_metadata: 对话元数据
         """
         if session_key is None:
             session_key = f"{uuid.uuid4().hex}"
@@ -665,19 +670,19 @@ class AsyncChatClient:
 
     # ── 私有方法 ──────────────────────────────────────────────────────────
 
-    def _get_session(self, session_key: str) -> _SessionState | None:
+    def _get_session(self, session_key: str) -> SessionState | None:
         """获取指定 sessionKey 的状态（支持模糊匹配）。"""
         result = self._session_matcher.find(session_key)
         return result.state if result else None
 
     @staticmethod
-    def _emit_stream_chunk(state: _SessionState, chunk: StreamChunk) -> None:
+    def _emit_stream_chunk(state: SessionState, chunk: StreamChunk) -> None:
         if state.stream_queue is not None:
             state.stream_queue.put_nowait(chunk)
 
     @staticmethod
     def _handle_terminal_error(
-        state: _SessionState, session_key: str, error_msg: str, source: str
+        state: SessionState, session_key: str, error_msg: str, source: str
     ) -> None:
         msg = error_msg or f"{source} error"
         logger.warning("[%s] error: sessionKey=%s, errMsg=%s", source, session_key, msg)
@@ -693,7 +698,7 @@ class AsyncChatClient:
         payload: dict[str, Any],
         *,
         session_key: str,
-        state: _SessionState | None,
+        state: SessionState | None,
     ) -> None:
         """内部 chat 事件处理器。
 
@@ -779,7 +784,7 @@ class AsyncChatClient:
         payload: dict[str, Any],
         *,
         session_key: str,
-        state: _SessionState | None,
+        state: SessionState | None,
     ) -> None:
         """内部 agent 事件处理器。
 
@@ -866,22 +871,24 @@ class AsyncChatClient:
         payload: JsonObject,
         *,
         session_key: str,
-        state: _SessionState | None,
+        state: SessionState | None,
     ) -> None:
         """Persist and expose a validated engine interaction request."""
+        if self._interaction_service is None:
+            logger.debug("interaction processing is disabled; skip requested event")
+            return
+
         event = EngineInteractionRequestedEvent.from_payload(
             session_key=session_key,
             payload=payload,
         )
-        created = True
-        if self._interaction_service is not None:
-            created = self._interaction_service.record_requested(
-                session_key=event.session_key,
-                interaction_id=event.interaction_id,
-                envelope=event.envelope,
-                allowed_decisions=event.allowed_decisions,
-                expires_at_ms=event.expires_at_ms,
-            )
+        created = self._interaction_service.record_requested(
+            session_key=event.session_key,
+            interaction_id=event.interaction_id,
+            envelope=event.envelope,
+            allowed_decisions=event.allowed_decisions,
+            expires_at_ms=event.expires_at_ms,
+        )
         if created and state is not None:
             self._emit_stream_chunk(
                 state,
@@ -895,8 +902,11 @@ class AsyncChatClient:
                 ),
             )
 
-        if self._interaction_service is None or self._client is None:
+        # Engine events normally arrive only on an active client. Keep persistence
+        # and SSE delivery above, but do not start a dispatcher without an uplink.
+        if self._client is None:
             return
+
         task_key = (event.session_key, event.interaction_id)
         if task_key in self._interaction_tasks:
             return
@@ -920,20 +930,22 @@ class AsyncChatClient:
         payload: JsonObject,
         *,
         session_key: str,
-        state: _SessionState | None,
+        state: SessionState | None,
     ) -> None:
-        """Persist one terminal event and expose it as interaction.resolve."""
+        """Persist and expose one terminal interaction.resolved event."""
+        if self._interaction_service is None:
+            logger.debug("interaction processing is disabled; skip resolved event")
+            return
+
         event = EngineInteractionResolvedEvent.from_payload(
             session_key=session_key,
             payload=payload,
         )
-        applied = True
-        if self._interaction_service is not None:
-            applied = self._interaction_service.mark_resolved(
-                session_key=event.session_key,
-                interaction_id=event.interaction_id,
-                envelope=event.envelope,
-            )
+        applied = self._interaction_service.mark_resolved(
+            session_key=event.session_key,
+            interaction_id=event.interaction_id,
+            envelope=event.envelope,
+        )
         if not applied:
             return
 
@@ -944,7 +956,7 @@ class AsyncChatClient:
                     type="interaction",
                     content="",
                     metadata={
-                        "event": "interaction.resolve",
+                        "event": "interaction.resolved",
                         "payload": event.envelope,
                     },
                 ),
@@ -1048,7 +1060,7 @@ class AsyncChatClient:
         payload: dict[str, Any],
         *,
         session_key: str,
-        state: _SessionState | None,
+        state: SessionState | None,
     ) -> None:
         """error 处理器
         Args:
@@ -1077,7 +1089,7 @@ class AsyncChatClient:
         payload: dict[str, Any],
         *,
         session_key: str,
-        state: _SessionState | None,
+        state: SessionState | None,
     ) -> None:
         """兜底事件处理器
 
@@ -1202,9 +1214,6 @@ class AsyncChatClient:
                     )
                     new_client.on_event(
                         "interaction.resolved", self._on_interaction_resolved
-                    )
-                    new_client.on_event(
-                        "interaction.resolve", self._on_interaction_resolved
                     )
                     new_client.on_event("error", self._on_error)
                     new_client.on_event("*", self._log_event)

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client_pool.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client_pool.py
@@ -70,7 +70,8 @@ class AsyncChatClientPool:
             session_key_timeout: 同一 sessionKey 并发等待超时（秒）
             max_retries: WS 断连后自动重连次数，0 表示不重试
             retry_base_backoff: 重连退避基数（秒）
-            system_config_service: 系统配置服务，传递给 AsyncChatClient 用于读取开关
+            system_config_service: 系统配置服务，用于创建连接时读取运行开关
+            interaction_service: 交互持久化与应答服务；仅在交互开关启用时注入连接
         """
         self._max_size = max_size
         self._max_conns_per_sandbox = max_conns_per_sandbox
@@ -180,7 +181,9 @@ class AsyncChatClientPool:
                 max_retries=self._max_retries,
                 retry_base_backoff=self._retry_base_backoff,
                 ignore_case=self._read_ignore_case(self._system_config_service),
-                interaction_service=self._interaction_service,
+                interaction_service=self._interaction_service
+                if self._enable_process_interaction(self._system_config_service)
+                else None,
             )
             await new_client.connect()
 
@@ -237,6 +240,25 @@ class AsyncChatClientPool:
         except Exception:
             logger.warning(
                 "failed to read session_key_ignore_case config, defaulting to false",
+                exc_info=True,
+            )
+            return False
+        if resp is None:
+            return False
+        return (resp.conf_value or "").strip().lower() == "true"
+
+    @staticmethod
+    def _enable_process_interaction(
+        system_config_service: SystemConfigManageService | None,
+    ) -> bool:
+        """读取新连接是否启用 interaction 事件处理，缺省为关闭。"""
+        if system_config_service is None:
+            return False
+        try:
+            resp = system_config_service.get_config(SystemConfigKey.INTERACTION_PROCESS)
+        except Exception:
+            logger.warning(
+                "failed to read interaction_process config, defaulting to false",
                 exc_info=True,
             )
             return False

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client_pool.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client_pool.py
@@ -23,6 +23,7 @@ from secbaas.community.api.config_manage import SystemConfigManageService
 from secbaas.community.core.service.config import SystemConfigKey
 from secbaas.community.logger import get_logger
 
+from ..bot_interaction import BotInteractionService
 from ._async_chat_client import AsyncChatClient
 
 logger = get_logger("core-bot-run")
@@ -58,6 +59,7 @@ class AsyncChatClientPool:
         max_retries: int = 1,
         retry_base_backoff: float = 0.5,
         system_config_service: SystemConfigManageService | None = None,
+        interaction_service: BotInteractionService | None = None,
     ) -> None:
         """初始化连接池
 
@@ -77,6 +79,7 @@ class AsyncChatClientPool:
         self._max_retries = max_retries
         self._retry_base_backoff = retry_base_backoff
         self._system_config_service = system_config_service
+        self._interaction_service = interaction_service
         # sandbox_id -> 连接列表
         self._clients: dict[str, list[_ConnEntry]] = {}
         # per-key lock，保护同一 sandbox_id 的并发创建
@@ -177,6 +180,7 @@ class AsyncChatClientPool:
                 max_retries=self._max_retries,
                 retry_base_backoff=self._retry_base_backoff,
                 ignore_case=self._read_ignore_case(self._system_config_service),
+                interaction_service=self._interaction_service,
             )
             await new_client.connect()
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py
@@ -26,6 +26,11 @@ from websockets.asyncio.client import ClientConnection
 from secbaas.community.core.utils.env_utils import is_dev
 from secbaas.community.logger import get_logger
 
+from ._interaction_protocol import (
+    EngineInteractionResolveExchange,
+    build_interaction_resolve_request,
+)
+
 logger = get_logger("core-bot-run")
 
 # 事件处理器类型：同步或异步均可，不关心返回值
@@ -323,6 +328,24 @@ class BotWebSocketClient:
 
         return result
 
+    async def interaction_resolve(
+        self,
+        *,
+        interaction_id: str,
+        decision: str,
+    ) -> EngineInteractionResolveExchange:
+        """Resolve an interaction and return the exact validated RPC exchange."""
+        request = build_interaction_resolve_request(
+            request_id=self._next_request_id(),
+            interaction_id=interaction_id,
+            decision=decision,
+        )
+        response = await self._send_request_frame(request, timeout=30.0)
+        return EngineInteractionResolveExchange.from_frames(
+            request=request,
+            response=response,
+        )
+
     async def chat_abort(
         self,
         session_key: str,
@@ -478,28 +501,34 @@ class BotWebSocketClient:
         if not self._connected or self._ws is None:
             raise RuntimeError("Not connected")
 
-        request_id = self._next_request_id()
         request_frame = {
             "type": "req",
-            "id": request_id,
+            "id": self._next_request_id(),
             "method": method,
             "params": params,
         }
+        return await self._send_request_frame(request_frame, timeout=timeout)
 
-        # 注册 Future 等待响应
+    async def _send_request_frame(
+        self,
+        request_frame: dict[str, Any],
+        *,
+        timeout: float,
+    ) -> dict[str, Any]:
+        """Send an already-built request frame and await its matching response."""
+        if not self._connected or self._ws is None:
+            raise RuntimeError("Not connected")
+
+        request_id = request_frame["id"]
+        method = request_frame["method"]
         loop = asyncio.get_running_loop()
         future: asyncio.Future[dict[str, Any]] = loop.create_future()
         self._pending_requests[request_id] = future
-
         await self._ws.send(json.dumps(request_frame))
 
-        # 等待响应
         try:
-            result = await asyncio.wait_for(future, timeout=timeout)
+            return await asyncio.wait_for(future, timeout=timeout)
         except TimeoutError:
-            self._pending_requests.pop(request_id, None)
             raise TimeoutError(f"Request {method} timed out")
         finally:
             self._pending_requests.pop(request_id, None)
-
-        return result

--- a/src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py
@@ -23,6 +23,7 @@ from urllib.parse import urlsplit
 import websockets
 from websockets.asyncio.client import ClientConnection
 
+from secbaas.community.api.bot_interaction import InteractionResolution
 from secbaas.community.core.utils.env_utils import is_dev
 from secbaas.community.logger import get_logger
 
@@ -332,13 +333,13 @@ class BotWebSocketClient:
         self,
         *,
         interaction_id: str,
-        decision: str,
+        resolution: InteractionResolution,
     ) -> EngineInteractionResolveExchange:
         """Resolve an interaction and return the exact validated RPC exchange."""
         request = build_interaction_resolve_request(
             request_id=self._next_request_id(),
             interaction_id=interaction_id,
-            decision=decision,
+            resolution=resolution,
         )
         response = await self._send_request_frame(request, timeout=30.0)
         return EngineInteractionResolveExchange.from_frames(
@@ -444,7 +445,7 @@ class BotWebSocketClient:
     async def _handle_message(self, message: str) -> None:
         """处理收到的文本消息"""
         try:
-            logger.debug(f"Received text message: {message[:500]}...")
+            logger.debug("Received text message: length=%d", len(message))
             data = json.loads(message)
             frame_type = data.get("type")
             logger.debug(f"Parsed message: type={frame_type}, keys={list(data.keys())}")

--- a/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
@@ -530,6 +530,9 @@ class BotRunRequestExecutor:
                     stream_error = chunk.content or "stream error"
                     _write_chunk(chunk)
                     last_flush_ts = time.monotonic()
+                elif chunk.type == "interaction":
+                    _write_chunk(chunk)
+                    last_flush_ts = time.monotonic()
                 else:
                     logger.debug(
                         "[BotRequestWorker] ignore chunk type: %s, run_id: %s",

--- a/src/baas/src/secbaas/community/core/service/bot_run/_interaction_protocol.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_interaction_protocol.py
@@ -6,8 +6,16 @@ import json
 from dataclasses import dataclass
 from typing import Literal
 
+from secbaas.community.api.bot_interaction import InteractionResolution
+
 JsonObject = dict[str, object]
-InteractionEventName = Literal["interaction.requested", "interaction.resolved"]
+InteractionEventName = Literal[
+    "interaction.requested",
+    "interaction.resolved",
+    "mode_transition.resolved",
+]
+
+_DEFAULT_EXEC_DECISIONS = ("allow-once", "allow-always", "deny")
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,6 +65,21 @@ class EngineInteractionResolvedEvent:
             envelope=_event_envelope("interaction.resolved", payload),
         )
 
+    @classmethod
+    def from_mode_transition_payload(
+        cls,
+        *,
+        session_key: str,
+        payload: JsonObject,
+    ) -> EngineInteractionResolvedEvent:
+        if payload.get("kind") != "mode_switch":
+            raise ValueError("mode transition resolved kind must be mode_switch")
+        return cls(
+            session_key=_required_identity(session_key, "sessionKey"),
+            interaction_id=_interaction_id(payload),
+            envelope=_event_envelope("mode_transition.resolved", payload),
+        )
+
 
 @dataclass(frozen=True, slots=True)
 class EngineInteractionResolveExchange:
@@ -94,17 +117,39 @@ def build_interaction_resolve_request(
     *,
     request_id: str,
     interaction_id: str,
-    decision: str,
+    resolution: InteractionResolution,
 ) -> JsonObject:
     """Build the exact engine request frame sent over websocket."""
+    identity_key = (
+        "transitionId" if resolution.kind == "mode_switch" else "interactionId"
+    )
+    method = (
+        "mode_transition.resolve"
+        if resolution.kind == "mode_switch"
+        else "interaction.resolve"
+    )
+    params: JsonObject = {
+        identity_key: _required_identity(interaction_id, identity_key),
+        "decision": resolution.decision,
+    }
+    if resolution.kind == "ask_user":
+        if resolution.answer is not None:
+            params["answer"] = resolution.answer
+        if resolution.message is not None:
+            params["message"] = resolution.message
+        if resolution.values is not None:
+            params["values"] = dict(resolution.values)
+        if resolution.answers is not None:
+            params["answers"] = dict(resolution.answers)
+        if resolution.selected_options is not None:
+            params["selectedOptions"] = [
+                list(options) for options in resolution.selected_options
+            ]
     return {
         "type": "req",
         "id": _required_identity(request_id, "request id"),
-        "method": "interaction.resolve",
-        "params": {
-            "interactionId": _required_identity(interaction_id, "interactionId"),
-            "decision": _required_identity(decision, "decision"),
-        },
+        "method": method,
+        "params": params,
     }
 
 
@@ -125,24 +170,41 @@ def _event_envelope(event: InteractionEventName, payload: JsonObject) -> JsonObj
 
 
 def _allowed_decisions(payload: JsonObject) -> tuple[str, ...]:
+    kind = payload.get("kind")
+    if kind == "ask_user":
+        return ("submit", "cancel")
+    if kind not in {"exec", "mode_switch"}:
+        return ()
+
+    if "options" not in payload:
+        if kind == "exec":
+            return _DEFAULT_EXEC_DECISIONS
+        return ()
+
     options = payload.get("options")
     if options is None:
         return ()
     if not isinstance(options, list):
-        raise ValueError("interaction options must be an array")
+        return ()
 
     decisions: list[str] = []
     for option in options:
         if not isinstance(option, dict):
-            raise ValueError("interaction option must be an object")
-        value = option.get("decision")
+            continue
+        if _non_empty_str(option.get("label")) is None:
+            continue
+        value = _non_empty_str(option.get("decision")) or _non_empty_str(
+            option.get("value")
+        )
         if value is None:
-            value = option.get("value")
-        if not isinstance(value, str) or not value:
-            raise ValueError("interaction option is missing decision")
+            continue
         if value not in decisions:
             decisions.append(value)
     return tuple(decisions)
+
+
+def _non_empty_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value.strip() else None
 
 
 def _optional_int(payload: JsonObject, key: str) -> int | None:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_interaction_protocol.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_interaction_protocol.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 JsonObject = dict[str, object]
-InteractionEventName = Literal["interaction.requested", "interaction.resolve"]
+InteractionEventName = Literal["interaction.requested", "interaction.resolved"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,7 +54,7 @@ class EngineInteractionResolvedEvent:
         return cls(
             session_key=_required_identity(session_key, "sessionKey"),
             interaction_id=_interaction_id(payload),
-            envelope=_event_envelope("interaction.resolve", payload),
+            envelope=_event_envelope("interaction.resolved", payload),
         )
 
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_interaction_protocol.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_interaction_protocol.py
@@ -1,0 +1,178 @@
+"""Typed protocol boundary for engine human-interaction frames."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Literal
+
+JsonObject = dict[str, object]
+InteractionEventName = Literal["interaction.requested", "interaction.resolve"]
+
+
+@dataclass(frozen=True, slots=True)
+class EngineInteractionRequestedEvent:
+    """Validated engine request ready for persistence and SSE delivery."""
+
+    session_key: str
+    interaction_id: str
+    envelope: JsonObject
+    allowed_decisions: tuple[str, ...]
+    expires_at_ms: int | None
+
+    @classmethod
+    def from_payload(
+        cls,
+        *,
+        session_key: str,
+        payload: JsonObject,
+    ) -> EngineInteractionRequestedEvent:
+        return cls(
+            session_key=_required_identity(session_key, "sessionKey"),
+            interaction_id=_interaction_id(payload),
+            envelope=_event_envelope("interaction.requested", payload),
+            allowed_decisions=_allowed_decisions(payload),
+            expires_at_ms=_optional_int(payload, "expiresAtMs"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EngineInteractionResolvedEvent:
+    """Validated terminal engine event ready for persistence and SSE delivery."""
+
+    session_key: str
+    interaction_id: str
+    envelope: JsonObject
+
+    @classmethod
+    def from_payload(
+        cls,
+        *,
+        session_key: str,
+        payload: JsonObject,
+    ) -> EngineInteractionResolvedEvent:
+        return cls(
+            session_key=_required_identity(session_key, "sessionKey"),
+            interaction_id=_interaction_id(payload),
+            envelope=_event_envelope("interaction.resolve", payload),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EngineInteractionResolveExchange:
+    """Validated engine RPC request/response pair."""
+
+    request: JsonObject
+    response: JsonObject
+    accepted: bool
+    error_message: str | None
+
+    @classmethod
+    def from_frames(
+        cls,
+        *,
+        request: JsonObject,
+        response: JsonObject,
+    ) -> EngineInteractionResolveExchange:
+        request_id = _required_str(request, "id")
+        if response.get("type") != "res":
+            raise ValueError("interaction.resolve response type must be res")
+        if _required_str(response, "id") != request_id:
+            raise ValueError("interaction.resolve response id does not match request")
+        ok = response.get("ok")
+        if not isinstance(ok, bool):
+            raise ValueError("interaction.resolve response ok must be boolean")
+        return cls(
+            request=request,
+            response=response,
+            accepted=ok,
+            error_message=None if ok else _error_message(response.get("error")),
+        )
+
+
+def build_interaction_resolve_request(
+    *,
+    request_id: str,
+    interaction_id: str,
+    decision: str,
+) -> JsonObject:
+    """Build the exact engine request frame sent over websocket."""
+    return {
+        "type": "req",
+        "id": _required_identity(request_id, "request id"),
+        "method": "interaction.resolve",
+        "params": {
+            "interactionId": _required_identity(interaction_id, "interactionId"),
+            "decision": _required_identity(decision, "decision"),
+        },
+    }
+
+
+def _interaction_id(payload: JsonObject) -> str:
+    value = payload.get("interactionId")
+    if value is None:
+        value = payload.get("id")
+    if not isinstance(value, str) or not value:
+        raise ValueError("interaction event is missing interactionId")
+    return value
+
+
+def _event_envelope(event: InteractionEventName, payload: JsonObject) -> JsonObject:
+    envelope: JsonObject = {"type": "event", "event": event, "payload": payload}
+    if "seq" in payload:
+        envelope["seq"] = payload["seq"]
+    return envelope
+
+
+def _allowed_decisions(payload: JsonObject) -> tuple[str, ...]:
+    options = payload.get("options")
+    if options is None:
+        return ()
+    if not isinstance(options, list):
+        raise ValueError("interaction options must be an array")
+
+    decisions: list[str] = []
+    for option in options:
+        if not isinstance(option, dict):
+            raise ValueError("interaction option must be an object")
+        value = option.get("decision")
+        if value is None:
+            value = option.get("value")
+        if not isinstance(value, str) or not value:
+            raise ValueError("interaction option is missing decision")
+        if value not in decisions:
+            decisions.append(value)
+    return tuple(decisions)
+
+
+def _optional_int(payload: JsonObject, key: str) -> int | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"interaction {key} must be an integer")
+    return value
+
+
+def _required_str(value: JsonObject, key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str) or not item:
+        raise ValueError(f"interaction frame is missing {key}")
+    return item
+
+
+def _required_identity(value: str, name: str) -> str:
+    if not value:
+        raise ValueError(f"interaction event is missing {name}")
+    return value
+
+
+def _error_message(value: object) -> str:
+    if isinstance(value, dict):
+        message = value.get("message")
+        if isinstance(message, str) and message:
+            return message
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    if isinstance(value, str) and value:
+        return value
+    return "engine rejected interaction.resolve"

--- a/src/baas/src/secbaas/community/core/service/bot_run/_session_key_matcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_session_key_matcher.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 
 from secbaas.community.logger import get_logger
 
-from ._session_state import _SessionState
+from ._session_state import SessionState
 
 logger = get_logger("core-bot-run")
 
@@ -36,7 +36,7 @@ class _MatchResult:
     """
 
     key: str
-    state: _SessionState
+    state: SessionState
     matched_by: str
 
 
@@ -69,7 +69,7 @@ class SessionKeyMatcher:
     """
 
     def __init__(
-        self, store: dict[str, _SessionState], ignore_case: bool = False
+        self, store: dict[str, SessionState], ignore_case: bool = False
     ) -> None:
         """初始化匹配器。
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_session_state.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_session_state.py
@@ -26,3 +26,5 @@ class SessionState:
     # 流式模式专用：_on_chat/_on_agent push StreamChunk 到此 queue，
     # send_message_stream 从中消费。仅流式请求时创建，非流式为 None。
     stream_queue: asyncio.Queue[Any] | None = None
+    # 已向当前流暴露、正在等待 Engine 终态事件的 mode-switch interaction。
+    pending_mode_transition_ids: set[str] = field(default_factory=set)

--- a/src/baas/src/secbaas/community/core/service/bot_run/_session_state.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_session_state.py
@@ -11,7 +11,7 @@ from typing import Any
 
 
 @dataclass
-class _SessionState:
+class SessionState:
     """Per-sessionKey 状态，用于多路复用场景下隔离不同会话的消息。"""
 
     content: str = ""

--- a/src/baas/src/secbaas/community/core/service/config/_constants.py
+++ b/src/baas/src/secbaas/community/core/service/config/_constants.py
@@ -49,6 +49,14 @@ class SystemConfigKey(StrEnum):
     SessionKeyMatcher performs case-insensitive contains matching.
     """
 
+    INTERACTION_PROCESS = "bot_run.interaction_process"
+    """Whether engine interaction events are persisted and forwarded to SSE.
+
+    Value: "true" or "false" (default: "false")
+    Usage: Read when a new pooled AsyncChatClient connection is created.
+    Existing pooled connections keep the value selected at creation time.
+    """
+
     # Add more system config keys here as needed
     # Example:
     # ARCA_DEFAULT_TIMEOUT = "arca.default_timeout"

--- a/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
+++ b/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
@@ -9,7 +9,7 @@
   - chunk.type == "aborted"   → SSE event: chat (中止)
   - chunk.type == "agent"     → SSE event: agent (引擎事件)
   - chunk.type == "heartbeat" → SSE 注释帧: : heartbeat
-  - chunk.type == "interaction" → SSE event: interaction.requested / interaction.resolve
+  - chunk.type == "interaction" → SSE event: interaction.requested / interaction.resolved
   - chunk.type == "usage"     → 无独立事件（忽略）
 """
 
@@ -158,9 +158,7 @@ def _transform_chunk(chunk: StreamChunk, engine: str) -> dict[str, Any] | None:
 def _transform_interaction(chunk: StreamChunk) -> dict[str, Any] | None:
     metadata = chunk.metadata or {}
     event = metadata.get("event")
-    if event == "interaction.resolved":
-        event = "interaction.resolve"
-    if event not in {"interaction.requested", "interaction.resolve"}:
+    if event not in {"interaction.requested", "interaction.resolved"}:
         return None
     payload = metadata.get("payload")
     if not isinstance(payload, dict):

--- a/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
+++ b/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
@@ -9,6 +9,7 @@
   - chunk.type == "aborted"   → SSE event: chat (中止)
   - chunk.type == "agent"     → SSE event: agent (引擎事件)
   - chunk.type == "heartbeat" → SSE 注释帧: : heartbeat
+  - chunk.type == "interaction" → SSE event: interaction.requested / interaction.resolve
   - chunk.type == "usage"     → 无独立事件（忽略）
 """
 
@@ -144,11 +145,29 @@ def _transform_chunk(chunk: StreamChunk, engine: str) -> dict[str, Any] | None:
     if ctype == "agent":
         return _transform_agent(_agent_payload(chunk), engine)
 
+    if ctype == "interaction":
+        return _transform_interaction(chunk)
+
     if ctype == "heartbeat":
         return {"event": ": heartbeat", "data": {}}
 
     # usage / unknown: no standalone SSE event.
     return None
+
+
+def _transform_interaction(chunk: StreamChunk) -> dict[str, Any] | None:
+    metadata = chunk.metadata or {}
+    event = metadata.get("event")
+    if event == "interaction.resolved":
+        event = "interaction.resolve"
+    if event not in {"interaction.requested", "interaction.resolve"}:
+        return None
+    payload = metadata.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    # Payload is already the public protocol envelope. The generic builder will
+    # only set missing runId/ts and assign the SSE seq/id.
+    return {"event": event, "data": payload}
 
 
 def _transform_agent(payload: dict[str, Any], engine: str) -> dict[str, Any] | None:

--- a/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
+++ b/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
@@ -9,7 +9,7 @@
   - chunk.type == "aborted"   → SSE event: chat (中止)
   - chunk.type == "agent"     → SSE event: agent (引擎事件)
   - chunk.type == "heartbeat" → SSE 注释帧: : heartbeat
-  - chunk.type == "interaction" → SSE event: interaction.requested / interaction.resolved
+  - chunk.type == "interaction" → SSE event: interaction (扁平 BCN 数据)
   - chunk.type == "usage"     → 无独立事件（忽略）
 """
 
@@ -20,6 +20,21 @@ import time
 from typing import Any
 
 from secbaas.community.api.sse import SseEvent, StreamChunk
+from secbaas.community.logger import get_logger
+
+logger = get_logger("core-service")
+
+_INTERACTION_EVENT_PHASES = {
+    "interaction.requested": "requested",
+    "interaction.resolved": "resolved",
+    "mode_transition.resolved": "resolved",
+}
+_INTERACTION_KINDS = {"ask_user", "exec", "mode_switch"}
+_DEFAULT_EXEC_OPTIONS = (
+    {"label": "Allow once", "decision": "allow-once"},
+    {"label": "Allow always", "decision": "allow-always"},
+    {"label": "Deny", "decision": "deny"},
+)
 
 
 class DefaultStreamConverter:
@@ -47,7 +62,7 @@ class DefaultStreamConverter:
         return "default"
 
     def convert(self, chunk: StreamChunk, *, run_id: str) -> SseEvent | None:
-        converted = _transform_chunk(chunk, _engine_name(chunk))
+        converted = _transform_chunk(chunk, _engine_name(chunk), run_id)
         if converted is None:
             return None
         if converted["event"].startswith(":"):
@@ -101,7 +116,11 @@ def _agent_payload(chunk: StreamChunk) -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-def _transform_chunk(chunk: StreamChunk, engine: str) -> dict[str, Any] | None:
+def _transform_chunk(
+    chunk: StreamChunk,
+    engine: str,
+    run_id: str,
+) -> dict[str, Any] | None:
     """Route by StreamChunk.type. delta/final/error are chat events built from
     the chunk's own fields; agent events read the raw engine payload."""
     ctype = chunk.type
@@ -146,7 +165,7 @@ def _transform_chunk(chunk: StreamChunk, engine: str) -> dict[str, Any] | None:
         return _transform_agent(_agent_payload(chunk), engine)
 
     if ctype == "interaction":
-        return _transform_interaction(chunk)
+        return _transform_interaction(chunk, run_id)
 
     if ctype == "heartbeat":
         return {"event": ": heartbeat", "data": {}}
@@ -155,17 +174,711 @@ def _transform_chunk(chunk: StreamChunk, engine: str) -> dict[str, Any] | None:
     return None
 
 
-def _transform_interaction(chunk: StreamChunk) -> dict[str, Any] | None:
+def _transform_interaction(
+    chunk: StreamChunk,
+    run_id: str,
+) -> dict[str, Any] | None:
     metadata = chunk.metadata or {}
     event = metadata.get("event")
-    if event not in {"interaction.requested", "interaction.resolved"}:
+    if event not in _INTERACTION_EVENT_PHASES:
+        _warn_interaction(
+            run_id=run_id,
+            field_path="metadata.event",
+            error_type="unsupported_event",
+        )
         return None
-    payload = metadata.get("payload")
+
+    envelope = metadata.get("payload")
+    if not isinstance(envelope, dict):
+        _warn_interaction(
+            run_id=run_id,
+            field_path="metadata.payload",
+            error_type="invalid_envelope",
+        )
+        return None
+    if envelope.get("type") != "event" or envelope.get("event") != event:
+        _warn_interaction(
+            run_id=run_id,
+            field_path="metadata.payload",
+            error_type="invalid_envelope",
+        )
+        return None
+
+    payload = envelope.get("payload")
     if not isinstance(payload, dict):
+        _warn_interaction(
+            run_id=run_id,
+            field_path="metadata.payload.payload",
+            error_type="invalid_envelope",
+        )
         return None
-    # Payload is already the public protocol envelope. The generic builder will
-    # only set missing runId/ts and assign the SSE seq/id.
-    return {"event": event, "data": payload}
+
+    phase = _INTERACTION_EVENT_PHASES[event]
+    data = _common_interaction_data(payload, phase=phase, run_id=run_id)
+    if data is None:
+        return None
+
+    if phase == "resolved":
+        _copy_present(
+            payload,
+            data,
+            ("decision", "action", "answers", "idempotencyKey"),
+        )
+        return {"event": "interaction", "data": data}
+
+    try:
+        if data["kind"] == "ask_user":
+            converted = _transform_ask_user_requested(
+                payload,
+                data,
+                run_id=run_id,
+            )
+        elif data["kind"] == "exec":
+            converted = _transform_exec_requested(
+                payload,
+                data,
+                run_id=run_id,
+            )
+        elif data["kind"] == "mode_switch":
+            converted = _transform_mode_switch_requested(
+                payload,
+                data,
+                run_id=run_id,
+            )
+        else:
+            # Kind-specific requested mappings are added independently. Dropping an
+            # unsupported requested shape is safer than leaking the Engine payload.
+            return None
+        if not converted:
+            return None
+        return {"event": "interaction", "data": data}
+    except Exception as exc:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=data["interactionId"],
+            kind=data["kind"],
+            field_path="kind_converter",
+            error_type=type(exc).__name__,
+        )
+        return None
+
+
+def _transform_ask_user_requested(
+    payload: dict[str, Any],
+    data: dict[str, Any],
+    *,
+    run_id: str,
+) -> bool:
+    raw_questions = payload.get("questions")
+    if isinstance(raw_questions, list):
+        for index, question in enumerate(raw_questions):
+            if not isinstance(question, dict):
+                continue
+            for key in ("secret", "isSecret"):
+                if key in question:
+                    _warn_interaction(
+                        run_id=run_id,
+                        interaction_id=data["interactionId"],
+                        kind=data["kind"],
+                        field_path=f"payload.questions[{index}].{key}",
+                        error_type="secret_question_unsupported",
+                    )
+                    return False
+
+    questions = _convert_ask_user_questions(
+        raw_questions,
+        run_id=run_id,
+        interaction_id=data["interactionId"],
+        kind=data["kind"],
+    )
+    if not questions:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=data["interactionId"],
+            kind=data["kind"],
+            field_path="payload.questions",
+            error_type="no_valid_questions",
+        )
+        return False
+    data["questions"] = questions
+    return True
+
+
+def _convert_ask_user_questions(
+    value: Any,
+    *,
+    run_id: str,
+    interaction_id: str,
+    kind: str,
+) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path="payload.questions",
+            error_type="invalid_type",
+        )
+        return []
+
+    converted: list[dict[str, Any]] = []
+    seen_headers: set[str] = set()
+    for index, question in enumerate(value):
+        field_path = f"payload.questions[{index}]"
+        if not isinstance(question, dict):
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=field_path,
+                error_type="invalid_type",
+            )
+            continue
+
+        question_text = _non_empty_str(question.get("question"))
+        if question_text is None:
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=f"{field_path}.question",
+                error_type="missing_required_field",
+            )
+            continue
+
+        header = _non_empty_str(question.get("header"))
+        if header is None:
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=f"{field_path}.header",
+                error_type="invalid_header",
+            )
+            return []
+
+        converted_question: dict[str, Any] = {
+            "questionId": f"question_{index + 1}",
+            "question": question_text,
+            "header": header,
+        }
+        has_options = "options" in question
+        if has_options:
+            options = _convert_ask_user_options(
+                question.get("options"),
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=f"{field_path}.options",
+            )
+            if not options:
+                continue
+            converted_question["options"] = options
+
+        _copy_optional_bool(
+            question,
+            converted_question,
+            "multiSelect",
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path=f"{field_path}.multiSelect",
+        )
+        if has_options:
+            _copy_optional_bool(
+                question,
+                converted_question,
+                "allowOther",
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=f"{field_path}.allowOther",
+            )
+        elif question.get("allowOther") is not None:
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=f"{field_path}.allowOther",
+                error_type="unsupported_without_options",
+            )
+
+        if header in seen_headers:
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=f"{field_path}.header",
+                error_type="duplicate_header",
+            )
+        if len(converted) >= 4:
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=field_path,
+                error_type="max_items_exceeded",
+            )
+            continue
+        seen_headers.add(header)
+        converted.append(converted_question)
+    return converted
+
+
+def _convert_ask_user_options(
+    value: Any,
+    *,
+    run_id: str,
+    interaction_id: str,
+    kind: str,
+    field_path: str,
+) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path=field_path,
+            error_type="invalid_type",
+        )
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path=field_path,
+            error_type="no_valid_options",
+        )
+        return []
+
+    converted: list[dict[str, Any]] = []
+    option_positions: dict[str, int] = {}
+    for index, option in enumerate(value):
+        option_path = f"{field_path}[{index}]"
+        if not isinstance(option, dict):
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=option_path,
+                error_type="invalid_type",
+            )
+            continue
+
+        label = _non_empty_str(option.get("label"))
+        option_value = _non_empty_str(option.get("decision")) or _non_empty_str(
+            option.get("value")
+        )
+        if label is None:
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=option_path,
+                error_type="missing_required_field",
+            )
+            continue
+        if option_value is None:
+            option_value = label
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=option_path,
+                error_type="legacy_label_fallback",
+            )
+
+        converted_option: dict[str, Any] = {
+            "label": label,
+            "value": option_value,
+        }
+        _copy_present(option, converted_option, ("description",))
+        existing_position = option_positions.get(option_value)
+        if existing_position is not None:
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=f"{option_path}.value",
+                error_type="duplicate_option_value",
+            )
+            converted[existing_position] = converted_option
+            continue
+        if len(converted) >= 4:
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=option_path,
+                error_type="max_items_exceeded",
+            )
+            continue
+        option_positions[option_value] = len(converted)
+        converted.append(converted_option)
+    if not converted:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path=field_path,
+            error_type="no_valid_options",
+        )
+    return converted
+
+
+def _copy_optional_bool(
+    source: dict[str, Any],
+    target: dict[str, Any],
+    key: str,
+    *,
+    run_id: str,
+    interaction_id: str,
+    kind: str,
+    field_path: str,
+) -> None:
+    value = source.get(key)
+    if value is None:
+        return
+    if isinstance(value, bool):
+        target[key] = value
+        return
+    _warn_interaction(
+        run_id=run_id,
+        interaction_id=interaction_id,
+        kind=kind,
+        field_path=field_path,
+        error_type="invalid_type",
+    )
+
+
+def _transform_exec_requested(
+    payload: dict[str, Any],
+    data: dict[str, Any],
+    *,
+    run_id: str,
+) -> bool:
+    command = _non_empty_str(payload.get("command"))
+    if command is None:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=data["interactionId"],
+            kind=data["kind"],
+            field_path="payload.command",
+            error_type="missing_required_field",
+        )
+        return False
+    data["command"] = command
+    _copy_present(payload, data, ("cwd",))
+
+    if "options" not in payload:
+        data["options"] = [dict(option) for option in _DEFAULT_EXEC_OPTIONS]
+        return True
+
+    options = _convert_decision_options(
+        payload.get("options"),
+        run_id=run_id,
+        interaction_id=data["interactionId"],
+        kind=data["kind"],
+    )
+    if not options:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=data["interactionId"],
+            kind=data["kind"],
+            field_path="payload.options",
+            error_type="no_valid_options",
+        )
+        return False
+    data["options"] = options
+    return True
+
+
+def _transform_mode_switch_requested(
+    payload: dict[str, Any],
+    data: dict[str, Any],
+    *,
+    run_id: str,
+) -> bool:
+    subject = payload.get("subject")
+    subject = subject if isinstance(subject, dict) else {}
+    _copy_first_present(
+        data,
+        "fromMode",
+        _non_empty_str(payload.get("fromMode")),
+        _non_empty_str(subject.get("fromMode")),
+    )
+    _copy_first_present(
+        data,
+        "targetMode",
+        _non_empty_str(payload.get("toMode")),
+        _non_empty_str(subject.get("toMode")),
+    )
+
+    options = _convert_mode_switch_options(
+        payload.get("options"),
+        run_id=run_id,
+        interaction_id=data["interactionId"],
+        kind=data["kind"],
+    )
+    if not options:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=data["interactionId"],
+            kind=data["kind"],
+            field_path="payload.options",
+            error_type="no_valid_options",
+        )
+        return False
+    data["options"] = options
+    return True
+
+
+def _common_interaction_data(
+    payload: dict[str, Any],
+    *,
+    phase: str,
+    run_id: str,
+) -> dict[str, Any] | None:
+    interaction_id = _non_empty_str(payload.get("interactionId")) or _non_empty_str(
+        payload.get("id")
+    )
+    kind = _non_empty_str(payload.get("kind"))
+    if interaction_id is None:
+        _warn_interaction(
+            run_id=run_id,
+            kind=kind or "",
+            field_path="interactionId",
+            error_type="missing_required_field",
+        )
+        return None
+    if kind is None:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            field_path="kind",
+            error_type="missing_required_field",
+        )
+        return None
+    if kind not in _INTERACTION_KINDS:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path="payload.kind",
+            error_type="unsupported_kind",
+        )
+        return None
+
+    payload_phase = payload.get("phase")
+    if payload_phase is not None and payload_phase != phase:
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path="phase",
+            error_type="phase_conflict",
+        )
+
+    data: dict[str, Any] = {
+        "interactionId": interaction_id,
+        "kind": kind,
+        "phase": phase,
+    }
+    _copy_first_present(data, "title", payload.get("title"))
+    _copy_first_present(data, "description", payload.get("description"))
+
+    subject = payload.get("subject")
+    subject_tool_call_id = (
+        subject.get("toolCallId") if isinstance(subject, dict) else None
+    )
+    _copy_first_present(
+        data,
+        "toolCallId",
+        _non_empty_str(payload.get("toolCallId")),
+        _non_empty_str(subject_tool_call_id),
+    )
+    return data
+
+
+def _convert_decision_options(
+    value: Any,
+    *,
+    run_id: str,
+    interaction_id: str,
+    kind: str,
+) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path="payload.options",
+            error_type="invalid_type",
+        )
+        return []
+
+    converted: list[dict[str, str]] = []
+    decision_positions: dict[str, int] = {}
+    for index, option in enumerate(value):
+        field_path = f"payload.options[{index}]"
+        if not isinstance(option, dict):
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=field_path,
+                error_type="invalid_type",
+            )
+            continue
+
+        label = _non_empty_str(option.get("label"))
+        decision = _non_empty_str(option.get("decision")) or _non_empty_str(
+            option.get("value")
+        )
+        if label is None or decision is None:
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=field_path,
+                error_type="missing_required_field",
+            )
+            continue
+        converted_option = {"label": label, "decision": decision}
+        existing_position = decision_positions.get(decision)
+        if existing_position is not None:
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=f"{field_path}.decision",
+                error_type="duplicate_option_decision",
+            )
+            converted[existing_position] = converted_option
+            continue
+        decision_positions[decision] = len(converted)
+        converted.append(converted_option)
+    return converted
+
+
+def _convert_mode_switch_options(
+    value: Any,
+    *,
+    run_id: str,
+    interaction_id: str,
+    kind: str,
+) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        _warn_interaction(
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path="payload.options",
+            error_type="invalid_type",
+        )
+        return []
+
+    converted: list[dict[str, Any]] = []
+    decision_positions: dict[str, int] = {}
+    for index, option in enumerate(value):
+        field_path = f"payload.options[{index}]"
+        if not isinstance(option, dict):
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=field_path,
+                error_type="invalid_type",
+            )
+            continue
+
+        label = _non_empty_str(option.get("label"))
+        decision = _non_empty_str(option.get("decision")) or _non_empty_str(
+            option.get("value")
+        )
+        if label is None or decision is None:
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=field_path,
+                error_type="missing_required_field",
+            )
+            continue
+
+        converted_option: dict[str, Any] = {
+            "label": label,
+            "decision": decision,
+        }
+        if "targetMode" in option:
+            target_mode = _non_empty_str(option.get("targetMode"))
+            if target_mode is None:
+                _warn_interaction(
+                    run_id=run_id,
+                    interaction_id=interaction_id,
+                    kind=kind,
+                    field_path=f"{field_path}.targetMode",
+                    error_type="invalid_type",
+                )
+            else:
+                converted_option["targetMode"] = target_mode
+        _copy_optional_bool(
+            option,
+            converted_option,
+            "recommended",
+            run_id=run_id,
+            interaction_id=interaction_id,
+            kind=kind,
+            field_path=f"{field_path}.recommended",
+        )
+
+        existing_position = decision_positions.get(decision)
+        if existing_position is not None:
+            _warn_interaction(
+                run_id=run_id,
+                interaction_id=interaction_id,
+                kind=kind,
+                field_path=f"{field_path}.decision",
+                error_type="duplicate_option_decision",
+            )
+            converted[existing_position] = converted_option
+            continue
+        decision_positions[decision] = len(converted)
+        converted.append(converted_option)
+    return converted
+
+
+def _non_empty_str(value: Any) -> str | None:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _copy_first_present(
+    target: dict[str, Any],
+    key: str,
+    *values: Any,
+) -> None:
+    for value in values:
+        if value is not None:
+            target[key] = value
+            return
+
+
+def _warn_interaction(
+    *,
+    run_id: str,
+    interaction_id: str = "",
+    kind: str = "",
+    field_path: str,
+    error_type: str,
+) -> None:
+    logger.warning(
+        "Interaction conversion warning: run_id=%s interaction_id=%s "
+        "kind=%s field_path=%s error_type=%s",
+        run_id,
+        interaction_id,
+        kind,
+        field_path,
+        error_type,
+    )
 
 
 def _transform_agent(payload: dict[str, Any], engine: str) -> dict[str, Any] | None:

--- a/src/baas/tests/architecture/check_protocols/api/bcn/check_bcn_downlink_service.py
+++ b/src/baas/tests/architecture/check_protocols/api/bcn/check_bcn_downlink_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 from secbaas.community.api.bcn import BcnDownlinkService as BcnDownlinkServiceProtocol
+from secbaas.community.api.bot_interaction import BotInteractionService
 from secbaas.community.core.repository.api_gateway import APIKeyRepository
 from secbaas.community.core.repository.bot_run import BotRunRepository
 from secbaas.community.core.service.bcn import DefaultBcnDownlinkService
@@ -14,4 +15,5 @@ _bcn_downlink_service: BcnDownlinkServiceProtocol = DefaultBcnDownlinkService(
     bcn_api_key_prefix="test-prefix",
     uplink_client=MagicMock(spec=BcnUplinkClient),
     run_repository=MagicMock(spec=BotRunRepository),
+    interaction_service=MagicMock(spec=BotInteractionService),
 )

--- a/src/baas/tests/e2e/asgi/baseline/test_bcn_downlink_extended.py
+++ b/src/baas/tests/e2e/asgi/baseline/test_bcn_downlink_extended.py
@@ -7,9 +7,13 @@ Covers additional error scenarios and transport variants:
 - Response JSON structure and field presence
 """
 
+from copy import deepcopy
+
 import pytest
 
+from secbaas.community.api.bcn import BcnInteractionResolveResult
 from tests.e2e.asgi.conftest import APITestHelper
+from tests.unit.adapters.web.conftest import iter_api_routes
 
 pytestmark = [pytest.mark.e2e_asgi]
 
@@ -46,6 +50,31 @@ _CHAT_INJECT_BODY: dict = {
     },
 }
 
+_INTERACTION_RESOLVE_BODY: dict = {
+    "type": "req",
+    "id": "resolve-001",
+    "method": "interaction.resolve",
+    "session_id": "test-session-001",
+    "bcn_group_id": "test-group-001",
+    "to_bot": {"provider_id": "baas", "provider_bot_ref": "test-bot"},
+    "params": {
+        "bcsRunId": "bcs-run-001",
+        "runId": "provider-run-001",
+        "interactionId": "interaction-001",
+        "kind": "ask_user",
+        "idempotencyKey": "idem-001",
+        "action": "submit",
+        "answers": {
+            "components": {
+                "header": "Components",
+                "question": "Which components?",
+                "values": ["web", "worker"],
+            }
+        },
+    },
+    "timeout_ms": 600_000,
+}
+
 
 def _assert_json_response(response, expected_status=None):
     """Assert response is JSON with expected structure."""
@@ -55,6 +84,71 @@ def _assert_json_response(response, expected_status=None):
         assert isinstance(data, dict)
         if expected_status is not None:
             assert response.status_code == expected_status
+
+
+class TestInteractionResolve:
+    @pytest.mark.asyncio
+    async def test_invalid_resolve_returns_sanitized_finite_ack(
+        self,
+        api: APITestHelper,
+    ) -> None:
+        body = deepcopy(_INTERACTION_RESOLVE_BODY)
+        body["params"]["answers"]["components"]["values"] = [
+            "answer-must-not-leak",
+            "",
+        ]
+
+        response = await api.client.post(
+            _BCN_DOWNLINK_URL,
+            json=body,
+            headers=_VALID_HEADERS,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "ok": False,
+            "retryable": False,
+            "error": "invalid interaction.resolve request",
+        }
+        assert "answer-must-not-leak" not in response.text
+
+    @pytest.mark.asyncio
+    async def test_ask_user_resolve_returns_provider_ack(
+        self,
+        api: APITestHelper,
+        _testclient_app,
+    ) -> None:
+        captured = {}
+
+        class _CapturingService:
+            async def handle_interaction_resolve(self, resolve_input):
+                captured["input"] = resolve_input
+                return BcnInteractionResolveResult(ok=True)
+
+        downlink_route = next(
+            route
+            for route in iter_api_routes(_testclient_app)
+            if route.path == _BCN_DOWNLINK_URL
+        )
+        dep_key = next(
+            dependency.call
+            for dependency in downlink_route.dependant.dependencies
+            if dependency.name == "service"
+        )
+        _testclient_app.dependency_overrides[dep_key] = lambda: _CapturingService()
+        try:
+            response = await api.client.post(
+                _BCN_DOWNLINK_URL,
+                json=_INTERACTION_RESOLVE_BODY,
+                headers=_VALID_HEADERS,
+            )
+        finally:
+            _testclient_app.dependency_overrides.pop(dep_key, None)
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True, "retryable": None, "error": None}
+        assert captured["input"].answers["components"].values == ("web", "worker")
+        assert captured["input"].answers["components"].header == "Components"
 
 
 class TestChatInject:

--- a/src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
@@ -2,23 +2,212 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
+from pydantic import ValidationError
 
 from secbaas.community.adapters.web.routers.bcn_downlink.bcn_model import (
     ChatSendRequest,
+    InteractionResolveRequest,
 )
 from secbaas.community.adapters.web.routers.bcn_downlink.bcn_router import (
+    _METHOD_DISPATCH,
     _dispatch_chat_send,
     _dispatch_chat_send_stream,
+    _dispatch_interaction_resolve,
     validate_bcn_token,
 )
 from secbaas.community.api.bcn import (
     Attachment as DomainAttachment,
 )
 from secbaas.community.api.bcn import (
+    BcnInteractionResolveResult,
     BcnInvalidRequestError,
 )
+from secbaas.community.api.bot_interaction import InteractionBadRequestError
 from secbaas.community.api.sse import StreamChunk
 from secbaas.community.core.service.sse import DefaultStreamConverter
+
+
+def _interaction_resolve_body(**param_overrides):
+    params = {
+        "bcsRunId": "bcs-run-1",
+        "runId": "provider-run-1",
+        "interactionId": "interaction-ask-1",
+        "kind": "ask_user",
+        "idempotencyKey": "idem-ask-1",
+        "action": "submit",
+        "answers": {
+            "deploy_target": {
+                "header": "Deployment environment",
+                "values": ["staging"],
+                "question": "what's your deploy target?",
+            },
+            "components": {
+                "header": "Components",
+                "values": ["web", "worker"],
+                "question": "whats' the components?",
+            },
+        },
+    }
+    params.update(param_overrides)
+    return {
+        "type": "req",
+        "id": "bcn-resolve-1",
+        "method": "interaction.resolve",
+        "session_id": "session-1",
+        "bcn_group_id": "group-1",
+        "to_bot": {"provider_id": "baas", "provider_bot_ref": "bot-1"},
+        "params": params,
+        "timeout_ms": 3_600_000,
+    }
+
+
+def test_interaction_resolve_request_accepts_bcs_ask_user_shape() -> None:
+    request = InteractionResolveRequest.model_validate(_interaction_resolve_body())
+
+    assert request.params.interaction_id == "interaction-ask-1"
+    assert request.params.action == "submit"
+    assert request.params.answers is not None
+    assert request.params.answers["components"].values == ["web", "worker"]
+    assert request.params.answers["deploy_target"].header == ("Deployment environment")
+
+
+def test_interaction_resolve_is_registered_on_json_downlink() -> None:
+    request_model, dispatcher = _METHOD_DISPATCH["interaction.resolve"]
+
+    assert request_model is InteractionResolveRequest
+    assert dispatcher is _dispatch_interaction_resolve
+
+
+@pytest.mark.asyncio
+async def test_dispatch_interaction_resolve_preserves_full_request() -> None:
+    captured = {}
+
+    class _CapturingService:
+        async def handle_interaction_resolve(self, resolve_input):
+            captured["input"] = resolve_input
+            return BcnInteractionResolveResult(ok=True)
+
+    request = InteractionResolveRequest.model_validate(_interaction_resolve_body())
+
+    response = await _dispatch_interaction_resolve(request, _CapturingService())
+
+    assert response.model_dump(exclude_none=True) == {"ok": True}
+    resolve_input = captured["input"]
+    assert resolve_input.id == "bcn-resolve-1"
+    assert resolve_input.session_id == "session-1"
+    assert resolve_input.bcn_group_id == "group-1"
+    assert resolve_input.interaction_id == "interaction-ask-1"
+    assert resolve_input.kind == "ask_user"
+    assert resolve_input.idempotency_key == "idem-ask-1"
+    assert resolve_input.action == "submit"
+    assert resolve_input.answers["components"].values == ("web", "worker")
+    assert resolve_input.answers["components"].question == "whats' the components?"
+    assert resolve_input.answers["deploy_target"].header == "Deployment environment"
+    assert resolve_input.request_envelope == _interaction_resolve_body()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_interaction_resolve_returns_finite_domain_error() -> None:
+    class _RejectingService:
+        async def handle_interaction_resolve(self, _resolve_input):
+            raise InteractionBadRequestError("resolution does not match interaction")
+
+    request = InteractionResolveRequest.model_validate(_interaction_resolve_body())
+
+    response = await _dispatch_interaction_resolve(request, _RejectingService())
+
+    assert response.model_dump(exclude_none=True) == {
+        "ok": False,
+        "retryable": False,
+        "error": "resolution does not match interaction",
+    }
+    assert "staging" not in response.error
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"answers": {}},
+        {
+            "answers": {
+                "question-1": {
+                    "header": "Question",
+                    "values": [],
+                    "question": "Question?",
+                },
+            }
+        },
+        {
+            "answers": {
+                "question-1": {
+                    "header": "Question",
+                    "values": [""],
+                    "question": "Question?",
+                },
+            }
+        },
+        {
+            "answers": {
+                "question-1": {
+                    "header": "Question",
+                    "values": ["value"],
+                    "question": "   ",
+                },
+            }
+        },
+        {
+            "answers": {
+                "question-1": {
+                    "values": ["value"],
+                    "question": "Question?",
+                },
+            }
+        },
+        {
+            "answers": {
+                "question-1": {
+                    "header": "",
+                    "values": ["value"],
+                    "question": "Question?",
+                },
+            }
+        },
+        {
+            "answers": {
+                "question-1": {
+                    "header": "   ",
+                    "values": ["value"],
+                    "question": "Question?",
+                },
+            }
+        },
+        {
+            "answers": {
+                "question-1": {
+                    "header": 7,
+                    "values": ["value"],
+                    "question": "Question?",
+                },
+            }
+        },
+    ],
+)
+def test_interaction_resolve_request_rejects_bad_ask_user_answers(params) -> None:
+    with pytest.raises(ValidationError):
+        InteractionResolveRequest.model_validate(_interaction_resolve_body(**params))
+
+
+@pytest.mark.parametrize("kind", ["exec", "mode_switch"])
+def test_interaction_resolve_request_requires_decision_for_non_ask(kind) -> None:
+    with pytest.raises(ValidationError):
+        InteractionResolveRequest.model_validate(
+            _interaction_resolve_body(
+                kind=kind,
+                action=None,
+                answers=None,
+                decision=None,
+            )
+        )
 
 
 def test_validate_bcn_token_uses_secret_store_when_env_is_unset(monkeypatch):

--- a/src/baas/tests/unit/adapters/web/open_api/test_message_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_message_router.py
@@ -991,6 +991,7 @@ class TestResolveMessageInteraction:
         from secbaas.community.adapters.web.routers.open_api.model import (
             InteractionResolveEnvelope,
         )
+        from secbaas.community.api.bot_interaction import InteractionResolution
         from secbaas.community.core.service.bot_interaction import (
             InteractionResolveResult,
         )
@@ -1020,7 +1021,7 @@ class TestResolveMessageInteraction:
         service.resolve.assert_called_once_with(
             session_key="s-1",
             interaction_id="int-1",
-            decision="allow-once",
+            resolution=InteractionResolution(decision="allow-once"),
             request_envelope={
                 "type": "req",
                 "id": "req-1",

--- a/src/baas/tests/unit/adapters/web/open_api/test_message_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_message_router.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 
 from secbaas.community.adapters.web.routers.open_api.message_router import (
     deliver_message,
@@ -979,3 +980,192 @@ class TestGetMessageResult:
                 bot_runner=self._make_runner(record),
             )
             mock_policy.assert_called_once_with(api_key, "bot-42:entity-7")
+
+
+class TestResolveMessageInteraction:
+    @pytest.mark.asyncio
+    async def test_returns_rpc_res_envelope(self):
+        from secbaas.community.adapters.web.routers.open_api.message_router import (
+            resolve_message_interaction,
+        )
+        from secbaas.community.adapters.web.routers.open_api.model import (
+            InteractionResolveEnvelope,
+        )
+        from secbaas.community.core.service.bot_interaction import (
+            InteractionResolveResult,
+        )
+
+        service = MagicMock()
+        service.resolve.return_value = InteractionResolveResult(interaction_id="int-1")
+
+        response = await resolve_message_interaction(
+            request=InteractionResolveEnvelope(
+                type="req",
+                id="req-1",
+                method="interaction.resolve",
+                params={
+                    "sessionKey": "s-1",
+                    "interactionId": "int-1",
+                    "decision": "allow-once",
+                },
+            ),
+            api_key_record=_make_api_key_record(),
+            interaction_service=service,
+        )
+
+        body = response.model_dump(by_alias=True)
+        assert body["type"] == "res"
+        assert body["id"] == "req-1"
+        assert body["ok"] is True
+        service.resolve.assert_called_once_with(
+            session_key="s-1",
+            interaction_id="int-1",
+            decision="allow-once",
+            request_envelope={
+                "type": "req",
+                "id": "req-1",
+                "method": "interaction.resolve",
+                "params": {
+                    "sessionKey": "s-1",
+                    "interactionId": "int-1",
+                    "decision": "allow-once",
+                },
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_forbidden_app_type_raises_403(self):
+        from secbaas.community.adapters.web.routers.open_api.message_router import (
+            resolve_message_interaction,
+        )
+        from secbaas.community.adapters.web.routers.open_api.model import (
+            InteractionResolveEnvelope,
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await resolve_message_interaction(
+                request=InteractionResolveEnvelope(
+                    type="req",
+                    id="req-1",
+                    method="interaction.resolve",
+                    params={
+                        "sessionKey": "s-1",
+                        "interactionId": "int-1",
+                        "decision": "allow-once",
+                    },
+                ),
+                api_key_record=_make_api_key_record(app_type="user"),
+                interaction_service=MagicMock(),
+            )
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_domain_conflict_returns_typed_rpc_error(self):
+        from secbaas.community.adapters.web.routers.open_api.message_router import (
+            resolve_message_interaction,
+        )
+        from secbaas.community.adapters.web.routers.open_api.model import (
+            InteractionResolveEnvelope,
+        )
+        from secbaas.community.core.service.bot_interaction import (
+            InteractionConflictError,
+        )
+
+        service = MagicMock()
+        service.resolve.side_effect = InteractionConflictError(
+            "interaction state is queued"
+        )
+        response = await resolve_message_interaction(
+            request=InteractionResolveEnvelope(
+                type="req",
+                id="req-1",
+                method="interaction.resolve",
+                params={
+                    "sessionKey": "s-1",
+                    "interactionId": "int-1",
+                    "decision": "allow-once",
+                },
+            ),
+            api_key_record=_make_api_key_record(),
+            interaction_service=service,
+        )
+
+        assert response.model_dump(by_alias=True) == {
+            "type": "res",
+            "id": "req-1",
+            "ok": False,
+            "error": {
+                "code": "CONFLICT",
+                "message": "interaction state is queued",
+            },
+        }
+
+    @pytest.mark.asyncio
+    async def test_repository_failure_propagates(self):
+        from secbaas.community.adapters.web.routers.open_api.message_router import (
+            resolve_message_interaction,
+        )
+        from secbaas.community.adapters.web.routers.open_api.model import (
+            InteractionResolveEnvelope,
+        )
+
+        service = MagicMock()
+        service.resolve.side_effect = RuntimeError("db down")
+        with pytest.raises(RuntimeError, match="db down"):
+            await resolve_message_interaction(
+                request=InteractionResolveEnvelope(
+                    type="req",
+                    id="req-1",
+                    method="interaction.resolve",
+                    params={
+                        "sessionKey": "s-1",
+                        "interactionId": "int-1",
+                        "decision": "allow-once",
+                    },
+                ),
+                api_key_record=_make_api_key_record(),
+                interaction_service=service,
+            )
+
+    @pytest.mark.parametrize(
+        "request_body",
+        [
+            {
+                "type": "event",
+                "id": "req-1",
+                "method": "interaction.resolve",
+                "params": {
+                    "sessionKey": "s-1",
+                    "interactionId": "int-1",
+                    "decision": "allow-once",
+                },
+            },
+            {
+                "type": "req",
+                "id": "req-1",
+                "method": "interaction.answer",
+                "params": {
+                    "sessionKey": "s-1",
+                    "interactionId": "int-1",
+                    "decision": "allow-once",
+                },
+            },
+            {
+                "type": "req",
+                "id": "req-1",
+                "method": "interaction.resolve",
+                "params": {
+                    "sessionKey": "",
+                    "interactionId": "int-1",
+                    "decision": "allow-once",
+                },
+            },
+        ],
+    )
+    def test_request_contract_rejects_invalid_envelopes(self, request_body):
+        from secbaas.community.adapters.web.routers.open_api.model import (
+            InteractionResolveEnvelope,
+        )
+
+        with pytest.raises(ValidationError):
+            InteractionResolveEnvelope.model_validate(request_body)

--- a/src/baas/tests/unit/bootstrap/test_infra.py
+++ b/src/baas/tests/unit/bootstrap/test_infra.py
@@ -1,8 +1,8 @@
 """Tests for InfraContainer — standalone, no database needed.
 
 Config-based providers (bot_service_config, baas_bot_service_config) are
-testable with config.from_dict.  The chat_client_pool resolves without any
-dependencies.  Providers that require MOSN/Layotto (claw_bot_service,
+testable with config.from_dict. The chat_client_pool resolves with its repository
+dependencies overridden.  Providers that require MOSN/Layotto (claw_bot_service,
 baas_bot_service, etc.) are verified structurally — they exist and accept
 overrides.
 """
@@ -59,10 +59,11 @@ class TestInfraContainerStandalone:
         for attr in expected:
             assert hasattr(container, attr), f"Missing provider: {attr}"
 
-    def test_chat_client_pool_resolves_without_deps(self):
-        """AsyncChatClientPool resolves with system_config_repo mocked."""
+    def test_chat_client_pool_resolves_with_mocked_repositories(self):
+        """AsyncChatClientPool resolves with its repository dependencies mocked."""
         container = InfraContainer()
         container.system_config_repo.override(MagicMock())
+        container.bot_run_interaction_repository.override(MagicMock())
         pool = container.chat_client_pool()
         assert isinstance(pool, AsyncChatClientPool)
 
@@ -70,6 +71,7 @@ class TestInfraContainerStandalone:
         """AsyncChatClientPool is a singleton — same instance returned."""
         container = InfraContainer()
         container.system_config_repo.override(MagicMock())
+        container.bot_run_interaction_repository.override(MagicMock())
         pool1 = container.chat_client_pool()
         pool2 = container.chat_client_pool()
         assert pool1 is pool2
@@ -133,6 +135,7 @@ class TestInfraContainerStandalone:
         container.ac_bot_publish_repo.override(mock_repo)
         container.device_binding_repo.override(mock_repo)
         container.system_config_repo.override(mock_repo)
+        container.bot_run_interaction_repository.override(mock_repo)
 
         store = container.chat_client_pool()
         assert isinstance(store, AsyncChatClientPool)

--- a/src/baas/tests/unit/core/repository/bot_run_interaction/test_orm_repository.py
+++ b/src/baas/tests/unit/core/repository/bot_run_interaction/test_orm_repository.py
@@ -11,7 +11,7 @@ from secbaas.community.core.repository.bot_run_interaction import (
     BotRunInteractionPayloadPatch,
     OrmBotRunInteractionRepository,
 )
-from secbaas.community.plugins.database.stub.sqlite_orm import SqliteOrmPlugin
+from secbaas.community.plugins.database.sqlite.sqlite_orm import SqliteOrmPlugin
 
 
 @pytest.fixture
@@ -61,6 +61,8 @@ def test_transition_merges_typed_payload(
         patch=BotRunInteractionPayloadPatch(
             decision="allow-once",
             client_req={"type": "req"},
+            resolution={"kind": "exec", "decision": "allow-once"},
+            idempotency_key="idem-1",
         ),
     )
 
@@ -69,6 +71,11 @@ def test_transition_merges_typed_payload(
     assert queued.payload.requested == {"type": "event"}
     assert queued.payload.decision == "allow-once"
     assert queued.payload.client_req == {"type": "req"}
+    assert queued.payload.resolution == {
+        "kind": "exec",
+        "decision": "allow-once",
+    }
+    assert queued.payload.idempotency_key == "idem-1"
 
 
 def test_late_payload_write_is_rejected_after_terminal_transition(

--- a/src/baas/tests/unit/core/repository/bot_run_interaction/test_orm_repository.py
+++ b/src/baas/tests/unit/core/repository/bot_run_interaction/test_orm_repository.py
@@ -1,0 +1,124 @@
+"""Real SQLite tests for interaction payload/state persistence."""
+
+from __future__ import annotations
+
+import pytest
+
+import secbaas.community.core.repository.bot_run_interaction._orm_model  # noqa: F401
+from secbaas.community.core.database import DatabaseManager
+from secbaas.community.core.repository.bot_run_interaction import (
+    BotRunInteractionPayload,
+    BotRunInteractionPayloadPatch,
+    OrmBotRunInteractionRepository,
+)
+from secbaas.community.plugins.database.stub.sqlite_orm import SqliteOrmPlugin
+
+
+@pytest.fixture
+def repository() -> OrmBotRunInteractionRepository:
+    plugin = SqliteOrmPlugin("sqlite:///:memory:")
+    plugin.create_all()
+    database = DatabaseManager()
+    database._sync_session_factory = plugin._sync_session_factory
+    database._sync_engine = plugin._sync_engine
+    return OrmBotRunInteractionRepository(database=database)
+
+
+def test_create_requested_is_idempotent(
+    repository: OrmBotRunInteractionRepository,
+) -> None:
+    payload = BotRunInteractionPayload(
+        requested={"type": "event"},
+        allowed_decisions=("allow-once", "deny"),
+    )
+
+    first = repository.create_requested(
+        session_key="s-1", interaction_id="int-1", payload=payload
+    )
+    second = repository.create_requested(
+        session_key="s-1", interaction_id="int-1", payload=payload
+    )
+
+    assert first.created is True
+    assert second.created is False
+    assert second.record.id == first.record.id
+
+
+def test_transition_merges_typed_payload(
+    repository: OrmBotRunInteractionRepository,
+) -> None:
+    repository.create_requested(
+        session_key="s-1",
+        interaction_id="int-1",
+        payload=BotRunInteractionPayload(requested={"type": "event"}),
+    )
+
+    queued = repository.transition(
+        session_key="s-1",
+        interaction_id="int-1",
+        from_states=frozenset({"requested"}),
+        to_state="queued",
+        patch=BotRunInteractionPayloadPatch(
+            decision="allow-once",
+            client_req={"type": "req"},
+        ),
+    )
+
+    assert queued is not None
+    assert queued.state == "queued"
+    assert queued.payload.requested == {"type": "event"}
+    assert queued.payload.decision == "allow-once"
+    assert queued.payload.client_req == {"type": "req"}
+
+
+def test_late_payload_write_is_rejected_after_terminal_transition(
+    repository: OrmBotRunInteractionRepository,
+) -> None:
+    repository.create_requested(
+        session_key="s-1",
+        interaction_id="int-1",
+        payload=BotRunInteractionPayload(requested={"type": "event"}),
+    )
+    resolved = repository.transition(
+        session_key="s-1",
+        interaction_id="int-1",
+        from_states=frozenset({"requested"}),
+        to_state="resolved",
+        patch=BotRunInteractionPayloadPatch(resolved={"type": "event"}),
+    )
+    assert resolved is not None
+
+    late = repository.merge_payload(
+        session_key="s-1",
+        interaction_id="int-1",
+        allowed_states=frozenset({"dispatching"}),
+        patch=BotRunInteractionPayloadPatch(engine_res={"ok": True}),
+    )
+
+    assert late is None
+    stored = repository.get(session_key="s-1", interaction_id="int-1")
+    assert stored is not None
+    assert stored.payload.resolved == {"type": "event"}
+    assert stored.payload.engine_res is None
+
+
+def test_corrupt_payload_shape_is_not_silently_downgraded(
+    repository: OrmBotRunInteractionRepository,
+) -> None:
+    created = repository.create_requested(
+        session_key="s-1",
+        interaction_id="int-1",
+        payload=BotRunInteractionPayload(requested={"type": "event"}),
+    )
+    with repository._database.orm_session() as session:
+        from secbaas.community.core.repository.bot_run_interaction import (
+            BotRunInteractionModel,
+        )
+
+        session.query(BotRunInteractionModel).filter(
+            BotRunInteractionModel.id == created.record.id
+        ).update({"payload": '{"requested":[],"decision":7}'})
+        session.commit()
+
+    with pytest.raises(ValueError, match="requested must be an object"):
+        repository.get(session_key="s-1", interaction_id="int-1")

--- a/src/baas/tests/unit/core/service/bcn/test_bcn_service.py
+++ b/src/baas/tests/unit/core/service/bcn/test_bcn_service.py
@@ -7,6 +7,8 @@ import pytest
 
 from secbaas.community.api.bcn import (
     Attachment,
+    BcnInteractionAnswer,
+    BcnInteractionResolveInput,
     BotRef,
     ChatHistoryInput,
     ChatInjectInput,
@@ -14,6 +16,10 @@ from secbaas.community.api.bcn import (
     ContentBlock,
     DownlinkMessage,
     FromRef,
+)
+from secbaas.community.api.bot_interaction import (
+    InteractionResolution,
+    InteractionResolveResult,
 )
 from secbaas.community.core.service.bcn._bcn_service import (
     DefaultBcnDownlinkService,
@@ -95,13 +101,29 @@ def mock_run_repo():
 
 
 @pytest.fixture
-def service(mock_bot_runner, mock_api_key_repo, mock_uplink_client, mock_run_repo):
+def mock_interaction_service():
+    service = MagicMock()
+    service.resolve.return_value = InteractionResolveResult(
+        interaction_id="interaction-ask-1"
+    )
+    return service
+
+
+@pytest.fixture
+def service(
+    mock_bot_runner,
+    mock_api_key_repo,
+    mock_uplink_client,
+    mock_run_repo,
+    mock_interaction_service,
+):
     return DefaultBcnDownlinkService(
         bot_runner=mock_bot_runner,
         api_key_repository=mock_api_key_repo,
         bcn_api_key_prefix="baas-prefix",
         uplink_client=mock_uplink_client,
         run_repository=mock_run_repo,
+        interaction_service=mock_interaction_service,
     )
 
 
@@ -154,6 +176,182 @@ def _make_attachment(attachment_id="att_1", **overrides) -> Attachment:
         file_name="test.png",
         url=f"https://cdn.example.com/{attachment_id}",
         **overrides,
+    )
+
+
+def _make_interaction_resolve_input(**overrides) -> BcnInteractionResolveInput:
+    defaults = dict(
+        id="bcn-resolve-1",
+        session_id="session-1",
+        bcn_group_id="group-1",
+        interaction_id="interaction-ask-1",
+        kind="ask_user",
+        idempotency_key="idem-ask-1",
+        action="submit",
+        decision=None,
+        answers={
+            "deploy_target": BcnInteractionAnswer(
+                values=("staging",),
+                question="what's your deploy target?",
+                header="Deployment environment",
+            ),
+            "components": BcnInteractionAnswer(
+                values=("web", "worker"),
+                question="whats' the components?",
+                header="Components",
+            ),
+        },
+        request_envelope={
+            "type": "req",
+            "id": "bcn-resolve-1",
+            "method": "interaction.resolve",
+        },
+    )
+    defaults.update(overrides)
+    return BcnInteractionResolveInput(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_handle_ask_user_resolve_normalizes_all_values_as_ordinary(
+    service, mock_interaction_service
+) -> None:
+    result = await service.handle_interaction_resolve(
+        _make_interaction_resolve_input(
+            answers={
+                "deploy_target": BcnInteractionAnswer(
+                    values=("staging",),
+                    question="what's your deploy target?",
+                    header="Deployment environment",
+                ),
+                "components": BcnInteractionAnswer(
+                    values=("web", "worker", "custom raw value"),
+                    question="whats' the components?",
+                    header="Components",
+                ),
+            }
+        )
+    )
+
+    assert result.ok is True
+    mock_interaction_service.resolve.assert_called_once_with(
+        session_key="session-1",
+        interaction_id="interaction-ask-1",
+        resolution=InteractionResolution(
+            kind="ask_user",
+            decision="submit",
+            answer=(
+                "Deployment environment: staging；"
+                "Components: web，worker，custom raw value"
+            ),
+            message=(
+                "Deployment environment: staging；"
+                "Components: web，worker，custom raw value"
+            ),
+            values={
+                "Deployment environment": "staging",
+                "Components": "web，worker，custom raw value",
+            },
+            answers={
+                "what's your deploy target?": "staging",
+                "whats' the components?": "web，worker，custom raw value",
+            },
+            selected_options=(
+                ("staging",),
+                ("web", "worker", "custom raw value"),
+            ),
+        ),
+        request_envelope={
+            "type": "req",
+            "id": "bcn-resolve-1",
+            "method": "interaction.resolve",
+        },
+        idempotency_key="idem-ask-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_ask_user_resolve_duplicate_headers_last_write_wins_safely(
+    service, mock_interaction_service, caplog
+) -> None:
+    await service.handle_interaction_resolve(
+        _make_interaction_resolve_input(
+            answers={
+                "first_question_id": BcnInteractionAnswer(
+                    values=("first private value",),
+                    question="first private question",
+                    header="Shared private header",
+                ),
+                "second_question_id": BcnInteractionAnswer(
+                    values=("second private value",),
+                    question="second private question",
+                    header="Shared private header",
+                ),
+            }
+        )
+    )
+
+    resolution = mock_interaction_service.resolve.call_args.kwargs["resolution"]
+    assert resolution.answer == (
+        "Shared private header: first private value；"
+        "Shared private header: second private value"
+    )
+    assert resolution.message == resolution.answer
+    assert resolution.values == {"Shared private header": "second private value"}
+    assert resolution.answers == {
+        "first private question": "first private value",
+        "second private question": "second private value",
+    }
+    assert resolution.selected_options == (
+        ("first private value",),
+        ("second private value",),
+    )
+
+    warnings = [
+        record.getMessage()
+        for record in caplog.records
+        if "duplicate_answer_header" in record.getMessage()
+    ]
+    assert len(warnings) == 1
+    assert "Shared private header" not in warnings[0]
+    assert "first private question" not in warnings[0]
+    assert "second private value" not in warnings[0]
+
+
+@pytest.mark.asyncio
+async def test_handle_ask_user_cancel_omits_answer_fields(
+    service, mock_interaction_service
+) -> None:
+    await service.handle_interaction_resolve(
+        _make_interaction_resolve_input(action="cancel", answers=None)
+    )
+
+    assert mock_interaction_service.resolve.call_args.kwargs["resolution"] == (
+        InteractionResolution(kind="ask_user", decision="cancel")
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kind", "decision"),
+    [("exec", "allow-once"), ("exec", "deny"), ("mode_switch", "stay")],
+)
+async def test_handle_decision_resolve_preserves_kind_and_decision(
+    service,
+    mock_interaction_service,
+    kind,
+    decision,
+) -> None:
+    await service.handle_interaction_resolve(
+        _make_interaction_resolve_input(
+            kind=kind,
+            action=None,
+            decision=decision,
+            answers=None,
+        )
+    )
+
+    assert mock_interaction_service.resolve.call_args.kwargs["resolution"] == (
+        InteractionResolution(kind=kind, decision=decision)
     )
 
 

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
@@ -21,9 +21,9 @@ _TEST_SESSION_KEY = "test-session-key"
 
 def _setup_session_state(client, session_key=_TEST_SESSION_KEY):
     """Helper: register a _SessionState for a given session_key."""
-    from secbaas.community.core.service.bot_run._async_chat_client import _SessionState
+    from secbaas.community.core.service.bot_run._async_chat_client import SessionState
 
-    return client._sessions.setdefault(session_key, _SessionState())
+    return client._sessions.setdefault(session_key, SessionState())
 
 
 @pytest.fixture
@@ -1589,7 +1589,7 @@ class TestChatRequestErrorStream:
         """send_message_stream sets chat_complete when ChatRequestError is raised."""
         from secbaas.community.core.service.bot_run._async_chat_client import (
             AsyncChatClient,
-            _SessionState,
+            SessionState,
         )
         from secbaas.community.core.service.bot_run._bot_websocket_client import (
             ChatRequestError,
@@ -1605,7 +1605,7 @@ class TestChatRequestErrorStream:
 
         # Pre-register a session state so we can inspect it after the error
         sk = "sk-err"
-        state = _SessionState()
+        state = SessionState()
         client._sessions[sk] = state
 
         mock_bot_ws_instance.chat_send.side_effect = ChatRequestError(
@@ -1801,7 +1801,7 @@ class TestBotSessionError:
         """send_message_stream sets chat_complete when ChatRequestError is raised."""
         from secbaas.community.core.service.bot_run._async_chat_client import (
             AsyncChatClient,
-            _SessionState,
+            SessionState,
         )
         from secbaas.community.core.service.bot_run._bot_websocket_client import (
             ChatRequestError,
@@ -1817,7 +1817,7 @@ class TestBotSessionError:
 
         # Pre-register a session state so we can inspect it after the error
         sk = "sk-err"
-        state = _SessionState()
+        state = SessionState()
         client._sessions[sk] = state
 
         mock_bot_ws_instance.chat_send.side_effect = ChatRequestError(

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
@@ -8,10 +8,13 @@ chat state with stopReason=inject, agent error handling, and verbose paths.
 """
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+import json
+from copy import deepcopy
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
+from secbaas.community.api.bot_interaction import InteractionResolution
 from secbaas.community.api.sse import StreamChunk
 from secbaas.community.core.service.bot_interaction import InteractionDispatch
 from secbaas.community.core.service.bot_run._async_chat_client import (
@@ -24,6 +27,7 @@ from secbaas.community.core.service.bot_run._async_chat_client import (
 from secbaas.community.core.service.bot_run._interaction_protocol import (
     EngineInteractionResolveExchange,
 )
+from secbaas.community.core.service.sse import DefaultStreamConverter
 
 _TEST_SESSION_KEY = "test-session-key"
 
@@ -112,6 +116,22 @@ class TestProperties:
         client._active_sessions.add("s1")
         client._active_sessions.add("s2")
         assert client.active_session_count == 2
+
+    @pytest.mark.asyncio
+    async def test_connect_registers_mode_transition_resolved_handler(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        client = AsyncChatClient(uri="ws://host/ws", max_retries=0)
+
+        await client.connect()
+
+        assert (
+            call(
+                "mode_transition.resolved",
+                client._on_mode_transition_resolved,
+            )
+            in mock_bot_ws_instance.on_event.call_args_list
+        )
 
 
 # ==================== _capture_trace_context ====================
@@ -746,6 +766,61 @@ class TestOnError:
 
 class TestLogEvent:
     @pytest.mark.asyncio
+    async def test_log_event_interaction_resolved_keeps_only_metadata(
+        self, mock_bot_ws
+    ):
+        client = AsyncChatClient(uri="ws://host/ws")
+        _setup_session_state(client, "sk1")
+
+        with patch(
+            "secbaas.community.core.service.bot_run._async_chat_client.logger"
+        ) as mock_logger:
+            client._log_event(
+                "interaction.resolved",
+                {
+                    "sessionKey": "sk1",
+                    "interactionId": "int-1",
+                    "kind": "ask_user",
+                    "answers": {"Question?": "answer-must-not-leak"},
+                    "selectedOptions": [["answer-must-not-leak"]],
+                },
+            )
+
+        logged = str(mock_logger.info.call_args)
+        assert "interactionId" in logged
+        assert "answer-must-not-leak" not in logged
+
+    @pytest.mark.asyncio
+    async def test_log_event_mode_transition_resolved_keeps_only_metadata(
+        self, mock_bot_ws
+    ):
+        client = AsyncChatClient(uri="ws://host/ws")
+        _setup_session_state(client, "sk1")
+
+        with patch(
+            "secbaas.community.core.service.bot_run._async_chat_client.logger"
+        ) as mock_logger:
+            client._log_event(
+                "mode_transition.resolved",
+                {
+                    "sessionKey": "sk1",
+                    "interactionId": "int-mode",
+                    "kind": "mode_switch",
+                    "phase": "proceeded",
+                    "options": [
+                        {
+                            "label": "private-mode-option-label",
+                            "decision": "proceed",
+                        }
+                    ],
+                },
+            )
+
+        logged = str(mock_logger.info.call_args)
+        assert "interactionId" in logged
+        assert "private-mode-option-label" not in logged
+
+    @pytest.mark.asyncio
     async def test_log_event_chat_filters_sensitive(self, mock_bot_ws):
         client = AsyncChatClient(uri="ws://host/ws")
         _setup_session_state(client, "sk1")
@@ -1142,6 +1217,15 @@ class TestReconnectLoop:
 
         # The second BotWebSocketClient instance should have been created
         assert mock_bot_ws.call_count >= 2
+        assert (
+            mock_bot_ws_instance.on_event.call_args_list.count(
+                call(
+                    "mode_transition.resolved",
+                    client._on_mode_transition_resolved,
+                )
+            )
+            >= 2
+        )
 
         await client.close()
 
@@ -1306,9 +1390,10 @@ class TestInteractionEvents:
         payload = {
             "sessionKey": "sk1",
             "interactionId": "int-1",
+            "kind": "exec",
             "seq": 42,
             "expiresAtMs": 123456,
-            "options": [{"decision": "allow-once"}],
+            "options": [{"label": "Once", "decision": "allow-once"}],
         }
         client._on_interaction_requested(payload)
 
@@ -1329,6 +1414,47 @@ class TestInteractionEvents:
         assert chunk.metadata["event"] == "interaction.requested"
         assert chunk.metadata["payload"]["event"] == "interaction.requested"
         assert chunk.metadata["payload"]["seq"] == 42
+
+    @pytest.mark.asyncio
+    async def test_requested_mixed_options_reach_persistence_chunk_and_converter(
+        self, mock_bot_ws
+    ):
+        service = MagicMock()
+        service.record_requested.return_value = True
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+        payload = {
+            "sessionKey": "sk1",
+            "interactionId": "int-mixed",
+            "kind": "exec",
+            "command": "make test",
+            "options": [
+                "not-an-object",
+                {"label": "Once", "decision": "", "value": "allow-once"},
+                {"label": "Deny", "decision": 42, "value": "deny"},
+                {"label": "Once replacement", "decision": "allow-once"},
+                {},
+            ],
+        }
+        original = deepcopy(payload)
+
+        client._on_interaction_requested(payload)
+
+        persisted = service.record_requested.call_args.kwargs
+        assert persisted["allowed_decisions"] == ("allow-once", "deny")
+        assert persisted["envelope"]["payload"] is payload
+        assert payload == original
+        chunk = state.stream_queue.get_nowait()
+        event = DefaultStreamConverter().convert(chunk, run_id="bcn-run")
+        assert event is not None
+        data = json.loads(event.data)
+        assert data["options"] == [
+            {"label": "Once replacement", "decision": "allow-once"},
+            {"label": "Deny", "decision": "deny"},
+        ]
 
     @pytest.mark.asyncio
     async def test_duplicate_requested_does_not_emit_duplicate_chunk(self, mock_bot_ws):
@@ -1414,14 +1540,163 @@ class TestInteractionEvents:
 
         assert state.stream_queue.qsize() == 1
 
+    @pytest.mark.asyncio
+    async def test_mode_transition_resolved_emits_once_after_rpc_terminalized_record(
+        self, mock_bot_ws
+    ):
+        service = MagicMock()
+        service.record_requested.return_value = True
+        service.mark_resolved.return_value = False
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+        requested = {
+            "sessionKey": "sk1",
+            "interactionId": "int-mode",
+            "kind": "mode_switch",
+            "options": [
+                {"label": "Continue to execution", "decision": "proceed"},
+                {"label": "Stay in planning", "decision": "stay"},
+            ],
+        }
+        client._on_interaction_requested(requested)
+        requested_chunk = state.stream_queue.get_nowait()
+        assert requested_chunk.metadata["event"] == "interaction.requested"
+        resolved = {
+            "sessionKey": "sk1",
+            "interactionId": "int-mode",
+            "transitionId": "int-mode",
+            "kind": "mode_switch",
+            "phase": "proceeded",
+            "decision": "proceed",
+            "status": "resolved",
+            "options": [
+                {"label": "Continue to execution", "decision": "proceed"},
+                {"label": "Stay in planning", "decision": "stay"},
+            ],
+            "seq": 131,
+        }
+
+        client._on_mode_transition_resolved(resolved)
+        client._on_mode_transition_resolved(resolved)
+
+        assert state.stream_queue.qsize() == 1
+        chunk = state.stream_queue.get_nowait()
+        assert chunk.metadata["event"] == "mode_transition.resolved"
+        assert chunk.metadata["payload"] == {
+            "type": "event",
+            "event": "mode_transition.resolved",
+            "payload": resolved,
+            "seq": 131,
+        }
+        event = DefaultStreamConverter().convert(chunk, run_id="bcn-run")
+        assert event is not None
+        data = json.loads(event.data)
+        assert isinstance(data.pop("ts"), int)
+        assert data == {
+            "runId": "bcn-run",
+            "seq": 1,
+            "interactionId": "int-mode",
+            "kind": "mode_switch",
+            "phase": "resolved",
+            "decision": "proceed",
+        }
+
+    def test_mode_transition_resolved_without_exposed_request_does_not_emit(
+        self, mock_bot_ws
+    ):
+        service = MagicMock()
+        service.mark_resolved.return_value = True
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        client._on_mode_transition_resolved(
+            {
+                "sessionKey": "sk1",
+                "interactionId": "int-mode",
+                "kind": "mode_switch",
+                "decision": "stay",
+            }
+        )
+
+        assert state.stream_queue.empty()
+
+    def test_mode_transition_requested_without_stream_queue_is_not_exposed(
+        self, mock_bot_ws
+    ):
+        service = MagicMock()
+        service.record_requested.return_value = True
+        service.mark_resolved.return_value = False
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+
+        client._on_interaction_requested(
+            {
+                "sessionKey": "sk1",
+                "interactionId": "int-mode",
+                "kind": "mode_switch",
+                "options": [{"label": "Continue", "decision": "proceed"}],
+            }
+        )
+        state.stream_queue = asyncio.Queue()
+        client._on_mode_transition_resolved(
+            {
+                "sessionKey": "sk1",
+                "interactionId": "int-mode",
+                "kind": "mode_switch",
+                "decision": "proceed",
+            }
+        )
+
+        assert state.stream_queue.empty()
+
+    def test_mode_transition_resolved_rejects_non_mode_kind_before_delivery(
+        self, mock_bot_ws
+    ):
+        service = MagicMock()
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        with pytest.raises(ValueError, match="kind must be mode_switch"):
+            client._on_mode_transition_resolved(
+                {
+                    "sessionKey": "sk1",
+                    "interactionId": "int-exec",
+                    "kind": "exec",
+                    "decision": "allow-once",
+                }
+            )
+
+        assert state.stream_queue.empty()
+        service.mark_resolved.assert_not_called()
+
 
 @pytest.mark.asyncio
 async def test_interaction_dispatch_uses_typed_claim_command(mock_bot_ws):
     service = MagicMock()
+    resolution = InteractionResolution(
+        kind="ask_user",
+        decision="submit",
+        answer="target: staging",
+        message="target: staging",
+        values={"target": "staging"},
+        answers={"Where?": "staging"},
+        selected_options=(("staging",),),
+    )
     service.claim_for_dispatch.return_value = InteractionDispatch(
         session_key="sk1",
         interaction_id="int-1",
-        decision="allow-once",
+        resolution=resolution,
     )
     engine_client = MagicMock()
     engine_request = {
@@ -1450,11 +1725,61 @@ async def test_interaction_dispatch_uses_typed_claim_command(mock_bot_ws):
 
     engine_client.interaction_resolve.assert_awaited_once_with(
         interaction_id="int-1",
-        decision="allow-once",
+        resolution=resolution,
     )
     service.record_engine_exchange.assert_called_once_with(
         session_key="sk1",
         interaction_id="int-1",
         engine_req=engine_request,
         engine_res=engine_response,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mode_switch_dispatch_marks_accepted_rpc_resolved(mock_bot_ws):
+    service = MagicMock()
+    resolution = InteractionResolution(kind="mode_switch", decision="stay")
+    service.claim_for_dispatch.return_value = InteractionDispatch(
+        session_key="sk1",
+        interaction_id="int-mode-1",
+        resolution=resolution,
+    )
+    engine_client = MagicMock()
+    engine_request = {
+        "type": "req",
+        "id": "engine-mode-1",
+        "method": "mode_transition.resolve",
+        "params": {"transitionId": "int-mode-1", "decision": "stay"},
+    }
+    engine_response = {
+        "type": "res",
+        "id": "engine-mode-1",
+        "ok": True,
+        "payload": {
+            "accepted": True,
+            "transitionId": "int-mode-1",
+            "decision": "stay",
+        },
+    }
+    engine_client.interaction_resolve = AsyncMock(
+        return_value=EngineInteractionResolveExchange.from_frames(
+            request=engine_request,
+            response=engine_response,
+        )
+    )
+    client = AsyncChatClient(
+        uri="ws://host/ws", max_retries=0, interaction_service=service
+    )
+    client._client = engine_client
+
+    await client._dispatch_interaction_answer(
+        session_key="sk1",
+        interaction_id="int-mode-1",
+        deadline_ms=None,
+    )
+
+    service.mark_resolved.assert_called_once_with(
+        session_key="sk1",
+        interaction_id="int-mode-1",
+        envelope=engine_response,
     )

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
@@ -18,8 +18,8 @@ from secbaas.community.core.service.bot_run._async_chat_client import (
     AsyncChatClient,
     ConcurrentSessionError,
     NotConnectedError,
+    SessionState,
     _capture_trace_context,
-    _SessionState,
 )
 from secbaas.community.core.service.bot_run._interaction_protocol import (
     EngineInteractionResolveExchange,
@@ -29,7 +29,7 @@ _TEST_SESSION_KEY = "test-session-key"
 
 
 def _setup_session_state(client, session_key=_TEST_SESSION_KEY):
-    return client._sessions.setdefault(session_key, _SessionState())
+    return client._sessions.setdefault(session_key, SessionState())
 
 
 @pytest.fixture
@@ -269,7 +269,7 @@ class TestGetSession:
 class TestEmitStreamChunk:
     def test_put_chunk_when_queue_exists(self, mock_bot_ws):
         client = AsyncChatClient(uri="ws://host/ws")
-        state = _SessionState()
+        state = SessionState()
         state.stream_queue = asyncio.Queue()
         chunk = StreamChunk(type="delta", content="hello")
         AsyncChatClient._emit_stream_chunk(state, chunk)
@@ -278,7 +278,7 @@ class TestEmitStreamChunk:
 
     def test_no_queue_no_error(self, mock_bot_ws):
         client = AsyncChatClient(uri="ws://host/ws")
-        state = _SessionState()
+        state = SessionState()
         state.stream_queue = None
         # Should not raise
         AsyncChatClient._emit_stream_chunk(
@@ -291,13 +291,13 @@ class TestEmitStreamChunk:
 
 class TestHandleTerminalError:
     def test_sets_error_state_and_completes(self, mock_bot_ws):
-        state = _SessionState()
+        state = SessionState()
         AsyncChatClient._handle_terminal_error(state, "sk1", "boom", "agent")
         assert state.state == "error"
         assert state.chat_complete.is_set()
 
     def test_emits_error_chunk_to_queue(self, mock_bot_ws):
-        state = _SessionState()
+        state = SessionState()
         state.stream_queue = asyncio.Queue()
         AsyncChatClient._handle_terminal_error(state, "sk1", "boom", "agent")
         chunk = state.stream_queue.get_nowait()
@@ -305,7 +305,7 @@ class TestHandleTerminalError:
         assert chunk.content == "boom"
 
     def test_empty_error_msg_uses_source(self, mock_bot_ws):
-        state = _SessionState()
+        state = SessionState()
         AsyncChatClient._handle_terminal_error(state, "sk1", "", "agent")
         assert state.state == "error"
         assert state.chat_complete.is_set()
@@ -1266,6 +1266,31 @@ class TestCloseAdditional:
 
 
 class TestInteractionEvents:
+    def test_requested_is_ignored_when_interaction_processing_is_disabled(
+        self, mock_bot_ws
+    ):
+        client = AsyncChatClient(uri="ws://host/ws", max_retries=0)
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        client._on_interaction_requested(
+            {"sessionKey": "sk1", "interactionId": "int-1"}
+        )
+
+        assert state.stream_queue.empty()
+        assert client._interaction_tasks == {}
+
+    def test_resolved_is_ignored_when_interaction_processing_is_disabled(
+        self, mock_bot_ws
+    ):
+        client = AsyncChatClient(uri="ws://host/ws", max_retries=0)
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        client._on_interaction_resolved({"sessionKey": "sk1", "interactionId": "int-1"})
+
+        assert state.stream_queue.empty()
+
     @pytest.mark.asyncio
     async def test_requested_passes_validated_identity_and_emits_chunk(
         self, mock_bot_ws
@@ -1364,14 +1389,14 @@ class TestInteractionEvents:
             interaction_id="int-1",
             envelope={
                 "type": "event",
-                "event": "interaction.resolve",
+                "event": "interaction.resolved",
                 "payload": payload,
             },
         )
         chunk = state.stream_queue.get_nowait()
         assert chunk.type == "interaction"
-        assert chunk.metadata["event"] == "interaction.resolve"
-        assert chunk.metadata["payload"]["event"] == "interaction.resolve"
+        assert chunk.metadata["event"] == "interaction.resolved"
+        assert chunk.metadata["payload"]["event"] == "interaction.resolved"
 
     @pytest.mark.asyncio
     async def test_duplicate_resolved_does_not_emit_duplicate_chunk(self, mock_bot_ws):

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_coverage.py
@@ -13,12 +13,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from secbaas.community.api.sse import StreamChunk
+from secbaas.community.core.service.bot_interaction import InteractionDispatch
 from secbaas.community.core.service.bot_run._async_chat_client import (
     AsyncChatClient,
     ConcurrentSessionError,
     NotConnectedError,
     _capture_trace_context,
     _SessionState,
+)
+from secbaas.community.core.service.bot_run._interaction_protocol import (
+    EngineInteractionResolveExchange,
 )
 
 _TEST_SESSION_KEY = "test-session-key"
@@ -1259,3 +1263,173 @@ class TestCloseAdditional:
         await client.close()
         # Double close should not raise
         await client.close()
+
+
+class TestInteractionEvents:
+    @pytest.mark.asyncio
+    async def test_requested_passes_validated_identity_and_emits_chunk(
+        self, mock_bot_ws
+    ):
+        service = MagicMock()
+        service.record_requested.return_value = True
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        payload = {
+            "sessionKey": "sk1",
+            "interactionId": "int-1",
+            "seq": 42,
+            "expiresAtMs": 123456,
+            "options": [{"decision": "allow-once"}],
+        }
+        client._on_interaction_requested(payload)
+
+        service.record_requested.assert_called_once_with(
+            session_key="sk1",
+            interaction_id="int-1",
+            envelope={
+                "type": "event",
+                "event": "interaction.requested",
+                "payload": payload,
+                "seq": 42,
+            },
+            allowed_decisions=("allow-once",),
+            expires_at_ms=123456,
+        )
+        chunk = state.stream_queue.get_nowait()
+        assert chunk.type == "interaction"
+        assert chunk.metadata["event"] == "interaction.requested"
+        assert chunk.metadata["payload"]["event"] == "interaction.requested"
+        assert chunk.metadata["payload"]["seq"] == 42
+
+    @pytest.mark.asyncio
+    async def test_duplicate_requested_does_not_emit_duplicate_chunk(self, mock_bot_ws):
+        service = MagicMock()
+        service.record_requested.side_effect = [True, False]
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+        payload = {"sessionKey": "sk1", "interactionId": "int-1"}
+
+        client._on_interaction_requested(payload)
+        client._on_interaction_requested(payload)
+
+        assert state.stream_queue.qsize() == 1
+
+    @pytest.mark.asyncio
+    async def test_requested_persistence_failure_is_not_silently_ignored(
+        self, mock_bot_ws
+    ):
+        service = MagicMock()
+        service.record_requested.side_effect = RuntimeError("db unavailable")
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        with pytest.raises(RuntimeError, match="db unavailable"):
+            client._on_interaction_requested(
+                {"sessionKey": "sk1", "interactionId": "int-1"}
+            )
+
+        assert state.stream_queue.empty()
+
+    @pytest.mark.asyncio
+    async def test_resolved_uses_callback_identity_and_emits_public_chunk(
+        self, mock_bot_ws
+    ):
+        service = MagicMock()
+        service.mark_resolved.return_value = True
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+
+        payload = {
+            "sessionKey": "sk1",
+            "interactionId": "int-1",
+            "decision": "allow-once",
+        }
+        client._on_interaction_resolved(payload)
+
+        service.mark_resolved.assert_called_once_with(
+            session_key="sk1",
+            interaction_id="int-1",
+            envelope={
+                "type": "event",
+                "event": "interaction.resolve",
+                "payload": payload,
+            },
+        )
+        chunk = state.stream_queue.get_nowait()
+        assert chunk.type == "interaction"
+        assert chunk.metadata["event"] == "interaction.resolve"
+        assert chunk.metadata["payload"]["event"] == "interaction.resolve"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_resolved_does_not_emit_duplicate_chunk(self, mock_bot_ws):
+        service = MagicMock()
+        service.mark_resolved.side_effect = [True, False]
+        client = AsyncChatClient(
+            uri="ws://host/ws", max_retries=0, interaction_service=service
+        )
+        state = _setup_session_state(client, "sk1")
+        state.stream_queue = asyncio.Queue()
+        payload = {"sessionKey": "sk1", "interactionId": "int-1"}
+
+        client._on_interaction_resolved(payload)
+        client._on_interaction_resolved(payload)
+
+        assert state.stream_queue.qsize() == 1
+
+
+@pytest.mark.asyncio
+async def test_interaction_dispatch_uses_typed_claim_command(mock_bot_ws):
+    service = MagicMock()
+    service.claim_for_dispatch.return_value = InteractionDispatch(
+        session_key="sk1",
+        interaction_id="int-1",
+        decision="allow-once",
+    )
+    engine_client = MagicMock()
+    engine_request = {
+        "type": "req",
+        "id": "engine-1",
+        "method": "interaction.resolve",
+        "params": {"interactionId": "int-1", "decision": "allow-once"},
+    }
+    engine_response = {"type": "res", "id": "engine-1", "ok": True}
+    engine_client.interaction_resolve = AsyncMock(
+        return_value=EngineInteractionResolveExchange.from_frames(
+            request=engine_request,
+            response=engine_response,
+        )
+    )
+    client = AsyncChatClient(
+        uri="ws://host/ws", max_retries=0, interaction_service=service
+    )
+    client._client = engine_client
+
+    await client._dispatch_interaction_answer(
+        session_key="sk1",
+        interaction_id="int-1",
+        deadline_ms=None,
+    )
+
+    engine_client.interaction_resolve.assert_awaited_once_with(
+        interaction_id="int-1",
+        decision="allow-once",
+    )
+    service.record_engine_exchange.assert_called_once_with(
+        session_key="sk1",
+        interaction_id="int-1",
+        engine_req=engine_request,
+        engine_res=engine_response,
+    )

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_pool.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_pool.py
@@ -110,6 +110,57 @@ class TestParamPassthrough:
 
         await pool.close_all()
 
+    @pytest.mark.asyncio
+    async def test_enabled_interaction_service_passed_to_new_client(
+        self, mock_chat_client_class
+    ):
+        mock_cls, _ = mock_chat_client_class
+
+        from secbaas.community.core.service.bot_run._async_chat_client_pool import (
+            AsyncChatClientPool,
+        )
+
+        config_service = MagicMock()
+        config_service.get_config.side_effect = [
+            MagicMock(conf_value="false"),
+            MagicMock(conf_value="true"),
+        ]
+        interaction_service = MagicMock()
+        pool = AsyncChatClientPool(
+            system_config_service=config_service,
+            interaction_service=interaction_service,
+        )
+
+        await pool.get("sandbox-1", "ws://host/ws")
+
+        assert mock_cls.call_args.kwargs["interaction_service"] is interaction_service
+        await pool.close_all()
+
+    @pytest.mark.asyncio
+    async def test_disabled_interaction_service_not_passed_to_new_client(
+        self, mock_chat_client_class
+    ):
+        mock_cls, _ = mock_chat_client_class
+
+        from secbaas.community.core.service.bot_run._async_chat_client_pool import (
+            AsyncChatClientPool,
+        )
+
+        config_service = MagicMock()
+        config_service.get_config.side_effect = [
+            MagicMock(conf_value="false"),
+            MagicMock(conf_value="false"),
+        ]
+        pool = AsyncChatClientPool(
+            system_config_service=config_service,
+            interaction_service=MagicMock(),
+        )
+
+        await pool.get("sandbox-1", "ws://host/ws")
+
+        assert mock_cls.call_args.kwargs["interaction_service"] is None
+        await pool.close_all()
+
 
 # ==================== reconnect awareness tests ====================
 
@@ -505,3 +556,57 @@ class TestReadIgnoreCase:
         svc.get_config.side_effect = RuntimeError("db error")
         result = AsyncChatClientPool._read_ignore_case(svc)
         assert result is False
+
+
+# ==================== interaction processing flag tests ====================
+
+
+class TestEnableProcessInteraction:
+    @pytest.mark.parametrize(
+        ("conf_value", "expected"),
+        [
+            ("true", True),
+            ("  True  ", True),
+            ("false", False),
+            ("invalid", False),
+            (None, False),
+        ],
+    )
+    def test_reads_boolean_value(self, conf_value, expected):
+        from secbaas.community.core.service.bot_run._async_chat_client_pool import (
+            AsyncChatClientPool,
+        )
+        from secbaas.community.core.service.config import SystemConfigKey
+
+        service = MagicMock()
+        service.get_config.return_value = MagicMock(conf_value=conf_value)
+
+        assert AsyncChatClientPool._enable_process_interaction(service) is expected
+        service.get_config.assert_called_once_with(SystemConfigKey.INTERACTION_PROCESS)
+
+    def test_none_service_returns_false(self):
+        from secbaas.community.core.service.bot_run._async_chat_client_pool import (
+            AsyncChatClientPool,
+        )
+
+        assert AsyncChatClientPool._enable_process_interaction(None) is False
+
+    def test_missing_config_returns_false(self):
+        from secbaas.community.core.service.bot_run._async_chat_client_pool import (
+            AsyncChatClientPool,
+        )
+
+        service = MagicMock()
+        service.get_config.return_value = None
+
+        assert AsyncChatClientPool._enable_process_interaction(service) is False
+
+    def test_read_failure_returns_false(self):
+        from secbaas.community.core.service.bot_run._async_chat_client_pool import (
+            AsyncChatClientPool,
+        )
+
+        service = MagicMock()
+        service.get_config.side_effect = RuntimeError("db unavailable")
+
+        assert AsyncChatClientPool._enable_process_interaction(service) is False

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_pool.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_pool.py
@@ -105,6 +105,7 @@ class TestParamPassthrough:
             max_retries=3,
             retry_base_backoff=2.0,
             ignore_case=False,
+            interaction_service=None,
         )
 
         await pool.close_all()

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_websocket_client.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_websocket_client.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from secbaas.community.api.bot_interaction import InteractionResolution
 from secbaas.community.core.service.bot_run._bot_websocket_client import (
     BotWebSocketClient,
     ChatRequestError,
@@ -145,6 +146,46 @@ class TestInit:
 )
 def test_is_loopback_websocket_uri_handles_hostname_edges(uri, expected):
     assert _is_loopback_websocket_uri(uri) is expected
+
+
+@pytest.mark.asyncio
+async def test_interaction_resolve_sends_complete_normalized_frame(client) -> None:
+    client._send_request_frame = AsyncMock(
+        return_value={"type": "res", "id": "1", "ok": True}
+    )
+    resolution = InteractionResolution(
+        kind="ask_user",
+        decision="submit",
+        answer="target: staging",
+        message="target: staging",
+        values={"target": "staging"},
+        answers={"Where?": "staging"},
+        selected_options=(("staging",),),
+    )
+
+    exchange = await client.interaction_resolve(
+        interaction_id="int-1",
+        resolution=resolution,
+    )
+
+    assert exchange.accepted is True
+    client._send_request_frame.assert_awaited_once_with(
+        {
+            "type": "req",
+            "id": "1",
+            "method": "interaction.resolve",
+            "params": {
+                "interactionId": "int-1",
+                "decision": "submit",
+                "answer": "target: staging",
+                "message": "target: staging",
+                "values": {"target": "staging"},
+                "answers": {"Where?": "staging"},
+                "selectedOptions": [["staging"]],
+            },
+        },
+        timeout=30.0,
+    )
 
 
 # ==================== Tests: _next_request_id ====================
@@ -506,6 +547,25 @@ class TestSendRequest:
 
 class TestHandleMessage:
     """Tests for BotWebSocketClient._handle_message."""
+
+    async def test_handle_message_does_not_log_raw_interaction_answers(self, client):
+        message = json.dumps(
+            {
+                "type": "event",
+                "event": "interaction.resolved",
+                "payload": {
+                    "interactionId": "int-1",
+                    "answers": {"Question?": "answer-must-not-leak"},
+                },
+            }
+        )
+
+        with patch(
+            "secbaas.community.core.service.bot_run._bot_websocket_client.logger"
+        ) as mock_logger:
+            await client._handle_message(message)
+
+        assert "answer-must-not-leak" not in str(mock_logger.debug.call_args_list)
 
     # [单测用例]测试场景：响应帧路由到 pending future
     async def test_handle_message_routes_response_to_pending_request(self, client):

--- a/src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from copy import deepcopy
+
 import pytest
 
+from secbaas.community.api.bot_interaction import InteractionResolution
 from secbaas.community.core.service.bot_run._interaction_protocol import (
     EngineInteractionRequestedEvent,
     EngineInteractionResolvedEvent,
@@ -14,11 +17,12 @@ def test_requested_event_is_parsed_once_into_explicit_fields() -> None:
     payload = {
         "sessionKey": "payload-session",
         "interactionId": "int-1",
+        "kind": "exec",
         "expiresAtMs": 123,
         "options": [
-            {"decision": "allow-once"},
-            {"value": "deny"},
-            {"decision": "allow-once"},
+            {"label": "Once", "decision": "allow-once"},
+            {"label": "Deny", "value": "deny"},
+            {"label": "Once again", "decision": "allow-once"},
         ],
         "seq": 9,
     }
@@ -36,16 +40,102 @@ def test_requested_event_is_parsed_once_into_explicit_fields() -> None:
     assert event.envelope["seq"] == 9
 
 
+def test_requested_event_skips_bad_options_and_preserves_source_payload() -> None:
+    payload = {
+        "interactionId": "int-mixed",
+        "kind": "exec",
+        "command": "make test",
+        "options": [
+            "not-an-object",
+            {"label": "Once", "decision": "", "value": "allow-once"},
+            {"label": "Deny", "decision": 42, "value": "deny"},
+            {"decision": "hidden"},
+            {"label": "Once again", "decision": "allow-once", "value": "ignored"},
+            {},
+        ],
+    }
+    original = deepcopy(payload)
+
+    event = EngineInteractionRequestedEvent.from_payload(
+        session_key="trusted-session",
+        payload=payload,
+    )
+
+    assert event.allowed_decisions == ("allow-once", "deny")
+    assert event.envelope["payload"] is payload
+    assert payload == original
+
+
+def test_exec_without_options_uses_bcn_default_allowed_decisions() -> None:
+    event = EngineInteractionRequestedEvent.from_payload(
+        session_key="trusted-session",
+        payload={
+            "interactionId": "int-defaults",
+            "kind": "exec",
+            "command": "pwd",
+        },
+    )
+
+    assert event.allowed_decisions == ("allow-once", "allow-always", "deny")
+
+
+def test_exec_with_explicit_null_options_does_not_use_defaults() -> None:
+    event = EngineInteractionRequestedEvent.from_payload(
+        session_key="trusted-session",
+        payload={
+            "interactionId": "int-null",
+            "kind": "exec",
+            "command": "pwd",
+            "options": None,
+        },
+    )
+
+    assert event.allowed_decisions == ()
+
+
+def test_ask_user_uses_fixed_actions_and_ignores_top_level_options() -> None:
+    event = EngineInteractionRequestedEvent.from_payload(
+        session_key="trusted-session",
+        payload={
+            "interactionId": "int-ask",
+            "kind": "ask_user",
+            "questions": [{"header": "Name", "question": "Your name?"}],
+            "options": [{"label": "Hidden", "decision": "hidden"}],
+        },
+    )
+
+    assert event.allowed_decisions == ("submit", "cancel")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"interactionId": "int-mode", "kind": "mode_switch"},
+        {"interactionId": "int-mode", "kind": "mode_switch", "options": None},
+        {"interactionId": "int-mode", "kind": "mode_switch", "options": {}},
+        {
+            "interactionId": "int-mode",
+            "kind": "mode_switch",
+            "options": [{"decision": "hidden-without-label"}],
+        },
+        {"interactionId": "int-unknown", "kind": "future_kind"},
+        {"interactionId": "int-missing-kind"},
+    ],
+)
+def test_non_exec_without_visible_options_is_fail_closed(payload) -> None:
+    event = EngineInteractionRequestedEvent.from_payload(
+        session_key="trusted-session",
+        payload=payload,
+    )
+
+    assert event.allowed_decisions == ()
+
+
 @pytest.mark.parametrize(
     "payload, message",
     [
-        ({"interactionId": "int-1", "options": {}}, "options must be an array"),
         (
-            {"interactionId": "int-1", "options": [{}]},
-            "option is missing decision",
-        ),
-        (
-            {"interactionId": "int-1", "expiresAtMs": "soon"},
+            {"interactionId": "int-1", "kind": "exec", "expiresAtMs": "soon"},
             "expiresAtMs must be an integer",
         ),
     ],
@@ -76,11 +166,45 @@ def test_resolved_event_uses_explicit_session_identity() -> None:
     }
 
 
+def test_mode_transition_resolved_preserves_raw_event_name() -> None:
+    payload = {
+        "sessionKey": "payload-session",
+        "interactionId": "int-mode",
+        "transitionId": "int-mode",
+        "kind": "mode_switch",
+        "phase": "proceeded",
+        "decision": "proceed",
+        "seq": 131,
+    }
+
+    event = EngineInteractionResolvedEvent.from_mode_transition_payload(
+        session_key="trusted-session",
+        payload=payload,
+    )
+
+    assert event.session_key == "trusted-session"
+    assert event.interaction_id == "int-mode"
+    assert event.envelope == {
+        "type": "event",
+        "event": "mode_transition.resolved",
+        "payload": payload,
+        "seq": 131,
+    }
+
+
+def test_mode_transition_resolved_rejects_non_mode_kind() -> None:
+    with pytest.raises(ValueError, match="kind must be mode_switch"):
+        EngineInteractionResolvedEvent.from_mode_transition_payload(
+            session_key="s-1",
+            payload={"interactionId": "int-1", "kind": "exec"},
+        )
+
+
 def test_engine_exchange_validates_and_preserves_exact_frames() -> None:
     request = build_interaction_resolve_request(
         request_id="engine-1",
         interaction_id="int-1",
-        decision="allow-once",
+        resolution=InteractionResolution(kind="exec", decision="allow-once"),
     )
     response = {"type": "res", "id": "engine-1", "ok": True}
 
@@ -99,7 +223,7 @@ def test_engine_exchange_rejects_mismatched_response_id() -> None:
     request = build_interaction_resolve_request(
         request_id="engine-1",
         interaction_id="int-1",
-        decision="deny",
+        resolution=InteractionResolution(kind="exec", decision="deny"),
     )
 
     with pytest.raises(ValueError, match="does not match"):
@@ -107,3 +231,214 @@ def test_engine_exchange_rejects_mismatched_response_id() -> None:
             request=request,
             response={"type": "res", "id": "engine-2", "ok": True},
         )
+
+
+def test_engine_exchange_rejects_non_res_response_type() -> None:
+    request = build_interaction_resolve_request(
+        request_id="engine-1",
+        interaction_id="int-1",
+        resolution=InteractionResolution(kind="exec", decision="allow-once"),
+    )
+    with pytest.raises(ValueError, match="response type must be res"):
+        EngineInteractionResolveExchange.from_frames(
+            request=request,
+            response={"type": "event", "id": "engine-1", "ok": True},
+        )
+
+
+def test_engine_exchange_rejects_non_boolean_ok() -> None:
+    request = build_interaction_resolve_request(
+        request_id="engine-1",
+        interaction_id="int-1",
+        resolution=InteractionResolution(kind="exec", decision="allow-once"),
+    )
+    with pytest.raises(ValueError, match="ok must be boolean"):
+        EngineInteractionResolveExchange.from_frames(
+            request=request,
+            response={"type": "res", "id": "engine-1", "ok": "true"},
+        )
+
+
+def test_engine_exchange_rejects_request_without_id() -> None:
+    with pytest.raises(ValueError, match="missing id"):
+        EngineInteractionResolveExchange.from_frames(
+            request={"type": "req", "method": "interaction.resolve", "params": {}},
+            response={"type": "res", "id": "engine-1", "ok": True},
+        )
+
+
+@pytest.mark.parametrize(
+    "error, expected",
+    [
+        ({"message": "boom"}, "boom"),
+        ({"detail": "x"}, '{"detail":"x"}'),
+        ("plain error", "plain error"),
+        (None, "engine rejected interaction.resolve"),
+    ],
+)
+def test_engine_exchange_captures_error_message_shapes(error, expected) -> None:
+    request = build_interaction_resolve_request(
+        request_id="engine-1",
+        interaction_id="int-1",
+        resolution=InteractionResolution(kind="exec", decision="deny"),
+    )
+    exchange = EngineInteractionResolveExchange.from_frames(
+        request=request,
+        response={"type": "res", "id": "engine-1", "ok": False, "error": error},
+    )
+    assert exchange.accepted is False
+    assert exchange.error_message == expected
+
+
+def test_build_resolve_request_rejects_empty_identity() -> None:
+    with pytest.raises(ValueError, match="missing request id"):
+        build_interaction_resolve_request(
+            request_id="",
+            interaction_id="int-1",
+            resolution=InteractionResolution(kind="exec", decision="allow-once"),
+        )
+    with pytest.raises(ValueError, match="missing interactionId"):
+        build_interaction_resolve_request(
+            request_id="engine-1",
+            interaction_id="",
+            resolution=InteractionResolution(kind="exec", decision="allow-once"),
+        )
+
+
+def test_build_ask_user_submit_request_preserves_complete_answer() -> None:
+    request = build_interaction_resolve_request(
+        request_id="engine-ask-1",
+        interaction_id="int-ask-1",
+        resolution=InteractionResolution(
+            kind="ask_user",
+            decision="submit",
+            answer="deploy_target: staging；components: web，worker",
+            message="deploy_target: staging；components: web，worker",
+            values={
+                "deploy_target": "staging",
+                "components": "web，worker",
+            },
+            answers={
+                "what's your deploy target?": "staging",
+                "whats' the components?": "web，worker",
+            },
+            selected_options=(("staging",), ("web", "worker")),
+        ),
+    )
+
+    assert request == {
+        "type": "req",
+        "id": "engine-ask-1",
+        "method": "interaction.resolve",
+        "params": {
+            "interactionId": "int-ask-1",
+            "decision": "submit",
+            "answer": "deploy_target: staging；components: web，worker",
+            "message": "deploy_target: staging；components: web，worker",
+            "values": {
+                "deploy_target": "staging",
+                "components": "web，worker",
+            },
+            "answers": {
+                "what's your deploy target?": "staging",
+                "whats' the components?": "web，worker",
+            },
+            "selectedOptions": [["staging"], ["web", "worker"]],
+        },
+    }
+
+
+def test_build_ask_user_cancel_request_omits_answer_fields() -> None:
+    request = build_interaction_resolve_request(
+        request_id="engine-ask-cancel",
+        interaction_id="int-ask-1",
+        resolution=InteractionResolution(kind="ask_user", decision="cancel"),
+    )
+
+    assert request["method"] == "interaction.resolve"
+    assert request["params"] == {
+        "interactionId": "int-ask-1",
+        "decision": "cancel",
+    }
+
+
+@pytest.mark.parametrize("decision", ["allow-once", "deny"])
+def test_build_exec_request_uses_interaction_resolve(decision: str) -> None:
+    request = build_interaction_resolve_request(
+        request_id="engine-exec-1",
+        interaction_id="int-exec-1",
+        resolution=InteractionResolution(kind="exec", decision=decision),
+    )
+
+    assert request["method"] == "interaction.resolve"
+    assert request["params"] == {
+        "interactionId": "int-exec-1",
+        "decision": decision,
+    }
+
+
+@pytest.mark.parametrize("decision", ["proceed", "stay"])
+def test_build_mode_switch_request_uses_transition_rpc(decision: str) -> None:
+    request = build_interaction_resolve_request(
+        request_id="engine-mode-1",
+        interaction_id="int-mode-1",
+        resolution=InteractionResolution(kind="mode_switch", decision=decision),
+    )
+
+    assert request == {
+        "type": "req",
+        "id": "engine-mode-1",
+        "method": "mode_transition.resolve",
+        "params": {
+            "transitionId": "int-mode-1",
+            "decision": decision,
+        },
+    }
+
+
+def test_build_legacy_request_uses_interaction_resolve() -> None:
+    request = build_interaction_resolve_request(
+        request_id="engine-legacy-1",
+        interaction_id="int-legacy-1",
+        resolution=InteractionResolution(decision="legacy-decision"),
+    )
+
+    assert request["method"] == "interaction.resolve"
+    assert request["params"] == {
+        "interactionId": "int-legacy-1",
+        "decision": "legacy-decision",
+    }
+
+
+def test_resolved_event_falls_back_to_id_when_interaction_id_absent() -> None:
+    event = EngineInteractionResolvedEvent.from_payload(
+        session_key="s-1", payload={"id": "fallback-id"}
+    )
+    assert event.interaction_id == "fallback-id"
+
+
+def test_resolved_event_rejects_missing_interaction_identity() -> None:
+    with pytest.raises(ValueError, match="missing interactionId"):
+        EngineInteractionResolvedEvent.from_payload(session_key="s-1", payload={})
+
+
+def test_resolved_event_rejects_empty_session_key() -> None:
+    with pytest.raises(ValueError, match="missing sessionKey"):
+        EngineInteractionResolvedEvent.from_payload(
+            session_key="", payload={"interactionId": "int-1"}
+        )
+
+
+def test_allowed_decisions_skips_option_with_label_but_no_value() -> None:
+    event = EngineInteractionRequestedEvent.from_payload(
+        session_key="s-1",
+        payload={
+            "interactionId": "int-skip",
+            "kind": "exec",
+            "options": [
+                {"label": "No Value"},
+                {"label": "Once", "decision": "allow-once"},
+            ],
+        },
+    )
+    assert event.allowed_decisions == ("allow-once",)

--- a/src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py
@@ -71,7 +71,7 @@ def test_resolved_event_uses_explicit_session_identity() -> None:
     assert event.interaction_id == "int-1"
     assert event.envelope == {
         "type": "event",
-        "event": "interaction.resolve",
+        "event": "interaction.resolved",
         "payload": payload,
     }
 

--- a/src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import pytest
+
+from secbaas.community.core.service.bot_run._interaction_protocol import (
+    EngineInteractionRequestedEvent,
+    EngineInteractionResolvedEvent,
+    EngineInteractionResolveExchange,
+    build_interaction_resolve_request,
+)
+
+
+def test_requested_event_is_parsed_once_into_explicit_fields() -> None:
+    payload = {
+        "sessionKey": "payload-session",
+        "interactionId": "int-1",
+        "expiresAtMs": 123,
+        "options": [
+            {"decision": "allow-once"},
+            {"value": "deny"},
+            {"decision": "allow-once"},
+        ],
+        "seq": 9,
+    }
+
+    event = EngineInteractionRequestedEvent.from_payload(
+        session_key="trusted-session",
+        payload=payload,
+    )
+
+    assert event.session_key == "trusted-session"
+    assert event.interaction_id == "int-1"
+    assert event.allowed_decisions == ("allow-once", "deny")
+    assert event.expires_at_ms == 123
+    assert event.envelope["payload"] is payload
+    assert event.envelope["seq"] == 9
+
+
+@pytest.mark.parametrize(
+    "payload, message",
+    [
+        ({"interactionId": "int-1", "options": {}}, "options must be an array"),
+        (
+            {"interactionId": "int-1", "options": [{}]},
+            "option is missing decision",
+        ),
+        (
+            {"interactionId": "int-1", "expiresAtMs": "soon"},
+            "expiresAtMs must be an integer",
+        ),
+    ],
+)
+def test_requested_event_rejects_malformed_dispatch_metadata(payload, message) -> None:
+    with pytest.raises(ValueError, match=message):
+        EngineInteractionRequestedEvent.from_payload(session_key="s-1", payload=payload)
+
+
+def test_resolved_event_uses_explicit_session_identity() -> None:
+    payload = {
+        "sessionKey": "payload-session",
+        "interactionId": "int-1",
+        "decision": "allow-once",
+    }
+
+    event = EngineInteractionResolvedEvent.from_payload(
+        session_key="trusted-session",
+        payload=payload,
+    )
+
+    assert event.session_key == "trusted-session"
+    assert event.interaction_id == "int-1"
+    assert event.envelope == {
+        "type": "event",
+        "event": "interaction.resolve",
+        "payload": payload,
+    }
+
+
+def test_engine_exchange_validates_and_preserves_exact_frames() -> None:
+    request = build_interaction_resolve_request(
+        request_id="engine-1",
+        interaction_id="int-1",
+        decision="allow-once",
+    )
+    response = {"type": "res", "id": "engine-1", "ok": True}
+
+    exchange = EngineInteractionResolveExchange.from_frames(
+        request=request,
+        response=response,
+    )
+
+    assert exchange.request is request
+    assert exchange.response is response
+    assert exchange.accepted is True
+    assert exchange.error_message is None
+
+
+def test_engine_exchange_rejects_mismatched_response_id() -> None:
+    request = build_interaction_resolve_request(
+        request_id="engine-1",
+        interaction_id="int-1",
+        decision="deny",
+    )
+
+    with pytest.raises(ValueError, match="does not match"):
+        EngineInteractionResolveExchange.from_frames(
+            request=request,
+            response={"type": "res", "id": "engine-2", "ok": True},
+        )

--- a/src/baas/tests/unit/core/service/sse/test_default_converter.py
+++ b/src/baas/tests/unit/core/service/sse/test_default_converter.py
@@ -414,3 +414,43 @@ class TestEngineNameFallback:
             run_id="run-1",
         )
         assert event is not None
+
+
+class TestInteractionBranch:
+    def test_interaction_requested_passthrough_envelope(self):
+        converter = DefaultStreamConverter()
+        envelope = {
+            "type": "event",
+            "event": "interaction.requested",
+            "payload": {"sessionKey": "s", "interactionId": "int-1"},
+        }
+        event = converter.convert(
+            StreamChunk(
+                type="interaction",
+                metadata={"event": "interaction.requested", "payload": envelope},
+            ),
+            run_id="run-1",
+        )
+        assert event is not None
+        assert event.event == "interaction.requested"
+        data = _data(event)
+        assert data["type"] == "event"
+        assert data["event"] == "interaction.requested"
+        assert data["payload"]["interactionId"] == "int-1"
+
+    def test_interaction_resolved_is_exposed_as_resolve(self):
+        converter = DefaultStreamConverter()
+        envelope = {
+            "type": "event",
+            "event": "interaction.resolve",
+            "payload": {"sessionKey": "s", "interactionId": "int-1"},
+        }
+        event = converter.convert(
+            StreamChunk(
+                type="interaction",
+                metadata={"event": "interaction.resolved", "payload": envelope},
+            ),
+            run_id="run-1",
+        )
+        assert event is not None
+        assert event.event == "interaction.resolve"

--- a/src/baas/tests/unit/core/service/sse/test_default_converter.py
+++ b/src/baas/tests/unit/core/service/sse/test_default_converter.py
@@ -8,6 +8,8 @@ delta with empty content, final with empty content.
 """
 
 import json
+import logging
+from copy import deepcopy
 
 from secbaas.community.api.sse import StreamChunk
 from secbaas.community.core.service.sse import DefaultStreamConverter
@@ -17,6 +19,30 @@ def _data(event) -> dict:
     d = json.loads(event.data)
     d.pop("ts", None)
     return d
+
+
+def _interaction_chunk(event: str, payload: dict) -> StreamChunk:
+    envelope = {
+        "type": "event",
+        "event": event,
+        "payload": payload,
+    }
+    if "seq" in payload:
+        envelope["seq"] = payload["seq"]
+    return StreamChunk(
+        type="interaction",
+        metadata={"event": event, "payload": envelope},
+    )
+
+
+def _capture_interaction_logs(monkeypatch, caplog) -> None:
+    logger = logging.getLogger("test.interaction-converter")
+    logger.propagate = True
+    monkeypatch.setattr(
+        "secbaas.community.core.service.sse._default_converter.logger",
+        logger,
+    )
+    caplog.set_level(logging.WARNING, logger=logger.name)
 
 
 class TestHeartbeat:
@@ -417,40 +443,1786 @@ class TestEngineNameFallback:
 
 
 class TestInteractionBranch:
-    def test_interaction_requested_passthrough_envelope(self):
+    def test_exec_requested_is_flat_bcn_interaction(self):
         converter = DefaultStreamConverter()
-        envelope = {
-            "type": "event",
-            "event": "interaction.requested",
-            "payload": {"sessionKey": "s", "interactionId": "int-1"},
+        payload = {
+            "interactionId": "int-1",
+            "id": "engine-id",
+            "runId": "engine-run",
+            "seq": 91,
+            "ts": 123456,
+            "status": "pending",
+            "kind": "exec",
+            "phase": "engine-phase-must-not-win",
+            "title": "Approve command",
+            "description": "The command needs approval",
+            "toolCallId": "tool-1",
+            "cwd": "/workspace",
+            "command": "make test",
+            "options": [
+                {
+                    "label": "Run",
+                    "decision": "proceed",
+                    "value": "ignored-value",
+                    "description": "ignored-description",
+                    "optionId": "opt-1",
+                },
+                {"label": "Cancel", "value": "cancel"},
+            ],
         }
         event = converter.convert(
-            StreamChunk(
-                type="interaction",
-                metadata={"event": "interaction.requested", "payload": envelope},
-            ),
-            run_id="run-1",
+            _interaction_chunk("interaction.requested", payload),
+            run_id="bcn-run",
         )
         assert event is not None
-        assert event.event == "interaction.requested"
-        data = _data(event)
-        assert data["type"] == "event"
-        assert data["event"] == "interaction.requested"
-        assert data["payload"]["interactionId"] == "int-1"
+        assert event.event == "interaction"
+        assert event.id == "1"
+        raw_data = json.loads(event.data)
+        assert isinstance(raw_data["ts"], int)
+        assert raw_data["ts"] != payload["ts"]
+        assert _data(event) == {
+            "runId": "bcn-run",
+            "seq": 1,
+            "interactionId": "int-1",
+            "kind": "exec",
+            "phase": "requested",
+            "title": "Approve command",
+            "description": "The command needs approval",
+            "toolCallId": "tool-1",
+            "cwd": "/workspace",
+            "command": "make test",
+            "options": [
+                {"label": "Run", "decision": "proceed"},
+                {"label": "Cancel", "decision": "cancel"},
+            ],
+        }
 
-    def test_interaction_resolved_is_preserved(self):
+    def test_exec_requested_uses_id_and_subject_tool_call_id_fallbacks(self):
         converter = DefaultStreamConverter()
-        envelope = {
-            "type": "event",
-            "event": "interaction.resolved",
-            "payload": {"sessionKey": "s", "interactionId": "int-1"},
+        payload = {
+            "id": "int-fallback",
+            "kind": "exec",
+            "subject": {"toolCallId": "tool-fallback"},
+            "command": "pwd",
         }
         event = converter.convert(
-            StreamChunk(
-                type="interaction",
-                metadata={"event": "interaction.resolved", "payload": envelope},
+            _interaction_chunk("interaction.requested", payload),
+            run_id="run-1",
+        )
+        assert event is not None
+        data = _data(event)
+        assert data["interactionId"] == "int-fallback"
+        assert data["toolCallId"] == "tool-fallback"
+        assert data["phase"] == "requested"
+        assert "title" not in data
+        assert "description" not in data
+        assert "cwd" not in data
+        assert data["options"] == [
+            {"label": "Allow once", "decision": "allow-once"},
+            {"label": "Allow always", "decision": "allow-always"},
+            {"label": "Deny", "decision": "deny"},
+        ]
+
+    def test_exec_requested_without_options_uses_bcn_default_options(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-1",
+                    "kind": "exec",
+                    "command": "pwd",
+                },
             ),
             run_id="run-1",
         )
         assert event is not None
-        assert event.event == "interaction.resolved"
+        assert _data(event)["options"] == [
+            {"label": "Allow once", "decision": "allow-once"},
+            {"label": "Allow always", "decision": "allow-always"},
+            {"label": "Deny", "decision": "deny"},
+        ]
+
+    def test_phase_conflict_uses_event_phase_and_warns(self, monkeypatch, caplog):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-1",
+                    "kind": "exec",
+                    "phase": "resolved",
+                    "command": "pwd",
+                },
+            ),
+            run_id="run-1",
+        )
+        assert event is not None
+        assert _data(event)["phase"] == "requested"
+        assert "Interaction conversion warning" in caplog.text
+        assert "field_path=phase" in caplog.text
+        assert "error_type=phase_conflict" in caplog.text
+
+    def test_exec_option_empty_decision_falls_back_to_value(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-1",
+                    "kind": "exec",
+                    "command": "echo ok",
+                    "options": [
+                        {"label": "Continue", "decision": "", "value": "proceed"}
+                    ],
+                },
+            ),
+            run_id="run-1",
+        )
+        assert event is not None
+        assert _data(event)["options"] == [{"label": "Continue", "decision": "proceed"}]
+
+    def test_exec_option_non_string_decision_falls_back_to_value(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-1",
+                    "kind": "exec",
+                    "command": "echo ok",
+                    "options": [
+                        {
+                            "label": "Continue",
+                            "decision": {"unexpected": True},
+                            "value": "proceed",
+                        }
+                    ],
+                },
+            ),
+            run_id="run-1",
+        )
+        assert event is not None
+        assert _data(event)["options"] == [{"label": "Continue", "decision": "proceed"}]
+
+    def test_exec_mixed_options_filter_and_duplicate_decision_last_wins(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-mixed",
+                    "kind": "exec",
+                    "command": "make test",
+                    "options": [
+                        "not-an-object",
+                        {"label": "Once", "decision": "", "value": "allow-once"},
+                        {"label": "Deny", "decision": 42, "value": "deny"},
+                        {"label": "Missing decision"},
+                        {"label": "Once replacement", "decision": "allow-once"},
+                    ],
+                },
+            ),
+            run_id="run-log",
+        )
+
+        assert event is not None
+        assert _data(event)["options"] == [
+            {"label": "Once replacement", "decision": "allow-once"},
+            {"label": "Deny", "decision": "deny"},
+        ]
+        assert "field_path=payload.options[0]" in caplog.text
+        assert "field_path=payload.options[3]" in caplog.text
+        assert "field_path=payload.options[4].decision" in caplog.text
+        assert "error_type=duplicate_option_decision" in caplog.text
+
+    def test_invalid_exec_command_drops_interaction_without_consuming_seq(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        for index, command in enumerate((None, 42, "", "   ")):
+            converter = DefaultStreamConverter()
+            payload = {
+                "interactionId": f"int-command-{index}",
+                "kind": "exec",
+                "title": "Sensitive title",
+            }
+            if index:
+                payload["command"] = command
+            interaction = converter.convert(
+                _interaction_chunk("interaction.requested", payload),
+                run_id="run-log",
+            )
+            chat = converter.convert(
+                StreamChunk(type="delta", content="after invalid exec"),
+                run_id="run-log",
+            )
+
+            assert interaction is None
+            assert chat is not None
+            assert chat.id == "1"
+            assert _data(chat)["seq"] == 1
+
+        assert caplog.text.count("field_path=payload.command") == 4
+        assert "Sensitive title" not in caplog.text
+
+    def test_invalid_explicit_exec_options_drop_interaction_without_seq(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        cases = (
+            None,
+            {"label": "not-an-array"},
+            [],
+            ["bad", {"label": "Missing decision"}, {"decision": "missing-label"}],
+        )
+        for index, options in enumerate(cases):
+            converter = DefaultStreamConverter()
+            interaction = converter.convert(
+                _interaction_chunk(
+                    "interaction.requested",
+                    {
+                        "interactionId": f"int-options-{index}",
+                        "kind": "exec",
+                        "command": "make test",
+                        "options": options,
+                    },
+                ),
+                run_id="run-log",
+            )
+            chat = converter.convert(
+                StreamChunk(type="delta", content="after invalid exec options"),
+                run_id="run-log",
+            )
+
+            assert interaction is None
+            assert chat is not None
+            assert chat.id == "1"
+            assert _data(chat)["seq"] == 1
+
+        assert caplog.text.count("error_type=no_valid_options") == len(cases)
+        assert "after invalid exec options" not in caplog.text
+
+    def test_exec_converter_exception_is_dropped_without_consuming_seq(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+
+        def _raise_sensitive_error(*args, **kwargs):
+            raise RuntimeError("sensitive-message")
+
+        monkeypatch.setattr(
+            "secbaas.community.core.service.sse._default_converter."
+            "_transform_exec_requested",
+            _raise_sensitive_error,
+            raising=False,
+        )
+        converter = DefaultStreamConverter()
+        interaction = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-1",
+                    "kind": "exec",
+                    "command": "sensitive-command",
+                },
+            ),
+            run_id="run-1",
+        )
+        chat = converter.convert(
+            StreamChunk(type="delta", content="ok"),
+            run_id="run-1",
+        )
+
+        assert interaction is None
+        assert chat is not None
+        assert chat.event == "chat"
+        assert chat.id == "1"
+        assert _data(chat)["seq"] == 1
+        assert "error_type=RuntimeError" in caplog.text
+        assert "sensitive-message" not in caplog.text
+        assert "sensitive-command" not in caplog.text
+
+    def test_missing_interaction_id_warns_without_business_data(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.resolved",
+                {
+                    "kind": "ask_user",
+                    "title": "sensitive-title",
+                    "description": "sensitive-description",
+                    "command": "sensitive-command",
+                    "answers": {"secret": "sensitive-answer"},
+                },
+            ),
+            run_id="run-log",
+        )
+
+        assert event is None
+        assert "run_id=run-log" in caplog.text
+        assert "interaction_id=" in caplog.text
+        assert "kind=ask_user" in caplog.text
+        assert "field_path=interactionId" in caplog.text
+        assert "error_type=missing_required_field" in caplog.text
+        for sensitive_value in (
+            "sensitive-title",
+            "sensitive-description",
+            "sensitive-command",
+            "sensitive-answer",
+        ):
+            assert sensitive_value not in caplog.text
+
+    def test_missing_kind_warns_without_business_data(self, monkeypatch, caplog):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-log",
+                    "title": "sensitive-title",
+                    "description": "sensitive-description",
+                    "command": "sensitive-command",
+                },
+            ),
+            run_id="run-log",
+        )
+
+        assert event is None
+        assert "run_id=run-log" in caplog.text
+        assert "interaction_id=int-log" in caplog.text
+        assert "kind=" in caplog.text
+        assert "field_path=kind" in caplog.text
+        assert "error_type=missing_required_field" in caplog.text
+        assert "sensitive-title" not in caplog.text
+        assert "sensitive-description" not in caplog.text
+        assert "sensitive-command" not in caplog.text
+
+    def test_exec_resolved_is_flat_and_allowlisted(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.resolved",
+                {
+                    "interactionId": "int-1",
+                    "kind": "exec",
+                    "phase": "requested",
+                    "decision": "proceed",
+                    "idempotencyKey": "idem-1",
+                    "status": "completed",
+                    "runId": "engine-run",
+                    "seq": 92,
+                    "ts": 123457,
+                },
+            ),
+            run_id="bcn-run",
+        )
+        assert event is not None
+        assert event.event == "interaction"
+        assert _data(event) == {
+            "runId": "bcn-run",
+            "seq": 1,
+            "interactionId": "int-1",
+            "kind": "exec",
+            "phase": "resolved",
+            "decision": "proceed",
+            "idempotencyKey": "idem-1",
+        }
+
+    def test_ask_user_resolved_copies_action_and_answers(self):
+        converter = DefaultStreamConverter()
+        answers = {"environment": "staging"}
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.resolved",
+                {
+                    "interactionId": "int-ask",
+                    "kind": "ask_user",
+                    "action": "submit",
+                    "answers": answers,
+                },
+            ),
+            run_id="run-1",
+        )
+        assert event is not None
+        data = _data(event)
+        assert data["phase"] == "resolved"
+        assert data["action"] == "submit"
+        assert data["answers"] == answers
+
+    def test_invalid_envelope_is_dropped(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            StreamChunk(
+                type="interaction",
+                metadata={
+                    "event": "interaction.requested",
+                    "payload": {
+                        "type": "event",
+                        "event": "interaction.requested",
+                        "payload": [],
+                    },
+                },
+            ),
+            run_id="run-1",
+        )
+        assert event is None
+
+    def test_unknown_kind_is_dropped(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {"interactionId": "int-1", "kind": "future_kind"},
+            ),
+            run_id="run-1",
+        )
+        assert event is None
+
+    def test_dropped_interactions_do_not_consume_chat_sequence(self):
+        converter = DefaultStreamConverter()
+        first_chat = converter.convert(
+            StreamChunk(type="delta", content="first"),
+            run_id="run-1",
+        )
+        invalid_envelope = converter.convert(
+            StreamChunk(
+                type="interaction",
+                metadata={
+                    "event": "interaction.requested",
+                    "payload": {
+                        "type": "event",
+                        "event": "interaction.requested",
+                        "payload": [],
+                    },
+                },
+            ),
+            run_id="run-1",
+        )
+        unknown_kind = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {"interactionId": "int-unknown", "kind": "future_kind"},
+            ),
+            run_id="run-1",
+        )
+        second_chat = converter.convert(
+            StreamChunk(type="delta", content="second"),
+            run_id="run-1",
+        )
+
+        assert first_chat is not None
+        assert first_chat.id == "1"
+        assert invalid_envelope is None
+        assert unknown_kind is None
+        assert second_chat is not None
+        assert second_chat.id == "2"
+        assert _data(second_chat)["seq"] == 2
+
+
+class TestInteractionStreamInvariants:
+    def test_agent_interaction_and_chat_share_sequence_and_bcn_run_id(self):
+        converter = DefaultStreamConverter()
+        run_id = "bcn-run"
+
+        agent = converter.convert(
+            StreamChunk(
+                type="agent",
+                metadata={
+                    "engine_frame": {
+                        "stream": "lifecycle",
+                        "data": {"phase": "start", "model": "test-model"},
+                    }
+                },
+            ),
+            run_id=run_id,
+        )
+        interaction = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-mode",
+                    "kind": "mode_switch",
+                    "options": [{"label": "Stay", "decision": "stay"}],
+                },
+            ),
+            run_id=run_id,
+        )
+        chat = converter.convert(
+            StreamChunk(type="delta", content="hello"),
+            run_id=run_id,
+        )
+
+        assert agent is not None
+        assert interaction is not None
+        assert chat is not None
+        assert [event.event for event in (agent, interaction, chat)] == [
+            "agent",
+            "interaction",
+            "chat",
+        ]
+        assert [event.id for event in (agent, interaction, chat)] == ["1", "2", "3"]
+        for expected_seq, event in enumerate((agent, interaction, chat), start=1):
+            data = _data(event)
+            assert data["runId"] == run_id
+            assert data["seq"] == expected_seq
+            assert event.id == str(data["seq"])
+        assert _data(interaction) == {
+            "runId": run_id,
+            "seq": 2,
+            "interactionId": "int-mode",
+            "kind": "mode_switch",
+            "phase": "requested",
+            "options": [{"label": "Stay", "decision": "stay"}],
+        }
+
+    def test_unknown_interaction_between_agent_and_chat_does_not_consume_seq(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        agent = converter.convert(
+            StreamChunk(
+                type="agent",
+                metadata={
+                    "engine_frame": {
+                        "stream": "lifecycle",
+                        "data": {"phase": "start"},
+                    }
+                },
+            ),
+            run_id="bcn-run",
+        )
+        dropped = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-unknown",
+                    "kind": "future_kind",
+                    "title": "sensitive-title",
+                },
+            ),
+            run_id="bcn-run",
+        )
+        chat = converter.convert(
+            StreamChunk(type="delta", content="after interaction"),
+            run_id="bcn-run",
+        )
+
+        assert agent is not None
+        assert agent.id == "1"
+        assert dropped is None
+        assert chat is not None
+        assert chat.id == "2"
+        assert _data(chat)["seq"] == 2
+        assert "error_type=unsupported_kind" in caplog.text
+        assert "sensitive-title" not in caplog.text
+
+    def test_mode_transition_resolved_maps_actual_engine_event_to_common_path(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "mode_transition.resolved",
+                {
+                    "interactionId": "int-mode",
+                    "kind": "mode_switch",
+                    "phase": "proceeded",
+                    "decision": "proceed",
+                    "status": "resolved",
+                    "options": [
+                        {"label": "Continue to execution", "decision": "proceed"}
+                    ],
+                },
+            ),
+            run_id="bcn-run",
+        )
+
+        assert event is not None
+        assert event.event == "interaction"
+        assert _data(event) == {
+            "runId": "bcn-run",
+            "seq": 1,
+            "interactionId": "int-mode",
+            "kind": "mode_switch",
+            "phase": "resolved",
+            "decision": "proceed",
+        }
+
+    def test_conversion_does_not_mutate_engine_envelope_or_nested_payload(self):
+        converter = DefaultStreamConverter()
+        payload = {
+            "interactionId": "int-ask",
+            "kind": "ask_user",
+            "subject": {
+                "toolCallId": "subject-tool-call",
+                "internal": {"secret": "subject-internal"},
+            },
+            "questions": [
+                {
+                    "header": "Environment",
+                    "question": "Where should this deploy?",
+                    "multiSelect": False,
+                    "allowOther": False,
+                    "options": [
+                        {
+                            "label": "Staging",
+                            "decision": "staging",
+                            "value": "legacy-staging",
+                            "internal": {"secret": "option-internal"},
+                        }
+                    ],
+                }
+            ],
+            "internal": {"secret": "payload-internal"},
+            "status": "pending",
+        }
+        chunk = _interaction_chunk("interaction.requested", payload)
+        original_metadata = deepcopy(chunk.metadata)
+        original_payload = deepcopy(payload)
+
+        event = converter.convert(chunk, run_id="bcn-run")
+
+        assert event is not None
+        assert chunk.metadata == original_metadata
+        assert payload == original_payload
+        assert _data(event) == {
+            "runId": "bcn-run",
+            "seq": 1,
+            "interactionId": "int-ask",
+            "kind": "ask_user",
+            "phase": "requested",
+            "toolCallId": "subject-tool-call",
+            "questions": [
+                {
+                    "questionId": "question_1",
+                    "question": "Where should this deploy?",
+                    "header": "Environment",
+                    "options": [{"label": "Staging", "value": "staging"}],
+                    "multiSelect": False,
+                    "allowOther": False,
+                }
+            ],
+        }
+
+
+class TestAskUserInteraction:
+    def test_secret_question_aliases_drop_entire_interaction_without_seq(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        for secret_key, secret_value in (
+            ("secret", True),
+            ("secret", False),
+            ("isSecret", None),
+        ):
+            converter = DefaultStreamConverter()
+            interaction = converter.convert(
+                _interaction_chunk(
+                    "interaction.requested",
+                    {
+                        "interactionId": f"int-{secret_key}-{secret_value}",
+                        "kind": "ask_user",
+                        "description": "Sensitive description",
+                        "questions": [
+                            {
+                                "header": "safe",
+                                "question": "Safe-looking question",
+                            },
+                            {
+                                "header": "secret",
+                                "question": "Sensitive secret question body",
+                                secret_key: secret_value,
+                            },
+                        ],
+                    },
+                ),
+                run_id="run-log",
+            )
+            chat = converter.convert(
+                StreamChunk(type="delta", content="after secret question"),
+                run_id="run-log",
+            )
+
+            assert interaction is None
+            assert chat is not None
+            assert chat.id == "1"
+            assert _data(chat)["seq"] == 1
+
+        assert "field_path=payload.questions[1].secret" in caplog.text
+        assert "field_path=payload.questions[1].isSecret" in caplog.text
+        assert caplog.text.count("error_type=secret_question_unsupported") == 3
+        assert "Sensitive description" not in caplog.text
+        assert "Sensitive secret question body" not in caplog.text
+        assert "Safe-looking question" not in caplog.text
+
+    def test_maps_complete_questions_and_options(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-ask",
+                    "kind": "ask_user",
+                    "phase": "requested",
+                    "title": "Choose deployment",
+                    "description": "Select the deployment settings",
+                    "toolCallId": "tool-ask",
+                    "questions": [
+                        {
+                            "header": "Environment",
+                            "questionId": "engine-question-id",
+                            "question": "Where should this deploy?",
+                            "allowOther": True,
+                            "multiSelect": False,
+                            "options": [
+                                {
+                                    "label": "Production",
+                                    "decision": "prod",
+                                    "value": "ignored-value",
+                                    "description": "Deploy to production",
+                                    "optionId": "engine-option-id",
+                                },
+                                {
+                                    "label": "Staging",
+                                    "value": "staging",
+                                },
+                            ],
+                        }
+                    ],
+                },
+            ),
+            run_id="bcn-run",
+        )
+
+        assert event is not None
+        assert event.event == "interaction"
+        assert _data(event) == {
+            "runId": "bcn-run",
+            "seq": 1,
+            "interactionId": "int-ask",
+            "kind": "ask_user",
+            "phase": "requested",
+            "title": "Choose deployment",
+            "description": "Select the deployment settings",
+            "toolCallId": "tool-ask",
+            "questions": [
+                {
+                    "header": "Environment",
+                    "questionId": "question_1",
+                    "question": "Where should this deploy?",
+                    "allowOther": True,
+                    "multiSelect": False,
+                    "options": [
+                        {
+                            "label": "Production",
+                            "value": "prod",
+                            "description": "Deploy to production",
+                        },
+                        {"label": "Staging", "value": "staging"},
+                    ],
+                }
+            ],
+        }
+
+    def test_missing_header_drops_entire_interaction_without_seq(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        interaction = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-ask",
+                    "kind": "ask_user",
+                    "questions": [{"question": "Sensitive optional question"}],
+                },
+            ),
+            run_id="run-1",
+        )
+        chat = converter.convert(
+            StreamChunk(type="delta", content="after invalid interaction"),
+            run_id="run-1",
+        )
+
+        assert interaction is None
+        assert chat is not None
+        assert chat.id == "1"
+        assert _data(chat)["seq"] == 1
+        assert "field_path=payload.questions[0].header" in caplog.text
+        assert "error_type=invalid_header" in caplog.text
+        assert "Sensitive optional question" not in caplog.text
+
+    def test_empty_header_drops_entire_interaction(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-ask",
+                    "kind": "ask_user",
+                    "questions": [
+                        {
+                            "header": "   ",
+                            "question": "Sensitive empty-header question",
+                        },
+                    ],
+                },
+            ),
+            run_id="run-log",
+        )
+
+        assert event is None
+        assert "field_path=payload.questions[0].header" in caplog.text
+        assert "error_type=invalid_header" in caplog.text
+        assert "Sensitive empty-header question" not in caplog.text
+
+    def test_duplicate_headers_keep_distinct_indexed_question_ids(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-ask",
+                    "kind": "ask_user",
+                    "questions": [
+                        {
+                            "header": "Sensitive duplicate header",
+                            "question": "Sensitive first question",
+                        },
+                        {
+                            "header": "Sensitive duplicate header",
+                            "question": "Sensitive second question",
+                        },
+                    ],
+                },
+            ),
+            run_id="run-log",
+        )
+
+        assert event is not None
+        questions = _data(event)["questions"]
+        assert questions == [
+            {
+                "header": "Sensitive duplicate header",
+                "questionId": "question_1",
+                "question": "Sensitive first question",
+            },
+            {
+                "header": "Sensitive duplicate header",
+                "questionId": "question_2",
+                "question": "Sensitive second question",
+            },
+        ]
+        assert "field_path=payload.questions[1].header" in caplog.text
+        assert "error_type=duplicate_header" in caplog.text
+        for sensitive_value in (
+            "Sensitive duplicate header",
+            "Sensitive first question",
+            "Sensitive second question",
+        ):
+            assert sensitive_value not in caplog.text
+
+    def test_engine_question_ids_do_not_override_provider_indexed_identity(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-ask",
+                    "kind": "ask_user",
+                    "questions": [
+                        {
+                            "questionId": "engine-owned-id",
+                            "header": "Display header",
+                            "question": "Question body",
+                        },
+                    ],
+                },
+            ),
+            run_id="run-log",
+        )
+
+        assert event is not None
+        assert _data(event)["questions"] == [
+            {
+                "header": "Display header",
+                "questionId": "question_1",
+                "question": "Question body",
+            }
+        ]
+
+    def test_malformed_children_are_skipped_and_warnings_are_sanitized(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-ask",
+                    "kind": "ask_user",
+                    "questions": [
+                        "Sensitive non-object question",
+                        {"header": "Sensitive missing-question header"},
+                        {
+                            "header": "Sensitive valid header",
+                            "question": "Sensitive valid question",
+                            "options": [
+                                "Sensitive non-object option",
+                                {
+                                    "decision": "sensitive-decision",
+                                    "description": "Sensitive missing-label description",
+                                },
+                                {"label": "Sensitive missing-decision label"},
+                                {
+                                    "label": "Sensitive valid label",
+                                    "value": "valid-value",
+                                },
+                            ],
+                        },
+                        {
+                            "header": "Sensitive invalid-options header",
+                            "question": "Sensitive invalid-options question",
+                            "options": {"label": "Sensitive nested label"},
+                        },
+                    ],
+                },
+            ),
+            run_id="run-log",
+        )
+
+        assert event is not None
+        assert _data(event)["questions"] == [
+            {
+                "header": "Sensitive valid header",
+                "questionId": "question_3",
+                "question": "Sensitive valid question",
+                "options": [
+                    {
+                        "label": "Sensitive missing-decision label",
+                        "value": "Sensitive missing-decision label",
+                    },
+                    {"label": "Sensitive valid label", "value": "valid-value"},
+                ],
+            },
+        ]
+        for expected_warning in (
+            "field_path=payload.questions[0]",
+            "field_path=payload.questions[1].question",
+            "field_path=payload.questions[2].options[0]",
+            "field_path=payload.questions[2].options[1]",
+            "field_path=payload.questions[3].options",
+        ):
+            assert expected_warning in caplog.text
+        assert "error_type=invalid_type" in caplog.text
+        assert "error_type=missing_required_field" in caplog.text
+        assert "field_path=payload.questions[2].options[2]" in caplog.text
+        assert "error_type=legacy_label_fallback" in caplog.text
+        for sensitive_value in (
+            "Sensitive non-object question",
+            "Sensitive missing-question header",
+            "Sensitive valid header",
+            "Sensitive valid question",
+            "Sensitive non-object option",
+            "sensitive-decision",
+            "Sensitive missing-label description",
+            "Sensitive missing-decision label",
+            "Sensitive valid label",
+            "Sensitive invalid-options header",
+            "Sensitive invalid-options question",
+            "Sensitive nested label",
+        ):
+            assert sensitive_value not in caplog.text
+
+    def test_real_engine_label_only_and_mixed_options_are_bcn_valid(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        interaction = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-real-engine-ask",
+                    "kind": "ask_user",
+                    "questions": [
+                        {
+                            "question": "Choose a fruit?",
+                            "header": "Fruit",
+                            "options": [
+                                {"label": "Apple", "description": "Red"},
+                                {"label": "Banana", "description": "Yellow"},
+                                {
+                                    "label": "New shape",
+                                    "decision": "new-decision",
+                                    "value": "ignored-value",
+                                },
+                                {"label": "Value shape", "value": "new-value"},
+                                {"label": "Apple", "description": "Green"},
+                            ],
+                            "multiSelect": False,
+                        },
+                    ],
+                },
+            ),
+            run_id="run-log",
+        )
+        chat = converter.convert(
+            StreamChunk(type="delta", content="after ask user"),
+            run_id="run-log",
+        )
+
+        assert interaction is not None
+        assert _data(interaction)["questions"] == [
+            {
+                "header": "Fruit",
+                "questionId": "question_1",
+                "question": "Choose a fruit?",
+                "options": [
+                    {"label": "Apple", "value": "Apple", "description": "Green"},
+                    {
+                        "label": "Banana",
+                        "value": "Banana",
+                        "description": "Yellow",
+                    },
+                    {"label": "New shape", "value": "new-decision"},
+                    {"label": "Value shape", "value": "new-value"},
+                ],
+                "multiSelect": False,
+            }
+        ]
+        assert chat is not None
+        assert interaction.id == "1"
+        assert chat.id == "2"
+        assert _data(chat)["seq"] == 2
+        assert caplog.text.count("error_type=legacy_label_fallback") == 3
+        assert "error_type=duplicate_option_value" in caplog.text
+        for business_text in (
+            "Choose a fruit?",
+            "Apple",
+            "Banana",
+            "New shape",
+            "Value shape",
+            "Red",
+            "Yellow",
+            "Green",
+        ):
+            assert business_text not in caplog.text
+
+    def test_option_decision_falls_back_to_valid_value(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-ask",
+                    "kind": "ask_user",
+                    "questions": [
+                        {
+                            "header": "Action",
+                            "question": "Choose an action",
+                            "options": [
+                                {
+                                    "label": "Empty decision",
+                                    "decision": "",
+                                    "value": "empty-fallback",
+                                },
+                                {
+                                    "label": "Invalid decision",
+                                    "decision": {"unexpected": True},
+                                    "value": "invalid-fallback",
+                                },
+                            ],
+                        }
+                    ],
+                },
+            ),
+            run_id="run-1",
+        )
+
+        assert event is not None
+        assert _data(event)["questions"][0]["options"] == [
+            {"label": "Empty decision", "value": "empty-fallback"},
+            {"label": "Invalid decision", "value": "invalid-fallback"},
+        ]
+
+    def test_missing_nonlist_and_all_invalid_questions_are_dropped_without_seq(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+
+        missing = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {"interactionId": "int-missing", "kind": "ask_user"},
+            ),
+            run_id="run-log",
+        )
+        invalid = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-invalid",
+                    "kind": "ask_user",
+                    "questions": {"question": "Sensitive hidden question"},
+                },
+            ),
+            run_id="run-log",
+        )
+        all_invalid = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-all-invalid",
+                    "kind": "ask_user",
+                    "questions": [
+                        "Sensitive invalid child",
+                        {"header": "Sensitive missing body"},
+                    ],
+                },
+            ),
+            run_id="run-log",
+        )
+        chat = converter.convert(
+            StreamChunk(type="delta", content="after invalid interactions"),
+            run_id="run-log",
+        )
+
+        assert missing is None
+        assert invalid is None
+        assert all_invalid is None
+        assert chat is not None
+        assert chat.id == "1"
+        assert _data(chat)["seq"] == 1
+        assert caplog.text.count("field_path=payload.questions") >= 3
+        assert caplog.text.count("error_type=invalid_type") >= 2
+        assert "error_type=no_valid_questions" in caplog.text
+        assert "Sensitive hidden question" not in caplog.text
+        assert "Sensitive invalid child" not in caplog.text
+        assert "Sensitive missing body" not in caplog.text
+
+    def test_invalid_explicit_options_drop_question_and_interaction(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+
+        for index, options in enumerate(
+            (
+                {"label": "not-an-array"},
+                [],
+                [
+                    "not-an-object",
+                    {"label": 42, "value": "invalid-label-type"},
+                    {"value": "missing-label"},
+                ],
+            )
+        ):
+            event = converter.convert(
+                _interaction_chunk(
+                    "interaction.requested",
+                    {
+                        "interactionId": f"int-options-{index}",
+                        "kind": "ask_user",
+                        "questions": [
+                            {
+                                "header": "Approval",
+                                "question": "Sensitive approval question",
+                                "options": options,
+                            }
+                        ],
+                    },
+                ),
+                run_id="run-log",
+            )
+            assert event is None
+
+        chat = converter.convert(
+            StreamChunk(type="delta", content="after invalid options"),
+            run_id="run-log",
+        )
+        assert chat is not None
+        assert chat.id == "1"
+        assert "field_path=payload.questions[0].options" in caplog.text
+        assert "error_type=no_valid_options" in caplog.text
+        assert "error_type=no_valid_questions" in caplog.text
+        assert "Sensitive approval question" not in caplog.text
+        assert "invalid-label-type" not in caplog.text
+        assert "missing-label" not in caplog.text
+
+    def test_limits_questions_to_four_and_keeps_first_four(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        questions = [
+            {"header": f"q{index}", "question": f"Question {index}"}
+            for index in range(1, 6)
+        ]
+        questions.append({"header": "q1", "question": "Replacement question"})
+
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-ask",
+                    "kind": "ask_user",
+                    "questions": questions,
+                },
+            ),
+            run_id="run-1",
+        )
+
+        assert event is not None
+        assert _data(event)["questions"] == [
+            {
+                "header": "q1",
+                "questionId": "question_1",
+                "question": "Question 1",
+            },
+            {"header": "q2", "questionId": "question_2", "question": "Question 2"},
+            {"header": "q3", "questionId": "question_3", "question": "Question 3"},
+            {"header": "q4", "questionId": "question_4", "question": "Question 4"},
+        ]
+        assert "field_path=payload.questions[4]" in caplog.text
+        assert "error_type=max_items_exceeded" in caplog.text
+        assert "field_path=payload.questions[5].header" in caplog.text
+        assert "error_type=duplicate_header" in caplog.text
+
+    def test_limits_unique_options_to_four_and_last_duplicate_wins(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        options = [
+            {"label": f"Option {index}", "value": f"v{index}"} for index in range(1, 6)
+        ]
+        options.append({"label": "Replacement option", "value": "v1"})
+
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-ask",
+                    "kind": "ask_user",
+                    "questions": [
+                        {
+                            "header": "Action",
+                            "question": "Choose an action",
+                            "options": options,
+                        }
+                    ],
+                },
+            ),
+            run_id="run-log",
+        )
+
+        assert event is not None
+        assert _data(event)["questions"][0]["options"] == [
+            {"label": "Replacement option", "value": "v1"},
+            {"label": "Option 2", "value": "v2"},
+            {"label": "Option 3", "value": "v3"},
+            {"label": "Option 4", "value": "v4"},
+        ]
+        assert "field_path=payload.questions[0].options[4]" in caplog.text
+        assert "error_type=max_items_exceeded" in caplog.text
+        assert "field_path=payload.questions[0].options[5].value" in caplog.text
+        assert "error_type=duplicate_option_value" in caplog.text
+
+    def test_boolean_fields_and_free_text_allow_other_follow_bcn_contract(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-ask",
+                    "kind": "ask_user",
+                    "questions": [
+                        {
+                            "header": "with-options",
+                            "question": "With options",
+                            "options": [{"label": "Yes", "value": "yes"}],
+                            "allowOther": False,
+                            "multiSelect": False,
+                        },
+                        {
+                            "header": "invalid-bools",
+                            "question": "Invalid bools",
+                            "options": [{"label": "No", "value": "no"}],
+                            "allowOther": "false",
+                            "multiSelect": 0,
+                        },
+                        {
+                            "header": "free-true",
+                            "question": "Free text true",
+                            "allowOther": True,
+                            "multiSelect": False,
+                        },
+                        {
+                            "header": "free-false",
+                            "question": "Free text false",
+                            "options": None,
+                            "allowOther": False,
+                            "multiSelect": True,
+                        },
+                    ],
+                },
+            ),
+            run_id="run-log",
+        )
+
+        assert event is not None
+        assert _data(event)["questions"] == [
+            {
+                "header": "with-options",
+                "questionId": "question_1",
+                "question": "With options",
+                "options": [{"label": "Yes", "value": "yes"}],
+                "allowOther": False,
+                "multiSelect": False,
+            },
+            {
+                "header": "invalid-bools",
+                "questionId": "question_2",
+                "question": "Invalid bools",
+                "options": [{"label": "No", "value": "no"}],
+            },
+            {
+                "header": "free-true",
+                "questionId": "question_3",
+                "question": "Free text true",
+                "multiSelect": False,
+            },
+        ]
+        assert "field_path=payload.questions[1].allowOther" in caplog.text
+        assert "field_path=payload.questions[1].multiSelect" in caplog.text
+        assert "error_type=invalid_type" in caplog.text
+        assert "field_path=payload.questions[2].allowOther" in caplog.text
+        assert "error_type=unsupported_without_options" in caplog.text
+        assert "field_path=payload.questions[3].options" in caplog.text
+        assert "error_type=no_valid_options" in caplog.text
+
+    def test_null_options_drop_interaction_without_consuming_seq(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        interaction = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-null-options",
+                    "kind": "ask_user",
+                    "questions": [
+                        {
+                            "header": "Approval",
+                            "question": "Sensitive approval question",
+                            "options": None,
+                        }
+                    ],
+                },
+            ),
+            run_id="run-log",
+        )
+        chat = converter.convert(
+            StreamChunk(type="delta", content="after null options"),
+            run_id="run-log",
+        )
+
+        assert interaction is None
+        assert chat is not None
+        assert chat.id == "1"
+        assert _data(chat)["seq"] == 1
+        assert "field_path=payload.questions[0].options" in caplog.text
+        assert "error_type=invalid_type" in caplog.text
+        assert "error_type=no_valid_options" in caplog.text
+        assert "error_type=no_valid_questions" in caplog.text
+        assert "Sensitive approval question" not in caplog.text
+
+    def test_whitespace_fields_use_only_valid_label_fallbacks(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-ask",
+                    "kind": "ask_user",
+                    "questions": [
+                        {"header": "blank-question", "question": "   "},
+                        {
+                            "header": "valid-question",
+                            "question": "Choose",
+                            "options": [
+                                {"label": "   ", "value": "invalid-label"},
+                                {"label": "Invalid value", "value": "\t"},
+                                {"label": "Valid", "value": " valid "},
+                            ],
+                        },
+                    ],
+                },
+            ),
+            run_id="run-1",
+        )
+
+        assert event is not None
+        assert _data(event)["questions"] == [
+            {
+                "header": "valid-question",
+                "questionId": "question_2",
+                "question": "Choose",
+                "options": [
+                    {"label": "Invalid value", "value": "Invalid value"},
+                    {"label": "Valid", "value": " valid "},
+                ],
+            }
+        ]
+
+
+_CAPTURED_MODE_SWITCH_PAYLOAD = {
+    "interactionId": "int:14136f21-01a0-42ed-8000-14136f2102ed",
+    "id": "int:14136f21-01a0-42ed-8000-14136f2102ed",
+    "runId": "a007d8cedca74d1dac159139d46af06f",
+    "sessionKey": "engine-session-1",
+    "kind": "mode_switch",
+    "interactionType": "mode_switch",
+    "phase": "requested",
+    "status": "pending",
+    "title": "Plan mode transition",
+    "description": "Transition from plan to execute",
+    "subject": {
+        "type": "mode",
+        "toolName": "ExitPlanMode",
+        "toolCallId": "subject-tool-call",
+        "fromMode": "subject-plan",
+        "toMode": "subject-execute",
+    },
+    "toolName": "ExitPlanMode",
+    "toolCallId": "top-level-tool-call",
+    "options": [
+        {
+            "value": "legacy-proceed",
+            "decision": "proceed",
+            "label": "Continue to execution",
+            "recommended": True,
+            "targetMode": "execute",
+            "optionId": "opt-0",
+        },
+        {
+            "value": "stay",
+            "label": "Stay in planning",
+            "optionId": "opt-1",
+        },
+    ],
+    "fromMode": "plan",
+    "toMode": "execute",
+    "inputSchema": {"type": "choices", "multiSelect": False},
+    "uiHints": {"variant": "plan", "severity": "info"},
+    "createdAtMs": 1787043213089,
+    "expiresAtMs": 1787043513089,
+    "schemaVersion": 2,
+    "actionable": True,
+    "lifecycleState": "pending",
+    "deliveryStatus": "not_dispatched",
+    "stateVersion": 1,
+    "sessionStateVersion": 16,
+    "updatedAtMs": 1787043213089,
+    "notifyPersisted": True,
+    "seq": 7279,
+    "ts": 1787043219471,
+}
+
+
+class TestModeSwitchInteraction:
+    def test_maps_captured_engine_payload_to_flat_bcn_event(self):
+        converter = DefaultStreamConverter()
+        payload = deepcopy(_CAPTURED_MODE_SWITCH_PAYLOAD)
+
+        event = converter.convert(
+            _interaction_chunk("interaction.requested", payload),
+            run_id="bcn-run",
+        )
+
+        assert event is not None
+        assert event.event == "interaction"
+        assert event.id == "1"
+        raw_data = json.loads(event.data)
+        assert isinstance(raw_data["ts"], int)
+        assert raw_data["ts"] != payload["ts"]
+        assert _data(event) == {
+            "runId": "bcn-run",
+            "seq": 1,
+            "interactionId": "int:14136f21-01a0-42ed-8000-14136f2102ed",
+            "kind": "mode_switch",
+            "phase": "requested",
+            "title": "Plan mode transition",
+            "description": "Transition from plan to execute",
+            "toolCallId": "top-level-tool-call",
+            "fromMode": "plan",
+            "targetMode": "execute",
+            "options": [
+                {
+                    "label": "Continue to execution",
+                    "decision": "proceed",
+                    "targetMode": "execute",
+                    "recommended": True,
+                },
+                {"label": "Stay in planning", "decision": "stay"},
+            ],
+        }
+
+    def test_uses_subject_fields_for_old_engine_payload(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-old-mode",
+                    "kind": "mode_switch",
+                    "subject": {
+                        "toolCallId": "subject-tool-call",
+                        "fromMode": "plan",
+                        "toMode": "execute",
+                    },
+                    "options": [{"label": "Continue", "value": "proceed"}],
+                },
+            ),
+            run_id="bcn-run",
+        )
+
+        assert event is not None
+        assert _data(event) == {
+            "runId": "bcn-run",
+            "seq": 1,
+            "interactionId": "int-old-mode",
+            "kind": "mode_switch",
+            "phase": "requested",
+            "toolCallId": "subject-tool-call",
+            "fromMode": "plan",
+            "targetMode": "execute",
+            "options": [{"label": "Continue", "decision": "proceed"}],
+        }
+
+    def test_invalid_top_level_fields_fall_back_to_subject(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-mode",
+                    "kind": "mode_switch",
+                    "toolCallId": 42,
+                    "fromMode": " ",
+                    "toMode": {"invalid": True},
+                    "subject": {
+                        "toolCallId": "subject-tool-call",
+                        "fromMode": "plan",
+                        "toMode": "execute",
+                    },
+                    "options": [{"label": "Continue", "decision": "proceed"}],
+                },
+            ),
+            run_id="bcn-run",
+        )
+
+        assert event is not None
+        data = _data(event)
+        assert data["toolCallId"] == "subject-tool-call"
+        assert data["fromMode"] == "plan"
+        assert data["targetMode"] == "execute"
+
+    def test_mode_option_optional_fields_are_validated(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-mode",
+                    "kind": "mode_switch",
+                    "options": [
+                        {
+                            "label": "Stay",
+                            "decision": "stay",
+                            "recommended": False,
+                        },
+                        {
+                            "label": "Continue",
+                            "decision": "proceed",
+                            "recommended": "yes",
+                            "targetMode": {"invalid": True},
+                        },
+                    ],
+                },
+            ),
+            run_id="bcn-run",
+        )
+
+        assert event is not None
+        assert _data(event)["options"] == [
+            {"label": "Stay", "decision": "stay", "recommended": False},
+            {"label": "Continue", "decision": "proceed"},
+        ]
+        assert "field_path=payload.options[1].recommended" in caplog.text
+        assert "field_path=payload.options[1].targetMode" in caplog.text
+        assert caplog.text.count("error_type=invalid_type") == 2
+
+    def test_invalid_options_drop_only_current_interaction_and_preserve_seq(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        cases = [
+            {},
+            {"options": None},
+            {"options": {"not": "a list"}},
+            {"options": []},
+            {
+                "options": [
+                    {"label": "Missing decision"},
+                    {"decision": "missing-label"},
+                ]
+            },
+        ]
+
+        for index, extra_payload in enumerate(cases):
+            converter = DefaultStreamConverter()
+            payload = {
+                "interactionId": f"int-invalid-mode-{index}",
+                "kind": "mode_switch",
+                **extra_payload,
+            }
+            interaction = converter.convert(
+                _interaction_chunk("interaction.requested", payload),
+                run_id="bcn-run",
+            )
+            chat = converter.convert(
+                StreamChunk(type="delta", content="after invalid mode switch"),
+                run_id="bcn-run",
+            )
+
+            assert interaction is None
+            assert chat is not None
+            assert chat.id == "1"
+            assert _data(chat)["seq"] == 1
+
+        assert caplog.text.count("error_type=no_valid_options") == len(cases)
+        assert "after invalid mode switch" not in caplog.text
+
+    def test_duplicate_decisions_replace_in_place_and_warn(
+        self,
+        monkeypatch,
+        caplog,
+    ):
+        _capture_interaction_logs(monkeypatch, caplog)
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-mode",
+                    "kind": "mode_switch",
+                    "options": [
+                        {"label": "Old", "decision": "same"},
+                        {"label": "Other", "decision": "other"},
+                        {
+                            "label": "New",
+                            "decision": "same",
+                            "recommended": True,
+                        },
+                    ],
+                },
+            ),
+            run_id="bcn-run",
+        )
+
+        assert event is not None
+        assert _data(event)["options"] == [
+            {"label": "New", "decision": "same", "recommended": True},
+            {"label": "Other", "decision": "other"},
+        ]
+        assert "field_path=payload.options[2].decision" in caplog.text
+        assert "error_type=duplicate_option_decision" in caplog.text
+
+    def test_invalid_decision_falls_back_to_value(self):
+        converter = DefaultStreamConverter()
+        event = converter.convert(
+            _interaction_chunk(
+                "interaction.requested",
+                {
+                    "interactionId": "int-mode",
+                    "kind": "mode_switch",
+                    "options": [
+                        {"label": "Continue", "decision": "", "value": "proceed"},
+                        {"label": "Stay", "decision": 42, "value": "stay"},
+                    ],
+                },
+            ),
+            run_id="bcn-run",
+        )
+
+        assert event is not None
+        assert _data(event)["options"] == [
+            {"label": "Continue", "decision": "proceed"},
+            {"label": "Stay", "decision": "stay"},
+        ]

--- a/src/baas/tests/unit/core/service/sse/test_default_converter.py
+++ b/src/baas/tests/unit/core/service/sse/test_default_converter.py
@@ -438,11 +438,11 @@ class TestInteractionBranch:
         assert data["event"] == "interaction.requested"
         assert data["payload"]["interactionId"] == "int-1"
 
-    def test_interaction_resolved_is_exposed_as_resolve(self):
+    def test_interaction_resolved_is_preserved(self):
         converter = DefaultStreamConverter()
         envelope = {
             "type": "event",
-            "event": "interaction.resolve",
+            "event": "interaction.resolved",
             "payload": {"sessionKey": "s", "interactionId": "int-1"},
         }
         event = converter.convert(
@@ -453,4 +453,4 @@ class TestInteractionBranch:
             run_id="run-1",
         )
         assert event is not None
-        assert event.event == "interaction.resolve"
+        assert event.event == "interaction.resolved"

--- a/src/baas/tests/unit/core/service/test_bot_interaction_service.py
+++ b/src/baas/tests/unit/core/service/test_bot_interaction_service.py
@@ -5,16 +5,68 @@ from dataclasses import replace
 
 import pytest
 
+from secbaas.community.api.bot_interaction import (
+    InteractionConflictError,
+    InteractionResolution,
+)
 from secbaas.community.core.repository.bot_run_interaction import (
     BotRunInteractionCreateResult,
     BotRunInteractionPayload,
     BotRunInteractionPayloadPatch,
     BotRunInteractionRecord,
 )
+
+
+def test_interaction_resolution_round_trips_ask_user_payload() -> None:
+    resolution = InteractionResolution(
+        kind="ask_user",
+        decision="submit",
+        answer="deploy_target: staging；components: web，worker",
+        message="deploy_target: staging；components: web，worker",
+        values={
+            "deploy_target": "staging",
+            "components": "web，worker",
+        },
+        answers={
+            "what's your deploy target?": "staging",
+            "whats' the components?": "web，worker",
+        },
+        selected_options=(("staging",), ("web", "worker")),
+    )
+
+    payload = resolution.to_dict()
+
+    assert payload == {
+        "kind": "ask_user",
+        "decision": "submit",
+        "answer": "deploy_target: staging；components: web，worker",
+        "message": "deploy_target: staging；components: web，worker",
+        "values": {
+            "deploy_target": "staging",
+            "components": "web，worker",
+        },
+        "answers": {
+            "what's your deploy target?": "staging",
+            "whats' the components?": "web，worker",
+        },
+        "selectedOptions": [["staging"], ["web", "worker"]],
+    }
+    assert InteractionResolution.from_dict(payload) == resolution
+
+
+def test_interaction_resolution_omits_absent_optional_fields() -> None:
+    resolution = InteractionResolution(kind="exec", decision="deny")
+
+    assert resolution.to_dict() == {"kind": "exec", "decision": "deny"}
+
+
 from secbaas.community.core.service.bot_interaction import (
-    BotInteractionService,
+    DefaultBotInteractionService,
     InteractionBadRequestError,
     InteractionDispatch,
+)
+from secbaas.community.core.service.bot_run._interaction_protocol import (
+    EngineInteractionRequestedEvent,
 )
 
 
@@ -104,7 +156,7 @@ def _requested_envelope(*, session_key: str = "payload-session") -> dict:
     }
 
 
-def _record_requested(repo: FakeRepo, service: BotInteractionService) -> None:
+def _record_requested(repo: FakeRepo, service: DefaultBotInteractionService) -> None:
     created = service.record_requested(
         session_key="s-1",
         interaction_id="int-1",
@@ -115,7 +167,14 @@ def _record_requested(repo: FakeRepo, service: BotInteractionService) -> None:
     assert created is True
 
 
-def _resolve(service: BotInteractionService, *, decision: str = "allow-once"):
+def _resolve(
+    service: DefaultBotInteractionService,
+    *,
+    decision: str = "allow-once",
+    resolution: InteractionResolution | None = None,
+    idempotency_key: str | None = None,
+):
+    resolution = resolution or InteractionResolution(decision=decision)
     request = {
         "type": "req",
         "id": "client-1",
@@ -123,20 +182,23 @@ def _resolve(service: BotInteractionService, *, decision: str = "allow-once"):
         "params": {
             "sessionKey": "s-1",
             "interactionId": "int-1",
-            "decision": decision,
+            "decision": resolution.decision,
         },
     }
+    if idempotency_key is not None:
+        request["params"]["idempotencyKey"] = idempotency_key
     return service.resolve(
         session_key="s-1",
         interaction_id="int-1",
-        decision=decision,
+        resolution=resolution,
         request_envelope=request,
+        idempotency_key=idempotency_key,
     )
 
 
 def test_record_requested_uses_explicit_identity_not_envelope_identity() -> None:
     repo = FakeRepo()
-    service = BotInteractionService(repo)
+    service = DefaultBotInteractionService(repo)
 
     service.record_requested(
         session_key="trusted-session",
@@ -158,7 +220,7 @@ def test_record_requested_uses_explicit_identity_not_envelope_identity() -> None
 
 def test_duplicate_requested_is_idempotent() -> None:
     repo = FakeRepo()
-    service = BotInteractionService(repo)
+    service = DefaultBotInteractionService(repo)
     kwargs = {
         "session_key": "s-1",
         "interaction_id": "int-1",
@@ -174,7 +236,7 @@ def test_duplicate_requested_is_idempotent() -> None:
 
 def test_http_resolve_moves_requested_to_queued() -> None:
     repo = FakeRepo()
-    service = BotInteractionService(repo)
+    service = DefaultBotInteractionService(repo)
     _record_requested(repo, service)
 
     result = _resolve(service)
@@ -184,13 +246,121 @@ def test_http_resolve_moves_requested_to_queued() -> None:
     assert record is not None
     assert record.state == "queued"
     assert record.payload.decision == "allow-once"
+    assert record.payload.resolution == {"decision": "allow-once"}
     assert record.payload.client_req is not None
     assert record.payload.client_req["id"] == "client-1"
 
 
+def test_provider_resolve_persists_complete_resolution_and_idempotency() -> None:
+    repo = FakeRepo()
+    service = DefaultBotInteractionService(repo)
+    _record_requested(repo, service)
+    resolution = InteractionResolution(
+        kind="exec",
+        decision="allow-once",
+    )
+
+    _resolve(service, resolution=resolution, idempotency_key="idem-1")
+
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.payload.resolution == resolution.to_dict()
+    assert record.payload.idempotency_key == "idem-1"
+
+
+def test_provider_resolve_same_key_and_resolution_is_idempotent() -> None:
+    repo = FakeRepo()
+    service = DefaultBotInteractionService(repo)
+    _record_requested(repo, service)
+    resolution = InteractionResolution(kind="exec", decision="allow-once")
+
+    first = _resolve(service, resolution=resolution, idempotency_key="idem-1")
+    second = _resolve(service, resolution=resolution, idempotency_key="idem-1")
+
+    assert first.interaction_id == "int-1"
+    assert second.interaction_id == "int-1"
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "queued"
+
+
+@pytest.mark.parametrize("terminal_state", ["failed", "expired"])
+def test_provider_resolve_same_key_remains_idempotent_after_terminal_state(
+    terminal_state: str,
+) -> None:
+    repo = FakeRepo()
+    service = DefaultBotInteractionService(repo)
+    _record_requested(repo, service)
+    resolution = InteractionResolution(kind="exec", decision="allow-once")
+    _resolve(service, resolution=resolution, idempotency_key="idem-1")
+    record = repo.rows[("s-1", "int-1")]
+    repo.rows[("s-1", "int-1")] = replace(record, state=terminal_state)
+
+    result = _resolve(
+        service,
+        resolution=resolution,
+        idempotency_key="idem-1",
+    )
+
+    assert result.interaction_id == "int-1"
+
+
+def test_provider_resolve_rereads_after_lost_transition_race() -> None:
+    repo = FakeRepo()
+    service = DefaultBotInteractionService(repo)
+    _record_requested(repo, service)
+    resolution = InteractionResolution(kind="exec", decision="allow-once")
+    original_transition = repo.transition
+
+    def transition_as_concurrent_winner(**kwargs):
+        updated = original_transition(**kwargs)
+        if kwargs["to_state"] == "queued":
+            return None
+        return updated
+
+    repo.transition = transition_as_concurrent_winner  # type: ignore[method-assign]
+
+    result = _resolve(
+        service,
+        resolution=resolution,
+        idempotency_key="idem-1",
+    )
+
+    assert result.interaction_id == "int-1"
+
+
+def test_provider_resolve_same_key_with_different_resolution_conflicts() -> None:
+    repo = FakeRepo()
+    service = DefaultBotInteractionService(repo)
+    _record_requested(repo, service)
+    _resolve(
+        service,
+        resolution=InteractionResolution(kind="exec", decision="allow-once"),
+        idempotency_key="idem-1",
+    )
+
+    with pytest.raises(InteractionConflictError):
+        _resolve(
+            service,
+            resolution=InteractionResolution(kind="exec", decision="deny"),
+            idempotency_key="idem-1",
+        )
+
+
+def test_provider_resolve_different_key_after_queue_conflicts() -> None:
+    repo = FakeRepo()
+    service = DefaultBotInteractionService(repo)
+    _record_requested(repo, service)
+    resolution = InteractionResolution(kind="exec", decision="allow-once")
+    _resolve(service, resolution=resolution, idempotency_key="idem-1")
+
+    with pytest.raises(InteractionConflictError):
+        _resolve(service, resolution=resolution, idempotency_key="idem-2")
+
+
 def test_http_resolve_rejects_unknown_decision() -> None:
     repo = FakeRepo()
-    service = BotInteractionService(repo)
+    service = DefaultBotInteractionService(repo)
     _record_requested(repo, service)
 
     with pytest.raises(InteractionBadRequestError):
@@ -201,9 +371,172 @@ def test_http_resolve_rejects_unknown_decision() -> None:
     assert record.state == "requested"
 
 
+def test_http_resolve_rejects_decision_when_allowed_set_is_empty() -> None:
+    repo = FakeRepo()
+    service = DefaultBotInteractionService(repo)
+    service.record_requested(
+        session_key="s-1",
+        interaction_id="int-1",
+        envelope=_requested_envelope(),
+        allowed_decisions=(),
+        expires_at_ms=int(time.time() * 1000) + 60_000,
+    )
+
+    with pytest.raises(InteractionBadRequestError):
+        _resolve(service, decision="hidden")
+
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "requested"
+
+
+def test_legacy_payload_without_allowed_decisions_remains_unrestricted() -> None:
+    repo = FakeRepo()
+    service = DefaultBotInteractionService(repo)
+    payload = BotRunInteractionPayload.from_dict({"requested": _requested_envelope()})
+    assert payload.allowed_decisions is None
+    assert "allowedDecisions" not in payload.to_dict()
+    repo.rows[("s-1", "int-1")] = BotRunInteractionRecord(
+        id=1,
+        session_key="s-1",
+        interaction_id="int-1",
+        state="requested",
+        payload=payload,
+    )
+
+    result = _resolve(service, decision="legacy-decision")
+
+    assert result.interaction_id == "int-1"
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "queued"
+    assert record.payload.decision == "legacy-decision"
+
+
+def test_explicit_empty_allowed_decisions_round_trip_and_reject_all() -> None:
+    repo = FakeRepo()
+    service = DefaultBotInteractionService(repo)
+    payload = BotRunInteractionPayload.from_dict(
+        {
+            "requested": _requested_envelope(),
+            "allowedDecisions": [],
+        }
+    )
+    assert payload.allowed_decisions == ()
+    assert payload.to_dict()["allowedDecisions"] == []
+    repo.rows[("s-1", "int-1")] = BotRunInteractionRecord(
+        id=1,
+        session_key="s-1",
+        interaction_id="int-1",
+        state="requested",
+        payload=BotRunInteractionPayload.from_dict(payload.to_dict()),
+    )
+
+    with pytest.raises(InteractionBadRequestError):
+        _resolve(service, decision="anything")
+
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "requested"
+    assert record.payload.allowed_decisions == ()
+
+
+@pytest.mark.parametrize("decision", ["submit", "cancel"])
+def test_ask_user_fixed_actions_can_be_queued(decision: str) -> None:
+    repo = FakeRepo()
+    service = DefaultBotInteractionService(repo)
+    event = EngineInteractionRequestedEvent.from_payload(
+        session_key="s-1",
+        payload={
+            "interactionId": "int-1",
+            "kind": "ask_user",
+            "questions": [{"header": "Name", "question": "Your name?"}],
+            "options": [{"label": "Hidden", "decision": "hidden"}],
+        },
+    )
+    service.record_requested(
+        session_key=event.session_key,
+        interaction_id=event.interaction_id,
+        envelope=event.envelope,
+        allowed_decisions=event.allowed_decisions,
+        expires_at_ms=event.expires_at_ms,
+    )
+
+    result = _resolve(service, decision=decision)
+
+    assert result.interaction_id == "int-1"
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "queued"
+    assert record.payload.allowed_decisions == ("submit", "cancel")
+
+
+def test_ask_user_hidden_top_level_decision_is_rejected() -> None:
+    repo = FakeRepo()
+    service = DefaultBotInteractionService(repo)
+    event = EngineInteractionRequestedEvent.from_payload(
+        session_key="s-1",
+        payload={
+            "interactionId": "int-1",
+            "kind": "ask_user",
+            "questions": [{"header": "Name", "question": "Your name?"}],
+            "options": [{"label": "Hidden", "decision": "hidden"}],
+        },
+    )
+    service.record_requested(
+        session_key=event.session_key,
+        interaction_id=event.interaction_id,
+        envelope=event.envelope,
+        allowed_decisions=event.allowed_decisions,
+        expires_at_ms=event.expires_at_ms,
+    )
+
+    with pytest.raises(InteractionBadRequestError):
+        _resolve(service, decision="hidden")
+
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "requested"
+
+
+def test_parsed_hidden_decision_is_rejected_but_visible_decision_resolves() -> None:
+    repo = FakeRepo()
+    service = DefaultBotInteractionService(repo)
+    payload = {
+        "interactionId": "int-1",
+        "kind": "exec",
+        "command": "make test",
+        "options": [
+            {"decision": "hidden"},
+            {"label": "Allow once", "decision": "allow-once"},
+        ],
+    }
+    event = EngineInteractionRequestedEvent.from_payload(
+        session_key="s-1",
+        payload=payload,
+    )
+    service.record_requested(
+        session_key=event.session_key,
+        interaction_id=event.interaction_id,
+        envelope=event.envelope,
+        allowed_decisions=event.allowed_decisions,
+        expires_at_ms=event.expires_at_ms,
+    )
+
+    with pytest.raises(InteractionBadRequestError):
+        _resolve(service, decision="hidden")
+
+    result = _resolve(service, decision="allow-once")
+    assert result.interaction_id == "int-1"
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "queued"
+    assert record.payload.allowed_decisions == ("allow-once",)
+
+
 def test_claim_returns_typed_dispatch_without_exposing_payload_layout() -> None:
     repo = FakeRepo()
-    service = BotInteractionService(repo)
+    service = DefaultBotInteractionService(repo)
     _record_requested(repo, service)
     _resolve(service)
 
@@ -212,16 +545,39 @@ def test_claim_returns_typed_dispatch_without_exposing_payload_layout() -> None:
     assert command == InteractionDispatch(
         session_key="s-1",
         interaction_id="int-1",
-        decision="allow-once",
+        resolution=InteractionResolution(decision="allow-once"),
     )
     record = repo.get(session_key="s-1", interaction_id="int-1")
     assert record is not None
     assert record.state == "dispatching"
 
 
+def test_claim_legacy_queued_payload_builds_decision_only_resolution() -> None:
+    repo = FakeRepo()
+    service = DefaultBotInteractionService(repo)
+    repo.rows[("s-1", "int-1")] = BotRunInteractionRecord(
+        id=1,
+        session_key="s-1",
+        interaction_id="int-1",
+        state="queued",
+        payload=BotRunInteractionPayload(
+            requested=_requested_envelope(),
+            decision="deny",
+        ),
+    )
+
+    command = service.claim_for_dispatch(session_key="s-1", interaction_id="int-1")
+
+    assert command == InteractionDispatch(
+        session_key="s-1",
+        interaction_id="int-1",
+        resolution=InteractionResolution(decision="deny"),
+    )
+
+
 def test_duplicate_resolved_transition_is_suppressed() -> None:
     repo = FakeRepo()
-    service = BotInteractionService(repo)
+    service = DefaultBotInteractionService(repo)
     _record_requested(repo, service)
     envelope = {
         "type": "event",
@@ -248,7 +604,7 @@ def test_duplicate_resolved_transition_is_suppressed() -> None:
 
 def test_late_engine_exchange_does_not_modify_terminal_payload() -> None:
     repo = FakeRepo()
-    service = BotInteractionService(repo)
+    service = DefaultBotInteractionService(repo)
     _record_requested(repo, service)
     _resolve(service)
     assert (
@@ -277,7 +633,7 @@ def test_late_engine_exchange_does_not_modify_terminal_payload() -> None:
 
 def test_expiry_can_close_a_queued_answer_before_dispatch() -> None:
     repo = FakeRepo()
-    service = BotInteractionService(repo)
+    service = DefaultBotInteractionService(repo)
     _record_requested(repo, service)
     _resolve(service)
 

--- a/src/baas/tests/unit/core/service/test_bot_interaction_service.py
+++ b/src/baas/tests/unit/core/service/test_bot_interaction_service.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import time
+from dataclasses import replace
+
+import pytest
+
+from secbaas.community.core.repository.bot_run_interaction import (
+    BotRunInteractionCreateResult,
+    BotRunInteractionPayload,
+    BotRunInteractionPayloadPatch,
+    BotRunInteractionRecord,
+)
+from secbaas.community.core.service.bot_interaction import (
+    BotInteractionService,
+    InteractionBadRequestError,
+    InteractionDispatch,
+)
+
+
+class FakeRepo:
+    def __init__(self) -> None:
+        self.rows: dict[tuple[str, str], BotRunInteractionRecord] = {}
+        self.next_id = 1
+
+    def create_requested(
+        self,
+        *,
+        session_key: str,
+        interaction_id: str,
+        payload: BotRunInteractionPayload,
+    ) -> BotRunInteractionCreateResult:
+        key = (session_key, interaction_id)
+        existing = self.rows.get(key)
+        if existing is not None:
+            return BotRunInteractionCreateResult(existing, created=False)
+        record = BotRunInteractionRecord(
+            id=self.next_id,
+            session_key=session_key,
+            interaction_id=interaction_id,
+            state="requested",
+            payload=payload,
+        )
+        self.rows[key] = record
+        self.next_id += 1
+        return BotRunInteractionCreateResult(record, created=True)
+
+    def get(
+        self, *, session_key: str, interaction_id: str
+    ) -> BotRunInteractionRecord | None:
+        return self.rows.get((session_key, interaction_id))
+
+    def transition(
+        self,
+        *,
+        session_key,
+        interaction_id,
+        from_states,
+        to_state,
+        patch,
+    ):
+        key = (session_key, interaction_id)
+        record = self.rows.get(key)
+        if record is None or record.state not in from_states:
+            return None
+        updated = replace(
+            record,
+            state=to_state,
+            payload=record.payload.merge(patch),
+        )
+        self.rows[key] = updated
+        return updated
+
+    def merge_payload(
+        self,
+        *,
+        session_key,
+        interaction_id,
+        allowed_states,
+        patch,
+    ):
+        key = (session_key, interaction_id)
+        record = self.rows.get(key)
+        if record is None or record.state not in allowed_states:
+            return None
+        updated = replace(record, payload=record.payload.merge(patch))
+        self.rows[key] = updated
+        return updated
+
+
+def _requested_envelope(*, session_key: str = "payload-session") -> dict:
+    return {
+        "type": "event",
+        "event": "interaction.requested",
+        "payload": {
+            "sessionKey": session_key,
+            "interactionId": "int-1",
+            "expiresAtMs": int(time.time() * 1000) + 60_000,
+            "options": [
+                {"decision": "allow-once", "label": "Allow once"},
+                {"decision": "deny", "label": "Deny"},
+            ],
+        },
+    }
+
+
+def _record_requested(repo: FakeRepo, service: BotInteractionService) -> None:
+    created = service.record_requested(
+        session_key="s-1",
+        interaction_id="int-1",
+        envelope=_requested_envelope(),
+        allowed_decisions=("allow-once", "deny"),
+        expires_at_ms=int(time.time() * 1000) + 60_000,
+    )
+    assert created is True
+
+
+def _resolve(service: BotInteractionService, *, decision: str = "allow-once"):
+    request = {
+        "type": "req",
+        "id": "client-1",
+        "method": "interaction.resolve",
+        "params": {
+            "sessionKey": "s-1",
+            "interactionId": "int-1",
+            "decision": decision,
+        },
+    }
+    return service.resolve(
+        session_key="s-1",
+        interaction_id="int-1",
+        decision=decision,
+        request_envelope=request,
+    )
+
+
+def test_record_requested_uses_explicit_identity_not_envelope_identity() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+
+    service.record_requested(
+        session_key="trusted-session",
+        interaction_id="trusted-interaction",
+        envelope=_requested_envelope(session_key="untrusted-payload-session"),
+        allowed_decisions=("allow-once",),
+        expires_at_ms=None,
+    )
+
+    assert (
+        repo.get(session_key="trusted-session", interaction_id="trusted-interaction")
+        is not None
+    )
+    assert (
+        repo.get(session_key="untrusted-payload-session", interaction_id="int-1")
+        is None
+    )
+
+
+def test_duplicate_requested_is_idempotent() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    kwargs = {
+        "session_key": "s-1",
+        "interaction_id": "int-1",
+        "envelope": _requested_envelope(),
+        "allowed_decisions": ("allow-once", "deny"),
+        "expires_at_ms": None,
+    }
+
+    assert service.record_requested(**kwargs) is True
+    assert service.record_requested(**kwargs) is False
+    assert len(repo.rows) == 1
+
+
+def test_http_resolve_moves_requested_to_queued() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    _record_requested(repo, service)
+
+    result = _resolve(service)
+
+    assert result.interaction_id == "int-1"
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "queued"
+    assert record.payload.decision == "allow-once"
+    assert record.payload.client_req is not None
+    assert record.payload.client_req["id"] == "client-1"
+
+
+def test_http_resolve_rejects_unknown_decision() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    _record_requested(repo, service)
+
+    with pytest.raises(InteractionBadRequestError):
+        _resolve(service, decision="always")
+
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "requested"
+
+
+def test_claim_returns_typed_dispatch_without_exposing_payload_layout() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    _record_requested(repo, service)
+    _resolve(service)
+
+    command = service.claim_for_dispatch(session_key="s-1", interaction_id="int-1")
+
+    assert command == InteractionDispatch(
+        session_key="s-1",
+        interaction_id="int-1",
+        decision="allow-once",
+    )
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "dispatching"
+
+
+def test_duplicate_resolved_transition_is_suppressed() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    _record_requested(repo, service)
+    envelope = {
+        "type": "event",
+        "event": "interaction.resolve",
+        "payload": {"interactionId": "different-id"},
+    }
+
+    assert (
+        service.mark_resolved(
+            session_key="s-1", interaction_id="int-1", envelope=envelope
+        )
+        is True
+    )
+    assert (
+        service.mark_resolved(
+            session_key="s-1", interaction_id="int-1", envelope=envelope
+        )
+        is False
+    )
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.payload.resolved == envelope
+
+
+def test_late_engine_exchange_does_not_modify_terminal_payload() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    _record_requested(repo, service)
+    _resolve(service)
+    assert (
+        service.claim_for_dispatch(session_key="s-1", interaction_id="int-1")
+        is not None
+    )
+    assert service.mark_resolved(
+        session_key="s-1",
+        interaction_id="int-1",
+        envelope={"type": "event", "event": "interaction.resolve", "payload": {}},
+    )
+
+    updated = service.record_engine_exchange(
+        session_key="s-1",
+        interaction_id="int-1",
+        engine_req={"type": "req"},
+        engine_res={"type": "res", "ok": True},
+    )
+
+    assert updated is False
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.payload.engine_req is None
+    assert record.payload.engine_res is None
+
+
+def test_expiry_can_close_a_queued_answer_before_dispatch() -> None:
+    repo = FakeRepo()
+    service = BotInteractionService(repo)
+    _record_requested(repo, service)
+    _resolve(service)
+
+    assert service.mark_expired(session_key="s-1", interaction_id="int-1") is True
+    record = repo.get(session_key="s-1", interaction_id="int-1")
+    assert record is not None
+    assert record.state == "expired"
+    assert record.payload.expire_reason == "interaction deadline elapsed"
+    assert service.claim_for_dispatch(session_key="s-1", interaction_id="int-1") is None

--- a/src/baas/tests/unit/core/service/test_bot_interaction_service.py
+++ b/src/baas/tests/unit/core/service/test_bot_interaction_service.py
@@ -225,7 +225,7 @@ def test_duplicate_resolved_transition_is_suppressed() -> None:
     _record_requested(repo, service)
     envelope = {
         "type": "event",
-        "event": "interaction.resolve",
+        "event": "interaction.resolved",
         "payload": {"interactionId": "different-id"},
     }
 
@@ -258,7 +258,7 @@ def test_late_engine_exchange_does_not_modify_terminal_payload() -> None:
     assert service.mark_resolved(
         session_key="s-1",
         interaction_id="int-1",
-        envelope={"type": "event", "event": "interaction.resolve", "payload": {}},
+        envelope={"type": "event", "event": "interaction.resolved", "payload": {}},
     )
 
     updated = service.record_engine_exchange(


### PR DESCRIPTION
## Problem

BaaS previously forwarded Engine interaction envelopes almost unchanged, while BCN Provider 2.0 requires flat `event: interaction` SSE data. As a result, BCN could not reliably render or resolve `ask_user`, command approval, and mode-switch interactions.

The reverse path was also missing: `/bcn/downlink` did not accept `interaction.resolve`, and the existing decision-only persistence path could not retain ask-user answers until the WebSocket owner delivered them to Engine.

Mode-switch completion had one additional compatibility gap. Current Engine versions emit `mode_transition.resolved`, but BaaS only subscribed to `interaction.resolved`; the accepted mode-transition RPC could terminalize the database record while the canonical BCN resolved SSE was still lost.

Ask-user answers also conflated two separate concepts: the outer `questionId` identity was reused as display text. This is invalid for Providers such as BaaS, where `header` is required and may differ from `questionId`.

## Solution

- Convert Engine `interaction.requested` and `interaction.resolved` events into BCN-compatible SSE frames for `ask_user`, `exec`, and `mode_switch`.
- Normalize legacy and deployed Engine option shapes, including `decision > value > label` option fallback, exec compatibility decisions, and mode-switch target metadata.
- Give BaaS-produced ask-user questions independent deterministic IDs (`question_<source position>`) and require a non-empty Provider-owned header. Missing headers fail closed without consuming an SSE sequence; duplicate headers remain distinct questions and produce only sanitized warnings.
- Register JSON `interaction.resolve` on `/bcn/downlink` and validate the full BCN Provider webhook.
- Canonicalize ask-user answers in BCS from the stored requested question before fingerprinting and Provider delivery. Stored `question` and non-empty stored `header` override untrusted Frontend fields; BCS never derives a header from `questionId`, question text, or Frontend input.
- Require each BaaS ask-user answer to contain a non-empty `header`. Build Engine `answer`, `message`, and `values` from that header; keep `answers` keyed by the full question and preserve two-dimensional `selectedOptions`. Duplicate headers retain all textual summaries while `values` uses deterministic last-write-wins with content-free logging.
- Send exec decisions through `interaction.resolve`; send mode switches through `mode_transition.resolve` with `transitionId`.
- Subscribe to the raw Engine `mode_transition.resolved` event, preserve its original envelope, and map lifecycle phases such as `proceeded` to the canonical BCN `phase: resolved` with the Engine decision.
- Deliver a mode-switch terminal SSE once for a request exposed on the same active stream, even if the accepted RPC fallback won the database race; suppress replayed and unsolicited terminal events with stream-local state.
- Persist the complete normalized resolution and idempotency key, then let the Engine WebSocket owner claim and dispatch it. Existing decision-only queued records remain compatible.
- Return finite, sanitized Provider acknowledgements for invalid or rejected interaction requests, redact interaction answer content from logs, retain accepted mode-switch RPC terminalization for older Engines, and make identical retries safe across terminal states and transition races.
- Keep Engine source and wire contracts unchanged; all translation remains in BaaS and BCS boundaries.

## Validation

- Complete BaaS unit suite from the main implementation: **8181 passed, 3 skipped, 8 xpassed, 0 failed**.
- Complete BaaS SSE and bot-run regression suites from the main implementation: **1003 passed, 8 xpassed, 0 failed**.
- Latest answer-header affected BaaS regression: **227 passed**.
- Latest BCN `/bcn/downlink` ASGI interaction resolve regression: **2 passed**.
- Latest BCS interaction service tests: **27 passed**.
- Latest BCS Provider HTTP tests: **49 passed**.
- Latest focused BCS WebSocket compatibility test: **1 passed**.
- Ruff check and format passed for all nine Python files changed by the answer-header work.
- `git diff --check`, the lint-only pre-push SAST gate, and the no-Engine-diff audit passed.
- Independent code review reported no remaining Critical, Important, or Minor findings.

The full BaaS unit suite reports eight existing warnings from third-party deprecations and intentionally short JWT test keys. The previously recorded architecture formatting baseline remains outside this PR's changed lines.

## Compatibility and risk

The SSE wire format intentionally changes from nested Engine envelopes to BCN Provider 2.0 flat interaction events. Consumers of `event: interaction.requested` or `data.payload` must migrate to `event: interaction`.

The BaaS ask-user resolve boundary now requires `answers[*].header`. This is an intentional Provider-specific tightening: BCN keeps header optional globally, while BaaS only publishes requested questions with non-empty headers. Deploy BCS before the strict BaaS version so stored requested headers are canonicalized into Provider resolve requests. There is no header fallback in either component.

Legacy Engine option variants and existing decision-only queued records remain supported. Older Engines that do not emit `mode_transition.resolved` still terminalize mode switches from an accepted RPC response; current Engines additionally produce one canonical resolved SSE without overwriting the first database terminal evidence. Provider idempotency prevents duplicate Engine dispatch. Malformed requests fail closed with sanitized finite acknowledgements, and answer content and interaction options are excluded from logs.

## Spec

- `src/baas/docs/2026-08-19-baas-bcn-interaction-sse-design.md`
- `src/baas/docs/2026-08-19-baas-bcn-interaction-sse-implementation.md`
- `src/baas/docs/2026-08-20-bcn-interaction-resolve-design.md`
- `src/baas/docs/2026-08-20-bcn-interaction-resolve-implementation.md`
- `src/baas/docs/2026-08-20-mode-transition-resolved-sse-design.md`
- `src/baas/docs/2026-08-20-mode-transition-resolved-sse-implementation.md`
- `src/baas/docs/2026-08-20-bcn-answer-header-design.md`
- `src/baas/docs/2026-08-20-bcn-answer-header-implementation.md`
- `src/bcs/docs/bcs-provider-2.0-sse-protocol.md`
