### PR TITLE
perf(backend): fan out MCP detail delivery in sync_mcp_desired_state

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -61,6 +61,10 @@ SKILLS_DIR = Path("/home/admin/.openclaw/workspace/skills")
 SKILLS_REPO_DIR = SKILLS_DIR / "skills-repo"
 SKILLS_LOCAL_DIR = SKILLS_DIR / "skills-local"
 
+# MCP 详情投递的并发上限。与 ``MCPSyncService._sync_mcp_details`` 取同一口径:
+# 每条投递最终是一次设备侧阻塞 HTTP(插件内含 3 次重试),并发放开会把引擎压垮。
+_MCP_DETAIL_SYNC_CONCURRENCY = 5
+
 logger = get_logger()
 
 
@@ -526,6 +530,11 @@ class SkillSetService:
         set: it is the device-level reconciliation command that clears stale
         allow-list entries.  Per-server detail delivery precedes that full
         declaration so all newly allowed MCPs have their configured payload.
+
+        Detail delivery fans out instead of running one MCP at a time: every
+        ``sync_mcp_detail`` ends in a blocking device HTTP call that carries its
+        own retries, so a bot with many MCPs used to make the caller wait for
+        the sum of them.
         """
         try:
             entries: list[dict[str, Any]] = []
@@ -534,15 +543,8 @@ class SkillSetService:
                 if not detail:
                     return False
                 entries.append(detail)
-                result = await self._mcp_sync_service.sync_mcp_detail(
-                    user_id=self.user_id or self.entity_id or "",
-                    mcp_data=detail,
-                    bot_id=self.bot_id,
-                    entity_id=self.entity_id,
-                    engine_type=self.engine_type,
-                )
-                if not result.get("success"):
-                    return False
+            if not await self._deliver_mcp_details(entries):
+                return False
             ctx = self._resolver.resolve_for_bot(
                 self.bot_id, self.entity_id or self.user_id or ""
             )
@@ -556,6 +558,54 @@ class SkillSetService:
                 exc_info=True,
             )
             return False
+
+    async def _deliver_mcp_details(self, entries: list[dict[str, Any]]) -> bool:
+        """Push every MCP payload to the device concurrently.
+
+        Bounded by a semaphore for the same reason
+        ``MCPSyncService._sync_mcp_details`` bounds its own fan-out: an
+        unbounded burst of device HTTP requests overwhelms the engine.  Unlike
+        the previous serial loop this attempts every entry even after one
+        fails; a failed run still withholds ``sync_all_mcp_servers``, so no
+        extra MCP becomes reachable and the reconciler retries the whole
+        projection.
+        """
+        semaphore = asyncio.Semaphore(_MCP_DETAIL_SYNC_CONCURRENCY)
+
+        async def deliver(detail: dict[str, Any]) -> bool:
+            async with semaphore:
+                result = await self._mcp_sync_service.sync_mcp_detail(
+                    user_id=self.user_id or self.entity_id or "",
+                    mcp_data=detail,
+                    bot_id=self.bot_id,
+                    entity_id=self.entity_id,
+                    engine_type=self.engine_type,
+                )
+                return bool(result.get("success"))
+
+        # return_exceptions=True: 单条失败不能让其余任务变成 orphan——否则它们会在
+        # 本方法返回后继续往设备投递。
+        results = await asyncio.gather(
+            *(deliver(entry) for entry in entries), return_exceptions=True
+        )
+
+        delivered = True
+        for entry, result in zip(entries, results, strict=True):
+            if isinstance(result, asyncio.CancelledError):
+                # 取消来自上层,不是单条 MCP 失败,必须向上抛。
+                raise result
+            if isinstance(result, Exception):
+                logger.warning(
+                    "[sync_mcp_desired_state] MCP detail delivery raised for "
+                    "bot_id=%s server_code=%s",
+                    self.bot_id,
+                    entry.get("serverCode") or entry.get("server_code"),
+                    exc_info=result,
+                )
+                delivered = False
+            elif not result:
+                delivered = False
+        return delivered
 
     def _validate_name(self, name: str) -> None:
         """Validate skill set name (cannot contain underscore)."""

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -61,9 +61,13 @@ SKILLS_DIR = Path("/home/admin/.openclaw/workspace/skills")
 SKILLS_REPO_DIR = SKILLS_DIR / "skills-repo"
 SKILLS_LOCAL_DIR = SKILLS_DIR / "skills-local"
 
-# MCP 详情投递的并发上限。与 ``MCPSyncService._sync_mcp_details`` 取同一口径:
-# 每条投递最终是一次设备侧阻塞 HTTP(插件内含 3 次重试),并发放开会把引擎压垮。
-_MCP_DETAIL_SYNC_CONCURRENCY = 5
+# MCP 详情投递的并发上限。每条投递最终是一次设备侧阻塞 HTTP(插件内含 3 次重试),
+# 经 ``asyncio.to_thread`` 落到 event loop 的默认线程池,所以这个值同时约束两头:
+# 对单台设备的突发请求数,以及本路径占用的共享线程数。默认池只有
+# ``min(32, cpu_count + 4)`` 个线程(4 核容器 = 8)且全进程共用,取值再大只会排队
+# 并挤占其它 ``to_thread`` 调用方。``MCPSyncService._sync_mcp_details`` 的同名上限
+# 仍是 5——那条链路是同一台设备的另一个入口,两者可能并发。
+_MCP_DETAIL_SYNC_CONCURRENCY = 10
 
 logger = get_logger()
 

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -1550,13 +1550,16 @@ class TestSyncMcpDesiredState:
             return {"success": True}
 
         svc, plugin = self._make_svc(sync_mcp_detail=sync_mcp_detail)
-        codes = {f"mcp.s{i}" for i in range(12)}
+        # Twice the bound, so the semaphore is genuinely exercised whatever the
+        # bound is tuned to.
+        total = mod._MCP_DETAIL_SYNC_CONCURRENCY * 2
+        codes = {f"mcp.s{i}" for i in range(total)}
 
         assert await svc.sync_mcp_desired_state(server_codes=codes) is True
 
         assert peak > 1, "detail delivery ran serially"
         assert peak == mod._MCP_DETAIL_SYNC_CONCURRENCY
-        assert svc._mcp_sync_service.sync_mcp_detail.await_count == 12
+        assert svc._mcp_sync_service.sync_mcp_detail.await_count == total
         # The allow-list declaration still carries every entry, in sorted order.
         plugin.sync_all_mcp_servers.assert_called_once_with(
             [{"server_code": code} for code in sorted(codes)]

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -1493,3 +1493,157 @@ class TestSyncSkillSetToActiveOwnerIdResolution:
         skill_service.activate_skill.assert_called_once_with(
             "git://biz/skill-a", user_id="user1", bolt_id="bot-1"
         )
+
+
+# ── TestSyncMcpDesiredState ──────────────────────────────────────────
+
+
+class TestSyncMcpDesiredState:
+    """sync_mcp_desired_state: bounded concurrent detail delivery + projection contract."""
+
+    def _make_svc(self, *, sync_mcp_detail):
+        from agentclaw.community.core.skill_center.services.skill_set_service import SkillSetService
+
+        with patch("agentclaw.community.core.skill_center.services.skill_set_service.WorkspacePathFactory"):
+            svc = SkillSetService(
+                skill_repo=MagicMock(),
+                skill_set_repo=MagicMock(),
+                mcp_center=MagicMock(),
+                mcp_config_service=MagicMock(),
+                skill_service=MagicMock(),
+                bot_repo=MagicMock(),
+                path_factory=MagicMock(),
+            )
+        svc.bot_id = "bot1"
+        svc.user_id = "user1"
+        svc.entity_id = "staff_user1"
+        svc.engine_type = "moltis"
+        svc.mcp_center = MagicMock()
+        svc.mcp_center.get_mcp_detail.side_effect = lambda code: {"server_code": code}
+        svc._mcp_sync_service = MagicMock()
+        svc._mcp_sync_service.sync_mcp_detail = AsyncMock(side_effect=sync_mcp_detail)
+
+        plugin = MagicMock()
+        plugin.sync_all_mcp_servers = MagicMock(return_value=True)
+        svc._resolver = MagicMock()
+        svc._device_sync_dispatcher = MagicMock()
+        svc._device_sync_dispatcher.dispatch.return_value = plugin
+        return svc, plugin
+
+    @pytest.mark.asyncio
+    async def test_details_are_delivered_concurrently_within_the_bound(self):
+        """The serial loop delivered one MCP at a time; delivery now overlaps,
+        capped at _MCP_DETAIL_SYNC_CONCURRENCY so the device is not flooded."""
+        import asyncio
+
+        from agentclaw.community.core.skill_center.services import skill_set_service as mod
+
+        inflight = 0
+        peak = 0
+
+        async def sync_mcp_detail(**_kwargs):
+            nonlocal inflight, peak
+            inflight += 1
+            peak = max(peak, inflight)
+            await asyncio.sleep(0.01)
+            inflight -= 1
+            return {"success": True}
+
+        svc, plugin = self._make_svc(sync_mcp_detail=sync_mcp_detail)
+        codes = {f"mcp.s{i}" for i in range(12)}
+
+        assert await svc.sync_mcp_desired_state(server_codes=codes) is True
+
+        assert peak > 1, "detail delivery ran serially"
+        assert peak == mod._MCP_DETAIL_SYNC_CONCURRENCY
+        assert svc._mcp_sync_service.sync_mcp_detail.await_count == 12
+        # The allow-list declaration still carries every entry, in sorted order.
+        plugin.sync_all_mcp_servers.assert_called_once_with(
+            [{"server_code": code} for code in sorted(codes)]
+        )
+
+    @pytest.mark.asyncio
+    async def test_failed_detail_withholds_the_allow_list_declaration(self):
+        delivered: list[str] = []
+
+        async def sync_mcp_detail(*, mcp_data, **_kwargs):
+            code = mcp_data["server_code"]
+            delivered.append(code)
+            return {"success": code != "mcp.s1"}
+
+        svc, plugin = self._make_svc(sync_mcp_detail=sync_mcp_detail)
+
+        result = await svc.sync_mcp_desired_state(
+            server_codes={"mcp.s0", "mcp.s1", "mcp.s2"}
+        )
+
+        assert result is False
+        plugin.sync_all_mcp_servers.assert_not_called()
+        # Fan-out attempts every entry; only the projection is withheld.
+        assert sorted(delivered) == ["mcp.s0", "mcp.s1", "mcp.s2"]
+
+    @pytest.mark.asyncio
+    async def test_raising_detail_fails_the_projection_without_escaping(self):
+        delivered: list[str] = []
+
+        async def sync_mcp_detail(*, mcp_data, **_kwargs):
+            code = mcp_data["server_code"]
+            delivered.append(code)
+            if code == "mcp.s1":
+                raise RuntimeError("device refused the payload")
+            return {"success": True}
+
+        svc, plugin = self._make_svc(sync_mcp_detail=sync_mcp_detail)
+
+        result = await svc.sync_mcp_desired_state(
+            server_codes={"mcp.s0", "mcp.s1", "mcp.s2"}
+        )
+
+        assert result is False
+        plugin.sync_all_mcp_servers.assert_not_called()
+        assert sorted(delivered) == ["mcp.s0", "mcp.s1", "mcp.s2"]
+
+    @pytest.mark.asyncio
+    async def test_cancellation_propagates_instead_of_reporting_failure(self):
+        """A cancelled run is the caller's decision, not a per-MCP failure."""
+        import asyncio
+
+        async def sync_mcp_detail(*, mcp_data, **_kwargs):
+            if mcp_data["server_code"] == "mcp.s1":
+                raise asyncio.CancelledError()
+            return {"success": True}
+
+        svc, plugin = self._make_svc(sync_mcp_detail=sync_mcp_detail)
+
+        with pytest.raises(asyncio.CancelledError):
+            await svc.sync_mcp_desired_state(server_codes={"mcp.s0", "mcp.s1"})
+
+        plugin.sync_all_mcp_servers.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_mcp_center_detail_skips_delivery_entirely(self):
+        async def sync_mcp_detail(**_kwargs):
+            return {"success": True}
+
+        svc, plugin = self._make_svc(sync_mcp_detail=sync_mcp_detail)
+        svc.mcp_center.get_mcp_detail.side_effect = (
+            lambda code: None if code == "mcp.s1" else {"server_code": code}
+        )
+
+        result = await svc.sync_mcp_desired_state(server_codes={"mcp.s0", "mcp.s1"})
+
+        assert result is False
+        svc._mcp_sync_service.sync_mcp_detail.assert_not_awaited()
+        plugin.sync_all_mcp_servers.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_desired_state_still_declares_the_empty_allow_list(self):
+        async def sync_mcp_detail(**_kwargs):
+            raise AssertionError("no MCP to deliver")
+
+        svc, plugin = self._make_svc(sync_mcp_detail=sync_mcp_detail)
+
+        assert await svc.sync_mcp_desired_state(server_codes=set()) is True
+
+        svc._mcp_sync_service.sync_mcp_detail.assert_not_awaited()
+        plugin.sync_all_mcp_servers.assert_called_once_with([])


