### PR TITLE
fix(skillsets): include global default in owner list

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_set_control_plane.py
@@ -8,7 +8,7 @@ would make a SkillSet only *eventually* atomic.
 from __future__ import annotations
 
 from injector import inject
-from sqlalchemy import or_
+from sqlalchemy import and_, or_
 from agentclaw.community.core.models.skill import (
     BotSkillInstallation,
     Skill,
@@ -91,8 +91,17 @@ class SkillSetControlPlaneRepository(
     ) -> list[dict]:
         with self._db.orm_session() as session:
             query = self._scope(session.query(SkillSet), SkillSet).filter(
-                SkillSet.bolt_id == bot_id,
-                SkillSet.user_id == owner_id,
+                or_(
+                    and_(
+                        SkillSet.bolt_id == bot_id,
+                        SkillSet.user_id == owner_id,
+                    ),
+                    and_(
+                        SkillSet.is_default.is_(True),
+                        or_(SkillSet.bolt_id == "", SkillSet.bolt_id.is_(None)),
+                        or_(SkillSet.user_id == "", SkillSet.user_id.is_(None)),
+                    ),
+                )
             )
             if engine_type is not None:
                 query = query.filter(SkillSet.engine_type == engine_type)

--- a/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
@@ -73,6 +73,22 @@ def test_list_sets_is_scoped_to_exact_owner_for_shared_default_bot_id():
                     engine_type="openclaw",
                     env="dev",
                 ),
+                SkillSet(
+                    name="system-default",
+                    user_id="",
+                    bolt_id="",
+                    engine_type="openclaw",
+                    is_default=True,
+                    env="dev",
+                ),
+                SkillSet(
+                    name="other-engine-default",
+                    user_id="",
+                    bolt_id="",
+                    engine_type="hermes",
+                    is_default=True,
+                    env="dev",
+                ),
             ]
         )
 
@@ -80,7 +96,7 @@ def test_list_sets_is_scoped_to_exact_owner_for_shared_default_bot_id():
         bot_id="default", owner_id="owner-a", engine_type="openclaw"
     )
 
-    assert [item["name"] for item in items] == ["mine"]
+    assert [item["name"] for item in items] == ["system-default", "mine"]
 
 
 def test_activation_rolls_back_all_membership_installations_when_nth_insert_fails():


### PR DESCRIPTION
## 修复
- Owner-scoped SkillSet 列表保留当前引擎的全局 System Default 投影。
- 普通集合仍严格按 owner_id + bot_id 隔离，不会回归 default Bot 的跨用户泄漏。

## 验证
- 新增回归：仅返回当前 Owner 的普通 Set + 当前引擎的全局 Default，不返回其他 Owner 或其他引擎 Default。
- 相关 Repository、Control Plane、OpenAPI 与架构测试通过；Ruff 通过。