### PR TITLE
Feat/collaboration bots public external path

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -176,7 +176,7 @@ from fastapi import APIRouter, Depends
 from .authorized_apps import app_view_router as authorized_bots_router
 from .authorized_apps import router as authorized_apps_router
 from .bots import router as bots_router
-from .collaboration_bots import router as collaboration_bots_router
+from .collaboration_bots import public_router as collaboration_public_router
 from .bots.engine_config import router as engine_config_router
 from .org import dept_router as org_dept_router
 from .org import router as org_router
@@ -520,12 +520,14 @@ def build_public_router() -> APIRouter:
     public.include_router(
         bots_router, responses=ERROR_RESPONSES, dependencies=_PUBLIC_AUTH
     )
-    # New-version bcs publish-to-users (backend route: /openapi/v1/bots/{bot_id}/public-bcs;
-    # the gateway rewrites the external /openapi/v1/collaboration/bots/{bot_uuid}/public onto
-    # it). Declares user-scoped responses for the openapi_v1 admission contract; authz
-    # is deferred per design (caller identity via _PUBLIC_AUTH/UserIdDep, no grant check yet).
+    # New-version bcs publish-to-users: served at the external contract path
+    # POST /openapi/v1/collaboration/bots/{bot_uuid}/public. The gateway's
+    # collaboration-publish domain verbatim-forwards it here (no rewrite), so the
+    # backend serves the public address directly. user-scoped responses for the
+    # openapi_v1 admission contract; authz deferred per design (caller identity
+    # via _PUBLIC_AUTH/UserIdDep, no grant check yet).
     public.include_router(
-        collaboration_bots_router,
+        collaboration_public_router,
         responses=USER_SCOPED_ERROR_RESPONSES,
         dependencies=_PUBLIC_AUTH,
     )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -574,7 +574,8 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     ("GET", "/openapi/v1/bots/mcp/servers/{server_code}"): AdmissionMode.OPEN,
     ("GET", "/openapi/v1/bots/mcp/tenants"): AdmissionMode.OPEN,
     # New-version bcs publish-to-users: auth baseline only, no grant check; authz deferred.
-    ("POST", "/openapi/v1/bots/{bot_id}/public-bcs"): AdmissionMode.OPEN,
+    # Served at the external contract path the gateway verbatim-forwards here.
+    ("POST", "/openapi/v1/collaboration/bots/{bot_uuid}/public"): AdmissionMode.OPEN,
     # Department directory search — a tenant-wide catalogue read, not a user's.
     ("GET", "/openapi/v1/org/dept"): AdmissionMode.OPEN,
     ("POST", "/openapi/v1/bots/market/skills"): AdmissionMode.OPEN,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
