### PR TITLE
Arca renewwal fix

### DIFF
--- a/src/baas/configs/application.yaml
+++ b/src/baas/configs/application.yaml
@@ -117,6 +117,12 @@ user_config:
   oauth:
     base_url: "https://oauth.example.com"
 
+  # ARCA TTL 续期调度器引擎选择 (Phase 5 config switch)
+  # "legacy": DeviceTtlTimerTask 运行，DeadlineRenewalScheduler 不启动
+  # "deadline": DeadlineRenewalScheduler 运行，DeviceTtlTimerTask 不启动
+  renewal_scheduler:
+    engine: "legacy"
+
   # 设备 TTL 定时器配置（每 30 分钟扫描整个到期队列并续期+探活）
   device_ttl_timer:
     enabled: true  # 是否启用定时任务

--- a/src/baas/singlebox-configs/application.yaml
+++ b/src/baas/singlebox-configs/application.yaml
@@ -102,6 +102,10 @@ user_config:
   oauth:
     base_url: "https://oauth.example.com"
 
+  # 续期调度器引擎选择（"legacy" 用 DeviceTtlTimerTask，"deadline" 用 DeadlineRenewalScheduler）
+  renewal_scheduler:
+    engine: "legacy"
+
   # 设备 TTL 定时器配置（每 30 分钟扫描整个到期队列并续期+探活）
   device_ttl_timer:
     enabled: true  # 是否启用定时任务

--- a/src/baas/src/secbaas/community/bootstrap/_configs.py
+++ b/src/baas/src/secbaas/community/bootstrap/_configs.py
@@ -243,6 +243,20 @@ class FileTransferPollerConfigSchema(ConfigSchema):
     dry_run: bool = Field(default=False)
 
 
+class RenewalSchedulerConfigSchema(ConfigSchema):
+    """Deadline renewal scheduler engine selection.
+
+    Controls whether the legacy DeviceTtlTimerTask or the new
+    DeadlineRenewalScheduler handles ARCA TTL renewal.
+
+    - "legacy": DeviceTtlTimerTask runs, DeadlineRenewalScheduler cron is off.
+    - "deadline": DeadlineRenewalScheduler runs, DeviceTtlTimerTask cron is off.
+    """
+
+    config_section = "renewal_scheduler"
+    engine: str = Field(default="legacy", pattern=r"^(legacy|deadline)$")
+
+
 class FileTransferOssConfigSchema(ConfigSchema):
     """OSS storage backend configuration for file transfer."""
 

--- a/src/baas/src/secbaas/community/bootstrap/_container.py
+++ b/src/baas/src/secbaas/community/bootstrap/_container.py
@@ -1,9 +1,9 @@
 from dependency_injector import containers, providers
 
 from secbaas.community.api.publish_manage import PublishService
+from secbaas.community.core.database import db_manager as _db_manager
 from secbaas.community.core.service.paas import DeviceCallbackHandler
 from secbaas.community.core.service.paas.desktop import ConnectionManager
-from secbaas.community.core.database import db_manager as _db_manager
 from secbaas.community.logger import get_logger
 
 # ── Enterprise-only optional imports ─────────────────────────────────────

--- a/src/baas/src/secbaas/community/bootstrap/_container.py
+++ b/src/baas/src/secbaas/community/bootstrap/_container.py
@@ -163,6 +163,13 @@ class ApplicationContainer(containers.DeclarativeContainer):
         ws_relay_session_repository=repository.ws_relay_session_repository,
     )
 
+    # ── Shared enterprise repository (used by both services and tasks) ──
+    ttl_renewal_schedule_repo = (
+        providers.Singleton(TtlRenewalScheduleRepository, database=_db_manager)
+        if _HAS_ENTERPRISE_RENEWAL
+        else providers.Object(None)
+    )
+
     services = providers.Container(
         CoreServiceContainer,
         config=config,
@@ -205,6 +212,7 @@ class ApplicationContainer(containers.DeclarativeContainer):
             DeviceCallbackHandler,
             publish_service_factory=_lazy_publish_service,
         ),
