### PR TITLE
feat(skills): support Gateway folder upload

### DIFF
--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -262,6 +262,7 @@ skills-local / skills-repo / skill-center / MCP projection
 | --- | --- | --- | --- |
 | GET | `/openapi/v1/bots/{bot_id}/skills` | Local Skill 列表 | 不传 `type` 时严格保持 Local-only |
 | POST | `/openapi/v1/bots/{bot_id}/skills` | raw ZIP 上传或同名替换 Local | 新建 inactive；替换保留 `skill_id` 和 active |
+| POST | `/openapi/v1/bots/{bot_id}/skills/upload-folder` | multipart 文件夹上传 | additive；复用旧 `/api/skills/upload` 的 `files + file_paths` 相对路径语义，结果与 raw ZIP 相同 |
 | GET | `/openapi/v1/bots/{bot_id}/skills/{skill_id}` | Local 详情 | 旧 wire 不变 |
 | DELETE | `/openapi/v1/bots/{bot_id}/skills/{skill_id}` | 删除 inactive Local 资产 | Repo/Space 不能复用为资产删除 |
 | POST | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/activate` | 激活 Skill | 旧 Local 不变；additive 支持 Repo/Space |
@@ -304,6 +305,30 @@ deactivate
 ```
 
 对 Repo/Space，Direct activate 即 runtime install，deactivate 即 runtime uninstall。Local deactivate 只删除 Installation，Local 资产保留。
+
+#### 5.3 Skill 添加来源与 Skill Center 懒物化
+
+添加弹窗读取三个独立目录：
+
+| 入口 | 接口 | 权威来源 |
+| --- | --- | --- |
+| TeamClaw 市场 | `GET /openapi/v1/bots/skills/repository` | aiworkbench 扫描得到的 `git://` Asset |
+| Skill Center 市场 | `POST /openapi/v1/bots/market/skill-center/skills` | Skill Center PUBLIC 市场；Gateway 固定 `team_id=None`、`access_level=PUBLIC` |
+| 工坊 Skill | `GET /openapi/v1/bots/spaces/{space_id}/skills/consumable` | 当前 Space 的 Published 且已物化 Version |
+
+旧 `POST /openapi/v1/bots/market/skills` 保留为 TeamClaw 市场兼容入口。Skill Center 的团队搜索不得作为工坊目录；TC 才是 Space、Grant、Draft 和消费状态的权威。
+
+Skill Center 市场有万级且持续增长的外部记录，禁止全量扫描/写入 `ac_skill`。用户确认引用时才按需物化，目标公开命令为：
+
+```text
+POST /openapi/v1/bots/{bot_id}/skill-sets/{set_id}/market-skill-references
+{
+  market_source: SKILLCENTER,
+  skill_code: <SkillCenter stable code>
+}
+```
+
+该命令的后续实现必须完成 SC 授权、稳定 `skillCode` 解析、TeamClaw 可消费引用的幂等物化，并仅在成功取得 TeamClaw `skill_id` 后写 `ac_skill_set_skill`。当前阶段只冻结合同；不得提前发布为可成功调用的 Gateway 路由。
 
 ### 6. Phase 1：Repo Catalog
 

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -262,7 +262,7 @@ skills-local / skills-repo / skill-center / MCP projection
 | --- | --- | --- | --- |
 | GET | `/openapi/v1/bots/{bot_id}/skills` | Local Skill 列表 | 不传 `type` 时严格保持 Local-only |
 | POST | `/openapi/v1/bots/{bot_id}/skills` | raw ZIP 上传或同名替换 Local | 新建 inactive；替换保留 `skill_id` 和 active |
-| POST | `/openapi/v1/bots/{bot_id}/skills/upload-folder` | multipart 文件夹上传 | additive；复用旧 `/api/skills/upload` 的 `files + file_paths` 相对路径语义，结果与 raw ZIP 相同 |
+| POST | `/openapi/v1/bots/{bot_id}/skills/upload-folder` | multipart 文件夹上传 | additive；沿用旧 `/api/skills/upload` 的 `files + file_paths` wire 语义，并与新 raw ZIP OpenAPI 共用 `LocalSkillUploadService` |
 | GET | `/openapi/v1/bots/{bot_id}/skills/{skill_id}` | Local 详情 | 旧 wire 不变 |
 | DELETE | `/openapi/v1/bots/{bot_id}/skills/{skill_id}` | 删除 inactive Local 资产 | Repo/Space 不能复用为资产删除 |
 | POST | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/activate` | 激活 Skill | 旧 Local 不变；additive 支持 Repo/Space |
@@ -305,6 +305,8 @@ deactivate
 ```
 
 对 Repo/Space，Direct activate 即 runtime install，deactivate 即 runtime uninstall。Local deactivate 只删除 Installation，Local 资产保留。
+
+旧 `/api/skills/upload` 的实现本期原样冻结，等待产品链路下线；不将其纳入新上传模块改造。新 OpenAPI 的 raw ZIP 与 multipart 文件夹入口必须在 HTTP 解码后汇入同一个 `LocalSkillUploadService.upload_local_skill()` 生命周期，共用包校验、同名替换、存储、DB 更新和失败补偿。
 
 #### 5.3 Skill 添加来源与 Skill Center 懒物化
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -40,8 +40,10 @@ themselves.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import StrEnum
 
+from agentclaw.community.adapters.http.openapi_v1.admission_modes import (
+    AdmissionMode,
+)
 from agentclaw.community.adapters.http.openapi_v1.errors import (
     GrantNotResolvableError,
 )
@@ -49,73 +51,8 @@ from agentclaw.community.adapters.http.openapi_v1.log_safe import for_log
 from agentclaw.community.api.bot_app_grant_service import BotAppGrantServiceProtocol
 from agentclaw.community.log import get_logger
 
+
 logger = get_logger()
