### PR TITLE
fix(bcs): log Provider HITL interaction payloads

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
@@ -1205,9 +1205,6 @@ fn provider_body_log(body: &ProviderWebhookRequest) -> String {
         Ok(value) => value,
         Err(error) => return format!("{{\"serialize_error\":\"{}\"}}", error),
     };
-    if body.method == "interaction.resolve" {
-        redact_interaction_resolution_params(&mut redacted);
-    }
     if let Some(attachments) = redacted
         .get_mut("attachments")
         .and_then(Value::as_array_mut)
@@ -1221,24 +1218,6 @@ fn provider_body_log(body: &ProviderWebhookRequest) -> String {
     serde_json::to_string(&redacted).unwrap_or_else(|error| {
         format!("{{\"serialize_error\":\"{}\"}}", error)
     })
-}
-
-fn redact_interaction_resolution_params(body: &mut Value) {
-    const SAFE_KEYS: &[&str] = &[
-        "bcsRunId",
-        "runId",
-        "interactionId",
-        "kind",
-        "idempotencyKey",
-    ];
-    let Some(params) = body.get_mut("params").and_then(Value::as_object_mut) else {
-        return;
-    };
-    for (key, value) in params {
-        if !SAFE_KEYS.contains(&key.as_str()) {
-            *value = Value::String("<redacted>".to_string());
-        }
-    }
 }
 
 fn sse_data_log(event: &str, data: &str) -> String {
@@ -2243,7 +2222,7 @@ Connection: keep-alive\r\n\
     }
 
     #[test]
-    fn provider_body_log_redacts_interaction_answers_and_extensions() {
+    fn provider_body_log_preserves_interaction_business_payload() {
         let body = ProviderWebhookRequest {
             frame_type: "req".to_string(),
             id: "resolve-frame-1".to_string(),
@@ -2277,11 +2256,10 @@ Connection: keep-alive\r\n\
 
         let logged = provider_body_log(&body);
 
-        assert!(logged.contains("\"action\":\"<redacted>\""));
-        assert!(logged.contains("\"answers\":\"<redacted>\""));
-        assert!(logged.contains("\"providerExtension\":\"<redacted>\""));
-        assert!(!logged.contains("sensitive answer"));
-        assert!(!logged.contains("sensitive extension"));
+        assert!(logged.contains("\"action\":\"submit\""));
+        assert!(logged.contains("sensitive answer"));
+        assert!(logged.contains("sensitive extension"));
+        assert!(!logged.contains("<redacted>"));
     }
 
     #[test]

--- a/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
@@ -1220,25 +1220,8 @@ fn provider_body_log(body: &ProviderWebhookRequest) -> String {
     })
 }
 
