### PR TITLE
fix(backend): keep edit action for bot collaborators on /bots/all cards

### DIFF
--- a/src/backend/specs/2026-08-25-bot-inventory-edit-member-level/design.md
+++ b/src/backend/specs/2026-08-25-bot-inventory-edit-member-level/design.md
@@ -1,0 +1,70 @@
+# `/bots/all` 卡片 `edit` 动作对 MEMBER 放行设计
+
+- **日期**：2026-08-25
+- **状态**：待评审
+- **范围**：Backend OpenAPI Bot Inventory（`GET /openapi/v1/bots/all`）卡片动作收缩
+- **目标分支**：`dev`
+
+## 1. 背景与证据
+
+`/all` 卡片的 `actions` 收缩（`BotInventoryService._actions_for_level`）现状：非 service 卡的
+**非 OWNER**（含 ADMIN/MEMBER/NONE）一律只保留 `view`，其余动作 disabled
+（"Bot editor permission required"）。
+
+这与同一代码库里三处既有语义冲突：
+
+| 机制 | 语义 | 位置 |
+| --- | --- | --- |
+| `PermissionLevel.MEMBER` 的定义 | **"仅可编辑内容"** | `bot_collaborator/models.py:44` |
+| skill / skill-sets 端点门禁 | `Check/ServiceChecked(PermissionLevel.MEMBER)`——协作者可增删技能 | `openapi_v1/authorization.py:319-347` |
+| 老内部接口 `can_edit_bot` | owner-or-collaborator 列表内非 service bot 恒 `True` | `bot_service.py:2494`、`bot_publish_service.py:863` |
+
+后果：前端若按卡片 `actions.edit` 渲染"技能集管理"入口，MEMBER/ADMIN 协作者会被卡片
+误导为无权限，端点实际却允许——"按 actions 渲染"这一卡片区设计承诺失效。
+
+## 2. 决策
+
+非 service 卡的非 OWNER 分支：`level >= MEMBER` 时**保留 `EDIT`**：
+
+```text
+kept = [EDIT]  当且仅当 level >= MEMBER
+actions_out = (VIEW, *kept)
+其余动作（restart/delete/data_init/passport 等 owner 型）disabled 逻辑与文案不变
+```
+
+- NONE：行为不变（仅 view；disabled 文案沿用 "Bot editor permission required"）。
+- OWNER：不变（全额动作）。
+- SERVICE 卡：不受影响（原本 MEMBER+ 即保留除 DELETE 外动作，仅重述既有语义）。
+- disabled 文案本轮不动；对 MEMBER 级 owner 型动作的文案精确化
+  （"Bot Owner permission required"）留作可选后续，避免联动 service-viewer 断言。
+
+卡片与端点的动作-门禁对应（修正后）：
+
+| 卡片动作 | 收缩档位 | 对应端点门禁 |
+| --- | --- | --- |
+| `edit` | MEMBER+ | skills/skill-sets 族 `Check(MEMBER)` |
+| `restart` / `delete` / `data_init` 等 | OWNER+ | `/restart` `PUT /{bot_id}` `DELETE /{bot_id}` 均 OWNER_SCOPED |
+
+## 3. 影响评估
+
+- 老内部路径零影响：`BotInventoryService` 全仓唯一消费方是 `/all` 端点；
+  `/api/bots/*`（含 `can_edit_bot`）不经此实现。
+- 公开 schema 零变化：`edit` 已在 `BotAction` 枚举，响应属 additive（actions 数组多一个值）。
+- 无数据库、无配置、无内部 API 变化。
+- `/all` 响应变化仅一处：MEMBER/ADMIN 级非 service 卡 `actions` 增加 `edit`，
+  `disabled` 减少对应项（补齐与技能能力的对齐）。
+
+## 4. 测试
+
+- 更新 `tests/community/core/bot_inventory/services/test_bot_inventory_service.py`：
+  非 service 卡 member-editor → `(VIEW, EDIT)`；viewer（NONE）→ 仅 view 不变；
+  owner 不变；service 卡断言全部不变。
+- 路由层回归：`tests/community/adapters/http/openapi_v1/inventory/`、
+  bot_management 全量与 architecture 不回归。
+
+## 5. 验收标准
+
+- [ ] MEMBER/ADMIN 协作者的非 service 卡含 `edit`；NONE 不变。
+- [ ] service 卡、OWNER 卡行为不变。
+- [ ] disabled 文案与既有断言不漂移。
+- [ ] 上述测试与架构测试全绿。

--- a/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
@@ -361,10 +361,20 @@ class BotInventoryService:
                     BotAction.DELETE.value, "Bot Owner permission required"
                 )
             return allowed, disabled
+        # MEMBER is defined as "edit content only": editing (skills/skill-sets,
+        # whose endpoints gate on PermissionLevel.MEMBER) stays available to
+        # collaborators on every card kind, while the owner-scoped actions
+        # (restart/delete/update...) remain disabled. NONE keeps view-only.
+        kept = [
+            action
+            for action in actions
+            if action is BotAction.EDIT and level >= PermissionLevel.MEMBER
+        ]
         for action in actions:
