### PR TITLE
feat(backend): register OpenClaw personal bots via BCN plugin

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bcn_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bcn_service.py
@@ -3,10 +3,10 @@
 负责与 BCN (Bot Coordination Network) 服务交互，包括：
 - Bot 入网注册 (onboard, 上行)
 - Bot 信息同步 (name, summary)
-- claude_code engine 启动时的 Provider Bot 注册 (下行, 见 register_provider_bot)
+- Bot create/start 时的 Provider Bot 注册 (下行, 见 register_provider_bot)
 """
 
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Literal, Mapping, Optional
 
 import httpx
 
@@ -230,8 +230,9 @@ class BcnService:
         owner_workno: str,
         name: str,
         summary: str,
+        connection_mode: Literal["plugin"] | None = None,
     ) -> Dict[str, Any]:
-        """claude_code engine start 时把 bot 注册为 Provider 的 bot (下行链路)。
+        """将 bot 注册为 Provider bot (下行链路)。
 
         语雀: doc 548864073, POST /providers/{provider_id}/bots
 
@@ -240,6 +241,8 @@ class BcnService:
             owner_workno: bot 所有者工号 (例如 "100000")
             name: bot 显示名
             summary: bot 简介 (空字符串也可)
+            connection_mode: 仅 OpenClaw personal 使用 ``plugin``；未传时由 BCN
+                按既有 ``gateway`` 默认处理。
 
         Returns:
             BCN 返回的 dict, 关键字段:
@@ -262,7 +265,8 @@ class BcnService:
         if not provider_cfg:
             logger.info(
                 f"[BcnService.register_provider_bot] env={env} skipped "
-                f"(no provider credentials), provider_bot_ref={provider_bot_ref}"
+                f"(no provider credentials), provider_bot_ref={provider_bot_ref} "
+                f"connection_mode={connection_mode}"
             )
             return {
                 "bot_uuid": "",
@@ -282,6 +286,8 @@ class BcnService:
             "owners": owners,
             "provider_bot_ref": provider_bot_ref,
         }
+        if connection_mode is not None:
+            payload["connection_mode"] = connection_mode
         path = f"/providers/{provider_id}/bots"
         headers = {
             "Content-Type": "application/json",
@@ -289,8 +295,7 @@ class BcnService:
         }
         logger.info(
             f"[BcnService.register_provider_bot] POST {path} "
-            f"provider_bot_ref={provider_bot_ref} name={name} "
-            f"summary_len={len(summary or '')}"
+            f"provider_bot_ref={provider_bot_ref} connection_mode={connection_mode}"
         )
 
         try:
@@ -302,7 +307,8 @@ class BcnService:
             if response.status_code == 409:
                 logger.warning(
                     f"[BcnService.register_provider_bot] 409 idempotent: "
-                    f"provider_bot_ref={provider_bot_ref} already registered"
+                    f"provider_bot_ref={provider_bot_ref} connection_mode={connection_mode} "
+                    f"already registered"
                 )
                 body: Dict[str, Any] = {}
                 try:
@@ -319,7 +325,7 @@ class BcnService:
             logger.info(
                 f"[BcnService.register_provider_bot] OK "
                 f"bot_uuid={response_data.get('bot_uuid')} "
-                f"provider_bot_ref={provider_bot_ref}"
+                f"provider_bot_ref={provider_bot_ref} connection_mode={connection_mode}"
             )
             return response_data
 
@@ -328,22 +334,23 @@ class BcnService:
             status = e.response.status_code if e.response else "N/A"
             logger.error(
                 f"[BcnService.register_provider_bot] HTTP error: "
-                f"status={status} body={error_body} "
-                f"provider_bot_ref={provider_bot_ref}"
+                f"status={status} "
+                f"provider_bot_ref={provider_bot_ref} connection_mode={connection_mode}"
             )
             raise BcnServiceError(
                 f"BCN register_provider_bot HTTP error: {status} - {error_body}"
             )
         except httpx.TimeoutException as e:
             logger.error(
-                f"[BcnService.register_provider_bot] Timeout: {e} "
-                f"provider_bot_ref={provider_bot_ref}"
+                f"[BcnService.register_provider_bot] Timeout: "
+                f"provider_bot_ref={provider_bot_ref} connection_mode={connection_mode}"
             )
             raise BcnServiceError(f"BCN register_provider_bot timeout: {e}")
         except Exception as e:
             logger.error(
-                f"[BcnService.register_provider_bot] Unexpected error: {e} "
-                f"provider_bot_ref={provider_bot_ref}"
+                f"[BcnService.register_provider_bot] Unexpected error: "
+                f"error_type={type(e).__name__} provider_bot_ref={provider_bot_ref} "
+                f"connection_mode={connection_mode}"
             )
             raise BcnServiceError(f"BCN register_provider_bot error: {e}")
 

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -14,7 +14,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Optional, Dict, Any, List, Tuple, TYPE_CHECKING
+from typing import Callable, Optional, Dict, Any, List, Literal, Tuple, TYPE_CHECKING
 
 from agentclaw.community.core.bot_management.capabilities import (
     can_join_bcn_as_provider,
@@ -1468,6 +1468,48 @@ class BotService:
                 )
                 return bot_record
 
+            # Bot 已落库并完成名称/简介解析后，在设备分配前注册 BCN Provider。
+            # 这样创建路径与 start_bot 对齐；BCN 注册为 best-effort，不影响后续分配。
+            should_register_bcn = self._should_register_bcn_provider(
+                active_engine=resolved_active_engine,
+                bot_type=resolved_bot_type,
+                template_type=template_type,
+                template_config=template_config,
+            )
+            connection_mode = self._resolve_bcn_provider_connection_mode(
+                active_engine=resolved_active_engine,
+                bot_type=resolved_bot_type,
+            )
+            if should_register_bcn:
+                logger.info(
+                    f"[bot_service.create_bot] register bot to BCN as provider: "
+                    f"bot_id={bot_id} active_engine={resolved_active_engine} "
+                    f"bot_type={resolved_bot_type} template_type={template_type} "
+                    f"connection_mode={connection_mode}"
+                )
+                try:
+                    self._register_bot_to_bcn_as_provider(
+                        bot_id=bot_id,
+                        user_id=user_id,
+                        owner_workno=user_id,
+                        bot_name=resolved_bot_name or bot_id,
+                        bot_summary=bot_desc or "",
+                        connection_mode=connection_mode,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"[bot_service.create_bot] BCN provider registration failed for bot {bot_id}, "
+                        f"connection_mode={connection_mode}, "
+                        f"error_type={type(e).__name__}, will retry on next start"
+                    )
+            else:
+                logger.info(
+                    f"[bot_service.create_bot] skip BCN provider registration: "
+                    f"bot_id={bot_id} active_engine={resolved_active_engine} "
+                    f"bot_type={resolved_bot_type} template_type={template_type} "
+                    f"connection_mode={connection_mode}"
+                )
+
             # Step 2: 设备分配（错误立即透出给前端）。teclaw bot 走 BaaS 即时备容器
             # (create + approve)，不经 DeviceService.apply_device()；其余引擎走 apply_device。
             # 两条路径汇合到下方共享尾部（更新 bot_record + 注册 BCN + service 发布单创建）。
@@ -1585,46 +1627,6 @@ class BotService:
                 bot_record["device_id"] = device_id
                 bot_record["status"] = final_status
                 bot_record["engine_types"] = resolved_engine_types
-
-                # 创建时注册 BCN Provider（与 start_bot 条件一致）
-                # 触发条件:
-                #   - active_engine == "claude_code" 且 template_type == "normalCC"
-                #   - active_engine == "claude_code" 且 template_type == "personalCoding"
-                #   - active_engine == "aicoding" 且 template_type == "personalCoding"
-                #   - active_engine == "teclaw" (所有 bot_type)
-                #   - active_engine == "openclaw" 且 bot_type == "service"
-                # 排查日志关键字: [bot_service.create_bot] register bot to BCN as provider
-                should_register_bcn = self._should_register_bcn_provider(
-                    active_engine=resolved_active_engine,
-                    bot_type=resolved_bot_type,
-                    template_type=template_type,
-                    template_config=template_config,
-                )
-                if should_register_bcn:
-                    logger.info(
-                        f"[bot_service.create_bot] register bot to BCN as provider: "
-                        f"bot_id={bot_id} active_engine={resolved_active_engine} "
-                        f"bot_type={resolved_bot_type} template_type={template_type}"
-                    )
-                    try:
-                        self._register_bot_to_bcn_as_provider(
-                            bot_id=bot_id,
-                            user_id=user_id,
-                            owner_workno=user_id,
-                            bot_name=resolved_bot_name or bot_id,
-                            bot_summary=bot_desc or "",
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            f"[bot_service.create_bot] BCN provider registration failed for bot {bot_id}, "
-                            f"will retry on next start: {e}"
-                        )
-                else:
-                    logger.info(
-                        f"[bot_service.create_bot] skip BCN provider registration: "
-                        f"bot_id={bot_id} active_engine={resolved_active_engine} "
-                        f"bot_type={resolved_bot_type} template_type={template_type}"
-                    )
 
                 # 如果是服务型 bot，创建发布单
                 if resolved_bot_type == "service":
@@ -3136,8 +3138,18 @@ class BotService:
                 and template_type == "normalCC"
             )
             or active_engine == "teclaw"
-            or (active_engine == "openclaw" and bot_type == "service")
+            or (active_engine == "openclaw" and bot_type in ("service", "personal"))
         )
+
+    @staticmethod
+    def _resolve_bcn_provider_connection_mode(
+        active_engine: Optional[str],
+        bot_type: Optional[str],
+    ) -> Optional[Literal["plugin"]]:
+        """Return the BCN connection mode selected by the Bot lifecycle."""
+        if active_engine == "openclaw" and bot_type == "personal":
+            return "plugin"
+        return None
 
     def _register_bot_to_bcn_as_provider(
         self,
@@ -3146,6 +3158,7 @@ class BotService:
         owner_workno: str,
         bot_name: str,
         bot_summary: str,
+        connection_mode: Optional[Literal["plugin"]] = None,
     ) -> None:
         """Bot 创建/启动时把自己注册到 BCN 为 Provider (下行链路).
 
