### PR TITLE
feat(backend): query TeamClaw Bot catalog from BCS

### DIFF
--- a/docs/superpowers/plans/2026-08-21-bcs-catalog-search.md
+++ b/docs/superpowers/plans/2026-08-21-bcs-catalog-search.md
@@ -1,0 +1,178 @@
+# BCS Catalog Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `GET /openapi/v1/bots/catalog/search` query BCS `/v2/bots/search` for the requested page, then return only the current page's exact `(bot_id, entity_id)` matches from Backend.
+
+**Architecture:** The BCS adapter uses the existing BCS-qualified `HttpClient` and a fixed relative path. It maps the OpenAPI query `search/page/page_size` to BCS `q/offset/limit` and fixes `tc_bot=true`, parses each BCS `bot_uuid` as `<bot_id>:<entity_id>`, and exposes only typed addresses to the core service. The core service uses the existing tenant-scoped ORM repository pair lookup, preserves BCS page order, and reports the count of joins in the current page as `total`.
+
+**Tech Stack:** FastAPI, Python, Injector, typed `HttpClient`, SQLAlchemy ORM, pytest.
+
+**Spec:** `spec/pipeline/openapi-bot-public-bcs-join/001-spec-output.md`
+
+## Global Constraints
+
+- Do not add or expose `binding_id`, device data, BCS raw fields, tokens, environments, or BCS caller headers.
+- Use only the configured BCS-qualified `HttpClient` and the constant relative path `/v2/bots/search`; do not construct URLs from request data.
+- Map `page` to `offset=(page-1)*page_size`, `page_size` to `limit`, non-empty `search` to `q`, and always send `tc_bot=true`; do not pass visibility, status, friendship, or identity filters to BCS.
+- Parse BCS `bot_uuid` only as the stable `<bot_id>:<entity_id>` pair. Reject malformed or non-Bot BCS records without returning a partial page.
+- Backend remains authoritative for public Bot fields and uses the existing tenant-scoped ORM pair lookup. `total` is the current page's joined count, not BCS's cross-page `total`.
+- Keep legacy `/api/v1/bot-public/search` Backend-only, keep Discover and `bot_discover_service.py` unchanged, and do not modify, stage, or remove `.superpowers/`.
+- Logs contain only request ID, counts, and failure categories.
+
+---
+
+### Task 1: Define and test the BCS page adapter
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py`
+- Modify: `src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py`
+- Test: `src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py`
+
+**Interfaces:**
+- Consumes: `HttpClient[QUALIFIER_BCN]`, `BotCatalogCaller`, request trace ID.
+- Produces: `BotCatalogMetadataServiceProtocol.search_public_bot_metadata(search, page, page_size, caller, request_id) -> Sequence[BotCatalogMetadata]`.
+
+- [ ] **Step 1: Write failing adapter tests**
+
+```python
+def test_bcs_catalog_search_maps_current_page_and_parses_exact_address():
+    result = service.search_public_bot_metadata(
+        search="agent", page=2, page_size=20, caller=caller, request_id="trace"
+    )
+    assert result == [BotCatalogMetadata(BotCatalogAddress("bot-1", "owner-1"), "bot")]
+    assert client.calls_to("get")[0].kwargs["params"] == {
+        "q": "agent", "offset": 20, "limit": 20, "tc_bot": True
+    }
+```
+
+Add independent tests that a blank search omits `q`, and malformed `bot_uuid`, duplicate addresses, non-Bot records, malformed JSON, or upstream HTTP failure raises `BotCatalogMetadataUnavailableError` without exposing upstream detail.
+
+- [ ] **Step 2: Run the adapter tests and verify RED**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_public/test_bot_catalog_metadata_service.py -q`
+
+Expected: FAIL because the protocol and real BCS adapter do not yet support page search.
+
+- [ ] **Step 3: Implement the minimum typed adapter**
+
+```python
+response = self._http.get(
+    "/v2/bots/search", params=params, timeout=self._timeout
+)
+response.raise_for_status()
+```
+
+Use a fixed client/relative path, validate root `items`, require `actor_kind == "bot"`, split `bot_uuid.rsplit(":", 1)`, and emit a low-sensitivity result/failure log. Convert all transport and shape failures to the typed unavailable error.
+
+- [ ] **Step 4: Run the adapter tests and verify GREEN**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_public/test_bot_catalog_metadata_service.py -q`
+
+Expected: PASS.
+
+### Task 2: Join the current BCS page in Backend
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py`
+- Test: `src/backend/tests/community/core/bot_public/test_bot_public_service.py`
+
+**Interfaces:**
+- Consumes: ordered `Sequence[BotCatalogMetadata]` from Task 1 and `BotRepository.list_public_bots_by_owner_bot_pairs`.
+- Produces: `{"total": len(joined_current_page), "items": joined_current_page}` in BCS result order.
+
+- [ ] **Step 1: Write failing orchestration tests**
+
+```python
+def test_catalog_search_joins_only_the_current_bcs_page_and_reports_its_count():
+    metadata.search_public_bot_metadata.return_value = [
+        BotCatalogMetadata(BotCatalogAddress("bot-1", "owner-1"), "bot"),
+        BotCatalogMetadata(BotCatalogAddress("missing", "owner-2"), "bot"),
+    ]
+    repository.list_public_bots_by_owner_bot_pairs.return_value = [backend_bot("bot-1", "owner-1")]
+
+    result = service.search_catalog_public_bots_by_keyword(search="agent", page=3, page_size=20, caller=caller, request_id="trace")
+
+    assert result["total"] == 1
+    assert [item["bot_id"] for item in result["items"]] == ["bot-1"]
+```
+
+Add tests for BCS order restoration after unordered ORM rows, same `bot_id` under a different `entity_id` not joining, BCS unavailable translating to the fixed public 502 error, and legacy search never calling BCS.
+
+- [ ] **Step 2: Run the service tests and verify RED**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_public/test_bot_public_service.py -q`
+
+Expected: FAIL because current code asks Backend for all candidates first and computes global joined pagination.
+
+- [ ] **Step 3: Implement the minimum current-page join**
+
+Call the metadata port before the repository. Request only the ordered unique address pairs from `BotRepository.list_public_bots_by_owner_bot_pairs`, map Backend results by exact address, restore BCS order, retain current sensitive-value clearing as defense in depth, and do not re-slice the page.
+
+- [ ] **Step 4: Run the service tests and verify GREEN**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_public/test_bot_public_service.py -q`
+
+Expected: PASS.
+
+### Task 3: Wire DI and update the published contract
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/di/modules/bot_public_module.py`
+- Modify: `src/backend/tests/community/endpoints/test_openapi_bot_public_catalog.py`
+- Modify: `src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md`
+- Modify: `src/backend/docs/openapi-v1/README.md`
+- Modify: `spec/pipeline/openapi-bot-public-bcs-join/001-spec-output.md`
+- Modify: `spec/pipeline/openapi-bot-public-bcs-join/002-code-report.md`
+- Modify: `/Users/helloworld/Desktop/codes/teamclaw/log.md`
+
+**Interfaces:**
+- Consumes: BCS adapter from Task 1.
+- Produces: all profiles resolve a real BCS catalog adapter; `/search` returns 200 for an available BCS page even when the join is empty, and 502 only for BCS failure.
+
+- [ ] **Step 1: Write failing DI/endpoint tests**
+
+```python
+def test_test_profile_binds_catalog_port_to_bcs_adapter():
+    port = build_injector(profile=DeployProfile.TEST).get(BotCatalogMetadataServiceProtocol)
+    assert isinstance(port, BcnBotCatalogMetadataService)
+```
+
+Keep the endpoint test at the HTTP boundary and add an available empty-page assertion so an empty BCS page is not confused with the former unconfigured 502 mode.
+
+- [ ] **Step 2: Run DI/endpoint tests and verify RED**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_public/test_bot_catalog_metadata_service.py tests/community/endpoints -q -k 'catalog'`
+
+Expected: FAIL because DI still uses `UnavailableBotCatalogMetadataService`.
+
+- [ ] **Step 3: Make the narrow DI and documentation changes**
+
+Bind the port to the BCS adapter using the existing BCS-qualified client. Update documentation from “fixed 502” to “current BCS page is queried with `q/offset/limit`; Backend returns the exact current-page join and its joined count.” Regenerate OpenAPI only if the generated schema changes.
+
+- [ ] **Step 4: Run DI/endpoint tests and verify GREEN**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_public/test_bot_catalog_metadata_service.py tests/community/endpoints -q -k 'catalog'`
+
+Expected: PASS.
+
+### Task 4: Verify the smallest safe diff
+
+**Files:**
+- Modify only files from Tasks 1–3 plus generated schema if generation changes it.
+
+- [ ] **Step 1: Run targeted and architecture tests**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_public tests/community/adapters/http/openapi_v1/bot_public tests/community/endpoints -q -k 'catalog or bot_public'`
+
+- [ ] **Step 2: Run static and contract checks**
+
+Run: `cd src/backend && uv run ruff check <changed-python-files>`
+
+Run: `git diff --check`
+
+Run the existing OpenAPI dump/compare command if documentation or descriptions changed.
+
+- [ ] **Step 3: Check scope and record the outcome**
+
+Confirm the diff has no BCSFuse/Discover changes, no raw SQL, no URL construction from inputs, and no `.superpowers/` changes. Append the verified implementation and test result to the project log.

