### PR TITLE
fix(backend): align bot space IDs with unsigned bigint storage

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -244,8 +244,8 @@ ALTER TABLE ac_bots
 -- during code rollback; platform owners should assess DROP COLUMN only after no
 -- deployed version uses it.
 ALTER TABLE ac_bots
-  ADD COLUMN space_id VARCHAR(128) NULL
-    COMMENT 'business-space ownership; NULL uses the owner personal-space fallback';
+  ADD COLUMN space_id BIGINT UNSIGNED NULL
+    COMMENT 'Bot owning space id, references ac_space.id; NULL uses the owner personal-space fallback';
 ```
 
 The delivery record for `space_id` must identify the environment, change/version

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -215,8 +215,8 @@ ALTER TABLE ac_bots
 -- 解释该状态，因此无需一次性回填历史行。回滚代码前可保留此兼容列；确认没有
 -- 旧版本/新版本代码再使用后，才可由平台单独评估 DROP COLUMN。
 ALTER TABLE ac_bots
-  ADD COLUMN space_id VARCHAR(128) NULL
-    COMMENT 'business-space ownership; NULL uses the owner personal-space fallback';
+  ADD COLUMN space_id BIGINT UNSIGNED NULL
+    COMMENT 'Bot owning space id, references ac_space.id; NULL uses the owner personal-space fallback';
 ```
 
 `space_id` 的平台执行记录必须随交付补充环境、变更单/版本、执行时间和回滚负责人；

--- a/src/backend/src/agentclaw/community/adapters/bot_space_context.py
+++ b/src/backend/src/agentclaw/community/adapters/bot_space_context.py
@@ -27,11 +27,11 @@ _PERSONAL_SPACE_ID_PREFIX = "personal:"
 class SpaceServiceBotSpaceContext(BusinessSpaceContextProtocol):
     """Resolve inventory space context through the owning Spaces module.
 
-    ``ac_bots.space_id`` is a legacy string column while public Space IDs are
-    integers.  This adapter is the canonicalization boundary between them.  It
-    also preserves the synthetic ``personal:<user>`` fallback for accounts
-    whose personal Space has not been initialized yet; reads must not create a
-    Space as a side effect.
+    ``ac_bots.space_id`` stores the numeric ``ac_space.id``. This adapter maps
+    it to the inventory contract's string identifier and preserves the
+    synthetic ``personal:<user>`` fallback for accounts whose personal Space
+    has not been initialized yet; reads must not create a Space as a side
+    effect.
     """
 
     @inject

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -141,6 +141,7 @@ from .schemas import (
 
 logger = get_logger()
 
+
 #: The bot authorization for an application caller, on the own-bot operations
 #: of this group.
 #:
@@ -404,7 +405,7 @@ async def create_bot(
             bot_type=body.bot_type,
             bot_name=body.bot_name,
             bot_desc=body.bot_desc,
-            space_id=current_space.space_id,
+            space_id=current_space.numeric_id,
         ),
         bot_service=bot_service,
         passport_plugin=passport_plugin,
@@ -989,7 +990,7 @@ async def get_bot_auth_status(
             bot_type=bot_type or "personal",
             bot_name=bot_name,
             bot_desc=bot_desc,
-            space_id=current_space.space_id,
+            space_id=current_space.numeric_id,
         ),
         bot_service=bot_service,
         passport_plugin=passport_plugin,

--- a/src/backend/src/agentclaw/community/core/bot_inventory/types.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/types.py
@@ -63,6 +63,13 @@ class BusinessSpaceRef:
     name: str
     kind: str
 
+    @property
+    def numeric_id(self) -> int | None:
+        """Return the real Space id, or None for a synthetic personal fallback."""
+        if self.space_id.startswith("personal:"):
+            return None
+        return int(self.space_id, 10)
+
 
 @dataclass(frozen=True)
 class ServiceLifecycleCard:

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -149,7 +149,7 @@ class BotCreateSpec:
     share_policy: dict[str, Any] | None = None
     template_type: str | None = None
     template_config: dict[str, Any] | None = None
-    space_id: str | None = None
+    space_id: int | None = None
     # Engine/vendor-specific inputs belong here, NOT as new named fields. The
     # spec is the contract shared by every surface, so it stays engine-agnostic
     # rather than growing an attribute per engine; anything meaningful to only

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -1246,7 +1246,7 @@ class BotService:
         template_type: Optional[str] = None,
         template_config: Optional[Dict[str, Any]] = None,
         cookie: Optional[str] = None,
-        space_id: Optional[str] = None,
+        space_id: Optional[int] = None,
     ) -> Dict[str, Any]:
         """
         Create a new bot with async device allocation.

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_space_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_space_service.py
@@ -64,8 +64,8 @@ class BotSpaceService:
                 "local bots can only belong to their owner's personal space"
             )
 
-        persisted_space_id = str(space.id)
-        changed = str(bot.get("space_id") or "") != persisted_space_id
+        persisted_space_id = space.id
+        changed = bot.get("space_id") != persisted_space_id
         if not changed:
             return BotSpaceAssignmentResult(bot=bot, space=space, changed=False)
 

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
@@ -489,7 +489,7 @@ class BotRepository(
         return self.get_by_id_and_owner(bot_id, owner_id)
 
     def update_space_by_owner(
-        self, *, bot_id: str, owner_id: str, space_id: str
+        self, *, bot_id: str, owner_id: str, space_id: int
     ) -> Optional[Dict[str, Any]]:
         """Update only ``space_id`` without widening the generic allowlist.
 

