### PR TITLE
fix(baas): respect strict flag in env interpolation and align ACK template id

### DIFF
--- a/src/baas/configs/application.yaml
+++ b/src/baas/configs/application.yaml
@@ -43,7 +43,7 @@ user_config:
     token: ""
     namespace: "default"
     default_images:
-      ALIYUN_ACK_OPENCLAW: "openclaw:latest"
+      ALIYUN_ACK_DEFAULT: "openclaw:latest"
 
   bot_service:
     proxy_base_url: "https://bot_service.example.com"

--- a/src/baas/singlebox-configs/application.yaml
+++ b/src/baas/singlebox-configs/application.yaml
@@ -43,7 +43,7 @@ user_config:
     token: ""
     namespace: "default"
     default_images:
-      ALIYUN_ACK_OPENCLAW: "openclaw:latest"
+      ALIYUN_ACK_DEFAULT: "openclaw:latest"
 
   bot_service:
     proxy_base_url: "https://proxy.example.com"

--- a/src/baas/src/secbaas/community/config/_config_loader.py
+++ b/src/baas/src/secbaas/community/config/_config_loader.py
@@ -83,6 +83,8 @@ class ConfigLoader:
             default = match.group("default")
             if default is not None:
                 return default
+            if not strict:
+                return match.group(0)
             msg = (
                 f"Environment variable '{name}' referenced by "
                 f"${{{name}}} in config is not set and has no default"

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox_plugin.py
@@ -177,7 +177,10 @@ class AliyunAckSandboxPlugin(ArcaSandboxPlugin):
         """
         image = self._default_images.get(template_id, "openclaw:latest")
         variables = _build_template_vars(
-            uid, namespace, image, storage=storage,
+            uid,
+            namespace,
+            image,
+            storage=storage,
             resource_spec=resource_spec,
         )
         rendered = _render_template(template_id, variables)

--- a/src/baas/tests/integration/core/service/paas/test_aliyun_ack_integration.py
+++ b/src/baas/tests/integration/core/service/paas/test_aliyun_ack_integration.py
@@ -23,7 +23,7 @@ from secbaas.community.plugins.sandbox.arca.aliyun_ack._client_manager import (
 
 # Seeded by _seed.py (it-sqlite overlay) under tenant "team_claw"
 TEMPLATE_ARCA = "TEMPLATE-4d0e2849d7004111836333de782b95d8"
-TEMPLATE_ID = "ALIYUN_ACK_OPENCLAW"
+TEMPLATE_ID = "ALIYUN_ACK_DEFAULT"
 TEST_TENANT = "team_claw"
 
 _SANDBOX = "secbaas.community.plugins.sandbox.arca.aliyun_ack._sandbox"

--- a/src/baas/tests/unit/bootstrap/test_plugins.py
+++ b/src/baas/tests/unit/bootstrap/test_plugins.py
@@ -86,7 +86,7 @@ class TestAliyunAckSelector:
             template_uuid="u",
             base_url="http://x",
             api_key="k",
-            arca_template_id="ALIYUN_ACK_OPENCLAW",
+            arca_template_id="ALIYUN_ACK_DEFAULT",
         )
         plugin = self._container().arca_sandbox_plugin_factory(creds)
         assert isinstance(plugin, AliyunAckSandboxPlugin)

--- a/src/baas/tests/unit/plugins/sandbox/arca/aliyun_ack/test_sandbox_plugin.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/aliyun_ack/test_sandbox_plugin.py
@@ -22,7 +22,7 @@ _SANDBOX = "secbaas.community.plugins.sandbox.arca.aliyun_ack._sandbox"
 _PLUGIN = "secbaas.community.plugins.sandbox.arca.aliyun_ack._sandbox_plugin"
 _MGR = "secbaas.community.plugins.sandbox.arca.aliyun_ack._client_manager"
 
-TEMPLATE_ID = "ALIYUN_ACK_OPENCLAW"
+TEMPLATE_ID = "ALIYUN_ACK_DEFAULT"
 
 
 def _creds(arca_template_id: str = TEMPLATE_ID) -> ArcaCredentials:


### PR DESCRIPTION
## Problem
- `_expand_env_placeholders` in the BaaS config loader ignored its `strict` flag: the `_env_replacer` closure always raised `KeyError` for an unresolvable `${NAME}` placeholder, breaking the backward-compatible `strict=False` mode.
- The Aliyun ACK sandbox template was renamed to `template/ALIYUN_ACK_DEFAULT.yaml`, but tests and `default_images` config keys still referenced the old `ALIYUN_ACK_OPENCLAW` name, causing `FileNotFoundError`.

## Solution
- Return the raw placeholder when `strict=False` instead of raising.
- Align tests and `default_images` config keys to `ALIYUN_ACK_DEFAULT`.

## Validation
- `pytest tests/unit/config/ tests/unit/plugins/sandbox/ tests/unit/bootstrap/` → 670 passed, 3 skipped.
- Repair the 4 previously failing tests (`test_backward_compatible_mode_left_unchanged`, `test_get_config_backward_compatible_mode`, `test_create_success`, `test_create_timeout_cleans_up`).