### PR TITLE
fix(bcs-api-http): support context patch in openapi update_group

### DIFF
--- a/src/bcs/api-contracts/v1/openapi/groups.yaml
+++ b/src/bcs/api-contracts/v1/openapi/groups.yaml
@@ -576,6 +576,8 @@ UpdateGroup:
   properties:
     name:
       type: string
+    context:
+      type: string
     opening_message:
       oneOf:
         - $ref: ../domain-models.yaml#/OpeningMessage

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/group.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/group.rs
@@ -274,6 +274,8 @@ impl CreateGroupRequest {
 pub struct UpdateGroupRequest {
     #[serde(default, deserialize_with = "deserialize_present_non_null")]
     pub name: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_present_non_null")]
+    pub context: Option<String>,
     #[serde(default, deserialize_with = "deserialize_present_nullable")]
     pub opening_message: Option<Option<OpeningMessage>>,
     #[serde(default, deserialize_with = "deserialize_present_non_null")]
@@ -294,7 +296,7 @@ impl From<UpdateGroupRequest> for GroupPatch {
     fn from(value: UpdateGroupRequest) -> Self {
         Self {
             name: value.name,
-            context: None,
+            context: value.context,
             opening_message: value.opening_message,
             visibility: value.visibility,
             delivery_policy: value.delivery_policy.map(|policy| GroupDeliveryPolicy {

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/group_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/group_routes.rs
@@ -831,6 +831,39 @@ async fn patch_rejects_explicit_null_for_every_mutable_field() {
 }
 
 #[tokio::test]
+async fn patch_forwards_context_to_the_group_service() {
+    let service = Arc::new(FakeGroupService::default());
+    let app = test_router(service.clone());
+
+    let response = app
+        .oneshot(authenticated_request(
+            "PATCH",
+            "/openapi/v1/collaboration/groups/group-1",
+            json!({
+                "name": "Renamed",
+                "context": "updated context"
+            }),
+        ))
+        .await
+        .expect("patch response");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let command = service
+        .updated
+        .lock()
+        .expect("update lock")
+        .as_ref()
+        .expect("update command")
+        .clone();
+    assert_eq!(command.group_id, "group-1");
+    assert_eq!(command.patch.name.as_deref(), Some("Renamed"));
+    assert_eq!(command.patch.context.as_deref(), Some("updated context"));
+    assert!(command.patch.delivery_policy.is_none());
+    assert!(command.patch.visibility.is_none());
+    assert!(command.patch.opening_message.is_none());
+}
+
+#[tokio::test]
 async fn malformed_percent_encoded_paths_use_the_common_error_envelope() {
     let service = Arc::new(FakeGroupService::default());
     let app = test_router(service);


### PR DESCRIPTION
## Problem

The OpenAPI v1 `update_group` route (`bcs_api_http::v1::openapi::routes::group::update_group`) could not update a group's `context`, while the legacy `patch_group` route (`bcs_http::routes::groups::patch_group`) can. The gap existed at three layers:

- `UpdateGroupRequest` DTO had no `context` field.
- `From<UpdateGroupRequest> for GroupPatch` hardcoded `context: None`, so even if the field existed it would never reach the application layer.
- The `UpdateGroup` contract schema (`api-contracts/v1/openapi/groups.yaml`) is `additionalProperties: false` and listed no `context` property, so contract-conformant clients could not send it at all.

## Solution

Add `context` patching to the OpenAPI path, matching the legacy route's semantics:

- Added `context: Option<String>` to `UpdateGroupRequest` with `deserialize_present_non_null` (present-non-null semantics, identical to `name` — explicit `null` is rejected with 400, matching the existing `patch_rejects_explicit_null_for_every_mutable_field` test).
- Mapped `context: value.context` in `From<UpdateGroupRequest> for GroupPatch` (was `context: None`).
- Added a `context` string property to the `UpdateGroup` contract schema.

No application-layer change: `GroupPatch.context` and `GroupServiceImpl::update` already persist `context`. The fix is confined to the OpenAPI delivery adapter and contract, restoring parity with `patch_group`.

## Validation

- `cargo test --package bcs-api-http --test group_routes` — 21 passed, including:
  - new `patch_forwards_context_to_the_group_service` (asserts `{"name":"Renamed","context":"updated context"}` reaches `UpdateGroup.patch.context`, other fields stay `None`);
  - existing `patch_rejects_explicit_null_for_every_mutable_field` (`{"context": null}` still rejected as 400, now via the deserializer rather than unknown-field).
- `scripts/validate_openapi_contract.py --root api-contracts/v1` — 49 operations validated.

## Compatibility and risk

Contract-additive only: a new optional `context` property on `UpdateGroup`. Clients that omit it are unaffected; clients that send it now work where they previously got 400 (unknown field). No schema migration, no persistence change — `context` was already a persisted mutable field via the legacy route.