-
-class AdmissionMode(StrEnum):
-    """How an operation treats a caller that names no end user.
-
-    Every mode answers one question — *an application is calling with no human
-    on the wire; what does this operation do about it?* — and what separates
-    them is two things: whether the operation names a bot, and **how it decides
-    which bot**.
-
-    That second part is the whole of the own-bot / addressed-bot split, and
-    it is not a
-    permission rule: both run the identical grant check. They differ only in
-    where the addressed bot's owner comes from, because ``bot_id`` alone does
-    not identify a bot.
-
-    **Each mode with something to enforce has a dependency that spells it**, so
-    a route's declaration and its table entry say the same thing in two places
-    and ``test_admission_inventory.py`` fails when they disagree:
-    ``require_granted_own_bot`` for own-bot, ``require_granted_addressed_bot``
-    for addressed-bot, ``refuse_app_only_caller`` for refused (all in
-    ``principal.py``). ``GRANT_FILTERED`` and ``USER_GATED`` cannot be a route
-    dependency — they shape the *result* through
-    :meth:`ActingCaller.granted_bot_ids` — and ``OPEN`` has nothing to declare.
-    """
-
-    #: **One bot, always the delegating user's own.** These groups resolve
-    #: through ``get_by_id_and_owner(bot_id, delegating user)``, so the owner is
-    #: that user by construction and the request cannot name another. Admitted
-    #: iff a live grant covers ``(app, bot, delegating user)``. Declared as
-    #: ``Depends(require_granted_own_bot)``, which never reads an owner off the
-    #: wire.
-    GRANT_CHECKED_OWN_BOT = "grant-checked"
-    #: **One bot, possibly someone else's.** The same check, against the bot
-    #: the request addresses: these operations publish an ``owner_id`` query
-    #: parameter that defaults to the caller's own, and the grant is looked up
-    #: on ``(app, bot, that owner, delegating user)``. Declared as
-    #: ``Depends(require_granted_addressed_bot)``, the one dependency entitled
-    #: to read that parameter.
-    #:
-    #: The owner therefore comes *from the request*, not from the grant record.
-    #: An earlier revision had it the other way round — the lookup asked "any
-    #: grant on this bot id" and took whatever owner came back — which was safe
-    #: only while the unique key happened to make that row singular.
-    GRANT_CHECKED_ADDRESSED_BOT = "grant-checked-owner-addressed"
-    #: **A set of bots, not one.** Admitted unconditionally; it is the *result*
-    #: that is narrowed, to the bots this application was granted. Refusing
-    #: outright would be wrong — the question "which bots may I reach?" is one
-    #: an application is entitled to ask, and the empty answer discloses nothing.
-    GRANT_FILTERED = "grant-filtered"
-    #: **No bot; the named user's account.** Nothing to scope to a bot, so the
-    #: gate is the relationship itself: admitted only while the application
-    #: holds at least one live grant from that user. A stranger application
-    #: therefore learns nothing about an account that never authorized it.
-    USER_GATED = "user-gated"
-    #: **No bot and no user.** The answer is identical for every authenticated
-    #: caller in the tenant — a name-availability check and the MCP catalogue —
-    #: so there is no scope to enforce and authentication alone is the bar.
-    OPEN = "open"
-    #: **Refused**, with a ``401``. Also what an operation *absent* from the
-    #: table gets, which is the point: a route added tomorrow is refused until
-    #: someone decides otherwise, rather than admitted because nobody noticed.
-    #: A *listed* refused operation additionally declares
-    #: ``Depends(refuse_app_only_caller)``, so the decision is visible on the
-    #: route and holds even if this table were mislabelled; the absent-by-default
-    #: refusal has no route to declare anything on and stays central.
-    REFUSED = "refused"
 
 
 #: Every public operation, keyed by ``(method, path)`` exactly as FastAPI

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -343,6 +343,10 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
         "/openapi/v1/bots/{bot_id}/skills",
     ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/skills/upload-folder",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
         "GET",
         "/openapi/v1/bots/{bot_id}/skills/{skill_id}",
     ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission_modes.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission_modes.py
