### PR TITLE
fix(backend): retire stale SkillSet runtime mappings

### DIFF
--- a/src/backend/src/agentclaw/community/api/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/api/bot_runtime_projection_reconciler.py
@@ -15,6 +15,13 @@ class BotRuntimeProjectionReconcilerProtocol(
 ):
     """Transport-facing contract; Core depends only on its sibling contract."""
 
+    async def snapshot_skill_mappings(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ) -> tuple[PoolSkillMapping, ...]: ...
+
     async def reconcile(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
@@ -12,6 +12,15 @@ from agentclaw.community.core.skills_pool.models import PoolSkillMapping
 class BotRuntimeProjectionReconcilerProtocol(Protocol):
     """Apply database desired state through the selected runtime authority."""
 
+    async def snapshot_skill_mappings(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ) -> tuple[PoolSkillMapping, ...]:
+        """Return the current desired Skill mappings without publishing them."""
+        ...
+
     async def reconcile(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projection_reconciler.py
@@ -32,7 +32,10 @@ from agentclaw.community.core.skill_center.runtime_policy import (
     require_supported_bot_skill_runtime,
     runtime_layout_engine_for_bot,
 )
-from agentclaw.community.core.skills_pool.mapping_intent import mapping_contract_for
+from agentclaw.community.core.skills_pool.mapping_intent import (
+    build_logical_skill_mappings,
+    mapping_contract_for,
+)
 from agentclaw.community.core.skills_pool.models import (
     PoolSkillMapping,
     SkillMappingSourceLayout,
@@ -71,6 +74,36 @@ class BotRuntimeProjectionReconciler:
         self._pool_runtime = pool_runtime
         self._pool_layouts = pool_layouts
         self._passport = passport
+
+    async def snapshot_skill_mappings(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+    ) -> tuple[PoolSkillMapping, ...]:
+        """Resolve the current desired Skills without changing runtime state.
+
+        Callers use this before a mutating reconcile so a later desired-state
+        rollback can retire mappings that were already published.
+        """
+        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
+        if bot is None:
+            raise LocalSkillNotFoundError()
+        require_supported_bot_skill_runtime(bot)
+        engine = str(bot.get("active_engine") or "openclaw")
+        skill_assets = list(
+            self._pool_skills.list_bot_active_assets(
+                env=str(bot["env"]),
+                bot_id=bot_id,
+                owner_id=owner_id,
+                engine=engine,
+            )
+        )
+        if engine == "teclaw" and any(
+            asset.git_path.startswith("center://") for asset in skill_assets
+        ):
+            raise SkillSetRuntimeReconcileError()
+        return tuple(build_logical_skill_mappings(skill_assets))
 
     async def reconcile(
         self,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from injector import inject
 
 from agentclaw.community.core.skill_center.authorization_hook import (
@@ -38,6 +40,10 @@ from agentclaw.community.core.skill_center.runtime_policy import (
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectionReconcilerProtocol,
 )
+from agentclaw.community.core.skills_pool.mapping_intent import (
+    retired_logical_skill_mappings,
+)
+from agentclaw.community.core.skills_pool.models import PoolSkillMapping
 from agentclaw.community.core.workspace.skill_layout import runtime_layout_engine_for_bot
 from agentclaw.community.plugin_api.passport import PassportPlugin
 
@@ -609,6 +615,12 @@ class SkillSetControlPlaneService:
     ) -> dict:
         """Apply one desired-state mutation and synchronously reconcile runtime."""
         mode = self._require_mutable_bot(bot, command)
+        previous_mappings: Sequence[PoolSkillMapping] = ()
+        if mode is not BotSkillRuntimeMutationMode.CLEANUP_ONLY:
+            previous_mappings = await self._runtime.snapshot_skill_mappings(
+                bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
+            )
         mutation_result = mutation()
         # An inactive-set membership change has no runtime projection
         # to apply.  Reconcile only becomes a required side effect
@@ -633,6 +645,7 @@ class SkillSetControlPlaneService:
                 mutation=mutation_result,
                 command=command,
                 mode=mode,
+                previous_mappings=previous_mappings,
             )
         self._audit(
             bot_id=bot_id,
@@ -651,11 +664,25 @@ class SkillSetControlPlaneService:
         mutation: SkillSetMutation,
         command: BotSkillRuntimeCommand,
         mode: BotSkillRuntimeMutationMode,
+        previous_mappings: Sequence[PoolSkillMapping],
     ) -> dict:
         owner_id = str(bot["owner_id"])
+        current_mappings: Sequence[PoolSkillMapping] = ()
         try:
+            if mode is not BotSkillRuntimeMutationMode.CLEANUP_ONLY:
+                current_mappings = await self._runtime.snapshot_skill_mappings(
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                )
             await self._reconcile_runtime(
-                command=command, mode=mode, bot_id=bot_id, owner_id=owner_id
+                command=command,
+                mode=mode,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                retired_mappings=retired_logical_skill_mappings(
+                    list(previous_mappings),
+                    list(current_mappings),
+                ),
             )
         except Exception as exc:
             self._repository.restore_desired_state(
@@ -666,7 +693,14 @@ class SkillSetControlPlaneService:
             )
             try:
                 await self._reconcile_runtime(
-                    command=command, mode=mode, bot_id=bot_id, owner_id=owner_id
+                    command=command,
+                    mode=mode,
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                    retired_mappings=retired_logical_skill_mappings(
+                        list(current_mappings),
+                        list(previous_mappings),
+                    ),
                 )
             except Exception as restore_error:
                 raise SkillSetRuntimeReconcileError() from restore_error
@@ -734,8 +768,13 @@ class SkillSetControlPlaneService:
         mode: BotSkillRuntimeMutationMode,
         bot_id: str,
         owner_id: str,
+        retired_mappings: Sequence[PoolSkillMapping] = (),
     ) -> None:
         if mode is BotSkillRuntimeMutationMode.CLEANUP_ONLY:
             await self._runtime.reconcile_cleanup(bot_id=bot_id, owner_id=owner_id)
             return
-        await self._runtime.reconcile(bot_id=bot_id, owner_id=owner_id)
+        await self._runtime.reconcile(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            retired_mappings=retired_mappings,
+        )

--- a/src/backend/tests/community/contracts/test_bot_runtime_projection_reconciler.py
+++ b/src/backend/tests/community/contracts/test_bot_runtime_projection_reconciler.py
@@ -21,6 +21,12 @@ class _RecordingReconciler:
         self.error = error
         self.calls: list[dict] = []
 
+    async def snapshot_skill_mappings(self, **kwargs):
+        self.calls.append({"operation": "snapshot", **kwargs})
+        if self.error is not None:
+            raise self.error
+        return ()
+
     async def reconcile(self, **kwargs) -> None:
         self.calls.append({"operation": "full", **kwargs})
         if self.error is not None:
@@ -44,6 +50,9 @@ class _Consumer:
 
     async def refresh(self) -> None:
         await self._runtime.reconcile(bot_id="bot-1", owner_id="owner-1")
+
+    async def snapshot_skill_mappings(self) -> None:
+        await self._runtime.snapshot_skill_mappings(bot_id="bot-1", owner_id="owner-1")
 
     async def refresh_non_skill(self) -> None:
         await self._runtime.reconcile_non_skill_projection(
@@ -81,6 +90,18 @@ async def test_reconcile_service_api_success_reaches_the_bound_implementation(
 
     assert runtime.calls == [
         {"operation": "full", "bot_id": "bot-1", "owner_id": "owner-1"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_service_api_reads_without_reconciliation(world) -> None:
+    runtime = _RecordingReconciler()
+    consumer = _consumer(world, runtime)
+
+    await consumer.snapshot_skill_mappings()
+
+    assert runtime.calls == [
+        {"operation": "snapshot", "bot_id": "bot-1", "owner_id": "owner-1"}
     ]
 
 

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -23,7 +23,10 @@ from agentclaw.community.core.skill_center.services.skill_set_control_plane impo
 from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
     BotRuntimeProjectionReconciler,
 )
-from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+from agentclaw.community.core.skills_pool.models import (
+    PoolSkillMapping,
+    RegisteredSkillAsset,
+)
 
 
 class _Repository:
@@ -155,13 +158,40 @@ class _AicodingImageBots(_Bots):
 
 
 class _Runtime:
-    def __init__(self) -> None:
+    def __init__(self, *, snapshots=(), fail_first: bool = True) -> None:
         self.owners = []
+        self.reconcile_calls: list[dict] = []
+        self.snapshot_calls: list[dict] = []
+        self._fail_first = fail_first
+        self._snapshots = list(snapshots) or [(), self._skill_mappings()]
 
-    async def reconcile(self, *, bot_id: str, owner_id: str) -> None:
+    @staticmethod
+    def _skill_mappings():
+        return (
+            PoolSkillMapping(corpus="local", relative_path="qa", link_name="qa"),
+            PoolSkillMapping(
+                corpus="repo", relative_path="business/eva", link_name="eva"
+            ),
+        )
+
+    async def snapshot_skill_mappings(self, *, bot_id: str, owner_id: str):
+        assert bot_id == "bot-1"
+        self.snapshot_calls.append({"bot_id": bot_id, "owner_id": owner_id})
+        return self._snapshots[len(self.snapshot_calls) - 1]
+
+    async def reconcile(
+        self, *, bot_id: str, owner_id: str, retired_mappings=()
+    ) -> None:
         assert bot_id == "bot-1"
         self.owners.append(owner_id)
-        if len(self.owners) == 1:
+        self.reconcile_calls.append(
+            {
+                "bot_id": bot_id,
+                "owner_id": owner_id,
+                "retired_mappings": tuple(retired_mappings),
+            }
+        )
+        if self._fail_first and len(self.owners) == 1:
             raise RuntimeError("runtime failed")
 
     async def reconcile_cleanup(self, *, bot_id: str, owner_id: str) -> None:
@@ -174,6 +204,9 @@ class _Audit:
 
 
 class _SuccessfulRuntime:
+    async def snapshot_skill_mappings(self, **_kwargs):
+        return ()
+
     async def reconcile(self, **_kwargs) -> None:
         return None
 
@@ -419,6 +452,9 @@ class _FailingMaterializationRepository(_McpInstallations):
 
 
 class _RuntimeSkills:
+    def __init__(self, assets=()) -> None:
+        self._assets = list(assets)
+
     def list_bot_active_assets(self, **kwargs):
         assert kwargs == {
             "env": "pre",
@@ -426,7 +462,7 @@ class _RuntimeSkills:
             "owner_id": "true-owner",
             "engine": "openclaw",
         }
-        return []
+        return self._assets
 
 
 class _HistoricalAicodingRuntimeSkills(_RuntimeSkills):
@@ -562,7 +598,60 @@ async def test_collaborator_command_restores_desired_state_and_uses_true_owner()
         }
     ]
     assert runtime.owners == ["true-owner", "true-owner"]
+    assert runtime.snapshot_calls == [
+        {"bot_id": "bot-1", "owner_id": "true-owner"},
+        {"bot_id": "bot-1", "owner_id": "true-owner"},
+    ]
+    assert runtime.reconcile_calls == [
+        {
+            "bot_id": "bot-1",
+            "owner_id": "true-owner",
+            "retired_mappings": (),
+        },
+        {
+            "bot_id": "bot-1",
+            "owner_id": "true-owner",
+            "retired_mappings": (
+                PoolSkillMapping(corpus="local", relative_path="qa", link_name="qa"),
+                PoolSkillMapping(
+                    corpus="repo", relative_path="business/eva", link_name="eva"
+                ),
+            ),
+        },
+    ]
     assert len(repository.restore_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_deactivate_retires_mappings_removed_from_the_runtime_projection():
+    repository = _Repository()
+    runtime = _Runtime(snapshots=[_Runtime._skill_mappings(), ()], fail_first=False)
+    service = SkillSetControlPlaneService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=runtime,
+        legacy_factory=object(),
+        passport=object(),
+        authorization=_Collaborators(),
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=_McpAuth(allowed=True),
+    )
+
+    await service.deactivate(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="collaborator",
+        set_id="set-1",
+    )
+
+    assert runtime.reconcile_calls == [
+        {
+            "bot_id": "bot-1",
+            "owner_id": "true-owner",
+            "retired_mappings": _Runtime._skill_mappings(),
+        }
+    ]
 
 
 def test_create_rejects_missing_bot_instead_of_creating_orphan_set():
@@ -1145,6 +1234,48 @@ async def test_mcp_direct_activation_denies_before_writing_desired_state():
             server_code="mcp.weather",
         )
     assert repository.direct_calls == []
+
+
+@pytest.mark.asyncio
+async def test_runtime_mapping_snapshot_has_no_runtime_side_effects():
+    repository = _McpInstallations()
+    pool = _RuntimePool()
+    runtime = BotRuntimeProjectionReconciler(
+        factory=_RuntimeFactory(),
+        bot_repo=_RuntimeBots(),
+        repository=repository,
+        pool_skills=_RuntimeSkills(
+            [
+                RegisteredSkillAsset(
+                    skill_id=1,
+                    name="qa",
+                    git_path="local://qa",
+                ),
+                RegisteredSkillAsset(
+                    skill_id=2,
+                    name="eva",
+                    git_path="git://business/eva",
+                ),
+            ]
+        ),
+        pool_runtime=pool,
+        pool_layouts=_RuntimeLayouts(),
+        passport=_RuntimePassport(),
+    )
+
+    snapshot = await runtime.snapshot_skill_mappings(
+        bot_id="bot-1", owner_id="true-owner"
+    )
+
+    assert snapshot == (
+        PoolSkillMapping(corpus="local", relative_path="qa", link_name="qa"),
+        PoolSkillMapping(
+            corpus="repo", relative_path="business/eva", link_name="eva"
+        ),
+    )
+    assert repository.materialize_calls == []
+    assert pool.publish_calls == []
+    assert pool.verify_calls == []
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
@@ -65,7 +65,12 @@ class _Runtime:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str]] = []
 
