### PR TITLE
fix(bcs): append task SSE response deltas directly

### DIFF
--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -841,7 +841,7 @@ async fn handle_task_bot_event(
         return Ok(Vec::new());
     }
 
-    let response_text = preview_task_response_text(&entry, cmd).await;
+    let response_text = preview_task_response_text(flow, &entry, cmd).await;
     let group = flow.group.get(&entry.group_id).await;
 
     let target_bot_name = entry
@@ -938,10 +938,15 @@ async fn handle_task_bot_event(
     Ok(vec![result])
 }
 
-async fn preview_task_response_text(entry: &TaskEntry, cmd: &BotEventCommand) -> String {
+async fn preview_task_response_text(
+    flow: &BcsMessageFlow,
+    entry: &TaskEntry,
+    cmd: &BotEventCommand,
+) -> String {
     let scratch = TaskStore::new();
     scratch.register(entry.clone()).await;
-    record_task_response_event_in_store(&scratch, &entry.task_id, cmd).await;
+    let is_delta_mode = flow.message_tracker.is_chat_delta_mode(&cmd.run_id).await;
+    record_task_response_event_in_store(&scratch, &entry.task_id, cmd, is_delta_mode).await;
     let attempted_entry = scratch.get(&entry.task_id).await.unwrap_or_else(|| entry.clone());
     task_response_text(&attempted_entry, cmd)
 }
@@ -962,13 +967,21 @@ fn task_response_text(entry: &TaskEntry, cmd: &BotEventCommand) -> String {
 }
 
 async fn record_task_response_event(flow: &BcsMessageFlow, task_id: &str, cmd: &BotEventCommand) {
-    record_task_response_event_in_store(flow.task_store.as_ref(), task_id, cmd).await;
+    let is_delta_mode = flow.message_tracker.is_chat_delta_mode(&cmd.run_id).await;
+    record_task_response_event_in_store(
+        flow.task_store.as_ref(),
+        task_id,
+        cmd,
+        is_delta_mode,
+    )
+    .await;
 }
 
 async fn record_task_response_event_in_store(
     task_store: &TaskStore,
     task_id: &str,
     cmd: &BotEventCommand,
+    is_delta_mode: bool,
 ) {
     if cmd.event_type == "agent"
         && cmd.event_payload.get("stream").and_then(|value| value.as_str()) == Some("tool")
@@ -981,12 +994,22 @@ async fn record_task_response_event_in_store(
             task_store.record_response_tool_call(task_id).await;
         }
         ChatEventState::Delta => {
-            let text = extract_message_text(&cmd.event_payload);
-            task_store.record_response_text(task_id, &text).await;
+            if let Some(delta) = extract_delta_text(&cmd.event_payload) {
+                task_store.record_response_delta(task_id, delta).await;
+            } else {
+                let text = extract_message_text(&cmd.event_payload);
+                task_store.record_response_text(task_id, &text).await;
+            }
         }
         ChatEventState::Final => {
-            let text = extract_message_text(&cmd.event_payload);
-            task_store.record_final_response_text(task_id, &text).await;
+            // In SSE delta mode every byte of visible response text was already
+            // appended from `delta_text`. The synthesized final `message` is
+            // only the current MessageTracker segment, not a task-level
+            // snapshot, so merging it here would append that segment twice.
+            if !is_delta_mode {
+                let text = extract_message_text(&cmd.event_payload);
+                task_store.record_final_response_text(task_id, &text).await;
+            }
         }
         ChatEventState::Error | ChatEventState::Aborted => {}
     }

--- a/src/bcs/crates/services/bcs-message-flow/src/task_store.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/task_store.rs
@@ -57,6 +57,27 @@ impl TaskStore {
         self.record_response_text_with_final(task_id, text, false).await;
     }
 
+    /// Append one authoritative streaming delta to the task response.
+    ///
+    /// Unlike [`Self::record_response_text`], this does not try to infer
+    /// whether `delta` is a cumulative snapshot. SSE `delta_text` frames are
+    /// already incremental, including when MessageTracker starts a new chat
+    /// segment after a thinking or approval boundary.
+    pub async fn record_response_delta(&self, task_id: &str, delta: &str) {
+        if delta.is_empty() {
+            return;
+        }
+        let mut tasks = self.tasks.write().await;
+        let Some(entry) = tasks.get_mut(task_id) else {
+            return;
+        };
+        if entry.response_mode == ChatResponseMode::Full {
+            return;
+        }
+        entry.response_full_content.push_str(delta);
+        entry.response_content.push_str(delta);
+    }
+
     pub async fn record_final_response_text(&self, task_id: &str, text: &str) {
         self.record_response_text_with_final(task_id, text, true).await;
     }

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -3394,6 +3394,89 @@ async fn manager_worker_task_final_delta_mode_flushes_only_open_worker_segment()
 }
 
 #[tokio::test]
