### PR TITLE
feat: public bcs add bot_uuid to context

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -488,7 +488,7 @@ class BotPublicService:
             raise BotNotFoundError(f"Bot not found: {bot_uid}")
         operator_id = operator.staff_id if operator else owner_id
         # Context mirrors the normal-bot publish (publishHint/botSkills/botMcps
-        # via _build_public_approval_context) plus the two new-version fields.
+        # via _build_public_approval_context) plus the new-version fields.
         # All values are str -> stays dict[str, str] for the antprocess echo.
         context: Dict[str, str] = self._build_public_approval_context(bot, operator)
         # BCS publish uses its own approval prompt (发布→开放, scene resolved
@@ -496,6 +496,14 @@ class BotPublicService:
         context["publishHint"] = self._build_bcs_publish_hint(bot, operator, public_scope)
         context["public_scope"] = public_scope
         context["viewFriendDeps"] = self._build_view_friend_deps(view_depts)
+        # bot_id (the full BCS identity "{backend_bot_id}:{entity_id}", used
+        # verbatim as bot_uuid by the callback's _apply_callback_decision) and
+        # owner_id ride the context so antprocess echoes them back (snake→camel:
+        # bot_id→botId, owner_id→ownerId) on the /callback POST — without
+        # bot_id the callback can't resolve the bot and the AGREE visibility
+        # flip is a no-op.
+        context["bot_id"] = bot_uid
+        context["owner_id"] = owner_id
         approval_result = self._process_service.start_approval(
             applicant=operator_id,
             # biz_id flows into the approval service's puid, which only accepts

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -126,6 +126,36 @@ class TestPublicBcsBot:
         assert "同学正在开放" in ctx["publishHint"]
         assert "bot到加好友场景，" in ctx["publishHint"]
 
+    def test_context_carries_bot_id_and_owner_id_for_callback_echo(self):
+        # antprocess echoes the ticket context back on the /callback POST
+        # (snake→camel: bot_id→botId, owner_id→ownerId). The new-version
+        # callback path uses bot_id verbatim as the BCS bot_uuid
+        # (_apply_callback_decision → get_attributes(bot_uuid=bot_id)) and
+        # owner_id for the legacy branch; without them in the context the
+        # callback arrives with botId/ownerId=None and the AGREE visibility
+        # flip is a no-op.
+        process = MagicMock()
+        process.start_approval.return_value = {
+            "success": True, "puid": "p1", "state": "PROCESSING",
+        }
+        bot_repo = MagicMock()
+        bot_repo.get_by_id_and_owner.return_value = _make_bot(bot_id="b1", owner_id="u1")
+        svc = _make_service(process_service=process, bot_repository=bot_repo)
+
+        # bot_uid is the full BCS identity "{backend_bot_id}:{entity_id}"; it
+        # must echo back unchanged so the callback addresses the right bot —
+        # backend_bot_id alone would not resolve via BCS get_attributes.
+        svc.public_bcs_bot(
+            bot_uid="b1:entity1",
+            owner_id="u1",
+            public_scope="user",
+            operator=_make_operator(staff_id="op_user"),
+        )
+
+        ctx = process.start_approval.call_args.kwargs["context"]
+        assert ctx["bot_id"] == "b1:entity1"
+        assert ctx["owner_id"] == "u1"
+
     def test_completed_runs_callback_inline_with_public_scope(self):
         process = MagicMock()
         process.start_approval.return_value = {


### PR DESCRIPTION
## Problem

The live antprocess callback (`POST /api/v1/antprocess/callback`) arrived with only three fields:

```
form: {'publicScope': 'user', 'globalUniqueId': 'antprocess-agentclaw_botpublic_20260803-8tcq1p7d-16552820260823165718', 'lastOperate': 'agree'}
```

No `botId`, no `ownerId`. With both `None`, the new-version callback path (`handle_public_approval_callback` → `public_scope:` branch → `_apply_callback_decision(bot_uid=None, …)`) calls `get_attributes(bot_uuid=None)` → no-op, so the AGREE visibility flip never fires and even DISAGREE/CANCEL can't locate the pending-approval `friend_ext` block to record status.

Root cause: `public_bcs_bot` builds the approval `context` via `_build_public_approval_context` (`publishHint`/`botSkills`/`botMcps`) then adds an overriding `publishHint`, `public_scope`, and `viewFriendDeps` — but **never places `bot_id`/`owner_id` into the `context` passed to `start_approval`**. The antprocess platform echoes the ticket `context` back on the `/callback` POST, so with nothing put in, nothing echoed back. (The earlier assumption that "the antprocess async echo carries `bot_id`" was wrong — antprocess echoes only what the ticket `context` actually contained.)

Two compounding facts established the diagnosis:

1. The entire callback chain already existed and worked — `antprocess/router.py` `/callback` → `core/approval/callback_handler.py` → `handle_public_approval_callback` → `_apply_callback_decision` (AGREE flips `user_visibility`/`visibility` per scope; DISAGREE/CANCEL writes status only). The **only** gap was the missing context keys.
2. The one surviving echo sample proved antprocess *does* echo and camelCase short scalar context values (`public_scope`="user" → `publicScope`); long/multiline (`publishHint`/`botSkills`/`botMcps`) and empty (`viewFriendDeps`) were dropped — so a short scalar `bot_id`/`owner_id` is expected to survive and return as `botId`/`ownerId`, which is exactly what the router reads.

## Solution

In `public_bcs_bot`, after the `viewFriendDeps` assignment and before `start_approval`, add the two identity keys to the ticket `context`:

```python
# bot_id (the full BCS identity "{backend_bot_id}:{entity_id}", used
# verbatim as bot_uuid by the callback's _apply_callback_decision) and
# owner_id ride the context so antprocess echoes them back (snake→camel:
# bot_id→botId, owner_id→ownerId) on the /callback POST — without
# bot_id the callback can't resolve the bot and the AGREE visibility
# flip is a no-op.
context["bot_id"] = bot_uid
context["owner_id"] = owner_id
```

- **`bot_id` is the full `bot_uid`** (BCS identity `"{backend_bot_id}:{entity_id}"`), **not** `backend_bot_id = bot_uid.split(":")[0]`. The new-version callback path uses `bot_id` verbatim as `bot_uuid` in `_apply_callback_decision`'s `get_attributes(bot_uuid=…)`; passing only the `:[0]` half would fail BCS lookup.
- **snake_case keys**: antprocess camelCases on echo (proven `public_scope`→`publicScope`), so they return as `botId`/`ownerId`, matching the router's `data.get("botId")`/`data.get("ownerId")`.
- **`owner_id`** is not strictly required by the BCS path (it uses only `bot_uid`) but is included for the legacy branch and audit symmetry.

**Rejected alternative — parse `bot_uid` back out of the echoed `globalUniqueId` (puid):** the puid is `antprocess-agentclaw_botpublic_{biz_id}` and `biz_id = re.sub(r'[^a-zA-Z0-9-]', '-', bot_uid) + timestamp`. #1380's sanitize collapsed the `:`/`_` in `bot_uid` into `-`, so the puid's `-`-delimited segments can't be split back into `{backend_bot_id}:{entity_id}` + timestamp — delimiter collision makes the puid un-parseable for a round-trip. The ticket `context` echo is the clean channel for the identity; the puid is a verification token, not a lookup key.

**Rejected alternative — snake_case fallback on the read side** (`data.get("botId") or data.get("bot_id")`): `public_scope`→`publicScope` already proves the camelCase transform, so `data.get("botId")` is correct as-is; the read-side tolerance was scoped out as unnecessary.

Avernet community source only — the inbound callback router + service live in `agentclaw.community`. ocb carries no inbound code here (corp only ships the outbound `ProdAntProcessService`), so no ocb change.

## Validation

- `tests/community/core/bot_public/test_bot_public_service.py` + `tests/community/endpoints/test_openapi_public_bcs.py` + `tests/community/core/approval/` — **134 passed** on `fix/collaboration-bots-callback-context` (off latest `origin/dev_refactory_collaboration` `0025869de`, which includes the merged #1380).
- New pin `TestPublicBcsBot::test_context_carries_bot_id_and_owner_id_for_callback_echo` asserts `start_approval`'s `context` carries the **full** `bot_uid` as `bot_id` (`"b1:entity1"`, not `backend_bot_id`) and `owner_id`; red→green (KeyError before the fix).
- Existing `test_context_mirrors_normal_bot_plus_public_scope_and_view_friend_deps` stays green — the two added context lines don't disturb the publishHint/scene/botuid-split assertions.

**Not run:** full openapi_v1 conformance (1268). The change is internal to the antprocess ticket `context` dict — it adds no route and touches no published schema (`BcsPublicRequest`/`BcsPublishResult` unchanged) — so the conformance pin count is unaffected. Live `pre`/`prod` redeploy + a real antprocess callback: after this lands a new ticket must echo `botId`/`ownerId`; confirm the `[回调] 收到表单数据` log includes them and that AGREE flips BCS `user_visibility` (user scope) / `visibility` (agent scope).

## Compatibility and risk

- **No contract/schema change.** `BcsPublicRequest`/`BcsPublishResult` byte-identical; published OpenAPI unaffected. The `context` dict is internal to the antprocess ticket, never surfaced to the publish caller.
- **puid shape unchanged** — #1380's `biz_id` sanitize is untouched.
- **New runtime behavior:** newly created tickets now carry `bot_id`/`owner_id` in their `context`; in-flight tickets created before this fix keep their context and their callback still lacks `botId`/`ownerId` (the pre-fix broken state — not a regression, just unresolved until those age out).
- **Live-unknown — will antprocess surface `bot_id`/`owner_id`?** The short-scalar echo model predicts yes, but if the `agentclaw_botpublic` process template whitelists only `public_scope` out-of-band, the keys won't surface and the template config must also surface them. Caught by the live-echo check above.
- **Rollback:** revert the single commit — the missing-context broken state returns (pre-fix behavior; no data risk).

## Spec

Implements the `/api/v1/antprocess/callback` resolution contract that the existing handler already expected: the ticket `context` must carry the BCS bot identity `bot_id` (= the full `{backend_bot_id}:{entity_id}`) and `owner_id` so the echoed callback can address the bot. Without them the handler's new-version branch dead-ends at `bot_uuid=None`.

## Related issues

Follow-up to #1380 (sanitize `biz_id` + map service error — now merged into `dev_refactory_collaboration`) and #1378 (external publish path). Both wired the publish/start side and the visibility-flip logic; this wires the missing identity hand-off that lets the async callback actually resolve the bot and complete the AGREE flip. `/api/v1/antprocess/callback` route-level auth hardening (the endpoint is currently unauthenticated — no shared-secret/signature) remains a separate concern tracked independently.
