### PR TITLE
 feat(backend): allow group member bots to view all group traces

### DIFF
--- a/docs/superpowers/specs/2026-08-24-bot-chat-group-trace-aggregation-design.md
+++ b/docs/superpowers/specs/2026-08-24-bot-chat-group-trace-aggregation-design.md
@@ -1,0 +1,515 @@
+# Bot Chats 按群 ID 关联 Trace 聚合
+
+- **日期**：2026-08-24
+- **状态**：approved
+- **基准设计**：Bot Chats 详情抽屉“按群 ID 关联”设计稿
+- **涉及模块**：TeamClaw 新前端、Backend Bot Logs、Gateway 路由（如现有配置需同步）
+- **关联 Spec**：TeamClaw 新前端 `docs/specs/bot-chats/spec.md`
+- **文档性质**：跨模块行为与契约设计。正式 API Contract 是实现权威来源。
+
+---
+
+## 1. 产品结论
+
+Bot Chats 的“按群 ID”不是群消息聊天记录页面，也不是只查询当前 Bot 的 Trace。
+
+其准确语义是：
+
+> 用户打开一条属于 Group 的 Trace 详情后，切换到“按群 ID”，系统根据该 Trace 的 `group_id` 查询这个 Group 下所有 Session 产生的全部关联 Trace；结果包含群内所有 Bot 的 Trace，并在每条 Trace 上标明来源 Bot。选择任意关联 Trace 后，继续展示该 Trace 的 Timeline、Observation、Input 和 Output。
+
+交互链路：
+
+```text
+打开当前 Trace 详情
+  → 当前 Trace 提供 group_id
+  → 切换“按群 ID”
+  → 按 group_id 查询全群关联 Trace
+  → 左栏展示所有来源 Bot 的 Trace
+  → 点击任意 Trace
+  → 中栏展示该 Trace Timeline
+  → 右栏展示选中 Observation 详情
+```
+
+当前 Trace 只是进入 Group 关联视图的上下文，不限制查询结果只能属于当前 Bot。
+
+---
+
+## 2. 与设计稿对齐
+
+设计稿明确要求以下页面结构：
+
+```text
+功能区
+  按 sessionID | 按任务ID | 按群ID
+  sessionID: 当前 Trace 的 sessionID
+  群ID: 当前 Trace 的 group_id
+  共 N 条关联 Trace
+
+左栏：关联 TRACE（群ID）
+  trace_006  来源 Bot C
+  trace_005  来源 Bot B
+  trace_004  来源 Bot A
+  trace_003  来源 Bot B（当前选中）
+  ...
+
+中栏：TIMELINE
+  当前：trace_003
+  Trace / Span / Generation / Tool Observation 树
+
+右栏：Observation 详情
+  Observation 名称与类型
+  时间、耗时
+  来源 Bot
+  Input
+  Output
+  Metadata / Token / 成本（按现有详情能力）
+```
+
+### 2.1 必须保留
+
+- 左、中、右三栏 Trace 详情结构；
+- 按 sessionID、按任务ID、按群ID三个关联维度；
+- Group 左栏为关联 Trace，而不是聊天气泡或消息 Timeline；
+- 每条 Group 关联 Trace 展示真实来源 Bot；
+- 点击其他 Bot 的 Trace 后可查看该 Trace 的完整 Timeline 和 Observation；
+- 当前 Trace 在左栏保持选中态；
+- 关联总数使用后端 `total`，不能只显示当前页数组长度。
+
+### 2.2 本期不做
+
+- 不新增 Group Session 选择器；
+- 不展示 BCS 原始 Human/Bot/System 群消息列表；
+- 不把没有 Trace 的普通群消息补入左栏；
+- 不新增聊天消息游标分页；
+- 不把 Group 模式改造成 Workspace 群聊页面；
+- 不要求新增 Group Message History API；
+- 不使用前端 Mock 拼接其他 Bot 的 Trace。
+
+---
+
+## 3. 已确认的查询范围
+
+### 3.1 Group 下所有 Session
+
+只要目标 Bot 是该 Group 的当前正式成员，按群 ID 查询应覆盖：
+
+- Group 下所有 Session；
+- 目标 Bot 未参与的 Session；
+- 目标 Bot 加入前已存在的 Session；
+- 当前 Trace 所在 Session 之外的其他 Session。
+
+Session Participant 关系不用于缩窄 Group 关联 Trace 的查询结果。
+
+### 3.2 全部可用历史 Trace
+
+Group 关联查询使用精确 `group_id` 和全历史范围：
+
+```text
+match_mode = exact
+time_scope = all
+```
+
+“全部历史”指 Backend OTEL/legacy Trace 真源和 BCS Group-Session 映射中仍可查询到的数据；不要求恢复已删除、未上报或超过合法保留期的 Trace。
+
+Group Trace 聚合只查询 Backend 的 Trace 日志和已有 Group-Session 关联表，不进入群消息读取链路，因此不涉及消息可见性、加入时间或消息 Owner Filter。
+
+### 3.3 所有来源 Bot
+
+Group 查询不能增加：
+
+```text
+trace.bot_id = 当前 bot_id
+```
+
+正确范围是：
+
+```text
+Trace.session_key 属于 group_id 映射出的任一 Group Session
+```
+
+结果可包含：
+
+- 当前 Bot 的 Trace；
+- Group 中其他 Bot 的 Trace；
+- Manager Bot 的 Trace；
+- 所有 Worker Bot 的 Trace。
+
+Manager-Worker 场景不按 Worker 身份隔离 Trace。所有已写入 Backend 日志库、且 Session 属于目标 Group 的 Trace 都进入结果。
+
+### 3.4 Trace 与群消息的边界
+
+本功能聚合的是 Trace：
+
+- Bot 执行有 Trace 时进入列表；
+- Human 普通群消息如果没有 Trace，不进入列表；
+- Bot 消息如果没有完成 OTEL 上报，也不伪造 Trace；
+- Group 下“全部聊天记录”在本 Spec 中指全部可用关联 Trace，不等同于 BCS 原始消息历史。
+
+---
+
+## 4. 权限模型
+
+Group 关联 Trace 的 Group 范围判定只依赖一个核心条件：
+
+```text
+Query 中作为查看上下文的当前 bot_id 是 group_id 的当前正式成员
+```
+
+通过后，该 Bot 获得该 Group 的关联 Trace 读取范围：
+
+```text
+Group 下所有 Session
++
+这些 Session 的所有可用 Trace
++
+这些 Trace 的完整详情和 Observation
+```
+
+不再按以下条件缩窄结果：
+
+- Trace 是否由当前 Bot 产生；
+- 当前 Bot 是否参与对应 Session；
+- 当前 Bot 加入 Group 或 Session 的时间；
+- Manager/Worker 身份；
+- Trace 来源 Bot 的 Owner 是否与当前调用者相同。
+
+Bot Owner 与 Bot Collaborator 通过同一当前 Bot 进入日志页时，Group 关联范围一致，不因 Owner/Collaborator 身份返回不同 Trace 集合。
+
+仍需保留的最低安全边界：
+
+1. 请求经过现有 Gateway 身份认证；
+2. `bot_id`、`group_id` 和 Trace ID 必须真实关联，服务端不能只信任前端；
+3. 当前 Bot 被移出 Group 后，后续 Group 关联请求失败；
+4. Group 关联详情只能打开该 Group 查询结果范围内的 Trace；
+5. 仅知道 `group_id`，但不能以该 Group 成员 Bot 建立查询上下文时，不得通过产品接口读取。
+
+---
+
+## 5. API 方案
+
+### 5.1 关联查询使用现有 Backend Bot Logs 接口
+
+本期不新增 Group History 接口，也不需要修改 BCS API。
+
+Backend 已有以下关联 Trace 原子接口：
+
+```http
+GET /openapi/v1/bots/logs/sessions/{session_key}/traces
+GET /openapi/v1/bots/logs/tasks/{biz_scene}/{biz_task_id}/traces
+GET /openapi/v1/bots/logs/groups/{group_id}/traces
+GET /openapi/v1/bots/logs/traces/{trace_id}
+```
+
+按群 ID 时继续复用原路由，仅增加可选查询上下文：
+
+```http
+GET /openapi/v1/bots/logs/groups/{group_id}/traces
+    ?bot_id={当前日志页 bot_id}
+    &user_id={当前用户}
+    &owner_id={Bot 所有者，可选}
+    &page=1
+    &limit=100
+```
+
+选择左栏任意关联 Trace 后继续复用原详情路由，并可携带同一 Group 上下文：
+
+```http
+GET /openapi/v1/bots/logs/traces/{trace_id}
+    ?bot_id={当前日志页 bot_id}
+    &group_id={当前关联 group_id}
+    &user_id={当前用户}
+    &owner_id={Bot 所有者，可选}
+```
+
+`bot_id`、`group_id`、`user_id`、`owner_id` 均为向后兼容的可选参数。增强 Group 上下文中，`owner_id` 未传时使用 `user_id`，Backend 据此生成 BCS 成员身份 `bot_id:owner_id`：
+
+- 新前端 Group 模式必须传入，用于落实“当前 Bot 属于 Group”以及“Trace 属于 Group”的校验；
+- 老前端或既有调用方不传时，不产生 422，不改变原路由行为；
+- 不修改 URL Path、HTTP Method、分页参数、Envelope 或 DTO 字段；
+- 不创建 `/v2`，不复制新增一组 Group logs 接口。
+
+新前端已经定义了这些路径的 `botLogController`，当前问题是 Group 关联流程仍在调用 Bot-scoped 产品接口，没有切换到对应的 logs 原子接口。
+
+### 5.2 Group logs 接口语义
+
+Backend Group logs 查询按以下逻辑执行：
+
+```text
+1. 根据 group_id 查询 Backend 本地 bcs_group_sessions 读模型；
+2. 将 Group 下全部 session_id 规范化成日志 session_key；
+3. 查询 Trace.session_key IN group_session_keys；
+4. 不附加 Trace.bot_id = 当前 Bot；
+5. 按 start_time DESC, trace_id DESC 稳定排序；
+6. enrich 每条 Trace 的 bot_id、bot_name、group_id 和 session 信息；
+7. 返回标准 SessionListResponse。
+```
+
+Backend 当前已有 `list_group_sessions()`、`OpenBotChatRepository.list_scope_traces()` 和 Group logs route，优先复用这些实现，不新增跨服务调用。
+
+响应示例：
+
+```json
+{
+  "sessions": [
+    {
+      "id": "trace_003",
+      "bot_id": "BOT_002",
+      "bot_name": "客服助手",
+      "group_id": "group_001",
+      "session_id": "sess_001",
+      "session_key": "...",
+      "timestamp": "2026-06-29T14:30:00Z",
+      "status": "SUCCESS"
+    }
+  ],
+  "total": 6,
+  "page": 1,
+  "limit": 100,
+  "has_more": false
+}
+```
+
+### 5.3 权限上下文与兼容模式
+
+Group 关联视图从一条当前可查看、且携带 `group_id` 的 Trace 进入。Group 范围不再按照来源 Bot 的 Owner、Collaborator、Session Participant 或 Worker 身份过滤。
+
+产品确认的核心条件仍是“当前日志页 Bot 属于该 Group”。Backend logs 只在调用方显式传入 Group 查询上下文时执行增强校验：
+
+```text
+列表：bot_id:(owner_id 或 user_id) 属于 path.group_id
+详情：bot_id:(owner_id 或 user_id) 属于 query.group_id
+     且 trace_id 对应 Trace 的 session_key 属于 query.group_id
+```
+
+兼容规则：
+
+1. `GET /groups/{group_id}/traces` 不传 `bot_id` 时，保留现有 logs 调用语义；
+2. `GET /traces/{trace_id}` 不传 `bot_id/group_id` 时，保留现有 logs 详情语义；
+3. 增强 Group 上下文至少同时提供 `bot_id`、`group_id`、`user_id`；`owner_id` 可选，Collaborator 查看共享 Bot 时传真实 Owner；详情禁止只传部分上下文；
+4. 普通 `/bots/{bot_id}/chats/**` 路由、参数、授权和返回完全不变；
+5. 新前端必须使用增强上下文，老前端可以零改造继续运行；
+6. 校验只在 Backend logs 边界读取现有 Group Membership 数据，不修改 BCS Contract 或 BCS 运行逻辑。
+
+该兼容分支是已有调用方的迁移保护，不应被新前端当作绕过 Group 校验的降级路径。
+
+### 5.4 不使用 Bot-scoped 接口做 Group 聚合
+
+以下接口继续用于当前 Bot 的普通列表和详情：
+
+```http
+GET /openapi/v1/bots/{bot_id}/chats
+GET /openapi/v1/bots/{bot_id}/chats/{trace_id}
+```
+
+它们带有 Bot scope，不适合作为“按群 ID”跨 Bot 关联 Trace 的数据源。Group Tab 应切换到 `/openapi/v1/bots/logs/**`；这样点击其他 Bot Trace 时也直接使用 logs detail，不需要放宽普通 Bot-scoped 详情接口。
+
+---
+
+## 6. Backend 改造
+
+### 6.1 当前能力
+
+Backend 已具备：
+
+- `bcs_group_sessions`：Group 到 Session 的本地读模型；
+- `list_group_sessions()`：将 Group Session 解析为日志 `session_key`；
+- `OpenBotChatRepository.list_scope_traces()`：按 Session/Task/Group 查询非 Bot-scoped Trace；
+- `/openapi/v1/bots/logs/groups/{group_id}/traces`：跨 Bot Group Trace 列表；
+- `/openapi/v1/bots/logs/traces/{trace_id}`：Trace 完整详情；
+- 上述路由可通过新增的可选查询上下文增强 Group 校验，同时兼容不传新参数的老调用方。
+
+因此不需要新增 Group History Service，也不需要修改 BCS。
+
+### 6.2 需要核对或修正的 Backend 内容
+
+- Group logs route 在 Gateway 环境可访问；
+- Group 查询覆盖 `bcs_group_sessions` 中该 Group 的全部 Session；
+- 查询不附加 `bot_id`、Owner 或 Worker Filter；
+- OCB Trace 和 legacy Trace 均按相同 Group Scope 查询；
+- 列表 DTO稳定返回每条 Trace 的 `bot_id/bot_name`；
+- `total/page/limit/has_more` 正确；
+- Trace detail 能返回 Group 列表中任意 Trace 的 Timeline 和 Observation；
+- Group 列表新增可选 `bot_id/user_id/owner_id` 查看上下文，传入时按 BCS `bot_id:owner_id` 身份校验该 Bot 属于 Path 中的 Group；
+- Trace 详情新增可选的 `bot_id/group_id/user_id/owner_id` 查看上下文，传入时同时校验 Bot-in-Group 与 Trace-in-Group；
+- 不传新增参数时保持既有 logs 行为，避免老前端和其他既有调用方回归；
+- 校验只修改 Backend logs 授权边界并复用已有数据/能力，不扩展 BCS Contract。
+
+### 6.3 明确不修改
+
+- 不修改 BCS Application Service；
+- 不修改 BCS HTTP Contract；
+- 不修改 BCS Session 或 Message 查询；
+- 不新增 Group Message History；
+- 不修改 `visible_from_seq`、参与者历史或 Manager-Worker 消息逻辑；
+- 不放宽普通 `/bots/{bot_id}/chats/**` 的 Bot scope。
+
+---
+
+## 7. 新前端改造
+
+### 7.1 当前问题
+
+新版前端当前存在以下偏差：
+
+1. `botChatService.related(..., 'group')` 仍调用：
+
+   ```text
+   GET /openapi/v1/bots/{当前 bot_id}/chats?group_id=...
+   ```
+
+   而当前后端响应仍是 Bot-scoped，导致其他 Bot Trace 缺失。
+
+2. 新前端虽已定义：
+
+   ```text
+   BOT_LOG_ENDPOINTS.groupTraces(group_id)
+   ```
+
+   但 Group 关联流程没有使用。
+
+3. `BotChatSummary` 未保存 `botId/botName`。
+
+4. `BotChatRelatedTraceList` 在 Group 模式下把每条 Trace 的来源固定渲染为页面当前 `botName/botId`，即使后端返回其他 Bot，也会标错来源。
+
+5. 关联计数使用 `page.items.length`，设计稿要求显示后端 `total`。
+
+### 7.2 必须修改
+
+- Group Tab 按当前 Trace 的 `groupId` 发起全群 Trace 查询，并携带页面当前 `botId/userId/ownerId`；
+- Domain Model 增加每条 Trace 的：
+
+  ```text
+  botId
+  botName
+  ```
+
+- Mapper 映射 DTO 的 `bot_id/bot_name`；
+- Group 左栏每条 Trace 使用该 Trace 自己的来源 Bot；
+- 点击其他 Bot Trace 时，向 logs detail 同时传当前页面 `botId/userId/ownerId` 和关联锚点 `groupId`；
+- 选中 Trace 后更新中栏 Timeline 和右栏 Observation；
+- 保持 Group Tab 和当前选择，不能因选中其他 Bot Trace 自动退回 Session Tab；
+- 总数显示 `page.total`；
+- `has_more=true` 时提供加载更多或分页，不能固定只展示前 100 条；
+- 当前 Trace 在返回结果中高亮；
+- 无 `group_id` 时禁用“按群 ID”并显示原有提示。
+
+### 7.3 不需要修改
+
+- 不新增 Group Session 列表组件；
+- 不新增群消息气泡组件；
+- 不接入 Workspace Group Chat Provider；
+- 不新增消息 Store；
+- 不改变普通日志列表和筛选页；
+- 不改变 Observation 树的主体展示结构。
+
+---
+
+## 8. 验收标准
+
+### 8.1 Group Trace 范围
+
+- [ ] 当前 Trace 有 `group_id` 时，“按群 ID”可用。
+- [ ] 查询覆盖 Group 下所有 Session。
+- [ ] 返回当前 Bot 和其他 Bot 的 Trace。
+- [ ] 当前 Bot 未参与某 Session 时，该 Session 的 Trace 仍可返回。
+- [ ] 当前 Bot 加入 Group 前的仍存 Trace 可以返回。
+- [ ] Manager、所有 Worker 的 Trace 均可返回，不做 Worker 隔离。
+- [ ] Group 查询不附加 `trace.bot_id = 当前 bot_id`。
+- [ ] 当前 Bot 不属于 Group 或已被移出时，查询失败。
+
+### 8.2 页面展示
+
+- [ ] 左栏标题为“关联 TRACE（群ID）”。
+- [ ] 左栏每条 Trace 展示真实来源 Bot 名称和 Bot ID。
+- [ ] 关联总数使用后端 `total`。
+- [ ] 当前 Trace 保持高亮。
+- [ ] 点击其他 Bot Trace 后，中栏切换到该 Trace Timeline。
+- [ ] 右栏显示该 Trace 选中 Observation 的 Input、Output、模型、耗时、Token 和成本。
+- [ ] Group Tab 不被切换 Trace 的动作重置。
+- [ ] 超过单页上限时可以继续加载。
+
+### 8.3 权限与回归
+
+- [ ] Group 上下文只要求当前 Bot 是 Group 正式成员，不按来源 Bot Owner/Worker 缩窄结果。
+- [ ] Owner 和 Collaborator 通过同一 Bot 查看时返回一致的 Group Trace 集合。
+- [ ] 非 Group 模式仍保持原有 Bot-scoped 列表和详情边界。
+- [ ] 不能用 Group A 的上下文打开仅属于 Group B 的 Trace。
+- [ ] 仅知道 Group ID 不能绕过产品上下文读取。
+
+---
+
+## 9. 测试要求
+
+### 9.1 Backend
+
+至少覆盖：
+
+1. Group G 有 Session S1、S2；
+2. Bot A 是 Group G 成员，但只参与 S1；
+3. Bot B、Bot C 在 S1/S2 分别产生 Trace；
+4. 以 Bot A 查询 Group G，返回 A/B/C 的全部 Trace；
+5. 以 Bot A 和 Group G 上下文打开 Bot B Trace 详情成功；
+6. 不带新增参数调用既有 logs 列表和详情时，HTTP 契约与历史行为不变；
+7. Group 详情缺少 `bot_id`、`group_id`、`user_id` 中任一必需上下文时明确拒绝；
+8. Bot A 被移出 Group 后，带 Group 上下文的列表和跨 Bot 详情失败；
+9. Group G 上下文不能打开 Group H 的 Trace；
+10. 普通 Bot 列表、详情、Session、Task 查询不回归；
+11. OCB Trace 和 legacy Trace 路径行为一致；
+12. 老前端既有请求不增加必填参数即可继续成功。
+
+### 9.2 新前端
+
+至少覆盖：
+
+1. Group Tab 使用 `detail.groupId` 查询；
+2. 返回多个 `bot_id` 时全部展示；
+3. 每条 Trace 标签使用自身 `botName/botId`；
+4. 点击其他 Bot Trace 携带 Group 上下文；
+5. 切换 Trace 后保持 Group Scope；
+6. `total` 与当前页长度不同时显示 `total`；
+7. `hasMore` 时加载下一页并按 Trace ID 去重；
+8. 当前 Trace 高亮；
+9. 空态、401、无权、5xx 和重试可用；
+10. Component → Hook → Service → Controller 分层不回归。
+
+### 9.3 真实数据验收
+
+不得只使用前端 Mock。至少写入或通过真实调用产生：
+
+```text
+Group G
+  Session S1
+    Bot A → Trace A1
+    Bot B → Trace B1
+  Session S2
+    Bot C → Trace C1
+    Worker D → Trace D1
+```
+
+从 Bot A 的 Trace A1 进入“按群 ID”后，应看到 A1、B1、C1、D1，并能依次打开完整 Trace 详情。
+
+---
+
+## 10. 实施顺序
+
+1. Backend：验证现有 Group logs 列表和 Trace detail 的真实数据行为；
+2. Backend：仅在发现缺口时修正 logs 查询、DTO 或 Gateway 暴露；
+3. 新前端：Group Tab 改用 `botLogController.groupTraces()`；
+4. 新前端：关联 Trace 详情改用 `botLogController.getBotTrace()`；
+5. 新前端：映射并展示每条 Trace 的真实来源 Bot；
+6. 新前端：对齐设计稿左中右布局、总数与分页；
+7. 使用真实多 Bot Group Trace 完成 E2E。
+
+---
+
+## 11. 兼容与回滚
+
+- 普通 Bot Chats 列表和详情保持 Bot-scoped；
+- 新增查询参数全部可选，旧请求 URL 和调用方式继续有效；
+- 不删除、不重命名、不改为必填任何既有参数；
+- 不改变既有 Envelope、HTTP 状态码映射和响应主体结构；
+- Session/Task 关联行为不在本 Spec 中扩大；
+- 跨 Bot 聚合只发生在明确的 `/bots/logs/groups/{group_id}/traces` Group logs 接口；
+- 现有 Trace/Observation DTO 仅补充或正确使用 `bot_id/bot_name`，不改动主体结构；
+- 回滚时恢复新前端原关联调用即可，Backend 现有 logs 原子接口和其他日志能力不受影响；
+- 不涉及 Group 消息数据迁移或消息数据库变更。

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_logs/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_logs/router.py
@@ -134,12 +134,33 @@ async def list_group_traces(
     limit: int = Query(
         default=100, ge=1, le=100, description="Traces per page (max 100)."
     ),
+    bot_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=256,
+        description="Optional viewing Bot. When supplied, it must belong to the group.",
+    ),
+    user_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=256,
+        description="Acting user for the optional viewing Bot context.",
+    ),
+    owner_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=256,
+        description="Owner of the viewing Bot; defaults to user_id.",
+    ),
     service: OpenBotChatServiceProtocol = Injected(OpenBotChatServiceProtocol),
 ) -> Envelope[SessionListResponse]:
     """List the traces of every session in one collaboration group, newest first."""
     del principal
     result = await service.list_open_sessions(
         group_id=group_id,
+        bot_id=bot_id,
+        user_id=user_id,
+        owner_id=owner_id,
         page=page,
         limit=limit,
     )
