### PR TITLE
fix(skills): refresh Teclaw skill artifacts without symlinks

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -477,20 +477,32 @@ class SkillSetService:
             True if sync attempted, False otherwise
         """
         try:
-            # 获取当前激活技能集的软链配置（包括空列表，表示清空）
-            symlinks = self.get_symlink_mappings(
-                user_id=user_id,
-                bolt_id=self.bot_id
-            )
-
             # 通过 DeviceSyncPlugin 同步到设备 — 经 resolver + dispatcher 收口
             effective_user_id = user_id or self.entity_id or "default"
             ctx = self._resolver.resolve_for_bot(self.bot_id, effective_user_id)
             device_sync = self._device_sync_dispatcher.dispatch(ctx)
 
-            logger.info(f"[_sync_symlinks_to_device_if_needed] Syncing {len(symlinks)} symlinks to device (bot_id={self.bot_id})")
+            # Teclaw owns its workspace and receives a complete composed artifact.
+            # It has no filesystem Skills Pool layout, so it must not receive the
+            # file-engine symlink mappings below. Its device-sync plugin treats an
+            # empty list as a request to refresh that artifact.
+            if ctx.provider == "teclaw":
+                symlinks_dict: list[dict[str, str]] = []
+            else:
+                symlinks = self.get_symlink_mappings(
+                    user_id=user_id,
+                    bolt_id=self.bot_id,
+                )
+                symlinks_dict = [sm.to_dict() for sm in symlinks]
 
-            symlinks_dict = [sm.to_dict() for sm in symlinks]
+            logger.info(
+                "[_sync_symlinks_to_device_if_needed] Syncing %d symlinks to device "
+                "(bot_id=%s, provider=%s)",
+                len(symlinks_dict),
+                self.bot_id,
+                ctx.provider,
+            )
+
             sync_result = device_sync.sync_symlinks(symlinks_dict)
 
             if sync_result.get("success"):
@@ -2389,12 +2401,26 @@ class _DeviceSyncMixin:
             ctx = self._resolver.resolve_for_bot(bot_id, user_id)
             device_sync = self._device_sync_dispatcher.dispatch(ctx)
             logger.info(f"[DEVICE-PLUGIN-DEBUG] {caller}._do_device_sync: factory returned {type(device_sync).__name__}")
-            symlinks = self.skill_set_service.get_symlink_mappings(
-                user_id=user_id,
-                bolt_id=bot_id,
+            # Teclaw is a whole-artifact runtime, not a filesystem Skills Pool
+            # runtime. Passing file-engine symlink mappings into its plugin makes
+            # the plugin resolve a nonexistent teclaw Pool layout. An empty list
+            # is the established Teclaw refresh signal; the plugin recomposes and
+            # delivers the artifact from persisted metadata.
+            if ctx.provider == "teclaw":
+                symlinks_dict: list[dict[str, str]] = []
+            else:
+                symlinks = self.skill_set_service.get_symlink_mappings(
+                    user_id=user_id,
+                    bolt_id=bot_id,
+                )
+                symlinks_dict = [sm.to_dict() for sm in symlinks]
+            logger.info(
+                "[DEVICE-PLUGIN-DEBUG] %s._do_device_sync: %d symlinks to sync "
+                "(provider=%s)",
+                caller,
+                len(symlinks_dict),
+                ctx.provider,
             )
-            symlinks_dict = [sm.to_dict() for sm in symlinks]
-            logger.info(f"[DEVICE-PLUGIN-DEBUG] {caller}._do_device_sync: {len(symlinks_dict)} symlinks to sync")
             sync_result = device_sync.sync_symlinks(symlinks_dict)
             logger.info(f"[DEVICE-PLUGIN-DEBUG] {caller}._do_device_sync: result={sync_result}")
 

--- a/src/backend/tests/community/core/skill_center/services/test_skill_center_uses_resolver.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_center_uses_resolver.py
@@ -121,6 +121,48 @@ class TestSkillSetServiceUsesResolver:
         resolver.resolve_for_bot.assert_called_once_with("bot-1", "owner-1")
         bot_repo.get_by_id_and_owner.assert_called_once_with("bot-1", "owner-1")
 
+    def test_sync_runtime_teclaw_refreshes_without_file_symlink_mappings(self):
+        from agentclaw.community.core.skill_center.services.skill_set_service import (
+            SkillSetService,
+        )
+
+        ctx = DeviceContext(
+            provider="teclaw",
+            conn_info={},
+            binding_id=42,
+            bot_id="bot-1",
+            user_id="user-1",
+        )
+        resolver = MagicMock()
+        resolver.resolve_for_bot.return_value = ctx
+        sync_plugin = MagicMock()
+        sync_plugin.sync_symlinks.return_value = {"success": True, "message": "ok"}
+        dispatcher = MagicMock()
+        dispatcher.dispatch.return_value = sync_plugin
+
+        with patch(
+            "agentclaw.community.core.skill_center.services.skill_set_service."
+            "WorkspacePathFactory"
+        ):
+            svc = SkillSetService(
+                skill_repo=MagicMock(),
+                skill_set_repo=MagicMock(),
+                mcp_center=MagicMock(),
+                mcp_config_service=MagicMock(),
+                skill_service=MagicMock(),
+                bot_repo=MagicMock(),
+                bot_id="bot-1",
+                resolver=resolver,
+                device_sync_dispatcher=dispatcher,
+                path_factory=MagicMock(),
+            )
+
+        svc.get_symlink_mappings = MagicMock()
+
+        assert svc._sync_symlinks_to_device_if_needed(user_id="user-1") is True
+        svc.get_symlink_mappings.assert_not_called()
+        sync_plugin.sync_symlinks.assert_called_once_with([])
+
 
 # ── _DeviceSyncMixin via SkillSetSwitcher ────────────────────────────
 
@@ -169,6 +211,51 @@ class TestDeviceSyncMixinUsesResolver:
         assert result["success"] is True
         resolver.resolve_for_bot.assert_called_once_with("bot-1", "user-1")
         dispatcher.dispatch.assert_called_once_with(ctx)
+        sync_plugin.sync_symlinks.assert_called_once_with([])
+
+    def test_do_device_sync_teclaw_refreshes_without_file_symlink_mappings(self):
+        from agentclaw.community.core.skill_center.services.skill_set_service import (
+            SkillSetSwitcher,
+        )
+
+        ctx = DeviceContext(
+            provider="teclaw",
+            conn_info={},
+            binding_id=42,
+            bot_id="bot-1",
+            user_id="user-1",
+        )
+        resolver = MagicMock()
+        resolver.resolve_for_bot.return_value = ctx
+        sync_plugin = MagicMock()
+        sync_plugin.sync_symlinks.return_value = {"success": True, "message": "ok"}
+        dispatcher = MagicMock()
+        dispatcher.dispatch.return_value = sync_plugin
+
+        skill_set_factory = MagicMock()
+        fake_inner = MagicMock()
+        fake_inner.bot_id = "bot-1"
+        fake_inner.get_symlink_mappings = MagicMock()
+        skill_set_factory.create.return_value = fake_inner
+
+        switcher = SkillSetSwitcher(
+            skill_set_factory=skill_set_factory,
+            resolver=resolver,
+            device_sync_dispatcher=dispatcher,
+            device_plugin=MagicMock(),
+            path_factory=MagicMock(),
+            device_fs_dispatcher=MagicMock(),
+            edit_guard=MagicMock(),
+            user_id="user-1",
+            entity_id="user-1",
+            bot_id="bot-1",
+            engine_type="teclaw",
+        )
+
+        result = switcher._do_device_sync(user_id="user-1", caller="test")
+
+        assert result["success"] is True
+        fake_inner.get_symlink_mappings.assert_not_called()
         sync_plugin.sync_symlinks.assert_called_once_with([])
 
 


### PR DESCRIPTION
## Summary
- route Teclaw Skill Set sync through its empty-mapping artifact refresh signal
- keep file-engine symlink mapping unchanged for non-Teclaw providers
- add regression coverage for both SkillSetService and SkillSetActivator/Switcher sync paths

## Verification
- `uv run pytest -q tests/community/core/skill_center/services/test_skill_center_uses_resolver.py`
- `uv run ruff check src/agentclaw/community/core/skill_center/services/skill_set_service.py tests/community/core/skill_center/services/test_skill_center_uses_resolver.py`
- `git diff --check`