### PR TITLE
fix(baas): accept custom and skipped ask-user answers

### DIFF
--- a/src/baas/docs/2026-08-20-bcn-interaction-resolve-design.md
+++ b/src/baas/docs/2026-08-20-bcn-interaction-resolve-design.md
@@ -96,7 +96,8 @@ was already exposed before migration so in-flight resolves remain compatible.
 
 BCN requires `action = submit | cancel`. A submit requires one or more answers.
 Each answer is keyed by `questionId` and contains a non-empty `question` plus a
-non-empty ordered list of string `values`.
+required ordered list of string `values`. The list may be empty and its strings
+may be empty or whitespace-only; these shapes represent a skipped question.
 
 Given:
 
@@ -143,8 +144,14 @@ summaries are joined with the Chinese semicolon `；`. JSON object and array
 order follows the incoming answer order. `selectedOptions` is a two-dimensional
 array: each inner array is an unchanged copy of one answer's `values`.
 
-No option lookup or `other` substitution occurs. Cancel produces only
-`decision = cancel`.
+Skipped values use the same projections without rewriting. For example,
+`values: []` produces an empty string in the summary, `values`, and `answers`
+maps and an empty inner array in `selectedOptions`. Empty and whitespace-only
+strings are likewise preserved exactly.
+
+No option lookup, membership validation, trimming, or `other` substitution
+occurs. Custom strings are ordinary values. Cancel produces only `decision =
+cancel`.
 
 ### `exec`
 

--- a/src/baas/docs/2026-08-21-permissive-ask-user-answers-design.md
+++ b/src/baas/docs/2026-08-21-permissive-ask-user-answers-design.md
@@ -1,0 +1,55 @@
+# Permissive Ask-User Answers Design
+
+## Context
+
+The BaaS BCN downlink currently rejects ask-user answers whose `values` array
+is empty or contains an empty or whitespace-only string. BCS now treats these
+shapes as an explicit skipped answer and allows arbitrary custom strings, so
+the BaaS Provider boundary must preserve the same contract through to Engine.
+
+## Goals
+
+- Accept custom strings without comparing them to requested options.
+- Accept `values: []`, `values: [""]`, and whitespace-only strings.
+- Preserve the incoming value list exactly in the durable resolution and
+  Engine `selectedOptions` projection.
+- Keep question ID, question text, header, action, and value element types
+  validated.
+- Keep validation failures sanitized so answer content is not logged or
+  returned.
+
+## Non-goals
+
+- Allowing missing `values`.
+- Allowing non-string elements in `values`.
+- Allowing submit with no answer entries.
+- Looking up requested options or rewriting custom values to `other`.
+- Changing Engine source or wire methods.
+
+## Contract and normalization
+
+For every submitted answer, `values` is a required `list[str]` with no minimum
+length and no non-blank constraint. An empty list or blank string represents a
+skip. BaaS joins values exactly as before for the summary, `values`, and
+`answers` projections; therefore a skip produces an empty or whitespace value
+in those projections. `selectedOptions` preserves the original nested arrays,
+including empty arrays and blank strings.
+
+The outer `answers` object must remain non-empty on submit. BCS remains
+responsible for ensuring all requested question IDs are represented before the
+Provider call.
+
+## Compatibility and propagation
+
+This is a backward-compatible input relaxation. Existing non-empty answers
+produce byte-for-byte equivalent Engine fields. BCS must make the corresponding
+relaxation on its dev-based branch; this BaaS change is based on REL20260821.
+
+## Verification
+
+- Transport model tests accept all skip representations and continue rejecting
+  non-string values and missing required fields.
+- Service tests assert exact summary, value maps, answer maps, and nested
+  `selectedOptions` output for skip values.
+- The finite sanitized validation-ack test uses a genuinely invalid non-string
+  value instead of a blank value.

