### PR TITLE
feat(backend): P1-05 runtime projection and compatibility matrix

### DIFF
--- a/src/backend/src/agentclaw/community/api/README.md
+++ b/src/backend/src/agentclaw/community/api/README.md
@@ -47,6 +47,7 @@ purpose: "Service API Protocols — transport-agnostic contracts between adapter
 provides:
   - "One Protocol per public service / factory"
   - "Structural conformance gate via tests/architecture/test_service_api_conformance.py"
+  - BotRuntimeProjectionReconcilerProtocol
 consumes:
   - "No service impls at import time — Protocols only declare shape, they don't depend on concrete services"
   - "A small number of core dataclass / schema types used to type Protocol method signatures (see internal_dependencies)"

--- a/src/backend/src/agentclaw/community/api/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/api/bot_runtime_projection_reconciler.py
@@ -1,8 +1,41 @@
-"""Public Service API alias for Bot runtime projection reconciliation."""
+"""Public Service API for Bot runtime projection reconciliation."""
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
 
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
-    BotRuntimeProjectionReconcilerProtocol,
+    BotRuntimeProjectionReconcilerProtocol as CoreBotRuntimeProjectionReconcilerProtocol,
 )
+from agentclaw.community.core.skills_pool.models import PoolSkillMapping
+
+
+@runtime_checkable
+class BotRuntimeProjectionReconcilerProtocol(
+    CoreBotRuntimeProjectionReconcilerProtocol, Protocol
+):
+    """Transport-facing contract; Core depends only on its sibling contract."""
+
+    async def reconcile(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+    ) -> None: ...
+
+    async def reconcile_non_skill_projection(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ) -> None: ...
+
+    async def reconcile_cleanup(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ) -> None: ...
 
 
 __all__ = ["BotRuntimeProjectionReconcilerProtocol"]

--- a/src/backend/src/agentclaw/community/api/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/api/bot_runtime_projection_reconciler.py
@@ -1,33 +1,8 @@
-"""Service API for applying one Bot's complete capability projection."""
+"""Public Service API alias for Bot runtime projection reconciliation."""
 
-from __future__ import annotations
-
-from collections.abc import Sequence
-from typing import Protocol, runtime_checkable
-
-from agentclaw.community.core.skills_pool.models import PoolSkillMapping
-
-
-@runtime_checkable
-class BotRuntimeProjectionReconcilerProtocol(Protocol):
-    """Apply the complete database desired state for one Bot."""
-
-    async def reconcile(
-        self,
-        *,
-        bot_id: str,
-        owner_id: str,
-        retired_mappings: Sequence[PoolSkillMapping] = (),
-    ) -> None: ...
-
-    async def reconcile_non_skill_projection(
-        self,
-        *,
-        bot_id: str,
-        owner_id: str,
-    ) -> None:
-        """Project MCP/CLI while an external authority owns Skill mappings."""
-        ...
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    BotRuntimeProjectionReconcilerProtocol,
+)
 
 
 __all__ = ["BotRuntimeProjectionReconcilerProtocol"]

--- a/src/backend/src/agentclaw/community/api/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/api/bot_runtime_projection_reconciler.py
@@ -1,0 +1,24 @@
+"""Service API for applying one Bot's complete capability projection."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.core.skills_pool.models import PoolSkillMapping
+
+
+@runtime_checkable
+class BotRuntimeProjectionReconcilerProtocol(Protocol):
+    """Apply the complete database desired state for one Bot."""
+
+    async def reconcile(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+    ) -> None: ...
+
+
+__all__ = ["BotRuntimeProjectionReconcilerProtocol"]

--- a/src/backend/src/agentclaw/community/api/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/api/bot_runtime_projection_reconciler.py
@@ -20,5 +20,14 @@ class BotRuntimeProjectionReconcilerProtocol(Protocol):
         retired_mappings: Sequence[PoolSkillMapping] = (),
     ) -> None: ...
 
+    async def reconcile_non_skill_projection(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ) -> None:
+        """Project MCP/CLI while an external authority owns Skill mappings."""
+        ...
+
 
 __all__ = ["BotRuntimeProjectionReconcilerProtocol"]

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -1111,9 +1111,10 @@ class DeviceService:
                 f"[report_device_alive] device_id={device_id} sync_bot_config done: "
                 f"cost_ms={(_time.time() - _t_sync) * 1000:.0f}"
             )
-            # MCP 同步：由注入的 McpSyncProtocol 在后台线程中执行，
-            # 不阻塞 alive 回调。失败仅记录日志，不影响主流程。
-            self._sync_mcps_when_device_active(record)
+            # Skill/MCP/CLI 的完整 desired-state 投影只由随后发布的
+            # DeviceActivatedEvent → BotRuntimeProjectionReconciler 执行。
+            # 不再同时调用旧 MCP writer，否则一次激活会产生两次 Passport
+            # 覆盖写和两轮设备推送，且先后顺序不可控。
             # data-init 触发已移至 report_device_status(status=SUCCEEDED) 回调
             logger.info(
                 f"[report_device_alive] device_id={device_id} all_callbacks done: "

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
@@ -542,6 +542,7 @@ class SkillRepository(
                     git_path=row.git_path,
                     skill_uuid=getattr(row, "skill_uuid", None),
                     sc_version_number=getattr(row, "sc_version_number", None),
+                    mcp_dependencies=tuple(_skill_to_dict(row).get("mcp_dependencies") or ()),
                 )
                 for row in rows
             ]
@@ -610,6 +611,7 @@ class SkillRepository(
                             if row.get("sc_version_number") is not None
                             else None
                         ),
+                        mcp_dependencies=tuple(row.get("mcp_dependencies") or ()),
                     )
                 )
         for row in self.list_bot_installed_skills(env=env, bot_id=bot_id):
@@ -628,6 +630,7 @@ class SkillRepository(
                     git_path=git_path,
                     skill_uuid=skill_uuid,
                     sc_version_number=sc_version_number,
+                    mcp_dependencies=tuple(row.get("mcp_dependencies") or ()),
                 )
             )
         return assets

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
@@ -562,26 +562,10 @@ class SkillRepository(
         reconciliation cannot disagree about whether a Local Skill is active.
         """
 
-        from agentclaw.community.core.models.skill import BotSkillInstallation
-        from agentclaw.community.core.skill_center.installation_compatibility import (
-            includes_default_skill_member,
-        )
         from agentclaw.community.core.skills_pool.models import (
             RegisteredSkillAsset,
         )
 