@@ -193,6 +214,30 @@ async def get_trace(
         max_length=256,
         description="The trace's id, as returned in a listing entry's id.",
     ),
+    bot_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=256,
+        description="Optional viewing Bot for a group-scoped detail request.",
+    ),
+    group_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=256,
+        description="Optional group context; must be supplied together with bot_id.",
+    ),
+    user_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=256,
+        description="Acting user for the optional viewing Bot context.",
+    ),
+    owner_id: str | None = Query(
+        default=None,
+        min_length=1,
+        max_length=256,
+        description="Owner of the viewing Bot; defaults to user_id.",
+    ),
     service: OpenBotChatServiceProtocol = Injected(OpenBotChatServiceProtocol),
 ) -> Envelope[ConversationDetail]:
     """Return one recorded chat turn (trace) in full.
@@ -201,5 +246,11 @@ async def get_trace(
     model generations and tool calls that made up the turn.
     """
     del principal
-    result = await service.get_open_session(trace_id)
+    result = await service.get_open_session(
+        trace_id,
+        bot_id=bot_id,
+        group_id=group_id,
+        user_id=user_id,
+        owner_id=owner_id,
+    )
     return envelope(result, request)

--- a/src/backend/src/agentclaw/community/api/bot_chat_service.py
+++ b/src/backend/src/agentclaw/community/api/bot_chat_service.py
@@ -57,11 +57,21 @@ class OpenBotChatServiceProtocol(Protocol):
         biz_scene: str | None = None,
         biz_task_id: str | None = None,
         group_id: str | None = None,
