### PR TITLE
feat(bcs): forward canonical interaction metadata

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/tests/provider_transport_contract.rs
@@ -83,6 +83,56 @@ async fn interaction_resolve_reuses_provider_route_and_expects_json_ack() {
     assert_eq!(request.body["timeout_ms"], 3_600_000);
     server.abort();
 }
+
+#[tokio::test]
+async fn interaction_resolve_forwards_ask_user_header() {
+    let captured: CapturedState = Arc::new(Mutex::new(None));
+    let app = Router::new()
+        .route("/webhook", post(capture_ack))
+        .with_state(captured.clone());
+    let (webhook_url, server) = spawn_server(app).await;
+    let target = provider_target_v2(webhook_url);
+    let transport = HttpProviderTransport::allowing_private_networks_for_tests();
+
+    let ack = transport
+        .resolve_interaction(InteractionProviderCommand {
+            target,
+            provider_bypass_headers: Vec::new(),
+            bcs_run_id: "bcs-run-1".to_string(),
+            provider_run_id: "provider-run-1".to_string(),
+            bcs_session_id: "session-1".to_string(),
+            group_id: "group-1".to_string(),
+            bot_id: "bot-1".to_string(),
+            interaction_id: "interaction-ask-1".to_string(),
+            kind: InteractionKind::AskUser,
+            idempotency_key: "idem-ask-1".to_string(),
+            resolution: json!({
+                "action": "submit",
+                "answers": {
+                    "deploy_target": {
+                        "header": "Deployment environment",
+                        "question": "Where should this be deployed?",
+                        "values": ["staging"]
+                    }
+                }
+            }),
+        })
+        .await
+        .unwrap();
+
+    assert!(ack.ok);
+    let request = captured.lock().await.clone().unwrap();
+    assert_eq!(request.body["params"]["kind"], "ask_user");
+    assert_eq!(
+        request.body["params"]["answers"]["deploy_target"],
+        json!({
+            "header": "Deployment environment",
+            "question": "Where should this be deployed?",
+            "values": ["staging"]
+        })
+    );
+    server.abort();
+}
 use serde_json::{Value, json};
 use tokio::sync::{Mutex, RwLock};
 use tracing::Instrument;

--- a/src/bcs/crates/contracts/bcs-protocol/src/stream/parse.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/stream/parse.rs
@@ -290,6 +290,42 @@ mod tests {
     }
 
     #[test]
