### PR TITLE
fix(bcs-session): allow group originator to leave a session

### DIFF
--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -2218,6 +2218,89 @@ async fn delete_participant_emits_bot_left_system_message() {
     );
 }
 
+#[tokio::test]
+async fn delete_participant_allows_removing_group_originator() {
+    let fixture = Fixture::new().await;
+    fixture.add_bot("driver").await;
+    // Group whose originator is the human `human_owner-1` (distinct from the
+    // driver bot). The originator is a session participant and must be allowed
+    // to leave the session — only the driver/manager are structurally pinned.
+    fixture
+        .store_group_with_originator("g1", "driver", "human_owner-1", None)
+        .await;
+    let group = fixture.groups.get("g1").await.expect("group exists");
+    let session = fixture
+        .session_repo
+        .create(
+            "g1",
+            NewSessionParams {
+                participants: vec![
+                    Participant::bot("driver", ParticipantRole::Driver),
+                    Participant::human("human_owner-1", ParticipantRole::Observer),
+                ],
+                group_version: Some(group.version),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("seed Session");
+
+    let removed = fixture
+        .service
+        .delete_participant(DeleteSessionParticipant {
+            caller: human_principal("owner-1"),
+            session_id: session.id.clone(),
+            bot_uuid: "human_owner-1".into(),
+        })
+        .await
+        .expect("originator can leave the session");
+    assert!(removed.deleted);
+    let left = recorded_bot_left(&fixture, &session.id);
+    assert_eq!(left.len(), 1);
+    assert_eq!(left[0], "human_owner-1");
+}
+
+#[tokio::test]
+async fn delete_participant_still_rejects_group_driver() {
+    let fixture = Fixture::new().await;
+    fixture.add_bot("driver").await;
+    fixture
+        .store_group_with_originator("g1", "driver", "human_owner-1", None)
+        .await;
+    let group = fixture.groups.get("g1").await.expect("group exists");
+    let session = fixture
+        .session_repo
+        .create(
+            "g1",
+            NewSessionParams {
+                participants: vec![
+                    Participant::bot("driver", ParticipantRole::Driver),
+                    Participant::human("human_owner-1", ParticipantRole::Observer),
+                ],
+                group_version: Some(group.version),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("seed Session");
+
+    let error = fixture
+        .service
+        .delete_participant(DeleteSessionParticipant {
+            caller: human_principal("owner-1"),
+            session_id: session.id.clone(),
+            bot_uuid: "driver".into(),
+        })
+        .await
+        .expect_err("driver remains pinned");
+    assert!(
+        matches!(error, bcs_service_api::application::v1::ApplicationError::InvalidInput { .. }),
+        "expected invalid_request, got {error:?}"
+    );
+    // No leave event when removal is rejected.
+    assert!(recorded_bot_left(&fixture, &session.id).is_empty());
+}
+
 /// Collect `ParticipantModeChanged` events recorded for `session_id`.
 fn recorded_mode_changes(
     fixture: &Fixture,

--- a/src/bcs/crates/services/bcs-session/src/application.rs
+++ b/src/bcs/crates/services/bcs-session/src/application.rs
@@ -375,9 +375,14 @@ impl SessionManagementService for SessionManagementServiceImpl {
             .ok_or_else(|| SessionUseCaseError::NotFound(session_id.to_string()))?;
 
         if let Some(group) = self.group_repo.get(&session.group_id).await {
-            if bot_uuid == group.driver_bot || Some(bot_uuid.to_string()) == group.originator {
+            // The group driver (and, for ManagerWorker, the Manager) is
+            // structurally required and cannot be removed from a session. The
+            // group originator/coordinator, however, may leave a session —
+            // session membership is session-scoped and does not affect the
+            // group's coordination structure.
+            if bot_uuid == group.driver_bot {
                 return Err(SessionUseCaseError::InvalidParams(
-                    "Cannot remove the group driver/coordinator from a session".to_string(),
+                    "Cannot remove the group driver from a session".to_string(),
                 ));
             }
 


### PR DESCRIPTION
## Problem

Removing a group's originator (coordinator) from a session fails with:

```
Cannot remove the group driver/coordinator from a session
```

even though the originator is neither the group driver nor the ManagerWorker manager. This blocks the human originator (typically `human_{staff_no}`) from ever leaving a session of their own group via either the OpenAPI or legacy `remove_session_participant` path.

### Root cause

`SessionManagementServiceImpl::remove_participant` (bcs-session/src/application.rs) rejected removal whenever the target equaled `group.driver_bot` **or `group.originator`**. The originator check was over-broad: session membership is session-scoped, and removing the originator from a session does not alter the group's coordination structure. Both HTTP entry points delegate to this shared core service, so both were affected. (This is pre-existing behavior, not a regression from the recent join/left system-message work.)

## Solution

Drop the `group.originator` clause from the session-level removal guard. Keep the structural protections intact:

- `group.driver_bot` is still rejected (`"Cannot remove the group driver from a session"`).
- ManagerWorker `Manager` is still rejected (unchanged, separate branch).

The group-level member-removal guard (`bcs-group/src/application/management.rs`) is untouched — the originator still cannot be removed from the **group**, only from an individual **session**, which is the intended session-scoped behavior.

## Validation

- `cargo build -p bcs` ✅
- `cargo test -p bcs-app-session --test v1_session_service` ✅ (69 passed)
- `cargo test -p bcs-session` ✅
- `cargo test -p bcs-group --test management` ✅ (76 passed — group-level guard unaffected)
- `cargo test -p bcs-http --test session_members_contract` ✅ (7 passed — driver-removal protection intact)
- New `delete_participant_allows_removing_group_originator`: originator `human_owner-1` (a session participant, distinct from the driver bot) is removable; `deleted: true` and a `BotLeft` event fires.
- New `delete_participant_still_rejects_group_driver`: removing the driver bot is still rejected with `InvalidInput`; no `BotLeft` event.