### PR TITLE
fix(skills): align AICoding runtime probe identity

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -14,6 +14,9 @@ from typing import Any, Dict
 from agentclaw.community.core.bot_management.capabilities import (
     is_template_factory_config,
 )
+from agentclaw.community.core.workspace.runtime_identity import (
+    claude_code_uses_aicoding_runtime,
+)
 
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.utils import secret_utils
@@ -30,7 +33,6 @@ from ..provisioning import BotProvisioningContext, EngineProvisioningStrategy
 CODING_TEMPLATE_TYPES = frozenset({"applicationCoding", "personalCoding"})
 AICODING_ENGINE_TYPE = "aicoding"
 CLAUDE_CODE_ENGINE_TYPE = "claude_code"
-NORMAL_CC_TEMPLATE_TYPE = "normalcc"
 TEMPLATE_CONFIG_CONSUMING_ENGINES = frozenset(
     {AICODING_ENGINE_TYPE, CLAUDE_CODE_ENGINE_TYPE}
 )
@@ -97,10 +99,6 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         return (engine_type or default).strip().lower().replace("-", "_")
 
     @staticmethod
-    def normalize_template_type(template_type: str | None) -> str:
-        return (template_type or "").strip().lower()
-
-    @staticmethod
     def is_coding_template(template_type: str | None) -> bool:
         return template_type in CODING_TEMPLATE_TYPES
 
@@ -112,15 +110,9 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         template_type: str | None,
     ) -> bool:
         """Whether this bot should use the aicoding runtime engine."""
-        if (
-            cls.normalize_engine_type(active_engine, default="")
-            != CLAUDE_CODE_ENGINE_TYPE
-        ):
-            return False
-        normalized_template_type = cls.normalize_template_type(template_type)
-        return bool(
-            normalized_template_type
-            and normalized_template_type != NORMAL_CC_TEMPLATE_TYPE
+        return claude_code_uses_aicoding_runtime(
+            active_engine=active_engine,
+            template_type=template_type,
         )
 
     @classmethod

--- a/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/recovery_service.py
@@ -27,19 +27,26 @@ from agentclaw.community.core.skills_pool.mapping_intent import (
 )
 from agentclaw.community.core.skills_pool.edit_guard import SkillsPoolEditGuard
 from agentclaw.community.core.skills_pool.ports import SkillsPoolRuntimeProtocol
-from agentclaw.community.core.repository.protocols.skills_pool import SkillsPoolSkillRepositoryProtocol
+from agentclaw.community.core.repository.protocols.skills_pool import (
+    SkillsPoolSkillRepositoryProtocol,
+)
 from agentclaw.community.core.skills_pool.reconcile_task import (
     SKILLS_POOL_RECONCILE_DEADLINE_SECONDS,
     SKILLS_POOL_RECONCILE_TASK,
     build_skills_pool_reconcile_payload,
 )
-from agentclaw.community.core.repository.protocols.skills_pool import SkillsPoolLayoutRepositoryProtocol
+from agentclaw.community.core.repository.protocols.skills_pool import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
     SkillLayoutPhase,
 )
 from agentclaw.community.core.task_queue.services.task_queue_service import (
     TaskQueueService,
+)
+from agentclaw.community.core.workspace.skill_layout import (
+    runtime_layout_engine_for_bot,
 )
 from agentclaw.community.log import get_logger
 
@@ -328,15 +335,16 @@ class SkillsPoolRollbackService:
                 evidence={"reason": f"engine Pool layout not implemented: {engine}"},
             )
         user_id = str(owner_id)
