### PR TITLE
fix(backend): preserve Repo catalog name compatibility

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_parser.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_parser.py
@@ -239,6 +239,26 @@ class SkillParser:
 
     @classmethod
     def parse(cls, skill_path: Path) -> dict[str, Any] | None:
+        """Parse a package whose wrapper directory is part of its identity."""
+        return cls._parse_path(skill_path, require_directory_name_match=True)
+
+    @classmethod
+    def parse_repository(cls, skill_path: Path) -> dict[str, Any] | None:
+        """Parse a governed Repo asset with path and display-name separation.
+
+        Repo catalog identity is its ``git://`` directory path while the
+        manifest ``name`` is display metadata.  Historical catalog entries
+        intentionally allow those values to differ.
+        """
+        return cls._parse_path(skill_path, require_directory_name_match=False)
+
+    @classmethod
+    def _parse_path(
+        cls,
+        skill_path: Path,
+        *,
+        require_directory_name_match: bool,
+    ) -> dict[str, Any] | None:
         skill_file = cls.find_skill_file(skill_path)
         if not skill_file:
             return None
@@ -249,7 +269,7 @@ class SkillParser:
             raise SkillManifestError("SKILL_FILE_READ_ERROR", str(exc)) from exc
 
         skill_info = cls.parse_content(content)
