### PR TITLE
feat(bot-catalog): add fail-closed BCS metadata port

### DIFF
--- a/spec/pipeline/openapi-bot-public-bcs-join/001-spec-output.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/001-spec-output.md
@@ -2,7 +2,7 @@
 agent: tc-review
 status: superseded-by-004
 created: 2026-08-20T00:00:00+08:00
-iteration: 3
+iteration: 4
 ---
 
 # 系分 Spec：Public Bot Catalog BCS 元信息端口
@@ -34,6 +34,16 @@ BCS HTTP 接口。
   `502000 / Catalog service unavailable`。
 - [x] Legacy `/api/v1/bot-public/search` 保持 Backend-only；Discover 保持既有 BCSFuse 行为与日志。
 
+## 最小完整变更边界
+
+- 只保留实现上述端口、严格 inner join、fixed-502、DI、公开文档和行为测试所必需的改动。
+- 撤销与本功能无关的纯格式化、重排、重命名、注释润色和邻近代码清理；即使格式化工具建议修改，
+  也不得扩大到未承担本次行为变化的行。
+- 必须修改共享签名或仓储分页行为时，保留最小的类型与实现改动，并用直接行为测试证明它是
+  join-before-pagination 所必需；不得顺手重构其他调用方。
+- 评审必须逐文件对照 base diff，明确证明每个生产代码变更都能追溯到本 Spec；发现仅改变排版而
+  不改变所需行为的 diff 即 REJECT。
+
 ## 验收标准
 
 - 任何未配置或不可用的 metadata port（包括空候选）均令 `/search` 返回固定 `502000` envelope。
@@ -51,6 +61,7 @@ BCS HTTP 接口。
 | TC-02 | metadata 含非 Bot、重复、未知或空白地址 | fail closed，不返回部分结果。 |
 | TC-03 | 同一 bot_id、不同 entity_id | 仅 exact address 可 join。 |
 | TC-04 | 502 OpenAPI response | 有 `ErrorEnvelope` 与固定 `502000` 示例。 |
+| TC-05 | 对照 base 审查生产代码 diff | 不含与本功能无关的纯格式化或邻近清理。 |
 
 ## Ship Spec
 

--- a/spec/pipeline/openapi-bot-public-bcs-join/001-spec-output.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/001-spec-output.md
@@ -1,52 +1,60 @@
 ---
 agent: tc-review
-status: completed
+status: superseded-by-004
 created: 2026-08-20T00:00:00+08:00
-iteration: 2
+iteration: 3
 ---
 
-# 系分 Spec: Public Bot Catalog BCSFuse 元信息内连接
+# 系分 Spec：Public Bot Catalog BCS 元信息端口
+
+> 当前实现与发布约束以 [004-implementation-plan.md](004-implementation-plan.md) 为准。本文件只保留
+> 本次已批准的端口设计；不得据此推断任何 BCS HTTP URL、路径、请求体、凭据、超时或网络调用。
 
 ## 需求概述
 
-`GET /openapi/v1/bots/catalog/search` 保持 Backend 的公开 Bot 搜索语义，使用每个候选的
-`(bot_id, owner_id)` 生成 worker ID，批量查询 BCSFuse 的 Bot 元信息。仅当 BCSFuse 返回同一
-worker ID 时该 Backend Bot 才能返回给前端；所有公开响应字段仍由 Backend 白名单投影生成。
+`GET /openapi/v1/bots/catalog/search` 保持 Backend 的公开 Bot 搜索语义。Backend 从当前租户的
+公开候选构造有序、去重的 `(bot_id, entity_id)` 地址，并将这些地址、已验证的
+`tenant_id` / `user_id` / `app_id` caller 投影及 request ID 交给 BCS 元信息端口决定成员资格。
+Backend 是全部公开响应字段的唯一权威来源。
 
-BCSFuse 的 batch 合约需要已有 worker ID，因此实现顺序是 Backend 产生当前租户的候选 key，
-再批量查询 BCSFuse，最后才向调用方返回 join 结果。这不是 Backend-only fallback。
+当前 production、local 和 test 均绑定为 unavailable 端口实现。因此 Catalog Search 固定返回
+`502000 / Catalog service unavailable`，不会退化为 Backend-only 结果，也不会猜测或调用未实现的
+BCS HTTP 接口。
 
 ## 编码 Spec
 
-- [x] `BotPublicService.search_public_bots_by_keyword` 先读取完整、稳定排序的 Backend public
-  candidate set；禁止先分页后 join。
-- [x] 以 Backend 记录生成唯一 `{bot_id}:{owner_id}`，每批最多 100 个调用
-  `POST /v1/workers/batch`，仅承认本批请求中出现在 `data` 的 key。
-- [x] 仅保留 BCSFuse 和 Backend 都存在的记录，在完成交集后计算 `total`、再应用页面切片。
-- [x] BCSFuse 非 2xx、超时、坏 JSON 或不成功响应 fail closed，OpenAPI 返回 `502000`，不返回
-  Backend 单边数据。
-- [x] BCSFuse 响应和 worker ID 不写日志、不透传。日志只含候选数、join 数、页大小和失败类别。
-- [x] 对 BCSFuse 使用独立的、配置 base URL 的 `HttpClient` qualifier，5 秒单批超时；测试环境
-  使用无网络的 LocalHttpClient。
+- [x] 在 Backend Service API 定义 frozen `BotCatalogAddress`、`BotCatalogCaller`、
+  `BotCatalogMetadata`、runtime-checkable metadata protocol 及 unavailable error。
+- [x] Catalog 专用 service 方法先读取完整、稳定排序的 Backend public candidate set，生成精确
+  `(bot_id, entity_id)` 地址后才做内连接；`total` 与分页均基于完整 join 后结果。
+- [x] 即使地址列表为空也调用 metadata protocol；当前 unavailable 实现仅记录 request ID、候选数
+  与 `unconfigured` 类别后 fail closed。
+- [x] 任何非 `kind == "bot"`、重复、未请求、无效或空白地址的 metadata 结果均 fail closed。
+- [x] OpenAPI router 只从 verified principal 投影 caller；固定错误 envelope 为
+  `502000 / Catalog service unavailable`。
+- [x] Legacy `/api/v1/bot-public/search` 保持 Backend-only；Discover 保持既有 BCSFuse 行为与日志。
 
 ## 验收标准
 
-- Backend-only 和 BCSFuse-only Bot 均不出现在 `items`；join key 是完整 `(bot_id, owner_id)`。
-- 大于 100 个候选时按批查询，输出仍保持 Backend 排序；分页和 `total` 均针对完整交集。
-- BCSFuse 故障返回固定 `502000`，空成功结果返回 `200000` 的空列表。
-- 公开响应不含 BCSFuse 原始字段，也不含 binding、设备、ext、token 或环境数据。
+- 任何未配置或不可用的 metadata port（包括空候选）均令 `/search` 返回固定 `502000` envelope。
+- 未来配置端口时，只有 exact `(bot_id, entity_id)` metadata 命中的 Backend Bot 可以出现；同一
+  `bot_id` 的不同 entity 不得混淆。
+- 公开响应不含 metadata 原始字段，也不含 binding、设备、ext、token 或环境数据。
+- 机器可读 OpenAPI 的 502 response 使用 `ErrorEnvelope`，示例固定为
+  `502000 / Catalog service unavailable`。
 
 ## QA Spec
 
 | 编号 | 用例 | 预期 |
 |---|---|---|
-| TC-01 | 101 个 Backend 候选，BCSFuse 两批均确认 | 两个 batch 请求；第 2 页只有第 101 个 Bot；`total=101`。 |
-| TC-02 | BCSFuse 返回额外 worker ID | 额外 key 不会出现在前端结果。 |
-| TC-03 | BCSFuse 调用异常 | `/search` 返回 `502000`，不降级为 Backend-only。 |
-| TC-04 | 多个 owner 使用同一 bot_id | 仅完整 `{bot_id}:{owner_id}` 匹配的记录返回。 |
+| TC-01 | 空与非空地址调用 unavailable port | 均 fail closed，接口返回 `502000`。 |
+| TC-02 | metadata 含非 Bot、重复、未知或空白地址 | fail closed，不返回部分结果。 |
+| TC-03 | 同一 bot_id、不同 entity_id | 仅 exact address 可 join。 |
+| TC-04 | 502 OpenAPI response | 有 `ErrorEnvelope` 与固定 `502000` 示例。 |
 
 ## Ship Spec
 
-- 分支：`feat/openapi-bot-public-catalog`
-- 发布前确认目标环境的 `bcsfuse.base_url` 已配置并可访问 `/v1/workers/batch`。
-- 如需回滚，回滚本功能提交可恢复原 Backend-only 目录搜索；不要在线改为静默降级。
+- 当前阶段不得配置或发布任何推测的 BCS HTTP integration。
+- 若要启用 Catalog Search，先单独批准并实现 tenant/caller-scoped metadata protocol、DI binding、
+  contract tests 和 deployment configuration；完成前保持当前 fixed-502 行为。
+- 回滚只需恢复本功能改动；绝不能在线改为静默 Backend-only fallback。

--- a/spec/pipeline/openapi-bot-public-bcs-join/001-spec-output.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/001-spec-output.md
@@ -23,7 +23,7 @@ BCS HTTP 接口。
 
 ## 编码 Spec
 
-- [x] 在 Backend Service API 定义 frozen `BotCatalogAddress`、`BotCatalogCaller`、
+- [x] 在 Backend Core 内部端口定义 frozen `BotCatalogAddress`、`BotCatalogCaller`、
   `BotCatalogMetadata`、runtime-checkable metadata protocol 及 unavailable error。
 - [x] Catalog 专用 service 方法先读取完整、稳定排序的 Backend public candidate set，生成精确
   `(bot_id, entity_id)` 地址后才做内连接；`total` 与分页均基于完整 join 后结果。

--- a/spec/pipeline/openapi-bot-public-bcs-join/001-spec-output.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/001-spec-output.md
@@ -1,0 +1,52 @@
+---
+agent: tc-review
+status: completed
+created: 2026-08-20T00:00:00+08:00
+iteration: 2
+---
+
+# 系分 Spec: Public Bot Catalog BCSFuse 元信息内连接
+
+## 需求概述
+
+`GET /openapi/v1/bots/catalog/search` 保持 Backend 的公开 Bot 搜索语义，使用每个候选的
+`(bot_id, owner_id)` 生成 worker ID，批量查询 BCSFuse 的 Bot 元信息。仅当 BCSFuse 返回同一
+worker ID 时该 Backend Bot 才能返回给前端；所有公开响应字段仍由 Backend 白名单投影生成。
+
+BCSFuse 的 batch 合约需要已有 worker ID，因此实现顺序是 Backend 产生当前租户的候选 key，
+再批量查询 BCSFuse，最后才向调用方返回 join 结果。这不是 Backend-only fallback。
+
+## 编码 Spec
+
+- [x] `BotPublicService.search_public_bots_by_keyword` 先读取完整、稳定排序的 Backend public
+  candidate set；禁止先分页后 join。
+- [x] 以 Backend 记录生成唯一 `{bot_id}:{owner_id}`，每批最多 100 个调用
+  `POST /v1/workers/batch`，仅承认本批请求中出现在 `data` 的 key。
+- [x] 仅保留 BCSFuse 和 Backend 都存在的记录，在完成交集后计算 `total`、再应用页面切片。
+- [x] BCSFuse 非 2xx、超时、坏 JSON 或不成功响应 fail closed，OpenAPI 返回 `502000`，不返回
+  Backend 单边数据。
+- [x] BCSFuse 响应和 worker ID 不写日志、不透传。日志只含候选数、join 数、页大小和失败类别。
+- [x] 对 BCSFuse 使用独立的、配置 base URL 的 `HttpClient` qualifier，5 秒单批超时；测试环境
+  使用无网络的 LocalHttpClient。
+
+## 验收标准
+
+- Backend-only 和 BCSFuse-only Bot 均不出现在 `items`；join key 是完整 `(bot_id, owner_id)`。
+- 大于 100 个候选时按批查询，输出仍保持 Backend 排序；分页和 `total` 均针对完整交集。
+- BCSFuse 故障返回固定 `502000`，空成功结果返回 `200000` 的空列表。
+- 公开响应不含 BCSFuse 原始字段，也不含 binding、设备、ext、token 或环境数据。
+
+## QA Spec
+
+| 编号 | 用例 | 预期 |
+|---|---|---|
+| TC-01 | 101 个 Backend 候选，BCSFuse 两批均确认 | 两个 batch 请求；第 2 页只有第 101 个 Bot；`total=101`。 |
+| TC-02 | BCSFuse 返回额外 worker ID | 额外 key 不会出现在前端结果。 |
+| TC-03 | BCSFuse 调用异常 | `/search` 返回 `502000`，不降级为 Backend-only。 |
+| TC-04 | 多个 owner 使用同一 bot_id | 仅完整 `{bot_id}:{owner_id}` 匹配的记录返回。 |
+
+## Ship Spec
+
+- 分支：`feat/openapi-bot-public-catalog`
+- 发布前确认目标环境的 `bcsfuse.base_url` 已配置并可访问 `/v1/workers/batch`。
+- 如需回滚，回滚本功能提交可恢复原 Backend-only 目录搜索；不要在线改为静默降级。

--- a/spec/pipeline/openapi-bot-public-bcs-join/002-code-report.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/002-code-report.md
@@ -1,5 +1,9 @@
 # Bot Catalog BCS metadata port — coding report
 
+> This report describes the current port/fixed-502 implementation. It does not
+> define or imply any BCS HTTP route, base-URL configuration, credentials, or
+> network call; see [004-implementation-plan.md](004-implementation-plan.md).
+
 ## Delivered
 
 - `/openapi/v1/bots/catalog/search` now depends on a typed, tenant-scoped BCS metadata port.
@@ -7,7 +11,7 @@
   verified caller projection plus request ID.
 - The current production, local, and test binding is intentionally unavailable. It logs only
   request ID, candidate count, and the `unconfigured` category, then causes the route to return
-  the fixed `502000 / Catalog service unavailable` response.
+  the fixed `502000 / Catalog service unavailable` `ErrorEnvelope` response.
 - A future configured port will use strict metadata validation, exact inner join, stable Backend
   order, and join-before-pagination. Backend remains authoritative for all public response fields.
 - Legacy `/api/v1/bot-public/search` remains Backend-only; Discover retains its BCSFuse behavior.

--- a/spec/pipeline/openapi-bot-public-bcs-join/002-code-report.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/002-code-report.md
@@ -1,22 +1,100 @@
+---
+agent: tc-code
+status: completed
+created: 2026-08-20T21:35:33+08:00
+iteration: 4
+---
+
 # Bot Catalog BCS metadata port — coding report
 
-> This report describes the current port/fixed-502 implementation. It does not
-> define or imply any BCS HTTP route, base-URL configuration, credentials, or
-> network call; see [004-implementation-plan.md](004-implementation-plan.md).
+> This report describes the current port/fixed-502 implementation and the iteration-4 minimal-diff
+> audit against `origin/dev_refactory_collaboration`. It does not define or imply any BCS HTTP
+> route, base-URL configuration, credentials, timeout, or network call; see
+> [004-implementation-plan.md](004-implementation-plan.md).
 
-## Delivered
+## Worktree
 
