### PR TITLE
feat(backend): support applicationCoding bot creation

### DIFF
--- a/docs/superpowers/plans/2026-08-24-openapi-application-coding-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-24-openapi-application-coding-implementation-plan.md
@@ -1,0 +1,300 @@
+# OpenAPI Application Coding 实现计划
+
+- **日期**：2026-08-24
+- **关联方案**：`../specs/2026-08-24-openapi-application-coding-decision.md`
+- **状态**：部分实施
+- **实施进度**：Task 1–6、Task 8 已实施并通过当前回归测试；Task 7（删除 hosted workspace）**Blocked**，等待 corp-only DIMA delete contract。
+- **Task 7 解阻最小契约**：HTTP/RPC 类型、endpoint/RPC 方法、workspace_id 参数位置、鉴权、成功/不存在/超时语义、幂等删除语义、request_id 透传方式。
+- **Task 7 当前验收**：保留“非服务 applicationCoding 删除后无 hosted workspace 残留”未勾选；未拿到契约前不实现猜测性的 client/service 删除调用。
+
+## 0. 两条硬约束（贯穿每个 Task）
+
+1. **不影响原有常见逻辑**：普通 Bot、`claude_code`、`aicoding`、服务化的创建路径行为逐字节不变；`template_type` 未传时零变化。
+2. **与原 `create_bot` 链路一致**：新增字段只做并列扩展，不重排、不改 `entity_id`/`engine_type`/`space_id` 的既有解析。
+
+落地口诀：**可选字段并列扩展 + 校验前置 fail-closed + Application Coding 失败显式返回 + 复用现有 auth-status echo**。
+
+---
+
+## Task 1：契约定义 + 错误码
+
+**目标**：`BotCreate` 可接收 `template_type` / `template_config`，未知字段仍被拒。
+
+**文件**：
+- `src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py`
+- `src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors.py`
+- `src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py`
+- `src/backend/src/agentclaw/community/adapters/http/openapi_v1/contracts.py`（如需新增公共错误响应模型）
+
+**改动**：
+- `BotCreate` 增加两个**可选**字段（保留 `extra="forbid"`）：
+  ```python
+  template_type: str | None = Field(default=None, description=...)
+  template_config: dict[str, Any] | None = Field(default=None, description=...)
+  ```
+- `template_config` 使用**受控薄透传**：公共契约声明为 `dict[str, Any] | None`，不猜测或重塑内部字段形状。原因是历史 Application Coding 配置与新模板/引擎配置并非同一套结构：
+  - 历史真实 fixture 使用扁平业务字段，例如 `devflow_workflow`、`yuque_kb_repos`、`code_repos`、`token`；
+  - 当前引擎侧还消费 `bot_template_config.preset_capabilities`、`bot_template_config.ext_config.thetaKey` 等嵌套字段；
+  - 因此不得引入 `model/runtime/repos/config` 这组未经历史契约证明的顶层字段。
+- `template_config` 只做边界控制，不做业务字段重映射：
+  - 必须是 JSON object；保留嵌套对象、数组、标量和未知业务字段；
+  - `to_internal_template_config()` 只做深拷贝/JSON 归一化，不改变 key 层级，不把字段搬到 `bot_template_config`；
+  - 客户端不得写入服务端管理字段：顶层 `dima_space_id`、`template_uid`、Bot ID、workspace 状态字段；这些由 Workspace Hosting 或 BaaS template resolver 生成/补充；
+  - `template_key` 不在本期单独声明为公共字段；若历史校验器或模板 resolver 后续需要，必须另行补充契约，而不是借薄透传静默赋予公共语义；
+  - 具体字段合法性由既有 Application Coding/模板校验器负责，校验失败统一映射为 `OPENAPI_BOT_TEMPLATE_INVALID`；公共层不得静默丢弃未知字段。
+
+**已核历史 fixture**（`src/backend/tests/community/acceptance/bot_management/test_bot_live_lifecycle.py`）：
+```python
+old_template = {
+    "devflow_workflow": "old-flow",
+    "yuque_kb_repos": [],
+    "code_repos": [],
+    "token": "old-token",
+}
+```
+该 fixture 用于既有 Application Coding Bot 的模板更新/回读，证明 legacy 配置不是 `model/runtime/repos/config` 形状。嵌套 `bot_template_config` 结构来自引擎/模板消费路径，公共 API 必须原样保留，不能擅自扁平化或包装。
+- 定义稳定错误码常量（放错误/响应层，不与内部异常名耦合）：
+  ```text
+  OPENAPI_BOT_TEMPLATE_INVALID          # 模板参数非法 / template_config 单传
+  OPENAPI_BOT_COMBINATION_UNSUPPORTED   # 引擎/部署/空间/服务化组合不支持
+  OPENAPI_APPLICATION_CODING_UNAVAILABLE # Workspace Hosting 未绑定或不可用
+  ```
+
+**测试**：
+- `template_type`/`template_config` 正常解析；
+- 外层未知字段仍被 `extra="forbid"` 拒绝；
+- 历史扁平字段与嵌套 `bot_template_config` 字段均原样保留；服务端字段（如 `dima_space_id`、`template_uid`）被拒；
+- 只传 `template_config` 不传 `template_type` 被拒；
+
+**不破坏常见逻辑的依据**：字段 `default=None`，不传不影响既有请求。
+
+---
+
+## Task 2：组合策略 + Workspace Hosting 绑定检查
+
+**目标**：applicationCoding 的组合校验收敛成一个纯函数；复用现有 Workspace Hosting 绑定检查。
+
+**文件**：
+- `src/backend/src/agentclaw/community/core/bot_inventory/policies/combo_policy.py`（组合校验）
+- `bot_management` 下复用 Workspace Hosting Service 的绑定检查
+
+**改动**：
+- 新增纯策略函数：
+  ```python
+  assert_application_coding_create(
+      *,
+      engine: str,
+      bot_type: str,
+      space_kind: SpaceKind,
+      deployment_mode: DeploymentMode,
+  ) -> ComboDecision
+  ```
+  规则：
+  - `engine == "claude_code"`；Application Coding 不是 `engine=aicoding` 的别名，后者作为既有 AI Coding 引擎单独使用；
+  - `bot_type == "personal"`；
+  - `space_kind == PERSONAL`；
+  - `deployment_mode == CLOUD`；
+  - 服务端模板校验器按历史 Application Coding 配置规则校验必要字段，不用“至少其一”作为通用兜底。
+  `space_kind` 必须来自 `BusinessSpaceContextProtocol.resolve_current()`，不能用 `bot_type` 推断个人空间；`deployment_mode` 必须来自现有后端部署/创建能力解析，不能由客户端新增字段绕过。
+- 复用现有 Workspace Hosting Service 的绑定检查，不新增独立的 capability probe protocol、探测任务或 Application Coding 专属运维 flag。
+  - 未绑定真实 hosting 实现时直接返回 503 `OPENAPI_APPLICATION_CODING_UNAVAILABLE`。
+  - 已绑定但创建 workspace 失败时，按创建失败处理并透出错误；不能通过吞异常或访问私有地址伪装成可用。
+  - hosting 的具体 client/URL 仍留在 core 的既有 service/adapter 边界内，不泄漏到 HTTP 契约。
+
+**测试**：§13.2 组合矩阵（通过/拒绝两向）+ `space_kind`/`deployment_mode` 真实值校验 + 未绑定 hosting 返回 503。
+
+---
+
+## Task 3：路由层 preflight（副作用之前 fail-closed）
+
+**目标**：所有校验发生在 passport 申请、insert、设备、workspace **之前**。
+
+**文件**：`src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py`
+
+**改动**：
+- 在现有 `if body.engine not in _get_engine_types()` / `validate_engine_cluster` / `_require_service_capable_engine` 之后，先调用 `resolve_current` 获取 `space_kind`，再执行 Application Coding preflight；所有副作用（Passport、insert、设备、workspace）之前完成：
+  ```python
+  if body.template_type == "applicationCoding":
+      # 组合校验（engine/bot_type/space_kind/deployment_mode）
+      # + 按历史配置校验器校验 template_config
+      # 组合不支持 → 409(error_code=OPENAPI_BOT_COMBINATION_UNSUPPORTED)
+      # hosting 未绑定/不可用 → 503(OPENAPI_APPLICATION_CODING_UNAVAILABLE)
+  elif body.template_type not in (None,):
+      # 不支持模板类型 → 422(error_code=OPENAPI_BOT_TEMPLATE_INVALID)（模板类型非法，对齐 §7.3，与组合 409 区分）
+  elif body.template_config is not None:
+      # 有 config 无 type → 422(OPENAPI_BOT_TEMPLATE_INVALID)
+  ```
+- `BotCreateSpec(...)` 并列增加 `template_type=body.template_type, template_config=to_internal_template_config(body.template_config)`，**不动** `entity_id`/`engine_type`/`space_id`。
+- `_complete_auth_status` 使用同一套 preflight；不能只在 POST 校验，不能让 echo 参数绕过空间/部署/模板策略。
+
+**测试**：端到端拒绝矩阵（§7.2）+ 普通 Bot `template_type=None` 回归。
+
+---
+
+## Task 4：202 异步授权参数透传（复用现有 echo 契约）
+
+**目标**：授权完成后模板参数不丢；不新增 create-intent 表，不改变现有授权状态契约。
+
+**关键事实（已核）**：当前 `auth-status` 轮询通过 query echo 重建 `BotCreateSpec`（`engine`/`bot_type`/`bot_name`/`bot_desc`/`space_id`），且 `BotAuthStatusPoll` 使用 `extra="forbid"`。当前没有 pending spec 持久化结构，本期继续沿用现有 echo 机制。
+
+**文件**：
+- `src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py`
+- `src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py`
+- `src/backend/src/agentclaw/community/core/bot_management/create_flow.py`
+- 相关 OpenAPI 授权流程测试
+
+**改动**：
+- `BotAuthStatusPoll` 增加可选 `template_type` / `template_config`，保持 `extra="forbid"`；
+- `auth-status` 使用与 POST 相同的模板 DTO 校验和 Application Coding 组合 preflight；
+- 将轮询请求中的模板字段转换为 `BotCreateSpec`，不改既有 `entity_id` / `engine_type` / `space_id` 解析；
+- 保留已有 `bot_id`、`space_id` 等 echo 字段，兼容现有客户端；
+- 本期不新增 `Idempotency-Key` 公共请求头，不把 response `request_id` 当作业务幂等键；
+- 不新增 create-intent 表，不新增 migration；
+- 授权失败或参数非法时不创建 Bot；普通 Bot 的现有授权行为保持不变。
+
+**已知边界（过渡态）**：本 Task 复用 `auth-status` echo（与 decision §8.2 一致），标注为**过渡态**——客户端丢失参数、服务重启后的 pending 意图恢复、并发 poll 的严格单写 claim 不在本期范围，后续若有要求再单独建设持久化 intent。
+
+**测试**：
+- POST 返回 202 后，auth-status 回传模板参数能够完成创建；
+- 模板配置较大或包含嵌套字段时不会在请求解析和 spec 转换中丢失；
+- `to_internal_template_config` 不改变历史扁平字段和 `bot_template_config` 嵌套层级；
+- 普通 Bot 老客户端仍可带 `space_id` 完成授权；
+- 重复 poll 不改变现有行为；
+- 授权失败不产生 Bot；
+- 模板字段非法或组合不支持时，在创建副作用前拒绝。
+
+---
+
+## Task 5：Application Coding 创建失败处理（复用现有存储）
+
+**目标**：不新增 workspace 资源表和通用创建 Saga；Application Coding 创建失败时不留下可用性错误的 Bot，沿用现有 Bot/template 存储完成必要清理；普通 Bot 路径不变。
+
+**文件**：
+- `src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py`
+- `src/backend/src/agentclaw/community/core/bot_management/create_flow.py`
+- `src/backend/src/agentclaw/community/core/bot_management/services/aicoding/workspace_hosting_service.py`
+- 相关 workspace / create_flow / bot_service 测试
+
+**改动**：
+- Application Coding 的 workspace 创建失败必须作为创建失败返回，不能继续创建一个没有 workspace 的 Bot；
+- 在现有 `create_bot` 失败路径中，按已有能力清理已插入的 Bot、模板记录、设备和 Passport；不改普通 Bot 的创建顺序和异常语义；不承诺为本期新增全量原子补偿；
+- workspace 创建成功后，继续将 `dima_space_id` 写入现有 `ac_templates.ext`；
+- workspace 创建失败但远端结果不确定时，本期记录 request_id 和错误日志，由调用方重试或人工补救；不新增 UNKNOWN 资源表和后台 reconcile；
+- 现有 `ensure_hosted_workspace()` 继续作为历史 Bot 的手动补救入口；新建链路不调用该补救 API。
+
+**明确不做**：
+- 不新增 `create_intent` 表；
+- 不新增 `hosted_workspace_resource` 表；
+- 不新增 CreationCompensationService；
+- 不新增 cleanup pending 状态机和 reconcile 任务；
+- 不引入 Application Coding 专属 `Idempotency-Key` 必填契约。
+
+**已知边界（明确 defer）**：owner relationship 写失败导致的「Bot 已建但 owner 关系缺失」孤儿，本期**不修**——仅验证其失败显式报错、不误报成功，压后续与 intent 持久化一并处理；workspace「超时但远端已成功」的孤儿同样走记录 request_id/日志 + 重试/人工补救，不引入 reconcile。
+
+**测试**：
+- workspace 返回失败和抛异常时，创建失败且不返回成功 Bot；
+- device 失败时，已创建的 Bot/template 按现有失败路径清理；
+- owner relationship 失败时，验证现有错误处理，不把失败误报为成功；
+- 普通 Bot 回归不变。
+
+## Task 6：ready 语义——现状已实现，仅补测试
+
+**目标**：确认 `READY` 经 `status` 暴露、不新增 `auth-status` 状态；**不改 `readiness.py`**。
+
+**关键事实（已核）**：`readiness.py:is_bot_ready(52-84)` **已完整实现** decision §10 语义：
+- `needs_repos = template_type == "applicationCoding" and active_engine in ("aicoding","claude_code")`；
+- `ext.start_status == "SUCCEEDED"` 才视为成功；
+- 历史无 marker 但 binding 已 ACTIVE 的兼容放行（`missing_marker_on_active_binding`）；
+- 非 application bot 忽略 start_status（保留既有行为）。
+
+**改动**：**本 Task 无生产代码改动**，仅补测试断言：
+- `READY` ≡ `is_ready==true`（`status==ACTIVE && binding==ACTIVE && start_status==SUCCEEDED`）；
+- ready 不早于 workspace 初始化完成（`start_status` 尚未 `SUCCEEDED` 时不 ready）；
+- 历史无 marker + binding ACTIVE 兼容放行；显式 `PENDING`/`FAILED` 仍阻塞。
+- 若 `GET /bots/{id}/status` 尚未复用 `is_bot_ready`，则该处接线为小改动单独核，**不应重写 readiness 逻辑**。
+
+**测试**：ready 语义 + 历史兼容。
+
+---
+
+## Task 7：applicationCoding 删除清理 hosted workspace（补齐现有 hosting 删除能力）
+
+**目标**：非服务 applicationCoding Bot 删除时回收 hosted workspace；复用 `ac_templates.ext.dima_space_id`，不新增 workspace 资源表；普通 Bot 删除路径不变。
+
+**文件**：
+- `src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py`（`delete_bot`）
+- `src/backend/src/agentclaw/community/core/bot_management/services/aicoding/workspace_hosting_service.py`
+- `src/backend/src/agentclaw/community/core/bot_management/services/aicoding/workspace_hosting_client.py`（如当前 client 尚无删除方法）
+
+**关键事实（已核）**：现状 `delete_bot` 只做 owner 校验、最早 Bot 保护、设备/Passport 清理和 Bot soft-delete，不调用 workspace hosting 清理。workspace ID 当前保存在 `ac_templates.ext.dima_space_id`。
+
+**改动**：在 `delete_bot` 的**非服务**删除分支，对 `template_type == "applicationCoding"`：
+1. 校验调用方权限；
+2. 读取现有模板配置中的 `dima_space_id`；
+3. 先通过 Workspace Hosting Service/Client 调用 workspace 删除能力（如当前 client 尚未提供，则补齐该薄封装；明确“不存在”视为已删除）；
+4. workspace 删除失败或结果不确定时返回错误，不继续报告 Bot 删除成功；
+5. workspace 删除成功后，沿用现有模板、设备和 Bot 删除逻辑。若后续既有删除步骤失败，允许 Bot 暂时保留并通过重试处理；不新增跨资源补偿状态。
+
+- 普通 Bot（`template_type is None` / 非 applicationCoding）删除路径完全不变；
+- 服务 Bot 仍走发布生命周期，普通 DELETE 不得绕过 `RELEASED` / `UPGRADED` 历史检查；
+- 本期不新增 `DELETING` / `DELETE_PENDING_CLEANUP` / `DELETED` 资源状态和后台 reconcile；未能确认 workspace 删除结果时由接口返回失败，后续通过重试或现有人工补救处理。
+
+**测试**：
+- 非服务 applicationCoding 删除会读取并清理 `dima_space_id`；
+- workspace 不存在时删除幂等；删除能力只补齐现有 hosting client/service，不新增资源表；
+- workspace 清理失败时不返回删除成功；
+- 服务 Bot 普通删除仍被拒绝；
+- `RELEASED`、`UPGRADED` 历史不会被普通删除误删；
+- 普通 Bot 删除行为不变。
+
+**不破坏常见逻辑的依据**：仅 applicationCoding 且非服务分支增加 workspace 清理，普通 Bot 删除逻辑不动。
+
+## Task 8：回归与收口
+
+**目标**：证明「原有常见逻辑不变」。
+
+- **改前改后语义兼容对比**：`template_type` 未传的创建请求，断言**语义等价**（业务字段/状态/engine 值/副作用一致）；新增可选字段（`template_type=null`/`template_config=null`）的序列化差异**不做逐字节比对**，避免误报。
+- **runtime 路由基线**（§13.5）：`claude_code + applicationCoding` 仍命中 `aicoding` adapter、`claude_code + normalCC/空` 仍命中 `claude_code` adapter。
+- 全量模块测试：`bots` 端点、`create_flow`、`bot_service`、`readiness`、`combo_policy`、workspace hosting。
+- 更新契约文档 + 上下文边界元数据；同步 `errors.py`/`responses.py`/路由 responses 与 OpenAPI schema；若触及架构边界，同步架构测试（不只改 Python schema）。
+
+---
+
+## 实施顺序与依赖
+
+```
+Task 1 (契约/错误响应) ─┬─> Task 3 (resolve + preflight)
+                         │
+Task 2 (策略/hosting 绑定检查) ─┘
+Task 4 (授权参数透传) ─> Task 5 (创建失败处理) ─> Task 6 (ready)
+Task 5 ─> Task 7 (删除 workspace) ─> Task 8 (回归)
+```
+
+- Task 1/2 可并行；Task 3 必须等待 Task 2 明确 `space_kind/deployment_mode` 与现有 hosting service 的绑定检查入口。
+- Task 4 必须在 Task 1 确定 auth-status 模板字段兼容规则后实施。
+- Task 5 依赖 Task 2 的 hosting 绑定检查；Task 7 复用现有模板配置中的 `dima_space_id`，不依赖新资源表。
+- Task 8 必须在 Task 1–7 全部完成后做基线对比。
+
+---
+
+## 风险与回滚
+
+- **Hosting 依赖**：未绑定真实 Workspace Hosting → 创建前 503（`OPENAPI_APPLICATION_CODING_UNAVAILABLE`）；不新增 Application Coding 专属 flag/probe 基础设施。组合不支持仍返回 409。
+- **向后兼容**：未传 `template_type`/`template_config` 的请求行为不变；新增字段 `default=None`。
+- **异步参数透传**：模板参数依赖 auth-status echo，客户端未回传时拒绝创建，不静默创建普通 Bot。
+- **workspace 不确定结果**：本期通过错误返回、request_id 日志和重试处理，不引入后台 reconcile。
+
+---
+
+## 验收清单（对照方案 §17）
+
+- [x] `template_type`/`template_config` 可经 OpenAPI 提交，未知字段仍拒。
+- [x] `applicationCoding + 云端 + 个人 + 非服务` 的前置准入链路已实现。
+- [x] 本地/服务/团队/非 Coding 引擎的 applicationCoding 全部后端拒绝（非前端隐藏）。
+- [x] Workspace Hosting 未绑定 → 创建前 503；前置检查不触发 Passport/Bot/设备/workspace。
+- [x] 202 授权完成后模板参数透传；POST auth-status 使用同一套校验。
+- [x] Application Coding workspace/template 创建失败不返回成功 Bot；已有清理路径按现状执行，不承诺本期全量原子补偿。
+- [x] 不新增 create-intent / hosted-workspace 表，不新增 reconcile。
+- [x] `READY` 经 `status` 暴露，不与 `auth-status` 混契约。
+- [ ] 非服务 applicationCoding 删除后无 hosted workspace 残留（Task 7 Blocked，等待 DIMA delete contract）。
+- [x] 普通 Bot / `claude_code` / `aicoding` / 服务化创建行为已完成相关回归测试。