### PR DESCRIPTION
## Problem

`SkillSetService.sync_mcp_desired_state` delivered MCP payloads one at a time:

```python
for server_code in sorted(server_codes):
    detail = self.mcp_center.get_mcp_detail(server_code)
    ...
    result = await self._mcp_sync_service.sync_mcp_detail(...)
```

Each `sync_mcp_detail` bottoms out in `asyncio.to_thread(plugin.sync_single_mcp, ...)` — a
blocking device HTTP call that already carries 3 retries inside the plugin. A bot with many
MCPs therefore paid the *sum* of those round trips, and every caller of the runtime
projection (`BotRuntimeProjectionReconciler._apply_non_skill_projection`) waited for it.

`MCPSyncService._sync_mcp_details` already pushes the same plugin calls concurrently; only
this desired-state path stayed serial.

## Solution

Split the loop in two:

- **MCP Center lookups stay serial.** They are cheap local/catalog reads, and keeping them
  ahead of any delivery preserves the fail-fast contract: a missing detail aborts the
  projection before anything reaches the device.
- **Detail delivery fans out** in a new `_deliver_mcp_details`, bounded by
  `asyncio.Semaphore(_MCP_DETAIL_SYNC_CONCURRENCY)`, set to 10.

The bound constrains two different things at once, which is why it is not simply "as high as
possible":

