### PR TITLE
fix(backend): preserve caller MCP identity during scope refresh

### DIFF
--- a/src/backend/src/agentclaw/community/core/mcp/README.md
+++ b/src/backend/src/agentclaw/community/core/mcp/README.md
@@ -40,8 +40,10 @@ consumes:
   - "MCPAuthPlugin"
   - "MCPCenterPlugin"
   - "PassportPlugin"
+  - "CallerIdentityRepositoryProtocol"
 internal_dependencies:
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
+  - agentclaw.community.core.repository.protocols.identity # Caller identity overrides used for Passport scope sync
   - agentclaw.community.core.default_capabilities
   - agentclaw.community.core.bot_management
   - agentclaw.community.core.config

--- a/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 from injector import inject
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.repository.protocols.identity import CallerIdentityRepositoryProtocol
 from agentclaw.community.core.devices.services.device_context import (
     DeviceNotBoundError,
     UnknownProviderError,
@@ -116,6 +117,7 @@ class MCPSyncService:
         passport_update: PassportPlugin,
         mcp_config_service: MCPConfigService,
         bot_repository: BotRepository,
+        caller_identity_repository: CallerIdentityRepositoryProtocol,
         resolver_provider: 'Callable[[], "DeviceContextResolver"]',
         device_sync_dispatcher_provider: 'Callable[[], "DeviceSyncDispatcher"]',
     ) -> None:
@@ -129,6 +131,7 @@ class MCPSyncService:
             passport_update: Passport 插件，用于更新 passport MCP 列表。
             mcp_config_service: MCP 配置服务，用于构建同步请求参数。
             bot_repository: Bot 仓库，用于查询 bot 信息。
+            caller_identity_repository: Caller 身份仓库，用于保留显式 MCP 调用身份。
             resolver_provider: Lazy thunk 返回 ``DeviceContextResolver`` — 全仓
                 唯一 provider 解析点。以 ``(bot_id, user_id)`` 入参,经 binding +
                 ConnInfoBuilder 输出 typed ``DeviceContext``,取代旧
@@ -150,6 +153,7 @@ class MCPSyncService:
         self.passport_update = passport_update
         self.mcp_config_service = mcp_config_service
         self.bot_repository = bot_repository
+        self.caller_identity_repository = caller_identity_repository
         self._resolver_provider = resolver_provider
         self._device_sync_dispatcher_provider = device_sync_dispatcher_provider
 
@@ -480,7 +484,7 @@ class MCPSyncService:
         passport_result = await self._update_passport(
             bot_id=bot_id,
             user_id=user_id,
-            synced_server_codes=passport_mcp_codes,
+            synced_mcps=active_mcps,
             engine_type=effective_engine,
         )
         if not passport_result.get("success"):
@@ -894,24 +898,10 @@ class MCPSyncService:
         self,
         bot_id: str,
         user_id: str,
-        synced_server_codes: list[str],
+        synced_mcps: list[dict[str, Any]],
         engine_type: Optional[str] = None,
     ) -> dict[str, Any]:
-        """通知 passport 系统更新 bot 当前可用的 MCP codes 列表。
-
-        passport 用该列表做前端权限校验等下游消费。bot 元数据同时用于
-        解析默认 CLI 授权范围；若查询失败，为避免写入不完整的 CLI 快照，
-        本次 passport 更新会中止并返回失败。
-
-        Args:
-            bot_id: 目标 bot ID。
-            user_id: 用户 ID。
-            synced_server_codes: 当前应生效的 MCP server code 列表。
-            engine_type: 引擎类型。
-
-        Returns:
-            ``{"success": bool, "error": str|None}`` 格式的结果字典。
-        """
+        """更新完整 MCP scope；身份或 bot 元数据不可读取时中止覆盖。"""
         bot_name: Optional[str] = None
         bot_desc: Optional[str] = None
         template_type: Optional[str] = None
@@ -923,21 +913,33 @@ class MCPSyncService:
                 bot_desc = bot.get("bot_desc")
                 template_type = bot.get("template_type")
                 raw_template_config = bot.get("template_config")
-                if isinstance(raw_template_config, Mapping):
-                    template_config = raw_template_config
-                engine_type = (
-                    bot.get("active_engine") or bot.get("engine_type") or engine_type
-                )
+                template_config = raw_template_config if isinstance(raw_template_config, Mapping) else None
+                engine_type = bot.get("active_engine") or bot.get("engine_type") or engine_type
         except Exception as e:
             error = f"获取 bot 信息失败，无法安全解析默认 CLI 范围: {e}"
             logger.error("[MCPSyncService] %s, bot_id=%s", error, bot_id)
             return {"success": False, "error": error}
 
