### PR TITLE
feat(proxy): add proxy deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ src/bcs/target
 .idea
 .codefuse
 .codegraph
+.opencode
+openspec

--- a/docker/kube-deploy.sh
+++ b/docker/kube-deploy.sh
@@ -64,6 +64,7 @@ ENV_FILE=""
 declare -A DEFAULT_PORT=(
     [baas]=8080
     [gateway]=8080
+    [proxy]=8080
     [bcs]=8080
     [backend]=8080
 )
@@ -111,7 +112,7 @@ done
 # --- Validate ---
 
 if [[ -z "$SERVICE" ]]; then
-    echo "error: --service is required (baas|gateway|bcs|backend)" >&2
+    echo "error: --service is required (baas|gateway|proxy|bcs|backend)" >&2
     exit 2
 fi
 if [[ -z "$IMAGE" ]]; then
@@ -120,16 +121,16 @@ if [[ -z "$IMAGE" ]]; then
 fi
 if [[ -z "${DEFAULT_PORT[$SERVICE]:-}" ]]; then
     echo "error: unknown service '$SERVICE'" >&2
-    echo "  supported: baas, gateway, bcs, backend" >&2
+    echo "  supported: baas, gateway, proxy, bcs, backend" >&2
     exit 2
 fi
 
 PORT="${PORT:-${DEFAULT_PORT[$SERVICE]}}"
-REPLICAS="$DEFAULT_REPLICAS"
-CPU_REQUEST="$DEFAULT_CPU_REQUEST"
-CPU_LIMIT="$DEFAULT_CPU_LIMIT"
-MEMORY_REQUEST="$DEFAULT_MEM_REQUEST"
-MEMORY_LIMIT="$DEFAULT_MEM_LIMIT"
+REPLICAS="${REPLICAS:-$DEFAULT_REPLICAS}"
+CPU_REQUEST="${CPU_REQUEST:-$DEFAULT_CPU_REQUEST}"
+CPU_LIMIT="${CPU_LIMIT:-$DEFAULT_CPU_LIMIT}"
+MEMORY_REQUEST="${MEMORY_REQUEST:-$DEFAULT_MEM_REQUEST}"
+MEMORY_LIMIT="${MEMORY_LIMIT:-$DEFAULT_MEM_LIMIT}"
 
 # --- Load env vars from file (if --env-file given) ---
 

--- a/scripts/k8s-tests/avernet/baas.env
+++ b/scripts/k8s-tests/avernet/baas.env
@@ -1,0 +1,21 @@
+# avernet/baas.env — baas env for the shared avernet demo stack.
+# In-cluster: mariadb + redis are shared, and the sandbox proxy is reachable
+# as the `proxy` Service (bot_service → proxy).
+SERVER_ENV=prod
+BAAS_PORT=8888
+DATABASE_URL=mysql+aiomysql://avernet:avernetpass@mariadb:3306/avernet?charset=utf8mb4
+REDIS_URL=redis://redis:6379/0
+# prod overlay references these under strict env expansion; inject test values
+# so config loading succeeds (aliyun_ack sandbox is a lazy factory, never
+# contacted during boot/health).
+ACK_SERVER=https://ack-test.example.com
+ACK_TOKEN=ack-test-token
+# Sandbox proxy (bot_service) — reach the `proxy` service in-cluster.
+BOT_SERVICE_PROXY_BASE_URL=http://proxy:8888
+BOT_SERVICE_PROXY_WS_BASE_URL=ws://proxy:8888
+# Sandbox image references (aliyun_ack; not contacted during health boot).
+AGENT_IMAGE=openclaw:latest
+SIDECAR_IMAGE=nginx:alpine
+INIT_IMAGE=busybox:latest
+NAS_SERVER=
+DEPLOY_ENV=prod

