### PR TITLE
feat(backend): add catalog search BCS filters

### DIFF
--- a/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
+++ b/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
@@ -1,6 +1,6 @@
 # Bot Catalog OpenAPI（前端接入文档）
 
-> 版本：2026-08-21
+> 版本：2026-08-24
 >
 > 机器可读权威契约为 `src/gateway/configs/schemas/bots.openapi.json`。
 
@@ -24,7 +24,9 @@ GET /openapi/v1/bots/catalog/search
 ```
 
 Backend 将 `search`、`page` 和 `page_size` 映射到 BCS `/bots/search` 的 `q`、`offset` 和
-`limit`，并固定传 `tc_bot=true`，只读取当前 BCS 页。该标识仅保留由 TeamClaw Backend onboard 的
+`limit`，并固定传 `tc_bot=true`，只读取当前 BCS 页。前端选择性传入的 `visibility`、
+`user_visibility`、`status`、`viewer_actor_type`、`viewer_actor_id` 与 `friendship` 经过本地
+校验后才映射到同名 BCS query；未传的字段不会产生默认过滤。该标识仅保留由 TeamClaw Backend onboard 的
 Bot。BCS 的 `bot_uuid` 按 `<bot_id>:<entity_id>` 解析后，Backend 在当前租户、当前环境内以精确二元组查询未删除的 live
 Bot 并内连接；Catalog Search 不再以 Backend `public="1"` 作为过滤条件，Backend 是全部对外字段的唯一权威来源。
 
@@ -35,18 +37,28 @@ BCS 的排序和分页边界保持不变。`tc_bot=true` 使正常数据下 BCS 
 
 若 BCS 当前目录项提供 `visibility`、`is_online`、`actor_kind`、`is_friend`、`friend_ext`、
 `friend_check_in_strategy` 或 `user_visibility`，Backend 在精确 `(bot_id, entity_id)` join 后原样返回；字段缺失或为
-`null` 时响应中省略。`friend_ext` 不删除内部键，前端可按需使用。Backend 不重新查询、推导或覆盖这些 BCS 值。
+`null` 时响应中省略。`is_friend` 仅在前端成对传入 `viewer_actor_type` 与 `viewer_actor_id` 且 BCS 返回该字段时出现；未传 viewer 不会以 `false` 代替。`friend_ext` 不删除内部键，前端可按需使用。Backend 不重新查询、推导或覆盖这些 BCS 值。
 
 | 参数 | 必填 | 规则 |
 |---|---:|---|
 | `search` | 否 | Bot 名称或 owner 名称关键词 |
 | `page` | 否 | 默认 1，最小 1 |
 | `page_size` | 否 | 默认 20，范围 1–100 |
+| `visibility` | 否 | BCS Bot 可见性；支持 `public`、`protected`、`private`，可重复传入或逗号分隔多值 |
+| `user_visibility` | 否 | BCS 用户侧可见性；取值和多值格式同 `visibility` |
+| `status` | 否 | 仅在传入时过滤 BCS 状态：`online` 或 `hidden` |
+| `viewer_actor_type` | 否 | BCS 关系视角 actor 类型：`human` 或 `bot`；必须与 `viewer_actor_id` 成对传入 |
+| `viewer_actor_id` | 否 | BCS 关系视角 actor ID；必须与 `viewer_actor_type` 成对传入 |
+| `friendship` | 否 | BCS 关系过滤：`all`、`friends`、`non_friends`；`friends`/`non_friends` 必须传 viewer pair |
 
 示例：
 
 ```text
 GET /openapi/v1/bots/catalog/search?search=marketing&page=1&page_size=20
