### PR TITLE
fix(skills): scope Pool commit and unblock SkillSet creation

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skills_pool/layout.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skills_pool/layout.py
@@ -649,6 +649,7 @@ class SkillsPoolLayoutRepository(
         self,
         *,
         scope: BotSkillLayoutScope,
+        owner_id: str,
         migration_generation: str,
         lease_owner: str,
         preparation_id: str,
@@ -669,6 +670,7 @@ class SkillsPoolLayoutRepository(
                 .filter(
                     Skill.env == scope.env,
                     Skill.bolt_id == scope.bot_id,
+                    Skill.user_id == owner_id,
                     Skill.git_path.like("local://%"),
                 )
                 .with_for_update()

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skills_pool.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skills_pool.py
@@ -259,12 +259,13 @@ class SkillsPoolLayoutRepositoryProtocol(Protocol):
         self,
         *,
         scope: BotSkillLayoutScope,
+        owner_id: str,
         migration_generation: str,
         lease_owner: str,
         preparation_id: str,
         local_locators: dict[int, str],
     ) -> bool:
-        """在一个事务中更新该 Bot 全部 local locator 并提交 Pool Active。"""
+        """在一个事务中更新该 Bot Owner 的全部 local locator 并提交 Pool Active。"""
         ...
 
     @abstractmethod

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -57,7 +57,6 @@ from agentclaw.community.core.skills_pool.edit_guard import (
 from agentclaw.community.core.skills_pool.types import BotSkillLayoutScope
 from agentclaw.community.core.workspace.skill_layout import runtime_layout_engine_for_bot
 from agentclaw.community.plugin_api.passport import PassportPlugin
-from agentclaw.community.utils.env_utils import get_current_env
 
 
 class SkillSetControlPlaneService:
@@ -138,31 +137,24 @@ class SkillSetControlPlaneService:
     ) -> dict:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
         self._require_mutable_bot(bot)
-        scope = self._scope(bot, bot_id)
-        try:
-            mutation_lease = self._mutation_guard.acquire(scope=scope)
-        except BotCapabilityMutationBusyError as exc:
-            raise SkillSetControlPlaneConflictError("BOT_MUTATION_BUSY") from exc
-        except BotCapabilityMutationLockUnavailableError as exc:
-            raise SkillSetControlPlaneLockUnavailableError() from exc
-        try:
-            item = self._repository.create_set(
-                bot_id=bot_id,
-                owner_id=str(bot["owner_id"]),
-                name=name,
-                description=description,
-                engine_type=self._engine(bot),
-            )
-            self._ensure_mutation_lease(mutation_lease)
-            self._audit(
-                bot_id=bot_id,
-                owner_id=str(bot["owner_id"]),
-                actor_id=user_id,
-                action="skill_set_create",
-            )
-            return item
-        finally:
-            self._mutation_guard.release(mutation_lease)
+        # Creating an inactive SkillSet is metadata-only: it neither changes
+        # the effective capability projection nor has a compensating runtime
+        # action.  Do not take the long-lived Bot mutation fence here; that
+        # fence belongs to operations which can race a desired-state rollback.
+        item = self._repository.create_set(
+            bot_id=bot_id,
+            owner_id=str(bot["owner_id"]),
+            name=name,
+            description=description,
+            engine_type=self._engine(bot),
+        )
+        self._audit(
+            bot_id=bot_id,
+            owner_id=str(bot["owner_id"]),
+            actor_id=user_id,
+            action="skill_set_create",
+        )
+        return item
 
     def create_legacy_set(
         self,
@@ -190,33 +182,20 @@ class SkillSetControlPlaneService:
                 description=description,
             )
 
-        scope = BotSkillLayoutScope(
-            env=get_current_env(), entity_id=actor_id, bot_id="default"
+        item = self._repository.create_set(
+            bot_id="default",
+            owner_id=actor_id,
+            name=name,
+            description=description,
+            engine_type="openclaw",
         )
-        try:
-            mutation_lease = self._mutation_guard.acquire(scope=scope)
-        except BotCapabilityMutationBusyError as exc:
-            raise SkillSetControlPlaneConflictError("BOT_MUTATION_BUSY") from exc
-        except BotCapabilityMutationLockUnavailableError as exc:
-            raise SkillSetControlPlaneLockUnavailableError() from exc
-        try:
-            item = self._repository.create_set(
-                bot_id="default",
-                owner_id=actor_id,
-                name=name,
-                description=description,
-                engine_type="openclaw",
-            )
-            self._ensure_mutation_lease(mutation_lease)
-            self._audit(
-                bot_id="default",
-                owner_id=actor_id,
-                actor_id=actor_id,
-                action="skill_set_create_legacy_default",
-            )
-            return item
-        finally:
-            self._mutation_guard.release(mutation_lease)
+        self._audit(
+            bot_id="default",
+            owner_id=actor_id,
+            actor_id=actor_id,
+            action="skill_set_create_legacy_default",
+        )
+        return item
 
     def get_set(self, *, bot_id: str, owner_id: str, user_id: str, set_id: str) -> dict:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)

--- a/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/reconcile_service.py
@@ -704,6 +704,7 @@ class SkillsPoolReconcileService:
             )
         if not self._layouts.commit_pool_active(
             scope=scope,
+            owner_id=user_id,
             migration_generation=generation,
             lease_owner=lease_owner,
             preparation_id=probe.preparation_id,

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -69,6 +69,17 @@ class _AnyMutationGuard(_MutationGuard):
         return object()
 
 
+class _CreationMustNotAcquireMutationGuard:
+    def acquire(self, **_kwargs):
+        raise AssertionError("metadata-only SkillSet creation must not take mutation guard")
+
+    def release(self, _lease) -> bool:
+        raise AssertionError("creation must not release a lease it did not acquire")
+
+    def ensure_valid(self, _lease) -> None:
+        raise AssertionError("creation must not validate a mutation lease")
+
+
 class _Repository:
     def __init__(self) -> None:
         self.restore_calls = []
@@ -701,7 +712,6 @@ def test_legacy_create_rejects_missing_bot_instead_of_creating_orphan_set():
 
 def test_legacy_create_retains_only_virtual_default_bot_compatibility():
     repository = _CreateRepository()
-    mutation_guard = _AnyMutationGuard()
     service = SkillSetControlPlaneService(
         repository=repository,
         bot_repo=_MissingBots(),
@@ -709,7 +719,7 @@ def test_legacy_create_retains_only_virtual_default_bot_compatibility():
         legacy_factory=object(),
         passport=object(),
         authorization=_Collaborators(),
-        mutation_guard=mutation_guard,
+        mutation_guard=_CreationMustNotAcquireMutationGuard(),
         edit_guard=_Guard(),
         audit_log_repo=_Audit(),
         mcp_center=_McpCenter(allowed=True),
@@ -725,7 +735,42 @@ def test_legacy_create_retains_only_virtual_default_bot_compatibility():
 
     assert result["bolt_id"] == "default"
     assert repository.create_calls[0]["owner_id"] == "actor"
-    assert mutation_guard.scope.entity_id == "actor"
+
+
+def test_addressed_create_does_not_take_mutation_guard() -> None:
+    repository = _CreateRepository()
+    service = SkillSetControlPlaneService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=object(),
+        passport=object(),
+        authorization=_Collaborators(),
+        mutation_guard=_CreationMustNotAcquireMutationGuard(),
+        edit_guard=_Guard(),
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=_McpAuth(allowed=True),
+    )
+
+    result = service.create_set(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="true-owner",
+        name="metadata-only",
+        description=None,
+    )
+
+    assert result["id"] == "set-1"
+    assert repository.create_calls == [
+        {
+            "bot_id": "bot-1",
+            "owner_id": "true-owner",
+            "name": "metadata-only",
+            "description": None,
+            "engine_type": "openclaw",
+        }
+    ]
 
 
 def test_legacy_virtual_default_read_is_owner_scoped():

--- a/src/backend/tests/community/core/skills_pool/test_layout_repository.py
+++ b/src/backend/tests/community/core/skills_pool/test_layout_repository.py
@@ -980,6 +980,7 @@ def test_finalizing_without_quarantine_accepts_runtime_identity_and_commits() ->
     )
     assert repository.commit_pool_active(
         scope=scope,
+        owner_id=scope.entity_id,
         migration_generation="generation-1",
         lease_owner="worker-1",
         preparation_id="preparation-1",
@@ -1229,16 +1230,18 @@ def test_operator_resolves_manual_repair_with_note_and_explicit_fact() -> None:
     )
     with database.transactional_orm_session() as session:
         session.add(
-            Skill(
-                id=91,
-                name="local-a",
-                git_path="local:///legacy/local-a",
-                bolt_id=scope.bot_id,
-                env=scope.env,
-            )
+                Skill(
+                    id=91,
+                    name="local-a",
+                    git_path="local:///legacy/local-a",
+                    user_id=scope.entity_id,
+                    bolt_id=scope.bot_id,
+                    env=scope.env,
+                )
         )
     assert repository.commit_pool_active(
         scope=scope,
+        owner_id=scope.entity_id,
         migration_generation="generation-1",
         lease_owner="worker-2",
         preparation_id="preparation-1",
@@ -1319,7 +1322,7 @@ def test_legacy_committed_repair_refresh_failure_keeps_refresh_phase() -> None:
     assert state.last_failure_code == "TRANSIENT_ERROR"
 
 
-def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:
+def test_pool_active_commit_updates_only_local_rows_for_exact_bot_owner() -> None:
     database = InMemorySqliteDB()
     repository = SkillsPoolLayoutRepository(database)
     scope = BotSkillLayoutScope(env="pre", entity_id="entity-1", bot_id="bot-1")
@@ -1368,6 +1371,7 @@ def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:
                     id=1,
                     name="local-a",
                     git_path="local:///legacy/local-a",
+                    user_id="owner-1",
                     bolt_id="bot-1",
                     env="pre",
                 ),
