### PR TITLE
fix(devices): break BotPublicService -> DeviceContextResolver DI cycle

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -8,7 +8,7 @@ import time
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
-from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 from agentclaw.community.plugin_api.approval_workflow import ApprovalWorkflowPlugin
 from agentclaw.community.core.repository.protocols.bot import BotRepository
@@ -133,7 +133,7 @@ class BotPublicService:
         auth_relationship_plugin: AuthRelationshipPlugin,
         publish_approval_plugin: BotPublishApprovalPlugin,
         skill_set_service_factory: "SkillSetServiceFactory",
-        device_context_resolver: DeviceContextResolver,
+        device_context_resolver_factory: "Callable[[], DeviceContextResolver]",
         device_sync_dispatcher: "DeviceSyncDispatcher",
         catalog_metadata_service: BotCatalogMetadataServiceProtocol,
     ) -> None:
@@ -148,7 +148,10 @@ class BotPublicService:
         self._skill_set_service_factory = skill_set_service_factory
         # Task 2.1: resolver + dispatcher 替代 device_sync_supplier 在
         # sync_bot_config_to_device 路径上的角色。Task 6 收口后 supplier 已删。
-        self._resolver = device_context_resolver
+        # Lazy: DeviceContextResolver's conn-info builders transitively reach
+        # DeviceService, which (corp) depends on BotPublicService itself —
+        # eager injection here would cycle. Resolved at call time instead.
+        self._resolver_factory = device_context_resolver_factory
         self._device_sync_dispatcher = device_sync_dispatcher
         self._catalog_metadata_service = catalog_metadata_service
         self._sync_lock = threading.Lock()
@@ -1029,7 +1032,7 @@ class BotPublicService:
             UnknownProviderError,
         )
         try:
