### PR TITLE
fix(skill_center): 恢复 get_symlink_mappings 未知引擎 default 兜底语义 (teclaw 激活报错)

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -1506,11 +1506,12 @@ class SkillSetService:
             "aicoding": "/home/admin/.aicoding/skills-repo",
             "hermes": "/home/admin/.hermes/skills-repo",
         }
-        if self.runtime_engine_type not in ENGINE_SKILLS_DIR_MAP:
-            raise ValueError(
-                f"engine Skill layout not implemented: {self.runtime_engine_type}"
+        base_skills_dir = Path(
+            ENGINE_SKILLS_DIR_MAP.get(
+                self.runtime_engine_type,
+                "/home/admin/.openclaw/workspace/skills",
             )
-        base_skills_dir = Path(ENGINE_SKILLS_DIR_MAP[self.runtime_engine_type])
+        )
         # aicoding 引擎使用独立的 skills-repo 目录
         skills_repo_dir = Path(
             ENGINE_SKILLS_REPO_DIR_MAP.get(

--- a/src/backend/tests/community/services/test_skill_set_service_engine_type.py
+++ b/src/backend/tests/community/services/test_skill_set_service_engine_type.py
@@ -119,9 +119,15 @@ class TestSkillSetServiceEngineTypeThreading:
         ]
 
 
-    async def test_get_symlink_mappings_rejects_unknown_runtime_engine(
+    async def test_get_symlink_mappings_unknown_engine_falls_back_to_default(
         self, skill_set_service
     ):
+        """未知引擎不报错，回落到 openclaw 默认技能目录（保留原 default 兜底语义）。
+
+        曾误加 ``not in ... raise`` check 拦住了 teclaw 等未在 ENGINE_SKILLS_DIR_MAP
+        里的引擎(它们不走容器软链，本就不该被此处拦下)。现恢复 ``.get(engine, 默认)``
+        兜底，未知引擎产出指向默认目录的软链配置、不抛错。
+        """
         skill_set_service.runtime_engine_type = "unknown_engine"
         skill_set_service.get_active_skills = MagicMock(
             return_value=[
@@ -129,8 +135,13 @@ class TestSkillSetServiceEngineTypeThreading:
             ]
         )
 
-        with pytest.raises(ValueError, match="engine Skill layout not implemented"):
-            skill_set_service.get_symlink_mappings()
+        mappings = skill_set_service.get_symlink_mappings()
+
+        assert len(mappings) == 1
+        m = mappings[0].to_dict()
+        # git:// business/reviewer → source skills-repo/business/reviewer, target reviewer
+        assert m["target"].endswith("/skills/reviewer")
+        assert m["source"].endswith("/skills/skills-repo/business/reviewer")
 
     def test_get_all_skill_sets_with_skills_passes_engine_type(self, skill_set_service, mock_skill_set_repo):
         """get_all_skill_sets_with_skills should pass engine_type to repo.list_all."""


### PR DESCRIPTION
## 背景

线上日志报错：
\`\`\`
2026-08-20 00:29:13,612 - ERROR - [SkillSetActivator.activate] Device sync failed:
{'success': False, 'message': 'engine Skill layout not implemented: teclaw',
 'error': 'engine Skill layout not implemented: teclaw'}
\`\`\`

teclaw bot 激活技能集时 \`SkillSetActivator.activate\` → \`_do_device_sync\` → \`get_symlink_mappings\` 抛出 \`ValueError\`。

## 根因

\`REL\` 分支在 \`get_symlink_mappings\` 中误加了硬抛错 check：

\`\`\`python
if self.runtime_engine_type not in ENGINE_SKILLS_DIR_MAP:
    raise ValueError(f"engine Skill layout not implemented: {self.runtime_engine_type}")
base_skills_dir = Path(ENGINE_SKILLS_DIR_MAP[self.runtime_engine_type])
\`\`\`

这改变了原设计的默认兜底语义。原设计（与 \`dev\` 分支一致）是：

\`\`\`python
base_skills_dir = Path(
    ENGINE_SKILLS_DIR_MAP.get(self.engine_type, "/home/admin/.openclaw/workspace/skills")
)
\`\`\`

teclaw 未在 \`ENGINE_SKILLS_DIR_MAP\` 中，被该 check 拦下报错。而 teclaw **本就不走容器软链链路**（它经 device-fs 的 \`/workspace/skills-local\` 文件级寻址，见 \`teclaw_paths.py\` + \`device_filesystem_dispatcher\` 的 teclaw 分支），这份软链清单对 teclaw 不会被消费，本不该在此处被拦截。

## 修复

去掉 \`raise\` check，恢复 \`.get(engine_type, openclaw 默认路径)\` 兜底语义，与 \`dev\` 分支行为一致。未在映射表里的引擎（如 teclaw）回落到默认容器路径、不抛错。

## 改动

- \`src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py\`：恢复 default 兜底。
- \`tests/community/services/test_skill_set_service_engine_type.py\`：对应用例由「未知引擎 must raise」改为「未知引擎回落默认、不抛错」。

## 影响

- 容器型引擎（openclaw/moltis/hermes/aicoding）：行为不变，仍在映射表内。
- teclaw / 其它未在表里的引擎：不再因该 check 报错；其软链清单对它们不被消费，兜底值不产生实际副作用。