-fn sse_data_log(event: &str, data: &str) -> String {
-    if event != "interaction" {
-        return data.to_string();
-    }
-    let Ok(Value::Object(source)) = serde_json::from_str::<Value>(data) else {
-        return serde_json::json!({
-            "redacted": true,
-            "bytes": data.len(),
-        })
-        .to_string();
-    };
-    let mut safe = serde_json::Map::new();
-    for key in ["runId", "seq", "ts", "phase", "interactionId", "kind"] {
-        if let Some(value) = source.get(key) {
-            safe.insert(key.to_string(), value.clone());
-        }
-    }
-    safe.insert("redacted".to_string(), Value::Bool(true));
-    Value::Object(safe).to_string()
+fn sse_data_log(_event: &str, data: &str) -> String {
+    data.to_string()
 }
 
 fn provider_history_log(response: &ProviderHistoryResponse) -> String {
@@ -2263,19 +2246,17 @@ Connection: keep-alive\r\n\
     }
 
     #[test]
-    fn sse_detail_log_redacts_interaction_business_payload() {
+    fn sse_detail_log_preserves_interaction_business_payload() {
         let logged = sse_data_log(
             "interaction",
             r#"{"runId":"run-1","seq":7,"phase":"resolved","interactionId":"i-1","kind":"ask_user","command":"sensitive command","answers":{"name":{"values":["sensitive answer"]}}}"#,
         );
 
-        assert!(logged.contains("\"interactionId\":\"i-1\""));
-        assert!(logged.contains("\"phase\":\"resolved\""));
-        assert!(!logged.contains("sensitive command"));
-        assert!(!logged.contains("sensitive answer"));
+        assert!(logged.contains("\"command\":\"sensitive command\""));
+        assert!(logged.contains("sensitive answer"));
 
-        let malformed = sse_data_log("interaction", "not-json sensitive answer");
-        assert!(!malformed.contains("sensitive answer"));
+        let malformed = sse_data_log("interaction", "not-json interaction payload");
+        assert_eq!(malformed, "not-json interaction payload");
     }
 
     #[tokio::test]

--- a/src/bcs/docs/bcs-provider-2.0-sse-protocol.md
+++ b/src/bcs/docs/bcs-provider-2.0-sse-protocol.md
@@ -752,10 +752,10 @@ stateDiagram-v2
   active 状态不直接按 TTL 删除。
 - 本期不写 `bcs_messages`，也不新增 interaction 数据库表。
 
-interaction 业务 payload（例如 command、questions、answers）不会写入普通 INFO/WARN
-或 `bcs_sse_detail` 日志；detail 日志只保留 runId、seq、ts、phase、interactionId、kind
-和字节数等关联元数据。resolve 接受、失败和失效日志记录 resolver actor 与状态，但不
-记录具体选择内容。
+为支持线上诊断，interaction 业务 payload（例如 command、questions、answers）会完整
+写入 Provider 请求体 INFO 日志或 `bcs_sse_detail` 日志；`interaction.resolve` 的 action、
+answers 和 Provider 扩展字段也会保留原文。认证 Token、Authorization Header 和临时附件
+URL 继续沿用独立的脱敏规则，不因 interaction 日志放开而输出。
 
 ## 10. 线上真实事件样例
 

--- a/src/bcs/docs/plans/2026-08-12-bcn-provider-sse-hitl-design.md
+++ b/src/bcs/docs/plans/2026-08-12-bcn-provider-sse-hitl-design.md
@@ -556,8 +556,11 @@ Record structured events and counters for:
 - cleanup counts and active interaction counts by status.
 
 Logs include `bcs_run_id`, `interaction_id`, `bcs_session_id`, `group_id`,
-`bot_id`, and Provider ID. They must not log secret user answers or sensitive
-command contents beyond existing redaction rules.
+`bot_id`, and Provider ID. For diagnostics, Provider request-body and SSE-detail
+logs preserve interaction business payloads such as commands, questions,
+answers, actions, and Provider extensions. Authentication tokens, authorization
+headers, and temporary attachment URLs remain redacted by their independent
+security rules.
 
 The process-local implementation additionally enforces a 256 KiB requested
 payload limit, 32 active interactions per run, 256 active interactions per

--- a/src/bcs/docs/plans/2026-08-21-bcs-interaction-log-unredaction-design.md
+++ b/src/bcs/docs/plans/2026-08-21-bcs-interaction-log-unredaction-design.md
@@ -1,0 +1,57 @@
+# BCS Interaction Log Unredaction Design
+
+## Goal
+
+Make Provider 2.0 HITL interaction business payloads visible in BCS logs so
+operators can diagnose failed or invalidated interaction resolutions without
+guessing the submitted action or answers.
+
+## Scope
+
+- Log the complete structured `interaction.resolve` request parameters,
+  including `action`, `answers`, and Provider extension fields.
+- Log the complete Provider `interaction` SSE data, including `command`,
+  `questions`, and `answers`.
+- Keep existing credential and transport-secret protections unchanged,
+  including authorization tokens and temporary attachment URLs.
+- Do not add a configuration switch in this change.
+
+## Design
+
+The change stays in the `bcs-provider-http` delivery adapter, which already
+owns Provider request and SSE detail serialization for logs.
+
+`provider_body_log` will continue serializing the structured Provider request
+and redacting temporary attachment URLs, but it will no longer replace
+`interaction.resolve` business parameters with `<redacted>`.
+
+`sse_data_log` will return Provider SSE data unchanged for `interaction`
+events, matching its existing behavior for other SSE event types. This removes
+the special interaction-only projection that currently drops business fields.
+
+No wire protocol, Service API, Plugin API, persistence model, or runtime
+routing behavior changes.
+
+## Error Handling
+
+Serialization failures keep the existing safe `serialize_error` fallback.
+Temporary attachment URL redaction remains independent of interaction payload
+logging. The change does not alter Provider request execution or SSE parsing.
+
+## Testing
+
+- Change the Provider request-body log test to require the original
+  `action`, answer values, and Provider extension content.
+- Change the SSE detail log test to require the original interaction command
+  and answer values.
+- Keep the attachment URL regression test unchanged to prove transport-secret
+  redaction still applies.
+- Run the focused `bcs-provider-http` tests, then the relevant BCS checks.
+
+## Compatibility and Risk
+
+The runtime protocol is unchanged. The operational risk is increased exposure
+of user-provided HITL business content in BCS logs; this is intentional and
+limited to interaction payloads. Authentication credentials, authorization
+headers, and temporary attachment URLs remain protected by their existing
+independent redaction paths.

--- a/src/bcs/docs/plans/2026-08-21-bcs-interaction-log-unredaction-implementation.md
+++ b/src/bcs/docs/plans/2026-08-21-bcs-interaction-log-unredaction-implementation.md
@@ -141,11 +141,14 @@ with the approved scoped policy.
 Run:
 
 ```bash
-rg -n "interaction 业务 payload|secret user answers|sensitive command contents" src/bcs/docs
+rg -n "interaction 业务 payload|preserve interaction business payloads" \
+  src/bcs/docs/bcs-provider-2.0-sse-protocol.md \
+  src/bcs/docs/plans/2026-08-12-bcn-provider-sse-hitl-design.md
 git diff --check
 ```
 
-Expected: no stale prohibition remains; `git diff --check` exits 0.
+Expected: both documents state the approved payload-logging policy;
+`git diff --check` exits 0.
 
 **Step 4: Commit**
 

--- a/src/bcs/docs/plans/2026-08-21-bcs-interaction-log-unredaction-implementation.md
+++ b/src/bcs/docs/plans/2026-08-21-bcs-interaction-log-unredaction-implementation.md
@@ -1,0 +1,193 @@
+# BCS Interaction Log Unredaction Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Log complete Provider 2.0 HITL interaction business payloads while retaining credential and temporary attachment URL redaction.
+
+**Architecture:** Keep the change inside the `bcs-provider-http` delivery adapter, where Provider request bodies and SSE detail records are already formatted. Remove only the interaction-specific business-payload projection; retain the independent attachment URL redaction and all authentication/credential protections.
+
+**Tech Stack:** Rust, Serde JSON, Tokio/Cargo tests, Markdown protocol documentation
+
+---
+
+### Task 1: Specify Unredacted Interaction Request Logs
+
+**Files:**
+- Modify: `src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs:2246-2285`
+
+**Step 1: Write the failing test**
+
+Rename `provider_body_log_redacts_interaction_answers_and_extensions` to
+`provider_body_log_preserves_interaction_business_payload` and replace its
+assertions with:
+
+```rust
+assert!(logged.contains("\"action\":\"submit\""));
+assert!(logged.contains("sensitive answer"));
+assert!(logged.contains("sensitive extension"));
+assert!(!logged.contains("<redacted>"));
+```
+
+**Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cd src/bcs
+cargo test -p bcs-provider-http provider_body_log_preserves_interaction_business_payload -- --exact
+```
+
+Expected: FAIL because `action`, `answers`, and `providerExtension` are still
+replaced with `<redacted>`.
+
+**Step 3: Implement the minimal request-log change**
+
+In `provider_body_log`, delete the `interaction.resolve` special case:
+
+```rust
+if body.method == "interaction.resolve" {
+    redact_interaction_resolution_params(&mut redacted);
+}
+```
+
+Delete the now-unused `redact_interaction_resolution_params` helper. Leave the
+attachment URL loop unchanged.
+
+**Step 4: Run the focused test**
+
+Run the same Cargo command. Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+git commit -m "fix(bcs): log interaction resolve payloads"
+```
+
+### Task 2: Specify Unredacted Interaction SSE Detail Logs
+
+**Files:**
+- Modify: `src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs:1226-1263`
+- Modify: `src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs:2288-2301`
+
+**Step 1: Write the failing test**
+
+Rename `sse_detail_log_redacts_interaction_business_payload` to
+`sse_detail_log_preserves_interaction_business_payload` and assert:
+
+```rust
+assert!(logged.contains("\"command\":\"sensitive command\""));
+assert!(logged.contains("sensitive answer"));
+
+let malformed = sse_data_log("interaction", "not-json interaction payload");
+assert_eq!(malformed, "not-json interaction payload");
+```
+
+**Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cd src/bcs
+cargo test -p bcs-provider-http sse_detail_log_preserves_interaction_business_payload -- --exact
+```
+
+Expected: FAIL because the helper currently keeps only correlation metadata and
+returns a redacted byte count for malformed interaction data.
+
+**Step 3: Implement the minimal SSE-log change**
+
+Replace `sse_data_log` with:
+
+```rust
+fn sse_data_log(_event: &str, data: &str) -> String {
+    data.to_string()
+}
+```
+
+This keeps the existing call sites stable while making interaction event logs
+consistent with other Provider SSE event logs.
+
+**Step 4: Run the focused test**
+
+Run the same Cargo command. Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+git commit -m "fix(bcs): log interaction SSE payloads"
+```
+
+### Task 3: Align Provider HITL Documentation
+
+**Files:**
+- Modify: `src/bcs/docs/bcs-provider-2.0-sse-protocol.md:755-758`
+- Modify: `src/bcs/docs/plans/2026-08-12-bcn-provider-sse-hitl-design.md:552-562`
+
+**Step 1: Update the current protocol documentation**
+
+State that BCS INFO/WARN and `bcs_sse_detail` logs include complete interaction
+business payloads for diagnostics, while authentication credentials,
+authorization headers, and temporary attachment URLs remain redacted.
+
+**Step 2: Update the original HITL design observability section**
+
+Replace the obsolete prohibition on logging user answers and command contents
+with the approved scoped policy.
+
+**Step 3: Check documentation consistency**
+
+Run:
+
+```bash
+rg -n "interaction 业务 payload|secret user answers|sensitive command contents" src/bcs/docs
+git diff --check
+```
+
+Expected: no stale prohibition remains; `git diff --check` exits 0.
+
+**Step 4: Commit**
+
+```bash
+git add src/bcs/docs/bcs-provider-2.0-sse-protocol.md \
+  src/bcs/docs/plans/2026-08-12-bcn-provider-sse-hitl-design.md
+git commit -m "docs(bcs): document interaction payload logging"
+```
+
+### Task 4: Verify the BCS Change
+
+**Files:**
+- Test: `src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs`
+
+**Step 1: Run the complete adapter test suite**
+
+```bash
+cd src/bcs
+cargo test -p bcs-provider-http
+```
+
+Expected: PASS.
+
+**Step 2: Run the BCS compile check**
+
+```bash
+cd src/bcs
+cargo check -p bcs
+```
+
+Expected: PASS.
+
+**Step 3: Run repository hygiene checks**
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: no whitespace errors; only intentional files are changed. Do not run
+`cargo fmt` or `cargo fmt --all`.
+
+**Step 4: Commit any remaining intentional verification/documentation changes**
+
+If all intended files were already committed, do not create an empty commit.


### PR DESCRIPTION
## Problem

BCS redacted the business payload of Provider 2.0 HITL interactions in both outbound `interaction.resolve` request logs and inbound interaction SSE detail logs. This hid actions, answers, commands, questions, and Provider extensions needed to diagnose failed or invalidated interaction resolutions.

## Solution

- Preserve the complete structured `interaction.resolve` business payload in Provider request-body logs.
- Preserve the complete interaction SSE payload in `bcs_sse_detail` logs.
- Keep independent protections for authentication tokens, authorization headers, and temporary attachment URLs unchanged.
- Update focused regression tests and the Provider HITL observability documentation.
- Do not introduce a configuration switch.

## Validation

- `cargo test -p bcs-provider-http` — 48 tests passed.
- `cargo check -p bcs` — passed.
- TDD red/green checks confirmed both new logging expectations failed before the implementation and passed afterward.
- The branch was pushed with `--no-verify` as requested; no additional pre-push hook verification was run.

## Compatibility and risk

No Provider wire contract, Service API, persistence model, or routing behavior changes. Interaction logs can now contain user-provided business content, which is intentional for diagnostics. Existing credential and temporary attachment URL redaction remains in place. The change can be rolled back by reverting this PR.

## Spec

- `src/bcs/docs/plans/2026-08-21-bcs-interaction-log-unredaction-design.md`
- `src/bcs/docs/plans/2026-08-21-bcs-interaction-log-unredaction-implementation.md`