### PR TITLE
fix(baas): propagate chat error state as ChatErrorStateError in bot run lifecycle

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/__init__.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/__init__.py
@@ -28,7 +28,11 @@ from ._bot_run_utils import (
     resolve_user_id,
 )
 from ._bot_service_selector import BotServiceSelector
-from ._bot_websocket_client import BotWebSocketClient, ChatRequestError
+from ._bot_websocket_client import (
+    BotWebSocketClient,
+    ChatErrorStateError,
+    ChatRequestError,
+)
 from ._claw_service import BotServiceConfig, ClawBotService
 from ._engine_adapter_registry import BotEngineAdapterRegistry
 from ._executor import BotRunRequestExecutor, ResultGuardExecutor, SerializingExecutor
@@ -55,6 +59,7 @@ __all__ = [
     "BotServiceConfig",
     "BotWebSocketClient",
     "ChatRequestError",
+    "ChatErrorStateError",
     "ClawBotService",
     "ConcurrentSessionError",
     "NotConnectedError",

--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -25,7 +25,11 @@ from secbaas.community.api.sse import StreamChunk
 from secbaas.community.logger import get_logger
 from secbaas.community.tracer import get_tracer_plugin
 
-from ._bot_websocket_client import BotWebSocketClient, ChatRequestError
+from ._bot_websocket_client import (
+    BotWebSocketClient,
+    ChatErrorStateError,
+    ChatRequestError,
+)
 from ._session_key_matcher import SessionKeyMatcher
 from ._session_state import _SessionState
 
@@ -396,6 +400,9 @@ class AsyncChatClient:
                     # 无超时等待
                     await state.chat_complete.wait()
 
+                if state.state == "error":
+                    raise ChatErrorStateError(state.error_message)
+
                 return state.content, state.agent_payloads
 
             finally:
@@ -641,6 +648,7 @@ class AsyncChatClient:
         msg = error_msg or f"{source} error"
         logger.warning("[%s] error: sessionKey=%s, errMsg=%s", source, session_key, msg)
         state.state = "error"
+        state.error_message = msg
         state.chat_complete.set()
         AsyncChatClient._emit_stream_chunk(
             state, StreamChunk(type="error", content=msg)
@@ -723,6 +731,7 @@ class AsyncChatClient:
         elif chat_state == "error":
             state.content = text
             state.state = chat_state
+            state.error_message = text or "chat error"
             state.chat_complete.set()
             self._emit_stream_chunk(state, StreamChunk(type="error", content=text))
             if self.verbose:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -51,6 +51,7 @@ from ._async_chat_client_pool import AsyncChatClientPool
 from ._async_session_client import AsyncSessionClient
 from ._async_session_client import SessionInfo as AdapterSessionInfo
 from ._bot_run_utils import resolve_user_id
+from ._bot_websocket_client import ChatErrorStateError
 from ._internal_protocols import BotService
 
 if TYPE_CHECKING:
@@ -410,6 +411,11 @@ class BaasBotService(BotService):
             return BotResponse(content=content)
         except TimeoutError:
             raise
+        except ChatErrorStateError as e:
+            self._mark_session_failed(baas_session_id, err_msg=f"Chat error state: {e}")
+            raise BotServiceError(
+                f"Chat error state on session {session_id}: {e}"
+            ) from e
         except ConcurrentSessionError as e:
             self._mark_session_failed(
                 baas_session_id, err_msg=f"Concurrent request: {e}"
@@ -462,6 +468,7 @@ class BaasBotService(BotService):
         app_id = context.app_id if context else None
 
         try:
+            stream_ended_with_error = False
             async for chunk in client.send_message_stream(
                 message=message,
                 session_key=session_id,
@@ -469,8 +476,20 @@ class BaasBotService(BotService):
                 auth_token=auth_token,
                 app_id=app_id,
             ):
+                if chunk.type in ("error",):
+                    stream_ended_with_error = True
                 yield replace(chunk, engine_type=engine_type)
-            self._mark_session_completed(baas_session_id)
+            if stream_ended_with_error:
+                self._mark_session_failed(
+                    baas_session_id, err_msg="Stream ended with error chunk"
+                )
+            else:
+                self._mark_session_completed(baas_session_id)
+        except ChatErrorStateError as e:
+            self._mark_session_failed(baas_session_id, err_msg=f"Chat error state: {e}")
+            raise BotServiceError(
+                f"Chat error state on session {session_id}: {e}"
+            ) from e
         except ConcurrentSessionError as e:
             self._mark_session_failed(
                 baas_session_id, err_msg=f"Concurrent request: {e}"

--- a/src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_bot_websocket_client.py
@@ -54,6 +54,16 @@ class ChatRequestError(Exception):
         self.retryable = retryable
 
 
+class ChatErrorStateError(Exception):
+    """WebSocket event state 为 error 时 chat 结束抛出。
+
+    当 agent/chat/error 事件的 state 为 "error" 时，
+    _SessionState.state 被设为 "error" 且 chat_complete 被唤醒。
+    AsyncChatClient.send_message 在检测到此状态后抛出此异常，
+    使上层能区分正常完成与错误终态。
+    """
+
+
 class BotWebSocketClient:
     """Bot WebSocket 客户端（纯异步版本）
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
@@ -37,6 +37,7 @@ from ._async_chat_client_pool import AsyncChatClientPool
 from ._async_session_client import AsyncSessionClient
 from ._async_session_client import SessionInfo as AdapterSessionInfo
 from ._bot_run_utils import resolve_user_id
+from ._bot_websocket_client import ChatErrorStateError
 from ._internal_protocols import BotService
 
 if TYPE_CHECKING:
@@ -247,6 +248,10 @@ class ClawBotService(BotService):
             return BotResponse(content=content)
         except TimeoutError:
             raise
+        except ChatErrorStateError as e:
+            raise BotServiceError(
+                f"Chat error state on session {session_id}: {e}"
+            ) from e
         except ConcurrentSessionError as e:
             raise BotServiceError(
                 f"Concurrent request on session {session_id}: {e}"
@@ -293,6 +298,10 @@ class ClawBotService(BotService):
                 app_id=app_id,
             ):
                 yield replace(chunk, engine_type=engine_type)
+        except ChatErrorStateError as e:
+            raise BotServiceError(
+                f"Chat error state on session {session_id}: {e}"
+            ) from e
         except BotServiceError:
             raise
         except ConcurrentSessionError as e:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
@@ -459,6 +459,7 @@ class BotRunRequestExecutor:
             )
 
         final_content = ""
+        stream_ended_with_error = False
         last_flush_ts = time.monotonic()
         try:
             async for chunk in bot_service.send_message_stream(
@@ -487,6 +488,7 @@ class BotRunRequestExecutor:
                     _write_chunk(chunk)
                     last_flush_ts = time.monotonic()
                 elif chunk.type == "error":
+                    stream_ended_with_error = True
                     _write_chunk(chunk)
                     last_flush_ts = time.monotonic()
                 else:
@@ -512,11 +514,14 @@ class BotRunRequestExecutor:
         # flush 残留 buffer
         _flush_buffers()
 
-        self._repo.update_result(
-            run_id=run.run_id,
-            content_long=final_content,
-            extra={"session_id": session_id, "stream": "true"},
-        )
+        if stream_ended_with_error:
+            self._repo.update_error(run.run_id, "stream ended with error chunk")
+        else:
+            self._repo.update_result(
+                run_id=run.run_id,
+                content_long=final_content,
+                extra={"session_id": session_id, "stream": "true"},
+            )
 
     async def _do_inject(
         self,

--- a/src/baas/src/secbaas/community/core/service/bot_run/_session_state.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_session_state.py
@@ -16,6 +16,7 @@ class _SessionState:
 
     content: str = ""
     state: str = ""
+    error_message: str = ""
     agent_payloads: list[dict[str, Any]] = field(default_factory=list)
     last_stream_is_assistant: bool = False
     chat_complete: asyncio.Event = field(default_factory=asyncio.Event)

--- a/src/baas/tests/unit/adapters/web/open_api/test_session_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_session_router.py
@@ -961,8 +961,7 @@ class TestListSessions:
 
         mock_runner.list_sessions.assert_called_once()
         assert (
-            mock_runner.list_sessions.call_args[1]["bot_id"]
-            == "bot-explicit:entity-1"
+            mock_runner.list_sessions.call_args[1]["bot_id"] == "bot-explicit:entity-1"
         )
 
     @pytest.mark.asyncio

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_error_state.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client_error_state.py
@@ -1,0 +1,226 @@
+"""Unit tests for AsyncChatClient error-state propagation (AVE-GOLD-002).
+
+Covers ChatErrorStateError raised by send_message when WebSocket event
+state is "error", and the error_message field on _SessionState.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_TEST_SESSION_KEY = "test-session-key"
+
+
+def _setup_session_state(client, session_key=_TEST_SESSION_KEY):
+    """Helper: register a _SessionState for a given session_key."""
+    from secbaas.community.core.service.bot_run._async_chat_client import _SessionState
+
+    return client._sessions.setdefault(session_key, _SessionState())
+
+
+@pytest.fixture
+def mock_bot_ws():
+    with patch(
+        "secbaas.community.core.service.bot_run._async_chat_client.BotWebSocketClient"
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_bot_ws_instance(mock_bot_ws):
+    instance = mock_bot_ws.return_value
+    instance.connect = AsyncMock(
+        return_value={
+            "server": {"host": "testsrv", "port": 8080},
+            "features": {"chat": True},
+        }
+    )
+    instance.close = AsyncMock()
+    instance.chat_send = AsyncMock()
+    instance.chat_inject = AsyncMock()
+    instance.connected = True
+    return instance
+
+
+class TestChatErrorStateErrorOnAgentError:
+    """send_message raises ChatErrorStateError when _on_agent sets state=error."""
+
+    @pytest.mark.asyncio
+    async def test_agent_error_state_raises_chat_error_state_error(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+        from secbaas.community.core.service.bot_run._bot_websocket_client import (
+            ChatErrorStateError,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        async def fire_agent_error(*args, **kwargs):
+            sk = kwargs["session_key"]
+            state = client._sessions.get(sk)
+            if state:
+                state.state = "error"
+                state.error_message = "CONNECTION_ERROR"
+                state.chat_complete.set()
+
+        mock_bot_ws_instance.chat_send.side_effect = fire_agent_error
+
+        with pytest.raises(ChatErrorStateError, match="CONNECTION_ERROR"):
+            await client.send_message("Hi", session_key=_TEST_SESSION_KEY)
+
+    @pytest.mark.asyncio
+    async def test_normal_final_does_not_raise(self, mock_bot_ws, mock_bot_ws_instance):
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        async def fire_chat_final(*args, **kwargs):
+            sk = kwargs["session_key"]
+            state = client._sessions.get(sk)
+            if state:
+                state.content = "OK"
+                state.state = "final"
+                state.chat_complete.set()
+
+        mock_bot_ws_instance.chat_send.side_effect = fire_chat_final
+
+        content, agent_payloads = await client.send_message(
+            "Hi", session_key=_TEST_SESSION_KEY
+        )
+        assert content == "OK"
+        assert agent_payloads == []
+
+
+class TestSessionStateErrorMessage:
+    """_SessionState.error_message is populated on error transitions."""
+
+    def test_handle_terminal_error_stores_error_message(self):
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+        from secbaas.community.core.service.bot_run._session_state import _SessionState
+
+        state = _SessionState()
+        AsyncChatClient._handle_terminal_error(
+            state, "sk-1", "CONNECTION_ERROR", "agent"
+        )
+        assert state.state == "error"
+        assert state.error_message == "CONNECTION_ERROR"
+
+    def test_handle_terminal_error_default_message(self):
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+        from secbaas.community.core.service.bot_run._session_state import _SessionState
+
+        state = _SessionState()
+        AsyncChatClient._handle_terminal_error(state, "sk-1", "", "agent")
+        assert state.state == "error"
+        assert state.error_message == "agent error"
+
+    @pytest.mark.asyncio
+    async def test_on_chat_error_stores_error_message(self):
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        state = _setup_session_state(client)
+
+        payload = {
+            "sessionKey": _TEST_SESSION_KEY,
+            "state": "error",
+            "message": {"content": [{"text": "chat error text"}]},
+        }
+        client._on_chat(payload)
+        await asyncio.sleep(0)
+        assert state.state == "error"
+        assert state.error_message == "chat error text"
+
+    @pytest.mark.asyncio
+    async def test_on_chat_error_empty_text_uses_default(self):
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        state = _setup_session_state(client)
+
+        payload = {
+            "sessionKey": _TEST_SESSION_KEY,
+            "state": "error",
+            "message": {"content": []},
+        }
+        client._on_chat(payload)
+        await asyncio.sleep(0)
+        assert state.state == "error"
+        assert state.error_message == "chat error"
+
+
+class TestChatErrorStateErrorDefinition:
+    """ChatErrorStateError class definition and behavior."""
+
+    def test_is_exception(self):
+        from secbaas.community.core.service.bot_run._bot_websocket_client import (
+            ChatErrorStateError,
+        )
+
+        assert issubclass(ChatErrorStateError, Exception)
+
+    def test_carries_message(self):
+        from secbaas.community.core.service.bot_run._bot_websocket_client import (
+            ChatErrorStateError,
+        )
+
+        err = ChatErrorStateError("CONNECTION_ERROR")
+        assert str(err) == "CONNECTION_ERROR"
+
+    def test_catchable_as_exception(self):
+        from secbaas.community.core.service.bot_run._bot_websocket_client import (
+            ChatErrorStateError,
+        )
+
+        with pytest.raises(Exception):
+            raise ChatErrorStateError("test error")
+
+
+class TestSendStreamErrorTerminalChunk:
+    """Stream path: error chunk as terminal chunk is tracked."""
+
+    @pytest.mark.asyncio
+    async def test_drain_stream_queue_yields_error_chunk(self):
+        """Stream consumer yields error chunk without raising."""
+        from secbaas.community.api.sse import StreamChunk
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        queue: asyncio.Queue[StreamChunk] = asyncio.Queue()
+        await queue.put(StreamChunk(type="delta", content="hello"))
+        await queue.put(StreamChunk(type="error", content="CONNECTION_ERROR"))
+
+        chunks_received = []
+        async for chunk in AsyncChatClient._drain_stream_queue(queue, None):
+            chunks_received.append(chunk)
+
+        types = [c.type for c in chunks_received]
+        assert types == ["delta", "error"]
+        assert chunks_received[-1].content == "CONNECTION_ERROR"

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -2185,8 +2185,15 @@ class TestListSessions:
         context = MagicMock()
 
         with (
-            patch.object(service, "_resolve_ws_connection_for_binding", new_callable=AsyncMock, return_value=_make_conn_info()),
-            patch.object(service, "_create_session_client", return_value=session_client),
+            patch.object(
+                service,
+                "_resolve_ws_connection_for_binding",
+                new_callable=AsyncMock,
+                return_value=_make_conn_info(),
+            ),
+            patch.object(
+                service, "_create_session_client", return_value=session_client
+            ),
         ):
             result = await service.list_sessions(
                 binding_info=binding,
@@ -2217,7 +2224,9 @@ class TestListSessions:
             new_callable=AsyncMock,
             side_effect=RuntimeError("conn failed"),
         ):
-            with pytest.raises(BotServiceError, match="Failed to resolve WS connection"):
+            with pytest.raises(
+                BotServiceError, match="Failed to resolve WS connection"
+            ):
                 await service.list_sessions(
                     binding_info=binding,
                     context=context,
@@ -2237,8 +2246,15 @@ class TestListSessions:
         context = MagicMock()
 
         with (
-            patch.object(service, "_resolve_ws_connection_for_binding", new_callable=AsyncMock, return_value=_make_conn_info()),
-            patch.object(service, "_create_session_client", return_value=session_client),
+            patch.object(
+                service,
+                "_resolve_ws_connection_for_binding",
+                new_callable=AsyncMock,
+                return_value=_make_conn_info(),
+            ),
+            patch.object(
+                service, "_create_session_client", return_value=session_client
+            ),
         ):
             with pytest.raises(BotServiceError, match="Failed to list sessions"):
                 await service.list_sessions(
@@ -2260,8 +2276,15 @@ class TestListSessions:
         context = MagicMock()
 
         with (
-            patch.object(service, "_resolve_ws_connection_for_binding", new_callable=AsyncMock, return_value=_make_conn_info()),
-            patch.object(service, "_create_session_client", return_value=session_client),
+            patch.object(
+                service,
+                "_resolve_ws_connection_for_binding",
+                new_callable=AsyncMock,
+                return_value=_make_conn_info(),
+            ),
+            patch.object(
+                service, "_create_session_client", return_value=session_client
+            ),
         ):
             with pytest.raises(BotServiceError, match="already wrapped"):
                 await service.list_sessions(

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service_engine_seams.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service_engine_seams.py
@@ -1,19 +1,24 @@
-"""§6.6 — BaasBotService 引擎接缝分流测试。
+"""§6.6 — BaasBotService 引擎接缝分流测试 + ChatErrorStateError 传播测试。
 
 验证 registry 注入 + `_adapter_for` 门控：新引擎走 adapter，openclaw/teclaw 走 else
 （`_adapter_for` 返回 None）。字节级不变性由 else 分支结构保证 + 现有 test_baas_service 回归。
+同时验证 ChatErrorStateError 在 BaasBotService.send_message 中被捕获并转为 BotServiceError。
 """
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from secbaas.community.api.bot_runtime import BotBindingInfo, BotServiceError
 from secbaas.community.core.service.bot_run import (
     BaasBotService,
     BaasBotServiceConfig,
     BotEngineAdapterRegistry,
+)
+from secbaas.community.core.service.bot_run._bot_websocket_client import (
+    ChatErrorStateError,
 )
 from secbaas.community.plugins.bot.engine_adapter.aicoding import MockAICodingAdapter
 
@@ -93,3 +98,86 @@ def test_create_session_client_openclaw_uses_legacy_suffix(registry) -> None:
     conn.token = "tok"
     client = svc._create_session_client(conn, "openclaw")
     assert client.base_url == "https://host/proxypass/tgt"
+
+
+# ---------------------------------------------------------------------------
+# ChatErrorStateError propagation tests
+# ---------------------------------------------------------------------------
+
+
+def _binding_info() -> BotBindingInfo:
+    return BotBindingInfo(
+        bot_id="bot-1",
+        entity_id="ent-1",
+        sandbox_id=None,
+        device_provider="baas",
+        device_id="dev-1",
+        engine_type="openclaw",
+        binding_id="bind-1",
+        baas_session_id="baas-sess-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_catches_chat_error_state_error() -> None:
+    """BaasBotService.send_message catches ChatErrorStateError → _mark_session_failed + BotServiceError."""
+    svc = _service(None)
+    binding = _binding_info()
+
+    mock_client = AsyncMock()
+    mock_client.send_message = AsyncMock(
+        side_effect=ChatErrorStateError("CONNECTION_ERROR")
+    )
+
+    mock_pool = MagicMock()
+    mock_pool.get = AsyncMock(return_value=mock_client)
+
+    # Resolve WS connection mock
+    svc._wss_resolver.dispatch_bot_ws_conn_info = AsyncMock(
+        return_value=MagicMock(ws_url="wss://h/ws", token="t", target="tgt")
+    )
+    svc._client_pool = mock_pool
+    svc._mark_session_failed = MagicMock()
+    svc._mark_session_completed = MagicMock()
+
+    with pytest.raises(BotServiceError, match="Chat error state"):
+        await svc.send_message(
+            session_id="s-1",
+            message="hi",
+            binding_info=binding,
+            timeout=30,
+        )
+
+    svc._mark_session_failed.assert_called_once()
+    svc._mark_session_completed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_message_normal_return_still_completed() -> None:
+    """Normal send_message return still calls _mark_session_completed."""
+    svc = _service(None)
+    binding = _binding_info()
+
+    mock_client = AsyncMock()
+    mock_client.send_message = AsyncMock(return_value=("content", []))
+
+    mock_pool = MagicMock()
+    mock_pool.get = AsyncMock(return_value=mock_client)
+
+    svc._wss_resolver.dispatch_bot_ws_conn_info = AsyncMock(
+        return_value=MagicMock(ws_url="wss://h/ws", token="t", target="tgt")
+    )
+    svc._client_pool = mock_pool
+    svc._mark_session_failed = MagicMock()
+    svc._mark_session_completed = MagicMock()
+
+    result = await svc.send_message(
+        session_id="s-1",
+        message="hi",
+        binding_info=binding,
+        timeout=30,
+    )
+
+    assert result.content == "content"
+    svc._mark_session_completed.assert_called_once()
+    svc._mark_session_failed.assert_not_called()

--- a/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
@@ -593,7 +593,9 @@ class TestListSessions:
             await service.list_sessions(binding_info=baas_binding)
 
     @pytest.mark.asyncio
-    async def test_success_path_with_pagination(self, service, arca_binding, monkeypatch):
+    async def test_success_path_with_pagination(
+        self, service, arca_binding, monkeypatch
+    ):
         """Successful list_sessions delegates to session client with correct args."""
         from secbaas.community.core.service.bot_run._async_session_client import (
             SessionInfo as AdapterSessionInfo,
@@ -645,7 +647,9 @@ class TestListSessions:
             await service.list_sessions(binding_info=arca_binding)
 
     @pytest.mark.asyncio
-    async def test_bot_service_error_passthrough(self, service, arca_binding, monkeypatch):
+    async def test_bot_service_error_passthrough(
+        self, service, arca_binding, monkeypatch
+    ):
         """Existing BotServiceError passes through without re-wrapping."""
         session_client = AsyncMock()
         session_client.__aenter__ = AsyncMock(return_value=session_client)

--- a/src/baas/tests/unit/core/service/bot_run/test_runner.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_runner.py
@@ -2042,10 +2042,13 @@ class TestListSessions:
     """BotRunner.list_sessions() coverage."""
 
     @pytest.mark.asyncio
-    async def test_delegates_to_bot_service(self, mock_bot_service, mock_selector, mock_run_repo, context):
+    async def test_delegates_to_bot_service(
+        self, mock_bot_service, mock_selector, mock_run_repo, context
+    ):
         """list_sessions resolves route and delegates to bot_service."""
+        from datetime import UTC, datetime
+
         from secbaas.community.api.bot_runtime import SessionInfo
-        from datetime import datetime, UTC
 
         binding = BotBindingInfo(
             bot_id=BOT_ID,
@@ -2080,7 +2083,9 @@ class TestListSessions:
         route.binding_info = binding
         route.bot_service = mock_bot_service
 
-        with patch.object(runner, "_resolve_bot_route", new_callable=AsyncMock, return_value=route):
+        with patch.object(
+            runner, "_resolve_bot_route", new_callable=AsyncMock, return_value=route
+        ):
             result = await runner.list_sessions(
                 bot_id=BOT_ID,
                 context=context,


### PR DESCRIPTION
## Summary

Add `ChatErrorStateError` to distinguish WebSocket error-state termination from normal chat completion in the bot run lifecycle.

## Changes

- **New exception**: `ChatErrorStateError` in `_bot_websocket_client.py` signals that the agent/chat/error event reported `state="error"`.
- **AsyncChatClient**: After `chat_complete` is set, checks `state.state == "error"` and raises `ChatErrorStateError(state.error_message)`.
- **Session state**: New `error_message` field on `_SessionState` captures the error detail when state transitions to `"error"`.
- **BaasBotService**: Catches `ChatErrorStateError` in both `send_message` and `send_message_stream`, marks session failed, and re-raises as `BotServiceError`.
- **ClawBotService**: Same `ChatErrorStateError` handling for `send_message` and `send_message_stream`.
- **Executor**: Tracks `stream_ended_with_error` flag; on error-ended streams calls `update_error` instead of `update_result`.
- **Tests**: Added coverage for `ChatErrorStateError` propagation in `BaasBotService` (both normal return and error paths), plus formatting alignment across existing test modules.

## Testing

- Unit tests pass for `ChatErrorStateError` propagation through `BaasBotService.send_message`.
- Existing session lifecycle tests remain green.