### PR TITLE
perf(backend): assemble the OpenAPI v1 test surface once per process

### DIFF
--- a/src/backend/scripts/ci_test.sh
+++ b/src/backend/scripts/ci_test.sh
@@ -100,10 +100,14 @@ fi
 # supports well before 3.14. Set ``BACKEND_CI_COVERAGE_CORE=ctrace`` to fall back.
 export COVERAGE_CORE="${BACKEND_CI_COVERAGE_CORE:-sysmon}"
 
+# No ``-v``: at 14k tests it prints ~14k lines that GitHub then has to ingest,
+# for ~30s of the run and no information the job does not already keep. A
+# failure prints its full section at any verbosity, and the per-test record is
+# in the JUnit XML this step writes and the job uploads.
 set +e
 DEPLOY_PROFILE=test \
 PYTHONPATH="$backend_dir/src:$backend_dir:${PYTHONPATH:-}" \
-run_without_git_local_env "$backend_python" -m pytest tests/community -v \
+run_without_git_local_env "$backend_python" -m pytest tests/community \
   "${xdist_args[@]}" \
   --continue-on-collection-errors \
   --junitxml="$junit_report" \

--- a/src/backend/scripts/ci_test.sh
+++ b/src/backend/scripts/ci_test.sh
@@ -104,6 +104,12 @@ export COVERAGE_CORE="${BACKEND_CI_COVERAGE_CORE:-sysmon}"
 # for ~30s of the run and no information the job does not already keep. A
 # failure prints its full section at any verbosity, and the per-test record is
 # in the JUnit XML this step writes and the job uploads.
+#
+# No ``term-missing``: it prints one line per source file under coverage
+# (~1,340 lines and growing) purely for a human reading the raw log.
+# report_check.py below is the only consumer that matters and it reads the
+# XML report, never stdout, so the terminal table adds log volume with no
+# gate depending on it.
 set +e
 DEPLOY_PROFILE=test \
 PYTHONPATH="$backend_dir/src:$backend_dir:${PYTHONPATH:-}" \
@@ -112,8 +118,7 @@ run_without_git_local_env "$backend_python" -m pytest tests/community \
   --continue-on-collection-errors \
   --junitxml="$junit_report" \
   --cov="$ci_workspace/src/backend/src" \
-  --cov-report="xml:$coverage_report" \
-  --cov-report=term-missing
+  --cov-report="xml:$coverage_report"
 pytest_status=$?
 set -e
 

--- a/src/backend/scripts/ci_test.sh
+++ b/src/backend/scripts/ci_test.sh
@@ -80,6 +80,12 @@ fi
 # in-memory SQLite engine, the DI singletons and the FastAPI ``app`` object are
 # isolated per worker for free; ``--dist loadfile`` additionally keeps every test
 # in a file on one worker so file-local ordering is preserved.
+#
+# ``auto`` is also the measured optimum, not just the obvious default: every
+# worker collects the whole suite for itself (~80s of the run), so a worker
+# past the core count adds more collection than it removes test time. On the
+# 4-core runner this targets — full suite, sysmon coverage — auto/4 took 276s,
+# -n 6 took 306s, and -n 8 took 367s. Raise it only along with the cores.
 pytest_workers="${BACKEND_CI_PYTEST_WORKERS:-auto}"
 xdist_args=()
 if [[ "$pytest_workers" != "0" ]]; then