--- a/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
@@ -235,7 +235,7 @@ class BotRepository(Protocol):
 
     @abstractmethod
     def update_space_by_owner(
-        self, *, bot_id: str, owner_id: str, space_id: str
+        self, *, bot_id: str, owner_id: str, space_id: int
     ) -> Optional[Dict[str, Any]]:
         """Atomically replace the structured Space assignment of an owned Bot."""
         ...

--- a/src/backend/src/agentclaw/community/plugin_api/models.py
+++ b/src/backend/src/agentclaw/community/plugin_api/models.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
+from sqlalchemy.dialects import mysql
 from sqlalchemy.sql import func
 
 from agentclaw.community.core.base import Base  # noqa: F401  — canonical registry lives in core/
@@ -39,6 +40,11 @@ from agentclaw.community.utils.env_utils import get_current_env  # noqa: E402
 # with_variant() makes SQLAlchemy use Integer (→ "INTEGER") on SQLite while
 # keeping BigInteger (→ "BIGINT") on MySQL/PostgreSQL.
 AutoIncrementBigInteger = BigInteger().with_variant(Integer, "sqlite")
+UnsignedBigInteger = (
+    BigInteger()
+    .with_variant(mysql.BIGINT(unsigned=True), "mysql")
+    .with_variant(Integer, "sqlite")
+)
 
 
 class BotModel(Base):
@@ -77,14 +83,12 @@ class BotModel(Base):
     ext = Column(Text, nullable=True)
     env = Column(String(20), default=get_current_env, nullable=False)
     bot_type = Column(String(128), default="personal", nullable=True)
-    # Business-space ownership (PRD §0.1 / 系分 §3-K). Single structured column —
-    # NOT a JSON ext field — so space filtering reads a real column, not
-    # ``ext.space_id``. Nullable because existing rows and any non-ORM insert
-    # predating the column have NULL here; the public surface falls back to the
-    # personal space ``personal:{owner_id}`` when NULL (matches the inventory
-    # ``NoopBusinessSpaceContext`` fallback). Name/kind live on the space owner,
-    # not duplicated on ac_bots.
-    space_id = Column(String(128), nullable=True)
+    # Business-space ownership (PRD §0.1 / 系分 §3-K). This mirrors
+    # ``ac_space.id BIGINT UNSIGNED``; NULL keeps the personal-space fallback
+    # for legacy rows and owners whose personal Space has not been initialized.
+    # Synthetic inventory ids such as ``personal:{owner_id}`` are presentation
+    # values and must never be persisted here.
+    space_id = Column(UnsignedBigInteger, nullable=True)
     template_type = Column(String(64), nullable=True)  # 模板类型，如 applicationCoding
     call_type = Column(String(16), default="owner", nullable=False)
     caller_config_revision = Column(BigInteger, default=0, nullable=False)

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -48,6 +48,7 @@ from agentclaw.community.core.bot_inventory.adapters.noop_business_space import 
 from agentclaw.community.core.bot_inventory.protocols import (
     BusinessSpaceContextProtocol,
 )
