### PR TITLE
feat(backend): opt-in immediate execution for enqueued task types

### DIFF
--- a/src/backend/src/agentclaw/community/core/task_queue/services/registry.py
+++ b/src/backend/src/agentclaw/community/core/task_queue/services/registry.py
@@ -15,7 +15,7 @@ so every participant sees the same instance.
 """
 from __future__ import annotations
 
-from typing import Dict, Optional, Protocol, runtime_checkable
+from typing import Dict, Optional, Protocol, Set, runtime_checkable
 
 from agentclaw.community.core.task_queue.types import TaskOutcome
 
@@ -50,6 +50,10 @@ class HandlerRegistry:
         #: Normalized ``task_type`` → the exact spelling registered under it.
         #: Only used to reject near-collisions; lookup stays exact.
         self._normalized: Dict[str, str] = {}
+        #: Task types whose enqueues wake the worker immediately instead of
+        #: waiting out the idle poll. Opt-in per type — a type absent from this
+        #: set (every existing one) keeps the poll-interval behaviour exactly.
+        self._wake_on_enqueue: Set[str] = set()
 
     @staticmethod
     def _normalize(task_type: str) -> str:
@@ -60,7 +64,7 @@ class HandlerRegistry:
         """
         return task_type.casefold()
 
-    def register(self, handler: TaskHandler) -> None:
+    def register(self, handler: TaskHandler, *, wake_on_enqueue: bool = False) -> None:
         """Register ``handler`` under its ``task_type``.
 
         Raises :class:`ValueError` on a duplicate ``task_type`` — two handlers
@@ -93,6 +97,17 @@ class HandlerRegistry:
 
         Lookup stays **exact**: rows store ``task_type`` verbatim, so the worker
         dispatches on the spelling that was enqueued.
+
+        **``wake_on_enqueue``** opts this task type into immediate execution: a
+        due enqueue of this type signals the worker to poll at once rather than
+        waiting out ``poll_interval_seconds``. It defaults to ``False`` so every
+        already-registered type keeps its current timing untouched; turn it on
+        for work a user is waiting on, and leave it off for background and
+        recurring work where a couple of seconds costs nothing.
+
+        The flag lives here, at the wiring site, rather than on the handler:
+        how eagerly a queue is drained is a deployment concern, and one grep
+        for ``wake_on_enqueue=True`` then lists every type that opted in.
         """
         task_type = handler.task_type
         if task_type != task_type.strip():
@@ -120,7 +135,20 @@ class HandlerRegistry:
             )
         self._handlers[task_type] = handler
         self._normalized[normalized] = task_type
+        if wake_on_enqueue:
+            self._wake_on_enqueue.add(task_type)
 
     def get(self, task_type: str) -> Optional[TaskHandler]:
         """Return the handler for ``task_type``, or ``None`` if unregistered."""
         return self._handlers.get(task_type)
+
+    def wakes_on_enqueue(self, task_type: str) -> bool:
+        """Whether ``task_type`` opted into immediate execution at registration.
+
+        ``False`` for an unregistered type, which is the honest answer rather
+        than an error: an enqueue for a type this process has no handler for is
+        pointless to wake for, since only a process that *can* run it benefits.
+        Matched exactly, like :meth:`get` — rows carry the spelling that was
+        enqueued.
+        """
+        return task_type in self._wake_on_enqueue

--- a/src/backend/src/agentclaw/community/core/task_queue/services/task_queue_service.py
+++ b/src/backend/src/agentclaw/community/core/task_queue/services/task_queue_service.py
@@ -4,6 +4,11 @@ Thin wrapper over the repository. Timing is owned by the database: this service
 just forwards the relative ``delay_seconds`` / ``deadline_seconds`` durations
 (the repository turns them into absolute ``run_at`` / ``deadline_at`` with the
 DB clock) and stamps the current ``env``.
+
+It also carries the one piece of policy the repository has no business knowing:
+whether an enqueue should wake the in-process worker immediately (see
+:class:`WorkerWakeup`) instead of leaving it to the next idle poll. That is
+opt-in per task type, declared at handler registration.
 """
 from __future__ import annotations
 
@@ -12,6 +17,8 @@ from injector import inject
 from typing import Optional
 
 from agentclaw.community.core.repository.protocols.platform import TaskQueueRepositoryProtocol
+from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
+from agentclaw.community.core.task_queue.services.wakeup import WorkerWakeup
 from agentclaw.community.core.task_queue.types import EnqueueResult
 from agentclaw.community.utils.env_utils import get_current_env
 
@@ -20,8 +27,15 @@ class TaskQueueService:
     """Persist background work for the in-process worker to pick up."""
 
     @inject
-    def __init__(self, repo: TaskQueueRepositoryProtocol) -> None:
+    def __init__(
+        self,
+        repo: TaskQueueRepositoryProtocol,
+        registry: HandlerRegistry,
+        wakeup: WorkerWakeup,
+    ) -> None:
         self._repo = repo
+        self._registry = registry
+        self._wakeup = wakeup
 
     def enqueue(
         self,
@@ -53,10 +67,18 @@ class TaskQueueService:
           (truncation under a non-strict server, space padding under the
           collation).
 
+        **Immediate execution.** If ``task_type`` was registered with
+        ``wake_on_enqueue=True`` and this call created a task that is due now,
+        the in-process worker is signalled to poll at once rather than waiting
+        out its idle interval. Every other task type is unaffected. The signal
+        is best-effort latency only — it never changes which task runs, who
+        claims it, or what happens if it is missed; a missed signal just means
+        the ordinary poll picks the task up.
+
         See ``TaskQueueRepositoryProtocol.enqueue`` for the key convention and
         the full contract.
         """