+        layout_engine = runtime_layout_engine_for_bot(bot)
 
         probe = await self._runtime.probe(
             bot_id=scope.bot_id,
-            owner_id=user_id,
-            engine=engine,
+            user_id=user_id,
+            engine=layout_engine,
         )
         restoration_resume = is_trusted_aicoding_repo_restoration_resume(
             state=state,
-            engine=engine,
+            engine=layout_engine,
             probe=probe,
         )
         if (

--- a/src/backend/src/agentclaw/community/core/workspace/runtime_identity.py
+++ b/src/backend/src/agentclaw/community/core/workspace/runtime_identity.py
@@ -1,0 +1,22 @@
+"""Pure runtime-implementation identity rules shared by Backend domains."""
+
+from __future__ import annotations
+
+
+def claude_code_uses_aicoding_runtime(
+    *,
+    active_engine: str | None,
+    template_type: str | None,
+) -> bool:
+    """Whether a logical Claude Code Bot runs the AICoding implementation."""
+
+    normalized_engine = (active_engine or "").strip().lower().replace("-", "_")
+    normalized_template = (template_type or "").strip().lower()
+    return (
+        normalized_engine == "claude_code"
+        and bool(normalized_template)
+        and normalized_template != "normalcc"
+    )
+
+
+__all__ = ["claude_code_uses_aicoding_runtime"]

--- a/src/backend/src/agentclaw/community/core/workspace/skill_layout.py
+++ b/src/backend/src/agentclaw/community/core/workspace/skill_layout.py
@@ -13,6 +13,10 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+from agentclaw.community.core.workspace.runtime_identity import (
+    claude_code_uses_aicoding_runtime,
+)
+
 
 @dataclass(frozen=True, slots=True)
 class OpenClawPoolPaths:
@@ -55,10 +59,6 @@ PoolPaths = (
 )
 FILESYSTEM_POOL_ENGINES = ("openclaw", "claude_code", "aicoding", "hermes")
 
-_CLAUDE_CODE_AICODING_TEMPLATES = frozenset(
-    {"personalCoding", "applicationCoding"}
-)
-
 
 def runtime_layout_engine_for_bot(bot: Mapping[str, object]) -> str:
     """Return the filesystem identity for a Bot's Skill runtime.
@@ -74,10 +74,10 @@ def runtime_layout_engine_for_bot(bot: Mapping[str, object]) -> str:
     """
 
     engine = str(bot.get("active_engine") or "")
-    if (
-        engine == "claude_code"
-        and str(bot.get("template_type") or "")
-        in _CLAUDE_CODE_AICODING_TEMPLATES
+    template_type = str(bot.get("template_type") or "")
+    if claude_code_uses_aicoding_runtime(
+        active_engine=engine,
+        template_type=template_type,
     ):
         return "aicoding"
     return engine

--- a/src/backend/tests/community/core/skill_center/test_runtime_resolver.py
+++ b/src/backend/tests/community/core/skill_center/test_runtime_resolver.py
@@ -10,7 +10,9 @@ from agentclaw.community.core.skill_center.runtime_resolver import (
     RuntimeProjectionResolver,
 )
 from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
-from agentclaw.community.core.workspace.skill_layout import runtime_layout_engine_for_bot
+from agentclaw.community.core.workspace.skill_layout import (
+    runtime_layout_engine_for_bot,
+)
 
 
 def test_resolver_projects_every_supported_skill_corpus_and_deduplicates_inputs() -> None:
@@ -108,7 +110,10 @@ def test_resolver_rejects_unknown_sources_instead_of_silently_dropping_them() ->
         )
 
 
-@pytest.mark.parametrize("template_type", ["personalCoding", "applicationCoding"])
+@pytest.mark.parametrize(
+    "template_type",
+    ["personalCoding", "applicationCoding", "architect", "customCC"],
+)
 def test_coding_template_has_aicoding_physical_layout_but_claude_logical_engine(
     template_type: str,
 ) -> None:
@@ -119,3 +124,16 @@ def test_coding_template_has_aicoding_physical_layout_but_claude_logical_engine(
     }
 
     assert runtime_layout_engine_for_bot(bot) == "aicoding"
+
+
+@pytest.mark.parametrize("template_type", [None, "", "normalCC", " NormalCC "])
+def test_native_claude_template_keeps_claude_code_physical_layout(
+    template_type: str | None,
+) -> None:
+    bot = {
+        "bot_type": "personal",
+        "active_engine": "claude_code",
+        "template_type": template_type,
+    }
+
+    assert runtime_layout_engine_for_bot(bot) == "claude_code"

--- a/src/backend/tests/community/core/skills_pool/test_recovery_service.py
+++ b/src/backend/tests/community/core/skills_pool/test_recovery_service.py
@@ -315,6 +315,18 @@ class _AICodingBots(_Bots):
         return {**value, "active_engine": "aicoding"}
 
 
+class _ClaudeProductAICodingBots(_Bots):
+    def get_by_id_and_entity(
+        self, bot_id: str, entity_id: str
+    ) -> dict[str, object]:
+        value = super().get_by_id_and_entity(bot_id, entity_id)
+        return {
+            **value,
+            "active_engine": "claude_code",
+            "template_type": "architect",
+        }
+
+
 class _Skills:
     local = [
         RegisteredSkillAsset(
@@ -364,6 +376,7 @@ class _RollbackRuntime:
         self.events: list[str] = []
         self.publish_results = [True, False]
         self.mapping_layouts: list[SkillMappingSourceLayout] = []
+        self.probe_requests: list[tuple[str, str, str]] = []
         self.expected_registered_local_names = ["local-a"]
         self.probe_result = RuntimeLayoutProbeResult(
             status=RuntimeLayoutProbeStatus.READY,
@@ -373,8 +386,15 @@ class _RollbackRuntime:
             evidence={"mapping_contract_version": MAPPING_CONTRACT_VERSION},
         )
 
-    async def probe(self, **kwargs: object) -> RuntimeLayoutProbeResult:
+    async def probe(
+        self,
+        *,
+        bot_id: str,
+        user_id: str,
+        engine: str,
+    ) -> RuntimeLayoutProbeResult:
         self.events.append("probe")
+        self.probe_requests.append((bot_id, user_id, engine))
         return self.probe_result
 
     async def rollback_to_legacy(self, **kwargs: object) -> PoolCutoverResult:
@@ -716,3 +736,34 @@ async def test_aicoding_rollback_resumes_after_active_repo_restoration() -> None
         "verify",
     ]
     assert layouts.events == ["begin", "cutover", "database"]
+
+
+@pytest.mark.asyncio
+async def test_claude_product_rollback_probes_aicoding_physical_layout() -> None:
+    layouts = _RollbackLayouts()
+    runtime = _RollbackRuntime()
+    runtime.publish_results = [True, True]
+    runtime.probe_result = RuntimeLayoutProbeResult(
+        status=RuntimeLayoutProbeStatus.READY,
+        engine="aicoding",
+        layout_contract_version=LAYOUT_CONTRACT_VERSION,
+        preparation_id="preparation-1",
+        evidence={"mapping_contract_version": MAPPING_CONTRACT_VERSION},
+    )
+
+    result = await SkillsPoolRollbackService(
+        bot_repository=_ClaudeProductAICodingBots(),
+        layout_repository=layouts,
+        skill_repository=_Skills(),
+        runtime=runtime,
+        edit_guard=_EditGuard(),
+    ).rollback(
+        scope=SCOPE,
+        rollback_generation="rollback-1",
+        lease_owner="operator-task-1",
+        operator="oncall-1",
+        note="restore mixed runtime",
+    )
+
+    assert result.outcome is SkillsPoolRollbackOutcome.LEGACY_ACTIVE
+    assert runtime.probe_requests == [(SCOPE.bot_id, "owner-1", "aicoding")]


### PR DESCRIPTION
## Problem

Mixed Claude Code product Bots can run the AICoding implementation, but Skills Pool used a narrower template allowlist than provisioning. Architect and custom templates therefore probed the wrong physical layout. The operator rollback path also passed the logical engine and an invalid `owner_id` keyword to the runtime probe.

## Solution

- Share one pure `claude_code_uses_aicoding_runtime` policy between provisioning and Skills layout resolution.
- Cover every non-empty, non-`normalCC` Claude Code template while keeping native Claude Code unchanged.
- Make rollback probe use `user_id` and the resolved physical layout engine; keep logical engine semantics for catalog/asset queries.
- Add regression coverage for legacy, architect, custom, and rollback paths.

## Validation

- `uv run pytest -q tests/community/core/skill_center/test_runtime_resolver.py tests/community/core/bot_management/services/test_engine_resolver.py tests/community/core/bot_management/test_engine_provisioning_strategy.py tests/community/core/skills_pool/test_recovery_service.py tests/community/architecture` — 265 passed
- `uv run ruff check` on all changed Python files — passed
- `git diff --check` — passed

## Compatibility and risk

No schema or public API change. Logical `active_engine=claude_code` remains unchanged in persisted/catalog semantics; only filesystem probe identity is projected to `aicoding` where the provisioning policy already selects the AICoding implementation.