@@ -1375,6 +1379,7 @@ def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:
                     id=2,
                     name="local-b",
                     git_path="local://local-b",
+                    user_id="owner-1",
                     bolt_id="bot-1",
                     env="pre",
                 ),
@@ -1399,11 +1404,22 @@ def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:
                     bolt_id="bot-1",
                     env="prod",
                 ),
+                # ``default`` is a shared Bot id.  Another owner's Local
+                # rows must not expand this owner's post-cutover locator set.
+                Skill(
+                    id=6,
+                    name="other-owner-local",
+                    git_path="local:///legacy/other-owner-local",
+                    user_id="entity-2",
+                    bolt_id="bot-1",
+                    env="pre",
+                ),
             ]
         )
 
     committed = repository.commit_pool_active(
         scope=scope,
+        owner_id="owner-1",
         migration_generation="generation-1",
         lease_owner="worker-1",
         preparation_id="preparation-1",
@@ -1553,6 +1569,7 @@ def test_pool_active_commit_updates_only_all_local_rows_for_exact_bot() -> None:
         3: "git://business/repo",
         4: "local:///legacy/other-bot",
         5: "local:///legacy/other-env",
+        6: "local:///legacy/other-owner-local",
     }
 
 
@@ -1613,6 +1630,7 @@ def test_pool_active_commit_rejects_partial_or_stale_local_locator_set() -> None
                     id=1,
                     name="local-a",
                     git_path="local:///legacy/local-a",
