### PR TITLE
fix(bot_public): correct agent approval subkey to public_agent_approval

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -78,10 +78,10 @@ _BCS_VISIBILITY_FIELD_BY_SCOPE: dict[str, str] = {
 }
 
 # 慢连路径(走工单)在 BCS friend_ext 下记录工单的 sub-key 随 public_scope 联动:
-# user → public_user_approval; agent → public_public_approval。内层 block 形状一致。
+# user → public_user_approval; agent → public_agent_approval。内层 block 形状一致。
 _BCS_APPROVAL_KEY_BY_SCOPE: dict[str, str] = {
     "user": "public_user_approval",
-    "agent": "public_public_approval",
+    "agent": "public_agent_approval",
 }
 
 # AGREE 回调时把 public_*_approval 子块里的 view_friend_deps 提到 friend_ext 顶层,
@@ -812,7 +812,7 @@ class BotPublicService:
 
         public_scope 非空即新版发布回调 (caller 保证 bot_id == bot_uid):
         - 把 (_BCS_APPROVAL_KEY_BY_SCOPE) 对应的 friend_ext 子块
-          (public_user_approval/public_public_approval) 的 status 写成 last_operate
+          (public_user_approval/public_agent_approval) 的 status 写成 last_operate
           (AGREE/DISAGREE/CANCEL)。
         - AGREE 时同时翻 BCS 可见性字段 (_BCS_VISIBILITY_FIELD_BY_SCOPE):
             - public_scope=user → user_visibility = block.visibility (block 存的请求值,
@@ -886,7 +886,7 @@ class BotPublicService:
         if public_scope:
             # New-version callback (public_scope 非空 → bot_id 即 bot_uid):
             # GET friend_ext → 按 public_scope 子块 (public_user_approval/
-            # public_public_approval) 写 status = last_operate → PATCH 回。
+            # public_agent_approval) 写 status = last_operate → PATCH 回。
             try:
                 return self._apply_callback_decision(
                     bot_uid=bot_id, public_scope=public_scope, last_operate=last_operate

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -413,7 +413,7 @@ class TestPublicBcsBot:
         # merge 仍保留已有 friend_ext 子键
         assert bcn.patch_attributes.call_args.kwargs["body"]["friend_ext"]["old"] == "x"
 
-    def test_agent_publish_stores_public_public_approval_block(self):
+    def test_agent_publish_stores_public_agent_approval_block(self):
         process = MagicMock()
         process.start_approval.return_value = {
             "success": True, "puid": "p1", "approval_url": "u1", "state": "PROCESSING",
@@ -430,9 +430,9 @@ class TestPublicBcsBot:
             visibility="public",
         )
         friend_ext = bcn.patch_attributes.call_args.kwargs["body"]["friend_ext"]
-        # agent → public_public_approval subkey (NOT public_user_approval); same block shape
+        # agent → public_agent_approval subkey (NOT public_user_approval); same block shape
         assert "public_user_approval" not in friend_ext
-        block = friend_ext["public_public_approval"]
+        block = friend_ext["public_agent_approval"]
         assert block["puid"] == "p1"
         assert block["approval_url"] == "u1"
         assert block["view_friend_deps"] == [{"deptNo": "D1", "deptName": "Tech"}]
@@ -464,11 +464,11 @@ class TestPublicBcsBot:
         assert block["puid"] == "p1"
         assert block["visibility"] == "public"
 
-    def test_callback_cancel_updates_public_public_approval_for_agent(self):
+    def test_callback_cancel_updates_public_agent_approval_for_agent(self):
         bcn = MagicMock()
         bcn.get_attributes.return_value = {
             "friend_ext": {
-                "public_public_approval": {"puid": "p1", "status": "PROCESSING"}
+                "public_agent_approval": {"puid": "p1", "status": "PROCESSING"}
             }
         }
         svc = _make_service(bcn_service=bcn)
@@ -476,7 +476,7 @@ class TestPublicBcsBot:
             bot_id="b", owner_id="u", puid="p1",
             last_operate="CANCEL", public_scope="agent",
         )
-        block = bcn.patch_attributes.call_args.kwargs["body"]["friend_ext"]["public_public_approval"]
+        block = bcn.patch_attributes.call_args.kwargs["body"]["friend_ext"]["public_agent_approval"]
         assert block["status"] == "CANCEL"
 
     def test_callback_agree_user_writes_block_visibility_to_user_visibility(self):
@@ -513,7 +513,7 @@ class TestPublicBcsBot:
     def test_callback_agree_agent_public_when_friend_check_open(self):
         bcn = MagicMock()
         bcn.get_attributes.return_value = {
-            "friend_ext": {"public_public_approval": {"puid": "p1", "status": "PROCESSING"}},
+            "friend_ext": {"public_agent_approval": {"puid": "p1", "status": "PROCESSING"}},
             "friend_check_in_strategy": "OPEN",
         }
         svc = _make_service(bcn_service=bcn)
@@ -522,14 +522,14 @@ class TestPublicBcsBot:
             last_operate="AGREE", public_scope="agent",
         )
         body = bcn.patch_attributes.call_args.kwargs["body"]