+        try:
+            identity_modes = self.caller_identity_repository.list_draft_call_types(
+                int(bot["id"]), str(engine_type)
+            )
+            mcp_items = passport_mcp_items_from_entries(
+                synced_mcps, identity_modes=identity_modes
+            )
+        except Exception as e:
+            error = f"查询 MCP 调用身份失败: {e}"
+            logger.error("[MCPSyncService] %s, bot_id=%s", error, bot_id)
+            return {"success": False, "error": error}
+
+        synced_server_codes = [item["mcp_code"] for item in mcp_items]
+        caller_mcp_codes = [
+            item["mcp_code"] for item in mcp_items if item["identity_mode"] == "caller"
+        ]
+
         # MCP 同步触发 resourceManifest 更新时，要回填当前 CLI，避免覆盖式更新丢失 CLI 授权。
         try:
-            current_cli_items = self.passport_update.query_passport_clis(
-                bot_id, user_id
-            )
+            current_cli_items = self.passport_update.query_passport_clis(bot_id, user_id)
         except Exception as e:
             error = f"查询 CLI 范围失败: {e}"
             logger.error("[MCPSyncService] %s", error)
@@ -964,12 +966,13 @@ class MCPSyncService:
             )
 
         try:
-            # resource_scope 是完整快照：MCP 来自同步结果，CLI 来自当前许可证 + 引擎默认 CLI。
+            # resource_scope 是完整快照：MCP 身份与 CLI 都必须回传，避免覆盖丢失授权。
             self.passport_update.update_passport(
                 bot_id=bot_id,
                 user_id=user_id,
                 resource_scope={
                     "mcp_codes": synced_server_codes,
+                    "mcp_items": mcp_items,
                     "cli_items": cli_items,
                 },
                 bot_name=bot_name,
@@ -978,11 +981,12 @@ class MCPSyncService:
             )
             logger.info(
                 "[MCPSyncService] updatePassport 成功: "
-                "bot_id=%s, user_id=%s, mcps=%s, clis=%s, "
+                "bot_id=%s, user_id=%s, mcps=%s, caller_mcps=%s, clis=%s, "
                 "engine_type=%s, bot_name=%s",
                 bot_id,
                 user_id,
                 synced_server_codes,
+                caller_mcp_codes,
                 cli_items,
                 engine_type,
                 bot_name,

--- a/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
@@ -920,13 +920,13 @@ class MCPSyncService:
             logger.error("[MCPSyncService] %s, bot_id=%s", error, bot_id)
             return {"success": False, "error": error}
 
+        identity_modes: Mapping[str, object] = {}
         try:
-            identity_modes = self.caller_identity_repository.list_draft_call_types(
-                int(bot["id"]), str(engine_type)
-            )
-            mcp_items = passport_mcp_items_from_entries(
-                synced_mcps, identity_modes=identity_modes
-            )
+            if bot:
+                identity_modes = self.caller_identity_repository.list_draft_call_types(int(bot["id"]), str(engine_type))
+            else:
+                logger.info("[MCPSyncService] 未找到持久化 bot，按 owner 刷新 MCP scope: bot_id=%s", bot_id)
+            mcp_items = passport_mcp_items_from_entries(synced_mcps, identity_modes=identity_modes)
         except Exception as e:
             error = f"查询 MCP 调用身份失败: {e}"
             logger.error("[MCPSyncService] %s, bot_id=%s", error, bot_id)

--- a/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
@@ -484,6 +484,7 @@ class MCPSyncService:
         passport_result = await self._update_passport(
             bot_id=bot_id,
             user_id=user_id,
+            owner_id=entity_id,
             synced_mcps=active_mcps,
             engine_type=effective_engine,
         )
@@ -898,6 +899,7 @@ class MCPSyncService:
         self,
         bot_id: str,
         user_id: str,
+        owner_id: str,
         synced_mcps: list[dict[str, Any]],
         engine_type: Optional[str] = None,
     ) -> dict[str, Any]:
@@ -907,7 +909,7 @@ class MCPSyncService:
         template_type: Optional[str] = None
         template_config: Optional[Mapping[str, Any]] = None
         try:
-            bot = self.bot_repository.get_by_id_and_owner(bot_id, user_id)
+            bot = self.bot_repository.get_by_id_and_owner(bot_id, owner_id)
             if bot:
                 bot_name = bot.get("bot_name")
                 bot_desc = bot.get("bot_desc")

