### PR TITLE
feat(backend): add durable bot-level skill activation sync task

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -28,6 +28,13 @@ provides:
   - "BotRuntimeProjectionReconcilerProtocol"
   - "ActiveSkillSetInstallationMaterializer"
   - "LocalSkillCleanupWorkModel"
+  - "SkillActivationSyncAction"
+  - "SkillActivationSyncScope"
+  - "SkillActivationSyncWork"
+  - "enqueue_skill_activation_sync"
+  - "build_skill_activation_sync_payload"
+  - "parse_skill_activation_sync_payload"
+  - "build_skill_activation_sync_idempotency_key"
 consumes:
   - "BotRepository"
   - "BotCollabLogRepositoryProtocol"
@@ -70,6 +77,7 @@ internal_dependencies:
   - agentclaw.community.core.models
   - agentclaw.community.core.spaces.services
   - agentclaw.community.core.skills_pool
+  - agentclaw.community.core.task_queue    # durable enqueue for Bot-level activation sync
   - agentclaw.community.core.workspace
   - agentclaw.community.di.modules
   - agentclaw.community.di.runtime_mode
@@ -126,6 +134,17 @@ deletion and Pool cutover/rollback paths. Phase 1 intentionally has no
 cache-backed cross-command Bot mutation fence: the current compensating restore
 remains a best-effort compatibility path for non-concurrent mutations, while
 durable serialization is deferred to the task-queue design.
+
+`skill_activation_sync_task.py` is the enqueue half of that durable design:
+`skill_center.activation_sync`, one task type shared by every
+activation-shaped operation, discriminated by the payload's `action_type` and
+deduped on the Bot — `(env, entity_id, bot_id)` — so at most one
+synchronization per Bot is ever live. A second operation arriving mid-sync
+joins the live task and gets `created=False`; that is only correct while the
+handler reconciles against desired state read from the database, so the
+handler that consumes these rows must not replay `action_args` as its
+desired-state write. No handler is registered yet and no call site enqueues,
+so the control plane's inline mutate-then-reconcile path is unchanged.
 
 Phase 1 does not run a global Local Installation backfill and does not treat
 historical Default exclusions as an active-state source. The small number of

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -30,6 +30,7 @@ provides:
   - "LocalSkillCleanupWorkModel"
   - "SkillActivationSyncAction"
   - "SkillActivationSyncScope"
+  - "SkillActivationSyncTaskHandler"
   - "SkillActivationSyncWork"
   - "enqueue_skill_activation_sync"
   - "build_skill_activation_sync_payload"
@@ -143,7 +144,9 @@ synchronization per Bot is ever live. A second operation arriving mid-sync
 joins the live task and gets `created=False`; that is only correct while the
 handler reconciles against desired state read from the database, so the
 handler that consumes these rows must not replay `action_args` as its
-desired-state write. No handler is registered yet and no call site enqueues,
+desired-state write. `SkillActivationSyncTaskHandler` is a skeleton: it owns
+the registry key and the payload validation, and its `_run` seam reports
+`Fail` until the body lands. It is not registered, and no call site enqueues,
 so the control plane's inline mutate-then-reconcile path is unchanged.
 
 Phase 1 does not run a global Local Installation backfill and does not treat

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_activation_sync_task.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_activation_sync_task.py
@@ -11,12 +11,14 @@ task-queue design"): the operation is persisted as a task *first*, so a crash
 resumes it instead of stranding the Bot with desired state its runtime never
 received.
 
-**Only the enqueue side lives here.** There is deliberately no
-:class:`~agentclaw.community.core.task_queue.services.registry.TaskHandler` and
-no registration yet; the handler that consumes these rows is a follow-up. Until
-it lands, nothing calls :func:`enqueue_skill_activation_sync`, so no row of this
-type can exist — and if one somehow did, the worker fails it loudly with "no
-handler registered" rather than silently dropping it.
+**The handler here is a skeleton.** :class:`SkillActivationSyncTaskHandler`
+declares the task type, parses and validates the payload, and then hands off to
+:meth:`SkillActivationSyncTaskHandler._run` — the single seam the follow-up
+fills in. ``_run`` currently reports :class:`~agentclaw.community.core.task_queue.types.Fail`,
+and it is not registered into a :class:`~agentclaw.community.core.task_queue.services.registry.HandlerRegistry`;
+registration lands with the body, alongside the first operation that enqueues.
+Until then nothing calls :func:`enqueue_skill_activation_sync`, so no row of this
+type exists to run.
 
 Two properties of the contract are worth reading before adopting it.
 
@@ -50,7 +52,11 @@ from enum import StrEnum
 from agentclaw.community.core.task_queue.services.task_queue_service import (
     TaskQueueService,
 )
-from agentclaw.community.core.task_queue.types import EnqueueResult
+from agentclaw.community.core.task_queue.types import (
+    EnqueueResult,
+    Fail,
+    TaskOutcome,
+)
 
 #: Registry key for this task. ``<module>.<name>``, matching the convention used
 #: by ``skills_pool.reconcile`` and ``session_resource.materialize``.
@@ -292,11 +298,68 @@ def enqueue_skill_activation_sync(
     )
 
 