--- a/spec/pipeline/openapi-bot-public-bcs-join/002-code-report.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/002-code-report.md
@@ -7,10 +7,32 @@ iteration: 4
 
 # Bot Catalog BCS metadata port — coding report
 
-> This report describes the current port/fixed-502 implementation and the iteration-4 minimal-diff
-> audit against `origin/dev_refactory_collaboration`. It does not define or imply any BCS HTTP
-> route, base-URL configuration, credentials, timeout, or network call; see
-> [004-implementation-plan.md](004-implementation-plan.md).
+## 2026-08-21：BCS 当前页 Search 接入
+
+- 已按 [005-bcs-search-integration-spec.md](005-bcs-search-integration-spec.md) 将 Catalog Search 的
+  unavailable metadata binding 改为 BCS `/v2/bots/search` 适配器；请求仅传 `q`、`offset`、`limit` 和
+  固定 `tc_bot=true`，不透传 caller 或认证头。
+- BCS `bot_uuid` 解析为精确 `(bot_id, entity_id)` 后，Backend 复用 tenant-scoped ORM 二元组查询做
+  当前页 inner join，并恢复 BCS 顺序。`tc_bot=true` 令正常数据下当前 BCS 页与 join 数量对齐；`total`
+  始终是当前页实际 join 数量，不再聚合或二次分页。
+- 非 Bot、重复、非法 UUID、上游错误和非法 JSON 均 fail closed 为既有 `502000`；响应继续由 OpenAPI
+  allowlist 投影，BCS 原始字段不外泄。
+- 未修改 Discover、`bot_discover_service.py`、legacy Search、BCSFuse 或 `.superpowers/`。
+
+## 本次最终验证
+
+| Check | Result |
+|---|---|
+| Catalog BCS adapter + service pytest | `108 passed`, `0 failed` |
+| Catalog router/endpoint pytest (`-k catalog`) | `12 passed`, `0 failed` |
+| Community architecture pytest | `169 passed`, `0 failed` |
+| Ruff（本次变更的 adapter 测试）与 `git diff --check` | PASS |
+| 独立代码复审 | PASS；远端 ACI 仍须在提交并推送当前 head 后执行 |
+
+> The following sections record the earlier iteration-4 unavailable-port audit against
+> `origin/dev_refactory_collaboration`; the BCS integration above supersedes that temporary
+> implementation. The current adapter uses the existing BCN-qualified `HttpClient` and only the
+> constant relative path `/v2/bots/search`; it adds no URL, credential, or transport configuration.
 
 ## Worktree
 

--- a/spec/pipeline/openapi-bot-public-bcs-join/003-review-report.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/003-review-report.md
@@ -1,8 +1,8 @@
 ---
 agent: tc-code-reviewer
 status: completed
-created: 2026-08-20T21:57:27+08:00
-iteration: 5
+created: 2026-08-21T15:05:20+08:00
+iteration: 8
 ---
 
 # 代码评审报告
@@ -12,88 +12,41 @@ iteration: 5
 - Worktree: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog`
 - 分支: `feat/openapi-bot-public-catalog`
 - Base: `origin/dev_refactory_collaboration@efa0b7da330d8f928b364de2b84a9012f9bbcedc`
-- Committed HEAD: `8de5e1d25bc5c593bde1e2c301edf15c623169ee`
-- 本轮修复增量: 仅 `src/backend/tests/community/core/bot_public/test_bot_public_service.py` 新增 3 个行为测试；无生产代码改动。
-- `.superpowers/` 未修改、未暂存、未删除；未 commit、push 或修改 PR。
-
-## 结论先行
-
-**结论: PASS**
-
-iteration 4 的唯一阻塞项已关闭：独立复跑 focused suite 为 `157/157`，按项目
-`report_check.py` 同口径计算的当前工作树变更可执行行覆盖率为 `103/103 = 100.00%`，达到
-`>= 90%`。新增测试均有直接业务断言，不是无断言覆盖率填充，也没有扩大功能或修改生产设计。
-
-远端 ACI 对当前仍含 tracked uncommitted diff 的最终 head 仍为 **PENDING**；本报告的 PASS 是代码
-复审结论，不得替代最终远端 ACI 三项门禁。
+- 当前 committed HEAD: `8de5e1d25bc5c593bde1e2c301edf15c623169ee`；功能仍含 tracked uncommitted diff。
+- 本轮增量: 用户确认的 BCS 契约 `tc_bot=true`。仅在 `BcsBotCatalogMetadataService` 的固定 `/v2/bots/search` params 增加该值，并同步 005 spec、前端文档和 adapter 调用断言；没有改动 join、`total`、BCSFuse、Discover、legacy Search、配置或 `.superpowers/`。
 
 ## 逐条评审意见
 
 ### 固定检查维度
 
 | 维度 | 结论 | 说明 |
-|---|---|---|
-| 正确性 | PASS | 三个新增测试真实驱动 Catalog 生产方法，覆盖 unexpected metadata exception、Catalog 脱敏和 blank Backend address 过滤，并断言对外行为。 |
-| 安全性 | PASS | 无生产代码变化；上轮 caller/tenant、exact address、fail-closed、allowlist、ORM 参数化结论不变。新增日志测试还断言私有上游错误细节不进入日志。 |
-| 性能 | PASS | 本轮只有 focused unit tests，无运行时代码或查询行为变化。 |
-| 代码风格 | PASS | 新增测试结构沿用现有 fixture/`MagicMock` 风格；无跳过、xfail、`no cover`、阈值调整或无关辅助抽象。 |
-| 测试覆盖 | PASS | `157/157` 通过；current-tree change-line coverage `103/103 = 100.00%`，原 12 条未覆盖变更行现均命中。 |
-| ACI 覆盖率门禁 | PENDING | 本地 case 与 change-line 预检通过；项目全量总行覆盖率及当前最终 committed head 的远端 ACI job 尚不可得。 |
-| 静态检查 | PASS | `ruff check test_bot_public_service.py` 通过；`git diff --check origin/dev_refactory_collaboration` 通过；未新增 unused import/variable 或 whitespace 告警。 |
-
-### 本轮三项行为断言核验
-
-| 测试 | 结论 | 独立核验 |
-|---|---|---|
-| `test_catalog_search_fails_closed_on_unexpected_metadata_error` | PASS | 令 metadata port 抛带唯一私密 sentinel 的 `RuntimeError`；断言转为无详情 `BotCatalogSearchUnavailableError`，日志含 request ID、候选数、固定 `invalid_metadata` 类别，且不含 sentinel。真实命中原缺口 `1135,1136,1142`。 |
-| `test_catalog_search_redacts_sensitive_fields_and_malformed_ext` | PASS | 同时构造 malformed JSON ext 与字符串 ext；断言 `device_id=None`、malformed ext 变 `{}`、passport token/`iam_token` 变 `None`，非敏感字段保留。真实命中原缺口 `1152,1155-1158,1161,1164`。 |
-| `test_catalog_search_filters_blank_backend_addresses` | PASS | 同时提供 blank `bot_id`、blank `entity_id` 和 valid address；断言 port 只收到 valid exact address，结果也只含 valid Bot。真实命中原缺口 `1183,1185`。 |
-
-三项均调用真实 `search_catalog_public_bots_by_keyword`，并对异常、日志、port 入参或返回数据作明确断言；
-没有直接调用仅为刷行的内部 helper，没有 `skip`/`xfail`/`pragma: no cover`，也没有与本功能无关的测试。
-
-## 测试与覆盖率证据
-
-- Focused pytest:
-  - `test_bot_public_service.py`
-  - `test_bot_catalog_metadata_service.py`
-  - `test_bot_public_router.py`
-  - `test_bot_repository_unified.py`
-  - `test_sync_bot_config_uses_resolver.py`
-- 用例: `157/157 (100.00%)`，skipped=0，failed=0。
-- 局部覆盖率: `1057/2907 = 36.36%`。该分母包含历史大文件，只用于定位缺口，不能替代项目全量 ACI 总行覆盖率。
-- 当前工作树变更可执行行覆盖率: `103/103 = 100.00%`，threshold `>= 90%`，PASS。
-- 未覆盖变更可执行行: 无。
+|------|------|------|
+| 正确性 | PASS | `tc_bot=True` 固定加入 BCS Search params；httpx 的实际 query 编码为 `tc_bot=true`。`q/offset/limit` 映射、exact pair join、BCS 顺序恢复和 `total=len(joined_current_page)` 均未改变。数量不一致时仍返回实际 join 数，不将 `tc_bot` 误作全量一致性承诺。 |
+| 安全性 | PASS | 参数为固定布尔值，不来源于用户输入；调用仍为固定相对路径且未新增 caller/header。BCS raw fields、credentials 和身份信息仍不进入日志或 HTTP 输出。 |
+| 性能 | PASS | 未新增请求、查询、循环或分页步骤。 |
+| 代码风格 | PASS | `ruff check` 覆盖 adapter 与修改测试，`git diff --check` 通过；无新增 unused import/variable 或格式告警。 |
+| 测试覆盖 | PASS | adapter 的有 query 和空 query 两个路径均精确断言 `tc_bot=True`；真实 httpx `QueryParams` 复核序列化为 `tc_bot=true`。adapter 局部覆盖 `51/54 (94%)`，剩余仅防御性 generic-exception `83-89`。 |
+| ACI 覆盖率门禁 | PENDING | 当前工作树未形成最终 committed head，不能把本地结果或之前 head 的结果记为远端 ACI PASS。 |
+| 静态检查 | PASS | 本轮涉及文件无新增 IDE/linter 告警。 |
 
 ### ACI 覆盖率证据
 
-- Base / Current tree: `efa0b7da330d8f928b364de2b84a9012f9bbcedc` / `8de5e1d25bc5c593bde1e2c301edf15c623169ee + tracked uncommitted diff`。
-- 用例: 本地 focused `157/157 (100.00%)`；远端 ACI casePassRate `PENDING`，threshold = 100%。
-- 总行覆盖率: 远端/项目全量 `PENDING`，threshold `>= 70%`；局部 `1057/2907` 不作为该门禁结论。
-- 变更行覆盖率: 本地当前工作树 `103/103 (100.00%)`，threshold `>= 90%`，PASS。
-- 远端 ACI job: `PENDING`。当前工作树尚未形成最终 committed head，不得沿用较早 head 的远端 PASS。
+- Base / Head: `efa0b7da330d8f928b364de2b84a9012f9bbcedc` / `8de5e1d25bc5c593bde1e2c301edf15c623169ee + tracked uncommitted diff`。
+- 用例: 本地复跑 `118/118 (100.00%)`，skipped=0，failed=0（108 core + 当前 router 文件实际收集的 10 项）；远端 `casePassRate >= 100%` 为 **PENDING**。
+- 总行覆盖率: adapter 局部 `51/54 (94.44%)`，只用于定位；远端 `lineCoverage >= 70%` 为 **PENDING**。
+- 变更行覆盖率: 无最终 head 的远端 base/head ACI 产物；`changeLineCoverage >= 90%` 为 **PENDING**。
+- 远端 ACI job: **PENDING**。
 
-## 最小性与回归核验
-
-- 本轮仅在已有 Catalog service 测试类中新增 3 个与 iteration-4 REJECT 一一对应的行为测试。
-- 未新增通用 fixture、测试框架、生产 helper、配置、依赖或 CI 排除规则。
-- 生产文件 blob 与上轮评审一致：
-  - `bot_public_service.py`: `83e0b7bf4a53cf1adedeacf202a7d0a64747c50b`
-  - repository `bot.py`: `1c1dc32f46bc83663838e3dd639378dba26f30ac`
-  - `bot_public_module.py`: `17cc60b01b7cdfd0f610161de7c90a83c20585e9`
-- iteration 4 已通过的最小性结论保持不变：legacy sanitizer、原 paginated query 行为、DI 空行和
-  base 既有 `pytest` F401 均保持恢复状态；没有要求顺手清理 base 告警。
-
-## Review Spec 检查项
+### Review Spec 检查项
 
 | 编号 | 检查项 | 结论 | 说明 |
-|---|---|---|---|
-| R-01 | unexpected metadata exception 必须 fail closed 且不泄露详情 | PASS | 异常类型、空公开错误详情、固定低敏日志与 sentinel 不泄露均有断言。 |
-| R-02 | Catalog sanitizer 行为有直接断言 | PASS | malformed ext、device、passport token、IAM token 和非敏感字段保留均覆盖。 |
-| R-03 | blank Backend address 不得进入 port 或结果 | PASS | blank bot/entity 两个分支均命中，port 入参和最终结果同时断言。 |
-| R-04 | 测试修复保持最小 | PASS | 只加 3 个目标测试；生产、协议、DI、schema、文档均无本轮变化。 |
-| R-05 | changeLineCoverage `>= 90%` | PASS | `103/103 = 100.00%`，原 12 行缺口全部关闭。 |
-| R-06 | 远端 ACI 不得误报 | PASS | 明确标记当前最终 committed head 的远端 ACI 为 PENDING。 |
+|------|--------|------|------|
+| R-01 | BCS Search 只传 q/offset/limit 与固定 `tc_bot=true` | PASS | 唯一调用 `/v2/bots/search` 的 params 包含 `tc_bot=True`；有/无 search 的两条 adapter 测试都断言完整 params，且无 `headers` 参数。 |
+| R-02 | `bot_uuid` 精确解析且 BCS 非法记录 fail closed | PASS | 保持并已覆盖 non-Bot、重复、空/无分隔符/non-string UUID、malformed JSON 与非法 root/items shape。 |
+| R-03 | tenant-scoped exact-pair current-page join | PASS | `BotModel` ORM tenant guard、精确 pair repository 查询、BCS order 恢复和同 bot_id 不同 entity 隔离均未改动。 |
+| R-04 | total 等于当前 BCS 页的实际 joined count | PASS | `tc_bot` 只筛 BCS 正常数据；服务仍以 `len(items)` 返回本页实际 join，不跨页聚合或补齐数量。 |
+| R-05 | 不暴露 raw BCS/credentials/caller headers | PASS | 新增参数不含敏感或请求派生信息；现有 typed adapter、低敏日志与 router allowlist 未改。 |
+| R-06 | 不改 BCSFuse、Discover 或 legacy Search；最小 diff | PASS | 当前一轮生产改动为一个固定 params entry，配套测试/spec/docs 对齐；未命中受保护的功能路径或 `.superpowers/`。 |
 
 ## 具体问题列表
 
@@ -107,7 +60,6 @@ iteration 4 的唯一阻塞项已关闭：独立复跑 focused suite 为 `157/15
 
 无。
 