--- a/scripts/k8s-tests/avernet/deploy-avernet.sh
+++ b/scripts/k8s-tests/avernet/deploy-avernet.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# scripts/k8s-tests/avernet/deploy-avernet.sh — deploy the full avernet demo
+# stack to a single Kubernetes namespace so the services can reach each other.
+#
+# Deploys, in one namespace:
+#   - shared MariaDB + Redis (shared-infra.yaml), exposed as `mariadb` / `redis`
+#   - baas, gateway, and proxy, each via docker/kube-deploy.sh with the
+#     avernet-specific env files (in-cluster Service DNS for cross-service
+#     links: gateway→baas/proxy, proxy→baas, baas→proxy)
+#
+# Subcommands:
+#   up      build all images, apply shared infra, deploy services, wait healthy
+#   build   build the three service images only
+#   infra   apply/refresh the shared MariaDB + Redis only
+#   services deploy the three app services only (assumes infra is up)
+#   down    delete the three app services and the shared infra
+#   status  show resources in the namespace
+#   (default: up)
+#
+# Prerequisites: kubectl reaching a cluster, namespace default `avernet`.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+K8S_TESTS_DIR="${SCRIPT_DIR}/.."
+# shellcheck source=../k8s-test-lib.sh
+source "${K8S_TESTS_DIR}/k8s-test-lib.sh"
+
+NAMESPACE="${NAMESPACE:-avernet}"
+INFRA_FILE="${SCRIPT_DIR}/shared-infra.yaml"
+DEPLOY="${K8S_TEST_DEPLOY}"
+
+SERVICES=(
+  "baas:services/baas.dockerfile:baas.env"
+  "gateway:services/gateway.dockerfile:gateway.env"
+  "proxy:services/proxy.dockerfile:proxy.env"
+)
+
+build_all() {
+  local svc dockerfile
+  for entry in "${SERVICES[@]}"; do
+    svc="${entry%%:*}"
+    dockerfile="$(echo "${entry#*:}" | awk -F: '{print $1}')"
+    build_image "${svc}" "${dockerfile}"
+  done
+}
+
+apply_infra() {
+  log "applying shared MariaDB + Redis (namespace ${NAMESPACE})"
+  kubectl get namespace "${NAMESPACE}" &>/dev/null || kubectl create namespace "${NAMESPACE}"
+  kubectl -n "${NAMESPACE}" apply -f "${INFRA_FILE}"
+  log "waiting for mariadb + redis to be ready"
+  kubectl -n "${NAMESPACE}" rollout status deployment/mariadb --timeout=120s
+  kubectl -n "${NAMESPACE}" rollout status deployment/redis --timeout=120s
+}
+
+deploy_services() {
+  local svc dockerfile envfile img args
+  export_resources
+  for entry in "${SERVICES[@]}"; do
+    svc="${entry%%:*}"
+    rest="${entry#*:}"
+    dockerfile="${rest%%:*}"
+    envfile="${rest#*:}"
+    img="${IMAGE_PREFIX:-}${svc}:${IMAGE_TAG:-local}"
+    args=(--service "${svc}" --image "${img}" --namespace "${NAMESPACE}"
+          --env-file "${SCRIPT_DIR}/${envfile}")
+    log "deploying ${svc} (image ${img}, env ${envfile})"
+    PORT="${PORT:-8888}" "${DEPLOY}" "${args[@]}" --apply
+  done
+}
+
+wait_all_healthy() {
+  local svc
+  for entry in "${SERVICES[@]}"; do
+    svc="${entry%%:*}"
+    NAMESPACE="${NAMESPACE}" PORT="${PORT:-8888}" wait_healthy "${svc}"
+  done
+}
+
+teardown() {
+  local svc
+  log "deleting app services"
+  for entry in "${SERVICES[@]}"; do
+    svc="${entry%%:*}"
+    kubectl -n "${NAMESPACE}" delete deployment "${svc}" --ignore-not-found
+    kubectl -n "${NAMESPACE}" delete service "${svc}" --ignore-not-found
+  done
+  log "deleting shared infra"
+  kubectl -n "${NAMESPACE}" delete -f "${INFRA_FILE}" --ignore-not-found
+}
+
+status_cmd() {
+  log "resources in namespace ${NAMESPACE}"
+  kubectl -n "${NAMESPACE}" get all || true
+}
+
+sub="${1:-up}"
+case "${sub}" in
+  build)    build_all ;;
+  infra)    require_kubectl; apply_infra ;;
+  services) require_kubectl; deploy_services ;;
+  up)       build_all
+            require_kubectl
+            apply_infra
+            deploy_services
+            wait_all_healthy ;;
+  down)     require_kubectl; teardown ;;
+  status)   require_kubectl; status_cmd ;;
+  *)
+    echo "usage: $0 {build|infra|services|up|down|status}" >&2
+    exit 2 ;;
+esac

--- a/scripts/k8s-tests/avernet/gateway.env
+++ b/scripts/k8s-tests/avernet/gateway.env
@@ -1,0 +1,14 @@
+# avernet/gateway.env — gateway env for the shared avernet demo stack.
+# In-cluster: mariadb + redis shared; upstreams reach baas/proxy via Service
+# DNS. backend/bcs/bcsfuse are not part of this demo stack.
+SERVER_ENV=prod
+GATEWAY_PORT=8888
+DATABASE_URL=mysql+aiomysql://avernet:avernetpass@mariadb:3306/avernet?charset=utf8mb4
+REDIS_URL=redis://redis:6379/0
+BACKEND_SERVER_URL=https://backend.avernet.com
+BAAS_SERVER_URL=http://baas:8888
+BCS_SERVER_URL=https://bcs.avernet.com
+ENGINE_PROXY_SERVER_URL=http://proxy:8888
+BCSFUSE_SERVER_URL=https://bcsfuse.avernet.com
+# Test-only HMAC signing key (community resolver reads AVERNET_SECRET_<NAME>_VALUE).
+AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE=gateway-test-signing-key-not-for-prod