1. The burst of HTTP requests against a **single** device — all entries in one desired state
   target the same bot.
2. This path's share of the event loop's **default thread pool**. `asyncio.to_thread` uses
   `loop.run_in_executor(None, ...)`, whose default is `min(32, cpu_count + 4)` threads —
   8 on a 4-core container — and that pool is process-wide, shared with ~120 other
   `asyncio.to_thread` call sites in the backend. Beyond that size, extra tasks queue rather
   than run, while squeezing every other `to_thread` caller.

So 10 gives real overlap on a typical container without leaving the shared pool with nothing
to spare. Going meaningfully higher would first require giving MCP delivery its own executor
instead of the shared default one; that is a change to `MCPSyncService._sync_mcp_detail`
(shared by three callers) and is deliberately not in this PR.

`asyncio.gather(..., return_exceptions=True)` is used rather than letting the first failure
propagate, so one bad MCP cannot leave sibling tasks orphaned and still pushing to the device
after the method returns. `CancelledError` is re-raised (caller-driven cancellation is not a
per-MCP failure) — matching the handling in `_sync_mcp_details`.

Rejected alternatives:

- **Threads (`ThreadPoolExecutor`).** The path is already `async`, and the only blocking leg
  is already wrapped in `asyncio.to_thread` inside `MCPSyncService`. Adding a second thread
  pool here would duplicate that and move DB-touching sync calls (`resolve_for_bot`,
  `build_mcp_sync_payload`) off the event loop thread, which they do not expect. With
  `asyncio.gather`, only `plugin.sync_single_mcp` runs off-loop — exactly as today.
