### PR TITLE
fix(aicoding): exclude declared repo working copies from build rsync

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -238,7 +238,10 @@ class BotBuildService:
         rsync_append = parse_build_rsync_excludes_from_ext(ext)
 
         # 传递 Bot 级别追加项（合并模式）
-        build_plan = provider.get_build_plan(build_rsync_excludes_append=rsync_append)
+        build_plan = provider.get_build_plan(
+            build_rsync_excludes_append=rsync_append,
+            bot=bot,
+        )
         engine_type = build_plan.engine_type
         logger.info(
             f"[BotBuildService.build] Starting build: "
@@ -1273,7 +1276,10 @@ class BotBuildService:
         rsync_append = parse_build_rsync_excludes_from_ext(ext)
 
         # 传递 Bot 级别追加项（合并模式）
-        build_plan = provider.get_build_plan(build_rsync_excludes_append=rsync_append)
+        build_plan = provider.get_build_plan(
+            build_rsync_excludes_append=rsync_append,
+            bot=bot,
+        )
         deadline = time.monotonic() + _DRAFT_RESTORE_TIMEOUT_SECONDS
 
         def remaining_timeout() -> float:

--- a/src/backend/src/agentclaw/community/core/workspace/engine_sandbox.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engine_sandbox.py
@@ -63,7 +63,7 @@ class EngineSandboxProvider(Protocol):
     def get_build_plan(
         self,
         build_rsync_excludes_append: list[str] | None = None,
-        bot: Any = None,
+        bot: dict[str, Any] | None = None,
     ) -> EngineBuildPlan:
         """Return build plan with optional Bot-level build_rsync_excludes append.
 
@@ -71,6 +71,14 @@ class EngineSandboxProvider(Protocol):
             build_rsync_excludes_append: Bot-level excludes from ac_bots.ext.
                 可选参数，为 None 时使用模块级默认值。
                 **合并语义**：与默认值合并（去重），而非完全覆盖。
+            bot: 可选的 per-Bot 上下文，实现可用来定制 build plan（例如派生
+                额外的 rsync excludes）。为 None 表示无 Bot 上下文，实现应回退
+                到默认行为。**默认 no-op 语义**：不消费本参数的实现（如
+                openclaw / claude_code）必须接受并忽略它；只有需要 per-Bot
+                定制的实现（如 aicoding）才会读取它。当前 aicoding 据此从
+                ``bot["template_config"]``（ac_templates.ext）派生 workspace
+                下声明仓库的排除项，且仅在 get_build_plan 内部消费，不会把
+                该参数透出到更上层。
         """
         ...
 

--- a/src/backend/src/agentclaw/community/core/workspace/engine_sandbox.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engine_sandbox.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 
 @dataclass(frozen=True)
@@ -63,6 +63,7 @@ class EngineSandboxProvider(Protocol):
     def get_build_plan(
         self,
         build_rsync_excludes_append: list[str] | None = None,
+        bot: Any = None,
     ) -> EngineBuildPlan:
         """Return build plan with optional Bot-level build_rsync_excludes append.
 

--- a/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlparse
 
 from agentclaw.community.core.workspace.engine_sandbox import DirectoryItem, EngineBuildPlan, ReadOnlyRule
 from agentclaw.community.di import config as cfg
@@ -85,6 +87,84 @@ def _make_aicoding_build_plan(rsync_excludes: list[str]) -> EngineBuildPlan:
 _AICODING_BUILD_PLAN = _make_aicoding_build_plan(list(_AICODING_RSYNC_EXCLUDES))
 
 
+def _repo_dirname_from_url(url: Any) -> str:
+    """Return the directory name git would use when cloning ``url``.
+
+    aicoding bots clone their code repos directly into ``.aicoding/workspace/``
+    under the repo's last path segment (``.git`` stripped). Handles https and
+    scp-like ssh forms, trailing slashes, query strings. Returns "" for unusable
+    input so callers can skip it.
+    """
+    if not isinstance(url, str):
+        return ""
+    value = url.strip()
+    if not value:
+        return ""
+
+    if "://" in value:
+        path = urlparse(value).path
+    elif ":" in value:
+        # git@host:owner/repo(.git)
+        path = value.split(":", 1)[1]
+    else:
+        path = value
+
+    path = path.split("?", 1)[0].split("#", 1)[0].strip().rstrip("/")
+    if path.endswith(".git"):
+        path = path[: -len(".git")]
+
+    name = path.rsplit("/", 1)[-1].strip()
+    if name in ("", ".", "..") or "/" in name:
+        return ""
+    return name
+
+
+def _repo_workspace_excludes_for_bot(bot: Any) -> list[str]:
+    """Derive ``workspace/<repo>`` rsync excludes from a bot's template_config.
+
+    aicoding clones the repos declared in the bot's template config
+    (``ac_templates.ext``: ``backend_repo`` / ``frontend_repo`` / ``lib_repo``
+    plus template-factory aliases) into ``.aicoding/workspace/<repo>``. Those
+    working trees are re-cloned/mounted by the runtime, so the build rsync must
+    NOT bake them into the published artifact (the static
+    ``workspace/*/.git/`` exclude only skips ``.git``, not the whole tree).
+    This reads the same repo URLs the rest of the platform uses (via
+    ``bot_management.utils._extract_code_repo_urls``) and maps each to its clone
+    directory name.
+
+    The repo source is ``bot["template_config"]`` — i.e. the ``ac_templates.ext``
+    column attached by ``BotService.get_bot``. It is deliberately NOT read from
+    ``bot["ext"]`` (``ac_bots.ext``), which is a different row carrying
+    operator/bot-level config, not the template's repo declarations.
+
+    This is aicoding-only knowledge: it is intentionally kept inside this module
+    rather than leaked into the shared engine registry or build service.
+    """
+    if not isinstance(bot, dict):
+        return []
+
+    # bot["template_config"] == ac_templates.ext (attached by BotService.get_bot
+    # via _template_service.get_template(...).get("ext")). This is the canonical
+    # source for repo declarations; do not fall back to ac_bots.ext.
+    template_config = bot.get("template_config")
+    if not isinstance(template_config, dict) or not template_config:
+        return []
+
+    # Lazy import: bot_management.utils pulls in requests/capabilities; keep it
+    # out of this module's import path.
+    from agentclaw.community.core.bot_management.utils import _extract_code_repo_urls
+
+    excludes: list[str] = []
+    seen: set[str] = set()
+    for url in _extract_code_repo_urls(template_config):
+        name = _repo_dirname_from_url(url)
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        excludes.append(f"workspace/{name}")
+    return excludes
+
+
 class AICodingSandboxProvider:
     """Workspace provider for the AICoding engine.
 
@@ -113,6 +193,7 @@ class AICodingSandboxProvider:
     def get_build_plan(
         self,
         build_rsync_excludes_append: list[str] | None = None,
+        bot: Any = None,
     ) -> EngineBuildPlan:
         # 合并模式：默认值 + 自定义项（去重）
         excludes = list(_AICODING_RSYNC_EXCLUDES)
@@ -121,6 +202,21 @@ class AICodingSandboxProvider:
             for item in build_rsync_excludes_append:
                 if item not in excludes:
                     excludes.append(item)
+        # aicoding 特有：bot 的 template_config 里声明的代码仓库被 clone
+        # 进 .aicoding/workspace/<repo>，其工作副本不应进入发布物。
+        # 这段是额外保护，任何异常都必须降级为"不追加仓库排除"，绝不能
+        # 让 get_build_plan 抛错而影响 build()/restore_draft() 主链路。
+        try:
+            for item in _repo_workspace_excludes_for_bot(bot):
+                if item not in excludes:
+                    excludes.append(item)
+        except Exception as e:  # noqa: BLE001 - 兜底，绝不影响构建主链路
+            logger.warning(
+                "[AICodingSandboxProvider.get_build_plan] derive repo workspace "
+                "excludes failed, falling back to excludes without them: %s",
+                e,
+                exc_info=True,
+            )
         return _make_aicoding_build_plan(excludes)
 
     def _normalize_sub_path(self, sub_path: str) -> str:

--- a/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
@@ -119,7 +119,66 @@ def _repo_dirname_from_url(url: Any) -> str:
     return name
 
 
-def _repo_workspace_excludes_for_bot(bot: Any) -> list[str]:
+# --- repo URL extraction (self-contained) -----------------------------------
+# Mirrored from ``bot_management.utils._extract_code_repo_urls`` so this engine
+# does NOT reach into another sub-domain's private symbol (arch Rule 15: no
+# hidden coupling via private internals). If the platform helper's repo
+# keys/markers evolve, keep this local copy in sync.
+_REPO_URL_KEYS: tuple[str, ...] = ("repo_url", "url", "git_url", "ssh_url")
+_REPO_DECL_KEYS: tuple[str, ...] = ("backend_repo", "frontend_repo", "lib_repo")
+_REPO_DECL_FACTORY_KEYS: tuple[str, ...] = (
+    "repos",
+    "init_repos",
+    "application_repo_urls",
+)
+_TEMPLATE_FACTORY_MARKER_KEYS: frozenset[str] = frozenset({
+    "template_key",
+    "template_uid",
+    "template_version_id",
+    "template_version",
+})
+
+
+def _extract_code_repo_urls(template_config: Any) -> list[str]:
+    """Return the code-repo URLs declared in ``template_config``.
+
+    Self-contained mirror of ``bot_management.utils._extract_code_repo_urls``;
+    kept local so this engine depends on no other module's private internals.
+    Reads ``backend_repo`` / ``frontend_repo`` / ``lib_repo`` (legacy, dict
+    items only) plus the template-factory aliases ``repos`` / ``init_repos`` /
+    ``application_repo_urls`` (string or dict items) exactly as the platform
+    helper does.
+    """
+    if not isinstance(template_config, dict):
+        return []
+    keys = _REPO_DECL_KEYS
+    if any(marker in template_config for marker in _TEMPLATE_FACTORY_MARKER_KEYS):
+        keys = keys + _REPO_DECL_FACTORY_KEYS
+    urls: list[str] = []
+    for key in keys:
+        value = template_config.get(key)
+        if not isinstance(value, list):
+            continue
+        for item in value:
+            # Legacy repo keys accept only dict items; template-factory alias
+            # keys may also use direct string items.
+            if isinstance(item, str) and key in _REPO_DECL_KEYS:
+                continue
+            url = ""
+            if isinstance(item, str):
+                url = item.strip()
+            elif isinstance(item, dict):
+                for url_key in _REPO_URL_KEYS:
+                    v = item.get(url_key)
+                    if isinstance(v, str) and v.strip():
+                        url = v.strip()
+                        break
+            if url:
+                urls.append(url)
+    return urls
+
+
+def _repo_workspace_excludes_for_bot(bot: dict[str, Any] | None) -> list[str]:
     """Derive ``workspace/<repo>`` rsync excludes from a bot's template_config.
 
     aicoding clones the repos declared in the bot's template config
@@ -128,9 +187,8 @@ def _repo_workspace_excludes_for_bot(bot: Any) -> list[str]:
     working trees are re-cloned/mounted by the runtime, so the build rsync must
     NOT bake them into the published artifact (the static
     ``workspace/*/.git/`` exclude only skips ``.git``, not the whole tree).
-    This reads the same repo URLs the rest of the platform uses (via
-    ``bot_management.utils._extract_code_repo_urls``) and maps each to its clone
-    directory name.
+    This reads the repo URLs via the self-contained ``_extract_code_repo_urls``
+    helper above and maps each to its clone directory name.
 
     The repo source is ``bot["template_config"]`` — i.e. the ``ac_templates.ext``
     column attached by ``BotService.get_bot``. It is deliberately NOT read from
@@ -149,10 +207,6 @@ def _repo_workspace_excludes_for_bot(bot: Any) -> list[str]:
     template_config = bot.get("template_config")
     if not isinstance(template_config, dict) or not template_config:
         return []
-
-    # Lazy import: bot_management.utils pulls in requests/capabilities; keep it
-    # out of this module's import path.
-    from agentclaw.community.core.bot_management.utils import _extract_code_repo_urls
 
     excludes: list[str] = []
     seen: set[str] = set()

--- a/src/backend/src/agentclaw/community/core/workspace/engines/claude_code.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/claude_code.py
@@ -134,7 +134,7 @@ class ClaudeCodeSandboxProvider:
     def get_build_plan(
         self,
         build_rsync_excludes_append: list[str] | None = None,
-        bot: Any = None,
+        bot: dict[str, Any] | None = None,
     ) -> EngineBuildPlan:
         # 合并模式：默认值 + 自定义项（去重）
         excludes = list(_CLAUDE_CODE_RSYNC_EXCLUDES)

--- a/src/backend/src/agentclaw/community/core/workspace/engines/claude_code.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/claude_code.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Any
 
 from pathlib import Path, PurePosixPath
 
@@ -133,6 +134,7 @@ class ClaudeCodeSandboxProvider:
     def get_build_plan(
         self,
         build_rsync_excludes_append: list[str] | None = None,
+        bot: Any = None,
     ) -> EngineBuildPlan:
         # 合并模式：默认值 + 自定义项（去重）
         excludes = list(_CLAUDE_CODE_RSYNC_EXCLUDES)

--- a/src/backend/src/agentclaw/community/core/workspace/engines/openclaw.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/openclaw.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import fnmatch
 from pathlib import Path, PurePosixPath
+from typing import Any
 
 from agentclaw.community.core.workspace.engine_sandbox import DirectoryItem, EngineBuildPlan, ReadOnlyRule
 from agentclaw.community.di import config as cfg
@@ -94,6 +95,7 @@ class OpenClawSandboxProvider:
     def get_build_plan(
         self,
         build_rsync_excludes_append: list[str] | None = None,
+        bot: Any = None,
     ) -> EngineBuildPlan:
         # 合并模式：默认值 + 自定义项（去重）
         excludes = list(_OPENCLAW_RSYNC_EXCLUDES)

--- a/src/backend/src/agentclaw/community/core/workspace/engines/openclaw.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/openclaw.py
@@ -95,7 +95,7 @@ class OpenClawSandboxProvider:
     def get_build_plan(
         self,
         build_rsync_excludes_append: list[str] | None = None,
-        bot: Any = None,
+        bot: dict[str, Any] | None = None,
     ) -> EngineBuildPlan:
         # 合并模式：默认值 + 自定义项（去重）
         excludes = list(_OPENCLAW_RSYNC_EXCLUDES)

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_openclaw_stage_configs.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_openclaw_stage_configs.py
@@ -145,7 +145,7 @@ class TestGenerateOpenClawStageConfigs:
         class DummyProvider:
             plan: EngineBuildPlan
 
-            def get_build_plan(self, build_rsync_excludes_append=None) -> EngineBuildPlan:
+            def get_build_plan(self, build_rsync_excludes_append=None, bot=None, **kwargs) -> EngineBuildPlan:
                 return self.plan
 
         plan = EngineBuildPlan(
@@ -203,7 +203,7 @@ class TestGenerateOpenClawStageConfigs:
         class DummyProvider:
             plan: EngineBuildPlan
 
-            def get_build_plan(self, build_rsync_excludes_append=None) -> EngineBuildPlan:
+            def get_build_plan(self, build_rsync_excludes_append=None, bot=None, **kwargs) -> EngineBuildPlan:
                 return self.plan
 
         plan = EngineBuildPlan(
@@ -255,7 +255,7 @@ class TestGenerateOpenClawStageConfigs:
         class DummyProvider:
             plan: EngineBuildPlan
 
-            def get_build_plan(self, build_rsync_excludes_append=None) -> EngineBuildPlan:
+            def get_build_plan(self, build_rsync_excludes_append=None, bot=None, **kwargs) -> EngineBuildPlan:
                 return self.plan
 
         plan = EngineBuildPlan(
@@ -315,7 +315,7 @@ class TestBuildMigrationPathWhitelist:
         class DummyProvider:
             plan: EngineBuildPlan
 
-            def get_build_plan(self, build_rsync_excludes_append=None) -> EngineBuildPlan:
+            def get_build_plan(self, build_rsync_excludes_append=None, bot=None, **kwargs) -> EngineBuildPlan:
                 return self.plan
 
         plan = EngineBuildPlan(

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_rsync_excludes.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_rsync_excludes.py
@@ -358,3 +358,61 @@ def test_build_uses_original_active_engine_for_nas_source_bucket_when_routed_to_
         "2",
         "aicoding",
     )
+
+
+# ---- repo-exclude integration via get_build_plan(bot=...) ----
+
+
+@pytest.mark.unit
+class TestBotBuildServiceBotParamForwarding:
+    """验证 build()/restore_draft() 把 bot 透传给 get_build_plan，
+    repo 排除由 aicoding provider 内部消费，build 服务不感知。"""
+
+    def _setup(self):
+        mock_provider = MagicMock()
+        mock_build_plan = EngineBuildPlan(
+            engine_type="openclaw",
+            source_root_name=".openclaw",
+            migration_subpath="openclaw",
+            workspace_subdir="workspace",
+            mcp_config_relpath="workspace/config/mcporter.json",
+            skill_source_relpath="workspace/skills",
+            skill_target_relpath="workspace/skills",
+            rsync_excludes=["workspace/memory/", "logs/"],
+        )
+        mock_provider.get_build_plan.return_value = mock_build_plan
+        service = BotBuildService.__new__(BotBuildService)
+        service._device_service = MagicMock()
+        service._migrate_bot_instance = MagicMock(return_value=True)
+        service._generate_mcp_config = MagicMock(return_value=True)
+        service._generate_openclaw_stage_configs = MagicMock(return_value=True)
+        service._get_migration_path_base = MagicMock(return_value="/fake/path")
+        service._resolve_sandbox_provider = MagicMock(return_value=mock_provider)
+        return service, mock_provider
+
+    def test_build_forwards_bot_to_get_build_plan(self):
+        bot = {
+            "bot_id": "b", "entity_id": "e", "entity_type": "staff",
+            "device_id": "d",
+            "ext": {"build_rsync_excludes": ["custom/"]},
+            "template_config": {"backend_repo": [
+                {"repo_url": "https://code.alipay.com/ASF/repo.git"}
+            ]},
+        }
+        service, mock_provider = self._setup()
+        try:
+            service.build(bot, version=1)
+        except Exception:
+            pass
+        mock_provider.get_build_plan.assert_called_once()
+        assert mock_provider.get_build_plan.call_args.kwargs["bot"] is bot
+
+    def test_build_forwards_bot_even_without_repos(self):
+        bot = {"bot_id": "b", "entity_id": "e", "entity_type": "staff",
+               "device_id": "d"}
+        service, mock_provider = self._setup()
+        try:
+            service.build(bot, version=1)
+        except Exception:
+            pass
+        assert mock_provider.get_build_plan.call_args.kwargs["bot"] is bot

--- a/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
+++ b/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
@@ -210,6 +210,50 @@ class TestAICodingProvider:
         ):
             assert path in rule_paths
 
+    def test_build_plan_excludes_repo_workspace_dirs_from_template_config(self):
+        """aicoding 注入 template_config 声明仓库的 workspace/<repo> 排除。"""
+        provider = AICodingSandboxProvider(workspace=_workspace())
+        bot = {
+            "template_config": {
+                "backend_repo": [
+                    {"repo_url": "https://code.alipay.com/ASF-Service-Platform/aixcore"}
+                ],
+                "frontend_repo": [
+                    {"repo_url": "https://code.alipay.com/ASF/web-frontend.git"}
+                ],
+            }
+        }
+        plan = provider.get_build_plan(bot=bot)
+        assert "workspace/aixcore" in plan.rsync_excludes
+        assert "workspace/web-frontend" in plan.rsync_excludes
+
+    def test_build_plan_without_bot_keeps_default_excludes(self):
+        """无 bot 时 aicoding 不追加额外仓库排除。"""
+        provider = AICodingSandboxProvider(workspace=_workspace())
+        plan = provider.get_build_plan()
+        assert "workspace/aixcore" not in plan.rsync_excludes
+
+    def test_build_plan_dedupes_repeated_repo(self):
+        """同一仓库在多个 key 声明时只追加一次。"""
+        provider = AICodingSandboxProvider(workspace=_workspace())
+        bot = {
+            "template_config": {
+                "backend_repo": [{"repo_url": "https://code.alipay.com/ASF/repo.git"}],
+                "lib_repo": [{"repo_url": "https://code.alipay.com/ASF/repo"}],
+            }
+        }
+        plan = provider.get_build_plan(bot=bot)
+        assert plan.rsync_excludes.count("workspace/repo") == 1
+
+    def test_build_plan_ignores_ac_bots_ext_template_config(self):
+        """bot.ext (ac_bots.ext) 不作为仓库来源，即便里面有 template_config 也不读取。"""
+        provider = AICodingSandboxProvider(workspace=_workspace())
+        bot = {"ext": {"template_config": {"lib_repo": [
+            {"repo_url": "https://code.alipay.com/ASF/lib.git"}
+        ]}}}
+        plan = provider.get_build_plan(bot=bot)
+        assert "workspace/lib" not in plan.rsync_excludes
+
 _OPENCLAW_ROOT = cfg.WorkspaceConfig().openclaw_root
 _CLAUDE_CODE_ROOT = cfg.WorkspaceConfig().claude_code_root
 
@@ -637,3 +681,33 @@ class TestAICodingProviderChangedLineCoverage:
         )
 
         assert await provider.list_directory() == []
+
+
+@pytest.mark.unit
+class TestGetBuildPlanBotParamCrossEngine:
+    """get_build_plan(bot=...) 在所有 provider 上都可用；只有 aicoding 消费它。"""
+
+    def test_openclaw_ignores_bot_repo(self):
+        provider = OpenClawSandboxProvider(workspace=_workspace())
+        bot = {"template_config": {"backend_repo": [
+            {"repo_url": "https://code.alipay.com/ASF/repo.git"}
+        ]}}
+        plan = provider.get_build_plan(bot=bot)
+        assert "workspace/repo" not in plan.rsync_excludes
+
+    def test_claude_code_ignores_bot_repo(self):
+        provider = ClaudeCodeSandboxProvider(workspace=_workspace())
+        bot = {"template_config": {"backend_repo": [
+            {"repo_url": "https://code.alipay.com/ASF/repo.git"}
+        ]}}
+        plan = provider.get_build_plan(bot=bot)
+        assert "workspace/repo" not in plan.rsync_excludes
+
+    def test_calling_without_bot_still_works(self):
+        for provider in (
+            OpenClawSandboxProvider(workspace=_workspace()),
+            ClaudeCodeSandboxProvider(workspace=_workspace()),
+            AICodingSandboxProvider(workspace=_workspace()),
+        ):
+            plan = provider.get_build_plan()
+            assert plan.rsync_excludes  # non-empty defaults preserved

--- a/src/backend/tests/community/core/workspace/test_repo_workspace_excludes.py
+++ b/src/backend/tests/community/core/workspace/test_repo_workspace_excludes.py
@@ -1,16 +1,19 @@
 """Unit tests for repo-derived workspace rsync excludes.
 
 Covers ``parse_repo_workspace_excludes`` / ``_repo_dirname_from_url`` in
-``agentclaw.community.core.workspace.engines``: code repositories declared in a
-bot's ``template_config`` (``backend_repo`` / ``frontend_repo`` / ``lib_repo``,
-plus template-factory aliases) must produce ``workspace/<repo>`` excludes so the
-build rsync does not bake cloned repo working copies into the artifact.
+``agentclaw.community.core.workspace.engines.aicoding``: code repositories
+declared in a bot's ``template_config`` (``backend_repo`` / ``frontend_repo`` /
+``lib_repo``, plus template-factory aliases) must produce ``workspace/<repo>``
+excludes so the build rsync does not bake cloned repo working copies into the
+artifact. URL extraction is mirrored locally (self-contained, no cross-module
+dependency on bot_management).
 """
 from __future__ import annotations
 
 import pytest
 
 from agentclaw.community.core.workspace.engines.aicoding import (
+    _extract_code_repo_urls,
     _repo_dirname_from_url,
     _repo_workspace_excludes_for_bot as parse_repo_workspace_excludes,
 )
@@ -151,7 +154,7 @@ class TestAixcoreEndToEnd:
 
     def test_extract_repo_url_to_aixcore_dirname(self):
         # repo_url 形如 [{"repo_url": "..."}] -> URL -> 仓库名 aixcore
-        from agentclaw.community.core.bot_management.utils import _extract_code_repo_urls
+        # 用 aicoding 自包含的 _extract_code_repo_urls（不依赖 bot_management）
         urls = _extract_code_repo_urls(self.SAMPLE)
         assert urls == ["https://code.alipay.com/ASF-Service-Platform/aixcore"]
         assert _repo_dirname_from_url(urls[0]) == "aixcore"

--- a/src/backend/tests/community/core/workspace/test_repo_workspace_excludes.py
+++ b/src/backend/tests/community/core/workspace/test_repo_workspace_excludes.py
@@ -1,0 +1,222 @@
+"""Unit tests for repo-derived workspace rsync excludes.
+
+Covers ``parse_repo_workspace_excludes`` / ``_repo_dirname_from_url`` in
+``agentclaw.community.core.workspace.engines``: code repositories declared in a
+bot's ``template_config`` (``backend_repo`` / ``frontend_repo`` / ``lib_repo``,
+plus template-factory aliases) must produce ``workspace/<repo>`` excludes so the
+build rsync does not bake cloned repo working copies into the artifact.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.workspace.engines.aicoding import (
+    _repo_dirname_from_url,
+    _repo_workspace_excludes_for_bot as parse_repo_workspace_excludes,
+)
+
+
+@pytest.mark.unit
+class TestRepoDirnameFromUrl:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://code.alipay.com/ASF-Service-Platform/aixcore", "aixcore"),
+            ("https://code.alipay.com/ASF-Service-Platform/aixcore.git", "aixcore"),
+            ("https://code.alipay.com/ASF-Service-Platform/aixcore/", "aixcore"),
+            ("https://code.alipay.com/ASF/aixcore.git?branch=dev", "aixcore"),
+            ("https://code.alipay.com/aixcore", "aixcore"),
+            ("git@code.alipay.com:ASF-Service-Platform/aixcore.git", "aixcore"),
+            ("git@code.alipay.com:ASF/shared-lib.git/", "shared-lib"),
+            ("ssh://git@code.alipay.com/ASF/openclaw.git", "openclaw"),
+            ("", ""),
+            (None, ""),
+            (123, ""),
+        ],
+    )
+    def test_dirname(self, url, expected):
+        assert _repo_dirname_from_url(url) == expected
+
+
+@pytest.mark.unit
+class TestParseRepoWorkspaceExcludes:
+    def test_legacy_repo_keys_produce_workspace_excludes(self):
+        bot = {
+            "template_config": {
+                "backend_repo": [
+                    {"repo_url": "https://code.alipay.com/ASF-Service-Platform/aixcore"}
+                ],
+                "frontend_repo": [
+                    {"repo_url": "https://code.alipay.com/ASF/web-frontend.git"}
+                ],
+                "lib_repo": [
+                    {"repo_url": "git@code.alipay.com:ASF/shared-lib.git/"}
+                ],
+            }
+        }
+        assert parse_repo_workspace_excludes(bot) == [
+            "workspace/aixcore",
+            "workspace/web-frontend",
+            "workspace/shared-lib",
+        ]
+
+    def test_dup_repo_across_keys_is_deduped(self):
+        bot = {
+            "template_config": {
+                "backend_repo": [
+                    {"repo_url": "https://code.alipay.com/ASF/aixcore"}
+                ],
+                "lib_repo": [
+                    {"repo_url": "https://code.alipay.com/ASF/aixcore.git"}
+                ],
+            }
+        }
+        assert parse_repo_workspace_excludes(bot) == ["workspace/aixcore"]
+
+    def test_ac_bots_ext_template_config_is_not_read(self):
+        """bot["ext"] (ac_bots.ext) must NOT be used as a repo source — only
+        bot["template_config"] (ac_templates.ext) is consulted."""
+        bot = {
+            "ext": {
+                # ac_bots.ext may carry a stale template_config snapshot; ignore it.
+                "template_config": {
+                    "frontend_repo": [
+                        {"repo_url": "https://code.alipay.com/ASF/should-be-ignored.git"}
+                    ],
+                }
+            }
+        }
+        assert parse_repo_workspace_excludes(bot) == []
+
+    def test_ac_bots_ext_ignored_when_template_config_present(self):
+        """Even when both exist, only ac_templates.ext (bot["template_config"]) wins."""
+        bot = {
+            "template_config": {
+                "backend_repo": [
+                    {"repo_url": "https://code.alipay.com/ASF/top.git"}
+                ],
+            },
+            "ext": {
+                "template_config": {
+                    "backend_repo": [
+                        {"repo_url": "https://code.alipay.com/ASF/should-be-ignored.git"}
+                    ],
+                }
+            },
+        }
+        assert parse_repo_workspace_excludes(bot) == ["workspace/top"]
+    def test_template_factory_alias_keys_supported(self):
+        bot = {
+            "template_config": {
+                "template_key": "app-factory",
+                "repos": [
+                    {"url": "https://code.alipay.com/ASF/aixcore.git"},
+                    "https://code.alipay.com/ASF/extra.git",
+                ],
+            }
+        }
+        assert parse_repo_workspace_excludes(bot) == [
+            "workspace/aixcore",
+            "workspace/extra",
+        ]
+
+    @pytest.mark.parametrize(
+        "bot",
+        [
+            None,
+            {},
+            {"ext": None},
+            {"ext": {}},
+            {"template_config": {}},
+            {"template_config": {"backend_repo": []}},
+            {"template_config": {"backend_repo": [{"repo_url": ""}]}},
+        ],
+    )
+    def test_no_repos_returns_empty(self, bot):
+        assert parse_repo_workspace_excludes(bot) == []
+
+
+
+@pytest.mark.unit
+class TestAixcoreEndToEnd:
+    """用户给出的真实样本：
+    backend_repo=[{"repo_url":"https://code.alipay.com/ASF-Service-Platform/aixcore"}]
+    必须提取出 workspace/aixcore。"""
+
+    SAMPLE = {
+        "backend_repo": [
+            {"repo_url": "https://code.alipay.com/ASF-Service-Platform/aixcore"}
+        ]
+    }
+
+    def test_extract_repo_url_to_aixcore_dirname(self):
+        # repo_url 形如 [{"repo_url": "..."}] -> URL -> 仓库名 aixcore
+        from agentclaw.community.core.bot_management.utils import _extract_code_repo_urls
+        urls = _extract_code_repo_urls(self.SAMPLE)
+        assert urls == ["https://code.alipay.com/ASF-Service-Platform/aixcore"]
+        assert _repo_dirname_from_url(urls[0]) == "aixcore"
+
+    def test_bot_template_config_produces_aixcore_exclude(self):
+        # bot["template_config"] == ac_templates.ext，端到端产出 workspace/aixcore
+        exclude = parse_repo_workspace_excludes({"template_config": self.SAMPLE})
+        assert exclude == ["workspace/aixcore"]
+
+    def test_build_plan_includes_aixcore_exclude(self):
+        from agentclaw.community.core.workspace.engines.aicoding import (
+            AICodingSandboxProvider,
+        )
+        from agentclaw.community.di import config as cfg
+
+        provider = AICodingSandboxProvider(workspace=cfg.WorkspaceConfig())
+        plan = provider.get_build_plan(bot={"template_config": self.SAMPLE})
+        assert "workspace/aixcore" in plan.rsync_excludes
+
+    def test_ac_bots_ext_does_not_produce_exclude(self):
+        # 反例：仓库声明放在 bot["ext"]（ac_bots.ext）不应被读取
+        exclude = parse_repo_workspace_excludes({"ext": {"template_config": self.SAMPLE}})
+        assert exclude == []
+
+
+@pytest.mark.unit
+class TestRepoExcludesFailSafe:
+    """新增的 repo 排除逻辑出错时，绝不影响 get_build_plan 主链路。"""
+
+    def test_build_plan_survives_repo_impl_error(self, monkeypatch):
+        from agentclaw.community.core.workspace.engines import aicoding as mod
+        from agentclaw.community.core.workspace.engines.aicoding import (
+            AICodingSandboxProvider,
+        )
+        from agentclaw.community.di import config as cfg
+
+        # 强制让 repo 排除逻辑抛错，模拟数据异常/导入失败等极端情况
+        def _boom(_bot):
+            raise RuntimeError("simulated repo-exclude failure")
+
+        monkeypatch.setattr(mod, "_repo_workspace_excludes_for_bot", _boom)
+
+        provider = AICodingSandboxProvider(workspace=cfg.WorkspaceConfig())
+        bot = {"template_config": {"backend_repo": [
+            {"repo_url": "https://code.alipay.com/ASF/aixcore.git"}
+        ]}}
+
+        # 不应抛错；仍返回有效 build plan
+        plan = provider.get_build_plan(bot=bot)
+        assert plan.engine_type == "aicoding"
+        assert plan.rsync_excludes  # 默认 excludes 保留
+        # repo 排除未生效（降级）
+        assert "workspace/aixcore" not in plan.rsync_excludes
+
+    def test_build_plan_survives_without_bot_when_impl_raises(self, monkeypatch):
+        from agentclaw.community.core.workspace.engines import aicoding as mod
+        from agentclaw.community.core.workspace.engines.aicoding import (
+            AICodingSandboxProvider,
+        )
+        from agentclaw.community.di import config as cfg
+
+        monkeypatch.setattr(mod, "_repo_workspace_excludes_for_bot",
+                            lambda _bot: (_ for _ in ()).throw(ValueError("boom")))
+
+        provider = AICodingSandboxProvider(workspace=cfg.WorkspaceConfig())
+        # 即使无 bot 调用，rep 错误也不应冒泡
+        plan = provider.get_build_plan()
+        assert plan.source_root_name == ".aicoding"


### PR DESCRIPTION
## 背景

`AICodingSandboxProvider.get_build_plan()` 此前会把 `.aicoding/workspace/` 下所有目录 rsync 进发布物，但其中的代码仓库工作副本不应被拷贝。

## 改动

根据 bot 的 `template_config`（`ac_templates.ext`）里声明的 `backend_repo` / `frontend_repo` / `lib_repo`（含 template-factory 别名）仓库 URL，生成 `workspace/<repo名>` 的 rsync 排除项，使这些仓库工作副本不被拷贝进发布物。

示例：`backend_repo=[{"repo_url": "https://code.alipay.com/ASF-Service-Platform/aixcore"}]` → `workspace/aixcore` 不被拷贝。

### 设计原则
- **repo 逻辑封闭在 `engines/aicoding.py` 内部**（私有 helper），不透出到公共模块：`EngineSandboxProvider.get_build_plan` 新增可选 `bot` 参数，由 `BotBuildService.build()/restore_draft()` 透明转发；`openclaw` / `claude_code` 接受但不消费。
- **复用** `bot_management.utils._extract_code_repo_urls` 提取 URL，不自造。
- **数据源是 `bot["template_config"]`（`ac_templates.ext`）**，不是 `bot["ext"]`（`ac_bots.ext`）。
- **fail-safe**：repo 排除派生逻辑用 `try/except` 包裹，任何异常降级为「不追加 repo 排除 + warning」，绝不影响 `build()` / `restore_draft()` 主链路。

## 测试

- 新增 `tests/community/core/workspace/test_repo_workspace_excludes.py`（URL 解析、legacy/别名键、去重、`ac_bots.ext` 不被读、真实 aixcore 样本端到端、fail-safe）。
- `test_engine_sandbox_providers.py`：aicoding 注入 repo 排除、无 bot 不追加、去重、跨引擎忽略 bot。
- `test_bot_build_service_rsync_excludes.py`：build() 透传 bot。
- `test_bot_build_service_openclaw_stage_configs.py`：桩加 `bot=None, **kwargs`。

`tests/community/core/workspace` + `tests/community/core/service_bot` 共 1034 passed，无回归。