@@ -299,7 +299,7 @@ AUTHORIZATION: dict[tuple[str, str], Authorization] = {
     ("GET", "/openapi/v1/bots/{bot_id}/nodes"):
         ServiceChecked(PermissionLevel.MEMBER, "…openapi_v1.engine_runtime.gating"),
     ("GET", "/openapi/v1/bots/{bot_id}/passport"): OWNER_SCOPED,
-    ("POST", "/openapi/v1/bots/{bot_id}/public-bcs"): OWNER_SCOPED,
+    ("POST", "/openapi/v1/collaboration/bots/{bot_uuid}/public"): OWNER_SCOPED,
     ("GET", "/openapi/v1/bots/{bot_id}/render-screens"):
         NoCheck("share and group viewers must render panels without an Editor relation"),
     ("POST", "/openapi/v1/bots/{bot_id}/render-screens"):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/collaboration_bots/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/collaboration_bots/__init__.py
@@ -6,6 +6,6 @@ out of the collaboration→bcs namespace onto the backend. Auth (grant /
 admission) is deferred for now: the handler identifies the caller but applies
 no bot-grant check.
 """
-from .router import router
+from .router import public_router
 
-__all__ = ["router"]
+__all__ = ["public_router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/collaboration_bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/collaboration_bots/router.py
@@ -1,8 +1,12 @@
 """New-version publish-to-users endpoint (BCS-delegated, backend-served).
 
-Internal backend route: POST /openapi/v1/bots/{bot_id}/public-bcs. The public
-openapi path /openapi/v1/collaboration/bots/{bot_uuid}/public is rewritten onto
-this backend route by the gateway (external path unchanged, gateway-side).
+Served path: POST /openapi/v1/collaboration/bots/{bot_uuid}/public  (contract path)
+
+The gateway exposes this address and its collaboration-publish domain
+verbatim-forwards it here (origin swap only, no rewrite), so the backend
+serves the public address directly rather than relying on a gateway path
+rewrite. bot_uuid is the BCS bot identity (backend_bot_id:entity_id); the
+service splits it internally (backend_bot_id = bot_uid.split(":")[0]).
 
 Starts a botpublish approval ticket whose context carries the normal-bot
 publishHint/botSkills/botMcps (built by _build_public_approval_context) plus
@@ -28,19 +32,23 @@ from agentclaw.community.di import Injected
 from .schemas import BcsPublicRequest, BcsPublishResult
 from agentclaw.community.adapters.http.openapi_v1.authorization import PublicAPIRoute
 
-router = APIRouter(prefix="/openapi/v1/bots", tags=["collaboration-bots"], route_class=PublicAPIRoute)
+public_router = APIRouter(prefix="/openapi/v1/collaboration/bots", tags=["collaboration-bots"], route_class=PublicAPIRoute)
 
 
-@router.post("/{bot_id}/public-bcs", response_model=Envelope[BcsPublishResult])
+@public_router.post("/{bot_uuid}/public", response_model=Envelope[BcsPublishResult])
 @envelope_errors
-async def publish_bcs_bot(
-    bot_id: BotIdPath,
+async def publish_bcs_bot_external(
+    bot_uuid: BotIdPath,
     actor_id: UserIdDep,
     request: Request,
     req: BcsPublicRequest,
     service: BotPublicServiceProtocol = Injected(BotPublicServiceProtocol),
 ) -> Envelope[BcsPublishResult]:
-    """Publish a bot to users — opens a botpublish approval ticket."""
+    """Publish a bot to users or agents — opens a botpublish approval ticket.
+
+    bot_uuid is the BCS bot identity the gateway forwards verbatim; the service
+    splits it internally to reverse-lookup the backend bot record.
+    """
     operator = OperatorContext(
         staff_id=actor_id,
         staff=actor_id,
@@ -49,7 +57,7 @@ async def publish_bcs_bot(
         tenant_id="default",
     )
     result = service.public_bcs_bot(
-        bot_uid=bot_id,
+        bot_uid=bot_uuid,
         owner_id=actor_id,
         public_scope=req.public_scope,
         view_depts=[dept.model_dump() for dept in req.view_depts] if req.view_depts else None,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/collaboration_bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/collaboration_bots/schemas.py
@@ -14,7 +14,7 @@ class ViewDept(BaseModel):
 
 
 class BcsPublicRequest(BaseModel):
-    """New-version publish body (backend route POST /openapi/v1/bots/{bot_uuid}/public-bcs)."""
+    """New-version publish body (POST /openapi/v1/collaboration/bots/{bot_uuid}/public)."""
 
     public_scope: Literal["user", "agent"] = Field(
         description=(

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_collaboration_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_collaboration_bots_endpoints.py
@@ -14,7 +14,7 @@ from fastapi_injector import attach_injector
 from injector import Injector, Module
 
 from agentclaw.community.adapters.http.openapi_v1.collaboration_bots import (
-    router as collaboration_bots_router,
+    public_router as collaboration_public_router,
 )
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.api.bot_public_service import BotPublicServiceProtocol
@@ -59,7 +59,7 @@ def make_client():
                 binder.bind(BotPublicServiceProtocol, to=svc)
 
         app = FastAPI()
-        app.include_router(collaboration_bots_router)
+        app.include_router(collaboration_public_router)
         app.dependency_overrides[require_principal] = _caller_with_user
         attach_injector(app, Injector([_M()]))
         mount_public_error_handlers(app)
@@ -76,7 +76,7 @@ def test_publish_endpoint_mounted_and_returns_envelope(make_client):
     client, svc = make_client(result)
 
     response = client.post(
-        "/openapi/v1/bots/b1:entity1/public-bcs",
+        "/openapi/v1/collaboration/bots/b1:entity1/public",
         json={
             "public_scope": "user",
             "visibility": "public",
@@ -89,7 +89,7 @@ def test_publish_endpoint_mounted_and_returns_envelope(make_client):
     body = response.json()
     assert body["data"]["success"] is True, body
     assert body["data"]["puid"] == "p1", body
-    # the {bot_id} wire param reaches the service as bot_uid (BCS identity, not split)
+    # the {bot_uuid} wire param reaches the service as bot_uid (BCS identity, not split)
     assert svc.captured["kwargs"]["bot_uid"] == "b1:entity1"
     assert svc.captured["kwargs"]["public_scope"] == "user"
     assert svc.captured["kwargs"]["visibility"] == "public"
@@ -99,7 +99,7 @@ def test_publish_endpoint_rejects_invalid_public_scope(make_client):
     client, _svc = make_client({"success": True, "puid": "p1", "state": "PROCESSING"})
 
     response = client.post(
-        "/openapi/v1/bots/b1/public-bcs",
+        "/openapi/v1/collaboration/bots/b1/public",
         json={"public_scope": "team"},  # not in Literal["user","agent"]
     )
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -369,8 +369,11 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: existing Caller path was renamed while the account-level IAM read went away,
 #: so ``path`` stays unchanged and ``none`` decreases by one. Bot editor
 #: requests then add one path-addressed Bot operation. The metadata query
-#: added alongside it is user-scoped but has no ``bot_id`` parameter.
-_BOT_ID_PLACEMENT = {"path": 141, "query": 1, "none": 58}
+#: added alongside it is user-scoped but has no ``bot_id`` parameter. The BCS
+#: publish-to-users route moved from /bots/{bot_id}/public-bcs to the external
+#: /collaboration/bots/{bot_uuid}/public, so one path-addressed {bot_id}
+#: operation became a {bot_uuid}-named one: path -1, none +1.
+_BOT_ID_PLACEMENT = {"path": 140, "query": 1, "none": 59}
 
 
 def _schema() -> dict:
@@ -466,7 +469,9 @@ def test_the_pinned_number_of_operations_take_it():
     # operations, Repo Catalog adds seven operations, SkillSet adds eleven, and
     # MCP adds eight operations, the Harness surface adds six Bot-addressed
     # operations, Session File adds six more, Bot metadata queries add one, and
-    # Bot editor requests add one.
+    # Bot editor requests add one. The BCS publish-to-users route moved from the
+    # internal /bots/{bot_id}/public-bcs path to the external contract path
+    # /collaboration/bots/{bot_uuid}/public (same op count, {bot_uuid} not {bot_id}).
     assert len(taking) == 181
 
 

--- a/src/backend/tests/community/contracts/gateway/test_public_namespace.py
+++ b/src/backend/tests/community/contracts/gateway/test_public_namespace.py
@@ -28,6 +28,11 @@ _DECLARED_PREFIXES = (
     # Department directory search — a tenant-wide catalogue read, declared with
     # its own gateway domain + route_security entry.
     "/openapi/v1/org/dept",
+    # BCS publish-to-users — the external contract path the gateway's
+    # `collaboration-publish` domain routes to the backend (pulled out of the
+    # broad collaboration→bcs namespace). Declared with its gateway domain +
+    # route_security entry.
+    "/openapi/v1/collaboration/bots",
 )
 
 

--- a/src/backend/tests/community/endpoints/test_openapi_public_bcs.py
+++ b/src/backend/tests/community/endpoints/test_openapi_public_bcs.py
@@ -1,6 +1,6 @@
 """Endpoint-framework coverage for the BCS publish-to-users operation.
 
-``POST /openapi/v1/bots/{bot_id}/public-bcs`` opens a botpublish approval
+``POST /openapi/v1/collaboration/bots/{bot_uuid}/public`` opens a botpublish approval
 ticket — it talks to an external approval system, a step no test host can run.
 So both cases stand the service in through the sanctioned DI seam (``bind``
 helpers), not a class-level mock that would outlive the case or lie about
@@ -39,7 +39,7 @@ from tests.community.framework import (
 )
 from tests.community.framework.di_seams import bind_failing_method, bind_method
 
-_PATH = "/openapi/v1/bots/{bot_id}/public-bcs"
+_PATH = "/openapi/v1/collaboration/bots/{bot_uuid}/public"
 _CALLER = "bcs-publisher"
 _KEY = "public-bcs-framework-signing-key-32b"
 
@@ -104,7 +104,7 @@ def _happy(_self, *_args, **_kwargs) -> BcsPublishResult:
     path=_PATH,
     scenario="starts_the_publish_approval_ticket",
     input=CaseInput(
-        path_params={"bot_id": "bcs-target-bot"},
+        path_params={"bot_uuid": "bcs-target-bot"},
         headers={PRINCIPAL_HEADER: _principal()},
         query_params={"user_id": _CALLER},
         json_body={"public_scope": "user"},
@@ -131,7 +131,7 @@ def public_bcs_opens_approval():
     path=_PATH,
     scenario="unknown_bot_surfaces_not_found",
     input=CaseInput(
-        path_params={"bot_id": "no-such-bot"},
+        path_params={"bot_uuid": "no-such-bot"},
         headers={PRINCIPAL_HEADER: _principal()},
         query_params={"user_id": _CALLER},
         json_body={"public_scope": "user"},

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -514,18 +514,6 @@ user_config:
           source: file
           path: schemas/bots.openapi.json
           refresh_seconds: 300
-      caller:
-        server: backend
-        schema:
-          source: file
-          path: schemas/bots.openapi.json
-          refresh_seconds: 300
-      dept:
-        server: backend
-        schema:
-          source: file
-          path: schemas/bots.openapi.json
-          refresh_seconds: 300
       repository-skills:
         match: /openapi/v1/bots/skills/**
         server: backend


### PR DESCRIPTION
<!--
Title format: <type>(<scope>): <concise outcome>
  e.g. feat(backend): add whitelist observed state
Types: feat | fix | refactor | docs | test | ci | build | chore
The title becomes the commit message on squash merge, so make it self-contained.
See "Pull Request Conventions" in AGENTS.md.
Delete the optional sections that do not apply.
-->

## Problem

The BCS publish-to-users endpoint (`POST /openapi/v1/collaboration/bots/{bot_uuid}/public`) returned `{"code": 404000, "message": "Not Found"}` in the deployed environment. The gateway was correctly forwarding the request to the backend (confirmed: request reached backend), but the backend had no route at that path — it only mounted the internal `POST /openapi/v1/bots/{bot_id}/public-bcs`.

The gateway's `collaboration-publish` domain verbatim-forwards the external contract path (origin swap only, no `rewrite`), so the request arrived at the backend as `/openapi/v1/collaboration/bots/{bot_uuid}/public` — a path no FastAPI route matched → route-level 404 → envelope `code: 404000 "Not Found"` (capital `F` distinguishes it from the `BotNotFoundError` path, which is lowercase `"Not found"` + `data: null`).

The original design assumed a gateway path rewrite would map the external path onto the internal `public-bcs` route. That rewrite was never wired, and **could never be**: gateway `PathRewrite` only does literal prefix substitution (`_domains.py:223-240`); it cannot reach the `public`→`public-bcs` tail change nor the `{bot_uuid}`→`{bot_id}` param rename. So the gateway-rewrite approach was structurally unviable — the backend serving the contract path directly is the clean fix.

## Solution

Move the backend route from the internal `/openapi/v1/bots/{bot_id}/public-bcs` to the external contract path `POST /openapi/v1/collaboration/bots/{bot_uuid}/public`, served directly. The gateway's verbatim forward now hits a real route; no rewrite is needed.

**Changes (commit `066f830a4`):**

- `collaboration_bots/router.py` — replaced the internal `router` (prefix `/openapi/v1/bots`, route `/{bot_id}/public-bcs`) with one `public_router` (prefix `/openapi/v1/collaboration/bots`, route `/{bot_uuid}/public`). The handler passes `bot_uid=bot_uuid` to the service; the service's existing `backend_bot_id = bot_uid.split(":")[0]` split is unchanged, so `{bot_uuid}` (the BCS identity `backend_bot_id:entity_id`) works as-is.
- `admission.py` / `authorization.py` — the `public-bcs` row is re-keyed to the external route-template path `/openapi/v1/collaboration/bots/{bot_uuid}/public`. Admission/authorization are route-aware (keyed by `route.path`, not the request URL), so FastAPI's route match provides the normalization.
- `collaboration_bots/__init__.py` — exports `public_router` only.
- `openapi_v1/__init__.py` — `build_public_router` includes `collaboration_public_router` with the same `USER_SCOPED_ERROR_RESPONSES` + `_PUBLIC_AUTH` as before.

**Test/contract updates:**

- `test_public_namespace.py::_DECLARED_PREFIXES` — gains `/openapi/v1/collaboration/bots` (the `collaboration-publish` gateway domain covers it). Deliberately the precise `bots` sub-prefix, **not** broad `/openapi/v1/collaboration`, so a future leak under `/collaboration/tasks` or `/collaboration/messages` is still caught.
- `test_explicit_user_id.py` conformance pins — operation count unchanged at 181 (one op moved, not added); `_BOT_ID_PLACEMENT` shifts `path 141→140` / `none 58→59` because the op's param went from `{bot_id}` to `{bot_uuid}` (it no longer carries a `bot_id` param).
- `test_collaboration_bots_endpoints.py` + `test_openapi_public_bcs.py` — moved to the external path and `{bot_uuid}` param.

**Rejected alternative — gateway `rewrite`:** structurally impossible (above). `PathRewrite.apply` swaps one literal prefix for another and carries the suffix through untouched; the two paths differ in three places (prefix, param name, **tail segment**), and the tail is out of reach.

**Companion cleanup (commit `1f0bc21bb`):** removed two dead gateway domains from `application.yaml` — `dept` (claimed `/openapi/v1/dept/**`, but the real route is `/openapi/v1/org/dept` under the `org` domain) and `caller` (claimed `/openapi/v1/caller/**`, no backend route exists; caller-identity router mounts at `/api/bots`). Both were dead config a request could never resolve.

## Validation

- `tests/community/adapters/http/openapi_v1/` full suite — **1268 passed, 2 skipped** (includes the two conformance pins that were re-baselined, and `test_the_published_document_contains_nothing_internal` which the new handler's docstring had to clear of backticks).
- `tests/community/contracts/` — **248 passed** (includes `test_no_internal_routes_leak_into_public_namespace` after `_DECLARED_PREFIXES` gained the collaboration-bots prefix).
- `tests/community/core/bot_public/` service suite — green (service layer unchanged; `public_bcs_bot` method name + behavior intact).
- `tests/community/adapters/http/openapi_v1/test_collaboration_bots_endpoints.py` + `tests/community/endpoints/test_openapi_public_bcs.py` — 5 passed (mounted-+served success Envelope, 422 validation, 404 not-found mapping).
- Pre-existing unrelated failures verified at HEAD before the change: `test_bcn_dump_uses_the_gateway_managed_python_environment` (assert 13==12), `test_ruff_lint_passes`, e2e `test_health` — all fail on the base branch without this change; not introduced here.

**Not run:** deployment e2e against the live gateway + backend. The fix is backend-route-only and is verified by the route-mounting + namespace contract tests; live confirmation lands after the branch merges and the backend redeploys.

## Compatibility and risk

- **External contract path is unchanged** — `POST /openapi/v1/collaboration/bots/{bot_uuid}/public` was already the documented public address and the gateway `collaboration-publish` domain already routes it. This change only makes the backend actually serve it.
- **Breaking for any internal caller of `/openapi/v1/bots/{bot_id}/public-bcs`** — that internal route is deleted. No code path was forwarding to it (the gateway rewrite it presumed never existed), and the contract tests + endpoint tests all exercise the external path, so no known caller is affected. If an internal integration existed, it must move to the external path.
- **No schema/migration impact** — request/response schemas (`BcsPublicRequest` / `BcsPublishResult`) are byte-identical; only the served path + path-param name changed.
- **ocb-side (enterprise mirror):** no backend change needed there — the community backend is Avernet-sourced. ocb already carries the gateway `collaboration-publish` domain (`ocb` commit `de1ef9be71`).
- **Rollback:** revert the branch — the internal `public-bcs` route returns, and the 404000 reappears for the external path (preserving the pre-fix broken state, not a data-risk regression).

## Spec

Implements the external contract path documented in `ocb-collaboration-bots-public-api.md` (field-level API doc): `{bot_uuid}` is the BCS bot identity; `owner_id` is derived server-side from the signed principal; `visibility` defaults to `private`; `protected` is a backend callback value, not caller input.

## Related issues

Resolves the deployed `404000 "Not Found"` on `POST /openapi/v1/collaboration/bots/{bot_uuid}/public`. Depends on the gateway `collaboration-publish` domain (already in `dev_refactory_collaboration`); this PR supplies the backend counterpart that domain forwards to.
