### PR TITLE
fix(skillsets): restore default MCP resource projection

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/legacy_skill_set_compatibility.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/legacy_skill_set_compatibility.py
@@ -6,11 +6,19 @@ from typing import Any, Protocol, runtime_checkable
 
 
 class LegacySkillSetCompatibilityProtocol(Protocol):
-    """Resolve or materialize a historical market reference as an ``ac_skill.id``."""
+    """Read Default projections and resolve historical market references."""
 
     def resolve_or_create_legacy_market_skill(
         self, *, identifier: str, owner_id: str, bot_id: str
     ) -> str: ...
+
+    def get_set_mcp_servers(
+        self,
+        skill_set_id: str,
+        user_id: str | None = None,
+        bot_id: str | None = None,
+        engine_type: str | None = None,
+    ) -> list[dict[str, Any]]: ...
 
 
 @runtime_checkable

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -658,25 +658,46 @@ class SkillSetControlPlaneService:
             engine_type=self._engine(bot),
             default_engine_types=self._default_engine_types(bot),
         )
-        return [
-            {
-                **item,
-                # System Default remains a platform projection.  Ordinary-set
-                # MCP membership is canonical desired state, not a legacy BFF
-                # association, so BFF reads observe the same rows as OpenAPI.
-                "mcps": (
-                    self._repository.list_mcps(
-                        bot_id=bot_id,
-                        owner_id=owner_id,
-                        set_id=item["id"],
-                        engine_type=self._engine(bot),
-                        default_engine_types=self._default_engine_types(bot),
-                    )
-                ),
-                "clis": default_clis if item["is_default"] else [],
-            }
-            for item in items
-        ]
+        # Default MCPs are not stored as ordinary ac_skill_set_mcp rows.  The
+        # legacy service combines engine/template defaults, explicit rows, and
+        # ac_default_skillset_mcp_exclusion.  Keep that proven projection for
+        # the published BFF resource response; ordinary Sets stay canonical.
+        legacy = (
+            self._legacy_factory.create(
+                entity_id=str(bot.get("entity_id") or owner_id),
+                bot_id=bot_id,
+                engine_type=self._engine(bot),
+                entity_type=bot.get("entity_type") or "staff",
+            )
+            if any(item["is_default"] for item in items)
+            else None
+        )
+        resources: list[dict] = []
+        for item in items:
+            if item["is_default"]:
+                assert legacy is not None
+                mcps = legacy.get_set_mcp_servers(
+                    str(item["id"]),
+                    user_id=owner_id,
+                    bot_id=bot_id,
+                    engine_type=self._engine(bot),
+                )
+            else:
+                mcps = self._repository.list_mcps(
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                    set_id=item["id"],
+                    engine_type=self._engine(bot),
+                    default_engine_types=self._default_engine_types(bot),
+                )
+            resources.append(
+                {
+                    **item,
+                    "mcps": mcps,
+                    "clis": default_clis if item["is_default"] else [],
+                }
+            )
+        return resources
 
     async def _mutate(
         self,

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -287,12 +287,17 @@ class _LegacyResolutionRepository(_Repository):
 class _LegacySkillSetService:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, str]] = []
+        self.default_mcp_calls: list[dict] = []
 
     def resolve_or_create_legacy_market_skill(
         self, *, identifier: str, owner_id: str, bot_id: str
     ) -> str:
         self.calls.append((identifier, owner_id, bot_id))
         return "stable-skill-id"
+
+    def get_set_mcp_servers(self, skill_set_id: str, **kwargs) -> list[dict]:
+        self.default_mcp_calls.append({"skill_set_id": skill_set_id, **kwargs})
+        return [{"server_code": "legacy-default-mcp"}]
 
 
 class _LegacyFactory:
@@ -339,9 +344,27 @@ class _DefaultResourceRepository(_ResourceRepository):
         return [{"server_code": "visible-default-mcp"}]
 
 
