### PR TITLE
fix(baas): forward exec interactions without command

### DIFF
--- a/src/baas/docs/2026-08-19-baas-bcn-interaction-sse-design.md
+++ b/src/baas/docs/2026-08-19-baas-bcn-interaction-sse-design.md
@@ -160,7 +160,7 @@ data: {
 | Engine 来源 | BCN `data` 字段 | 规则 |
 | --- | --- | --- |
 | `payload.cwd` | `cwd` | 可选 |
-| `payload.command` | `command` | 必需，必须为非空字符串 |
+| `payload.command` | `command` | 可选；仅非空字符串会被复制 |
 | `payload.options[].label` | `options[].label` | 必需 |
 | `payload.options[].decision`，fallback `.value` | `options[].decision` | 两者都缺失时跳过该选项并 warning |
 
@@ -168,6 +168,8 @@ data: {
 BCN 可执行的 `allow-once`、`allow-always`、`deny` 三个标准选项。显式提供
 `options` 时必须是非空数组；非法子项被过滤，重复 decision 由后一项覆盖前一项，
 过滤后没有有效选项则跳过当前 interaction。显式 `null` 不触发默认选项合成。
+`command` 缺失、为 `null`、非字符串、空字符串或仅含空白时不阻断 interaction，
+BaaS 省略该可选字段且不记录 warning；非空字符串保持原值透传。
 
 ```text
 event: interaction
@@ -291,8 +293,8 @@ warning 使用结构化上下文，仅记录 BCN runId、interactionId、kind、
   1..4/唯一性限制、bool-only `multiSelect`/`allowOther`、自由文本约束，以及 option
   decision/value/legacy-label fallback；用真实 Engine label+description-only shape
   验证输出仍满足 BCN 合约且 warning 不泄露业务文本。
-- exec 的必需 command、无 options 默认选项、显式非法 options 拒绝、option
-  fallback 与重复 decision 后写覆盖。
+- exec 的可选 command 省略规则、有效 command 透传、无 options 默认选项、显式
+  非法 options 拒绝、option fallback 与重复 decision 后写覆盖。
 - 使用实际抓包形状作为 mode_switch fixture，验证顶层 toMode 到 targetMode、
   subject fallback、decision/value fallback、recommended 和 option targetMode。
 - 验证 Engine 私有字段不会进入 BCN 数据。

--- a/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
+++ b/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
@@ -557,16 +557,8 @@ def _transform_exec_requested(
     run_id: str,
 ) -> bool:
     command = _non_empty_str(payload.get("command"))
-    if command is None:
-        _warn_interaction(
-            run_id=run_id,
-            interaction_id=data["interactionId"],
-            kind=data["kind"],
-            field_path="payload.command",
-            error_type="missing_required_field",
-        )
-        return False
-    data["command"] = command
+    if command is not None:
+        data["command"] = command
     _copy_present(payload, data, ("cwd",))
 
     if "options" not in payload:

--- a/src/baas/tests/unit/core/service/sse/test_default_converter.py
+++ b/src/baas/tests/unit/core/service/sse/test_default_converter.py
@@ -642,7 +642,7 @@ class TestInteractionBranch:
         assert "field_path=payload.options[4].decision" in caplog.text
         assert "error_type=duplicate_option_decision" in caplog.text
 
-    def test_invalid_exec_command_drops_interaction_without_consuming_seq(
+    def test_missing_or_invalid_exec_command_is_omitted(
         self,
         monkeypatch,
         caplog,
@@ -666,12 +666,21 @@ class TestInteractionBranch:
                 run_id="run-log",
             )
 
-            assert interaction is None
+            assert interaction is not None
+            assert interaction.event == "interaction"
+            interaction_data = _data(interaction)
+            assert interaction_data["seq"] == 1
+            assert "command" not in interaction_data
+            assert interaction_data["options"] == [
+                {"label": "Allow once", "decision": "allow-once"},
+                {"label": "Allow always", "decision": "allow-always"},
+                {"label": "Deny", "decision": "deny"},
+            ]
             assert chat is not None
-            assert chat.id == "1"
-            assert _data(chat)["seq"] == 1
+            assert chat.id == "2"
+            assert _data(chat)["seq"] == 2
 
-        assert caplog.text.count("field_path=payload.command") == 4
+        assert "field_path=payload.command" not in caplog.text
         assert "Sensitive title" not in caplog.text
 
     def test_invalid_explicit_exec_options_drop_interaction_without_seq(


### PR DESCRIPTION
## Problem

Some Engine `interaction.requested` events for `exec` approvals contain a stable interaction/tool-call identity but omit the human-readable `command`. The BaaS SSE converter treated `command` as required and dropped the complete interaction, so BCN never received the pending approval while the Engine continued waiting for a decision.

## Solution

- Treat Provider 2.0 exec `command` as optional at the BaaS delivery boundary.
- Copy `command` only when it is a non-empty string; omit missing, null, non-string, empty, and whitespace-only values without dropping the interaction or logging a command-field warning.
- Preserve the existing default options, explicit-options validation, sequencing, and valid-command behavior.
- Update the converter tests and the BaaS-to-BCN interaction design document.

## Validation

- `.venv/bin/pytest tests/unit/core/service/sse/test_default_converter.py -q` — 69 passed.
- `.venv/bin/ruff check src/secbaas/community/core/service/sse/_default_converter.py tests/unit/core/service/sse/test_default_converter.py` — passed.
- The automatic lint-only pre-push BaaS SAST gate passed.
- Full CI, coverage, and E2E were not run for this publish operation.

## Compatibility and risk

This is backward-compatible for events that already provide a valid command. Command-less interactions require the matching BCS change to be deployed first or at the same time; otherwise an older BCS service will reject the newly forwarded event. No persistence schema or migration changes are required.