+    fn preserves_requested_mode_switch_target_and_recommendation() {
+        let data = json!({
+            "runId": "provider-run-3",
+            "seq": 9,
+            "phase": "requested",
+            "interactionId": "interaction-mode-switch",
+            "kind": "mode_switch",
+            "fromMode": "plan",
+            "targetMode": "execute",
+            "options": [
+                {
+                    "decision": "proceed",
+                    "label": "Continue to execution",
+                    "targetMode": "execute",
+                    "recommended": true
+                },
+                {
+                    "decision": "stay",
+                    "label": "Stay in planning"
+                }
+            ]
+        });
+
+        match parse_stream_event("interaction", data.clone()) {
+            StreamEvent::Interaction(interaction) => {
+                assert_eq!(interaction.kind, InteractionKind::ModeSwitch);
+                assert_eq!(interaction.raw["targetMode"], json!("execute"));
+                assert_eq!(interaction.raw["options"][0]["targetMode"], json!("execute"));
+                assert_eq!(interaction.raw["options"][0]["recommended"], json!(true));
+                assert_eq!(interaction.raw, data);
+            }
+            other => panic!("expected interaction, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn parses_resolved_interaction_without_kind_specific_echo() {
         let data = json!({
             "runId": "provider-run-1",

--- a/src/bcs/crates/services/bcs-interaction/src/management.rs
+++ b/src/bcs/crates/services/bcs-interaction/src/management.rs
@@ -737,9 +737,10 @@ fn validate_ask_user_resolution(
 }
 
 /// AskUser submit 时，按 questionId（answers 对象的键）把 requested 阶段存储的
-/// 原始 question 文本补进每个 answer 对象，字段名 `question`，与 `values` 平级。
-/// 前端 resolve 只发 `values`，question 始终由 BCS 用权威存储文本补齐并覆盖前端
-/// 可能回传的同名字段。cancel / exec / mode_switch 原样返回。
+/// 原始 question 和可选 header 补进每个 answer 对象，与 `values` 平级。
+/// 前端 resolve 只发 `values`；question/header 始终由 BCS 用权威存储值覆盖，存储
+/// header 缺失时保持缺失，不从 questionId 或前端输入合成。canonical resolution
+/// 同时用于 fingerprint 与 Provider 转发。cancel / exec / mode_switch 原样返回。
 fn augment_ask_user_resolution(record: &InteractionRecord, mut resolution: Value) -> Value {
     if record.kind != bcs_service_api::InteractionKind::AskUser {
         return resolution;
@@ -768,10 +769,19 @@ fn augment_ask_user_resolution(record: &InteractionRecord, mut resolution: Value
             continue;
         };
         if let Some(answer) = answers.get_mut(question_id).and_then(Value::as_object_mut) {
+            answer.remove("question");
+            answer.remove("header");
             answer.insert(
                 "question".to_string(),
                 Value::String(question_text.to_string()),
             );
+            if let Some(header) = question
+                .get("header")
+                .and_then(Value::as_str)
+                .filter(|header| !header.trim().is_empty())
+            {
+                answer.insert("header".to_string(), Value::String(header.to_string()));
+            }
         }
     }
     resolution
@@ -1580,11 +1590,11 @@ mod tests {
             "interactionId":"ask-1",
             "kind":"ask_user",
             "questions":[
-                {"questionId":"target","question":"Where should this be deployed?","options":[
+                {"questionId":"target","header":"Deployment environment","question":"Where should this be deployed?","options":[
                     {"value":"staging","label":"Staging"},
                     {"value":"prod","label":"Production"}
                 ]},
-                {"questionId":"components","question":"Which components?","multiSelect":true,"options":[
+                {"questionId":"components","header":"Components","question":"Which components?","multiSelect":true,"options":[
                     {"value":"web","label":"Web"},
                     {"value":"worker","label":"Worker"}
                 ]}
@@ -1596,7 +1606,11 @@ mod tests {
         command.resolution = json!({
             "action":"submit",
             "answers":{
-                "target":{"values":["staging"]},
+                "target":{
+                    "values":["staging"],
+                    "question":"frontend question",
+                    "header":"frontend header"
+                },
                 "components":{"values":["web","worker"]}
             }
         });
@@ -1615,6 +1629,10 @@ mod tests {
             "Where should this be deployed?"
         );
         assert_eq!(
+            resolution["answers"]["target"]["header"],
+            "Deployment environment"
+        );
+        assert_eq!(
             resolution["answers"]["components"]["values"],
             json!(["web", "worker"])
         );
@@ -1622,6 +1640,45 @@ mod tests {
             resolution["answers"]["components"]["question"],
             "Which components?"
         );
+        assert_eq!(resolution["answers"]["components"]["header"], "Components");
+    }
+
+    #[tokio::test]
+    async fn ask_user_submit_omits_header_when_requested_header_is_absent() {
+        let (service, _store, provider, _frontend) = service(true);
+        let mut ask = requested("ask-1");
+        ask.kind = InteractionKind::AskUser;
+        ask.payload = json!({
+            "runId":"provider-run-1",
+            "phase":"requested",
+            "interactionId":"ask-1",
+            "kind":"ask_user",
+            "questions":[{
+                "questionId":"target",
+                "question":"Where?",
+                "options":[{"value":"staging","label":"Staging"}]
+            }]
+        });
+        service.on_provider_requested(ask).await.unwrap();
+
+        let mut command = resolve("ask-1", "idem-ask");
+        command.resolution = json!({
+            "action":"submit",
+            "answers":{
+                "target":{
+                    "values":["staging"],
+                    "question":"frontend question",
+                    "header":"untrusted"
+                }
+            }
+        });
+        let result = service.resolve(command).await.unwrap();
+        assert!(result.accepted);
+
+        let calls = provider.calls.lock().await;
+        let answer = &calls[0].resolution["answers"]["target"];
+        assert_eq!(answer["question"], "Where?");
+        assert!(answer.get("header").is_none());
     }
 
     #[tokio::test]

--- a/src/bcs/docs/bcs-provider-2.0-sse-protocol.md
+++ b/src/bcs/docs/bcs-provider-2.0-sse-protocol.md
@@ -439,14 +439,16 @@ Submit（前端回传，只发 `values`）：
 }
 ```
 
-BCS 转发给 Provider 时，按 `questionId` 把 requested 存储的原始 `question` 文本
-补进每个 answer（与 `values` 平级），Provider 收到的 answers 形如：
+BCS 转发给 Provider 时，按 `questionId` 把 requested 存储的原始 `question` 和
+存在时的原始 `header` 补进每个 answer（与 `values` 平级）。BCS 会覆盖前端可能
+携带的同名字段；requested 没有 header 时保持缺失，不从 questionId 或其他字段
+合成。Provider 收到的 answers 形如：
 
 ```json
 {
   "action": "submit",
   "answers": {
-    "deploy_target": {"values": ["canary"], "question": "Where should this be deployed?"},
+    "deploy_target": {"values": ["canary"], "question": "Where should this be deployed?", "header": "Environment"},
     "components": {"values": ["web", "worker"], "question": "Which components?"},
     "release_notes": {"values": ["Deploy after 22:00"], "question": "Additional deployment instructions?"}
   }
@@ -472,9 +474,12 @@ Cancel：
   option value 区分预定义值和自由文本，不引入第二套 custom 字段。
 - resolve 的 `action` 必须是 `submit/cancel`。submit 必须提供 answers，且
   questionId 集合与 requested 完全一致；本期所有问题都必须回答。
-- answers 的键是 `questionId`；每个 answer 只需 `values`，`question` 字段由 BCS
-  按 `questionId` 从 requested 存储的原始问题文本补齐后转发给 Provider，
-  前端 submit 不需要也不应自行回传 `question`。
+- answers 的键是 `questionId`；每个 Frontend answer 只需 `values`。BCS 按
+  `questionId` 从 requested 存储数据补齐 `question` 和存在时的 `header` 后转发给
+  Provider，并覆盖前端可能回传的同名字段。header 缺失时不 fallback。
+- `header` 在 BCN 通用协议中仍然可选；具体 Provider 可以声明更严格的输入约束。
+  例如 BaaS 产生的 ask_user question 始终带 header，因此 BaaS resolve 要求每个
+  answer 都包含非空 header。
 - cancel 的语义由 action 决定。BCS 不额外禁止携带 answers，但 Provider/Frontend
   应发送最小的 `{action:"cancel"}`，避免产生歧义。
 - 单选和纯文本恰好一个 value；多选一个或多个；每项都是非空字符串。
@@ -507,8 +512,9 @@ Requested：
   "kind": "mode_switch",
   "title": "Proceed with implementation?",
   "fromMode": "plan",
+  "targetMode": "execute",
   "options": [
-    {"decision": "proceed_accept_edits", "label": "Approve and accept edits", "targetMode": "acceptEdits"},
+    {"decision": "proceed_accept_edits", "label": "Approve and accept edits", "targetMode": "acceptEdits", "recommended": true},
     {"decision": "proceed_default", "label": "Approve and review edits", "targetMode": "default"},
     {"decision": "stay", "label": "Keep planning"}
   ]
@@ -529,9 +535,13 @@ Resolved：
 
 约束：
 
-- `options` 必填非空；每项 `decision/label` 必填，`description/targetMode` 可选。
-- `fromMode/targetMode` 是 Provider opaque string，BCS 不维护模式枚举。
-- 进入模式的 option 应提供 targetMode；保持、拒绝或继续规划的 option 可省略。
+- `options` 必填非空；每项 `decision/label` 必填，`description/targetMode/recommended`
+  可选。
+- 顶层 `fromMode`、`targetMode` 均为可选的 Provider opaque string，BCS 不维护
+  模式枚举。
+- `options[].targetMode` 是可选字段；进入已知模式的 option 应提供，保持、拒绝或
+  继续规划的 option 可省略。
+- `options[].recommended` 是可选 bool UI hint；省略表示该 option 无推荐标记。
 - resolve decision 必须来自 requested options；本期不支持附带反馈文本。
 - 该 kind 是 Provider 可选能力。不能可靠恢复同一 runtime 的引擎不应合成。
 - 本期必须保持同一 SSE、同一 run；创建新 thread/run 的模式选项不在范围内。
@@ -856,7 +866,7 @@ request/interaction ID、运行上下文以及 engine-native response。统一�
 | --- | --- | --- |
 | `exec` | interactionId、command、动态 decisions | interactionId + decision；toolCallId 可选关联 |
 | `ask_user` | 稳定 questionId、question、可选 options | action + questionId 到 values[]；Provider 可按原顺序或问题文本转回 |
-| `mode_switch` | 当前可用 decisions；fromMode 可选 | interactionId + decision；Provider 查回目标模式/原生 reply |
+| `mode_switch` | 当前可用 decisions；fromMode/targetMode 可选 | interactionId + decision；Provider 查回目标模式/原生 reply |
 
 因此协议不要求引擎本身统一事件名，也不要求每个引擎原生提供 `optionId`、BCS
 session ID 或 idempotency key。Provider 在 requested 时保存必要的 engine-native


### PR DESCRIPTION
## Problem

BCS needs to preserve provider-defined mode-switch metadata in interaction SSE events and forward authoritative ask-user context when resolving an interaction. Without this, providers cannot reliably recover the requested mode target or distinguish answer identity from display metadata.

## Solution

- Document optional top-level and per-option `targetMode` fields plus the optional `recommended` UI hint for `mode_switch` interactions.
- Add protocol characterization coverage proving these provider-owned fields remain available in the raw interaction payload.
- Canonicalize ask-user resolutions from the stored requested interaction: BCS overwrites untrusted frontend `question` and `header` values with the authoritative stored values, while leaving `header` absent when it was not originally provided.
- Add provider transport coverage proving canonical answer headers are forwarded unchanged.
- Update the BCN Provider 2.0 SSE contract with the resulting request and resolve semantics.

## Validation

- `cargo test -p bcs-protocol -p bcs-interaction -p bcs-provider-http`
  - 151 tests passed, 0 failed.
- `git diff --check c63759fb2...927a09a7b`
  - Passed.
- Verified the branch contains one commit and changes only four files under `src/bcs/`.

## Compatibility and risk

The mode-switch fields remain optional provider-owned metadata. Ask-user `header` also remains optional in the general BCN contract; BCS does not synthesize a fallback when the stored requested interaction omitted it. Existing providers that do not emit these fields retain their previous behavior.

## Spec

- `src/bcs/docs/bcs-provider-2.0-sse-protocol.md`