-- `/openapi/v1/bots/catalog/search` now depends on a typed, tenant-scoped BCS metadata port.
-  It addresses Backend candidates by exact `(bot_id, entity_id)` and gives the port only the
-  verified caller projection plus request ID.
+- Path: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog`
+- Branch: `feat/openapi-bot-public-catalog`
+- Audit base: `origin/dev_refactory_collaboration@efa0b7da330d8f928b364de2b84a9012f9bbcedc`
+- Audited HEAD: `8de5e1d25bc5c593bde1e2c301edf15c623169ee`
+- No commit or push was performed. Existing `.superpowers/` files were not modified, staged, or removed.
+
+## Retained complete behavior
+
+- `/openapi/v1/bots/catalog/search` depends on a typed BCS metadata port and passes only the exact
+  ordered/de-duplicated `(bot_id, entity_id)` addresses, the verified `tenant_id` / `user_id` /
+  `app_id` caller projection, and request ID.
 - The current production, local, and test binding is intentionally unavailable. It logs only
-  request ID, candidate count, and the `unconfigured` category, then causes the route to return
-  the fixed `502000 / Catalog service unavailable` `ErrorEnvelope` response.
-- A future configured port will use strict metadata validation, exact inner join, stable Backend
-  order, and join-before-pagination. Backend remains authoritative for all public response fields.
+  request ID, candidate count, and a low-sensitivity failure category, then fails closed to the
+  fixed `502000 / Catalog service unavailable` `ErrorEnvelope`.
+- A future configured port must validate `kind == "bot"`, reject duplicate/unknown/blank addresses,
+  inner join by the exact composite address, preserve Backend order, and paginate after the join.
+- Backend remains authoritative for public fields. The OpenAPI router retains its explicit
+  allowlist projection, so metadata, bindings, device data, `ext`, credentials, tokens, and
+  environment data cannot enter the public response.
 - Legacy `/api/v1/bot-public/search` remains Backend-only; Discover retains its BCSFuse behavior.
+  The repository's original paginated query chain and behavior are retained inside the normal
+  branch; the new stable `gmt_create DESC, id DESC` branch is used only when pagination is omitted
+  to build the complete Catalog candidate set.
 
-## Verification
+## Minimal-diff cleanup performed
 
-Focused pytest, DI resolution, router projection, OpenAPI generation, Ruff, and diff checks are
-recorded in the task report for this implementation.
+| File | Pure formatting / adjacent cleanup reverted | Necessary behavior retained |
+|---|---|---|
+| `src/backend/src/agentclaw/community/di/modules/bot_public_module.py` | Restored the base blank line after `from __future__`; removed a format-only deletion. | Protocol-to-unavailable binding and constructor injection. |
+| `src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py` | Restored the legacy search's original in-place redaction block and removed the shared sanitizer extraction that refactored adjacent code. | Catalog-only redaction, exact-address validation, fail-closed translation, and low-sensitivity diagnostics. |
+| `src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py` | Kept the original paginated query layout/order in the `else` branch instead of rewriting it for every caller. | The additive unpaginated stable-order branch required for join-before-pagination. |
+| `src/backend/tests/community/core/bot_public/services/test_sync_bot_config_uses_resolver.py` | Restored the base's pre-existing unused `pytest` import instead of retaining an unrelated cleanup. | Only the required metadata-port constructor argument remains in the diff. |
+| `src/backend/tests/community/core/bot_public/test_bot_public_service.py` | Restored the existing `_make_bot` signature and fixed entity fixture; avoided widening an established helper solely for new tests. | A new Catalog-specific helper and behavior tests cover exact entity identity. |
+| `src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md` | Restored the original `search` parameter wording; removed unrelated copy expansion. | Port/fixed-502/join-before-pagination documentation. |
+| `src/backend/docs/openapi-v1/README.zh-CN.md` | Preserved the base sentence without reflow and added the new contract as a separate continuation. | Current fixed-502 metadata-port behavior. |
+
+The final zero-context deletion audit (`git diff -U0 ... | rg '^-(?!-)'`) contains only required
+contract/call/schema replacements and the existing pagination block being wrapped by the new
+unpaginated branch. No unrelated import removal, rename, comment polish, or neighboring cleanup
+remains.
+
+## Production and generated-schema audit
+
+- Core port DTOs/protocol/errors, unavailable implementation, service orchestration, router caller
+  projection/error mapping, API protocol declaration, DI binding, Context Boundary metadata,
+  repository full-candidate seam, public docs, tests, and generated schema all trace directly to
+  iteration 4.
+- Database search remains on the existing SQLAlchemy ORM path. No raw SQL, SQL string concatenation,
+  new HTTP client, URL, credential, retry, or external configuration was introduced.
+- `src/gateway/configs/schemas/bots.openapi.json` has only the required Catalog Search 502 changes:
+  the example message and response description now use `Catalog service unavailable`.
+- A fresh `DEPLOY_PROFILE=community` OpenAPI dump is byte-identical to the checked-in schema. Both
+  files have SHA-256 `927347f1a73b27011dadd36c4b1bf92dcee8f849b5790e7b897e8205f423f4ad`.
+
+## Iteration-4 review coverage repair
+
+- Added three behavior tests only in `test_bot_public_service.py`: unexpected metadata exceptions
+  fail closed with the low-sensitivity `invalid_metadata` log; malformed/string `ext`, `device_id`,
+  passport token, and `iam_token` are redacted on Catalog results; blank Backend `bot_id` or
+  `entity_id` values are excluded from metadata addresses and results.
+- No production code, shared helper, API contract, formatting, or unrelated test was changed for
+  this repair.
+- `report_check.py` was run against a temporary tracked-worktree tree (no commit/stash/worktree
+  mutation): change-line coverage is `100.00% (103/103)`, above the required `>= 90.00%`.
+
+## Verification evidence
+
+| Check | Result |
+|---|---|
+| Focused Core/router/metadata/repository/sync pytest | `157 passed`, `0 failed` |
+| `report_check.py` change-line coverage | `100.00% (103/103)`; required `>= 90.00%` |
+| Declarative endpoint runner (`-k catalog`) | `4 passed`, `834 deselected`, `0 failed` |
+| Architecture/API-to-Core/DI resolution suite | `61 passed`, `0 failed` |
+| Gateway served-schema consumer test | `11 passed`, `0 failed` |
+| OpenAPI regenerate + `cmp` + JSON parse | PASS; byte-identical SHA-256 above |
+| Ruff on every changed Python file except the one inherited baseline finding | PASS |
+| Ruff unused import/variable check (`F401,F841`) on the same delta-clean set | PASS |
+| Python style checks required by `AGENTS.md` (`E203,E211,E265`) | PASS |
+| Full changed-file Ruff | One inherited `F401` at `test_sync_bot_config_uses_resolver.py:22`; the base file produces the identical finding, and the final diff does not change that import line |
+| `git diff --check` | PASS |
+
+The intentionally restored base `pytest` import is documented rather than deleted because iteration
+4 requires removing unrelated cleanup from the feature diff. There are no newly introduced unused
+imports or variables.

--- a/spec/pipeline/openapi-bot-public-bcs-join/002-code-report.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/002-code-report.md
@@ -1,0 +1,18 @@
+# Bot Catalog BCS metadata port — coding report
+
+## Delivered
+
+- `/openapi/v1/bots/catalog/search` now depends on a typed, tenant-scoped BCS metadata port.
+  It addresses Backend candidates by exact `(bot_id, entity_id)` and gives the port only the
+  verified caller projection plus request ID.
+- The current production, local, and test binding is intentionally unavailable. It logs only
+  request ID, candidate count, and the `unconfigured` category, then causes the route to return
+  the fixed `502000 / Catalog service unavailable` response.
+- A future configured port will use strict metadata validation, exact inner join, stable Backend
+  order, and join-before-pagination. Backend remains authoritative for all public response fields.
+- Legacy `/api/v1/bot-public/search` remains Backend-only; Discover retains its BCSFuse behavior.
+
+## Verification
+
+Focused pytest, DI resolution, router projection, OpenAPI generation, Ruff, and diff checks are
+recorded in the task report for this implementation.

--- a/spec/pipeline/openapi-bot-public-bcs-join/003-review-report.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/003-review-report.md
@@ -1,30 +1,31 @@
-> **SUPERSEDED HISTORICAL REVIEW — DO NOT USE AS CURRENT IMPLEMENTATION OR SHIP INSTRUCTION.**
->
-> This report records the rejected BCSFuse HTTP batch design only. The current binding design is
-> the tenant-scoped metadata port with a fixed unavailable response in
-> [004-implementation-plan.md](004-implementation-plan.md); it deliberately has no BCS HTTP
-> URL, path, payload, credentials, base-URL configuration, or network call.
-
 ---
 agent: tc-code-reviewer
 status: completed
-created: 2026-08-20T15:35:00+08:00
-iteration: 2
+created: 2026-08-20T21:57:27+08:00
+iteration: 5
 ---
 
-# 已废弃的 BCSFuse HTTP batch 代码评审报告（历史记录）
+# 代码评审报告
 
 ## 评审范围
 
 - Worktree: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog`
 - 分支: `feat/openapi-bot-public-catalog`
-- 范围: 当前未提交的 Backend-candidates → BCSFuse `/v1/workers/batch` catalog join 改动。
+- Base: `origin/dev_refactory_collaboration@efa0b7da330d8f928b364de2b84a9012f9bbcedc`
+- Committed HEAD: `8de5e1d25bc5c593bde1e2c301edf15c623169ee`
+- 本轮修复增量: 仅 `src/backend/tests/community/core/bot_public/test_bot_public_service.py` 新增 3 个行为测试；无生产代码改动。
+- `.superpowers/` 未修改、未暂存、未删除；未 commit、push 或修改 PR。
 
-## 验证证据
+## 结论先行
 
-- `uv run pytest -q tests/community/core/bot_public/test_bot_public_service.py tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py tests/community/core/bot_public/services/test_sync_bot_config_uses_resolver.py --cov=...`：**100 passed**, failed=0。
-- `uv run ruff check`（全部改动 Python 文件）及 `git diff --check`：通过。
-- 局部覆盖率：`BotPublicService` 484/551（88%）、catalog router 52/66（79%）、新增 BCSFuse DI module 29/43（67%）。新 BCS parse 失败分支 [bot_public_service.py:1139](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1139) 和 [bot_public_service.py:1142](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1142) 未覆盖。
+**结论: PASS**
+
+iteration 4 的唯一阻塞项已关闭：独立复跑 focused suite 为 `157/157`，按项目
+`report_check.py` 同口径计算的当前工作树变更可执行行覆盖率为 `103/103 = 100.00%`，达到
+`>= 90%`。新增测试均有直接业务断言，不是无断言覆盖率填充，也没有扩大功能或修改生产设计。
+
+远端 ACI 对当前仍含 tracked uncommitted diff 的最终 head 仍为 **PENDING**；本报告的 PASS 是代码
+复审结论，不得替代最终远端 ACI 三项门禁。
 
 ## 逐条评审意见
 
@@ -32,65 +33,81 @@ iteration: 2
 
 | 维度 | 结论 | 说明 |
 |---|---|---|
-| 正确性 | FAIL | Backend 全量有序候选、100 条分批、join 后 total/page 已实现；但 BCS membership key 无 tenant 维度，且未验证返回的是 physical Bot。 |
-| 安全性 | FAIL | Backend response 仍经 allowlist 投影且新日志只记录失败类型/计数。独立安全复核未发现置信度 >=0.8 的新增高/中危漏洞；但本 Review Spec 的强制 tenant-scoped membership 仍无法证明：BCSFuse 按全局 worker ID 查询且未携带 verified caller/tenant，不能排除跨 tenant 同 key 的错误命中。 |
-| 性能 | PASS | 采用可注入 client、每批最多 100 条、单次 5 秒 timeout，未见重试或 N+1。 |
-| 代码风格 | PASS | Ruff 和 `git diff --check` 通过。 |
-| 测试覆盖 | FAIL | 100 个 focused cases 均通过，但改动核心 module 仅 88%，并漏掉 malformed BCS envelope/item 与 tenant collision 等行为断言。 |
-| ACI 覆盖率门禁 | PENDING | 没有指定 PR base/head、远端 junit/coverage job 或 ACI report；不能宣称 PASS。 |
-| 静态检查 | PASS | 未发现本次新增的 unused import/variable 或 Python whitespace 告警。 |
+| 正确性 | PASS | 三个新增测试真实驱动 Catalog 生产方法，覆盖 unexpected metadata exception、Catalog 脱敏和 blank Backend address 过滤，并断言对外行为。 |
+| 安全性 | PASS | 无生产代码变化；上轮 caller/tenant、exact address、fail-closed、allowlist、ORM 参数化结论不变。新增日志测试还断言私有上游错误细节不进入日志。 |
+| 性能 | PASS | 本轮只有 focused unit tests，无运行时代码或查询行为变化。 |
+| 代码风格 | PASS | 新增测试结构沿用现有 fixture/`MagicMock` 风格；无跳过、xfail、`no cover`、阈值调整或无关辅助抽象。 |
+| 测试覆盖 | PASS | `157/157` 通过；current-tree change-line coverage `103/103 = 100.00%`，原 12 条未覆盖变更行现均命中。 |
+| ACI 覆盖率门禁 | PENDING | 本地 case 与 change-line 预检通过；项目全量总行覆盖率及当前最终 committed head 的远端 ACI job 尚不可得。 |
+| 静态检查 | PASS | `ruff check test_bot_public_service.py` 通过；`git diff --check origin/dev_refactory_collaboration` 通过；未新增 unused import/variable 或 whitespace 告警。 |
+
+### 本轮三项行为断言核验
+
+| 测试 | 结论 | 独立核验 |
+|---|---|---|
+| `test_catalog_search_fails_closed_on_unexpected_metadata_error` | PASS | 令 metadata port 抛带唯一私密 sentinel 的 `RuntimeError`；断言转为无详情 `BotCatalogSearchUnavailableError`，日志含 request ID、候选数、固定 `invalid_metadata` 类别，且不含 sentinel。真实命中原缺口 `1135,1136,1142`。 |
+| `test_catalog_search_redacts_sensitive_fields_and_malformed_ext` | PASS | 同时构造 malformed JSON ext 与字符串 ext；断言 `device_id=None`、malformed ext 变 `{}`、passport token/`iam_token` 变 `None`，非敏感字段保留。真实命中原缺口 `1152,1155-1158,1161,1164`。 |
+| `test_catalog_search_filters_blank_backend_addresses` | PASS | 同时提供 blank `bot_id`、blank `entity_id` 和 valid address；断言 port 只收到 valid exact address，结果也只含 valid Bot。真实命中原缺口 `1183,1185`。 |
+
+三项均调用真实 `search_catalog_public_bots_by_keyword`，并对异常、日志、port 入参或返回数据作明确断言；
+没有直接调用仅为刷行的内部 helper，没有 `skip`/`xfail`/`pragma: no cover`，也没有与本功能无关的测试。
+
+## 测试与覆盖率证据
+
+- Focused pytest:
+  - `test_bot_public_service.py`
+  - `test_bot_catalog_metadata_service.py`
+  - `test_bot_public_router.py`
+  - `test_bot_repository_unified.py`
+  - `test_sync_bot_config_uses_resolver.py`
+- 用例: `157/157 (100.00%)`，skipped=0，failed=0。
+- 局部覆盖率: `1057/2907 = 36.36%`。该分母包含历史大文件，只用于定位缺口，不能替代项目全量 ACI 总行覆盖率。
+- 当前工作树变更可执行行覆盖率: `103/103 = 100.00%`，threshold `>= 90%`，PASS。
+- 未覆盖变更可执行行: 无。
 
 ### ACI 覆盖率证据
 
-- Base / Head: 未提供 / 当前 worktree 未提交改动。
-- 用例: 本地 100/100（100%），skipped=0，failed=0；非远端 ACI casePassRate。
-- 总行覆盖率: selected modules 839/2907（29%）；它包含大模块历史行，不能替代 change-line 指标。核心改动 module `BotPublicService` 为 484/551（88%）。
-- 变更行覆盖率: PENDING；无可用 base/head/远端 coverage artifact。
-- 远端 ACI job: PENDING。
+- Base / Current tree: `efa0b7da330d8f928b364de2b84a9012f9bbcedc` / `8de5e1d25bc5c593bde1e2c301edf15c623169ee + tracked uncommitted diff`。
+- 用例: 本地 focused `157/157 (100.00%)`；远端 ACI casePassRate `PENDING`，threshold = 100%。
+- 总行覆盖率: 远端/项目全量 `PENDING`，threshold `>= 70%`；局部 `1057/2907` 不作为该门禁结论。
+- 变更行覆盖率: 本地当前工作树 `103/103 (100.00%)`，threshold `>= 90%`，PASS。
+- 远端 ACI job: `PENDING`。当前工作树尚未形成最终 committed head，不得沿用较早 head 的远端 PASS。
 
-### Review Spec 检查项
+## 最小性与回归核验
+
+- 本轮仅在已有 Catalog service 测试类中新增 3 个与 iteration-4 REJECT 一一对应的行为测试。
+- 未新增通用 fixture、测试框架、生产 helper、配置、依赖或 CI 排除规则。
+- 生产文件 blob 与上轮评审一致：
+  - `bot_public_service.py`: `83e0b7bf4a53cf1adedeacf202a7d0a64747c50b`
+  - repository `bot.py`: `1c1dc32f46bc83663838e3dd639378dba26f30ac`
+  - `bot_public_module.py`: `17cc60b01b7cdfd0f610161de7c90a83c20585e9`
+- iteration 4 已通过的最小性结论保持不变：legacy sanitizer、原 paginated query 行为、DI 空行和
+  base 既有 `pytest` F401 均保持恢复状态；没有要求顺手清理 base 告警。
+
+## Review Spec 检查项
 
 | 编号 | 检查项 | 结论 | 说明 |
 |---|---|---|---|
