### PR TITLE
chore(baas): disable ARCA sandbox TTL renew timer in community default

### DIFF
--- a/src/baas/configs/application.yaml
+++ b/src/baas/configs/application.yaml
@@ -124,8 +124,9 @@ user_config:
     base_url: "https://oauth.example.com"
 
   # 设备 TTL 定时器配置（每 30 分钟扫描整个到期队列并续期+探活）
+  # ARCA 沙箱 TTL 续期为企业版能力：社区版默认关闭此定时任务（enabled: false）。
   device_ttl_timer:
-    enabled: true  # 是否启用定时任务
+    enabled: false  # 社区版禁用 ARCA 沙箱 TTL 续期定时任务；企业 overlay 置 true
     cron_interval_seconds: 1800  # 执行间隔（秒），默认: 1800（30分钟）
     batch_size: 100  # 每页拉取条数，默认: 100
     max_page_concurrency: 10  # 每页内并发续期的最大并发数

--- a/src/baas/singlebox-configs/application.yaml
+++ b/src/baas/singlebox-configs/application.yaml
@@ -103,8 +103,9 @@ user_config:
     base_url: "https://oauth.example.com"
 
   # 设备 TTL 定时器配置（每 30 分钟扫描整个到期队列并续期+探活）
+  # ARCA 沙箱 TTL 续期为企业版能力：社区版默认关闭此定时任务（enabled: false）。
   device_ttl_timer:
-    enabled: true  # 是否启用定时任务
+    enabled: false  # 社区版禁用 ARCA 沙箱 TTL 续期定时任务
     cron_interval_seconds: 1800  # 执行间隔（秒），默认: 1800（30分钟）
     batch_size: 100  # 每页拉取条数，默认: 100
     max_page_concurrency: 10  # 每页内并发续期的最大并发数


### PR DESCRIPTION
## Problem

The `device_ttl_timer` scheduled task (which scans the expiry queue every 30 minutes and renews + probes ARCA sandboxes) is enabled by default in the community config. ARCA sandbox TTL renewal is an enterprise edition feature and should not run in community builds.

## Solution

Set `device_ttl_timer.enabled: false` as the community default in:
- `src/baas/configs/application.yaml`
- `src/baas/singlebox-configs/application.yaml`

Enterprise overlays that need this behavior can override `enabled: true`.

## Validation
Config-only change; reviewed the two YAML deltas. No runtime tests run (configuration flag only).

## Compatibility and risk
- Rollback: revert to `enabled: true`.
- Enterprise overlays that rely on the timer must explicitly set `enabled: true` going forward.