### PR TITLE
fix(aicoding): restore sessions/cron-tasks.json sync when admin cannot stat NAS file

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_build_service.py
@@ -82,6 +82,14 @@ _BOT_GONE_ERROR_CODES = frozenset({"BOT_NOT_FOUND", "DEVICE_NOT_FOUND"})
 # whole operation, rather than granting each individual command a fresh timeout.
 _DRAFT_RESTORE_TIMEOUT_SECONDS = 30 * 60
 
+# Extra-include pre-flight runs a ``sudo -n test -f`` probe. The publish
+# path does not carry a per-command timeout (timeout_seconds=None), so
+# without an upper bound a misbehaving sudo (e.g. stuck PAM) could hang
+# the whole migrate/publish flow. Cap the probe independently of the
+# caller: worst case it times out and we degrade to skipping the file
+# (the pre-fix behavior), never to blocking the publish.
+_SUDO_PROBE_FALLBACK_TIMEOUT_SECONDS = 10.0
+
 
 class BotBuildServiceError(Exception):
     """Bot build service error."""
@@ -729,6 +737,50 @@ class BotBuildService:
             raise BotBuildMigrationError(f"invalid extra include file path: {rel_path}")
         return str(parsed)
 
+    def _sudo_is_file(
+        self,
+        path: Path,
+        timeout_seconds: float | None = None,
+    ) -> bool:
+        """Return whether ``path`` is a regular file, probed as root.
+
+        This mirrors the privileges of the ``sudo rsync`` copy used below:
+        in-process ``sudo`` is passwordless (the primary migration rsync
+        already relies on that), so probing with ``sudo -n test -f`` lets us
+        tell "exists & readable by root" from "missing" even when the
+        service's own uid cannot ``stat`` the file. It is used as a fallback
+        for the pre-flight check when ``Path.exists()`` raises
+        ``PermissionError`` on sandbox-owned NAS files.
+
+        The probe is always time-bounded: when the caller passes
+        ``timeout_seconds=None`` (the publish path), a module-level fallback
+        cap is used so a hung sudo can never stall migrate/publish. Any
+        subprocess failure -- including timeout, or an NFS path with
+        ``root_squash``/``all_squash`` where root is mapped to nobody --
+        yields ``False``, so the caller simply skips the file rather than
+        aborting the publish/restore.
+        """
+        # Always bound the probe: callers may pass timeout_seconds=None (the
+        # publish path). A hung sudo would otherwise stall migrate/publish
+        # indefinitely, which must never happen. On timeout the probe returns
+        # False and the caller degrades to skipping the file (pre-fix behavior).
+        effective_timeout = (
+            timeout_seconds
+            if timeout_seconds is not None
+            else _SUDO_PROBE_FALLBACK_TIMEOUT_SECONDS
+        )
+        try:
+            completed = subprocess.run(
+                ["sudo", "-n", "test", "-f", str(path)],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=effective_timeout,
+            )
+        except Exception:
+            return False
+        return completed.returncode == 0
+
     def _sync_extra_include_files(
         self,
         *,
@@ -747,14 +799,35 @@ class BotBuildService:
             try:
                 normalized = self._normalize_extra_include_file(rel_path)
                 source_file = source_dir / normalized
-                if not source_file.exists():
+                # The service runs as a non-root uid that cannot stat
+                # sandbox-owned files on the NAS merge area (e.g. uid 1000 /
+                # mode 0600): Path.exists()/is_file() then raise
+                # PermissionError instead of returning False, which previously
+                # skipped a file the ``sudo rsync`` copy (running as root,
+                # passwordless in-process) *could* have copied. Re-probe at
+                # root privilege on EACCES; only skip if root also cannot read.
+                try:
+                    admin_exists = source_file.exists()
+                    admin_is_file = source_file.is_file()
+                except PermissionError:
+                    if not self._sudo_is_file(source_file, timeout_seconds):
+                        logger.info(
+                            "[BotBuildService._sync_extra_include_files] "
+                            "Skip unreadable extra include file (admin cannot "
+                            "stat, root probe failed): %s",
+                            source_file,
+                        )
+                        continue
+                    admin_exists = True
+                    admin_is_file = True
+                if not admin_exists:
                     logger.info(
                         "[BotBuildService._sync_extra_include_files] "
                         "Skip missing extra include file: %s",
                         source_file,
                     )
                     continue
-                if not source_file.is_file():
+                if not admin_is_file:
                     logger.warning(
                         "[BotBuildService._sync_extra_include_files] "
                         "Skip non-file extra include path: %s",

--- a/src/backend/tests/community/core/service_bot/services/test_bot_build_service_draft_restore.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_build_service_draft_restore.py
@@ -429,3 +429,132 @@ def test_sync_extra_include_files_logs_and_continues_on_invalid_path(tmp_path, c
 
     svc._run_local_command.assert_not_called()
     assert "Failed to sync extra include file" in caplog.text
+
+
+def test_sync_extra_include_files_syncs_when_admin_cannot_stat_but_root_can(tmp_path):
+    """Regression: the service uid (admin) cannot stat sandbox-owned NAS files
+    (uid 1000 / mode 0600). Before the fix ``Path.exists()`` raised
+    PermissionError, which was swallowed by the best-effort except and the file
+    was silently skipped -- even though ``sudo rsync`` (running as root,
+    passwordless in-process) could have copied it. The EACCES branch now
+    re-probes as root and, when root can read it, hands the file to the rsync
+    copy instead of skipping it."""
+    plan = EngineBuildPlan(
+        engine_type="aicoding",
+        source_root_name=".aicoding",
+        migration_subpath="aicoding",
+        workspace_subdir="workspace",
+        mcp_config_relpath="workspace/config/mcporter.json",
+        skill_source_relpath="workspace/skills",
+        skill_target_relpath="workspace/skills",
+        rsync_excludes=["sessions"],
+        extra_include_files=["sessions/cron-tasks.json"],
+    )
+    source_dir = tmp_path / "source"
+    sessions_dir = source_dir / "sessions"
+    sessions_dir.mkdir(parents=True)
+    cron_file = sessions_dir / "cron-tasks.json"
+    cron_file.write_text("{}")
+
+    svc = object.__new__(BotBuildService)
+    rsync_mock = MagicMock()
+    svc._run_local_command = rsync_mock
+    # Simulate "root can read it" (sudo test -f succeeds).
+    svc._sudo_is_file = MagicMock(return_value=True)
+
+    # admin cannot traverse the sessions dir -> Path.exists() raises
+    # PermissionError (verified: a 0o000 parent yields EACCES on child stat).
+    sessions_dir.chmod(0o000)
+    try:
+        svc._sync_extra_include_files(
+            source_dir=source_dir,
+            target_dir=tmp_path / "target",
+            build_plan=plan,
+            command_name="rsync extra include",
+            error_message="rsync extra include file failed",
+        )
+    finally:
+        sessions_dir.chmod(0o755)
+
+    # The rsync copy must be dispatched: do not skip a file root can read.
+    rsync_mock.assert_called_once()
+    cmd = rsync_mock.call_args.kwargs["cmd"]
+    assert cmd[:2] == ["sudo", "rsync"]
+    assert str(cron_file) in cmd
+    # The root fallback probe was consulted.
+    svc._sudo_is_file.assert_called_once()
+
+
+def test_sync_extra_include_files_skips_when_root_probe_also_fails(tmp_path):
+    """When admin cannot stat AND root also cannot read (e.g. NFS squash maps
+    root to nobody), skip the file quietly -- rsync-as-root could not copy it
+    anyway -- without raising, so publish/restore is not blocked."""
+    plan = EngineBuildPlan(
+        engine_type="aicoding",
+        source_root_name=".aicoding",
+        migration_subpath="aicoding",
+        workspace_subdir="workspace",
+        mcp_config_relpath="workspace/config/mcporter.json",
+        skill_source_relpath="workspace/skills",
+        skill_target_relpath="workspace/skills",
+        rsync_excludes=["sessions"],
+        extra_include_files=["sessions/cron-tasks.json"],
+    )
+    source_dir = tmp_path / "source"
+    sessions_dir = source_dir / "sessions"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "cron-tasks.json").write_text("{}")
+
+    svc = object.__new__(BotBuildService)
+    rsync_mock = MagicMock()
+    svc._run_local_command = rsync_mock
+    # Simulate "root also cannot read" (squashed): root probe fails.
+    svc._sudo_is_file = MagicMock(return_value=False)
+
+    sessions_dir.chmod(0o000)
+    try:
+        svc._sync_extra_include_files(
+            source_dir=source_dir,
+            target_dir=tmp_path / "target",
+            build_plan=plan,
+            command_name="rsync extra include",
+            error_message="rsync extra include file failed",
+        )
+    finally:
+        sessions_dir.chmod(0o755)
+
+    rsync_mock.assert_not_called()
+    svc._sudo_is_file.assert_called_once()
+
+
+
+def test_sudo_is_file_does_not_raise_on_timeout(monkeypatch):
+    """Safety contract: a hung sudo must never stall migrate/publish. The probe
+    is bounded; on timeout it returns False (caller skips the file) instead of
+    raising or hanging the flow."""
+    svc = object.__new__(BotBuildService)
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=kwargs.get("cmd", ["sudo"]), timeout=0.01)
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    assert svc._sudo_is_file(module.Path("/any/where")) is False
+
+
+def test_sudo_is_file_uses_bounded_timeout_when_caller_passes_none(monkeypatch):
+    """Safety contract: even when the caller does not supply a timeout (the
+    publish path passes timeout_seconds=None), the probe must still use a
+    finite timeout so it cannot hang the flow indefinitely."""
+    svc = object.__new__(BotBuildService)
+    captured = {}
+
+    class _Result:
+        returncode = 0
+
+    def fake_run(*args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        return _Result()
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    assert svc._sudo_is_file(module.Path("/x")) is True
+    assert captured.get("timeout") is not None and captured["timeout"] > 0


### PR DESCRIPTION
fix(aicoding): restore sessions/cron-tasks.json sync when admin cannot stat NAS file

BotBuildService._sync_extra_include_files pre-checked source files with
Path.exists()/is_file() as the non-root service uid, which raises
PermissionError (EACCES) on sandbox-owned NAS files (uid 1000 / mode 0600).
That was swallowed by the best-effort except and silently skipped
sessions/cron-tasks.json during publish/migrate -- even though the
sudo rsync copy (running as root) could read it.

On EACCES, re-probe the file at root privilege via `sudo -n test -f`; when
root can read it, hand the file to the existing sudo rsync copy instead of
skipping it. The probe is always time-bounded (caller timeout, else a 10s
fallback) so a hung sudo can never stall migrate/publish. Any probe or
subprocess failure falls back to skipping the file (the pre-fix behavior),
never to blocking the flow.

No impact on openclaw / claude_code: their build plans carry no
extra_include_files, so the function still returns early as before.

Adds regression tests for the admin-cannot-stat-but-root-can path and for
the bounded-timeout safety contract.