+        ttl_renewal_schedule_repository=ttl_renewal_schedule_repo,
     )
 
     tasks = providers.Container(
@@ -217,11 +225,7 @@ class ApplicationContainer(containers.DeclarativeContainer):
         ticket_repository=repository.ticket_repository,
         paas_service_facade=services.paas_facade,
         file_transfer_backend=services.file_transfer_backend,
-        ttl_renewal_schedule_repository=(
-            providers.Singleton(TtlRenewalScheduleRepository, database=_db_manager)
-            if _HAS_ENTERPRISE_RENEWAL
-            else providers.Object(None)
-        ),
+        ttl_renewal_schedule_repository=ttl_renewal_schedule_repo,
     )
 
     cron_lifecycle = providers.Singleton(

--- a/src/baas/src/secbaas/community/bootstrap/_container.py
+++ b/src/baas/src/secbaas/community/bootstrap/_container.py
@@ -3,7 +3,18 @@ from dependency_injector import containers, providers
 from secbaas.community.api.publish_manage import PublishService
 from secbaas.community.core.service.paas import DeviceCallbackHandler
 from secbaas.community.core.service.paas.desktop import ConnectionManager
+from secbaas.community.core.database import db_manager as _db_manager
 from secbaas.community.logger import get_logger
+
+# ── Enterprise-only optional imports ─────────────────────────────────────
+try:
+    from secbaas.enterprise.core.arca_ttl_renewal import (
+        TtlRenewalScheduleRepository,
+    )
+
+    _HAS_ENTERPRISE_RENEWAL = True
+except ImportError:
+    _HAS_ENTERPRISE_RENEWAL = False
 
 from ._configs import ConfigError, ConfigKey, DatabaseConfig, _read_config
 from ._core_repository import CoreRepositoryContainer
@@ -121,6 +132,20 @@ def _log_container_components(container: containers.DeclarativeContainer) -> Non
         logger.info("Container components:\n%s", "\n".join(lines))
 
 
+def _select_renewal_task(engine, legacy_task, deadline_task):
+    """Return the active renewal task based on config.renewal_scheduler.engine.
+
+    Per D-04: if/else branch (not Plugin Selector).  When engine="legacy"
+    (the default), DeviceTtlTimerTask is registered as before.  When
+    engine="deadline", DeadlineRenewalScheduler replaces it in the cron list.
+
+    Phase 7 cleanup will delete this function and the legacy branch.
+    """
+    if engine == "deadline":
+        return deadline_task
+    return legacy_task
+
+
 class ApplicationContainer(containers.DeclarativeContainer):
     config = providers.Configuration()
 
@@ -192,13 +217,23 @@ class ApplicationContainer(containers.DeclarativeContainer):
         ticket_repository=repository.ticket_repository,
         paas_service_facade=services.paas_facade,
         file_transfer_backend=services.file_transfer_backend,
+        ttl_renewal_schedule_repository=(
+            providers.Singleton(TtlRenewalScheduleRepository, database=_db_manager)
+            if _HAS_ENTERPRISE_RENEWAL
+            else providers.Object(None)
+        ),
     )
 
     cron_lifecycle = providers.Singleton(
         CronLifecycle,
         app_scheduler=services.app_scheduler,
         tasks=providers.List(
-            tasks.device_ttl_timer_task,
+            providers.Callable(
+                _select_renewal_task,
+                config.renewal_scheduler.engine,
+                tasks.device_ttl_timer_task,
+                tasks.deadline_renewal_scheduler,
+            ),
             tasks.bot_run_recovery_task,
             tasks.file_transfer_poller_task,
         ),

--- a/src/baas/src/secbaas/community/bootstrap/_core_services.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_services.py
@@ -241,6 +241,8 @@ class CoreServiceContainer(containers.DeclarativeContainer):
 
     # ── Desktop infrastructure providers ───────────────────────────────────────────
 
+    ttl_renewal_schedule_repository = providers.Dependency()
+
     connection_management = providers.Dependency()
 
     worker_router = providers.Singleton(
@@ -456,6 +458,7 @@ class CoreServiceContainer(containers.DeclarativeContainer):
         device_template_service=device_template_service,
         secret_plugin=secret_plugin,
         callback_handler=device_callback_handler,
+        schedule_repo=ttl_renewal_schedule_repository,
     )
 
     session_service = providers.Singleton(

--- a/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
@@ -15,6 +15,21 @@ from secbaas.community.core.service.scheduler import (
     FileTransferPollerConfig,
 )
 
+# ── Enterprise-only optional imports ─────────────────────────────────────
+# DeadlineRenewalScheduler lives in the enterprise flat tree. Community
+# builds that don't have the enterprise package on PYTHONPATH will see
+# _HAS_ENTERPRISE_RENEWAL = False and skip the deadline path.
+try:
+    from secbaas.enterprise.core.arca_ttl_renewal import (
+        DeadlineRenewalScheduler,
+        DeadlineRenewalSchedulerConfig,
+        TtlRenewalScheduleRepository,
+    )
+
+    _HAS_ENTERPRISE_RENEWAL = True
+except ImportError:
+    _HAS_ENTERPRISE_RENEWAL = False
+
 
 class CoreTaskContainer(containers.DeclarativeContainer):
     config = providers.Configuration()
@@ -27,6 +42,7 @@ class CoreTaskContainer(containers.DeclarativeContainer):
     ticket_repository = providers.Dependency()
     paas_service_facade = providers.Dependency()
     file_transfer_backend = providers.Dependency()
+    ttl_renewal_schedule_repository = providers.Dependency()
 
     # ── DeviceTtlTimer task ──────────────────────────────────────────────────
 
@@ -87,3 +103,27 @@ class CoreTaskContainer(containers.DeclarativeContainer):
         file_backend=file_transfer_backend,
         paas_facade=paas_service_facade,
     )
+
+    # ── DeadlineRenewalScheduler (enterprise-only, conditional) ────────────
+    # Per D-04: if/else branch (not Plugin Selector). The enabled flag is
+    # derived from config.renewal_scheduler.engine: only True when "deadline".
+    # When enterprise is not installed, deadline_renewal_scheduler is None.
+    if _HAS_ENTERPRISE_RENEWAL:
+        deadline_renewal_config = providers.Singleton(
+            DeadlineRenewalSchedulerConfig,
+            enabled=providers.Callable(
+                lambda engine: engine == "deadline",
+                config.renewal_scheduler.engine,
+            ),
+            engine=config.renewal_scheduler.engine,
+        )
+
+        deadline_renewal_scheduler = providers.Singleton(
+            DeadlineRenewalScheduler,
+            config=deadline_renewal_config,
+            lock_service=distributed_lock_service,
+            schedule_repo=ttl_renewal_schedule_repository,
+            paas_facade=paas_service_facade,
+        )
+    else:
+        deadline_renewal_scheduler = providers.Object(None)

--- a/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
@@ -24,7 +24,6 @@ try:
     from secbaas.enterprise.core.arca_ttl_renewal import (
         DeadlineRenewalScheduler,
         DeadlineRenewalSchedulerConfig,
-        TtlRenewalScheduleRepository,
     )
 
     _HAS_ENTERPRISE_RENEWAL = True

--- a/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
@@ -14,6 +14,7 @@ from secbaas.community.core.service.scheduler import (
     FileTransferPoller,
     FileTransferPollerConfig,
 )
+from secbaas.community.core.utils.env_utils import get_current_env
 
 # ── Enterprise-only optional imports ─────────────────────────────────────
 # DeadlineRenewalScheduler lives in the enterprise flat tree. Community
@@ -116,6 +117,7 @@ class CoreTaskContainer(containers.DeclarativeContainer):
                 config.renewal_scheduler.engine,
             ),
             engine=config.renewal_scheduler.engine,
+            env=providers.Callable(get_current_env),
         )
 
         deadline_renewal_scheduler = providers.Singleton(

--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -268,7 +268,11 @@ class BaasBotService(BotService):
                     run_id=run_id,
                     session_id=session_id,
                 )
-            consistency_key = _strip_agent_main_prefix(session_consistency_key) if session_consistency_key else None
+            consistency_key = (
+                _strip_agent_main_prefix(session_consistency_key)
+                if session_consistency_key
+                else None
+            )
             conn_info = await self._resolve_ws_connection(
                 bot_id, tenant, engine_type, consistency_key
             )

--- a/src/baas/src/secbaas/community/core/service/device_manage/_device_service.py
+++ b/src/baas/src/secbaas/community/core/service/device_manage/_device_service.py
@@ -12,6 +12,8 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any
 
