### PR TITLE
fix(backend): refresh Caller Service and Caller Instance targets

### DIFF
--- a/spec/pipeline/caller-iam-multi-target-refresh/001-spec-output.md
+++ b/spec/pipeline/caller-iam-multi-target-refresh/001-spec-output.md
@@ -19,6 +19,8 @@ Session Files runtime-binding resolver.
   instance, independently of the service lock.
 - Treat the IAM refresh as successful when at least one target is updated.
 - Return a controlled error only when no target is available or updated.
+- Exchange the opaque Caller credential once per IAM request, then reuse that
+  credential for every selected binding update.
 
 ## Explicit non-goals
 

--- a/spec/pipeline/caller-iam-multi-target-refresh/001-spec-output.md
+++ b/spec/pipeline/caller-iam-multi-target-refresh/001-spec-output.md
@@ -1,0 +1,89 @@
+# Caller IAM multi-target refresh
+
+## Goal
+
+Extend the existing IAM Caller refresh path so one authenticated request can
+refresh the eligible `CALLER_SERVICE` runtime for the requested stage and the
+current user's active `CALLER_INSTANCE`, while preserving the existing
+Session Files runtime-binding resolver.
+
+## Scope
+
+- Reuse `RuntimeBindingResolutionService` for all binding lookups.
+- Add an explicit resolver target so a Caller Bot can resolve either its
+  shared `CALLER_SERVICE` stage binding or the current user's
+  `CALLER_INSTANCE` binding.
+- Use the existing Bot collaboration lock snapshot to decide whether the
+  current actor may update `CALLER_SERVICE`.
+- Update `CALLER_INSTANCE` when the current user has an active Expert Chat
+  instance, independently of the service lock.
+- Treat the IAM refresh as successful when at least one target is updated.
+- Return a controlled error only when no target is available or updated.
+
+## Explicit non-goals
+
+- Do not add an Agent Run or binding-level execution lock.
+- Do not change relay/WebSocket/chat.send concurrency behavior.
+- Do not change the BaaS append implementation; its existing idempotent
+  semantics remain the lower-layer contract.
+- Do not accept a client-supplied binding id.
+
+## Existing chain and allowed changes
+
+```text
+GET /api/v1/token/iam
+  -> CallerIamTokenService
+  -> CallerIdentityService / runtime binding resolver
+  -> Caller runtime updater (BaaS)
+```
+
+Allowed files are the runtime-binding models/service, IAM application service,
+its DI wiring, and focused unit tests. The HTTP router remains a thin adapter.
+Unrelated relay, engine, BaaS transport, and Session Resource behavior remain
+unchanged.
+
+## Target rules
+
+`CALLER_SERVICE` uses the requested IAM stage:
+
+| stage | target |
+| --- | --- |
+| `draft` | service draft binding |
+| `verify` | service verify binding |
+| `online` | service online binding |
+
+The service target is eligible when either:
+
+1. a collaboration lock exists and its holder is the current actor; or
+2. no collaboration lock exists and the current actor is the Bot owner.
+
+The `CALLER_INSTANCE` target is eligible when the current actor's
+`ac_expert_chat_instance` is `success`, its `ext.binding_id` is valid, and the
+binding is active and scoped to the current Bot, owner, environment, and actor.
+
+For a Caller Service request, an IAM refresh succeeds when the service target
+or the caller-instance target is updated. It fails only when neither target is
+updated.
+
+## Security constraints
+
+- Resolve actor identity from the authenticated request context, never from a
+  query/body user id.
+- Resolve Bot owner and binding scope server-side.
+- Never expose binding ids, device ids, IAM tokens, Caller Tokens, cookies, or
+  raw outbound headers in responses or logs.
+- A service binding must not be updated when another collaborator holds the
+  collaboration lock.
+
+## Acceptance checks
+
+- A Caller Bot can resolve `CALLER_SERVICE` explicitly even when it also has a
+  Caller Instance.
+- An active Caller Instance is resolved independently of the service stage.
+- Owner + no lock updates the service target.
+- Current lock holder updates the service target.
+- Non-holder does not update the service target.
+- Caller Instance updates when present, regardless of service-lock outcome.
+- One successful target is sufficient for IAM success; zero successful targets
+  returns the controlled target-unavailable error.
+- Existing Session Files resolver behavior remains unchanged.