--- a/scripts/k8s-tests/avernet/proxy.env
+++ b/scripts/k8s-tests/avernet/proxy.env
@@ -1,0 +1,9 @@
+# avernet/proxy.env — proxy env for the shared avernet demo stack.
+# In-cluster: the relay baas client reaches the `baas` Service over DNS.
+SERVER_ENV=prod
+SANDBOXPROXY_PORT=8888
+# Test-only JWT secret (community reads it from config/env overlay).
+SANDBOXPROXY_JWT_SECRET=proxy-test-secret-not-for-prod
+# Relay client (`baas`) target — reach the shared `baas` service in-cluster.
+SANDBOXPROXY_BAAS_HOST=http://baas:8888
+SANDBOXPROXY_TECLAW_HOST=http://teclaw.internal.example

--- a/scripts/k8s-tests/avernet/shared-infra.yaml
+++ b/scripts/k8s-tests/avernet/shared-infra.yaml
@@ -1,0 +1,105 @@
+# shared-infra.yaml — Shared MariaDB + Redis for the avernet k8s-tests demo.
+#
+# Deployed into the same namespace as the baas/gateway/proxy services so they
+# can reach each other over in-cluster Service DNS:
+#   mariadb  -> mariadb:3306
+#   redis    -> redis:6379
+#
+# A single database/user (`avernet`) is provisioned and shared by all services
+# for the demo; each service's avernet env file points at it.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mariadb
+  labels:
+    app: mariadb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mariadb
+  template:
+    metadata:
+      labels:
+        app: mariadb
+    spec:
+      containers:
+      - name: mariadb
+        image: mariadb:11
+        env:
+        - name: MARIADB_ROOT_PASSWORD
+          value: "rootpass"
+        - name: MARIADB_DATABASE
+          value: "avernet"
+        - name: MARIADB_USER
+          value: "avernet"
+        - name: MARIADB_PASSWORD
+          value: "avernetpass"
+        ports:
+        - containerPort: 3306
+        readinessProbe:
+          exec:
+            command: ["healthcheck.sh", "--connect", "--innodb_initialized"]
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mariadb
+  labels:
+    app: mariadb
+spec:
+  type: ClusterIP
+  selector:
+    app: mariadb
+  ports:
+  - name: mysql
+    port: 3306
+    targetPort: 3306
+    protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:7
+        ports:
+        - containerPort: 6379
+        readinessProbe:
+          exec:
+            command: ["redis-cli", "ping"]
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  type: ClusterIP
+  selector:
+    app: redis
+  ports:
+  - name: redis
+    port: 6379
+    targetPort: 6379
+    protocol: TCP

--- a/scripts/k8s-tests/baas/baas.env
+++ b/scripts/k8s-tests/baas/baas.env
@@ -1,0 +1,15 @@
+# baas.env — env vars injected into the k8s deployment via --env-file.
+# One KEY=VALUE per line; '#' starts a comment (see docker/kube-deploy.sh).
+# These are test-only placeholder values mirroring src/baas/docker-test.
+
+SERVER_ENV=prod
+BAAS_PORT=8888
+DATABASE_URL=mysql+aiomysql://baas:baaspass@mariadb:3306/baas_test?charset=utf8mb4
+REDIS_URL=redis://redis:6379/0
+# prod overlay references these under strict env expansion; inject test values
+# so config loading succeeds (aliyun_ack sandbox is a lazy factory, never
+# contacted during boot/health).
+ACK_SERVER=https://ack-test.example.com
+ACK_TOKEN=ack-test-token
+DEFAULT_IMAGE=openclaw:latest
+DEPLOY_ENV=prod

--- a/scripts/k8s-tests/baas/test-k8s-baas.sh
+++ b/scripts/k8s-tests/baas/test-k8s-baas.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# scripts/k8s-tests/baas/test-k8s-baas.sh — build the baas image and demo its
+# deployment to Kubernetes.
+#
+# Flow (reusing docker/ shared tooling):
+#   1. Build baas:local from docker/services/baas.dockerfile
+#      (docker/build-image.sh)
+#   2. Deploy to Kubernetes via docker/kube-deploy.sh (renders + applies
+#      docker/services/service-deployment.yaml)
+#   3. Wait for the deployment rollout, port-forward the ClusterIP service,
+#      and probe /health
+#
+# Usage:
+#   scripts/k8s-tests/baas/test-k8s-baas.sh            # build + deploy + health check
+#   scripts/k8s-tests/baas/test-k8s-baas.sh up         # same as above
+#   scripts/k8s-tests/baas/test-k8s-baas.sh build      # only rebuild baas:local
+#   scripts/k8s-tests/baas/test-k8s-baas.sh down       # delete deployment + service
+#   scripts/k8s-tests/baas/test-k8s-baas.sh status     # show k8s resources
+#
+# Prerequisites:
+#   - kubectl on PATH, authenticated to a reachable cluster
+#   - the baas:local image available in the cluster's pull context
+#     (for remote clusters, build+push first, then set IMAGE accordingly)
+#
+# Configuration (all overridable via environment):
+#   NAMESPACE   (default avernet), PORT (default 8888), IMAGE (default baas),
+#   IMAGE_TAG (default local), ENV_FILE (default baas.env next to this script),
+#   HOST_PORT (port-forward local port, default 18080), HEALTH_WAIT_SECS.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/.."
+
+# shellcheck source=../k8s-test-lib.sh
+source "${LIB_DIR}/k8s-test-lib.sh"
+
+export NAMESPACE="${NAMESPACE:-avernet}"
+export PORT="${PORT:-8888}"
+export ENV_FILE="${ENV_FILE:-${SCRIPT_DIR}/baas.env}"
+
+run_k8s_test "baas" "services/baas.dockerfile" "${1:-up}"

