### PR TITLE
 fix(gateway): enable local cookie auth for harness OpenAPI

### DIFF
--- a/scripts/modules/backend.sh
+++ b/scripts/modules/backend.sh
@@ -82,6 +82,10 @@ backend_start() {
         log_info "Backend coverage mode enabled: ${coverage_dir}"
     fi
 
+    if [ "${SERVER_ENV:-dev}" = "local" ] || [ "${DEPLOY_PROFILE:-}" = "singlebox" ]; then
+        export AGENTCLAW_SECRET_GATEWAY_PRINCIPAL_SIGNING_KEY_VALUE="${AGENTCLAW_SECRET_GATEWAY_PRINCIPAL_SIGNING_KEY_VALUE:-avernet-dev-signing-key-NOT-FOR-PROD}"
+    fi
+
     log_info "Engine type: ${CHAT_ENGINE}"
     local backend_pid
     if [ "$LOCAL_MODE" = true ]; then

--- a/scripts/modules/gateway.sh
+++ b/scripts/modules/gateway.sh
@@ -62,7 +62,7 @@ gateway_start() {
 
     (
         cd "${GATEWAY_DIR}"
-        GATEWAY_PORT="${GATEWAY_PORT}" APP_PORT="${GATEWAY_PORT}" "${GATEWAY_APP_SCRIPT}" start --mode bare
+        SERVER_ENV="${SERVER_ENV:-local}" GATEWAY_PORT="${GATEWAY_PORT}" APP_PORT="${GATEWAY_PORT}" "${GATEWAY_APP_SCRIPT}" start --mode bare
     ) >> "${GATEWAY_LOG}" 2>&1
 
     local gateway_pid=""
@@ -88,7 +88,7 @@ gateway_stop() {
     log_info "Stopping Gateway..."
 
     if [ -x "${GATEWAY_APP_SCRIPT}" ]; then
-        (cd "${GATEWAY_DIR}" && GATEWAY_PORT="${GATEWAY_PORT}" APP_PORT="${GATEWAY_PORT}" "${GATEWAY_APP_SCRIPT}" stop) >> "${GATEWAY_LOG}" 2>&1 || true
+        (cd "${GATEWAY_DIR}" && SERVER_ENV="${SERVER_ENV:-local}" GATEWAY_PORT="${GATEWAY_PORT}" APP_PORT="${GATEWAY_PORT}" "${GATEWAY_APP_SCRIPT}" stop) >> "${GATEWAY_LOG}" 2>&1 || true
     fi
 
     if [ -f "${GATEWAY_PID_FILE}" ]; then

--- a/src/gateway/configs/application-local.yaml
+++ b/src/gateway/configs/application-local.yaml
@@ -1,0 +1,13 @@
+user_config:
+  # Local browser debugging: TeamClaw dev proxy forwards cookies, and this
+  # strategy maps staff_id -> UserPrincipal before falling back to Google token.
+  identity_strategies:
+    user: [dev_cookie, google]
+
+
+  upstream_vars:
+    backend_server_url: http://127.0.0.1:8888
+    baas_server_url: http://127.0.0.1:8890
+    bcs_server_url: http://127.0.0.1:21000
+    engine_proxy_server_url: http://127.0.0.1:8888
+    bcsfuse_server_url: http://127.0.0.1:8765

--- a/src/gateway/scripts/app.sh
+++ b/src/gateway/scripts/app.sh
@@ -32,6 +32,14 @@ log_warn() {
     echo -e "${YELLOW}[WARN]${NC} $1" | tee -a "$LOG_FILE"
 }
 
+start_detached() {
+    if command -v python3 >/dev/null 2>&1; then
+        nohup python3 -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' "$@" >> "$LOG_FILE" 2>&1 &
+    else
+        nohup "$@" >> "$LOG_FILE" 2>&1 &
+    fi
+}
+
 log_usage() {
     echo -e "${BLUE}Usage:${NC} $0 {start|stop|restart|status} [options]"
     echo ""
@@ -110,7 +118,7 @@ check_port() {
 
 do_start() {
     local debug_port=""
-    local env_name=""
+    local env_name="${SERVER_ENV:-}"
 
     while [[ $# -gt 0 ]]; do
         case $1 in
@@ -135,6 +143,9 @@ do_start() {
     local config_file="$CONFIG_DIR/application.yaml"
     if [[ -n "$env_name" ]]; then
         case "$env_name" in
+            local)
+                config_file="$CONFIG_DIR/application-local.yaml"
+                ;;
             dev)
                 config_file="$CONFIG_DIR/application-dev.yaml"
                 ;;
@@ -145,7 +156,7 @@ do_start() {
                 config_file="$CONFIG_DIR/application.yaml"
                 ;;
             *)
-                log_error "Unknown environment: $env_name (supported: dev/prepub/prod)"
+                log_error "Unknown environment: $env_name (supported: local/dev/prepub/prod)"
                 exit 1
                 ;;
         esac
@@ -174,6 +185,10 @@ do_start() {
         rm -f "$PID_FILE"
     fi
 
+    if [[ "$env_name" == "local" ]]; then
+        export AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE="${AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE:-avernet-dev-signing-key-NOT-FOR-PROD}"
+    fi
+
     log_info "Starting gateway application..."
     log_info "Config file: $config_file"
     log_info "Log file: $LOG_FILE"
@@ -187,11 +202,11 @@ do_start() {
     # aren't installed.
     if [[ -n "$debug_port" ]]; then
         log_info "Debug port: $debug_port (app starts immediately without waiting for debugger)"
-        SERVER_ENV="$env_name" nohup "$VENV_DIR/bin/python" -m debugpy --listen "0.0.0.0:$debug_port" \
-            "$WORK_DIR/src/gateway/community/main.py" -c "$CONFIG_DIR" --mode "$APP_MODE" >> "$LOG_FILE" 2>&1 &
+        SERVER_ENV="$env_name" start_detached "$VENV_DIR/bin/python" -m debugpy --listen "0.0.0.0:$debug_port" \
+            "$WORK_DIR/src/gateway/community/main.py" -c "$CONFIG_DIR" --mode "$APP_MODE"
     else
-        SERVER_ENV="$env_name" nohup "$VENV_DIR/bin/python" \
-            "$WORK_DIR/src/gateway/community/main.py" -c "$CONFIG_DIR" --mode "$APP_MODE" >> "$LOG_FILE" 2>&1 &
+        SERVER_ENV="$env_name" start_detached "$VENV_DIR/bin/python" \
+            "$WORK_DIR/src/gateway/community/main.py" -c "$CONFIG_DIR" --mode "$APP_MODE"
     fi
 
     APP_PID=$!

--- a/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
+++ b/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
@@ -7,6 +7,7 @@ from gateway.community.plugins.auth.stub import StubAuthPlugin
 from gateway.community.plugins.authn.access_key_token import AccessKeyTokenStrategy
 from gateway.community.plugins.authn.app_token import AppTokenStrategy
 from gateway.community.plugins.authn.bot_token import BotTokenStrategy
+from gateway.community.plugins.authn.dev_cookie import DevCookieUserStrategy
 from gateway.community.plugins.authn.google_token import GoogleUserStrategy
 from gateway.community.plugins.cache.in_memory import InMemoryCachePlugin
 from gateway.community.plugins.database.sqlite import SqliteDatabasePlugin
@@ -74,6 +75,8 @@ class PluginContainer(containers.DeclarativeContainer):
             "https://openidconnect.googleapis.com/v1/userinfo",
         ),
     )
+    dev_cookie_strategy = providers.Singleton(DevCookieUserStrategy)
+
     bot_token_strategy = providers.Singleton(
         BotTokenStrategy,
         registry=bot_registry,
@@ -107,6 +110,7 @@ class PluginContainer(containers.DeclarativeContainer):
     # (bootstrap/_authn.py), so without the env var it is never even imported.
     authn_strategies = providers.Dict(
         google=google_strategy,
+        dev_cookie=dev_cookie_strategy,
         bot_token=bot_token_strategy,
         app_token=app_token_strategy,
         access_key_token=access_key_token_strategy,

--- a/src/gateway/src/gateway/community/plugins/authn/dev_cookie/__init__.py
+++ b/src/gateway/src/gateway/community/plugins/authn/dev_cookie/__init__.py
@@ -1,0 +1,5 @@
+"""Development cookie authn strategy."""
+
+from ._strategy import DevCookieUserStrategy
+
+__all__ = ["DevCookieUserStrategy"]

--- a/src/gateway/src/gateway/community/plugins/authn/dev_cookie/_strategy.py
+++ b/src/gateway/src/gateway/community/plugins/authn/dev_cookie/_strategy.py
@@ -1,0 +1,54 @@
+"""Development cookie authn strategy for local browser-based integration.
+
+This strategy is intentionally inert outside local/dev/test environments. It lets
+local frontends that already carry an internal ``staff_id`` cookie exercise the
+public OpenAPI gateway path without requiring a Google OAuth token.
+"""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import unquote
+
+from gateway.community.spi.auth import AuthenticatedUser
+from gateway.community.spi.authn import CredentialBundle, Principal, PrincipalType, UserPrincipal
+
+
+class DevCookieUserStrategy:
+    """Resolve a local developer user from an internal staff-id cookie."""
+
+    name = "dev_cookie"
+    principal_type = PrincipalType.USER
+
+    def __init__(
+        self,
+        *,
+        staff_id_cookie: str = "staff_id",
+        fallback_staff_id_cookie: str = "__TRACERT_COOKIE_bucUserId",
+        nick_name_cookie: str = "nick_name",
+        enabled_envs: tuple[str, ...] = ("local", "dev", "test"),
+    ) -> None:
+        self._staff_id_cookie = staff_id_cookie
+        self._fallback_staff_id_cookie = fallback_staff_id_cookie
+        self._nick_name_cookie = nick_name_cookie
+        self._enabled_envs = {env.lower() for env in enabled_envs}
+
+    async def build(self, creds: CredentialBundle) -> Principal | None:
+        if os.getenv("SERVER_ENV", "").strip().lower() not in self._enabled_envs:
+            return None
+
+        staff_id = (
+            creds.cookies.get(self._staff_id_cookie)
+            or creds.cookies.get(self._fallback_staff_id_cookie)
+            or ""
+        ).strip()
+        if not staff_id:
+            return None
+
+        display_name = unquote(creds.cookies.get(self._nick_name_cookie, "")).strip() or staff_id
+        subject = AuthenticatedUser(
+            id=staff_id,
+            username=staff_id,
+            display_name=display_name,
+        )
+        return UserPrincipal(subject=subject)

--- a/src/gateway/tests/unit/plugins/test_dev_cookie_strategy.py
+++ b/src/gateway/tests/unit/plugins/test_dev_cookie_strategy.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from gateway.community.plugins.authn.dev_cookie import DevCookieUserStrategy
+from gateway.community.spi.authn import CredentialBundle, PrincipalType
+
+
+@pytest.mark.asyncio
+async def test_dev_cookie_strategy_builds_user_from_staff_cookie(monkeypatch) -> None:
+    monkeypatch.setenv("SERVER_ENV", "local")
+    strategy = DevCookieUserStrategy()
+
+    principal = await strategy.build(
+        CredentialBundle(
+            headers={},
+            cookies={"staff_id": "334018", "nick_name": "%E5%BC%80%E5%8F%91%E8%80%85"},
+            query={},
+        )
+    )
+
+    assert principal is not None
+    assert principal.type is PrincipalType.USER
+    assert principal.subject.id == "334018"
+    assert principal.subject.username == "334018"
+    assert principal.subject.display_name == "开发者"
+
+
+@pytest.mark.asyncio
+async def test_dev_cookie_strategy_is_inert_outside_enabled_envs(monkeypatch) -> None:
+    monkeypatch.setenv("SERVER_ENV", "prod")
+    strategy = DevCookieUserStrategy()
+
+    principal = await strategy.build(
+        CredentialBundle(headers={}, cookies={"staff_id": "334018"}, query={})
+    )
+
+    assert principal is None


### PR DESCRIPTION
 ## Summary

  This PR enables local gateway cookie authentication for the harness OpenAPI surface.

  It keeps the change scoped to the local development authentication path and avoids carrying unrelated changes from other merged branches.

  ## Changes

  - Add a development cookie authentication strategy for local gateway requests.
  - Register the dev cookie auth plugin in the gateway plugin bootstrap.
  - Enable local gateway configuration for cookie-based user identity resolution.
  - Update gateway startup/module scripts to load the local auth configuration.
  - Add unit tests for the dev cookie authentication strategy.

  ## Scope

  This PR only includes the harness-related local gateway authentication fix.

  It does not include unrelated changes from `dev` or other merged branches.

  ## Validation

  - Ran gateway unit test:

  ```bash
  cd src/gateway
  uv run pytest tests/unit/plugins/test_dev_cookie_strategy.py

  Result:

  2 passed
