### PR TITLE
fix(bcs): persist canonical routing policy JSON

### DIFF
--- a/src/bcs/crates/bootstrap/bcs/src/friend_connect_notification.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/friend_connect_notification.rs
@@ -265,8 +265,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn notify_returns_internal_error_when_backend_unreachable() {
-        let adapter = HttpFriendConnectNotificationPort::new("http://127.0.0.1:9").expect("valid url");
+    async fn notify_returns_internal_error_when_backend_is_unavailable() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind unavailable backend");
+        let mut adapter = HttpFriendConnectNotificationPort::new(&format!(
+            "http://{}",
+            listener.local_addr().expect("backend address")
+        ))
+        .expect("valid url");
+        adapter.client = reqwest::Client::builder()
+            .no_proxy()
+            .timeout(std::time::Duration::from_millis(100))
+            .build()
+            .expect("build test client");
         let result = adapter
             .notify(FriendConnectNotificationCommand {
                 kind: FriendConnectNotificationKind::ApprovalRequested,

--- a/src/bcs/crates/services/bcs-group-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-group-store/src/lib.rs
@@ -96,6 +96,12 @@ fn db_timestamp_from_millis(timestamp_ms: u64) -> ServiceResult<String> {
         .ok_or_else(|| ServiceError::InternalError("Group timestamp is invalid".to_string()))
 }
 
+fn routing_policy_json(policy: Option<&RoutingPolicy>, delivery: DefaultDelivery) -> String {
+    let mut policy = policy.cloned().unwrap_or_default();
+    policy.default_bot_final_delivery = delivery;
+    serde_json::to_string(&policy).expect("RoutingPolicy contains only JSON-compatible values")
+}
+
 fn group_version_update_step(
     env: &str,
     group_id: DbTransactionParam,
@@ -1323,14 +1329,10 @@ impl GroupRepoPort for MySqlGroupStore {
                     params.push(DbTransactionParam::value(visibility.as_str()));
                 }
                 if let Some(delivery) = patch.default_bot_final_delivery {
-                    assignments.push(match self.flavor {
-                        DbSqlFlavor::Mysql => "routing_policy_json = JSON_SET(COALESCE(routing_policy_json, JSON_OBJECT()), '$.default_bot_final_delivery', ?)".to_string(),
-                        DbSqlFlavor::Sqlite => "routing_policy_json = json_set(COALESCE(routing_policy_json, '{}'), '$.default_bot_final_delivery', ?)".to_string(),
-                    });
-                    params.push(DbTransactionParam::value(match delivery {
-                        DefaultDelivery::SendToDriver => "send_to_driver",
-                        DefaultDelivery::InjectObservers => "inject_observers",
-                    }));
+                    let policy_json =
+                        routing_policy_json(terminal.routing_policy.as_ref(), delivery);
+                    assignments.push("routing_policy_json = ?".to_string());
+                    params.push(DbTransactionParam::value(policy_json));
                 }
                 if assignments.is_empty() {
                     return Err(ServiceError::Conflict(
@@ -1566,9 +1568,10 @@ impl GroupRepoPort for MySqlGroupStore {
         id: &str,
         patch: GroupMutableFieldsPatch,
     ) -> ServiceResult<()> {
-        if self.try_get(id).await?.is_none() {
-            return Err(ServiceError::GroupNotFound(id.to_string()));
-        }
+        let group = self
+            .try_get(id)
+            .await?
+            .ok_or_else(|| ServiceError::GroupNotFound(id.to_string()))?;
 
         let mut assignments = Vec::new();
         let mut params = Vec::new();
@@ -1596,19 +1599,9 @@ impl GroupRepoPort for MySqlGroupStore {
             params.push(Value::from(visibility.as_str()));
         }
         if let Some(delivery) = patch.default_bot_final_delivery {
-            let expression = match self.flavor {
-                DbSqlFlavor::Mysql => {
-                    "routing_policy_json = JSON_SET(COALESCE(routing_policy_json, JSON_OBJECT()), '$.default_bot_final_delivery', ?)"
-                }
-                DbSqlFlavor::Sqlite => {
-                    "routing_policy_json = json_set(COALESCE(routing_policy_json, '{}'), '$.default_bot_final_delivery', ?)"
-                }
-            };
-            assignments.push(expression.to_string());
-            params.push(Value::from(match delivery {
-                DefaultDelivery::SendToDriver => "send_to_driver",
-                DefaultDelivery::InjectObservers => "inject_observers",
-            }));
+            let policy_json = routing_policy_json(group.routing_policy.as_ref(), delivery);
+            assignments.push("routing_policy_json = ?".to_string());
+            params.push(Value::from(policy_json));
         }
         if assignments.is_empty() {
             return Ok(());
@@ -3793,6 +3786,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn mutable_patch_reports_a_missing_group() {
+        let repo = MySqlGroupStore::new(Arc::new(RecordingDbPlugin::default()), "local".into());
+
+        let error = repo
+            .patch_mutable_fields(
+                "missing-group",
+                GroupMutableFieldsPatch {
+                    default_bot_final_delivery: Some(DefaultDelivery::InjectObservers),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("missing group must fail");
+
+        assert!(matches!(error, ServiceError::GroupNotFound(id) if id == "missing-group"));
+    }
+
+    #[tokio::test]
     async fn delete_aborts_before_persistence_when_snapshot_read_fails() {
         let db = Arc::new(RecordingDbPlugin::failing_queries());
         let repo = MySqlGroupStore::new(db.clone(), "local".to_string());
@@ -3950,10 +3961,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mutable_patch_uses_field_scoped_sql() {
+    async fn mutable_patch_serializes_routing_policy_before_sql() {
         let db = Arc::new(RecordingDbPlugin::with_first_execute_affected_rows(1));
         let repo = MySqlGroupStore::new(db.clone(), "local".to_string());
-        let group = Group::new("group-1", "driver", Vec::new());
+        let mut group = Group::new("group-1", "driver", Vec::new());
+        let mut policy = RoutingPolicy {
+            mode: bcs_service_api::RoutingMode::Mention,
+            default_bot_final_delivery: DefaultDelivery::SendToDriver,
+            sender_routes: HashMap::from([(
+                "driver".to_string(),
+                vec!["observer".to_string()],
+            )]),
+        };
+        group.routing_policy = Some(policy.clone());
         repo.cache.write().await.insert(group.id.clone(), group);
 
         repo.patch_mutable_fields(
@@ -3971,15 +3991,17 @@ mod tests {
         assert_eq!(statements.len(), 1);
         let sql = statements[0].sql();
         assert!(sql.contains("label = ?"));
-        assert!(sql.contains("JSON_SET"));
-        assert!(sql.contains("$.default_bot_final_delivery"));
-        assert!(!sql.contains("sender_routes"));
+        assert!(sql.contains("routing_policy_json = ?"));
+        assert!(!sql.contains("JSON_SET"));
+        assert!(!sql.contains("json_set"));
         assert!(!sql.contains("participants"));
+        policy.default_bot_final_delivery = DefaultDelivery::InjectObservers;
+        let policy_json = serde_json::to_string(&policy).expect("serialize routing policy");
         assert_eq!(
             statements[0].params(),
             &[
                 Value::from("Renamed"),
-                Value::from("inject_observers"),
+                Value::from(policy_json),
                 Value::from("group-1"),
                 Value::from("local"),
             ]

--- a/src/bcs/crates/services/bcs-group-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-group-store/src/lib.rs
@@ -102,12 +102,11 @@ fn routing_policy_json(policy: Option<&RoutingPolicy>, delivery: DefaultDelivery
     serde_json::to_string(&policy).expect("RoutingPolicy contains only JSON-compatible values")
 }
 
-fn patch_stored_routing_policy_json(
+fn parse_stored_routing_policy_json(
     stored_json: Option<&str>,
-    delivery: DefaultDelivery,
-) -> ServiceResult<String> {
-    let policy = match stored_json {
-        Some(json) if !json.is_empty() => Some(
+) -> ServiceResult<Option<RoutingPolicy>> {
+    Ok(match stored_json {
+        Some(json) => Some(
             serde_json::from_str::<RoutingPolicy>(json).map_err(|error| {
                 ServiceError::InternalError(format!(
                     "deserialize routing_policy_json before patch: {error}"
@@ -115,7 +114,14 @@ fn patch_stored_routing_policy_json(
             })?,
         ),
         _ => None,
-    };
+    })
+}
+
+fn patch_stored_routing_policy_json(
+    stored_json: Option<&str>,
+    delivery: DefaultDelivery,
+) -> ServiceResult<String> {
+    let policy = parse_stored_routing_policy_json(stored_json)?;
     Ok(routing_policy_json(policy.as_ref(), delivery))
 }
 
@@ -1304,6 +1310,22 @@ impl GroupRepoPort for MySqlGroupStore {
                 request_id: None,
             });
         }
+        let routing_policy_snapshot = match &command.mutation {
+            GroupEventfulMutation::PatchMutableFields(patch)
+                if patch.default_bot_final_delivery.is_some() =>
+            {
+                Some(
+                    self.load_raw_routing_policy_json(&command.group_id)
+                        .await?
+                        .ok_or_else(|| ServiceError::GroupNotFound(command.group_id.clone()))?,
+                )
+            }
+            _ => None,
+        };
+        let authoritative_routing_policy = routing_policy_snapshot
+            .as_ref()
+            .map(|stored_json| parse_stored_routing_policy_json(stored_json.as_deref()))
+            .transpose()?;
         let current = self
             .try_get(&command.group_id)
             .await?
@@ -1322,25 +1344,41 @@ impl GroupRepoPort for MySqlGroupStore {
             });
         }
         let mut terminal = current;
+        if let Some(policy) = authoritative_routing_policy {
+            terminal.routing_policy = policy;
+        }
         apply_db_group_mutation_candidate(&mut terminal, &command.mutation, command.mutated_at_ms)?;
         let mutated_at = db_timestamp_from_millis(command.mutated_at_ms)?;
-        let lock_sql = match self.flavor {
-            DbSqlFlavor::Mysql => {
-                "SELECT group_id FROM bcs_groups WHERE env = ? AND group_id = ? \
-                 AND version = ? AND record_status = 'active' FOR UPDATE"
+        let routing_policy_guard = match self.flavor {
+            DbSqlFlavor::Mysql if routing_policy_snapshot.is_some() => {
+                " AND routing_policy_json <=> ?"
             }
-            DbSqlFlavor::Sqlite => {
-                "SELECT group_id FROM bcs_groups WHERE env = ? AND group_id = ? \
-                 AND version = ? AND record_status = 'active'"
+            DbSqlFlavor::Sqlite if routing_policy_snapshot.is_some() => {
+                " AND routing_policy_json IS ?"
             }
+            _ => "",
         };
+        let lock_sql = match self.flavor {
+            DbSqlFlavor::Mysql => format!(
+                "SELECT group_id FROM bcs_groups WHERE env = ? AND group_id = ? \
+                 AND version = ? AND record_status = 'active'{routing_policy_guard} FOR UPDATE"
+            ),
+            DbSqlFlavor::Sqlite => format!(
+                "SELECT group_id FROM bcs_groups WHERE env = ? AND group_id = ? \
+                 AND version = ? AND record_status = 'active'{routing_policy_guard}"
+            ),
+        };
+        let mut lock_params = vec![
+            Value::from(self.env.as_str()),
+            Value::from(command.group_id.as_str()),
+            Value::from(command.expected_version),
+        ];
+        if let Some(stored_json) = &routing_policy_snapshot {
+            lock_params.push(Value::from(stored_json.as_deref()));
+        }
         let mut steps = vec![DbTransactionStep::Query(DbStatement::with_params(
             lock_sql,
-            vec![
-                Value::from(self.env.as_str()),
-                Value::from(command.group_id.as_str()),
-                Value::from(command.expected_version),
-            ],
+            lock_params,
         ))];
         let group_id = DbTransactionParam::query_result(0, 0, "group_id");
 
@@ -3848,12 +3886,14 @@ mod tests {
             DefaultDelivery::InjectObservers
         );
 
-        let error = patch_stored_routing_policy_json(
-            Some("{invalid-json"),
-            DefaultDelivery::InjectObservers,
-        )
-        .expect_err("invalid stored routing policy must not be overwritten");
-        assert!(error.to_string().contains("before patch"));
+        for invalid_json in ["", "{invalid-json"] {
+            let error = patch_stored_routing_policy_json(
+                Some(invalid_json),
+                DefaultDelivery::InjectObservers,
+            )
+            .expect_err("invalid stored routing policy must not be overwritten");
+            assert!(error.to_string().contains("before patch"));
+        }
     }
 
     #[tokio::test]
@@ -3969,7 +4009,9 @@ mod tests {
             .await
             .expect_err("concurrent routing change must fail the guarded write");
 
-        assert!(matches!(error, ServiceError::Conflict(message) if message.contains("concurrently")));
+        assert!(
+            matches!(error, ServiceError::Conflict(message) if message.contains("concurrently"))
+        );
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-group-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-group-store/src/lib.rs
@@ -102,6 +102,23 @@ fn routing_policy_json(policy: Option<&RoutingPolicy>, delivery: DefaultDelivery
     serde_json::to_string(&policy).expect("RoutingPolicy contains only JSON-compatible values")
 }
 
+fn patch_stored_routing_policy_json(
+    stored_json: Option<&str>,
+    delivery: DefaultDelivery,
+) -> ServiceResult<String> {
+    let policy = match stored_json {
+        Some(json) if !json.is_empty() => Some(
+            serde_json::from_str::<RoutingPolicy>(json).map_err(|error| {
+                ServiceError::InternalError(format!(
+                    "deserialize routing_policy_json before patch: {error}"
+                ))
+            })?,
+        ),
+        _ => None,
+    };
+    Ok(routing_policy_json(policy.as_ref(), delivery))
+}
+
 fn group_version_update_step(
     env: &str,
     group_id: DbTransactionParam,
@@ -541,6 +558,34 @@ impl MySqlGroupStore {
                 }
             }
         })
+    }
+
+    async fn load_raw_routing_policy_json(
+        &self,
+        group_id: &str,
+    ) -> ServiceResult<Option<Option<String>>> {
+        let rows = self
+            .db
+            .query_with(
+                &self.logical_db,
+                "SELECT routing_policy_json FROM bcs_groups WHERE group_id = ? AND env = ?",
+                vec![Value::from(group_id), Value::from(self.env.as_str())],
+            )
+            .await
+            .map_err(|error| {
+                ServiceError::InternalError(format!(
+                    "load Group '{group_id}' routing_policy_json: {error}"
+                ))
+            })?;
+        let Some(row) = rows.first() else {
+            return Ok(None);
+        };
+        let json = db_get_column_opt(row, "routing_policy_json").map_err(|error| {
+            ServiceError::InternalError(format!(
+                "load Group '{group_id}' routing_policy_json: {error}"
+            ))
+        })?;
+        Ok(Some(json))
     }
 
     fn deserialize_opening_message(
@@ -1568,10 +1613,20 @@ impl GroupRepoPort for MySqlGroupStore {
         id: &str,
         patch: GroupMutableFieldsPatch,
     ) -> ServiceResult<()> {
-        let group = self
-            .try_get(id)
-            .await?
-            .ok_or_else(|| ServiceError::GroupNotFound(id.to_string()))?;
+        let routing_policy_snapshot = match patch.default_bot_final_delivery {
+            Some(delivery) => Some((
+                delivery,
+                self.load_raw_routing_policy_json(id)
+                    .await?
+                    .ok_or_else(|| ServiceError::GroupNotFound(id.to_string()))?,
+            )),
+            None => {
+                self.try_get(id)
+                    .await?
+                    .ok_or_else(|| ServiceError::GroupNotFound(id.to_string()))?;
+                None
+            }
+        };
 
         let mut assignments = Vec::new();
         let mut params = Vec::new();
@@ -1598,21 +1653,38 @@ impl GroupRepoPort for MySqlGroupStore {
             assignments.push("visibility = ?".to_string());
             params.push(Value::from(visibility.as_str()));
         }
-        if let Some(delivery) = patch.default_bot_final_delivery {
-            let policy_json = routing_policy_json(group.routing_policy.as_ref(), delivery);
-            assignments.push("routing_policy_json = ?".to_string());
-            params.push(Value::from(policy_json));
+        let mut guard_routing_policy = false;
+        if let Some((delivery, stored_json)) = &routing_policy_snapshot {
+            let policy_json = patch_stored_routing_policy_json(stored_json.as_deref(), *delivery)?;
+            if stored_json.as_deref() != Some(policy_json.as_str()) {
+                assignments.push("routing_policy_json = ?".to_string());
+                params.push(Value::from(policy_json));
+                guard_routing_policy = true;
+            }
         }
         if assignments.is_empty() {
+            if routing_policy_snapshot.is_some() {
+                self.cache.write().await.remove(id);
+            }
             return Ok(());
         }
         assignments.push(self.flavor.set_modified_now().to_string());
         params.push(Value::from(id));
         params.push(Value::from(self.env.as_str()));
-        let sql = format!(
+        let mut sql = format!(
             "UPDATE bcs_groups SET {} WHERE group_id = ? AND env = ?",
             assignments.join(", ")
         );
+        if guard_routing_policy {
+            sql.push_str(match self.flavor {
+                DbSqlFlavor::Mysql => " AND routing_policy_json <=> ?",
+                DbSqlFlavor::Sqlite => " AND routing_policy_json IS ?",
+            });
+            let stored_json = routing_policy_snapshot
+                .as_ref()
+                .and_then(|(_, stored_json)| stored_json.as_deref());
+            params.push(Value::from(stored_json));
+        }
         let affected_rows = self
             .db
             .execute_with(&self.logical_db, &sql, params)
@@ -1627,6 +1699,11 @@ impl GroupRepoPort for MySqlGroupStore {
         self.cache.write().await.remove(id);
         if affected_rows == 0 && self.try_get(id).await?.is_none() {
             return Err(ServiceError::GroupNotFound(id.to_string()));
+        }
+        if affected_rows == 0 && guard_routing_policy {
+            return Err(ServiceError::Conflict(format!(
+                "Group '{id}' routing policy changed concurrently"
+            )));
         }
         Ok(())
     }
@@ -3616,7 +3693,7 @@ impl GroupRepoPort for MySqlGroupStore {
 mod tests {
     use super::*;
     use bcs_db_api::{DbExecuteResult, DbHealth};
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, VecDeque};
     use std::sync::Mutex as StdMutex;
 
     #[derive(Default)]
@@ -3627,6 +3704,7 @@ mod tests {
         first_execute_affected_rows: u64,
         fail_queries: bool,
         query_rows: Vec<DbRow>,
+        query_results: StdMutex<VecDeque<Vec<DbRow>>>,
         transaction_error: Option<String>,
     }
 
@@ -3667,6 +3745,14 @@ mod tests {
         async fn query(&self, _statement: DbStatement) -> DbResult<Vec<DbRow>> {
             if self.fail_queries {
                 return Err(DbError::Backend("database unavailable".to_string()));
+            }
+            if let Some(rows) = self
+                .query_results
+                .lock()
+                .expect("query results")
+                .pop_front()
+            {
+                return Ok(rows);
             }
             Ok(self.query_rows.clone())
         }
@@ -3751,6 +3837,25 @@ mod tests {
         );
     }
 
+    #[test]
+    fn stored_routing_policy_patch_handles_defaults_and_rejects_invalid_json() {
+        let default_json = patch_stored_routing_policy_json(None, DefaultDelivery::InjectObservers)
+            .expect("serialize default routing policy");
+        let default_policy =
+            serde_json::from_str::<RoutingPolicy>(&default_json).expect("routing policy");
+        assert_eq!(
+            default_policy.default_bot_final_delivery,
+            DefaultDelivery::InjectObservers
+        );
+
+        let error = patch_stored_routing_policy_json(
+            Some("{invalid-json"),
+            DefaultDelivery::InjectObservers,
+        )
+        .expect_err("invalid stored routing policy must not be overwritten");
+        assert!(error.to_string().contains("before patch"));
+    }
+
     #[tokio::test]
     async fn fallible_group_reads_propagate_database_failures() {
         let db = Arc::new(RecordingDbPlugin::failing_queries());
@@ -3783,6 +3888,88 @@ mod tests {
             .expect_err("patch preflight read must fail");
 
         assert!(error.to_string().contains("database unavailable"));
+
+        let routing_error = repo
+            .patch_mutable_fields(
+                "group-1",
+                GroupMutableFieldsPatch {
+                    default_bot_final_delivery: Some(DefaultDelivery::InjectObservers),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("routing patch preflight read must fail");
+
+        assert!(routing_error.to_string().contains("database unavailable"));
+    }
+
+    #[tokio::test]
+    async fn mutable_patch_rejects_a_non_string_routing_policy_column() {
+        let malformed = DbRow::new(BTreeMap::from([(
+            "routing_policy_json".to_string(),
+            Value::from(7_i64),
+        )]));
+        let db = Arc::new(RecordingDbPlugin::with_query_rows(vec![malformed]));
+        let repo = MySqlGroupStore::new(db, "local".to_string());
+
+        let error = repo
+            .patch_mutable_fields(
+                "group-1",
+                GroupMutableFieldsPatch {
+                    default_bot_final_delivery: Some(DefaultDelivery::InjectObservers),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("non-string routing policy must fail");
+
+        assert!(error.to_string().contains("routing_policy_json"));
+    }
+
+    #[tokio::test]
+    async fn mutable_patch_rejects_a_concurrent_routing_policy_change() {
+        let policy = RoutingPolicy {
+            mode: bcs_service_api::RoutingMode::Mention,
+            default_bot_final_delivery: DefaultDelivery::SendToDriver,
+            sender_routes: HashMap::new(),
+        };
+        let stored_policy_json =
+            serde_json::to_string(&policy).expect("serialize stored routing policy");
+        let routing_row = DbRow::new(BTreeMap::from([(
+            "routing_policy_json".to_string(),
+            Value::from(stored_policy_json.as_str()),
+        )]));
+        let group_row = DbRow::new(BTreeMap::from([
+            ("group_id".to_string(), Value::from("group-1")),
+            ("status".to_string(), Value::from("active")),
+            ("driver_bot".to_string(), Value::from("driver")),
+            (
+                "routing_policy_json".to_string(),
+                Value::from(stored_policy_json.as_str()),
+            ),
+        ]));
+        let db = Arc::new(RecordingDbPlugin {
+            query_results: StdMutex::new(VecDeque::from([
+                vec![routing_row],
+                vec![group_row],
+                Vec::new(),
+            ])),
+            ..Default::default()
+        });
+        let repo = MySqlGroupStore::new(db, "local".to_string());
+
+        let error = repo
+            .patch_mutable_fields(
+                "group-1",
+                GroupMutableFieldsPatch {
+                    default_bot_final_delivery: Some(DefaultDelivery::InjectObservers),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect_err("concurrent routing change must fail the guarded write");
+
+        assert!(matches!(error, ServiceError::Conflict(message) if message.contains("concurrently")));
     }
 
     #[tokio::test]
@@ -3962,17 +4149,24 @@ mod tests {
 
     #[tokio::test]
     async fn mutable_patch_serializes_routing_policy_before_sql() {
-        let db = Arc::new(RecordingDbPlugin::with_first_execute_affected_rows(1));
-        let repo = MySqlGroupStore::new(db.clone(), "local".to_string());
-        let mut group = Group::new("group-1", "driver", Vec::new());
         let mut policy = RoutingPolicy {
             mode: bcs_service_api::RoutingMode::Mention,
             default_bot_final_delivery: DefaultDelivery::SendToDriver,
-            sender_routes: HashMap::from([(
-                "driver".to_string(),
-                vec!["observer".to_string()],
-            )]),
+            sender_routes: HashMap::from([("driver".to_string(), vec!["observer".to_string()])]),
         };
+        let stored_policy_json =
+            serde_json::to_string(&policy).expect("serialize stored routing policy");
+        let policy_row = DbRow::new(BTreeMap::from([(
+            "routing_policy_json".to_string(),
+            Value::from(stored_policy_json.as_str()),
+        )]));
+        let db = Arc::new(RecordingDbPlugin {
+            first_execute_affected_rows: 1,
+            query_rows: vec![policy_row],
+            ..Default::default()
+        });
+        let repo = MySqlGroupStore::new(db.clone(), "local".to_string());
+        let mut group = Group::new("group-1", "driver", Vec::new());
         group.routing_policy = Some(policy.clone());
         repo.cache.write().await.insert(group.id.clone(), group);
 
@@ -3992,6 +4186,7 @@ mod tests {
         let sql = statements[0].sql();
         assert!(sql.contains("label = ?"));
         assert!(sql.contains("routing_policy_json = ?"));
+        assert!(sql.contains("routing_policy_json <=> ?"));
         assert!(!sql.contains("JSON_SET"));
         assert!(!sql.contains("json_set"));
         assert!(!sql.contains("participants"));
@@ -4004,6 +4199,7 @@ mod tests {
                 Value::from(policy_json),
                 Value::from("group-1"),
                 Value::from("local"),
+                Value::from(stored_policy_json),
             ]
         );
     }

--- a/src/bcs/crates/services/bcs-group-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-group-store/src/lib.rs
@@ -87,6 +87,14 @@ fn assert_empty_logical_db(logical_db: &str) -> DbResult<()> {
     }
 }
 
+fn transaction_lock_row_is_missing(error: &DbError) -> bool {
+    matches!(
+        error,
+        DbError::InvalidInput(message)
+            if message.contains("references missing row 0 from step 0")
+    )
+}
+
 fn db_timestamp_from_millis(timestamp_ms: u64) -> ServiceResult<String> {
     let timestamp_ms = i64::try_from(timestamp_ms)
         .map_err(|_| ServiceError::InternalError("Group timestamp is out of range".to_string()))?;
@@ -1634,9 +1642,18 @@ impl GroupRepoPort for MySqlGroupStore {
                 ),
             ));
         }
-        self.db.plugin().transaction(steps).await.map_err(|error| {
-            ServiceError::InternalError(format!("Eventful Group mutation failed: {error}"))
-        })?;
+        if let Err(error) = self.db.plugin().transaction(steps).await {
+            if routing_policy_snapshot.is_some() && transaction_lock_row_is_missing(&error) {
+                self.cache.write().await.remove(&command.group_id);
+                return Err(ServiceError::Conflict(format!(
+                    "Group '{}' routing policy changed concurrently",
+                    command.group_id
+                )));
+            }
+            return Err(ServiceError::InternalError(format!(
+                "Eventful Group mutation failed: {error}"
+            )));
+        }
         self.cache.write().await.remove(&command.group_id);
         if deleting {
             return Ok(terminal);
@@ -3744,6 +3761,7 @@ mod tests {
         query_rows: Vec<DbRow>,
         query_results: StdMutex<VecDeque<Vec<DbRow>>>,
         transaction_error: Option<String>,
+        missing_transaction_lock_row: bool,
     }
 
     impl RecordingDbPlugin {
@@ -3773,6 +3791,14 @@ mod tests {
                 transaction_error: Some(
                     "UNIQUE constraint failed: bcs_groups.env, bcs_groups.dm_pair_key".into(),
                 ),
+                ..Self::default()
+            }
+        }
+
+        fn with_missing_transaction_lock_row(query_rows: Vec<DbRow>) -> Self {
+            Self {
+                query_rows,
+                missing_transaction_lock_row: true,
                 ..Self::default()
             }
         }
@@ -3810,6 +3836,11 @@ mod tests {
             &self,
             steps: Vec<DbTransactionStep>,
         ) -> DbResult<Vec<DbTransactionStepResult>> {
+            if self.missing_transaction_lock_row {
+                return Err(DbError::InvalidInput(
+                    "transaction parameter 2 references missing row 0 from step 0".to_string(),
+                ));
+            }
             if let Some(error) = &self.transaction_error {
                 return Err(DbError::Backend(error.clone()));
             }
@@ -4012,6 +4043,48 @@ mod tests {
         assert!(
             matches!(error, ServiceError::Conflict(message) if message.contains("concurrently"))
         );
+    }
+
+    #[tokio::test]
+    async fn eventful_mutable_patch_reports_a_missing_routing_lock_as_a_conflict() {
+        let policy = RoutingPolicy {
+            mode: bcs_service_api::RoutingMode::Mention,
+            default_bot_final_delivery: DefaultDelivery::SendToDriver,
+            sender_routes: HashMap::new(),
+        };
+        let stored_policy_json =
+            serde_json::to_string(&policy).expect("serialize stored routing policy");
+        let routing_row = DbRow::new(BTreeMap::from([(
+            "routing_policy_json".to_string(),
+            Value::from(stored_policy_json),
+        )]));
+        let db = Arc::new(RecordingDbPlugin::with_missing_transaction_lock_row(vec![
+            routing_row,
+        ]));
+        let repo = MySqlGroupStore::new(db, "local".to_string());
+        let mut group = Group::new("group-1", "driver", Vec::new());
+        group.routing_policy = Some(policy);
+        let expected_version = group.version;
+        repo.cache.write().await.insert(group.id.clone(), group);
+
+        let error = repo
+            .commit_eventful_mutation(CommitGroupEventfulMutation {
+                group_id: "group-1".to_string(),
+                expected_version,
+                mutated_at_ms: 1,
+                mutation: GroupEventfulMutation::PatchMutableFields(GroupMutableFieldsPatch {
+                    default_bot_final_delivery: Some(DefaultDelivery::InjectObservers),
+                    ..Default::default()
+                }),
+                event: None,
+            })
+            .await
+            .expect_err("a missing guarded lock row must be reported as a conflict");
+
+        assert!(
+            matches!(error, ServiceError::Conflict(message) if message.contains("concurrently"))
+        );
+        assert!(repo.cache.read().await.get("group-1").is_none());
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-group-store/tests/conformance_group_repo.rs
+++ b/src/bcs/crates/services/bcs-group-store/tests/conformance_group_repo.rs
@@ -288,6 +288,69 @@ async fn sqlite_delivery_patches_persist_canonical_routing_policy_json() {
 }
 
 #[tokio::test]
+async fn sqlite_transactional_delivery_patch_rejects_stringified_routing_policy_json() {
+    let db: Arc<dyn DbPlugin> = Arc::new(LocalSqliteDbPlugin::new().expect("sqlite db"));
+    bootstrap_migrations::run_sqlite_migrations(db.as_ref())
+        .await
+        .expect("migrate sqlite");
+    let repo = MySqlGroupStore::sqlite(db.clone(), PROVISIONING_ENV.to_string());
+    let group = GroupBuilder::new("driver")
+        .id("invalid-routing-policy-group")
+        .build();
+    let expected_version = group.version;
+    repo.upsert(group).await.expect("persist group");
+
+    let embedded_policy = serde_json::json!({
+        "mode": "mention",
+        "default_bot_final_delivery": "send_to_driver",
+        "sender_routes": {"driver": ["observer"]}
+    })
+    .to_string();
+    let stringified_policy =
+        serde_json::to_string(&embedded_policy).expect("stringify routing policy object");
+    db.execute(DbStatement::with_params(
+        "UPDATE bcs_groups SET routing_policy_json = ? WHERE env = ? AND group_id = ?",
+        vec![
+            DbValue::from(stringified_policy.as_str()),
+            DbValue::from(PROVISIONING_ENV),
+            DbValue::from("invalid-routing-policy-group"),
+        ],
+    ))
+    .await
+    .expect("persist historical stringified routing policy");
+
+    let uncached_repo = MySqlGroupStore::sqlite(db.clone(), PROVISIONING_ENV.to_string());
+    let error = uncached_repo
+        .commit_eventful_mutation(CommitGroupEventfulMutation {
+            group_id: "invalid-routing-policy-group".to_string(),
+            expected_version,
+            mutated_at_ms: 1_787_028_300_000,
+            mutation: GroupEventfulMutation::PatchMutableFields(GroupMutableFieldsPatch {
+                default_bot_final_delivery: Some(DefaultDelivery::InjectObservers),
+                ..Default::default()
+            }),
+            event: None,
+        })
+        .await
+        .expect_err("stringified routing policy must not be overwritten");
+    assert!(error.to_string().contains("before patch"));
+
+    let rows = db
+        .query(DbStatement::with_params(
+            "SELECT routing_policy_json FROM bcs_groups WHERE env = ? AND group_id = ?",
+            vec![
+                DbValue::from(PROVISIONING_ENV),
+                DbValue::from("invalid-routing-policy-group"),
+            ],
+        ))
+        .await
+        .expect("reload stringified routing policy");
+    let stored_json =
+        db_get_column::<String>(&rows[0], "routing_policy_json").expect("routing_policy_json");
+    assert_eq!(stored_json, stringified_policy);
+}
+
+#[tokio::test]
 async fn sqlite_group_opening_message_rejects_invalid_persisted_json() {
     let db: Arc<dyn DbPlugin> = Arc::new(LocalSqliteDbPlugin::new().expect("sqlite db"));
     bootstrap_migrations::run_sqlite_migrations(db.as_ref())

--- a/src/bcs/crates/services/bcs-group-store/tests/conformance_group_repo.rs
+++ b/src/bcs/crates/services/bcs-group-store/tests/conformance_group_repo.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use bcs_db_api::{DbPlugin, DbStatement, DbValue, db_get_column};
@@ -18,8 +18,8 @@ use bcs_service_api::types::{
     EventSubject, EventSubscriptionScope, EventSubscriptionScopeType, EventSubscriptionStatus,
 };
 use bcs_service_api::{
-    GroupKind, GroupMutableFieldsPatch, GroupStatus, GroupStrategy, Participant, ParticipantRole,
-    ServiceError,
+    DefaultDelivery, GroupKind, GroupMutableFieldsPatch, GroupStatus, GroupStrategy, Participant,
+    ParticipantRole, RoutingMode, RoutingPolicy, ServiceError,
 };
 
 #[path = "../../../bootstrap/bcs/src/migrations.rs"]
@@ -157,6 +157,114 @@ async fn sqlite_group_opening_message_round_trips_and_can_be_cleared() {
             .expect("group")
             .opening_message,
         None
+    );
+}
+
+#[tokio::test]
+async fn sqlite_delivery_patches_persist_canonical_routing_policy_json() {
+    let db: Arc<dyn DbPlugin> = Arc::new(LocalSqliteDbPlugin::new().expect("sqlite db"));
+    bootstrap_migrations::run_sqlite_migrations(db.as_ref())
+        .await
+        .expect("migrate sqlite");
+    let repo = MySqlGroupStore::sqlite(db.clone(), PROVISIONING_ENV.to_string());
+    let mut group = GroupBuilder::new("driver").id("routing-policy-group").build();
+    group.routing_policy = Some(RoutingPolicy {
+        mode: RoutingMode::Mention,
+        default_bot_final_delivery: DefaultDelivery::SendToDriver,
+        sender_routes: HashMap::from([(
+            "driver".to_string(),
+            vec!["observer".to_string()],
+        )]),
+    });
+    repo.upsert(group).await.expect("persist group");
+
+    repo.patch_mutable_fields(
+        "routing-policy-group",
+        GroupMutableFieldsPatch {
+            default_bot_final_delivery: Some(DefaultDelivery::InjectObservers),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("apply direct delivery patch");
+    let directly_updated = repo
+        .try_get("routing-policy-group")
+        .await
+        .expect("load directly updated group")
+        .expect("group");
+    let direct_policy = directly_updated.routing_policy.expect("routing policy");
+    assert_eq!(direct_policy.mode, RoutingMode::Mention);
+    assert_eq!(
+        direct_policy.default_bot_final_delivery,
+        DefaultDelivery::InjectObservers
+    );
+    assert_eq!(
+        direct_policy.sender_routes.get("driver"),
+        Some(&vec!["observer".to_string()])
+    );
+
+    let transactionally_updated = repo
+        .commit_eventful_mutation(CommitGroupEventfulMutation {
+            group_id: "routing-policy-group".to_string(),
+            expected_version: directly_updated.version,
+            mutated_at_ms: 1_787_028_100_000,
+            mutation: GroupEventfulMutation::PatchMutableFields(GroupMutableFieldsPatch {
+                default_bot_final_delivery: Some(DefaultDelivery::SendToDriver),
+                ..Default::default()
+            }),
+            event: None,
+        })
+        .await
+        .expect("apply transactional delivery patch");
+    let repeatedly_updated = repo
+        .commit_eventful_mutation(CommitGroupEventfulMutation {
+            group_id: "routing-policy-group".to_string(),
+            expected_version: transactionally_updated.version,
+            mutated_at_ms: 1_787_028_200_000,
+            mutation: GroupEventfulMutation::PatchMutableFields(GroupMutableFieldsPatch {
+                default_bot_final_delivery: Some(DefaultDelivery::InjectObservers),
+                ..Default::default()
+            }),
+            event: None,
+        })
+        .await
+        .expect("apply repeated transactional delivery patch");
+    let repeated_policy = repeatedly_updated.routing_policy.expect("routing policy");
+    assert_eq!(repeated_policy.mode, RoutingMode::Mention);
+    assert_eq!(
+        repeated_policy.default_bot_final_delivery,
+        DefaultDelivery::InjectObservers
+    );
+    assert_eq!(
+        repeated_policy.sender_routes.get("driver"),
+        Some(&vec!["observer".to_string()])
+    );
+
+    let rows = db
+        .query(DbStatement::with_params(
+            "SELECT routing_policy_json FROM bcs_groups WHERE env = ? AND group_id = ?",
+            vec![
+                DbValue::from(PROVISIONING_ENV),
+                DbValue::from("routing-policy-group"),
+            ],
+        ))
+        .await
+        .expect("query stored routing policy");
+    let stored_json = db_get_column::<String>(&rows[0], "routing_policy_json")
+        .expect("routing_policy_json");
+    assert!(serde_json::from_str::<serde_json::Value>(&stored_json)
+        .expect("valid JSON")
+        .is_object());
+    let stored_policy =
+        serde_json::from_str::<RoutingPolicy>(&stored_json).expect("routing policy object");
+    assert_eq!(stored_policy.mode, RoutingMode::Mention);
+    assert_eq!(
+        stored_policy.default_bot_final_delivery,
+        DefaultDelivery::InjectObservers
+    );
+    assert_eq!(
+        stored_policy.sender_routes.get("driver"),
+        Some(&vec!["observer".to_string()])
     );
 }
 

--- a/src/bcs/crates/services/bcs-group-store/tests/conformance_group_repo.rs
+++ b/src/bcs/crates/services/bcs-group-store/tests/conformance_group_repo.rs
@@ -167,16 +167,33 @@ async fn sqlite_delivery_patches_persist_canonical_routing_policy_json() {
         .await
         .expect("migrate sqlite");
     let repo = MySqlGroupStore::sqlite(db.clone(), PROVISIONING_ENV.to_string());
-    let mut group = GroupBuilder::new("driver").id("routing-policy-group").build();
+    let mut group = GroupBuilder::new("driver")
+        .id("routing-policy-group")
+        .build();
     group.routing_policy = Some(RoutingPolicy {
         mode: RoutingMode::Mention,
         default_bot_final_delivery: DefaultDelivery::SendToDriver,
-        sender_routes: HashMap::from([(
-            "driver".to_string(),
-            vec!["observer".to_string()],
-        )]),
+        sender_routes: HashMap::from([("driver".to_string(), vec!["observer".to_string()])]),
     });
     repo.upsert(group).await.expect("persist group");
+
+    let concurrent_policy = RoutingPolicy {
+        mode: RoutingMode::Structured,
+        default_bot_final_delivery: DefaultDelivery::SendToDriver,
+        sender_routes: HashMap::from([("driver".to_string(), vec!["new-observer".to_string()])]),
+    };
+    let concurrent_policy_json =
+        serde_json::to_string(&concurrent_policy).expect("serialize concurrent routing policy");
+    db.execute(DbStatement::with_params(
+        "UPDATE bcs_groups SET routing_policy_json = ? WHERE env = ? AND group_id = ?",
+        vec![
+            DbValue::from(concurrent_policy_json),
+            DbValue::from(PROVISIONING_ENV),
+            DbValue::from("routing-policy-group"),
+        ],
+    ))
+    .await
+    .expect("simulate a concurrent routing update behind the repository cache");
 
     repo.patch_mutable_fields(
         "routing-policy-group",
@@ -193,14 +210,14 @@ async fn sqlite_delivery_patches_persist_canonical_routing_policy_json() {
         .expect("load directly updated group")
         .expect("group");
     let direct_policy = directly_updated.routing_policy.expect("routing policy");
-    assert_eq!(direct_policy.mode, RoutingMode::Mention);
+    assert_eq!(direct_policy.mode, RoutingMode::Structured);
     assert_eq!(
         direct_policy.default_bot_final_delivery,
         DefaultDelivery::InjectObservers
     );
     assert_eq!(
         direct_policy.sender_routes.get("driver"),
-        Some(&vec!["observer".to_string()])
+        Some(&vec!["new-observer".to_string()])
     );
 
     let transactionally_updated = repo
@@ -230,14 +247,14 @@ async fn sqlite_delivery_patches_persist_canonical_routing_policy_json() {
         .await
         .expect("apply repeated transactional delivery patch");
     let repeated_policy = repeatedly_updated.routing_policy.expect("routing policy");
-    assert_eq!(repeated_policy.mode, RoutingMode::Mention);
+    assert_eq!(repeated_policy.mode, RoutingMode::Structured);
     assert_eq!(
         repeated_policy.default_bot_final_delivery,
         DefaultDelivery::InjectObservers
     );
     assert_eq!(
         repeated_policy.sender_routes.get("driver"),
-        Some(&vec!["observer".to_string()])
+        Some(&vec!["new-observer".to_string()])
     );
 
     let rows = db
@@ -250,21 +267,23 @@ async fn sqlite_delivery_patches_persist_canonical_routing_policy_json() {
         ))
         .await
         .expect("query stored routing policy");
-    let stored_json = db_get_column::<String>(&rows[0], "routing_policy_json")
-        .expect("routing_policy_json");
-    assert!(serde_json::from_str::<serde_json::Value>(&stored_json)
-        .expect("valid JSON")
-        .is_object());
+    let stored_json =
+        db_get_column::<String>(&rows[0], "routing_policy_json").expect("routing_policy_json");
+    assert!(
+        serde_json::from_str::<serde_json::Value>(&stored_json)
+            .expect("valid JSON")
+            .is_object()
+    );
     let stored_policy =
         serde_json::from_str::<RoutingPolicy>(&stored_json).expect("routing policy object");
-    assert_eq!(stored_policy.mode, RoutingMode::Mention);
+    assert_eq!(stored_policy.mode, RoutingMode::Structured);
     assert_eq!(
         stored_policy.default_bot_final_delivery,
         DefaultDelivery::InjectObservers
     );
     assert_eq!(
         stored_policy.sender_routes.get("driver"),
-        Some(&vec!["observer".to_string()])
+        Some(&vec!["new-observer".to_string()])
     );
 }
 


### PR DESCRIPTION
## 背景

调用 Group PATCH 接口更新 `delivery_policy.bot_final_delivery` 时，数据库侧通过 `JSON_SET/json_set` 修改 `routing_policy_json`。

在部分 ZDAS/OB 适配环境中，`routing_policy_json` 是 TEXT 字段，数据库 JSON 函数的返回值会被再次当作字符串写入。重复更新后会形成多层转义：

```text
"\"\\\"...{\\\"mode\\\":\\\"hybrid\\\"}...\\\"\""
```

这会导致后续读取到的内容不再是规范 JSON object，并且更新次数越多，转义层数越深。

## 修改内容

- 由 Rust 侧读取并更新完整的 `RoutingPolicy`。
- 使用 `serde_json` 生成规范 JSON。
- SQL 统一改为 `routing_policy_json = ?` 参数绑定，不再依赖数据库的 `JSON_SET/json_set` 行为。
- 同时覆盖两条更新路径：
  - 普通 `patch_mutable_fields`
  - 事务型 `commit_eventful_mutation(PatchMutableFields)`
- 更新 delivery 时保留原有的：
  - `mode`
  - `sender_routes`
  - 其他 RoutingPolicy 字段
- 补充 Group 不存在时的错误分支测试。

## 测试

新增 SQLite 回归测试，覆盖：

1. 写入包含非默认 `mode` 和 `sender_routes` 的 RoutingPolicy。
2. 通过普通更新修改 delivery。
3. 通过事务更新连续多次修改 delivery。
4. 验证其他 RoutingPolicy 字段未丢失。
5. 直接读取 `routing_policy_json`，确认其为 JSON object，而不是嵌套 JSON 字符串。

验证结果：

- Unit tests：44 passed
- Integration/contract tests：31 passed，1 个 MySQL 环境测试按原配置 ignored
- 变更行覆盖率：94.87%
- `git diff --check`：通过

## 兼容性与影响

该修改消除了 MySQL、SQLite、ZDAS/OB 对 JSON 函数和 TEXT 字段处理差异的影响，后续写入统一由 Rust 生成规范 JSON。

本 PR 只阻止产生新的多层转义数据，不会自动修复数据库中已经损坏的 `routing_policy_json`；历史异常数据需要单独执行一次性清理。