-| R-01 | BCS request 由 Backend tenant-scoped public candidates 派生 | PASS | [service:1049](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1049) 先以 tenant-scoped ORM Backend 搜索枚举，再生成 worker IDs。 |
-| R-02 | canonical composite key、100 条 batch、physical Bot 校验 | FAIL | composite ID 与 colon bot ID 生成正确，batch size=100；但 BCSFuse response 不含/代码不验证 worker type，无法排除非 physical Bot，且 key 不含 tenant。 |
-| R-03 | join 后分页、total、stable order | PASS | [service:1055](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1055) 内连接后才在 [service:1084](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1084) 计算 total/slice；101 条跨批测试已通过。 |
-| R-04 | 5s fail-closed 固定 502、无 fallback | PASS | [service:1130](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1130) 使用 5 秒单次调用；异常转领域错误并由 [router:88](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py:88) 固定映射为 502。 |
-| R-05 | caller/tenant BCS 语义 | FAIL | router 的 verified principal 仅触发 admission；batch 调用只传 Content-Type。BCSFuse endpoint [worker_routes.py:285](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/bcsfuse/src/interfaces/api/worker_routes.py:285) 按 `store.get_by_id` 全局查找且没有 tenant/caller dependency。 |
-| R-06 | App-only 安全兼容性 | FAIL | App-only 仍可到达 Backend，但没有 BCSFuse scoped membership contract 或 authorization conformance evidence，无法与 tenant collision 隔离共同成立。 |
-| R-07 | public schema/response/log | PASS | Gateway public fields未扩张；router allowlist 投影，catalog 日志仅含计数/失败类别，未记录 BCS response、worker list、keyword 或认证头。 |
-| R-08 | adapter/core/DI 边界 | PASS | router 薄；HttpClient 通过 `QUALIFIER_BCSFUSE` 在 DI 注入，core 未直接构建 HTTP client 或读取环境。 |
-| R-09 | 改动文件覆盖 >90% | FAIL | 核心 service 88%，router 79%，且 BCS malformed-response 分支无断言覆盖。 |
+| R-01 | unexpected metadata exception 必须 fail closed 且不泄露详情 | PASS | 异常类型、空公开错误详情、固定低敏日志与 sentinel 不泄露均有断言。 |
+| R-02 | Catalog sanitizer 行为有直接断言 | PASS | malformed ext、device、passport token、IAM token 和非敏感字段保留均覆盖。 |
+| R-03 | blank Backend address 不得进入 port 或结果 | PASS | blank bot/entity 两个分支均命中，port 入参和最终结果同时断言。 |
+| R-04 | 测试修复保持最小 | PASS | 只加 3 个目标测试；生产、协议、DI、schema、文档均无本轮变化。 |
+| R-05 | changeLineCoverage `>= 90%` | PASS | `103/103 = 100.00%`，原 12 行缺口全部关闭。 |
+| R-06 | 远端 ACI 不得误报 | PASS | 明确标记当前最终 committed head 的远端 ACI 为 PENDING。 |
 
 ## 具体问题列表
 
-### 问题 1: 无 tenant/caller 维度的 BCSFuse membership 可跨 tenant 错配
-
-- 文件: [bot_public_service.py:1121](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1121), [worker_routes.py:285](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/bcsfuse/src/interfaces/api/worker_routes.py:285)
-- 严重程度: 必须修复
-- 描述: Backend `(bot_id, owner_id)` 仅在 tenant 内唯一，而 BCSFuse batch endpoint 没有 tenant 或 verified-caller input，并以 `store.get_by_id(worker_id)` 全局查找。tenant A 和 B 若存在同一 pair，A 未注册 BCS worker 也可能因 B 的 worker 存在而通过 inner join。
-- 建议修复方式: 使用 tenant/caller-scoped BCS contract，或将可信 tenant 纳入 BCS worker identity 与存储/查询约束；在 BCS side 增加 User+App/App-only authorization conformance tests，并增加 A/B same-pair regression。
-
-### 问题 2: 仅以 response map key 判定 membership，未验证 physical Bot/metadata shape
-
-- 文件: [bot_public_service.py:1137](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1137)
-- 严重程度: 必须修复
-- 描述: 代码只验证 `data` 是 dict，并把请求内 key 直接加入 available set；不验证 item 是有效 metadata 或 physical Bot。`{"success":true,"data":{"id":null}}` 会被视为命中。现有 batch response 本身也没有 worker `type`，故无法满足 Review Spec 的 physical-bot 防错配约束。
-- 建议修复方式: 将 batch contract 收紧为 tenant-scoped physical-Bot membership，并逐项校验 required fields/type；无效 item/envelope 均转 `BotCatalogSearchUnavailableError`。覆盖 missing data、invalid item、human/non-Bot、requested-key mismatch。
-
-### 问题 3: 共享 service 方法意外改变既有内部搜索 API
-
-- 文件: [bot_public_service.py:1027](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1027), [router_auth.py:117](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/adapters/http/bot_public/router_auth.py:117)
-- 严重程度: 必须修复
-- 描述: `/api/v1/bot-public/search` 也调用同一个 `search_public_bots_by_keyword`；本次使它依赖 BCSFuse 且在上游失败时进入其 generic 500/error body，并非只修改 catalog `/openapi/v1/.../search`。没有该现有 API 的兼容性或 failure mapping 测试。
-- 建议修复方式: 将 catalog join 编排拆成专用 service method/port，仅由 OpenAPI catalog router 调用；或明确更新 internal API 契约、固定错误映射并补齐兼容性测试。
+无。
 
 ## 整体结论
 
-**结论: REJECT**
+**结论: PASS**
 
 ### 必须修复项
 
-1. 使 BCS metadata membership 按可信 tenant/caller 隔离，并验证 physical Bot；不得以全局 worker ID 查询替代。
-2. 隔离或显式兼容 `/api/v1/bot-public/search` 的既有行为。
-3. 补足 BCS malformed/type、cross-tenant collision、internal route failure 与新增分支测试，使改动覆盖达到 >90%，再提供远端 ACI 证据。
+无。
+
+### 下一步
+
+继续 `tc-engine-regression`，并在当前 tracked diff 提交形成最终 head 后重新执行远端 ACI；只有
+`casePassRate >= 100%`、`lineCoverage >= 70%`、`changeLineCoverage >= 90%` 三项门禁均通过后才可部署。

--- a/spec/pipeline/openapi-bot-public-bcs-join/003-review-report.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/003-review-report.md
@@ -1,3 +1,10 @@
+> **SUPERSEDED HISTORICAL REVIEW — DO NOT USE AS CURRENT IMPLEMENTATION OR SHIP INSTRUCTION.**
+>
+> This report records the rejected BCSFuse HTTP batch design only. The current binding design is
+> the tenant-scoped metadata port with a fixed unavailable response in
+> [004-implementation-plan.md](004-implementation-plan.md); it deliberately has no BCS HTTP
+> URL, path, payload, credentials, base-URL configuration, or network call.
+
 ---
 agent: tc-code-reviewer
 status: completed
@@ -5,7 +12,7 @@ created: 2026-08-20T15:35:00+08:00
 iteration: 2
 ---
 
-# 代码评审报告（复审）
+# 已废弃的 BCSFuse HTTP batch 代码评审报告（历史记录）
 
 ## 评审范围
 

