### PR TITLE
fix(backend): recover Bot scope for legacy SkillSet routes

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -91,6 +91,9 @@ from agentclaw.community.adapters.http.skill_center.schemas import (
     UploadSkillResponse,
     VersionListResponse,
 )
+from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
+    recover_legacy_skill_set_scope,
+)
 from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.api.skill_set_control_plane import (
     SkillSetControlPlaneServiceProtocol,
@@ -382,6 +385,35 @@ def _get_path_params(
         runtime_engine,
         effective_entity_type,
         is_desktop,
+    )
+
+
+def _get_skill_set_path_params(
+    ctx: RequestContext,
+    *,
+    set_id: str,
+    entity_id: str | None,
+    entity_type: str | None,
+    bot_id: str | None,
+    engine_type: str | None,
+    bot_repo: BotRepository,
+    control_plane: SkillSetControlPlaneServiceProtocol,
+) -> tuple:
+    """Recover the deprecated SkillSet Bot address before path normalization."""
+    entity_id, bot_id = recover_legacy_skill_set_scope(
+        set_id=set_id,
+        actor_id=ctx.user_id,
+        owner_id_hint=entity_id,
+        bot_id_hint=bot_id,
+        control_plane=control_plane,
+    )
+    return _get_path_params(
+        ctx,
+        entity_id,
+        entity_type,
+        bot_id,
+        engine_type,
+        bot_repo=bot_repo,
     )
 
 
@@ -1112,8 +1144,15 @@ async def switch_skill_set(
         runtime_engine,
         effective_entity_type,
         is_desktop,
-    ) = _get_path_params(
-        ctx, entity_id, entity_type, bot_id, engine_type, bot_repo=bot_repo
+    ) = _get_skill_set_path_params(
+        ctx,
+        set_id=request.skill_set_id,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        bot_id=bot_id,
+        engine_type=engine_type,
+        bot_repo=bot_repo,
+        control_plane=control_plane,
     )
 
     result = await control_plane.switch(
@@ -1160,8 +1199,15 @@ async def sync_skill_set(
         runtime_engine,
         effective_entity_type,
         is_desktop,
-    ) = _get_path_params(
-        ctx, entity_id, entity_type, bot_id, engine_type, bot_repo=bot_repo
+    ) = _get_skill_set_path_params(
+        ctx,
+        set_id=request.skill_set_id,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        bot_id=bot_id,
+        engine_type=engine_type,
+        bot_repo=bot_repo,
+        control_plane=control_plane,
     )
 
     result = await control_plane.sync(
@@ -1218,13 +1264,15 @@ async def activate_skill_set(
         runtime_engine,
         effective_entity_type,
         is_desktop,
-    ) = _get_path_params(
+    ) = _get_skill_set_path_params(
         ctx,
-        request.entity_id,
-        request.entity_type,
-        request.bot_id,
-        request.engine_type,
+        set_id=request.skill_set_id,
+        entity_id=request.entity_id,
+        entity_type=request.entity_type,
+        bot_id=request.bot_id,
+        engine_type=request.engine_type,
         bot_repo=bot_repo,
+        control_plane=control_plane,
     )
 
     item = await control_plane.activate(
@@ -1275,13 +1323,15 @@ async def deactivate_skill_set(
         runtime_engine,
         effective_entity_type,
         is_desktop,
-    ) = _get_path_params(
+    ) = _get_skill_set_path_params(
         ctx,
-        request.entity_id,
-        request.entity_type,
-        request.bot_id,
-        request.engine_type,
+        set_id=request.skill_set_id,
+        entity_id=request.entity_id,
+        entity_type=request.entity_type,
+        bot_id=request.bot_id,
+        engine_type=request.engine_type,
         bot_repo=bot_repo,
+        control_plane=control_plane,
     )
 
     item = await control_plane.deactivate(

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
@@ -39,6 +39,9 @@ from agentclaw.community.adapters.http.skill_center.schemas import (
     AddMCPResponse,
     SetSkillSetActiveResponse,
 )
+from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
+    recover_legacy_skill_set_scope,
+)
 from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 from agentclaw.community.adapters.http.dependencies import (
     get_request_context,
@@ -181,6 +184,35 @@ def _get_path_params(
         )
 
     return effective_entity_id, effective_bot_id, effective_engine, runtime_engine, effective_entity_type, is_desktop
+
+
+def _get_skill_set_path_params(
+    ctx: RequestContext,
+    *,
+    set_id: str,
+    entity_id: Optional[str],
+    entity_type: Optional[str],
+    bot_id: Optional[str],
+    engine_type: Optional[str],
+    bot_repo: BotRepository,
+    control_plane: SkillSetControlPlaneServiceProtocol,
+) -> tuple:
+    """Resolve the deprecated optional Bot address before normal path handling."""
+    entity_id, bot_id = recover_legacy_skill_set_scope(
+        set_id=set_id,
+        actor_id=_legacy_actor(ctx, entity_id),
+        owner_id_hint=entity_id,
+        bot_id_hint=bot_id,
+        control_plane=control_plane,
+    )
+    return _get_path_params(
+        ctx,
+        entity_id,
+        entity_type,
+        bot_id,
+        engine_type,
+        bot_repo=bot_repo,
+    )
 
 
 # ==================== SkillSet Management APIs ====================
@@ -469,8 +501,15 @@ async def get_skill_set(
         runtime_engine,
         effective_entity_type,
         is_desktop,
-    ) = _get_path_params(
-        ctx, entity_id, entity_type, bot_id, engine_type, bot_repo=bot_repo
+    ) = _get_skill_set_path_params(
+        ctx,
+        set_id=skill_set_id,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        bot_id=bot_id,
+        engine_type=engine_type,
+        bot_repo=bot_repo,
+        control_plane=control_plane,
     )
 
     return SkillSetDetailResponse(
@@ -505,23 +544,24 @@ async def update_skill_set(
     ),
 ) -> SkillSetDetailResponse:
     """Update a skill set."""
-    # Priority: query param bot_id > request body bot_id > ctx.bot_id > default
-    effective_bot_id = bot_id or request.bot_id or ctx.bot_id or "default"
-    # Get effective path parameters (pass effective_bot_id directly)
+    # Preserve omission so the legacy resolver can recover a non-default Bot.
+    bot_id_hint = bot_id or request.bot_id
     (
         effective_entity_id,
-        _,
+        effective_bot_id,
         effective_engine,
         runtime_engine,
         effective_entity_type,
         _is_desktop,
-    ) = _get_path_params(
+    ) = _get_skill_set_path_params(
         ctx,
-        entity_id,
-        entity_type,
-        effective_bot_id,
-        engine_type,
+        set_id=skill_set_id,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        bot_id=bot_id_hint,
+        engine_type=engine_type,
         bot_repo=bot_repo,
+        control_plane=control_plane,
     )
 
     # ``is_default`` was accepted by the old schema but is not a mutable
@@ -563,9 +603,6 @@ async def delete_skill_set(
     ),
 ) -> MessageResponse:
     """Delete a skill set."""
-    # Get effective path parameters
-    # entity_id 优先使用 user_id，否则使用传入的 entity_id
-    effective_entity_id_param = user_id or entity_id
     (
         effective_entity_id,
         effective_bot_id,
@@ -573,13 +610,15 @@ async def delete_skill_set(
         runtime_engine,
         effective_entity_type,
         is_desktop,
-    ) = _get_path_params(
+    ) = _get_skill_set_path_params(
         ctx,
-        effective_entity_id_param,
-        entity_type,
-        bot_id,
-        engine_type,
+        set_id=skill_set_id,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        bot_id=bot_id,
+        engine_type=engine_type,
         bot_repo=bot_repo,
+        control_plane=control_plane,
     )
 
     control_plane.delete_set(
@@ -621,8 +660,15 @@ async def get_skill_set_skills(
         runtime_engine,
         effective_entity_type,
         is_desktop,
-    ) = _get_path_params(
-        ctx, entity_id, entity_type, bot_id, engine_type, bot_repo=bot_repo
+    ) = _get_skill_set_path_params(
+        ctx,
+        set_id=skill_set_id,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        bot_id=bot_id,
+        engine_type=engine_type,
+        bot_repo=bot_repo,
+        control_plane=control_plane,
     )
 
     skills = control_plane.list_skills(
@@ -673,25 +719,24 @@ async def add_skills_to_set(
     ),
 ) -> AddSkillsResponse:
     """Add skills to a skill set."""
-    # Get effective path parameters
-    # Priority: request body bot_id > query param bot_id > ctx.bot_id > default
-    effective_bot_id = request.bot_id or bot_id or ctx.bot_id or "default"
-    # entity_id 优先使用 request.user_id，否则使用传入的 entity_id
-    effective_entity_id_param = request.user_id or entity_id
+    # Preserve omission so the legacy resolver can recover a non-default Bot.
+    bot_id_hint = request.bot_id or bot_id
     (
         effective_entity_id,
-        _,
+        effective_bot_id,
         effective_engine,
         runtime_engine,
         effective_entity_type,
         _is_desktop,
-    ) = _get_path_params(
+    ) = _get_skill_set_path_params(
         ctx,
-        effective_entity_id_param,
-        entity_type,
-        effective_bot_id,
-        engine_type,
+        set_id=skill_set_id,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        bot_id=bot_id_hint,
+        engine_type=engine_type,
         bot_repo=bot_repo,
+        control_plane=control_plane,
     )
 
     # Historical batch wire permits partial success.  Each member remains
@@ -778,9 +823,6 @@ async def remove_skill_from_set(
     ),
 ) -> MessageResponse:
     """Remove a skill from a skill set."""
-    # Get effective path parameters
-    # entity_id 优先使用 user_id，否则使用传入的 entity_id
-    effective_entity_id_param = user_id or entity_id
     (
         effective_entity_id,
         effective_bot_id,
@@ -788,13 +830,15 @@ async def remove_skill_from_set(
         runtime_engine,
         effective_entity_type,
         is_desktop,
-    ) = _get_path_params(
+    ) = _get_skill_set_path_params(
         ctx,
-        effective_entity_id_param,
-        entity_type,
-        bot_id,
-        engine_type,
+        set_id=skill_set_id,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        bot_id=bot_id,
+        engine_type=engine_type,
         bot_repo=bot_repo,
+        control_plane=control_plane,
     )
 
     result = await control_plane.remove_skill(
@@ -1722,8 +1766,15 @@ async def get_skill_set_mcps(
         runtime_engine,
         effective_entity_type,
         is_desktop,
-    ) = _get_path_params(
-        ctx, entity_id, entity_type, bot_id, engine_type, bot_repo=bot_repo
+    ) = _get_skill_set_path_params(
+        ctx,
+        set_id=skill_set_id,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        bot_id=bot_id,
+        engine_type=engine_type,
+        bot_repo=bot_repo,
+        control_plane=control_plane,
     )
 
     legacy_set = control_plane.get_set(
@@ -1800,8 +1851,15 @@ async def add_mcp_to_skill_set(
         runtime_engine,
         effective_entity_type,
         is_desktop,
-    ) = _get_path_params(
-        ctx, entity_id, entity_type, bot_id, engine_type, bot_repo=bot_repo
+    ) = _get_skill_set_path_params(
+        ctx,
+        set_id=skill_set_id,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        bot_id=bot_id,
+        engine_type=engine_type,
+        bot_repo=bot_repo,
+        control_plane=control_plane,
     )
 
     await control_plane.add_mcp(
@@ -1854,8 +1912,15 @@ async def remove_mcp_from_skill_set(
         runtime_engine,
         effective_entity_type,
         is_desktop,
-    ) = _get_path_params(
-        ctx, entity_id, entity_type, bot_id, engine_type, bot_repo=bot_repo
+    ) = _get_skill_set_path_params(
+        ctx,
+        set_id=skill_set_id,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        bot_id=bot_id,
+        engine_type=engine_type,
+        bot_repo=bot_repo,
+        control_plane=control_plane,
     )
 
     await control_plane.remove_mcp(

--- a/src/backend/src/agentclaw/community/api/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/api/skill_set_control_plane.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import Any, Protocol, runtime_checkable
 
+from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
+    LegacySkillSetScope,
+)
+
 
 @runtime_checkable
 class SkillSetControlPlaneServiceProtocol(Protocol):
@@ -26,6 +30,14 @@ class SkillSetControlPlaneServiceProtocol(Protocol):
     def get_set(
         self, *, bot_id: str, owner_id: str, user_id: str, set_id: str
     ) -> dict[str, Any]: ...
+
+    def resolve_legacy_set_scope(
+        self,
+        *,
+        set_id: str,
+        actor_id: str,
+        owner_id_hint: str | None,
+    ) -> LegacySkillSetScope | None: ...
 
     def resolve_legacy_skill_id(
         self, *, bot_id: str, owner_id: str, actor_id: str, identifier: str

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/legacy_skill_set_scope.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/legacy_skill_set_scope.py
@@ -1,0 +1,38 @@
+"""Tenant-scoped address lookup for deprecated SkillSet wires."""
+
+from __future__ import annotations
+
+from agentclaw.community.core.models.skill import SkillSet
+from agentclaw.community.core.skill_center.errors import (
+    SkillSetControlPlaneNotFoundError,
+)
+from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
+    LegacySkillSetScope,
+)
+
+
+class LegacySkillSetScopeQueries:
+    """Repository mixin that exposes no SkillSet content before authorization."""
+
+    def resolve_legacy_set_scope(
+        self, *, set_id: str
+    ) -> LegacySkillSetScope | None:
+        with self._db.orm_session() as session:
+            row = (
+                self._scope(session.query(SkillSet), SkillSet)
+                .filter(SkillSet.id == int(set_id))
+                .one_or_none()
+            )
+            if row is None:
+                raise SkillSetControlPlaneNotFoundError()
+            if row.is_default:
+                return None
+            if not row.user_id or not row.bolt_id:
+                raise SkillSetControlPlaneNotFoundError()
+            return LegacySkillSetScope(
+                owner_id=str(row.user_id),
+                bot_id=str(row.bolt_id),
+            )
+
+
+__all__ = ["LegacySkillSetScopeQueries"]

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_set_control_plane.py
@@ -38,6 +38,7 @@ from agentclaw.community.core.repository.implementations.skill_center.installati
 from agentclaw.community.core.repository.implementations.skill_center.mcp_skill_set_control_plane import (
     McpSkillSetControlPlaneCommands,
 )
+from agentclaw.community.core.repository.implementations.skill_center.legacy_skill_set_scope import LegacySkillSetScopeQueries
 from agentclaw.community.core.repository.skill_set_control_plane_types import (
     SkillSetDesiredState,
     SkillSetMutation,
@@ -45,7 +46,6 @@ from agentclaw.community.core.repository.skill_set_control_plane_types import (
 from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
-
 
 from agentclaw.community.core.skill_center.errors import (
     SkillRuntimeNameConflictError,
@@ -55,7 +55,8 @@ from agentclaw.community.core.skill_center.errors import (
 
 
 class SkillSetControlPlaneRepository(
-    McpSkillSetControlPlaneCommands, SkillSetControlPlaneRepositoryProtocol
+    LegacySkillSetScopeQueries, McpSkillSetControlPlaneCommands,
+    SkillSetControlPlaneRepositoryProtocol,
 ):
     """Desired-state UoW for SkillSet Membership and Installations."""
 

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_set_control_plane.py
@@ -6,6 +6,9 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
+    from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
+        LegacySkillSetScope,
+    )
     from agentclaw.community.core.repository.skill_set_control_plane_types import (
         SkillSetDesiredState,
         SkillSetMutation,
@@ -24,6 +27,12 @@ class SkillSetControlPlaneRepositoryProtocol(Protocol):
         engine_type: str | None = None,
         default_engine_types: tuple[str, ...] | None = None,
     ) -> list[dict]: ...
+    @abstractmethod
+    def resolve_legacy_set_scope(
+        self, *, set_id: str
+    ) -> LegacySkillSetScope | None:
+        """Resolve an ordinary Set address; return ``None`` for System Default."""
+        ...
     @abstractmethod
     def ensure_active_skillset_installations(
         self,

--- a/src/backend/src/agentclaw/community/core/skill_center/legacy_skill_set_compatibility.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/legacy_skill_set_compatibility.py
@@ -2,7 +2,49 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True, slots=True)
+class LegacySkillSetScope:
+    """A persisted ordinary SkillSet's strict Bot address."""
+
+    owner_id: str
+    bot_id: str
+
+
+class LegacySkillSetScopeResolverProtocol(Protocol):
+    """Recover the strict Bot address for an omitted legacy Bot parameter."""
+
+    def resolve_legacy_set_scope(
+        self,
+        *,
+        set_id: str,
+        actor_id: str,
+        owner_id_hint: str | None,
+    ) -> LegacySkillSetScope | None: ...
+
+
+def recover_legacy_skill_set_scope(
+    *,
+    set_id: str,
+    actor_id: str,
+    owner_id_hint: str | None,
+    bot_id_hint: str | None,
+    control_plane: LegacySkillSetScopeResolverProtocol,
+) -> tuple[str | None, str | None]:
+    """Recover only an omitted Bot address; explicit addresses stay strict."""
+    if bot_id_hint is not None:
+        return owner_id_hint, bot_id_hint
+    scope = control_plane.resolve_legacy_set_scope(
+        set_id=set_id,
+        actor_id=actor_id,
+        owner_id_hint=owner_id_hint,
+    )
+    if scope is None:
+        return owner_id_hint, None
+    return scope.owner_id, scope.bot_id
 
 
 class LegacySkillSetCompatibilityProtocol(Protocol):

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -31,6 +31,7 @@ from agentclaw.community.plugin_api.mcp_center import MCPCenterPlugin
 from agentclaw.community.core.bot_management.readiness import is_bot_ready
 from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
     LegacySkillSetCompatibilityFactoryProtocol,
+    LegacySkillSetScope,
 )
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectionReconcilerProtocol,
@@ -162,6 +163,29 @@ class SkillSetControlPlaneService:
             bot_id=bot_id, owner_id=str(bot["owner_id"]), set_id=set_id,
             engine_type=self._engine(bot),
             default_engine_types=self._default_engine_types(bot),
+        )
+
+    def resolve_legacy_set_scope(
+        self,
+        *,
+        set_id: str,
+        actor_id: str,
+        owner_id_hint: str | None,
+    ) -> LegacySkillSetScope | None:
+        """Recover a deprecated wire's omitted Bot without weakening strict reads."""
+        scope = self._repository.resolve_legacy_set_scope(set_id=set_id)
+        if scope is None:
+            return None
+        if owner_id_hint is not None and owner_id_hint != scope.owner_id:
+            raise SkillSetControlPlaneNotFoundError()
+        bot = self._bot(
+            bot_id=scope.bot_id,
+            owner_id=scope.owner_id,
+            user_id=actor_id,
+        )
+        return LegacySkillSetScope(
+            owner_id=str(bot["owner_id"]),
+            bot_id=scope.bot_id,
         )
 
     def update_set(

--- a/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
+++ b/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
@@ -10,15 +10,18 @@ from fastapi import HTTPException
 from agentclaw.community.adapters.http.skill_center.schemas import (
     ActivateRequest,
     AddSkillsRequest,
+    DeactivateSkillSetRequest,
     SearchRequest,
 )
 from agentclaw.community.adapters.http.skill_center.skillsets import (
     add_skills_to_set,
     get_default_skill_set,
+    get_skill_set_mcps,
 )
 from agentclaw.community.adapters.http.skill_center.skills import (
     activate_skill,
     deactivate_skill,
+    deactivate_skill_set,
     get_market_tree,
     list_local_market_skills,
     list_market_skills,
@@ -96,6 +99,143 @@ class _Catalog:
             "status": "completed",
             "result": {"synced": True, "database": {"failed": 0}},
         }
+
+
+class _AddressedBots:
+    def get_by_id_and_owner(self, bot_id: str, owner_id: str):
+        assert (bot_id, owner_id) == ("persisted-bot", "owner")
+        return {
+            "active_engine": "claude_code",
+            "bot_type": "personal",
+            "template_type": "normalCC",
+        }
+
+
+class _LegacySetScopeControlPlane:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def resolve_legacy_set_scope(self, **kwargs):
+        self.calls.append(("resolve", kwargs))
+        return SimpleNamespace(owner_id="owner", bot_id="persisted-bot")
+
+    def get_set(self, **kwargs):
+        self.calls.append(("get_set", kwargs))
+        assert kwargs["bot_id"] == "persisted-bot"
+        assert kwargs["owner_id"] == "owner"
+        return {"id": "set-1", "is_default": False}
+
+    def list_mcps(self, **kwargs):
+        self.calls.append(("list_mcps", kwargs))
+        assert kwargs["bot_id"] == "persisted-bot"
+        assert kwargs["owner_id"] == "owner"
+        return [
+            {
+                "id": "mcp-1",
+                "server_code": "mcp.example",
+                "name": "Example MCP",
+                "description": None,
+                "icon": None,
+            }
+        ]
+
+    async def deactivate(self, **kwargs):
+        self.calls.append(("deactivate", kwargs))
+        assert kwargs["bot_id"] == "persisted-bot"
+        assert kwargs["owner_id"] == "owner"
+        return {"id": "set-1", "changed": True}
+
+
+@pytest.mark.asyncio
+async def test_legacy_mcp_read_recovers_non_default_bot_from_exact_set_id() -> None:
+    control_plane = _LegacySetScopeControlPlane()
+
+    response = await get_skill_set_mcps(
+        "set-1",
+        user_id="owner",
+        entity_id=None,
+        entity_type=None,
+        bot_id=None,
+        engine_type=None,
+        ctx=SimpleNamespace(user_id="owner", bot_id="default"),
+        bot_repo=_AddressedBots(),
+        skill_set_service_factory=object(),
+        control_plane=control_plane,
+    )
+
+    assert response.model_dump() == {
+        "success": True,
+        "data": [
+            {
+                "id": "mcp-1",
+                "server_code": "mcp.example",
+                "name": "Example MCP",
+                "description": None,
+                "icon": None,
+                "status": "ONLINE",
+            }
+        ],
+        "count": 1,
+    }
+    assert control_plane.calls[0] == (
+        "resolve",
+        {
+            "set_id": "set-1",
+            "actor_id": "owner",
+            "owner_id_hint": None,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_mcp_read_never_redirects_an_explicit_bot_address() -> None:
+    class _ExplicitControlPlane(_LegacySetScopeControlPlane):
+        def resolve_legacy_set_scope(self, **_kwargs):
+            raise AssertionError("explicit bot_id must not enter legacy fallback")
+
+    control_plane = _ExplicitControlPlane()
+
+    await get_skill_set_mcps(
+        "set-1",
+        user_id="owner",
+        entity_id="owner",
+        entity_type=None,
+        bot_id="persisted-bot",
+        engine_type=None,
+        ctx=SimpleNamespace(user_id="owner", bot_id="default"),
+        bot_repo=_AddressedBots(),
+        skill_set_service_factory=object(),
+        control_plane=control_plane,
+    )
+
+    assert control_plane.calls[0][0] == "get_set"
+
+
+@pytest.mark.asyncio
+async def test_legacy_deactivate_recovers_non_default_bot_from_exact_set_id() -> None:
+    control_plane = _LegacySetScopeControlPlane()
+
+    response = await deactivate_skill_set(
+        DeactivateSkillSetRequest(skill_set_id="set-1"),
+        ctx=SimpleNamespace(user_id="owner", bot_id="default"),
+        bot_repo=_AddressedBots(),
+        activator_factory=object(),
+        control_plane=control_plane,
+    )
+
+    assert response.model_dump() == {
+        "success": True,
+        "message": "Skill set deactivated",
+        "data": {"deactivated": ["set-1"], "failed": []},
+    }
+    assert control_plane.calls[0] == (
+        "resolve",
+        {
+            "set_id": "set-1",
+            "actor_id": "owner",
+            "owner_id_hint": None,
+        },
+    )
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -17,7 +17,6 @@ from agentclaw.community.core.repository.implementations.skill_center.skill_set_
 )
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillNotReadyError,
-    SkillSetAccessDeniedError,
     SkillSetControlPlaneNotFoundError,
     SkillSetRuntimeReconcileError,
     McpPermissionDeniedError,
@@ -27,6 +26,9 @@ from agentclaw.community.core.skill_center.services.skill_set_control_plane impo
 )
 from agentclaw.community.core.skill_center.services.bot_runtime_projection_reconciler import (
     BotRuntimeProjectionReconciler,
+)
+from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
+    LegacySkillSetScope,
 )
 from agentclaw.community.core.skills_pool.models import (
     PoolSkillMapping,
@@ -79,6 +81,17 @@ class _CreateRepository(_Repository):
             "is_default": False,
             "is_active": False,
         }
+
+
+class _LegacyScopeRepository(_Repository):
+    def __init__(self, scope: LegacySkillSetScope | None) -> None:
+        super().__init__()
+        self.scope = scope
+        self.scope_calls: list[str] = []
+
+    def resolve_legacy_set_scope(self, *, set_id: str):
+        self.scope_calls.append(set_id)
+        return self.scope
 
 
 class _InactiveMembershipRepository(_Repository):
@@ -816,6 +829,64 @@ def test_default_create_uses_owner_qualified_bot_lookup():
         ("default", owner_id),
     ]
     assert repository.create_calls[0]["owner_id"] == owner_id
+
+
+def test_legacy_set_scope_recovers_persisted_bot_then_applies_actor_acl() -> None:
+    repository = _LegacyScopeRepository(
+        LegacySkillSetScope(owner_id="true-owner", bot_id="bot-1")
+    )
+    authorization = _Authorization()
+    service = SkillSetControlPlaneService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=object(),
+        passport=object(),
+        authorization=authorization,
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=_McpAuth(allowed=True),
+    )
+
+    scope = service.resolve_legacy_set_scope(
+        set_id="set-1",
+        actor_id="collaborator",
+        owner_id_hint=None,
+    )
+
+    assert scope == LegacySkillSetScope(owner_id="true-owner", bot_id="bot-1")
+    assert repository.scope_calls == ["set-1"]
+    assert authorization.calls == [
+        {
+            "bot_id": "bot-1",
+            "owner_id": "true-owner",
+            "actor_id": "collaborator",
+        }
+    ]
+
+
+def test_legacy_set_scope_rejects_conflicting_owner_hint() -> None:
+    repository = _LegacyScopeRepository(
+        LegacySkillSetScope(owner_id="true-owner", bot_id="bot-1")
+    )
+    service = SkillSetControlPlaneService(
+        repository=repository,
+        bot_repo=_Bots(),
+        runtime=_SuccessfulRuntime(),
+        legacy_factory=object(),
+        passport=object(),
+        authorization=_Authorization(),
+        audit_log_repo=_Audit(),
+        mcp_center=_McpCenter(allowed=True),
+        mcp_auth=_McpAuth(allowed=True),
+    )
+
+    with pytest.raises(SkillSetControlPlaneNotFoundError):
+        service.resolve_legacy_set_scope(
+            set_id="set-1",
+            actor_id="collaborator",
+            owner_id_hint="wrong-owner",
+        )
 
 
 def test_addressed_create_persists_metadata_without_runtime_reconcile() -> None:

--- a/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
@@ -32,6 +32,9 @@ from agentclaw.community.core.skill_center.errors import (
     SkillSetControlPlaneConflictError,
     SkillSetControlPlaneNotFoundError,
 )
+from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
+    LegacySkillSetScope,
+)
 
 
 class _Database:
@@ -65,6 +68,39 @@ class _InstallationRecorder:
     def install(self, **kwargs) -> bool:
         self.calls.append(kwargs)
         return True
+
+
+def test_legacy_scope_resolution_returns_only_ordinary_set_address() -> None:
+    db = _Database()
+    with db.transactional_orm_session() as session:
+        ordinary = SkillSet(
+            name="ordinary",
+            user_id="owner",
+            bolt_id="persisted-bot",
+            engine_type="claude_code",
+            env="dev",
+        )
+        default = SkillSet(
+            name="default",
+            user_id="",
+            bolt_id="",
+            engine_type="openclaw",
+            is_default=True,
+            env="dev",
+        )
+        session.add_all([ordinary, default])
+        session.flush()
+        ordinary_id = str(ordinary.id)
+        default_id = str(default.id)
+
+    repository = SkillSetControlPlaneRepository(db)
+
+    assert repository.resolve_legacy_set_scope(
+        set_id=ordinary_id
+    ) == LegacySkillSetScope(owner_id="owner", bot_id="persisted-bot")
+    assert repository.resolve_legacy_set_scope(set_id=default_id) is None
+    with pytest.raises(SkillSetControlPlaneNotFoundError):
+        repository.resolve_legacy_set_scope(set_id="999999")
 
 
 def test_list_sets_is_scoped_to_exact_owner_for_shared_default_bot_id():


### PR DESCRIPTION
## Problem

Legacy BFF SkillSet endpoints keep `bot_id` optional for backward compatibility. After the Phase 1 refactor, a missing `bot_id` was normalized to `default` before the exact SkillSet lookup. A SkillSet belonging to a non-default Bot therefore returned `404 Skill set not found` even when the caller supplied the correct `set_id` and had access.

This was observed on pre-production trace `0be8ed2017874785083472657ee6bf` for Set `1115285`. The old `dev` implementation happened to succeed by globally querying `set_id`, but restoring that unrestricted lookup would violate the Phase 1 Bot-scoped identity contract.

## Solution

- Preserve an explicitly supplied `bot_id` and keep strict `owner_id + bot_id` lookup semantics.
- When and only when a legacy exact-Set endpoint omits `bot_id`, resolve the ordinary Set address by `tenant`, `env`, and exact `set_id`.
- Validate the owner hint, Bot existence, and caller authorization in the control plane before returning the recovered scope.
- Re-enter the existing strict Bot-scoped repository path for the actual read or mutation.
- Apply the compatibility seam consistently to legacy Set, Skill, MCP, switch, sync, activate, and deactivate endpoints.
- Keep System Default sets and canonical OpenAPI Bot-scoped routes unchanged.

## Validation

- `1101 passed`: relevant Skill Center HTTP, API, core, repository, and Gateway Rule 15 suites.
- `49 passed`: final focused control-plane service suite after cleanup.
- `196 passed`: complete Backend architecture suite.
- Ruff passed for all changed Python files.
- Backend local SAST block scan passed.
- `git diff --check` passed.
- `src/backend/scripts/dump_openapi.py` completed successfully.
- `src/gateway/scripts/gate_and_publish_openapi.py` was run without `--allow-breaking`. It remains blocked by an existing target-branch artifact drift: `POST /openapi/v1/bots/{bot_id}/public-bcs` is present in the published Gateway artifact but absent from the Backend-generated candidate. This PR does not modify that route or its schema.

## Compatibility and risk

No public parameter, response schema, database schema, or canonical route changes are introduced. Existing callers that provide `bot_id` remain strictly scoped and are never redirected. Missing `bot_id` recovery is limited to an exact ordinary `set_id` and still enforces Bot authorization; System Default sets retain the previous behavior because no Bot can be inferred safely.

Rollback is the single commit in this PR.
