### PR TITLE
fix(skills): align installation DDL with standards

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_bot_skill_installation.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_bot_skill_installation.sql
@@ -8,11 +8,9 @@ CREATE TABLE IF NOT EXISTS ac_bot_skill_installation (
     owner_id VARCHAR(128) NOT NULL,
     bot_id VARCHAR(100) NOT NULL,
     skill_id BIGINT UNSIGNED NOT NULL,
-    gmt_created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    gmt_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
     UNIQUE KEY uk_bot_skill_installation (avernet_tenant, env, owner_id, bot_id, skill_id),
-    KEY idx_bot_skill_installation_bot (avernet_tenant, env, owner_id, bot_id),
-    CONSTRAINT fk_bot_skill_installation_skill
-      FOREIGN KEY (skill_id) REFERENCES ac_skill(id)
+    KEY idx_bot_skill_installation_bot (avernet_tenant, env, owner_id, bot_id)
 );

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_skill_set_control_plane.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_20_skill_set_control_plane.sql
@@ -8,8 +8,8 @@ CREATE TABLE IF NOT EXISTS ac_bot_mcp_installation (
     owner_id VARCHAR(128) NOT NULL,
     bot_id VARCHAR(100) NOT NULL,
     server_code VARCHAR(256) NOT NULL,
-    gmt_created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    gmt_modified DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (id),
     UNIQUE KEY uk_bot_mcp_installation
       (avernet_tenant, env, owner_id, bot_id, server_code),

--- a/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
@@ -335,9 +335,29 @@ def test_skill_set_control_plane_sql_only_adds_owner_scoped_mcp_installation():
     assert "CREATE TABLE IF NOT EXISTS ac_bot_mcp_installation" in sql
     assert "owner_id VARCHAR(128) NOT NULL" in sql
     assert "(avernet_tenant, env, owner_id, bot_id, server_code)" in sql
+    assert "DATETIME" not in sql
+    assert sql.count("TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP") == 2
     assert "ac_skill_set_create_idempotency" not in sql
     assert "ALTER TABLE ac_skill_set_skill" not in sql
     assert "ALTER TABLE ac_skill_set_mcp" not in sql
+
+
+def test_direct_installation_ddl_uses_standard_audit_columns_without_foreign_keys():
+    sql_path = (
+        Path(__file__).parents[4]
+        / "src"
+        / "agentclaw"
+        / "community"
+        / "core"
+        / "skill_center"
+        / "sql"
+        / "2026_08_20_bot_skill_installation.sql"
+    )
+    sql = sql_path.read_text(encoding="utf-8")
+
+    assert "FOREIGN KEY" not in sql
+    assert "DATETIME" not in sql
+    assert sql.count("TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP") == 2
 
 
 def test_skill_set_name_is_unique_for_bot_across_engines():


### PR DESCRIPTION
## Problem

The Phase 1 Direct Installation DDL used a foreign key and `DATETIME` audit columns, which violate the applicable database development standards.

## Solution

- Remove the `ac_bot_skill_installation` foreign key.
- Use `TIMESTAMP` for `gmt_created` and `gmt_modified` in both Direct Installation tables.
- Add regression assertions for both requirements.

## Compatibility and risk

The two target tables are currently absent from the shared database, so this corrects the initial create shape without data migration or changes to existing tables.

## Validation

- `uv run pytest -q tests/community/repository/skill_center/test_skill_set_control_plane_uow.py` (16 passed)
- `uv run ruff check tests/community/repository/skill_center/test_skill_set_control_plane_uow.py`