+class SkillActivationSyncTaskHandler:
+    """Runs one Bot-level skill activation synchronization.
+
+    A plain object, as the :class:`~agentclaw.community.core.task_queue.services.registry.TaskHandler`
+    protocol expects — no base class, just ``task_type`` and ``handle``.
+
+    **The work itself is not implemented.** What is settled here is the shape
+    the implementation plugs into: the registry key, the payload validation
+    every attempt must pass, and the outcome the queue sees when the work
+    cannot proceed. :meth:`_run` is the seam.
+    """
+
+    @property
+    def task_type(self) -> str:
+        return SKILL_ACTIVATION_SYNC_TASK
+
+    def handle(self, payload: dict) -> TaskOutcome:
+        """Validate the payload, then run the operation it describes.
+
+        Takes ``dict`` rather than the protocol's ``Optional[dict]``:
+        ``TaskRecord.payload`` is non-optional and the worker only ever passes
+        a persisted row's deserialized payload. The protocol is structural, so
+        the narrower annotation still satisfies it.
+        """
+        try:
+            work = parse_skill_activation_sync_payload(payload)
+        except ValueError as error:
+            # Fail, not Retry. A payload that cannot be parsed will not parse
+            # on the next attempt either, and retrying would pin the Bot's
+            # dedup key until the deadline — blocking every later activation
+            # behind a row that can never run.
+            return Fail(f"invalid skill activation sync payload: {error}")
+        return self._run(work)
+
+    def _run(self, work: SkillActivationSyncWork) -> TaskOutcome:
+        """Execute one synchronization. **Not implemented yet.**
+
+        The follow-up fills this in: branch on ``work.action`` to identify the
+        operation, then converge ``work.scope``'s runtime projection against
+        the desired state held in the database — not against
+        ``work.action_args``, for the joined-task reason in the module
+        docstring.
+
+        Returning :class:`~agentclaw.community.core.task_queue.types.Fail` is
+        deliberate, rather than raising ``NotImplementedError``: the worker
+        treats a raise as an implicit ``Retry`` with backoff, which would hold
+        the Bot's dedup key for the full deadline and suppress the activations
+        queued behind it. ``Fail`` is terminal, so the key is released at once
+        and the error is recorded on the row.
+        """
+        return Fail(
+            "skill_center.activation_sync has no implementation yet "
+            f"(action_type={work.action.value}, bot_id={work.scope.bot_id})"
+        )
+
+
 __all__ = [
     "SKILL_ACTIVATION_SYNC_DEADLINE_SECONDS",
     "SKILL_ACTIVATION_SYNC_TASK",
     "SkillActivationSyncAction",
     "SkillActivationSyncScope",
+    "SkillActivationSyncTaskHandler",
     "SkillActivationSyncWork",
     "build_skill_activation_sync_idempotency_key",
     "build_skill_activation_sync_payload",

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_activation_sync_task.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_activation_sync_task.py
@@ -1,0 +1,341 @@
+"""Durable Bot-level skill activation synchronization task.
+
+A skill activation is two writes that must land together: the desired-state
+change in the database and the RPC that repoints the Bot's runtime symlinks.
+``SkillSetControlPlaneService._mutate`` performs them inline today and, when the
+RPC fails, compensates by restoring the previous desired state and reconciling
+again — a best-effort path that a pod restart between the two writes defeats
+outright. This module is the enqueue half of the durable replacement the
+skill_center README defers to ("durable serialization is deferred to the
+task-queue design"): the operation is persisted as a task *first*, so a crash
+resumes it instead of stranding the Bot with desired state its runtime never
+received.
+
+**Only the enqueue side lives here.** There is deliberately no
+:class:`~agentclaw.community.core.task_queue.services.registry.TaskHandler` and
+no registration yet; the handler that consumes these rows is a follow-up. Until
+it lands, nothing calls :func:`enqueue_skill_activation_sync`, so no row of this
+type can exist — and if one somehow did, the worker fails it loudly with "no
+handler registered" rather than silently dropping it.
+
+Two properties of the contract are worth reading before adopting it.
+
+**The dedup key is the Bot, not the operation.** The key is
+``(env, entity_id, bot_id)`` and deliberately excludes ``action_type``: the unit
+that must not be synchronized concurrently is the Bot's runtime projection, and
+two different operations racing on one Bot are exactly the case the durable path
+exists to serialize. The consequence is load-bearing for callers — a second
+operation arriving while a sync is live does **not** enqueue: it joins the live
+task and :class:`~agentclaw.community.core.task_queue.types.EnqueueResult`
+reports ``created=False``. That is correct for a level-triggered handler, which
+reconciles against whatever desired state the database holds when it runs and so
+picks up the newer operation's write for free. It would silently drop work for a
+handler that performed the desired-state write *itself* from ``action_args`` —
+so the handler this task is built for must read desired state from the database,
+not from the payload. The payload's ``action_type`` says which operation asked
+for the sync; it is not a command to replay.
+
+**The key is scoped by the Bot's ``env``, not the worker's.** ``TaskQueueService``
+stamps the row's ``env`` column from the current process, while the key carries
+the ``env`` of the Bot being synchronized. The two normally agree; where they do
+not, the Bot's own environment is the one that identifies the work.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from uuid import uuid4
+
+from agentclaw.community.core.task_queue.services.task_queue_service import (
+    TaskQueueService,
+)
+from agentclaw.community.core.task_queue.types import EnqueueResult
+
+#: Registry key for this task. ``<module>.<name>``, matching the convention used
+#: by ``skills_pool.reconcile`` and ``session_resource.materialize``.
+SKILL_ACTIVATION_SYNC_TASK = "skill_center.activation_sync"
+
+#: Give-up horizon for one synchronization, in seconds.
+#:
+#: Shorter than the day-long horizons used by publish and Pool migration, and
+#: for a reason specific to a keyed task: a live task *holds* its dedup key, so
+#: every subsequent activation on that Bot joins it instead of enqueuing. The
+#: deadline is therefore not just "how long to keep retrying" but "how long a
+#: wedged sync may keep suppressing the ones behind it". Fifteen minutes is far
+#: past the point where an interactive activation is still worth converging, and
+#: retiring the task ``TIMED_OUT`` releases the key so the next operation
+#: enqueues cleanly.
+SKILL_ACTIVATION_SYNC_DEADLINE_SECONDS = 15 * 60
+
+#: Hex characters of the SHA-256 digest kept in the dedup key. 128 bits — a
+#: collision would need two distinct Bots, and it is bounded so the key cannot
+#: outgrow its column. See :func:`build_skill_activation_sync_idempotency_key`.
+_KEY_DIGEST_CHARS = 32
+
+#: Separator for the digest input. A control character rather than ``:`` so that
+#: no ``entity_id`` containing the visible separator can be rearranged into
+#: another Bot's digest input.
+_DIGEST_SEPARATOR = "\x1f"
+
+
+class SkillActivationSyncAction(StrEnum):
+    """Which operation asked for the synchronization.
+
+    Persisted in the payload as ``action_type`` because one task type is shared
+    by every skill-activation-shaped operation (activate, deactivate, switch,
+    membership changes, MCP direct installs), and the handler has to know which
+    one it is executing.
+
+    Only a placeholder member exists so far — the operations adopt this task as
+    they migrate onto the durable path, and each adoption adds its member here.
+    Adding one is a one-line edit; the parse, validation, and enqueue plumbing
+    below is already generic over the enum.
+
+    **Rollout note.** :func:`parse_skill_activation_sync_payload` rejects an
+    ``action_type`` it does not recognise, so a task enqueued by a newer pod is
+    unrunnable on an older one. Ship a new member in a release before the
+    release that starts enqueuing it, the same ordering the task queue's own
+    idempotency mechanism required of its first adopter.
+    """
+
+    #: Not a real operation. Exists so the discriminator has a member — and a
+    #: test can exercise the payload contract — before the first operation
+    #: migrates. Remove it once a real member exists.
+    PLACEHOLDER = "placeholder"
+
+
+@dataclass(frozen=True, slots=True)
+class SkillActivationSyncScope:
+    """The Bot whose runtime projection is being synchronized.
+
+    Bot-level is the granularity the durable path serializes at: one runtime
+    projection, one symlink tree, one in-flight sync.
+
+    Structurally identical to :class:`~agentclaw.community.core.skills_pool.types.BotSkillLayoutScope`
+    and deliberately not that type. Layout scope identifies a row of Pool
+    migration state; this identifies the target of a Skill Center operation.
+    They agree on the triple today because the same three facts name a Bot, not
+    because either owns the other's meaning.
+    """
+
+    env: str
+    entity_id: str
+    bot_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class SkillActivationSyncWork:
+    """A parsed payload — what the handler receives after validation."""
+
+    scope: SkillActivationSyncScope
+    action: SkillActivationSyncAction
+    #: Operation-specific arguments (a set id, a skill id, …). Audit and
+    #: routing detail for the handler; see the module docstring for why it must
+    #: not be replayed as the desired-state write. Empty when the operation
+    #: needs none — never absent.
+    action_args: dict[str, object]
+    #: Correlates the task with the request that enqueued it.
+    request_id: str
+    #: When the operation was requested, timezone-aware and normalized to UTC.
+    requested_at: datetime
+
+
+def build_skill_activation_sync_idempotency_key(
+    scope: SkillActivationSyncScope,
+) -> str:
+    """Build the enqueue dedup key for ``scope``.
+
+    Shape: ``skill_activation_sync:<env>:<digest>``, where ``digest`` is the
+    first :data:`_KEY_DIGEST_CHARS` hex characters of the SHA-256 of
+    ``entity_id`` and ``bot_id``.
+
+    The identity is the ``(env, entity_id, bot_id)`` triple; the digest is only
+    how two of the three are *spelled*. They are hashed rather than embedded
+    because the key column is ``VARCHAR(190)`` while its sources are far wider —
+    ``entity_id`` is ``varchar(512)`` and ``bot_id`` ``varchar(128)`` on the
+    Skills Pool tables — and the task queue README is explicit that the variable
+    part of a key should be hashed rather than embedded for exactly this reason.
+    Embedding them would fit for every id in production today and raise
+    ``ValueError`` mid-activation on the first tenant whose id is long, which is
+    a worse failure than an opaque segment: a key that cannot be built is an
+    activation that cannot proceed, whereas a digest always fits. ``env`` stays
+    readable because it is ``varchar(20)`` and is what an operator scanning
+    ``ac_task_queue`` filters on first; the raw triple is preserved verbatim in
+    the payload, so nothing is lost to audit. To find a specific Bot's task, call
+    this function rather than eyeballing the column.
+
+    Raises ``ValueError`` if any component is empty or carries surrounding
+    whitespace. That mirrors the repository's own key validation and applies it
+    one level up, where the offending field can still be named: a padded
+    ``env`` would otherwise reach the queue as a padded key and be rejected
+    there with no clue which part of the scope was at fault.
+    """
+    for name, value in (
+        ("env", scope.env),
+        ("entity_id", scope.entity_id),
+        ("bot_id", scope.bot_id),
+    ):
+        if not value or not value.strip():
+            raise ValueError(f"scope.{name} must be a non-empty string")
+        if value != value.strip():
+            raise ValueError(
+                f"scope.{name} must not have leading or trailing whitespace "
+                f"({value!r})"
+            )
+    digest = hashlib.sha256(
+        f"{scope.entity_id}{_DIGEST_SEPARATOR}{scope.bot_id}".encode()
+    ).hexdigest()[:_KEY_DIGEST_CHARS]
+    return f"skill_activation_sync:{scope.env}:{digest}"
+
+
+def build_skill_activation_sync_payload(
+    *,
+    scope: SkillActivationSyncScope,
+    action: SkillActivationSyncAction,
+    action_args: dict[str, object] | None = None,
+    request_id: str | None = None,
+    requested_at: datetime | None = None,
+) -> dict[str, object]:
+    """Build the persisted work description.
+
+    ``request_id`` and ``requested_at`` default to a fresh id and the current
+    time, so a call site that has neither still produces a task that can be
+    correlated and aged. Both are stamped at *enqueue* time on purpose: they
+    describe the request, and a task that is retried or resumed after a restart
+    keeps the values of the request that created it.
+    """
+    return {
+        "scope": {
+            "env": scope.env,
+            "entity_id": scope.entity_id,
+            "bot_id": scope.bot_id,
+        },
+        "action_type": action.value,
+        "action_args": dict(action_args or {}),
+        "request_id": request_id or uuid4().hex,
+        "requested_at": (requested_at or datetime.now(UTC)).isoformat(),
+    }
+
+
+def parse_skill_activation_sync_payload(
+    payload: dict | None,
+) -> SkillActivationSyncWork:
+    """Validate a persisted payload and return the work it describes.
+
+    Raises ``ValueError`` on anything malformed, including an unrecognised
+    ``action_type``. The handler is expected to turn that into
+    :class:`~agentclaw.community.core.task_queue.types.Fail` rather than
+    :class:`~agentclaw.community.core.task_queue.types.Retry`: a payload that
+    cannot be understood will not become understandable on the next attempt, and
+    retrying it would hold the Bot's dedup key until the deadline while blocking
+    every subsequent activation behind a row that can never run.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be an object")
+
+    raw_scope = payload.get("scope")
+    if not isinstance(raw_scope, dict):
+        raise ValueError("scope must be an object")
+    scope_values: dict[str, str] = {}
+    for key in ("env", "entity_id", "bot_id"):
+        value = raw_scope.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"scope.{key} must be a non-empty string")
+        scope_values[key] = value
+
+    raw_action = payload.get("action_type")
+    if not isinstance(raw_action, str) or not raw_action:
+        raise ValueError("action_type must be a non-empty string")
+    try:
+        action = SkillActivationSyncAction(raw_action)
+    except ValueError as error:
+        raise ValueError(f"unknown action_type {raw_action!r}") from error
+
+    raw_args = payload.get("action_args")
+    if raw_args is None:
+        action_args: dict[str, object] = {}
+    elif isinstance(raw_args, dict):
+        action_args = dict(raw_args)
+    else:
+        raise ValueError("action_args must be an object")
+
+    request_id = payload.get("request_id")
+    if not isinstance(request_id, str) or not request_id.strip():
+        raise ValueError("request_id must be a non-empty string")
+
+    raw_requested_at = payload.get("requested_at")
+    if not isinstance(raw_requested_at, str):
+        raise ValueError("requested_at must be an ISO timestamp")
+    try:
+        requested_at = datetime.fromisoformat(raw_requested_at)
+    except ValueError as error:
+        raise ValueError("requested_at must be an ISO timestamp") from error
+    if requested_at.tzinfo is None:
+        raise ValueError("requested_at must include a timezone")
+
+    return SkillActivationSyncWork(
+        scope=SkillActivationSyncScope(**scope_values),
+        action=action,
+        action_args=action_args,
+        request_id=request_id,
+        requested_at=requested_at.astimezone(UTC),
+    )
+
+
+def enqueue_skill_activation_sync(
+    task_queue_service: TaskQueueService,
+    *,
+    scope: SkillActivationSyncScope,
+    action: SkillActivationSyncAction,
+    action_args: dict[str, object] | None = None,
+    request_id: str | None = None,
+    requested_at: datetime | None = None,
+    deadline_seconds: int = SKILL_ACTIVATION_SYNC_DEADLINE_SECONDS,
+    delay_seconds: int = 0,
+) -> EnqueueResult:
+    """Enqueue one durable synchronization for ``scope``, tagged with ``action``.
+
+    Returns the :class:`~agentclaw.community.core.task_queue.types.EnqueueResult`
+    unchanged — **check ``created``**. ``False`` means this Bot already had a
+    sync in flight and the returned record is that task, not a new one; see the
+    module docstring for why that is the intended outcome and what it obliges
+    the handler to do. Callers that surface a result to a user should treat
+    ``created=False`` as "already syncing", not as a failure.
+
+    A plain function rather than an injected service: every prospective call site
+    already holds a ``TaskQueueService``, and the enqueue carries no state of its
+    own beyond the constants in this module.
+
+    Enqueue before the external side effect, not after. The task is the record
+    that the operation was requested; if persisting it fails, nothing has
+    happened yet and the caller can report the failure honestly.
+    """
+    return task_queue_service.enqueue(
+        SKILL_ACTIVATION_SYNC_TASK,
+        build_skill_activation_sync_payload(
+            scope=scope,
+            action=action,
+            action_args=action_args,
+            request_id=request_id,
+            requested_at=requested_at,
+        ),
+        deadline_seconds=deadline_seconds,
+        delay_seconds=delay_seconds,
+        idempotency_key=build_skill_activation_sync_idempotency_key(scope),
+    )
+
+
+__all__ = [
+    "SKILL_ACTIVATION_SYNC_DEADLINE_SECONDS",
+    "SKILL_ACTIVATION_SYNC_TASK",
+    "SkillActivationSyncAction",
+    "SkillActivationSyncScope",
+    "SkillActivationSyncWork",
+    "build_skill_activation_sync_idempotency_key",
+    "build_skill_activation_sync_payload",
+    "enqueue_skill_activation_sync",
+    "parse_skill_activation_sync_payload",
+]

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_activation_sync_task.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_activation_sync_task.py
@@ -45,7 +45,6 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from enum import StrEnum
 from uuid import uuid4
 
