### PR TITLE
refactor(backend): move SkillSet error-to-HTTP mapping to the app layer

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -361,6 +361,13 @@ from agentclaw.community.core.caller_identity.contracts import (  # noqa: E402
     CallerMcpNotFoundError,
     CallerMcpSyncError,
 )
+from agentclaw.community.core.skill_center.errors import (  # noqa: E402
+    SkillSetAccessDeniedError,
+    SkillSetControlPlaneConflictError,
+    SkillSetControlPlaneLockUnavailableError,
+    SkillSetControlPlaneNotFoundError,
+    SkillSetRuntimeReconcileError,
+)
 
 _DOMAIN_ERROR_STATUS_MAP: dict[type[DomainError], int] = {
     ValidationError:       400,
@@ -381,6 +388,25 @@ _DOMAIN_ERROR_STATUS_MAP: dict[type[DomainError], int] = {
     CallerMcpNotFoundError: 404,
     CallerMcpSyncError: 500,
     CallerCallTypeInvalidError: 500,
+    # ── SkillSet control plane ────────────────────────────────────────────
+    # The legacy /api/skillsets routes used to translate these themselves, in a
+    # router-level helper that returned a hand-built HTTPException. That put the
+    # status decision inside the route and replaced the raised exception with a
+    # fresh one, so the ``__cause__`` chain never reached a log. Mapping them
+    # here instead means the route raises the situation and this layer alone
+    # decides the wire, exactly as every other domain error already works.
+    SkillSetControlPlaneNotFoundError: 404,
+    SkillSetAccessDeniedError: 403,
+    # 400, not 409: the published wire echoes the reason code as a rejected
+    # request and clients already parse it that way. Kept as-is deliberately.
+    SkillSetControlPlaneConflictError: 400,
+    # 409, not 503. The mutation fence could not be taken, so the command never
+    # ran and the caller may retry — but the service itself is up and serving,
+    # which is the only thing a 503 is allowed to mean. Answering 503 also tells
+    # proxies and clients to back off the whole endpoint over what is a
+    # per-Bot lock conflict.
+    SkillSetControlPlaneLockUnavailableError: 409,
+    SkillSetRuntimeReconcileError: 500,
 }
 
 _DATA_PROXY_ERROR_STATUS_MAP: dict[type[DataProxyError], int] = {

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -516,9 +516,16 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
         409,
         "SkillSet state conflicts with this operation",
     ),
+    # 409, not 503. Two of this error's three raise sites are a lease this
+    # request held being lost mid-mutation, and the third is the fence refusing
+    # to be taken — in every one of them the service is up and answering, and
+    # the command simply lost a race for one Bot's fence. A 503 would tell
+    # proxies and client retry layers the whole surface is out of rotation over
+    # a per-Bot conflict. The internal /api/skillsets mapping in
+    # ``adapters.http.app`` answers 409 for the same reason.
     SkillSetControlPlaneLockUnavailableError: (
-        503,
-        "SkillSet mutation service is temporarily unavailable",
+        409,
+        "Another SkillSet mutation holds this Bot's fence",
     ),
     SkillSetRuntimeReconcileError: (502, "Skill runtime synchronization failed"),
     SkillSetManagedResourceError: (409, "Skill is managed by a SkillSet"),
@@ -719,7 +726,7 @@ ENVELOPE_ERROR_CODES: dict[type[Exception], int] = {
     RepositoryCatalogSyncInProgressError: 409108,
     RepositoryCatalogSyncFailedError: 502103,
     SkillSetManagedResourceError: 409202,
-    SkillSetControlPlaneLockUnavailableError: 503201,
+    SkillSetControlPlaneLockUnavailableError: 409209,
     SkillSetAccessDeniedError: 403201,
     McpPermissionDeniedError: 403202,
 }

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
@@ -71,9 +71,6 @@ from agentclaw.community.core.skill_center.errors import (
     LocalSkillNotFoundError,
     SkillSetControlPlaneConflictError,
     SkillSetControlPlaneNotFoundError,
-    SkillSetControlPlaneLockUnavailableError,
-    SkillSetRuntimeReconcileError,
-    SkillSetAccessDeniedError,
 )
 from agentclaw.community.core.devices.services.device_context_resolver import (
     DeviceContextResolver,
@@ -112,21 +109,6 @@ def _legacy_skill_set(item: dict) -> SkillSetResponse:
             "type": item.get("type", "custom"),
         }
     )
