### PR TITLE
refactor(backend): let BotSkillAssetService inherit its Service API Protocol

### DIFF
--- a/src/backend/src/agentclaw/community/api/bot_skill_asset_service.py
+++ b/src/backend/src/agentclaw/community/api/bot_skill_asset_service.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import Any, Protocol, runtime_checkable
 
 
 @runtime_checkable
 class BotSkillAssetServiceProtocol(Protocol):
+    @abstractmethod
     def get_skill(
         self, *, skill_id: str, bot_id: str, owner_id: str, user_id: str
     ) -> dict[str, Any]: ...
 
+    @abstractmethod
     def resolve_legacy_skill_id(
         self,
         *,
@@ -21,6 +24,7 @@ class BotSkillAssetServiceProtocol(Protocol):
         user_id: str,
     ) -> str: ...
 
+    @abstractmethod
     async def set_active(
         self,
         *,
@@ -31,14 +35,17 @@ class BotSkillAssetServiceProtocol(Protocol):
         active: bool,
     ) -> dict[str, Any]: ...
 
+    @abstractmethod
     async def get_content(
         self, *, skill_id: str, bot_id: str, owner_id: str, user_id: str
     ) -> str: ...
 
+    @abstractmethod
     async def get_parameters(
         self, *, skill_id: str, bot_id: str, owner_id: str, user_id: str
     ) -> dict[str, Any]: ...
 
+    @abstractmethod
     async def replace_parameters(
         self,
         *,

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -59,6 +59,7 @@ internal_dependencies:
   - agentclaw.community.api.skill_market_service
   - agentclaw.community.api.space_skill_query_service
   - agentclaw.community.api.local_skill_query_service # Protocol LocalSkillQueryService inherits
+  - agentclaw.community.api.bot_skill_asset_service # Protocol BotSkillAssetService inherits
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.skill_center    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.skill_center_types # query projection types consumed by this module

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_skill_asset_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_skill_asset_service.py
@@ -11,6 +11,9 @@ from typing import Any, Callable, Protocol, TYPE_CHECKING
 
 from injector import inject
 
+from agentclaw.community.api.bot_skill_asset_service import (
+    BotSkillAssetServiceProtocol,
+)
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_collaborator.protocols import (
     CollaboratorServiceProtocol,
@@ -67,7 +70,7 @@ class _LocalSkillStatePort(Protocol):
     ) -> dict[str, Any]: ...
 
 
-class BotSkillAssetService:
+class BotSkillAssetService(BotSkillAssetServiceProtocol):
     """Resolve one public ``skill_id`` before invoking its registered reader."""
 
     @inject

--- a/src/backend/tests/community/architecture/test_architecture_compliance.py
+++ b/src/backend/tests/community/architecture/test_architecture_compliance.py
@@ -163,6 +163,15 @@ _IMPORT_EXCEPTIONS: frozenset[tuple[str, str]] = frozenset({
         "core/skill_center/services/local_skill_query_service.py",
         "agentclaw.community.api.local_skill_query_service",
     ),
+    # BotSkillAssetService implements the Service API Protocol defined in
+    # api/bot_skill_asset_service.py — same shape and same reason as the entry
+    # above: every member of that Protocol is @abstractmethod, so omitting one
+    # fails at construction naming the member, and inheriting it makes the
+    # contract navigable from Protocol to implementation in an IDE.
+    (
+        "core/skill_center/services/bot_skill_asset_service.py",
+        "agentclaw.community.api.bot_skill_asset_service",
+    ),
 })
 
 


### PR DESCRIPTION
## Problem

`BotSkillAssetService` satisfied `BotSkillAssetServiceProtocol` structurally
only — the class declared no base, so nothing linked the contract to its
implementation.

Same two consequences as #1375:

- **Navigation.** No edge for an IDE to follow, so you cannot jump from
  `BotSkillAssetServiceProtocol` to `BotSkillAssetService` or back.
- **Enforcement timing.** Protocol members were plain `...` stubs. A dropped or
  renamed member surfaced as an `AttributeError` at whichever router called it,
  not at construction.

## Solution

`BotSkillAssetService` now inherits `BotSkillAssetServiceProtocol`, and all six
Protocol members are `@abstractmethod` — the shape established by #1375 and
already used by `LocalSkillQueryService`, `BotStartupScriptService` and
`SpaceSkillQueryService`.

Duck-typed test doubles are unaffected: they do not inherit the Protocol, so
`@abstractmethod` is inert for them and `isinstance` still matches structurally.

Two supporting edits, exactly as in #1375:

- The `core → api` import is allowlisted in `test_architecture_compliance.py`,
  directly beside the entry #1375 added.
- The import is declared in the `skill_center` `## Context Boundary`, which
  `test_declared_deps_cover_actual_imports` checks.

**No new gate.** `test_concrete_service_is_not_left_abstract`, added in #1375,
already covers this pair through the conformance registry — this PR is the first
case that reuses it rather than adding to it.

`api/README.md` already documents this pattern from #1375, so no doc change is
needed here.

## Validation

Ran with `uv` against PyPI, as the pinned `mirrors.aliyun.com` index is
unreachable from this environment; `uv.lock` is unmodified.

- `pytest tests/community/architecture/ tests/community/core/skill_center/test_bot_skill_asset_service.py tests/community/api/skill_center/test_skills_api_async_correctness.py tests/community/endpoints/test_openapi_skill_asset.py tests/community/endpoints/test_skill_device_sync.py tests/community/adapters/http/test_http_adapters_use_resolver.py` — **248 passed**.
- `ruff check` on every changed `.py` file — clean.
- Behavioral checks, verified rather than assumed:
  - `issubclass(BotSkillAssetService, BotSkillAssetServiceProtocol)` → `True`, Protocol in the MRO.
  - `BotSkillAssetService.__abstractmethods__` is empty; the service constructs.
  - All six members checked individually for signature shape *and* awaitability against the Protocol — all match. **Four of the six are coroutines** (`set_active`, `get_content`, `get_parameters`, `replace_parameters`), so `async`→`def` drift matters more here than in #1375, whose members are all sync.
  - A subclass implementing only `get_skill` fails construction naming all five missing members.
  - A duck-typed fake that inherits nothing still passes `isinstance` against the `@runtime_checkable` Protocol.

### The reused guard, demonstrated

Worth recording because this pair makes the point more sharply than #1375 did. A
subclass implementing only `get_skill` — **missing five of six members** —
passes both pre-existing conformance checks:

```
--- the two ORIGINAL checks on a service missing 5 of 6 methods ---
2 passed

--- the guard kept from #1375 ---
E  AssertionError: _BrokenAsset inherits BotSkillAssetServiceProtocol but leaves
   ['get_content', 'get_parameters', 'replace_parameters',
    'resolve_legacy_skill_id', 'set_active'] unimplemented —
   the class is abstract and DI would fail at startup.
```

`issubclass` passes because every name resolves to the inherited stub, and the
signature comparison passes because it is comparing those stubs against the
Protocol that defines them. Only the `__abstractmethods__` check catches it.

## Compatibility and risk

No behavior change. The Protocol's method signatures, the DI binding, and the
routers are untouched. `@abstractmethod` on a `Protocol` does not alter
`isinstance`/`issubclass`, so every existing structural consumer and test double
keeps working.

Rollback is the revert; nothing is persisted or migrated.