### PR TITLE
fix(gateway): answer browser CORS at the gateway edge

### DIFF
--- a/src/gateway/README.md
+++ b/src/gateway/README.md
@@ -159,10 +159,16 @@ user_config:
 
 Responses carry `Access-Control-Allow-Credentials: true`, because a browser call
 through the gateway carries the cookie or `Authorization` header it
-authenticates with. Browsers reject a `"*"` origin on such a response, so every
-origin must be listed exactly or matched by a regex (matched against the whole
-origin — scheme, host and port). An overlay replaces a list rather than
-extending it.
+authenticates with. Every origin must therefore be listed exactly or matched by a
+regex (matched against the whole origin — scheme, host and port; each pattern is
+compiled on its own, so a pattern's inline flags apply to that pattern alone).
+`allow_origins: ["*"]` is refused at load time — with credentials enabled a
+wildcard silently admits every origin rather than failing loudly. An overlay
+replaces a list rather than extending it.
+
+A 500 that escapes the app is answered by Starlette above every installed
+middleware, so `install_cors` also registers the handler that stamps the origin
+on it; otherwise a browser would report a server error as a CORS failure.
 
 ## CI & Testing
 

--- a/src/gateway/README.md
+++ b/src/gateway/README.md
@@ -164,10 +164,11 @@ regex (matched against the whole origin — scheme, host and port; each pattern 
 compiled on its own, so a pattern's inline flags apply to that pattern alone).
 `allow_origins: ["*"]` is refused at load time — with credentials enabled a
 wildcard silently admits every origin rather than failing loudly — and so is a
-catch-all regex such as `.*` or `https://.*`, which reaches the same place; pin
-the host suffix the environment serves. A malformed regex is refused there too,
-naming the entry, rather than taking the gateway down at boot. An overlay
-replaces a list rather than extending it.
+catch-all regex, whichever scheme or port it names (`.*`, `https://.*`,
+`http://.*`, `https://.*:8443`), since all of them reach the same place. Pin the
+host: `http://localhost:[0-9]+` is accepted, `http://.*` is not. A malformed
+regex is refused there too, naming the entry, rather than taking the gateway
+down at boot. An overlay replaces a list rather than extending it.
 
 A 500 that escapes the app is answered by Starlette above every installed
 middleware, so `install_cors` also registers the handler that stamps the origin

--- a/src/gateway/README.md
+++ b/src/gateway/README.md
@@ -136,6 +136,34 @@ The gateway starts on port 8888 by default and exposes:
 - `http://127.0.0.1:8888/docs` — OpenAPI documentation (when enabled)
 - `http://127.0.0.1:8888/api/test` — connectivity test endpoint
 
+## Browser Access (CORS)
+
+The gateway is the origin a browser talks to, so it answers CORS itself: a
+cross-origin page sends a credential-less `OPTIONS` preflight, and that request
+is answered by the edge middleware before routing, `route_security`, or any
+upstream sees it. An upstream's own CORS headers are stripped on the way back,
+so exactly one `Access-Control-Allow-Origin` reaches the browser — the edge's.
+
+Origins are configuration, not code. Add a deployment's frontend origins to the
+`user_config.cors` block of its `application-<env>.yaml` overlay (selected by
+`SERVER_ENV`); the shipped `configs/application.yaml` allows only localhost:
+
+```yaml
+user_config:
+  cors:
+    allow_origins:
+      - "https://your-frontend.example.com"
+    allow_origin_regex:
+      - "https://[a-z0-9-]+\\.preview\\.example\\.com"
+```
+
+Responses carry `Access-Control-Allow-Credentials: true`, because a browser call
+through the gateway carries the cookie or `Authorization` header it
+authenticates with. Browsers reject a `"*"` origin on such a response, so every
+origin must be listed exactly or matched by a regex (matched against the whole
+origin — scheme, host and port). An overlay replaces a list rather than
+extending it.
+
 ## CI & Testing
 
 ```bash

--- a/src/gateway/README.md
+++ b/src/gateway/README.md
@@ -163,7 +163,10 @@ authenticates with. Every origin must therefore be listed exactly or matched by 
 regex (matched against the whole origin — scheme, host and port; each pattern is
 compiled on its own, so a pattern's inline flags apply to that pattern alone).
 `allow_origins: ["*"]` is refused at load time — with credentials enabled a
-wildcard silently admits every origin rather than failing loudly. An overlay
+wildcard silently admits every origin rather than failing loudly — and so is a
+catch-all regex such as `.*` or `https://.*`, which reaches the same place; pin
+the host suffix the environment serves. A malformed regex is refused there too,
+naming the entry, rather than taking the gateway down at boot. An overlay
 replaces a list rather than extending it.
 
 A 500 that escapes the app is answered by Starlette above every installed

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -102,6 +102,43 @@ user_config:
     engine_proxy_server_url: https://engineproxy.sample.com
     bcsfuse_server_url: http://127.0.0.1:8765
 
+  # Browser CORS allow-list for the gateway's own edge.
+  #
+  # A page on another origin cannot call the gateway without it: the browser
+  # sends a credential-less `OPTIONS` preflight first and refuses to send the
+  # real request unless the answer carries `Access-Control-Allow-Origin`. That
+  # preflight is answered by the gateway itself, before routing and before
+  # `route_security` — an upstream's own allow-list governs callers that reach
+  # that component directly and cannot speak for this address.
+  #
+  # The gateway answers with `Access-Control-Allow-Credentials: true`, because a
+  # browser call through it carries the cookie or `Authorization` header it
+  # authenticates with. Browsers refuse a `"*"` origin on such a response, so
+  # every origin must be listed exactly or matched by `allow_origin_regex`
+  # (Python regex, matched against the whole origin — scheme, host and port).
+  #
+  # Neutral default = localhost only, so a single-box UI works out of the box.
+  # A deployment adds its own frontend origins in its `application-<env>.yaml`
+  # overlay (selected by `SERVER_ENV`), e.g.:
+  #
+  #   user_config:
+  #     cors:
+  #       allow_origins:
+  #         - "https://your-frontend.example.com"
+  #       allow_origin_regex:
+  #         - "https://[a-z0-9-]+\\.preview\\.example\\.com"
+  #
+  # An overlay REPLACES a list rather than extending it, so repeat any localhost
+  # origin the environment still needs.
+  cors:
+    allow_origins:
+      - "http://localhost"
+      - "http://localhost:3000"
+      - "http://localhost:8000"
+      - "http://localhost:8080"
+      - "http://localhost:8888"
+    allow_origin_regex: []
+
   # Per-identity strategy chain (system-level config).
   # Each identity type runs its strategies in order; the first to recognise the
   # credential wins (design §5). Flavor-specific verification backends are wired

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -118,7 +118,9 @@ user_config:
   # scheme, host and port — and compiled on its own, so its own inline flags
   # apply to it alone). `allow_origins: ["*"]` is REFUSED at load time: with
   # credentials enabled a wildcard does not fail loudly, it silently admits
-  # every origin on the internet to credentialed calls.
+  # every origin on the internet to credentialed calls. A catch-all regex
+  # (`.*`, `https://.*`) is refused for the same reason — pin the scheme and the
+  # host suffix the environment actually serves.
   #
   # Neutral default = localhost only, so a single-box UI works out of the box.
   # A deployment adds its own frontend origins in its `application-<env>.yaml`

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -118,9 +118,11 @@ user_config:
   # scheme, host and port — and compiled on its own, so its own inline flags
   # apply to it alone). `allow_origins: ["*"]` is REFUSED at load time: with
   # credentials enabled a wildcard does not fail loudly, it silently admits
-  # every origin on the internet to credentialed calls. A catch-all regex
-  # (`.*`, `https://.*`) is refused for the same reason — pin the scheme and the
-  # host suffix the environment actually serves.
+  # every origin on the internet to credentialed calls. A catch-all regex is
+  # refused for the same reason, whichever scheme or port it names (`.*`,
+  # `https://.*`, `http://.*`, `https://.*:8443`) — pin the host suffix the
+  # environment actually serves. `http://localhost:[0-9]+` pins a host and is
+  # accepted; `http://.*` does not and is not.
   #
   # Neutral default = localhost only, so a single-box UI works out of the box.
   # A deployment adds its own frontend origins in its `application-<env>.yaml`

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -113,9 +113,12 @@ user_config:
   #
   # The gateway answers with `Access-Control-Allow-Credentials: true`, because a
   # browser call through it carries the cookie or `Authorization` header it
-  # authenticates with. Browsers refuse a `"*"` origin on such a response, so
-  # every origin must be listed exactly or matched by `allow_origin_regex`
-  # (Python regex, matched against the whole origin — scheme, host and port).
+  # authenticates with. Every origin must therefore be listed exactly or matched
+  # by `allow_origin_regex` (a Python regex, matched against the WHOLE origin —
+  # scheme, host and port — and compiled on its own, so its own inline flags
+  # apply to it alone). `allow_origins: ["*"]` is REFUSED at load time: with
+  # credentials enabled a wildcard does not fail loudly, it silently admits
+  # every origin on the internet to credentialed calls.
   #
   # Neutral default = localhost only, so a single-box UI works out of the box.
   # A deployment adds its own frontend origins in its `application-<env>.yaml`

--- a/src/gateway/src/gateway/community/adapters/web/_cors.py
+++ b/src/gateway/src/gateway/community/adapters/web/_cors.py
@@ -1,0 +1,106 @@
+"""Browser CORS for the gateway's own edge.
+
+A browser calling ``https://<gateway>/openapi/v1/...`` from a page served by a
+different origin sends a **preflight** first: ``OPTIONS``, no cookie, no
+``Authorization`` header — the browser strips credentials from that request by
+design — and it reads only the ``Access-Control-*`` headers of the answer. If
+the answer carries no ``Access-Control-Allow-Origin``, the real request is never
+sent and the page sees "blocked by CORS policy" rather than any status the
+gateway returned.
+
+Which is why this lives at the gateway rather than in an upstream:
+
+* The preflight cannot authenticate. Everything the catch-all forward does —
+  domain resolution, ``Authenticator.authenticate``, signing a principal — is
+  work a credential-less request cannot pass on any route whose
+  ``route_security`` names a required identity, and a 401 carries no
+  ``Access-Control-Allow-Origin``.
+* The address a browser is configured with is the *gateway's*. An upstream's
+  own allow-list governs callers that reach that component directly; it cannot
+  speak for an origin pair it never sees, and it differs per upstream, so which
+  endpoints a browser could reach would depend on which component happens to
+  serve them.
+
+The middleware is installed **outermost** (added last in ``create_app``), so a
+preflight is answered here and never reaches the forward route at all. The
+edge being the CORS authority also means an upstream's own CORS headers must
+not travel back through the gateway — two ``Access-Control-Allow-Origin``
+values in one response is an error a browser reports the same way as none.
+:data:`CORS_RESPONSE_HEADERS` is what the forwarder strips to keep that true.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from starlette.middleware.cors import CORSMiddleware
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from gateway.community.config import CorsConfig
+
+#: Response headers cross-origin JavaScript may read beyond the CORS-safelisted
+#: set. The backend stamps ``Deprecation`` / ``Sunset`` on legacy addresses
+#: (``adapters/http/openapi_v1/middleware.py``) and exposes them itself; through
+#: the gateway that exposure has to be re-declared here, because the edge owns
+#: every ``Access-Control-*`` header the browser ends up seeing. Not a
+#: deployment choice — the surface either lets a browser SDK learn that its
+#: address is retiring, or it does not — so it is not in ``CorsConfig``.
+EXPOSED_HEADERS = ("Deprecation", "Sunset")
+
+#: The response headers whose value the edge decides. Stripped from every
+#: upstream response by the forwarder, so the middleware's copy is the only one
+#: on the wire; a browser rejects a response carrying two of them exactly as it
+#: rejects one carrying none.
+CORS_RESPONSE_HEADERS = frozenset(
+    {
+        "access-control-allow-origin",
+        "access-control-allow-credentials",
+        "access-control-allow-methods",
+        "access-control-allow-headers",
+        "access-control-expose-headers",
+        "access-control-max-age",
+        "access-control-allow-private-network",
+    }
+)
+
+
+def _combined_origin_regex(patterns: list[str]) -> str | None:
+    """The configured patterns as one alternation, or ``None`` for an empty list.
+
+    Starlette takes a single regex and matches it with ``fullmatch``; the config
+    takes a list, because an environment's origins are several unrelated shapes
+    and one line per shape is what a reviewer can read. Each pattern is wrapped
+    in a non-capturing group so an alternation *inside* a pattern cannot swallow
+    the ones after it, and so ``fullmatch`` still anchors each alternative.
+    """
+    if not patterns:
+        return None
+    return "|".join(f"(?:{pattern})" for pattern in patterns)
+
+
+def install_cors(app: FastAPI, cors: CorsConfig) -> None:
+    """Attach the edge CORS middleware, driven by ``user_config.cors``.
+
+    ``allow_credentials=True`` because a browser call through this edge carries
+    the session cookie or the ``Authorization`` header the gateway authenticates
+    with — and it forbids a ``"*"`` origin, so an origin is admitted only by
+    being listed in ``allow_origins`` or matching one of ``allow_origin_regex``.
+
+    Methods and request headers are unrestricted (``"*"``): the gateway forwards
+    every method into every domain and does not know which headers an upstream
+    operation takes, so narrowing either here would refuse calls the upstream
+    accepts. What a caller is *allowed to do* is the authenticator's and the
+    upstream's decision, on the real request; CORS decides only which origin's
+    JavaScript may read the answer.
+    """
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=list(cors.allow_origins),
+        allow_origin_regex=_combined_origin_regex(list(cors.allow_origin_regex)),
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+        expose_headers=list(EXPOSED_HEADERS),
+    )

--- a/src/gateway/src/gateway/community/adapters/web/_cors.py
+++ b/src/gateway/src/gateway/community/adapters/web/_cors.py
@@ -21,22 +21,35 @@ Which is why this lives at the gateway rather than in an upstream:
   endpoints a browser could reach would depend on which component happens to
   serve them.
 
-The middleware is installed **outermost** (added last in ``create_app``), so a
-preflight is answered here and never reaches the forward route at all. The
-edge being the CORS authority also means an upstream's own CORS headers must
-not travel back through the gateway — two ``Access-Control-Allow-Origin``
-values in one response is an error a browser reports the same way as none.
-:data:`CORS_RESPONSE_HEADERS` is what the forwarder strips to keep that true.
+The middleware is installed **outermost** among the app's own middleware (added
+last in ``create_app``), so a preflight is answered here and never reaches the
+forward route at all. The edge being the CORS authority also means an upstream's
+own CORS headers must not travel back through the gateway — two
+``Access-Control-Allow-Origin`` values in one response is an error a browser
+reports the same way as none. :data:`CORS_RESPONSE_HEADERS` is what the
+forwarder strips to keep that true.
+
+One response is generated *outside* every middleware a FastAPI app installs: the
+500 that Starlette's ``ServerErrorMiddleware`` writes when an exception escapes
+the stack (``build_middleware_stack`` puts it outermost, above ``add_middleware``
+entries). Without a header it cannot get from here, a browser reports that 500 as
+a CORS failure and the page never learns the request even reached the gateway —
+so ``install_cors`` also registers the handler that answers it.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import re
+from typing import TYPE_CHECKING, Any
 
 from starlette.middleware.cors import CORSMiddleware
+from starlette.responses import PlainTextResponse
+from starlette.types import ASGIApp
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
+    from starlette.requests import Request
+    from starlette.responses import Response
 
     from gateway.community.config import CorsConfig
 
@@ -66,18 +79,72 @@ CORS_RESPONSE_HEADERS = frozenset(
 )
 
 
-def _combined_origin_regex(patterns: list[str]) -> str | None:
-    """The configured patterns as one alternation, or ``None`` for an empty list.
+class _OriginAllowList:
+    """The configured origins, as one question: may this origin read a response?
 
-    Starlette takes a single regex and matches it with ``fullmatch``; the config
-    takes a list, because an environment's origins are several unrelated shapes
-    and one line per shape is what a reviewer can read. Each pattern is wrapped
-    in a non-capturing group so an alternation *inside* a pattern cannot swallow
-    the ones after it, and so ``fullmatch`` still anchors each alternative.
+    Each regex is compiled and matched **on its own**. Starlette takes a single
+    pattern string, and the obvious way to satisfy it — joining the configured
+    list into one alternation — silently changes what an operator wrote: a
+    pattern that opens with a global inline flag (``(?i)https://...``, legal and
+    useful for a host match) is only legal at the very start of an expression,
+    so wrapping or concatenating it raises ``re.error: global flags not at the
+    start``. That error would surface when Starlette builds the middleware
+    stack, i.e. the gateway would refuse to serve at all. Matching each pattern
+    separately keeps every entry's semantics its own.
+
+    ``fullmatch`` rather than ``match``, exactly as Starlette does: an origin
+    that merely *starts* with an allowed one — ``https://ui.example.com.evil.test``
+    against ``https://[a-z]+\\.example\\.com`` — is a different origin.
     """
-    if not patterns:
-        return None
-    return "|".join(f"(?:{pattern})" for pattern in patterns)
+
+    def __init__(self, origins: list[str], patterns: list[str]) -> None:
+        self._origins = frozenset(origins)
+        self._patterns = tuple(re.compile(pattern) for pattern in patterns)
+
+    def allows(self, origin: str) -> bool:
+        if origin in self._origins:
+            return True
+        return any(pattern.fullmatch(origin) for pattern in self._patterns)
+
+
+class _AllowListCORSMiddleware(CORSMiddleware):
+    """Starlette's CORS middleware, asking :class:`_OriginAllowList` instead.
+
+    Only the origin *decision* is replaced; preflight handling, header mirroring
+    and the response-header stamping stay Starlette's. ``is_allowed_origin`` is
+    the single seam both the preflight path and the simple-response path call,
+    so overriding it is enough for the list and the regexes to agree everywhere.
+    """
+
+    def __init__(
+        self, app: ASGIApp, *, allow_list: _OriginAllowList, **kwargs: Any
+    ) -> None:
+        self._allow_list = allow_list
+        super().__init__(app, **kwargs)
+
+    def is_allowed_origin(self, origin: str) -> bool:
+        return self._allow_list.allows(origin)
+
+
+def _install_server_error_handler(app: FastAPI, allow_list: _OriginAllowList) -> None:
+    """Give the outermost 500 the two headers a browser needs to read it.
+
+    ``ServerErrorMiddleware`` sits above every ``add_middleware`` entry, so the
+    response it writes for an escaped exception never passes through the CORS
+    middleware. The body stays what Starlette would have sent; the headers are
+    what turns an opaque "CORS error" in the console into a legible 500.
+    """
+
+    async def server_error(request: Request, exc: Exception) -> Response:
+        response = PlainTextResponse("Internal Server Error", status_code=500)
+        origin = request.headers.get("origin")
+        if origin and allow_list.allows(origin):
+            response.headers["Access-Control-Allow-Origin"] = origin
+            response.headers["Access-Control-Allow-Credentials"] = "true"
+            response.headers["Vary"] = "Origin"
+        return response
+
+    app.add_exception_handler(Exception, server_error)
 
 
 def install_cors(app: FastAPI, cors: CorsConfig) -> None:
@@ -85,8 +152,10 @@ def install_cors(app: FastAPI, cors: CorsConfig) -> None:
 
     ``allow_credentials=True`` because a browser call through this edge carries
     the session cookie or the ``Authorization`` header the gateway authenticates
-    with — and it forbids a ``"*"`` origin, so an origin is admitted only by
-    being listed in ``allow_origins`` or matching one of ``allow_origin_regex``.
+    with — and it is why ``CorsConfig`` refuses a ``"*"`` origin: with
+    credentials enabled Starlette answers a wildcard by echoing whichever origin
+    asked, so ``"*"`` would not fail loudly, it would quietly admit every site
+    on the internet to credentialed calls.
 
     Methods and request headers are unrestricted (``"*"``): the gateway forwards
     every method into every domain and does not know which headers an upstream
@@ -95,12 +164,21 @@ def install_cors(app: FastAPI, cors: CorsConfig) -> None:
     upstream's decision, on the real request; CORS decides only which origin's
     JavaScript may read the answer.
     """
+    allow_list = _OriginAllowList(
+        list(cors.allow_origins), list(cors.allow_origin_regex)
+    )
     app.add_middleware(
-        CORSMiddleware,
+        # ``add_middleware``'s factory protocol describes a class whose only
+        # extra arguments are the ones it forwards; a subclass taking a keyword
+        # of its own does not satisfy it, though it is the same ASGI app at
+        # runtime. The alternative — smuggling the allow-list in through a
+        # module global — would be worse than the ignore.
+        _AllowListCORSMiddleware,  # type: ignore[arg-type]
+        allow_list=allow_list,
         allow_origins=list(cors.allow_origins),
-        allow_origin_regex=_combined_origin_regex(list(cors.allow_origin_regex)),
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
         expose_headers=list(EXPOSED_HEADERS),
     )
+    _install_server_error_handler(app, allow_list)

--- a/src/gateway/src/gateway/community/adapters/web/_forward.py
+++ b/src/gateway/src/gateway/community/adapters/web/_forward.py
@@ -25,6 +25,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from starlette.requests import HTTPConnection
 from starlette.responses import Response
 
+from gateway.community.adapters.web._cors import CORS_RESPONSE_HEADERS
 from gateway.community.adapters.web._log_redaction import redact_credentials
 from gateway.community.logger import get_logger
 from gateway.community.spi.auth import AuthError
@@ -303,7 +304,18 @@ async def forward_request(request: Request) -> Response:
         _request_id() or _ABSENT,
     )
     # Set raw headers directly so duplicate headers (Set-Cookie) survive verbatim.
+    #
+    # The one exception to verbatim relay is CORS. The browser talks to the
+    # gateway's origin, so the edge is what decides which page may read this
+    # response (``_cors.install_cors``); an upstream that also answers callers
+    # directly sends its own ``Access-Control-*`` headers, and letting those
+    # through would put two ``Access-Control-Allow-Origin`` values on the wire —
+    # which a browser rejects exactly as it rejects none — or admit an origin the
+    # edge does not. Dropped here rather than overwritten later so the middleware's
+    # copy is the only one, whatever the upstream said.
     response.raw_headers = [
-        (k.encode("latin-1"), v.encode("latin-1")) for k, v in upstream.headers
+        (k.encode("latin-1"), v.encode("latin-1"))
+        for k, v in upstream.headers
+        if k.lower() not in CORS_RESPONSE_HEADERS
     ]
     return response

--- a/src/gateway/src/gateway/community/adapters/web/app.py
+++ b/src/gateway/src/gateway/community/adapters/web/app.py
@@ -17,6 +17,7 @@ from fastapi import FastAPI
 from fastapi.openapi.docs import get_swagger_ui_html
 
 from gateway.community import __version__
+from gateway.community.adapters.web._cors import install_cors
 from gateway.community.adapters.web._forward import _ALL_METHODS, forward_request
 from gateway.community.adapters.web._log_redaction import install_credential_redaction
 from gateway.community.adapters.web._relay_ws import forward_websocket, relay_routes
@@ -159,6 +160,12 @@ def create_app() -> FastAPI:
         methods=_ALL_METHODS,
         include_in_schema=False,
     )
+
+    # Added last, so it is OUTERMOST: a browser preflight carries no credential
+    # and must be answered here, before the catch-all above resolves a domain or
+    # the authenticator refuses it. The allow-list is configuration
+    # (``user_config.cors``) — no origin is named in code.
+    install_cors(app, config.user_config.cors)
 
     return app
 

--- a/src/gateway/src/gateway/community/config/__init__.py
+++ b/src/gateway/src/gateway/community/config/__init__.py
@@ -8,6 +8,7 @@ from ._config_utils import get_config, get_config_by_path, reset_config
 from ._models import (
     AuthnPluginConfig,
     Config,
+    CorsConfig,
     DatabasePluginConfig,
     LogConfig,
     ModuleConfig,
@@ -22,6 +23,7 @@ __all__ = [
     "AuthnPluginConfig",
     "Config",
     "ConfigLoader",
+    "CorsConfig",
     "DatabasePluginConfig",
     "LogConfig",
     "ModuleConfig",

--- a/src/gateway/src/gateway/community/config/_models.py
+++ b/src/gateway/src/gateway/community/config/_models.py
@@ -69,6 +69,37 @@ class PrincipalSignerPluginConfig(BaseModel):
     ttl_seconds: int = 60
 
 
+class CorsConfig(BaseModel):
+    """Browser CORS allow-list for the gateway's own edge (``user_config.cors``).
+
+    The gateway is the origin a browser actually talks to, so it is the only hop
+    that can answer a preflight: the request that carries no credential and must
+    never reach authentication. An upstream's own allow-list governs callers that
+    reach *it* directly and says nothing about the gateway's address, which is
+    why this list lives here rather than being inherited from a component.
+
+    Neutral default = localhost origins only, so a single-box UI works out of the
+    box; every deployment adds its own frontend origin through the ``cors`` block
+    of its ``application-<env>.yaml`` overlay. Because the edge answers with
+    ``Access-Control-Allow-Credentials: true`` — the session cookie and the
+    ``Authorization`` header are exactly what a browser call carries — a ``"*"``
+    wildcard is not accepted by browsers: origins must be enumerated exactly or
+    matched by one of ``allow_origin_regex``.
+    """
+
+    model_config = {"extra": "allow"}
+    allow_origins: list[str] = Field(
+        default_factory=lambda: [
+            "http://localhost",
+            "http://localhost:3000",
+            "http://localhost:8000",
+            "http://localhost:8080",
+            "http://localhost:8888",
+        ]
+    )
+    allow_origin_regex: list[str] = Field(default_factory=list)
+
+
 class PluginConfig(BaseSettings):
     """Plugin selection config for gateway DI container.
 
@@ -101,6 +132,7 @@ class UserConfig(BaseModel):
     upstream_vars: dict[str, str] = Field(default_factory=dict)
     identity_strategies: dict[str, list[str]] = Field(default_factory=dict)
     route_security: dict[str, dict[str, str]] = Field(default_factory=dict)
+    cors: CorsConfig = Field(default_factory=CorsConfig)
     upstreams: dict[str, Any] = Field(default_factory=dict)
 
     def get(self, key: str, default: Any = None) -> Any:

--- a/src/gateway/src/gateway/community/config/_models.py
+++ b/src/gateway/src/gateway/community/config/_models.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -80,11 +80,9 @@ class CorsConfig(BaseModel):
 
     Neutral default = localhost origins only, so a single-box UI works out of the
     box; every deployment adds its own frontend origin through the ``cors`` block
-    of its ``application-<env>.yaml`` overlay. Because the edge answers with
-    ``Access-Control-Allow-Credentials: true`` — the session cookie and the
-    ``Authorization`` header are exactly what a browser call carries — a ``"*"``
-    wildcard is not accepted by browsers: origins must be enumerated exactly or
-    matched by one of ``allow_origin_regex``.
+    of its ``application-<env>.yaml`` overlay. Origins are enumerated exactly or
+    matched by one of ``allow_origin_regex``; a ``"*"`` wildcard is REFUSED at
+    load time (see :meth:`_reject_wildcard_origin`).
     """
 
     model_config = {"extra": "allow"}
@@ -98,6 +96,29 @@ class CorsConfig(BaseModel):
         ]
     )
     allow_origin_regex: list[str] = Field(default_factory=list)
+
+    @field_validator("allow_origins")
+    @classmethod
+    def _reject_wildcard_origin(cls, origins: list[str]) -> list[str]:
+        """Refuse ``"*"`` at load time rather than serving it.
+
+        The edge always answers with ``Access-Control-Allow-Credentials: true``,
+        and a wildcard does not fail loudly under that setting: Starlette
+        replaces ``"*"`` with whichever origin asked (``CORSMiddleware.send``
+        takes the ``allow_all_origins and allow_credentials`` branch), so a
+        deployment that wrote the conventional ``allow_origins: ["*"]`` would
+        boot, look correct, and admit every site on the internet to credentialed
+        calls through the gateway. A config error a browser cannot catch for us
+        is one this boundary has to catch itself.
+        """
+        if any(origin.strip() == "*" for origin in origins):
+            raise ValueError(
+                'cors.allow_origins must not contain "*": the gateway sends '
+                "Access-Control-Allow-Credentials: true, so a wildcard admits "
+                "every origin to credentialed calls. List each origin, or match "
+                "them with cors.allow_origin_regex."
+            )
+        return origins
 
 
 class PluginConfig(BaseSettings):

--- a/src/gateway/src/gateway/community/config/_models.py
+++ b/src/gateway/src/gateway/community/config/_models.py
@@ -70,10 +70,19 @@ class PrincipalSignerPluginConfig(BaseModel):
     ttl_seconds: int = 60
 
 
-#: Probe for a CORS pattern that admits origins its author never enumerated.
-#: Under ``.invalid`` (RFC 2606), which no real deployment can serve from, so a
-#: pattern pinned to a real host suffix cannot match it by accident.
-_CANARY_ORIGIN = "https://canary-origin.invalid"
+#: Probes for a CORS pattern that admits origins its author never enumerated.
+#: Every host is under ``.invalid`` (RFC 2606), which no real deployment can
+#: serve from, so a pattern pinned to a real host suffix cannot match one by
+#: accident. Both schemes a browser origin can carry are probed, with and
+#: without a port: a catch-all is a catch-all whether it is written
+#: ``https://.*``, ``http://.*`` or ``https://.*:8443``, and probing only one
+#: shape would refuse that shape while admitting its neighbours.
+_CANARY_ORIGINS = (
+    "https://canary-origin.invalid",
+    "http://canary-origin.invalid",
+    "https://canary-origin.invalid:8443",
+    "http://canary-origin.invalid:8080",
+)
 
 
 class CorsConfig(BaseModel):
@@ -139,12 +148,15 @@ class CorsConfig(BaseModel):
         localhost port" — admits every site on the internet exactly as ``"*"``
         would, and boots just as quietly.
 
-        The probe is a canary rather than a proof: a pattern that ``fullmatch``es
-        a host under the reserved ``.invalid`` TLD (RFC 2606 — never resolvable,
-        so no real allow-list names it) is matching things its author did not
-        enumerate. That catches the ``.*`` / ``.+`` shapes an operator actually
-        writes; a deliberately broad pattern that dodges the canary is not
-        claimed to be caught.
+        The probes are canaries rather than a proof: a pattern that
+        ``fullmatch``es a host under the reserved ``.invalid`` TLD (RFC 2606 —
+        never resolvable, so no real allow-list names it) is matching things its
+        author did not enumerate. Both schemes are probed, with and without a
+        port, so a catch-all is caught however it is spelled. That covers the
+        ``.*`` / ``.+`` / ``<scheme>://.*`` shapes an operator actually writes;
+        a deliberately broad pattern that dodges every probe is not claimed to
+        be caught. A pattern that pins anything real — ``http://localhost:[0-9]+``,
+        a host suffix — matches no probe and passes.
 
         Compiling here is the second half of the boundary: a malformed pattern
         fails at config load, naming the entry, rather than at middleware
@@ -158,14 +170,15 @@ class CorsConfig(BaseModel):
                     f"cors.allow_origin_regex entry {pattern!r} is not a valid "
                     f"regular expression: {exc}"
                 ) from exc
-            if compiled.fullmatch(_CANARY_ORIGIN):
-                raise ValueError(
-                    f"cors.allow_origin_regex entry {pattern!r} matches the "
-                    f"arbitrary origin {_CANARY_ORIGIN!r}: the gateway sends "
-                    "Access-Control-Allow-Credentials: true, so a pattern this "
-                    "broad admits every origin to credentialed calls. Pin the "
-                    "scheme and the host suffix each environment actually serves."
-                )
+            for canary in _CANARY_ORIGINS:
+                if compiled.fullmatch(canary):
+                    raise ValueError(
+                        f"cors.allow_origin_regex entry {pattern!r} matches the "
+                        f"arbitrary origin {canary!r}: the gateway sends "
+                        "Access-Control-Allow-Credentials: true, so a pattern "
+                        "this broad admits every origin to credentialed calls. "
+                        "Pin the host suffix each environment actually serves."
+                    )
         return patterns
 
 

--- a/src/gateway/src/gateway/community/config/_models.py
+++ b/src/gateway/src/gateway/community/config/_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, ClassVar
@@ -69,6 +70,12 @@ class PrincipalSignerPluginConfig(BaseModel):
     ttl_seconds: int = 60
 
 
+#: Probe for a CORS pattern that admits origins its author never enumerated.
+#: Under ``.invalid`` (RFC 2606), which no real deployment can serve from, so a
+#: pattern pinned to a real host suffix cannot match it by accident.
+_CANARY_ORIGIN = "https://canary-origin.invalid"
+
+
 class CorsConfig(BaseModel):
     """Browser CORS allow-list for the gateway's own edge (``user_config.cors``).
 
@@ -81,8 +88,9 @@ class CorsConfig(BaseModel):
     Neutral default = localhost origins only, so a single-box UI works out of the
     box; every deployment adds its own frontend origin through the ``cors`` block
     of its ``application-<env>.yaml`` overlay. Origins are enumerated exactly or
-    matched by one of ``allow_origin_regex``; a ``"*"`` wildcard is REFUSED at
-    load time (see :meth:`_reject_wildcard_origin`).
+    matched by one of ``allow_origin_regex``; either field is REFUSED at load
+    time when it would admit an arbitrary origin (see
+    :meth:`_reject_wildcard_origin` and :meth:`_reject_universal_regex`).
     """
 
     model_config = {"extra": "allow"}
@@ -119,6 +127,46 @@ class CorsConfig(BaseModel):
                 "them with cors.allow_origin_regex."
             )
         return origins
+
+    @field_validator("allow_origin_regex")
+    @classmethod
+    def _reject_universal_regex(cls, patterns: list[str]) -> list[str]:
+        """Refuse a pattern that would admit an origin nobody configured.
+
+        The sibling check above points an operator at this field, so this field
+        must not be the way back into the hole it closes: with credentials
+        enabled, ``allow_origin_regex: [".*"]`` — a plausible shorthand for "any
+        localhost port" — admits every site on the internet exactly as ``"*"``
+        would, and boots just as quietly.
+
+        The probe is a canary rather than a proof: a pattern that ``fullmatch``es
+        a host under the reserved ``.invalid`` TLD (RFC 2606 — never resolvable,
+        so no real allow-list names it) is matching things its author did not
+        enumerate. That catches the ``.*`` / ``.+`` shapes an operator actually
+        writes; a deliberately broad pattern that dodges the canary is not
+        claimed to be caught.
+
+        Compiling here is the second half of the boundary: a malformed pattern
+        fails at config load, naming the entry, rather than at middleware
+        construction — where it would take the whole gateway down at boot.
+        """
+        for pattern in patterns:
+            try:
+                compiled = re.compile(pattern)
+            except re.error as exc:
+                raise ValueError(
+                    f"cors.allow_origin_regex entry {pattern!r} is not a valid "
+                    f"regular expression: {exc}"
+                ) from exc
+            if compiled.fullmatch(_CANARY_ORIGIN):
+                raise ValueError(
+                    f"cors.allow_origin_regex entry {pattern!r} matches the "
+                    f"arbitrary origin {_CANARY_ORIGIN!r}: the gateway sends "
+                    "Access-Control-Allow-Credentials: true, so a pattern this "
+                    "broad admits every origin to credentialed calls. Pin the "
+                    "scheme and the host suffix each environment actually serves."
+                )
+        return patterns
 
 
 class PluginConfig(BaseSettings):

--- a/src/gateway/tests/integration/test_forward_route.py
+++ b/src/gateway/tests/integration/test_forward_route.py
@@ -16,13 +16,14 @@ import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
+from gateway.community.adapters.web._cors import install_cors
 from gateway.community.adapters.web._forward import (
     _ALL_METHODS,
     _request_body,
     forward_request,
 )
 from gateway.community.bootstrap._principal_signer import build_principal_signer
-from gateway.community.config import ConfigLoader, UserConfig
+from gateway.community.config import ConfigLoader, CorsConfig, UserConfig
 from gateway.community.core.forwarding import DomainMap
 from gateway.community.plugins.forwarder.httpx import HttpxForwarder
 from gateway.community.plugins.secret_resolver.community import CommunitySecretResolver
@@ -75,6 +76,23 @@ async def _stub_upstream(scope: Scope, receive: Receive, send: Send) -> None:
                     (b"content-type", b"application/json"),
                     (b"set-cookie", b"session=1"),
                     (b"set-cookie", b"csrf=2"),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": b'{"code":200000}'})
+    elif path == "/openapi/v1/bots/cors" and method == "GET":
+        # An upstream that is also reachable directly answers CORS for its own
+        # origin pairs. Those headers must not travel back through the gateway.
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"access-control-allow-origin", b"https://upstream.example.com"),
+                    (b"access-control-allow-credentials", b"true"),
+                    (b"access-control-expose-headers", b"X-Upstream"),
+                    (b"x-upstream", b"kept"),
                 ],
             }
         )
@@ -298,6 +316,50 @@ def test_successful_forward_streams_body_and_preserves_cookies() -> None:
     assert resp.status_code == 200
     assert resp.json() == {"code": 200000}
     assert resp.headers.get_list("set-cookie") == ["session=1", "csrf=2"]
+
+
+def test_upstream_cors_headers_are_not_relayed() -> None:
+    """The edge owns CORS, so an upstream's own headers stop at the gateway.
+
+    Two ``Access-Control-Allow-Origin`` values in one response are rejected by a
+    browser exactly as none are, and the upstream's value names an origin pair
+    the edge never agreed to.
+    """
+    app, _ = _build()
+    install_cors(app, CorsConfig(allow_origins=["https://frontend.example.com"]))
+    with TestClient(app) as client:
+        resp = client.get(
+            "/openapi/v1/bots/cors",
+            headers={"Origin": "https://frontend.example.com"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.headers.get_list("access-control-allow-origin") == [
+        "https://frontend.example.com"
+    ]
+    assert "X-Upstream" not in resp.headers.get("access-control-expose-headers", "")
+    # Only the CORS headers are dropped; the rest of the response is verbatim.
+    assert resp.headers["x-upstream"] == "kept"
+    assert resp.json() == {"code": 200000}
+
+
+def test_preflight_is_answered_before_the_authenticator_runs() -> None:
+    """A preflight carries no credential, so it must not reach auth at all."""
+    app, auth = _build()
+    auth.fail = True  # any request that reaches the authenticator is refused
+    install_cors(app, CorsConfig(allow_origins=["https://frontend.example.com"]))
+    with TestClient(app) as client:
+        resp = client.options(
+            "/openapi/v1/bots",
+            headers={
+                "Origin": "https://frontend.example.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.headers["access-control-allow-origin"] == "https://frontend.example.com"
+    assert auth.calls == []
 
 
 def test_sse_streaming_forward() -> None:

--- a/src/gateway/tests/unit/adapters/web/test_cors.py
+++ b/src/gateway/tests/unit/adapters/web/test_cors.py
@@ -207,17 +207,43 @@ def test_wildcard_origin_is_refused_at_config_load() -> None:
         UserConfig.model_validate({"cors": {"allow_origins": ["*"]}})
 
 
-def test_a_regex_that_admits_an_arbitrary_origin_is_refused_at_config_load() -> None:
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        ".*",
+        ".+",
+        "https://.*",
+        # A catch-all is a catch-all whichever scheme it names — `http://.*` is
+        # the shape an operator reaches for when they mean "localhost, any port".
+        "http://.*",
+        # ...and pinning a port does not narrow the HOST at all.
+        "https://.*:8443",
+    ],
+)
+def test_a_regex_that_admits_an_arbitrary_origin_is_refused_at_config_load(
+    pattern: str,
+) -> None:
     """The sibling check points operators here, so this field cannot be the way back in."""
-    for pattern in (".*", ".+", "https://.*"):
-        with pytest.raises(ValueError, match=r"matches the arbitrary origin"):
-            CorsConfig(allow_origin_regex=[pattern])
+    with pytest.raises(ValueError, match=r"matches the arbitrary origin"):
+        CorsConfig(allow_origin_regex=[pattern])
 
+
+def test_the_regex_refusal_reaches_a_real_config_load() -> None:
     with pytest.raises(ValueError, match=r"matches the arbitrary origin"):
         UserConfig.model_validate({"cors": {"allow_origin_regex": [".*"]}})
 
-    # A pattern pinned to a host suffix an environment actually serves is fine.
-    CorsConfig(allow_origin_regex=[r"https://[a-z0-9-]+\.preview\.example\.com"])
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        r"https://[a-z0-9-]+\.preview\.example\.com",
+        # What an operator actually means by "localhost on any port": the host is
+        # pinned, so no probe matches and the pattern is admitted.
+        r"http://localhost:[0-9]+",
+    ],
+)
+def test_a_pattern_that_pins_a_real_host_still_validates(pattern: str) -> None:
+    assert CorsConfig(allow_origin_regex=[pattern]).allow_origin_regex == [pattern]
 
 
 def test_a_malformed_regex_fails_at_config_load_not_at_boot() -> None:

--- a/src/gateway/tests/unit/adapters/web/test_cors.py
+++ b/src/gateway/tests/unit/adapters/web/test_cors.py
@@ -1,0 +1,138 @@
+"""The gateway answers browser CORS at its own edge.
+
+A cross-origin browser call reaches the gateway before it reaches anything else,
+and its preflight carries no credential — so the questions here are whether the
+preflight is answered *without* routing or authenticating, and whether the
+allow-list that answers it is the configured one.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+# The response type ``TestClient`` returns — starlette's test transport is built
+# on httpx2, so a bare ``httpx.Response`` annotation would not describe it.
+from httpx2 import Response
+
+from gateway.community.adapters.web._cors import EXPOSED_HEADERS, install_cors
+from gateway.community.adapters.web.app import create_app
+from gateway.community.config import CorsConfig
+
+_ALLOWED = "https://frontend.example.com"
+_FOREIGN = "https://not-the-frontend.example.com"
+
+
+def _app(cors: CorsConfig) -> tuple[FastAPI, list[str]]:
+    """An app whose only route records that it ran, behind the edge middleware."""
+    app = FastAPI()
+    reached: list[str] = []
+
+    @app.api_route("/openapi/v1/bots/all", methods=["GET", "OPTIONS", "POST"])
+    async def _route() -> dict[str, bool]:
+        reached.append("route")
+        return {"ok": True}
+
+    install_cors(app, cors)
+    return app, reached
+
+
+def _preflight(client: TestClient, origin: str, method: str = "GET") -> Response:
+    return client.options(
+        "/openapi/v1/bots/all",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": method,
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+
+
+def test_preflight_is_answered_at_the_edge_without_reaching_the_route() -> None:
+    app, reached = _app(CorsConfig(allow_origins=[_ALLOWED], allow_origin_regex=[]))
+    resp = _preflight(TestClient(app), _ALLOWED)
+
+    assert resp.status_code == 200
+    assert resp.headers["access-control-allow-origin"] == _ALLOWED
+    assert resp.headers["access-control-allow-credentials"] == "true"
+    # The preflight carries no credential, so it must never reach the forward
+    # route — where domain resolution and authentication would refuse it.
+    assert reached == []
+
+
+def test_preflight_mirrors_the_requested_headers_and_method() -> None:
+    app, _ = _app(CorsConfig(allow_origins=[_ALLOWED], allow_origin_regex=[]))
+    resp = _preflight(TestClient(app), _ALLOWED, method="POST")
+
+    assert resp.status_code == 200
+    allowed_headers = resp.headers["access-control-allow-headers"]
+    assert "authorization" in allowed_headers
+    assert "content-type" in allowed_headers
+    assert "POST" in resp.headers["access-control-allow-methods"]
+
+
+def test_simple_response_carries_the_origin_and_the_exposed_headers() -> None:
+    app, reached = _app(CorsConfig(allow_origins=[_ALLOWED], allow_origin_regex=[]))
+    resp = TestClient(app).get("/openapi/v1/bots/all", headers={"Origin": _ALLOWED})
+
+    assert reached == ["route"]
+    assert resp.headers["access-control-allow-origin"] == _ALLOWED
+    exposed = resp.headers["access-control-expose-headers"]
+    assert all(header in exposed for header in EXPOSED_HEADERS)
+
+
+def test_unlisted_origin_gets_no_allow_origin_header() -> None:
+    app, _ = _app(CorsConfig(allow_origins=[_ALLOWED], allow_origin_regex=[]))
+    client = TestClient(app)
+
+    assert "access-control-allow-origin" not in _preflight(client, _FOREIGN).headers
+    simple = client.get("/openapi/v1/bots/all", headers={"Origin": _FOREIGN})
+    assert "access-control-allow-origin" not in simple.headers
+
+
+@pytest.mark.parametrize(
+    ("origin", "allowed"),
+    [
+        ("https://team.preview.example.com", True),
+        ("https://other.internal.example.com", True),
+        # fullmatch, not a prefix match: a host that merely *starts* with an
+        # allowed one is a different origin and must not be admitted.
+        ("https://team.preview.example.com.evil.test", False),
+        ("https://team.preview.example.org", False),
+    ],
+)
+def test_each_configured_regex_is_matched_whole(origin: str, allowed: bool) -> None:
+    app, _ = _app(
+        CorsConfig(
+            allow_origins=[],
+            allow_origin_regex=[
+                r"https://[a-z0-9-]+\.preview\.example\.com",
+                r"https://[a-z0-9-]+\.internal\.example\.com",
+            ],
+        )
+    )
+    headers = _preflight(TestClient(app), origin).headers
+
+    assert ("access-control-allow-origin" in headers) is allowed
+
+
+def test_neutral_default_admits_a_localhost_ui() -> None:
+    app, _ = _app(CorsConfig())
+    headers = _preflight(TestClient(app), "http://localhost:8000").headers
+
+    assert headers["access-control-allow-origin"] == "http://localhost:8000"
+
+
+def test_the_served_app_answers_a_preflight_from_the_shipped_allow_list() -> None:
+    """The wiring, not just the middleware: the app built from configs/ answers.
+
+    ``create_app`` is where the allow-list is read and the middleware attached,
+    so a preflight reaching the real app is what proves an operator's ``cors``
+    block is in force — and that it is answered without a domain, a route or a
+    credential.
+    """
+    resp = _preflight(TestClient(create_app()), "http://localhost:8000")
+
+    assert resp.status_code == 200
+    assert resp.headers["access-control-allow-origin"] == "http://localhost:8000"

--- a/src/gateway/tests/unit/adapters/web/test_cors.py
+++ b/src/gateway/tests/unit/adapters/web/test_cors.py
@@ -205,3 +205,22 @@ def test_wildcard_origin_is_refused_at_config_load() -> None:
     # And the refusal reaches a real config load, not just direct construction.
     with pytest.raises(ValueError, match=r"must not contain"):
         UserConfig.model_validate({"cors": {"allow_origins": ["*"]}})
+
+
+def test_a_regex_that_admits_an_arbitrary_origin_is_refused_at_config_load() -> None:
+    """The sibling check points operators here, so this field cannot be the way back in."""
+    for pattern in (".*", ".+", "https://.*"):
+        with pytest.raises(ValueError, match=r"matches the arbitrary origin"):
+            CorsConfig(allow_origin_regex=[pattern])
+
+    with pytest.raises(ValueError, match=r"matches the arbitrary origin"):
+        UserConfig.model_validate({"cors": {"allow_origin_regex": [".*"]}})
+
+    # A pattern pinned to a host suffix an environment actually serves is fine.
+    CorsConfig(allow_origin_regex=[r"https://[a-z0-9-]+\.preview\.example\.com"])
+
+
+def test_a_malformed_regex_fails_at_config_load_not_at_boot() -> None:
+    """Compiled here, the entry is named; compiled by Starlette, the gateway dies."""
+    with pytest.raises(ValueError, match=r"is not a valid regular expression"):
+        CorsConfig(allow_origin_regex=["https://[unclosed"])

--- a/src/gateway/tests/unit/adapters/web/test_cors.py
+++ b/src/gateway/tests/unit/adapters/web/test_cors.py
@@ -18,7 +18,7 @@ from httpx2 import Response
 
 from gateway.community.adapters.web._cors import EXPOSED_HEADERS, install_cors
 from gateway.community.adapters.web.app import create_app
-from gateway.community.config import CorsConfig
+from gateway.community.config import CorsConfig, UserConfig
 
 _ALLOWED = "https://frontend.example.com"
 _FOREIGN = "https://not-the-frontend.example.com"
@@ -136,3 +136,72 @@ def test_the_served_app_answers_a_preflight_from_the_shipped_allow_list() -> Non
 
     assert resp.status_code == 200
     assert resp.headers["access-control-allow-origin"] == "http://localhost:8000"
+
+
+def test_a_pattern_may_open_with_a_global_inline_flag() -> None:
+    """Each configured regex is compiled on its own, so its own flags survive.
+
+    ``(?i)`` is legal only at the very start of an expression; combining the
+    configured patterns into one alternation would move it and raise
+    ``re.error: global flags not at the start`` while Starlette builds the
+    middleware stack — the gateway would refuse to serve rather than refuse an
+    origin.
+    """
+    app, _ = _app(
+        CorsConfig(
+            allow_origins=[],
+            allow_origin_regex=[
+                r"(?i)https://frontend\.example\.com",
+                r"https://[a-z0-9-]+\.preview\.example\.com",
+            ],
+        )
+    )
+    client = TestClient(app)
+
+    assert (
+        _preflight(client, "https://FRONTEND.example.com").headers[
+            "access-control-allow-origin"
+        ]
+        == "https://FRONTEND.example.com"
+    )
+    # The second pattern keeps its own (case-sensitive) semantics.
+    assert (
+        "access-control-allow-origin"
+        not in _preflight(client, "https://TEAM.preview.example.com").headers
+    )
+
+
+def test_an_escaped_exception_still_answers_with_the_origin() -> None:
+    """``ServerErrorMiddleware`` writes its 500 outside every added middleware.
+
+    Without the handler ``install_cors`` registers, a browser sees that 500 only
+    as a CORS failure and cannot tell the request reached the gateway at all.
+    """
+    app = FastAPI()
+
+    @app.get("/openapi/v1/bots/boom")
+    async def _boom() -> None:
+        raise RuntimeError("upstream exploded")
+
+    install_cors(app, CorsConfig(allow_origins=[_ALLOWED], allow_origin_regex=[]))
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get("/openapi/v1/bots/boom", headers={"Origin": _ALLOWED})
+    assert resp.status_code == 500
+    assert resp.headers["access-control-allow-origin"] == _ALLOWED
+    assert resp.headers["access-control-allow-credentials"] == "true"
+
+    # An origin the edge does not admit learns nothing from the failure either.
+    foreign = client.get("/openapi/v1/bots/boom", headers={"Origin": _FOREIGN})
+    assert foreign.status_code == 500
+    assert "access-control-allow-origin" not in foreign.headers
+
+
+def test_wildcard_origin_is_refused_at_config_load() -> None:
+    """``"*"`` must not boot: with credentials on, Starlette echoes every origin."""
+    with pytest.raises(ValueError, match=r"must not contain"):
+        CorsConfig(allow_origins=["*"])
+
+    # And the refusal reaches a real config load, not just direct construction.
+    with pytest.raises(ValueError, match=r"must not contain"):
+        UserConfig.model_validate({"cors": {"allow_origins": ["*"]}})


### PR DESCRIPTION
## Problem

A browser page served from one origin cannot call the gateway from another:

```
Access to fetch at 'https://GATEWAY_HOST/openapi/v1/bots/all?page=1&page_size=20'
from origin 'https://FRONTEND_HOST' has been blocked by CORS policy: Response to
preflight request doesn't pass access control check: No
'Access-Control-Allow-Origin' header is present on the requested resource.
```

The gateway had no CORS layer at all. Its only HTTP entrypoint is the catch-all
forward (`adapters/web/_forward.py`), which resolves a domain, authenticates,
then forwards. A CORS preflight is an `OPTIONS` request that a browser
deliberately sends **without** cookies or `Authorization`, so it fell into that
path and ended one of two ways, neither of which a browser accepts:

- On any route whose `route_security` names a required identity (`POST
  /openapi/v1/bots`, `/openapi/v1/collaboration/**`, `/openapi/v1/bcsfuse/**`,
  the top-level `"/**"` default), the credential-less preflight was refused with
  a 401 that carries no `Access-Control-*` header.
- On the routes where both identities are optional (`/openapi/v1/bots/**`), the
  preflight was relayed to the upstream, so whether a browser could reach the
  gateway depended on the **backend's** `cors` allow-list — a list that governs
  callers reaching the backend directly, never sees the gateway's address, and
  differs per upstream (`bots` to backend, `chat` to baas, `collaboration` to
  bcs, `bcsfuse-*` to bcsfuse).

Either way no `Access-Control-Allow-Origin` reached the browser and the real
request was never sent.

## Solution

Make the gateway the CORS authority for its own edge, since it is the origin the
browser is configured with and the only hop that can answer a request carrying
no credential.

**`adapters/web/_cors.py` (new)**

- `install_cors` attaches Starlette's `CORSMiddleware` with
  `allow_credentials=True` (a browser call through the edge carries the cookie /
  `Authorization` header the gateway authenticates with), and `allow_methods` /
  `allow_headers` of `"*"` — the gateway forwards every method into every domain
  and does not know which headers an upstream operation takes, so narrowing
  either here would refuse calls the upstream accepts. What a caller may *do*
  stays the authenticator's and the upstream's decision on the real request.
  `Deprecation` / `Sunset` are exposed so a browser SDK can still learn that its
  address is retiring.
- Origins are decided by `_OriginAllowList`, which holds the exact origins and
  compiles **each configured regex on its own**, matching with `fullmatch`. A
  thin `CORSMiddleware` subclass asks it through `is_allowed_origin` — the one
  seam both the preflight path and the simple-response path call. Per-pattern
  compilation is load-bearing: combining the list into one alternation would
  move a leading global inline flag (`(?i)https://…`, legal and useful for a
  host match) out of first position, and `re` rejects that with `global flags
  not at the start` — while Starlette is *building the middleware stack*, so the
  gateway would refuse to serve at all rather than refuse an origin.
- `install_cors` also registers the `Exception` handler that
  `ServerErrorMiddleware` invokes. That middleware sits above every
  `add_middleware` entry (`build_middleware_stack` composes `[ServerError] +
  user_middleware + [Exception]`), so the 500 it writes for an escaped exception
  would otherwise carry no `Access-Control-*` header and a browser would report
  a server error as a CORS failure. The handler shares the same
  `_OriginAllowList` instance, so the two cannot drift.

**`app.py`** — installed last, therefore outermost, so a preflight is answered
before domain resolution and before `Authenticator.authenticate`.

**`config/_models.py` + `configs/application.yaml`** — a `user_config.cors`
block (`allow_origins`, `allow_origin_regex`) with a neutral localhost-only
default. No origin is named in code; a deployment adds its frontend origins in
the `cors` block of its `application-{env}.yaml` overlay (selected by
`SERVER_ENV`). Two load-time refusals, because with credentials enabled a
too-broad value does not fail loudly — it succeeds silently:

- `allow_origins` may not contain `"*"`. Starlette replaces a wildcard with
  whichever origin asked (`send` takes the `allow_all_origins and
  allow_credentials` branch), so `["*"]` would boot, look correct, and admit
  every site on the internet to credentialed calls.
- `allow_origin_regex` may not contain a pattern that `fullmatch`es a canary
  origin — `.invalid` host (RFC 2606), both schemes, with and without a port —
  which catches `.*`, `.+`, `http://.*`, `https://.*:8443`. The same validator
  compiles each pattern, so a malformed regex fails at config load naming the
  entry instead of taking the gateway down at boot. This is a canary, not a
  proof, and says so in the docstring: a deliberately broad pattern such as
  `https://.*\.com` is not claimed to be caught (see the open thread on
  `_models.py` — deciding that requires knowing which hosts the deployment owns,
  which is what this config declares).

**`_forward.py`** — the one exception to verbatim relay: upstream
`Access-Control-*` response headers are dropped. An upstream that also answers
callers directly sends its own, and two `Access-Control-Allow-Origin` values on
one response are rejected by a browser exactly as none are.

Rejected alternative: adding the frontend origin to each upstream's own
allow-list. It cannot fix the preflight on any route the gateway authenticates
(the 401 happens before the upstream is reached), and it makes browser
reachability a per-component property of whichever service happens to serve a
path.

## Validation

**CI on `6d8de957`: 7/7 checks green.** The gateway gate reports:

```
970 passed, 3 skipped, 27 deselected      # unit + architecture + integration
27 passed                                  # e2e smoke — real app booted on :8888
case pass rate:        100.00% (970/970, required >= 100.00%)
line coverage:         95.47%  (required >= 90.00%)
change line coverage:  100.00% (65/65,  required >= 90.00%)
gateway CI gate passed
```

The e2e stage boots the real gateway against `configs/application.yaml`, so the
new `cors` block and both validators are exercised at actual startup.

Locally in `src/gateway`, `pytest tests/unit tests/architecture tests/integration`
→ 837 passed, 3 skipped, plus two failures in
`tests/architecture/test_ruff_lint_rules.py` that are **pre-existing on the
base** and name files this PR does not touch
(`plugins/authn/dev_cookie/_strategy.py`, `tests/unit/core/authn/test_route_security.py`,
`tests/unit/core/forwarding/test_served_openapi.py`). They do not fail in CI
because `run_check_basic` runs `ruff check --fix` / `ruff format` before the
tests. `ruff check` and `ruff format --check` pass on every file changed here.
`mypy src tests` → 306 errors in 75 files both with these commits and on the base
commit alone — zero new type errors.

New `tests/unit/adapters/web/test_cors.py`: a preflight is answered without
reaching the route; requested method/headers are mirrored; a simple response
carries the origin and the exposed headers; an unlisted origin gets no
allow-origin header on either path; a regex is matched *whole* (a host merely
prefixed by an allowed one is refused); a pattern may open with a global inline
flag and keeps it local to itself; an escaped exception still answers with the
origin (and does not, for an origin the edge refuses); `"*"` and catch-all /
malformed regexes are refused at config load while `http://localhost:[0-9]+` and
a host-suffix pattern still validate; and `create_app()` itself answers a
preflight, so the wiring — not just the middleware — is covered.

New cases in `tests/integration/test_forward_route.py`: an upstream's own
`Access-Control-*` headers do not survive the relay while the rest of the
response does, and a preflight is answered before the authenticator runs
(asserted against an authenticator set to refuse everything).

Not run locally: the gateway live-forwarding suite and the Singlebox coverage
gate, which need a running product stack this environment does not have — both
ran in CI and passed. The lockfile is unchanged by this PR.

## Compatibility and risk

Config-only surface change: a new optional `user_config.cors` block, defaulting
to localhost origins, so an existing deployment behaves as before until it lists
its origins. **A deployment must add its frontend origins to its
`application-{env}.yaml` overlay for browser traffic to work** — an overlay
replaces a list rather than extending it, so any localhost origin an environment
still needs must be repeated there.

Two things that will refuse to boot rather than serve, worth checking before
rollout if any overlay already carries a `cors` block: `allow_origins` with
`"*"`, and `allow_origin_regex` with a catch-all (`.*`, `http://.*`,
`https://.*:8443`) or a malformed pattern. Each error names the offending entry.

Behavior change worth naming: upstream CORS headers no longer pass through the
gateway. Any browser client that was relying on an upstream's allow-list via the
gateway must now be listed in the gateway's. Direct (non-gateway) access to each
upstream is untouched — each service keeps its own CORS config.

Rollback is reverting the commits; nothing is persisted or migrated.