### PR TITLE
fix(backend): keep Local Skill replacement transactional

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
@@ -790,7 +790,10 @@ class SkillRepository(
         new_locator: str,
         description: str,
     ) -> dict | None:
-        """Atomically switch one Local Skill to its canonical package locator."""
+        """Update one Local Skill while preserving its canonical locator."""
+
+        if old_locator != new_locator:
+            raise ValueError("Local Skill replacement cannot change git_path")
 
         with self._db.transactional_orm_session() as db:
             skill = (
@@ -808,7 +811,6 @@ class SkillRepository(
             if skill is None:
                 return None
             skill.description = description
-            skill.git_path = f"local://{new_locator}"
             skill.user_id = _normalize_user_id(owner_id)
             skill.gmt_modified = func.now()
             db.flush()

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -158,19 +158,17 @@ SkillSet/Direct commands continue to maintain Installation synchronously; the
 lazy materializer only fills the missing active ordinary SkillSet rows that
 pre-date the new command path.
 
-Local Skill replacement stages a complete package before switching the existing
-Skill metadata. Its old-package cleanup work is persisted before an Active
-runtime switch can commit; a rollback cancels that old-locator work before the
-old package becomes authoritative again. Failed post-switch obsolete-byte deletion is recorded through
-`LocalSkillCleanupRepository` in the exact deployment-wide Bot scope
-`(env, owner_id, bot_id)`.  The next serialized Local Skill mutation retries
-pending work; it marks successful work `cleaned` and retains failures with an
-attempt count and a stable operator-safe error.  A task that follows a failed
-Active rollback retains its staged bytes and restores the old runtime mapping
-before it attempts byte cleanup. Cleanup identity uses the full SHA-256 of the
-locator, while retaining the locator itself for execution; a digest collision
-fails closed. Apply
-`sql/2026_08_04_local_skill_cleanup_work.sql` before deploying this behavior.
+Local Skill replacement is defined only for an existing complete package at the
+stable layout-owned `skills-local/<skill-name>` locator. It stages and verifies
+the new package, backs up the old package, and publishes the replacement back to
+that same locator; the Skill ID, `git_path`, desired active state, membership,
+and Installation identity do not change. Staging and rollback directories are
+temporary implementation details and are removed before success is returned.
+If publication, metadata persistence, runtime reconcile, audit persistence, or
+temporary-package cleanup fails, the old canonical package and metadata are
+restored before the request fails. A non-canonical locator or a metadata row
+whose authoritative package is missing fails closed and is repaired outside the
+upload path.
 
 Public Local Skill deletion first persists a non-purgeable `preparing` record,
 then promotes it to `repair_required` before copying and verifying package

--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -341,18 +341,16 @@ class LocalSkillUploadService:
                 name=name,
             )
         )
