### PR TITLE
fix(bcs): allow HTTP for private webhook endpoints

### DIFF
--- a/src/bcs/crates/external-clients/bcs-webhook-client/src/lib.rs
+++ b/src/bcs/crates/external-clients/bcs-webhook-client/src/lib.rs
@@ -272,10 +272,13 @@ fn validate_endpoint_policy(
     url_guard: &OutboundUrlGuard,
 ) -> Result<(), &'static str> {
     let url = Url::parse(raw_url).map_err(|_| "invalid_url")?;
-    if url.scheme() != "https"
-        && (url.scheme() != "http"
-            || (policy.require_https && (!policy.allow_http_loopback || !is_loopback_host(&url))))
-    {
+    let allowlisted_http = url.scheme() == "http"
+        && url_guard.allows_allowlisted_host_port(raw_url);
+    let http_allowed = url.scheme() == "http"
+        && (!policy.require_https
+            || (policy.allow_http_loopback && is_loopback_host(&url))
+            || allowlisted_http);
+    if url.scheme() != "https" && !http_allowed {
         return Err("https_required");
     }
     if !url.username().is_empty() || url.password().is_some() {
@@ -428,11 +431,11 @@ mod tests {
     }
 
     #[test]
-    fn private_endpoint_allowlist_can_enable_an_exact_non_standard_port() {
+    fn private_endpoint_allowlist_can_enable_http_and_an_exact_non_standard_port() {
         let entry = bcs_config_api::PrivateEndpointAllowlistEntryConfig {
             host: "*.hooks.example.internal".to_string(),
             cidrs: vec!["10.20.0.0/16".to_string()],
-            ports: vec![8443],
+            ports: vec![80, 8443],
         };
         let guard = OutboundUrlGuard::strict()
             .with_private_endpoint_allowlist(&[entry])
@@ -449,6 +452,22 @@ mod tests {
         assert!(
             validate_endpoint_policy(
                 "https://worker.hooks.example.internal:9443/events",
+                WebhookEndpointPolicy::production(),
+                &guard,
+            )
+            .is_err()
+        );
+        assert!(
+            validate_endpoint_policy(
+                "http://worker.hooks.example.internal/events",
+                WebhookEndpointPolicy::production(),
+                &guard,
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_endpoint_policy(
+                "http://worker.hooks.example.internal:8080/events",
                 WebhookEndpointPolicy::production(),
                 &guard,
             )

--- a/src/bcs/crates/services/bcs-eventing/src/subscription.rs
+++ b/src/bcs/crates/services/bcs-eventing/src/subscription.rs
@@ -1245,7 +1245,16 @@ fn validate_webhook_url(
     let http_loopback_allowed = url.scheme() == "http"
         && policy.allow_http_loopback
         && is_loopback_host(&url);
-    if (url.scheme() != "https" && !http_loopback_allowed)
+    let http_private_endpoint_allowed = url.scheme() == "http"
+        && url.host_str().is_some_and(|host| {
+            url.port_or_known_default().is_some_and(|port| {
+                policy
+                    .private_endpoint_allowlist
+                    .iter()
+                    .any(|entry| entry.matches_host_and_port(host, port))
+            })
+        });
+    if (url.scheme() != "https" && !http_loopback_allowed && !http_private_endpoint_allowed)
         || url.host_str().is_none()
         || !url.username().is_empty()
         || url.password().is_some()

--- a/src/bcs/crates/services/bcs-eventing/tests/subscription_service.rs
+++ b/src/bcs/crates/services/bcs-eventing/tests/subscription_service.rs
@@ -430,7 +430,7 @@ async fn private_endpoint_allowlist_permits_only_matching_host_and_port() {
         PrivateEndpointAllowlistEntryConfig {
             host: "*.hooks.example.internal".to_string(),
             cidrs: vec!["10.20.0.0/16".to_string()],
-            ports: vec![8443],
+            ports: vec![80, 8443],
         },
     ];
     let harness = harness_with_eventing_config(true, eventing_config);
@@ -445,10 +445,21 @@ async fn private_endpoint_allowlist_permits_only_matching_host_and_port() {
         .await
         .expect("matching wildcard host and port should pass static validation");
 
+    let mut allowed_http =
+        create_command(vec!["group.*".to_string()], EventPayloadMode::MetadataOnly);
+    let EventSinkInput::Webhook { url, .. } = &mut allowed_http.request.sink;
+    *url = "http://worker.hooks.example.internal/events".to_string();
+    harness
+        .service
+        .create(allowed_http)
+        .await
+        .expect("matching private endpoint should permit HTTP on an allowlisted port");
+
     for rejected_url in [
         "https://hooks.example.internal:8443/events",
         "https://worker.hooks.example.internal:9443/events",
         "https://worker.evilhooks.example.internal:8443/events",
+        "http://worker.hooks.example.internal:8080/events",
     ] {
         let mut rejected =
             create_command(vec!["group.*".to_string()], EventPayloadMode::MetadataOnly);


### PR DESCRIPTION
## Problem

BCS supports private endpoint allowlists for event Webhooks, but production endpoint validation still required HTTPS unconditionally.

As a result, an internal Webhook such as `http://worker.hooks.example.internal/events` was rejected even when its domain, port, and private network configuration were explicitly allowlisted.

This made it impossible to integrate with trusted internal receivers that only expose HTTP.

## Solution

- Allow HTTP Webhook URLs when their domain and effective port match a configured `private_endpoint_allowlist` entry.
- Apply the same rule during both:
  - Event subscription creation and validation.
  - Webhook delivery client validation.
- Keep HTTPS behavior unchanged.
- Continue rejecting:
  - Public HTTP endpoints that do not match the allowlist.
  - HTTP endpoints using an unconfigured port.
  - IP-literal HTTP endpoints, because private endpoint rules only support DNS names.
  - URLs containing userinfo, query parameters, or fragments.
- Continue performing DNS resolution and outbound IP security validation for every delivery attempt.
- Add regression coverage for allowlisted HTTP port 80 and rejected HTTP port 8080.

Example configuration:

```toml
[[eventing.webhook.private_endpoint_allowlist]]
host = "*.hooks.example.internal"
cidrs = ["10.0.0.0/8"]
ports = [80, 443, 8443]
```