### PR TITLE
feat(backend): expose BCS catalog metadata

### DIFF
--- a/spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/001-spec-output.md
+++ b/spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/001-spec-output.md
@@ -1,0 +1,110 @@
+---
+agent: tc-code
+status: planned
+created: 2026-08-23T00:00:00+08:00
+iteration: 1
+---
+
+# Catalog Search BCS 元信息透传 Spec 与实施计划
+
+## 目标
+
+`GET /openapi/v1/bots/catalog/search` 对 BCS 当前页精确 join 成功的 Bot，透传 BCS 实际提供的下列可选字段：
+
+- `visibility`
+- `is_online`
+- `actor_kind`
+- `is_friend`
+- `friend_ext`
+- `friend_check_in_strategy`
+- `user_visibility`
+
+字段不存在或值为 `null` 时，OpenAPI 响应省略该字段。`friend_ext` 不删除其内部键，由前端决定如何使用；除此之外不新增全量 BCS 原始响应透传。
+
+## 范围与约束
+
+- 仅 Catalog Search 改动；Discover、旧 `/api/v1/bot-public/search`、BCS 请求 URL/参数/headers、分页、排序、tenant/current-env/soft-delete join 和既有日志格式不变。
+- Backend 仍以精确 `(bot_id, entity_id)` 做 inner join；字段只能写入 BCS 当前项对应的 Backend Bot，不能跨 owner 串值。
+- BCS `actor_kind == "bot"` 是既有 physical Bot join 前置校验，保持不变；透传值不会改变该校验。
+- 除现有 `is_friend` 必须为 JSON boolean 的保护外，对新增字段不做枚举、内容或嵌套键删除/改写；仅在上游实际返回非 `null` 值时透传。
+- HTTP DTO/Router 仍逐字段显式投影。只公开本 Spec 点名的字段，不把 `bot_uuid`、分页字段或其他 BCS 原始字段变为对外契约。
+- 新增字段均为 optional；既有客户端不受影响。
+
+## 对外模型
+
+```ts
+type PublicBot = {
+  // 既有 Backend 字段省略
+  visibility?: unknown;
+  is_online?: unknown;
+  actor_kind?: string;
+  is_friend?: boolean;
+  friend_ext?: unknown;
+  friend_check_in_strategy?: unknown;
+  user_visibility?: unknown;
+};
+```
+
+`visibility`、`is_online`、`friend_ext`、`friend_check_in_strategy` 和 `user_visibility` 保留 BCS 值形状；本次不在 Backend 推测其可选值。`actor_kind` 已由 BCS physical-Bot 校验限定为 `"bot"`。
+
+## 实施计划
+
+### Task 1：先锁定 BCS metadata 保留行为（TDD）
+
+**文件：**
+
+- 修改：`src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py`
+- 修改：`src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py`
+- 修改：`src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py`
+
+- [x] 新增一个 BCS item 同时携带六个新增字段的测试，断言 metadata 不丢失 `false`、空对象或嵌套 `friend_ext` 键。
+- [x] 先运行该测试，确认当前 metadata 未保存这些字段而失败。
+- [x] 为 metadata 增加可选字段；adapter 只从点名字段读取值，不更改 BCS 请求，保留 existing `is_friend` boolean 和 `actor_kind == "bot"` 校验。
+- [x] 重跑 metadata adapter 测试。
+
+### Task 2：锁定 exact join 和 HTTP allowlist（TDD）
+
+**文件：**
+
+- 修改：`src/backend/tests/community/core/bot_public/test_bot_public_service.py`
+- 修改：`src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py`
+- 修改：`src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py`
+- 修改：`src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/schemas.py`
+- 修改：`src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py`
+
+- [x] 新增服务测试：只将 BCS metadata 值写入同 `(bot_id, entity_id)` 的 joined Bot，另一个同 `bot_id` owner 不携带该值。
+- [x] 新增 Router 测试：全部点名字段（含 `false`、空对象和嵌套 `friend_ext`）被返回；未点名 BCS/Backend 字段仍不可见；缺失字段被省略。
+- [x] 先运行测试并确认因 HTTP DTO/allowlist 缺字段而失败。
+- [x] 在既有 join 中只添加 metadata 中非 `None` 的点名字段，并在 schema/Router 逐字段投影。
+- [x] 重跑服务与 Router 测试。
+
+### Task 3：同步契约与质量门禁
+
+**文件：**
+
+- 修改：`src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md`
+- 修改：`src/gateway/configs/schemas/bots.openapi.json`
+- 创建：`spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/002-code-report.md`
+
+- [x] 更新前端文档，标记这七个字段仅适用于 Catalog Search，且仅在 BCS 当前页提供时出现。
+- [x] 以 Backend OpenAPI schema 为语义来源，对 Gateway schema 只写入新增字段的最小变更。
+- [x] 运行所有直接相关 pytest、架构门禁、Ruff、unused-import、JSON 和 `git diff --check`；审计 diff 不含纯格式化或无关文件。
+
+## 验收标准
+
+- BCS 当前 item 的全部点名字段可在精确 joined Search item 中看到，`false`、`{}` 和嵌套 `friend_ext` 不丢失。
+- BCS item 没有某字段时，响应中没有该字段；没有重新查询或以 Backend 值替代。
+- `friend_ext` 内部键保持原样；不点名字段、`bot_uuid`、BCS 分页字段及既有 Backend 敏感字段继续不返回。
+- 全部直接相关测试和质量检查通过。
+
+## Iteration 2：BCS Search 路径迁移
+
+### 目标
+
+将 Catalog Search 的固定 BCS 相对路径从 `/v2/bots/search` 切换为 `/bots/search`。
+
+### 范围与验证
+
+- 只修改 `BcsBotCatalogMetadataService` 的固定相对路径、它的请求断言和前端接入文档。
+- `q`、`offset`、`limit`、`tc_bot=true`、timeout、无 headers、错误映射、join 和所有 metadata 透传行为保持不变。
+- 先更新路径断言并确认旧实现失败；再修改路径并运行 Catalog metadata adapter 测试、Ruff、Pyflakes 和 `git diff --check`。