--- a/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
@@ -27,6 +27,7 @@ from agentclaw.community.core.gateway_principal.models import (
 from agentclaw.community.core.gateway_principal.verifier import VerifiedCaller
 from tests.community.adapters.http.openapi_v1.conftest import (
     mount_public_error_handlers,
+    public_document,
     public_router,
 )
 
@@ -228,11 +229,9 @@ def test_search_omits_is_friend_when_bcs_did_not_return_it(
     assert "is_friend" not in response.json()["data"]["items"][0]
 
 
-def test_search_openapi_declares_the_fixed_catalog_unavailable_envelope(
-    app: FastAPI,
-) -> None:
+def test_search_openapi_declares_the_fixed_catalog_unavailable_envelope() -> None:
     """Catches generated clients losing the fixed 502 catalog error contract."""
-    response = app.openapi()["paths"][_SEARCH_PATH]["get"]["responses"]["502"]
+    response = public_document()["paths"][_SEARCH_PATH]["get"]["responses"]["502"]
 
     assert response["description"] == "Catalog service unavailable"
     content = response["content"]["application/json"]
@@ -244,16 +243,16 @@ def test_search_openapi_declares_the_fixed_catalog_unavailable_envelope(
     }
 
 
-def test_search_openapi_declares_optional_bcs_is_friend(app: FastAPI) -> None:
-    is_friend = app.openapi()["components"]["schemas"]["PublicBot"]["properties"][
+def test_search_openapi_declares_optional_bcs_is_friend() -> None:
+    is_friend = public_document()["components"]["schemas"]["PublicBot"]["properties"][
         "is_friend"
     ]
 
     assert is_friend["anyOf"] == [{"type": "boolean"}, {"type": "null"}]
 
 
-def test_search_openapi_declares_optional_bcs_metadata_fields(app: FastAPI) -> None:
-    properties = app.openapi()["components"]["schemas"]["PublicBot"]["properties"]
+def test_search_openapi_declares_optional_bcs_metadata_fields() -> None:
+    properties = public_document()["components"]["schemas"]["PublicBot"]["properties"]
 
     assert properties["visibility"]["description"] == (
         "BCS visibility returned by Catalog Search when available."
@@ -397,8 +396,8 @@ def test_discover_preserves_allowlisted_legacy_json_values(
         assert forbidden not in rendered
 
 
-def test_discover_openapi_allows_legacy_json_values(app: FastAPI) -> None:
-    schemas = app.openapi()["components"]["schemas"]
+def test_discover_openapi_allows_legacy_json_values() -> None:
+    schemas = public_document()["components"]["schemas"]
     public_bot = schemas["PublicBot"]["properties"]
     recommendation = schemas["Recommendation"]["properties"]
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
@@ -11,7 +11,6 @@ from fastapi.testclient import TestClient
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.api.bot_discover_service import BotDiscoverServiceProtocol
 from agentclaw.community.api.bot_public_service import BotPublicServiceProtocol
@@ -26,7 +25,10 @@ from agentclaw.community.core.gateway_principal.models import (
     UserPrincipal,
 )
 from agentclaw.community.core.gateway_principal.verifier import VerifiedCaller
-from tests.community.adapters.http.openapi_v1.conftest import mount_public_error_handlers
+from tests.community.adapters.http.openapi_v1.conftest import (
+    mount_public_error_handlers,
+    public_router,
+)
 
 _SEARCH_PATH = "/openapi/v1/bots/catalog/search"
 _DISCOVER_PATH = "/openapi/v1/bots/catalog/discover"
@@ -108,7 +110,7 @@ def app(services: tuple[_PublicService, _DiscoverService]) -> FastAPI:
             binder.bind(BotDiscoverServiceProtocol, to=discover_service)
 
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.dependency_overrides[require_principal] = lambda: VerifiedCaller(
         principals=(
             UserPrincipal(subject=GatewayUser(id="caller-1", username="caller-1")),

--- a/src/backend/tests/community/adapters/http/openapi_v1/conftest.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/conftest.py
@@ -1,11 +1,14 @@
 """Shared assembled-application fixtures for OpenAPI v1 adapter tests."""
 
+from copy import deepcopy
+from functools import lru_cache
 from urllib.parse import parse_qsl, urlsplit, urlunsplit
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.testclient import TestClient
 
+from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.errors import (
     BotAccessRefusedError,
     GrantNotResolvableError,
@@ -15,6 +18,65 @@ from agentclaw.community.adapters.http.openapi_v1.errors import (
 from agentclaw.community.adapters.http.openapi_v1.principal import USER_ID_QUERY
 from tests.community.framework.fixtures import app_with_testing_modules  # noqa: F401
 from tests.community.framework.fixtures import world  # noqa: F401
+
+
+@lru_cache(maxsize=1)
+def _assembled_public_router() -> APIRouter:
+    """``build_public_router()``, run once per process.
+
+    Assembling the surface is not cheap — every group's routes are cloned into
+    the public router, and each clone re-derives its dependency tree — so it
+    costs ~1.4s. This package builds the surface in ~40 places, most of them
+    per test rather than per module, which made assembly alone the largest
+    single cost in the whole backend suite.
+
+    Sharing one is safe for *mounting*, which is what almost every caller
+    does: assembly reads the group routers and writes a new one, and
+    ``include_router`` copies each route onto its target, so the result can be
+    mounted on any number of applications without any of them observing
+    another's mounting.
+
+    It is not safe for a caller that mounts something onto the router itself —
+    see :func:`public_router`.
+    """
+    return build_public_router()
+
+
+def public_router() -> APIRouter:
+    """The assembled public surface, for mounting on a test's own app.
+
+    Mounting is the cheap half (~1ms), so callers keep building their own
+    ``FastAPI()`` and stay isolated in the things that live on an application
+    rather than a router — ``dependency_overrides``, exception handlers, the
+    attached injector.
+
+    **The router itself is shared, so treat it as read-only.** A test that
+    mounts anything onto what it gets back — the assembly-refusal rows in
+    ``test_authorization_inventory.py`` are the ones that do — leaves that
+    route on the surface every later reader sees, and the failure surfaces in
+    an unrelated file. Those tests call ``build_public_router()`` directly and
+    pay the assembly cost, which is the right trade for the few that need it.
+    """
+    return _assembled_public_router()
+
+
+@lru_cache(maxsize=1)
+def _generated_public_document() -> dict:
+    """The published document, generated once per process (~2.4s a call)."""
+    app = FastAPI()
+    app.include_router(public_router())
+    return app.openapi()
+
+
+def public_document() -> dict:
+    """The document the public surface publishes — a fresh copy per call.
+
+    ``app.openapi()`` memoises on the application, so building one app per test
+    meant regenerating the whole document — 187 paths, 377 schemas — every
+    time. Generating it once and copying (~30ms) keeps each caller the owner of
+    what it gets, which is what a freshly built app used to give them.
+    """
+    return deepcopy(_generated_public_document())
 
 
 def user_scoped_client(app: FastAPI, user_id: str, **kwargs) -> TestClient:

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_engine_restart.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_engine_restart.py
@@ -53,13 +53,9 @@ def test_restart_on_a_bot_not_owned_by_caller_does_not_reach_the_device(client, 
 
 def test_restart_does_not_publish_a_made_up_legacy_address():
     """A new bot-first operation has no component-first contract to retire."""
-    from fastapi import FastAPI
+    from tests.community.adapters.http.openapi_v1.conftest import public_document
 
-    from agentclaw.community.adapters.http.openapi_v1 import build_public_router
-
-    app = FastAPI()
-    app.include_router(build_public_router())
-    paths = app.openapi()["paths"]
+    paths = public_document()["paths"]
 
     assert "/openapi/v1/bots/{bot_id}/engine/restart" in paths
     assert "/openapi/v1/bots/engine/{bot_id}/restart" not in paths

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_routing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_routing.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
 from fastapi.routing import APIRoute
 
 from agentclaw.community.adapters.http.openapi_v1 import (
     _ENGINE_RUNTIME_GROUPS,
     PUBLIC_API_PREFIX,
-    build_public_router,
 )
+from tests.community.adapters.http.openapi_v1.conftest import public_document
 
 #: sessions 10 + session files 6 + engine 4 + models 2 + nodes 1 + approvals 3 + connection 1
 _EXPECTED_ROUTE_COUNT = 27
@@ -52,9 +51,7 @@ def _document() -> dict:
     the thing external callers actually receive, which makes it the better
     subject for a contract assertion.
     """
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    return public_document()
 
 
 def _schema_path(path: str) -> str:

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
@@ -13,13 +13,10 @@ file.
 
 from __future__ import annotations
 
-from functools import lru_cache
-
 import pytest
 from fastapi import FastAPI
 from fastapi.routing import APIRoute
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.engine_runtime.enums import (
     RuntimeStage,
 )
@@ -27,6 +24,7 @@ from agentclaw.community.adapters.http.openapi_v1.engine_runtime.sessions import
     router as sessions_router,
 )
 from agentclaw.community.core.engine_runtime.models import EngineResult
+from tests.community.adapters.http.openapi_v1.conftest import public_document
 
 from .conftest import BOT, OWNER, fails, ok
 
@@ -306,13 +304,11 @@ def test_a_dead_stage_is_the_fixed_409(client, relay):
 # ── the document ─────────────────────────────────────────────────────────────
 
 
-@lru_cache(maxsize=1)
 def _schema() -> dict:
-    # Cached: four document tests read the same generated description, and
-    # assembling the whole public surface per test quadruples the cost.
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    # Four document tests read the same generated description. It is generated
+    # once per process by ``public_document()``, which hands each caller its
+    # own copy — so the caching no longer has to live here.
+    return public_document()
 
 
 def _operations(schema: dict):

--- a/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py
@@ -16,7 +16,6 @@ import httpx
 import pytest
 from fastapi import HTTPException, Request, Response
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.errors import MissingPrincipalError
 from agentclaw.community.adapters.http.openapi_v1.principal import require_user_id
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
@@ -42,6 +41,7 @@ from agentclaw.community.core.resources.factory import ResourceServiceFactory
 from agentclaw.community.core.devices.services.device_filesystem import (
     FileTooLargeError as DeviceFileTooLargeError,
 )
+from tests.community.adapters.http.openapi_v1.conftest import public_router
 
 
 def _request_scope() -> dict:
@@ -707,7 +707,7 @@ async def test_no_handler_can_fall_back_to_a_bot_derived_owner():
     """
     mounted = [
         route
-        for route in _api_routes(build_public_router())
+        for route in _api_routes(public_router())
         if route.path.startswith("/openapi/v1/bots/{bot_id}/resources")
     ]
     # 7 routes. The count is a tripwire — a resources route added without the

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_admission_inventory.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_admission_inventory.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import pytest
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.deprecated import (
     LEGACY_ROUTES,
     SELF_CHECKED_ROUTES,
@@ -44,6 +43,7 @@ from agentclaw.community.adapters.http.openapi_v1.principal import (
     require_granted_addressed_bot,
     require_granted_own_bot,
 )
+from .conftest import public_router
 
 #: The modes whose contract is "a grant is checked for the addressed bot",
 #: each mapped to the one dependency that spells it. The declaration *is* the
@@ -68,7 +68,7 @@ def _effective_routes():
     the test would pass while the wiring was absent. Reading the effective
     contexts is what makes this check about the assembled surface.
     """
-    router = build_public_router()
+    router = public_router()
     found = []
     for route in getattr(router, "routes", []):
         if hasattr(route, "effective_route_contexts"):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_refusals.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_refusals.py
@@ -24,7 +24,6 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.admission import (
     ADMISSION,
     AdmissionMode,
@@ -35,6 +34,7 @@ from agentclaw.community.utils.gateway_principal_config import (
     init_principal_verifier_config,
     reset_principal_verifier_config_cache,
 )
+from .conftest import public_router
 
 KEY = "refusal-test-shared-secret-at-least-32-bytes"
 TENANT = "acme-tenant"
@@ -106,7 +106,7 @@ def client():
 
     app = FastAPI()
     app.add_middleware(AvernetTenantMiddleware)
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.add_exception_handler(Exception, _unhandled_exception_handler)
     return TestClient(app, raise_server_exceptions=False)
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_authorization_inventory.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_authorization_inventory.py
@@ -53,6 +53,7 @@ from tests.community.adapters.http.openapi_v1._route_walk import (
     original_route_of,
     path_of,
 )
+from .conftest import public_router
 
 
 _RAN: list[str | None] = []
@@ -143,8 +144,20 @@ def test_attached_dependency_publishes_its_parameters(probe_surface):
 # ── the inventory ────────────────────────────────────────────────────────────
 
 
+def _own_surface() -> APIRouter:
+    """A surface belonging to this test alone.
+
+    The rows below assert on *assembly*: each mounts a deliberately wrong route
+    and expects the check to refuse it. They must therefore build their own
+    surface rather than take the shared ``public_router()`` — the bad route
+    they add would otherwise stay on it and reach every later reader, which is
+    a failure a long way from its cause.
+    """
+    return build_public_router()
+
+
 def _live_operations():
-    return {key for key, _ in operations(build_public_router())}
+    return {key for key, _ in operations(public_router())}
 
 
 def test_the_surface_and_the_table_agree_exactly():
@@ -199,7 +212,7 @@ def test_every_route_is_a_public_api_route():
     """
     offenders = [
         f"{sorted(getattr(ctx, 'methods', None) or {'WEBSOCKET'})} {path_of(ctx)}"
-        for ctx in effective_routes(build_public_router())
+        for ctx in effective_routes(public_router())
         if not isinstance(original_route_of(ctx), PublicAPIRoute)
         and hasattr(original_route_of(ctx), "methods")
     ]
@@ -233,7 +246,7 @@ def test_assembly_refuses_a_row_that_matches_no_operation():
     and a table that no longer describes the surface cannot be trusted to say
     an operation is covered.
     """
-    router = build_public_router()
+    router = public_router()
     AUTHORIZATION[("GET", "/openapi/v1/bots/{bot_id}/renamed-away")] = OWNER_SCOPED
     try:
         with pytest.raises(PublicRouteNotAuthorized) as refusal:
@@ -496,7 +509,7 @@ def test_a_router_cannot_opt_out_of_the_route_class():
     ``test_every_route_is_a_public_api_route``, which asserts today's surface is
     clean: this asserts the mechanism would notice if it stopped being.
     """
-    public = build_public_router()
+    public = _own_surface()
     opted_out = APIRouter()  # no route_class
 
     @opted_out.get("/openapi/v1/bots/{bot_id}/built-its-own-way")
@@ -523,7 +536,7 @@ def test_a_websocket_route_without_a_row_fails_assembly():
     with no declared authorization at all — the orphan check looks the other
     way and finds nothing to complain about.
     """
-    public = build_public_router()
+    public = _own_surface()
     sockets = APIRouter()
 
     @sockets.websocket("/openapi/v1/bots/undeclared/ws")
@@ -561,7 +574,7 @@ def test_a_websocket_check_row_fails_assembly():
     covered — and the inventory would agree — while the socket was served
     unguarded.
     """
-    public = build_public_router()
+    public = _own_surface()
     sockets = APIRouter()
 
     @sockets.websocket("/openapi/v1/bots/declared/ws")
@@ -593,7 +606,7 @@ def test_a_check_handler_must_consume_the_owner_the_gate_checks():
     So the migration cannot be half-done: the row and the handler move
     together, or assembly refuses.
     """
-    public = build_public_router()
+    public = _own_surface()
     diverging = APIRouter(route_class=PublicAPIRoute)
     key = ("GET", "/openapi/v1/bots/{bot_id}/diverging")
     AUTHORIZATION[key] = Check(PermissionLevel.MEMBER)
@@ -618,7 +631,7 @@ def test_a_check_handler_taking_owner_id_dep_is_accepted():
     Also exercises ``@envelope_errors``, since every real handler wears it and
     the check has to see through ``__wrapped__`` to the true signature.
     """
-    public = build_public_router()
+    public = _own_surface()
     correct = APIRouter(route_class=PublicAPIRoute)
     key = ("GET", "/openapi/v1/bots/{bot_id}/correct")
     AUTHORIZATION[key] = Check(PermissionLevel.MEMBER)
@@ -656,7 +669,7 @@ def test_a_check_row_without_bot_id_on_the_path_fails_assembly():
     under ``/openapi/v1/bots/{bot_id}/harness`` and pass this refusal. See
     ``_assert_check_rows_are_enforceable`` for what actually stops them.
     """
-    public = build_public_router()
+    public = _own_surface()
     pathless = APIRouter(route_class=PublicAPIRoute)
     key = ("GET", "/openapi/v1/bots/pathless-thing")
     AUTHORIZATION[key] = Check(PermissionLevel.MEMBER)
@@ -689,7 +702,7 @@ def test_bot_id_anywhere_on_the_path_is_accepted():
     today, so they do not reach this refusal yet; the moment Task 11 flips them
     to ``Check`` they do, and a refusal keyed on position would reject every one.
     """
-    public = build_public_router()
+    public = _own_surface()
     relocated = APIRouter(route_class=PublicAPIRoute)
     key = ("GET", "/openapi/v1/bots/relocated/{bot_id}/thing")
     AUTHORIZATION[key] = Check(PermissionLevel.MEMBER)

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -1542,13 +1542,9 @@ def test_the_write_contract_does_not_promise_starts_that_never_recompose(
     """
     # Asserted on the *published* description, not the docstring: that string is
     # what a caller reads, and it is what promised more than the feature does.
-    from fastapi import FastAPI
+    from tests.community.adapters.http.openapi_v1.conftest import public_document
 
-    from agentclaw.community.adapters.http.openapi_v1 import build_public_router
-
-    app = FastAPI()
-    app.include_router(build_public_router())
-    ops = app.openapi()["paths"]["/openapi/v1/bots/{bot_id}/startup-script"]
+    ops = public_document()["paths"]["/openapi/v1/bots/{bot_id}/startup-script"]
 
     put_doc = ops["put"]["description"]
     assert "composes" in put_doc

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_deprecation_headers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_deprecation_headers.py
@@ -19,9 +19,7 @@ from email.utils import parsedate_to_datetime
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
-
-from .conftest import mount_public_error_handlers
+from .conftest import mount_public_error_handlers, public_document, public_router
 from agentclaw.community.adapters.http.openapi_v1.deprecated import LEGACY_ROUTES
 from agentclaw.community.adapters.http.openapi_v1.middleware import (
     DEPRECATION,
@@ -32,9 +30,7 @@ from agentclaw.community.adapters.http.openapi_v1.middleware import (
 
 
 def _document() -> dict:
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    return public_document()
 
 
 #: ``LEGACY_ROUTES`` holds route paths, which keep Starlette's ``:path``
@@ -83,7 +79,7 @@ def test_every_legacy_address_answers_with_both_headers() -> None:
     thing a test of the registration alone would miss.
     """
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.add_middleware(DeprecationHeaderMiddleware)
     mount_public_error_handlers(app)
     client = TestClient(app)
@@ -111,7 +107,7 @@ def test_the_two_headers_use_their_own_spellings() -> None:
     so neither can drift into the other's format.
     """
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.add_middleware(DeprecationHeaderMiddleware)
     mount_public_error_handlers(app)
     method, path = sorted(LEGACY_ROUTES)[0]
@@ -221,7 +217,7 @@ def test_a_browser_can_actually_read_the_headers_cross_origin() -> None:
             return None
 
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     mount_public_error_handlers(app)
     # The real installer, with the two plugins stubbed: what is under test is
     # the CORS registration it performs, and re-creating that here would be the

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -29,7 +29,6 @@ from fastapi.testclient import TestClient
 
 from agentclaw.community.adapters.http.openapi_v1 import (
     PUBLIC_API_PREFIX,
-    build_public_router,
 )
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     ERROR_RESPONSES,
@@ -49,6 +48,7 @@ from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
 )
+from .conftest import public_document
 
 _CALLER = "u-42"
 _PROBE = f"{PUBLIC_API_PREFIX}/bots/_probe"
@@ -377,9 +377,7 @@ _BOT_ID_PLACEMENT = {"path": 140, "query": 1, "none": 59}
 
 
 def _schema() -> dict:
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    return public_document()
 
 
 def _current_operations(schema: dict):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_legacy_parity.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_legacy_parity.py
@@ -42,15 +42,14 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.deprecated import LEGACY_ROUTES
 
-from .conftest import mount_public_error_handlers
+from .conftest import mount_public_error_handlers, public_document, public_router
 
 
 def _client() -> TestClient:
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     mount_public_error_handlers(app)
     return TestClient(app)
 
@@ -96,7 +95,7 @@ def test_a_legacy_address_refuses_exactly_as_its_replacement_does(
 
 def test_every_legacy_route_names_a_replacement_that_exists() -> None:
     """A legacy address pointing at nothing would be a dead end in the document."""
-    published = set(_client().app.openapi()["paths"])
+    published = set(public_document()["paths"])
     missing = sorted(
         replacement
         for replacement in LEGACY_ROUTES.values()
@@ -138,7 +137,7 @@ def test_a_retiring_body_keeps_the_component_name_it_published() -> None:
     what would answer that, and that lives in the release compat gate rather
     than here.
     """
-    document = _client().app.openapi()
+    document = public_document()
 
     def body_schema(method: str, path: str) -> str | None:
         operation = document["paths"].get(path, {}).get(method.lower())

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_loadtest_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_loadtest_endpoints.py
@@ -29,7 +29,6 @@ from starlette.websockets import WebSocketDisconnect
 
 from agentclaw.community.adapters.http.openapi_v1 import (
     PUBLIC_API_PREFIX,
-    build_public_router,
 )
 from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     PRINCIPAL_HEADER,
@@ -40,7 +39,7 @@ from agentclaw.community.utils.gateway_principal_config import (
     reset_principal_verifier_config_cache,
 )
 
-from .conftest import mount_public_error_handlers
+from .conftest import mount_public_error_handlers, public_router
 from .test_principal_seam import KEY, boot_with_key, mint
 
 _HELLO = f"{PUBLIC_API_PREFIX}/bots/loadtest/hello"
@@ -64,7 +63,7 @@ def client() -> TestClient:
     ``@envelope_errors`` never sees it.
     """
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     return TestClient(mount_public_error_handlers(app))
 
 
@@ -213,7 +212,7 @@ def _routes():
             else:
                 walk(route)
 
-    walk(build_public_router())
+    walk(public_router())
     return found
 
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_no_duplicate_request_fields.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_no_duplicate_request_fields.py
@@ -28,8 +28,8 @@ from typing import Any
 
 from fastapi import FastAPI
 from fastapi.dependencies.utils import get_flat_params
+from .conftest import public_document, public_router
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 
 #: Every place a request field can be declared. ``path`` is read off the address
 #: template rather than the parameter list, so a path parameter counts even for a
@@ -39,12 +39,12 @@ _LOCATIONS = ("path", "query", "header", "cookie", "body")
 
 def _app() -> FastAPI:
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     return app
 
 
 def _document() -> dict[str, Any]:
-    return _app().openapi()
+    return public_document()
 
 
 def _body_fields(

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_openapi_error_schema.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_openapi_error_schema.py
@@ -13,10 +13,9 @@ as a change to the mapping itself.
 
 from __future__ import annotations
 
-from fastapi import FastAPI
-
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.contracts import ERROR_RESPONSES
+
+from .conftest import public_document
 
 _ERROR_REF = "#/components/schemas/ErrorEnvelope"
 
@@ -30,9 +29,7 @@ _DOCUMENTED_DATA_BEARING_ERRORS = {
 
 
 def _schema() -> dict:
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    return public_document()
 
 
 def _json_ref(operation: dict, status: str) -> str | None:

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_org_user_identity.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_org_user_identity.py
@@ -28,7 +28,6 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.utils.avernet_tenant import DEFAULT_AVERNET_TENANT
@@ -36,6 +35,7 @@ from agentclaw.community.utils.gateway_principal_config import (
     init_principal_verifier_config,
     reset_principal_verifier_config_cache,
 )
+from .conftest import public_router
 
 KEY = "caller-test-shared-secret-at-least-32-bytes"
 TENANT = "acme-tenant"
@@ -112,7 +112,7 @@ def client():
 
     app = FastAPI()
     app.add_middleware(AvernetTenantMiddleware)
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.add_exception_handler(Exception, _unhandled_exception_handler)
     return TestClient(app, raise_server_exceptions=False)
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_path_convention.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_path_convention.py
@@ -20,12 +20,9 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from fastapi import FastAPI
+from agentclaw.community.adapters.http.openapi_v1 import PUBLIC_API_PREFIX
 
-from agentclaw.community.adapters.http.openapi_v1 import (
-    PUBLIC_API_PREFIX,
-    build_public_router,
-)
+from .conftest import public_document
 
 _BASE = f"{PUBLIC_API_PREFIX}/bots"
 
@@ -44,9 +41,7 @@ _UNROUTED_ANCHOR = "<!-- reserved-component-names-unrouted -->"
 
 
 def _document() -> dict:
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    return public_document()
 
 
 def _paths() -> list[str]:

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_principal_seam.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_principal_seam.py
@@ -26,7 +26,6 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.testclient import TestClient
 
 from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     PRINCIPAL_HEADER,
     Principal,
@@ -47,6 +46,7 @@ from agentclaw.community.utils.gateway_principal_config import (
     init_principal_verifier_config,
     reset_principal_verifier_config_cache,
 )
+from .conftest import public_router
 
 KEY = "seam-test-shared-secret-at-least-32-bytes"
 TENANT = "acme-tenant"
@@ -367,7 +367,7 @@ def test_public_routes_require_principal():
     internal tenant's data for an unauthenticated caller, so this is checked
     rather than remembered.
     """
-    api_routes = _api_routes(build_public_router())
+    api_routes = _api_routes(public_router())
     assert api_routes, "no public routes found — the guard would pass vacuously"
 
     missing = [
@@ -382,7 +382,7 @@ def test_public_routes_require_principal():
 def test_bot_logs_routes_require_user_and_app_principal():
     bot_logs_routes = [
         route
-        for route in _api_routes(build_public_router())
+        for route in _api_routes(public_router())
         if route.path.startswith("/openapi/v1/bots/logs")
     ]
     assert bot_logs_routes, "no Bot Logs routes found"
@@ -410,7 +410,7 @@ def test_granting_a_bot_authorization_requires_user_and_app_principal():
     """
     routes = [
         route
-        for route in _api_routes(build_public_router())
+        for route in _api_routes(public_router())
         if route.path == _AUTHORIZED_APPS_PREFIX and "POST" in route.methods
     ]
     assert routes, "no grant route found"
@@ -433,7 +433,7 @@ def test_application_view_requires_user_and_app_principal():
     """
     routes = [
         route
-        for route in _api_routes(build_public_router())
+        for route in _api_routes(public_router())
         if route.path == _AUTHORIZED_BOTS_PATH
     ]
     assert routes, "no application-view route found"
@@ -456,7 +456,7 @@ def test_listing_and_withdrawing_authorizations_need_only_the_owner():
     """
     owner_only = [
         route
-        for route in _api_routes(build_public_router())
+        for route in _api_routes(public_router())
         if route.path.startswith(_AUTHORIZED_APPS_PREFIX)
         and ("GET" in route.methods or "DELETE" in route.methods)
     ]

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_schema_docs.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_schema_docs.py
@@ -16,17 +16,14 @@ published.
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from .conftest import public_document
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 
 _METHODS = {"get", "put", "post", "delete", "patch", "options", "head", "trace"}
 
 
 def _document() -> dict:
-    app = FastAPI()
-    app.include_router(build_public_router())
-    return app.openapi()
+    return public_document()
 
 
 def _operations(document: dict):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_self_checked_routes_refuse.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_self_checked_routes_refuse.py
@@ -29,7 +29,7 @@ routine creation. Those are separated below, so this file asserts the strongest
 thing that is actually true rather than a stricter one that would have to be
 weakened the first time it ran.
 
-Driven through ``build_public_router()`` rather than a hand-mounted subset,
+Driven through ``public_router()`` rather than a hand-mounted subset,
 because *how* these routes are mounted is half of what is under test.
 """
 
@@ -42,7 +42,6 @@ from fastapi import FastAPI
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.admission import (
     SKILL_SCOPED_OPERATIONS,
 )
@@ -69,7 +68,7 @@ from agentclaw.community.core.gateway_principal import (
     VerifiedCaller,
 )
 
-from .conftest import mount_public_error_handlers, user_scoped_client
+from .conftest import mount_public_error_handlers, public_router, user_scoped_client
 
 APP_ID = 99
 USER = "u-1"
@@ -188,7 +187,7 @@ def client(services):
                 binder.bind(protocol, to=services)
 
     app = FastAPI()
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.dependency_overrides[require_principal] = _app_caller
     attach_injector(app, Injector([_M()]))
     mount_public_error_handlers(app)

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_shared_bot_grant.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_shared_bot_grant.py
@@ -26,7 +26,6 @@ from fastapi import FastAPI
 from fastapi_injector import attach_injector
 from injector import Injector, Module
 
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.api.bot_app_grant_service import BotAppGrantServiceProtocol
 from agentclaw.community.api.local_skill_delete_service import (
@@ -56,6 +55,7 @@ from .conftest import (
     SeamCollaborators,
     bind_bot_access_seam,
     mount_public_error_handlers,
+    public_router,
     user_scoped_client,
 )
 
@@ -201,7 +201,7 @@ def client():
     # The assembled router, not a hand-mounted subset: what is under test is
     # partly *how* the group is mounted, so a fixture that mounted it its own
     # way could not see the defect this file was written for.
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.dependency_overrides[require_principal] = _app_caller
     attach_injector(app, Injector([_M()]))
     mount_public_error_handlers(app)

--- a/src/backend/tests/community/contracts/test_staff_dept.py
+++ b/src/backend/tests/community/contracts/test_staff_dept.py
@@ -29,7 +29,6 @@ from injector import Injector, Module, singleton
 
 from agentclaw.community.adapters.http.app import _unhandled_exception_handler
 from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
-from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
 from agentclaw.community.adapters.http.openapi_v1.errors import DeptLookupError
 from agentclaw.community.plugin_api.staff_dept import (
@@ -42,6 +41,7 @@ from agentclaw.community.utils.gateway_principal_config import (
     init_principal_verifier_config,
     reset_principal_verifier_config_cache,
 )
+from tests.community.adapters.http.openapi_v1.conftest import public_router
 
 _KEY = "staff-dept-contract-signing-key-at-least-32-bytes"
 _USER = {"id": "u-staff-1", "username": "bob@example.com"}
@@ -87,7 +87,7 @@ def _app_bound_to(staff_dept: StaffDeptPlugin) -> FastAPI:
 
     app = FastAPI()
     app.add_middleware(AvernetTenantMiddleware)
-    app.include_router(build_public_router())
+    app.include_router(public_router())
     app.add_exception_handler(Exception, _unhandled_exception_handler)
     attach_injector(app, Injector([_M()]))
     return app


### PR DESCRIPTION
## Problem

The backend suite has been getting slower as tests are added, and xdist was
already carrying it (`-n auto --dist loadfile`, sysmon coverage). Profiling the
full run showed the growth was not spread across the suite — it was
concentrated in one package.

Measured on a 4-core runner (the same shape as `ubuntu-latest`), full suite
with coverage at `-n auto`:

- **411s wall, 1449s CPU**, 13 989 tests
- `tests/community/adapters/http/openapi_v1/**` accounted for **720s of the
  1167s of test time — 62% of the runtime from 7.5% of the tests**

The cause: the package builds the public surface from scratch in ~40 places,
most of them per test rather than per module —
`FastAPI()` + `include_router(build_public_router())`, and frequently
`.openapi()` on top. Both halves are expensive and neither was shared:

| step | cost |
| --- | --- |
| `build_public_router()` | ~1.45s (clones every group's routes, re-derives each dependency tree) |
| `app.openapi()` | ~2.44s (187 paths, 377 schemas) |
| `app.include_router(existing)` | ~0.001s |
| `deepcopy(document)` | ~0.030s |

So each document test paid ~3.9s to rebuild something byte-identical, and the
bill grew with every route added to the surface. `test_legacy_parity.py` alone
spent 161s because it assembled the surface twice per parametrised row.

## Solution

Four commits, each independently revertible.

### 1. Assemble the surface once per process

Assemble the router once per process and generate the document once per
process, both behind the package conftest:

- `public_router()` — `build_public_router()` under an `lru_cache`. Callers
  keep building their own `FastAPI()`, because mounting is the cheap half, so
  everything that lives on an *application* — `dependency_overrides`,
  exception handlers, the attached injector — stays per test exactly as before.
- `public_document()` — the generated document, handed out as a `deepcopy` so
  each caller still owns what it gets, which is what a freshly built app used
  to give it. At ~30ms versus ~2.4s the copy is worth keeping rather than
  sharing one dict and hoping every reader stays read-only.

Reusing one router across applications is safe by construction:
`include_router` *copies* each route onto its target, so no application
observes another's mounting. Verified directly — the document generated from a
reused router is byte-identical to one from a freshly built router.

The exception is the rows in `test_authorization_inventory.py` that assert on
*assembly itself*: they mount a deliberately wrong route onto the router they
are handed and expect the check to refuse it. Those cannot share a surface —
the bad route would stay on it and fail an unrelated file later — so they build
their own via a local `_own_surface()` that records why. `public_router()`'s
docstring states the read-only constraint.

### 2. Stop printing a line per test

`-v` on a 14k-test suite prints ~14k lines that GitHub then has to ingest. It
buys nothing the job does not already keep: pytest prints a failure's full
section at any verbosity, and the per-test record is in the JUnit XML this step
writes and the job uploads as an artifact. Worth ~30s locally and, as it turned
out, **1m42s in CI**, where the log is streamed rather than written to a file.

### 3. Stop printing a line per source file

`--cov-report=term-missing` prints one line per file under coverage (~1,340
and growing) purely for a human reading the raw CI log. `report_check.py`, the
only consumer that matters, reads the XML report and never stdout, so the
table is log volume with no gate behind it.

### 4. The one real per-test document rebuild `public_router()` didn't catch

`test_bot_public_router.py` has a per-test `app` fixture that mounts the same
shared `public_router()` as everything else, but four tests then call
`app.openapi()` directly on it. FastAPI memoizes `.openapi()` on the
*application instance*, not globally, so each fresh `app` fixture regenerated
the whole document again — ~2.5-4s each, the same cost change 1 already fixed
everywhere it could see. Checked every other remaining `.openapi()` call site
in the package first: three others (`test_skill_publish_status.py`,
`test_skills_contract.py`, `test_bots_endpoints.py`'s `client` fixture, and
others) mount a *scoped* single-router app, not the full surface — swapping
those to `public_document()` would silently assert against the wrong document,
so they're untouched. Only these four, confirmed to mount the real
`public_router()`, read `public_document()` instead now.

### Rejected alternatives

- **More xdist workers.** Measured, and it is strictly worse — every worker
  collects the whole suite for itself (~82s), so a worker past the core count
  adds more collection than it removes test time. `auto`/4 = 276s, `-n 6` =
  306s, `-n 8` = 367s. `auto` is already the optimum; recorded as a comment in
  `ci_test.sh` so the next person does not re-run the experiment.
- **`--dist worksteal` instead of `loadfile`.** Would balance the tail better
  but gives up the file-local ordering `loadfile` guarantees; not worth the
  flakiness risk for the remaining imbalance.
- **Caching inside `build_public_router()` itself.** Production assembles the
  surface once at startup; it has no need of a cache, and adding one there to
  speed up tests would put test concerns in production code.
- **Caching AST parses across the 39 architecture-boundary test files.** They
  account for ~57s of ~936s total CPU (~6%) and each owns a different root and
  rule set, so sharing a parse cache safely means auditing 39 files for the
  same mutation hazard change 1 had to fix in one file. Poor risk/reward next
  to what's landed; flagged here rather than attempted.
- **Sharding the job across runners.** The only lever that would meaningfully
  cut the ~82s-per-worker collection floor, but it means combining coverage
  and merging JUnit across shards so the 100% pass-rate / 75% total / 80%
  changed-line gates stay exactly as strict — real risk of silently loosening
  a gate. Left as a follow-up decision, not attempted here.

## Validation

**Measured in CI**, on the `Backend unit tests` job, against the same job on
the base branch (`c9d6fa8`):

| | `Run unit tests with coverage` | job total |
| --- | --- | --- |
| base branch, before | 12m14s | **12m48s** |
| after commit 1 | 8m02s | 8m34s |
| after commit 2 | ~6m30s | **6m52s** |

Commits 3 and 4 are pushed and green on all 7 checks (confirmed via the CI
job's per-step timing on this head), landed after the table above was last
refreshed from a live run — their local numbers are below and the next CI run
on this head will show the updated job time.

Locally, on a 4-core box, full suite, sysmon coverage, `-n auto`, matching what
`scripts/ci_test.sh` does — **after all four commits**:

| | before (base) | after |
| --- | --- | --- |
| wall | 410.8s | **~276-288s** (−30 to −33%) |
| CPU | 1449s | ~936s (−35%) |
| result | 13 959 passed, 28 skipped | **13 959 passed, 28 skipped** |

- Affected tree in isolation (`openapi_v1` + `contracts/gateway`), after commit
  1: 618s → 197s, **1417 passed / 2 skipped before and after** — identical.
  Re-verified after commit 4: still 1417 passed / 2 skipped, 196s.
- `bot_public/test_bot_public_router.py` alone: the four `.openapi()` tests
  dropped from 2.5-4s each to effectively free (shared with whichever test in
  the process pays the one-time document generation first) — 17 tests, 6.9s
  total, all passing.
- Ran the full suite at `-n 4`, `-n 6` and `-n 8` (before commits 3-4). All
  three produce identical results, which also means three different
  file→worker distributions agreed — evidence the shared router does not leak
  across tests.
- Verified by execution that the `ci_test.sh` edits leave `DEPLOY_PROFILE` and
  `PYTHONPATH` reaching pytest and change no other argument.
- `scripts/ci/python_sast_local.sh src/backend` against the merge base: passes
  (re-run after commit 2, against the then-current base tip).
- `ruff check --select F401,F811,F821` (whole-file `ruff check` for commit 4's
  test file) on every changed file: clean.
- `git merge-tree` against the current `dev_refactory_collaboration` tip
  (`f4d3060`, which advanced after this PR opened): merges clean — the base
  branch's change is an unrelated router addition in the same `__init__.py`
  that commit 1 never touches.

Two failures are present in `test_bot_build_service_skill_artifact.py`
(`test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_write_nfs`)
both **before and after every commit here**, on the unmodified baseline
commit, in the local environment only — CI is green on them. They are
pre-existing and unrelated to this diff; not investigated here.

## Compatibility and risk

Test-only. No production code, contract, schema, or config is touched. Rollback
is a plain revert of any commit independently.

The one behavioural constraint introduced is that `public_router()` returns a
shared object and must be treated as read-only. It is documented on the
function, and the one place in the suite that needs a private surface has its
own helper explaining why.

Dropping `-v` means the Actions log no longer lists every passing test.
Dropping `term-missing` means the log no longer has an inline per-file
coverage table. Neither changes any gate: failure output is unchanged, and
both `pytest_report/TEST-junit.xml` and `TEST-cov.xml` are still uploaded with
the full per-test and per-file record.

## Notes for reviewers

What is left after these four commits is mostly a floor rather than waste:
collection is ~82s that every xdist worker repeats independently, so on one
runner the job cannot go far below ~5 minutes whatever the worker count.
Breaking that needs the job sharded across runners — see "Rejected
alternatives" above for why that's a separate, higher-risk decision rather
than something folded into this PR.