### PR TITLE
feat(backend): return catalog bot UUID

### DIFF
--- a/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
+++ b/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
@@ -35,8 +35,8 @@ BCS 的排序和分页边界保持不变。`tc_bot=true` 使正常数据下 BCS 
 返回实际 join 的记录。BCS 不可用或返回非法记录时固定返回 `502000 / Catalog service unavailable`，
 不会回退为 Backend-only 搜索。
 
-每个成功 join 的 Search item 还会返回 `bot_uuid`，它是经过 BCS `<bot_id>:<entity_id>` 解析和精确 join
-后重建的规范值。若 BCS 当前目录项提供 `visibility`、`is_online`、`actor_kind`、`is_friend`、`friend_ext`、
+每个成功 join 的 Search item 还会返回 `bot_uuid`：优先使用通过 BCS `<bot_id>:<entity_id>` 解析和精确 join
+校验后的 BCS 返回值；元信息端口未提供时，才以 Backend 的 `bot_id:entity_id` 兜底。若 BCS 当前目录项提供 `visibility`、`is_online`、`actor_kind`、`is_friend`、`friend_ext`、
 `friend_check_in_strategy` 或 `user_visibility`，Backend 在精确 `(bot_id, entity_id)` join 后原样返回；字段缺失或为
 `null` 时响应中省略。`is_friend` 仅在前端成对传入 `viewer_actor_type` 与 `viewer_actor_id` 且 BCS 返回该字段时出现；未传 viewer 不会以 `false` 代替。`friend_ext` 不删除内部键，前端可按需使用。Backend 不重新查询、推导或覆盖这些 BCS 值。
 
