### PR TITLE
feat(baas): add aliyun ack pod expiry scheduler

### DIFF
--- a/src/baas/README.md
+++ b/src/baas/README.md
@@ -89,6 +89,7 @@ Key configuration sections:
 | `user_config.bot_service` | Bot runtime proxy settings |
 | `user_config.bot_run_queue` | Task queue worker config |
 | `user_config.device_ttl_timer` | Device TTL renewal schedule |
+| `user_config.expire_sandbox_timer` | Aliyun ACK pod expiry sweep (destroy Pod + stop bot) schedule |
 | `user_config.bot_runner` | Concurrency limits per bot |
 
 ## Development

--- a/src/baas/configs/application-prod.yaml
+++ b/src/baas/configs/application-prod.yaml
@@ -96,6 +96,23 @@ user_config:
     lock_expire_seconds: 1750  # 分布式锁租约（秒），须 < cron 间隔以允许其它实例在轮次间获取，默认: 1750
     dry_run: false  # 测试模式：只打印日志
 
+  # Expired ACK sandbox timer config (periodically scans expired devices, destroys Pod, stops bot)
+  # NOTE: This task only takes effect for Aliyun ACK-created sandboxes
+  # (plugins.sandbox.arca == "aliyun_ack"). Enterprise arc_sdk sandboxes are
+  # reclaimed by the ARC platform itself; this task must not destroy sandboxes
+  # still within their ARC platform lease.
+  expire_sandbox_timer:
+    enabled: false  # 默认禁用过期沙箱销毁定时任务，验证通过后再显式启用
+    cron_interval_seconds: 86400  # 执行间隔（秒），默认: 86400（1天）
+    batch_size: 100  # 每页拉取条数，默认: 100
+    max_page_concurrency: 10  # 每页内并发停 bot 的最大并发数
+    query_retries: 3  # 单页查询 DB 失败时的重试次数
+    lock_name: "expire_sandbox_timer_lock"  # 分布式锁名称基准，运行时追加环境后缀
+    lock_expire_seconds: 1750  # 分布式锁租约（秒），须 < cron 间隔
+    dry_run: true  # staged rollout：先观察到期量，确认后再转 false
+    grace_seconds: 0  # 到期判定余量（秒），抵消时钟偏差
+    default_ttl_minutes: 10080  # 业务默认 TTL（分钟），extra_config 缺失时回退（7 天）
+
   # Bot Health Checker 配置
   bot_health_checker:
     health_check:

--- a/src/baas/configs/application.yaml
+++ b/src/baas/configs/application.yaml
@@ -137,6 +137,23 @@ user_config:
     stale_seconds: 120  # RUNNING 超过此时长无心跳视为悬挂（秒），默认: 120
     dry_run: false  # 测试模式：只打印日志
 
+  # Expired ACK sandbox timer config (periodically scans expired devices, destroys Pod, stops bot)
+  # NOTE: This task only takes effect for Aliyun ACK-created sandboxes
+  # (plugins.sandbox.arca == "aliyun_ack"). Enterprise arc_sdk sandboxes are
+  # reclaimed by the ARC platform itself; this task does not participate.
+  # Disabled by default in community (enabled: false).
+  expire_sandbox_timer:
+    enabled: false  # 社区版禁用过期沙箱销毁定时任务
+    cron_interval_seconds: 86400  # 执行间隔（秒），默认: 86400（1天）
+    batch_size: 100  # 每页拉取条数，默认: 100
+    max_page_concurrency: 10  # 每页内并发停 bot 的最大并发数
+    query_retries: 3  # 单页查询 DB 失败时的重试次数
+    lock_name: "expire_sandbox_timer_lock"  # 分布式锁名称基准，运行时追加环境后缀
+    lock_expire_seconds: 1750  # 分布式锁租约（秒），须 < cron 间隔
+    dry_run: false  # 测试模式：只打印日志，不销毁/停 bot
+    grace_seconds: 0  # 到期判定余量（秒），抵消时钟偏差
+    default_ttl_minutes: 10080  # 业务默认 TTL（分钟），extra_config 缺失时回退（7 天）
+
   # BCN 下行协议配置
   bcn:
     api_key:

--- a/src/baas/singlebox-configs/application.yaml
+++ b/src/baas/singlebox-configs/application.yaml
@@ -119,6 +119,23 @@ user_config:
     max_concurrent_tickets: 5  # 单次扫描并发处理的 ticket 数上限
     dry_run: false  # 测试模式：只打印日志
 
+  # Expired ACK sandbox timer config (periodically scans expired devices, destroys Pod, stops bot)
+  # NOTE: This task only takes effect for Aliyun ACK-created sandboxes
+  # (plugins.sandbox.arca == "aliyun_ack"). Enterprise arc_sdk sandboxes are
+  # reclaimed by the ARC platform itself; this task does not participate.
+  # Disabled by default (enabled: false).
+  expire_sandbox_timer:
+    enabled: false  # 社区版禁用过期沙箱销毁定时任务
+    cron_interval_seconds: 86400  # 执行间隔（秒），默认: 86400（1天）
+    batch_size: 100  # 每页拉取条数，默认: 100
+    max_page_concurrency: 10  # 每页内并发停 bot 的最大并发数
+    query_retries: 3  # 单页查询 DB 失败时的重试次数
+    lock_name: "expire_sandbox_timer_lock"  # 分布式锁名称基准，运行时追加环境后缀
+    lock_expire_seconds: 1750  # 分布式锁租约（秒），须 < cron 间隔
+    dry_run: false  # 测试模式：只打印日志，不销毁/停 bot
+    grace_seconds: 0  # 到期判定余量（秒），抵消时钟偏差
+    default_ttl_minutes: 10080  # 业务默认 TTL（分钟），extra_config 缺失时回退（7 天）
+
   # BotRun 队列 Worker 配置（单机模式）
   bot_run_queue:
     enabled: false

--- a/src/baas/src/secbaas/community/bootstrap/_container.py
+++ b/src/baas/src/secbaas/community/bootstrap/_container.py
@@ -179,6 +179,7 @@ class ApplicationContainer(containers.DeclarativeContainer):
         CoreTaskContainer,
         config=config,
         distributed_lock_service=services.distributed_lock_service,
+        device_repo=repository.device_repository,
         device_binding_repo=repository.device_binding_repository,
         sandbox_device_router=services.sandbox_device_router,
         bot_run_queue_repository=repository.bot_run_queue_repository,
@@ -186,6 +187,10 @@ class ApplicationContainer(containers.DeclarativeContainer):
         paas_service_facade=services.paas_facade,
         file_transfer_backend=services.file_transfer_backend,
         ttl_renewal_schedule_repository=ttl_renewal_schedule_repo,
+        device_service=services.device_service,
+        bot_manage_service=services.bot_management_service,
+        bot_repo=repository.bot_repository,
+        bot_device_rel_repo=repository.bot_device_rel_repository,
     )
 
     cron_lifecycle = providers.Singleton(
@@ -200,6 +205,7 @@ class ApplicationContainer(containers.DeclarativeContainer):
             ),
             tasks.bot_run_recovery_task,
             tasks.file_transfer_poller_task,
+            tasks.expire_sandbox_timer_task,
         ),
     )
 

--- a/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
@@ -11,6 +11,8 @@ from secbaas.community.core.service.scheduler import (
     BotRunRecoveryTaskConfig,
     DeviceTtlTimerTask,
     DeviceTtlTimerTaskConfig,
+    ExpireSandboxTimerTask,
+    ExpireSandboxTimerTaskConfig,
     FileTransferPoller,
     FileTransferPollerConfig,
 )
@@ -36,6 +38,7 @@ class CoreTaskContainer(containers.DeclarativeContainer):
 
     # Provided by ApplicationContainer (cross-container wiring)
     distributed_lock_service = providers.Dependency()
+    device_repo = providers.Dependency()
     device_binding_repo = providers.Dependency()
     sandbox_device_router = providers.Dependency()
     bot_run_queue_repository = providers.Dependency()
@@ -43,6 +46,10 @@ class CoreTaskContainer(containers.DeclarativeContainer):
     paas_service_facade = providers.Dependency()
     file_transfer_backend = providers.Dependency()
     ttl_renewal_schedule_repository = providers.Dependency()
+    device_service = providers.Dependency()
+    bot_manage_service = providers.Dependency()
+    bot_repo = providers.Dependency()
+    bot_device_rel_repo = providers.Dependency()
 
     # ── DeviceTtlTimer task ──────────────────────────────────────────────────
 
@@ -128,3 +135,30 @@ class CoreTaskContainer(containers.DeclarativeContainer):
         )
     else:
         deadline_renewal_scheduler = providers.Object(None)
+
+    # ── ExpireSandboxTimer task ───────────────────────────────────────────────
+
+    expire_sandbox_timer_config = providers.Singleton(
+        ExpireSandboxTimerTaskConfig,
+        enabled=config.expire_sandbox_timer.enabled,
+        arca_provider=config.plugins.sandbox.arca,
+        lock_name=config.expire_sandbox_timer.lock_name,
+        lock_expire_seconds=config.expire_sandbox_timer.lock_expire_seconds,
+        cron_interval_seconds=config.expire_sandbox_timer.cron_interval_seconds,
+        batch_size=config.expire_sandbox_timer.batch_size,
+        max_page_concurrency=config.expire_sandbox_timer.max_page_concurrency,
+        query_retries=config.expire_sandbox_timer.query_retries,
+        dry_run=config.expire_sandbox_timer.dry_run,
+        grace_seconds=config.expire_sandbox_timer.grace_seconds,
+        default_ttl_minutes=config.expire_sandbox_timer.default_ttl_minutes,
+    )
+
+    expire_sandbox_timer_task = providers.Singleton(
+        ExpireSandboxTimerTask,
+        config=expire_sandbox_timer_config,
+        lock_service=distributed_lock_service,
+        device_repo=device_repo,
+        bot_manage_service=bot_manage_service,
+        bot_repo=bot_repo,
+        bot_device_rel_repo=bot_device_rel_repo,
+    )

