### PR TITLE
feat(session-files): support large OpenAPI downloads

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/dependencies_session_files.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/dependencies_session_files.py
@@ -77,7 +77,7 @@ class OpenApiSessionFileAdapter:
         return self._session_resources.list_resources(ready_only=True, **kwargs)
 
     async def open_content(self, **kwargs: Any) -> Any:
-        return await self._session_resources.open_content(**kwargs)
+        return await self._session_resources.open_session_file_content(**kwargs)
 
     def delete(self, **kwargs: Any) -> Any:
         return self._session_resources.delete(**kwargs)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/engine_runtime/sessions/router.py
@@ -71,7 +71,9 @@ from agentclaw.community.adapters.http.openapi_v1.engine_runtime.gating import r
 from agentclaw.community.core.engine_runtime.errors import (
     EngineDeviceNotReadyError,
     EngineResourceNotFoundError,
+    EngineUpstreamError,
 )
+from agentclaw.community.core.resources.service import FileTooLargeError
 from agentclaw.community.core.bot_management.services.bot_service import BotNotFoundError
 from agentclaw.community.core.expert_chat.errors import (
     BotNotFoundError as ExpertBotNotFoundError,
@@ -639,7 +641,7 @@ def _session_file_headers(headers: object) -> dict[str, str]:
         return {"Content-Type": "application/octet-stream"}
     # COSEC: the upstream header bag is untrusted at this public boundary;
     # forward only a fixed response-header allowlist after rejecting CR/LF.
-    allowed = {"content-type", "content-length", "content-disposition"}
+    allowed = {"content-type", "content-length", "content-disposition", "retry-after", "cache-control"}
     safe: dict[str, str] = {}
     for key, value in headers.items():
         normalized = str(key).lower()
@@ -648,6 +650,10 @@ def _session_file_headers(headers: object) -> dict[str, str]:
         if "\r" in value or "\n" in value:
             continue
         if normalized == "content-length" and not value.isdecimal():
+            continue
+        if normalized == "retry-after" and not value.isdecimal():
+            continue
+        if normalized == "cache-control" and value.lower() != "no-store":
             continue
         safe["-".join(part.capitalize() for part in normalized.split("-"))] = value
     safe.setdefault("Content-Type", "application/octet-stream")
@@ -806,7 +812,15 @@ async def list_ready_session_files(
     )
 
 
-@router.get("/{session_id}/files/{resource_id}/content")
+@router.get(
+    "/{session_id}/files/{resource_id}/content",
+    response_model=None,
+    responses={
+        200: {"description": "File content or a ready external-download descriptor."},
+        202: {"description": "Large attachment download is being prepared."},
+        413: {"description": "Inline preview is too large."},
+    },
+)
 @envelope_errors
 async def stream_session_file_content(
     bot_id: BotIdPath,
@@ -833,6 +847,10 @@ async def stream_session_file_content(
             disposition=disposition,
         )
     except ValueError as exc:
+        if str(exc) == "resource_preview_too_large":
+            raise FileTooLargeError("File too large for preview") from exc
+        if str(exc) == "engine_content_unavailable":
+            raise EngineUpstreamError("session file content unavailable") from exc
         _session_file_not_found(exc)
     async def body() -> AsyncIterator[bytes]:
         try:
@@ -842,10 +860,13 @@ async def stream_session_file_content(
         finally:
             await upstream.close()
     headers = _session_file_headers(upstream.headers)
-    headers.setdefault(
-        "Content-Disposition", f'{disposition}; filename="{record.filename}"'
+    if upstream.status_code == 200 and headers.get("Content-Type", "").split(";", 1)[0].lower() != "application/json":
+        headers.setdefault("Content-Disposition", f'{disposition}; filename="{record.filename}"')
+    return StreamingResponse(
+        body(),
+        status_code=upstream.status_code,
+        headers=headers,
     )
-    return StreamingResponse(body(), headers=headers)
 
 
 @router.delete("/{session_id}/files/{resource_id}", response_model=Envelope[Deleted])

--- a/src/backend/src/agentclaw/community/api/session_resource_service.py
+++ b/src/backend/src/agentclaw/community/api/session_resource_service.py
@@ -24,6 +24,10 @@ class SessionResourceServiceProtocol(Protocol):
 
     async def open_content(self, *args: Any, **kwargs: Any) -> Any: ...
 
+    async def open_session_file_content(
+        self, *args: Any, **kwargs: Any
+    ) -> Any: ...
+
     def reference(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/session_resources/service.py
+++ b/src/backend/src/agentclaw/community/core/session_resources/service.py
@@ -305,6 +305,45 @@ class SessionResourceService:
         )
         raise ValueError("engine_content_unavailable")
 
+    async def open_session_file_content(
+        self,
+        *,
+        owner_id: str,
+        bot_id: str,
+        session_key: str,
+        resource_id: str,
+        disposition: str,
+    ) -> tuple[SessionResourceRecord, DeviceAdapterStreamResponse]:
+        if disposition not in {"inline", "attachment"}:
+            raise ValueError("invalid_disposition")
+        record = self._owned(
+            resource_id,
+            owner_id,
+            bot_id,
+            hash_identifier(session_key),
+        )
+        if record.status is not SessionResourceStatus.READY:
+            raise ValueError("resource_not_ready")
+        context = self._resolve_record_context(record)
+        response = await self._adapter_transport.stream(
+            context.conn_info,
+            "GET",
+            f"/api/session-files/{record.resource_id}/content",
+            params={
+                "sessionKey": session_key,
+                "disposition": disposition,
+            },
+            timeout=60.0,
+        )
+        if 200 <= response.status_code < 300:
+            return record, response
+        await response.close()
+        if response.status_code in {404, 409}:
+            raise ValueError("resource_missing")
+        if response.status_code == 413:
+            raise ValueError("resource_preview_too_large")
+        raise ValueError("engine_content_unavailable")
+
     def reference(
         self,
         *,

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_session_files.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_session_files.py
@@ -38,20 +38,28 @@ def test_session_file_endpoints_are_declared_in_the_existing_session_router():
 
 
 class _Body:
-    def __init__(self) -> None:
+    def __init__(self, content: bytes = b"file-bytes") -> None:
         self.closed = False
+        self.content = content
 
     def __aiter__(self):
         return self._chunks()
 
     async def _chunks(self):
-        yield b"file-bytes"
+        yield self.content
 
 
 class _Upstream:
-    def __init__(self) -> None:
-        self.body = _Body()
-        self.headers = {
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        content: bytes = b"file-bytes",
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.body = _Body(content)
+        self.headers = headers or {
             "content-type": "text/plain",
             "content-length": "10",
             "x-internal": "not-forwarded",
@@ -117,8 +125,10 @@ class _Resources:
         self.calls.append(("list", kwargs))
         return self.ready_records
 
-    async def open_content(self, **kwargs):
-        self.calls.append(("content", kwargs))
+    async def open_session_file_content(self, **kwargs):
+        self.calls.append(("session_file_content", kwargs))
+        if failure := self.failures.get("content"):
+            raise failure
         return self._record(status=SessionResourceStatus.READY), self.upstream
 
     def delete(self, **kwargs):
@@ -221,7 +231,99 @@ def test_content_filters_headers_and_closes_the_upstream(client, resources):
     assert "x-internal" not in response.headers
     assert "X: y" not in response.headers.get("content-disposition", "")
     assert resources.upstream.closed is True
-    assert resources.calls[-1][0] == "content"
+    assert resources.calls[-1][0] == "session_file_content"
+
+
+def test_content_preserves_engine_download_preparation_response(client, resources):
+    resources.upstream = _Upstream(
+        status_code=202,
+        content=b'{"status":"preparing_download","retry_after_seconds":2}',
+        headers={
+            "content-type": "application/json",
+            "retry-after": "2",
+            "cache-control": "no-store",
+            "x-internal": "not-forwarded",
+        },
+    )
+
+    response = client.get(_base() + "/sr_1/content?disposition=attachment")
+
+    assert response.status_code == 202
+    assert response.json() == {
+        "status": "preparing_download",
+        "retry_after_seconds": 2,
+    }
+    assert response.headers["retry-after"] == "2"
+    assert response.headers["cache-control"] == "no-store"
+    assert "content-disposition" not in response.headers
+    assert "x-internal" not in response.headers
+
+
+def test_content_rejects_unsafe_export_control_headers(client, resources):
+    resources.upstream = _Upstream(
+        status_code=202,
+        content=b'{"status":"preparing_download","retry_after_seconds":2}',
+        headers={
+            "content-type": "application/json",
+            "retry-after": "soon",
+            "cache-control": "public, max-age=3600",
+        },
+    )
+
+    response = client.get(_base() + "/sr_1/content?disposition=attachment")
+
+    assert response.status_code == 202
+    assert "retry-after" not in response.headers
+    assert "cache-control" not in response.headers
+
+
+def test_content_preserves_engine_external_download_response(client, resources):
+    resources.upstream = _Upstream(
+        content=(
+            b'{"status":"ready","delivery":"external_url",'
+            b'"download_url":"https://download.example.test/file",'
+            b'"expires_at":"2026-08-22T12:00:00Z",'
+            b'"filename":"report.txt","size_bytes":52428800}'
+        ),
+        headers={
+            "content-type": "application/json; charset=utf-8",
+            "cache-control": "no-store",
+        },
+    )
+
+    response = client.get(_base() + "/sr_1/content?disposition=attachment")
+
+    assert response.status_code == 200
+    assert response.json()["delivery"] == "external_url"
+    assert response.headers["cache-control"] == "no-store"
+    assert "content-disposition" not in response.headers
+
+
+def test_content_maps_engine_preview_limit_to_openapi_413(client, resources):
+    resources.failures["content"] = ValueError("resource_preview_too_large")
+
+    response = client.get(_base() + "/sr_1/content")
+
+    assert response.status_code == 413
+    assert response.json()["message"] == "File too large for preview"
+
+
+def test_content_maps_unavailable_engine_to_openapi_502(client, resources):
+    resources.failures["content"] = ValueError("engine_content_unavailable")
+
+    response = client.get(_base() + "/sr_1/content")
+
+    assert response.status_code == 502
+    assert response.json()["message"] == "Engine service error"
+
+
+def test_content_masks_missing_engine_resource_as_openapi_404(client, resources):
+    resources.failures["content"] = ValueError("resource_missing")
+
+    response = client.get(_base() + "/sr_1/content")
+
+    assert response.status_code == 404
+    assert response.json()["message"] == "Not found"
 
 
 def test_complete_and_status_return_public_resources(client, resources):

--- a/src/backend/tests/community/core/session_resources/test_service.py
+++ b/src/backend/tests/community/core/session_resources/test_service.py
@@ -185,8 +185,16 @@ class _Queue:
 
 
 class _Transport:
-    def __init__(self, status_code: int = 200) -> None:
+    def __init__(
+        self,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+    ) -> None:
         self.status_code = status_code
+        self.headers = headers or {
+            "content-type": "text/plain",
+            "x-internal": "hidden",
+        }
         self.calls = []
         self.closed = False
 
@@ -201,7 +209,7 @@ class _Transport:
 
         return DeviceAdapterStreamResponse(
             status_code=self.status_code,
-            headers={"content-type": "text/plain", "x-internal": "hidden"},
+            headers=self.headers,
             body=chunks(),
             close=close,
         )
@@ -682,11 +690,159 @@ async def test_content_streams_from_engine_without_baas_download_call():
     )
 
     assert record.resource_id == intent.resource.resource_id
-    assert transport.calls[0][2].endswith(f"/{intent.resource.resource_id}/content")
+    assert transport.calls[0][2] == (
+        f"/api/resource-materializations/{intent.resource.resource_id}/content"
+    )
+    assert transport.calls[0][4] == {"disposition": "inline"}
     assert resolver.binding_calls[-1] == (42, "owner-1", "bot-1")
     assert len(http.calls) == 1
     assert [chunk async for chunk in response.body] == [b"materialized bytes"]
     await response.close()
+    assert transport.closed is True
+
+
+@pytest.mark.asyncio
+async def test_openapi_content_uses_existing_session_file_engine_endpoint():
+    transport = _Transport()
+    service, repo, _ = _service(transport=transport)
+    intent = _intent(service)
+    repo.value = replace(intent.resource, status=SessionResourceStatus.READY)
+
+    record, response = await service.open_session_file_content(
+        owner_id="owner-1",
+        bot_id="bot-1",
+        session_key="session/raw value",
+        resource_id=intent.resource.resource_id,
+        disposition="attachment",
+    )
+
+    assert record.resource_id == intent.resource.resource_id
+    assert transport.calls[0][2] == (
+        f"/api/session-files/{intent.resource.resource_id}/content"
+    )
+    assert transport.calls[0][4] == {
+        "sessionKey": "session/raw value",
+        "disposition": "attachment",
+    }
+    await response.close()
+
+
+@pytest.mark.asyncio
+async def test_openapi_content_keeps_engine_preparing_response_open():
+    transport = _Transport(
+        status_code=202,
+        headers={
+            "content-type": "application/json",
+            "retry-after": "2",
+            "cache-control": "no-store",
+        },
+    )
+    service, repo, _ = _service(transport=transport)
+    intent = _intent(service)
+    repo.value = replace(intent.resource, status=SessionResourceStatus.READY)
+
+    _, response = await service.open_session_file_content(
+        owner_id="owner-1",
+        bot_id="bot-1",
+        session_key="session/raw value",
+        resource_id=intent.resource.resource_id,
+        disposition="attachment",
+    )
+
+    assert response.status_code == 202
+    assert transport.closed is False
+    await response.close()
+
+
+@pytest.mark.asyncio
+async def test_openapi_content_reports_inline_preview_size_limit():
+    transport = _Transport(status_code=413)
+    service, repo, _ = _service(transport=transport)
+    intent = _intent(service)
+    repo.value = replace(intent.resource, status=SessionResourceStatus.READY)
+
+    with pytest.raises(ValueError, match="resource_preview_too_large"):
+        await service.open_session_file_content(
+            owner_id="owner-1",
+            bot_id="bot-1",
+            session_key="session/raw value",
+            resource_id=intent.resource.resource_id,
+            disposition="inline",
+        )
+
+    assert transport.closed is True
+
+
+@pytest.mark.asyncio
+async def test_openapi_content_maps_missing_engine_resource_to_session_missing():
+    transport = _Transport(status_code=404)
+    service, repo, _ = _service(transport=transport)
+    intent = _intent(service)
+    repo.value = replace(intent.resource, status=SessionResourceStatus.READY)
+
+    with pytest.raises(ValueError, match="resource_missing"):
+        await service.open_session_file_content(
+            owner_id="owner-1",
+            bot_id="bot-1",
+            session_key="session/raw value",
+            resource_id=intent.resource.resource_id,
+            disposition="attachment",
+        )
+
+    assert transport.closed is True
+
+
+@pytest.mark.asyncio
+async def test_openapi_content_rejects_invalid_disposition_before_transport():
+    transport = _Transport()
+    service, _, _ = _service(transport=transport)
+
+    with pytest.raises(ValueError, match="invalid_disposition"):
+        await service.open_session_file_content(
+            owner_id="owner-1",
+            bot_id="bot-1",
+            session_key="session/raw value",
+            resource_id="sr_1",
+            disposition="invalid",
+        )
+
+    assert transport.calls == []
+
+
+@pytest.mark.asyncio
+async def test_openapi_content_requires_a_ready_resource():
+    transport = _Transport()
+    service, _, _ = _service(transport=transport)
+    intent = _intent(service)
+
+    with pytest.raises(ValueError, match="resource_not_ready"):
+        await service.open_session_file_content(
+            owner_id="owner-1",
+            bot_id="bot-1",
+            session_key="session/raw value",
+            resource_id=intent.resource.resource_id,
+            disposition="attachment",
+        )
+
+    assert transport.calls == []
+
+
+@pytest.mark.asyncio
+async def test_openapi_content_reports_unavailable_engine_without_leaking_status():
+    transport = _Transport(status_code=502)
+    service, repo, _ = _service(transport=transport)
+    intent = _intent(service)
+    repo.value = replace(intent.resource, status=SessionResourceStatus.READY)
+
+    with pytest.raises(ValueError, match="engine_content_unavailable"):
+        await service.open_session_file_content(
+            owner_id="owner-1",
+            bot_id="bot-1",
+            session_key="session/raw value",
+            resource_id=intent.resource.resource_id,
+            disposition="attachment",
+        )
+
     assert transport.closed is True
 
 

--- a/src/backend/tests/community/endpoints/test_openapi_session_files.py
+++ b/src/backend/tests/community/endpoints/test_openapi_session_files.py
@@ -107,6 +107,7 @@ def _record() -> SessionResourceRecord:
 
 
 class _ContentUpstream:
+    status_code = 200
     headers = {"content-type": "text/plain", "content-length": "3"}
 
     @property
@@ -172,7 +173,7 @@ def _seed_happy_services(world) -> None:
     def answer_records(_self, **_kwargs):
         return [record]
 
-    async def open_content(_self, **_kwargs):
+    async def open_session_file_content(_self, **_kwargs):
         return record, _ContentUpstream()
 
     bind_overrides(
@@ -183,7 +184,7 @@ def _seed_happy_services(world) -> None:
             "complete_upload": answer_record,
             "get_status": answer_record,
             "list_resources": answer_records,
-            "open_content": open_content,
+            "open_session_file_content": open_session_file_content,
             "delete": answer_record,
         },
     )


### PR DESCRIPTION
## Problem

OpenAPI Session File downloads used the materialization content path, which does not expose the existing Engine large-file export protocol. As a result, attachment downloads larger than the Engine threshold could not return the preparing or ready external-download responses through OpenAPI.

## Solution

- Add an OpenAPI-only `SessionResourceService.open_session_file_content()` path that retains resource ownership, bot, session, and device-context checks before calling the existing Engine `/api/session-files/{resource_id}/content` endpoint with `sessionKey` and `disposition`.
- Keep the legacy `open_content()` materialization path unchanged for existing callers.
- Preserve safe 200/202 response semantics, allowlisted download headers, JSON export responses without a fabricated `Content-Disposition`, and the standard 413 mapping for oversized inline previews.

## Validation

- `uv run pytest tests/community/architecture/test_no_oversized_modules.py::test_no_new_oversized_files 'tests/community/endpoints/test_endpoint_runner.py::test_endpoint_injection[GET /openapi/v1/bots/{bot_id}/sessions/{session_id}/files/{resource_id}/content :: happy]' tests/community/core/session_resources/test_service.py tests/community/adapters/http/openapi_v1/engine_runtime/test_session_files.py -q` — 52 passed.
- `PYTHONPATH=src uv run --with pytest pytest src/engine/community/api/session_files/tests/test_router.py::test_large_attachment_returns_preparing_then_external_url src/engine/community/api/session_files/tests/test_router.py::test_inline_rejects_large_files_without_starting_export -q` — 2 passed.
- Backend full suite — 13,708 passed, 23 skipped.
- `git diff origin/dev_refactory_collaboration...HEAD --check` — passed.

## Compatibility and risk

Engine, BaaS clients, existing logs, and the legacy materialization download path are unchanged. The Backend does not generate, persist, log, or fetch the Engine's short-lived external URL; it only returns the controlled Engine response after authorization.

## Spec

The local design and review records are intentionally excluded from this PR at the user's request: `spec/pipeline/openapi-session-file-large-download/`.
