### PR TITLE
fix(service-bot): restore draft deletion eligibility

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_inventory/adapters/service_lifecycle.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/adapters/service_lifecycle.py
@@ -30,11 +30,6 @@ _DEPLOYING = {
     PublishStatus.FAILED.value,
 }
 _ONLINE = {PublishStatus.SUCCESS.value}
-_PUBLISHED_HISTORY = {
-    PublishStatus.SUCCESS.value,
-    PublishStatus.UPGRADED.value,
-    PublishStatus.RELEASED.value,
-}
 
 
 class ServiceLifecycleView(ServiceLifecyclePort):
@@ -118,7 +113,9 @@ class ServiceLifecycleView(ServiceLifecyclePort):
 
         if record.status == PublishStatus.DRAFT.value:
             add(BotAction.EDIT, BotAction.PUBLISH_STAGING)
-            if not any(item.status in _PUBLISHED_HISTORY for item in all_records):
+            if not any(
+                item.status == PublishStatus.SUCCESS.value for item in all_records
+            ):
                 add(BotAction.DELETE)
         elif record.status == PublishStatus.VALIDATING.value:
             add(

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -985,18 +985,9 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
             env=self._env,
         )
 
-        # 4. Any formal-publish history makes the service Bot permanent.  An
-        # offline operation creates a fresh DRAFT, so checking SUCCESS alone
-        # would let that new row delete a Bot whose prior version is RELEASED
-        # (or UPGRADED).  FAILED is intentionally not included: a never-live
-        # initial draft may fail and still be discarded.
-        published_history = {
-            PublishStatus.SUCCESS.value,
-            PublishStatus.UPGRADED.value,
-            PublishStatus.RELEASED.value,
-        }
+        # 4. 检查是否有发布成功的记录（排除当前记录）
         for p in all_publishes:
-            if p.id != publish_id and p.status in published_history:
+            if p.id != publish_id and p.status == PublishStatus.SUCCESS:
                 return False
 
         return True

--- a/src/backend/src/agentclaw/community/core/service_bot/services/service_publication_facade.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/service_publication_facade.py
@@ -75,13 +75,6 @@ _DEPLOYING = {
     PublishStatus.VALIDATE_PUB.value,
     PublishStatus.ONLINE_PUB.value,
 }
-_PUBLISHED_HISTORY = {
-    PublishStatus.SUCCESS.value,
-    PublishStatus.UPGRADED.value,
-    PublishStatus.RELEASED.value,
-}
-
-
 @dataclass(frozen=True)
 class _ServiceEditLockInfo:
     """Public lock projection enriched with service-draft applicability."""
@@ -283,7 +276,7 @@ class ServicePublicationFacade:
         if record.status == PublishStatus.DRAFT.value:
             actions.append("publish_staging")
             if level >= PermissionLevel.OWNER and not any(
-                item.status in _PUBLISHED_HISTORY for item in all_records
+                item.status == PublishStatus.SUCCESS.value for item in all_records
             ):
                 actions.append("delete")
         elif record.status == PublishStatus.VALIDATING.value:

--- a/src/backend/tests/community/core/bot_inventory/adapters/test_service_lifecycle.py
+++ b/src/backend/tests/community/core/bot_inventory/adapters/test_service_lifecycle.py
@@ -73,7 +73,7 @@ def test_cards_are_batched_and_expand_each_service_bot(monkeypatch) -> None:
     assert result["service-1"][0].display_state is DisplayState.SERVICE_DRAFT
     assert result["service-1"][0].status == "draft"
     assert result["service-1"][0].internal_status == PublishStatus.DRAFT.value
-    assert BotAction.DELETE not in result["service-1"][0].actions
+    assert BotAction.DELETE in result["service-1"][0].actions
     assert result["service-2"][0].display_state is DisplayState.SERVICE_ONLINE
     assert result["service-2"][0].status == "running"
     assert result["service-2"][0].live_version == 7
@@ -148,3 +148,13 @@ def test_service_actions_follow_the_confirmed_product_matrix(status, expected) -
     row = record(1, 10, "service-1", status, 1)
 
     assert ServiceLifecycleView._record_actions(row, [row]) == expected
