### PR TITLE
fix(backend): scope template validation to OpenAPI creates

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -70,6 +70,7 @@ from agentclaw.community.core.bot_management.create_flow import (
     BotCreateContext,
     BotCreateDeploymentMode,
     BotCreateSpec,
+    BotCreateTemplateValidationMode,
     complete_bot_authorization,
     create_bot_with_authorization,
 )
@@ -433,6 +434,7 @@ async def create_bot(
                 "applicationCoding" if template_properties is not None else None
             ),
             template_config=template_properties,
+            template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
         ),
         context=BotCreateContext(
             deployment_mode=BotCreateDeploymentMode.CLOUD,
@@ -1035,6 +1037,7 @@ def _complete_auth_status(
                 space_id=current_space.numeric_id,
                 template_type=template_type,
                 template_config=template_config,
+                template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
             ),
             context=BotCreateContext(
                 deployment_mode=BotCreateDeploymentMode.CLOUD,

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -76,6 +76,13 @@ class BotCreateDeploymentMode(StrEnum):
     LOCAL = "local"
 
 
+class BotCreateTemplateValidationMode(StrEnum):
+    """Template validation contract selected by the caller's API surface."""
+
+    LEGACY = "legacy"
+    PUBLIC = "public"
+
+
 @dataclass(frozen=True)
 class BotCreateContext:
     """Caller-resolved business context required by creation policy."""
@@ -94,15 +101,23 @@ class PreparedBotCreate:
 
 def to_internal_template_config(
     value: dict[str, Any] | None,
+    *,
+    reject_server_managed_fields: bool = True,
 ) -> dict[str, Any] | None:
-    """Reject platform-managed template keys and detach caller-owned input."""
+    """Validate public ownership rules and detach caller-owned input.
+
+    The default keeps this helper's public-input behavior. Legacy internal
+    callers use the explicit opt-out because their template config is an
+    established internal snapshot that may contain platform-managed fields.
+    """
     if value is None:
         return None
-    reserved = sorted(_TEMPLATE_SERVER_RESERVED_FIELDS.intersection(value))
-    if reserved:
-        raise BotTemplateInvalidError(
-            f"template_config contains server-managed fields: {reserved}"
-        )
+    if reject_server_managed_fields:
+        reserved = sorted(_TEMPLATE_SERVER_RESERVED_FIELDS.intersection(value))
+        if reserved:
+            raise BotTemplateInvalidError(
+                f"template_config contains server-managed fields: {reserved}"
+            )
     return deepcopy(value)
 
 
@@ -147,6 +162,9 @@ def prepare_bot_create(
     bot_type: str,
     engine_type: str,
     context: BotCreateContext,
+    template_validation_mode: BotCreateTemplateValidationMode = (
+        BotCreateTemplateValidationMode.LEGACY
+    ),
 ) -> PreparedBotCreate:
     """Validate template-related creation inputs without transport dependencies."""
     if template_type is None:
@@ -158,7 +176,12 @@ def prepare_bot_create(
     # adapters/services retain their field semantics.
     if template_type != "applicationCoding":
         return PreparedBotCreate(
-            template_config=to_internal_template_config(template_config)
+            template_config=to_internal_template_config(
+                template_config,
+                reject_server_managed_fields=(
+                    template_validation_mode is BotCreateTemplateValidationMode.PUBLIC
+                ),
+            )
         )
 
     if context.deployment_mode is not BotCreateDeploymentMode.CLOUD:
@@ -176,7 +199,12 @@ def prepare_bot_create(
             "application coding is personal-space only"
         )
 
-    sanitized = to_internal_template_config(template_config)
+    sanitized = to_internal_template_config(
+        template_config,
+        reject_server_managed_fields=(
+            template_validation_mode is BotCreateTemplateValidationMode.PUBLIC
+        ),
+    )
     return PreparedBotCreate(
         template_config=_validate_application_coding_config(sanitized),
         requires_workspace_hosting=True,
@@ -284,6 +312,9 @@ class BotCreateSpec:
     share_policy: dict[str, Any] | None = None
     template_type: str | None = None
     template_config: dict[str, Any] | None = None
+    template_validation_mode: BotCreateTemplateValidationMode = (
+        BotCreateTemplateValidationMode.LEGACY
+    )
     space_id: int | None = None
     # Engine/vendor-specific inputs belong here, NOT as new named fields. The
     # spec is the contract shared by every surface, so it stays engine-agnostic
@@ -305,6 +336,7 @@ def _prepare_create(
         bot_type=spec.bot_type,
         engine_type=spec.engine_type,
         context=context,
+        template_validation_mode=spec.template_validation_mode,
     )
     if (
         prepared.requires_workspace_hosting

--- a/src/backend/tests/community/core/bot_management/test_application_coding_create.py
+++ b/src/backend/tests/community/core/bot_management/test_application_coding_create.py
@@ -17,6 +17,7 @@ from agentclaw.community.core.bot_management.create_flow import (
     BotCreateContext,
     BotCreateDeploymentMode,
     BotCreateSpec,
+    BotCreateTemplateValidationMode,
     complete_bot_authorization,
     create_bot_with_authorization,
     prepare_bot_create,
@@ -159,6 +160,29 @@ def test_prepare_valid_application_coding_returns_detached_config() -> None:
     assert prepared.template_config == payload
     assert prepared.template_config is not payload
     assert prepared.requires_workspace_hosting is True
+
+
+def test_prepare_legacy_application_coding_preserves_template_uid() -> None:
+    payload = {"template_uid": "legacy-template", "devflow_workflow": "x"}
+    prepared = _prepare(
+        template_type="applicationCoding",
+        template_config=payload,
+    )
+    assert prepared.template_config == payload
+    assert prepared.template_config is not payload
+    assert prepared.requires_workspace_hosting is True
+
+
+def test_prepare_public_application_coding_rejects_template_uid() -> None:
+    with pytest.raises(
+        BotTemplateInvalidError,
+        match="server-managed fields.*template_uid",
+    ):
+        _prepare(
+            template_type="applicationCoding",
+            template_config={"template_uid": "caller-value"},
+            template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
+        )
 
 
 def test_shared_create_rejects_missing_hosting_before_passport() -> None:


### PR DESCRIPTION
## Problem

The recent AICoding template validation was applied in the shared bot creation flow. This caused legacy internal `/api/bots` callers that pass `template_uid` in `template_config` to fail with `template_config contains server-managed fields`.

The stricter server-managed-field validation should apply to the OpenAPI contract only and must not change established legacy behavior.

## Solution

- Added an explicit template validation mode to the transport-agnostic bot creation spec:
  - `LEGACY` remains the default for existing internal callers.
  - `PUBLIC` is selected by the OpenAPI create and authorization-completion paths.
- Kept server-managed-field rejection enabled for OpenAPI inputs.
- Preserved legacy template snapshots, including `template_uid`, while retaining existing applicationCoding policy and validation checks.
- Added regression tests for both legacy preservation and OpenAPI-style rejection.

## Validation

- `python -m compileall -q` passed for the changed production and test files.
- `git diff --check` passed.
- The targeted pytest suite could not run because the environment could not resolve `mirrors.aliyun.com` while downloading `pyyaml==6.0.3`.

## Compatibility and risk

This is a compatibility fix. Existing `/api/bots` callers keep the previous template behavior. OpenAPI callers retain the newer server-managed-field validation. No database or public schema migration is required.