--- a/src/baas/docs/2026-08-21-permissive-ask-user-answers-implementation.md
+++ b/src/baas/docs/2026-08-21-permissive-ask-user-answers-implementation.md
@@ -15,6 +15,8 @@
 **Files:**
 - Modify: `src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py`
 - Modify: `src/baas/tests/unit/core/service/bcn/test_bcn_service.py`
+- Modify: `src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py`
+- Modify: `src/baas/tests/unit/core/service/test_bot_interaction_service.py`
 - Modify: `src/baas/tests/e2e/asgi/baseline/test_bcn_downlink_extended.py`
 
 **Step 1: Write the failing tests**
@@ -40,6 +42,7 @@ Expected: skip acceptance tests fail at Pydantic or normalization.
 ### Task 2: Relax BaaS value validation
 
 **Files:**
+- Modify: `src/baas/src/secbaas/community/api/bot_interaction/_models.py`
 - Modify: `src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_model.py`
 - Modify: `src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py`
 
@@ -48,6 +51,8 @@ Expected: skip acceptance tests fail at Pydantic or normalization.
 - Remove the `values` minimum-length constraint.
 - Remove the non-blank string validator while retaining `list[str]` typing.
 - Remove the defensive non-empty/non-blank normalization rejection.
+- Allow blank string map values, empty `selectedOptions` groups, and blank
+  selected option strings in the durable interaction resolution model.
 - Preserve all values exactly in existing output projections.
 
 **Step 2: Run tests to verify GREEN**