+        bot_id: str | None = None,
+        user_id: str | None = None,
+        owner_id: str | None = None,
         page: int = 1,
         limit: int = 100,
     ) -> SessionListResponse: ...
 
-    async def get_open_session(self, trace_id: str) -> ConversationDetail: ...
+    async def get_open_session(
+        self,
+        trace_id: str,
+        bot_id: str | None = None,
+        group_id: str | None = None,
+        user_id: str | None = None,
+        owner_id: str | None = None,
+    ) -> ConversationDetail: ...
 
     async def list_open_user_bot_traces(
         self,

--- a/src/backend/src/agentclaw/community/core/bot_chat/models.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/models.py
@@ -183,3 +183,18 @@ class BcsGroupSession(Base):
     env = Column(String(32), nullable=False, default="prod")
     status = Column(String(16), nullable=False, default="running")
     session_kind = Column(String(32), nullable=False, default="chat")
+
+
+class BcsGroupParticipant(Base):
+    """Read model for checking whether a Bot belongs to a BCS group."""
+
+    __tablename__ = "bcs_group_participants"
+    __table_args__ = {"extend_existing": True}
+
+    id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
+    group_id = Column(String(64), nullable=False)
+    bot_uuid = Column(String(256), nullable=False)
+    role = Column(String(256), nullable=False, default="consultant")
+    env = Column(String(64), nullable=False)
+    actor_kind = Column(String(16), nullable=False, default="bot")
+    mode = Column(String(16), nullable=False, default="auto")

--- a/src/backend/src/agentclaw/community/core/bot_chat/open_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_chat/open_service.py
@@ -4,8 +4,13 @@ from datetime import datetime, timedelta, timezone
 
 from injector import inject
 
-from agentclaw.community.core.bot_chat.errors import InvalidBotLogQueryError
-from agentclaw.community.core.repository.implementations.chat.open import OpenBotChatRepository
+from agentclaw.community.core.bot_chat.errors import (
+    InvalidBotLogQueryError,
+    SessionNotFoundError,
+)
+from agentclaw.community.core.repository.implementations.chat.open import (
+    OpenBotChatRepository,
+)
 from agentclaw.community.core.bot_chat.schemas import (
     ConversationDetail,
     SessionListResponse,
@@ -22,12 +27,43 @@ class OpenBotChatService:
     def __init__(self, repository: OpenBotChatRepository) -> None:
         self._repository = repository
 
+    def _require_group_viewer(
+        self,
+        *,
+        group_id: str | None,
+        bot_id: str | None,
+        user_id: str | None,
+        owner_id: str | None,
+        not_found_message: str,
+        allow_legacy_group: bool,
+    ) -> None:
+        """Validate an optional product-Bot viewer against BCS membership."""
+        has_viewer_context = any(
+            value is not None for value in (bot_id, user_id, owner_id)
+        )
+        if not has_viewer_context:
+            if group_id is not None and not allow_legacy_group:
+                raise InvalidBotLogQueryError(
+                    "group_id, bot_id and user_id must be provided together"
+                )
+            return
+        if group_id is None or bot_id is None or user_id is None:
+            raise InvalidBotLogQueryError(
+                "group_id, bot_id and user_id must be provided together"
+            )
+        bot_uuid = f"{bot_id}:{owner_id or user_id}"
+        if not self._repository.is_bot_in_group(group_id, bot_uuid):
+            raise SessionNotFoundError(not_found_message)
+
     async def list_open_sessions(
         self,
         session_key: str | None = None,
         biz_scene: str | None = None,
         biz_task_id: str | None = None,
         group_id: str | None = None,
+        bot_id: str | None = None,
+        user_id: str | None = None,
+        owner_id: str | None = None,
         page: int = 1,
         limit: int = _OPEN_PAGE_SIZE,
     ) -> SessionListResponse:
@@ -36,6 +72,9 @@ class OpenBotChatService:
         biz_scene = (biz_scene.strip() or None) if biz_scene is not None else None
         biz_task_id = (biz_task_id.strip() or None) if biz_task_id is not None else None
         group_id = (group_id.strip() or None) if group_id is not None else None
+        bot_id = (bot_id.strip() or None) if bot_id is not None else None
+        user_id = (user_id.strip() or None) if user_id is not None else None
+        owner_id = (owner_id.strip() or None) if owner_id is not None else None
 
         session_mode = session_key is not None
         task_mode = biz_scene is not None or biz_task_id is not None
@@ -48,6 +87,14 @@ class OpenBotChatService:
             raise InvalidBotLogQueryError(
                 "biz_scene and biz_task_id must be provided together"
             )
+        self._require_group_viewer(
+            group_id=group_id,
+            bot_id=bot_id,
+            user_id=user_id,
+            owner_id=owner_id,
+            not_found_message="group not found or not accessible",
+            allow_legacy_group=True,
+        )
 
         return self._repository.list_scope_traces(
             from_ms=0,
@@ -60,12 +107,34 @@ class OpenBotChatService:
             group_id=group_id,
         )
 
-    async def get_open_session(self, trace_id: str) -> ConversationDetail:
+    async def get_open_session(
+        self,
+        trace_id: str,
+        bot_id: str | None = None,
+        group_id: str | None = None,
+        user_id: str | None = None,
+        owner_id: str | None = None,
+    ) -> ConversationDetail:
         """Get an exact trace detail without applying owner access filters."""
         trace_id = trace_id.strip()
         if not trace_id:
             raise InvalidBotLogQueryError("trace_id must not be empty")
-        return self._repository.get_trace_detail(trace_id)
+        bot_id = (bot_id.strip() or None) if bot_id is not None else None
+        group_id = (group_id.strip() or None) if group_id is not None else None
+        user_id = (user_id.strip() or None) if user_id is not None else None
+        owner_id = (owner_id.strip() or None) if owner_id is not None else None
+        self._require_group_viewer(
+            group_id=group_id,
+            bot_id=bot_id,
+            user_id=user_id,
+            owner_id=owner_id,
+            not_found_message="trace not found or not accessible",
+            allow_legacy_group=False,
+        )
+        detail = self._repository.get_trace_detail(trace_id)
+        if group_id is not None and detail.group_id != group_id:
+            raise SessionNotFoundError("trace not found or not accessible")
+        return detail
 
     async def list_open_user_bot_traces(
         self,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/chat/open.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/chat/open.py
@@ -17,6 +17,7 @@ from agentclaw.community.core.bot_chat.models import (
     AcOtelLogTrace,
     AwLangfuseObservation,
     AwLangfuseTrace,
+    BcsGroupParticipant,
 )
 from agentclaw.community.core.bot_chat.query_support import (
     QueryScope,
@@ -36,6 +37,7 @@ from agentclaw.community.core.bot_chat.schemas import (
 )
 from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.core.repository.protocols.chat import OpenBotChatRepositoryProtocol
+from agentclaw.community.utils.env_utils import get_current_env
 
 _OUTPUT_PREVIEW_LENGTH = 500
 
@@ -99,6 +101,20 @@ class OpenBotChatRepository(
     @inject
     def __init__(self, db: DatabasePlugin) -> None:
         self._db = db
+
+    def is_bot_in_group(self, group_id: str, bot_uuid: str) -> bool:
+        """Return whether the addressed Bot is a current group participant."""
+        with self._db.orm_session() as session:
+            return (
+                session.query(BcsGroupParticipant.id)
+                .filter(
+                    BcsGroupParticipant.env == get_current_env(),
+                    BcsGroupParticipant.group_id == group_id,
+                    BcsGroupParticipant.bot_uuid == bot_uuid,
+                )
+                .first()
+                is not None
+            )
 
     def list_scope_traces(
         self,

--- a/src/backend/src/agentclaw/community/core/repository/protocols/chat.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/chat.py
@@ -296,6 +296,11 @@ class OpenBotChatRepositoryProtocol(Protocol):
     """Reads owned exclusively by the Bot Chat OpenAPI surface."""
 
     @abstractmethod
+    def is_bot_in_group(self, group_id: str, bot_uuid: str) -> bool:
+        """Return whether the Bot is a participant of the group."""
+        ...
+
+    @abstractmethod
     def list_scope_traces(
         self,
         *,

--- a/src/backend/tests/community/core/bot_chat/test_open_bot_chat_repository.py
+++ b/src/backend/tests/community/core/bot_chat/test_open_bot_chat_repository.py
@@ -9,10 +9,15 @@ from agentclaw.community.core.bot_chat.models import (
     AcOtelLogObservation,
     AwLangfuseObservation,
     AwLangfuseTrace,
+    BcsGroupParticipant,
     BcsGroupSession,
 )
-from agentclaw.community.core.repository.implementations.chat.db import BotChatDbRepository
-from agentclaw.community.core.repository.implementations.chat.open import OpenBotChatRepository
+from agentclaw.community.core.repository.implementations.chat.db import (
+    BotChatDbRepository,
+)
+from agentclaw.community.core.repository.implementations.chat.open import (
+    OpenBotChatRepository,
+)
 from agentclaw.community.plugin_api.models import Base
 from agentclaw.community.utils.env_utils import get_current_env
 
@@ -64,6 +69,30 @@ def _write_ocb_trace(
             "status": "SUCCESS",
             "usage": {},
         }
+    )
+
+
+def test_group_membership_is_scoped_by_group_bot_and_environment() -> None:
+    db = _LocalDb()
+    with db.orm_session() as session:
+        session.add(
+            BcsGroupParticipant(
+                group_id="group-fixture",
+                bot_uuid="bot-fixture:owner-fixture",
+                env=get_current_env(),
+            )
+        )
+
+    repository = OpenBotChatRepository(db)
+
+    assert (
+        repository.is_bot_in_group("group-fixture", "bot-fixture:owner-fixture") is True
+    )
+    assert (
+        repository.is_bot_in_group("group-fixture", "bot-fixture:other-owner") is False
+    )
+    assert (
+        repository.is_bot_in_group("other-group", "bot-fixture:owner-fixture") is False
     )
 
 
@@ -330,9 +359,7 @@ def test_task_scope_merges_direct_and_owned_relation_matches() -> None:
             "biz_task_id": "task-fixture",
             "user_id": "relation-user",
             "bot_id": "relation-bot",
-            "refs": [
-                {"ref_type": "trace_id", "ref_value": "relation-task-trace"}
-            ],
+            "refs": [{"ref_type": "trace_id", "ref_value": "relation-task-trace"}],
         }
     )
 
@@ -372,9 +399,7 @@ def test_task_scope_falls_back_to_legacy_relation() -> None:
             "biz_task_id": "legacy-task",
             "user_id": "legacy-user",
             "bot_id": "legacy-bot",
-            "refs": [
-                {"ref_type": "session_key", "ref_value": "legacy-task-key"}
-            ],
+            "refs": [{"ref_type": "session_key", "ref_value": "legacy-task-key"}],
         }
     )
 

--- a/src/backend/tests/community/core/bot_chat/test_open_bot_chat_service.py
+++ b/src/backend/tests/community/core/bot_chat/test_open_bot_chat_service.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from agentclaw.community.core.bot_chat.open_service import OpenBotChatService
+from agentclaw.community.core.bot_chat.errors import SessionNotFoundError
 from agentclaw.community.core.bot_chat.schemas import ConversationDetail
 
 
@@ -26,6 +27,52 @@ async def test_open_group_query_uses_independent_repository(service, repository)
     assert kwargs["group_id"] == "group_fixture"
     assert kwargs["session_key"] is None
     assert kwargs["from_ms"] == 0
+
+
+@pytest.mark.asyncio
+async def test_open_group_query_validates_optional_bot_membership(service, repository):
+    repository.is_bot_in_group.return_value = True
+
+    await service.list_open_sessions(
+        group_id=" group_fixture ",
+        bot_id=" bot_fixture ",
+        user_id=" collaborator_fixture ",
+        owner_id=" owner_fixture ",
+    )
+
+    repository.is_bot_in_group.assert_called_once_with(
+        "group_fixture", "bot_fixture:owner_fixture"
+    )
+    assert repository.list_scope_traces.call_args.kwargs["group_id"] == "group_fixture"
+
+
+@pytest.mark.asyncio
+async def test_open_group_query_hides_group_from_non_member(service, repository):
+    repository.is_bot_in_group.return_value = False
+
+    with pytest.raises(SessionNotFoundError):
+        await service.list_open_sessions(
+            group_id="group_fixture", bot_id="other_bot", user_id="owner_fixture"
+        )
+
+    repository.list_scope_traces.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_open_group_query_defaults_membership_owner_to_acting_user(
+    service, repository
+):
+    repository.is_bot_in_group.return_value = True
+
+    await service.list_open_sessions(
+        group_id="group_fixture",
+        bot_id="viewer_bot",
+        user_id="owner_fixture",
+    )
+
+    repository.is_bot_in_group.assert_called_once_with(
+        "group_fixture", "viewer_bot:owner_fixture"
+    )
 
 
 @pytest.mark.asyncio
@@ -55,6 +102,62 @@ async def test_open_detail_uses_independent_repository(service, repository):
 
 
 @pytest.mark.asyncio
+async def test_open_group_detail_allows_trace_from_another_bot(service, repository):
+    detail = MagicMock(spec=ConversationDetail)
+    detail.group_id = "group_fixture"
+    detail.bot_id = "source_bot"
+    repository.get_trace_detail.return_value = detail
+    repository.is_bot_in_group.return_value = True
+
+    result = await service.get_open_session(
+        "trace_fixture",
+        bot_id="viewer_bot",
+        group_id="group_fixture",
+        user_id="collaborator_fixture",
+        owner_id="owner_fixture",
+    )
+
+    assert result is detail
+    repository.is_bot_in_group.assert_called_once_with(
+        "group_fixture", "viewer_bot:owner_fixture"
+    )
+
+
+@pytest.mark.asyncio
+async def test_open_group_detail_rejects_trace_from_another_group(service, repository):
+    detail = MagicMock(spec=ConversationDetail)
+    detail.group_id = "other_group"
+    repository.get_trace_detail.return_value = detail
+    repository.is_bot_in_group.return_value = True
+
+    with pytest.raises(SessionNotFoundError):
+        await service.get_open_session(
+            "trace_fixture",
+            bot_id="viewer_bot",
+            group_id="group_fixture",
+            user_id="owner_fixture",
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("bot_id", "group_id", "user_id"),
+    [
+        ("viewer_bot", None, "owner_fixture"),
+        (None, "group_fixture", None),
+        ("viewer_bot", "group_fixture", None),
+    ],
+)
+async def test_open_group_detail_requires_complete_context(
+    service, bot_id, group_id, user_id
+):
+    with pytest.raises(ValueError):
+        await service.get_open_session(
+            "trace_fixture", bot_id=bot_id, group_id=group_id, user_id=user_id
+        )
+
+
+@pytest.mark.asyncio
 async def test_open_user_bot_query_uses_independent_repository(service, repository):
     result = MagicMock()
     repository.list_user_bot_traces.return_value = result
@@ -77,8 +180,6 @@ async def test_open_user_bot_query_uses_independent_repository(service, reposito
     ("user_id", "bot_id"),
     [("", "bot_fixture"), ("user_fixture", "  ")],
 )
-async def test_open_user_bot_query_rejects_blank_identifiers(
-    service, user_id, bot_id
-):
+async def test_open_user_bot_query_rejects_blank_identifiers(service, user_id, bot_id):
     with pytest.raises(ValueError):
         await service.list_open_user_bot_traces(user_id, bot_id)

--- a/src/backend/tests/community/core/bot_chat/test_open_bot_chat_service.py
+++ b/src/backend/tests/community/core/bot_chat/test_open_bot_chat_service.py
@@ -27,6 +27,7 @@ async def test_open_group_query_uses_independent_repository(service, repository)
     assert kwargs["group_id"] == "group_fixture"
     assert kwargs["session_key"] is None
     assert kwargs["from_ms"] == 0
+    repository.is_bot_in_group.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -99,6 +100,7 @@ async def test_open_detail_uses_independent_repository(service, repository):
 
     assert result is detail
     repository.get_trace_detail.assert_called_once_with("trace_fixture")
+    repository.is_bot_in_group.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/endpoints/test_open_bot_chat.py
+++ b/src/backend/tests/community/endpoints/test_open_bot_chat.py
@@ -7,8 +7,13 @@ from datetime import datetime, timezone
 
 import jwt
 
-from agentclaw.community.core.bot_chat.models import BcsGroupSession
-from agentclaw.community.core.repository.implementations.chat.db import BotChatDbRepository
+from agentclaw.community.core.bot_chat.models import (
+    BcsGroupParticipant,
+    BcsGroupSession,
+)
+from agentclaw.community.core.repository.implementations.chat.db import (
+    BotChatDbRepository,
+)
 from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.utils.gateway_principal_config import (
@@ -31,6 +36,10 @@ _TRACE_ID = "trace_open_endpoint_fixture"
 _SESSION_ID = "session_open_endpoint_fixture"
 _BCS_SESSION_ID = "group_open_endpoint_fixture:abcdef12"
 _SESSION_KEY = f"agent:main:bcs:group:{_BCS_SESSION_ID}"
+_GROUP_ID = "group_open_endpoint_fixture"
+_VIEWER_BOT_ID = "bot_open_endpoint_fixture"
+_VIEWER_OWNER_ID = "owner_open_endpoint_fixture"
+_VIEWER_BOT_UUID = f"{_VIEWER_BOT_ID}:{_VIEWER_OWNER_ID}"
 _SIGNING_KEY = "endpoint-test-shared-secret-at-least-32-bytes"
 
 
@@ -123,13 +132,20 @@ def _seed_trace(world) -> None:
 def _seed_group_trace(world) -> None:
     _seed_trace(world)
     with world.get(DatabasePlugin).orm_session() as session:
-        session.add(
-            BcsGroupSession(
-                session_id=_BCS_SESSION_ID,
-                group_id="group_open_endpoint_fixture",
-                session_kind="chat",
-                env=get_current_env(),
-            )
+        session.add_all(
+            [
+                BcsGroupSession(
+                    session_id=_BCS_SESSION_ID,
+                    group_id=_GROUP_ID,
+                    session_kind="chat",
+                    env=get_current_env(),
+                ),
+                BcsGroupParticipant(
+                    group_id=_GROUP_ID,
+                    bot_uuid=_VIEWER_BOT_UUID,
+                    env=get_current_env(),
+                ),
+            ]
         )
 
 
@@ -275,6 +291,52 @@ def open_bot_chat_group_list_happy():
 @endpoint_test(
     method="GET",
     path=_GROUP_PATH,
+    scenario="member_bot_happy",
+    seed=_seed_group_trace,
+    input=CaseInput(
+        path_params={"group_id": _GROUP_ID},
+        query_params={
+            "bot_id": _VIEWER_BOT_ID,
+            "user_id": "collaborator_open_endpoint_fixture",
+            "owner_id": _VIEWER_OWNER_ID,
+        },
+        headers=_principal_headers(),
+    ),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": {"total": 1, "sessions": [{"id": _TRACE_ID}]},
+        },
+    ),
+)
+def open_bot_chat_group_list_member_bot_happy():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_GROUP_PATH,
+    scenario="non_member_bot_hidden",
+    seed=_seed_group_trace,
+    input=CaseInput(
+        path_params={"group_id": _GROUP_ID},
+        query_params={
+            "bot_id": _VIEWER_BOT_ID,
+            "user_id": _VIEWER_OWNER_ID,
+            "owner_id": "other_owner",
+        },
+        headers=_principal_headers(),
+    ),
+    expect=ExpectError(status=404),
+)
+def open_bot_chat_group_list_non_member_bot_hidden():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_GROUP_PATH,
     scenario="invalid_limit",
     seed=_enable_public_auth,
     input=CaseInput(
@@ -351,6 +413,46 @@ def open_bot_chat_user_bot_list_missing_bot_id():
     ),
 )
 def open_bot_chat_detail_happy():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_DETAIL_PATH,
