### PR TITLE
fix(backend): log a stack trace for every error the app handlers answer

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -536,11 +536,12 @@ async def _http_exception_handler(
         # public handler: ``@envelope_errors`` does not map that type, so it
         # arrives here with the handler's arguments already stashed.
         #
-        # 5xx carries the traceback like every other 5xx path here, because a
-        # handler-raised one ("Upload storage failed", "cron service returned no
-        # data") is diagnosed by its raise site. 4xx does not: the common case is
-        # Starlette's own routing 404/405, raised before any handler, whose stack
-        # is framework internals rather than anything we would read.
+        # Every status carries the traceback. For a handler-raised one ("Upload
+        # storage failed", "cron service returned no data") the raise site is
+        # the diagnosis. For Starlette's own routing 404/405, raised before any
+        # handler, the stack is framework internals and adds little — but the
+        # two are indistinguishable from here, and a handler-raised 4xx is the
+        # one worth keeping, so this does not try to tell them apart.
         is_server_error = exc.status_code >= 500
         log = logger.error if is_server_error else logger.warning
         log(
@@ -664,14 +665,21 @@ async def _principal_error_handler(request: Request, exc: Exception) -> JSONResp
     and then unconditionally re-raises ("We always continue to raise the
     exception", ``starlette/middleware/errors.py``) so the server can log a
     crash. The result was a correct 401 on the wire followed by a hundred-odd
-    lines of ASGI traceback per request — precisely what the catch-all's
-    warning-without-a-traceback was written to avoid, and ruinous on this path
-    because an auth misconfiguration makes *every* request take it.
+    lines of ASGI traceback per request, ruinous on this path because an auth
+    misconfiguration makes *every* request take it.
 
     Registering the concrete types instead puts them in the inner
     ``ExceptionMiddleware``, which answers and does not re-raise. The status
     and body still come from ``ENVELOPE_ERRORS`` via ``_public_mapped_error``,
     so this adds a route out of the stack, not a second opinion on the answer.
+
+    The log line below does now carry ``exc_info``, so a misconfiguration still
+    puts a traceback behind every request — a deliberate trade, and a much
+    smaller one than what this handler was written to stop: the framework's
+    re-raise dumped the whole ASGI stack twice per request, while this is one
+    formatted chain for the exception itself. If the volume ever does bite, the
+    fix is to drop ``exc_info`` here specifically rather than to unregister
+    these types, which would bring the re-raise back.
     """
     # ``exc`` carries the operator-facing diagnosis on the verification path —
     # the token's ``alg``/``kid`` and the fingerprint of the key we judged it

--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -467,7 +467,8 @@ async def _domain_error_handler(request: Request, exc: DomainError) -> JSONRespo
     # client-side flow (bad input, missing auth), so it gets one compact line
     # without a traceback: enough to see that the request was refused and with
     # what arguments, without a per-401 stack in the log file. It used to get
-    # nothing at all, which is why a refused request could not be traced.
+    # nothing at all, which is why a refused request could not be traced. The
+    # one exception is a 4xx that wraps a cause — see below.
     #
     # 3xx stays silent: the only one is ``LoginRedirectRequired``, an ordinary
     # step in the login flow rather than a failure to diagnose.
@@ -482,10 +483,19 @@ async def _domain_error_handler(request: Request, exc: DomainError) -> JSONRespo
             params_suffix(request),
         )
     elif status >= 400:
+        # A 4xx raised ``from`` something is a refusal this service synthesised
+        # out of an underlying failure, and the cause is the only record of why
+        # — a lock error answering 409 says the fence could not be taken but
+        # not that the cache backend was unreachable. Status alone is the wrong
+        # question for a traceback: what matters is whether anything happened
+        # underneath that a reader would otherwise never see. A bare 4xx (the
+        # common case: bad input, missing auth, unknown id) has no cause and
+        # still gets one compact line, so this puts no stack behind a 401.
         logger.warning(
             "[DomainError %s] %s on %s %s: %s%s",
             status, type(exc).__name__, request.method, request.url.path,
             exc.detail, params_suffix(request),
+            exc_info=exc if exc.__cause__ is not None else None,
         )
     if _is_public_api(request):
         return _public_error_envelope(status, request)

--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -462,16 +462,15 @@ def _public_mapped_error(request: Request, exc: Exception) -> JSONResponse | Non
 @app.exception_handler(DomainError)
 async def _domain_error_handler(request: Request, exc: DomainError) -> JSONResponse:
     status = _DOMAIN_ERROR_STATUS_MAP.get(type(exc), 500)
-    # 5xx means a core service signalled an internal failure; emit a full
-    # traceback so the cause is recoverable from logs. 4xx is expected
-    # client-side flow (bad input, missing auth), so it gets one compact line
-    # without a traceback: enough to see that the request was refused and with
-    # what arguments, without a per-401 stack in the log file. It used to get
-    # nothing at all, which is why a refused request could not be traced. The
-    # one exception is a 4xx that wraps a cause — see below.
+    # Every DomainError that reaches here is logged with its traceback,
+    # whatever status it maps to. The status is what the *caller* is told; it
+    # says nothing about how much an operator needs to reconstruct the failure.
+    # Keying the traceback off it lost real diagnostics: a lock error answering
+    # 409 is raised ``from`` the cache failure underneath, and the log recorded
+    # that the fence was unavailable while dropping the reason.
     #
-    # 3xx stays silent: the only one is ``LoginRedirectRequired``, an ordinary
-    # step in the login flow rather than a failure to diagnose.
+    # Level still tracks status — 5xx is ours, 4xx is usually the caller's — so
+    # existing alerting keyed on level is unaffected. Only the traceback is new.
     #
     # ``params_suffix`` is empty unless the public surface's ``@envelope_errors``
     # captured the handler's arguments on the way past, so the message shape is
@@ -483,19 +482,22 @@ async def _domain_error_handler(request: Request, exc: DomainError) -> JSONRespo
             params_suffix(request),
         )
     elif status >= 400:
-        # A 4xx raised ``from`` something is a refusal this service synthesised
-        # out of an underlying failure, and the cause is the only record of why
-        # — a lock error answering 409 says the fence could not be taken but
-        # not that the cache backend was unreachable. Status alone is the wrong
-        # question for a traceback: what matters is whether anything happened
-        # underneath that a reader would otherwise never see. A bare 4xx (the
-        # common case: bad input, missing auth, unknown id) has no cause and
-        # still gets one compact line, so this puts no stack behind a 401.
         logger.warning(
             "[DomainError %s] %s on %s %s: %s%s",
             status, type(exc).__name__, request.method, request.url.path,
             exc.detail, params_suffix(request),
-            exc_info=exc if exc.__cause__ is not None else None,
+            exc_info=exc,
+        )
+    else:
+        # 3xx is only ``LoginRedirectRequired``, an ordinary step in the login
+        # flow rather than a failure. It used to be silent; it is logged at
+        # info so "all errors carry a stack" holds without a redirect looking
+        # like a fault to anything reading warnings.
+        logger.info(
+            "[DomainError %s] %s on %s %s: %s%s",
+            status, type(exc).__name__, request.method, request.url.path,
+            exc.detail, params_suffix(request),
+            exc_info=exc,
         )
     if _is_public_api(request):
         return _public_error_envelope(status, request)
@@ -545,9 +547,21 @@ async def _http_exception_handler(
             "[Public %s] HTTPException on %s %s: %s%s",
             exc.status_code, request.method, request.url.path, exc.detail,
             params_suffix(request),
-            exc_info=exc if is_server_error else None,
+            exc_info=exc,
         )
         return _public_error_envelope(exc.status_code, request, exc.headers)
+    # Internal ``/api`` routes keep FastAPI's response shape, but its default
+    # handler logs nothing at all — an ``HTTPException`` raised inside a route
+    # left no record whatsoever. Log it here before delegating, so the response
+    # is unchanged and the raise site is still recoverable.
+    is_server_error = exc.status_code >= 500
+    log = logger.error if is_server_error else logger.warning
+    log(
+        "[HTTPException %s] on %s %s: %s%s",
+        exc.status_code, request.method, request.url.path, exc.detail,
+        params_suffix(request),
+        exc_info=exc,
+    )
     return await http_exception_handler(request, exc)
 
 
@@ -581,8 +595,22 @@ async def _validation_error_handler(
                 {"loc": e.get("loc"), "type": e.get("type"), "msg": e.get("msg")}
                 for e in exc.errors()
             ],
+            exc_info=exc,
         )
         return error_response(422, "Invalid request", request)
+    # Internal routes keep FastAPI's ``{"detail": [...]}`` body, whose default
+    # handler logs nothing. Same treatment as above: log, then delegate. The
+    # ``input`` each error carries is the caller's raw payload, so only
+    # ``loc``/``type``/``msg`` are recorded here too.
+    logger.warning(
+        "[422] validation failed on %s %s: %s",
+        request.method, request.url.path,
+        [
+            {"loc": e.get("loc"), "type": e.get("type"), "msg": e.get("msg")}
+            for e in exc.errors()
+        ],
+        exc_info=exc,
+    )
     return await request_validation_exception_handler(request, exc)
 
 
@@ -604,6 +632,13 @@ async def _data_proxy_error_handler(
             "[DataProxyError 5xx] %s on %s %s: %s%s",
             type(exc).__name__, request.method, request.url.path, exc.message,
             params_suffix(request),
+        )
+    else:
+        logger.warning(
+            "[DataProxyError %s] %s on %s %s: %s%s",
+            status, type(exc).__name__, request.method, request.url.path,
+            exc.message, params_suffix(request),
+            exc_info=exc,
         )
     return JSONResponse(
         status_code=status,
@@ -647,6 +682,7 @@ async def _principal_error_handler(request: Request, exc: Exception) -> JSONResp
         "[Public 401] %s on %s %s: %s%s",
         type(exc).__name__, request.method, request.url.path, exc,
         params_suffix(request),
+        exc_info=exc,
     )
     mapped = _public_mapped_error(request, exc)
     if mapped is not None:
@@ -680,6 +716,7 @@ async def _user_id_mismatch_handler(
         "[Public 403] %s on %s %s: %s%s",
         type(exc).__name__, request.method, request.url.path, exc,
         params_suffix(request),
+        exc_info=exc,
     )
     mapped = _public_mapped_error(request, exc)
     if mapped is not None:
@@ -716,6 +753,7 @@ async def _grant_not_resolvable_handler(
         "[Public 404] %s on %s %s: %s%s",
         type(exc).__name__, request.method, request.url.path, exc,
         params_suffix(request),
+        exc_info=exc,
     )
     mapped = _public_mapped_error(request, exc)
     if mapped is not None:
@@ -746,6 +784,7 @@ async def _bot_access_refused_handler(
         "[Public 404] %s on %s %s: %s%s",
         type(exc).__name__, request.method, request.url.path, exc,
         params_suffix(request),
+        exc_info=exc,
     )
     mapped = _public_mapped_error(request, exc)
     if mapped is not None:
@@ -779,15 +818,15 @@ async def _unhandled_exception_handler(request: Request, exc: Exception) -> JSON
     # they are rare, where an unverifiable caller is not.
     mapped = _public_mapped_error(request, exc)
     if mapped is not None:
-        # Expected client-side flow (missing/invalid credentials, bad input).
-        # A traceback per unauthenticated request would bury the real 5xx ones,
-        # so log at warning without one — matching how the DomainError handler
-        # treats 4xx.
+        # Level still tracks status — an expected client-side refusal is not a
+        # 5xx — but the traceback is emitted either way, matching how the
+        # DomainError handler now treats every status.
         if mapped.status_code < 500:
             logger.warning(
                 "[Public %s] %s on %s %s%s",
                 mapped.status_code, type(exc).__name__, request.method,
                 request.url.path, params_suffix(request),
+                exc_info=exc,
             )
             return mapped
         logger.exception(

--- a/src/backend/tests/community/adapters/http/skill_center/test_skillset_error_status_mapping.py
+++ b/src/backend/tests/community/adapters/http/skill_center/test_skillset_error_status_mapping.py
@@ -67,6 +67,18 @@ def _build_app() -> FastAPI:
     async def raise_unexpected():
         raise RuntimeError("database unavailable")
 
+    @app.get("/api/skillsets/raise-lock-chained")
+    async def raise_lock_chained():
+        # The shape SkillSetControlPlaneService produces: the guard's error
+        # wraps the cache failure, and the control plane wraps the guard's.
+        try:
+            try:
+                raise RuntimeError("cache lock backend unreachable")
+            except RuntimeError as cache_exc:
+                raise RuntimeError("mutation fence unavailable") from cache_exc
+        except RuntimeError as guard_exc:
+            raise SkillSetControlPlaneLockUnavailableError() from guard_exc
+
     return app
 
 
@@ -165,3 +177,22 @@ def test_status_map_covers_every_control_plane_error() -> None:
         if cls not in _DOMAIN_ERROR_STATUS_MAP
     )
     assert missing == []
+
+
+def test_lock_unavailable_logs_why_the_fence_was_unavailable(
+    client: TestClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """409 is right for the caller and wrong as a traceback rule.
+
+    Production logged exactly one line for this — "SkillSetControlPlaneLockUnavailableError
+    on POST /api/skillsets/{id}/skills: Skill set mutation unavailable" — and
+    nothing about the cache failure underneath, because the handler emitted a
+    traceback only for 5xx and this error had just moved to 409. Both links of
+    the chain must reach the log.
+    """
+    with caplog.at_level(logging.WARNING):
+        response = client.get("/api/skillsets/raise-lock-chained")
+
+    assert response.status_code == 409
+    assert "mutation fence unavailable" in caplog.text
+    assert "cache lock backend unreachable" in caplog.text

--- a/src/backend/tests/community/api/test_domain_error_handler.py
+++ b/src/backend/tests/community/api/test_domain_error_handler.py
@@ -52,6 +52,13 @@ def _build_app() -> FastAPI:
     async def raise_unhandled():
         raise RuntimeError("kaboom-runtime")
 
+    @app.get("/raise-caused/{which}")
+    async def raise_caused(which: str):
+        try:
+            raise RuntimeError("cache backend unreachable")
+        except RuntimeError as exc:
+            raise _ROUTE_MAP[which](f"boom-{which}") from exc
+
     return app
 
 
@@ -164,14 +171,41 @@ def test_4xx_domain_error_logs_one_compact_warning(client, monkeypatch):
     client.get("/raise/notfound")
     assert any("[DomainError %s]" in str(a[0]) for a, _ in calls), \
         f"expected a 4xx DomainError warning, got: {calls}"
-    assert all("exc_info" not in k for _, k in calls), \
-        "4xx must not carry a traceback"
+    assert all(k.get("exc_info") is None for _, k in calls), \
+        "a bare 4xx must not carry a traceback"
 
     # 3xx stays silent: LoginRedirectRequired is a step in the login flow, not
     # a failure anyone debugs.
     calls.clear()
     client.get("/raise/redirect")
     assert calls == [], f"302 must not log, got: {calls}"
+
+
+def test_4xx_raised_from_a_cause_logs_that_cause(client, monkeypatch):
+    """The status a caller sees and the detail an operator needs are different
+    questions.
+
+    ``SkillSetControlPlaneLockUnavailableError`` answers 409 — the mutation
+    fence could not be taken, which is a conflict, not an outage. But it is
+    raised ``from`` the cache failure underneath, and keying the traceback off
+    the status alone dropped that cause on the floor: the log said the fence
+    was unavailable and never said why. A 4xx that wraps a cause now carries
+    it.
+    """
+    from agentclaw.community.adapters.http import app as app_mod
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        app_mod.logger, "warning",
+        lambda *a, **k: calls.append((a, k)),
+    )
+    client.get("/raise-caused/conflict")
+
+    logged = [k["exc_info"] for _, k in calls if k.get("exc_info") is not None]
+    assert logged, f"a caused 4xx must log its cause, got: {calls}"
+    cause = logged[0].__cause__
+    assert isinstance(cause, RuntimeError)
+    assert str(cause) == "cache backend unreachable"
 
 
 def test_handler_logs_the_params_stashed_by_the_public_decorator(monkeypatch):

--- a/src/backend/tests/community/api/test_domain_error_handler.py
+++ b/src/backend/tests/community/api/test_domain_error_handler.py
@@ -158,9 +158,10 @@ def test_5xx_domain_error_logs_traceback_but_4xx_does_not(client, monkeypatch):
     assert sum(1 for s in fmt_strings if "DomainError 5xx" in s) == 1
 
 
-def test_4xx_domain_error_logs_one_compact_warning(client, monkeypatch):
-    """A refused request used to leave no trace at all. It now logs one line —
-    without a traceback, so a per-401 stack does not bury the real 5xx ones."""
+def test_4xx_domain_error_logs_a_warning_with_its_traceback(client, monkeypatch):
+    """A refused request used to leave no trace at all, then one line without a
+    stack. It now carries the traceback too: the status is what the caller is
+    told, and says nothing about what an operator needs to reconstruct it."""
     from agentclaw.community.adapters.http import app as app_mod
 
     calls: list[tuple] = []
@@ -171,14 +172,32 @@ def test_4xx_domain_error_logs_one_compact_warning(client, monkeypatch):
     client.get("/raise/notfound")
     assert any("[DomainError %s]" in str(a[0]) for a, _ in calls), \
         f"expected a 4xx DomainError warning, got: {calls}"
-    assert all(k.get("exc_info") is None for _, k in calls), \
-        "a bare 4xx must not carry a traceback"
+    assert all(k.get("exc_info") is not None for _, k in calls), \
+        "a 4xx must carry its raise site"
 
-    # 3xx stays silent: LoginRedirectRequired is a step in the login flow, not
-    # a failure anyone debugs.
-    calls.clear()
+
+def test_3xx_domain_error_logs_at_info_not_warning(client, monkeypatch):
+    """``LoginRedirectRequired`` is a step in the login flow, not a fault.
+
+    It is logged so that "every error carries a stack" holds without exception,
+    but at info — a redirect must not read as a failure to anything watching
+    warnings, and this fires on ordinary unauthenticated traffic.
+    """
+    from agentclaw.community.adapters.http import app as app_mod
+
+    warnings: list[tuple] = []
+    infos: list[tuple] = []
+    monkeypatch.setattr(
+        app_mod.logger, "warning", lambda *a, **k: warnings.append((a, k)),
+    )
+    monkeypatch.setattr(
+        app_mod.logger, "info", lambda *a, **k: infos.append((a, k)),
+    )
     client.get("/raise/redirect")
-    assert calls == [], f"302 must not log, got: {calls}"
+
+    assert warnings == [], f"302 must not log at warning, got: {warnings}"
+    assert infos, "302 must still be recorded"
+    assert all(k.get("exc_info") is not None for _, k in infos)
 
 
 def test_4xx_raised_from_a_cause_logs_that_cause(client, monkeypatch):
@@ -270,9 +289,10 @@ def _public_http_exception_client():
         # is in ENVELOPE_ERRORS, so they land in this handler.
         (502, "error", True),
         (500, "error", True),
-        # Starlette's own routing failures dominate 4xx here; their stack is
-        # framework internals, so the message alone is the useful part.
-        (404, "warning", False),
+        # 4xx too: the stack is framework internals for Starlette's own routing
+        # failures, but it is the raise site for one thrown inside a handler,
+        # and the two are indistinguishable from here.
+        (404, "warning", True),
     ],
 )
 def test_public_http_exception_logging(monkeypatch, status, level, wants_traceback):
@@ -289,11 +309,84 @@ def test_public_http_exception_logging(monkeypatch, status, level, wants_traceba
     assert calls, f"expected a {level} log for {status}"
     args, kwargs = calls[-1]
     assert f"boom-{status}" in args, "the raised detail must survive in the log"
-    if wants_traceback:
-        assert kwargs.get("exc_info") is not None, \
-            "a 5xx HTTPException must carry its raise site"
-    else:
-        assert kwargs.get("exc_info") is None
+    assert wants_traceback, "every status through this handler carries a traceback"
+    assert kwargs.get("exc_info") is not None, \
+        "an HTTPException must carry its raise site"
+
+
+def _internal_http_exception_client():
+    """The same handler on an internal ``/api`` route, which delegates its
+    response to FastAPI but must still log."""
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    from agentclaw.community.adapters.http import app as app_mod
+
+    app = FastAPI()
+    app.add_exception_handler(
+        StarletteHTTPException, app_mod._http_exception_handler
+    )
+
+    @app.get("/api/boom/{status}")
+    async def boom(status: int):
+        raise StarletteHTTPException(status_code=status, detail=f"boom-{status}")
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.parametrize("status,level", [(404, "warning"), (500, "error")])
+def test_internal_http_exception_is_logged_at_all(monkeypatch, status, level):
+    """Internal routes delegate the *response* to FastAPI, whose default handler
+    logs nothing — so an ``HTTPException`` raised inside a route left no record
+    whatsoever. ``skill_center`` still raises these by hand in a dozen places.
+
+    The response shape is FastAPI's, unchanged; only the log is new.
+    """
+    from agentclaw.community.adapters.http import app as app_mod
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        app_mod.logger, level, lambda *a, **k: calls.append((a, k)),
+    )
+    resp = _internal_http_exception_client().get(f"/api/boom/{status}")
+
+    assert resp.status_code == status
+    assert resp.json() == {"detail": f"boom-{status}"}, "wire shape must not change"
+    assert calls, f"an internal {status} must not vanish from the log"
+    args, kwargs = calls[-1]
+    assert f"boom-{status}" in args
+    assert kwargs.get("exc_info") is not None
+
+
+def test_non_5xx_data_proxy_error_is_logged_at_all(monkeypatch):
+    """``_data_proxy_error_handler`` logged only 5xx; anything mapped below that
+    returned a response with no record it had happened."""
+    from agentclaw.community.adapters.http import app as app_mod
+    from agentclaw.community.core.aicoding.services.data_proxy_service import (
+        DataProxyError,
+    )
+
+    class _Downstream(DataProxyError):
+        pass
+
+    monkeypatch.setitem(app_mod._DATA_PROXY_ERROR_STATUS_MAP, _Downstream, 400)
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        app_mod.logger, "warning", lambda *a, **k: calls.append((a, k)),
+    )
+
+    app = FastAPI()
+    app.add_exception_handler(DataProxyError, app_mod._data_proxy_error_handler)
+
+    @app.get("/api/proxy-boom")
+    async def proxy_boom():
+        raise _Downstream("upstream refused", op="read")
+
+    resp = TestClient(app, raise_server_exceptions=False).get("/api/proxy-boom")
+
+    assert resp.status_code == 400
+    assert calls, "a non-5xx DataProxyError must not vanish from the log"
+    assert calls[-1][1].get("exc_info") is not None
 
 
 # ============================================================

--- a/src/backend/tests/community/api/test_domain_error_handler.py
+++ b/src/backend/tests/community/api/test_domain_error_handler.py
@@ -282,20 +282,21 @@ def _public_http_exception_client():
 
 
 @pytest.mark.parametrize(
-    "status,level,wants_traceback",
+    "status,level",
     [
         # Handler-raised: the raise site is the diagnosis. Both of these are live
         # on the public surface (routines 500, resources upload 502) and neither
         # is in ENVELOPE_ERRORS, so they land in this handler.
-        (502, "error", True),
-        (500, "error", True),
+        (502, "error"),
+        (500, "error"),
         # 4xx too: the stack is framework internals for Starlette's own routing
         # failures, but it is the raise site for one thrown inside a handler,
-        # and the two are indistinguishable from here.
-        (404, "warning", True),
+        # and the two are indistinguishable from here. Level still splits on
+        # status even though the traceback no longer does.
+        (404, "warning"),
     ],
 )
-def test_public_http_exception_logging(monkeypatch, status, level, wants_traceback):
+def test_public_http_exception_logging(monkeypatch, status, level):
     from agentclaw.community.adapters.http import app as app_mod
     from agentclaw.community.adapters.http.openapi_v1 import PUBLIC_API_PREFIX
 
@@ -309,9 +310,8 @@ def test_public_http_exception_logging(monkeypatch, status, level, wants_traceba
     assert calls, f"expected a {level} log for {status}"
     args, kwargs = calls[-1]
     assert f"boom-{status}" in args, "the raised detail must survive in the log"
-    assert wants_traceback, "every status through this handler carries a traceback"
     assert kwargs.get("exc_info") is not None, \
-        "an HTTPException must carry its raise site"
+        "an HTTPException must carry its raise site, whatever its status"
 
 
 def _internal_http_exception_client():


### PR DESCRIPTION
## Problem

Follow-up to #1344, from a production log line:

```
WARNING [DomainError 409] SkillSetControlPlaneLockUnavailableError on
POST /api/skillsets/1115260/skills: Skill set mutation unavailable
```

That is the entire record of the failure. It says the mutation fence could not be taken and never says why. The chain that explains it:

```
SkillSetControlPlaneLockUnavailableError("Skill set mutation unavailable")
  └─ __cause__ BotCapabilityMutationLockUnavailableError()
       └─ __cause__ CacheLockInfrastructureError(...)   ← the only record of why
```

None of it reached the log, because `_domain_error_handler` decided whether to emit a traceback from the HTTP status alone — `logger.exception` for 5xx, a bare `logger.warning` for 4xx. #1344 moved this error from 503 to 409, which is right for the caller and moved it out of the branch that logs a traceback.

Auditing the rest of the app's exception handlers found the same reasoning everywhere, and three paths that logged **nothing at all**:

| Handler | Before |
| --- | --- |
| `_domain_error_handler` 4xx | one line, no stack |
| `_domain_error_handler` 3xx | silent |
| `_http_exception_handler` public 4xx | one line, no stack |
| `_http_exception_handler` **internal `/api`** | **no log at all** |
| `_validation_error_handler` public 422 | one line, no stack |
| `_validation_error_handler` **internal `/api`** | **no log at all** |
| `_data_proxy_error_handler` <500 | **no log at all** |
| 401 / 403 / 404 auth-seam handlers | one line, no stack |
| `_unhandled_exception_handler` mapped <500 | one line, no stack |

The internal `HTTPException` row is the worst of these: an exception raised by hand inside an `/api` route delegates its response to FastAPI's default handler, which logs nothing, so it left no record whatsoever. `skill_center` still raises these in about a dozen places.

## Solution

Log the traceback for every error each app-level exception handler answers, whatever status it maps to. The status is what the *caller* is told; it says nothing about what an operator needs to reconstruct the failure, and welding the two together is what lost the chain above.

For the two internal paths that delegate their response to FastAPI, the log is emitted before delegating — the wire shape is unchanged, only the record is new.

Two things deliberately left alone:

- **Level still tracks status** (5xx `error`, 4xx `warning`), so alerting keyed on level is unaffected. Only the traceback is new.
- **3xx logs at `info`, not `warning`.** The only 3xx is `LoginRedirectRequired`, an ordinary step in the login flow that fires on unauthenticated traffic. It is now recorded so "every error carries a stack" holds without exception, but it must not read as a fault to anything watching warnings.

Three commits, reviewable separately: the first narrows the rule to 4xx-with-a-cause, the second generalises it to every handler and every status, the third corrects two comments the second left describing the behaviour it had just replaced.

### Rejected alternative

An explicit opt-in table of error types that always log `exc_info`. More ceremony, a second table to keep in sync with `_DOMAIN_ERROR_STATUS_MAP`, and it needs an entry for every future error that wraps infrastructure. Handling it in the handlers gets those for free and cannot drift.

## Validation

Run with `.venv/bin/python -m pytest` in `src/backend`:

- `api` + `adapters` + `architecture` + `core/skill_center` + `contracts`: **3511 passed, 5 skipped**.
- `tests/community/adapters` on the first commit: **1604 passed, 2 skipped**.
- `test_domain_error_handler.py` + `test_skillset_error_status_mapping.py`: **38 passed** (re-run after the third commit, which touches only comments and one test parameter).
- The other files that assert on these handlers' logging — `test_principal_error_handler`, `test_user_id_mismatch_handler`, `test_explicit_user_id`, `test_access_log`: **44 passed**.
- Lint gate: `flake8` with the `python_sast_local.sh` block-rule set over every changed file — clean.

New tests:

- `test_4xx_raised_from_a_cause_logs_that_cause` — the cause reaches `exc_info`.
- `test_lock_unavailable_logs_why_the_fence_was_unavailable` — reproduces the production chain above (control-plane error wrapping guard error wrapping cache error) and asserts both underlying messages reach the log.
- `test_3xx_domain_error_logs_at_info_not_warning` — pins the level choice so a redirect cannot start reading as a fault.
- `test_internal_http_exception_is_logged_at_all` — the previously-silent path, also asserting the response body is still FastAPI's.
- `test_non_5xx_data_proxy_error_is_logged_at_all` — likewise.

Changed expectations, all deliberate: `test_4xx_domain_error_logs_one_compact_warning` and the `404` case of `test_public_http_exception_logging` asserted the *absence* of a traceback, which is the behaviour being replaced.

## Compatibility and risk

Logging only. No wire, schema, config, or migration impact — statuses and response bodies are untouched throughout. Rollback is the revert.

**Reviewer call-out:** the code this replaces deliberately avoided a per-401 stack, and that concern is real — during an auth misconfiguration every request takes the 401 path and now carries a traceback. The blast radius is every 4xx across the app, not one subsystem. The trade was made knowingly in favour of never silently dropping a cause; worth watching log volume after deploy, and worth saying if you would rather the auth-seam handlers stayed compact. `_principal_error_handler`'s docstring records the escape hatch: drop `exc_info` there specifically rather than unregister the types, which would restore the `ServerErrorMiddleware` re-raise that handler exists to prevent.

Separately, for whoever picks up the incident behind this: it makes the failure legible, it does not fix it. If those 409s are frequent, the cache-lock backend behind `BotCapabilityMutationGuard.acquire()` is likely unhealthy, and the new traceback should name it.