### PR TITLE
fix(gateway): fail CI on code format drift

### DIFF
--- a/src/gateway/scripts/ci_check_format.sh
+++ b/src/gateway/scripts/ci_check_format.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check-only format/lint gate for the gateway module.
+#
+# Runs `ruff check .` and `ruff format --check .` (non-fixing) so that format
+# and lint drift fail the gate with a non-zero exit. Unlike `check-basic`
+# (which runs ruff in `--fix` mode for local developer convenience), this gate
+# never mutates files.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+gateway_dir="$(cd "$script_dir/.." && pwd)"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "gateway format gate failed: uv not found" >&2
+  exit 127
+fi
+
+cd "$gateway_dir"
+
+echo "[CHECK] check-format-ci: ruff check . && ruff format --check ."
+
+uv run ruff check .
+uv run ruff format --check .
+
+echo "gateway format gate passed"

--- a/src/gateway/scripts/lib/checks.sh
+++ b/src/gateway/scripts/lib/checks.sh
@@ -18,3 +18,21 @@ run_check_basic() {
     cd "$_origin"
     log_info "check-basic passed"
 }
+
+run_check_format_ci() {
+    local _origin
+    _origin="$(pwd)"
+    cd "$GATEWAY_DIR" || return 1
+
+    log_stage
+    echo "[CHECK] check-format-ci: ruff check + ruff format --check (non-fixing)"
+
+    log_sub "Lint check (ruff check ...)..."
+    _run uv run ruff check . || { cd "$_origin"; return 1; }
+
+    log_sub "Format check (ruff format --check ...)..."
+    _run uv run ruff format --check . || { cd "$_origin"; return 1; }
+
+    cd "$_origin"
+    log_info "check-format-ci passed"
+}