--- a/scripts/k8s-tests/gateway/gateway.env
+++ b/scripts/k8s-tests/gateway/gateway.env
@@ -1,0 +1,15 @@
+# gateway.env — env vars injected into the k8s deployment via --env-file.
+# One KEY=VALUE per line; '#' starts a comment (see docker/kube-deploy.sh).
+# These are test-only placeholder values mirroring src/gateway/docker-test.
+
+SERVER_ENV=prod
+GATEWAY_PORT=8888
+DATABASE_URL=mysql+aiomysql://gateway:gatewaypass@mariadb:3306/gateway_test?charset=utf8mb4
+REDIS_URL=redis://redis:6379/0
+BACKEND_SERVER_URL=https://backend.avernet.com
+BAAS_SERVER_URL=https://baas.avernet.com
+BCS_SERVER_URL=https://bcs.avernet.com
+ENGINE_PROXY_SERVER_URL=https://engineproxy.avernet.com
+BCSFUSE_SERVER_URL=https://bcsfuse.avernet.com
+# Test-only HMAC signing key (community resolver reads AVERNET_SECRET_<NAME>_VALUE).
+AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE=gateway-test-signing-key-not-for-prod

--- a/scripts/k8s-tests/gateway/test-k8s-gateway.sh
+++ b/scripts/k8s-tests/gateway/test-k8s-gateway.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# scripts/k8s-tests/gateway/test-k8s-gateway.sh — build the gateway image and
+# demo its deployment to Kubernetes.
+#
+# Flow (reusing docker/ shared tooling):
+#   1. Build gateway:local from docker/services/gateway.dockerfile
+#      (docker/build-image.sh)
+#   2. Deploy to Kubernetes via docker/kube-deploy.sh (renders + applies
+#      docker/services/service-deployment.yaml)
+#   3. Wait for the deployment rollout, port-forward the ClusterIP service,
+#      and probe /health
+#
+# Usage:
+#   scripts/k8s-tests/gateway/test-k8s-gateway.sh            # build + deploy + health check
+#   scripts/k8s-tests/gateway/test-k8s-gateway.sh up         # same as above
+#   scripts/k8s-tests/gateway/test-k8s-gateway.sh build      # only rebuild gateway:local
+#   scripts/k8s-tests/gateway/test-k8s-gateway.sh down       # delete deployment + service
+#   scripts/k8s-tests/gateway/test-k8s-gateway.sh status     # show k8s resources
+#
+# Prerequisites:
+#   - kubectl on PATH, authenticated to a reachable cluster
+#   - the gateway:local image available in the cluster's pull context
+#     (for remote clusters, build+push first, then set IMAGE accordingly)
+#
+# Configuration (all overridable via environment):
+#   NAMESPACE   (default avernet), PORT (default 8888), IMAGE (default gateway),
+#   IMAGE_TAG (default local), ENV_FILE (default gateway.env next to this script),
+#   HOST_PORT (port-forward local port, default 18080), HEALTH_WAIT_SECS.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/.."
+
+# shellcheck source=../k8s-test-lib.sh
+source "${LIB_DIR}/k8s-test-lib.sh"
+
+export NAMESPACE="${NAMESPACE:-avernet}"
+export PORT="${PORT:-8888}"
+export ENV_FILE="${ENV_FILE:-${SCRIPT_DIR}/gateway.env}"
+
+run_k8s_test "gateway" "services/gateway.dockerfile" "${1:-up}"