-        staged_locator, staged = (
-            self._skill_service_factory.local_skill_package_storage(
-                entity_id=str(bot["entity_id"]),
-                owner_id=owner_id,
-                bot_id=bot_id,
-                engine_type=bot.get("active_engine"),
-                entity_type=str(bot.get("entity_type") or "staff"),
-                is_desktop=bot.get("bot_type") == "desktop",
-                is_teclaw=is_teclaw,
-                name=name,
-                directory_name=version_dir,
-            )
+        _, staged = self._skill_service_factory.local_skill_package_storage(
+            entity_id=str(bot["entity_id"]),
+            owner_id=owner_id,
+            bot_id=bot_id,
+            engine_type=bot.get("active_engine"),
+            entity_type=str(bot.get("entity_type") or "staff"),
+            is_desktop=bot.get("bot_type") == "desktop",
+            is_teclaw=is_teclaw,
+            name=name,
+            directory_name=version_dir,
         )
         old_storage = (
             self._skill_service_factory.local_skill_package_storage_for_locator(
@@ -367,13 +365,12 @@ class LocalSkillUploadService:
             )
         )
         has_old_package = await old_storage.exists()
-        # A previous delete can leave a stale Local Skill row while its
-        # canonical package directory is already gone.  That row still makes
-        # this a same-name replacement, but it provides no bytes to back up.
-        # Treat it as a metadata-only legacy record and publish the staged
-        # package directly to the stable canonical locator.
-        old_is_canonical = old_locator == canonical_locator and has_old_package
-        obsolete_storage = old_storage if has_old_package else None
+        # Replacement is defined only for the stable layout-owned locator.
+        # It must never migrate ``git_path`` or manufacture a new package for a
+        # metadata row whose old bytes are already missing: either case would
+        # leave no authoritative old package to restore on failure.
+        if old_locator != canonical_locator or not has_old_package:
+            raise LocalSkillStorageError()
         backup = None
         old_metadata = {
             "description": skill.get("description"),
@@ -386,23 +383,19 @@ class LocalSkillUploadService:
         try:
             await staged.write(files)
             await staged.verify()
-            if old_is_canonical:
-                backup_dir = f".{name}.rollback-{uuid4().hex}"
-                _, backup = (
-                    self._skill_service_factory.local_skill_package_storage(
-                        entity_id=str(bot["entity_id"]),
-                        owner_id=owner_id,
-                        bot_id=bot_id,
-                        engine_type=bot.get("active_engine"),
-                        entity_type=str(bot.get("entity_type") or "staff"),
-                        is_desktop=bot.get("bot_type") == "desktop",
-                        is_teclaw=is_teclaw,
-                        name=name,
-                        directory_name=backup_dir,
-                    )
-                )
-                await old_storage.copy_to(backup)
-                obsolete_storage = backup
+            backup_dir = f".{name}.rollback-{uuid4().hex}"
+            _, backup = self._skill_service_factory.local_skill_package_storage(
+                entity_id=str(bot["entity_id"]),
+                owner_id=owner_id,
+                bot_id=bot_id,
+                engine_type=bot.get("active_engine"),
+                entity_type=str(bot.get("entity_type") or "staff"),
+                is_desktop=bot.get("bot_type") == "desktop",
+                is_teclaw=is_teclaw,
+                name=name,
+                directory_name=backup_dir,
+            )
+            await old_storage.copy_to(backup)
             # ``copy_to(..., replace=True)`` can fail after clearing or partly
             # writing the canonical directory.  Mark the mutation before the
             # call so every such failure restores the old authority.
@@ -436,14 +429,10 @@ class LocalSkillUploadService:
             await self._restore_replacement(
                 skill=skill,
                 old_metadata=old_metadata,
-                bot=bot,
                 owner_id=owner_id,
                 bot_id=bot_id,
                 staged=staged,
-                staged_locator=staged_locator,
                 canonical=canonical,
-                canonical_locator=canonical_locator,
-                old_is_canonical=old_is_canonical,
                 backup=backup,
                 canonical_published=canonical_published,
                 switched=switched,
@@ -455,14 +444,10 @@ class LocalSkillUploadService:
                 await self._restore_replacement(
                     skill=skill,
                     old_metadata=old_metadata,
-                    bot=bot,
                     owner_id=owner_id,
                     bot_id=bot_id,
                     staged=staged,
-                    staged_locator=staged_locator,
                     canonical=canonical,
-                    canonical_locator=canonical_locator,
-                    old_is_canonical=old_is_canonical,
                     backup=backup,
                     canonical_published=canonical_published,
                     switched=switched,
@@ -473,9 +458,29 @@ class LocalSkillUploadService:
                     await self._discard(backup)
                 await self._discard(staged)
             raise LocalSkillStorageError() from exc
-        if obsolete_storage is not None:
-            await self._discard(obsolete_storage)
-        await self._discard(staged)
+        try:
+            # Keep the rollback copy until every other temporary package has
+            # been removed.  If any cleanup fails, the operation still has the
+            # bytes required to restore the old canonical package.
+            await self._discard(staged)
+            await self._discard(backup)
+        except Exception as exc:
+            try:
+                await self._restore_replacement(
+                    skill=skill,
+                    old_metadata=old_metadata,
+                    owner_id=owner_id,
+                    bot_id=bot_id,
+                    staged=staged,
+                    canonical=canonical,
+                    backup=backup,
+                    canonical_published=canonical_published,
+                    switched=switched,
+                    runtime_sync_attempted=runtime_sync_attempted,
+                )
+            except Exception as rollback_exc:
+                raise LocalSkillStorageError() from rollback_exc
+            raise LocalSkillStorageError() from exc
         return {
             "operation": "updated",
             "skill": {
@@ -492,14 +497,10 @@ class LocalSkillUploadService:
         *,
         skill: dict[str, Any],
         old_metadata: dict[str, Any],
-        bot: dict[str, Any],
         owner_id: str,
         bot_id: str,
         staged,
-        staged_locator: str,
         canonical,
-        canonical_locator: str,
-        old_is_canonical: bool,
         backup,
         canonical_published: bool,
         switched: bool,
@@ -507,12 +508,9 @@ class LocalSkillUploadService:
     ) -> None:
         if canonical_published:
             try:
-                if old_is_canonical:
-                    if backup is None:
-                        raise LocalSkillStorageError()
-                    await backup.copy_to(canonical, replace=True)
-                elif not await canonical.cleanup():
+                if backup is None:
                     raise LocalSkillStorageError()
+                await backup.copy_to(canonical, replace=True)
             except Exception as exc:
                 raise LocalSkillStorageError() from exc
         if switched:
@@ -543,6 +541,7 @@ class LocalSkillUploadService:
         except Exception as exc:
             raise LocalSkillStorageError() from exc
         return context.provider == "teclaw"
+
     def _same_name_matches(
         self, *, bot_id: str, owner_id: str, name: str
     ) -> list[dict[str, Any]]:

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -601,7 +601,14 @@ class _DeviceResolver:
 
 
 def _replacement_service(
-    filesystem, repo, runtime, _unused_cleanup=None, guard=None, *, provider="local", sets=None
+    filesystem,
+    repo,
+    runtime,
+    _unused_cleanup=None,
+    guard=None,
+    *,
+    provider="local",
+    sets=None,
 ):
     return LocalSkillUploadService(
         repo,
@@ -828,9 +835,9 @@ async def test_multipart_single_zip_keeps_legacy_auto_extract_behavior():
     )
 
     assert result["skill"]["name"] == "archive-skill"
-    assert filesystem.files["/private/skills-local/archive-skill/SKILL.md"] == _skill_md(
-        "archive-skill"
-    )
+    assert filesystem.files[
+        "/private/skills-local/archive-skill/SKILL.md"
+    ] == _skill_md("archive-skill")
 
 
 @pytest.mark.asyncio
@@ -1182,54 +1189,79 @@ async def test_same_name_replacement_preserves_id_owner_and_desired_state_after_
 
 
 @pytest.mark.asyncio
-async def test_replacement_recreates_a_missing_canonical_package_for_a_stale_row():
+async def test_replacement_rejects_a_stale_row_with_no_authoritative_package():
     filesystem = _Filesystem()
     skill = _existing_skill(active=False)
     repo = _ReplacementRepo([skill])
 
-    result = await _replacement_service(
-        filesystem, repo, _ReplacementRuntime([True])
-    ).upload_local_skill(
-        bot_id="bot",
-        owner_id="owner",
-        actor_id="owner",
-        package=_zip(
-            {"SKILL.md": b"name: upload-skill\ndescription: restored\n"}
-        ),
-    )
+    with pytest.raises(LocalSkillStorageError):
+        await _replacement_service(
+            filesystem, repo, _ReplacementRuntime([True])
+        ).upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="owner",
+            package=_zip({"SKILL.md": b"name: upload-skill\ndescription: restored\n"}),
+        )
 
-    assert result["operation"] == "updated"
     assert skill["git_path"] == "local:///private/skills-local/upload-skill"
-    assert filesystem.files["/private/skills-local/upload-skill/SKILL.md"] == (
-        b"name: upload-skill\ndescription: restored\n"
-    )
+    assert filesystem.files == {}
     assert not any(".replacement-" in path for path in filesystem.files)
 
 
 @pytest.mark.asyncio
-async def test_replacement_migrates_a_legacy_hidden_locator_to_the_canonical_path():
+async def test_replacement_rejects_a_noncanonical_existing_locator_without_writing():
     old_locator = "/private/skills-local/.upload-skill.replacement-old"
     filesystem = _Filesystem()
     filesystem.files[f"{old_locator}/SKILL.md"] = b"old"
     old = {**_existing_skill(active=False), "git_path": f"local://{old_locator}"}
     repo = _ReplacementRepo([old])
 
-    result = await _replacement_service(
-        filesystem, repo, _ReplacementRuntime([True])
-    ).upload_local_skill(
-        bot_id="bot",
-        owner_id="owner",
-        actor_id="owner",
-        package=_zip({"SKILL.md": b"name: upload-skill\ndescription: canonical\n"}),
-    )
+    with pytest.raises(LocalSkillStorageError):
+        await _replacement_service(
+            filesystem, repo, _ReplacementRuntime([True])
+        ).upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="owner",
+            package=_zip({"SKILL.md": b"name: upload-skill\ndescription: canonical\n"}),
+        )
 
     canonical = "/private/skills-local/upload-skill"
-    assert result["skill"]["git_path"] == f"local://{canonical}"
+    assert old["git_path"] == f"local://{old_locator}"
+    assert f"{canonical}/SKILL.md" not in filesystem.files
+    assert filesystem.files[f"{old_locator}/SKILL.md"] == b"old"
+    assert set(filesystem.files) == {f"{old_locator}/SKILL.md"}
+
+
+@pytest.mark.asyncio
+async def test_post_commit_temp_cleanup_failure_restores_old_package_and_metadata():
+    # canonical publish succeeds, then the first final temp cleanup fails once.
+    # The upload must restore the previous package before reporting failure.
+    filesystem = _Filesystem(cleanup_results=[True, False, True, True, True])
+    canonical = "/private/skills-local/upload-skill"
+    filesystem.files[f"{canonical}/SKILL.md"] = b"old"
+    old = _existing_skill(active=False)
+    repo = _ReplacementRepo([old])
+
+    with pytest.raises(LocalSkillStorageError):
+        await _replacement_service(
+            filesystem, repo, _ReplacementRuntime([True, True])
+        ).upload_local_skill(
+            bot_id="bot",
+            owner_id="owner",
+            actor_id="owner",
+            package=_zip({"SKILL.md": _skill_md(description="new description")}),
+        )
+
     assert old["git_path"] == f"local://{canonical}"
-    assert filesystem.files[f"{canonical}/SKILL.md"] == (
-        b"name: upload-skill\ndescription: canonical\n"
+    assert old["description"] == "old description"
+    assert filesystem.files[f"{canonical}/SKILL.md"] == b"old"
+    assert not any(
+        marker in path
+        for path in filesystem.files
+        for marker in (".replacement-", ".rollback-")
     )
-    assert not any(".replacement-" in path for path in filesystem.files)
 
 
 @pytest.mark.asyncio
@@ -1276,41 +1308,10 @@ async def test_restore_replacement_requires_backup_after_canonical_publish():
         await service._restore_replacement(
             skill=skill,
             old_metadata={},
-            bot={"env": "test", "entity_id": "owner", "active_engine": "moltis"},
             owner_id="owner",
             bot_id="bot",
             staged=_Storage(filesystem, "/private/staged"),
-            staged_locator="/private/staged",
             canonical=_Storage(filesystem, "/private/canonical"),
-            canonical_locator="/private/canonical",
-            old_is_canonical=True,
-            backup=None,
-            canonical_published=True,
-            switched=False,
-            runtime_sync_attempted=False,
-        )
-
-
-@pytest.mark.asyncio
-async def test_restore_replacement_requires_noncanonical_publish_cleanup():
-    filesystem = _Filesystem(cleanup_results=[False])
-    skill = _existing_skill(active=False)
-    service = _replacement_service(
-        filesystem, _ReplacementRepo([skill]), _ReplacementRuntime([True])
-    )
-
-    with pytest.raises(LocalSkillStorageError):
-        await service._restore_replacement(
-            skill=skill,
-            old_metadata={},
-            bot={"env": "test", "entity_id": "owner", "active_engine": "moltis"},
-            owner_id="owner",
-            bot_id="bot",
-            staged=_Storage(filesystem, "/private/staged"),
-            staged_locator="/private/staged",
-            canonical=_Storage(filesystem, "/private/canonical"),
-            canonical_locator="/private/canonical",
-            old_is_canonical=False,
             backup=None,
             canonical_published=True,
             switched=False,

--- a/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
@@ -256,6 +256,36 @@ def test_public_local_delete_commits_cleanup_work_with_derived_state(skills, set
             assert session.query(DefaultSkillsetSkillExclusion).count() == 0
 
 
+def test_public_local_replace_rejects_a_locator_change(skills, db):
+    with avernet_tenant_scope("tenant-a"):
+        skill = skills.create(
+            {
+                "name": "local",
+                "description": "old",
+                "git_path": "local:///skills/local",
+                "user_id": "owner",
+                "bolt_id": "bot",
+            }
+        )
+
+        with pytest.raises(
+            ValueError, match="Local Skill replacement cannot change git_path"
+        ):
+            skills.replace_bot_local_skill(
+                skill_id=skill["id"],
+                owner_id="owner",
+                bot_id="bot",
+                old_locator="/skills/local",
+                new_locator="/skills/.local.replacement-1",
+                description="new",
+            )
+
+        with db.orm_session() as session:
+            persisted = session.query(Skill).one()
+            assert persisted.git_path == "local:///skills/local"
+            assert persisted.description == "old"
+
+
 @pytest.mark.skip(reason="durable cleanup work was removed")
 def test_public_local_replace_commits_locator_and_cleanup_work_atomically(skills, db):
     from agentclaw.community.core.repository.implementations.skill_center.local_skill_cleanup import SqlLocalSkillCleanupRepository


### PR DESCRIPTION
## Problem

Same-name Local Skill replacement must preserve the stable `skills-local/<skill-name>` locator and behave atomically. The existing flow could accept a non-canonical or missing package locator, and a failure while removing temporary replacement/rollback packages after runtime reconciliation could return an error while leaving the new package and metadata committed.

## Solution

- Fail closed unless the existing package is complete and already at the canonical layout-owned locator.
- Enforce in the repository that replacement cannot change `git_path`.
- Keep the rollback package until staging cleanup has completed.
- If final temporary-package cleanup fails, restore the old canonical package, metadata, and runtime projection before returning failure.
- Document that historical non-canonical rows are repaired outside the upload path.

## Validation

- `uv run --project src/backend pytest -q src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py src/backend/tests/community/endpoints/test_openapi_skill_upload.py src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py src/backend/tests/community/architecture/test_module_boundaries.py`
  - 128 passed, 15 skipped
- Ruff checks passed for all changed Python files.
- Local Python SAST blocking-rule scan passed for all changed Python files.
- `git diff --check` passed.

## Compatibility and risk

The published Local Skill HTTP response and stable Skill identity are unchanged. Same-name replacement now explicitly refuses historical non-canonical locators or rows whose authoritative package is missing; the known pre-release residue is intentionally cleaned separately rather than migrated by the upload path. Rollback is the existing recovery path and now also covers final temporary-package cleanup failure. No schema change is required.