+async fn manager_worker_sse_task_response_appends_raw_deltas_across_thinking_boundary() {
+    let (_support, repo, flow) = manager_worker_flow_with_repo().await;
+    register_manager_worker_task(
+        &flow,
+        "task-response-delta-thinking",
+        ChatResponseMode::AfterLastToolCall,
+    )
+    .await;
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-worker".to_string(),
+        run_id: "task-response-delta-thinking".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "chat.event".to_string(),
+        event_payload: json!({ "state": "delta", "delta_text": "A" }),
+        state: ChatEventState::Delta,
+        bcs_session_id: Some("group-1:abcdef12".to_string()),
+    })
+    .await
+    .unwrap();
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-worker".to_string(),
+        run_id: "task-response-delta-thinking".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "agent".to_string(),
+        event_payload: json!({
+            "stream": "thinking",
+            "data": { "delta": "checking" },
+        }),
+        state: ChatEventState::Delta,
+        bcs_session_id: Some("group-1:abcdef12".to_string()),
+    })
+    .await
+    .unwrap();
+    for delta in ["B1", "B2"] {
+        flow.handle_bot_event(BotEventCommand {
+            bot_id: "bot-worker".to_string(),
+            run_id: "task-response-delta-thinking".to_string(),
+            group_id: "group-1".to_string(),
+            event_type: "chat.event".to_string(),
+            event_payload: json!({ "state": "delta", "delta_text": delta }),
+            state: ChatEventState::Delta,
+            bcs_session_id: Some("group-1:abcdef12".to_string()),
+        })
+        .await
+        .unwrap();
+    }
+
+    assert_eq!(
+        flow.task_store
+            .get("task-response-delta-thinking")
+            .await
+            .unwrap()
+            .response_content,
+        "AB1B2",
+        "TaskStore must append raw SSE deltas instead of synthesized segment snapshots"
+    );
+
+    flow.handle_bot_event(BotEventCommand {
+        bot_id: "bot-worker".to_string(),
+        run_id: "task-response-delta-thinking".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "chat.event".to_string(),
+        event_payload: json!({ "state": "final" }),
+        state: ChatEventState::Final,
+        bcs_session_id: Some("group-1:abcdef12".to_string()),
+    })
+    .await
+    .unwrap();
+
+    let appended = repo.appended().await;
+    let manager_result = appended
+        .iter()
+        .find(|msg| {
+            msg.sender_id == "bot-worker"
+                && msg.message_type == "chat"
+                && msg.owner_bot_id.is_none()
+        })
+        .expect("manager result history");
+    assert_eq!(manager_result.content, json!("AB1B2"));
+}
+
+#[tokio::test]
 async fn manager_worker_task_result_defaults_to_text_after_last_tool_call() {
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
     support.registry.insert_named_actor("bot-manager", "Manager").await;


### PR DESCRIPTION
## Problem

Task response aggregation consumed MessageTracker's synthesized segment-cumulative snapshots as if they were task-level snapshots or raw deltas. After a thinking or approval boundary reset the MessageTracker segment, subsequent SSE snapshots no longer started with the TaskStore's existing response. The fallback append path then produced triangular duplication in long manager-worker responses.

## Solution

- Add an explicit TaskStore path for authoritative SSE `delta_text` increments.
- Route SSE task deltas to direct append while preserving the legacy snapshot merge path for WS/plugin events without `delta_text`.
- Skip merging synthesized final segment snapshots after a run has entered SSE delta mode.
- Add a regression covering `A -> thinking -> B1 -> B2 -> final`, including the manager-visible persisted result.

No wire protocol, database schema, or public service contract changes.

## Validation

- `cargo test -p bcs-message-flow` — passed, 232 tests.
- `git diff --check` — passed.
- Targeted regression test — passed.
- Clippy with `-D warnings` was attempted but remains blocked by pre-existing warnings in `bcs-domain` and `bcs-message-flow` unrelated to this diff.
- Commit and push hooks were skipped with `--no-verify` as required by the publishing workflow.

## Compatibility and risk

Legacy WS/plugin snapshot handling is unchanged. SSE task aggregation now relies on the protocol's existing `delta_text` incremental semantics. The main risk is an SSE producer omitting visible content from deltas and supplying it only in a final snapshot; current SSE behavior and tests treat deltas as authoritative, while final-only runs continue to use the final response fallback.