### PR TITLE
feat(baas): trace BCN conversion inputs and outputs

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py
@@ -24,6 +24,7 @@ import json
 import os
 import uuid
 from collections.abc import AsyncIterator, Callable
+from contextlib import suppress
 from typing import Any
 
 from dependency_injector.wiring import Provide, inject
@@ -135,24 +136,26 @@ class _BcnLoggingStreamConverter:
         try:
             event = self._delegate.convert(chunk, run_id=run_id)
         except Exception as exc:
-            bcn_converter_logger.exception(
+            with suppress(Exception):
+                bcn_converter_logger.exception(
+                    "[convert] source=bcn_downlink run_id=%s input=%s output=%s",
+                    run_id,
+                    raw_input,
+                    _log_json(
+                        {
+                            "error_type": type(exc).__name__,
+                            "error_message": _safe_log_string(exc),
+                        }
+                    ),
+                )
+            raise
+        with suppress(Exception):
+            bcn_converter_logger.info(
                 "[convert] source=bcn_downlink run_id=%s input=%s output=%s",
                 run_id,
                 raw_input,
-                _log_json(
-                    {
-                        "error_type": type(exc).__name__,
-                        "error_message": _safe_log_string(exc),
-                    }
-                ),
+                _log_json(_event_log_payload(event)),
             )
-            raise
-        bcn_converter_logger.info(
-            "[convert] source=bcn_downlink run_id=%s input=%s output=%s",
-            run_id,
-            raw_input,
-            _log_json(_event_log_payload(event)),
-        )
         return event
 
 

--- a/src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py
@@ -65,6 +65,7 @@ from secbaas.community.api.sse import (
     SseConverterFactory,
     SseEvent,
     StreamChunk,
+    StreamConverter,
     convert_chunks_to_sse,
     with_sse_heartbeat,
 )
@@ -73,6 +74,87 @@ from secbaas.community.logger import get_logger
 from secbaas.community.spi.secret import SecretStorePlugin
 
 logger = get_logger("router-open-api")
+bcn_converter_logger = get_logger("bcn-converter")
+
+
+def _safe_log_string(value: Any) -> str:
+    try:
+        return str(value)
+    except Exception:
+        try:
+            return repr(value)
+        except Exception:
+            return "<unserializable>"
+
+
+def _log_json(value: Any) -> str:
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            default=_safe_log_string,
+            separators=(",", ":"),
+        )
+    except Exception:
+        return _safe_log_string(value)
+
+
+def _chunk_log_payload(chunk: StreamChunk) -> dict[str, Any]:
+    return {
+        "type": chunk.type,
+        "content": chunk.content,
+        "usage": chunk.usage,
+        "metadata": chunk.metadata,
+        "engine_type": chunk.engine_type,
+    }
+
+
+def _event_log_payload(event: SseEvent | None) -> dict[str, Any] | None:
+    if event is None:
+        return None
+    return {
+        "event": event.event,
+        "data": event.data,
+        "id": event.id,
+        "retry": event.retry,
+    }
+
+
+class _BcnLoggingStreamConverter:
+    """Log raw input and output for conversions initiated by BCN downlink."""
+
+    def __init__(self, delegate: StreamConverter) -> None:
+        self._delegate = delegate
+
+    @staticmethod
+    def name() -> str:
+        return "bcn-logging"
+
+    def convert(self, chunk: StreamChunk, *, run_id: str) -> SseEvent | None:
+        raw_input = _log_json(_chunk_log_payload(chunk))
+        try:
+            event = self._delegate.convert(chunk, run_id=run_id)
+        except Exception as exc:
+            bcn_converter_logger.exception(
+                "[convert] source=bcn_downlink run_id=%s input=%s output=%s",
+                run_id,
+                raw_input,
+                _log_json(
+                    {
+                        "error_type": type(exc).__name__,
+                        "error_message": _safe_log_string(exc),
+                    }
+                ),
+            )
+            raise
+        bcn_converter_logger.info(
+            "[convert] source=bcn_downlink run_id=%s input=%s output=%s",
+            run_id,
+            raw_input,
+            _log_json(_event_log_payload(event)),
+        )
+        return event
+
 
 router = APIRouter(prefix="/bcn", tags=["BCN Downlink"])
 