@@ -137,10 +136,9 @@ class SkillActivationSyncWork:
     #: not be replayed as the desired-state write. Empty when the operation
     #: needs none — never absent.
     action_args: dict[str, object]
-    #: Correlates the task with the request that enqueued it.
+    #: Correlates every attempt at this task in the logs. Generated at enqueue;
+    #: the handler receives no row id of its own.
     request_id: str
-    #: When the operation was requested, timezone-aware and normalized to UTC.
-    requested_at: datetime
 
 
 def build_skill_activation_sync_idempotency_key(
@@ -195,17 +193,19 @@ def build_skill_activation_sync_payload(
     *,
     scope: SkillActivationSyncScope,
     action: SkillActivationSyncAction,
-    action_args: dict[str, object] | None = None,
-    request_id: str | None = None,
-    requested_at: datetime | None = None,
+    action_args: dict[str, object] = {},
 ) -> dict[str, object]:
     """Build the persisted work description.
 
-    ``request_id`` and ``requested_at`` default to a fresh id and the current
-    time, so a call site that has neither still produces a task that can be
-    correlated and aged. Both are stamped at *enqueue* time on purpose: they
-    describe the request, and a task that is retried or resumed after a restart
-    keeps the values of the request that created it.
+    ``request_id`` is generated here rather than accepted, because it exists for
+    the handler rather than the caller: ``TaskHandler.handle`` is given the
+    payload and nothing else — not the row id — so without it a handler has no
+    identifier to log. It is stamped once at enqueue and travels with the task,
+    so every attempt at the same work logs the same id.
+
+    ``action_args`` is copied rather than stored by reference: the empty default
+    is shared across calls, and the caller's dict must not be able to change a
+    payload after it is built.
     """
     return {
         "scope": {
@@ -214,15 +214,12 @@ def build_skill_activation_sync_payload(
             "bot_id": scope.bot_id,
         },
         "action_type": action.value,
-        "action_args": dict(action_args or {}),
-        "request_id": request_id or uuid4().hex,
-        "requested_at": (requested_at or datetime.now(UTC)).isoformat(),
+        "action_args": dict(action_args),
+        "request_id": uuid4().hex,
     }
 
 
-def parse_skill_activation_sync_payload(
-    payload: dict | None,
-) -> SkillActivationSyncWork:
+def parse_skill_activation_sync_payload(payload: dict) -> SkillActivationSyncWork:
     """Validate a persisted payload and return the work it describes.
 
     Raises ``ValueError`` on anything malformed, including an unrecognised
@@ -233,9 +230,6 @@ def parse_skill_activation_sync_payload(
     retrying it would hold the Bot's dedup key until the deadline while blocking
     every subsequent activation behind a row that can never run.
     """
-    if not isinstance(payload, dict):
-        raise ValueError("payload must be an object")
-
     raw_scope = payload.get("scope")
     if not isinstance(raw_scope, dict):
         raise ValueError("scope must be an object")
@@ -255,33 +249,18 @@ def parse_skill_activation_sync_payload(
         raise ValueError(f"unknown action_type {raw_action!r}") from error
 
     raw_args = payload.get("action_args")
-    if raw_args is None:
-        action_args: dict[str, object] = {}
-    elif isinstance(raw_args, dict):
-        action_args = dict(raw_args)
-    else:
+    if not isinstance(raw_args, dict):
         raise ValueError("action_args must be an object")
 
     request_id = payload.get("request_id")
     if not isinstance(request_id, str) or not request_id.strip():
         raise ValueError("request_id must be a non-empty string")
 
-    raw_requested_at = payload.get("requested_at")
-    if not isinstance(raw_requested_at, str):
-        raise ValueError("requested_at must be an ISO timestamp")
-    try:
-        requested_at = datetime.fromisoformat(raw_requested_at)
-    except ValueError as error:
-        raise ValueError("requested_at must be an ISO timestamp") from error
-    if requested_at.tzinfo is None:
-        raise ValueError("requested_at must include a timezone")
-
     return SkillActivationSyncWork(
         scope=SkillActivationSyncScope(**scope_values),
         action=action,
-        action_args=action_args,
+        action_args=dict(raw_args),
         request_id=request_id,
-        requested_at=requested_at.astimezone(UTC),
     )
 
 
@@ -290,9 +269,7 @@ def enqueue_skill_activation_sync(
     *,
     scope: SkillActivationSyncScope,
     action: SkillActivationSyncAction,
-    action_args: dict[str, object] | None = None,
-    request_id: str | None = None,
-    requested_at: datetime | None = None,
+    action_args: dict[str, object] = {},
     deadline_seconds: int = SKILL_ACTIVATION_SYNC_DEADLINE_SECONDS,
     delay_seconds: int = 0,
 ) -> EnqueueResult:
@@ -319,8 +296,6 @@ def enqueue_skill_activation_sync(
             scope=scope,
             action=action,
             action_args=action_args,
-            request_id=request_id,
-            requested_at=requested_at,
         ),
         deadline_seconds=deadline_seconds,
         delay_seconds=delay_seconds,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_activation_sync_task.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_activation_sync_task.py
@@ -46,7 +46,6 @@ from __future__ import annotations
 import hashlib
 from dataclasses import dataclass
 from enum import StrEnum
-from uuid import uuid4
 
 from agentclaw.community.core.task_queue.services.task_queue_service import (
     TaskQueueService,
@@ -136,9 +135,6 @@ class SkillActivationSyncWork:
     #: not be replayed as the desired-state write. Empty when the operation
     #: needs none — never absent.
     action_args: dict[str, object]
-    #: Correlates every attempt at this task in the logs. Generated at enqueue;
-    #: the handler receives no row id of its own.
-    request_id: str
 
 
 def build_skill_activation_sync_idempotency_key(
@@ -197,11 +193,10 @@ def build_skill_activation_sync_payload(
 ) -> dict[str, object]:
     """Build the persisted work description.
 
-    ``request_id`` is generated here rather than accepted, because it exists for
-    the handler rather than the caller: ``TaskHandler.handle`` is given the
-    payload and nothing else — not the row id — so without it a handler has no
-    identifier to log. It is stamped once at enqueue and travels with the task,
-    so every attempt at the same work logs the same id.
+    The payload carries only what identifies the work: which Bot, which
+    operation, and that operation's arguments. It deliberately holds no
+    generated correlation id — a fresh UUID would correlate to nothing the
+    caller knows, and ``ac_task_queue.id`` is already the task's identity.
 
     ``action_args`` is copied rather than stored by reference: the empty default
     is shared across calls, and the caller's dict must not be able to change a
@@ -215,7 +210,6 @@ def build_skill_activation_sync_payload(
         },
         "action_type": action.value,
         "action_args": dict(action_args),
-        "request_id": uuid4().hex,
     }
 
 
@@ -252,15 +246,10 @@ def parse_skill_activation_sync_payload(payload: dict) -> SkillActivationSyncWor
     if not isinstance(raw_args, dict):
         raise ValueError("action_args must be an object")
 
-    request_id = payload.get("request_id")
-    if not isinstance(request_id, str) or not request_id.strip():
-        raise ValueError("request_id must be a non-empty string")
-
     return SkillActivationSyncWork(
         scope=SkillActivationSyncScope(**scope_values),
         action=action,
         action_args=dict(raw_args),
-        request_id=request_id,
     )
 
 

--- a/src/backend/tests/community/core/skill_center/test_skill_activation_sync_task.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_activation_sync_task.py
@@ -61,15 +61,19 @@ def test_payload_carries_scope_and_action_type():
     # The discriminator is persisted as the enum's plain value, not repr().
     assert payload["action_type"] == "placeholder"
     assert payload["action_args"] == {"set_id": "s-1"}
-    assert payload["request_id"]
 
 
-def test_payload_defaults_are_generated_per_call():
-    first = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
-    second = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
+def test_payload_defaults_action_args_to_empty():
+    payload = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
 
-    assert first["action_args"] == {}
-    assert first["request_id"] != second["request_id"]
+    assert payload["action_args"] == {}
+
+
+def test_payload_carries_nothing_beyond_the_work_identity():
+    """No generated correlation id: the task row's own id is the identity."""
+    payload = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
+
+    assert set(payload) == {"scope", "action_type", "action_args"}
 
 
 def test_payload_copies_action_args():
@@ -103,7 +107,6 @@ def test_parse_round_trips_a_built_payload():
     assert work.scope == _scope()
     assert work.action is ACTION
     assert work.action_args == {"set_id": "s-1"}
-    assert work.request_id == payload["request_id"]
 
 
 def test_parse_rejects_an_absent_action_args():
@@ -126,8 +129,6 @@ def test_parse_rejects_an_absent_action_args():
         (lambda p: p.update(action_type=""), "action_type"),
         (lambda p: p.update(action_args=["set_id"]), "action_args"),
         (lambda p: p.update(action_args=None), "action_args"),
-        (lambda p: p.update(request_id=" "), "request_id"),
-        (lambda p: p.pop("request_id"), "request_id"),
     ],
 )
 def test_parse_rejects_malformed_payloads(mutate, expected):

--- a/src/backend/tests/community/core/skill_center/test_skill_activation_sync_task.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_activation_sync_task.py
@@ -8,7 +8,6 @@ rather than a mock, because "the second enqueue joins the first" is a property
 of the unique index, not of the helper.
 """
 from contextlib import contextmanager
-from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -63,7 +62,6 @@ def test_payload_carries_scope_and_action_type():
     assert payload["action_type"] == "placeholder"
     assert payload["action_args"] == {"set_id": "s-1"}
     assert payload["request_id"]
-    assert payload["requested_at"]
 
 
 def test_payload_defaults_are_generated_per_call():
@@ -85,43 +83,36 @@ def test_payload_copies_action_args():
     assert payload["action_args"] == {"set_id": "s-1"}
 
 
+def test_payload_does_not_leak_into_the_shared_empty_default():
+    """``action_args`` defaults to a shared ``{}``; the copy is what keeps it safe."""
+    first = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
+    first["action_args"]["set_id"] = "s-1"
+
+    second = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
+
+    assert second["action_args"] == {}
+
+
 def test_parse_round_trips_a_built_payload():
-    requested_at = datetime(2026, 8, 22, 10, 30, tzinfo=UTC)
-    work = parse_skill_activation_sync_payload(
-        build_skill_activation_sync_payload(
-            scope=_scope(),
-            action=ACTION,
-            action_args={"set_id": "s-1"},
-            request_id="req-1",
-            requested_at=requested_at,
-        )
+    payload = build_skill_activation_sync_payload(
+        scope=_scope(), action=ACTION, action_args={"set_id": "s-1"}
     )
+
+    work = parse_skill_activation_sync_payload(payload)
 
     assert work.scope == _scope()
     assert work.action is ACTION
     assert work.action_args == {"set_id": "s-1"}
-    assert work.request_id == "req-1"
-    assert work.requested_at == requested_at
+    assert work.request_id == payload["request_id"]
 
 
-def test_parse_normalizes_requested_at_to_utc():
-    tokyo = timezone(timedelta(hours=9))
-    work = parse_skill_activation_sync_payload(
-        build_skill_activation_sync_payload(
-            scope=_scope(),
-            action=ACTION,
-            requested_at=datetime(2026, 8, 22, 19, 0, tzinfo=tokyo),
-        )
-    )
-
-    assert work.requested_at == datetime(2026, 8, 22, 10, 0, tzinfo=UTC)
-
-
-def test_parse_defaults_absent_action_args_to_empty():
+def test_parse_rejects_an_absent_action_args():
+    """The builder always writes the key, so a payload missing it is malformed."""
     payload = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
     del payload["action_args"]
 
-    assert parse_skill_activation_sync_payload(payload).action_args == {}
+    with pytest.raises(ValueError, match="action_args"):
+        parse_skill_activation_sync_payload(payload)
 
 
 @pytest.mark.parametrize(
@@ -134,14 +125,9 @@ def test_parse_defaults_absent_action_args_to_empty():
         (lambda p: p.update(action_type="switch"), "unknown action_type"),
         (lambda p: p.update(action_type=""), "action_type"),
         (lambda p: p.update(action_args=["set_id"]), "action_args"),
+        (lambda p: p.update(action_args=None), "action_args"),
         (lambda p: p.update(request_id=" "), "request_id"),
-        (lambda p: p.update(requested_at="not-a-time"), "requested_at"),
-        (lambda p: p.update(requested_at=None), "requested_at"),
-        # A naive timestamp cannot be compared with anything the queue records.
-        (
-            lambda p: p.update(requested_at="2026-08-22T10:30:00"),
-            "requested_at must include a timezone",
-        ),
+        (lambda p: p.pop("request_id"), "request_id"),
     ],
 )
 def test_parse_rejects_malformed_payloads(mutate, expected):
@@ -150,11 +136,6 @@ def test_parse_rejects_malformed_payloads(mutate, expected):
 
     with pytest.raises(ValueError, match=expected):
         parse_skill_activation_sync_payload(payload)
-
-
-def test_parse_rejects_a_non_object_payload():
-    with pytest.raises(ValueError, match="payload must be an object"):
-        parse_skill_activation_sync_payload(None)
 
 
 def test_parse_rejects_an_unknown_action_type_rather_than_ignoring_it():

--- a/src/backend/tests/community/core/skill_center/test_skill_activation_sync_task.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_activation_sync_task.py
@@ -27,15 +27,20 @@ from agentclaw.community.core.skill_center.services.skill_activation_sync_task i
     SKILL_ACTIVATION_SYNC_TASK,
     SkillActivationSyncAction,
     SkillActivationSyncScope,
+    SkillActivationSyncTaskHandler,
     build_skill_activation_sync_idempotency_key,
     build_skill_activation_sync_payload,
     enqueue_skill_activation_sync,
     parse_skill_activation_sync_payload,
 )
+from agentclaw.community.core.task_queue.services.registry import (
+    HandlerRegistry,
+    TaskHandler,
+)
 from agentclaw.community.core.task_queue.services.task_queue_service import (
     TaskQueueService,
 )
-from agentclaw.community.core.task_queue.types import TaskStatus
+from agentclaw.community.core.task_queue.types import Fail, TaskStatus
 
 ENV = "dev"
 ACTION = SkillActivationSyncAction.PLACEHOLDER
@@ -247,6 +252,49 @@ def test_enqueue_returns_the_queue_result_unchanged():
         enqueue_skill_activation_sync(service, scope=_scope(), action=ACTION)
         is sentinel
     )
+
+
+# ── handler skeleton ────────────────────────────────────────────────────────
+
+
+def test_handler_serves_the_task_type():
+    assert SkillActivationSyncTaskHandler().task_type == SKILL_ACTIVATION_SYNC_TASK
+
+
+def test_handler_satisfies_the_task_handler_protocol():
+    assert isinstance(SkillActivationSyncTaskHandler(), TaskHandler)
+
+
+def test_handler_is_registrable():
+    """The registry rejects padded or case-colliding types; this one passes."""
+    registry = HandlerRegistry()
+    handler = SkillActivationSyncTaskHandler()
+
+    registry.register(handler)
+
+    assert registry.get(SKILL_ACTIVATION_SYNC_TASK) is handler
+
+
+def test_handler_fails_a_malformed_payload_rather_than_retrying():
+    """Retry would pin the Bot's dedup key until the deadline for nothing."""
+    payload = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
+    del payload["scope"]
+
+    outcome = SkillActivationSyncTaskHandler().handle(payload)
+
+    assert isinstance(outcome, Fail)
+    assert "invalid skill activation sync payload" in outcome.error
+
+
+def test_handler_reports_the_unimplemented_body_as_a_terminal_failure():
+    """The body lands later; until then it must not spin on the queue."""
+    payload = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
+
+    outcome = SkillActivationSyncTaskHandler().handle(payload)
+
+    assert isinstance(outcome, Fail)
+    assert "no implementation yet" in outcome.error
+    assert ACTION.value in outcome.error
 
 
 # ── dedup against a real queue ──────────────────────────────────────────────

--- a/src/backend/tests/community/core/skill_center/test_skill_activation_sync_task.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_activation_sync_task.py
@@ -1,0 +1,353 @@
+"""Contract tests for the durable Bot-level skill activation sync task.
+
+The handler is a follow-up, so what is under test here is the enqueue contract:
+the payload's shape (including the ``action_type`` discriminator), the parse
+that a handler will rely on, and the Bot-level dedup key. The dedup itself is
+exercised end-to-end against a real ``TaskQueueRepository`` on in-memory SQLite
+rather than a mock, because "the second enqueue joins the first" is a property
+of the unique index, not of the helper.
+"""
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+# Side-effect import: registers TaskQueueModel on Base.metadata so create_all()
+# builds ac_task_queue.
+from agentclaw.community.core.task_queue.repository.models import TaskQueueModel  # noqa: F401
+from agentclaw.community.core.repository.implementations.platform.task_queue import (
+    _MAX_IDEMPOTENCY_KEY_LEN,
+    TaskQueueRepository,
+)
+from agentclaw.community.core.skill_center.services.skill_activation_sync_task import (
+    SKILL_ACTIVATION_SYNC_DEADLINE_SECONDS,
+    SKILL_ACTIVATION_SYNC_TASK,
+    SkillActivationSyncAction,
+    SkillActivationSyncScope,
+    build_skill_activation_sync_idempotency_key,
+    build_skill_activation_sync_payload,
+    enqueue_skill_activation_sync,
+    parse_skill_activation_sync_payload,
+)
+from agentclaw.community.core.task_queue.services.task_queue_service import (
+    TaskQueueService,
+)
+from agentclaw.community.core.task_queue.types import TaskStatus
+
+ENV = "dev"
+ACTION = SkillActivationSyncAction.PLACEHOLDER
+
+
+def _scope(env=ENV, entity_id="ent-1", bot_id="bot-1") -> SkillActivationSyncScope:
+    return SkillActivationSyncScope(env=env, entity_id=entity_id, bot_id=bot_id)
+
+
+# ── payload contract ────────────────────────────────────────────────────────
+
+
+def test_payload_carries_scope_and_action_type():
+    payload = build_skill_activation_sync_payload(
+        scope=_scope(), action=ACTION, action_args={"set_id": "s-1"}
+    )
+
+    assert payload["scope"] == {
+        "env": ENV,
+        "entity_id": "ent-1",
+        "bot_id": "bot-1",
+    }
+    # The discriminator is persisted as the enum's plain value, not repr().
+    assert payload["action_type"] == "placeholder"
+    assert payload["action_args"] == {"set_id": "s-1"}
+    assert payload["request_id"]
+    assert payload["requested_at"]
+
+
+def test_payload_defaults_are_generated_per_call():
+    first = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
+    second = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
+
+    assert first["action_args"] == {}
+    assert first["request_id"] != second["request_id"]
+
+
+def test_payload_copies_action_args():
+    """A later mutation of the caller's dict must not reach the persisted task."""
+    args = {"set_id": "s-1"}
+    payload = build_skill_activation_sync_payload(
+        scope=_scope(), action=ACTION, action_args=args
+    )
+    args["set_id"] = "s-2"
+
+    assert payload["action_args"] == {"set_id": "s-1"}
+
+
+def test_parse_round_trips_a_built_payload():
+    requested_at = datetime(2026, 8, 22, 10, 30, tzinfo=UTC)
+    work = parse_skill_activation_sync_payload(
+        build_skill_activation_sync_payload(
+            scope=_scope(),
+            action=ACTION,
+            action_args={"set_id": "s-1"},
+            request_id="req-1",
+            requested_at=requested_at,
+        )
+    )
+
+    assert work.scope == _scope()
+    assert work.action is ACTION
+    assert work.action_args == {"set_id": "s-1"}
+    assert work.request_id == "req-1"
+    assert work.requested_at == requested_at
+
+
+def test_parse_normalizes_requested_at_to_utc():
+    tokyo = timezone(timedelta(hours=9))
+    work = parse_skill_activation_sync_payload(
+        build_skill_activation_sync_payload(
+            scope=_scope(),
+            action=ACTION,
+            requested_at=datetime(2026, 8, 22, 19, 0, tzinfo=tokyo),
+        )
+    )
+
+    assert work.requested_at == datetime(2026, 8, 22, 10, 0, tzinfo=UTC)
+
+
+def test_parse_defaults_absent_action_args_to_empty():
+    payload = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
+    del payload["action_args"]
+
+    assert parse_skill_activation_sync_payload(payload).action_args == {}
+
+
+@pytest.mark.parametrize(
+    "mutate, expected",
+    [
+        (lambda p: p.update(scope="nope"), "scope must be an object"),
+        (lambda p: p["scope"].update(bot_id=""), "scope.bot_id"),
+        (lambda p: p["scope"].update(env="   "), "scope.env"),
+        (lambda p: p["scope"].pop("entity_id"), "scope.entity_id"),
+        (lambda p: p.update(action_type="switch"), "unknown action_type"),
+        (lambda p: p.update(action_type=""), "action_type"),
+        (lambda p: p.update(action_args=["set_id"]), "action_args"),
+        (lambda p: p.update(request_id=" "), "request_id"),
+        (lambda p: p.update(requested_at="not-a-time"), "requested_at"),
+        (lambda p: p.update(requested_at=None), "requested_at"),
+        # A naive timestamp cannot be compared with anything the queue records.
+        (
+            lambda p: p.update(requested_at="2026-08-22T10:30:00"),
+            "requested_at must include a timezone",
+        ),
+    ],
+)
+def test_parse_rejects_malformed_payloads(mutate, expected):
+    payload = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
+    mutate(payload)
+
+    with pytest.raises(ValueError, match=expected):
+        parse_skill_activation_sync_payload(payload)
+
+
+def test_parse_rejects_a_non_object_payload():
+    with pytest.raises(ValueError, match="payload must be an object"):
+        parse_skill_activation_sync_payload(None)
+
+
+def test_parse_rejects_an_unknown_action_type_rather_than_ignoring_it():
+    """An older pod must fail loudly on a newer pod's action, not run it blind."""
+    payload = build_skill_activation_sync_payload(scope=_scope(), action=ACTION)
+    payload["action_type"] = "activate_from_a_future_release"
+
+    with pytest.raises(ValueError, match="unknown action_type"):
+        parse_skill_activation_sync_payload(payload)
+
+
+# ── idempotency key ─────────────────────────────────────────────────────────
+
+
+def test_key_is_deterministic():
+    assert build_skill_activation_sync_idempotency_key(
+        _scope()
+    ) == build_skill_activation_sync_idempotency_key(_scope())
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        _scope(env="prod"),
+        _scope(entity_id="ent-2"),
+        _scope(bot_id="bot-2"),
+    ],
+)
+def test_key_distinguishes_every_scope_component(other):
+    assert build_skill_activation_sync_idempotency_key(
+        other
+    ) != build_skill_activation_sync_idempotency_key(_scope())
+
+
+def test_key_keeps_env_readable_and_digests_the_rest():
+    """Operators filter ``ac_task_queue`` by env first, so it stays literal."""
+    prefix, env, digest = build_skill_activation_sync_idempotency_key(
+        _scope()
+    ).split(":")
+
+    assert prefix == "skill_activation_sync"
+    assert env == ENV
+    assert len(digest) == 32
+    assert all(char in "0123456789abcdef" for char in digest)
+
+
+def test_key_does_not_reorder_across_the_entity_bot_boundary():
+    """``entity_id``/``bot_id`` are digested with a separator, not concatenated."""
+    assert build_skill_activation_sync_idempotency_key(
+        _scope(entity_id="a", bot_id="bc")
+    ) != build_skill_activation_sync_idempotency_key(
+        _scope(entity_id="ab", bot_id="c")
+    )
+
+
+def test_key_fits_the_column_even_for_maximum_width_ids():
+    """entity_id is varchar(512) and bot_id varchar(128) at their widest."""
+    key = build_skill_activation_sync_idempotency_key(
+        _scope(env="x" * 20, entity_id="e" * 512, bot_id="b" * 128)
+    )
+
+    assert len(key) <= _MAX_IDEMPOTENCY_KEY_LEN
+    assert key == key.strip()
+
+
+@pytest.mark.parametrize(
+    "scope, expected",
+    [
+        (_scope(env=""), "scope.env"),
+        (_scope(entity_id="  "), "scope.entity_id"),
+        (_scope(bot_id="bot-1 "), "scope.bot_id"),
+        (_scope(env=" dev"), "scope.env"),
+    ],
+)
+def test_key_rejects_unrepresentable_scope_components(scope, expected):
+    with pytest.raises(ValueError, match=expected):
+        build_skill_activation_sync_idempotency_key(scope)
+
+
+# ── enqueue helper ──────────────────────────────────────────────────────────
+
+
+def test_enqueue_forwards_the_task_type_key_and_schedule():
+    service = MagicMock(spec=TaskQueueService)
+    scope = _scope()
+
+    enqueue_skill_activation_sync(
+        service, scope=scope, action=ACTION, action_args={"set_id": "s-1"}
+    )
+
+    args, kwargs = service.enqueue.call_args
+    assert args[0] == SKILL_ACTIVATION_SYNC_TASK
+    assert args[1]["action_type"] == ACTION.value
+    assert args[1]["action_args"] == {"set_id": "s-1"}
+    assert kwargs["deadline_seconds"] == SKILL_ACTIVATION_SYNC_DEADLINE_SECONDS
+    assert kwargs["delay_seconds"] == 0
+    assert kwargs["idempotency_key"] == (
+        build_skill_activation_sync_idempotency_key(scope)
+    )
+
+
+def test_enqueue_returns_the_queue_result_unchanged():
+    service = MagicMock(spec=TaskQueueService)
+    sentinel = object()
+    service.enqueue.return_value = sentinel
+
+    assert (
+        enqueue_skill_activation_sync(service, scope=_scope(), action=ACTION)
+        is sentinel
+    )
+
+
+# ── dedup against a real queue ──────────────────────────────────────────────
+
+
+class _InMemorySqliteDB:
+    def __init__(self, engine):
+        self._session_factory = sessionmaker(bind=engine, autoflush=False)
+
+    @contextmanager
+    def orm_session(self):
+        db = self._session_factory()
+        try:
+            yield db
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+
+@pytest.fixture
+def queue(monkeypatch):
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    from agentclaw.community.core.base import Base
+
+    Base.metadata.create_all(engine)
+    monkeypatch.setattr(
+        "agentclaw.community.core.task_queue.services.task_queue_service.get_current_env",
+        lambda: ENV,
+    )
+    return TaskQueueService(TaskQueueRepository(_InMemorySqliteDB(engine)))
+
+
+@pytest.mark.integration
+def test_second_operation_on_the_same_bot_joins_the_live_task(queue):
+    first, created_first = enqueue_skill_activation_sync(
+        queue, scope=_scope(), action=ACTION, action_args={"set_id": "s-1"}
+    )
+    second, created_second = enqueue_skill_activation_sync(
+        queue, scope=_scope(), action=ACTION, action_args={"set_id": "s-2"}
+    )
+
+    assert created_first is True
+    assert created_second is False
+    # The caller is handed the task already in flight — including its payload,
+    # which still describes the first operation. A handler that replayed
+    # ``action_args`` would therefore drop the second operation's work.
+    assert second.id == first.id
+    assert second.payload["action_args"] == {"set_id": "s-1"}
+
+
+@pytest.mark.integration
+def test_a_different_bot_is_not_deduped(queue):
+    first, created_first = enqueue_skill_activation_sync(
+        queue, scope=_scope(), action=ACTION
+    )
+    second, created_second = enqueue_skill_activation_sync(
+        queue, scope=_scope(bot_id="bot-2"), action=ACTION
+    )
+
+    assert created_first is True
+    assert created_second is True
+    assert second.id != first.id
+
+
+@pytest.mark.integration
+def test_a_terminal_task_releases_the_bot_for_the_next_operation(queue, monkeypatch):
+    first, _ = enqueue_skill_activation_sync(queue, scope=_scope(), action=ACTION)
+    repo = queue._repo
+    claimed = repo.claim_batch(worker_id="w-1", env=ENV, limit=1, lease_seconds=60)
+    assert [task.id for task in claimed] == [first.id]
+    assert repo.complete(task_id=first.id, worker_id="w-1") is True
+
+    second, created_second = enqueue_skill_activation_sync(
+        queue, scope=_scope(), action=ACTION
+    )
+
+    assert created_second is True
+    assert second.id != first.id
+    assert second.status is TaskStatus.PENDING

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -912,8 +912,6 @@ def test_resources_keeps_ordinary_mcp_membership_on_canonical_repository_path():
         legacy_factory=legacy,
         passport=object(),
         authorization=_Collaborators(),
-        mutation_guard=_MutationGuard(),
-        edit_guard=_Guard(),
         audit_log_repo=_Audit(),
         mcp_center=_McpCenter(allowed=True),
         mcp_auth=_McpAuth(allowed=True),


### PR DESCRIPTION
## Problem

A skill activation is two writes that must land together: the desired-state change in the database, and the RPC that repoints the Bot's runtime symlinks. `SkillSetControlPlaneService._mutate` performs both inline and, when the RPC fails, compensates by restoring the previous desired state and reconciling again — a best-effort path that a pod restart between the two writes defeats outright, leaving the Bot with desired state its runtime never received.

The `skill_center` README already names this gap and defers the fix: *"Phase 1 intentionally has no cache-backed cross-command Bot mutation fence: the current compensating restore remains a best-effort compatibility path for non-concurrent mutations, while durable serialization is deferred to the task-queue design."*

## Solution

Adds the task type and its enqueue path — `src/backend/src/agentclaw/community/core/skill_center/services/skill_activation_sync_task.py`:

- `SKILL_ACTIVATION_SYNC_TASK = "skill_center.activation_sync"` — one task type shared by every activation-shaped operation (activate, deactivate, switch, membership changes, MCP direct installs).
- `SkillActivationSyncAction` — the `action_type` payload discriminator, so the handler knows which operation it is executing. Ships with a single `PLACEHOLDER` member; each operation adds its own as it migrates onto the durable path.
- `SkillActivationSyncScope` / `SkillActivationSyncWork` — the `(env, entity_id, bot_id)` target and the parsed payload.
- `build_skill_activation_sync_payload` / `parse_skill_activation_sync_payload` / `build_skill_activation_sync_idempotency_key`.
- `enqueue_skill_activation_sync(...)` — the enqueue helper, which stamps the action type and the dedup key.
- `SkillActivationSyncTaskHandler` — **a skeleton.** It owns `task_type` and the per-attempt payload validation, then hands off to a single `_run` seam that the implementation replaces. It is not registered into a `HandlerRegistry`; registration lands with the body, alongside the first operation that enqueues. Until then nothing calls the enqueue helper, so no row of this type exists to run, and the control plane's inline path is untouched.

Three design choices worth review:

**The dedup key is the Bot, not the operation.** `(env, entity_id, bot_id)`, excluding `action_type`, because the Bot's runtime projection is the unit that must not be synchronized concurrently — two operations racing on one Bot are exactly what the durable path exists to serialize. The consequence is load-bearing: a second operation arriving mid-sync joins the live task and gets `created=False`. That is correct for a level-triggered handler that reconciles against whatever desired state the database holds when it runs, and it would silently drop work for a handler that performed the desired-state write itself from `action_args`. The module docstring states that obligation explicitly, and an integration test pins the observable behaviour (the joined task still carries the *first* operation's `action_args`).