@@ -3154,7 +3167,7 @@ class BotService:
           - active_engine == "claude_code" 且 template_type == "personalCoding"
           - active_engine == "aicoding" 且 template_type == "personalCoding"
           - active_engine == "teclaw"
-          - active_engine == "openclaw" 且 bot_type == "service"
+          - active_engine == "openclaw" 且 bot_type 为 service 或 personal
 
         受 DRM 开关 ``ClaudeCodeBcnRegister.enabled`` 控制 (默认关),
         失败仅记 warning, 不阻塞 start 主流程 (与 _sync_bot_to_bcn 风格一致).
@@ -3172,24 +3185,29 @@ class BotService:
         if not self._is_claude_code_bcn_register_enabled():
             logger.info(
                 f"[bot_service._register_bot_to_bcn_as_provider] disabled by DRM, "
-                f"skip bot_id={bot_id} owner={owner_workno}"
+                f"skip bot_id={bot_id} owner={owner_workno} connection_mode={connection_mode}"
             )
             return
 
         try:
             from agentclaw.community.core.bot_management.services.bcn_service import BcnServiceError
 
+            register_kwargs: Dict[str, Any] = {
+                "teamclaw_bot_uuid": bot_id,
+                "owner_workno": owner_workno,
+                "name": bot_name,
+                "summary": bot_summary,
+            }
+            if connection_mode is not None:
+                register_kwargs["connection_mode"] = connection_mode
             result = self._bcn_service.register_provider_bot(
-                teamclaw_bot_uuid=bot_id,
-                owner_workno=owner_workno,
-                name=bot_name,
-                summary=bot_summary,
+                **register_kwargs,
             )
 
             if result.get("skipped"):
                 logger.info(
                     f"[bot_service._register_bot_to_bcn_as_provider] env-skipped, "
-                    f"bot_id={bot_id} owner={owner_workno}"
+                    f"bot_id={bot_id} owner={owner_workno} connection_mode={connection_mode}"
                 )
                 return
 