-            ctx = self._resolver.resolve_for_bot(bot_id, user_id)
+            ctx = self._resolver_factory().resolve_for_bot(bot_id, user_id)
         except (DeviceNotBoundError, UnknownProviderError) as e:
             logger.warning(
                 "[bot_service.sync_bot_config_to_device] bot=%s no syncable device: %s",

--- a/src/backend/src/agentclaw/community/di/modules/bot_public_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_public_module.py
@@ -19,9 +19,9 @@ through the injector.
 """
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Callable
 
-from injector import Binder, Module, inject, provider, singleton
+from injector import Binder, Injector, Module, inject, provider, singleton
 
 from agentclaw.community.api.bot_discover_service import BotDiscoverServiceProtocol
 from agentclaw.community.api.bot_public_service import BotPublicServiceProtocol
@@ -102,6 +102,18 @@ class BotPublicModule(Module):
 
     @singleton
     @provider
+    @inject
+    def device_context_resolver_factory(
+        self, injector: Injector
+    ) -> Callable[[], DeviceContextResolver]:
+        # Lazy (cycle-safe): DeviceContextResolver's conn-info builders reach
+        # DeviceService, which in some profiles depends on BotPublicService
+        # itself (BotPublicService -> DeviceContextResolver -> ... ->
+        # DeviceService -> BotPublicService). Eager injection would cycle.
+        return lambda: injector.get(DeviceContextResolver)
+
+    @singleton
+    @provider
     def bot_public_service(
         self,
         bot_friend_repo: BotFriendRepositoryProtocol,
@@ -113,7 +125,7 @@ class BotPublicModule(Module):
         auth_relationship_plugin: AuthRelationshipPlugin,
         publish_approval_plugin: BotPublishApprovalPlugin,
         skill_set_service_factory: SkillSetServiceFactory,
-        device_context_resolver: DeviceContextResolver,
+        device_context_resolver_factory: Callable[[], DeviceContextResolver],
         device_sync_dispatcher: DeviceSyncDispatcher,
         catalog_metadata_service: BotCatalogMetadataServiceProtocol,
     ) -> BotPublicService:
@@ -131,7 +143,7 @@ class BotPublicModule(Module):
             auth_relationship_plugin=auth_relationship_plugin,
             publish_approval_plugin=publish_approval_plugin,
             skill_set_service_factory=skill_set_service_factory,
-            device_context_resolver=device_context_resolver,
+            device_context_resolver_factory=device_context_resolver_factory,
             device_sync_dispatcher=device_sync_dispatcher,
             catalog_metadata_service=catalog_metadata_service,
         )

--- a/src/backend/tests/community/core/bot_public/services/test_sync_bot_config_uses_resolver.py
+++ b/src/backend/tests/community/core/bot_public/services/test_sync_bot_config_uses_resolver.py
@@ -35,6 +35,7 @@ def _make_service(
 
     Task 6 收口后 ``device_sync_supplier`` 入参已删除。
     """
+    resolved = resolver or MagicMock()
     return BotPublicService(
         bot_friend_repo=MagicMock(),
         bot_repository=MagicMock(),
@@ -45,7 +46,7 @@ def _make_service(
         auth_relationship_plugin=MagicMock(),
         publish_approval_plugin=MagicMock(),
         skill_set_service_factory=MagicMock(),
-        device_context_resolver=resolver or MagicMock(),
+        device_context_resolver_factory=lambda: resolved,
         device_sync_dispatcher=device_sync_dispatcher or MagicMock(),
         catalog_metadata_service=MagicMock(),
     )

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -40,6 +40,7 @@ def _make_service(
     device_sync_dispatcher=None,
     catalog_metadata_service=None,
 ):
+    resolver = device_context_resolver or MagicMock()
     return BotPublicService(
         bot_friend_repo=bot_friend_repo or MagicMock(),
         bot_repository=bot_repository or MagicMock(),
@@ -50,7 +51,7 @@ def _make_service(
         auth_relationship_plugin=auth_relationship_plugin or MagicMock(),
         publish_approval_plugin=publish_approval_plugin or MagicMock(),
         skill_set_service_factory=skill_set_service_factory or MagicMock(),
-        device_context_resolver=device_context_resolver or MagicMock(),
+        device_context_resolver_factory=lambda: resolver,
         device_sync_dispatcher=device_sync_dispatcher or MagicMock(),
         catalog_metadata_service=catalog_metadata_service or MagicMock(),
     )


### PR DESCRIPTION
## Problem

`SessionResourceTaskLifecycle.bootstrap` (`session_resources/materialization.py`) resolves `SessionResourceMaterializeHandler`, which eagerly injects `DeviceContextResolver`. `DeviceContextResolver`'s `ArcaConnInfoBuilder` dependency transitively resolves a `DeviceService` binding, and in profiles where the `device_service` provider itself depends on `BotPublicService` (e.g. the corp ARCA-aware infrastructure column), the graph closes a cycle back through `bot_public_module.bot_public_service`, which injected `DeviceContextResolver` eagerly:

```
SessionResourceMaterializeHandler -> DeviceContextResolver -> ArcaConnInfoBuilder
  -> DeviceService -> BotPublicService -> DeviceContextResolver (cycle)
```

`injector` raises `CircularDependency` during bootstrap, and this crashes on startup wherever that profile's `device_service` provider closes the loop.

## Solution

`BotPublicService` only reaches `DeviceContextResolver` at call time, inside `sync_bot_config_to_device` (`ctx = self._resolver.resolve_for_bot(...)`) — never during construction. So the eager dependency is unnecessary: `bot_public_module.py` now binds a `Callable[[], DeviceContextResolver]` lazy factory (`injector.get(DeviceContextResolver)` deferred to call time) instead of the resolver itself, and `BotPublicService` stores/calls that factory instead of a resolved instance. This mirrors the existing `DataInitService <-> DeviceService` cycle-break pattern already used in `bot_management_module.py` (`data_init_service_factory`).

No corp-side code lives in this repo, so this fix addresses the community-side edge that any profile's DI graph shares; it removes the shared circular edge regardless of which `device_service` provider a given profile installs.

## Validation

- `pytest tests/community/core/bot_public/ tests/community/core/devices/ tests/community/core/session_resources/ tests/community/di/` — 997 passed.
- Updated the two test call sites (`test_bot_public_service.py`, `test_sync_bot_config_uses_resolver.py`) that constructed `BotPublicService` directly to pass `device_context_resolver_factory` instead of `device_context_resolver`.
- Could not reproduce the corp-side `CircularDependency` traceback directly (the corp `device_service` provider that closes the cycle isn't in this repo); validated instead that the community DI container still wires and resolves `BotPublicService`/`DeviceContextResolver`/`SessionResourceMaterializeHandler` cleanly after the change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CNahvHzUo9T9b5fFoM6s1i)_