--- a/spec/pipeline/caller-iam-multi-target-refresh/002-code-report.md
+++ b/spec/pipeline/caller-iam-multi-target-refresh/002-code-report.md
@@ -1,0 +1,34 @@
+---
+agent: tc-code
+status: completed
+iteration: 1
+source: current-worktree
+---
+
+# Coding Report
+
+## Worktree
+
+- Path: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/caller-iam-multi-target`
+- Branch: `feat/caller-iam-multi-target-refresh`
+
+## Changes
+
+- Added explicit `RuntimeBindingTarget.CALLER_SERVICE` and
+  `RuntimeBindingTarget.CALLER_INSTANCE` selection while preserving `AUTO`.
+- Extended IAM refresh to resolve eligible Caller Service and active Caller
+  Instance targets and treat one successful target update as success.
+- Applied the existing Bot collaboration lock rule to Caller Service target
+  selection; no Agent Run locking or BaaS append behavior was changed.
+- Added focused tests for target resolution, owner/no-lock, lock-holder,
+  non-holder, partial success, and no-target failure behavior.
+
+## Files
+
+- `src/backend/src/agentclaw/community/core/runtime_binding/models.py`
+- `src/backend/src/agentclaw/community/core/runtime_binding/service.py`
+- `src/backend/src/agentclaw/community/core/runtime_binding/README.md`
+- `src/backend/src/agentclaw/community/core/caller_identity/iam_token_service.py`
+- `src/backend/src/agentclaw/community/di/modules/caller_identity_module.py`
+- `src/backend/tests/community/core/runtime_binding/test_service.py`
+- `src/backend/tests/community/core/caller_identity/test_iam_token_service.py`

--- a/spec/pipeline/caller-iam-multi-target-refresh/002-code-report.md
+++ b/spec/pipeline/caller-iam-multi-target-refresh/002-code-report.md
@@ -20,6 +20,8 @@ source: current-worktree
   Instance targets and treat one successful target update as success.
 - Applied the existing Bot collaboration lock rule to Caller Service target
   selection; no Agent Run locking or BaaS append behavior was changed.
+- Exchange one Caller Token per IAM request and reuse it for all selected
+  runtime binding updates.
 - Added focused tests for target resolution, owner/no-lock, lock-holder,
   non-holder, partial success, and no-target failure behavior.
 

--- a/spec/pipeline/caller-iam-multi-target-refresh/003-review-report.md
+++ b/spec/pipeline/caller-iam-multi-target-refresh/003-review-report.md
@@ -30,3 +30,11 @@ No blocking findings. The implementation covers:
 
 PASS, subject to the recorded local regression results in
 `003b-regression-report.md`.
+
+## Follow-up review correction
+
+The initial multi-target loop exchanged a Caller Token once per target. It now
+exchanges the opaque token once before the loop and passes that same token to
+each target update. Focused regression coverage proves that both binding
+updates receive the same token object and that the token provider is called
+once.

--- a/spec/pipeline/caller-iam-multi-target-refresh/003-review-report.md
+++ b/spec/pipeline/caller-iam-multi-target-refresh/003-review-report.md
@@ -1,0 +1,32 @@
+---
+agent: tc-code-reviewer
+status: completed
+iteration: 1
+---
+
+# Code Review Report
+
+## Scope review
+
+- Runtime binding changes are limited to explicit target selection.
+- IAM changes are limited to target planning and existing Caller exchange
+  invocation.
+- Session Files keeps its `AUTO` resolver behavior.
+- No relay, WebSocket, BaaS transport, or Agent Run lock changes were made.
+
+## Findings
+
+No blocking findings. The implementation covers:
+
+1. Caller Service draft/verify/online resolution for Caller Bots.
+2. Caller Instance resolution for the authenticated user's active instance.
+3. Owner-without-lock and current-lock-holder service updates.
+4. Non-holder service suppression with independent Caller Instance refresh.
+5. Success when at least one target updates and failure when no target updates.
+6. Server-side identity, owner, environment, binding activity, and instance
+   scope checks through the existing resolver.
+
+## Conclusion
+
+PASS, subject to the recorded local regression results in
+`003b-regression-report.md`.

--- a/spec/pipeline/caller-iam-multi-target-refresh/003b-regression-report.md
+++ b/spec/pipeline/caller-iam-multi-target-refresh/003b-regression-report.md
@@ -35,7 +35,7 @@ git diff --check
 
 ## Results
 
-- Pytest: `78 passed`
+- Pytest: `79 passed`
 - Ruff: passed
 - Compileall: passed
 - Git diff check: passed

--- a/spec/pipeline/caller-iam-multi-target-refresh/003b-regression-report.md
+++ b/spec/pipeline/caller-iam-multi-target-refresh/003b-regression-report.md
@@ -1,0 +1,44 @@
+---
+agent: tc-engine-regression
+status: completed
+iteration: 1
+---
+
+# Local Regression Report
+
+## Commands
+
+```bash
+uv run --project src/backend pytest -q \
+  src/backend/tests/community/core/runtime_binding \
+  src/backend/tests/community/core/caller_identity \
+  src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_session_files.py \
+  src/backend/tests/community/endpoints/test_openapi_session_files.py \
+  src/backend/tests/community/di/test_community_router_bindings_resolve.py
+
+uv run --project src/backend ruff check \
+  src/backend/src/agentclaw/community/core/runtime_binding/models.py \
+  src/backend/src/agentclaw/community/core/runtime_binding/service.py \
+  src/backend/src/agentclaw/community/core/runtime_binding/__init__.py \
+  src/backend/src/agentclaw/community/core/caller_identity/iam_token_service.py \
+  src/backend/src/agentclaw/community/di/modules/caller_identity_module.py \
+  src/backend/tests/community/core/runtime_binding/test_service.py \
+  src/backend/tests/community/core/caller_identity/test_iam_token_service.py
+
+uv run --project src/backend python -m compileall -q \
+  src/backend/src/agentclaw/community/core/runtime_binding \
+  src/backend/src/agentclaw/community/core/caller_identity/iam_token_service.py \
+  src/backend/src/agentclaw/community/di/modules/caller_identity_module.py
+
+git diff --check
+```
+
+## Results
+
+- Pytest: `78 passed`
+- Ruff: passed
+- Compileall: passed
+- Git diff check: passed
+
+The test run emitted pre-existing Pydantic/Starlette deprecation warnings;
+there were no test failures or new lint errors.

--- a/src/backend/src/agentclaw/community/api/caller_identity_service.py
+++ b/src/backend/src/agentclaw/community/api/caller_identity_service.py
@@ -8,6 +8,7 @@ from agentclaw.community.core.caller_identity.protocols import (
     CallerRuntimeUpdaterProtocol,
     CallerTokenProviderProtocol,
 )
+from agentclaw.community.core.caller_identity.credential import CallerToken
 from agentclaw.community.core.caller_identity.contracts import (
     CALLER_IDENTITY_CAPABILITY,
     CallerCallTypeInvalidError,
@@ -29,6 +30,16 @@ from agentclaw.community.core.caller_identity.contracts import (
 
 @runtime_checkable
 class CallerIdentityServiceProtocol(Protocol):
+    def exchange_caller_token(
+        self,
+        *,
+        iam_token: str,
+        caller_user_id: str,
+        bot_id: str,
+        owner_user_id: str,
+        token_provider: CallerTokenProviderProtocol,
+    ) -> CallerToken: ...
+
     async def update_mcp_call_type(
         self,
         *,
@@ -97,7 +108,8 @@ class CallerIdentityServiceProtocol(Protocol):
         entity_id: str | None = None,
         binding_id: int | None = None,
         is_test_exchange: bool = False,
-    ) -> None: ...
+        caller_token: CallerToken | None = None,
+    ) -> CallerToken: ...
 
 
 __all__ = [

--- a/src/backend/src/agentclaw/community/core/caller_identity/iam_token_service.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/iam_token_service.py
@@ -8,6 +8,7 @@ from agentclaw.community.core.caller_identity.credential import (
     CALLER_CREDENTIAL_REQUEST_INVALID,
     CALLER_OUTBOUND_UPDATE_FAILED,
     CallerCredentialError,
+    CallerToken,
 )
 from agentclaw.community.core.caller_identity.contracts import (
     CallerIdentityAmbiguousError,
@@ -126,6 +127,14 @@ class CallerIamTokenService:
                 stage=stage,
             )
             updated_targets = 0
+            caller_token = await asyncio.to_thread(
+                self._caller_identity.exchange_caller_token,
+                iam_token=iam_token,
+                caller_user_id=identity.staffId,
+                bot_id=bot_id,
+                owner_user_id=context.owner_id,
+                token_provider=self._token_provider,
+            )
             for target in targets:
                 try:
                     await self._exchange_target(
@@ -138,6 +147,7 @@ class CallerIamTokenService:
                         entity_id=entity_id,
                         binding_id=target.binding_id,
                         is_test_exchange=False,
+                        caller_token=caller_token,
                     )
                     updated_targets += 1
                     logger.info(
@@ -182,6 +192,7 @@ class CallerIamTokenService:
         entity_id: str | None,
         binding_id: int | None,
         is_test_exchange: bool,
+        caller_token: CallerToken | None = None,
     ) -> None:
         await asyncio.to_thread(
             self._caller_identity.exchange_caller_identity,
@@ -196,6 +207,7 @@ class CallerIamTokenService:
             entity_id=entity_id,
             binding_id=binding_id,
             is_test_exchange=is_test_exchange,
+            caller_token=caller_token,
         )
 
     def _resolve_refresh_targets(

--- a/src/backend/src/agentclaw/community/core/caller_identity/iam_token_service.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/iam_token_service.py
@@ -15,6 +15,17 @@ from agentclaw.community.core.caller_identity.contracts import (
     CallerIdentityPermissionError,
     CallerIdentityStage,
 )
+from agentclaw.community.core.repository.protocols.bot import (
+    BotCollabLockRepositoryProtocol,
+)
+from agentclaw.community.core.runtime_binding.errors import RuntimeBindingResolutionError
+from agentclaw.community.core.runtime_binding.models import (
+    ResolvedRuntimeBinding,
+    RuntimeBindingRequest,
+    RuntimeBindingSource,
+    RuntimeBindingTarget,
+)
+from agentclaw.community.core.runtime_binding.service import RuntimeBindingResolutionService
 from agentclaw.community.core.caller_identity.protocols import (
     CallerIdentityTokenExchangeProtocol,
     CallerRuntimeUpdaterProtocol,
@@ -37,11 +48,15 @@ class CallerIamTokenService:
         auth_plugin: AuthPlugin,
         token_provider: CallerTokenProviderProtocol,
         runtime_updater: CallerRuntimeUpdaterProtocol,
+        runtime_bindings: RuntimeBindingResolutionService,
+        lock_repository: BotCollabLockRepositoryProtocol,
     ) -> None:
         self._caller_identity = caller_identity
         self._auth_plugin = auth_plugin
         self._token_provider = token_provider
         self._runtime_updater = runtime_updater
+        self._runtime_bindings = runtime_bindings
+        self._lock_repository = lock_repository
 
     async def get_iam_token(
         self,
@@ -88,26 +103,162 @@ class CallerIamTokenService:
                     owner_user_id=context.owner_id,
                     is_test_exchange=True,
                 )
-            await asyncio.to_thread(
-                self._caller_identity.exchange_caller_identity,
-                iam_token=iam_token,
-                caller_user_id=identity.staffId,
+            if is_test_exchange:
+                await self._exchange_target(
+                    iam_token=iam_token,
+                    caller_user_id=identity.staffId,
+                    bot_id=bot_id,
+                    owner_id=context.owner_id,
+                    stage=stage,
+                    publish_id=publish_id,
+                    entity_id=entity_id,
+                    binding_id=context.binding_id,
+                    is_test_exchange=True,
+                )
+                logger.info("caller_token_exchange_succeeded bot_id=%s stage=%s", bot_id, stage.value)
+                return CallerIamTokenOutcome(iam_token=iam_token)
+
+            targets = await asyncio.to_thread(
+                self._resolve_refresh_targets,
                 bot_id=bot_id,
-                owner_user_id=context.owner_id,
-                token_provider=self._token_provider,
-                runtime_updater=self._runtime_updater,
-                stage=stage.value,
-                publish_id=publish_id,
-                entity_id=entity_id,
-                binding_id=context.binding_id,
-                is_test_exchange=is_test_exchange,
+                owner_id=context.owner_id,
+                actor_user_id=identity.staffId,
+                stage=stage,
             )
+            updated_targets = 0
+            for target in targets:
+                try:
+                    await self._exchange_target(
+                        iam_token=iam_token,
+                        caller_user_id=identity.staffId,
+                        bot_id=bot_id,
+                        owner_id=context.owner_id,
+                        stage=stage,
+                        publish_id=publish_id,
+                        entity_id=entity_id,
+                        binding_id=target.binding_id,
+                        is_test_exchange=False,
+                    )
+                    updated_targets += 1
+                    logger.info(
+                        "caller_target_refresh_succeeded bot_id=%s source=%s stage=%s",
+                        bot_id,
+                        target.source.value,
+                        stage.value if target.source is not RuntimeBindingSource.CALLER_INSTANCE else "instance",
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "caller_target_refresh_failed bot_id=%s source=%s error_type=%s",
+                        bot_id,
+                        target.source.value,
+                        type(exc).__name__,
+                    )
+            if updated_targets == 0:
+                return CallerIamTokenOutcome(iam_token="", error=CALLER_OUTBOUND_UPDATE_FAILED)
         except CallerCredentialError as exc:
             return CallerIamTokenOutcome(iam_token="", error=exc.code)
         except CallerIdentityPermissionError as exc:
             return CallerIamTokenOutcome(iam_token="", error=exc.detail)
-        except Exception:
-            logger.warning("caller_runtime_update_failed bot_id=%s stage=%s", bot_id, stage.value)
+        except Exception as exc:
+            logger.warning(
+                "caller_runtime_update_failed bot_id=%s stage=%s error_type=%s",
+                bot_id,
+                stage.value,
+                type(exc).__name__,
+            )
             return CallerIamTokenOutcome(iam_token="", error=CALLER_OUTBOUND_UPDATE_FAILED)
         logger.info("caller_token_exchange_succeeded bot_id=%s stage=%s", bot_id, stage.value)
         return CallerIamTokenOutcome(iam_token=iam_token)
+
+    async def _exchange_target(
+        self,
+        *,
+        iam_token: str,
+        caller_user_id: str,
+        bot_id: str,
+        owner_id: str,
+        stage: CallerIdentityStage,
+        publish_id: int | None,
+        entity_id: str | None,
+        binding_id: int | None,
+        is_test_exchange: bool,
+    ) -> None:
+        await asyncio.to_thread(
+            self._caller_identity.exchange_caller_identity,
+            iam_token=iam_token,
+            caller_user_id=caller_user_id,
+            bot_id=bot_id,
+            owner_user_id=owner_id,
+            token_provider=self._token_provider,
+            runtime_updater=self._runtime_updater,
+            stage=stage.value,
+            publish_id=publish_id,
+            entity_id=entity_id,
+            binding_id=binding_id,
+            is_test_exchange=is_test_exchange,
+        )
+
+    def _resolve_refresh_targets(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        actor_user_id: str,
+        stage: CallerIdentityStage,
+    ) -> list[ResolvedRuntimeBinding]:
+        targets: list[ResolvedRuntimeBinding] = []
+        lock = self._lock_repository.get_by_key(f"{bot_id}:{owner_id}")
+        service_allowed = lock is None and actor_user_id == owner_id
+        service_allowed = service_allowed or (
+            lock is not None and lock.holder_user_id == actor_user_id
+        )
+        if service_allowed:
+            try:
+                targets.append(
+                    self._runtime_bindings.resolve(
+                        RuntimeBindingRequest(
+                            bot_id=bot_id,
+                            owner_id=owner_id,
+                            actor_user_id=actor_user_id,
+                            stage=stage.value,
+                            target=RuntimeBindingTarget.CALLER_SERVICE,
+                        )
+                    )
+                )
+            except RuntimeBindingResolutionError:
+                logger.info(
+                    "caller_target_refresh_unavailable bot_id=%s source=caller_service stage=%s",
+                    bot_id,
+                    stage.value,
+                )
+        try:
+            targets.append(
+                self._runtime_bindings.resolve(
+                    RuntimeBindingRequest(
+                        bot_id=bot_id,
+                        owner_id=owner_id,
+                        actor_user_id=actor_user_id,
+                        stage=stage.value,
+                        target=RuntimeBindingTarget.CALLER_INSTANCE,
+                    )
+                )
+            )
+        except RuntimeBindingResolutionError:
+            logger.info(
+                "caller_target_refresh_unavailable bot_id=%s source=caller_instance",
+                bot_id,
+            )
+        return self._dedupe_targets(targets)
+
+    @staticmethod
+    def _dedupe_targets(
+        targets: list[ResolvedRuntimeBinding],
+    ) -> list[ResolvedRuntimeBinding]:
+        seen: set[int] = set()
+        unique: list[ResolvedRuntimeBinding] = []
+        for target in targets:
+            if target.binding_id in seen:
+                continue
+            seen.add(target.binding_id)
+            unique.append(target)
+        return unique

--- a/src/backend/src/agentclaw/community/core/caller_identity/protocols.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/protocols.py
@@ -67,6 +67,16 @@ class CallerRuntimeUpdaterProtocol(Protocol):
 class CallerIdentityTokenExchangeProtocol(Protocol):
     """Core port for the Caller IAM-token exchange use case."""
 
+    def exchange_caller_token(
+        self,
+        *,
+        iam_token: str,
+        caller_user_id: str,
+        bot_id: str,
+        owner_user_id: str,
+        token_provider: CallerTokenProviderProtocol,
+    ) -> CallerToken: ...
+
     def get_iam_token_context(
         self,
         bot_id: str,
@@ -98,7 +108,8 @@ class CallerIdentityTokenExchangeProtocol(Protocol):
         entity_id: str | None = None,
         binding_id: int | None = None,
         is_test_exchange: bool = False,
-    ) -> None: ...
+        caller_token: CallerToken | None = None,
+    ) -> CallerToken: ...
 
 
 __all__ = [

--- a/src/backend/src/agentclaw/community/core/caller_identity/service.py
+++ b/src/backend/src/agentclaw/community/core/caller_identity/service.py
@@ -28,6 +28,7 @@ from agentclaw.community.core.caller_identity.contracts import (
 from agentclaw.community.core.caller_identity.credential import (
     CALLER_CHAT_TASK,
     AuthContext,
+    CallerToken,
 )
 from agentclaw.community.core.caller_identity.protocols import (
     CallerMcpSyncProtocol,
@@ -332,15 +333,18 @@ class CallerIdentityService:
         entity_id: str | None = None,
         binding_id: int | None = None,
         is_test_exchange: bool = False,
-    ) -> None:
+        caller_token: CallerToken | None = None,
+    ) -> CallerToken:
         """Exchange and install the Caller credential for one chat request."""
-        caller_token = token_provider.exchange(
-            auth_context=AuthContext(user_id=caller_user_id),
-            iam_token=iam_token,
-            bot_id=bot_id,
-            owner_user_id=owner_user_id,
-            task_metadata=CALLER_CHAT_TASK,
-        )
+        token_reused = caller_token is not None
+        if caller_token is None:
+            caller_token = self.exchange_caller_token(
+                iam_token=iam_token,
+                caller_user_id=caller_user_id,
+                bot_id=bot_id,
+                owner_user_id=owner_user_id,
+                token_provider=token_provider,
+            )
         runtime_update_kwargs: dict[str, Any] = {
             "bot_id": bot_id,
             "owner_user_id": owner_user_id,
@@ -358,13 +362,33 @@ class CallerIdentityService:
             # that controlled end-to-end test.
             runtime_update_kwargs["is_test_exchange"] = True
         logger.info(
-            "caller_runtime_update_requested bot_id=%s stage=%s test_exchange=%s",
+            "caller_runtime_update_requested bot_id=%s stage=%s test_exchange=%s token_reused=%s",
             bot_id,
             stage,
             is_test_exchange,
+            token_reused,
         )
         runtime_updater.update_caller_identity(
             **runtime_update_kwargs,
+        )
+        return caller_token
+
+    def exchange_caller_token(
+        self,
+        *,
+        iam_token: str,
+        caller_user_id: str,
+        bot_id: str,
+        owner_user_id: str,
+        token_provider: CallerTokenProviderProtocol,
+    ) -> CallerToken:
+        """Exchange one opaque Caller token for the current IAM request."""
+        return token_provider.exchange(
+            auth_context=AuthContext(user_id=caller_user_id),
+            iam_token=iam_token,
+            bot_id=bot_id,
+            owner_user_id=owner_user_id,
+            task_metadata=CALLER_CHAT_TASK,
         )
 
     def _compensate_after_sync_failure(

--- a/src/backend/src/agentclaw/community/core/runtime_binding/README.md
+++ b/src/backend/src/agentclaw/community/core/runtime_binding/README.md
@@ -5,10 +5,11 @@ Read-only resolution of a trusted Bot request to an existing `binding_id`.
 ## Context Boundary
 
 ```yaml