--- a/scripts/k8s-tests/justfile
+++ b/scripts/k8s-tests/justfile
@@ -1,0 +1,107 @@
+#!/usr/bin/env just --justfile
+
+# ── Kubernetes deployment demo tests ─────────────────────────────────────
+#
+# Exercises the per-service k8s deploy scripts under scripts/k8s-tests/ and
+# the combined `avernet` stack. Each recipe shells out to the corresponding
+# script; prerequisites (kubectl reaching a cluster, docker) match the scripts.
+
+# Per-service scripts (relative to this justfile).
+baas-script := 'baas/test-k8s-baas.sh'
+gateway-script := 'gateway/test-k8s-gateway.sh'
+proxy-script := 'proxy/test-k8s-proxy.sh'
+avernet-script := 'avernet/deploy-avernet.sh'
+
+_default:
+    @just --list --list-prefix '==> '
+
+# ── Individual services ───────────────────────────────────────────────────
+
+# Build + deploy baas to k8s and wait for /health. Pass extra args (build/down/status).
+k8s-baas *args='':
+    @./{{baas-script}} {{args}}
+
+# Build only the baas image.
+k8s-baas-build:
+    @./{{baas-script}} build
+
+# Deploy baas and wait for /health.
+k8s-baas-up:
+    @./{{baas-script}} up
+
+# Tear down baas from k8s.
+k8s-baas-down:
+    @./{{baas-script}} down
+
+# Build + deploy gateway to k8s and wait for /health.
+k8s-gateway *args='':
+    @./{{gateway-script}} {{args}}
+
+# Build only the gateway image.
+k8s-gateway-build:
+    @./{{gateway-script}} build
+
+# Deploy gateway and wait for /health.
+k8s-gateway-up:
+    @./{{gateway-script}} up
+
+# Tear down gateway from k8s.
+k8s-gateway-down:
+    @./{{gateway-script}} down
+
+# Build + deploy proxy to k8s and wait for /health.
+k8s-proxy *args='':
+    @./{{proxy-script}} {{args}}
+
+# Build only the proxy image.
+k8s-proxy-build:
+    @./{{proxy-script}} build
+
+# Deploy proxy and wait for /health.
+k8s-proxy-up:
+    @./{{proxy-script}} up
+
+# Tear down proxy from k8s.
+k8s-proxy-down:
+    @./{{proxy-script}} down
+
+# ── Combined avernet stack (all services + shared mariadb/redis) ─────────
+
+# Build all images, apply shared infra, deploy all services, wait healthy.
+k8s-avernet *args='':
+    @./{{avernet-script}} {{args}}
+
+# Bring up the full avernet stack (build + infra + services + health).
+k8s-avernet-up:
+    @./{{avernet-script}} up
+
+# Build the three service images only.
+k8s-avernet-build:
+    @./{{avernet-script}} build
+
+# Apply/refresh the shared MariaDB + Redis only.
+k8s-avernet-infra:
+    @./{{avernet-script}} infra
+
+# Deploy the three app services only (assumes infra is up).
+k8s-avernet-services:
+    @./{{avernet-script}} services
+
+# Tear down the full avernet stack (services + shared infra).
+k8s-avernet-down:
+    @./{{avernet-script}} down
+
+# Show avernet resources.
+k8s-avernet-status:
+    @./{{avernet-script}} status
+
+# ── Everything ────────────────────────────────────────────────────────────
+
+# Build all three service images (no cluster needed).
+k8s-test-all-build: k8s-baas-build k8s-gateway-build k8s-proxy-build
+
+# Bring up the full avernet stack and wait for every service's /health.
+k8s-test-all: k8s-avernet-up
+
+# Tear everything down.
+k8s-test-all-down: k8s-avernet-down

