### PR TITLE
refactor(backend): own bot create engine_properties in engine strategies

### DIFF
--- a/src/backend/specs/2026-08-24-engine-properties-polymorphic-create/design.md
+++ b/src/backend/specs/2026-08-24-engine-properties-polymorphic-create/design.md
@@ -1,0 +1,577 @@
+# Bot Create `engine_properties` 与 Engine Strategy 创建预检设计
+
+- **日期**：2026-08-24
+- **状态**：已实现（2026-08-25，分支 `feat/engine-properties-create`，基于最新 `origin/dev`）
+- **范围**：Backend OpenAPI Bot Create / Passport authorization completion
+- **目标分支**：`dev`
+
+---
+
+## 0. 实现基线修正（2026-08-25）
+
+实现时发现最新 `origin/dev` 的状态与本设计早前评审假设不同：**公共契约迁移已经发生**——
+`engine_properties`（含必填 `template`）已发布为 `BotCreate`/`BotAuthStatusPoll` 的公开字段，
+顶层 `template` 已删除，且 Router 中存在 `body.engine_properties.template` 解包与
+`"applicationCoding"` 推断（即本设计要消除的反模式，也正是初稿背景描述的状态）。
+另有 #1442（LEGACY/PUBLIC 模板校验模式）已合入。
+
+因此本实现相对 §3 的 D2 做如下收敛：
+
+1. **不引入兼容窗口**：公开契约保持 dev 现状（只有 `engine_properties`），不重新发布已删除的
+   legacy `template` 字段；schema 零改动，公开 JSON schema（gateway artifact）零改动。
+2. 本 PR 的范围回到纯内部架构：Router 透明化（删除解包与 applicationCoding 推断）、
+   application-coding 创建策略下沉到 `AicodingProvisioningStrategy.prepare_create` 成为唯一实现、
+   `{"template": None}` 键存在性兼容语义、Core 层来源互斥与未知键拒绝。
+3. **#1442 的 LEGACY/PUBLIC 语义完整保留**并移植进新架构：
+   `BotCreateSpec.template_validation_mode` 经 routing 传入 `prepare_create`，
+   内部快照可携带 `template_uid`，OpenAPI 入口保持严格校验。
+   `BotCreateTemplateValidationMode` 移至 `engines/provisioning.py`（create_flow 再导出），
+   避免策略反向依赖 create_flow。
+4. **错误码决策（已实现）**：Default Strategy 对含 `template` 键的 engine_properties 抛
+   `BotCombinationUnsupportedError`，保持 openclaw/teclaw/hermes + applicationCoding 的历史 409
+   映射（内部 409 / OpenAPI 409）；其余未知键抛 `BotTemplateInvalidError`。
+5. gateway artifact 在 dev 上存在大量既有漂移（task-graph 等未 re-dump）；由于本 PR 契约零
+   变化，不夹带 catch-up，建议单独 regeneration。
+
+其余各节描述的目标架构（Strategy 契约、三路路由、测试计划）按原文落地。
+
+---
+
+## 1. 仓库现状（事实基线）
+
+当前代码尚不存在 `engine_properties`。公开创建契约为：
+
+```python
+class BotCreate(BaseModel):
+    template: BotCreateTemplate | None
+
+class BotCreateTemplate(BaseModel):
+    type: Literal["applicationCoding"]
+    properties: dict[str, Any]
+```
+
+OpenAPI Router 当前执行的是协议拆包：
+
+```python
+template_type = body.template.type if body.template is not None else None
+template_config = body.template.properties if body.template is not None else None
+```
+
+随后写入已有 Core DTO：
+
+```python
+BotCreateSpec(
+    template_type=template_type,
+    template_config=template_config,
+)
+```
+
+`applicationCoding` 不是 Router 推断生成的值，而是 caller 通过
+`template.type` 显式提交，并由 Pydantic `Literal` 约束。
+
+创建前置策略也已经收敛到 Core：
+
+- `create_bot_with_authorization()` 和 `complete_bot_authorization()` 都调用
+  `_prepare_create()`；
+- application-coding 的 cloud / engine / bot type / space 校验已经在
+  `prepare_bot_create()` 中；
+- reserved 字段、配置类型和 workspace hosting capability 校验均发生在
+  Passport 和 persistence 之前。
+
+因此，本次不是“把 Router 中现有的一坨 application-coding 业务逻辑下沉”。
+现有 Router 主要承担 DTO 转换。本次真实改动目标是：
+
+1. **新增并迁移公开请求字段**：`template` → `engine_properties`；
+2. **将已经位于通用 Core create flow 的 application-coding 规则迁移到现有
+   per-engine Strategy**，避免通用编排长期持有具体引擎规则。
+
+---
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+1. 新 OpenAPI 请求使用：
+
+   ```json
+   {
+     "engine": "claude_code",
+     "engine_properties": {
+       "template": {
+         "devflow_workflow": "app-flow",
+         "code_repos": []
+       }
+     }
+   }
+   ```
+
+2. Router 将 `engine_properties` 转成 plain `dict` 后透传，不读取
+   `engine_properties.template` 的业务字段。
+3. 复用现有 `EngineProvisioningStrategy`，由具体 Strategy 解析和校验自己
+   拥有的创建参数。
+4. 同步创建与 Passport 授权完成继续经过同一个 `_prepare_create()`。
+5. 所有校验继续发生在 Passport、Bot persistence 和 workspace 创建之前。
+6. legacy `template_type/template_config` 调用不被清空或静默降级。
+7. unsupported 或冲突输入明确失败，不静默忽略。
+
+### 2.2 非目标
+
+1. 不重写 `BotService.create_bot()`。
+2. 不新增第二套 engine registry。
+3. 不新增 pending intent 表、Saga 或 reconcile 机制。
+4. 不重构 update/restart/delete 的全部模板逻辑。
+5. 不改变已有错误码和 HTTP 状态映射。
+
+---
+
+## 3. 公共契约决策
+
+### D1. 这是公开契约迁移，不描述成既有事实
+
+`engine_properties` 是本次要新增的字段，不是仓库当前已经发布的字段。
+本次必须同时修改：
+
+- `adapters/http/openapi_v1/bots/schemas.py`；
+- Create Router；
+- auth-completion echo schema 和 Router；
+- OpenAPI 文档与 gateway JSON schema；
+- 兼容性/契约测试。
+
+### D2. 采用一个兼容窗口，不在同一 PR 直接删除 `template`
+
+当前 `template` 已经是公开 schema 字段。为避免未确认调用方直接收到 422，
+本次确定：
+
+```python
+class BotCreateEngineProperties(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # engine_properties 一旦出现，template 必须是非空对象。
+    template: dict[str, Any] = Field(min_length=1)
+
+
+class BotCreate(BaseModel):
+    engine_properties: BotCreateEngineProperties | None = None
+    template: BotCreateTemplate | None = Field(
+        default=None,
+        deprecated=True,
+    )
+```
+
+规则：
+
+| 输入 | 行为 |
+| --- | --- |
+| 两者都不传 | plain Bot 创建 |
+| 只传 `engine_properties` | 走新 Strategy 路径 |
+| 只传 legacy `template` | 走兼容路径，但 application-coding 仍路由到同一 Strategy |
+| 两者同时传 | 422/领域参数错误，不定义覆盖顺序 |
+
+后续删除 `template` 必须单独做 breaking-change PR，并明确版本或下线窗口；
+本次实现不得再以“可能没有外部 caller”为由隐式改成一次性删除。
+
+### D3. 接受新结构暂时失去显式 template discriminator 的代价
+
+目标命名由调用方要求确定为：
+
+```text
+body.template.properties -> body.engine_properties.template
+```
+
+因此新结构不再携带 `template.type`，其语义由 `engine` 选择出的 Strategy 决定。
+代价是：同一 engine 将来若支持第二种 template 类型，当前结构没有显式
+ discriminator。届时需要新增类型字段或版本化扩展结构。
+
+本次确认接受这一 tradeoff，不为尚不存在的第二种类型提前增加抽象。
+
+---
+
+## 4. Core DTO 决策
+
+### D4. 将现有未消费的 `extra_properties` 明确改为 `engine_properties`
+
+当前 `BotCreateSpec` 已有：
+
+```python
+extra_properties: dict[str, Any] = field(default_factory=dict)
+```
+
+它目前没有公共 schema 映射，也没有创建逻辑消费。本次应明确选择一种做法，
+不能同时保留两个含义相同的 opaque bag。
+
+推荐直接改名：
+
+```python
+engine_properties: dict[str, Any] = field(default_factory=dict)
+```
+
+并更新所有 `BotCreateSpec` 构造点。该字段是 Core 内部 DTO，不表示当前公共 API
+已经存在同名字段。
+
+历史字段暂时保留：
+
+```python
+template_type: str | None = None
+template_config: dict[str, Any] | None = None
+```
+
+它们服务于 internal `/api/bots` 和其他存量调用者。
+
+### D5. 新旧输入互斥在 `_prepare_create()` 入口统一校验
+
+规则必须落实在目标代码中，而不是只写在兼容章节：
+
+```python
+has_legacy_template = (
+    spec.template_type is not None or spec.template_config is not None
+)
+if spec.engine_properties and has_legacy_template:
+    raise BotTemplateInvalidError(
+        "engine_properties cannot be combined with legacy template fields"
+    )
+```
+
+Router/Pydantic 可以提前提供更友好的 422，但 Core 仍保留该不变量，避免内部调用
+绕过 HTTP 层。
+
+---
+
+## 5. Strategy 契约
+
+复用现有 `EngineProvisioningStrategy`，增加唯一一个创建预检 hook：
+
+```python
+@dataclass(frozen=True)
+class PreparedBotCreate:
+    template_type: str | None = None
+    template_config: dict[str, Any] | None = None
+    requires_workspace_hosting: bool = False
+
+
+class EngineProvisioningStrategy(ABC):
+    @abstractmethod
+    def prepare_create(
+        self,
+        *,
+        engine_properties: dict[str, Any],
+        bot_type: str,
+        deployment_mode: str,
+        space_kind: str,
+    ) -> PreparedBotCreate:
+        """Validate engine-owned create input before side effects."""
+```
+
+`PreparedBotCreate` 放在 Strategy contract 所在的 Core 中性模块，避免
+`provisioning.py` 反向导入 `create_flow.py`。
+
+本次不新增 `EnginePropertiesHandlerRegistry`、`EngineCreatePlan` 或新的 Context
+DTO。
+
+---
+
+## 6. Strategy 行为
+
+### 6.1 DefaultProvisioningStrategy
+
+默认 Strategy 不支持非空创建扩展。输入按语义分两类拒绝：
+
+```python
+if not engine_properties:
+    return PreparedBotCreate()
+if "template" in engine_properties:
+    # application-coding intent（新公共契约或 legacy 归一化）落到非 coding 引擎：
+    # 组合错误保持历史 409 映射（内部 409 / OpenAPI 409），不得变成 422。
+    raise BotCombinationUnsupportedError(
+        f"application coding does not support engine: {self.engine_type}"
+    )
+raise BotTemplateInvalidError(
+    f"engine {self.engine_type} does not support engine_properties: ..."
+)
+```
+
+**实现确定的错误码决策**（2026-08-24 评审遗留决策）：legacy
+`applicationCoding` + 非 claude_code 引擎（openclaw/teclaw/hermes）现状是
+`BotCombinationUnsupportedError`（内部 409 / OpenAPI 409）。若 Default 只抛
+`BotTemplateInvalidError`（内部 400 / OpenAPI 422），同一请求的映射就变了，
+违反 §2.2"不改变已有错误码"。因此 Default 对含 `template` 键的输入抛组合错误，
+其余未知键抛模板无效错误。这样 caller 输入不会被静默忽略，历史映射也保持不变。
+
+### 6.2 AicodingProvisioningStrategy
+
+Registry 当前分别注册：
+
+```python
+AicodingProvisioningStrategy("aicoding")
+AicodingProvisioningStrategy("claude_code")
+```
+
+但现有 application-coding 创建门禁只允许 `claude_code`。因此创建 hook 必须检查
+Strategy 实例自己的 `engine_type`，不能因为复用同一个类而放宽行为：
+
+```python
+if engine_properties and self.engine_type != "claude_code":
+    raise BotCombinationUnsupportedError(
+        f"application coding does not support engine: {self.engine_type}"
+    )
+```
+
+随后先校验 Core 不变量：
+
+```python
+unknown_keys = set(engine_properties) - {"template"}
+if unknown_keys:
+    raise BotTemplateInvalidError(
+        f"unsupported engine_properties fields: {sorted(unknown_keys)}"
+    )
+if "template" not in engine_properties:
+    raise BotTemplateInvalidError("engine_properties.template is required")
+
+template = engine_properties["template"]
+if template is None:
+    # Only produced by the legacy template_type path in _prepare_create().
+    sanitized_template = None
+elif not isinstance(template, dict) or not template:
+    raise BotTemplateInvalidError(
+        "engine_properties.template must be a non-empty object"
+    )
+else:
+    sanitized_template = _validate_and_detach_template(template)
+```
+
+这里必须按 **键是否存在** 判断 intent，不能使用 `get()` 后按值的 truthiness
+判断。`{"template": None}` 与 `{}` 在 Core 中语义不同：前者是 legacy
+application-coding 无配置，后者是没有 engine properties。
+
+不能只依赖 HTTP schema 的 `extra="forbid"`，因为 Core 也可能被内部调用者直接
+构造。`claude_code + {"other": ...}` 必须明确失败，不能静默忽略。
+
+随后执行现有等价校验：
+
+1. 只允许 cloud deployment；
+2. 只允许 personal Bot；
+3. 只允许 personal space；
+4. 新公共契约传入的 `template` 必须是非空对象；
+5. 拒绝 server-managed 字段；
+6. 校验已声明字段类型；
+7. 深拷贝 caller 输入；
+8. 返回：
+
+   ```python
+   PreparedBotCreate(
+       template_type="applicationCoding",
+       template_config=sanitized_template,
+       requires_workspace_hosting=True,
+   )
+   ```
+
+`aicoding + engine_properties.template` 必须保持拒绝，与当前行为一致。
+
+---
+
+## 7. Legacy 路由：application-coding 只保留一份实现
+
+不能让新输入走 Strategy、legacy application-coding 继续走
+`prepare_bot_create()` 的旧实现，否则会形成两份校验规则。
+
+`_prepare_create()` 应先判定输入来源，再统一路由：
+
+```python
+def _prepare_create(...):
+    _reject_mixed_sources(spec)
+
+    if spec.engine_properties:
+        prepared = _prepare_with_engine_strategy(spec, context)
+    elif spec.template_type == "applicationCoding":
+        # Core-only compatibility representation. Key presence preserves the
+        # legacy intent even when the legacy caller intentionally omitted config.
+        prepared = _prepare_with_engine_strategy(
+            replace(
+                spec,
+                engine_properties={"template": spec.template_config},
+            ),
+            context,
+        )
+    else:
+        # plain Bot 或其他历史 template 类型，保持现有通用兼容行为；返回值
+        # 必须同时保留 template_type 和经过 sanitation 的 template_config。
+        prepared = _prepare_legacy_non_application_template(spec)
+
+    if (
+        prepared.requires_workspace_hosting
+        and not bot_service.is_workspace_hosting_available()
+    ):
+        raise ApplicationCodingUnavailableError()
+
+    return replace(
+        spec,
+        template_type=prepared.template_type,
+        template_config=prepared.template_config,
+    )
+```
+
+关键约束：
+
+- legacy `applicationCoding` 和新 `engine_properties.template` 都由同一具体 Strategy
+  校验；
+- `{"template": None}` 是 **Core-only 的 legacy compatibility representation**：
+  `"template"` 键存在表示 application-coding intent，值为 `None` 表示 legacy caller
+  有意省略配置。Strategy 必须返回
+  `PreparedBotCreate(template_type="applicationCoding", template_config=None,
+  requires_workspace_hosting=True)`，并照常执行 engine/deployment/bot/space 门禁；
+- 新 HTTP schema 不允许 caller 提交 `template: null`，所以该兼容语义不会扩展为新的
+  公共契约；空字典表示没有新 engine properties，而不是 application-coding intent；
+- legacy 非 application-coding template 保持原行为；
+- plain Bot 不会因空 `PreparedBotCreate` 被意外清空已有字段；
+- 迁移后 `create_flow.py` 可以删除 application-coding 专属常量和校验函数，但仍可
+  保留中性的 legacy template sanitation；
+- 不接受“双份实现只是临时过渡”的隐式状态。
+
+---
+
+## 8. Router 与授权完成路径
+
+### 8.1 新 Create 请求
+
+Router 只做 DTO 转换：
+
+```python
+engine_properties = (
+    body.engine_properties.model_dump(exclude_none=True)
+    if body.engine_properties is not None
+    else {}
+)
+```
+
+它不读取 `engine_properties.template`，也不推断 application-coding 语义。
+
+### 8.2 Legacy `template` 请求
+
+兼容窗口内，Router 可以把公开 legacy DTO 映射到 Core 的历史字段：
+
+```python
+template_type = body.template.type
+template_config = body.template.properties
+```
+
+这是协议兼容转换。application-coding 的组合校验、reserved 字段和 capability
+判断仍只在 Strategy 中执行。
+
+### 8.3 Passport authorization completion
+
+`BotAuthStatusPoll` 必须同步增加 `engine_properties`，并在兼容窗口保留 deprecated
+`template` echo。两者互斥规则与 Create 完全一致。
+
+同步创建和授权完成都构造同一种 `BotCreateSpec`，并调用同一个
+`_prepare_create()`。本次仍依赖 caller echo，不新增 pending intent persistence；
+缺失或非法输入返回明确错误并记录日志，由 caller 携带原请求重试。
+
+---
+
+## 9. 文件级改动计划
+
+| 文件 | 改动 |
+| --- | --- |
+| `adapters/http/openapi_v1/bots/schemas.py` | 新增 `BotCreateEngineProperties`；Create/Poll 增加 `engine_properties`；legacy `template` 标记 deprecated；增加互斥校验 |
+| `adapters/http/openapi_v1/bots/router.py` | 新字段转 plain dict；兼容旧 `template` DTO；不读取新字段内部业务内容 |
+| `core/bot_management/create_flow.py` | `BotCreateSpec.extra_properties` 改名；统一新旧来源路由；移除 application-coding 专属校验实现，保留通用编排和 capability check |
+| `core/bot_management/engines/provisioning.py` | 增加 `PreparedBotCreate` 和 `prepare_create` contract |
+| `core/bot_management/engines/default.py` | 非空 unsupported properties 明确失败 |
+| `core/bot_management/engines/aicoding/strategy.py` | application-coding 唯一校验实现；保留 `claude_code` engine gate |
+| `docs/superpowers/specs/2026-08-12-bot-workshop-openapi-inventory.md`（如端点清单涉及创建契约） | 更新真实存在的端点清单；仓库当前没有 `docs/openapi-v1/` |
+| `src/gateway/configs/schemas/bots.openapi.json` | 同步 Avernet 侧公开 JSON schema |
+| `src/gateway/tests/fixtures/bots.openapi.json` | 若该 fixture 继续镜像公开 schema，则与配置 schema 同步更新 |
+| `~/IdeaProjects/ocb/src/gateway/configs/schemas/bots.openapi.json` | 按双仓约束同步 OCB 侧同一公开 JSON schema；两侧内容必须一致 |
+| 相关 OpenAPI/Core/Strategy tests | 覆盖新字段、legacy、互斥、engine gate 和副作用顺序 |
+
+Context Boundary metadata 仅在 provides/requires 实际变化时更新，不为字段重命名制造
+无意义边界变更。
+
+---
+
+## 10. 测试与验收
+
+### 10.1 公共契约
+
+- 新 `engine_properties.template` 非空对象请求通过 schema；
+- 新 HTTP 请求中的 `template: null`、空对象和未知键明确失败；
+- legacy `template` 在兼容窗口继续通过并标记 deprecated；
+- 两者同时出现明确失败；
+- Create 与 auth-completion echo schema 一致；
+- OpenAPI 文档和 gateway schema 同步。
+
+### 10.2 Strategy/Core
+
+- `claude_code + engine_properties.template` 合法输入通过；
+- `aicoding + engine_properties.template` 保持拒绝；
+- openclaw/teclaw 等 default 引擎收到含 `template` 的 properties 时保持
+  `BotCombinationUnsupportedError`（历史 409 映射），不变成 422；
+- default engine 收到其他非空 properties 键明确失败；
+- cloud/personal/personal-space、reserved 字段和类型校验保持现有行为；
+- legacy application-coding 与新输入命中同一 Strategy；
+- legacy application-coding 省略 config 时仍保留 `template_type="applicationCoding"`、`template_config=None` 和 `requires_workspace_hosting=True`；
+- legacy 非 application-coding template 的 `template_type` 和 `template_config` 都不被清空；
+- Core 直接收到未知 `engine_properties` 键时明确失败；
+- workspace hosting 校验在 Passport 前；
+- 同步和授权完成路径使用同一 preflight。
+
+### 10.3 回归与架构
+
+至少运行：
+
+```bash
+cd src/backend
+uv run pytest <affected bot create tests>
+uv run pytest tests/community/architecture
+
+cd ../..
+scripts/ci/python_sast_local.sh src/backend
+```
+
+PR Validation 必须记录实际执行结果；无法执行的 gate 需说明原因。
+
+---
+
+## 11. 风险与回滚
+
+### R1. 公共字段迁移影响已有 caller
+
+控制：已决定采用 deprecated 兼容窗口；删除旧字段单独提 breaking-change PR。
+回滚：保留 legacy schema 和 Router 映射即可，不影响 Core Strategy。Avernet 与 OCB 的 gateway schema 必须同步修改或同步回滚。
+
+### R2. 新结构没有 template discriminator
+
+控制：明确限定当前一个模板语义；出现第二种真实类型时再版本化扩展。
+
+### R3. 共享 Strategy 类意外放宽 aicoding engine
+
+控制：`prepare_create()` 显式检查 `self.engine_type == "claude_code"`，增加回归测试。
+
+### R4. 新旧来源覆盖顺序不明确
+
+控制：Schema 和 Core 双层互斥校验，不提供覆盖或 merge 规则。
+
+### R5. legacy 校验出现双份实现
+
+控制：legacy application-coding 先标准化，再进入同一 Strategy；通用 create flow 不再
+保存 application-coding 专属规则。
+
+---
+
+## 12. 已确认决策
+
+本轮评审已确认：
+
+1. 接受 D2 的 deprecated 兼容窗口。本次不直接删除已发布的 `template` 字段；
+2. 接受 D3 的无 discriminator 结构，出现同一 engine 的第二种真实模板类型时再进行
+   版本化扩展。
+
+实现约束如下：
+
+- 新旧来源互斥；
+- legacy application-coding 省略 config 的既有契约保持不变；
+- legacy application-coding 和新输入都由同一 Strategy 执行组合门禁和配置校验；
+- application-coding 仍只允许 `claude_code`；
+- Strategy 在 Core 层拒绝未知 `engine_properties` 键；
+- legacy 非 application-coding 路径必须保留 `template_type`；
+- `schemas.py`、Poll echo、Avernet/OCB 两侧 gateway schema 和契约测试均属于本次
+  改动范围。

