### PR TITLE
feat(bot_management): opt-in Passport authorization refresh on restart for aicoding/claude_code

### DIFF
--- a/src/backend/specs/2026-08-20-template-update-consented-authorization/plan.md
+++ b/src/backend/specs/2026-08-20-template-update-consented-authorization/plan.md
@@ -1,0 +1,80 @@
+# 实施计划：模板变更驱动的 MCP/CLI 授权知情同意（简化版）
+
+> 配套 spec.md。聚焦"如何落地"。
+
+## 核心动作（唯一新增能力）
+
+「确认重启」= `POST /restart` 带 `confirmed_template_update=true` 时，按顺序执行：
+1. 按 `template_uid` 向模板市场拉取最新版本模板配置；
+2. 注入 `bot.template_config`（复用 `apply_restart_extra_configs`/`update_template`）；
+3. `refresh_mcp_scope` 授权（MCP+CLI）。
+
+普通重启（默认 false）不升级、不授权，语义不变（代码现状即如此）。
+
+## 复用映射
+
+| 能力 | 复用对象 | 位置 | 说明 |
+|---|---|---|---|
+| 版本比较/注入 | `apply_restart_extra_configs` + `_template_version_id` | `strategy.py:424`/`:412` | 把拉取到的最新配置构造成 `extra_configs={"template_config":latest}` 传入，复用 `incoming>stored` 判定与 `update_template` |
+| 写 template_config | `template_service.update_template` | `template_service.py:301` | 现有，不改 |
+| 授权 MCP+CLI | `MCPSyncService.refresh_mcp_scope` | `sync_service.py:325` | 对 MCP 与 CLI 都写 passport；CLI 默认来自注入后的 `bot.template_config` |
+| CLI 合并/默认 | `_merge_cli_items` + `get_default_cli_items` | `sync_service.py:43` / `_defaults.py:295` | fail-closed；注入后读取即授权新 CLI |
+| 创建授权时机（参照） | `create_bot_with_authorization`→`_apply_passport`→`create_bot` | `create_flow.py:307/191/357` | 重启不走 apply，走 `update_passport` |
+| 重启幂等 | `ac_bot_restart_lock` | restart 链路 | 沿用 |
+| 详情透出版本 | `template_uid`/`template_version`/`template_version_id` | `capabilities.py:12-14` | 已有，无需改 |
+
+## 改动面（2 处，均不碰 diff、无状态机）
+
+### 改动①　重启端点增 `confirmed_template_update`
+- `adapters/http/bot_management/router.py:2627` `restart_bot`：从 body 解析
+  `confirmed_template_update`（默认 false，向后兼容），透传进 `bot_service.restart_bot`。
+- `openapi_v1/bots/router.py:600` 同步加同名字段（可选）。
+
+### 改动②　`restart_bot` 的确认分支：拉取→注入→授权
+- `core/bot_management/services/bot_service.py:4098` `restart_bot`：
+  - `confirmed_template_update==false` → 现有普通重启路径，不动。
+  - `confirmed_template_update==true`：
+    a. **拉取最新配置**：新增「调用模板市场按 `template_uid` 取最新版本配置」的 client/method。
+       - 入参/出参契约见 spec §拉取最新配置接口契约（待与模板市场同学确认）。
+       - 出参须能直接喂 `update_template` 与 `get_default_cli_items(ext_info={template_config})`。
+    b. **注入**：把拉取到的配置构造成 `extra_configs={"template_config": latest}`，复用现有
+       `apply_restart_extra_configs`（`:4182`）→ 命中 `incoming>stored` 才 `update_template`；
+       已是最新则跳过注入。
+    c. **授权**：注入后调 `refresh_mcp_scope`。需把 `MCPSyncService`（或其 factory）注入到
+       `restart_bot` 可达处（沿用现有 `skill_set_factory`/DI 模式）。
+    d. **失败不静默**：拉取/注入/授权任一失败 → 日志告警 + 上抛，不降级为"重启但没升级没授权"。
+- `confirmed_template_update` 不写 bot.ext、不透出。
+
+### 不再做的事（相对旧版）
+- 不新增 `template-update/confirm` 接口（Path A/B 确认动作都是 restart 带参）。
+- 不写 `bot.ext.template_update` 状态字段、不引入状态机。
+- 不写 MCP 排除表、不实现 CLI 拒绝（无拒绝语义）。
+
+## 前端契约（OCB 仅保证下发/入参）
+- 详情接口下发：`template_uid`/`template_version`/`template_version_id`（已有）。
+- restart 入参 `confirmed_template_update: bool`（可选，默认 false）。
+- diff 由前端直连模板市场取；弹窗条件「diff 有差异 且 首次进入页面」（前端实现，OCB 不参与）。
+
+## 分阶段
+1. **P1 模板市场接口对齐**：与模板市场同学确认 ①diff 入参；②「按 template_uid 拉最新配置」
+   入参/出参/鉴权。若无现成"拉取最新配置"接口，需模板市场新增。
+2. **P2 确认重启分支**：改动①+②-a/b（拉取+注入）；先不含授权，端到端跑通"确认重启→bot 升级
+   到最新配置"。单测覆盖拉取失败上抛、已是最新跳过注入、版本比较。
+3. **P3 授权接入**：②-c 注入后 `refresh_mcp_scope`；注入 MCPSyncService 注入；失败上抛。
+   端到端：确认重启后新增 mcp+cli 已授权；普通重启不升级不授权（验证现状未被破坏）。
+4. **P4 openapi surface + 边界**：openapi restart 字段、admission（`admission.py`）、错误码、
+   仅 `TEMPLATE_CONFIG_CONSUMING_ENGINES` 触发；评审守住"后端不算 diff"。
+
+## 风险与对策
+- **拉取最新配置依赖外部接口**：P1 前无法实现 P2；优先确认契约。若模板市场无现成接口，需
+  其新增，工期依赖外部。
+- **授权时序**：必须注入成功后才 `refresh_mcp_scope`，否则读旧配置漏授权新 CLI。代码注释固化。
+- **拉取/注入失败静默化**：严禁"重启成功但配置没升级、授权没做"。失败必须上抛、让用户可重试。
+- **幂等**：确认重启对已是最新版本的 bot，注入被 `incoming<=stored` 跳过，授权刷新幂等无副作用。
+- **多引擎**：非 `TEMPLATE_CONFIG_CONSUMING_ENGINES` 确认重启退化为普通重启，不误拉取/授权。
+- **diff 与授权解耦**：评审守住"授权路径不读/不算 diff"。
+
+## 开放项（需模板市场/前端确认）
+- diff 接口入参（待与模板市场同学确认）。
+- 「按 template_uid 拉取最新配置」接口入参/出参/鉴权（待确认；若无现成需新增）。
+- 「首次进入页面」判定（前端实现）。