@@ -3203,7 +3221,7 @@ class BotService:
                 f"[bot_service._register_bot_to_bcn_as_provider] registered "
                 f"bot_id={bot_id} owner={owner_workno} "
                 f"bot_uuid={bot_uuid} idempotent={idempotent} "
-                f"runtime_token_present={has_token}"
+                f"runtime_token_present={has_token} connection_mode={connection_mode}"
             )
 
             try:
@@ -3221,12 +3239,14 @@ class BotService:
         except BcnServiceError as e:
             logger.warning(
                 f"[bot_service._register_bot_to_bcn_as_provider] BCN register failed: "
-                f"bot_id={bot_id} owner={owner_workno} error={e}"
+                f"bot_id={bot_id} owner={owner_workno} connection_mode={connection_mode} "
+                f"error_type={type(e).__name__}"
             )
         except Exception as e:
             logger.warning(
                 f"[bot_service._register_bot_to_bcn_as_provider] Unexpected error: "
-                f"bot_id={bot_id} owner={owner_workno} error={e}"
+                f"bot_id={bot_id} owner={owner_workno} connection_mode={connection_mode} "
+                f"error_type={type(e).__name__}"
             )
 
     # DRM 控制开关: claude_code 启动时是否往 BCN 注册 Provider bot.
@@ -4077,7 +4097,7 @@ class BotService:
         #   - active_engine == "claude_code" 且 template_type == "personalCoding"
         #   - active_engine == "aicoding" 且 template_type == "personalCoding"
         #   - active_engine == "teclaw" (所有 bot_type)