**`entity_id` and `bot_id` are digested into the key.** The key column is `VARCHAR(190)` while its sources are `varchar(512)` and `varchar(128)` on the Skills Pool tables. The task queue README is explicit that the variable part of a key should be hashed rather than embedded for exactly this reason. The rejected alternative — embedding them raw and validating the length — fits every id in production today and raises `ValueError` mid-activation on the first tenant whose id is long; a key that cannot be built is an activation that cannot proceed, whereas a digest always fits. `env` stays literal because operators filter `ac_task_queue` on it first, and the raw triple is preserved verbatim in the payload so nothing is lost to audit.

**Both handler exits are `Fail`, not a raise.** The worker turns an exception into an implicit `Retry` with backoff. Because a live task holds the Bot's dedup key, an unparseable payload or the not-yet-implemented body would then pin that key for the whole 15-minute deadline and suppress every activation queued behind a row that can never succeed. `Fail` is terminal, so the key is released at once and the reason is recorded on the row. The 15-minute deadline itself is short for the same reason — far below the day-long horizons used by publish and Pool migration — since it bounds how long a wedged sync may keep suppressing the ones behind it.

Optionality is deliberately absent from the public surface: `action_args` defaults to `{}` and is copied on the way in, `parse_...` takes `dict` rather than `dict | None` (`TaskRecord.payload` is non-optional and `enqueue` is its only writer), and `handle` narrows the protocol's `Optional[dict]` to `dict` — the protocol is structural, and a test asserts conformance plus that `HandlerRegistry` accepts the type. The payload carries no generated correlation id: a fresh UUID would correlate to nothing the caller knows, and `ac_task_queue.id` is already the task's identity.