--- a/src/backend/specs/2026-08-20-template-update-consented-authorization/spec.md
+++ b/src/backend/specs/2026-08-20-template-update-consented-authorization/spec.md
@@ -1,0 +1,294 @@
+# 模板变更驱动的 MCP/CLI 授权知情同意（简化版）
+
+GitHub issue: 待建（与本 spec 同步提交）。
+
+## Summary
+
+模板有版本更新、新版本会向默认能力新增 MCP/CLI。容器重启时授权不会自动跟随——现有
+授权只在 SkillSet 显式变更时触发（`refresh_mcp_scope`）。结果：即便 bot 用到了新模板
+配置，新默认 MCP/CLI 也处于**未授权**，用户既不知情也无法选择。
+
+本方案把这个静默升级变成一次**知情同意**，只有「同意 / 一键添加」语义，**无拒绝、无状态机**：
+
+- **diff 由前端直连模板市场取**：比较「**bot 当前配置**」与「**最新版本模板**」的差别
+  （added/removed mcp/cli）。**OCB 后端不算 diff。** diff 入参待与模板市场同学确认
+  （见 §diff 接口契约）。
+- **确认重启**（`POST /restart` 带 `confirmed_template_update=true`）是唯一的「升级 + 授权」
+  动作，Path A / Path B 都复用它：
+  - 后端按 `template_uid` 向模板市场**拉取最新版本模板配置**，注入 `bot.template_config`
+    （复用 `apply_restart_extra_configs`→`update_template`，但 incoming 不再来自请求 body，
+    而来自「拉取最新」）。
+  - 注入后调 `refresh_mcp_scope` **自动授权**新增 MCP/CLI。
+- **普通重启**（不带参数）：既不升级配置、也不授权，语义不变（代码现状即如此）。
+- **弹窗条件**：仅当 **diff 有差异** **且** **首次进入页面** 同时满足才弹；否则不弹。
+
+授权链路复用现有 `MCPSyncService.refresh_mcp_scope`（对 MCP 与 CLI 都写 passport，CLI 默认项
+从当前 `bot.template_config` 派生），不新增 passport 协议、不新增状态字段、不写排除表、
+不存在「拒绝」分支。
+
+## 代码现状（方案立足的事实基础）
+
+经核实，OCB 后端**不会**在普通重启时把 bot 升级到模板最新版本：
+
+- `bot.template_config` 只在创建、用户 `update_bot`、或上游主动传
+  `extra_configs.template_config` 时变化。
+- `restart_bot` 的 `extra_configs` 默认 `None`（`bot_service.py:4098`），
+  `restart_scheduler` 也不传；`apply_restart_extra_configs`（`strategy.py:424`）仅当
+  `extra_configs.get("template_config")` 存在且 `incoming_version > stored_version` 才
+  `update_template`。无传入则什么都不做。
+- 重启 / 设备重分配路径（`_allocate_device_async`、`start_bot`、`baas_device_service`）读的都是
+  `get_template_config(bot_id)`=**当前已存配置**；`_start_publish_polling` 成功回调不碰
+  `template_config`。全仓**无**按 `template_uid` 拉取最新版本配置回写的调用。
+
+因此「把 bot 升到最新模板配置」在 OCB 现状里**不存在**，必须由本方案在「确认重启」路径里
+**新增**。普通重启保持不升级（代码现状），这正是 Path B 能在「重启后」仍取到非空 diff 的
+前提——也是与用户新 diff 定义（bot 当前配置 vs 最新模板）自洽的关键。
+
+## Motivation
+
+现状缺口：重启不升级配置、即便升级授权也不跟随；新建时授权发生在 `_apply_passport`
+（`create_flow.py:191`，mcp_codes + `get_default_cli_items(...template_config)` 一次性写入
+passport），重启路径无等价一步。用户对「新模板带来哪些新 MCP/CLI」无感知、无选择权。
+
+## 目标 / 非目标
+
+目标：
+
+- 模板版本变更导致默认 MCP/CLI 变化时，用户能**知情**（看到 diff）、能**一键同意并升级+授权**。
+- 同意 → bot 升级到最新模板配置，新增 MCP/CLI 自动获得 AgentPass 授权。
+- diff 由模板市场提供，前端直连；OCB 后端不算 diff。
+- 「拉取最新配置 + 授权」仅发生在「确认重启」，复用现有注入与授权链路。
+- 不引入状态机、不引入拒绝语义、不新增持久字段。
+
+非目标：
+
+- 不在 OCB 后端实现/缓存 diff（仅前端取 diff）。
+- 不实现「拒绝新增」——只有「同意并升级+授权」。（「拒绝/永久排除」是独立增强，不在本期。）
+- 不改变模板发布与版本机制。
+- 普通重启语义不变（不升级、不授权）。
+
+## 整体架构
+
+```
+                 ┌─────────────── 模板市场 ───────────────┐
+   ① diff 接口     │  比较：bot 当前配置 vs 最新版本模板        │
+   (前端直连)  ──▶ │  出参：added/removed mcp、added/removed cli │
+                 │  入参：待与模板市场同学确认（见契约）          │
+                 └──────────────────────────────────────────┘
+                              ▲
+                 前端用「定位 bot 当前配置」的信息调（具体入参待确认）
+                              │
+   ┌──────────────────────────┴────────────────────────────────────────┐
+   │ 前端（bot 页面）                                                      │
+   │  - 进页面：调详情接口拿 template_uid/template_version；调模板市场 diff  │
+   │  - 弹窗条件：diff 有差异 且 首次进入页面（二者同时满足）才弹             │
+   │      Path A：点「允许变更并重启」│ Path B：弹「是否一键添加」            │
+   │      ——两者动作相同：restart{confirmed_template_update:true}          │
+   │  - diff 无差异 / 非首次进入 → 不弹                                      │
+   └─────────────────────────────────┬────────────────────────────────────┘
+                                     │ restart{confirmed_template_update:true}
+                                     ▼
+   ┌───────────────────── OCB 后端（不算 diff、无状态机）──────────────────┐
+   │  restart 解析 confirmed_template_update：                              │
+   │   false（默认）→ 普通重启：不升级、不授权（现状）                         │
+   │   true → 确认重启：                                                     │
+   │     1) 按 template_uid 向模板市场拉取最新版本模板配置                     │
+   │     2) 注入 bot.template_config（复用 update_template）                 │
+   │     3) refresh_mcp_scope 自动授权（MCP+CLI）                            │
+   │  详情接口下发 template_uid/template_version（已有，无需新增字段）        │
+   └────────────────────────────────────────────────────────────────────────┘
+```
+
+关键边界：**后端不算 diff、不存状态**。后端在「确认重启」里做三件事——拉取最新配置、注入、
+授权。授权正确性来自「注入后 `get_default_cli_items` 读到新配置」，与 diff 无关。
+
+## diff 接口契约（模板市场提供，OCB 仅消费约定）
+
+- 调用方：前端。
+- **比较语义**：「**bot 当前配置**」 vs 「**最新版本模板**」的差别（added/removed mcp/cli）。
+- **入参：待与模板市场同学确认**（不写死）。候选：足以定位「bot 当前配置」的标识，如
+  `{ template_uid, template_version }` 或 `{ template_uid, template_version_id }`
+  （均来自 `bot.template_config`，详情接口已透出）。最终以模板市场定义为准。
+- 出参（建议结构，以模板市场为准）：
+  ```jsonc
+  {
+    "has_change": true,
+    "added_mcp":   [ { "server_code": "...", "name": "..." } ],
+    "removed_mcp": [ { "server_code": "...", "name": "..." } ],
+    "added_cli":   [ { "cli_code": "...", "name": "..." } ],
+    "removed_cli": [ { "cli_code": "...", "name": "..." } ]
+  }
+  ```
+- `has_change=false` 时前端不弹窗。
+- 两条路径入参相同（都定位「bot 当前配置」）：
+  - **Path A**（重启前）：bot 当前配置 = 旧版本 → diff(旧 vs 最新) 有差异 → 提示。
+  - **Path B**（重启后）：因普通重启不升级配置，bot 当前配置**仍是旧版本** →
+    diff(旧 vs 最新) **仍有差异** → 首次进入页面时弹窗。
+  - 这与"普通重启不升级"的代码现状自洽，避免"重启后入参变空"的死结。
+
+## 拉取最新配置接口契约（模板市场提供，OCB 后端调用）⚠️需确认
+
+「确认重启」需要 OCB **主动拉取最新版本模板配置**注入 bot。这是新增的后端↔模板市场调用，
+契约**待与模板市场同学确认**：
+
+- 调用方：OCB 后端（确认重启路径内）。
+- 入参：定位「要拉哪个模板的最新版本」的标识，候选 `{ template_uid }`（并带上
+  `template_type`/`engine_type` 辅助），最终以模板市场为准。
+- 出参：最新版本的完整模板配置（含 `template_uid`/`template_version`/`template_version_id`
+  及默认 MCP/CLI 等），结构需能直接喂给 `template_service.update_template` 与
+  `get_default_cli_items(ext_info={template_config})`。
+- 鉴权/网络：沿用现有 OCB↔模板市场调用的鉴权方式（若无既有调用，需新增 OCB 侧 client）。
+
+> 注：与 diff 接口是两条不同的模板市场接口——diff 服务前端展示，本接口服务后端注入。
+> 两者入参都待确认。若模板市场能合并为「一个接口同时返回 diff + 最新配置」，可简化前端与
+> 后端，但默认按两条接口设计。
+
+## 数据模型
+
+**无新增状态字段、无状态机。** 不写 `bot.ext.template_update` 之类。
+
+- `confirmed_template_update`（restart 请求 body 的可选 bool，默认 false）：在重启链路内消费，
+  **不持久化**、不入 bot.ext。
+- `template_service.update_template` 写入最新 `template_config`（复用现有表 `ac_templates.ext`）。
+- `refresh_mcp_scope` 调用（现有能力，无 schema 变更）。
+
+## 接口设计
+
+### 1) 详情接口（已有，无改动）
+
+已透出 `template_uid`/`template_version`/`template_version_id`（来自 `bot.template_config`，
+`capabilities.py:12-14`）。前端据此取 diff。**不新增字段、不新增状态。**
+
+### 2) 重启接口 `POST /api/bots/{bot_id}/restart`（现有，增一个入参 + 一个分支）
+
+- 位置：`adapters/http/bot_management/router.py:2627`；openapi 对应
+  `adapters/http/openapi_v1/bots/router.py:600`。
+- 新增可选 body 字段：`confirmed_template_update: bool`（默认 `false`，向后兼容）。
+- 后端逻辑（`restart_bot`→`bot_service.restart_bot`）：
+  1. 现有生命周期校验照旧。
+  2. `confirmed_template_update==false`（默认）→ **普通重启，不升级、不授权**（现状，不动）。
+  3. `confirmed_template_update==true` → **确认重启**：
+     a. 按 `template_uid` 调模板市场**拉取最新版本模板配置**。
+     b. 复用 `apply_restart_extra_configs` 的注入判定（`incoming_version > stored_version` 才
+        `update_template`；相等或更旧则跳过注入，但仍可继续步骤 c 做幂等授权刷新）。
+        - 复用方式：把拉取到的最新配置构造成 `extra_configs={"template_config": latest}` 传入，
+          或新增一个「按 template_uid 注入最新」的 strategy 方法。实现择优（见 plan.md）。
+     c. 注入完成后调 `refresh_mcp_scope` **授权**新增 MCP/CLI。
+  4. 拉取或注入失败：日志告警 + 返回值上抛（**不降级为静默授权缺失**；用户可重试，幂等无害）。
+- 重启沿用现有幂等锁 `ac_bot_restart_lock` 与异步 202 语义。
+- `confirmed_template_update` 不写 bot.ext、不透出。
+
+### 不新增的接口
+
+- 不新增 `confirm`/`authorize` 类接口：Path A / Path B 确认后的动作都是「再调一次
+  restart 带 `confirmed_template_update=true`」，复用同一路径。
+
+## 授权链路复用与落点
+
+复用核心：`MCPSyncService.refresh_mcp_scope`（`mcp/services/sync_service.py:325`）。对 **MCP 与
+CLI 都写 passport**：
+
+- MCP：`collect_bot_active_mcps` → `_declare_mcp_scope`（设备白名单）→ `_update_passport` 写 mcp_codes。
+- CLI：`_update_passport`（`sync_service.py:850`）读 `bot.template_config`，调
+  `get_default_cli_items(engine_type, template_type, ext_info={template_config})`（`_defaults.py:295`）
+  取**当前模板默认 CLI**，`_merge_cli_items`（`sync_service.py:43`）去重合并后覆盖写 passport。
+
+故「**授权（MCP+CLI）**」= **注入最新 template_config 之后调一次 `refresh_mcp_scope`**。新默认
+CLI 因 `get_default_cli_items` 读到新配置而被自动补入。无需新增授权代码。
+
+授权时机（与创建对齐）：
+
+- 创建：`create_bot_with_authorization`（`create_flow.py:307`）先 `_apply_passport`（L357）再
+  `create_bot`（L413）。
+- 重启：passport 身份已存在（`agent_code`），不走 apply，只走 `update_passport`。故
+  **确认重启授权 = 注入最新配置之后调 `refresh_mcp_scope`**。
+- 必须保证「拉取并注入最新配置」成功之后才 `refresh_mcp_scope`，否则读旧配置、漏授权新 CLI。
+
+落点（推荐 R1）：在 `bot_service.restart_bot` 的确认分支内，按顺序执行「拉取→注入→授权」，
+注入复用 `apply_restart_extra_configs`，授权调用 `refresh_mcp_scope`。MCPSyncService 的注入由
+DI 提供；若 `restart_bot` 当前不持有 MCPSyncService，按现有 factory 模式注入（见 plan.md）。
+
+## Path A 流程（重启前确认 → 升级 + 授权）
+
+```
+[用户进 bot 页面]
+   │ 前端调详情接口 → 拿 template_uid/template_version（=当前旧版本 v_old）
+   │ 前端调模板市场 diff(定位 bot 当前配置) → has_change=true
+   ▼
+[展示「新版本模板更新内容：added/removed MCP/CLI」]
+   │ 用户点「允许变更并重启」
+   ▼
+[前端 POST /restart {confirmed_template_update:true}]
+   │ 后端：按 template_uid 拉取最新配置 → 注入 bot.template_config → refresh_mcp_scope 授权
+   ▼
+[重启完成；新增 mcp+cli 已授权] → 前端轮询 status 完成即结束
+[拉取/注入/授权失败：日志告警 + 上抛；用户可重试]
+```
+
+## Path B 流程（重启后弹窗 → 一键添加）
+
+```
+[用户此前未确认、普通重启了该 bot（默认 confirmed=false）]
+   │ 后端：普通重启，不升级配置、不授权（现状）；bot.template_config 仍为 v_old
+   ▼
+[重启完成，bot 仍是旧版本 v_old，新增 mcp/cli 未授权]
+   │
+[用户首次进入页面]
+   │ 前端调模板市场 diff(定位 bot 当前配置=v_old) → has_change=true（旧 vs 最新 有差异）
+   │ 满足「diff 有差异 且 首次进入页面」→ 弹窗
+   ▼
+[弹窗「本次重启更新内容：added MCP/CLI，是否一键添加？」]
+   │ 用户点「一键添加」
+   ▼
+[前端 POST /restart {confirmed_template_update:true}]
+   │ 后端：按 template_uid 拉取最新配置 → 注入 → refresh_mcp_scope 授权（同 Path A）
+   ▼
+[bot 升级到最新 + 新增 mcp/cli 已授权]
+[diff 无差异 / 非首次进入 → 不弹窗]
+```
+
+> 重启后若用户一直不点「一键添加」：bot 保持旧配置、新 MCP/CLI 不授权（可接受——用户知情后
+> 主动放弃，非静默脱节）。下次进页面若仍「首次针对该变更」可再弹；前端用「已对该 bot 展示
+> 过该版本变更」标记避免重复打扰（前端实现细节，OCB 不参与）。
+
+## Path B 待澄清项（前端/产品，非后端阻塞）
+
+1. **「首次进入页面」判定**：前端按 bot_id + 当前 template_version 维护「是否已弹过」标记
+   （如 localStorage），避免重复弹。OCB 后端不参与。
+2. **diff 入参最终定义**：见 §diff 接口契约，待与模板市场同学确认。
+3. **拉取配置接口入参/出参**：见 §拉取最新配置接口契约，待确认。
+
+## 边界与约束
+
+- **授权与 diff 解耦**：后端不算 diff；授权正确性来自「注入最新配置 + get_default_cli_items 派生」。
+- **无状态、无拒绝**：不写 bot.ext、不引入 status；不存在 reject/排除表写入。
+- **fail-closed（CLI）**：沿用 `get_default_cli_items` 未知桶返回空、`_merge_cli_items` 仅合并
+  已知默认、`query_passport_clis` 失败则 `_update_passport` 中止（不写半截快照）。
+- **幂等**：`refresh_mcp_scope` 多次调用无害；`restart` 沿用 `ac_bot_restart_lock`；确认重启对
+  「已是最新版本」的 bot 调用，注入会被 `incoming<=stored` 跳过，授权刷新幂等无副作用。
+- **拉取最新配置失败不静默**：确认重启里拉取/注入失败必须上抛，不可悄悄继续成「重启了但没
+  升级没授权」的半成品态。
+- **多引擎**：仅 `TEMPLATE_CONFIG_CONSUMING_ENGINES`（`apply_restart_extra_configs` 已限定）
+  参与注入与授权；其他引擎确认重启退化为普通重启。
+- **移除项**：模板移除的 MCP/CLI 不需特殊处理——下次 `refresh_mcp_scope` 自然不再包含。
+
+## 参考（代码坐标）
+
+- 重启端点：`adapters/http/bot_management/router.py:2627`（`restart_bot`）、
+  `adapters/http/openapi_v1/bots/router.py:600`。
+- 模板版本字段：`core/bot_management/capabilities.py:12-14`。
+- restart 链路：`core/bot_management/services/bot_service.py:4098`（`restart_bot` 签名/默认
+  `extra_configs=None`）、`:4182`（`apply_restart_extra_configs` 调用点）。
+- 版本比较与注入：`core/bot_management/engines/aicoding/strategy.py:412`（`_template_version_id`）、
+  `:424`（`apply_restart_extra_configs`，`:449` `update_template`）。
+- 模板读写：`core/bot_management/services/template_service.py:232`（`get_template_config`）、
+  `:301`（`update_template`）。
+- 创建授权：`core/bot_management/create_flow.py:307`（`create_bot_with_authorization`）、
+  `:191`（`_apply_passport`）、`:357`（apply 调用）。
+- 授权刷新（MCP+CLI）：`core/mcp/services/sync_service.py:325`（`refresh_mcp_scope`）、
+  `:850`（`_update_passport`）、`:43`（`_merge_cli_items`）。
+- 默认 CLI/MCP：`core/mcp/services/_defaults.py:295`（`get_default_cli_items`）、
+  `:199`（`get_default_mcp_servers`）。
+- 重启服务：`core/desktop_bot/services/desktop_bot_service.py:781`（`restart`）、
+  `_start_publish_polling`、幂等锁 `ac_bot_restart_lock`。
+- passport 协议：`plugin_api/passport.py`（`update_passport` 覆盖写 resourceManifest）。

