### PR TITLE
fix(baas): disable file_transfer cleanly by default

### DIFF
--- a/src/baas/configs/application.yaml
+++ b/src/baas/configs/application.yaml
@@ -28,7 +28,7 @@ user_config:
     #   password: "@redis_password"   # plain value or secret reference
     bot_service: "stub"  # real | local | stub
     engine_adapter: "stub"  # stub | real (aicoding/hermes/claude_code engine adapter)
-    file_transfer: "stub"  # stub | real
+    file_transfer: "stub"  # stub | real（默认关闭；启用需企业包真实 OSS 后端并配置 file_transfer_oss）
     database:
       plugin_database: "SQLITE_ORM"    # ZDAS_ORM (production ORM) | SQLITE_ORM (test only)
       database_url: "sqlite:////tmp/secbaas.db"
@@ -135,8 +135,10 @@ user_config:
     dry_run: false  # 测试模式：只打印日志
 
   # 文件传输轮询器配置（定期检测 OSS 上传完成并触发 device 下载）
+  # 默认关闭：社区版仅提供 no-op 后端，必须选择真实后端
+  # （plugins.file_transfer = "real"，企业包提供）并配置 file_transfer_oss 后才能启用。
   file_transfer_poller:
-    enabled: true  # 是否启用定时任务
+    enabled: false  # 是否启用定时任务（默认关闭；启用需配置真实 OSS 后端）
     cron_interval_seconds: 10  # 执行间隔（秒），默认: 10
     upload_timeout_seconds: 3600  # 上传超时（秒），超时未完成写入的 ticket 标记 FAILED
     lock_expire_seconds: 300  # per-ticket 分布式锁过期时间（秒），默认: 300

--- a/src/baas/singlebox-configs/application.yaml
+++ b/src/baas/singlebox-configs/application.yaml
@@ -22,7 +22,7 @@ user_config:
     cache: "stub"           # stub | real
     bot_service: "stub"     # real | local | stub
     engine_adapter: "stub"  # stub | real (aicoding/hermes/claude_code engine adapter)
-    file_transfer: "stub"  # stub | real
+    file_transfer: "stub"  # stub | real（默认关闭；启用需企业包真实 OSS 后端并配置 file_transfer_oss）
     database:
       plugin_database: "SQLITE_ORM"    # ZDAS_ORM (production ORM) | SQLITE_ORM (test only)
       database_url: "sqlite:////tmp/secbaas.db"
@@ -124,8 +124,10 @@ user_config:
     dry_run: false  # 测试模式：只打印日志
 
   # 文件传输轮询器配置（定期检测 OSS 上传完成并触发 device 下载）
+  # 默认关闭：社区版仅提供 no-op 后端，必须选择真实后端
+  # （plugins.file_transfer = "real"，企业包提供）并配置 file_transfer_oss 后才能启用。
   file_transfer_poller:
-    enabled: true  # 是否启用定时任务
+    enabled: false  # 是否启用定时任务（默认关闭；启用需配置真实 OSS 后端）
     cron_interval_seconds: 10  # 执行间隔（秒），默认: 10
     upload_timeout_seconds: 3600  # 上传超时（秒），超时未完成写入的 ticket 标记 FAILED
     lock_expire_seconds: 300  # per-ticket 分布式锁过期时间（秒），默认: 300

--- a/src/baas/src/secbaas/community/bootstrap/_cron.py
+++ b/src/baas/src/secbaas/community/bootstrap/_cron.py
@@ -34,11 +34,16 @@ class CronLifecycle:
     def _start_sync(self) -> None:
         """Register and start AppScheduler tasks.
 
-        All exceptions are caught and logged — this method never raises.
+        Tasks that report an ``enabled`` property of ``False`` are skipped
+        (fail-closed) so disabled features are not scheduled. All exceptions are
+        caught and logged — this method never raises.
         """
         try:
             log.info("Starting scheduled jobs")
             for task in self._tasks:
