### PR TITLE
fix(gateway): isolate singlebox config environment

### DIFF
--- a/scripts/fixtures/gateway_env_capture.sh
+++ b/scripts/fixtures/gateway_env_capture.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s:%s\n' "$1" "${SERVER_ENV:-}" >> "${CAPTURE_FILE}"

--- a/scripts/modules/gateway.sh
+++ b/scripts/modules/gateway.sh
@@ -8,6 +8,7 @@ GATEWAY_LOG="${LOG_DIR}/gateway.log"
 GATEWAY_PID_FILE="${DEP_DIR}/gateway.pid"
 GATEWAY_APP_SCRIPT="${GATEWAY_DIR}/scripts/app.sh"
 GATEWAY_PORT="${GATEWAY_PORT:-8889}"
+GATEWAY_SERVER_ENV="${GATEWAY_SERVER_ENV:-local}"
 
 
 gateway_setup() {
@@ -62,7 +63,7 @@ gateway_start() {
 
     (
         cd "${GATEWAY_DIR}"
-        SERVER_ENV="${SERVER_ENV:-local}" GATEWAY_PORT="${GATEWAY_PORT}" APP_PORT="${GATEWAY_PORT}" "${GATEWAY_APP_SCRIPT}" start --mode bare
+        SERVER_ENV="${GATEWAY_SERVER_ENV}" GATEWAY_PORT="${GATEWAY_PORT}" APP_PORT="${GATEWAY_PORT}" "${GATEWAY_APP_SCRIPT}" start --mode bare
     ) >> "${GATEWAY_LOG}" 2>&1
 
     local gateway_pid=""
@@ -88,7 +89,7 @@ gateway_stop() {
     log_info "Stopping Gateway..."
 
     if [ -x "${GATEWAY_APP_SCRIPT}" ]; then
-        (cd "${GATEWAY_DIR}" && SERVER_ENV="${SERVER_ENV:-local}" GATEWAY_PORT="${GATEWAY_PORT}" APP_PORT="${GATEWAY_PORT}" "${GATEWAY_APP_SCRIPT}" stop) >> "${GATEWAY_LOG}" 2>&1 || true
+        (cd "${GATEWAY_DIR}" && SERVER_ENV="${GATEWAY_SERVER_ENV}" GATEWAY_PORT="${GATEWAY_PORT}" APP_PORT="${GATEWAY_PORT}" "${GATEWAY_APP_SCRIPT}" stop) >> "${GATEWAY_LOG}" 2>&1 || true
     fi
 
     if [ -f "${GATEWAY_PID_FILE}" ]; then

--- a/scripts/test_singlebox_gateway_env.sh
+++ b/scripts/test_singlebox_gateway_env.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE="${ROOT}/scripts/fixtures/gateway_env_capture.sh"
+TEST_ROOT="$(mktemp -d)"
+
+cleanup() {
+  local status=$?
+  rm -rf "${TEST_ROOT}"
+  exit "${status}"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_capture() {
+  local expected_env="$1"
+  local expected
+  expected="$(printf 'start:%s\nstop:%s\n' "${expected_env}" "${expected_env}")"
+  [[ "$(cat "${CAPTURE_FILE}")" == "${expected%$'\n'}" ]] || fail "Gateway should receive ${expected_env}, got $(tr '\n' ',' < "${CAPTURE_FILE}")"
+}
+
+export LOG_DIR="${TEST_ROOT}/logs"
+export DEP_DIR="${TEST_ROOT}/dependencies"
+export GATEWAY_DIR="${ROOT}/src/gateway"
+export GATEWAY_PORT="18889"
+export CAPTURE_FILE="${TEST_ROOT}/gateway-env.txt"
+mkdir -p "${LOG_DIR}" "${DEP_DIR}"
+
+source "${ROOT}/scripts/modules/gateway.sh"
+
+GATEWAY_APP_SCRIPT="${TEST_ROOT}/gateway-env-capture.sh"
+cp "${FIXTURE}" "${GATEWAY_APP_SCRIPT}"
+chmod +x "${GATEWAY_APP_SCRIPT}"
+
+log_info() { :; }
+log_error() { :; }
+gateway_setup() { :; }
+check_directory_exists() { [[ -d "$1" ]]; }
+stop_port_processes_if_owned() { :; }
+stop_matching_processes_if_owned() { :; }
+require_port_available_after_owned_stop() { :; }
+stop_process_if_owned() { :; }
+gateway_ready() { return 0; }
+
+export SERVER_ENV="dev"
+GATEWAY_SERVER_ENV="${GATEWAY_SERVER_ENV:-local}"
+gateway_start
+gateway_stop
+assert_capture "local"
+
+: > "${CAPTURE_FILE}"
+export GATEWAY_SERVER_ENV="prepub"
+gateway_start
+gateway_stop
+assert_capture "prepub"
+
+printf 'PASS: singlebox gateway environment tests\n'


### PR DESCRIPTION
## Problem

Singlebox exports `SERVER_ENV=dev` for the backend, causing Gateway to select the unavailable `application-dev.yaml` and fail before serving port 8889.

## Solution

Give Gateway an independent `GATEWAY_SERVER_ENV`, defaulting to `local`, and use it consistently for both start and stop. Add a shell regression test that verifies the global `SERVER_ENV=dev` cannot leak into Gateway while an explicit Gateway override remains available.

## Validation

- `bash scripts/test_singlebox_gateway_env.sh`
- `bash scripts/test_singlebox_default_mode.sh`
- `bash scripts/test_singlebox_service_guards.sh`
- `bash -n scripts/modules/gateway.sh scripts/test_singlebox_gateway_env.sh scripts/fixtures/gateway_env_capture.sh`
- `cd src/gateway && uv run pytest -q tests/architecture/test_config_key_consistency.py tests/architecture/test_env_import_regression.py tests/unit/scripts/test_dump_and_publish_script.py tests/unit/scripts/test_gate_and_publish.py` — 12 passed
- Live isolated startup with `SERVER_ENV=dev GATEWAY_PORT=18889 ./scripts/singlebox.sh start gateway`; `GET /health` returned `{"status":"ok"}`.

## Compatibility and risk

No public API or OpenAPI contract changes. Existing explicit Gateway deployments can set `GATEWAY_SERVER_ENV`; otherwise Singlebox now reliably selects `application-local.yaml` independently of the backend environment.