### PR TITLE
fix(bcs-app-session): allow collecting a session as the human's own actor

### DIFF
--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -296,32 +296,38 @@ impl SessionServiceImpl {
         Ok(session)
     }
 
-    async fn load_owned_participant_bot(
+    async fn load_session_for_collection(
         &self,
         caller: &AuthenticatedCaller,
         session_id: &str,
         participant: &str,
     ) -> Result<Session, ApplicationError> {
         let user = require_authenticated_user(caller)?;
+        // The participant must be owned by the authenticated Human: one of the
+        // Human's own bots, OR the Human's own actor entry. `ensure_human_actor`
+        // registers the latter as `human_{staff_no}` with `created_by` =
+        // `staff_no` and `actor_kind = Human`. The legacy
+        // `resolve_collector_bot` admits both via `list_bots_by_creator`, which
+        // does not filter by actor kind — so a Human can collect a Session as
+        // itself, not only through an owned bot. Match that contract by keying
+        // ownership on `created_by` alone.
         let owned = self
             .registry
             .try_get(participant)
             .await
             .map_err(map_service_error)?
-            .is_some_and(|bot| {
-                bot.actor_kind == ActorKind::Bot
-                    && bot.created_by.as_deref() == Some(user.id.as_str())
-            });
+            .is_some_and(|bot| bot.created_by.as_deref() == Some(user.id.as_str()));
         if !owned {
             return Err(ApplicationError::forbidden(
-                "The target Bot is not owned by the authenticated Human",
+                "The target participant is not owned by the authenticated Human",
             ));
         }
 
         let session = self.load_session(session_id).await?;
-        let present = session.participants.iter().any(|entry| {
-            entry.actor_kind == ActorKind::Bot && entry.bot_uuid == participant
-        });
+        let present = session
+            .participants
+            .iter()
+            .any(|entry| entry.bot_uuid == participant);
         if !present {
             return Err(ApplicationError::not_found(
                 "session_not_found",
@@ -810,7 +816,7 @@ impl SessionService for SessionServiceImpl {
         &self,
         command: CollectSession,
     ) -> Result<SessionCollectionResult, ApplicationError> {
-        self.load_owned_participant_bot(
+        self.load_session_for_collection(
             &command.caller,
             &command.session_id,
             &command.participant,
@@ -831,7 +837,7 @@ impl SessionService for SessionServiceImpl {
         &self,
         command: UncollectSession,
     ) -> Result<SessionCollectionResult, ApplicationError> {
-        self.load_owned_participant_bot(
+        self.load_session_for_collection(
             &command.caller,
             &command.session_id,
             &command.participant,

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -1275,6 +1275,134 @@ async fn human_collects_and_uncollects_for_owned_participant_bot_idempotently() 
 }
 
 #[tokio::test]
+async fn human_collects_as_own_human_actor_idempotently() {
+    let fixture = Fixture::new().await;
+    fixture.add_bot("driver").await;
+    // Register the human's own actor entry (`human_owner-1`) the way
+    // `ensure_human_actor` does: actor_kind = Human, created_by = the staff_no.
+    fixture
+        .bots
+        .ensure_human_actor("owner-1", "Owner")
+        .await
+        .expect("provision human actor");
+    fixture
+        .store_group_with_originator("g1", "driver", "human_owner-1", None)
+        .await;
+    let group = fixture.groups.get("g1").await.expect("group exists");
+    let session = fixture
+        .session_repo
+        .create(
+            "g1",
+            NewSessionParams {
+                participants: vec![
+                    Participant::bot("driver", ParticipantRole::Driver),
+                    Participant::human("human_owner-1", ParticipantRole::Observer),
+                ],
+                group_version: Some(group.version),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("seed Session");
+
+    // Collect as the human's own actor id (participant = "human_owner-1").
+    for _ in 0..2 {
+        let result = fixture
+            .service
+            .collect(CollectSession {
+                caller: human_principal("owner-1"),
+                session_id: session.id.clone(),
+                participant: "human_owner-1".into(),
+            })
+            .await
+            .expect("human can collect as its own actor");
+        assert_eq!(result.session_id, session.id);
+        assert_eq!(result.participant, "human_owner-1");
+        assert!(result.collected);
+    }
+    let collected = fixture
+        .session_repo
+        .collected_at_map(&[session.id.as_str()], "human_owner-1")
+        .await;
+    assert_eq!(collected.len(), 1);
+    assert_eq!(collected[0].0, session.id);
+
+    // Uncollecting as the human actor is idempotent.
+    for _ in 0..2 {
+        let result = fixture
+            .service
+            .uncollect(UncollectSession {
+                caller: human_principal("owner-1"),
+                session_id: session.id.clone(),
+                participant: "human_owner-1".into(),
+            })
+            .await
+            .expect("human can uncollect as its own actor");
+        assert_eq!(result.participant, "human_owner-1");
+        assert!(!result.collected);
+    }
+    assert!(
+        fixture
+            .session_repo
+            .collected_at_map(&[session.id.as_str()], "human_owner-1")
+            .await
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn collect_rejects_participant_not_owned_by_authenticated_human() {
+    let fixture = Fixture::new().await;
+    fixture.add_bot("driver").await;
+    fixture
+        .bots
+        .ensure_human_actor("owner-1", "Owner")
+        .await
+        .expect("provision authenticated human actor");
+    fixture
+        .bots
+        .ensure_human_actor("other", "Other")
+        .await
+        .expect("provision a different human actor");
+    fixture
+        .store_group_with_originator("g1", "driver", "human_owner-1", None)
+        .await;
+    let group = fixture.groups.get("g1").await.expect("group exists");
+    let session = fixture
+        .session_repo
+        .create(
+            "g1",
+            NewSessionParams {
+                participants: vec![
+                    Participant::bot("driver", ParticipantRole::Driver),
+                    Participant::human("human_owner-1", ParticipantRole::Observer),
+                    Participant::human("human_other", ParticipantRole::Observer),
+                ],
+                group_version: Some(group.version),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("seed Session");
+
+    let error = fixture
+        .service
+        .collect(CollectSession {
+            caller: human_principal("owner-1"),
+            session_id: session.id.clone(),
+            // `human_other` is registered, but not owned by the authenticated
+            // human (`owner-1`); collecting on its behalf must be forbidden.
+            participant: "human_other".into(),
+        })
+        .await
+        .expect_err("must not collect as an actor the human does not own");
+    assert!(
+        matches!(error, bcs_service_api::application::v1::ApplicationError::Forbidden(_)),
+        "expected forbidden, got {error:?}"
+    );
+}
+
+#[tokio::test]
 async fn list_surfaces_per_session_collected_for_explicit_view_actor() {
     let fixture = Fixture::new().await;
     fixture.add_bot("bot-1").await;


### PR DESCRIPTION
## Problem

Calling the OpenAPI v1 `POST /openapi/v1/collaboration/sessions/{session_id}/collect` with body `{"participant": "human_xxx"}` returns:

```json
{ "code": 40300, "message": "The target Bot is not owned by the authenticated Human" }
```

while the legacy endpoint (`bcs_http::routes::sessions::collect_session`) accepts the same request.

### Root cause

`ensure_human_actor` registers a Human's own actor in the bot registry as `bot_uuid = "human_{staff_no}"`, `actor_kind = Human`, `created_by = staff_no`. The two collect paths diverge on how they authorize `participant`:

- Legacy `resolve_collector_bot` uses `registry.list_bots_by_creator(staff_no)`, which does **not** filter by `actor_kind` — so the human's own `human_{staff_no}` entry matches and the collect succeeds (the Human collects as itself).
- OpenAPI v1 `load_owned_participant_bot` required `bot.actor_kind == ActorKind::Bot`, excluding the human's own Human-kind entry → `owned = false` → 403.

The v1 presence check (`actor_kind == Bot && bot_uuid == participant`) had the same flaw, excluding Human session participants.

## Solution

In `SessionServiceImpl`, align the OpenAPI collect/uncollect authorization with the legacy semantics by keying ownership on `created_by` alone and dropping the `actor_kind == Bot` restriction in both checks:

- Ownership: `bot.created_by == user.id` (admits the human's own `human_{id}` entry as well as owned bots).
- Session presence: `entry.bot_uuid == participant` (admits Human participants).
- Renamed `load_owned_participant_bot` → `load_session_for_collection` and updated the 403 message to `"The target participant is not owned by the authenticated Human"` (no longer Bot-specific).

Unowned participants are still 403; non-members still 404 — the security guarantees are unchanged, only the erroneous `actor_kind == Bot` exclusion of the human's own actor is removed. The OpenAPI contract schema (`CollectSessionRequest.participant: string`) already permits `human_xxx`, so no contract change is required.

## Validation

- `cargo build -p bcs` ✅
- `cargo test -p bcs-app-session --test v1_session_service` ✅ (65 passed)
- `cargo test -p bcs-api-http --test session_routes` ✅ (34 passed)
- New `human_collects_as_own_human_actor_idempotently`: `participant = "human_owner-1"` collects / uncollects idempotently; `collected_at_map` keys under the human actor id.
- New `collect_rejects_participant_not_owned_by_authenticated_human`: collecting as a registered-but-unowned actor (`human_other`) is still 403, confirming the ownership gate was not over-relaxed.