+                if not getattr(task, "enabled", True):
+                    log.info("Skipping disabled task: %s", task.name)
+                    continue
                 self._app_scheduler.add_task(task)
             self._app_scheduler.start()
             log.info("AppScheduler started")

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_file_transfer_poller.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_file_transfer_poller.py
@@ -33,7 +33,9 @@ _DOWNLOAD_URL_EXPIRE_SECONDS = 86400
 class FileTransferPollerConfig:
     """文件传输轮询器配置"""
 
-    enabled: bool = True
+    # Disabled by default: the community edition ships only a no-op backend,
+    # so the poller must not run unless a real backend is configured.
+    enabled: bool = False
     lock_expire_seconds: int = 300
     cron_interval_seconds: int = 10
     upload_timeout_seconds: int = 3600
@@ -72,12 +74,26 @@ class FileTransferPoller:
     def interval_seconds(self) -> int:
         return self._config.cron_interval_seconds
 
+    @property
+    def enabled(self) -> bool:
+        """Whether the poller should run.
+
+        Fail-closed: a real backend must be configured AND the poller enabled.
+        When the backend reports disabled (community no-op), the poller is off
+        regardless of the config flag so no-op storage operations are never
+        attempted.
+        """
+        return bool(self._config.enabled) and not self._file_backend.disabled
+
     async def run(self) -> None:
         start_time = time.monotonic()
         log.info("[FileTransferPoller] Task triggered at %s", datetime.now())
 
-        if not self._config.enabled:
-            log.info("[FileTransferPoller] Disabled, skipping")
+        if not self.enabled:
+            log.info(
+                "[FileTransferPoller] Disabled (no real backend or disabled by "
+                "config), skipping"
+            )
             return
 
         if self._config.dry_run:

--- a/src/baas/src/secbaas/community/plugins/file_transfer/_noop.py
+++ b/src/baas/src/secbaas/community/plugins/file_transfer/_noop.py
@@ -12,6 +12,8 @@ from secbaas.community.spi.file_transfer import (
     PartInfo,
 )
 
+_DISABLED_MESSAGE = "file_transfer is disabled in this deployment"
+
 
 class NoopFileTransferBackend(FileTransferBackend):
     """No-op implementation for when file transfer is disabled.
@@ -21,19 +23,18 @@ class NoopFileTransferBackend(FileTransferBackend):
     raises NotImplementedError.
     """
 
+    @property
+    def disabled(self) -> bool:
+        """Report that this no-op backend is disabled."""
+        return True
+
     def generate_upload_url(
         self, staging_path: str, expire_seconds: int, content_type: str | None = None
     ) -> str:
-        raise NotImplementedError(
-            "File transfer is not configured. "
-            "Set config.plugins.file_transfer to 'real' to enable."
-        )
+        raise NotImplementedError(_DISABLED_MESSAGE)
 
     def check_object_exists(self, staging_path: str) -> bool:
-        raise NotImplementedError(
-            "File transfer is not configured. "
-            "Set config.plugins.file_transfer to 'real' to enable."
-        )
+        raise NotImplementedError(_DISABLED_MESSAGE)
 
     def generate_download_url(
         self,
@@ -41,10 +42,7 @@ class NoopFileTransferBackend(FileTransferBackend):
         expire_seconds: int,
         response_params: dict | None = None,
     ) -> str:
-        raise NotImplementedError(
-            "File transfer is not configured. "
-            "Set config.plugins.file_transfer to 'real' to enable."
-        )
+        raise NotImplementedError(_DISABLED_MESSAGE)
 
     def initiate_multipart_upload(
         self,
@@ -53,36 +51,21 @@ class NoopFileTransferBackend(FileTransferBackend):
         part_count: int = 2,
         content_type: str | None = None,
     ) -> MultipartSession:
-        raise NotImplementedError(
-            "File transfer is not configured. "
-            "Set config.plugins.file_transfer to 'real' to enable."
-        )
+        raise NotImplementedError(_DISABLED_MESSAGE)
 
     def list_parts(self, staging_path: str, session_id: str) -> list[PartInfo]:
-        raise NotImplementedError(
-            "File transfer is not configured. "
-            "Set config.plugins.file_transfer to 'real' to enable."
-        )
+        raise NotImplementedError(_DISABLED_MESSAGE)
 
     def complete_multipart_upload(
         self, staging_path: str, session_id: str, parts: list[PartInfo]
     ) -> None:
