### PR TITLE
fix(skills): scope installations by owner

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -320,6 +320,12 @@ def _get_path_params(
     Raises:
         HTTPException 403: if entity_type is staff and entity_id does not match ctx.user_id (IDOR prevention).
     """
+    # Direct router-unit calls retain FastAPI's Query default objects instead
+    # of resolved ``None``. They are not caller-supplied identity values.
+    entity_id = entity_id if isinstance(entity_id, str) else None
+    entity_type = entity_type if isinstance(entity_type, str) else None
+    bot_id = bot_id if isinstance(bot_id, str) else None
+    engine_type = engine_type if isinstance(engine_type, str) else None
     effective_entity_type = entity_type if entity_type else "staff"
 
     # IDOR prevention: staff-type entity_id must match the authenticated user
@@ -433,6 +439,7 @@ async def _set_legacy_asset_active_if_resolved(
     skill_reference: str,
     source_path: str,
     bot_id: str,
+    owner_id: str,
     actor_id: str,
     active: bool,
 ) -> dict[str, Any] | None:
@@ -454,20 +461,20 @@ async def _set_legacy_asset_active_if_resolved(
                 skill_reference=skill_reference,
                 source_path=source_path,
                 bot_id=bot_id,
-                owner_id=actor_id,
+                owner_id=owner_id,
                 user_id=actor_id,
             )
         )
         asset_service.get_skill(
             skill_id=skill_id,
             bot_id=bot_id,
-            owner_id=actor_id,
+            owner_id=owner_id,
             user_id=actor_id,
         )
         return await asset_service.set_active(
             skill_id=skill_id,
             bot_id=bot_id,
-            owner_id=actor_id,
+            owner_id=owner_id,
             user_id=actor_id,
             active=active,
         )
@@ -1362,6 +1369,7 @@ async def activate_skill(
             skill_reference=request.relative_path or skill_id,
             source_path=request.source_path,
             bot_id=effective_bot_id,
+            owner_id=effective_entity_id,
             actor_id=ctx.user_id,
             active=True,
         )
@@ -1516,6 +1524,7 @@ async def deactivate_skill(
             skill_reference=skill_id,
             source_path="",
             bot_id=effective_bot_id,
+            owner_id=effective_entity_id,
             actor_id=ctx.user_id,
             active=False,
         )
@@ -2076,7 +2085,7 @@ async def activate_skills_batch(
     ),
 ) -> ActivateSkillsResponse:
     """Compatibility batch adapter over the canonical Direct control plane."""
-    _, effective_bot_id, _, _, _ = _get_path_params(
+    effective_owner_id, effective_bot_id, _, _, _ = _get_path_params(
         ctx,
         entity_id,
         entity_type,
@@ -2091,13 +2100,13 @@ async def activate_skills_batch(
                 skill_reference=path,
                 source_path=path,
                 bot_id=effective_bot_id,
-                owner_id=ctx.user_id,
+                owner_id=effective_owner_id,
                 user_id=ctx.user_id,
             )
             item = await asset_service.set_active(
                 skill_id=skill_id,
                 bot_id=effective_bot_id,
-                owner_id=ctx.user_id,
+                owner_id=effective_owner_id,
                 user_id=ctx.user_id,
                 active=True,
             )

--- a/src/backend/src/agentclaw/community/core/models/skill.py
+++ b/src/backend/src/agentclaw/community/core/models/skill.py
@@ -311,6 +311,7 @@ class BotSkillInstallation(Base):
         autoincrement=True,
     )
     bot_id = Column(String(100), nullable=False, index=True)
+    owner_id = Column(String(128), nullable=False, index=True)
     skill_id = Column(
         _UNSIGNED_BIGINT, ForeignKey("ac_skill.id"), nullable=False, index=True
     )
@@ -325,6 +326,7 @@ class BotSkillInstallation(Base):
         UniqueConstraint(
             "avernet_tenant",
             "env",
+            "owner_id",
             "bot_id",
             "skill_id",
             name="uk_bot_skill_installation",

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/installation.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/installation.py
@@ -21,12 +21,15 @@ class SkillInstallationRepository(SkillInstallationRepositoryProtocol):
     def __init__(self, db: DatabasePlugin) -> None:
         self._db = db
 
-    def install(self, *, env: str, bot_id: str, skill_id: str | int) -> bool:
+    def install(
+        self, *, env: str, owner_id: str, bot_id: str, skill_id: str | int
+    ) -> bool:
         skill_id = int(skill_id)
         tenant = get_current_avernet_tenant()
         values = {
             "avernet_tenant": tenant,
             "env": env,
+            "owner_id": owner_id,
             "bot_id": bot_id,
             "skill_id": skill_id,
         }
@@ -46,6 +49,7 @@ class SkillInstallationRepository(SkillInstallationRepositoryProtocol):
                     select(BotSkillInstallation.id).where(
                         BotSkillInstallation.avernet_tenant == tenant,
                         BotSkillInstallation.env == env,
+                        BotSkillInstallation.owner_id == owner_id,
                         BotSkillInstallation.bot_id == bot_id,
                         BotSkillInstallation.skill_id == skill_id,
                     )
@@ -54,13 +58,16 @@ class SkillInstallationRepository(SkillInstallationRepositoryProtocol):
                 return False
             raise
 
-    def uninstall(self, *, env: str, bot_id: str, skill_id: str | int) -> bool:
+    def uninstall(
+        self, *, env: str, owner_id: str, bot_id: str, skill_id: str | int
+    ) -> bool:
         with self._db.orm_session() as db:
             count = (
                 db.query(BotSkillInstallation)
                 .filter(
                     BotSkillInstallation.avernet_tenant == get_current_avernet_tenant(),
                     BotSkillInstallation.env == env,
+                    BotSkillInstallation.owner_id == owner_id,
                     BotSkillInstallation.bot_id == bot_id,
                     BotSkillInstallation.skill_id == int(skill_id),
                 )
@@ -68,13 +75,16 @@ class SkillInstallationRepository(SkillInstallationRepositoryProtocol):
             )
             return count > 0
 
-    def list_installed_skill_ids(self, *, env: str, bot_id: str) -> set[int]:
+    def list_installed_skill_ids(
+        self, *, env: str, owner_id: str, bot_id: str
+    ) -> set[int]:
         with self._db.orm_session() as db:
             rows = (
                 db.query(BotSkillInstallation.skill_id)
                 .filter(
                     BotSkillInstallation.avernet_tenant == get_current_avernet_tenant(),
                     BotSkillInstallation.env == env,
+                    BotSkillInstallation.owner_id == owner_id,
                     BotSkillInstallation.bot_id == bot_id,
                 )
                 .all()

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
@@ -40,11 +40,11 @@ class McpSkillSetControlPlaneCommands:
                 for item in rows
             ]
 
-    def add_mcp(self, *, bot_id: str, set_id: str, server_code: str, engine_type: str | None = None) -> SkillSetMutation:
+    def add_mcp(self, *, bot_id: str, owner_id: str, set_id: str, server_code: str, engine_type: str | None = None) -> SkillSetMutation:
         with self._db.transactional_orm_session() as session:
             row = self._set(session, bot_id=bot_id, set_id=set_id, engine_type=engine_type, locked=True)
             self._ordinary(row)
-            old = self._snapshot(session, bot_id, engine_type=engine_type)
+            old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
             current = (
                 self._scope(session.query(SkillSetMCPServer), SkillSetMCPServer)
                 .filter(SkillSetMCPServer.skill_set_id == row.id, SkillSetMCPServer.server_code == server_code)
@@ -75,11 +75,11 @@ class McpSkillSetControlPlaneCommands:
             session.flush()
             return SkillSetMutation(self._as_item(row), True, old)
 
-    def remove_mcp(self, *, bot_id: str, set_id: str, server_code: str, engine_type: str | None = None) -> SkillSetMutation:
+    def remove_mcp(self, *, bot_id: str, owner_id: str, set_id: str, server_code: str, engine_type: str | None = None) -> SkillSetMutation:
         with self._db.transactional_orm_session() as session:
             row = self._set(session, bot_id=bot_id, set_id=set_id, engine_type=engine_type, locked=True)
             self._ordinary(row)
-            old = self._snapshot(session, bot_id, engine_type=engine_type)
+            old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
             membership = (
                 self._scope(session.query(SkillSetMCPServer), SkillSetMCPServer)
                 .filter(SkillSetMCPServer.skill_set_id == row.id, SkillSetMCPServer.server_code == server_code)
@@ -96,9 +96,9 @@ class McpSkillSetControlPlaneCommands:
             session.flush()
             return SkillSetMutation(self._as_item(row), True, old)
 
-    def activate_mcp_direct(self, *, bot_id: str, server_code: str, engine_type: str | None = None) -> SkillSetMutation:
+    def activate_mcp_direct(self, *, bot_id: str, owner_id: str, server_code: str, engine_type: str | None = None) -> SkillSetMutation:
         with self._db.transactional_orm_session() as session:
-            old = self._snapshot(session, bot_id, engine_type=engine_type)
+            old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
             if self._mcp_has_ordinary_membership(session, bot_id, server_code):
                 raise SkillSetControlPlaneConflictError("RESOURCE_MANAGED_BY_SKILL_SET")
             if server_code in old.mcp_installations:
@@ -110,9 +110,9 @@ class McpSkillSetControlPlaneCommands:
             session.flush()
             return SkillSetMutation({}, True, old)
 
-    def deactivate_mcp_direct(self, *, bot_id: str, server_code: str, engine_type: str | None = None) -> SkillSetMutation:
+    def deactivate_mcp_direct(self, *, bot_id: str, owner_id: str, server_code: str, engine_type: str | None = None) -> SkillSetMutation:
         with self._db.transactional_orm_session() as session:
-            old = self._snapshot(session, bot_id, engine_type=engine_type)
+            old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
             if self._mcp_has_ordinary_membership(session, bot_id, server_code):
                 raise SkillSetControlPlaneConflictError("RESOURCE_MANAGED_BY_SKILL_SET")
             changed = self._scope(session.query(BotMCPInstallation), BotMCPInstallation).filter(

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
@@ -424,6 +424,7 @@ class SkillRepository(
                     BotSkillInstallation.avernet_tenant
                     == get_current_avernet_tenant(),
                     BotSkillInstallation.env == get_current_env(),
+                    BotSkillInstallation.owner_id == _normalize_user_id(user_id),
                     BotSkillInstallation.bot_id == bot_id,
                     BotSkillInstallation.skill_id == self.Skill.id,
                 )
@@ -471,6 +472,7 @@ class SkillRepository(
                     BotSkillInstallation.avernet_tenant
                     == get_current_avernet_tenant(),
                     BotSkillInstallation.env == get_current_env(),
+                    BotSkillInstallation.owner_id == _normalize_user_id(user_id),
                     BotSkillInstallation.bot_id == bot_id,
                     BotSkillInstallation.skill_id == self.Skill.id,
                 )
@@ -489,7 +491,9 @@ class SkillRepository(
             )
             return self._public_local_skill(*row) if row else None
 
-    def list_bot_installed_skills(self, *, env: str, bot_id: str) -> list[dict]:
+    def list_bot_installed_skills(
+        self, *, env: str, owner_id: str, bot_id: str
+    ) -> list[dict]:
         """Return assets selected by the active-only Installation fact."""
         from agentclaw.community.core.models.skill import BotSkillInstallation
 
@@ -504,6 +508,7 @@ class SkillRepository(
                     BotSkillInstallation.avernet_tenant
                     == get_current_avernet_tenant(),
                     BotSkillInstallation.env == env,
+                    BotSkillInstallation.owner_id == _normalize_user_id(owner_id),
                     BotSkillInstallation.bot_id == bot_id,
                     self.Skill.env == env,
                 )
@@ -516,6 +521,7 @@ class SkillRepository(
         self,
         *,
         env: str,
+        owner_id: str,
         bot_id: str,
     ):
         """列出精确 Bot 范围内的全部 local 来源行，不包含全局记录。"""
@@ -529,6 +535,7 @@ class SkillRepository(
                 db.query(self.Skill)
                 .filter(
                     self.Skill.env == env,
+                    self.Skill.user_id == _normalize_user_id(owner_id),
                     self.Skill.bolt_id == bot_id,
                     self.Skill.git_path.like("local://%"),
                 )
@@ -552,7 +559,7 @@ class SkillRepository(
         *,
         env: str,
         bot_id: str,
-        user_id: str,
+        owner_id: str,
         engine: str,
     ):
         """Return active SkillSet assets plus direct Installation assets.
@@ -569,7 +576,7 @@ class SkillRepository(
 
         skill_sets = SkillSetRepository(self._db)
         active_sets = skill_sets.get_all_active_skill_sets_for_env(
-            user_id=user_id,
+            user_id=owner_id,
             bolt_id=bot_id,
             engine_type=engine,
             env=env,
@@ -614,7 +621,9 @@ class SkillRepository(
                         mcp_dependencies=tuple(row.get("mcp_dependencies") or ()),
                     )
                 )
-        for row in self.list_bot_installed_skills(env=env, bot_id=bot_id):
+        for row in self.list_bot_installed_skills(
+            env=env, owner_id=owner_id, bot_id=bot_id
+        ):
             skill_id = int(row["id"])
             name = str(row["name"])
             git_path = str(row.get("git_path") or "")

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_set_control_plane.py
@@ -319,7 +319,13 @@ class SkillSetControlPlaneRepository(
             return str(skill.id)
 
     def add_skill(
-        self, *, bot_id: str, set_id: str, skill_id: str, engine_type: str | None = None
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        set_id: str,
+        skill_id: str,
+        engine_type: str | None = None,
     ) -> SkillSetMutation:
         with self._db.transactional_orm_session() as session:
             row = self._set(
@@ -341,7 +347,9 @@ class SkillSetControlPlaneRepository(
                 and skill.bolt_id != bot_id
             ):
                 raise SkillSetControlPlaneNotFoundError()
-            old = self._snapshot(session, bot_id, engine_type=engine_type)
+            old = self._snapshot(
+                session, bot_id, owner_id, engine_type=engine_type
+            )
             current = (
                 self._scope(session.query(SkillSetSkill), SkillSetSkill)
                 .filter(
@@ -371,7 +379,10 @@ class SkillSetControlPlaneRepository(
                 )
             if row.is_active:
                 self._require_unique_runtime_names(
-                    session, bot_id=bot_id, candidate_ids={int(skill.id)}
+                    session,
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                    candidate_ids={int(skill.id)},
                 )
             session.add(
                 SkillSetSkill(
@@ -387,6 +398,7 @@ class SkillSetControlPlaneRepository(
                 session.add(
                     BotSkillInstallation(
                         bot_id=bot_id,
+                        owner_id=owner_id,
                         skill_id=skill.id,
                         env=get_current_env(),
                         avernet_tenant=get_current_avernet_tenant(),
@@ -396,7 +408,13 @@ class SkillSetControlPlaneRepository(
             return SkillSetMutation(_item(row), True, old)
 
     def remove_skill(
-        self, *, bot_id: str, set_id: str, skill_id: str, engine_type: str | None = None
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        set_id: str,
+        skill_id: str,
+        engine_type: str | None = None,
     ) -> SkillSetMutation:
         with self._db.transactional_orm_session() as session:
             row = self._set(
@@ -407,7 +425,9 @@ class SkillSetControlPlaneRepository(
                 locked=True,
             )
             self._ordinary(row)
-            old = self._snapshot(session, bot_id, engine_type=engine_type)
+            old = self._snapshot(
+                session, bot_id, owner_id, engine_type=engine_type
+            )
             membership = (
                 self._scope(session.query(SkillSetSkill), SkillSetSkill)
                 .filter(
@@ -423,6 +443,7 @@ class SkillSetControlPlaneRepository(
                 self._scope(
                     session.query(BotSkillInstallation), BotSkillInstallation
                 ).filter(
+                    BotSkillInstallation.owner_id == owner_id,
                     BotSkillInstallation.bot_id == bot_id,
                     BotSkillInstallation.skill_id == int(skill_id),
                 ).delete(synchronize_session=False)
@@ -430,7 +451,13 @@ class SkillSetControlPlaneRepository(
             return SkillSetMutation(_item(row), True, old)
 
     def set_active(
-        self, *, bot_id: str, set_id: str, active: bool, engine_type: str | None = None
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        set_id: str,
+        active: bool,
+        engine_type: str | None = None,
     ) -> SkillSetMutation:
         with self._db.transactional_orm_session() as session:
             row = self._set(
@@ -446,9 +473,13 @@ class SkillSetControlPlaneRepository(
                 return SkillSetMutation(
                     _item(row),
                     False,
-                    self._snapshot(session, bot_id, engine_type=engine_type),
+                    self._snapshot(
+                        session, bot_id, owner_id, engine_type=engine_type
+                    ),
                 )
-            old = self._snapshot(session, bot_id, engine_type=engine_type)
+            old = self._snapshot(
+                session, bot_id, owner_id, engine_type=engine_type
+            )
             members = (
                 self._scope(session.query(SkillSetSkill), SkillSetSkill)
                 .filter(SkillSetSkill.skill_set_id == row.id)
@@ -469,13 +500,14 @@ class SkillSetControlPlaneRepository(
             row.is_active = active
             if active:
                 self._require_unique_runtime_names(
-                    session, bot_id=bot_id, candidate_ids=ids
+                    session, bot_id=bot_id, owner_id=owner_id, candidate_ids=ids
                 )
-                existing = self._installations(session, bot_id)
+                existing = self._installations(session, bot_id, owner_id)
                 for skill_id in ids - existing:
                     session.add(
                         BotSkillInstallation(
                             bot_id=bot_id,
+                            owner_id=owner_id,
                             skill_id=skill_id,
                             env=get_current_env(),
                             avernet_tenant=get_current_avernet_tenant(),
@@ -495,6 +527,7 @@ class SkillSetControlPlaneRepository(
                 self._scope(
                     session.query(BotSkillInstallation), BotSkillInstallation
                 ).filter(
+                    BotSkillInstallation.owner_id == owner_id,
                     BotSkillInstallation.bot_id == bot_id,
                     BotSkillInstallation.skill_id.in_(ids),
                 ).delete(synchronize_session=False)
@@ -509,7 +542,12 @@ class SkillSetControlPlaneRepository(
             return SkillSetMutation(_item(row), changed, old)
 
     def replace_active_set(
-        self, *, bot_id: str, set_id: str, engine_type: str | None = None
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        set_id: str,
+        engine_type: str | None = None,
     ) -> SkillSetMutation:
         """Atomically replace all ordinary active sets with ``set_id``.
 
@@ -527,7 +565,9 @@ class SkillSetControlPlaneRepository(
                 locked=True,
             )
             self._ordinary(target)
-            old = self._snapshot(session, bot_id, engine_type=engine_type)
+            old = self._snapshot(
+                session, bot_id, owner_id, engine_type=engine_type
+            )
             query = self._scope(session.query(SkillSet), SkillSet).filter(
                 SkillSet.bolt_id == bot_id, SkillSet.is_default.is_(False)
             )
@@ -578,6 +618,7 @@ class SkillSetControlPlaneRepository(
             self._require_unique_runtime_names(
                 session,
                 bot_id=bot_id,
+                owner_id=owner_id,
                 candidate_ids=target_member_ids,
                 retired_ids=active_member_ids,
             )
@@ -585,14 +626,16 @@ class SkillSetControlPlaneRepository(
                 self._scope(
                     session.query(BotSkillInstallation), BotSkillInstallation
                 ).filter(
+                    BotSkillInstallation.owner_id == owner_id,
                     BotSkillInstallation.bot_id == bot_id,
                     BotSkillInstallation.skill_id.in_(active_member_ids),
                 ).delete(synchronize_session=False)
-            existing = self._installations(session, bot_id)
+            existing = self._installations(session, bot_id, owner_id)
             for skill_id in target_member_ids - existing:
                 session.add(
                     BotSkillInstallation(
                         bot_id=bot_id,
+                        owner_id=owner_id,
                         skill_id=skill_id,
                         env=get_current_env(),
                         avernet_tenant=get_current_avernet_tenant(),
@@ -643,6 +686,7 @@ class SkillSetControlPlaneRepository(
         self,
         *,
         bot_id: str,
+        owner_id: str,
         state: SkillSetDesiredState,
         engine_type: str | None = None,
     ) -> None:
@@ -697,7 +741,10 @@ class SkillSetControlPlaneRepository(
                     )
             self._scope(
                 session.query(BotSkillInstallation), BotSkillInstallation
-            ).filter(BotSkillInstallation.bot_id == bot_id).delete(
+            ).filter(
+                BotSkillInstallation.owner_id == owner_id,
+                BotSkillInstallation.bot_id == bot_id,
+            ).delete(
                 synchronize_session=False
             )
             session.flush()
@@ -705,6 +752,7 @@ class SkillSetControlPlaneRepository(
                 session.add(
                     BotSkillInstallation(
                         bot_id=bot_id,
+                        owner_id=owner_id,
                         skill_id=skill_id,
                         env=get_current_env(),
                         avernet_tenant=get_current_avernet_tenant(),
@@ -727,10 +775,12 @@ class SkillSetControlPlaneRepository(
             session.flush()
 
     def snapshot_desired_state(
-        self, *, bot_id: str, engine_type: str | None = None
+        self, *, bot_id: str, owner_id: str, engine_type: str | None = None
     ) -> SkillSetDesiredState:
         with self._db.orm_session() as session:
-            return self._snapshot(session, bot_id, engine_type=engine_type)
+            return self._snapshot(
+                session, bot_id, owner_id, engine_type=engine_type
+            )
 
     def _set(
         self,
@@ -810,13 +860,16 @@ class SkillSetControlPlaneRepository(
         if row.is_default:
             raise SkillSetControlPlaneConflictError("SYSTEM_DEFAULT_IMMUTABLE")
 
-    def _installations(self, session, bot_id: str) -> set[int]:
+    def _installations(self, session, bot_id: str, owner_id: str) -> set[int]:
         return {
             int(value[0])
             for value in self._scope(
                 session.query(BotSkillInstallation.skill_id), BotSkillInstallation
             )
-            .filter(BotSkillInstallation.bot_id == bot_id)
+            .filter(
+                BotSkillInstallation.owner_id == owner_id,
+                BotSkillInstallation.bot_id == bot_id,
+            )
             .all()
         }
 
@@ -848,12 +901,13 @@ class SkillSetControlPlaneRepository(
         session,
         *,
         bot_id: str,
+        owner_id: str,
         candidate_ids: set[int],
         retired_ids: set[int] | None = None,
     ) -> None:
         """Validate the complete post-command projection before any write."""
         selected_ids = (
-            self._installations(session, bot_id) - (retired_ids or set())
+            self._installations(session, bot_id, owner_id) - (retired_ids or set())
         ) | candidate_ids
         if not selected_ids:
             return
@@ -871,7 +925,12 @@ class SkillSetControlPlaneRepository(
             owner_by_name[runtime_name] = int(skill_id)
 
     def _snapshot(
-        self, session, bot_id: str, *, engine_type: str | None = None
+        self,
+        session,
+        bot_id: str,
+        owner_id: str,
+        *,
+        engine_type: str | None = None,
     ) -> SkillSetDesiredState:
         """Lock and capture every ordinary-set desired fact for this Bot."""
         query = self._scope(session.query(SkillSet), SkillSet).filter(
@@ -910,7 +969,7 @@ class SkillSetControlPlaneRepository(
                     str(member.server_code)
                 )
         return SkillSetDesiredState(
-            installations=self._installations(session, bot_id),
+            installations=self._installations(session, bot_id, owner_id),
             set_active={int(row.id): bool(row.is_active) for row in sets},
             memberships={set_id: tuple(items) for set_id, items in memberships.items()},
             mcp_installations=self._mcp_installations(session, bot_id),

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
@@ -135,7 +135,9 @@ class SkillRepository(Protocol):
         ...
 
     @abstractmethod
-    def list_bot_installed_skills(self, *, env: str, bot_id: str) -> list[dict]:
+    def list_bot_installed_skills(
+        self, *, env: str, owner_id: str, bot_id: str
+    ) -> list[dict]:
         """Return active-only Installation assets for one Bot."""
         ...
 

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_installation.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_installation.py
@@ -10,13 +10,19 @@ class SkillInstallationRepositoryProtocol(Protocol):
     """Persist and query a Bot's desired active Skill set."""
 
     @abstractmethod
-    def install(self, *, env: str, bot_id: str, skill_id: str | int) -> bool:
+    def install(
+        self, *, env: str, owner_id: str, bot_id: str, skill_id: str | int
+    ) -> bool:
         """Create the active row; return false if it already existed."""
 
     @abstractmethod
-    def uninstall(self, *, env: str, bot_id: str, skill_id: str | int) -> bool:
+    def uninstall(
+        self, *, env: str, owner_id: str, bot_id: str, skill_id: str | int
+    ) -> bool:
         """Delete the active row; return false if it was already absent."""
 
     @abstractmethod
-    def list_installed_skill_ids(self, *, env: str, bot_id: str) -> set[int]:
+    def list_installed_skill_ids(
+        self, *, env: str, owner_id: str, bot_id: str
+    ) -> set[int]:
         """Return only active desired-state Skill ids for one Bot."""

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_set_control_plane.py
@@ -60,27 +60,51 @@ class SkillSetControlPlaneRepositoryProtocol(Protocol):
     def resolve_legacy_skill_id(self, *, bot_id: str, identifier: str) -> str: ...
     @abstractmethod
     def add_skill(
-        self, *, bot_id: str, set_id: str, skill_id: str, engine_type: str | None = None
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        set_id: str,
+        skill_id: str,
+        engine_type: str | None = None,
     ) -> SkillSetMutation: ...
     @abstractmethod
     def remove_skill(
-        self, *, bot_id: str, set_id: str, skill_id: str, engine_type: str | None = None
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        set_id: str,
+        skill_id: str,
+        engine_type: str | None = None,
     ) -> SkillSetMutation: ...
     @abstractmethod
     def add_mcp(
-        self, *, bot_id: str, set_id: str, server_code: str, engine_type: str | None = None
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        set_id: str,
+        server_code: str,
+        engine_type: str | None = None,
     ) -> SkillSetMutation: ...
     @abstractmethod
     def remove_mcp(
-        self, *, bot_id: str, set_id: str, server_code: str, engine_type: str | None = None
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        set_id: str,
+        server_code: str,
+        engine_type: str | None = None,
     ) -> SkillSetMutation: ...
     @abstractmethod
     def activate_mcp_direct(
-        self, *, bot_id: str, server_code: str, engine_type: str | None = None
+        self, *, bot_id: str, owner_id: str, server_code: str, engine_type: str | None = None
     ) -> SkillSetMutation: ...
     @abstractmethod
     def deactivate_mcp_direct(
-        self, *, bot_id: str, server_code: str, engine_type: str | None = None
+        self, *, bot_id: str, owner_id: str, server_code: str, engine_type: str | None = None
     ) -> SkillSetMutation: ...
     @abstractmethod
     def list_installed_mcps(
@@ -88,21 +112,28 @@ class SkillSetControlPlaneRepositoryProtocol(Protocol):
     ) -> set[str]: ...
     @abstractmethod
     def set_active(
-        self, *, bot_id: str, set_id: str, active: bool, engine_type: str | None = None
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        set_id: str,
+        active: bool,
+        engine_type: str | None = None,
     ) -> SkillSetMutation: ...
     @abstractmethod
     def replace_active_set(
-        self, *, bot_id: str, set_id: str, engine_type: str | None = None
+        self, *, bot_id: str, owner_id: str, set_id: str, engine_type: str | None = None
     ) -> SkillSetMutation: ...
     @abstractmethod
     def snapshot_desired_state(
-        self, *, bot_id: str, engine_type: str | None = None
+        self, *, bot_id: str, owner_id: str, engine_type: str | None = None
     ) -> SkillSetDesiredState: ...
     @abstractmethod
     def restore_desired_state(
         self,
         *,
         bot_id: str,
+        owner_id: str,
         state: SkillSetDesiredState,
         engine_type: str | None = None,
     ) -> None: ...

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skills_pool.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skills_pool.py
@@ -418,7 +418,7 @@ class SkillsPoolSkillRepositoryProtocol(Protocol):
 
     @abstractmethod
     def list_bot_local_assets(
-        self, *, env: str, bot_id: str
+        self, *, env: str, owner_id: str, bot_id: str
     ) -> list[RegisteredSkillAsset]: ...
 
     @abstractmethod
@@ -427,7 +427,7 @@ class SkillsPoolSkillRepositoryProtocol(Protocol):
         *,
         env: str,
         bot_id: str,
-        user_id: str,
+        owner_id: str,
         engine: str,
     ) -> list[RegisteredSkillAsset]: ...
 

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -97,7 +97,8 @@ internal_dependencies:
 Skill-set switching is the highest-throughput flow in production. Changes here can break every chat session in flight. Coordinate with the propagation log schema before changing repository protocols.
 
 Local Skill compatibility materializes active state in
-`ac_bot_skill_installation` and reads it through the Installation repository.
+`ac_bot_skill_installation`, whose identity is `(tenant, env, owner_id, bot_id,
+skill_id)`, and reads it through the Installation repository.
 HTTP and runtime adapters must not write that table or reconstruct Local active
 state from Default SkillSet exclusions.
 
@@ -127,7 +128,13 @@ The P1-01 Local migration is a two-step operation: run the read-only
 complete result, then explicitly approve and run
 `sql/2026_08_20_bot_skill_installation_backfill_apply.sql` under the same
 Local-writer freeze. Its selector mirrors the legacy rule that *any* matching
-Default exclusion is inactive, including a stale former-default exclusion.
+Default exclusion is inactive, including a stale former-default exclusion; it
+does not require a Default SkillSet membership. It only migrates a `local://`
+asset when its `(env, owner_id, bot_id)` resolves to a live, non-deleted Bot.
+Multiple live Bot rows for the same identity are a fail-closed exception. The
+dry-run reports the exception and the apply script records per-environment
+`legacy_active_local`, `live_exact_bot_candidates`, `ambiguous`, `inserted`,
+and `missing` counts in the run audit before an operator decides to commit.
 The apply script leaves its transaction open; source the paired
 `backfill_verify_commit.sql` in that same session and issue `COMMIT` only after
 its missing-installations count is zero (otherwise `ROLLBACK`).

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
@@ -203,7 +203,7 @@ class BotRuntimeProjectionReconciler:
             self._pool_skills.list_bot_active_assets(
                 env=str(bot["env"]),
                 bot_id=bot_id,
-                user_id=owner_id,
+                owner_id=owner_id,
                 engine=engine,
             )
         )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_skill_asset_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_skill_asset_service.py
@@ -105,7 +105,7 @@ class BotSkillAssetService:
             user_id=user_id,
         )
         installed = self._skill_repo.list_bot_installed_skills(
-            env=str(bot["env"]), bot_id=bot_id
+            env=str(bot["env"]), owner_id=_owner_id, bot_id=bot_id
         )
         # ``active`` is a desired-state projection, never an asset attribute.
         # This keeps shared Repo detail aligned with the same Installation fact

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_state_service.py
@@ -131,6 +131,7 @@ class LocalSkillStateService:
                 changed = self._write_desired_state(
                     active=active,
                     env=str(bot["env"]),
+                    owner_id=owner_id,
                     bot_id=bot_id,
                     skill_id=skill_id,
                 )
@@ -159,6 +160,7 @@ class LocalSkillStateService:
                             self._write_desired_state(
                                 active=not active,
                                 env=str(bot["env"]),
+                                owner_id=owner_id,
                                 bot_id=bot_id,
                                 skill_id=skill_id,
                             )
@@ -253,6 +255,7 @@ class LocalSkillStateService:
                     changed = self._write_desired_state(
                         active=active,
                         env=str(bot["env"]),
+                        owner_id=owner_id,
                         bot_id=bot_id,
                         skill_id=skill_id,
                     )
@@ -289,6 +292,7 @@ class LocalSkillStateService:
                         self._write_desired_state(
                             active=not active,
                             env=str(bot["env"]),
+                            owner_id=owner_id,
                             bot_id=bot_id,
                             skill_id=skill_id,
                         )
@@ -376,14 +380,17 @@ class LocalSkillStateService:
         *,
         active: bool,
         env: str,
+        owner_id: str,
         bot_id: str,
         skill_id: str,
     ) -> bool:
         if active:
             return self._installations.install(
-                env=env, bot_id=bot_id, skill_id=skill_id
+                env=env, owner_id=owner_id, bot_id=bot_id, skill_id=skill_id
             )
-        return self._installations.uninstall(env=env, bot_id=bot_id, skill_id=skill_id)
+        return self._installations.uninstall(
+            env=env, owner_id=owner_id, bot_id=bot_id, skill_id=skill_id
+        )
 
     @staticmethod
     def _require_repo_runtime_command(
@@ -441,7 +448,7 @@ class LocalSkillStateService:
             assets = self._pool_skills.list_bot_active_assets(
                 env=str(bot["env"]),
                 bot_id=bot_id,
-                user_id=owner_id,
+                owner_id=owner_id,
                 engine=str(bot["active_engine"]),
             )
             candidate = RegisteredSkillAsset(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -376,6 +376,7 @@ class SkillSetControlPlaneService:
             action="skill_set_add_skill",
             mutation=lambda: self._repository.add_skill(
                 bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
                 set_id=set_id,
                 skill_id=skill_id,
                 engine_type=self._engine(bot),
@@ -400,6 +401,7 @@ class SkillSetControlPlaneService:
             command=BotSkillRuntimeCommand.CLEANUP,
             mutation=lambda: self._repository.remove_skill(
                 bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
                 set_id=set_id,
                 skill_id=skill_id,
                 engine_type=self._engine(bot),
@@ -480,6 +482,7 @@ class SkillSetControlPlaneService:
             action="skill_set_add_mcp",
             mutation=lambda: self._repository.add_mcp(
                 bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
                 set_id=set_id,
                 server_code=server_code,
                 engine_type=self._engine(bot),
@@ -504,6 +507,7 @@ class SkillSetControlPlaneService:
             command=BotSkillRuntimeCommand.CLEANUP,
             mutation=lambda: self._repository.remove_mcp(
                 bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
                 set_id=set_id,
                 server_code=server_code,
                 engine_type=self._engine(bot),
@@ -522,6 +526,7 @@ class SkillSetControlPlaneService:
             action="mcp_direct_activate",
             mutation=lambda: self._repository.activate_mcp_direct(
                 bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
                 server_code=server_code,
                 engine_type=self._engine(bot),
             ),
@@ -539,6 +544,7 @@ class SkillSetControlPlaneService:
             command=BotSkillRuntimeCommand.CLEANUP,
             mutation=lambda: self._repository.deactivate_mcp_direct(
                 bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
                 server_code=server_code,
                 engine_type=self._engine(bot),
             ),
@@ -569,7 +575,11 @@ class SkillSetControlPlaneService:
             actor_id=user_id,
             action="skill_set_activate",
             mutation=lambda: self._repository.set_active(
-                bot_id=bot_id, set_id=set_id, active=True, engine_type=self._engine(bot)
+                bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
+                set_id=set_id,
+                active=True,
+                engine_type=self._engine(bot),
             ),
         )
 
@@ -585,6 +595,7 @@ class SkillSetControlPlaneService:
             command=BotSkillRuntimeCommand.CLEANUP,
             mutation=lambda: self._repository.set_active(
                 bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
                 set_id=set_id,
                 active=False,
                 engine_type=self._engine(bot),
@@ -600,7 +611,10 @@ class SkillSetControlPlaneService:
             actor_id=actor_id,
             action="skill_set_switch",
             mutation=lambda: self._repository.replace_active_set(
-                bot_id=bot_id, set_id=set_id, engine_type=self._engine(bot)
+                bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
+                set_id=set_id,
+                engine_type=self._engine(bot),
             ),
         )
 
@@ -614,6 +628,7 @@ class SkillSetControlPlaneService:
             action="skill_set_sync",
             mutation=lambda: self._repository.set_active(
                 bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
                 set_id=set_id,
                 active=True,
                 engine_type=self._engine(bot),
@@ -758,6 +773,7 @@ class SkillSetControlPlaneService:
             self._ensure_mutation_lease(mutation_lease)
             self._repository.restore_desired_state(
                 bot_id=bot_id,
+                owner_id=owner_id,
                 state=mutation.previous_state,
                 engine_type=self._engine(bot),
             )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -935,7 +935,10 @@ class SkillSetService:
                 and self._installations is not None
             ):
                 changed = self._installations.uninstall(
-                    env=str(skill["env"]), bot_id=self.bot_id, skill_id=skill_id
+                    env=str(skill["env"]),
+                    owner_id=self.entity_id,
+                    bot_id=self.bot_id,
+                    skill_id=skill_id,
                 )
                 synced = await self._sync_symlinks_to_device_if_needed(
                     user_id or self.entity_id
@@ -943,6 +946,7 @@ class SkillSetService:
                 if not synced and changed:
                     self._installations.install(
                         env=str(skill["env"]),
+                        owner_id=self.entity_id,
                         bot_id=self.bot_id,
                         skill_id=skill_id,
                     )
@@ -1256,7 +1260,10 @@ class SkillSetService:
             ]
         """
         effective_bolt_id = bolt_id if bolt_id else self.bot_id
-        effective_user_id = user_id if user_id else self.entity_id
+        # ``user_id`` is the caller in historical adapters. Installation and
+        # Default exclusion state belong to the Bot owner carried by the
+        # factory's entity_id, never to a collaborator acting on that Bot.
+        effective_user_id = self.entity_id
 
         logger.info(f"[get_all_skill_sets_with_mcps] user_id={effective_user_id}, bolt_id={effective_bolt_id}")
 
@@ -1306,7 +1313,9 @@ class SkillSetService:
         from agentclaw.community.utils.env_utils import get_current_env
 
         installed_skills = self.skill_repo.list_bot_installed_skills(
-            env=get_current_env(), bot_id=effective_bolt_id
+            env=get_current_env(),
+            owner_id=effective_user_id,
+            bot_id=effective_bolt_id,
         )
         # 1. 查询所有激活的技能集（包含默认能力集）
         active_skill_sets = self.skill_set_repo.get_all_active_skill_sets(

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_bot_skill_installation.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_bot_skill_installation.sql
@@ -5,13 +5,14 @@ CREATE TABLE IF NOT EXISTS ac_bot_skill_installation (
     id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
     avernet_tenant VARCHAR(64) NOT NULL DEFAULT 'teamclaw',
     env VARCHAR(20) NOT NULL,
+    owner_id VARCHAR(128) NOT NULL,
     bot_id VARCHAR(100) NOT NULL,
     skill_id BIGINT UNSIGNED NOT NULL,
     gmt_created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     gmt_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
-    UNIQUE KEY uk_bot_skill_installation (avernet_tenant, env, bot_id, skill_id),
-    KEY idx_bot_skill_installation_bot (avernet_tenant, env, bot_id),
+    UNIQUE KEY uk_bot_skill_installation (avernet_tenant, env, owner_id, bot_id, skill_id),
+    KEY idx_bot_skill_installation_bot (avernet_tenant, env, owner_id, bot_id),
     CONSTRAINT fk_bot_skill_installation_skill
       FOREIGN KEY (skill_id) REFERENCES ac_skill(id)
 );
@@ -23,9 +24,25 @@ CREATE TABLE IF NOT EXISTS ac_bot_skill_installation_backfill_audit (
     run_id CHAR(36) NOT NULL,
     avernet_tenant VARCHAR(64) NOT NULL,
     env VARCHAR(20) NOT NULL,
+    owner_id VARCHAR(128) NOT NULL,
     bot_id VARCHAR(100) NOT NULL,
     skill_id BIGINT UNSIGNED NOT NULL,
     gmt_created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (run_id, avernet_tenant, env, bot_id, skill_id),
+    PRIMARY KEY (run_id, avernet_tenant, env, owner_id, bot_id, skill_id),
     KEY idx_bot_skill_installation_backfill_audit_run (run_id)
+);
+
+-- One immutable rollout summary per tenant/environment. It archives the
+-- observed legacy population and the apply result; it is not desired state.
+CREATE TABLE IF NOT EXISTS ac_bot_skill_installation_backfill_run_audit (
+    run_id CHAR(36) NOT NULL,
+    avernet_tenant VARCHAR(64) NOT NULL,
+    env VARCHAR(20) NOT NULL,
+    legacy_active_local BIGINT UNSIGNED NOT NULL,
+    live_exact_bot_candidates BIGINT UNSIGNED NOT NULL,
+    ambiguous_live_bot_candidates BIGINT UNSIGNED NOT NULL,
+    inserted_installations BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    missing_installations BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    gmt_created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (run_id, avernet_tenant, env)
 );

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_bot_skill_installation_backfill_apply.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_bot_skill_installation_backfill_apply.sql
@@ -1,62 +1,126 @@
 -- P1-01 Installation backfill apply. Run only after the separate dry-run has
 -- been reviewed and while the same Local Skill writer freeze remains active.
 --
--- 1. Run 2026_08_20_bot_skill_installation_backfill_dry_run.sql and retain its
---    complete result as the change record.
--- 2. Replace the run id below with a newly generated UUID and change approval
---    from 0 to 1. Leaving either placeholder/default intact produces no writes.
--- 3. Commit only after missing_installations is zero; retain the returned run
---    id with the dry-run evidence. The audit rows identify the exact rollback
---    set.
+-- 1. Run the paired dry-run and retain all three result sets.
+-- 2. Any ambiguous live Bot identity is a hard stop. This script records the
+--    metric but inserts no Installation/audit candidates while ambiguity > 0.
+-- 3. Replace the run id and change approval from 0 to 1. Otherwise this script
+--    only builds a session-local candidate view and writes nothing persistent.
+-- 4. Source verify-and-commit in this same session. It commits only after every
+--    recorded candidate has an Installation row.
 SET @p1_01_installation_backfill_run_id = 'REPLACE_WITH_NEW_UUID';
 SET @p1_01_installation_backfill_approved = 0;
 
+DROP TEMPORARY TABLE IF EXISTS p1_01_legacy_active_local_candidates;
+CREATE TEMPORARY TABLE p1_01_legacy_active_local_candidates AS
+SELECT skill.avernet_tenant,
+       skill.env,
+       skill.user_id AS owner_id,
+       skill.bolt_id AS bot_id,
+       skill.id AS skill_id,
+       COUNT(bot.id) AS live_bot_count
+FROM ac_skill skill
+LEFT JOIN ac_bots bot
+  ON bot.avernet_tenant = skill.avernet_tenant
+ AND bot.env = skill.env
+ AND bot.owner_id = skill.user_id
+ AND bot.bot_id = skill.bolt_id
+ AND bot.is_delete = 0
+WHERE skill.git_path LIKE 'local://%'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM ac_default_skillset_skill_exclusion exclusion
+      WHERE exclusion.avernet_tenant = skill.avernet_tenant
+        AND exclusion.user_id = skill.user_id
+        AND exclusion.bot_id = skill.bolt_id
+        AND exclusion.skill_id = skill.id
+  )
+GROUP BY skill.avernet_tenant, skill.env, skill.user_id, skill.bolt_id, skill.id;
+
+SELECT COUNT(*) INTO @p1_01_installation_backfill_ambiguous_count
+FROM p1_01_legacy_active_local_candidates
+WHERE live_bot_count > 1;
+
 START TRANSACTION;
 
-INSERT INTO ac_bot_skill_installation_backfill_audit
-  (run_id, avernet_tenant, env, bot_id, skill_id)
-SELECT DISTINCT @p1_01_installation_backfill_run_id, rel.avernet_tenant, rel.env,
-       skill_set.bolt_id, rel.skill_id
-FROM ac_skill_set_skill rel
-JOIN ac_skill_set skill_set ON skill_set.id = rel.skill_set_id
- AND skill_set.avernet_tenant = rel.avernet_tenant AND skill_set.env = rel.env
-JOIN ac_skill skill ON skill.id = rel.skill_id
- AND skill.avernet_tenant = rel.avernet_tenant AND skill.env = rel.env
+INSERT INTO ac_bot_skill_installation_backfill_run_audit
+  (run_id, avernet_tenant, env, legacy_active_local,
+   live_exact_bot_candidates, ambiguous_live_bot_candidates,
+   inserted_installations, missing_installations)
+SELECT @p1_01_installation_backfill_run_id,
+       avernet_tenant,
+       env,
+       COUNT(*),
+       SUM(live_bot_count = 1),
+       SUM(live_bot_count > 1),
+       0,
+       0
+FROM p1_01_legacy_active_local_candidates
 WHERE @p1_01_installation_backfill_approved = 1
- AND @p1_01_installation_backfill_run_id <> 'REPLACE_WITH_NEW_UUID'
- AND skill_set.is_default = 1
- AND skill.git_path LIKE 'local://%'
- AND NOT EXISTS (
-     SELECT 1
-     FROM ac_default_skillset_skill_exclusion exclusion
-     WHERE exclusion.avernet_tenant = rel.avernet_tenant
-       AND exclusion.user_id = skill_set.user_id
-       AND exclusion.bot_id = skill_set.bolt_id
-       AND exclusion.skill_id = rel.skill_id
- )
- AND NOT EXISTS (
-     SELECT 1
-     FROM ac_bot_skill_installation installation
-     WHERE installation.avernet_tenant = rel.avernet_tenant
-       AND installation.env = rel.env
-       AND installation.bot_id = skill_set.bolt_id
-       AND installation.skill_id = rel.skill_id
- );
-SELECT ROW_COUNT() AS audited_candidates;
+  AND @p1_01_installation_backfill_run_id <> 'REPLACE_WITH_NEW_UUID'
+GROUP BY avernet_tenant, env;
 
-INSERT INTO ac_bot_skill_installation (avernet_tenant, env, bot_id, skill_id)
-SELECT avernet_tenant, env, bot_id, skill_id
+INSERT INTO ac_bot_skill_installation_backfill_audit
+  (run_id, avernet_tenant, env, owner_id, bot_id, skill_id)
+SELECT @p1_01_installation_backfill_run_id,
+       candidate.avernet_tenant,
+       candidate.env,
+       candidate.owner_id,
+       candidate.bot_id,
+       candidate.skill_id
+FROM p1_01_legacy_active_local_candidates candidate
+WHERE @p1_01_installation_backfill_approved = 1
+  AND @p1_01_installation_backfill_run_id <> 'REPLACE_WITH_NEW_UUID'
+  AND @p1_01_installation_backfill_ambiguous_count = 0
+  AND candidate.live_bot_count = 1
+  AND NOT EXISTS (
+      SELECT 1
+      FROM ac_bot_skill_installation installation
+      WHERE installation.avernet_tenant = candidate.avernet_tenant
+        AND installation.env = candidate.env
+        AND installation.owner_id = candidate.owner_id
+        AND installation.bot_id = candidate.bot_id
+        AND installation.skill_id = candidate.skill_id
+  );
+
+INSERT INTO ac_bot_skill_installation
+  (avernet_tenant, env, owner_id, bot_id, skill_id)
+SELECT avernet_tenant, env, owner_id, bot_id, skill_id
 FROM ac_bot_skill_installation_backfill_audit
 WHERE run_id = @p1_01_installation_backfill_run_id;
-SELECT ROW_COUNT() AS created_installations;
+
+UPDATE ac_bot_skill_installation_backfill_run_audit run_audit
+SET inserted_installations = (
+        SELECT COUNT(*)
+        FROM ac_bot_skill_installation_backfill_audit audit
+        WHERE audit.run_id = run_audit.run_id
+          AND audit.avernet_tenant = run_audit.avernet_tenant
+          AND audit.env = run_audit.env
+    ),
+    missing_installations = (
+        SELECT COUNT(*)
+        FROM ac_bot_skill_installation_backfill_audit audit
+        LEFT JOIN ac_bot_skill_installation installation
+          ON installation.avernet_tenant = audit.avernet_tenant
+         AND installation.env = audit.env
+         AND installation.owner_id = audit.owner_id
+         AND installation.bot_id = audit.bot_id
+         AND installation.skill_id = audit.skill_id
+        WHERE audit.run_id = run_audit.run_id
+          AND audit.avernet_tenant = run_audit.avernet_tenant
+          AND audit.env = run_audit.env
+          AND installation.id IS NULL
+    )
+WHERE run_audit.run_id = @p1_01_installation_backfill_run_id;
+
+SELECT @p1_01_installation_backfill_ambiguous_count AS ambiguous_live_bot_candidates,
+       CASE WHEN @p1_01_installation_backfill_ambiguous_count = 0 THEN 1 ELSE 0 END
+         AS apply_allowed;
+SELECT *
+FROM ac_bot_skill_installation_backfill_run_audit
+WHERE run_id = @p1_01_installation_backfill_run_id
+ORDER BY avernet_tenant, env;
 
 -- Do not COMMIT in this script. Source the paired verify-and-commit file in
--- this same database session. If the check is non-zero it executes ROLLBACK;
--- a disconnected session rolls this transaction back automatically.
-SELECT COUNT(*) AS missing_installations
-FROM ac_bot_skill_installation_backfill_audit audit
-LEFT JOIN ac_bot_skill_installation installation
- ON installation.avernet_tenant = audit.avernet_tenant AND installation.env = audit.env
- AND installation.bot_id = audit.bot_id AND installation.skill_id = audit.skill_id
-WHERE audit.run_id = @p1_01_installation_backfill_run_id AND installation.id IS NULL;
-SELECT @p1_01_installation_backfill_run_id AS installation_backfill_run_id;
+-- this same database session. A disconnected session rolls this transaction
+-- back automatically.

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_bot_skill_installation_backfill_dry_run.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_bot_skill_installation_backfill_dry_run.sql
@@ -1,35 +1,126 @@
 -- P1-01 Installation backfill dry-run. This file is intentionally read-only.
 --
--- First freeze every Local Skill writer. Keep that same writer freeze through
--- the separately-reviewed apply step, otherwise the reviewed candidate set is
--- no longer evidence for the rows that would be written.
+-- Freeze every Local Skill writer before this query and retain that same freeze
+-- through the separately reviewed apply step. The published Local contract is
+-- independent of Default SkillSet membership: a local:// Skill is active when
+-- no exact historical exclusion exists.
 --
--- This exactly mirrors the published Local active read: any exclusion matching
--- tenant + user_id + bot_id + skill_id makes the Local Skill inactive. Do not
--- scope the exclusion to the current Default SkillSet; former-default rows are
--- still observed by the legacy contract.
-SELECT DISTINCT rel.avernet_tenant, rel.env, skill_set.bolt_id, rel.skill_id
-FROM ac_skill_set_skill rel
-JOIN ac_skill_set skill_set ON skill_set.id = rel.skill_set_id
- AND skill_set.avernet_tenant = rel.avernet_tenant AND skill_set.env = rel.env
-JOIN ac_skill skill ON skill.id = rel.skill_id
- AND skill.avernet_tenant = rel.avernet_tenant AND skill.env = rel.env
-WHERE skill_set.is_default = 1
- AND skill.git_path LIKE 'local://%'
- AND NOT EXISTS (
-     SELECT 1
-     FROM ac_default_skillset_skill_exclusion exclusion
-     WHERE exclusion.avernet_tenant = rel.avernet_tenant
-       AND exclusion.user_id = skill_set.user_id
-       AND exclusion.bot_id = skill_set.bolt_id
-       AND exclusion.skill_id = rel.skill_id
- )
- AND NOT EXISTS (
-     SELECT 1
-     FROM ac_bot_skill_installation installation
-     WHERE installation.avernet_tenant = rel.avernet_tenant
-       AND installation.env = rel.env
-       AND installation.bot_id = skill_set.bolt_id
-       AND installation.skill_id = rel.skill_id
- )
-ORDER BY rel.avernet_tenant, rel.env, skill_set.bolt_id, rel.skill_id;
+-- ``live_bot_count`` must be exactly one. A duplicated live Bot identity is
+-- an exception, not a tie to break: apply will fail closed while any such row
+-- exists. This matters especially for bot_id='default'.
+
+-- 1. Archive these result rows with the release change record before apply.
+WITH legacy_active_local AS (
+    SELECT skill.avernet_tenant,
+           skill.env,
+           skill.user_id AS owner_id,
+           skill.bolt_id AS bot_id,
+           skill.id AS skill_id,
+           COUNT(bot.id) AS live_bot_count
+    FROM ac_skill skill
+    LEFT JOIN ac_bots bot
+      ON bot.avernet_tenant = skill.avernet_tenant
+     AND bot.env = skill.env
+     AND bot.owner_id = skill.user_id
+     AND bot.bot_id = skill.bolt_id
+     AND bot.is_delete = 0
+    WHERE skill.git_path LIKE 'local://%'
+      AND NOT EXISTS (
+          SELECT 1
+          FROM ac_default_skillset_skill_exclusion exclusion
+          WHERE exclusion.avernet_tenant = skill.avernet_tenant
+            AND exclusion.user_id = skill.user_id
+            AND exclusion.bot_id = skill.bolt_id
+            AND exclusion.skill_id = skill.id
+      )
+    GROUP BY skill.avernet_tenant, skill.env, skill.user_id, skill.bolt_id, skill.id
+)
+SELECT avernet_tenant,
+       env,
+       COUNT(*) AS legacy_active_local,
+       SUM(live_bot_count = 1) AS live_exact_bot_candidates,
+       SUM(live_bot_count > 1) AS ambiguous_live_bot_candidates,
+       CASE WHEN SUM(live_bot_count > 1) = 0 THEN 1 ELSE 0 END AS apply_allowed
+FROM legacy_active_local
+GROUP BY avernet_tenant, env
+ORDER BY avernet_tenant, env;
+
+-- 2. Every row here is a blocking exception. Do not run apply until empty.
+WITH legacy_active_local AS (
+    SELECT skill.avernet_tenant,
+           skill.env,
+           skill.user_id AS owner_id,
+           skill.bolt_id AS bot_id,
+           skill.id AS skill_id,
+           COUNT(bot.id) AS live_bot_count
+    FROM ac_skill skill
+    LEFT JOIN ac_bots bot
+      ON bot.avernet_tenant = skill.avernet_tenant
+     AND bot.env = skill.env
+     AND bot.owner_id = skill.user_id
+     AND bot.bot_id = skill.bolt_id
+     AND bot.is_delete = 0
+    WHERE skill.git_path LIKE 'local://%'
+      AND NOT EXISTS (
+          SELECT 1
+          FROM ac_default_skillset_skill_exclusion exclusion
+          WHERE exclusion.avernet_tenant = skill.avernet_tenant
+            AND exclusion.user_id = skill.user_id
+            AND exclusion.bot_id = skill.bolt_id
+            AND exclusion.skill_id = skill.id
+      )
+    GROUP BY skill.avernet_tenant, skill.env, skill.user_id, skill.bolt_id, skill.id
+)
+SELECT avernet_tenant, env, owner_id, bot_id, skill_id, live_bot_count
+FROM legacy_active_local
+WHERE live_bot_count > 1
+ORDER BY avernet_tenant, env, owner_id, bot_id, skill_id;
+
+-- 3. These are the exact candidate identities. They are returned only when
+-- no ambiguity exists anywhere in the frozen rollout scope.
+WITH legacy_active_local AS (
+    SELECT skill.avernet_tenant,
+           skill.env,
+           skill.user_id AS owner_id,
+           skill.bolt_id AS bot_id,
+           skill.id AS skill_id,
+           COUNT(bot.id) AS live_bot_count
+    FROM ac_skill skill
+    LEFT JOIN ac_bots bot
+      ON bot.avernet_tenant = skill.avernet_tenant
+     AND bot.env = skill.env
+     AND bot.owner_id = skill.user_id
+     AND bot.bot_id = skill.bolt_id
+     AND bot.is_delete = 0
+    WHERE skill.git_path LIKE 'local://%'
+      AND NOT EXISTS (
+          SELECT 1
+          FROM ac_default_skillset_skill_exclusion exclusion
+          WHERE exclusion.avernet_tenant = skill.avernet_tenant
+            AND exclusion.user_id = skill.user_id
+            AND exclusion.bot_id = skill.bolt_id
+            AND exclusion.skill_id = skill.id
+      )
+    GROUP BY skill.avernet_tenant, skill.env, skill.user_id, skill.bolt_id, skill.id
+)
+SELECT candidate.avernet_tenant,
+       candidate.env,
+       candidate.owner_id,
+       candidate.bot_id,
+       candidate.skill_id
+FROM legacy_active_local candidate
+WHERE candidate.live_bot_count = 1
+  AND NOT EXISTS (
+      SELECT 1 FROM legacy_active_local ambiguity WHERE ambiguity.live_bot_count > 1
+  )
+  AND NOT EXISTS (
+      SELECT 1
+      FROM ac_bot_skill_installation installation
+      WHERE installation.avernet_tenant = candidate.avernet_tenant
+        AND installation.env = candidate.env
+        AND installation.owner_id = candidate.owner_id
+        AND installation.bot_id = candidate.bot_id
+        AND installation.skill_id = candidate.skill_id
+  )
+ORDER BY candidate.avernet_tenant, candidate.env, candidate.owner_id,
+         candidate.bot_id, candidate.skill_id;

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_bot_skill_installation_backfill_rollback.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_bot_skill_installation_backfill_rollback.sql
@@ -8,7 +8,8 @@ START TRANSACTION;
 DELETE installation FROM ac_bot_skill_installation installation
 JOIN ac_bot_skill_installation_backfill_audit audit
  ON audit.avernet_tenant = installation.avernet_tenant AND audit.env = installation.env
- AND audit.bot_id = installation.bot_id AND audit.skill_id = installation.skill_id
+ AND audit.owner_id = installation.owner_id AND audit.bot_id = installation.bot_id
+ AND audit.skill_id = installation.skill_id
 WHERE audit.run_id = @p1_01_installation_backfill_run_id;
 SELECT ROW_COUNT() AS rolled_back_installations;
 COMMIT;

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_bot_skill_installation_backfill_verify_commit.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_bot_skill_installation_backfill_verify_commit.sql
@@ -1,12 +1,20 @@
--- Source immediately after the apply file in the SAME database session.
--- This is deliberately a separate explicit operator step: inspect the first
--- result, issue ROLLBACK if it is non-zero, otherwise execute COMMIT below.
-SELECT COUNT(*) AS missing_installations
-FROM ac_bot_skill_installation_backfill_audit audit
-LEFT JOIN ac_bot_skill_installation installation
- ON installation.avernet_tenant = audit.avernet_tenant AND installation.env = audit.env
- AND installation.bot_id = audit.bot_id AND installation.skill_id = audit.skill_id
-WHERE audit.run_id = @p1_01_installation_backfill_run_id AND installation.id IS NULL;
+-- Source immediately after apply in the SAME database session. This is a
+-- deliberately separate explicit operator step: ROLLBACK unless every row is
+-- apply_allowed, non-ambiguous, and has zero missing Installations.
+SELECT avernet_tenant,
+       env,
+       legacy_active_local,
+       live_exact_bot_candidates,
+       ambiguous_live_bot_candidates,
+       inserted_installations,
+       missing_installations,
+       CASE
+           WHEN ambiguous_live_bot_candidates = 0 AND missing_installations = 0
+           THEN 1 ELSE 0
+       END AS commit_allowed
+FROM ac_bot_skill_installation_backfill_run_audit
+WHERE run_id = @p1_01_installation_backfill_run_id
+ORDER BY avernet_tenant, env;
 
 -- Only run this statement after the preceding count is zero.
 COMMIT;

--- a/src/backend/src/agentclaw/community/core/skills_pool/active_aicoding_bridge_repair.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/active_aicoding_bridge_repair.py
@@ -75,6 +75,7 @@ async def request_active_aicoding_bridge_repair(
             local_skill_name(asset)
             for asset in skills.list_bot_local_assets(
                 env=scope.env,
+                owner_id=user_id,
                 bot_id=scope.bot_id,
             )
         ]
@@ -82,7 +83,7 @@ async def request_active_aicoding_bridge_repair(
             skills.list_bot_active_assets(
                 env=scope.env,
                 bot_id=scope.bot_id,
-                user_id=user_id,
+                owner_id=user_id,
                 engine=logical_engine,
             )
         )

--- a/src/backend/src/agentclaw/community/core/skills_pool/mapping_convergence.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/mapping_convergence.py
@@ -65,7 +65,7 @@ async def converge_post_cutover_mappings(
             skills.list_bot_active_assets(
                 env=scope.env,
                 bot_id=scope.bot_id,
-                user_id=user_id,
+                owner_id=user_id,
                 engine=engine,
             )
         )
@@ -122,7 +122,7 @@ async def converge_post_cutover_mappings(
                 skills.list_bot_active_assets(
                     env=scope.env,
                     bot_id=scope.bot_id,
-                    user_id=user_id,
+                    owner_id=user_id,
                     engine=engine,
                 )
             )

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -314,12 +314,13 @@ class SkillsPoolReconcileService:
 
         local_assets = self._skills.list_bot_local_assets(
             env=scope.env,
+            owner_id=user_id,
             bot_id=scope.bot_id,
         )
         active_assets = self._skills.list_bot_active_assets(
             env=scope.env,
             bot_id=scope.bot_id,
-            user_id=user_id,
+            owner_id=user_id,
             engine=engine,
         )
         try:
@@ -850,7 +851,7 @@ class SkillsPoolReconcileService:
                     self._skills.list_bot_active_assets(
                         env=scope.env,
                         bot_id=scope.bot_id,
-                        user_id=str(owner_id),
+                        owner_id=str(owner_id),
                         engine=engine,
                     )
                 )

--- a/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
@@ -331,7 +331,7 @@ class SkillsPoolRollbackService:
 
         probe = await self._runtime.probe(
             bot_id=scope.bot_id,
-            user_id=user_id,
+            owner_id=user_id,
             engine=engine,
         )
         restoration_resume = is_trusted_aicoding_repo_restoration_resume(
@@ -360,12 +360,13 @@ class SkillsPoolRollbackService:
 
         local_assets = self._skills.list_bot_local_assets(
             env=scope.env,
+            owner_id=user_id,
             bot_id=scope.bot_id,
         )
         active_assets = self._skills.list_bot_active_assets(
             env=scope.env,
             bot_id=scope.bot_id,
-            user_id=user_id,
+            owner_id=user_id,
             engine=engine,
         )
         try:

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_tenant_isolation.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_tenant_isolation.py
@@ -111,7 +111,10 @@ def test_every_skills_operation_is_guarded_from_another_tenant(
             }
         )
         assert world.get(SkillInstallationRepositoryProtocol).install(
-            env="dev", bot_id=_PRIVATE_BOT_ID, skill_id=skill["id"]
+            env="dev",
+            owner_id=_OWNER,
+            bot_id=_PRIVATE_BOT_ID,
+            skill_id=skill["id"],
         )
         world.get(BotRepository).insert(
             {

--- a/src/backend/tests/community/core/skill_center/test_bot_skill_asset_service.py
+++ b/src/backend/tests/community/core/skill_center/test_bot_skill_asset_service.py
@@ -20,8 +20,8 @@ class _Skills:
             "bolt_id": "bot",
         }
 
-    def list_bot_installed_skills(self, *, env: str, bot_id: str):
-        assert (env, bot_id) == ("pre", "bot")
+    def list_bot_installed_skills(self, *, env: str, owner_id: str, bot_id: str):
+        assert (env, owner_id, bot_id) == ("pre", "owner", "bot")
         return [{"id": "42"}]
 
 

--- a/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_state_service.py
@@ -134,14 +134,14 @@ class _Installations:
         self.skills = skills
         self.events: list[str] = []
 
-    def install(self, *, env: str, bot_id: str, skill_id: str) -> bool:
+    def install(self, *, env: str, owner_id: str, bot_id: str, skill_id: str) -> bool:
         self.events.append(f"install:{env}:{bot_id}:{skill_id}")
         if self.skills.active:
             return False
         self.skills.active = True
         return True
 
-    def uninstall(self, *, env: str, bot_id: str, skill_id: str) -> bool:
+    def uninstall(self, *, env: str, owner_id: str, bot_id: str, skill_id: str) -> bool:
         self.events.append(f"uninstall:{env}:{bot_id}:{skill_id}")
         if not self.skills.active:
             return False

--- a/src/backend/tests/community/core/skill_center/test_skill_installation_backfill_sql.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_installation_backfill_sql.py
@@ -18,71 +18,118 @@ _SQL_DIR = (
 def _seed_schema(connection: sqlite3.Connection) -> None:
     connection.executescript(
         """
-        CREATE TABLE ac_skill_set_skill (
-            avernet_tenant TEXT, env TEXT, skill_set_id INTEGER, skill_id INTEGER
-        );
-        CREATE TABLE ac_skill_set (
-            id INTEGER, avernet_tenant TEXT, env TEXT, user_id TEXT,
-            bolt_id TEXT, is_default INTEGER
-        );
         CREATE TABLE ac_skill (
-            id INTEGER, avernet_tenant TEXT, env TEXT, git_path TEXT
+            id INTEGER, avernet_tenant TEXT, env TEXT, user_id TEXT,
+            bolt_id TEXT, git_path TEXT
+        );
+        CREATE TABLE ac_bots (
+            id INTEGER, avernet_tenant TEXT, env TEXT, bot_id TEXT, owner_id TEXT,
+            is_delete INTEGER
         );
         CREATE TABLE ac_default_skillset_skill_exclusion (
-            avernet_tenant TEXT, user_id TEXT, bot_id TEXT, skill_set_id INTEGER,
-            skill_id INTEGER
+            avernet_tenant TEXT, user_id TEXT, bot_id TEXT, skill_id INTEGER
         );
         CREATE TABLE ac_bot_skill_installation (
-            avernet_tenant TEXT, env TEXT, bot_id TEXT, skill_id INTEGER
+            avernet_tenant TEXT, env TEXT, owner_id TEXT, bot_id TEXT,
+            skill_id INTEGER
         );
         """
     )
 
 
-def test_dry_run_does_not_backfill_a_skill_excluded_by_a_former_default_set() -> None:
-    """The published Local read path treats any matching exclusion as inactive."""
+def _dry_run_section(connection: sqlite3.Connection, section: int) -> list[tuple]:
+    sql = (
+        _SQL_DIR / "2026_08_20_bot_skill_installation_backfill_dry_run.sql"
+    ).read_text()
+    markers = (
+        "-- 1. Archive",
+        "-- 2. Every",
+        "-- 3. These",
+    )
+    statement = sql.split(markers[section], 1)[1]
+    if section + 1 < len(markers):
+        statement = statement.split(markers[section + 1], 1)[0]
+    return connection.execute(statement[statement.index("WITH ") :]).fetchall()
+
+
+def test_dry_run_uses_legacy_exclusion_semantics_without_default_membership() -> None:
     connection = sqlite3.connect(":memory:")
     _seed_schema(connection)
     connection.execute(
-        "INSERT INTO ac_skill_set VALUES (101, 'tenant', 'prod', 'user', 'bot', 1)"
+        "INSERT INTO ac_bots VALUES (1, 'tenant', 'prod', 'bot', 'owner', 0)"
     )
     connection.executemany(
-        "INSERT INTO ac_skill VALUES (?, 'tenant', 'prod', ?)",
+        "INSERT INTO ac_skill VALUES (?, 'tenant', 'prod', 'owner', 'bot', ?)",
         [
-            (1, "local://stale-exclusion"),
-            (2, "local://active"),
-            (3, "local://current-exclusion"),
-            (4, "git://market"),
-            (5, "local://already-installed"),
-        ],
-    )
-    connection.executemany(
-        "INSERT INTO ac_skill_set_skill VALUES ('tenant', 'prod', 101, ?)",
-        [(1,), (2,), (3,), (4,), (5,)],
-    )
-    connection.executemany(
-        "INSERT INTO ac_default_skillset_skill_exclusion VALUES ('tenant', 'user', 'bot', ?, ?)",
-        [
-            (99, 1),  # stale former-default exclusion: still inactive on old reads
-            (101, 3),
+            (1, "local://excluded"),
+            (2, "local://active-without-default-membership"),
+            (3, "git://market"),
         ],
     )
     connection.execute(
-        "INSERT INTO ac_bot_skill_installation VALUES ('tenant', 'prod', 'bot', 5)"
+        "INSERT INTO ac_default_skillset_skill_exclusion VALUES ('tenant', 'owner', 'bot', 1)"
     )
 
-    dry_run = (_SQL_DIR / "2026_08_20_bot_skill_installation_backfill_dry_run.sql").read_text()
-    assert connection.execute(dry_run).fetchall() == [("tenant", "prod", "bot", 2)]
+    assert _dry_run_section(connection, 2) == [
+        ("tenant", "prod", "owner", "bot", 2)
+    ]
+
+
+def test_dry_run_scopes_shared_default_bot_by_live_owner_and_skips_deleted_bot() -> None:
+    connection = sqlite3.connect(":memory:")
+    _seed_schema(connection)
+    connection.executemany(
+        "INSERT INTO ac_bots VALUES (?, 'tenant', 'pre', 'default', ?, ?)",
+        [(1, "owner-a", 0), (2, "owner-b", 0), (3, "owner-deleted", 1)],
+    )
+    connection.executemany(
+        "INSERT INTO ac_skill VALUES (?, 'tenant', 'pre', ?, 'default', 'local://x')",
+        [(11, "owner-a"), (12, "owner-b"), (13, "owner-deleted")],
+    )
+
+    assert _dry_run_section(connection, 2) == [
+        ("tenant", "pre", "owner-a", "default", 11),
+        ("tenant", "pre", "owner-b", "default", 12),
+    ]
+
+
+def test_dry_run_marks_duplicate_live_bot_identity_and_fails_closed() -> None:
+    connection = sqlite3.connect(":memory:")
+    _seed_schema(connection)
+    connection.executemany(
+        "INSERT INTO ac_bots VALUES (?, 'tenant', 'pre', 'default', 'owner', 0)",
+        [(1,), (2,)],
+    )
+    connection.execute(
+        "INSERT INTO ac_skill VALUES (1, 'tenant', 'pre', 'owner', 'default', 'local://x')"
+    )
+
+    assert _dry_run_section(connection, 0) == [("tenant", "pre", 1, 0, 1, 0)]
+    assert _dry_run_section(connection, 1) == [
+        ("tenant", "pre", "owner", "default", 1, 2)
+    ]
+    assert _dry_run_section(connection, 2) == []
 
 
 def test_backfill_is_split_into_read_only_dry_run_and_explicitly_approved_apply() -> None:
-    dry_run = (_SQL_DIR / "2026_08_20_bot_skill_installation_backfill_dry_run.sql").read_text()
-    apply = (_SQL_DIR / "2026_08_20_bot_skill_installation_backfill_apply.sql").read_text()
+    dry_run = (
+        _SQL_DIR / "2026_08_20_bot_skill_installation_backfill_dry_run.sql"
+    ).read_text()
+    apply = (
+        _SQL_DIR / "2026_08_20_bot_skill_installation_backfill_apply.sql"
+    ).read_text()
 
     assert "INSERT" not in dry_run.upper()
     assert "START TRANSACTION" not in dry_run.upper()
+    assert "ac_skill_set_skill" not in dry_run
+    assert "skill_set.is_default" not in apply
     assert "@p1_01_installation_backfill_approved = 0" in apply
     assert "@p1_01_installation_backfill_approved = 1" in apply
     for sql in (dry_run, apply):
-        assert "NOT EXISTS" in sql
-        assert "exclusion.skill_set_id = skill_set.id" not in sql
+        assert "bot.is_delete = 0" in sql
+        assert "bot.owner_id = skill.user_id" in sql
+        assert "installation.owner_id = candidate.owner_id" in sql or (
+            "installation.owner_id = bot.owner_id" in sql
+        )
+    assert "ac_bot_skill_installation_backfill_run_audit" in apply
+    assert "@p1_01_installation_backfill_ambiguous_count = 0" in apply

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -415,7 +415,7 @@ class _RuntimeSkills:
         assert kwargs == {
             "env": "pre",
             "bot_id": "bot-1",
-            "user_id": "true-owner",
+            "owner_id": "true-owner",
             "engine": "openclaw",
         }
         return []
@@ -426,7 +426,7 @@ class _HistoricalAicodingRuntimeSkills(_RuntimeSkills):
         assert kwargs == {
             "env": "pre",
             "bot_id": "bot-1",
-            "user_id": "true-owner",
+            "owner_id": "true-owner",
             "engine": "aicoding",
         }
         return []
@@ -719,6 +719,7 @@ async def test_legacy_sync_activates_additively_without_replacing_other_sets():
     assert repository.set_active_calls == [
         {
             "bot_id": "bot-1",
+            "owner_id": "true-owner",
             "set_id": "set-1",
             "active": True,
             "engine_type": "openclaw",
@@ -805,6 +806,7 @@ async def test_historical_bot_skill_set_deactivate_uses_cleanup_projection():
     assert repository.set_active_calls == [
         {
             "bot_id": "bot-1",
+            "owner_id": "true-owner",
             "set_id": "set-1",
             "active": False,
             "engine_type": "claude_code",
@@ -985,7 +987,12 @@ async def test_mcp_direct_activation_checks_permission_before_writing_desired_st
 
     assert mcp_center.calls == [("true-owner", "mcp.weather")]
     assert repository.direct_calls == [
-        {"bot_id": "bot-1", "server_code": "mcp.weather", "engine_type": "openclaw"}
+        {
+            "bot_id": "bot-1",
+            "owner_id": "true-owner",
+            "server_code": "mcp.weather",
+            "engine_type": "openclaw",
+        }
     ]
 
 

--- a/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_reconcile_service.py
@@ -367,9 +367,10 @@ class FakeSkillRepository:
         ]
 
     def list_bot_local_assets(
-        self, *, env: str, bot_id: str
+        self, *, env: str, owner_id: str, bot_id: str
     ) -> list[RegisteredSkillAsset]:
         assert (env, bot_id) == (SCOPE.env, SCOPE.bot_id)
+        assert owner_id == "owner-1"
         return self.registered
 
     def list_bot_active_assets(
@@ -377,11 +378,11 @@ class FakeSkillRepository:
         *,
         env: str,
         bot_id: str,
-        user_id: str,
+        owner_id: str,
         engine: str,
     ) -> list[RegisteredSkillAsset]:
         assert (env, bot_id) == (SCOPE.env, SCOPE.bot_id)
-        assert (user_id, engine) == ("owner-1", self.engine)
+        assert (owner_id, engine) == ("owner-1", self.engine)
         return self.active
 
 

--- a/src/backend/tests/community/endpoints/test_openapi_skill_delete.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_delete.py
@@ -179,7 +179,7 @@ def _seed_delete(world, *, active: bool) -> None:
         )
         if active:
             world.get(SkillInstallationRepositoryProtocol).install(
-                env="dev", bot_id=_BOT_ID, skill_id=skill["id"]
+                env="dev", owner_id=_OWNER, bot_id=_BOT_ID, skill_id=skill["id"]
             )
         else:
             world.get(SkillSetRepository).add_default_skill_exclusion(

--- a/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
@@ -147,6 +147,7 @@ def _seed(world, *, member: bool = False) -> None:
         if member:
             repository.add_skill(
                 bot_id=_BOT_ID,
+                owner_id=_OWNER,
                 set_id=str(skill_set["id"]),
                 skill_id=str(skill["id"]),
                 engine_type="openclaw",
@@ -472,7 +473,11 @@ def _seed_mcp_member(world) -> None:
     _seed(world)
     with avernet_tenant_scope(_TENANT):
         world.get(SkillSetControlPlaneRepositoryProtocol).add_mcp(
-            bot_id=_BOT_ID, set_id="1", server_code="mcp.test", engine_type="openclaw"
+            bot_id=_BOT_ID,
+            owner_id=_OWNER,
+            set_id="1",
+            server_code="mcp.test",
+            engine_type="openclaw",
         )
 
 

--- a/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
@@ -179,7 +179,11 @@ def _seed_active(world) -> None:
     _seed_member(world)
     with avernet_tenant_scope(_TENANT):
         world.get(SkillSetControlPlaneRepositoryProtocol).set_active(
-            bot_id=_BOT_ID, set_id="1", active=True, engine_type="openclaw"
+            bot_id=_BOT_ID,
+            owner_id=_OWNER,
+            set_id="1",
+            active=True,
+            engine_type="openclaw",
         )
 
 

--- a/src/backend/tests/community/repository/skill_center/test_skill_installation_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_installation_repository.py
@@ -45,18 +45,37 @@ def test_skill_installation_is_active_only_idempotent_and_tenant_scoped(tmp_path
     installations = SkillInstallationRepository(_Database(engine))
 
     with avernet_tenant_scope("tenant-a"):
-        assert installations.install(env="pre", bot_id="bot-1", skill_id="42") is True
-        assert installations.install(env="pre", bot_id="bot-1", skill_id="42") is False
-        assert installations.list_installed_skill_ids(env="pre", bot_id="bot-1") == {42}
+        assert installations.install(
+            env="pre", owner_id="owner-a", bot_id="bot-1", skill_id="42"
+        ) is True
+        assert installations.install(
+            env="pre", owner_id="owner-a", bot_id="bot-1", skill_id="42"
+        ) is False
+        assert installations.list_installed_skill_ids(
+            env="pre", owner_id="owner-a", bot_id="bot-1"
+        ) == {42}
+        assert installations.list_installed_skill_ids(
+            env="pre", owner_id="owner-b", bot_id="bot-1"
+        ) == set()
 
     with avernet_tenant_scope("tenant-b"):
-        assert installations.list_installed_skill_ids(env="pre", bot_id="bot-1") == set()
-        assert installations.install(env="pre", bot_id="bot-1", skill_id="42") is True
+        assert installations.list_installed_skill_ids(
+            env="pre", owner_id="owner-a", bot_id="bot-1"
+        ) == set()
+        assert installations.install(
+            env="pre", owner_id="owner-a", bot_id="bot-1", skill_id="42"
+        ) is True
 
     with avernet_tenant_scope("tenant-a"):
-        assert installations.uninstall(env="pre", bot_id="bot-1", skill_id="42") is True
-        assert installations.uninstall(env="pre", bot_id="bot-1", skill_id="42") is False
-        assert installations.list_installed_skill_ids(env="pre", bot_id="bot-1") == set()
+        assert installations.uninstall(
+            env="pre", owner_id="owner-a", bot_id="bot-1", skill_id="42"
+        ) is True
+        assert installations.uninstall(
+            env="pre", owner_id="owner-a", bot_id="bot-1", skill_id="42"
+        ) is False
+        assert installations.list_installed_skill_ids(
+            env="pre", owner_id="owner-a", bot_id="bot-1"
+        ) == set()
 
 
 def test_direct_installation_is_included_in_the_existing_runtime_mapping_query(tmp_path) -> None:
@@ -76,10 +95,12 @@ def test_direct_installation_is_included_in_the_existing_runtime_mapping_query(t
                 "bolt_id": "bot-1",
             }
         )
-        assert installations.install(env="dev", bot_id="bot-1", skill_id=skill["id"])
+        assert installations.install(
+            env="dev", owner_id="owner", bot_id="bot-1", skill_id=skill["id"]
+        )
 
         projected = skills.list_bot_active_assets(
-            env="dev", bot_id="bot-1", user_id="owner", engine="openclaw"
+            env="dev", bot_id="bot-1", owner_id="owner", engine="openclaw"
         )
 
     assert [(asset.skill_id, asset.git_path) for asset in projected] == [
@@ -96,4 +117,5 @@ def test_skill_installation_fk_matches_production_unsigned_skill_identity() -> N
 
     assert "id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT" in skill_ddl
     assert "skill_id BIGINT UNSIGNED NOT NULL" in installation_ddl
+    assert "owner_id VARCHAR(128) NOT NULL" in installation_ddl
     assert "FOREIGN KEY(skill_id) REFERENCES ac_skill (id)" in installation_ddl

--- a/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
@@ -603,6 +603,7 @@ def test_skills_pool_asset_views_are_exactly_bot_scoped(skills, sets):
             "name": "local-a",
             "git_path": "local:///legacy/local-a",
             "bolt_id": "bot-x",
+            "user_id": "owner-x",
         }
     )
     repo = skills.create(
@@ -617,6 +618,7 @@ def test_skills_pool_asset_views_are_exactly_bot_scoped(skills, sets):
             "name": "other-local",
             "git_path": "local:///legacy/other-local",
             "bolt_id": "bot-y",
+            "user_id": "other-owner",
         }
     )
     skill_set = sets.create(
@@ -633,12 +635,13 @@ def test_skills_pool_asset_views_are_exactly_bot_scoped(skills, sets):
 
     local_assets = skills.list_bot_local_assets(
         env=local["env"],
+        owner_id="owner-x",
         bot_id="bot-x",
     )
     active_assets = skills.list_bot_active_assets(
         env=local["env"],
         bot_id="bot-x",
-        user_id="owner-x",
+        owner_id="owner-x",
         engine="openclaw",
     )
 
@@ -686,7 +689,7 @@ def test_skills_pool_active_assets_include_system_default_without_exclusion_stat
     assets = skills.list_bot_active_assets(
         env=default_enabled["env"],
         bot_id="bot-x",
-        user_id="owner-x",
+        owner_id="owner-x",
         engine="openclaw",
     )
 

--- a/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
@@ -82,7 +82,7 @@ def test_activation_rolls_back_all_membership_installations_when_nth_insert_fail
     try:
         with pytest.raises(RuntimeError, match="second installation"):
             SkillSetControlPlaneRepository(db).set_active(
-                bot_id="bot", set_id="1", active=True
+                bot_id="bot", owner_id="owner", set_id="1", active=True
             )
     finally:
         event.remove(BotSkillInstallation, "before_insert", fail_second_install)
@@ -103,7 +103,9 @@ def test_activation_rejects_runtime_name_conflict_before_installation_write():
         session.flush()
         session.add_all(
             [
-                BotSkillInstallation(bot_id="bot", skill_id=active.id, env="dev"),
+                BotSkillInstallation(
+                    bot_id="bot", owner_id="owner", skill_id=active.id, env="dev"
+                ),
                 SkillSetSkill(
                     skill_set_id=skill_set.id,
                     skill_id=candidate.id,
@@ -115,7 +117,7 @@ def test_activation_rejects_runtime_name_conflict_before_installation_write():
 
     with pytest.raises(SkillRuntimeNameConflictError):
         SkillSetControlPlaneRepository(db).set_active(
-            bot_id="bot", set_id="1", active=True
+            bot_id="bot", owner_id="owner", set_id="1", active=True
         )
 
     with db.orm_session() as session:
@@ -134,7 +136,9 @@ def test_legacy_switch_rejects_direct_runtime_name_conflict_before_writes():
         session.flush()
         session.add_all(
             [
-                BotSkillInstallation(bot_id="bot", skill_id=direct.id, env="dev"),
+                BotSkillInstallation(
+                    bot_id="bot", owner_id="owner", skill_id=direct.id, env="dev"
+                ),
                 SkillSetSkill(
                     skill_set_id=target.id,
                     skill_id=candidate.id,
@@ -146,7 +150,7 @@ def test_legacy_switch_rejects_direct_runtime_name_conflict_before_writes():
 
     with pytest.raises(SkillRuntimeNameConflictError):
         SkillSetControlPlaneRepository(db).replace_active_set(
-            bot_id="bot", set_id="1"
+            bot_id="bot", owner_id="owner", set_id="1"
         )
 
     with db.orm_session() as session:
@@ -194,7 +198,9 @@ def test_default_projection_is_always_active_even_for_historical_false_row():
 
     repository = SkillSetControlPlaneRepository(db)
     assert repository.list_sets(bot_id="bot")[0]["is_active"] is True
-    result = repository.set_active(bot_id="bot", set_id="1", active=True)
+    result = repository.set_active(
+        bot_id="bot", owner_id="owner", set_id="1", active=True
+    )
     assert result.item["is_active"] is True
 
 
@@ -262,7 +268,7 @@ def test_active_skill_set_mutates_mcp_membership_and_installation_atomically():
         session.flush()
 
     added = repository.add_mcp(
-        bot_id="bot", set_id=str(skill_set.id), server_code="mcp.weather"
+        bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather"
     )
     assert added.changed is True
     with db.orm_session() as session:
@@ -272,7 +278,7 @@ def test_active_skill_set_mutates_mcp_membership_and_installation_atomically():
         } == {"mcp.weather"}
 
     removed = repository.remove_mcp(
-        bot_id="bot", set_id=str(skill_set.id), server_code="mcp.weather"
+        bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather"
     )
     assert removed.changed is True
     with db.orm_session() as session:
@@ -288,23 +294,27 @@ def test_mcp_direct_and_skill_set_ownership_conflicts_are_enforced():
         session.add(skill_set)
         session.flush()
 
-    assert repository.activate_mcp_direct(bot_id="bot", server_code="mcp.weather").changed
+    assert repository.activate_mcp_direct(
+        bot_id="bot", owner_id="owner", server_code="mcp.weather"
+    ).changed
     with pytest.raises(
         SkillSetControlPlaneConflictError, match="RESOURCE_DIRECT_ACTIVE"
     ):
         repository.add_mcp(
-            bot_id="bot", set_id=str(skill_set.id), server_code="mcp.weather"
+            bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather"
         )
     assert repository.deactivate_mcp_direct(
-        bot_id="bot", server_code="mcp.weather"
+        bot_id="bot", owner_id="owner", server_code="mcp.weather"
     ).changed
     assert repository.add_mcp(
-        bot_id="bot", set_id=str(skill_set.id), server_code="mcp.weather"
+        bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather"
     ).changed
     with pytest.raises(
         SkillSetControlPlaneConflictError, match="RESOURCE_MANAGED_BY_SKILL_SET"
     ):
-        repository.activate_mcp_direct(bot_id="bot", server_code="mcp.weather")
+        repository.activate_mcp_direct(
+            bot_id="bot", owner_id="owner", server_code="mcp.weather"
+        )
 
 
 def test_skill_set_control_plane_sql_creates_before_upgrade_and_adds_bot_key():
@@ -422,12 +432,14 @@ def test_legacy_switch_replaces_all_ordinary_active_sets_in_one_uow():
                 SkillSetSkill(
                     skill_set_id=target_set.id, skill_id=target_skill.id, env="dev"
                 ),
-                BotSkillInstallation(bot_id="bot", skill_id=old_skill.id, env="dev"),
+                BotSkillInstallation(
+                    bot_id="bot", owner_id="owner", skill_id=old_skill.id, env="dev"
+                ),
             ]
         )
 
     result = SkillSetControlPlaneRepository(db).replace_active_set(
-        bot_id="bot", set_id="2"
+        bot_id="bot", owner_id="owner", set_id="2"
     )
 
     assert result.changed is True

--- a/src/backend/tests/community/services/test_skill_set_service.py
+++ b/src/backend/tests/community/services/test_skill_set_service.py
@@ -89,7 +89,7 @@ class TestGetSymlinkMappings:
         assert symlinks[0].source == "/workspace/skills-local/direct-local"
         assert symlinks[0].target.endswith("/workspace/skills/direct-local")
         mock_skill_repo.list_bot_installed_skills.assert_called_once_with(
-            env="dev", bot_id="default"
+            env="dev", owner_id="100015", bot_id="default"
         )
 
     def test_pool_locator_is_used_as_mapping_source_without_legacy_rewrite(


### PR DESCRIPTION
## 变更
- 将 Bot Skill Installation 的唯一身份收敛为 `(tenant, env, owner_id, bot_id, skill_id)`，覆盖 DDL、Repository、Local/Legacy 读取写入、SkillSet 控制面与运行时投影。
- 重写 Local backfill：从 `ac_skill` 的 legacy active 语义出发，不再依赖 Default SkillSet membership；仅迁 live 精确 Bot。
- 对重复 live Bot identity fail-closed；运行级 audit 留档 `legacy_active_local`、`live_exact_bot_candidates`、`ambiguous`、`inserted`、`missing`。
- 保留 `ac_default_skillset_skill_exclusion`，不改 MCP Installation 表。

## 验证
- `ruff check`（所有改动文件）
- 336 条定向 pytest（OpenAPI/BFF、Installation、Backfill、SkillSet、Runtime、Skills Pool、架构门禁）

## 发布前操作
按 README 执行：冻结 Local 写入口 → dry-run 审阅（ambiguity 必须为 0）→ approved apply → verify-and-commit。