+    scenario="group_member_happy",
+    seed=_seed_group_trace,
+    input=CaseInput(
+        path_params={"trace_id": _TRACE_ID},
+        query_params={
+            "bot_id": _VIEWER_BOT_ID,
+            "group_id": _GROUP_ID,
+            "user_id": "collaborator_open_endpoint_fixture",
+            "owner_id": _VIEWER_OWNER_ID,
+        },
+        headers=_principal_headers(),
+    ),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"code": 200000, "data": {"id": _TRACE_ID}},
+    ),
+)
+def open_bot_chat_detail_group_member_happy():
+    """The framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_DETAIL_PATH,
+    scenario="partial_group_context",
+    seed=_seed_group_trace,
+    input=CaseInput(
+        path_params={"trace_id": _TRACE_ID},
+        query_params={"bot_id": _VIEWER_BOT_ID, "group_id": _GROUP_ID},
+        headers=_principal_headers(),
+    ),
+    expect=ExpectError(status=400),
+)
+def open_bot_chat_detail_partial_group_context():
     """The framework owns invocation."""
 
 


### PR DESCRIPTION
现有 Bot Logs 的 Group 模式只能通过当前 Bot 的日志接口查询，导致群聊内其他 Bot、个人以及其他 Session 产生的 Trace 无法展示。

  期望行为是：只要当前查看的 Bot 属于该 Group，就可以查看该 Group 下所有 Session 的完整历史 Trace，包括其他 Bot 和个人产生的群聊日志。同时需要保持老前端和现有 Backend 调用兼容，不影响 Session、Task 以及普通 Bot
  日志查询。

  ## Solution

  - 复用现有 Bot Logs 接口，没有新增接口：
      - GET /openapi/v1/bots/logs/groups/{group_id}/traces
      - GET /openapi/v1/bots/logs/traces/{trace_id}

  - 为 Group 列表和 Group Trace 详情增加可选的 Viewer Bot 上下文：
      - bot_id
      - user_id
      - owner_id
      - 详情接口额外传入 group_id

  - 根据 bot_id:{owner_id or user_id} 检查当前 Bot 是否属于目标 Group。
  - 成员校验通过后，Group 列表根据 group_id 查询该群全部 Session 的 Trace，不再按照当前 Bot 过滤。
  - Group Trace 详情额外校验 Trace 归属的 group_id，避免跨群读取。
  - 保留不带 Viewer 上下文的原有 Group 列表和 Trace 详情行为，兼容老前端及已有调用方。
  - 未修改 BCS，也未修改 Session、Task、普通 Bot Trace 和 /openapi/v1/bots/{bot_id}/chats/** 的查询逻辑。

  ## Validation

  已执行以下验证：

  Backend Bot Logs Service、Repository、Endpoint 测试：
  31 passed

  Backend 架构门禁：
  5 passed

  Ruff：
  All checks passed

  git diff --check：
  passed

  推送时 Backend pre-push SAST/lint 门禁通过：

  OCB pre-push gate passed

  另外增加了回归断言，确保：

  - 老 Group 列表请求不带 Viewer 上下文时，不访问 Group 成员表；
  - 老 Trace 详情请求不带 Group 上下文时，不访问 Group 成员表；
  - Group 成员 Bot 可以读取其他 Bot 产生的 Trace；
  - 非 Group 成员无法使用增强的 Group 查询；
  - Group Trace 详情不能跨 Group 读取。

  ## Compatibility and risk

  - 接口兼容：没有删除或新增路由，仅增加可选 Query 参数。
  - 老前端兼容：老前端不传新增参数时，继续执行原查询逻辑。
  - 现有 Backend 兼容：Session、Task、普通 Trace 和原 Bot Chats API 未改变。
  - BCS 影响：无 BCS 代码修改，仅通过 Backend 数据库 Read Model 查询现有 bcs_group_participants 和 bcs_group_sessions 数据。
  - 数据变更：无数据库 Schema 变更，无数据迁移。
  - 回滚方式：回滚本 PR 即可恢复原 Group 日志行为。

  ## Spec

  docs/superpowers/specs/2026-08-24-bot-chat-group-trace-aggregation-design.md