--- a/scripts/k8s-tests/k8s-test-lib.sh
+++ b/scripts/k8s-tests/k8s-test-lib.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# scripts/k8s-tests/k8s-test-lib.sh — shared helpers for k8s deployment demo tests.
+#
+# This is NOT meant to be executed directly. It is sourced by the per-service
+# scripts under scripts/k8s-tests/<service>/test-k8s-<service>.sh and exposes a
+# single parameterized entrypoint `run_k8s_test` plus supporting functions.
+#
+# Reused shared tooling (do not re-implement these):
+#   docker/build-image.sh  — builds <service>:local from a dockerfile
+#   docker/kube-deploy.sh  — renders + applies service-deployment.yaml
+#
+# Configuration (all overridable via environment):
+#   NAMESPACE   — Kubernetes namespace (default: avernet)
+#   PORT        — container listen port (default: 8888, matching the
+#                 dockerfiles; overrides kube-deploy.sh's stale 80 default)
+#   IMAGE       — image reference (default: <service>:local)
+#   IMAGE_TAG   — image tag (default: local)
+#   ENV_FILE    — path to a KEY=VALUE env file passed via --env-file (optional)
+#   HOST_PORT   — local port for the port-forward health probe (default: 18080)
+#   HEALTH_WAIT_SECS — max seconds to wait for the deployment to roll out
+#                      and /health to respond (default: 120)
+
+set -euo pipefail
+
+# Locate repo root relative to this file (scripts/k8s-tests/k8s-test-lib.sh).
+K8S_TEST_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export K8S_TEST_REPO_ROOT="$(cd "${K8S_TEST_LIB_DIR}/../.." && pwd)"
+export K8S_TEST_BUILD_IMAGE="${K8S_TEST_REPO_ROOT}/docker/build-image.sh"
+export K8S_TEST_DEPLOY="${K8S_TEST_REPO_ROOT}/docker/kube-deploy.sh"
+
+log() { printf "\n==> %s\n" "$*"; }
+
+# Require kubectl, failing clearly when a cluster is unreachable.
+require_kubectl() {
+  command -v kubectl >/dev/null 2>&1 || {
+    echo "error: kubectl not found on PATH" >&2
+    exit 1
+  }
+  if ! kubectl cluster-info >/dev/null 2>&1; then
+    echo "error: kubectl cannot reach a cluster; configure kubeconfig first" >&2
+    exit 1
+  fi
+}
+
+# Build the service image via docker/build-image.sh.
+build_image() {
+  local service="$1"
+  local dockerfile="$2"   # e.g. services/baas.dockerfile
+  local image="${IMAGE:-${service}}"
+  local tag="${IMAGE_TAG:-local}"
+  log "building ${image}:${tag} from ${dockerfile}"
+  "${K8S_TEST_BUILD_IMAGE}" "${dockerfile}" --image "${image}" --tag "${tag}"
+}
+
+# Export the k8s resource spec for the deploy. Defaults to a small demo
+# footprint (1 replica, modest CPU/memory) so the stack schedules on a local
+# single-node cluster; each is overridable via the same-named env var.
+#   REPLICAS, CPU_REQUEST, CPU_LIMIT, MEMORY_REQUEST, MEMORY_LIMIT
+export_resources() {
+  export REPLICAS="${REPLICAS:-1}"
+  export CPU_REQUEST="${CPU_REQUEST:-250m}"
+  export CPU_LIMIT="${CPU_LIMIT:-500m}"
+  export MEMORY_REQUEST="${MEMORY_REQUEST:-256Mi}"
+  export MEMORY_LIMIT="${MEMORY_LIMIT:-512Mi}"
+}
+
+# Deploy the service via docker/kube-deploy.sh.
+deploy() {
+  local service="$1"
+  local namespace="${NAMESPACE:-avernet}"
+  local port="${PORT:-8888}"
+  local image="${IMAGE:-${service}}:${IMAGE_TAG:-local}"
+  local args=(--service "${service}" --image "${image}" --namespace "${namespace}")
+  if [[ -n "${ENV_FILE:-}" ]]; then
+    [[ -f "${ENV_FILE}" ]] || { echo "error: env file not found: ${ENV_FILE}" >&2; exit 2; }
+    args+=(--env-file "${ENV_FILE}")
+  fi
+  log "deploying ${service} to namespace ${namespace} (image ${image}, port ${port})"
+  export_resources
+  PORT="${port}" "${K8S_TEST_DEPLOY}" "${args[@]}" --apply
+}
+
+# Wait for the deployment to become available, then probe /health via a
+# background kubectl port-forward (the service is ClusterIP).
+wait_healthy() {
+  local service="$1"
+  local namespace="${NAMESPACE:-avernet}"
+  local port="${PORT:-8888}"
+  local host_port="${HOST_PORT:-18080}"
+  local max="${HEALTH_WAIT_SECS:-120}"
+
+  log "waiting for rollout of deployment/${service} (up to ${max}s)"
+  if ! kubectl -n "${namespace}" rollout status "deployment/${service}" \
+      --timeout="${max}s" >/dev/null 2>&1; then
+    echo "error: deployment/${service} did not become ready" >&2
+    kubectl -n "${namespace}" get pods -l "app=${service}" >&2
+    return 1
+  fi
+
+  log "port-forwarding svc/${service}:${port} -> 127.0.0.1:${host_port}"
+  kubectl -n "${namespace}" port-forward "svc/${service}" "${host_port}:${port}" \
+      >/dev/null 2>&1 &
+  local pf_pid=$!
+  trap 'kill "${pf_pid:-}" 2>/dev/null || true' RETURN
+
+  local url="http://127.0.0.1:${host_port}/health"
+  local i=0
+  log "waiting for /health at ${url}"
+  until curl -fsS "${url}" >/dev/null 2>&1; do
+    i=$((i + 1))
+    if [[ "${i}" -ge "${max}" ]]; then
+      echo "error: ${service} /health did not respond within ${max}s" >&2
+      kubectl -n "${namespace}" logs "deployment/${service}" --tail 40 >&2 || true
+      return 1
+    fi
+    sleep 1
+  done
+  printf "\n==> %s healthy: " "${service}"
+  curl -fsS "${url}"
+  printf "\n"
+}
+
+# Tear down the deployment + service resources.
+teardown() {
+  local service="$1"
+  local namespace="${NAMESPACE:-avernet}"
+  local manifest
+  log "deleting deployment, service, and namespace-owned resources for ${service}"
+  kubectl -n "${namespace}" delete deployment "${service}" --ignore-not-found
+  kubectl -n "${namespace}" delete service "${service}" --ignore-not-found
+}
+
+# Report k8s resource state and current /health result.
+status() {
+  local service="$1"
+  local namespace="${NAMESPACE:-avernet}"
+  log "resources for ${service} in namespace ${namespace}"
+  kubectl -n "${namespace}" get all -l "app=${service}" || true
+}
+
+# Entry point: run_k8s_test <service> <dockerfile> <subcommand>.
+#   <subcommand> is one of build|up|down|status (default up).
+run_k8s_test() {
+  local service="$1"
+  local dockerfile="$2"
+  local sub="${3:-up}"
+
+  case "${sub}" in
+    build)  build_image "${service}" "${dockerfile}" ;;
+    up)     build_image "${service}" "${dockerfile}"
+            require_kubectl
+            deploy "${service}"
+            wait_healthy "${service}" ;;
+    down)   require_kubectl
+            teardown "${service}" ;;
+    status) require_kubectl
+            status "${service}" ;;
+    *)
+      echo "usage: $0 {build|up|down|status}" >&2
+      exit 2 ;;
+  esac
+}

