### PR TITLE
fix(backend): log skill pool mapping responses

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/runtime.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/runtime.py
@@ -173,7 +173,27 @@ class SkillsPoolRuntime:
                 bot_id,
             )
             return False
-        return response.get("success") is True
+        success = response.get("success") is True
+        if not success:
+            logger.warning(
+                "[skills_pool.runtime] mapping publish returned non-success "
+                "bot_id=%s user_id=%s contract=%s success=%s response=%s",
+                bot_id,
+                user_id,
+                mapping_contract_version,
+                response.get("success"),
+                response,
+            )
+        else:
+            logger.info(
+                "[skills_pool.runtime] mapping publish succeeded bot_id=%s "
+                "user_id=%s contract=%s response_keys=%s",
+                bot_id,
+                user_id,
+                mapping_contract_version,
+                sorted(response.keys()),
+            )
+        return success
 
     async def rollback_to_legacy(
         self,
@@ -319,11 +339,32 @@ class SkillsPoolRuntime:
             )
             return False
         data = response.get("data")
-        return (
+        verified = (
             response.get("success") is True
             and isinstance(data, dict)
             and data.get("valid") is True
         )
+        if not verified:
+            logger.warning(
+                "[skills_pool.runtime] mapping verify returned non-verified "
+                "bot_id=%s user_id=%s contract=%s success=%s valid=%s response=%s",
+                bot_id,
+                user_id,
+                mapping_contract_version,
+                response.get("success"),
+                data.get("valid") if isinstance(data, dict) else None,
+                response,
+            )
+        else:
+            logger.info(
+                "[skills_pool.runtime] mapping verify succeeded bot_id=%s "
+                "user_id=%s contract=%s response_keys=%s",
+                bot_id,
+                user_id,
+                mapping_contract_version,
+                sorted(response.keys()),
+            )
+        return verified
 
     async def _ensure_center_mappings(
         self,


### PR DESCRIPTION
 ## Problem

  POST /api/skillsets/{id}/mcps was failing with SkillSetRuntimeReconcileError during runtime reconciliation, but the existing logs only showed HTTP 200 access entries. That was not enough to
  tell whether the failure came from:

  - success != true in the publish response
  - an unexpected response shape
  - or a failed verify step

  As a result, troubleshooting the mapping sync failure was blocked by lack of response-level visibility.

  ## Solution

  Added response logging in src/backend/src/agentclaw/community/core/skills_pool/runtime.py:

  - In publish_mappings():
      - log the downstream response
      - emit a warning when success != true
      - log a success summary when publish succeeds

  - In verify_mappings():
      - log the downstream response
      - emit a warning when verification does not pass
      - log a success summary when verification succeeds

  This makes it possible to pinpoint whether runtime reconciliation fails at publish or verify time.

  ## Validation

  Ran:

  - python -m py_compile src/backend/src/agentclaw/community/core/skills_pool/runtime.py

  Also verified the change was pushed successfully and the pre-push gate passed.

  Not run:

  - full unit tests / coverage / E2E, since this is a logging-only change with no behavior change.

  ## Compatibility and risk

  This is a logging-only change and does not alter business logic, return values, or contracts.

  The only impact is slightly more log volume on the skill pool publish / verify path.

  ———

  If you want, I can also give you a shorter, more polished PR title option, such as:

  - fix(backend): surface skill pool mapping sync responses
  - fix(backend): add diagnostics for skill pool mapping sync