-        return self._repo.enqueue(
+        result = self._repo.enqueue(
             task_type=task_type,
             payload=payload,
             delay_seconds=delay_seconds,
@@ -64,3 +86,31 @@ class TaskQueueService:
             env=get_current_env(),
             idempotency_key=idempotency_key,
         )
+        if self._should_wake(result, task_type=task_type, delay_seconds=delay_seconds):
+            # Signalled only *after* the repository call returns, which matters:
+            # ``orm_session()`` commits on clean exit, so the row is committed
+            # and visible to any claim the wake triggers. Signalling earlier
+            # would race the worker against our own uncommitted insert.
+            self._wakeup.notify()
+        return result
+
+    def _should_wake(
+        self, result: EnqueueResult, *, task_type: str, delay_seconds: int
+    ) -> bool:
+        """Whether this enqueue should cut short the worker's idle wait.
+
+        Three conditions, all required:
+
+        - **The type opted in.** Default-off, so existing task types keep their
+          current timing (see ``HandlerRegistry.register``).
+        - **The task is due now.** A delayed task has ``run_at > now()`` and so
+          fails the claim's eligibility predicate; waking for it would burn a
+          poll and change nothing.
+        - **A task was actually created.** A keyed enqueue that joined a live
+          holder (``created=False``) added no work — the holder is already
+          pending or running, and waking cannot make a future ``run_at``
+          eligible any sooner.
+        """
+        if delay_seconds > 0 or not result.created:
+            return False
+        return self._registry.wakes_on_enqueue(task_type)

--- a/src/backend/src/agentclaw/community/core/task_queue/services/wakeup.py
+++ b/src/backend/src/agentclaw/community/core/task_queue/services/wakeup.py
@@ -1,0 +1,108 @@
+"""WorkerWakeup — the latch that lets an enqueue cut short the worker's idle wait.
+
+The worker's poll loop sleeps ``poll_interval_seconds`` between claims, so a
+task enqueued just after a tick waits out most of that interval before anything
+looks at it. This latch turns that interval into a **ceiling** rather than a
+fixed cost: :meth:`notify` wakes the loop immediately, and the timer only
+applies when nobody signalled.
+
+A DI singleton shared by :class:`TaskQueueService` (which signals) and
+:class:`TaskWorker` (which waits), so neither has to depend on the other.
+
+**Thread safety is the whole point of this class.** ``enqueue()`` is
+synchronous and runs on whatever thread called it — which, for a handler
+enqueuing follow-up work, is a ``asyncio.to_thread`` pool thread, not the event
+loop thread. ``asyncio.Event`` has no internal locking (it assumes only the loop
+thread touches it), and more importantly a plain ``set()`` from a foreign thread
+appends to the loop's ready queue *without waking the loop out of ``select()``*
+— so the callback would sit there until the poll timer expired anyway, silently
+costing exactly the latency this class exists to remove. ``call_soon_threadsafe``
+both queues the callback and writes to the loop's self-pipe, which is what
+actually ends the sleep. Every cross-thread signal must go through it.
+
+Signals **coalesce**: the latch is one ``asyncio.Event``, so a handler fanning
+out five hundred tasks produces one extra poll, not five hundred. The worker's
+existing greedy re-poll then drains the backlog at full speed.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+
+class WorkerWakeup:
+    """A coalescing, thread-safe wake latch for the task worker's poll loop."""
+
+    def __init__(self) -> None:
+        self._event = asyncio.Event()
+        # The loop the worker's poll runs on. ``None`` is a real state, not a
+        # widened type: it means this process has no running worker loop — the
+        # worker is disabled by config, has not reached ``startup()`` yet, or
+        # has already shut down. In every one of those cases there is genuinely
+        # nothing to wake, and a signal is correctly a no-op.
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    # ── bound by the worker ─────────────────────────────────────────────
+    def bind(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Attach the loop that :meth:`wait` runs on.
+
+        Called from the worker's ``startup()``, which runs *on* that loop —
+        ``asyncio.get_running_loop()`` only works from the loop thread, so the
+        handle has to be captured there rather than looked up at signal time.
+        """
+        self._loop = loop
+
+    def unbind(self) -> None:
+        """Detach the loop. Called from the worker's ``shutdown()`` so a late
+        signal from a still-draining handler thread becomes a no-op instead of
+        touching a loop that is going away."""
+        self._loop = None
+
+    # ── signalled by enqueue (any thread) ───────────────────────────────
+    def notify(self) -> None:
+        """Ask the worker to poll now. Safe to call from any thread.
+
+        A no-op when no worker loop is bound in this process, or when the loop
+        has already closed — both mean the wake has nowhere to go, and the task
+        is still picked up by the next claim (here or on another pod). Never
+        raises: an enqueue must not fail because the latency optimisation
+        could not be delivered.
+        """
+        loop = self._loop
+        if loop is None:
+            return
+        try:
+            # NB: ``self._event.set`` is passed unbound and *uncalled* — the
+            # loop invokes it on its own thread. Adding parentheses here would
+            # run it on the calling thread, which is the exact bug this class
+            # exists to prevent.
+            loop.call_soon_threadsafe(self._event.set)
+        except RuntimeError:
+            # ``_check_closed()`` firing: the loop shut down between the read of
+            # ``self._loop`` above and this call. A real race whenever handler
+            # threads outlive teardown.
+            logger.debug("[WorkerWakeup] notify skipped — event loop is closed")
+
+    # ── awaited by the worker ───────────────────────────────────────────
+    async def wait(self, timeout: float) -> bool:
+        """Block until signalled or ``timeout`` elapses. Returns whether a
+        signal arrived (diagnostic only — the caller polls either way).
+
+        The latch is cleared **after** waking and **before** the caller's poll,
+        which is what makes a signal impossible to lose: anything enqueued
+        before the clear is visible to the poll that follows it, and anything
+        enqueued after it re-sets the latch, so the next wait returns at once.
+        Clearing *before* waiting would instead discard a signal that arrived
+        while the previous poll was still running.
+        """
+        try:
+            await asyncio.wait_for(self._event.wait(), timeout=timeout)
+            return True
+        except asyncio.TimeoutError:
+            return False
+        finally:
+            self._event.clear()

--- a/src/backend/src/agentclaw/community/core/task_queue/services/worker.py
+++ b/src/backend/src/agentclaw/community/core/task_queue/services/worker.py
@@ -8,7 +8,10 @@ A ``Lifecycle`` singleton: ``startup()`` launches an asyncio loop,
 2. runs each claimed task's handler concurrently, bounded by a semaphore;
 3. maps the handler's :class:`TaskOutcome` back to a repository transition;
 4. **greedy re-poll** when the batch came back full (a backlog likely exists)
-   else sleeps a jittered idle interval.
+   else waits out a jittered idle interval — interruptibly. An enqueue of a task
+   type registered with ``wake_on_enqueue=True`` signals :class:`WorkerWakeup`
+   and the wait ends at once, so the interval is a latency *ceiling* rather than
+   a fixed cost. Types that did not opt in are unaffected.
 
 Give-up is a deadline from first enqueue, enforced entirely DB-side by the
 repository: a past-deadline task is retired ``TIMED_OUT`` at claim time (never
@@ -36,6 +39,7 @@ from injector import inject
 
 from agentclaw.community.core.repository.protocols.platform import TaskQueueRepositoryProtocol
 from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
+from agentclaw.community.core.task_queue.services.wakeup import WorkerWakeup
 from agentclaw.community.core.task_queue.types import (
     Complete,
     Fail,
@@ -66,10 +70,12 @@ class TaskWorker(LifecycleBase):
         repo: TaskQueueRepositoryProtocol,
         registry: HandlerRegistry,
         config: TaskQueueWorkerConfig,
+        wakeup: WorkerWakeup,
     ) -> None:
         self._repo = repo
         self._registry = registry
         self._config = config
+        self._wakeup = wakeup
         self._worker_id = _make_worker_id()
         self._env = get_current_env()
         self._running = False
@@ -91,6 +97,10 @@ class TaskWorker(LifecycleBase):
             )
             return
         self._running = True
+        # Capture the loop for cross-thread wake-ups. ``startup()`` runs *on*
+        # the loop, which is the only place ``get_running_loop()`` works — a
+        # handler thread signalling later cannot look it up for itself.
+        self._wakeup.bind(asyncio.get_running_loop())
         self._task = asyncio.create_task(self._loop())
         logger.info(
             "[TaskWorker] started worker_id=%s env=%s batch=%d poll=%.1fs lease=%ds",
@@ -103,6 +113,10 @@ class TaskWorker(LifecycleBase):
 
     async def shutdown(self) -> None:
         self._running = False
+        # Unbind first: handler threads can outlive teardown, and a signal
+        # arriving after this point should be a no-op rather than a callback
+        # scheduled onto a loop that is going away.
+        self._wakeup.unbind()
         if self._task and not self._task.done():
             self._task.cancel()
             try:
@@ -124,7 +138,10 @@ class TaskWorker(LifecycleBase):
             # Greedy: a full batch implies more is waiting → re-poll now.
             if claimed >= self._config.batch_size:
                 continue
-            await asyncio.sleep(self._idle_delay())
+            # Otherwise idle — but interruptibly. An opted-in enqueue ends this
+            # wait immediately; nothing else changes, and a missed signal costs
+            # only the ordinary interval.
+            await self._wakeup.wait(self._idle_delay())
 
     def _idle_delay(self) -> float:
         jitter = self._config.poll_jitter_seconds

--- a/src/backend/src/agentclaw/community/di/modules/task_queue_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/task_queue_module.py
@@ -6,6 +6,10 @@ no ``@plugin_impl``), the handler registry, the enqueue service, and the
 ``discover_lifecycle_participants`` finds it at app startup and runs its
 ``startup()`` / ``shutdown()`` — no explicit lifecycle list to maintain.
 
+A task type opts into immediate execution at registration
+(``registry.register(handler, wake_on_enqueue=True)``); the default is off, so
+existing task types keep their poll-interval timing unchanged.
+
 The ``HandlerRegistry`` singleton is created empty. BaaS and Teclaw register
 their production handlers in their own ``Lifecycle.bootstrap()`` methods
 (which the lifespan runner completes before any ``startup()``), so the worker
@@ -18,6 +22,7 @@ from injector import Binder, Module, singleton
 from agentclaw.community.core.repository.protocols.platform import TaskQueueRepositoryProtocol
 from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
 from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
+from agentclaw.community.core.task_queue.services.wakeup import WorkerWakeup
 from agentclaw.community.core.task_queue.services.worker import TaskWorker
 from agentclaw.community.core.repository.implementations.platform.task_queue import TaskQueueRepository
 
@@ -37,5 +42,9 @@ class TaskQueueModule(Module):
         binder.bind(HandlerRegistry, to=HandlerRegistry, scope=singleton)
         # Enqueue facade for adopters.
         binder.bind(TaskQueueService, to=TaskQueueService, scope=singleton)
+        # The wake latch shared by the enqueue path and the worker's poll
+        # loop. A singleton so both see the same one; binding it separately
+        # keeps TaskQueueService from having to depend on TaskWorker.
+        binder.bind(WorkerWakeup, to=WorkerWakeup, scope=singleton)
         # The in-process worker — a Lifecycle singleton, auto-discovered.
         binder.bind(TaskWorker, to=TaskWorker, scope=singleton)

--- a/src/backend/tests/community/core/task_queue/test_task_worker.py
+++ b/src/backend/tests/community/core/task_queue/test_task_worker.py
@@ -27,6 +27,7 @@ from agentclaw.community.core.task_queue.examples import (
 from agentclaw.community.core.task_queue.repository.models import TaskQueueModel  # noqa: F401
 from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
 from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
+from agentclaw.community.core.task_queue.services.wakeup import WorkerWakeup
 from agentclaw.community.core.task_queue.services.worker import TaskWorker
 from agentclaw.community.core.task_queue.types import Complete, TaskStatus
 from agentclaw.community.di.config import TaskQueueWorkerConfig
@@ -67,8 +68,11 @@ class _World:
         self.repo = TaskQueueRepository(InMemorySqliteDB(engine))
         self.registry = HandlerRegistry()
         self.config = config
-        self.service = TaskQueueService(self.repo)
-        self.worker = TaskWorker(self.repo, self.registry, config)
+        # One latch, shared by the enqueue path and the worker — same wiring
+        # the DI module provides in production.
+        self.wakeup = WorkerWakeup()
+        self.service = TaskQueueService(self.repo, self.registry, self.wakeup)
+        self.worker = TaskWorker(self.repo, self.registry, config, self.wakeup)
 
     def enqueue(
         self,
@@ -330,7 +334,7 @@ def test_teclaw_publish_task_is_reclaimed_after_worker_restart():
     )
     assert [task.id for task in abandoned] == [record.id]
 
-    restarted_worker = TaskWorker(w.repo, w.registry, w.config)
+    restarted_worker = TaskWorker(w.repo, w.registry, w.config, w.wakeup)
     asyncio.run(restarted_worker.run_once())
 
     assert w.status_of(record.id) == TaskStatus.SUCCEEDED
@@ -341,3 +345,139 @@ def test_teclaw_publish_task_is_reclaimed_after_worker_restart():
         publish_id=9,
         status="ACTIVE",
     )
+
+
+# ── opt-in immediate execution ──────────────────────────────────────────────
+# A task type may ask for its enqueues to wake the worker at once instead of
+# waiting out the idle poll. Off by default, so every pre-existing type keeps
+# the timing it already had — that default is what most of these tests pin down.
+
+
+class _RecordingWakeup:
+    """Stands in for ``WorkerWakeup`` to count signals without a live loop."""
+
+    def __init__(self):
+        self.notifies = 0
+
+    def notify(self):
+        self.notifies += 1
+
+
+def _service_with(world, wakeup):
+    """A service over ``world``'s repo/registry but a countable latch."""
+    return TaskQueueService(world.repo, world.registry, wakeup)
+
+
+def test_registry_defaults_to_not_waking_on_enqueue():
+    """The default is opt-out: registering a handler the way every existing
+    adopter does must leave its task type on the ordinary poll cadence."""
+    registry = HandlerRegistry()
+    registry.register(NoopTaskHandler("legacy"))
+    assert registry.wakes_on_enqueue("legacy") is False
+
+
+def test_registry_records_an_explicit_opt_in():
+    registry = HandlerRegistry()
+    registry.register(NoopTaskHandler("urgent"), wake_on_enqueue=True)
+    assert registry.wakes_on_enqueue("urgent") is True
+
+
+def test_registry_reports_no_wake_for_an_unregistered_type():
+    """Only a process that can actually run the type benefits from waking, so
+    an unknown type is a plain False rather than an error."""
+    assert HandlerRegistry().wakes_on_enqueue("never-registered") is False
+
+
+def test_opted_in_type_signals_the_worker_on_enqueue():
+    w = _world()
+    w.registry.register(NoopTaskHandler("urgent"), wake_on_enqueue=True)
+    wakeup = _RecordingWakeup()
+    _service_with(w, wakeup).enqueue("urgent", {}, 3600)
+    assert wakeup.notifies == 1
+
+
+def test_type_that_did_not_opt_in_is_left_on_the_poll_cadence():
+    """The core guarantee for existing task types: nothing about their timing
+    changes."""
+    w = _world()
+    w.registry.register(NoopTaskHandler("legacy"))
+    wakeup = _RecordingWakeup()
+    _service_with(w, wakeup).enqueue("legacy", {}, 3600)
+    assert wakeup.notifies == 0
+
+
+def test_delayed_enqueue_does_not_signal_even_when_opted_in():
+    """A delayed task has ``run_at > now()``, so it fails the claim's
+    eligibility predicate — waking would burn a poll and change nothing."""
+    w = _world()
+    w.registry.register(NoopTaskHandler("urgent"), wake_on_enqueue=True)
+    wakeup = _RecordingWakeup()
+    _service_with(w, wakeup).enqueue("urgent", {}, 3600, delay_seconds=30)
+    assert wakeup.notifies == 0
+
+
+def test_keyed_enqueue_that_joined_a_live_task_does_not_signal():
+    """``created=False`` means no work was added — the holder is already
+    pending or running, so there is nothing new for a wake to pick up."""
+    w = _world()
+    w.registry.register(NoopTaskHandler("urgent"), wake_on_enqueue=True)
+    wakeup = _RecordingWakeup()
+    service = _service_with(w, wakeup)
+
+    first = service.enqueue("urgent", {}, 3600, idempotency_key="k1")
+    second = service.enqueue("urgent", {}, 3600, idempotency_key="k1")
+
+    assert first.created is True
+    assert second.created is False
+    assert second.record.id == first.record.id
+    assert wakeup.notifies == 1  # the create signalled; the join did not
+
+
+def test_signalling_never_breaks_the_enqueue_contract():
+    """A latency optimisation must not change what enqueue returns or persists."""
+    w = _world()
+    w.registry.register(NoopTaskHandler("urgent"), wake_on_enqueue=True)
+    record = _service_with(w, _RecordingWakeup()).enqueue(
+        "urgent", {"a": 1}, 3600
+    ).record
+    assert record.task_type == "urgent"
+    assert record.payload == {"a": 1}
+    assert w.status_of(record.id) == TaskStatus.PENDING
+
+
+def test_enqueue_survives_a_wakeup_that_has_no_loop_bound():
+    """End-to-end with the real latch and no running worker: the notify is a
+    no-op and the task is still enqueued for the next poll to claim."""
+    w = _world()
+    w.registry.register(NoopTaskHandler("urgent"), wake_on_enqueue=True)
+    record = w.enqueue("urgent")  # w.wakeup is real and unbound
+    assert w.status_of(record.id) == TaskStatus.PENDING
+    asyncio.run(w.worker.run_once())
+    assert w.status_of(record.id) == TaskStatus.SUCCEEDED
+
+
+def test_idle_worker_loop_wakes_on_an_opted_in_enqueue():
+    """The whole feature, end to end through the real loop: with a poll interval
+    far longer than the test could tolerate, an enqueue still gets claimed
+    promptly because it cuts the idle wait short."""
+    w = _world(poll_interval_seconds=30.0, poll_jitter_seconds=0.0)
+    w.registry.register(NoopTaskHandler("urgent"), wake_on_enqueue=True)
+
+    async def drive():
+        await w.worker.startup()
+        try:
+            # First tick finds nothing and settles into the 30s idle wait.
+            await asyncio.sleep(0.1)
+            record = await asyncio.to_thread(w.enqueue, "urgent")
+            started = time.monotonic()
+            while time.monotonic() - started < 5.0:
+                if w.status_of(record.id) == TaskStatus.SUCCEEDED:
+                    return time.monotonic() - started
+                await asyncio.sleep(0.02)
+            return None
+        finally:
+            await w.worker.shutdown()
+
+    elapsed = asyncio.run(drive())
+    assert elapsed is not None, "task was not claimed — the wake never landed"
+    assert elapsed < 5.0

--- a/src/backend/tests/community/core/task_queue/test_worker_wakeup.py
+++ b/src/backend/tests/community/core/task_queue/test_worker_wakeup.py
@@ -1,0 +1,172 @@
+"""Unit tests for WorkerWakeup — the latch that cuts short the worker's idle wait.
+
+The interesting cases are all about *thread boundaries* and *lost signals*, not
+about the happy path:
+
+- a signal raised from a real non-loop thread must actually end the wait (a
+  plain ``Event.set()`` would queue the callback without waking the loop out of
+  ``select()``, so the wait would run its full timeout and the feature would be
+  a silent no-op);
+- a signal raised while the caller is *between* waits must survive to the next
+  one, because that is exactly when an enqueue lands during a poll.
+
+Timeouts here are deliberately lopsided: the "slow" timeout is far longer than
+any real signal delay, so a test that accidentally falls back to the timer fails
+loudly on elapsed time instead of passing slowly.
+"""
+import asyncio
+import threading
+import time
+
+import pytest
+
+from agentclaw.community.core.task_queue.services.wakeup import WorkerWakeup
+
+pytestmark = pytest.mark.integration
+
+#: Long enough that reaching it means the wake mechanism did not work at all.
+_SLOW_TIMEOUT = 10.0
+#: Short enough to keep the suite fast when a timeout is the expected outcome.
+_FAST_TIMEOUT = 0.05
+
+
+# ── binding ─────────────────────────────────────────────────────────────────
+def test_notify_before_bind_is_a_noop():
+    """The worker may be disabled by config, or simply not have reached
+    ``startup()`` yet. An enqueue must not blow up because there is no loop to
+    wake — the task is still picked up by whatever polls next."""
+    WorkerWakeup().notify()  # must not raise
+
+
+def test_notify_after_unbind_is_a_noop():
+    """``shutdown()`` unbinds, but handler threads can still be draining and
+    may enqueue follow-up work on the way out."""
+    wakeup = WorkerWakeup()
+
+    async def drive():
+        wakeup.bind(asyncio.get_running_loop())
+        wakeup.unbind()
+
+    asyncio.run(drive())
+    wakeup.notify()  # must not raise
+
+
+def test_notify_after_the_loop_closed_is_a_noop():
+    """Still bound, but the loop is gone: ``call_soon_threadsafe`` raises
+    ``RuntimeError`` from ``_check_closed()``. A latency optimisation must never
+    turn into a failed enqueue."""
+    wakeup = WorkerWakeup()
+
+    async def drive():
+        wakeup.bind(asyncio.get_running_loop())
+
+    asyncio.run(drive())  # returns with the loop closed but still bound
+    wakeup.notify()  # must not raise
+
+
+# ── waiting ─────────────────────────────────────────────────────────────────
+def test_wait_times_out_when_nobody_signals():
+    """The unsignalled path is the old behaviour: wait out the interval."""
+
+    async def drive():
+        wakeup = WorkerWakeup()
+        wakeup.bind(asyncio.get_running_loop())
+        return await wakeup.wait(_FAST_TIMEOUT)
+
+    assert asyncio.run(drive()) is False
+
+
+def test_wait_returns_immediately_when_already_signalled():
+    """A signal raised *between* waits — an enqueue landing while the worker was
+    mid-poll — must not be lost. This is the case that a clear-before-wait
+    implementation would silently drop."""
+
+    async def drive():
+        wakeup = WorkerWakeup()
+        wakeup.bind(asyncio.get_running_loop())
+        wakeup.notify()
+        await asyncio.sleep(0)  # let the queued set() run
+        started = time.monotonic()
+        signalled = await wakeup.wait(_SLOW_TIMEOUT)
+        return signalled, time.monotonic() - started
+
+    signalled, elapsed = asyncio.run(drive())
+    assert signalled is True
+    assert elapsed < _SLOW_TIMEOUT / 5
+
+
+def test_wait_clears_the_latch_so_the_next_wait_blocks_again():
+    """One signal buys one wake. Leaving the latch set would spin the poll loop
+    at full speed forever."""
+
+    async def drive():
+        wakeup = WorkerWakeup()
+        wakeup.bind(asyncio.get_running_loop())
+        wakeup.notify()
+        await asyncio.sleep(0)
+        first = await wakeup.wait(_SLOW_TIMEOUT)
+        second = await wakeup.wait(_FAST_TIMEOUT)
+        return first, second
+
+    first, second = asyncio.run(drive())
+    assert first is True
+    assert second is False
+
+
+def test_a_burst_of_notifies_coalesces_into_a_single_wake():
+    """A handler fanning out many tasks must not schedule one poll per task. The
+    latch is a single Event, so N signals collapse to one wake — after which the
+    worker's greedy re-poll drains the backlog."""
+
+    async def drive():
+        wakeup = WorkerWakeup()
+        wakeup.bind(asyncio.get_running_loop())
+        for _ in range(500):
+            wakeup.notify()
+        await asyncio.sleep(0)
+        woke = await wakeup.wait(_SLOW_TIMEOUT)
+        # If the burst had queued 500 independent wakes, this would return True.
+        extra = await wakeup.wait(_FAST_TIMEOUT)
+        return woke, extra
+
+    woke, extra = asyncio.run(drive())
+    assert woke is True
+    assert extra is False
+
+
+# ── the cross-thread case this class exists for ─────────────────────────────
+def test_notify_from_a_non_loop_thread_ends_the_wait_promptly():
+    """The motivating case: a handler running under ``asyncio.to_thread``
+    enqueues follow-up work and signals from that pool thread.
+
+    A bare ``Event.set()`` here would append to the loop's ready queue without
+    waking it out of ``select()``, so this wait would run the full
+    ``_SLOW_TIMEOUT`` and the test would fail on elapsed time — which is exactly
+    the silent regression the assertion below is guarding.
+    """
+    wakeup = WorkerWakeup()
+    idents: dict[str, int] = {}
+
+    async def drive():
+        wakeup.bind(asyncio.get_running_loop())
+        idents["loop"] = threading.get_ident()
+
+        def signal_from_another_thread():
+            idents["notifier"] = threading.get_ident()
+            time.sleep(0.05)  # let the loop reach select() first
+            wakeup.notify()
+
+        thread = threading.Thread(target=signal_from_another_thread)
+        thread.start()
+        started = time.monotonic()
+        signalled = await wakeup.wait(_SLOW_TIMEOUT)
+        elapsed = time.monotonic() - started
+        thread.join()
+        return signalled, elapsed
+
+    signalled, elapsed = asyncio.run(drive())
+
+    # Guards the premise: if these ever matched, the test would prove nothing.
+    assert idents["notifier"] != idents["loop"]
+    assert signalled is True
+    assert elapsed < _SLOW_TIMEOUT / 5

--- a/src/backend/tests/community/repository/platform/test_task_queue_repository.py
+++ b/src/backend/tests/community/repository/platform/test_task_queue_repository.py
@@ -18,7 +18,9 @@ from sqlalchemy.pool import StaticPool
 # create_all() builds the ac_task_queue table.
 from agentclaw.community.core.task_queue.repository.models import TaskQueueModel  # noqa: F401
 from agentclaw.community.core.task_queue.types import TaskStatus
+from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
 from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
+from agentclaw.community.core.task_queue.services.wakeup import WorkerWakeup
 from agentclaw.community.core.repository.implementations.platform.task_queue import _ACTIVE_IDEM_INDEX, _KEYED_INSERT_ATTEMPTS, _MAX_IDEMPOTENCY_KEY_LEN, _MAX_TASK_TYPE_LEN
 from agentclaw.community.core.repository.implementations.platform.task_queue import TaskQueueRepository, _is_active_idem_conflict
 
@@ -624,7 +626,7 @@ def test_key_is_stored_verbatim_without_stripping(repo):
 def test_validation_also_applies_through_the_service_facade(repo):
     """Adopters call TaskQueueService, so the guard must hold on that path too;
     it delegates to the repository, which is where the check lives."""
-    service = TaskQueueService(repo)
+    service = TaskQueueService(repo, HandlerRegistry(), WorkerWakeup())
     with pytest.raises(ValueError, match="exceeds"):
         service.enqueue(
             "demo", {}, 3600, idempotency_key="k" * (_MAX_IDEMPOTENCY_KEY_LEN + 1)
@@ -795,7 +797,7 @@ def test_unkeyed_enqueue_still_accepts_any_task_type(repo, task_type):
 
 def test_padded_task_type_is_rejected_through_the_service_facade(repo):
     """Adopters call the service, so the guard has to hold on that path too."""
-    service = TaskQueueService(repo)
+    service = TaskQueueService(repo, HandlerRegistry(), WorkerWakeup())
     with pytest.raises(ValueError, match="leading or trailing whitespace"):
         service.enqueue("job ", {}, 3600, idempotency_key="k1")
     assert _all_rows(repo) == []


### PR DESCRIPTION
## Problem

`TaskWorker`'s poll loop ended every non-full tick with an unconditional
`asyncio.sleep(self._idle_delay())`. A task enqueued just after a tick therefore
waited out most of `poll_interval_seconds` (default 2.0s ± 0.5 jitter) before
anything looked at it, no matter how urgent it was.

That is the right default for background and recurring work, but some operations
are user-visible and should start as soon as they are enqueued.

## Solution

The idle wait becomes a race between the timer and a signal, so the interval is
a latency **ceiling** rather than a fixed cost. Claiming, leases, deadline
handling, backoff and the greedy re-poll are all untouched.

**Opt-in per task type, default off.** A type asks for this at registration:

```python
registry.register(MyHandler(), wake_on_enqueue=True)
```

Every already-registered type keeps exactly the timing it had — the default is
`False` and no existing registration call changes. The flag lives at the wiring
site rather than on the handler because how eagerly a queue is drained is a
deployment concern, and one grep for `wake_on_enqueue=True` then lists every
type that opted in.

**New `WorkerWakeup`** — a coalescing latch bound as a DI singleton and shared by
the enqueue path and the worker's loop, so `TaskQueueService` never has to depend
on `TaskWorker`. A burst of 500 enqueues produces one extra poll, not 500; the
existing greedy re-poll then drains the backlog at full speed.

Two details carry the correctness:

- **The signal is raised only after `repo.enqueue` returns.** `orm_session()`
  commits on clean exit, so the row is committed and visible to any claim the
  wake triggers, rather than racing our own uncommitted insert.
- **`notify()` goes through `loop.call_soon_threadsafe`.** `enqueue()` is
  synchronous, and for a handler enqueuing follow-up work it runs on an
  `asyncio.to_thread` pool thread, not the loop thread. A bare `Event.set()`
  there appends to the loop's ready queue *without* waking it out of `select()`,
  so the wait would run its full timeout — the feature would be a silent no-op
  with no exception and no failing test. A test pins this down: with the naive
  set, the wake takes the entire 10s timeout instead of ~50ms.

The latch also declines to signal where a wake cannot help: a delayed enqueue
(`run_at` in the future, so ineligible to claim), a keyed enqueue that joined a
live holder (`created=False`, no new work), and a type this process has no
handler for.

### Scope

The wake is in-process. The enqueuing pod's own worker starts claiming within a
millisecond; other pods still poll on their normal interval, which is correct
since any worker may claim any task. A fleet-wide wake would need a broker, and
`notify()` is the seam if that is ever wanted — deliberately not taken here, as
the queue being DB-only is a real virtue.

This does not make a task jump a backlog: `claim_batch` still orders `run_at
ASC`. Priority ordering would be a separate change.

## Validation

**CI: all 7 checks green on `887ee70`** — including Backend unit tests and
Singlebox coverage, which exercise the real `uv sync --frozen` environment and
the `ci_test.sh` coverage gate.

Locally, before pushing:

- **252 passed** across `tests/community/core/task_queue/`, the task queue
  repository suite, and `tests/community/di/` (wiring resolves with the two
  changed constructor signatures).
- **New coverage** (25 tests): the default-off guarantee, explicit opt-in,
  delayed and keyed-duplicate enqueues not signalling, latch clearing and
  coalescing, notify before bind / after unbind / after loop close, a
  cross-thread wake asserted to come from a different thread ident, and an
  end-to-end test that claims a task in well under a 30s poll interval.
- **Mutation-checked** both key tests rather than trusting green: reverting
  `notify()` to a bare `Event.set()` makes the cross-thread test fail on elapsed
  time (10.01s vs. the &lt;2s bound), and disabling `_should_wake` fails the
  end-to-end test. Both were restored and re-verified.
- **Full backend suite**: 12,385 passed, 46 skipped. The 8 remaining failures
  (3 architecture, 5 in `service_bot` / `bot_startup_script`) reproduce
  identically on an unmodified `origin/dev` tree in that container — they are
  environment artifacts, not regressions, and CI confirms this.
- **flake8 SAST block scan** (`scripts/ci/python_sast_local.sh` rule set) clean
  on all 8 changed files.

Note on the local environment: the container could not reach the pinned Aliyun
package index (the proxy denies it), so the local run used an ad-hoc
PyPI-resolved venv rather than `uv sync --frozen`. `uv.lock` was **not**
modified. CI covers what that environment could not.

## Compatibility and risk

No schema, config, or contract change — no new `task_queue_worker` config key,
so the golden config fixtures are untouched. `HandlerRegistry.register` gains a
keyword-only parameter with a default, so every existing call site is unchanged.

`TaskQueueService.__init__` and `TaskWorker.__init__` each take one new
dependency; both are DI-resolved in production, and the four direct construction
sites in tests are updated in this PR.

Risk is low and self-limiting: the signal only ever removes waiting. If it is
never delivered, behaviour is exactly what it is today. Rollback is reverting
the commit; there is no persisted state to migrate.