--- a/src/backend/specs/2026-08-20-template-update-consented-authorization/tasks.md
+++ b/src/backend/specs/2026-08-20-template-update-consented-authorization/tasks.md
@@ -1,0 +1,45 @@
+# 任务清单：模板变更驱动的 MCP/CLI 授权知情同意（简化版）
+
+> 配套 spec.md / plan.md。`[ ]`待办 `[~]`进行中 `[x]`完成。
+
+## P0　接口契约对齐（外部依赖，优先）
+- [ ] 与模板市场同学确认 **diff 接口入参**（比较「bot 当前配置 vs 最新版本模板」）。
+- [ ] 与模板市场同学确认 **「按 template_uid 拉取最新版本模板配置」接口**：入参/出参/鉴权。
+      出参须能直接喂 `template_service.update_template` 与
+      `get_default_cli_items(ext_info={template_config})`。
+- [ ] 若模板市场无「拉取最新配置」现成接口 → 推动其新增，出接口契约。
+
+## P1　重启端点增参（改动①）
+- [ ] `restart_bot`（`router.py:2627`）从 body 解析 `confirmed_template_update`（默认 false），
+      透传 `bot_service.restart_bot`。
+- [ ] `openapi_v1/bots/router.py:600` 同步加可选字段。
+- [ ] `confirmed_template_update` 不写 bot.ext、不透出。单测：默认 false 向后兼容。
+
+## P2　确认重启：拉取 + 注入（改动②-a/b）
+- [ ] 新增「按 template_uid 调模板市场拉取最新版本配置」的 client/method（契约按 P0）。
+- [ ] `bot_service.restart_bot` 确认分支：拉取最新配置 → 构造
+      `extra_configs={"template_config": latest}` → 复用 `apply_restart_extra_configs`(`:4182`)
+      注入（命中 `incoming>stored` 才 `update_template`）。
+- [ ] 拉取/注入失败：日志告警 + 上抛，不静默降级。
+- [ ] 单测：拉取失败上抛；已是最新版本跳过注入幂等；版本比较沿用 `_template_version_id`。
+- [ ] 端到端（先不含授权）：确认重启 → bot.template_config 升级到最新版本。
+
+## P3　确认重启：授权接入（改动②-c）
+- [ ] 注入 MCPSyncService（或 factory）到 `restart_bot` 可达处（沿用现有 DI 模式）。
+- [ ] 注入成功后调 `refresh_mcp_scope` 授权（MCP+CLI）。
+- [ ] 代码注释固化：`refresh_mcp_scope` 必须在 `update_template` 成功之后调
+      （保证 `get_default_cli_items` 读到新配置）。
+- [ ] 授权失败：日志告警 + 上抛，不静默。
+- [ ] 端到端：确认重启后新增 mcp+cli 已授权；普通重启（false）不升级不授权、现状未被破坏。
+
+## P4　边界与收口
+- [ ] 仅 `TEMPLATE_CONFIG_CONSUMING_ENGINES` 触发拉取/注入/授权；非该集合退化为普通重启。
+- [ ] openapi admission（`admission.py`）按需；错误码与文案（拉取/注入/授权失败可重试）。
+- [ ] 评审守住"后端不算 diff、不存状态、无拒绝语义"。
+- [ ] 移除（或不引入）旧版残留：`template_update` ext 状态、`confirm` 端点、MCP 排除表写入、
+      CLI 拒绝语义——本版均不需要。
+
+## 待办（前端，OCB 不参与，仅记录口径）
+- [ ] 弹窗条件：diff 有差异 且 首次进入页面，二者同时满足才弹；否则不弹。
+- [ ] 「首次进入页面」判定（按 bot_id + template_version 维护已弹标记，前端实现）。
+- [ ] Path A/B 确认动作统一为 `restart{confirmed_template_update:true}`。

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -452,6 +452,87 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             incoming_version,
         )
 