@@ -1,0 +1,16 @@
+"""Admission modes shared by the public OpenAPI route inventory and edge seams."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class AdmissionMode(StrEnum):
+    """How an operation admits an application caller with no human on the wire."""
+
+    GRANT_CHECKED_OWN_BOT = "grant-checked"
+    GRANT_CHECKED_ADDRESSED_BOT = "grant-checked-owner-addressed"
+    GRANT_FILTERED = "grant-filtered"
+    USER_GATED = "user-gated"
+    OPEN = "open"
+    REFUSED = "refused"

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
@@ -385,6 +385,8 @@ AUTHORIZATION: dict[tuple[str, str], Authorization] = {
         ServiceChecked(PermissionLevel.MEMBER, "…core.skill_center.services.bot_skill_asset_service"),
     ("POST", "/openapi/v1/bots/{bot_id}/skills"):
         ServiceChecked(PermissionLevel.MEMBER, "…core.skill_center.services.bot_skill_asset_service"),
+    ("POST", "/openapi/v1/bots/{bot_id}/skills/upload-folder"):
+        ServiceChecked(PermissionLevel.MEMBER, "…core.skill_center.services.bot_skill_asset_service"),
     ("DELETE", "/openapi/v1/bots/{bot_id}/skills/{skill_id}"):
         ServiceChecked(PermissionLevel.MEMBER, "…core.skill_center.services.bot_skill_asset_service"),
     ("GET", "/openapi/v1/bots/{bot_id}/skills/{skill_id}"):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
@@ -10,8 +10,7 @@ from __future__ import annotations
 import json
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Body, Depends, Path, Query, Request, Response
-
+from agentclaw.community.adapters.http.openapi_v1.admission import ActingCaller
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     EXAMPLE_TRACE_ID,
     BotIdPath,
@@ -21,7 +20,6 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Page,
     PageParamsDep,
 )
-from agentclaw.community.adapters.http.openapi_v1.admission import ActingCaller
 from agentclaw.community.adapters.http.openapi_v1.authorization import PublicAPIRoute
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.params import (
     OwnerIdDep,
@@ -35,19 +33,21 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import require_pr
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
+)
+from agentclaw.community.adapters.http.openapi_v1.responses import (
     page as page_envelope,
 )
-from agentclaw.community.api.local_skill_upload_service import (
-    LocalSkillUploadServiceProtocol,
-)
-from agentclaw.community.api.local_skill_query_service import (
-    LocalSkillQueryServiceProtocol,
+from agentclaw.community.api.bot_skill_asset_service import (
+    BotSkillAssetServiceProtocol,
 )
 from agentclaw.community.api.local_skill_delete_service import (
     LocalSkillDeleteServiceProtocol,
 )
-from agentclaw.community.api.bot_skill_asset_service import (
-    BotSkillAssetServiceProtocol,
+from agentclaw.community.api.local_skill_query_service import (
+    LocalSkillQueryServiceProtocol,
+)
+from agentclaw.community.api.local_skill_upload_service import (
+    LocalSkillUploadServiceProtocol,
 )
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillInvalidPackageError,
@@ -66,6 +66,18 @@ from .schemas import (
     SkillPublishStatus,
     SkillState,
     SkillUpload,
+)
+from fastapi import (
+    APIRouter,
+    Body,
+    Depends,
+    File,
+    Form,
+    Path,
+    Query,
+    Request,
+    Response,
+    UploadFile,
 )
 
 publish_status_router = APIRouter(
@@ -192,6 +204,40 @@ def _to_skill(record: dict[str, Any]) -> Skill:
         created_at=record.get("gmt_created"),
         updated_at=record.get("gmt_modified"),
     )
+
+
+def _uploaded_skill_response(
+    result: dict[str, Any], request: Request, response: Response
+) -> Envelope[SkillUpload]:
+    operation = str(result["operation"])
+    if operation == "updated":
+        response.status_code = 200
+    return envelope(
+        SkillUpload(operation=operation, skill=_to_skill(result["skill"])),
+        request,
+        code=201000 if operation == "created" else 200000,
+        message="Created" if operation == "created" else "OK",
+    )
+
+
+def _directory_relative_paths(
+    raw_paths: str | None, files: list[UploadFile]
+) -> list[str]:
+    """Preserve the legacy multipart folder wire without trusting filenames."""
+    if raw_paths is None:
+        paths = [file.filename or "" for file in files]
+    else:
+        try:
+            paths = json.loads(raw_paths)
+        except json.JSONDecodeError as exc:
+            raise LocalSkillInvalidPackageError() from exc
+        if not isinstance(paths, list) or not all(
+            isinstance(path, str) for path in paths
+        ):
+            raise LocalSkillInvalidPackageError()
+    if len(paths) != len(files):
+        raise LocalSkillInvalidPackageError()
+    return paths
 
 
 @router.get(
@@ -428,15 +474,63 @@ async def upload_skill(
         actor_id=user_id,
         package=package,
     )
-    operation = str(result["operation"])
-    if operation == "updated":
-        response.status_code = 200
-    return envelope(
-        SkillUpload(operation=operation, skill=_to_skill(result["skill"])),
-        request,
-        code=201000 if operation == "created" else 200000,
-        message="Created" if operation == "created" else "OK",
+    return _uploaded_skill_response(result, request, response)
+
+
+@router.post(
+    "/upload-folder",
+    status_code=201,
+    dependencies=_GRANT_CHECKED_ADDRESSED_BOT,
+    response_model=Envelope[SkillUpload],
+    responses={
+        200: {
+            "model": Envelope[SkillUpload],
+            "description": "Existing Local Skill safely replaced.",
+        },
+        413: {
+            "model": ErrorEnvelope,
+            "description": "Directory package exceeds an upload limit.",
+        },
+    },
+)
+@envelope_errors
+async def upload_skill_folder(
+    bot_id: BotIdPath,
+    user_id: UserIdDep,
+    request: Request,
+    response: Response,
+    owner_id: OwnerIdDep,
+    files: list[UploadFile] = File(
+        ..., description="Files selected from exactly one local Skill directory."
+    ),
+    file_paths: str | None = Form(
+        default=None,
+        description=(
+            "JSON array of relative paths aligned one-to-one with files. "
+            "When omitted, each uploaded filename is used as its relative path."
+        ),
+    ),
+    upload_service: LocalSkillUploadServiceProtocol = Injected(
+        LocalSkillUploadServiceProtocol
+    ),
+) -> Envelope[SkillUpload]:
+    """Upload a browser-selected local Skill directory.
+
+    This preserves the legacy multipart ``files`` + ``file_paths`` contract.
+    The Service API converts the directory into the exact same validated
+    package authority as the existing raw-ZIP endpoint.
+    """
+    paths = _directory_relative_paths(file_paths, files)
+    uploaded = [
+        (path, await file.read()) for path, file in zip(paths, files, strict=True)
+    ]
+    result = await upload_service.upload_local_skill_files(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        actor_id=user_id,
+        files=uploaded,
     )
+    return _uploaded_skill_response(result, request, response)
 
 
 @router.post(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
@@ -62,6 +62,7 @@ from agentclaw.community.plugin_api.skill_center_client import (
 from .schemas import (
     Skill,
     SkillContent,
+    SkillFolderUpload,
     SkillParameters,
     SkillPublishStatus,
     SkillState,
@@ -71,7 +72,6 @@ from fastapi import (
     APIRouter,
     Body,
     Depends,
-    File,
     Form,
     Path,
     Query,
@@ -500,29 +500,21 @@ async def upload_skill_folder(
     request: Request,
     response: Response,
     owner_id: OwnerIdDep,
-    files: list[UploadFile] = File(
-        ..., description="Files selected from exactly one local Skill directory."
-    ),
-    file_paths: str | None = Form(
-        default=None,
-        description=(
-            "JSON array of relative paths aligned one-to-one with files. "
-            "When omitted, each uploaded filename is used as its relative path."
-        ),
-    ),
+    payload: Annotated[SkillFolderUpload, Form(media_type="multipart/form-data")],
     upload_service: LocalSkillUploadServiceProtocol = Injected(
         LocalSkillUploadServiceProtocol
     ),
 ) -> Envelope[SkillUpload]:
     """Upload a browser-selected local Skill directory.
 
