### PR TITLE
fix(skills): preserve legacy repo authority before cutover

### DIFF
--- a/src/engine/src/engine/community/plugins/claude_code/tests/test_pool_layout.py
+++ b/src/engine/src/engine/community/plugins/claude_code/tests/test_pool_layout.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import threading
 from pathlib import Path
 
@@ -35,6 +36,7 @@ def _prepared_home(
     active_root = home / ".claude" / "skills"
     local_bridge = active_root / "skills-local"
     repo_bridge = active_root / "skills-repo"
+    legacy_repo = home / ".claude_code" / "skills-repo"
     pool_root = home / ".claude_code" / "workspace" / "skills-pool"
     pool_local = pool_root / "skills-local"
     pool_repo = pool_root / "skills-repo"
@@ -45,9 +47,11 @@ def _prepared_home(
     (pool_local / "handmade" / "SKILL.md").write_text("prepared")
     (pool_repo / "business" / "shared").mkdir(parents=True)
     (pool_repo / "business" / "shared" / "SKILL.md").write_text("repo")
+    (legacy_repo / "business" / "shared").mkdir(parents=True)
+    (legacy_repo / "business" / "shared" / "SKILL.md").write_text("legacy repo")
     active_root.mkdir(parents=True, exist_ok=True)
     local_bridge.symlink_to(legacy_local, target_is_directory=True)
-    repo_bridge.symlink_to(pool_repo, target_is_directory=True)
+    repo_bridge.symlink_to(legacy_repo, target_is_directory=True)
 
     marker = {
         "engine": "claude_code",
@@ -74,10 +78,15 @@ def _prepared_home(
                 {
                     "name": "stable_repo_bridge",
                     "path": str(repo_bridge),
-                    "target": str(pool_repo),
+                    "target": str(legacy_repo),
                     "valid": True,
                 },
             ],
+            "legacy_repo": {
+                "path": str(legacy_repo),
+                "actual_directory": True,
+                "valid": True,
+            },
             "managed_active_entries": [],
             "external_active_entry_count": 0,
         },
@@ -95,10 +104,11 @@ def _prepared_home(
 
 def test_claude_code_probe_requires_both_stable_bridges(tmp_path: Path) -> None:
     home, _, _, repo_bridge, _, pool_repo = _prepared_home(tmp_path)
+    legacy_repo = home / ".claude_code" / "skills-repo"
 
     ready = inspect_claude_code_runtime_layout(
         home=home,
-        repo_is_mounted=lambda path: path == pool_repo,
+        repo_is_mounted=lambda path: path in {legacy_repo, pool_repo},
     )
 
     assert ready.status is RuntimeLayoutInspectionStatus.READY
@@ -111,11 +121,74 @@ def test_claude_code_probe_requires_both_stable_bridges(tmp_path: Path) -> None:
     repo_bridge.symlink_to(home / "wrong", target_is_directory=True)
     invalid = inspect_claude_code_runtime_layout(
         home=home,
-        repo_is_mounted=lambda path: path == pool_repo,
+        repo_is_mounted=lambda path: path in {legacy_repo, pool_repo},
     )
 
     assert invalid.status is RuntimeLayoutInspectionStatus.INVALID
     assert invalid.evidence["reason"] == "stable_repo_bridge_invalid"
+
+
+def test_claude_code_probe_rejects_legacy_repo_redirected_to_pool(
+    tmp_path: Path,
+) -> None:
+    home, _, _, _, _, pool_repo = _prepared_home(tmp_path)
+    legacy_repo = home / ".claude_code" / "skills-repo"
+    shutil.rmtree(legacy_repo)
+    legacy_repo.symlink_to(pool_repo, target_is_directory=True)
+
+    invalid = inspect_claude_code_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path in {legacy_repo, pool_repo},
+    )
+
+    assert invalid.status is RuntimeLayoutInspectionStatus.INVALID
+    assert invalid.evidence["reason"] == "legacy_repo_not_independent"
+
+
+def test_claude_code_probe_rejects_missing_legacy_repo(tmp_path: Path) -> None:
+    home, _, _, _, _, pool_repo = _prepared_home(tmp_path)
+    legacy_repo = home / ".claude_code" / "skills-repo"
+    shutil.rmtree(legacy_repo)
+
+    invalid = inspect_claude_code_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert invalid.status is RuntimeLayoutInspectionStatus.INVALID
+    assert invalid.evidence["reason"] == "legacy_repo_not_independent"
+
+
+def test_claude_code_probe_reports_legacy_mount_transient_error(
+    tmp_path: Path,
+) -> None:
+    home, _, _, _, _, pool_repo = _prepared_home(tmp_path)
+    legacy_repo = home / ".claude_code" / "skills-repo"
+
+    def repo_is_mounted(path: Path) -> bool:
+        if path == legacy_repo:
+            raise OSError("mount table unavailable")
+        return path == pool_repo
+
+    transient = inspect_claude_code_runtime_layout(
+        home=home,
+        repo_is_mounted=repo_is_mounted,
+    )
+
+    assert transient.status is RuntimeLayoutInspectionStatus.TRANSIENT_ERROR
+    assert transient.evidence["reason"] == "legacy_repo_temporarily_unavailable"
+
+
+def test_claude_code_probe_requires_legacy_repo_mount(tmp_path: Path) -> None:
+    home, _, _, _, _, pool_repo = _prepared_home(tmp_path)
+
+    invalid = inspect_claude_code_runtime_layout(
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+    )
+
+    assert invalid.status is RuntimeLayoutInspectionStatus.INVALID
+    assert invalid.evidence["reason"] == "legacy_repo_not_mounted"
 
 
 def test_claude_code_probe_rejects_non_file_marker(tmp_path: Path) -> None:
@@ -146,6 +219,7 @@ def test_claude_code_activation_retires_physical_legacy_local(
         pool_local,
         pool_repo,
     ) = _prepared_home(tmp_path)
+    legacy_repo = home / ".claude_code" / "skills-repo"
     mappings = [
         SkillMapping(
             source=str(pool_local / "handmade"),
@@ -163,7 +237,7 @@ def test_claude_code_activation_retires_physical_legacy_local(
         registered_local_names=["handmade"],
         mappings=mappings,
         home=home,
-        repo_is_mounted=lambda path: path == pool_repo,
+        repo_is_mounted=lambda path: path in {legacy_repo, pool_repo},
     )
 
     assert result.status is PoolActivationStatus.COMMITTED
@@ -209,6 +283,32 @@ def test_claude_code_publishes_and_verifies_pool_mappings(tmp_path: Path) -> Non
 
     assert mismatch.valid is False
     assert mismatch.evidence["failures"][0]["reason"] == "managed_source_conflict"
+
+
+def test_claude_code_accepts_active_repo_alias_for_legacy_mappings(
+    tmp_path: Path,
+) -> None:
+    home, _, _, repo_bridge, _, _ = _prepared_home(tmp_path)
+    source = repo_bridge / "business" / "shared"
+    target = repo_bridge.parent / "shared"
+    mapping = SkillMapping(source=str(source), target=str(target))
+
+    published = publish_claude_code_pool_mappings(
+        mappings=[mapping],
+        source_layout=MappingSourceLayout.LEGACY,
+        home=home,
+    )
+    verified = verify_claude_code_pool_mappings(
+        mappings=[mapping],
+        source_layout=MappingSourceLayout.LEGACY,
+        home=home,
+    )
+
+    assert published.published is True
+    assert target.is_symlink()
+    legacy_repo = home / ".claude_code" / "skills-repo"
+    assert target.resolve() == (legacy_repo / "business" / "shared").resolve()
+    assert verified.valid is True
 
 
 @pytest.mark.asyncio

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_activation.py
@@ -680,9 +680,12 @@ def _source_failure(
     source_layout: MappingSourceLayout,
 ) -> str | None:
     if source_layout is MappingSourceLayout.LEGACY:
+        roots = [layout.legacy_local, layout.legacy_repo, layout.pool_center]
+        if layout.engine_type == "claude_code":
+            roots.append(layout.repo_bridge)
         return _managed_source_failure(
             source,
-        roots=(layout.legacy_local, layout.legacy_repo, layout.pool_center),
+            roots=tuple(roots),
             outside_reason="source_outside_legacy",
         )
     return _managed_source_failure(

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -264,20 +264,35 @@ def _marker_contract_valid(
             and bridge.get("target") == str(layout.pool_repo)
             and bridge.get("valid") is True
         )
-    bridges_valid = summary.get("structural_bridges") == [
+    expected_bridges = [
         {
             "name": "stable_local_bridge",
             "path": str(layout.local_bridge),
             "target": str(layout.legacy_local),
             "valid": True,
-        },
+        }
+    ]
+    if expected_engine == "claude_code":
+        repo_target = layout.legacy_repo
+    else:
+        repo_target = layout.pool_repo
+    expected_bridges.append(
         {
             "name": "stable_repo_bridge",
             "path": str(layout.repo_bridge),
-            "target": str(layout.pool_repo),
+            "target": str(repo_target),
             "valid": True,
-        },
-    ]
+        }
+    )
+    bridges_valid = summary.get("structural_bridges") == expected_bridges
+    if expected_engine == "claude_code":
+        legacy_repo = summary.get("legacy_repo")
+        bridges_valid = bridges_valid and (
+            isinstance(legacy_repo, dict)
+            and legacy_repo.get("path") == str(layout.legacy_repo)
+            and legacy_repo.get("actual_directory") is True
+            and legacy_repo.get("valid") is True
+        )
     if expected_engine == "hermes":
         return bridges_valid and summary.get("legacy_bridge_verified") is True
     return bridges_valid
@@ -829,6 +844,52 @@ def inspect_runtime_layout(
                 checks=active_checks,
             ),
         )
+    if engine == "claude_code" and effective_repo_delivery is RepoDelivery.MOUNT:
+        try:
+            legacy_repo_stat = layout.legacy_repo.lstat()
+        except (FileNotFoundError, NotADirectoryError, PermissionError):
+            legacy_repo_stat = None
+        except OSError as error:
+            return _transient(
+                engine=engine,
+                contract_version=expected_contract_version,
+                layout=layout,
+                reason="legacy_repo_temporarily_unavailable",
+                error=error,
+                preparation_id=preparation_id,
+            )
+        if (
+            legacy_repo_stat is None
+            or stat.S_ISLNK(legacy_repo_stat.st_mode)
+            or not stat.S_ISDIR(legacy_repo_stat.st_mode)
+        ):
+            return _invalid(
+                engine=engine,
+                contract_version=expected_contract_version,
+                layout=layout,
+                reason="legacy_repo_not_independent",
+                preparation_id=preparation_id,
+            )
+        try:
+            legacy_repo_mounted = repo_is_mounted(layout.legacy_repo)
+        except OSError as error:
+            return _transient(
+                engine=engine,
+                contract_version=expected_contract_version,
+                layout=layout,
+                reason="legacy_repo_temporarily_unavailable",
+                error=error,
+                preparation_id=preparation_id,
+            )
+        if not legacy_repo_mounted:
+            return _invalid(
+                engine=engine,
+                contract_version=expected_contract_version,
+                layout=layout,
+                reason="legacy_repo_not_mounted",
+                preparation_id=preparation_id,
+            )
+
     if effective_repo_delivery is RepoDelivery.DOWNLOAD:
         required_bridges = [
             ("legacy_repo_delivery", layout.legacy_repo, layout.pool_repo)
@@ -843,7 +904,12 @@ def inspect_runtime_layout(
             )
     else:
         required_bridges = [("legacy_repo", layout.repo_bridge, layout.pool_repo)]
-        if engine != "openclaw":
+        if engine == "claude_code":
+            required_bridges = [
+                ("stable_local", layout.local_bridge, layout.legacy_local),
+                ("stable_repo", layout.repo_bridge, layout.legacy_repo),
+            ]
+        elif engine != "openclaw":
             required_bridges = [
                 ("stable_local", layout.local_bridge, layout.legacy_local),
                 ("stable_repo", layout.repo_bridge, layout.pool_repo),
@@ -927,6 +993,8 @@ def inspect_runtime_layout(
             checks["stable_local_bridge_valid"] = True
         if effective_repo_delivery is RepoDelivery.MOUNT:
             checks["stable_repo_bridge_valid"] = True
+            if engine == "claude_code":
+                checks["legacy_repo_mounted"] = True
         if engine == "hermes":
             checks["legacy_local_bridge_valid"] = True
     return RuntimeLayoutInspection(


### PR DESCRIPTION
## Summary

Preserve independent Legacy and Pool Repo data planes for native Claude Code before cutover. Engine validates both mounts, keeps the historical active Repo alias authorized as Legacy, and rejects any Legacy-to-Pool redirect.

## Changes

- require `~/.claude_code/skills-repo` to remain an independent mounted directory
- validate `~/.claude/skills/skills-repo -> ~/.claude_code/skills-repo` before cutover
- keep historical Backend Legacy Repo mappings valid without changing Backend paths
- retain direct Pool mappings only for committed cutover

## Test Plan

- `309 passed` across Skills Pool, Claude Code, AICoding, and Hermes focused suites
- changed-line coverage: `30/32 = 93.8%`
- Ruff check passed