--- a/src/baas/docs/2026-08-21-permissive-ask-user-answers-implementation.md
+++ b/src/baas/docs/2026-08-21-permissive-ask-user-answers-implementation.md
@@ -1,0 +1,76 @@
+# Permissive Ask-User Answers Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let the BaaS REL20260821 Provider boundary accept and preserve custom and skipped ask-user values.
+
+**Architecture:** Relax only the typed BCN transport model and Engine-neutral normalization guard. Keep the durable interaction pipeline and Engine request construction unchanged so input values flow through the existing projections without option lookup or rewriting.
+
+**Tech Stack:** Python, Pydantic v2, pytest, BaaS BCN downlink service.
+
+---
+
+### Task 1: Add failing BaaS transport and service tests
+
+**Files:**
+- Modify: `src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py`
+- Modify: `src/baas/tests/unit/core/service/bcn/test_bcn_service.py`
+- Modify: `src/baas/tests/e2e/asgi/baseline/test_bcn_downlink_extended.py`
+
+**Step 1: Write the failing tests**
+
+Add coverage proving that empty arrays, empty strings, whitespace-only strings,
+and custom values are accepted and preserved. Change the sanitized invalid
+request fixture to a non-string value.
+
+**Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+cd src/baas
+.venv/bin/pytest \
+  tests/unit/adapters/web/open_api/test_bcn_router.py \
+  tests/unit/core/service/bcn/test_bcn_service.py \
+  tests/e2e/asgi/baseline/test_bcn_downlink_extended.py -q
+```
+
+Expected: skip acceptance tests fail at Pydantic or normalization.
+
+### Task 2: Relax BaaS value validation
+
+**Files:**
+- Modify: `src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_model.py`
+- Modify: `src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py`
+
+**Step 1: Implement the minimum behavior**
+
+- Remove the `values` minimum-length constraint.
+- Remove the non-blank string validator while retaining `list[str]` typing.
+- Remove the defensive non-empty/non-blank normalization rejection.
+- Preserve all values exactly in existing output projections.
+
+**Step 2: Run tests to verify GREEN**
+
+Run the Task 1 command. Expected: all selected tests pass.
+
+### Task 3: Update BaaS contract documentation
+
+**Files:**
+- Modify: `src/baas/docs/2026-08-20-bcn-interaction-resolve-design.md`
+
+Document empty/blank skip values and the absence of option membership checks.
+
+### Task 4: Run focused verification
+
+Run:
+
+```bash
+cd src/baas
+.venv/bin/pytest \
+  tests/unit/adapters/web/open_api/test_bcn_router.py \
+  tests/unit/core/service/bcn/test_bcn_service.py \
+  tests/e2e/asgi/baseline/test_bcn_downlink_extended.py -q
+```
+
+Then run `git diff --check`. Expected: all commands exit 0.

--- a/src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_model.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_model.py
@@ -226,7 +226,7 @@ class ChatHistoryRequest(BaseModel):
 class InteractionResolveAnswer(BaseModel):
     """One ask-user answer forwarded by BCS."""
 
-    values: list[str] = Field(..., min_length=1)
+    values: list[str]
     question: str
     header: str
 
@@ -236,14 +236,6 @@ class InteractionResolveAnswer(BaseModel):
         if not value.strip():
             raise ValueError("interaction answer text fields must be non-empty")
         return value
-
-    @field_validator("values")
-    @classmethod
-    def _values_must_be_non_empty(cls, values: list[str]) -> list[str]:
-        if any(not value.strip() for value in values):
-            raise ValueError("interaction answer values must be non-empty strings")
-        return values
-
 
 class InteractionResolveParams(BaseModel):
     """BCS Provider 2.0 kind-specific interaction resolution."""

--- a/src/baas/src/secbaas/community/api/bot_interaction/_models.py
+++ b/src/baas/src/secbaas/community/api/bot_interaction/_models.py
@@ -34,12 +34,8 @@ class InteractionResolution:
                     "interaction resolution selectedOptions cannot be empty"
                 )
             for options in self.selected_options:
-                if not options:
-                    raise ValueError(
-                        "interaction resolution selectedOptions entries cannot be empty"
-                    )
                 for option in options:
-                    _require_non_empty_string(option, "selectedOptions value")
+                    _require_string(option, "selectedOptions value")
 
     def to_dict(self) -> dict[str, object]:
         """Encode the durable JSON shape, omitting absent optional fields."""
@@ -134,7 +130,7 @@ def _optional_string_map_field(
     result: dict[str, str] = {}
     for map_key, map_value in item.items():
         _require_non_empty_string(map_key, f"{key} key")
-        _require_non_empty_string(map_value, f"{key} value")
+        _require_string(map_value, f"{key} value")
         result[map_key] = map_value
     if not result:
         raise ValueError(f"interaction resolution {key} cannot be empty")
@@ -171,7 +167,12 @@ def _validate_optional_string_map(value: dict[str, str] | None, name: str) -> No
         raise ValueError(f"interaction resolution {name} cannot be empty")
     for map_key, map_value in value.items():
         _require_non_empty_string(map_key, f"{name} key")
-        _require_non_empty_string(map_value, f"{name} value")
+        _require_string(map_value, f"{name} value")
+
+
+def _require_string(value: object, name: str) -> None:
+    if not isinstance(value, str):
+        raise ValueError(f"interaction resolution {name} must be a string")
 
 
 def _require_non_empty_string(value: object, name: str) -> None:

--- a/src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py
+++ b/src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py
@@ -94,10 +94,6 @@ def _normalize_interaction_resolution(
             or not source_answer.question.strip()
         ):
             raise ValueError("ask_user answer identity must be non-empty")
-        if not source_answer.values or any(
-            not value.strip() for value in source_answer.values
-        ):
-            raise ValueError("ask_user answer values must be non-empty")
         joined_values = "，".join(source_answer.values)
         summaries.append(f"{source_answer.header}: {joined_values}")
         if source_answer.header in values:

--- a/src/baas/tests/e2e/asgi/baseline/test_bcn_downlink_extended.py
+++ b/src/baas/tests/e2e/asgi/baseline/test_bcn_downlink_extended.py
@@ -94,8 +94,7 @@ class TestInteractionResolve:
     ) -> None:
         body = deepcopy(_INTERACTION_RESOLVE_BODY)
         body["params"]["answers"]["components"]["values"] = [
-            "answer-must-not-leak",
-            "",
+            {"private": "answer-must-not-leak"},
         ]
 
         response = await api.client.post(
@@ -136,10 +135,12 @@ class TestInteractionResolve:
             if dependency.name == "service"
         )
         _testclient_app.dependency_overrides[dep_key] = lambda: _CapturingService()
+        body = deepcopy(_INTERACTION_RESOLVE_BODY)
+        body["params"]["answers"]["components"]["values"] = []
         try:
             response = await api.client.post(
                 _BCN_DOWNLINK_URL,
-                json=_INTERACTION_RESOLVE_BODY,
+                json=body,
                 headers=_VALID_HEADERS,
             )
         finally:
@@ -147,7 +148,7 @@ class TestInteractionResolve:
 
         assert response.status_code == 200
         assert response.json() == {"ok": True, "retryable": None, "error": None}
-        assert captured["input"].answers["components"].values == ("web", "worker")
+        assert captured["input"].answers["components"].values == ()
         assert captured["input"].answers["components"].header == "Components"
 
 

--- a/src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
@@ -71,6 +71,26 @@ def test_interaction_resolve_request_accepts_bcs_ask_user_shape() -> None:
     assert request.params.answers["deploy_target"].header == ("Deployment environment")
 
 
+@pytest.mark.parametrize("values", [[], [""], ["   "], ["custom raw value"]])
+def test_interaction_resolve_request_accepts_custom_and_skipped_values(
+    values: list[str],
+) -> None:
+    request = InteractionResolveRequest.model_validate(
+        _interaction_resolve_body(
+            answers={
+                "question-1": {
+                    "header": "Question",
+                    "values": values,
+                    "question": "Question?",
+                }
+            }
+        )
+    )
+
+    assert request.params.answers is not None
+    assert request.params.answers["question-1"].values == values
+
+
 def test_interaction_resolve_is_registered_on_json_downlink() -> None:
     request_model, dispatcher = _METHOD_DISPATCH["interaction.resolve"]
 
@@ -132,16 +152,7 @@ async def test_dispatch_interaction_resolve_returns_finite_domain_error() -> Non
             "answers": {
                 "question-1": {
                     "header": "Question",
-                    "values": [],
-                    "question": "Question?",
-                },
-            }
-        },
-        {
-            "answers": {
-                "question-1": {
-                    "header": "Question",
-                    "values": [""],
+                    "values": [7],
                     "question": "Question?",
                 },
             }

--- a/src/baas/tests/unit/core/service/bcn/test_bcn_service.py
+++ b/src/baas/tests/unit/core/service/bcn/test_bcn_service.py
@@ -269,6 +269,45 @@ async def test_handle_ask_user_resolve_normalizes_all_values_as_ordinary(
 
 
 @pytest.mark.asyncio
+async def test_handle_ask_user_resolve_preserves_skipped_values(
+    service, mock_interaction_service
+) -> None:
+    result = await service.handle_interaction_resolve(
+        _make_interaction_resolve_input(
+            answers={
+                "empty_array": BcnInteractionAnswer(
+                    values=(),
+                    question="Skip with an empty array?",
+                    header="Array",
+                ),
+                "empty_string": BcnInteractionAnswer(
+                    values=("",),
+                    question="Skip with an empty string?",
+                    header="Empty",
+                ),
+                "whitespace": BcnInteractionAnswer(
+                    values=("   ",),
+                    question="Skip with whitespace?",
+                    header="Blank",
+                ),
+            }
+        )
+    )
+
+    assert result.ok is True
+    resolution = mock_interaction_service.resolve.call_args.kwargs["resolution"]
+    assert resolution.answer == "；".join(["Array: ", "Empty: ", "Blank:    "])
+    assert resolution.message == resolution.answer
+    assert resolution.values == {"Array": "", "Empty": "", "Blank": "   "}
+    assert resolution.answers == {
+        "Skip with an empty array?": "",
+        "Skip with an empty string?": "",
+        "Skip with whitespace?": "   ",
+    }
+    assert resolution.selected_options == ((), ("",), ("   ",))
+
+
+@pytest.mark.asyncio
 async def test_handle_ask_user_resolve_duplicate_headers_last_write_wins_safely(
     service, mock_interaction_service, caplog
 ) -> None:

--- a/src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_interaction_protocol.py
@@ -348,6 +348,38 @@ def test_build_ask_user_submit_request_preserves_complete_answer() -> None:
     }
 
 
+def test_build_ask_user_submit_request_preserves_skipped_values() -> None:
+    request = build_interaction_resolve_request(
+        request_id="engine-ask-skip",
+        interaction_id="int-ask-skip",
+        resolution=InteractionResolution(
+            kind="ask_user",
+            decision="submit",
+            answer="Array: ；Empty: ；Blank:    ",
+            message="Array: ；Empty: ；Blank:    ",
+            values={"Array": "", "Empty": "", "Blank": "   "},
+            answers={
+                "Skip with an empty array?": "",
+                "Skip with an empty string?": "",
+                "Skip with whitespace?": "   ",
+            },
+            selected_options=((), ("",), ("   ",)),
+        ),
+    )
+
+    assert request["params"]["values"] == {
+        "Array": "",
+        "Empty": "",
+        "Blank": "   ",
+    }
+    assert request["params"]["answers"] == {
+        "Skip with an empty array?": "",
+        "Skip with an empty string?": "",
+        "Skip with whitespace?": "   ",
+    }
+    assert request["params"]["selectedOptions"] == [[], [""], ["   "]]
+
+
 def test_build_ask_user_cancel_request_omits_answer_fields() -> None:
     request = build_interaction_resolve_request(
         request_id="engine-ask-cancel",

--- a/src/baas/tests/unit/core/service/test_bot_interaction_service.py
+++ b/src/baas/tests/unit/core/service/test_bot_interaction_service.py
@@ -54,6 +54,27 @@ def test_interaction_resolution_round_trips_ask_user_payload() -> None:
     assert InteractionResolution.from_dict(payload) == resolution
 
 
+def test_interaction_resolution_round_trips_skipped_ask_user_values() -> None:
+    resolution = InteractionResolution(
+        kind="ask_user",
+        decision="submit",
+        answer="Array: ；Empty: ；Blank:    ",
+        message="Array: ；Empty: ；Blank:    ",
+        values={"Array": "", "Empty": "", "Blank": "   "},
+        answers={
+            "Skip with an empty array?": "",
+            "Skip with an empty string?": "",
+            "Skip with whitespace?": "   ",
+        },
+        selected_options=((), ("",), ("   ",)),
+    )
+
+    payload = resolution.to_dict()
+
+    assert payload["selectedOptions"] == [[], [""], ["   "]]
+    assert InteractionResolution.from_dict(payload) == resolution
+
+
 def test_interaction_resolution_omits_absent_optional_fields() -> None:
     resolution = InteractionResolution(kind="exec", decision="deny")
 


### PR DESCRIPTION
## Problem

The BaaS BCN transport and durable interaction models rejected empty arrays, empty strings, and whitespace-only ask_user values. That would still block skipped questions after BCS relaxed its validation, and could prevent custom answers from reaching the Engine unchanged.

## Solution

- Allow ask_user values to be empty or blank at the BCN request boundary while retaining string typing.
- Remove the duplicate non-empty guard from service normalization.
- Preserve skipped and custom values across summaries, durable values and answers maps, selectedOptions, and the Engine interaction.resolve request.
- Keep question and header identity validation unchanged.
- Update the protocol design and add transport, service, persistence, Engine serialization, and ASGI regression coverage.

## Validation

- Focused BaaS unit tests: 185 passed.
- BCN interaction protocol regression tests: 126 passed.
- ASGI TestInteractionResolve end-to-end tests: 2 passed.
- Python SAST local block scan: passed.
- git diff --check: passed.

## Compatibility and risk

This is a backward-compatible validation relaxation limited to answer values. Existing non-empty answers remain unchanged, non-string values are still rejected, and question and header fields remain required and non-empty. The rollback path is to revert the implementation commit.