-        assert body["friend_ext"]["public_public_approval"]["status"] == "AGREE"
+        assert body["friend_ext"]["public_agent_approval"]["status"] == "AGREE"
         # agent: visibility 由 friend_check_in_strategy=OPEN → public
         assert body["visibility"] == "public"
 
     def test_callback_agree_agent_protected_when_friend_check_not_open(self):
         bcn = MagicMock()
         bcn.get_attributes.return_value = {
-            "friend_ext": {"public_public_approval": {"puid": "p1", "status": "PROCESSING"}},
+            "friend_ext": {"public_agent_approval": {"puid": "p1", "status": "PROCESSING"}},
             "friend_check_in_strategy": "APPROVAL",
         }
         svc = _make_service(bcn_service=bcn)
@@ -566,7 +566,7 @@ class TestPublicBcsBot:
         bcn = MagicMock()
         bcn.get_attributes.return_value = {
             "friend_ext": {
-                "public_public_approval": {
+                "public_agent_approval": {
                     "puid": "p1", "status": "PROCESSING",
                     "view_friend_deps": [{"deptNo": "D2", "deptName": "Sales"}],
                 }


### PR DESCRIPTION

  ## Problem

  When a bot is published with `public_scope=agent`, the approval sub-block written into the BCS `friend_ext` (and read back on the approval callback) was keyed as `public_public_approval`, but it must be
  `public_agent_approval` to follow the `public_{scope}_approval` convention. This is what showed up as the wrong key in the ticket-detail view.

  Root cause: `BotPublicService._BCS_APPROVAL_KEY_BY_SCOPE` was

  ```python
  {"user": "public_user_approval", "agent": "public_public_approval"}

  The agent entry mistakenly fills the {scope} slot with the literal public instead of agent. The same map is used by _persist_public_approval (write, on ticket creation → friend_ext[...] = block) and
  _apply_callback_decision (read, on the callback → friend_ext.get(key)), so the block is internally self-consistent — the bug surfaces only as the wrong key name against the contract.

  Why it matters: anything consuming friend_ext by name (ticket detail, downstream readers) looks for public_agent_approval and misses the agent block. The sibling scope-keyed maps in the same file already follow the
  correct rule (agent → view_scope_agent_friend_deps; agent → visibility, user → user_visibility), so this is an isolated typo, not a deliberate public convention.

  Solution

  Set _BCS_APPROVAL_KEY_BY_SCOPE["agent"] = "public_agent_approval", and sync the in-code docstrings/comments plus the affected unit-test assertions and test names.

  Why a one-shot rename rather than a read-side fallback: BCS friend_ext is an opaque pass-through store — the key name is a private convention, there is no external contract defining public_public_approval (verified:
  zero repo references after the fix, and none to public_agent_approval before). Confirmed pre-prod with low dirty-data volume, so a clean rename is preferred over a dual-read shim that would carry the typo forward.

  Rejected alternative: dual-read fallback (public_agent_approval miss → public_public_approval) — keeps the wrong key alive; rejected given pre-prod status.

  Validation

  - cd src/backend && uv run pytest tests/community/core/bot_public/test_bot_public_service.py -q → 131 passed, incl. test_agent_publish_stores_public_agent_approval_block,
  test_callback_cancel_updates_public_agent_approval_for_agent, test_callback_agree_agent_public_when_friend_check_open, test_callback_agree_agent_protected_when_friend_check_not_open,
  test_callback_agree_lifts_view_friend_deps_for_agent.
  - grep -rn public_public_approval repo-wide (excl. .venv/.git/node_modules) → no remaining references.
  - Not run: the full pre-push gate (scripts/ci/pre_push.sh with OCB_PRE_PUSH_RUN_CI=1) and singlebox coverage / BCS E2E — this change only touches the backend bot_public unit, so the targeted unit suite was run; SAST
  and changed-line coverage will run under normal PR CI on the changed path src/backend/.

  Compatibility and risk

  - Contract/schema: no change to any BCS-interpreted field — friend_ext is pass-through; the renamed sub-key is internal.
  - Migration impact: pre-existing agent bot rows on pre-prod that wrote public_public_approval will, after this fix, miss on the next callback read (empty block → view_friend_deps lift and visibility use defaults).
  Confirmed acceptable for current pre-prod (low dirty-data volume); no prod data yet.
  - Rollback: git revert 55e028dbc — on revert the old key is read again.