-        #   - active_engine == "openclaw" 且 bot_type == "service"
+        #   - active_engine == "openclaw" 且 bot_type 为 "service" 或 "personal"
         # 失败不阻塞主流程, 与 _sync_bot_to_bcn 一致.
         # 排查日志关键字: [bot_service._register_bot_to_bcn_as_provider]
         should_register_bcn = self._should_register_bcn_provider(
@@ -4086,11 +4106,16 @@ class BotService:
             template_type=template_type,
             template_config=resolved_template_config,
         )
+        connection_mode = self._resolve_bcn_provider_connection_mode(
+            active_engine=active_engine,
+            bot_type=bot_type,
+        )
         if should_register_bcn:
             logger.info(
                 f"[bot_service.start_bot] register bot to BCN as provider: "
                 f"bot_id={bot_id} active_engine={active_engine} "
-                f"bot_type={bot_type} template_type={template_type}"
+                f"bot_type={bot_type} template_type={template_type} "
+                f"connection_mode={connection_mode}"
             )
             self._register_bot_to_bcn_as_provider(
                 bot_id=bot_id,
@@ -4098,12 +4123,14 @@ class BotService:
                 owner_workno=bot_owner_id,
                 bot_name=bot.get("bot_name") or bot_id,
                 bot_summary=bot.get("bot_desc") or "",
+                connection_mode=connection_mode,
             )
         else:
             logger.info(
                 f"[bot_service.start_bot] skip BCN provider registration: "
                 f"bot_id={bot_id} active_engine={active_engine} "
-                f"bot_type={bot_type} template_type={template_type}"
+                f"bot_type={bot_type} template_type={template_type} "
+                f"connection_mode={connection_mode}"
             )
 
         logger.info(
@@ -4552,19 +4579,25 @@ class BotService:
 
         # BaaS 原地重启不会经过 start_bot，这里补齐启动链路的 BCN Provider 注册。
         # 注册接口幂等：已注册时直接返回，也能重试创建阶段失败的注册。
-        if self._should_register_bcn_provider(
+        should_register_bcn = self._should_register_bcn_provider(
             active_engine=active_engine,
             bot_type=bot_type,
             template_type=bot_template_type,
             template_config=resolved_template_config,
-        ):
+        )
+        connection_mode = self._resolve_bcn_provider_connection_mode(
+            active_engine=active_engine,
+            bot_type=bot_type,
+        )
+        if should_register_bcn:
             logger.info(
                 "[bot_service._restart_bot_baas] register bot to BCN as provider: "
-                "bot_id=%s active_engine=%s bot_type=%s template_type=%s",
+                "bot_id=%s active_engine=%s bot_type=%s template_type=%s connection_mode=%s",
                 bot_id,
                 active_engine,
                 bot_type,
                 bot_template_type,
+                connection_mode,
             )
             self._register_bot_to_bcn_as_provider(
                 bot_id=bot_id,
@@ -4572,6 +4605,7 @@ class BotService:
                 owner_workno=bot.get("owner_id") or user_id,
                 bot_name=bot.get("bot_name") or bot_id,
                 bot_summary=bot.get("bot_desc") or "",
+                connection_mode=connection_mode,
             )
 
         # 普通 restart 入口只重启当前 bot，不使用发布态 build 产物目录。

--- a/src/backend/tests/community/core/bot_management/services/test_bcn_service_register_provider.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bcn_service_register_provider.py
@@ -119,6 +119,41 @@ class TestRegisterProviderBotEnvSelection:
 
     @patch(
         "agentclaw.community.core.bot_management.services.bcn_service.get_current_env",
+        return_value="pre",
+    )
+    def test_pre_env_plugin_mode_serializes_connection_mode(self, _mock_env, service, http):
+        """Plugin provider registrations must explicitly select BCN plugin mode."""
+        http.set_response("post", _ok_response(200, {"bot_uuid": "u1"}))
+
+        service.register_provider_bot(
+            teamclaw_bot_uuid="bot-uuid",
+            owner_workno="123",
+            name="Plugin Bot",
+            summary="",
+            connection_mode="plugin",
+        )
+
+        assert http.calls_to("post")[0].kwargs["json"]["connection_mode"] == "plugin"
+
+    @patch(
+        "agentclaw.community.core.bot_management.services.bcn_service.get_current_env",
+        return_value="pre",
+    )
+    def test_pre_env_default_registration_omits_connection_mode(self, _mock_env, service, http):
+        """Gateway-default registrations must not send a connection-mode override."""
+        http.set_response("post", _ok_response(200, {"bot_uuid": "u1"}))
+
+        service.register_provider_bot(
+            teamclaw_bot_uuid="bot-uuid",
+            owner_workno="123",
+            name="Gateway Bot",
+            summary="",
+        )
+
+        assert "connection_mode" not in http.calls_to("post")[0].kwargs["json"]
+
+    @patch(
+        "agentclaw.community.core.bot_management.services.bcn_service.get_current_env",
         return_value="prod",
     )
     def test_prod_env_uses_prod_provider_credentials(self, _mock_env, service, http):

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py
@@ -1,11 +1,11 @@
 """Unit tests for BCN provider registration during create_bot.
 
-create_bot 在设备分配成功后，应按与 start_bot 相同的条件注册 BCN Provider:
+create_bot 在 Bot 落库后、设备分配前，应按与 start_bot 相同的条件注册 BCN Provider:
 - active_engine == "claude_code" 且 template_type == "normalCC"
 - active_engine == "claude_code" 且 template_type == "personalCoding"
 - active_engine == "aicoding" 且 template_type == "personalCoding"
 - active_engine == "teclaw" (所有 bot_type)
-- active_engine == "openclaw" 且 bot_type == "service"
+- active_engine == "openclaw" 且 bot_type 为 "service" 或 "personal"
 - 注册失败不阻塞 create_bot 主流程
 """
 from __future__ import annotations
@@ -375,10 +375,18 @@ class TestCreateBotBcnRegister:
             summary="oc svc desc",
         )
 