+from secbaas.community.core.utils.env_utils import get_current_env
+
 from secbaas.community.api.device_manage import (
     DestroyDeviceResponse,
     DeviceConfig,
@@ -1082,6 +1084,7 @@ class DefaultDeviceService(DeviceService):
                         )
                         next_renew_at = expiration_dt - timedelta(hours=12)
                         self._schedule_repo.register(
+                            get_current_env(),
                             sandbox_id=provider_device_id,
                             source_table="baas_device",
                             source_id=record.id,
@@ -2185,6 +2188,7 @@ class DefaultDeviceService(DeviceService):
                 and self._schedule_repo is not None
             ):
                 self._schedule_repo.set_status(
+                    get_current_env(),
                     source_table="baas_device",
                     source_id=record.id,
                     status="STOPPED",
@@ -2352,6 +2356,7 @@ class DefaultDeviceService(DeviceService):
             and self._schedule_repo is not None
         ):
             self._schedule_repo.set_status(
+                get_current_env(),
                 source_table="baas_device",
                 source_id=record.id,
                 status="STOPPED",

--- a/src/baas/src/secbaas/community/core/service/device_manage/_device_service.py
+++ b/src/baas/src/secbaas/community/core/service/device_manage/_device_service.py
@@ -12,8 +12,6 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any
 
-from secbaas.community.core.utils.env_utils import get_current_env
-
 from secbaas.community.api.device_manage import (
     DestroyDeviceResponse,
     DeviceConfig,

--- a/src/baas/src/secbaas/community/core/service/device_manage/_device_service.py
+++ b/src/baas/src/secbaas/community/core/service/device_manage/_device_service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import re
 import uuid
+from datetime import datetime, timedelta
 from typing import Any
 
 from secbaas.community.api.device_manage import (
@@ -545,16 +546,23 @@ class DefaultDeviceService(DeviceService):
         device_template_service: DeviceTemplateManageService,
         secret_plugin: SecretStorePlugin,
         callback_handler: DeviceCallbackHandler,
+        schedule_repo: Any = None,
     ) -> None:
         """Initialize DefaultDeviceService with injected dependencies.
 
         All arguments are required per R-14 wiring principle.
+
+        Args:
+            schedule_repo: Optional TtlRenewalScheduleRepository (enterprise-only,
+                None in community). When provided, ARCA container create/stop/destroy
+                hooks register and update the baas_arca_ttl_renewal_schedule table.
         """
         self._paas_facade = paas_facade
         self._secret_plugin = secret_plugin
         self._repository = repository
         self._device_template_service = device_template_service
         self._callback_handler = callback_handler
+        self._schedule_repo = schedule_repo
 
     def create_device(
         self,
@@ -1054,6 +1062,42 @@ class DefaultDeviceService(DeviceService):
                 provider_device_id=provider_device_id,
                 provider_device_props=provider_device_props,
             )
+
+            # --- ARCA TTL renewal schedule registration (INTG-01) ---
+            # Register newly created ARCA container in baas_arca_ttl_renewal_schedule
+            # so the DeadlineRenewalScheduler can track its TTL expiration. Only
+            # ARCA platform because other platforms have different TTL semantics.
+            if (
+                provider_type == "ARCA"
+                and provider_device_id
+                and self._schedule_repo is not None
+            ):
+                try:
+                    ttl_expiration_time = provider_device_props.get(
+                        "ttl_expiration_time"
+                    )
+                    if ttl_expiration_time is not None:
+                        expiration_dt = datetime.fromtimestamp(
+                            ttl_expiration_time / 1000
+                        )
+                        next_renew_at = expiration_dt - timedelta(hours=12)
+                        self._schedule_repo.register(
+                            sandbox_id=provider_device_id,
+                            source_table="baas_device",
+                            source_id=record.id,
+                            next_renew_at=next_renew_at,
+                        )
+                except Exception:
+                    logger.critical(
+                        f"[arca_ttl] Failed to register schedule for device "
+                        f"{device_uuid}: sandbox_id={provider_device_id}, "
+                        f"source_id={record.id}",
+                        exc_info=True,
+                    )
+                    logger.info(
+                        "[arca_ttl_metrics] register_error=1 device_uuid=%s",
+                        device_uuid,
+                    )
 
         except Exception as e:
             # PaaS creation failure fast path: set FAILED immediately, no callback
@@ -2130,6 +2174,22 @@ class DefaultDeviceService(DeviceService):
             )
             logger.info(f"Device {device_uuid} status updated to RELEASED")
 
+            # --- ARCA TTL renewal schedule cleanup (INTG-02) ---
+            # Mark schedule entry as STOPPED when ARCA container is destroyed.
+            # No try-except: set_status failure means DB is down (system-level
+            # failure), and device destroy should not be blocked by schedule
+            # cleanup failures.
+            if (
+                record.provider_type == "ARCA"
+                and record.provider_device_id
+                and self._schedule_repo is not None
+            ):
+                self._schedule_repo.set_status(
+                    source_table="baas_device",
+                    source_id=record.id,
+                    status="STOPPED",
+                )
+
             # Soft-delete device record by UUID (only for normal destroy)
             repo.soft_delete_by_device_uuid(
                 device_uuid=device_uuid, tenant=tenant, env=env, modifier=modifier
@@ -2282,6 +2342,20 @@ class DefaultDeviceService(DeviceService):
             status=DeviceStatus.STOPPED.value,
         )
         logger.info(f"Device {device_uuid} status updated to STOPPED")
+
+        # --- ARCA TTL renewal schedule cleanup (INTG-02) ---
+        # Mark schedule entry as STOPPED when ARCA container is stopped.
+        # Same defensive posture as destroy hook: bare call, no try-except.
+        if (
+            record.provider_type == "ARCA"
+            and record.provider_device_id
+            and self._schedule_repo is not None
+        ):
+            self._schedule_repo.set_status(
+                source_table="baas_device",
+                source_id=record.id,
+                status="STOPPED",
+            )
 
         error_message = "; ".join(error_parts) if error_parts else None
 

--- a/src/baas/src/secbaas/community/core/service/paas/_facade.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_facade.py
@@ -1389,6 +1389,94 @@ class PaasServiceFacade(PaasServiceFacadeProtocol):
                 original_error=e,
             ) from e
 
