### PR TITLE
refactor(bcs): align edge-permission IDs to bigint auto-increment key…

### DIFF
--- a/src/bcs/api-contracts/v1/domain-models.yaml
+++ b/src/bcs/api-contracts/v1/domain-models.yaml
@@ -37,6 +37,22 @@ BotVisibility:
     - private
   description: Discovery and collaboration visibility stored for the Bot.
 
+UserVisibility:
+  type: string
+  enum:
+    - public
+    - protected
+    - private
+  description: Human-side addability visibility used by friend connection policy.
+
+FriendCheckInStrategy:
+  type: string
+  enum:
+    - OPEN
+    - APPROVAL
+    - DEPT_FREE
+  description: Friend request approval strategy used by friend connection policy.
+
 BotStatus:
   type: string
   enum:
@@ -130,6 +146,9 @@ PhysicalBot:
     - updated_at
     - task_claim_mode
     - task_dream_mode
+    - user_visibility
+    - friend_ext
+    - friend_check_in_strategy
   properties:
     bot_id:
       type: string
@@ -178,6 +197,14 @@ PhysicalBot:
     task_dream_mode:
       type: boolean
       description: Task-dream opt-in toggle. Defaults to false when never set.
+    user_visibility:
+      $ref: "#/UserVisibility"
+    friend_ext:
+      type: object
+      additionalProperties: true
+      description: Friend connection policy extension, including department scopes.
+    friend_check_in_strategy:
+      $ref: "#/FriendCheckInStrategy"
   description: >-
     A physical software Bot. descriptor and reachability are normalized even
     when their legacy source columns are incomplete.
@@ -192,6 +219,9 @@ HumanBot:
     - visibility
     - status
     - env
+    - user_visibility
+    - friend_ext
+    - friend_check_in_strategy
     - created_at
     - updated_at
   properties:
@@ -217,6 +247,14 @@ HumanBot:
       minLength: 1
       description: >-
         Immutable creator staff_no. Omitted when a legacy row has no creator.
+    user_visibility:
+      $ref: "#/UserVisibility"
+    friend_ext:
+      type: object
+      additionalProperties: true
+      description: Friend connection policy extension, including department scopes.
+    friend_check_in_strategy:
+      $ref: "#/FriendCheckInStrategy"
     created_at:
       type: integer
       format: int64
@@ -1732,7 +1770,8 @@ FriendConnectionCreateResult:
     edge_ids:
       type: array
       items:
-        type: string
+        type: integer
+        format: int64
     status:
       $ref: "#/FriendConnectionCreateStatus"
     auto_accepted:
@@ -1751,7 +1790,8 @@ FriendConnectionRequest:
     request_id:
       type: string
     edge_id:
-      type: string
+      type: integer
+      format: int64
     from_actor:
       $ref: "#/FriendConnectionActor"
     to_actor:

--- a/src/bcs/api-contracts/v1/openapi/bots.yaml
+++ b/src/bcs/api-contracts/v1/openapi/bots.yaml
@@ -580,3 +580,11 @@ UpdateBotRequest:
       description: >-
         Task-dream opt-in toggle. Omit to leave the stored value unchanged;
         defaults to false when never set. Physical bots only.
+    user_visibility:
+      $ref: ../domain-models.yaml#/UserVisibility
+    friend_ext:
+      type: object
+      additionalProperties: true
+      description: Friend connection policy extension, including department scopes.
+    friend_check_in_strategy:
+      $ref: ../domain-models.yaml#/FriendCheckInStrategy

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/bot.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/dto/bot.rs
@@ -1,8 +1,9 @@
 use bcs_service_api::application::v1::{
     BotCandidatePurpose, BotDescriptorPatch, BotKind, BotPatch, BotReachability, BotSkill,
-    BotStatus, BotVisibility,
+    BotStatus, BotVisibility, FriendCheckInStrategy, UserVisibility,
 };
 use serde::Deserialize;
+use serde_json::{Map, Value};
 
 fn default_limit() -> u64 {
     20
@@ -92,6 +93,12 @@ pub struct UpdateBotRequest {
     pub task_claim_mode: Option<bool>,
     #[serde(default)]
     pub task_dream_mode: Option<bool>,
+    #[serde(default)]
+    pub user_visibility: Option<UserVisibility>,
+    #[serde(default)]
+    pub friend_ext: Option<Map<String, Value>>,
+    #[serde(default)]
+    pub friend_check_in_strategy: Option<FriendCheckInStrategy>,
 }
 
 impl From<UpdateBotRequest> for BotPatch {
@@ -103,6 +110,9 @@ impl From<UpdateBotRequest> for BotPatch {
             descriptor: value.descriptor.map(BotDescriptorPatch::from),
             task_claim_mode: value.task_claim_mode,
             task_dream_mode: value.task_dream_mode,
+            user_visibility: value.user_visibility,
+            friend_ext: value.friend_ext,
+            friend_check_in_strategy: value.friend_check_in_strategy,
         }
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/bot_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/bot_routes.rs
@@ -406,7 +406,10 @@ async fn all_six_bot_routes_forward_verified_human_and_contract_inputs() {
                 "name": "Renamed",
                 "visibility": "protected",
                 "status": "hidden",
-                "descriptor": {"domains": [], "skills": [{"name": "plan"}]}
+                "descriptor": {"domains": [], "skills": [{"name": "plan"}]},
+                "user_visibility": "private",
+                "friend_ext": {"no_check_scope_friend_deps": ["dep-1"]},
+                "friend_check_in_strategy": "DEPT_FREE"
             }),
         ))
         .await