--- a/src/baas/src/secbaas/community/core/repository/device/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/device/_orm_repository.py
@@ -1,7 +1,7 @@
 """ORM-based device repository for baas_device table."""
 
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from secbaas.community.core.repository import OrmConnectionMixin, with_orm_session
@@ -461,16 +461,29 @@ class OrmDeviceRepository(OrmConnectionMixin, DeviceRepository):
 
     @with_orm_session
     def update_status_by_device_uuid(
-        self, device_uuid: str, tenant: str, env: str, status: str
+        self,
+        device_uuid: str,
+        tenant: str,
+        env: str,
+        status: str,
+        modifier: str | None = None,
     ) -> int:
         log.info(
-            "update_status_by_device_uuid: device_uuid=%s, tenant=%s, env=%s, status=%s",
+            "update_status_by_device_uuid: device_uuid=%s, tenant=%s, env=%s, status=%s, modifier=%s",
             device_uuid,
             tenant,
             env,
             status,
+            modifier,
         )
         from sqlalchemy import func as sa_func
+
+        values: dict[str, Any] = {
+            "status": status,
+            "gmt_modified": sa_func.now(),
+        }
+        if modifier is not None:
+            values["modifier"] = modifier
 
         result = (
             self._session.query(DeviceModel)
@@ -481,10 +494,7 @@ class OrmDeviceRepository(OrmConnectionMixin, DeviceRepository):
                 DeviceModel.is_deleted == 0,
             )
             .update(
-                {
-                    "status": status,
-                    "gmt_modified": sa_func.now(),
-                },
+                values,
                 synchronize_session=False,
             )
         )
@@ -527,6 +537,106 @@ class OrmDeviceRepository(OrmConnectionMixin, DeviceRepository):
         items = [r.to_record() for r in rows]
         log.info("[device:list_devices] result: %s rows", len(items))
         return total, items
+
+    @with_orm_session
+    def list_expired_paginated(
+        self,
+        *,
+        last_id: int = 0,
+        limit: int = 100,
+        grace_seconds: int = 0,
+        default_ttl_minutes: int = 10080,
+    ) -> list[dict[str, Any]]:
+        """查询 baas_device 中已到期的 ACK pod 设备，按 id ASC keyset 分页。
+
+        仅捞 ``provider_type = 'ARCA'``、``status = 'ACTIVE'``、``provider_device_props``
+        含非空 ``sandbox_id`` 的记录。到期判定以续期路径维护的
+        ``provider_device_props.ttl_expiration_timestamp``（毫秒 epoch）为准，
+        当其缺失时回退到派生 deadline = ``gmt_create`` + effective lifetime（分钟），
+        其中 effective lifetime 优先取每 bot 的
+        ``extra_config.deploy_config.ttl_in_minutes``（JSON 路径），缺失/零值时
+        回退到 ``default_ttl_minutes``。到期判定加入 ``grace_seconds`` 余量。
+        """
+        from sqlalchemy import Integer, case, func, text
+
+        # 续期路径写下的到期时间戳（毫秒 epoch），JSON 取值。
+        ttl_ts_expr = func.json_extract(
+            DeviceModel.provider_device_props, text("'$.ttl_expiration_timestamp'")
+        )
+        ttl_ts = func.cast(ttl_ts_expr, Integer)
+
+        # 派生 deadline 的 effective lifetime（分钟）。
+        json_lifetime = func.json_extract(
+            DeviceModel.extra_config, text("'$.deploy_config.ttl_in_minutes'")
+        )
+        parsed_lifetime = func.cast(json_lifetime, Integer)
+        effective_lifetime = case(
+            (
+                func.coalesce(func.nullif(parsed_lifetime, 0), 0) > 0,
+                func.coalesce(func.nullif(parsed_lifetime, 0), 0),
+            ),
+            else_=default_ttl_minutes,
+        )
+
+        sandbox_id_expr = DeviceModel.provider_device_props.op("->>")("$.sandbox_id")
+
+        is_sqlite = self._session.bind.dialect.name == "sqlite"
+        now = datetime.now()
+        now_ms = int(now.timestamp() * 1000)
+
+        if is_sqlite:
+            # deadline = gmt_create + effective_lifetime 分钟，用 julianday 比较。
+            deadline_days = func.julianday(DeviceModel.gmt_create) + (
+                effective_lifetime / 1440.0
+            )
+            cutoff_days = func.julianday(now) - (grace_seconds / 86400.0)
+            fallback_expired = deadline_days <= cutoff_days
+        else:
+            deadline_expr = func.timestampadd(
+                text("MINUTE"), effective_lifetime, DeviceModel.gmt_create
+            )
+            cutoff = now - timedelta(seconds=grace_seconds)
+            fallback_expired = deadline_expr <= cutoff
+
+        # 有 ttl_expiration_timestamp 用其判定到期；否则用派生 deadline。
+        # 到期判定：ttl_expiration_timestamp（毫秒）早于 now - grace（即到期已过
+        # grace 秒），与 fallback 的 deadline <= now - grace 语义保持一致。
+        has_ts = ttl_ts.isnot(None)
+        ts_expired = ttl_ts <= (now_ms - grace_seconds * 1000)
+        expired_filter = case((has_ts, ts_expired), else_=fallback_expired)
+
+        rows = (
+            self._session.query(DeviceModel)
+            .filter(
+                DeviceModel.status == "ACTIVE",
+                DeviceModel.provider_type == "ARCA",
+                sandbox_id_expr.isnot(None),
+                DeviceModel.id > last_id,
+                expired_filter,
+            )
+            .order_by(DeviceModel.id.asc())
+            .limit(limit)
+            .all()
+        )
+        result = []
+        for r in rows:
+            record = r.to_record()
+            result.append(
+                {
+                    "id": record.id,
+                    "tenant": record.tenant,
+                    "env": record.env,
+                    "status": record.status,
+                    "provider_type": record.provider_type,
+                    "device_uuid": record.device_uuid,
+                    "provider_device_id": record.provider_device_id,
+                    "provider_device_props": record.provider_device_props,
+                    "extra_config": record.extra_config,
+                    "is_deleted": record.is_deleted,
+                }
+            )
+        log.info("[device:list_expired_paginated] result: %s rows", len(result))
+        return result
 
     @with_orm_session
     def list_by_bot_id(

--- a/src/baas/src/secbaas/community/core/repository/device/_protocol.py
+++ b/src/baas/src/secbaas/community/core/repository/device/_protocol.py
@@ -146,7 +146,12 @@ class DeviceRepository(Protocol):
         ...
 
     def update_status_by_device_uuid(
-        self, device_uuid: str, tenant: str, env: str, status: str
+        self,
+        device_uuid: str,
+        tenant: str,
+        env: str,
+        status: str,
+        modifier: str | None = None,
     ) -> int:
         """Update device status by device_uuid with tenant+env isolation. Returns affected row count."""
         ...
@@ -173,6 +178,24 @@ class DeviceRepository(Protocol):
         page_size: int = 20,
     ) -> tuple[int, list[DeviceRecord]]:
         """List devices with tenant+env isolation and optional status filtering."""
+        ...
+
+    def list_expired_paginated(
+        self,
+        *,
+        last_id: int = 0,
+        limit: int = 100,
+        grace_seconds: int = 0,
+        default_ttl_minutes: int = 10080,
+    ) -> list[dict[str, Any]]:
+        """查询 baas_device 中已到期的 ACK pod 设备，按 id ASC keyset 分页。
+
+        用于 ExpireSandboxTimer 定时任务：选择 provider_type='ARCA'、status='ACTIVE'、
+        含非空 sandbox_id 的记录。到期以续期路径维护的
+        provider_device_props.ttl_expiration_timestamp（毫秒 epoch）为准；缺失时回退到
+        派生 deadline = gmt_create + effective lifetime（其中 lifetime 优先取
+        extra_config.deploy_config.ttl_in_minutes，缺失回退 default_ttl_minutes）。
+        """
         ...
 
     def list_by_bot_id(

--- a/src/baas/src/secbaas/community/core/service/device_manage/_device_service.py
+++ b/src/baas/src/secbaas/community/core/service/device_manage/_device_service.py
@@ -2342,6 +2342,7 @@ class DefaultDeviceService(DeviceService):
             tenant=tenant,
             env=env,
             status=DeviceStatus.STOPPED.value,
+            modifier=modifier,
         )
         logger.info(f"Device {device_uuid} status updated to STOPPED")
 

--- a/src/baas/src/secbaas/community/core/service/scheduler/__init__.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/__init__.py
@@ -7,6 +7,8 @@ from ._tasks import (
     BotRunRecoveryTaskConfig,
     DeviceTtlTimerTask,
     DeviceTtlTimerTaskConfig,
+    ExpireSandboxTimerTask,
+    ExpireSandboxTimerTaskConfig,
     FileTransferPoller,
     FileTransferPollerConfig,
 )