--- a/docs/superpowers/plans/2026-08-24-openapi-application-coding-implementation-plan.md
+++ b/docs/superpowers/plans/2026-08-24-openapi-application-coding-implementation-plan.md
@@ -151,6 +151,7 @@ old_template = {
 - 本期不新增 `Idempotency-Key` 公共请求头，不把 response `request_id` 当作业务幂等键；
 - 不新增 create-intent 表，不新增 migration；
 - 授权失败或参数非法时不创建 Bot；普通 Bot 的现有授权行为保持不变。
+- **GET / POST 契约**：Application Coding 的模板透传只在 **POST** `/{bot_id}/auth-status`；已退休的 **GET** 同路径**仅兼容普通 Bot**（无模板参数，用它轮询 Application Coding 会静默创建普通 Bot，不支持）。已在 `deprecated/auth_status.py` 的 GET docstring 中标注。
 
 **已知边界（过渡态）**：本 Task 复用 `auth-status` echo（与 decision §8.2 一致），标注为**过渡态**——客户端丢失参数、服务重启后的 pending 意图恢复、并发 poll 的严格单写 claim 不在本期范围，后续若有要求再单独建设持久化 intent。
 

--- a/docs/superpowers/specs/2026-08-24-openapi-application-coding-decision.md
+++ b/docs/superpowers/specs/2026-08-24-openapi-application-coding-decision.md
@@ -1,0 +1,748 @@
+# OpenAPI Application Coding Bot 支持方案与决策
+
+- **日期**：2026-08-24
+- **状态**：已决策，部分实施（Task 7 Blocked）
+- **范围**：OpenAPI 创建云端 Bot，重点覆盖 `Claudecode-应用 coding`
+- **不在本次范围**：直接修改代码、开放服务 Bot 的 Application Coding、开放本地 Application Coding
+- **实施进度**：Task 1–6、Task 8 已实施并通过当前回归测试；Task 7“删除 hosted workspace”等待 corp-only DIMA delete contract。
+- **Task 7 前置契约**：需明确 HTTP/RPC 类型、endpoint/RPC 方法、workspace_id 参数位置、鉴权、成功/不存在/超时语义、幂等删除语义和 request_id 透传方式；契约缺失期间不实现猜测性的删除调用。
+
+## 1. 决策摘要
+
+### 1.1 最终决策
+
+**支持 Application Coding，但第一期仅开放“云端 + 个人空间 + 非服务 Bot”组合。**
+
+对外不新增 `claudecode-app` 这样的独立引擎值，而是沿用现有引擎字段，并通过模板字段表达 Coding 模式：
+
+```text
+engine = claude_code
+template_type = applicationCoding
+```
+
+其中：
+
+- `engine` 表示 Bot 的引擎/runtime 维度；Application Coding 第一期固定使用 `claude_code` 作为对外 engine 值；
+- `template_type` 表示 Coding Bot 的业务模板/运行模式；
+- `applicationCoding` 不是新的引擎类型；
+- `claude_code + applicationCoding` 按历史逻辑路由到 `aicoding` adapter，但 Bot 数据中的调用方 `engine` 值仍保留为 `claude_code`。
+
+OpenAPI 只有在 Workspace Hosting 已完成真实绑定并通过能力检查后，才允许创建 `applicationCoding` Bot。若当前部署没有 Workspace Hosting 能力，必须在创建前失败，不能先创建 Bot、Passport 或设备后再失败。
+
+### 1.2 第一期支持矩阵
+
+| 组合 | 是否开放 | 说明 |
+| --- | :---: | --- |
+| `claude_code` + 云端 + 个人 + 非服务 | ✅ | 现有能力，继续支持 |
+| `claude_code` + 云端 + 团队 + 非服务 | ✅ | 是否开放由现有空间权限控制 |
+| `claude_code` + 本地 + 个人 + 非服务 | ✅ | 现有能力，继续支持 |
+| `claude_code` + 云端 + 服务 | ✅ | 现有服务化策略支持 |
+| `aicoding` + 云端 + 个人 + 非服务 | ✅ | 当前引擎组合策略支持 |
+| `aicoding` + 本地 + 非服务 | ❌ | 当前本地能力策略拒绝 |
+| `aicoding` + 云端 + 服务 | ❌ | 当前服务化能力策略拒绝 |
+| `applicationCoding` + 云端 + 个人 + 非服务 | ✅ | 第一期新增 OpenAPI 能力，依赖 Workspace Hosting |
+| `applicationCoding` + 云端 + 团队 + 非服务 | ❌ | 第一期收窄到个人空间，避免团队 workspace/协作语义未定义 |
+| `applicationCoding` + 云端 + 服务 | ❌ | 服务生命周期、发布资源和多实例语义尚未完成 |
+| `applicationCoding` + 本地 | ❌ | 本地没有对应的 hosted workspace 运行链路 |
+
+## 2. 背景与问题
+
+当前 OpenAPI `POST /openapi/v1/bots` 的创建契约只接收以下字段：
+
+```text
+bot_name
+bot_desc
+engine
+cluster_name
+bot_type
+space_id
+```
+
+请求模型配置了 `extra="forbid"`，因此以下字段会被拒绝：
+
+```text
+template_type
+template_key
+template_uid
+template_config
+engine_options
+```
+
+这导致一个重要的不一致：后端内部创建链路已经能够表达模板创建，但 OpenAPI 公共契约无法提交 Application Coding 所需的信息。
+
+因此，当前问题不是简单地把前端选项显示出来，而是需要同时补齐：
+
+1. OpenAPI 请求契约；
+2. 创建授权异步流程中的参数保存与恢复；
+3. Workspace Hosting/DIMA 前置能力检查；
+4. Application Coding 的 ready 语义；
+5. 组合约束和回归测试。
+
+## 3. 历史逻辑依据
+
+### 3.1 Application Coding 历史上不是独立引擎
+
+历史提交 `5f35d8f8d feat(baas): route claude_code active-engine to aicoding adapter by template_type (#1056)` 已经形成了以下路由规则：
+
+```text
+engine = claude_code 且 template_type 为空或 normalCC
+    → claude_code adapter
+
+engine = claude_code 且 template_type 为其他 Coding 模板
+    → aicoding adapter
+
+其他 engine
+    → 按各自引擎逻辑处理
+```
+
+因此，Application Coding 的正确表达方式是“引擎 + 模板”的组合，而不是新增一个 `claudecode-app` 引擎。
+
+新增独立引擎会把模板维度错误提升为引擎维度，进而要求重复改造：
+
+- 引擎注册与组合策略；
+- BaaS/运行时路由；
+- Skill/MCP 能力挂载；
+- 服务化判定；
+- 健康检查；
+- 资源和 workspace 管理；
+- 版本及发布逻辑。
+
+### 3.2 Coding workspace 能力已被抽象，但仍有部署前置条件
+
+历史提交 `5a55cfd12 feat: allow coding bots to ensure DIMA workspace` 将 workspace 初始化能力从只处理 `applicationCoding` 扩展为 Coding Bot 通用能力，覆盖：
+
+- `applicationCoding`；
+- `aicoding`；
+- `claude_code`。
+
+这证明 workspace hosting 是 Coding Bot 创建链路的一部分，但不等于所有环境都已经具备该能力。当前社区实现中，`WorkspaceHostingService` 没有默认绑定，相关部署必须显式提供真实实现。
+
+结论：**不能因为内部 Service 已有接口，就直接宣称 OpenAPI 已完整支持 Application Coding。**
+
+### 3.3 服务 Bot 删除逻辑不应被本次创建改造带偏
+
+服务 Bot 的删除仍然必须遵循发布生命周期，而不是走普通 Bot 删除：
+
+- 草稿且没有成功发布历史时，可以真正删除；
+- `RELEASED`、`UPGRADED` 都属于正式发布历史；
+- 下线后生成的新草稿不能仅根据当前草稿状态删除整个源 Bot；
+- 有正式发布历史时，应通过服务发布生命周期判断删除资格并清理资源；
+- OpenAPI 普通删除接口对服务 Bot 应保持拒绝，避免绕过发布记录、预发资源和线上资源清理。
+
+这部分是既有生命周期约束，与本次 Application Coding 创建能力独立。Application Coding 第一期不开放服务化，因此不会新增 Application Coding 服务 Bot 删除分支。
+
+## 4. `aicoding` 与 `applicationCoding` 的定义
+
+| 维度 | `aicoding` | `applicationCoding` |
+| --- | --- | --- |
+| 所属维度 | 引擎/runtime | 模板/业务模式 |
+| 对外表达 | `engine=aicoding` | `template_type=applicationCoding` |
+| 是否可以单独出现 | 可以作为云端非服务引擎使用 | 不应脱离 Coding 引擎单独出现 |
+| 主要语义 | AI Coding 运行时能力 | 面向应用开发的模板化工作区能力 |
+| workspace | 依赖 Coding workspace 能力 | 必须依赖 Workspace Hosting/DIMA workspace |
+| 当前服务化 | 不支持 | 第一期不支持 |
+| 当前本地创建 | 不支持 | 不支持 |
+
+必须避免把两者混成一个枚举：
+
+```text
+错误：engine = claudecode-app
+正确：engine = claude_code + template_type = applicationCoding
+```
+
+## 5. 当前代码能力盘点
+
+### 5.1 OpenAPI 层
+
+当前 `BotCreate` 仅允许基础字段，且 `extra="forbid"`。创建前已经存在以下校验：
+
+- 引擎是否在支持列表中；
+- 引擎与集群是否匹配；
+- 服务 Bot 是否使用可服务化引擎；
+- 通过授权后进入统一创建流程。
+
+缺口是：OpenAPI 没有接收并传递 `template_type` 与 `template_config`。
+
+### 5.2 内部创建层
+
+`BotCreateSpec` 已经包含：
+
+```python
+template_type: str | None
+template_config: dict[str, Any] | None
+extra_properties: dict[str, Any]
+```
+
+`BotService.create_bot()` 已经能够：
+
+- 持久化 `template_type`；
+- 在模板参数完整时创建模板记录；
+- 对 `applicationCoding` 调用 Workspace Hosting 创建 workspace；
+- 继续执行设备分配、模板配置透传、记忆初始化等流程。
+
+因此本次改造重点是公共契约、参数完整性和能力前置检查，而不是重新设计内部 Bot 创建服务。
+
+### 5.3 引擎组合层
+
+当前实际组合策略为：
+
+```text
+本地可用：openclaw、claude_code
+个人云端可用：全部已注册引擎
+服务可用：openclaw、claude_code、teclaw
+```
+
+所以：
+
+- `aicoding`：云端非服务可用，本地和服务不可用；
+- `claude_code`：云端、本地、服务可用；
+- `applicationCoding`：不能仅根据 `engine` 判断，必须联合模板、部署方式、空间和服务化属性校验。
+
+## 6. OpenAPI 契约设计
+
+### 6.1 推荐方案：最小兼容扩展
+
+在 `POST /openapi/v1/bots` 的请求体增加两个可选字段：
+
+```json
+{
+  "bot_name": "my-app-coding-bot",
+  "bot_desc": "application coding bot",
+  "engine": "claude_code",
+  "cluster_name": "ACRA",
+  "bot_type": "personal",
+  "space_id": "personal-space-id",
+  "template_type": "applicationCoding",
+  "template_config": {
+    "devflow_workflow": "app-flow",
+    "yuque_kb_repos": [],
+    "code_repos": [],
+    "token": "caller-supplied-business-token",
+    "bot_template_config": {
+      "preset_capabilities": {},
+      "ext_config": {"thetaKey": "caller-supplied-business-value"}
+    }
+  }
+}
+```
+
+内部转换为：
+
+```python
+BotCreateSpec(
+    entity_id=owner_id,
+    engine_type=body.engine,
+    bot_type=body.bot_type,
+    bot_name=body.bot_name,
+    bot_desc=body.bot_desc,
+    space_id=current_space.numeric_id,
+    template_type=body.template_type,
+    template_config=body.template_config,
+)
+```
+
+> **转换说明**：`owner_id` 来自 `UserIdDep`（已验证调用者）；`current_space = space_context.resolve_current(owner_id=owner_id, header_space_id=body.space_id)`。
+> `cluster_name` **不在 `BotCreateSpec` 上** —— 它仅在请求期做 `validate_engine_cluster(body.engine, body.cluster_name)` 校验，不进入创建 spec。
+> `space_id` 在 `BotCreateSpec` 上是 `int | None`（numeric id，个人空间时为 `None`），必须经 `resolve_current` 解析，不能用 `body.space_id` 这个 `str | None` 直传。
+> 新增的 `template_type`/`template_config` 与既有字段并列即可，不改变 `entity_id`/`engine_type`/`space_id` 的既有解析路径。
+
+### 6.2 `template_config` 不做猜测性强 DTO
+
+历史 Application Coding 的真实 fixture 位于
+`src/backend/tests/community/acceptance/bot_management/test_bot_live_lifecycle.py`：
+
+```python
+{
+    "devflow_workflow": "old-flow",
+    "yuque_kb_repos": [],
+    "code_repos": [],
+    "token": "old-token",
+}
+```
+
+同时，引擎/模板消费路径会读取如下嵌套结构：
+
+```python
+{
+    "bot_template_config": {
+        "preset_capabilities": {...},
+        "ext_config": {"thetaKey": "..."},
+    }
+}
+```
+
+这说明 `template_config` 是历史兼容的自由字典，而不是可以抽象成
+`model/runtime/repos/config` 的稳定 DTO。第一期采用受控薄透传：
+
+```python
+template_config: dict[str, Any] | None
+```
+
+边界规则：
+
+- 只接受 JSON object；不做字段重命名、扁平化或自动包装；
+- `to_internal_template_config()` 只做深拷贝/JSON 归一化，保证上述扁平和嵌套结构原样进入内部 `BotCreateSpec`；
+- 拒绝客户端写入服务端字段：顶层 `dima_space_id`、`template_uid`、Bot ID、workspace 状态字段；
+- `template_key` 不作为本期公共字段单独定义；模板身份由既有 resolver/服务端逻辑决定；
+- 其余字段由既有 Application Coding/模板校验器解释，校验失败返回 `OPENAPI_BOT_TEMPLATE_INVALID`，未知业务字段不得被静默丢弃。
+
+这不是放弃校验，而是把校验放在真实拥有字段语义的历史校验器中，避免公共层制造第二套不一致的 schema。后续若要开放稳定模板工厂契约，应另立版本化 DTO，不在本期混入 legacy Application Coding。
+
+### 6.3 普通 Bot 的兼容行为
+
+当 `template_type` 未传时：
+
+- 按现有普通 Bot 流程创建；
+- `template_config` 不应单独传入；
+- 若只传 `template_config` 而未传 `template_type`，请求应被拒绝，而不是静默忽略配置。
+
+当前仅允许的模板类型：
+
+```text
+无模板（普通 Bot）
+applicationCoding
+```
+
+其他模板类型第一期拒绝，并返回明确的“不支持模板类型”错误。
+
+## 7. 创建前校验规则
+
+所有组合和依赖校验必须发生在以下副作用之前：
+
+- Passport 授权申请；
+- Bot 落库；
+- 设备分配；
+- workspace 创建；
+- 模板记录创建。
+
+### 7.1 Application Coding 校验
+
+当：
+
+```text
+template_type = applicationCoding
+```
+
+必须同时满足：
+
+```text
+source = cloud
+bot_type = personal
+engine = claude_code
+服务化 = false
+template_config 存在且为 JSON object
+template_config 通过历史 Application Coding 配置校验
+WorkspaceHostingService 已绑定且可用
+```
+
+其中 `source` 由创建端点决定——`POST /openapi/v1/bots` 即 cloud（本地走 `POST /openapi/v1/bots/local`），不应由调用方通过不受控的额外字段绕过组合策略。`cluster_name` 是引擎集群（ANDC/ACRA）判定，只在请求期 `validate_engine_cluster` 使用、不进入 `BotCreateSpec`，与 source（cloud/local）无关。
+
+### 7.2 拒绝场景
+
+| 请求 | 结果 |
+| --- | --- |
+| `template_type=applicationCoding` + 本地 | 拒绝，组合不支持 |
+| `template_type=applicationCoding` + 服务 Bot | 拒绝，服务生命周期未支持 |
+| `template_type=applicationCoding` + 团队空间 | 第一期拒绝，先收敛到个人空间 |
+| `template_type=applicationCoding` + 非 Coding 引擎 | 拒绝，模板与引擎不兼容 |
+| `template_type` 未传但传 `template_config` | 拒绝，参数关系非法 |
+| 未配置 Workspace Hosting | 创建前拒绝，不产生副作用 |
+| 不支持的 `template_type` | 拒绝 |
+
+### 7.3 错误语义
+
+建议区分：
+
+- **400/422**：请求字段缺失、格式错误、模板配置非法；
+- **409**：引擎、部署方式、空间或服务化组合不支持；
+- **503**：当前环境未启用 Workspace Hosting，暂时无法创建 Application Coding。
+
+错误响应应包含稳定的错误码，例如：
+
+```text
+OPENAPI_BOT_TEMPLATE_INVALID
+OPENAPI_BOT_COMBINATION_UNSUPPORTED
+OPENAPI_APPLICATION_CODING_UNAVAILABLE
+```
+
+不要返回内部依赖名称、堆栈或私有服务地址。
+
+## 8. 202 异步授权流程
+
+当前创建接口可能返回：
+
+```http
+202 Accepted
+```
+
+这意味着不能只修改 POST 请求模型，否则授权完成后可能丢失模板参数。
+
+### 8.1 必须保证的参数链路
+
+```text
+POST /openapi/v1/bots
+  → 生成授权申请
+  → 用户完成 Passport 授权
+  → auth-status 查询并回传模板参数
+  → ISSUED 后恢复完整 BotCreateSpec
+  → 创建 Bot
+```
+
+`auth-status` 需要能够恢复以下字段：
+
+```text
+bot_name
+bot_desc
+engine_type
+bot_type
+space_id
+template_type
+template_config
+```
+
+其中 `engine_type` 是 `body.engine` 解析后的内部字段，`space_id` 仍保存 `resolve_current` 得到的 numeric id（`int | None`）。`cluster_name` 只在 POST 请求期做 `validate_engine_cluster` 校验，不进入异步恢复参数。
+
+### 8.2 推荐实现
+
+本期不新增 `create_intent` 表，继续复用现有 `auth-status` echo 流程：
+
+- `BotAuthStatusPoll` 增加可选的 `template_type` / `template_config` 字段；
+- `auth-status` 根据轮询请求恢复完整 `BotCreateSpec`；
+- POST 和 auth-status 使用同一套模板 DTO、组合校验和 Workspace Hosting 绑定检查；
+- 保留现有 `bot_id`、`space_id` 等字段，兼容已有客户端；
+- 普通 Bot 的授权流程和字段行为不变。
+
+该方案的边界是：模板参数仍由客户端在 auth-status 中回传，不保证服务重启后的 pending 意图恢复，也不新增并发 claim 机制。若后续需要跨进程恢复、严格并发幂等或审计，再单独建设持久化 intent。
+
+### 8.3 幂等要求
+
+本期不新增 `Idempotency-Key` 公共请求头。继续沿用现有 `bot_id`、Passport 授权状态和创建逻辑处理重复查询；严格的跨请求幂等、创建意图持久化和并发 claim 不在本期范围。
+
+如果后续新增 `Idempotency-Key`，需要另行更新公共 OpenAPI 契约、错误码、客户端接入文档和兼容性评估，不能只在实现计划中增加。
+
+## 9. Workspace Hosting 与 DIMA 前置条件
+
+Application Coding 的核心资源不是普通 Bot 记录，而是一个由 Workspace Hosting 管理的开发工作区。
+
+创建链路沿用现有存储和调用方式：
+
+```text
+校验模板配置
+  → 确认 Workspace Hosting 已绑定
+  → 进入现有 `create_bot` 链路（不重排普通 Bot 的既有顺序）
+  → 在 Application Coding 分支创建/关联 hosted workspace
+  → 将 workspace 标识写入现有 `ac_templates.ext.dima_space_id`
+  → 完成 Bot 与模板记录
+```
+
+本期不新增独立的 `hosted_workspace_resource` 表，`ac_templates.ext.dima_space_id` 继续作为已创建 workspace 的关联记录。workspace 创建接口需要提供明确的成功/失败结果；如果远端调用超时且结果不确定，本期返回失败并记录 request_id，交由调用方重试或现有人工补救流程处理，不引入后台 reconcile。
+
+如果 hosted workspace 创建失败：
+
+- 整体创建失败；
+- 不返回成功的 Bot 创建结果；
+- 不允许留下没有可用 workspace 的 Application Coding Bot；
+- 记录可检索的失败原因和 request_id；
+- 对已有清理路径覆盖到的 Bot、模板和设备按现有逻辑清理；不承诺本期为所有部分成功场景增加原子补偿；
+- workspace 已创建但本地模板持久化失败时记录 request_id 和 workspace_id，返回失败并支持人工补救。
+
+社区部署未绑定 Workspace Hosting 时，必须 fail closed。不能用空实现伪装成成功，也不能依赖调用方自行补写 DIMA workspace id。
+
+### 9.1 与现有 `create_bot` 顺序的取舍
+
+`bot_service.create_bot` 现状是先落库 Bot，再创建 workspace/template，再分配设备。本期不重排普通 Bot 的公共创建顺序，避免影响现有 `claude_code`、`aicoding` 和服务化路径。
+
+Application Coding 通过两点保证失败语义：
+
+- router preflight 在 Passport 之前复用现有 hosting 绑定检查；
+- `create_bot` 内 workspace 创建失败时，Application Coding 分支直接失败，不允许返回一个没有 workspace 的成功 Bot；已存在的局部清理按现有路径执行，不新增通用补偿编排。
+
+普通 Bot（未传 `template_type`）不调用 workspace hosting，路径保持不变。
+
+## 10. Ready 语义与对外可用性
+
+Application Coding 不是 workspace 创建成功就立即可用。还需要等待仓库初始化/`.repos/` clone 等异步动作完成。
+
+因此：
+
+```text
+binding.status = ACTIVE
+```
+
+不一定代表 Application Coding 已可对话或可执行任务。
+
+对 Application Coding 应同时检查：
+
+```text
+binding.status == ACTIVE
+ext.start_status == SUCCEEDED
+```
+
+兼容历史数据时：
+
+- 显式 `PENDING`/`FAILED` 仍然阻塞；
+- 老数据没有 `start_status` marker，但 binding 已 ACTIVE 时，可按兼容规则放行；
+- 新创建的 Application Coding 必须写入明确的 start marker，避免新旧数据语义混用。
+
+建议 OpenAPI 的异步状态中区分：
+
+```text
+AUTHORIZED
+CREATING
+WORKSPACE_PREPARING
+READY
+FAILED
+```
+
+只有 `READY` 才表示调用方可以继续使用 Application Coding Bot。
+
+### 10.1 状态暴露点与契约兼容
+
+为不破坏现有 `POST /{bot_id}/auth-status` 返回 `PENDING`/`ISSUED` 的契约（外部 tenant 已依赖），上面 `AUTHORIZED/CREATING/WORKSPACE_PREPARING/READY/FAILED` 是**内部概念状态机**，对外只通过 `GET /openapi/v1/bots/{bot_id}/status` 暴露 `READY`：
+
+- `auth-status` 仍只回 `PENDING`/`ISSUED`：`ISSUED` 触发 `create_bot` 落库返回 `bot status=PENDING`，**不新增** `WORKSPACE_PREPARING` 之类中间态到 `auth-status`；
+- applicationCoding bot 落库后 workspace 仍在 prepare，这段“未就绪”由 `GET /bots/{id}/status` 的 `is_ready` 表达（复用 `is_bot_ready`：`binding.status==ACTIVE` 且 `ext.start_status==SUCCEEDED` 才为 `true`）；
+- `READY` 对等于 `is_ready==true`，不向 `BotAuthStatus` 新增对外状态枚举；
+- 历史 applicationCoding 数据按 §10 兼容规则放行（binding 已 ACTIVE 但无 start_status marker）。
+
+即：创建进度查询走 `auth-status`（到 `ISSUED` 为止），就绪查询走 `status`，两者不混入彼此契约。
+
+## 11. 服务化、本地、更新和删除边界
+
+### 11.1 服务化
+
+第一期不开放：
+
+```text
+applicationCoding + service
+```
+
+原因：
+
+- 当前 `aicoding` 不在服务化引擎集合中；
+- Application Coding 的 workspace 与服务 Bot 发布版本如何绑定尚未定义；
+- 预发、线上、回滚、多实例、容器回收、健康检查的资源语义尚未定义；
+- 下线后 workspace 是否保留、冻结或销毁也没有稳定契约。
+
+因此不能仅在前端隐藏服务化按钮；后端组合策略也必须拒绝该组合。
+
+### 11.2 本地
+
+第一期不开放本地 Application Coding：
+
+- 本地没有 Workspace Hosting/DIMA 的对应托管链路；
+- 本地资源目录与 hosted workspace 的生命周期不同；
+- 当前组合策略已经拒绝 `aicoding` 本地；
+- 不能通过修改前端枚举绕过后端拒绝。
+
+### 11.3 更新
+
+第一期支持：
+
+- 更新普通 Bot 基础信息，沿用现有规则；
+- Application Coding 模板配置更新必须经过模板校验；
+- workspace/repository 变更应由 Workspace Hosting 负责，不允许 OpenAPI 直接写内部路径；
+- 更新失败不得覆盖原有可用配置。
+
+第一期不支持：
+
+- 将普通 Bot 在线转换为 Application Coding；
+- 将 Application Coding 转换为普通 Bot；
+- 将 Application Coding 迁移为服务 Bot。
+
+如需转换，采用新建 Bot + 迁移业务数据的显式流程，不在本次 OpenAPI 更新接口中隐式完成。
+
+### 11.4 删除
+
+Application Coding 非服务 Bot 继续沿用非服务 Bot 删除逻辑，但删除前必须处理现有模板配置中的 hosted workspace：
+
+1. 校验调用方权限；
+2. 从 `ac_templates.ext` 读取 `dima_space_id`；
+3. 先通过 Workspace Hosting Service/Client 删除或回收 hosted workspace；如果当前 client 尚无对应方法，只补齐该现有 service 的删除薄封装，不新增资源表；
+4. workspace 删除成功（或明确不存在）后，沿用现有模板绑定、设备和 Bot 删除逻辑；
+5. workspace 删除失败或结果不确定时返回错误，不得静默返回成功。
+
+本期不新增 `DELETING`、`DELETE_PENDING_CLEANUP`、`DELETED` 资源状态，不新增 workspace reconcile。由于没有状态表或 Saga，删除不提供跨远端 workspace、Bot、设备和 Passport 的原子一致性：若 workspace 已删除而后续既有 Bot 删除步骤失败，Bot 可能暂时保留但可重试；该边界必须记录日志并在实现/验收中明确。
+
+服务 Bot 删除仍必须走发布生命周期服务。即使未来开放 Application Coding 服务化，也不能复用普通 `DELETE /bots/{id}` 绕过 `RELEASED`/`UPGRADED` 历史检查。
+
+## 12. 前端展示边界
+
+OpenAPI 是公共服务契约，前端工作台的枚举不能作为唯一控制面。
+
+前端应根据后端能力矩阵展示：
+
+- `Claudecode-原生`：按现有云端、本地、服务能力展示；
+- `Claudecode-AIcoding`：仅云端非服务；
+- `Claudecode-应用 coding`：第一期仅云端个人非服务；
+- 本地 Application Coding、服务 Application Coding：不展示且后端同步拒绝。
+
+前端隐藏只是用户体验优化，真正的安全边界必须在后端：
+
+```text
+前端过滤 ≠ 能力授权
+后端组合策略 + 依赖能力检查 = 最终准入
+```
+
+## 13. 测试计划
+
+### 13.1 契约测试
+
+覆盖：
+
+- `template_type`/`template_config` 正常解析；
+- 未知字段仍被拒绝；
+- `template_config` 单独传入被拒绝；
+- `template_config` 中的历史扁平字段和 `bot_template_config` 嵌套字段原样透传；
+- `dima_space_id`、`template_uid` 等服务端字段被拒绝；
+- 不支持模板类型被拒绝；
+- OpenAPI 文档/schema 与实际请求一致。
+
+### 13.2 组合策略测试
+
+至少覆盖：
+
+| 场景 | 预期 |
+| --- | --- |
+| `claude_code` + applicationCoding + 云端个人非服务 | 通过 |
+| `aicoding` + applicationCoding + 云端个人非服务 | 拒绝；`aicoding` 是既有引擎值，不作为本期 Application Coding 的表达 |
+| applicationCoding + 本地 | 拒绝 |
+| applicationCoding + 服务 | 拒绝 |
+| applicationCoding + 团队空间 | 第一期拒绝 |
+| 非 Coding engine + applicationCoding | 拒绝 |
+| 普通 Bot不传模板 | 兼容通过 |
+
+### 13.3 Workspace Hosting 测试
+
+- Workspace Hosting 未绑定时，创建前返回 503；
+- workspace 创建失败时不返回成功 Bot；已有清理路径覆盖到的资源按现有逻辑清理，不把全量原子补偿作为本期承诺；
+- workspace 标识正确写入 `ac_templates.ext.dima_space_id`；
+- workspace 删除失败时删除接口返回错误；
+- device 或 owner relationship 失败时不误报创建成功，且不把“全部资源已补偿清理”作为一期承诺；
+- `dima_space_id`/workspace 标识正确写入现有 `ac_templates.ext`；
+- 创建成功后 ready 状态不会早于 workspace 初始化完成。
+
+### 13.4 异步授权测试
+
+- POST 返回 202 后，授权成功仍保留完整模板参数；
+- auth-status 重复查询不重复创建 Bot；
+- 授权失败不产生 Bot；
+- 模板配置较大或包含嵌套字段时不会在持久化/恢复中丢失；
+- 转换函数不改变 key 层级，不把扁平字段错误包装到 `bot_template_config`；
+- 授权回调重放具备幂等性；
+
+### 13.5 路由与运行时测试
+
+- `claude_code + normalCC` 仍路由到 claude_code adapter；
+- `claude_code + applicationCoding` 路由到 aicoding adapter；
+- `aicoding + applicationCoding` 被拒绝；`aicoding` 不传 `template_type` 时仍按既有 AI Coding 引擎路径回归；
+- Skill/MCP、workspace、readiness 不因模板路由回归。
+
+### 13.6 删除测试
+
+- 非服务 Application Coding 删除会清理 hosted workspace；
+- workspace 清理失败时删除不返回成功；
+- 服务 Bot 普通删除仍被拒绝；
+- `RELEASED`、`UPGRADED` 历史不会被误删；
+- 下线后生成的新草稿不会误删整个服务 Bot。
+
+## 14. 分期实施计划
+
+### Phase 0：能力探测与契约准备
+
+1. 复用 Workspace Hosting Service 的绑定检查，不新增独立 capability probe；
+2. 增加 `template_type` 和 `template_config` 的契约定义；
+3. 定义稳定错误码；
+4. 补齐组合策略单测。
+
+### Phase 1：开放 Application Coding 非服务创建
+
+1. OpenAPI 接收模板参数；
+2. 创建授权异步链路透传并恢复完整模板参数；
+3. 创建前完成组合和 Workspace Hosting 检查；
+4. 创建 workspace、模板记录和 Bot；
+5. 以 `READY` 作为对外可用状态；
+6. 开放云端个人非服务组合；
+7. 完成契约、集成和回归测试。
+
+### Phase 2：评估团队空间
+
+只有在以下条件具备后再评估：
+
+- workspace owner 与团队空间 owner 的映射规则；
+- 团队成员、共同编辑和 workspace 权限的一致性；
+- Bot 迁移、授权和删除的血缘规则；
+- 团队 workspace 的回收与审计能力。
+
+### Phase 3：评估服务化
+
+只有在以下条件具备后再评估：
+
+- Application Coding 发布版本与 workspace snapshot 的绑定；
+- 预发/线上 workspace 隔离；
+- 回滚、下线、重启和多实例语义；
+- `RELEASED`/`UPGRADED` 历史资源清理；
+- 服务 Bot 对话、健康检查和容器指标适配。
+
+## 15. 风险、回滚与兼容性
+
+### 15.1 主要风险
+
+- OpenAPI 参数增加但异步授权链路未保存，导致模板丢失；
+- Workspace Hosting 依赖不可用，产生半成品 Bot；
+- `ACTIVE` 被误认为 Application Coding 已 ready；
+- 把 Application Coding 误做成独立引擎，造成多个模块枚举不一致；
+- 删除时只删 Bot 记录，遗留 DIMA workspace；本期先处理 `dima_space_id`，失败即返回；但在无状态表/Saga 前提下，不承诺跨资源删除原子性，后续步骤失败时允许保留可重试的 Bot 记录；
+- 通过前端隐藏但后端未拒绝，导致非法组合可被直接调用。
+
+### 15.2 回滚策略
+
+- 通过关闭/移除 Workspace Hosting 绑定，使 Application Coding 创建前返回 503；
+- 保留普通 Bot 与现有 `claude_code`/`aicoding` 创建逻辑；
+- 已创建的 Application Coding Bot 不回滚为普通 Bot；遗留 workspace 按现有人工补救/运维流程处理；
+- 任何新增模板字段均保持向后兼容，未传模板字段的请求行为不变；
+- auth-status 未回传模板参数时拒绝 Application Coding 创建，不静默降级为普通 Bot。
+
+### 15.3 数据兼容
+
+- 现有普通 Bot 不增加隐含模板；
+- `template_type` 为空仍表示普通 Bot；
+- 历史 `applicationCoding` 数据按 readiness 兼容规则处理；
+- 不对已有 `engine` 值做批量重写；
+- 不新增 `claudecode-app` 数据值，避免后续迁移成本。
+
+## 16. 预计修改范围
+
+本次实施预计涉及以下边界，具体文件以实现时实际代码为准：
+
+```text
+src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+src/backend/src/agentclaw/community/core/bot_management/readiness.py
+src/backend/src/agentclaw/community/core/bot_inventory/policies/combo_policy.py
+src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+相关 workspace hosting、授权参数透传和集成测试文件
+```
+
+如果实际改动触及架构边界，还必须同步更新相应的契约文档、上下文边界元数据和架构测试，而不能只修改 Python schema。
+
+## 17. 最终结论
+
+1. **可以支持 Application Coding。**
+2. 第一阶段只支持：**云端 + 个人空间 + 非服务 Bot**。
+3. 不新增 `claudecode-app` 引擎值。
+4. 使用：
+   ```text
+   engine = claude_code
+   template_type = applicationCoding
+   ```
+5. `claude_code + applicationCoding` 延续历史逻辑，运行时路由到 aicoding adapter。
+6. OpenAPI 必须补齐 `template_type`、`template_config`，并保证 202 异步授权流程不丢参数；本期复用 auth-status echo，不新增 intent 表。
+7. Workspace Hosting 未绑定或不可用时，创建前失败；workspace 创建失败时沿用现有清理路径，不新增 workspace 资源表。
+8. Application Coding 的可用状态必须等待 workspace 初始化完成，不能仅以 `ACTIVE` 判断。
+9. 本地、团队、服务 Application Coding 第一阶段全部拒绝；这既要前端不展示，也要后端组合策略强校验。
+10. 普通服务 Bot 删除继续走发布生命周期；`RELEASED`、`UPGRADED` 属于正式发布历史，不得被普通删除逻辑误删。
+
+本决策的核心原则是：**沿用历史上“引擎负责 runtime、模板负责业务模式”的模型，先开放后端已经具备真实闭环的最小组合，再按 workspace、协作和服务生命周期逐步扩展。**

--- a/docs/superpowers/specs/2026-08-24-openapi-application-coding-decision.md
+++ b/docs/superpowers/specs/2026-08-24-openapi-application-coding-decision.md
@@ -414,6 +414,8 @@ template_config
 
 该方案的边界是：模板参数仍由客户端在 auth-status 中回传，不保证服务重启后的 pending 意图恢复，也不新增并发 claim 机制。若后续需要跨进程恢复、严格并发幂等或审计，再单独建设持久化 intent。
 
+**GET / POST 契约**：Application Coding 的模板恢复只走 **POST** `/{bot_id}/auth-status`（`BotAuthStatusPoll` 接收 `template_type`/`template_config`）；已退休的 **GET** 同路径**仅兼容普通 Bot**——它没有模板 query 参数，用它轮询 Application Coding 会因缺模板字段而静默创建普通 Bot，属于**不支持**的用法。Application Coding 接入方必须使用 POST。
+
 ### 8.3 幂等要求
 
 本期不新增 `Idempotency-Key` 公共请求头。继续沿用现有 `bot_id`、Passport 授权状态和创建逻辑处理重复查询；严格的跨请求幂等、创建意图持久化和并发 claim 不在本期范围。

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -36,6 +36,9 @@ from agentclaw.community.adapters.http.openapi_v1.clusters import (
     validate_engine_cluster,
 )
 from agentclaw.community.adapters.http.openapi_v1.errors import (
+    ApplicationCodingUnavailableError,
+    BotCombinationUnsupportedError,
+    BotTemplateInvalidError,
     StartupScriptUnsupportedError,
     UnsupportedEngineError,
 )
@@ -103,6 +106,7 @@ from agentclaw.community.core.bot_inventory.protocols import (
     BusinessSpaceContextProtocol,
 )
 from agentclaw.community.core.bot_inventory.policies.combo_policy import (
+    assert_application_coding_create,
     assert_service_upgrade,
 )
 from agentclaw.community.core.bot_inventory.types import (
@@ -141,6 +145,7 @@ from .schemas import (
     Passport,
     StartupScript,
     StartupScriptWrite,
+    to_internal_template_config,
 )
 from agentclaw.community.adapters.http.openapi_v1.authorization import PublicAPIRoute
 
@@ -176,6 +181,47 @@ def _require_service_capable_engine(bot_type: str, engine: str) -> None:
         raise ServicePublicationUnsupportedError(
             decision.reason or "engine cannot be used by a service bot"
         )
+
+
+def _application_coding_preflight(
+    *,
+    template_type: str | None,
+    template_config: dict[str, Any] | None,
+    bot_type: str,
+    engine: str,
+    space_kind: str,
+    bot_service: BotServiceProtocol,
+) -> dict[str, Any] | None:
+    """Validate an applicationCoding create before any side effect.
+
+    Returns the passed-through template_config for a coding bot, or ``None`` for
+    a plain bot. Raises a mapped public error otherwise: 422 for a malformed
+    template pairing, 409 for an unsupported combination, 503 when the
+    deployment has no Workspace Hosting.
+    """
+    if template_type is None:
+        if template_config is not None:
+            raise BotTemplateInvalidError("template_config requires template_type")
+        return None
+    if template_type != "applicationCoding":
+        raise BotTemplateInvalidError(f"unsupported template type: {template_type}")
+    if template_config is None:
+        raise BotTemplateInvalidError(
+            "template_config is required for applicationCoding"
+        )
+    decision = assert_application_coding_create(
+        engine=engine,
+        bot_type=bot_type,
+        space_kind=space_kind,
+        deployment_mode=CoreDeployMode.CLOUD,
+    )
+    if not decision.ok:
+        raise BotCombinationUnsupportedError(
+            decision.reason or "application coding combination is not supported"
+        )
+    if not bot_service.is_workspace_hosting_available():
+        raise ApplicationCodingUnavailableError()
+    return to_internal_template_config(template_config)
 
 
 def _to_bot(d: dict[str, Any]) -> Bot:
@@ -411,6 +457,14 @@ async def create_bot(
         owner_id=owner_id,
         header_space_id=body.space_id,
     )
+    template_config = _application_coding_preflight(
+        template_type=body.template_type,
+        template_config=body.template_config,
+        bot_type=body.bot_type,
+        engine=body.engine,
+        space_kind=current_space.kind,
+        bot_service=bot_service,
+    )
 
     bot_id = generate_bot_id(owner_id, bot_repo)
     outcome = create_bot_with_authorization(
@@ -424,6 +478,8 @@ async def create_bot(
             bot_name=body.bot_name,
             bot_desc=body.bot_desc,
             space_id=current_space.numeric_id,
+            template_type=body.template_type,
+            template_config=template_config,
         ),
         bot_service=bot_service,
         passport_plugin=passport_plugin,
@@ -962,6 +1018,8 @@ def _complete_auth_status(
     bot_desc: str | None,
     bot_type: BotType | None,
     space_id: str | None,
+    template_type: str | None = None,
+    template_config: dict[str, Any] | None = None,
     bot_service: BotServiceProtocol,
     passport_plugin: PassportPlugin,
     auth_rel_plugin: AuthRelationshipPlugin,
@@ -996,6 +1054,14 @@ def _complete_auth_status(
         owner_id=owner_id,
         header_space_id=space_id,
     )
+    resolved_template_config = _application_coding_preflight(
+        template_type=template_type,
+        template_config=template_config,
+        bot_type=bot_type or "personal",
+        engine=effective_engine,
+        space_kind=current_space.kind,
+        bot_service=bot_service,
+    )
     try:
         result = complete_bot_authorization(
             user_id=owner_id,
@@ -1008,6 +1074,8 @@ def _complete_auth_status(
                 bot_name=bot_name,
                 bot_desc=bot_desc,
                 space_id=current_space.numeric_id,
+                template_type=template_type,
+                template_config=resolved_template_config,
             ),
             bot_service=bot_service,
             passport_plugin=passport_plugin,
@@ -1090,6 +1158,8 @@ async def poll_bot_auth_status(
         bot_desc=body.bot_desc,
         bot_type=body.bot_type,
         space_id=body.space_id,
+        template_type=body.template_type,
+        template_config=body.template_config,
         bot_service=bot_service,
         passport_plugin=passport_plugin,
         auth_rel_plugin=auth_rel_plugin,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -7,12 +7,14 @@ internal names belong in ``#`` comments.
 
 from __future__ import annotations
 
+from copy import deepcopy
 from datetime import datetime
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 
 from agentclaw.community.adapters.http.openapi_v1.clusters import ClusterName
+from agentclaw.community.adapters.http.openapi_v1.errors import BotTemplateInvalidError
 
 # Request bodies reject unknown keys. Pydantic's default is to *ignore* them,
 # which on a public API means a typo'd or immutable field (``engine`` on update)
@@ -148,6 +150,41 @@ class BotMetadata(BaseModel):
     status: str = Field(description="Current lifecycle status.")
 
 
+_TEMPLATE_SERVER_RESERVED_FIELDS = frozenset(
+    {
+        "dima_space_id",
+        "workspace_id",
+        "template_uid",
+        "bot_id",
+        "workspace_status",
+        "workspace_state",
+        "start_status",
+    }
+)
+
+
+def to_internal_template_config(
+    value: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Validate and pass through a template payload unchanged.
+
+    The public ``template_config`` is a thin passthrough into the owning template
+    adapter's own structure: legacy applicationCoding is a flat dict while
+    template-factory configurations are nested, with no stable common field set,
+    so this deliberately does not map fields. It rejects the server-managed keys
+    that must never originate from a caller and deep-copies so the downstream
+    Workspace Hosting write-back cannot mutate the request object.
+    """
+    if value is None:
+        return None
+    reserved = sorted(_TEMPLATE_SERVER_RESERVED_FIELDS.intersection(value))
+    if reserved:
+        raise BotTemplateInvalidError(
+            f"template_config contains server-managed fields: {reserved}"
+        )
+    return deepcopy(value)
+
+
 class BotCreate(BaseModel):
     """Create-a-bot request body."""
 
@@ -176,6 +213,23 @@ class BotCreate(BaseModel):
     space_id: str | None = Field(
         default=None,
         description="Business space to associate with the bot, when applicable.",
+    )
+    template_type: str | None = Field(
+        default=None,
+        description=(
+            "Coding mode template: omit for a plain bot, or 'applicationCoding' "
+            "for an application-coding bot (requires a workspace-capable "
+            "deployment). Any other value is refused (422)."
+        ),
+    )
+    template_config: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Template payload supplied with 'applicationCoding'; must be omitted "
+            "for a plain bot. Passed through unchanged to the template validator. "
+            "Server-managed fields (dima_space_id, template_uid, bot_id) are not "
+            "accepted."
+        ),
     )
     # ``engine_options`` is deliberately absent. Nothing downstream consumes
     # ``BotCreateSpec.extra_properties`` yet, so declaring the field would
@@ -341,6 +395,14 @@ class BotAuthStatusPoll(BaseModel):
         default=None,
         description="Echo of the business space the bot was requested with; "
         "omitted resolves the caller's current space, exactly as on create.",
+    )
+    template_type: str | None = Field(
+        default=None,
+        description="Echo of the coding template the bot was requested with.",
+    )
+    template_config: dict[str, Any] | None = Field(
+        default=None,
+        description="Echo of the template payload the bot was requested with.",
     )
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/auth_status.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/auth_status.py
@@ -119,7 +119,7 @@ async def get_bot_auth_status(
 
     This retired GET spelling is plain-bot only: it carries no template
     parameters, so an application-coding creation must be completed through the
-    POST at the same path, which accepts ``template_type`` / ``template_config``.
+    POST at the same path, which accepts 'template_type' / 'template_config'.
     Polling an application-coding creation here would complete it as a plain bot,
     which is not supported.
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/auth_status.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/auth_status.py
@@ -117,6 +117,12 @@ async def get_bot_auth_status(
     the same engine registry check, the same engine/cluster pairing, and the
     same personal/service restriction on bot_type.
 
+    This retired GET spelling is plain-bot only: it carries no template
+    parameters, so an application-coding creation must be completed through the
+    POST at the same path, which accepts ``template_type`` / ``template_config``.
+    Polling an application-coding creation here would complete it as a plain bot,
+    which is not supported.
+
     While the authorization service has no status for the bot yet — the
     Passport is not ready — the poll answers PENDING with a message saying
     so, rather than an error: keep polling.

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors.py
@@ -108,6 +108,34 @@ class UnsupportedEngineError(Exception):
     """
 
 
+class BotTemplateInvalidError(Exception):
+    """A ``template_type``/``template_config`` pairing is invalid (→ 422).
+
+    Covers a ``template_config`` without a ``template_type``, an unsupported
+    template type, and a template payload that fails the application-coding
+    validation. Deliberately a 422, not 400: the request is well-formed but the
+    template contract is wrong.
+    """
+
+
+class BotCombinationUnsupportedError(Exception):
+    """An application-coding combination is recognized but not creatable (→ 409).
+
+    The engine / deployment / space / service combination is valid in the
+    abstract but not supported in this deployment — distinct from a malformed
+    template (422) and from a deployment that cannot host workspaces at all
+    (503).
+    """
+
+
+class ApplicationCodingUnavailableError(Exception):
+    """The deployment has no Workspace Hosting bound (→ 503).
+
+    Checked before any side effect. A 503 rather than 409: the caller's
+    combination may be valid, but this deployment cannot honor it right now.
+    """
+
+
 class StartupScriptUnsupportedError(Exception):
     """A bot whose container cannot run a startup script was sent one.
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -45,7 +45,10 @@ from agentclaw.community.api.bot_startup_script_service import (
     StartupScriptTooLargeError,
 )
 from agentclaw.community.adapters.http.openapi_v1.errors import (
+    ApplicationCodingUnavailableError,
     BotAccessRefusedError,
+    BotCombinationUnsupportedError,
+    BotTemplateInvalidError,
     CallerIdentityConflictError,
     CallerIdentityForbiddenError,
     CallerIdentityInvalidError,
@@ -500,6 +503,12 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     ChannelEditLockedError: (423, "Edit lock required"),
     ClusterMismatchError: (400, "engine and cluster_name do not match"),
     UnsupportedEngineError: (400, "Unsupported engine"),
+    BotTemplateInvalidError: (422, "Invalid coding template"),
+    BotCombinationUnsupportedError: (409, "Coding template combination not supported"),
+    ApplicationCodingUnavailableError: (
+        503,
+        "Application coding is unavailable in this deployment",
+    ),
     PassportError: (502, "Authorization service error"),
     AuthRelationshipError: (502, "Authorization relationship service error"),
     # Engine-config failures. None of these is a BotServiceError, so the base

--- a/src/backend/src/agentclaw/community/api/bot_service.py
+++ b/src/backend/src/agentclaw/community/api/bot_service.py
@@ -42,6 +42,10 @@ class BotServiceProtocol(Protocol):
 
     def check_create_bot_preflight(self, *args: Any, **kwargs: Any) -> Any: ...
 
+    # Whether Workspace Hosting (applicationCoding) is bound in this deployment.
+    # The route preflight consults this to answer 503 before any side effect.
+    def is_workspace_hosting_available(self) -> bool: ...
+
     # Whether the owner has no Bots yet. ``create_flow`` keeps this separate
     # from Passport selection so the response can preserve its first-Bot field.
     def is_first_bot(self, *args: Any, **kwargs: Any) -> Any: ...

--- a/src/backend/src/agentclaw/community/core/bot_inventory/policies/combo_policy.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/policies/combo_policy.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from agentclaw.community.core.bot_inventory.types import DeployMode
 from agentclaw.community.core.workspace.constants import SUPPORTED_ENGINE_TYPES
 
 LOCAL_CAPABLE_ENGINES = frozenset({"openclaw", "claude_code"})
 PERSONAL_CLOUD_CAPABLE_ENGINES = frozenset(SUPPORTED_ENGINE_TYPES)
 SERVICE_CAPABLE_ENGINES = frozenset({"openclaw", "claude_code", "teclaw"})
+APPLICATION_CODING_ENGINES = frozenset({"claude_code"})
 
 
 @dataclass(frozen=True)
@@ -38,4 +40,31 @@ def assert_local_create(engine: str, space_kind: str) -> ComboDecision:
 def assert_service_upgrade(engine: str) -> ComboDecision:
     if engine not in SERVICE_CAPABLE_ENGINES:
         return ComboDecision(False, f"engine cannot be serviced: {engine}")
+    return ComboDecision(True)
+
+
+def assert_application_coding_create(
+    *,
+    engine: str,
+    bot_type: str,
+    space_kind: str,
+    deployment_mode: DeployMode,
+) -> ComboDecision:
+    """Application-coding create combo: cloud + personal + non-service + claude_code.
+
+    ``deployment_mode`` and ``space_kind`` are explicit rather than inferred from
+    the calling endpoint, so the rule is self-contained and unit-testable.
+    ``claude_code`` is the only external engine value: the runtime routing to the
+    ``aicoding`` adapter is an internal concern, not an alternative engine.
+    """
+    if deployment_mode is not DeployMode.CLOUD:
+        return ComboDecision(False, "application coding is cloud-only")
+    if engine not in APPLICATION_CODING_ENGINES:
+        return ComboDecision(
+            False, f"application coding does not support engine: {engine}"
+        )
+    if bot_type != "personal":
+        return ComboDecision(False, "application coding bot must be personal")
+    if space_kind != "personal":
+        return ComboDecision(False, "application coding is personal-space only")
     return ComboDecision(True)

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -377,7 +377,7 @@ def create_bot_with_authorization(
             spec.engine_type,
             spec.template_type,
             ext_info={"template_config": spec.template_config}
-            if spec.template_config
+            if spec.template_config is not None
             else None,
         ),
         use_first_passport=use_first_passport,

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -1392,28 +1392,51 @@ class BotService:
             logger.info(f"[bot_service.create_bot] Bot {bot_id} created with PENDING status")
 
             # Step 1.5: Create template record if template_config is provided
-            if template_config and template_type:
-                try:
-                    logger.info(
-                        "[bot_service.create_bot] Creating template for bot %s, template_type=%s",
-                        bot_id, template_type,
-                    )
-
-                    # For applicationCoding template, ensure DIMA workspace exists
-                    if template_type == "applicationCoding":
-                        # Create DIMA workspace and update template_config with dima_space_id
+            if template_type and template_config is not None:
+                if template_type == "applicationCoding":
+                    # A coding bot without a hosted workspace is unusable, so a
+                    # failed workspace create is fatal here (unlike a plain bot,
+                    # where template creation stays best-effort). The already-
+                    # inserted bot row is soft-deleted; deeper compensation
+                    # (Passport / workspace / template) stays best-effort-by-
+                    # caller, per the plan's explicit deferral.
+                    try:
                         workspace_id = self._require_workspace_hosting().create_workspace_for_bot(
                             staff_id=user_id,
                             bot_id=bot_id,
                             bot_name=resolved_bot_name,
                             template_config=template_config,
                         )
+                    except Exception as exc:
+                        logger.exception(
+                            "[bot_service.create_bot] hosted workspace creation failed bot_id=%s",
+                            bot_id,
+                        )
+                        self._repository.soft_delete_by_owner(bot_id, user_id)
+                        raise BotServiceError(
+                            "applicationCoding workspace creation failed"
+                        ) from exc
+                    if not workspace_id:
+                        logger.error(
+                            "[bot_service.create_bot] hosted workspace creation returned "
+                            "no id bot_id=%s",
+                            bot_id,
+                        )
+                        self._repository.soft_delete_by_owner(bot_id, user_id)
+                        raise BotServiceError(
+                            "applicationCoding workspace creation returned no id"
+                        )
+                    logger.info(
+                        "[bot_service.create_bot] Created hosted workspace %s for bot %s",
+                        workspace_id,
+                        bot_id,
+                    )
 
-                        if workspace_id:
-                            logger.info(f"[bot_service.create_bot] Created DIMA workspace {workspace_id} for bot {bot_id}")
-                        else:
-                            logger.warning(f"[bot_service.create_bot] Failed to create DIMA workspace for bot {bot_id}, continuing without it")
-
+                try:
+                    logger.info(
+                        "[bot_service.create_bot] Creating template for bot %s, template_type=%s",
+                        bot_id, template_type,
+                    )
                     self._template_service.create_template(
                         bot_id=bot_id,
                         template_config=template_config,
@@ -1423,8 +1446,18 @@ class BotService:
                     logger.info(f"[bot_service.create_bot] Template created for bot {bot_id}")
                 except Exception as e:
                     logger.error(f"[bot_service.create_bot] Failed to create template for bot {bot_id}: {e}", exc_info=True)
-                    # Don't fail bot creation if template creation fails
-                    # Just log the error
+                    if template_type == "applicationCoding":
+                        # An applicationCoding bot without its template record is
+                        # not a usable bot. Do not report success after hosting
+                        # succeeded but local template persistence failed. The
+                        # remote workspace may require manual cleanup because the
+                        # delete contract is intentionally deferred.
+                        self._repository.soft_delete_by_owner(bot_id, user_id)
+                        raise BotServiceError(
+                            "applicationCoding template creation failed"
+                        ) from e
+                    # Keep the historical best-effort behavior for non-coding
+                    # template creation.
 
             # 桌面 bot 的设备分配走 BaaS 流程（DesktopBotService._execute_creation），
             # 不应走 DeviceService.apply_device()（会生成 staff_xxx 格式 device_id）。
@@ -5695,6 +5728,15 @@ class BotService:
                 "applicationCoding bots require it."
             )
         return self._workspace_hosting_service
+
+    def is_workspace_hosting_available(self) -> bool:
+        """Whether this deployment has a bound Workspace Hosting implementation.
+
+        The route preflight calls this so applicationCoding can be refused (503)
+        before a bot id is allocated or a Passport is applied, rather than
+        tripping ``_require_workspace_hosting`` mid-create after side effects.
+        """
+        return self._workspace_hosting_service is not None
 
     def ensure_hosted_workspace(self, bot_id: str, user_id: str) -> Optional[str]:
         """为 Coding bot 确保 DIMA workspace 存在（幂等）。

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -586,6 +586,22 @@ def test_create_bot_202_pending(client, passport):
     assert body["data"]["iframe_url"] == "http://auth"
 
 
+def test_create_application_coding_requires_template_config(client, svc, passport):
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine": "claude_code",
+            "cluster_name": "ACRA",
+            "bot_type": "personal",
+            "template_type": "applicationCoding",
+        },
+    )
+    assert response.status_code == 422, response.json()
+    passport.apply_first_agent_passport.assert_not_called()
+    svc.create_bot.assert_not_called()
+
+
 def test_create_bot_cluster_mismatch_400(client, svc):
     bad = {**_CREATE_BODY, "cluster_name": "ANDC"}  # openclaw must be ACRA
     with patch.object(bots_router, "generate_bot_id", return_value="default"):
@@ -731,6 +747,22 @@ def test_post_auth_status_preserves_create_attributes(client, svc, passport):
     assert kw["bot_name"] == "NewBot"
     assert kw["bot_desc"] == "d"
     assert kw["bot_type"] == "service"
+
+
+def test_post_auth_status_application_coding_requires_template_config(
+    client, svc, passport
+):
+    response = client.post(
+        "/openapi/v1/bots/b1/auth-status",
+        json={
+            "engine": "claude_code",
+            "cluster_name": "ACRA",
+            "template_type": "applicationCoding",
+        },
+    )
+    assert response.status_code == 422, response.json()
+    passport.query_auth_status.assert_not_called()
+    svc.create_bot.assert_not_called()
 
 
 def test_post_auth_status_engine_cluster_mismatch_400(client, svc):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_template_config_passthrough.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_template_config_passthrough.py
@@ -1,0 +1,61 @@
+"""Unit tests for the ``template_config`` passthrough contract.
+
+The public ``template_config`` is a thin passthrough into the owning template
+adapter's own structure (legacy flat applicationCoding vs nested template
+factory) — there is no stable common DTO, so the contract is: unchanged
+passthrough, deep-copied, and server-managed keys rejected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.adapters.http.openapi_v1.bots.schemas import (
+    to_internal_template_config,
+)
+from agentclaw.community.adapters.http.openapi_v1.errors import BotTemplateInvalidError
+
+
+def test_none_passes_through() -> None:
+    assert to_internal_template_config(None) is None
+
+
+def test_empty_dict_is_a_valid_passthrough() -> None:
+    # An empty object is a legitimate (if minimal) template payload, and must
+    # survive as {} rather than being collapsed to None by a truthiness check.
+    assert to_internal_template_config({}) == {}
+
+
+def test_payload_passes_through_unchanged_flat() -> None:
+    payload = {
+        "devflow_workflow": "app-flow",
+        "yuque_kb_repos": [],
+        "code_repos": [],
+    }
+    assert to_internal_template_config(payload) == payload
+
+
+def test_payload_passes_through_unchanged_nested() -> None:
+    payload = {
+        "bot_template_config": {
+            "preset_capabilities": {},
+            "ext_config": {"thetaKey": "value"},
+        }
+    }
+    assert to_internal_template_config(payload) == payload
+
+
+def test_payload_is_deep_copied() -> None:
+    payload = {"bot_template_config": {"ext_config": {"thetaKey": "v"}}}
+    result = to_internal_template_config(payload)
+    result["bot_template_config"]["ext_config"]["thetaKey"] = "mutated"
+    assert payload["bot_template_config"]["ext_config"]["thetaKey"] == "v"
+
+
+@pytest.mark.parametrize(
+    "reserved",
+    ["dima_space_id", "workspace_id", "template_uid", "bot_id", "workspace_status", "workspace_state", "start_status"],
+)
+def test_server_reserved_field_is_rejected(reserved: str) -> None:
+    with pytest.raises(BotTemplateInvalidError):
+        to_internal_template_config({reserved: "x"})

--- a/src/backend/tests/community/core/bot_inventory/policies/test_combo_policy.py
+++ b/src/backend/tests/community/core/bot_inventory/policies/test_combo_policy.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import pytest
 
 from agentclaw.community.core.bot_inventory.policies.combo_policy import (
+    APPLICATION_CODING_ENGINES,
     LOCAL_CAPABLE_ENGINES,
     PERSONAL_CLOUD_CAPABLE_ENGINES,
     SERVICE_CAPABLE_ENGINES,
+    assert_application_coding_create,
     assert_local_create,
     assert_personal_cloud_create,
     assert_service_upgrade,
 )
+from agentclaw.community.core.bot_inventory.types import DeployMode
 
 
 @pytest.mark.unit
@@ -72,3 +75,55 @@ def test_service_upgrade_engine_matrix() -> None:
     rejected = assert_service_upgrade("hermes")
     assert not rejected.ok
     assert rejected.reason == "engine cannot be serviced: hermes"
+
+
+@pytest.mark.unit
+def test_application_coding_engine_matrix() -> None:
+    assert APPLICATION_CODING_ENGINES == frozenset({"claude_code"})
+
+
+@pytest.mark.unit
+def test_application_coding_supported_combination() -> None:
+    ok = assert_application_coding_create(
+        engine="claude_code",
+        bot_type="personal",
+        space_kind="personal",
+        deployment_mode=DeployMode.CLOUD,
+    )
+    assert ok.ok
+
+
+@pytest.mark.unit
+def test_application_coding_rejects_aicoding_engine() -> None:
+    # aicoding is the internal adapter, not an external engine value — the only
+    # external engine for applicationCoding is claude_code.
+    rejected = assert_application_coding_create(
+        engine="aicoding",
+        bot_type="personal",
+        space_kind="personal",
+        deployment_mode=DeployMode.CLOUD,
+    )
+    assert not rejected.ok
+    assert "aicoding" in (rejected.reason or "")
+
+
+@pytest.mark.unit
+def test_application_coding_rejects_service_team_and_local() -> None:
+    assert not assert_application_coding_create(
+        engine="claude_code",
+        bot_type="service",
+        space_kind="personal",
+        deployment_mode=DeployMode.CLOUD,
+    ).ok
+    assert not assert_application_coding_create(
+        engine="claude_code",
+        bot_type="personal",
+        space_kind="team",
+        deployment_mode=DeployMode.CLOUD,
+    ).ok
+    assert not assert_application_coding_create(
+        engine="claude_code",
+        bot_type="personal",
+        space_kind="personal",
+        deployment_mode=DeployMode.LOCAL,
+    ).ok

--- a/src/backend/tests/community/core/bot_management/test_application_coding_create.py
+++ b/src/backend/tests/community/core/bot_management/test_application_coding_create.py
@@ -1,0 +1,216 @@
+"""Coverage tests for the applicationCoding create failure paths.
+
+The CI changed-line gate flags the create preflight error branches and the
+create_bot workspace/template failure handling; these drive exactly those new
+lines.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.adapters.http.openapi_v1.bots.router import (
+    _application_coding_preflight,
+)
+from agentclaw.community.adapters.http.openapi_v1.errors import (
+    ApplicationCodingUnavailableError,
+    BotCombinationUnsupportedError,
+    BotTemplateInvalidError,
+)
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotService,
+    BotServiceError,
+)
+
+
+def _mock_bot_service(hosting_available: bool = True) -> MagicMock:
+    svc = MagicMock()
+    svc.is_workspace_hosting_available.return_value = hosting_available
+    return svc
+
+
+# ── create preflight error branches ──────────────────────────────────────
+
+
+def test_preflight_plain_bot_returns_none() -> None:
+    assert (
+        _application_coding_preflight(
+            template_type=None,
+            template_config=None,
+            bot_type="personal",
+            engine="claude_code",
+            space_kind="personal",
+            bot_service=_mock_bot_service(),
+        )
+        is None
+    )
+
+
+def test_preflight_config_without_type_is_rejected() -> None:
+    with pytest.raises(BotTemplateInvalidError):
+        _application_coding_preflight(
+            template_type=None,
+            template_config={"devflow_workflow": "x"},
+            bot_type="personal",
+            engine="claude_code",
+            space_kind="personal",
+            bot_service=_mock_bot_service(),
+        )
+
+
+def test_preflight_unsupported_type_is_rejected() -> None:
+    with pytest.raises(BotTemplateInvalidError):
+        _application_coding_preflight(
+            template_type="personalCoding",
+            template_config={"devflow_workflow": "x"},
+            bot_type="personal",
+            engine="claude_code",
+            space_kind="personal",
+            bot_service=_mock_bot_service(),
+        )
+
+
+def test_preflight_application_coding_without_config_is_rejected() -> None:
+    with pytest.raises(BotTemplateInvalidError):
+        _application_coding_preflight(
+            template_type="applicationCoding",
+            template_config=None,
+            bot_type="personal",
+            engine="claude_code",
+            space_kind="personal",
+            bot_service=_mock_bot_service(),
+        )
+
+
+def test_preflight_wrong_engine_is_rejected() -> None:
+    with pytest.raises(BotCombinationUnsupportedError):
+        _application_coding_preflight(
+            template_type="applicationCoding",
+            template_config={"devflow_workflow": "x"},
+            bot_type="personal",
+            engine="aicoding",  # internal adapter, not an external engine
+            space_kind="personal",
+            bot_service=_mock_bot_service(),
+        )
+
+
+def test_preflight_missing_hosting_is_rejected() -> None:
+    with pytest.raises(ApplicationCodingUnavailableError):
+        _application_coding_preflight(
+            template_type="applicationCoding",
+            template_config={"devflow_workflow": "x"},
+            bot_type="personal",
+            engine="claude_code",
+            space_kind="personal",
+            bot_service=_mock_bot_service(hosting_available=False),
+        )
+
+
+def test_preflight_valid_application_coding_passes_through() -> None:
+    payload = {"devflow_workflow": "app-flow"}
+    result = _application_coding_preflight(
+        template_type="applicationCoding",
+        template_config=payload,
+        bot_type="personal",
+        engine="claude_code",
+        space_kind="personal",
+        bot_service=_mock_bot_service(),
+    )
+    assert result == payload
+
+
+# ── create_bot workspace/template failure ────────────────────────────────
+
+
+def _create_bot_service() -> BotService:
+    service = BotService(
+        drm_reader=MagicMock(),
+        repository=MagicMock(),
+        allocation_config=MagicMock(mode="multi", max_devices_per_entity=5),
+        device_binding_repo=MagicMock(),
+        skill_set_factory=MagicMock(),
+        cleanup_service=MagicMock(),
+        bcn_service=MagicMock(),
+        bot_publish_repo=MagicMock(),
+        passport_plugin=MagicMock(),
+        oss_record_repo=MagicMock(),
+        bot_publish_service_provider=lambda: MagicMock(),
+        device_service_provider=lambda: MagicMock(),
+        bot_app_grant_service_provider=lambda: MagicMock(),
+        path_factory=MagicMock(),
+        template_service=MagicMock(),
+        workspace_hosting_service=MagicMock(),
+        collaborator_repo=MagicMock(),
+        restart_lock_repo=MagicMock(),
+        teclaw_provision_service_provider=lambda: MagicMock(
+            is_teclaw=MagicMock(return_value=False)
+        ),
+        device_status_client=MagicMock(),
+        cron_auto_setup_service_provider=lambda: MagicMock(),
+    )
+    # Drive create_bot past the pre-device gates so it reaches Step 1.5.
+    service.check_create_bot_preflight = MagicMock()
+    service._check_device_limit = MagicMock()
+    service._resolve_bot_name = MagicMock(return_value="app-coding-bot")
+    service._repository.get_by_id_and_owner = MagicMock(return_value=None)
+    service._repository.insert = MagicMock(
+        return_value={"id": 1, "bot_id": "b1", "owner_id": "u1"}
+    )
+    service._repository.soft_delete_by_owner = MagicMock()
+    return service
+
+
+def _create(service: BotService) -> None:
+    service.create_bot(
+        user_id="u1",
+        nick_name="n",
+        bot_id="b1",
+        bot_type="personal",
+        engine_type="claude_code",
+        template_type="applicationCoding",
+        template_config={"devflow_workflow": "x"},
+    )
+
+
+def test_workspace_creation_exception_is_fatal() -> None:
+    svc = _create_bot_service()
+    svc._workspace_hosting_service = MagicMock()
+    svc._workspace_hosting_service.create_workspace_for_bot = MagicMock(
+        side_effect=RuntimeError("boom")
+    )
+    with pytest.raises(BotServiceError):
+        _create(svc)
+    svc._repository.soft_delete_by_owner.assert_called_once_with("b1", "u1")
+
+
+def test_workspace_creation_falsy_return_is_fatal() -> None:
+    svc = _create_bot_service()
+    svc._workspace_hosting_service = MagicMock()
+    svc._workspace_hosting_service.create_workspace_for_bot = MagicMock(
+        return_value=None
+    )
+    with pytest.raises(BotServiceError):
+        _create(svc)
+    svc._repository.soft_delete_by_owner.assert_called_once_with("b1", "u1")
+
+
+def test_template_creation_failure_is_fatal() -> None:
+    svc = _create_bot_service()
+    svc._workspace_hosting_service = MagicMock()
+    svc._workspace_hosting_service.create_workspace_for_bot = MagicMock(
+        return_value="ws-1"
+    )
+    svc._template_service.create_template = MagicMock(side_effect=RuntimeError("boom"))
+    with pytest.raises(BotServiceError):
+        _create(svc)
+    svc._repository.soft_delete_by_owner.assert_called_once_with("b1", "u1")
+
+
+def test_is_workspace_hosting_available() -> None:
+    svc = _create_bot_service()
+    svc._workspace_hosting_service = None
+    assert svc.is_workspace_hosting_available() is False
+    svc._workspace_hosting_service = MagicMock()
+    assert svc.is_workspace_hosting_available() is True

--- a/src/backend/tests/community/core/bot_management/test_readiness.py
+++ b/src/backend/tests/community/core/bot_management/test_readiness.py
@@ -35,3 +35,38 @@ def test_explicit_application_initialization_state_remains_authoritative() -> No
     }
 
     assert is_bot_ready(bot) is False
+
+
+def test_application_bot_ready_when_start_succeeded_and_binding_active() -> None:
+    bot = {
+        "status": "ACTIVE",
+        "active_engine": "claude_code",
+        "template_type": "applicationCoding",
+        "device_binding": {"status": "ACTIVE"},
+        "ext": {"start_status": "SUCCEEDED"},
+    }
+
+    assert is_bot_ready(bot) is True
+
+
+def test_application_bot_not_ready_when_start_failed() -> None:
+    bot = {
+        "status": "ACTIVE",
+        "active_engine": "claude_code",
+        "template_type": "applicationCoding",
+        "device_binding": {"status": "ACTIVE"},
+        "ext": {"start_status": "FAILED"},
+    }
+
+    assert is_bot_ready(bot) is False
+
+
+def test_non_application_bot_ignores_start_status() -> None:
+    bot = {
+        "status": "ACTIVE",
+        "active_engine": "openclaw",
+        "device_binding": {"status": "ACTIVE"},
+        "ext": {"start_status": "FAILED"},
+    }
+
+    assert is_bot_ready(bot) is True


### PR DESCRIPTION
## Problem

OpenAPI `POST /openapi/v1/bots` could create plain and service bots but not an Application Coding bot — the public contract had no way to name the coding template (`template_type` / `template_config`), even though the internal create chain already expressed it. First phase scope: cloud + personal space + non-service, `engine=claude_code` + `template_type=applicationCoding`.

## Solution

- Add optional `template_type` / `template_config` to `BotCreate` and `BotAuthStatusPoll`. `template_config` is a thin passthrough dict (deep-copied, no field remapping) that rejects server-managed keys (`workspace_id`, `template_uid`, `bot_id`, `workspace_status`, `workspace_state`, `start_status`, `dima_space_id`).
- `assert_application_coding_create` combo policy (claude_code + personal + cloud + non-service) plus a Workspace Hosting binding check answered as 503 before any side effect.
- `_application_coding_preflight` shared by create and auth-status, mapping failures to 422 / 409 / 503.
- 202 async auth reuses the existing echo: `BotAuthStatusPoll` gains the template fields; the retired GET spelling stays plain-bot only (documented).
- Workspace creation failure for applicationCoding is now fatal (soft-delete the inserted bot) instead of silently continuing; template-factory and plain-bot paths are unchanged.
- No new resource tables, saga, or reconciliation, matching the simplified plan.

## Validation

- ruff clean across all changed files.
- Unit + endpoint suites (template passthrough, combo policy, readiness, bots endpoints, auth-status, passport): 174 passed.
- Full `openapi_v1` test directory: 1328 passed (one `test_schema_docs` RST-backtick leak fixed along the way).
- Not run: corp DIMA workspace integration (`WorkspaceHostingService` is unbound in the community profile).

## Compatibility and risk

- Additive: `template_type`/`template_config` default to `None`, so plain-bot and existing template-factory (`normalCC`/`architect`/`personalCoding`) creation is unchanged.
- Application-coding deletion is intentionally out of scope (Blocked on the DIMA delete contract); deleting an application-coding bot does not yet reclaim its hosted workspace.

## Spec

- `docs/superpowers/specs/2026-08-24-openapi-application-coding-decision.md`
- `docs/superpowers/plans/2026-08-24-openapi-application-coding-implementation-plan.md`