--- a/spec/pipeline/openapi-bot-public-bcs-join/003-review-report.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/003-review-report.md
@@ -1,0 +1,89 @@
+---
+agent: tc-code-reviewer
+status: completed
+created: 2026-08-20T15:35:00+08:00
+iteration: 2
+---
+
+# 代码评审报告（复审）
+
+## 评审范围
+
+- Worktree: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog`
+- 分支: `feat/openapi-bot-public-catalog`
+- 范围: 当前未提交的 Backend-candidates → BCSFuse `/v1/workers/batch` catalog join 改动。
+
+## 验证证据
+
+- `uv run pytest -q tests/community/core/bot_public/test_bot_public_service.py tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py tests/community/core/bot_public/services/test_sync_bot_config_uses_resolver.py --cov=...`：**100 passed**, failed=0。
+- `uv run ruff check`（全部改动 Python 文件）及 `git diff --check`：通过。
+- 局部覆盖率：`BotPublicService` 484/551（88%）、catalog router 52/66（79%）、新增 BCSFuse DI module 29/43（67%）。新 BCS parse 失败分支 [bot_public_service.py:1139](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1139) 和 [bot_public_service.py:1142](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1142) 未覆盖。
+
+## 逐条评审意见
+
+### 固定检查维度
+
+| 维度 | 结论 | 说明 |
+|---|---|---|
+| 正确性 | FAIL | Backend 全量有序候选、100 条分批、join 后 total/page 已实现；但 BCS membership key 无 tenant 维度，且未验证返回的是 physical Bot。 |
+| 安全性 | FAIL | Backend response 仍经 allowlist 投影且新日志只记录失败类型/计数。独立安全复核未发现置信度 >=0.8 的新增高/中危漏洞；但本 Review Spec 的强制 tenant-scoped membership 仍无法证明：BCSFuse 按全局 worker ID 查询且未携带 verified caller/tenant，不能排除跨 tenant 同 key 的错误命中。 |
+| 性能 | PASS | 采用可注入 client、每批最多 100 条、单次 5 秒 timeout，未见重试或 N+1。 |
+| 代码风格 | PASS | Ruff 和 `git diff --check` 通过。 |
+| 测试覆盖 | FAIL | 100 个 focused cases 均通过，但改动核心 module 仅 88%，并漏掉 malformed BCS envelope/item 与 tenant collision 等行为断言。 |
+| ACI 覆盖率门禁 | PENDING | 没有指定 PR base/head、远端 junit/coverage job 或 ACI report；不能宣称 PASS。 |
+| 静态检查 | PASS | 未发现本次新增的 unused import/variable 或 Python whitespace 告警。 |
+
+### ACI 覆盖率证据
+
+- Base / Head: 未提供 / 当前 worktree 未提交改动。
+- 用例: 本地 100/100（100%），skipped=0，failed=0；非远端 ACI casePassRate。
+- 总行覆盖率: selected modules 839/2907（29%）；它包含大模块历史行，不能替代 change-line 指标。核心改动 module `BotPublicService` 为 484/551（88%）。
+- 变更行覆盖率: PENDING；无可用 base/head/远端 coverage artifact。
+- 远端 ACI job: PENDING。
+
+### Review Spec 检查项
+
+| 编号 | 检查项 | 结论 | 说明 |
+|---|---|---|---|
+| R-01 | BCS request 由 Backend tenant-scoped public candidates 派生 | PASS | [service:1049](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1049) 先以 tenant-scoped ORM Backend 搜索枚举，再生成 worker IDs。 |
+| R-02 | canonical composite key、100 条 batch、physical Bot 校验 | FAIL | composite ID 与 colon bot ID 生成正确，batch size=100；但 BCSFuse response 不含/代码不验证 worker type，无法排除非 physical Bot，且 key 不含 tenant。 |
+| R-03 | join 后分页、total、stable order | PASS | [service:1055](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1055) 内连接后才在 [service:1084](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1084) 计算 total/slice；101 条跨批测试已通过。 |
+| R-04 | 5s fail-closed 固定 502、无 fallback | PASS | [service:1130](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1130) 使用 5 秒单次调用；异常转领域错误并由 [router:88](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py:88) 固定映射为 502。 |
+| R-05 | caller/tenant BCS 语义 | FAIL | router 的 verified principal 仅触发 admission；batch 调用只传 Content-Type。BCSFuse endpoint [worker_routes.py:285](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/bcsfuse/src/interfaces/api/worker_routes.py:285) 按 `store.get_by_id` 全局查找且没有 tenant/caller dependency。 |
+| R-06 | App-only 安全兼容性 | FAIL | App-only 仍可到达 Backend，但没有 BCSFuse scoped membership contract 或 authorization conformance evidence，无法与 tenant collision 隔离共同成立。 |
+| R-07 | public schema/response/log | PASS | Gateway public fields未扩张；router allowlist 投影，catalog 日志仅含计数/失败类别，未记录 BCS response、worker list、keyword 或认证头。 |
+| R-08 | adapter/core/DI 边界 | PASS | router 薄；HttpClient 通过 `QUALIFIER_BCSFUSE` 在 DI 注入，core 未直接构建 HTTP client 或读取环境。 |
+| R-09 | 改动文件覆盖 >90% | FAIL | 核心 service 88%，router 79%，且 BCS malformed-response 分支无断言覆盖。 |
+
+## 具体问题列表
+
+### 问题 1: 无 tenant/caller 维度的 BCSFuse membership 可跨 tenant 错配
+
+- 文件: [bot_public_service.py:1121](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1121), [worker_routes.py:285](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/bcsfuse/src/interfaces/api/worker_routes.py:285)
+- 严重程度: 必须修复
+- 描述: Backend `(bot_id, owner_id)` 仅在 tenant 内唯一，而 BCSFuse batch endpoint 没有 tenant 或 verified-caller input，并以 `store.get_by_id(worker_id)` 全局查找。tenant A 和 B 若存在同一 pair，A 未注册 BCS worker 也可能因 B 的 worker 存在而通过 inner join。
+- 建议修复方式: 使用 tenant/caller-scoped BCS contract，或将可信 tenant 纳入 BCS worker identity 与存储/查询约束；在 BCS side 增加 User+App/App-only authorization conformance tests，并增加 A/B same-pair regression。
+
+### 问题 2: 仅以 response map key 判定 membership，未验证 physical Bot/metadata shape
+
+- 文件: [bot_public_service.py:1137](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1137)
+- 严重程度: 必须修复
+- 描述: 代码只验证 `data` 是 dict，并把请求内 key 直接加入 available set；不验证 item 是有效 metadata 或 physical Bot。`{"success":true,"data":{"id":null}}` 会被视为命中。现有 batch response 本身也没有 worker `type`，故无法满足 Review Spec 的 physical-bot 防错配约束。
+- 建议修复方式: 将 batch contract 收紧为 tenant-scoped physical-Bot membership，并逐项校验 required fields/type；无效 item/envelope 均转 `BotCatalogSearchUnavailableError`。覆盖 missing data、invalid item、human/non-Bot、requested-key mismatch。
+
+### 问题 3: 共享 service 方法意外改变既有内部搜索 API
+
+- 文件: [bot_public_service.py:1027](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py:1027), [router_auth.py:117](/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog/src/backend/src/agentclaw/community/adapters/http/bot_public/router_auth.py:117)
+- 严重程度: 必须修复
+- 描述: `/api/v1/bot-public/search` 也调用同一个 `search_public_bots_by_keyword`；本次使它依赖 BCSFuse 且在上游失败时进入其 generic 500/error body，并非只修改 catalog `/openapi/v1/.../search`。没有该现有 API 的兼容性或 failure mapping 测试。
+- 建议修复方式: 将 catalog join 编排拆成专用 service method/port，仅由 OpenAPI catalog router 调用；或明确更新 internal API 契约、固定错误映射并补齐兼容性测试。
+
+## 整体结论
+
+**结论: REJECT**
+
+### 必须修复项
+
+1. 使 BCS metadata membership 按可信 tenant/caller 隔离，并验证 physical Bot；不得以全局 worker ID 查询替代。
+2. 隔离或显式兼容 `/api/v1/bot-public/search` 的既有行为。
+3. 补足 BCS malformed/type、cross-tenant collision、internal route failure 与新增分支测试，使改动覆盖达到 >90%，再提供远端 ACI 证据。

--- a/spec/pipeline/openapi-bot-public-bcs-join/004-implementation-plan.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/004-implementation-plan.md
@@ -15,7 +15,7 @@
 
 Follow strict TDD: add focused tests first and run them to observe the expected failure before changing production code.
 
-1. Add frozen domain DTOs `BotCatalogAddress`, `BotCatalogCaller`, and `BotCatalogMetadata`, plus runtime-checkable `BotCatalogMetadataServiceProtocol.query_public_bot_metadata(...)` and `BotCatalogMetadataUnavailableError` in the Backend API layer.
+1. Add frozen domain DTOs `BotCatalogAddress`, `BotCatalogCaller`, and `BotCatalogMetadata`, plus runtime-checkable `BotCatalogMetadataServiceProtocol.query_public_bot_metadata(...)` and `BotCatalogMetadataUnavailableError` in the Backend Core internal-port layer, preserving the enforced `api -> core` dependency direction.
 2. Add `UnavailableBotCatalogMetadataService`. It must always log a low-sensitivity unconfigured category with request ID and candidate count, then raise `BotCatalogMetadataUnavailableError`, including for an empty address list.
 3. Inject the protocol into `BotPublicService`. Its dedicated Catalog Search method must:
    - query all current-tenant public Backend candidates in stable order;

--- a/spec/pipeline/openapi-bot-public-bcs-join/004-implementation-plan.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/004-implementation-plan.md
@@ -1,0 +1,32 @@
+# Bot Catalog Search：预留 BCS 元信息端口
+
+## Global Constraints
+
+- Public API remains `GET /openapi/v1/bots/catalog/search` with `search`, `page`, and `page_size`; do not add `user_id`.
+- The verified principal is the only source of `tenant_id`, `user_id`, and `app_id`.
+- The join key is tenant-scoped `(bot_id, entity_id)`; `bot_id` alone or a global composite worker ID is insufficient.
+- Backend remains the only authority for public response fields. BCS metadata only decides membership.
+- Current production/local/test bindings make Catalog Search fail closed with `502000`; no BCS URL, path, payload, credentials, or network call is guessed now.
+- Legacy `/api/v1/bot-public/search` remains Backend-only. Discover keeps its existing BCSFuse behavior and `bot_discover_service.py` logging unchanged.
+- Do not modify, stage, or remove `.superpowers/`.
+- Logs contain only request ID, counts, and failure categories; never log bot addresses, raw upstream data, caller identifiers, credentials, tokens, or request keywords.
+
+## Task 1: Implement the complete Backend seam and fail-closed Catalog Search
+
+Follow strict TDD: add focused tests first and run them to observe the expected failure before changing production code.
+
+1. Add frozen domain DTOs `BotCatalogAddress`, `BotCatalogCaller`, and `BotCatalogMetadata`, plus runtime-checkable `BotCatalogMetadataServiceProtocol.query_public_bot_metadata(...)` and `BotCatalogMetadataUnavailableError` in the Backend API layer.
+2. Add `UnavailableBotCatalogMetadataService`. It must always log a low-sensitivity unconfigured category with request ID and candidate count, then raise `BotCatalogMetadataUnavailableError`, including for an empty address list.
+3. Inject the protocol into `BotPublicService`. Its dedicated Catalog Search method must:
+   - query all current-tenant public Backend candidates in stable order;
+   - build ordered, de-duplicated `(bot_id, entity_id)` addresses from Backend data;
+   - always invoke the metadata protocol with addresses, trusted caller context, and request ID;
+   - reject the complete metadata result as unavailable when an item is not `kind == "bot"`, duplicates another item, was not requested, or has an invalid/blank address;
+   - inner join by exact address, preserve Backend order, sanitize existing sensitive fields, and compute total/page after the join;
+   - translate the metadata unavailable error into `BotCatalogSearchUnavailableError` without exposing its details.
+4. Project the verified principal in the Catalog Search router into `BotCatalogCaller(tenant_id=principal.tenant, user_id=principal.user_id or None, app_id=principal.app_id)`, pass it and the trace ID to the service, and keep the fixed `502000 / Catalog service unavailable` response.
+5. Bind the protocol to the unavailable implementation in production/local/test DI. Remove only the Catalog Search BCSFuse HTTP qualifier/client/constructor/query code and its dedicated tests. Keep `BcsFuseConfig` and Discover untouched.
+6. Keep the legacy Search path Backend-only and retain join-after-filter pagination behavior for a future configured protocol implementation.
+7. Update the Chinese frontend document, Backend OpenAPI README references, generated `bots.openapi.json`, and the pipeline spec/report to describe the BCS port and temporary fixed 502 behavior. Do not describe an unimplemented BCS HTTP route.
+8. Add focused tests for protocol/DI resolution, unavailable behavior with empty and non-empty candidates, caller projection for user-only/app-only/user+app, exact address join, same-bot/different-entity isolation, stable ordering/de-duplication, invalid metadata fail-closed behavior, join-before-pagination, legacy Search compatibility, Discover compatibility, and response-field leakage.
+9. Run targeted pytest, architecture and DI tests, Ruff on changed Python files, unused-import checks, OpenAPI consistency checks, and `git diff --check`. Do not commit `.superpowers/`.

--- a/spec/pipeline/openapi-bot-public-catalog/009-pr-report.md
+++ b/spec/pipeline/openapi-bot-public-catalog/009-pr-report.md
@@ -124,3 +124,10 @@ PR head `e595d27ef` 的首次 Backend unit tests 失败已收敛为三个测试�
 - ACI/CI: PASS；BCS E2E、Singlebox coverage、BCS/Backend/Engine/BaaS/Gateway unit tests 共 7 个 jobs 全部 SUCCESS，0 pending/failing/cancelled。Singlebox coverage 16m47s，Backend unit 9m30s。
 - 人工意见: CLEAR；最终刷新未发现人工 review 或 comment。
 - 下一步: 等待仓库侧必需条件或审批解除 `mergeStateStatus=BLOCKED`；未自动合并、回复或 resolve thread。本次终态报告提交只修改本报告，不改变已通过远端门禁的实现与测试代码。
+
+### PR #1293 最小差异复审（2026-08-20）
+
+- 按用户要求撤销本功能不需要的纯格式化、邻近清理和共享重构；legacy sanitizer、既有分页查询分支、DI 基线空行、测试基线 import 与旧 helper 约定均恢复为 base 形态。最终 reviewer 未发现纯格式化、推测性扩展或无关重构。
+- 首轮复审因本地 change-line coverage `91/103=88.35%` REJECT；只新增 3 个行为断言后，独立复审为 PASS。Fresh focused suite `157/157`，`report_check.py` 为 case pass `100%`、change-line coverage `103/103=100%`。
+- 改动 Python 文件的增量 Ruff、F401/F841、E203/E211/E265 与 `git diff --check` 通过。`test_sync_bot_config_uses_resolver.py` 的唯一 F401 与 base 完全相同，按最小变更要求保留，未作为本功能顺手清理。
+- 本节所述 diff 尚待形成新 head 并推送；此前 7/7 SUCCESS 属于旧 head，不作为新 head 的远端 ACI 证据。推送后重新监控全部远端检查与评论。

--- a/spec/pipeline/openapi-bot-public-catalog/009-pr-report.md
+++ b/spec/pipeline/openapi-bot-public-catalog/009-pr-report.md
@@ -10,7 +10,8 @@
   / `code.alipay.com/mirrors/Avernet`
 - Head / base: `feat/openapi-bot-public-catalog` /
   `dev_refactory_collaboration` in both independent repositories.
-- Avernet PR: [#1238](https://github.com/inclusionAI/Avernet/pull/1238), OPEN.
+- Avernet PR: [#1238](https://github.com/inclusionAI/Avernet/pull/1238), MERGED;
+  the BCS metadata-port follow-up is local-only pending a decision on a new PR.
 - Conflict-resolution merge: `e9d4b4ed8` merges current
   `dev_refactory_collaboration` (`3d6531c5`) into the topic without rewriting
   or force-pushing branch history.
@@ -105,3 +106,11 @@ PR head `e595d27ef` 的首次 Backend unit tests 失败已收敛为三个测试�
 - 本轮仅 `test_explicit_user_id.py` 发生内容冲突。保留 base 新增的 `94/1/46` operation 变化，并叠加 catalog 的两个无 Bot、无 user 维度读接口，最终 Bot ID placement 为 `94/1/48`；user-scoped operation 数保持 base 的 `130`。
 - 重新生成 Gateway `bots.openapi.json`，保留最新 base 的 token、session-favorites 等 schema，同时保留 catalog search/discover。
 - 验证：Backend catalog/admission/principal/path/coverage 合并回归 74 passed；Gateway route-security/served-schema/domain-map 184 passed；无新的 active review thread。
+
+## BCS 元信息端口后续（2026-08-20）
+
+- GitHub 已确认 PR #1238 为 `MERGED`，合并 head 为 `c41c927020070a5828fd3e0c84376f252750642b`；远端 `feat/openapi-bot-public-catalog` 已删除，因此本次后续不能追加到原 PR。
+- 本地主题分支仅保留新增后续提交，并重放到最新 `origin/dev_refactory_collaboration@efa0b7da3`：`f717ebd5d`（BCS metadata port）和 `50434a1b6`（固定 502 OpenAPI 契约）。唯一冲突为英文 OpenAPI changelog，已保留 base 的 Editors/Spaces/Render Screen 内容并叠加本功能说明。
+- 当前实现不调用或猜测 BCS HTTP API；production/local/test 均绑定 fail-closed unavailable service，Catalog Search 固定返回 `502000`。Legacy Search 与 Discover 保持原行为。
+- 本地最终验证：Backend 184 passed；Gateway schema/auth/forwarding 222 passed；Ruff、JSON、OpenAPI 重生成和 `git diff --check` 通过。仅存在既有依赖弃用和 schema 生成告警。
+- 当前结论：后续 PR `NOT_CREATED`。创建新的远端分支/PR 需要用户确认；未强推、未合并、未回复或 resolve review thread。

--- a/spec/pipeline/openapi-bot-public-catalog/009-pr-report.md
+++ b/spec/pipeline/openapi-bot-public-catalog/009-pr-report.md
@@ -27,7 +27,7 @@
 
 | 结果 | 证据 | 说明 |
 |---|---|---|
-| Avernet follow-up PR | [#1293](https://github.com/inclusionAI/Avernet/pull/1293) | OPEN；head `bcbe0c94a87770946e5ffbccabb5c9c43c612770`，base `dev_refactory_collaboration`。Title 使用语义化 outcome，body 含 Problem / Solution / Validation / Compatibility and risk / Spec / Related issues。 |
+| Avernet follow-up PR | [#1293](https://github.com/inclusionAI/Avernet/pull/1293) | OPEN；CI 验证 head `2afea50c280c360f2b69611326d1f294e4a632c4`，base `dev_refactory_collaboration`。Title 使用语义化 outcome，body 含 Problem / Solution / Validation / Compatibility and risk / Spec / Related issues。 |
 | Avernet open PR | [#1238](https://github.com/inclusionAI/Avernet/pull/1238) | Created after verifying its base is `dev_refactory_collaboration`, head is `feat/openapi-bot-public-catalog`, and its title/body contain all required sections. Initial head: `70c54bdd5`. |
 | PR merge conflict | resolved | GitHub reported `CONFLICTING` after the base advanced to `3d6531c5`. The merge kept both the Bot Workshop/local additions and the public-catalog routes, regenerated `bots.openapi.json`, and did not touch `.superpowers/`. |
 | OCB mirror PR | BLOCKED | Its local gateway-sync commit is `e23bf4ff3`; `git push --no-verify -u origin feat/openapi-bot-public-catalog` was rejected because the current user has no access to `mirrors/Avernet`. |
@@ -117,10 +117,10 @@ PR head `e595d27ef` 的首次 Backend unit tests 失败已收敛为三个测试�
 - 整分支 Review 为 Ready，安全审查无 high/medium 候选；顺序测试与 Core 分层修复的 scoped rereview 为 PASS（Critical/Important/Minor 均为 0）。
 - 当前结论：后续 PR [#1293](https://github.com/inclusionAI/Avernet/pull/1293) 已创建且为 `OPEN`；未强推、未合并、未回复或 resolve review thread。
 
-### PR #1293 初始收敛状态
+### PR #1293 收敛状态
 
-- PR: OPEN，head `bcbe0c94a87770946e5ffbccabb5c9c43c612770`，base `dev_refactory_collaboration`，metadata 已核验。
-- 自动意见: CLEAR；创建后未发现 review、inline comment 或普通 comment。
-- ACI/CI: PENDING；BCS E2E、Singlebox coverage、BCS/BaaS unit tests 为 QUEUED，Backend/Engine/Gateway unit tests 为 IN_PROGRESS，均未当作通过。
-- 人工意见: CLEAR；创建后未发现人工 review 或 comment。
-- 下一步: 等待当前 head 的远端 jobs 终态，再按实际评论与失败日志继续收敛。
+- PR: OPEN，CI 验证 head `2afea50c280c360f2b69611326d1f294e4a632c4`，base `dev_refactory_collaboration`，metadata 已核验。GitHub 报告 `mergeable=MERGEABLE`、`mergeStateStatus=BLOCKED`；分支保护详情不可访问，不猜测具体仓库规则。
+- 自动意见: CLEAR；最终刷新未发现 BOT review、inline comment 或普通 comment。
+- ACI/CI: PASS；BCS E2E、Singlebox coverage、BCS/Backend/Engine/BaaS/Gateway unit tests 共 7 个 jobs 全部 SUCCESS，0 pending/failing/cancelled。Singlebox coverage 16m47s，Backend unit 9m30s。
+- 人工意见: CLEAR；最终刷新未发现人工 review 或 comment。
+- 下一步: 等待仓库侧必需条件或审批解除 `mergeStateStatus=BLOCKED`；未自动合并、回复或 resolve thread。本次终态报告提交只修改本报告，不改变已通过远端门禁的实现与测试代码。

--- a/spec/pipeline/openapi-bot-public-catalog/009-pr-report.md
+++ b/spec/pipeline/openapi-bot-public-catalog/009-pr-report.md
@@ -110,7 +110,8 @@ PR head `e595d27ef` 的首次 Backend unit tests 失败已收敛为三个测试�
 ## BCS 元信息端口后续（2026-08-20）
 
 - GitHub 已确认 PR #1238 为 `MERGED`，合并 head 为 `c41c927020070a5828fd3e0c84376f252750642b`；远端 `feat/openapi-bot-public-catalog` 已删除，因此本次后续不能追加到原 PR。
-- 本地主题分支仅保留新增后续提交，并重放到最新 `origin/dev_refactory_collaboration@efa0b7da3`：`f717ebd5d`（BCS metadata port）和 `50434a1b6`（固定 502 OpenAPI 契约）。唯一冲突为英文 OpenAPI changelog，已保留 base 的 Editors/Spaces/Render Screen 内容并叠加本功能说明。
+- 本地主题分支仅保留新增后续提交，并重放到最新 `origin/dev_refactory_collaboration@efa0b7da3`：`f717ebd5d`（BCS metadata port）、`50434a1b6`（固定 502 OpenAPI 契约）、`7621f0dc3`（交付状态）、`52af6f506`（稳定顺序断言）和 `dfdbebd93`（Core 内部端口分层）。唯一冲突为英文 OpenAPI changelog，已保留 base 的 Editors/Spaces/Render Screen 内容并叠加本功能说明。
 - 当前实现不调用或猜测 BCS HTTP API；production/local/test 均绑定 fail-closed unavailable service，Catalog Search 固定返回 `502000`。Legacy Search 与 Discover 保持原行为。
-- 本地最终验证：Backend 184 passed；Gateway schema/auth/forwarding 222 passed；Ruff、JSON、OpenAPI 重生成和 `git diff --check` 通过。仅存在既有依赖弃用和 schema 生成告警。
+- 本地最终验证：Backend 全量 `13149 passed, 21 skipped`；Gateway schema/auth/forwarding `228 passed`；全部改动 Python 文件 Ruff、JSON、OpenAPI 重生成一致性和 `git diff --check` 通过。Gateway 项目级全量另有 12 个非本分支失败：10 个 live/baseline E2E 因未启动 Gateway 而连接失败，2 个项目级 Ruff 门禁命中三个相对 base 未改动的文件；未越界修改这些基线问题。
+- 整分支 Review 为 Ready，安全审查无 high/medium 候选；顺序测试与 Core 分层修复的 scoped rereview 为 PASS（Critical/Important/Minor 均为 0）。
 - 当前结论：后续 PR `NOT_CREATED`。创建新的远端分支/PR 需要用户确认；未强推、未合并、未回复或 resolve review thread。

--- a/spec/pipeline/openapi-bot-public-catalog/009-pr-report.md
+++ b/spec/pipeline/openapi-bot-public-catalog/009-pr-report.md
@@ -10,23 +10,24 @@
   / `code.alipay.com/mirrors/Avernet`
 - Head / base: `feat/openapi-bot-public-catalog` /
   `dev_refactory_collaboration` in both independent repositories.
-- Avernet PR: [#1238](https://github.com/inclusionAI/Avernet/pull/1238), MERGED;
-  the BCS metadata-port follow-up is local-only pending a decision on a new PR.
+- Avernet PR: [#1293](https://github.com/inclusionAI/Avernet/pull/1293), OPEN;
+  follow-up to merged PR [#1238](https://github.com/inclusionAI/Avernet/pull/1238).
 - Conflict-resolution merge: `e9d4b4ed8` merges current
   `dev_refactory_collaboration` (`3d6531c5`) into the topic without rewriting
   or force-pushing branch history.
 - OCB mirror PR: BLOCKED; its topic-branch push was rejected by remote project
   authorization.
-- Planned titles:
-  - Avernet: `feat(openapi): add public bot catalog endpoints`
+- Final titles:
+  - Avernet follow-up: `feat(bot-catalog): add fail-closed BCS metadata port`
   - OCB mirror: `feat(gateway): expose public bot catalog routes`
-- PR description sections: Problem / Solution / Validation / Compatibility and risk / Spec
+- PR description sections: Problem / Solution / Validation / Compatibility and risk / Spec / Related issues
 - 人工意见模式: auto
 
 ## PR 判定
 
 | 结果 | 证据 | 说明 |
 |---|---|---|
+| Avernet follow-up PR | [#1293](https://github.com/inclusionAI/Avernet/pull/1293) | OPEN；head `bcbe0c94a87770946e5ffbccabb5c9c43c612770`，base `dev_refactory_collaboration`。Title 使用语义化 outcome，body 含 Problem / Solution / Validation / Compatibility and risk / Spec / Related issues。 |
 | Avernet open PR | [#1238](https://github.com/inclusionAI/Avernet/pull/1238) | Created after verifying its base is `dev_refactory_collaboration`, head is `feat/openapi-bot-public-catalog`, and its title/body contain all required sections. Initial head: `70c54bdd5`. |
 | PR merge conflict | resolved | GitHub reported `CONFLICTING` after the base advanced to `3d6531c5`. The merge kept both the Bot Workshop/local additions and the public-catalog routes, regenerated `bots.openapi.json`, and did not touch `.superpowers/`. |
 | OCB mirror PR | BLOCKED | Its local gateway-sync commit is `e23bf4ff3`; `git push --no-verify -u origin feat/openapi-bot-public-catalog` was rejected because the current user has no access to `mirrors/Avernet`. |
@@ -114,4 +115,12 @@ PR head `e595d27ef` 的首次 Backend unit tests 失败已收敛为三个测试�
 - 当前实现不调用或猜测 BCS HTTP API；production/local/test 均绑定 fail-closed unavailable service，Catalog Search 固定返回 `502000`。Legacy Search 与 Discover 保持原行为。
 - 本地最终验证：Backend 全量 `13149 passed, 21 skipped`；Gateway schema/auth/forwarding `228 passed`；全部改动 Python 文件 Ruff、JSON、OpenAPI 重生成一致性和 `git diff --check` 通过。Gateway 项目级全量另有 12 个非本分支失败：10 个 live/baseline E2E 因未启动 Gateway 而连接失败，2 个项目级 Ruff 门禁命中三个相对 base 未改动的文件；未越界修改这些基线问题。
 - 整分支 Review 为 Ready，安全审查无 high/medium 候选；顺序测试与 Core 分层修复的 scoped rereview 为 PASS（Critical/Important/Minor 均为 0）。
-- 当前结论：后续 PR `NOT_CREATED`。创建新的远端分支/PR 需要用户确认；未强推、未合并、未回复或 resolve review thread。
+- 当前结论：后续 PR [#1293](https://github.com/inclusionAI/Avernet/pull/1293) 已创建且为 `OPEN`；未强推、未合并、未回复或 resolve review thread。
+
+### PR #1293 初始收敛状态
+
+- PR: OPEN，head `bcbe0c94a87770946e5ffbccabb5c9c43c612770`，base `dev_refactory_collaboration`，metadata 已核验。
+- 自动意见: CLEAR；创建后未发现 review、inline comment 或普通 comment。
+- ACI/CI: PENDING；BCS E2E、Singlebox coverage、BCS/BaaS unit tests 为 QUEUED，Backend/Engine/Gateway unit tests 为 IN_PROGRESS，均未当作通过。
+- 人工意见: CLEAR；创建后未发现人工 review 或 comment。
+- 下一步: 等待当前 head 的远端 jobs 终态，再按实际评论与失败日志继续收敛。

--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -2093,6 +2093,9 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
 - **2026-08-20** — Added authenticated Bot catalog reads at
   `GET /openapi/v1/bots/catalog/search` and `/discover`. User and App
   principals see the same allowlisted public projection.
+  `/search` has a tenant-scoped `(bot_id, entity_id)` BCS metadata port; its
+  current fail-closed binding returns `502000 / Catalog service unavailable`
+  until a concrete BCS protocol is configured, with no Backend-only fallback.
 
 - **2026-08-19 — Bot Editors CRUD.** The public surface now exposes
   `GET/POST /openapi/v1/bots/{bot_id}/editors`,

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -1089,8 +1089,8 @@ domain —— `bots` 未声明 `protocols`，因此只服务 HTTP 平面 —— 
 
 - **2026-08-20** —— **新增认证 Bot Catalog 查询。** 提供
   `GET /openapi/v1/bots/catalog/search` 与 `/discover`；User 和 App 身份读取
-  相同的公开白名单投影，不再接受 `user_id` 或返回用户 `friendship`。`/search`
-  通过租户范围的 `(bot_id, entity_id)` BCS 元信息端口做内连接；当前端口未配置，固定返回
+  相同的公开白名单投影，不再接受 `user_id` 或返回用户 `friendship`。
+  `/search` 通过租户范围的 `(bot_id, entity_id)` BCS 元信息端口做内连接；当前端口未配置，固定返回
   `502000 / Catalog service unavailable`，不会降级为 Backend-only 结果。
 
 - **2026-08-19** —— **新增 Bot 归属空间变更能力。** 新增

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -1089,7 +1089,9 @@ domain —— `bots` 未声明 `protocols`，因此只服务 HTTP 平面 —— 
 
 - **2026-08-20** —— **新增认证 Bot Catalog 查询。** 提供
   `GET /openapi/v1/bots/catalog/search` 与 `/discover`；User 和 App 身份读取
-  相同的公开白名单投影，不再接受 `user_id` 或返回用户 `friendship`。
+  相同的公开白名单投影，不再接受 `user_id` 或返回用户 `friendship`。`/search`
+  通过租户范围的 `(bot_id, entity_id)` BCS 元信息端口做内连接；当前端口未配置，固定返回
+  `502000 / Catalog service unavailable`，不会降级为 Backend-only 结果。
 
 - **2026-08-19** —— **新增 Bot 归属空间变更能力。** 新增
   `PUT /openapi/v1/bots/{bot_id}/space`：显式传 `user_id` 和数值型目标

--- a/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
+++ b/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
@@ -21,9 +21,14 @@ GET /openapi/v1/bots/catalog/discover
 GET /openapi/v1/bots/catalog/search
 ```
 