-        with self._db.orm_session() as db:
-            installed_ids = {
-                int(row[0])
-                for row in db.query(BotSkillInstallation.skill_id)
-                .filter(
-                    BotSkillInstallation.avernet_tenant
-                    == get_current_avernet_tenant(),
-                    BotSkillInstallation.env == env,
-                    BotSkillInstallation.bot_id == bot_id,
-                )
-                .all()
-            }
         skill_sets = SkillSetRepository(self._db)
         active_sets = skill_sets.get_all_active_skill_sets_for_env(
             user_id=user_id,
@@ -597,21 +581,14 @@ class SkillRepository(
                 env=env,
             )
             if skill_set.get("is_default"):
-                excluded_ids = set(
-                    skill_sets.get_excluded_skills(
-                        user_id=user_id,
-                        bot_id=bot_id,
-                        skill_set_id=int(skill_set["id"]),
-                    )
-                )
+                # System Default is an independent input to the Resolver.
+                # The historical per-Bot Local exclusion is migration-only
+                # compatibility data and must never decide a runtime entry.
+                # Bot-owned Local assets are selected solely by Installation.
                 rows = [
                     row
                     for row in rows
-                    if includes_default_skill_member(
-                        row,
-                        installed_ids=installed_ids,
-                        excluded_ids=excluded_ids,
-                    )
+                    if not str(row.get("git_path") or "").startswith("local://")
                 ]
             for row in rows:
                 git_path = str(row.get("git_path") or "")

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -25,6 +25,7 @@ provides:
   - "SkillInstallationRepositoryProtocol"
   - "BotSkillAssetService"
   - "RuntimeProjectionResolver"
+  - "BotRuntimeProjectionReconciler"
   - "LocalSkillCleanupWorkModel"
 consumes:
   - "BotRepository"
@@ -43,7 +44,9 @@ consumes:
   - "SkillRepoSyncPlugin"
   - "WorkspacePathFactory"
   - "LocalSkillCleanupRepository"
+  - "BotRuntimeProjectionReconcilerProtocol"
 internal_dependencies:
+  - agentclaw.community.api.bot_runtime_projection_reconciler
   - agentclaw.community.api.skill_parameter_service_factory
   - agentclaw.community.api.skill_market_service
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -24,6 +24,7 @@ provides:
   - "SkillSetControlPlaneService"
   - "SkillInstallationRepositoryProtocol"
   - "BotSkillAssetService"
+  - "RuntimeProjectionResolver"
   - "LocalSkillCleanupWorkModel"
 consumes:
   - "BotRepository"
@@ -99,6 +100,12 @@ active-only desired-state and compensation boundary as Skills.  The MCP
 catalogue, user configuration, and permission grant remain separate facts;
 the control plane consults the MCP authorization Service API before any MCP
 membership or Direct-installation write.
+
+`RuntimeProjectionResolver` is the only source of a mutation/restart runtime
+snapshot. It receives Installation, active ordinary SkillSet membership,
+System Default assets and required configuration, then produces a complete
+Local/Repo/Center/MCP/CLI projection. Engine adapters receive that snapshot;
+they do not reconstruct it from Default exclusions or BFF state.
 
 All Direct activation and canonical SkillSet mutations first acquire the
 layout-neutral `BotCapabilityMutationGuard`, keyed by `(tenant, env, entity_id, bot)`.

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -26,6 +26,7 @@ provides:
   - "BotSkillAssetService"
   - "RuntimeProjectionResolver"
   - "BotRuntimeProjectionReconciler"
+  - "BotRuntimeProjectionReconcilerProtocol"
   - "LocalSkillCleanupWorkModel"
 consumes:
   - "BotRepository"
@@ -46,7 +47,6 @@ consumes:
   - "LocalSkillCleanupRepository"
   - "BotRuntimeProjectionReconcilerProtocol"
 internal_dependencies:
-  - agentclaw.community.api.bot_runtime_projection_reconciler
   - agentclaw.community.api.skill_parameter_service_factory
   - agentclaw.community.api.skill_market_service
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_policy.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_policy.py
@@ -8,6 +8,9 @@ from typing import Any
 from agentclaw.community.core.skill_center.errors import (
     SkillEngineNotSupportedError,
 )
+from agentclaw.community.core.workspace.skill_layout import (
+    runtime_layout_engine_for_bot,
+)
 
 
 _SUPPORTED_BOT_SKILL_RUNTIMES = {
@@ -40,25 +43,6 @@ class BotSkillRuntimeCommand(StrEnum):
 
     WRITE = "WRITE"
     CLEANUP = "CLEANUP"
-
-
-def runtime_layout_engine_for_bot(bot: dict[str, Any]) -> str:
-    """Return the physical engine used exclusively for filesystem Pool I/O.
-
-    Coding templates retain ``claude_code`` as their domain/catalogue engine,
-    but their active skill directory belongs to the AICoding image.  Only the
-    runtime layout probe must see that physical identity; factories, catalogues
-    and Passport remain keyed by the logical engine.
-    """
-
-    engine = str(bot.get("active_engine") or "")
-    if (
-        engine == "claude_code"
-        and str(bot.get("template_type") or "")
-        in _CLAUDE_CODE_WRITABLE_TEMPLATES
-    ):
-        return "aicoding"
-    return engine
 
 
 def bot_skill_runtime_mutation_mode(

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_policy.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_policy.py
@@ -15,18 +15,26 @@ _SUPPORTED_BOT_SKILL_RUNTIMES = {
     "service": frozenset({"openclaw", "claude_code", "teclaw"}),
 }
 
-# AICoding images implement the Claude Code logical Skill contract.  Runtime
-# probes/adapters, not a second product matrix, decide their physical layout.
-_LOGICAL_ENGINE_ALIASES = {"aicoding": "claude_code"}
+_CLAUDE_CODE_WRITABLE_TEMPLATES = frozenset(
+    {"personalCoding", "applicationCoding"}
+)
 
 
 def require_supported_bot_skill_runtime(bot: dict[str, Any]) -> None:
     """Fail closed outside the product-approved Bot × Engine matrix."""
     bot_type = str(bot.get("bot_type") or "")
-    engine = _LOGICAL_ENGINE_ALIASES.get(
-        str(bot.get("active_engine") or ""), str(bot.get("active_engine") or "")
-    )
+    # New AICoding-image Bots still expose the logical ``claude_code`` engine
+    # (their template_type selects the physical image). Historical rows whose
+    # active_engine is literally ``aicoding`` retain safe read/delete only and
+    # must not silently gain new mutation/runtime support.
+    engine = str(bot.get("active_engine") or "")
     if engine not in _SUPPORTED_BOT_SKILL_RUNTIMES.get(bot_type, frozenset()):
+        raise SkillEngineNotSupportedError()
+    if (
+        engine == "claude_code"
+        and str(bot.get("template_type") or "")
+        not in _CLAUDE_CODE_WRITABLE_TEMPLATES
+    ):
         raise SkillEngineNotSupportedError()
 
 

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_policy.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_policy.py
@@ -15,11 +15,17 @@ _SUPPORTED_BOT_SKILL_RUNTIMES = {
     "service": frozenset({"openclaw", "claude_code", "teclaw"}),
 }
 
+# AICoding images implement the Claude Code logical Skill contract.  Runtime
+# probes/adapters, not a second product matrix, decide their physical layout.
+_LOGICAL_ENGINE_ALIASES = {"aicoding": "claude_code"}
+
 
 def require_supported_bot_skill_runtime(bot: dict[str, Any]) -> None:
     """Fail closed outside the product-approved Bot × Engine matrix."""
     bot_type = str(bot.get("bot_type") or "")
-    engine = str(bot.get("active_engine") or "")
+    engine = _LOGICAL_ENGINE_ALIASES.get(
+        str(bot.get("active_engine") or ""), str(bot.get("active_engine") or "")
+    )
     if engine not in _SUPPORTED_BOT_SKILL_RUNTIMES.get(bot_type, frozenset()):
         raise SkillEngineNotSupportedError()
 

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_policy.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Any
 
 from agentclaw.community.core.skill_center.errors import (
@@ -20,22 +21,108 @@ _CLAUDE_CODE_WRITABLE_TEMPLATES = frozenset(
 )
 
 
-def require_supported_bot_skill_runtime(bot: dict[str, Any]) -> None:
-    """Fail closed outside the product-approved Bot × Engine matrix."""
-    bot_type = str(bot.get("bot_type") or "")
-    # New AICoding-image Bots still expose the logical ``claude_code`` engine
-    # (their template_type selects the physical image). Historical rows whose
-    # active_engine is literally ``aicoding`` retain safe read/delete only and
-    # must not silently gain new mutation/runtime support.
+class BotSkillRuntimeMutationMode(StrEnum):
+    """The mutation authority available to a persisted Bot runtime.
+
+    ``FULL`` is the product-supported matrix and may create or activate
+    capability state.  ``CLEANUP_ONLY`` deliberately exists for historical
+    records that can still safely *remove* existing Local/Repo/MCP state but
+    cannot receive a new Pool/Center projection.  A named mode is important:
+    callers must never turn this safety boundary into an ambiguous boolean.
+    """
+
+    FULL = "FULL"
+    CLEANUP_ONLY = "CLEANUP_ONLY"
+
+
+class BotSkillRuntimeCommand(StrEnum):
+    """Explicit command intent at a Bot capability mutation boundary."""
+
+    WRITE = "WRITE"
+    CLEANUP = "CLEANUP"
+
+
+def runtime_layout_engine_for_bot(bot: dict[str, Any]) -> str:
+    """Return the physical engine used exclusively for filesystem Pool I/O.
+
+    Coding templates retain ``claude_code`` as their domain/catalogue engine,
+    but their active skill directory belongs to the AICoding image.  Only the
+    runtime layout probe must see that physical identity; factories, catalogues
+    and Passport remain keyed by the logical engine.
+    """
+
     engine = str(bot.get("active_engine") or "")
-    if engine not in _SUPPORTED_BOT_SKILL_RUNTIMES.get(bot_type, frozenset()):
-        raise SkillEngineNotSupportedError()
     if (
         engine == "claude_code"
         and str(bot.get("template_type") or "")
-        not in _CLAUDE_CODE_WRITABLE_TEMPLATES
+        in _CLAUDE_CODE_WRITABLE_TEMPLATES
     ):
+        return "aicoding"
+    return engine
+
+
+def bot_skill_runtime_mutation_mode(
+    bot: dict[str, Any],
+) -> BotSkillRuntimeMutationMode:
+    """Classify the intentional mutation authority of a Bot record.
+
+    Historical plain Claude Code, literal AICoding, and Desktop Claude Code
+    records are not eligible for new capability writes.  They remain able to
+    reconcile an already-reduced legacy Local/Repo/MCP projection while users
+    remove old state.  Everything else outside the declared matrix stays
+    fail-closed.
+    """
+
+    # Historical Local rows predate a durable ``bot_type`` column.  Their
+    # released behaviour was personal-Bot semantics, so retain that narrow
+    # compatibility default instead of rejecting every old Local operation.
+    bot_type = str(bot.get("bot_type") or "personal")
+    engine = str(bot.get("active_engine") or "")
+    template_type = str(bot.get("template_type") or "")
+
+    if engine in _SUPPORTED_BOT_SKILL_RUNTIMES.get(bot_type, frozenset()):
+        if engine != "claude_code" or template_type in _CLAUDE_CODE_WRITABLE_TEMPLATES:
+            return BotSkillRuntimeMutationMode.FULL
+
+    if engine == "aicoding" or (engine == "claude_code" and bot_type == "desktop"):
+        return BotSkillRuntimeMutationMode.CLEANUP_ONLY
+    if engine == "claude_code" and bot_type in {"personal", "service"}:
+        return BotSkillRuntimeMutationMode.CLEANUP_ONLY
+    raise SkillEngineNotSupportedError()
+
+
+def require_supported_bot_skill_runtime(bot: dict[str, Any]) -> None:
+    """Fail closed outside the product-approved Bot × Engine matrix."""
+    if bot_skill_runtime_mutation_mode(bot) is not BotSkillRuntimeMutationMode.FULL:
         raise SkillEngineNotSupportedError()
 
 
-__all__ = ["require_supported_bot_skill_runtime"]
+def require_cleanup_capable_bot_skill_runtime(
+    bot: dict[str, Any],
+) -> BotSkillRuntimeMutationMode:
+    """Allow the explicit safe-cleanup subset without granting full writes."""
+
+    return bot_skill_runtime_mutation_mode(bot)
+
+
+def require_bot_skill_runtime_command(
+    bot: dict[str, Any],
+    command: BotSkillRuntimeCommand,
+) -> BotSkillRuntimeMutationMode:
+    """Authorize a named command without widening a cleanup-only record."""
+
+    mode = bot_skill_runtime_mutation_mode(bot)
+    if command is BotSkillRuntimeCommand.WRITE:
+        require_supported_bot_skill_runtime(bot)
+    return mode
+
+
+__all__ = [
+    "BotSkillRuntimeMutationMode",
+    "BotSkillRuntimeCommand",
+    "bot_skill_runtime_mutation_mode",
+    "require_bot_skill_runtime_command",
+    "require_cleanup_capable_bot_skill_runtime",
+    "require_supported_bot_skill_runtime",
+    "runtime_layout_engine_for_bot",
+]

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
@@ -29,5 +29,14 @@ class BotRuntimeProjectionReconcilerProtocol(Protocol):
         """Project MCP/CLI while an external authority owns Skill mappings."""
         ...
 
+    async def reconcile_cleanup(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ) -> None:
+        """Remove historical capability state through the legacy runtime path."""
+        ...
+
 
 __all__ = ["BotRuntimeProjectionReconcilerProtocol"]

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
@@ -1,0 +1,33 @@
+"""Core contract for applying one Bot capability projection."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.core.skills_pool.models import PoolSkillMapping
+
+
+@runtime_checkable
+class BotRuntimeProjectionReconcilerProtocol(Protocol):
+    """Apply database desired state through the selected runtime authority."""
+
+    async def reconcile(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+    ) -> None: ...
+
+    async def reconcile_non_skill_projection(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ) -> None:
+        """Project MCP/CLI while an external authority owns Skill mappings."""
+        ...
+
+
+__all__ = ["BotRuntimeProjectionReconcilerProtocol"]

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_resolver.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_resolver.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from agentclaw.community.core.skills_pool.mapping_intent import (
+    RuntimeMappingNameConflictError,
     build_logical_skill_mappings,
 )
 from agentclaw.community.core.skills_pool.models import (
@@ -38,6 +39,7 @@ class RuntimeProjection:
     """Engine-neutral full snapshot; adapters must apply it as a whole."""
 
     skill_mappings: tuple[PoolSkillMapping, ...]
+    skill_assets: tuple[RegisteredSkillAsset, ...]
     mcp_server_codes: tuple[str, ...]
     cli_commands: tuple[str, ...]
 
@@ -72,12 +74,11 @@ class RuntimeProjectionResolver:
                 raise ValueError("unsupported skill source in runtime projection")
         try:
             mappings = build_logical_skill_mappings(list(assets))
-        except ValueError as exc:
-            if "duplicate managed target" in str(exc):
-                raise RuntimeNameConflictError() from exc
-            raise
+        except RuntimeMappingNameConflictError as exc:
+            raise RuntimeNameConflictError() from exc
         return RuntimeProjection(
             skill_mappings=tuple(mappings),
+            skill_assets=assets,
             mcp_server_codes=tuple(sorted(state.installed_mcp_server_codes)),
             cli_commands=tuple(dict.fromkeys(state.system_default_cli_commands)),
         )

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_resolver.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_resolver.py
@@ -1,0 +1,92 @@
+"""Resolve one complete, transport-independent Skill/MCP runtime projection.
+
+The resolver is deliberately a pure domain service.  Its only input is the
+already-authorized desired state: active Installation assets, active normal
+SkillSet members, System Defaults, and the MCP/CLI facts those inputs select.
+It neither reads legacy Default exclusions nor treats a runtime result as
+desired state.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agentclaw.community.core.skills_pool.mapping_intent import (
+    build_logical_skill_mappings,
+)
+from agentclaw.community.core.skills_pool.models import (
+    PoolSkillMapping,
+    RegisteredSkillAsset,
+)
+
+
+class RuntimeNameConflictError(ValueError):
+    """Two distinct desired assets resolve to one runtime name."""
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeDesiredState:
+    """The complete, canonical input to one runtime reconciliation."""
+
+    skills: tuple[RegisteredSkillAsset, ...]
+    installed_mcp_server_codes: frozenset[str] = frozenset()
+    system_default_cli_commands: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeProjection:
+    """Engine-neutral full snapshot; adapters must apply it as a whole."""
+
+    skill_mappings: tuple[PoolSkillMapping, ...]
+    mcp_server_codes: tuple[str, ...]
+    cli_commands: tuple[str, ...]
+
+
+class RuntimeNamePolicy:
+    """The sole policy for logical runtime names.
+
+    ``ac_skill.name`` is the authority.  Locators are content addresses and
+    must never influence the visible/runtime entry name.
+    """
+
+    @staticmethod
+    def name_for(asset: RegisteredSkillAsset) -> str:
+        name = asset.name
+        if not isinstance(name, str) or not name or name.strip() != name:
+            raise ValueError("invalid ac_skill.name for runtime projection")
+        if "/" in name or "\\" in name or name in {".", ".."}:
+            raise ValueError("unsafe ac_skill.name for runtime projection")
+        return name
+
+
+class RuntimeProjectionResolver:
+    """Build the deduplicated Local/Repo/Center/MCP/CLI snapshot."""
+
+    def resolve(self, state: RuntimeDesiredState) -> RuntimeProjection:
+        # Validate all names before mapping so unsupported/ambiguous desired
+        # state cannot be partially delivered by an Engine Adapter.
+        assets = tuple(state.skills)
+        for asset in assets:
+            RuntimeNamePolicy.name_for(asset)
+            if not asset.git_path.startswith(("local://", "git://", "center://")):
+                raise ValueError("unsupported skill source in runtime projection")
+        try:
+            mappings = build_logical_skill_mappings(list(assets))
+        except ValueError as exc:
+            if "duplicate managed target" in str(exc):
+                raise RuntimeNameConflictError() from exc
+            raise
+        return RuntimeProjection(
+            skill_mappings=tuple(mappings),
+            mcp_server_codes=tuple(sorted(state.installed_mcp_server_codes)),
+            cli_commands=tuple(dict.fromkeys(state.system_default_cli_commands)),
+        )
+
+
+__all__ = [
+    "RuntimeDesiredState",
+    "RuntimeNameConflictError",
+    "RuntimeNamePolicy",
+    "RuntimeProjection",
+    "RuntimeProjectionResolver",
+]

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_resolver.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_resolver.py
@@ -31,6 +31,7 @@ class RuntimeDesiredState:
 
     skills: tuple[RegisteredSkillAsset, ...]
     installed_mcp_server_codes: frozenset[str] = frozenset()
+    system_default_mcp_server_codes: frozenset[str] = frozenset()
     system_default_cli_commands: tuple[str, ...] = ()
 
 
@@ -76,10 +77,24 @@ class RuntimeProjectionResolver:
             mappings = build_logical_skill_mappings(list(assets))
         except RuntimeMappingNameConflictError as exc:
             raise RuntimeNameConflictError() from exc
+        mcp_codes = set(state.installed_mcp_server_codes)
+        mcp_codes.update(state.system_default_mcp_server_codes)
+        for asset in assets:
+            for dependency in asset.mcp_dependencies:
+                if isinstance(dependency, str):
+                    mcp_codes.add(dependency)
+                elif isinstance(dependency, dict) and isinstance(
+                    dependency.get("server_code") or dependency.get("code"), str
+                ):
+                    mcp_codes.add(dependency.get("server_code") or dependency["code"])
+                else:
+                    raise ValueError("invalid Skill MCP dependency in runtime projection")
+        if any(not isinstance(code, str) or not code for code in mcp_codes):
+            raise ValueError("invalid MCP server code in runtime projection")
         return RuntimeProjection(
             skill_mappings=tuple(mappings),
             skill_assets=assets,
-            mcp_server_codes=tuple(sorted(state.installed_mcp_server_codes)),
+            mcp_server_codes=tuple(sorted(mcp_codes)),
             cli_commands=tuple(dict.fromkeys(state.system_default_cli_commands)),
         )
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
@@ -1,0 +1,219 @@
+"""Deep module for applying one complete Bot capability projection."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from injector import inject
+
+from agentclaw.community.core.mcp.services._defaults import (
+    get_default_cli_items,
+    get_default_mcp_servers,
+)
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.repository.protocols.skill_set_control_plane import (
+    SkillSetControlPlaneRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.skills_pool import (
+    SkillsPoolLayoutRepositoryProtocol,
+    SkillsPoolSkillRepositoryProtocol,
+)
+from agentclaw.community.core.skill_center.errors import (
+    LocalSkillNotFoundError,
+    SkillSetRuntimeReconcileError,
+)
+from agentclaw.community.core.skill_center.factories import SkillSetServiceFactory
+from agentclaw.community.core.skill_center.runtime_resolver import (
+    RuntimeDesiredState,
+    RuntimeProjectionResolver,
+)
+from agentclaw.community.core.skills_pool.mapping_intent import mapping_contract_for
+from agentclaw.community.core.skills_pool.models import (
+    PoolSkillMapping,
+    SkillMappingSourceLayout,
+)
+from agentclaw.community.core.skills_pool.ports import SkillsPoolRuntimeProtocol
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    runtime_uses_pool_paths,
+)
+from agentclaw.community.plugin_api.passport import PassportPlugin
+
+
+class BotRuntimeProjectionReconcilerProtocol(Protocol):
+    """Apply the complete database desired state for one Bot."""
+
+    async def reconcile(self, *, bot_id: str, owner_id: str) -> None: ...
+
+
+class BotRuntimeProjectionReconciler:
+    """Resolve and apply Skill, MCP, and CLI state through one boundary.
+
+    Callers own command compensation. This module owns desired-state loading,
+    runtime contract selection, full mapping publication, MCP delivery, and the
+    overwrite-style Passport MCP/CLI manifest.
+    """
+
+    @inject
+    def __init__(
+        self,
+        factory: SkillSetServiceFactory,
+        bot_repo: BotRepository,
+        repository: SkillSetControlPlaneRepositoryProtocol,
+        pool_skills: SkillsPoolSkillRepositoryProtocol,
+        pool_runtime: SkillsPoolRuntimeProtocol,
+        pool_layouts: SkillsPoolLayoutRepositoryProtocol,
+        passport: PassportPlugin,
+    ) -> None:
+        self._factory = factory
+        self._bot_repo = bot_repo
+        self._repository = repository
+        self._pool_skills = pool_skills
+        self._pool_runtime = pool_runtime
+        self._pool_layouts = pool_layouts
+        self._passport = passport
+
+    async def reconcile(self, *, bot_id: str, owner_id: str) -> None:
+        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
+        if bot is None:
+            raise LocalSkillNotFoundError()
+
+        engine = str(bot.get("active_engine") or "openclaw")
+        template_type = bot.get("template_type")
+        default_mcp_items = get_default_mcp_servers(engine, template_type)
+        default_cli_items = get_default_cli_items(engine, template_type)
+        service = self._factory.create(
+            user_id=owner_id,
+            entity_id=str(bot.get("entity_id") or owner_id),
+            bot_id=bot_id,
+            engine_type=engine,
+            entity_type=bot.get("entity_type") or "staff",
+        )
+        projection = RuntimeProjectionResolver().resolve(
+            RuntimeDesiredState(
+                skills=tuple(
+                    self._pool_skills.list_bot_active_assets(
+                        env=str(bot["env"]),
+                        bot_id=bot_id,
+                        user_id=owner_id,
+                        engine=engine,
+                    )
+                ),
+                installed_mcp_server_codes=frozenset(
+                    self._repository.list_installed_mcps(bot_id=bot_id)
+                ),
+                system_default_mcp_server_codes=frozenset(
+                    str(item["server_code"])
+                    for item in default_mcp_items
+                    if item.get("server_code")
+                ),
+                system_default_cli_commands=tuple(
+                    str(item["cli_code"])
+                    for item in default_cli_items
+                    if item.get("cli_code")
+                ),
+            )
+        )
+
+        if any(mapping.corpus == "center" for mapping in projection.skill_mappings):
+            await self._apply_pool_mappings(
+                bot=bot,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                engine=engine,
+                mappings=list(projection.skill_mappings),
+            )
+        elif not service.sync_runtime(
+            desired_skills=[
+                {
+                    "id": str(asset.skill_id),
+                    "name": asset.name,
+                    "git_path": asset.git_path,
+                    "skill_uuid": asset.skill_uuid,
+                    "sc_version_number": asset.sc_version_number,
+                }
+                for asset in projection.skill_assets
+            ]
+        ):
+            raise SkillSetRuntimeReconcileError()
+
+        if not await service.sync_mcp_desired_state(
+            server_codes=set(projection.mcp_server_codes)
+        ):
+            raise SkillSetRuntimeReconcileError()
+
+        try:
+            self._passport.update_passport(
+                bot_id=bot_id,
+                user_id=owner_id,
+                engine_type=engine,
+                resource_scope={
+                    "mcp_codes": list(projection.mcp_server_codes),
+                    "cli_items": default_cli_items,
+                },
+            )
+        except Exception as exc:
+            raise SkillSetRuntimeReconcileError() from exc
+
+    async def _apply_pool_mappings(
+        self,
+        *,
+        bot: dict,
+        bot_id: str,
+        owner_id: str,
+        engine: str,
+        mappings: list[PoolSkillMapping],
+    ) -> None:
+        scope = BotSkillLayoutScope(
+            env=str(bot["env"]),
+            entity_id=str(bot.get("entity_id") or owner_id),
+            bot_id=bot_id,
+        )
+        layout_state = self._pool_layouts.get(scope)
+        source_layout = (
+            SkillMappingSourceLayout.POOL
+            if layout_state is not None and runtime_uses_pool_paths(layout_state)
+            else SkillMappingSourceLayout.LEGACY
+        )
+        try:
+            probe = await self._pool_runtime.probe(
+                bot_id=bot_id,
+                user_id=owner_id,
+                engine=engine,
+            )
+            contract = mapping_contract_for(
+                mappings,
+                probe.evidence.get("supported_mapping_contract_versions"),
+            )
+            published = await self._pool_runtime.publish_mappings(
+                bot_id=bot_id,
+                user_id=owner_id,
+                mappings=mappings,
+                source_layout=source_layout,
+                mapping_contract_version=contract,
+            )
+            verified = published and await self._pool_runtime.verify_mappings(
+                bot_id=bot_id,
+                user_id=owner_id,
+                mappings=mappings,
+                source_layout=source_layout,
+                mapping_contract_version=contract,
+            )
+        except Exception as exc:
+            raise SkillSetRuntimeReconcileError() from exc
+        if not verified:
+            raise SkillSetRuntimeReconcileError()
+
+
+# Compatibility names for existing constructors and tests. They are aliases,
+# not subclasses: the implementation authority remains this Bot-level module.
+SkillSetRuntimeReconcilerProtocol = BotRuntimeProjectionReconcilerProtocol
+SkillSetRuntimeReconciler = BotRuntimeProjectionReconciler
+
+
+__all__ = [
+    "BotRuntimeProjectionReconciler",
+    "BotRuntimeProjectionReconcilerProtocol",
+    "SkillSetRuntimeReconciler",
+    "SkillSetRuntimeReconcilerProtocol",
+]

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Protocol
 
 from injector import inject
@@ -43,7 +44,13 @@ from agentclaw.community.plugin_api.passport import PassportPlugin
 class BotRuntimeProjectionReconcilerProtocol(Protocol):
     """Apply the complete database desired state for one Bot."""
 
-    async def reconcile(self, *, bot_id: str, owner_id: str) -> None: ...
+    async def reconcile(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+    ) -> None: ...
 
 
 class BotRuntimeProjectionReconciler:
@@ -73,7 +80,13 @@ class BotRuntimeProjectionReconciler:
         self._pool_layouts = pool_layouts
         self._passport = passport
 
-    async def reconcile(self, *, bot_id: str, owner_id: str) -> None:
+    async def reconcile(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+    ) -> None:
         bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
         if bot is None:
             raise LocalSkillNotFoundError()
@@ -115,13 +128,36 @@ class BotRuntimeProjectionReconciler:
             )
         )
 
-        if any(mapping.corpus == "center" for mapping in projection.skill_mappings):
+        scope = BotSkillLayoutScope(
+            env=str(bot["env"]),
+            entity_id=str(bot.get("entity_id") or owner_id),
+            bot_id=bot_id,
+        )
+        layout_state = self._pool_layouts.get(scope)
+        pool_owns_runtime = layout_state is not None and runtime_uses_pool_paths(
+            layout_state
+        )
+        mappings = list(projection.skill_mappings)
+        retired = list(retired_mappings)
+        if (
+            pool_owns_runtime
+            or any(
+                mapping.corpus in {"repo", "center"}
+                for mapping in [*mappings, *retired]
+            )
+            or retired
+        ):
             await self._apply_pool_mappings(
-                bot=bot,
                 bot_id=bot_id,
                 owner_id=owner_id,
                 engine=engine,
-                mappings=list(projection.skill_mappings),
+                mappings=mappings,
+                retired_mappings=retired,
+                source_layout=(
+                    SkillMappingSourceLayout.POOL
+                    if pool_owns_runtime
+                    else SkillMappingSourceLayout.LEGACY
+                ),
             )
         elif not service.sync_runtime(
             desired_skills=[
@@ -158,37 +194,31 @@ class BotRuntimeProjectionReconciler:
     async def _apply_pool_mappings(
         self,
         *,
-        bot: dict,
         bot_id: str,
         owner_id: str,
         engine: str,
         mappings: list[PoolSkillMapping],
+        retired_mappings: list[PoolSkillMapping],
+        source_layout: SkillMappingSourceLayout,
     ) -> None:
-        scope = BotSkillLayoutScope(
-            env=str(bot["env"]),
-            entity_id=str(bot.get("entity_id") or owner_id),
-            bot_id=bot_id,
-        )
-        layout_state = self._pool_layouts.get(scope)
-        source_layout = (
-            SkillMappingSourceLayout.POOL
-            if layout_state is not None and runtime_uses_pool_paths(layout_state)
-            else SkillMappingSourceLayout.LEGACY
-        )
         try:
-            probe = await self._pool_runtime.probe(
-                bot_id=bot_id,
-                user_id=owner_id,
-                engine=engine,
-            )
-            contract = mapping_contract_for(
-                mappings,
-                probe.evidence.get("supported_mapping_contract_versions"),
-            )
+            contract_mappings = [*mappings, *retired_mappings]
+            supported_versions: object = None
+            if any(mapping.corpus == "center" for mapping in contract_mappings):
+                probe = await self._pool_runtime.probe(
+                    bot_id=bot_id,
+                    user_id=owner_id,
+                    engine=engine,
+                )
+                supported_versions = probe.evidence.get(
+                    "supported_mapping_contract_versions"
+                )
+            contract = mapping_contract_for(contract_mappings, supported_versions)
             published = await self._pool_runtime.publish_mappings(
                 bot_id=bot_id,
                 user_id=owner_id,
                 mappings=mappings,
+                retired_mappings=retired_mappings,
                 source_layout=source_layout,
                 mapping_contract_version=contract,
             )
@@ -196,6 +226,7 @@ class BotRuntimeProjectionReconciler:
                 bot_id=bot_id,
                 user_id=owner_id,
                 mappings=mappings,
+                retired_mappings=retired_mappings,
                 source_layout=source_layout,
                 mapping_contract_version=contract,
             )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
@@ -172,7 +172,7 @@ class BotRuntimeProjectionReconciler:
             if item.get("server_code") or item.get("serverCode")
         )
         try:
-            # CLI removal is currently persisted by AgentPass itself.  Its
+            # CLI removal is currently persisted by the authorization service. Its
             # current scope is therefore the only effective Default CLI fact;
             # merging static engine defaults here would undo that removal.
             effective_cli_items = self._passport.query_passport_clis(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Protocol
 
 from injector import inject
 
-from agentclaw.community.core.mcp.services._defaults import (
-    get_default_cli_items,
-    get_default_mcp_servers,
+from agentclaw.community.core.mcp.services.passport_scope import (
+    filter_passport_mcp_codes,
 )
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.repository.protocols.skill_set_control_plane import (
@@ -42,18 +40,6 @@ from agentclaw.community.core.skills_pool.types import (
     runtime_uses_pool_paths,
 )
 from agentclaw.community.plugin_api.passport import PassportPlugin
-
-
-class BotRuntimeProjectionReconcilerProtocol(Protocol):
-    """Apply the complete database desired state for one Bot."""
-
-    async def reconcile(
-        self,
-        *,
-        bot_id: str,
-        owner_id: str,
-        retired_mappings: Sequence[PoolSkillMapping] = (),
-    ) -> None: ...
 
 
 class BotRuntimeProjectionReconciler:
@@ -96,9 +82,6 @@ class BotRuntimeProjectionReconciler:
         require_supported_bot_skill_runtime(bot)
 
         engine = str(bot.get("active_engine") or "openclaw")
-        template_type = bot.get("template_type")
-        default_mcp_items = get_default_mcp_servers(engine, template_type)
-        default_cli_items = get_default_cli_items(engine, template_type)
         service = self._factory.create(
             user_id=owner_id,
             entity_id=str(bot.get("entity_id") or owner_id),
@@ -106,6 +89,31 @@ class BotRuntimeProjectionReconciler:
             engine_type=engine,
             entity_type=bot.get("entity_type") or "staff",
         )
+        # The legacy SkillSet service remains the authority for effective
+        # System Defaults during Phase 1.  It resolves template presets and
+        # applies ac_default_skillset_mcp_exclusion; rebuilding defaults from
+        # static constants here would silently resurrect user exclusions.
+        effective_mcp_entries = service.collect_bot_active_mcps(
+            entity_id=str(bot.get("entity_id") or owner_id),
+            bot_id=bot_id,
+            user_id=owner_id,
+            entity_type=bot.get("entity_type") or "staff",
+            engine_type=engine,
+        )
+        effective_default_mcp_codes = frozenset(
+            str(item.get("server_code") or item.get("serverCode") or "").strip()
+            for item in effective_mcp_entries
+            if item.get("server_code") or item.get("serverCode")
+        )
+        try:
+            # CLI removal is currently persisted by AgentPass itself.  Its
+            # current scope is therefore the only effective Default CLI fact;
+            # merging static engine defaults here would undo that removal.
+            effective_cli_items = self._passport.query_passport_clis(
+                bot_id, owner_id
+            )
+        except Exception as exc:
+            raise SkillSetRuntimeReconcileError() from exc
         projection = RuntimeProjectionResolver().resolve(
             RuntimeDesiredState(
                 skills=tuple(
@@ -119,14 +127,10 @@ class BotRuntimeProjectionReconciler:
                 installed_mcp_server_codes=frozenset(
                     self._repository.list_installed_mcps(bot_id=bot_id)
                 ),
-                system_default_mcp_server_codes=frozenset(
-                    str(item["server_code"])
-                    for item in default_mcp_items
-                    if item.get("server_code")
-                ),
+                system_default_mcp_server_codes=effective_default_mcp_codes,
                 system_default_cli_commands=tuple(
                     str(item["cli_code"])
-                    for item in default_cli_items
+                    for item in effective_cli_items
                     if item.get("cli_code")
                 ),
             )
@@ -195,8 +199,10 @@ class BotRuntimeProjectionReconciler:
                 user_id=owner_id,
                 engine_type=engine,
                 resource_scope={
-                    "mcp_codes": list(projection.mcp_server_codes),
-                    "cli_items": default_cli_items,
+                    "mcp_codes": filter_passport_mcp_codes(
+                        projection.mcp_server_codes
+                    ),
+                    "cli_items": effective_cli_items,
                 },
             )
         except Exception as exc:
@@ -249,13 +255,10 @@ class BotRuntimeProjectionReconciler:
 
 # Compatibility names for existing constructors and tests. They are aliases,
 # not subclasses: the implementation authority remains this Bot-level module.
-SkillSetRuntimeReconcilerProtocol = BotRuntimeProjectionReconcilerProtocol
 SkillSetRuntimeReconciler = BotRuntimeProjectionReconciler
 
 
 __all__ = [
     "BotRuntimeProjectionReconciler",
-    "BotRuntimeProjectionReconcilerProtocol",
     "SkillSetRuntimeReconciler",
-    "SkillSetRuntimeReconcilerProtocol",
 ]

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
@@ -28,7 +28,9 @@ from agentclaw.community.core.skill_center.runtime_resolver import (
     RuntimeProjectionResolver,
 )
 from agentclaw.community.core.skill_center.runtime_policy import (
+    require_cleanup_capable_bot_skill_runtime,
     require_supported_bot_skill_runtime,
+    runtime_layout_engine_for_bot,
 )
 from agentclaw.community.core.skills_pool.mapping_intent import mapping_contract_for
 from agentclaw.community.core.skills_pool.models import (
@@ -120,6 +122,36 @@ class BotRuntimeProjectionReconciler:
             effective_cli_items=effective_cli_items,
         )
 
+    async def reconcile_cleanup(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ) -> None:
+        """Safely remove legacy state without granting new runtime writes.
+
+        Historical engines use their existing full legacy synchronizer for
+        Local/Repo removal.  Center requires the Pool v3 contract and is never
+        permitted on this compatibility path.
+        """
+        service, _bot, engine, projection, effective_cli_items = (
+            self._resolve_cleanup_plan(bot_id=bot_id, owner_id=owner_id)
+        )
+        if any(mapping.corpus == "center" for mapping in projection.skill_mappings):
+            raise SkillSetRuntimeReconcileError()
+        if not service.sync_runtime(
+            desired_skills=self._desired_skills(projection)
+        ):
+            raise SkillSetRuntimeReconcileError()
+        await self._apply_non_skill_projection(
+            service=service,
+            engine=engine,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            projection=projection,
+            effective_cli_items=effective_cli_items,
+        )
+
     def _resolve_plan(
         self,
         *,
@@ -132,6 +164,33 @@ class BotRuntimeProjectionReconciler:
             raise LocalSkillNotFoundError()
         require_supported_bot_skill_runtime(bot)
 
+        return self._build_plan(
+            bot=bot,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            retired_mappings=retired_mappings,
+        )
+
+    def _resolve_cleanup_plan(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ):
+        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
+        if bot is None:
+            raise LocalSkillNotFoundError()
+        require_cleanup_capable_bot_skill_runtime(bot)
+        return self._build_plan(bot=bot, bot_id=bot_id, owner_id=owner_id)
+
+    def _build_plan(
+        self,
+        *,
+        bot: dict,
+        bot_id: str,
+        owner_id: str,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+    ):
         engine = str(bot.get("active_engine") or "openclaw")
         service = self._factory.create(
             user_id=owner_id,
@@ -218,16 +277,7 @@ class BotRuntimeProjectionReconciler:
             # MCP, Passport, probe, or mapping request is emitted.
             raise SkillSetRuntimeReconcileError()
 
-        desired_skills = [
-            {
-                "id": str(asset.skill_id),
-                "name": asset.name,
-                "git_path": asset.git_path,
-                "skill_uuid": asset.skill_uuid,
-                "sc_version_number": asset.sc_version_number,
-            }
-            for asset in projection.skill_assets
-        ]
+        desired_skills = self._desired_skills(projection)
         if engine == "teclaw":
             # Teclaw v4 consumes a complete Artifact projection through the
             # existing DeviceSync dispatcher. It has no Skills Pool mapping
@@ -256,7 +306,7 @@ class BotRuntimeProjectionReconciler:
             await self._apply_pool_mappings(
                 bot_id=bot_id,
                 owner_id=owner_id,
-                engine=engine,
+                layout_engine=runtime_layout_engine_for_bot(bot),
                 mappings=mappings,
                 retired_mappings=retired,
                 source_layout=(
@@ -303,7 +353,7 @@ class BotRuntimeProjectionReconciler:
         *,
         bot_id: str,
         owner_id: str,
-        engine: str,
+        layout_engine: str,
         mappings: list[PoolSkillMapping],
         retired_mappings: list[PoolSkillMapping],
         source_layout: SkillMappingSourceLayout,
@@ -315,7 +365,7 @@ class BotRuntimeProjectionReconciler:
                 probe = await self._pool_runtime.probe(
                     bot_id=bot_id,
                     user_id=owner_id,
-                    engine=engine,
+                    engine=layout_engine,
                 )
                 supported_versions = probe.evidence.get(
                     "supported_mapping_contract_versions"
@@ -341,6 +391,19 @@ class BotRuntimeProjectionReconciler:
             raise SkillSetRuntimeReconcileError() from exc
         if not verified:
             raise SkillSetRuntimeReconcileError()
+
+    @staticmethod
+    def _desired_skills(projection: RuntimeProjection) -> list[dict[str, str | None]]:
+        return [
+            {
+                "id": str(asset.skill_id),
+                "name": asset.name,
+                "git_path": asset.git_path,
+                "skill_uuid": asset.skill_uuid,
+                "sc_version_number": asset.sc_version_number,
+            }
+            for asset in projection.skill_assets
+        ]
 
 
 # Compatibility names for existing constructors and tests. They are aliases,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
@@ -28,6 +28,9 @@ from agentclaw.community.core.skill_center.runtime_resolver import (
     RuntimeDesiredState,
     RuntimeProjectionResolver,
 )
+from agentclaw.community.core.skill_center.runtime_policy import (
+    require_supported_bot_skill_runtime,
+)
 from agentclaw.community.core.skills_pool.mapping_intent import mapping_contract_for
 from agentclaw.community.core.skills_pool.models import (
     PoolSkillMapping,
@@ -90,6 +93,7 @@ class BotRuntimeProjectionReconciler:
         bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
         if bot is None:
             raise LocalSkillNotFoundError()
+        require_supported_bot_skill_runtime(bot)
 
         engine = str(bot.get("active_engine") or "openclaw")
         template_type = bot.get("template_type")
@@ -139,6 +143,13 @@ class BotRuntimeProjectionReconciler:
         )
         mappings = list(projection.skill_mappings)
         retired = list(retired_mappings)
+        if engine == "teclaw" and any(
+            mapping.corpus == "center" for mapping in [*mappings, *retired]
+        ):
+            # Teclaw v4 has no Center request contract. Phase 2 may add its
+            # OSS-backed Center store, but Phase 1 must not tunnel the Engine
+            # mapping-v3 protocol through the legacy Teclaw artifact path.
+            raise SkillSetRuntimeReconcileError()
         if (
             pool_owns_runtime
             or any(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
@@ -24,6 +24,7 @@ from agentclaw.community.core.skill_center.errors import (
 from agentclaw.community.core.skill_center.factories import SkillSetServiceFactory
 from agentclaw.community.core.skill_center.runtime_resolver import (
     RuntimeDesiredState,
+    RuntimeProjection,
     RuntimeProjectionResolver,
 )
 from agentclaw.community.core.skill_center.runtime_policy import (
@@ -76,6 +77,56 @@ class BotRuntimeProjectionReconciler:
         owner_id: str,
         retired_mappings: Sequence[PoolSkillMapping] = (),
     ) -> None:
+        service, bot, engine, projection, effective_cli_items = self._resolve_plan(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            retired_mappings=retired_mappings,
+        )
+        await self._apply_skill_projection(
+            service=service,
+            bot=bot,
+            engine=engine,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            projection=projection,
+            retired_mappings=retired_mappings,
+        )
+        await self._apply_non_skill_projection(
+            service=service,
+            engine=engine,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            projection=projection,
+            effective_cli_items=effective_cli_items,
+        )
+
+    async def reconcile_non_skill_projection(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ) -> None:
+        """Rebuild MCP/CLI when a cutover task exclusively owns Skill mappings."""
+        service, _bot, engine, projection, effective_cli_items = self._resolve_plan(
+            bot_id=bot_id,
+            owner_id=owner_id,
+        )
+        await self._apply_non_skill_projection(
+            service=service,
+            engine=engine,
+            bot_id=bot_id,
+            owner_id=owner_id,
+            projection=projection,
+            effective_cli_items=effective_cli_items,
+        )
+
+    def _resolve_plan(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
+    ):
         bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
         if bot is None:
             raise LocalSkillNotFoundError()
@@ -89,6 +140,21 @@ class BotRuntimeProjectionReconciler:
             engine_type=engine,
             entity_type=bot.get("entity_type") or "staff",
         )
+        skill_assets = tuple(
+            self._pool_skills.list_bot_active_assets(
+                env=str(bot["env"]),
+                bot_id=bot_id,
+                user_id=owner_id,
+                engine=engine,
+            )
+        )
+        if engine == "teclaw" and (
+            any(asset.git_path.startswith("center://") for asset in skill_assets)
+            or any(mapping.corpus == "center" for mapping in retired_mappings)
+        ):
+            # Reject before querying or writing any external MCP, Passport, or
+            # runtime boundary. Teclaw Center delivery belongs to Phase 2.
+            raise SkillSetRuntimeReconcileError()
         # The legacy SkillSet service remains the authority for effective
         # System Defaults during Phase 1.  It resolves template presets and
         # applies ac_default_skillset_mcp_exclusion; rebuilding defaults from
@@ -116,14 +182,7 @@ class BotRuntimeProjectionReconciler:
             raise SkillSetRuntimeReconcileError() from exc
         projection = RuntimeProjectionResolver().resolve(
             RuntimeDesiredState(
-                skills=tuple(
-                    self._pool_skills.list_bot_active_assets(
-                        env=str(bot["env"]),
-                        bot_id=bot_id,
-                        user_id=owner_id,
-                        engine=engine,
-                    )
-                ),
+                skills=skill_assets,
                 installed_mcp_server_codes=frozenset(
                     self._repository.list_installed_mcps(bot_id=bot_id)
                 ),
@@ -136,6 +195,47 @@ class BotRuntimeProjectionReconciler:
             )
         )
 
+        return service, bot, engine, projection, effective_cli_items
+
+    async def _apply_skill_projection(
+        self,
+        *,
+        service,
+        bot: dict,
+        engine: str,
+        bot_id: str,
+        owner_id: str,
+        projection: RuntimeProjection,
+        retired_mappings: Sequence[PoolSkillMapping],
+    ) -> None:
+        mappings = list(projection.skill_mappings)
+        retired = list(retired_mappings)
+        if engine == "teclaw" and any(
+            mapping.corpus == "center" for mapping in [*mappings, *retired]
+        ):
+            # Teclaw v4 has no Center request contract. Phase 2 adds its
+            # OSS-backed Center Store; Phase 1 must fail before any runtime,
+            # MCP, Passport, probe, or mapping request is emitted.
+            raise SkillSetRuntimeReconcileError()
+
+        desired_skills = [
+            {
+                "id": str(asset.skill_id),
+                "name": asset.name,
+                "git_path": asset.git_path,
+                "skill_uuid": asset.skill_uuid,
+                "sc_version_number": asset.sc_version_number,
+            }
+            for asset in projection.skill_assets
+        ]
+        if engine == "teclaw":
+            # Teclaw v4 consumes a complete Artifact projection through the
+            # existing DeviceSync dispatcher. It has no Skills Pool mapping
+            # endpoint; Repo/Local and their retirements must stay on v4.
+            if not service.sync_runtime(desired_skills=desired_skills):
+                raise SkillSetRuntimeReconcileError()
+            return
+
         scope = BotSkillLayoutScope(
             env=str(bot["env"]),
             entity_id=str(bot.get("entity_id") or owner_id),
@@ -145,15 +245,6 @@ class BotRuntimeProjectionReconciler:
         pool_owns_runtime = layout_state is not None and runtime_uses_pool_paths(
             layout_state
         )
-        mappings = list(projection.skill_mappings)
-        retired = list(retired_mappings)
-        if engine == "teclaw" and any(
-            mapping.corpus == "center" for mapping in [*mappings, *retired]
-        ):
-            # Teclaw v4 has no Center request contract. Phase 2 may add its
-            # OSS-backed Center store, but Phase 1 must not tunnel the Engine
-            # mapping-v3 protocol through the legacy Teclaw artifact path.
-            raise SkillSetRuntimeReconcileError()
         if (
             pool_owns_runtime
             or any(
@@ -174,20 +265,19 @@ class BotRuntimeProjectionReconciler:
                     else SkillMappingSourceLayout.LEGACY
                 ),
             )
-        elif not service.sync_runtime(
-            desired_skills=[
-                {
-                    "id": str(asset.skill_id),
-                    "name": asset.name,
-                    "git_path": asset.git_path,
-                    "skill_uuid": asset.skill_uuid,
-                    "sc_version_number": asset.sc_version_number,
-                }
-                for asset in projection.skill_assets
-            ]
-        ):
+        elif not service.sync_runtime(desired_skills=desired_skills):
             raise SkillSetRuntimeReconcileError()
 
+    async def _apply_non_skill_projection(
+        self,
+        *,
+        service,
+        engine: str,
+        bot_id: str,
+        owner_id: str,
+        projection: RuntimeProjection,
+        effective_cli_items: list[dict],
+    ) -> None:
         if not await service.sync_mcp_desired_state(
             server_codes=set(projection.mcp_server_codes)
         ):

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
@@ -33,7 +33,7 @@ from agentclaw.community.core.skill_center.runtime_resolver import (
     RuntimeDesiredState,
     RuntimeProjectionResolver,
 )
-from agentclaw.community.api.bot_runtime_projection_reconciler import (
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectionReconcilerProtocol,
 )
 from agentclaw.community.core.skill_center.services.bot_capability_mutation_guard import (

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
@@ -445,6 +445,18 @@ class LocalSkillStateService:
 
     def _sync_runtime(self, *, bot: dict[str, Any], owner_id: str, bot_id: str) -> bool:
         try:
+            projection = RuntimeProjectionResolver().resolve(
+                RuntimeDesiredState(
+                    skills=tuple(
+                        self._pool_skills.list_bot_active_assets(
+                            env=str(bot["env"]),
+                            bot_id=bot_id,
+                            user_id=owner_id,
+                            engine=str(bot.get("active_engine") or "openclaw"),
+                        )
+                    )
+                )
+            )
             service = self._skill_set_service_factory.create(
                 user_id=owner_id,
                 entity_id=str(bot["entity_id"]),
@@ -452,7 +464,20 @@ class LocalSkillStateService:
                 engine_type=bot.get("active_engine"),
                 entity_type=bot.get("entity_type"),
             )
-            return bool(service.sync_runtime())
+            return bool(
+                service.sync_runtime(
+                    desired_skills=[
+                        {
+                            "id": str(asset.skill_id),
+                            "name": asset.name,
+                            "git_path": asset.git_path,
+                            "skill_uuid": asset.skill_uuid,
+                            "sc_version_number": asset.sc_version_number,
+                        }
+                        for asset in projection.skill_assets
+                    ]
+                )
+            )
         except Exception:
             return False
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
@@ -33,7 +33,7 @@ from agentclaw.community.core.skill_center.runtime_resolver import (
     RuntimeDesiredState,
     RuntimeProjectionResolver,
 )
-from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
+from agentclaw.community.api.bot_runtime_projection_reconciler import (
     BotRuntimeProjectionReconcilerProtocol,
 )
 from agentclaw.community.core.skill_center.services.bot_capability_mutation_guard import (

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
@@ -27,7 +27,9 @@ from agentclaw.community.core.skill_center.errors import (
 )
 from agentclaw.community.core.skill_center.factories import SkillSetServiceFactory
 from agentclaw.community.core.skill_center.runtime_policy import (
-    require_supported_bot_skill_runtime,
+    BotSkillRuntimeCommand,
+    BotSkillRuntimeMutationMode,
+    require_bot_skill_runtime_command,
 )
 from agentclaw.community.core.skill_center.runtime_resolver import (
     RuntimeDesiredState,
@@ -124,6 +126,8 @@ class LocalSkillStateService:
                     raise LocalSkillNotFoundError()
                 if not is_bot_ready(bot):
                     raise LocalSkillNotReadyError()
+                command = self._runtime_command(active=active)
+                mode = require_bot_skill_runtime_command(bot, command)
                 changed = self._write_desired_state(
                     active=active,
                     env=str(bot["env"]),
@@ -134,13 +138,18 @@ class LocalSkillStateService:
 
                 if active:
                     synced = await self._reconcile_runtime(
-                        bot_id=bot_id, owner_id=owner_id
+                        bot_id=bot_id,
+                        owner_id=owner_id,
+                        command=command,
+                        mode=mode,
                     )
                 else:
                     synced = await self._reconcile_deactivation(
                         skill=skill,
                         owner_id=owner_id,
                         bot_id=bot_id,
+                        command=command,
+                        mode=mode,
                     )
                 self._ensure_mutation_lease(mutation_lease)
                 if not synced:
@@ -159,7 +168,10 @@ class LocalSkillStateService:
                         # It owns each engine's actual active-root compatibility,
                         # including Claude Code's historical workspace root.
                         restored = await self._reconcile_runtime(
-                            bot_id=bot_id, owner_id=owner_id
+                            bot_id=bot_id,
+                            owner_id=owner_id,
+                            command=command,
+                            mode=mode,
                         )
                         self._ensure_mutation_lease(mutation_lease)
                         if not restored:
@@ -197,7 +209,8 @@ class LocalSkillStateService:
                 raise LocalSkillNotFoundError()
         if not is_bot_ready(bot):
             raise LocalSkillNotReadyError()
-        self._require_supported_repo_runtime(bot)
+        command = self._runtime_command(active=active)
+        mode = self._require_repo_runtime_command(bot, command)
         scope = self._scope_for(bot, bot_id)
         try:
             mutation_lease = self._mutation_guard.acquire(scope=scope)
@@ -243,13 +256,18 @@ class LocalSkillStateService:
                 self._ensure_mutation_lease(mutation_lease)
                 if active:
                     synced = await self._reconcile_runtime(
-                        owner_id=owner_id, bot_id=bot_id
+                        owner_id=owner_id,
+                        bot_id=bot_id,
+                        command=command,
+                        mode=mode,
                     )
                 else:
                     synced = await self._reconcile_deactivation(
                         skill=raw,
                         owner_id=owner_id,
                         bot_id=bot_id,
+                        command=command,
+                        mode=mode,
                     )
                 self._ensure_mutation_lease(mutation_lease)
                 if synced:
@@ -272,7 +290,10 @@ class LocalSkillStateService:
                     except Exception as exc:
                         raise LocalSkillStorageError() from exc
                     if not await self._reconcile_runtime(
-                        owner_id=owner_id, bot_id=bot_id
+                        owner_id=owner_id,
+                        bot_id=bot_id,
+                        command=command,
+                        mode=mode,
                     ):
                         raise LocalSkillRuntimeSyncError()
                     self._ensure_mutation_lease(mutation_lease)
@@ -360,8 +381,18 @@ class LocalSkillStateService:
         return self._installations.uninstall(env=env, bot_id=bot_id, skill_id=skill_id)
 
     @staticmethod
-    def _require_supported_repo_runtime(bot: dict[str, Any]) -> None:
-        require_supported_bot_skill_runtime(bot)
+    def _require_repo_runtime_command(
+        bot: dict[str, Any], command: BotSkillRuntimeCommand
+    ) -> BotSkillRuntimeMutationMode:
+        return require_bot_skill_runtime_command(bot, command)
+
+    @staticmethod
+    def _runtime_command(*, active: bool) -> BotSkillRuntimeCommand:
+        return (
+            BotSkillRuntimeCommand.WRITE
+            if active
+            else BotSkillRuntimeCommand.CLEANUP
+        )
 
     def _require_no_normal_skill_set_membership(
         self,
@@ -439,8 +470,16 @@ class LocalSkillStateService:
         owner_id: str,
         bot_id: str,
         retired_mappings=(),
+        command: BotSkillRuntimeCommand,
+        mode: BotSkillRuntimeMutationMode,
     ) -> bool:
         try:
+            if mode is BotSkillRuntimeMutationMode.CLEANUP_ONLY:
+                await self._runtime_reconciler.reconcile_cleanup(
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                )
+                return True
             if retired_mappings:
                 await self._runtime_reconciler.reconcile(
                     bot_id=bot_id,
@@ -462,6 +501,8 @@ class LocalSkillStateService:
         skill: dict[str, Any],
         owner_id: str,
         bot_id: str,
+        command: BotSkillRuntimeCommand,
+        mode: BotSkillRuntimeMutationMode,
     ) -> bool:
         try:
             retired_mapping = list(
@@ -495,4 +536,6 @@ class LocalSkillStateService:
             owner_id=owner_id,
             bot_id=bot_id,
             retired_mappings=retired_mapping,
+            command=command,
+            mode=mode,
         )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
@@ -33,6 +33,9 @@ from agentclaw.community.core.skill_center.runtime_resolver import (
     RuntimeDesiredState,
     RuntimeProjectionResolver,
 )
+from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
+    BotRuntimeProjectionReconcilerProtocol,
+)
 from agentclaw.community.core.skill_center.services.bot_capability_mutation_guard import (
     BotCapabilityMutationBusyError,
     BotCapabilityMutationGuard,
@@ -47,7 +50,6 @@ from agentclaw.community.core.repository.protocols.skill_installation import (
     SkillInstallationRepositoryProtocol,
 )
 from agentclaw.community.core.repository.protocols.skills_pool import (
-    SkillsPoolLayoutRepositoryProtocol,
     SkillsPoolSkillRepositoryProtocol,
 )
 from agentclaw.community.core.skills_pool.edit_guard import (
@@ -61,19 +63,9 @@ from agentclaw.community.core.skills_pool.mapping_intent import (
     build_logical_skill_mappings,
 )
 from agentclaw.community.core.skills_pool.models import (
-    PoolSkillMapping,
     RegisteredSkillAsset,
-    SkillMappingSourceLayout,
 )
-from agentclaw.community.core.skills_pool.ports import SkillsPoolRuntimeProtocol
-from agentclaw.community.core.skills_pool.types import (
-    BotSkillLayoutScope,
-    runtime_uses_pool_paths,
-)
-from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
-    MAPPING_CONTRACT_VERSION,
-    MAPPING_V3_CONTRACT_VERSION,
-)
+from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
 
 
 class LocalSkillStateService:
@@ -89,10 +81,9 @@ class LocalSkillStateService:
         skill_set_service_factory: SkillSetServiceFactory,
         mutation_guard: BotCapabilityMutationGuard,
         edit_guard: SkillsPoolEditGuard,
-        pool_runtime: SkillsPoolRuntimeProtocol,
         pool_skills: SkillsPoolSkillRepositoryProtocol,
-        pool_layouts: SkillsPoolLayoutRepositoryProtocol,
         skill_set_repo: SkillSetRepository,
+        runtime_reconciler: BotRuntimeProjectionReconcilerProtocol,
     ) -> None:
         self._skill_repo = skill_repo
         self._installations = installations
@@ -101,10 +92,9 @@ class LocalSkillStateService:
         self._skill_set_service_factory = skill_set_service_factory
         self._mutation_guard = mutation_guard
         self._edit_guard = edit_guard
-        self._pool_runtime = pool_runtime
         self._pool_skills = pool_skills
-        self._pool_layouts = pool_layouts
         self._skill_set_repo = skill_set_repo
+        self._runtime_reconciler = runtime_reconciler
 
     async def set_local_skill_active(
         self, *, skill_id: str, actor_id: str, active: bool
@@ -143,13 +133,11 @@ class LocalSkillStateService:
                 self._ensure_mutation_lease(mutation_lease)
 
                 if active:
-                    synced = self._sync_runtime(
-                        bot=bot, owner_id=owner_id, bot_id=bot_id
+                    synced = await self._reconcile_runtime(
+                        bot_id=bot_id, owner_id=owner_id
                     )
                 else:
                     synced = await self._reconcile_deactivation(
-                        scope=scope,
-                        bot=bot,
                         skill=skill,
                         owner_id=owner_id,
                         bot_id=bot_id,
@@ -170,8 +158,8 @@ class LocalSkillStateService:
                         # Restore through the established runtime synchronizer.
                         # It owns each engine's actual active-root compatibility,
                         # including Claude Code's historical workspace root.
-                        restored = self._sync_runtime(
-                            bot=bot, owner_id=owner_id, bot_id=bot_id
+                        restored = await self._reconcile_runtime(
+                            bot_id=bot_id, owner_id=owner_id
                         )
                         self._ensure_mutation_lease(mutation_lease)
                         if not restored:
@@ -254,13 +242,11 @@ class LocalSkillStateService:
                     raise LocalSkillStorageError() from exc
                 self._ensure_mutation_lease(mutation_lease)
                 if active:
-                    synced = await self._publish_current_mappings(
-                        scope=scope, bot=bot, owner_id=owner_id, bot_id=bot_id
+                    synced = await self._reconcile_runtime(
+                        owner_id=owner_id, bot_id=bot_id
                     )
                 else:
                     synced = await self._reconcile_deactivation(
-                        scope=scope,
-                        bot=bot,
                         skill=raw,
                         owner_id=owner_id,
                         bot_id=bot_id,
@@ -285,8 +271,8 @@ class LocalSkillStateService:
                         )
                     except Exception as exc:
                         raise LocalSkillStorageError() from exc
-                    if not await self._publish_current_mappings(
-                        scope=scope, bot=bot, owner_id=owner_id, bot_id=bot_id
+                    if not await self._reconcile_runtime(
+                        owner_id=owner_id, bot_id=bot_id
                     ):
                         raise LocalSkillRuntimeSyncError()
                     self._ensure_mutation_lease(mutation_lease)
@@ -447,49 +433,32 @@ class LocalSkillStateService:
             ):
                 raise SkillSetManagedResourceError()
 
-    def _sync_runtime(self, *, bot: dict[str, Any], owner_id: str, bot_id: str) -> bool:
+    async def _reconcile_runtime(
+        self,
+        *,
+        owner_id: str,
+        bot_id: str,
+        retired_mappings=(),
+    ) -> bool:
         try:
-            projection = RuntimeProjectionResolver().resolve(
-                RuntimeDesiredState(
-                    skills=tuple(
-                        self._pool_skills.list_bot_active_assets(
-                            env=str(bot["env"]),
-                            bot_id=bot_id,
-                            user_id=owner_id,
-                            engine=str(bot.get("active_engine") or "openclaw"),
-                        )
-                    )
+            if retired_mappings:
+                await self._runtime_reconciler.reconcile(
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                    retired_mappings=retired_mappings,
                 )
-            )
-            service = self._skill_set_service_factory.create(
-                user_id=owner_id,
-                entity_id=str(bot["entity_id"]),
-                bot_id=bot_id,
-                engine_type=bot.get("active_engine"),
-                entity_type=bot.get("entity_type"),
-            )
-            return bool(
-                service.sync_runtime(
-                    desired_skills=[
-                        {
-                            "id": str(asset.skill_id),
-                            "name": asset.name,
-                            "git_path": asset.git_path,
-                            "skill_uuid": asset.skill_uuid,
-                            "sc_version_number": asset.sc_version_number,
-                        }
-                        for asset in projection.skill_assets
-                    ]
+            else:
+                await self._runtime_reconciler.reconcile(
+                    bot_id=bot_id,
+                    owner_id=owner_id,
                 )
-            )
+            return True
         except Exception:
             return False
 
     async def _reconcile_deactivation(
         self,
         *,
-        scope: BotSkillLayoutScope,
-        bot: dict[str, Any],
         skill: dict[str, Any],
         owner_id: str,
         bot_id: str,
@@ -522,64 +491,8 @@ class LocalSkillStateService:
             )
         except (KeyError, TypeError, ValueError):
             return False
-        return await self._publish_current_mappings(
-            scope=scope,
-            bot=bot,
+        return await self._reconcile_runtime(
             owner_id=owner_id,
             bot_id=bot_id,
             retired_mappings=retired_mapping,
         )
-
-    async def _publish_current_mappings(
-        self,
-        *,
-        scope: BotSkillLayoutScope,
-        bot: dict[str, Any],
-        owner_id: str,
-        bot_id: str,
-        retired_mappings: list[PoolSkillMapping] | None = None,
-    ) -> bool:
-        try:
-            projection = RuntimeProjectionResolver().resolve(
-                RuntimeDesiredState(
-                    skills=tuple(
-                        self._pool_skills.list_bot_active_assets(
-                            env=scope.env,
-                            bot_id=bot_id,
-                            user_id=owner_id,
-                            engine=str(bot["active_engine"]),
-                        )
-                    )
-                )
-            )
-            mappings = list(projection.skill_mappings)
-            source_layout = (
-                SkillMappingSourceLayout.POOL
-                if runtime_uses_pool_paths(self._pool_layouts.get(scope))
-                else SkillMappingSourceLayout.LEGACY
-            )
-            retired = retired_mappings or []
-            mapping_contract = (
-                MAPPING_V3_CONTRACT_VERSION
-                if any(mapping.corpus == "center" for mapping in mappings)
-                else MAPPING_CONTRACT_VERSION
-            )
-            if not await self._pool_runtime.publish_mappings(
-                bot_id=bot_id,
-                user_id=owner_id,
-                mappings=mappings,
-                retired_mappings=retired,
-                source_layout=source_layout,
-                mapping_contract_version=mapping_contract,
-            ):
-                return False
-            return await self._pool_runtime.verify_mappings(
-                bot_id=bot_id,
-                user_id=owner_id,
-                mappings=mappings,
-                retired_mappings=retired,
-                source_layout=source_layout,
-                mapping_contract_version=mapping_contract,
-            )
-        except Exception:
-            return False

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
@@ -29,6 +29,10 @@ from agentclaw.community.core.skill_center.factories import SkillSetServiceFacto
 from agentclaw.community.core.skill_center.runtime_policy import (
     require_supported_bot_skill_runtime,
 )
+from agentclaw.community.core.skill_center.runtime_resolver import (
+    RuntimeDesiredState,
+    RuntimeProjectionResolver,
+)
 from agentclaw.community.core.skill_center.services.bot_capability_mutation_guard import (
     BotCapabilityMutationBusyError,
     BotCapabilityMutationGuard,
@@ -462,24 +466,30 @@ class LocalSkillStateService:
         bot_id: str,
     ) -> bool:
         try:
-            retired_mapping = build_logical_skill_mappings(
-                [
-                    RegisteredSkillAsset(
-                        skill_id=int(skill["id"]),
-                        name=str(skill["name"]),
-                        git_path=str(skill["git_path"]),
-                        skill_uuid=(
-                            str(skill["skill_uuid"])
-                            if skill.get("skill_uuid") is not None
-                            else None
-                        ),
-                        sc_version_number=(
-                            str(skill["sc_version_number"])
-                            if skill.get("sc_version_number") is not None
-                            else None
-                        ),
+            retired_mapping = list(
+                RuntimeProjectionResolver()
+                .resolve(
+                    RuntimeDesiredState(
+                        skills=(
+                            RegisteredSkillAsset(
+                                skill_id=int(skill["id"]),
+                                name=str(skill["name"]),
+                                git_path=str(skill["git_path"]),
+                                skill_uuid=(
+                                    str(skill["skill_uuid"])
+                                    if skill.get("skill_uuid") is not None
+                                    else None
+                                ),
+                                sc_version_number=(
+                                    str(skill["sc_version_number"])
+                                    if skill.get("sc_version_number") is not None
+                                    else None
+                                ),
+                            ),
+                        )
                     )
-                ]
+                )
+                .skill_mappings
             )
         except (KeyError, TypeError, ValueError):
             return False
@@ -501,14 +511,19 @@ class LocalSkillStateService:
         retired_mappings: list[PoolSkillMapping] | None = None,
     ) -> bool:
         try:
-            mappings = build_logical_skill_mappings(
-                self._pool_skills.list_bot_active_assets(
-                    env=scope.env,
-                    bot_id=bot_id,
-                    user_id=owner_id,
-                    engine=str(bot["active_engine"]),
+            projection = RuntimeProjectionResolver().resolve(
+                RuntimeDesiredState(
+                    skills=tuple(
+                        self._pool_skills.list_bot_active_assets(
+                            env=scope.env,
+                            bot_id=bot_id,
+                            user_id=owner_id,
+                            engine=str(bot["active_engine"]),
+                        )
+                    )
                 )
             )
+            mappings = list(projection.skill_mappings)
             source_layout = (
                 SkillMappingSourceLayout.POOL
                 if runtime_uses_pool_paths(self._pool_layouts.get(scope))

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
@@ -70,6 +70,10 @@ from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     runtime_uses_pool_paths,
 )
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    MAPPING_CONTRACT_VERSION,
+    MAPPING_V3_CONTRACT_VERSION,
+)
 
 
 class LocalSkillStateService:
@@ -555,12 +559,18 @@ class LocalSkillStateService:
                 else SkillMappingSourceLayout.LEGACY
             )
             retired = retired_mappings or []
+            mapping_contract = (
+                MAPPING_V3_CONTRACT_VERSION
+                if any(mapping.corpus == "center" for mapping in mappings)
+                else MAPPING_CONTRACT_VERSION
+            )
             if not await self._pool_runtime.publish_mappings(
                 bot_id=bot_id,
                 user_id=owner_id,
                 mappings=mappings,
                 retired_mappings=retired,
                 source_layout=source_layout,
+                mapping_contract_version=mapping_contract,
             ):
                 return False
             return await self._pool_runtime.verify_mappings(
@@ -569,6 +579,7 @@ class LocalSkillStateService:
                 mappings=mappings,
                 retired_mappings=retired,
                 source_layout=source_layout,
+                mapping_contract_version=mapping_contract,
             )
         except Exception:
             return False

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -55,7 +55,7 @@ from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditRollbackError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
-from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
+from agentclaw.community.api.bot_runtime_projection_reconciler import (
     BotRuntimeProjectionReconcilerProtocol,
 )
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -53,6 +53,10 @@ from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditRollbackError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.core.skill_center.runtime_resolver import (
+    RuntimeDesiredState,
+    RuntimeProjectionResolver,
+)
 
 if TYPE_CHECKING:
     from agentclaw.community.core.devices.services.device_context_resolver import (
@@ -671,6 +675,18 @@ class LocalSkillUploadService:
 
     def _sync_runtime(self, bot: dict[str, Any], owner_id: str, bot_id: str) -> bool:
         try:
+            projection = RuntimeProjectionResolver().resolve(
+                RuntimeDesiredState(
+                    skills=tuple(
+                        self._skill_repo.list_bot_active_assets(
+                            env=str(bot["env"]),
+                            bot_id=bot_id,
+                            user_id=owner_id,
+                            engine=str(bot.get("active_engine") or "openclaw"),
+                        )
+                    )
+                )
+            )
             service = self._skill_set_service_factory.create(
                 user_id=owner_id,
                 entity_id=str(bot["entity_id"]),
@@ -678,7 +694,20 @@ class LocalSkillUploadService:
                 engine_type=bot.get("active_engine"),
                 entity_type=bot.get("entity_type"),
             )
-            return bool(service.sync_runtime())
+            return bool(
+                service.sync_runtime(
+                    desired_skills=[
+                        {
+                            "id": str(asset.skill_id),
+                            "name": asset.name,
+                            "git_path": asset.git_path,
+                            "skill_uuid": asset.skill_uuid,
+                            "sc_version_number": asset.sc_version_number,
+                        }
+                        for asset in projection.skill_assets
+                    ]
+                )
+            )
         except Exception:
             return False
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -39,6 +39,9 @@ from agentclaw.community.core.skill_center.services.skill_parser import (
     SkillManifestError,
     SkillParser,
 )
+from agentclaw.community.core.skill_center.runtime_policy import (
+    require_supported_bot_skill_runtime,
+)
 from agentclaw.community.core.bot_management.readiness import is_bot_ready
 from agentclaw.community.core.skill_center.factories import (
     SkillServiceFactory,
@@ -123,6 +126,7 @@ class LocalSkillUploadService:
                 raise LocalSkillNotFoundError()
             if not is_bot_ready(bot):
                 raise LocalSkillNotReadyError()
+            require_supported_bot_skill_runtime(bot)
             name, description, files = self._unpack(package)
             is_teclaw = self._is_teclaw(bot_id=bot_id, owner_id=owner_id)
             await self._retry_pending_cleanup(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -55,7 +55,7 @@ from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditRollbackError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
-from agentclaw.community.api.bot_runtime_projection_reconciler import (
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectionReconcilerProtocol,
 )
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -42,7 +42,6 @@ from agentclaw.community.core.skill_center.services.skill_parser import (
 from agentclaw.community.core.bot_management.readiness import is_bot_ready
 from agentclaw.community.core.skill_center.factories import (
     SkillServiceFactory,
-    SkillSetServiceFactory,
 )
 from agentclaw.community.core.repository.protocols.skill_center import LocalSkillCleanupRepository
 from agentclaw.community.core.skills_pool.edit_guard import (
@@ -53,9 +52,8 @@ from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditRollbackError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
-from agentclaw.community.core.skill_center.runtime_resolver import (
-    RuntimeDesiredState,
-    RuntimeProjectionResolver,
+from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
+    BotRuntimeProjectionReconcilerProtocol,
 )
 
 if TYPE_CHECKING:
@@ -81,22 +79,22 @@ class LocalSkillUploadService:
         bot_repo: BotRepository,
         collaborator_service: CollaboratorServiceProtocol,
         skill_service_factory: SkillServiceFactory,
-        skill_set_service_factory: SkillSetServiceFactory,
         audit_log_repo: BotCollabLogRepositoryProtocol,
         edit_guard: SkillsPoolEditGuard,
         cleanup_repo: LocalSkillCleanupRepository,
         device_context_resolver_provider: Callable[[], "DeviceContextResolver"],
+        runtime_reconciler: BotRuntimeProjectionReconcilerProtocol,
     ) -> None:
         self._skill_repo = skill_repo
         self._skill_set_repo = skill_set_repo
         self._bot_repo = bot_repo
         self._collaborators = collaborator_service
         self._skill_service_factory = skill_service_factory
-        self._skill_set_service_factory = skill_set_service_factory
         self._audit_log_repo = audit_log_repo
         self._edit_guard = edit_guard
         self._cleanup_repo = cleanup_repo
         self._device_context_resolver_provider = device_context_resolver_provider
+        self._runtime_reconciler = runtime_reconciler
 
     async def upload_local_skill(
         self, *, bot_id: str, owner_id: str, actor_id: str, package: bytes
@@ -374,7 +372,7 @@ class LocalSkillUploadService:
                 raise RuntimeError("Local Skill metadata switch failed")
             switched = True
             runtime_sync_attempted = True
-            if not self._sync_runtime(bot, owner_id, bot_id):
+            if not await self._sync_runtime(owner_id, bot_id):
                 raise LocalSkillRuntimeSyncError()
             self._audit_log_repo.insert(
                 {
@@ -472,7 +470,7 @@ class LocalSkillUploadService:
                 raise LocalSkillStorageError()
             if (
                 runtime_sync_attempted
-                and not self._sync_runtime(bot, owner_id, bot_id)
+                and not await self._sync_runtime(owner_id, bot_id)
             ):
                 # Runtime may have switched partway before reporting failure.
                 # Keep the complete staged package until a later serialized
@@ -576,8 +574,8 @@ class LocalSkillUploadService:
                     int(work["id"]), bot, owner_id, bot_id
                 )
                 continue
-            if bool(work.get("requires_runtime_restore")) and not self._sync_runtime(
-                bot, owner_id, bot_id
+            if bool(work.get("requires_runtime_restore")) and not await self._sync_runtime(
+                owner_id, bot_id
             ):
                 if not self._cleanup_repo.mark_failed(
                     work_id=int(work["id"]),
@@ -673,41 +671,13 @@ class LocalSkillUploadService:
             matches.append({**row, "active": bool(current["active"])})
         return matches
 
-    def _sync_runtime(self, bot: dict[str, Any], owner_id: str, bot_id: str) -> bool:
+    async def _sync_runtime(self, owner_id: str, bot_id: str) -> bool:
         try:
-            projection = RuntimeProjectionResolver().resolve(
-                RuntimeDesiredState(
-                    skills=tuple(
-                        self._skill_repo.list_bot_active_assets(
-                            env=str(bot["env"]),
-                            bot_id=bot_id,
-                            user_id=owner_id,
-                            engine=str(bot.get("active_engine") or "openclaw"),
-                        )
-                    )
-                )
-            )
-            service = self._skill_set_service_factory.create(
-                user_id=owner_id,
-                entity_id=str(bot["entity_id"]),
+            await self._runtime_reconciler.reconcile(
                 bot_id=bot_id,
-                engine_type=bot.get("active_engine"),
-                entity_type=bot.get("entity_type"),
+                owner_id=owner_id,
             )
-            return bool(
-                service.sync_runtime(
-                    desired_skills=[
-                        {
-                            "id": str(asset.skill_id),
-                            "name": asset.name,
-                            "git_path": asset.git_path,
-                            "skill_uuid": asset.skill_uuid,
-                            "sc_version_number": asset.sc_version_number,
-                        }
-                        for asset in projection.skill_assets
-                    ]
-                )
-            )
+            return True
         except Exception:
             return False
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -39,6 +39,10 @@ from agentclaw.community.core.skill_center.factories import SkillSetServiceFacto
 from agentclaw.community.core.skill_center.runtime_policy import (
     require_supported_bot_skill_runtime,
 )
+from agentclaw.community.core.skill_center.runtime_resolver import (
+    RuntimeDesiredState,
+    RuntimeProjectionResolver,
+)
 from agentclaw.community.core.skill_center.services.bot_capability_mutation_guard import (
     BotCapabilityMutationBusyError,
     BotCapabilityMutationGuard,
@@ -53,6 +57,9 @@ from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditRollbackError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.core.repository.protocols.skills_pool import (
+    SkillsPoolSkillRepositoryProtocol,
+)
 from agentclaw.community.plugin_api.passport import PassportPlugin
 from agentclaw.community.utils.env_utils import get_current_env
 
@@ -74,10 +81,12 @@ class SkillSetRuntimeReconciler:
         factory: SkillSetServiceFactory,
         bot_repo: BotRepository,
         repository: SkillSetControlPlaneRepositoryProtocol,
+        pool_skills: SkillsPoolSkillRepositoryProtocol,
     ) -> None:
         self._factory = factory
         self._bot_repo = bot_repo
         self._repository = repository
+        self._pool_skills = pool_skills
 
     async def reconcile(self, *, bot_id: str, owner_id: str) -> None:
         bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
@@ -90,10 +99,28 @@ class SkillSetRuntimeReconciler:
             engine_type=bot.get("active_engine"),
             entity_type=bot.get("entity_type") or "staff",
         )
+        projection = RuntimeProjectionResolver().resolve(
+            RuntimeDesiredState(
+                skills=tuple(
+                    self._pool_skills.list_bot_active_assets(
+                        env=str(bot["env"]),
+                        bot_id=bot_id,
+                        user_id=owner_id,
+                        engine=str(bot.get("active_engine") or "openclaw"),
+                    )
+                ),
+                installed_mcp_server_codes=frozenset(
+                    self._repository.list_installed_mcps(bot_id=bot_id)
+                ),
+            )
+        )
+        # The legacy Adapter still owns physical path translation, but gets a
+        # full reconciliation command only after the shared Resolver has
+        # validated the canonical desired-state snapshot.
         if not service.sync_runtime():
             raise SkillSetRuntimeReconcileError()
         if not await service.sync_mcp_desired_state(
-            server_codes=self._repository.list_installed_mcps(bot_id=bot_id)
+            server_codes=set(projection.mcp_server_codes)
         ):
             raise SkillSetRuntimeReconcileError()
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -36,7 +36,7 @@ from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import
 from agentclaw.community.core.skill_center.runtime_policy import (
     require_supported_bot_skill_runtime,
 )
-from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
+from agentclaw.community.api.bot_runtime_projection_reconciler import (
     BotRuntimeProjectionReconcilerProtocol,
 )
 from agentclaw.community.core.skill_center.services.bot_capability_mutation_guard import (

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -61,6 +61,10 @@ from agentclaw.community.core.repository.protocols.skills_pool import (
     SkillsPoolSkillRepositoryProtocol,
 )
 from agentclaw.community.plugin_api.passport import PassportPlugin
+from agentclaw.community.core.mcp.services._defaults import (
+    get_default_cli_items,
+    get_default_mcp_servers,
+)
 from agentclaw.community.utils.env_utils import get_current_env
 
 
@@ -111,6 +115,22 @@ class SkillSetRuntimeReconciler:
                 ),
                 installed_mcp_server_codes=frozenset(
                     self._repository.list_installed_mcps(bot_id=bot_id)
+                ),
+                system_default_mcp_server_codes=frozenset(
+                    str(item["server_code"])
+                    for item in get_default_mcp_servers(
+                        str(bot.get("active_engine") or "openclaw"),
+                        bot.get("template_type"),
+                    )
+                    if item.get("server_code")
+                ),
+                system_default_cli_commands=tuple(
+                    str(item["cli_code"])
+                    for item in get_default_cli_items(
+                        str(bot.get("active_engine") or "openclaw"),
+                        bot.get("template_type"),
+                    )
+                    if item.get("cli_code")
                 ),
             )
         )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -114,10 +114,22 @@ class SkillSetRuntimeReconciler:
                 ),
             )
         )
-        # The legacy Adapter still owns physical path translation, but gets a
-        # full reconciliation command only after the shared Resolver has
-        # validated the canonical desired-state snapshot.
-        if not service.sync_runtime():
+        # The Engine adapter owns physical translation, while the Resolver
+        # supplies its complete canonical asset snapshot.  It must not query
+        # Default exclusions or rebuild state from legacy BFF records.
+        if not service.sync_runtime(
+            desired_skills=[
+                {
+                    "id": str(asset.skill_id),
+                    "name": asset.name,
+                    "git_path": asset.git_path,
+                    "skill_uuid": asset.skill_uuid,
+                    "sc_version_number": asset.sc_version_number,
+                }
+                for asset in projection.skill_assets
+                if not asset.git_path.startswith("center://")
+            ]
+        ):
             raise SkillSetRuntimeReconcileError()
         if not await service.sync_mcp_desired_state(
             server_codes=set(projection.mcp_server_codes)

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -34,7 +34,9 @@ from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import
     LegacySkillSetCompatibilityFactoryProtocol,
 )
 from agentclaw.community.core.skill_center.runtime_policy import (
-    require_supported_bot_skill_runtime,
+    BotSkillRuntimeCommand,
+    BotSkillRuntimeMutationMode,
+    require_bot_skill_runtime_command,
 )
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectionReconcilerProtocol,
@@ -264,7 +266,15 @@ class SkillSetControlPlaneService:
 
     def delete_set(self, *, bot_id: str, actor_id: str, set_id: str) -> None:
         bot = self._bot(bot_id, actor_id)
-        self._require_mutable_bot(bot)
+        item = self._repository.get_set(
+            bot_id=bot_id, set_id=set_id, engine_type=self._engine(bot)
+        )
+        command = (
+            BotSkillRuntimeCommand.CLEANUP
+            if not item.get("is_active")
+            else BotSkillRuntimeCommand.WRITE
+        )
+        self._require_mutable_bot(bot, command)
         scope = self._scope(bot, bot_id)
         try:
             mutation_lease = self._mutation_guard.acquire(scope=scope)
@@ -353,6 +363,7 @@ class SkillSetControlPlaneService:
             bot_id=bot_id,
             actor_id=actor_id,
             action="skill_set_remove_skill",
+            command=BotSkillRuntimeCommand.CLEANUP,
             mutation=lambda: self._repository.remove_skill(
                 bot_id=bot_id,
                 set_id=set_id,
@@ -424,6 +435,7 @@ class SkillSetControlPlaneService:
             bot_id=bot_id,
             actor_id=actor_id,
             action="skill_set_remove_mcp",
+            command=BotSkillRuntimeCommand.CLEANUP,
             mutation=lambda: self._repository.remove_mcp(
                 bot_id=bot_id, set_id=set_id, server_code=server_code,
                 engine_type=self._engine(bot),
@@ -455,6 +467,7 @@ class SkillSetControlPlaneService:
             bot_id=bot_id,
             actor_id=actor_id,
             action="mcp_direct_deactivate",
+            command=BotSkillRuntimeCommand.CLEANUP,
             mutation=lambda: self._repository.deactivate_mcp_direct(
                 bot_id=bot_id, server_code=server_code,
                 engine_type=self._engine(bot),
@@ -493,6 +506,7 @@ class SkillSetControlPlaneService:
             bot_id=bot_id,
             actor_id=actor_id,
             action="skill_set_deactivate",
+            command=BotSkillRuntimeCommand.CLEANUP,
             mutation=lambda: self._repository.set_active(
                 bot_id=bot_id,
                 set_id=set_id,
@@ -568,7 +582,14 @@ class SkillSetControlPlaneService:
         ]
 
     async def _mutate(
-        self, *, bot: dict, bot_id: str, actor_id: str, action: str, mutation
+        self,
+        *,
+        bot: dict,
+        bot_id: str,
+        actor_id: str,
+        action: str,
+        mutation,
+        command: BotSkillRuntimeCommand = BotSkillRuntimeCommand.WRITE,
     ) -> dict:
         """Keep one Bot edit lease across UoW, projection and compensation.
 
@@ -596,7 +617,7 @@ class SkillSetControlPlaneService:
             except SkillsPoolEditLockUnavailableError as exc:
                 raise SkillSetControlPlaneLockUnavailableError() from exc
             try:
-                self._require_mutable_bot(bot)
+                mode = self._require_mutable_bot(bot, command)
                 self._ensure_mutation_lease(mutation_lease)
                 mutation_result = mutation()
                 self._ensure_mutation_lease(mutation_lease)
@@ -622,6 +643,8 @@ class SkillSetControlPlaneService:
                         actor_id=actor_id,
                         mutation=mutation_result,
                         mutation_lease=mutation_lease,
+                        command=command,
+                        mode=mode,
                     )
                 self._ensure_mutation_lease(mutation_lease)
                 self._audit(
@@ -644,10 +667,14 @@ class SkillSetControlPlaneService:
         actor_id: str,
         mutation: SkillSetMutation,
         mutation_lease: BotCapabilityMutationLease,
+        command: BotSkillRuntimeCommand,
+        mode: BotSkillRuntimeMutationMode,
     ) -> dict:
         owner_id = str(bot["owner_id"])
         try:
-            await self._runtime.reconcile(bot_id=bot_id, owner_id=owner_id)
+            await self._reconcile_runtime(
+                command=command, mode=mode, bot_id=bot_id, owner_id=owner_id
+            )
         except Exception as exc:
             # A stale holder must never compensate over a newer command.
             self._ensure_mutation_lease(mutation_lease)
@@ -657,7 +684,9 @@ class SkillSetControlPlaneService:
                 engine_type=self._engine(bot),
             )
             try:
-                await self._runtime.reconcile(bot_id=bot_id, owner_id=owner_id)
+                await self._reconcile_runtime(
+                    command=command, mode=mode, bot_id=bot_id, owner_id=owner_id
+                )
             except Exception as restore_error:
                 raise SkillSetRuntimeReconcileError() from restore_error
             self._ensure_mutation_lease(mutation_lease)
@@ -709,7 +738,22 @@ class SkillSetControlPlaneService:
         return str(bot["active_engine"])
 
     @staticmethod
-    def _require_mutable_bot(bot: dict) -> None:
+    def _require_mutable_bot(
+        bot: dict, command: BotSkillRuntimeCommand = BotSkillRuntimeCommand.WRITE
+    ) -> BotSkillRuntimeMutationMode:
         if not is_bot_ready(bot):
             raise LocalSkillNotReadyError()
-        require_supported_bot_skill_runtime(bot)
+        return require_bot_skill_runtime_command(bot, command)
+
+    async def _reconcile_runtime(
+        self,
+        *,
+        command: BotSkillRuntimeCommand,
+        mode: BotSkillRuntimeMutationMode,
+        bot_id: str,
+        owner_id: str,
+    ) -> None:
+        if mode is BotSkillRuntimeMutationMode.CLEANUP_ONLY:
+            await self._runtime.reconcile_cleanup(bot_id=bot_id, owner_id=owner_id)
+            return
+        await self._runtime.reconcile(bot_id=bot_id, owner_id=owner_id)

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -36,7 +36,7 @@ from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import
 from agentclaw.community.core.skill_center.runtime_policy import (
     require_supported_bot_skill_runtime,
 )
-from agentclaw.community.api.bot_runtime_projection_reconciler import (
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectionReconcilerProtocol,
 )
 from agentclaw.community.core.skill_center.services.bot_capability_mutation_guard import (

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Protocol
-
 from injector import inject
 
 from agentclaw.community.core.skill_center.authorization_hook import (
@@ -35,13 +33,11 @@ from agentclaw.community.core.bot_management.readiness import is_bot_ready
 from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
     LegacySkillSetCompatibilityFactoryProtocol,
 )
-from agentclaw.community.core.skill_center.factories import SkillSetServiceFactory
 from agentclaw.community.core.skill_center.runtime_policy import (
     require_supported_bot_skill_runtime,
 )
-from agentclaw.community.core.skill_center.runtime_resolver import (
-    RuntimeDesiredState,
-    RuntimeProjectionResolver,
+from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
+    BotRuntimeProjectionReconcilerProtocol,
 )
 from agentclaw.community.core.skill_center.services.bot_capability_mutation_guard import (
     BotCapabilityMutationBusyError,
@@ -57,104 +53,8 @@ from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditRollbackError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
-from agentclaw.community.core.repository.protocols.skills_pool import (
-    SkillsPoolSkillRepositoryProtocol,
-)
 from agentclaw.community.plugin_api.passport import PassportPlugin
-from agentclaw.community.core.mcp.services._defaults import (
-    get_default_cli_items,
-    get_default_mcp_servers,
-)
 from agentclaw.community.utils.env_utils import get_current_env
-
-
-class SkillSetRuntimeReconcilerProtocol(Protocol):
-    async def reconcile(self, *, bot_id: str, owner_id: str) -> None: ...
-
-
-class SkillSetRuntimeReconciler:
-    """Runtime adapter shared with the legacy compatibility surface.
-
-    The control-plane service deliberately calls this once after a successful
-    UoW; it never calls the legacy per-item activate/deactivate paths.
-    """
-
-    @inject
-    def __init__(
-        self,
-        factory: SkillSetServiceFactory,
-        bot_repo: BotRepository,
-        repository: SkillSetControlPlaneRepositoryProtocol,
-        pool_skills: SkillsPoolSkillRepositoryProtocol,
-    ) -> None:
-        self._factory = factory
-        self._bot_repo = bot_repo
-        self._repository = repository
-        self._pool_skills = pool_skills
-
-    async def reconcile(self, *, bot_id: str, owner_id: str) -> None:
-        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
-        if bot is None:
-            raise LocalSkillNotFoundError()
-        service = self._factory.create(
-            user_id=owner_id,
-            entity_id=str(bot.get("entity_id") or owner_id),
-            bot_id=bot_id,
-            engine_type=bot.get("active_engine"),
-            entity_type=bot.get("entity_type") or "staff",
-        )
-        projection = RuntimeProjectionResolver().resolve(
-            RuntimeDesiredState(
-                skills=tuple(
-                    self._pool_skills.list_bot_active_assets(
-                        env=str(bot["env"]),
-                        bot_id=bot_id,
-                        user_id=owner_id,
-                        engine=str(bot.get("active_engine") or "openclaw"),
-                    )
-                ),
-                installed_mcp_server_codes=frozenset(
-                    self._repository.list_installed_mcps(bot_id=bot_id)
-                ),
-                system_default_mcp_server_codes=frozenset(
-                    str(item["server_code"])
-                    for item in get_default_mcp_servers(
-                        str(bot.get("active_engine") or "openclaw"),
-                        bot.get("template_type"),
-                    )
-                    if item.get("server_code")
-                ),
-                system_default_cli_commands=tuple(
-                    str(item["cli_code"])
-                    for item in get_default_cli_items(
-                        str(bot.get("active_engine") or "openclaw"),
-                        bot.get("template_type"),
-                    )
-                    if item.get("cli_code")
-                ),
-            )
-        )
-        # The Engine adapter owns physical translation, while the Resolver
-        # supplies its complete canonical asset snapshot.  It must not query
-        # Default exclusions or rebuild state from legacy BFF records.
-        if not service.sync_runtime(
-            desired_skills=[
-                {
-                    "id": str(asset.skill_id),
-                    "name": asset.name,
-                    "git_path": asset.git_path,
-                    "skill_uuid": asset.skill_uuid,
-                    "sc_version_number": asset.sc_version_number,
-                }
-                for asset in projection.skill_assets
-                if not asset.git_path.startswith("center://")
-            ]
-        ):
-            raise SkillSetRuntimeReconcileError()
-        if not await service.sync_mcp_desired_state(
-            server_codes=set(projection.mcp_server_codes)
-        ):
-            raise SkillSetRuntimeReconcileError()
 
 
 class SkillSetControlPlaneService:
@@ -163,7 +63,7 @@ class SkillSetControlPlaneService:
         self,
         repository: SkillSetControlPlaneRepositoryProtocol,
         bot_repo: BotRepository,
-        runtime: SkillSetRuntimeReconcilerProtocol,
+        runtime: BotRuntimeProjectionReconcilerProtocol,
         legacy_factory: LegacySkillSetCompatibilityFactoryProtocol,
         passport: PassportPlugin,
         authorization: BotCapabilityAuthorizationHookProtocol,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -1515,6 +1515,13 @@ class SkillSetService:
                     source = str(skills_local_dir / source_name)
                 target = str(base_skills_dir / link_name)
                 symlinks.append(SynlinkMappingInfo(source=source, target=target))
+            elif git_path.startswith('center://'):
+                # This legacy file adapter has no Center request contract. A
+                # caller must route such a projection through the mapping-v3
+                # Engine adapter; silently omitting it would be fail-open.
+                raise ValueError("center skill requires a Center-capable runtime adapter")
+            else:
+                raise ValueError("unsupported skill source in runtime projection")
 
         resolved_mappings = symlinks
         if requested_paths:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -38,9 +38,6 @@ from agentclaw.community.core.skill_center.services.skill_service import SkillSe
 from agentclaw.community.core.skill_center.path_resolution import (
     canonical_pool_local_path,
 )
-from agentclaw.community.core.skill_center.installation_compatibility import (
-    includes_default_skill_member,
-)
 from agentclaw.community.core.skill_center.utils.skill_metadata_writer import SkillSetMetadataWriter
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE  # noqa: E402
 from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
@@ -1307,8 +1304,6 @@ class SkillSetService:
         installed_skills = self.skill_repo.list_bot_installed_skills(
             env=get_current_env(), bot_id=effective_bolt_id
         )
-        installed_ids = {int(skill["id"]) for skill in installed_skills}
-
         # 1. 查询所有激活的技能集（包含默认能力集）
         active_skill_sets = self.skill_set_repo.get_all_active_skill_sets(
             user_id=effective_user_id,
@@ -1325,27 +1320,13 @@ class SkillSetService:
             skill_set_id = skill_set.get('id')
             skills = self.skill_set_repo.get_skills_in_set(str(skill_set_id))
 
-            # Compatibility adapter: historical Local inactivity used a
-            # Default-SkillSet exclusion.  New desired state is Installation;
-            # leave non-Local Default membership untouched and accept a Local
-            # member only when its Installation exists.
-            if skill_set.get('is_default') and effective_user_id and effective_bolt_id:
-                excluded_ids = {
-                    int(skill_id)
-                    for skill_id in self.skill_set_repo.get_excluded_skills(
-                        user_id=effective_user_id,
-                        bot_id=effective_bolt_id,
-                        skill_set_id=int(skill_set_id),
-                    )
-                }
+            if skill_set.get('is_default'):
+                # Desired Local state is the active-only Installation fact.
+                # Never recover it from the legacy Default exclusion table.
                 skills = [
                     skill
                     for skill in skills
-                    if includes_default_skill_member(
-                        skill,
-                        installed_ids=installed_ids,
-                        excluded_ids=excluded_ids,
-                    )
+                    if not str(skill.get("git_path") or "").startswith("local://")
                 ]
             all_skills.extend(skills)
         all_skills.extend(installed_skills)

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -351,11 +351,10 @@ class SkillSetService:
         """
         try:
             # 获取当前激活技能集的软链配置（包括空列表，表示清空）
-            symlinks = self.get_symlink_mappings(
-                user_id=user_id,
-                bolt_id=self.bot_id,
-                desired_skills=desired_skills,
-            )
+            mapping_kwargs = {"user_id": user_id, "bolt_id": self.bot_id}
+            if desired_skills is not None:
+                mapping_kwargs["desired_skills"] = desired_skills
+            symlinks = self.get_symlink_mappings(**mapping_kwargs)
 
             # 通过 DeviceSyncPlugin 同步到设备 — 经 resolver + dispatcher 收口
             effective_user_id = user_id or self.entity_id or "default"

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -335,7 +335,9 @@ class SkillSetService:
             logger.warning(f"Error getting current active skill set: {e}")
         return None
 
-    def _sync_symlinks_to_device_if_needed(self, user_id: str | None = None) -> bool:
+    def _sync_symlinks_to_device_if_needed(
+        self, user_id: str | None = None, desired_skills: list[dict] | None = None
+    ) -> bool:
         """如果需要，同步软链配置到设备。
 
         将当前激活技能集的软链配置同步到远程设备或本地文件系统。
@@ -351,7 +353,8 @@ class SkillSetService:
             # 获取当前激活技能集的软链配置（包括空列表，表示清空）
             symlinks = self.get_symlink_mappings(
                 user_id=user_id,
-                bolt_id=self.bot_id
+                bolt_id=self.bot_id,
+                desired_skills=desired_skills,
             )
 
             # 通过 DeviceSyncPlugin 同步到设备 — 经 resolver + dispatcher 收口
@@ -375,9 +378,11 @@ class SkillSetService:
             logger.warning(f"[_sync_symlinks_to_device_if_needed] Failed to sync symlinks: {e}", exc_info=True)
             return False
 
-    def sync_runtime(self) -> bool:
-        """Reconcile this Bot's desired Skill mapping to its runtime."""
-        return self._sync_symlinks_to_device_if_needed(self.user_id or self.entity_id)
+    def sync_runtime(self, *, desired_skills: list[dict] | None = None) -> bool:
+        """Apply one complete resolver-owned skill snapshot to the runtime."""
+        return self._sync_symlinks_to_device_if_needed(
+            self.user_id or self.entity_id, desired_skills
+        )
 
     async def sync_mcp_desired_state(self, *, server_codes: set[str]) -> bool:
         """Project the complete MCP desired state to the Bot runtime.
@@ -1348,6 +1353,7 @@ class SkillSetService:
         user_id: str | None = None,
         bolt_id: str | None = None,
         additional_skill_paths: list[str] | None = None,
+        desired_skills: list[dict] | None = None,
     ) -> list[SynlinkMappingInfo]:
         """生成技能激活软链配置（支持多能力集激活）
 
@@ -1364,7 +1370,11 @@ class SkillSetService:
         Returns:
             List[SynlinkMappingInfo]: 软链配置列表（已去重）
         """
-        unique_skills = self.get_active_skills(user_id=user_id, bolt_id=bolt_id)
+        unique_skills = (
+            list(desired_skills)
+            if desired_skills is not None
+            else self.get_active_skills(user_id=user_id, bolt_id=bolt_id)
+        )
 
         # Direct Skill CRUD is intentionally orthogonal to SkillSet membership.
         # The device boundary accepts a complete mapping publish, so the current

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_symlink_listener.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_symlink_listener.py
@@ -11,9 +11,10 @@ just the event payload.
 """
 from __future__ import annotations
 
-from collections.abc import Callable
 import asyncio
-from typing import TYPE_CHECKING
+import threading
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.events.types import DeviceActivatedEvent
@@ -29,6 +30,26 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 _TRANSITION_AUTHORITY = "transition"
+
+
+def _run_reconcile_blocking(coro: Any) -> Any:
+    """Run an async reconcile while synchronously handling a lifecycle event."""
+    from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
+
+    box: dict[str, Any] = {}
+
+    def runner() -> None:
+        try:
+            box["result"] = asyncio.run(coro)
+        except BaseException as error:  # noqa: BLE001 - preserve failure semantics
+            box["error"] = error
+
+    thread = threading.Thread(target=bind_current_avernet_tenant(runner), daemon=True)
+    thread.start()
+    thread.join()
+    if "error" in box:
+        raise box["error"]
+    return box.get("result")
 
 
 class SkillSymlinkListener(LifecycleBase):
@@ -143,7 +164,7 @@ class SkillSymlinkListener(LifecycleBase):
                 # a legacy Default-exclusion mapping in this listener.
                 outcome = self._runtime_reconcile(str(bot_id), str(owner_id))
                 if asyncio.iscoroutine(outcome):
-                    asyncio.run(outcome)
+                    _run_reconcile_blocking(outcome)
                 return
 
             from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_symlink_listener.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_symlink_listener.py
@@ -12,6 +12,7 @@ just the event payload.
 from __future__ import annotations
 
 from collections.abc import Callable
+import asyncio
 from typing import TYPE_CHECKING
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
@@ -47,6 +48,7 @@ class SkillSymlinkListener(LifecycleBase):
         desktop_reconcile_wakeup: (
             Callable[[DeviceActivatedEvent], None] | None
         ) = None,
+        runtime_reconcile: Callable[[str, str], object] | None = None,
     ) -> None:
         self._bot_repo = bot_repo
         self._skill_set_factory = skill_set_factory
@@ -54,6 +56,7 @@ class SkillSymlinkListener(LifecycleBase):
         self._device_sync_dispatcher = device_sync_dispatcher
         self._desktop_layout_authority = desktop_layout_authority
         self._desktop_reconcile_wakeup = desktop_reconcile_wakeup
+        self._runtime_reconcile = runtime_reconcile
 
     async def startup(self) -> None:
         """Lifecycle hook — subscribe ``self.handle`` to DeviceActivatedEvent.
@@ -131,6 +134,16 @@ class SkillSymlinkListener(LifecycleBase):
                     event.binding_id,
                     ctx.binding_id,
                 )
+                return
+
+            if self._runtime_reconcile is not None:
+                # DeviceActivatedEvent is emitted after a restart/ready
+                # transition.  Rebuild the complete DB desired state through
+                # the same Reconciler as explicit mutations; do not rebuild
+                # a legacy Default-exclusion mapping in this listener.
+                outcome = self._runtime_reconcile(str(bot_id), str(owner_id))
+                if asyncio.iscoroutine(outcome):
+                    asyncio.run(outcome)
                 return
 
             from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_symlink_listener.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_symlink_listener.py
@@ -70,6 +70,7 @@ class SkillSymlinkListener(LifecycleBase):
             Callable[[DeviceActivatedEvent], None] | None
         ) = None,
         runtime_reconcile: Callable[[str, str], object] | None = None,
+        runtime_non_skill_reconcile: Callable[[str, str], object] | None = None,
     ) -> None:
         self._bot_repo = bot_repo
         self._skill_set_factory = skill_set_factory
@@ -78,6 +79,7 @@ class SkillSymlinkListener(LifecycleBase):
         self._desktop_layout_authority = desktop_layout_authority
         self._desktop_reconcile_wakeup = desktop_reconcile_wakeup
         self._runtime_reconcile = runtime_reconcile
+        self._runtime_non_skill_reconcile = runtime_non_skill_reconcile
 
     async def startup(self) -> None:
         """Lifecycle hook — subscribe ``self.handle`` to DeviceActivatedEvent.
@@ -137,14 +139,6 @@ class SkillSymlinkListener(LifecycleBase):
                 is_desktop=is_desktop,
             )
             initial_authority = self._resolve_desktop_layout_authority(bot)
-            if initial_authority == _TRANSITION_AUTHORITY:
-                logger.info(
-                    "[skill_symlink_listener] Desktop transitional mapping "
-                    "is owned by durable reconciliation: bot_id=%s",
-                    bot_id,
-                )
-                return
-
             ctx = self._resolver.resolve_for_bot(bot_id, owner_id)
             if ctx.binding_id != event.binding_id:
                 logger.info(
@@ -157,14 +151,35 @@ class SkillSymlinkListener(LifecycleBase):
                 )
                 return
 
+            if initial_authority == _TRANSITION_AUTHORITY:
+                logger.info(
+                    "[skill_symlink_listener] Desktop transitional mapping "
+                    "is owned by durable reconciliation: bot_id=%s",
+                    bot_id,
+                )
+                if self._runtime_non_skill_reconcile is not None:
+                    outcome = self._runtime_non_skill_reconcile(
+                        str(bot_id), str(owner_id)
+                    )
+                    if asyncio.iscoroutine(outcome):
+                        _run_reconcile_blocking(outcome)
+                return
+
             if self._runtime_reconcile is not None:
                 # DeviceActivatedEvent is emitted after a restart/ready
                 # transition.  Rebuild the complete DB desired state through
                 # the same Reconciler as explicit mutations; do not rebuild
                 # a legacy Default-exclusion mapping in this listener.
-                outcome = self._runtime_reconcile(str(bot_id), str(owner_id))
-                if asyncio.iscoroutine(outcome):
-                    _run_reconcile_blocking(outcome)
+                try:
+                    outcome = self._runtime_reconcile(str(bot_id), str(owner_id))
+                    if asyncio.iscoroutine(outcome):
+                        _run_reconcile_blocking(outcome)
+                finally:
+                    self._reenqueue_if_desktop_cutover_started(
+                        event=event,
+                        bot=bot if is_desktop else None,
+                        initial_authority=initial_authority,
+                    )
                 return
 
             from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE

--- a/src/backend/src/agentclaw/community/core/skills_pool/active_aicoding_bridge_repair.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/active_aicoding_bridge_repair.py
@@ -48,7 +48,8 @@ async def request_active_aicoding_bridge_repair(
     state: BotSkillLayoutState,
     bot_id: str,
     user_id: str,
-    engine: str,
+    logical_engine: str,
+    layout_engine: str,
     initial_probe: RuntimeLayoutProbeResult,
 ) -> ActiveAICodingBridgeRepairResult:
     """Ask the Engine to repair only a bridge it can prove is trusted.
@@ -82,7 +83,7 @@ async def request_active_aicoding_bridge_repair(
                 env=scope.env,
                 bot_id=scope.bot_id,
                 user_id=user_id,
-                engine=engine,
+                engine=logical_engine,
             )
         )
     except ValueError as error:
@@ -114,7 +115,7 @@ async def request_active_aicoding_bridge_repair(
     refreshed_probe = await runtime.probe(
         bot_id=bot_id,
         user_id=user_id,
-        engine=engine,
+        engine=layout_engine,
     )
     if refreshed_probe.status is not RuntimeLayoutProbeStatus.READY:
         return ActiveAICodingBridgeRepairResult(
@@ -131,7 +132,7 @@ async def request_active_aicoding_bridge_repair(
             probe_status=refreshed_probe.status,
         )
     if (
-        refreshed_probe.engine != engine
+        refreshed_probe.engine != layout_engine
         or refreshed_probe.preparation_id is None
         or refreshed_probe.preparation_id != state.preparation_id
         or refreshed_probe.layout_contract_version != state.layout_contract_version

--- a/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
@@ -65,11 +65,17 @@ def build_logical_skill_mappings(
             relative = None
             corpus = "center"
         else:
-            continue
+            # A complete projection is fail-closed.  Silently ignoring a
+            # selected asset would make the database desired state and the
+            # delivered runtime disagree.
+            raise ValueError(f"unsupported skill source: {asset.git_path}")
         # ``ac_skill.name`` is the single runtime-name policy for every shared
         # asset.  Repo paths are locators, not user-visible link identities:
         # two different directories can legitimately share the same tail.
-        link_name = asset.name if corpus in {"repo", "center"} else relative.name
+        # ``ac_skill.name`` is the only RuntimeNamePolicy input for every
+        # corpus.  ``local://`` and ``git://`` tails are locators, never the
+        # runtime identity exposed to an Engine.
+        link_name = asset.name
         identity = (
             f"center:{asset.skill_uuid}:{asset.sc_version_number}"
             if corpus == "center"

--- a/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
@@ -197,7 +197,11 @@ def logical_skill_mappings_from_evidence(
             or path.is_absolute()
             or ".." in path.parts
             or path.as_posix() != relative_path
-            or path.name != link_name
+            or not link_name
+            or link_name.strip() != link_name
+            or "/" in link_name
+            or "\\" in link_name
+            or link_name in {".", ".."}
         ):
             raise ValueError("invalid retired mapping evidence")
         mapping = PoolSkillMapping(

--- a/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
@@ -13,6 +13,10 @@ MAPPING_CONTRACT_V2 = "skills-pool-mapping-v2"
 MAPPING_CONTRACT_V3 = "skills-pool-mapping-v3"
 
 
+class RuntimeMappingNameConflictError(ValueError):
+    """Different selected assets claim one canonical runtime entry name."""
+
+
 def mapping_contract_for(
     mappings: list[PoolSkillMapping],
     supported_versions: object,
@@ -84,7 +88,9 @@ def build_logical_skill_mappings(
         if targets.get(link_name) == identity:
             continue
         if link_name in targets:
-            raise ValueError(f"duplicate managed target: {link_name}")
+            raise RuntimeMappingNameConflictError(
+                f"duplicate managed target: {link_name}"
+            )
         targets[link_name] = identity
         mappings.append(
             PoolSkillMapping(
@@ -243,4 +249,5 @@ __all__ = [
     "mapping_contract_for",
     "merge_retired_logical_skill_mappings",
     "retired_logical_skill_mappings",
+    "RuntimeMappingNameConflictError",
 ]

--- a/src/backend/src/agentclaw/community/core/skills_pool/models.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/models.py
@@ -35,6 +35,7 @@ class RegisteredSkillAsset:
     git_path: str
     skill_uuid: str | None = None
     sc_version_number: str | None = None
+    mcp_dependencies: tuple[object, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from injector import inject
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.workspace.skill_layout import (
+    runtime_layout_engine_for_bot,
+)
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
     CUTOVER_EVIDENCE_CONTRACT_VERSION,
     RuntimeLayoutProbeResult,
@@ -119,6 +122,13 @@ class SkillsPoolReconcileService:
         if engine not in FILESYSTEM_POOL_ENGINES:
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
 
+        # ``engine`` is the logical control-plane identity.  Coding-template
+        # Bots retain Claude Code catalogue/asset semantics while their image
+        # exposes the AICoding filesystem layout to the Pool runtime.
+        layout_engine = runtime_layout_engine_for_bot(bot)
+        if layout_engine not in FILESYSTEM_POOL_ENGINES:
+            return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
+
         owner_id = bot.get("owner_id")
         if not isinstance(owner_id, (str, int)) or isinstance(owner_id, bool):
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
@@ -133,7 +143,7 @@ class SkillsPoolReconcileService:
         probe = await self._runtime.probe(
             bot_id=scope.bot_id,
             user_id=user_id,
-            engine=engine,
+            engine=layout_engine,
         )
         logger.info(
             "[skills_pool.reconcile] runtime probe bot_id=%s generation=%s "
@@ -146,7 +156,7 @@ class SkillsPoolReconcileService:
         )
         finalizing_repo_retirement_resume = is_trusted_aicoding_repo_retirement_resume(
             state=state,
-            engine=engine,
+            engine=layout_engine,
             probe=probe,
         )
         if (
@@ -789,6 +799,9 @@ class SkillsPoolReconcileService:
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
         if engine not in FILESYSTEM_POOL_ENGINES:
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
+        layout_engine = runtime_layout_engine_for_bot(bot)
+        if layout_engine not in FILESYSTEM_POOL_ENGINES:
+            return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
         owner_id = bot.get("owner_id")
         if not isinstance(owner_id, (str, int)) or isinstance(owner_id, bool):
             return SkillsPoolReconcileResult(SkillsPoolReconcileOutcome.BOT_CHANGED)
@@ -796,11 +809,11 @@ class SkillsPoolReconcileService:
         probe = await self._runtime.probe(
             bot_id=scope.bot_id,
             user_id=str(owner_id),
-            engine=engine,
+            engine=layout_engine,
         )
         if is_aicoding_active_mapping_reconciliation_candidate(
             state=state,
-            engine=engine,
+            engine=layout_engine,
             probe=probe,
         ):
             return await self._reconcile_active_aicoding_repo_bridges(
@@ -808,7 +821,8 @@ class SkillsPoolReconcileService:
                 state=state,
                 bot_id=scope.bot_id,
                 user_id=str(owner_id),
-                engine=engine,
+                logical_engine=engine,
+                layout_engine=layout_engine,
                 initial_probe=probe,
             )
         if probe.status is not RuntimeLayoutProbeStatus.READY:
@@ -887,7 +901,8 @@ class SkillsPoolReconcileService:
         state: BotSkillLayoutState,
         bot_id: str,
         user_id: str,
-        engine: str,
+        logical_engine: str,
+        layout_engine: str,
         initial_probe: RuntimeLayoutProbeResult,
     ) -> SkillsPoolReconcileResult:
         repair = await request_active_aicoding_bridge_repair(
@@ -897,7 +912,8 @@ class SkillsPoolReconcileService:
             state=state,
             bot_id=bot_id,
             user_id=user_id,
-            engine=engine,
+            logical_engine=logical_engine,
+            layout_engine=layout_engine,
             initial_probe=initial_probe,
         )
         if repair.status is ActiveAICodingBridgeRepairStatus.ENGINE_REJECTED:

--- a/src/backend/src/agentclaw/community/core/workspace/skill_layout.py
+++ b/src/backend/src/agentclaw/community/core/workspace/skill_layout.py
@@ -10,6 +10,7 @@ the DI composition root.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 
@@ -54,6 +55,33 @@ PoolPaths = (
 )
 FILESYSTEM_POOL_ENGINES = ("openclaw", "claude_code", "aicoding", "hermes")
 
+_CLAUDE_CODE_AICODING_TEMPLATES = frozenset(
+    {"personalCoding", "applicationCoding"}
+)
+
+
+def runtime_layout_engine_for_bot(bot: Mapping[str, object]) -> str:
+    """Return the filesystem identity for a Bot's Skill runtime.
+
+    ``claude_code`` remains the logical product engine for coding templates:
+    catalogue selection, Passport, and persisted control-plane state therefore
+    continue to use it.  Those templates run in an AICoding image, however,
+    so every filesystem Pool operation must address AICoding's physical roots.
+
+    This dependency-free workspace contract is deliberately shared by Skill
+    Center and Skills Pool.  It prevents either domain from inferring a
+    physical path from ``active_engine`` alone.
+    """
+
+    engine = str(bot.get("active_engine") or "")
+    if (
+        engine == "claude_code"
+        and str(bot.get("template_type") or "")
+        in _CLAUDE_CODE_AICODING_TEMPLATES
+    ):
+        return "aicoding"
+    return engine
+
 
 def pool_paths_for_engine(engine: str) -> PoolPaths:
     """Resolve explicitly supported filesystem engines; never fall back."""
@@ -77,4 +105,5 @@ __all__ = [
     "OpenClawPoolPaths",
     "PoolPaths",
     "pool_paths_for_engine",
+    "runtime_layout_engine_for_bot",
 ]

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -129,7 +129,10 @@ from agentclaw.community.core.repository.protocols.skills_pool import (
 from agentclaw.community.core.skills_pool.reconcile_task import (
     SkillsPoolReconcileWakeupListener,
 )
-from agentclaw.community.core.skills_pool.models import pool_paths_for_engine
+from agentclaw.community.core.workspace.skill_layout import (
+    pool_paths_for_engine,
+    runtime_layout_engine_for_bot,
+)
 from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
@@ -712,7 +715,7 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
             )
             if not runtime_uses_pool_paths(state):
                 return None
-            paths = pool_paths_for_engine(engine)
+            paths = pool_paths_for_engine(runtime_layout_engine_for_bot(bot))
             return paths.active, paths.pool_local, paths.pool_repo
 
         return SkillServiceFactory(

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -182,8 +182,10 @@ from agentclaw.community.core.skill_center.services.bot_skill_asset_service impo
 )
 from agentclaw.community.core.skill_center.services.skill_set_control_plane import (
     SkillSetControlPlaneService,
-    SkillSetRuntimeReconciler,
-    SkillSetRuntimeReconcilerProtocol,
+)
+from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
+    BotRuntimeProjectionReconciler,
+    BotRuntimeProjectionReconcilerProtocol,
 )
 from agentclaw.community.core.skill_center.authorization_hook import (
     BotCapabilityAuthorizationHookProtocol,
@@ -345,8 +347,8 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
             scope=singleton,
         )
         binder.bind(
-            SkillSetRuntimeReconcilerProtocol,
-            to=SkillSetRuntimeReconciler,
+            BotRuntimeProjectionReconcilerProtocol,
+            to=BotRuntimeProjectionReconciler,
             scope=singleton,
         )
         binder.bind(
@@ -945,7 +947,7 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
         device_sync_dispatcher: DeviceSyncDispatcher,
         layout_repository: SkillsPoolLayoutRepositoryProtocol,
         skills_pool_wakeup: SkillsPoolReconcileWakeupListener,
-        runtime_reconciler: SkillSetRuntimeReconcilerProtocol,
+        runtime_reconciler: BotRuntimeProjectionReconcilerProtocol,
     ) -> SkillSymlinkListener:
         def desktop_layout_authority(bot: dict) -> str | None:
             if bot.get("bot_type") != "desktop":

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -945,6 +945,7 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
         device_sync_dispatcher: DeviceSyncDispatcher,
         layout_repository: SkillsPoolLayoutRepositoryProtocol,
         skills_pool_wakeup: SkillsPoolReconcileWakeupListener,
+        runtime_reconciler: SkillSetRuntimeReconcilerProtocol,
     ) -> SkillSymlinkListener:
         def desktop_layout_authority(bot: dict) -> str | None:
             if bot.get("bot_type") != "desktop":
@@ -976,4 +977,7 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
             device_sync_dispatcher=device_sync_dispatcher,
             desktop_layout_authority=desktop_layout_authority,
             desktop_reconcile_wakeup=skills_pool_wakeup.handle,
+            runtime_reconcile=lambda bot_id, owner_id: runtime_reconciler.reconcile(
+                bot_id=bot_id, owner_id=owner_id
+            ),
         )

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -183,7 +183,10 @@ from agentclaw.community.core.skill_center.services.skill_set_control_plane impo
     SkillSetControlPlaneService,
 )
 from agentclaw.community.api.bot_runtime_projection_reconciler import (
-    BotRuntimeProjectionReconcilerProtocol,
+    BotRuntimeProjectionReconcilerProtocol as ApiBotRuntimeProjectionReconcilerProtocol,
+)
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    BotRuntimeProjectionReconcilerProtocol as CoreBotRuntimeProjectionReconcilerProtocol,
 )
 from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
     BotRuntimeProjectionReconciler,
@@ -348,7 +351,7 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
             scope=singleton,
         )
         binder.bind(
-            BotRuntimeProjectionReconcilerProtocol,
+            BotRuntimeProjectionReconciler,
             to=BotRuntimeProjectionReconciler,
             scope=singleton,
         )
@@ -367,6 +370,24 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
             to=SkillPublishService,
             scope=singleton,
         )
+
+    @singleton
+    @provider
+    @inject
+    def core_runtime_projection_reconciler_protocol(
+        self, service: BotRuntimeProjectionReconciler
+    ) -> CoreBotRuntimeProjectionReconcilerProtocol:
+        """Expose the one reconciler singleton to Core consumers."""
+        return service
+
+    @singleton
+    @provider
+    @inject
+    def api_runtime_projection_reconciler_protocol(
+        self, service: BotRuntimeProjectionReconciler
+    ) -> ApiBotRuntimeProjectionReconcilerProtocol:
+        """Expose that same singleton through the public Service API."""
+        return service
 
     @singleton
     @provider
@@ -432,7 +453,7 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
         edit_guard: SkillsPoolEditGuard,
         cleanup_repo: LocalSkillCleanupRepository,
         injector: Injector,
-        runtime_reconciler: BotRuntimeProjectionReconcilerProtocol,
+        runtime_reconciler: CoreBotRuntimeProjectionReconcilerProtocol,
     ) -> LocalSkillUploadServiceProtocol:
         return LocalSkillUploadService(
             skill_repo,
@@ -469,7 +490,7 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
         mutation_guard: BotCapabilityMutationGuard,
         edit_guard: SkillsPoolEditGuard,
         pool_skills: SkillsPoolSkillRepositoryProtocol,
-        runtime_reconciler: BotRuntimeProjectionReconcilerProtocol,
+        runtime_reconciler: CoreBotRuntimeProjectionReconcilerProtocol,
     ) -> LocalSkillStateServiceProtocol:
         return LocalSkillStateService(
             skill_repo,
@@ -946,7 +967,7 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
         device_sync_dispatcher: DeviceSyncDispatcher,
         layout_repository: SkillsPoolLayoutRepositoryProtocol,
         skills_pool_wakeup: SkillsPoolReconcileWakeupListener,
-        runtime_reconciler: BotRuntimeProjectionReconcilerProtocol,
+        runtime_reconciler: CoreBotRuntimeProjectionReconcilerProtocol,
     ) -> SkillSymlinkListener:
         def desktop_layout_authority(bot: dict) -> str | None:
             if bot.get("bot_type") != "desktop":

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -150,7 +150,6 @@ from agentclaw.community.core.repository.protocols.skills_pool import (
 from agentclaw.community.core.repository.protocols.skills_pool import (
     SkillsPoolSkillRepositoryProtocol,
 )
-from agentclaw.community.core.skills_pool.ports import SkillsPoolRuntimeProtocol
 from agentclaw.community.core.skills_pool.reconcile_task import (
     SkillsPoolReconcileWakeupListener,
 )
@@ -427,11 +426,11 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
         bot_repo: BotRepository,
         collaborator_service: CollaboratorServiceProtocol,
         skill_service_factory: SkillServiceFactory,
-        skill_set_service_factory: SkillSetServiceFactory,
         audit_log_repo: BotCollabLogRepositoryProtocol,
         edit_guard: SkillsPoolEditGuard,
         cleanup_repo: LocalSkillCleanupRepository,
         injector: Injector,
+        runtime_reconciler: BotRuntimeProjectionReconcilerProtocol,
     ) -> LocalSkillUploadServiceProtocol:
         return LocalSkillUploadService(
             skill_repo,
@@ -439,11 +438,11 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
             bot_repo,
             collaborator_service,
             skill_service_factory,
-            skill_set_service_factory,
             audit_log_repo,
             edit_guard,
             cleanup_repo,
             lambda: injector.get(DeviceContextResolver),
+            runtime_reconciler,
         )
 
     @singleton
@@ -467,9 +466,8 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
         skill_set_service_factory: SkillSetServiceFactory,
         mutation_guard: BotCapabilityMutationGuard,
         edit_guard: SkillsPoolEditGuard,
-        pool_runtime: SkillsPoolRuntimeProtocol,
         pool_skills: SkillsPoolSkillRepositoryProtocol,
-        pool_layouts: SkillsPoolLayoutRepositoryProtocol,
+        runtime_reconciler: BotRuntimeProjectionReconcilerProtocol,
     ) -> LocalSkillStateServiceProtocol:
         return LocalSkillStateService(
             skill_repo,
@@ -479,10 +477,9 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
             skill_set_service_factory,
             mutation_guard,
             edit_guard,
-            pool_runtime,
             pool_skills,
-            pool_layouts,
             skill_set_repo,
+            runtime_reconciler,
         )
 
     @singleton

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -182,9 +182,11 @@ from agentclaw.community.core.skill_center.services.bot_skill_asset_service impo
 from agentclaw.community.core.skill_center.services.skill_set_control_plane import (
     SkillSetControlPlaneService,
 )
+from agentclaw.community.api.bot_runtime_projection_reconciler import (
+    BotRuntimeProjectionReconcilerProtocol,
+)
 from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
     BotRuntimeProjectionReconciler,
-    BotRuntimeProjectionReconcilerProtocol,
 )
 from agentclaw.community.core.skill_center.authorization_hook import (
     BotCapabilityAuthorizationHookProtocol,

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -1,31 +1,7 @@
-"""SkillCenterModule — production singletons & factories for skill_center.
+"""Production Skill Center DI bindings.
 
-Replaces the module-globals in
-``core/skill_center/dependencies/skills.py`` (``_skill_repo``,
-``_skill_set_repo``, ``_device_plugin``, ``_skill_repo_sync_plugin``,
-plus the legacy ``git_sync_service`` global at the bottom of
-``services/git_sync.py``).
-
-Production bindings are wired here. The ``test`` / ``singlebox`` profiles
-install :class:`TestingSkillCenterModule` (via ``modules_for``) to
-override these with the local stubs.
-
-Three categories of binding:
-
-- **Plugin / repo singletons**: ``SkillRepository``,
-  ``SkillSetRepository``, ``DeviceAccessor``, ``SkillRepoSyncPlugin``,
-  ``GitSyncService``. Each ``@singleton @provider``.
-- **Service factories**: ``SkillServiceFactory``,
-  ``SkillSetServiceFactory``, ``SkillParameterServiceFactory``. Each
-  factory holds the @inject-supplied singletons and mints a fresh
-  service per ``create()`` call with caller-supplied request-scoped
-  arguments (paths, IDs).
-- **Stateless services**: ``SkillAuthService`` is a clean singleton with
-  no per-call state — bound directly.
-
-This module never branches on mode. Local / test boots layer
-``TestingSkillCenterModule`` on top to override the database-mode-keyed
-plugin_api and repos.
+Test and singlebox profiles layer ``TestingSkillCenterModule`` on top of this
+module; request-scoped service factories remain here.
 """
 
 from __future__ import annotations

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -981,4 +981,10 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
             runtime_reconcile=lambda bot_id, owner_id: runtime_reconciler.reconcile(
                 bot_id=bot_id, owner_id=owner_id
             ),
+            runtime_non_skill_reconcile=lambda bot_id, owner_id: (
+                runtime_reconciler.reconcile_non_skill_projection(
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                )
+            ),
         )

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -752,12 +752,11 @@ async def test_state_command_cannot_cross_the_real_tenant_guard(tmp_path):
         object(),
         factory,
         _MutationGuard(),
-        _Guard(),
-        object(),
-        object(),
-        object(),
-        object(),
-    )
+            _Guard(),
+            object(),
+            object(),
+            object(),
+        )
     with avernet_tenant_scope("tenant-b"):
         with pytest.raises(LocalSkillNotFoundError):
             await service.set_local_skill_active(

--- a/src/backend/tests/community/architecture/test_service_api_conformance.py
+++ b/src/backend/tests/community/architecture/test_service_api_conformance.py
@@ -41,6 +41,9 @@ import pytest
 from agentclaw.community.api.bot_dormant_service import (
     BotDormantActivateServiceProtocol,
 )
+from agentclaw.community.api.bot_runtime_projection_reconciler import (
+    BotRuntimeProjectionReconcilerProtocol,
+)
 from agentclaw.community.api.bot_skill_asset_service import BotSkillAssetServiceProtocol
 from agentclaw.community.api.bot_inventory_service import BotInventoryServiceProtocol
 from agentclaw.community.api.bot_startup_script_service import (
@@ -116,6 +119,9 @@ from agentclaw.community.core.skill_center.services.local_skill_query_service im
 from agentclaw.community.core.skill_center.services.bot_skill_asset_service import (
     BotSkillAssetService,
 )
+from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
+    BotRuntimeProjectionReconciler,
+)
 from agentclaw.community.core.skill_center.services.local_skill_upload_service import (
     LocalSkillUploadService,
 )
@@ -153,6 +159,7 @@ _PAIRS = [
     (EngineConnectionServiceProtocol, EngineConnectionService),
     (HealthDiagnosisServiceProtocol, HealthDiagnosisService),
     (BotSkillAssetServiceProtocol, BotSkillAssetService),
+    (BotRuntimeProjectionReconcilerProtocol, BotRuntimeProjectionReconciler),
     (LocalSkillQueryServiceProtocol, LocalSkillQueryService),
     (LocalSkillUploadServiceProtocol, LocalSkillUploadService),
     (LocalSkillStateServiceProtocol, LocalSkillStateService),

--- a/src/backend/tests/community/contracts/test_bot_runtime_projection_reconciler.py
+++ b/src/backend/tests/community/contracts/test_bot_runtime_projection_reconciler.py
@@ -19,7 +19,12 @@ class _RecordingReconciler:
         self.calls: list[dict] = []
 
     async def reconcile(self, **kwargs) -> None:
-        self.calls.append(kwargs)
+        self.calls.append({"operation": "full", **kwargs})
+        if self.error is not None:
+            raise self.error
+
+    async def reconcile_non_skill_projection(self, **kwargs) -> None:
+        self.calls.append({"operation": "non_skill", **kwargs})
         if self.error is not None:
             raise self.error
 
@@ -31,6 +36,11 @@ class _Consumer:
 
     async def refresh(self) -> None:
         await self._runtime.reconcile(bot_id="bot-1", owner_id="owner-1")
+
+    async def refresh_non_skill(self) -> None:
+        await self._runtime.reconcile_non_skill_projection(
+            bot_id="bot-1", owner_id="owner-1"
+        )
 
 
 def _consumer(world, runtime: _RecordingReconciler) -> _Consumer:
@@ -58,7 +68,21 @@ async def test_reconcile_service_api_success_reaches_the_bound_implementation(
 
     await consumer.refresh()
 
-    assert runtime.calls == [{"bot_id": "bot-1", "owner_id": "owner-1"}]
+    assert runtime.calls == [
+        {"operation": "full", "bot_id": "bot-1", "owner_id": "owner-1"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_non_skill_service_api_reaches_the_bound_implementation(world) -> None:
+    runtime = _RecordingReconciler()
+    consumer = _consumer(world, runtime)
+
+    await consumer.refresh_non_skill()
+
+    assert runtime.calls == [
+        {"operation": "non_skill", "bot_id": "bot-1", "owner_id": "owner-1"}
+    ]
 
 
 @pytest.mark.asyncio
@@ -71,4 +95,6 @@ async def test_reconcile_service_api_propagates_failure_after_actual_invocation(
     with pytest.raises(RuntimeError, match="runtime unavailable"):
         await consumer.refresh()
 
-    assert runtime.calls == [{"bot_id": "bot-1", "owner_id": "owner-1"}]
+    assert runtime.calls == [
+        {"operation": "full", "bot_id": "bot-1", "owner_id": "owner-1"}
+    ]

--- a/src/backend/tests/community/contracts/test_bot_runtime_projection_reconciler.py
+++ b/src/backend/tests/community/contracts/test_bot_runtime_projection_reconciler.py
@@ -1,0 +1,74 @@
+"""Consumer conformance for the Bot runtime projection Service API."""
+
+from __future__ import annotations
+
+import pytest
+from injector import inject, singleton
+
+from agentclaw.community.api.bot_runtime_projection_reconciler import (
+    BotRuntimeProjectionReconcilerProtocol,
+)
+from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
+    BotRuntimeProjectionReconciler,
+)
+
+
+class _RecordingReconciler:
+    def __init__(self, *, error: Exception | None = None) -> None:
+        self.error = error
+        self.calls: list[dict] = []
+
+    async def reconcile(self, **kwargs) -> None:
+        self.calls.append(kwargs)
+        if self.error is not None:
+            raise self.error
+
+
+class _Consumer:
+    @inject
+    def __init__(self, runtime: BotRuntimeProjectionReconcilerProtocol) -> None:
+        self._runtime = runtime
+
+    async def refresh(self) -> None:
+        await self._runtime.reconcile(bot_id="bot-1", owner_id="owner-1")
+
+
+def _consumer(world, runtime: _RecordingReconciler) -> _Consumer:
+    world.injector.binder.bind(
+        BotRuntimeProjectionReconcilerProtocol,
+        to=runtime,
+        scope=singleton,
+    )
+    return world.injector.create_object(_Consumer)
+
+
+def test_world_wires_service_api_to_the_real_reconciler(world) -> None:
+    assert isinstance(
+        world.get(BotRuntimeProjectionReconcilerProtocol),
+        BotRuntimeProjectionReconciler,
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_service_api_success_reaches_the_bound_implementation(
+    world,
+) -> None:
+    runtime = _RecordingReconciler()
+    consumer = _consumer(world, runtime)
+
+    await consumer.refresh()
+
+    assert runtime.calls == [{"bot_id": "bot-1", "owner_id": "owner-1"}]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_service_api_propagates_failure_after_actual_invocation(
+    world,
+) -> None:
+    runtime = _RecordingReconciler(error=RuntimeError("runtime unavailable"))
+    consumer = _consumer(world, runtime)
+
+    with pytest.raises(RuntimeError, match="runtime unavailable"):
+        await consumer.refresh()
+
+    assert runtime.calls == [{"bot_id": "bot-1", "owner_id": "owner-1"}]

--- a/src/backend/tests/community/contracts/test_bot_runtime_projection_reconciler.py
+++ b/src/backend/tests/community/contracts/test_bot_runtime_projection_reconciler.py
@@ -8,6 +8,9 @@ from injector import inject, singleton
 from agentclaw.community.api.bot_runtime_projection_reconciler import (
     BotRuntimeProjectionReconcilerProtocol,
 )
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    BotRuntimeProjectionReconcilerProtocol as CoreBotRuntimeProjectionReconcilerProtocol,
+)
 from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
     BotRuntimeProjectionReconciler,
 )
@@ -25,6 +28,11 @@ class _RecordingReconciler:
 
     async def reconcile_non_skill_projection(self, **kwargs) -> None:
         self.calls.append({"operation": "non_skill", **kwargs})
+        if self.error is not None:
+            raise self.error
+
+    async def reconcile_cleanup(self, **kwargs) -> None:
+        self.calls.append({"operation": "cleanup", **kwargs})
         if self.error is not None:
             raise self.error
 
@@ -57,6 +65,9 @@ def test_world_wires_service_api_to_the_real_reconciler(world) -> None:
         world.get(BotRuntimeProjectionReconcilerProtocol),
         BotRuntimeProjectionReconciler,
     )
+    assert world.get(BotRuntimeProjectionReconcilerProtocol) is world.get(
+        CoreBotRuntimeProjectionReconcilerProtocol
+    )
 
 
 @pytest.mark.asyncio
@@ -82,6 +93,18 @@ async def test_non_skill_service_api_reaches_the_bound_implementation(world) -> 
 
     assert runtime.calls == [
         {"operation": "non_skill", "bot_id": "bot-1", "owner_id": "owner-1"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_service_api_reaches_the_bound_implementation(world) -> None:
+    runtime = _RecordingReconciler()
+    consumer = _consumer(world, runtime)
+
+    await consumer._runtime.reconcile_cleanup(bot_id="bot-1", owner_id="owner-1")
+
+    assert runtime.calls == [
+        {"operation": "cleanup", "bot_id": "bot-1", "owner_id": "owner-1"}
     ]
 
 

--- a/src/backend/tests/community/core/devices/services/test_device_service.py
+++ b/src/backend/tests/community/core/devices/services/test_device_service.py
@@ -872,6 +872,32 @@ class TestReportDeviceAlive:
         assert event.sandbox_id == "sbx-abc@alt-0"
         reset_event_bus()
 
+    def test_pending_activation_has_one_mcp_writer_owned_by_device_event(self):
+        """The Device callback publishes one event; it must not also sync MCP."""
+        from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
+        from agentclaw.community.core.events.types import DeviceActivatedEvent
+
+        reset_event_bus()
+        received: list[DeviceActivatedEvent] = []
+        get_event_bus().subscribe(DeviceActivatedEvent, received.append)
+        record = _make_record(
+            status=DeviceBindingStatus.PENDING.value,
+            device_props={"callback_token": "tok123"},
+        )
+        updated = _make_record(status=DeviceBindingStatus.ACTIVE.value)
+        repo = MagicMock()
+        repo.get_by_device_id.return_value = record
+        repo.get_by_id.return_value = updated
+        svc = _make_service(repo=repo, bot_query=MagicMock())
+        legacy_mcp_writer = MagicMock()
+        svc._sync_mcps_when_device_active = legacy_mcp_writer
+
+        svc.report_device_alive(device_id=record.device_id, token="tok123")
+
+        assert len(received) == 1
+        legacy_mcp_writer.assert_not_called()
+        reset_event_bus()
+
     def test_no_event_published_on_alive_refresh_when_already_active(self):
         from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
         from agentclaw.community.core.events.types import DeviceActivatedEvent

--- a/src/backend/tests/community/core/skill_center/services/test_skill_symlink_listener.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_symlink_listener.py
@@ -40,6 +40,7 @@ def _make_listener(
     layout_repository=None,
     skills_pool_wakeup=None,
     runtime_reconcile=None,
+    runtime_non_skill_reconcile=None,
 ):
     factory = MagicMock()
     if skill_set_service is not None:
@@ -78,6 +79,7 @@ def _make_listener(
             else None
         ),
         runtime_reconcile=runtime_reconcile,
+        runtime_non_skill_reconcile=runtime_non_skill_reconcile,
     )
     return listener, factory, dispatcher, resolver
 
@@ -340,21 +342,55 @@ class TestHandleDeviceActivated:
         )
         sync_plugin = MagicMock()
         wakeup = MagicMock()
+        non_skill_reconcile = MagicMock()
         listener, factory, dispatcher, resolver = _make_listener(
             MagicMock(),
             sync_plugin,
             bot_query,
             layout_repository,
             wakeup,
+            runtime_non_skill_reconcile=non_skill_reconcile,
         )
 
         listener.handle(event)
 
         wakeup.handle.assert_called_once_with(event)
+        non_skill_reconcile.assert_called_once_with("desktop-1", "owner-1")
         factory.create.assert_not_called()
-        resolver.resolve_for_bot.assert_not_called()
+        resolver.resolve_for_bot.assert_called_once_with("desktop-1", "owner-1")
         dispatcher.dispatch.assert_not_called()
         sync_plugin.sync_symlinks.assert_not_called()
+
+    def test_full_runtime_reconcile_reenqueues_when_desktop_cutover_starts(self):
+        event = _make_event(device_provider="baas")
+        bot_query = MagicMock()
+        bot_query.get_by_binding_id.return_value = {
+            "bot_id": "desktop-1",
+            "owner_id": "owner-1",
+            "entity_id": "entity-1",
+            "env": "pre",
+            "bot_type": "desktop",
+            "active_engine": "openclaw",
+        }
+        layout_repository = MagicMock()
+        layout_repository.get.side_effect = [
+            _layout_state(),
+            _layout_state(phase=SkillLayoutPhase.POOL_ACTIVATING_PRE_CUTOVER),
+        ]
+        wakeup = MagicMock()
+        runtime_reconcile = MagicMock()
+        listener, _, dispatcher, _ = _make_listener(
+            bot_query=bot_query,
+            layout_repository=layout_repository,
+            skills_pool_wakeup=wakeup,
+            runtime_reconcile=runtime_reconcile,
+        )
+
+        listener.handle(event)
+
+        runtime_reconcile.assert_called_once_with("desktop-1", "owner-1")
+        assert wakeup.handle.call_args_list == [call(event), call(event)]
+        dispatcher.dispatch.assert_not_called()
 
     def test_cutover_started_during_legacy_sync_reenqueues_convergence(self):
         event = _make_event(device_provider="baas")

--- a/src/backend/tests/community/core/skill_center/services/test_skill_symlink_listener.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_symlink_listener.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import MagicMock, call
+
+import pytest
 
 from agentclaw.community.core.events.types import DeviceActivatedEvent
 from agentclaw.community.core.skill_center.services.skill_symlink_listener import (
@@ -36,6 +39,7 @@ def _make_listener(
     bot_query=None,
     layout_repository=None,
     skills_pool_wakeup=None,
+    runtime_reconcile=None,
 ):
     factory = MagicMock()
     if skill_set_service is not None:
@@ -73,6 +77,7 @@ def _make_listener(
             if skills_pool_wakeup is not None
             else None
         ),
+        runtime_reconcile=runtime_reconcile,
     )
     return listener, factory, dispatcher, resolver
 
@@ -97,6 +102,27 @@ def _layout_state(
 
 
 class TestHandleDeviceActivated:
+    @pytest.mark.asyncio
+    async def test_runtime_reconcile_blocks_even_inside_a_running_loop(self):
+        completed = []
+
+        async def reconcile(bot_id, owner_id):
+            await asyncio.sleep(0)
+            completed.append((bot_id, owner_id))
+
+        bot_query = MagicMock()
+        bot_query.get_by_binding_id.return_value = {
+            "bot_id": "default", "owner_id": "u001"
+        }
+        listener, _, dispatcher, _ = _make_listener(
+            bot_query=bot_query, runtime_reconcile=reconcile
+        )
+
+        listener.handle(_make_event())
+
+        assert completed == [("default", "u001")]
+        dispatcher.dispatch.assert_not_called()
+
     def test_happy_path_syncs_symlinks(self):
         event = _make_event()
 

--- a/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
@@ -150,17 +150,26 @@ class _Installations:
 
 
 class _Bots:
-    def __init__(self, status: str, entity_id: str = "owner") -> None:
+    def __init__(
+        self,
+        status: str,
+        entity_id: str = "owner",
+        engine: str = "openclaw",
+        bot_type: str | None = None,
+    ) -> None:
         self.status = status
         self.entity_id = entity_id
+        self.engine = engine
+        self.bot_type = bot_type
 
     def get_by_id_and_owner(self, *_args):
         return {
             "status": self.status,
-            "active_engine": "openclaw",
+            "active_engine": self.engine,
             "env": "pre",
             "entity_id": self.entity_id,
             "entity_type": "staff",
+            **({"bot_type": self.bot_type} if self.bot_type is not None else {}),
         }
 
 
@@ -232,6 +241,7 @@ class _RuntimeReconciler:
         self.skills = skills
         self.pool_layout = pool_layout
         self.calls: list[dict] = []
+        self.cleanup_calls: list[dict] = []
 
     async def reconcile(self, **kwargs) -> None:
         self.calls.append(kwargs)
@@ -293,6 +303,25 @@ class _RuntimeReconciler:
         ):
             raise RuntimeError("runtime reconcile failed")
 
+    async def reconcile_cleanup(self, **kwargs) -> None:
+        self.cleanup_calls.append(kwargs)
+        if not self.runtime.sync_runtime(
+            desired_skills=[
+                {
+                    "id": str(asset.skill_id),
+                    "name": asset.name,
+                    "git_path": asset.git_path,
+                }
+                for asset in self.skills.list_bot_active_assets(
+                    env="pre",
+                    bot_id=kwargs["bot_id"],
+                    user_id=kwargs["owner_id"],
+                    engine="aicoding",
+                )
+            ]
+        ):
+            raise RuntimeError("runtime cleanup failed")
+
 
 class _Layouts:
     def __init__(self, *, pool: bool = False) -> None:
@@ -344,6 +373,8 @@ def _service(
     guard_error=None,
     guard_release_error: Exception | None = None,
     mutation_guard=None,
+    engine: str = "openclaw",
+    bot_type: str | None = None,
 ):
     skills = _Skills(active=active, git_path=git_path)
     sets = _Sets(skills, associated=associated)
@@ -363,7 +394,7 @@ def _service(
     service = LocalSkillStateService(
         skills,
         sets,
-        _Bots(status, entity_id),
+        _Bots(status, entity_id, engine=engine, bot_type=bot_type),
         collaborators or _Collaborators(),
         factory,
         mutation_guard,
@@ -629,6 +660,55 @@ async def test_repo_direct_fails_closed_for_unsupported_bot_engine_pair():
         )
 
     assert installations.events == []
+
+
+@pytest.mark.asyncio
+async def test_historical_aicoding_local_skill_can_deactivate_but_cannot_activate():
+    service, skills, installations, _guard, runtime, _factory = _service(
+        active=True,
+        engine="aicoding",
+        bot_type="personal",
+    )
+
+    result = await service.set_local_skill_active(
+        skill_id="9", actor_id="owner", active=False
+    )
+
+    assert result["active"] is False
+    assert skills.active is False
+    assert installations.events == ["add"]
+    assert service._runtime_reconciler.cleanup_calls == [
+        {"bot_id": "bot", "owner_id": "owner"}
+    ]
+    assert runtime.publish_calls == []
+
+    with pytest.raises(SkillEngineNotSupportedError):
+        await service.set_local_skill_active(skill_id="9", actor_id="owner", active=True)
+    assert installations.events == ["add"]
+
+
+@pytest.mark.asyncio
+async def test_historical_aicoding_repo_skill_can_deactivate_but_cannot_activate():
+    service, _skills, installations, runtime = _repo_service(
+        active=True,
+        engine="aicoding",
+    )
+
+    result = await service.set_repo_skill_active(
+        skill_id="9", bot_id="bot", actor_id="owner", active=False
+    )
+
+    assert result["active"] is False
+    assert installations.events == ["uninstall:pre:bot:9"]
+    assert service._runtime_reconciler.cleanup_calls == [
+        {"bot_id": "bot", "owner_id": "owner"}
+    ]
+    assert runtime.publish_calls == []
+
+    with pytest.raises(SkillEngineNotSupportedError):
+        await service.set_repo_skill_active(
+            skill_id="9", bot_id="bot", actor_id="owner", active=True
+        )
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
@@ -19,6 +19,10 @@ from agentclaw.community.core.skill_center.errors import (
 from agentclaw.community.core.skill_center.services.local_skill_state_service import (
     LocalSkillStateService,
 )
+from agentclaw.community.core.skill_center.runtime_resolver import (
+    RuntimeDesiredState,
+    RuntimeProjectionResolver,
+)
 from agentclaw.community.core.skills_pool.models import (
     RegisteredSkillAsset,
     SkillMappingSourceLayout,
@@ -222,6 +226,74 @@ class _Runtime:
         return self.verify_results.pop(0)
 
 
+class _RuntimeReconciler:
+    def __init__(self, runtime: _Runtime, skills, *, pool_layout: bool = False) -> None:
+        self.runtime = runtime
+        self.skills = skills
+        self.pool_layout = pool_layout
+        self.calls: list[dict] = []
+
+    async def reconcile(self, **kwargs) -> None:
+        self.calls.append(kwargs)
+        projection = RuntimeProjectionResolver().resolve(
+            RuntimeDesiredState(
+                skills=tuple(
+                    self.skills.list_bot_active_assets(
+                        env="pre",
+                        bot_id=kwargs["bot_id"],
+                        user_id=kwargs["owner_id"],
+                        engine="openclaw",
+                    )
+                )
+            )
+        )
+        retired = list(kwargs.get("retired_mappings") or ())
+        if (
+            self.pool_layout
+            or retired
+            or any(mapping.corpus == "repo" for mapping in projection.skill_mappings)
+        ):
+            contract_mappings = [*projection.skill_mappings, *retired]
+            contract = (
+                "skills-pool-mapping-v3"
+                if any(mapping.corpus == "center" for mapping in contract_mappings)
+                else "skills-pool-mapping-v2"
+            )
+            published = await self.runtime.publish_mappings(
+                mappings=list(projection.skill_mappings),
+                retired_mappings=retired,
+                source_layout=(
+                    SkillMappingSourceLayout.POOL
+                    if self.pool_layout
+                    else SkillMappingSourceLayout.LEGACY
+                ),
+                mapping_contract_version=contract,
+            )
+            if not published or not await self.runtime.verify_mappings(
+                mappings=list(projection.skill_mappings),
+                retired_mappings=retired,
+                source_layout=(
+                    SkillMappingSourceLayout.POOL
+                    if self.pool_layout
+                    else SkillMappingSourceLayout.LEGACY
+                ),
+                mapping_contract_version=contract,
+            ):
+                raise RuntimeError("runtime reconcile failed")
+            return
+        if not self.runtime.sync_runtime(
+            desired_skills=[
+                {
+                    "id": str(asset.skill_id),
+                    "name": asset.name,
+                    "git_path": asset.git_path,
+                }
+                for asset in projection.skill_assets
+            ]
+        ):
+            raise RuntimeError("runtime reconcile failed")
+
+
 class _Layouts:
     def __init__(self, *, pool: bool = False) -> None:
         self.pool = pool
@@ -284,6 +356,9 @@ def _service(
 
         guard.acquire_for_edit = fail_acquire
     runtime = _Runtime(sync_success)
+    runtime_reconciler = _RuntimeReconciler(
+        runtime, skills, pool_layout=pool_layout
+    )
     factory = _Factory(runtime)
     service = LocalSkillStateService(
         skills,
@@ -293,10 +368,9 @@ def _service(
         factory,
         mutation_guard,
         guard,
-        runtime,
         skills,
-        _Layouts(pool=pool_layout),
         sets,
+        runtime_reconciler,
     )
     return service, skills, sets, guard, runtime, factory
 
@@ -356,13 +430,9 @@ async def test_activate_changes_desired_state_then_reconciles_under_bot_layout_l
     assert sets.events == ["remove"]
     assert runtime.calls == 1
     assert guard.events == ["acquire:pre:owner:bot", "release"]
-    assert factory.kwargs == {
-        "user_id": "owner",
-        "entity_id": "owner",
-        "bot_id": "bot",
-        "engine_type": "openclaw",
-        "entity_type": "staff",
-    }
+    assert service._runtime_reconciler.calls == [
+        {"bot_id": "bot", "owner_id": "owner"}
+    ]
 
 
 @pytest.mark.asyncio
@@ -481,6 +551,7 @@ def _repo_service(
     skills = _RepoSkills(active=active, references=references)
     installations = _Installations(skills)
     runtime = _Runtime(sync_success)
+    runtime_reconciler = _RuntimeReconciler(runtime, skills)
     factory = _RepoFactory(runtime, normal_member=bool(references))
     guard = _Guard()
     if active_assets is not None:
@@ -493,10 +564,9 @@ def _repo_service(
         factory,
         _MutationGuard(),
         guard,
-        runtime,
         skills,
-        _Layouts(),
         factory.set_service,
+        runtime_reconciler,
     )
     return service, skills, installations, runtime
 
@@ -596,14 +666,16 @@ async def test_repo_direct_idempotent_runtime_failure_preserves_old_installation
 
 
 @pytest.mark.asyncio
-async def test_runtime_sync_uses_the_bot_entity_for_skill_paths():
+async def test_runtime_sync_delegates_the_stable_bot_identity():
     service, _skills, _sets, _guard, _runtime, factory = _service(
         entity_id="project-entity"
     )
 
     await service.set_local_skill_active(skill_id="9", actor_id="owner", active=True)
 
-    assert factory.kwargs["entity_id"] == "project-entity"
+    assert service._runtime_reconciler.calls == [
+        {"bot_id": "bot", "owner_id": "owner"}
+    ]
 
 
 @pytest.mark.asyncio
@@ -818,15 +890,15 @@ async def test_runtime_failure_republishes_the_rolled_back_desired_state():
 
 
 @pytest.mark.asyncio
-async def test_runtime_factory_failure_also_compensates_before_fixed_failure():
-    service, skills, sets, _guard, _runtime, factory = _service(
+async def test_runtime_reconciler_failure_also_compensates_before_fixed_failure():
+    service, skills, sets, _guard, _runtime, _factory = _service(
         active=False, sync_success=True
     )
 
-    def fail_create(**_kwargs):
+    async def fail_reconcile(**_kwargs):
         raise RuntimeError("private runtime resolution")
 
-    factory.create = fail_create
+    service._runtime_reconciler.reconcile = fail_reconcile
     with pytest.raises(LocalSkillRuntimeSyncError):
         await service.set_local_skill_active(
             skill_id="9", actor_id="owner", active=True

--- a/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
@@ -704,6 +704,31 @@ async def test_deactivate_selects_pool_source_layout_after_cutover():
 
 
 @pytest.mark.asyncio
+async def test_center_projection_uses_v3_adapter_contract_without_current_locator():
+    service, skills, _sets, _guard, runtime, _factory = _service(active=True)
+    skills.list_bot_active_assets = lambda **_kwargs: [
+        RegisteredSkillAsset(
+            skill_id=9,
+            name="center-skill",
+            git_path="center://skill-uuid",
+            skill_uuid="skill-uuid",
+            sc_version_number="42",
+        )
+    ]
+
+    await service.set_local_skill_active(skill_id="9", actor_id="owner", active=False)
+
+    assert runtime.publish_calls[0]["mapping_contract_version"] == "skills-pool-mapping-v3"
+    assert runtime.verify_calls[0]["mapping_contract_version"] == "skills-pool-mapping-v3"
+    assert runtime.publish_calls[0]["mappings"][0].to_dict() == {
+        "corpus": "center",
+        "skill_uuid": "skill-uuid",
+        "sc_version_number": "42",
+        "link_name": "center-skill",
+    }
+
+
+@pytest.mark.asyncio
 async def test_deactivate_invalid_locator_fails_closed_and_restores_desired_state():
     service, skills, sets, _guard, runtime, _factory = _service(
         active=True, git_path="local://folder/../one"

--- a/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
@@ -209,7 +209,7 @@ class _Runtime:
         self.publish_calls = []
         self.verify_calls = []
 
-    def sync_runtime(self):
+    def sync_runtime(self, *, desired_skills=None):
         self.calls += 1
         return self.success
 
@@ -688,7 +688,7 @@ async def test_deactivate_mapping_repository_failure_fails_closed_and_restores_s
     assert skills.active is True
     assert runtime.publish_calls == []
     assert runtime.verify_calls == []
-    assert runtime.calls == 1
+    assert runtime.calls == 0
 
 
 @pytest.mark.asyncio
@@ -717,7 +717,7 @@ async def test_deactivate_invalid_locator_fails_closed_and_restores_desired_stat
     assert sets.events == ["add", "remove"]
     assert skills.active is True
     assert runtime.publish_calls == []
-    assert runtime.calls == 1
+    assert runtime.calls == 0
 
 
 @pytest.mark.asyncio
@@ -777,7 +777,7 @@ async def test_runtime_failure_republishes_the_rolled_back_desired_state():
     service, skills, sets, _guard, runtime, _factory = _service(active=False)
     outcomes = iter([False, True])
 
-    def sync_with_recovery():
+    def sync_with_recovery(*, desired_skills=None):
         runtime.calls += 1
         return next(outcomes)
 

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -17,6 +17,7 @@ from agentclaw.community.core.skill_center.errors import (
     LocalSkillNotReadyError,
     LocalSkillRuntimeSyncError,
     LocalSkillStorageError,
+    SkillEngineNotSupportedError,
 )
 from agentclaw.community.core.skill_center.services.local_skill_upload_service import (
     LocalSkillUploadService,
@@ -146,14 +147,24 @@ class _Sets:
 
 
 class _Bot:
-    def __init__(self, status="ACTIVE", entity_id="owner"):
+    def __init__(
+        self,
+        status="ACTIVE",
+        entity_id="owner",
+        *,
+        bot_type="personal",
+        engine="openclaw",
+    ):
         self.status = status
         self.entity_id = entity_id
+        self.bot_type = bot_type
+        self.engine = engine
 
     def get_by_id_and_owner(self, *_):
         return {
             "status": self.status,
-            "active_engine": "moltis",
+            "active_engine": self.engine,
+            "bot_type": self.bot_type,
             "env": "test",
             "entity_id": self.entity_id,
         }
@@ -579,6 +590,22 @@ async def test_upload_maps_guard_failures_to_public_domain_errors(
 
 
 @pytest.mark.asyncio
+async def test_upload_fails_closed_for_unsupported_bot_engine_pair():
+    service = _service(
+        _Filesystem(),
+        bot=_Bot(bot_type="desktop", engine="claude_code"),
+    )
+
+    with pytest.raises(SkillEngineNotSupportedError):
+        await service.upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="owner",
+            package=_zip({"SKILL.md": _skill_md()}),
+        )
+
+
+@pytest.mark.asyncio
 async def test_upload_keeps_bot_owner_when_collaborator_is_actor():
     filesystem = _Filesystem()
     audit = _Audit()
@@ -656,7 +683,7 @@ async def test_upload_resolves_package_storage_with_bot_entity():
             "entity_id": "project-entity",
             "owner_id": "owner",
             "bot_id": "bot",
-            "engine_type": "moltis",
+            "engine_type": "openclaw",
             "entity_type": "staff",
             "is_desktop": False,
             "is_teclaw": False,

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -85,6 +85,17 @@ class _Repo:
         self.created.clear()
         return True
 
+    def list_bot_active_assets(self, **_kwargs):
+        from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+
+        return [
+            RegisteredSkillAsset(
+                skill_id=int(row["id"]), name=row["name"], git_path=row["git_path"]
+            )
+            for row in self.created
+            if row.get("active")
+        ]
+
 
 class _Sets:
     def __init__(self, fail_at=None, default_exists=True):
@@ -361,7 +372,7 @@ class _RuntimeFactory:
     def create(self, **kwargs):
         return self
 
-    def sync_runtime(self):
+    def sync_runtime(self, *, desired_skills=None):
         return True
 
 
@@ -372,6 +383,17 @@ class _ReplacementRepo(_Repo):
         self.updates = []
         self.atomic_replacements = []
         self.cleanup = None
+
+    def list_bot_active_assets(self, **_kwargs):
+        from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+
+        return [
+            RegisteredSkillAsset(
+                skill_id=int(row["id"]), name=row["name"], git_path=row["git_path"]
+            )
+            for row in self.rows
+            if row.get("active")
+        ]
 
     def list_bot_local_by_name(self, **_kwargs):
         return self.rows
@@ -460,7 +482,7 @@ class _ReplacementRuntime:
     def create(self, **_kwargs):
         return self
 
-    def sync_runtime(self):
+    def sync_runtime(self, *, desired_skills=None):
         self.calls += 1
         return next(self.results)
 

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -375,6 +375,9 @@ class _RuntimeFactory:
     def sync_runtime(self, *, desired_skills=None):
         return True
 
+    async def reconcile(self, **_kwargs):
+        return None
+
 
 class _ReplacementRepo(_Repo):
     def __init__(self, rows):
@@ -486,6 +489,11 @@ class _ReplacementRuntime:
         self.calls += 1
         return next(self.results)
 
+    async def reconcile(self, **_kwargs):
+        self.calls += 1
+        if not next(self.results):
+            raise RuntimeError("runtime reconcile failed")
+
 
 class _DeviceResolver:
     def __init__(self, provider="local"):
@@ -506,11 +514,11 @@ def _replacement_service(
         _Bot(),
         _Collaborators(),
         _ReplacementFactory(filesystem),
-        runtime,
         _Audit(),
         guard or _Guard(),
         cleanup,
         lambda: _DeviceResolver(provider),
+        runtime,
     )
 
 
@@ -533,11 +541,11 @@ def _service(
         bot or _Bot(status),
         collaborators or _Collaborators(),
         factory or _Factory(filesystem),
-        _RuntimeFactory(),
         audit or _Audit(),
         guard or _Guard(),
         _Cleanup(),
         lambda: _DeviceResolver(provider),
+        _RuntimeFactory(),
     )
 
 

--- a/src/backend/tests/community/core/skill_center/test_runtime_resolver.py
+++ b/src/backend/tests/community/core/skill_center/test_runtime_resolver.py
@@ -1,0 +1,135 @@
+"""Contract tests for the complete Skill/MCP runtime projection."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.skill_center.runtime_resolver import (
+    RuntimeDesiredState,
+    RuntimeNameConflictError,
+    RuntimeProjectionResolver,
+)
+from agentclaw.community.core.skill_center.runtime_policy import (
+    require_supported_bot_skill_runtime,
+)
+from agentclaw.community.core.skill_center.errors import SkillEngineNotSupportedError
+from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+
+
+def test_resolver_projects_every_supported_skill_corpus_and_deduplicates_inputs() -> None:
+    state = RuntimeDesiredState(
+        skills=(
+            RegisteredSkillAsset(skill_id=1, name="local", git_path="local://local"),
+            RegisteredSkillAsset(skill_id=2, name="repo", git_path="git://team/repo"),
+            RegisteredSkillAsset(
+                skill_id=3,
+                name="center",
+                git_path="center://center-uuid",
+                skill_uuid="center-uuid",
+                sc_version_number="7",
+            ),
+            # Installation and System Default can select the same asset.  It is
+            # one runtime entry, not a second source-specific projection.
+            RegisteredSkillAsset(skill_id=2, name="repo", git_path="git://team/repo"),
+        ),
+        installed_mcp_server_codes=frozenset({"mcp-b", "mcp-a"}),
+        system_default_cli_commands=("builtin",),
+    )
+
+    projection = RuntimeProjectionResolver().resolve(state)
+
+    assert [mapping.to_dict() for mapping in projection.skill_mappings] == [
+        {"corpus": "local", "link_name": "local", "relative_path": "local"},
+        {"corpus": "repo", "link_name": "repo", "relative_path": "team/repo"},
+        {
+            "corpus": "center",
+            "link_name": "center",
+            "skill_uuid": "center-uuid",
+            "sc_version_number": "7",
+        },
+    ]
+    assert projection.mcp_server_codes == ("mcp-a", "mcp-b")
+    assert projection.cli_commands == ("builtin",)
+
+
+def test_resolver_uses_ac_skill_name_for_local_runtime_entry_not_locator_tail() -> None:
+    projection = RuntimeProjectionResolver().resolve(
+        RuntimeDesiredState(
+            skills=(
+                RegisteredSkillAsset(
+                    skill_id=1,
+                    name="display-name",
+                    git_path="local://uploaded-directory",
+                ),
+            )
+        )
+    )
+
+    assert projection.skill_mappings[0].link_name == "display-name"
+    assert projection.skill_mappings[0].relative_path == "uploaded-directory"
+
+
+def test_resolver_fails_closed_when_distinct_assets_have_same_runtime_name() -> None:
+    with pytest.raises(RuntimeNameConflictError):
+        RuntimeProjectionResolver().resolve(
+            RuntimeDesiredState(
+                skills=(
+                    RegisteredSkillAsset(skill_id=1, name="same", git_path="local://one"),
+                    RegisteredSkillAsset(skill_id=2, name="same", git_path="git://two"),
+                )
+            )
+        )
+
+
+def test_resolver_rejects_unknown_sources_instead_of_silently_dropping_them() -> None:
+    with pytest.raises(ValueError, match="unsupported skill source"):
+        RuntimeProjectionResolver().resolve(
+            RuntimeDesiredState(
+                skills=(
+                    RegisteredSkillAsset(skill_id=1, name="unknown", git_path="ftp://x"),
+                )
+            )
+        )
+
+
+def test_aicoding_image_uses_the_claude_code_support_entry() -> None:
+    require_supported_bot_skill_runtime(
+        {"bot_type": "personal", "active_engine": "aicoding"}
+    )
+
+
+@pytest.mark.parametrize(
+    ("bot_type", "engine"),
+    [
+        ("personal", "openclaw"),
+        ("personal", "claude_code"),
+        ("personal", "aicoding"),
+        ("personal", "hermes"),
+        ("personal", "teclaw"),
+        ("desktop", "openclaw"),
+        ("desktop", "hermes"),
+        ("service", "openclaw"),
+        ("service", "claude_code"),
+        ("service", "aicoding"),
+        ("service", "teclaw"),
+    ],
+)
+def test_confirmed_bot_engine_matrix_is_accepted_by_every_projection_adapter_entry(
+    bot_type: str, engine: str
+) -> None:
+    require_supported_bot_skill_runtime(
+        {"bot_type": bot_type, "active_engine": engine}
+    )
+
+
+@pytest.mark.parametrize(
+    ("bot_type", "engine"),
+    [("desktop", "claude_code"), ("desktop", "teclaw"), ("service", "hermes")],
+)
+def test_unconfirmed_bot_engine_matrix_fails_closed(
+    bot_type: str, engine: str
+) -> None:
+    with pytest.raises(SkillEngineNotSupportedError):
+        require_supported_bot_skill_runtime(
+            {"bot_type": bot_type, "active_engine": engine}
+        )

--- a/src/backend/tests/community/core/skill_center/test_runtime_resolver.py
+++ b/src/backend/tests/community/core/skill_center/test_runtime_resolver.py
@@ -10,7 +10,10 @@ from agentclaw.community.core.skill_center.runtime_resolver import (
     RuntimeProjectionResolver,
 )
 from agentclaw.community.core.skill_center.runtime_policy import (
+    BotSkillRuntimeMutationMode,
+    bot_skill_runtime_mutation_mode,
     require_supported_bot_skill_runtime,
+    runtime_layout_engine_for_bot,
 )
 from agentclaw.community.core.skill_center.errors import SkillEngineNotSupportedError
 from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
@@ -116,6 +119,34 @@ def test_historical_aicoding_engine_fails_closed_for_new_mutations() -> None:
         require_supported_bot_skill_runtime(
             {"bot_type": "personal", "active_engine": "aicoding"}
         )
+
+
+@pytest.mark.parametrize(
+    "bot",
+    [
+        {"bot_type": "personal", "active_engine": "aicoding"},
+        {"bot_type": "personal", "active_engine": "claude_code"},
+        {"bot_type": "desktop", "active_engine": "claude_code"},
+    ],
+)
+def test_historical_runtime_rows_are_cleanup_only_not_writable(bot: dict) -> None:
+    assert bot_skill_runtime_mutation_mode(bot) is BotSkillRuntimeMutationMode.CLEANUP_ONLY
+    with pytest.raises(SkillEngineNotSupportedError):
+        require_supported_bot_skill_runtime(bot)
+
+
+@pytest.mark.parametrize("template_type", ["personalCoding", "applicationCoding"])
+def test_coding_template_has_aicoding_physical_layout_but_claude_logical_engine(
+    template_type: str,
+) -> None:
+    bot = {
+        "bot_type": "personal",
+        "active_engine": "claude_code",
+        "template_type": template_type,
+    }
+
+    assert bot_skill_runtime_mutation_mode(bot) is BotSkillRuntimeMutationMode.FULL
+    assert runtime_layout_engine_for_bot(bot) == "aicoding"
 
 
 @pytest.mark.parametrize("template_type", ["personalCoding", "applicationCoding"])

--- a/src/backend/tests/community/core/skill_center/test_runtime_resolver.py
+++ b/src/backend/tests/community/core/skill_center/test_runtime_resolver.py
@@ -33,6 +33,7 @@ def test_resolver_projects_every_supported_skill_corpus_and_deduplicates_inputs(
             RegisteredSkillAsset(skill_id=2, name="repo", git_path="git://team/repo"),
         ),
         installed_mcp_server_codes=frozenset({"mcp-b", "mcp-a"}),
+        system_default_mcp_server_codes=frozenset({"mcp-default"}),
         system_default_cli_commands=("builtin",),
     )
 
@@ -48,7 +49,7 @@ def test_resolver_projects_every_supported_skill_corpus_and_deduplicates_inputs(
             "sc_version_number": "7",
         },
     ]
-    assert projection.mcp_server_codes == ("mcp-a", "mcp-b")
+    assert projection.mcp_server_codes == ("mcp-a", "mcp-b", "mcp-default")
     assert projection.cli_commands == ("builtin",)
 
 
@@ -67,6 +68,24 @@ def test_resolver_uses_ac_skill_name_for_local_runtime_entry_not_locator_tail() 
 
     assert projection.skill_mappings[0].link_name == "display-name"
     assert projection.skill_mappings[0].relative_path == "uploaded-directory"
+
+
+def test_resolver_merges_explicit_and_skill_declared_mcp_dependencies() -> None:
+    projection = RuntimeProjectionResolver().resolve(
+        RuntimeDesiredState(
+            skills=(
+                RegisteredSkillAsset(
+                    skill_id=1,
+                    name="skill",
+                    git_path="git://team/skill",
+                    mcp_dependencies=("mcp.explicit", {"server_code": "mcp.object"}),
+                ),
+            ),
+            installed_mcp_server_codes=frozenset({"mcp.explicit", "mcp.direct"}),
+        )
+    )
+
+    assert projection.mcp_server_codes == ("mcp.direct", "mcp.explicit", "mcp.object")
 
 
 def test_resolver_fails_closed_when_distinct_assets_have_same_runtime_name() -> None:

--- a/src/backend/tests/community/core/skill_center/test_runtime_resolver.py
+++ b/src/backend/tests/community/core/skill_center/test_runtime_resolver.py
@@ -111,39 +111,64 @@ def test_resolver_rejects_unknown_sources_instead_of_silently_dropping_them() ->
         )
 
 
-def test_aicoding_image_uses_the_claude_code_support_entry() -> None:
+def test_historical_aicoding_engine_fails_closed_for_new_mutations() -> None:
+    with pytest.raises(SkillEngineNotSupportedError):
+        require_supported_bot_skill_runtime(
+            {"bot_type": "personal", "active_engine": "aicoding"}
+        )
+
+
+@pytest.mark.parametrize("template_type", ["personalCoding", "applicationCoding"])
+def test_aicoding_image_uses_the_claude_code_logical_engine(
+    template_type: str,
+) -> None:
     require_supported_bot_skill_runtime(
-        {"bot_type": "personal", "active_engine": "aicoding"}
+        {
+            "bot_type": "personal",
+            "active_engine": "claude_code",
+            "template_type": template_type,
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("bot_type", "engine", "template_type"),
+    [
+        ("personal", "openclaw", None),
+        ("personal", "claude_code", "personalCoding"),
+        ("personal", "claude_code", "applicationCoding"),
+        ("personal", "hermes", None),
+        ("personal", "teclaw", None),
+        ("desktop", "openclaw", None),
+        ("desktop", "hermes", None),
+        ("service", "openclaw", None),
+        ("service", "claude_code", "personalCoding"),
+        ("service", "claude_code", "applicationCoding"),
+        ("service", "teclaw", None),
+    ],
+)
+def test_confirmed_bot_engine_matrix_is_accepted_by_every_projection_adapter_entry(
+    bot_type: str, engine: str, template_type: str | None
+) -> None:
+    require_supported_bot_skill_runtime(
+        {
+            "bot_type": bot_type,
+            "active_engine": engine,
+            "template_type": template_type,
+        }
     )
 
 
 @pytest.mark.parametrize(
     ("bot_type", "engine"),
     [
-        ("personal", "openclaw"),
-        ("personal", "claude_code"),
+        ("desktop", "claude_code"),
+        ("desktop", "teclaw"),
+        ("service", "hermes"),
         ("personal", "aicoding"),
-        ("personal", "hermes"),
-        ("personal", "teclaw"),
-        ("desktop", "openclaw"),
-        ("desktop", "hermes"),
-        ("service", "openclaw"),
+        ("personal", "claude_code"),
         ("service", "claude_code"),
-        ("service", "aicoding"),
-        ("service", "teclaw"),
     ],
-)
-def test_confirmed_bot_engine_matrix_is_accepted_by_every_projection_adapter_entry(
-    bot_type: str, engine: str
-) -> None:
-    require_supported_bot_skill_runtime(
-        {"bot_type": bot_type, "active_engine": engine}
-    )
-
-
-@pytest.mark.parametrize(
-    ("bot_type", "engine"),
-    [("desktop", "claude_code"), ("desktop", "teclaw"), ("service", "hermes")],
 )
 def test_unconfirmed_bot_engine_matrix_fails_closed(
     bot_type: str, engine: str

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -27,6 +27,7 @@ from agentclaw.community.core.skill_center.services.bot_capability_mutation_guar
     BotCapabilityMutationLockUnavailableError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
+from agentclaw.community.core.mcp.services._defaults import get_default_mcp_servers
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
 
 
@@ -758,4 +759,11 @@ async def test_runtime_reconcile_projects_full_mcp_desired_state():
 
     await runtime.reconcile(bot_id="bot-1", owner_id="true-owner")
 
-    assert factory.service.mcp_codes == {"mcp.weather"}
+    assert factory.service.mcp_codes == {
+        "mcp.weather",
+        *{
+            item["server_code"]
+            for item in get_default_mcp_servers("openclaw", None)
+            if item.get("server_code")
+        },
+    }

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -296,7 +296,8 @@ class _RuntimeFactoryService:
     def __init__(self) -> None:
         self.mcp_codes: set[str] | None = None
 
-    def sync_runtime(self) -> bool:
+    def sync_runtime(self, *, desired_skills: list[dict]) -> bool:
+        assert desired_skills == []
         return True
 
     async def sync_mcp_desired_state(self, *, server_codes: set[str]) -> bool:

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -91,6 +91,9 @@ class _Repository:
     def get_set(self, **_kwargs):
         return {"is_default": False}
 
+    def delete_set(self, **_kwargs) -> None:
+        return None
+
 
 class _CreateRepository(_Repository):
     def __init__(self) -> None:
@@ -175,6 +178,9 @@ class _Runtime:
         if len(self.owners) == 1:
             raise RuntimeError("runtime failed")
 
+    async def reconcile_cleanup(self, *, bot_id: str, owner_id: str) -> None:
+        await self.reconcile(bot_id=bot_id, owner_id=owner_id)
+
 
 class _Audit:
     def insert(self, _data) -> None:
@@ -210,10 +216,27 @@ class _BlockingRuntime:
         self._started.set()
         await self._unblock.wait()
 
+    async def reconcile_cleanup(self, **kwargs) -> None:
+        await self.reconcile(**kwargs)
+
 
 class _SuccessfulRuntime:
     async def reconcile(self, **_kwargs) -> None:
         return None
+
+    async def reconcile_cleanup(self, **_kwargs) -> None:
+        return None
+
+
+class _CleanupRuntime(_SuccessfulRuntime):
+    def __init__(self) -> None:
+        self.cleanup_calls: list[dict] = []
+
+    async def reconcile(self, **_kwargs) -> None:
+        raise AssertionError("cleanup-only Bot must not receive a full projection")
+
+    async def reconcile_cleanup(self, **kwargs) -> None:
+        self.cleanup_calls.append(kwargs)
 
 
 class _FailingReleaseGuard(_Guard):
@@ -351,6 +374,23 @@ class _UnsupportedRuntimeBots(_RuntimeBots):
         }
 
 
+class _AicodingImageRuntimeBots(_RuntimeBots):
+    def get_by_id_and_owner(self, bot_id: str, owner_id: str) -> dict:
+        return {
+            **super().get_by_id_and_owner(bot_id, owner_id),
+            "active_engine": "claude_code",
+            "template_type": "personalCoding",
+        }
+
+
+class _HistoricalAicodingRuntimeBots(_RuntimeBots):
+    def get_by_id_and_owner(self, bot_id: str, owner_id: str) -> dict:
+        return {
+            **super().get_by_id_and_owner(bot_id, owner_id),
+            "active_engine": "aicoding",
+        }
+
+
 class _TeclawRuntimeBots(_RuntimeBots):
     def get_by_id_and_owner(self, bot_id: str, owner_id: str) -> dict:
         return {
@@ -373,6 +413,17 @@ class _RuntimeSkills:
             "bot_id": "bot-1",
             "user_id": "true-owner",
             "engine": "openclaw",
+        }
+        return []
+
+
+class _HistoricalAicodingRuntimeSkills(_RuntimeSkills):
+    def list_bot_active_assets(self, **kwargs):
+        assert kwargs == {
+            "env": "pre",
+            "bot_id": "bot-1",
+            "user_id": "true-owner",
+            "engine": "aicoding",
         }
         return []
 
@@ -422,6 +473,12 @@ class _CenterRuntimeSkills:
                 sc_version_number="3.0.0",
             )
         ]
+
+
+class _AicodingImageCenterRuntimeSkills(_CenterRuntimeSkills):
+    def list_bot_active_assets(self, **kwargs):
+        assert kwargs["engine"] == "claude_code"
+        return super().list_bot_active_assets(**kwargs)
 
 
 class _TeclawRuntimeSkills:
@@ -695,6 +752,37 @@ async def test_skill_set_mutation_fails_closed_for_unsupported_bot_engine_pair()
     assert repository.set_active_calls == []
 
 
+@pytest.mark.asyncio
+async def test_historical_bot_skill_set_deactivate_uses_cleanup_projection():
+    repository = _Repository()
+    runtime = _CleanupRuntime()
+    service = SkillSetControlPlaneService(
+        repository=repository,
+        bot_repo=_UnsupportedBots(),
+        runtime=runtime,
+        legacy_factory=object(),
+        passport=object(),
+        authorization=_Collaborators(),
+        mutation_guard=_MutationGuard(),
+        edit_guard=_Guard(),
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=_McpAuth(allowed=True),
+    )
+
+    await service.deactivate(bot_id="bot-1", actor_id="true-owner", set_id="set-1")
+
+    assert repository.set_active_calls == [
+        {
+            "bot_id": "bot-1",
+            "set_id": "set-1",
+            "active": False,
+            "engine_type": "claude_code",
+        }
+    ]
+    assert runtime.cleanup_calls == [{"bot_id": "bot-1", "owner_id": "true-owner"}]
+
+
 def test_skill_set_metadata_mutations_share_the_runtime_matrix_gate():
     service = SkillSetControlPlaneService(
         repository=_Repository(),
@@ -725,14 +813,29 @@ def test_skill_set_metadata_mutations_share_the_runtime_matrix_gate():
             name="new-name",
             description=None,
         ),
-        lambda: service.delete_set(
-            bot_id="bot-1", actor_id="true-owner", set_id="set-1"
-        ),
     ]
 
     for operation in operations:
         with pytest.raises(SkillEngineNotSupportedError):
             operation()
+
+
+def test_historical_bot_may_delete_an_inactive_skill_set_without_new_runtime_write():
+    service = SkillSetControlPlaneService(
+        repository=_Repository(),
+        bot_repo=_UnsupportedBots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=object(),
+        passport=object(),
+        authorization=_Collaborators(),
+        mutation_guard=_MutationGuard(),
+        edit_guard=_Guard(),
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=_McpAuth(allowed=True),
+    )
+
+    service.delete_set(bot_id="bot-1", actor_id="true-owner", set_id="set-1")
 
 
 def test_mutation_guard_heartbeat_fails_closed_and_stops_on_release(monkeypatch):
@@ -962,6 +1065,75 @@ async def test_runtime_reconcile_requires_and_uses_mapping_v3_for_center():
         "skill_uuid": "stable-skill-uuid",
         "sc_version_number": "3.0.0",
     }
+
+
+@pytest.mark.asyncio
+async def test_coding_template_uses_aicoding_for_center_probe_but_keeps_logical_engine():
+    factory = _RuntimeFactory()
+    pool = _CenterRuntimePool()
+    runtime = BotRuntimeProjectionReconciler(
+        factory=factory,
+        bot_repo=_AicodingImageRuntimeBots(),
+        repository=_McpInstallations(),
+        pool_skills=_AicodingImageCenterRuntimeSkills(),
+        pool_runtime=pool,
+        pool_layouts=_RuntimeLayouts(),
+        passport=_RuntimePassport(),
+    )
+
+    await runtime.reconcile(bot_id="bot-1", owner_id="true-owner")
+
+    assert factory.kwargs["engine_type"] == "claude_code"
+    assert pool.probe_calls == [
+        {"bot_id": "bot-1", "user_id": "true-owner", "engine": "aicoding"}
+    ]
+    assert len(pool.publish_calls) == len(pool.verify_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_historical_aicoding_cleanup_uses_legacy_runtime_not_pool_mapping():
+    factory = _RuntimeFactory()
+    pool = _RuntimePool()
+    runtime = BotRuntimeProjectionReconciler(
+        factory=factory,
+        bot_repo=_HistoricalAicodingRuntimeBots(),
+        repository=_McpInstallations(),
+        pool_skills=_HistoricalAicodingRuntimeSkills(),
+        pool_runtime=pool,
+        pool_layouts=_RuntimeLayouts(),
+        passport=_RuntimePassport(),
+    )
+
+    await runtime.reconcile_cleanup(bot_id="bot-1", owner_id="true-owner")
+
+    assert factory.kwargs["engine_type"] == "aicoding"
+    assert factory.service.desired_skills == []
+    assert factory.service.mcp_codes is not None
+    assert pool.publish_calls == []
+    assert pool.verify_calls == []
+
+
+@pytest.mark.asyncio
+async def test_historical_cleanup_rejects_center_before_runtime_or_mcp_delivery():
+    factory = _RuntimeFactory()
+    pool = _CenterRuntimePool()
+    runtime = BotRuntimeProjectionReconciler(
+        factory=factory,
+        bot_repo=_HistoricalAicodingRuntimeBots(),
+        repository=_McpInstallations(),
+        pool_skills=_CenterRuntimeSkills(),
+        pool_runtime=pool,
+        pool_layouts=_RuntimeLayouts(),
+        passport=_RuntimePassport(),
+    )
+
+    with pytest.raises(SkillSetRuntimeReconcileError):
+        await runtime.reconcile_cleanup(bot_id="bot-1", owner_id="true-owner")
+
+    assert factory.service.desired_skills is None
+    assert factory.service.mcp_codes is None
+    assert pool.probe_calls == []
+    assert pool.publish_calls == []
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -315,13 +315,29 @@ class _RuntimeFactory:
 class _RuntimeBots:
     def get_by_id_and_owner(self, bot_id: str, owner_id: str) -> dict:
         assert (bot_id, owner_id) == ("bot-1", "true-owner")
-        return {"entity_id": "entity-1", "active_engine": "openclaw", "entity_type": "staff"}
+        return {
+            "entity_id": "entity-1",
+            "active_engine": "openclaw",
+            "entity_type": "staff",
+            "env": "pre",
+        }
 
 
 class _McpInstallations:
     def list_installed_mcps(self, *, bot_id: str) -> set[str]:
         assert bot_id == "bot-1"
         return {"mcp.weather"}
+
+
+class _RuntimeSkills:
+    def list_bot_active_assets(self, **kwargs):
+        assert kwargs == {
+            "env": "pre",
+            "bot_id": "bot-1",
+            "user_id": "true-owner",
+            "engine": "openclaw",
+        }
+        return []
 
 
 @pytest.mark.asyncio
@@ -736,6 +752,7 @@ async def test_runtime_reconcile_projects_full_mcp_desired_state():
         factory=factory,
         bot_repo=_RuntimeBots(),
         repository=_McpInstallations(),
+        pool_skills=_RuntimeSkills(),
     )
 
     await runtime.reconcile(bot_id="bot-1", owner_id="true-owner")

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from types import SimpleNamespace
 
 import pytest
 
@@ -20,14 +21,20 @@ from agentclaw.community.core.skill_center.errors import (
 )
 from agentclaw.community.core.skill_center.services.skill_set_control_plane import (
     SkillSetControlPlaneService,
-    SkillSetRuntimeReconciler,
+)
+from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
+    BotRuntimeProjectionReconciler,
 )
 from agentclaw.community.core.skill_center.services.bot_capability_mutation_guard import (
     BotCapabilityMutationGuard,
     BotCapabilityMutationLockUnavailableError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
-from agentclaw.community.core.mcp.services._defaults import get_default_mcp_servers
+from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+from agentclaw.community.core.mcp.services._defaults import (
+    get_default_cli_items,
+    get_default_mcp_servers,
+)
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
 
 
@@ -340,6 +347,61 @@ class _RuntimeSkills:
             "engine": "openclaw",
         }
         return []
+
+
+class _RuntimePool:
+    def __init__(self) -> None:
+        self.publish_calls: list[dict] = []
+        self.verify_calls: list[dict] = []
+
+    async def probe(self, **_kwargs):
+        raise AssertionError("non-Center projection must keep the legacy adapter")
+
+    async def publish_mappings(self, **kwargs):
+        self.publish_calls.append(kwargs)
+        return True
+
+    async def verify_mappings(self, **kwargs):
+        self.verify_calls.append(kwargs)
+        return True
+
+
+class _CenterRuntimePool(_RuntimePool):
+    async def probe(self, **_kwargs):
+        return SimpleNamespace(
+            evidence={
+                "supported_mapping_contract_versions": [
+                    "skills-pool-mapping-v2",
+                    "skills-pool-mapping-v3",
+                ]
+            }
+        )
+
+
+class _CenterRuntimeSkills:
+    def list_bot_active_assets(self, **_kwargs):
+        return [
+            RegisteredSkillAsset(
+                skill_id=7,
+                name="center-skill",
+                git_path="center://stable-skill-uuid",
+                skill_uuid="stable-skill-uuid",
+                sc_version_number="3.0.0",
+            )
+        ]
+
+
+class _RuntimeLayouts:
+    def get(self, _scope):
+        return None
+
+
+class _RuntimePassport:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def update_passport(self, **kwargs) -> None:
+        self.calls.append(kwargs)
 
 
 @pytest.mark.asyncio
@@ -750,11 +812,15 @@ async def test_mcp_direct_activation_denies_before_writing_desired_state():
 @pytest.mark.asyncio
 async def test_runtime_reconcile_projects_full_mcp_desired_state():
     factory = _RuntimeFactory()
-    runtime = SkillSetRuntimeReconciler(
+    passport = _RuntimePassport()
+    runtime = BotRuntimeProjectionReconciler(
         factory=factory,
         bot_repo=_RuntimeBots(),
         repository=_McpInstallations(),
         pool_skills=_RuntimeSkills(),
+        pool_runtime=_RuntimePool(),
+        pool_layouts=_RuntimeLayouts(),
+        passport=passport,
     )
 
     await runtime.reconcile(bot_id="bot-1", owner_id="true-owner")
@@ -766,4 +832,44 @@ async def test_runtime_reconcile_projects_full_mcp_desired_state():
             for item in get_default_mcp_servers("openclaw", None)
             if item.get("server_code")
         },
+    }
+    assert passport.calls == [
+        {
+            "bot_id": "bot-1",
+            "user_id": "true-owner",
+            "engine_type": "openclaw",
+            "resource_scope": {
+                "mcp_codes": sorted(factory.service.mcp_codes),
+                "cli_items": get_default_cli_items("openclaw", None),
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_reconcile_requires_and_uses_mapping_v3_for_center():
+    factory = _RuntimeFactory()
+    pool = _CenterRuntimePool()
+    runtime = BotRuntimeProjectionReconciler(
+        factory=factory,
+        bot_repo=_RuntimeBots(),
+        repository=_McpInstallations(),
+        pool_skills=_CenterRuntimeSkills(),
+        pool_runtime=pool,
+        pool_layouts=_RuntimeLayouts(),
+        passport=_RuntimePassport(),
+    )
+
+    await runtime.reconcile(bot_id="bot-1", owner_id="true-owner")
+
+    assert factory.service.mcp_codes is not None
+    assert len(pool.publish_calls) == len(pool.verify_calls) == 1
+    assert pool.publish_calls[0]["mapping_contract_version"] == (
+        "skills-pool-mapping-v3"
+    )
+    assert pool.publish_calls[0]["mappings"][0].to_dict() == {
+        "corpus": "center",
+        "link_name": "center-skill",
+        "skill_uuid": "stable-skill-uuid",
+        "sc_version_number": "3.0.0",
     }

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -329,8 +329,27 @@ class _RuntimeBots:
         return {
             "entity_id": "entity-1",
             "active_engine": "openclaw",
+            "bot_type": "personal",
             "entity_type": "staff",
             "env": "pre",
+        }
+
+
+class _UnsupportedRuntimeBots(_RuntimeBots):
+    def get_by_id_and_owner(self, bot_id: str, owner_id: str) -> dict:
+        return {
+            **super().get_by_id_and_owner(bot_id, owner_id),
+            "bot_type": "desktop",
+            "active_engine": "claude_code",
+        }
+
+
+class _TeclawRuntimeBots(_RuntimeBots):
+    def get_by_id_and_owner(self, bot_id: str, owner_id: str) -> dict:
+        return {
+            **super().get_by_id_and_owner(bot_id, owner_id),
+            "bot_type": "personal",
+            "active_engine": "teclaw",
         }
 
 
@@ -369,7 +388,12 @@ class _RuntimePool:
 
 
 class _CenterRuntimePool(_RuntimePool):
+    def __init__(self) -> None:
+        super().__init__()
+        self.probe_calls: list[dict] = []
+
     async def probe(self, **_kwargs):
+        self.probe_calls.append(_kwargs)
         return SimpleNamespace(
             evidence={
                 "supported_mapping_contract_versions": [
@@ -882,3 +906,39 @@ async def test_runtime_reconcile_requires_and_uses_mapping_v3_for_center():
         "skill_uuid": "stable-skill-uuid",
         "sc_version_number": "3.0.0",
     }
+
+
+@pytest.mark.asyncio
+async def test_runtime_reconcile_fails_closed_for_unsupported_bot_engine_pair():
+    runtime = BotRuntimeProjectionReconciler(
+        factory=_RuntimeFactory(),
+        bot_repo=_UnsupportedRuntimeBots(),
+        repository=_McpInstallations(),
+        pool_skills=_RuntimeSkills(),
+        pool_runtime=_RuntimePool(),
+        pool_layouts=_RuntimeLayouts(),
+        passport=_RuntimePassport(),
+    )
+
+    with pytest.raises(SkillEngineNotSupportedError):
+        await runtime.reconcile(bot_id="bot-1", owner_id="true-owner")
+
+
+@pytest.mark.asyncio
+async def test_teclaw_v4_rejects_center_without_any_center_runtime_request():
+    pool = _CenterRuntimePool()
+    runtime = BotRuntimeProjectionReconciler(
+        factory=_RuntimeFactory(),
+        bot_repo=_TeclawRuntimeBots(),
+        repository=_McpInstallations(),
+        pool_skills=_CenterRuntimeSkills(),
+        pool_runtime=pool,
+        pool_layouts=_RuntimeLayouts(),
+        passport=_RuntimePassport(),
+    )
+
+    with pytest.raises(SkillSetRuntimeReconcileError):
+        await runtime.reconcile(bot_id="bot-1", owner_id="true-owner")
+
+    assert pool.probe_calls == []
+    assert pool.publish_calls == []

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -300,9 +300,10 @@ class _RuntimeFactoryService:
     def __init__(self) -> None:
         self.mcp_codes: set[str] | None = None
         self.collect_calls: list[dict] = []
+        self.desired_skills: list[dict] | None = None
 
     def sync_runtime(self, *, desired_skills: list[dict]) -> bool:
-        assert desired_skills == []
+        self.desired_skills = desired_skills
         return True
 
     async def sync_mcp_desired_state(self, *, server_codes: set[str]) -> bool:
@@ -419,6 +420,17 @@ class _CenterRuntimeSkills:
                 git_path="center://stable-skill-uuid",
                 skill_uuid="stable-skill-uuid",
                 sc_version_number="3.0.0",
+            )
+        ]
+
+
+class _TeclawRuntimeSkills:
+    def list_bot_active_assets(self, **_kwargs):
+        return [
+            RegisteredSkillAsset(
+                skill_id=8,
+                name="repo-skill",
+                git_path="git://team/repo-skill",
             )
         ]
 
@@ -971,8 +983,9 @@ async def test_runtime_reconcile_fails_closed_for_unsupported_bot_engine_pair():
 @pytest.mark.asyncio
 async def test_teclaw_v4_rejects_center_without_any_center_runtime_request():
     pool = _CenterRuntimePool()
+    factory = _RuntimeFactory()
     runtime = BotRuntimeProjectionReconciler(
-        factory=_RuntimeFactory(),
+        factory=factory,
         bot_repo=_TeclawRuntimeBots(),
         repository=_McpInstallations(),
         pool_skills=_CenterRuntimeSkills(),
@@ -986,3 +999,57 @@ async def test_teclaw_v4_rejects_center_without_any_center_runtime_request():
 
     assert pool.probe_calls == []
     assert pool.publish_calls == []
+    assert factory.service.collect_calls == []
+
+
+@pytest.mark.asyncio
+async def test_teclaw_v4_repo_projection_uses_artifact_runtime_not_pool_mapping():
+    pool = _RuntimePool()
+    factory = _RuntimeFactory()
+    runtime = BotRuntimeProjectionReconciler(
+        factory=factory,
+        bot_repo=_TeclawRuntimeBots(),
+        repository=_McpInstallations(),
+        pool_skills=_TeclawRuntimeSkills(),
+        pool_runtime=pool,
+        pool_layouts=_RuntimeLayouts(),
+        passport=_RuntimePassport(),
+    )
+
+    await runtime.reconcile(bot_id="bot-1", owner_id="true-owner")
+
+    assert factory.service.desired_skills == [
+        {
+            "id": "8",
+            "name": "repo-skill",
+            "git_path": "git://team/repo-skill",
+            "skill_uuid": None,
+            "sc_version_number": None,
+        }
+    ]
+    assert pool.publish_calls == []
+    assert pool.verify_calls == []
+
+
+@pytest.mark.asyncio
+async def test_non_skill_projection_never_writes_skill_mappings():
+    pool = _RuntimePool()
+    factory = _RuntimeFactory()
+    runtime = BotRuntimeProjectionReconciler(
+        factory=factory,
+        bot_repo=_RuntimeBots(),
+        repository=_McpInstallations(),
+        pool_skills=_RuntimeSkills(),
+        pool_runtime=pool,
+        pool_layouts=_RuntimeLayouts(),
+        passport=_RuntimePassport(),
+    )
+
+    await runtime.reconcile_non_skill_projection(
+        bot_id="bot-1", owner_id="true-owner"
+    )
+
+    assert factory.service.desired_skills is None
+    assert factory.service.mcp_codes is not None
+    assert pool.publish_calls == []
+    assert pool.verify_calls == []

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -316,8 +316,10 @@ class _RuntimeFactoryService:
 class _RuntimeFactory:
     def __init__(self) -> None:
         self.service = _RuntimeFactoryService()
+        self.kwargs: dict | None = None
 
-    def create(self, **_kwargs):
+    def create(self, **kwargs):
+        self.kwargs = kwargs
         return self.service
 
 
@@ -825,6 +827,13 @@ async def test_runtime_reconcile_projects_full_mcp_desired_state():
 
     await runtime.reconcile(bot_id="bot-1", owner_id="true-owner")
 
+    assert factory.kwargs == {
+        "user_id": "true-owner",
+        "entity_id": "entity-1",
+        "bot_id": "bot-1",
+        "engine_type": "openclaw",
+        "entity_type": "staff",
+    }
     assert factory.service.mcp_codes == {
         "mcp.weather",
         *{

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -31,10 +31,6 @@ from agentclaw.community.core.skill_center.services.bot_capability_mutation_guar
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
 from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
-from agentclaw.community.core.mcp.services._defaults import (
-    get_default_cli_items,
-    get_default_mcp_servers,
-)
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
 
 
@@ -303,6 +299,7 @@ class _McpCenter:
 class _RuntimeFactoryService:
     def __init__(self) -> None:
         self.mcp_codes: set[str] | None = None
+        self.collect_calls: list[dict] = []
 
     def sync_runtime(self, *, desired_skills: list[dict]) -> bool:
         assert desired_skills == []
@@ -311,6 +308,15 @@ class _RuntimeFactoryService:
     async def sync_mcp_desired_state(self, *, server_codes: set[str]) -> bool:
         self.mcp_codes = server_codes
         return True
+
+    def collect_bot_active_mcps(self, **kwargs) -> list[dict]:
+        self.collect_calls.append(kwargs)
+        # ``hitl`` is a real LOCAL/stdio default: it belongs in the runtime
+        # projection but must never be declared to AgentPass.
+        return [
+            {"server_code": "mcp.template-preset"},
+            {"server_code": "hitl", "source": "local"},
+        ]
 
 
 class _RuntimeFactory:
@@ -428,6 +434,18 @@ class _RuntimePassport:
 
     def update_passport(self, **kwargs) -> None:
         self.calls.append(kwargs)
+
+    def query_passport_clis(self, bot_id: str, owner_id: str) -> list[dict]:
+        assert (bot_id, owner_id) == ("bot-1", "true-owner")
+        # This is the effective Default CLI scope after a user removed a
+        # static default. A reconcile must preserve it exactly, not revive the
+        # engine's static list.
+        return [{"cli_code": "kept-cli", "cli_name": "Kept"}]
+
+
+class _FailingRuntimePassport(_RuntimePassport):
+    def query_passport_clis(self, bot_id: str, owner_id: str) -> list[dict]:
+        raise RuntimeError("passport unavailable")
 
 
 @pytest.mark.asyncio
@@ -860,23 +878,49 @@ async def test_runtime_reconcile_projects_full_mcp_desired_state():
     }
     assert factory.service.mcp_codes == {
         "mcp.weather",
-        *{
-            item["server_code"]
-            for item in get_default_mcp_servers("openclaw", None)
-            if item.get("server_code")
-        },
+        "mcp.template-preset",
+        "hitl",
     }
+    assert factory.service.collect_calls == [
+        {
+            "entity_id": "entity-1",
+            "bot_id": "bot-1",
+            "user_id": "true-owner",
+            "entity_type": "staff",
+            "engine_type": "openclaw",
+        }
+    ]
     assert passport.calls == [
         {
             "bot_id": "bot-1",
             "user_id": "true-owner",
             "engine_type": "openclaw",
             "resource_scope": {
-                "mcp_codes": sorted(factory.service.mcp_codes),
-                "cli_items": get_default_cli_items("openclaw", None),
+                "mcp_codes": ["mcp.template-preset", "mcp.weather"],
+                "cli_items": [{"cli_code": "kept-cli", "cli_name": "Kept"}],
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_reconcile_fails_closed_when_effective_cli_scope_cannot_be_read():
+    factory = _RuntimeFactory()
+    passport = _FailingRuntimePassport()
+    runtime = BotRuntimeProjectionReconciler(
+        factory=factory,
+        bot_repo=_RuntimeBots(),
+        repository=_McpInstallations(),
+        pool_skills=_RuntimeSkills(),
+        pool_runtime=_RuntimePool(),
+        pool_layouts=_RuntimeLayouts(),
+        passport=passport,
+    )
+
+    with pytest.raises(SkillSetRuntimeReconcileError):
+        await runtime.reconcile(bot_id="bot-1", owner_id="true-owner")
+
+    assert passport.calls == []
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skills_pool/test_mapping_intent.py
+++ b/src/backend/tests/community/core/skills_pool/test_mapping_intent.py
@@ -183,6 +183,56 @@ def test_repo_runtime_name_uses_skill_name_not_path_tail() -> None:
         )
 
 
+def test_repo_retirement_evidence_round_trips_when_name_differs_from_locator_tail() -> None:
+    current = build_logical_skill_mappings(
+        [
+            RegisteredSkillAsset(
+                skill_id=1,
+                name="incident-review",
+                git_path="git://ops/weekly-report",
+            )
+        ]
+    )
+
+    assert logical_skill_mappings_from_evidence(
+        {"retired_mappings": [current[0].to_dict()]}
+    ) == current
+
+
+def test_retirement_evidence_rejects_same_runtime_name_with_different_identities() -> None:
+    with pytest.raises(ValueError, match="ambiguous retired mapping evidence"):
+        logical_skill_mappings_from_evidence(
+            {
+                "retired_mappings": [
+                    {
+                        "corpus": "repo",
+                        "relative_path": "ops/weekly-report",
+                        "link_name": "incident-review",
+                    },
+                    {
+                        "corpus": "repo",
+                        "relative_path": "finance/monthly-report",
+                        "link_name": "incident-review",
+                    },
+                ]
+            }
+        )
+
+
+def test_legacy_retirement_evidence_with_matching_tail_remains_compatible() -> None:
+    assert logical_skill_mappings_from_evidence(
+        {
+            "retired_mappings": [
+                {
+                    "corpus": "local",
+                    "relative_path": "writer",
+                    "link_name": "writer",
+                }
+            ]
+        }
+    ) == [PoolSkillMapping(corpus="local", relative_path="writer", link_name="writer")]
+
+
 def test_validates_and_keys_engine_returned_locator_evidence() -> None:
     assets = [
         RegisteredSkillAsset(

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -582,6 +582,38 @@ async def test_ready_claimed_bot_completes_pool_activation() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("template_type", ("personalCoding", "applicationCoding"))
+async def test_coding_template_probes_aicoding_pool_layout_but_reads_claude_assets(
+    template_type: str,
+) -> None:
+    """The runtime layout is AICoding while the Skill catalogue stays Claude."""
+
+    layouts = FakeLayoutRepository()
+    runtime = FakeRuntime(engine="aicoding")
+    skills = FakeSkillRepository("claude_code")
+    service = build_service(
+        layouts,
+        runtime,
+        engine="claude_code",
+        skills=skills,
+    )
+    service._bots.bot["template_type"] = template_type
+
+    result = await service.reconcile(scope=SCOPE, lease_owner="worker-1")
+
+    assert result.outcome is SkillsPoolReconcileOutcome.POOL_ACTIVE
+    assert runtime.events == ["probe", "cutover", "mapping", "verify"]
+    assert layouts.committed_locators == {
+        11: (
+            "local:///home/admin/.aicoding/workspace/skills-pool/skills-local/local-a"
+        ),
+        12: (
+            "local:///home/admin/.aicoding/workspace/skills-pool/skills-local/local-b"
+        ),
+    }
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("engine", ["openclaw", "claude_code", "hermes"])
 async def test_product_deactivation_during_cutover_retires_stale_mapping(
     engine: str,

--- a/src/backend/tests/community/di/test_skills_pool_wiring.py
+++ b/src/backend/tests/community/di/test_skills_pool_wiring.py
@@ -242,3 +242,75 @@ def test_skill_symlink_listener_uses_public_desktop_layout_state(
         migration_generation=None,
     )
     assert authority(bot) == "legacy"
+
+
+@pytest.mark.parametrize("template_type", ("personalCoding", "applicationCoding"))
+def test_coding_template_pool_paths_use_aicoding_physical_layout(
+    monkeypatch,
+    template_type: str,
+) -> None:
+    """Pool Local upload/replace/delete must never address .claude_code."""
+
+    injector = build_injector(profile=DeployProfile.TEST)
+    bot_repository = injector.get(BotRepository)
+    layout_repository = injector.get(SkillsPoolLayoutRepositoryProtocol)
+    scope = BotSkillLayoutScope(env="pre", entity_id="staff_1", bot_id="coding-1")
+    monkeypatch.setattr(
+        bot_repository,
+        "get_by_id_and_owner",
+        lambda *_: {
+            "bot_id": scope.bot_id,
+            "owner_id": "owner-1",
+            "entity_id": scope.entity_id,
+            "env": scope.env,
+            "bot_type": "personal",
+            "active_engine": "claude_code",
+            "template_type": template_type,
+        },
+    )
+    monkeypatch.setattr(
+        layout_repository,
+        "get",
+        lambda _scope: BotSkillLayoutState(
+            scope=scope,
+            active_layout=SkillLayout.POOL,
+            target_layout=None,
+            phase=SkillLayoutPhase.POOL_ACTIVE,
+            migration_generation="G1",
+            persisted=True,
+        ),
+    )
+
+    factory = injector.get(SkillServiceFactory)
+    factory._device_fs_dispatcher.for_bot = lambda *_: object()
+    paths = factory.resolve_pool_paths("owner-1", scope.bot_id, "claude_code")
+    assert paths == (
+        "/home/admin/.claude/skills",
+        "/home/admin/.aicoding/workspace/skills-pool/skills-local",
+        "/home/admin/.aicoding/workspace/skills-pool/skills-repo",
+    )
+
+    local_directory, upload_storage = factory.local_skill_package_storage(
+        entity_id=scope.entity_id,
+        owner_id="owner-1",
+        bot_id=scope.bot_id,
+        engine_type="claude_code",
+        entity_type="staff",
+        is_desktop=False,
+        is_teclaw=False,
+        name="replacement",
+    )
+    delete_storage = factory.local_skill_package_storage_for_locator(
+        entity_id=scope.entity_id,
+        owner_id="owner-1",
+        bot_id=scope.bot_id,
+        engine_type="claude_code",
+        entity_type="staff",
+        is_desktop=False,
+        is_teclaw=False,
+        locator="replacement",
+    )
+    expected = "/home/admin/.aicoding/workspace/skills-pool/skills-local/replacement"
+    assert local_directory == expected
+    assert upload_storage._device_directory == expected
+    assert delete_storage._device_directory == expected

--- a/src/backend/tests/community/endpoints/test_openapi_skill_state.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_state.py
@@ -27,9 +27,6 @@ from agentclaw.community.core.repository.protocols.skill_center import SkillRepo
 from agentclaw.community.core.repository.protocols.skill_installation import (
     SkillInstallationRepositoryProtocol,
 )
-from agentclaw.community.core.repository.protocols.skills_pool import (
-    SkillsPoolLayoutRepositoryProtocol,
-)
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
 from agentclaw.community.utils.gateway_principal_config import (
     init_principal_verifier_config,
@@ -79,6 +76,10 @@ class _Runtime:
 
     async def verify_mappings(self, **_kwargs) -> bool:
         return self.success
+
+    async def reconcile(self, **_kwargs) -> None:
+        if not self.success:
+            raise RuntimeError("runtime reconcile failed")
 
 
 class _RuntimeFactory:
@@ -180,10 +181,9 @@ def _seed_state(world, *, runtime_success: bool) -> None:
             runtime_factory,
             world.get(BotCapabilityMutationGuard),
             _Guard(),
-            runtime_factory._runtime,
             world.get(SkillRepository),
-            world.get(SkillsPoolLayoutRepositoryProtocol),
             world.get(SkillSetRepository),
+            runtime_factory._runtime,
         ),
         scope=None,
     )

--- a/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
@@ -82,6 +82,9 @@ class _RuntimeFactory:
     def sync_runtime(self):
         return True
 
+    async def reconcile(self, **_kwargs):
+        return None
+
 
 class _DeviceContextResolverStub:
     def resolve_for_bot(self, _bot_id, _owner_id):
@@ -205,11 +208,11 @@ def _seed_uploadable_bot(world) -> None:
             world.get(BotRepository),
             world.get(CollaboratorServiceProtocol),
             storage_factory,
-            _RuntimeFactory(),
             world.get(BotCollabLogRepositoryProtocol),
             world.get(SkillsPoolEditGuard),
             _Cleanup(),
             lambda: _DeviceContextResolverStub(),
+            _RuntimeFactory(),
         ),
         scope=None,
     )

--- a/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
@@ -651,7 +651,7 @@ def test_skills_pool_asset_views_are_exactly_bot_scoped(skills, sets):
     }
 
 
-def test_skills_pool_active_assets_include_default_set_and_exclusions(
+def test_skills_pool_active_assets_include_system_default_without_exclusion_state(
     skills, sets
 ):
     default_enabled = skills.create(
@@ -690,8 +690,11 @@ def test_skills_pool_active_assets_include_default_set_and_exclusions(
         engine="openclaw",
     )
 
+    # System Default is an unconditional Resolver input.  Its historical
+    # exclusion table is migration-only compatibility data, not desired state.
     assert [asset.git_path for asset in assets] == [
-        "git://defaults/enabled"
+        "git://defaults/enabled",
+        "git://defaults/excluded",
     ]
 
 


### PR DESCRIPTION
Closes #1251

## 内容
- 收敛 Bot Desired State 到统一运行时投影
- 覆盖 Local / Repo / MCP / CLI 的投影和历史兼容清理
- 支持 Claude Code + Coding Template 的 AICoding 物理 Skill Pool 路径
- 保持 Teclaw v4 与历史 Claude Code 安全边界

## 明确不包含
- 异步 DeviceSync 的事件循环优化（本轮暂缓）
- ACTIVE Bot 重启失败后的持久化重试（本轮暂缓）

## 验证
- 全量 Backend：12,574 passed，1 skipped
- AICoding 路径、Runtime Resolver、Pool/DI、架构门禁：163 项聚焦测试通过
- OpenAPI 从真实 Router 生成，Gateway 向前兼容门禁通过（150 条 path，无漂移）
- Ruff 通过

未包含用户本地未跟踪的 frontend-api-integration.md。