-### 下一步
+### 改进建议（非阻塞）
 
-继续 `tc-engine-regression`，并在当前 tracked diff 提交形成最终 head 后重新执行远端 ACI；只有
-`casePassRate >= 100%`、`lineCoverage >= 70%`、`changeLineCoverage >= 90%` 三项门禁均通过后才可部署。
+1. 提交当前 diff 形成最终 head 后执行远端 ACI；只有 `casePassRate >= 100%`、`lineCoverage >= 70%`、`changeLineCoverage >= 90%` 的实际分子/分母均通过后才可部署。

--- a/spec/pipeline/openapi-bot-public-bcs-join/003b-regression-report.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/003b-regression-report.md
@@ -1,0 +1,81 @@
+# Catalog Search BCS Adapter：本地回归报告
+
+## 范围
+
+- Worktree：`/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog`
+- 分支：`feat/openapi-bot-public-catalog`
+- 基线：`origin/dev_refactory_collaboration`
+- 本轮验证对象：Catalog Search 对 BCS `GET /v2/bots/search` 的 `q`、`offset`、`limit`、`tc_bot=true` 映射，以及 BCS `bot_uuid` 到当前租户 Backend `(bot_id, entity_id)` 的精确 inner join。
+- 未运行 Engine 回归：本次没有 Engine 或 relay 改动，启动 `claude_code` 本地环境与变更无关。
+- 未修改生产代码、`.superpowers/`、未提交、未推送、未部署。
+
+## 结果汇总
+
+**PASS** — 与本次改动直接相关的功能、OpenAPI 契约和架构门禁均通过。
+
+| 检查 | 结果 | 证据 |
+|---|---:|---|
+| Catalog BCS adapter、应用服务、Router、endpoint 回归 | PASS | 118 passed，9.23s |
+| 分层与 DI 架构门禁 | PASS | 71 passed，6.36s |
+| OpenAPI schema、错误响应、显式身份和统一响应文档门禁 | PASS | 79 passed（6 + 8 + 20 + 45） |
+| Ruff 规则 / unused import | PASS | `ruff check` 目标源码与测试均通过 |
+| Python 编译 | PASS | `compileall -q` 目标模块通过 |
+| Diff 完整性 | PASS | 工作区与 `origin/dev_refactory_collaboration...HEAD` 均通过 `git diff --check` |
+
+## 执行命令
+
+```bash
+cd src/backend
+
+DEPLOY_PROFILE=test .venv/bin/python -m pytest -q -p no:cacheprovider \
+  tests/community/core/bot_public/test_bot_catalog_metadata_service.py \
+  tests/community/core/bot_public/test_bot_public_service.py \
+  tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py \
+  tests/community/endpoints/test_openapi_bot_public_catalog.py
+
+DEPLOY_PROFILE=test .venv/bin/python -m pytest -q -p no:cacheprovider \
+  tests/community/architecture/test_module_boundaries.py \
+  tests/community/architecture/test_http_adapter_layer_is_http_only.py \
+  tests/community/architecture/test_core_no_concrete_plugin_imports.py \
+  tests/community/architecture/test_protocol_contracts.py \
+  tests/community/architecture/test_service_api_conformance.py \
+  tests/community/architecture/test_build_injector_composition_root_only.py
+
+DEPLOY_PROFILE=test .venv/bin/python -m pytest -q -p no:cacheprovider \
+  tests/community/adapters/http/openapi_v1/test_schema_docs.py \
+  tests/community/adapters/http/openapi_v1/test_openapi_error_schema.py \
+  tests/community/adapters/http/openapi_v1/test_explicit_user_id.py \
+  tests/community/adapters/http/openapi_v1/test_responses.py
+
+.venv/bin/ruff check \
+  src/agentclaw/community/core/bot_public/catalog_metadata.py \
+  src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py \
+  src/agentclaw/community/core/bot_public/services/bot_public_service.py \
+  src/agentclaw/community/di/modules/bot_public_module.py \
+  tests/community/core/bot_public/test_bot_catalog_metadata_service.py \
+  tests/community/core/bot_public/test_bot_public_service.py
+
+.venv/bin/python -m compileall -q \
+  src/agentclaw/community/core/bot_public/catalog_metadata.py \
+  src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py \
+  src/agentclaw/community/core/bot_public/services/bot_public_service.py \
+  src/agentclaw/community/di/modules/bot_public_module.py
+
+git diff --check
+git diff --check origin/dev_refactory_collaboration...HEAD
+```
+
+## 已覆盖行为
+
+- BCS 固定路径、当前页参数映射及空 `search` 不传 `q`。
+- 仅接受 `actor_kind=bot` 和非空、不重复的 `<bot_id>:<entity_id>`；HTTP 失败、错误 JSON、非法响应和重复记录均 fail closed。
+- 以 BCS 页为顺序，按精确复合键查询 Backend；同 `bot_id` 的不同 `entity_id` 不会交叉 join。
+- `total` 与 `items` 都是当前 BCS 页的实际 join 数；不会退化为 Backend-only 搜索。
+- BCS 不可用映射固定 `502000`，不泄露上游细节；公共投影继续清除敏感字段。
+- Router 维持 Protocol 注入，BCS HTTP client 通过 DI 的 BCN qualifier 提供；旧 Search 与 Discover 的既有逻辑未受本次验证范围影响。
+
+## 非阻断提示与边界
+
+- 测试过程仅出现项目既有 Pydantic/Starlette deprecation warnings，未出现失败。
+- 额外运行的 `ruff format --check` 提示 4 个本轮已修改文件可自动重排。项目要求的 `ruff check` 已通过，且本轮不为消除该提示做无关格式化改动；此项不作为回归阻断。
+- 本地验证通过 `LocalHttpClient` 测试缝验证报文与错误映射；未对真实 BCS 环境发请求，因此真实 BCS 连通性和凭据应在部署环境单独验收。