-    This preserves the legacy multipart ``files`` + ``file_paths`` contract.
+    This preserves the legacy multipart files and file_paths contract.
     The Service API converts the directory into the exact same validated
     package authority as the existing raw-ZIP endpoint.
     """
-    paths = _directory_relative_paths(file_paths, files)
+    paths = _directory_relative_paths(payload.file_paths, payload.files)
     uploaded = [
-        (path, await file.read()) for path, file in zip(paths, files, strict=True)
+        (path, await file.read())
+        for path, file in zip(paths, payload.files, strict=True)
     ]
     result = await upload_service.upload_local_skill_files(
         bot_id=bot_id,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/schemas.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from fastapi import UploadFile
+from pydantic import BaseModel, ConfigDict, Field, create_model
 
 
 class Skill(BaseModel):
@@ -167,6 +168,30 @@ class SkillUpload(BaseModel):
         "keeping its id and active state; answers 200."
     )
     skill: Skill = Field(description="The skill as stored after the upload.")
+
+
+# Keep this pre-existing generated component name stable for clients that have
+# already generated multipart request types from the Gateway OpenAPI document.
+SkillFolderUpload = create_model(
+    "Body_upload_skill_folder_openapi_v1_bots__bot_id__skills_upload_folder_post",
+    __base__=BaseModel,
+    __config__=ConfigDict(
+        json_schema_extra={
+            "description": "Files and optional relative paths for one local Skill directory."
+        }
+    ),
+    files=(
+        list[UploadFile],
+        Field(description="All files from the selected local Skill directory."),
+    ),
+    file_paths=(
+        str | None,
+        Field(
+            default=None,
+            description="Optional JSON array of relative paths aligned one-to-one with files.",
+        ),
+    ),
+)
 
 
 class SkillState(BaseModel):

--- a/src/backend/src/agentclaw/community/api/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/api/local_skill_upload_service.py
@@ -2,13 +2,29 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any, Protocol, runtime_checkable
 
 
 @runtime_checkable
 class LocalSkillUploadServiceProtocol(Protocol):
-    """Create or safely replace one Bot-owned Local Skill from a ZIP package."""
+    """Create or safely replace one Bot-owned Local Skill from a complete package."""
 
     async def upload_local_skill(
         self, *, bot_id: str, owner_id: str, actor_id: str, package: bytes
     ) -> dict[str, Any]: ...
+
+    async def upload_local_skill_files(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        actor_id: str,
+        files: Sequence[tuple[str, bytes]],
+    ) -> dict[str, Any]:
+        """Create or replace from one browser-selected directory's files.
+
+        Each tuple is ``(relative_path, content)``.  The Service API owns the
+        conversion to the same validated package contract as raw ZIP upload.
+        """
+        ...

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -10,43 +10,49 @@ import io
 import json
 import re
 import zipfile
-from typing import Any, Callable, TYPE_CHECKING
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Callable
 from uuid import uuid4
-
-from injector import inject
 
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_collaborator.protocols import (
     CollaboratorServiceProtocol,
 )
-from agentclaw.community.core.repository.protocols.bot import BotCollabLogRepositoryProtocol
-from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.bot_management.readiness import is_bot_ready
+from agentclaw.community.core.repository.protocols.bot import (
+    BotCollabLogRepositoryProtocol,
+    BotRepository,
+)
+from agentclaw.community.core.repository.protocols.skill_center import (
+    LocalSkillCleanupRepository,
+    SkillRepository,
+    SkillSetRepository,
+)
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillDuplicateError,
     LocalSkillEditBusyError,
     LocalSkillEditLockUnavailableError,
     LocalSkillEditPausedError,
     LocalSkillInvalidPackageError,
+    LocalSkillLayoutRollbackError,
     LocalSkillNotReadyError,
     LocalSkillRuntimeSyncError,
     LocalSkillStorageError,
     LocalSkillTooLargeError,
-    LocalSkillLayoutRollbackError,
 )
-from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
-from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
-from agentclaw.community.core.skill_center.services.skill_parser import (
-    SkillManifestError,
-    SkillParser,
+from agentclaw.community.core.skill_center.factories import (
+    SkillServiceFactory,
 )
 from agentclaw.community.core.skill_center.runtime_policy import (
     require_supported_bot_skill_runtime,
 )
-from agentclaw.community.core.bot_management.readiness import is_bot_ready
-from agentclaw.community.core.skill_center.factories import (
-    SkillServiceFactory,
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    BotRuntimeProjectionReconcilerProtocol,
 )
-from agentclaw.community.core.repository.protocols.skill_center import LocalSkillCleanupRepository
+from agentclaw.community.core.skill_center.services.skill_parser import (
+    SkillManifestError,
+    SkillParser,
+)
 from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditBusyError,
     SkillsPoolEditGuard,
@@ -55,9 +61,7 @@ from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditRollbackError,
 )
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
-from agentclaw.community.core.skill_center.runtime_projection_contract import (
-    BotRuntimeProjectionReconcilerProtocol,
-)
+from injector import inject
 
 if TYPE_CHECKING:
     from agentclaw.community.core.devices.services.device_context_resolver import (
@@ -177,6 +181,32 @@ class LocalSkillUploadService:
             )
         finally:
             self._edit_guard.release(lease)
+
+    async def upload_local_skill_files(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        actor_id: str,
+        files: Sequence[tuple[str, bytes]],
+    ) -> dict[str, Any]:
+        """Accept a browser directory selection through the ZIP authority.
+
+        The old product API represents a directory as a flat multipart file
+        list plus relative paths.  Repackage it once here, then reuse the
+        complete ZIP validation, same-name replacement and compensation flow.
+        """
+        package = (
+            files[0][1]
+            if len(files) == 1 and files[0][0].endswith(".zip")
+            else self._pack_directory(files)
+        )
+        return await self.upload_local_skill(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            actor_id=actor_id,
+            package=package,
+        )
 
     async def _create(
         self,
@@ -472,9 +502,8 @@ class LocalSkillUploadService:
             restored = self._skill_repo.update(skill["id"], old_metadata)
             if restored is None:
                 raise LocalSkillStorageError()
-            if (
-                runtime_sync_attempted
-                and not await self._sync_runtime(owner_id, bot_id)
+            if runtime_sync_attempted and not await self._sync_runtime(
+                owner_id, bot_id
             ):
                 # Runtime may have switched partway before reporting failure.
                 # Keep the complete staged package until a later serialized
@@ -578,9 +607,9 @@ class LocalSkillUploadService:
                     int(work["id"]), bot, owner_id, bot_id
                 )
                 continue
-            if bool(work.get("requires_runtime_restore")) and not await self._sync_runtime(
-                owner_id, bot_id
-            ):
+            if bool(
+                work.get("requires_runtime_restore")
+            ) and not await self._sync_runtime(owner_id, bot_id):
                 if not self._cleanup_repo.mark_failed(
                     work_id=int(work["id"]),
                     env=str(bot["env"]),
@@ -642,9 +671,12 @@ class LocalSkillUploadService:
             skill = self._skill_repo.get_by_id(str(skill_id))
             if skill and skill.get("git_path") == f"local://{locator}":
                 return True
-        return self._skill_repo.get_bot_local_by_locator(
-            bot_id=bot_id, user_id=owner_id, locator=locator
-        ) is not None
+        return (
+            self._skill_repo.get_bot_local_by_locator(
+                bot_id=bot_id, user_id=owner_id, locator=locator
+            )
+            is not None
+        )
 
     def _same_name_matches(
         self, *, bot_id: str, owner_id: str, name: str
@@ -791,3 +823,51 @@ class LocalSkillUploadService:
             raise LocalSkillInvalidPackageError()
         normalized = [(p[len(wrapper) + 1 :] if wrapper else p, c) for p, c in files]
         return name, description, normalized
+
+    @staticmethod
+    def _pack_directory(files: Sequence[tuple[str, bytes]]) -> bytes:
+        """Encode directory files without trusting browser-provided paths."""
+        if not files or len(files) > _MAX_FILES:
+            raise LocalSkillInvalidPackageError()
+        seen: set[str] = set()
+        total = 0
+        stream = io.BytesIO()
+        try:
+            with zipfile.ZipFile(
+                stream, mode="w", compression=zipfile.ZIP_DEFLATED
+            ) as archive:
+                for path, content in files:
+                    if not isinstance(path, str) or not isinstance(content, bytes):
+                        raise LocalSkillInvalidPackageError()
+                    if (
+                        not path
+                        or path.startswith(("/", "\\"))
+                        or re.match(r"^[A-Za-z]:", path) is not None
+                        or "\\" in path
+                        or any(part == "" for part in path.split("/"))
+                        or ".." in path.split("/")
+                        or len(path) > 256
+                    ):
+                        raise LocalSkillInvalidPackageError()
+                    normalized = "/".join(
+                        part for part in path.split("/") if part not in ("", ".")
+                    )
+                    if not normalized or normalized in seen:
+                        raise LocalSkillInvalidPackageError()
+                    if len(content) > _MAX_FILE:
+                        raise LocalSkillTooLargeError()
+                    total += len(content)
+                    if total > _MAX_EXPANDED:
+                        raise LocalSkillTooLargeError()
+                    seen.add(normalized)
+                    archive.writestr(normalized, content)
+        except LocalSkillInvalidPackageError:
+            raise
+        except LocalSkillTooLargeError:
+            raise
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise LocalSkillInvalidPackageError() from exc
+        package = stream.getvalue()
+        if len(package) > _MAX_COMPRESSED:
+            raise LocalSkillTooLargeError()
+        return package

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
@@ -94,6 +94,7 @@ _OWNER_ADDRESSED_ELSEWHERE = {
     # bot-first change, which is why it was not in this set before.
     ("get", "/openapi/v1/bots/{bot_id}/skills"),
     ("post", "/openapi/v1/bots/{bot_id}/skills"),
+    ("post", "/openapi/v1/bots/{bot_id}/skills/upload-folder"),
     # The product chat reads address a bot that may be shared with the acting
     # user, so they take the owner half of ``(owner, bot_id)`` for the same
     # reason and with the same default — the caller's own bot.

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -367,10 +367,7 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: ``path`` then moved 132 → 133 with the BCS publish-to-users operation
 #: (``POST /openapi/v1/bots/{bot_id}/public-bcs``): it addresses a bot and acts
 #: for the operator, so it is bot-path-addressed like the rest of the surface.
-#: The two IAM operations then merged into one Bot-addressed operation: the
-#: existing Caller path was renamed while the account-level IAM read went away,
-#: so ``path`` stays unchanged and ``none`` decreases by one.
-_BOT_ID_PLACEMENT = {"path": 139, "query": 1, "none": 57}
+_BOT_ID_PLACEMENT = {"path": 140, "query": 1, "none": 57}
 
 
 def _schema() -> dict:
@@ -466,7 +463,7 @@ def test_the_pinned_number_of_operations_take_it():
     # operations, Repo Catalog adds seven operations, SkillSet adds eleven, and
     # MCP adds eight operations, the Harness surface adds six Bot-addressed
     # operations, and Session File adds six more.
-    assert len(taking) == 177
+    assert len(taking) == 178
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_contract.py
@@ -22,6 +22,7 @@ def test_openapi_exposes_local_compatibility_and_skill_asset_operations() -> Non
 
     assert skill_paths == {
         "/openapi/v1/bots/{bot_id}/skills": {"get", "post"},
+        "/openapi/v1/bots/{bot_id}/skills/upload-folder": {"post"},
         "/openapi/v1/bots/{bot_id}/skills/{skill_id}": {"get", "delete"},
         "/openapi/v1/bots/{bot_id}/skills/{skill_id}/activate": {"post"},
         "/openapi/v1/bots/{bot_id}/skills/{skill_id}/deactivate": {"post"},
@@ -49,6 +50,10 @@ def test_collection_and_upload_are_bot_addressed_contracts() -> None:
     assert upload_parameters["bot_id"]["in"] == "path"
     assert upload_parameters["owner_id"]["required"] is False
     assert set(upload["requestBody"]["content"]) == {"application/zip"}
+
+    folder_upload = paths["/openapi/v1/bots/{bot_id}/skills/upload-folder"]["post"]
+    assert folder_upload["parameters"][0]["name"] == "bot_id"
+    assert set(folder_upload["requestBody"]["content"]) == {"multipart/form-data"}
 
 
 def test_operation_responses_use_the_ratified_local_skill_models() -> None:

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 from contextlib import contextmanager
 
@@ -15,36 +16,39 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
-from tests.community.adapters.http.openapi_v1.conftest import (
-    user_scoped_client,
-)
 from agentclaw.community.adapters.http.openapi_v1.contracts import EXAMPLE_TRACE_ID
 from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     PRINCIPAL_HEADER,
     require_principal,
 )
 from agentclaw.community.adapters.http.openapi_v1.skills.router import router
-from agentclaw.community.api.local_skill_query_service import (
-    LocalSkillQueryServiceProtocol,
-)
-from agentclaw.community.api.local_skill_upload_service import (
-    LocalSkillUploadServiceProtocol,
-)
-from agentclaw.community.api.local_skill_state_service import (
-    LocalSkillStateServiceProtocol,
+from agentclaw.community.api.bot_skill_asset_service import (
+    BotSkillAssetServiceProtocol,
 )
 from agentclaw.community.api.local_skill_delete_service import (
     LocalSkillDeleteServiceProtocol,
 )
-from agentclaw.community.api.bot_skill_asset_service import (
-    BotSkillAssetServiceProtocol,
+from agentclaw.community.api.local_skill_query_service import (
+    LocalSkillQueryServiceProtocol,
+)
+from agentclaw.community.api.local_skill_state_service import (
+    LocalSkillStateServiceProtocol,
+)
+from agentclaw.community.api.local_skill_upload_service import (
+    LocalSkillUploadServiceProtocol,
 )
 from agentclaw.community.core.models.skill import BotSkillInstallation, Skill
+from agentclaw.community.core.repository.implementations.bot.bot import BotRepository
+from agentclaw.community.core.repository.implementations.skill_center.skill import (
+    SkillRepository,
+    SkillSetRepository,
+)
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillActiveError,
     LocalSkillNotFoundError,
     LocalSkillOwnerAmbiguousError,
 )
+from agentclaw.community.core.skill_center.orm import DefaultSkillsetSkillExclusion
 from agentclaw.community.core.skill_center.services.local_skill_query_service import (
     LocalSkillQueryService,
 )
@@ -53,16 +57,13 @@ from agentclaw.community.core.skill_center.services.local_skill_state_service im
 )
 from agentclaw.community.plugin_api.models import BotModel
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
-from agentclaw.community.core.repository.implementations.bot.bot import BotRepository
-from agentclaw.community.core.skill_center.orm import DefaultSkillsetSkillExclusion
-from agentclaw.community.core.repository.implementations.skill_center.skill import (
-    SkillRepository,
-    SkillSetRepository,
-)
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
 from agentclaw.community.utils.gateway_principal_config import (
     init_principal_verifier_config,
     reset_principal_verifier_config_cache,
+)
+from tests.community.adapters.http.openapi_v1.conftest import (
+    user_scoped_client,
 )
 
 
@@ -114,6 +115,10 @@ class _Upload:
                 "gmt_modified": "2026-08-04T00:00:00",
             },
         }
+
+    async def upload_local_skill_files(self, **kwargs):
+        self.folder_args = kwargs
+        return await self.upload_local_skill(**kwargs)
 
 
 class _State:
@@ -259,6 +264,76 @@ def test_upload_rejects_multipart_and_other_content_types_before_service_call():
         )
         assert response.status_code == 400
         assert response.json()["code"] == 400101
+
+
+def test_upload_folder_preserves_legacy_file_paths_and_returns_created_skill():
+    query = _Query()
+    upload = _Upload()
+
+    class Bindings(Module):
+        def configure(self, binder):
+            binder.bind(LocalSkillQueryServiceProtocol, to=query)
+            binder.bind(LocalSkillUploadServiceProtocol, to=upload)
+            binder.bind(LocalSkillStateServiceProtocol, to=_State())
+            binder.bind(LocalSkillDeleteServiceProtocol, to=_Delete())
+            binder.bind(BotSkillAssetServiceProtocol, to=_Asset())
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_principal] = lambda: {"user_id": "actor"}
+    attach_injector(app, Injector([Bindings()]))
+    client = user_scoped_client(app, "actor")
+
+    response = client.post(
+        "/openapi/v1/bots/bot-1/skills/upload-folder",
+        data={"file_paths": json.dumps(["folder/SKILL.md", "folder/scripts/check.py"])},
+        files=[
+            ("files", ("SKILL.md", b"---\nname: folder\n---", "text/markdown")),
+            ("files", ("check.py", b"print('ok')", "text/plain")),
+        ],
+    )
+
+    assert response.status_code == 201
+    assert upload.folder_args == {
+        "bot_id": "bot-1",
+        "owner_id": "actor",
+        "actor_id": "actor",
+        "files": [
+            ("folder/SKILL.md", b"---\nname: folder\n---"),
+            ("folder/scripts/check.py", b"print('ok')"),
+        ],
+    }
+
+
+def test_upload_folder_rejects_misaligned_paths_before_service_call():
+    query = _Query()
+    upload = _Upload()
+
+    class Bindings(Module):
+        def configure(self, binder):
+            binder.bind(LocalSkillQueryServiceProtocol, to=query)
+            binder.bind(LocalSkillUploadServiceProtocol, to=upload)
+            binder.bind(LocalSkillStateServiceProtocol, to=_State())
+            binder.bind(LocalSkillDeleteServiceProtocol, to=_Delete())
+            binder.bind(BotSkillAssetServiceProtocol, to=_Asset())
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[require_principal] = lambda: {"user_id": "actor"}
+    attach_injector(app, Injector([Bindings()]))
+    client = user_scoped_client(app, "actor")
+
+    response = client.post(
+        "/openapi/v1/bots/bot-1/skills/upload-folder",
+        data={"file_paths": json.dumps(["folder/SKILL.md"])},
+        files=[
+            ("files", ("SKILL.md", b"manifest", "text/markdown")),
+            ("files", ("check.py", b"print('ok')", "text/plain")),
+        ],
+    )
+
+    assert response.status_code == 400
+    assert not hasattr(upload, "folder_args")
 
 
 def test_activate_and_deactivate_derive_scope_from_id_and_return_desired_state():
@@ -427,6 +502,7 @@ def test_openapi_declares_local_compatibility_and_skill_asset_operations():
     }
     assert {path: set(operations) for path, operations in skill_paths.items()} == {
         "/openapi/v1/bots/{bot_id}/skills": {"get", "post"},
+        "/openapi/v1/bots/{bot_id}/skills/upload-folder": {"post"},
         "/openapi/v1/bots/{bot_id}/skills/{skill_id}": {"get", "delete"},
         "/openapi/v1/bots/{bot_id}/skills/{skill_id}/activate": {"post"},
         "/openapi/v1/bots/{bot_id}/skills/{skill_id}/deactivate": {"post"},
@@ -452,6 +528,11 @@ def test_openapi_declares_local_compatibility_and_skill_asset_operations():
     upload = schema["paths"]["/openapi/v1/bots/{bot_id}/skills"]["post"]
     assert {"200", "201", "413"} <= set(upload["responses"])
     assert set(upload["requestBody"]["content"]) == {"application/zip"}
+    folder_upload = schema["paths"]["/openapi/v1/bots/{bot_id}/skills/upload-folder"][
+        "post"
+    ]
+    assert {"200", "201", "413"} <= set(folder_upload["responses"])
+    assert set(folder_upload["requestBody"]["content"]) == {"multipart/form-data"}
     error_example = upload["responses"]["413"]["content"]["application/json"]["example"]
     # request_id carries the surface-wide illustrative trace id, so rendered
     # samples show a realistic value instead of an empty placeholder.
@@ -470,7 +551,14 @@ def test_openapi_declares_local_compatibility_and_skill_asset_operations():
     }
     for path, methods in skill_paths.items():
         for method, operation in methods.items():
-            if path != "/openapi/v1/bots/{bot_id}/skills" or method != "post":
+            if (
+                path
+                not in {
+                    "/openapi/v1/bots/{bot_id}/skills",
+                    "/openapi/v1/bots/{bot_id}/skills/upload-folder",
+                }
+                or method != "post"
+            ):
                 assert "413" not in operation.get("responses", {})
     for status in ("200", "201"):
         assert upload["responses"][status]["content"]["application/json"]["schema"][

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -8,23 +8,22 @@ import zipfile
 from types import SimpleNamespace
 
 import pytest
-
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillEditBusyError,
     LocalSkillEditLockUnavailableError,
-    LocalSkillLayoutRollbackError,
     LocalSkillInvalidPackageError,
+    LocalSkillLayoutRollbackError,
     LocalSkillNotReadyError,
     LocalSkillRuntimeSyncError,
     LocalSkillStorageError,
     SkillEngineNotSupportedError,
 )
-from agentclaw.community.core.skill_center.services.local_skill_upload_service import (
-    LocalSkillUploadService,
-)
 from agentclaw.community.core.skill_center.factories import LocalSkillPackageStorage
 from agentclaw.community.core.skill_center.services import (
     local_skill_upload_service as upload_module,
+)
+from agentclaw.community.core.skill_center.services.local_skill_upload_service import (
+    LocalSkillUploadService,
 )
 from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditBusyError,
@@ -713,6 +712,44 @@ async def test_upload_stays_inactive_without_creating_a_default_set_membership()
 
 
 @pytest.mark.asyncio
+async def test_directory_upload_uses_the_same_create_flow_as_raw_zip():
+    filesystem = _Filesystem()
+    result = await _service(filesystem).upload_local_skill_files(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="owner",
+        files=[
+            ("folder-skill/SKILL.md", _skill_md("folder-skill")),
+            ("folder-skill/scripts/main.py", b"print('ok')"),
+        ],
+    )
+
+    assert result["operation"] == "created"
+    assert filesystem.files == {
+        "/private/skills-local/folder-skill/SKILL.md": _skill_md("folder-skill"),
+        "/private/skills-local/folder-skill/scripts/main.py": b"print('ok')",
+    }
+
+
+@pytest.mark.asyncio
+async def test_multipart_single_zip_keeps_legacy_auto_extract_behavior():
+    filesystem = _Filesystem()
+    archive = _zip({"SKILL.md": _skill_md("archive-skill")})
+
+    result = await _service(filesystem).upload_local_skill_files(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="owner",
+        files=[("archive.zip", archive)],
+    )
+
+    assert result["skill"]["name"] == "archive-skill"
+    assert filesystem.files["/private/skills-local/archive-skill/SKILL.md"] == _skill_md(
+        "archive-skill"
+    )
+
+
+@pytest.mark.asyncio
 async def test_not_ready_and_storage_failure_leave_no_public_skill():
     package = _zip({"SKILL.md": _skill_md()})
     with pytest.raises(LocalSkillNotReadyError):
@@ -880,9 +917,7 @@ class _FailAudit(_Audit):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "stage", ["write", "create", "audit"]
-)
+@pytest.mark.parametrize("stage", ["write", "create", "audit"])
 async def test_each_creation_failure_compensates_and_never_returns_success(stage):
     package = _zip({"SKILL.md": _skill_md()})
     filesystem = _Filesystem(fail=stage == "write")
@@ -1421,3 +1456,28 @@ async def test_concurrent_same_name_uploads_serialize_then_converge_on_one_skill
     assert {first["operation"], second["operation"]} == {"created", "updated"}
     assert len(repo.rows) == 1
     assert first["skill"]["id"] == second["skill"]["id"] == "9"
+
+
+def test_directory_package_uses_the_same_wrapper_normalization_as_zip_upload():
+    package = LocalSkillUploadService._pack_directory(
+        [
+            ("weather/SKILL.md", _skill_md(name="weather")),
+            ("weather/scripts/fetch.py", b"print('weather')"),
+        ]
+    )
+
+    name, description, files = LocalSkillUploadService._unpack(package)
+
+    assert name == "weather"
+    assert description == "useful"
+    assert files == [
+        ("SKILL.md", _skill_md(name="weather")),
+        ("scripts/fetch.py", b"print('weather')"),
+    ]
+
+
+def test_directory_package_rejects_path_traversal_before_it_can_be_archived():
+    with pytest.raises(LocalSkillInvalidPackageError):
+        LocalSkillUploadService._pack_directory(
+            [("skill/../outside/SKILL.md", _skill_md())]
+        )

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -1476,6 +1476,56 @@ def test_directory_package_uses_the_same_wrapper_normalization_as_zip_upload():
     ]
 
 
+@pytest.mark.asyncio
+async def test_directory_upload_reuses_the_raw_zip_upload_lifecycle():
+    class _CapturingUploadService(LocalSkillUploadService):
+        def __init__(self) -> None:
+            self.call: dict[str, object] | None = None
+
+        async def upload_local_skill(
+            self,
+            *,
+            bot_id: str,
+            owner_id: str,
+            actor_id: str,
+            package: bytes,
+        ) -> dict[str, object]:
+            self.call = {
+                "bot_id": bot_id,
+                "owner_id": owner_id,
+                "actor_id": actor_id,
+                "package": package,
+            }
+            return {"operation": "created"}
+
+    service = _CapturingUploadService()
+    result = await service.upload_local_skill_files(
+        bot_id="bot",
+        owner_id="owner",
+        actor_id="collaborator",
+        files=[
+            ("weather/SKILL.md", _skill_md(name="weather")),
+            ("weather/scripts/fetch.py", b"print('weather')"),
+        ],
+    )
+
+    assert result == {"operation": "created"}
+    assert service.call is not None
+    assert service.call.keys() == {"bot_id", "owner_id", "actor_id", "package"}
+    assert service.call["bot_id"] == "bot"
+    assert service.call["owner_id"] == "owner"
+    assert service.call["actor_id"] == "collaborator"
+    name, description, files = LocalSkillUploadService._unpack(
+        service.call["package"]  # type: ignore[arg-type]
+    )
+    assert name == "weather"
+    assert description == "useful"
+    assert files == [
+        ("SKILL.md", _skill_md(name="weather")),
+        ("scripts/fetch.py", b"print('weather')"),
+    ]
+
+
 def test_directory_package_rejects_path_traversal_before_it_can_be_archived():
     with pytest.raises(LocalSkillInvalidPackageError):
         LocalSkillUploadService._pack_directory(

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -912,8 +912,6 @@ def test_resources_keeps_ordinary_mcp_membership_on_canonical_repository_path():
         legacy_factory=legacy,
         passport=object(),
         authorization=_Collaborators(),
-        mutation_guard=_MutationGuard(),
-        edit_guard=_Guard(),
         audit_log_repo=_Audit(),
         mcp_center=_McpCenter(allowed=True),
         mcp_auth=_McpAuth(allowed=True),

--- a/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_upload.py
@@ -271,6 +271,52 @@ def multipart_upload_is_an_explicit_error_case():
     """The public endpoint accepts only raw ``application/zip`` bodies."""
 
 
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/skills/upload-folder",
+    scenario="directory_created_in_verified_tenant",
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID},
+        query_params={"user_id": _OWNER},
+        headers={PRINCIPAL_HEADER: _principal()},
+        form_data={"file_paths": '["SKILL.md"]'},
+        files=[("files", ("SKILL.md", b"name: folder-upload\ndescription: folder coverage\n"))],
+    ),
+    seed=_seed_uploadable_bot,
+    extra_assertions=(_assert_created_inactive_without_default_membership,),
+    expect=ExpectSuccess(
+        status=201,
+        json_contains={
+            "code": 201000,
+            "data": {
+                "operation": "created",
+                "skill": {"name": "folder-upload", "active": False},
+            },
+        },
+    ),
+)
+def folder_upload_creates_an_inactive_skill():
+    """A multipart directory upload follows the same inactive Local contract."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/skills/upload-folder",
+    scenario="directory_rejects_misaligned_relative_paths",
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID},
+        query_params={"user_id": _OWNER},
+        headers={PRINCIPAL_HEADER: _principal()},
+        form_data={"file_paths": '["SKILL.md", "extra.py"]'},
+        files=[("files", ("SKILL.md", b"name: folder-upload\n"))],
+    ),
+    seed=_seed_uploadable_bot,
+    expect=ExpectError(status=400),
+)
+def folder_upload_rejects_misaligned_relative_paths():
+    """The declared paths must remain one-to-one with uploaded files."""
+
+
 # The retiring address. `POST /openapi/v1/bots/skills/upload?bot_id=` is what
 # clients call today, and it is not a re-registration: the shim publishes
 # `bot_id` in the query and `owner_entity_id` where the current address

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -359,6 +359,37 @@
         "title": "BcsPublishResult",
         "type": "object"
       },