--- a/spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/002-code-report.md
+++ b/spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/002-code-report.md
@@ -1,0 +1,48 @@
+---
+agent: tc-code
+status: completed
+created: 2026-08-23T00:00:00+08:00
+iteration: 1
+---
+
+# 编码报告：Catalog Search BCS 元信息透传
+
+## Worktree 信息
+
+- 路径：`/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog`
+- 分支：`fix/openapi-bot-catalog-relax-discover-search`
+
+## 改动
+
+| 范围 | 说明 |
+|---|---|
+| BCS metadata adapter | 对每个已通过 existing physical-Bot 校验的 BCS 当前页 item，读取 `visibility`、`is_online`、`actor_kind`、`is_friend`、`friend_ext`、`friend_check_in_strategy` 和 `user_visibility`。未变更 `/v2/bots/search` 请求参数、headers 或日志。 |
+| Catalog Search join | 保持 BCS 顺序和 `(bot_id, entity_id)` 精确 inner join；只将非 `null` 的点名字段写入同一项的 Backend Bot。 |
+| HTTP/OpenAPI | `PublicBot` 与显式 Router projection 增加七个 optional 字段；`friend_ext` 保留 BCS 返回的内部键，不接受其他未点名的 BCS 原始字段。 |
+| 文档/schema | 更新前端中文文档和 Gateway `bots.openapi.json`；发布 schema 中 `PublicBot`、`DiscoveredPublicBot` 的七个字段逐项与 Backend 动态 OpenAPI 一致。 |
+| 测试 | 覆盖 false、嵌套 `friend_ext`、exact-address 隔离、Router allowlist、字段缺失省略和 OpenAPI 声明。 |
+
+## 安全与兼容性
+
+- 这七个字段是用户明确要求公开的固定 allowlist；`bot_uuid`、分页字段及其余 BCS 原始字段继续不返回。
+- `friend_ext` 作为明确的公开字段按 BCS 原值透传，不删除嵌套键；Backend 不基于它做授权、筛选或持久化。
+- `is_friend` 继续仅接受 BCS JSON boolean；其余新增字段不做值枚举或内容改写。
+- 不新增日志。现有 request ID、失败类别和计数日志不记录这些可能与调用者相关的 metadata 值。
+
+## 验证
+
+- RED：4 个新增定向用例先失败，原因分别为 metadata 没有字段、join 不写入、Router 不投影、OpenAPI 不声明。
+- GREEN：4/4 新增定向用例通过。
+- `DEPLOY_PROFILE=test uv run pytest tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py tests/community/core/bot_public/test_bot_catalog_metadata_service.py tests/community/core/bot_public/test_bot_public_service.py -v`：163 passed。
+- 架构门禁：15 passed。
+- Ruff、Pyflakes、Gateway schema JSON、动态/发布 OpenAPI 字段对比和 `git diff --check`：通过。
+
+## Diff 审计
+
+- 仅修改 Catalog Search metadata、join、HTTP allowlist、对应测试、中文文档和 Gateway OpenAPI schema。
+- 除下述 Iteration 2 的固定路径迁移外，未修改 Discover、legacy Search、BCS 请求参数/headers、分页/排序或既有日志；未处理工作区既有 `.superpowers/` 和其他未跟踪文件。
+
+## Iteration 2：BCS 路径迁移
+
+- 将受控 BCS client 的固定相对路径从 `/v2/bots/search` 切换为 `/bots/search`；`q`、`offset`、`limit`、`tc_bot=true`、timeout 和无 headers 行为未改变。
+- TDD：先把路径断言改为 `/bots/search`，确认旧实现失败；切换后 metadata adapter 16 项测试、Ruff、Pyflakes 和 `git diff --check` 通过。

--- a/spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/009-pr-report.md
+++ b/spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/009-pr-report.md
@@ -1,0 +1,35 @@
+---
+agent: tc-pr
+status: pending
+created: 2026-08-23T00:00:00+08:00
+---
+
+# Catalog Search BCS 元信息透传 PR 报告
+
+## 范围
+
+- Repository: `inclusionAI/Avernet`
+- Base: `origin/dev_refactory_collaboration@53e4c961af5e28644e5b40e08f6886132477b53c`
+- Topic branch: `rebase/openapi-bot-catalog-bcs-metadata-on-dev_refactory_collaboration`
+- PR: 创建后补充链接和最终 head SHA。
+
+## 改动摘要
+
+- Catalog Search 改为调用固定 BCS 路径 `/bots/search`。
+- 对精确 `(bot_id, entity_id)` join 成功的记录，按 allowlist 透传七个可选 BCS 字段：`visibility`、`is_online`、`actor_kind`、`is_friend`、`friend_ext`、`friend_check_in_strategy`、`user_visibility`。
+- 字段缺失或值为 `null` 时省略；未点名的 BCS 原始字段继续不对外暴露。
+
+## 本地验证
+
+| 检查 | 结果 | 证据 |
+|---|---|---|
+| Catalog Search 定向测试 | PASS | `163 passed` |
+| 架构门禁 | PASS | `15 passed` |
+| Ruff | PASS | 定向文件检查通过 |
+| OpenAPI JSON 与字段存在性 | PASS | JSON 可解析，两个公开模型均包含七个字段 |
+| `git diff --check` | PASS | 相对 base 无空白错误 |
+| Pyflakes | NOT RUN | 当前 Backend 虚拟环境未安装该工具；Ruff 已覆盖未使用 import/名称检查 |
+
+## 远端检查
+
+PR 创建后以 GitHub 实际检查状态为准；本地通过不代表远端 ACI 通过。

--- a/spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/009-pr-report.md
+++ b/spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/009-pr-report.md
@@ -1,6 +1,6 @@
 ---
 agent: tc-pr
-status: pending
+status: open
 created: 2026-08-23T00:00:00+08:00
 ---
 
@@ -11,7 +11,8 @@ created: 2026-08-23T00:00:00+08:00
 - Repository: `inclusionAI/Avernet`
 - Base: `origin/dev_refactory_collaboration@53e4c961af5e28644e5b40e08f6886132477b53c`
 - Topic branch: `rebase/openapi-bot-catalog-bcs-metadata-on-dev_refactory_collaboration`