+                    user_id=scope.entity_id,
                     bolt_id="bot-1",
                     env="pre",
                 ),
@@ -1620,6 +1638,7 @@ def test_pool_active_commit_rejects_partial_or_stale_local_locator_set() -> None
                     id=2,
                     name="local-b",
                     git_path="local:///legacy/local-b",
+                    user_id=scope.entity_id,
                     bolt_id="bot-1",
                     env="pre",
                 ),
@@ -1628,6 +1647,7 @@ def test_pool_active_commit_rejects_partial_or_stale_local_locator_set() -> None
 
     assert not repository.commit_pool_active(
         scope=scope,
+        owner_id=scope.entity_id,
         migration_generation="generation-1",
         lease_owner="worker-1",
         preparation_id="preparation-1",


### PR DESCRIPTION
## Problem
SkillSet creation was incorrectly serialized behind the Bot runtime mutation fence. Separately, Pool activation counted `local://` rows for every owner sharing a `bot_id`, causing valid cutovers to fail with `DATABASE_COMMIT_FAILED`.

## Solution
- Keep `BotCapabilityMutationGuard` on Desired State/runtime mutations, but remove it from canonical and legacy SkillSet creation, which only writes inactive metadata.
- Make `commit_pool_active` receive the exact Bot owner and filter Local Skills by `env + bot_id + owner_id + local://` (the Skill ORM tenant guard remains in force).
- Propagate the owner from the exact Bot resolved by `SkillsPoolReconcileService`.

## Validation
- `uv run pytest tests/community/core/skill_center/test_skill_set_control_plane_service.py tests/community/core/skills_pool/test_layout_repository.py tests/community/core/skills_pool/test_reconcile_service.py -q` — 141 passed.
- Focused Ruff and `git diff --check` passed.
- Standards + spec review completed; reviewer finding on owner/entity distinction was fixed.

## Compatibility and risk
No OpenAPI/BFF wire or DDL change. Activation/deactivation/member mutations retain their existing fencing. The Pool locator check is narrowed to the exact owner, fixing shared `bot_id=default` isolation.