### PR TITLE
feat(backend): add bot editor request work orders

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -625,6 +625,10 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
         "POST",
         "/openapi/v1/bots/spaces/{space_id}/join-requests",
     ): AdmissionMode.USER_GATED,
+    (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/editor-requests",
+    ): AdmissionMode.USER_GATED,
     ("GET", "/openapi/v1/bots/skills/{skill_code}/publish/status"): AdmissionMode.OPEN,
     ("GET", "/openapi/v1/bots/market/skill-center/tags"): AdmissionMode.OPEN,
     ("GET", "/openapi/v1/bots/work-orders"): AdmissionMode.USER_GATED,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
@@ -478,6 +478,8 @@ AUTHORIZATION: dict[tuple[str, str], Authorization] = {
         NoCheck("Space membership, adjudicated by the Space service"),
     ("POST", "/openapi/v1/bots/spaces/{space_id}/join-requests"):
         NoCheck("Space membership, adjudicated by the Space service"),
+    ("POST", "/openapi/v1/bots/{bot_id}/editor-requests"):
+        NoCheck("Team Space membership and Bot eligibility, adjudicated by the work-order service"),
     ("POST", "/openapi/v1/bots/spaces/{space_id}/market-favorites"):
         NoCheck("Space membership, adjudicated by the Space service"),
     ("POST", "/openapi/v1/bots/spaces/{space_id}/market-favorites/cancel"):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_work_order.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_work_order.py
@@ -14,6 +14,8 @@ class WorkOrderErrorCode(IntEnum):
     APPLICANT_ALREADY_MEMBER = 409203
     NO_REVIEWER = 409204
     JOIN_NOT_ALLOWED = 409205
+    APPLICANT_ALREADY_EDITOR = 409206
+    BOT_EDITOR_REQUEST_NOT_ALLOWED = 409207
 
 
 class WorkOrderPublicErrorMessage(StrEnum):
@@ -26,3 +28,5 @@ class WorkOrderPublicErrorMessage(StrEnum):
     APPLICANT_ALREADY_MEMBER = "Applicant is already a space member"
     NO_REVIEWER = "The space has no available approver"
     JOIN_NOT_ALLOWED = "The space does not accept join requests"
+    APPLICANT_ALREADY_EDITOR = "Applicant already has Bot editor access"
+    BOT_EDITOR_REQUEST_NOT_ALLOWED = "The Bot does not accept editor requests"

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -164,7 +164,9 @@ from agentclaw.community.core.work_orders.errors import (
     WorkOrderAccessDeniedError,
     WorkOrderAlreadyPendingError,
     WorkOrderAlreadyProcessedError,
+    WorkOrderApplicantAlreadyEditorError,
     WorkOrderApplicantAlreadyMemberError,
+    WorkOrderBotEditorRequestNotAllowedError,
     WorkOrderInvalidReasonError,
     WorkOrderInvalidRemarkError,
     WorkOrderJoinNotAllowedError,
@@ -375,9 +377,17 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
         409,
         WorkOrderPublicErrorMessage.APPLICANT_ALREADY_MEMBER,
     ),
+    WorkOrderApplicantAlreadyEditorError: (
+        409,
+        WorkOrderPublicErrorMessage.APPLICANT_ALREADY_EDITOR,
+    ),
     WorkOrderJoinNotAllowedError: (
         409,
         WorkOrderPublicErrorMessage.JOIN_NOT_ALLOWED,
+    ),
+    WorkOrderBotEditorRequestNotAllowedError: (
+        409,
+        WorkOrderPublicErrorMessage.BOT_EDITOR_REQUEST_NOT_ALLOWED,
     ),
     WorkOrderNoReviewerError: (
         409,
@@ -709,8 +719,10 @@ ENVELOPE_ERROR_CODES: dict[type[Exception], int] = {
     WorkOrderAlreadyPendingError: WorkOrderErrorCode.ALREADY_PENDING,
     WorkOrderAlreadyProcessedError: WorkOrderErrorCode.ALREADY_PROCESSED,
     WorkOrderApplicantAlreadyMemberError: WorkOrderErrorCode.APPLICANT_ALREADY_MEMBER,
+    WorkOrderApplicantAlreadyEditorError: WorkOrderErrorCode.APPLICANT_ALREADY_EDITOR,
     WorkOrderNoReviewerError: WorkOrderErrorCode.NO_REVIEWER,
     WorkOrderJoinNotAllowedError: WorkOrderErrorCode.JOIN_NOT_ALLOWED,
+    WorkOrderBotEditorRequestNotAllowedError: WorkOrderErrorCode.BOT_EDITOR_REQUEST_NOT_ALLOWED,
     LocalSkillOwnerAmbiguousError: 409104,
     LocalSkillInvalidPackageError: 400101,
     LocalSkillNotReadyError: 409101,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
@@ -23,6 +23,9 @@ from agentclaw.community.adapters.http.openapi_v1.responses import (
 )
 from agentclaw.community.adapters.http.openapi_v1.work_orders.schemas import (
     CreateSpaceJoinRequest,
+    CreateBotEditorRequest,
+    BotEditorRequestCreated,
+    BotEditorWorkOrderDetailContent,
     NotificationDetailResponse,
     NotificationReadResponse,
     NotificationsReadAllResponse,
@@ -31,6 +34,7 @@ from agentclaw.community.adapters.http.openapi_v1.work_orders.schemas import (
     WorkOrderDetailContent,
     WorkOrderDetailResponse,
     WorkOrderItemType,
+    WorkOrderBizType,
     WorkOrderListItem,
     WorkOrderQueryType,
     WorkOrderReviewRequest,
@@ -54,6 +58,9 @@ from agentclaw.community.adapters.http.openapi_v1.authorization import PublicAPI
 
 router = APIRouter(tags=["work-orders"], route_class=PublicAPIRoute)
 PositiveIdPath = Annotated[int, Path(ge=1, description="Positive numeric identifier.")]
+BotIdPath = Annotated[
+    str, Path(min_length=1, max_length=64, description="Identifier of the Bot.")
+]
 PageNoQuery = Annotated[int, Query(ge=1, description="One-based page number.")]
 PageSizeQuery = Annotated[
     int, Query(ge=1, le=100, description="Maximum items returned per page.")
@@ -109,6 +116,16 @@ def _approval_display(work_order) -> tuple[str, str | None]:
     return work_order.biz_type, work_order.apply_reason
 
 
+def _biz_data(raw: str | None) -> dict[str, object]:
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
 def _list_item(item: DomainListItem) -> WorkOrderListItem:
     work_order = item.work_order
     notification = item.notification
@@ -162,6 +179,43 @@ def _list_item(item: DomainListItem) -> WorkOrderListItem:
 
 
 @router.post(
+    "/openapi/v1/bots/{bot_id}/editor-requests",
+    status_code=201,
+    response_model=Envelope[BotEditorRequestCreated],
+)
+@envelope_errors
+async def create_bot_editor_request(
+    bot_id: BotIdPath,
+    body: CreateBotEditorRequest,
+    request: Request,
+    caller: ActingCallerDep,
+    owner_id: Annotated[
+        str | None,
+        Query(
+            max_length=256,
+            description="Owner of the Bot. Defaults to the current user.",
+        ),
+    ] = None,
+    service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
+) -> Envelope[BotEditorRequestCreated]:
+    actor_id = _require_user_delegation(caller)
+    record = service.create_bot_editor_request(
+        bot_id=bot_id,
+        owner_id=owner_id or actor_id,
+        applicant_user_id=actor_id,
+        reason=body.reason,
+    )
+    return created(
+        BotEditorRequestCreated(
+            work_order_id=record.id,
+            work_order_no=record.work_order_no,
+            status=record.status,
+        ),
+        request,
+    )
+
+
+@router.post(
     "/openapi/v1/bots/spaces/{space_id}/join-requests",
     status_code=201,
     response_model=Envelope[SpaceJoinRequestCreated],
@@ -205,6 +259,17 @@ async def list_work_orders(
     item_type: Annotated[
         WorkOrderItemType, Query(description="Category of inbox item to return.")
     ] = WorkOrderItemType.ALL,
+    biz_type: Annotated[
+        str | None,
+        Query(
+            max_length=64,
+            description="Business type to return, or all business types.",
+        ),
+    ] = None,
+    biz_id: Annotated[
+        str | None,
+        Query(max_length=128, description="Business identifier to return."),
+    ] = None,
     page_no: PageNoQuery = 1,
     page_size: PageSizeQuery = 20,
     service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
@@ -214,6 +279,8 @@ async def list_work_orders(
         actor_id=actor_id,
         query_type=DomainWorkOrderQueryType(query_type),
         item_type=DomainWorkOrderItemType(item_type),
+        biz_type=biz_type,
+        biz_id=biz_id,
         page_no=page_no,
         page_size=page_size,
     )
@@ -234,6 +301,28 @@ async def get_work_order(
     actor_id = _require_user_delegation(caller)
     detail = service.get_detail(work_order_id=work_order_id, actor_id=actor_id)
     work_order = detail.work_order
+    if work_order.biz_type == WorkOrderBizType.BOT_COLLABORATOR.value:
+        data = _biz_data(work_order.biz_data)
+        content = BotEditorWorkOrderDetailContent(
+            bot_id=str(data.get("bot_id") or work_order.biz_id),
+            bot_name=str(data.get("bot_name") or work_order.biz_id),
+            owner_id=str(data.get("owner_id") or ""),
+            space_id=int(data.get("space_id") or 0),
+            applicant_user_id=work_order.applicant_user_id,
+            applicant_name=str(
+                data.get("applicant_name") or work_order.applicant_user_id
+            ),
+            requested_role=str(data.get("requested_role") or "member"),
+            reason=work_order.apply_reason,
+        )
+    else:
+        content = WorkOrderDetailContent(
+            space_id=detail.space_id,
+            space_name=detail.space_name,
+            applicant_user_id=work_order.applicant_user_id,
+            applicant_name=detail.applicant_name,
+            reason=work_order.apply_reason,
+        )
     return envelope(
         WorkOrderDetailResponse(
             work_order_id=work_order.id,
@@ -244,13 +333,7 @@ async def get_work_order(
             else work_order.biz_id,
             event_type=detail.event_type,
             title=detail.title,
-            content=WorkOrderDetailContent(
-                space_id=detail.space_id,
-                space_name=detail.space_name,
-                applicant_user_id=work_order.applicant_user_id,
-                applicant_name=detail.applicant_name,
-                reason=work_order.apply_reason,
-            ),
+            content=content,
             status=work_order.status,
             reviewer_user_id=work_order.reviewer_user_id,
             review_remark=work_order.review_remark,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
@@ -39,8 +39,12 @@ class WorkOrderBizType(_DocumentedEnum):
     """Business object represented by a work order."""
 
     SPACE_JOIN = "SPACE_JOIN"
+    BOT_COLLABORATOR = "BOT_COLLABORATOR"
 
-    __descriptions__ = {"SPACE_JOIN": "A request to join a Space."}
+    __descriptions__ = {
+        "SPACE_JOIN": "A request to join a Space.",
+        "BOT_COLLABORATOR": "A request to jointly edit a Bot.",
+    }
 
 
 class NotificationCategory(_DocumentedEnum):
@@ -164,6 +168,22 @@ class SpaceJoinRequestCreated(BaseModel):
     status: WorkOrderStatus = Field(description="Initial work-order status.")
 
 
+class CreateBotEditorRequest(BaseModel):
+    """Request for jointly editing a Team Space Bot."""
+
+    reason: str = Field(
+        min_length=1, max_length=512, description="Reason for requesting edit access."
+    )
+
+
+class BotEditorRequestCreated(BaseModel):
+    """Work-order identity returned for a Bot editor request."""
+
+    work_order_id: int = Field(description="Identifier of the created work order.")
+    work_order_no: str = Field(description="Human-readable work-order number.")
+    status: WorkOrderStatus = Field(description="Initial work-order status.")
+
+
 class WorkOrderApprovalRequest(BaseModel):
     """Decision submitted to the unified work-order approval endpoint."""
 
@@ -281,6 +301,19 @@ class WorkOrderDetailContent(BaseModel):
     reason: str | None = Field(description="Applicant's reason, when supplied.")
 
 
+class BotEditorWorkOrderDetailContent(BaseModel):
+    """Business details for a Bot joint-editor work order."""
+
+    bot_id: str = Field(description="Identifier of the requested Bot.")
+    bot_name: str = Field(description="Display name of the requested Bot.")
+    owner_id: str = Field(description="Owner who reviews the application.")
+    space_id: int = Field(description="Team Space containing the Bot.")
+    applicant_user_id: str = Field(description="Identifier of the applicant.")
+    applicant_name: str = Field(description="Display name of the applicant.")
+    requested_role: str = Field(description="Editor role granted after approval.")
+    reason: str | None = Field(description="Applicant's reason, when supplied.")
+
+
 class WorkOrderDetailResponse(_UtcResponseModel):
     """Detailed view of one work order."""
 
@@ -292,8 +325,8 @@ class WorkOrderDetailResponse(_UtcResponseModel):
         default=None, description="Legacy originating event, when available."
     )
     title: str = Field(description="Display title of the work order.")
-    content: WorkOrderDetailContent | dict | None = Field(
-        default=None, description="Business detail payload."
+    content: WorkOrderDetailContent | BotEditorWorkOrderDetailContent | dict | None = (
+        Field(default=None, description="Business detail payload.")
     )
     biz_data: str | None = Field(
         default=None, description="Business detail JSON payload."

--- a/src/backend/src/agentclaw/community/api/work_order_service.py
+++ b/src/backend/src/agentclaw/community/api/work_order_service.py
@@ -50,12 +50,24 @@ class WorkOrderServiceProtocol(Protocol):
     ) -> WorkOrderRecord: ...
 
     @abstractmethod
+    def create_bot_editor_request(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        applicant_user_id: str,
+        reason: str,
+    ) -> WorkOrderRecord: ...
+
+    @abstractmethod
     def list_items(
         self,
         *,
         actor_id: str,
         query_type: WorkOrderQueryType,
         item_type: WorkOrderItemType,
+        biz_type: str | None = None,
+        biz_id: str | None = None,
         page_no: int,
         page_size: int,
     ) -> tuple[int, list[WorkOrderListItem]]: ...

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/protocols.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/protocols.py
@@ -47,6 +47,10 @@ class CollaboratorServiceProtocol(Protocol):
         """获取叠加实时 Space 成员关系后的有效 Bot 权限."""
         ...
 
+    def on_collaboration_changed(self, *args: Any, **kwargs: Any) -> Any:
+        """Run best-effort downstream synchronization after a relation change."""
+        ...
+
 
 def resolve_operable_permission_level(
     collaborators: CollaboratorServiceProtocol,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/bot_editor.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/bot_editor.py
@@ -42,7 +42,7 @@ from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugin_api.models import BotModel
 
 
-class BotEditorWorkOrderRepository:
+class _BotEditorWorkOrderRepository:
     """Own the atomic create/review workflows specific to Bot editors."""
 
     def __init__(self, db: DatabasePlugin) -> None:

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/bot_editor.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/bot_editor.py
@@ -1,0 +1,368 @@
+"""Transactional persistence for Bot editor request work orders."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from sqlalchemy.exc import IntegrityError
+
+from agentclaw.community.core.bot_collaborator.models import (
+    BotCollaboratorModel,
+    CollaboratorRole,
+)
+from agentclaw.community.core.spaces.repository.models import SpaceMemberModel
+from agentclaw.community.core.work_orders.errors import (
+    WorkOrderAccessDeniedError,
+    WorkOrderAlreadyPendingError,
+    WorkOrderAlreadyProcessedError,
+    WorkOrderApplicantAlreadyEditorError,
+    WorkOrderBotEditorRequestNotAllowedError,
+    WorkOrderNotFoundError,
+)
+from agentclaw.community.core.work_orders.models import (
+    NotificationCategory,
+    WorkOrderApproverStatus,
+    WorkOrderBizType,
+    WorkOrderDecision,
+    WorkOrderEventType,
+    WorkOrderMessageContent,
+    WorkOrderMessageTitle,
+    WorkOrderNotificationDraft,
+    WorkOrderReviewResult,
+    WorkOrderStatus,
+)
+from agentclaw.community.core.work_orders.repository.models import (
+    WorkOrderApproverModel,
+    WorkOrderModel,
+    WorkOrderNotificationModel,
+)
+from agentclaw.community.plugin_api.database import DatabasePlugin
+from agentclaw.community.plugin_api.models import BotModel
+
+
+class BotEditorWorkOrderRepository:
+    """Own the atomic create/review workflows specific to Bot editors."""
+
+    def __init__(self, db: DatabasePlugin) -> None:
+        self._db = db
+        self._WorkOrder = WorkOrderModel
+        self._Notification = WorkOrderNotificationModel
+        self._Approver = WorkOrderApproverModel
+        self._Member = SpaceMemberModel
+        self._Bot = BotModel
+        self._Collaborator = BotCollaboratorModel
+
+    @staticmethod
+    def _new_no() -> str:
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        return f"WO{stamp}{uuid4().hex[:10].upper()}"
+
+    def create_bot_editor_request(
+        self,
+        *,
+        bot_pk: int,
+        bot_id: str,
+        bot_name: str,
+        owner_id: str,
+        space_id: int,
+        applicant_user_id: str,
+        applicant_name: str,
+        apply_reason: str,
+        env: str,
+    ):
+        with self._db.transactional_orm_session() as db:
+            # Serializing on the Bot prevents concurrent requests from creating
+            # more than one pending application for the same applicant.
+            bot = (
+                db.query(self._Bot)
+                .filter(
+                    self._Bot.id == bot_pk,
+                    self._Bot.bot_id == bot_id,
+                    self._Bot.owner_id == owner_id,
+                    self._Bot.space_id == space_id,
+                    self._Bot.env == env,
+                    self._Bot.is_delete == 0,
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if bot is None:
+                raise WorkOrderNotFoundError("Bot not found during request creation")
+
+            member = (
+                db.query(self._Member.id)
+                .filter(
+                    self._Member.space_id == space_id,
+                    self._Member.user_id == applicant_user_id,
+                    self._Member.status == "ACTIVE",
+                    self._Member.env == env,
+                )
+                .first()
+            )
+            if member is None:
+                raise WorkOrderAccessDeniedError(
+                    "applicant must be an active Team Space member"
+                )
+
+            collaborator = (
+                db.query(self._Collaborator.id)
+                .filter(
+                    self._Collaborator.bot_pk == bot_pk,
+                    self._Collaborator.user_id == applicant_user_id,
+                    self._Collaborator.env == env,
+                )
+                .first()
+            )
+            if collaborator is not None:
+                raise WorkOrderApplicantAlreadyEditorError(
+                    "applicant already has Bot editor access"
+                )
+
+            pending_candidates = (
+                db.query(self._WorkOrder.biz_data)
+                .filter(
+                    self._WorkOrder.biz_type == WorkOrderBizType.BOT_COLLABORATOR.value,
+                    self._WorkOrder.biz_id == bot_id,
+                    self._WorkOrder.applicant_user_id == applicant_user_id,
+                    self._WorkOrder.status == WorkOrderStatus.PENDING.value,
+                    self._WorkOrder.env == env,
+                )
+                .all()
+            )
+            if any(
+                _bot_pk_from_business_data(raw_data) == bot_pk
+                for (raw_data,) in pending_candidates
+            ):
+                raise WorkOrderAlreadyPendingError("pending request already exists")
+
+            title = WorkOrderMessageTitle.BOT_COLLABORATOR_PENDING.value
+            content = WorkOrderMessageContent.BOT_COLLABORATOR_PENDING.value.format(
+                applicant_name=applicant_name,
+                bot_name=bot_name,
+            )
+            row = self._WorkOrder(
+                work_order_no=self._new_no(),
+                biz_type=WorkOrderBizType.BOT_COLLABORATOR.value,
+                biz_id=bot_id,
+                biz_data=json.dumps(
+                    {
+                        "bot_pk": bot_pk,
+                        "bot_id": bot_id,
+                        "bot_name": bot_name,
+                        "owner_id": owner_id,
+                        "space_id": space_id,
+                        "applicant_name": applicant_name,
+                        "requested_role": CollaboratorRole.MEMBER.value,
+                        "display_title": {
+                            WorkOrderStatus.PENDING.value: title,
+                            WorkOrderStatus.APPROVED.value: WorkOrderMessageTitle.BOT_COLLABORATOR_APPROVED.value,
+                            WorkOrderStatus.REJECTED.value: WorkOrderMessageTitle.BOT_COLLABORATOR_REJECTED.value,
+                        },
+                        "display_content": {
+                            WorkOrderStatus.PENDING.value: content,
+                            WorkOrderStatus.APPROVED.value: WorkOrderMessageContent.BOT_COLLABORATOR_APPROVED.value.format(
+                                bot_name=bot_name
+                            ),
+                        },
+                    },
+                    ensure_ascii=False,
+                ),
+                applicant_user_id=applicant_user_id,
+                apply_reason=apply_reason,
+                status=WorkOrderStatus.PENDING.value,
+                env=env,
+            )
+            db.add(row)
+            db.flush()
+            db.add(
+                self._Approver(
+                    work_order_id=row.id,
+                    approver_user_id=owner_id,
+                    status=WorkOrderApproverStatus.PENDING.value,
+                    env=env,
+                )
+            )
+            db.add(
+                self._Notification(
+                    work_order_id=row.id,
+                    recipient_user_id=owner_id,
+                    notification_category=NotificationCategory.APPROVAL.value,
+                    event_type=WorkOrderEventType.BOT_COLLABORATOR_APPLIED.value,
+                    biz_type=WorkOrderBizType.BOT_COLLABORATOR.value,
+                    biz_id=bot_id,
+                    title=title,
+                    content=content,
+                    env=env,
+                )
+            )
+            db.flush()
+            db.refresh(row)
+            return row.to_record()
+
+    def review_bot_editor_request(
+        self,
+        *,
+        work_order_id: int,
+        reviewer_user_id: str,
+        review_remark: str | None,
+        target_status: WorkOrderStatus,
+        notification: WorkOrderNotificationDraft,
+        env: str,
+    ):
+        reviewed_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        with self._db.transactional_orm_session() as db:
+            work_order = (
+                db.query(self._WorkOrder)
+                .filter(
+                    self._WorkOrder.id == work_order_id,
+                    self._WorkOrder.biz_type == WorkOrderBizType.BOT_COLLABORATOR.value,
+                    self._WorkOrder.env == env,
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if work_order is None:
+                raise WorkOrderNotFoundError("Bot editor work order not found")
+            if work_order.status != WorkOrderStatus.PENDING.value:
+                raise WorkOrderAlreadyProcessedError("work order already processed")
+
+            try:
+                data = json.loads(work_order.biz_data or "{}")
+                bot_pk = int(data["bot_pk"])
+                bot_id = str(data["bot_id"])
+                owner_id = str(data["owner_id"])
+                space_id = int(data["space_id"])
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+                raise WorkOrderBotEditorRequestNotAllowedError(
+                    "work-order Bot identity is invalid"
+                ) from exc
+            if reviewer_user_id != owner_id:
+                raise WorkOrderAccessDeniedError("Bot owner role required")
+
+            approver = (
+                db.query(self._Approver)
+                .filter(
+                    self._Approver.work_order_id == work_order_id,
+                    self._Approver.approver_user_id == reviewer_user_id,
+                    self._Approver.status == WorkOrderApproverStatus.PENDING.value,
+                    self._Approver.env == env,
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if approver is None:
+                raise WorkOrderAccessDeniedError("current user is not an approver")
+
+            bot = (
+                db.query(self._Bot)
+                .filter(
+                    self._Bot.id == bot_pk,
+                    self._Bot.bot_id == bot_id,
+                    self._Bot.owner_id == owner_id,
+                    self._Bot.space_id == space_id,
+                    self._Bot.env == env,
+                    self._Bot.is_delete == 0,
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if bot is None:
+                raise WorkOrderNotFoundError("work-order Bot not found")
+
+            if target_status is WorkOrderStatus.APPROVED:
+                active_member = (
+                    db.query(self._Member.id)
+                    .filter(
+                        self._Member.space_id == space_id,
+                        self._Member.user_id == work_order.applicant_user_id,
+                        self._Member.status == "ACTIVE",
+                        self._Member.env == env,
+                    )
+                    .first()
+                )
+                if active_member is None:
+                    raise WorkOrderBotEditorRequestNotAllowedError(
+                        "applicant is no longer an active Team Space member"
+                    )
+                existing = (
+                    db.query(self._Collaborator.id)
+                    .filter(
+                        self._Collaborator.bot_pk == bot_pk,
+                        self._Collaborator.user_id == work_order.applicant_user_id,
+                        self._Collaborator.env == env,
+                    )
+                    .first()
+                )
+                if existing is None:
+                    db.add(
+                        self._Collaborator(
+                            bot_pk=bot_pk,
+                            bot_id=bot_id,
+                            owner_id=owner_id,
+                            user_id=work_order.applicant_user_id,
+                            user_name=work_order.applicant_user_id,
+                            role=CollaboratorRole.MEMBER.value,
+                            operator_id=reviewer_user_id,
+                            env=env,
+                        )
+                    )
+
+            work_order.status = target_status.value
+            work_order.reviewer_user_id = reviewer_user_id
+            work_order.review_remark = review_remark
+            work_order.reviewed_at = reviewed_at
+            work_order.gmt_modified = reviewed_at
+            approver.status = target_status.value
+            approver.review_remark = review_remark
+            approver.reviewed_at = reviewed_at
+            approver.gmt_modified = reviewed_at
+            db.add(
+                self._Notification(
+                    work_order_id=work_order_id,
+                    recipient_user_id=notification.recipient_user_id,
+                    notification_category=notification.notification_category.value,
+                    event_type=getattr(
+                        notification.event_type, "value", notification.event_type
+                    ),
+                    biz_type=getattr(
+                        notification.biz_type, "value", notification.biz_type
+                    ),
+                    biz_id=notification.biz_id,
+                    title=notification.title,
+                    content=notification.content,
+                    env=env,
+                )
+            )
+            db.query(self._Notification).filter(
+                self._Notification.work_order_id == work_order_id,
+                self._Notification.notification_category
+                == NotificationCategory.APPROVAL.value,
+                self._Notification.env == env,
+            ).update(
+                {self._Notification.gmt_modified: reviewed_at},
+                synchronize_session=False,
+            )
+            try:
+                db.flush()
+            except IntegrityError as exc:
+                raise WorkOrderApplicantAlreadyEditorError(
+                    "unable to create approved Bot editor relation"
+                ) from exc
+            return WorkOrderReviewResult(
+                work_order_id=work_order_id,
+                status=target_status,
+                decision=WorkOrderDecision(target_status.value),
+                reviewer_user_id=reviewer_user_id,
+                review_remark=review_remark,
+                reviewed_at=reviewed_at,
+            )
+
+
+def _bot_pk_from_business_data(raw: str | None) -> int | None:
+    try:
+        data = json.loads(raw or "{}")
+        return int(data["bot_pk"])
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
@@ -10,6 +10,10 @@ from injector import inject
 from sqlalchemy import and_, func, or_
 from sqlalchemy.exc import IntegrityError
 
+from agentclaw.community.core.bot_collaborator.models import (
+    BotCollaboratorModel,
+    CollaboratorRole,
+)
 from agentclaw.community.core.repository.protocols.work_orders import (
     WorkOrderRepositoryProtocol,
 )
@@ -22,7 +26,9 @@ from agentclaw.community.core.work_orders.errors import (
     WorkOrderAlreadyPendingError,
     WorkOrderAccessDeniedError,
     WorkOrderAlreadyProcessedError,
+    WorkOrderApplicantAlreadyEditorError,
     WorkOrderApplicantAlreadyMemberError,
+    WorkOrderBotEditorRequestNotAllowedError,
     WorkOrderNoReviewerError,
     WorkOrderNotFoundError,
 )
@@ -50,6 +56,7 @@ from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
 )
 from agentclaw.community.plugin_api.database import DatabasePlugin
+from agentclaw.community.plugin_api.models import BotModel
 
 
 _ADMINISTRATOR_ROLE = "ADMINISTRATOR"
@@ -64,6 +71,8 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
         self._Approver = WorkOrderApproverModel
         self._Space = SpaceModel
         self._Member = SpaceMemberModel
+        self._Bot = BotModel
+        self._Collaborator = BotCollaboratorModel
 
     @staticmethod
     def _new_no() -> str:
@@ -338,6 +347,148 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
             db.refresh(row)
             return row.to_record()
 
+    def create_bot_editor_request(
+        self,
+        *,
+        bot_pk: int,
+        bot_id: str,
+        bot_name: str,
+        owner_id: str,
+        space_id: int,
+        applicant_user_id: str,
+        applicant_name: str,
+        apply_reason: str,
+        env: str,
+    ):
+        with self._db.transactional_orm_session() as db:
+            # Serializing on the Bot prevents concurrent requests from creating
+            # more than one pending application for the same applicant.
+            bot = (
+                db.query(self._Bot)
+                .filter(
+                    self._Bot.id == bot_pk,
+                    self._Bot.bot_id == bot_id,
+                    self._Bot.owner_id == owner_id,
+                    self._Bot.space_id == space_id,
+                    self._Bot.env == env,
+                    self._Bot.is_delete == 0,
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if bot is None:
+                raise WorkOrderNotFoundError("Bot not found during request creation")
+
+            member = (
+                db.query(self._Member.id)
+                .filter(
+                    self._Member.space_id == space_id,
+                    self._Member.user_id == applicant_user_id,
+                    self._Member.status == "ACTIVE",
+                    self._Member.env == env,
+                )
+                .first()
+            )
+            if member is None:
+                raise WorkOrderAccessDeniedError(
+                    "applicant must be an active Team Space member"
+                )
+
+            collaborator = (
+                db.query(self._Collaborator.id)
+                .filter(
+                    self._Collaborator.bot_pk == bot_pk,
+                    self._Collaborator.user_id == applicant_user_id,
+                    self._Collaborator.env == env,
+                )
+                .first()
+            )
+            if collaborator is not None:
+                raise WorkOrderApplicantAlreadyEditorError(
+                    "applicant already has Bot editor access"
+                )
+
+            pending_candidates = (
+                db.query(self._WorkOrder.biz_data)
+                .filter(
+                    self._WorkOrder.biz_type == WorkOrderBizType.BOT_COLLABORATOR.value,
+                    self._WorkOrder.biz_id == bot_id,
+                    self._WorkOrder.applicant_user_id == applicant_user_id,
+                    self._WorkOrder.status == WorkOrderStatus.PENDING.value,
+                    self._WorkOrder.env == env,
+                )
+                .all()
+            )
+            if any(
+                _bot_pk_from_business_data(raw_data) == bot_pk
+                for (raw_data,) in pending_candidates
+            ):
+                raise WorkOrderAlreadyPendingError("pending request already exists")
+
+            title = WorkOrderMessageTitle.BOT_COLLABORATOR_PENDING.value
+            content = WorkOrderMessageContent.BOT_COLLABORATOR_PENDING.value.format(
+                applicant_name=applicant_name,
+                bot_name=bot_name,
+            )
+            row = self._WorkOrder(
+                work_order_no=self._new_no(),
+                biz_type=WorkOrderBizType.BOT_COLLABORATOR.value,
+                biz_id=bot_id,
+                biz_data=json.dumps(
+                    {
+                        "bot_pk": bot_pk,
+                        "bot_id": bot_id,
+                        "bot_name": bot_name,
+                        "owner_id": owner_id,
+                        "space_id": space_id,
+                        "applicant_name": applicant_name,
+                        "requested_role": CollaboratorRole.MEMBER.value,
+                        "display_title": {
+                            WorkOrderStatus.PENDING.value: title,
+                            WorkOrderStatus.APPROVED.value: WorkOrderMessageTitle.BOT_COLLABORATOR_APPROVED.value,
+                            WorkOrderStatus.REJECTED.value: WorkOrderMessageTitle.BOT_COLLABORATOR_REJECTED.value,
+                        },
+                        "display_content": {
+                            WorkOrderStatus.PENDING.value: content,
+                            WorkOrderStatus.APPROVED.value: WorkOrderMessageContent.BOT_COLLABORATOR_APPROVED.value.format(
+                                bot_name=bot_name
+                            ),
+                        },
+                    },
+                    ensure_ascii=False,
+                ),
+                applicant_user_id=applicant_user_id,
+                apply_reason=apply_reason,
+                status=WorkOrderStatus.PENDING.value,
+                env=env,
+            )
+            db.add(row)
+            db.flush()
+            db.add(
+                self._Approver(
+                    work_order_id=row.id,
+                    approver_user_id=owner_id,
+                    status=WorkOrderApproverStatus.PENDING.value,
+                    env=env,
+                )
+            )
+            db.add(
+                self._Notification(
+                    work_order_id=row.id,
+                    recipient_user_id=owner_id,
+                    notification_category=NotificationCategory.APPROVAL.value,
+                    event_type=WorkOrderEventType.BOT_COLLABORATOR_APPLIED.value,
+                    biz_type=WorkOrderBizType.BOT_COLLABORATOR.value,
+                    biz_id=bot_id,
+                    title=title,
+                    content=content,
+                    env=env,
+                )
+            )
+            db.flush()
+            db.refresh(row)
+            return row.to_record()
+
     def list_items(
         self,
         *,
@@ -345,6 +496,8 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
         env: str,
         query_type: WorkOrderQueryType,
         item_type: WorkOrderItemType,
+        biz_type: str | None = None,
+        biz_id: str | None = None,
         offset: int,
         limit: int,
     ):
@@ -426,6 +579,11 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                     query = query.filter(
                         self._Notification.notification_category == item_type.value
                     )
+
+            if biz_type is not None:
+                query = query.filter(self._WorkOrder.biz_type == biz_type)
+            if biz_id is not None:
+                query = query.filter(self._WorkOrder.biz_id == biz_id)
 
             total = query.count()
             rows = (
@@ -717,6 +875,164 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                 reviewed_at=reviewed_at,
             )
 
+    def review_bot_editor_request(
+        self,
+        *,
+        work_order_id: int,
+        reviewer_user_id: str,
+        review_remark: str | None,
+        target_status: WorkOrderStatus,
+        notification: WorkOrderNotificationDraft,
+        env: str,
+    ):
+        reviewed_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        with self._db.transactional_orm_session() as db:
+            work_order = (
+                db.query(self._WorkOrder)
+                .filter(
+                    self._WorkOrder.id == work_order_id,
+                    self._WorkOrder.biz_type == WorkOrderBizType.BOT_COLLABORATOR.value,
+                    self._WorkOrder.env == env,
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if work_order is None:
+                raise WorkOrderNotFoundError("Bot editor work order not found")
+            if work_order.status != WorkOrderStatus.PENDING.value:
+                raise WorkOrderAlreadyProcessedError("work order already processed")
+
+            try:
+                data = json.loads(work_order.biz_data or "{}")
+                bot_pk = int(data["bot_pk"])
+                bot_id = str(data["bot_id"])
+                owner_id = str(data["owner_id"])
+                space_id = int(data["space_id"])
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+                raise WorkOrderBotEditorRequestNotAllowedError(
+                    "work-order Bot identity is invalid"
+                ) from exc
+            if reviewer_user_id != owner_id:
+                raise WorkOrderAccessDeniedError("Bot owner role required")
+
+            approver = (
+                db.query(self._Approver)
+                .filter(
+                    self._Approver.work_order_id == work_order_id,
+                    self._Approver.approver_user_id == reviewer_user_id,
+                    self._Approver.status == WorkOrderApproverStatus.PENDING.value,
+                    self._Approver.env == env,
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if approver is None:
+                raise WorkOrderAccessDeniedError("current user is not an approver")
+
+            bot = (
+                db.query(self._Bot)
+                .filter(
+                    self._Bot.id == bot_pk,
+                    self._Bot.bot_id == bot_id,
+                    self._Bot.owner_id == owner_id,
+                    self._Bot.space_id == space_id,
+                    self._Bot.env == env,
+                    self._Bot.is_delete == 0,
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if bot is None:
+                raise WorkOrderNotFoundError("work-order Bot not found")
+
+            if target_status is WorkOrderStatus.APPROVED:
+                active_member = (
+                    db.query(self._Member.id)
+                    .filter(
+                        self._Member.space_id == space_id,
+                        self._Member.user_id == work_order.applicant_user_id,
+                        self._Member.status == "ACTIVE",
+                        self._Member.env == env,
+                    )
+                    .first()
+                )
+                if active_member is None:
+                    raise WorkOrderBotEditorRequestNotAllowedError(
+                        "applicant is no longer an active Team Space member"
+                    )
+                existing = (
+                    db.query(self._Collaborator.id)
+                    .filter(
+                        self._Collaborator.bot_pk == bot_pk,
+                        self._Collaborator.user_id == work_order.applicant_user_id,
+                        self._Collaborator.env == env,
+                    )
+                    .first()
+                )
+                if existing is None:
+                    db.add(
+                        self._Collaborator(
+                            bot_pk=bot_pk,
+                            bot_id=bot_id,
+                            owner_id=owner_id,
+                            user_id=work_order.applicant_user_id,
+                            user_name=work_order.applicant_user_id,
+                            role=CollaboratorRole.MEMBER.value,
+                            operator_id=reviewer_user_id,
+                            env=env,
+                        )
+                    )
+
+            work_order.status = target_status.value
+            work_order.reviewer_user_id = reviewer_user_id
+            work_order.review_remark = review_remark
+            work_order.reviewed_at = reviewed_at
+            work_order.gmt_modified = reviewed_at
+            approver.status = target_status.value
+            approver.review_remark = review_remark
+            approver.reviewed_at = reviewed_at
+            approver.gmt_modified = reviewed_at
+            db.add(
+                self._Notification(
+                    work_order_id=work_order_id,
+                    recipient_user_id=notification.recipient_user_id,
+                    notification_category=notification.notification_category.value,
+                    event_type=getattr(
+                        notification.event_type, "value", notification.event_type
+                    ),
+                    biz_type=getattr(
+                        notification.biz_type, "value", notification.biz_type
+                    ),
+                    biz_id=notification.biz_id,
+                    title=notification.title,
+                    content=notification.content,
+                    env=env,
+                )
+            )
+            db.query(self._Notification).filter(
+                self._Notification.work_order_id == work_order_id,
+                self._Notification.notification_category
+                == NotificationCategory.APPROVAL.value,
+                self._Notification.env == env,
+            ).update(
+                {self._Notification.gmt_modified: reviewed_at},
+                synchronize_session=False,
+            )
+            try:
+                db.flush()
+            except IntegrityError as exc:
+                raise WorkOrderApplicantAlreadyEditorError(
+                    "unable to create approved Bot editor relation"
+                ) from exc
+            return WorkOrderReviewResult(
+                work_order_id=work_order_id,
+                status=target_status,
+                decision=WorkOrderDecision(target_status.value),
+                reviewer_user_id=reviewer_user_id,
+                review_remark=review_remark,
+                reviewed_at=reviewed_at,
+            )
+
     def get_notification(
         self,
         *,
@@ -904,3 +1220,11 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                     synchronize_session=False,
                 )
             )
+
+
+def _bot_pk_from_business_data(raw: str | None) -> int | None:
+    try:
+        data = json.loads(raw or "{}")
+        return int(data["bot_pk"])
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
@@ -11,7 +11,7 @@ from sqlalchemy import and_, func, or_
 from sqlalchemy.exc import IntegrityError
 
 from agentclaw.community.core.repository.implementations.work_orders.bot_editor import (
-    BotEditorWorkOrderRepository,
+    _BotEditorWorkOrderRepository,
 )
 from agentclaw.community.core.repository.protocols.work_orders import (
     WorkOrderRepositoryProtocol,
@@ -67,7 +67,7 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
         self._Approver = WorkOrderApproverModel
         self._Space = SpaceModel
         self._Member = SpaceMemberModel
-        self._bot_editor = BotEditorWorkOrderRepository(db)
+        self._bot_editor = _BotEditorWorkOrderRepository(db)
 
     @staticmethod
     def _new_no() -> str:

--- a/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/work_orders/work_order.py
@@ -10,9 +10,8 @@ from injector import inject
 from sqlalchemy import and_, func, or_
 from sqlalchemy.exc import IntegrityError
 
-from agentclaw.community.core.bot_collaborator.models import (
-    BotCollaboratorModel,
-    CollaboratorRole,
+from agentclaw.community.core.repository.implementations.work_orders.bot_editor import (
+    BotEditorWorkOrderRepository,
 )
 from agentclaw.community.core.repository.protocols.work_orders import (
     WorkOrderRepositoryProtocol,
@@ -26,9 +25,7 @@ from agentclaw.community.core.work_orders.errors import (
     WorkOrderAlreadyPendingError,
     WorkOrderAccessDeniedError,
     WorkOrderAlreadyProcessedError,
-    WorkOrderApplicantAlreadyEditorError,
     WorkOrderApplicantAlreadyMemberError,
-    WorkOrderBotEditorRequestNotAllowedError,
     WorkOrderNoReviewerError,
     WorkOrderNotFoundError,
 )
@@ -56,7 +53,6 @@ from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
 )
 from agentclaw.community.plugin_api.database import DatabasePlugin
-from agentclaw.community.plugin_api.models import BotModel
 
 
 _ADMINISTRATOR_ROLE = "ADMINISTRATOR"
@@ -71,8 +67,7 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
         self._Approver = WorkOrderApproverModel
         self._Space = SpaceModel
         self._Member = SpaceMemberModel
-        self._Bot = BotModel
-        self._Collaborator = BotCollaboratorModel
+        self._bot_editor = BotEditorWorkOrderRepository(db)
 
     @staticmethod
     def _new_no() -> str:
@@ -360,134 +355,17 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
         apply_reason: str,
         env: str,
     ):
-        with self._db.transactional_orm_session() as db:
-            # Serializing on the Bot prevents concurrent requests from creating
-            # more than one pending application for the same applicant.
-            bot = (
-                db.query(self._Bot)
-                .filter(
-                    self._Bot.id == bot_pk,
-                    self._Bot.bot_id == bot_id,
-                    self._Bot.owner_id == owner_id,
-                    self._Bot.space_id == space_id,
-                    self._Bot.env == env,
-                    self._Bot.is_delete == 0,
-                )
-                .with_for_update()
-                .one_or_none()
-            )
-            if bot is None:
-                raise WorkOrderNotFoundError("Bot not found during request creation")
-
-            member = (
-                db.query(self._Member.id)
-                .filter(
-                    self._Member.space_id == space_id,
-                    self._Member.user_id == applicant_user_id,
-                    self._Member.status == "ACTIVE",
-                    self._Member.env == env,
-                )
-                .first()
-            )
-            if member is None:
-                raise WorkOrderAccessDeniedError(
-                    "applicant must be an active Team Space member"
-                )
-
-            collaborator = (
-                db.query(self._Collaborator.id)
-                .filter(
-                    self._Collaborator.bot_pk == bot_pk,
-                    self._Collaborator.user_id == applicant_user_id,
-                    self._Collaborator.env == env,
-                )
-                .first()
-            )
-            if collaborator is not None:
-                raise WorkOrderApplicantAlreadyEditorError(
-                    "applicant already has Bot editor access"
-                )
-
-            pending_candidates = (
-                db.query(self._WorkOrder.biz_data)
-                .filter(
-                    self._WorkOrder.biz_type == WorkOrderBizType.BOT_COLLABORATOR.value,
-                    self._WorkOrder.biz_id == bot_id,
-                    self._WorkOrder.applicant_user_id == applicant_user_id,
-                    self._WorkOrder.status == WorkOrderStatus.PENDING.value,
-                    self._WorkOrder.env == env,
-                )
-                .all()
-            )
-            if any(
-                _bot_pk_from_business_data(raw_data) == bot_pk
-                for (raw_data,) in pending_candidates
-            ):
-                raise WorkOrderAlreadyPendingError("pending request already exists")
-
-            title = WorkOrderMessageTitle.BOT_COLLABORATOR_PENDING.value
-            content = WorkOrderMessageContent.BOT_COLLABORATOR_PENDING.value.format(
-                applicant_name=applicant_name,
-                bot_name=bot_name,
-            )
-            row = self._WorkOrder(
-                work_order_no=self._new_no(),
-                biz_type=WorkOrderBizType.BOT_COLLABORATOR.value,
-                biz_id=bot_id,
-                biz_data=json.dumps(
-                    {
-                        "bot_pk": bot_pk,
-                        "bot_id": bot_id,
-                        "bot_name": bot_name,
-                        "owner_id": owner_id,
-                        "space_id": space_id,
-                        "applicant_name": applicant_name,
-                        "requested_role": CollaboratorRole.MEMBER.value,
-                        "display_title": {
-                            WorkOrderStatus.PENDING.value: title,
-                            WorkOrderStatus.APPROVED.value: WorkOrderMessageTitle.BOT_COLLABORATOR_APPROVED.value,
-                            WorkOrderStatus.REJECTED.value: WorkOrderMessageTitle.BOT_COLLABORATOR_REJECTED.value,
-                        },
-                        "display_content": {
-                            WorkOrderStatus.PENDING.value: content,
-                            WorkOrderStatus.APPROVED.value: WorkOrderMessageContent.BOT_COLLABORATOR_APPROVED.value.format(
-                                bot_name=bot_name
-                            ),
-                        },
-                    },
-                    ensure_ascii=False,
-                ),
-                applicant_user_id=applicant_user_id,
-                apply_reason=apply_reason,
-                status=WorkOrderStatus.PENDING.value,
-                env=env,
-            )
-            db.add(row)
-            db.flush()
-            db.add(
-                self._Approver(
-                    work_order_id=row.id,
-                    approver_user_id=owner_id,
-                    status=WorkOrderApproverStatus.PENDING.value,
-                    env=env,
-                )
-            )
-            db.add(
-                self._Notification(
-                    work_order_id=row.id,
-                    recipient_user_id=owner_id,
-                    notification_category=NotificationCategory.APPROVAL.value,
-                    event_type=WorkOrderEventType.BOT_COLLABORATOR_APPLIED.value,
-                    biz_type=WorkOrderBizType.BOT_COLLABORATOR.value,
-                    biz_id=bot_id,
-                    title=title,
-                    content=content,
-                    env=env,
-                )
-            )
-            db.flush()
-            db.refresh(row)
-            return row.to_record()
+        return self._bot_editor.create_bot_editor_request(
+            bot_pk=bot_pk,
+            bot_id=bot_id,
+            bot_name=bot_name,
+            owner_id=owner_id,
+            space_id=space_id,
+            applicant_user_id=applicant_user_id,
+            applicant_name=applicant_name,
+            apply_reason=apply_reason,
+            env=env,
+        )
 
     def list_items(
         self,
@@ -885,153 +763,14 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
         notification: WorkOrderNotificationDraft,
         env: str,
     ):
-        reviewed_at = datetime.now(timezone.utc).replace(tzinfo=None)
-        with self._db.transactional_orm_session() as db:
-            work_order = (
-                db.query(self._WorkOrder)
-                .filter(
-                    self._WorkOrder.id == work_order_id,
-                    self._WorkOrder.biz_type == WorkOrderBizType.BOT_COLLABORATOR.value,
-                    self._WorkOrder.env == env,
-                )
-                .with_for_update()
-                .one_or_none()
-            )
-            if work_order is None:
-                raise WorkOrderNotFoundError("Bot editor work order not found")
-            if work_order.status != WorkOrderStatus.PENDING.value:
-                raise WorkOrderAlreadyProcessedError("work order already processed")
-
-            try:
-                data = json.loads(work_order.biz_data or "{}")
-                bot_pk = int(data["bot_pk"])
-                bot_id = str(data["bot_id"])
-                owner_id = str(data["owner_id"])
-                space_id = int(data["space_id"])
-            except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
-                raise WorkOrderBotEditorRequestNotAllowedError(
-                    "work-order Bot identity is invalid"
-                ) from exc
-            if reviewer_user_id != owner_id:
-                raise WorkOrderAccessDeniedError("Bot owner role required")
-
-            approver = (
-                db.query(self._Approver)
-                .filter(
-                    self._Approver.work_order_id == work_order_id,
-                    self._Approver.approver_user_id == reviewer_user_id,
-                    self._Approver.status == WorkOrderApproverStatus.PENDING.value,
-                    self._Approver.env == env,
-                )
-                .with_for_update()
-                .one_or_none()
-            )
-            if approver is None:
-                raise WorkOrderAccessDeniedError("current user is not an approver")
-
-            bot = (
-                db.query(self._Bot)
-                .filter(
-                    self._Bot.id == bot_pk,
-                    self._Bot.bot_id == bot_id,
-                    self._Bot.owner_id == owner_id,
-                    self._Bot.space_id == space_id,
-                    self._Bot.env == env,
-                    self._Bot.is_delete == 0,
-                )
-                .with_for_update()
-                .one_or_none()
-            )
-            if bot is None:
-                raise WorkOrderNotFoundError("work-order Bot not found")
-
-            if target_status is WorkOrderStatus.APPROVED:
-                active_member = (
-                    db.query(self._Member.id)
-                    .filter(
-                        self._Member.space_id == space_id,
-                        self._Member.user_id == work_order.applicant_user_id,
-                        self._Member.status == "ACTIVE",
-                        self._Member.env == env,
-                    )
-                    .first()
-                )
-                if active_member is None:
-                    raise WorkOrderBotEditorRequestNotAllowedError(
-                        "applicant is no longer an active Team Space member"
-                    )
-                existing = (
-                    db.query(self._Collaborator.id)
-                    .filter(
-                        self._Collaborator.bot_pk == bot_pk,
-                        self._Collaborator.user_id == work_order.applicant_user_id,
-                        self._Collaborator.env == env,
-                    )
-                    .first()
-                )
-                if existing is None:
-                    db.add(
-                        self._Collaborator(
-                            bot_pk=bot_pk,
-                            bot_id=bot_id,
-                            owner_id=owner_id,
-                            user_id=work_order.applicant_user_id,
-                            user_name=work_order.applicant_user_id,
-                            role=CollaboratorRole.MEMBER.value,
-                            operator_id=reviewer_user_id,
-                            env=env,
-                        )
-                    )
-
-            work_order.status = target_status.value
-            work_order.reviewer_user_id = reviewer_user_id
-            work_order.review_remark = review_remark
-            work_order.reviewed_at = reviewed_at
-            work_order.gmt_modified = reviewed_at
-            approver.status = target_status.value
-            approver.review_remark = review_remark
-            approver.reviewed_at = reviewed_at
-            approver.gmt_modified = reviewed_at
-            db.add(
-                self._Notification(
-                    work_order_id=work_order_id,
-                    recipient_user_id=notification.recipient_user_id,
-                    notification_category=notification.notification_category.value,
-                    event_type=getattr(
-                        notification.event_type, "value", notification.event_type
-                    ),
-                    biz_type=getattr(
-                        notification.biz_type, "value", notification.biz_type
-                    ),
-                    biz_id=notification.biz_id,
-                    title=notification.title,
-                    content=notification.content,
-                    env=env,
-                )
-            )
-            db.query(self._Notification).filter(
-                self._Notification.work_order_id == work_order_id,
-                self._Notification.notification_category
-                == NotificationCategory.APPROVAL.value,
-                self._Notification.env == env,
-            ).update(
-                {self._Notification.gmt_modified: reviewed_at},
-                synchronize_session=False,
-            )
-            try:
-                db.flush()
-            except IntegrityError as exc:
-                raise WorkOrderApplicantAlreadyEditorError(
-                    "unable to create approved Bot editor relation"
-                ) from exc
-            return WorkOrderReviewResult(
-                work_order_id=work_order_id,
-                status=target_status,
-                decision=WorkOrderDecision(target_status.value),
-                reviewer_user_id=reviewer_user_id,
-                review_remark=review_remark,
-                reviewed_at=reviewed_at,
-            )
+        return self._bot_editor.review_bot_editor_request(
+            work_order_id=work_order_id,
+            reviewer_user_id=reviewer_user_id,
+            review_remark=review_remark,
+            target_status=target_status,
+            notification=notification,
+            env=env,
+        )
 
     def get_notification(
         self,
@@ -1220,11 +959,3 @@ class WorkOrderRepository(WorkOrderRepositoryProtocol):
                     synchronize_session=False,
                 )
             )
-
-
-def _bot_pk_from_business_data(raw: str | None) -> int | None:
-    try:
-        data = json.loads(raw or "{}")
-        return int(data["bot_pk"])
-    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
-        return None

--- a/src/backend/src/agentclaw/community/core/repository/protocols/work_orders.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/work_orders.py
@@ -60,6 +60,21 @@ class WorkOrderRepositoryProtocol(Protocol):
     ) -> WorkOrderRecord: ...
 
     @abstractmethod
+    def create_bot_editor_request(
+        self,
+        *,
+        bot_pk: int,
+        bot_id: str,
+        bot_name: str,
+        owner_id: str,
+        space_id: int,
+        applicant_user_id: str,
+        applicant_name: str,
+        apply_reason: str,
+        env: str,
+    ) -> WorkOrderRecord: ...
+
+    @abstractmethod
     def list_items(
         self,
         *,
@@ -67,6 +82,8 @@ class WorkOrderRepositoryProtocol(Protocol):
         env: str,
         query_type: WorkOrderQueryType,
         item_type: WorkOrderItemType,
+        biz_type: str | None = None,
+        biz_id: str | None = None,
         offset: int,
         limit: int,
     ) -> tuple[int, list[WorkOrderListItem]]: ...
@@ -78,6 +95,18 @@ class WorkOrderRepositoryProtocol(Protocol):
 
     @abstractmethod
     def review_space_join(
+        self,
+        *,
+        work_order_id: int,
+        reviewer_user_id: str,
+        review_remark: str | None,
+        target_status: WorkOrderStatus,
+        notification: WorkOrderNotificationDraft,
+        env: str,
+    ) -> WorkOrderReviewResult: ...
+
+    @abstractmethod
+    def review_bot_editor_request(
         self,
         *,
         work_order_id: int,

--- a/src/backend/src/agentclaw/community/core/work_orders/errors.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/errors.py
@@ -37,7 +37,15 @@ class WorkOrderApplicantAlreadyMemberError(WorkOrderError):
     pass
 
 
+class WorkOrderApplicantAlreadyEditorError(WorkOrderError):
+    pass
+
+
 class WorkOrderJoinNotAllowedError(WorkOrderError):
+    pass
+
+
+class WorkOrderBotEditorRequestNotAllowedError(WorkOrderError):
     pass
 
 

--- a/src/backend/src/agentclaw/community/core/work_orders/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/models.py
@@ -28,6 +28,7 @@ class WorkOrderApproverStatus(StrEnum):
 
 class WorkOrderBizType(StrEnum):
     SPACE_JOIN = "SPACE_JOIN"
+    BOT_COLLABORATOR = "BOT_COLLABORATOR"
 
 
 class NotificationCategory(StrEnum):
@@ -106,6 +107,9 @@ class WorkOrderMessageTitle(StrEnum):
     SPACE_JOIN_APPROVED = "空间加入申请已通过"
     SPACE_JOIN_REJECTED = "空间加入申请未通过"
     SPACE_MEMBER_ADDED = "你已被添加到空间"
+    BOT_COLLABORATOR_PENDING = "Bot 共同编辑申请待审批"
+    BOT_COLLABORATOR_APPROVED = "Bot 共同编辑申请已通过"
+    BOT_COLLABORATOR_REJECTED = "Bot 共同编辑申请未通过"
 
 
 class WorkOrderMessageContent(StrEnum):
@@ -117,6 +121,13 @@ class WorkOrderMessageContent(StrEnum):
         "你加入空间「{space_name}」的申请未通过。拒绝原因：{review_remark}"
     )
     SPACE_MEMBER_ADDED = "你已被添加到空间「{space_name}」。"
+    BOT_COLLABORATOR_PENDING = (
+        "用户「{applicant_name}」申请共同编辑 Bot「{bot_name}」，请及时处理。"
+    )
+    BOT_COLLABORATOR_APPROVED = "你共同编辑 Bot「{bot_name}」的申请已通过。"
+    BOT_COLLABORATOR_REJECTED = (
+        "你共同编辑 Bot「{bot_name}」的申请未通过。拒绝原因：{review_remark}"
+    )
 
 
 class WorkOrderApproverRecord(BaseModel):

--- a/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/services/work_order_service.py
@@ -2,20 +2,37 @@
 
 from __future__ import annotations
 
+import json
+
 from injector import inject
 
+from agentclaw.community.core.bot_collaborator.protocols import (
+    CollaboratorServiceProtocol,
+)
+from agentclaw.community.core.bot_collaborator.services.member_management_capability import (
+    MemberManagementCapabilityService,
+)
+from agentclaw.community.core.repository.protocols.bot import (
+    BotRepository,
+    CollaboratorRepositoryProtocol,
+)
 from agentclaw.community.core.repository.protocols.spaces import SpaceRepositoryProtocol
 from agentclaw.community.core.repository.protocols.work_orders import (
     WorkOrderRepositoryProtocol,
 )
-from agentclaw.community.core.spaces.errors import SpaceAccessDeniedError
+from agentclaw.community.core.spaces.errors import (
+    SpaceAccessDeniedError,
+    SpaceNotFoundError,
+)
 from agentclaw.community.core.spaces.models import SpaceType
 from agentclaw.community.core.spaces.services.space_access_service import (
     SpaceAccessService,
 )
 from agentclaw.community.core.work_orders.errors import (
     WorkOrderAccessDeniedError,
+    WorkOrderApplicantAlreadyEditorError,
     WorkOrderApplicantAlreadyMemberError,
+    WorkOrderBotEditorRequestNotAllowedError,
     WorkOrderInvalidReasonError,
     WorkOrderInvalidRemarkError,
     WorkOrderJoinNotAllowedError,
@@ -25,6 +42,8 @@ from agentclaw.community.core.work_orders.errors import (
 )
 from agentclaw.community.core.work_orders.models import (
     EVENT_CATEGORIES,
+    NotificationCategory,
+    WorkOrderBizType,
     WorkOrderDetail,
     WorkOrderEventType,
     WorkOrderItemType,
@@ -46,11 +65,19 @@ class WorkOrderService:
         spaces: SpaceRepositoryProtocol,
         access: SpaceAccessService,
         notifications: WorkOrderNotificationService,
+        bot_repository: BotRepository,
+        collaborator_repository: CollaboratorRepositoryProtocol,
+        collaborators: CollaboratorServiceProtocol,
+        member_management: MemberManagementCapabilityService,
     ) -> None:
         self._repository = repository
         self._spaces = spaces
         self._access = access
         self._notifications = notifications
+        self._bots = bot_repository
+        self._collaborator_repository = collaborator_repository
+        self._collaborators = collaborators
+        self._member_management = member_management
 
     @staticmethod
     def _required_text(value: str, *, limit: int, error: type[Exception]) -> str:
@@ -119,11 +146,86 @@ class WorkOrderService:
             )
         if decision is WorkOrderDecision.REJECTED and normalized is None:
             raise WorkOrderInvalidRemarkError("review remark is required")
+        detail = self.get_detail(work_order_id=work_order_id, actor_id=actor_id)
+        if detail.work_order.biz_type == WorkOrderBizType.SPACE_JOIN.value:
+            return self._review_space_join(
+                detail=detail,
+                actor_id=actor_id,
+                review_remark=normalized,
+                target_status=WorkOrderStatus(decision.value),
+            )
+        if detail.work_order.biz_type == WorkOrderBizType.BOT_COLLABORATOR.value:
+            return self._review_bot_editor_request(
+                detail=detail,
+                actor_id=actor_id,
+                review_remark=normalized,
+                target_status=WorkOrderStatus(decision.value),
+            )
         return self._repository.process_approval(
             work_order_id=work_order_id,
             reviewer_user_id=actor_id,
             decision=decision,
             review_remark=normalized,
+            env=get_current_env(),
+        )
+
+    def create_bot_editor_request(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        applicant_user_id: str,
+        reason: str,
+    ):
+        reason = self._required_text(
+            reason, limit=512, error=WorkOrderInvalidReasonError
+        )
+        bot = self._bots.get_by_id_and_owner(bot_id, owner_id)
+        if not bot:
+            raise WorkOrderNotFoundError("bot not found")
+        if applicant_user_id == str(bot.get("owner_id") or ""):
+            raise WorkOrderApplicantAlreadyEditorError("Bot owner already has access")
+        if not self._member_management.can_manage_collaborators(bot, bot_id):
+            raise WorkOrderBotEditorRequestNotAllowedError(
+                "Bot does not support editor management"
+            )
+        raw_space_id = bot.get("space_id")
+        try:
+            space = self._access.require_space_reference(space_ref=str(raw_space_id))
+        except (SpaceNotFoundError, ValueError) as exc:
+            raise WorkOrderBotEditorRequestNotAllowedError(
+                "Bot is not assigned to an available Team Space"
+            ) from exc
+        if space.space_type is not SpaceType.TEAM:
+            raise WorkOrderBotEditorRequestNotAllowedError(
+                "Only Team Space Bots accept editor requests"
+            )
+        try:
+            self._access.require_space_member(
+                space_id=space.id, user_id=applicant_user_id
+            )
+        except SpaceAccessDeniedError as exc:
+            raise WorkOrderAccessDeniedError(
+                "applicant must be a Team Space member"
+            ) from exc
+        if (
+            self._collaborator_repository.get_by_bot_and_user(
+                int(bot["id"]), applicant_user_id, get_current_env()
+            )
+            is not None
+        ):
+            raise WorkOrderApplicantAlreadyEditorError(
+                "applicant already has Bot editor access"
+            )
+        return self._repository.create_bot_editor_request(
+            bot_pk=int(bot["id"]),
+            bot_id=bot_id,
+            bot_name=str(bot.get("bot_name") or bot_id),
+            owner_id=str(bot["owner_id"]),
+            space_id=space.id,
+            applicant_user_id=applicant_user_id,
+            applicant_name=applicant_user_id,
+            apply_reason=reason,
             env=get_current_env(),
         )
 
@@ -163,6 +265,8 @@ class WorkOrderService:
         actor_id: str,
         query_type: WorkOrderQueryType,
         item_type: WorkOrderItemType,
+        biz_type: str | None = None,
+        biz_id: str | None = None,
         page_no: int,
         page_size: int,
     ):
@@ -171,6 +275,8 @@ class WorkOrderService:
             env=get_current_env(),
             query_type=query_type,
             item_type=item_type,
+            biz_type=biz_type,
+            biz_id=biz_id,
             offset=(page_no - 1) * page_size,
             limit=page_size,
         )
@@ -191,8 +297,8 @@ class WorkOrderService:
             raise WorkOrderInvalidRemarkError(
                 "value must contain no more than 512 characters"
             )
-        return self._review(
-            work_order_id=work_order_id,
+        return self._review_space_join(
+            detail=self.get_detail(work_order_id=work_order_id, actor_id=actor_id),
             actor_id=actor_id,
             review_remark=normalized_remark,
             target_status=WorkOrderStatus.APPROVED,
@@ -202,22 +308,23 @@ class WorkOrderService:
         normalized_remark = self._required_text(
             review_remark or "", limit=512, error=WorkOrderInvalidRemarkError
         )
-        return self._review(
-            work_order_id=work_order_id,
+        return self._review_space_join(
+            detail=self.get_detail(work_order_id=work_order_id, actor_id=actor_id),
             actor_id=actor_id,
             review_remark=normalized_remark,
             target_status=WorkOrderStatus.REJECTED,
         )
 
-    def _review(
+    def _review_space_join(
         self,
         *,
-        work_order_id: int,
+        detail: WorkOrderDetail,
         actor_id: str,
         review_remark: str | None,
         target_status: WorkOrderStatus,
     ):
-        detail = self.get_detail(work_order_id=work_order_id, actor_id=actor_id)
+        if detail.work_order.biz_type != WorkOrderBizType.SPACE_JOIN.value:
+            raise WorkOrderNotFoundError("space join work order not found")
         try:
             self._access.require_space_owner(space_id=detail.space_id, user_id=actor_id)
         except SpaceAccessDeniedError as exc:
@@ -228,13 +335,47 @@ class WorkOrderService:
             review_remark=review_remark,
         )
         return self._repository.review_space_join(
-            work_order_id=work_order_id,
+            work_order_id=detail.work_order.id,
             reviewer_user_id=actor_id,
             review_remark=review_remark,
             target_status=target_status,
             notification=notification,
             env=get_current_env(),
         )
+
+    def _review_bot_editor_request(
+        self,
+        *,
+        detail: WorkOrderDetail,
+        actor_id: str,
+        review_remark: str | None,
+        target_status: WorkOrderStatus,
+    ):
+        data = _business_data(detail.work_order.biz_data)
+        bot_id = str(data.get("bot_id") or "")
+        owner_id = str(data.get("owner_id") or "")
+        bot_name = str(data.get("bot_name") or bot_id)
+        if not bot_id or not owner_id or actor_id != owner_id:
+            raise WorkOrderAccessDeniedError("Bot owner role required")
+        notification = self._notifications.build_bot_editor_review_result(
+            detail=detail,
+            bot_name=bot_name,
+            target_status=target_status,
+            review_remark=review_remark,
+        )
+        result = self._repository.review_bot_editor_request(
+            work_order_id=detail.work_order.id,
+            reviewer_user_id=actor_id,
+            review_remark=review_remark,
+            target_status=target_status,
+            notification=notification,
+            env=get_current_env(),
+        )
+        if target_status is WorkOrderStatus.APPROVED:
+            self._collaborators.on_collaboration_changed(
+                bot_id, owner_id, get_current_env()
+            )
+        return result
 
 
 class WorkOrderNotificationService:
@@ -276,6 +417,38 @@ class WorkOrderNotificationService:
             content=content,
         )
 
+    @staticmethod
+    def build_bot_editor_review_result(
+        *,
+        detail: WorkOrderDetail,
+        bot_name: str,
+        target_status: WorkOrderStatus,
+        review_remark: str | None,
+    ) -> WorkOrderNotificationDraft:
+        if target_status is WorkOrderStatus.APPROVED:
+            title = WorkOrderMessageTitle.BOT_COLLABORATOR_APPROVED.value
+            content = WorkOrderMessageContent.BOT_COLLABORATOR_APPROVED.value.format(
+                bot_name=bot_name
+            )
+        elif target_status is WorkOrderStatus.REJECTED:
+            if review_remark is None:
+                raise WorkOrderInvalidRemarkError("review remark is required")
+            title = WorkOrderMessageTitle.BOT_COLLABORATOR_REJECTED.value
+            content = WorkOrderMessageContent.BOT_COLLABORATOR_REJECTED.value.format(
+                bot_name=bot_name, review_remark=review_remark
+            )
+        else:
+            raise ValueError(f"unsupported review status: {target_status}")
+        return WorkOrderNotificationDraft(
+            recipient_user_id=detail.work_order.applicant_user_id,
+            notification_category=NotificationCategory.NOTICE,
+            event_type=WorkOrderEventType.BOT_COLLABORATOR_REVIEWED,
+            biz_type=WorkOrderBizType.BOT_COLLABORATOR,
+            biz_id=detail.work_order.biz_id,
+            title=title,
+            content=content,
+        )
+
     def get_detail(self, *, notification_id: int, actor_id: str):
         result = self._repository.get_notification(
             notification_id=notification_id,
@@ -311,3 +484,13 @@ class WorkOrderNotificationService:
         return self._repository.mark_all_notifications_read(
             recipient_user_id=actor_id, env=get_current_env()
         )
+
+
+def _business_data(raw: str | None) -> dict[str, object]:
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
@@ -126,6 +126,7 @@ _OWNER_ADDRESSED_ELSEWHERE = {
     ("put", "/openapi/v1/bots/{bot_id}/channels/{channel_id}/status"),
     ("get", "/openapi/v1/bots/{bot_id}/editors"),
     ("post", "/openapi/v1/bots/{bot_id}/editors"),
+    ("post", "/openapi/v1/bots/{bot_id}/editor-requests"),
     ("patch", "/openapi/v1/bots/{bot_id}/editors/{editor_id}"),
     ("delete", "/openapi/v1/bots/{bot_id}/editors/{editor_id}"),
     ("delete", "/openapi/v1/bots/{bot_id}/editors/me"),

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
@@ -706,6 +706,14 @@ _UNGRANTED_APP_CASES = {
         ),
         "assert_starved": lambda response: response.status_code == 404,
     },
+    ("POST", "/openapi/v1/bots/{bot_id}/editor-requests"): {
+        "request": lambda client: client.post(
+            "/openapi/v1/bots/bot-1/editor-requests",
+            params={"owner_id": "owner-1"},
+            json={"reason": "joint editing"},
+        ),
+        "assert_starved": lambda response: response.status_code == 404,
+    },
     ("GET", "/openapi/v1/bots/work-orders"): {
         "request": lambda client: client.get("/openapi/v1/bots/work-orders"),
         "assert_starved": lambda response: response.status_code == 404,

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -365,7 +365,9 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: ``path`` then moved 132 → 133 with the BCS publish-to-users operation
 #: (``POST /openapi/v1/bots/{bot_id}/public-bcs``): it addresses a bot and acts
 #: for the operator, so it is bot-path-addressed like the rest of the surface.
-_BOT_ID_PLACEMENT = {"path": 140, "query": 1, "none": 57}
+#: Bot editor requests then add one path-addressed Bot operation. The metadata
+#: query added alongside it is user-scoped but has no ``bot_id`` parameter.
+_BOT_ID_PLACEMENT = {"path": 141, "query": 1, "none": 57}
 
 
 def _schema() -> dict:
@@ -460,8 +462,9 @@ def test_the_pinned_number_of_operations_take_it():
     # the final operation. Skill Installation adds three further Bot-addressed
     # operations, Repo Catalog adds seven operations, SkillSet adds eleven, and
     # MCP adds eight operations, the Harness surface adds six Bot-addressed
-    # operations, Session File adds six more, and Bot metadata queries add one.
-    assert len(taking) == 179
+    # operations, Session File adds six more, Bot metadata queries add one, and
+    # Bot editor requests add one.
+    assert len(taking) == 180
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
@@ -127,6 +127,34 @@ def test_create_join_request_uses_principal_and_returns_created(
     )
 
 
+def test_create_bot_editor_request_uses_principal_and_named_owner(
+    client, work_order_service
+):
+    record = _work_order()
+    record.biz_type = WorkOrderBizType.BOT_COLLABORATOR
+    record.biz_id = "bot-7"
+    work_order_service.create_bot_editor_request.return_value = record
+
+    response = client.post(
+        "/openapi/v1/bots/bot-7/editor-requests",
+        params={"owner_id": "bot-owner"},
+        json={"reason": "joint editing"},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["data"] == {
+        "work_order_id": 11,
+        "work_order_no": "WO-11",
+        "status": "PENDING",
+    }
+    work_order_service.create_bot_editor_request.assert_called_once_with(
+        bot_id="bot-7",
+        owner_id="bot-owner",
+        applicant_user_id="owner-1",
+        reason="joint editing",
+    )
+
+
 def _space_join_display_data() -> str:
     return json.dumps(
         {
@@ -188,6 +216,8 @@ def test_list_work_orders_maps_plain_and_notification_items(client, work_order_s
         "actor_id": "owner-1",
         "query_type": "INITIATED_BY_ME",
         "item_type": "ALL",
+        "biz_type": None,
+        "biz_id": None,
         "page_no": 2,
         "page_size": 5,
     }
@@ -292,6 +322,46 @@ def test_get_work_order_maps_nested_content(client, work_order_service):
     work_order_service.get_detail.assert_called_once_with(
         work_order_id=11, actor_id="owner-1"
     )
+
+
+def test_get_bot_editor_work_order_maps_business_content(client, work_order_service):
+    record = _work_order(
+        biz_data=json.dumps(
+            {
+                "bot_id": "bot-7",
+                "bot_name": "Data Bot",
+                "owner_id": "owner-1",
+                "space_id": 7,
+                "applicant_name": "Applicant",
+                "requested_role": "member",
+            }
+        )
+    )
+    record.biz_type = WorkOrderBizType.BOT_COLLABORATOR
+    record.biz_id = "bot-7"
+    work_order_service.get_detail.return_value = WorkOrderDetail(
+        work_order=record,
+        event_type=WorkOrderEventType.BOT_COLLABORATOR_APPLIED,
+        title="pending",
+        space_id=0,
+        space_name="",
+        applicant_name="applicant-1",
+        can_approve=True,
+    )
+
+    response = client.get("/openapi/v1/bots/work-orders/11")
+
+    assert response.status_code == 200
+    assert response.json()["data"]["content"] == {
+        "bot_id": "bot-7",
+        "bot_name": "Data Bot",
+        "owner_id": "owner-1",
+        "space_id": 7,
+        "applicant_user_id": "applicant-1",
+        "applicant_name": "Applicant",
+        "requested_role": "member",
+        "reason": "join",
+    }
 
 
 @pytest.mark.parametrize(

--- a/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_market_work_order_repositories.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 import pytest
 
+from agentclaw.community.core.bot_collaborator.models import BotCollaboratorModel
 from agentclaw.community.core.market_favorites.models import (
     FavoriteTargetType,
     MarketSource,
@@ -43,6 +44,7 @@ from agentclaw.community.core.work_orders.repository.models import (
     WorkOrderApproverModel,
     WorkOrderNotificationModel,
 )
+from agentclaw.community.plugin_api.models import BotModel
 from agentclaw.community.plugins.local.database import SqliteDB, reset_for_tests
 
 
@@ -75,6 +77,115 @@ def _review_notification(
         title=title,
         content=content,
     )
+
+
+def _bot_review_notification(
+    *, applicant_user_id: str, bot_id: str
+) -> WorkOrderNotificationDraft:
+    return WorkOrderNotificationDraft(
+        recipient_user_id=applicant_user_id,
+        notification_category=NotificationCategory.NOTICE,
+        event_type=WorkOrderEventType.BOT_COLLABORATOR_REVIEWED,
+        biz_type=WorkOrderBizType.BOT_COLLABORATOR,
+        biz_id=bot_id,
+        title="Bot 共同编辑申请已通过",
+        content="approved",
+    )
+
+
+def test_bot_editor_request_approval_creates_member_collaborator(db) -> None:
+    spaces = SpaceRepository(db)
+    team = _team(spaces)
+    spaces.add_member(
+        space_id=team.id,
+        user_id="applicant-1",
+        role=SpaceRole.MEMBER,
+        creator_id="owner-1",
+        env="dev",
+    )
+    with db.orm_session() as session:
+        bot = BotModel(
+            bot_id="bot-editor-1",
+            bot_name="Editor Bot",
+            entity_id="owner-1",
+            entity_type="user",
+            creator_id="owner-1",
+            owner_id="owner-1",
+            status="ACTIVE",
+            bot_type="service",
+            space_id=team.id,
+            env="dev",
+        )
+        session.add(bot)
+        session.flush()
+        session.refresh(bot)
+        bot_pk = bot.id
+
+    repository = WorkOrderRepository(db)
+    record = repository.create_bot_editor_request(
+        bot_pk=bot_pk,
+        bot_id="bot-editor-1",
+        bot_name="Editor Bot",
+        owner_id="owner-1",
+        space_id=team.id,
+        applicant_user_id="applicant-1",
+        applicant_name="Applicant",
+        apply_reason="joint editing",
+        env="dev",
+    )
+    data = json.loads(record.biz_data)
+    assert data["requested_role"] == "member"
+    assert data["space_id"] == team.id
+
+    with pytest.raises(WorkOrderAlreadyPendingError):
+        repository.create_bot_editor_request(
+            bot_pk=bot_pk,
+            bot_id="bot-editor-1",
+            bot_name="Editor Bot",
+            owner_id="owner-1",
+            space_id=team.id,
+            applicant_user_id="applicant-1",
+            applicant_name="Applicant",
+            apply_reason="again",
+            env="dev",
+        )
+
+    result = repository.review_bot_editor_request(
+        work_order_id=record.id,
+        reviewer_user_id="owner-1",
+        review_remark=None,
+        target_status=WorkOrderStatus.APPROVED,
+        notification=_bot_review_notification(
+            applicant_user_id="applicant-1", bot_id="bot-editor-1"
+        ),
+        env="dev",
+    )
+    assert result.status is WorkOrderStatus.APPROVED
+    with db.orm_session() as session:
+        collaborator = (
+            session.query(BotCollaboratorModel)
+            .filter(
+                BotCollaboratorModel.bot_pk == bot_pk,
+                BotCollaboratorModel.user_id == "applicant-1",
+                BotCollaboratorModel.env == "dev",
+            )
+            .one()
+        )
+        assert collaborator.role == "member"
+        assert collaborator.operator_id == "owner-1"
+
+    total, items = repository.list_items(
+        actor_id="applicant-1",
+        env="dev",
+        query_type=WorkOrderQueryType.INITIATED_BY_ME,
+        item_type=WorkOrderItemType.ALL,
+        biz_type=WorkOrderBizType.BOT_COLLABORATOR.value,
+        biz_id="bot-editor-1",
+        offset=0,
+        limit=20,
+    )
+    assert total == 1
+    assert items[0].work_order.id == record.id
 
 
 def test_unified_work_order_create_and_approval_lifecycle(db) -> None:

--- a/src/backend/tests/community/core/work_orders/test_work_order_service.py
+++ b/src/backend/tests/community/core/work_orders/test_work_order_service.py
@@ -1,5 +1,6 @@
 """Unit tests for work-order orchestration and recipient notifications."""
 
+import json
 from datetime import datetime
 from unittest.mock import MagicMock
 
@@ -9,6 +10,7 @@ from agentclaw.community.core.spaces.errors import SpaceAccessDeniedError
 from agentclaw.community.core.spaces.models import SpaceRecord, SpaceType
 from agentclaw.community.core.work_orders.errors import (
     WorkOrderAccessDeniedError,
+    WorkOrderApplicantAlreadyEditorError,
     WorkOrderApplicantAlreadyMemberError,
     WorkOrderInvalidReasonError,
     WorkOrderInvalidRemarkError,
@@ -20,6 +22,7 @@ from agentclaw.community.core.work_orders.models import (
     NotificationCategory,
     WorkOrderBizType,
     WorkOrderDetail,
+    WorkOrderDecision,
     APPROVAL_EVENT_TYPES,
     EVENT_CATEGORIES,
     WorkOrderEventType,
@@ -110,12 +113,183 @@ def _service():
     spaces = MagicMock()
     access = MagicMock()
     notifications = MagicMock(spec=WorkOrderNotificationService)
+    bots = MagicMock()
+    collaborator_repository = MagicMock()
+    collaborators = MagicMock()
+    member_management = MagicMock()
     return (
-        WorkOrderService(repository, spaces, access, notifications),
+        WorkOrderService(
+            repository,
+            spaces,
+            access,
+            notifications,
+            bots,
+            collaborator_repository,
+            collaborators,
+            member_management,
+        ),
         repository,
         spaces,
         access,
         notifications,
+    )
+
+
+def _bot_editor_service():
+    repository = MagicMock()
+    spaces = MagicMock()
+    access = MagicMock()
+    notifications = MagicMock(spec=WorkOrderNotificationService)
+    bots = MagicMock()
+    collaborator_repository = MagicMock()
+    collaborators = MagicMock()
+    member_management = MagicMock()
+    service = WorkOrderService(
+        repository,
+        spaces,
+        access,
+        notifications,
+        bots,
+        collaborator_repository,
+        collaborators,
+        member_management,
+    )
+    return (
+        service,
+        repository,
+        access,
+        notifications,
+        bots,
+        collaborator_repository,
+        collaborators,
+        member_management,
+    )
+
+
+def test_create_bot_editor_request_enforces_eligibility_and_delegates() -> None:
+    (
+        service,
+        repository,
+        access,
+        _,
+        bots,
+        collaborator_repository,
+        _,
+        member_management,
+    ) = _bot_editor_service()
+    bots.get_by_id_and_owner.return_value = {
+        "id": 17,
+        "bot_id": "bot-17",
+        "bot_name": "Editor Bot",
+        "bot_type": "service",
+        "owner_id": "owner-1",
+        "space_id": 7,
+    }
+    member_management.can_manage_collaborators.return_value = True
+    access.require_space_reference.return_value = _space()
+    collaborator_repository.get_by_bot_and_user.return_value = None
+    repository.create_bot_editor_request.return_value = _work_order()
+
+    result = service.create_bot_editor_request(
+        bot_id="bot-17",
+        owner_id="owner-1",
+        applicant_user_id="applicant-1",
+        reason="  joint editing  ",
+    )
+
+    assert result == _work_order()
+    access.require_space_member.assert_called_once_with(
+        space_id=7, user_id="applicant-1"
+    )
+    repository.create_bot_editor_request.assert_called_once_with(
+        bot_pk=17,
+        bot_id="bot-17",
+        bot_name="Editor Bot",
+        owner_id="owner-1",
+        space_id=7,
+        applicant_user_id="applicant-1",
+        applicant_name="applicant-1",
+        apply_reason="joint editing",
+        env="dev",
+    )
+
+
+def test_bot_owner_cannot_request_editor_access() -> None:
+    service, repository, _, _, bots, _, _, _ = _bot_editor_service()
+    bots.get_by_id_and_owner.return_value = {
+        "id": 17,
+        "bot_id": "bot-17",
+        "owner_id": "owner-1",
+    }
+
+    with pytest.raises(WorkOrderApplicantAlreadyEditorError):
+        service.create_bot_editor_request(
+            bot_id="bot-17",
+            owner_id="owner-1",
+            applicant_user_id="owner-1",
+            reason="joint editing",
+        )
+
+    repository.create_bot_editor_request.assert_not_called()
+
+
+def test_unified_approval_dispatches_bot_editor_side_effect() -> None:
+    service, repository, _, notifications, _, _, collaborators, _ = (
+        _bot_editor_service()
+    )
+    work_order = _work_order().model_copy(
+        update={
+            "biz_type": WorkOrderBizType.BOT_COLLABORATOR,
+            "biz_id": "bot-17",
+            "biz_data": json.dumps(
+                {
+                    "bot_id": "bot-17",
+                    "bot_name": "Editor Bot",
+                    "owner_id": "owner-1",
+                }
+            ),
+        }
+    )
+    detail = _detail().model_copy(update={"work_order": work_order})
+    repository.get_detail.return_value = detail
+    notification = WorkOrderNotificationDraft(
+        recipient_user_id="applicant-1",
+        notification_category=NotificationCategory.NOTICE,
+        event_type=WorkOrderEventType.BOT_COLLABORATOR_REVIEWED,
+        biz_type=WorkOrderBizType.BOT_COLLABORATOR,
+        biz_id="bot-17",
+        title="approved",
+        content="approved",
+    )
+    notifications.build_bot_editor_review_result.return_value = notification
+    expected = WorkOrderReviewResult(
+        work_order_id=11,
+        status=WorkOrderStatus.APPROVED,
+        decision=WorkOrderDecision.APPROVED,
+        reviewer_user_id="owner-1",
+        review_remark=None,
+        reviewed_at=NOW,
+    )
+    repository.review_bot_editor_request.return_value = expected
+
+    result = service.process_approval(
+        work_order_id=11,
+        actor_id="owner-1",
+        decision=WorkOrderDecision.APPROVED,
+        review_remark=None,
+    )
+
+    assert result == expected
+    repository.review_bot_editor_request.assert_called_once_with(
+        work_order_id=11,
+        reviewer_user_id="owner-1",
+        review_remark=None,
+        target_status=WorkOrderStatus.APPROVED,
+        notification=notification,
+        env="dev",
+    )
+    collaborators.on_collaboration_changed.assert_called_once_with(
+        "bot-17", "owner-1", "dev"
     )
 
 
@@ -197,6 +371,8 @@ def test_list_items_forwards_filters_and_normalizes_pagination() -> None:
         env="dev",
         query_type=WorkOrderQueryType.PROCESSED_BY_ME,
         item_type=WorkOrderItemType.NOTICE,
+        biz_type=None,
+        biz_id=None,
         offset=20,
         limit=10,
     )

--- a/src/backend/tests/community/endpoints/test_work_orders_router.py
+++ b/src/backend/tests/community/endpoints/test_work_orders_router.py
@@ -12,6 +12,7 @@ someone other than the verified caller.
 from __future__ import annotations
 
 import time
+from types import SimpleNamespace
 
 import jwt
 
@@ -24,12 +25,14 @@ from tests.community.framework import (
     CaseInput,
     ExpectError,
     ExpectSuccess,
+    bind_overrides,
     endpoint_test,
 )
 
 _USER_ID = "work-orders-endpoint-user"
 _APPLICANT_ID = "work-orders-endpoint-applicant"
 _OTHER_OWNER_ID = "work-orders-endpoint-owner"
+_BOT_ID = "work-orders-endpoint-bot"
 _SIGNING_KEY = "work-orders-endpoint-secret-at-least-32-bytes"
 
 
@@ -96,6 +99,23 @@ def _seed_joinable_space(world) -> None:
     )
 
 
+def _seed_bot_editor_request(world) -> None:
+    _enable_public_auth(world)
+
+    def _create_bot_editor_request(_self, **_kwargs):
+        return SimpleNamespace(
+            id=1,
+            work_order_no="WO-BOT-EDITOR-1",
+            status="PENDING",
+        )
+
+    bind_overrides(
+        world,
+        WorkOrderServiceProtocol,
+        {"create_bot_editor_request": _create_bot_editor_request},
+    )
+
+
 def _mismatched_user(path_params: dict | None = None, json_body: dict | None = None):
     """The uniform error case: naming someone other than the caller is a 403."""
     return CaseInput(
@@ -143,6 +163,47 @@ def create_space_join_request_happy():
     expect=ExpectError(status=403),
 )
 def create_space_join_request_wrong_user():
+    """The framework owns invocation."""
+
+
+# ── POST /openapi/v1/bots/{bot_id}/editor-requests ───────────────────────────────
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/editor-requests",
+    scenario="happy",
+    seed=_seed_bot_editor_request,
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID},
+        query_params={"user_id": _USER_ID, "owner_id": _OTHER_OWNER_ID},
+        json_body={"reason": "please let me edit"},
+        headers=_principal_headers(),
+    ),
+    expect=ExpectSuccess(
+        status=201,
+        json_contains={
+            "code": 201000,
+            "data": {"work_order_id": 1, "status": "PENDING"},
+        },
+    ),
+)
+def create_bot_editor_request_happy():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/editor-requests",
+    scenario="wrong_user",
+    seed=_enable_public_auth,
+    input=_mismatched_user(
+        path_params={"bot_id": _BOT_ID},
+        json_body={"reason": "please let me edit"},
+    ),
+    expect=ExpectError(status=403),
+)
+def create_bot_editor_request_wrong_user():
     """The framework owns invocation."""
 
 


### PR DESCRIPTION
## Summary

- add a Bot editor-request OpenAPI for Team Space members
- route Bot collaboration approval through the unified work-order center
- atomically grant the `member` collaborator role on approval and notify the applicant
- add `biz_type` / `biz_id` work-order filters and Bot-specific detail payloads

## Validation

- 113 DI, OpenAPI, admission, authorization, service, and repository tests passed
- 62 final OpenAPI/admission contract tests passed
- Ruff checks and `git diff --check` passed
- pre-push SAST gate passed against `origin/dev_refactory_collaboration`

## Notes

- no database schema migration is required
- the editor request intentionally does not require an existing addressed-Bot grant; eligibility is adjudicated by the Team Space/work-order service