--- a/spec/pipeline/openapi-bot-public-bcs-join/005-bcs-search-integration-spec.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/005-bcs-search-integration-spec.md
@@ -1,0 +1,23 @@
+# 系分 Spec：Catalog Search 接入 BCS `/v2/bots/search`
+
+## 已确认的对齐规则
+
+- 对外接口仍为 `GET /openapi/v1/bots/catalog/search`，不新增或暴露 `binding_id`、实例、设备、`ext`、token 或环境字段。
+- Backend 将当前请求的 `search`、`page`、`page_size` 映射为 BCS 的 `q`、`offset=(page-1)*page_size`、`limit=page_size`，并固定传 `tc_bot=true`；不传 visibility、status、好友关系、caller 或认证头。
+- BCS 的 `bot_uuid` 固定按 `<bot_id>:<entity_id>` 解析。每条必须是 `actor_kind=bot` 且二元组非空、不重复；否则整个请求 fail closed 为 `502000`。
+- BCS 返回当前页后，Backend 使用现有 tenant-scoped ORM `list_public_bots_by_owner_bot_pairs` 按精确 `(bot_id, entity_id)` 查询公开 Bot，恢复 BCS 排序，只返回能 join 的记录。
+- `total` 是当前 BCS 页的 join 数量。例如 BCS 当前页 20 条、Backend 命中 10 条时，返回 10 条且 `total=10`。不跨 BCS 页聚合，也不二次切页。
+- Backend 仍是 `PublicBot` 对外字段的唯一权威；BCS 原始响应不得进入 HTTP 响应或日志。
+- Legacy `/api/v1/bot-public/search` 保持 Backend-only；Discover 和 `bot_discover_service.py` 不改。
+
+## 验收
+
+| 用例 | 预期 |
+|---|---|
+| `page=2,page_size=20,search=agent` | BCS 收到 `q=agent,offset=20,limit=20,tc_bot=true`。 |
+| BCS `tc_bot=true` | BCS 仅返回由 TeamClaw Backend onboard 的 owner-suffixed Bot；正常数据下该页与 Backend join 数量相等。 |
+| BCS UUID `bot-1:owner-1` | Backend 只按 `("bot-1", "owner-1")` 查询当前租户公开 Bot。 |
+| 同 bot_id、不同 entity_id | 不得跨 owner join。 |
+| BCS 20 条、Backend 命中 10 条 | 返回 10 条，`total=10`。 |
+| BCS 5xx、错误 JSON、Human、重复或不合法 UUID | 返回固定 `502000`，不退化为 Backend-only。 |
+| 旧 Search / Discover | 保持原有行为。 |

--- a/spec/pipeline/openapi-bot-public-bcs-join/009-pr-report.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/009-pr-report.md
@@ -1,0 +1,44 @@
+# PR 收敛报告：openapi-bot-public-bcs-join
+
+## 范围
+
+- Worktree / repo: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog` / `inclusionAI/Avernet`
+- Head / base: `replay/openapi-bot-public-catalog-on-dev_refactory_collaboration@2217920de` / `dev_refactory_collaboration@974d2f9e1`
+- PR: 创建前未发现相同 head/base 的 PR。
+- PR title: `feat(backend): query TeamClaw Bot catalog from BCS`
+- PR description sections: Problem / Solution / Validation / Compatibility and risk / Spec
+- 人工意见模式: auto
+
+## PR 判定
+
+| 结果 | 证据 | 说明 |
+|---|---|---|
+| Head 与 base 已核验 | `git rev-parse` | Replay 分支仅比最新 base 多 BCS Catalog Search 提交。 |
+| 本地验证通过 | Catalog 118、architecture/DI 71 | Ruff 和相对 base `git diff --check` 通过。 |
+| PR | NOT_CREATED | 下一步推送 replay 分支并创建 PR。 |
+
+## 自动意见
+
+| 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | 无 | — | CLEAR | PR 创建前尚无远端自动意见。 | — | — |
+
+## ACI/CI
+
+| Job/指标 | 状态 | 证据 | 根因 | 修复/提交 | 验证 |
+|---|---|---|---|---|---|
+| 远端 ACI/CI | PENDING | PR 尚未创建 | 无当前 head 的远端 job | — | 本地相关验证已通过 |
+
+## 人工意见
+
+| 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
+|---|---|---|---|---|---|---|
+| 0 | 无 | — | CLEAR | PR 创建前尚无人工意见。 | — | — |
+
+## 当前结论
+
+- PR: NOT_CREATED
+- 自动意见: CLEAR
+- ACI/CI: PENDING
+- 人工意见: CLEAR
+- 下一步: 推送 replay 分支并以 `dev_refactory_collaboration` 创建 PR。

--- a/spec/pipeline/openapi-bot-public-bcs-join/009-pr-report.md
+++ b/spec/pipeline/openapi-bot-public-bcs-join/009-pr-report.md
@@ -3,8 +3,8 @@
 ## 范围
 
 - Worktree / repo: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog` / `inclusionAI/Avernet`
