### PR TITLE
feat(backend): filter bot inventory by service classification

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -681,6 +681,15 @@ async def list_inventory(
         DeployMode | None,
         Query(description="Filter inventory items by cloud or local deployment."),
     ] = None,
+    is_service: Annotated[
+        bool | None,
+        Query(
+            description=(
+                "Filter by service classification: true returns service Bots, "
+                "false returns non-service Bots, and omission returns both."
+            )
+        ),
+    ] = None,
     service: BotInventoryServiceProtocol = Injected(BotInventoryServiceProtocol),
     space_context: BusinessSpaceContextProtocol = Injected(
         BusinessSpaceContextProtocol
@@ -700,6 +709,7 @@ async def list_inventory(
         keyword=keyword,
         engine=engine,
         deploy_mode=CoreDeployMode(deploy_mode) if deploy_mode is not None else None,
+        is_service=is_service,
         bot_ids=sorted(granted) if granted is not None else None,
         page=page_params.page,
         page_size=page_params.page_size,

--- a/src/backend/src/agentclaw/community/api/bot_inventory_service.py
+++ b/src/backend/src/agentclaw/community/api/bot_inventory_service.py
@@ -23,6 +23,7 @@ class BotInventoryServiceProtocol(Protocol):
         keyword: str | None,
         engine: str | None,
         deploy_mode: DeployMode | None,
+        is_service: bool | None = None,
         bot_ids: list[str] | None = None,
         page: int,
         page_size: int,

--- a/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
@@ -53,6 +53,7 @@ class BotInventoryService:
         keyword: str | None,
         engine: str | None,
         deploy_mode: DeployMode | None,
+        is_service: bool | None = None,
         bot_ids: list[str] | None = None,
         page: int,
         page_size: int,
@@ -66,6 +67,14 @@ class BotInventoryService:
                 engine=engine,
                 bot_ids=bot_ids,
             )
+            if is_service is True:
+                cloud_rows = [
+                    row for row in cloud_rows if row.get("bot_type") == "service"
+                ]
+            elif is_service is False:
+                cloud_rows = [
+                    row for row in cloud_rows if row.get("bot_type") != "service"
+                ]
             service_rows = [
                 row for row in cloud_rows if row.get("bot_type") == "service"
             ]
@@ -95,8 +104,10 @@ class BotInventoryService:
                     )
                     for lifecycle_card in service_cards.get(bot_id, ())
                 )