@@ -18,6 +20,8 @@ __all__ = [
     "BotRunRecoveryTaskConfig",
     "DeviceTtlTimerTask",
     "DeviceTtlTimerTaskConfig",
+    "ExpireSandboxTimerTask",
+    "ExpireSandboxTimerTaskConfig",
     "FileTransferPoller",
     "FileTransferPollerConfig",
 ]

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/__init__.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/__init__.py
@@ -2,6 +2,10 @@
 
 from ._bot_run_recovery_task import BotRunRecoveryTask, BotRunRecoveryTaskConfig
 from ._device_ttl_timer_task import DeviceTtlTimerTask, DeviceTtlTimerTaskConfig
+from ._expire_sandbox_timer_task import (
+    ExpireSandboxTimerTask,
+    ExpireSandboxTimerTaskConfig,
+)
 from ._file_transfer_poller import FileTransferPoller, FileTransferPollerConfig
 
 __all__ = [
@@ -9,6 +13,8 @@ __all__ = [
     "BotRunRecoveryTaskConfig",
     "DeviceTtlTimerTask",
     "DeviceTtlTimerTaskConfig",
+    "ExpireSandboxTimerTask",
+    "ExpireSandboxTimerTaskConfig",
     "FileTransferPoller",
     "FileTransferPollerConfig",
 ]

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_expire_sandbox_timer_task.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_expire_sandbox_timer_task.py
@@ -1,0 +1,315 @@
+"""过期 ACK pod 沙箱定时 task
+
+> **Only effective for Aliyun ACK-created sandboxes.** This task handles only
+> devices whose sandbox was created by Aliyun ACK (Kubernetes Pod). Sandboxes
+> created via the enterprise `arca_sdk` (Aliyun official ARC SDK) have their
+> lifecycle and expiry managed by the ARC platform itself, and are **NOT routed
+> through this task**, to avoid this task destroying sandboxes still within the
+> ARC platform lease. The gate checks ``arca_provider`` and only executes when
+> ``plugins.sandbox.arca == "aliyun_ack"``.
+
+每 N 秒扫描 baas_device 中已到期（derived deadline <= now + grace）的 ACK pod
+服务设备，对绑定到该设备的 bot 走高级别 BotManageService.stop_bot 流程停 bot：
+创建 STOP publish、把 bot 状态置为 STOPPING，并沿用 publish 流程销毁底层
+Kubernetes Pod（404 幂等）、把设备记录置为 STOPPED。bot 状态与设备状态由此
+在同一条生命周期链路上保持一致。
+
+deadline 由每 bot 的 extra_config.deploy_config.ttl_in_minutes（缺失回退业务
+默认 default_ttl_minutes）派生。按 id keyset 分页，``id > last_id`` 保证逐页
+推进、整轮 drain 整个到期队列。
+
+cron 路径抢环境作用域分布式锁，多实例下同一时刻只有一个实例执行；页内以
+bounded concurrency 停 bot。依赖通过构造方法注入，由 DI 容器管理生命周期。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from uuid import uuid4
+
+from secbaas.community.api.bot_manage import BotManageService
+from secbaas.community.core.repository.bot import BotRepository
+from secbaas.community.core.repository.bot_device_rel import BotDeviceRelRepository
+from secbaas.community.core.repository.device import DeviceRepository
+from secbaas.community.core.service.distributed_lock import DistributedLockService
+from secbaas.community.core.utils.env_utils import get_current_env
+from secbaas.community.logger import get_logger
+
+log = get_logger("core-scheduler")
+
+
+@dataclass
+class ExpireSandboxTimerTaskConfig:
+    """过期沙箱定时 task 配置"""
+
+    enabled: bool = False
+    # ARCA sandbox provider variant (plugins.sandbox.arca). This task only takes
+    # effect for "aliyun_ack"; enterprise "arca_sdk" sandboxes are reclaimed by
+    # the ARC platform itself and are not allowed through.
+    arca_provider: str = "stub"
+    lock_name: str = "expire_sandbox_timer_lock"
+    # 锁过期时间须 < cron 间隔：租约在下一轮触发前到期释放，允许其它机器
+    # 在轮次间抢到锁。
+    lock_expire_seconds: int = 1750
+    cron_interval_seconds: int = 86400
+    batch_size: int = 100
+    max_page_concurrency: int = 10
+    query_retries: int = 3
+    dry_run: bool = False
+    # 到期判定余量（秒），抵消时钟偏差 / 边界 race。
+    grace_seconds: int = 0
+    # 业务默认 TTL（分钟），extra_config.deploy_config.ttl_in_minutes 缺失时回退。
+    default_ttl_minutes: int = 10080
+    # 停 bot 时记录的 modifier，便于审计。
+    modifier: str = "expire_sandbox_timer"
+
+    def resolved_lock_name(self) -> str:
+        """返回按环境作用域的分布式锁名（追加环境后缀，隔离 pre/prod）。"""
+        env = get_current_env()
+        return f"{self.lock_name}_{env}"
+
+    def provider_is_aliyun_ack(self) -> bool:
+        """Whether this task may take effect for the configured ARCA provider.
+
+        Only sandboxes created by Aliyun ACK are reclaimed by this task.
+        Enterprise ``arca_sdk`` sandboxes (managed by the ARC platform) are
+        reclaimed by the platform itself; this task must not destroy them, so it
+        only proceeds when the ARCA provider is ``aliyun_ack``.
+        """
+        return self.arca_provider == "aliyun_ack"
+
+
+@dataclass
+class ExpireSandboxRunReport:
+    """一轮过期扫描结束后的完整执行报告。"""
+
+    run_uuid: str
+    duration_seconds: float = 0.0
+    scanned: int = 0
+    stopped: int = 0
+    failed: int = 0
+    skipped: int = 0
+    pages: int = 0
+    skipped_reasons: dict[str, int] = field(default_factory=dict)
+
+    def to_log(self) -> str:
+        return (
+            f"expire_sandbox_report,uuid={self.run_uuid},duration={self.duration_seconds:.2f},"
+            f"scanned={self.scanned},stopped={self.stopped},failed={self.failed},"
+            f"skipped={self.skipped},pages={self.pages}"
+        )
+
+
+class ExpireSandboxTimerTask:
+    """过期 ACK pod 沙箱 task
+
+    cron 走 ``run()``（带分布式锁，避免多实例并发同一轮）。
+    同一进程内用 ``_running`` 标志防止并发重复扫描。
+    """
+
+    def __init__(
+        self,
+        config: ExpireSandboxTimerTaskConfig,
+        lock_service: DistributedLockService,
+        device_repo: DeviceRepository,
+        bot_manage_service: BotManageService,
+        bot_repo: BotRepository,
+        bot_device_rel_repo: BotDeviceRelRepository,
+    ) -> None:
+        self._config = config
+        self._lock_service = lock_service
+        self._device_repo = device_repo
+        self._bot_manage_service = bot_manage_service
+        self._bot_repo = bot_repo
+        self._bot_device_rel_repo = bot_device_rel_repo
+        self._running = False
+
+    @property
+    def name(self) -> str:
+        return "expire_sandbox_timer"
+
+    @property
+    def interval_seconds(self) -> int:
+        return self._config.cron_interval_seconds
+
+    async def run(self, *, run_uuid: str | None = None) -> dict | None:
+        """定时路径：先抢分布式锁，抢到才执行一轮完整过期扫描。
+
+        返回本轮摘要（{scanned, stopped, failed, pages, duration}），
+        未执行（disabled/dry_run/已在跑/未抢到锁）返回 ``None``。
+        """
+        run_uuid = run_uuid or str(uuid4())
+        log.info(
+            "[ExpireSandbox] Cron trigger at %s run_uuid=%s", datetime.now(), run_uuid
+        )
+
+        if not self._config.enabled:
+            log.info("[ExpireSandbox] Disabled, skipping")
+            return None
+
+        if not self._config.provider_is_aliyun_ack():
+            log.info(
+                "[ExpireSandbox] ARCA provider=%s is not aliyun_ack, skipping "
+                "(task only applies to Aliyun ACK-created sandboxes)",
+                self._config.arca_provider,
+            )
+            return None
+
+        if self._config.dry_run:
+            log.info(
+                "[ExpireSandbox] DRY_RUN mode - skipping (no destroy/stop). "
+                "batch_size=%s",
+                self._config.batch_size,
+            )
+            return None
+
+        if self._running:
+            log.info("[ExpireSandbox] Another run in progress, skipping cron trigger")
+            return None
+
+        lock_name = self._config.resolved_lock_name()
+        with self._lock_service.try_lock(
+            lock_name=lock_name,
+            expire_seconds=self._config.lock_expire_seconds,
+            block=False,
+        ) as lock:
+            if not lock.acquired:
+                log.info("[ExpireSandbox] Lock %s not acquired, skipping", lock_name)
+                return None
+
+            log.info("[ExpireSandbox] Lock %s acquired", lock_name)
+            self._running = True
+            try:
+                return await self._run_once(run_uuid=run_uuid)
+            finally:
+                self._running = False
+
+    async def _run_once(self, *, run_uuid: str) -> ExpireSandboxRunReport:
+        """执行一轮：keyset 分页扫描到期设备，页内 bounded concurrency 停 bot。
+
+        每个到期设备都通过高级别 ``BotManageService.stop_bot`` 流程停 bot
+        （创建 STOP publish → 状态转 STOPPING → 销毁设备），保证 bot 状态与设备
+        状态一致，而不是只把设备置为 STOPPED。
+        """
+        start_time = time.monotonic()
+        effective_batch = self._config.batch_size
+        sem = asyncio.Semaphore(self._config.max_page_concurrency)
+
+        last_id: int = 0
+        page_count: int = 0
+        scanned: int = 0
+        stopped: int = 0
+        failed: int = 0
+        skipped: int = 0
+        skipped_reasons: dict[str, int] = {}
+
+        def _mark_skip(reason: str) -> None:
+            nonlocal skipped
+            skipped += 1
+            skipped_reasons[reason] = skipped_reasons.get(reason, 0) + 1
+
+        while True:
+            rows: list | None = None
+            for attempt in range(1, self._config.query_retries + 1):
+                try:
+                    rows = self._device_repo.list_expired_paginated(
+                        last_id=last_id,
+                        limit=effective_batch,
+                        grace_seconds=self._config.grace_seconds,
+                        default_ttl_minutes=self._config.default_ttl_minutes,
+                    )
+                    break
+                except Exception as e:
+                    log.warning(
+                        "[ExpireSandbox] query attempt %d/%d failed: %s",
+                        attempt,
+                        self._config.query_retries,
+                        e,
+                    )
+                    if attempt < self._config.query_retries:
+                        await asyncio.sleep(0.2)
+
+            if rows is None:
+                log.error(
+                    "[ExpireSandbox] query failed after %d retries, aborting run",
+                    self._config.query_retries,
+                )
+                break
+
+            if not rows:
+                break
+
+            page_count += 1
+            scanned += len(rows)
+
+            async def _stop_one(row: dict) -> None:
+                nonlocal stopped, failed
+                async with sem:
+                    tenant = row.get("tenant")
+                    device_uuid = row.get("device_uuid")
+                    env = row.get("env")
+                    if not tenant or not device_uuid or not env:
+                        log.warning(
+                            "[ExpireSandbox] row missing tenant/device_uuid/env, skip id=%s",
+                            row.get("id"),
+                        )
+                        _mark_skip("missing_identity")
+                        return
+                    try:
+                        bot_uuid = self._resolve_bot_uuid(tenant, env, device_uuid)
+                        if bot_uuid is None:
+                            log.warning(
+                                "[ExpireSandbox] no active bot bound to device %s, skip",
+                                device_uuid,
+                            )
+                            _mark_skip("no_bot")
+                            return
+                        await self._bot_manage_service.stop_bot(
+                            tenant=tenant,
+                            bot_uuid=bot_uuid,
+                            operator=self._config.modifier,
+                            request_id=str(uuid4()),
+                        )
+                        stopped += 1
+                    except Exception as e:
+                        failed += 1
+                        log.error(
+                            "[ExpireSandbox] stop bot for device %s error: %s",
+                            device_uuid,
+                            e,
+                            exc_info=True,
+                        )
+
+            await asyncio.gather(*(_stop_one(row) for row in rows))
+
+            next_id = rows[-1]["id"]
+            if next_id <= last_id:
+                break
+            last_id = next_id
+
+        duration = time.monotonic() - start_time
+        report = ExpireSandboxRunReport(
+            run_uuid=run_uuid,
+            duration_seconds=duration,
+            scanned=scanned,
+            stopped=stopped,
+            failed=failed,
+            skipped=skipped,
+            pages=page_count,
+            skipped_reasons=skipped_reasons,
+        )
+        log.info("[ExpireSandbox] Report: %s", report.to_log())
+        return report
+
+    def _resolve_bot_uuid(self, tenant: str, env: str, device_uuid: str) -> str | None:
+        """Resolve the active bot bound to a device, if any."""
+        rel = self._bot_device_rel_repo.get_by_device_uuid(device_uuid, tenant, env)
+        if rel is None:
+            return None
+        bot = self._bot_repo.get_by_id(rel.bot_id, tenant=tenant, env=env)
+        if bot is None:
+            return None
+        return bot.bot_uuid

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox.py
@@ -51,6 +51,7 @@ class AliyunAckSandbox(ArcaSandbox):
         deployment_name: str | None = None,
         container_name: str | None = None,
         image: str | None = None,
+        ttl_in_minutes: float | int | None = None,
     ) -> None:
         self._sandbox_id = sandbox_id
         self._namespace = namespace
@@ -60,6 +61,7 @@ class AliyunAckSandbox(ArcaSandbox):
         self._deployment_name = deployment_name or ""
         self._container_name = container_name
         self._image = image
+        self._ttl_in_minutes = ttl_in_minutes
 
     @property
     def is_ready(self) -> bool:
@@ -75,17 +77,29 @@ class AliyunAckSandbox(ArcaSandbox):
         return self._sandbox_id
 
     def get_info(self) -> ArcaSandboxInfo:
-        """Extract Pod status into the unified ArcaSandboxInfo."""
+        """Extract Pod status into the unified ArcaSandboxInfo.
+
+        Also derives ``ttl_timestamp`` (ms epoch) from the Pod's
+        ``metadata.creation_timestamp`` plus the
+        ``avernet.arcasandbox/ttl-minutes`` annotation. This lets the renew path
+        treat an ACK Pod like any other Arca sandbox and extend its TTL.
+        """
         try:
             core_api = CoreV1Api(self._client)
             pod = core_api.read_namespaced_pod(
                 name=self._pod_name, namespace=self._namespace
             )
             status = getattr(pod, "status", None)
+
+            ttl_in_minutes = self._ttl_in_minutes
+            ttl_timestamp = self._derive_ttl_timestamp(pod, ttl_in_minutes)
+
             return ArcaSandboxInfo(
                 sandbox_id=self._sandbox_id,
                 status=getattr(status, "phase", None) or "UNKNOWN",
                 template_id=self._template_id,
+                ttl_in_minutes=ttl_in_minutes,
+                ttl_timestamp=ttl_timestamp,
                 metadata={
                     "pod_name": self._pod_name,
                     "namespace": self._namespace,
@@ -95,6 +109,40 @@ class AliyunAckSandbox(ArcaSandbox):
             raise RuntimeError(
                 f"get_info failed for sandbox {self._sandbox_id} ({e.status})"
             ) from e
+
+    def _derive_ttl_timestamp(
+        self, pod: Any, ttl_in_minutes: float | int | None
+    ) -> int | None:
+        """Compute the Pod expiry as a ms epoch timestamp.
+
+        Expiry = pod ``metadata.creation_timestamp`` + ``ttl-minutes`` annotation
+        (falling back to ``self._ttl_in_minutes``). Returns ``None`` when either
+        the creation time or the TTL cannot be resolved, so callers can fall back
+        to their own defaults rather than assuming a value.
+        """
+        from datetime import datetime as _datetime
+
+        metadata = getattr(pod, "metadata", None)
+        creation = getattr(metadata, "creation_timestamp", None) if metadata else None
+        if not isinstance(creation, _datetime):
+            return None
+
+        ttl = ttl_in_minutes
+        if ttl is None and metadata is not None:
+            annotations = getattr(metadata, "annotations", None) or {}
+            raw_ttl = annotations.get("avernet.arcasandbox/ttl-minutes")
+            if raw_ttl is not None:
+                try:
+                    ttl = float(raw_ttl)
+                except (TypeError, ValueError):
+                    ttl = None
+        if ttl is None:
+            return None
+
+        import calendar
+
+        created_epoch_s = calendar.timegm(creation.utctimetuple())
+        return int((created_epoch_s + ttl * 60) * 1000)
 
     def destroy(self) -> bool:
         """Delete the backing Deployment. Idempotent on 404.

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox_plugin.py
@@ -300,6 +300,7 @@ class AliyunAckSandboxPlugin(ArcaSandboxPlugin):
             deployment_name=deployment_name,
             container_name=container_name,
             image=image or "",
+            ttl_in_minutes=ttl_in_minutes,
         )
         logger.info(
             "[aliyun_ack] sandbox created template=%s sandbox_id=%s pod=%s",
@@ -344,6 +345,15 @@ class AliyunAckSandboxPlugin(ArcaSandboxPlugin):
         if pod.spec and pod.spec.containers:
             container_name = pod.spec.containers[0].name
 
+        ttl_in_minutes: float | int | None = None
+        if pod.metadata and pod.metadata.annotations:
+            raw_ttl = pod.metadata.annotations.get("avernet.arcasandbox/ttl-minutes")
+            if raw_ttl is not None:
+                try:
+                    ttl_in_minutes = float(raw_ttl)
+                except (TypeError, ValueError):
+                    ttl_in_minutes = None
+
         logger.info("[aliyun_ack] sandbox connected sandbox_id=%s", sandbox_id)
         return AliyunAckSandbox(
             sandbox_id=sandbox_id,
@@ -354,6 +364,7 @@ class AliyunAckSandboxPlugin(ArcaSandboxPlugin):
             deployment_name=deployment_name,
             container_name=container_name,
             image="",
+            ttl_in_minutes=ttl_in_minutes,
         )
 
     def resolve_ws_conn_info(

--- a/src/baas/tests/integration/core/repository/test_device_expired.py
+++ b/src/baas/tests/integration/core/repository/test_device_expired.py
@@ -1,0 +1,188 @@
+"""Integration tests for DeviceRepository.list_expired_paginated.
+
+Covers derived-deadline selection: per-bot extra_config.deploy_config.ttl_in_minutes
+as primary lifetime, fallback to default_ttl_minutes, ACTIVE/ARCA/non-null-sandbox
+constraints, and keyset pagination.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from secbaas.community.bootstrap import get_container
+from secbaas.community.core.repository.device import DeviceRepository
+from secbaas.community.core.utils.env_utils import get_current_env
+
+pytestmark = pytest.mark.integration
+
+TEST_ENV = get_current_env()
+
+
+def _uid() -> str:
+    return uuid4().hex
+
+
+def _insert_device(
+    *,
+    provider_type: str = "ARCA",
+    sandbox_id: str = "sbx-expired",
+    extra_config: dict | None = None,
+    provider_device_props: dict | None = None,
+) -> int:
+    device_repo = get_container().repository.device_repository()
+    props = {"sandbox_id": sandbox_id}
+    if provider_device_props:
+        props.update(provider_device_props)
+    return device_repo.insert_device(
+        device_uuid=_uid(),
+        tenant="tenant-expire",
+        env=TEST_ENV,
+        domain="test",
+        creator="tester",
+        modifier="tester",
+        status="ACTIVE",
+        provider_type=provider_type,
+        provider_device_id=sandbox_id,
+        provider_device_props=props,
+        extra_config=extra_config,
+    )
+
+
+class TestExpiredPagination:
+    def _repo(self) -> DeviceRepository:
+        return get_container().repository.device_repository()
+
+    def test_excludes_non_arca_providers(self):
+        repo = self._repo()
+        _insert_device(provider_type="ARCA", sandbox_id="sbx-arca")
+        _insert_device(provider_type="TECLAW", sandbox_id="sbx-teclaw")
+
+        result = repo.list_expired_paginated(default_ttl_minutes=0, grace_seconds=3600)
+        provider_types = {row["provider_type"] for row in result}
+        assert "TECLAW" not in provider_types
+
+    def test_zero_ttl_makes_recent_device_due(self):
+        # default_ttl_minutes=0 → deadline = gmt_create ≤ now(+grace), so due.
+        repo = self._repo()
+        device_id = _insert_device(sandbox_id="sbx-due", extra_config=None)
+
+        result = repo.list_expired_paginated(default_ttl_minutes=0, grace_seconds=3600)
+        ids = {row["id"] for row in result}
+        assert device_id in ids
+
+    def test_large_ttl_excludes_recent_device(self):
+        # default_ttl_minutes=10080 → deadline far in future, not due.
+        repo = self._repo()
+        device_id = _insert_device(sandbox_id="sbx-not-due", extra_config=None)
+
+        result = repo.list_expired_paginated(default_ttl_minutes=10080, grace_seconds=0)
+        ids = {row["id"] for row in result}
+        assert device_id not in ids
+
+    def test_expired_ttl_timestamp_due(self):
+        # A past ttl_expiration_timestamp marks the device due, regardless of
+        # gmt_create / default TTL.
+        import time as _time
+
+        past_ms = int((_time.time() - 3600) * 1000)
+        repo = self._repo()
+        device_id = _insert_device(
+            sandbox_id="sbx-ts-past",
+            provider_device_props={"ttl_expiration_timestamp": past_ms},
+        )
+
+        result = repo.list_expired_paginated(default_ttl_minutes=10080, grace_seconds=0)
+        ids = {row["id"] for row in result}
+        assert device_id in ids
+
+    def test_future_ttl_timestamp_not_due(self):
+        # A future ttl_expiration_timestamp must keep the device alive even when
+        # gmt_create + default would otherwise be expired (timestamp wins).
+        import time as _time
+
+        future_ms = int((_time.time() + 3600) * 1000)
+        repo = self._repo()
+        device_id = _insert_device(
+            sandbox_id="sbx-ts-future",
+            provider_device_props={"ttl_expiration_timestamp": future_ms},
+        )
+
+        result = repo.list_expired_paginated(default_ttl_minutes=0, grace_seconds=3600)
+        ids = {row["id"] for row in result}
+        assert device_id not in ids
+
+    def test_per_bot_ttl_overrides_default(self):
+        # A usable per-bot lifetime overrides default_ttl_minutes. Here the
+        # per-bot TTL is large (7 days) while the default would be due (0):
+        # the per-bot value must win, so the device is NOT expired.
+        repo = self._repo()
+        device_id = _insert_device(
+            sandbox_id="sbx-perbot",
+            extra_config={"deploy_config": {"ttl_in_minutes": 10080}},
+        )
+
+        result = repo.list_expired_paginated(default_ttl_minutes=0, grace_seconds=3600)
+        ids = {row["id"] for row in result}
+        assert device_id not in ids
+
+    def test_missing_or_zero_ttl_falls_back_to_default(self):
+        # When extra_config.deploy_config.ttl_in_minutes is missing or zero, the
+        # row is ineligible via the per-bot lifetime and must fall back to default.
+        repo = self._repo()
+        missing_id = _insert_device(sandbox_id="sbx-missing", extra_config=None)
+        zero_id = _insert_device(
+            sandbox_id="sbx-zero",
+            extra_config={"deploy_config": {"ttl_in_minutes": 0}},
+        )
+
+        # default=0 → both fall back to 0 → deadline = gmt_create → due.
+        result = repo.list_expired_paginated(default_ttl_minutes=0, grace_seconds=3600)
+        ids = {row["id"] for row in result}
+        assert missing_id in ids
+        assert zero_id in ids
+
+    def test_missing_sandbox_skipped(self):
+        # provider_device_props with no sandbox_id must be excluded.
+        repo = self._repo()
+        device_repo = get_container().repository.device_repository()
+        device_repo.insert_device(
+            device_uuid=_uid(),
+            tenant="tenant-expire",
+            env=TEST_ENV,
+            domain="test",
+            creator="tester",
+            modifier="tester",
+            status="ACTIVE",
+            provider_type="ARCA",
+            provider_device_id=None,
+            provider_device_props={},
+            extra_config=None,
+        )
+
+        result = repo.list_expired_paginated(default_ttl_minutes=0, grace_seconds=3600)
+        sandboxes = {row["provider_device_id"] for row in result}
+        assert None not in sandboxes
+
+    def test_keyset_pagination(self):
+        repo = self._repo()
+        prefix = f"sbx-page-{_uid()[:6]}"
+        ids = []
+        for i in range(5):
+            ids.append(_insert_device(sandbox_id=f"{prefix}-{i}"))
+
+        collected = []
+        last_id = 0
+        while True:
+            page = repo.list_expired_paginated(
+                last_id=last_id, limit=2, default_ttl_minutes=0, grace_seconds=3600
+            )
+            if not page:
+                break
+            collected.extend(int(row["id"]) for row in page)
+            last_id = max(int(row["id"]) for row in page)
+
+        # the specifically-inserted due devices must all be visited, in ascending id order.
+        own = [i for i in ids if i in collected]
+        assert own == sorted(own)

--- a/src/baas/tests/integration/core/service/scheduler/test_expire_sandbox_timer_task.py
+++ b/src/baas/tests/integration/core/service/scheduler/test_expire_sandbox_timer_task.py
@@ -1,0 +1,184 @@
+"""Integration tests for ExpireSandboxTimerTask routing.
+
+Verifies the expiry sweep routes an expired ACK device through the high-level
+``BotManageService.stop_bot`` flow (STOP publish + bot STOPPING), rather than
+silently marking only the device STOPPED and leaving the bot ACTIVE/inconsistent.
+
+Full teardown to bot STOPPED + device STOPPED is owned by the STOP-publish
+pipeline and covered by ``core/service/test_bot_management_service.py`` plus the
+publish service tests; here we assert the task's routing and the resulting
+intermediate consistency contract.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from secbaas.community.api.bot_manage import BotStatus
+from secbaas.community.api.device_manage import DeviceStatus
+from secbaas.community.api.publish_manage import PublishType
+from secbaas.community.bootstrap import get_container
+from secbaas.community.core.service.scheduler._tasks._expire_sandbox_timer_task import (
+    ExpireSandboxTimerTask,
+    ExpireSandboxTimerTaskConfig,
+)
+from secbaas.community.core.utils.env_utils import get_current_env
+
+pytestmark = pytest.mark.integration
+
+TEST_ENV = get_current_env()
+
+
+def _acquired_lock():
+    return SimpleNamespace(acquired=True)
+
+
+def _build_task(container) -> ExpireSandboxTimerTask:
+    lock = MagicMock()
+    lock.try_lock.return_value.__enter__.return_value = _acquired_lock()
+    return ExpireSandboxTimerTask(
+        config=ExpireSandboxTimerTaskConfig(
+            enabled=True, dry_run=False, arca_provider="aliyun_ack"
+        ),
+        lock_service=lock,
+        device_repo=container.repository.device_repository(),
+        bot_manage_service=container.services.bot_management_service(),
+        bot_repo=container.repository.bot_repository(),
+        bot_device_rel_repo=container.repository.bot_device_rel_repository(),
+    )
+
+
+class TestExpireSandboxStopsBot:
+    @pytest.mark.asyncio
+    async def test_expired_device_routes_through_stop_bot(
+        self,
+        bot_repository,
+        device_repository,
+        rel_repository,
+        publish_repository,
+        created_bot_ids,
+        created_device_ids,
+        created_rel_ids,
+        created_publish_ids,
+    ):
+        tenant = f"t-{uuid4().hex[:8]}"
+
+        bot_uuid = uuid4().hex
+        bot_id = bot_repository.insert_bot(
+            bot_uuid=bot_uuid,
+            tenant=tenant,
+            env=TEST_ENV,
+            domain="test",
+            creator="tester",
+            modifier="tester",
+            status=BotStatus.ACTIVE.value,
+            name="expiry-bot",
+            description=None,
+            template_uuid=None,
+            replica_desired=1,
+            replica_minimum=1,
+            replica_maximum=10,
+            auto_scaling_enabled=0,
+            sla_grade="standard",
+            extra_config={},
+        )
+        created_bot_ids.append(bot_id)
+
+        device_uuid = uuid4().hex
+        device_id = device_repository.insert_device(
+            device_uuid=device_uuid,
+            tenant=tenant,
+            env=TEST_ENV,
+            domain="test",
+            creator="tester",
+            modifier="tester",
+            status=DeviceStatus.ACTIVE.value,
+            provider_type="ARCA",
+            provider_device_id="sbx-expiry",
+            provider_device_props={
+                "sandbox_id": "sbx-expiry",
+                # already expired: timestamp in the past
+                "ttl_expiration_timestamp": int((time.time() - 3600) * 1000),
+            },
+            extra_config={"deploy_config": {"ttl_in_minutes": 10080}},
+        )
+        created_device_ids.append(device_id)
+
+        rel_id = rel_repository.insert_rel(
+            bot_id=bot_id,
+            device_uuid=device_uuid,
+            tenant=tenant,
+            env=TEST_ENV,
+            domain="test",
+            creator="tester",
+            modifier="tester",
+        )
+        created_rel_ids.append(rel_id)
+
+        container = get_container()
+        task = _build_task(container)
+        report = await task.run()
+
+        # The due device was scanned and routed through stop_bot, not left dangling.
+        assert report is not None
+        assert report.scanned >= 1
+        assert report.stopped >= 1
+        assert report.failed == 0
+
+        # Bot was transitioned to STOPPING (stop_bot initiated), not left ACTIVE.
+        bot = bot_repository.get_by_id(bot_id, tenant=tenant, env=TEST_ENV)
+        assert bot is not None
+        assert bot.status == BotStatus.STOPPING.value
+
+        # A STOP publish was created for the bot.
+        publishes = publish_repository.list_by_bot_id(
+            bot_id=bot_id, tenant=tenant, env=TEST_ENV
+        )
+        stop_publishes = [
+            p for p in publishes if p.publish_type == PublishType.STOP.value
+        ]
+        assert len(stop_publishes) >= 1
+        created_publish_ids.extend(p.id for p in publishes)
+
+    @pytest.mark.asyncio
+    async def test_unbound_device_is_skipped(
+        self,
+        device_repository,
+        created_device_ids,
+    ):
+        tenant = f"t-{uuid4().hex[:8]}"
+        device_uuid = uuid4().hex
+        device_id = device_repository.insert_device(
+            device_uuid=device_uuid,
+            tenant=tenant,
+            env=TEST_ENV,
+            domain="test",
+            creator="tester",
+            modifier="tester",
+            status=DeviceStatus.ACTIVE.value,
+            provider_type="ARCA",
+            provider_device_id="sbx-unbound",
+            provider_device_props={
+                "sandbox_id": "sbx-unbound",
+                "ttl_expiration_timestamp": int((time.time() - 3600) * 1000),
+            },
+            extra_config={"deploy_config": {"ttl_in_minutes": 10080}},
+        )
+        created_device_ids.append(device_id)
+
+        container = get_container()
+        task = _build_task(container)
+        report = await task.run()
+
+        assert report is not None
+        assert report.scanned >= 1
+        assert report.skipped >= 1
+
+        device = device_repository.get_by_id(device_id, tenant=tenant, env=TEST_ENV)
+        assert device is not None
+        assert device.status == DeviceStatus.ACTIVE.value

--- a/src/baas/tests/unit/core/repository/device/test_orm_device_repository.py
+++ b/src/baas/tests/unit/core/repository/device/test_orm_device_repository.py
@@ -706,6 +706,27 @@ class TestUpdateStatusByDeviceUuid:
         update_dict = call_kwargs[0][0]
         assert update_dict["status"] == "UPDATING"
         assert "gmt_modified" in update_dict
+        assert "modifier" not in update_dict
+
+    def test_updates_with_modifier(self, repository, mock_session):
+        mock_session.query.return_value.filter.return_value.update.return_value = 1
+
+        result = repository.update_status_by_device_uuid(
+            "DEVICE-UUID",
+            "test_tenant",
+            "prod",
+            "STOPPED",
+            modifier="expire_sandbox_timer",
+        )
+
+        assert result == 1
+        call_kwargs = (
+            mock_session.query.return_value.filter.return_value.update.call_args
+        )
+        update_dict = call_kwargs[0][0]
+        assert update_dict["status"] == "STOPPED"
+        assert "gmt_modified" in update_dict
+        assert update_dict["modifier"] == "expire_sandbox_timer"
 
     def test_not_found_returns_zero(self, repository, mock_session):
         mock_session.query.return_value.filter.return_value.update.return_value = 0
@@ -714,6 +735,63 @@ class TestUpdateStatusByDeviceUuid:
             "MISSING", "test_tenant", "prod", "DELETED"
         )
         assert result == 0
+
+
+# ==================== list_expired_paginated ====================
+
+
+class TestListExpiredPaginated:
+    def _mock_query_chain(self, mock_session, rows, dialect="mysql"):
+        """Configure the chain `query().filter().order_by().limit().all()` and the
+        dialect name used by ``list_expired_paginated`` for SQL branching."""
+        mock_session.bind.dialect.name = dialect
+        mock_session.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = rows
+
+    def test_returns_expired_rows_mysql(self, repository, mock_session):
+        model = _make_mock_device_model(id_val=7, device_uuid="DEVICE-EXPIRED")
+        self._mock_query_chain(mock_session, [model], dialect="mysql")
+
+        result = repository.list_expired_paginated(
+            limit=100, grace_seconds=0, default_ttl_minutes=10080
+        )
+
+        assert len(result) == 1
+        assert result[0]["id"] == 7
+        assert result[0]["device_uuid"] == "DEVICE-EXPIRED"
+        assert result[0]["status"] == "ACTIVE"
+        assert result[0]["provider_device_props"] == {}
+        model.to_record.assert_called_once()
+
+    def test_returns_expired_rows_sqlite(self, repository, mock_session):
+        model = _make_mock_device_model(id_val=8, device_uuid="DEVICE-EXPIRED-SQLITE")
+        self._mock_query_chain(mock_session, [model], dialect="sqlite")
+
+        result = repository.list_expired_paginated(
+            limit=100, grace_seconds=30, default_ttl_minutes=10080
+        )
+
+        assert len(result) == 1
+        assert result[0]["id"] == 8
+        assert result[0]["device_uuid"] == "DEVICE-EXPIRED-SQLITE"
+        model.to_record.assert_called_once()
+
+    def test_empty_result(self, repository, mock_session):
+        self._mock_query_chain(mock_session, [], dialect="mysql")
+
+        result = repository.list_expired_paginated(limit=100)
+
+        assert result == []
+
+    def test_pagination_passes_last_id(self, repository, mock_session):
+        model_a = _make_mock_device_model(id_val=21, device_uuid="D-21")
+        model_b = _make_mock_device_model(id_val=22, device_uuid="D-22")
+        self._mock_query_chain(mock_session, [model_a, model_b], dialect="mysql")
+
+        result = repository.list_expired_paginated(last_id=20, limit=10)
+
+        assert [r["id"] for r in result] == [21, 22]
+        model_a.to_record.assert_called_once()
+        model_b.to_record.assert_called_once()
 
 
 # ==================== list_devices ====================

--- a/src/baas/tests/unit/core/service/device_manage/test_device_service.py
+++ b/src/baas/tests/unit/core/service/device_manage/test_device_service.py
@@ -2326,6 +2326,7 @@ class TestStopDeviceByUuid:
             tenant="test_tenant",
             env="test",
             status=DeviceStatus.STOPPED.value,
+            modifier="test_user",
         )
 
     @pytest.mark.asyncio