-    async def reconcile(self, *, bot_id: str, owner_id: str) -> None:
+    async def snapshot_skill_mappings(self, **_kwargs):
+        return ()
+
+    async def reconcile(
+        self, *, bot_id: str, owner_id: str, retired_mappings=()
+    ) -> None:
         self.calls.append((bot_id, owner_id))
 
 


### PR DESCRIPTION
## Problem
SkillSet lifecycle reconciliation published only the current mapping set. Successful deactivate therefore left removed Local/Repo soft links at runtime, and a later non-skill projection failure could restore database desired state without retiring mappings already published by the failed attempt.

A second prepub reproduction showed why explicit retirement is required for Legacy layout too: an `xlsx` active link pointed to a missing legacy Local source. The Engine returned HTTP 200 with business `success=false` and `source_missing` / `managed_source_missing`; without a retirement intent, publish could neither converge nor reach verify.

## Solution
Snapshot logical Skill mappings before and after the desired-state mutation. Reconcile with the exact `retired_logical_skill_mappings(previous, current)` difference; if reconciliation fails, restore desired state and reconcile again with the reverse difference. The snapshot is read-only and does not materialize installations or touch runtime.

This preserves the current Engine contract for both Pool and Legacy source layouts: current mappings are created or corrected, while only exact product-managed retired identities are removed.

## Validation
- Control-plane, Service API contract, and architecture suites — 96 passed.
- Focused canonical SkillSet/MCP OpenAPI endpoint cases — 42 passed.
- Engine mapping retirement suite — 25 passed.
- Focused Ruff, compile, and diff checks passed.
- Previous Backend CI fixture failures were fixed by synchronizing the latest `dev_refactory_collaboration` baseline and updating the endpoint runtime fake to the new Service API.

## Compatibility and risk
No HTTP/OpenAPI, schema, or storage contract changes. The new internal Service API read method is covered by Core/Public protocol tests. Retirements are an exact previous-versus-current mapping difference, so mappings that remain active or have been rebound externally are not removed.

If the compensation reconcile itself also fails, the command still reports failure rather than hiding runtime uncertainty.

## Related issues
Phase 1 P1: pre-runtime drift after failed SkillSet activation and successful deactivate.