+    def refresh_restart_authorization(
+        self,
+        ctx: BotProvisioningContext,
+        bot: Dict[str, Any],
+        extra_configs: Dict[str, Any] | None,
+        *,
+        passport_plugin: Any,
+        skill_set_factory: Any,
+        template_service: Any,
+    ) -> None:
+        """Refresh this bot's Passport authorization scope on restart.
+
+        Mirrors the create-time passport scope (``create_flow._apply_passport``)
+        so an ``aicoding`` / ``claude_code`` bot keeps the same MCP + CLI grants
+        after a restart: recompute the passport MCP codes and the engine default
+        CLI items, then push them to Passport via ``update_passport`` as a full
+        ``resource_scope`` snapshot (Passport treats each resource list as a
+        full replacement). Best-effort: failures are logged by the caller and
+        must not block the restart.
+
+        Opt-in: only runs when ``extra_configs['confirmed_template_update']`` is
+        truthy — a plain restart must never silently rewrite the Passport
+        authorization scope. Anything falsy (missing key, None, false) no-ops.
+        """
+        if not (isinstance(extra_configs, dict) and extra_configs.get("confirmed_template_update")):
+            logger.info(
+                "[aicoding.restart] skip passport refresh: confirmed_template_update is not set "
+                "for bot_id=%s",
+                ctx.bot_id,
+            )
+            return
+        from agentclaw.community.core.bot_management.create_flow import (
+            _get_bot_mcp_codes,
+        )
+        from agentclaw.community.core.mcp.services._defaults import (
+            get_default_cli_items
+        )
+
+        stored_config: Dict[str, Any] = (
+            template_service.get_template_config(ctx.bot_id) or {}
+        )
+        engine_type = ctx.active_engine or self.engine_type
+        entity_id = str(bot.get("entity_id") or "")
+        entity_type = str(bot.get("entity_type") or "staff")
+        owner_id = ctx.owner_id
+
+        mcp_codes = _get_bot_mcp_codes(
+            skill_set_factory,
+            owner_id,
+            ctx.bot_id,
+            entity_id,
+            entity_type,
+            engine_type,
+        )
+        cli_items = get_default_cli_items(
+            engine_type,
+            ctx.template_type,
+            ext_info={"template_config": stored_config}
+            if stored_config
+            else None,
+        )
+
+        passport_plugin.update_passport(
+            bot_id=ctx.bot_id,
+            user_id=owner_id,
+            bot_name=bot.get("bot_name"),
+            bot_desc=bot.get("bot_desc"),
+            engine_type=engine_type,
+            resource_scope={
+                "mcp_codes": mcp_codes,
+                "cli_items": cli_items,
+            },
+        )
+        logger.info(
+            "[aicoding.restart] refreshed passport authorization scope: "
+            "bot_id=%s mcp_codes=%s cli_items=%s",
+            ctx.bot_id,
+            mcp_codes,
+            cli_items,
+        )
+
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:
         # Application-only hooks (DIMA workspace/memory/cron) intentionally stay
         # out of the personalCoding path.  Existing call sites can be migrated

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
@@ -57,6 +57,18 @@ class DefaultProvisioningStrategy(EngineProvisioningStrategy):
     ) -> None:
         return None
 
