### PR TITLE
feat(backend): restore teclaw's default MCP roster

### DIFF
--- a/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
@@ -46,12 +46,23 @@ _DEFAULT_MCP_SERVERS_BY_ENGINE: Dict[str, List[dict]] = {
         {"server_code": "hitl"},
     ],
     "moltis": [],
-    # Intentionally empty: teclaw bots start with no default MCP servers and
-    # get every MCP from their owner's own skill-set configuration. The key
-    # stays declared (like ``moltis``) so teclaw keeps resolving its own
-    # bucket — dropping it would make teclaw indistinguishable from an
-    # unknown engine and hide a future bucket-aliasing regression.
-    "teclaw": [],
+    "teclaw": [
+        {"server_code": "mcp.ant.lwawchat.cogmessagemcp", "name": "蚂蚁钉协作群消息相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingreportmcpserver", "name": "蚂蚁钉日志服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdinggroupmcpserver", "name": "蚂蚁钉群服务"},
+        {"server_code": "mcp.ant.lwawchat.cogdocumentmcp", "name": "蚂蚁钉协作群文档相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingeventmcpserver", "name": "蚂蚁钉日程相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingrobotmcpserver", "name": "蚂蚁钉机器人相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingmessagemcpserver", "name": "蚂蚁钉消息相关-MCP服务"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingtodomcpserver", "name": "蚂蚁钉待办服务"},
+        {"server_code": "mcp.ant.faas.skylarkmcpserver.skylarkmcpserver", "name": "语雀 MCP"},
+        {"server_code": "mcp.ant.arkai.dimamcpserver", "name": "Dima-MCP服务"},
+        {"server_code": "mcp.ant.homistudio.recordmcp", "name": "会中会话记录查询服务"},
+        {"server_code": "mcp.ant.rpc.dcanttouch.adminservice", "name": "行政小宝MCP服务"},
+        # Local/stdio; resolved through LocalMCPRegistry, not MCP Center. Kept
+        # last to match the other engines' lists.
+        {"server_code": "hitl", "name": "HITL"},
+    ],
     "claude_code": [
         {"server_code": "mcp.ant.antprocessai.anttaskmcp", "name": "任务中心MCP", "description": "任务中心待办任务，已办任务等相关任务查询MCP"},
         {"server_code": "mcp.ant.arkai.dimamcpserver", "name": "Dima MCP", "description": "Dima MCP"},

--- a/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
+++ b/src/backend/tests/community/core/mcp/test_defaults_per_engine.py
@@ -545,3 +545,51 @@ def test_template_config_cli_presets_are_aicoding_specific():
         "openclaw",
         ext_info={"template_config": template_config},
     ) == []
+
+
+# The teclaw roster, spelled out independently of the source list. The publish
+# suite's ``_install_default_mcp_catalog`` derives its mock *from*
+# ``_DEFAULT_MCP_SERVERS_BY_ENGINE["teclaw"]``, so it proves only that a build
+# resolves whatever the roster happens to hold — a typo'd or duplicated
+# ``server_code`` would sail straight through it. This second, independent copy
+# is what makes such an edit fail loudly.
+TECLAW_DEFAULT_MCP_CODES = (
+    "mcp.ant.lwawchat.cogmessagemcp",
+    "mcp.ant.antdingopenapi.antdingreportmcpserver",
+    "mcp.ant.antdingopenapi.antdinggroupmcpserver",
+    "mcp.ant.lwawchat.cogdocumentmcp",
+    "mcp.ant.antdingopenapi.antdingeventmcpserver",
+    "mcp.ant.antdingopenapi.antdingrobotmcpserver",
+    "mcp.ant.antdingopenapi.antdingmessagemcpserver",
+    "mcp.ant.antdingopenapi.antdingtodomcpserver",
+    "mcp.ant.faas.skylarkmcpserver.skylarkmcpserver",
+    "mcp.ant.arkai.dimamcpserver",
+    "mcp.ant.homistudio.recordmcp",
+    "mcp.ant.rpc.dcanttouch.adminservice",
+    "hitl",
+)
+
+
+def test_teclaw_default_roster_shape():
+    """teclaw's roster: exact codes, exact order, no dupes, local entry last."""
+    codes = [s["server_code"] for s in get_default_mcp_servers("teclaw")]
+    assert codes == list(TECLAW_DEFAULT_MCP_CODES)
+    assert len(codes) == len(set(codes)), "duplicate server_code in the teclaw roster"
+    # ``hitl`` is the only local/stdio entry and stays last, matching how the
+    # other engines list it. The artifact path resolves its launch instruction
+    # through LocalMCPRegistry, not MCP Center — see ``_stdio_launch_for``.
+    assert codes[-1] == "hitl"
+
+
+def test_teclaw_roster_is_its_own_bucket():
+    """teclaw resolves its own defaults rather than inheriting another engine's.
+
+    ``_resolve_default_mcp_engine_bucket`` normalizes case and delegates bucket
+    overrides to the engine registry; an alias onto ``openclaw`` would silently
+    swap the whole roster, so pin both the normalization and the distinctness.
+    """
+    assert [s["server_code"] for s in get_default_mcp_servers("TECLAW")] == list(
+        TECLAW_DEFAULT_MCP_CODES
+    )
+    openclaw_codes = {s["server_code"] for s in get_default_mcp_servers("openclaw")}
+    assert "mcp.ant.lwawchat.cogmessagemcp" not in openclaw_codes

--- a/src/backend/tests/community/endpoints/test_service_bot_publish_flow.py
+++ b/src/backend/tests/community/endpoints/test_service_bot_publish_flow.py
@@ -228,10 +228,7 @@ def _install_default_mcp_catalog(world) -> None:
     to what these cases assert.
 
     Derived from ``_DEFAULT_MCP_SERVERS_BY_ENGINE`` rather than a hardcoded
-    list: adding a server to the roster must not silently skip it here. teclaw's
-    roster is empty today, so the override currently answers ``None`` for every
-    code — same as ``NoopMCPCenterPlugin`` — and the seam is kept so a roster
-    that regains entries stays resolvable without touching this suite.
+    list: adding a server to the roster must not silently skip it here.
     Servers the local-MCP registry owns (``hitl``) are left unresolved on
     purpose — they are stdio, and the collector resolves their launch
     instruction from that registry, so answering REMOTE here would misclassify


### PR DESCRIPTION
## Problem

`_DEFAULT_MCP_SERVERS_BY_ENGINE["teclaw"]` was emptied in #1307, so a new teclaw bot boots with no MCP at all and every owner has to add the twelve MCP Center servers plus the local `hitl` entry by hand before the bot can do the collaboration work teclaw exists for. The roster is wanted back as the engine's default.

## Solution

Restore the roster literal removed by #1307 — the twelve remote MCP Center servers in their original order, with the local/stdio `hitl` entry kept last to match how the other engines list it. This is a straight revert of that commit; no other engine bucket, resolver, or contract is touched.

```
mcp.ant.lwawchat.cogmessagemcp                     蚂蚁钉协作群消息相关-MCP服务
mcp.ant.antdingopenapi.antdingreportmcpserver      蚂蚁钉日志服务
mcp.ant.antdingopenapi.antdinggroupmcpserver       蚂蚁钉群服务
mcp.ant.lwawchat.cogdocumentmcp                    蚂蚁钉协作群文档相关-MCP服务
mcp.ant.antdingopenapi.antdingeventmcpserver       蚂蚁钉日程相关-MCP服务
mcp.ant.antdingopenapi.antdingrobotmcpserver       蚂蚁钉机器人相关-MCP服务
mcp.ant.antdingopenapi.antdingmessagemcpserver     蚂蚁钉消息相关-MCP服务
mcp.ant.antdingopenapi.antdingtodomcpserver        蚂蚁钉待办服务
mcp.ant.faas.skylarkmcpserver.skylarkmcpserver     语雀 MCP
mcp.ant.arkai.dimamcpserver                        Dima-MCP服务
mcp.ant.homistudio.recordmcp                       会中会话记录查询服务
mcp.ant.rpc.dcanttouch.adminservice                行政小宝MCP服务
hitl                                               HITL  (local/stdio, last)
```

The guard tests come back with it. #1307 replaced them with emptiness assertions, and the dev merge-back in #1396 then dropped those, leaving the teclaw bucket with no coverage at all:

- `TECLAW_DEFAULT_MCP_CODES` — the roster spelled out independently of the source list, so a typo'd or duplicated `server_code` fails loudly rather than sailing through the publish suite's derived mock.
- `test_teclaw_default_roster_shape` — exact codes, exact order, no dupes, `hitl` last.
- `test_teclaw_roster_is_its_own_bucket` — case normalization plus non-inheritance from openclaw's bucket.

`_install_default_mcp_catalog` in the publish suite derives its mock from the roster and needs no change; its docstring loses the "empty today" note.

## Validation

Run in `src/backend` with `uv run pytest`:

- `tests/community/core/mcp/` — **199 passed**.
- `tests/community/endpoints/` — **1056 passed**, including the 55 publish-flow cases the roster feeds through `_install_default_mcp_catalog`.
- `scripts/ci/python_sast_local.sh src/backend` — no findings in the three changed files; the pre-existing repo-wide findings are untouched.

Not run: the full backend suite, changed-line coverage, and the Singlebox acceptance/E2E gate. The sandbox cannot reach this repo's configured package index (`mirrors.aliyun.com`), so the environment was resolved against pypi.org for the runs above; `uv.lock` was restored and is not part of this diff. The heavier gates are left to CI.

## Compatibility and risk

Behavior change, no schema or contract change. New teclaw bots get these thirteen MCPs in their default skill set again; existing bots that already persisted a skill set are unaffected. The teclaw artifact path composes the roster as a unit, so a build fails if any single entry cannot be resolved — the same exposure the roster carried before #1307. Rollback is emptying the `teclaw` bucket again.

## Related issues

Reverts #1307.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWUbRX7zSQKPuiyaSgfRK7)_