### PR TITLE
fix(backend): restore default SkillSet exclusion removals

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
@@ -16,6 +16,7 @@ from agentclaw.community.core.repository.skill_set_control_plane_types import (
 from agentclaw.community.core.skill_center.errors import (
     SkillSetControlPlaneConflictError,
 )
+from agentclaw.community.core.skill_center.orm import DefaultSkillsetMcpExclusion
 from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
 
@@ -111,8 +112,34 @@ class McpSkillSetControlPlaneCommands:
     ) -> SkillSetMutation:
         with self._db.transactional_orm_session() as session:
             row = self._set(session, bot_id=bot_id, owner_id=owner_id, set_id=set_id, engine_type=engine_type, default_engine_types=default_engine_types, locked=True)
-            self._ordinary(row)
             old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
+            if row.is_default:
+                existing = (
+                    session.query(DefaultSkillsetMcpExclusion)
+                    .filter(
+                        DefaultSkillsetMcpExclusion.avernet_tenant
+                        == get_current_avernet_tenant(),
+                        DefaultSkillsetMcpExclusion.user_id == owner_id,
+                        DefaultSkillsetMcpExclusion.bot_id == bot_id,
+                        DefaultSkillsetMcpExclusion.skill_set_id == int(row.id),
+                        DefaultSkillsetMcpExclusion.server_code == server_code,
+                    )
+                    .first()
+                )
+                if existing is not None:
+                    return SkillSetMutation(self._as_item(row), False, old)
+                session.add(
+                    DefaultSkillsetMcpExclusion(
+                        user_id=owner_id,
+                        bot_id=bot_id,
+                        skill_set_id=int(row.id),
+                        server_code=server_code,
+                        avernet_tenant=get_current_avernet_tenant(),
+                    )
+                )
+                session.flush()
+                return SkillSetMutation(self._as_item(row), True, old)
+            self._ordinary(row)
             membership = (
                 self._scope(session.query(SkillSetMCPServer), SkillSetMCPServer)
                 .filter(SkillSetMCPServer.skill_set_id == row.id, SkillSetMCPServer.server_code == server_code)

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_set_control_plane.py
@@ -47,6 +47,10 @@ from agentclaw.community.core.repository.skill_set_control_plane_types import (
     SkillSetDesiredState,
     SkillSetMutation,
 )
+from agentclaw.community.core.skill_center.orm import (
+    DefaultSkillsetMcpExclusion,
+    DefaultSkillsetSkillExclusion,
+)
 from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
@@ -406,7 +410,6 @@ class SkillSetControlPlaneRepository(
                 default_engine_types=default_engine_types,
                 locked=True,
             )
-            self._ordinary(row)
             old = self._snapshot(
                 session, bot_id, owner_id, engine_type=engine_type
             )
@@ -420,6 +423,56 @@ class SkillSetControlPlaneRepository(
             )
             if membership is None:
                 return SkillSetMutation(_item(row), False, old)
+            if row.is_default:
+                existing = (
+                    session.query(DefaultSkillsetSkillExclusion)
+                    .filter(
+                        DefaultSkillsetSkillExclusion.avernet_tenant
+                        == get_current_avernet_tenant(),
+                        DefaultSkillsetSkillExclusion.user_id == owner_id,
+                        DefaultSkillsetSkillExclusion.bot_id == bot_id,
+                        DefaultSkillsetSkillExclusion.skill_set_id == int(row.id),
+                        DefaultSkillsetSkillExclusion.skill_id == int(skill_id),
+                    )
+                    .first()
+                )
+                if existing is not None:
+                    return SkillSetMutation(_item(row), False, old)
+                session.add(
+                    DefaultSkillsetSkillExclusion(
+                        user_id=owner_id,
+                        bot_id=bot_id,
+                        skill_set_id=int(row.id),
+                        skill_id=int(skill_id),
+                        avernet_tenant=get_current_avernet_tenant(),
+                    )
+                )
+                other_active = (
+                    self._scope(session.query(SkillSet), SkillSet)
+                    .join(SkillSetSkill, SkillSetSkill.skill_set_id == SkillSet.id)
+                    .filter(
+                        SkillSet.bolt_id == bot_id,
+                        SkillSet.user_id == owner_id,
+                        SkillSet.is_default.is_(False),
+                        SkillSet.is_active.is_(True),
+                        SkillSetSkill.skill_id == int(skill_id),
+                    )
+                )
+                if engine_type is not None:
+                    other_active = other_active.filter(
+                        SkillSet.engine_type == engine_type
+                    )
+                if other_active.first() is None:
+                    self._scope(
+                        session.query(BotSkillInstallation), BotSkillInstallation
+                    ).filter(
+                        BotSkillInstallation.owner_id == owner_id,
+                        BotSkillInstallation.bot_id == bot_id,
+                        BotSkillInstallation.skill_id == int(skill_id),
+                    ).delete(synchronize_session=False)
+                session.flush()
+                return SkillSetMutation(_item(row), True, old)
+            self._ordinary(row)
             # The difference is what this membership was providing.
             before = self._teardown_ids(session, {int(row.id)})
             session.delete(membership)
@@ -540,7 +593,7 @@ class SkillSetControlPlaneRepository(
         state: SkillSetDesiredState,
         engine_type: str | None = None,
     ) -> None:
-        """Atomically restore Membership, set-state and Installation facts."""
+        """Atomically restore every Bot-owned SkillSet desired-state fact."""
         with self._db.transactional_orm_session() as session:
             query = self._scope(session.query(SkillSet), SkillSet).filter(
                 SkillSet.bolt_id == bot_id,
@@ -624,6 +677,37 @@ class SkillSetControlPlaneRepository(
                         server_code=server_code,
                         env=get_current_env(),
                         avernet_tenant=get_current_avernet_tenant(),
+                    )
+                )
+            tenant = get_current_avernet_tenant()
+            session.query(DefaultSkillsetSkillExclusion).filter(
+                DefaultSkillsetSkillExclusion.avernet_tenant == tenant,
+                DefaultSkillsetSkillExclusion.user_id == owner_id,
+                DefaultSkillsetSkillExclusion.bot_id == bot_id,
+            ).delete(synchronize_session=False)
+            session.query(DefaultSkillsetMcpExclusion).filter(
+                DefaultSkillsetMcpExclusion.avernet_tenant == tenant,
+                DefaultSkillsetMcpExclusion.user_id == owner_id,
+                DefaultSkillsetMcpExclusion.bot_id == bot_id,
+            ).delete(synchronize_session=False)
+            for set_id, skill_id in state.default_skill_exclusions:
+                session.add(
+                    DefaultSkillsetSkillExclusion(
+                        user_id=owner_id,
+                        bot_id=bot_id,
+                        skill_set_id=set_id,
+                        skill_id=skill_id,
+                        avernet_tenant=tenant,
+                    )
+                )
+            for set_id, server_code in state.default_mcp_exclusions:
+                session.add(
+                    DefaultSkillsetMcpExclusion(
+                        user_id=owner_id,
+                        bot_id=bot_id,
+                        skill_set_id=set_id,
+                        server_code=server_code,
+                        avernet_tenant=tenant,
                     )
                 )
             session.flush()
@@ -795,7 +879,7 @@ class SkillSetControlPlaneRepository(
         *,
         engine_type: str | None = None,
     ) -> SkillSetDesiredState:
-        """Lock and capture every ordinary-set desired fact for this Bot."""
+        """Lock and capture every SkillSet desired fact for this Bot."""
         query = self._scope(session.query(SkillSet), SkillSet).filter(
             SkillSet.bolt_id == bot_id,
             SkillSet.user_id == owner_id,
@@ -833,6 +917,29 @@ class SkillSetControlPlaneRepository(
                 mcp_memberships[int(member.skill_set_id)].append(
                     str(member.server_code)
                 )
+        tenant = get_current_avernet_tenant()
+        default_skill_exclusions = {
+            (int(row.skill_set_id), int(row.skill_id))
+            for row in session.query(DefaultSkillsetSkillExclusion)
+            .filter(
+                DefaultSkillsetSkillExclusion.avernet_tenant == tenant,
+                DefaultSkillsetSkillExclusion.user_id == owner_id,
+                DefaultSkillsetSkillExclusion.bot_id == bot_id,
+            )
+            .with_for_update()
+            .all()
+        }
+        default_mcp_exclusions = {
+            (int(row.skill_set_id), str(row.server_code))
+            for row in session.query(DefaultSkillsetMcpExclusion)
+            .filter(
+                DefaultSkillsetMcpExclusion.avernet_tenant == tenant,
+                DefaultSkillsetMcpExclusion.user_id == owner_id,
+                DefaultSkillsetMcpExclusion.bot_id == bot_id,
+            )
+            .with_for_update()
+            .all()
+        }
         return SkillSetDesiredState(
             installations=self._installations(session, bot_id, owner_id),
             set_active={int(row.id): bool(row.is_active) for row in sets},
@@ -841,4 +948,6 @@ class SkillSetControlPlaneRepository(
             mcp_memberships={
                 set_id: tuple(items) for set_id, items in mcp_memberships.items()
             },
+            default_skill_exclusions=default_skill_exclusions,
+            default_mcp_exclusions=default_mcp_exclusions,
         )

--- a/src/backend/src/agentclaw/community/core/repository/skill_set_control_plane_types.py
+++ b/src/backend/src/agentclaw/community/core/repository/skill_set_control_plane_types.py
@@ -12,6 +12,8 @@ class SkillSetDesiredState:
     memberships: dict[int, tuple[tuple[int, str | None, str | None], ...]]
     mcp_installations: set[str] = field(default_factory=set)
     mcp_memberships: dict[int, tuple[str, ...]] = field(default_factory=dict)
+    default_skill_exclusions: set[tuple[int, int]] = field(default_factory=set)
+    default_mcp_exclusions: set[tuple[int, str]] = field(default_factory=set)
 
 
 @dataclass(frozen=True)

--- a/src/backend/tests/community/contracts/gateway/test_rule15_skillsets.py
+++ b/src/backend/tests/community/contracts/gateway/test_rule15_skillsets.py
@@ -114,8 +114,10 @@ def _bind_skillset_deps(app):
     control.delete_set.return_value = None
     control.create_set.return_value = {**MOCK_SKILLSET_ROW, "name": "NewSet"}
     control.update_set.return_value = {**MOCK_SKILLSET_ROW, "name": "Updated"}
+    control.remove_skill = AsyncMock(return_value={"changed": True})
+    control.remove_mcp = AsyncMock(return_value={"changed": True})
     bind_mock_service(SkillSetControlPlaneServiceProtocol, control, app)
-    return mock_factory, mock_passport
+    return mock_factory, mock_passport, control
 
 
 class TestListSkillsets:
@@ -204,7 +206,7 @@ class TestDeleteSkillsetCli:
     """DELETE /api/skillsets/{id}/clis/{resource_code} — 删除默认能力集 CLI。"""
 
     def test_delete_cli_updates_passport_with_remaining_latest_clis(self, gw_client, app_with_testing_modules):
-        _mock_factory, mock_passport = _bind_skillset_deps(app_with_testing_modules)
+        _mock_factory, mock_passport, _control = _bind_skillset_deps(app_with_testing_modules)
 
         resp = gw_client.delete("/api/skillsets/1/clis/cli.delete", params={
             "entity_id": "448524",
@@ -222,4 +224,44 @@ class TestDeleteSkillsetCli:
                 "mcp_codes": ["test-mcp"],
                 "cli_items": [{"cli_code": "cli.keep", "cli_name": "Keep CLI", "cli_desc": "kept"}],
             },
+        )
+
+
+class TestDeleteDefaultMembers:
+    """Default resource removal stays on the shared control-plane seam."""
+
+    def test_delete_default_skill_calls_control_plane_with_owner_scope(
+        self, gw_client, app_with_testing_modules
+    ):
+        _factory, _passport, control = _bind_skillset_deps(app_with_testing_modules)
+        response = gw_client.delete(
+            "/api/skillsets/1/skills/10",
+            params={
+                "user_id": "448524", "entity_id": "448524",
+                "bot_id": "bot_test_001", "engine_type": "openclaw",
+            },
+        )
+
+        assert_success(response.json(), "DELETE default Skill")
+        control.remove_skill.assert_awaited_once_with(
+            bot_id="bot_test_001", owner_id="448524", user_id="448524",
+            set_id="1", skill_id="10",
+        )
+
+    def test_delete_default_mcp_calls_control_plane_with_owner_scope(
+        self, gw_client, app_with_testing_modules
+    ):
+        _factory, _passport, control = _bind_skillset_deps(app_with_testing_modules)
+        response = gw_client.delete(
+            "/api/skillsets/1/mcps/mcp.dynamic-default",
+            params={
+                "entity_id": "448524", "entity_type": "staff",
+                "bot_id": "bot_test_001", "engine_type": "openclaw",
+            },
+        )
+
+        assert_success(response.json(), "DELETE default MCP")
+        control.remove_mcp.assert_awaited_once_with(
+            bot_id="bot_test_001", owner_id="448524", user_id="448524",
+            set_id="1", server_code="mcp.dynamic-default",
         )

--- a/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
@@ -27,10 +27,16 @@ from agentclaw.community.core.repository.protocols.skill_set_control_plane impor
     SkillSetControlPlaneRepositoryProtocol,
 )
 from agentclaw.community.core.skill_center.factories import SkillSetServiceFactory
+from agentclaw.community.core.models.skill import SkillSet, SkillSetSkill
+from agentclaw.community.core.skill_center.orm import (
+    DefaultSkillsetMcpExclusion,
+    DefaultSkillsetSkillExclusion,
+)
 from agentclaw.community.core.skill_center.services.skill_set_control_plane import (
     SkillSetControlPlaneService,
 )
 from agentclaw.community.plugin_api.passport import PassportPlugin
+from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugin_api.mcp_auth import MCPAuthPlugin
 from agentclaw.community.plugin_api.mcp_center import MCPCenterPlugin
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
@@ -183,6 +189,66 @@ def _seed_active(world) -> None:
             active=True,
             engine_type="openclaw",
         )
+
+
+def _seed_default(world) -> None:
+    init_principal_verifier_config(_Resolver(), "test-key", strict=False)
+    with avernet_tenant_scope(_TENANT):
+        world.get(BotRepository).insert({
+            "bot_id": _BOT_ID, "bot_name": "Default SkillSet endpoint Bot",
+            "owner_id": _OWNER, "owner_name": _OWNER, "entity_id": _OWNER,
+            "entity_type": "staff", "creator_id": _OWNER, "status": "ACTIVE",
+            "active_engine": "openclaw",
+        })
+        with world.get(DatabasePlugin).transactional_orm_session() as session:
+            default = SkillSet(
+                name="System Default", user_id="", bolt_id="",
+                engine_type="openclaw", is_default=True, is_active=True,
+                env="dev", avernet_tenant=_TENANT,
+            )
+            session.add(default)
+            session.flush()
+            skill = world.get(SkillRepository).create({
+                "name": "default-endpoint-skill",
+                "description": "Default exclusion endpoint coverage",
+                "git_path": "git://default-endpoint-skill", "category": "general",
+                "tags": "[]", "is_public": True, "source_type": "git",
+            })
+            session.add(SkillSetSkill(
+                skill_set_id=default.id, skill_id=int(skill["id"]), env="dev",
+                avernet_tenant=_TENANT,
+            ))
+    runtime = _Runtime()
+    control_plane = SkillSetControlPlaneService(
+        repository=world.get(SkillSetControlPlaneRepositoryProtocol),
+        bot_repo=world.get(BotRepository), runtime=runtime,
+        legacy_factory=world.get(SkillSetServiceFactory),
+        passport=world.get(PassportPlugin),
+        authorization=world.get(BotCapabilityAuthorizationHookProtocol),
+        audit_log_repo=world.get(BotCollabLogRepositoryProtocol),
+        mcp_center=world.get(MCPCenterPlugin), mcp_auth=world.get(MCPAuthPlugin),
+    )
+    world.injector.binder.bind(
+        SkillSetControlPlaneServiceProtocol, to=control_plane, scope=None
+    )
+
+
+def _assert_default_skill_excluded(_response, world) -> None:
+    with avernet_tenant_scope(_TENANT):
+        with world.get(DatabasePlugin).orm_session() as session:
+            row = session.query(DefaultSkillsetSkillExclusion).one()
+            assert (row.user_id, row.bot_id, row.skill_set_id, row.skill_id) == (
+                _OWNER, _BOT_ID, 1, 1,
+            )
+
+
+def _assert_default_mcp_excluded(_response, world) -> None:
+    with avernet_tenant_scope(_TENANT):
+        with world.get(DatabasePlugin).orm_session() as session:
+            row = session.query(DefaultSkillsetMcpExclusion).one()
+            assert (row.user_id, row.bot_id, row.skill_set_id, row.server_code) == (
+                _OWNER, _BOT_ID, 1, "mcp.dynamic-default",
+            )
 
 
 def _assert_reconciled(_response, world) -> None:
@@ -415,6 +481,17 @@ def remove_member_happy():
 
 
 @_case(
+    "DELETE", "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/skills/{skill_id}",
+    "excludes_default_skill",
+    ExpectSuccess(status=200, json_contains={"data": {"changed": True}}),
+    seed=_seed_default,
+    extra=(_assert_default_skill_excluded, _assert_reconciled),
+)
+def remove_default_member_happy():
+    pass
+
+
+@_case(
     "DELETE",
     "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/skills/{skill_id}",
     "missing_set",
@@ -505,6 +582,21 @@ def add_mcp_error():
 
 @_case("DELETE", "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps/{server_code}", "removes_mcp", ExpectSuccess(status=200, json_contains={"data": {"changed": True}}), seed=_seed_mcp_member)
 def remove_mcp_happy():
+    pass
+
+
+@_case(
+    "DELETE", "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps/{server_code}",
+    "excludes_dynamic_default_mcp",
+    ExpectSuccess(status=200, json_contains={"data": {"changed": True}}),
+    seed=_seed_default,
+    extra=(_assert_default_mcp_excluded, _assert_reconciled),
+    path_params={
+        "bot_id": _BOT_ID, "set_id": "1",
+        "server_code": "mcp.dynamic-default",
+    },
+)
+def remove_default_mcp_happy():
     pass
 
 

--- a/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
@@ -302,6 +302,174 @@ def test_global_default_reads_apply_owner_bot_exclusions_without_hiding_membersh
         bot_id="default", owner_id="owner-b", set_id=str(default.id), engine_type="openclaw"
     )] == ["included", "excluded"]
 
+
+def test_remove_skill_from_global_default_writes_owner_bot_exclusion_only():
+    db = _Database()
+    with db.transactional_orm_session() as session:
+        default = SkillSet(
+            name="system-default", user_id="", bolt_id="", engine_type="openclaw",
+            is_default=True, is_active=True, env="dev",
+        )
+        skill = Skill(name="default-skill", git_path="git://default-skill", env="dev")
+        session.add_all([default, skill])
+        session.flush()
+        session.add_all([
+            SkillSetSkill(skill_set_id=default.id, skill_id=skill.id, env="dev"),
+            BotSkillInstallation(
+                bot_id="bot", owner_id="owner", skill_id=skill.id, env="dev"
+            ),
+        ])
+        set_id, skill_id = str(default.id), str(skill.id)
+
+    repository = SkillSetControlPlaneRepository(db)
+    first = repository.remove_skill(
+        bot_id="bot", owner_id="owner", set_id=set_id, skill_id=skill_id,
+        engine_type="openclaw",
+    )
+    second = repository.remove_skill(
+        bot_id="bot", owner_id="owner", set_id=set_id, skill_id=skill_id,
+        engine_type="openclaw",
+    )
+
+    assert first.changed is True
+    assert second.changed is False
+    with db.orm_session() as session:
+        exclusion = session.query(DefaultSkillsetSkillExclusion).one()
+        assert (
+            exclusion.user_id, exclusion.bot_id,
+            exclusion.skill_set_id, exclusion.skill_id,
+        ) == ("owner", "bot", int(set_id), int(skill_id))
+        assert session.query(SkillSetSkill).count() == 1
+        assert session.query(BotSkillInstallation).count() == 0
+
+
+def test_default_skill_exclusion_preserves_active_ordinary_set_installation():
+    db = _Database()
+    with db.transactional_orm_session() as session:
+        default = SkillSet(
+            name="system-default", user_id="", bolt_id="", engine_type="openclaw",
+            is_default=True, is_active=True, env="dev",
+        )
+        ordinary = SkillSet(
+            name="ordinary", user_id="owner", bolt_id="bot", engine_type="openclaw",
+            is_active=True, env="dev",
+        )
+        skill = Skill(name="shared", git_path="git://shared", env="dev")
+        session.add_all([default, ordinary, skill])
+        session.flush()
+        session.add_all([
+            SkillSetSkill(skill_set_id=default.id, skill_id=skill.id, env="dev"),
+            SkillSetSkill(skill_set_id=ordinary.id, skill_id=skill.id, env="dev"),
+            BotSkillInstallation(
+                bot_id="bot", owner_id="owner", skill_id=skill.id, env="dev"
+            ),
+        ])
+        set_id, skill_id = str(default.id), str(skill.id)
+
+    mutation = SkillSetControlPlaneRepository(db).remove_skill(
+        bot_id="bot", owner_id="owner", set_id=set_id, skill_id=skill_id,
+        engine_type="openclaw",
+    )
+
+    assert mutation.changed is True
+    with db.orm_session() as session:
+        assert session.query(DefaultSkillsetSkillExclusion).count() == 1
+        assert session.query(BotSkillInstallation).count() == 1
+
+
+def test_remove_mcp_from_global_default_writes_dynamic_default_exclusion_only():
+    """Default MCPs are projected, so no ac_skill_set_mcp row is required."""
+    db = _Database()
+    with db.transactional_orm_session() as session:
+        default = SkillSet(
+            name="system-default", user_id="", bolt_id="", engine_type="teclaw",
+            is_default=True, is_active=True, env="dev",
+        )
+        session.add(default)
+        session.flush()
+        session.add(BotMCPInstallation(
+            bot_id="bot", owner_id="owner",
+            server_code="mcp.dynamic-default", env="dev",
+        ))
+        set_id = str(default.id)
+
+    repository = SkillSetControlPlaneRepository(db)
+    first = repository.remove_mcp(
+        bot_id="bot", owner_id="owner", set_id=set_id,
+        server_code="mcp.dynamic-default", engine_type="teclaw",
+    )
+    second = repository.remove_mcp(
+        bot_id="bot", owner_id="owner", set_id=set_id,
+        server_code="mcp.dynamic-default", engine_type="teclaw",
+    )
+
+    assert first.changed is True
+    assert second.changed is False
+    with db.orm_session() as session:
+        exclusion = session.query(DefaultSkillsetMcpExclusion).one()
+        assert (
+            exclusion.user_id, exclusion.bot_id,
+            exclusion.skill_set_id, exclusion.server_code,
+        ) == ("owner", "bot", int(set_id), "mcp.dynamic-default")
+        assert session.query(SkillSetMCPServer).count() == 0
+        assert session.query(BotMCPInstallation).count() == 1
+
+
+def test_restore_desired_state_restores_default_exclusions():
+    db = _Database()
+    with db.transactional_orm_session() as session:
+        default = SkillSet(
+            name="system-default", user_id="", bolt_id="", engine_type="openclaw",
+            is_default=True, is_active=True, env="dev",
+        )
+        first = Skill(name="first", git_path="git://first", env="dev")
+        second = Skill(name="second", git_path="git://second", env="dev")
+        session.add_all([default, first, second])
+        session.flush()
+        session.add_all([
+            SkillSetSkill(skill_set_id=default.id, skill_id=first.id, env="dev"),
+            SkillSetSkill(skill_set_id=default.id, skill_id=second.id, env="dev"),
+            DefaultSkillsetSkillExclusion(
+                user_id="owner", bot_id="bot", skill_set_id=default.id,
+                skill_id=first.id,
+            ),
+            DefaultSkillsetMcpExclusion(
+                user_id="owner", bot_id="bot", skill_set_id=default.id,
+                server_code="mcp.existing",
+            ),
+            BotSkillInstallation(
+                bot_id="bot", owner_id="owner", skill_id=second.id, env="dev"
+            ),
+        ])
+        set_id, second_id = str(default.id), str(second.id)
+
+    repository = SkillSetControlPlaneRepository(db)
+    mutation = repository.remove_skill(
+        bot_id="bot", owner_id="owner", set_id=set_id, skill_id=second_id,
+        engine_type="openclaw",
+    )
+    repository.remove_mcp(
+        bot_id="bot", owner_id="owner", set_id=set_id,
+        server_code="mcp.new", engine_type="openclaw",
+    )
+    repository.restore_desired_state(
+        bot_id="bot", owner_id="owner", state=mutation.previous_state,
+        engine_type="openclaw",
+    )
+
+    with db.orm_session() as session:
+        assert {
+            (row.skill_set_id, row.skill_id)
+            for row in session.query(DefaultSkillsetSkillExclusion).all()
+        } == {(int(set_id), 1)}
+        assert {
+            (row.skill_set_id, row.server_code)
+            for row in session.query(DefaultSkillsetMcpExclusion).all()
+        } == {(int(set_id), "mcp.existing")}
+        assert {
+            row.skill_id for row in session.query(BotSkillInstallation).all()
+        } == {int(second_id)}
+
 def test_ensure_active_skillset_installations_uses_install_repository_upsert_seam():
     db = _Database()
     with db.transactional_orm_session() as session:


### PR DESCRIPTION
## Problem

Default SkillSet Skill and MCP removal was routed through the canonical control plane, where ordinary-membership immutability checks rejected the shared system Default with `SYSTEM_DEFAULT_IMMUTABLE`. BFF and OpenAPI Gateway callers therefore could not create the per-owner, per-Bot exclusions that preserve the published Default Set contract.

## Solution

- Branch Default Skill removal before the ordinary-Set guard and persist `ac_default_skillset_skill_exclusion` under the resolved Bot owner.
- Retire the Default-governed Skill installation on first exclusion, while preserving it when an active ordinary Set still provides the Skill.
- Branch projected Default MCP removal to `ac_default_skillset_mcp_exclusion` without requiring an ordinary MCP membership row or deleting explicit MCP installations.
- Include both exclusion collections in desired-state snapshots and compensating restore so runtime reconcile failures roll back atomically.
- Keep Default Set add/update/delete/deactivate immutability unchanged.

## Validation

- `uv run --project src/backend pytest -q src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py src/backend/tests/community/contracts/gateway/test_rule15_skillsets.py` — 104 passed.
- `uv run --project src/backend pytest -q src/backend/tests/community/endpoints/test_endpoint_runner.py -k "excludes_default_skill or excludes_dynamic_default_mcp"` — 2 passed.
- `uv run --project src/backend pytest -q src/backend/tests/community/architecture/test_module_boundaries.py src/backend/tests/community/architecture/test_service_api_conformance.py src/backend/tests/community/core/skill_center src/backend/tests/community/repository/skill_center` — 1083 passed, 27 skipped.
- `scripts/ci/python_sast_local.sh src/backend 1 --base origin/dev --head HEAD` — passed.
- Changed-file Ruff checks — passed; the repository test file retains its pre-existing unused `sqlalchemy.text` import and was checked with F401 ignored rather than mixing unrelated cleanup.

## Compatibility and risk

No HTTP schema or database schema changes. The change restores the existing Default exclusion semantics for both BFF and Gateway through their shared control plane. Ordinary SkillSet membership behavior is unchanged. On reconcile failure, exclusion and installation desired state are restored before runtime compensation.