@@ -422,9 +425,13 @@ async fn all_six_bot_routes_forward_verified_human_and_contract_inputs() {
         .await
         .expect("mine response");
     assert_eq!(mine.status(), StatusCode::OK);
+    let mine_body = response_json(mine).await;
+    assert_eq!(mine_body["data"]["items"][0]["kind"], "human");
+    assert_eq!(mine_body["data"]["items"][0]["user_visibility"], "protected");
+    assert_eq!(mine_body["data"]["items"][0]["friend_ext"], json!({}));
     assert_eq!(
-        response_json(mine).await["data"]["items"][0]["kind"],
-        "human"
+        mine_body["data"]["items"][0]["friend_check_in_strategy"],
+        "APPROVAL"
     );
 
     let candidates = service.candidates.lock().expect("candidates lock");
@@ -464,6 +471,15 @@ async fn all_six_bot_routes_forward_verified_human_and_contract_inputs() {
     let update = update.as_ref().expect("update command");
     assert_eq!(update.patch.visibility, Some(BotVisibility::Protected));
     assert_eq!(update.patch.status, Some(BotStatus::Hidden));
+    assert_eq!(update.patch.user_visibility, Some(UserVisibility::Private));
+    assert_eq!(
+        update.patch.friend_check_in_strategy,
+        Some(FriendCheckInStrategy::DeptFree)
+    );
+    assert_eq!(
+        update.patch.friend_ext.as_ref().expect("friend ext")["no_check_scope_friend_deps"],
+        json!(["dep-1"])
+    );
     assert_eq!(
         update
             .patch
@@ -637,6 +653,9 @@ fn physical_bot() -> PhysicalBot {
         agent_code: Some("agent-code".to_string()),
         task_claim_mode: false,
         task_dream_mode: false,
+        user_visibility: UserVisibility::Protected,
+        friend_ext: Default::default(),
+        friend_check_in_strategy: FriendCheckInStrategy::Approval,
         created_at: 1,
         updated_at: 2,
     }
@@ -651,6 +670,9 @@ fn human_bot() -> HumanBot {
         status: BotStatus::Online,
         env: "dev".to_string(),
         created_by: Some("staff-1".to_string()),
+        user_visibility: UserVisibility::Protected,
+        friend_ext: Default::default(),
+        friend_check_in_strategy: FriendCheckInStrategy::Approval,
         created_at: 1,
         updated_at: 2,
     }

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/friendship_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/friendship_routes.rs
@@ -458,8 +458,8 @@ impl FriendConnectionService for FakeFriendConnectionService {
 
 fn friend_connection_create_result() -> FriendConnectionCreateResult {
     FriendConnectionCreateResult {
-        request_ids: vec!["req-1".into()],
-        edge_ids: vec!["edge-1".into()],
+        request_ids: vec!["1".to_string()],
+        edge_ids: vec![11],
         status: FriendConnectionCreateStatus::Pending,
         auto_accepted: false,
     }
@@ -467,8 +467,8 @@ fn friend_connection_create_result() -> FriendConnectionCreateResult {
 
 fn friend_connection_request_view() -> FriendConnectionRequestView {
     FriendConnectionRequestView {
-        request_id: "req-1".into(),
-        edge_id: Some("edge-1".into()),
+        request_id: "1".to_string(),
+        edge_id: Some(11),
         from_actor: FriendConnectionActor {
             actor_type: FriendConnectionActorType::Bot,
             id: "bot-1".into(),
@@ -851,8 +851,8 @@ fn openapi_test_router(service: Arc<FakeFriendConnectionService>) -> axum::Route
 async fn openapi_friend_connection_routes_forward_commands_and_serialize_responses() {
     let service = Arc::new(FakeFriendConnectionService::default());
     *service.create_result.lock().expect("create result lock") = FriendConnectionCreateResult {
-        request_ids: vec!["req-99".into()],
-        edge_ids: vec!["edge-99".into()],
+        request_ids: vec!["99".to_string()],
+        edge_ids: vec![199],
         status: FriendConnectionCreateStatus::Approved,
         auto_accepted: true,
     };
@@ -875,8 +875,8 @@ async fn openapi_friend_connection_routes_forward_commands_and_serialize_respons
     let body = response_json(create_response).await;
     assert_eq!(body["code"], 20_100);
     assert_eq!(body["data"]["status"], "approved");
-    assert_eq!(body["data"]["request_ids"], serde_json::json!(["req-99"]));
-    assert_eq!(body["data"]["edge_ids"], serde_json::json!(["edge-99"]));
+    assert_eq!(body["data"]["request_ids"], serde_json::json!(["99"]));
+    assert_eq!(body["data"]["edge_ids"], serde_json::json!([199]));
     assert_eq!(body["data"]["auto_accepted"], true);
     {
         let created = service.created_request.lock().expect("create request lock");
@@ -972,7 +972,7 @@ async fn openapi_friend_connection_routes_support_default_query_values_and_optio
     let reject_response = app
         .oneshot(authenticated_request(
             "POST",
-            "/openapi/v1/collaboration/friend-connections/requests/req-2/reject",
+            "/openapi/v1/collaboration/friend-connections/requests/2/reject",
             serde_json::json!({"reason": "no thanks"}),
         ))
         .await
@@ -982,7 +982,7 @@ async fn openapi_friend_connection_routes_support_default_query_values_and_optio
         let rejected = service.rejected_request.lock().expect("reject lock");
         let rejected = rejected.as_ref().expect("reject command");
         assert_eq!(rejected.reason.as_deref(), Some("no thanks"));
-        assert_eq!(rejected.request_id, "req-2");
+        assert_eq!(rejected.request_id, "2".to_string());
     }
 }
 
@@ -995,19 +995,19 @@ async fn openapi_friend_connection_routes_forward_decisions_and_delete() {
         .clone()
         .oneshot(authenticated_request(
             "POST",
-            "/openapi/v1/collaboration/friend-connections/requests/req-1/accept",
+            "/openapi/v1/collaboration/friend-connections/requests/1/accept",
             Value::Null,
         ))
         .await
         .expect("accept response");
     assert_eq!(accept_response.status(), StatusCode::OK);
     let body = response_json(accept_response).await;
-    assert_eq!(body["data"]["request_id"], "req-1");
+    assert_eq!(body["data"]["request_id"], "1");
     {
         let accepted = service.accepted_request.lock().expect("accept lock");
         let accepted = accepted.as_ref().expect("accept command");
         assert_eq!(accepted.caller.user.as_ref().expect("user").id, "staff-1");
-        assert_eq!(accepted.request_id, "req-1");
+        assert_eq!(accepted.request_id, "1".to_string());
     }
 
     let reject_response = app
@@ -1015,7 +1015,7 @@ async fn openapi_friend_connection_routes_forward_decisions_and_delete() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/openapi/v1/collaboration/friend-connections/requests/req-1/reject")
+                .uri("/openapi/v1/collaboration/friend-connections/requests/1/reject")
                 .header("x-test-auth", "yes")
                 .header("x-request-id", "request-123")
                 .body(Body::empty())
@@ -1034,7 +1034,7 @@ async fn openapi_friend_connection_routes_forward_decisions_and_delete() {
         .clone()
         .oneshot(authenticated_request(
             "POST",
-            "/openapi/v1/collaboration/friend-connections/requests/req-1/cancel",
+            "/openapi/v1/collaboration/friend-connections/requests/1/cancel",
             Value::Null,
         ))
         .await
@@ -1043,7 +1043,7 @@ async fn openapi_friend_connection_routes_forward_decisions_and_delete() {
     {
         let cancelled = service.cancelled_request.lock().expect("cancel lock");
         let cancelled = cancelled.as_ref().expect("cancel command");
-        assert_eq!(cancelled.request_id, "req-1");
+        assert_eq!(cancelled.request_id, "1".to_string());
     }
 
     let delete_response = app

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bots.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bots.rs
@@ -11,11 +11,14 @@ use bcs_protocol::{
 use bcs_service_api::{
     ActorKind, ActorStatus, BotConnectCommand, BotDetailCommand, BotDetailResult, BotLeaveCommand,
     BotListCommand, BotListEntry, BotPagedListCommand, BotQueryByIdsCommand, BotQueryEntry,
+    application::v1::{
+        ApplicationError, BotInternalAttributes, FriendCheckInStrategy, UserVisibility,
+    },
     BotStatusUpdateCommand, BotUseCaseError, BotVisibilityCommand, BotVisibilityQueryCommand,
     BotVisibilityQueryResult, ConnectError, MyBotsCommand, SearchBotsCommand, ServiceError,
 };
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 use crate::error::HttpAdapterError;
 use crate::mapping::capabilities::{
@@ -449,7 +452,21 @@ fn bot_visibility_to_json(result: BotVisibilityQueryResult) -> Value {
     })
 }
 
-/// `GET /bots/search` — bot search with name fuzzy + keyword filtering + is_friend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FriendshipFilter {
+    All,
+    Friends,
+    NonFriends,
+}
+
+#[derive(Debug, Clone)]
+struct BotSearchPolicy {
+    user_visibility: String,
+    friend_ext: Map<String, Value>,
+    friend_check_in_strategy: String,
+}
+
+/// `GET /bots/search` — bot search with name fuzzy + keyword filtering + friendship filters.
 /// Spec: docs/superpowers/specs/2026-08-20-bot-search-endpoint-design.md
 pub async fn search_bots(
     State(state): State<HttpAppState>,
@@ -467,15 +484,16 @@ pub async fn search_bots(
             )))
         }
     };
-    let visibility = match q.visibility.as_deref() {
-        Some(v) if matches!(v, "public" | "protected" | "private") => Some(v.to_string()),
-        Some(v) => {
-            return Err(HttpAdapterError::BadRequest(format!(
-                "visibility must be public|protected|private, got '{v}'"
-            )))
-        }
-        None => None,
-    };
+    let visibility = parse_csv_filter(
+        q.visibility.as_deref(),
+        "visibility",
+        &["public", "protected", "private"],
+    )?;
+    let user_visibility = parse_csv_filter(
+        q.user_visibility.as_deref(),
+        "user_visibility",
+        &["public", "protected", "private"],
+    )?;
     let status = match q.status.as_deref() {
         Some("online") => Some(ActorStatus::Online),
         Some("hidden") => Some(ActorStatus::Hidden),
@@ -486,18 +504,54 @@ pub async fn search_bots(
         }
         None => None,
     };
+    let friendship = parse_friendship_filter(q.friendship.as_deref(), q.is_friend)?;
 
     // ── Resolve caller (optional Bearer) ───────────────────────────────────────
     let caller_id = caller_actor_id_from_headers(&state, &headers, &uri).await;
 
-    // ── Effective visibility scope (spec §3.6.2) ───────────────────────────────
-    // No Bearer → force public (ignore any client-provided visibility). Bearer +
-    // explicit visibility → respect it. Bearer + no visibility → None (service
-    // yields the default public+protected scope).
-    let effective_visibility = match (&caller_id, &visibility) {
-        (None, _) => Some("public".to_string()),
-        (Some(_), v) => v.clone(),
+    // ── Resolve explicit friendship viewer ─────────────────────────────────────
+    let viewer_actor_id = match (&q.viewer_actor_type, &q.viewer_actor_id) {
+        (None, None) => None,
+        (Some(actor_type), Some(actor_id)) => {
+            let actor_type = actor_type.trim();
+            if !matches!(actor_type, "human" | "bot") {
+                return Err(HttpAdapterError::BadRequest(format!(
+                    "viewer_actor_type must be human|bot, got '{actor_type}'"
+                )));
+            }
+            let actor_id = actor_id.trim();
+            if actor_id.is_empty() {
+                return Err(HttpAdapterError::BadRequest(
+                    "viewer_actor_id must not be empty".to_string(),
+                ));
+            }
+            Some(actor_id.to_string())
+        }
+        _ => {
+            return Err(HttpAdapterError::BadRequest(
+                "viewer_actor_type and viewer_actor_id must be provided together".to_string(),
+            ));
+        }
     };
+    if matches!(friendship, FriendshipFilter::Friends | FriendshipFilter::NonFriends)
+        && viewer_actor_id.is_none()
+    {
+        return Err(HttpAdapterError::BadRequest(
+            "friendship filter requires viewer_actor_type and viewer_actor_id".to_string(),
+        ));
+    }
+
+    // ── Effective visibility scope (spec §3.6.2) ───────────────────────────────
+    // No Bearer → only public can be returned. If the caller provided a visibility
+    // filter, intersect it with public so unsupported combinations produce an
+    // empty result instead of widening scope. Bearer + explicit visibility →
+    // respect it. Bearer + no visibility → None (service yields public+protected).
+    let effective_visibility = match (&caller_id, visibility) {
+        (None, None) => Some(vec!["public".to_string()]),
+        (None, Some(values)) => Some(values.into_iter().filter(|v| v == "public").collect()),
+        (Some(_), values) => values,
+    };
+    let effective_visibility_filter = effective_visibility.clone();
 
     // ── Query the registry via the application service (carries status/online) ─
     let result = state
@@ -513,46 +567,67 @@ pub async fn search_bots(
         .await
         .map_err(bot_use_case_error_to_http)?;
 
-    // ── Friend set from the caller's edge_grants (spec §3.7) ───────────────────
-    // Anonymous callers are friends with nobody (empty set), so the is_friend
-    // filter naturally resolves is_friend=true → none, is_friend=false → all.
-    let friend_ids: std::collections::HashSet<String> = match &caller_id {
-        Some(caller) => match state.connect.list_friends(caller).await {
-            Ok(entries) => entries.into_iter().map(|e| e.actor_id).collect(),
-            Err(_) => std::collections::HashSet::new(),
-        },
-        None => std::collections::HashSet::new(),
+    // ── Friend set from the explicit viewer's edge_grants ──────────────────────
+    let needs_friend_set = viewer_actor_id.is_some();
+    let friend_ids: std::collections::HashSet<String> = match (&viewer_actor_id, needs_friend_set) {
+        (Some(viewer), true) => state
+            .connect
+            .list_friends(viewer)
+            .await
+            .map_err(HttpAdapterError::Service)?
+            .into_iter()
+            .map(|e| e.actor_id)
+            .collect(),
+        _ => std::collections::HashSet::new(),
     };
 
-    // ── is_friend post-filter (caller-dependent) + pagination ──────────────────
-    let filtered: Vec<BotQueryEntry> = result
-        .items
-        .into_iter()
-        .filter(|bot| match q.is_friend {
-            Some(want_friend) => friend_ids.contains(&bot.bot_uuid) == want_friend,
-            None => true,
-        })
-        .collect();
+    // ── Enrich policy, post-filter viewer-dependent fields, then paginate ──────
+    let mut filtered: Vec<(BotQueryEntry, BotSearchPolicy)> = Vec::new();
+    for bot in result.items {
+        if let Some(wants) = effective_visibility_filter.as_ref() {
+            if !wants.iter().any(|want| bot.visibility == *want) {
+                continue;
+            }
+        }
+        let policy = load_bot_search_policy(&state, &bot.bot_uuid).await?;
+        if let Some(wants) = user_visibility.as_ref() {
+            if !wants.iter().any(|want| policy.user_visibility == *want) {
+                continue;
+            }
+        }
+        let is_friend = friend_ids.contains(&bot.bot_uuid);
+        let friendship_matches = match friendship {
+            FriendshipFilter::All => true,
+            FriendshipFilter::Friends => is_friend,
+            FriendshipFilter::NonFriends => !is_friend,
+        };
+        if friendship_matches {
+            filtered.push((bot, policy));
+        }
+    }
 
     let total = filtered.len() as u64;
-    let page_items: Vec<BotQueryEntry> = filtered
+    let page_items: Vec<(BotQueryEntry, BotSearchPolicy)> = filtered
         .into_iter()
         .skip(offset as usize)
         .take(limit as usize)
         .collect();
 
-    // ── Build response (is_friend field only for authenticated callers) ────────
+    // ── Build response (is_friend field only for an explicit viewer) ───────────
     let items: Vec<BotSearchEntry> = page_items
         .into_iter()
-        .map(|bot| BotSearchEntry {
+        .map(|(bot, policy)| BotSearchEntry {
             bot_uuid: bot.bot_uuid.clone(),
             name: bot.capabilities.name.clone(),
             summary: bot.capabilities.summary.clone(),
             visibility: bot.visibility,
+            user_visibility: policy.user_visibility,
+            friend_ext: policy.friend_ext,
+            friend_check_in_strategy: policy.friend_check_in_strategy,
             status: actor_status_to_wire(bot.status).to_string(),
             actor_kind: actor_kind_to_wire(bot.actor_kind).to_string(),
             is_online: bot.dynamic_status.status == "active",
-            is_friend: caller_id.as_ref().map(|_| friend_ids.contains(&bot.bot_uuid)),
+            is_friend: viewer_actor_id.as_ref().map(|_| friend_ids.contains(&bot.bot_uuid)),
         })
         .collect();
 
@@ -562,6 +637,123 @@ pub async fn search_bots(
         "offset": offset,
         "limit": limit,
     })))
+}
+
+fn parse_csv_filter(
+    raw: Option<&str>,
+    name: &str,
+    allowed: &[&str],
+) -> Result<Option<Vec<String>>, HttpAdapterError> {
+    let Some(raw) = raw else { return Ok(None) };
+    let mut values = Vec::new();
+    for part in raw.split(',') {
+        let value = part.trim();
+        if value.is_empty() || !allowed.contains(&value) {
+            return Err(HttpAdapterError::BadRequest(format!(
+                "{name} must be {}, got '{raw}'",
+                allowed.join("|")
+            )));
+        }
+        if !values.iter().any(|existing| existing == value) {
+            values.push(value.to_string());
+        }
+    }
+    Ok(Some(values))
+}
+
+fn parse_friendship_filter(
+    friendship: Option<&str>,
+    is_friend: Option<bool>,
+) -> Result<FriendshipFilter, HttpAdapterError> {
+    if friendship.is_some() && is_friend.is_some() {
+        return Err(HttpAdapterError::BadRequest(
+            "friendship and deprecated is_friend must not be provided together".to_string(),
+        ));
+    }
+    if let Some(is_friend) = is_friend {
+        return Ok(if is_friend {
+            FriendshipFilter::Friends
+        } else {
+            FriendshipFilter::NonFriends
+        });
+    }
+    match friendship.unwrap_or("all") {
+        "all" => Ok(FriendshipFilter::All),
+        "friends" => Ok(FriendshipFilter::Friends),
+        "non_friends" => Ok(FriendshipFilter::NonFriends),
+        value => Err(HttpAdapterError::BadRequest(format!(
+            "friendship must be all|friends|non_friends, got '{value}'"
+        ))),
+    }
+}
+
+async fn load_bot_search_policy(
+    state: &HttpAppState,
+    bot_id: &str,
+) -> Result<BotSearchPolicy, HttpAdapterError> {
+    let Some(service) = state.internal_bot_attributes_service.as_ref() else {
+        return Ok(default_bot_search_policy());
+    };
+    match service.get(bot_id.to_string()).await {
+        Ok(attributes) => Ok(bot_search_policy_from_attributes(attributes)),
+        Err(ApplicationError::NotFound { .. }) => Ok(default_bot_search_policy()),
+        Err(ApplicationError::InvalidInput { message, .. }) => {
+            Err(HttpAdapterError::BadRequest(message))
+        }
+        Err(ApplicationError::Unauthenticated) => Err(HttpAdapterError::Unauthorized(
+            "authentication is required".to_string(),
+        )),
+        Err(ApplicationError::Forbidden(message) | ApplicationError::ForbiddenCode { message, .. }) => {
+            Err(HttpAdapterError::Forbidden(message))
+        }
+        Err(ApplicationError::Conflict { message, .. }) => Err(HttpAdapterError::Conflict(message)),
+        Err(ApplicationError::Gone { message, .. }) => Err(HttpAdapterError::Gone(message)),
+        Err(ApplicationError::QuotaExceeded { message, .. })
+        | Err(ApplicationError::PayloadTooLarge { message, .. })
+        | Err(ApplicationError::Unprocessable { message, .. })
+        | Err(ApplicationError::BadGateway { message, .. })
+        | Err(ApplicationError::Internal(message)) => Err(HttpAdapterError::Service(
+            ServiceError::InternalError(message),
+        )),
+    }
+}
+
+fn bot_search_policy_from_attributes(attributes: BotInternalAttributes) -> BotSearchPolicy {
+    BotSearchPolicy {
+        user_visibility: user_visibility_to_wire(attributes.user_visibility).to_string(),
+        friend_ext: attributes.friend_ext,
+        friend_check_in_strategy: friend_check_in_strategy_to_wire(
+            attributes.friend_check_in_strategy,
+        )
+        .to_string(),
+    }
+}
+
+fn default_bot_search_policy() -> BotSearchPolicy {
+    BotSearchPolicy {
+        user_visibility: user_visibility_to_wire(UserVisibility::Protected).to_string(),
+        friend_ext: Map::new(),
+        friend_check_in_strategy: friend_check_in_strategy_to_wire(
+            FriendCheckInStrategy::Approval,
+        )
+        .to_string(),
+    }
+}
+
+fn user_visibility_to_wire(value: UserVisibility) -> &'static str {
+    match value {
+        UserVisibility::Public => "public",
+        UserVisibility::Protected => "protected",
+        UserVisibility::Private => "private",
+    }
+}
+
+fn friend_check_in_strategy_to_wire(value: FriendCheckInStrategy) -> &'static str {
+    match value {
+        FriendCheckInStrategy::Open => "OPEN",
+        FriendCheckInStrategy::Approval => "APPROVAL",
+        FriendCheckInStrategy::DeptFree => "DEPT_FREE",
+    }
 }
 
 async fn resolve_bot_caller(

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bots_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bots_contract.rs
@@ -4,6 +4,7 @@ use axum::{
     body::{Body, to_bytes},
     http::{Request, StatusCode},
 };
+use async_trait::async_trait;
 use bcs_auth_api::{AuthPluginChain, AuthPrincipal};
 use bcs_auth_local::StaticAuthPlugin;
 use bcs_bot::{Bot, BotCore};
@@ -11,20 +12,116 @@ use bcs_http::{
     router::build_router,
     state::{ChainUserIdentityPort, HttpAppState},
 };
+use bcs_domain::edge_permission::{FriendListEntry, PermissionRequest, RequestStatus};
 use bcs_service_api::{
+    application::connect::{
+        ConnectResult, ConnectService, ConnectStatus, RequestDirection, RequestsPage,
+    },
+    application::v1::{
+        ApplicationError, BotInternalAttributes, FriendCheckInStrategy,
+        InternalBotAttributesService, UserVisibility,
+    },
     ActorKind, ActorStatus, BotConnectCommand, BotConnectResult, BotDetailCommand, BotDetailResult,
     BotDynamicStatus, BotLeaveResult, BotListCommand, BotListEntry, BotListResult,
     BotManagementService, BotPagedListResult, BotQueryByIdsResult, BotQueryEntry, BotQueryService,
     BotRegistryCoreService, BotSearchResult, BotStatusUpdateCommand, BotStatusUpdateResult,
     BotUseCaseError, BotVisibilityCommand, BotVisibilityQueryResult, BotVisibilityResult,
-    ConnectError, DynamicStatusResponse, ServiceError, Skill,
+    ConnectError, DynamicStatusResponse, ServiceError, ServiceResult, Skill,
 };
 use bcs_services_container::Services;
 use serde_json::Value;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use support::bot_use_cases::{RecordingBotManagementService, RecordingBotQueryService};
 use tempfile::TempDir;
 use tower::ServiceExt;
+
+struct RecordingSearchPolicyService {
+    attributes: HashMap<String, BotInternalAttributes>,
+}
+
+#[async_trait]
+impl InternalBotAttributesService for RecordingSearchPolicyService {
+    async fn get(&self, bot_id: String) -> Result<BotInternalAttributes, ApplicationError> {
+        self.attributes
+            .get(&bot_id)
+            .cloned()
+            .ok_or_else(|| ApplicationError::not_found("bot_not_found", "bot not found"))
+    }
+
+    async fn patch(
+        &self,
+        _command: bcs_service_api::application::v1::PatchBotInternalAttributes,
+    ) -> Result<BotInternalAttributes, ApplicationError> {
+        Err(ApplicationError::internal("patch is not configured"))
+    }
+}
+
+struct RecordingSearchConnectService {
+    list_friends_commands: tokio::sync::Mutex<Vec<String>>,
+    friends: Vec<FriendListEntry>,
+}
+
+impl RecordingSearchConnectService {
+    fn with_friends(friends: Vec<FriendListEntry>) -> Self {
+        Self {
+            list_friends_commands: tokio::sync::Mutex::new(Vec::new()),
+            friends,
+        }
+    }
+}
+
+#[async_trait]
+impl ConnectService for RecordingSearchConnectService {
+    async fn create_connect(
+        &self,
+        _: &str,
+        _: &str,
+        _: Option<String>,
+    ) -> ServiceResult<ConnectResult> {
+        Ok(ConnectResult {
+            request_ids: vec![],
+            edge_ids: vec![],
+            status: ConnectStatus::Pending,
+            auto_accepted: false,
+        })
+    }
+
+    async fn approve(&self, _: &str, _: &str) -> ServiceResult<Vec<u64>> {
+        Ok(vec![])
+    }
+
+    async fn reject(&self, _: &str, _: &str, _: Option<String>) -> ServiceResult<()> {
+        Ok(())
+    }
+
+    async fn cancel(&self, _: &str) -> ServiceResult<()> {
+        Ok(())
+    }
+
+    async fn get_request(&self, _: &str) -> ServiceResult<PermissionRequest> {
+        Err(ServiceError::FriendRequestNotFound("not configured".to_string()))
+    }
+
+    async fn revoke_friend(&self, _: &str, _: &str) -> ServiceResult<Vec<u64>> {
+        Ok(vec![])
+    }
+
+    async fn list_friends(&self, actor: &str) -> ServiceResult<Vec<FriendListEntry>> {
+        self.list_friends_commands.lock().await.push(actor.to_string());
+        Ok(self.friends.clone())
+    }
+
+    async fn list_requests(
+        &self,
+        _: &str,
+        _: RequestDirection,
+        _: Option<RequestStatus>,
+        page: u32,
+        page_size: u32,
+    ) -> ServiceResult<RequestsPage> {
+        Ok(RequestsPage { items: vec![], total: 0, page, page_size })
+    }
+}
 
 fn static_auth_chain(staff_no: &str, nick_name: &str) -> Arc<AuthPluginChain> {
     let principal = AuthPrincipal {
@@ -1188,8 +1285,8 @@ async fn search_bots_route_forces_public_scope_without_bearer() {
     // No user-identity port ⇒ anonymous caller.
     let app = build_router(HttpAppState::new(services));
 
-    // Client tries visibility=protected, but without a Bearer it must be forced
-    // to public (spec §3.6.2).
+    // Client tries visibility=protected, but without a Bearer it is intersected
+    // with the anonymous public-only scope, producing an empty visibility set.
     let response = app
         .oneshot(
             Request::builder()
@@ -1203,25 +1300,18 @@ async fn search_bots_route_forces_public_scope_without_bearer() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let json: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["total"], 2);
+    assert_eq!(json["total"], 0);
     assert_eq!(json["offset"], 0);
     assert_eq!(json["limit"], 20);
-    let items = json["items"].as_array().unwrap();
-    assert_eq!(items.len(), 2);
-    // Anonymous callers do not get the is_friend field (spec §3.4).
-    assert!(items[0].get("is_friend").is_none());
-    // status / visibility / is_online are surfaced from the registry query.
-    assert_eq!(items[0]["status"], "online");
-    assert_eq!(items[0]["visibility"], "public");
-    assert_eq!(items[0]["is_online"], true);
+    assert_eq!(json["items"].as_array().unwrap().len(), 0);
 
     let commands = query.search_commands.lock().await;
     assert_eq!(commands.len(), 1);
-    assert_eq!(commands[0].visibility.as_deref(), Some("public"));
+    assert!(commands[0].visibility.as_ref().unwrap().is_empty());
 }
 
 #[tokio::test]
-async fn search_bots_route_includes_is_friend_field_with_bearer() {
+async fn search_bots_route_omits_is_friend_without_explicit_viewer() {
     let query = Arc::new(RecordingBotQueryService {
         search_result: Ok(BotSearchResult {
             items: vec![query_entry("bot-alpha")],
@@ -1235,9 +1325,8 @@ async fn search_bots_route_includes_is_friend_field_with_bearer() {
         ChainUserIdentityPort::new(chain),
     )));
 
-    // No visibility param ⇒ default public+protected scope (None), and the
-    // is_friend field is included (false, since the noop connect service knows
-    // no friends).
+    // No visibility param with authenticated caller still controls visibility,
+    // but friendship is only calculated when explicit viewer params are present.
     let response = app
         .oneshot(
             Request::builder()
@@ -1253,12 +1342,78 @@ async fn search_bots_route_includes_is_friend_field_with_bearer() {
     let json: Value = serde_json::from_slice(&body).unwrap();
     let items = json["items"].as_array().unwrap();
     assert_eq!(items.len(), 1);
-    assert_eq!(items[0]["is_friend"], false);
+    assert!(items[0].get("is_friend").is_none());
 
     let commands = query.search_commands.lock().await;
     assert_eq!(commands.len(), 1);
     assert!(commands[0].visibility.is_none());
     assert_eq!(commands[0].requester_actor_id.as_deref(), Some("human_alice"));
+}
+
+#[tokio::test]
+async fn search_bots_route_uses_explicit_viewer_for_is_friend_filter() {
+    let query = Arc::new(RecordingBotQueryService {
+        search_result: Ok(BotSearchResult {
+            items: vec![query_entry("bot-alpha"), query_entry("bot-beta")],
+            total: 2,
+        }),
+        ..Default::default()
+    });
+    let connect = Arc::new(RecordingSearchConnectService::with_friends(vec![FriendListEntry {
+        actor_id: "bot-alpha".to_string(),
+        name: Some("Alpha".to_string()),
+        summary: Some("friend".to_string()),
+        is_online: true,
+        kind: ActorKind::Bot,
+    }]));
+    let services = Services::builder().bot_query(query.clone()).build_for_test();
+    let app = build_router(HttpAppState::new(services).with_connect(connect.clone()));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/bots/search?viewer_actor_type=bot&viewer_actor_id=viewer-bot&friendship=friends")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total"], 1);
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["bot_uuid"], "bot-alpha");
+    assert_eq!(items[0]["is_friend"], true);
+    assert_eq!(
+        connect.list_friends_commands.lock().await.as_slice(),
+        ["viewer-bot"]
+    );
+}
+
+#[tokio::test]
+async fn search_bots_route_rejects_friendship_filter_without_explicit_viewer() {
+    let query = Arc::new(RecordingBotQueryService {
+        search_result: Ok(BotSearchResult { items: vec![], total: 0 }),
+        ..Default::default()
+    });
+    let services = Services::builder().bot_query(query.clone()).build_for_test();
+    let app = build_router(HttpAppState::new(services));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/bots/search?friendship=friends")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert!(query.search_commands.lock().await.is_empty());
 }
 
 #[tokio::test]
@@ -1284,6 +1439,136 @@ async fn search_bots_route_forwards_tc_bot_filter_param() {
     let commands = query.search_commands.lock().await;
     assert_eq!(commands.len(), 1);
     assert_eq!(commands[0].tc_bot, Some(true));
+}
+
+
+#[tokio::test]
+async fn search_bots_route_accepts_multi_visibility_and_returns_friend_policy_fields() {
+    let query = Arc::new(RecordingBotQueryService {
+        search_result: Ok(BotSearchResult {
+            items: vec![query_entry("bot-alpha")],
+            total: 1,
+        }),
+        ..Default::default()
+    });
+    let services = Services::builder().bot_query(query.clone()).build_for_test();
+    let chain = static_auth_chain("alice", "Alice");
+    let app = build_router(HttpAppState::new(services).with_user_identity(Arc::new(
+        ChainUserIdentityPort::new(chain),
+    )));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/bots/search?visibility=public,protected")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["user_visibility"], "protected");
+    assert_eq!(items[0]["friend_ext"], serde_json::json!({}));
+    assert_eq!(items[0]["friend_check_in_strategy"], "APPROVAL");
+
+    let commands = query.search_commands.lock().await;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(
+        commands[0].visibility.as_ref().unwrap(),
+        &vec!["public".to_string(), "protected".to_string()]
+    );
+}
+
+
+#[tokio::test]
+async fn search_bots_route_filters_and_returns_internal_user_visibility() {
+    let query = Arc::new(RecordingBotQueryService {
+        search_result: Ok(BotSearchResult {
+            items: vec![query_entry("bot-alpha"), query_entry("bot-beta")],
+            total: 2,
+        }),
+        ..Default::default()
+    });
+    let mut attributes = HashMap::new();
+    attributes.insert(
+        "bot-alpha".to_string(),
+        BotInternalAttributes {
+            visibility: "public".to_string(),
+            user_visibility: UserVisibility::Public,
+            friend_ext: serde_json::json!({"view_scope_user_friend_deps": ["dep-1"]})
+                .as_object()
+                .unwrap()
+                .clone(),
+            friend_check_in_strategy: FriendCheckInStrategy::Open,
+        },
+    );
+    attributes.insert(
+        "bot-beta".to_string(),
+        BotInternalAttributes {
+            visibility: "public".to_string(),
+            user_visibility: UserVisibility::Private,
+            friend_ext: serde_json::Map::new(),
+            friend_check_in_strategy: FriendCheckInStrategy::Approval,
+        },
+    );
+    let services = Services::builder().bot_query(query.clone()).build_for_test();
+    let app = build_router(HttpAppState::new(services).with_internal_bot_attributes_service(
+        Arc::new(RecordingSearchPolicyService { attributes }),
+    ));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/bots/search?user_visibility=public")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total"], 1);
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items[0]["bot_uuid"], "bot-alpha");
+    assert_eq!(items[0]["user_visibility"], "public");
+    assert_eq!(items[0]["friend_ext"]["view_scope_user_friend_deps"][0], "dep-1");
+    assert_eq!(items[0]["friend_check_in_strategy"], "OPEN");
+}
+
+#[tokio::test]
+async fn search_bots_route_filters_default_user_visibility() {
+    let query = Arc::new(RecordingBotQueryService {
+        search_result: Ok(BotSearchResult {
+            items: vec![query_entry("bot-alpha")],
+            total: 1,
+        }),
+        ..Default::default()
+    });
+    let services = Services::builder().bot_query(query.clone()).build_for_test();
+    let app = build_router(HttpAppState::new(services));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/bots/search?user_visibility=private")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total"], 0);
+    assert_eq!(json["items"].as_array().unwrap().len(), 0);
 }
 
 fn query_entry(bot_uuid: &str) -> BotQueryEntry {

--- a/src/bcs/crates/adapters/http/bcs-http/tests/friend_connections_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/friend_connections_contract.rs
@@ -51,8 +51,8 @@ impl Default for RecordingConnectService {
             list_friends_commands: Mutex::new(Vec::new()),
             list_requests_commands: Mutex::new(Vec::new()),
             create_result: ConnectResult {
-                request_ids: vec!["req-1".to_string()],
-                edge_ids: vec!["edge-1".to_string()],
+                request_ids: vec!["1".to_string()],
+                edge_ids: vec![11],
                 status: ConnectStatus::Pending,
                 auto_accepted: false,
             },
@@ -88,12 +88,12 @@ impl ConnectService for RecordingConnectService {
         Ok(self.create_result.clone())
     }
 
-    async fn approve(&self, request_id: &str, decider: &str) -> ServiceResult<Vec<String>> {
+    async fn approve(&self, request_id: &str, decider: &str) -> ServiceResult<Vec<u64>> {
         self.approve_commands
             .lock()
             .await
             .push((request_id.to_string(), decider.to_string()));
-        Ok(vec!["edge-approved".to_string()])
+        Ok(vec![211])
     }
 
     async fn reject(
@@ -125,12 +125,12 @@ impl ConnectService for RecordingConnectService {
             })
     }
 
-    async fn revoke_friend(&self, caller: &str, target: &str) -> ServiceResult<Vec<String>> {
+    async fn revoke_friend(&self, caller: &str, target: &str) -> ServiceResult<Vec<u64>> {
         self.revoke_commands
             .lock()
             .await
             .push((caller.to_string(), target.to_string()));
-        Ok(vec!["edge-revoked".to_string()])
+        Ok(vec![311])
     }
 
     async fn list_friends(&self, actor: &str) -> ServiceResult<Vec<FriendListEntry>> {
@@ -399,7 +399,7 @@ async fn friend_connection_request_allows_human_to_act_as_owned_bot() {
     let json: Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["success"], true);
     assert_eq!(json["data"]["status"], "pending");
-    assert_eq!(json["data"]["request_ids"], serde_json::json!(["req-1"]));
+    assert_eq!(json["data"]["request_ids"], serde_json::json!(["1"]));
 
     let calls = connect.create_commands.lock().await;
     assert_eq!(
@@ -556,8 +556,8 @@ async fn friend_connection_list_by_actor_translates_human_actor_kind() {
 async fn friend_connection_request_maps_connect_status_variants_and_accepted_alias() {
     let connect_approved = Arc::new(RecordingConnectService {
         create_result: ConnectResult {
-            request_ids: vec!["req-approved".to_string()],
-            edge_ids: vec!["edge-approved".to_string()],
+            request_ids: vec!["101".to_string()],
+            edge_ids: vec![111],
             status: ConnectStatus::Approved,
             auto_accepted: true,
         },
@@ -598,8 +598,8 @@ async fn friend_connection_request_maps_connect_status_variants_and_accepted_ali
 
     let connect_public = Arc::new(RecordingConnectService {
         create_result: ConnectResult {
-            request_ids: vec!["req-public".to_string()],
-            edge_ids: vec!["edge-public".to_string()],
+            request_ids: vec!["102".to_string()],
+            edge_ids: vec![112],
             status: ConnectStatus::PublicNoEdge,
             auto_accepted: true,
         },
@@ -676,7 +676,7 @@ async fn friend_connection_request_accepts_via_recorded_service() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/collaboration/friend-connections/requests/req-77/accept")
+                .uri("/collaboration/friend-connections/requests/77/accept")
                 .header("authorization", "Bearer caller-token")
                 .body(Body::empty())
                 .unwrap(),
@@ -688,10 +688,10 @@ async fn friend_connection_request_accepts_via_recorded_service() {
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let json: Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["success"], true);
-    assert_eq!(json["data"]["edge_ids"], serde_json::json!(["edge-approved"]));
+    assert_eq!(json["data"]["edge_ids"], serde_json::json!([211]));
 
     let calls = connect.approve_commands.lock().await;
-    assert_eq!(calls.as_slice(), &[("req-77".to_string(), "caller-bot".to_string())]);
+    assert_eq!(calls.as_slice(), &[("77".to_string(), "caller-bot".to_string())]);
 }
 
 #[tokio::test]
@@ -711,7 +711,7 @@ async fn friend_connection_request_rejects_with_reason() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/collaboration/friend-connections/requests/req-88/reject")
+                .uri("/collaboration/friend-connections/requests/88/reject")
                 .header("authorization", "Bearer caller-token")
                 .header("content-type", "application/json")
                 .body(Body::from(serde_json::json!({ "reason": "nope" }).to_string()))
@@ -729,7 +729,7 @@ async fn friend_connection_request_rejects_with_reason() {
     let calls = connect.reject_commands.lock().await;
     assert_eq!(
         calls.as_slice(),
-        &[("req-88".to_string(), "caller-bot".to_string(), Some("nope".to_string()))]
+        &[("88".to_string(), "caller-bot".to_string(), Some("nope".to_string()))]
     );
 }
 
@@ -737,9 +737,9 @@ async fn friend_connection_request_rejects_with_reason() {
 async fn friend_connection_request_cancel_and_revoke_delegate_to_service() {
     let connect = Arc::new(RecordingConnectService::default());
     connect.request_lookup.lock().await.insert(
-        "req-99".to_string(),
+        "99".to_string(),
         PermissionRequest {
-            request_id: "req-99".to_string(),
+            request_id: "99".to_string(),
             edge_id: None,
             env: "dev".to_string(),
             from_id: "caller-bot".to_string(),
@@ -770,7 +770,7 @@ async fn friend_connection_request_cancel_and_revoke_delegate_to_service() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/collaboration/friend-connections/requests/req-99/cancel")
+                .uri("/collaboration/friend-connections/requests/99/cancel")
                 .header("authorization", "Bearer caller-token")
                 .body(Body::empty())
                 .unwrap(),
@@ -796,10 +796,10 @@ async fn friend_connection_request_cancel_and_revoke_delegate_to_service() {
     assert_eq!(revoke_response.status(), StatusCode::OK);
     let revoke_body = to_bytes(revoke_response.into_body(), usize::MAX).await.unwrap();
     let revoke_json: Value = serde_json::from_slice(&revoke_body).unwrap();
-    assert_eq!(revoke_json["data"]["revoked_edges"], serde_json::json!(["edge-revoked"]));
+    assert_eq!(revoke_json["data"]["revoked_edges"], serde_json::json!([311]));
 
     let cancel_calls = connect.cancel_commands.lock().await;
-    assert_eq!(cancel_calls.as_slice(), &["req-99".to_string()]);
+    assert_eq!(cancel_calls.as_slice(), &["99".to_string()]);
     let revoke_calls = connect.revoke_commands.lock().await;
     assert_eq!(revoke_calls.as_slice(), &[("caller-bot".to_string(), "peer-bot".to_string())]);
 }
@@ -809,9 +809,9 @@ async fn friend_connection_request_cancel_and_revoke_delegate_to_service() {
 async fn friend_connection_request_cancel_rejects_other_caller() {
     let connect = Arc::new(RecordingConnectService::default());
     connect.request_lookup.lock().await.insert(
-        "req-100".to_string(),
+        "100".to_string(),
         PermissionRequest {
-            request_id: "req-100".to_string(),
+            request_id: "100".to_string(),
             edge_id: None,
             env: "dev".to_string(),
             from_id: "other-bot".to_string(),
@@ -841,7 +841,7 @@ async fn friend_connection_request_cancel_rejects_other_caller() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/collaboration/friend-connections/requests/req-100/cancel")
+                .uri("/collaboration/friend-connections/requests/100/cancel")
                 .header("authorization", "Bearer caller-token")
                 .body(Body::empty())
                 .unwrap(),

--- a/src/bcs/crates/application/v1/bcs-app-bot/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-bot/src/lib.rs
@@ -234,6 +234,9 @@ impl BotServiceImpl {
                         status,
                         env: record.env,
                         created_by: record.created_by,
+                        user_visibility: record.user_visibility,
+                        friend_ext: record.friend_ext,
+                        friend_check_in_strategy: record.friend_check_in_strategy,
                         created_at: record.created_at,
                         updated_at: record.updated_at,
                     }));
@@ -277,6 +280,9 @@ impl BotServiceImpl {
                     agent_code: record.agent_code,
                     task_claim_mode: record.task_claim_mode,
                     task_dream_mode: record.task_dream_mode,
+                    user_visibility: record.user_visibility,
+                    friend_ext: record.friend_ext,
+                    friend_check_in_strategy: record.friend_check_in_strategy,
                     created_at: record.created_at,
                     updated_at: record.updated_at,
                 }))
@@ -565,6 +571,9 @@ impl BotService for BotServiceImpl {
                     descriptor,
                     task_claim_mode: command.patch.task_claim_mode,
                     task_dream_mode: command.patch.task_dream_mode,
+                    user_visibility: command.patch.user_visibility,
+                    friend_ext: command.patch.friend_ext,
+                    friend_check_in_strategy: command.patch.friend_check_in_strategy,
                     ..Default::default()
                 },
             )

--- a/src/bcs/crates/application/v1/bcs-app-bot/tests/v1_bot_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-bot/tests/v1_bot_service.rs
@@ -13,8 +13,9 @@ use bcs_bot_store::{MemoryBotRepo, MemoryProviderStore};
 use bcs_friend::FriendCore;
 use bcs_service_api::application::v1::{
     ApplicationError, Bot, BotCandidatePurpose, BotCandidateSearchMode, BotDescriptorPatch,
-    BotKind, BotPatch, BotReachability, BotService, BotStatus, BotVisibility, GetBot,
-    ListBotCandidates, ListMyBots, QueryBots, SearchBotCandidates, UpdateBot,
+    BotKind, BotPatch, BotReachability, BotService, BotStatus, BotVisibility,
+    FriendCheckInStrategy, GetBot, ListBotCandidates, ListMyBots, QueryBots,
+    SearchBotCandidates, UpdateBot, UserVisibility,
 };
 use bcs_service_api::{
     ActorKind, ActorStatus, BotCandidateSearchCoreResult, BotCandidateSearchCoreService,
@@ -68,6 +69,9 @@ fn v1_bot_commands_expose_the_approved_control_plane_surface() {
             }),
             task_claim_mode: None,
             task_dream_mode: None,
+            user_visibility: None,
+            friend_ext: None,
+            friend_check_in_strategy: None,
         },
     };
     let _ = ListMyBots {
@@ -984,10 +988,19 @@ async fn query_preserves_first_occurrence_and_projects_both_kinds_provider_and_r
         bots.iter().map(Bot::bot_id).collect::<Vec<_>>(),
         vec!["human_staff-1", "physical"]
     );
+    let Bot::Human(human) = &bots[0] else {
+        panic!("expected human bot");
+    };
+    assert_eq!(human.user_visibility, UserVisibility::Protected);
+    assert_eq!(human.friend_ext, serde_json::Map::new());
+    assert_eq!(human.friend_check_in_strategy, FriendCheckInStrategy::Approval);
     let Bot::Physical(physical) = &bots[1] else {
         panic!("expected physical bot");
     };
     assert_eq!(physical.reachability, BotReachability::Reachable);
+    assert_eq!(physical.user_visibility, UserVisibility::Protected);
+    assert_eq!(physical.friend_ext, serde_json::Map::new());
+    assert_eq!(physical.friend_check_in_strategy, FriendCheckInStrategy::Approval);
     assert_eq!(
         physical.provider.as_ref().map(|p| p.name.as_str()),
         Some("Provider One")
@@ -1068,6 +1081,12 @@ async fn update_requires_created_by_and_rejects_descriptor_for_human() {
                 }),
                 task_claim_mode: None,
                 task_dream_mode: None,
+                user_visibility: Some(UserVisibility::Private),
+                friend_ext: Some(serde_json::Map::from_iter([(
+                    "no_check_scope_friend_deps".to_string(),
+                    serde_json::json!(["dep-1"]),
+                )])),
+                friend_check_in_strategy: Some(FriendCheckInStrategy::DeptFree),
             },
         })
         .await
@@ -1078,6 +1097,12 @@ async fn update_requires_created_by_and_rejects_descriptor_for_human() {
     assert_eq!(updated.name, "Renamed");
     assert_eq!(updated.visibility, BotVisibility::Protected);
     assert_eq!(updated.status, BotStatus::Hidden);
+    assert_eq!(updated.user_visibility, UserVisibility::Private);
+    assert_eq!(updated.friend_check_in_strategy, FriendCheckInStrategy::DeptFree);
+    assert_eq!(
+        updated.friend_ext["no_check_scope_friend_deps"],
+        serde_json::json!(["dep-1"])
+    );
     assert!(updated.descriptor.domains.is_empty());
     assert_eq!(updated.descriptor.scopes, vec!["new-scope"]);
 }

--- a/src/bcs/crates/bootstrap/bcs/src/friend_connect_notification.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/friend_connect_notification.rs
@@ -196,7 +196,11 @@ impl FriendWorkOrderEventRequest {
             event_category: event_category_for(command.kind).to_string(),
             event_type: event_type.to_string(),
             biz_type: "BOT_FRIEND".to_string(),
-            biz_id: command.request_ids.first().cloned().unwrap_or_default(),
+            biz_id: command
+                .request_ids
+                .first()
+                .map(|id| id.to_string())
+                .unwrap_or_default(),
             applicant_user_id,
             approver_user_ids,
             recipient_user_ids,
@@ -254,7 +258,7 @@ mod tests {
             .notify(FriendConnectNotificationCommand {
                 kind: FriendConnectNotificationKind::Reviewed,
                 env: "dev".to_string(),
-                request_ids: vec!["req_3".to_string()],
+                request_ids: vec!["3".to_string()],
                 applicant_actor_id: "bot_1001".to_string(),
                 target_bot_id: "bot_2001".to_string(),
                 recipient_user_ids: Vec::new(),
@@ -283,7 +287,7 @@ mod tests {
             .notify(FriendConnectNotificationCommand {
                 kind: FriendConnectNotificationKind::ApprovalRequested,
                 env: "dev".to_string(),
-                request_ids: vec!["req_1".to_string()],
+                request_ids: vec!["1".to_string()],
                 applicant_actor_id: "human_1001".to_string(),
                 target_bot_id: "bot_2001".to_string(),
                 recipient_user_ids: vec!["user_2001".to_string()],
@@ -298,7 +302,7 @@ mod tests {
         let payload = FriendWorkOrderEventRequest::from_command(&FriendConnectNotificationCommand {
             kind: FriendConnectNotificationKind::ApprovalRequested,
             env: "dev".to_string(),
-            request_ids: vec!["req_1".to_string()],
+            request_ids: vec!["1".to_string()],
             applicant_actor_id: "human_1001".to_string(),
             target_bot_id: "bot_2001".to_string(),
             recipient_user_ids: vec!["user_2001".to_string()],
@@ -308,7 +312,7 @@ mod tests {
         assert_eq!(payload.event_category, "APPROVAL");
         assert_eq!(payload.event_type, "HUMAN2BOT_FRIEND_APPLIED");
         assert_eq!(payload.biz_type, "BOT_FRIEND");
-        assert_eq!(payload.biz_id, "req_1");
+        assert_eq!(payload.biz_id, "1");
         assert_eq!(payload.applicant_user_id.as_deref(), Some("1001"));
         assert_eq!(payload.apply_reason.as_deref(), Some("please add me"));
         assert_eq!(payload.approver_user_ids, vec!["user_2001".to_string()]);
@@ -321,7 +325,7 @@ mod tests {
         assert_eq!(
             payload.biz_data,
             Some(serde_json::json!({
-                "request_ids": ["req_1"],
+                "request_ids": ["1"],
                 "applicant_actor_id": "human_1001",
                 "target_bot_id": "bot_2001",
                 "notification_kind": "approval_requested",
@@ -335,7 +339,7 @@ mod tests {
         let payload = FriendWorkOrderEventRequest::from_command(&FriendConnectNotificationCommand {
             kind: FriendConnectNotificationKind::AutoApproved,
             env: "dev".to_string(),
-            request_ids: vec!["req_2".to_string()],
+            request_ids: vec!["2".to_string()],
             applicant_actor_id: "bot_1001".to_string(),
             target_bot_id: "bot_2001".to_string(),
             recipient_user_ids: vec!["user_2001".to_string()],
@@ -355,7 +359,7 @@ mod tests {
         let payload = FriendWorkOrderEventRequest::from_command(&FriendConnectNotificationCommand {
             kind: FriendConnectNotificationKind::ApprovalRequested,
             env: "dev".to_string(),
-            request_ids: vec!["req_4".to_string()],
+            request_ids: vec!["4".to_string()],
             applicant_actor_id: "bot_1001".to_string(),
             target_bot_id: "bot_2001".to_string(),
             recipient_user_ids: vec!["user_2001".to_string()],
@@ -380,7 +384,7 @@ mod tests {
         let payload = FriendWorkOrderEventRequest::from_command(&FriendConnectNotificationCommand {
             kind: FriendConnectNotificationKind::Reviewed,
             env: "dev".to_string(),
-            request_ids: vec!["req_5".to_string()],
+            request_ids: vec!["5".to_string()],
             applicant_actor_id: "human_1001".to_string(),
             target_bot_id: "bot_2001".to_string(),
             recipient_user_ids: vec!["user_2001".to_string()],
@@ -416,7 +420,7 @@ mod tests {
         let pending = FriendConnectNotificationCommand {
             kind: FriendConnectNotificationKind::ApprovalRequested,
             env: "dev".to_string(),
-            request_ids: vec!["req_1".to_string()],
+            request_ids: vec!["1".to_string()],
             applicant_actor_id: "human_1001".to_string(),
             target_bot_id: "bot_2001".to_string(),
             recipient_user_ids: vec!["user_2001".to_string()],
@@ -427,7 +431,7 @@ mod tests {
         let notice = FriendConnectNotificationCommand {
             kind: FriendConnectNotificationKind::Reviewed,
             env: "dev".to_string(),
-            request_ids: vec!["req_1".to_string()],
+            request_ids: vec!["1".to_string()],
             applicant_actor_id: "bot_1001".to_string(),
             target_bot_id: "bot_2001".to_string(),
             recipient_user_ids: vec!["user_2001".to_string()],

--- a/src/bcs/crates/bootstrap/bcs/src/migrations.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/migrations.rs
@@ -1416,20 +1416,21 @@ async fn add_sqlite_human_input_output_metadata_schema(db: &dyn DbPlugin) -> DbR
 async fn add_sqlite_edge_permission_schema(db: &dyn DbPlugin) -> DbResult<()> {
     // Five edge-permission tables (idempotent; spec §3.1).
     for stmt in [
-        "CREATE TABLE IF NOT EXISTS edge_grants (edge_id TEXT PRIMARY KEY, env TEXT NOT NULL, from_id TEXT NOT NULL, to_id TEXT NOT NULL, grant_kind TEXT NOT NULL, grant_ref_id TEXT NOT NULL, rules TEXT, status TEXT NOT NULL DEFAULT 'approved', originator_policy_type TEXT NOT NULL DEFAULT 'any', originator_policy_data TEXT, gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+        "CREATE TABLE IF NOT EXISTS edge_grants (id INTEGER PRIMARY KEY AUTOINCREMENT, env TEXT NOT NULL, from_id TEXT NOT NULL, to_id TEXT NOT NULL, grant_kind TEXT NOT NULL, grant_ref_id INTEGER NOT NULL, rules TEXT, status TEXT NOT NULL DEFAULT 'approved', originator_policy_type TEXT NOT NULL DEFAULT 'any', originator_policy_data TEXT, gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
         "CREATE UNIQUE INDEX IF NOT EXISTS uk_edge_from_to_env_ref ON edge_grants(from_id, to_id, env, grant_ref_id)",
         "CREATE INDEX IF NOT EXISTS idx_edge_from_env_status ON edge_grants(from_id, env, status)",
         "CREATE INDEX IF NOT EXISTS idx_edge_to_env_status ON edge_grants(to_id, env, status)",
-        "CREATE TABLE IF NOT EXISTS permission_profiles (permission_profile_id TEXT PRIMARY KEY, bot_id TEXT NOT NULL, env TEXT NOT NULL, name TEXT NOT NULL DEFAULT 'default', description TEXT, rules_template TEXT NOT NULL, revision INTEGER NOT NULL DEFAULT 1, digest TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active', created_by TEXT NOT NULL, updated_by TEXT, gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+        "CREATE TABLE IF NOT EXISTS permission_profiles (id INTEGER PRIMARY KEY AUTOINCREMENT, bot_id TEXT NOT NULL, env TEXT NOT NULL, name TEXT NOT NULL DEFAULT 'default', description TEXT, rules_template TEXT NOT NULL, revision INTEGER NOT NULL DEFAULT 1, digest TEXT NOT NULL, is_default INTEGER NOT NULL DEFAULT 0, status TEXT NOT NULL DEFAULT 'active', created_by TEXT NOT NULL, updated_by TEXT, gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
         "CREATE UNIQUE INDEX IF NOT EXISTS uk_profile_bot_env_default ON permission_profiles(bot_id, env, is_default) WHERE status = 'active'",
         "CREATE INDEX IF NOT EXISTS idx_profile_bot_env ON permission_profiles(bot_id, env, status)",
-        "CREATE TABLE IF NOT EXISTS permission_requests (request_id TEXT PRIMARY KEY, edge_id TEXT, env TEXT NOT NULL, from_id TEXT NOT NULL, to_id TEXT NOT NULL, request_kind TEXT NOT NULL, requested_ref_id TEXT, requested_rules TEXT, message TEXT, status TEXT NOT NULL DEFAULT 'pending', decision_reason TEXT, created_by TEXT NOT NULL, decided_by TEXT, decided_at TEXT, gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+        "CREATE TABLE IF NOT EXISTS permission_requests (id INTEGER PRIMARY KEY AUTOINCREMENT, request_id TEXT NOT NULL, edge_id INTEGER, env TEXT NOT NULL, from_id TEXT NOT NULL, to_id TEXT NOT NULL, request_kind TEXT NOT NULL, requested_ref_id INTEGER, requested_rules TEXT, message TEXT, status TEXT NOT NULL DEFAULT 'pending', decision_reason TEXT, created_by TEXT NOT NULL, decided_by TEXT, decided_at TEXT, gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+        "CREATE UNIQUE INDEX IF NOT EXISTS uk_req_request_id ON permission_requests(request_id)",
         "CREATE INDEX IF NOT EXISTS idx_req_to_env_status ON permission_requests(to_id, env, status)",
         "CREATE INDEX IF NOT EXISTS idx_req_from_env_status ON permission_requests(from_id, env, status)",
         "CREATE INDEX IF NOT EXISTS idx_req_edge ON permission_requests(edge_id)",
-        "CREATE TABLE IF NOT EXISTS capabilities (capability_id TEXT PRIMARY KEY, bot_id TEXT NOT NULL, env TEXT NOT NULL, tool TEXT NOT NULL, operation TEXT, specifier_schema TEXT, source TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'active', raw_metadata TEXT, gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+        "CREATE TABLE IF NOT EXISTS capabilities (id INTEGER PRIMARY KEY AUTOINCREMENT, bot_id TEXT NOT NULL, env TEXT NOT NULL, tool TEXT NOT NULL, operation TEXT, specifier_schema TEXT, source TEXT NOT NULL, status TEXT NOT NULL DEFAULT 'active', raw_metadata TEXT, gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
         "CREATE INDEX IF NOT EXISTS idx_cap_bot_env ON capabilities(bot_id, env, status)",
-        "CREATE TABLE IF NOT EXISTS authz_decision_logs (decision_id TEXT PRIMARY KEY, env TEXT NOT NULL, task_id TEXT, run_id TEXT, from_id TEXT NOT NULL, to_id TEXT NOT NULL, originator TEXT, context_type TEXT NOT NULL, decision TEXT NOT NULL, reason_code TEXT NOT NULL, grant_refs TEXT NOT NULL, context_json TEXT, gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
+        "CREATE TABLE IF NOT EXISTS authz_decision_logs (id INTEGER PRIMARY KEY AUTOINCREMENT, env TEXT NOT NULL, task_id TEXT, run_id TEXT, from_id TEXT NOT NULL, to_id TEXT NOT NULL, originator TEXT, context_type TEXT NOT NULL, decision TEXT NOT NULL, reason_code TEXT NOT NULL, grant_refs TEXT NOT NULL, context_json TEXT, gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
         "CREATE INDEX IF NOT EXISTS idx_adl_env_from_to ON authz_decision_logs(env, from_id, to_id)",
     ] {
         db.execute(DbStatement::new(stmt)).await?;
@@ -1915,9 +1916,9 @@ assert_eq!(report.pending_versions[10].version, 11);
 
         let before = check_sqlite_migrations(&db).await?;
         // Deleting only the v11 (group_opening_message) record leaves later
-        // migrations applied, so the max applied version stays 16 even though
-        // v11 is the sole pending re-apply.
-        assert_eq!(before.current_version, Some(16));
+        // migrations applied, so the max applied version stays at the latest
+        // schema version even though v11 is the sole pending re-apply.
+        assert_eq!(before.current_version, Some(sqlite_target_version()));
         assert_eq!(
             before
                 .pending_versions
@@ -2112,6 +2113,8 @@ assert_eq!(report.pending_versions[10].version, 11);
                 "{table} missing gmt_modified"
             );
         }
+        let request_columns = column_names(&db, "permission_requests").await?;
+        assert!(request_columns.iter().any(|c| c == "request_id"));
         Ok(())
     }
 
@@ -2121,11 +2124,11 @@ assert_eq!(report.pending_versions[10].version, 11);
     async fn edge_table_audit_columns_backfilled_for_legacy_db() -> DbResult<()> {
         let db = LocalSqliteDbPlugin::new()?;
         // Legacy shape: edge_grants as built before the gmt_* audit-column
-        // requirement landed (full real columns, minus gmt_create/gmt_modified).
+        // requirement landed (current bigint PK + real columns, minus gmt_create/gmt_modified).
         db.execute(DbStatement::new(
-            "CREATE TABLE edge_grants (edge_id TEXT PRIMARY KEY, env TEXT NOT NULL, \
+            "CREATE TABLE edge_grants (id INTEGER PRIMARY KEY AUTOINCREMENT, env TEXT NOT NULL, \
              from_id TEXT NOT NULL, to_id TEXT NOT NULL, grant_kind TEXT NOT NULL, \
-             grant_ref_id TEXT NOT NULL, rules TEXT, status TEXT NOT NULL DEFAULT 'approved', \
+             grant_ref_id INTEGER NOT NULL, rules TEXT, status TEXT NOT NULL DEFAULT 'approved', \
              originator_policy_type TEXT NOT NULL DEFAULT 'any', originator_policy_data TEXT)",
         ))
         .await?;

--- a/src/bcs/crates/contracts/bcs-domain/src/edge_permission.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/edge_permission.rs
@@ -55,14 +55,14 @@ pub enum OriginatorPolicyType {
 /// `target`'s default profile id (D12).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EdgeGrant {
-    pub edge_id: String,
+    pub edge_id: u64,
     pub env: String,
     pub from_id: String,
     pub to_id: String,
     pub grant_kind: GrantKind,
     /// `PermissionProfile` -> target's default (or other) profile id;
     /// `Rules` -> opaque rules ref.
-    pub grant_ref_id: String,
+    pub grant_ref_id: u64,
     /// Inline rules; `None` unless `GrantKind::Rules`.
     #[serde(default)]
     pub rules: Option<Value>,
@@ -108,7 +108,7 @@ pub enum CapabilityStatus {
 /// default profile regardless of capabilities). See spec §3.1.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Capability {
-    pub capability_id: String,
+    pub capability_id: u64,
     pub bot_id: String,
     pub env: String,
     pub tool: String,
@@ -149,7 +149,7 @@ pub struct Rule {
 /// Every bot seeds exactly one `default` profile (wildcard-allow) at onboard.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PermissionProfile {
-    pub permission_profile_id: String,
+    pub permission_profile_id: u64,
     pub bot_id: String,
     pub env: String,
     pub name: String,
@@ -195,16 +195,19 @@ pub enum RequestStatus {
 /// A connect/apply/revoke request record.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PermissionRequest {
+    /// External business id (a bare UUID v4, simple form); the internal bigint
+    /// PK (`id`) stays in the DB row for FK joins and is not exposed on this
+    /// struct.
     pub request_id: String,
     /// Back-filled after approval creates the edge; `None` while pending.
     #[serde(default)]
-    pub edge_id: Option<String>,
+    pub edge_id: Option<u64>,
     pub env: String,
     pub from_id: String,
     pub to_id: String,
     pub request_kind: RequestKind,
     #[serde(default)]
-    pub requested_ref_id: Option<String>,
+    pub requested_ref_id: Option<u64>,
     #[serde(default)]
     pub requested_rules: Option<Value>,
     #[serde(default)]
@@ -234,7 +237,7 @@ pub enum GrantSource {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthzGrantRef {
     pub kind: GrantKind,
-    pub ref_id: String,
+    pub ref_id: u64,
     #[serde(default)]
     pub revision: Option<u64>,
     #[serde(default)]
@@ -344,10 +347,10 @@ mod tests {
     #[test]
     fn edge_grant_roundtrip() {
         let g = EdgeGrant {
-            edge_id: "eg_1".into(), env: "prod".into(),
+            edge_id: 1, env: "prod".into(),
             from_id: "human_88001".into(), to_id: "20260421_x:85020".into(),
             grant_kind: GrantKind::PermissionProfile,
-            grant_ref_id: "pp_20260421_x:85020_default".into(),
+            grant_ref_id: 2,
             rules: None, status: EdgeStatus::Approved,
             originator_policy_type: OriginatorPolicyType::Any,
             originator_policy_data: None,
@@ -357,7 +360,7 @@ mod tests {
         assert_eq!(g, back);
         assert_eq!(back.status, EdgeStatus::Approved);
         let def: EdgeGrant = serde_json::from_str(
-            r#"{"edge_id":"e","env":"prod","from_id":"a","to_id":"b","grant_kind":"permission_profile","grant_ref_id":"r"}"#,
+            r#"{"edge_id":1,"env":"prod","from_id":"a","to_id":"b","grant_kind":"permission_profile","grant_ref_id":2}"#,
         ).unwrap();
         assert_eq!(def.status, EdgeStatus::Approved);
         assert_eq!(def.originator_policy_type, OriginatorPolicyType::Any);
@@ -366,7 +369,7 @@ mod tests {
     #[test]
     fn permission_request_pending_has_no_edge() {
         let r = PermissionRequest {
-            request_id: "req_1".into(), edge_id: None, env: "prod".into(),
+            request_id: "1".into(), edge_id: None, env: "prod".into(),
             from_id: "human_88001".into(), to_id: "b".into(),
             request_kind: RequestKind::Connect, requested_ref_id: None,
             requested_rules: None, message: None, status: RequestStatus::Pending,

--- a/src/bcs/crates/contracts/bcs-protocol/src/http/bots.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/http/bots.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
 use crate::{BindingChannels, Skill, deserialize_skills};
 
@@ -10,13 +11,25 @@ pub struct BotSearchQuery {
     /// Name/summary fuzzy search (contains, case-insensitive).
     #[serde(default)]
     pub q: Option<String>,
-    /// Visibility filter: public | protected | private.
+    /// Visibility filter: comma-separated public | protected | private values.
     #[serde(default)]
     pub visibility: Option<String>,
+    /// User visibility filter: comma-separated public | protected | private values.
+    #[serde(default)]
+    pub user_visibility: Option<String>,
     /// Status filter: online | hidden.
     #[serde(default)]
     pub status: Option<String>,
-    /// Friend status filter (requires Bearer): true | false.
+    /// Viewer actor kind used to calculate friendship: human | bot.
+    #[serde(default)]
+    pub viewer_actor_type: Option<String>,
+    /// Viewer actor id used to calculate friendship.
+    #[serde(default)]
+    pub viewer_actor_id: Option<String>,
+    /// Friendship filter relative to the explicit viewer: all | friends | non_friends.
+    #[serde(default)]
+    pub friendship: Option<String>,
+    /// Deprecated compatibility alias for `friendship`: true -> friends, false -> non_friends.
     #[serde(default)]
     pub is_friend: Option<bool>,
     /// TC (TeamClaw backend) bot filter. `true` → only bots onboarded from the
@@ -40,6 +53,9 @@ pub struct BotSearchEntry {
     pub name: Option<String>,
     pub summary: Option<String>,
     pub visibility: String,
+    pub user_visibility: String,
+    pub friend_ext: Map<String, Value>,
+    pub friend_check_in_strategy: String,
     pub status: String,
     pub actor_kind: String,
     pub is_online: bool,

--- a/src/bcs/crates/contracts/bcs-protocol/src/http/friends.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/http/friends.rs
@@ -31,14 +31,14 @@ pub struct CreateFriendRequestResponse {
     pub request_ids: Vec<String>,
     /// "pending" | "approved" | "public_no_edge"
     pub status: String,
-    pub edge_ids: Vec<String>,
+    pub edge_ids: Vec<u64>,
     pub auto_accepted: bool,
 }
 
 /// `POST /friends/requests/{id}/accept` response.
 #[derive(Debug, Clone, Serialize)]
 pub struct AcceptFriendRequestResponse {
-    pub edge_ids: Vec<String>,
+    pub edge_ids: Vec<u64>,
 }
 
 /// Body for reject/cancel/revoke decision endpoints.
@@ -85,7 +85,7 @@ fn default_page_size() -> u32 {
 /// `POST /friends/{actor}/revoke` response.
 #[derive(Debug, Clone, Serialize)]
 pub struct RevokeFriendResponse {
-    pub revoked_edges: Vec<String>,
+    pub revoked_edges: Vec<u64>,
 }
 
 /// `GET /bots/{id}/friends` response.

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/bot_query.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/bot_query.rs
@@ -87,8 +87,9 @@ pub struct BotQueryByIdsResult {
 /// + actor-status filtering over the active bot registry.
 ///
 /// `visibility`: `None` → return `public` + `protected` bots (default visible
-/// scope); `Some(v)` → return only bots with that visibility (including
-/// `"private"` when explicitly requested). The delivery adapter decides the
+/// scope); `Some(values)` → return only bots whose visibility is one of those
+/// values (including `"private"` when explicitly requested). An empty values
+/// list intentionally matches no bots. The delivery adapter decides the
 /// effective scope per its auth state.
 ///
 /// `requester_actor_id`: when present, the caller is excluded from its own
@@ -100,7 +101,7 @@ pub struct BotQueryByIdsResult {
 #[derive(Debug, Clone, Default)]
 pub struct SearchBotsCommand {
     pub q: Option<String>,
-    pub visibility: Option<String>,
+    pub visibility: Option<Vec<String>>,
     pub status: Option<ActorStatus>,
     pub requester_actor_id: Option<String>,
     pub tc_bot: Option<bool>,

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/connect.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/connect.rs
@@ -20,7 +20,7 @@ pub enum ConnectStatus {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConnectResult {
     pub request_ids: Vec<String>,
-    pub edge_ids: Vec<String>,
+    pub edge_ids: Vec<u64>,
     pub status: ConnectStatus,
     pub auto_accepted: bool,
 }
@@ -57,7 +57,7 @@ pub trait ConnectService: Send + Sync {
 
     /// Owner (or auto) approves; same-tx builds edge(s) + back-fills request.edge_id.
     /// Returns created edge_ids. Idempotent on already-approved.
-    async fn approve(&self, request_id: &str, decider: &str) -> ServiceResult<Vec<String>>;
+    async fn approve(&self, request_id: &str, decider: &str) -> ServiceResult<Vec<u64>>;
 
     async fn reject(
         &self,
@@ -74,7 +74,7 @@ pub trait ConnectService: Send + Sync {
 
     /// Unfriend: revoke friend edge(s) only (human→bot 1 / bot↔bot 2). Other edges untouched.
     /// Returns the revoked edge_ids.
-    async fn revoke_friend(&self, caller: &str, target: &str) -> ServiceResult<Vec<String>>;
+    async fn revoke_friend(&self, caller: &str, target: &str) -> ServiceResult<Vec<u64>>;
 
     /// Friend list (any direction, default-profile edge), enriched.
     async fn list_friends(&self, actor: &str) -> ServiceResult<Vec<FriendListEntry>>;

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/bot.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/bot.rs
@@ -4,8 +4,9 @@ use std::collections::BTreeMap;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
-use super::{ApplicationError, AuthenticatedCaller, Page};
+use super::{ApplicationError, AuthenticatedCaller, FriendCheckInStrategy, Page, UserVisibility};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -82,6 +83,10 @@ pub struct PhysicalBot {
     pub agent_code: Option<String>,
     pub task_claim_mode: bool,
     pub task_dream_mode: bool,
+    pub user_visibility: UserVisibility,
+    #[serde(default)]
+    pub friend_ext: Map<String, Value>,
+    pub friend_check_in_strategy: FriendCheckInStrategy,
     pub created_at: u64,
     pub updated_at: u64,
 }
@@ -96,6 +101,10 @@ pub struct HumanBot {
     pub env: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub created_by: Option<String>,
+    pub user_visibility: UserVisibility,
+    #[serde(default)]
+    pub friend_ext: Map<String, Value>,
+    pub friend_check_in_strategy: FriendCheckInStrategy,
     pub created_at: u64,
     pub updated_at: u64,
 }
@@ -133,7 +142,7 @@ pub struct BotCandidate {
 pub struct BotCandidateSearchItem {
     pub bot: PhysicalBot,
     pub is_friend: bool,
-    pub tags: BTreeMap<String, serde_json::Value>,
+    pub tags: BTreeMap<String, Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub score: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -214,6 +223,9 @@ pub struct BotPatch {
     pub descriptor: Option<BotDescriptorPatch>,
     pub task_claim_mode: Option<bool>,
     pub task_dream_mode: Option<bool>,
+    pub user_visibility: Option<UserVisibility>,
+    pub friend_ext: Option<Map<String, Value>>,
+    pub friend_check_in_strategy: Option<FriendCheckInStrategy>,
 }
 
 impl BotPatch {
@@ -224,6 +236,9 @@ impl BotPatch {
             && self.descriptor.is_none()
             && self.task_claim_mode.is_none()
             && self.task_dream_mode.is_none()
+            && self.user_visibility.is_none()
+            && self.friend_ext.is_none()
+            && self.friend_check_in_strategy.is_none()
     }
 }
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/friend_connection.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/friend_connection.rs
@@ -51,7 +51,7 @@ pub enum FriendConnectionCreateStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FriendConnectionCreateResult {
     pub request_ids: Vec<String>,
-    pub edge_ids: Vec<String>,
+    pub edge_ids: Vec<u64>,
     pub status: FriendConnectionCreateStatus,
     pub auto_accepted: bool,
 }
@@ -60,7 +60,7 @@ pub struct FriendConnectionCreateResult {
 pub struct FriendConnectionRequestView {
     pub request_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub edge_id: Option<String>,
+    pub edge_id: Option<u64>,
     pub from_actor: FriendConnectionActor,
     pub to_actor: FriendConnectionActor,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/edge_grant.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/edge_grant.rs
@@ -22,10 +22,10 @@ pub trait EdgeGrantRepoPort: Send + Sync {
     /// Friends of `actor` (any direction, default-profile edge) — actor ids only.
     async fn list_friends(&self, actor: &str, env: &str) -> Vec<String>;
 
-    async fn insert_grant(&self, grant: EdgeGrant) -> ServiceResult<()>;
+    async fn insert_grant(&self, grant: EdgeGrant) -> ServiceResult<u64>;
 
-    async fn revoke_grant(&self, edge_id: &str, env: &str) -> ServiceResult<()>;
+    async fn revoke_grant(&self, edge_id: u64, env: &str) -> ServiceResult<()>;
 
     /// Cached source for friend-edge discrimination: `(bot_id, env) -> default profile_id`.
-    async fn get_default_profile_id(&self, bot_id: &str, env: &str) -> Option<String>;
+    async fn get_default_profile_id(&self, bot_id: &str, env: &str) -> Option<u64>;
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/permission_profile.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/permission_profile.rs
@@ -8,7 +8,7 @@ use crate::core::error::ServiceResult;
 pub trait PermissionProfileRepoPort: Send + Sync {
     /// Idempotent: seed bot's default profile (wildcard-allow) if absent.
     /// Never overwrites or bumps revision of an existing default (D12 rule 2).
-    async fn ensure_default_profile(&self, bot_id: &str, env: &str) -> ServiceResult<()>;
+    async fn ensure_default_profile(&self, bot_id: &str, env: &str) -> ServiceResult<u64>;
 
     async fn get_active_default(&self, bot_id: &str, env: &str) -> Option<PermissionProfile>;
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/permission_request.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/permission_request.rs
@@ -38,5 +38,5 @@ pub trait PermissionRequestRepoPort: Send + Sync {
     ) -> ServiceResult<()>;
 
     /// Back-fill `edge_id` after approval creates the edge.
-    async fn backfill_edge_id(&self, request_id: &str, env: &str, edge_id: &str) -> ServiceResult<()>;
+    async fn backfill_edge_id(&self, request_id: &str, env: &str, edge_id: u64) -> ServiceResult<()>;
 }

--- a/src/bcs/crates/services/bcs-bot-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/lib.rs
@@ -1670,10 +1670,32 @@ impl BotRepoPort for PersistentBotRepo {
     }
 
     async fn list_active(&self) -> Vec<RegisteredBot> {
-        // Master has all active connections in memory
+        // Master has active connections in memory, while soft-delete state is
+        // authoritative in the DB. Re-registering a retained soft-deleted row
+        // intentionally does not clear `is_deleted`, so default active reads
+        // must cross-check the DB before exposing memory entries.
+        let env = resolve_env();
+        let active_bot_ids = match self
+            .db_query(
+                "SELECT bot_uuid FROM bcs_bots WHERE env = ? AND COALESCE(is_deleted, 0) = 0",
+                vec![Value::from(env.as_str())],
+            )
+            .await
+        {
+            Ok(rows) => rows
+                .into_iter()
+                .filter_map(|row| db_get_column::<String>(&row, "bot_uuid").ok())
+                .collect::<std::collections::HashSet<_>>(),
+            Err(error) => {
+                warn!(env = %env, error = %error, "list_active: failed to load active bot ids from DB; returning empty result to preserve DB tombstone authority");
+                return Vec::new();
+            }
+        };
+
         let bots = self.bots.read().await;
         bots.values()
             .filter(|b| !b.is_expired())
+            .filter(|b| active_bot_ids.contains(&b.bot_uuid))
             .map(|b| b.to_registered_bot())
             .collect()
     }

--- a/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_repo.rs
+++ b/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_repo.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use bcs_bot_store::{PersistentBotRepo, MemoryBotRepo};
 use bcs_cache_local::InMemoryCachePlugin;
-use bcs_db_api::{DbPlugin, DbStatement, DbValue as Value};
+use bcs_db_api::{
+    DbError, DbExecuteResult, DbHealth, DbPlugin, DbRow, DbStatement, DbTransactionStep,
+    DbTransactionStepResult, DbValue as Value,
+};
 use bcs_db_local::LocalSqliteDbPlugin;
 use bcs_service_api::{
     ActorKind, ActorStatus, BotCapabilities, BotMetricsSnapshotPort, BotRepoPort,
@@ -95,6 +98,61 @@ async fn persistent_bot_repo_unregister_marks_is_deleted_and_filters_default_rea
 }
 
 #[tokio::test]
+async fn persistent_bot_repo_list_active_fails_closed_when_tombstone_query_fails() {
+    let cache = Arc::new(InMemoryCachePlugin::new());
+    let inner_db = sqlite_db().await;
+    let db = Arc::new(FailActiveBotIdsQueryDb {
+        inner: inner_db.clone(),
+    });
+    let repo = PersistentBotRepo::with_plugins(cache, db);
+    repo.register_with_owner_and_token(
+        "soft-delete-bot".to_string(),
+        BotCapabilities {
+            name: Some("Soft Delete Bot".to_string()),
+            visibility: "public".to_string(),
+            ..Default::default()
+        },
+        "11111111",
+        "soft-delete-token",
+    )
+    .await
+    .expect("register bot");
+
+    assert!(repo.unregister("soft-delete-bot").await);
+
+    repo.register_with_owner_and_token(
+        "soft-delete-bot".to_string(),
+        BotCapabilities {
+            name: Some("Re-registered Soft Delete Bot".to_string()),
+            visibility: "public".to_string(),
+            ..Default::default()
+        },
+        "11111111",
+        "new-soft-delete-token",
+    )
+    .await
+    .expect("re-register bot into memory");
+
+    assert_eq!(
+        inner_db
+            .query(DbStatement::with_params(
+                "SELECT is_deleted FROM bcs_bots WHERE bot_uuid = ? AND env = ?",
+                vec![
+                    Value::from("soft-delete-bot"),
+                    Value::from(bcs_config::resolve_env_str()),
+                ],
+            ))
+            .await
+            .expect("query soft deleted row")[0]
+            .get("is_deleted")
+            .and_then(Value::as_i64),
+        Some(1)
+    );
+
+    assert!(repo.list_active().await.is_empty());
+}
+
+#[tokio::test]
 async fn persistent_bot_repo_register_after_soft_delete_does_not_clear_is_deleted_column() {
     let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
@@ -164,6 +222,39 @@ async fn memory_bot_repo_passes_bot_metrics_snapshot_contract() {
     seed_metrics_actors(&repo).await;
     bot_metrics_snapshot_port_contract_tests(&repo).await;
     assert_metrics_actors_counted(&repo).await;
+}
+
+
+struct FailActiveBotIdsQueryDb {
+    inner: Arc<dyn DbPlugin>,
+}
+
+#[async_trait::async_trait]
+impl DbPlugin for FailActiveBotIdsQueryDb {
+    async fn query(&self, statement: DbStatement) -> bcs_db_api::DbResult<Vec<DbRow>> {
+        if statement
+            .sql()
+            .starts_with("SELECT bot_uuid FROM bcs_bots WHERE env = ? AND COALESCE(is_deleted, 0) = 0")
+        {
+            return Err(DbError::Backend("injected active bot ids query failure".to_string()));
+        }
+        self.inner.query(statement).await
+    }
+
+    async fn execute(&self, statement: DbStatement) -> bcs_db_api::DbResult<DbExecuteResult> {
+        self.inner.execute(statement).await
+    }
+
+    async fn transaction(
+        &self,
+        steps: Vec<DbTransactionStep>,
+    ) -> bcs_db_api::DbResult<Vec<DbTransactionStepResult>> {
+        self.inner.transaction(steps).await
+    }
+
+    async fn health_check(&self) -> bcs_db_api::DbResult<DbHealth> {
+        self.inner.health_check().await
+    }
 }
 
 async fn seed_metrics_actors(repo: &dyn BotRepoPort) {

--- a/src/bcs/crates/services/bcs-bot/src/application/bot.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/bot.rs
@@ -364,8 +364,8 @@ impl BotQueryService for Bot {
             .filter(|bot| {
                 command.requester_actor_id.as_deref() != Some(bot.bot_uuid.as_str())
             })
-            .filter(|bot| match command.visibility.as_deref() {
-                Some(want) => bot.capabilities.visibility == want,
+            .filter(|bot| match command.visibility.as_ref() {
+                Some(wants) => wants.iter().any(|want| bot.capabilities.visibility == *want),
                 None => is_discover_visible(&bot.capabilities.visibility),
             })
             .filter(|bot| {

--- a/src/bcs/crates/services/bcs-bot/src/application/onboarding.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/onboarding.rs
@@ -1545,12 +1545,12 @@ mod tests {
                 &self,
                 bot_uuid: &str,
                 env: &str,
-            ) -> ServiceResult<()> {
+            ) -> ServiceResult<u64> {
                 self.calls
                     .lock()
                     .await
                     .push((bot_uuid.to_string(), env.to_string()));
-                Ok(())
+                Ok(1)
             }
 
             async fn get_active_default(

--- a/src/bcs/crates/services/bcs-bot/tests/bot_search_contract.rs
+++ b/src/bcs/crates/services/bcs-bot/tests/bot_search_contract.rs
@@ -4,8 +4,12 @@
 use std::sync::Arc;
 
 use bcs_bot::{Bot, BotCore};
+use bcs_bot_store::PersistentBotRepo;
+use bcs_cache_local::InMemoryCachePlugin;
+use bcs_db_api::{DbPlugin, DbStatement};
+use bcs_db_local::LocalSqliteDbPlugin;
 use bcs_service_api::{
-    BotCapabilities, BotQueryService, BotRegistryCoreService, SearchBotsCommand,
+    BotCapabilities, BotQueryService, BotRegistryCoreService, BotRepoPort, SearchBotsCommand,
 };
 use tempfile::TempDir;
 
@@ -16,6 +20,31 @@ fn capabilities(name: &str, visibility: &str) -> BotCapabilities {
         visibility: visibility.to_string(),
         ..Default::default()
     }
+}
+
+async fn sqlite_db() -> Arc<dyn DbPlugin> {
+    let db = Arc::new(LocalSqliteDbPlugin::new().expect("sqlite db"));
+    db.execute(DbStatement::new(
+        "CREATE TABLE bcs_bots (
+            bot_uuid TEXT NOT NULL,
+            name TEXT,
+            bot_info TEXT,
+            session_token TEXT,
+            created_by TEXT,
+            visibility TEXT,
+            status TEXT NOT NULL DEFAULT 'online',
+            actor_kind TEXT NOT NULL DEFAULT 'bot',
+            is_deleted INTEGER NOT NULL DEFAULT 0,
+            agent_code TEXT DEFAULT NULL,
+            env TEXT NOT NULL,
+            registered_at TEXT,
+            updated_at TEXT,
+            PRIMARY KEY (bot_uuid, env)
+        )",
+    ))
+    .await
+    .expect("create bcs_bots table");
+    db
 }
 
 async fn build_bot() -> (Bot, Arc<BotCore>, TempDir) {
@@ -79,4 +108,70 @@ async fn search_bots_tc_bot_filter_keeps_only_owner_suffixed_bots() {
         .map(|b| b.bot_uuid.as_str())
         .collect();
     assert_eq!(native_uuids, vec!["ws-native-bot"]);
+}
+
+
+
+#[tokio::test]
+async fn search_bots_visibility_filter_accepts_multiple_values() {
+    let (bot, core, _data_dir) = build_bot().await;
+    core.register("public-bot".to_string(), capabilities("Public", "public"))
+        .await
+        .expect("register public bot");
+    core.register("protected-bot".to_string(), capabilities("Protected", "protected"))
+        .await
+        .expect("register protected bot");
+    core.register("private-bot".to_string(), capabilities("Private", "private"))
+        .await
+        .expect("register private bot");
+
+    let result = bot
+        .search_bots(SearchBotsCommand {
+            visibility: Some(vec!["public".to_string(), "private".to_string()]),
+            ..Default::default()
+        })
+        .await
+        .expect("search bots by multiple visibility values");
+
+    let uuids: Vec<&str> = result.items.iter().map(|b| b.bot_uuid.as_str()).collect();
+    assert_eq!(uuids, vec!["private-bot", "public-bot"]);
+    assert_eq!(result.total, 2);
+}
+
+#[tokio::test]
+async fn search_bots_excludes_soft_deleted_persistent_rows_even_if_memory_has_bot() {
+    let cache = Arc::new(InMemoryCachePlugin::new());
+    let db = sqlite_db().await;
+    let repo = Arc::new(PersistentBotRepo::with_plugins(cache, db));
+    let core = Arc::new(BotCore::with_repo(repo.clone()));
+    let bot = Bot::new(core.clone() as Arc<dyn BotRegistryCoreService>);
+
+    repo.register_with_owner_and_token(
+        "soft-delete-bot".to_string(),
+        capabilities("Soft Delete Bot", "public"),
+        "11111111",
+        "soft-delete-token",
+    )
+    .await
+    .expect("register bot");
+    assert!(repo.soft_delete("soft-delete-bot").await);
+
+    // Re-registering a retained soft-deleted row intentionally does not clear
+    // `is_deleted`; `/bots/search` must still not leak the in-memory bot.
+    repo.register_with_owner_and_token(
+        "soft-delete-bot".to_string(),
+        capabilities("Soft Delete Bot", "public"),
+        "11111111",
+        "new-soft-delete-token",
+    )
+    .await
+    .expect("re-register soft-deleted bot");
+
+    let result = bot
+        .search_bots(SearchBotsCommand::default())
+        .await
+        .expect("search bots");
+
+    assert!(result.items.is_empty());
+    assert_eq!(result.total, 0);
 }

--- a/src/bcs/crates/services/bcs-edge-permission-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-edge-permission-store/src/lib.rs
@@ -9,7 +9,7 @@
 //! and [`PermissionProfileRepoPort`] (T8) for [`DbPermissionProfileStore`].
 //! `PermissionRequestRepoPort` (T9) will be added to this same crate later.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -93,15 +93,15 @@ impl DbEdgeGrantStore {
         match self.flavor {
             EdgeGrantSqlFlavor::Mysql => {
                 "INSERT IGNORE INTO edge_grants \
-                 (edge_id, env, from_id, to_id, grant_kind, grant_ref_id, rules, \
+                 (env, from_id, to_id, grant_kind, grant_ref_id, rules, \
                   status, originator_policy_type, originator_policy_data) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
             }
             EdgeGrantSqlFlavor::Sqlite => {
                 "INSERT INTO edge_grants \
-                 (edge_id, env, from_id, to_id, grant_kind, grant_ref_id, rules, \
+                 (env, from_id, to_id, grant_kind, grant_ref_id, rules, \
                   status, originator_policy_type, originator_policy_data) \
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) \
                  ON CONFLICT(from_id, to_id, env, grant_ref_id) DO NOTHING"
             }
         }
@@ -115,7 +115,7 @@ impl EdgeGrantRepoPort for DbEdgeGrantStore {
             .query(
                 "list_active_grants",
                 DbStatement::with_params(
-                    "SELECT edge_id, env, from_id, to_id, grant_kind, grant_ref_id, \
+                    "SELECT id, env, from_id, to_id, grant_kind, grant_ref_id, \
                             rules, status, originator_policy_type, originator_policy_data \
                      FROM edge_grants \
                      WHERE from_id = ? AND to_id = ? AND env = ? AND status = 'approved'",
@@ -161,11 +161,15 @@ impl EdgeGrantRepoPort for DbEdgeGrantStore {
         let dy = self.get_default_profile_id(y, env).await;
         let dx = self.get_default_profile_id(x, env).await;
 
-        if dy.is_some() && self.has_default_edge(x, y, env, dy.as_deref()).await {
-            return true;
+        if let Some(dy) = dy {
+            if self.has_default_edge(x, y, env, Some(dy)).await {
+                return true;
+            }
         }
-        if dx.is_some() && self.has_default_edge(y, x, env, dx.as_deref()).await {
-            return true;
+        if let Some(dx) = dx {
+            if self.has_default_edge(y, x, env, Some(dx)).await {
+                return true;
+            }
         }
         false
     }
@@ -175,8 +179,7 @@ impl EdgeGrantRepoPort for DbEdgeGrantStore {
         // memory compare. Avoids a SQL join.
         let d_actor = self.get_default_profile_id(actor, env).await;
 
-        let mut cache: std::collections::HashMap<String, Option<String>> =
-            std::collections::HashMap::new();
+        let mut cache: HashMap<String, Option<u64>> = HashMap::new();
         let mut friends: HashSet<String> = HashSet::new();
 
         // Branch ① actor initiated: actor → to_id. Keep if grant_ref_id ==
@@ -201,7 +204,7 @@ impl EdgeGrantRepoPort for DbEdgeGrantStore {
                         continue;
                     }
                 };
-                let grant_ref_id = match required_string(&row, "grant_ref_id") {
+                let grant_ref_id = match required_u64(&row, "grant_ref_id") {
                     Ok(v) => v,
                     Err(err) => {
                         warn!(error = %err, "list_friends_outbound: missing grant_ref_id");
@@ -209,10 +212,10 @@ impl EdgeGrantRepoPort for DbEdgeGrantStore {
                     }
                 };
                 let d_y = match cache.get(&to_id) {
-                    Some(v) => v.clone(),
+                    Some(v) => *v,
                     None => {
                         let v = self.get_default_profile_id(&to_id, env).await;
-                        cache.insert(to_id.clone(), v.clone());
+                        cache.insert(to_id.clone(), v);
                         v
                     }
                 };
@@ -228,7 +231,7 @@ impl EdgeGrantRepoPort for DbEdgeGrantStore {
 
         // Branch ② others initiated: from_id → actor. Only if actor has a
         // default profile (is a bot). Keep if grant_ref_id == actor's default.
-        if let Some(d_actor) = d_actor.as_deref() {
+        if let Some(d_actor) = d_actor {
             let inbound = self
                 .query(
                     "list_friends_inbound",
@@ -249,7 +252,7 @@ impl EdgeGrantRepoPort for DbEdgeGrantStore {
                             continue;
                         }
                     };
-                    let grant_ref_id = match required_string(&row, "grant_ref_id") {
+                    let grant_ref_id = match required_u64(&row, "grant_ref_id") {
                         Ok(v) => v,
                         Err(err) => {
                             warn!(error = %err, "list_friends_inbound: missing grant_ref_id");
@@ -268,49 +271,84 @@ impl EdgeGrantRepoPort for DbEdgeGrantStore {
         out
     }
 
-    async fn insert_grant(&self, grant: EdgeGrant) -> ServiceResult<()> {
-        let rules_val = json_to_db_value(&grant.rules);
-        let policy_data_val = json_to_db_value(&grant.originator_policy_data);
-        self.execute(
-            "insert_grant",
+    async fn insert_grant(&self, grant: EdgeGrant) -> ServiceResult<u64> {
+        let EdgeGrant {
+            edge_id: _,
+            env,
+            from_id,
+            to_id,
+            grant_kind,
+            grant_ref_id,
+            rules,
+            status,
+            originator_policy_type,
+            originator_policy_data,
+        } = grant;
+        let rules_val = json_to_db_value(&rules);
+        let policy_data_val = json_to_db_value(&originator_policy_data);
+        let result = self
+            .execute_result(
+                "insert_grant",
+                DbStatement::with_params(
+                    self.insert_grant_sql(),
+                    vec![
+                        DbValue::from(env.clone()),
+                        DbValue::from(from_id.clone()),
+                        DbValue::from(to_id.clone()),
+                        DbValue::from(grant_kind_str(grant_kind)),
+                        DbValue::from(grant_ref_id),
+                        rules_val,
+                        DbValue::from(edge_status_str(status)),
+                        DbValue::from(originator_policy_type_str(originator_policy_type)),
+                        policy_data_val,
+                    ],
+                ),
+            )
+            .await?;
+        if let Some(id) = result.last_insert_id {
+            if id != 0 {
+                return Ok(id);
+            }
+        }
+        self.query(
+            "insert_grant_lookup",
             DbStatement::with_params(
-                self.insert_grant_sql(),
+                "SELECT id FROM edge_grants WHERE from_id = ? AND to_id = ? AND env = ? AND grant_ref_id = ? LIMIT 1",
                 vec![
-                    DbValue::from(grant.edge_id),
-                    DbValue::from(grant.env),
-                    DbValue::from(grant.from_id),
-                    DbValue::from(grant.to_id),
-                    DbValue::from(grant_kind_str(grant.grant_kind)),
-                    DbValue::from(grant.grant_ref_id),
-                    rules_val,
-                    DbValue::from(edge_status_str(grant.status)),
-                    DbValue::from(originator_policy_type_str(grant.originator_policy_type)),
-                    policy_data_val,
+                    DbValue::from(from_id),
+                    DbValue::from(to_id),
+                    DbValue::from(env),
+                    DbValue::from(grant_ref_id),
                 ],
             ),
         )
-        .await
+        .await?
+        .into_iter()
+        .next()
+        .and_then(|row| row.get_i64("id").ok().flatten())
+        .and_then(|id| if id < 0 { None } else { Some(id as u64) })
+        .ok_or_else(|| ServiceError::InternalError("edge_grants insert did not return an id".to_string()))
     }
 
-    async fn revoke_grant(&self, edge_id: &str, env: &str) -> ServiceResult<()> {
+    async fn revoke_grant(&self, edge_id: u64, env: &str) -> ServiceResult<()> {
         self.execute(
             "revoke_grant",
             DbStatement::with_params(
                 "UPDATE edge_grants SET status = 'revoked', \
                      gmt_modified = CURRENT_TIMESTAMP \
-                 WHERE edge_id = ? AND env = ?",
+                 WHERE id = ? AND env = ?",
                 vec![DbValue::from(edge_id), DbValue::from(env)],
             ),
         )
         .await
     }
 
-    async fn get_default_profile_id(&self, bot_id: &str, env: &str) -> Option<String> {
+    async fn get_default_profile_id(&self, bot_id: &str, env: &str) -> Option<u64> {
         let rows = self
             .query(
                 "get_default_profile_id",
                 DbStatement::with_params(
-                    "SELECT permission_profile_id FROM permission_profiles \
+                    "SELECT id FROM permission_profiles \
                      WHERE bot_id = ? AND env = ? AND is_default = 1 \
                        AND status = 'active' LIMIT 1",
                     vec![DbValue::from(bot_id), DbValue::from(env)],
@@ -319,9 +357,7 @@ impl EdgeGrantRepoPort for DbEdgeGrantStore {
             .await;
         match rows {
             Ok(rows) => rows.into_iter().next().and_then(|row| {
-                row.get_string("permission_profile_id")
-                    .ok()
-                    .flatten()
+                row.get_i64("id").ok().flatten().and_then(|value| if value < 0 { None } else { Some(value as u64) })
             }),
             Err(err) => {
                 warn!(error = %err, "db_edge_grant: get_default_profile_id failed");
@@ -339,7 +375,7 @@ impl DbEdgeGrantStore {
         from: &str,
         to: &str,
         env: &str,
-        default_ref: Option<&str>,
+        default_ref: Option<u64>,
     ) -> bool {
         let Some(default_ref) = default_ref else {
             return false;
@@ -411,6 +447,17 @@ impl DbPermissionProfileStore {
             })
     }
 
+    async fn execute_result(
+        &self,
+        operation: &'static str,
+        statement: DbStatement,
+    ) -> ServiceResult<DbExecuteResult> {
+        self.db.execute(statement).await.map_err(|err| {
+            warn!(operation, error = %err, "db_permission_profile: execute failed");
+            service_db_error(operation, err)
+        })
+    }
+
     async fn query(
         &self,
         operation: &'static str,
@@ -422,30 +469,29 @@ impl DbPermissionProfileStore {
         })
     }
 
-    /// Idempotent INSERT of the default profile on PK `permission_profile_id`.
-    /// SQLite `ON CONFLICT(permission_profile_id) DO NOTHING` vs MySQL
-    /// `INSERT IGNORE` — D12 rule 2: never overwrite or bump an existing default.
+    /// Idempotent INSERT of the default profile on PK `id`.
+    /// SQLite `INSERT OR IGNORE` vs MySQL `INSERT IGNORE` — D12 rule 2:
+    /// never overwrite or bump an existing default.
     fn insert_default_profile_sql(&self) -> &'static str {
         match self.flavor {
             EdgeGrantSqlFlavor::Mysql => {
                 "INSERT IGNORE INTO permission_profiles \
-                 (permission_profile_id, bot_id, env, name, description, rules_template, \
+                 (bot_id, env, name, description, rules_template, \
                   revision, digest, is_default, status, created_by, updated_by) \
-                 VALUES (?, ?, ?, ?, NULL, ?, ?, ?, 1, 'active', 'system', NULL)"
+                 VALUES (?, ?, ?, NULL, ?, ?, ?, 1, 'active', 'system', NULL)"
             }
             EdgeGrantSqlFlavor::Sqlite => {
-                "INSERT INTO permission_profiles \
-                 (permission_profile_id, bot_id, env, name, description, rules_template, \
+                "INSERT OR IGNORE INTO permission_profiles \
+                 (bot_id, env, name, description, rules_template, \
                   revision, digest, is_default, status, created_by, updated_by) \
-                 VALUES (?, ?, ?, ?, NULL, ?, ?, ?, 1, 'active', 'system', NULL) \
-                 ON CONFLICT(permission_profile_id) DO NOTHING"
+                 VALUES (?, ?, ?, NULL, ?, ?, ?, 1, 'active', 'system', NULL)"
             }
         }
     }
 
     /// SELECT all columns of a default, active profile for (bot_id, env).
     const SELECT_DEFAULT_SQL: &'static str =
-        "SELECT permission_profile_id, bot_id, env, name, description, rules_template, \
+        "SELECT id, bot_id, env, name, description, rules_template, \
                 revision, digest, is_default, status, created_by, updated_by \
          FROM permission_profiles \
          WHERE bot_id = ? AND env = ? AND is_default = 1 AND status = 'active' LIMIT 1";
@@ -453,28 +499,36 @@ impl DbPermissionProfileStore {
 
 #[async_trait]
 impl PermissionProfileRepoPort for DbPermissionProfileStore {
-    async fn ensure_default_profile(&self, bot_id: &str, env: &str) -> ServiceResult<()> {
-        let profile_id = format!("pp_{}_default", bot_id);
+    async fn ensure_default_profile(&self, bot_id: &str, env: &str) -> ServiceResult<u64> {
         let digest = sha256_hex(WILDCARD_ALLOW);
         // INSERT all cols (description/updated_by NULL; gmt_* default to now).
-        // Idempotent on PK: a pre-existing default is left untouched — its
+        // Idempotent on unique active default: a pre-existing default is left untouched — its
         // rules_template, revision, and digest are NOT overwritten (D12 rule 2).
-        self.execute(
-            "ensure_default_profile",
-            DbStatement::with_params(
-                self.insert_default_profile_sql(),
-                vec![
-                    DbValue::from(profile_id),
-                    DbValue::from(bot_id),
-                    DbValue::from(env),
-                    DbValue::from("default"),
-                    DbValue::from(WILDCARD_ALLOW),
-                    DbValue::from(1_i64), // revision
-                    DbValue::from(digest),
-                ],
-            ),
-        )
-        .await
+        let result = self
+            .execute_result(
+                "ensure_default_profile",
+                DbStatement::with_params(
+                    self.insert_default_profile_sql(),
+                    vec![
+                        DbValue::from(bot_id),
+                        DbValue::from(env),
+                        DbValue::from("default"),
+                        DbValue::from(WILDCARD_ALLOW),
+                        DbValue::from(1_i64), // revision
+                        DbValue::from(digest),
+                    ],
+                ),
+            )
+            .await?;
+        if let Some(id) = result.last_insert_id {
+            if id != 0 {
+                return Ok(id);
+            }
+        }
+        self.get_active_default(bot_id, env)
+            .await
+            .map(|profile| profile.permission_profile_id)
+            .ok_or_else(|| ServiceError::InternalError(format!("default profile for bot '{}' missing after ensure", bot_id)))
     }
 
     async fn get_active_default(&self, bot_id: &str, env: &str) -> Option<PermissionProfile> {
@@ -514,7 +568,7 @@ impl PermissionProfileRepoPort for DbPermissionProfileStore {
             DbStatement::with_params(
                 "UPDATE permission_profiles SET rules_template = ?, revision = ?, \
                      digest = ?, updated_by = ?, gmt_modified = CURRENT_TIMESTAMP \
-                 WHERE permission_profile_id = ?",
+                 WHERE id = ?",
                 vec![
                     rules_val,
                     DbValue::from(profile.revision as i64),
@@ -565,6 +619,17 @@ impl DbPermissionRequestStore {
             })
     }
 
+    async fn execute_result(
+        &self,
+        operation: &'static str,
+        statement: DbStatement,
+    ) -> ServiceResult<DbExecuteResult> {
+        self.db.execute(statement).await.map_err(|err| {
+            warn!(operation, error = %err, "db_permission_request: execute failed");
+            service_db_error(operation, err)
+        })
+    }
+
     async fn query(
         &self,
         operation: &'static str,
@@ -576,8 +641,7 @@ impl DbPermissionRequestStore {
         })
     }
 
-    /// Idempotent INSERT on PK `request_id`: SQLite
-    /// `ON CONFLICT(request_id) DO NOTHING` vs MySQL `INSERT IGNORE`.
+    /// Idempotent INSERT on auto-increment PK `id`.
     ///
     /// `decided_at` is a DB-managed timestamp: derived from `status` at insert
     /// time (`CURRENT_TIMESTAMP` for a decided status, else NULL) so that
@@ -586,7 +650,7 @@ impl DbPermissionRequestStore {
     fn insert_request_sql(&self) -> &'static str {
         match self.flavor {
             EdgeGrantSqlFlavor::Mysql => {
-                "INSERT IGNORE INTO permission_requests \
+                "INSERT INTO permission_requests \
                  (request_id, edge_id, env, from_id, to_id, request_kind, requested_ref_id, \
                   requested_rules, message, status, decision_reason, created_by, decided_by, \
                   decided_at) \
@@ -601,39 +665,38 @@ impl DbPermissionRequestStore {
                   decided_at) \
                  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, \
                          CASE WHEN ? IN ('approved','rejected','cancelled') \
-                              THEN CURRENT_TIMESTAMP ELSE NULL END) \
-                 ON CONFLICT(request_id) DO NOTHING"
+                              THEN CURRENT_TIMESTAMP ELSE NULL END)"
             }
         }
     }
 
     const SELECT_REQUEST_SQL: &'static str =
-        "SELECT request_id, edge_id, env, from_id, to_id, request_kind, requested_ref_id, \
+        "SELECT request_id, id, edge_id, env, from_id, to_id, request_kind, requested_ref_id, \
                 requested_rules, message, status, decision_reason, created_by, decided_by, \
                 decided_at \
          FROM permission_requests WHERE request_id = ? AND env = ? LIMIT 1";
 
     const LIST_INBOX_ALL_SQL: &'static str =
-        "SELECT request_id, edge_id, env, from_id, to_id, request_kind, requested_ref_id, \
+        "SELECT request_id, id, edge_id, env, from_id, to_id, request_kind, requested_ref_id, \
                 requested_rules, message, status, decision_reason, created_by, decided_by, \
                 decided_at \
          FROM permission_requests WHERE to_id = ? AND env = ? ORDER BY gmt_modified DESC";
 
     const LIST_INBOX_STATUS_SQL: &'static str =
-        "SELECT request_id, edge_id, env, from_id, to_id, request_kind, requested_ref_id, \
+        "SELECT request_id, id, edge_id, env, from_id, to_id, request_kind, requested_ref_id, \
                 requested_rules, message, status, decision_reason, created_by, decided_by, \
                 decided_at \
          FROM permission_requests WHERE to_id = ? AND env = ? AND status = ? \
          ORDER BY gmt_modified DESC";
 
     const LIST_SENT_ALL_SQL: &'static str =
-        "SELECT request_id, edge_id, env, from_id, to_id, request_kind, requested_ref_id, \
+        "SELECT request_id, id, edge_id, env, from_id, to_id, request_kind, requested_ref_id, \
                 requested_rules, message, status, decision_reason, created_by, decided_by, \
                 decided_at \
          FROM permission_requests WHERE from_id = ? AND env = ? ORDER BY gmt_modified DESC";
 
     const LIST_SENT_STATUS_SQL: &'static str =
-        "SELECT request_id, edge_id, env, from_id, to_id, request_kind, requested_ref_id, \
+        "SELECT request_id, id, edge_id, env, from_id, to_id, request_kind, requested_ref_id, \
                 requested_rules, message, status, decision_reason, created_by, decided_by, \
                 decided_at \
          FROM permission_requests WHERE from_id = ? AND env = ? AND status = ? \
@@ -643,30 +706,54 @@ impl DbPermissionRequestStore {
 #[async_trait]
 impl PermissionRequestRepoPort for DbPermissionRequestStore {
     async fn insert(&self, request: PermissionRequest) -> ServiceResult<()> {
-        self.execute(
-            "insert_request",
-            DbStatement::with_params(
-                self.insert_request_sql(),
-                vec![
-                    DbValue::from(request.request_id),
-                    DbValue::from(request.edge_id),
-                    DbValue::from(request.env),
-                    DbValue::from(request.from_id),
-                    DbValue::from(request.to_id),
-                    DbValue::from(request_kind_str(request.request_kind)),
-                    DbValue::from(request.requested_ref_id),
-                    json_to_db_value(&request.requested_rules),
-                    DbValue::from(request.message),
-                    DbValue::from(request_status_str(request.status)),
-                    DbValue::from(request.decision_reason),
-                    DbValue::from(request.created_by),
-                    DbValue::from(request.decided_by),
-                    // The CASE in insert_request_sql keys decided_at off status.
-                    DbValue::from(request_status_str(request.status)),
-                ],
-            ),
-        )
-        .await
+        let PermissionRequest {
+            request_id,
+            edge_id,
+            env,
+            from_id,
+            to_id,
+            request_kind,
+            requested_ref_id,
+            requested_rules,
+            message,
+            status,
+            decision_reason,
+            created_by,
+            decided_by,
+            decided_at: _,
+        } = request;
+        self
+            .execute_result(
+                "insert_request",
+                DbStatement::with_params(
+                    self.insert_request_sql(),
+                    vec![
+                        DbValue::from(request_id),
+                        match edge_id {
+                            Some(id) => DbValue::from(id),
+                            None => DbValue::Null,
+                        },
+                        DbValue::from(env.clone()),
+                        DbValue::from(from_id.clone()),
+                        DbValue::from(to_id.clone()),
+                        DbValue::from(request_kind_str(request_kind)),
+                        match requested_ref_id {
+                            Some(id) => DbValue::from(id),
+                            None => DbValue::Null,
+                        },
+                        json_to_db_value(&requested_rules),
+                        DbValue::from(message.clone()),
+                        DbValue::from(request_status_str(status)),
+                        DbValue::from(decision_reason.clone()),
+                        DbValue::from(created_by.clone()),
+                        DbValue::from(decided_by.clone()),
+                        // The CASE in insert_request_sql keys decided_at off status.
+                        DbValue::from(request_status_str(status)),
+                    ],
+                ),
+            )
+            .await?;
+        Ok(())
     }
 
     async fn get(&self, request_id: &str, env: &str) -> Option<PermissionRequest> {
@@ -836,7 +923,7 @@ impl PermissionRequestRepoPort for DbPermissionRequestStore {
         &self,
         request_id: &str,
         env: &str,
-        edge_id: &str,
+        edge_id: u64,
     ) -> ServiceResult<()> {
         self.execute(
             "backfill_edge_id",
@@ -951,12 +1038,12 @@ fn row_to_permission_request(row: &DbRow) -> ServiceResult<PermissionRequest> {
         .and_then(|s| parse_timestamp_epoch_ms(&s));
     Ok(PermissionRequest {
         request_id: required_string(row, "request_id")?,
-        edge_id: optional_string(row, "edge_id")?,
+        edge_id: optional_u64(row, "edge_id")?,
         env: required_string(row, "env")?,
         from_id: required_string(row, "from_id")?,
         to_id: required_string(row, "to_id")?,
         request_kind: parse_request_kind(&required_string(row, "request_kind")?)?,
-        requested_ref_id: optional_string(row, "requested_ref_id")?,
+        requested_ref_id: optional_u64(row, "requested_ref_id")?,
         requested_rules: parse_json_opt(&optional_string(row, "requested_rules")?)?,
         message: optional_string(row, "message")?,
         status: parse_request_status(&required_string(row, "status")?)?,
@@ -1029,7 +1116,7 @@ fn row_to_permission_profile(row: &DbRow) -> ServiceResult<PermissionProfile> {
         })?,
     };
     Ok(PermissionProfile {
-        permission_profile_id: required_string(row, "permission_profile_id")?,
+        permission_profile_id: required_u64(row, "id")?,
         bot_id: required_string(row, "bot_id")?,
         env: required_string(row, "env")?,
         name: required_string(row, "name")?,
@@ -1046,12 +1133,12 @@ fn row_to_permission_profile(row: &DbRow) -> ServiceResult<PermissionProfile> {
 
 fn row_to_edge_grant(row: &DbRow) -> ServiceResult<EdgeGrant> {
     Ok(EdgeGrant {
-        edge_id: required_string(row, "edge_id")?,
+        edge_id: required_u64(row, "id")?,
         env: required_string(row, "env")?,
         from_id: required_string(row, "from_id")?,
         to_id: required_string(row, "to_id")?,
         grant_kind: parse_grant_kind(&required_string(row, "grant_kind")?)?,
-        grant_ref_id: required_string(row, "grant_ref_id")?,
+        grant_ref_id: required_u64(row, "grant_ref_id")?,
         rules: parse_json_opt(&optional_string(row, "rules")?)?,
         status: parse_edge_status(&required_string(row, "status")?)?,
         originator_policy_type: parse_originator_policy_type(
@@ -1106,6 +1193,24 @@ fn required_string(row: &DbRow, column: &'static str) -> ServiceResult<String> {
 
 fn optional_string(row: &DbRow, column: &'static str) -> ServiceResult<Option<String>> {
     row.get_string(column).map_err(|err| service_db_error(column, err))
+}
+
+fn required_u64(row: &DbRow, column: &'static str) -> ServiceResult<u64> {
+    let value = row
+        .get_i64(column)
+        .map_err(|err| service_db_error(column, err))?
+        .ok_or_else(|| ServiceError::InternalError(format!("missing edge_permission column {}", column)))?;
+    if value < 0 {
+        return Err(ServiceError::InternalError(format!("negative edge_permission column {}", column)));
+    }
+    Ok(value as u64)
+}
+
+fn optional_u64(row: &DbRow, column: &'static str) -> ServiceResult<Option<u64>> {
+    Ok(row
+        .get_i64(column)
+        .map_err(|err| service_db_error(column, err))?
+        .and_then(|value| if value < 0 { None } else { Some(value as u64) }))
 }
 
 fn parse_json_opt(value: &Option<String>) -> ServiceResult<Option<serde_json::Value>> {
@@ -1289,70 +1394,61 @@ mod tests {
         // migrations/mysql/014_edge_permission.sql for SQLite).
         db.execute(DbStatement::new(
             "CREATE TABLE edge_grants (\
-                edge_id VARCHAR(128) NOT NULL, \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
                 env VARCHAR(32) NOT NULL, \
                 from_id VARCHAR(128) NOT NULL, \
                 to_id VARCHAR(128) NOT NULL, \
                 grant_kind VARCHAR(32) NOT NULL, \
-                grant_ref_id VARCHAR(128) NOT NULL, \
+                grant_ref_id INTEGER NOT NULL, \
                 rules TEXT, \
                 status VARCHAR(16) NOT NULL DEFAULT 'approved', \
                 originator_policy_type VARCHAR(32) NOT NULL DEFAULT 'any', \
                 originator_policy_data TEXT, \
                 gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
                 gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                PRIMARY KEY (edge_id), \
                 UNIQUE (from_id, to_id, env, grant_ref_id))",
         ))
         .await
         .expect("create edge_grants");
         db.execute(DbStatement::new(
             "CREATE TABLE permission_profiles (\
-                permission_profile_id VARCHAR(128) NOT NULL, \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
                 bot_id VARCHAR(128) NOT NULL, \
                 env VARCHAR(32) NOT NULL, \
-                name VARCHAR(128) NOT NULL, \
+                name VARCHAR(128) NOT NULL DEFAULT 'default', \
+                description VARCHAR(512), \
                 rules_template TEXT NOT NULL, \
+                revision INTEGER NOT NULL DEFAULT 1, \
+                digest VARCHAR(128) NOT NULL, \
                 is_default INTEGER NOT NULL DEFAULT 0, \
                 status VARCHAR(16) NOT NULL DEFAULT 'active', \
                 created_by VARCHAR(128) NOT NULL, \
+                updated_by VARCHAR(128), \
                 gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
                 gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                PRIMARY KEY (permission_profile_id))",
+                UNIQUE (bot_id, env, is_default, status))",
         ))
         .await
         .expect("create permission_profiles");
         DbEdgeGrantStore::sqlite(Arc::new(db))
     }
 
-    async fn seed_default(store: &DbEdgeGrantStore, bot_id: &str, env: &str, profile_id: &str) {
-        store
-            .execute(
-                "seed_profile",
-                DbStatement::with_params(
-                    "INSERT INTO permission_profiles \
-                     (permission_profile_id, bot_id, env, name, rules_template, \
-                      is_default, status, created_by) \
-                     VALUES (?, ?, ?, 'default', '{}', 1, 'active', 'test')",
-                    vec![
-                        DbValue::from(profile_id),
-                        DbValue::from(bot_id),
-                        DbValue::from(env),
-                    ],
-                ),
-            )
+    async fn seed_default(store: &DbEdgeGrantStore, bot_id: &str, env: &str) -> u64 {
+        let profile_store = DbPermissionProfileStore::sqlite(store.db.clone());
+        profile_store
+            .ensure_default_profile(bot_id, env)
             .await
-            .expect("seed profile");
+            .expect("seed profile")
     }
 
-    fn default_grant(from: &str, to: &str, env: &str, ref_id: &str) -> EdgeGrant {
+    fn default_grant(from: &str, to: &str, env: &str, ref_id: u64) -> EdgeGrant {
         EdgeGrant {
-            edge_id: format!("eg_{}_{}_{}", from, to, ref_id),
+            edge_id: 0,
             env: env.to_string(),
             from_id: from.to_string(),
             to_id: to.to_string(),
             grant_kind: GrantKind::PermissionProfile,
-            grant_ref_id: ref_id.to_string(),
+            grant_ref_id: ref_id,
             rules: None,
             status: EdgeStatus::Approved,
             originator_policy_type: OriginatorPolicyType::Any,
@@ -1363,21 +1459,20 @@ mod tests {
     #[tokio::test]
     async fn get_default_profile_id_roundtrip() {
         let store = sqlite_store().await;
-        seed_default(&store, "bot_a", "dev", "pp_a").await;
-        assert_eq!(
-            store.get_default_profile_id("bot_a", "dev").await,
-            Some("pp_a".to_string())
-        );
+        let profile_id = seed_default(&store, "bot_a", "dev").await;
+        assert_eq!(store.get_default_profile_id("bot_a", "dev").await, Some(profile_id));
         assert_eq!(store.get_default_profile_id("human_x", "dev").await, None);
     }
 
     #[tokio::test]
     async fn insert_and_list_active_grants() {
         let store = sqlite_store().await;
-        let g = default_grant("a", "b", "dev", "pp_b");
-        store.insert_grant(g.clone()).await.expect("insert");
+        let ref_id = seed_default(&store, "b", "dev").await;
+        let g = default_grant("a", "b", "dev", ref_id);
+        let edge_id = store.insert_grant(g.clone()).await.expect("insert");
         let listed = store.list_active_grants("a", "b", "dev").await;
         assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].edge_id, edge_id);
         assert_eq!(listed[0].from_id, "a");
         assert_eq!(listed[0].grant_kind, GrantKind::PermissionProfile);
     }
@@ -1385,23 +1480,26 @@ mod tests {
     #[tokio::test]
     async fn insert_idempotent_on_unique_key() {
         let store = sqlite_store().await;
-        let mut g = default_grant("a", "b", "dev", "pp_b");
-        store.insert_grant(g.clone()).await.expect("insert 1");
+        let ref_id = seed_default(&store, "b", "dev").await;
+        let mut g = default_grant("a", "b", "dev", ref_id);
+        let edge_id = store.insert_grant(g.clone()).await.expect("insert 1");
         // Re-insert with same (from,to,env,ref) but different edge_id: DO NOTHING.
-        g.edge_id = "different_id".to_string();
-        store.insert_grant(g).await.expect("insert 2");
+        g.edge_id = 9999;
+        let dup_id = store.insert_grant(g).await.expect("insert 2");
         let listed = store.list_active_grants("a", "b", "dev").await;
         assert_eq!(listed.len(), 1);
-        // The original edge_id survives (DO NOTHING kept the first row).
-        assert_eq!(listed[0].edge_id, "eg_a_b_pp_b");
+        // The original auto-generated edge_id survives.
+        assert_eq!(listed[0].edge_id, edge_id);
+        assert_eq!(dup_id, edge_id);
     }
 
     #[tokio::test]
     async fn revoke_removes_from_active() {
         let store = sqlite_store().await;
-        let g = default_grant("a", "b", "dev", "pp_b");
-        store.insert_grant(g.clone()).await.expect("insert");
-        store.revoke_grant(&g.edge_id, "dev").await.expect("revoke");
+        let ref_id = seed_default(&store, "b", "dev").await;
+        let g = default_grant("a", "b", "dev", ref_id);
+        let edge_id = store.insert_grant(g.clone()).await.expect("insert");
+        store.revoke_grant(edge_id, "dev").await.expect("revoke");
         let listed = store.list_active_grants("a", "b", "dev").await;
         assert!(listed.is_empty());
     }
@@ -1409,9 +1507,9 @@ mod tests {
     #[tokio::test]
     async fn has_friend_edge_any_direction() {
         let store = sqlite_store().await;
-        seed_default(&store, "bot_b", "dev", "pp_b").await;
+        let ref_id = seed_default(&store, "bot_b", "dev").await;
         // a (human) → b : friend edge (ref = b's default).
-        let g = default_grant("human_a", "bot_b", "dev", "pp_b");
+        let g = default_grant("human_a", "bot_b", "dev", ref_id);
         store.insert_grant(g).await.expect("insert");
         assert!(store.has_friend_edge("human_a", "bot_b", "dev").await);
         assert!(store.has_friend_edge("bot_b", "human_a", "dev").await);
@@ -1420,21 +1518,21 @@ mod tests {
     #[tokio::test]
     async fn list_friends_outbound_human_actor() {
         let store = sqlite_store().await;
-        seed_default(&store, "bot_b", "dev", "pp_b").await;
-        seed_default(&store, "bot_c", "dev", "pp_c").await;
+        let ref_b = seed_default(&store, "bot_b", "dev").await;
+        let ref_c = seed_default(&store, "bot_c", "dev").await;
         store
-            .insert_grant(default_grant("human_a", "bot_b", "dev", "pp_b"))
+            .insert_grant(default_grant("human_a", "bot_b", "dev", ref_b))
             .await
             .expect("insert b");
         store
-            .insert_grant(default_grant("human_a", "bot_c", "dev", "pp_c"))
+            .insert_grant(default_grant("human_a", "bot_c", "dev", ref_c))
             .await
             .expect("insert c");
         // non-friend (wrong ref) should not be listed
         store
-            .insert_grant(default_grant("human_a", "bot_c", "dev", "pp_b"))
+            .insert_grant(default_grant("human_a", "bot_c", "dev", ref_b))
             .await
-            .expect("insert wrong ref (idempotent vs pp_c? different ref)");
+            .expect("insert wrong ref (different ref)");
 
         let mut friends = store.list_friends("human_a", "dev").await;
         friends.sort();
@@ -1449,7 +1547,7 @@ mod tests {
         let db = LocalSqliteDbPlugin::new().expect("local sqlite");
         db.execute(DbStatement::new(
             "CREATE TABLE permission_profiles (\
-                permission_profile_id VARCHAR(128) NOT NULL, \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
                 bot_id VARCHAR(128) NOT NULL, \
                 env VARCHAR(32) NOT NULL, \
                 name VARCHAR(128) NOT NULL DEFAULT 'default', \
@@ -1463,7 +1561,7 @@ mod tests {
                 updated_by VARCHAR(128), \
                 gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
                 gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                PRIMARY KEY (permission_profile_id))",
+                UNIQUE (bot_id, env, is_default, status))",
         ))
         .await
         .expect("create permission_profiles");
@@ -1474,22 +1572,22 @@ mod tests {
     async fn ensure_default_profile_idempotent() {
         let store = profile_store().await;
         // First call seeds the default profile.
-        store
+        let profile_id = store
             .ensure_default_profile("bot_x", "dev")
             .await
             .expect("seed 1");
         // Second call must be a no-op (D12 rule 2): no overwrite, no revision bump.
-        store
+        let profile_id_2 = store
             .ensure_default_profile("bot_x", "dev")
             .await
             .expect("seed 2");
+        assert_eq!(profile_id, profile_id_2);
 
         let profile = store
             .get_active_default("bot_x", "dev")
             .await
             .expect("default exists");
-        // Deterministic profile_id.
-        assert_eq!(profile.permission_profile_id, "pp_bot_x_default");
+        assert_eq!(profile.permission_profile_id, profile_id);
         assert!(profile.is_default);
         assert_eq!(profile.status, ProfileStatus::Active);
         assert_eq!(profile.created_by, "system");
@@ -1574,13 +1672,14 @@ mod tests {
         let db = LocalSqliteDbPlugin::new().expect("local sqlite");
         db.execute(DbStatement::new(
             "CREATE TABLE permission_requests (\
-                request_id VARCHAR(128) NOT NULL, \
-                edge_id VARCHAR(128), \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                request_id VARCHAR(64) NOT NULL, \
+                edge_id INTEGER, \
                 env VARCHAR(32) NOT NULL, \
                 from_id VARCHAR(128) NOT NULL, \
                 to_id VARCHAR(128) NOT NULL, \
                 request_kind VARCHAR(32) NOT NULL, \
-                requested_ref_id VARCHAR(128), \
+                requested_ref_id INTEGER, \
                 requested_rules TEXT, \
                 message TEXT, \
                 status VARCHAR(16) NOT NULL DEFAULT 'pending', \
@@ -1589,17 +1688,25 @@ mod tests {
                 decided_by VARCHAR(128), \
                 decided_at TEXT, \
                 gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                PRIMARY KEY (request_id))",
+                gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
         ))
         .await
         .expect("create permission_requests");
         DbPermissionRequestStore::sqlite(Arc::new(db))
     }
 
-    fn sample_request(id: &str, env: &str) -> PermissionRequest {
+    static REQUEST_ID_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    fn next_test_request_id() -> String {
+        format!(
+            "test_{}",
+            REQUEST_ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        )
+    }
+
+    fn sample_request(env: &str) -> PermissionRequest {
         PermissionRequest {
-            request_id: id.to_string(),
+            request_id: next_test_request_id(),
             edge_id: None,
             env: env.to_string(),
             from_id: "human_a".to_string(),
@@ -1619,31 +1726,29 @@ mod tests {
     #[tokio::test]
     async fn request_insert_and_get() {
         let store = request_store().await;
-        store
-            .insert(sample_request("req_1", "dev"))
-            .await
-            .expect("insert");
-        let got = store.get("req_1", "dev").await.expect("found");
+        let req = sample_request("dev");
+        let request_id = req.request_id.clone();
+        store.insert(req).await.expect("insert");
+        let got = store.get(&request_id, "dev").await.expect("found");
+        assert_eq!(got.request_id, request_id);
         assert_eq!(got.status, RequestStatus::Pending);
         assert!(got.edge_id.is_none(), "pending → no edge_id");
         assert_eq!(got.request_kind, RequestKind::Connect);
-        assert!(store.get("req_x", "dev").await.is_none(), "missing → None");
+        assert!(store.get("missing", "dev").await.is_none(), "missing → None");
     }
 
     #[tokio::test]
     async fn request_list_inbox_all_and_status_filter() {
         let store = request_store().await;
-        store
-            .insert(sample_request("r1", "dev"))
-            .await
-            .expect("insert r1");
-        store
-            .insert(sample_request("r2", "dev"))
-            .await
-            .expect("insert r2");
+        let r1 = sample_request("dev");
+        let r1_id = r1.request_id.clone();
+        store.insert(r1).await.expect("insert r1");
+        let r2 = sample_request("dev");
+        let r2_id = r2.request_id.clone();
+        store.insert(r2).await.expect("insert r2");
         // decide r2 → approved
         store
-            .decide("r2", "dev", RequestStatus::Approved, "85020", Some("ok"))
+            .decide(&r2_id, "dev", RequestStatus::Approved, "85020", Some("ok"))
             .await
             .expect("decide");
         let all = store.list_inbox("bot_b", "dev", None).await;
@@ -1652,12 +1757,12 @@ mod tests {
             .list_inbox("bot_b", "dev", Some(RequestStatus::Pending))
             .await;
         assert_eq!(pending.len(), 1);
-        assert_eq!(pending[0].request_id, "r1");
+        assert_eq!(pending[0].request_id, r1_id);
         let approved = store
             .list_inbox("bot_b", "dev", Some(RequestStatus::Approved))
             .await;
         assert_eq!(approved.len(), 1);
-        assert_eq!(approved[0].request_id, "r2");
+        assert_eq!(approved[0].request_id, r2_id);
         assert_eq!(approved[0].decided_by.as_deref(), Some("85020"));
         assert!(
             approved[0].decided_at.is_some(),
@@ -1668,16 +1773,15 @@ mod tests {
     #[tokio::test]
     async fn request_backfill_edge_id() {
         let store = request_store().await;
+        let req = sample_request("dev");
+        let request_id = req.request_id.clone();
+        store.insert(req).await.expect("insert");
         store
-            .insert(sample_request("r1", "dev"))
-            .await
-            .expect("insert");
-        store
-            .backfill_edge_id("r1", "dev", "eg_1")
+            .backfill_edge_id(&request_id, "dev", 1001)
             .await
             .expect("backfill");
-        let got = store.get("r1", "dev").await.expect("found");
-        assert_eq!(got.edge_id.as_deref(), Some("eg_1"));
+        let got = store.get(&request_id, "dev").await.expect("found");
+        assert_eq!(got.edge_id, Some(1001));
     }
 
     // ---- DbBotActorConfigStore (T12) ----

--- a/src/bcs/crates/services/bcs-edge-permission-store/tests/conformance_edge_grant.rs
+++ b/src/bcs/crates/services/bcs-edge-permission-store/tests/conformance_edge_grant.rs
@@ -40,26 +40,25 @@ async fn sqlite_with_schema() -> Arc<dyn DbPlugin> {
     let db = Arc::new(LocalSqliteDbPlugin::new().expect("local sqlite"));
     db.execute(DbStatement::new(
         "CREATE TABLE edge_grants (\
-            edge_id VARCHAR(128) NOT NULL, \
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
             env VARCHAR(32) NOT NULL, \
             from_id VARCHAR(128) NOT NULL, \
             to_id VARCHAR(128) NOT NULL, \
             grant_kind VARCHAR(32) NOT NULL, \
-            grant_ref_id VARCHAR(128) NOT NULL, \
+            grant_ref_id INTEGER NOT NULL, \
             rules TEXT, \
             status VARCHAR(16) NOT NULL DEFAULT 'approved', \
             originator_policy_type VARCHAR(32) NOT NULL DEFAULT 'any', \
             originator_policy_data TEXT, \
             gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
             gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-            PRIMARY KEY (edge_id), \
             UNIQUE (from_id, to_id, env, grant_ref_id))",
     ))
     .await
     .expect("create edge_grants");
     db.execute(DbStatement::new(
         "CREATE TABLE permission_profiles (\
-            permission_profile_id VARCHAR(128) NOT NULL, \
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
             bot_id VARCHAR(128) NOT NULL, \
             env VARCHAR(32) NOT NULL, \
             name VARCHAR(128) NOT NULL DEFAULT 'default', \
@@ -73,7 +72,7 @@ async fn sqlite_with_schema() -> Arc<dyn DbPlugin> {
             updated_by VARCHAR(128), \
             gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
             gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-            PRIMARY KEY (permission_profile_id))",
+            UNIQUE (bot_id, env, is_default, status))",
     ))
     .await
     .expect("create permission_profiles");

--- a/src/bcs/crates/services/bcs-edge-permission-store/tests/conformance_permission_profile.rs
+++ b/src/bcs/crates/services/bcs-edge-permission-store/tests/conformance_permission_profile.rs
@@ -27,7 +27,7 @@ async fn sqlite_with_schema() -> Arc<dyn DbPlugin> {
     let db = Arc::new(LocalSqliteDbPlugin::new().expect("local sqlite"));
     db.execute(DbStatement::new(
         "CREATE TABLE permission_profiles (\
-            permission_profile_id VARCHAR(128) NOT NULL, \
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
             bot_id VARCHAR(128) NOT NULL, \
             env VARCHAR(32) NOT NULL, \
             name VARCHAR(128) NOT NULL DEFAULT 'default', \
@@ -41,7 +41,7 @@ async fn sqlite_with_schema() -> Arc<dyn DbPlugin> {
             updated_by VARCHAR(128), \
             gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
             gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-            PRIMARY KEY (permission_profile_id))",
+            UNIQUE (bot_id, env, is_default, status))",
     ))
     .await
     .expect("create permission_profiles");

--- a/src/bcs/crates/services/bcs-edge-permission-store/tests/conformance_permission_request.rs
+++ b/src/bcs/crates/services/bcs-edge-permission-store/tests/conformance_permission_request.rs
@@ -27,13 +27,14 @@ async fn sqlite_with_schema() -> Arc<dyn DbPlugin> {
     let db = Arc::new(LocalSqliteDbPlugin::new().expect("local sqlite"));
     db.execute(DbStatement::new(
         "CREATE TABLE permission_requests (\
-            request_id VARCHAR(128) NOT NULL, \
-            edge_id VARCHAR(128), \
+            id INTEGER PRIMARY KEY AUTOINCREMENT, \
+            request_id VARCHAR(64) NOT NULL, \
+            edge_id INTEGER, \
             env VARCHAR(32) NOT NULL, \
             from_id VARCHAR(128) NOT NULL, \
             to_id VARCHAR(128) NOT NULL, \
             request_kind VARCHAR(32) NOT NULL, \
-            requested_ref_id VARCHAR(128), \
+            requested_ref_id INTEGER, \
             requested_rules TEXT, \
             message TEXT, \
             status VARCHAR(16) NOT NULL DEFAULT 'pending', \
@@ -42,8 +43,7 @@ async fn sqlite_with_schema() -> Arc<dyn DbPlugin> {
             decided_by VARCHAR(128), \
             decided_at TEXT, \
             gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-            gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-            PRIMARY KEY (request_id))",
+            gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
     ))
     .await
     .expect("create permission_requests");

--- a/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
+++ b/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
@@ -26,6 +26,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use uuid::Uuid;
 use bcs_domain::actor::ActorKind;
 use bcs_domain::edge_permission::{
     AdmissionReason, AdmissionResult, AuthzContext, AuthzGrantRef, EdgeGrant, EdgeStatus,
@@ -45,7 +46,14 @@ use bcs_service_api::port::repo::{
     PermissionRequestRepoPort,
 };
 use bcs_service_api::{ServiceError, ServiceResult};
-use uuid::Uuid;
+
+/// Generate a fresh external request id (a bare UUID v4, simple form — no
+/// prefix). The internal bigint PK (`permission_requests.id`) is assigned by
+/// the DB; this string is the client-facing stable id stored in the
+/// `request_id` column.
+fn new_request_id() -> String {
+    Uuid::new_v4().simple().to_string()
+}
 
 /// DB-backed `ConnectService` implementation.
 ///
@@ -134,17 +142,6 @@ fn bot_friend_ext_no_check_scope_friend_deps(
                 .collect()
         })
         .unwrap_or_default()
-}
-
-/// Fresh opaque id for a new edge grant. UUID v4 — collision-safe, unlike a
-/// formatted `from_to` id which collides on re-create after revoke.
-fn new_edge_id() -> String {
-    format!("eg_{}", Uuid::new_v4().simple())
-}
-
-/// Fresh opaque id for a new permission request.
-fn new_request_id() -> String {
-    format!("req_{}", Uuid::new_v4().simple())
 }
 
 #[async_trait]
@@ -279,7 +276,7 @@ impl ConnectService for DbConnectService {
         }
     }
 
-    async fn approve(&self, request_id: &str, decider: &str) -> ServiceResult<Vec<String>> {
+    async fn approve(&self, request_id: &str, decider: &str) -> ServiceResult<Vec<u64>> {
         let req = self
             .requests
             .get(request_id, &self.env)
@@ -300,7 +297,7 @@ impl ConnectService for DbConnectService {
                     "approve: request {} is not a connect request (kind={:?})",
                     req.request_id, req.request_kind
                 ),
-                request_id: Some(req.request_id.clone()),
+                request_id: Some(req.request_id.to_string()),
             });
         }
 
@@ -319,12 +316,12 @@ impl ConnectService for DbConnectService {
         let forward_edge = edge_ids.first().cloned();
         if let Some(eid) = forward_edge.as_ref() {
             self.requests
-                .backfill_edge_id(&req.request_id, &self.env, eid)
+                .backfill_edge_id(req.request_id.as_str(), &self.env, *eid)
                 .await?;
         }
         self.requests
             .decide(
-                &req.request_id,
+                req.request_id.as_str(),
                 &self.env,
                 RequestStatus::Approved,
                 decider,
@@ -341,12 +338,12 @@ impl ConnectService for DbConnectService {
             for r in reverse_pending {
                 if let Some(eid) = reverse_edge.as_ref() {
                     self.requests
-                        .backfill_edge_id(&r.request_id, &self.env, eid)
+                        .backfill_edge_id(r.request_id.as_str(), &self.env, *eid)
                         .await?;
                 }
                 self.requests
                     .decide(
-                        &r.request_id,
+                        r.request_id.as_str(),
                         &self.env,
                         RequestStatus::Approved,
                         decider,
@@ -381,7 +378,7 @@ impl ConnectService for DbConnectService {
 
         self.requests
             .decide(
-                &req.request_id,
+                req.request_id.as_str(),
                 &self.env,
                 RequestStatus::Rejected,
                 decider,
@@ -400,7 +397,7 @@ impl ConnectService for DbConnectService {
             for r in reverse_pending {
                 self.requests
                     .decide(
-                        &r.request_id,
+                        r.request_id.as_str(),
                         &self.env,
                         RequestStatus::Rejected,
                         decider,
@@ -432,7 +429,7 @@ impl ConnectService for DbConnectService {
                         "cancel: request {} is approved (cancel not allowed; use revoke_friend)",
                         req.request_id
                     ),
-                    request_id: Some(req.request_id.clone()),
+                    request_id: Some(req.request_id.to_string()),
                 });
             }
         }
@@ -442,7 +439,7 @@ impl ConnectService for DbConnectService {
         let decider = req.created_by.as_str();
         self.requests
             .decide(
-                &req.request_id,
+                req.request_id.as_str(),
                 &self.env,
                 RequestStatus::Cancelled,
                 decider,
@@ -461,7 +458,7 @@ impl ConnectService for DbConnectService {
             for r in reverse_pending {
                 self.requests
                     .decide(
-                        &r.request_id,
+                        r.request_id.as_str(),
                         &self.env,
                         RequestStatus::Cancelled,
                         decider,
@@ -480,12 +477,12 @@ impl ConnectService for DbConnectService {
             .ok_or_else(|| ServiceError::FriendRequestNotFound(request_id.to_string()))
     }
 
-    async fn revoke_friend(&self, caller: &str, target: &str) -> ServiceResult<Vec<String>> {
+    async fn revoke_friend(&self, caller: &str, target: &str) -> ServiceResult<Vec<u64>> {
         // D12 friend edges are `grant_ref_id == target.default` (caller→target)
         // or `grant_ref_id == caller.default` (target→caller, Bot↔Bot). Revoke
         // exactly those friend edges; leave other (profile/rules) edges alone.
         // Returns the revoked edge_ids (B4c fix — previously a count).
-        let mut revoked: Vec<String> = Vec::new();
+        let mut revoked: Vec<u64> = Vec::new();
 
         // Forward: caller → target, ref == target's default profile id.
         if let Some(target_default) = self
@@ -500,7 +497,7 @@ impl ConnectService for DbConnectService {
             for g in forward {
                 if g.grant_ref_id == target_default && g.grant_kind == GrantKind::PermissionProfile
                 {
-                    self.edge_grants.revoke_grant(&g.edge_id, &self.env).await?;
+                    self.edge_grants.revoke_grant(g.edge_id, &self.env).await?;
                     revoked.push(g.edge_id);
                 }
             }
@@ -520,7 +517,7 @@ impl ConnectService for DbConnectService {
             for g in reverse {
                 if g.grant_ref_id == caller_default && g.grant_kind == GrantKind::PermissionProfile
                 {
-                    self.edge_grants.revoke_grant(&g.edge_id, &self.env).await?;
+                    self.edge_grants.revoke_grant(g.edge_id, &self.env).await?;
                     revoked.push(g.edge_id);
                 }
             }
@@ -734,10 +731,10 @@ impl DbConnectService {
         let mut ids = Vec::new();
 
         // Forward: caller → to_bot.
-        let fwd_id = new_request_id();
+        let fwd_request_id = new_request_id();
         self.requests
             .insert(PermissionRequest {
-                request_id: fwd_id.clone(),
+                request_id: fwd_request_id.clone(),
                 edge_id: None,
                 env: self.env.clone(),
                 from_id: caller.to_string(),
@@ -753,14 +750,14 @@ impl DbConnectService {
                 decided_at: None,
             })
             .await?;
-        ids.push(fwd_id);
+        ids.push(fwd_request_id);
 
         // Reverse: to_bot → caller (Bot↔Bot only).
         if caller_kind == ActorKind::Bot && target_kind == ActorKind::Bot {
-            let rev_id = new_request_id();
+            let rev_request_id = new_request_id();
             self.requests
                 .insert(PermissionRequest {
-                    request_id: rev_id.clone(),
+                    request_id: rev_request_id.clone(),
                     edge_id: None,
                     env: self.env.clone(),
                     from_id: to_bot.to_string(),
@@ -776,7 +773,7 @@ impl DbConnectService {
                     decided_at: None,
                 })
                 .await?;
-            ids.push(rev_id);
+            ids.push(rev_request_id);
         }
 
         Ok(ids)
@@ -800,7 +797,7 @@ impl DbConnectService {
         to_bot: &str,
         caller_kind: ActorKind,
         target_kind: ActorKind,
-    ) -> ServiceResult<(Vec<String>, [String; 2])> {
+    ) -> ServiceResult<(Vec<u64>, [u64; 2])> {
         let mut edge_ids = Vec::new();
 
         // Forward target default profile.
@@ -808,15 +805,15 @@ impl DbConnectService {
         let target_default = self.default_profile_id_of(to_bot).await?;
 
         // Forward edge: caller → to_bot (ref = to_bot.default).
-        let fwd_edge_id = new_edge_id();
-        self.edge_grants
+        let fwd_edge_id = self
+            .edge_grants
             .insert_grant(EdgeGrant {
-                edge_id: fwd_edge_id.clone(),
+                edge_id: 0,
                 env: self.env.clone(),
                 from_id: caller.to_string(),
                 to_id: to_bot.to_string(),
                 grant_kind: GrantKind::PermissionProfile,
-                grant_ref_id: target_default.clone(),
+                grant_ref_id: target_default,
                 rules: None,
                 status: EdgeStatus::Approved,
                 originator_policy_type: OriginatorPolicyType::Any,
@@ -825,22 +822,22 @@ impl DbConnectService {
             .await?;
         edge_ids.push(fwd_edge_id);
 
-        let mut default_refs = [target_default, String::new()];
+        let mut default_refs = [target_default, 0];
 
         // Reverse edge: to_bot → caller (ref = caller.default), Bot↔Bot only.
         if caller_kind == ActorKind::Bot && target_kind == ActorKind::Bot {
             self.profiles.ensure_default_profile(caller, &self.env).await?;
             let caller_default = self.default_profile_id_of(caller).await?;
 
-            let rev_edge_id = new_edge_id();
-            self.edge_grants
+            let rev_edge_id = self
+                .edge_grants
                 .insert_grant(EdgeGrant {
-                    edge_id: rev_edge_id.clone(),
+                    edge_id: 0,
                     env: self.env.clone(),
                     from_id: to_bot.to_string(),
                     to_id: caller.to_string(),
                     grant_kind: GrantKind::PermissionProfile,
-                    grant_ref_id: caller_default.clone(),
+                    grant_ref_id: caller_default,
                     rules: None,
                     status: EdgeStatus::Approved,
                     originator_policy_type: OriginatorPolicyType::Any,
@@ -857,7 +854,7 @@ impl DbConnectService {
     /// Resolve a bot's default profile id, preferring the edge-grant cache and
     /// falling back to the profile store. Errors if still missing after an
     /// `ensure_default_profile` (caller's responsibility to ensure first).
-    async fn default_profile_id_of(&self, bot_id: &str) -> ServiceResult<String> {
+    async fn default_profile_id_of(&self, bot_id: &str) -> ServiceResult<u64> {
         if let Some(id) = self
             .edge_grants
             .get_default_profile_id(bot_id, &self.env)
@@ -888,23 +885,23 @@ impl DbConnectService {
         caller_kind: ActorKind,
         target_kind: ActorKind,
         decider: &str,
-        edge_ids: &[String],
-        default_refs: &[String; 2],
+        edge_ids: &[u64],
+        default_refs: &[u64; 2],
         message: Option<&str>,
     ) -> ServiceResult<Vec<String>> {
         let mut request_ids = Vec::new();
 
         // Forward approved snapshot.
-        let fwd_req_id = new_request_id();
+        let fwd_request_id = new_request_id();
         self.requests
             .insert(PermissionRequest {
-                request_id: fwd_req_id.clone(),
-                edge_id: Some(edge_ids[0].clone()),
+                request_id: fwd_request_id.clone(),
+                edge_id: Some(edge_ids[0]),
                 env: self.env.clone(),
                 from_id: caller.to_string(),
                 to_id: to_bot.to_string(),
                 request_kind: RequestKind::Connect,
-                requested_ref_id: Some(default_refs[0].clone()),
+                requested_ref_id: Some(default_refs[0]),
                 requested_rules: None,
                 message: message.map(|s| s.to_string()),
                 status: RequestStatus::Approved,
@@ -915,23 +912,23 @@ impl DbConnectService {
                 decided_at: None,
             })
             .await?;
-        request_ids.push(fwd_req_id);
+        request_ids.push(fwd_request_id);
 
         // Reverse approved snapshot (Bot↔Bot only).
         if caller_kind == ActorKind::Bot
             && target_kind == ActorKind::Bot
             && edge_ids.len() == 2
         {
-            let rev_req_id = new_request_id();
+            let rev_request_id = new_request_id();
             self.requests
                 .insert(PermissionRequest {
-                    request_id: rev_req_id.clone(),
-                    edge_id: Some(edge_ids[1].clone()),
+                    request_id: rev_request_id.clone(),
+                    edge_id: Some(edge_ids[1]),
                     env: self.env.clone(),
                     from_id: to_bot.to_string(),
                     to_id: caller.to_string(),
                     request_kind: RequestKind::Connect,
-                    requested_ref_id: Some(default_refs[1].clone()),
+                    requested_ref_id: Some(default_refs[1]),
                     requested_rules: None,
                     message: None,
                     status: RequestStatus::Approved,
@@ -941,7 +938,7 @@ impl DbConnectService {
                     decided_at: None,
                 })
                 .await?;
-            request_ids.push(rev_req_id);
+            request_ids.push(rev_request_id);
         }
 
         Ok(request_ids)
@@ -1147,7 +1144,7 @@ impl AdmissionService for DbAdmissionService {
             // resolve via the profile store keyed by the target bot. Non-default
             // profile edges leave revision/digest None (acceptable at T14).
             let (revision, digest) = if g.grant_kind == GrantKind::PermissionProfile
-                && self.is_default_profile_ref(&g.grant_ref_id, to, env).await
+                && self.is_default_profile_ref(g.grant_ref_id, to, env).await
             {
                 self.profiles
                     .get_active_default(to, env)
@@ -1200,7 +1197,7 @@ impl AdmissionService for DbAdmissionService {
 impl DbAdmissionService {
     /// Is `ref_id` the default profile id of `bot`? Used to decide whether to
     /// enrich revision/digest for a permission_profile edge ref.
-    async fn is_default_profile_ref(&self, ref_id: &str, bot: &str, env: &str) -> bool {
+    async fn is_default_profile_ref(&self, ref_id: u64, bot: &str, env: &str) -> bool {
         if let Some(cached) = self.edge_grants.get_default_profile_id(bot, env).await {
             return cached == ref_id;
         }
@@ -1235,19 +1232,18 @@ mod tests {
 
         db.execute(DbStatement::new(
             "CREATE TABLE edge_grants (\
-                edge_id VARCHAR(128) NOT NULL, \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
                 env VARCHAR(32) NOT NULL, \
                 from_id VARCHAR(128) NOT NULL, \
                 to_id VARCHAR(128) NOT NULL, \
                 grant_kind VARCHAR(32) NOT NULL, \
-                grant_ref_id VARCHAR(128) NOT NULL, \
+                grant_ref_id BIGINT NOT NULL, \
                 rules TEXT, \
                 status VARCHAR(16) NOT NULL DEFAULT 'approved', \
                 originator_policy_type VARCHAR(32) NOT NULL DEFAULT 'any', \
                 originator_policy_data TEXT, \
                 gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
                 gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                PRIMARY KEY (edge_id), \
                 UNIQUE (from_id, to_id, env, grant_ref_id))",
         ))
         .await
@@ -1255,7 +1251,7 @@ mod tests {
 
         db.execute(DbStatement::new(
             "CREATE TABLE permission_profiles (\
-                permission_profile_id VARCHAR(128) NOT NULL, \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
                 bot_id VARCHAR(128) NOT NULL, \
                 env VARCHAR(32) NOT NULL, \
                 name VARCHAR(128) NOT NULL DEFAULT 'default', \
@@ -1268,21 +1264,21 @@ mod tests {
                 created_by VARCHAR(128) NOT NULL, \
                 updated_by VARCHAR(128), \
                 gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                PRIMARY KEY (permission_profile_id))",
+                gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
         ))
         .await
         .expect("create permission_profiles");
 
         db.execute(DbStatement::new(
             "CREATE TABLE permission_requests (\
-                request_id VARCHAR(128) NOT NULL, \
-                edge_id VARCHAR(128), \
+                id INTEGER PRIMARY KEY AUTOINCREMENT, \
+                request_id VARCHAR(64) NOT NULL, \
+                edge_id BIGINT, \
                 env VARCHAR(32) NOT NULL, \
                 from_id VARCHAR(128) NOT NULL, \
                 to_id VARCHAR(128) NOT NULL, \
                 request_kind VARCHAR(32) NOT NULL, \
-                requested_ref_id VARCHAR(128), \
+                requested_ref_id BIGINT, \
                 requested_rules TEXT, \
                 message TEXT, \
                 status VARCHAR(16) NOT NULL DEFAULT 'pending', \
@@ -1291,8 +1287,7 @@ mod tests {
                 decided_by VARCHAR(128), \
                 decided_at TEXT, \
                 gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, \
-                PRIMARY KEY (request_id))",
+                gmt_modified TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP)",
         ))
         .await
         .expect("create permission_requests");
@@ -1545,7 +1540,7 @@ mod tests {
         assert_eq!(active.len(), 1, "public auto should create a durable edge");
         let r = rq.get(&res.request_ids[0], "dev").await.expect("approved req");
         assert_eq!(r.status, RequestStatus::Approved);
-        assert_eq!(r.edge_id.as_deref(), Some(res.edge_ids[0].as_str()));
+        assert_eq!(r.edge_id, Some(res.edge_ids[0]));
     }
 
 
@@ -1701,8 +1696,8 @@ mod tests {
         assert!(res.edge_ids.is_empty());
         // default profile should NOT have been seeded (no edge built).
         assert!(pp.get_active_default("x:man", "dev").await.is_none());
-        let id = &res.request_ids[0];
-        let r = rq.get(id, "dev").await.expect("pending request exists");
+        let id = res.request_ids[0].clone();
+        let r = rq.get(&id, "dev").await.expect("pending request exists");
         assert_eq!(r.status, RequestStatus::Pending);
         assert_eq!(r.from_id, "human_1");
         assert_eq!(r.to_id, "x:man");
@@ -1734,7 +1729,7 @@ mod tests {
         let r = rq.get(&res.request_ids[0], "dev").await.expect("approved req");
         assert_eq!(r.status, RequestStatus::Approved);
         assert_eq!(r.decided_by.as_deref(), Some("auto"));
-        assert_eq!(r.edge_id.as_deref(), Some(res.edge_ids[0].as_str()));
+        assert_eq!(r.edge_id, Some(res.edge_ids[0]));
     }
 
     #[tokio::test]
@@ -1817,14 +1812,14 @@ mod tests {
             .await
             .expect("manual pending");
         assert_eq!(pending.status, ConnectStatus::Pending);
-        let rid = &pending.request_ids[0];
+        let rid = pending.request_ids[0].clone();
 
-        let edge_ids = svc.approve(rid, "85020").await.expect("approve ok");
+        let edge_ids = svc.approve(&rid, "85020").await.expect("approve ok");
         assert_eq!(edge_ids.len(), 1, "Human→Bot approve: 1 edge");
         // Original pending request is now approved + edge_id backfilled.
-        let r = rq.get(rid, "dev").await.expect("request still exists");
+        let r = rq.get(&rid, "dev").await.expect("request still exists");
         assert_eq!(r.status, RequestStatus::Approved);
-        assert_eq!(r.edge_id.as_deref(), Some(edge_ids[0].as_str()));
+        assert_eq!(r.edge_id, Some(edge_ids[0]));
         assert!(eg.has_friend_edge("human_1", "x:appr", "dev").await);
     }
 
@@ -1841,9 +1836,9 @@ mod tests {
             .create_connect("human_1", "x:nodupe", None)
             .await
             .expect("manual pending");
-        let rid = &pending.request_ids[0];
+        let rid = pending.request_ids[0].clone();
 
-        svc.approve(rid, "85020").await.expect("approve ok");
+        svc.approve(&rid, "85020").await.expect("approve ok");
 
         // The bot's inbox (to_id=x:nodupe) should contain exactly 1 request
         // for this connect (the original, now approved) — not 2.
@@ -1867,13 +1862,13 @@ mod tests {
             .await
             .expect("manual pending Bot↔Bot");
         assert_eq!(pending.request_ids.len(), 2);
-        let fwd_id = &pending.request_ids[0];
+        let fwd_id = pending.request_ids[0].clone();
 
-        let edge_ids = svc.approve(fwd_id, "owner").await.expect("approve ok");
+        let edge_ids = svc.approve(&fwd_id, "owner").await.expect("approve ok");
         assert_eq!(edge_ids.len(), 2, "Bot↔Bot approve: 2 edges");
 
         // BOTH pending requests are now approved (single accept, §4.1).
-        let fwd = rq.get(fwd_id, "dev").await.expect("fwd present");
+        let fwd = rq.get(&fwd_id, "dev").await.expect("fwd present");
         let rev = rq
             .get(&pending.request_ids[1], "dev")
             .await
@@ -1892,11 +1887,11 @@ mod tests {
             .create_connect("human_1", "x:rej", None)
             .await
             .expect("manual pending");
-        let rid = &pending.request_ids[0];
-        svc.reject(rid, "85020", Some("no thanks".into()))
+        let rid = pending.request_ids[0].clone();
+        svc.reject(&rid, "85020", Some("no thanks".into()))
             .await
             .expect("reject ok");
-        let r = rq.get(rid, "dev").await.expect("request present");
+        let r = rq.get(&rid, "dev").await.expect("request present");
         assert_eq!(r.status, RequestStatus::Rejected);
         assert!(r.edge_id.is_none());
         let active = eg.list_active_grants("human_1", "x:rej", "dev").await;
@@ -1931,14 +1926,14 @@ mod tests {
             .create_connect("human_1", "x:canc", None)
             .await
             .expect("pending");
-        let rid = &pending.request_ids[0];
-        svc.cancel(rid).await.expect("cancel ok");
-        let r = rq.get(rid, "dev").await.expect("request still exists");
+        let rid = pending.request_ids[0].clone();
+        svc.cancel(&rid).await.expect("cancel ok");
+        let r = rq.get(&rid, "dev").await.expect("request still exists");
         assert_eq!(r.status, RequestStatus::Cancelled);
         // cancelling an already-cancelled request is idempotent (B4e): Ok, not
         // an error. Spec says "已 rejected/cancelled 幂等".
-        svc.cancel(rid).await.expect("idempotent cancel ok");
-        let r2 = rq.get(rid, "dev").await.expect("request still exists");
+        svc.cancel(&rid).await.expect("idempotent cancel ok");
+        let r2 = rq.get(&rid, "dev").await.expect("request still exists");
         assert_eq!(r2.status, RequestStatus::Cancelled);
     }
 
@@ -1983,12 +1978,12 @@ mod tests {
         svc.create_connect("human_1", "x:keep", None).await.expect("connect");
         // Manually insert a writer-profile edge with a different ref id.
         eg.insert_grant(EdgeGrant {
-            edge_id: "eg_writer_1".to_string(),
+            edge_id: 4001,
             env: "dev".to_string(),
             from_id: "human_1".to_string(),
             to_id: "x:keep".to_string(),
             grant_kind: GrantKind::PermissionProfile,
-            grant_ref_id: "pp_x:keep_writer".to_string(), // NOT the default
+            grant_ref_id: 4002, // NOT the default
             rules: None,
             status: EdgeStatus::Approved,
             originator_policy_type: OriginatorPolicyType::Any,
@@ -2001,7 +1996,7 @@ mod tests {
         assert_eq!(n.len(), 1, "only the friend (default) edge revoked");
         let active = eg.list_active_grants("human_1", "x:keep", "dev").await;
         assert_eq!(active.len(), 1, "writer edge survives");
-        assert_eq!(active[0].grant_ref_id, "pp_x:keep_writer");
+        assert_eq!(active[0].grant_ref_id, 4002);
     }
 
     #[tokio::test]
@@ -2261,12 +2256,12 @@ mod tests {
         // then insert a Rules edge (grant_kind=Rules, arbitrary ref) from→to.
         pp.ensure_default_profile("x:rules", "dev").await.expect("ensure default");
         eg.insert_grant(EdgeGrant {
-            edge_id: "eg_rules_1".to_string(),
+            edge_id: 5001,
             env: "dev".to_string(),
             from_id: "human_1".to_string(),
             to_id: "x:rules".to_string(),
             grant_kind: GrantKind::Rules,
-            grant_ref_id: "rules_ref_1".to_string(),
+            grant_ref_id: 5003,
             rules: None,
             status: EdgeStatus::Approved,
             originator_policy_type: OriginatorPolicyType::Any,
@@ -2300,12 +2295,12 @@ mod tests {
         seed_bot(&db, "x:radm", "protected", "protected", "APPROVAL", "online", Some("85020")).await;
         pp.ensure_default_profile("x:radm", "dev").await.expect("ensure default");
         eg.insert_grant(EdgeGrant {
-            edge_id: "eg_radm_1".to_string(),
+            edge_id: 5002,
             env: "dev".to_string(),
             from_id: "human_1".to_string(),
             to_id: "x:radm".to_string(),
             grant_kind: GrantKind::Rules,
-            grant_ref_id: "rules_ref_2".to_string(),
+            grant_ref_id: 5004,
             rules: None,
             status: EdgeStatus::Approved,
             originator_policy_type: OriginatorPolicyType::Any,
@@ -2338,7 +2333,7 @@ mod tests {
             .create_connect("human_1", "x:sa", Some("hi".into()))
             .await
             .expect("pending");
-        let rid = &pending.request_ids[0];
+        let rid = pending.request_ids[0].clone();
 
         // Sent: the human caller's outbox has the pending request.
         let sent = svc
@@ -2346,7 +2341,7 @@ mod tests {
             .await
             .expect("sent ok");
         assert_eq!(sent.total, 1);
-        assert_eq!(sent.items[0].request_id, *rid);
+        assert_eq!(sent.items[0].request_id, rid);
         assert_eq!(sent.items[0].from_id, "human_1");
 
         // Sent + Approved filter ⇒ empty (still pending).
@@ -2369,11 +2364,11 @@ mod tests {
             .await
             .expect("all ok");
         assert_eq!(all.total, 1);
-        assert_eq!(all.items[0].request_id, *rid);
+        assert_eq!(all.items[0].request_id, rid);
 
         // Approve, then All from the bot's view: inbox (1 approved) ∪ sent
         // (the bot sent nothing) ⇒ total 1, status approved.
-        svc.approve(rid, "85020").await.expect("approve");
+        svc.approve(&rid, "85020").await.expect("approve");
         let all_bot = svc
             .list_requests("x:sa", RequestDirection::All, None, 1, 20)
             .await

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/edge_grant.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/edge_grant.rs
@@ -43,18 +43,18 @@ pub async fn run_edge_grant_repo_contract<T: EdgeGrantRepoPort + ?Sized>(
 
     // 3. Insert a friend edge (human → target, grant_ref = target's default).
     let edge = EdgeGrant {
-        edge_id: "eg_c1".into(),
+        edge_id: 0,
         env: env.into(),
         from_id: human.into(),
         to_id: target_bot.into(),
         grant_kind: GrantKind::PermissionProfile,
-        grant_ref_id: default_id.clone(),
+        grant_ref_id: default_id,
         rules: None,
         status: EdgeStatus::Approved,
         originator_policy_type: OriginatorPolicyType::Any,
         originator_policy_data: None,
     };
-    repo.insert_grant(edge.clone()).await.unwrap();
+    let edge_id = repo.insert_grant(edge.clone()).await.unwrap();
 
     // 4. has_friend_edge both directions (D12 symmetric).
     assert!(
@@ -69,7 +69,7 @@ pub async fn run_edge_grant_repo_contract<T: EdgeGrantRepoPort + ?Sized>(
     // 5. list_active_grants has exactly the friend edge.
     let grants = repo.list_active_grants(human, target_bot, env).await;
     assert_eq!(grants.len(), 1, "one active grant after friend insert");
-    assert_eq!(grants[0].edge_id, "eg_c1");
+    assert_eq!(grants[0].edge_id, edge_id);
 
     // 6. list_friends(human) contains target.
     assert!(
@@ -84,8 +84,8 @@ pub async fn run_edge_grant_repo_contract<T: EdgeGrantRepoPort + ?Sized>(
     //    but is NOT a friend edge (D12 discrimination: only the default-ref
     //    edge counts as a friend).
     let wrong = EdgeGrant {
-        edge_id: "eg_c_wrong".into(),
-        grant_ref_id: "wrong_id".into(),
+        edge_id: 0,
+        grant_ref_id: default_id + 1,
         ..edge.clone()
     };
     repo.insert_grant(wrong).await.unwrap();
@@ -110,12 +110,13 @@ pub async fn run_edge_grant_repo_contract<T: EdgeGrantRepoPort + ?Sized>(
     //    with the same key — even under a different `edge_id` — does NOT add a
     //    new active grant.
     let dup = EdgeGrant {
-        edge_id: "eg_c_dup".into(),
+        edge_id: 1234,
         ..edge.clone()
     };
-    repo.insert_grant(dup)
+    let dup_id = repo.insert_grant(dup)
         .await
         .expect("dup insert must not error (ON CONFLICT)");
+    assert_eq!(dup_id, edge_id, "duplicate insert returns existing id");
     assert_eq!(
         repo.list_active_grants(human, target_bot, env).await.len(),
         2,
@@ -124,7 +125,7 @@ pub async fn run_edge_grant_repo_contract<T: EdgeGrantRepoPort + ?Sized>(
 
     // 9. Revoke the friend edge → has_friend_edge false (default revoked, the
     //    wrong-ref edge cannot substitute for a friend edge).
-    repo.revoke_grant("eg_c1", env).await.unwrap();
+    repo.revoke_grant(edge_id, env).await.unwrap();
     assert!(
         !repo.has_friend_edge(human, target_bot, env).await,
         "revoked friend edge → not friends (wrong-ref does not count)"

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/permission_request.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/permission_request.rs
@@ -17,8 +17,9 @@ pub async fn run_permission_request_repo_contract<T: PermissionRequestRepoPort +
     repo: &T,
     env: &str,
 ) {
+    let request_id = "contract-1".to_string();
     let req = PermissionRequest {
-        request_id: "req_c1".into(),
+        request_id: request_id.clone(),
         edge_id: None,
         env: env.into(),
         from_id: "human_1".into(),
@@ -36,7 +37,8 @@ pub async fn run_permission_request_repo_contract<T: PermissionRequestRepoPort +
     repo.insert(req).await.expect("insert request");
 
     // get — pending request round-trips, edge_id unset.
-    let got = repo.get("req_c1", env).await.expect("found");
+    let got = repo.get(&request_id, env).await.expect("found");
+    assert_eq!(got.request_id, request_id);
     assert_eq!(got.status, RequestStatus::Pending);
     assert!(got.edge_id.is_none(), "pending → no edge_id");
     assert_eq!(got.request_kind, RequestKind::Connect);
@@ -72,7 +74,7 @@ pub async fn run_permission_request_repo_contract<T: PermissionRequestRepoPort +
 
     // decide — status, decided_by, decided_at mutate.
     repo.decide(
-        "req_c1",
+        &request_id,
         env,
         RequestStatus::Approved,
         "owner",
@@ -80,7 +82,7 @@ pub async fn run_permission_request_repo_contract<T: PermissionRequestRepoPort +
     )
     .await
     .expect("decide");
-    let got2 = repo.get("req_c1", env).await.expect("found after decide");
+    let got2 = repo.get(&request_id, env).await.expect("found after decide");
     assert_eq!(got2.status, RequestStatus::Approved, "status → approved");
     assert_eq!(got2.decided_by.as_deref(), Some("owner"), "decided_by set");
     // decided_at is a DB-managed timestamp set at decision time.
@@ -88,19 +90,19 @@ pub async fn run_permission_request_repo_contract<T: PermissionRequestRepoPort +
     assert_eq!(got2.decision_reason.as_deref(), Some("ok"), "decision_reason set");
 
     // backfill_edge_id — annotate the approved request with its new edge.
-    repo.backfill_edge_id("req_c1", env, "eg_c1")
+    repo.backfill_edge_id(&request_id, env, 3001)
         .await
         .expect("backfill_edge_id");
-    let got3 = repo.get("req_c1", env).await.expect("found after backfill");
+    let got3 = repo.get(&request_id, env).await.expect("found after backfill");
     assert_eq!(
-        got3.edge_id.as_deref(),
-        Some("eg_c1"),
+        got3.edge_id,
+        Some(3001),
         "edge_id back-filled after approval"
     );
 
     // Missing request → None (non-fallible).
     assert!(
-        repo.get("req_missing", env).await.is_none(),
+        repo.get("missing", env).await.is_none(),
         "missing request → None"
     );
 }

--- a/src/bcs/crates/test-support/bcs-test-support/src/edge_permission_noop.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/edge_permission_noop.rs
@@ -21,15 +21,15 @@ impl EdgeGrantRepoPort for NoopEdgeGrantRepo {
     async fn is_authorized(&self, _: &str, _: &str, _: &str) -> bool { false }
     async fn has_friend_edge(&self, _: &str, _: &str, _: &str) -> bool { false }
     async fn list_friends(&self, _: &str, _: &str) -> Vec<String> { vec![] }
-    async fn insert_grant(&self, _: EdgeGrant) -> ServiceResult<()> { Ok(()) }
-    async fn revoke_grant(&self, _: &str, _: &str) -> ServiceResult<()> { Ok(()) }
-    async fn get_default_profile_id(&self, _: &str, _: &str) -> Option<String> { None }
+    async fn insert_grant(&self, _: EdgeGrant) -> ServiceResult<u64> { Ok(1) }
+    async fn revoke_grant(&self, _: u64, _: &str) -> ServiceResult<()> { Ok(()) }
+    async fn get_default_profile_id(&self, _: &str, _: &str) -> Option<u64> { None }
 }
 
 pub struct NoopPermissionProfileRepo;
 #[async_trait]
 impl PermissionProfileRepoPort for NoopPermissionProfileRepo {
-    async fn ensure_default_profile(&self, _: &str, _: &str) -> ServiceResult<()> { Ok(()) }
+    async fn ensure_default_profile(&self, _: &str, _: &str) -> ServiceResult<u64> { Ok(1) }
     async fn get_active_default(&self, _: &str, _: &str) -> Option<PermissionProfile> { None }
     async fn upsert_revision(&self, _: PermissionProfile) -> ServiceResult<()> { Ok(()) }
 }
@@ -42,7 +42,7 @@ impl PermissionRequestRepoPort for NoopPermissionRequestRepo {
     async fn list_inbox(&self, _: &str, _: &str, _: Option<RequestStatus>) -> Vec<PermissionRequest> { vec![] }
     async fn list_sent(&self, _: &str, _: &str, _: Option<RequestStatus>) -> Vec<PermissionRequest> { vec![] }
     async fn decide(&self, _: &str, _: &str, _: RequestStatus, _: &str, _: Option<&str>) -> ServiceResult<()> { Ok(()) }
-    async fn backfill_edge_id(&self, _: &str, _: &str, _: &str) -> ServiceResult<()> { Ok(()) }
+    async fn backfill_edge_id(&self, _: &str, _: &str, _: u64) -> ServiceResult<()> { Ok(()) }
 }
 
 pub struct NoopConnectService;
@@ -51,13 +51,13 @@ impl ConnectService for NoopConnectService {
     async fn create_connect(&self, _: &str, _: &str, _: Option<String>) -> ServiceResult<ConnectResult> {
         Ok(ConnectResult { request_ids: vec![], edge_ids: vec![], status: ConnectStatus::Pending, auto_accepted: false })
     }
-    async fn approve(&self, _: &str, _: &str) -> ServiceResult<Vec<String>> { Ok(vec![]) }
+    async fn approve(&self, _: &str, _: &str) -> ServiceResult<Vec<u64>> { Ok(vec![]) }
     async fn reject(&self, _: &str, _: &str, _: Option<String>) -> ServiceResult<()> { Ok(()) }
     async fn cancel(&self, _: &str) -> ServiceResult<()> { Ok(()) }
     async fn get_request(&self, _: &str) -> ServiceResult<PermissionRequest> {
         Err(bcs_service_api::ServiceError::FriendRequestNotFound("noop".to_string()))
     }
-    async fn revoke_friend(&self, _: &str, _: &str) -> ServiceResult<Vec<String>> { Ok(vec![]) }
+    async fn revoke_friend(&self, _: &str, _: &str) -> ServiceResult<Vec<u64>> { Ok(vec![]) }
     async fn list_friends(&self, _: &str) -> ServiceResult<Vec<FriendListEntry>> { Ok(vec![]) }
     async fn list_requests(
         &self,

--- a/src/bcs/docs/superpowers/specs/2026-08-18-friend-edge-permission-reform.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-18-friend-edge-permission-reform.md
@@ -174,7 +174,7 @@ erDiagram
     BOT ||--o{ PERMISSION_PROFILE : owns
     BOT ||--o{ CAPABILITY : exposes
     PERMISSION_PROFILE ||--o{ EDGE_GRANT : "referenced_by(target.default)"
-    EDGE_GRANT ||--o{ PERMISSION_REQUEST : "request.edge_id -> edge.edge_id"
+    EDGE_GRANT ||--o{ PERMISSION_REQUEST : "request.edge_id -> edge.id"
 
     EDGE_GRANT {
         string edge_id PK
@@ -469,14 +469,32 @@ ensure_default_profile(bot_uuid, env):
 
 ### 8.4 Phase 2：全量 ETL（一次性，幂等可重放）
 
-> 按 env 分批（singlebox→pre→prod）。脚本顺序 0→5。全 `ON CONFLICT DO NOTHING` + 确定性 MD5 id。全程只读旧表。
+> 按 env 分批（singlebox→pre→prod）。脚本顺序 0→5。全 `ON CONFLICT DO NOTHING`/`INSERT IGNORE` + 确定性 MD5 id。全程只读旧表。`ac_bot_friend` 与 `bcs_friend_requests` 必须先按关系维度取 latest-status（`ROW_NUMBER() ... ORDER BY gmt_create DESC, id DESC`），全量迁移只消费最新行，避免历史流水旧状态污染。
 
-**映射视图**（D11）：
+**映射与 latest-status 视图**（D11）：
 ```sql
 CREATE VIEW v_ac_bot_map AS
-SELECT CONCAT(bot_id,':',owner_id) AS bot_uuid, public,
+SELECT CONCAT(bot_id,':',owner_id) AS bot_uuid, bot_id, owner_id, public,
        JSON_EXTRACT(ext,'$.friend_approval') AS friend_approval
 FROM ac_bots WHERE is_delete=0;
+
+CREATE VIEW v_ac_bot_friend_latest AS
+SELECT * FROM (
+  SELECT f.*, ROW_NUMBER() OVER (
+    PARTITION BY requester_entity_id, target_bot_id, target_entity_id, env
+    ORDER BY gmt_create DESC, id DESC
+  ) AS rn
+  FROM ac_bot_friend f
+) ranked WHERE rn=1;
+
+CREATE VIEW v_bcs_friend_requests_latest AS
+SELECT * FROM (
+  SELECT fr.*, ROW_NUMBER() OVER (
+    PARTITION BY from_bot, to_bot, env
+    ORDER BY gmt_create DESC, id DESC
+  ) AS rn
+  FROM bcs_friend_requests fr
+) ranked WHERE rn=1;
 ```
 
 **脚本 0 — default profile 批量 seed**（每 bot 一条）：
@@ -509,7 +527,7 @@ SELECT
   CONCAT('eg_',MD5(CONCAT('human_',f.requester_entity_id,'|',m.bot_uuid,'|',f.env,'|pp_',m.bot_uuid,'_default'))),
   f.env, CONCAT('human_',f.requester_entity_id), m.bot_uuid,
   'permission_profile', CONCAT('pp_',m.bot_uuid,'_default'), NULL, 'approved', 'any', NULL
-FROM ac_bot_friend f
+FROM v_ac_bot_friend_latest f
 JOIN v_ac_bot_map m ON m.bot_id=f.target_bot_id AND m.owner_id=f.target_entity_id
 WHERE f.status='ACCEPTED'
 ON CONFLICT (from_id,to_id,env,grant_ref_id) DO NOTHING;
@@ -524,25 +542,28 @@ SELECT
   COALESCE(JSON_EXTRACT(f.ext,'$.approvals[0].approver'), f.target_entity_id),
   JSON_EXTRACT(f.ext,'$.approvals[0].approval_time'),
   f.requester_entity_id, f.gmt_create, f.gmt_modified
-FROM ac_bot_friend f JOIN v_ac_bot_map m ON m.bot_id=f.target_bot_id AND m.owner_id=f.target_entity_id
+FROM v_ac_bot_friend_latest f JOIN v_ac_bot_map m ON m.bot_id=f.target_bot_id AND m.owner_id=f.target_entity_id
 WHERE f.status='ACCEPTED'
 ON CONFLICT (request_id) DO NOTHING;
 ```
 > 自动批（`ext.approvals[].type=AUTO`）→ `decided_by='auto'`。
 
-**脚本 3 — System A PENDING/REJECTED/CANCELLED → permission_requests（无 edge）**：同源 `migration-plan` 脚本 4，`CASE status WHEN 'PENDING' THEN 'pending' ...`，`ON CONFLICT (request_id) DO NOTHING`。
+**脚本 3 — System A latest PENDING/REJECTED/CANCELLED → permission_requests（无 edge）**：同源 `migration-plan` 脚本 4，但输入必须是 `v_ac_bot_friend_latest`，`CASE status WHEN 'PENDING' THEN 'pending' ...`，`ON CONFLICT (request_id) DO NOTHING`。
 
 **脚本 4 — System B `bcs_friendships` → Bot↔Bot 双向 2 边 + 2 approved requests**：同源 `actor-info` §2.2 脚本 4（=`migration-plan` 脚本 5），`A→B ref=B.default`、`B→A ref=A.default`，`UNION ALL`，`ON CONFLICT DO NOTHING`。`bcs_actor_relations` 友谊边（is_creator=0）**不单独迁**（双写镜像，仅对账校验 pair 集）。
 
-**脚本 5 — System B `bcs_friend_requests` pending/rejected → permission_requests**：同源脚本 6，`WHERE status<>'accepted'`（accepted 已被脚本 4 覆盖）。
+**脚本 5 — System B latest `bcs_friend_requests` pending/rejected → permission_requests**：同源脚本 6，但输入必须是 `v_bcs_friend_requests_latest`，`WHERE status<>'accepted'`（accepted 已被脚本 4 覆盖）。
 
 **actor 配置 ETL**（与好友同批，`actor-info` §1.5）：ETL1 `human_addable←ac_bots.public`、ETL2 `friend_approval←ext.friend_approval`（取严融合）、ETL3 `visibility` 修正（`public=0` 的 bot 改 private）。
 
 **验证门 2→3**：
 ```sql
 -- 计数对账
-SELECT (SELECT COUNT(*) FROM ac_bot_friend WHERE status='ACCEPTED' AND env=?) AS old_h,
-       (SELECT COUNT(*) FROM edge_grants WHERE from_id LIKE 'human_%' AND env=?) AS new_h;  -- 等
+SELECT f.env, COUNT(*) AS old_h
+FROM v_ac_bot_friend_latest f
+WHERE f.status='ACCEPTED'
+GROUP BY f.env;
+-- 与 edge_grants human_* approved 按 env 对齐；同时检查 orphan、actor_relation mirror drift、request/edge 一致性。
 SELECT (SELECT COUNT(*)*2 FROM bcs_friendships WHERE env=?) AS old_b,
        (SELECT COUNT(*) FROM edge_grants WHERE from_id NOT LIKE 'human_%' AND to_id NOT LIKE 'human_%' AND env=?) AS new_b;  -- 等
 SELECT (SELECT COUNT(*) FROM bcs_bots WHERE env=?) AS bots,
@@ -2188,69 +2209,69 @@ Plan complete and saved to `docs/superpowers/plans/2026-08-18-friend-edge-permis
 -- Spec: docs/superpowers/specs/2026-08-18-friend-edge-permission-reform.md §3.1.
 
 CREATE TABLE IF NOT EXISTS `edge_grants` (
-  `edge_id`                  VARCHAR(48)  NOT NULL,
-  `env`                      VARCHAR(16)  NOT NULL,
-  `from_id`                  VARCHAR(256) NOT NULL,
-  `to_id`                    VARCHAR(256) NOT NULL,
-  `grant_kind`               VARCHAR(16)  NOT NULL,           -- permission_profile | rules
-  `grant_ref_id`             VARCHAR(128) NOT NULL,
-  `rules`                    JSON         DEFAULT NULL,
-  `status`                   VARCHAR(16)  NOT NULL DEFAULT 'approved',
-  `originator_policy_type`   VARCHAR(16)  NOT NULL DEFAULT 'any',
-  `originator_policy_data`   JSON         DEFAULT NULL,
-  `created_at`               BIGINT       NOT NULL,
-  `updated_at`               BIGINT       NOT NULL,
-  PRIMARY KEY (`edge_id`),
+  `id`                    BIGINT       NOT NULL AUTO_INCREMENT,
+  `env`                   VARCHAR(16)  NOT NULL,
+  `from_id`               VARCHAR(256) NOT NULL,
+  `to_id`                 VARCHAR(256) NOT NULL,
+  `grant_kind`            VARCHAR(16)  NOT NULL,           -- permission_profile | rules
+  `grant_ref_id`          BIGINT       NOT NULL,
+  `rules`                 JSON         DEFAULT NULL,
+  `status`                VARCHAR(16)  NOT NULL DEFAULT 'approved',
+  `originator_policy_type` VARCHAR(16)  NOT NULL DEFAULT 'any',
+  `originator_policy_data` JSON         DEFAULT NULL,
+  `gmt_create`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `gmt_modified`          timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
   UNIQUE KEY `ux_edge_from_to_env_ref` (`from_id`, `to_id`, `env`, `grant_ref_id`),
   KEY `idx_edge_from_env_status` (`from_id`, `env`, `status`),
   KEY `idx_edge_to_env_status`   (`to_id`, `env`, `status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `permission_profiles` (
-  `permission_profile_id`    VARCHAR(48)  NOT NULL,
-  `bot_id`                   VARCHAR(256) NOT NULL,
-  `env`                      VARCHAR(16)  NOT NULL,
-  `name`                     VARCHAR(64)  NOT NULL DEFAULT 'default',
-  `description`              VARCHAR(512) DEFAULT NULL,
-  `rules_template`           JSON         NOT NULL,
-  `revision`                 BIGINT       NOT NULL DEFAULT 1,
-  `digest`                   VARCHAR(128) NOT NULL,
-  `is_default`               TINYINT(1)   NOT NULL DEFAULT 0,
-  `status`                   VARCHAR(16)  NOT NULL DEFAULT 'active',
-  `created_by`               VARCHAR(64)  NOT NULL,
-  `updated_by`               VARCHAR(64)  DEFAULT NULL,
-  `created_at`               BIGINT       NOT NULL,
-  `updated_at`               BIGINT       NOT NULL,
-  PRIMARY KEY (`permission_profile_id`),
+  `id`                    BIGINT       NOT NULL AUTO_INCREMENT,
+  `bot_id`                VARCHAR(256) NOT NULL,
+  `env`                   VARCHAR(16)  NOT NULL,
+  `name`                  VARCHAR(64)  NOT NULL DEFAULT 'default',
+  `description`           VARCHAR(512) DEFAULT NULL,
+  `rules_template`        JSON         NOT NULL,
+  `revision`              BIGINT       NOT NULL DEFAULT 1,
+  `digest`                VARCHAR(128) NOT NULL,
+  `is_default`            TINYINT(1)   NOT NULL DEFAULT 0,
+  `status`                VARCHAR(16)  NOT NULL DEFAULT 'active',
+  `created_by`            VARCHAR(64)  NOT NULL,
+  `updated_by`            VARCHAR(64)  DEFAULT NULL,
+  `gmt_create`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `gmt_modified`          timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
   UNIQUE KEY `ux_profile_bot_env_default` (`bot_id`, `env`, `is_default`, `status`),
   KEY `idx_profile_bot_env` (`bot_id`, `env`, `status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `permission_requests` (
-  `request_id`        VARCHAR(48)  NOT NULL,
-  `edge_id`           VARCHAR(48)  DEFAULT NULL,
+  `id`                BIGINT       NOT NULL AUTO_INCREMENT,
+  `edge_id`           BIGINT       DEFAULT NULL,
   `env`               VARCHAR(16)  NOT NULL,
   `from_id`           VARCHAR(256) NOT NULL,
   `to_id`             VARCHAR(256) NOT NULL,
   `request_kind`      VARCHAR(16)  NOT NULL,                  -- connect | permission_profile | rules | revoke
-  `requested_ref_id`  VARCHAR(128) DEFAULT NULL,
+  `requested_ref_id`  BIGINT       DEFAULT NULL,
   `requested_rules`   JSON         DEFAULT NULL,
   `message`           TEXT         DEFAULT NULL,
   `status`            VARCHAR(16)  NOT NULL DEFAULT 'pending',
   `decision_reason`   TEXT         DEFAULT NULL,
   `created_by`        VARCHAR(64)  NOT NULL,
   `decided_by`        VARCHAR(64)  DEFAULT NULL,
-  `created_at`        BIGINT       NOT NULL,
-  `updated_at`        BIGINT       NOT NULL,
-  `decided_at`        BIGINT       DEFAULT NULL,
-  PRIMARY KEY (`request_id`),
+  `gmt_create`        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `gmt_modified`      timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `decided_at`        timestamp    DEFAULT NULL,
+  PRIMARY KEY (`id`),
   KEY `idx_req_to_env_status` (`to_id`, `env`, `status`),
   KEY `idx_req_from_env_status` (`from_id`, `env`, `status`),
   KEY `idx_req_edge` (`edge_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `capabilities` (
-  `capability_id`     VARCHAR(48)  NOT NULL,
+  `id`                BIGINT       NOT NULL AUTO_INCREMENT,
   `bot_id`            VARCHAR(256) NOT NULL,
   `env`               VARCHAR(16)  NOT NULL,
   `tool`              VARCHAR(64)  NOT NULL,
@@ -2261,12 +2282,12 @@ CREATE TABLE IF NOT EXISTS `capabilities` (
   `raw_metadata`      JSON         DEFAULT NULL,
   `created_at`        BIGINT       NOT NULL,
   `updated_at`        BIGINT       NOT NULL,
-  PRIMARY KEY (`capability_id`),
+  PRIMARY KEY (`id`),
   KEY `idx_cap_bot_env` (`bot_id`, `env`, `status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `authz_decision_logs` (
-  `decision_id`   VARCHAR(48)  NOT NULL,
+  `id`            BIGINT       NOT NULL AUTO_INCREMENT,
   `env`           VARCHAR(16)  NOT NULL,
   `task_id`       VARCHAR(128) DEFAULT NULL,
   `run_id`        VARCHAR(128) DEFAULT NULL,
@@ -2279,7 +2300,7 @@ CREATE TABLE IF NOT EXISTS `authz_decision_logs` (
   `grant_refs`    JSON         NOT NULL,
   `context_json`  JSON         DEFAULT NULL,
   `created_at`    BIGINT       NOT NULL,
-  PRIMARY KEY (`decision_id`),
+  PRIMARY KEY (`id`),
   KEY `idx_adl_env_from_to` (`env`, `from_id`, `to_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -2323,12 +2344,12 @@ SqliteMigration {
     name: "edge_permission",
     sql: r#"
 CREATE TABLE IF NOT EXISTS edge_grants (
-  edge_id TEXT PRIMARY KEY,
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
   env TEXT NOT NULL,
   from_id TEXT NOT NULL,
   to_id TEXT NOT NULL,
   grant_kind TEXT NOT NULL,
-  grant_ref_id TEXT NOT NULL,
+  grant_ref_id INTEGER NOT NULL,
   rules TEXT,
   status TEXT NOT NULL DEFAULT 'approved',
   originator_policy_type TEXT NOT NULL DEFAULT 'any',
@@ -2341,7 +2362,7 @@ CREATE INDEX IF NOT EXISTS idx_edge_from_env_status ON edge_grants(from_id, env,
 CREATE INDEX IF NOT EXISTS idx_edge_to_env_status   ON edge_grants(to_id, env, status);
 
 CREATE TABLE IF NOT EXISTS permission_profiles (
-  permission_profile_id TEXT PRIMARY KEY,
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
   bot_id TEXT NOT NULL,
   env TEXT NOT NULL,
   name TEXT NOT NULL DEFAULT 'default',
@@ -2361,13 +2382,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS ux_profile_bot_env_default
 CREATE INDEX IF NOT EXISTS idx_profile_bot_env ON permission_profiles(bot_id, env, status);
 
 CREATE TABLE IF NOT EXISTS permission_requests (
-  request_id TEXT PRIMARY KEY,
-  edge_id TEXT,
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  edge_id INTEGER,
   env TEXT NOT NULL,
   from_id TEXT NOT NULL,
   to_id TEXT NOT NULL,
   request_kind TEXT NOT NULL,
-  requested_ref_id TEXT,
+  requested_ref_id INTEGER,
   requested_rules TEXT,
   message TEXT,
   status TEXT NOT NULL DEFAULT 'pending',
@@ -2383,7 +2404,7 @@ CREATE INDEX IF NOT EXISTS idx_req_from_env_status ON permission_requests(from_i
 CREATE INDEX IF NOT EXISTS idx_req_edge            ON permission_requests(edge_id);
 
 CREATE TABLE IF NOT EXISTS capabilities (
-  capability_id TEXT PRIMARY KEY,
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
   bot_id TEXT NOT NULL,
   env TEXT NOT NULL,
   tool TEXT NOT NULL,
@@ -2398,7 +2419,7 @@ CREATE TABLE IF NOT EXISTS capabilities (
 CREATE INDEX IF NOT EXISTS idx_cap_bot_env ON capabilities(bot_id, env, status);
 
 CREATE TABLE IF NOT EXISTS authz_decision_logs (
-  decision_id TEXT PRIMARY KEY,
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
   env TEXT NOT NULL,
   task_id TEXT,
   run_id TEXT,

--- a/src/bcs/docs/superpowers/specs/2026-08-20-bot-search-endpoint-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-20-bot-search-endpoint-design.md
@@ -1,8 +1,8 @@
 # Bot Search 接口设计
 
-> 状态：已实现（`GET /bots/search`，commit `feat(bots): implement GET /bots/search with filtering + tc_bot`）
-> 日期：2026-08-20
-> 范围：为好友申请页面提供 bot 列表查询接口，支持名称模糊搜索 + 其他关键字过滤 + 分页 + friend 状态。
+> 状态：修订待确认（本次仅更新 spec，确认后再改代码）
+> 日期：2026-08-20；修订：2026-08-24
+> 范围：为好友申请页面提供 bot 列表查询接口，支持名称模糊搜索 + 可见性/好友策略过滤 + 分页 + friend 状态。
 
 ## 1. 背景
 
@@ -36,9 +36,12 @@ GET /bots/search
 | 参数 | 类型 | 默认 | 说明 |
 |---|---|---|---|
 | `q` | string | — | 名称/简介模糊搜索（contains，大小写不敏感） |
-| `visibility` | string | — | 可见性过滤：`public` / `protected` / `private`；非法值 → 400 |
+| `visibility` | string | — | Bot 可见性过滤，支持单值或多值 OR：`public` / `protected` / `private`，推荐逗号分隔如 `visibility=public,protected`；非法值 → 400 |
+| `user_visibility` | string | — | 用户侧可见/可加好友策略过滤，支持单值或多值 OR：`public` / `protected` / `private`，推荐逗号分隔如 `user_visibility=public,protected`；非法值 → 400 |
 | `status` | string | — | 状态过滤：`online` / `hidden`；非法值 → 400 |
-| `is_friend` | bool | — | friend 状态过滤：`true` / `false`（需 Bearer 认证） |
+| `viewer_actor_type` | string | — | 好友关系视角 actor 类型：`human` / `bot`；必须和 `viewer_actor_id` 同传 |
+| `viewer_actor_id` | string | — | 好友关系视角 actor id；必须和 `viewer_actor_type` 同传 |
+| `friendship` | string | `all` | 相对显式 viewer 的好友关系过滤：`all` / `friends` / `non_friends`。`all` 表示不过滤；`friends` 仅好友；`non_friends` 仅非好友。`friends`/`non_friends` 必须同时传 viewer |
 | `tc_bot` | bool | — | TC（TeamClaw backend）bot 过滤：`true` 仅返回 backend 过来的 bot，`false` 仅返回 native bot，缺省不过滤（见 §3.6.6） |
 | `offset` | int | 0 | 分页起始 |
 | `limit` | int | 20 | 每页数，取值范围 `1..=100`，越界 → 400 |
@@ -46,8 +49,10 @@ GET /bots/search
 ### 3.3 认证
 
 - **Bearer（可选）** — 任何 actor（人或 bot）
-- 无 Bearer → 仅返回 `visibility=public` 的 bot，`is_friend` 字段不返回
-- 有 Bearer → 返回可见 bot 列表 + 附带 `is_friend` 状态（从 `edge_grants` 读取）
+- 无 Bearer → 仅返回 `visibility=public` 的 bot
+- 有 Bearer → 返回可见 bot 列表；Bearer 只影响可见性范围和排除调用者自身
+- 好友关系不从 Bearer/请求身份隐式计算；仅当显式传 `viewer_actor_type + viewer_actor_id` 时返回 `is_friend` 字段。
+- `friendship` 是查询过滤条件，默认 `all`；`friendship=friends/non_friends` 必须提供显式 viewer。
 
 ### 3.4 响应
 
@@ -59,6 +64,13 @@ GET /bots/search
       "name": "研发助手",
       "summary": "代码审查专家",
       "visibility": "public",
+      "user_visibility": "protected",
+      "friend_ext": {
+        "no_check_scope_friend_deps": ["dep-1"],
+        "view_scope_user_friend_deps": [],
+        "view_scope_agent_friend_deps": []
+      },
+      "friend_check_in_strategy": "APPROVAL",
       "status": "online",
       "is_friend": false,
       "actor_kind": "bot",
@@ -71,27 +83,38 @@ GET /bots/search
 }
 ```
 
-> `is_friend` 字段仅在有 Bearer 时返回；匿名调用该字段缺省（`skip_serializing_if`）。
+> `user_visibility` / `friend_ext` / `friend_check_in_strategy` 直接透出 Bot 当前好友策略配置；缺省值按现有 bot 配置模型兜底。
+> `is_friend` 是响应字段，不再作为查询参数名使用；仅在显式传 `viewer_actor_type + viewer_actor_id` 时返回，未传 viewer 时该字段缺省（`skip_serializing_if`）。
 > `status` 来自 `ActorStatus`（`online`/`hidden`），`is_online` 来自 `effective_dynamic_status`（`active`/`offline`）。
 
 ### 3.5 错误码
 
 | HTTP | code | 说明 |
 |---|---|---|
-| 400 | BadRequest | 参数非法：`limit` 越界、`visibility`/`status` 取值非法 |
+| 400 | BadRequest | 参数非法：`limit` 越界、`visibility`/`user_visibility`/`status`/`viewer_actor_type`/`friendship` 取值非法、viewer 参数未成对传入、`friendship=friends/non_friends` 缺少 viewer |
 | 401 | Unauthorized | Bearer 提供但解析失败 |
 | 500 | Internal | 服务内部错误 |
 
 ### 3.6 行为规则
 
 1. **名称搜索**：`q` 匹配 `capabilities.name` 或 `capabilities.summary`（contains，大小写不敏感，trim 后空串视为不过滤）。
-2. **可见性过滤**：
-   - 无 Bearer → 强制 `visibility=public`（忽略用户传入的 visibility 参数）。
-   - 有 Bearer → 默认返回 `public` + `protected`（服务侧 `visibility=None`）；若传 `visibility` 参数则按参数过滤（含 `private`）。
-3. **friend 过滤**：`is_friend=true` → 仅返回已是好友的 bot；`is_friend=false` → 仅返回非好友的 bot。无此参数 → 不过滤。
-4. **排序**：按 `name` 升序（无 name 的排最后；可扩展为多字段排序参数）。
-5. **is_friend** 判定：handler 调 `ConnectService::list_friends(caller)` 取好友 actor_id 集合，按 `bot_uuid` 是否在集合内判定。
-6. **匿名 is_friend 过滤**：无 Bearer 时好友集合为空，`is_friend=true` → 返回空，`is_friend=false` → 返回全部 public bot（逻辑自洽：匿名者与任何 bot 都不是好友）。
+2. **Bot 可见性过滤（`visibility`）**：
+   - 支持多值 OR，推荐格式：`visibility=public,protected`。为降低接入成本，代码实现可同时兼容重复 query：`visibility=public&visibility=protected`。
+   - 无 Bearer → 强制有效范围为 `public`，即使请求传 `visibility=protected/private` 也不能扩大匿名可见范围。建议实现为“请求过滤值 ∩ 匿名允许值 `{public}`”；交集为空则返回空列表。
+   - 有 Bearer → 默认返回 `public` + `protected`；若传 `visibility` 则按传入集合过滤（可包含 `private`）。
+3. **用户侧可见性过滤（`user_visibility`）**：
+   - 支持单值/多值 OR，取值同 `visibility`：`public` / `protected` / `private`。
+   - 该字段对应好友添加策略里的用户侧可见/可加好友配置，用于筛选“对用户侧是否可见/可添加”的 bot。
+   - 不传则不过滤。
+4. **viewer 校验**：`viewer_actor_type` 和 `viewer_actor_id` 必须同时传或同时不传；`viewer_actor_type` 仅允许 `human` / `bot`；`viewer_actor_id` trim 后不能为空。
+5. **friend 过滤（`friendship`）**：
+   - `friendship=all` 或不传 → 不按好友关系过滤，返回好友 + 非好友。
+   - `friendship=friends` → 仅返回与 viewer 已是好友的 bot。
+   - `friendship=non_friends` → 仅返回与 viewer 非好友的 bot。
+   - `friends` / `non_friends` 必须同时传 `viewer_actor_type + viewer_actor_id`；`all` 不要求 viewer。
+   - 为避免“`is_friend` 不传到底是 false 还是不过滤”的歧义，查询参数不再使用 `is_friend`；`is_friend` 仅保留为响应字段。
+6. **排序**：按 `name` 升序（无 name 的排最后；可扩展为多字段排序参数）。
+7. **is_friend 响应判定**：handler 调 `ConnectService::list_friends(viewer_actor_id)` 取好友 actor_id 集合，按 `bot_uuid` 是否在集合内判定；仅显式 viewer 存在时返回 `is_friend` 字段。
 
 ### 3.6.6 TC bot 过滤（`tc_bot`）
 
@@ -104,7 +127,7 @@ GET /bots/search
 | 复用 | 来源 |
 |---|---|
 | bot 列表查询 | 新增 `BotQueryService::search_bots`（基于 `BotRegistryCoreService::list_active`，携带 `status` + `effective_dynamic_status`） |
-| friend 状态 | `ConnectService::list_friends(caller)` |
+| friend 状态 | `ConnectService::list_friends(viewer_actor_id)` |
 | caller 解析 | `caller_actor_id_from_headers`（现有，可选） |
 | TC bot 判据 | `is_tc_bot(&RegisteredBot)`（后缀 == `created_by`，见 `bcs-bot/src/application/bot.rs`） |
 
@@ -114,6 +137,7 @@ GET /bots/search
 - `GET /bots/search` 新路径，不 modifies 任何现有端点。
 - 老 `/bots/discover` 保持不变（老前端继续用）。
 - 响应结构独立，不依赖老 `{success,data}` envelope。
+- 查询参数 `is_friend` 拟由 `friendship` 替代；若线上已有调用方使用 `is_friend`，实现时建议短期兼容读取并记录 deprecation 日志，但正式文档只推荐 `friendship`。
 
 ### 可扩展性
 | 未来需求 | 扩展方式 |
@@ -122,7 +146,7 @@ GET /bots/search
 | 按 domain 过滤 | 新增 `domain` query param |
 | 按 tag 过滤 | 新增 `tag` query param |
 | 多字段排序 | 新增 `sort` param（如 `sort=-created_at,name`） |
-| 仅返回可加好友的 bot | 新增 `human_addable=true` param |
+| 仅返回可加好友的 bot | 使用 `user_visibility` + `friend_check_in_strategy` / 后续新增更明确的 `addable=true` param |
 | 分页游标 | 新增 `cursor` param（与 offset/limit 并存） |
 
 所有扩展都是新增 query param，不破坏已有参数和响应结构。
@@ -131,11 +155,11 @@ GET /bots/search
 
 | 层 | 改动 | 文件 |
 |---|---|---|
-| **wire** | `BotSearchQuery`（含 `tc_bot`）+ `BotSearchEntry` response struct；crate root re-export | `bcs-protocol/src/http/bots.rs`、`http/mod.rs`、`lib.rs` |
-| **handler** | `search_bots` handler：参数校验（limit/visibility/status → 400）、caller 解析、可见性规则、is_friend 后过滤 + 分页、`BotSearchEntry` 组装 | `bcs-http/src/routes/bots.rs` |
+| **wire** | `BotSearchQuery`（含 `visibility` 多值、`user_visibility`、`viewer_actor_type`、`viewer_actor_id`、`friendship`、`tc_bot`）+ `BotSearchEntry` response struct 增加 `user_visibility` / `friend_ext` / `friend_check_in_strategy`；crate root re-export | `bcs-protocol/src/http/bots.rs`、`http/mod.rs`、`lib.rs` |
+| **handler** | `search_bots` handler：参数校验（limit/visibility/user_visibility/status/viewer/friendship → 400）、caller 解析、可见性规则、显式 viewer 的 friendship 后过滤 + 分页、`BotSearchEntry` 组装 | `bcs-http/src/routes/bots.rs` |
 | **router** | 注册 `.route("/bots/search", get(routes::bots::search_bots))` | `bcs-http/src/router.rs` |
-| **service** | 新增 `BotQueryService::search_bots(SearchBotsCommand) -> BotSearchResult`（默认 impl 兜底），基于 `list_active()` 过滤 `q`/`visibility`/`status`/`tc_bot` + name 排序，经 `bot_to_query_entry` 带 status/online；`is_tc_bot` helper | `bcs-service-api/.../bot_query.rs`（trait）、`bcs-bot/src/application/bot.rs`（impl） |
-| **friend** | `is_friend` 在 handler 调 `ConnectService::list_friends` 取集合判定 | 复用现有，无新增 |
+| **service** | `BotQueryService::search_bots(SearchBotsCommand) -> BotSearchResult` 基于 `list_active()` 过滤 `q`/`visibility[]`/`user_visibility[]`/`status`/`tc_bot` + name 排序，经 `bot_to_query_entry` 带 status/online/friend policy 字段；`is_tc_bot` helper | `bcs-service-api/.../bot_query.rs`（trait）、`bcs-bot/src/application/bot.rs`（impl） |
+| **friend** | `friendship` 在 handler 按显式 `viewer_actor_id` 调 `ConnectService::list_friends` 取集合判定；响应字段仍叫 `is_friend` | 复用现有，无新增 |
 | **store** | 无改动（复用 `bcs-bot-store` 现有 query 能力） | — |
 | **测试** | handler 契约测试 + `search_bots` 服务级测试 | `bcs-http/tests/bots_contract.rs`、`bcs-bot/tests/bot_search_contract.rs` |
 
@@ -148,17 +172,26 @@ GET /bots/search
 - 不加 `cursor` 分页（先用 offset/limit，未来扩展）。
 - 不做复杂全文搜索（先用 SQL LIKE，未来可换 FTS/ES）。
 
+## 6.1 待确认点
+
+1. `visibility` / `user_visibility` 多值传法：本文档推荐逗号分隔，并建议实现兼容重复 query。若希望只支持一种，建议只保留逗号分隔，改动最小。
+2. `is_friend` 查询参数兼容：正式推荐新参数 `friendship=all|friends|non_friends`。如果确认没有线上调用方依赖 `is_friend`，实现时可直接删除/不支持旧 query；否则短期兼容旧参数但不在公开文档展示。
+3. `friendship=all` 且传 viewer 时：本文档建议返回全部并附带每个 item 的 `is_friend`；不传 viewer 时返回全部但不带 `is_friend`。
+
 ## 7. 示例调用
 
 ```
 # 搜索名称含"研"的 bot
 GET /bots/search?q=研
 
-# 搜索所有 public bot，第二页
-GET /bots/search?visibility=public&offset=20&limit=20
+# 搜索所有 public 或 protected bot，第二页
+GET /bots/search?visibility=public,protected&offset=20&limit=20
 
-# 搜索非好友的 protected bot
-GET /bots/search?visibility=protected&is_friend=false
+# 搜索 user_visibility 为 public 或 protected 的 bot
+GET /bots/search?user_visibility=public,protected
+
+# 以 bot-viewer 视角搜索非好友的 protected bot
+GET /bots/search?visibility=protected&viewer_actor_type=bot&viewer_actor_id=bot-viewer&friendship=non_friends
   Authorization: Bearer <bot_token>
 
 # 仅返回 TeamClaw backend 过来的 bot

--- a/src/bcs/migrations/etl/README.md
+++ b/src/bcs/migrations/etl/README.md
@@ -2,13 +2,14 @@
 
 ## 概述
 
-把 System A（`ac_bot_friend`, 人→Bot）+ System B（`bcs_friendships`/`bcs_friend_requests`, Bot↔Bot）的历史好友数据迁移到 08-12 边权限表（`edge_grants`/`permission_profiles`/`permission_requests`）。
+把 System A（`ac_bot_friend`, 人→Bot）+ System B（`bcs_friendships`/`bcs_friend_requests`, Bot↔Bot）的历史好友数据迁移到 08-12 边权限表（`edge_grants`/`permission_profiles`/`permission_requests`）。`ac_bot_friend` 和 `bcs_friend_requests` 按关系维度取 latest-status 后迁移，避免历史流水中的旧状态污染新事实源。
 
 ## 前置条件
 
 1. Phase 1 Build 已部署：五表 DDL（`014_edge_permission.sql`）已 apply + ensure 端点已上线。
 2. Phase 0 补录完成：所有 `ac_bots` 中的 bot 都已在 BCS 注册（`scripts/phase0_backfill_missing_bots.py`）。
 3. 备份：对 `ac_bot_friend`、`bcs_friendships`、`bcs_friend_requests`、`bcs_actor_relations` 做快照。
+4. 明确 System B SoR：好友关系以 `bcs_friendships` 为准；`bcs_actor_relations` 中 `is_creator=0` 的 bot↔bot 关系只作为镜像缓存，不单独迁移。脚本会输出镜像 drift 检查，非 0 时必须先人工修复或补充迁移来源。
 
 ## 执行步骤
 
@@ -33,25 +34,33 @@ SOURCE src/bcs/migrations/etl/full_etl_friend_migration.sql;
 
 脚本顺序（在同一文件中）：
 0. default profile 批量 seed（每 bot 一条 wildcard-allow）
-1. bot_uuid 映射视图 `v_ac_bot_map`
-2. System A ACCEPTED → 人→Bot 边 (1 条) + approved request
-3. System A PENDING/REJECTED/CANCELLED → permission_requests (无 edge)
-4. System B bcs_friendships → Bot↔Bot 双向 2 边 + 2 approved requests
-5. System B bcs_friend_requests pending/rejected → permission_requests
+1. bot_uuid 映射视图 `v_ac_bot_map` + latest-status 视图 `v_ac_bot_friend_latest` / `v_bcs_friend_requests_latest`
+2. System A latest ACCEPTED → 人→Bot 边 (1 条) + approved request
+3. System A latest PENDING/REJECTED/CANCELLED → permission_requests (无 edge)
+4. System B `bcs_friendships` → Bot↔Bot 双向 2 边 + 2 approved requests
+5. System B latest `bcs_friend_requests` pending/rejected → permission_requests
 
 ### 对账
 
-文件末尾的 reconciliation 查询验证：
-- 人→Bot 边数 = ac_bot_friend ACCEPTED 数
-- Bot↔Bot 边数 = bcs_friendships × 2
-- default profile 覆盖 = bcs_bots 数
+文件末尾的 reconciliation 查询验证，输出字段尽量统一为 `check_name/env/old_count/new_count/diff/result` 或 `check_name/env/*_count/result`：
+- `bcs_actor_relations` 镜像 drift 必须为 0
+- System A bot 映射 orphan 必须为 0
+- System B friendship orphan bot 必须为 0
+- 人→Bot 边数 = `ac_bot_friend` latest ACCEPTED 数（按 env）
+- Bot↔Bot 边数 = `bcs_friendships` × 2（按 env）
+- default profile 覆盖 = `bcs_bots` 数（按 env）
+- System B latest accepted request 必须存在对应 `bcs_friendships`
+- System B latest 非 accepted request 不应仍存在 `bcs_friendships`
+- approved request 必须有对应 approved edge
+- approved edge 必须有对应 approved request
+- 非 approved request 不应挂 approved edge
 
 ### 重放
 
-所有 INSERT 用 `INSERT IGNORE` + 确定性 MD5 id → 可重跑。第二次跑 `affected_rows=0`，计数不变。
+所有 INSERT 用 `INSERT IGNORE` + 自然键/临时映射表 → 可重跑。第二次跑 `affected_rows=0`，计数不变。
 
 ## 后续
 
-- Phase 3 增量对账（Installment 5）：定期重跑 ETL 拾取旧侧变更（latest-status 双向 reconciliation）。
+- Phase 3 增量对账：手动重跑全量 ETL 拾取新增，再执行 `incremental_reconciliation.sql` 做 latest-status 双向 reconciliation（UPDATE + REVOKE）。
 - Phase 4 shadow（Installment 5）：新读 vs 旧读并行比对。
 - Phase 5 cutover + 退役（Installment 6）：翻转读写到 BCS → 旧冻结 → drop 旧表。

--- a/src/bcs/migrations/etl/full_etl_friend_migration.sql
+++ b/src/bcs/migrations/etl/full_etl_friend_migration.sql
@@ -15,16 +15,21 @@ USE <your_database>;
 -- 脚本 0 — default profile 批量 seed (每 bot 一条 wildcard-allow)
 -- =========================================================================
 INSERT IGNORE INTO permission_profiles
-  (permission_profile_id, bot_id, env, name, description, rules_template,
+  (bot_id, env, name, description, rules_template,
    revision, digest, is_default, status, created_by)
 SELECT
-  CONCAT('pp_', b.bot_uuid, '_default'),
   b.bot_uuid, b.env, 'default', NULL,
   '[{"tool":"*","specifier":"*","effect":"allow"}]',
   1,
   SHA2('[{"tool":"*","specifier":"*","effect":"allow"}]', 256),
   TRUE, 'active', 'system'
 FROM bcs_bots b;
+
+DROP TEMPORARY TABLE IF EXISTS tmp_default_profile_map;
+CREATE TEMPORARY TABLE tmp_default_profile_map AS
+SELECT id AS permission_profile_id, bot_id, env
+FROM permission_profiles
+WHERE is_default = TRUE AND status = 'active';
 
 
 -- =========================================================================
@@ -38,6 +43,35 @@ SELECT
 FROM ac_bots
 WHERE is_delete = 0;
 
+-- latest-status 视图：ac_bot_friend 可能是历史流水表，迁移只认同一申请关系的最新行。
+CREATE OR REPLACE VIEW v_ac_bot_friend_latest AS
+SELECT
+  id, requester_entity_id, target_bot_id, target_entity_id, env, status,
+  requester_name, target_name, target_owner_name, ext, gmt_create, gmt_modified
+FROM (
+  SELECT f.*,
+         ROW_NUMBER() OVER (
+           PARTITION BY requester_entity_id, target_bot_id, target_entity_id, env
+           ORDER BY gmt_create DESC, id DESC
+         ) AS rn
+  FROM ac_bot_friend f
+) ranked
+WHERE rn = 1;
+
+-- latest-status 视图：bcs_friend_requests 如存在历史多版本，只迁同方向同 env 最新申请。
+CREATE OR REPLACE VIEW v_bcs_friend_requests_latest AS
+SELECT
+  id, request_id, from_bot, to_bot, status, env, gmt_create, gmt_modified
+FROM (
+  SELECT fr.*,
+         ROW_NUMBER() OVER (
+           PARTITION BY from_bot, to_bot, env
+           ORDER BY gmt_create DESC, id DESC
+         ) AS rn
+  FROM bcs_friend_requests fr
+) ranked
+WHERE rn = 1;
+
 
 -- =========================================================================
 -- 脚本 2 — System A: ac_bot_friend ACCEPTED → 人→Bot 边 (1 条) + approved request
@@ -45,22 +79,20 @@ WHERE is_delete = 0;
 
 -- 2a. edge_grants（人→Bot 单向, 不建反向边）
 INSERT IGNORE INTO edge_grants
-  (edge_id, env, from_id, to_id, grant_kind, grant_ref_id, rules,
+  (env, from_id, to_id, grant_kind, grant_ref_id, rules,
    status, originator_policy_type, originator_policy_data)
 SELECT
-  CONCAT('eg_', MD5(CONCAT(
-    'human_', f.requester_entity_id, '|',
-    m.bot_uuid, '|', f.env, '|pp_', m.bot_uuid, '_default'
-  ))),
   f.env,
   CONCAT('human_', f.requester_entity_id),
   m.bot_uuid,
   'permission_profile',
-  CONCAT('pp_', m.bot_uuid, '_default'),
+  p.permission_profile_id,
   NULL, 'approved', 'any', NULL
-FROM ac_bot_friend f
+FROM v_ac_bot_friend_latest f
 JOIN v_ac_bot_map m
   ON m.bot_id = f.target_bot_id AND m.owner_id = f.target_entity_id
+JOIN tmp_default_profile_map p
+  ON p.bot_id = m.bot_uuid AND p.env = f.env
 WHERE f.status = 'ACCEPTED';
 
 -- 2b. approved permission_requests（connect）
@@ -70,12 +102,8 @@ INSERT IGNORE INTO permission_requests
    decision_reason, created_by, decided_by,
    decided_at)
 SELECT
-  CONCAT('req_', MD5(CONCAT(
-    'human_', f.requester_entity_id, '|', m.bot_uuid, '|', f.env, '|connect'
-  ))),
-  CONCAT('eg_', MD5(CONCAT(
-    'human_', f.requester_entity_id, '|', m.bot_uuid, '|', f.env, '|pp_', m.bot_uuid, '_default'
-  ))),
+  REPLACE(UUID(), '-', ''),
+  eg.id,
   f.env,
   CONCAT('human_', f.requester_entity_id),
   m.bot_uuid,
@@ -86,9 +114,17 @@ SELECT
   f.requester_entity_id,
   COALESCE(JSON_EXTRACT(f.ext, '$.approvals[0].approver'), f.target_entity_id),
   CURRENT_TIMESTAMP
-FROM ac_bot_friend f
+FROM v_ac_bot_friend_latest f
 JOIN v_ac_bot_map m
   ON m.bot_id = f.target_bot_id AND m.owner_id = f.target_entity_id
+JOIN tmp_default_profile_map p
+  ON p.bot_id = m.bot_uuid AND p.env = f.env
+JOIN edge_grants eg
+  ON eg.env = f.env
+ AND eg.from_id = CONCAT('human_', f.requester_entity_id)
+ AND eg.to_id = m.bot_uuid
+ AND eg.grant_kind = 'permission_profile'
+ AND eg.grant_ref_id = p.permission_profile_id
 WHERE f.status = 'ACCEPTED';
 
 
@@ -96,15 +132,12 @@ WHERE f.status = 'ACCEPTED';
 -- 脚本 3 — System A: ac_bot_friend PENDING/REJECTED/CANCELLED → permission_requests (无 edge)
 -- =========================================================================
 INSERT IGNORE INTO permission_requests
-  (request_id, edge_id, env, from_id, to_id, request_kind,
+  (request_id, env, from_id, to_id, request_kind,
    requested_ref_id, requested_rules, message, status,
    decision_reason, created_by, decided_by,
    decided_at)
 SELECT
-  CONCAT('req_', MD5(CONCAT(
-    'human_', f.requester_entity_id, '|', m.bot_uuid, '|', f.env, '|connect'
-  ))),
-  NULL,
+  REPLACE(UUID(), '-', ''),
   f.env,
   CONCAT('human_', f.requester_entity_id),
   m.bot_uuid,
@@ -124,7 +157,7 @@ SELECT
        ELSE COALESCE(JSON_EXTRACT(f.ext, '$.approvals[0].approver'), f.target_entity_id)
   END,
   CURRENT_TIMESTAMP
-FROM ac_bot_friend f
+FROM v_ac_bot_friend_latest f
 JOIN v_ac_bot_map m
   ON m.bot_id = f.target_bot_id AND m.owner_id = f.target_entity_id
 WHERE f.status IN ('PENDING', 'REJECTED', 'CANCELLED');
@@ -136,23 +169,42 @@ WHERE f.status IN ('PENDING', 'REJECTED', 'CANCELLED');
 
 -- 4a. 两条 edge_grants（A→B ref=B.default, B→A ref=A.default）
 INSERT IGNORE INTO edge_grants
-  (edge_id, env, from_id, to_id, grant_kind, grant_ref_id, rules,
+  (env, from_id, to_id, grant_kind, grant_ref_id, rules,
    status, originator_policy_type, originator_policy_data)
 SELECT
-  CONCAT('eg_', MD5(CONCAT(left_bot, '|', right_bot, '|', env, '|pp_', right_bot, '_default'))),
-  env, left_bot, right_bot,
-  'permission_profile', CONCAT('pp_', right_bot, '_default'),
-  NULL, 'approved', 'any', NULL
-FROM bcs_friendships
-WHERE left_bot NOT LIKE 'human_%' AND right_bot NOT LIKE 'human_%'
-UNION ALL
-SELECT
-  CONCAT('eg_', MD5(CONCAT(right_bot, '|', left_bot, '|', env, '|pp_', left_bot, '_default'))),
-  env, right_bot, left_bot,
-  'permission_profile', CONCAT('pp_', left_bot, '_default'),
-  NULL, 'approved', 'any', NULL
-FROM bcs_friendships
-WHERE left_bot NOT LIKE 'human_%' AND right_bot NOT LIKE 'human_%';
+  b.env, b.from_id, b.to_id, b.grant_kind, b.grant_ref_id, b.rules,
+  b.status, b.originator_policy_type, b.originator_policy_data
+FROM (
+  SELECT
+    env,
+    left_bot AS from_id,
+    right_bot AS to_id,
+    'permission_profile' AS grant_kind,
+    p.permission_profile_id AS grant_ref_id,
+    NULL AS rules,
+    'approved' AS status,
+    'any' AS originator_policy_type,
+    NULL AS originator_policy_data
+  FROM bcs_friendships
+  JOIN tmp_default_profile_map p
+    ON p.bot_id = bcs_friendships.right_bot AND p.env = bcs_friendships.env
+  WHERE left_bot NOT LIKE 'human_%' AND right_bot NOT LIKE 'human_%'
+  UNION ALL
+  SELECT
+    env,
+    right_bot AS from_id,
+    left_bot AS to_id,
+    'permission_profile' AS grant_kind,
+    p.permission_profile_id AS grant_ref_id,
+    NULL AS rules,
+    'approved' AS status,
+    'any' AS originator_policy_type,
+    NULL AS originator_policy_data
+  FROM bcs_friendships
+  JOIN tmp_default_profile_map p
+    ON p.bot_id = bcs_friendships.left_bot AND p.env = bcs_friendships.env
+  WHERE left_bot NOT LIKE 'human_%' AND right_bot NOT LIKE 'human_%'
+) AS b;
 
 -- 4b. 配套 approved permission_requests (每对 2 条, decided_by = 对端 bot 的 created_by)
 INSERT IGNORE INTO permission_requests
@@ -161,39 +213,42 @@ INSERT IGNORE INTO permission_requests
    decision_reason, created_by, decided_by,
    decided_at)
 SELECT
-  CONCAT('req_', MD5(CONCAT(left_bot, '|', right_bot, '|', env, '|connect'))),
-  CONCAT('eg_', MD5(CONCAT(left_bot, '|', right_bot, '|', env, '|pp_', right_bot, '_default'))),
-  env, left_bot, right_bot, 'connect',
+  REPLACE(UUID(), '-', ''),
+  eg.id,
+  fs.env, fs.from_id, fs.to_id, 'connect',
   NULL, NULL, NULL, 'approved',
-  NULL, left_bot,
-  (SELECT b.created_by FROM bcs_bots b WHERE b.bot_uuid = bcs_friendships.right_bot AND b.env = bcs_friendships.env LIMIT 1),
+  NULL, fs.from_id,
+  (SELECT b.created_by FROM bcs_bots b WHERE b.bot_uuid = fs.to_id AND b.env = fs.env LIMIT 1),
   CURRENT_TIMESTAMP
-FROM bcs_friendships
-WHERE left_bot NOT LIKE 'human_%' AND right_bot NOT LIKE 'human_%'
-UNION ALL
-SELECT
-  CONCAT('req_', MD5(CONCAT(right_bot, '|', left_bot, '|', env, '|connect'))),
-  CONCAT('eg_', MD5(CONCAT(right_bot, '|', left_bot, '|', env, '|pp_', left_bot, '_default'))),
-  env, right_bot, left_bot, 'connect',
-  NULL, NULL, NULL, 'approved',
-  NULL, right_bot,
-  (SELECT b.created_by FROM bcs_bots b WHERE b.bot_uuid = bcs_friendships.left_bot AND b.env = bcs_friendships.env LIMIT 1),
-  CURRENT_TIMESTAMP
-FROM bcs_friendships
-WHERE left_bot NOT LIKE 'human_%' AND right_bot NOT LIKE 'human_%';
+FROM (
+  SELECT left_bot AS from_id, right_bot AS to_id, env, right_bot AS target_bot
+  FROM bcs_friendships
+  WHERE left_bot NOT LIKE 'human_%' AND right_bot NOT LIKE 'human_%'
+  UNION ALL
+  SELECT right_bot AS from_id, left_bot AS to_id, env, left_bot AS target_bot
+  FROM bcs_friendships
+  WHERE left_bot NOT LIKE 'human_%' AND right_bot NOT LIKE 'human_%'
+) AS fs
+JOIN tmp_default_profile_map p
+  ON p.bot_id = fs.target_bot AND p.env = fs.env
+JOIN edge_grants eg
+  ON eg.env = fs.env
+ AND eg.from_id = fs.from_id
+ AND eg.to_id = fs.to_id
+ AND eg.grant_kind = 'permission_profile'
+ AND eg.grant_ref_id = p.permission_profile_id;
 
 
 -- =========================================================================
 -- 脚本 5 — System B: bcs_friend_requests pending/rejected → permission_requests (accepted 已被脚本 4 覆盖)
 -- =========================================================================
 INSERT IGNORE INTO permission_requests
-  (request_id, edge_id, env, from_id, to_id, request_kind,
+  (request_id, env, from_id, to_id, request_kind,
    requested_ref_id, requested_rules, message, status,
    decision_reason, created_by, decided_by,
    decided_at)
 SELECT
-  CONCAT('req_', MD5(CONCAT(from_bot, '|', to_bot, '|', env, '|connect'))),
-  NULL,
+  REPLACE(UUID(), '-', ''),
   env, from_bot, to_bot, 'connect',
   NULL, NULL, NULL,
   CASE status
@@ -202,7 +257,7 @@ SELECT
   END,
   NULL,
   from_bot, NULL, NULL
-FROM bcs_friend_requests
+FROM v_bcs_friend_requests_latest
 WHERE status <> 'accepted';
 
 
@@ -210,28 +265,194 @@ WHERE status <> 'accepted';
 -- 对账 (reconciliation)
 -- =========================================================================
 
--- 人→Bot: ac_bot_friend ACCEPTED 数 == edge_grants from LIKE 'human_%' 数
+-- bcs_actor_relations 说明：好友迁移以 bcs_friendships 为 System B SoR；
+-- bcs_actor_relations 中 is_creator=0 的 bot↔bot 关系应只是 bcs_friendships 镜像，不单独迁移。
+-- 如下 drift 检查非 0，说明镜像与 SoR 已分叉，必须先人工修复或补充迁移来源。
+SELECT 'actor_relation_friend_mirror_drift' AS check_name,
+       r.env,
+       COUNT(*) AS drift_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM bcs_actor_relations r
+WHERE r.is_creator = 0
+  AND r.from_id NOT LIKE 'human_%'
+  AND r.to_id NOT LIKE 'human_%'
+  AND NOT EXISTS (
+    SELECT 1 FROM bcs_friendships f
+    WHERE f.env = r.env
+      AND ((f.left_bot = r.from_id AND f.right_bot = r.to_id)
+        OR (f.left_bot = r.to_id AND f.right_bot = r.from_id))
+  )
+GROUP BY r.env;
+
+-- orphan bot 映射：System A 好友记录找不到 ac_bots 映射会漏迁。
+SELECT 'system_a_orphan_bot_map' AS check_name,
+       f.env,
+       COUNT(*) AS orphan_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM v_ac_bot_friend_latest f
+LEFT JOIN v_ac_bot_map m
+  ON m.bot_id = f.target_bot_id AND m.owner_id = f.target_entity_id
+WHERE m.bot_uuid IS NULL
+GROUP BY f.env;
+
+-- orphan bot：System B friendship 中任一 bot 不存在会导致 default profile 或 owner 信息缺失。
+SELECT 'system_b_friendship_orphan_bot' AS check_name,
+       fs.env,
+       COUNT(*) AS orphan_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM bcs_friendships fs
+LEFT JOIN bcs_bots lb ON lb.bot_uuid = fs.left_bot AND lb.env = fs.env
+LEFT JOIN bcs_bots rb ON rb.bot_uuid = fs.right_bot AND rb.env = fs.env
+WHERE fs.left_bot NOT LIKE 'human_%'
+  AND fs.right_bot NOT LIKE 'human_%'
+  AND (lb.bot_uuid IS NULL OR rb.bot_uuid IS NULL)
+GROUP BY fs.env;
+
+-- 人→Bot: latest ACCEPTED 数 == edge_grants from human_* approved 数（按 env）
 SELECT 'human_to_bot_edges' AS check_name,
-       (SELECT COUNT(*) FROM ac_bot_friend f
-        JOIN v_ac_bot_map m ON m.bot_id=f.target_bot_id AND m.owner_id=f.target_entity_id
-        WHERE f.status='ACCEPTED') AS old_count,
-       (SELECT COUNT(*) FROM edge_grants WHERE from_id LIKE 'human_%' AND status='approved') AS new_count;
--- 期望: old_count == new_count
+       old_side.env,
+       old_side.old_count,
+       COALESCE(new_side.new_count, 0) AS new_count,
+       old_side.old_count - COALESCE(new_side.new_count, 0) AS diff,
+       CASE WHEN old_side.old_count = COALESCE(new_side.new_count, 0) THEN 'PASS' ELSE 'FAIL' END AS result
+FROM (
+  SELECT f.env, COUNT(*) AS old_count
+  FROM v_ac_bot_friend_latest f
+  JOIN v_ac_bot_map m ON m.bot_id=f.target_bot_id AND m.owner_id=f.target_entity_id
+  WHERE f.status='ACCEPTED'
+  GROUP BY f.env
+) old_side
+LEFT JOIN (
+  SELECT e.env, COUNT(*) AS new_count
+  FROM edge_grants e
+  JOIN tmp_default_profile_map p
+    ON p.bot_id = e.to_id AND p.env = e.env
+  WHERE e.from_id LIKE 'human_%'
+    AND e.status='approved'
+    AND e.grant_kind='permission_profile'
+    AND e.grant_ref_id = p.permission_profile_id
+  GROUP BY e.env
+) new_side ON new_side.env = old_side.env;
 
--- Bot↔Bot: bcs_friendships*2 == edge_grants 两端均非 human_ 数
+-- Bot↔Bot: bcs_friendships*2 == edge_grants 两端均非 human_ 数（按 env）
 SELECT 'bot_to_bot_edges' AS check_name,
-       (SELECT COUNT(*)*2 FROM bcs_friendships
-        WHERE left_bot NOT LIKE 'human_%' AND right_bot NOT LIKE 'human_%') AS old_count,
-       (SELECT COUNT(*) FROM edge_grants
-        WHERE from_id NOT LIKE 'human_%' AND to_id NOT LIKE 'human_%'
-          AND status='approved') AS new_count;
--- 期望: old_count == new_count
+       old_side.env,
+       old_side.old_count,
+       COALESCE(new_side.new_count, 0) AS new_count,
+       old_side.old_count - COALESCE(new_side.new_count, 0) AS diff,
+       CASE WHEN old_side.old_count = COALESCE(new_side.new_count, 0) THEN 'PASS' ELSE 'FAIL' END AS result
+FROM (
+  SELECT env, COUNT(*) * 2 AS old_count
+  FROM bcs_friendships
+  WHERE left_bot NOT LIKE 'human_%' AND right_bot NOT LIKE 'human_%'
+  GROUP BY env
+) old_side
+LEFT JOIN (
+  SELECT e.env, COUNT(*) AS new_count
+  FROM edge_grants e
+  JOIN tmp_default_profile_map p
+    ON p.bot_id = e.to_id AND p.env = e.env
+  WHERE e.from_id NOT LIKE 'human_%' AND e.to_id NOT LIKE 'human_%'
+    AND e.status='approved'
+    AND e.grant_kind='permission_profile'
+    AND e.grant_ref_id = p.permission_profile_id
+  GROUP BY e.env
+) new_side ON new_side.env = old_side.env;
 
--- default profile 覆盖: 每 bcs_bots bot 都有一条 default profile
+-- default profile 覆盖: 每 bcs_bots bot 都有一条 active default profile（按 env）
 SELECT 'default_profile_coverage' AS check_name,
-       (SELECT COUNT(*) FROM bcs_bots) AS bots,
-       (SELECT COUNT(*) FROM permission_profiles WHERE is_default=TRUE AND status='active') AS profiles;
--- 期望: bots == profiles
+       bots.env,
+       bots.bot_count AS old_count,
+       COALESCE(profiles.profile_count, 0) AS new_count,
+       bots.bot_count - COALESCE(profiles.profile_count, 0) AS diff,
+       CASE WHEN bots.bot_count = COALESCE(profiles.profile_count, 0) THEN 'PASS' ELSE 'FAIL' END AS result
+FROM (
+  SELECT env, COUNT(*) AS bot_count FROM bcs_bots GROUP BY env
+) bots
+LEFT JOIN (
+  SELECT env, COUNT(*) AS profile_count
+  FROM permission_profiles
+  WHERE is_default=TRUE AND status='active'
+  GROUP BY env
+) profiles ON profiles.env = bots.env;
+
+-- System B latest accepted request 必须能找到 friendship；否则 accepted request 无法由脚本 4 生成 edge。
+SELECT 'system_b_accepted_request_without_friendship' AS check_name,
+       fr.env,
+       COUNT(*) AS mismatch_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM v_bcs_friend_requests_latest fr
+WHERE fr.status = 'accepted'
+  AND NOT EXISTS (
+    SELECT 1 FROM bcs_friendships fs
+    WHERE fs.env = fr.env
+      AND ((fs.left_bot = fr.from_bot AND fs.right_bot = fr.to_bot)
+        OR (fs.left_bot = fr.to_bot AND fs.right_bot = fr.from_bot))
+  )
+GROUP BY fr.env;
+
+-- System B latest 非 accepted request 不应仍有 friendship；否则旧侧 request 与 friendship 事实分叉。
+SELECT 'system_b_non_accepted_request_with_friendship' AS check_name,
+       fr.env,
+       COUNT(*) AS mismatch_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM v_bcs_friend_requests_latest fr
+WHERE fr.status <> 'accepted'
+  AND EXISTS (
+    SELECT 1 FROM bcs_friendships fs
+    WHERE fs.env = fr.env
+      AND ((fs.left_bot = fr.from_bot AND fs.right_bot = fr.to_bot)
+        OR (fs.left_bot = fr.to_bot AND fs.right_bot = fr.from_bot))
+  )
+GROUP BY fr.env;
+
+-- approved request 必须有对应 approved edge。
+SELECT 'approved_request_without_edge' AS check_name,
+       r.env,
+       COUNT(*) AS mismatch_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM permission_requests r
+LEFT JOIN edge_grants e
+  ON e.id = r.edge_id
+ AND e.env = r.env
+ AND e.status = 'approved'
+WHERE r.request_kind = 'connect'
+  AND r.status = 'approved'
+  AND e.id IS NULL
+GROUP BY r.env;
+
+-- approved edge 必须有对应 approved request。
+SELECT 'approved_edge_without_request' AS check_name,
+       e.env,
+       COUNT(*) AS mismatch_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM edge_grants e
+JOIN tmp_default_profile_map p
+  ON p.bot_id = e.to_id AND p.env = e.env
+LEFT JOIN permission_requests r
+  ON r.edge_id = e.id
+ AND r.env = e.env
+ AND r.request_kind = 'connect'
+ AND r.status = 'approved'
+WHERE e.grant_kind = 'permission_profile'
+  AND e.grant_ref_id = p.permission_profile_id
+  AND e.status = 'approved'
+  AND r.id IS NULL
+GROUP BY e.env;
+
+-- 非通过状态 request 不应有关联 approved edge。
+SELECT 'non_approved_request_with_edge' AS check_name,
+       r.env,
+       COUNT(*) AS mismatch_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM permission_requests r
+JOIN edge_grants e
+  ON e.id = r.edge_id
+ AND e.env = r.env
+ AND e.status = 'approved'
+WHERE r.request_kind = 'connect'
+  AND r.status <> 'approved'
+GROUP BY r.env;
 
 -- spot check: 某个老好友在新表是否 are_friends
 -- SELECT * FROM edge_grants WHERE from_id='human_88001';

--- a/src/bcs/migrations/etl/incremental_reconciliation.sql
+++ b/src/bcs/migrations/etl/incremental_reconciliation.sql
@@ -2,8 +2,8 @@
 -- Phase 3: 增量对账（latest-status 双向 reconciliation，非 INSERT-only）
 --
 -- 与 full_etl_friend_migration.sql 的区别：
---   全量 ETL = INSERT-only（INSERT IGNORE，只加不删）—— 靠双写兜底删除。
---   增量对账 = 全量 INSERT + REVOKE（旧侧友谊消失→撤边）+ UPDATE（状态迁移）。
+--   全量 ETL = latest-status INSERT-only（INSERT IGNORE，只加不删），用于初次灌数。
+--   增量对账 = 重跑全量 INSERT + REVOKE（旧侧友谊消失→撤边）+ UPDATE（状态迁移）。
 --
 -- 幂等可重跑。手动触发（非 cron）。每次 shadow 前跑一轮，cutover 前跑最终对账。
 --
@@ -11,6 +11,42 @@
 -- 来源: spec §8.5 双向对账。
 
 USE <your_database>;
+
+-- 与 full_etl 保持一致的 latest-status 视图，保证本脚本可独立重跑。
+CREATE OR REPLACE VIEW v_ac_bot_map AS
+SELECT
+  CONCAT(bot_id, ':', owner_id) AS bot_uuid,
+  bot_id, owner_id, public,
+  JSON_EXTRACT(ext, '$.friend_approval') AS friend_approval
+FROM ac_bots
+WHERE is_delete = 0;
+
+CREATE OR REPLACE VIEW v_ac_bot_friend_latest AS
+SELECT
+  id, requester_entity_id, target_bot_id, target_entity_id, env, status,
+  requester_name, target_name, target_owner_name, ext, gmt_create, gmt_modified
+FROM (
+  SELECT f.*,
+         ROW_NUMBER() OVER (
+           PARTITION BY requester_entity_id, target_bot_id, target_entity_id, env
+           ORDER BY gmt_create DESC, id DESC
+         ) AS rn
+  FROM ac_bot_friend f
+) ranked
+WHERE rn = 1;
+
+CREATE OR REPLACE VIEW v_bcs_friend_requests_latest AS
+SELECT
+  id, request_id, from_bot, to_bot, status, env, gmt_create, gmt_modified
+FROM (
+  SELECT fr.*,
+         ROW_NUMBER() OVER (
+           PARTITION BY from_bot, to_bot, env
+           ORDER BY gmt_create DESC, id DESC
+         ) AS rn
+  FROM bcs_friend_requests fr
+) ranked
+WHERE rn = 1;
 
 -- =========================================================================
 -- Part 1: 重新运行全量 INSERT（幂等——新行被 IGNORE 拾取）
@@ -25,16 +61,12 @@ USE <your_database>;
 -- 2a. System A: ac_bot_friend 最新行 status ≠ ACCEPTED → 撤人→Bot default 边
 -- (取每对 gmt_create 最新行, 镜像 backend get_by_entity_ids: ORDER BY gmt_create DESC)
 UPDATE edge_grants e
-INNER JOIN (
-  SELECT requester_entity_id, target_bot_id, target_entity_id, env, status,
-         ROW_NUMBER() OVER (
-           PARTITION BY requester_entity_id, target_bot_id, target_entity_id, env
-           ORDER BY gmt_create DESC
-         ) AS rn
-  FROM ac_bot_friend
-) latest ON latest.rn = 1 AND latest.status <> 'ACCEPTED'
+INNER JOIN v_ac_bot_friend_latest latest
+  ON latest.status <> 'ACCEPTED'
 INNER JOIN v_ac_bot_map m
   ON m.bot_id = latest.target_bot_id AND m.owner_id = latest.target_entity_id
+INNER JOIN tmp_default_profile_map p
+  ON p.bot_id = m.bot_uuid AND p.env = latest.env
 SET e.status = 'revoked',
     e.gmt_modified = CURRENT_TIMESTAMP
 WHERE e.from_id = CONCAT('human_', latest.requester_entity_id)
@@ -42,7 +74,7 @@ WHERE e.from_id = CONCAT('human_', latest.requester_entity_id)
   AND e.env = latest.env
   AND e.status = 'approved'
   AND e.grant_kind = 'permission_profile'
-  AND e.grant_ref_id = CONCAT('pp_', m.bot_uuid, '_default');
+  AND e.grant_ref_id = p.permission_profile_id;
 
 -- 2b. System B: bcs_friendships pair 已不存在 → 撤 Bot↔Bot 双向 default 边
 UPDATE edge_grants e
@@ -66,14 +98,8 @@ WHERE e.from_id NOT LIKE 'human_%'
 -- 3a. System A: ac_bot_friend latest status → permission_requests status
 -- (INSERT IGNORE 已处理新行；此处处理已存在 request 的状态迁移：pending→approved/rejected/cancelled)
 UPDATE permission_requests r
-INNER JOIN (
-  SELECT requester_entity_id, target_bot_id, target_entity_id, env, status,
-         ROW_NUMBER() OVER (
-           PARTITION BY requester_entity_id, target_bot_id, target_entity_id, env
-           ORDER BY gmt_create DESC
-         ) AS rn
-  FROM ac_bot_friend
-) latest ON latest.rn = 1
+INNER JOIN v_ac_bot_friend_latest latest
+  ON TRUE
 INNER JOIN v_ac_bot_map m
   ON m.bot_id = latest.target_bot_id AND m.owner_id = latest.target_entity_id
 SET r.status = CASE latest.status
@@ -88,9 +114,9 @@ WHERE r.from_id = CONCAT('human_', latest.requester_entity_id)
   AND r.env = latest.env
   AND r.request_kind = 'connect';
 
--- 3b. System B: bcs_friend_requests status → permission_requests status
+-- 3b. System B: bcs_friend_requests latest status → permission_requests status
 UPDATE permission_requests r
-INNER JOIN bcs_friend_requests fr
+INNER JOIN v_bcs_friend_requests_latest fr
   ON fr.from_bot = r.from_id AND fr.to_bot = r.to_id AND fr.env = r.env
 SET r.status = CASE fr.status
     WHEN 'pending'  THEN 'pending'
@@ -101,31 +127,183 @@ WHERE r.request_kind = 'connect'
   AND fr.status <> 'accepted';
 
 -- =========================================================================
--- Part 4: 对账（同 full ETL，但新增 revoke 计数）
+-- Part 4: 对账（latest-status + request/edge 一致性 + revoke 计数）
 -- =========================================================================
 
--- 人→Bot 边数：ac_bot_friend latest ACCEPTED == edge_grants human_* approved
-SELECT 'human_to_bot' AS metric,
-  (SELECT COUNT(DISTINCT CONCAT(f.requester_entity_id, '|', CONCAT(f.target_bot_id, ':', f.target_entity_id))
-   FROM ac_bot_friend f
-   WHERE f.status = 'ACCEPTED' AND f.env = ?) AS old_active,
-  (SELECT COUNT(*) FROM edge_grants
-   WHERE from_id LIKE 'human_%' AND status = 'approved'
-     AND grant_kind = 'permission_profile') AS new_active;
--- 期望相等
+-- bcs_actor_relations 仅作为 bcs_friendships 的镜像缓存，不单独作为迁移 SoR；非 0 必须先人工处理。
+SELECT 'actor_relation_friend_mirror_drift' AS check_name,
+       r.env,
+       COUNT(*) AS drift_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM bcs_actor_relations r
+WHERE r.is_creator = 0
+  AND r.from_id NOT LIKE 'human_%'
+  AND r.to_id NOT LIKE 'human_%'
+  AND NOT EXISTS (
+    SELECT 1 FROM bcs_friendships f
+    WHERE f.env = r.env
+      AND ((f.left_bot = r.from_id AND f.right_bot = r.to_id)
+        OR (f.left_bot = r.to_id AND f.right_bot = r.from_id))
+  )
+GROUP BY r.env;
 
--- Bot↔Bot 边数：bcs_friendships*2 == edge_grants bot↔bot approved
-SELECT 'bot_to_bot' AS metric,
-  (SELECT COUNT(*) * 2 FROM bcs_friendships
-   WHERE left_bot NOT LIKE 'human_%' AND right_bot NOT LIKE 'human_%') AS old_active,
-  (SELECT COUNT(*) FROM edge_grants
-   WHERE from_id NOT LIKE 'human_%' AND to_id NOT LIKE 'human_%'
-     AND status = 'approved') AS new_active;
--- 期望相等
+-- orphan bot 映射。
+SELECT 'system_a_orphan_bot_map' AS check_name,
+       f.env,
+       COUNT(*) AS orphan_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM v_ac_bot_friend_latest f
+LEFT JOIN v_ac_bot_map m
+  ON m.bot_id = f.target_bot_id AND m.owner_id = f.target_entity_id
+WHERE m.bot_uuid IS NULL
+GROUP BY f.env;
 
--- revoke 的边数（对账时观察迁移了多少 unfriend）
-SELECT 'revoked_edges' AS metric,
-  (SELECT COUNT(*) FROM edge_grants WHERE status = 'revoked') AS count;
+SELECT 'system_b_friendship_orphan_bot' AS check_name,
+       fs.env,
+       COUNT(*) AS orphan_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM bcs_friendships fs
+LEFT JOIN bcs_bots lb ON lb.bot_uuid = fs.left_bot AND lb.env = fs.env
+LEFT JOIN bcs_bots rb ON rb.bot_uuid = fs.right_bot AND rb.env = fs.env
+WHERE fs.left_bot NOT LIKE 'human_%'
+  AND fs.right_bot NOT LIKE 'human_%'
+  AND (lb.bot_uuid IS NULL OR rb.bot_uuid IS NULL)
+GROUP BY fs.env;
+
+-- 人→Bot 边数：ac_bot_friend latest ACCEPTED == edge_grants human_* approved（按 env）。
+SELECT 'human_to_bot' AS check_name,
+       old_side.env,
+       old_side.old_count,
+       COALESCE(new_side.new_count, 0) AS new_count,
+       old_side.old_count - COALESCE(new_side.new_count, 0) AS diff,
+       CASE WHEN old_side.old_count = COALESCE(new_side.new_count, 0) THEN 'PASS' ELSE 'FAIL' END AS result
+FROM (
+  SELECT f.env, COUNT(*) AS old_count
+  FROM v_ac_bot_friend_latest f
+  JOIN v_ac_bot_map m ON m.bot_id=f.target_bot_id AND m.owner_id=f.target_entity_id
+  WHERE f.status = 'ACCEPTED'
+  GROUP BY f.env
+) old_side
+LEFT JOIN (
+  SELECT e.env, COUNT(*) AS new_count
+  FROM edge_grants e
+  JOIN tmp_default_profile_map p
+    ON p.bot_id = e.to_id AND p.env = e.env
+  WHERE e.from_id LIKE 'human_%'
+    AND e.status = 'approved'
+    AND e.grant_kind = 'permission_profile'
+    AND e.grant_ref_id = p.permission_profile_id
+  GROUP BY e.env
+) new_side ON new_side.env = old_side.env;
+
+-- Bot↔Bot 边数：bcs_friendships*2 == edge_grants bot↔bot approved（按 env）。
+SELECT 'bot_to_bot' AS check_name,
+       old_side.env,
+       old_side.old_count,
+       COALESCE(new_side.new_count, 0) AS new_count,
+       old_side.old_count - COALESCE(new_side.new_count, 0) AS diff,
+       CASE WHEN old_side.old_count = COALESCE(new_side.new_count, 0) THEN 'PASS' ELSE 'FAIL' END AS result
+FROM (
+  SELECT env, COUNT(*) * 2 AS old_count
+  FROM bcs_friendships
+  WHERE left_bot NOT LIKE 'human_%' AND right_bot NOT LIKE 'human_%'
+  GROUP BY env
+) old_side
+LEFT JOIN (
+  SELECT e.env, COUNT(*) AS new_count
+  FROM edge_grants e
+  JOIN tmp_default_profile_map p
+    ON p.bot_id = e.to_id AND p.env = e.env
+  WHERE e.from_id NOT LIKE 'human_%' AND e.to_id NOT LIKE 'human_%'
+    AND e.status = 'approved'
+    AND e.grant_kind = 'permission_profile'
+    AND e.grant_ref_id = p.permission_profile_id
+  GROUP BY e.env
+) new_side ON new_side.env = old_side.env;
+
+-- System B latest accepted request 必须能找到 friendship；否则 accepted request 无法由脚本 4 生成 edge。
+SELECT 'system_b_accepted_request_without_friendship' AS check_name,
+       fr.env,
+       COUNT(*) AS mismatch_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM v_bcs_friend_requests_latest fr
+WHERE fr.status = 'accepted'
+  AND NOT EXISTS (
+    SELECT 1 FROM bcs_friendships fs
+    WHERE fs.env = fr.env
+      AND ((fs.left_bot = fr.from_bot AND fs.right_bot = fr.to_bot)
+        OR (fs.left_bot = fr.to_bot AND fs.right_bot = fr.from_bot))
+  )
+GROUP BY fr.env;
+
+-- System B latest 非 accepted request 不应仍有 friendship；否则旧侧 request 与 friendship 事实分叉。
+SELECT 'system_b_non_accepted_request_with_friendship' AS check_name,
+       fr.env,
+       COUNT(*) AS mismatch_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM v_bcs_friend_requests_latest fr
+WHERE fr.status <> 'accepted'
+  AND EXISTS (
+    SELECT 1 FROM bcs_friendships fs
+    WHERE fs.env = fr.env
+      AND ((fs.left_bot = fr.from_bot AND fs.right_bot = fr.to_bot)
+        OR (fs.left_bot = fr.to_bot AND fs.right_bot = fr.from_bot))
+  )
+GROUP BY fr.env;
+
+-- request/edge 一致性。
+SELECT 'approved_request_without_edge' AS check_name,
+       r.env,
+       COUNT(*) AS mismatch_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM permission_requests r
+LEFT JOIN edge_grants e
+  ON e.id = r.edge_id
+ AND e.env = r.env
+ AND e.status = 'approved'
+WHERE r.request_kind = 'connect'
+  AND r.status = 'approved'
+  AND e.id IS NULL
+GROUP BY r.env;
+
+SELECT 'approved_edge_without_request' AS check_name,
+       e.env,
+       COUNT(*) AS mismatch_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM edge_grants e
+JOIN tmp_default_profile_map p
+  ON p.bot_id = e.to_id AND p.env = e.env
+LEFT JOIN permission_requests r
+  ON r.edge_id = e.id
+ AND r.env = e.env
+ AND r.request_kind = 'connect'
+ AND r.status = 'approved'
+WHERE e.grant_kind = 'permission_profile'
+  AND e.grant_ref_id = p.permission_profile_id
+  AND e.status = 'approved'
+  AND r.id IS NULL
+GROUP BY e.env;
+
+SELECT 'non_approved_request_with_edge' AS check_name,
+       r.env,
+       COUNT(*) AS mismatch_count,
+       CASE WHEN COUNT(*) = 0 THEN 'PASS' ELSE 'FAIL' END AS result
+FROM permission_requests r
+JOIN edge_grants e
+  ON e.id = r.edge_id
+ AND e.env = r.env
+ AND e.status = 'approved'
+WHERE r.request_kind = 'connect'
+  AND r.status <> 'approved'
+GROUP BY r.env;
+
+-- revoke 的边数（对账时观察迁移了多少 unfriend）。
+SELECT 'revoked_edges' AS check_name,
+       env,
+       COUNT(*) AS count
+FROM edge_grants
+WHERE status = 'revoked'
+GROUP BY env;
 
 -- =========================================================================
 -- 使用说明:

--- a/src/bcs/migrations/mysql/014_edge_permission.sql
+++ b/src/bcs/migrations/mysql/014_edge_permission.sql
@@ -12,19 +12,19 @@
 -- grant_kind=permission_profile 且 grant_ref_id == B 的默认 profile id（D12）。
 -- 同一 (A→B) 可携带多条边（默认 + writer + 内联 rules）。
 CREATE TABLE IF NOT EXISTS `edge_grants` (
-  `edge_id`                VARCHAR(48)  NOT NULL COMMENT 'PK；opaque id（eg_<md5>）',
+  `id`                    BIGINT       NOT NULL AUTO_INCREMENT COMMENT 'PK；自增 bigint',
   `env`                    VARCHAR(16)  NOT NULL COMMENT '环境标签（仅标记写入，不参与查询隔离，§3.1）',
   `from_id`                VARCHAR(256) NOT NULL COMMENT '授权方 actor id（A）：human_<工号> 或 bot uuid',
   `to_id`                  VARCHAR(256) NOT NULL COMMENT '被授权目标（B）：bot uuid',
   `grant_kind`             VARCHAR(16)  NOT NULL COMMENT 'permission_profile | rules',
-  `grant_ref_id`           VARCHAR(128) NOT NULL COMMENT 'permission_profile -> 目标 profile id；rules -> 不透明 ref',
+  `grant_ref_id`          BIGINT       NOT NULL COMMENT 'permission_profile -> 目标 profile id；rules -> 不透明 ref',
   `rules`                  TEXT         DEFAULT NULL COMMENT '内联规则；grant_kind=rules 时非空（JSON 字符串）',
   `status`                 VARCHAR(16)  NOT NULL DEFAULT 'approved' COMMENT 'approved（生效）| revoked（撤回，不再授权）',
   `originator_policy_type` VARCHAR(16)  NOT NULL DEFAULT 'any' COMMENT 'any | same_as_from | specific | owner（friend 边恒为 any，D7）',
   `originator_policy_data` TEXT         DEFAULT NULL COMMENT 'policy_type=specific 时的发起方集合（JSON 字符串）',
   `gmt_create`             timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
   `gmt_modified`           timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
-  PRIMARY KEY (`edge_id`),
+  PRIMARY KEY (`id`),
   UNIQUE KEY `uk_edge_from_to_env_ref` (`from_id`, `to_id`, `env`, `grant_ref_id`) COMMENT '每个 (A,B,env,ref) 至多一行',
   KEY `idx_edge_from_env_status` (`from_id`, `env`, `status`) COMMENT 'list_friends / 出边扫描',
   KEY `idx_edge_to_env_status` (`to_id`, `env`, `status`) COMMENT 'admission / 入边扫描'
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS `edge_grants` (
 -- 恰好 seed 一条 `default` profile（wildcard-allow，§5.1.1）。revision/digest 随
 -- upsert 递增，profile_id 不变（D12 rule 2：不覆盖、不 bump 既有 default）。
 CREATE TABLE IF NOT EXISTS `permission_profiles` (
-  `permission_profile_id` VARCHAR(48)  NOT NULL COMMENT 'PK；pp_<bot_uuid>_default 为默认 profile 约定',
+  `id`                    BIGINT       NOT NULL AUTO_INCREMENT COMMENT 'PK；自增 bigint',
   `bot_id`                VARCHAR(256) NOT NULL COMMENT '所属 bot uuid（被授权方的默认权限）',
   `env`                   VARCHAR(16)  NOT NULL COMMENT '环境标签',
   `name`                  VARCHAR(64)  NOT NULL DEFAULT 'default' COMMENT '角色名：default | reader | writer | maintainer',
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS `permission_profiles` (
   `updated_by`            VARCHAR(64)  DEFAULT NULL COMMENT '最近修订者（NULL 表示无人改过）',
   `gmt_create`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
   `gmt_modified`          timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
-  PRIMARY KEY (`permission_profile_id`),
+  PRIMARY KEY (`id`),
   UNIQUE KEY `uk_profile_bot_env_default` (`bot_id`, `env`, `is_default`, `status`) COMMENT '每 (bot,env) 至多一条 active default',
   KEY `idx_profile_bot_env` (`bot_id`, `env`, `status`) COMMENT '默认 profile 查找'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -58,13 +58,14 @@ CREATE TABLE IF NOT EXISTS `permission_profiles` (
 -- connect/apply/revoke 请求记录。pending 时无 edge_id；approve 后回填 edge_id 并把
 -- decided_* 置位。Bot↔Bot 单次 accept 会连带批准反向 pending（AC-20，§4.1）。
 CREATE TABLE IF NOT EXISTS `permission_requests` (
-  `request_id`        VARCHAR(48)  NOT NULL COMMENT 'PK；req_<md5>',
-  `edge_id`           VARCHAR(48)  DEFAULT NULL COMMENT '批准后回填对应 edge_grants.edge_id；pending 时 NULL',
+  `id`               BIGINT       NOT NULL AUTO_INCREMENT COMMENT 'PK；自增 bigint',
+  `request_id`       VARCHAR(64)  NOT NULL COMMENT '外部业务 id（裸 UUID v4）；内部 bigint PK 见 id 列',
+  `edge_id`          BIGINT       DEFAULT NULL COMMENT '批准后回填对应 edge_grants.id；pending 时 NULL',
   `env`               VARCHAR(16)  NOT NULL COMMENT '环境标签',
   `from_id`           VARCHAR(256) NOT NULL COMMENT '发起方 actor id',
   `to_id`             VARCHAR(256) NOT NULL COMMENT '目标 actor id',
   `request_kind`      VARCHAR(16)  NOT NULL COMMENT 'connect | permission_profile | rules | revoke',
-  `requested_ref_id`  VARCHAR(128) DEFAULT NULL COMMENT 'permission_profile/rules 请求的目标 ref；connect 时 NULL',
+  `requested_ref_id` BIGINT       DEFAULT NULL COMMENT 'permission_profile/rules 请求的目标 ref；connect 时 NULL',
   `requested_rules`   TEXT         DEFAULT NULL COMMENT 'rules 请求带的内联规则（JSON 字符串）',
   `message`           TEXT         DEFAULT NULL COMMENT '发起方留言',
   `status`            VARCHAR(16)  NOT NULL DEFAULT 'pending' COMMENT 'pending | approved | rejected | cancelled',
@@ -74,7 +75,8 @@ CREATE TABLE IF NOT EXISTS `permission_requests` (
   `decided_at`        timestamp    NULL DEFAULT NULL COMMENT '决定时刻（DB 托管，CURRENT_TIMESTAMP 写入）；未决定时 NULL',
   `gmt_create`        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
   `gmt_modified`      timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
-  PRIMARY KEY (`request_id`),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_permission_requests_request_id` (`request_id`) COMMENT '外部 request_id 全局唯一',
   KEY `idx_req_to_env_status` (`to_id`, `env`, `status`) COMMENT '收件箱（received）扫描',
   KEY `idx_req_from_env_status` (`from_id`, `env`, `status`) COMMENT '发件箱（sent）扫描',
   KEY `idx_req_edge` (`edge_id`) COMMENT '按边反查请求'
@@ -85,7 +87,7 @@ CREATE TABLE IF NOT EXISTS `permission_requests` (
 -- （source=agent_card）；**非** 默认/friend 访问的前提（friend 边用 wildcard-allow
 -- 默认 profile，与 capabilities 无关，§3.1）。
 CREATE TABLE IF NOT EXISTS `capabilities` (
-  `capability_id`     VARCHAR(48)  NOT NULL COMMENT 'PK',
+  `id`                BIGINT       NOT NULL AUTO_INCREMENT COMMENT 'PK',
   `bot_id`            VARCHAR(256) NOT NULL COMMENT '所属 bot uuid',
   `env`               VARCHAR(16)  NOT NULL COMMENT '环境标签',
   `tool`              VARCHAR(64)  NOT NULL COMMENT '工具名（如 bcs_fuse）',
@@ -96,7 +98,7 @@ CREATE TABLE IF NOT EXISTS `capabilities` (
   `raw_metadata`      TEXT         DEFAULT NULL COMMENT '原始元数据（JSON 字符串，透传）',
   `gmt_create`        timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
   `gmt_modified`      timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
-  PRIMARY KEY (`capability_id`),
+  PRIMARY KEY (`id`),
   KEY `idx_cap_bot_env` (`bot_id`, `env`, `status`) COMMENT '按 bot/env 列能力'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -104,7 +106,7 @@ CREATE TABLE IF NOT EXISTS `capabilities` (
 -- 准入决策审计日志（append-only）。记录某次 A→B 准入判定结果与命中的授权边，
 -- 供运营排查与 shadow 比对（§8.5/§8.6）。不计入业务查询路径，仅写入。
 CREATE TABLE IF NOT EXISTS `authz_decision_logs` (
-  `decision_id`   VARCHAR(48)  NOT NULL COMMENT 'PK',
+  `id`            BIGINT       NOT NULL AUTO_INCREMENT COMMENT 'PK',
   `env`           VARCHAR(16)  NOT NULL COMMENT '环境标签',
   `task_id`       VARCHAR(128) DEFAULT NULL COMMENT '关联任务 id（可空）',
   `run_id`        VARCHAR(128) DEFAULT NULL COMMENT '关联 run id（可空）',
@@ -118,7 +120,7 @@ CREATE TABLE IF NOT EXISTS `authz_decision_logs` (
   `context_json`  TEXT         DEFAULT NULL COMMENT '决策上下文快照（JSON 字符串）',
   `gmt_create`    timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
   `gmt_modified`  timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
-  PRIMARY KEY (`decision_id`),
+  PRIMARY KEY (`id`),
   KEY `idx_adl_env_from_to` (`env`, `from_id`, `to_id`) COMMENT '按对查决策历史'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 


### PR DESCRIPTION
…s (#1401)

Edge-permission related tables and APIs were partially split between two ID models:

  - historical string business IDs such as `req_<uuid>`
  - database-generated bigint IDs exposed as `request_id` / `edge_id`

This caused contract and implementation drift across domain models, repositories, OpenAPI schemas, migration logic, and friend-connection APIs. In particular, friend-connection request IDs and edge IDs need one consistent representation so create / approve / reject / cancel / list flows can be idempotent, queryable, and compatible with migration and reconciliation.

  ## Solution

Standardized edge-permission IDs on database auto-increment bigint primary keys:

- use `id BIGINT AUTO_INCREMENT` as the database primary key for edge-permission tables
  - expose the same numeric ID as `request_id` for permission requests
- expose the same numeric ID as `edge_id` for edge grants where the internal API needs it
- keep business-level duplicate detection based on stable relationship dimensions instead of generated string IDs
- keep migration / reconciliation idempotency based on natural unique fields or migration helper fields rather than externally visible string IDs
- update domain, repository, service, storage, migration, and tests to use numeric IDs consistently
  - preserve existing friend-connection lifecycle semantics:
    - pending requests have no `edge_id`
    - approved requests are backfilled with the generated edge ID
- repeated approvals reuse the existing request / edge state instead of creating duplicate edges

  Rejected alternative:

- Keeping `req_<uuid>` / string business IDs as the public ID was rejected because the agreed direction is to use database-generated IDs as the single request / edge identifier and rely on unique business
  dimensions for duplicate detection.

  ## Validation

Ran / updated relevant BCS tests for the edge-permission ID migration and friend-connection flow, including coverage around:

  - request insert returning the generated bigint ID
  - request lookup / decide / backfill by numeric request ID
- auto-approved friend requests returning numeric `request_ids` and `edge_ids`
  - pending friend requests carrying no `edge_id`
  - manual approval backfilling the created `edge_id`
  - duplicate / idempotent friend-add behavior
- migration and reconciliation paths using business dimensions rather than string request IDs

  Validation commands:

  ```bash cargo check -p bcs-edge-permission -p bcs-service-api -p bcs-domain cargo test -p bcs-edge-permission cargo test -p bcs-http --test friend_connections_contract cargo test -p bcs-api-http --test friendship_routes

  ## Compatibility and risk

This is a schema and contract-impacting change for edge-permission internals and friend-connection APIs.

  Compatibility impact:

- request_id / edge_id are numeric bigint IDs instead of string IDs in the edge-permission friend-connection model.
- Existing persisted rows or migration inputs that relied on string business IDs must be migrated or reconciled through natural business keys / migration helper fields.
- OpenAPI schemas must represent friend-connection request IDs as integer/int64 where those IDs are exposed.
- edge_id should remain internal-only unless an external API has a clear operation that requires it.

  Risk:

- If any caller still treats request_id as a string business ID, approval / rejection / cancellation requests may fail type validation.
- Migration idempotency depends on the correctness of the chosen natural unique keys or migration helper fields.
- Exposing edge_id in public OpenAPI may leak internal authorization-edge details without a real external use case.

  Rollback path:

- Roll back schema, repository, and service changes together; partial rollback will reintroduce ID type drift.
- If public API compatibility becomes a concern, keep numeric IDs internally and add an adapter-only compatibility layer instead of changing the domain model back to string IDs.

  ## Spec

  Implements the agreed edge-permission ID model:

- edge-permission tables use id BIGINT AUTO_INCREMENT as the primary key
  - request_id maps to permission_requests.id
  - edge_id maps to edge_grants.id
- duplicate business detection is based on relationship dimensions / unique constraints, not generated string IDs
- migration and reconciliation may use internal helper fields, but those fields are not exposed as public business IDs

---------

<!--
Title format: <type>(<scope>): <concise outcome>
  e.g. feat(backend): add whitelist observed state
Types: feat | fix | refactor | docs | test | ci | build | chore
The title becomes the commit message on squash merge, so make it self-contained.
See "Pull Request Conventions" in AGENTS.md.
Delete the optional sections that do not apply.
-->

## Problem

<!-- The defect, gap, or requirement, and why it matters. -->

## Solution

<!-- The approach taken, and rejected alternatives when the choice is not obvious. -->

## Validation

<!-- Tests, gates, and manual checks you ran, with results. State what you could not run and why. -->

## Compatibility and risk (optional)

<!-- Contract, schema, config, or migration impact, and the rollback path. -->

## Spec (optional)

<!-- The contract or design document this change implements. -->

## Related issues (optional)

<!-- Issues this closes or relates to. -->