-        if deploy_mode in (None, DeployMode.LOCAL) and (
-            space is None or space.kind == "personal"
+        if (
+            is_service is not True
+            and deploy_mode in (None, DeployMode.LOCAL)
+            and (space is None or space.kind == "personal")
         ):
             cards.extend(
                 self._to_local_item(row, owner_id, space, PermissionLevel.OWNER)

--- a/src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py
@@ -113,6 +113,40 @@ def test_list_inventory_combines_personal_cloud_and_local(client):
     assert ids == {"c1", "l1"}
 
 
+def test_list_inventory_filters_non_service_bots(client):
+    data = _ok(
+        client.get("/openapi/v1/bots/all", params={"is_service": "false"})
+    )
+
+    assert data["total"] == 2
+    assert {item["bot_id"] for item in data["items"]} == {"c1", "l1"}
+
+
+def test_list_inventory_filters_service_bots_without_leaking_local_bots(client):
+    data = _ok(
+        client.get("/openapi/v1/bots/all", params={"is_service": "true"})
+    )
+
+    assert data["total"] == 0
+    assert data["items"] == []
+
+
+def test_list_inventory_combines_engine_deploy_and_service_filters(client):
+    data = _ok(
+        client.get(
+            "/openapi/v1/bots/all",
+            params={
+                "engine": "openclaw",
+                "deploy_mode": "local",
+                "is_service": "false",
+            },
+        )
+    )
+
+    assert data["total"] == 1
+    assert [item["bot_id"] for item in data["items"]] == ["l1"]
+
+
 def test_inventory_consumes_space_header_fail_closed(client):
     resp = client.get("/openapi/v1/bots/all", headers={"X-Space-Id": "team:1"})
 

--- a/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
+++ b/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
@@ -193,15 +193,74 @@ def test_service_bot_expands_to_publication_cards_before_pagination() -> None:
         keyword=None,
         engine=None,
         deploy_mode=DeployMode.CLOUD,
+        is_service=True,
         page=1,
         page_size=10,
     )
 
-    assert total == 3
+    assert total == 2
+    assert {item.bot_id for item in items} == {"s1"}
     service_items = [item for item in items if item.bot_id == "s1"]
     assert [item.publication_id for item in service_items] == [4, 3]
     assert [item.card_id for item in service_items] == ["service:s1:4", "service:s1:3"]
     lifecycle_port.cards_for_bots.assert_called_once_with(bots=[service_row])
+
+
+@pytest.mark.unit
+def test_non_service_filter_excludes_service_cards_before_total(service) -> None:
+    inventory, bot, _ = service
+    service_row = {
+        **CLOUD,
+        "id": 10,
+        "bot_id": "s1",
+        "bot_name": "Service",
+        "bot_type": "service",
+    }
+    bot.list_bots_by_conditions.return_value = {
+        "total": 2,
+        "items": [CLOUD, service_row],
+    }
+
+    items, total = inventory.list_items(
+        owner_id="u1",
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
+        keyword=None,
+        engine=None,
+        deploy_mode=None,
+        is_service=False,
+        page=1,
+        page_size=10,
+    )
+
+    assert total == 2
+    assert {item.bot_id for item in items} == {"c1", "l1"}
+
+
+@pytest.mark.unit
+def test_local_deploy_with_service_filter_returns_empty_without_source_calls(
+    service,
+) -> None:
+    inventory, bot, desktop = service
+
+    items, total = inventory.list_items(
+        owner_id="u1",
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
+        keyword=None,
+        engine=None,
+        deploy_mode=DeployMode.LOCAL,
+        is_service=True,
+        page=1,
+        page_size=10,
+    )
+
+    assert total == 0
+    assert items == []
+    bot.list_bots_by_conditions.assert_not_called()
+    desktop.list_user_bots.assert_not_called()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem
`GET /openapi/v1/bots/all` (bot inventory) could not narrow results by service classification. Callers wanting only service Bots, or only non-service Bots, had to fetch everything and filter client-side, and local (non-service) Bots could still leak into results even when only service Bots were requested.

## Solution
Add an optional `is_service: bool | None` query parameter to `list_inventory` (`/openapi/v1/bots/all`), threaded through `BotInventoryServiceProtocol.list_items` into `BotInventoryService`:

- `is_service=true` → only service Bots (`bot_type == "service"`); the local-source inclusion path is gated off so non-service locals don't leak.
- `is_service=false` → only non-service Bots.
- omitted → both (unchanged behavior).

Filtering is applied before pagination so `total` reflects the filter; when only service Bots are requested, the local/desktop source is not queried. Additive and backward-compatible: the new param defaults to `None`, and the protocol signature gains an optional default so existing callers and `list_items` implementations are unaffected.

Cherry-picked onto a fresh branch from `origin/dev` to isolate it from the already-merged bot-create collaboration work (PRs #1403, #1420) still carried on `dev_refactory_collaboration_rz`.

## Validation
- Tests added with the change (+95 lines):
  - `tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py` — non-service filter; service filter without local leakage; combined engine/deploy_mode/is_service filter.
  - `tests/community/core/bot_inventory/services/test_bot_inventory_service.py` — `is_service=True` excludes non-service cards before `total`; `is_service=True` + local deploy returns empty with no source calls; existing service-bot test updated for the filter path.
- Pre-push SAST (`scripts/ci/python_sast_local.sh`, backend, changed files) passed via the repo pre-push hook on push.
- Cherry-pick auto-merged clean; `list_inventory` wiring (new param + pass-through to `list_items`) verified.
- Full backend unit + changed-line coverage (≥80%) + Singlebox coverage will run in PR CI. Local `ci_test.sh` pre-flight was not run here — the isolated worktree has no backend venv; I'll report green/red once CI runs.

## Compatibility and risk
- Additive OpenAPI change (new optional boolean query param). No existing request shape changed; existing clients unaffected. Low risk, no migration.
- `BotInventoryServiceProtocol.list_items` gains `is_service: bool | None = None` (optional default) — backward compatible for protocol implementations.

## Related issues
- Builds on the inventory list established by the bot-create collaboration work (PRs #1403, #1420), now on `dev`.