+搜索先按当前租户的 Backend 候选生成有序去重的 `(bot_id, entity_id)` 地址，并通过受信任调用者
+上下文交给 BCS 元信息端口做成员资格内连接。Backend 是对外字段的唯一权威来源；当前各环境的
+端口尚未配置，因此此接口固定返回 `502000 / Catalog service unavailable`，不会回退为
+Backend-only 搜索。未来配置端口后，`total` 与分页仍将基于完整 join 后的候选集。
+
 | 参数 | 必填 | 规则 |
 |---|---:|---|
-| `search` | 否 | Bot 名称或 owner 名称关键词 |
+| `search` | 否 | Bot 名称或 owner 名称的模糊关键词；由 Backend 检索 |
 | `page` | 否 | 默认 1，最小 1 |
 | `page_size` | 否 | 默认 20，范围 1–100 |
 
@@ -93,6 +98,6 @@ type DiscoveredPublicBot = PublicBot & {
 | `401000` | User/App Principal 缺失或无效 |
 | `422000` | 参数缺失或范围错误 |
 | `500000` | 搜索服务内部错误 |
-| `502000` | 推荐服务暂不可用 |
+| `502000` | Catalog Search 的 BCS 元信息端口未配置，或推荐服务暂不可用 |
 
 前端记录 `request_id` 用于排障，不记录认证信息、完整请求 URL 或搜索关键词。

--- a/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
+++ b/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
@@ -28,7 +28,7 @@ Backend-only 搜索。未来配置端口后，`total` 与分页仍将基于完�
 
 | 参数 | 必填 | 规则 |
 |---|---:|---|
-| `search` | 否 | Bot 名称或 owner 名称的模糊关键词；由 Backend 检索 |
+| `search` | 否 | Bot 名称或 owner 名称关键词 |
 | `page` | 否 | 默认 1，最小 1 |
 | `page_size` | 否 | 默认 20，范围 1–100 |
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
@@ -15,7 +15,11 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import (
 )
 from agentclaw.community.adapters.http.openapi_v1.responses import error_response, page
 from agentclaw.community.api.bot_discover_service import BotDiscoverServiceProtocol
-from agentclaw.community.api.bot_public_service import BotPublicServiceProtocol
+from agentclaw.community.api.bot_public_service import (
+    BotCatalogCaller,
+    BotCatalogSearchUnavailableError,
+    BotPublicServiceProtocol,
+)
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger
 
@@ -67,10 +71,11 @@ def _public_bot(record: Mapping[str, Any]) -> PublicBot:
     "/search",
     response_model=Envelope[Page[PublicBot]],
     response_model_exclude_none=True,
+    responses={502: {"description": "Catalog service unavailable"}},
 )
 async def search_public_bots(
     request: Request,
-    _principal: PrincipalDep,
+    principal: PrincipalDep,
     search: str | None = Query(default=None, description="Bot or owner name keyword."),
     page_number: int = Query(
         default=1, alias="page", ge=1, description="1-based page number."
@@ -79,9 +84,20 @@ async def search_public_bots(
     service: BotPublicServiceProtocol = Injected(BotPublicServiceProtocol),
 ) -> Envelope[Page[PublicBot]]:
     try:
-        result = service.search_public_bots_by_keyword(
-            search=search, page=page_number, page_size=page_size
+        result = service.search_catalog_public_bots_by_keyword(
+            search=search,
+            page=page_number,
+            page_size=page_size,
+            caller=BotCatalogCaller(
+                tenant_id=principal.tenant,
+                user_id=principal.user_id or None,
+                app_id=principal.app_id,
+            ),
+            request_id=_request_id(request),
         )
+    except BotCatalogSearchUnavailableError:
+        _log_failure("search", request, "bcs_unavailable")
+        return error_response(502, "Catalog service unavailable", request)
     except Exception:  # noqa: BLE001 - the public error must remain fixed
         _log_failure("search", request, "service_failure")
         return error_response(500, "Internal Server Error", request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
@@ -8,7 +8,12 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, Query, Request
 from pydantic import ValidationError
 
-from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope, Page
+from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    Envelope,
+    ErrorEnvelope,
+    Page,
+    error_example,
+)
 from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     Principal,
     require_principal,
@@ -71,7 +76,13 @@ def _public_bot(record: Mapping[str, Any]) -> PublicBot:
     "/search",
     response_model=Envelope[Page[PublicBot]],
     response_model_exclude_none=True,
-    responses={502: {"description": "Catalog service unavailable"}},
+    responses={
+        502: {
+            "model": ErrorEnvelope,
+            "description": "Catalog service unavailable",
+            **error_example(502, "Catalog service unavailable"),
+        }
+    },
 )
 async def search_public_bots(
     request: Request,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
@@ -20,10 +20,10 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import (
 )
 from agentclaw.community.adapters.http.openapi_v1.responses import error_response, page
 from agentclaw.community.api.bot_discover_service import BotDiscoverServiceProtocol
-from agentclaw.community.api.bot_public_service import (
+from agentclaw.community.api.bot_public_service import BotPublicServiceProtocol
+from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogCaller,
     BotCatalogSearchUnavailableError,
-    BotPublicServiceProtocol,
 )
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger

--- a/src/backend/src/agentclaw/community/api/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/api/bot_public_service.py
@@ -1,7 +1,54 @@
 """Service API Protocol for public-bot lifecycle + friend approvals."""
 from __future__ import annotations
 
-from typing import Any, Dict, Protocol, runtime_checkable
+from dataclasses import dataclass
+from typing import Any, Dict, Protocol, Sequence, runtime_checkable
+
+
+@dataclass(frozen=True)
+class BotCatalogAddress:
+    """Tenant-scoped Backend identity of one catalog Bot."""
+
+    bot_id: str
+    entity_id: str
+
+
+@dataclass(frozen=True)
+class BotCatalogCaller:
+    """Trusted principal context supplied to the catalog metadata port."""
+
+    tenant_id: str
+    user_id: str | None
+    app_id: int | None
+
+
+@dataclass(frozen=True)
+class BotCatalogMetadata:
+    """Membership-only metadata returned by the catalog metadata port."""
+
+    address: BotCatalogAddress
+    kind: str
+
+
+class BotCatalogMetadataUnavailableError(Exception):
+    """The catalog metadata port cannot make an authoritative decision."""
+
+
+@runtime_checkable
+class BotCatalogMetadataServiceProtocol(Protocol):
+    """Authoritative membership lookup for tenant-scoped catalog Bots."""
+
+    def query_public_bot_metadata(
+        self,
+        *,
+        addresses: Sequence[BotCatalogAddress],
+        caller: BotCatalogCaller,
+        request_id: str,
+    ) -> Sequence[BotCatalogMetadata]: ...
+
+
+class BotCatalogSearchUnavailableError(Exception):
+    """The BCS-backed catalog metadata source is unavailable."""
 
 
 @runtime_checkable
@@ -17,6 +64,8 @@ class BotPublicServiceProtocol(Protocol):
     def handle_friend_request_approval_callback(self, *args: Any, **kwargs: Any) -> Any: ...
 
     def search_public_bots_by_keyword(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    def search_catalog_public_bots_by_keyword(self, *args: Any, **kwargs: Any) -> Any: ...
 
     def list_my_bot_friends(self, *args: Any, **kwargs: Any) -> Any: ...
 

--- a/src/backend/src/agentclaw/community/api/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/api/bot_public_service.py
@@ -1,54 +1,7 @@
 """Service API Protocol for public-bot lifecycle + friend approvals."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Dict, Protocol, Sequence, runtime_checkable
-
-
-@dataclass(frozen=True)
-class BotCatalogAddress:
-    """Tenant-scoped Backend identity of one catalog Bot."""
-
-    bot_id: str
-    entity_id: str
-
-
-@dataclass(frozen=True)
-class BotCatalogCaller:
-    """Trusted principal context supplied to the catalog metadata port."""
-
-    tenant_id: str
-    user_id: str | None
-    app_id: int | None
-
-
-@dataclass(frozen=True)
-class BotCatalogMetadata:
-    """Membership-only metadata returned by the catalog metadata port."""
-
-    address: BotCatalogAddress
-    kind: str
-
-
-class BotCatalogMetadataUnavailableError(Exception):
-    """The catalog metadata port cannot make an authoritative decision."""
-
-
-@runtime_checkable
-class BotCatalogMetadataServiceProtocol(Protocol):
-    """Authoritative membership lookup for tenant-scoped catalog Bots."""
-
-    def query_public_bot_metadata(
-        self,
-        *,
-        addresses: Sequence[BotCatalogAddress],
-        caller: BotCatalogCaller,
-        request_id: str,
-    ) -> Sequence[BotCatalogMetadata]: ...
-
-
-class BotCatalogSearchUnavailableError(Exception):
-    """The BCS-backed catalog metadata source is unavailable."""
+from typing import Any, Dict, Protocol, runtime_checkable
 
 
 @runtime_checkable

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -2218,8 +2218,8 @@ class BotService:
         self,
         public: Optional[str] = None,
         search: Optional[str] = None,
-        page: int = 1,
-        page_size: int = 20,
+        page: int | None = 1,
+        page_size: int | None = 20,
     ) -> Dict[str, Any]:
         """
         List bots with search and pagination.

--- a/src/backend/src/agentclaw/community/core/bot_public/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_public/README.md
@@ -12,10 +12,12 @@ provides:
   - "Bot-public SQLAlchemy models"
 consumes:
   - "BotManagement repo + service"
+  - "BotCatalogMetadata port (membership-only, joined by (bot_id, entity_id))"
   - "AntProcess plugins (auth_relationship, bot_publish_approval, antprocess)"
   - "PassportPlugin"
   - "SkillCenter factories"
 internal_dependencies:
+  - agentclaw.community.api.bot_public_service
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.bot_management
   - agentclaw.community.core.devices

--- a/src/backend/src/agentclaw/community/core/bot_public/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_public/README.md
@@ -17,7 +17,7 @@ consumes:
   - "PassportPlugin"
   - "SkillCenter factories"
 internal_dependencies:
-  - agentclaw.community.api.bot_public_service
+  - agentclaw.community.core.bot_public.catalog_metadata
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.bot_management
   - agentclaw.community.core.devices

--- a/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
@@ -1,0 +1,52 @@
+"""Transport-neutral contract for public Bot catalog membership metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, Sequence, runtime_checkable
+
+
+@dataclass(frozen=True)
+class BotCatalogAddress:
+    """Tenant-scoped Backend identity of one catalog Bot."""
+
+    bot_id: str
+    entity_id: str
+
+
+@dataclass(frozen=True)
+class BotCatalogCaller:
+    """Trusted principal context supplied to the catalog metadata port."""
+
+    tenant_id: str
+    user_id: str | None
+    app_id: int | None
+
+
+@dataclass(frozen=True)
+class BotCatalogMetadata:
+    """Membership-only metadata returned by the catalog metadata port."""
+
+    address: BotCatalogAddress
+    kind: str
+
+
+class BotCatalogMetadataUnavailableError(Exception):
+    """The catalog metadata port cannot make an authoritative decision."""
+
+
+@runtime_checkable
+class BotCatalogMetadataServiceProtocol(Protocol):
+    """Authoritative membership lookup for tenant-scoped catalog Bots."""
+
+    def query_public_bot_metadata(
+        self,
+        *,
+        addresses: Sequence[BotCatalogAddress],
+        caller: BotCatalogCaller,
+        request_id: str,
+    ) -> Sequence[BotCatalogMetadata]: ...
+
+
+class BotCatalogSearchUnavailableError(Exception):
+    """The BCS-backed catalog metadata source is unavailable."""

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
@@ -1,0 +1,34 @@
+"""Fail-closed implementation of the catalog metadata port."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from agentclaw.community.api.bot_public_service import (
+    BotCatalogAddress,
+    BotCatalogCaller,
+    BotCatalogMetadata,
+    BotCatalogMetadataUnavailableError,
+)
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+
+class UnavailableBotCatalogMetadataService:
+    """Temporary binding used until the BCS metadata protocol is configured."""
+
+    def query_public_bot_metadata(
+        self,
+        *,
+        addresses: Sequence[BotCatalogAddress],
+        caller: BotCatalogCaller,
+        request_id: str,
+    ) -> Sequence[BotCatalogMetadata]:
+        del caller
+        logger.warning(
+            "[BotCatalogMetadata] request_id=%s candidate_count=%s failure=unconfigured",
+            request_id,
+            len(addresses),
+        )
+        raise BotCatalogMetadataUnavailableError()

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from agentclaw.community.api.bot_public_service import (
+from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogAddress,
     BotCatalogCaller,
     BotCatalogMetadata,

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -19,7 +19,7 @@ from agentclaw.community.utils.avernet_tenant import (
 from agentclaw.community.core.repository.protocols.bot import BotFriendRepositoryProtocol
 from agentclaw.community.core.bot_public.repository.models import BotFriendQueryKey, BotFriendStatus, ApprovalStatus, ApprovalType
 from agentclaw.community.core.operator_context import OperatorContext
-from agentclaw.community.api.bot_public_service import (
+from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogAddress,
     BotCatalogCaller,
     BotCatalogMetadata,

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -1056,7 +1056,26 @@ class BotPublicService:
         if not items:
             return public_bot_result
 
-        self._sanitize_public_bots(items)
+        # Sanitize sensitive fields to avoid leaking them through the public search API.
+        EXT_SENSITIVE_KEYS = {"iam_token"}
+        for bot in items:
+            # Redact top-level device_id
+            if "device_id" in bot:
+                bot["device_id"] = None
+            # Redact sensitive fields inside ext
+            ext = bot.get("ext")
+            if isinstance(ext, str):
+                try:
+                    ext = json.loads(ext)
+                except json.JSONDecodeError:
+                    ext = {}
+            if isinstance(ext, dict):
+                if isinstance(ext.get("passport"), dict) and "token" in ext["passport"]:
+                    ext["passport"]["token"] = None
+                for key in EXT_SENSITIVE_KEYS:
+                    if key in ext:
+                        ext[key] = None
+                bot["ext"] = ext
 
         # 查询好友申请记录。公开 catalog 不携带用户作用域，因此不读取关系数据。
         if not user_id:
@@ -1126,7 +1145,24 @@ class BotPublicService:
             for bot in candidates
             if self._catalog_address(bot) in admitted
         ]
-        self._sanitize_public_bots(items)
+        # Sanitize sensitive fields before pagination and public projection.
+        EXT_SENSITIVE_KEYS = {"iam_token"}
+        for bot in items:
+            if "device_id" in bot:
+                bot["device_id"] = None
+            ext = bot.get("ext")
+            if isinstance(ext, str):
+                try:
+                    ext = json.loads(ext)
+                except json.JSONDecodeError:
+                    ext = {}
+            if isinstance(ext, dict):
+                if isinstance(ext.get("passport"), dict) and "token" in ext["passport"]:
+                    ext["passport"]["token"] = None
+                for key in EXT_SENSITIVE_KEYS:
+                    if key in ext:
+                        ext[key] = None
+                bot["ext"] = ext
         total = len(items)
         page_items = items[(page - 1) * page_size:page * page_size]
         logger.info(
@@ -1182,27 +1218,6 @@ class BotPublicService:
                 raise BotCatalogMetadataUnavailableError()
             admitted.add(address)
         return admitted
-
-    @staticmethod
-    def _sanitize_public_bots(items: list[dict[str, Any]]) -> None:
-        """Redact fields that must not leave either public-search path."""
-        EXT_SENSITIVE_KEYS = {"iam_token"}
-        for bot in items:
-            if "device_id" in bot:
-                bot["device_id"] = None
-            ext = bot.get("ext")
-            if isinstance(ext, str):
-                try:
-                    ext = json.loads(ext)
-                except json.JSONDecodeError:
-                    ext = {}
-            if isinstance(ext, dict):
-                if isinstance(ext.get("passport"), dict) and "token" in ext["passport"]:
-                    ext["passport"]["token"] = None
-                for key in EXT_SENSITIVE_KEYS:
-                    if key in ext:
-                        ext[key] = None
-                bot["ext"] = ext
 
     def list_my_bot_friends(
         self,

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -19,6 +19,14 @@ from agentclaw.community.utils.avernet_tenant import (
 from agentclaw.community.core.repository.protocols.bot import BotFriendRepositoryProtocol
 from agentclaw.community.core.bot_public.repository.models import BotFriendQueryKey, BotFriendStatus, ApprovalStatus, ApprovalType
 from agentclaw.community.core.operator_context import OperatorContext
+from agentclaw.community.api.bot_public_service import (
+    BotCatalogAddress,
+    BotCatalogCaller,
+    BotCatalogMetadata,
+    BotCatalogMetadataServiceProtocol,
+    BotCatalogMetadataUnavailableError,
+    BotCatalogSearchUnavailableError,
+)
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 from agentclaw.community.log import get_logger
 
@@ -94,6 +102,7 @@ class BotPublicService:
         skill_set_service_factory: "SkillSetServiceFactory",
         device_context_resolver: DeviceContextResolver,
         device_sync_dispatcher: "DeviceSyncDispatcher",
+        catalog_metadata_service: BotCatalogMetadataServiceProtocol,
     ) -> None:
         self._bot_friend_repo = bot_friend_repo
         self._bot_repository = bot_repository
@@ -107,6 +116,7 @@ class BotPublicService:
         # sync_bot_config_to_device 路径上的角色。Task 6 收口后 supplier 已删。
         self._resolver = device_context_resolver
         self._device_sync_dispatcher = device_sync_dispatcher
+        self._catalog_metadata_service = catalog_metadata_service
         self._sync_lock = threading.Lock()
         self._syncing_bots: set[str] = set()
         self._pending_syncs: dict[str, tuple[str, str]] = {}  # sync_key -> (access_mode, public)
@@ -1046,26 +1056,7 @@ class BotPublicService:
         if not items:
             return public_bot_result
 
-        # Sanitize sensitive fields to avoid leaking them through the public search API.
-        EXT_SENSITIVE_KEYS = {"iam_token"}
-        for bot in items:
-            # Redact top-level device_id
-            if "device_id" in bot:
-                bot["device_id"] = None
-            # Redact sensitive fields inside ext
-            ext = bot.get("ext")
-            if isinstance(ext, str):
-                try:
-                    ext = json.loads(ext)
-                except json.JSONDecodeError:
-                    ext = {}
-            if isinstance(ext, dict):
-                if isinstance(ext.get("passport"), dict) and "token" in ext["passport"]:
-                    ext["passport"]["token"] = None
-                for key in EXT_SENSITIVE_KEYS:
-                    if key in ext:
-                        ext[key] = None
-                bot["ext"] = ext
+        self._sanitize_public_bots(items)
 
         # 查询好友申请记录。公开 catalog 不携带用户作用域，因此不读取关系数据。
         if not user_id:
@@ -1091,6 +1082,127 @@ class BotPublicService:
                 logger.warning(f"[search_public_bots_by_keyword] Failed to query friend records: {e}")
 
         return public_bot_result
+
+    def search_catalog_public_bots_by_keyword(
+        self,
+        search: Optional[str] = None,
+        page: int = 1,
+        page_size: int = 20,
+        *,
+        caller: BotCatalogCaller,
+        request_id: str,
+    ) -> Dict[str, Any]:
+        """Return public Backend Bots admitted by the metadata port."""
+        public_bot_result = self._bot_service.list_bots_by_search(
+            public="1", search=search, page=None, page_size=None
+        )
+        candidates = public_bot_result.get("items", [])
+        addresses = self._catalog_addresses(candidates)
+        try:
+            metadata = self._catalog_metadata_service.query_public_bot_metadata(
+                addresses=addresses,
+                caller=caller,
+                request_id=request_id,
+            )
+            admitted = self._validated_catalog_addresses(metadata, addresses)
+        except BotCatalogMetadataUnavailableError as exc:
+            logger.warning(
+                "[BotPublicService.catalog_search] request_id=%s candidate_count=%s "
+                "failure=metadata_unavailable",
+                request_id,
+                len(candidates),
+            )
+            raise BotCatalogSearchUnavailableError() from exc
+        except Exception as exc:  # noqa: BLE001 - metadata is fail-closed
+            logger.warning(
+                "[BotPublicService.catalog_search] request_id=%s candidate_count=%s "
+                "failure=invalid_metadata",
+                request_id,
+                len(candidates),
+            )
+            raise BotCatalogSearchUnavailableError() from exc
+        items = [
+            bot
+            for bot in candidates
+            if self._catalog_address(bot) in admitted
+        ]
+        self._sanitize_public_bots(items)
+        total = len(items)
+        page_items = items[(page - 1) * page_size:page * page_size]
+        logger.info(
+            "[BotPublicService.catalog_search] request_id=%s candidate_count=%s "
+            "joined_count=%s page_count=%s",
+            request_id,
+            len(candidates),
+            total,
+            len(page_items),
+        )
+        return {"total": total, "items": page_items}
+
+    @staticmethod
+    def _catalog_address(bot: dict[str, Any]) -> BotCatalogAddress | None:
+        bot_id = bot.get("bot_id")
+        entity_id = bot.get("entity_id")
+        if not isinstance(bot_id, str) or not bot_id.strip():
+            return None
+        if not isinstance(entity_id, str) or not entity_id.strip():
+            return None
+        return BotCatalogAddress(bot_id=bot_id, entity_id=entity_id)
+
+    @classmethod
+    def _catalog_addresses(
+        cls, candidates: list[dict[str, Any]]
+    ) -> tuple[BotCatalogAddress, ...]:
+        return tuple(
+            dict.fromkeys(
+                address
+                for candidate in candidates
+                if (address := cls._catalog_address(candidate)) is not None
+            )
+        )
+
+    @staticmethod
+    def _validated_catalog_addresses(
+        metadata: Any,
+        requested: tuple[BotCatalogAddress, ...],
+    ) -> set[BotCatalogAddress]:
+        requested_set = set(requested)
+        admitted: set[BotCatalogAddress] = set()
+        for item in metadata:
+            if not isinstance(item, BotCatalogMetadata) or item.kind != "bot":
+                raise BotCatalogMetadataUnavailableError()
+            address = item.address
+            if (
+                not isinstance(address, BotCatalogAddress)
+                or not address.bot_id.strip()
+                or not address.entity_id.strip()
+                or address not in requested_set
+                or address in admitted
+            ):
+                raise BotCatalogMetadataUnavailableError()
+            admitted.add(address)
+        return admitted
+
+    @staticmethod
+    def _sanitize_public_bots(items: list[dict[str, Any]]) -> None:
+        """Redact fields that must not leave either public-search path."""
+        EXT_SENSITIVE_KEYS = {"iam_token"}
+        for bot in items:
+            if "device_id" in bot:
+                bot["device_id"] = None
+            ext = bot.get("ext")
+            if isinstance(ext, str):
+                try:
+                    ext = json.loads(ext)
+                except json.JSONDecodeError:
+                    ext = {}
+            if isinstance(ext, dict):
+                if isinstance(ext.get("passport"), dict) and "token" in ext["passport"]:
+                    ext["passport"]["token"] = None
+                for key in EXT_SENSITIVE_KEYS:
+                    if key in ext:
+                        ext[key] = None
+                bot["ext"] = ext
 
     def list_my_bot_friends(
         self,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
@@ -436,8 +436,8 @@ class BotRepository(
         self,
         public: Optional[str] = None,
         search: Optional[str] = None,
-        page: int = 1,
-        page_size: int = 20,
+        page: int | None = 1,
+        page_size: int | None = 20,
     ) -> tuple[int, List[Dict[str, Any]]]:
         with self._db.orm_session() as db:
             query = db.query(self.Model).filter(self.Model.is_delete == 0, self._env())
@@ -451,12 +451,10 @@ class BotRepository(
                     )
                 )
             total = query.count()
-            bots = (
-                query.order_by(self.Model.gmt_create.desc())
-                .offset((page - 1) * page_size)
-                .limit(page_size)
-                .all()
-            )
+            query = query.order_by(self.Model.gmt_create.desc(), self.Model.id.desc())
+            if page is not None and page_size is not None:
+                query = query.offset((page - 1) * page_size).limit(page_size)
+            bots = query.all()
             return total, [b.to_dict() for b in bots]
 
     # ── updates (single conditional statements) ─────────────────

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
@@ -451,10 +451,17 @@ class BotRepository(
                     )
                 )
             total = query.count()
-            query = query.order_by(self.Model.gmt_create.desc(), self.Model.id.desc())
-            if page is not None and page_size is not None:
-                query = query.offset((page - 1) * page_size).limit(page_size)
-            bots = query.all()
+            if page is None or page_size is None:
+                bots = query.order_by(
+                    self.Model.gmt_create.desc(), self.Model.id.desc()
+                ).all()
+            else:
+                bots = (
+                    query.order_by(self.Model.gmt_create.desc())
+                    .offset((page - 1) * page_size)
+                    .limit(page_size)
+                    .all()
+                )
             return total, [b.to_dict() for b in bots]
 
     # ── updates (single conditional statements) ─────────────────

--- a/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
@@ -199,8 +199,8 @@ class BotRepository(Protocol):
         self,
         public: Optional[str] = None,
         search: Optional[str] = None,
-        page: int = 1,
-        page_size: int = 20,
+        page: int | None = 1,
+        page_size: int | None = 20,
     ) -> tuple[int, List[Dict[str, Any]]]:
         """List bots with pagination and search."""
         ...

--- a/src/backend/src/agentclaw/community/di/modules/bot_public_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_public_module.py
@@ -22,10 +22,7 @@ from __future__ import annotations
 from injector import Binder, Module, inject, provider, singleton
 
 from agentclaw.community.api.bot_discover_service import BotDiscoverServiceProtocol
-from agentclaw.community.api.bot_public_service import (
-    BotCatalogMetadataServiceProtocol,
-    BotPublicServiceProtocol,
-)
+from agentclaw.community.api.bot_public_service import BotPublicServiceProtocol
 from agentclaw.community.plugin_api.approval_workflow import ApprovalWorkflowPlugin
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.bot_management.services.bot_service import BotService
@@ -34,6 +31,9 @@ from agentclaw.community.core.bot_public.services.bot_discover_service import Bo
 from agentclaw.community.core.bot_public.services.bot_public_service import BotPublicService
 from agentclaw.community.core.bot_public.services.bot_catalog_metadata_service import (
     UnavailableBotCatalogMetadataService,
+)
+from agentclaw.community.core.bot_public.catalog_metadata import (
+    BotCatalogMetadataServiceProtocol,
 )
 from agentclaw.community.core.devices.services.device_context_resolver import (
     DeviceContextResolver,

--- a/src/backend/src/agentclaw/community/di/modules/bot_public_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_public_module.py
@@ -19,17 +19,22 @@ through the injector.
 """
 from __future__ import annotations
 
-
 from injector import Binder, Module, inject, provider, singleton
 
 from agentclaw.community.api.bot_discover_service import BotDiscoverServiceProtocol
-from agentclaw.community.api.bot_public_service import BotPublicServiceProtocol
+from agentclaw.community.api.bot_public_service import (
+    BotCatalogMetadataServiceProtocol,
+    BotPublicServiceProtocol,
+)
 from agentclaw.community.plugin_api.approval_workflow import ApprovalWorkflowPlugin
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.bot_management.services.bot_service import BotService
 from agentclaw.community.core.repository.protocols.bot import BotFriendRepositoryProtocol
 from agentclaw.community.core.bot_public.services.bot_discover_service import BotDiscoverService
 from agentclaw.community.core.bot_public.services.bot_public_service import BotPublicService
+from agentclaw.community.core.bot_public.services.bot_catalog_metadata_service import (
+    UnavailableBotCatalogMetadataService,
+)
 from agentclaw.community.core.devices.services.device_context_resolver import (
     DeviceContextResolver,
 )
@@ -61,6 +66,11 @@ class BotPublicModule(Module):
         binder.bind(
             BotFriendRepositoryProtocol,
             to=UnifiedBotFriendRepository,
+            scope=singleton,
+        )
+        binder.bind(
+            BotCatalogMetadataServiceProtocol,
+            to=UnavailableBotCatalogMetadataService,
             scope=singleton,
         )
 
@@ -96,6 +106,7 @@ class BotPublicModule(Module):
         skill_set_service_factory: SkillSetServiceFactory,
         device_context_resolver: DeviceContextResolver,
         device_sync_dispatcher: DeviceSyncDispatcher,
+        catalog_metadata_service: BotCatalogMetadataServiceProtocol,
     ) -> BotPublicService:
         # Explicit provider (not ``binder.bind``): BotPublicService types
         # ``skill_set_service_factory`` under TYPE_CHECKING to avoid a
@@ -112,6 +123,7 @@ class BotPublicModule(Module):
             skill_set_service_factory=skill_set_service_factory,
             device_context_resolver=device_context_resolver,
             device_sync_dispatcher=device_sync_dispatcher,
+            catalog_metadata_service=catalog_metadata_service,
         )
 
     @singleton

--- a/src/backend/src/agentclaw/community/di/modules/bot_public_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_public_module.py
@@ -19,6 +19,7 @@ through the injector.
 """
 from __future__ import annotations
 
+
 from injector import Binder, Module, inject, provider, singleton
 
 from agentclaw.community.api.bot_discover_service import BotDiscoverServiceProtocol

--- a/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
@@ -14,10 +14,10 @@ from injector import Injector, Module
 from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.api.bot_discover_service import BotDiscoverServiceProtocol
-from agentclaw.community.api.bot_public_service import (
+from agentclaw.community.api.bot_public_service import BotPublicServiceProtocol
+from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogCaller,
     BotCatalogSearchUnavailableError,
-    BotPublicServiceProtocol,
 )
 from agentclaw.community.core.gateway_principal.models import (
     AppPrincipal,

--- a/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
@@ -170,6 +170,22 @@ def test_search_projects_only_catalog_fields(
     ]
 
 
+def test_search_openapi_declares_the_fixed_catalog_unavailable_envelope(
+    app: FastAPI,
+) -> None:
+    """Catches generated clients losing the fixed 502 catalog error contract."""
+    response = app.openapi()["paths"][_SEARCH_PATH]["get"]["responses"]["502"]
+
+    assert response["description"] == "Catalog service unavailable"
+    content = response["content"]["application/json"]
+    assert content["schema"] == {"$ref": "#/components/schemas/ErrorEnvelope"}
+    assert content["example"] == {
+        "code": 502000,
+        "message": "Catalog service unavailable",
+        "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+    }
+
+
 @pytest.mark.parametrize(
     ("principal", "expected_caller"),
     [

--- a/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
@@ -14,8 +14,17 @@ from injector import Injector, Module
 from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.api.bot_discover_service import BotDiscoverServiceProtocol
-from agentclaw.community.api.bot_public_service import BotPublicServiceProtocol
-from agentclaw.community.core.gateway_principal.models import AppPrincipal, GatewayApp
+from agentclaw.community.api.bot_public_service import (
+    BotCatalogCaller,
+    BotCatalogSearchUnavailableError,
+    BotPublicServiceProtocol,
+)
+from agentclaw.community.core.gateway_principal.models import (
+    AppPrincipal,
+    GatewayApp,
+    GatewayUser,
+    UserPrincipal,
+)
 from agentclaw.community.core.gateway_principal.verifier import VerifiedCaller
 from tests.community.adapters.http.openapi_v1.conftest import mount_public_error_handlers
 
@@ -53,7 +62,7 @@ class _PublicService:
     )
     calls: list[dict[str, Any]] = field(default_factory=list)
 
-    def search_public_bots_by_keyword(self, **kwargs: Any) -> dict[str, Any]:
+    def search_catalog_public_bots_by_keyword(self, **kwargs: Any) -> dict[str, Any]:
         self.calls.append(kwargs)
         return self.result
 
@@ -100,7 +109,11 @@ def app(services: tuple[_PublicService, _DiscoverService]) -> FastAPI:
 
     app = FastAPI()
     app.include_router(build_public_router())
-    app.dependency_overrides[require_principal] = lambda: {"user_id": "caller-1"}
+    app.dependency_overrides[require_principal] = lambda: VerifiedCaller(
+        principals=(
+            UserPrincipal(subject=GatewayUser(id="caller-1", username="caller-1")),
+        )
+    )
     attach_injector(app, Injector([_Bindings()]))
     mount_public_error_handlers(app)
     return app
@@ -145,8 +158,80 @@ def test_search_projects_only_catalog_fields(
     ):
         assert forbidden not in rendered
     assert services[0].calls == [
-        {"search": "catalog", "page": 2, "page_size": 5}
+        {
+            "search": "catalog",
+            "page": 2,
+            "page_size": 5,
+            "caller": BotCatalogCaller(
+                tenant_id="teamclaw", user_id="caller-1", app_id=None
+            ),
+            "request_id": "",
+        }
     ]
+
+
+@pytest.mark.parametrize(
+    ("principal", "expected_caller"),
+    [
+        (
+            VerifiedCaller(
+                principals=(
+                    UserPrincipal(
+                        subject=GatewayUser(id="user-1", username="user-1")
+                    ),
+                )
+            ),
+            BotCatalogCaller(tenant_id="teamclaw", user_id="user-1", app_id=None),
+        ),
+        (
+            VerifiedCaller(
+                principals=(
+                    AppPrincipal(
+                        tenant="tenant-2",
+                        app=GatewayApp(
+                            app_id=2,
+                            app_name="partner",
+                            owners="team",
+                            tenant="tenant-2",
+                        ),
+                    ),
+                )
+            ),
+            BotCatalogCaller(tenant_id="tenant-2", user_id=None, app_id=2),
+        ),
+        (
+            VerifiedCaller(
+                principals=(
+                    UserPrincipal(
+                        subject=GatewayUser(id="user-3", username="user-3")
+                    ),
+                    AppPrincipal(
+                        tenant="tenant-3",
+                        app=GatewayApp(
+                            app_id=3,
+                            app_name="partner",
+                            owners="team",
+                            tenant="tenant-3",
+                        ),
+                    ),
+                )
+            ),
+            BotCatalogCaller(tenant_id="tenant-3", user_id="user-3", app_id=3),
+        ),
+    ],
+)
+def test_search_projects_the_verified_principal_to_catalog_caller(
+    app: FastAPI,
+    services: tuple[_PublicService, _DiscoverService],
+    principal: VerifiedCaller,
+    expected_caller: BotCatalogCaller,
+) -> None:
+    app.dependency_overrides[require_principal] = lambda: principal
+
+    response = TestClient(app, raise_server_exceptions=False).get(_SEARCH_PATH)
+
+    assert response.status_code == 200, response.text
+    assert services[0].calls[-1]["caller"] == expected_caller
 
 
 def test_discover_uses_online_filter_by_default(
@@ -202,6 +287,21 @@ def test_discover_returns_fixed_502_when_recommender_is_unavailable(
     }
 
     response = client.get(_DISCOVER_PATH, params={"keyword": "automation"})
+
+    assert response.status_code == 502, response.text
+    assert response.json()["code"] == 502000
+    assert response.json()["data"] is None
+
+
+def test_search_returns_fixed_502_when_bcs_catalog_is_unavailable(
+    client: TestClient, services: tuple[_PublicService, _DiscoverService]
+) -> None:
+    def _unavailable(**_kwargs: Any) -> dict[str, Any]:
+        raise BotCatalogSearchUnavailableError("upstream unavailable")
+
+    services[0].search_catalog_public_bots_by_keyword = _unavailable
+
+    response = client.get(_SEARCH_PATH, params={"search": "catalog"})
 
     assert response.status_code == 502, response.text
     assert response.json()["code"] == 502000

--- a/src/backend/tests/community/core/bot_public/services/test_sync_bot_config_uses_resolver.py
+++ b/src/backend/tests/community/core/bot_public/services/test_sync_bot_config_uses_resolver.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from agentclaw.community.core.bot_public.services.bot_public_service import BotPublicService
 from agentclaw.community.core.devices.services.device_context import DeviceContext
 

--- a/src/backend/tests/community/core/bot_public/services/test_sync_bot_config_uses_resolver.py
+++ b/src/backend/tests/community/core/bot_public/services/test_sync_bot_config_uses_resolver.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from agentclaw.community.core.bot_public.services.bot_public_service import BotPublicService
 from agentclaw.community.core.devices.services.device_context import DeviceContext
 
@@ -45,6 +43,7 @@ def _make_service(
         skill_set_service_factory=MagicMock(),
         device_context_resolver=resolver or MagicMock(),
         device_sync_dispatcher=device_sync_dispatcher or MagicMock(),
+        catalog_metadata_service=MagicMock(),
     )
 
 

--- a/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
@@ -1,0 +1,42 @@
+"""Catalog metadata port behavior."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.api.bot_public_service import (
+    BotCatalogAddress,
+    BotCatalogCaller,
+    BotCatalogMetadataServiceProtocol,
+    BotCatalogMetadataUnavailableError,
+)
+from agentclaw.community.core.bot_public.services.bot_catalog_metadata_service import (
+    UnavailableBotCatalogMetadataService,
+)
+from agentclaw.community.di.container import build_injector
+from agentclaw.community.di.profile import DeployProfile
+
+
+@pytest.mark.parametrize("addresses", [(), (BotCatalogAddress("bot-1", "entity-1"),)])
+def test_unavailable_catalog_metadata_service_fails_closed_for_every_candidate_shape(
+    addresses: tuple[BotCatalogAddress, ...],
+) -> None:
+    """Catches a future fallback that silently treats an unconfigured BCS port as empty."""
+    service = UnavailableBotCatalogMetadataService()
+    assert isinstance(service, BotCatalogMetadataServiceProtocol)
+
+    with pytest.raises(BotCatalogMetadataUnavailableError):
+        service.query_public_bot_metadata(
+            addresses=addresses,
+            caller=BotCatalogCaller(tenant_id="tenant-1", user_id="user-1", app_id=9),
+            request_id="trace-1",
+        )
+
+
+def test_test_profile_binds_catalog_metadata_protocol_to_unavailable_service() -> None:
+    """Catches an accidental local/test fallback that would make catalog membership up."""
+    port = build_injector(profile=DeployProfile.TEST).get(
+        BotCatalogMetadataServiceProtocol
+    )
+
+    assert isinstance(port, UnavailableBotCatalogMetadataService)

--- a/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from agentclaw.community.api.bot_public_service import (
+from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogAddress,
     BotCatalogCaller,
     BotCatalogMetadataServiceProtocol,

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -7,6 +7,13 @@ from agentclaw.community.core.bot_public.services.bot_public_service import (
     BotNotFoundError,
     BotPublicServiceError,
 )
+from agentclaw.community.api.bot_public_service import (
+    BotCatalogAddress,
+    BotCatalogCaller,
+    BotCatalogMetadata,
+    BotCatalogMetadataUnavailableError,
+    BotCatalogSearchUnavailableError,
+)
 from agentclaw.community.core.bot_public.repository.models import BotFriendStatus
 from agentclaw.community.core.operator_context import OperatorContext
 from agentclaw.community.utils.avernet_tenant import DEFAULT_AVERNET_TENANT
@@ -30,6 +37,7 @@ def _make_service(
     skill_set_service_factory=None,
     device_context_resolver=None,
     device_sync_dispatcher=None,
+    catalog_metadata_service=None,
 ):
     return BotPublicService(
         bot_friend_repo=bot_friend_repo or MagicMock(),
@@ -42,6 +50,7 @@ def _make_service(
         skill_set_service_factory=skill_set_service_factory or MagicMock(),
         device_context_resolver=device_context_resolver or MagicMock(),
         device_sync_dispatcher=device_sync_dispatcher or MagicMock(),
+        catalog_metadata_service=catalog_metadata_service or MagicMock(),
     )
 
 def _make_operator(staff_id="op_user", nick_name="Operator") -> OperatorContext:
@@ -52,7 +61,7 @@ def _make_operator(staff_id="op_user", nick_name="Operator") -> OperatorContext:
     return op
 
 
-def _make_bot(bot_id="bot1", owner_id="owner1", public="0", ext=None):
+def _make_bot(bot_id="bot1", owner_id="owner1", entity_id="entity1", public="0", ext=None):
     return {
         "id": 42,
         "bot_id": bot_id,
@@ -61,7 +70,7 @@ def _make_bot(bot_id="bot1", owner_id="owner1", public="0", ext=None):
         "bot_name": "TestBot",
         "owner_name": "owner_nick",
         "binding_id": 10,
-        "entity_id": "entity1",
+        "entity_id": entity_id,
         "ext": ext or {},
     }
 
@@ -723,6 +732,128 @@ class TestCreateFriendRequestApproval:
 # ---------------------------------------------------------------------------
 
 class TestSearchPublicBotsByKeyword:
+    def test_legacy_search_does_not_depend_on_catalog_metadata(self):
+        bot_service = MagicMock()
+        bot_service.list_bots_by_search.return_value = {
+            "total": 1,
+            "items": [_make_bot()],
+        }
+        metadata = MagicMock()
+        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+
+        result = svc.search_public_bots_by_keyword(search="catalog")
+
+        assert result["total"] == 1
+        metadata.query_public_bot_metadata.assert_not_called()
+
+    def test_catalog_search_joins_exact_addresses_before_pagination(self):
+        bots = [
+            _make_bot(bot_id="bot-1", entity_id="entity-1"),
+            _make_bot(bot_id="bot-2", entity_id="entity-2"),
+            _make_bot(bot_id="bot-3", entity_id="entity-3"),
+        ]
+        bot_service = MagicMock()
+        bot_service.list_bots_by_search.return_value = {"total": 3, "items": bots}
+        metadata = MagicMock()
+        metadata.query_public_bot_metadata.return_value = [
+            BotCatalogMetadata(BotCatalogAddress("bot-1", "entity-1"), "bot"),
+            BotCatalogMetadata(BotCatalogAddress("bot-3", "entity-3"), "bot"),
+        ]
+        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+
+        result = svc.search_catalog_public_bots_by_keyword(
+            search="catalog",
+            page=2,
+            page_size=1,
+            caller=BotCatalogCaller("tenant-1", "user-1", 7),
+            request_id="trace-1",
+        )
+
+        bot_service.list_bots_by_search.assert_called_once_with(
+            public="1", search="catalog", page=None, page_size=None
+        )
+        assert result["total"] == 2
+        assert [bot["bot_id"] for bot in result["items"]] == ["bot-3"]
+
+    def test_catalog_search_de_duplicates_ordered_addresses_and_keeps_entity_identity(self):
+        bots = [
+            _make_bot(bot_id="shared", entity_id="entity-a"),
+            _make_bot(bot_id="shared", entity_id="entity-b"),
+            _make_bot(bot_id="shared", entity_id="entity-a"),
+        ]
+        bot_service = MagicMock()
+        bot_service.list_bots_by_search.return_value = {"total": 3, "items": bots}
+        metadata = MagicMock()
+        metadata.query_public_bot_metadata.return_value = [
+            BotCatalogMetadata(BotCatalogAddress("shared", "entity-b"), "bot"),
+        ]
+        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+
+        result = svc.search_catalog_public_bots_by_keyword(
+            caller=BotCatalogCaller("tenant-1", None, 7), request_id="trace-2"
+        )
+
+        assert result["total"] == 1
+        assert result["items"][0]["entity_id"] == "entity-b"
+        assert metadata.query_public_bot_metadata.call_args.kwargs["addresses"] == (
+            BotCatalogAddress("shared", "entity-a"),
+            BotCatalogAddress("shared", "entity-b"),
+        )
+
+    @pytest.mark.parametrize(
+        "metadata_result",
+        [
+            [BotCatalogMetadata(BotCatalogAddress("bot-1", "entity-1"), "group")],
+            [BotCatalogMetadata(BotCatalogAddress("bot-1", "entity-1"), "bot")] * 2,
+            [BotCatalogMetadata(BotCatalogAddress("other", "entity-1"), "bot")],
+            [BotCatalogMetadata(BotCatalogAddress("", "entity-1"), "bot")],
+        ],
+    )
+    def test_catalog_search_fails_closed_on_invalid_metadata(self, metadata_result):
+        bot_service = MagicMock()
+        bot_service.list_bots_by_search.return_value = {"total": 1, "items": [_make_bot()]}
+        metadata = MagicMock()
+        metadata.query_public_bot_metadata.return_value = metadata_result
+        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+
+        with pytest.raises(BotCatalogSearchUnavailableError):
+            svc.search_catalog_public_bots_by_keyword(
+                search="catalog",
+                caller=BotCatalogCaller("tenant-1", "user-1", None),
+                request_id="trace-3",
+            )
+
+    def test_catalog_search_translates_metadata_unavailable_without_details(self):
+        bot_service = MagicMock()
+        bot_service.list_bots_by_search.return_value = {"total": 1, "items": [_make_bot()]}
+        metadata = MagicMock()
+        metadata.query_public_bot_metadata.side_effect = BotCatalogMetadataUnavailableError(
+            "internal detail"
+        )
+        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+
+        with pytest.raises(BotCatalogSearchUnavailableError) as error:
+            svc.search_catalog_public_bots_by_keyword(
+                caller=BotCatalogCaller("tenant-1", "user-1", None),
+                request_id="trace-4",
+            )
+
+        assert str(error.value) == ""
+
+    def test_catalog_search_queries_metadata_even_when_backend_has_no_candidates(self):
+        bot_service = MagicMock()
+        bot_service.list_bots_by_search.return_value = {"total": 0, "items": []}
+        metadata = MagicMock()
+        metadata.query_public_bot_metadata.side_effect = BotCatalogMetadataUnavailableError()
+        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+
+        with pytest.raises(BotCatalogSearchUnavailableError):
+            svc.search_catalog_public_bots_by_keyword(
+                caller=BotCatalogCaller("tenant-1", None, None), request_id="trace-5"
+            )
+
+        assert metadata.query_public_bot_metadata.call_args.kwargs["addresses"] == ()
+
     def test_catalog_read_without_user_skips_friendship_lookup(self):
         bot_service = MagicMock()
         bot_service.list_bots_by_search.return_value = {

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -7,7 +7,7 @@ from agentclaw.community.core.bot_public.services.bot_public_service import (
     BotNotFoundError,
     BotPublicServiceError,
 )
-from agentclaw.community.api.bot_public_service import (
+from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogAddress,
     BotCatalogCaller,
     BotCatalogMetadata,

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -61,7 +61,7 @@ def _make_operator(staff_id="op_user", nick_name="Operator") -> OperatorContext:
     return op
 
 
-def _make_bot(bot_id="bot1", owner_id="owner1", entity_id="entity1", public="0", ext=None):
+def _make_bot(bot_id="bot1", owner_id="owner1", public="0", ext=None):
     return {
         "id": 42,
         "bot_id": bot_id,
@@ -70,9 +70,13 @@ def _make_bot(bot_id="bot1", owner_id="owner1", entity_id="entity1", public="0",
         "bot_name": "TestBot",
         "owner_name": "owner_nick",
         "binding_id": 10,
-        "entity_id": entity_id,
+        "entity_id": "entity1",
         "ext": ext or {},
     }
+
+
+def _make_catalog_bot(bot_id: str, entity_id: str):
+    return {**_make_bot(bot_id=bot_id), "entity_id": entity_id}
 
 
 # ---------------------------------------------------------------------------
@@ -748,9 +752,9 @@ class TestSearchPublicBotsByKeyword:
 
     def test_catalog_search_joins_exact_addresses_before_pagination(self):
         bots = [
-            _make_bot(bot_id="bot-1", entity_id="entity-1"),
-            _make_bot(bot_id="bot-2", entity_id="entity-2"),
-            _make_bot(bot_id="bot-3", entity_id="entity-3"),
+            _make_catalog_bot("bot-1", "entity-1"),
+            _make_catalog_bot("bot-2", "entity-2"),
+            _make_catalog_bot("bot-3", "entity-3"),
         ]
         bot_service = MagicMock()
         bot_service.list_bots_by_search.return_value = {"total": 3, "items": bots}
@@ -777,9 +781,9 @@ class TestSearchPublicBotsByKeyword:
 
     def test_catalog_search_de_duplicates_ordered_addresses_and_keeps_entity_identity(self):
         bots = [
-            _make_bot(bot_id="shared", entity_id="entity-a"),
-            _make_bot(bot_id="shared", entity_id="entity-b"),
-            _make_bot(bot_id="shared", entity_id="entity-a"),
+            _make_catalog_bot("shared", "entity-a"),
+            _make_catalog_bot("shared", "entity-b"),
+            _make_catalog_bot("shared", "entity-a"),
         ]
         bot_service = MagicMock()
         bot_service.list_bots_by_search.return_value = {"total": 3, "items": bots}
@@ -839,6 +843,101 @@ class TestSearchPublicBotsByKeyword:
             )
 
         assert str(error.value) == ""
+
+    def test_catalog_search_fails_closed_on_unexpected_metadata_error(self, caplog):
+        bot_service = MagicMock()
+        bot_service.list_bots_by_search.return_value = {
+            "total": 1,
+            "items": [_make_bot()],
+        }
+        metadata = MagicMock()
+        metadata.query_public_bot_metadata.side_effect = RuntimeError(
+            "private upstream detail"
+        )
+        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+
+        with caplog.at_level("WARNING"), pytest.raises(
+            BotCatalogSearchUnavailableError
+        ) as error:
+            svc.search_catalog_public_bots_by_keyword(
+                caller=BotCatalogCaller("tenant-1", "user-1", None),
+                request_id="trace-unexpected",
+            )
+
+        assert str(error.value) == ""
+        assert (
+            "request_id=trace-unexpected candidate_count=1 "
+            "failure=invalid_metadata"
+        ) in caplog.text
+        assert "private upstream detail" not in caplog.text
+
+    def test_catalog_search_redacts_sensitive_fields_and_malformed_ext(self):
+        malformed = _make_catalog_bot("malformed", "entity-malformed")
+        malformed.update({"device_id": "device-secret", "ext": "{not-json"})
+        sensitive = _make_catalog_bot("sensitive", "entity-sensitive")
+        sensitive.update(
+            {
+                "device_id": "device-secret",
+                "ext": (
+                    '{"passport":{"token":"passport-secret","status":"ISSUED"},'
+                    '"iam_token":"iam-secret","visible":"kept"}'
+                ),
+            }
+        )
+        bot_service = MagicMock()
+        bot_service.list_bots_by_search.return_value = {
+            "total": 2,
+            "items": [malformed, sensitive],
+        }
+        metadata = MagicMock()
+        metadata.query_public_bot_metadata.return_value = [
+            BotCatalogMetadata(
+                BotCatalogAddress("malformed", "entity-malformed"), "bot"
+            ),
+            BotCatalogMetadata(
+                BotCatalogAddress("sensitive", "entity-sensitive"), "bot"
+            ),
+        ]
+        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+
+        result = svc.search_catalog_public_bots_by_keyword(
+            caller=BotCatalogCaller("tenant-1", "user-1", None),
+            request_id="trace-redaction",
+        )
+
+        by_id = {bot["bot_id"]: bot for bot in result["items"]}
+        assert by_id["malformed"]["device_id"] is None
+        assert by_id["malformed"]["ext"] == {}
+        assert by_id["sensitive"]["device_id"] is None
+        assert by_id["sensitive"]["ext"] == {
+            "passport": {"token": None, "status": "ISSUED"},
+            "iam_token": None,
+            "visible": "kept",
+        }
+
+    def test_catalog_search_filters_blank_backend_addresses(self):
+        bots = [
+            _make_catalog_bot(" ", "entity-blank-bot"),
+            _make_catalog_bot("bot-blank-entity", "\t"),
+            _make_catalog_bot("valid", "entity-valid"),
+        ]
+        bot_service = MagicMock()
+        bot_service.list_bots_by_search.return_value = {"total": 3, "items": bots}
+        metadata = MagicMock()
+        metadata.query_public_bot_metadata.return_value = [
+            BotCatalogMetadata(BotCatalogAddress("valid", "entity-valid"), "bot")
+        ]
+        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+
+        result = svc.search_catalog_public_bots_by_keyword(
+            caller=BotCatalogCaller("tenant-1", "user-1", None),
+            request_id="trace-blank-address",
+        )
+
+        assert metadata.query_public_bot_metadata.call_args.kwargs["addresses"] == (
+            BotCatalogAddress("valid", "entity-valid"),
+        )
+        assert [bot["bot_id"] for bot in result["items"]] == ["valid"]
 
     def test_catalog_search_queries_metadata_even_when_backend_has_no_candidates(self):
         bot_service = MagicMock()

--- a/src/backend/tests/community/endpoints/test_openapi_bot_public_catalog.py
+++ b/src/backend/tests/community/endpoints/test_openapi_bot_public_catalog.py
@@ -85,7 +85,7 @@ def _seed_search(world) -> None:
     bind_overrides(
         world,
         BotPublicServiceProtocol,
-        {"search_public_bots_by_keyword": _search},
+        {"search_catalog_public_bots_by_keyword": _search},
     )
 
 

--- a/src/backend/tests/community/repository/bot/test_bot_repository_unified.py
+++ b/src/backend/tests/community/repository/bot/test_bot_repository_unified.py
@@ -322,7 +322,7 @@ def test_list_by_search_can_return_complete_ordered_candidate_set(repo):
     total, rows = repo.list_by_search(public="1", page=None, page_size=None)
 
     assert total == 3
-    assert {row["bot_id"] for row in rows} == {"b1", "b2", "b3"}
+    assert [row["bot_id"] for row in rows] == ["b3", "b2", "b1"]
 
 
 def test_list_by_conditions_owner_engine_status_filters(repo):

--- a/src/backend/tests/community/repository/bot/test_bot_repository_unified.py
+++ b/src/backend/tests/community/repository/bot/test_bot_repository_unified.py
@@ -313,6 +313,18 @@ def test_list_and_count(repo):
     assert t4 == 2
 
 
+def test_list_by_search_can_return_complete_ordered_candidate_set(repo):
+    """Catalog joins must happen before pagination to avoid page holes."""
+    repo.insert(_data(bot_id="b1", public="1"))
+    repo.insert(_data(bot_id="b2", public="1"))
+    repo.insert(_data(bot_id="b3", public="1"))
+
+    total, rows = repo.list_by_search(public="1", page=None, page_size=None)
+
+    assert total == 3
+    assert {row["bot_id"] for row in rows} == {"b1", "b2", "b3"}
+
+
 def test_list_by_conditions_owner_engine_status_filters(repo):
     """Additive owner_id / engine / status filters narrow with exact totals."""
     repo.insert(

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -16154,19 +16154,7 @@
             "description": "Internal error"
           },
           "502": {
-            "content": {
-              "application/json": {
-                "example": {
-                  "code": 502000,
-                  "message": "Bad Gateway",
-                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
-                },
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorEnvelope"
-                }
-              }
-            },
-            "description": "Upstream service error"
+            "description": "Catalog service unavailable"
           }
         },
         "summary": "Search Public Bots",

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -16154,6 +16154,18 @@
             "description": "Internal error"
           },
           "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Catalog service unavailable",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
             "description": "Catalog service unavailable"
           }
         },


### PR DESCRIPTION
## Problem

The OpenAPI Bot Catalog Search needs BCS to confirm which Backend public Bot records are physical Bots, but the available BCSFuse worker lookup is not tenant/caller scoped and no stable BCS metadata HTTP contract has been delivered. Calling that endpoint directly could admit the wrong `(bot_id, entity_id)` record or make pagination depend on an unrelated recommendation response.

## Solution

- Add a transport-neutral Core metadata port with typed Bot address, verified caller, and membership-only result models.
- Query the complete tenant-scoped Backend public candidate set, validate metadata fail-closed, join by the exact `(bot_id, entity_id)` address, preserve Backend order, and paginate only after the join.
- Bind production, local, and test profiles to a no-network unavailable implementation. Until a real BCS adapter is supplied, valid Catalog Search requests consistently return `502000 / Catalog service unavailable`.
- Keep Backend as the only source of public response fields, preserve legacy `/api/v1/bot-public/search`, and leave Discover plus its existing BCSFuse behavior/logging unchanged.
- Document the temporary 502 contract and regenerate the pinned Gateway OpenAPI schema.

## Validation

- Backend full suite on the preceding functionally equivalent implementation head: `13149 passed, 21 skipped`; the final minimal-diff head is being revalidated by PR CI.
- Fresh final-head focused suite: `157 passed`; local change-line coverage gate: `103/103` (`100%`, required `>=90%`).
- Gateway schema/auth/forwarding suite: `228 passed`; the minimal-diff cleanup does not change Gateway code or schema.
- Delta Ruff, unused import/variable checks, Python whitespace checks, and `git diff --check`: passed. One pre-existing `pytest` F401 is intentionally retained because deleting it was unrelated cleanup; the base branch reports the identical finding.
- Generated OpenAPI matches `src/gateway/configs/schemas/bots.openapi.json`; JSON parsing and `git diff --check` passed.
- Minimality and scoped follow-up reviews: PASS; no pure formatting, speculative extension, or unrelated refactor remains. Security review found no high/medium candidate.
- Gateway project-wide run: `960 passed, 4 skipped, 12 failed`. Ten failures require a running local Gateway for baseline/live E2E; two project-wide Ruff gates point to three files unchanged from the base branch. Those unrelated baseline files were not modified.

## Compatibility and risk

This intentionally keeps Catalog Search unavailable rather than falling back to Backend-only results or guessing a BCS URL/payload. Enabling successful Search later requires a separately reviewed BCS HTTP adapter and DI replacement. The public response model is unchanged, and no BCS raw response, internal ID, binding, instance, device, extension, credential, or environment field is exposed.

## Spec

- `spec/pipeline/openapi-bot-public-bcs-join/004-implementation-plan.md`
- `src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md`

## Related issues

- Follow-up to merged PR #1238.
