### PR TITLE
fix(bcs): classify spaced timeout text

### DIFF
--- a/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
@@ -1185,7 +1185,9 @@ fn direct_chat_service_error_reason(error: &ServiceError) -> DirectChatRunReason
 }
 
 fn is_timeout_text(normalized: &str) -> bool {
-    normalized.contains("timeout") || normalized.contains("timed out")
+    normalized.contains("timeout")
+        || normalized.contains("timed out")
+        || normalized.contains("time out")
 }
 
 fn ensure_run_owner(record: &ChatRunRecord, from_bot_id: &str) -> ServiceResult<()> {
@@ -1350,6 +1352,10 @@ mod tests {
         );
         assert_eq!(
             direct_chat_failure_reason("Agent response timed out before completion."),
+            DirectChatRunReason::Timeout
+        );
+        assert_eq!(
+            direct_chat_failure_reason("executor safety-net: time out"),
             DirectChatRunReason::Timeout
         );
         assert_eq!(


### PR DESCRIPTION
## Problem

  BCS direct single-chat failure metrics were showing unexpected `internal_error`
  spikes for `bcs_cli` runs around 2026-08-20 noon.

  Log investigation showed provider callbacks with terminal error text like:

  `executor safety-net: time out`

  The direct-chat failure reason classifier recognized `timeout` and `timed out`,
  but did not recognize the spaced form `time out`. As a result, these timeout
  failures fell through to `DirectChatRunReason::InternalError` and were emitted
  as `reason="internal_error"` in `bcs_direct_chat_run_events_total`.

  ## Solution

  Update the direct-chat timeout text classifier to also recognize `time out`.

  Add a regression assertion covering the observed provider callback text:

  `executor safety-net: time out`

  This keeps the existing legacy handling for `timeout` and `timed out` unchanged.

  ## Validation

  Ran the focused regression test:

  ```bash
  cargo test --package bcs-message-flow direct_chat_failure_reason_maps_legacy_bot_error_text

  Result: passed.

  Ran the full package test suite:

  cargo test --package bcs-message-flow

  Result: passed.