-    def test_openclaw_personal_does_not_trigger_bcn_register(self):
-        """openclaw 引擎 personal bot 创建时不应触发 BCN 注册。"""
+    def test_openclaw_personal_registers_plugin_before_device_allocation(self):
+        """OpenClaw personal creation registers plugin mode before apply_device."""
         svc = _make_service()
-        _attach_device_service(svc)
+        device_service = _attach_device_service(svc)
+        timeline = []
+        device_result = _device_result()
+        device_service.apply_device.side_effect = lambda **kwargs: (
+            timeline.append(("apply_device", kwargs)), device_result
+        )[1]
+        svc._bcn_service.register_provider_bot.side_effect = lambda **kwargs: (
+            timeline.append(("register", kwargs)), {"bot_uuid": "u1"}
+        )[1]
 
         with patch.object(BotService, "_is_claude_code_bcn_register_enabled", return_value=True):
             svc.create_bot(
@@ -390,7 +398,31 @@ class TestCreateBotBcnRegister:
                 bot_type="personal",
             )
 
-        svc._bcn_service.register_provider_bot.assert_not_called()
+        assert [name for name, _ in timeline[:2]] == ["register", "apply_device"]
+        assert timeline[0][1]["connection_mode"] == "plugin"
+
+    @pytest.mark.parametrize(
+        ("capabilities", "expected"),
+        [
+            ({"bcn": {"join_as_provider": False}}, False),
+            ({"enable_bcn_network": True}, True),
+        ],
+    )
+    def test_openclaw_personal_respects_declared_bcn_capability(
+        self,
+        capabilities,
+        expected,
+    ):
+        """Factory capability must stay ahead of the legacy OpenClaw fallback."""
+        assert BotService._should_register_bcn_provider(
+            active_engine="openclaw",
+            bot_type="personal",
+            template_type="personal",
+            template_config={
+                "template_key": "openclaw-personal",
+                "capabilities": capabilities,
+            },
+        ) is expected
 
     def test_moltis_engine_does_not_trigger_bcn_register(self):
         """moltis 引擎不应触发 BCN 注册。"""

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py
@@ -304,6 +304,28 @@ class TestRestartBaasImagePolicy:
 
 
 class TestRestartBaasEnvInjection:
+    def test_openclaw_personal_restart_registers_plugin_mode(self):
+        """BaaS restart must preserve the OpenClaw personal plugin selection."""
+        svc, _, _ = _make_service(
+            active_engine="openclaw",
+            template_config=None,
+        )
+        svc._drm_reader.read.return_value = "true"
+        svc._bcn_service.register_provider_bot.return_value = {"bot_uuid": "u1"}
+        bot = _make_bot(active_engine="openclaw", template_type="")
+
+        svc._restart_bot_baas(
+            bot_id="bot001", user_id="user001", binding_id=42, bot=bot
+        )
+
+        svc._bcn_service.register_provider_bot.assert_called_once_with(
+            teamclaw_bot_uuid="bot001",
+            owner_workno="user001",
+            name="TestBot",
+            summary="",
+            connection_mode="plugin",
+        )
+
     def test_restart_records_current_publish_id_and_clears_stale_baas_failure(self):
         """BaaS 原地重启进入新 publish 轮次时，持久化当前 publish_id，
         并清理上一轮 BaaS publish 失败 marker。"""

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
@@ -466,20 +466,35 @@ class TestStartBotBcnRegister:
             ext_update={"bcn_registered": True},
         )
 
-    def test_openclaw_personal_bot_does_not_trigger_bcn_register(self):
-        # 反例: active_engine=openclaw + bot_type=personal 不应触发 BCN 注册.
+    def test_openclaw_personal_bot_registers_plugin_mode(self):
+        # active_engine=openclaw + bot_type=personal 必须显式注册 BCN plugin 模式.
         svc = _make_service()
         svc._bcn_service = MagicMock()
+        svc._bcn_service.register_provider_bot.return_value = {
+            "bot_uuid": "u-openclaw-personal",
+        }
         bot = _make_bot()
         bot["active_engine"] = "openclaw"
         bot["bot_type"] = "personal"
         svc._repository.get_by_id_and_owner.side_effect = [bot, bot]
 
         with patch.object(svc, "_allocate_device_async"), \
+             patch.object(svc, "update_bot_ext") as mock_ext, \
              patch.object(BotService, "_is_claude_code_bcn_register_enabled", return_value=True):
             svc.start_bot(bot_id="bot001", user_id="user001")
 
-        svc._bcn_service.register_provider_bot.assert_not_called()
+        svc._bcn_service.register_provider_bot.assert_called_once_with(
+            teamclaw_bot_uuid="bot001",
+            owner_workno="user001",
+            name="TestBot",
+            summary="",
+            connection_mode="plugin",
+        )
+        mock_ext.assert_called_once_with(
+            bot_id="bot001",
+            user_id="user001",
+            ext_update={"bcn_registered": True},
+        )
 
     def test_bcn_register_failure_does_not_block_start(self):
         from agentclaw.community.core.bot_management.services.bcn_service import BcnServiceError


### PR DESCRIPTION
## Problem

OpenClaw personal Bots did not register as BCN Providers during creation or startup. As a result, they could not opt into the existing BCN plugin delivery path.

## Solution

- Register `openclaw + personal` Bots with `connection_mode="plugin"`.
- Keep all existing gateway registrations unchanged by omitting `connection_mode`.
- Register after the Bot record exists and before `apply_device()` during creation; use the same mode selection for start and BaaS restart.
- Preserve factory capability gates, DRM controls, idempotency, and best-effort lifecycle behavior.

## Validation

- `uv run pytest -q tests/community/core/bot_management/services/test_bcn_service_register_provider.py tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py tests/community/core/bot_management/services/test_bot_service_stop_start.py tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py tests/community/unit/test_template_capabilities.py` — 103 passed.
- `uv run ruff check` for the six changed files — passed.
- `git diff --check` — passed.

## Compatibility and risk

- The BCS provider ID must be included in `allowed_switch_provider_ids`; registration failures remain best-effort and do not block Bot lifecycle operations.
- This PR only changes Avernet. It relies on the existing BCS plugin registration and WebSocket bootstrap implementation, which must be assessed by BCS owners before production rollout.
