### PR TITLE
revert(config): restore community app_name to agentclaw

### DIFF
--- a/src/backend/src/agentclaw/community/configs/application.yaml
+++ b/src/backend/src/agentclaw/community/configs/application.yaml
@@ -1,5 +1,5 @@
 # 基础配置
-app_name: "agentclawengine"
+app_name: "agentclaw"
 enable_sidecar: true
 workers: 6
 
@@ -31,7 +31,7 @@ module_config:
     enabled: true
     tenant: "ALIPAY" # 必填，主站为'ALIPAY'
     mode: "prod" # 必填，需与机密平台上配置的'mode'一致
-    app_name: "agentclawengine" # 需与机密平台上的授权应用一致
+    app_name: "agentclaw" # 需与机密平台上的授权应用一致
 
   zdas:
     enabled: true


### PR DESCRIPTION
## Problem

Commit `a9c0bf6` ("agentclaw -> agentclawengine") temporarily changed the app
name in the neutral community base config to `agentclawengine` for testing.
That testing is finished, so the placeholder value needs to go back.

The value is not cosmetic: `module_config.mist.app_name` must match the
authorized application registered on the secrets platform (per the inline
comment on that line), so leaving the test value in place would point Mist at
the wrong authorized application.

## Solution

Reverted both occurrences in
`src/backend/src/agentclaw/community/configs/application.yaml` back to
`agentclaw`:

- top-level `app_name`
- `module_config.mist.app_name`

These are the only two occurrences of `agentclawengine` anywhere in the
repository — a repo-wide grep (not just YAML) now returns no matches. The other
configs that set an app name were never touched by the test change and already
carry their intended values (`application-community.yaml` and
`application-singlebox.yaml` set `agentclaw`; the gateway and baas configs set
their own names).

## Validation

- Repo-wide `grep -rn agentclawengine` → no matches remain.
- `git diff a9c0bf6^ -- <file>` → **zero lines**: the file is byte-identical to
  its pre-`a9c0bf6` state, so this is an exact revert rather than a re-typed
  value.
- Both YAML files parse, and the resolved values are `agentclaw` for the base
  `app_name`, the base `module_config.mist.app_name`, and the community overlay
  `app_name`.
- `tests/community/local/test_load_yaml_configs.py` asserts the merged community
  config resolves `app_name == "agentclaw"`. That assertion reads the merged
  result, where the community overlay's own `app_name` takes precedence, so it
  held under both values; this change makes the neutral base agree with it
  rather than silently relying on the overlay to mask the test value.
- **Not run:** the test suite could not be executed in this environment — `uv`
  cannot install dev dependencies because the pinned package mirror is
  unreachable from the sandbox (`werkzeug==3.1.8` fetch fails with a tunnel
  error). The verification above was done by direct YAML parsing and blob
  comparison instead.

## Compatibility and risk

Config-value-only change; no schema, contract, or migration impact. Restores the
value that was in place before the test commit, so the rollback path is simply
re-applying `a9c0bf6`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmwXufEusGyRq7qZ6ANyR3)_