@@ -314,7 +396,7 @@ async def _dispatch_chat_send_stream(
     except ValueError as exc:
         raise BcnInvalidRequestError(str(exc)) from exc
 
-    converter = converter_factory.create("default")
+    converter = _BcnLoggingStreamConverter(converter_factory.create("default"))
 
     def on_error(e: Exception) -> str:
         logger.exception("[chat.send.stream] Unexpected error: run_id=%s", req.id)

--- a/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
+++ b/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
@@ -270,21 +270,6 @@ def _transform_ask_user_requested(
     run_id: str,
 ) -> bool:
     raw_questions = payload.get("questions")
-    if isinstance(raw_questions, list):
-        for index, question in enumerate(raw_questions):
-            if not isinstance(question, dict):
-                continue
-            for key in ("secret", "isSecret"):
-                if key in question:
-                    _warn_interaction(
-                        run_id=run_id,
-                        interaction_id=data["interactionId"],
-                        kind=data["kind"],
-                        field_path=f"payload.questions[{index}].{key}",
-                        error_type="secret_question_unsupported",
-                    )
-                    return False
-
     questions = _convert_ask_user_questions(
         raw_questions,
         run_id=run_id,

--- a/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
+++ b/src/baas/src/secbaas/community/core/service/sse/_default_converter.py
@@ -22,7 +22,7 @@ from typing import Any
 from secbaas.community.api.sse import SseEvent, StreamChunk
 from secbaas.community.logger import get_logger
 
-logger = get_logger("core-service")
+logger = get_logger("bcn-converter")
 
 _INTERACTION_EVENT_PHASES = {
     "interaction.requested": "requested",

--- a/src/baas/tests/architecture/test_logger_usage.py
+++ b/src/baas/tests/architecture/test_logger_usage.py
@@ -79,6 +79,7 @@ def test_no_direct_logging_getlogger_outside_legacy_layers():
 ALLOWED_LOGGER_NAMES = frozenset(
     {
         "core-service",
+        "bcn-converter",  # core/service/sse/**
         "orm",
         "router",
         "router-open-api",

--- a/src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
@@ -290,6 +290,14 @@ class _ConverterFactory:
         return DefaultStreamConverter()
 
 
+class _FailingLogBackend:
+    def info(self, *_args, **_kwargs) -> None:
+        raise RuntimeError("log backend boom")
+
+    def exception(self, *_args, **_kwargs) -> None:
+        raise RuntimeError("log backend boom")
+
+
 def test_bcn_logging_converter_has_distinct_name() -> None:
     converter = _BcnLoggingStreamConverter(DefaultStreamConverter())
 
@@ -483,6 +491,51 @@ async def test_stream_dispatch_log_serialization_cannot_abort_conversion():
     assert len(items) == 1
     assert items[0].startswith("id: 1\nevent: chat\n")
     assert "hello" in items[0]
+
+
+@pytest.mark.asyncio
+async def test_stream_dispatch_log_backend_failure_cannot_abort_conversion(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "secbaas.community.adapters.web.routers.bcn_downlink.bcn_router.bcn_converter_logger",
+        _FailingLogBackend(),
+    )
+
+    response = await _dispatch_chat_send_stream(
+        _chat_send_request(),
+        _StreamService(),
+        _ConverterFactory(),
+    )
+
+    items = [item async for item in response.body_iterator]
+
+    assert len(items) == 1
+    assert items[0].startswith("id: 1\nevent: chat\n")
+
+
+def test_converter_preserves_delegate_error_when_exception_logging_fails(
+    monkeypatch,
+) -> None:
+    class _FailingConverter:
+        @staticmethod
+        def name() -> str:
+            return "failing"
+
+        def convert(self, _chunk, *, run_id: str):
+            raise ValueError(f"convert boom: {run_id}")
+
+    monkeypatch.setattr(
+        "secbaas.community.adapters.web.routers.bcn_downlink.bcn_router.bcn_converter_logger",
+        _FailingLogBackend(),
+    )
+    converter = _BcnLoggingStreamConverter(_FailingConverter())
+
+    with pytest.raises(ValueError, match="convert boom: run-1"):
+        converter.convert(
+            StreamChunk(type="delta", content="hello"),
+            run_id="run-1",
+        )
 
 
 @pytest.mark.asyncio

--- a/src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
@@ -410,6 +410,92 @@ async def test_stream_dispatch_logs_raw_conversion_input_and_output(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("secret_key", "secret_value"),
+    (("secret", True), ("secret", False), ("isSecret", None)),
+)
+async def test_stream_dispatch_logs_and_delivers_secret_ask_user_input(
+    monkeypatch,
+    caplog,
+    secret_key,
+    secret_value,
+):
+    class _SecretInteractionStreamService:
+        async def handle_chat_send_stream(self, _input):
+            async def _chunks():
+                yield StreamChunk(
+                    type="interaction",
+                    content="Sensitive chunk content",
+                    metadata={
+                        "event": "interaction.requested",
+                        "payload": {
+                            "type": "event",
+                            "event": "interaction.requested",
+                            "payload": {
+                                "interactionId": "int-secret",
+                                "kind": "ask_user",
+                                "phase": "requested",
+                                "toolCallId": "tool-secret",
+                                "description": "Sensitive description",
+                                "questions": [
+                                    {
+                                        "header": "secret",
+                                        "question": "Sensitive secret question body",
+                                        secret_key: secret_value,
+                                    }
+                                ],
+                            },
+                        },
+                    },
+                )
+                yield StreamChunk(type="delta", content="after secret question")
+
+            return _chunks()
+
+    conversion_logger = logging.getLogger(f"test.bcn-secret-{secret_key}")
+    conversion_logger.handlers.clear()
+    conversion_logger.propagate = True
+    monkeypatch.setattr(
+        "secbaas.community.adapters.web.routers.bcn_downlink.bcn_router.bcn_converter_logger",
+        conversion_logger,
+    )
+    caplog.set_level(logging.INFO, logger=conversion_logger.name)
+
+    response = await _dispatch_chat_send_stream(
+        _chat_send_request(),
+        _SecretInteractionStreamService(),
+        _ConverterFactory(),
+    )
+    items = [item async for item in response.body_iterator]
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == conversion_logger.name
+        and record.getMessage().startswith("[convert]")
+    ]
+    assert len(items) == 2
+    assert items[0].startswith("id: 1\nevent: interaction\n")
+    assert items[1].startswith("id: 2\nevent: chat\n")
+
+    first_input, first_output = messages[0].split(" input=", 1)[1].split(" output=", 1)
+    logged_input = json.loads(first_input)
+    logged_question = logged_input["metadata"]["payload"]["payload"]["questions"][0]
+    assert logged_input["content"] == "Sensitive chunk content"
+    assert logged_input["metadata"]["payload"]["payload"]["description"] == (
+        "Sensitive description"
+    )
+    assert logged_question["question"] == "Sensitive secret question body"
+    assert logged_question[secret_key] is secret_value
+
+    converted = json.loads(first_output)
+    assert converted["event"] == "interaction"
+    converted_question = json.loads(converted["data"])["questions"][0]
+    assert converted_question["question"] == "Sensitive secret question body"
+    assert secret_key not in converted_question
+
+
+@pytest.mark.asyncio
 async def test_stream_dispatch_logs_raw_input_when_conversion_raises(
     monkeypatch,
     caplog,

--- a/src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_bcn_router.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,9 +11,11 @@ from secbaas.community.adapters.web.routers.bcn_downlink.bcn_model import (
 )
 from secbaas.community.adapters.web.routers.bcn_downlink.bcn_router import (
     _METHOD_DISPATCH,
+    _BcnLoggingStreamConverter,
     _dispatch_chat_send,
     _dispatch_chat_send_stream,
     _dispatch_interaction_resolve,
+    _log_json,
     validate_bcn_token,
 )
 from secbaas.community.api.bcn import (
@@ -287,6 +290,23 @@ class _ConverterFactory:
         return DefaultStreamConverter()
 
 
+def test_bcn_logging_converter_has_distinct_name() -> None:
+    converter = _BcnLoggingStreamConverter(DefaultStreamConverter())
+
+    assert converter.name() == "bcn-logging"
+
+
+def test_log_json_degrades_when_container_cannot_be_serialized() -> None:
+    class _UnserializableKey:
+        def __str__(self) -> str:
+            raise RuntimeError("str boom")
+
+        def __repr__(self) -> str:
+            raise RuntimeError("repr boom")
+
+    assert _log_json({_UnserializableKey(): "value"}) == "<unserializable>"
+
+
 def _chat_send_request() -> ChatSendRequest:
     return ChatSendRequest.model_validate(
         {
@@ -329,6 +349,140 @@ async def test_stream_dispatch_skips_dropped_converter_events():
         "state": "delta",
         "deltaText": "hello",
     }
+
+
+@pytest.mark.asyncio
+async def test_stream_dispatch_logs_raw_conversion_input_and_output(
+    monkeypatch,
+    caplog,
+):
+    conversion_logger = logging.getLogger("test.bcn-converter")
+    conversion_logger.handlers.clear()
+    conversion_logger.propagate = True
+    monkeypatch.setattr(
+        "secbaas.community.adapters.web.routers.bcn_downlink.bcn_router.bcn_converter_logger",
+        conversion_logger,
+    )
+    caplog.set_level(logging.INFO, logger=conversion_logger.name)
+
+    response = await _dispatch_chat_send_stream(
+        _chat_send_request(),
+        _StreamService(),
+        _ConverterFactory(),
+    )
+    async for _ in response.body_iterator:
+        pass
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == conversion_logger.name
+        and record.getMessage().startswith("[convert]")
+    ]
+    assert len(messages) == 2
+
+    first_input, first_output = messages[0].split(" input=", 1)[1].split(" output=", 1)
+    assert "source=bcn_downlink run_id=run-1" in messages[0]
+    assert json.loads(first_input)["type"] == "agent"
+    assert json.loads(first_output) is None
+
+    second_input, second_output = (
+        messages[1].split(" input=", 1)[1].split(" output=", 1)
+    )
+    assert json.loads(second_input) == {
+        "type": "delta",
+        "content": "hello",
+        "usage": None,
+        "metadata": None,
+        "engine_type": None,
+    }
+    converted = json.loads(second_output)
+    assert converted["event"] == "chat"
+    assert json.loads(converted["data"])["deltaText"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_stream_dispatch_logs_raw_input_when_conversion_raises(
+    monkeypatch,
+    caplog,
+):
+    class _FailingConverterFactory:
+        def create(self, name):
+            assert name == "default"
+
+            class _FailingConverter:
+                @staticmethod
+                def name():
+                    return "failing"
+
+                def convert(self, chunk, *, run_id):
+                    raise RuntimeError("convert boom")
+
+            return _FailingConverter()
+
+    conversion_logger = logging.getLogger("test.bcn-converter-error")
+    conversion_logger.handlers.clear()
+    conversion_logger.propagate = True
+    monkeypatch.setattr(
+        "secbaas.community.adapters.web.routers.bcn_downlink.bcn_router.bcn_converter_logger",
+        conversion_logger,
+    )
+    caplog.set_level(logging.INFO, logger=conversion_logger.name)
+
+    response = await _dispatch_chat_send_stream(
+        _chat_send_request(),
+        _StreamService(),
+        _FailingConverterFactory(),
+    )
+    async for _ in response.body_iterator:
+        pass
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == conversion_logger.name
+        and record.getMessage().startswith("[convert]")
+    ]
+    assert len(messages) == 1
+    raw_input, raw_output = messages[0].split(" input=", 1)[1].split(" output=", 1)
+    assert json.loads(raw_input)["type"] == "agent"
+    assert json.loads(raw_output) == {
+        "error_type": "RuntimeError",
+        "error_message": "convert boom",
+    }
+
+
+@pytest.mark.asyncio
+async def test_stream_dispatch_log_serialization_cannot_abort_conversion():
+    class _UnserializableLogValue:
+        def __str__(self) -> str:
+            raise RuntimeError("str boom")
+
+        def __repr__(self) -> str:
+            raise RuntimeError("repr boom")
+
+    class _OpaqueMetadataStreamService:
+        async def handle_chat_send_stream(self, _input):
+            async def _chunks():
+                yield StreamChunk(
+                    type="delta",
+                    content="hello",
+                    metadata={"opaque": _UnserializableLogValue()},
+                )
+
+            return _chunks()
+
+    response = await _dispatch_chat_send_stream(
+        _chat_send_request(),
+        _OpaqueMetadataStreamService(),
+        _ConverterFactory(),
+    )
+
+    items = [item async for item in response.body_iterator]
+
+    assert len(items) == 1
+    assert items[0].startswith("id: 1\nevent: chat\n")
+    assert "hello" in items[0]
 
 
 @pytest.mark.asyncio

--- a/src/baas/tests/unit/core/service/sse/test_default_converter.py
+++ b/src/baas/tests/unit/core/service/sse/test_default_converter.py
@@ -1142,12 +1142,9 @@ class TestInteractionStreamInvariants:
 
 
 class TestAskUserInteraction:
-    def test_secret_question_aliases_drop_entire_interaction_without_seq(
+    def test_secret_question_aliases_are_ignored_and_interaction_is_delivered(
         self,
-        monkeypatch,
-        caplog,
     ):
-        _capture_interaction_logs(monkeypatch, caplog)
         for secret_key, secret_value in (
             ("secret", True),
             ("secret", False),
@@ -1181,17 +1178,23 @@ class TestAskUserInteraction:
                 run_id="run-log",
             )
 
-            assert interaction is None
+            assert interaction is not None
+            assert _data(interaction)["questions"] == [
+                {
+                    "questionId": "question_1",
+                    "header": "safe",
+                    "question": "Safe-looking question",
+                },
+                {
+                    "questionId": "question_2",
+                    "header": "secret",
+                    "question": "Sensitive secret question body",
+                },
+            ]
             assert chat is not None
-            assert chat.id == "1"
-            assert _data(chat)["seq"] == 1
-
-        assert "field_path=payload.questions[1].secret" in caplog.text
-        assert "field_path=payload.questions[1].isSecret" in caplog.text
-        assert caplog.text.count("error_type=secret_question_unsupported") == 3
-        assert "Sensitive description" not in caplog.text
-        assert "Sensitive secret question body" not in caplog.text
-        assert "Safe-looking question" not in caplog.text
+            assert interaction.id == "1"
+            assert chat.id == "2"
+            assert _data(chat)["seq"] == 2
 
     def test_maps_complete_questions_and_options(self):
         converter = DefaultStreamConverter()

--- a/src/baas/tests/unit/core/service/sse/test_default_converter.py
+++ b/src/baas/tests/unit/core/service/sse/test_default_converter.py
@@ -9,10 +9,17 @@ delta with empty content, final with empty content.
 
 import json
 import logging
+import sys
 from copy import deepcopy
 
 from secbaas.community.api.sse import StreamChunk
 from secbaas.community.core.service.sse import DefaultStreamConverter
+
+
+def test_converter_uses_dedicated_logger():
+    converter_module = sys.modules[DefaultStreamConverter.__module__]
+
+    assert converter_module.logger.name == "bcn-converter"
 
 
 def _data(event) -> dict:


### PR DESCRIPTION
## Problem

BCN stream conversion shared the broad `core-service` log and only emitted
warnings for malformed interaction payloads. This made it difficult to
correlate the raw stream chunk received from the engine with the SSE event
produced for BCN, especially when diagnosing duplicated tool lifecycle events.

Secret-marked `ask_user` interactions were also dropped during projection,
which could leave downstream consumers waiting for an interaction that was
never delivered.

## Solution

- Route existing `DefaultStreamConverter` warnings to the dedicated
  `bcn-converter` logger.
- Wrap the converter only at the BCN `chat.send` streaming boundary and emit
  one structured record per conversion containing the run ID, complete raw
  `StreamChunk`, and complete `SseEvent` result or `null` when filtered.
- Record conversion exceptions with the raw input and structured error details,
  then re-raise them so the existing SSE error path remains authoritative.
- Isolate serialization and logger backend failures from the conversion path.
- Treat `secret` and `isSecret` as unsupported extension fields: omit the
  markers from the BCN question projection but deliver the interaction as a
  standard `ask_user` event.
- Leave OpenAPI and Gateway conversion wiring unchanged.
- Register the new canonical logger name and add focused regression coverage.

## Validation

- `uv run pytest tests/unit/core/service/sse/test_default_converter.py tests/unit/adapters/web/open_api/test_bcn_router.py tests/architecture/test_exception_handling.py tests/architecture/test_logger_usage.py -q`
  - 110 passed (the architecture exception audit also emitted its existing
    non-blocking repository-wide warning)
- `uv run ruff format --check src/secbaas/community/core/service/sse/_default_converter.py src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py tests/unit/core/service/sse/test_default_converter.py tests/unit/adapters/web/open_api/test_bcn_router.py`
  - All files formatted
- `uv run ruff check src/secbaas/community/core/service/sse/_default_converter.py src/secbaas/community/adapters/web/routers/bcn_downlink/bcn_router.py tests/unit/core/service/sse/test_default_converter.py tests/unit/adapters/web/open_api/test_bcn_router.py`
  - All checks passed

## Compatibility and risk

- The BCN wire schema is unchanged: `secret` and `isSecret` are not emitted.
- Secret-marked questions are no longer dropped; downstream receives them as
  ordinary plaintext `ask_user` questions so the interaction can complete.
- INFO records intentionally contain complete raw message content and complete
  converted output, including secret-marked interaction content. Access and
  retention must therefore follow the existing SecBaaS sensitive-log policy.
- Deployment must add an AntLogs collector for
  `/home/admin/logs/secbaas/bcn-converter.log`; the application will create and
  rotate the file through the existing logger plugin.