-        if skill_info["name"] != skill_path.name:
+        if require_directory_name_match and skill_info["name"] != skill_path.name:
             raise SkillManifestError(
                 "NAME_DIRECTORY_MISMATCH",
                 "Skill folder name must match SKILL.md field 'name'. "

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -1043,7 +1043,7 @@ class SkillService:
                     # 只有包含 SKILL.md 的目录才被认为是技能
                     if SkillParser.has_skill_file(item):
                         # 是技能目录，解析并缓存
-                        skill_info = SkillParser.parse(item)
+                        skill_info = SkillParser.parse_repository(item)
                         if skill_info:
                             index[rel_path] = skill_info
                     else:
@@ -1078,7 +1078,7 @@ class SkillService:
 
         # 检查是否是技能目录（不在索引中的情况）- 只有 SKILL.md 才算
         if SkillParser.has_skill_file(path):
-            skill_info = SkillParser.parse(path)
+            skill_info = SkillParser.parse_repository(path)
             if skill_info:
                 # 添加到索引
                 skills_index[rel_path] = skill_info
@@ -1116,7 +1116,7 @@ class SkillService:
 
         # 只有包含 SKILL.md 的目录才被认为是技能
         if SkillParser.has_skill_file(path):
-            skill_info = SkillParser.parse(path)
+            skill_info = SkillParser.parse_repository(path)
             return SkillTreeNode(
                 name=skill_info.get("name", path.name) if skill_info else path.name,
                 path=str(path.relative_to(market_repo_dir)),
@@ -1345,7 +1345,8 @@ class SkillService:
                 # 不透传会导致 sync_market 把 "Distributed lock held" 当成 500 错误抛出。
                 "error": result.get("error"),
                 "message": "Sync completed" if result.get("success") else result.get("error", "Sync failed"),
-                "subtrees": result.get("subtrees", {})
+                "subtrees": result.get("subtrees", {}),
+                "database": result.get("database"),
             }
         except Exception as e:
             logger.error(f"[sync_repo_with_lock] Error: {e}")
@@ -1595,7 +1596,7 @@ class SkillService:
 
     def _parse_skill_md_for_db(self, skill_path: Path) -> dict[str, Any] | None:
         """解析技能文件，返回数据库需要的格式"""
-        base_info = SkillParser.parse(skill_path)
+        base_info = SkillParser.parse_repository(skill_path)
         if not base_info:
             return None
 

--- a/src/backend/src/agentclaw/community/plugin_api/skill_repo_sync.py
+++ b/src/backend/src/agentclaw/community/plugin_api/skill_repo_sync.py
@@ -62,8 +62,10 @@ class SkillRepoSyncPlugin(Plugin, Protocol):
           to fall back to the NAS path because concurrent rsyncs can
           create transient partial-delete races (see incident
           2026-05-13: 32 skill rows wrongly deleted).
-        - **Local (noop sync)**: returns ``default_fallback`` directly.
-          No NAS race surface; lenient fallback is safe.
+        - **Local (host-directory sync)**: returns the existing
+          ``get_local_skills_root()/skills-repo`` corpus it inspected during
+          ``sync()``; falls back to ``default_fallback`` when that source is
+          absent so offline development remains lenient.
 
         Args:
             default_fallback: Path to use when the sync plugin has no

--- a/src/backend/src/agentclaw/community/plugins/local/skill_repo_sync.py
+++ b/src/backend/src/agentclaw/community/plugins/local/skill_repo_sync.py
@@ -77,16 +77,17 @@ class LocalSkillRepoSyncPlugin(MockSeam, SkillRepoSyncPlugin):
         return Path.home() / ".openclaw" / "workspace" / "skills"
 
     def get_scan_target(self, default_fallback: Path) -> Path:
-        """Local mode has no atomic skills_target; return the caller's
-        fallback (typically the market repo dir). Lenient on purpose:
-        local has no NAS race surface, so the strict cloud behavior
-        (raise) would be unhelpful for offline dev.
-        """
-        logger.info(
-            "[LocalSkillRepoSync.get_scan_target] scan_target=%s (fallback, local mode)",
-            default_fallback,
+        """Prefer the host corpus reported by this local sync implementation."""
+        root = self.get_local_skills_root()
+        repo_dir = root / "skills-repo" if root is not None else None
+        scan_target = (
+            repo_dir if repo_dir is not None and repo_dir.is_dir() else default_fallback
         )
-        return default_fallback
+        logger.info(
+            "[LocalSkillRepoSync.get_scan_target] scan_target=%s (local mode)",
+            scan_target,
+        )
+        return scan_target
 
     def get_data_init_skill_md_path(self) -> str:
         """Prefer ``$DATA_INIT_SKILL_MD_PATH``, else ``~/.agents/skills/data-init/SKILL.md``

--- a/src/backend/tests/community/contracts/test_skill_repo_sync.py
+++ b/src/backend/tests/community/contracts/test_skill_repo_sync.py
@@ -63,3 +63,15 @@ def test_local_skills_root_is_under_home(world) -> None:
     # Local impl returns ~/.openclaw/workspace/skills — fingerprint.
     assert ".openclaw" in str(root)
     assert root.name == "skills"
+
+
+def test_local_scan_target_prefers_host_repo_source(
+    world, tmp_path, monkeypatch
+) -> None:
+    plugin = world.get(SkillRepoSyncPlugin)
+    repo_dir = tmp_path / "skills-repo"
+    repo_dir.mkdir()
+    fallback = tmp_path / "engine-view-fallback"
+    monkeypatch.setattr(plugin, "get_local_skills_root", lambda: tmp_path)
+
+    assert plugin.get_scan_target(fallback) == repo_dir

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service.py
@@ -170,6 +170,42 @@ class TestSkillServiceActivation:
 class TestSkillServiceSync:
     """sync_skills_from_git"""
 
+    def test_sync_accepts_repo_folder_name_distinct_from_manifest_name(
+        self, skill_dirs, mock_skill_repo
+    ):
+        repo_dir = skill_dirs["repo_dir"]
+        _make_skill_dir(
+            repo_dir,
+            "infra/dima-mcp",
+            skill_md_content=(
+                "---\n"
+                "name: dima\n"
+                "description: Dima integration\n"
+                "---\n"
+            ),
+        )
+        mock_skill_repo.list_skills.return_value = []
+
+        svc = SkillService(
+            skill_repo=mock_skill_repo,
+            skill_repo_sync=_lenient_skill_repo_sync(),
+            category_repo=MagicMock(),
+            active_dir=skill_dirs["active_dir"],
+            repo_dir=repo_dir,
+            local_dir=skill_dirs["local_dir"],
+            market_cache=MagicMock(),
+            device_fs_factory=MagicMock(),
+            git_sync_service_factory=MagicMock(),
+        )
+
+        result = svc.sync_skills_from_git()
+
+        assert result["failed"] == 0
+        assert result["created"] == 1
+        created = mock_skill_repo.create.call_args.args[0]
+        assert created["git_path"] == "git://infra/dima-mcp"
+        assert created["name"] == "dima"
+
     def test_sync_creates_new_skills(self, skill_dirs, mock_skill_repo):
         repo_dir = skill_dirs["repo_dir"]
         _make_skill_dir(repo_dir, "infra/demo")
@@ -1178,3 +1214,29 @@ class TestSyncRepoWithLock:
         assert result["success"] is False
         assert result["error"] == "Git fetch failed: boom"
         assert result["message"] == "Git fetch failed: boom"
+
+    def test_database_scan_failure_propagates_structured_result(
+        self, skill_dirs, mock_skill_repo
+    ):
+        database = {
+            "created": 0,
+            "updated": 0,
+            "deleted": 0,
+            "failed": 1,
+            "skipped": 3,
+            "errors": ["invalid manifest"],
+        }
+        svc = self._make_svc(
+            skill_dirs,
+            mock_skill_repo,
+            {
+                "success": False,
+                "error": "Database scan failed",
+                "database": database,
+            },
+        )
+
+        result = svc.sync_repo_with_lock()
+
+        assert result["success"] is False
+        assert result["database"] == database


### PR DESCRIPTION
## Problem

The legacy BFF Repo market sync rejected ten long-lived catalog entries whose directory path and SKILL.md display name differ. The strict shared parser counted those compatible Repo assets as failed rows, so the canonical sync returned Database scan failed. Singlebox also scanned an engine-view fallback instead of the host corpus used by its local sync implementation.

## Solution

- Keep strict wrapper-name validation for Local and other governed packages.
- Add Repo-specific parsing that keeps the git directory as stable identity while using SKILL.md name as display metadata.
- Preserve real database scan failure semantics and propagate structured database diagnostics through the legacy BFF service wrapper.
- Make the Singlebox local sync scanner use the host skills-repo corpus it just inspected, with the historical fallback only when that corpus is absent.
- Add Core regression tests and a SkillRepoSync Plugin contract test.

## Validation

- 118 focused Backend tests passed.
- 170 Backend architecture tests passed.
- Ruff checks passed for all changed Python files.
- git diff --check passed.
- Singlebox Backend only:
  - GET /api/health returned 200.
  - POST /api/skills/market/sync returned 200 with synced=true, failed=0, skipped=380, errors=[].
  - SQLite retained git://infra/demo/dima-mcp with name dima and git://business/content-dsp/dsp-static-model with name dsp-base-static-model.
- No public route or schema changed, so OpenAPI dump and publish gates were not applicable.

## Compatibility and risk

Repo catalog behavior returns to the dev-compatible contract: git path identity and manifest display name may differ. Local Skill upload validation remains strict. Genuine manifest, persistence, cache, and fetch failures still propagate. The local scan-target change is covered by the Plugin contract and falls back when no host corpus exists.

Rollback is the single commit in this PR.