### PR TITLE
feat(collaborator): add batch list endpoint

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_collaborator/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_collaborator/router.py
@@ -12,6 +12,7 @@ from agentclaw.community.adapters.http.bot_collaborator.schemas import (
     AddCollaboratorRequest,
     AddCollaboratorResponse,
     CollaboratorInfo,
+    BatchListCollaboratorsRequest,
     ListCollaboratorsResponse,
     UpdateCollaboratorRequest,
     UpdateCollaboratorResponse,
@@ -360,6 +361,69 @@ async def list_collaborators(
     except Exception as e:
         logger.error(f"[list_collaborators] Unexpected error: {e}")
         return ApiResponse(success=False, message=f"查询协作者失败: {str(e)}", error_code=500, data=None)
+
+
+@router.post(
+    "/batch-list",
+    response_model=ApiResponse,
+    summary="批量获取协作者列表",
+)
+async def batch_list_collaborators(
+    request: BatchListCollaboratorsRequest,
+    user: AuthenticatedUser = Depends(get_current_user),
+    service: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
+) -> ApiResponse:
+    """批量查询候选 Bot 的协作者，供 accservice 当前协作授权使用。"""
+    try:
+        user_id = user.staffId
+        if not user_id or user_id == "anonymous":
+            return ApiResponse(success=False, message="无法获取用户信息", error_code=400, data=None)
+
+        bot_ids = list(dict.fromkeys(
+            bot_id.strip() for bot_id in request.bot_ids if bot_id.strip()
+        ))
+        if not bot_ids:
+            return ApiResponse(success=False, message="bot_ids 不能为空", error_code=400, data=None)
+        if len(bot_ids) > 100:
+            return ApiResponse(success=False, message="单次最多查询 100 个 bot_id", error_code=400, data=None)
+
+        logger.info(
+            "[batch_list_collaborators] Listing: bot_count=%s, user=%s",
+            len(bot_ids), user_id
+        )
+        records = service.batch_list_collaborators(
+            bot_ids=bot_ids,
+            user_id=user_id,
+            role=request.role,
+        )
+        collaborators = [
+            CollaboratorInfo(
+                id=r.id,
+                bot_pk=r.bot_pk,
+                bot_id=r.bot_id,
+                owner_id=r.owner_id,
+                user_id=r.user_id,
+                user_name=r.user_name,
+                role=r.role,
+                operator_id=r.operator_id,
+                gmt_create=r.gmt_create,
+                gmt_modified=r.gmt_modified,
+            )
+            for r in records
+        ]
+        return ApiResponse(
+            success=True,
+            data=ListCollaboratorsResponse(collaborators=collaborators).model_dump(),
+            message="查询成功",
+        )
+
+    except CollaboratorServiceError as e:
+        logger.error(f"[batch_list_collaborators] Service error: {e}")
+        return ApiResponse(success=False, message=str(e), error_code=500, data=None)
+
+    except Exception as e:
+        logger.error(f"[batch_list_collaborators] Unexpected error: {e}")
+        return ApiResponse(success=False, message=f"批量查询协作者失败: {str(e)}", error_code=500, data=None)
 
 
 @router.post(

--- a/src/backend/src/agentclaw/community/adapters/http/bot_collaborator/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_collaborator/schemas.py
@@ -62,6 +62,12 @@ class ListCollaboratorsRequest(BaseModel):
     role: Optional[str] = Field(default=None, description="角色过滤（admin/member）")
 
 
+class BatchListCollaboratorsRequest(BaseModel):
+    """批量获取协作者列表请求。"""
+    bot_ids: List[str] = Field(..., description="当前协作参与的 Bot ID 列表")
+    role: Optional[str] = Field(default=None, description="角色过滤（admin/member）")
+
+
 class ListCollaboratorsResponse(BaseModel):
     """获取协作者列表响应。"""
     collaborators: List[CollaboratorInfo] = Field(default_factory=list, description="协作者列表")

--- a/src/backend/src/agentclaw/community/api/collaborator_service.py
+++ b/src/backend/src/agentclaw/community/api/collaborator_service.py
@@ -35,6 +35,14 @@ class CollaboratorServiceProtocol(Protocol):
         env: Optional[str] = None,
     ) -> List[CollaboratorRecord]: ...
 
+    def batch_list_collaborators(
+        self,
+        bot_ids: list[str],
+        user_id: str,
+        role: Optional[str] = None,
+        env: Optional[str] = None,
+    ) -> List[CollaboratorRecord]: ...
+
     def update_collaborator(
         self,
         collaborator_id: int,

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_query_mixin.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_query_mixin.py
@@ -1,0 +1,132 @@
+"""协作者查询能力。
+
+将单 Bot 和批量协作者读取从 ``CollaboratorService`` 主模块拆出，保持原有
+service API，同时让查询职责独立演进。
+"""
+from typing import List, Optional
+
+from agentclaw.community.core.bot_collaborator.errors import (
+    BotNotFoundError,
+    PermissionDeniedError,
+)
+from agentclaw.community.core.bot_collaborator.models import (
+    CollaboratorRecord,
+    PermissionLevel,
+)
+from agentclaw.community.core.repository.protocols.bot import (
+    BotRepository,
+    CollaboratorRepositoryProtocol,
+)
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+class CollaboratorQueryMixin:
+    """为 ``CollaboratorService`` 提供单 Bot 与批量协作者查询。"""
+
+    _bot_repo: BotRepository
+    _collaborator_repo: CollaboratorRepositoryProtocol
+
+    def check_permission(
+        self,
+        bot_pk: int,
+        user_id: str,
+        owner_id: str,
+        required_level: PermissionLevel,
+        env: Optional[str] = None,
+    ) -> None:
+        """由 ``CollaboratorService`` 的权限实现覆盖。"""
+        raise NotImplementedError
+
+    def list_collaborators(
+        self,
+        bot_id: str,
+        owner_id: str,
+        user_id: str,
+        role: Optional[str] = None,
+        env: Optional[str] = None,
+    ) -> List[CollaboratorRecord]:
+        """获取 Bot 的协作者列表。
+
+        Args:
+            bot_id: Bot ID
+            owner_id: Bot 拥有者工号
+            user_id: 请求用户工号
+            role: 角色过滤（可选）
+            env: 环境标识
+
+        Returns:
+            CollaboratorRecord 列表
+
+        Raises:
+            BotNotFoundError: Bot 不存在
+            PermissionDeniedError: 用户无权限查看
+        """
+        if env is None:
+            env = get_current_env()
+
+        # 1. 查询 Bot 信息
+        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
+        if not bot:
+            raise BotNotFoundError(f"Bot 不存在: bot_id={bot_id}, owner_id={owner_id}")
+
+        bot_pk = bot["id"]
+        owner_id_from_bot = bot["owner_id"]
+
+        # 2. 检查用户权限（需要 MEMBER 或更高）
+        self.check_permission(
+            bot_pk=bot_pk,
+            user_id=user_id,
+            owner_id=owner_id_from_bot,
+            required_level=PermissionLevel.MEMBER,
+            env=env,
+        )
+
+        # 3. 获取协作者列表
+        return self._collaborator_repo.list_by_bot(
+            bot_id=bot_id,
+            owner_id=owner_id_from_bot,
+            env=env,
+            role=role,
+        )
+
+    def batch_list_collaborators(
+        self,
+        bot_ids: list[str],
+        user_id: str,
+        role: Optional[str] = None,
+        env: Optional[str] = None,
+    ) -> List[CollaboratorRecord]:
+        """批量查询候选 Bot 的协作者，跳过不存在或当前用户不可访问的 Bot。"""
+        if env is None:
+            env = get_current_env()
+
+        normalized_bot_ids = list(dict.fromkeys(
+            bot_id.strip() for bot_id in bot_ids if bot_id.strip()
+        ))
+        records: List[CollaboratorRecord] = []
+        for bot_id in normalized_bot_ids:
+            bot = self._bot_repo.get_by_id(bot_id)
+            if not bot:
+                continue
+
+            bot_pk = bot["id"]
+            owner_id = bot["owner_id"]
+            try:
+                self.check_permission(
+                    bot_pk=bot_pk,
+                    user_id=user_id,
+                    owner_id=owner_id,
+                    required_level=PermissionLevel.MEMBER,
+                    env=env,
+                )
+            except PermissionDeniedError:
+                continue
+
+            records.extend(self._collaborator_repo.list_by_bot(
+                bot_id=bot_id,
+                owner_id=owner_id,
+                env=env,
+                role=role,
+            ))
+
+        return records

--- a/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_collaborator/services/collaborator_service.py
@@ -33,6 +33,9 @@ from agentclaw.community.core.bot_collaborator.services.member_management_capabi
 from agentclaw.community.core.bot_collaborator.services.editor_policy import (
     EditorPolicy,
 )
+from agentclaw.community.core.bot_collaborator.services.collaborator_query_mixin import (
+    CollaboratorQueryMixin,
+)
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
 from agentclaw.community.utils.env_utils import get_current_env
@@ -68,7 +71,7 @@ __all__ = [
 # ============================================================================
 # 服务实现
 # ============================================================================
-class CollaboratorService:
+class CollaboratorService(CollaboratorQueryMixin):
     """Bot 协作者管理服务。
 
     提供协作者的 CRUD 操作和权限检查功能。
@@ -541,62 +544,6 @@ class CollaboratorService:
             owner_id=owner_id,
             user_id=user_id,
             env=resolved_env,
-        )
-
-    # ========================================================================
-    # 获取协作者列表
-    # ========================================================================
-
-    def list_collaborators(
-        self,
-        bot_id: str,
-        owner_id: str,
-        user_id: str,
-        role: Optional[str] = None,
-        env: Optional[str] = None,
-    ) -> List[CollaboratorRecord]:
-        """获取 Bot 的协作者列表。
-
-        Args:
-            bot_id: Bot ID
-            owner_id: Bot 拥有者工号
-            user_id: 请求用户工号
-            role: 角色过滤（可选）
-            env: 环境标识
-
-        Returns:
-            CollaboratorRecord 列表
-
-        Raises:
-            BotNotFoundError: Bot 不存在
-            PermissionDeniedError: 用户无权限查看
-        """
-        if env is None:
-            env = get_current_env()
-
-        # 1. 查询 Bot 信息
-        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
-        if not bot:
-            raise BotNotFoundError(f"Bot 不存在: bot_id={bot_id}, owner_id={owner_id}")
-
-        bot_pk = bot["id"]
-        owner_id_from_bot = bot["owner_id"]
-
-        # 2. 检查用户权限（需要 MEMBER 或更高）
-        self.check_permission(
-            bot_pk=bot_pk,
-            user_id=user_id,
-            owner_id=owner_id_from_bot,
-            required_level=PermissionLevel.MEMBER,
-            env=env,
-        )
-
-        # 3. 获取协作者列表
-        return self._collaborator_repo.list_by_bot(
-            bot_id=bot_id,
-            owner_id=owner_id_from_bot,
-            env=env,
-            role=role,
         )
 
     # ========================================================================

--- a/src/backend/tests/community/core/bot_collaborator/test_collaborator_service_coding.py
+++ b/src/backend/tests/community/core/bot_collaborator/test_collaborator_service_coding.py
@@ -17,6 +17,7 @@ from agentclaw.community.core.bot_collaborator.services.collaborator_service imp
 from agentclaw.community.core.bot_collaborator.models import (
     CollaboratorRecord,
     CollaboratorRole,
+    PermissionLevel,
 )
 from agentclaw.community.core.bot_collaborator.services.aicoding.member_management_capability import (
     AICodingMemberManagementCapability,
@@ -377,3 +378,140 @@ def test_leave_collaboration_owner_is_not_collaborator_record(
 
     collaborator_repo.get_by_bot_and_user.assert_not_called()
     collaborator_repo.delete.assert_not_called()
+
+
+
+def test_batch_list_collaborators_accepts_multiple_bot_ids(
+    service, bot_repo, collaborator_repo
+):
+    """Batch list resolves each Bot owner and returns one flat collaborator list."""
+    bot_repo.get_by_id.side_effect = lambda bot_id: {
+        "bot-a": {"id": 11, "owner_id": "owner-a"},
+        "bot-b": {"id": 22, "owner_id": "owner-b"},
+    }.get(bot_id)
+    record_a = Mock(bot_id="bot-a")
+    record_b = Mock(bot_id="bot-b")
+    collaborator_repo.list_by_bot.side_effect = [[record_a], [record_b]]
+    service.check_permission = Mock()
+
+    records = service.batch_list_collaborators(
+        bot_ids=["bot-a", "bot-b", "bot-a"],
+        user_id="user-1",
+        role="admin",
+        env="dev",
+    )
+
+    assert records == [record_a, record_b]
+    assert bot_repo.get_by_id.call_count == 2
+    service.check_permission.assert_any_call(
+        bot_pk=11,
+        user_id="user-1",
+        owner_id="owner-a",
+        required_level=PermissionLevel.MEMBER,
+        env="dev",
+    )
+    assert collaborator_repo.list_by_bot.call_count == 2
+
+
+def test_batch_list_collaborators_skips_missing_candidate(
+    service, bot_repo, collaborator_repo
+):
+    """Batch mode omits missing Bots instead of failing the whole candidate set."""
+    bot_repo.get_by_id.side_effect = lambda bot_id: (
+        {"id": 11, "owner_id": "owner-a"} if bot_id == "bot-a" else None
+    )
+    record = Mock(bot_id="bot-a")
+    collaborator_repo.list_by_bot.return_value = [record]
+    service.check_permission = Mock()
+
+    records = service.batch_list_collaborators(
+        bot_ids=["bot-a", "bot-missing"],
+        user_id="user-1",
+        env="dev",
+    )
+
+    assert records == [record]
+
+
+def test_list_collaborators_single_keeps_strict_not_found(service, bot_repo):
+    """The legacy single-Bot request keeps its existing strict error semantics."""
+    bot_repo.get_by_id_and_owner.return_value = None
+
+    with pytest.raises(BotNotFoundError):
+        service.list_collaborators(
+            bot_id="bot-missing",
+            owner_id=OWNER,
+            user_id="user-1",
+            env="dev",
+        )
+
+
+def test_list_collaborators_single_with_owner_keeps_legacy_behavior(
+    service, bot_repo, collaborator_repo
+):
+    """Legacy bot_id + owner_id calls keep the original repository and result path."""
+    bot = {"id": 11, "owner_id": OWNER}
+    record = Mock(bot_id="bot-123", owner_id=OWNER)
+    bot_repo.get_by_id_and_owner.return_value = bot
+    collaborator_repo.list_by_bot.return_value = [record]
+    service.check_permission = Mock()
+
+    records = service.list_collaborators(
+        bot_id="bot-123",
+        owner_id=OWNER,
+        user_id=MEMBER,
+        role="admin",
+        env="dev",
+    )
+
+    assert records == [record]
+    bot_repo.get_by_id_and_owner.assert_called_once_with("bot-123", OWNER)
+    bot_repo.get_by_id.assert_not_called()
+    service.check_permission.assert_called_once_with(
+        bot_pk=11,
+        user_id=MEMBER,
+        owner_id=OWNER,
+        required_level=PermissionLevel.MEMBER,
+        env="dev",
+    )
+    collaborator_repo.list_by_bot.assert_called_once_with(
+        bot_id="bot-123",
+        owner_id=OWNER,
+        env="dev",
+        role="admin",
+    )
+
+
+def test_batch_list_collaborators_skips_permission_denied_candidate(
+    service, bot_repo, collaborator_repo
+):
+    """One inaccessible Bot must not fail a batch containing an accessible Bot."""
+    bot_repo.get_by_id.side_effect = lambda bot_id: {
+        "bot-a": {"id": 11, "owner_id": "owner-a"},
+        "bot-b": {"id": 22, "owner_id": "owner-b"},
+    }[bot_id]
+    record = Mock(bot_id="bot-a")
+    collaborator_repo.list_by_bot.return_value = [record]
+
+    def check_permission(**kwargs):
+        if kwargs["bot_pk"] == 22:
+            from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
+                PermissionDeniedError,
+            )
+            raise PermissionDeniedError("no access")
+
+    service.check_permission = Mock(side_effect=check_permission)
+
+    records = service.batch_list_collaborators(
+        bot_ids=["bot-a", "bot-b"],
+        user_id=MEMBER,
+        env="dev",
+    )
+
+    assert records == [record]
+    collaborator_repo.list_by_bot.assert_called_once_with(
+        bot_id="bot-a",
+        owner_id="owner-a",
+        env="dev",
+        role=None,
+    )

--- a/src/backend/tests/community/endpoints/test_bot_collaborator_router.py
+++ b/src/backend/tests/community/endpoints/test_bot_collaborator_router.py
@@ -56,6 +56,30 @@ def _seed_collaborator(world):
     )
 
 
+def _seed_batch_collaborators(world):
+    """Seed two Bots owned by the caller, each with one collaborator."""
+    make_staff_user(world, user_id="u_owner")
+    for bot_id, collaborator_id in [
+        ("bot_batch_a", "u_collab_a"),
+        ("bot_batch_b", "u_collab_b"),
+    ]:
+        make_bot(
+            world,
+            bot_id=bot_id,
+            owner_id="u_owner",
+            bot_type="service",
+            status="ACTIVE",
+        )
+        make_collaborator(
+            world,
+            bot_id=bot_id,
+            owner_id="u_owner",
+            user_id=collaborator_id,
+            role="admin",
+            operator_id="u_owner",
+        )
+
+
 def _seed_bot_with_collab_for_lock(world):
     """Seed bot with collaborator for lock tests (lock requires collaborator to work)."""
     make_staff_user(world, user_id="u_owner")
@@ -179,8 +203,11 @@ def _assert_collaborator_for_others_operator(response, world):
 
 
 def _assert_collaborator_list_fields(response, world):
-    """Assert that collaborator list items have all required fields."""
-    data = response.json()["data"]
+    """Assert that the legacy response envelope and collaborator fields stay unchanged."""
+    body = response.json()
+    assert set(body) == {"success", "message", "error_code", "data"}
+    assert set(body["data"]) == {"collaborators"}
+    data = body["data"]
     collaborators = data.get("collaborators", [])
     if len(collaborators) > 0:
         c = collaborators[0]
@@ -205,6 +232,18 @@ def _assert_list_contains_collaborator(response, world):
     assert len(collaborators) >= 1, "Expected at least one collaborator"
     found = any(c["user_id"] == "u_collab" for c in collaborators)
     assert found, "Expected to find collaborator with user_id=u_collab"
+
+
+def _assert_batch_list_contains_both_bots(response, world):
+    collaborators = response.json()["data"]["collaborators"]
+    assert {item["bot_id"] for item in collaborators} == {
+        "bot_batch_a",
+        "bot_batch_b",
+    }
+    assert {item["user_id"] for item in collaborators} == {
+        "u_collab_a",
+        "u_collab_b",
+    }
 
 
 def _assert_permission_level(expected_level, expected_has_permission):
@@ -541,6 +580,46 @@ def add_collaborator_for_others_forbidden():
 )
 def list_collaborators_ok():
     """List collaborators returns success with correct collaborator data and all required fields."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/bot/collaborator/batch-list",
+    scenario="batch_bot_ids",
+    input=CaseInput(
+        headers={"x-user-id": "u_owner"},
+        json_body={"bot_ids": ["bot_batch_a", "bot_batch_b", "bot_batch_a"]},
+    ),
+    seed=_seed_batch_collaborators,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"success": True},
+    ),
+    extra_assertions=(
+        _assert_batch_list_contains_both_bots,
+        _assert_collaborator_list_fields,
+    ),
+)
+def batch_list_collaborators_ok():
+    """Dedicated batch endpoint returns one flat, unchanged collaborators list."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/bot/collaborator/batch-list",
+    scenario="empty_bot_ids",
+    input=CaseInput(
+        headers={"x-user-id": "u_owner"},
+        json_body={"bot_ids": []},
+    ),
+    seed=lambda world: make_staff_user(world, user_id="u_owner"),
+    expect=ExpectError(
+        status=200,
+        json_contains={"success": False, "error_code": 400},
+    ),
+)
+def batch_list_collaborators_rejects_empty_ids():
+    """Dedicated batch endpoint rejects an empty candidate list."""
 
 
 @endpoint_test(


### PR DESCRIPTION
## Problem

  DDF 在进行协作任务级人工授权时，需要查询**当前协作中实际参与的少量 Bot**所对应的协作者关系。

  现有接口只支持查询单个 Bot，并要求调用方同时传入 Bot owner：

  ```http
  GET /api/bot/collaborator/list?bot_id={botId}&owner_id={ownerId}
```

  如果直接修改现有接口，使其支持多个 bot_id 并将 owner_id 改为可选，会改变原接口的参数契约、服务方法签名和
  错误处理语义，可能影响现有前端及其他业务调用方。

  因此需要新增独立的批量查询接口，在满足 accservice 使用需求的同时，保证原有单 Bot 查询接口完全不受影响。

  ## Solution

  新增独立的批量协作者查询接口：

```http
POST /api/bot/collaborator/batch-list
Content-Type: application/json
```
  请求示例：

```
  {
    "bot_ids": [
      "bot-initiator",
      "bot-member-a",
      "bot-member-b"
    ],
    "role": "admin"
  }
```

  新接口的处理规则如下：

  - 单次最多查询 100 个去重后的 Bot ID；
  - 清理 Bot ID 首尾空格并排除空字符串；
  - 按请求中的原始顺序对 Bot ID 去重；
  - 根据每个 bot_id 查询对应的真实 owner；
  - 对每个 Bot 执行原有的 MEMBER 权限校验；
  - 跳过不存在的候选 Bot；
  - 跳过当前用户无权访问的候选 Bot；
  - 数据库或其他系统异常仍然整体返回失败，不会被错误处理为空列表；
  - 保持现有 data.collaborators 平铺响应结构；
  - 每条协作者记录继续返回 bot_id、owner_id、user_id 和 role 等现有字段。

  新增独立的 Service 方法：

```
  batch_list_collaborators(
      bot_ids: list[str],
      user_id: str,
      role: Optional[str] = None,
      env: Optional[str] = None,
  )
```

  原有接口和 Service 方法保持不变：

```http
GET /api/bot/collaborator/list?bot_id={botId}&owner_id={ownerId}
```

```
  list_collaborators(
      bot_id: str,
      owner_id: str,
      user_id: str,
      role: Optional[str] = None,
      env: Optional[str] = None,
  )
```

  通过单独增加批量路由和 Service 方法，避免在原接口内部增加“单个/批量”“owner 必填/可选”等兼容分支，降低对
  现有功能的影响。

  ## Validation

  执行了完整的 Bot 协作者核心逻辑、HTTP 接口和 E2E 测试：

```
  DEPLOY_PROFILE=test uv run pytest \
    tests/community/core/bot_collaborator \
    tests/community/endpoints/test_bot_collaborator_router.py \
    tests/community/e2e/test_bot_collaborator_flows.py -q
```

  测试结果：

  189 passed, 0 failed

  测试覆盖范围包括：

  - 原有 bot_id + owner_id 单 Bot 查询；
  - 原有单 Bot 严格的 Bot 不存在处理；
  - 原有单 Bot权限不足处理；
  - 新增批量查询接口；
  - Bot ID 清理和去重；
  - 空 Bot ID 列表校验；
  - 跳过不存在的候选 Bot；
  - 跳过当前用户无权访问的候选 Bot；
  - 保持原有响应 envelope 和协作者字段不变；
  - 原有协作者增删查 E2E 流程；
  - 原有协作者锁相关流程。

  由于新接口尚未部署到预发环境，本次未执行预发环境真实接口验证。

  ## Compatibility and risk

  原有接口契约保持不变：

```http
GET /api/bot/collaborator/list
```

  具体包括：

  - bot_id 继续为必填的单个字符串；
  - owner_id 继续必填；
  - 原有 Repository 查询继续使用 get_by_id_and_owner；
  - 原有权限校验逻辑保持不变；
  - 原有 403 和 404 错误语义保持不变；
  - 原有响应 JSON 结构保持不变；
  - 现有调用方不需要进行任何改造。

  新增能力被隔离在以下接口中：

```http
POST /api/bot/collaborator/batch-list
```

  本次变更不涉及数据库表结构调整，不需要执行数据库迁移，也没有新增必需的配置项。

  如需回滚，可以直接回滚本次提交。由于原有接口没有变化，回滚不会影响已有调用方。