-
-
-def _legacy_error(exc: Exception) -> HTTPException:
-    if isinstance(exc, (LocalSkillNotFoundError, SkillSetControlPlaneNotFoundError)):
-        return HTTPException(status_code=404, detail="Skill set not found")
-    if isinstance(exc, SkillSetAccessDeniedError):
-        return HTTPException(status_code=403, detail="Forbidden")
-    if isinstance(exc, SkillSetControlPlaneConflictError):
-        return HTTPException(status_code=400, detail=str(exc))
-    if isinstance(exc, SkillSetControlPlaneLockUnavailableError):
-        return HTTPException(status_code=503, detail="Skill set mutation unavailable")
-    if isinstance(exc, SkillSetRuntimeReconcileError):
-        return HTTPException(status_code=500, detail="Skill set runtime sync failed")
-    logger.exception("[skillsets] compatibility adapter failed", exc_info=exc)
-    return HTTPException(status_code=500, detail="Skill set operation failed")
 
 
 def _get_path_params(
@@ -242,38 +224,35 @@ async def list_skill_sets(
     )
 
     actor_id = _legacy_actor(ctx, user_id or entity_id)
-    try:
-        skill_sets = control_plane.list_sets(
+    skill_sets = control_plane.list_sets(
+        bot_id=effective_bot_id,
+        owner_id=effective_entity_id,
+        user_id=actor_id,
+    )
+    data = []
+    for item in skill_sets:
+        skills = control_plane.list_skills(
             bot_id=effective_bot_id,
             owner_id=effective_entity_id,
             user_id=actor_id,
+            set_id=item["id"],
         )
-        data = []
-        for item in skill_sets:
-            skills = control_plane.list_skills(
-                bot_id=effective_bot_id,
-                owner_id=effective_entity_id,
-                user_id=actor_id,
-                set_id=item["id"],
-            )
-            skill_set_dict = {
-                **item,
-                "is_active": True if item.get("is_default") else item.get("is_active"),
-                "skills": [
-                    SkillInSetSummary(
-                        id=str(skill.get("id")) if skill.get("id") is not None else "",
-                        name=skill.get("name"),
-                        description=skill.get("description"),
-                        path=skill.get(
-                            "git_path"
-                        ),  # git_path stores both git:// and local:// paths
-                    )
-                    for skill in skills
-                ],
-            }
-            data.append(_legacy_skill_set(skill_set_dict))
-    except Exception as exc:
-        raise _legacy_error(exc) from exc
+        skill_set_dict = {
+            **item,
+            "is_active": True if item.get("is_default") else item.get("is_active"),
+            "skills": [
+                SkillInSetSummary(
+                    id=str(skill.get("id")) if skill.get("id") is not None else "",
+                    name=skill.get("name"),
+                    description=skill.get("description"),
+                    path=skill.get(
+                        "git_path"
+                    ),  # git_path stores both git:// and local:// paths
+                )
+                for skill in skills
+            ],
+        }
+        data.append(_legacy_skill_set(skill_set_dict))
 
     return SkillSetListResponse(success=True, data=data, count=len(data))
 
@@ -321,16 +300,13 @@ async def create_skill_set(
         bot_repo=bot_repo,
     )
 
-    try:
-        skill_set = control_plane.create_legacy_set(
-            bot_id=effective_bot_id,
-            actor_id=_legacy_actor(ctx, request.user_id),
-            name=request.name,
-            description=request.description,
-        )
-        return SkillSetDetailResponse(success=True, data=_legacy_skill_set(skill_set))
-    except Exception as e:
-        raise _legacy_error(e) from e
+    skill_set = control_plane.create_legacy_set(
+        bot_id=effective_bot_id,
+        actor_id=_legacy_actor(ctx, request.user_id),
+        name=request.name,
+        description=request.description,
+    )
+    return SkillSetDetailResponse(success=True, data=_legacy_skill_set(skill_set))
 
 
 @router.get("/with-mcps", response_model=SkillSetsWithMCPsResponse, deprecated=True)
@@ -496,19 +472,16 @@ async def get_skill_set(
         ctx, entity_id, entity_type, bot_id, engine_type, bot_repo=bot_repo
     )
 
-    try:
-        return SkillSetDetailResponse(
-            success=True,
-            data=_legacy_skill_set(
-                control_plane.get_legacy_set(
-                    bot_id=effective_bot_id,
-                    actor_id=_legacy_actor(ctx, user_id or entity_id),
-                    set_id=skill_set_id,
-                )
-            ),
-        )
-    except Exception as exc:
-        raise _legacy_error(exc) from exc
+    return SkillSetDetailResponse(
+        success=True,
+        data=_legacy_skill_set(
+            control_plane.get_legacy_set(
+                bot_id=effective_bot_id,
+                actor_id=_legacy_actor(ctx, user_id or entity_id),
+                set_id=skill_set_id,
+            )
+        ),
+    )
 
 
 @router.put("/{skill_set_id}", response_model=SkillSetDetailResponse)
@@ -549,21 +522,18 @@ async def update_skill_set(
         bot_repo=bot_repo,
     )
 
-    try:
-        # ``is_default`` was accepted by the old schema but is not a mutable
-        # domain field.  Preserve the wire by ignoring it as the old handler
-        # did for immutable system sets.
-        skill_set = control_plane.update_set(
-            bot_id=effective_bot_id,
-            owner_id=effective_entity_id,
-            user_id=_legacy_actor(ctx, request.user_id or entity_id),
-            set_id=skill_set_id,
-            name=request.name,
-            description=request.description,
-        )
-        return SkillSetDetailResponse(success=True, data=_legacy_skill_set(skill_set))
-    except Exception as exc:
-        raise _legacy_error(exc) from exc
+    # ``is_default`` was accepted by the old schema but is not a mutable
+    # domain field.  Preserve the wire by ignoring it as the old handler
+    # did for immutable system sets.
+    skill_set = control_plane.update_set(
+        bot_id=effective_bot_id,
+        owner_id=effective_entity_id,
+        user_id=_legacy_actor(ctx, request.user_id or entity_id),
+        set_id=skill_set_id,
+        name=request.name,
+        description=request.description,
+    )
+    return SkillSetDetailResponse(success=True, data=_legacy_skill_set(skill_set))
 
 
 @router.delete("/{skill_set_id}", response_model=MessageResponse)
@@ -610,16 +580,13 @@ async def delete_skill_set(
         bot_repo=bot_repo,
     )
 
-    try:
-        control_plane.delete_set(
-            bot_id=effective_bot_id,
-            owner_id=effective_entity_id,
-            user_id=_legacy_actor(ctx, user_id or entity_id),
-            set_id=skill_set_id,
-        )
-        return MessageResponse(success=True, message="Skill set deleted successfully")
-    except Exception as exc:
-        raise _legacy_error(exc) from exc
+    control_plane.delete_set(
+        bot_id=effective_bot_id,
+        owner_id=effective_entity_id,
+        user_id=_legacy_actor(ctx, user_id or entity_id),
+        set_id=skill_set_id,
+    )
+    return MessageResponse(success=True, message="Skill set deleted successfully")
 
 
 # ==================== SkillSet-Skill Association APIs ====================
@@ -656,15 +623,12 @@ async def get_skill_set_skills(
         ctx, entity_id, entity_type, bot_id, engine_type, bot_repo=bot_repo
     )
 
-    try:
-        skills = control_plane.list_skills(
-            bot_id=effective_bot_id,
-            owner_id=effective_entity_id,
-            user_id=_legacy_actor(ctx, user_id or entity_id),
-            set_id=skill_set_id,
-        )
-    except Exception as exc:
-        raise _legacy_error(exc) from exc
+    skills = control_plane.list_skills(
+        bot_id=effective_bot_id,
+        owner_id=effective_entity_id,
+        user_id=_legacy_actor(ctx, user_id or entity_id),
+        set_id=skill_set_id,
+    )
     return SkillSetSkillsResponse(
         success=True,
         data=[
@@ -728,64 +692,61 @@ async def add_skills_to_set(
         bot_repo=bot_repo,
     )
 
-    try:
-        # Historical batch wire permits partial success.  Each member remains
-        # an atomic control-plane command; the adapter only serializes results.
-        results: dict[str, list] = {
-            "success": [],
-            "failed": [],
-            "activation_failed": [],
-        }
-        actor_id = _legacy_actor(ctx, request.user_id or entity_id)
-        # Validate the target before the legacy resolver may materialise a
-        # missing Repo asset.  A missing or immutable Set must not leave an
-        # orphan ac_skill row behind.
-        target_set = control_plane.get_set(
-            bot_id=effective_bot_id,
-            owner_id=effective_entity_id,
-            user_id=actor_id,
-            set_id=skill_set_id,
-        )
-        if target_set.get("is_default"):
-            raise SkillSetControlPlaneConflictError("SYSTEM_DEFAULT_IMMUTABLE")
-        for skill_id in request.skill_ids:
-            try:
-                stable_skill_id = control_plane.resolve_legacy_skill_id(
-                    bot_id=effective_bot_id,
-                    actor_id=actor_id,
-                    identifier=skill_id,
-                )
-                await control_plane.add_skill(
-                    bot_id=effective_bot_id,
-                    owner_id=effective_entity_id,
-                    user_id=actor_id,
-                    set_id=skill_set_id,
-                    skill_id=stable_skill_id,
-                )
-                results["success"].append(
-                    {"skill_id": str(stable_skill_id), "name": str(skill_id)}
-                )
-            except (
-                LocalSkillNotFoundError,
-                SkillSetControlPlaneNotFoundError,
-            ) as exc:
-                results["failed"].append({"skill_id": skill_id, "error": str(exc)})
-            except SkillSetControlPlaneConflictError as exc:
-                if str(exc) not in {
-                    "RESOURCE_DIRECT_ACTIVE",
-                    "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET",
-                }:
-                    raise
-                results["failed"].append({"skill_id": skill_id, "error": str(exc)})
-        success_count = len(results["success"])
-        failed_count = len(results["failed"])
-        return AddSkillsResponse(
-            success=True,
-            data=results,
-            message=f"成功添加 {success_count} 个技能，失败 {failed_count} 个",
-        )
-    except Exception as exc:
-        raise _legacy_error(exc) from exc
+    # Historical batch wire permits partial success.  Each member remains
+    # an atomic control-plane command; the adapter only serializes results.
+    results: dict[str, list] = {
+        "success": [],
+        "failed": [],
+        "activation_failed": [],
+    }
+    actor_id = _legacy_actor(ctx, request.user_id or entity_id)
+    # Validate the target before the legacy resolver may materialise a
+    # missing Repo asset.  A missing or immutable Set must not leave an
+    # orphan ac_skill row behind.
+    target_set = control_plane.get_set(
+        bot_id=effective_bot_id,
+        owner_id=effective_entity_id,
+        user_id=actor_id,
+        set_id=skill_set_id,
+    )
+    if target_set.get("is_default"):
+        raise SkillSetControlPlaneConflictError("SYSTEM_DEFAULT_IMMUTABLE")
+    for skill_id in request.skill_ids:
+        try:
+            stable_skill_id = control_plane.resolve_legacy_skill_id(
+                bot_id=effective_bot_id,
+                actor_id=actor_id,
+                identifier=skill_id,
+            )
+            await control_plane.add_skill(
+                bot_id=effective_bot_id,
+                owner_id=effective_entity_id,
+                user_id=actor_id,
+                set_id=skill_set_id,
+                skill_id=stable_skill_id,
+            )
+            results["success"].append(
+                {"skill_id": str(stable_skill_id), "name": str(skill_id)}
+            )
+        except (
+            LocalSkillNotFoundError,
+            SkillSetControlPlaneNotFoundError,
+        ) as exc:
+            results["failed"].append({"skill_id": skill_id, "error": str(exc)})
+        except SkillSetControlPlaneConflictError as exc:
+            if str(exc) not in {
+                "RESOURCE_DIRECT_ACTIVE",
+                "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET",
+            }:
+                raise
+            results["failed"].append({"skill_id": skill_id, "error": str(exc)})
+    success_count = len(results["success"])
+    failed_count = len(results["failed"])
+    return AddSkillsResponse(
+        success=True,
+        data=results,
+        message=f"成功添加 {success_count} 个技能，失败 {failed_count} 个",
+    )
 
 
 @router.delete("/{skill_set_id}/skills/{skill_id}", response_model=MessageResponse)
@@ -833,21 +794,16 @@ async def remove_skill_from_set(
         bot_repo=bot_repo,
     )
 
-    try:
-        result = await control_plane.remove_skill(
-            bot_id=effective_bot_id,
-            owner_id=effective_entity_id,
-            user_id=_legacy_actor(ctx, user_id or entity_id),
-            set_id=skill_set_id,
-            skill_id=skill_id,
-        )
-        if not result.get("changed"):
-            raise HTTPException(status_code=404, detail="Skill not found in skill set")
-        return MessageResponse(success=True, message="Skill removed from skill set")
-    except HTTPException:
-        raise
-    except Exception as exc:
-        raise _legacy_error(exc) from exc
+    result = await control_plane.remove_skill(
+        bot_id=effective_bot_id,
+        owner_id=effective_entity_id,
+        user_id=_legacy_actor(ctx, user_id or entity_id),
+        set_id=skill_set_id,
+        skill_id=skill_id,
+    )
+    if not result.get("changed"):
+        raise SkillSetControlPlaneNotFoundError("Skill not found in skill set")
+    return MessageResponse(success=True, message="Skill removed from skill set")
 
 
 # ==================== Default SkillSet APIs ====================
@@ -1844,21 +1800,18 @@ async def add_mcp_to_skill_set(
         ctx, entity_id, entity_type, bot_id, engine_type, bot_repo=bot_repo
     )
 
-    try:
-        await control_plane.add_mcp(
-            bot_id=effective_bot_id,
-            owner_id=effective_entity_id,
-            user_id=_legacy_actor(ctx, entity_id),
-            set_id=skill_set_id,
-            server_code=request.server_code,
-        )
-        return AddMCPResponse(
-            success=True,
-            message="MCP server added to skill set successfully",
-            server_code=request.server_code,
-        )
-    except Exception as e:
-        raise _legacy_error(e) from e
+    await control_plane.add_mcp(
+        bot_id=effective_bot_id,
+        owner_id=effective_entity_id,
+        user_id=_legacy_actor(ctx, entity_id),
+        set_id=skill_set_id,
+        server_code=request.server_code,
+    )
+    return AddMCPResponse(
+        success=True,
+        message="MCP server added to skill set successfully",
+        server_code=request.server_code,
+    )
 
 
 @router.delete("/{skill_set_id}/mcps/{server_code}", response_model=MessageResponse)
@@ -1901,16 +1854,13 @@ async def remove_mcp_from_skill_set(
         ctx, entity_id, entity_type, bot_id, engine_type, bot_repo=bot_repo
     )
 
-    try:
-        await control_plane.remove_mcp(
-            bot_id=effective_bot_id,
-            owner_id=effective_entity_id,
-            user_id=_legacy_actor(ctx, entity_id),
-            set_id=skill_set_id,
-            server_code=server_code,
-        )
-    except Exception as e:
-        raise _legacy_error(e) from e
+    await control_plane.remove_mcp(
+        bot_id=effective_bot_id,
+        owner_id=effective_entity_id,
+        user_id=_legacy_actor(ctx, entity_id),
+        set_id=skill_set_id,
+        server_code=server_code,
+    )
     return MessageResponse(
         success=True, message="MCP server removed from skill set successfully"
     )

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -65,6 +65,7 @@ internal_dependencies:
   - agentclaw.community.core.config
   - agentclaw.community.core.config_compose
   - agentclaw.community.core.devices
+  - agentclaw.community.core.errors    # transport-free DomainError base for SkillSet control-plane errors
   - agentclaw.community.core.events
   - agentclaw.community.core.mcp
   - agentclaw.community.core.models

--- a/src/backend/src/agentclaw/community/core/skill_center/errors.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/errors.py
@@ -1,5 +1,7 @@
 """Domain errors raised by Skill Center operations."""
 
+from agentclaw.community.core.errors import DomainError
+
 
 class SkillDeleteConsistencyError(RuntimeError):
     """A Skill delete could not safely converge filesystem and database state."""
@@ -117,24 +119,62 @@ class RepositoryCatalogSyncFailedError(Exception):
     """The governed Repo synchronization could not finish successfully."""
 
 
-class SkillSetControlPlaneNotFoundError(Exception):
-    """A canonical SkillSet is absent from the addressed Bot scope."""
+# ── SkillSet control plane ────────────────────────────────────────────────
+# These are ``DomainError`` subclasses so the SkillSet routers can raise the
+# situation and let the HTTP adapter decide the status: the mapping lives in
+# ``adapters.http.app._DOMAIN_ERROR_STATUS_MAP`` (Rule 7 — core/ is
+# transport-free), and ``_domain_error_handler`` logs 5xx with a traceback, so
+# the ``__cause__`` chain survives to the log instead of being replaced by a
+# hand-built ``HTTPException`` at the route.
+#
+# Each default ``detail`` is the message the legacy ``/api/skillsets`` wire
+# already published, so callers see the same body as before. Every raise site
+# may override it when it has something more specific to say.
 
 
-class SkillSetAccessDeniedError(Exception):
+class SkillSetControlPlaneNotFoundError(DomainError):
+    """The addressed Bot scope, or a canonical SkillSet inside it, is absent."""
+
+    def __init__(self, detail: str = "Skill set not found") -> None:
+        super().__init__(detail)
+
+
+class SkillSetAccessDeniedError(DomainError):
     """The authenticated principal cannot mutate the addressed Bot SkillSet."""
 
+    def __init__(self, detail: str = "Forbidden") -> None:
+        super().__init__(detail)
 
-class SkillSetControlPlaneConflictError(Exception):
-    """A canonical SkillSet command conflicts with desired state."""
+
+class SkillSetControlPlaneConflictError(DomainError):
+    """A canonical SkillSet command conflicts with desired state.
+
+    Raised with a stable uppercase reason code (``SKILL_SET_NAME_CONFLICT``,
+    ``BOT_MUTATION_BUSY``, ...) that the published wire echoes verbatim.
+    """
+
+    def __init__(self, detail: str = "Skill set operation conflict") -> None:
+        super().__init__(detail)
 
 
-class SkillSetRuntimeReconcileError(Exception):
+class SkillSetRuntimeReconcileError(DomainError):
     """Runtime reconciliation failed after desired-state compensation."""
 
+    def __init__(self, detail: str = "Skill set runtime sync failed") -> None:
+        super().__init__(detail)
 
-class SkillSetControlPlaneLockUnavailableError(Exception):
-    """The Bot capability mutation fence is unavailable; mutation failed closed."""
+
+class SkillSetControlPlaneLockUnavailableError(DomainError):
+    """The Bot capability mutation fence is unavailable; mutation failed closed.
+
+    The mutation never started, so the caller may retry once the fence is
+    reachable again. That is a conflict with the current state of the Bot, not
+    the service being out of rotation — see the status map for why this is not
+    a 503.
+    """
+
+    def __init__(self, detail: str = "Skill set mutation unavailable") -> None:
+        super().__init__(detail)
 
 
 class SkillSetManagedResourceError(Exception):

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -18,7 +18,6 @@ from agentclaw.community.core.repository.skill_set_control_plane_types import (
     SkillSetMutation,
 )
 from agentclaw.community.core.skill_center.errors import (
-    LocalSkillNotFoundError,
     LocalSkillNotReadyError,
     McpPermissionDeniedError,
     SkillSetControlPlaneConflictError,
@@ -91,7 +90,10 @@ class SkillSetControlPlaneService:
         """Resolve the exact addressed Bot before applying caller policy."""
         bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
         if bot is None:
-            raise LocalSkillNotFoundError()
+            # The SkillSet control plane speaks one error vocabulary so the HTTP
+            # adapter maps a single family: an invisible Bot scope is a SkillSet
+            # not-found, not a Local Skill one.
+            raise SkillSetControlPlaneNotFoundError()
         if not self._authorization.can_manage_bot(
             bot_id=bot_id,
             owner_id=owner_id,
@@ -104,7 +106,7 @@ class SkillSetControlPlaneService:
         """Resolve the owner only for a released wire that cannot name one."""
         bot = self._bot_repo.get_unique_by_id(bot_id)
         if bot is None:
-            raise LocalSkillNotFoundError()
+            raise SkillSetControlPlaneNotFoundError()
         return self._bot(
             bot_id=bot_id,
             owner_id=str(bot["owner_id"]),
@@ -216,7 +218,7 @@ class SkillSetControlPlaneService:
                 set_id=set_id,
             )
         if bot_id != "default":
-            raise LocalSkillNotFoundError()
+            raise SkillSetControlPlaneNotFoundError()
         item = self._repository.get_set(
             bot_id=bot_id, owner_id=actor_id, set_id=set_id, engine_type="openclaw"
         )

--- a/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
+++ b/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
@@ -355,7 +355,9 @@ async def test_legacy_skill_set_batch_validates_target_before_materialising_asse
             return "7"
 
     control_plane = _ControlPlane()
-    with pytest.raises(HTTPException) as failure:
+    # The route raises the situation, not a status: ``adapters.http.app``
+    # answers 404 for this class. See test_skillset_error_status_mapping.py.
+    with pytest.raises(SkillSetControlPlaneNotFoundError):
         await add_skills_to_set(
             "missing-set",
             AddSkillsRequest(skill_ids=["7"], user_id="owner", bot_id="bot"),
@@ -368,7 +370,6 @@ async def test_legacy_skill_set_batch_validates_target_before_materialising_asse
             control_plane=control_plane,
         )
 
-    assert failure.value.status_code == 404
     assert control_plane.resolved is False
 
 
@@ -384,7 +385,12 @@ async def test_legacy_skill_set_batch_propagates_infrastructure_failure() -> Non
         async def add_skill(self, **_kwargs):
             raise RuntimeError("database unavailable")
 
-    with pytest.raises(HTTPException) as failure:
+    # The route used to catch this and return a 500 reading "Skill set
+    # operation failed", which named the endpoint rather than the fault and
+    # left "database unavailable" nowhere in the response or the traceback the
+    # caller could act on. It now escapes to the app's catch-all, which logs
+    # the real exception with its traceback before answering 500.
+    with pytest.raises(RuntimeError, match="database unavailable"):
         await add_skills_to_set(
             "set-1",
             AddSkillsRequest(skill_ids=["7"], user_id="owner", bot_id="bot"),
@@ -396,9 +402,6 @@ async def test_legacy_skill_set_batch_propagates_infrastructure_failure() -> Non
             bot_repo=_Bots(),
             control_plane=_ControlPlane(),
         )
-
-    assert failure.value.status_code == 500
-    assert failure.value.detail == "Skill set operation failed"
 
 
 @pytest.mark.asyncio
@@ -413,7 +416,10 @@ async def test_legacy_skill_set_batch_does_not_hide_mutation_busy() -> None:
         async def add_skill(self, **_kwargs):
             raise SkillSetControlPlaneConflictError("BOT_MUTATION_BUSY")
 
-    with pytest.raises(HTTPException) as failure:
+    # A busy fence is not one of the two per-skill conflicts the batch records
+    # as a partial failure, so it must abort the request. The reason code is
+    # the published wire and survives to the caller as the error detail.
+    with pytest.raises(SkillSetControlPlaneConflictError) as failure:
         await add_skills_to_set(
             "set-1",
             AddSkillsRequest(skill_ids=["7"], user_id="owner", bot_id="bot"),
@@ -426,8 +432,7 @@ async def test_legacy_skill_set_batch_does_not_hide_mutation_busy() -> None:
             control_plane=_ControlPlane(),
         )
 
-    assert failure.value.status_code == 400
-    assert failure.value.detail == "BOT_MUTATION_BUSY"
+    assert str(failure.value) == "BOT_MUTATION_BUSY"
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/adapters/http/skill_center/test_skillset_error_status_mapping.py
+++ b/src/backend/tests/community/adapters/http/skill_center/test_skillset_error_status_mapping.py
@@ -1,0 +1,167 @@
+"""SkillSet control-plane errors get their HTTP status at the app layer.
+
+The legacy ``/api/skillsets`` routes used to translate these themselves, in a
+router-level ``_legacy_error`` helper that returned a hand-built
+``HTTPException``. That put the status decision inside the route, and — because
+the helper returned a *new* exception — the raised one and its ``__cause__``
+chain never reached a log.
+
+The mapping now lives in ``adapters.http.app._DOMAIN_ERROR_STATUS_MAP`` like
+every other domain error, so this test asserts the wire from the same handler
+wiring production uses.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agentclaw.community.core.errors import DomainError
+from agentclaw.community.core.skill_center.errors import (
+    SkillSetAccessDeniedError,
+    SkillSetControlPlaneConflictError,
+    SkillSetControlPlaneLockUnavailableError,
+    SkillSetControlPlaneNotFoundError,
+    SkillSetRuntimeReconcileError,
+)
+
+_ROUTE_MAP: dict[str, type[DomainError]] = {
+    "notfound": SkillSetControlPlaneNotFoundError,
+    "denied": SkillSetAccessDeniedError,
+    "conflict": SkillSetControlPlaneConflictError,
+    "lock": SkillSetControlPlaneLockUnavailableError,
+    "reconcile": SkillSetRuntimeReconcileError,
+}
+
+
+def _build_app() -> FastAPI:
+    # Import the handlers from app.py so the test cannot drift from prod.
+    from agentclaw.community.adapters.http.app import (
+        _domain_error_handler,
+        _unhandled_exception_handler,
+    )
+
+    app = FastAPI()
+    app.add_exception_handler(DomainError, _domain_error_handler)
+    app.add_exception_handler(Exception, _unhandled_exception_handler)
+
+    @app.get("/api/skillsets/raise/{which}")
+    async def raiser(which: str):
+        raise _ROUTE_MAP[which]()
+
+    @app.get("/api/skillsets/raise-detail/{which}")
+    async def raiser_with_detail(which: str):
+        raise _ROUTE_MAP[which]("spelled-out reason")
+
+    @app.get("/api/skillsets/raise-chained")
+    async def raise_chained():
+        try:
+            raise RuntimeError("lock backend refused the connection")
+        except RuntimeError as exc:
+            raise SkillSetRuntimeReconcileError() from exc
+
+    @app.get("/api/skillsets/raise-unexpected")
+    async def raise_unexpected():
+        raise RuntimeError("database unavailable")
+
+    return app
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    # raise_server_exceptions=False so the catch-all handler actually runs
+    # instead of TestClient re-raising before it can answer.
+    return TestClient(_build_app(), raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize(
+    "which,expected_status,expected_detail",
+    [
+        ("notfound", 404, "Skill set not found"),
+        ("denied", 403, "Forbidden"),
+        ("conflict", 400, "Skill set operation conflict"),
+        ("lock", 409, "Skill set mutation unavailable"),
+        ("reconcile", 500, "Skill set runtime sync failed"),
+    ],
+)
+def test_each_control_plane_error_maps_to_its_status(
+    client: TestClient, which: str, expected_status: int, expected_detail: str
+) -> None:
+    response = client.get(f"/api/skillsets/raise/{which}")
+
+    assert response.status_code == expected_status
+    # The legacy surface keeps the ``{"detail": ...}`` shape its clients parse.
+    assert response.json() == {"detail": expected_detail}
+
+
+def test_lock_unavailable_is_a_conflict_not_a_service_outage(
+    client: TestClient,
+) -> None:
+    """503 would be a lie, and clients act on it.
+
+    The mutation fence is per-Bot: failing to take it means this command
+    conflicts with another one in flight, while the service itself is up and
+    answering. A 503 tells proxies and retry layers the whole endpoint is out
+    of rotation, which is both wrong and disruptive to unrelated callers.
+    """
+    response = client.get("/api/skillsets/raise/lock")
+
+    assert response.status_code == 409
+    assert response.status_code != 503
+
+
+def test_a_raise_site_may_say_more_than_the_default_detail(
+    client: TestClient,
+) -> None:
+    """``remove_skill_from_set`` relies on this to keep its own 404 wording."""
+    response = client.get("/api/skillsets/raise-detail/notfound")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "spelled-out reason"}
+
+
+def test_server_side_failure_logs_the_root_cause(
+    client: TestClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The reason the router no longer builds the HTTPException itself.
+
+    A helper that returns a fresh exception discards the one that was raised,
+    so the ``__cause__`` explaining *why* reconciliation failed never reached
+    the log. Raising through to the app handler keeps the chain intact.
+    """
+    with caplog.at_level(logging.ERROR):
+        response = client.get("/api/skillsets/raise-chained")
+
+    assert response.status_code == 500
+    assert "lock backend refused the connection" in caplog.text
+
+
+def test_unexpected_failure_is_not_rewritten_as_a_skillset_error(
+    client: TestClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A bug is not a SkillSet outcome.
+
+    The old helper answered every unrecognised exception with a 500 reading
+    "Skill set operation failed", which named the endpoint rather than the
+    fault. The catch-all reports it as what it is and logs the traceback.
+    """
+    with caplog.at_level(logging.ERROR):
+        response = client.get("/api/skillsets/raise-unexpected")
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Internal Server Error"}
+    assert "database unavailable" in caplog.text
+
+
+def test_status_map_covers_every_control_plane_error() -> None:
+    from agentclaw.community.adapters.http.app import _DOMAIN_ERROR_STATUS_MAP
+
+    missing = sorted(
+        cls.__name__
+        for cls in _ROUTE_MAP.values()
+        if cls not in _DOMAIN_ERROR_STATUS_MAP
+    )
+    assert missing == []

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -12,7 +12,6 @@ from agentclaw.community.core.repository.implementations.skill_center.skill_set_
     SkillSetMutation,
 )
 from agentclaw.community.core.skill_center.errors import (
-    LocalSkillNotFoundError,
     SkillSetAccessDeniedError,
     SkillSetControlPlaneNotFoundError,
     SkillSetRuntimeReconcileError,
@@ -701,7 +700,10 @@ def test_legacy_create_rejects_missing_bot_instead_of_creating_orphan_set():
         mcp_auth=_McpAuth(allowed=True),
     )
 
-    with pytest.raises(LocalSkillNotFoundError):
+    # The control plane speaks one error vocabulary: an invisible Bot scope is
+    # a SkillSet not-found, so the HTTP adapter maps a single family rather
+    # than also having to know about the Local Skill errors.
+    with pytest.raises(SkillSetControlPlaneNotFoundError):
         service.create_legacy_set(
             bot_id="missing",
             actor_id="actor",


### PR DESCRIPTION
## Problem

`adapters/http/skill_center/skillsets.py` translated control-plane failures itself, in a `_legacy_error` helper that returned a hand-built `HTTPException`, wrapped around each handler body by a blanket `except Exception`.

Three problems with that:

1. **The status decision lived inside the route.** Every other domain error in this service gets its status at the wire-up layer — `core/errors.py` defines transport-free `DomainError` subclasses (Rule 7), and `adapters/http/app.py::_DOMAIN_ERROR_STATUS_MAP` maps them. The SkillSet routes were the exception.

2. **The root cause was swallowed.** The helper returned a *new* exception, so the raised one and its `__cause__` chain never reached a log — the known branches logged nothing at all, and the internal `/api` surface uses Starlette's default `HTTPException` handler, which logs nothing either. Anything unrecognised came back as a 500 reading `"Skill set operation failed"`, a message naming the endpoint rather than the fault; a `RuntimeError("database unavailable")` was indistinguishable on the wire from a bug in the serializer.

3. **`SkillSetControlPlaneLockUnavailableError` answered 503.** That error has three raise sites in `BotCapabilityMutationGuard`: `acquire()` when the cache refuses the lock, and `ensure_valid()` / `renew()` when a lease *this request already held* was lost mid-mutation. In all three the service is up and answering — the command lost a race for one Bot's fence. 503 is the one status that means the server is out of rotation, and proxies and client retry layers act on it, backing off an endpoint that is serving every other caller fine.

## Solution

The five SkillSet control-plane errors become `DomainError` subclasses, each with a default `detail` equal to the message the legacy wire already published (raise sites may override it). Their statuses go in `_DOMAIN_ERROR_STATUS_MAP` alongside every other domain error, and `_legacy_error` and its `except Exception` wrappers are deleted.

That gets all three points at once:

- The route raises the situation; this layer alone decides the wire.
- `_domain_error_handler` logs 5xx with `logger.exception`, so the `__cause__` chain survives to the log. Unexpected exceptions now reach the app's catch-all, which logs the full traceback and reports them as what they are.
- The lock error maps to **409**, on the internal surface and on the public one (`openapi_v1/responses.py` had the same 503). Its public business code follows the status from `503201` into the SkillSet `4092xx` range as `409209`, per the status-then-sequence convention that table already uses (`409` + `209`).

Two supporting changes:

- `SkillSetControlPlaneService` stops raising `LocalSkillNotFoundError` when the addressed Bot scope is invisible, and raises `SkillSetControlPlaneNotFoundError` instead. A SkillSet service raising a Local Skill error was what forced the router helper to map two error families; now the surface maps one. `LocalSkillNotFoundError` is untouched everywhere else — with ~50 raise sites across Skill Center, giving it an app-level status is a separate decision.
- `remove_skill_from_set`'s own `HTTPException(404, "Skill not found in skill set")` becomes `SkillSetControlPlaneNotFoundError("Skill not found in skill set")`, keeping its wording via the overridable detail.

### Rejected alternative

A second status table scoped to the legacy `/api` surface, leaving the exception classes alone. It avoids touching `core/`, but adds a parallel mechanism for the same job on the same surface — the drift `core/errors.py` is explicitly written to prevent — and `test_domain_error_status_map_complete` would not cover it.

### Not in scope

`skillsets.py` still has ~10 hand-rolled `HTTPException` raises in the older passport-CLI and admin handlers, which do not go through the control plane. Same layering smell, different services; worth a follow-up.

## Validation

Run with `.venv/bin/python -m pytest` in `src/backend`:

- Full backend suite: **13604 passed, 26 skipped, 3 failed**. Two failures are environmental (`rsync: not found` in this container — `test_bot_build_service_skill_artifact.py`, confirmed by `which rsync`). The third, `test_module_boundaries.py::test_declared_deps_cover_actual_imports`, was caused by this change and is fixed in it: `core/skill_center` now imports `core.errors`, declared in its README boundary section.
- `adapters/http/openapi_v1` + `adapters/http/skill_center` + `core/skill_center` + `contracts`, after the public-surface status change: **2291 passed, 5 skipped**.
- Final consolidated run of `adapters/http/skill_center`, `core/skill_center`, `architecture`, `api/skill_center`, `api/test_domain_error_handler.py`: **1212 passed, 3 skipped**.
- Lint gate: `flake8` with the `python_sast_local.sh` block-rule set over every changed file — clean.

New `tests/community/adapters/http/skill_center/test_skillset_error_status_mapping.py` asserts the wire from the same handler wiring production uses: each error's status and detail, that the lock error is 409 and never 503, that a raise site may override the default detail, that a chained 5xx puts its root cause in the log, and that an unexpected exception is not rewritten as a SkillSet outcome.

Three existing tests changed expectation, all deliberately: two now assert the domain error the route raises instead of an `HTTPException`, and `test_legacy_skill_set_batch_propagates_infrastructure_failure` now asserts `RuntimeError("database unavailable")` propagates rather than being masked as `"Skill set operation failed"`.

## Compatibility and risk

Statuses on the legacy `/api/skillsets` wire are unchanged apart from the 503 → 409, and the `{"detail": ...}` body shape is preserved by `_domain_error_handler`. Detail strings are preserved except for unexpected failures, which now return `"Internal Server Error"` like every other unhandled error instead of `"Skill set operation failed"`. No frontend or gateway artifact references any of these strings.

**Reviewer call-out:** the public-surface change (`503` → `409`, code `503201` → `409209`) is a published contract change. Nothing in `src/gateway` or `docs/` pins either value, and leaving it would mean one exception answering 409 internally and 503 publicly — but it is a separable hunk if you would rather ship the internal fix alone.

Rollback is the revert; no schema, config, or migration impact.