### PR TITLE
feat(backend): ship teclaw with an empty default MCP roster

### DIFF
--- a/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
@@ -46,23 +46,12 @@ _DEFAULT_MCP_SERVERS_BY_ENGINE: Dict[str, List[dict]] = {
         {"server_code": "hitl"},
     ],
     "moltis": [],
-    "teclaw": [
-        {"server_code": "mcp.ant.lwawchat.cogmessagemcp", "name": "蚂蚁钉协作群消息相关-MCP服务"},
-        {"server_code": "mcp.ant.antdingopenapi.antdingreportmcpserver", "name": "蚂蚁钉日志服务"},
-        {"server_code": "mcp.ant.antdingopenapi.antdinggroupmcpserver", "name": "蚂蚁钉群服务"},
-        {"server_code": "mcp.ant.lwawchat.cogdocumentmcp", "name": "蚂蚁钉协作群文档相关-MCP服务"},
-        {"server_code": "mcp.ant.antdingopenapi.antdingeventmcpserver", "name": "蚂蚁钉日程相关-MCP服务"},
-        {"server_code": "mcp.ant.antdingopenapi.antdingrobotmcpserver", "name": "蚂蚁钉机器人相关-MCP服务"},
-        {"server_code": "mcp.ant.antdingopenapi.antdingmessagemcpserver", "name": "蚂蚁钉消息相关-MCP服务"},
-        {"server_code": "mcp.ant.antdingopenapi.antdingtodomcpserver", "name": "蚂蚁钉待办服务"},
-        {"server_code": "mcp.ant.faas.skylarkmcpserver.skylarkmcpserver", "name": "语雀 MCP"},
-        {"server_code": "mcp.ant.arkai.dimamcpserver", "name": "Dima-MCP服务"},
-        {"server_code": "mcp.ant.homistudio.recordmcp", "name": "会中会话记录查询服务"},
-        {"server_code": "mcp.ant.rpc.dcanttouch.adminservice", "name": "行政小宝MCP服务"},
-        # Local/stdio; resolved through LocalMCPRegistry, not MCP Center. Kept
-        # last to match the other engines' lists.
-        {"server_code": "hitl", "name": "HITL"},
-    ],
+    # Intentionally empty: teclaw bots start with no default MCP servers and
+    # get every MCP from their owner's own skill-set configuration. The key
+    # stays declared (like ``moltis``) so teclaw keeps resolving its own
+    # bucket — dropping it would make teclaw indistinguishable from an
+    # unknown engine and hide a future bucket-aliasing regression.
+    "teclaw": [],
     "claude_code": [
         {"server_code": "mcp.ant.antprocessai.anttaskmcp", "name": "任务中心MCP", "description": "任务中心待办任务，已办任务等相关任务查询MCP"},
         {"server_code": "mcp.ant.arkai.dimamcpserver", "name": "Dima MCP", "description": "Dima MCP"},

--- a/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
+++ b/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
@@ -547,49 +547,45 @@ def test_template_config_cli_presets_are_aicoding_specific():
     ) == []
 
 
-# The teclaw roster, spelled out independently of the source list. The publish
-# suite's ``_install_default_mcp_catalog`` derives its mock *from*
-# ``_DEFAULT_MCP_SERVERS_BY_ENGINE["teclaw"]``, so it proves only that a build
-# resolves whatever the roster happens to hold — a typo'd or duplicated
-# ``server_code`` would sail straight through it. This second, independent copy
-# is what makes such an edit fail loudly.
-TECLAW_DEFAULT_MCP_CODES = (
-    "mcp.ant.lwawchat.cogmessagemcp",
-    "mcp.ant.antdingopenapi.antdingreportmcpserver",
-    "mcp.ant.antdingopenapi.antdinggroupmcpserver",
-    "mcp.ant.lwawchat.cogdocumentmcp",
-    "mcp.ant.antdingopenapi.antdingeventmcpserver",
-    "mcp.ant.antdingopenapi.antdingrobotmcpserver",
-    "mcp.ant.antdingopenapi.antdingmessagemcpserver",
-    "mcp.ant.antdingopenapi.antdingtodomcpserver",
-    "mcp.ant.faas.skylarkmcpserver.skylarkmcpserver",
-    "mcp.ant.arkai.dimamcpserver",
-    "mcp.ant.homistudio.recordmcp",
-    "mcp.ant.rpc.dcanttouch.adminservice",
-    "hitl",
-)
+# teclaw ships no default MCP servers: a teclaw bot starts empty and every MCP
+# it runs comes from its owner's own skill-set configuration. The publish suite's
+# ``_install_default_mcp_catalog`` derives its mock *from*
+# ``_DEFAULT_MCP_SERVERS_BY_ENGINE["teclaw"]``, so it only ever proves that a
+# build resolves whatever the roster happens to hold — a roster that silently
+# regrew an entry would sail straight through it. These cases are what make such
+# an edit fail loudly.
 
 
-def test_teclaw_default_roster_shape():
-    """teclaw's roster: exact codes, exact order, no dupes, local entry last."""
-    codes = [s["server_code"] for s in get_default_mcp_servers("teclaw")]
-    assert codes == list(TECLAW_DEFAULT_MCP_CODES)
-    assert len(codes) == len(set(codes)), "duplicate server_code in the teclaw roster"
-    # ``hitl`` is the only local/stdio entry and stays last, matching how the
-    # other engines list it. The artifact path resolves its launch instruction
-    # through LocalMCPRegistry, not MCP Center — see ``_stdio_launch_for``.
-    assert codes[-1] == "hitl"
+def test_teclaw_has_no_default_mcp_servers():
+    """teclaw's roster is empty — no MCP is granted without the owner asking."""
+    assert get_default_mcp_servers("teclaw") == []
+    assert get_default_mcp_server_codes("teclaw") == []
+    # ``hitl`` is local/stdio and was the roster's last entry; it is not an
+    # exception to the empty default, only an MCP the owner may add explicitly.
+    assert "hitl" not in get_default_mcp_server_codes("teclaw")
 
 
 def test_teclaw_roster_is_its_own_bucket():