-purpose: "Resolve Bot, owner, actor, and stage to one existing binding id."
+purpose: "Resolve Bot, owner, actor, stage, and an explicit runtime target to one existing binding id."
 provides:
   - RuntimeBindingRequest
   - RuntimeBindingSource
+  - RuntimeBindingTarget
   - ResolvedRuntimeBinding
   - RuntimeBindingResolutionService
 consumes:
@@ -19,6 +20,11 @@ consumes:
 internal_dependencies:
   - agentclaw.community.core.engine_runtime.stage
 ```
+
+`RuntimeBindingTarget.CALLER_SERVICE` explicitly resolves a service Bot's draft,
+verify, or online runtime even when the Bot also has a caller instance.
+`RuntimeBindingTarget.CALLER_INSTANCE` resolves the authenticated user's active
+Expert Chat instance. `AUTO` preserves the existing Session Files behavior.
 
 It does not select a device, retain session affinity, mutate state, or call the
 Session Resource state machine. The OpenAPI adapter resolves once for upload

--- a/src/backend/src/agentclaw/community/core/runtime_binding/__init__.py
+++ b/src/backend/src/agentclaw/community/core/runtime_binding/__init__.py
@@ -4,6 +4,7 @@ from agentclaw.community.core.runtime_binding.models import (
     ResolvedRuntimeBinding,
     RuntimeBindingRequest,
     RuntimeBindingSource,
+    RuntimeBindingTarget,
 )
 from agentclaw.community.core.runtime_binding.service import (
     RuntimeBindingResolutionService,
@@ -14,4 +15,5 @@ __all__ = [
     "RuntimeBindingRequest",
     "RuntimeBindingResolutionService",
     "RuntimeBindingSource",
+    "RuntimeBindingTarget",
 ]

--- a/src/backend/src/agentclaw/community/core/runtime_binding/models.py
+++ b/src/backend/src/agentclaw/community/core/runtime_binding/models.py
@@ -14,6 +14,14 @@ class RuntimeBindingSource(StrEnum):
     CALLER_INSTANCE = "caller_instance"
 
 
+class RuntimeBindingTarget(StrEnum):
+    """Explicit runtime family requested by a trusted server-side caller."""
+
+    AUTO = "auto"
+    CALLER_SERVICE = "caller_service"
+    CALLER_INSTANCE = "caller_instance"
+
+
 @dataclass(frozen=True, slots=True)
 class RuntimeBindingRequest:
     """Trusted request context used to find one existing binding."""
@@ -24,6 +32,7 @@ class RuntimeBindingRequest:
     stage: str = "draft"
     allow_initializing_caller_binding_id: int | None = None
     environment: str | None = None
+    target: RuntimeBindingTarget = RuntimeBindingTarget.AUTO
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,4 +47,5 @@ __all__ = [
     "ResolvedRuntimeBinding",
     "RuntimeBindingRequest",
     "RuntimeBindingSource",
+    "RuntimeBindingTarget",
 ]

--- a/src/backend/src/agentclaw/community/core/runtime_binding/service.py
+++ b/src/backend/src/agentclaw/community/core/runtime_binding/service.py
@@ -21,6 +21,7 @@ from agentclaw.community.core.runtime_binding.models import (
     ResolvedRuntimeBinding,
     RuntimeBindingRequest,
     RuntimeBindingSource,
+    RuntimeBindingTarget,
 )
 from agentclaw.community.utils.env_utils import get_current_env
 
@@ -78,6 +79,14 @@ class RuntimeBindingResolutionService:
     ) -> RuntimeBindingSource:
         require_known_stage(request.stage)
         bot_type = self._value(bot.get("bot_type"))
+        if request.target is RuntimeBindingTarget.CALLER_INSTANCE:
+            return RuntimeBindingSource.CALLER_INSTANCE
+        if request.target is RuntimeBindingTarget.CALLER_SERVICE:
+            if bot_type != SERVICE_BOT_TYPE:
+                raise RuntimeBindingNotFoundError(
+                    "personal bot has no Caller Service runtime binding"
+                )
+            return self._service_source(request.stage)
         if bot_type == SERVICE_BOT_TYPE and self._value(bot.get("call_type")) == "caller":
             return RuntimeBindingSource.CALLER_INSTANCE
         if bot_type != SERVICE_BOT_TYPE:
@@ -89,6 +98,14 @@ class RuntimeBindingResolutionService:
         if request.stage == STAGE_DRAFT:
             return RuntimeBindingSource.SERVICE_DRAFT
         if request.stage == STAGE_VERIFY:
+            return RuntimeBindingSource.SERVICE_VERIFY
+        return RuntimeBindingSource.SERVICE_ONLINE
+
+    @staticmethod
+    def _service_source(stage: str) -> RuntimeBindingSource:
+        if stage == STAGE_DRAFT:
+            return RuntimeBindingSource.SERVICE_DRAFT
+        if stage == STAGE_VERIFY:
             return RuntimeBindingSource.SERVICE_VERIFY
         return RuntimeBindingSource.SERVICE_ONLINE
 

--- a/src/backend/src/agentclaw/community/di/modules/caller_identity_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/caller_identity_module.py
@@ -29,6 +29,7 @@ from agentclaw.community.core.caller_identity.service import CallerIdentityServi
 from agentclaw.community.core.caller_identity.iam_token_service import (
     CallerIamTokenService,
 )
+from agentclaw.community.core.runtime_binding.service import RuntimeBindingResolutionService
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.mcp.services.repositories import BotMCPProvider
 from agentclaw.community.core.repository.implementations.identity.caller_identity import CallerIdentityRepository
@@ -130,10 +131,14 @@ class CallerIdentityModule(Module):
         auth_plugin: AuthPlugin,
         token_provider: CallerTokenProvider,
         runtime_updater: CallerRuntimeUpdater,
+        runtime_bindings: RuntimeBindingResolutionService,
+        lock_repository: BotCollabLockRepositoryProtocol,
     ) -> CallerIamTokenServiceProtocol:
         return CallerIamTokenService(
             caller_identity=caller_identity,
             auth_plugin=auth_plugin,
             token_provider=token_provider,
             runtime_updater=runtime_updater,
+            runtime_bindings=runtime_bindings,
+            lock_repository=lock_repository,
         )

--- a/src/backend/tests/community/core/caller_identity/test_iam_token_service.py
+++ b/src/backend/tests/community/core/caller_identity/test_iam_token_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -14,6 +15,7 @@ from agentclaw.community.core.caller_identity.credential import (
     CALLER_CREDENTIAL_REQUEST_INVALID,
     CALLER_OUTBOUND_UPDATE_FAILED,
     CallerCredentialError,
+    CallerToken,
 )
 from agentclaw.community.core.caller_identity.iam_token_service import (
     CallerIamTokenService,
@@ -40,6 +42,15 @@ def _context(*, exchange: bool = True, owner_id: str | None = "owner-1") -> Call
     )
 
 
+def _caller_token() -> CallerToken:
+    return CallerToken(
+        access_token="caller-token",
+        subject_user_id="caller-1",
+        expires_at=datetime.now(),
+        fingerprint="fingerprint",
+    )
+
+
 def _service(
     *,
     context: CallerIamTokenContext | None = None,
@@ -49,6 +60,8 @@ def _service(
 ):
     identity = MagicMock()
     identity.get_iam_token_context.return_value = context or _context()
+    identity.exchange_caller_identity.return_value = _caller_token()
+    identity.exchange_caller_token.return_value = _caller_token()
     auth = MagicMock()
     auth.resolve_user_from_request = AsyncMock(
         return_value=SimpleNamespace(staffId="caller-1")
@@ -133,9 +146,13 @@ async def test_service_refresh_updates_service_and_caller_instance_targets():
 
     assert result.error is None
     assert runtime_bindings.resolve.call_count == 2
-    assert [
-        call.kwargs["binding_id"] for call in identity.exchange_caller_identity.call_args_list
-    ] == [31, 41]
+    assert identity.exchange_caller_identity.call_count == 2
+    identity.exchange_caller_token.assert_called_once()
+    first_call, second_call = identity.exchange_caller_identity.call_args_list
+    assert first_call.kwargs["binding_id"] == 31
+    assert first_call.kwargs["caller_token"] is identity.exchange_caller_token.return_value
+    assert second_call.kwargs["binding_id"] == 41
+    assert second_call.kwargs["caller_token"] is identity.exchange_caller_token.return_value
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/caller_identity/test_iam_token_service.py
+++ b/src/backend/tests/community/core/caller_identity/test_iam_token_service.py
@@ -18,6 +18,11 @@ from agentclaw.community.core.caller_identity.credential import (
 from agentclaw.community.core.caller_identity.iam_token_service import (
     CallerIamTokenService,
 )
+from agentclaw.community.core.runtime_binding.errors import RuntimeBindingResolutionError
+from agentclaw.community.core.runtime_binding.models import (
+    ResolvedRuntimeBinding,
+    RuntimeBindingSource,
+)
 from agentclaw.community.plugin_api.auth import AuthRequestContext
 from agentclaw.community.api.caller_credential import UnavailableCallerTokenProvider
 from agentclaw.community.di.modules.caller_identity_module import CallerIdentityModule
@@ -35,7 +40,13 @@ def _context(*, exchange: bool = True, owner_id: str | None = "owner-1") -> Call
     )
 
 
-def _service(*, context: CallerIamTokenContext | None = None):
+def _service(
+    *,
+    context: CallerIamTokenContext | None = None,
+    service_target: ResolvedRuntimeBinding | Exception | None = None,
+    caller_target: ResolvedRuntimeBinding | Exception | None = None,
+    lock_holder: str | None = "caller-1",
+):
     identity = MagicMock()
     identity.get_iam_token_context.return_value = context or _context()
     auth = MagicMock()
@@ -44,17 +55,32 @@ def _service(*, context: CallerIamTokenContext | None = None):
     )
     provider = MagicMock()
     updater = MagicMock()
+    runtime_bindings = MagicMock()
+    if service_target is None:
+        service_target = ResolvedRuntimeBinding(9, RuntimeBindingSource.SERVICE_DRAFT)
+    runtime_bindings.resolve.side_effect = [
+        service_target,
+        caller_target or RuntimeBindingResolutionError("caller target missing"),
+    ]
+    lock_repository = MagicMock()
+    lock_repository.get_by_key.return_value = (
+        SimpleNamespace(holder_user_id=lock_holder) if lock_holder else None
+    )
     return (
         CallerIamTokenService(
             caller_identity=identity,
             auth_plugin=auth,
             token_provider=provider,
             runtime_updater=updater,
+            runtime_bindings=runtime_bindings,
+            lock_repository=lock_repository,
         ),
         identity,
         auth,
         provider,
         updater,
+        runtime_bindings,
+        lock_repository,
     )
 
 
@@ -64,25 +90,10 @@ def _request() -> AuthRequestContext:
 
 @pytest.mark.asyncio
 async def test_service_installs_caller_token_without_returning_it() -> None:
-    identity = MagicMock()
-    identity.get_iam_token_context.return_value = CallerIamTokenContext(
-        bot_id="bot-1",
-        owner_id="owner-1",
-        stage=CallerIdentityStage.DRAFT,
-        publish_id=None,
-        bot_call_type=McpCallType.CALLER,
-        should_exchange_caller_token=True,
-        binding_id=9,
-    )
-    auth = MagicMock()
-    auth.resolve_user_from_request = AsyncMock(
-        return_value=SimpleNamespace(staffId="caller-1")
-    )
-    service = CallerIamTokenService(
-        caller_identity=identity,
-        auth_plugin=auth,
-        token_provider=MagicMock(),
-        runtime_updater=MagicMock(),
+    service, identity, *_ = _service(
+        service_target=ResolvedRuntimeBinding(9, RuntimeBindingSource.SERVICE_DRAFT),
+        caller_target=RuntimeBindingResolutionError("caller target missing"),
+        lock_holder="caller-1",
     )
 
     result = await service.get_iam_token(
@@ -98,6 +109,131 @@ async def test_service_installs_caller_token_without_returning_it() -> None:
     assert result.error is None
     assert result.iam_token == "iam-token"
     assert identity.exchange_caller_identity.call_args.kwargs["binding_id"] == 9
+
+
+@pytest.mark.asyncio
+async def test_service_refresh_updates_service_and_caller_instance_targets():
+    service_target = ResolvedRuntimeBinding(31, RuntimeBindingSource.SERVICE_ONLINE)
+    caller_target = ResolvedRuntimeBinding(41, RuntimeBindingSource.CALLER_INSTANCE)
+    service, identity, _, _, _, runtime_bindings, _ = _service(
+        service_target=service_target,
+        caller_target=caller_target,
+        lock_holder="caller-1",
+    )
+
+    result = await service.get_iam_token(
+        iam_token="iam-token",
+        auth_request=_request(),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.ONLINE,
+        publish_id=None,
+        entity_id="owner-1",
+        is_test_exchange=False,
+    )
+
+    assert result.error is None
+    assert runtime_bindings.resolve.call_count == 2
+    assert [
+        call.kwargs["binding_id"] for call in identity.exchange_caller_identity.call_args_list
+    ] == [31, 41]
+
+
+@pytest.mark.asyncio
+async def test_owner_without_lock_updates_caller_service_target():
+    service, identity, _, _, _, runtime_bindings, lock_repository = _service(
+        context=_context(owner_id="caller-1"),
+        service_target=ResolvedRuntimeBinding(31, RuntimeBindingSource.SERVICE_ONLINE),
+        caller_target=RuntimeBindingResolutionError("caller target missing"),
+        lock_holder=None,
+    )
+
+    result = await service.get_iam_token(
+        iam_token="iam-token",
+        auth_request=_request(),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.ONLINE,
+        publish_id=None,
+        entity_id="owner-1",
+        is_test_exchange=False,
+    )
+
+    assert result.error is None
+    lock_repository.get_by_key.assert_called_once_with("bot-1:caller-1")
+    assert runtime_bindings.resolve.call_count == 2
+    identity.exchange_caller_identity.assert_called_once()
+    assert identity.exchange_caller_identity.call_args.kwargs["binding_id"] == 31
+
+
+@pytest.mark.asyncio
+async def test_non_holder_skips_caller_service_but_updates_caller_instance():
+    caller_target = ResolvedRuntimeBinding(41, RuntimeBindingSource.CALLER_INSTANCE)
+    service, identity, _, _, _, runtime_bindings, _ = _service(
+        service_target=ResolvedRuntimeBinding(31, RuntimeBindingSource.SERVICE_ONLINE),
+        caller_target=caller_target,
+        lock_holder="other-user",
+    )
+    runtime_bindings.resolve.side_effect = [caller_target]
+
+    result = await service.get_iam_token(
+        iam_token="iam-token",
+        auth_request=_request(),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.ONLINE,
+        publish_id=None,
+        entity_id="owner-1",
+        is_test_exchange=False,
+    )
+
+    assert result.error is None
+    runtime_bindings.resolve.assert_called_once()
+    identity.exchange_caller_identity.assert_called_once()
+    assert identity.exchange_caller_identity.call_args.kwargs["binding_id"] == 41
+
+
+@pytest.mark.asyncio
+async def test_service_refresh_keeps_success_when_only_caller_instance_updates():
+    caller_target = ResolvedRuntimeBinding(41, RuntimeBindingSource.CALLER_INSTANCE)
+    service, identity, _, _, _, runtime_bindings, _ = _service(
+        service_target=RuntimeBindingResolutionError("service target missing"),
+        caller_target=caller_target,
+    )
+
+    result = await service.get_iam_token(
+        iam_token="iam-token",
+        auth_request=_request(),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.ONLINE,
+        publish_id=None,
+        entity_id="owner-1",
+        is_test_exchange=False,
+    )
+
+    assert result.error is None
+    assert runtime_bindings.resolve.call_count == 2
+    identity.exchange_caller_identity.assert_called_once()
+    assert identity.exchange_caller_identity.call_args.kwargs["binding_id"] == 41
+
+
+@pytest.mark.asyncio
+async def test_service_refresh_fails_when_no_target_is_updated():
+    service, identity, _, _, _, runtime_bindings, _ = _service(
+        service_target=RuntimeBindingResolutionError("service target missing"),
+        caller_target=RuntimeBindingResolutionError("caller target missing"),
+    )
+
+    result = await service.get_iam_token(
+        iam_token="iam-token",
+        auth_request=_request(),
+        bot_id="bot-1",
+        stage=CallerIdentityStage.ONLINE,
+        publish_id=None,
+        entity_id="owner-1",
+        is_test_exchange=False,
+    )
+
+    assert result.error == "CALLER_OUTBOUND_UPDATE_FAILED"
+    assert runtime_bindings.resolve.call_count == 2
+    identity.exchange_caller_identity.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -215,5 +351,6 @@ def test_unavailable_provider_and_module_provider_fail_closed() -> None:
     service = CallerIdentityModule().caller_iam_token_service(
         caller_identity=MagicMock(), auth_plugin=MagicMock(),
         token_provider=MagicMock(), runtime_updater=MagicMock(),
+        runtime_bindings=MagicMock(), lock_repository=MagicMock(),
     )
     assert isinstance(service, CallerIamTokenService)

--- a/src/backend/tests/community/core/caller_identity/test_service.py
+++ b/src/backend/tests/community/core/caller_identity/test_service.py
@@ -282,6 +282,36 @@ def test_exchange_caller_identity_installs_opaque_token_without_passport_lookup(
     )
 
 
+def test_exchange_caller_identity_reuses_supplied_caller_token() -> None:
+    service, _ = _service(bot=_bot(call_type="caller"))
+    token_provider = MagicMock()
+    caller_token = CallerToken(
+        access_token="caller-token",
+        subject_user_id="caller-1",
+        expires_at=datetime.now(),
+        fingerprint="fingerprint",
+    )
+    runtime_updater = MagicMock()
+
+    result = service.exchange_caller_identity(
+        iam_token="iam-token",
+        caller_user_id="caller-1",
+        bot_id="bot-1",
+        owner_user_id="owner-1",
+        token_provider=token_provider,
+        runtime_updater=runtime_updater,
+        stage="online",
+        publish_id=1,
+        entity_id="entity-1",
+        binding_id=9,
+        caller_token=caller_token,
+    )
+
+    assert result is caller_token
+    token_provider.exchange.assert_not_called()
+    assert runtime_updater.update_caller_identity.call_args.kwargs["caller_token"] is caller_token
+
+
 def test_exchange_caller_identity_propagates_test_exchange_to_runtime() -> None:
     service, _ = _service(bot=_bot(call_type="owner"))
     token_provider = MagicMock()

--- a/src/backend/tests/community/core/runtime_binding/test_service.py
+++ b/src/backend/tests/community/core/runtime_binding/test_service.py
@@ -11,6 +11,7 @@ from agentclaw.community.core.runtime_binding.errors import (
 from agentclaw.community.core.runtime_binding.models import (
     RuntimeBindingRequest,
     RuntimeBindingSource,
+    RuntimeBindingTarget,
 )
 from agentclaw.community.core.runtime_binding.service import (
     RuntimeBindingResolutionService,
@@ -134,6 +135,56 @@ def test_caller_bot_uses_the_authenticated_users_online_instance_record():
     )
 
     resolved = service.resolve(RuntimeBindingRequest(BOT, OWNER, CALLER, "online"))
+
+    assert resolved.binding_id == 41
+    assert resolved.source is RuntimeBindingSource.CALLER_INSTANCE
+    assert caller_repository.calls == [(CALLER, BOT, OWNER)]
+
+
+def test_caller_bot_can_explicitly_resolve_its_shared_online_service_binding():
+    service, caller_repository = _service(
+        {"id": 3, "bot_type": "service", "call_type": "caller", "binding_id": 12},
+        bindings={31: _Binding(31)},
+        records=[_PublishRecord(31)],
+        caller_instance={"status": "success", "ext": {"binding_id": 41}},
+    )
+
+    resolved = service.resolve(
+        RuntimeBindingRequest(
+            BOT,
+            OWNER,
+            CALLER,
+            "online",
+            target=RuntimeBindingTarget.CALLER_SERVICE,
+        )
+    )
+
+    assert resolved.binding_id == 31
+    assert resolved.source is RuntimeBindingSource.SERVICE_ONLINE
+    assert caller_repository.calls == []
+
+
+def test_caller_bot_can_explicitly_resolve_its_caller_instance():
+    service, caller_repository = _service(
+        {"id": 3, "bot_type": "service", "call_type": "caller"},
+        bindings={41: _Binding(
+            41,
+            entity_id=OWNER,
+            apply_reason=f"caller_instance:{BOT}",
+            applied_by=CALLER,
+        )},
+        caller_instance={"status": "success", "ext": {"binding_id": 41}},
+    )
+
+    resolved = service.resolve(
+        RuntimeBindingRequest(
+            BOT,
+            OWNER,
+            CALLER,
+            "online",
+            target=RuntimeBindingTarget.CALLER_INSTANCE,
+        )
+    )
 
     assert resolved.binding_id == 41
     assert resolved.source is RuntimeBindingSource.CALLER_INSTANCE


### PR DESCRIPTION
## Problem

The IAM Caller refresh path resolved only one runtime binding. Caller Bots
therefore could not explicitly refresh both their shared Caller Service stage
runtime and an authenticated user's active Expert Chat Caller Instance. The
existing Session Files resolver already knew how to validate these runtime
bindings, but the IAM service did not reuse it for multi-target refreshes.

## Solution

- Add explicit `CALLER_SERVICE` and `CALLER_INSTANCE` runtime targets while
  preserving the existing `AUTO` resolver behavior for Session Files.
- Use the existing collaboration lock to authorize Caller Service refreshes:
  the current lock holder may update the requested stage, and the owner may
  update it when no lock exists.
- Independently refresh the authenticated user's active Caller Instance when
  one exists.
- Exchange one opaque Caller Token per IAM request and reuse it for every
  selected outbound-rule update.
- Treat the refresh as successful when at least one eligible target is updated;
  return the existing Caller outbound failure when no target is updated.
- Keep Agent Run locking, relay/WebSocket behavior, and the lower-layer BaaS
  append semantics unchanged.

## Validation

- `uv run --project src/backend pytest -q src/backend/tests/community/core/runtime_binding src/backend/tests/community/core/caller_identity src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_session_files.py src/backend/tests/community/endpoints/test_openapi_session_files.py src/backend/tests/community/di/test_community_router_bindings_resolve.py` — 79 passed.
- `uv run --project src/backend ruff check ...` on all changed Python files — passed.
- `uv run --project src/backend python -m compileall -q ...` on changed backend modules — passed.
- `git diff --check` — passed.

## Compatibility and risk

The change is server-side and does not add a client-controlled binding id.
Session Files continues to use the existing `AUTO` resolution behavior. Agent
Run-level serialization is intentionally out of scope for this PR.

## Spec

`spec/pipeline/caller-iam-multi-target-refresh/001-spec-output.md`
