### PR TITLE
feat(backend): allow +, (, ) in bot name whitelist

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -213,9 +213,9 @@ class DefaultBotTeclawNotAllowedError(BotServiceError):
         super().__init__(DEFAULT_BOT_TECLAW_NOT_ALLOWED_MESSAGE)
 
 
-# 仅允许中英文、数字、下划线、中划线、空格；禁止 @ # / 等特殊字符。
+# 仅允许中英文、数字、下划线、中划线、空格，以及产品名/版本说明所需的 +、(、) ；禁止 @ # / 等特殊字符。
 _BOT_NAME_MAX_LEN = 32
-_BOT_NAME_ALLOWED_RE = re.compile(r"^[\w一-鿿 \-]+$", re.UNICODE)
+_BOT_NAME_ALLOWED_RE = re.compile(r"^[\w一-鿿 \-()+]+$", re.UNICODE)
 
 
 def validate_bot_name(bot_name: Optional[str]) -> str:
@@ -224,7 +224,7 @@ def validate_bot_name(bot_name: Optional[str]) -> str:
     Rules:
     - must be non-empty after strip
     - length <= 32 characters
-    - only Chinese/letters/digits/underscore/hyphen/space allowed
+    - only Chinese/letters/digits/underscore/hyphen/space and + ( ) allowed
     """
     if bot_name is None:
         raise BotNameInvalidError("Bot 名称不能为空")
@@ -237,7 +237,8 @@ def validate_bot_name(bot_name: Optional[str]) -> str:
         )
     if not _BOT_NAME_ALLOWED_RE.match(trimmed):
         raise BotNameInvalidError(
-            "Bot 名称只能包含中英文、数字、下划线、中划线和空格，不允许 @、# 等特殊字符"
+            "Bot 名称只能包含中英文、数字、下划线、中划线、空格以及 +、(、) ，"
+            "不允许 @、# 等特殊字符"
         )
     return trimmed
 

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_create_validation.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_create_validation.py
@@ -130,6 +130,32 @@ class TestValidateBotName:
         # 若未来想收紧到仅 ASCII 数字，需先评估并修改测试。
         assert validate_bot_name("Bot１２３") == "Bot１２３"
 
+    # ---------- whitelist extension: + ( ) ----------
+
+    def test_plus_sign_accepted(self):
+        # 产品名中的 + 应放行（如 "Rp+"）
+        assert validate_bot_name("Rp+ Bot") == "Rp+ Bot"
+
+    def test_parens_accepted(self):
+        # 版本说明中的括号应放行（如 "(claude code版本)"）
+        assert validate_bot_name("Bot (claude code版本)") == "Bot (claude code版本)"
+
+    def test_plus_and_parens_combined_accepted(self):
+        # 复合用例：产品名 RP+ 与版本说明
+        assert validate_bot_name("Rp+ Bot (claude code版本)") == "Rp+ Bot (claude code版本)"
+
+    def test_plus_only_name_accepted(self):
+        assert validate_bot_name("a+b") == "a+b"
+
+    def test_parens_only_name_accepted(self):
+        assert validate_bot_name("a(b)c") == "a(b)c"
+
+    def test_still_rejected_chars_not_in_whitelist(self):
+        # 未加入白名单的字符仍被拒：@ # < > " ' ` \
+        for n in ["a@b", "a#b", "a<b", "a>b", 'a"b', "a'b", "a`b", "a\\b"]:
+            with pytest.raises(BotNameInvalidError):
+                validate_bot_name(n)
+
 
 # ---------------------------------------------------------------------------
 # BotService.create_bot — validation paths


### PR DESCRIPTION
## What
Allow `+`, `(`, `)` in Bot names so that product names / version notes containing these characters (e.g. `Rp+ Bot (claude code版本)`) can be used. Other non-safety characters such as `@`, `#`, `<`, `>`, double/single quote, backtick, and backslash remain rejected.

## Why
Bot name validation only allowed Chinese/Latin letters, digits, underscore, hyphen, and space. Teams whose product names contain `+` or parentheses were unable to name bots to match the product. These characters do not widen the injection surface (bot name does not enter file paths, shell, or URL segments; backend only renders it via ORM-bound DB columns, JSON responses, and logger).

## Changes
- `src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py`
  - `_BOT_NAME_ALLOWED_RE`: `^[\w一-鿿 \-]+$` → `^[\w一-鿿 \-()+]+$` (`-` stays escaped as a literal at the end of the class; `+` is a literal inside the class).
  - Updated the inline comment, the `validate_bot_name` docstring, and the `BotNameInvalidError` message text to reflect the new allowed set while still calling out that `@`, `#`, etc. are not allowed.
- `src/backend/tests/community/core/bot_management/services/test_bot_service_create_validation.py`
  - Added positive cases for `+`, `()` and the combined example `Rp+ Bot (claude code版本)`.
  - Added a negative case asserting `@ # < > " ' \` \ `` and backslash remain rejected.

All create/edit/check entry points reuse the single `validate_bot_name` helper, so the authority-point change propagates without per-entry edits. The length limit (32), strip and non-empty rules are unchanged, and existing bot names are not re-validated.

## Test
- `tests/community/core/bot_management/services/test_bot_service_create_validation.py`: 51 passed (incl. new whitelist cases).
- `tests/community/api/bot_management/test_router.py` + `tests/community/architecture/test_http_adapter_layer_is_http_only.py`: 160 passed (no regression).

## Compatibility & risk
- Whitelist is only widened, not tightened; existing valid names keep validating.
- No contract/config/schema change; no cross-module runtime impact.
- Rollback: revert the regex and text changes.

## Out of scope
Frontend validation prompt text sync and frontend UI HTML-escaping review are intentionally not included in this backend PR.