### PR TITLE
feat(bcs-app-session): emit join/left system messages on openapi participant add/remove

### DIFF
--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -912,6 +912,41 @@ impl SessionService for SessionServiceImpl {
             .add_participant(&command.session_id, participant)
             .await
             .map_err(map_session_error)?;
+        // Emit a `BotJoined` system message so the newly added participant (and
+        // the rest of the session) receives the join notification — mirroring
+        // the legacy `bcs_http::routes::sessions::add_session_participant` path,
+        // which the OpenAPI route previously lacked. Best-effort: a dispatch
+        // failure is logged and never surfaces to the caller.
+        if let Some(actor) = updated
+            .participants
+            .iter()
+            .find(|p| p.bot_uuid == command.bot_uuid)
+            .cloned()
+        {
+            let event = SystemMessageEvent::BotJoined {
+                group_id: updated.group_id.clone(),
+                actor,
+                session_id: command.session_id.clone(),
+                session_input: updated.input.clone(),
+            };
+            if let Err(error) = self
+                .system_message
+                .notify(
+                    &updated.group_id,
+                    event,
+                    &command.session_id,
+                    &updated.participants,
+                )
+                .await
+            {
+                tracing::warn!(
+                    session_id = %command.session_id,
+                    bot_uuid = %command.bot_uuid,
+                    error = %error,
+                    "notify bot joined failed"
+                );
+            }
+        }
         self.backfill_and_project_participant(&mut updated.participants, &command.bot_uuid)
             .await
     }
@@ -1071,20 +1106,52 @@ impl SessionService for SessionServiceImpl {
         let (session, _) = self
             .load_session_for_manage(&principal, &command.session_id)
             .await?;
+        // Capture the participant being removed (its real role/mode/actor_kind)
+        // before the mutation so the `BotLeft` event carries accurate identity
+        // — the legacy `remove_session_participant` hardcodes `Observer`/`None`.
+        let removed = session
+            .participants
+            .iter()
+            .find(|p| p.bot_uuid == command.bot_uuid)
+            .cloned();
         // Idempotent: if the target is not a current participant, return
         // `deleted: false` without invoking the legacy removal (which would
         // surface a `SessionInvalidParams` "not in session" error otherwise).
-        let present = session
-            .participants
-            .iter()
-            .any(|p| p.bot_uuid == command.bot_uuid);
-        if !present {
+        if removed.is_none() {
             return Ok(DeleteResult { deleted: false });
         }
-        self.sessions
+        let updated = self
+            .sessions
             .remove_participant(&command.session_id, &command.bot_uuid)
             .await
             .map_err(map_session_error)?;
+        // Emit a `BotLeft` system message so the remaining participants receive
+        // the leave notification — mirroring the legacy
+        // `remove_session_participant` path, which the OpenAPI route lacked.
+        // Best-effort: a dispatch failure is logged and never surfaces.
+        if let Some(actor) = removed {
+            let event = SystemMessageEvent::BotLeft {
+                group_id: updated.group_id.clone(),
+                actor,
+            };
+            if let Err(error) = self
+                .system_message
+                .notify(
+                    &updated.group_id,
+                    event,
+                    &command.session_id,
+                    &updated.participants,
+                )
+                .await
+            {
+                tracing::warn!(
+                    session_id = %command.session_id,
+                    bot_uuid = %command.bot_uuid,
+                    error = %error,
+                    "notify bot left failed"
+                );
+            }
+        }
         Ok(DeleteResult { deleted: true })
     }
 }

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -2101,6 +2101,123 @@ async fn update_participant_emits_mode_changed_system_message_only_on_change() {
     );
 }
 