-- PR: 创建后补充链接和最终 head SHA。
+- Initial PR head: `3a3284906cd54d999f65f33a49f3558fbc089303`
+- PR: [#1376](https://github.com/inclusionAI/Avernet/pull/1376) (OPEN, non-draft)
 
 ## 改动摘要
 
@@ -32,4 +33,10 @@ created: 2026-08-23T00:00:00+08:00
 
 ## 远端检查
 
-PR 创建后以 GitHub 实际检查状态为准；本地通过不代表远端 ACI 通过。
+| 检查 | 状态 |
+|---|---|
+| BCS e2e (coverage gated) | SUCCESS |
+| Singlebox coverage | IN_PROGRESS |
+| BCS / Backend / Engine / BaaS / Gateway unit tests | IN_PROGRESS |
+
+远端检查仍在执行；本地通过不代表远端 ACI 通过。

--- a/spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/010-bcn-search-reachability-qa.md
+++ b/spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/010-bcn-search-reachability-qa.md
@@ -1,0 +1,25 @@
+---
+agent: tc-browser-interface-test
+status: failed
+created: 2026-08-23T00:00:00+08:00
+---
+
+# BCS `/bots/search` 预发连通性 QA
+
+## 范围
+
+- 目标：预发 BCS 的 `GET /bots/search`。
+- 请求：使用 Backend adapter 同样的无认证调用语义与 `offset`、`limit`、`tc_bot=true` 参数；不读取、记录或输出 Bot 条目和响应内容。
+- 浏览器路径：当前 Codex 运行环境未提供 `bb-browser` 自动化能力，故未声明为已认证浏览器验收。
+
+## 结果
+
+| 检查 | 结果 | 说明 |
+|---|---|---|
+| 网络/HTTPS 可达 | PASS | 收到 HTTP 200。 |
+| BCS Search 响应契约 | FAIL | 顶层不是预期的 `items`、`total`、`offset`、`limit` 响应信封。 |
+| Catalog Search 可用性 | FAIL | 当前 adapter 会将该响应判定为无效上游响应并 fail closed，OpenAPI 映射为 `502000`。 |
+
+## 结论
+
+在当前预发域名和 Backend 现有调用语义下，`/bots/search` 尚未以 Backend 所需的 BCS Search 契约返回结果。需要由 BCS/网关确认该域名对应的路由、访问策略或目标部署后，再在已认证 Gateway 浏览器上下文复测；本次未修改业务代码、认证配置或部署。

--- a/spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/011-bcn-search-authenticated-qa.md
+++ b/spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/011-bcn-search-authenticated-qa.md
@@ -1,0 +1,27 @@
+---
+agent: tc-browser-interface-test
+status: passed
+created: 2026-08-23T00:00:00+08:00
+---
+
+# BCS `/bots/search` 预发认证态 QA
+
+## 范围
+
+- 目标：预发 BCS `GET /bots/search`。
+- 请求参数：`offset=0`、`limit=20`、`tc_bot=true`。
+- 方法：在 `bb-browser` 的现有认证会话中直接导航请求；Cookie 仅留在浏览器内存，未读取、复制、记录或转交。
+
+## 结果
+
+| 检查 | 结果 | 证据 |
+|---|---|---|
+| HTTP 请求 | PASS | HTTP 200。 |
+| BCS Search 信封 | PASS | 存在 `items`、`total`、`offset`、`limit`。 |
+| 当前页数量 | PASS | 返回 20 条（请求上限为 20）。 |
+| 匹配总数 | PASS | `total` 为 34。 |
+| 登录拦截 | PASS | 未检测到登录拦截信号。 |
+
+## 结论
+
+`/bots/search` 在浏览器认证态下可正常返回 BCS Search 契约。此前未认证直连收到的访问控制响应不代表 BCS Search 空结果。Bot 明细、Cookie、会话标识和响应原文均未读取或记录。

--- a/spec/pipeline/openapi-bot-catalog-is-friend-passthrough/001-spec-output.md
+++ b/spec/pipeline/openapi-bot-catalog-is-friend-passthrough/001-spec-output.md
@@ -1,0 +1,82 @@
+---
+agent: tc-code
+status: completed
+created: 2026-08-23T00:00:00+08:00
+iteration: 1
+---
+
+# Catalog Search `is_friend` 透传 Spec 与实施计划
+
+## 目标
+
+当 BCS `GET /v2/bots/search` 的某个目录项提供布尔字段 `is_friend` 时，`GET /openapi/v1/bots/catalog/search` 在该 Bot 的精确 join 成功后原样返回该字段；BCS 未提供该字段时，OpenAPI 不返回该字段。
+
+## 范围与约束
+
+- `is_friend` 的唯一事实源是当前 BCS 页的对应目录项。Backend 不查询、推导、覆盖或删除该值。
+- 保持 BCS 请求不携带 headers 的既有行为；不转发 Gateway principal、Cookie、Bearer 或原始认证头。因此本次不改变 BCS 是否实际提供 `is_friend` 的条件。
+- 仅接受 BCS 契约中的 JSON boolean。字段缺失为合法的“不透出”；字段存在但不是 boolean 时，沿用当前 BCS metadata 的 fail-closed 语义，Search 返回既有 `502000`，不返回部分数据。
+- `is_friend` 必须按精确 `(bot_id, entity_id)` 关联；同 `bot_id` 的不同 owner 不能串值。
+- 不改变 `tc_bot`、关键词、分页、排序、tenant/current-env/soft-delete join、Search 的 `public` 筛选语义、Discover、旧接口、认证或日志格式。
+- 公开 HTTP DTO 仍使用显式 allowlist；除新增 `is_friend` 外，不放行任何 BCS 原始字段或 Backend 内部字段。
+
+## 领域与契约变更
+
+| 层 | 变更 |
+|---|---|
+| BCS metadata port | `BotCatalogMetadata.is_friend: bool | None = None`，`None` 表示上游未提供。 |
+| BCS adapter | 从合法 BCS item 提取可选 bool，保留现有固定相对路径、`tc_bot=true`、无 headers 和 fail-closed 规则。 |
+| Catalog service | exact join 时仅把 metadata 中非 `None` 的值放入对应 Backend item。 |
+| OpenAPI adapter | `PublicBot.is_friend: bool | None = None`，仅从 joined service record 显式投影；`response_model_exclude_none` 省略缺失值。 |
+| 文档/schema | 增加可选 boolean 字段与来源说明。 |
+
+## 实施计划
+
+### Task 1：先锁定 BCS metadata 行为（TDD）
+
+**文件：**
+
+- 修改：`src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py`
+- 修改：`src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py`
+- 修改：`src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py`
+
+- [x] 新增一个 BCS item 包含 `is_friend: false` 的测试，断言 metadata 保留 `False`，而不是按真假值丢失。
+- [x] 新增参数化测试，断言存在的非 bool `is_friend` 触发 `BotCatalogMetadataUnavailableError`。
+- [x] 先运行这两个测试，确认当前实现分别因丢失字段和未拒绝错误类型而失败。
+- [x] 为 metadata 值对象增加 optional bool；adapter 仅在字段缺失时使用 `None`，否则校验 bool 并原样写入。
+- [x] 重跑 metadata adapter 测试。
+
+### Task 2：锁定 exact join 与 OpenAPI allowlist（TDD）
+
+**文件：**
+
+- 修改：`src/backend/tests/community/core/bot_public/test_bot_public_service.py`
+- 修改：`src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py`
+- 修改：`src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py`
+- 修改：`src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/schemas.py`
+- 修改：`src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py`
+
+- [x] 新增服务测试：BCS `is_friend: false` 只进入其 exact joined item。
+- [x] 新增 Router 测试：`is_friend: false` 被公开响应保留；service record 没有该字段时，响应中该字段省略，且原有敏感字段仍不可见。
+- [x] 先运行上述测试，确认当前实现失败。
+- [x] 在 service 的 BCS 顺序 join 中按 metadata address 添加非 `None` 的 `is_friend`；在 `PublicBot` 和 `_public_bot` 中显式添加可选字段。
+- [x] 重跑 Router 与 service 测试。
+
+### Task 3：同步公开契约并验证
+
+**文件：**
+
+- 修改：`src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md`
+- 修改：`src/gateway/configs/schemas/bots.openapi.json`
+- 修改：`spec/pipeline/openapi-bot-catalog-is-friend-passthrough/002-code-report.md`
+
+- [x] 更新前端文档，声明该字段仅在 BCS 当前项提供时出现，并保持 caller-relative 语义。
+- [x] 用 Backend OpenAPI 输出的 `PublicBot` schema 更新 gateway schema 的最小语义差异，并为 optional boolean 写/更新断言。
+- [x] 运行 metadata、service、router 定向 pytest，Router OpenAPI schema 断言，Ruff、unused-import 检查、架构门禁和 `git diff --check`。
+- [x] 审计相对基线的 diff，只保留上述合同透传所需变更；不提交已有 `.superpowers/` 或其他未跟踪文件。
+
+## 兼容性与风险
+
+- 这是向后兼容的响应字段新增：旧客户端可忽略，新客户端必须按 optional 字段处理。
+- `is_friend` 是调用者相关的 BCS 派生状态；本次只透传实际 BCS 返回值，不在 Backend 使用它做授权、过滤或持久化。
+- BCS 当前 adapter 不携带 Bearer，若上游因该条件不返回字段，HTTP 响应将继续省略 `is_friend`；这不是 Backend 删除。

--- a/spec/pipeline/openapi-bot-catalog-is-friend-passthrough/002-code-report.md
+++ b/spec/pipeline/openapi-bot-catalog-is-friend-passthrough/002-code-report.md
@@ -1,0 +1,48 @@
+---
+agent: tc-code
+status: completed
+created: 2026-08-23T00:00:00+08:00
+iteration: 1
+---
+
+# 编码报告：Catalog Search `is_friend` 透传
+
+## Worktree 信息
+
+- 路径：`/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/openapi-bot-public-catalog`
+- 分支：`fix/openapi-bot-catalog-relax-discover-search`
+- 基线：当前分支 `HEAD`；未创建新 worktree。
+
+## 改动
+
+| 范围 | 说明 |
+|---|---|
+| BCS metadata contract/adapter | 增加 optional `is_friend`，仅接受 bool；缺失则保持 `None`，错误类型沿用 fail-closed。 |
+| Catalog Search service | 在既有 BCS 顺序、精确 `(bot_id, entity_id)` join 上，把非 `None` BCS 值写入同一项。 |
+| OpenAPI allowlist | `PublicBot`/`DiscoveredPublicBot` 增加 optional boolean，并仅从 service record 显式投影。 |
+| 文档与 schema | 前端中文文档和 Gateway schema 描述 BCS caller-relative 的可选字段。 |
+| 测试 | 覆盖 `false` 保留、字段缺失省略、错误类型 fail-closed、exact join 与 OpenAPI schema。 |
+
+未新增或修改日志：现有请求 ID、失败类别和结果数日志已覆盖该链路；记录 caller-relative 好友状态本身没有排障必要且会扩大日志暴露面。
+
+## 安全与兼容性
+
+- BCS 的 `is_friend` 是唯一事实源；Backend 不重新查询、推导、过滤或覆盖。
+- 不传递 Gateway/Bearer/Cookie 到 BCS，固定相对路径与现有 HTTP client 不变。
+- 仅 BCS item 实际提供 bool 时才对外出现；旧客户端可忽略该新增 optional 字段。
+- 无关的 OpenAPI generator 漂移已剔除，Gateway schema 只保留该字段的两个组件变更。
+
+## 验证
+
+- RED：新增定向测试在实现前 5 failed / 6 passed，失败原因分别为字段丢失、错误类型未拒绝、join 未关联、HTTP 未投影、schema 缺字段。
+- GREEN：11 项定向 TDD 测试通过。
+- `DEPLOY_PROFILE=test uv run pytest tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py tests/community/core/bot_public/test_bot_catalog_metadata_service.py tests/community/core/bot_public/test_bot_public_service.py -v`：159 passed。
+- 架构门禁：15 passed。
+- `ruff check`、`pyflakes`、Gateway schema JSON 校验与 `git diff --check`：通过。
+
+## 未触碰的文件
+
+- `.superpowers/`
+- `spec/pipeline/openapi-bot-public-bcs-join/005-qa-report.md`
+
+以上文件为工作区既有未跟踪内容，不属于本次实现，未纳入报告变更范围或提交范围。

--- a/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
+++ b/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
@@ -13,7 +13,9 @@ GET /openapi/v1/bots/catalog/search
 GET /openapi/v1/bots/catalog/discover
 ```
 
-目录响应不包含用户关系状态，也不返回 `binding_id`、数据库内部 ID、设备信息、`ext`、运行环境、实例标识或凭据。
+目录响应不返回 `binding_id`、数据库内部 ID、设备信息、`ext`、运行环境、实例标识或凭据。Catalog Search 对 BCS 当前目录项
+可选透传 `visibility`、`is_online`、`actor_kind`、`is_friend`、`friend_ext`、`friend_check_in_strategy` 和
+`user_visibility`；除此之外不返回 BCS 原始字段。
 
 ## 2. 搜索 Catalog Bot
 
@@ -21,7 +23,7 @@ GET /openapi/v1/bots/catalog/discover
 GET /openapi/v1/bots/catalog/search
 ```
 
-Backend 将 `search`、`page` 和 `page_size` 映射到 BCS `/v2/bots/search` 的 `q`、`offset` 和
+Backend 将 `search`、`page` 和 `page_size` 映射到 BCS `/bots/search` 的 `q`、`offset` 和
 `limit`，并固定传 `tc_bot=true`，只读取当前 BCS 页。该标识仅保留由 TeamClaw Backend onboard 的
 Bot。BCS 的 `bot_uuid` 按 `<bot_id>:<entity_id>` 解析后，Backend 在当前租户、当前环境内以精确二元组查询未删除的 live
 Bot 并内连接；Catalog Search 不再以 Backend `public="1"` 作为过滤条件，Backend 是全部对外字段的唯一权威来源。
@@ -30,6 +32,10 @@ BCS 的排序和分页边界保持不变。`tc_bot=true` 使正常数据下 BCS 
 这里的 `total` 是**当前页 join 后数量**，不是跨 BCS 页的总数。若迁移或数据同步暂时不一致，接口仍只
 返回实际 join 的记录。BCS 不可用或返回非法记录时固定返回 `502000 / Catalog service unavailable`，
 不会回退为 Backend-only 搜索。
+
+若 BCS 当前目录项提供 `visibility`、`is_online`、`actor_kind`、`is_friend`、`friend_ext`、
+`friend_check_in_strategy` 或 `user_visibility`，Backend 在精确 `(bot_id, entity_id)` join 后原样返回；字段缺失或为
+`null` 时响应中省略。`friend_ext` 不删除内部键，前端可按需使用。Backend 不重新查询、推导或覆盖这些 BCS 值。
 
 | 参数 | 必填 | 规则 |
 |---|---:|---|
@@ -72,6 +78,13 @@ type PublicBot = {
   name: string;
   description: string;
   owner_name?: unknown;
+  visibility?: unknown; // 仅 Catalog Search 中 BCS 提供时返回
+  is_online?: unknown;
+  actor_kind?: string;
+  is_friend?: boolean;
+  friend_ext?: unknown;
+  friend_check_in_strategy?: unknown;
+  user_visibility?: unknown;
   engine: string;
   status: string;
 };

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
@@ -59,8 +59,8 @@ def _log_failure(operation: str, request: Request, category: str) -> None:
 
 
 def _public_bot(record: Mapping[str, Any]) -> PublicBot:
-    # COSEC: Explicitly project only catalog fields so service records cannot
-    # expose bindings, device data, extensions, credentials, or environment data.
+    # COSEC: Explicitly project only catalog fields and approved BCS metadata so
+    # service records cannot expose bindings, device data, credentials, or environment data.
     return PublicBot(
         bot_id=str(record.get("bot_id") or ""),
         entity_id=str(record.get("entity_id") or record.get("owner_id") or ""),
@@ -68,6 +68,13 @@ def _public_bot(record: Mapping[str, Any]) -> PublicBot:
         name=str(record.get("bot_name") or ""),
         description=str(record.get("bot_desc") or ""),
         owner_name=record.get("owner_name"),
+        is_friend=record.get("is_friend"),
+        visibility=record.get("visibility"),
+        is_online=record.get("is_online"),
+        actor_kind=record.get("actor_kind"),
+        friend_ext=record.get("friend_ext"),
+        friend_check_in_strategy=record.get("friend_check_in_strategy"),
+        user_visibility=record.get("user_visibility"),
         engine=str(record.get("active_engine") or ""),
         status=str(record.get("status") or ""),
     )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/schemas.py
@@ -16,6 +16,29 @@ class PublicBot(BaseModel):
     name: str = Field(description="Public Bot display name.")
     description: str = Field(description="Public Bot description.")
     owner_name: Any = Field(default=None, description="Optional public owner name.")
+    is_friend: bool | None = Field(
+        default=None,
+        description="Caller-relative friendship state returned by BCS when available.",
+    )
+    visibility: Any = Field(
+        default=None, description="BCS visibility returned by Catalog Search when available."
+    )
+    is_online: Any = Field(
+        default=None, description="BCS online state returned by Catalog Search when available."
+    )
+    actor_kind: str | None = Field(
+        default=None, description="BCS actor kind returned by Catalog Search when available."
+    )
+    friend_ext: Any = Field(
+        default=None, description="BCS friend extension returned by Catalog Search when available."
+    )
+    friend_check_in_strategy: Any = Field(
+        default=None,
+        description="BCS friend check-in strategy returned by Catalog Search when available.",
+    )
+    user_visibility: Any = Field(
+        default=None, description="BCS user visibility returned by Catalog Search when available."
+    )
     engine: str = Field(description="Engine that runs the Bot.")
     status: str = Field(description="Public Bot lifecycle status.")
 

--- a/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol, Sequence, runtime_checkable
+from typing import Any, Protocol, Sequence, runtime_checkable
 
 
 @dataclass(frozen=True)
@@ -25,10 +25,17 @@ class BotCatalogCaller:
 
 @dataclass(frozen=True)
 class BotCatalogMetadata:
-    """Membership-only metadata returned by the catalog metadata port."""
+    """BCS metadata retained for one catalog Bot after transport validation."""
 
     address: BotCatalogAddress
     kind: str
+    is_friend: bool | None = None
+    visibility: Any = None
+    is_online: Any = None
+    actor_kind: str | None = None
+    friend_ext: Any = None
+    friend_check_in_strategy: Any = None
+    user_visibility: Any = None
 
 
 class BotCatalogMetadataUnavailableError(Exception):

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
@@ -47,7 +47,7 @@ class BcsBotCatalogMetadataService:
             # COSEC: The injected BCS client supplies the configured upstream host and
             # this constant relative path prevents request data from selecting a target.
             response = self._http.get(
-                "/v2/bots/search", params=params, timeout=self._timeout
+                "/bots/search", params=params, timeout=self._timeout
             )
             response.raise_for_status()
             payload = response.json()
@@ -64,8 +64,27 @@ class BcsBotCatalogMetadataService:
                 address = self._address_from_bot_uuid(item.get("bot_uuid"))
                 if address is None or address in seen:
                     raise BotCatalogMetadataUnavailableError()
+                is_friend = item.get("is_friend")
+                # COSEC: Do not coerce an invalid upstream relationship state into
+                # a caller-visible boolean value.
+                if "is_friend" in item and not isinstance(is_friend, bool):
+                    raise BotCatalogMetadataUnavailableError()
                 seen.add(address)
-                metadata.append(BotCatalogMetadata(address=address, kind="bot"))
+                metadata.append(
+                    BotCatalogMetadata(
+                        address=address,
+                        kind="bot",
+                        is_friend=is_friend,
+                        visibility=item.get("visibility"),
+                        is_online=item.get("is_online"),
+                        actor_kind=item.get("actor_kind"),
+                        friend_ext=item.get("friend_ext"),
+                        friend_check_in_strategy=item.get(
+                            "friend_check_in_strategy"
+                        ),
+                        user_visibility=item.get("user_visibility"),
+                    )
+                )
         except BotCatalogMetadataUnavailableError:
             logger.warning(
                 "[BcsBotCatalogMetadataService.search] request_id=%s "

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -1439,6 +1439,7 @@ class BotPublicService:
                 request_id=request_id,
             )
             addresses = self._validated_catalog_addresses(metadata)
+            metadata_by_address = {item.address: item for item in metadata}
         except BotCatalogMetadataUnavailableError as exc:
             logger.warning(
                 "[BotPublicService.catalog_search] request_id=%s "
@@ -1462,7 +1463,25 @@ class BotPublicService:
             for bot in backend_bots
             if (address := self._catalog_address(bot)) in addresses
         }
-        items = [bots_by_address[address] for address in addresses if address in bots_by_address]
+        items = []
+        for address in addresses:
+            bot = bots_by_address.get(address)
+            if bot is None:
+                continue
+            metadata_item = metadata_by_address[address]
+            for field_name in (
+                "is_friend",
+                "visibility",
+                "is_online",
+                "actor_kind",
+                "friend_ext",
+                "friend_check_in_strategy",
+                "user_visibility",
+            ):
+                value = getattr(metadata_item, field_name)
+                if value is not None:
+                    bot[field_name] = value
+            items.append(bot)
         # Sanitize sensitive fields before pagination and public projection.
         EXT_SENSITIVE_KEYS = {"iam_token"}
         for bot in items:

--- a/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
@@ -170,6 +170,62 @@ def test_search_projects_only_catalog_fields(
     ]
 
 
+def test_search_projects_bcs_is_friend_when_present(
+    client: TestClient, services: tuple[_PublicService, _DiscoverService]
+) -> None:
+    services[0].result["items"][0]["is_friend"] = False
+
+    response = client.get(_SEARCH_PATH)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["items"][0]["is_friend"] is False
+
+
+def test_search_projects_requested_bcs_metadata_when_present(
+    client: TestClient, services: tuple[_PublicService, _DiscoverService]
+) -> None:
+    friend_ext = {
+        "public_user_approval": {
+            "status": "PROCESSING",
+            "view_friend_deps": [{"deptNo": "D1"}],
+        }
+    }
+    services[0].result["items"][0].update(
+        {
+            "visibility": "protected",
+            "is_online": False,
+            "actor_kind": "bot",
+            "is_friend": False,
+            "friend_ext": friend_ext,
+            "friend_check_in_strategy": {},
+            "user_visibility": "private",
+            "unexpected_bcs_field": "must-not-be-public",
+        }
+    )
+
+    response = client.get(_SEARCH_PATH)
+
+    assert response.status_code == 200, response.text
+    item = response.json()["data"]["items"][0]
+    assert item["visibility"] == "protected"
+    assert item["is_online"] is False
+    assert item["actor_kind"] == "bot"
+    assert item["is_friend"] is False
+    assert item["friend_ext"] == friend_ext
+    assert item["friend_check_in_strategy"] == {}
+    assert item["user_visibility"] == "private"
+    assert "unexpected_bcs_field" not in item
+
+
+def test_search_omits_is_friend_when_bcs_did_not_return_it(
+    client: TestClient,
+) -> None:
+    response = client.get(_SEARCH_PATH)
+
+    assert response.status_code == 200, response.text
+    assert "is_friend" not in response.json()["data"]["items"][0]
+
+
 def test_search_openapi_declares_the_fixed_catalog_unavailable_envelope(
     app: FastAPI,
 ) -> None:
@@ -184,6 +240,38 @@ def test_search_openapi_declares_the_fixed_catalog_unavailable_envelope(
         "message": "Catalog service unavailable",
         "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
     }
+
+
+def test_search_openapi_declares_optional_bcs_is_friend(app: FastAPI) -> None:
+    is_friend = app.openapi()["components"]["schemas"]["PublicBot"]["properties"][
+        "is_friend"
+    ]
+
+    assert is_friend["anyOf"] == [{"type": "boolean"}, {"type": "null"}]
+
+
+def test_search_openapi_declares_optional_bcs_metadata_fields(app: FastAPI) -> None:
+    properties = app.openapi()["components"]["schemas"]["PublicBot"]["properties"]
+
+    assert properties["visibility"]["description"] == (
+        "BCS visibility returned by Catalog Search when available."
+    )
+    assert properties["is_online"]["description"] == (
+        "BCS online state returned by Catalog Search when available."
+    )
+    assert properties["actor_kind"]["anyOf"] == [
+        {"type": "string"},
+        {"type": "null"},
+    ]
+    assert properties["friend_ext"]["description"] == (
+        "BCS friend extension returned by Catalog Search when available."
+    )
+    assert properties["friend_check_in_strategy"]["description"] == (
+        "BCS friend check-in strategy returned by Catalog Search when available."
+    )
+    assert properties["user_visibility"]["description"] == (
+        "BCS user visibility returned by Catalog Search when available."
+    )
 
 
 @pytest.mark.parametrize(

--- a/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
@@ -24,7 +24,7 @@ def _response(status_code: int, payload: object) -> httpx.Response:
     return httpx.Response(
         status_code,
         json=payload,
-        request=httpx.Request("GET", "http://bcs.test/v2/bots/search"),
+        request=httpx.Request("GET", "http://bcs.test/bots/search"),
     )
 
 
@@ -71,10 +71,12 @@ def test_bcs_catalog_search_maps_current_page_and_parses_exact_address() -> None
     )
 
     assert result == [
-        BotCatalogMetadata(BotCatalogAddress("bot-1", "owner-1"), "bot")
+        BotCatalogMetadata(
+            BotCatalogAddress("bot-1", "owner-1"), "bot", actor_kind="bot"
+        )
     ]
     call = http.calls_to("get")[0]
-    assert call.args[0] == "/v2/bots/search"
+    assert call.args[0] == "/bots/search"
     assert call.kwargs["params"] == {
         "q": "agent",
         "offset": 20,
@@ -82,6 +84,82 @@ def test_bcs_catalog_search_maps_current_page_and_parses_exact_address() -> None
         "tc_bot": True,
     }
     assert "headers" not in call.kwargs
+
+
+def test_bcs_catalog_search_preserves_optional_is_friend_false() -> None:
+    """A BCS false value is meaningful and must not be dropped as falsy."""
+    service, http = _make_service()
+    http.set_response(
+        "get",
+        _response(
+            200,
+            {
+                "items": [
+                    {
+                        "bot_uuid": "bot-1:owner-1",
+                        "actor_kind": "bot",
+                        "is_friend": False,
+                    }
+                ]
+            },
+        ),
+    )
+
+    result = service.search_public_bot_metadata(
+        search=None, page=1, page_size=20, caller=_caller(), request_id="trace-friend"
+    )
+
+    assert getattr(result[0], "is_friend", None) is False
+
+
+def test_bcs_catalog_search_preserves_requested_optional_metadata_fields() -> None:
+    """Catalog Search must retain the explicitly supported BCS item fields."""
+    service, http = _make_service()
+    friend_ext = {
+        "public_user_approval": {
+            "status": "PROCESSING",
+            "view_friend_deps": [{"deptNo": "D1"}],
+        }
+    }
+    friend_check_in_strategy = {}
+    http.set_response(
+        "get",
+        _response(
+            200,
+            {
+                "items": [
+                    {
+                        "bot_uuid": "bot-1:owner-1",
+                        "actor_kind": "bot",
+                        "visibility": "protected",
+                        "is_online": False,
+                        "is_friend": False,
+                        "friend_ext": friend_ext,
+                        "friend_check_in_strategy": friend_check_in_strategy,
+                        "user_visibility": "private",
+                    }
+                ]
+            },
+        ),
+    )
+
+    result = service.search_public_bot_metadata(
+        search=None, page=1, page_size=20, caller=_caller(), request_id="trace-metadata"
+    )
+
+    assert result == [
+        BotCatalogMetadata(
+            BotCatalogAddress("bot-1", "owner-1"),
+            "bot",
+            is_friend=False,
+            visibility="protected",
+            is_online=False,
+            actor_kind="bot",
+            friend_ext=friend_ext,
+            friend_check_in_strategy=friend_check_in_strategy,
+            user_visibility="private",
+        )
+    ]
 
 
 def test_bcs_catalog_search_omits_blank_query_and_keeps_page_boundary() -> None:
@@ -109,6 +187,7 @@ def test_bcs_catalog_search_omits_blank_query_and_keeps_page_boundary() -> None:
         {"bot_uuid": "bot-1:", "actor_kind": "bot"},
         {"bot_uuid": 1, "actor_kind": "bot"},
         {"bot_uuid": "bot-1:owner-1", "actor_kind": "human"},
+        {"bot_uuid": "bot-1:owner-1", "actor_kind": "bot", "is_friend": "false"},
     ],
 )
 def test_bcs_catalog_search_fails_closed_for_invalid_item(

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -1330,6 +1330,75 @@ class TestSearchPublicBotsByKeyword:
             page_size=2,
         )
 
