### PR TITLE
fix(collaboration-bots): sanitize biz_id for approval puid + map serv…

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -96,6 +96,7 @@ from agentclaw.community.core.bot_management.services.bot_service import (
 )
 from agentclaw.community.core.bot_public.services.bot_public_service import (
     BotNotFoundError as BotPublicBotNotFoundError,
+    BotPublicServiceError,
 )
 from agentclaw.community.core.channel.errors import (
     ChannelEditLockedError,
@@ -440,6 +441,14 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     # public route), so it answers the same 404 the surface answers everywhere a
     # bot is addressed that does not exist.
     BotPublicBotNotFoundError: (404, "Not found"),
+    # The bot-public service's own ``BotPublicServiceError`` — a server-side
+    # failure of the BCS publish-to-users flow (approval-ticket submit rejected
+    # by the approval service, e.g. a malformed biz_id/puid, or any other
+    # invariant the service guards). Distinct from the not-found case above: the
+    # bot was addressed and found, the publish itself failed. Mapped here so it
+    # surfaces as a business-coded 5xx through ``@envelope_errors`` rather than
+    # escaping as a bare 500; the cause is logged at the raise site.
+    BotPublicServiceError: (500, "Publish failed"),
     CollaboratorPermissionDeniedError: (404, "Not found"),
     CollaboratorNotFoundError: (404, "Not found"),
     CollaboratorAlreadyExistsError: (409, "Editor already exists"),

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -3,6 +3,7 @@
 纯业务逻辑层，不包含任何 HTTP 关注点。
 """
 import json
+import re
 import time
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -497,7 +498,14 @@ class BotPublicService:
         context["viewFriendDeps"] = self._build_view_friend_deps(view_depts)
         approval_result = self._process_service.start_approval(
             applicant=operator_id,
-            biz_id=f"{bot_uid}{datetime.now().strftime('%Y%m%d%H%M%S')}",
+            # biz_id flows into the approval service's puid, which only accepts
+            # alphanumeric + hyphen. bot_uid is the BCS identity
+            # "{backend_bot_id}:{entity_id}" and may carry ":" and "_" (the
+            # backend bot id has its own underscores) — both rejected by the
+            # approval service's PARAM_CHECKED. Sanitize every non-alphanumeric
+            # char to "-" so the puid carries the identity without the colon/_
+            # that would break its "-" / "_" field delimiters.
+            biz_id=f"{re.sub(r'[^a-zA-Z0-9-]', '-', bot_uid)}{datetime.now().strftime('%Y%m%d%H%M%S')}",
             biz_type="botpublic",
             context=context,
         )

--- a/src/backend/tests/community/endpoints/test_openapi_public_bcs.py
+++ b/src/backend/tests/community/endpoints/test_openapi_public_bcs.py
@@ -27,6 +27,7 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_
 from agentclaw.community.api.bot_public_service import BotPublicServiceProtocol
 from agentclaw.community.core.bot_public.services.bot_public_service import (
     BotNotFoundError,
+    BotPublicServiceError,
 )
 from agentclaw.community.utils.gateway_principal_config import (
     init_principal_verifier_config,
@@ -156,4 +157,39 @@ def public_bcs_unknown_bot_is_not_found():
     ``bind_failing_method`` raises the production ``BotNotFoundError`` on the
     per-test injector so the case documents the mapping it pins rather than name
     a different error the route never raises.
+    """
+
+
+@endpoint_test(
+    method="POST",
+    path=_PATH,
+    scenario="publish_service_failure_surfaces_500",
+    input=CaseInput(
+        path_params={"bot_uuid": "bcs-target-bot"},
+        headers={PRINCIPAL_HEADER: _principal()},
+        query_params={"user_id": _CALLER},
+        json_body={"public_scope": "user"},
+    ),
+    seed=lambda world: (
+        _boot_verifier(world),
+        bind_failing_method(
+            world,
+            BotPublicServiceProtocol,
+            "public_bcs_bot",
+            BotPublicServiceError("创建审批失败: puid PARAM_CHECKED_ERROR"),
+        ),
+    ),
+    expect=ExpectError(
+        status=500,
+        json_contains={"code": 500000, "message": "Publish failed", "data": None},
+    ),
+)
+def public_bcs_service_failure_is_500():
+    """The server-side failure branch maps through ``@envelope_errors`` → 500.
+
+    ``BotPublicServiceError`` is the service's invariant guard (approval-ticket
+    submit rejected, etc.). Without the ``@envelope_errors`` mapping it escaped
+    as a bare 500; the mapping pins it as a business-coded 5xx so the caller
+    gets ``code: 500000 "Publish failed"`` rather than a generic Internal Server
+    Error, with the cause logged at the raise site.
     """


### PR DESCRIPTION
## Problem

Once PR #1378 (external publish path) merged and reached the `pre` environment, `POST /openapi/v1/collaboration/bots/{bot_uuid}/public` with a real BCS bot identity returned `500 Internal Server Error`. The backend log showed the approval service rejecting the ticket:

```
puId check error
engineErrorCode: PARAM_CHECKED_ERROR
success: False
```

Two issues stacked — the rejection itself, and how the rejection surfaced.

1. **biz_id carried illegal characters into the approval puid.** `public_bcs_bot` built the approval `biz_id` as `f"{bot_uid}{timestamp}"`, where `bot_uid` is the BCS identity `"{backend_bot_id}:{entity_id}"` (e.g. `20260803_8tcq1p7d:165528`). That string carries `:` (illegal in the approval service's puid, which accepts alphanumeric + hyphen only) and `_` (the backend bot id's own underscores, which collide with the puid's `_` field delimiter — `{run_app}-{app_name}_{biz_type}_{biz_id}`). The approval service answered `PARAM_CHECKED_ERROR`.

2. **The rejection surfaced as a bare 500, not a business-coded response.** On approval-submit failure `public_bcs_bot` raises `BotPublicServiceError`, but that exception was **not** in `@envelope_errors`' map — so it escaped the envelope and reached the app's generic 500 handler. The caller saw `Internal Server Error` with no business code, indistinguishable from an unhandled exception, and the only clue was in the backend log.

Both are pre-existing on `dev_refactory_collaboration` (the biz_id line dates to #1327); the external path just made the flow reachable in `pre` with a real `{bot_uuid}` identity.

## Solution

**1. Sanitize biz_id before it enters the puid.** In `public_bcs_bot`, every non-alphanumeric character in `bot_uid` is replaced with `-` (`re.sub(r'[^a-zA-Z0-9-]', '-', bot_uid)`) before being joined with the timestamp into `biz_id`. `20260803_8tcq1p7d:165528` → `20260803-8tcq1p7d-165528`. The identity rides into the puid without the `:`/`_` that broke its `-`/`_` field structure. The approval service's `PARAM_CHECKED_ERROR` no longer fires.

Rejected alternative — use `backend_bot_id` only (`bot_uid.split(':')[0]`): simplest, but drops the `entity_id` half of the identity, relying on the timestamp alone to disambiguate multiple entities of one backend bot. Sanitize keeps the full identity and is robust to any future non-alphanumeric char, not just the two known ones.

**2. Map `BotPublicServiceError` through `@envelope_errors`.** Added the entry `BotPublicServiceError: (500, "Publish failed")` to the exception map in `responses.py`. A publish-side failure (approval-submit rejected, or any other invariant the service guards) now answers `code: 500000 "Publish failed"` — business-coded and distinct from a generic unhandled-exception 500 — with the cause logged at the raise site. This is consistent with how the sibling `BotNotFoundError` is already mapped (`404, "Not found"`), and benefits every route using `@envelope_errors`, not just this one.

Rejected alternative — a hand-written `except BotPublicServiceError` in the handler (as the legacy `bot_public/router.py` does): local to one route, and leaves the next route that raises it naked again. The map entry fixes it once, structurally.

## Validation

- `tests/community/core/bot_public/` + `tests/community/endpoints/test_openapi_public_bcs.py` — **145 passed**. The service-layer suite already pinned `start_approval` returning `success: False` → `BotPublicServiceError` (match `"workflow unavailable"`); the sanitize does not touch that branch.
- Added HTTP-layer case `public_bcs_service_failure_is_500`: binds `public_bcs_bot` to raise `BotPublicServiceError("error: puid PARAM_CHECKED_ERROR")` and asserts the response is `500` + `{"code": 500000, "message": "Publish failed", "data": None}` — pinning the new mapping (previously this escaped as a bare 500).
- Sanitize logic verified against the real identity: `"20260803_8tcq1p7d:165528"` → `"20260803-8tcq1p7d-165528"`, matches `^[a-zA-Z0-9-]+$`.
- openapi_v1 conformance + gateway contract suites remain green (the map addition adds an exception mapping, not a route; no pin moves).

**Not run:** `pre` redeploy + live re-request of the publish endpoint. The fix is verified by the service + HTTP-layer tests; live confirmation lands after this PR merges and `pre` backend redeploys. Expected live result: `success: true, state: PROCESSING, puid: ...` instead of 500.

## Compatibility and risk

- **No contract/schema change.** Request and response shapes (`BcsPublicRequest` / `BcsPublishResult`) are byte-identical; the published OpenAPI document is unaffected. The `biz_id`/puid is an internal approval-service identifier, never exposed to the caller.
- **puid value changes shape.** Existing in-flight approval tickets (if any were created before this fix by a bot_uid that happened to be alphanumeric-only) keep their old puid; only newly created tickets get the sanitized form. `query_approval_status`/`cancel_approval` key off the puid the approval service returned, not off a locally-reconstructed one, so existing tickets remain addressable.
- **Error response code changes for the failure path.** A publish-side failure that previously returned a bare `500 Internal Server Error` now returns `500` + `{"code": 500000, "message": "Publish failed"}`. Callers that string-matched on `"Internal Server Error"` (none known — the surface is envelope-coded) would need to match `code: 500000` instead. This is the intended improvement, not a regression.
- **Rollback:** revert the single commit — the `PARAM_CHECKED_ERROR` 500 returns for any `{bot_uuid}` carrying `:` or `_`.

## Spec

Implements the error model implied by `ocb-collaboration-bots-public-api.md` §4.2 (a publish-side failure answers a business-coded 5xx, not a bare 500) and the `{bot_uuid}` BCS-identity contract (the identity flows through to the approval service in a form its puid validator accepts).

## Related issues

Follow-up to #1378 (external publish path) — surfaces and fixes the 500 that blocked the publish flow in `pre`. The biz_id line traces back to #1327 (`Bcn_collaboration_bots_public`); the external path made it reachable with a real `{bot_uuid}` identity.