--- a/src/backend/src/agentclaw/community/di/modules/mcp_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/mcp_module.py
@@ -31,6 +31,9 @@ from agentclaw.community.api.mcp_config_service import MCPConfigServiceProtocol
 from agentclaw.community.api.mcp_market_service import MCPMarketServiceProtocol
 from agentclaw.community.api.mcp_sync_service import MCPSyncServiceProtocol
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.repository.protocols.identity import (
+    CallerIdentityRepositoryProtocol,
+)
 from agentclaw.community.core.devices.services.device_context_resolver import (
     DeviceContextResolver,
 )
@@ -116,6 +119,7 @@ class McpModule(Module):
         passport_update: PassportPlugin,
         mcp_config_service: MCPConfigService,
         bot_repository: BotRepository,
+        caller_identity_repository: CallerIdentityRepositoryProtocol,
         injector: Injector,
     ) -> MCPSyncService:
         """Cycle break: lazy thunks for ``DeviceContextResolver`` /
@@ -133,6 +137,7 @@ class McpModule(Module):
             passport_update=passport_update,
             mcp_config_service=mcp_config_service,
             bot_repository=bot_repository,
+            caller_identity_repository=caller_identity_repository,
             resolver_provider=lambda: injector.get(DeviceContextResolver),
             device_sync_dispatcher_provider=lambda: injector.get(DeviceSyncDispatcher),
         )

--- a/src/backend/tests/community/core/mcp/services/test_caller_identity_principal_sync.py
+++ b/src/backend/tests/community/core/mcp/services/test_caller_identity_principal_sync.py
@@ -17,6 +17,7 @@ async def test_identity_sync_replaces_complete_non_local_mcp_manifest() -> None:
         passport_update=passport,
         mcp_config_service=MagicMock(),
         bot_repository=MagicMock(),
+        caller_identity_repository=MagicMock(),
         resolver_provider=MagicMock(),
         device_sync_dispatcher_provider=MagicMock(),
     )

--- a/src/backend/tests/community/core/mcp/services/test_sync_service.py
+++ b/src/backend/tests/community/core/mcp/services/test_sync_service.py
@@ -142,8 +142,8 @@ class TestRefreshMcpScope:
         )
 
         result = await service.refresh_mcp_scope(
-            user_id="owner-1",
-            entity_id="entity-1",
+            user_id="caller-1",
+            entity_id="owner-1",
             bot_id="default",
             entity_type="staff",
             engine_type="claude_code",
@@ -191,14 +191,15 @@ class TestRefreshMcpScope:
         )
 
         result = await service.refresh_mcp_scope(
-            user_id="owner-1",
-            entity_id="entity-1",
+            user_id="caller-1",
+            entity_id="owner-1",
             bot_id="default",
             entity_type="staff",
             engine_type="openclaw",
         )
 
         assert result["success"] is True
+        bot_repository.get_by_id_and_owner.assert_called_once_with("default", "owner-1")
         caller_identity_repository.list_draft_call_types.assert_not_called()
         assert passport_update.update_passport.call_args.kwargs["resource_scope"][
             "mcp_items"

--- a/src/backend/tests/community/core/mcp/services/test_sync_service.py
+++ b/src/backend/tests/community/core/mcp/services/test_sync_service.py
@@ -21,6 +21,7 @@ from agentclaw.community.core.devices.services.device_context import (
     DeviceContext,
     DeviceNotBoundError,
 )
+from agentclaw.community.core.caller_identity.models import McpCallType
 from agentclaw.community.core.mcp.services.sync_service import MCPSyncService
 
 
@@ -74,6 +75,7 @@ def _make_sync_service(
     passport_update=None,
     mcp_config_service=None,
     bot_repository=None,
+    caller_identity_repository=None,
     mcp_center=None,
     resolver=None,
     dispatcher=None,
@@ -96,6 +98,10 @@ def _make_sync_service(
         None, {}, "PROD", None
     )
     service.bot_repository = bot_repository or MagicMock()
+    if caller_identity_repository is None:
+        caller_identity_repository = MagicMock()
+        caller_identity_repository.list_draft_call_types.return_value = {}
+    service.caller_identity_repository = caller_identity_repository
     if resolver is None or dispatcher is None:
         _r, _d, _ = _make_resolver_and_dispatcher(plugin=plugin)
         service._resolver_provider = (lambda r=(resolver or _r): r)
@@ -108,6 +114,95 @@ def _make_sync_service(
 
 class TestRefreshMcpScope:
     """Test refresh_mcp_scope: scope declaration + passport update."""
+
+    @pytest.mark.asyncio
+    async def test_preserves_explicit_caller_identity_in_passport_scope(self):
+        """A normal MCP refresh must not rewrite a configured caller MCP to owner."""
+        caller_identity_repository = MagicMock()
+        caller_identity_repository.list_draft_call_types.return_value = {
+            "mcp.deepinsight": McpCallType.CALLER,
+        }
+        bot_repository = MagicMock()
+        bot_repository.get_by_id_and_owner.return_value = {
+            "id": 42,
+            "active_engine": "claude_code",
+            "template_type": "generalCC",
+        }
+        passport_update = MagicMock()
+        passport_update.query_passport_clis.return_value = []
+
+        service = _make_sync_service(
+            mcp_provider=_make_mcp_provider(mcps=[
+                {"server_code": "mcp.deepinsight", "name": "DeepInsight"},
+                {"server_code": "mcp.owner", "name": "Owner MCP"},
+            ]),
+            passport_update=passport_update,
+            bot_repository=bot_repository,
+            caller_identity_repository=caller_identity_repository,
+        )
+
+        result = await service.refresh_mcp_scope(
+            user_id="owner-1",
+            entity_id="entity-1",
+            bot_id="bot-1",
+            entity_type="staff",
+            engine_type="claude_code",
+        )
+
+        assert result["success"] is True
+        caller_identity_repository.list_draft_call_types.assert_called_once_with(
+            42,
+            "claude_code",
+        )
+        assert passport_update.update_passport.call_args.kwargs["resource_scope"][
+            "mcp_items"
+        ] == [
+            {
+                "mcp_code": "mcp.deepinsight",
+                "mcp_name": "DeepInsight",
+                "mcp_desc": None,
+                "identity_mode": "caller",
+            },
+            {
+                "mcp_code": "mcp.owner",
+                "mcp_name": "Owner MCP",
+                "mcp_desc": None,
+                "identity_mode": "owner",
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_does_not_update_passport_when_identity_scope_lookup_fails(self):
+        """Do not replace a Passport scope when caller identity cannot be read."""
+        caller_identity_repository = MagicMock()
+        caller_identity_repository.list_draft_call_types.side_effect = RuntimeError(
+            "database unavailable"
+        )
+        bot_repository = MagicMock()
+        bot_repository.get_by_id_and_owner.return_value = {
+            "id": 42,
+            "active_engine": "claude_code",
+        }
+        passport_update = MagicMock()
+
+        service = _make_sync_service(
+            mcp_provider=_make_mcp_provider(mcps=[{"server_code": "mcp.deepinsight"}]),
+            passport_update=passport_update,
+            bot_repository=bot_repository,
+            caller_identity_repository=caller_identity_repository,
+        )
+
+        result = await service.refresh_mcp_scope(
+            user_id="owner-1",
+            entity_id="entity-1",
+            bot_id="bot-1",
+            entity_type="staff",
+            engine_type="claude_code",
+        )
+
+        assert result["success"] is False
+        assert "查询 MCP 调用身份失败" in result["error"]
+        passport_update.update_passport.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_updates_passport_when_scope_ok(self):
@@ -192,6 +287,7 @@ class TestRefreshMcpScope:
         passport_update.query_passport_clis.return_value = []
         bot_repository = MagicMock()
         bot_repository.get_by_id_and_owner.return_value = {
+            "id": 1,
             "bot_name": "AICoding Bot",
             "bot_desc": "desc",
             "active_engine": "aicoding",
@@ -236,6 +332,7 @@ class TestRefreshMcpScope:
         ]
         bot_repository = MagicMock()
         bot_repository.get_by_id_and_owner.return_value = {
+            "id": 1,
             "active_engine": "claude_code",
             "template_type": "personalCoding",
         }
@@ -274,6 +371,7 @@ class TestRefreshMcpScope:
         passport_update.query_passport_clis.return_value = []
         bot_repository = MagicMock()
         bot_repository.get_by_id_and_owner.return_value = {
+            "id": 1,
             "active_engine": "aicoding",
             "template_type": "personalCoding",
         }
@@ -414,6 +512,7 @@ class TestRefreshMcpScope:
         passport_update.update_passport.assert_called_once()
         assert passport_update.update_passport.call_args.kwargs["resource_scope"] == {
             "mcp_codes": [],
+            "mcp_items": [],
             "cli_items": [],
         }
 

--- a/src/backend/tests/community/core/mcp/services/test_sync_service.py
+++ b/src/backend/tests/community/core/mcp/services/test_sync_service.py
@@ -144,7 +144,7 @@ class TestRefreshMcpScope:
         result = await service.refresh_mcp_scope(
             user_id="owner-1",
             entity_id="entity-1",
-            bot_id="bot-1",
+            bot_id="default",
             entity_type="staff",
             engine_type="claude_code",
         )
@@ -154,6 +154,7 @@ class TestRefreshMcpScope:
             42,
             "claude_code",
         )
+        bot_repository.get_by_id_and_owner.assert_called_once_with("default", "owner-1")
         assert passport_update.update_passport.call_args.kwargs["resource_scope"][
             "mcp_items"
         ] == [
@@ -166,6 +167,45 @@ class TestRefreshMcpScope:
             {
                 "mcp_code": "mcp.owner",
                 "mcp_name": "Owner MCP",
+                "mcp_desc": None,
+                "identity_mode": "owner",
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_updates_virtual_default_bot_without_caller_identity_lookup(self):
+        """A default bot without an ac_bots row still refreshes owner MCP scope."""
+        caller_identity_repository = MagicMock()
+        bot_repository = MagicMock()
+        bot_repository.get_by_id_and_owner.return_value = None
+        passport_update = MagicMock()
+        passport_update.query_passport_clis.return_value = []
+
+        service = _make_sync_service(
+            mcp_provider=_make_mcp_provider(mcps=[
+                {"server_code": "mcp.default", "name": "Default MCP"},
+            ]),
+            passport_update=passport_update,
+            bot_repository=bot_repository,
+            caller_identity_repository=caller_identity_repository,
+        )
+
+        result = await service.refresh_mcp_scope(
+            user_id="owner-1",
+            entity_id="entity-1",
+            bot_id="default",
+            entity_type="staff",
+            engine_type="openclaw",
+        )
+
+        assert result["success"] is True
+        caller_identity_repository.list_draft_call_types.assert_not_called()
+        assert passport_update.update_passport.call_args.kwargs["resource_scope"][
+            "mcp_items"
+        ] == [
+            {
+                "mcp_code": "mcp.default",
+                "mcp_name": "Default MCP",
                 "mcp_desc": None,
                 "identity_mode": "owner",
             },

--- a/src/backend/tests/community/core/mcp/services/test_sync_service_uses_resolver.py
+++ b/src/backend/tests/community/core/mcp/services/test_sync_service_uses_resolver.py
@@ -62,6 +62,7 @@ def _make_service(
     plugin=None,
     mcp_provider=None,
     bot_repository=None,
+    caller_identity_repository=None,
     passport_update=None,
 ):
     """Construct MCPSyncService bypassing __init__, wiring resolver + dispatcher."""
@@ -79,6 +80,8 @@ def _make_service(
         None, {}, "PROD", None
     )
     service.bot_repository = bot_repository or MagicMock()
+    service.caller_identity_repository = caller_identity_repository or MagicMock()
+    service.caller_identity_repository.list_draft_call_types.return_value = {}
 
     # New resolver/dispatcher wiring — provider thunks (Task 1 style)
     actual_resolver = resolver or MagicMock()

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_service.py
@@ -989,6 +989,8 @@ class TestAddMcpToSkillSetTeclawEndToEnd:
         svc.mcp_config_service = MagicMock()
         svc.mcp_config_service.build_mcp_sync_payload.return_value = (None, {}, "PROD", None)
         svc.bot_repository = MagicMock()
+        svc.caller_identity_repository = MagicMock()
+        svc.caller_identity_repository.list_draft_call_types.return_value = {}
         # 新链路:resolver + dispatcher (旧 device_sync_supplier 已废弃) — provider thunks
         svc._resolver_provider = lambda: resolver
         svc._device_sync_dispatcher_provider = lambda: dispatcher


### PR DESCRIPTION
## Problem

An ordinary MCP scope refresh only sent MCP codes to Passport. Because Passport
replaces the resource manifest, a later skill-set update could serialize an
explicit Caller MCP as Owner and overwrite the selected caller identity.

## Solution

Build the normal refresh manifest from active MCP entries plus the existing
per-MCP caller identity overrides. Send `mcp_items` with each `identity_mode`
while retaining the `mcp_codes` compatibility projection and existing CLI
scope merge. Resolve a historical `bot_id="default"` by `(bot_id, entity_id)`
before reading its numeric caller-config key; keep `user_id` as the Passport
target. Abort the Passport update if the identity scope cannot be read.

## Validation

- Focused MCP/resolver/Teclaw/architecture tests: 56 passed.
- Full `tests/community`: 14,167 passed, 0 failures/errors.
- Line coverage: 86.96%; changed executable lines: 19/19 (100%).
- Ruff, Python compileall, and diff checks passed.

## Compatibility and risk

No HTTP API, schema, caller-token exchange, device-sync behavior, or CLI merge
behavior changes. The source PR must be merged and synchronized to the OCB
submodule mirror before the separate gitlink-only OCB PR is created.