+
+
+@pytest.mark.unit
+def test_draft_delete_is_blocked_while_an_online_version_exists() -> None:
+    draft = record(2, 10, "service-1", PublishStatus.DRAFT, 2)
+    online = record(1, 10, "service-1", PublishStatus.SUCCESS, 1)
+
+    actions = ServiceLifecycleView._record_actions(draft, [draft, online])
+
+    assert BotAction.DELETE not in actions

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -899,10 +899,10 @@ class TestCanDeleteBot:
         "historical_status",
         [PublishStatus.UPGRADED, PublishStatus.RELEASED],
     )
-    def test_can_delete_bot_rejects_formally_published_history(
+    def test_can_delete_bot_allows_inactive_publish_history(
         self, historical_status
     ):
-        """下线/升级后新建的草稿不能反向删除整个服务 Bot。"""
+        """历史版本已升级或下线时，当前草稿仍可删除。"""
         mock_repo = Mock()
         draft_record = _create_mock_record(
             record_id=2,
@@ -917,7 +917,7 @@ class TestCanDeleteBot:
 
         service = _make_service(bot_publish_repo=mock_repo)
 
-        assert service.can_delete_bot(publish_id=2) is False
+        assert service.can_delete_bot(publish_id=2) is True
 
 
 class TestCanEditBot:

--- a/src/backend/tests/community/core/service_bot/services/test_service_publication_facade.py
+++ b/src/backend/tests/community/core/service_bot/services/test_service_publication_facade.py
@@ -308,6 +308,34 @@ def test_projection_status_and_actions(
     assert result["available_actions"] == actions
 
 
+@pytest.mark.parametrize(
+    "historical_status",
+    [PublishStatus.UPGRADED, PublishStatus.RELEASED],
+)
+def test_draft_delete_remains_available_after_inactive_publish_history(
+    deps, historical_status
+):
+    draft = record(2, PublishStatus.DRAFT, version=2)
+    historical = record(1, historical_status, version=1)
+
+    assert deps.facade._actions(
+        draft,
+        level=PermissionLevel.OWNER,
+        all_records=[draft, historical],
+    ) == ["publish_staging", "delete"]
+
+
+def test_draft_delete_is_blocked_while_an_online_version_exists(deps):
+    draft = record(2, PublishStatus.DRAFT, version=2)
+    online = record(1, PublishStatus.SUCCESS, version=1)
+
+    assert deps.facade._actions(
+        draft,
+        level=PermissionLevel.OWNER,
+        all_records=[draft, online],
+    ) == ["publish_staging"]
+
+
 def test_failed_projection_sanitizes_error_and_uses_source_status(deps, monkeypatch):
     monkeypatch.setattr(
         "agentclaw.community.core.service_bot.services.service_publication_facade.get_current_env",


### PR DESCRIPTION
## Summary

Restore the legacy, product-confirmed service Bot draft deletion rule after the workshop reconstruction merge:

- block draft deletion only while another `SUCCESS` publication exists
- allow deletion when prior publications are `RELEASED` or `UPGRADED`
- keep lifecycle detail actions, unified inventory actions, and the domain guard consistent
- retain all other lifecycle behavior, including VERIFY runtime teardown on staging cancellation

## Behavior

| Publication history | Current draft deletion |
| --- | --- |
| `SUCCESS + DRAFT` | blocked |
| `RELEASED + DRAFT` | allowed for Owner |
| `UPGRADED + DRAFT` | allowed for Owner |

The delete operation retains its existing semantics: it deletes the service Bot, not only the publication row.

## Validation

- `DEPLOY_PROFILE=test uv run pytest tests/community/core/service_bot/services/test_bot_publish_service.py tests/community/core/service_bot/services/test_service_publication_facade.py tests/community/core/bot_inventory/adapters/test_service_lifecycle.py tests/community/adapters/http/openapi_v1/test_service_publication_endpoints.py -q` (`203 passed`)
- focused Ruff check passed
- `git diff --check` passed
- pre-push required gate passed against `origin/dev`