--- a/src/backend/specs/2026-08-24-engine-properties-polymorphic-create/design.md
+++ b/src/backend/specs/2026-08-24-engine-properties-polymorphic-create/design.md
@@ -35,6 +35,37 @@
 
 其余各节描述的目标架构（Strategy 契约、三路路由、测试计划）按原文落地。
 
+### 0.1 评审修复（2026-08-25，合并前）
+
+PR 评审以 origin/dev 为基线逐项对比存量行为，发现四处偏差；实现按下述修正，
+与 §6.1/§6.2/§7 代码示意冲突之处以本节为准：
+
+1. **`prepare_create` 契约增加 `engine_type` 参数**（镜像被删除的 `prepare_bot_create`
+   的同名参数）。策略实例的 `engine_type` 是注册键，但共享的 Default 回退实例
+   服务于所有未注册引擎（如 `SUPPORTED_ENGINE_TYPES` 中的 `moltis`、内部
+   `/api/bots` 的任意字符串）：报错必须取请求的 `engine_type` 才能复现历史消息
+   （`application coding does not support engine: moltis`，而非 `... : default`）。
+2. **Default Strategy 恢复历史门禁顺序**：含 `template` 键的输入先做 cloud-only
+   检查、再报引擎错误——与被删除的 `prepare_bot_create` 一致（local +
+   applicationCoding 历史上报 "application coding is cloud-only"）。§6.1 的示意
+   缺少这一顺序。
+3. **模板值仅按 falsy 拒绝，去掉 `isinstance(template, dict)` 收紧**：内部
+   `/api/bots` 无类型透传 `template_config`，truthy 非 dict 值（str/list）在
+   dev 的校验链中经鸭子类型语义被放行并存原值；策略保持该契约（§6.2 示意中的
+   isinstance 分支已删除）。falsy 非 dict（如 `0`）从历史上的未处理
+   `TypeError` 变为干净的 `BotTemplateInvalidError`，属可接受的体验修正。
+4. **`_prepare_create` 返回的 spec 清空 `engine_properties`**（§7 示意补上
+   `engine_properties={}`）：策略翻译后的 spec 只携带 template_type/
+   template_config；保留非空 bag 会使返回值违反入口的 mixed-source 不变量，
+   阻塞将来 §8.3 deferred 的 pending-intent 重放（重放会喂回已 prepare 的 spec）。
+5. 门禁与 `bot_inventory/policies/combo_policy.py` 的
+   `assert_application_coding_create`（生产无人调用）互为镜像；两侧已加交叉引用
+   注释。bot_management 目前零依赖 bot_inventory，引入跨域 import 需先过
+   module boundary 测试与 Context Boundary 声明，留待单独决策。
+
+随附修整：Context Boundary `provides` 移除已删除的 `prepare_bot_create`；
+`schemas.py` 中引用 `BotCreateSpec.extra_properties` 的过期注释更新为现状。
+
 ---
 
 ## 1. 仓库现状（事实基线）

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -343,6 +343,20 @@ def _sync_passport_identity(
         raise PassportError(f"Passport metadata update failed: {exc}") from exc
 
 
+def _engine_properties_from_body(
+    body: BotCreate | BotAuthStatusPoll,
+) -> dict[str, Any]:
+    """Plain-dict engine_properties for the Core spec.
+
+    The only conversion this adapter performs on engine-owned creation input:
+    Pydantic models stay in the HTTP layer, and the bag's contents remain
+    opaque here — the engine-selected Core strategy interprets them.
+    """
+    if body.engine_properties is None:
+        return {}
+    return body.engine_properties.model_dump(exclude_none=True)
+
+
 @router.post(
     "",
     status_code=201,
@@ -394,12 +408,14 @@ async def create_bot(
 
     On a 202, have the user complete authorization at one of the returned
     URLs, then poll the auth-status endpoint — the bot is only created there,
-    on ISSUED. Template-specific creation properties belong under "template";
+    on ISSUED. Engine-specific creation properties belong under
+    "engine_properties" and are interpreted by the selected engine;
     engine configuration is managed through the engine-config endpoints after
     creation.
     """
-    # Template-specific public input is unpacked by this HTTP adapter below;
-    # core creation keeps its established template_type/template_config contract.
+    # Engine-owned creation input is passed through opaquely below; the
+    # engine-selected Core strategy owns its semantics and validation, so this
+    # adapter stays free of engine-specific business knowledge.
     # Validate the engine against the configured registry FIRST: the cluster rule
     # below treats every non-teclaw value as ACRA, so an unknown engine would
     # otherwise sail through, allocate an id, apply for a Passport, and only fail
@@ -413,11 +429,6 @@ async def create_bot(
         owner_id=owner_id,
         header_space_id=body.space_id,
     )
-    template_properties = (
-        body.engine_properties.template
-        if body.engine_properties is not None
-        else None
-    )
     bot_id = generate_bot_id(owner_id, bot_repo)
     outcome = create_bot_with_authorization(
         user_id=owner_id,
@@ -430,11 +441,8 @@ async def create_bot(
             bot_name=body.bot_name,
             bot_desc=body.bot_desc,
             space_id=current_space.numeric_id,
-            template_type=(
-                "applicationCoding" if template_properties is not None else None
-            ),
-            template_config=template_properties,
             template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
+            engine_properties=_engine_properties_from_body(body),
         ),
         context=BotCreateContext(
             deployment_mode=BotCreateDeploymentMode.CLOUD,
@@ -987,8 +995,7 @@ def _complete_auth_status(
     bot_desc: str | None,
     bot_type: BotType | None,
     space_id: str | None,
-    template_type: str | None = None,
-    template_config: dict[str, Any] | None = None,
+    engine_properties: dict[str, Any] | None = None,
     bot_service: BotServiceProtocol,
     passport_plugin: PassportPlugin,
     auth_rel_plugin: AuthRelationshipPlugin,
@@ -1035,9 +1042,8 @@ def _complete_auth_status(
                 bot_name=bot_name,
                 bot_desc=bot_desc,
                 space_id=current_space.numeric_id,
-                template_type=template_type,
-                template_config=template_config,
                 template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
+                engine_properties=engine_properties or {},
             ),
             context=BotCreateContext(
                 deployment_mode=BotCreateDeploymentMode.CLOUD,
@@ -1124,14 +1130,7 @@ async def poll_bot_auth_status(
         bot_desc=body.bot_desc,
         bot_type=body.bot_type,
         space_id=body.space_id,
-        template_type=(
-            "applicationCoding" if body.engine_properties is not None else None
-        ),
-        template_config=(
-            body.engine_properties.template
-            if body.engine_properties is not None
-            else None
-        ),
+        engine_properties=_engine_properties_from_body(body),
         bot_service=bot_service,
         passport_plugin=passport_plugin,
         auth_rel_plugin=auth_rel_plugin,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -198,13 +198,15 @@ class BotCreate(BaseModel):
             "template for an application-coding bot."
         ),
     )
-    # ``engine_options`` is deliberately absent. Nothing downstream consumes
-    # ``BotCreateSpec.extra_properties`` yet, so declaring the field would
-    # publish a contract slot the server rejects on every non-empty value —
+    # ``engine_options`` is deliberately absent. The engine-owned bag the
+    # server actually consumes is ``engine_properties`` above (routed to the
+    # engine-selected ``EngineProvisioningStrategy.prepare_create``); an
+    # additional options slot would publish a contract nothing reads, so
+    # every non-empty value would be a request the server always rejects —
     # generated clients would compile a request that always fails. It returns
-    # here, unchanged in shape, once ``create_bot`` reads the bag; until then
-    # ``extra="forbid"`` names it in the error rather than the schema promising
-    # something untrue.
+    # here, unchanged in shape, once ``create_bot`` reads such a bag; until
+    # then ``extra="forbid"`` names it in the error rather than the schema
+    # promising something untrue.
 
 
 class BotSpaceUpdate(BaseModel):

--- a/src/backend/src/agentclaw/community/core/bot_inventory/policies/combo_policy.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/policies/combo_policy.py
@@ -56,6 +56,13 @@ def assert_application_coding_create(
     the calling endpoint, so the rule is self-contained and unit-testable.
     ``claude_code`` is the only external engine value: the runtime routing to the
     ``aicoding`` adapter is an internal concern, not an alternative engine.
+
+    The production implementation of this gate is
+    ``bot_management/engines/aicoding/strategy.py``
+    ``AicodingProvisioningStrategy.prepare_create`` (same order, same
+    messages). This copy has no production caller today — keep the two in
+    sync, or single-source them once bot_inventory may depend on
+    bot_management.
     """
     if deployment_mode is not DeployMode.CLOUD:
         return ComboDecision(False, "application coding is cloud-only")

--- a/src/backend/src/agentclaw/community/core/bot_management/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_management/README.md
@@ -11,7 +11,6 @@ provides:
   - "BotCreateContext"
   - "BotCreateDeploymentMode"
   - "PreparedBotCreate"
-  - "prepare_bot_create"
   - "BotRepository protocol + impl"
   - "EngineResolver"
   - "DataInitService"

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -19,14 +19,20 @@ ownership of id allocation.
 
 from __future__ import annotations
 
-from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
+from agentclaw.community.core.bot_management.engines.provisioning import (
+    BotCreateTemplateValidationMode,
+    PreparedBotCreate,
+    to_internal_template_config,
+)
+from agentclaw.community.core.bot_management.engines.registry import (
+    get_engine_provisioning_registry,
+)
 from agentclaw.community.core.bot_management.errors import (
     ApplicationCodingUnavailableError,
-    BotCombinationUnsupportedError,
     BotTemplateInvalidError,
 )
 from agentclaw.community.core.bot_management.services.bot_service import (
@@ -54,33 +60,11 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 
-APPLICATION_CODING_ENGINES = frozenset({"claude_code"})
-
-# Public template input must not set platform-owned identity or lifecycle data.
-_TEMPLATE_SERVER_RESERVED_FIELDS = frozenset(
-    {
-        "workspace_id",
-        "template_uid",
-        "bot_id",
-        "workspace_status",
-        "workspace_state",
-        "start_status",
-    }
-)
-
-
 class BotCreateDeploymentMode(StrEnum):
     """Deployment boundary relevant to Bot creation policy."""
 
     CLOUD = "cloud"
     LOCAL = "local"
-
-
-class BotCreateTemplateValidationMode(StrEnum):
-    """Template validation contract selected by the caller's API surface."""
-
-    LEGACY = "legacy"
-    PUBLIC = "public"
 
 
 @dataclass(frozen=True)
@@ -91,123 +75,57 @@ class BotCreateContext:
     space_kind: str
 
 
-@dataclass(frozen=True)
-class PreparedBotCreate:
-    """Sanitized creation attributes plus required platform capabilities."""
+def _reject_mixed_create_sources(spec: BotCreateSpec) -> None:
+    """Reject requests combining the new and the legacy template inputs.
 
-    template_config: dict[str, Any] | None
-    requires_workspace_hosting: bool = False
-
-
-def to_internal_template_config(
-    value: dict[str, Any] | None,
-    *,
-    reject_server_managed_fields: bool = True,
-) -> dict[str, Any] | None:
-    """Validate public ownership rules and detach caller-owned input.
-
-    The default keeps this helper's public-input behavior. Legacy internal
-    callers use the explicit opt-out because their template config is an
-    established internal snapshot that may contain platform-managed fields.
+    A Core-level invariant, not only a schema rule: two sources would leave the
+    override order ambiguous, so internal callers cannot bypass the check.
     """
-    if value is None:
-        return None
-    if reject_server_managed_fields:
-        reserved = sorted(_TEMPLATE_SERVER_RESERVED_FIELDS.intersection(value))
-        if reserved:
-            raise BotTemplateInvalidError(
-                f"template_config contains server-managed fields: {reserved}"
-            )
-    return deepcopy(value)
-
-
-def _validate_application_coding_config(
-    value: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    """Validate the stable outer contract while preserving extensions."""
-    # Legacy internal callers may intentionally omit the config. When a config
-    # is supplied, reject malformed input before external or persistence effects.
-    if value is None:
-        return None
-    if not value:
-        raise BotTemplateInvalidError(
-            "applicationCoding template_config must not be empty"
-        )
-    expected_types: dict[str, type | tuple[type, ...]] = {
-        "devflow_workflow": (str, dict),
-        "yuque_kb_repos": list,
-        "code_repos": list,
-        "bot_template_config": dict,
-        "token": str,
-    }
-    for key, expected in expected_types.items():
-        if key not in value:
-            continue
-        field_value = value[key]
-        if not isinstance(field_value, expected):
-            raise BotTemplateInvalidError(
-                f"applicationCoding template_config.{key} has invalid type"
-            )
-        if key == "token" and not field_value.strip():
-            raise BotTemplateInvalidError(
-                "applicationCoding template_config.token cannot be empty"
-            )
-    return value
-
-
-def prepare_bot_create(
-    *,
-    template_type: str | None,
-    template_config: dict[str, Any] | None,
-    bot_type: str,
-    engine_type: str,
-    context: BotCreateContext,
-    template_validation_mode: BotCreateTemplateValidationMode = (
-        BotCreateTemplateValidationMode.LEGACY
-    ),
-) -> PreparedBotCreate:
-    """Validate template-related creation inputs without transport dependencies."""
-    if template_type is None:
-        if template_config is not None:
-            raise BotTemplateInvalidError("template_config requires template_type")
-        return PreparedBotCreate(template_config=None)
-
-    # Other template types are established internal inputs. Their owning
-    # adapters/services retain their field semantics.
-    if template_type != "applicationCoding":
-        return PreparedBotCreate(
-            template_config=to_internal_template_config(
-                template_config,
-                reject_server_managed_fields=(
-                    template_validation_mode is BotCreateTemplateValidationMode.PUBLIC
-                ),
-            )
-        )
-
-    if context.deployment_mode is not BotCreateDeploymentMode.CLOUD:
-        raise BotCombinationUnsupportedError("application coding is cloud-only")
-    if engine_type not in APPLICATION_CODING_ENGINES:
-        raise BotCombinationUnsupportedError(
-            f"application coding does not support engine: {engine_type}"
-        )
-    if bot_type != "personal":
-        raise BotCombinationUnsupportedError(
-            "application coding bot must be personal"
-        )
-    if context.space_kind != "personal":
-        raise BotCombinationUnsupportedError(
-            "application coding is personal-space only"
-        )
-
-    sanitized = to_internal_template_config(
-        template_config,
-        reject_server_managed_fields=(
-            template_validation_mode is BotCreateTemplateValidationMode.PUBLIC
-        ),
+    has_legacy_template = (
+        spec.template_type is not None or spec.template_config is not None
     )
+    if spec.engine_properties and has_legacy_template:
+        raise BotTemplateInvalidError(
+            "engine_properties cannot be combined with legacy template fields"
+        )
+
+
+def _prepare_with_engine_strategy(
+    spec: BotCreateSpec, context: BotCreateContext
+) -> PreparedBotCreate:
+    """Run the engine-selected strategy's create prevalidation."""
+    strategy = get_engine_provisioning_registry().resolve(spec.engine_type)
+    return strategy.prepare_create(
+        engine_properties=spec.engine_properties,
+        bot_type=spec.bot_type,
+        deployment_mode=context.deployment_mode,
+        space_kind=context.space_kind,
+        template_validation_mode=spec.template_validation_mode,
+    )
+
+
+def _prepare_legacy_non_application_template(
+    spec: BotCreateSpec,
+) -> PreparedBotCreate:
+    """Sanitize established internal template inputs, keeping their type.
+
+    Server-managed-field rejection honors the caller's validation mode: public
+    inputs get the strict ownership rules, legacy internal snapshots may carry
+    platform-managed fields.
+    """
+    if spec.template_type is None:
+        if spec.template_config is not None:
+            raise BotTemplateInvalidError("template_config requires template_type")
+        return PreparedBotCreate()
     return PreparedBotCreate(
-        template_config=_validate_application_coding_config(sanitized),
-        requires_workspace_hosting=True,
+        template_type=spec.template_type,
+        template_config=to_internal_template_config(
+            spec.template_config,
+            reject_server_managed_fields=(
+                spec.template_validation_mode
+                is BotCreateTemplateValidationMode.PUBLIC
+            ),
+        ),
     )
 
 
@@ -312,15 +230,18 @@ class BotCreateSpec:
     share_policy: dict[str, Any] | None = None
     template_type: str | None = None
     template_config: dict[str, Any] | None = None
+    # How strictly template ownership rules apply: PUBLIC for OpenAPI inputs,
+    # LEGACY for established internal snapshots (may carry ``template_uid``).
     template_validation_mode: BotCreateTemplateValidationMode = (
         BotCreateTemplateValidationMode.LEGACY
     )
     space_id: int | None = None
-    # Engine/vendor-specific inputs belong here, NOT as new named fields. The
-    # spec is the contract shared by every surface, so it stays engine-agnostic
-    # rather than growing an attribute per engine; anything meaningful to only
-    # one engine goes in this bag.
-    extra_properties: dict[str, Any] = field(default_factory=dict)
+    # Engine-owned creation properties (the public ``engine_properties``
+    # contract), kept opaque here: only the engine-selected
+    # ``EngineProvisioningStrategy`` may interpret its keys. The legacy
+    # template_type/template_config pair above serves established internal
+    # callers and is mutually exclusive with this bag.
+    engine_properties: dict[str, Any] = field(default_factory=dict)
 
 
 def _prepare_create(
@@ -330,20 +251,33 @@ def _prepare_create(
     bot_service: BotService,
 ) -> BotCreateSpec:
     """Apply shared creation policy before any external or persistence effects."""
-    prepared = prepare_bot_create(
-        template_type=spec.template_type,
-        template_config=spec.template_config,
-        bot_type=spec.bot_type,
-        engine_type=spec.engine_type,
-        context=context,
-        template_validation_mode=spec.template_validation_mode,
-    )
+    _reject_mixed_create_sources(spec)
+
+    if spec.engine_properties:
+        prepared = _prepare_with_engine_strategy(spec, context)
+    elif spec.template_type == "applicationCoding":
+        # Core-only compatibility representation: the "template" key's presence
+        # preserves the legacy intent even when the caller intentionally
+        # omitted the config, so both input shapes share the Strategy's gate.
+        prepared = _prepare_with_engine_strategy(
+            replace(spec, engine_properties={"template": spec.template_config}),
+            context,
+        )
+    else:
+        # Plain bots and other established template types keep the generic path;
+        # the returned value must carry template_type through unchanged.
+        prepared = _prepare_legacy_non_application_template(spec)
+
     if (
         prepared.requires_workspace_hosting
         and not bot_service.is_workspace_hosting_available()
     ):
         raise ApplicationCodingUnavailableError()
-    return replace(spec, template_config=prepared.template_config)
+    return replace(
+        spec,
+        template_type=prepared.template_type,
+        template_config=prepared.template_config,
+    )
 
 
 def _get_bot_mcp_codes(

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -96,6 +96,7 @@ def _prepare_with_engine_strategy(
     """Run the engine-selected strategy's create prevalidation."""
     strategy = get_engine_provisioning_registry().resolve(spec.engine_type)
     return strategy.prepare_create(
+        engine_type=spec.engine_type,
         engine_properties=spec.engine_properties,
         bot_type=spec.bot_type,
         deployment_mode=context.deployment_mode,
@@ -273,10 +274,16 @@ def _prepare_create(
         and not bot_service.is_workspace_hosting_available()
     ):
         raise ApplicationCodingUnavailableError()
+    # The translated form carries only the Core-internal template fields: the
+    # bag has been consumed by the strategy, and leaving it set would make the
+    # returned spec violate the mixed-source invariant enforced at entry —
+    # a retry or future pending-intent replay that re-feeds the prepared
+    # spec would be rejected as a mixed source.
     return replace(
         spec,
         template_type=prepared.template_type,
         template_config=prepared.template_config,
+        engine_properties={},
     )
 
 

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -14,6 +14,10 @@ from typing import Any, Dict
 from agentclaw.community.core.bot_management.capabilities import (
     is_template_factory_config,
 )
+from agentclaw.community.core.bot_management.errors import (
+    BotCombinationUnsupportedError,
+    BotTemplateInvalidError,
+)
 from agentclaw.community.core.workspace.runtime_identity import (
     claude_code_uses_aicoding_runtime,
 )
@@ -22,7 +26,13 @@ from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.utils import secret_utils
 from agentclaw.community.log import get_logger
 
-from ..provisioning import BotProvisioningContext, EngineProvisioningStrategy
+from ..provisioning import (
+    BotCreateTemplateValidationMode,
+    BotProvisioningContext,
+    EngineProvisioningStrategy,
+    PreparedBotCreate,
+    to_internal_template_config,
+)
 
 
 # Legacy coding template types.  This is only used for old call sites that
@@ -44,6 +54,42 @@ _THETA_KEY_PATH = ("bot_template_config", "ext_config", "thetaKey")
 _ENCRYPTED_VALUE_PREFIX = "enc:v1:"
 
 logger = get_logger()
+
+
+def _validate_application_coding_config(
+    value: Dict[str, Any] | None,
+) -> Dict[str, Any] | None:
+    """Validate the stable outer contract while preserving extensions.
+
+    Input must already be detached by ``to_internal_template_config``. An empty
+    config is rejected; unknown keys survive as engine-owned extensions.
+    """
+    if value is None:
+        return None
+    if not value:
+        raise BotTemplateInvalidError(
+            "applicationCoding template_config must not be empty"
+        )
+    expected_types: dict[str, type | tuple[type, ...]] = {
+        "devflow_workflow": (str, dict),
+        "yuque_kb_repos": list,
+        "code_repos": list,
+        "bot_template_config": dict,
+        "token": str,
+    }
+    for key, expected in expected_types.items():
+        if key not in value:
+            continue
+        field_value = value[key]
+        if not isinstance(field_value, expected):
+            raise BotTemplateInvalidError(
+                f"applicationCoding template_config.{key} has invalid type"
+            )
+        if key == "token" and not field_value.strip():
+            raise BotTemplateInvalidError(
+                "applicationCoding template_config.token cannot be empty"
+            )
+    return value
 
 
 class AicodingBaasEngineBucketResolver:
@@ -81,6 +127,83 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
     @property
     def engine_type(self) -> str:
         return self._engine_type
+
+    def prepare_create(
+        self,
+        *,
+        engine_properties: Dict[str, Any],
+        bot_type: str,
+        deployment_mode: str,
+        space_kind: str,
+        template_validation_mode: BotCreateTemplateValidationMode = (
+            BotCreateTemplateValidationMode.LEGACY
+        ),
+    ) -> PreparedBotCreate:
+        """Parse and validate application-coding create input (single owner).
+
+        The one implementation behind both input shapes: the public
+        ``engine_properties.template`` contract and the legacy
+        ``template_type="applicationCoding"`` normalized by the create flow.
+        Combination gates keep their historical order, error types and messages
+        so the HTTP mappings answer identically; server-managed-field rejection
+        follows the caller's validation mode.
+        """
+        if not engine_properties:
+            return PreparedBotCreate()
+
+        # Envelope integrity for keys this engine owns. The public schema's
+        # ``extra="forbid"`` cannot guard direct Core-level spec construction,
+        # so unknown keys fail here instead of being silently ignored.
+        unknown_keys = set(engine_properties) - {"template"}
+        if unknown_keys:
+            raise BotTemplateInvalidError(
+                f"unsupported engine_properties fields: {sorted(unknown_keys)}"
+            )
+        if "template" not in engine_properties:
+            raise BotTemplateInvalidError("engine_properties.template is required")
+
+        # Historical combination gates, in their historical order.
+        if deployment_mode != "cloud":
+            raise BotCombinationUnsupportedError("application coding is cloud-only")
+        if self.engine_type != CLAUDE_CODE_ENGINE_TYPE:
+            raise BotCombinationUnsupportedError(
+                f"application coding does not support engine: {self.engine_type}"
+            )
+        if bot_type != "personal":
+            raise BotCombinationUnsupportedError(
+                "application coding bot must be personal"
+            )
+        if space_kind != "personal":
+            raise BotCombinationUnsupportedError(
+                "application coding is personal-space only"
+            )
+
+        template = engine_properties["template"]
+        if template is None:
+            # Core-only legacy compatibility shape: the key's presence is the
+            # application-coding intent, ``None`` the intentionally-omitted
+            # config. The public schema requires a non-empty dict, so callers
+            # cannot express this through HTTP.
+            return PreparedBotCreate(
+                template_type="applicationCoding",
+                template_config=None,
+                requires_workspace_hosting=True,
+            )
+        if not isinstance(template, dict) or not template:
+            raise BotTemplateInvalidError(
+                "applicationCoding template_config must not be empty"
+            )
+        sanitized = to_internal_template_config(
+            template,
+            reject_server_managed_fields=(
+                template_validation_mode is BotCreateTemplateValidationMode.PUBLIC
+            ),
+        )
+        return PreparedBotCreate(
+            template_type="applicationCoding",
+            template_config=_validate_application_coding_config(sanitized),
+            requires_workspace_hosting=True,
+        )
 
     def resolve_bot_engine(self, bot: dict[str, Any]) -> str | None:
         active_engine = bot.get("active_engine")
@@ -476,18 +599,23 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         truthy — a plain restart must never silently rewrite the Passport
         authorization scope. Anything falsy (missing key, None, false) no-ops.
         """
-        if not (isinstance(extra_configs, dict) and extra_configs.get("confirmed_template_update")):
+        if not (
+            isinstance(extra_configs, dict)
+            and extra_configs.get("confirmed_template_update")
+        ):
             logger.info(
-                "[aicoding.restart] skip passport refresh: confirmed_template_update is not set "
-                "for bot_id=%s",
+                "[aicoding.restart] skip passport refresh: "
+                "confirmed_template_update is not set for bot_id=%s",
                 ctx.bot_id,
             )
             return
+        # Imported lazily: create_flow imports this module's registry, so a
+        # module-level import would cycle.
         from agentclaw.community.core.bot_management.create_flow import (
             _get_bot_mcp_codes,
         )
         from agentclaw.community.core.mcp.services._defaults import (
-            get_default_cli_items
+            get_default_cli_items,
         )
 
         stored_config: Dict[str, Any] = (

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -131,6 +131,7 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
     def prepare_create(
         self,
         *,
+        engine_type: str,
         engine_properties: Dict[str, Any],
         bot_type: str,
         deployment_mode: str,
@@ -162,12 +163,18 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         if "template" not in engine_properties:
             raise BotTemplateInvalidError("engine_properties.template is required")
 
-        # Historical combination gates, in their historical order.
+        # Historical combination gates, in their historical order. The gate set
+        # and messages are mirrored (production-dead) in
+        # ``bot_inventory/policies/combo_policy.py``
+        # ``assert_application_coding_create`` — keep the two in sync, or
+        # single-source them once bot_management may depend on bot_inventory.
         if deployment_mode != "cloud":
             raise BotCombinationUnsupportedError("application coding is cloud-only")
-        if self.engine_type != CLAUDE_CODE_ENGINE_TYPE:
+        if engine_type != CLAUDE_CODE_ENGINE_TYPE:
+            # The strategy class is registered for both engine types, but
+            # application-coding creation stays claude_code-only.
             raise BotCombinationUnsupportedError(
-                f"application coding does not support engine: {self.engine_type}"
+                f"application coding does not support engine: {engine_type}"
             )
         if bot_type != "personal":
             raise BotCombinationUnsupportedError(
@@ -189,7 +196,12 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                 template_config=None,
                 requires_workspace_hosting=True,
             )
-        if not isinstance(template, dict) or not template:
+        if not template:
+            # Byte-identical to the historical ladder: only genuinely empty
+            # payloads are rejected. Truthy non-dict values (legacy internal
+            # callers forwarding raw JSON ``template_config``) keep the
+            # historical pass-through — the expected-type checks and
+            # reserved-field scan below treat them exactly as before.
             raise BotTemplateInvalidError(
                 "applicationCoding template_config must not be empty"
             )

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
@@ -30,6 +30,7 @@ class DefaultProvisioningStrategy(EngineProvisioningStrategy):
     def prepare_create(
         self,
         *,
+        engine_type: str,
         engine_properties: dict[str, Any],
         bot_type: str,
         deployment_mode: str,
@@ -43,16 +44,28 @@ class DefaultProvisioningStrategy(EngineProvisioningStrategy):
         A ``template`` key means application-coding intent (new public contract
         or legacy normalization); the combination error keeps the historical
         409 mapping for the legacy shape instead of turning it into a 422.
+        Gates replicate the deleted ``prepare_bot_create`` ladder exactly:
+        error messages name the *requested* engine (the shared fallback
+        instance's own ``engine_type`` would say "default"), and the cloud-only
+        check still answers before the engine check.
         """
         if not engine_properties:
             return PreparedBotCreate()
         if "template" in engine_properties:
+            # Historical gate order: a local deployment reports "cloud-only"
+            # before the engine gate gets to answer.
+            if deployment_mode != "cloud":
+                raise BotCombinationUnsupportedError(
+                    "application coding is cloud-only"
+                )
+            # claude_code resolves to the Aicoding strategy, so any engine
+            # reaching this default-managed branch fails the engine gate.
             raise BotCombinationUnsupportedError(
-                f"application coding does not support engine: {self.engine_type}"
+                f"application coding does not support engine: {engine_type}"
             )
         raise BotTemplateInvalidError(
             "engine {} does not support engine_properties: {}".format(
-                self.engine_type, sorted(engine_properties)
+                engine_type, sorted(engine_properties)
             )
         )
 

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
@@ -1,9 +1,20 @@
 """Default no-op provisioning strategy."""
 from __future__ import annotations
 
+from typing import Any
+
+from agentclaw.community.core.bot_management.errors import (
+    BotCombinationUnsupportedError,
+    BotTemplateInvalidError,
+)
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 
-from .provisioning import BotProvisioningContext, EngineProvisioningStrategy
+from .provisioning import (
+    BotCreateTemplateValidationMode,
+    BotProvisioningContext,
+    EngineProvisioningStrategy,
+    PreparedBotCreate,
+)
 
 
 class DefaultProvisioningStrategy(EngineProvisioningStrategy):
@@ -15,6 +26,35 @@ class DefaultProvisioningStrategy(EngineProvisioningStrategy):
     @property
     def engine_type(self) -> str:
         return self._engine_type
+
+    def prepare_create(
+        self,
+        *,
+        engine_properties: dict[str, Any],
+        bot_type: str,
+        deployment_mode: str,
+        space_kind: str,
+        template_validation_mode: BotCreateTemplateValidationMode = (
+            BotCreateTemplateValidationMode.LEGACY
+        ),
+    ) -> PreparedBotCreate:
+        """Reject create-time engine properties this engine does not own.
+
+        A ``template`` key means application-coding intent (new public contract
+        or legacy normalization); the combination error keeps the historical
+        409 mapping for the legacy shape instead of turning it into a 422.
+        """
+        if not engine_properties:
+            return PreparedBotCreate()
+        if "template" in engine_properties:
+            raise BotCombinationUnsupportedError(
+                f"application coding does not support engine: {self.engine_type}"
+            )
+        raise BotTemplateInvalidError(
+            "engine {} does not support engine_properties: {}".format(
+                self.engine_type, sorted(engine_properties)
+            )
+        )
 
     def resolve_bot_engine(self, bot: dict[str, object]) -> str | None:
         engine = bot.get("active_engine")

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
@@ -3,14 +3,83 @@
 This module keeps bot/device/template services engine-agnostic.  Public
 services ask a strategy what should be provisioned; concrete engines own their
 special template/env/token rules in their own strategy modules.
+
+It also carries the create-time prevalidation contract shared by the create
+flow and the strategies: :class:`PreparedBotCreate` and the neutral template
+sanitation helpers.  Strategies must not import ``create_flow`` (that would
+cycle), so everything both sides need lives here.
 """
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any, Dict, Optional
 
+from agentclaw.community.core.bot_management.errors import BotTemplateInvalidError
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
+
+# Public template input must not set platform-owned identity or lifecycle data.
+TEMPLATE_SERVER_RESERVED_FIELDS = frozenset(
+    {
+        "workspace_id",
+        "template_uid",
+        "bot_id",
+        "workspace_status",
+        "workspace_state",
+        "start_status",
+    }
+)
+
+
+@dataclass(frozen=True)
+class PreparedBotCreate:
+    """Sanitized creation attributes plus required platform capabilities.
+
+    ``template_type`` / ``template_config`` are the Core-internal compatibility
+    contract consumed by ``BotService.create_bot``; strategies translate their
+    engine-owned properties into it.
+    """
+
+    template_type: Optional[str] = None
+    template_config: Optional[Dict[str, Any]] = None
+    requires_workspace_hosting: bool = False
+
+
+class BotCreateTemplateValidationMode(StrEnum):
+    """Template validation contract selected by the caller's API surface.
+
+    ``PUBLIC`` keeps the strict ownership rules of the OpenAPI contract;
+    ``LEGACY`` (the default for internal callers) accepts established internal
+    template snapshots that may contain platform-managed fields such as
+    ``template_uid``.
+    """
+
+    LEGACY = "legacy"
+    PUBLIC = "public"
+
+
+def to_internal_template_config(
+    value: Dict[str, Any] | None,
+    *,
+    reject_server_managed_fields: bool = True,
+) -> Dict[str, Any] | None:
+    """Validate public ownership rules and detach caller-owned input.
+
+    The default keeps this helper's public-input behavior. Legacy internal
+    callers use the explicit opt-out because their template config is an
+    established internal snapshot that may contain platform-managed fields.
+    """
+    if value is None:
+        return None
+    if reject_server_managed_fields:
+        reserved = sorted(TEMPLATE_SERVER_RESERVED_FIELDS.intersection(value))
+        if reserved:
+            raise BotTemplateInvalidError(
+                f"template_config contains server-managed fields: {reserved}"
+            )
+    return deepcopy(value)
 
 
 @dataclass(frozen=True)
@@ -57,6 +126,33 @@ class EngineProvisioningStrategy(ABC):
     @abstractmethod
     def engine_type(self) -> str:
         """Stable identifier this strategy is registered under."""
+
+    @abstractmethod
+    def prepare_create(
+        self,
+        *,
+        engine_properties: Dict[str, Any],
+        bot_type: str,
+        deployment_mode: str,
+        space_kind: str,
+        template_validation_mode: BotCreateTemplateValidationMode = (
+            BotCreateTemplateValidationMode.LEGACY
+        ),
+    ) -> PreparedBotCreate:
+        """Validate engine-owned create input before side effects.
+
+        ``engine_properties`` is the opaque bag routed by engine type; only this
+        strategy may interpret its keys. Called before Passport apply and any
+        persistence, so every violation must raise, never silently drop input.
+
+        ``{"template": None}`` is a Core-only legacy compatibility shape (the
+        public schema requires a non-empty object): the key's *presence* carries
+        the application-coding intent when a legacy caller omitted the config.
+
+        ``template_validation_mode`` carries the caller's surface: public
+        inputs get full ownership validation, legacy internal snapshots stay
+        accepted verbatim.
+        """
 
     @abstractmethod
     def resolve_bot_engine(self, bot: Dict[str, Any]) -> str | None:

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
@@ -131,6 +131,7 @@ class EngineProvisioningStrategy(ABC):
     def prepare_create(
         self,
         *,
+        engine_type: str,
         engine_properties: Dict[str, Any],
         bot_type: str,
         deployment_mode: str,
@@ -140,6 +141,11 @@ class EngineProvisioningStrategy(ABC):
         ),
     ) -> PreparedBotCreate:
         """Validate engine-owned create input before side effects.
+
+        ``engine_type`` is the engine the request asked for. It equals this
+        instance's registration key, except for the shared default fallback
+        instance, which serves *every* unregistered engine — so error messages
+        must name this parameter's value, never ``self.engine_type``.
 
         ``engine_properties`` is the opaque bag routed by engine type; only this
         strategy may interpret its keys. Called before Passport apply and any

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -678,6 +678,24 @@ def test_create_rejects_unknown_engine_properties_fields(client, svc):
     svc.create_bot.assert_not_called()
 
 
+def test_create_engine_properties_for_non_coding_engine_is_combination_error(
+    client, svc
+):
+    # openclaw + application-coding intent answers 409 (combination
+    # unsupported), not a template-invalid 422 — the mapping the routing
+    # through the default engine strategy preserves.
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine_properties": {"template": {"devflow_workflow": "x"}},
+        },
+    )
+    assert response.status_code == 409, response.json()
+    assert response.json()["code"] == 409000
+    svc.create_bot.assert_not_called()
+
+
 def test_create_bot_cluster_mismatch_400(client, svc):
     bad = {**_CREATE_BODY, "cluster_name": "ANDC"}  # openclaw must be ACRA
     with patch.object(bots_router, "generate_bot_id", return_value="default"):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_template_config_passthrough.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_template_config_passthrough.py
@@ -1,4 +1,4 @@
-"""Unit tests for the ``engine_properties.template`` passthrough contract.
+"""Unit tests for the ``template.properties`` passthrough contract.
 
 The public property bag is a thin passthrough into the owning template adapter's
 own structure (legacy flat applicationCoding vs nested template factory) — there
@@ -13,7 +13,7 @@ import pytest
 from agentclaw.community.core.bot_management.errors import (
     BotTemplateInvalidError,
 )
-from agentclaw.community.core.bot_management.create_flow import (
+from agentclaw.community.core.bot_management.engines.provisioning import (
     to_internal_template_config,
 )
 
@@ -26,6 +26,17 @@ def test_empty_dict_is_a_valid_passthrough() -> None:
     # An empty object is a legitimate (if minimal) template payload, and must
     # survive as {} rather than being collapsed to None by a truthiness check.
     assert to_internal_template_config({}) == {}
+
+
+def test_legacy_mode_keeps_server_managed_fields() -> None:
+    # Internal snapshots may carry platform-managed fields (#1442): the
+    # explicit opt-in accepts them while still detaching the input.
+    payload = {"template_uid": "legacy-template", "devflow_workflow": "x"}
+    result = to_internal_template_config(
+        payload, reject_server_managed_fields=False
+    )
+    assert result == payload
+    assert result is not payload
 
 
 def test_payload_passes_through_unchanged_flat() -> None:

--- a/src/backend/tests/community/core/bot_management/test_application_coding_create.py
+++ b/src/backend/tests/community/core/bot_management/test_application_coding_create.py
@@ -1,4 +1,12 @@
-"""Application Coding creation policy and failure-path coverage."""
+"""Application Coding creation policy and failure-path coverage.
+
+The policy's single implementation is
+``AicodingProvisioningStrategy.prepare_create``. ``create_flow._prepare_create``
+routes both input shapes into it — the public ``engine_properties`` bag and the
+legacy ``template_type="applicationCoding"`` pair normalized to
+``{"template": config}`` — so the tests below cover the strategy directly plus
+the flow's routing on top.
+"""
 
 from __future__ import annotations
 
@@ -7,20 +15,27 @@ from unittest.mock import MagicMock
 import pytest
 
 from agentclaw.community.api.bot_service import BotServiceProtocol
+from agentclaw.community.core.bot_management.create_flow import (
+    BotCreateContext,
+    BotCreateDeploymentMode,
+    BotCreateSpec,
+    _prepare_create,
+    complete_bot_authorization,
+    create_bot_with_authorization,
+)
+from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
+    AicodingProvisioningStrategy,
+)
+from agentclaw.community.core.bot_management.engines.default import (
+    DefaultProvisioningStrategy,
+)
+from agentclaw.community.core.bot_management.engines.provisioning import (
+    BotCreateTemplateValidationMode,
+)
 from agentclaw.community.core.bot_management.errors import (
     ApplicationCodingUnavailableError,
     BotCombinationUnsupportedError,
     BotTemplateInvalidError,
-)
-from agentclaw.community.core.bot_management.create_flow import (
-    APPLICATION_CODING_ENGINES,
-    BotCreateContext,
-    BotCreateDeploymentMode,
-    BotCreateSpec,
-    BotCreateTemplateValidationMode,
-    complete_bot_authorization,
-    create_bot_with_authorization,
-    prepare_bot_create,
 )
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotService,
@@ -35,16 +50,33 @@ _CLOUD_PERSONAL = BotCreateContext(
 )
 
 
-def _prepare(**overrides):
-    params = dict(
-        template_type=None,
-        template_config=None,
-        bot_type="personal",
-        engine_type="claude_code",
-        context=_CLOUD_PERSONAL,
+def _strategy_prepare(
+    engine_type: str = "claude_code",
+    engine_properties: dict | None = None,
+    bot_type: str = "personal",
+    deployment_mode: str = "cloud",
+    space_kind: str = "personal",
+    template_validation_mode: BotCreateTemplateValidationMode = (
+        BotCreateTemplateValidationMode.LEGACY
+    ),
+):
+    return AicodingProvisioningStrategy(engine_type).prepare_create(
+        engine_properties=engine_properties or {},
+        bot_type=bot_type,
+        deployment_mode=deployment_mode,
+        space_kind=space_kind,
+        template_validation_mode=template_validation_mode,
     )
-    params.update(overrides)
-    return prepare_bot_create(**params)
+
+
+def _prepare_spec(
+    spec: BotCreateSpec,
+    context: BotCreateContext = _CLOUD_PERSONAL,
+    hosting_available: bool = True,
+) -> BotCreateSpec:
+    bot_service = MagicMock(spec=BotServiceProtocol)
+    bot_service.is_workspace_hosting_available.return_value = hosting_available
+    return _prepare_create(spec=spec, context=context, bot_service=bot_service)
 
 
 def _application_coding_spec(**overrides) -> BotCreateSpec:
@@ -60,128 +92,200 @@ def _application_coding_spec(**overrides) -> BotCreateSpec:
     return BotCreateSpec(**params)
 
 
-def test_application_coding_engine_matrix() -> None:
-    assert APPLICATION_CODING_ENGINES == frozenset({"claude_code"})
+# ── engine gate ────────────────────────────────────────────────────────────
+
+
+def test_application_coding_engine_gate_reads_the_strategy_instance() -> None:
+    # The aicoding strategy class is registered for both engine types, but
+    # application-coding creation stays claude_code-only.
+    prepared = _strategy_prepare(
+        "claude_code", {"template": {"devflow_workflow": "x"}}
+    )
+    assert prepared.template_type == "applicationCoding"
+    with pytest.raises(BotCombinationUnsupportedError):
+        _strategy_prepare("aicoding", {"template": {"devflow_workflow": "x"}})
+
+
+def test_default_engine_rejects_application_coding_as_combination_error() -> None:
+    # openclaw/teclaw/hermes + applicationCoding historically answered 409
+    # (BotCombinationUnsupportedError); routing by engine must keep that
+    # mapping instead of turning it into a template-invalid 422.
+    with pytest.raises(BotCombinationUnsupportedError):
+        DefaultProvisioningStrategy("openclaw").prepare_create(
+            engine_properties={"template": {"devflow_workflow": "x"}},
+            bot_type="personal",
+            deployment_mode="cloud",
+            space_kind="personal",
+        )
+
+
+def test_default_engine_rejects_other_engine_properties_keys() -> None:
+    with pytest.raises(BotTemplateInvalidError):
+        DefaultProvisioningStrategy("openclaw").prepare_create(
+            engine_properties={"surprise": 1},
+            bot_type="personal",
+            deployment_mode="cloud",
+            space_kind="personal",
+        )
+
+
+def test_unknown_engine_properties_keys_are_rejected_by_the_strategy() -> None:
+    # Core-level invariant: the HTTP schema's extra="forbid" cannot guard
+    # direct spec construction by internal callers.
+    with pytest.raises(BotTemplateInvalidError, match="unsupported"):
+        _strategy_prepare("claude_code", {"template": {"a": 1}, "other": 2})
+
+
+# ── strategy policy ────────────────────────────────────────────────────────
 
 
 def test_prepare_plain_bot_has_no_hosting_requirement() -> None:
-    prepared = _prepare()
+    prepared = _strategy_prepare()
+    assert prepared.template_type is None
     assert prepared.template_config is None
-    assert prepared.requires_workspace_hosting is False
-
-
-def test_prepare_preserves_existing_non_application_template() -> None:
-    payload = {"legacy": {"enabled": True}}
-    prepared = _prepare(
-        template_type="personalCoding",
-        template_config=payload,
-    )
-    assert prepared.template_config == payload
-    assert prepared.template_config is not payload
     assert prepared.requires_workspace_hosting is False
 
 
 @pytest.mark.parametrize(
     ("overrides", "error"),
     [
-        ({"template_config": {}}, BotTemplateInvalidError),
-        (
-            {
-                "template_type": "applicationCoding",
-                "template_config": {},
-                "engine_type": "aicoding",
-            },
-            BotCombinationUnsupportedError,
-        ),
-        (
-            {
-                "template_type": "applicationCoding",
-                "template_config": {},
-                "bot_type": "service",
-            },
-            BotCombinationUnsupportedError,
-        ),
-        (
-            {
-                "template_type": "applicationCoding",
-                "template_config": {},
-                "context": BotCreateContext(
-                    deployment_mode=BotCreateDeploymentMode.CLOUD,
-                    space_kind="team",
-                ),
-            },
-            BotCombinationUnsupportedError,
-        ),
-        (
-            {
-                "template_type": "applicationCoding",
-                "template_config": {},
-                "context": BotCreateContext(
-                    deployment_mode=BotCreateDeploymentMode.LOCAL,
-                    space_kind="personal",
-                ),
-            },
-            BotCombinationUnsupportedError,
-        ),
+        ({"engine_properties": {"template": {}}}, BotTemplateInvalidError),
+        ({"engine_type": "aicoding"}, BotCombinationUnsupportedError),
+        ({"bot_type": "service"}, BotCombinationUnsupportedError),
+        ({"space_kind": "team"}, BotCombinationUnsupportedError),
+        ({"deployment_mode": "local"}, BotCombinationUnsupportedError),
     ],
 )
 def test_prepare_rejects_invalid_application_coding_combinations(
     overrides, error
 ) -> None:
+    params = dict(
+        engine_type="claude_code",
+        engine_properties={"template": {"devflow_workflow": "x"}},
+        bot_type="personal",
+        deployment_mode="cloud",
+        space_kind="personal",
+    )
+    params.update(overrides)
     with pytest.raises(error):
-        _prepare(**overrides)
+        _strategy_prepare(**params)
 
 
 def test_prepare_application_coding_without_config_preserves_legacy_default() -> None:
-    prepared = _prepare(template_type="applicationCoding")
+    # ``{"template": None}`` is the Core-only legacy compatibility shape: key
+    # presence is the intent, None the intentionally-omitted config.
+    prepared = _strategy_prepare("claude_code", {"template": None})
+    assert prepared.template_type == "applicationCoding"
     assert prepared.template_config is None
     assert prepared.requires_workspace_hosting is True
 
 
 def test_prepare_application_coding_rejects_supplied_empty_config() -> None:
     with pytest.raises(BotTemplateInvalidError, match="must not be empty"):
-        _prepare(template_type="applicationCoding", template_config={})
+        _strategy_prepare("claude_code", {"template": {}})
 
 
 def test_prepare_application_coding_rejects_known_field_with_wrong_type() -> None:
     with pytest.raises(BotTemplateInvalidError, match="code_repos"):
-        _prepare(
-            template_type="applicationCoding",
-            template_config={"code_repos": "not-a-list"},
-        )
+        _strategy_prepare("claude_code", {"template": {"code_repos": "not-a-list"}})
 
 
 def test_prepare_valid_application_coding_returns_detached_config() -> None:
     payload = {"devflow_workflow": "x"}
-    prepared = _prepare(
-        template_type="applicationCoding",
-        template_config=payload,
-    )
+    prepared = _strategy_prepare("claude_code", {"template": payload})
     assert prepared.template_config == payload
     assert prepared.template_config is not payload
     assert prepared.requires_workspace_hosting is True
 
 
-def test_prepare_legacy_application_coding_preserves_template_uid() -> None:
+def test_legacy_application_coding_preserves_template_uid() -> None:
+    # Internal snapshots may carry platform-managed fields; the LEGACY mode
+    # (the internal callers' default) must keep accepting them (#1442).
     payload = {"template_uid": "legacy-template", "devflow_workflow": "x"}
-    prepared = _prepare(
-        template_type="applicationCoding",
-        template_config=payload,
-    )
+    prepared = _strategy_prepare("claude_code", {"template": payload})
     assert prepared.template_config == payload
     assert prepared.template_config is not payload
     assert prepared.requires_workspace_hosting is True
 
 
-def test_prepare_public_application_coding_rejects_template_uid() -> None:
+def test_public_application_coding_rejects_template_uid() -> None:
     with pytest.raises(
         BotTemplateInvalidError,
         match="server-managed fields.*template_uid",
     ):
-        _prepare(
-            template_type="applicationCoding",
-            template_config={"template_uid": "caller-value"},
+        _strategy_prepare(
+            "claude_code",
+            {"template": {"template_uid": "caller-value"}},
             template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
+        )
+
+
+def test_flow_preserves_legacy_template_uid_through_the_strategy() -> None:
+    payload = {"template_uid": "legacy-template", "devflow_workflow": "x"}
+    prepared = _prepare_spec(_application_coding_spec(template_config=payload))
+    assert prepared.template_type == "applicationCoding"
+    assert prepared.template_config == payload
+    assert prepared.template_config is not payload
+
+
+# ── create-flow source routing ─────────────────────────────────────────────
+
+
+def test_flow_routes_both_input_shapes_through_the_same_strategy() -> None:
+    legacy = _prepare_spec(_application_coding_spec())
+    modern = _prepare_spec(
+        BotCreateSpec(
+            entity_id="u1",
+            engine_type="claude_code",
+            bot_type="personal",
+            bot_name="Coding Bot",
+            engine_properties={"template": {"devflow_workflow": "x"}},
+        )
+    )
+    assert legacy.template_type == modern.template_type == "applicationCoding"
+    assert legacy.template_config == modern.template_config
+    # The legacy spec's bag stays untouched: normalization happens on the copy
+    # handed to the strategy, never on the caller's spec.
+    assert legacy.engine_properties == {}
+
+
+def test_flow_preserves_legacy_non_application_template() -> None:
+    payload = {"legacy": {"enabled": True}}
+    prepared = _prepare_spec(
+        BotCreateSpec(
+            entity_id="u1",
+            engine_type="openclaw",
+            bot_type="personal",
+            bot_name="Bot",
+            template_type="personalCoding",
+            template_config=payload,
+        )
+    )
+    assert prepared.template_type == "personalCoding"
+    assert prepared.template_config == payload
+    assert prepared.template_config is not payload
+
+
+def test_flow_preserves_legacy_application_coding_without_config() -> None:
+    prepared = _prepare_spec(
+        _application_coding_spec(template_config=None),
+    )
+    assert prepared.template_type == "applicationCoding"
+    assert prepared.template_config is None
+
+
+def test_flow_rejects_mixed_template_sources() -> None:
+    with pytest.raises(BotTemplateInvalidError):
+        _prepare_spec(
+            BotCreateSpec(
+                entity_id="u1",
+                engine_type="claude_code",
+                bot_type="personal",
+                bot_name="Coding Bot",
+                template_type="applicationCoding",
+                template_config={"devflow_workflow": "x"},
+                engine_properties={"template": {"devflow_workflow": "x"}},
+            )
         )
 
 

--- a/src/backend/tests/community/core/bot_management/test_application_coding_create.py
+++ b/src/backend/tests/community/core/bot_management/test_application_coding_create.py
@@ -61,6 +61,7 @@ def _strategy_prepare(
     ),
 ):
     return AicodingProvisioningStrategy(engine_type).prepare_create(
+        engine_type=engine_type,
         engine_properties=engine_properties or {},
         bot_type=bot_type,
         deployment_mode=deployment_mode,
@@ -112,6 +113,7 @@ def test_default_engine_rejects_application_coding_as_combination_error() -> Non
     # mapping instead of turning it into a template-invalid 422.
     with pytest.raises(BotCombinationUnsupportedError):
         DefaultProvisioningStrategy("openclaw").prepare_create(
+            engine_type="openclaw",
             engine_properties={"template": {"devflow_workflow": "x"}},
             bot_type="personal",
             deployment_mode="cloud",
@@ -119,13 +121,47 @@ def test_default_engine_rejects_application_coding_as_combination_error() -> Non
         )
 
 
+def test_default_engine_answers_cloud_only_before_the_engine_gate() -> None:
+    # Historical gate order: the deleted prepare_bot_create checked the
+    # deployment mode first, so a local deployment reports "cloud-only" even
+    # when the engine gate would also reject.
+    with pytest.raises(BotCombinationUnsupportedError, match="cloud-only"):
+        DefaultProvisioningStrategy("openclaw").prepare_create(
+            engine_type="openclaw",
+            engine_properties={"template": {"devflow_workflow": "x"}},
+            bot_type="personal",
+            deployment_mode="local",
+            space_kind="personal",
+        )
+
+
 def test_default_engine_rejects_other_engine_properties_keys() -> None:
     with pytest.raises(BotTemplateInvalidError):
         DefaultProvisioningStrategy("openclaw").prepare_create(
+            engine_type="openclaw",
             engine_properties={"surprise": 1},
             bot_type="personal",
             deployment_mode="cloud",
             space_kind="personal",
+        )
+
+
+def test_unregistered_engine_is_named_in_the_combination_error() -> None:
+    # Engines that pass the router's engine gate but have no registered
+    # strategy (e.g. "moltis" in SUPPORTED_ENGINE_TYPES, or any free-form
+    # engine_type on the untyped internal surface) resolve to the shared
+    # default fallback. The error used to name "default"; it must name the
+    # engine the caller actually asked for.
+    with pytest.raises(BotCombinationUnsupportedError, match="moltis"):
+        _prepare_spec(
+            BotCreateSpec(
+                entity_id="u1",
+                engine_type="moltis",
+                bot_type="personal",
+                bot_name="Coding Bot",
+                template_type="applicationCoding",
+                template_config={"devflow_workflow": "x"},
+            )
         )
 
 
@@ -208,6 +244,17 @@ def test_legacy_application_coding_preserves_template_uid() -> None:
     assert prepared.requires_workspace_hosting is True
 
 
+def test_legacy_non_dict_template_config_keeps_historical_passthrough() -> None:
+    # The internal /api/bots surface forwards template_config untyped; the
+    # pre-strategy ladder let truthy non-dict values through (only genuinely
+    # empty payloads were rejected). The strategy keeps that contract instead
+    # of tightening it into a rejection.
+    prepared = _strategy_prepare("claude_code", {"template": "legacy-ref"})
+    assert prepared.template_type == "applicationCoding"
+    assert prepared.template_config == "legacy-ref"
+    assert prepared.requires_workspace_hosting is True
+
+
 def test_public_application_coding_rejects_template_uid() -> None:
     with pytest.raises(
         BotTemplateInvalidError,
@@ -247,6 +294,28 @@ def test_flow_routes_both_input_shapes_through_the_same_strategy() -> None:
     # The legacy spec's bag stays untouched: normalization happens on the copy
     # handed to the strategy, never on the caller's spec.
     assert legacy.engine_properties == {}
+
+
+def test_flow_output_satisfies_its_own_mixed_source_invariant() -> None:
+    # The translated spec is what a retry (or the deferred pending-intent
+    # replay) would re-feed into _prepare_create: it may carry the translated
+    # template fields, so the consumed engine_properties bag must be cleared
+    # rather than travelling alongside them as a second source.
+    prepared = _prepare_spec(
+        BotCreateSpec(
+            entity_id="u1",
+            engine_type="claude_code",
+            bot_type="personal",
+            bot_name="Coding Bot",
+            engine_properties={"template": {"devflow_workflow": "x"}},
+        )
+    )
+    assert prepared.template_type == "applicationCoding"
+    assert prepared.engine_properties == {}
+    # Re-prepare must not hit the mixed-source guard.
+    roundtrip = _prepare_spec(prepared)
+    assert roundtrip.template_type == "applicationCoding"
+    assert roundtrip.template_config == {"devflow_workflow": "x"}
 
 
 def test_flow_preserves_legacy_non_application_template() -> None:


### PR DESCRIPTION
## Problem

The public `engine_properties` contract was already published on dev, but the OpenAPI create / auth-completion routers unpacked `engine_properties.template` themselves and synthesized the internal `template_type="applicationCoding"`, while the application-coding combination policy lived in the generic `create_flow.prepare_bot_create`. Every new engine property would therefore grow HTTP-layer business knowledge, and the existing `EngineProvisioningStrategy` extension point was not the single owner of engine-specific creation rules.

## Solution

- `AicodingProvisioningStrategy.prepare_create` is now the single implementation of application-coding creation policy. `create_flow._prepare_create` routes both input shapes into it: the public `engine_properties` bag, and the legacy internal `template_type="applicationCoding"` pair normalized to the Core-only `{"template": None}` key-presence shape (legacy callers may intentionally omit the config).
- Routers pass `engine_properties` through as a plain dict — Pydantic models stay in the HTTP layer; the adapter no longer unpacks template or synthesizes `"applicationCoding"`.
- `DefaultProvisioningStrategy` answers template intent with the historical `BotCombinationUnsupportedError` (keeps the 409 mapping for openclaw/teclaw/hermes + application-coding) and other unknown keys as `BotTemplateInvalidError`.
- #1442's LEGACY/PUBLIC template-validation semantics are preserved: `BotCreateSpec.template_validation_mode` flows into `prepare_create`; internal snapshots keep `template_uid`, OpenAPI inputs stay strict. The enum moved to `engines/provisioning.py` (re-exported by `create_flow`) so strategies do not depend on the flow module.
- Core-level invariants beyond the schema: mixed sources rejected, unknown `engine_properties` keys rejected.

Rejected alternative: a legacy `template` deprecation window re-publishing a field dev had already removed — dropped once the latest-dev state was verified; this PR keeps the public contract byte-identical instead.

## Validation

- `uv run pytest tests/community/core/bot_management tests/community/adapters/http/bot_management tests/community/architecture` — 1171 passed.
- `uv run pytest tests/community/adapters/http/openapi_v1` — 1351 passed, 2 skipped; dev's existing endpoint expectations needed no edits, confirming identical HTTP behavior.
- New regression tests: 409 combination error for engine_properties on non-coding engines, LEGACY `template_uid` preservation / PUBLIC rejection (#1442 port), key-presence no-config legacy shape, unknown-key Core invariant.
- `scripts/ci/python_sast_local.sh src/backend` — changed files clean; the script's exit-1 findings are byte-identical to the `origin/dev` baseline (pre-existing, unrelated files).
- Not run locally: changed-line coverage (`ci_test.sh`) — left to PR CI.

## Compatibility and risk

No public contract change: `BotCreate` / `BotAuthStatusPoll` schemas and the gateway artifact are untouched. All error-type → HTTP mappings are preserved (including the historical 409 above); #1442's legacy internal behavior is preserved and covered by tests. Rollback is a single-commit revert.

A pre-existing, unrelated issue noticed while preparing this: the committed gateway `bots.openapi.json` has drifted far behind the backend's public surface (task-graph DTOs etc. never re-dumped). It should be catch-up regenerated separately; this PR deliberately does not ride that change.

## Spec

`src/backend/specs/2026-08-24-engine-properties-polymorphic-create/design.md` (§0 records the latest-dev baseline correction this implementation is based on).