--- a/src/gateway/scripts/lib/pipeline.sh
+++ b/src/gateway/scripts/lib/pipeline.sh
@@ -12,6 +12,11 @@ run_ci_pipeline() {
     echo "  GATEWAY CI Pipeline"
     echo "==========================================="
 
+    if ! run_check_format_ci; then
+        log_error "check-format-ci failed — aborting"
+        return 1
+    fi
+
     if ! run_check_basic; then
         log_error "check-basic failed — aborting"
         return 1

--- a/src/gateway/src/gateway/community/plugins/authn/dev_cookie/_strategy.py
+++ b/src/gateway/src/gateway/community/plugins/authn/dev_cookie/_strategy.py
@@ -11,7 +11,12 @@ import os
 from urllib.parse import unquote
 
 from gateway.community.spi.auth import AuthenticatedUser
-from gateway.community.spi.authn import CredentialBundle, Principal, PrincipalType, UserPrincipal
+from gateway.community.spi.authn import (
+    CredentialBundle,
+    Principal,
+    PrincipalType,
+    UserPrincipal,
+)
 
 
 class DevCookieUserStrategy:
@@ -45,7 +50,9 @@ class DevCookieUserStrategy:
         if not staff_id:
             return None
 
-        display_name = unquote(creds.cookies.get(self._nick_name_cookie, "")).strip() or staff_id
+        display_name = (
+            unquote(creds.cookies.get(self._nick_name_cookie, "")).strip() or staff_id
+        )
         subject = AuthenticatedUser(
             id=staff_id,
             username=staff_id,

--- a/src/gateway/tests/unit/core/authn/test_route_security.py
+++ b/src/gateway/tests/unit/core/authn/test_route_security.py
@@ -115,9 +115,7 @@ def test_shipped_config_still_requires_a_user_where_a_human_is_required(
         ("POST", "/openapi/v1/bots/bot-123/iam-token"),
     ],
 )
-def test_iam_operations_do_not_resolve_an_app_identity(
-    method: str, path: str
-) -> None:
+def test_iam_operations_do_not_resolve_an_app_identity(method: str, path: str) -> None:
     raw = yaml.safe_load(_CONFIG.read_text())
     req = RouteSecurity.from_table(raw["user_config"]["route_security"]).resolve(
         method, path

--- a/src/gateway/tests/unit/core/forwarding/test_domain_map.py
+++ b/src/gateway/tests/unit/core/forwarding/test_domain_map.py
@@ -121,9 +121,12 @@ def test_shipped_config_routes_collaboration_verbatim_to_bcs() -> None:
     assert friend_connections is not None
     assert friend_connections.server.name == "bcs"
     assert friend_connections.rewrite is None
-    assert friend_connections.upstream_path(
-        "/openapi/v1/collaboration/friend-connections/requests"
-    ) == "/openapi/v1/collaboration/friend-connections/requests"
+    assert (
+        friend_connections.upstream_path(
+            "/openapi/v1/collaboration/friend-connections/requests"
+        )
+        == "/openapi/v1/collaboration/friend-connections/requests"
+    )
 
     security = RouteSecurity.from_table(raw["user_config"]["route_security"])
     requirement = security.resolve("GET", "/openapi/v1/collaboration/groups/group-1")

--- a/src/gateway/tests/unit/core/forwarding/test_served_openapi.py
+++ b/src/gateway/tests/unit/core/forwarding/test_served_openapi.py
@@ -80,9 +80,9 @@ def test_backend_artifact_serves_spaces_through_its_own_domain() -> None:
 
     space_skills_path = "/openapi/v1/bots/spaces/{space_id}/skills"
     assert space_skills_path in document["paths"]
-    assert document["paths"][space_skills_path]["get"][
-        "x-avernet-security"
-    ] == {"user": "required"}
+    assert document["paths"][space_skills_path]["get"]["x-avernet-security"] == {
+        "user": "required"
+    }
 
 
 def test_every_served_operation_carries_security() -> None:
@@ -345,10 +345,7 @@ def test_bcsfuse_paths_served_with_user_security() -> None:
 
 
 _BOTS_ARTIFACT = (
-    Path(__file__).resolve().parents[4]
-    / "configs"
-    / "schemas"
-    / "bots.openapi.json"
+    Path(__file__).resolve().parents[4] / "configs" / "schemas" / "bots.openapi.json"
 )
 
 

--- a/src/gateway/tests/unit/scripts/test_dump_and_publish_script.py
+++ b/src/gateway/tests/unit/scripts/test_dump_and_publish_script.py
@@ -52,10 +52,7 @@ def test_bcn_dump_uses_the_gateway_managed_python_environment(tmp_path: Path) ->
         "post"
         in document["paths"]["/openapi/v1/collaboration/friend-connections/requests"]
     )
-    assert (
-        "delete"
-        in document["paths"]["/openapi/v1/collaboration/friend-connections"]
-    )
+    assert "delete" in document["paths"]["/openapi/v1/collaboration/friend-connections"]
     collection = document["paths"][
         "/openapi/v1/collaboration/sessions/{session_id}/collect"
     ]
@@ -76,9 +73,7 @@ def test_bcn_dump_uses_the_gateway_managed_python_environment(tmp_path: Path) ->
     assert (
         "post" in internal["paths"]["/api/v1/collaboration/sessions/{session_id}/files"]
     )
-    assert (
-        "post" in internal["paths"]["/api/v1/collaboration/definitions/validate"]
-    )
+    assert "post" in internal["paths"]["/api/v1/collaboration/definitions/validate"]
     assert [tag["name"] for tag in document["tags"]] == [
         "Collaboration / Bots",
         "Collaboration / Friendships",

--- a/src/gateway/tests/unit/scripts/test_gate_and_publish.py
+++ b/src/gateway/tests/unit/scripts/test_gate_and_publish.py
@@ -130,9 +130,7 @@ def test_checked_in_bcn_artifacts_split_public_and_internal_operations() -> None
     )
     assert (
         "delete"
-        in public_document["paths"][
-            "/openapi/v1/collaboration/friend-connections"
-        ]
+        in public_document["paths"]["/openapi/v1/collaboration/friend-connections"]
     )
     assert (
         "/openapi/v1/collaboration/sessions/{session_id}/files/{file_id}/content"


### PR DESCRIPTION
## Problem

The gateway CI never blocked unformatted or lint-dirty code. Its check stage ran `ruff` in `--fix` mode (silently rewriting files), and the only check-only enforcement (`tests/architecture/test_ruff_lint_rules.py`) was never wired into the pipeline. Additionally, `scripts/ci/pre_push.sh` skipped gateway changes in lint-only mode, so pushes weren't blocked either.

## Solution

- Added `run_check_format_ci` (`src/gateway/scripts/lib/checks.sh`): a non-fixing `ruff check .` + `ruff format --check .` gate that fails on any violation.
- Wired it as a required first stage of `run_ci_pipeline` (`src/gateway/scripts/lib/pipeline.sh`).
- Added `src/gateway/scripts/ci_check_format.sh` as a standalone hook entrypoint.
- Updated `scripts/ci/pre_push.sh` so the gateway format/lint gate runs via `run_required` in the default lint-only mode.
- Reformatted 6 pre-existing drifted files so the gate passes.

## Validation

- `./scripts/ci_check_format.sh` returns exit 1 with an introduced format violation and 0 after revert.
- `run_ci_pipeline` aborts with "check-format-ci failed — aborting" on a violation.
- `ruff format --check .` and `ruff check .` now pass on the gateway tree.
- Bash syntax check (`bash -n`) passed for all changed scripts.

## Related issues

- Fixes https://github.com/inclusionAI/Avernet/issues/1422