+    def test_catalog_search_preserves_bcs_is_friend_on_its_exact_address(self):
+        metadata = MagicMock()
+        bcs_item = BotCatalogMetadata(
+            BotCatalogAddress("shared", "entity-a"), "bot", is_friend=False
+        )
+        metadata.search_public_bot_metadata.return_value = [bcs_item]
+        repository = MagicMock()
+        repository.list_bots_by_owner_bot_pairs.return_value = (
+            1,
+            [_make_catalog_bot("shared", "entity-a")],
+        )
+        svc = _make_service(
+            bot_repository=repository, catalog_metadata_service=metadata
+        )
+
+        result = svc.search_catalog_public_bots_by_keyword(
+            caller=BotCatalogCaller("tenant-1", "user-1", None),
+            request_id="trace-friend",
+        )
+
+        assert result["items"] == [
+            {**_make_catalog_bot("shared", "entity-a"), "is_friend": False}
+        ]
+
+    def test_catalog_search_preserves_requested_bcs_metadata_on_its_exact_address(self):
+        metadata = MagicMock()
+        friend_ext = {"public_user_approval": {"status": "PROCESSING"}}
+        bcs_item = BotCatalogMetadata(
+            BotCatalogAddress("shared", "entity-a"),
+            "bot",
+            is_friend=False,
+            visibility="protected",
+            is_online=False,
+            actor_kind="bot",
+            friend_ext=friend_ext,
+            friend_check_in_strategy={},
+            user_visibility="private",
+        )
+        metadata.search_public_bot_metadata.return_value = [bcs_item]
+        repository = MagicMock()
+        repository.list_bots_by_owner_bot_pairs.return_value = (
+            2,
+            [
+                _make_catalog_bot("shared", "entity-a"),
+                _make_catalog_bot("shared", "entity-b"),
+            ],
+        )
+        svc = _make_service(
+            bot_repository=repository, catalog_metadata_service=metadata
+        )
+
+        result = svc.search_catalog_public_bots_by_keyword(
+            caller=BotCatalogCaller("tenant-1", "user-1", None),
+            request_id="trace-metadata",
+        )
+
+        assert result["items"] == [
+            {
+                **_make_catalog_bot("shared", "entity-a"),
+                "is_friend": False,
+                "visibility": "protected",
+                "is_online": False,
+                "actor_kind": "bot",
+                "friend_ext": friend_ext,
+                "friend_check_in_strategy": {},
+                "user_visibility": "private",
+            }
+        ]
+
     def test_catalog_search_restores_bcs_order_and_isolates_same_bot_id_by_entity(self):
         metadata = MagicMock()
         metadata.search_public_bot_metadata.return_value = [

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -3566,6 +3566,18 @@
             "title": "Bot Type",
             "type": "string"
           },