-        raise NotImplementedError(
-            "File transfer is not configured. "
-            "Set config.plugins.file_transfer to 'real' to enable."
-        )
+        raise NotImplementedError(_DISABLED_MESSAGE)
 
     def abort_multipart_upload(self, staging_path: str, session_id: str) -> None:
-        raise NotImplementedError(
-            "File transfer is not configured. "
-            "Set config.plugins.file_transfer to 'real' to enable."
-        )
+        raise NotImplementedError(_DISABLED_MESSAGE)
 
     def delete_object(self, key: str) -> None:
-        raise NotImplementedError(
-            "File transfer is not configured. "
-            "Set config.plugins.file_transfer to 'real' to enable."
-        )
+        raise NotImplementedError(_DISABLED_MESSAGE)
 
     def build_staging_path(
         self,
@@ -91,10 +74,7 @@ class NoopFileTransferBackend(FileTransferBackend):
         filename: str,
         subdir: str | None = None,
     ) -> str:
-        raise NotImplementedError(
-            "File transfer is not configured. "
-            "Set config.plugins.file_transfer to 'real' to enable."
-        )
+        raise NotImplementedError(_DISABLED_MESSAGE)
 
     def build_session_staging_path(
         self,
@@ -104,7 +84,4 @@ class NoopFileTransferBackend(FileTransferBackend):
         filename: str,
         subdir: str | None = None,
     ) -> str:
-        raise NotImplementedError(
-            "File transfer is not configured. "
-            "Set config.plugins.file_transfer to 'real' to enable."
-        )
+        raise NotImplementedError(_DISABLED_MESSAGE)

--- a/src/baas/src/secbaas/community/spi/file_transfer/_protocols.py
+++ b/src/baas/src/secbaas/community/spi/file_transfer/_protocols.py
@@ -67,9 +67,29 @@ class ObjectListing:
 class FileTransferBackend(Protocol):
     """Protocol for file transfer storage backend operations.
 
+    Community-only (open-source) deployments are **disabled by default**: the only
+    shipped implementation is ``NoopFileTransferBackend``, which reports
+    ``disabled = True`` and raises ``NotImplementedError`` for every operation.
+    A real production backend is **enterprise-provided** via ``plugin_registry``.
+
     Implementations:
-    - AliyunOssFileTransferBackend: production OSS operations via oss2 SDK.
+    - AliyunOssFileTransferBackend: production OSS operations via oss2 SDK
+      (enterprise-provided). Available (``disabled = False``).
+    - NoopFileTransferBackend: community no-op that disables the feature.
+
+    ``disabled`` reports whether the backend is a no-op and the file-transfer
+    feature should be treated as off (callers SHOULD short-circuit and not
+    perform storage operations). A real backend leaves it ``False``.
     """