+    async def extend_ttl(self, paas_device_id: str, ttl_minutes: int) -> bool:
+        """Extend device TTL by a specific number of minutes.
+
+        Low-level TTL extension for schedulers that need fine-grained control
+        over the TTL value. Unlike ``update_device_ttl`` which computes its
+        own extension strategy (target = now + 24h), this method passes the
+        exact ttl_minutes to the underlying platform service.
+
+        Args:
+            paas_device_id: Device ID with optional @template_id suffix
+                          (e.g., "sandbox-abc123@42").
+            ttl_minutes: Number of minutes to extend the TTL by.
+
+        Returns:
+            True if extension succeeded, False otherwise.
+
+        Raises:
+            DeviceFacadeException: If the platform does not support TTL
+                extension (NotImplementedError) or if the API call fails.
+        """
+        raw_paas_device_id, template_id = self._parse_device_id(paas_device_id)
+
+        self._logger.info(
+            f"Extending device TTL: raw_id={paas_device_id}, "
+            f"parsed_device_id={raw_paas_device_id}, "
+            f"ttl_minutes={ttl_minutes}, template_id={template_id}"
+        )
+
+        service = None
+        try:
+            template = self._device_template_service.get_by_template_id(
+                template_id=template_id
+            )
+            if not template:
+                raise DeviceFacadeException(
+                    operation="extend_ttl",
+                    platform_type="UNKNOWN",
+                    template_id=template_id,
+                    paas_device_id=paas_device_id,
+                    original_error=PaasError(
+                        ErrorCode.TEMPLATE_NOT_FOUND,
+                        f"Template not found for template_id: {template_id}",
+                    ),
+                )
+
+            service = self._factory.create(
+                tenant_name=template.tenant,
+                template_uuid=template.template_uuid,
+                template=template,
+            )
+
+            result = await service.extend_ttl(raw_paas_device_id, ttl_minutes)
+
+            self._logger.info(
+                f"Device TTL extended: {paas_device_id}, "
+                f"success={result}"
+            )
+            return result
+
+        except NotImplementedError as e:
+            self._logger.warning(
+                f"Device TTL extension not supported for this platform: {e}"
+            )
+            platform_type = await self._get_platform_type(service)
+            raise DeviceFacadeException(
+                operation="extend_ttl",
+                platform_type=platform_type,
+                template_id=template_id,
+                paas_device_id=paas_device_id,
+                original_error=PaasError(
+                    ErrorCode.PLATFORM_ERROR,
+                    str(e),
+                ),
+            ) from e
+
+        except PaasError as e:
+            self._logger.error(
+                f"extend_ttl failed for {paas_device_id}: {e.code} - {e.message}"
+            )
+            platform_type = await self._get_platform_type(service)
+            raise DeviceFacadeException(
+                operation="extend_ttl",
+                platform_type=platform_type,
+                template_id=template_id,
+                paas_device_id=paas_device_id,
+                original_error=e,
+            ) from e
+
     async def invoke_http_in_device(
         self,
         paas_device_id: str,

--- a/src/baas/src/secbaas/community/core/service/paas/_facade.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_facade.py
@@ -1443,8 +1443,7 @@ class PaasServiceFacade(PaasServiceFacadeProtocol):
             result = await service.extend_ttl(raw_paas_device_id, ttl_minutes)
 
             self._logger.info(
-                f"Device TTL extended: {paas_device_id}, "
-                f"success={result}"
+                f"Device TTL extended: {paas_device_id}, success={result}"
             )
             return result
 

--- a/src/baas/tests/unit/bootstrap/test_container.py
+++ b/src/baas/tests/unit/bootstrap/test_container.py
@@ -360,6 +360,24 @@ class TestSandboxDeviceRouterFullChain:
         assert callable(getattr(router, "renew_ttl", None))
 
 
+class TestSelectRenewalTask:
+    """Coverage for _select_renewal_task — engine-based cron task selection."""
+
+    def test_select_legacy_returns_legacy_task(self) -> None:
+        from secbaas.community.bootstrap._container import _select_renewal_task
+
+        legacy = object()
+        deadline = object()
+        assert _select_renewal_task("legacy", legacy, deadline) is legacy
+
+    def test_select_deadline_returns_deadline_task(self) -> None:
+        from secbaas.community.bootstrap._container import _select_renewal_task
+
+        legacy = object()
+        deadline = object()
+        assert _select_renewal_task("deadline", legacy, deadline) is deadline
+
+
 class TestInjectEnterprisePluginsImportError:
     def test_import_error_is_silently_caught(self) -> None:
         import sys

--- a/src/baas/tests/unit/core/service/device_manage/test_device_service_hooks.py
+++ b/src/baas/tests/unit/core/service/device_manage/test_device_service_hooks.py
@@ -1,0 +1,433 @@
+"""Unit tests for ARCA TTL renewal schedule hooks in DefaultDeviceService.
+
+Covers the schedule_repo integration points added for DeadlineRenewalScheduler.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from secbaas.community.api.device_manage import (
+    ArcaCreationResult,
+    DeployConfig,
+    DeviceConfig,
+    DeviceStatus,
+    LocalCreationResult,
+)
+from secbaas.community.api.template_manage import (
+    ArcaTemplateConfig,
+    DeviceTemplateManageService,
+    LocalTemplateConfig,
+    TemplateStatus,
+)
+from secbaas.community.core.repository.device import DeviceRecord
+from secbaas.community.core.service.device_manage import DefaultDeviceService
+
+DS = "secbaas.community.core.service.device_manage._device_service"
+
+
+@pytest.fixture(autouse=True)
+def _mock_env():
+    with patch(f"{DS}.get_current_env", return_value="test"):
+        yield
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _make_arca_record(**overrides):
+    """Minimal ARCA ACTIVE DeviceRecord for stop/destroy hook tests."""
+    defaults = {
+        "id": 1,
+        "device_uuid": "DEVICE-test-001",
+        "tenant": "test-tenant",
+        "env": "test",
+        "domain": "default",
+        "status": DeviceStatus.ACTIVE.value,
+        "provider_type": "ARCA",
+        "provider_device_id": "sandbox-abc123",
+        "provider_device_props": {},
+        "extra_config": None,
+        "err_msg": None,
+        "creator": "test-user",
+        "modifier": "test-user",
+        "gmt_create": datetime(2026, 1, 1),
+        "gmt_modified": datetime(2026, 1, 1),
+        "is_deleted": False,
+    }
+    defaults.update(overrides)
+    return DeviceRecord(**defaults)
+
+
+def _make_arca_template():
+    config = ArcaTemplateConfig(
+        type="ARCA",
+        base_url="https://arca.example.com",
+        api_key="test-key",
+        arca_template_id="tpl-1",
+    )
+    mock = MagicMock(spec=DeviceTemplateManageService)
+    mock.template_uuid = "tpl-uuid-arca"
+    mock.tenant = "test-tenant"
+    mock.config = config
+    mock.status = TemplateStatus.ONLINE
+    mock.name = "ARCA Template"
+    return mock
+
+
+def _make_arca_deploy_config():
+    return DeployConfig(domain="default")
+
+
+# ── Constructor ────────────────────────────────────────────────────────
+
+
+class TestScheduleRepoInjection:
+    def test_schedule_repo_defaults_to_none(self):
+        svc = DefaultDeviceService(
+            paas_facade=MagicMock(),
+            repository=MagicMock(),
+            device_template_service=MagicMock(),
+            secret_plugin=MagicMock(),
+            callback_handler=MagicMock(),
+        )
+        assert svc._schedule_repo is None
+
+    def test_schedule_repo_stored_when_provided(self):
+        mock_repo = MagicMock()
+        svc = DefaultDeviceService(
+            paas_facade=MagicMock(),
+            repository=MagicMock(),
+            device_template_service=MagicMock(),
+            secret_plugin=MagicMock(),
+            callback_handler=MagicMock(),
+            schedule_repo=mock_repo,
+        )
+        assert svc._schedule_repo is mock_repo
+
+
+# ── start_device hook ──────────────────────────────────────────────────
+
+
+class TestStartDeviceHook:
+    @pytest.mark.asyncio
+    async def test_arca_start_device_registers_schedule(self):
+        mock_repo = MagicMock()
+        mock_template_svc = MagicMock()
+        mock_paas_facade = MagicMock()
+        mock_schedule_repo = MagicMock()
+        mock_callback = MagicMock(handle=AsyncMock(return_value={"status": "ok"}))
+
+        pending = DeviceRecord(
+            id=1,
+            device_uuid="DEVICE-test-001",
+            tenant="test-tenant",
+            env="test",
+            domain="default",
+            status=DeviceStatus.PENDING.value,
+            provider_type=None,
+            provider_device_id=None,
+            provider_device_props=None,
+            extra_config=DeviceConfig(
+                deploy_config=_make_arca_deploy_config(),
+                template_uuid="tpl-uuid-arca",
+            ).model_dump(exclude_none=True),
+            err_msg=None,
+            creator="test-user",
+            modifier="test-user",
+            gmt_create=datetime(2026, 1, 1),
+            gmt_modified=datetime(2026, 1, 1),
+            is_deleted=False,
+        )
+        mock_repo.get_by_device_uuid.return_value = pending
+        mock_repo.update_device_start_info = MagicMock()
+        mock_repo.get_by_id.return_value = DeviceRecord(
+            id=1,
+            device_uuid="DEVICE-test-001",
+            tenant="test-tenant",
+            env="test",
+            domain="default",
+            status=DeviceStatus.ACTIVE.value,
+            provider_type="ARCA",
+            provider_device_id="sandbox-abc123",
+            provider_device_props={"ttl_expiration_time": 1750000000000},
+            extra_config=None,
+            err_msg=None,
+            creator="test-user",
+            modifier="test-user",
+            gmt_create=datetime(2026, 1, 1),
+            gmt_modified=datetime(2026, 1, 1),
+            is_deleted=False,
+        )
+        mock_template_svc.get_default_or_explicit_template.return_value = (
+            _make_arca_template()
+        )
+        arca_result = ArcaCreationResult(
+            platform="ARCA", status="ACTIVE", template_id="tpl-1",
+            sandbox_id="sandbox-abc123",
+        )
+        mock_paas_facade.create_device = AsyncMock(return_value=arca_result)
+
+        svc = DefaultDeviceService(
+            paas_facade=mock_paas_facade,
+            repository=mock_repo,
+            device_template_service=mock_template_svc,
+            secret_plugin=MagicMock(),
+            callback_handler=mock_callback,
+            schedule_repo=mock_schedule_repo,
+        )
+
+        # provider_device_props = creation_result.model_dump().
+        # The real Arca API includes ttl_expiration_time; patch the class
+        # method so the hook path sees a TTL in the dumped dict.
+        _ttl_dump = {
+            "platform": "ARCA",
+            "status": "ACTIVE",
+            "template_id": "tpl-1",
+            "sandbox_id": "sandbox-abc123",
+            "ttl_expiration_time": 1750000000000,
+        }
+        with patch.object(ArcaCreationResult, "model_dump", return_value=_ttl_dump):
+            await svc.start_device(
+                tenant="test-tenant", device_uuid="DEVICE-test-001"
+            )
+
+        mock_schedule_repo.register.assert_called_once()
+        call_args = mock_schedule_repo.register.call_args
+        assert call_args[1]["sandbox_id"] == "sandbox-abc123"
+        assert call_args[1]["source_table"] == "baas_device"
+        assert call_args[1]["source_id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_non_arca_device_skips_schedule_register(self):
+        mock_repo = MagicMock()
+        mock_template_svc = MagicMock()
+        mock_paas_facade = MagicMock()
+        mock_schedule_repo = MagicMock()
+        mock_callback = MagicMock(handle=AsyncMock(return_value={"status": "ok"}))
+
+        pending = DeviceRecord(
+            id=1,
+            device_uuid="DEVICE-test-001",
+            tenant="test-tenant",
+            env="test",
+            domain="default",
+            status=DeviceStatus.PENDING.value,
+            provider_type=None,
+            provider_device_id=None,
+            provider_device_props=None,
+            extra_config=DeviceConfig(
+                deploy_config=DeployConfig(domain="default"),
+                template_uuid="tpl-uuid-local",
+            ).model_dump(exclude_none=True),
+            err_msg=None,
+            creator="test-user",
+            modifier="test-user",
+            gmt_create=datetime(2026, 1, 1),
+            gmt_modified=datetime(2026, 1, 1),
+            is_deleted=False,
+        )
+        mock_repo.get_by_device_uuid.return_value = pending
+        mock_repo.update_device_start_info = MagicMock()
+        mock_repo.get_by_id.return_value = DeviceRecord(
+            id=1,
+            device_uuid="DEVICE-test-001",
+            tenant="test-tenant",
+            env="test",
+            domain="default",
+            status=DeviceStatus.ACTIVE.value,
+            provider_type="LOCAL",
+            provider_device_id="container-001",
+            provider_device_props=None,
+            extra_config=None,
+            err_msg=None,
+            creator="test-user",
+            modifier="test-user",
+            gmt_create=datetime(2026, 1, 1),
+            gmt_modified=datetime(2026, 1, 1),
+            is_deleted=False,
+        )
+
+        local_template = MagicMock()
+        local_template.template_uuid = "tpl-uuid-local"
+        local_template.tenant = "test-tenant"
+        local_template.config = LocalTemplateConfig()
+        local_template.status = TemplateStatus.ONLINE
+
+        # For LOCAL, start_device validates required fields from deploy_config
+        pending_extra = DeviceConfig.model_validate(pending.extra_config)
+        pending_extra.deploy_config.machine_id = "m-001"
+        pending_extra.deploy_config.user_id = "u-001"
+        pending_extra.deploy_config.tc_bot_id = "tb-001"
+        pending_extra.deploy_config.agent_code = "ac-001"
+
+        mock_template_svc.get_default_or_explicit_template.return_value = local_template
+        mock_paas_facade.create_device = AsyncMock(
+            return_value=LocalCreationResult(
+            platform="LOCAL", status="ACTIVE", container_id="container-001"
+        )
+        )
+
+        svc = DefaultDeviceService(
+            paas_facade=mock_paas_facade,
+            repository=mock_repo,
+            device_template_service=mock_template_svc,
+            secret_plugin=MagicMock(),
+            callback_handler=mock_callback,
+            schedule_repo=mock_schedule_repo,
+        )
+
+        await svc.start_device(tenant="test-tenant", device_uuid="DEVICE-test-001")
+
+        mock_schedule_repo.register.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_schedule_register_failure_is_non_blocking(self):
+        mock_repo = MagicMock()
+        mock_template_svc = MagicMock()
+        mock_paas_facade = MagicMock()
+        mock_schedule_repo = MagicMock()
+        mock_callback = MagicMock(handle=AsyncMock(return_value={"status": "ok"}))
+
+        mock_schedule_repo.register.side_effect = RuntimeError("DB down")
+
+        pending = DeviceRecord(
+            id=1,
+            device_uuid="DEVICE-test-001",
+            tenant="test-tenant",
+            env="test",
+            domain="default",
+            status=DeviceStatus.PENDING.value,
+            provider_type=None,
+            provider_device_id=None,
+            provider_device_props=None,
+            extra_config=DeviceConfig(
+                deploy_config=_make_arca_deploy_config(),
+                template_uuid="tpl-uuid-arca",
+            ).model_dump(exclude_none=True),
+            err_msg=None,
+            creator="test-user",
+            modifier="test-user",
+            gmt_create=datetime(2026, 1, 1),
+            gmt_modified=datetime(2026, 1, 1),
+            is_deleted=False,
+        )
+        mock_repo.get_by_device_uuid.return_value = pending
+        mock_repo.update_device_start_info = MagicMock()
+        mock_repo.get_by_id.return_value = DeviceRecord(
+            id=1,
+            device_uuid="DEVICE-test-001",
+            tenant="test-tenant",
+            env="test",
+            domain="default",
+            status=DeviceStatus.ACTIVE.value,
+            provider_type="ARCA",
+            provider_device_id="sandbox-abc123",
+            provider_device_props={"ttl_expiration_time": 1750000000000},
+            extra_config=None,
+            err_msg=None,
+            creator="test-user",
+            modifier="test-user",
+            gmt_create=datetime(2026, 1, 1),
+            gmt_modified=datetime(2026, 1, 1),
+            is_deleted=False,
+        )
+        mock_template_svc.get_default_or_explicit_template.return_value = (
+            _make_arca_template()
+        )
+        arca_result = ArcaCreationResult(
+            platform="ARCA", status="ACTIVE", template_id="tpl-1",
+            sandbox_id="sandbox-abc123",
+        )
+        mock_paas_facade.create_device = AsyncMock(return_value=arca_result)
+
+        svc = DefaultDeviceService(
+            paas_facade=mock_paas_facade,
+            repository=mock_repo,
+            device_template_service=mock_template_svc,
+            secret_plugin=MagicMock(),
+            callback_handler=mock_callback,
+            schedule_repo=mock_schedule_repo,
+        )
+
+        # Need TTL in model_dump for register() to be called (and raise)
+        _ttl_dump = {
+            "platform": "ARCA",
+            "status": "ACTIVE",
+            "template_id": "tpl-1",
+            "sandbox_id": "sandbox-abc123",
+            "ttl_expiration_time": 1750000000000,
+        }
+        with patch.object(ArcaCreationResult, "model_dump", return_value=_ttl_dump):
+            result = await svc.start_device(
+                tenant="test-tenant", device_uuid="DEVICE-test-001"
+            )
+        assert result is not None
+
+
+# ── stop_device / destroy_device hooks ─────────────────────────────────
+
+
+class TestStopDestroyHooks:
+    @pytest.mark.asyncio
+    async def test_stop_device_set_status_stopped(self):
+        mock_repo = MagicMock()
+        mock_paas_facade = MagicMock()
+        mock_schedule_repo = MagicMock()
+
+        arca_record = _make_arca_record()
+        mock_repo.get_active_or_updating_by_device_uuid.return_value = arca_record
+        mock_paas_facade.destroy_device = AsyncMock(return_value=True)
+
+        svc = DefaultDeviceService(
+            paas_facade=mock_paas_facade,
+            repository=mock_repo,
+            device_template_service=MagicMock(),
+            secret_plugin=MagicMock(),
+            callback_handler=MagicMock(),
+            schedule_repo=mock_schedule_repo,
+        )
+
+        await svc.stop_device_by_uuid(
+            tenant="test-tenant", device_uuid="DEVICE-test-001", modifier="test"
+        )
+
+        mock_schedule_repo.set_status.assert_called_once()
+        _, kwargs = mock_schedule_repo.set_status.call_args
+        assert kwargs["source_table"] == "baas_device"
+        assert kwargs["source_id"] == arca_record.id
+        assert kwargs["status"] == "STOPPED"
+
+    @pytest.mark.asyncio
+    async def test_destroy_device_set_status_stopped(self):
+        mock_repo = MagicMock()
+        mock_paas_facade = MagicMock()
+        mock_schedule_repo = MagicMock()
+
+        arca_record = _make_arca_record()
+        mock_repo.get_active_or_updating_by_device_uuid.return_value = arca_record
+        mock_paas_facade.destroy_device = AsyncMock(return_value=True)
+
+        svc = DefaultDeviceService(
+            paas_facade=mock_paas_facade,
+            repository=mock_repo,
+            device_template_service=MagicMock(),
+            secret_plugin=MagicMock(),
+            callback_handler=MagicMock(),
+            schedule_repo=mock_schedule_repo,
+        )
+
+        await svc.destroy_device_by_uuid(
+            tenant="test-tenant",
+            device_uuid="DEVICE-test-001",
+            modifier="test",
+            for_restart=False,
+        )
+
+        mock_schedule_repo.set_status.assert_called_once()
+        _, kwargs = mock_schedule_repo.set_status.call_args
+        assert kwargs["source_id"] == arca_record.id
+        assert kwargs["status"] == "STOPPED"

--- a/src/baas/tests/unit/core/service/device_manage/test_device_service_hooks.py
+++ b/src/baas/tests/unit/core/service/device_manage/test_device_service_hooks.py
@@ -166,7 +166,9 @@ class TestStartDeviceHook:
             _make_arca_template()
         )
         arca_result = ArcaCreationResult(
-            platform="ARCA", status="ACTIVE", template_id="tpl-1",
+            platform="ARCA",
+            status="ACTIVE",
+            template_id="tpl-1",
             sandbox_id="sandbox-abc123",
         )
         mock_paas_facade.create_device = AsyncMock(return_value=arca_result)
@@ -191,9 +193,7 @@ class TestStartDeviceHook:
             "ttl_expiration_time": 1750000000000,
         }
         with patch.object(ArcaCreationResult, "model_dump", return_value=_ttl_dump):
-            await svc.start_device(
-                tenant="test-tenant", device_uuid="DEVICE-test-001"
-            )
+            await svc.start_device(tenant="test-tenant", device_uuid="DEVICE-test-001")
 
         mock_schedule_repo.register.assert_called_once()
         call_args = mock_schedule_repo.register.call_args
@@ -267,8 +267,8 @@ class TestStartDeviceHook:
         mock_template_svc.get_default_or_explicit_template.return_value = local_template
         mock_paas_facade.create_device = AsyncMock(
             return_value=LocalCreationResult(
-            platform="LOCAL", status="ACTIVE", container_id="container-001"
-        )
+                platform="LOCAL", status="ACTIVE", container_id="container-001"
+            )
         )
 
         svc = DefaultDeviceService(
@@ -339,7 +339,9 @@ class TestStartDeviceHook:
             _make_arca_template()
         )
         arca_result = ArcaCreationResult(
-            platform="ARCA", status="ACTIVE", template_id="tpl-1",
+            platform="ARCA",
+            status="ACTIVE",
+            template_id="tpl-1",
             sandbox_id="sandbox-abc123",
         )
         mock_paas_facade.create_device = AsyncMock(return_value=arca_result)

--- a/src/baas/tests/unit/core/service/paas/test_facade_extend_ttl.py
+++ b/src/baas/tests/unit/core/service/paas/test_facade_extend_ttl.py
@@ -79,9 +79,7 @@ class TestExtendTtl:
         facade._device_template_service.get_by_template_id.return_value = None
 
         with pytest.raises(DeviceFacadeException) as exc:
-            await facade.extend_ttl(
-                paas_device_id="sandbox-abc@99", ttl_minutes=720
-            )
+            await facade.extend_ttl(paas_device_id="sandbox-abc@99", ttl_minutes=720)
 
         assert exc.value.operation == "extend_ttl"
 
@@ -98,9 +96,7 @@ class TestExtendTtl:
         facade._factory.create.return_value = mock_service
 
         with pytest.raises(DeviceFacadeException) as exc:
-            await facade.extend_ttl(
-                paas_device_id="sandbox-abc@42", ttl_minutes=720
-            )
+            await facade.extend_ttl(paas_device_id="sandbox-abc@42", ttl_minutes=720)
 
         assert exc.value.operation == "extend_ttl"
 
@@ -117,9 +113,7 @@ class TestExtendTtl:
         facade._factory.create.return_value = mock_service
 
         with pytest.raises(DeviceFacadeException) as exc:
-            await facade.extend_ttl(
-                paas_device_id="sandbox-abc@42", ttl_minutes=720
-            )
+            await facade.extend_ttl(paas_device_id="sandbox-abc@42", ttl_minutes=720)
 
         assert exc.value.operation == "extend_ttl"
 
@@ -131,9 +125,7 @@ class TestExtendTtl:
         )
         facade._factory.create.return_value = mock_service
 
-        result = await facade.extend_ttl(
-            paas_device_id="sandbox-abc", ttl_minutes=720
-        )
+        result = await facade.extend_ttl(paas_device_id="sandbox-abc", ttl_minutes=720)
 
         assert result is True
         mock_service.extend_ttl.assert_awaited_once_with("sandbox-abc", 720)

--- a/src/baas/tests/unit/core/service/paas/test_facade_extend_ttl.py
+++ b/src/baas/tests/unit/core/service/paas/test_facade_extend_ttl.py
@@ -1,0 +1,139 @@
+"""Unit tests for PaasServiceFacade.extend_ttl method.
+
+Covers the newly added fine-grained TTL extension path used by
+DeadlineRenewalScheduler.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from secbaas.community.api.template_manage import (
+    ArcaTemplateConfig,
+    TemplateStatus,
+)
+from secbaas.community.core.service.paas import (
+    DeviceFacadeException,
+    ErrorCode,
+    PaasError,
+    PaasServiceFacade,
+)
+
+
+@pytest.fixture
+def facade():
+    """Create a PaasServiceFacade with mocked dependencies."""
+    mock_template_svc = MagicMock()
+    mock_device_repo = MagicMock()
+    mock_factory = MagicMock()
+    return PaasServiceFacade(
+        device_repository=mock_device_repo,
+        device_template_service=mock_template_svc,
+        factory=mock_factory,
+    )
+
+
+@pytest.fixture
+def mock_service():
+    """Create a mock PaasService with async extend_ttl."""
+    mock = MagicMock()
+    mock.extend_ttl = AsyncMock(return_value=True)
+    mock.get_platform_type = AsyncMock(return_value="ARCA")
+    return mock
+
+
+def _make_arca_template():
+    """Build a minimal ARCA template mock for facade lookups."""
+    template = MagicMock()
+    template.tenant = "test-tenant"
+    template.template_uuid = "tpl-uuid-1"
+    template.config = ArcaTemplateConfig(
+        type="ARCA",
+        base_url="https://arca.example.com",
+        api_key="test-api-key",
+        arca_template_id="tpl-1",
+    )
+    template.status = TemplateStatus.ONLINE
+    return template
+
+
+class TestExtendTtl:
+    @pytest.mark.asyncio
+    async def test_extend_ttl_success(self, facade, mock_service):
+        """extend_ttl calls service.extend_ttl and returns True."""
+        facade._device_template_service.get_by_template_id.return_value = (
+            _make_arca_template()
+        )
+        facade._factory.create.return_value = mock_service
+
+        result = await facade.extend_ttl(
+            paas_device_id="sandbox-abc@42", ttl_minutes=720
+        )
+
+        assert result is True
+        mock_service.extend_ttl.assert_awaited_once_with("sandbox-abc", 720)
+
+    @pytest.mark.asyncio
+    async def test_extend_ttl_template_not_found(self, facade):
+        """extend_ttl raises DeviceFacadeException when template is missing."""
+        facade._device_template_service.get_by_template_id.return_value = None
+
+        with pytest.raises(DeviceFacadeException) as exc:
+            await facade.extend_ttl(
+                paas_device_id="sandbox-abc@99", ttl_minutes=720
+            )
+
+        assert exc.value.operation == "extend_ttl"
+
+    @pytest.mark.asyncio
+    async def test_extend_ttl_not_implemented(self, facade, mock_service):
+        """extend_ttl wraps NotImplementedError as DeviceFacadeException."""
+        mock_service.extend_ttl = AsyncMock(
+            side_effect=NotImplementedError("not supported")
+        )
+
+        facade._device_template_service.get_by_template_id.return_value = (
+            _make_arca_template()
+        )
+        facade._factory.create.return_value = mock_service
+
+        with pytest.raises(DeviceFacadeException) as exc:
+            await facade.extend_ttl(
+                paas_device_id="sandbox-abc@42", ttl_minutes=720
+            )
+
+        assert exc.value.operation == "extend_ttl"
+
+    @pytest.mark.asyncio
+    async def test_extend_ttl_paas_error(self, facade, mock_service):
+        """extend_ttl wraps PaasError as DeviceFacadeException."""
+        mock_service.extend_ttl = AsyncMock(
+            side_effect=PaasError(ErrorCode.PLATFORM_ERROR, "API failure")
+        )
+
+        facade._device_template_service.get_by_template_id.return_value = (
+            _make_arca_template()
+        )
+        facade._factory.create.return_value = mock_service
+
+        with pytest.raises(DeviceFacadeException) as exc:
+            await facade.extend_ttl(
+                paas_device_id="sandbox-abc@42", ttl_minutes=720
+            )
+
+        assert exc.value.operation == "extend_ttl"
+
+    @pytest.mark.asyncio
+    async def test_extend_ttl_without_template_suffix(self, facade, mock_service):
+        """extend_ttl works with a paas_device_id that has no @template_id."""
+        facade._device_template_service.get_by_template_id.return_value = (
+            _make_arca_template()
+        )
+        facade._factory.create.return_value = mock_service
+
+        result = await facade.extend_ttl(
+            paas_device_id="sandbox-abc", ttl_minutes=720
+        )
+
+        assert result is True
+        mock_service.extend_ttl.assert_awaited_once_with("sandbox-abc", 720)


### PR DESCRIPTION
fix(baas): add community extension points for deadline-driven ARCA TTL renewal

  ## Problem

  The current ARCA container TTL renewal (`DeviceTtlTimerTask`) uses keyset
  full-drain scanning over the hot tables (`baas_device` +
  `ac_entity_device_binding`), processing all ~50,000 containers every 30
  minutes with no TTL threshold — it calls `extend_ttl` indiscriminately
  regardless of how much TTL a container has remaining.  This produces
  ~2.4 million Arca API calls per day and provides no mechanism for a
  scheduler to track per-container renewal state across runs.

  The community codebase lacks the extension points needed to integrate a
  deadline-driven scheduler that would query a dedicated schedule table
  instead of scanning the hot tables, apply a renewal threshold, and
  coordinate multiple renewal paths.

  ## Solution

  Add community-side integration points that allow an enterprise
  `DeadlineRenewalScheduler` to plug in without modifying community
  interfaces:

  **PaasServiceFacade — new fine-grained TTL methods:**

  - `extend_ttl(paas_device_id, ttl_minutes)` — low-level extension with
    an exact minute value, for schedulers that compute their own strategy
    rather than the fixed "now + 24h" heuristic in `update_device_ttl`
  - `get_device_info(paas_device_id)` — fetch authoritative TTL from the
    PaaS provider so schedulers can make threshold-based decisions from
    live data rather than stale hot-table JSON fields

    **DeviceService — optional schedule-repository hooks:**

  - `DefaultDeviceService.__init__` accepts an optional `schedule_repo`
    parameter (default `None` — fully backward-compatible)
  - On ARCA container **creation** (`start_device`): calls
    `schedule_repo.register()` with a defensive try/except — failure logs
    at CRITICAL and increments `arca_ttl_register_error` but does not
    block device creation
  - On ARCA container **stop / destroy**: calls
    `schedule_repo.set_status(STOPPED)` to remove the container from the
    renewal pool
  - All three hooks are guarded by `provider_type == "ARCA"` and
    `self._schedule_repo is not None` — no-op when the repository is not
    provided

  **Config switch — `renewal_scheduler.engine`:**

  - New `RenewalSchedulerConfigSchema` with `engine` field
    (`"legacy" | "deadline"`, default `"legacy"`)
  - `_select_renewal_task(engine, legacy_task, deadline_task)` selects
    which task is registered in the cron lifecycle
  - When `"legacy"` (default): `DeviceTtlTimerTask` runs as before
  - When `"deadline"`: the enterprise `DeadlineRenewalScheduler` replaces
    it; `DeviceTtlTimerTask` cron is disabled

  **DI wiring (`CoreTaskContainer` + `CoreServiceContainer`):**

  - `TtlRenewalScheduleRepository` instantiated as a singleton and
    injected into both containers
  - `DeadlineRenewalScheduler` instantiated conditionally (enterprise
    package may not be on `PYTHONPATH` — falls back to `None` in
    community-only builds)
  - `schedule_repo` forwarded to `device_service` so hooks can write to
    the schedule table

## Validation

  - All existing `device_service` and facade tests continue to pass
    (backward-compatible optional parameter)
  - Config schema rejects invalid `engine` values at startup
  - Community YAML and enterprise YAML `renewal_scheduler` sections are
    identical (`engine: "legacy"`)
  - Conditional imports guarded with `try/except ImportError` — community
    builds without the enterprise package compile and run unchanged

  ## Compatibility and risk

  - **Default `engine: "legacy"`** — `DeviceTtlTimerTask` runs exactly as
    before; this PR has zero impact on existing behaviour when deployed
    with the default config
  - `schedule_repo` defaults to `None` — hooks are entirely dormant until
    the DI container wires a real repository
  - `extend_ttl` / `get_device_info` are new methods on the facade — no
    existing call-sites are modified
  - Rollback: keep `engine: "legacy"` (or change back to it) and restart