+```
+
+```text
+GET /openapi/v1/bots/catalog/search?visibility=public,protected&user_visibility=public&status=online&viewer_actor_type=human&viewer_actor_id=330429&friendship=non_friends
 ```
 
 ## 3. 发现推荐 Bot

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Query, Request
@@ -23,6 +23,7 @@ from agentclaw.community.api.bot_discover_service import BotDiscoverServiceProto
 from agentclaw.community.api.bot_public_service import BotPublicServiceProtocol
 from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogCaller,
+    BotCatalogSearchFilters,
     BotCatalogSearchUnavailableError,
 )
 from agentclaw.community.di import Injected
@@ -34,6 +35,11 @@ from agentclaw.community.adapters.http.openapi_v1.authorization import PublicAPI
 logger = get_logger()
 PrincipalDep = Annotated[Principal, Depends(require_principal)]
 router = APIRouter(prefix="/openapi/v1/bots/catalog", tags=["bot-catalog"], route_class=PublicAPIRoute)
+
+_CATALOG_VISIBILITIES = frozenset({"public", "protected", "private"})
+_CATALOG_STATUSES = frozenset({"online", "hidden"})
+_CATALOG_VIEWER_TYPES = frozenset({"human", "bot"})
+_CATALOG_FRIENDSHIPS = frozenset({"all", "friends", "non_friends"})
 
 
 def _request_id(request: Request) -> str:
@@ -55,6 +61,77 @@ def _log_failure(operation: str, request: Request, category: str) -> None:
         operation,
         _request_id(request),
         category,
+    )
+
+
+def _normalize_catalog_values(
+    values: Sequence[str] | None,
+    *,
+    allowed: frozenset[str],
+) -> tuple[str, ...]:
+    """Normalize repeated and comma-separated optional Catalog filters."""
+    if values is None:
+        return ()
+    normalized: list[str] = []
+    for raw_value in values:
+        for value in raw_value.split(","):
+            candidate = value.strip()
+            if not candidate or candidate not in allowed:
+                raise ValueError("invalid catalog filter value")
+            if candidate not in normalized:
+                normalized.append(candidate)
+    return tuple(normalized)
+
+
+def _optional_catalog_value(
+    value: str | None,
+    *,
+    allowed: frozenset[str],
+) -> str | None:
+    if value is None:
+        return None
+    candidate = value.strip()
+    if not candidate or candidate not in allowed:
+        raise ValueError("invalid catalog filter value")
+    return candidate
+
+
+def _catalog_search_filters(
+    *,
+    visibility: Sequence[str] | None,
+    user_visibility: Sequence[str] | None,
+    status: str | None,
+    viewer_actor_type: str | None,
+    viewer_actor_id: str | None,
+    friendship: str | None,
+) -> BotCatalogSearchFilters:
+    """Validate frontend filters before sending the fixed BCS query."""
+    normalized_viewer_type = _optional_catalog_value(
+        viewer_actor_type, allowed=_CATALOG_VIEWER_TYPES
+    )
+    normalized_viewer_id = viewer_actor_id.strip() if viewer_actor_id else None
+    if viewer_actor_id is not None and not normalized_viewer_id:
+        raise ValueError("invalid catalog viewer")
+    if (normalized_viewer_type is None) != (normalized_viewer_id is None):
+        raise ValueError("catalog viewer must be supplied as a pair")
+
+    normalized_friendship = _optional_catalog_value(
+        friendship, allowed=_CATALOG_FRIENDSHIPS
+    )
+    if normalized_friendship in {"friends", "non_friends"} and normalized_viewer_id is None:
+        raise ValueError("catalog friendship filter requires viewer")
+
+    return BotCatalogSearchFilters(
+        visibility=_normalize_catalog_values(
+            visibility, allowed=_CATALOG_VISIBILITIES
+        ),
+        user_visibility=_normalize_catalog_values(
+            user_visibility, allowed=_CATALOG_VISIBILITIES
+        ),
+        status=_optional_catalog_value(status, allowed=_CATALOG_STATUSES),
+        viewer_actor_type=normalized_viewer_type,
+        viewer_actor_id=normalized_viewer_id,
+        friendship=normalized_friendship,
     )
 
 
@@ -100,13 +177,47 @@ async def search_public_bots(
         default=1, alias="page", ge=1, description="1-based page number."
     ),
     page_size: int = Query(default=20, ge=1, le=100, description="Items per page."),
+    visibility: list[str] | None = Query(
+        default=None,
+        description="Optional BCS visibility filter; repeat or comma-separate public, protected, private.",
+    ),
+    user_visibility: list[str] | None = Query(
+        default=None,
+        description="Optional BCS user visibility filter; repeat or comma-separate public, protected, private.",
+    ),
+    status: str | None = Query(
+        default=None, description="Optional BCS status filter: online or hidden."
+    ),
+    viewer_actor_type: str | None = Query(
+        default=None, description="Explicit BCS viewer actor type: human or bot."
+    ),
+    viewer_actor_id: str | None = Query(
+        default=None, description="Explicit BCS viewer actor id; requires viewer_actor_type."
+    ),
+    friendship: str | None = Query(
+        default=None,
+        description="Optional BCS friendship filter: all, friends, or non_friends.",
+    ),
     service: BotPublicServiceProtocol = Injected(BotPublicServiceProtocol),
 ) -> Envelope[Page[PublicBot]]:
+    try:
+        filters = _catalog_search_filters(
+            visibility=visibility,
+            user_visibility=user_visibility,
+            status=status,
+            viewer_actor_type=viewer_actor_type,
+            viewer_actor_id=viewer_actor_id,
+            friendship=friendship,
+        )
+    except ValueError:
+        _log_failure("search", request, "invalid_filters")
+        return error_response(422, "Invalid Catalog Search filters", request)
     try:
         result = service.search_catalog_public_bots_by_keyword(
             search=search,
             page=page_number,
             page_size=page_size,
+            filters=filters,
             caller=BotCatalogCaller(
                 tenant_id=principal.tenant,
                 user_id=principal.user_id or None,

--- a/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
@@ -24,6 +24,18 @@ class BotCatalogCaller:
 
 
 @dataclass(frozen=True)
+class BotCatalogSearchFilters:
+    """Validated optional BCS Catalog Search filters."""
+
+    visibility: tuple[str, ...] = ()
+    user_visibility: tuple[str, ...] = ()
+    status: str | None = None
+    viewer_actor_type: str | None = None
+    viewer_actor_id: str | None = None
+    friendship: str | None = None
+
+
+@dataclass(frozen=True)
 class BotCatalogMetadata:
     """BCS metadata retained for one catalog Bot after transport validation."""
 
@@ -52,6 +64,7 @@ class BotCatalogMetadataServiceProtocol(Protocol):
         search: str | None,
         page: int,
         page_size: int,
+        filters: BotCatalogSearchFilters | None,
         caller: BotCatalogCaller,
         request_id: str,
     ) -> Sequence[BotCatalogMetadata]: ...

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
@@ -11,6 +11,7 @@ from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogCaller,
     BotCatalogMetadata,
     BotCatalogMetadataUnavailableError,
+    BotCatalogSearchFilters,
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.http_client import HttpClient
@@ -31,6 +32,7 @@ class BcsBotCatalogMetadataService:
         search: str | None,
         page: int,
         page_size: int,
+        filters: BotCatalogSearchFilters | None = None,
         caller: BotCatalogCaller,
         request_id: str,
     ) -> Sequence[BotCatalogMetadata]:
@@ -43,6 +45,19 @@ class BcsBotCatalogMetadataService:
         }
         if search and search.strip():
             params["q"] = search
+        if filters is not None:
+            if filters.visibility:
+                params["visibility"] = ",".join(filters.visibility)
+            if filters.user_visibility:
+                params["user_visibility"] = ",".join(filters.user_visibility)
+            if filters.status is not None:
+                params["status"] = filters.status
+            if filters.viewer_actor_type is not None:
+                params["viewer_actor_type"] = filters.viewer_actor_type
+            if filters.viewer_actor_id is not None:
+                params["viewer_actor_id"] = filters.viewer_actor_id
+            if filters.friendship is not None:
+                params["friendship"] = filters.friendship
         try:
             # COSEC: The injected BCS client supplies the configured upstream host and
             # this constant relative path prevents request data from selecting a target.
@@ -107,11 +122,30 @@ class BcsBotCatalogMetadataService:
             )
             raise BotCatalogMetadataUnavailableError() from None
         logger.info(
-            "[BcsBotCatalogMetadataService.search] request_id=%s result_count=%s",
+            "[BcsBotCatalogMetadataService.search] request_id=%s result_count=%s "
+            "filter_count=%s has_viewer=%s",
             request_id,
             len(metadata),
+            self._filter_count(filters),
+            filters is not None and filters.viewer_actor_id is not None,
         )
         return metadata
+
+    @staticmethod
+    def _filter_count(filters: BotCatalogSearchFilters | None) -> int:
+        if filters is None:
+            return 0
+        return sum(
+            value is not None and value != ()
+            for value in (
+                filters.visibility,
+                filters.user_visibility,
+                filters.status,
+                filters.viewer_actor_type,
+                filters.viewer_actor_id,
+                filters.friendship,
+            )
+        )
 
     @staticmethod
     def _address_from_bot_uuid(value: object) -> BotCatalogAddress | None:

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -27,6 +27,7 @@ from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogMetadata,
     BotCatalogMetadataServiceProtocol,
     BotCatalogMetadataUnavailableError,
+    BotCatalogSearchFilters,
     BotCatalogSearchUnavailableError,
 )
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
@@ -1444,15 +1445,21 @@ class BotPublicService:
         *,
         caller: BotCatalogCaller,
         request_id: str,
+        filters: BotCatalogSearchFilters | None = None,
     ) -> Dict[str, Any]:
         """Return the current BCS catalog page joined to public Backend Bots."""
         try:
+            metadata_kwargs: dict[str, Any] = {
+                "search": search,
+                "page": page,
+                "page_size": page_size,
+                "caller": caller,
+                "request_id": request_id,
+            }
+            if filters is not None:
+                metadata_kwargs["filters"] = filters
             metadata = self._catalog_metadata_service.search_public_bot_metadata(
-                search=search,
-                page=page,
-                page_size=page_size,
-                caller=caller,
-                request_id=request_id,
+                **metadata_kwargs
             )
             addresses = self._validated_catalog_addresses(metadata)
             metadata_by_address = {item.address: item for item in metadata}

--- a/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
@@ -17,6 +17,7 @@ from agentclaw.community.api.bot_discover_service import BotDiscoverServiceProto
 from agentclaw.community.api.bot_public_service import BotPublicServiceProtocol
 from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogCaller,
+    BotCatalogSearchFilters,
     BotCatalogSearchUnavailableError,
 )
 from agentclaw.community.core.gateway_principal.models import (
@@ -162,12 +163,74 @@ def test_search_projects_only_catalog_fields(
             "search": "catalog",
             "page": 2,
             "page_size": 5,
+            "filters": BotCatalogSearchFilters(),
             "caller": BotCatalogCaller(
                 tenant_id="teamclaw", user_id="caller-1", app_id=None
             ),
             "request_id": "",
         }
     ]
+
+
+def test_search_selectively_projects_frontend_bcs_filters(
+    client: TestClient, services: tuple[_PublicService, _DiscoverService]
+) -> None:
+    response = client.get(
+        _SEARCH_PATH,
+        params=[
+            ("visibility", "public,protected"),
+            ("visibility", "private"),
+            ("user_visibility", "protected"),
+            ("user_visibility", "public,protected"),
+            ("status", "online"),
+            ("viewer_actor_type", "human"),
+            ("viewer_actor_id", "caller-1"),
+            ("friendship", "friends"),
+        ],
+    )
+
+    assert response.status_code == 200, response.text
+    assert services[0].calls[0]["filters"] == BotCatalogSearchFilters(
+        visibility=("public", "protected", "private"),
+        user_visibility=("protected", "public"),
+        status="online",
+        viewer_actor_type="human",
+        viewer_actor_id="caller-1",
+        friendship="friends",
+    )
+
+
+def test_search_all_friendship_does_not_require_a_viewer(
+    client: TestClient, services: tuple[_PublicService, _DiscoverService]
+) -> None:
+    response = client.get(_SEARCH_PATH, params={"friendship": "all"})
+
+    assert response.status_code == 200, response.text
+    assert services[0].calls[0]["filters"] == BotCatalogSearchFilters(
+        friendship="all"
+    )
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"viewer_actor_type": "human"},
+        {"viewer_actor_id": "caller-1"},
+        {"friendship": "friends"},
+        {"visibility": "public,unknown"},
+        {"status": "busy"},
+    ],
+)
+def test_search_rejects_invalid_bcs_filter_combinations(
+    client: TestClient,
+    services: tuple[_PublicService, _DiscoverService],
+    params: dict[str, str],
+) -> None:
+    response = client.get(_SEARCH_PATH, params=params)
+
+    assert response.status_code == 422, response.text
+    assert response.json()["code"] == 422000
+    assert services[0].calls == []
 
 
 def test_search_projects_bcs_is_friend_when_present(
@@ -240,6 +303,28 @@ def test_search_openapi_declares_the_fixed_catalog_unavailable_envelope(
         "message": "Catalog service unavailable",
         "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
     }
+
+
+def test_search_openapi_declares_optional_bcs_filter_parameters(app: FastAPI) -> None:
+    parameters = {
+        parameter["name"]: parameter
+        for parameter in app.openapi()["paths"][_SEARCH_PATH]["get"]["parameters"]
+    }
+
+    assert {
+        "visibility",
+        "user_visibility",
+        "status",
+        "viewer_actor_type",
+        "viewer_actor_id",
+        "friendship",
+    } <= parameters.keys()
+    assert parameters["visibility"]["required"] is False
+    assert parameters["user_visibility"]["required"] is False
+    assert "comma-separate" in parameters["visibility"]["description"]
+    assert "requires viewer_actor_type" in parameters["viewer_actor_id"][
+        "description"
+    ]
 
 
 def test_search_openapi_declares_optional_bcs_is_friend(app: FastAPI) -> None:

--- a/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
@@ -14,6 +14,7 @@ from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogMetadata,
     BotCatalogMetadataServiceProtocol,
     BotCatalogMetadataUnavailableError,
+    BotCatalogSearchFilters,
 )
 from agentclaw.community.di.container import build_injector
 from agentclaw.community.di.profile import DeployProfile
@@ -177,6 +178,44 @@ def test_bcs_catalog_search_omits_blank_query_and_keeps_page_boundary() -> None:
         "limit": 10,
         "tc_bot": True,
     }
+
+
+def test_bcs_catalog_search_forwards_only_supplied_frontend_filters() -> None:
+    """The adapter must preserve the explicit BCS filter contract without headers."""
+    service, http = _make_service()
+    http.set_response("get", _response(200, {"total": 0, "items": []}))
+
+    result = service.search_public_bot_metadata(
+        search=None,
+        page=2,
+        page_size=10,
+        filters=BotCatalogSearchFilters(
+            visibility=("public", "protected"),
+            user_visibility=("private",),
+            status="online",
+            viewer_actor_type="bot",
+            viewer_actor_id="viewer:owner",
+            friendship="non_friends",
+        ),
+        caller=_caller(),
+        request_id="trace-filters",
+    )
+
+    assert result == []
+    call = http.calls_to("get")[0]
+    assert call.args[0] == "/bots/search"
+    assert call.kwargs["params"] == {
+        "offset": 10,
+        "limit": 10,
+        "tc_bot": True,
+        "visibility": "public,protected",
+        "user_visibility": "private",
+        "status": "online",
+        "viewer_actor_type": "bot",
+        "viewer_actor_id": "viewer:owner",
+        "friendship": "non_friends",
+    }
+    assert "headers" not in call.kwargs
 
 
 @pytest.mark.parametrize(

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -19140,6 +19140,120 @@
               "title": "Page Size",
               "type": "integer"
             }
+          },
+          {
+            "description": "Optional BCS visibility filter; repeat or comma-separate public, protected, private.",
+            "in": "query",
+            "name": "visibility",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional BCS visibility filter; repeat or comma-separate public, protected, private.",
+              "title": "Visibility"
+            }
+          },
+          {
+            "description": "Optional BCS user visibility filter; repeat or comma-separate public, protected, private.",
+            "in": "query",
+            "name": "user_visibility",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional BCS user visibility filter; repeat or comma-separate public, protected, private.",
+              "title": "User Visibility"
+            }
+          },
+          {
+            "description": "Optional BCS status filter: online or hidden.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional BCS status filter: online or hidden.",
+              "title": "Status"
+            }
+          },
+          {
+            "description": "Explicit BCS viewer actor type: human or bot.",
+            "in": "query",
+            "name": "viewer_actor_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit BCS viewer actor type: human or bot.",
+              "title": "Viewer Actor Type"
+            }
+          },
+          {
+            "description": "Explicit BCS viewer actor id; requires viewer_actor_type.",
+            "in": "query",
+            "name": "viewer_actor_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Explicit BCS viewer actor id; requires viewer_actor_type.",
+              "title": "Viewer Actor Id"
+            }
+          },
+          {
+            "description": "Optional BCS friendship filter: all, friends, or non_friends.",
+            "in": "query",
+            "name": "friendship",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional BCS friendship filter: all, friends, or non_friends.",
+              "title": "Friendship"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
## Problem

Catalog Search could only pass its keyword and pagination to BCS. Frontend callers could not request the documented BCS visibility, user-visibility, status, or friendship-perspective filters, so `is_friend` could not be requested through an explicit viewer context.

## Solution

- Add optional Catalog Search query parameters for `visibility`, `user_visibility`, `status`, `viewer_actor_type`, `viewer_actor_id`, and `friendship`.
- Validate values and viewer/friendship combinations in the OpenAPI adapter, normalize repeated or comma-separated visibility values, and return an enveloped 422 before any invalid request reaches BCS.
- Pass only supplied filters to the fixed `/bots/search` BCS path while retaining `q`, pagination, `tc_bot=true`, the exact Backend join, and the existing public response allowlist.
- Update the Catalog frontend document and only the matching Gateway OpenAPI parameter section.

## Validation

- `DEPLOY_PROFILE=test uv run pytest tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py tests/community/core/bot_public/test_bot_catalog_metadata_service.py tests/community/core/bot_public/test_bot_public_service.py -q` — 173 passed.
- `DEPLOY_PROFILE=test uv run pytest tests/community/architecture/test_repository_contracts.py tests/community/architecture/test_http_adapter_layer_is_http_only.py tests/community/architecture/test_no_fastapi_in_core.py -q` — 15 passed.
- Ruff, generated/static Catalog Search OpenAPI parameter comparison, Gateway schema JSON validation, and `git diff --check` passed.

## Compatibility and risk

All new request parameters are optional. Omitted filters preserve the previous BCS request shape; callers that use viewer or friendship filters must follow the documented paired-parameter contract.

## Spec

`spec/pipeline/catalog-search-bcs-filters/`