@@ -2482,6 +2483,7 @@ class TestStopDeviceByUuid:
             tenant="test_tenant",
             env="test",
             status=DeviceStatus.STOPPED.value,
+            modifier="test_user",
         )
 
 

--- a/src/baas/tests/unit/core/service/scheduler/test_expire_sandbox_timer_task.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_expire_sandbox_timer_task.py
@@ -1,0 +1,399 @@
+"""Coverage tests for ExpireSandboxTimerTask (expired ACK pod sweep).
+
+Covers keyset pagination, disabled/dry_run/lock short-circuits, per-row bot stop via
+BotManageService.stop_bot, device->bot resolution, and bounded page concurrency.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+
+import pytest
+
+from secbaas.community.core.service.scheduler._tasks._expire_sandbox_timer_task import (
+    ExpireSandboxTimerTask,
+    ExpireSandboxTimerTaskConfig,
+)
+
+
+def _acquired_lock():
+    return SimpleNamespace(acquired=True)
+
+
+def _not_acquired_lock():
+    return SimpleNamespace(acquired=False)
+
+
+def _lock():
+    lock_service = MagicMock()
+    lock_service.try_lock.return_value.__enter__.return_value = _acquired_lock()
+    return lock_service
+
+
+def _row(
+    device_id: int,
+    tenant: str = "tenant-x",
+    device_uuid: str | None = None,
+    env: str = "prod",
+):
+    return {
+        "id": device_id,
+        "tenant": tenant,
+        "env": env,
+        "device_uuid": device_uuid or f"DEVICE-{device_id:032x}",
+        "provider_device_id": f"arc-{device_id}",
+    }
+
+
+def _pages(*pgs):
+    pages = list(pgs) + [[]]
+    return [list(pg) for pg in pages]
+
+
+def _bot_rel(bot_id: int):
+    return SimpleNamespace(bot_id=bot_id)
+
+
+def _bot_record(bot_uuid: str):
+    return SimpleNamespace(bot_uuid=bot_uuid)
+
+
+def _task(
+    config=None,
+    *,
+    repo=None,
+    bot_manage=None,
+    bot_repo=None,
+    rel_repo=None,
+    lock_service=None,
+):
+    if config is None:
+        config = ExpireSandboxTimerTaskConfig(enabled=True, arca_provider="aliyun_ack")
+    elif config.arca_provider == "stub":
+        # Tests that only intend to exercise the enabled path default to "stub",
+        # so normalize it to the eligible provider unless a non-ack variant is
+        # explicitly requested.
+        config.arca_provider = "aliyun_ack"
+    return ExpireSandboxTimerTask(
+        config=config,
+        lock_service=lock_service or _lock(),
+        device_repo=repo or MagicMock(),
+        bot_manage_service=bot_manage or MagicMock(),
+        bot_repo=bot_repo or MagicMock(),
+        bot_device_rel_repo=rel_repo or MagicMock(),
+    )
+
+
+class TestDefaults:
+    def test_name(self):
+        task = _task()
+        assert task.name == "expire_sandbox_timer"
+
+    def test_defaults(self):
+        cfg = ExpireSandboxTimerTaskConfig()
+        assert cfg.enabled is False
+        assert cfg.default_ttl_minutes == 10080
+        assert cfg.lock_name == "expire_sandbox_timer_lock"
+        assert cfg.modifier == "expire_sandbox_timer"
+
+    def test_provider_is_aliyun_ack(self):
+        assert ExpireSandboxTimerTaskConfig(
+            arca_provider="aliyun_ack"
+        ).provider_is_aliyun_ack() is True
+        for variant in ("arca_sdk", "stub", "local_proc"):
+            assert (
+                ExpireSandboxTimerTaskConfig(
+                    arca_provider=variant
+                ).provider_is_aliyun_ack()
+                is False
+            )
+
+    def test_interval_seconds(self):
+        cfg = ExpireSandboxTimerTaskConfig(cron_interval_seconds=42)
+        task = _task(cfg)
+        assert task.interval_seconds == 42
+
+
+class TestResolvedLockName:
+    def test_env_suffix(self):
+        with patch(
+            "secbaas.community.core.service.scheduler._tasks._expire_sandbox_timer_task.get_current_env",
+            return_value="prod",
+        ):
+            assert (
+                ExpireSandboxTimerTaskConfig().resolved_lock_name()
+                == "expire_sandbox_timer_lock_prod"
+            )
+
+
+class TestEarlyReturns:
+    @pytest.mark.asyncio
+    async def test_disabled_skips(self):
+        task = _task(ExpireSandboxTimerTaskConfig(enabled=False))
+        report = await task.run()
+        assert report is None
+
+    @pytest.mark.asyncio
+    async def test_non_ack_provider_skips(self):
+        repo = MagicMock()
+        bot_manage = MagicMock()
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True, arca_provider="arca_sdk"),
+            repo=repo,
+            bot_manage=bot_manage,
+        )
+        report = await task.run()
+        assert report is None
+        repo.list_expired_paginated.assert_not_called()
+        bot_manage.stop_bot.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_skips(self):
+        repo = MagicMock()
+        bot_manage = MagicMock()
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True, dry_run=True),
+            repo=repo,
+            bot_manage=bot_manage,
+        )
+        await task.run()
+        repo.list_expired_paginated.assert_not_called()
+        bot_manage.stop_bot.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_lock_not_acquired(self):
+        repo = MagicMock()
+        bot_manage = MagicMock()
+        lock_service = MagicMock()
+        lock_service.try_lock.return_value.__enter__.return_value = _not_acquired_lock()
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True),
+            repo=repo,
+            bot_manage=bot_manage,
+            lock_service=lock_service,
+        )
+        await task.run()
+        repo.list_expired_paginated.assert_not_called()
+        bot_manage.stop_bot.assert_not_called()
+
+
+class TestRun:
+    @pytest.mark.asyncio
+    async def test_empty_queue(self):
+        repo = MagicMock()
+        repo.list_expired_paginated.return_value = []
+        bot_manage = MagicMock()
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True),
+            repo=repo,
+            bot_manage=bot_manage,
+        )
+        report = await task.run()
+        assert report.scanned == 0
+        assert report.stopped == 0
+        bot_manage.stop_bot.assert_not_called()
+
+    def _resolving_mocks(self, bot_uuid="BOT-UUID-1"):
+        bot_manage = MagicMock()
+        bot_manage.stop_bot = AsyncMock(return_value=MagicMock())
+        rel_repo = MagicMock()
+        rel_repo.get_by_device_uuid.return_value = _bot_rel(7)
+        bot_repo = MagicMock()
+        bot_repo.get_by_id.return_value = _bot_record(bot_uuid)
+        return bot_manage, rel_repo, bot_repo
+
+    @pytest.mark.asyncio
+    async def test_stops_due_bot(self):
+        repo = MagicMock()
+        repo.list_expired_paginated.side_effect = _pages([_row(1)])
+        bot_manage, rel_repo, bot_repo = self._resolving_mocks()
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True),
+            repo=repo,
+            bot_manage=bot_manage,
+            bot_repo=bot_repo,
+            rel_repo=rel_repo,
+        )
+        report = await task.run()
+        assert report.stopped == 1
+        bot_manage.stop_bot.assert_awaited_once_with(
+            tenant="tenant-x",
+            bot_uuid="BOT-UUID-1",
+            operator="expire_sandbox_timer",
+            request_id=ANY,
+        )
+
+    @pytest.mark.asyncio
+    async def test_pagination_drains_all_pages(self):
+        p1 = [_row(i) for i in range(1, 4)]
+        p2 = [_row(j) for j in range(4, 7)]
+        repo = MagicMock()
+        repo.list_expired_paginated.side_effect = _pages(p1, p2)
+        bot_manage, rel_repo, bot_repo = self._resolving_mocks()
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True, batch_size=3),
+            repo=repo,
+            bot_manage=bot_manage,
+            bot_repo=bot_repo,
+            rel_repo=rel_repo,
+        )
+        report = await task.run()
+        assert report.scanned == 6
+        assert report.stopped == 6
+        assert bot_manage.stop_bot.await_count == 6
+
+    @pytest.mark.asyncio
+    async def test_cursor_advances_from_last_row(self):
+        p1 = [_row(1), _row(5)]
+        p2 = [_row(9)]
+        repo = MagicMock()
+        repo.list_expired_paginated.side_effect = _pages(p1, p2)
+        bot_manage, rel_repo, bot_repo = self._resolving_mocks()
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True, batch_size=2),
+            repo=repo,
+            bot_manage=bot_manage,
+            bot_repo=bot_repo,
+            rel_repo=rel_repo,
+        )
+        await task.run()
+        second_call = repo.list_expired_paginated.call_args_list[1]
+        assert second_call.kwargs["last_id"] == 5
+
+    @pytest.mark.asyncio
+    async def test_passes_grace_and_default_ttl(self):
+        repo = MagicMock()
+        repo.list_expired_paginated.return_value = []
+        task = _task(
+            ExpireSandboxTimerTaskConfig(
+                enabled=True, grace_seconds=300, default_ttl_minutes=1440
+            ),
+            repo=repo,
+        )
+        await task.run()
+        call = repo.list_expired_paginated.call_args
+        assert call.kwargs["grace_seconds"] == 300
+        assert call.kwargs["default_ttl_minutes"] == 1440
+
+    @pytest.mark.asyncio
+    async def test_row_missing_identity_skipped(self):
+        row = {"id": 1, "tenant": None, "env": "prod", "device_uuid": None}
+        repo = MagicMock()
+        repo.list_expired_paginated.side_effect = _pages([row])
+        bot_manage = MagicMock()
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True),
+            repo=repo,
+            bot_manage=bot_manage,
+        )
+        report = await task.run()
+        assert report.scanned == 1
+        assert report.stopped == 0
+        assert report.skipped == 1
+        bot_manage.stop_bot.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_bot_bound_skipped(self):
+        repo = MagicMock()
+        repo.list_expired_paginated.side_effect = _pages([_row(1)])
+        bot_manage = MagicMock()
+        bot_manage.stop_bot = AsyncMock(return_value=MagicMock())
+        rel_repo = MagicMock()
+        rel_repo.get_by_device_uuid.return_value = None
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True),
+            repo=repo,
+            bot_manage=bot_manage,
+            rel_repo=rel_repo,
+        )
+        report = await task.run()
+        assert report.scanned == 1
+        assert report.stopped == 0
+        assert report.skipped == 1
+        bot_manage.stop_bot.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rel_bound_bot_missing_skipped(self):
+        repo = MagicMock()
+        repo.list_expired_paginated.side_effect = _pages([_row(1)])
+        bot_manage = MagicMock()
+        bot_manage.stop_bot = AsyncMock(return_value=MagicMock())
+        rel_repo = MagicMock()
+        rel_repo.get_by_device_uuid.return_value = _bot_rel(7)
+        bot_repo = MagicMock()
+        bot_repo.get_by_id.return_value = None
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True),
+            repo=repo,
+            bot_manage=bot_manage,
+            bot_repo=bot_repo,
+            rel_repo=rel_repo,
+        )
+        report = await task.run()
+        assert report.scanned == 1
+        assert report.stopped == 0
+        assert report.skipped == 1
+        bot_manage.stop_bot.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cursor_not_advanced_breaks_loop(self):
+        # A subsequent page whose last id fails to advance past last_id would
+        # loop forever; the task must break to avoid an infinite drain loop.
+        p1 = [_row(5), _row(2)]
+        p2 = [_row(1)]
+        repo = MagicMock()
+        repo.list_expired_paginated.side_effect = _pages(p1, p2)
+        bot_manage, rel_repo, bot_repo = self._resolving_mocks()
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True, batch_size=2),
+            repo=repo,
+            bot_manage=bot_manage,
+            bot_repo=bot_repo,
+            rel_repo=rel_repo,
+        )
+        report = await task.run()
+        assert report.scanned == 3
+        assert report.stopped == 3
+        # Third call (empty page) is skipped: loop breaks when next_id (1) <= last_id (2).
+        assert repo.list_expired_paginated.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stop_failure_counted_not_raised(self):
+        repo = MagicMock()
+        repo.list_expired_paginated.side_effect = _pages([_row(1)])
+        bot_manage = MagicMock()
+        bot_manage.stop_bot = AsyncMock(side_effect=RuntimeError("down"))
+        rel_repo = MagicMock()
+        rel_repo.get_by_device_uuid.return_value = _bot_rel(7)
+        bot_repo = MagicMock()
+        bot_repo.get_by_id.return_value = _bot_record("BOT-UUID-1")
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True),
+            repo=repo,
+            bot_manage=bot_manage,
+            bot_repo=bot_repo,
+            rel_repo=rel_repo,
+        )
+        report = await task.run()
+        assert report.failed == 1
+        assert report.stopped == 0
+
+    @pytest.mark.asyncio
+    async def test_query_error_aborts_run(self):
+        repo = MagicMock()
+        repo.list_expired_paginated.side_effect = RuntimeError("db down")
+        bot_manage = MagicMock()
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True),
+            repo=repo,
+            bot_manage=bot_manage,
+        )
+        report = await task.run()
+        assert report.scanned == 0
+        bot_manage.stop_bot.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reentrant_run_returns_none(self):
+        task = _task(ExpireSandboxTimerTaskConfig(enabled=True))
+        task._running = True
+        report = await task.run()
+        assert report is None

--- a/src/baas/tests/unit/plugins/sandbox/arca/aliyun_ack/test_sandbox_plugin.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/aliyun_ack/test_sandbox_plugin.py
@@ -64,7 +64,9 @@ class _FakePodSpec:
 
 class _FakePod:
     def __init__(
-        self, phase: str = "Running", name: str = "openclaw-ack-test-pod"
+        self,
+        phase: str = "Running",
+        name: str = "openclaw-ack-test-pod",
     ) -> None:
         self.status = MagicMock()
         self.status.phase = phase
@@ -72,6 +74,8 @@ class _FakePod:
         self.metadata.name = name
         self.metadata.labels = {"avernet.arcasandbox/template": TEMPLATE_ID}
         self.metadata.owner_references = [_FakeOwnerRef()]
+        self.metadata.creation_timestamp = None
+        self.metadata.annotations = {}
         self.spec = _FakePodSpec()
 
 
@@ -147,6 +151,22 @@ class TestConnect:
         assert isinstance(sb, AliyunAckSandbox)
         assert sb.sandbox_id == "aliyun-ack-abc123"
 
+    def test_connect_reads_ttl_annotation(self) -> None:
+        with _CoreHarness() as h:
+            pod = _FakePod()
+            pod.metadata.annotations = {"avernet.arcasandbox/ttl-minutes": "10080"}
+            h.core.list_namespaced_pod.return_value = _FakePodList([pod])
+            sb = _plugin().connect_sync_sandbox("aliyun-ack-abc123")
+        assert sb._ttl_in_minutes == 10080.0
+
+    def test_connect_ignores_invalid_ttl_annotation(self) -> None:
+        with _CoreHarness() as h:
+            pod = _FakePod()
+            pod.metadata.annotations = {"avernet.arcasandbox/ttl-minutes": "bad"}
+            h.core.list_namespaced_pod.return_value = _FakePodList([pod])
+            sb = _plugin().connect_sync_sandbox("aliyun-ack-abc123")
+        assert sb._ttl_in_minutes is None
+
     def test_connect_not_found(self) -> None:
         with _CoreHarness() as h:
             h.core.list_namespaced_pod.return_value = _FakePodList([])
@@ -216,6 +236,89 @@ class TestSandbox:
         assert isinstance(info, ArcaSandboxInfo)
         assert info.sandbox_id == "aliyun-ack-1"
         assert info.status == "Running"
+
+    def test_get_info_echoes_ttl_in_minutes(self) -> None:
+        with _CoreHarness() as h:
+            sb = AliyunAckSandbox(
+                "aliyun-ack-1",
+                "ns",
+                TEMPLATE_ID,
+                MagicMock(),
+                pod_name="aliyun-ack-1",
+                ttl_in_minutes=10080,
+            )
+            info = sb.get_info()
+        assert info.ttl_in_minutes == 10080
+
+    def test_get_info_ttl_none_by_default(self) -> None:
+        with _CoreHarness() as h:
+            sb = AliyunAckSandbox(
+                "aliyun-ack-1", "ns", TEMPLATE_ID, MagicMock(), pod_name="aliyun-ack-1"
+            )
+            info = sb.get_info()
+        assert info.ttl_in_minutes is None
+
+    def test_get_info_derives_ttl_timestamp_from_pod(self) -> None:
+        from datetime import UTC, datetime
+
+        created = datetime(2026, 8, 1, 0, 0, 0, tzinfo=UTC)
+        with _CoreHarness() as h:
+            pod = _FakePod()
+            pod.metadata.creation_timestamp = created
+            pod.metadata.annotations = {"avernet.arcasandbox/ttl-minutes": "10080"}
+            h.core.read_namespaced_pod.return_value = pod
+            sb = AliyunAckSandbox(
+                "aliyun-ack-1", "ns", TEMPLATE_ID, MagicMock(), pod_name="aliyun-ack-1"
+            )
+            info = sb.get_info()
+        # 10080 minutes after 2026-08-01T00:00:00Z = 2026-08-08T00:00:00Z
+        expected_ms = int(created.timestamp() * 1000) + 10080 * 60 * 1000
+        assert info.ttl_timestamp == expected_ms
+
+    def test_get_info_ttl_timestamp_none_without_creation(self) -> None:
+        with _CoreHarness() as h:
+            sb = AliyunAckSandbox(
+                "aliyun-ack-1",
+                "ns",
+                TEMPLATE_ID,
+                MagicMock(),
+                pod_name="aliyun-ack-1",
+                ttl_in_minutes=10080,
+            )
+            info = sb.get_info()
+        assert info.ttl_timestamp is None
+
+    def test_get_info_ttl_timestamp_none_with_invalid_annotation(self) -> None:
+        from datetime import UTC, datetime
+
+        created = datetime(2026, 8, 1, 0, 0, 0, tzinfo=UTC)
+        with _CoreHarness() as h:
+            pod = _FakePod()
+            pod.metadata.creation_timestamp = created
+            pod.metadata.annotations = {
+                "avernet.arcasandbox/ttl-minutes": "not-a-number"
+            }
+            h.core.read_namespaced_pod.return_value = pod
+            sb = AliyunAckSandbox(
+                "aliyun-ack-1", "ns", TEMPLATE_ID, MagicMock(), pod_name="aliyun-ack-1"
+            )
+            info = sb.get_info()
+        assert info.ttl_timestamp is None
+
+    def test_get_info_ttl_timestamp_none_without_ttl(self) -> None:
+        from datetime import UTC, datetime
+
+        created = datetime(2026, 8, 1, 0, 0, 0, tzinfo=UTC)
+        with _CoreHarness() as h:
+            pod = _FakePod()
+            pod.metadata.creation_timestamp = created
+            pod.metadata.annotations = {}
+            h.core.read_namespaced_pod.return_value = pod
+            sb = AliyunAckSandbox(
+                "aliyun-ack-1", "ns", TEMPLATE_ID, MagicMock(), pod_name="aliyun-ack-1"
+            )
+            info = sb.get_info()
+        assert info.ttl_timestamp is None
 
     def test_destroy_idempotent(self) -> None:
         class _ApiClientException(Exception):


### PR DESCRIPTION
Add a self-managed MariaDB backend to the community gateway, mirroring the
baas MariaDB plugin pattern.

- Add MARIADB_ORM to PluginDatabaseType and wire it into the database
  providers.Selector.
- Add MariaDbOrmPlugin under community/plugins/database/mariadb implementing
  the DataSourcePlugin SPI with mysql+aiomysql (async) and mysqlconnector
  (sync) drivers.
- Extend DatabasePluginConfig with structured mariadb_* settings and env
  overrides.
- Add e2e-mariadb test overlay and runtime deps (aiomysql,
  mysql-connector-python).
- Add unit + SPI contract + E2E tests; MariaDB tests skip without a live DB.

Closes #1154
