### PR TITLE
fix(bcs): support provider bot visibility attributes

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
@@ -45,6 +45,8 @@ pub struct ProviderStreamGrayResponse {
 #[serde(deny_unknown_fields)]
 pub struct PatchProviderBotAttributesRequest {
     #[serde(default, deserialize_with = "deserialize_present_non_null")]
+    pub visibility: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_present_non_null")]
     pub user_visibility: Option<UserVisibility>,
     #[serde(default, deserialize_with = "deserialize_present_non_null")]
     pub friend_ext: Option<Map<String, Value>>,
@@ -54,7 +56,8 @@ pub struct PatchProviderBotAttributesRequest {
 
 impl PatchProviderBotAttributesRequest {
     fn is_empty(&self) -> bool {
-        self.user_visibility.is_none()
+        self.visibility.is_none()
+            && self.user_visibility.is_none()
             && self.friend_ext.is_none()
             && self.friend_check_in_strategy.is_none()
     }
@@ -62,6 +65,7 @@ impl PatchProviderBotAttributesRequest {
     fn into_command(self, bot_id: String) -> PatchBotInternalAttributes {
         PatchBotInternalAttributes {
             bot_id,
+            visibility: self.visibility,
             user_visibility: self.user_visibility,
             friend_ext: self.friend_ext,
             friend_check_in_strategy: self.friend_check_in_strategy,
@@ -357,6 +361,7 @@ pub async fn patch_provider_bot_attributes(
     info!(
         provider_id,
         bot_uuid,
+        has_visibility = body.visibility.is_some(),
         has_user_visibility = body.user_visibility.is_some(),
         has_friend_ext = body.friend_ext.is_some(),
         friend_ext_key_count = body.friend_ext.as_ref().map(|value| value.len()),

--- a/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
@@ -52,6 +52,7 @@ struct RecordingInternalBotAttributesService {
 impl InternalBotAttributesService for RecordingInternalBotAttributesService {
     async fn get(&self, _bot_id: String) -> Result<BotInternalAttributes, ApplicationError> {
         Ok(BotInternalAttributes {
+            visibility: "protected".to_string(),
             user_visibility: UserVisibility::Protected,
             friend_ext: serde_json::Map::new(),
             friend_check_in_strategy: FriendCheckInStrategy::Approval,
@@ -63,6 +64,10 @@ impl InternalBotAttributesService for RecordingInternalBotAttributesService {
         command: PatchBotInternalAttributes,
     ) -> Result<BotInternalAttributes, ApplicationError> {
         let attributes = BotInternalAttributes {
+            visibility: command
+                .visibility
+                .clone()
+                .unwrap_or_else(|| "protected".to_string()),
             user_visibility: command.user_visibility.unwrap_or(UserVisibility::Protected),
             friend_ext: command.friend_ext.clone().unwrap_or_default(),
             friend_check_in_strategy: command
@@ -1930,6 +1935,7 @@ async fn provider_bot_attributes_require_an_allowlisted_provider_admin_and_bound
         .unwrap();
     assert_eq!(get.status(), StatusCode::OK);
     let get_body = response_json(get).await;
+    assert_eq!(get_body["visibility"], "protected");
     assert_eq!(get_body["user_visibility"], "protected");
     assert_eq!(get_body["friend_ext"], json!({}));
     assert_eq!(get_body["friend_check_in_strategy"], "APPROVAL");
@@ -1946,6 +1952,7 @@ async fn provider_bot_attributes_require_an_allowlisted_provider_admin_and_bound
                 .header("authorization", format!("Bearer {admin_token}"))
                 .body(Body::from(
                     json!({
+                        "visibility": "private",
                         "user_visibility": "public",
                         "friend_ext": {"department_code": "TECH"},
                         "friend_check_in_strategy": "DEPT_FREE"
@@ -1958,6 +1965,7 @@ async fn provider_bot_attributes_require_an_allowlisted_provider_admin_and_bound
         .unwrap();
     assert_eq!(patch.status(), StatusCode::OK);
     let patch_body = response_json(patch).await;
+    assert_eq!(patch_body["visibility"], "private");
     assert_eq!(patch_body["user_visibility"], "public");
     assert_eq!(patch_body["friend_ext"]["department_code"], "TECH");
     assert_eq!(patch_body["friend_check_in_strategy"], "DEPT_FREE");
@@ -1989,6 +1997,7 @@ async fn provider_bot_attributes_require_an_allowlisted_provider_admin_and_bound
     let patches = internal_bot_attributes.patches.lock().await;
     assert_eq!(patches.len(), 1);
     assert_eq!(patches[0].bot_id, "teamclaw-bot:alice");
+    assert_eq!(patches[0].visibility.as_deref(), Some("private"));
     assert_eq!(patches[0].user_visibility, Some(UserVisibility::Public));
     assert_eq!(
         patches[0].friend_check_in_strategy,

--- a/src/bcs/crates/application/v1/bcs-app-bot/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-bot/src/lib.rs
@@ -58,6 +58,18 @@ impl InternalBotAttributesServiceImpl {
         Ok(())
     }
 
+    fn validate_visibility(visibility: Option<&str>) -> Result<(), ApplicationError> {
+        if let Some(visibility) = visibility
+            && !matches!(visibility, "public" | "protected" | "private")
+        {
+            return Err(ApplicationError::invalid(
+                "invalid_request",
+                "visibility must be public, protected, or private",
+            ));
+        }
+        Ok(())
+    }
+
     async fn load_record(&self, bot_id: &str) -> Result<BotControlPlaneRecord, ApplicationError> {
         self.control_plane
             .get_record(bot_id, &self.config.env)
@@ -87,6 +99,7 @@ impl InternalBotAttributesService for InternalBotAttributesServiceImpl {
         command: PatchBotInternalAttributes,
     ) -> Result<bcs_service_api::BotInternalAttributes, ApplicationError> {
         Self::validate_bot_id(&command.bot_id)?;
+        Self::validate_visibility(command.visibility.as_deref())?;
         if command.is_empty() {
             return Err(ApplicationError::invalid(
                 "invalid_request",
@@ -99,6 +112,7 @@ impl InternalBotAttributesService for InternalBotAttributesServiceImpl {
                 &command.bot_id,
                 &self.config.env,
                 BotControlPlanePatch {
+                    visibility: command.visibility,
                     user_visibility: command.user_visibility,
                     friend_ext: command.friend_ext,
                     friend_check_in_strategy: command.friend_check_in_strategy,

--- a/src/bcs/crates/application/v1/bcs-app-bot/tests/internal_bot_attributes.rs
+++ b/src/bcs/crates/application/v1/bcs-app-bot/tests/internal_bot_attributes.rs
@@ -10,10 +10,22 @@ use bcs_app_bot::{BotServiceConfig, InternalBotAttributesServiceImpl};
 use bcs_bot::BotControlPlaneCore;
 use bcs_bot_store::MemoryBotRepo;
 use bcs_service_api::{
-    BotCapabilities, BotControlPlaneCoreService, BotRepoPort, FriendCheckInStrategy,
-    InternalBotAttributesService, PatchBotInternalAttributes, ServiceError, ServiceResult,
-    UserVisibility,
+    BotCapabilities, BotControlPlaneCoreService, BotInternalAttributes, BotRepoPort,
+    FriendCheckInStrategy, InternalBotAttributesService, PatchBotInternalAttributes, ServiceError,
+    ServiceResult, UserVisibility,
 };
+
+#[test]
+fn internal_attributes_deserialize_legacy_data_with_default_visibility() {
+    let attributes: BotInternalAttributes = serde_json::from_value(serde_json::json!({
+        "user_visibility": "protected",
+        "friend_ext": {},
+        "friend_check_in_strategy": "APPROVAL"
+    }))
+    .expect("legacy attributes deserialize");
+
+    assert_eq!(attributes.visibility, "protected");
+}
 
 #[tokio::test]
 async fn internal_attributes_default_and_partial_patch_round_trip_through_control_plane() {

--- a/src/bcs/crates/application/v1/bcs-app-bot/tests/internal_bot_attributes.rs
+++ b/src/bcs/crates/application/v1/bcs-app-bot/tests/internal_bot_attributes.rs
@@ -49,6 +49,7 @@ async fn internal_attributes_default_and_partial_patch_round_trip_through_contro
     assert_eq!(
         serde_json::to_value(&attributes).expect("serialize attributes"),
         serde_json::json!({
+            "visibility": "protected",
             "user_visibility": "protected",
             "friend_ext": {},
             "friend_check_in_strategy": "APPROVAL"
@@ -58,6 +59,7 @@ async fn internal_attributes_default_and_partial_patch_round_trip_through_contro
     let attributes = service
         .patch(PatchBotInternalAttributes {
             bot_id: "bot-1".to_string(),
+            visibility: Some("private".to_string()),
             user_visibility: Some(UserVisibility::Public),
             friend_ext: Some(serde_json::Map::from_iter([(
                 "department".to_string(),
@@ -67,6 +69,7 @@ async fn internal_attributes_default_and_partial_patch_round_trip_through_contro
         })
         .await
         .expect("set internal attributes");
+    assert_eq!(attributes.visibility, "private");
     assert_eq!(attributes.user_visibility, UserVisibility::Public);
     assert_eq!(
         attributes.friend_check_in_strategy,
@@ -83,6 +86,7 @@ async fn internal_attributes_default_and_partial_patch_round_trip_through_contro
         .await
         .expect("clear friend extension");
     assert_eq!(attributes.friend_ext, serde_json::Map::new());
+    assert_eq!(attributes.visibility, "private");
     assert_eq!(attributes.user_visibility, UserVisibility::Public);
     assert_eq!(
         attributes.friend_check_in_strategy,
@@ -120,6 +124,18 @@ async fn internal_attributes_map_invalid_empty_and_missing_requests_to_applicati
             })
             .await
             .expect_err("empty patch is invalid")
+            .code(),
+        "invalid_request"
+    );
+    assert_eq!(
+        service
+            .patch(PatchBotInternalAttributes {
+                bot_id: "bot-1".to_string(),
+                visibility: Some("friends".to_string()),
+                ..Default::default()
+            })
+            .await
+            .expect_err("invalid visibility is rejected")
             .code(),
         "invalid_request"
     );

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/internal_bot_attributes.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/internal_bot_attributes.rs
@@ -34,17 +34,6 @@ pub struct BotInternalAttributes {
     pub friend_check_in_strategy: FriendCheckInStrategy,
 }
 
-impl Default for BotInternalAttributes {
-    fn default() -> Self {
-        Self {
-            visibility: default_visibility(),
-            user_visibility: UserVisibility::default(),
-            friend_ext: Map::new(),
-            friend_check_in_strategy: FriendCheckInStrategy::default(),
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct PatchBotInternalAttributes {
     pub bot_id: String,

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/internal_bot_attributes.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/internal_bot_attributes.rs
@@ -24,17 +24,31 @@ pub enum FriendCheckInStrategy {
     DeptFree,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BotInternalAttributes {
+    #[serde(default = "default_visibility")]
+    pub visibility: String,
     pub user_visibility: UserVisibility,
     #[serde(default)]
     pub friend_ext: Map<String, Value>,
     pub friend_check_in_strategy: FriendCheckInStrategy,
 }
 
+impl Default for BotInternalAttributes {
+    fn default() -> Self {
+        Self {
+            visibility: default_visibility(),
+            user_visibility: UserVisibility::default(),
+            friend_ext: Map::new(),
+            friend_check_in_strategy: FriendCheckInStrategy::default(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct PatchBotInternalAttributes {
     pub bot_id: String,
+    pub visibility: Option<String>,
     pub user_visibility: Option<UserVisibility>,
     pub friend_ext: Option<Map<String, Value>>,
     pub friend_check_in_strategy: Option<FriendCheckInStrategy>,
@@ -42,10 +56,15 @@ pub struct PatchBotInternalAttributes {
 
 impl PatchBotInternalAttributes {
     pub fn is_empty(&self) -> bool {
-        self.user_visibility.is_none()
+        self.visibility.is_none()
+            && self.user_visibility.is_none()
             && self.friend_ext.is_none()
             && self.friend_check_in_strategy.is_none()
     }
+}
+
+fn default_visibility() -> String {
+    "protected".to_string()
 }
 
 #[async_trait]

--- a/src/bcs/crates/service-api/bcs-service-api/src/types/bot_control_plane.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/types/bot_control_plane.rs
@@ -110,6 +110,7 @@ pub struct BotControlPlanePatch {
 impl BotControlPlaneRecord {
     pub fn internal_attributes(&self) -> BotInternalAttributes {
         BotInternalAttributes {
+            visibility: self.visibility.clone(),
             user_visibility: self.user_visibility,
             friend_ext: self.friend_ext.clone(),
             friend_check_in_strategy: self.friend_check_in_strategy,

--- a/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_control_plane_repo.rs
+++ b/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_control_plane_repo.rs
@@ -649,6 +649,7 @@ async fn persistent_control_plane_internal_attributes_round_trip_and_clear_frien
             "attributes",
             "dev",
             BotControlPlanePatch {
+                visibility: Some("private".to_string()),
                 user_visibility: Some(UserVisibility::Private),
                 friend_ext: Some(serde_json::Map::from_iter([(
                     "scope".to_string(),
@@ -661,6 +662,7 @@ async fn persistent_control_plane_internal_attributes_round_trip_and_clear_frien
         .await
         .expect("patch internal attributes")
         .expect("patched row exists");
+    assert_eq!(updated.visibility, "private");
     assert_eq!(updated.user_visibility, UserVisibility::Private);
     assert_eq!(updated.friend_ext["scope"], "engineering");
     assert_eq!(
@@ -669,7 +671,7 @@ async fn persistent_control_plane_internal_attributes_round_trip_and_clear_frien
     );
     let rows = db
         .query(DbStatement::with_params(
-            "SELECT user_visibility, friend_ext, friend_check_in_strategy, \
+            "SELECT visibility, user_visibility, friend_ext, friend_check_in_strategy, \
                     json_extract(bot_info, '$.user_visibility') AS bot_info_user_visibility, \
                     json_extract(bot_info, '$.friend_ext') AS bot_info_friend_ext, \
                     json_extract(bot_info, '$.friend_check_in_strategy') AS bot_info_friend_check_in_strategy \
@@ -679,6 +681,10 @@ async fn persistent_control_plane_internal_attributes_round_trip_and_clear_frien
         .await
         .expect("read physical attributes");
     let row = rows.first().expect("physical attributes row");
+    assert_eq!(
+        db_get_column::<String>(row, "visibility").expect("visibility"),
+        "private"
+    );
     assert_eq!(
         db_get_column::<String>(row, "user_visibility").expect("user visibility"),
         "private"


### PR DESCRIPTION
## Problem

The provider-admin Bot attributes endpoint rejected Backend agent-scope updates because it did not accept the existing Bot `visibility` property. The Backend sends `{"visibility":"private"}` for `public_scope=agent`, which caused a 400 response.

## Solution

- Expose `visibility` alongside `user_visibility`, `friend_ext`, and `friend_check_in_strategy` in the provider-admin GET/PATCH contract.
- Validate `public`, `protected`, and `private`, then reuse the existing `bcs_bots.visibility` persistence path.
- Preserve strict unknown-field rejection, existing provider-admin-token authorization, and the independent semantics of `user_visibility`.

## Compatibility and risk

No DDL, schema, authentication, or public-route change. `visibility` remains separate from `user_visibility`; the patch reuses the pre-existing control-plane/store behavior.

## Validation

- `cargo test -p bcs-http --test provider_routes_contract` — 41 passed
- `cargo test -p bcs-app-bot` — 21 passed
- `cargo test -p bcs-bot-store --test conformance_bot_control_plane_repo` — 14 passed
- `git diff --check` — passed
