### PR TITLE
fix(backend): correct task callback-report convergence/auth and inline BBS relay snapshot

### DIFF
--- a/src/backend/specs/2026-08-09-task-goal-driven-bbs-active-relay/bbs-relay-single-task/SKILL.md
+++ b/src/backend/specs/2026-08-09-task-goal-driven-bbs-active-relay/bbs-relay-single-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bbs-relay-single-task
-description: BBS 接力单任务版:收到引擎主动通知后,直接从 dashboard 读剩余事项→attach→执行→result。
+description: BBS 接力单任务版:收到引擎主动通知(含内联任务态快照)后,据快照归纳剩余事项→attach→执行→result(dashboard 仅兜底)。
 version: 1.0.0
 author: avernet-task-framework
 tags: [task, bbs, relay]
@@ -10,17 +10,17 @@ tags: [task, bbs, relay]
 
 ## 触发
 
-收到引擎主动发的任务消息(含 task_id + backend base url + 自身 bot_id)。
+收到引擎主动发的任务消息(含 task_id + backend base url + 自身 bot_id + **内联任务态快照** JSON)。
 引擎已替你占根(bbs_owner已设为你的bot_id)——**不需要 scan、不需要 claim、不需要自判**。
 
 ## 执行步骤
 
-### 步骤① 读 dashboard 了解剩余事项
+### 步骤① 据消息内联快照归纳剩余事项(dashboard 仅兜底)
 
-- `GET {backend}/api/v1/collaboration/tasks/dashboard?task_id={task_id}`
-- 读根 `goal.objective` + `goal.acceptances[]` + 已 DONE 叶子的 `run_info.output`(已完成的部分)
-- 自己归纳"剩余事项"(未完成的 acceptances 对应的工作)
-- 自己组织 `task_spec`(`metadata{title, instruction}`, `context{background}`, `goal{objective, acceptances[]}`)
+- 引擎发的任务消息已**内联任务态快照**(JSON):`goal`(objective+acceptances)、`instruction`、`background`、`done_children`(已 DONE 子节点+`output`)、`gaps`、`loop_round`、`task_id`/`node_id`。
+- **直接据快照归纳"剩余事项"**:`剩余 = goal.acceptances 全集 − {done_children 的 output 并集}`,再按 `gaps` 细化;**正常路径不读 dashboard**。
+- 仅当快照缺字段 / 字段不全时,才 `GET {backend}/api/v1/collaboration/tasks/dashboard?task_id={task_id}` 兜底补全。
+- 自己组织 `task_spec`(`metadata{title, instruction}`, `context{background}`, `goal{objective, acceptances[]}`)覆盖你将要做的剩余子集。
 
 ### 步骤② attach(挂 scoped 节点)
 