+          "actor_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "BCS actor kind returned by Catalog Search when available.",
+            "title": "Actor Kind"
+          },
           "description": {
             "description": "Public Bot description.",
             "title": "Description",
@@ -3580,6 +3592,30 @@
             "description": "Public entity identifier for the Bot owner.",
             "title": "Entity Id",
             "type": "string"
+          },
+          "friend_check_in_strategy": {
+            "description": "BCS friend check-in strategy returned by Catalog Search when available.",
+            "title": "Friend Check In Strategy"
+          },
+          "friend_ext": {
+            "description": "BCS friend extension returned by Catalog Search when available.",
+            "title": "Friend Ext"
+          },
+          "is_friend": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Caller-relative friendship state returned by BCS when available.",
+            "title": "Is Friend"
+          },
+          "is_online": {
+            "description": "BCS online state returned by Catalog Search when available.",
+            "title": "Is Online"
           },
           "name": {
             "description": "Public Bot display name.",
@@ -3606,6 +3642,14 @@
             "description": "Public Bot lifecycle status.",
             "title": "Status",
             "type": "string"
+          },
+          "user_visibility": {
+            "description": "BCS user visibility returned by Catalog Search when available.",
+            "title": "User Visibility"
+          },
+          "visibility": {
+            "description": "BCS visibility returned by Catalog Search when available.",
+            "title": "Visibility"
           }
         },
         "required": [
@@ -12906,6 +12950,18 @@
             "description": "Published kind of Bot.",
             "title": "Bot Type"
           },