@@ -86,7 +86,7 @@ GET /openapi/v1/bots/catalog/discover?keyword=contract&top_k=10
 ```ts
 type PublicBot = {
   bot_id: string;
-  bot_uuid?: string; // Catalog Search 的规范 BCS <bot_id>:<entity_id>
+  bot_uuid?: string; // 优先 BCS 返回值，缺失时为 Backend <bot_id>:<entity_id>
   entity_id: string;
   bot_type: unknown;
   name: string;

--- a/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
+++ b/src/backend/docs/openapi-v1/bot-public-catalog-api.zh-CN.md
@@ -35,7 +35,8 @@ BCS 的排序和分页边界保持不变。`tc_bot=true` 使正常数据下 BCS 
 返回实际 join 的记录。BCS 不可用或返回非法记录时固定返回 `502000 / Catalog service unavailable`，
 不会回退为 Backend-only 搜索。
 
-若 BCS 当前目录项提供 `visibility`、`is_online`、`actor_kind`、`is_friend`、`friend_ext`、
+每个成功 join 的 Search item 还会返回 `bot_uuid`，它是经过 BCS `<bot_id>:<entity_id>` 解析和精确 join
+后重建的规范值。若 BCS 当前目录项提供 `visibility`、`is_online`、`actor_kind`、`is_friend`、`friend_ext`、
 `friend_check_in_strategy` 或 `user_visibility`，Backend 在精确 `(bot_id, entity_id)` join 后原样返回；字段缺失或为
 `null` 时响应中省略。`is_friend` 仅在前端成对传入 `viewer_actor_type` 与 `viewer_actor_id` 且 BCS 返回该字段时出现；未传 viewer 不会以 `false` 代替。`friend_ext` 不删除内部键，前端可按需使用。Backend 不重新查询、推导或覆盖这些 BCS 值。
 
@@ -85,6 +86,7 @@ GET /openapi/v1/bots/catalog/discover?keyword=contract&top_k=10
 ```ts
 type PublicBot = {
   bot_id: string;
+  bot_uuid?: string; // Catalog Search 的规范 BCS <bot_id>:<entity_id>
   entity_id: string;
   bot_type: unknown;
   name: string;

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/router.py
@@ -140,6 +140,7 @@ def _public_bot(record: Mapping[str, Any]) -> PublicBot:
     # service records cannot expose bindings, device data, credentials, or environment data.
     return PublicBot(
         bot_id=str(record.get("bot_id") or ""),
+        bot_uuid=record.get("bot_uuid"),
         entity_id=str(record.get("entity_id") or record.get("owner_id") or ""),
         bot_type=record["bot_type"],
         name=str(record.get("bot_name") or ""),

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/schemas.py
@@ -11,6 +11,10 @@ class PublicBot(BaseModel):
     """The allowlisted public projection of a catalog Bot."""
 
     bot_id: str = Field(description="Stable public Bot identifier.")
+    bot_uuid: str | None = Field(
+        default=None,
+        description="Canonical BCS Bot UUID returned by Catalog Search when available.",
+    )
     entity_id: str = Field(description="Public entity identifier for the Bot owner.")
     bot_type: Any = Field(description="Published kind of Bot.")
     name: str = Field(description="Public Bot display name.")

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bot_public/schemas.py
@@ -13,7 +13,7 @@ class PublicBot(BaseModel):
     bot_id: str = Field(description="Stable public Bot identifier.")
     bot_uuid: str | None = Field(
         default=None,
-        description="Canonical BCS Bot UUID returned by Catalog Search when available.",
+        description="Catalog Search Bot UUID, preferring BCS with a Backend address fallback.",
     )
     entity_id: str = Field(description="Public entity identifier for the Bot owner.")
     bot_type: Any = Field(description="Published kind of Bot.")

--- a/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
@@ -41,6 +41,7 @@ class BotCatalogMetadata:
 
     address: BotCatalogAddress
     kind: str
+    bot_uuid: str | None = None
     is_friend: bool | None = None
     visibility: Any = None
     is_online: Any = None

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
@@ -76,7 +76,10 @@ class BcsBotCatalogMetadataService:
             for item in payload["items"]:
                 if not isinstance(item, Mapping) or item.get("actor_kind") != "bot":
                     raise BotCatalogMetadataUnavailableError()
-                address = self._address_from_bot_uuid(item.get("bot_uuid"))
+                bot_uuid = item.get("bot_uuid")
+                if not isinstance(bot_uuid, str):
+                    raise BotCatalogMetadataUnavailableError()
+                address = self._address_from_bot_uuid(bot_uuid)
                 if address is None or address in seen:
                     raise BotCatalogMetadataUnavailableError()
                 is_friend = item.get("is_friend")
@@ -89,6 +92,7 @@ class BcsBotCatalogMetadataService:
                     BotCatalogMetadata(
                         address=address,
                         kind="bot",
+                        bot_uuid=bot_uuid,
                         is_friend=is_friend,
                         visibility=item.get("visibility"),
                         is_online=item.get("is_online"),

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -1495,6 +1495,9 @@ class BotPublicService:
             if bot is None:
                 continue
             metadata_item = metadata_by_address[address]
+            # COSEC: Return only the canonical UUID reconstructed from the BCS
+            # address that passed exact composite-key validation, never raw upstream data.
+            bot["bot_uuid"] = f"{address.bot_id}:{address.entity_id}"
             for field_name in (
                 "is_friend",
                 "visibility",

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -1495,9 +1495,11 @@ class BotPublicService:
             if bot is None:
                 continue
             metadata_item = metadata_by_address[address]
-            # COSEC: Return only the canonical UUID reconstructed from the BCS
-            # address that passed exact composite-key validation, never raw upstream data.
-            bot["bot_uuid"] = f"{address.bot_id}:{address.entity_id}"
+            # COSEC: The BCS value reached this service only after the adapter
+            # validated its composite address; fall back only to the exact joined Backend address.
+            bot["bot_uuid"] = metadata_item.bot_uuid or (
+                f"{address.bot_id}:{address.entity_id}"
+            )
             for field_name in (
                 "is_friend",
                 "visibility",

--- a/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
@@ -37,6 +37,7 @@ def _bot() -> dict[str, Any]:
     return {
         "id": 91,
         "bot_id": "catalog-bot",
+        "bot_uuid": "catalog-bot:owner-1",
         "entity_id": "owner-1",
         "bot_type": "service",
         "bot_name": "Catalog Bot",
@@ -139,6 +140,7 @@ def test_search_projects_only_catalog_fields(
         "items": [
             {
                 "bot_id": "catalog-bot",
+                "bot_uuid": "catalog-bot:owner-1",
                 "entity_id": "owner-1",
                 "bot_type": "service",
                 "name": "Catalog Bot",
@@ -333,6 +335,19 @@ def test_search_openapi_declares_optional_bcs_is_friend(app: FastAPI) -> None:
     ]
 
     assert is_friend["anyOf"] == [{"type": "boolean"}, {"type": "null"}]
+
+
+def test_search_openapi_declares_optional_canonical_bcs_bot_uuid(
+    app: FastAPI,
+) -> None:
+    bot_uuid = app.openapi()["components"]["schemas"]["PublicBot"]["properties"][
+        "bot_uuid"
+    ]
+
+    assert bot_uuid["anyOf"] == [{"type": "string"}, {"type": "null"}]
+    assert bot_uuid["description"] == (
+        "Canonical BCS Bot UUID returned by Catalog Search when available."
+    )
 
 
 def test_search_openapi_declares_optional_bcs_metadata_fields(app: FastAPI) -> None:

--- a/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py
@@ -337,7 +337,7 @@ def test_search_openapi_declares_optional_bcs_is_friend(app: FastAPI) -> None:
     assert is_friend["anyOf"] == [{"type": "boolean"}, {"type": "null"}]
 
 
-def test_search_openapi_declares_optional_canonical_bcs_bot_uuid(
+def test_search_openapi_declares_optional_bcs_preferred_bot_uuid(
     app: FastAPI,
 ) -> None:
     bot_uuid = app.openapi()["components"]["schemas"]["PublicBot"]["properties"][
@@ -346,7 +346,7 @@ def test_search_openapi_declares_optional_canonical_bcs_bot_uuid(
 
     assert bot_uuid["anyOf"] == [{"type": "string"}, {"type": "null"}]
     assert bot_uuid["description"] == (
-        "Canonical BCS Bot UUID returned by Catalog Search when available."
+        "Catalog Search Bot UUID, preferring BCS with a Backend address fallback."
     )
 
 

--- a/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
@@ -58,7 +58,7 @@ def test_bcs_catalog_search_maps_current_page_and_parses_exact_address() -> None
                 "total": 21,
                 "items": [
                     {
-                        "bot_uuid": "bot-1:owner-1",
+                        "bot_uuid": " bot-1 : owner-1 ",
                         "actor_kind": "bot",
                         "name": "ignored-by-backend",
                     }
@@ -73,7 +73,10 @@ def test_bcs_catalog_search_maps_current_page_and_parses_exact_address() -> None
 
     assert result == [
         BotCatalogMetadata(
-            BotCatalogAddress("bot-1", "owner-1"), "bot", actor_kind="bot"
+            BotCatalogAddress("bot-1", "owner-1"),
+            "bot",
+            bot_uuid=" bot-1 : owner-1 ",
+            actor_kind="bot",
         )
     ]
     call = http.calls_to("get")[0]
@@ -152,6 +155,7 @@ def test_bcs_catalog_search_preserves_requested_optional_metadata_fields() -> No
         BotCatalogMetadata(
             BotCatalogAddress("bot-1", "owner-1"),
             "bot",
+            bot_uuid="bot-1:owner-1",
             is_friend=False,
             visibility="protected",
             is_online=False,

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -1362,6 +1362,31 @@ class TestSearchPublicBotsByKeyword:
             page_size=2,
         )
 
+    def test_catalog_search_prefers_validated_bcs_bot_uuid(self):
+        metadata = MagicMock()
+        metadata.search_public_bot_metadata.return_value = [
+            BotCatalogMetadata(
+                BotCatalogAddress("bot-1", "entity-1"),
+                "bot",
+                bot_uuid=" bot-1 : entity-1 ",
+            )
+        ]
+        repository = MagicMock()
+        repository.list_bots_by_owner_bot_pairs.return_value = (
+            1,
+            [_make_catalog_bot("bot-1", "entity-1")],
+        )
+        svc = _make_service(
+            bot_repository=repository, catalog_metadata_service=metadata
+        )
+
+        result = svc.search_catalog_public_bots_by_keyword(
+            caller=BotCatalogCaller("tenant-1", "user-1", None),
+            request_id="trace-bcs-bot-uuid",
+        )
+
+        assert result["items"][0]["bot_uuid"] == " bot-1 : entity-1 "
+
     def test_catalog_search_preserves_bcs_is_friend_on_its_exact_address(self):
         metadata = MagicMock()
         bcs_item = BotCatalogMetadata(

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -1348,6 +1348,7 @@ class TestSearchPublicBotsByKeyword:
 
         assert result["total"] == 1
         assert [bot["bot_id"] for bot in result["items"]] == ["bot-1"]
+        assert [bot["bot_uuid"] for bot in result["items"]] == ["bot-1:entity-1"]
         metadata.search_public_bot_metadata.assert_called_once_with(
             search="agent",
             page=3,
@@ -1382,7 +1383,11 @@ class TestSearchPublicBotsByKeyword:
         )
 
         assert result["items"] == [
-            {**_make_catalog_bot("shared", "entity-a"), "is_friend": False}
+            {
+                **_make_catalog_bot("shared", "entity-a"),
+                "bot_uuid": "shared:entity-a",
+                "is_friend": False,
+            }
         ]
 
     def test_catalog_search_preserves_requested_bcs_metadata_on_its_exact_address(self):
@@ -1420,6 +1425,7 @@ class TestSearchPublicBotsByKeyword:
         assert result["items"] == [
             {
                 **_make_catalog_bot("shared", "entity-a"),
+                "bot_uuid": "shared:entity-a",
                 "is_friend": False,
                 "visibility": "protected",
                 "is_online": False,

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -3661,7 +3661,7 @@
                 "type": "null"
               }
             ],
-            "description": "Canonical BCS Bot UUID returned by Catalog Search when available.",
+            "description": "Catalog Search Bot UUID, preferring BCS with a Backend address fallback.",
             "title": "Bot Uuid"
           },
           "bot_type": {
@@ -13092,7 +13092,7 @@
                 "type": "null"
               }
             ],
-            "description": "Canonical BCS Bot UUID returned by Catalog Search when available.",
+            "description": "Catalog Search Bot UUID, preferring BCS with a Backend address fallback.",
             "title": "Bot Uuid"
           },
           "bot_type": {

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -3652,6 +3652,18 @@
             "title": "Bot Id",
             "type": "string"
           },
+          "bot_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Canonical BCS Bot UUID returned by Catalog Search when available.",
+            "title": "Bot Uuid"
+          },
           "bot_type": {
             "description": "Published kind of Bot.",
             "title": "Bot Type"
@@ -13070,6 +13082,18 @@
             "description": "Stable public Bot identifier.",
             "title": "Bot Id",
             "type": "string"
+          },
+          "bot_uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Canonical BCS Bot UUID returned by Catalog Search when available.",
+            "title": "Bot Uuid"
           },
           "bot_type": {
             "description": "Published kind of Bot.",


### PR DESCRIPTION
## Problem

Catalog Search needs to expose the BCS Bot UUID associated with each joined catalog result while preserving the existing exact BCS/Backend address join.

## Solution

- Preserve BCS `bot_uuid` after the adapter validates its composite address.
- Prefer that BCS value in the public Catalog Search response.
- Fall back to the exact joined Backend `bot_id:entity_id` only when the metadata port does not provide `bot_uuid`.
- Update the OpenAPI model, Gateway schema, Chinese frontend documentation, and focused tests.

## Validation

- `DEPLOY_PROFILE=test uv run pytest tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py tests/community/core/bot_public/test_bot_catalog_metadata_service.py tests/community/core/bot_public/test_bot_public_service.py -q` — 175 passed.
- `DEPLOY_PROFILE=test uv run pytest tests/community/architecture/test_repository_contracts.py tests/community/architecture/test_http_adapter_layer_is_http_only.py tests/community/architecture/test_no_fastapi_in_core.py -q` — 15 passed.
- Ruff, `git diff --check`, and static-versus-generated OpenAPI schema checks passed.

## Compatibility and risk

`bot_uuid` remains optional on the shared public model. BCS values are preserved only after the existing composite-address validation; BCS request parameters, join rules, and the sensitive-field allowlist are unchanged.

## Spec

`spec/pipeline/catalog-search-bcs-filters/012-bot-uuid-source-preference.md` (intentionally not committed).