+      "Body_upload_skill_folder_openapi_v1_bots__bot_id__skills_upload_folder_post": {
+        "description": "Files and optional relative paths for one local Skill directory.",
+        "properties": {
+          "file_paths": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional JSON array of relative paths aligned one-to-one with files.",
+            "title": "File Paths"
+          },
+          "files": {
+            "description": "All files from the selected local Skill directory.",
+            "items": {
+              "contentMediaType": "application/octet-stream",
+              "type": "string"
+            },
+            "title": "Files",
+            "type": "array"
+          }
+        },
+        "required": [
+          "files"
+        ],
+        "title": "Body_upload_skill_folder_openapi_v1_bots__bot_id__skills_upload_folder_post",
+        "type": "object"
+      },
       "Bot": {
         "description": "An agent (bot) record.",
         "example": {
@@ -61588,6 +61619,222 @@
           }
         },
         "summary": "Upload Skill",
+        "tags": [
+          "skills"
+        ]
+      }
+    },
+    "/openapi/v1/bots/{bot_id}/skills/upload-folder": {
+      "post": {
+        "description": "Upload a browser-selected local Skill directory.\n\nThis preserves the legacy multipart files and file_paths contract.\nThe Service API converts the directory into the exact same validated\npackage authority as the existing raw-ZIP endpoint.",
+        "operationId": "upload_skill_folder_openapi_v1_bots__bot_id__skills_upload_folder_post",
+        "parameters": [
+          {
+            "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+            "in": "path",
+            "name": "bot_id",
+            "required": true,
+            "schema": {
+              "description": "The bot this operation addresses — its `bot_id` as issued at creation and returned by the bots listing, e.g. `20260813_a7k2m9p1`.",
+              "title": "Bot Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+            "in": "query",
+            "name": "owner_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The owner of the bot this request addresses. Defaults to the caller — name it only to operate a bot shared with you. The caller must be the bot's owner or a collaborator on it; anyone else is answered exactly as if the bot did not exist (404).",
+              "title": "Owner Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_skill_folder_openapi_v1_bots__bot_id__skills_upload_folder_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SkillUpload_"
+                }
+              }
+            },
+            "description": "Existing Local Skill safely replaced."
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SkillUpload_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Directory package exceeds an upload limit."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Upload Skill Folder",
         "tags": [
           "skills"
         ]

--- a/src/gateway/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
+++ b/src/gateway/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
@@ -85,6 +85,16 @@ Backend 真实路由自动生成并经过向前兼容检查，前端可据此查
 - 同 Bot 同名上传原地替换，保留 skill_id 和原 active。
 - 产品随后把它加入 SkillSet；若该 Set 当前 active，添加成功后立即生效。
 
+“添加本地文件夹”保持现有产品的 multipart 交互，不要求前端自行把文件夹压成 ZIP：
+
+`POST /openapi/v1/bots/{bot_id}/skills/upload-folder`
+
+- Content-Type：`multipart/form-data`。
+- `files`：重复字段，包含选中文件夹中的全部文件。
+- `file_paths`：可选 JSON 字符串数组，与 `files` 一一对应，保存相对目录结构；不传时退回每个文件名。
+- 与 raw ZIP 共用同一包校验、唯一 `SKILL.md`、同名替换、新建 inactive、大小/文件数限制和响应 Envelope。
+- 旧 `/api/skills/upload` 继续作为兼容 Adapter；其 `files + file_paths` 语义不得漂移。
+
 ### 4.3 Item 与内容
 
 | Method | Path | 前端用途 |
@@ -116,6 +126,30 @@ Backend 真实路由自动生成并经过向前兼容检查，前端可据此查
 
 Sync 是同步接口。前端 await 返回后刷新列表，不轮询新的 sync-status。并发同步返回
 `SYNC_IN_PROGRESS`。
+
+### 5.1 添加 Skill 弹窗的三个来源
+
+三个目录独立读取，不能把 Skill Center 团队搜索当作能力工坊搜索：
+
+| 产品入口 | 前端接口 | 结果来源 |
+| --- | --- | --- |
+| 引用市场 Skill / TeamClaw | `GET /openapi/v1/bots/skills/repository` | aiworkbench 扫描后的 `git://` Repo Skill |
+| 引用市场 Skill / Skill Center | `POST /openapi/v1/bots/market/skill-center/skills` | Skill Center PUBLIC 市场；服务端注入凭据，固定不传 `teamId` |
+| 引用工坊 Skill | `GET /openapi/v1/bots/spaces/{space_id}/skills/consumable` | 当前 Space 中已发布且运行时物化完成的 Skill |
+
+已发布兼容接口 `POST /openapi/v1/bots/market/skills` 同样读取 TeamClaw Git 市场；新产品页面优先使用 Repository Catalog。
+
+Skill Center Public Skill 不做全量扫描入 `ac_skill`。前端选中后，目标合同为：
+
+```text
+POST /openapi/v1/bots/{bot_id}/skill-sets/{set_id}/market-skill-references
+{
+  "market_source": "SKILLCENTER",
+  "skill_code": "stable-skill-code"
+}
+```
+
+该命令后续负责按需解析/物化为 TeamClaw `skill_id`，再写普通 SkillSet Membership。当前仅冻结该接口合同，未实现物化前不得将其加入 Gateway 正式 OpenAPI artifact，也不得返回“已引用成功”的假结果。
 
 ## 6. Phase 1：SkillSet
 

--- a/src/gateway/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
+++ b/src/gateway/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
@@ -93,7 +93,7 @@ Backend 真实路由自动生成并经过向前兼容检查，前端可据此查
 - `files`：重复字段，包含选中文件夹中的全部文件。
 - `file_paths`：可选 JSON 字符串数组，与 `files` 一一对应，保存相对目录结构；不传时退回每个文件名。
 - 与 raw ZIP 共用同一包校验、唯一 `SKILL.md`、同名替换、新建 inactive、大小/文件数限制和响应 Envelope。
-- 旧 `/api/skills/upload` 继续作为兼容 Adapter；其 `files + file_paths` 语义不得漂移。
+- 旧 `/api/skills/upload` 原样保留，本期不修改其实现；新接口沿用其 `files + file_paths` wire 语义。新 OpenAPI 的文件夹与 raw ZIP 入口在请求解码后共用同一个 `LocalSkillUploadService` 生命周期。
 
 ### 4.3 Item 与内容
 


### PR DESCRIPTION
## 变更
- 新增 multipart 目录上传：`POST /openapi/v1/bots/{bot_id}/skills/upload-folder`，兼容旧 `/api/skills/upload` 的 `files + file_paths` 语义。
- 目录上传复用 raw ZIP 的包校验、同名替换、补偿与 Runtime 同步链路；原 raw ZIP 合同不变。
- 更新生成的 Gateway OpenAPI 与前端接口文档。
- 冻结 Skill Center 公共市场按需物化命令合同；当前不发布未实现路由。

## 验证
- `uv run pytest -q tests/community/adapters/http/openapi_v1/test_admission_inventory.py tests/community/adapters/http/openapi_v1/test_skills_endpoints.py tests/community/core/skill_center/test_local_skill_upload_service.py`
- `uv run pytest -q tests/community/architecture/test_service_api_conformance.py tests/community/endpoints/test_openapi_skill_upload.py tests/community/adapters/http/openapi_v1/test_self_checked_routes_refuse.py tests/community/adapters/http/openapi_v1/test_skills_shared_bot_grant.py tests/community/adapters/http/openapi_v1/test_app_only_bot_not_on_the_wire.py`
- `ruff check`、Gateway OpenAPI compatibility gate、`git diff --check`