`skill_center/README.md` is updated: `agentclaw.community.core.task_queue` added to `internal_dependencies` (the boundary test fails without it), the new symbols added to `provides`, and the change-impact section extended.

### Drive-by CI fix

`tests/community/core/skill_center/test_skill_set_control_plane_service.py` had one test still constructing `SkillSetControlPlaneService` with `mutation_guard=` and `edit_guard=`. Those parameters were removed when the control plane stopped acquiring `SkillsPoolEditGuard`, and the `_MutationGuard` / `_Guard` fakes went with them, so the name lookup raised `NameError` before the service was built. It was failing `Backend unit tests` on the base branch, not just here. Deleting the two arguments is the whole fix — the test itself is not about the guards (it asserts that `resources()` reports ordinary SkillSet MCP membership via the canonical repository path, which the neighbouring legacy default-path test does not cover), so it stays.

## Validation

Run with `uv` against in-memory SQLite in the session container:

- `pytest tests/community/core/skill_center/test_skill_activation_sync_task.py` — **37 passed**. Covers the payload contract and `action_type` round trip, defensive copying of `action_args` (including that the shared `{}` default cannot be poisoned), the payload carrying nothing beyond the work identity, malformed-payload rejections, key determinism/component-sensitivity/shape, the key fitting `VARCHAR(190)` at maximum column widths, the enqueue helper's forwarding, and the handler skeleton (task type, protocol conformance, registrability, and both `Fail` exits). Three integration tests drive a real `TaskQueueRepository`: a second operation on the same Bot joins the live task, a different Bot does not dedup, and a terminal task releases the key for the next operation.
- `pytest tests/community/core/skill_center tests/community/core/task_queue tests/community/architecture` — **997 passed, 3 skipped, 0 failed**. Includes the module-boundary check; verified that check is actually load-bearing here by temporarily breaking the README entry and confirming it fails on the two new `task_queue` imports.
- `ruff check` on every changed file — clean, including an isolated run against the `python_sast_local.sh` block-rule set.
- CI on this head (`7057a24`): all 7 checks green — `Backend unit tests`, `Singlebox coverage`, `BCS unit tests`, `BCS e2e (coverage gated)`, `BaaS unit tests`, `Engine unit tests`, `Gateway unit tests`.

Not run locally: the full backend suite and Singlebox E2E (both covered by CI). The pre-push hook is not installed in this container, and dependency resolution had to be pointed at PyPI because the pinned Aliyun mirror is unreachable from here; `uv.lock` was restored afterwards and is not part of this diff.

## Compatibility and risk

No schema change and no behaviour change — the handler is not registered and nothing enqueues, so this is additive and inert until the follow-up. Rollback is deleting the module.

One ordering note for the follow-up: the task queue's own idempotency mechanism required its first keyed adopter to ship in a strictly later release than the mechanism, because a pre-change worker never releases `active_idempotency_key`. This is that first adopter, so it must not ship alongside the mechanism's release. The same ordering applies to each new `SkillActivationSyncAction` member: ship the member one release before the release that starts enqueuing it, since an older pod rejects an `action_type` it does not recognise.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCp99D1NuSHGDJBSUWzQQv)_