--- a/scripts/k8s-tests/proxy/proxy.env
+++ b/scripts/k8s-tests/proxy/proxy.env
@@ -1,0 +1,8 @@
+# proxy.env — env vars injected into the k8s deployment via --env-file.
+# One KEY=VALUE per line; '#' starts a comment (see docker/kube-deploy.sh).
+# These are test-only placeholder values mirroring src/proxy/docker-test.
+
+SERVER_ENV=prod
+SANDBOXPROXY_PORT=8888
+# Test-only JWT secret (community reads it from config/env overlay).
+SANDBOXPROXY_JWT_SECRET=proxy-test-secret-not-for-prod

--- a/scripts/k8s-tests/proxy/test-k8s-proxy.sh
+++ b/scripts/k8s-tests/proxy/test-k8s-proxy.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# scripts/k8s-tests/proxy/test-k8s-proxy.sh — build the proxy image and demo its
+# deployment to Kubernetes.
+#
+# Flow (reusing docker/ shared tooling):
+#   1. Build proxy:local from docker/services/proxy.dockerfile
+#      (docker/build-image.sh)
+#   2. Deploy to Kubernetes via docker/kube-deploy.sh (renders + applies
+#      docker/services/service-deployment.yaml)
+#   3. Wait for the deployment rollout, port-forward the ClusterIP service,
+#      and probe /health
+#
+# Usage:
+#   scripts/k8s-tests/proxy/test-k8s-proxy.sh            # build + deploy + health check
+#   scripts/k8s-tests/proxy/test-k8s-proxy.sh up         # same as above
+#   scripts/k8s-tests/proxy/test-k8s-proxy.sh build      # only rebuild proxy:local
+#   scripts/k8s-tests/proxy/test-k8s-proxy.sh down       # delete deployment + service
+#   scripts/k8s-tests/proxy/test-k8s-proxy.sh status     # show k8s resources
+#
+# Prerequisites:
+#   - kubectl on PATH, authenticated to a reachable cluster
+#   - the proxy:local image available in the cluster's pull context
+#     (for remote clusters, build+push first, then set IMAGE accordingly)
+#
+# Configuration (all overridable via environment):
+#   NAMESPACE   (default avernet), PORT (default 8888), IMAGE (default proxy),
+#   IMAGE_TAG (default local), ENV_FILE (default proxy.env next to this script),
+#   HOST_PORT (port-forward local port, default 18080), HEALTH_WAIT_SECS.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="${SCRIPT_DIR}/.."
+
+# shellcheck source=../k8s-test-lib.sh
+source "${LIB_DIR}/k8s-test-lib.sh"
+
+export NAMESPACE="${NAMESPACE:-avernet}"
+export PORT="${PORT:-8888}"
+export ENV_FILE="${ENV_FILE:-${SCRIPT_DIR}/proxy.env}"
+
+run_k8s_test "proxy" "services/proxy.dockerfile" "${1:-up}"

--- a/src/baas/configs/application-prod.yaml
+++ b/src/baas/configs/application-prod.yaml
@@ -15,11 +15,11 @@ module_config:
 user_config:
   # 插件配置
   plugins:
-    auth: "stub"
+    auth: "oauth"
     secret: "env"
     cache: "redis"
-    bot_service: "stub"
-    engine_adapter: "stub"
+    bot_service: "real"
+    engine_adapter: "real"
     file_transfer: "stub"
     database: "mariadb"
     sandbox:
@@ -58,8 +58,8 @@ user_config:
       nas-server: "${NAS_SERVER}"
 
   bot_service:
-    proxy_base_url: "https://bot_service.example.com"
-    proxy_ws_base_url: "wss://bot_service.example.com"
+    proxy_base_url: "${BOT_SERVICE_PROXY_BASE_URL:-https://backend.avernet-inc.com}"
+    proxy_ws_base_url: "${BOT_SERVICE_PROXY_WS_BASE_URL:-wss://backend.avernet-inc.com}"
     adapter_port: 20003
     ws_path: "/api/openclaw/ws"
     connect_timeout: 10