- **Routing through `MCPSyncService.sync_mcp_details`.** That method re-collects MCPs from
  `BotMCPProvider` instead of honouring the caller's `server_codes` desired state, so it is
  not a drop-in.

## Validation

Ran from `src/backend` with the project venv (`uv sync`):

- `pytest tests/community/core/skill_center tests/community/core/mcp` — 986 passed, 3 skipped.
- `pytest tests/community/services tests/community/api/skill_center tests/community/integration/skill_center tests/community/contracts` — 602 passed.
- `scripts/ci/python_sast_local.sh src/backend 1` over this PR's changed files (base = the
  base branch head) — clean, exit 0.

New tests in `tests/community/core/skill_center/services/test_skill_set_service.py::TestSyncMcpDesiredState`
cover concurrency and the failure contract; the concurrency test sizes its input off the
constant, so the semaphore stays exercised if the bound is retuned. Verified the tests are
meaningful by re-running the class against the previous serial implementation: 4 of the 6 fail
there (peak in-flight deliveries of 1 instead of the bound, plus the fail-fast differences
below).

Not run locally: `singlebox_coverage.sh` and the full backend `ci_test.sh` coverage gate — the
authoring sandbox cannot reach the configured `mirrors.aliyun.com` index (deps were installed
from `pypi.org` instead), so the `uv sync --frozen` based entrypoints do not start there. Both
run here in PR CI.

## Compatibility and risk

Same inputs, same return contract (`bool`), same call to `sync_all_mcp_servers` with the
entries in sorted order — including the deliberate empty-set declaration. Two observable
differences on the failure path, both intentional:

- A failing delivery no longer short-circuits the remaining pushes; every entry is attempted.
  Nothing extra becomes reachable, because `sync_all_mcp_servers` (the allow-list declaration)
  is still withheld and the reconciler still raises `SkillSetRuntimeReconcileError` and retries.
- A missing MCP Center detail now aborts before *any* delivery, where previously the entries
  sorted ahead of it had already been pushed. Strictly fewer device writes for a projection
  that cannot complete.

Concurrent delivery is safe for every plugin shape the contract describes: arca/baas push
per-`server_code` over `/api/mcp` (independent), teclaw re-delivers the whole composed
artifact (idempotent), local/community are no-ops — and `_sync_mcp_details` already exercises
them concurrently.

`_sync_mcp_details` keeps its own bound of 5. It is a second entrypoint to the same device, so
worst case the two paths overlap at 15 in-flight pushes against one bot and 15 borrowed
threads. If that is judged too much, the two constants should be unified — say which way and
I will follow up.

Rollback: revert the commits; the serial loop returns with no state migration.