+#[tokio::test]
+async fn add_participant_emits_bot_joined_system_message() {
+    let fixture = Fixture::new().await;
+    for bot in ["driver", "expert"] {
+        fixture.add_bot(bot).await;
+    }
+    fixture.store_group("g1", "driver", None).await;
+    let outcome = create_session(
+        &fixture,
+        bot_principal("driver"),
+        "g1",
+        "driver",
+        vec![],
+        None,
+        None,
+    )
+    .await;
+    let session_id = outcome.session.session_id.clone();
+
+    // Adding a participant must emit a BotJoined notification (parity with the
+    // legacy `add_session_participant` route).
+    fixture
+        .service
+        .add_participant(AddSessionParticipant {
+            caller: bot_principal("driver"),
+            session_id: session_id.clone(),
+            bot_uuid: "expert".into(),
+        })
+        .await
+        .expect("add expert");
+
+    let joined = recorded_bot_joined(&fixture, &session_id);
+    assert_eq!(joined.len(), 1, "exactly one BotJoined event");
+    assert_eq!(joined[0], "expert");
+
+    // A duplicate add is a conflict and must NOT emit another event.
+    let error = fixture
+        .service
+        .add_participant(AddSessionParticipant {
+            caller: bot_principal("driver"),
+            session_id: session_id.clone(),
+            bot_uuid: "expert".into(),
+        })
+        .await
+        .expect_err("duplicate add should conflict");
+    assert_eq!(error.code(), "participant_already_exists");
+    assert_eq!(
+        recorded_bot_joined(&fixture, &session_id).len(),
+        1,
+        "no new event on duplicate add"
+    );
+}
+
+#[tokio::test]
+async fn delete_participant_emits_bot_left_system_message() {
+    let fixture = Fixture::new().await;
+    for bot in ["driver", "expert"] {
+        fixture.add_bot(bot).await;
+    }
+    fixture.store_group("g1", "driver", None).await;
+    let outcome = create_session(
+        &fixture,
+        bot_principal("driver"),
+        "g1",
+        "driver",
+        vec![],
+        None,
+        None,
+    )
+    .await;
+    let session_id = outcome.session.session_id.clone();
+    fixture
+        .service
+        .add_participant(AddSessionParticipant {
+            caller: bot_principal("driver"),
+            session_id: session_id.clone(),
+            bot_uuid: "expert".into(),
+        })
+        .await
+        .expect("add expert");
+
+    // Removing a participant must emit a BotLeft notification (parity with the
+    // legacy `remove_session_participant` route).
+    let removed = fixture
+        .service
+        .delete_participant(DeleteSessionParticipant {
+            caller: bot_principal("driver"),
+            session_id: session_id.clone(),
+            bot_uuid: "expert".into(),
+        })
+        .await
+        .expect("delete expert");
+    assert!(removed.deleted);
+
+    let left = recorded_bot_left(&fixture, &session_id);
+    assert_eq!(left.len(), 1, "exactly one BotLeft event");
+    assert_eq!(left[0], "expert");
+
+    // Removing an already-absent participant is idempotent and must NOT emit
+    // another event.
+    let again = fixture
+        .service
+        .delete_participant(DeleteSessionParticipant {
+            caller: bot_principal("driver"),
+            session_id: session_id.clone(),
+            bot_uuid: "expert".into(),
+        })
+        .await
+        .expect("idempotent delete");
+    assert!(!again.deleted);
+    assert_eq!(
+        recorded_bot_left(&fixture, &session_id).len(),
+        1,
+        "no new event on idempotent delete"
+    );
+}
+
 /// Collect `ParticipantModeChanged` events recorded for `session_id`.
 fn recorded_mode_changes(
     fixture: &Fixture,
@@ -2125,6 +2242,38 @@ fn recorded_mode_changes(
             } else {
                 None
             }
+        })
+        .collect()
+}
+
+/// Collect `BotJoined` actor ids recorded for `session_id`.
+fn recorded_bot_joined(fixture: &Fixture, session_id: &str) -> Vec<String> {
+    fixture
+        .system_messages
+        .events
+        .lock()
+        .expect("sysmsg lock")
+        .iter()
+        .filter(|recorded| recorded.session_id == session_id)
+        .filter_map(|recorded| match &recorded.event {
+            SystemMessageEvent::BotJoined { actor, .. } => Some(actor.bot_uuid.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Collect `BotLeft` actor ids recorded for `session_id`.
+fn recorded_bot_left(fixture: &Fixture, session_id: &str) -> Vec<String> {
+    fixture
+        .system_messages
+        .events
+        .lock()
+        .expect("sysmsg lock")
+        .iter()
+        .filter(|recorded| recorded.session_id == session_id)
+        .filter_map(|recorded| match &recorded.event {
+            SystemMessageEvent::BotLeft { actor, .. } => Some(actor.bot_uuid.clone()),
+            _ => None,
         })
         .collect()
 }


### PR DESCRIPTION
## Problem

The OpenAPI v1 session-participant endpoints did not notify participants of membership changes, while the legacy `bcs_http` routes did:

- `POST /openapi/v1/collaboration/sessions/{session_id}/participants` (add) → `SessionServiceImpl::add_participant` emitted **no** system message; legacy `add_session_participant` emits `BotJoined`.
- `DELETE /openapi/v1/collaboration/sessions/{session_id}/participants/{bot_uuid}` (remove) → `SessionServiceImpl::delete_participant` emitted **no** system message; legacy `remove_session_participant` emits `BotLeft`.

So members joining/leaving via the OpenAPI surface went unnoticed by the rest of the session.

## Solution

Emit the matching system messages from the application facade (use-case orchestration layer), mirroring the legacy endpoints. The `system_message` dependency is already on `SessionServiceImpl` (merged via #1212).

`crates/application/v1/bcs-app-session/src/lib.rs`:

- `add_participant`: after a successful `add_participant`, emit `BotJoined { group_id, actor, session_id, session_input }`, taking `actor` from the updated session's newly added participant.
- `delete_participant`: capture the participant being removed (with its real role/mode/actor_kind — more accurate than the legacy path, which hardcodes `Observer`/`None`) before the mutation, then after a successful `remove_participant` emit `BotLeft { group_id, actor }`. The idempotent path (participant already absent, `deleted: false`) emits nothing.

Both dispatches are best-effort: failures are logged via `tracing::warn!` and never surface to the caller, consistent with the existing `update_participant` → `ParticipantModeChanged` behavior.

The route handlers and OpenAPI response contracts are unchanged — these are side effects, not response-shape changes.

## Validation

- `cargo build -p bcs` ✅
- `cargo test -p bcs-app-session --test v1_session_service` ✅ (67 passed)
- `cargo test -p bcs-api-http --test session_routes` ✅ (34 passed)
- New `add_participant_emits_bot_joined_system_message`: adding `expert` emits exactly one `BotJoined` (`actor == expert`); a duplicate add returns `participant_already_exists` with no new event.
- New `delete_participant_emits_bot_left_system_message`: removing `expert` emits exactly one `BotLeft` (`actor == expert`); an idempotent re-remove returns `deleted: false` with no new event.