### PR TITLE
fix(backend): align OpenAPI Skill ZIP parsing with BFF

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/local_skill_upload_service.py
@@ -635,6 +635,13 @@ class LocalSkillUploadService:
             normalized_path = "/".join(
                 part for part in path.split("/") if part not in ("", ".")
             )
+            # Preserve the retiring BFF upload behavior for common platform
+            # metadata. These files are not Skill content and must not create
+            # a second wrapper root for a valid macOS ZIP archive.
+            if LocalSkillUploadService._is_legacy_ignored_upload_path(
+                normalized_path
+            ):
+                continue
             if normalized_path in seen:
                 raise LocalSkillInvalidPackageError("duplicate_file_path")
             if info.file_size > _MAX_FILE:
@@ -689,6 +696,18 @@ class LocalSkillUploadService:
             raise LocalSkillInvalidPackageError("invalid_wrapper")
         normalized = [(p[len(wrapper) + 1 :] if wrapper else p, c) for p, c in files]
         return name, description, normalized
+
+    @staticmethod
+    def _is_legacy_ignored_upload_path(relative_path: str) -> bool:
+        """Match the retiring BFF parser's platform-metadata exclusions."""
+        parts = relative_path.split("/")
+        name = parts[-1]
+        return (
+            name == ".DS_Store"
+            or parts[0] == "__MACOSX"
+            or "__pycache__" in parts
+            or name.endswith((".pyc", ".pyo"))
+        )
 
     @staticmethod
     def _pack_directory(files: Sequence[tuple[str, bytes]]) -> bytes:

--- a/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_upload_service.py
@@ -6,6 +6,7 @@ import asyncio
 import io
 import zipfile
 from types import SimpleNamespace
+from types import MethodType
 
 import pytest
 from agentclaw.community.core.skill_center.errors import (
@@ -24,6 +25,7 @@ from agentclaw.community.core.skill_center.services import (
 from agentclaw.community.core.skill_center.services.local_skill_upload_service import (
     LocalSkillUploadService,
 )
+from agentclaw.community.core.skill_center.services.skill_service import SkillService
 from agentclaw.community.core.skills_pool.edit_guard import (
     SkillsPoolEditBusyError,
     SkillsPoolEditGuard,
@@ -51,6 +53,19 @@ def _zip(entries: dict[str, bytes], *, attrs: dict[str, int] | None = None) -> b
                 info.external_attr = attrs[path]
             archive.writestr(info, content)
     return payload.getvalue()
+
+
+def _legacy_upload_plan(package: bytes) -> tuple[str, str, list[tuple[str, bytes]]]:
+    """Parse a ZIP through the retiring BFF upload semantics."""
+    legacy = SimpleNamespace(RESERVED_SKILL_NAMES=SkillService.RESERVED_SKILL_NAMES)
+    legacy._validate_upload_path = SkillService._validate_upload_path
+    legacy._is_ignored_upload_path = SkillService._is_ignored_upload_path
+    legacy._prepare_upload_plan = MethodType(SkillService._prepare_upload_plan, legacy)
+    uploaded_files = SkillService._extract_zip_files(legacy, package)
+    name, metadata, files = legacy._prepare_upload_plan(uploaded_files)
+    return name, metadata["description"], [
+        (item["relative_path"], item["content"]) for item in files
+    ]
 
 
 class _Repo:
@@ -887,6 +902,37 @@ def test_zip_accepts_root_skill_with_subdirectories_and_matching_wrapper():
         )
     )
     assert name == "wrapped" and [path for path, _ in files] == ["SKILL.md", "a.txt"]
+
+
+@pytest.mark.parametrize(
+    ("entries", "expected_name"),
+    [
+        (
+            {
+                "rd-prd-review/SKILL.md": _skill_md("rd-prd-review"),
+                "rd-prd-review/.DS_Store": b"finder metadata",
+                "__MACOSX/._rd-prd-review": b"appledouble",
+                "__MACOSX/rd-prd-review/._SKILL.md": b"appledouble",
+            },
+            "rd-prd-review",
+        ),
+        ({"rd-cr-java/SKILL.md": _skill_md("rd-cr-java")}, "rd-cr-java"),
+        (
+            {
+                "rd-development/SKILL.md": _skill_md("rd-development"),
+                "rd-development/references/implementer-prompt.md": b"prompt",
+            },
+            "rd-development",
+        ),
+    ],
+)
+def test_openapi_zip_normalization_matches_legacy_bff_upload_parser(
+    entries, expected_name
+):
+    package = _zip(entries)
+
+    assert LocalSkillUploadService._unpack(package) == _legacy_upload_plan(package)
+    assert LocalSkillUploadService._unpack(package)[0] == expected_name
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

The raw OpenAPI Local Skill upload rejected ordinary macOS ZIP archives containing `__MACOSX` and `.DS_Store` as an `invalid_wrapper`, while the retiring BFF upload parser ignores the same platform metadata. This blocked `rd-prd-review.zip` even though its real Skill wrapper and manifest were valid.

## Solution

Apply the BFF-compatible platform-metadata exclusions in the OpenAPI ZIP unpacker after path safety validation and before wrapper detection. No BFF code, route, request field, response schema, or Skill runtime behavior changes.

Add a regression seam that compares the raw OpenAPI ZIP normalization result with the retiring BFF ZIP parser for macOS metadata, `rd-cr-java`, and `rd-development` layouts.

## Validation

- 89 passed, 10 skipped: Local Skill upload core, OpenAPI upload endpoint, and OpenAPI skills adapter suites.
- 4 passed: relevant architecture boundary suites.
- 3 passed: supplied `rd-prd-review.zip`, `rd-cr-java.zip`, and `rd-development.zip` each normalize identically through BFF and OpenAPI parsers.
- Ruff and local Python SAST block scans passed for changed files.
- `git diff --check` passed.
- `DEPLOY_PROFILE=community uv run --project src/backend python src/backend/scripts/dump_openapi.py /tmp/openapi-skill-zip-compat.json` completed.
- Gateway compatibility gate was run against a temporary copy of the published artifact and was blocked by an existing target artifact drift: `POST /openapi/v1/bots/{bot_id}/public-bcs` exists in the committed Gateway artifact but is absent from the Backend-generated candidate. This PR does not modify that route or its schema.

## Compatibility and risk

This restores existing BFF acceptance semantics for non-Skill platform metadata only. Unsafe paths, multiple real roots, duplicate content paths, file-count and size limits, manifest validation, and wrapper-name validation remain unchanged. Rollback is the single commit in this PR.