+    def refresh_restart_authorization(
+        self,
+        ctx: BotProvisioningContext,
+        bot: dict[str, object],
+        extra_configs: dict[str, object] | None,
+        *,
+        passport_plugin: object,
+        skill_set_factory: object,
+        template_service: object,
+    ) -> None:
+        return None
+
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:
         return None
 

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
@@ -123,6 +123,34 @@ class EngineProvisioningStrategy(ABC):
         """
 
     @abstractmethod
+    def refresh_restart_authorization(
+        self,
+        ctx: BotProvisioningContext,
+        bot: Dict[str, Any],
+        extra_configs: Dict[str, Any] | None,
+        *,
+        passport_plugin: Any,
+        skill_set_factory: Any,
+        template_service: Any,
+    ) -> None:
+        """Re-sync engine-owned external authorization on restart.
+
+        Engines that mint/provision external credentials at create time (e.g.
+        the AICoding Passport MCP/CLI grants from ``create_flow._apply_passport``)
+        recompute and push the same grants here so a restart does not silently
+        drop the authorization scope the bot was created with. Engines without
+        such external authorization should no-op.
+
+        ``extra_configs`` is the restart extension envelope from the caller; a
+        strategy may require an opt-in flag (e.g. ``confirmed_template_update``)
+        before performing any side effect so a plain restart never silently
+        rewrites authorization.
+
+        Failures must not block the restart: the call site wraps this in the
+        same try/except as the restart extension envelope.
+        """
+
+    @abstractmethod
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:
         """Post-create hook. Default strategies should no-op."""
 

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -4246,6 +4246,17 @@ class BotService:
                 extra_configs,
                 template_service=self._template_service,
             )
+            # Re-sync the engine's external authorization scope (e.g. the
+            # aicoding Passport MCP/CLI grants) to match what was provisioned
+            # at create time, so a restart does not silently drop grants.
+            strategy.refresh_restart_authorization(
+                ctx,
+                bot,
+                extra_configs,
+                passport_plugin=self._passport_plugin,
+                skill_set_factory=self._skill_set_factory,
+                template_service=self._template_service,
+            )
         except Exception as exc:
             # Optional engine extensions must never block the existing restart path.
             logger.warning(

--- a/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
+++ b/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
@@ -1,0 +1,294 @@
+"""Unit tests for ``AicodingProvisioningStrategy.refresh_restart_authorization``.
+
+These mirror the create-time passport scope (``create_flow._apply_passport``)
+so an ``aicoding`` / ``claude_code`` bot keeps the same MCP + CLI grants after a
+restart. The strategy is opt-in: only when the caller passes
+``extra_configs['confirmed_template_update']`` truthy does it recompute the
+passport MCP codes + engine default CLI items and push them to Passport as a
+full ``resource_scope`` snapshot (full replacement).
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
+    AicodingProvisioningStrategy,
+)
+from agentclaw.community.core.bot_management.engines.default import (
+    DefaultProvisioningStrategy,
+)
+from agentclaw.community.core.bot_management.engines.provisioning import (
+    BotProvisioningContext,
+)
+
+# Patch targets for the function-local imports inside
+# ``refresh_restart_authorization`` (kept local to avoid the create_flow ->
+# bot_service import cycle).
+_MCP_CODES_PATH = "agentclaw.community.core.bot_management.create_flow._get_bot_mcp_codes"
+_CLI_ITEMS_PATH = "agentclaw.community.core.mcp.services._defaults.get_default_cli_items"
+
+
+def _ctx(active_engine="claude_code"):
+    return BotProvisioningContext(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        bot_type="personal",
+        active_engine=active_engine,
+        template_type="architect",
+    )
+
+
+def _bot(entity_id="ent-1", entity_type="staff", bot_name="my-bot", bot_desc="d"):
+    return {
+        "entity_id": entity_id,
+        "entity_type": entity_type,
+        "bot_name": bot_name,
+        "bot_desc": bot_desc,
+    }
+
+
+def _template_service(stored_config):
+    service = MagicMock()
+    service.get_template_config.return_value = stored_config
+    return service
+
+
+def _assert_skip(extra_configs):
+    """Run refresh with ``extra_configs`` and assert a complete no-op.
+
+    A no-op must not touch the template service, the MCP/CLI collectors, nor the
+    passport plugin — the gate returns before any of them are touched.
+    """
+    template_service = _template_service({"template_key": "architect"})
+    passport_plugin = MagicMock()
+    skill_set_factory = MagicMock(name="skill_set_factory")
+    strategy = AicodingProvisioningStrategy("claude_code")
+
+    with patch(_MCP_CODES_PATH) as mcp_mock, patch(_CLI_ITEMS_PATH) as cli_mock:
+        strategy.refresh_restart_authorization(
+            _ctx(),
+            _bot(),
+            extra_configs,
+            passport_plugin=passport_plugin,
+            skill_set_factory=skill_set_factory,
+            template_service=template_service,
+        )
+        template_service.get_template_config.assert_not_called()
+        mcp_mock.assert_not_called()
+        cli_mock.assert_not_called()
+        passport_plugin.update_passport.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# Gate / no-op branch                                                         #
+# --------------------------------------------------------------------------- #
+def test_skip_when_extra_configs_is_none():
+    _assert_skip(None)
+
+
+def test_skip_when_extra_configs_is_empty_dict():
+    _assert_skip({})
+
+
+def test_skip_when_confirmed_template_update_key_missing():
+    _assert_skip({"unrelated_key": True})
+
+
+def test_skip_when_confirmed_template_update_is_false():
+    _assert_skip({"confirmed_template_update": False})
+
+
+def test_skip_when_confirmed_template_update_is_none():
+    _assert_skip({"confirmed_template_update": None})
+
+
+def test_skip_when_extra_configs_is_not_a_dict():
+    # A non-dict envelope (str / list / bool) must also no-op without raising.
+    for extra_configs in ("confirmed_template_update=true", ["confirmed"], True):
+        _assert_skip(extra_configs)
+
+
+# --------------------------------------------------------------------------- #
+# Active branch: opt-in confirmed                                             #
+# --------------------------------------------------------------------------- #
+def _do_refresh(stored_config, active_engine="claude_code", strategy_engine="claude_code"):
+    """Run refresh with the opt-in flag set; return all collaborators + mocks."""
+    ctx = _ctx(active_engine=active_engine)
+    bot = _bot()
+    template_service = _template_service(stored_config)
+    passport_plugin = MagicMock()
+    skill_set_factory = MagicMock(name="skill_set_factory")
+    strategy = AicodingProvisioningStrategy(strategy_engine)
+
+    with patch(_MCP_CODES_PATH, return_value=["mcp-a", "mcp-b"]) as mcp_mock, \
+            patch(_CLI_ITEMS_PATH, return_value=["cli-1"]) as cli_mock:
+        strategy.refresh_restart_authorization(
+            ctx,
+            bot,
+            {"confirmed_template_update": True},
+            passport_plugin=passport_plugin,
+            skill_set_factory=skill_set_factory,
+            template_service=template_service,
+        )
+    return {
+        "ctx": ctx,
+        "bot": bot,
+        "template_service": template_service,
+        "passport_plugin": passport_plugin,
+        "skill_set_factory": skill_set_factory,
+        "mcp_mock": mcp_mock,
+        "cli_mock": cli_mock,
+    }
+
+
+def test_active_updates_passport_with_full_resource_scope():
+    r = _do_refresh({"template_key": "architect"})
+
+    r["template_service"].get_template_config.assert_called_once_with("bot-1")
+    r["mcp_mock"].assert_called_once_with(
+        r["skill_set_factory"], "owner-1", "bot-1", "ent-1", "staff", "claude_code"
+    )
+    r["cli_mock"].assert_called_once_with(
+        "claude_code", "architect",
+        ext_info={"template_config": {"template_key": "architect"}},
+    )
+    r["passport_plugin"].update_passport.assert_called_once_with(
+        bot_id="bot-1",
+        user_id="owner-1",
+        bot_name="my-bot",
+        bot_desc="d",
+        engine_type="claude_code",
+        resource_scope={"mcp_codes": ["mcp-a", "mcp-b"], "cli_items": ["cli-1"]},
+    )
+
+
+def test_active_passes_ext_info_none_when_stored_config_is_none():
+    # template_service.get_template_config -> None  =>  stored_config = {}
+    r = _do_refresh(None)
+    r["cli_mock"].assert_called_once_with(
+        "claude_code", "architect", ext_info=None,
+    )
+    r["passport_plugin"].update_passport.assert_called_once()
+
+
+def test_active_passes_ext_info_none_when_stored_config_is_empty_dict():
+    r = _do_refresh({})
+    r["cli_mock"].assert_called_once_with(
+        "claude_code", "architect", ext_info=None,
+    )
+    r["passport_plugin"].update_passport.assert_called_once()
+
+
+def test_active_uses_strategy_engine_type_when_ctx_active_engine_is_none():
+    r = _do_refresh(
+        {"template_key": "architect"},
+        active_engine=None,
+        strategy_engine="aicoding",
+    )
+    r["mcp_mock"].assert_called_once_with(
+        r["skill_set_factory"], "owner-1", "bot-1", "ent-1", "staff", "aicoding"
+    )
+    r["cli_mock"].assert_called_once_with(
+        "aicoding", "architect", ext_info={"template_config": {"template_key": "architect"}},
+    )
+    r["passport_plugin"].update_passport.assert_called_once_with(
+        bot_id="bot-1",
+        user_id="owner-1",
+        bot_name="my-bot",
+        bot_desc="d",
+        engine_type="aicoding",
+        resource_scope={"mcp_codes": ["mcp-a", "mcp-b"], "cli_items": ["cli-1"]},
+    )
+
+
+def test_active_defaults_entity_type_when_bot_missing_entity_type():
+    bot = {"entity_id": "ent-9", "bot_name": "b", "bot_desc": "x"}  # no entity_type
+    ctx = _ctx()
+    template_service = _template_service({})
+    passport_plugin = MagicMock()
+    skill_set_factory = MagicMock(name="skill_set_factory")
+    strategy = AicodingProvisioningStrategy("claude_code")
+
+    with patch(_MCP_CODES_PATH, return_value=[]) as mcp_mock, \
+            patch(_CLI_ITEMS_PATH, return_value=[]) as cli_mock:
+        strategy.refresh_restart_authorization(
+            ctx, bot, {"confirmed_template_update": True},
+            passport_plugin=passport_plugin,
+            skill_set_factory=skill_set_factory,
+            template_service=template_service,
+        )
+    mcp_mock.assert_called_once_with(
+        skill_set_factory, "owner-1", "bot-1", "ent-9", "staff", "claude_code"
+    )
+    passport_plugin.update_passport.assert_called_once_with(
+        bot_id="bot-1",
+        user_id="owner-1",
+        bot_name="b",
+        bot_desc="x",
+        engine_type="claude_code",
+        resource_scope={"mcp_codes": [], "cli_items": []},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Failure propagation                                                         #
+# --------------------------------------------------------------------------- #
+def test_passport_failure_propagates_and_is_not_swallowed():
+    """The strategy must let update_passport raise so the caller's try/except
+    can log-and-continue; it must not swallow authorization errors itself."""
+
+    ctx = _ctx()
+    bot = _bot()
+    template_service = _template_service({})
+    passport_plugin = MagicMock()
+    passport_plugin.update_passport.side_effect = RuntimeError("passport down")
+    skill_set_factory = MagicMock(name="skill_set_factory")
+    strategy = AicodingProvisioningStrategy("claude_code")
+
+    with patch(_MCP_CODES_PATH, return_value=["mcp-a"]), \
+            patch(_CLI_ITEMS_PATH, return_value=[]):
+        raised = False
+        try:
+            strategy.refresh_restart_authorization(
+                ctx, bot, {"confirmed_template_update": True},
+                passport_plugin=passport_plugin,
+                skill_set_factory=skill_set_factory,
+                template_service=template_service,
+            )
+        except RuntimeError:
+            raised = True
+        assert raised, "update_passport failure must propagate to the caller"
+
+
+# --------------------------------------------------------------------------- #
+# Default engine strategy: no-op                                              #
+# --------------------------------------------------------------------------- #
+def test_default_strategy_no_op_does_not_touch_passport():
+    template_service = MagicMock()
+    passport_plugin = MagicMock()
+    skill_set_factory = MagicMock(name="skill_set_factory")
+    strategy = DefaultProvisioningStrategy("openclaw")
+
+    # Even an opt-in request on a default engine must not authorize anything.
+    strategy.refresh_restart_authorization(
+        _ctx(),
+        _bot(),
+        {"confirmed_template_update": True},
+        passport_plugin=passport_plugin,
+        skill_set_factory=skill_set_factory,
+        template_service=template_service,
+    )
+    passport_plugin.update_passport.assert_not_called()
+    template_service.get_template_config.assert_not_called()
+
+
+def test_default_strategy_no_op_returns_none():
+    strategy = DefaultProvisioningStrategy("openclaw")
+    result = strategy.refresh_restart_authorization(
+        _ctx(),
+        _bot(),
+        None,
+        passport_plugin=MagicMock(),
+        skill_set_factory=MagicMock(),
+        template_service=MagicMock(),
+    )
+    assert result is None


### PR DESCRIPTION
## What

Add an opt-in engine strategy hook `refresh_restart_authorization` that re-syncs the Passport MCP/CLI grants on restart, mirroring create-time `create_flow._apply_passport`.

## Why

A `aicoding` / `claude_code` bot's Passport authorization scope (MCP codes + CLI items) is provisioned at create time. A restart should optionally re-sync the same grants so a template/config update does not silently drop the authorization scope the bot was created with — but only when the operator explicitly confirms a template update (front-end passes `extra_configs.confirmed_template_update=true`). A plain restart must never silently rewrite authorization.

## Changes

- `engines/provisioning.py`: add abstract `refresh_restart_authorization(ctx, bot, extra_configs, *, passport_plugin, skill_set_factory, template_service)`
- `engines/default.py`: no-op implementation for engines without external Passport authorization
- `engines/aicoding/strategy.py`: real implementation with the opt-in gate — recomputes `mcp_codes` via `_get_bot_mcp_codes` and `cli_items` via `get_default_cli_items`, then pushes the full `resource_scope` snapshot to `passport_plugin.update_passport` (full replacement, matching create time)
- `services/bot_service.py`: invoke the hook inside the existing `try/except` after `apply_restart_extra_configs`, so a refresh failure is logged and skipped without blocking the restart
- `tests/test_restart_authorization_refresh.py`: 14 unit tests covering the opt-in gate (None / empty / false / missing / non-dict), active branch (update_passport args + ext_info sub-branches + engine_type fallback + entity_type default), failure propagation, and default-engine no-op
- `specs/2026-08-20-template-update-consented-authorization/`: design doc

## Behavior

| Scenario | Action |
|---|---|
| `confirmed_template_update` not truthy | no-op (log + return), no side effects |
| `confirmed_template_update=true` (aicoding/claude_code) | recompute mcp+cli, push full scope to Passport |
| default / non-aicoding engine | no-op |
| Passport refresh fails | caller catches, logs warning, restart continues (never blocks) |

## Test

- `pytest tests/community/core/bot_management/services/test_restart_authorization_refresh.py` → 14 passed
- Regression (engine strategy contract + routing + restart paths, 225 tests) → all green
- `py_compile` for all changed files → OK