### PR TITLE
fix(skillsets): scope resources by bot owner

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_set_control_plane.py
@@ -82,10 +82,17 @@ class SkillSetControlPlaneRepository(
             model.env == get_current_env(),
         )
 
-    def list_sets(self, *, bot_id: str, engine_type: str | None = None) -> list[dict]:
+    def list_sets(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        engine_type: str | None = None,
+    ) -> list[dict]:
         with self._db.orm_session() as session:
             query = self._scope(session.query(SkillSet), SkillSet).filter(
-                SkillSet.bolt_id == bot_id
+                SkillSet.bolt_id == bot_id,
+                SkillSet.user_id == owner_id,
             )
             if engine_type is not None:
                 query = query.filter(SkillSet.engine_type == engine_type)

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_set_control_plane.py
@@ -17,7 +17,7 @@ class SkillSetControlPlaneRepositoryProtocol(Protocol):
 
     @abstractmethod
     def list_sets(
-        self, *, bot_id: str, engine_type: str | None = None
+        self, *, bot_id: str, owner_id: str, engine_type: str | None = None
     ) -> list[dict]: ...
     @abstractmethod
     def create_set(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -119,7 +119,11 @@ class SkillSetControlPlaneService:
 
     def list_sets(self, *, bot_id: str, owner_id: str, user_id: str) -> list[dict]:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
-        return self._repository.list_sets(bot_id=bot_id, engine_type=self._engine(bot))
+        return self._repository.list_sets(
+            bot_id=bot_id,
+            owner_id=str(bot["owner_id"]),
+            engine_type=self._engine(bot),
+        )
 
     def create_set(
         self,
@@ -650,7 +654,11 @@ class SkillSetControlPlaneService:
             )
         except Exception:
             default_clis = []
-        items = self._repository.list_sets(bot_id=bot_id, engine_type=self._engine(bot))
+        items = self._repository.list_sets(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            engine_type=self._engine(bot),
+        )
         return [
             {
                 **item,

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -291,6 +291,21 @@ class _McpRepository(_Repository):
         return SkillSetMutation({}, True, SkillSetDesiredState(set(), {}, {}))
 
 
+class _ResourceRepository(_Repository):
+    def __init__(self) -> None:
+        super().__init__()
+        self.list_set_calls: list[dict] = []
+
+    def list_sets(self, **kwargs) -> list[dict]:
+        self.list_set_calls.append(kwargs)
+        return []
+
+
+class _ResourceLegacyFactory:
+    def create(self, **_kwargs):
+        return _LegacySkillSetService()
+
+
 class _McpAuth:
     def __init__(self, allowed: bool) -> None:
         self.allowed = allowed
@@ -747,6 +762,34 @@ def test_skill_set_acl_denial_is_forbidden_not_not_found():
             owner_id="true-owner",
             user_id="collaborator",
         )
+
+
+def test_resources_forwards_resolved_bot_owner_to_owner_scoped_set_listing():
+    repository = _ResourceRepository()
+    service = SkillSetControlPlaneService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=_ResourceLegacyFactory(),
+        passport=object(),
+        authorization=_Collaborators(),
+        mutation_guard=_MutationGuard(),
+        edit_guard=_Guard(),
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=_McpAuth(allowed=True),
+    )
+
+    assert service.resources(
+        bot_id="bot-1", owner_id="true-owner", user_id="true-owner"
+    ) == []
+    assert repository.list_set_calls == [
+        {
+            "bot_id": "bot-1",
+            "owner_id": "true-owner",
+            "engine_type": "openclaw",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
@@ -53,6 +53,36 @@ class _Database:
             session.close()
 
 
+def test_list_sets_is_scoped_to_exact_owner_for_shared_default_bot_id():
+    """``bot_id=default`` is reused, so it cannot identify a user's sets."""
+    db = _Database()
+    with db.transactional_orm_session() as session:
+        session.add_all(
+            [
+                SkillSet(
+                    name="mine",
+                    user_id="owner-a",
+                    bolt_id="default",
+                    engine_type="openclaw",
+                    env="dev",
+                ),
+                SkillSet(
+                    name="other-owner",
+                    user_id="owner-b",
+                    bolt_id="default",
+                    engine_type="openclaw",
+                    env="dev",
+                ),
+            ]
+        )
+
+    items = SkillSetControlPlaneRepository(db).list_sets(
+        bot_id="default", owner_id="owner-a", engine_type="openclaw"
+    )
+
+    assert [item["name"] for item in items] == ["mine"]
+
+
 def test_activation_rolls_back_all_membership_installations_when_nth_insert_fails():
     """No half-selected set can survive a storage failure at member N."""
     db = _Database()
@@ -181,6 +211,7 @@ def test_default_projection_is_always_active_even_for_historical_false_row():
         session.add(
             SkillSet(
                 name="default",
+                user_id="owner",
                 bolt_id="bot",
                 is_default=True,
                 is_active=False,
@@ -189,7 +220,7 @@ def test_default_projection_is_always_active_even_for_historical_false_row():
         )
 
     repository = SkillSetControlPlaneRepository(db)
-    assert repository.list_sets(bot_id="bot")[0]["is_active"] is True
+    assert repository.list_sets(bot_id="bot", owner_id="owner")[0]["is_active"] is True
     result = repository.set_active(
         bot_id="bot", owner_id="owner", set_id="1", active=True
     )


### PR DESCRIPTION
## 修复
- 修复 `/api/skillsets/resources` 在 `bot_id=default` 下按 bot_id/engine 全局读取 SkillSet 的数据泄漏。
- Repository `list_sets` 现在要求 `owner_id`，查询增加 `ac_skill_set.user_id = owner_id`。
- 控制面 list/resources 均传入已解析并经 ACL 验证的 Bot Owner；调用者 `user_id` 仍仅用于授权审计。

## 验证
- 新增 default Bot 跨 Owner 隔离回归。
- 46 个相关测试、60 个架构/服务 API 测试通过；Ruff 通过。