-            if action is not BotAction.VIEW:
-                disabled.setdefault(action.value, "Bot editor permission required")
-        return (BotAction.VIEW,), disabled
+            if action is BotAction.VIEW or action in kept:
+                continue
+            disabled.setdefault(action.value, "Bot editor permission required")
+        return (BotAction.VIEW, *kept), disabled
 
 
 def _as_mapping(value: Any) -> Mapping[str, Any]:

--- a/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
+++ b/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
@@ -24,6 +24,7 @@ from agentclaw.community.core.bot_inventory.services.lifecycle_view import (
 )
 from agentclaw.community.core.bot_inventory.types import (
     BotAction,
+    BotInventoryKind,
     BusinessSpaceRef,
     DeployMode,
     DisplayState,
@@ -441,3 +442,46 @@ def test_team_space_lists_all_owners_and_scopes_actions_by_bot_permission() -> N
         "delete": "Bot editor permission required",
     }
     assert all(item.space == team_space for item in items)
+
+
+def test_actions_for_level_keeps_edit_for_non_service_editors() -> None:
+    """Non-service cards: collaborators (MEMBER/ADMIN) keep the edit action —
+    the skills/skill-sets endpoints gate on PermissionLevel.MEMBER — while
+    owner-scoped actions stay disabled; NONE is view-only; OWNER is unchanged.
+    """
+    actions = (BotAction.VIEW, BotAction.EDIT, BotAction.RESTART, BotAction.DELETE)
+
+    owner_actions, owner_disabled = BotInventoryService._actions_for_level(
+        kind=BotInventoryKind.PERSONAL_CLOUD,
+        actions=actions,
+        disabled={},
+        level=PermissionLevel.OWNER,
+    )
+    assert owner_actions == actions
+    assert owner_disabled == {}
+
+    for level in (PermissionLevel.MEMBER, PermissionLevel.ADMIN):
+        kept_actions, disabled = BotInventoryService._actions_for_level(
+            kind=BotInventoryKind.PERSONAL_CLOUD,
+            actions=actions,
+            disabled={},
+            level=level,
+        )
+        assert kept_actions == (BotAction.VIEW, BotAction.EDIT)
+        assert disabled == {
+            "restart": "Bot editor permission required",
+            "delete": "Bot editor permission required",
+        }
+
+    none_actions, none_disabled = BotInventoryService._actions_for_level(
+        kind=BotInventoryKind.PERSONAL_CLOUD,
+        actions=actions,
+        disabled={},
+        level=PermissionLevel.NONE,
+    )
+    assert none_actions == (BotAction.VIEW,)
+    assert none_disabled == {
+        "edit": "Bot editor permission required",
+        "restart": "Bot editor permission required",
+        "delete": "Bot editor permission required",
+    }


### PR DESCRIPTION
## Problem

The `/bots/all` card shrink (`BotInventoryService._actions_for_level`) left **non-service cards view-only for every non-OWNER level**, including MEMBER/ADMIN collaborators. That contradicts three existing semantics in the same codebase:

- `PermissionLevel.MEMBER` is defined as "edit content only" (`bot_collaborator/models.py`);
- the skills / skill-sets endpoints gate on `Check(PermissionLevel.MEMBER)` — a MEMBER collaborator **can** add skill sets;
- the internal `can_edit_bot` keeps collaborators editable on the legacy list.

A frontend keying the skill-management entry off card `actions.edit` would hide it from collaborators the endpoint would authorize — the "render by actions" card contract was broken for exactly the audience that needs it.

## Solution

In `_actions_for_level`'s non-OWNER, non-service branch: keep `EDIT` for `level >= MEMBER`. Owner-scoped actions (restart/delete/…) stay disabled with the existing wording; NONE stays view-only; service cards, OWNER cards, and the public schema (EDIT was already in the `BotAction` enum) are unchanged — the response change is purely additive (`actions` may include `edit`).

Impact assessment (in the spec): `BotInventoryService` has exactly one consumer (the `/all` endpoint) — internal `/api/bots/*` paths, including `can_edit_bot`, do not pass through this code. No DB, config, or schema change.

## Validation

- `uv run pytest tests/community/core/bot_inventory tests/community/adapters/http/openapi_v1/inventory tests/community/core/bot_collaborator tests/community/architecture` — **448 passed** (no existing assertion pinned the old shrink; added a level-matrix regression test: MEMBER/ADMIN → `view+edit`, NONE → view-only, OWNER → unchanged).
- `scripts/ci/python_sast_local.sh src/backend` — changed files clean.
- Not run locally: changed-line coverage — left to PR CI.

## Spec

`src/backend/specs/2026-08-25-bot-inventory-edit-member-level/design.md`