@@ -79,12 +79,12 @@ user_config:
     enabled: false                    # 是否启用队列 Worker
 
   teamclaw:
-    base_url: "https://teamclaw.example.com"
+    base_url: "${TEAMCLAW_BASE_URL:-https://teamclaw.example.com}"
     timeout: 30
 
   # OAuth 客户端配置
   oauth:
-    base_url: "https://oauth.example.com"
+    base_url: "${OAUTH_BASE_URL:-https://oauth.example.com}"
 
   # 设备 TTL 定时器配置（每 30 分钟扫描整个到期队列并续期+探活）
   device_ttl_timer:
@@ -124,21 +124,21 @@ user_config:
       target_ttl_hours: 24             # 续期目标 TTL（小时）
 
   bot_chat_log_relation:
-    base_url: "https://backend.example.com"
+    base_url: "${BOT_CHAT_LOG_RELATION_BASE_URL:-https://backend.avernet-inc.com}"
     timeout: 10
     max_retries: 0
 
   agentclawproxy:
     host:
-      dev: "agentclawproxy-dev.example.com"
-      pre: "agentclawproxy-pre.example.com"
-      prod: "agentclawproxy-prod.example.com"
+      dev: "${PROXY_HOST_DEV:-proxy-dev.avernet-inc.com}"
+      pre: "${PROXY_HOST_PRE:-proxy-pre.avernet-inc.com}"
+      prod: "${PROXY_HOST_PROD:-proxy.avernet-inc.com}"
 
   poolab:
     endpoint:
-      dev: "https://poolab-dev.example.com"
-      pre: "https://poolab-pre.example.com"
-      prod: "https://poolab-prod.example.com"
+      dev: "${POOLAB_ENDPOINT_DEV:-https://poolab-dev.example.com}"
+      pre: "${POOLAB_ENDPOINT_PRE:-https://poolab-pre.example.com}"
+      prod: "${POOLAB_ENDPOINT_PROD:-https://poolab-prod.example.com}"
 
 # File transfer OSS storage backend configuration (enterprise/prod deployments only)
   file_transfer_oss:
@@ -151,9 +151,9 @@ user_config:
   secbaas:
     callback:
       host:
-        dev: "https://secbaas-dev.example.com"
-        pre: "https://secbaas-pre.example.com"
-        prod: "https://secbaas-prod.example.com"
+        dev: "${BAAS_CALLBACK_HOST_DEV:-https://baas-dev.avernet-inc.com}"
+        pre: "${BAAS_CALLBACK_HOST_PRE:-https://baas-pre.avernet-inc.com}"
+        prod: "${BAAS_CALLBACK_HOST_PROD:-https://baas.avernet-inc.com}"
 
   api_gateway:
     admin_operators:
@@ -164,4 +164,4 @@ user_config:
 
   env:
     # 用于探测当前部署环境的环境变量名称
-    deploy_env_var: "ALI_YUN_ACK"
+    deploy_env_var: "DEPLOY_ENV"

--- a/src/proxy/configs/application-prod.yaml
+++ b/src/proxy/configs/application-prod.yaml
@@ -1,0 +1,19 @@
+# Proxy production overlay — env-driven host overrides for deployed editions.
+# Loaded on top of application.yaml when SERVER_ENV=prod (see
+# sandboxproxy.community.config._config_loader.ConfigLoader).
+#
+# Hosts that point at in-cluster or environment-specific endpoints are
+# parameterized as ${NAME:-default} so a deployment sets them via env without
+# editing this file. Defaults mirror the community placeholders in
+# application.yaml; a k8s deployment overrides them to Service DNS (e.g.
+# SANDBOXPROXY_BAAS_HOST=http://baas:8888).
+
+user_config:
+  aliyun_ack_cluster:
+    api_server: ${ALIYUN_ACK_API_SERVER:-https://ack.avernet-inc.com}
+
+  baas:
+    host: ${SANDBOXPROXY_BAAS_HOST:-http://baas.avernet-inc.com}
+
+  teclaw:
+    host: ${SANDBOXPROXY_TECLAW_HOST:-http://teclaw.avernet-inc.com}


### PR DESCRIPTION
Add a self-managed MariaDB backend to the community gateway, mirroring the
baas MariaDB plugin pattern.

- Add MARIADB_ORM to PluginDatabaseType and wire it into the database
  providers.Selector.
- Add MariaDbOrmPlugin under community/plugins/database/mariadb implementing
  the DataSourcePlugin SPI with mysql+aiomysql (async) and mysqlconnector
  (sync) drivers.
- Extend DatabasePluginConfig with structured mariadb_* settings and env
  overrides.
- Add e2e-mariadb test overlay and runtime deps (aiomysql,
  mysql-connector-python).
- Add unit + SPI contract + E2E tests; MariaDB tests skip without a live DB.