@@ -40,11 +40,6 @@ tags: [task, bbs, relay]
   "acceptance_result": {"verdict": "PASS", "acceptances_metric": [...]},
   "output_patch": {"{deliverable_key}": {产出}}}`
 - 200 → 接力完成(框架经 on_bbs_report 收口)
-
-## 与 bbs-relay-pickup 的区别
-
-- bbs-relay-pickup:步① 扫全量任务筛选 bbs_mode → 步②claim → 步③自判 → 步④attach → ...
-- bbs-relay-single-task:**跳过 ①②③**(引擎已发现+占根+选了你),直接 **attach→执行→result**
 
 ## 环境约束
 

--- a/src/backend/src/agentclaw/community/adapters/http/task/auth.py
+++ b/src/backend/src/agentclaw/community/adapters/http/task/auth.py
@@ -10,7 +10,7 @@ import hmac
 import time
 from typing import Mapping, Protocol, runtime_checkable
 
-from agentclaw.community.core.errors import ValidationError
+from agentclaw.community.core.errors import CallbackAuthError
 
 _TOKEN_HEADER = "X-TaskLoop-Token"
 _TIMESTAMP_HEADER = "X-TaskLoop-Timestamp"
@@ -36,22 +36,22 @@ class HmacCallbackAuthenticator:
     def verify(self, *, source, headers, raw_body, method, path) -> None:
         secret = self._secrets.get(source)
         if secret is None:
-            raise ValidationError(f"unknown callback source: {source}")
+            raise CallbackAuthError(f"unknown callback source: {source}")
         ts = headers.get(_TIMESTAMP_HEADER)
         sig = headers.get(_SIGNATURE_HEADER)
         if not ts or not sig:
-            raise ValidationError("missing timestamp/signature header")
+            raise CallbackAuthError("missing timestamp/signature header")
         try:
             ts_int = int(ts)
         except ValueError:
-            raise ValidationError("invalid timestamp")
+            raise CallbackAuthError("invalid timestamp")
         if abs(int(time.time()) - ts_int) > self._max_skew_s:
-            raise ValidationError("stale timestamp")
+            raise CallbackAuthError("stale timestamp")
         body_hex = hashlib.sha256(raw_body).hexdigest()
         sign_str = f"{ts}{method}{path}{body_hex}"
         expected = hmac.new(secret.encode(), sign_str.encode(), hashlib.sha256).hexdigest()
         if not hmac.compare_digest(expected, sig):
-            raise ValidationError("signature mismatch")
+            raise CallbackAuthError("signature mismatch")
 
 
 class NoopCallbackAuthenticator:

--- a/src/backend/src/agentclaw/community/adapters/http/task/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/task/router.py
@@ -522,33 +522,37 @@ async def _dispatch(
                 _graph_detail = _graph_resp.json() if _graph_resp.status_code == 200 else None
                 if _run_detail:
                     _tc.data.data["_raw_callback_body"] = _run_detail
-                    logger.info("[callback] BCN run 明细已取回 run_id=%s → orig_callback_data", _run_id)
+                    logger.info("[task_callback_report] BCN run 明细已取回 run_id=%s → orig_callback_data", _run_id)
                 else:
-                    logger.warning("[callback] BCS run 明细非 200 run_id=%s status=%s",
+                    logger.warning("[task_callback_report] BCS run 明细非 200 run_id=%s status=%s",
                                    _run_id, _run_resp.status_code)
                 # 结合 DAG(graph nodes+edges)与执行结果(run nodes)→ 任务状态图谱 → execution_graph
                 _task_graph = _build_task_status_graph(_run_detail, _graph_detail)
                 if _task_graph:
                     _tc.data.data["execution_graph"] = _task_graph
-                    logger.info("[callback] 任务状态图谱已构建 run_id=%s nodes=%d edges=%d → execution_graph",
+                    logger.info("[task_callback_report] 任务状态图谱已构建 run_id=%s nodes=%d edges=%d → execution_graph",
                                 _run_id, len(_task_graph.get("nodes") or []), len(_task_graph.get("edges") or []))
             except Exception as exc:  # noqa: BLE001 查 BCS 明细/DAG 失败不阻断落库(fallback 存原始 CloudEvent)
-                logger.warning("[callback] 查 BCS run 明细/DAG 失败 run_id=%s: %s", _run_id, exc)
+                logger.warning("[task_callback_report] 查 BCS run 明细/DAG 失败 run_id=%s: %s", _run_id, exc)
         await svc.callback.ingest(_tc.data)
-        # 终态收敛:run.status in (completed/failed/aborted) → 按 session_id 查 task_node_run_info
-        # → 框架 (task_id, node_id) → svc.converge_by_session → on_report → 翻态(引擎验收+传播+根 DONE)。
-        if _run_detail:
-            _run_status = ((_run_detail.get("run") or {}).get("status"))
-            if _run_status in ("completed", "failed", "aborted"):
-                _session_id = ((_raw_obj.get("scope") or {}).get("session_id")) if isinstance(_raw_obj, dict) else None
-                if _session_id:
-                    _success = _run_status == "completed"
-                    _run_output = ((_run_detail.get("run") or {}).get("output"))
-                    try:
-                        await svc.converge_by_session(_session_id, success=_success, output=_run_output)
-                        logger.info("[callback] 终态收敛已触发 session_id=%s success=%s", _session_id, _success)
-                    except Exception as exc:  # noqa: BLE001 收敛失败不阻断(回调查询/落库已完成)
-                        logger.warning("[callback] 终态收敛失败 session_id=%s: %s", _session_id, exc)
+        # 终态收敛:优先用 BCS run 明细(run_detail.run.status);fetch 失败/非 200 时,若事件本身是
+        # state_machine.run.completed(BCS 已表明 run 成功完成),用事件体兜底收敛,不让 BCS 瞬时
+        # 抖动丢掉终态翻转(任务节点停在 RUNNING)。按 session_id 查 task_node_run_info → 框架
+        # (task_id, node_id) → svc.converge_by_session → on_report → 翻态(验收+传播+根收敛)。
+        _run_status = ((_run_detail.get("run") or {}).get("status")) if _run_detail else None
+        _converge_output = ((_run_detail.get("run") or {}).get("output")) if _run_detail else None
+        if _run_status is None and _tc.data.data.get("status") == "state_machine.run.completed":
+            _run_status = "completed"
+            _converge_output = _tc.data.data.get("result", {}).get("data")
+        if _run_status in ("completed", "failed", "aborted"):
+            _session_id = ((_raw_obj.get("scope") or {}).get("session_id")) if isinstance(_raw_obj, dict) else None
+            if _session_id:
+                _success = _run_status == "completed"
+                try:
+                    await svc.converge_by_session(_session_id, success=_success, output=_converge_output)
+                    logger.info("[task_callback_report] 终态收敛已触发 session_id=%s success=%s", _session_id, _success)
+                except Exception as exc:  # noqa: BLE001 收敛失败不阻断(回调查询/落库已完成)
+                    logger.warning("[task_callback_report] 终态收敛失败 session_id=%s: %s", _session_id, exc)
         return envelope({"ok": True}, request)
     # 羽雀/框架节点级回投:先按 schema_cls(TaskCallbackRequest 富 schema)校验 → translate → report_result/start_run;
     # 不符合则兜底 TaskCallbackDataDTO(loop_task_id+result,report_callback 旧契约)→ callback_from_dto → report_result。

--- a/src/backend/src/agentclaw/community/adapters/http/task/translator.py
+++ b/src/backend/src/agentclaw/community/adapters/http/task/translator.py
@@ -268,15 +268,27 @@ def parse_manager_worker_bcn(raw) -> dict | None:
     }
 
 
+# 子任务 status 单调秩:防止乱序投递时后到的非终态(assigned)回退已写的终态(completed)。
+_TASK_ENTRY_STATUS_RANK = {"assigned": 1, "completed": 2}
+
+
 def _upsert_task_entry(tasks: list, entry: dict) -> None:
-    """按 ``task_id`` upsert 子任务条目(后到自己覆盖;``None`` 值不覆盖以保留前一个事件已写的信息)。"""
+    """按 ``task_id`` upsert 子任务条目(后到自己覆盖;``None`` 值不覆盖以保留前一个事件已写的信息)。
+
+    ``status`` 单调保护:已 ``completed`` 的子任务不被后到的 ``assigned`` 回退(乱序兜底);
+    有序投递(assigned→completed)秩递增,照常覆盖。其余字段仍"非 None 即覆盖"。"""
     tid = entry.get("task_id")
     idx = next((i for i, t in enumerate(tasks) if t.get("task_id") == tid), None)
     if idx is not None:
         merged = dict(tasks[idx])
         for k, v in entry.items():
-            if v is not None:
-                merged[k] = v
+            if v is None:
+                continue
+            if (k == "status"
+                    and _TASK_ENTRY_STATUS_RANK.get(merged.get("status"), 0)
+                    > _TASK_ENTRY_STATUS_RANK.get(v, 0)):
+                continue  # 已处更高状态,不回退(completed 不被 assigned 覆盖)
+            merged[k] = v
         tasks[idx] = merged
     else:
         tasks.append({k: v for k, v in entry.items() if v is not None})

--- a/src/backend/src/agentclaw/community/core/task/task_center/task_service.py
+++ b/src/backend/src/agentclaw/community/core/task/task_center/task_service.py
@@ -248,6 +248,11 @@ class TaskService:
         result: dict[str, Any] = {"success": success}
         if output is not None:
             result["data"] = output
+        if not success:
+            # 失败收敛须带 gaps:CallbackAdapter.adapt 对"success=False 且无 gaps"会产出
+            # exec_error(→ harness 重投),而非验收 FAIL(→ 终态 FAILED)。补一个 gap 让失败
+            # 正确翻态为 FAILED(失败详情已随 output 落 run_info.output)。
+            result["gaps"] = ["external collaboration ended without success"]
         data = TaskCallbackData(data={
             "loop_task_id": loop_task_id,
             "workflow_source": "bcn",

--- a/src/backend/src/agentclaw/community/core/task/task_runner/integration/bbs_runner.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/integration/bbs_runner.py
@@ -95,7 +95,7 @@ async def notify(execution_graph, *, bot_public, bot, graph, backend_url: str,
         logger.warning("[bbs-runner] claim 失败 task=%s:%s", task_id, exc)
         return
 
-    msg = _task_msg(skill_name, task_id, backend_url, winner_bot_id)
+    msg = _task_msg(skill_name, execution_graph, backend_url, winner_bot_id)
     try:
         await bot.send_message(
             bot_id=winner_bot_id, message=msg, metadata={"biz_task_id": task_id},
@@ -112,12 +112,13 @@ async def notify(execution_graph, *, bot_public, bot, graph, backend_url: str,
 async def _bid_one(bot, rost_entry, execution_graph) -> dict | None:
     """一发一收:发给 bot 评估 prompt,取回复 content JSON {completion_rate}。"""
     task_id = execution_graph.task_id
-    prompt = _bid_prompt(task_id, rost_entry.bot_id)
+    prompt = _bid_prompt(execution_graph, rost_entry.bot_id)
     try:
         run = await bot.send_and_wait_async(
             bot_id=rost_entry.bot_id, message=prompt,
             metadata={"biz_task_id": task_id}, timeout=_BID_TIMEOUT,
         )
+        logger.info("[bbs-runner] bid send_and_wait 成功 bot=%s，%s", rost_entry.bot_id, run)
     except Exception as exc:
         logger.warning("[bbs-runner] bid send_and_wait 失败 bot=%s:%s", rost_entry.bot_id, exc)
         return None
@@ -154,23 +155,89 @@ def _parse_bid(bid_result: Any) -> dict | None:
     return {"bot_id": bot_id, "completion_rate": int(rate)}
 
 
-def _bid_prompt(task_id: str, bot_id: str) -> str:
-    """让 bot 自评能完成多少,输出 JSON。"""
+def _build_task_snapshot(execution_graph) -> dict:
+    """构造任务态快照(bid 自评 + dispatch 共用;参考 task_plan._compose_planning_prompt 的 snapshot,以**根节点**为 target)。
+
+    根 node_id == execution_graph.task_id(升 BBS 的那条单子)。``done_children`` = 根的已 DONE 结构子
+    及其产出(本地复刻 task_plan._done_children 逻辑——用 execution_graph.relations + RelationType.DEPENDENCY,
+    不跨模块 import task_plan 私有助手,保持 task_runner 自洽)。供 bot 据 goal/验收/已产出/gaps 自评可完成
+    剩余事项百分比。字段零 case 知识。根节点缺失(理论不该发生)→ 极简快照,不抛(不阻断 BBS dispatch)。
+    """
+    from agentclaw.community.core.task.domain.models import RelationType, Status
+
+    task_id = getattr(execution_graph, "task_id", "") or ""
+    tasks = list(getattr(execution_graph, "tasks", []) or [])
+    root = next((n for n in tasks if getattr(n, "node_id", None) == task_id), None)
+    loop_round = getattr(execution_graph, "loop_round", 0)
+    if root is None:
+        return {"task_id": task_id, "loop_round": loop_round, "note": "root node missing"}
+    spec = root.task_spec
+    goal = spec.goal
+    ctx = spec.context
+    acc = root.run_info.acceptance_result if root.run_info else None
+    gaps = list(acc.gaps) if acc else []
+    child_ids = [
+        r.dst_id for r in (getattr(execution_graph, "relations", []) or [])
+        if r.src_id == root.node_id and r.type == RelationType.DEPENDENCY
+    ]
+    done_children = [
+        {
+            "node_id": n.node_id,
+            "title": n.task_spec.metadata.title,
+            "output": (n.run_info.output if n.run_info else None),
+        }
+        for n in tasks
+        if n.node_id in child_ids and n.status == Status.DONE
+    ]
+    return {
+        "task_id": task_id,
+        "node_id": root.node_id,
+        "status": str(root.status),
+        "goal": goal.objective,
+        "instruction": spec.metadata.instruction,
+        "background": ctx.background if ctx else None,
+        "acceptances": [
+            {"id": a.id, "description": a.description} for a in goal.acceptances
+        ],
+        "done_children": done_children,
+        "gaps": gaps,
+        "loop_round": loop_round,
+    }
+
+
+def _bid_prompt(execution_graph, bot_id: str) -> str:
+    """让 bot 据内联任务快照自评能完成多少剩余事项,输出 JSON。
+
+    snapshot 内联(参考 task_plan._compose_planning_prompt),免 bot 再读 dashboard;``task_id`` 仅作引用,
+    可选深读 dashboard URL。返回格式 ``{"completion_rate": <0-100整数>}``。
+    """
+    task_id = getattr(execution_graph, "task_id", "") or ""
+    snapshot = _build_task_snapshot(execution_graph)
     return (
-        f"请评估你能完成 task_id={task_id} 的多少剩余事项。\n"
-        f"你自身 bot_id={bot_id}。\n"
-        "请查看 dashboard (/api/v1/collaboration/tasks/dashboard?task_id="
-        f"{task_id}) 了解根 goal 和已完成的叶子输出,\n"
-        "自评你**能完成剩余事项的百分比**,输出 JSON: "
-        '{"completion_rate": <0-100整数>}'
+        "[bbs-bid] 请基于以下任务快照自评:你能完成该任务**剩余事项的百分比**(0-100)。\n"
+        f"你自身 bot_id={bot_id};task_id={task_id}(仅作引用)。\n"
+        "快照含根 goal/验收项/已 DONE 子节点产出/gaps;据 goal 与已完成产出算剩余 gap,"
+        "基于自身能力(不联网)自评能补完的剩余事项占比,输出 JSON: "
+        '{"completion_rate": <0-100整数>}\n'
+        f"任务态快照\n{json.dumps(snapshot, ensure_ascii=False)}\n"
     )
 
 
-def _task_msg(skill_name: str, task_id: str, backend_url: str, bot_id: str) -> str:
-    """给胜出 bot 的任务消息(不含 task_spec——skill 自派生)。"""
+def _task_msg(skill_name: str, execution_graph, backend_url: str, bot_id: str) -> str:
+    """给胜出 bot 的任务消息:内联任务态快照,skill 据快照归纳剩余事项(免读 dashboard)→ attach → 执行 → result。
+
+    task_id/backend_url/bot_id 仍保留供步骤② attach / 步骤④ result 的 API 调用;dashboard 仅作可选兜底深读。
+    """
+    task_id = getattr(execution_graph, "task_id", "") or ""
+    snapshot = _build_task_snapshot(execution_graph)
     return (
         f"请用 {skill_name} 接力执行已升 BBS 的单子。\n"
-        f"task_id={task_id};task API backend base url={backend_url};"
-        f"你自身 bot_id={bot_id}。\n"
-        "引擎已替你占根(bbs_owner已设),直接从 dashboard 读剩余事项 → attach → 执行 → result。"
+        f"你自身 bot_id={bot_id};task_id={task_id};task API backend base url={backend_url}。\n"
+        "引擎已替你占根(bbs_owner已设为你的 bot_id)——不需 scan/claim/自判。\n"
+        "**任务态快照已内联**(下方 JSON):含根 goal(objective+acceptances)、instruction、background、"
+        "done_children(已 DONE 子节点+产出)、gaps、loop_round。**直接据快照归纳剩余事项**"
+        "(剩余 = goal.acceptances 全集 − done_children 产出并集,再按 gaps 细化),无需先读 dashboard;\n"
+        "随后步骤② attach(用 task_id/backend_url/bot_id)→ 步骤③ 执行 → 步骤④ result。"
+        "仅当快照缺字段时才 GET dashboard 兜底。\n"
+        f"任务态快照\n{json.dumps(snapshot, ensure_ascii=False)}"
     )

--- a/src/backend/tests/community/adapters/http/task/test_auth.py
+++ b/src/backend/tests/community/adapters/http/task/test_auth.py
@@ -7,7 +7,7 @@ import pytest
 from agentclaw.community.adapters.http.task.auth import (
     HmacCallbackAuthenticator, NoopCallbackAuthenticator,
 )
-from agentclaw.community.core.errors import ValidationError
+from agentclaw.community.core.errors import CallbackAuthError
 
 _SECRET = "s3cr3t"
 
@@ -36,14 +36,14 @@ def test_hmac_bad_signature_raises():
     auth = HmacCallbackAuthenticator(secrets={"bcn": _SECRET})
     h = _signed()
     h["X-TaskLoop-Signature"] = "deadbeef"
-    with pytest.raises(ValidationError):
+    with pytest.raises(CallbackAuthError):
         auth.verify(source="bcn", headers=h, raw_body=b'{"x":1}',
                     method="POST", path="/p")
 
 
 def test_hmac_unknown_source_raises():
     auth = HmacCallbackAuthenticator(secrets={"bcn": _SECRET})
-    with pytest.raises(ValidationError):
+    with pytest.raises(CallbackAuthError):
         auth.verify(source="claw_mind", headers={"X-TaskLoop-Timestamp": str(int(time.time()))},
                     raw_body=b"x", method="POST", path="/p")
 
@@ -52,7 +52,7 @@ def test_hmac_stale_timestamp_raises():
     auth = HmacCallbackAuthenticator(secrets={"bcn": _SECRET}, max_skew_s=300)
     old_ts = str(int(time.time()) - 1000)
     h = _signed(ts=old_ts)
-    with pytest.raises(ValidationError):
+    with pytest.raises(CallbackAuthError):
         auth.verify(source="bcn", headers=h, raw_body=b'{"x":1}',
                     method="POST", path="/p")
 
@@ -60,7 +60,7 @@ def test_hmac_stale_timestamp_raises():
 def test_hmac_body_tamper_raises():
     auth = HmacCallbackAuthenticator(secrets={"bcn": _SECRET})
     h = _signed(body=b'{"x":1}')
-    with pytest.raises(ValidationError):
+    with pytest.raises(CallbackAuthError):
         auth.verify(source="bcn", headers=h, raw_body=b'{"x":2}',
                     method="POST", path="/p")
 

--- a/src/backend/tests/community/adapters/http/task/test_translator_manager_worker.py
+++ b/src/backend/tests/community/adapters/http/task/test_translator_manager_worker.py
@@ -100,7 +100,8 @@ def test_merge_session_completed_sets_reason_and_summary():
 
 
 def test_merge_reorder_tolerant_completed_first_then_assigned():
-    """乱序:task.completed 先到(异常),随后 task.assigned 追到——upsert 不崩,最终该 task 仍存在。"""
+    """乱序:task.completed 先到(异常),随后 task.assigned 追到——upsert 不崩,最终该 task 仍存在。
+    status 单调保护:已 completed 不被后到的 assigned 回退(乱序容忍的落地);assigned 的元数据照常补齐。"""
     p_completed = parse_manager_worker_bcn(_ce("task.completed", scope={"session_id": "s1", "task_id": "t1"},
                                                   data={"task_id": "t1", "result": {"ok": 1}}))
     st = merge_manager_worker_execution_graph(None, p_completed)
@@ -108,6 +109,8 @@ def test_merge_reorder_tolerant_completed_first_then_assigned():
     p_assigned = parse_manager_worker_bcn(_ce("task.assigned", scope={"session_id": "s1", "task_id": "t1"},
                                                   data={"task_id": "t1", "worker_id": "w"}))
     st = merge_manager_worker_execution_graph(st, p_assigned)
-    # 后到的 assigned 覆盖 status 回 assigned(乱序本不应发生;只验不崩 + upsert 单条)
+    # 单条 upsert;status 不回退(仍 completed);后到 assigned 的 worker_id 照常补齐
     assert len(st["tasks"]) == 1
-    assert st["tasks"][0]["status"] == "assigned"
+    assert st["tasks"][0]["status"] == "completed"
+    assert st["tasks"][0]["worker_id"] == "w"
+    assert st["tasks"][0]["result"] == {"ok": 1}

--- a/src/backend/tests/community/core/task/task_runner/integration/test_bbs_runner.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_bbs_runner.py
@@ -1,7 +1,12 @@
 # tests/community/core/task/task_runner/integration/test_bbs_runner.py
 import asyncio
 import json
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import MagicMock
+
+from agentclaw.community.core.task.domain.models import (
+    AcceptanceCriteria, Context, Goal, Metadata, RuntimeInfo, Status,
+    TaskExecutionGraph, TaskNode, TaskSpec,
+)
 from agentclaw.community.core.task.task_runner.integration.bbs_runner import notify
 
 
@@ -9,11 +14,23 @@ def _run(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
 
 
-def _execution_graph(task_id="t1"):
-    g = MagicMock()
-    g.task_id = task_id
-    g.tasks = []
-    return g
+def _execution_graph(task_id="t1", objective="整理基础架构方向架构师名册"):
+    """真实最小 TaskExecutionGraph:一个根 TaskNode(BBS 升态)。
+
+    bid prompt 现内联 task snapshot,需真实图(MagicMock 会让 json.dumps 失败);根 node_id == task_id。
+    """
+    root = TaskNode(
+        node_id=task_id, task_id=task_id, status=Status.HUNG,
+        task_spec=TaskSpec(
+            metadata=Metadata(task_id=task_id, title="架构师名册", instruction="整理3位架构师"),
+            context=Context(background="基础架构方向"),
+            goal=Goal(objective=objective,
+                      acceptances=[AcceptanceCriteria("ac_arch", "给出3位架构师姓名/角色+职责")]),
+        ),
+        run_info=RuntimeInfo(),
+        node_run_graph=None,  # type: ignore[arg-type]
+    )
+    return TaskExecutionGraph(run_id=1, loop_round=2, status=Status.HUNG, tasks=[root], task_id=task_id)
 
 
 class _FakeBot:
@@ -21,8 +38,10 @@ class _FakeBot:
         """rates: {bot_id: completion_rate or None (None=simulate error)}"""
         self._rates = rates
         self.sent_messages: list[tuple] = []
+        self.bid_prompts: list[str] = []
 
     async def send_and_wait_async(self, *, bot_id, message, metadata=None, timeout=180.0, poll_interval=2.0):
+        self.bid_prompts.append(message)
         rate = self._rates.get(bot_id)
         if rate is None:
             raise RuntimeError("bot error")
@@ -61,6 +80,9 @@ class _FakeGraph:
             self.cleared = True
 
 
+_GOAL = "整理基础架构方向架构师名册"
+
+
 def test_notify_selects_highest_completion_rate_and_claims_and_sends():
     """bid→select→claim→send: picks highest completion_rate, claims root, sends task message."""
     roster = [
@@ -71,7 +93,7 @@ def test_notify_selects_highest_completion_rate_and_claims_and_sends():
     bot = _FakeBot(rates={"A": 50, "B": 90, "C": 70})
     bot_public = _FakeBotPublic(roster)
     graph = _FakeGraph()
-    g = _execution_graph()
+    g = _execution_graph("t1", _GOAL)
 
     _run(notify(g, bot_public=bot_public, bot=bot, graph=graph, backend_url="http://localhost:8888", skill_name="bbs-relay-single-task"))
 
@@ -84,6 +106,11 @@ def test_notify_selects_highest_completion_rate_and_claims_and_sends():
     assert "http://localhost:8888" in msg_text
     assert "B" in msg_text  # winner's own bot_id
     assert not graph.cleared  # send succeeded, claim not rolled back
+    # bid prompt 内联了 task snapshot(goal objective 嵌入),而非只发 task_id
+    assert bot.bid_prompts, "bid 未发出(空 bid_prompts)"
+    assert any(_GOAL in p for p in bot.bid_prompts), "bid prompt 未内联 goal snapshot"
+    # dispatch 消息也内联了 task snapshot(skill 据快照归纳剩余事项,免读 dashboard)
+    assert _GOAL in msg_text, "dispatch msg 未内联 snapshot"
 
 
 # Append to test_bbs_runner.py
@@ -96,6 +123,7 @@ def test_notify_empty_roster_returns_silently():
     _run(notify(_execution_graph("t2"), bot_public=bot_public, bot=bot, graph=graph, backend_url="http://x", skill_name="s"))
     assert graph.claimed is None
     assert bot.sent_messages == []
+    assert bot.bid_prompts == []
 
 
 def test_notify_all_bids_failed_returns_silently():

--- a/src/backend/tests/community/core/task/task_runner/test_task_callback_report.py
+++ b/src/backend/tests/community/core/task/task_runner/test_task_callback_report.py
@@ -1,0 +1,946 @@
+"""``POST /api/v1/collaboration/tasks/callback/report`` 单测 —— 覆盖三种回投形态。
+
+被测对象:``adapters/http/task/router.py::report_callback``(route ``/callback/report``)
+及其核心 ``_dispatch``。``report_callback`` 固定 ``disposition="result"``、``schema_cls=
+TaskCallbackRequest``,把原始 body 交 ``_dispatch`` 按 body 形态分流:
+
+  1. ClawMind(``HttpCallbackPayload`` 四字段 ``workflow_id/flow_id/status/ext_info``)→
+     ``auth.verify(source="claw_mind")`` → ``translate_claw_mind`` → ``svc.callback.ingest``
+     (仅落 ``task_callback`` 审计,不推进编排核);
+  2. BCN manager-worker(CloudEvent,``group.created/session.created/task.assigned/
+     task.completed/session.completed``)→ ``auth.verify(source="bcn")`` →
+     ``svc.apply_manager_worker_event``(merge 进单 session 行;``session.completed`` 收敛);
+  3. BCN state-machine(CloudEvent,``state_machine.*``)→ ``auth.verify(source="bcn")`` →
+     ``translate_bcn`` + 经 BCS ``GET /state-machine-runs/{run_id}`` 取回 run 明细/DAG →
+     ``ingest`` 落库;run 终态(``completed/failed/aborted``)→ ``svc.converge_by_session``
+     收敛(按 ``session_id`` 反查框架节点 → ``on_report`` 翻态);
+  4. 羽雀/框架节点级(``TaskCallbackRequest`` 富 schema)→ ``translate`` → ``report_result``;
+  5. 兜底 ``TaskCallbackDataDTO``(``loop_task_id+result`` 旧契约)→ ``callback_from_dto`` →
+     ``report_result``;非 JSON → ``HTTPException(422)``。
+
+正确性校验两点:(1) 转换后落 ``task_callback`` 的 ``TaskCallbackRecord`` 字段全面/正确;
+(2) 任务/任务图谱状态收敛正确(success→DONE / failed→FAILED)。
+
+输入数据形态对齐语雀:
+- ClawMind《ClawMind回调服务》§八 ``HttpCallbackPayload``;
+- BCN《BCS Group 回调接入说明》§4 manager-worker 与 §3 state-machine。
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agentclaw.community.adapters.http.task import router
+from agentclaw.community.adapters.http.task.auth import NoopCallbackAuthenticator
+from agentclaw.community.adapters.http.task.translator import (
+    merge_manager_worker_execution_graph,
+    parse_manager_worker_bcn,
+)
+from agentclaw.community.core.task.domain.errors import TaskStateError
+from agentclaw.community.core.task.domain.models import (
+    AcceptanceVerdict,
+    Context,
+    Goal,
+    Metadata,
+    RuntimeInfo,
+    Status,
+    TaskExecutionGraph,
+    TaskNode,
+    TaskNodePatch,
+    TaskSpec,
+)
+from agentclaw.community.core.task.repository.types import (
+    TaskCallbackRecord,
+    TaskNodeRunInfoRecord,
+)
+from agentclaw.community.core.task.task_center.task_service import TaskService
+from agentclaw.community.core.task.task_runner.callback_correlation import (
+    InMemoryCallbackCorrelationRegistry,
+)
+
+_CLAW_MIND_BODY = {
+    "workflow_id": "risk-review-pipeline",
+    "flow_id": "flow-abc-123",
+    "status": "node_succeeded",  # 顶层仅粗粒度事件类型,取值不统一
+    "ext_info": {
+        "flow_runs": {
+            "id": "fr1", "flow_id": "flow-abc-123", "status": "succeeded",
+            "origin_session_id": "S-9",
+        },
+        "node_executions": [
+            {"node_id": "N1", "status": "succeeded",
+             "output_json": {"answer": 42}, "error_text": None},
+        ],
+    },
+}
+
+
+def _bcn_event(event_type: str, *, scope: dict | None = None, data: dict | None = None,
+               event_id: str = "evt-1") -> dict:
+    """构造 BCN(BCS Group)CloudEvent 信封骨架(对齐语雀《BCS Group 回调接入说明》)。"""
+    return {
+        "spec_version": "1.0", "event_id": event_id, "event_type": event_type,
+        "schema_version": "1.0", "source": "bcs",
+        "occurred_at": "2026-08-18T10:01:00.000Z",
+        "recorded_at": "2026-08-18T10:01:00.005Z",
+        "scope": scope or {},
+        "stream": {"key": "state-machine-run:run-1", "sequence": 6},
+        "actor": {"type": "bot", "id": "b1"},
+        "data": data or {},
+    }
+
+
+# ===== 测试替身 =====
+
+class _FakeRequest:
+    """轻量 Starlette Request 替身:仅满足 ``_dispatch``/``envelope`` 所需面。
+
+    非 ``starlette.Request`` 子类 → ``envelope_errors._find_request`` 返 ``None``,
+    领域异常原样上抛(单测按 ``pytest.raises`` 断言);成功路径返回 ``Envelope``。
+    """
+
+    def __init__(self, body: bytes, *, method: str = "POST",
+                 path: str = "/api/v1/collaboration/tasks/callback/report",
+                 headers: dict | None = None) -> None:
+        self._body = body
+        self.method = method
+        self.url = SimpleNamespace(path=path)
+        self.headers = headers or {}
+        self.state = SimpleNamespace(trace_id="")
+
+    async def body(self) -> bytes:
+        # Starlette 首次读后缓存;二次读仍得同一份(report_callback 与 _dispatch 各读一次)。
+        return self._body
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, payload: Any) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Any:
+        return self._payload
+
+
+def _install_fake_bcs(
+    monkeypatch: pytest.MonkeyPatch, *,
+    run_detail: Any = None, run_status: int = 200,
+    graph_detail: Any = None, graph_status: int = 200,
+    raise_on_get: bool = False,
+) -> None:
+    """替换 ``router.httpx.AsyncClient`` 为可控假客户端,断真网。"""
+    rd = run_detail if run_detail is not None else {
+        "run": {"status": "completed", "output": {"final": "ok"}}, "nodes": [],
+    }
+    gd = graph_detail if graph_detail is not None else {
+        "definition": {"name": "sm"}, "nodes": [], "edges": [],
+    }
+
+    class _Client:
+        # 真实签名 ``AsyncClient(timeout=10.0)`` —— 接受并忽略构造参数。
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self) -> "_Client":
+            return self
+
+        async def __aexit__(self, *exc) -> bool:
+            return False
+
+        async def get(self, url: str) -> _FakeResp:
+            if raise_on_get:
+                raise RuntimeError("bcs unreachable")
+            if url.endswith("/graph"):
+                return _FakeResp(graph_status, gd)
+            return _FakeResp(run_status, rd)
+
+    monkeypatch.setattr(router.httpx, "AsyncClient", _Client)
+
+
+class _RecordingEngine:
+    """编排核 stub:记录 ``on_report``/``on_start`` 入参 ``TaskNodePatch``(async 签名)。"""
+
+    def __init__(self) -> None:
+        self.reports: list[TaskNodePatch] = []
+        self.starts: list[TaskNodePatch] = []
+
+    async def on_report(self, patch: TaskNodePatch) -> TaskNodePatch:
+        self.reports.append(patch)
+        return patch
+
+    async def on_start(self, patch: TaskNodePatch) -> TaskNodePatch:
+        self.starts.append(patch)
+        return patch
+
+
+class _TaskStateErrorEngine(_RecordingEngine):
+    """``on_report`` 抛 ``TaskStateError``,模拟"回投到已终态节点"的框架拒绝。"""
+
+    def __init__(self, *, terminal: bool = True) -> None:
+        super().__init__()
+        self._terminal = terminal
+
+    async def on_report(self, patch: TaskNodePatch) -> TaskNodePatch:
+        raise TaskStateError("node in terminal state" if self._terminal else "bad transition")
+
+
+class _FakeCallbackRepo:
+    """``TaskCallbackRepositoryProtocol`` 内存实现:记录所有 upsert,支持按 session 反查。"""
+
+    def __init__(self) -> None:
+        self.calls: list[TaskCallbackRecord] = []
+
+    def upsert(self, rec: TaskCallbackRecord) -> TaskCallbackRecord:
+        self.calls.append(rec)
+        return rec
+
+    def get_latest_by_session(self, main_session_id: str) -> TaskCallbackRecord | None:
+        latest = None
+        for rec in self.calls:
+            if rec.main_session_id == main_session_id:
+                latest = rec
+        return latest
+
+    def get(self, run_id: str, node_id: str) -> TaskCallbackRecord | None:
+        for rec in reversed(self.calls):
+            if rec.run_id == run_id and rec.node_id == node_id:
+                return rec
+        return None
+
+
+class _FakeRunInfoRepo:
+    """``TaskNodeRunInfoRepositoryProtocol`` 内存实现:按 ``session_id`` 反查框架节点。"""
+
+    def __init__(self, by_session: dict[str, TaskNodeRunInfoRecord] | None = None) -> None:
+        self._by_session = by_session or {}
+        self.inserts: list[TaskNodeRunInfoRecord] = []
+
+    def get_by_session_id(self, session_id: str) -> TaskNodeRunInfoRecord | None:
+        return self._by_session.get(session_id)
+
+    def insert(self, rec: TaskNodeRunInfoRecord) -> TaskNodeRunInfoRecord:
+        self.inserts.append(rec)
+        return rec
+
+
+class _FakeGraph:
+    """``TaskGraphService`` 替身:``query_task_dashboard`` 返回配置好的节点状态。"""
+
+    def __init__(self, nodes_by_task: dict[str, list[TaskNode]] | None = None) -> None:
+        self._nodes_by_task = nodes_by_task or {}
+
+    def query_task_dashboard(self, task_id: str, node_id: str | None = None) -> TaskExecutionGraph:
+        return TaskExecutionGraph(
+            run_id=1, loop_round=0, status=Status.RUNNING,
+            tasks=list(self._nodes_by_task.get(task_id, [])),
+            relations=[], task_id=task_id,
+        )
+
+
+def _node(task_id: str, node_id: str, status: Status = Status.RUNNING) -> TaskNode:
+    spec = TaskSpec(
+        metadata=Metadata(task_id=task_id, title="t", instruction="i"),
+        context=Context(background=""), goal=Goal(objective="", acceptances=[]),
+    )
+    return TaskNode(
+        node_id=node_id, task_id=task_id, status=status, task_spec=spec,
+        run_info=RuntimeInfo(), node_run_graph=None,  # node_run_graph 仅作引用,测试不读
+    )
+
+
+class _CallbackTestService(TaskService):
+    """真实 ``TaskService`` + 注入式编排核:test seam 是覆写 ``_build_engine``。
+
+    用真实 ``apply_manager_worker_event``/``converge_by_session``/``get_task_dashboard``,
+    配合内存 repo 与 ``_FakeGraph``,可端到端观察"回投 → 转换 → 落库 → adapt → on_report 翻态"。
+    """
+
+    def __init__(self, *, graph: _FakeGraph, engine: _RecordingEngine,
+                 callback_repo: _FakeCallbackRepo, run_info_repo: _FakeRunInfoRepo) -> None:
+        self._test_engine = engine
+        super().__init__(
+            graph, callback_repo=callback_repo, task_node_run_info_repo=run_info_repo,
+        )
+
+    def _build_engine(self, **kw):  # noqa: D401, ANN202
+        return self._test_engine
+
+
+def _make_svc(*, engine: _RecordingEngine | None = None,
+              graph_nodes: dict[str, list[TaskNode]] | None = None,
+              run_info_by_session: dict[str, TaskNodeRunInfoRecord] | None = None,
+              ) -> tuple[_CallbackTestService, _RecordingEngine, _FakeCallbackRepo, _FakeRunInfoRepo]:
+    engine = engine or _RecordingEngine()
+    callback_repo = _FakeCallbackRepo()
+    run_info_repo = _FakeRunInfoRepo(run_info_by_session)
+    graph = _FakeGraph(graph_nodes)
+    svc = _CallbackTestService(
+        graph=graph, engine=engine, callback_repo=callback_repo, run_info_repo=run_info_repo,
+    )
+    return svc, engine, callback_repo, run_info_repo
+
+
+def _run_info(task_id: str, node_id: str, session_id: str) -> TaskNodeRunInfoRecord:
+    return TaskNodeRunInfoRecord(
+        id=0, node_id=node_id, task_id=task_id, run_mode="coop_group", assignee="g1",
+        output=None, acceptance_result=None, retry=0, session_id=session_id,
+        extend_props=None, start_time=1, update_time=1, end_time=None,
+    )
+
+
+def _req(body: dict | str | bytes) -> _FakeRequest:
+    if isinstance(body, (dict, list)):
+        raw = json.dumps(body).encode("utf-8")
+    elif isinstance(body, str):
+        raw = body.encode("utf-8")
+    else:
+        raw = body
+    return _FakeRequest(raw)
+
+
+def _dispatch_call(req: _FakeRequest, svc, auth, registry):
+    """直接调用被 ``@envelope_errors`` 包裹的端点函数(成功 → ``Envelope``,异常 → 上抛)。"""
+    return router.report_callback(request=req, svc=svc, auth=auth, registry=registry)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _ok_envelope(result):
+    """断言成功路径返回 ``Envelope{code=OK,data={"ok":True}}``。"""
+    from agentclaw.community.adapters.http.openapi_v1.responses import CODE_OK
+    assert result.code == CODE_OK, f"expected OK envelope, got {result!r}"
+    assert result.data == {"ok": True}, f"expected ok envelope data, got {result!r}"
+    return result
+
+
+# ===== ClawMind =====
+
+class TestClawMind:
+    """ClawMind ``HttpCallbackPayload`` → ``ingest`` 仅落审计,不推进编排核、不收敛。"""
+
+    def test_claw_mind_persists_full_fields_and_advances_nothing(self):
+        svc, engine, repo, _ri = _make_svc()
+        result = _run(_dispatch_call(_req(_CLAW_MIND_BODY), svc, NoopCallbackAuthenticator(),
+                                     InMemoryCallbackCorrelationRegistry()))
+        _ok_envelope(result)
+
+        # 仅落 ``task_callback``,不推进编排核(/callback/report 固定 result,且 ClawMind 走 ingest)
+        assert engine.reports == [] and engine.starts == []
+        assert len(repo.calls) == 1
+        rec = repo.calls[0]
+        # 转换后落库字段(对齐 task_callback 列 + 语雀 §八)
+        assert rec.invoker == "claw_mind"
+        assert rec.run_id == "risk-review-pipeline"  # loop_task_id = workflow_id
+        assert rec.node_id == ""                      # workflow 级回投,node_id 空
+        assert rec.main_session_id == "S-9"           # origin_session_id → main_session_id
+        assert rec.status == "succeeded"              # 底层 flow_runs.status(非顶层 node_succeeded)
+        assert rec.result_success is True
+        assert rec.result == {"success": True, "data": {"answer": 42}}
+        assert rec.exec_error is None
+        assert rec.execution_graph == _CLAW_MIND_BODY["ext_info"]  # 全量 ext_info 快照
+        assert rec.extend_props is None               # claw_mind 无额外扩展
+        assert json.loads(rec.orig_callback_data) == _CLAW_MIND_BODY  # 原始 body
+
+    def test_claw_mind_failed_node_maps_exec_error_and_success_false(self):
+        body = {
+            "workflow_id": "w", "flow_id": "f", "status": "node_failed",
+            "ext_info": {
+                "flow_runs": {"origin_session_id": "S-1"},
+                "node_executions": [{"node_id": "N1", "status": "failed",
+                                      "output_json": None, "error_text": "boom"}],
+            },
+        }
+        svc, engine, repo, _ri = _make_svc()
+        _run(_dispatch_call(_req(body), svc, NoopCallbackAuthenticator(),
+                            InMemoryCallbackCorrelationRegistry()))
+        rec = repo.calls[0]
+        assert rec.status == "failed"
+        assert rec.main_session_id == "S-1"
+        assert rec.result_success is False
+        assert rec.exec_error == "boom"
+        assert engine.reports == []  # 仍不推进编排核(ClawMind 仅审计)
+
+    def test_claw_mind_does_not_converge_even_on_workflow_success(self):
+        # 文档语义:ClawMind 回投只落审计,框架节点状态不由此路径翻态。
+        svc, engine, _repo, _ri = _make_svc(
+            run_info_by_session={"S-9": _run_info("task-99", "root", "S-9")},
+        )
+        _run(_dispatch_call(_req(_CLAW_MIND_BODY), svc, NoopCallbackAuthenticator(),
+                            InMemoryCallbackCorrelationRegistry()))
+        assert engine.reports == []  # 即便 session_id 能反查到节点,ClawMind 也不收敛
+
+
+# ===== BCN manager-worker(任务协作群)=====
+
+class TestBCNManagerWorker:
+    """BCN manager-worker 事件 → ``apply_manager_worker_event``(merge 进单 session 行 + 收敛)。"""
+
+    @staticmethod
+    def _mw_event(event_type: str, *, session_id="s-1", group_id="g1", task_id="task-1",
+                  data=None) -> dict:
+        scope = {"group_id": group_id, "session_id": session_id}
+        if task_id and event_type.startswith("task."):
+            scope["task_id"] = task_id
+        return _bcn_event(event_type, scope=scope, data=data or {})
+
+    def test_task_assigned_persists_merged_graph_single_session_row(self):
+        data = {"task_id": "task-1", "manager_id": "bot-m", "worker_id": "bot-w",
+                "session_id": "s-1", "assignment": {"included": False, "size_bytes": 42}}
+        ev = self._mw_event("task.assigned", data=data)
+        svc, engine, repo, _ri = _make_svc()
+        _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
+                            InMemoryCallbackCorrelationRegistry()))
+        assert engine.reports == [] and engine.starts == []  # 非 session.completed 不收敛
+        assert len(repo.calls) == 1
+        rec = repo.calls[0]
+        # 单 session 行:(run_id=session_id, node_id="")
+        assert rec.invoker == "bcn_manager_worker"
+        assert rec.run_id == "s-1" and rec.node_id == ""
+        assert rec.main_session_id == "s-1"
+        assert rec.status == "task.assigned"
+        assert rec.result is None and rec.result_success is None and rec.exec_error is None
+        assert rec.extend_props == {"event_id": "evt-1"}
+        assert json.loads(rec.orig_callback_data) == ev
+        eg = rec.execution_graph
+        assert eg["session_id"] == "s-1" and eg["group_id"] == "g1"
+        assert eg["last_event_type"] == "task.assigned"
+        assert eg["tasks"] == [{"task_id": "task-1", "manager_id": "bot-m",
+                                "worker_id": "bot-w", "status": "assigned",
+                                "assignment": {"included": False, "size_bytes": 42},
+                                "session_id": "s-1"}]
+
+    def test_session_completed_converges_to_done_when_reason_completed(self):
+        data = {"completed_by": "bcs-system", "reason": "completed", "summary": "all done"}
+        ev = self._mw_event("session.completed", data=data)
+        svc, engine, _repo, _ri = _make_svc(
+            run_info_by_session={"s-1": _run_info("task-99", "root", "s-1")},
+        )
+        _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
+                            InMemoryCallbackCorrelationRegistry()))
+        # 收敛:session_id 反查框架节点 → on_report → acceptance PASS(→ DONE)
+        assert len(engine.reports) == 1
+        patch = engine.reports[0]
+        assert (patch.task_id, patch.node_id) == ("task-99", "root")
+        assert patch.acceptance_result is not None
+        assert patch.acceptance_result.verdict == AcceptanceVerdict.PASS
+        assert patch.output_patch == {"data": "all done"}
+        assert engine.starts == []
+
+    def test_session_completed_converges_to_failed_when_reason_failed(self):
+        data = {"completed_by": "bcs-system", "reason": "failed", "summary": "boom"}
+        ev = self._mw_event("session.completed", data=data)
+        svc, engine, _repo, _ri = _make_svc(
+            run_info_by_session={"s-1": _run_info("task-99", "root", "s-1")},
+        )
+        _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
+                            InMemoryCallbackCorrelationRegistry()))
+        # failed session → acceptance FAIL → 节点 FAILED(converge_by_session 给失败分支补 gaps)。
+        assert len(engine.reports) == 1
+        patch = engine.reports[0]
+        assert patch.acceptance_result is not None
+        assert patch.acceptance_result.verdict == AcceptanceVerdict.FAIL
+
+    def test_manager_worker_events_accumulate_in_single_session_row(self):
+        sid = "s-1"
+        events = [
+            self._mw_event("group.created", data={"status": "active", "name": "G",
+                                                  "group_kind": "normal"}),
+            self._mw_event("session.created", data={"status": "active", "session_kind": "task"}),
+            self._mw_event("task.assigned", task_id="t-a",
+                           data={"task_id": "t-a", "manager_id": "m", "worker_id": "w",
+                                 "session_id": sid, "assignment": {"size_bytes": 1}}),
+            self._mw_event("task.completed", task_id="t-a",
+                           data={"task_id": "t-a", "manager_id": "m", "worker_id": "w",
+                                 "session_id": sid, "result": {"size_bytes": 9},
+                                 "completed_at": "T"}),
+        ]
+        svc, engine, repo, _ri = _make_svc()
+        for ev in events:
+            _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
+                                InMemoryCallbackCorrelationRegistry()))
+        # 4 次回投同 session → 均 upsert(repo.calls 记全量,真实库按 (run_id,node_id) 仅 1 行)
+        assert len(repo.calls) == 4
+        assert all(r.run_id == sid and r.node_id == "" for r in repo.calls)
+        eg = repo.calls[-1].execution_graph  # 最后一条即累积后图谱
+        assert eg["group_status"] == "active"
+        assert eg["session_status"] == "active"
+        assert eg["last_event_type"] == "task.completed"
+        assert len(eg["tasks"]) == 1
+        task = eg["tasks"][0]
+        assert task["task_id"] == "t-a"
+        assert task["status"] == "completed"          # assigned → completed 累积
+        assert task["assignment"] == {"size_bytes": 1}  # assigned 阶段字段保留
+        assert task["result"] == {"size_bytes": 9} and task["completed_at"] == "T"
+        assert engine.reports == []  # 未到 session.completed,不收敛
+
+
+# ===== BCN state-machine(自定义协作群)=====
+
+class TestBCNStateMachine:
+    """BCN state-machine 事件 → ``translate_bcn`` + BCS run 明细/DAG → ``ingest`` + 终态收敛。"""
+
+    @staticmethod
+    def _sm_event(event_type: str, *, run_id="run-1", session_id="s-1", node_id=None,
+                  data=None) -> dict:
+        scope = {"group_id": "g1", "session_id": session_id, "run_id": run_id}
+        d = data or {}
+        if node_id:
+            d = {"node_id": node_id, **d}
+        return _bcn_event(event_type, scope=scope, data=d)
+
+    def test_node_completed_with_run_still_running_persists_but_no_converge(self, monkeypatch):
+        run_detail = {"run": {"status": "running", "output": {}},
+                      "nodes": [{"node_id": "N1", "status": "completed", "attempt": 1,
+                                 "outcome": "success", "artifact_text": "x"}]}
+        graph_detail = {"definition": {"name": "sm"},
+                        "nodes": [{"node_id": "N1", "display_name": "Step1", "kind": "task",
+                                   "assignee": "b1", "final_output": "x"}],
+                        "edges": [{"src": "N1", "dst": "N2"}]}
+        _install_fake_bcs(monkeypatch, run_detail=run_detail, graph_detail=graph_detail)
+        ev = self._sm_event("state_machine.node.completed", node_id="N1",
+                            data={"attempt": 1, "outcome": "success",
+                                  "output": {"answer": 7}, "completed_at": "T"})
+        svc, engine, repo, _ri = _make_svc()
+        result = _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
+                                     InMemoryCallbackCorrelationRegistry()))
+        _ok_envelope(result)
+        assert engine.reports == []  # run 仍 running,不收敛
+        assert len(repo.calls) == 1
+        rec = repo.calls[0]
+        assert rec.invoker == "bcn"
+        assert rec.run_id == "run-1" and rec.node_id == "N1"  # loop_task_id = run_id::node_id
+        assert rec.main_session_id == "s-1"
+        assert rec.status == "state_machine.node.completed"
+        assert rec.result_success is True
+        assert rec.result == {"success": True, "data": {"answer": 7}}
+        # router 用 BCS run 明细覆盖 _raw_callback_body → orig_callback_data 是 run 明细,非原始 CloudEvent
+        assert json.loads(rec.orig_callback_data) == run_detail
+        # execution_graph = DAG(run nodes)+定义(graph nodes/edges)合并后的任务状态图谱
+        eg = rec.execution_graph
+        assert eg["run_status"] == "running"
+        assert eg["definition"] == {"name": "sm"}
+        assert len(eg["nodes"]) == 1 and eg["nodes"][0]["node_id"] == "N1"
+        assert eg["nodes"][0]["display_name"] == "Step1"
+        assert eg["nodes"][0]["execution"]["status"] == "completed"
+        assert eg["edges"] == [{"src": "N1", "dst": "N2"}]
+
+    def test_run_completed_converges_to_done(self, monkeypatch):
+        run_detail = {"run": {"status": "completed", "output": {"final": "ok"}}, "nodes": []}
+        _install_fake_bcs(monkeypatch, run_detail=run_detail)
+        ev = self._sm_event("state_machine.run.completed",
+                            data={"completed_at": "T", "output": {"final": "ok"}, "duration_ms": 9})
+        svc, engine, repo, _ri = _make_svc(
+            run_info_by_session={"s-1": _run_info("task-99", "root", "s-1")},
+        )
+        result = _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
+                                     InMemoryCallbackCorrelationRegistry()))
+        _ok_envelope(result)
+        # ingest 落审计(run-1,"") + converge 落收敛行(task-99,"root")
+        assert {r.run_id for r in repo.calls} == {"run-1", "task-99"}
+        assert len(engine.reports) == 1
+        patch = engine.reports[0]
+        assert (patch.task_id, patch.node_id) == ("task-99", "root")
+        assert patch.acceptance_result.verdict == AcceptanceVerdict.PASS  # → DONE
+        assert patch.output_patch == {"data": {"final": "ok"}}
+
+    def test_run_failed_converges_to_failed(self, monkeypatch):
+        run_detail = {"run": {"status": "failed", "output": {"err": "x"}}, "nodes": []}
+        _install_fake_bcs(monkeypatch, run_detail=run_detail)
+        ev = self._sm_event("state_machine.run.completed",
+                            data={"completed_at": "T", "output": {"err": "x"}})
+        svc, engine, _repo, _ri = _make_svc(
+            run_info_by_session={"s-1": _run_info("task-99", "root", "s-1")},
+        )
+        _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
+                            InMemoryCallbackCorrelationRegistry()))
+        # failed run → acceptance FAIL → 节点 FAILED(converge_by_session 给失败分支补 gaps)。
+        assert len(engine.reports) == 1
+        patch = engine.reports[0]
+        assert patch.acceptance_result is not None
+        assert patch.acceptance_result.verdict == AcceptanceVerdict.FAIL
+
+    def test_run_completed_converges_even_when_bcs_fetch_fails(self, monkeypatch):
+        # BCS run 明细 fetch 失败时,事件本身 state_machine.run.completed 已表明 run 成功完成
+        # → 用事件体兜底收敛,不依赖 fetch(success 由事件推,output 取事件 data.output)。
+        _install_fake_bcs(monkeypatch, raise_on_get=True)
+        ev = self._sm_event("state_machine.run.completed",
+                            data={"completed_at": "T", "output": {"final": "ok"}})
+        svc, engine, _repo, _ri = _make_svc(
+            run_info_by_session={"s-1": _run_info("task-99", "root", "s-1")},
+        )
+        result = _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
+                                     InMemoryCallbackCorrelationRegistry()))
+        _ok_envelope(result)
+        patch = engine.reports[0]
+        assert (patch.task_id, patch.node_id) == ("task-99", "root")
+        assert patch.acceptance_result.verdict == AcceptanceVerdict.PASS  # → DONE
+        assert patch.output_patch == {"data": {"final": "ok"}}
+
+    def test_fetch_failure_falls_back_to_raw_cloudevent_but_still_converges(self, monkeypatch):
+        """fetch 失败时:审计行仍 fallback 落原始 CloudEvent(_raw_callback_body 未覆盖),
+        但终态收敛改由事件本身兜底(不再被 fetch 失败吞掉)。"""
+        _install_fake_bcs(monkeypatch, raise_on_get=True)
+        ev = self._sm_event("state_machine.run.completed",
+                            data={"completed_at": "T", "output": {"final": "ok"}})
+        svc, engine, repo, _ri = _make_svc(
+            run_info_by_session={"s-1": _run_info("task-99", "root", "s-1")},
+        )
+        result = _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
+                                     InMemoryCallbackCorrelationRegistry()))
+        _ok_envelope(result)
+        # 收敛已触发(事件兜底)
+        assert len(engine.reports) == 1
+        assert engine.reports[0].acceptance_result.verdict == AcceptanceVerdict.PASS
+        # ingest 审计行(run-1,"")仍 fallback 落原始 CloudEvent;converge 另落一行(task-99,"root")
+        ingest = repo.get("run-1", "")
+        assert ingest is not None
+        assert json.loads(ingest.orig_callback_data) == ev  # 原始 CloudEvent(未覆盖)
+        assert ingest.execution_graph == ev["data"]          # 事件体 data
+
+    def test_bcs_non_200_fetch_falls_back_to_raw_event(self, monkeypatch):
+        _install_fake_bcs(monkeypatch, run_status=500)
+        ev = self._sm_event("state_machine.run.completed",
+                            data={"completed_at": "T", "output": {}})
+        svc, engine, repo, _ri = _make_svc()
+        _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
+                            InMemoryCallbackCorrelationRegistry()))
+        assert engine.reports == []
+        assert json.loads(repo.calls[0].orig_callback_data) == ev  # 非 200 → 用原始事件
+
+    def test_handled_event_without_node_uses_run_id_as_loop_task_id(self, monkeypatch):
+        _install_fake_bcs(monkeypatch, run_detail={"run": {"status": "running"}, "nodes": []})
+        ev = self._sm_event("state_machine.run.started",
+                            data={"run_mode": "configured", "started_at": "T"})
+        svc, _engine, repo, _ri = _make_svc()
+        _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
+                            InMemoryCallbackCorrelationRegistry()))
+        rec = repo.calls[0]
+        assert rec.run_id == "run-1" and rec.node_id == ""  # 无 node_id
+        assert rec.status == "state_machine.run.started"
+
+    def test_non_handled_bcn_event_acks_without_persist(self):
+        # message.created 非 manager-worker、非 handled state_machine → 不落库、不收敛、ack 带说明
+        ev = _bcn_event("message.created",
+                        scope={"group_id": "g1", "session_id": "s-1"},
+                        data={"logical_message_id": "m1", "message_type": "chat"})
+        svc, engine, repo, _ri = _make_svc()
+        result = _run(_dispatch_call(_req(ev), svc, NoopCallbackAuthenticator(),
+                                     InMemoryCallbackCorrelationRegistry()))
+        assert result.data == {"ok": True}
+        assert result.message == "bcn event not handled"
+        assert repo.calls == [] and engine.reports == []
+
+
+# ===== manager-worker merge 纯函数(当前零覆盖)=====
+
+def _parsed(event_type: str, *, task_id="t-a", session_id="s-1", group_id="g1",
+            data=None) -> dict:
+    return {"event_id": "evt-1", "event_type": event_type, "group_id": group_id,
+            "session_id": session_id, "task_id": task_id, "data": data or {}}
+
+
+class TestManagerWorkerMerge:
+    """``merge_manager_worker_execution_graph`` / ``parse_manager_worker_bcn`` 纯函数覆盖。"""
+
+    def test_parse_returns_none_for_non_manager_worker_events(self):
+        for et in ("state_machine.run.completed", "state_machine.node.started",
+                   "message.created", "group.foo"):
+            assert parse_manager_worker_bcn(_bcn_event(et, scope={"group_id": "g"})) is None
+        assert parse_manager_worker_bcn(None) is None
+
+    def test_parse_extracts_scope_and_data(self):
+        ev = _bcn_event("task.assigned",
+                        scope={"group_id": "g1", "session_id": "s-1", "task_id": "t-a"},
+                        data={"task_id": "t-a", "manager_id": "m", "worker_id": "w"})
+        parsed = parse_manager_worker_bcn(ev)
+        assert parsed == {"event_id": "evt-1", "event_type": "task.assigned",
+                          "group_id": "g1", "session_id": "s-1", "task_id": "t-a",
+                          "data": {"task_id": "t-a", "manager_id": "m", "worker_id": "w"}}
+
+    def test_group_created_sets_group_status(self):
+        merged = merge_manager_worker_execution_graph(None, _parsed(
+            "group.created", data={"status": "active", "name": "G"}))
+        assert merged["group_status"] == "active"
+        assert merged["last_event_type"] == "group.created"
+        assert merged["tasks"] == []
+
+    def test_session_created_defaults_active_status(self):
+        merged = merge_manager_worker_execution_graph(None, _parsed("session.created", data={}))
+        assert merged["session_status"] == "active"  # data 无 status → 默认 active
+
+    def test_task_assigned_then_completed_accumulates_in_order(self):
+        state = merge_manager_worker_execution_graph(None, _parsed(
+            "task.assigned", task_id="t-a", data={"manager_id": "m", "worker_id": "w",
+                                                  "assignment": {"size_bytes": 1}}))
+        state = merge_manager_worker_execution_graph(state, _parsed(
+            "task.completed", task_id="t-a", data={"result": {"size_bytes": 9},
+                                                   "completed_at": "T"}))
+        assert len(state["tasks"]) == 1
+        task = state["tasks"][0]
+        assert task["status"] == "completed"            # assigned → completed
+        assert task["assignment"] == {"size_bytes": 1}  # assigned 阶段字段保留
+        assert task["result"] == {"size_bytes": 9} and task["completed_at"] == "T"
+
+    def test_none_values_do_not_overwrite_existing(self):
+        # task.completed 缺 manager_id(None)→ 不覆盖 task.assigned 已写的 manager_id
+        state = merge_manager_worker_execution_graph(None, _parsed(
+            "task.assigned", task_id="t-a", data={"manager_id": "m", "worker_id": "w"}))
+        state = merge_manager_worker_execution_graph(state, _parsed(
+            "task.completed", task_id="t-a",
+            data={"manager_id": None, "worker_id": None, "result": {"ok": 1}}))
+        assert state["tasks"][0]["manager_id"] == "m"   # None 不覆盖
+        assert state["tasks"][0]["worker_id"] == "w"
+        assert state["tasks"][0]["result"] == {"ok": 1}
+
+    def test_session_completed_records_reason_summary_completed_by(self):
+        state = merge_manager_worker_execution_graph(None, _parsed(
+            "session.completed", data={"reason": "failed", "completed_by": "bcs-system",
+                                       "summary": "boom"}))
+        assert state["session_status"] == "failed"
+        assert state["session_completed_by"] == "bcs-system"
+        assert state["session_summary"] == "boom"
+
+    def test_task_completed_survives_late_assigned(self):
+        """乱序兜底:同 task 的 completed 早于 assigned 到达时,后到的 assigned 不得把
+        已完成的 status 回退为 assigned(_upsert_task_entry 对 status 单调保护)。语雀
+        保证同 task 严格按 stream.sequence 投递,正常链路不触发;此为乱序容忍的落地。"""
+        state = merge_manager_worker_execution_graph(None, _parsed(
+            "task.completed", task_id="t-a", data={"result": {"ok": 1}, "completed_at": "T"}))
+        assert state["tasks"][0]["status"] == "completed"
+        state = merge_manager_worker_execution_graph(state, _parsed(
+            "task.assigned", task_id="t-a",
+            data={"manager_id": "m", "worker_id": "w", "assignment": {"size_bytes": 1}}))
+        # status 不回退,仍为 completed;assigned 阶段元数据(manager/worker/assignment)照常补齐
+        task = state["tasks"][0]
+        assert task["status"] == "completed"
+        assert task["manager_id"] == "m" and task["worker_id"] == "w"
+        assert task["assignment"] == {"size_bytes": 1}
+
+    def test_different_tasks_do_not_clobber_each_other(self):
+        state = merge_manager_worker_execution_graph(None, _parsed(
+            "task.assigned", task_id="t-a", data={"manager_id": "m", "worker_id": "w"}))
+        state = merge_manager_worker_execution_graph(state, _parsed(
+            "task.assigned", task_id="t-b", data={"manager_id": "m2", "worker_id": "w2"}))
+        assert {t["task_id"] for t in state["tasks"]} == {"t-a", "t-b"}
+
+
+# ===== 羽雀/框架节点级回投(TaskCallbackRequest)=====
+
+class TestFrameworkCallback:
+    """``TaskCallbackRequest`` 富 schema → ``translate`` → ``report_result`` 推进编排核。"""
+
+    @staticmethod
+    def _req_body(**kw) -> dict:
+        d = dict(task_id="t1", workflow_source="bcn", workflow_id="w7",
+                 workflow_instance_id="i1", status="COMPLETED", is_success=True)
+        d.update(kw)
+        return d
+
+    def test_node_level_report_result_advances_engine_with_pass(self):
+        # /callback/report 用 TaskCallbackRequest(无 node_id 字段),故框架节点级回投走
+        # loop_task_id 回声(node_id 直拼仅 /callback/node_result 的 TaskNodeCallbackRequest 用)。
+        body = self._req_body(loop_task_id="t1::c1", is_success=True, output={"r": 1})
+        svc, engine, repo, _ri = _make_svc()
+        result = _run(_dispatch_call(_req(body), svc, NoopCallbackAuthenticator(),
+                                     InMemoryCallbackCorrelationRegistry()))
+        _ok_envelope(result)
+        assert engine.starts == []                      # /callback/report 固定 result,不 start_run
+        assert len(engine.reports) == 1
+        patch = engine.reports[0]
+        assert (patch.task_id, patch.node_id) == ("t1", "c1")  # node_id 直拼
+        assert patch.acceptance_result.verdict == AcceptanceVerdict.PASS
+        assert patch.output_patch == {"data": {"r": 1}}
+        # 同时落 task_callback 审计(invoker 来自 workflow_source)
+        assert repo.calls[0].invoker == "bcn"
+        assert repo.calls[0].run_id == "t1" and repo.calls[0].node_id == "c1"
+
+    def test_failed_framework_result_routes_to_fail_acceptance_with_gaps(self):
+        body = self._req_body(loop_task_id="t1::c1", is_success=False, failed_info="证据不足")
+        svc, engine, _repo, _ri = _make_svc()
+        _run(_dispatch_call(_req(body), svc, NoopCallbackAuthenticator(),
+                            InMemoryCallbackCorrelationRegistry()))
+        patch = engine.reports[0]
+        assert patch.acceptance_result.verdict == AcceptanceVerdict.FAIL
+        assert patch.acceptance_result.gaps == ["证据不足"]  # failed_info → 单 gap
+
+    def test_task_level_uses_echo_loop_task_id(self):
+        body = self._req_body(loop_task_id="t1::root1", is_success=True)
+        svc, engine, _repo, _ri = _make_svc()
+        _run(_dispatch_call(_req(body), svc, NoopCallbackAuthenticator(),
+                            InMemoryCallbackCorrelationRegistry()))
+        assert (engine.reports[0].task_id, engine.reports[0].node_id) == ("t1", "root1")
+
+    def test_task_level_resolves_via_registry_when_no_echo(self):
+        reg = InMemoryCallbackCorrelationRegistry()
+        reg.register(source="bcn", workflow_id=7, instance_id=77, task_id="t1",
+                     node_id="root1", loop_task_id="t1::root1",
+                     workflow_id_str="w7", instance_id_str="i1")
+        body = self._req_body(is_success=True)  # 无 loop_task_id 回声
+        svc, engine, _repo, _ri = _make_svc()
+        _run(_dispatch_call(_req(body), svc, NoopCallbackAuthenticator(), reg))
+        assert (engine.reports[0].task_id, engine.reports[0].node_id) == ("t1", "root1")
+
+
+# ===== 兜底 TaskCallbackDataDTO / 非法 body =====
+
+class TestFallbackAndInvalid:
+    def test_legacy_dto_report_result_advances_engine(self):
+        body = {"loop_task_id": "t1::c1", "workflow_type": "single_bot",
+                "result": {"success": True, "data": "done"}}
+        svc, engine, repo, _ri = _make_svc()
+        result = _run(_dispatch_call(_req(body), svc, NoopCallbackAuthenticator(),
+                                     InMemoryCallbackCorrelationRegistry()))
+        _ok_envelope(result)
+        assert len(engine.reports) == 1
+        patch = engine.reports[0]
+        assert (patch.task_id, patch.node_id) == ("t1", "c1")
+        assert patch.acceptance_result.verdict == AcceptanceVerdict.PASS
+        # ``callback_from_dto`` 不写 workflow_source,故 invoker 落空串(auth 用 workflow_type
+        # 校验但未记录到 invoker 列 —— 轻微审计缺口);DTO 无 instance → main_session_id 空。
+        assert repo.calls[0].invoker == ""
+        assert repo.calls[0].main_session_id == ""
+
+    def test_non_json_body_raises_http_422(self):
+        from fastapi import HTTPException
+        svc, engine, _repo, _ri = _make_svc()
+        with pytest.raises(HTTPException) as excinfo:
+            _run(_dispatch_call(_req("not-json{"), svc, NoopCallbackAuthenticator(),
+                                InMemoryCallbackCorrelationRegistry()))
+        assert excinfo.value.status_code == 422
+        assert engine.reports == [] and engine.starts == []
+
+    def test_invalid_json_dict_raises_http_422(self):
+        from fastapi import HTTPException
+        svc, _engine, _repo, _ri = _make_svc()
+        # 合法 JSON 但不满足任何 schema(缺 loop_task_id、非 ClawMind/BCN)→ 兜底 DTO 校验失败
+        with pytest.raises(HTTPException) as excinfo:
+            _run(_dispatch_call(_req({"foo": "bar"}), svc, NoopCallbackAuthenticator(),
+                                InMemoryCallbackCorrelationRegistry()))
+        assert excinfo.value.status_code == 422
+
+
+# ===== 幂等:result 重投到已终态节点 =====
+
+class TestIdempotency:
+    """``_dispatch`` 框架分支对 ``TaskStateError`` 的幂等吞错 vs 上抛分流。"""
+
+    @staticmethod
+    def _body(loop_task_id="t1::n1", success=True):
+        return {"task_id": "t1", "workflow_source": "bcn", "workflow_id": "w7",
+                "workflow_instance_id": "i1", "status": "COMPLETED",
+                "is_success": success, "loop_task_id": loop_task_id, "node_id": "n1",
+                "output": {"r": 1}}
+
+    def test_result_replay_to_terminal_node_acks_idempotent(self):
+        # 引擎 on_report 抛 TaskStateError;节点当前 DONE(终态)→ 200 idempotent
+        engine = _TaskStateErrorEngine(terminal=True)
+        svc, _e, _repo, _ri = _make_svc(
+            engine=engine,
+            graph_nodes={"t1": [_node("t1", "n1", Status.DONE)]},
+        )
+        result = _run(_dispatch_call(_req(self._body()), svc, NoopCallbackAuthenticator(),
+                                     InMemoryCallbackCorrelationRegistry()))
+        assert result.data == {"ok": True}
+        assert result.message == "idempotent"
+
+    def test_result_replay_to_non_terminal_re_raises_task_state_error(self):
+        # 节点当前 RUNNING(非终态)→ TaskStateError 上抛(envelope_errors→409,单测直接捕异常)
+        engine = _TaskStateErrorEngine(terminal=False)
+        svc, _e, _repo, _ri = _make_svc(
+            engine=engine,
+            graph_nodes={"t1": [_node("t1", "n1", Status.RUNNING)]},
+        )
+        with pytest.raises(TaskStateError):
+            _run(_dispatch_call(_req(self._body()), svc, NoopCallbackAuthenticator(),
+                                InMemoryCallbackCorrelationRegistry()))
+
+
+# ===== 分流选择 + 鉴权 source =====
+
+class _RecordingAuth:
+    """记录 ``verify`` 调用 source 的鉴权替身(永不失败;失败路径用真实 HmacCallbackAuthenticator)。"""
+
+    def __init__(self) -> None:
+        self.sources: list[str] = []
+
+    def verify(self, *, source, headers, raw_body, method, path) -> None:
+        self.sources.append(source)
+
+
+class TestDispatchSelectionAndAuth:
+    """按 body 形态分流至不同 svc 入口;auth.verify 的 source 与端点 disposition 校验。"""
+
+    def test_claw_mind_routes_to_ingest_only(self):
+        svc, engine, _repo, _ri = _make_svc()
+        auth = _RecordingAuth()
+        _run(_dispatch_call(_req(_CLAW_MIND_BODY), svc, auth,
+                            InMemoryCallbackCorrelationRegistry()))
+        assert auth.sources == ["claw_mind"]
+        assert engine.reports == [] and engine.starts == []  # ingest 不推进
+
+    def test_bcn_manager_worker_routes_to_apply_manager_worker_event(self):
+        ev = _bcn_event("task.assigned",
+                        scope={"group_id": "g1", "session_id": "s-1", "task_id": "t-a"},
+                        data={"task_id": "t-a", "manager_id": "m", "worker_id": "w"})
+        svc, engine, repo, _ri = _make_svc()
+        auth = _RecordingAuth()
+        _run(_dispatch_call(_req(ev), svc, auth, InMemoryCallbackCorrelationRegistry()))
+        assert auth.sources == ["bcn"]
+        # manager_worker 分支 → apply_manager_worker_event → invoker=="bcn_manager_worker"
+        assert repo.calls[0].invoker == "bcn_manager_worker"
+
+    def test_bcn_state_machine_routes_to_ingest_with_bcn_auth(self, monkeypatch):
+        _install_fake_bcs(monkeypatch, run_detail={"run": {"status": "running"}, "nodes": []})
+        ev = _bcn_event("state_machine.node.completed",
+                        scope={"group_id": "g1", "session_id": "s-1", "run_id": "run-1"},
+                        data={"node_id": "N1", "attempt": 1, "outcome": "success"})
+        svc, engine, repo, _ri = _make_svc()
+        auth = _RecordingAuth()
+        _run(_dispatch_call(_req(ev), svc, auth, InMemoryCallbackCorrelationRegistry()))
+        assert auth.sources == ["bcn"]
+        assert repo.calls[0].invoker == "bcn"  # state-machine 走 translate_bcn+ingest
+
+    def test_framework_routes_auth_source_from_request(self):
+        body = {"task_id": "t1", "workflow_source": "claw_mind", "workflow_id": "w7",
+                "workflow_instance_id": "i1", "status": "COMPLETED", "is_success": True,
+                "loop_task_id": "t1::c1", "output": {"r": 1}}
+        svc, engine, _repo, _ri = _make_svc()
+        auth = _RecordingAuth()
+        _run(_dispatch_call(_req(body), svc, auth, InMemoryCallbackCorrelationRegistry()))
+        assert auth.sources == ["claw_mind"]  # framework 取 req.workflow_source
+        assert len(engine.reports) == 1
+
+    def test_callback_report_never_calls_start_run(self, monkeypatch):
+        # /callback/report 固定 disposition="result";所有形态均不应触发 start_run。
+        _install_fake_bcs(monkeypatch, run_detail={"run": {"status": "running"}, "nodes": []})
+        bodies = [
+            _CLAW_MIND_BODY,
+            _bcn_event("state_machine.node.completed",
+                       scope={"group_id": "g1", "session_id": "s-1", "run_id": "run-1"},
+                       data={"node_id": "N1", "attempt": 1, "outcome": "success"}),
+            {"task_id": "t1", "workflow_source": "bcn", "workflow_id": "w7",
+             "workflow_instance_id": "i1", "status": "COMPLETED", "is_success": True,
+             "loop_task_id": "t1::c1"},
+        ]
+        for body in bodies:
+            svc, engine, _repo, _ri = _make_svc()
+            _run(_dispatch_call(_req(body), svc, NoopCallbackAuthenticator(),
+                                InMemoryCallbackCorrelationRegistry()))
+            assert engine.starts == [], f"start_run 不应在 /callback/report 被调用: {body}"
+
+    def test_auth_failure_raises_callback_auth_error(self):
+        # 真实 HmacCallbackAuthenticator:伪造回调(无签名头)→ raise CallbackAuthError(→ 401),
+        # 而非 ValidationError(→ 400)。对齐 auth.py docstring 与 ENVELOPE_ERRORS。
+        from agentclaw.community.adapters.http.task.auth import HmacCallbackAuthenticator
+        from agentclaw.community.core.errors import CallbackAuthError
+        svc, _engine, _repo, _ri = _make_svc()
+        auth = HmacCallbackAuthenticator(secrets={"claw_mind": "k"})  # headers 空缺 → 校验失败
+        with pytest.raises(CallbackAuthError):
+            _run(_dispatch_call(_req(_CLAW_MIND_BODY), svc, auth,
+                                InMemoryCallbackCorrelationRegistry()))


### PR DESCRIPTION
## Problem

  本 commit 修复任务模块外部回投(`POST /api/v1/collaboration/tasks/callback/report`,BCS/ClawMind)路径的 4 个正确性缺陷,并改进 BBS 接力单任务通知的可靠性。

  外部回投缺陷:

  1. **失败收敛不翻 FAILED** — `converge_by_session(success=False)` 构造的 `result` 缺 `gaps`,`CallbackAdapter.adapt` 据此产出 `exec_error`(→ harness 重投)而非验收 `FAIL`(→ 终态 FAILED)。失败的 BCN
  state-machine run、manager-worker `session.completed`(reason=failed)不会收敛到 FAILED,反被当作可重试执行错反复重投直至 HUNG。
  2. **鉴权失败状态码错误** — `auth.py` HMAC 校验失败抛 `ValidationError`(经 `_DOMAIN_ERROR_STATUS_MAP` → 400),而非 docstring/`ENVELOPE_ERRORS` 声明的 `CallbackAuthError`(→ 401)。伪造/过期回调返回
  400(Bad Request)而非 401(Unauthorized)。
  3. **BCS fetch 失败丢终态收敛** — `_dispatch` 终态收敛完全依赖 BCS `GET /state-machine-runs/{run_id}` 成功取回的 run 明细;fetch 失败(网络/超时/non-200)时即便事件本身是 `state_machine.run.completed`
  也不收敛,任务节点停在 RUNNING。
  4. **manager-worker 乱序 status 回退** — `_upsert_task_entry` 只保护 `None` 不覆盖,后到的 `task.assigned` 会把已 `completed` 的子任务 status 回退为 `assigned`(注释自称"乱序容忍",实际对 status 未保护)。

  BBS 接力:胜出 bot 收到的任务消息此前依赖 `GET /dashboard` 读剩余事项,多一次往返且强依赖该接口可用。

  ## Solution

  外部回投修复:

  1. `task_service.py::converge_by_session` — 失败分支补 `result["gaps"]`,让 `adapt` 走 `acceptance_result=FAIL`(→ FAILED);失败详情仍随 `output` 落 `run_info.output`。
  2. `auth.py` — `ValidationError` → `CallbackAuthError`(5 处 + import),与 docstring 及 `ENVELOPE_ERRORS`(401)对齐。
  3. `router.py::_dispatch` — 收敛不再仅以 `_run_detail` 为前提;fetch 失败/非 200 时,若事件是 `state_machine.run.completed`,用事件体兜底(`success=True`、`output` 取事件 `data.output`)收敛;审计行仍
  fallback 落原始 CloudEvent。
  4. `translator.py::_upsert_task_entry` — `status` 加单调秩保护(`completed` > `assigned`),后到的 `assigned` 不覆盖已 `completed`;其余字段"非 None 即覆盖"不变。

  BBS 接力:`bbs_runner.py` 新增 `_build_task_snapshot`,把任务态快照(goal/instruction/background、已 DONE 子节点 + output、gaps、loop_round、status)内联进竞价 prompt `_bid_prompt` 与任务消息
  `_task_msg`;胜出 bot 据快照归纳剩余事项,dashboard 降级为字段缺失时兜底。`SKILL.md` 同步更新步骤①语义(dashboard 仅兜底)。

  测试:补全此前为空的 `test_task_callback_report.py`(覆盖 ClawMind / BCN manager-worker / BCN state-machine 三种回投的字段落库与状态收敛),并更新
  `test_auth.py`、`test_translator_manager_worker.py`、`test_bbs_runner.py` 的对应断言/签名。

  ## Validation

  - 直接相关测试 **91 passed**(`test_task_callback_report` 39 + `test_auth` 7 + `test_translator_manager_worker` 6 + `test_schemas`/`test_translator`)。
  - bbs_runner + task_runner + task_graph:**245 passed, 4 skipped**。
  - 4 个回投修复按 TDD:先写断言正确行为的失败用例(RED)再修源码(GREEN)。

  ## Compatibility and risk

  - **鉴权 400 → 401**:依赖该端点、按 400 处理的调用方需改判 401(语义更正确,属对外契约变化)。
  - **fetch 失败兜底收敛**:语雀《BCS Group 回调接入说明》中 `run.completed` = 整 run 成功完成,故按事件推定 `success=True` 与规范一致;若 BCS 未来对失败 run 也发 `run.completed`,需复核。
  - **失败收敛改走 FAIL 终态**(此前是 harness 重投):原本会重试的失败协作现在直接判 FAILED,行为变化但更符合预期。
  - **乱序 status 保护**:仅影响乱序投递(语雀保证同 task 严格按 `stream.sequence`,正常链路不触发)。
  - **BBS 消息体增加内联快照字段**:消息为自由文本 + JSON,旧 bot 若对消息体做严格断言需兼容;通常无影响。

  ## Spec

  - 回投输入数据形态对齐语雀《ClawMind回调服务》§八(HttpCallbackPayload)与《BCS Group 回调接入说明》§3/§4(state-machine / manager-worker 事件链)。
  - BBS 接力单任务流程见 `specs/2026-08-09-task-goal-driven-bbs-active-relay/bbs-relay-single-task/SKILL.md`。

  ## Related issues

  (无)