-    """teclaw resolves its own defaults rather than inheriting another engine's.
+    """teclaw resolves its own (empty) defaults rather than inheriting another
+    engine's.
 
     ``_resolve_default_mcp_engine_bucket`` normalizes case and delegates bucket
     overrides to the engine registry; an alias onto ``openclaw`` would silently
-    swap the whole roster, so pin both the normalization and the distinctness.
+    hand teclaw a full roster, so pin both the normalization and the emptiness.
     """
-    assert [s["server_code"] for s in get_default_mcp_servers("TECLAW")] == list(
-        TECLAW_DEFAULT_MCP_CODES
+    assert get_default_mcp_servers("TECLAW") == []
+    assert get_default_mcp_servers("openclaw") != []
+
+
+def test_teclaw_bucket_is_declared_not_missing():
+    """The empty roster is a declared decision, not an unknown-engine fallback.
+
+    ``get_default_mcp_servers`` fails closed for engines it does not know, so an
+    accidentally deleted ``teclaw`` key would return the same ``[]`` while losing
+    the bucket that keeps teclaw distinguishable from a typo'd engine name.
+    """
+    from agentclaw.community.core.mcp.services._defaults import (
+        _DEFAULT_MCP_SERVERS_BY_ENGINE,
     )
-    openclaw_codes = {s["server_code"] for s in get_default_mcp_servers("openclaw")}
-    assert "mcp.ant.lwawchat.cogmessagemcp" not in openclaw_codes
+
+    assert _DEFAULT_MCP_SERVERS_BY_ENGINE["teclaw"] == []

--- a/src/backend/tests/community/endpoints/test_service_bot_publish_flow.py
+++ b/src/backend/tests/community/endpoints/test_service_bot_publish_flow.py
@@ -228,7 +228,10 @@ def _install_default_mcp_catalog(world) -> None:
     to what these cases assert.
 
     Derived from ``_DEFAULT_MCP_SERVERS_BY_ENGINE`` rather than a hardcoded
-    list: adding a server to the roster must not silently skip it here.
+    list: adding a server to the roster must not silently skip it here. teclaw's
+    roster is empty today, so the override currently answers ``None`` for every
+    code — same as ``NoopMCPCenterPlugin`` — and the seam is kept so a roster
+    that regains entries stays resolvable without touching this suite.
     Servers the local-MCP registry owns (``hitl``) are left unresolved on
     purpose — they are stdio, and the collector resolves their launch
     instruction from that registry, so answering REMOTE here would misclassify


### PR DESCRIPTION
## Problem

`_DEFAULT_MCP_SERVERS_BY_ENGINE["teclaw"]` granted every new teclaw bot 13 MCP
servers up front (12 remote MCP Center servers plus the local/stdio `hitl`).
Two consequences:

- A teclaw bot boots with capabilities its owner never configured.
- The teclaw artifact path composes the roster as a unit and fails the whole
  build when any single entry cannot be resolved, so a default nobody asked for
  can block a publish.

teclaw's MCPs should come from the owner's own skill-set configuration, not from
a baked-in list.

## Solution

Empty the teclaw bucket: `"teclaw": []`.

The key stays **declared** rather than deleted. `get_default_mcp_servers` fails
closed to `[]` for engines it does not know, so removing the key would return the
same empty list while making teclaw indistinguishable from a typo'd engine name
— and would silently hide a future bucket-aliasing regression (e.g. teclaw being
routed onto openclaw's roster). This matches how `moltis` already declares an
empty roster.

`hitl` goes with the rest. It was the roster's local/stdio entry, but it is a
default like any other; its per-engine launch instruction in
`local-mcp-servers.yaml` is untouched, so an owner who adds `hitl` explicitly
still gets the teclaw-specific `/usr/local/bin/teclaw_hitl_mcp_server.py` path.

Test changes:

- `test_teclaw_default_roster_shape` → `test_teclaw_has_no_default_mcp_servers`
  (roster and codes are empty; `hitl` is not an exception to the empty default).
- `test_teclaw_roster_is_its_own_bucket` keeps pinning case normalization and
  non-inheritance, now against emptiness.
- New `test_teclaw_bucket_is_declared_not_missing` guards the key itself, since
  emptiness alone cannot distinguish a declared decision from a deleted key.
- `_install_default_mcp_catalog` in the publish suite is unchanged in behavior —
  it derives from the roster, so it self-adjusts — but its docstring now says the
  roster is empty today and why the seam is kept.

## Validation

Run in `src/backend` with `uv run pytest`:

- `tests/community/core/mcp/` + `tests/community/endpoints/test_service_bot_publish_flow.py` — **185 passed**.
- `tests/community/core/mcp/test_defaults_per_engine.py` alone — **37 passed**.

Not run: the full backend suite, changed-line coverage, and the Singlebox
acceptance/E2E gate. The sandbox cannot reach this repo's configured package
index (`mirrors.aliyun.com`), so the environment was resolved against pypi.org
for the runs above; `uv.lock` was restored and is not part of this diff. The
heavier gates are left to CI.

## Compatibility and risk

Behavior change, no schema or contract change. Existing teclaw bots that already
have these servers persisted in their skill set keep them — only the implicit
defaults merged into the *default* skill set go away; bots relying on an
un-persisted default lose that MCP until an owner adds it back explicitly.
Rollback is restoring the roster literal in `_defaults.py`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXXbghR7fwYTdcfc1FP5hM)_