### PR TITLE
perf(backend): cut /bots/all serial query count for faster inventory

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_inventory/protocols.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/protocols.py
@@ -36,6 +36,9 @@ class BotInventoryBotPort(Protocol):
         page: int = 1,
         page_size: int = 20,
         bot_ids: list[str] | None = None,
+        # Inventory cards never surface template_config, so inventory pulls
+        # opt out of the batched template read.
+        attach_templates: bool = True,
     ) -> Mapping[str, Any]: ...
 
 

--- a/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
@@ -151,6 +151,10 @@ class BotInventoryService:
                 engine=engine,
                 status=None,
                 bot_ids=bot_ids,
+                # Inventory cards carry no template_config (verified: neither
+                # BotInventoryItem nor the router mapping reads it), so skip
+                # the batched template read on every pulled page.
+                attach_templates=False,
                 page=page,
                 page_size=fetch_size,
             )

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -2208,6 +2208,7 @@ class BotService:
         page: int = 1,
         page_size: int = 20,
         bot_ids: Optional[List[str]] = None,
+        attach_templates: bool = True,
     ) -> Dict[str, Any]:
         """
         List bots by conditions with pagination.
@@ -2227,6 +2228,9 @@ class BotService:
                 an empty list means none. The distinction is load-bearing —
                 treating empty as unrestricted would show a caller entitled to
                 nothing everything.
+            attach_templates: Attach ac_templates.ext as template_config to
+                each returned bot (the get/list consistency contract). Pass
+                False only when the caller provably never reads that field.
 
         Returns:
             Dictionary with 'total' and 'items' keys
@@ -2244,7 +2248,12 @@ class BotService:
             page_size=page_size,
             bot_ids=bot_ids,
         )
-        self._attach_template_configs_to_bots(items)
+        # Callers that never surface template_config (the bot inventory pulls
+        # every matching row) pay one batched template read per page for data
+        # they drop; they opt out here. Default stays True for the established
+        # list/detail consistency contract.
+        if attach_templates:
+            self._attach_template_configs_to_bots(items)
         return {
             "total": total,
             "items": items,

--- a/src/backend/src/agentclaw/community/core/desktop_bot/services/desktop_bot_service.py
+++ b/src/backend/src/agentclaw/community/core/desktop_bot/services/desktop_bot_service.py
@@ -120,24 +120,44 @@ class DesktopBotService:
 
     _CHECK_STATUSES = ("PENDING", "ACTIVE", "OFFLINE", "RELEASING", "FAILED")
 
+    # 一次 IN 查询的页大小。历史实现按状态各取 100（5 次串行往返、上限 500 行），
+    # 这里用同样的上限一页取完；超出再翻页，覆盖只会更全。
+    _LIST_PAGE_SIZE = 500
+
     def list_user_bots(self, user_id: str) -> list[dict[str, Any]]:
-        """列出指定用户的桌面 Bot。"""
+        """列出指定用户的桌面 Bot（一次 status-IN 查询 + 翻页补拉）。
+
+        按状态逐个查询的旧实现每次调用要 5 次 DB 往返，是 /bots/all 聚合
+        p50 里占比最大的单点。查询失败沿用旧契约：记 warning、返回已取到的
+        行（单查询下即空列表），不向上抛。
+        """
         all_bots: list[dict[str, Any]] = []
-        for status in self._CHECK_STATUSES:
+        page = 1
+        while True:
             try:
-                _, bots = self._bot_repo.search_bots(
+                total, bots = self._bot_repo.search_bots(
                     bot_type="desktop",
                     owner_id=user_id,
-                    bot_status=status,
-                    page=1,
-                    page_size=100,
+                    bot_status=None,
+                    bot_status_list=list(self._CHECK_STATUSES),
+                    page=page,
+                    page_size=self._LIST_PAGE_SIZE,
                 )
-                all_bots.extend(bots)
             except Exception as e:
                 logger.warning(
                     "[DesktopBotService.list_user_bots] query failed "
-                    "user_id=%s status=%s: %s", user_id, status, e,
+                    "user_id=%s page=%s: %s", user_id, page, e,
                 )
+                break
+            page_bots = list(bots)
+            all_bots.extend(page_bots)
+            if not page_bots:
+                break
+            if isinstance(total, int) and len(all_bots) >= total:
+                break
+            if len(page_bots) < self._LIST_PAGE_SIZE:
+                break
+            page += 1
         return all_bots
 
     def check_user_bots_status(self, user_id: str) -> None:

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/bot.py
@@ -790,6 +790,7 @@ class BotRepository(
         bot_id: Optional[str] = None,
         provider: Optional[str] = None,
         template_type: Optional[str] = None,
+        bot_status_list: Optional[List[str]] = None,
         page: int = 1,
         page_size: int = 20,
     ) -> tuple[int, List[Dict[str, Any]]]:
@@ -845,6 +846,8 @@ class BotRepository(
             # bot_status 过滤
             if bot_status:
                 query = query.filter(self.Model.status == bot_status)
+            if bot_status_list:
+                query = query.filter(self.Model.status.in_(bot_status_list))
 
             # public 过滤
             if public:

--- a/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/bot/bot.py
@@ -333,6 +333,7 @@ class BotRepository(Protocol):
         bot_id: Optional[str] = None,
         provider: Optional[str] = None,
         template_type: Optional[str] = None,
+        bot_status_list: Optional[List[str]] = None,
         page: int = 1,
         page_size: int = 20,
     ) -> tuple[int, List[Dict[str, Any]]]:
@@ -342,6 +343,7 @@ class BotRepository(Protocol):
         Args:
             key: 模糊搜索 bot_name 或 owner_name
             bot_status: ac_bots.status 过滤
+            bot_status_list: ac_bots.status IN 过滤（与 bot_status 同时给出时叠加）；避免调用方为多个状态各查一次
             public: ac_bots.public 过滤
             owner_id: ac_bots.owner_id 过滤
             service_status_list: 服务状态列表过滤（不影响 bot 返回）

--- a/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
+++ b/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
@@ -99,6 +99,29 @@ def test_list_items_combines_filters_and_paginates(service) -> None:
 
 
 @pytest.mark.unit
+def test_cloud_pull_opts_out_of_template_attach(service) -> None:
+    # Inventory cards never surface template_config, so every pulled page must
+    # skip the batched template read — one fewer DB round trip per page on the
+    # /bots/all path.
+    inventory, bot, _ = service
+
+    inventory.list_items(
+        owner_id="u1",
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
+        keyword=None,
+        engine=None,
+        deploy_mode=DeployMode.CLOUD,
+        is_service=None,
+        page=1,
+        page_size=10,
+    )
+
+    assert bot.list_bots_by_conditions.call_args.kwargs["attach_templates"] is False
+
+
+@pytest.mark.unit
 def test_cloud_source_fetches_all_pages_for_exact_total(service) -> None:
     inventory, bot, desktop = service
     cloud_rows = [
@@ -419,6 +442,7 @@ def test_team_space_lists_all_owners_and_scopes_actions_by_bot_permission() -> N
         engine=None,
         status=None,
         bot_ids=None,
+        attach_templates=False,
         page=1,
         page_size=200,
     )

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_misc.py
@@ -1123,6 +1123,22 @@ class TestTemplateFactoryBranchCoverage:
         assert result == {"total": 1, "items": items}
         assert result["items"][0]["template_config"] == {"template_key": "normalCC"}
 
+    def test_list_bots_by_conditions_skips_template_enrichment_when_opted_out(self):
+        # The inventory pull fetches every matching row and never surfaces
+        # template_config; it opts out so the batched template read disappears
+        # from the /bots/all request path.
+        svc = _make_service()
+        items = [{"bot_id": "b1", "template_type": "normalCC"}]
+        svc._repository.list_by_conditions.return_value = (1, items)
+
+        result = svc.list_bots_by_conditions(
+            page=1, page_size=10, attach_templates=False
+        )
+
+        assert result == {"total": 1, "items": items}
+        assert "template_config" not in result["items"][0]
+        svc._template_service.list_templates_by_bot_ids.assert_not_called()
+
     def test_aicoding_personal_coding_uses_legacy_bcn_provider_fallback(self):
         assert BotService._should_register_bcn_provider(
             active_engine="aicoding",

--- a/src/backend/tests/community/core/desktop_bot/services/test_desktop_bot_service.py
+++ b/src/backend/tests/community/core/desktop_bot/services/test_desktop_bot_service.py
@@ -1521,13 +1521,14 @@ def _setup_local_lookup(mocks, bot_id, device_id="m-001", active_engine="opencla
 class TestListUserBots:
     def test_returns_bots_for_user(self):
         service, mocks = _make_service_with_mocks()
-        mocks["bot_repo"].search_bots.side_effect = [
-            (1, [{"bot_id": "b1", "status": "PENDING"}]),
-            (1, [{"bot_id": "b2", "status": "ACTIVE"}]),
-            (1, [{"bot_id": "b3", "status": "OFFLINE"}]),
-            (0, []),  # RELEASING
-            (0, []),  # FAILED
-        ]
+        mocks["bot_repo"].search_bots.return_value = (
+            3,
+            [
+                {"bot_id": "b1", "status": "PENDING"},
+                {"bot_id": "b2", "status": "ACTIVE"},
+                {"bot_id": "b3", "status": "OFFLINE"},
+            ],
+        )
 
         result = service.list_user_bots(user_id="u001")
 
@@ -1535,8 +1536,18 @@ class TestListUserBots:
         assert result[0]["bot_id"] == "b1"
         assert result[1]["bot_id"] == "b2"
         assert result[2]["bot_id"] == "b3"
-        # Called for PENDING, ACTIVE, OFFLINE, RELEASING, FAILED
-        assert mocks["bot_repo"].search_bots.call_count == 5
+        # All five statuses are fetched by ONE status-IN query — the historical
+        # per-status fan-out (5 serial DB round trips) is what made /bots/all slow.
+        assert mocks["bot_repo"].search_bots.call_count == 1
+        kwargs = mocks["bot_repo"].search_bots.call_args.kwargs
+        assert set(kwargs["bot_status_list"]) == {
+            "PENDING",
+            "ACTIVE",
+            "OFFLINE",
+            "RELEASING",
+            "FAILED",
+        }
+        assert kwargs["bot_status"] is None
 
     def test_returns_empty_when_no_bots(self):
         service, mocks = _make_service_with_mocks()
@@ -1556,16 +1567,30 @@ class TestListUserBots:
             assert call.kwargs["owner_id"] == "u001"
             assert call.kwargs["bot_type"] == "desktop"
 
-    def test_continues_on_query_failure(self):
+    def test_fetches_all_pages_when_total_exceeds_page_size(self):
         service, mocks = _make_service_with_mocks()
+        page1 = [{"bot_id": f"b{i:03d}", "status": "ACTIVE"} for i in range(500)]
+        page2 = [{"bot_id": f"b{i:03d}", "status": "PENDING"} for i in range(500, 600)]
         mocks["bot_repo"].search_bots.side_effect = [
-            Exception("DB error"),
-            (1, [{"bot_id": "b1", "status": "ACTIVE"}]),
-            (0, []),
-            (0, []),
-            (0, []),
+            (600, page1),
+            (600, page2),
         ]
 
         result = service.list_user_bots(user_id="u001")
 
-        assert len(result) == 1
+        assert len(result) == 600
+        assert mocks["bot_repo"].search_bots.call_count == 2
+        assert mocks["bot_repo"].search_bots.call_args_list[1].kwargs["page"] == 2
+
+    def test_query_failure_is_swallowed(self):
+        # The historical per-status loop swallowed one status's failure and kept
+        # going. With a single query there is nothing left to fall back on, so
+        # the same swallow-and-log contract now means "empty result", never a
+        # raise — callers treat [] as "no local bots".
+        service, mocks = _make_service_with_mocks()
+        mocks["bot_repo"].search_bots.side_effect = Exception("DB error")
+
+        result = service.list_user_bots(user_id="u001")
+
+        assert result == []
+        assert mocks["bot_repo"].search_bots.call_count == 1


### PR DESCRIPTION
## Problem

Prepub `GET /openapi/v1/bots/all` responds at RT p50=622ms (p90=3.7s, max 17.4s; access.log, 6h sample). One request runs ~12-14 serial DB round trips. Two avoidable chunks dominate:

- `DesktopBotService.list_user_bots` queried once per status — 5 serial trips (PENDING/ACTIVE/OFFLINE/RELEASING/FAILED)
- Every 200-row page pulled by the inventory passed through `_attach_template_configs_to_bots`, although the inventory response provably never reads `template_config` (neither `BotInventoryItem` nor the router `_to_inventory_item` maps it)

## Solution

- `search_bots` gains `bot_status_list` (status IN filter); `list_user_bots` collapses 5 serial queries into one (500/page with a fill loop, coverage ≥ the old 100×5; failure keeps the old swallow-and-log contract)
- `list_bots_by_conditions` gains `attach_templates: bool = True` (default preserves the established get/list consistency contract); the inventory cloud pull passes `False` — one fewer batched read per pulled page, behavior unchanged
- No API shape, response, or error behavior changes

## Validation

- `ci_test.sh --base origin/REL20260826`: 14460 passed, case pass rate 100%, line coverage 87.08%, changed-line coverage 94.44% (≥80% gate)
- `TestListUserBots` rewritten for single-query semantics (single-IN + pagination fill + swallowed failure); new opt-out (misc) and pass-through (inventory) coverage
- All `search_bots` call sites verified keyword-only — the new parameter cannot shift positional mappings
- Post-deploy check: prepub /bots/all RT p50/p90 tracked via antlogs (current baseline p50 ~600-800ms); P2 (query parallelization + SQL pagination pushdown) targets <150ms next