-- Head / base: `replay/openapi-bot-public-catalog-on-dev_refactory_collaboration@2217920de` / `dev_refactory_collaboration@974d2f9e1`
-- PR: 创建前未发现相同 head/base 的 PR。
+- Head / base: `replay/openapi-bot-public-catalog-on-dev_refactory_collaboration@f8b34af65` / `dev_refactory_collaboration@974d2f9e1`
+- PR: [#1319](https://github.com/inclusionAI/Avernet/pull/1319)，OPEN，非 Draft。
 - PR title: `feat(backend): query TeamClaw Bot catalog from BCS`
 - PR description sections: Problem / Solution / Validation / Compatibility and risk / Spec
 - 人工意见模式: auto
@@ -15,30 +15,32 @@
 |---|---|---|
 | Head 与 base 已核验 | `git rev-parse` | Replay 分支仅比最新 base 多 BCS Catalog Search 提交。 |
 | 本地验证通过 | Catalog 118、architecture/DI 71 | Ruff 和相对 base `git diff --check` 通过。 |
-| PR | NOT_CREATED | 下一步推送 replay 分支并创建 PR。 |
+| PR | OPEN | #1319 的 head/base 与当前任务匹配，标题和五个说明段落已核验。 |
 
 ## 自动意见
 
 | 轮次 | 来源 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
 |---|---|---|---|---|---|---|
-| 0 | 无 | — | CLEAR | PR 创建前尚无远端自动意见。 | — | — |
+| 0 | 无 | — | CLEAR | 创建后未发现 review 或 comment。 | — | — |
 
 ## ACI/CI
 
 | Job/指标 | 状态 | 证据 | 根因 | 修复/提交 | 验证 |
 |---|---|---|---|---|---|
-| 远端 ACI/CI | PENDING | PR 尚未创建 | 无当前 head 的远端 job | — | 本地相关验证已通过 |
+| Singlebox coverage | PENDING | GitHub check 已排队 | 当前 head 尚未完成 | — | 本地相关验证已通过 |
+| BCS e2e / unit tests | PENDING | GitHub checks 运行中 | 当前 head 尚未完成 | — | 本地相关验证已通过 |
+| Backend / Engine / BaaS / Gateway unit tests | PENDING | GitHub checks 运行中 | 当前 head 尚未完成 | — | 本地相关验证已通过 |
 
 ## 人工意见
 
 | 轮次 | 作者 | 链接 | 决定 | 理由 | 修改/提交 | 验证 |
 |---|---|---|---|---|---|---|
-| 0 | 无 | — | CLEAR | PR 创建前尚无人工意见。 | — | — |
+| 0 | 无 | — | CLEAR | 创建后未发现人工 review 或 comment。 | — | — |
 
 ## 当前结论
 
-- PR: NOT_CREATED
+- PR: OPEN
 - 自动意见: CLEAR
 - ACI/CI: PENDING
 - 人工意见: CLEAR
-- 下一步: 推送 replay 分支并以 `dev_refactory_collaboration` 创建 PR。
+- 下一步: 等待当前 head 的远端 ACI/CI；有新的自动或人工意见时按 PR 流程处理。

--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -2116,9 +2116,11 @@ in **[`engine-surface.md`](engine-surface.md)**. Summary:
 - **2026-08-20** — Added authenticated Bot catalog reads at
   `GET /openapi/v1/bots/catalog/search` and `/discover`. User and App
   principals see the same allowlisted public projection.
-  `/search` has a tenant-scoped `(bot_id, entity_id)` BCS metadata port; its
-  current fail-closed binding returns `502000 / Catalog service unavailable`
-  until a concrete BCS protocol is configured, with no Backend-only fallback.
+  `/search` maps its current request page to BCS `/v2/bots/search` with
+  `tc_bot=true`, parses each `bot_uuid` as the tenant-scoped `(bot_id, entity_id)`
+  join key, and exposes only the exact public Backend matches. Its `total` is
+  the current page's joined count; BCS failures or invalid response shapes return
+  `502000 / Catalog service unavailable`, with no Backend-only fallback.
 
 - **2026-08-19 — Bot Editors CRUD.** The public surface now exposes
   `GET/POST /openapi/v1/bots/{bot_id}/editors`,

--- a/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
+++ b/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
@@ -1,6 +1,6 @@
 # Bot Catalog OpenAPI（前端接入文档）
 
-> 版本：2026-08-20
+> 版本：2026-08-21
 >
 > 机器可读权威契约为 `src/gateway/configs/schemas/bots.openapi.json`。
 
@@ -21,10 +21,15 @@ GET /openapi/v1/bots/catalog/discover
 GET /openapi/v1/bots/catalog/search
 ```
 
-搜索先按当前租户的 Backend 候选生成有序去重的 `(bot_id, entity_id)` 地址，并通过受信任调用者
-上下文交给 BCS 元信息端口做成员资格内连接。Backend 是对外字段的唯一权威来源；当前各环境的
-端口尚未配置，因此此接口固定返回 `502000 / Catalog service unavailable`，不会回退为
-Backend-only 搜索。未来配置端口后，`total` 与分页仍将基于完整 join 后的候选集。
+Backend 将 `search`、`page` 和 `page_size` 映射到 BCS `/v2/bots/search` 的 `q`、`offset` 和
+`limit`，并固定传 `tc_bot=true`，只读取当前 BCS 页。该标识仅保留由 TeamClaw Backend onboard 的
+Bot。BCS 的 `bot_uuid` 按 `<bot_id>:<entity_id>` 解析后，Backend 在当前租户内以精确二元组查询公开
+Bot 并内连接；Backend 是全部对外字段的唯一权威来源。
+
+BCS 的排序和分页边界保持不变。`tc_bot=true` 使正常数据下 BCS 当前页数量与 Backend join 数量一致；
+这里的 `total` 是**当前页 join 后数量**，不是跨 BCS 页的总数。若迁移或数据同步暂时不一致，接口仍只
+返回实际 join 的记录。BCS 不可用或返回非法记录时固定返回 `502000 / Catalog service unavailable`，
+不会回退为 Backend-only 搜索。
 
 | 参数 | 必填 | 规则 |
 |---|---:|---|
@@ -98,6 +103,6 @@ type DiscoveredPublicBot = PublicBot & {
 | `401000` | User/App Principal 缺失或无效 |
 | `422000` | 参数缺失或范围错误 |
 | `500000` | 搜索服务内部错误 |
-| `502000` | Catalog Search 的 BCS 元信息端口未配置，或推荐服务暂不可用 |
+| `502000` | Catalog Search 的 BCS 请求失败或响应非法，或推荐服务暂不可用 |
 
 前端记录 `request_id` 用于排障，不记录认证信息、完整请求 URL 或搜索关键词。

--- a/src/backend/src/agentclaw/community/core/bot_public/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_public/README.md
@@ -12,7 +12,7 @@ provides:
   - "Bot-public SQLAlchemy models"
 consumes:
   - "BotManagement repo + service"
-  - "BotCatalogMetadata port (membership-only, joined by (bot_id, entity_id))"
+  - "BotCatalogMetadata port (current BCS page, joined by (bot_id, entity_id))"
   - "AntProcess plugins (auth_relationship, bot_publish_approval, antprocess)"
   - "PassportPlugin"
   - "SkillCenter factories"
@@ -30,6 +30,7 @@ internal_dependencies:
   - agentclaw.community.plugin_api.auth_relationship
   - agentclaw.community.plugin_api.bot_publish_approval
   - agentclaw.community.plugin_api.device_sync
+  - agentclaw.community.plugin_api.http_client
   - agentclaw.community.plugin_api.models
   - agentclaw.community.plugin_api.passport
   - agentclaw.community.utils.avernet_tenant

--- a/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
@@ -37,12 +37,14 @@ class BotCatalogMetadataUnavailableError(Exception):
 
 @runtime_checkable
 class BotCatalogMetadataServiceProtocol(Protocol):
-    """Authoritative membership lookup for tenant-scoped catalog Bots."""
+    """Authoritative BCS page lookup for tenant-scoped catalog Bots."""
 
-    def query_public_bot_metadata(
+    def search_public_bot_metadata(
         self,
         *,
-        addresses: Sequence[BotCatalogAddress],
+        search: str | None,
+        page: int,
+        page_size: int,
         caller: BotCatalogCaller,
         request_id: str,
     ) -> Sequence[BotCatalogMetadata]: ...

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
@@ -1,8 +1,10 @@
-"""Fail-closed implementation of the catalog metadata port."""
+"""BCS adapter for the catalog metadata port."""
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+
+import httpx
 
 from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogAddress,
@@ -11,24 +13,95 @@ from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogMetadataUnavailableError,
 )
 from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.http_client import HttpClient
 
 logger = get_logger()
 
 
-class UnavailableBotCatalogMetadataService:
-    """Temporary binding used until the BCS metadata protocol is configured."""
+class BcsBotCatalogMetadataService:
+    """Resolve the requested BCS catalog page into Backend address pairs."""
 
-    def query_public_bot_metadata(
+    def __init__(self, http_client: HttpClient, timeout: float = 30.0) -> None:
+        self._http = http_client
+        self._timeout = timeout
+
+    def search_public_bot_metadata(
         self,
         *,
-        addresses: Sequence[BotCatalogAddress],
+        search: str | None,
+        page: int,
+        page_size: int,
         caller: BotCatalogCaller,
         request_id: str,
     ) -> Sequence[BotCatalogMetadata]:
+        """Read one BCS result page without exposing BCS response data."""
         del caller
-        logger.warning(
-            "[BotCatalogMetadata] request_id=%s candidate_count=%s failure=unconfigured",
+        params: dict[str, str | int] = {
+            "offset": (page - 1) * page_size,
+            "limit": page_size,
+            "tc_bot": True,
+        }
+        if search and search.strip():
+            params["q"] = search
+        try:
+            # COSEC: The injected BCS client supplies the configured upstream host and
+            # this constant relative path prevents request data from selecting a target.
+            response = self._http.get(
+                "/v2/bots/search", params=params, timeout=self._timeout
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, Mapping) or not isinstance(
+                payload.get("items"), list
+            ):
+                raise BotCatalogMetadataUnavailableError()
+
+            seen: set[BotCatalogAddress] = set()
+            metadata: list[BotCatalogMetadata] = []
+            for item in payload["items"]:
+                if not isinstance(item, Mapping) or item.get("actor_kind") != "bot":
+                    raise BotCatalogMetadataUnavailableError()
+                address = self._address_from_bot_uuid(item.get("bot_uuid"))
+                if address is None or address in seen:
+                    raise BotCatalogMetadataUnavailableError()
+                seen.add(address)
+                metadata.append(BotCatalogMetadata(address=address, kind="bot"))
+        except BotCatalogMetadataUnavailableError:
+            logger.warning(
+                "[BcsBotCatalogMetadataService.search] request_id=%s "
+                "failure=invalid_response",
+                request_id,
+            )
+            raise
+        except (httpx.HTTPError, ValueError, TypeError):
+            logger.warning(
+                "[BcsBotCatalogMetadataService.search] request_id=%s "
+                "failure=upstream_unavailable",
+                request_id,
+            )
+            raise BotCatalogMetadataUnavailableError() from None
+        except Exception:  # noqa: BLE001 - BCS failures must fail closed
+            logger.warning(
+                "[BcsBotCatalogMetadataService.search] request_id=%s "
+                "failure=upstream_unavailable",
+                request_id,
+            )
+            raise BotCatalogMetadataUnavailableError() from None
+        logger.info(
+            "[BcsBotCatalogMetadataService.search] request_id=%s result_count=%s",
             request_id,
-            len(addresses),
+            len(metadata),
         )
-        raise BotCatalogMetadataUnavailableError()
+        return metadata
+
+    @staticmethod
+    def _address_from_bot_uuid(value: object) -> BotCatalogAddress | None:
+        if not isinstance(value, str):
+            return None
+        parts = value.rsplit(":", 1)
+        if len(parts) != 2:
+            return None
+        bot_id, entity_id = (part.strip() for part in parts)
+        if not bot_id or not entity_id:
+            return None
+        return BotCatalogAddress(bot_id=bot_id, entity_id=entity_id)

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -1111,40 +1111,38 @@ class BotPublicService:
         caller: BotCatalogCaller,
         request_id: str,
     ) -> Dict[str, Any]:
-        """Return public Backend Bots admitted by the metadata port."""
-        public_bot_result = self._bot_service.list_bots_by_search(
-            public="1", search=search, page=None, page_size=None
-        )
-        candidates = public_bot_result.get("items", [])
-        addresses = self._catalog_addresses(candidates)
+        """Return the current BCS catalog page joined to public Backend Bots."""
         try:
-            metadata = self._catalog_metadata_service.query_public_bot_metadata(
-                addresses=addresses,
+            metadata = self._catalog_metadata_service.search_public_bot_metadata(
+                search=search,
+                page=page,
+                page_size=page_size,
                 caller=caller,
                 request_id=request_id,
             )
-            admitted = self._validated_catalog_addresses(metadata, addresses)
+            addresses = self._validated_catalog_addresses(metadata)
         except BotCatalogMetadataUnavailableError as exc:
             logger.warning(
-                "[BotPublicService.catalog_search] request_id=%s candidate_count=%s "
+                "[BotPublicService.catalog_search] request_id=%s "
                 "failure=metadata_unavailable",
                 request_id,
-                len(candidates),
             )
             raise BotCatalogSearchUnavailableError() from exc
         except Exception as exc:  # noqa: BLE001 - metadata is fail-closed
             logger.warning(
-                "[BotPublicService.catalog_search] request_id=%s candidate_count=%s "
-                "failure=invalid_metadata",
+                "[BotPublicService.catalog_search] request_id=%s failure=invalid_metadata",
                 request_id,
-                len(candidates),
             )
             raise BotCatalogSearchUnavailableError() from exc
-        items = [
-            bot
-            for bot in candidates
-            if self._catalog_address(bot) in admitted
-        ]
+        backend_bots = self._bot_repository.list_public_bots_by_owner_bot_pairs(
+            [(address.bot_id, address.entity_id) for address in addresses]
+        )
+        bots_by_address = {
+            address: bot
+            for bot in backend_bots
+            if (address := self._catalog_address(bot)) in addresses
+        }
+        items = [bots_by_address[address] for address in addresses if address in bots_by_address]
         # Sanitize sensitive fields before pagination and public projection.
         EXT_SENSITIVE_KEYS = {"iam_token"}
         for bot in items:
@@ -1164,46 +1162,31 @@ class BotPublicService:
                         ext[key] = None
                 bot["ext"] = ext
         total = len(items)
-        page_items = items[(page - 1) * page_size:page * page_size]
         logger.info(
-            "[BotPublicService.catalog_search] request_id=%s candidate_count=%s "
-            "joined_count=%s page_count=%s",
+            "[BotPublicService.catalog_search] request_id=%s bcs_count=%s "
+            "joined_count=%s",
             request_id,
-            len(candidates),
+            len(addresses),
             total,
-            len(page_items),
         )
-        return {"total": total, "items": page_items}
+        return {"total": total, "items": items}
 
     @staticmethod
     def _catalog_address(bot: dict[str, Any]) -> BotCatalogAddress | None:
         bot_id = bot.get("bot_id")
-        entity_id = bot.get("entity_id")
+        entity_id = bot.get("entity_id") or bot.get("owner_id")
         if not isinstance(bot_id, str) or not bot_id.strip():
             return None
         if not isinstance(entity_id, str) or not entity_id.strip():
             return None
         return BotCatalogAddress(bot_id=bot_id, entity_id=entity_id)
 
-    @classmethod
-    def _catalog_addresses(
-        cls, candidates: list[dict[str, Any]]
-    ) -> tuple[BotCatalogAddress, ...]:
-        return tuple(
-            dict.fromkeys(
-                address
-                for candidate in candidates
-                if (address := cls._catalog_address(candidate)) is not None
-            )
-        )
-
     @staticmethod
     def _validated_catalog_addresses(
         metadata: Any,
-        requested: tuple[BotCatalogAddress, ...],
-    ) -> set[BotCatalogAddress]:
-        requested_set = set(requested)
-        admitted: set[BotCatalogAddress] = set()
+    ) -> tuple[BotCatalogAddress, ...]:
+        addresses: list[BotCatalogAddress] = []
+        seen: set[BotCatalogAddress] = set()
         for item in metadata:
             if not isinstance(item, BotCatalogMetadata) or item.kind != "bot":
                 raise BotCatalogMetadataUnavailableError()
@@ -1212,12 +1195,12 @@ class BotPublicService:
                 not isinstance(address, BotCatalogAddress)
                 or not address.bot_id.strip()
                 or not address.entity_id.strip()
-                or address not in requested_set
-                or address in admitted
+                or address in seen
             ):
                 raise BotCatalogMetadataUnavailableError()
-            admitted.add(address)
-        return admitted
+            seen.add(address)
+            addresses.append(address)
+        return tuple(addresses)
 
     def list_my_bot_friends(
         self,

--- a/src/backend/src/agentclaw/community/di/modules/bot_public_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_public_module.py
@@ -19,6 +19,7 @@ through the injector.
 """
 from __future__ import annotations
 
+from typing import Annotated
 
 from injector import Binder, Module, inject, provider, singleton
 
@@ -31,7 +32,7 @@ from agentclaw.community.core.repository.protocols.bot import BotFriendRepositor
 from agentclaw.community.core.bot_public.services.bot_discover_service import BotDiscoverService
 from agentclaw.community.core.bot_public.services.bot_public_service import BotPublicService
 from agentclaw.community.core.bot_public.services.bot_catalog_metadata_service import (
-    UnavailableBotCatalogMetadataService,
+    BcsBotCatalogMetadataService,
 )
 from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogMetadataServiceProtocol,
@@ -47,6 +48,7 @@ from agentclaw.community.plugin_api.bot_publish_approval import BotPublishApprov
 from agentclaw.community.plugin_api.passport import PassportPlugin
 from agentclaw.community.core.repository.implementations.bot.friend import BotFriendRepository as UnifiedBotFriendRepository
 from agentclaw.community.core.devices.services.device_sync_dispatcher import DeviceSyncDispatcher
+from agentclaw.community.plugin_api.http_client import QUALIFIER_BCN, HttpClient
 
 
 logger = get_logger()
@@ -69,11 +71,15 @@ class BotPublicModule(Module):
             to=UnifiedBotFriendRepository,
             scope=singleton,
         )
-        binder.bind(
-            BotCatalogMetadataServiceProtocol,
-            to=UnavailableBotCatalogMetadataService,
-            scope=singleton,
-        )
+
+    @singleton
+    @provider
+    @inject
+    def catalog_metadata_service(
+        self,
+        http_client: Annotated[HttpClient, QUALIFIER_BCN],
+    ) -> BotCatalogMetadataServiceProtocol:
+        return BcsBotCatalogMetadataService(http_client=http_client)
 
     @singleton
     @provider

--- a/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
@@ -1,42 +1,204 @@
-"""Catalog metadata port behavior."""
+"""BCS-backed catalog metadata adapter behavior."""
 
 from __future__ import annotations
 
+import importlib
+from unittest.mock import Mock
+
+import httpx
 import pytest
 
 from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogAddress,
     BotCatalogCaller,
+    BotCatalogMetadata,
     BotCatalogMetadataServiceProtocol,
     BotCatalogMetadataUnavailableError,
 )
-from agentclaw.community.core.bot_public.services.bot_catalog_metadata_service import (
-    UnavailableBotCatalogMetadataService,
-)
 from agentclaw.community.di.container import build_injector
 from agentclaw.community.di.profile import DeployProfile
+from agentclaw.community.plugins.local.http_client import LocalHttpClient
 
 
-@pytest.mark.parametrize("addresses", [(), (BotCatalogAddress("bot-1", "entity-1"),)])
-def test_unavailable_catalog_metadata_service_fails_closed_for_every_candidate_shape(
-    addresses: tuple[BotCatalogAddress, ...],
+def _response(status_code: int, payload: object) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json=payload,
+        request=httpx.Request("GET", "http://bcs.test/v2/bots/search"),
+    )
+
+
+def _caller() -> BotCatalogCaller:
+    return BotCatalogCaller(tenant_id="tenant-1", user_id="user-1", app_id=9)
+
+
+def _service_class():
+    module = importlib.import_module(
+        "agentclaw.community.core.bot_public.services.bot_catalog_metadata_service"
+    )
+    service_class = getattr(module, "BcsBotCatalogMetadataService", None)
+    assert service_class is not None, "BCS catalog adapter must be available"
+    return service_class
+
+
+def _make_service() -> tuple[BotCatalogMetadataServiceProtocol, LocalHttpClient]:
+    http = LocalHttpClient(base_url="http://bcs.test")
+    return _service_class()(http_client=http), http
+
+
+def test_bcs_catalog_search_maps_current_page_and_parses_exact_address() -> None:
+    """A wrong page mapping or UUID split would return the wrong catalog page."""
+    service, http = _make_service()
+    http.set_response(
+        "get",
+        _response(
+            200,
+            {
+                "total": 21,
+                "items": [
+                    {
+                        "bot_uuid": "bot-1:owner-1",
+                        "actor_kind": "bot",
+                        "name": "ignored-by-backend",
+                    }
+                ],
+            },
+        ),
+    )
+
+    result = service.search_public_bot_metadata(
+        search="agent", page=2, page_size=20, caller=_caller(), request_id="trace-1"
+    )
+
+    assert result == [
+        BotCatalogMetadata(BotCatalogAddress("bot-1", "owner-1"), "bot")
+    ]
+    call = http.calls_to("get")[0]
+    assert call.args[0] == "/v2/bots/search"
+    assert call.kwargs["params"] == {
+        "q": "agent",
+        "offset": 20,
+        "limit": 20,
+        "tc_bot": True,
+    }
+    assert "headers" not in call.kwargs
+
+
+def test_bcs_catalog_search_omits_blank_query_and_keeps_page_boundary() -> None:
+    """Listing all catalog Bots must not turn a blank query into a BCS filter."""
+    service, http = _make_service()
+    http.set_response("get", _response(200, {"total": 0, "items": []}))
+
+    result = service.search_public_bot_metadata(
+        search=" ", page=3, page_size=10, caller=_caller(), request_id="trace-2"
+    )
+
+    assert result == []
+    assert http.calls_to("get")[0].kwargs["params"] == {
+        "offset": 20,
+        "limit": 10,
+        "tc_bot": True,
+    }
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        {"bot_uuid": "bot-without-owner", "actor_kind": "bot"},
+        {"bot_uuid": ":owner-1", "actor_kind": "bot"},
+        {"bot_uuid": "bot-1:", "actor_kind": "bot"},
+        {"bot_uuid": 1, "actor_kind": "bot"},
+        {"bot_uuid": "bot-1:owner-1", "actor_kind": "human"},
+    ],
+)
+def test_bcs_catalog_search_fails_closed_for_invalid_item(
+    item: dict[str, object],
 ) -> None:
-    """Catches a future fallback that silently treats an unconfigured BCS port as empty."""
-    service = UnavailableBotCatalogMetadataService()
-    assert isinstance(service, BotCatalogMetadataServiceProtocol)
+    """Malformed or non-Bot BCS records must not produce partial public results."""
+    service, http = _make_service()
+    http.set_response("get", _response(200, {"total": 1, "items": [item]}))
 
     with pytest.raises(BotCatalogMetadataUnavailableError):
-        service.query_public_bot_metadata(
-            addresses=addresses,
-            caller=BotCatalogCaller(tenant_id="tenant-1", user_id="user-1", app_id=9),
-            request_id="trace-1",
+        service.search_public_bot_metadata(
+            search="agent", page=1, page_size=20, caller=_caller(), request_id="trace-3"
         )
 
 
-def test_test_profile_binds_catalog_metadata_protocol_to_unavailable_service() -> None:
-    """Catches an accidental local/test fallback that would make catalog membership up."""
+@pytest.mark.parametrize("payload", [{}, {"items": {}}])
+def test_bcs_catalog_search_fails_closed_for_invalid_response_shape(
+    payload: dict[str, object],
+) -> None:
+    """A BCS response without a list of records must not yield a partial page."""
+    service, http = _make_service()
+    http.set_response("get", _response(200, payload))
+
+    with pytest.raises(BotCatalogMetadataUnavailableError):
+        service.search_public_bot_metadata(
+            search="agent", page=1, page_size=20, caller=_caller(), request_id="trace-shape"
+        )
+
+
+def test_bcs_catalog_search_fails_closed_for_malformed_json(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Malformed BCS JSON stays unavailable and never logs the upstream detail."""
+    response = Mock()
+    response.raise_for_status.return_value = None
+    response.json.side_effect = ValueError("private malformed BCS body")
+    service, http = _make_service()
+    http.set_response("get", response)
+
+    with caplog.at_level("WARNING"), pytest.raises(BotCatalogMetadataUnavailableError):
+        service.search_public_bot_metadata(
+            search="agent", page=1, page_size=20, caller=_caller(), request_id="trace-json"
+        )
+
+    assert "failure=upstream_unavailable" in caplog.text
+    assert "private malformed BCS body" not in caplog.text
+
+
+def test_bcs_catalog_search_fails_closed_for_duplicate_or_upstream_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Duplicate addresses and upstream details must not escape through the catalog."""
+    service, http = _make_service()
+    http.set_response(
+        "get",
+        _response(
+            200,
+            {
+                "total": 2,
+                "items": [
+                    {"bot_uuid": "bot-1:owner-1", "actor_kind": "bot"},
+                    {"bot_uuid": "bot-1:owner-1", "actor_kind": "bot"},
+                ],
+            },
+        ),
+    )
+
+    with caplog.at_level("WARNING"), pytest.raises(BotCatalogMetadataUnavailableError):
+        service.search_public_bot_metadata(
+            search="agent", page=1, page_size=20, caller=_caller(), request_id="trace-4"
+        )
+
+    assert "failure=invalid_response" in caplog.text
+
+
+def test_bcs_catalog_search_fails_closed_for_http_error() -> None:
+    """A BCS failure must remain a fixed unavailable decision, not a Backend fallback."""
+    service, http = _make_service()
+    http.set_response("get", _response(503, {"message": "private upstream detail"}))
+
+    with pytest.raises(BotCatalogMetadataUnavailableError):
+        service.search_public_bot_metadata(
+            search="agent", page=1, page_size=20, caller=_caller(), request_id="trace-5"
+        )
+
+
+def test_test_profile_binds_catalog_metadata_protocol_to_bcs_adapter() -> None:
+    """The test profile must use the real adapter with a no-network HTTP seam."""
     port = build_injector(profile=DeployProfile.TEST).get(
         BotCatalogMetadataServiceProtocol
     )
 
-    assert isinstance(port, UnavailableBotCatalogMetadataService)
+    assert isinstance(port, _service_class())

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -76,7 +76,10 @@ def _make_bot(bot_id="bot1", owner_id="owner1", public="0", ext=None):
 
 
 def _make_catalog_bot(bot_id: str, entity_id: str):
-    return {**_make_bot(bot_id=bot_id), "entity_id": entity_id}
+    return {
+        **_make_bot(bot_id=bot_id, owner_id=entity_id),
+        "entity_id": entity_id,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -748,113 +751,94 @@ class TestSearchPublicBotsByKeyword:
         result = svc.search_public_bots_by_keyword(search="catalog")
 
         assert result["total"] == 1
-        metadata.query_public_bot_metadata.assert_not_called()
+        metadata.search_public_bot_metadata.assert_not_called()
 
-    def test_catalog_search_joins_exact_addresses_before_pagination(self):
-        bots = [
-            _make_catalog_bot("bot-1", "entity-1"),
-            _make_catalog_bot("bot-2", "entity-2"),
-            _make_catalog_bot("bot-3", "entity-3"),
-        ]
-        bot_service = MagicMock()
-        bot_service.list_bots_by_search.return_value = {"total": 3, "items": bots}
+    def test_catalog_search_joins_only_the_current_bcs_page_and_reports_its_count(self):
         metadata = MagicMock()
-        metadata.query_public_bot_metadata.return_value = [
+        metadata.search_public_bot_metadata.return_value = [
             BotCatalogMetadata(BotCatalogAddress("bot-1", "entity-1"), "bot"),
-            BotCatalogMetadata(BotCatalogAddress("bot-3", "entity-3"), "bot"),
+            BotCatalogMetadata(BotCatalogAddress("missing", "entity-2"), "bot"),
         ]
-        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+        repository = MagicMock()
+        repository.list_public_bots_by_owner_bot_pairs.return_value = [
+            _make_catalog_bot("bot-1", "entity-1"),
+        ]
+        svc = _make_service(
+            bot_repository=repository, catalog_metadata_service=metadata
+        )
 
         result = svc.search_catalog_public_bots_by_keyword(
-            search="catalog",
-            page=2,
-            page_size=1,
+            search="agent",
+            page=3,
+            page_size=20,
             caller=BotCatalogCaller("tenant-1", "user-1", 7),
             request_id="trace-1",
         )
 
-        bot_service.list_bots_by_search.assert_called_once_with(
-            public="1", search="catalog", page=None, page_size=None
+        assert result["total"] == 1
+        assert [bot["bot_id"] for bot in result["items"]] == ["bot-1"]
+        metadata.search_public_bot_metadata.assert_called_once_with(
+            search="agent",
+            page=3,
+            page_size=20,
+            caller=BotCatalogCaller("tenant-1", "user-1", 7),
+            request_id="trace-1",
         )
-        assert result["total"] == 2
-        assert [bot["bot_id"] for bot in result["items"]] == ["bot-3"]
+        repository.list_public_bots_by_owner_bot_pairs.assert_called_once_with(
+            [("bot-1", "entity-1"), ("missing", "entity-2")]
+        )
 
-    def test_catalog_search_de_duplicates_ordered_addresses_and_keeps_entity_identity(self):
-        bots = [
-            _make_catalog_bot("shared", "entity-a"),
-            _make_catalog_bot("shared", "entity-b"),
-            _make_catalog_bot("shared", "entity-a"),
-        ]
-        bot_service = MagicMock()
-        bot_service.list_bots_by_search.return_value = {"total": 3, "items": bots}
+    def test_catalog_search_restores_bcs_order_and_isolates_same_bot_id_by_entity(self):
         metadata = MagicMock()
-        metadata.query_public_bot_metadata.return_value = [
+        metadata.search_public_bot_metadata.return_value = [
+            BotCatalogMetadata(BotCatalogAddress("shared", "entity-a"), "bot"),
             BotCatalogMetadata(BotCatalogAddress("shared", "entity-b"), "bot"),
         ]
-        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+        repository = MagicMock()
+        repository.list_public_bots_by_owner_bot_pairs.return_value = [
+            _make_catalog_bot("shared", "entity-b"),
+            _make_catalog_bot("shared", "entity-other"),
+            _make_catalog_bot("shared", "entity-a"),
+        ]
+        svc = _make_service(
+            bot_repository=repository, catalog_metadata_service=metadata
+        )
 
         result = svc.search_catalog_public_bots_by_keyword(
             caller=BotCatalogCaller("tenant-1", None, 7), request_id="trace-2"
         )
 
-        assert result["total"] == 1
-        assert result["items"][0]["entity_id"] == "entity-b"
-        assert metadata.query_public_bot_metadata.call_args.kwargs["addresses"] == (
-            BotCatalogAddress("shared", "entity-a"),
-            BotCatalogAddress("shared", "entity-b"),
-        )
-
-    @pytest.mark.parametrize(
-        "metadata_result",
-        [
-            [BotCatalogMetadata(BotCatalogAddress("bot-1", "entity-1"), "group")],
-            [BotCatalogMetadata(BotCatalogAddress("bot-1", "entity-1"), "bot")] * 2,
-            [BotCatalogMetadata(BotCatalogAddress("other", "entity-1"), "bot")],
-            [BotCatalogMetadata(BotCatalogAddress("", "entity-1"), "bot")],
-        ],
-    )
-    def test_catalog_search_fails_closed_on_invalid_metadata(self, metadata_result):
-        bot_service = MagicMock()
-        bot_service.list_bots_by_search.return_value = {"total": 1, "items": [_make_bot()]}
-        metadata = MagicMock()
-        metadata.query_public_bot_metadata.return_value = metadata_result
-        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
-
-        with pytest.raises(BotCatalogSearchUnavailableError):
-            svc.search_catalog_public_bots_by_keyword(
-                search="catalog",
-                caller=BotCatalogCaller("tenant-1", "user-1", None),
-                request_id="trace-3",
-            )
+        assert result["total"] == 2
+        assert [bot["entity_id"] for bot in result["items"]] == [
+            "entity-a",
+            "entity-b",
+        ]
 
     def test_catalog_search_translates_metadata_unavailable_without_details(self):
-        bot_service = MagicMock()
-        bot_service.list_bots_by_search.return_value = {"total": 1, "items": [_make_bot()]}
         metadata = MagicMock()
-        metadata.query_public_bot_metadata.side_effect = BotCatalogMetadataUnavailableError(
+        metadata.search_public_bot_metadata.side_effect = BotCatalogMetadataUnavailableError(
             "internal detail"
         )
-        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+        repository = MagicMock()
+        svc = _make_service(
+            bot_repository=repository, catalog_metadata_service=metadata
+        )
 
         with pytest.raises(BotCatalogSearchUnavailableError) as error:
             svc.search_catalog_public_bots_by_keyword(
                 caller=BotCatalogCaller("tenant-1", "user-1", None),
-                request_id="trace-4",
+                request_id="trace-3",
             )
 
         assert str(error.value) == ""
+        repository.list_public_bots_by_owner_bot_pairs.assert_not_called()
 
     def test_catalog_search_fails_closed_on_unexpected_metadata_error(self, caplog):
-        bot_service = MagicMock()
-        bot_service.list_bots_by_search.return_value = {
-            "total": 1,
-            "items": [_make_bot()],
-        }
         metadata = MagicMock()
-        metadata.query_public_bot_metadata.side_effect = RuntimeError(
+        metadata.search_public_bot_metadata.side_effect = RuntimeError(
             "private upstream detail"
         )
-        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+        svc = _make_service(catalog_metadata_service=metadata)
 
         with caplog.at_level("WARNING"), pytest.raises(
             BotCatalogSearchUnavailableError
@@ -865,10 +849,7 @@ class TestSearchPublicBotsByKeyword:
             )
 
         assert str(error.value) == ""
-        assert (
-            "request_id=trace-unexpected candidate_count=1 "
-            "failure=invalid_metadata"
-        ) in caplog.text
+        assert "request_id=trace-unexpected failure=invalid_metadata" in caplog.text
         assert "private upstream detail" not in caplog.text
 
     def test_catalog_search_redacts_sensitive_fields_and_malformed_ext(self):
@@ -884,13 +865,8 @@ class TestSearchPublicBotsByKeyword:
                 ),
             }
         )
-        bot_service = MagicMock()
-        bot_service.list_bots_by_search.return_value = {
-            "total": 2,
-            "items": [malformed, sensitive],
-        }
         metadata = MagicMock()
-        metadata.query_public_bot_metadata.return_value = [
+        metadata.search_public_bot_metadata.return_value = [
             BotCatalogMetadata(
                 BotCatalogAddress("malformed", "entity-malformed"), "bot"
             ),
@@ -898,7 +874,14 @@ class TestSearchPublicBotsByKeyword:
                 BotCatalogAddress("sensitive", "entity-sensitive"), "bot"
             ),
         ]
-        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
+        repository = MagicMock()
+        repository.list_public_bots_by_owner_bot_pairs.return_value = [
+            malformed,
+            sensitive,
+        ]
+        svc = _make_service(
+            bot_repository=repository, catalog_metadata_service=metadata
+        )
 
         result = svc.search_catalog_public_bots_by_keyword(
             caller=BotCatalogCaller("tenant-1", "user-1", None),
@@ -914,44 +897,6 @@ class TestSearchPublicBotsByKeyword:
             "iam_token": None,
             "visible": "kept",
         }
-
-    def test_catalog_search_filters_blank_backend_addresses(self):
-        bots = [
-            _make_catalog_bot(" ", "entity-blank-bot"),
-            _make_catalog_bot("bot-blank-entity", "\t"),
-            _make_catalog_bot("valid", "entity-valid"),
-        ]
-        bot_service = MagicMock()
-        bot_service.list_bots_by_search.return_value = {"total": 3, "items": bots}
-        metadata = MagicMock()
-        metadata.query_public_bot_metadata.return_value = [
-            BotCatalogMetadata(BotCatalogAddress("valid", "entity-valid"), "bot")
-        ]
-        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
-
-        result = svc.search_catalog_public_bots_by_keyword(
-            caller=BotCatalogCaller("tenant-1", "user-1", None),
-            request_id="trace-blank-address",
-        )
-
-        assert metadata.query_public_bot_metadata.call_args.kwargs["addresses"] == (
-            BotCatalogAddress("valid", "entity-valid"),
-        )
-        assert [bot["bot_id"] for bot in result["items"]] == ["valid"]
-
-    def test_catalog_search_queries_metadata_even_when_backend_has_no_candidates(self):
-        bot_service = MagicMock()
-        bot_service.list_bots_by_search.return_value = {"total": 0, "items": []}
-        metadata = MagicMock()
-        metadata.query_public_bot_metadata.side_effect = BotCatalogMetadataUnavailableError()
-        svc = _make_service(bot_service=bot_service, catalog_metadata_service=metadata)
-
-        with pytest.raises(BotCatalogSearchUnavailableError):
-            svc.search_catalog_public_bots_by_keyword(
-                caller=BotCatalogCaller("tenant-1", None, None), request_id="trace-5"
-            )
-
-        assert metadata.query_public_bot_metadata.call_args.kwargs["addresses"] == ()
 
     def test_catalog_read_without_user_skips_friendship_lookup(self):
         bot_service = MagicMock()


### PR DESCRIPTION
## Problem

Catalog Search had a fail-closed metadata seam but no concrete BCS page query. The OpenAPI catalog endpoint therefore could not return the BCS-selected TeamClaw Bot page while retaining Backend as the authority for public response fields.

## Solution

- Query BCS `GET /v2/bots/search` with the requested page mapped to `q`, `offset`, and `limit`, plus fixed `tc_bot=true`.
- Parse only `bot_uuid=<bot_id>:<entity_id>` records, then perform one tenant-scoped Backend exact-pair inner join in BCS page order.
- Return the current page's actual joined count as `total`; preserve fail-closed `502000` mapping for BCS transport or response failures.
- Keep legacy `/api/v1/bot-public/search`, Discover, BCSFuse behavior, and the public allowlist projection unchanged.

## Validation

- `uv run pytest tests/community/core/bot_public/test_bot_catalog_metadata_service.py tests/community/core/bot_public/test_bot_public_service.py tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py tests/community/endpoints/test_openapi_bot_public_catalog.py -q` — 118 passed.
- Relevant architecture/DI suite — 71 passed.
- Ruff and `git diff --check origin/dev_refactory_collaboration...HEAD` passed.

## Compatibility and risk

The public Catalog Search path and request parameters are unchanged. BCS is the page membership authority and Backend remains the public-field authority. Normal synchronized `tc_bot=true` data joins one-to-one; a temporary mismatch returns only the actual joined records rather than fabricating a total. Real BCS connectivity is covered by deployment/CI, not the local `LocalHttpClient` seam.

## Spec

- `spec/pipeline/openapi-bot-public-bcs-join/005-bcs-search-integration-spec.md`
- `spec/pipeline/openapi-bot-public-bcs-join/003-review-report.md`
- `spec/pipeline/openapi-bot-public-bcs-join/003b-regression-report.md`