+from agentclaw.community.core.bot_inventory.types import BusinessSpaceRef
 from agentclaw.community.api.engine_config_service import EngineConfigServiceProtocol
 from agentclaw.community.api.bot_startup_script_service import (
     BotStartupScriptServiceProtocol,
@@ -103,7 +104,7 @@ def bot_repo():
 def bot_space():
     service = MagicMock()
     service.change_space.return_value = SimpleNamespace(
-        bot={**BOT, "space_id": "42"},
+        bot={**BOT, "space_id": 42},
         space=SimpleNamespace(
             id=42,
             space_code="spc-42",
@@ -442,6 +443,24 @@ def test_create_bot_201(client, svc, passport):
     assert body["code"] == 201000
     assert body["data"]["bot_id"] == "b1"
     svc.create_bot.assert_called_once()
+    assert svc.create_bot.call_args.kwargs["space_id"] is None
+
+
+def test_real_space_reference_exposes_numeric_id():
+    assert (
+        BusinessSpaceRef(space_id="42", name="Team", kind="team").numeric_id == 42
+    )
+
+
+def test_synthetic_personal_reference_has_no_numeric_id():
+    assert (
+        BusinessSpaceRef(
+            space_id="personal:u1",
+            name="Personal",
+            kind="personal",
+        ).numeric_id
+        is None
+    )
 
 
 def test_create_bot_owner_relationship_failure_is_enveloped_502(

--- a/src/backend/tests/community/adapters/test_bot_space_context.py
+++ b/src/backend/tests/community/adapters/test_bot_space_context.py
@@ -135,7 +135,7 @@ def test_reassigned_bot_uses_current_team_without_extra_lookup() -> None:
     current = BusinessSpaceRef(space_id="42", name="Team", kind="team")
 
     result = context.bot_space(
-        bot={"bot_id": "b1", "space_id": "42"},
+        bot={"bot_id": "b1", "space_id": 42},
         owner_id="u1",
         current_space=current,
     )
@@ -151,7 +151,7 @@ def test_numeric_personal_assignment_is_visible_in_default_inventory() -> None:
     access.reset_mock()
 
     result = context.bot_space(
-        bot={"bot_id": "b1", "space_id": "8"},
+        bot={"bot_id": "b1", "space_id": 8},
         owner_id="u1",
         current_space=current,
     )

--- a/src/backend/tests/community/core/bot_management/services/test_bot_space_service.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_space_service.py
@@ -48,7 +48,7 @@ def _service(*, bot: dict | None = None, space: SpaceRecord | None = None):
     repository = MagicMock()
     repository.get_by_id_and_owner.return_value = bot
     repository.update_space_by_owner.return_value = (
-        {**bot, "space_id": str(space.id)}
+        {**bot, "space_id": space.id}
         if bot is not None and space is not None
         else None
     )
@@ -59,7 +59,7 @@ def _service(*, bot: dict | None = None, space: SpaceRecord | None = None):
 
 
 def test_moves_owned_cloud_bot_to_joined_team_space():
-    bot = {"bot_id": "b1", "bot_type": "personal", "space_id": "7"}
+    bot = {"bot_id": "b1", "bot_type": "personal", "space_id": 7}
     target = _space(space_id=42)
     service, repository, access = _service(bot=bot, space=target)
 
@@ -67,15 +67,15 @@ def test_moves_owned_cloud_bot_to_joined_team_space():
 
     assert result.changed is True
     assert result.space == target
-    assert result.bot["space_id"] == "42"
+    assert result.bot["space_id"] == 42
     access.require_space_member.assert_called_once_with(space_id=42, user_id="u1")
     repository.update_space_by_owner.assert_called_once_with(
-        bot_id="b1", owner_id="u1", space_id="42"
+        bot_id="b1", owner_id="u1", space_id=42
     )
 
 
 def test_moves_bot_back_to_owners_numeric_personal_space():
-    bot = {"bot_id": "b1", "bot_type": "service", "space_id": "42"}
+    bot = {"bot_id": "b1", "bot_type": "service", "space_id": 42}
     target = _space(
         space_id=8,
         space_type=SpaceType.PERSONAL,
@@ -87,7 +87,7 @@ def test_moves_bot_back_to_owners_numeric_personal_space():
 
     assert result.changed is True
     repository.update_space_by_owner.assert_called_once_with(
-        bot_id="b1", owner_id="u1", space_id="8"
+        bot_id="b1", owner_id="u1", space_id=8
     )
 
 
@@ -141,7 +141,7 @@ def test_desktop_bot_cannot_move_to_team_space():
 
 
 def test_same_space_is_idempotent_and_skips_the_write():
-    bot = {"bot_id": "b1", "bot_type": "personal", "space_id": "42"}
+    bot = {"bot_id": "b1", "bot_type": "personal", "space_id": 42}
     target = _space(space_id=42)
     service, repository, _access = _service(bot=bot, space=target)
 
@@ -153,7 +153,7 @@ def test_same_space_is_idempotent_and_skips_the_write():
 
 
 def test_bot_disappearing_during_write_is_masked_as_not_found():
-    bot = {"bot_id": "b1", "bot_type": "personal", "space_id": "7"}
+    bot = {"bot_id": "b1", "bot_type": "personal", "space_id": 7}
     service, repository, _access = _service(bot=bot, space=_space())
     repository.update_space_by_owner.return_value = None
 
@@ -162,7 +162,7 @@ def test_bot_disappearing_during_write_is_masked_as_not_found():
 
 
 def test_persistence_failure_propagates_instead_of_returning_success():
-    bot = {"bot_id": "b1", "bot_type": "personal", "space_id": "7"}
+    bot = {"bot_id": "b1", "bot_type": "personal", "space_id": 7}
     service, repository, _access = _service(bot=bot, space=_space())
     repository.update_space_by_owner.side_effect = RuntimeError("database unavailable")
 

--- a/src/backend/tests/community/repository/bot/test_bot_repository_unified.py
+++ b/src/backend/tests/community/repository/bot/test_bot_repository_unified.py
@@ -778,25 +778,25 @@ def test_list_by_conditions_treats_like_wildcards_literally(repo):
 
 
 def test_update_space_by_owner_persists_space_and_modifier(repo):
-    repo.insert(_data(bot_id="space-bot", space_id="7", modifier_id="creator"))
+    repo.insert(_data(bot_id="space-bot", space_id=7, modifier_id="creator"))
 
-    out = repo.update_space_by_owner(bot_id="space-bot", owner_id="emp1", space_id="42")
+    out = repo.update_space_by_owner(bot_id="space-bot", owner_id="emp1", space_id=42)
 
     assert out is not None
-    assert out["space_id"] == "42"
+    assert out["space_id"] == 42
     assert out["modifier_id"] == "emp1"
 
 
 def test_update_space_by_owner_missing_or_deleted_returns_none(repo):
     assert (
-        repo.update_space_by_owner(bot_id="missing", owner_id="emp1", space_id="42")
+        repo.update_space_by_owner(bot_id="missing", owner_id="emp1", space_id=42)
         is None
     )
 
-    repo.insert(_data(bot_id="deleted-space-bot", is_delete=1, space_id="7"))
+    repo.insert(_data(bot_id="deleted-space-bot", is_delete=1, space_id=7))
     assert (
         repo.update_space_by_owner(
-            bot_id="deleted-space-bot", owner_id="emp1", space_id="42"
+            bot_id="deleted-space-bot", owner_id="emp1", space_id=42
         )
         is None
     )

--- a/src/backend/tests/community/repository/bot/test_bot_tenant_guard.py
+++ b/src/backend/tests/community/repository/bot/test_bot_tenant_guard.py
@@ -178,13 +178,13 @@ def test_skip_option_sees_all_tenants(repo, db):
 
 def test_update_space_by_owner_cross_tenant_is_noop(repo):
     with avernet_tenant_scope("tenant-a"):
-        repo.insert(_data(bot_id="space-bot", owner_id="own-a", space_id="7"))
+        repo.insert(_data(bot_id="space-bot", owner_id="own-a", space_id=7))
     with avernet_tenant_scope("tenant-b"):
         assert (
             repo.update_space_by_owner(
-                bot_id="space-bot", owner_id="own-a", space_id="42"
+                bot_id="space-bot", owner_id="own-a", space_id=42
             )
             is None
         )
     with avernet_tenant_scope("tenant-a"):
-        assert repo.get_by_id("space-bot")["space_id"] == "7"
+        assert repo.get_by_id("space-bot")["space_id"] == 7


### PR DESCRIPTION
## Problem

The submitted `ac_bots.space_id` DDL stores the owning Space as `BIGINT UNSIGNED`, while the Bot ORM, repository contract, creation flow, and assignment service still treated the value as a string. This mismatch could persist string values, make idempotency checks compare `"42"` with `42`, and leave the documented schema inconsistent with runtime behavior.

## Solution

- Model `ac_bots.space_id` as MySQL `BIGINT UNSIGNED` while retaining SQLite `INTEGER` compatibility for tests.
- Carry real Space IDs as `int` through Bot creation, assignment service, and repository contracts.
- Keep public inventory Space identifiers as strings because the public contract also represents the synthetic `personal:{user_id}` fallback.
- Persist the synthetic personal fallback as `NULL`; only real numeric `ac_space.id` values are written to `ac_bots.space_id`.
- Update the English and Chinese OpenAPI delivery documentation and the affected tests.

## Validation

- `cd src/backend && uv run pytest -q`
  - `12426 passed, 1 skipped, 408 warnings in 443.16s`
- Focused Bot Space/Repository/OpenAPI suite:
  - `182 passed, 18 warnings`
- Architecture contract suite:
  - `59 passed, 17 warnings`
- Ruff checks for all changed Python files: passed.
- `git diff --check`: passed.
- Pre-push Backend SAST/lint gate against `origin/dev_refactory_collaboration`: passed.
- Singlebox coverage was not rerun because this change only aligns the persistence type and the full Backend suite passed; PR CI remains the authoritative Singlebox gate.

## Compatibility and risk

This change expects the platform DDL for `ac_bots.space_id` to be `BIGINT UNSIGNED NULL`. Existing rows may remain `NULL` and continue to use the owner personal-Space fallback, so no historical-row backfill is required. `ZEROFILL` is unnecessary for application behavior and should preferably be omitted from the final DDL. Rollback can retain the nullable column while reverting the application code, provided no incompatible non-numeric values are introduced.