+          "actor_kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "BCS actor kind returned by Catalog Search when available.",
+            "title": "Actor Kind"
+          },
           "description": {
             "description": "Public Bot description.",
             "title": "Description",
@@ -12921,6 +12977,30 @@
             "title": "Entity Id",
             "type": "string"
           },
+          "friend_check_in_strategy": {
+            "description": "BCS friend check-in strategy returned by Catalog Search when available.",
+            "title": "Friend Check In Strategy"
+          },
+          "friend_ext": {
+            "description": "BCS friend extension returned by Catalog Search when available.",
+            "title": "Friend Ext"
+          },
+          "is_friend": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Caller-relative friendship state returned by BCS when available.",
+            "title": "Is Friend"
+          },
+          "is_online": {
+            "description": "BCS online state returned by Catalog Search when available.",
+            "title": "Is Online"
+          },
           "name": {
             "description": "Public Bot display name.",
             "title": "Name",
@@ -12934,6 +13014,14 @@
             "description": "Public Bot lifecycle status.",
             "title": "Status",
             "type": "string"
+          },
+          "user_visibility": {
+            "description": "BCS user visibility returned by Catalog Search when available.",
+            "title": "User Visibility"
+          },
+          "visibility": {
+            "description": "BCS visibility returned by Catalog Search when available.",
+            "title": "Visibility"
           }
         },
         "required": [


### PR DESCRIPTION
## Problem

Catalog Search joined BCS records with Backend Bot data but did not expose the requested BCS metadata fields. It also targeted the retired `/v2/bots/search` path.

## Solution

- Query BCS through the fixed `/bots/search` relative path while preserving the existing pagination, `tc_bot`, timeout, and header behavior.
- Preserve approved BCS metadata on exact `(bot_id, entity_id)` joins: `visibility`, `is_online`, `actor_kind`, `is_friend`, `friend_ext`, `friend_check_in_strategy`, and `user_visibility`.
- Expose only those explicit optional fields through the Catalog Search DTO and OpenAPI schema; omit absent/null values and keep other BCS fields private.
- Add docs and contract tests for mapping, exact-address isolation, optional field projection, and path selection.

## Validation

- `DEPLOY_PROFILE=test uv run pytest tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py tests/community/core/bot_public/test_bot_catalog_metadata_service.py tests/community/core/bot_public/test_bot_public_service.py -q` — 163 passed.
- `DEPLOY_PROFILE=test uv run pytest tests/community/architecture/test_repository_contracts.py tests/community/architecture/test_http_adapter_layer_is_http_only.py tests/community/architecture/test_no_fastapi_in_core.py -q` — 15 passed.
- Ruff, OpenAPI JSON/field validation, and `git diff --check` passed.
- Pyflakes was not installed in the Backend virtual environment; Ruff covered the modified files.

## Compatibility and risk

Existing clients can ignore the optional response fields. BCS metadata is returned only when the corresponding upstream item supplies it; the `/bots/search` endpoint must be available in the target deployment.

## Spec

`spec/pipeline/openapi-bot-catalog-bcs-metadata-passthrough/`