### PR TITLE
fix(bot_run): fall back to queue meta timeout when metadata timeout i…

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
@@ -275,7 +275,11 @@ class BotRunRequestExecutor:
         )
         request_type = metadata.get("request_type", "chat")
         stream = metadata.get("stream", "false") == "true"
-        timeout_sec = metadata.get("timeout")
+        timeout_sec = (
+            metadata.get("timeout")
+            if metadata.get("timeout")
+            else queue_meta.get("timeout")
+        )
         chat_metadata = build_chat_metadata(metadata, run.run_id)
 
         context = _rebuild_context(

--- a/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
@@ -21,6 +21,7 @@ BCN uplink 逻辑已从执行器链中剥离，改为 ``BcnUplinkCallback``（Po
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from typing import TYPE_CHECKING, Any
@@ -107,6 +108,13 @@ class ResultGuardExecutor:
         try:
             await self._inner.execute(record)
         except RequeuedToPendingError:
+            raise
+        except asyncio.CancelledError:
+            logger.warning(
+                "[ResultGuardExecutor] executor cancelled run_id=%s",
+                record.run_id,
+            )
+            self._mark_failed(record.run_id, "execution cancelled (timeout)")
             raise
         except TimeoutError:
             logger.warning(

--- a/src/baas/src/secbaas/community/core/service/bot_run/_worker.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_worker.py
@@ -24,6 +24,7 @@ import time
 import uuid
 from collections.abc import Generator
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 from secbaas.community.core.repository.bot_run_queue import (
@@ -78,6 +79,7 @@ class BotRequestWorkerConfig:
     max_concurrent: int = 50  # 单 Worker 最大并发执行数
     heartbeat_interval_seconds: float = 30.0
     timeout_scan_interval_seconds: float = 5.0  # 超时扫描间隔
+    stale_heartbeat_seconds: float = 120.0  # 心跳过期阈值（判定对端 worker 已 down）
     bucket_sweep_interval_seconds: float = 300.0  # 空闲桶扫描间隔
     bucket_idle_ttl_seconds: float = 600.0  # 空闲桶淘汰 TTL
 
@@ -116,6 +118,8 @@ class BotRequestWorker:
         self._stop_event: asyncio.Event | None = None
         self._loop_task: asyncio.Task[None] | None = None
         self._timeout_task: asyncio.Task[None] | None = None
+        # run_id -> 正在执行的 _run_one task，用于超时扫描时 cancel 本机任务
+        self._running_tasks: dict[str, asyncio.Task[None]] = {}
 
     @property
     def worker_id(self) -> str:
@@ -191,21 +195,52 @@ class BotRequestWorker:
                 logger.exception("[BotRequestWorker] timeout scan error: %s", e)
             await asyncio.sleep(interval)
 
+    def _is_heartbeat_stale(self, record: BotRunQueueRecord) -> bool:
+        """判断 RUNNING 记录的心跳是否已过期（对端 worker 可能已 down）。"""
+        if record.last_heartbeat is None:
+            return True
+        elapsed = (datetime.now() - record.last_heartbeat).total_seconds()
+        return elapsed > self._config.stale_heartbeat_seconds
+
     async def _timeout_scan_once(self) -> None:
-        """扫描一轮超时工作项：委托 executor 写结果终态后强制终结队列项。"""
+        """扫描一轮超时工作项：区分 PENDING / 本机 RUNNING / 非本机 RUNNING。
+
+        - PENDING：委托 executor 写结果终态后强制终结队列项。
+        - RUNNING + 本机：cancel 本机 task，再由 executor 标 FAILED + force_done。
+        - RUNNING + 非本机：仅当心跳过期（对端 worker 已 down）才 force_done；
+          心跳正常则跳过（对端还在执行，由对端的超时检查兜底）。
+        """
         records = self._queue.scan_timeout()
         for record in records:
-            try:
-                await self._executor.execute(record)
-            except RequeuedToPendingError:
-                # ResultGuardExecutor 会在进入 session lock 前处理 timeout；如果这里仍
-                # 透出 requeue，说明 executor 链未包含 timeout guard，保持队列原状。
+            if record.status == "RUNNING" and record.assigned_worker != self._worker_id:
+                if not self._is_heartbeat_stale(record):
+                    # 对端 worker 还活着，由对端自己处理超时
+                    continue
+                # 对端 worker 已 down，直接 force_done
+                with contextlib.suppress(Exception):
+                    self._queue.force_done(record.run_id)
                 logger.warning(
-                    "[BotRequestWorker] timeout scan requeued run_id=%s status=%s",
+                    "[BotRequestWorker] timeout scan: run_id=%s status=%s "
+                    "stale heartbeat (worker=%s), force done",
                     record.run_id,
                     record.status,
+                    record.assigned_worker,
                 )
+                callback = self._resolve_callback(record)
+                if callback is not None:
+                    try:
+                        await callback(record.run_id)
+                    except Exception as e:
+                        logger.error(
+                            "[BotRequestWorker] timeout scan callback failed run_id=%s: %s",
+                            record.run_id,
+                            e,
+                            exc_info=True,
+                        )
                 continue
+
+            # PENDING 或本机 RUNNING：走 executor 标 FAILED + force_done
+            await self._executor.execute(record)
             with contextlib.suppress(Exception):
                 self._queue.force_done(record.run_id)
             logger.warning(
@@ -213,6 +248,15 @@ class BotRequestWorker:
                 record.run_id,
                 record.status,
             )
+            # cancel 本机正在执行的超时任务
+            if record.assigned_worker == self._worker_id:
+                running_task = self._running_tasks.get(record.run_id)
+                if running_task is not None and not running_task.done():
+                    running_task.cancel()
+                    logger.warning(
+                        "[BotRequestWorker] timeout scan: cancelled local task run_id=%s",
+                        record.run_id,
+                    )
             callback = self._resolve_callback(record)
             if callback is not None:
                 try:
@@ -263,7 +307,8 @@ class BotRequestWorker:
                 bucket.try_acquire()
                 self._active += 1
                 dispatched += 1
-                asyncio.create_task(self._run_one(record))
+                task = asyncio.create_task(self._run_one(record))
+                self._running_tasks[record.run_id] = task
 
         self._sweep_idle_buckets()
         return dispatched
@@ -297,6 +342,7 @@ class BotRequestWorker:
                 await self._post_run(record, post_run_callback)
                 self._mark_queue_done(record)
         finally:
+            self._running_tasks.pop(record.run_id, None)
             heartbeat.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await heartbeat

--- a/src/baas/tests/unit/core/service/bot_run/test_result_guard_executor.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_result_guard_executor.py
@@ -6,6 +6,7 @@ ResultGuardExecutor 是 executor 链的业务结果兜底层：Worker 不直接�
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta
 from uuid import uuid4
 
@@ -62,6 +63,13 @@ class _TimeoutInner:
 class _RequeueInner:
     async def execute(self, record: BotRunQueueRecord) -> None:
         raise RequeuedToPendingError(record.run_id, "sess-1")
+
+
+class _CancelledInner:
+    async def execute(self, record: BotRunQueueRecord) -> None:
+        import asyncio
+
+        raise asyncio.CancelledError()
 
 
 class _RecordingInner:
@@ -147,3 +155,15 @@ async def test_timeout_error_inner_marks_failed(repo: OrmBotRunRepository):
     rec = repo.get_by_run_id(run_id)
     assert rec.status == "FAILED"
     assert "Task execution timeout" in (rec.error or "")
+
+
+async def test_cancelled_error_marks_failed_and_reraises(repo: OrmBotRunRepository):
+    run_id = _insert_run(repo)
+    ex = ResultGuardExecutor(_CancelledInner(), repo)
+
+    with pytest.raises(asyncio.CancelledError):
+        await ex.execute(_record(run_id))
+
+    rec = repo.get_by_run_id(run_id)
+    assert rec.status == "FAILED"
+    assert "execution cancelled" in (rec.error or "")

--- a/src/baas/tests/unit/core/service/bot_run/test_worker.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_worker.py
@@ -556,22 +556,251 @@ async def test_timeout_scan_marks_failed_and_force_done(repo, queue):
     assert queue.get_by_run_id(run_id).status == "DONE"
 
 
-async def test_timeout_scan_requeue_keeps_queue_running(repo, queue):
-    _insert(repo, queue, "bot-1")
-    worker = _worker(queue, repo, _RequeuedExecutor())
-    record = queue.claim_pending_by_bot("bot-1", worker.worker_id, candidates=5)
+async def test_timeout_scan_skips_remote_running_with_fresh_heartbeat(repo, queue):
+    """非本机 RUNNING + 心跳正常 → 跳过，不 force_done。"""
+    run_id = _insert(repo, queue, "bot-1")
+    # 模拟另一台机器 claim 了这个任务
+    record = queue.claim_pending_by_bot("bot-1", "remote-worker", candidates=5)
     assert record is not None
+    # 设置超时 meta 使 scan_timeout 能扫到
+    queue.update_meta(run_id, {"timeout": -1})
 
-    mock_scan = MagicMock(return_value=[record])
-    mock_force_done = MagicMock(wraps=queue.force_done)
-    with (
-        patch.object(worker._queue, "scan_timeout", mock_scan),
-        patch.object(worker._queue, "force_done", mock_force_done),
-    ):
+    ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
+    worker = _worker(queue, repo, ex)
+
+    # mock scan_timeout 返回这条 record（模拟它已超时）
+    record = queue.get_by_run_id(run_id)
+    with patch.object(worker._queue, "scan_timeout", MagicMock(return_value=[record])):
         await worker._timeout_scan_once()
 
-    mock_force_done.assert_not_called()
-    assert queue.get_by_run_id(record.run_id).status == "RUNNING"
+    # 心跳刚被 claim 时设置，应该是 fresh 的 → 不 force_done
+    assert queue.get_by_run_id(run_id).status == "RUNNING"
+
+
+async def test_timeout_scan_force_done_remote_running_with_stale_heartbeat(repo, queue):
+    """非本机 RUNNING + 心跳过期 → force_done。"""
+    run_id = _insert(repo, queue, "bot-1")
+    record = queue.claim_pending_by_bot("bot-1", "remote-worker", candidates=5)
+    assert record is not None
+    queue.update_meta(run_id, {"timeout": -1})
+
+    # 手动把 last_heartbeat 改到很久以前，模拟对端 worker 已 down
+    from datetime import datetime, timedelta
+
+    stale_time = datetime.now() - timedelta(seconds=300)
+    with patch.object(
+        queue,
+        "scan_timeout",
+        MagicMock(
+            return_value=[
+                BotRunQueueRecord(
+                    id=record.id,
+                    gmt_create=record.gmt_create,
+                    gmt_modified=record.gmt_modified,
+                    run_id=record.run_id,
+                    bot_id=record.bot_id,
+                    session_id=record.session_id,
+                    status="RUNNING",
+                    assigned_worker="remote-worker",
+                    last_heartbeat=stale_time,
+                    meta={"timeout": -1},
+                    env=record.env,
+                )
+            ]
+        ),
+    ):
+        ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
+        worker = _worker(queue, repo, ex)
+        await worker._timeout_scan_once()
+
+    assert queue.get_by_run_id(run_id).status == "DONE"
+
+
+async def test_timeout_scan_force_done_remote_running_with_no_heartbeat(repo, queue):
+    """非本机 RUNNING + 无心跳（last_heartbeat=None）→ 视为过期，force_done。"""
+    run_id = _insert(repo, queue, "bot-1")
+    record = queue.claim_pending_by_bot("bot-1", "remote-worker", candidates=5)
+    assert record is not None
+
+    stale_record = BotRunQueueRecord(
+        id=record.id,
+        gmt_create=record.gmt_create,
+        gmt_modified=record.gmt_modified,
+        run_id=record.run_id,
+        bot_id=record.bot_id,
+        session_id=record.session_id,
+        status="RUNNING",
+        assigned_worker="remote-worker",
+        last_heartbeat=None,
+        meta={"timeout": -1},
+        env=record.env,
+    )
+    ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
+    worker = _worker(queue, repo, ex)
+    with patch.object(worker._queue, "scan_timeout", MagicMock(return_value=[stale_record])):
+        await worker._timeout_scan_once()
+
+    assert queue.get_by_run_id(run_id).status == "DONE"
+
+
+async def test_timeout_scan_cancels_local_running_task(repo, queue):
+    """本机 RUNNING 超时 → cancel 本机 task。"""
+    run_id = _insert(repo, queue, "bot-1")
+    record = queue.claim_pending_by_bot("bot-1", "worker-1", candidates=5)
+    assert record is not None
+    queue.update_meta(run_id, {"timeout": -1})
+
+    # 模拟一个正在执行的 task
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def fake_run():
+        started.set()
+        try:
+            await asyncio.sleep(999)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    task = asyncio.create_task(fake_run())
+    await started.wait()
+
+    ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
+    worker = _worker(queue, repo, ex)
+    worker._running_tasks[run_id] = task
+
+    local_record = queue.get_by_run_id(run_id)
+    with patch.object(worker._queue, "scan_timeout", MagicMock(return_value=[local_record])):
+        await worker._timeout_scan_once()
+
+    # 让出事件循环，让被 cancel 的 task 执行 except CancelledError
+    await asyncio.sleep(0)
+    assert cancelled.is_set()
+    assert queue.get_by_run_id(run_id).status == "DONE"
+
+
+async def test_timeout_scan_skips_cancel_when_task_already_done(repo, queue):
+    """本机 RUNNING 超时但 task 已完成 → 不 cancel，仍 force_done。"""
+    run_id = _insert(repo, queue, "bot-1")
+    record = queue.claim_pending_by_bot("bot-1", "worker-1", candidates=5)
+    assert record is not None
+    queue.update_meta(run_id, {"timeout": -1})
+
+    async def done_task():
+        pass
+
+    task = asyncio.create_task(done_task())
+    await task
+
+    ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
+    worker = _worker(queue, repo, ex)
+    worker._running_tasks[run_id] = task
+
+    local_record = queue.get_by_run_id(run_id)
+    with patch.object(worker._queue, "scan_timeout", MagicMock(return_value=[local_record])):
+        await worker._timeout_scan_once()
+
+    assert queue.get_by_run_id(run_id).status == "DONE"
+
+
+async def test_tick_tracks_running_task(repo, queue):
+    """_tick 派发后 _running_tasks 应有记录，_run_one 完成后清除。"""
+    run_id = _insert(repo, queue, "bot-1")
+    ex = _CompletingExecutor(repo)
+    worker = _worker(queue, repo, ex)
+
+    dispatched = await worker._tick()
+    assert dispatched == 1
+    # task 刚创建，_running_tasks 中应有记录
+    assert run_id in worker._running_tasks
+
+    # 等 task 完成
+    await asyncio.gather(*worker._running_tasks.values(), return_exceptions=True)
+    await _drain()
+
+    # _run_one finally 中应清除
+    assert run_id not in worker._running_tasks
+
+
+async def test_timeout_scan_stale_heartbeat_with_callback(repo, queue):
+    """非本机 RUNNING + 心跳过期 + 有 callback → force_done 并执行 callback。"""
+    from datetime import datetime, timedelta
+
+    run_id = _insert(repo, queue, "bot-1")
+    record = queue.claim_pending_by_bot("bot-1", "remote-worker", candidates=5)
+    assert record is not None
+
+    stale_record = BotRunQueueRecord(
+        id=record.id,
+        gmt_create=record.gmt_create,
+        gmt_modified=record.gmt_modified,
+        run_id=record.run_id,
+        bot_id=record.bot_id,
+        session_id=record.session_id,
+        status="RUNNING",
+        assigned_worker="remote-worker",
+        last_heartbeat=datetime.now() - timedelta(seconds=300),
+        meta={"timeout": -1, "callback_function": "test_cb"},
+        env=record.env,
+    )
+
+    callback_called = asyncio.Event()
+
+    async def test_callback(rid: str) -> None:
+        assert rid == run_id
+        callback_called.set()
+
+    ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
+    worker = _worker(
+        queue,
+        repo,
+        ex,
+        post_run_callback_factories={"test_cb": test_callback},
+    )
+    with patch.object(worker._queue, "scan_timeout", MagicMock(return_value=[stale_record])):
+        await worker._timeout_scan_once()
+
+    assert callback_called.is_set()
+    assert queue.get_by_run_id(run_id).status == "DONE"
+
+
+async def test_timeout_scan_stale_heartbeat_callback_error_is_logged(repo, queue):
+    """非本机 RUNNING + 心跳过期 + callback 抛异常 → force_done，错误被 log。"""
+    from datetime import datetime, timedelta
+
+    run_id = _insert(repo, queue, "bot-1")
+    record = queue.claim_pending_by_bot("bot-1", "remote-worker", candidates=5)
+    assert record is not None
+
+    stale_record = BotRunQueueRecord(
+        id=record.id,
+        gmt_create=record.gmt_create,
+        gmt_modified=record.gmt_modified,
+        run_id=record.run_id,
+        bot_id=record.bot_id,
+        session_id=record.session_id,
+        status="RUNNING",
+        assigned_worker="remote-worker",
+        last_heartbeat=datetime.now() - timedelta(seconds=300),
+        meta={"timeout": -1, "callback_function": "bad_cb"},
+        env=record.env,
+    )
+
+    async def bad_callback(rid: str) -> None:
+        raise RuntimeError("callback boom")
+
+    ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
+    worker = _worker(
+        queue,
+        repo,
+        ex,
+        post_run_callback_factories={"bad_cb": bad_callback},
+    )
+    with patch.object(worker._queue, "scan_timeout", MagicMock(return_value=[stale_record])):
+        await worker._timeout_scan_once()
+
+    # callback 失败不影响 force_done
+    assert queue.get_by_run_id(run_id).status == "DONE"
 
 
 async def test_requeue_pending_release_error_is_swallowed(repo, queue):


### PR DESCRIPTION
    * Track running tasks in _running_tasks map (run_id -> Task)
    * Timeout scan now distinguishes three cases:
    * PENDING: mark FAILED via executor + force_done (unchanged)
    * RUNNING + local worker: mark FAILED + force_done + cancel local task
        to release concurrency slot
    * RUNNING + remote worker: only force_done when heartbeat is stale
        (peer worker likely down); skip if heartbeat is fresh
    * ResultGuardExecutor handles CancelledError: marks FAILED then re-raises
    * Remove defensive RequeuedToPendingError catch in timeout scan
      (ResultGuardExecutor always intercepts timed-out records before session lock)