### PR TITLE
fix(baas): wire test-e2e-mariadb config so the target runs

### DIFF
--- a/src/baas/configs/overlays/e2e-mariadb.yaml
+++ b/src/baas/configs/overlays/e2e-mariadb.yaml
@@ -2,21 +2,16 @@
 # Select via: SOFAPY_CONFIG_OVERLAY=e2e-mariadb
 # Enables schema creation and seed data so the E2E acceptance suite can run
 # against a freshly-created database. Requires a reachable MariaDB server.
-# Values below target the local E2E devbox container
-# (docker run -d -p 33306:3306 -e MARIADB_DATABASE=secbaas_test \
-#   -e MARIADB_USER=secbaas -e MARIADB_PASSWORD=secbaaspass mariadb:11) and can be
-# overridden at deploy time via MARIADB_HOST / MARIADB_PORT / MARIADB_DATABASE /
-# MARIADB_USER / MARIADB_PASSWORD environment variables (read by
-# DatabasePluginConfig via pydantic-settings).
+# Values below target the local E2E devbox container started by
+# `just test-e2e-mariadb` (in src/baas/justfiles/test-mariadb.just):
+#   docker run -d -p 33306:3306 \
+#     -e MARIADB_DATABASE=secbaas_test \
+#     -e MARIADB_USER=secbaas -e MARIADB_PASSWORD=secbaaspass mariadb:11
 workers: 1
 user_config:
   plugins:
-    database:
-      plugin_database: "MARIADB_ORM"
-      create_schema: true
-      seed_data: true
-      mariadb_host: "127.0.0.1"
-      mariadb_port: 33306
-      mariadb_database: "secbaas_test"
-      mariadb_user: "secbaas"
-      mariadb_password: "secbaaspass"
+    database: "mariadb"
+  database:
+    database_url: "mysql+aiomysql://secbaas:secbaaspass@127.0.0.1:33306/secbaas_test?charset=utf8mb4"
+    create_schema: true
+    seed_data: true

--- a/src/baas/justfiles/test-mariadb.just
+++ b/src/baas/justfiles/test-mariadb.just
@@ -3,7 +3,7 @@
 # Defaults mirror configs/overlays/e2e-mariadb.yaml
 mariadb-container := 'baas-e2e-mariadb'
 mariadb-image := 'mariadb:11'
-mariadb-port := '33307'
+mariadb-port := '33306'
 mariadb-database := 'secbaas_test'
 mariadb-user := 'secbaas'
 mariadb-password := 'secbaaspass'
@@ -63,8 +63,5 @@ test-e2e-mariadb:
         i=$((i+1)); [ "$i" -ge 45 ] && { echo "test-e2e-mariadb: MariaDB did not become ready — skipping"; exit 0; }; \
         sleep 1; done
     echo "MariaDB ready ({{mariadb-container}} :{{mariadb-port}})"
-    MARIADB_HOST=127.0.0.1 MARIADB_PORT={{mariadb-port}} \
-    MARIADB_DATABASE={{mariadb-database}} MARIADB_USER={{mariadb-user}} \
-    MARIADB_PASSWORD={{mariadb-password}} \
     TEST_OVERLAY=e2e-mariadb \
         uv run pytest tests/e2e/asgi/ -v --tb=short --color=yes


### PR DESCRIPTION
## Problem
The `test-e2e-mariadb` make target in src/baas was broken by config wiring, not the test suite:

- `configs/overlays/e2e-mariadb.yaml` set `plugins.database` as a nested dict with a
  `plugin_database: "MARIADB_ORM"` key, but the schema expects a string selector
  (`sqlite | mariadb`) and the DI Selector at `_plugin_core.py` keys off lowercase
  `mariadb=`.
- The overlay never set the top-level `database.database_url` (the `mariadb_*` keys are
  unread), so `MariaDbOrmPlugin.init_database()` would raise "requires database_url".
- The justfile ran the container on port 33307 and set MARIADB_* env vars that nothing reads;
  the URL/comment referenced 33306.

## Solution
- `e2e-mariadb.yaml`: use the string selector `"mariadb"`, add the full
  `database.database_url` (`mysql+aiomysql://...:33306/...`), keep create_schema/seed_data
  true, and drop the dead `mariadb_*` keys.
- `test-mariadb.just`: align the container port to 33306 and remove the unread
  `MARIADB_*` env passthrough; the connection URL now comes solely from the overlay.

## Validation
- Verified `ConfigLoader.load()` with the overlay resolves `plugins.database='mariadb' +
  full URL + create/seed=true.
- Ran `just test-e2e-mariadb`: 1189 passed, 46 skipped against live MariaDB; container
  auto-cleaned by the trap.

## Compatibility and risk
Low. Only the e2e overlay and its justfile recipe changed; production
`application-aliyun.yaml` (`plugins.database: mariadb` + `${DATABASE_URL}`) is
unaffected and is the canonical source for real deployments.