+
+    @property
+    def disabled(self) -> bool:
+        """Return True when this backend is a disabled no-op.
+
+        Defaults to ``False`` (enabled). The community no-op backend
+        overrides this to ``True``.
+        """
+        return False
 
     def generate_upload_url(
         self, staging_path: str, expire_seconds: int, content_type: str | None = None

--- a/src/baas/tests/unit/adapters/web/routers/bot_service/test_file_transfer_router.py
+++ b/src/baas/tests/unit/adapters/web/routers/bot_service/test_file_transfer_router.py
@@ -76,6 +76,30 @@ async def _delete(uri: str):
         return await client.delete(uri)
 
 
+# ── feature-disabled (no-op backend) tests ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_upload_url_feature_disabled_501_message(mock_dispatcher):
+    """When the no-op backend raises the standardized message, upload-url returns
+    a 501 with the feature-disabled message."""
+    from secbaas.community.plugins.file_transfer._noop import _DISABLED_MESSAGE
+
+    mock_dispatcher.dispatch_get_upload_url.side_effect = NotImplementedError(
+        _DISABLED_MESSAGE
+    )
+
+    resp = await _post(
+        "/api/v1/bots/t1/bot-001/files/upload-url",
+        json_data={"device_path": "/x", "filename": "x"},
+    )
+
+    assert resp.status_code == 501
+    detail = resp.json()["detail"]
+    assert detail["error"] == "NOT_IMPLEMENTED"
+    assert detail["message"] == _DISABLED_MESSAGE
+
+
 # ── get_upload_url tests ─────────────────────────────────────────────
 
 

--- a/src/baas/tests/unit/bootstrap/test_cron_lifecycle.py
+++ b/src/baas/tests/unit/bootstrap/test_cron_lifecycle.py
@@ -56,6 +56,26 @@ class TestCronLifecycleStart:
         cl = _make_cron_lifecycle(app_scheduler=mock_scheduler)
         await cl.start()  # Should not raise
 
+    @pytest.mark.asyncio
+    async def test_skips_disabled_tasks(self):
+        """Tasks reporting ``enabled = False`` are not added to the scheduler."""
+        mock_scheduler = MagicMock()
+        task_a = MagicMock()
+        task_a.enabled = True
+        task_b = MagicMock()
+        task_b.enabled = False  # e.g. FileTransferPoller with a no-op backend
+        task_c = MagicMock()  # no ``enabled`` attribute -> scheduled
+        cl = _make_cron_lifecycle(
+            app_scheduler=mock_scheduler,
+            tasks=[task_a, task_b, task_c],
+        )
+        await cl.start()
+
+        added = [c.args[0] for c in mock_scheduler.add_task.call_args_list]
+        assert task_a in added
+        assert task_c in added
+        assert task_b not in added
+
 
 # ---------------------------------------------------------------------------
 # CronLifecycle.stop

--- a/src/baas/tests/unit/core/service/scheduler/test_file_transfer_poller.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_file_transfer_poller.py
@@ -20,6 +20,11 @@ from secbaas.community.core.service.scheduler._tasks._file_transfer_poller impor
 # ── Helpers ──────────────────────────────────────────────────────────
 
 
+def test_config_enabled_defaults_false():
+    """The FileTransferPollerConfig.enabled field defaults to False (disabled)."""
+    assert FileTransferPollerConfig().enabled is False
+
+
 def _make_config(**overrides):
     defaults = dict(
         enabled=True,
@@ -66,6 +71,10 @@ def _make_poller(config=None, **overrides):
     if config is None:
         config = _make_config()
 
+    # A real, available backend by default (non-disabled) so existing
+    # processing tests behave as before.
+    file_backend.disabled = False
+
     # Default: lock acquired
     lock_ctx = MagicMock()
     lock_ctx.acquired = True
@@ -106,6 +115,27 @@ class TestRun:
         await poller.run()
         # Should return early without hitting ticket_repo
         poller._ticket_repo.list_pending_uploads.assert_not_called()
+
+    def test_disabled_backend_disables_poller_even_when_config_enabled(self):
+        """A disabled backend turns the poller off even if config.enabled is True."""
+        config = _make_config(enabled=True)
+        poller = _make_poller(config=config, file_backend=MagicMock(disabled=True))
+        assert poller.enabled is False
+
+    @pytest.mark.asyncio
+    async def test_noop_backend_default_config_produces_no_backend_work(self):
+        """With a no-op backend and default (disabled) config, run() is silent:
+        it must not query tickets or perform storage operations."""
+        config = FileTransferPollerConfig()
+        assert config.enabled is False
+        noop_backend = AsyncMock()
+        noop_backend.disabled = True
+        poller = _make_poller(config=config, file_backend=noop_backend)
+
+        await poller.run()
+
+        poller._ticket_repo.list_pending_uploads.assert_not_called()
+        noop_backend.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_run_dry_run(self):

--- a/src/baas/tests/unit/plugins/file_transfer/test_noop.py
+++ b/src/baas/tests/unit/plugins/file_transfer/test_noop.py
@@ -6,7 +6,7 @@ Tests all methods raise NotImplementedError with the correct message.
 import pytest
 
 from secbaas.community.plugins.file_transfer._noop import NoopFileTransferBackend
-from secbaas.community.spi.file_transfer import PartInfo
+from secbaas.community.spi.file_transfer import FileTransferBackend, PartInfo
 
 
 @pytest.fixture
@@ -14,10 +14,29 @@ def backend():
     return NoopFileTransferBackend()
 
 
-_EXPECTED_MSG = (
-    "File transfer is not configured. "
-    "Set config.plugins.file_transfer to 'real' to enable."
-)
+class _RealBackend(FileTransferBackend):
+    """A minimal real backend that does not override ``disabled``.
+
+    Exercises the protocol's default ``disabled`` implementation
+    (a real backend is enabled unless it says otherwise).
+    """
+
+    def generate_upload_url(
+        self, staging_path: str, expire_seconds: int, content_type: str | None = None
+    ) -> str:
+        return ""
+
+
+def test_real_backend_reports_enabled_by_default():
+    """A backend that does not override ``disabled`` is enabled by default."""
+    assert _RealBackend().disabled is False
+
+
+_EXPECTED_MSG = "file_transfer is disabled in this deployment"
+
+
+def test_noop_reports_disabled(backend):
+    assert backend.disabled is True
 
 
 def test_generate_upload_url_raises(backend):
@@ -64,3 +83,8 @@ def test_delete_object_raises(backend):
 def test_build_staging_path_raises(backend):
     with pytest.raises(NotImplementedError, match=_EXPECTED_MSG):
         backend.build_staging_path("tenant", "tf-001", "file.txt")
+
+
+def test_build_session_staging_path_raises(backend):
+    with pytest.raises(NotImplementedError, match=_EXPECTED_MSG):
+        backend.build_session_staging_path("tenant", "session-1", "tf-001", "file.txt")


### PR DESCRIPTION
## Problem

The baas `file_transfer` plugin is OSS-oriented by design: its `FileTransferBackend` SPI is built around Alibaba Cloud OSS semantics (pre-signed PUT/GET URLs, OSS multipart upload sessions, existence-implies-complete atomic writes). In the open-source community edition the only shipped implementation is `NoopFileTransferBackend`, which raises `NotImplementedError` for every operation.

Today the feature is neither genuinely on nor cleanly off:
- `file_transfer_poller.enabled` defaults to `true` and `FileTransferPollerConfig.enabled` defaults to `True`, so in a default (non-OSS) deployment the background poller runs against the no-op stub and logs a `FileTransferPoller ... failed` error every cycle.
- A simple local/filesystem backend cannot honor the SPI semantics the dispatcher + poller rely on, so a community replacement would only be a misleading single-host toy.

This change makes the feature deterministic and off by default (fail-closed), rather than half-implemented.

## Solution

- Flip `file_transfer_poller.enabled` to `false` in both `configs/application.yaml` and `singlebox-configs/application.yaml`, and default `FileTransferPollerConfig.enabled` to `False`.
- Add a `disabled` property to the `FileTransferBackend` SPI (default `False` = enabled). `NoopFileTransferBackend` overrides it to `True`.
- `CronLifecycle` skips tasks whose `enabled` is `False`, so a disabled poller is never scheduled.
- The poller `run()` short-circuits (and logs once) when the backend reports `disabled`, so a stale/forced run never calls no-op storage operations.
- Standardize `NoopFileTransferBackend` errors to `"file_transfer is disabled in this deployment"`; the existing route handling maps that to HTTP 501.

The added `disabled` field is fully backward-compatible with the enterprise `AliyunOssFileTransferBackend`, which inherits the enabled-by-default (`False`) behavior and requires no change.

## Validation

- Full baas unit suite: **8046 passed, 3 skipped, 8 xpassed** (exit 0).
- Targeted file-transfer / poller / router / cron tests: **77 passed**.
- Changed-file line coverage: `_cron.py` 100%, `_noop.py` 100%, `_protocols.py` 100%, `_file_transfer_poller.py` 99% (only pre-existing `name`/`interval_seconds` lines uncovered); changed-line coverage = 100%, above the CI 90% gate.
- ruff check + ruff format: all changed Python files pass.
- `openspec validate` passes (4/4 artifacts).

## Compatibility and risk

- Linux/macOS unaffected by config change; a real (enterprise) OSS backend leaves `disabled = False` and runs unchanged. Community deployments no longer log recurring poller errors.
- Rollback: revert the config default flip if an operator wants the poller active against a configured real backend.

Closes #1229