+class _MixedResourceRepository(_DefaultResourceRepository):
+    def list_sets(self, **kwargs) -> list[dict]:
+        self.list_set_calls.append(kwargs)
+        return [
+            {"id": "global-default", "is_default": True},
+            {"id": "ordinary-set", "is_default": False},
+        ]
+
+    def list_mcps(self, **kwargs):
+        self.list_mcp_calls.append(kwargs)
+        return [{"server_code": "ordinary-set-mcp"}]
+
+
 class _ResourceLegacyFactory:
+    def __init__(self) -> None:
+        self.service = _LegacySkillSetService()
+        self.calls: list[dict] = []
+
     def create(self, **_kwargs):
-        return _LegacySkillSetService()
+        self.calls.append(_kwargs)
+        return self.service
 
 
 class _McpAuth:
@@ -947,11 +970,12 @@ def test_update_set_uses_runtime_default_candidates_for_coding_image():
 def test_resources_reads_global_default_mcp_projection_for_collaborator_owner_scope():
     repository = _DefaultResourceRepository()
     authorization = _Collaborators()
+    legacy = _ResourceLegacyFactory()
     service = SkillSetControlPlaneService(
         repository=repository,
         bot_repo=_Bots(),
         runtime=_SuccessfulRuntime(),
-        legacy_factory=_ResourceLegacyFactory(),
+        legacy_factory=legacy,
         passport=object(),
         authorization=authorization,
         mutation_guard=_MutationGuard(),
@@ -965,16 +989,48 @@ def test_resources_reads_global_default_mcp_projection_for_collaborator_owner_sc
         bot_id="bot-1", owner_id="true-owner", user_id="collaborator"
     )
 
-    assert result[0]["mcps"] == [{"server_code": "visible-default-mcp"}]
+    assert result[0]["mcps"] == [{"server_code": "legacy-default-mcp"}]
     assert authorization.calls == [{
         "bot_id": "bot-1", "owner_id": "true-owner", "actor_id": "collaborator"
     }]
+    assert repository.list_mcp_calls == []
+    assert legacy.service.default_mcp_calls == [{
+        "skill_set_id": "global-default",
+        "user_id": "true-owner",
+        "bot_id": "bot-1",
+        "engine_type": "openclaw",
+    }]
+
+
+def test_resources_keeps_ordinary_mcp_membership_on_canonical_repository_path():
+    repository = _MixedResourceRepository()
+    legacy = _ResourceLegacyFactory()
+    service = SkillSetControlPlaneService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=legacy,
+        passport=object(),
+        authorization=_Collaborators(),
+        mutation_guard=_MutationGuard(),
+        edit_guard=_Guard(),
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=_McpAuth(allowed=True),
+    )
+
+    result = service.resources(
+        bot_id="bot-1", owner_id="true-owner", user_id="true-owner"
+    )
+
+    assert result[0]["mcps"] == [{"server_code": "legacy-default-mcp"}]
+    assert result[1]["mcps"] == [{"server_code": "ordinary-set-mcp"}]
     assert repository.list_mcp_calls == [{
         "bot_id": "bot-1",
         "owner_id": "true-owner",
-            "set_id": "global-default",
-            "engine_type": "openclaw",
-            "default_engine_types": ("openclaw",),
+        "set_id": "ordinary-set",
+        "engine_type": "openclaw",
+        "default_engine_types": ("openclaw",),
     }]
 
 


### PR DESCRIPTION
## 问题
`GET /api/skillsets/resources` 在 #1245 后统一通过 Control Plane 读取 MCP。普通 SkillSet 正确读取 `ac_skill_set_mcp`，但 System Default 的 MCP 原本来自引擎默认配置并需扣除 `ac_default_skillset_mcp_exclusion`；仅查关联表会返回空列表。

## 修复
- System Default 通过既有 `SkillSetService.get_set_mcp_servers()` 读取。
- 保留 engine/template 默认 MCP、显式关联行与 owner+bot exclusion 的旧语义。
- 普通 SkillSet 继续只通过 canonical Repository Membership 读取。

## 验证
- 839 passed：Skill Center、OpenAPI、架构/协议相关回归。
- Ruff、`git diff --check` 通过。
- 新增 Default 投影与普通 Set 不串路径测试。