### PR TITLE
fix(skills-pool): accept omitted locators for empty local skills

### DIFF
--- a/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/mapping_intent.py
@@ -222,6 +222,17 @@ def local_locators_from_evidence(
     names: list[str],
     evidence: dict[str, object] | None,
 ) -> dict[int, str]:
+    # ``local_locators`` carries no information when this Bot has no Local
+    # Skills.  Older runtime mapping consumers omit that empty field, so retain
+    # compatibility with their valid zero-Local-Skill response shape.  An
+    # explicit null or a malformed value remains invalid evidence.
+    if (
+        not assets
+        and not names
+        and isinstance(evidence, dict)
+        and "local_locators" not in evidence
+    ):
+        return {}
     raw_locators = (
         evidence.get("local_locators") if isinstance(evidence, dict) else None
     )

--- a/src/backend/tests/community/core/skills_pool/test_mapping_intent.py
+++ b/src/backend/tests/community/core/skills_pool/test_mapping_intent.py
@@ -273,6 +273,31 @@ def test_reuses_one_engine_locator_for_historical_skill_versions() -> None:
     }
 
 
+@pytest.mark.parametrize("evidence", [{}, {"other_runtime_evidence": "kept"}])
+def test_accepts_omitted_locator_evidence_when_no_local_skills(
+    evidence: dict[str, object],
+) -> None:
+    """Old runtimes may omit a field that has no values to report."""
+
+    assert local_locators_from_evidence([], [], evidence) == {}
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        None,
+        {"local_locators": None},
+        {"local_locators": []},
+        {"local_locators": {"unexpected": "local:///runtime/pool/unexpected"}},
+    ],
+)
+def test_rejects_invalid_locator_evidence_when_no_local_skills(
+    evidence: dict[str, object] | None,
+) -> None:
+    with pytest.raises(ValueError, match="Engine"):
+        local_locators_from_evidence([], [], evidence)
+
+
 @pytest.mark.parametrize(
     "evidence",
     [


### PR DESCRIPTION
## Problem
A service Bot with no Local Skills can finish runtime cutover but remains in `pool_cutover_committed` when an older mapping runtime omits the empty `local_locators` field. Service artifact builds correctly refuse this non-terminal state.

## Solution
Treat an omitted `local_locators` field as an empty mapping only when both the registered Local Skill assets and names are empty. Explicit null, malformed payloads, unexpected keys, and every non-empty Local Skill case remain fail-closed.

## Validation
- `uv run --directory src/backend ruff check src/agentclaw/community/core/skills_pool/mapping_intent.py tests/community/core/skills_pool/test_mapping_intent.py`
- `uv run --directory src/backend pytest tests/community/core/skills_pool/test_mapping_intent.py tests/community/core/skills_pool/test_reconcile_service.py -q` (107 passed)
- `uv run --directory src/backend pytest tests/community/architecture/test_module_boundaries.py -q` (3 passed)

## Compatibility and risk
This is backward-compatible normalization for a zero-value field only; malformed evidence continues to fail closed. No API, schema, or migration changes.