### PR TITLE
feat(backend): expose service bot version upgrade API

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -447,6 +447,10 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
         "/openapi/v1/bots/{bot_id}/lifecycle/upgrade",
     ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/lifecycle/{publication_id}/upgrade",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
         "GET",
         "/openapi/v1/bots/{bot_id}/lifecycle",
     ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
@@ -245,6 +245,7 @@ AUTHORIZATION: dict[tuple[str, str], Authorization] = {
     ("POST", "/openapi/v1/bots/{bot_id}/lifecycle/restart"): Check(PermissionLevel.MEMBER),
     ("POST", "/openapi/v1/bots/{bot_id}/lifecycle/retry"): Check(PermissionLevel.MEMBER),
     ("POST", "/openapi/v1/bots/{bot_id}/lifecycle/upgrade"): Check(PermissionLevel.OWNER),
+    ("POST", "/openapi/v1/bots/{bot_id}/lifecycle/{publication_id}/upgrade"): Check(PermissionLevel.ADMIN),
     ("DELETE", "/openapi/v1/bots/{bot_id}/local"): OWNER_SCOPED,
     ("GET", "/openapi/v1/bots/{bot_id}/local"): OWNER_SCOPED,
     ("GET", "/openapi/v1/bots/{bot_id}/local/auth-status"): OWNER_SCOPED,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/service_publications/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/service_publications/router.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Path, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import (
     BotIdPath,
@@ -45,6 +45,11 @@ from agentclaw.community.adapters.http.openapi_v1.authorization import PublicAPI
 router = APIRouter(prefix="/openapi/v1/bots/{bot_id}/lifecycle", route_class=PublicAPIRoute)
 edit_lock_router = APIRouter(prefix="/openapi/v1/bots/{bot_id}/edit-lock", route_class=PublicAPIRoute)
 
+PublicationIdPath = Annotated[
+    int,
+    Path(ge=1, description="The service-Bot publication version to upgrade."),
+]
+
 
 def _lock_payload(info: Any, *, acquired: bool | None = None) -> EditLock:
     lock = getattr(info, "lock", None)
@@ -73,6 +78,31 @@ async def upgrade_to_service(
 ) -> Envelope[ServicePublication]:
     """Irreversibly upgrade an eligible personal cloud Bot to a service Bot."""
     result = facade.convert_to_service(bot_id, actor_id=actor_id, owner_id=owner_id)
+    return envelope(ServicePublication.model_validate(result), request)
+
+
+@router.post(
+    "/{publication_id}/upgrade",
+    response_model=Envelope[ServicePublication],
+)
+@envelope_errors
+async def upgrade_publication(
+    bot_id: BotIdPath,
+    publication_id: PublicationIdPath,
+    request: Request,
+    actor_id: UserIdDep,
+    owner_id: OwnerIdDep,
+    facade: ServicePublicationFacadeProtocol = Injected(
+        ServicePublicationFacadeProtocol
+    ),
+) -> Envelope[ServicePublication]:
+    """Create the next draft version from a running service publication."""
+    result = facade.upgrade_publication(
+        bot_id,
+        publication_id,
+        actor_id=actor_id,
+        owner_id=owner_id,
+    )
     return envelope(ServicePublication.model_validate(result), request)
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/service_publications/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/service_publications/schemas.py
@@ -83,6 +83,7 @@ class ServicePublication(BaseModel):
             "publish_online",
             "restart_publish",
             "cancel_staging",
+            "upgrade",
             "offline",
             "retry",
             "delete",

--- a/src/backend/src/agentclaw/community/api/service_publication_facade.py
+++ b/src/backend/src/agentclaw/community/api/service_publication_facade.py
@@ -17,6 +17,15 @@ class ServicePublicationFacadeProtocol(Protocol):
         self, bot_id: str, *, actor_id: str, owner_id: str
     ) -> dict[str, Any]: ...
 
+    def upgrade_publication(
+        self,
+        bot_id: str,
+        publication_id: int,
+        *,
+        actor_id: str,
+        owner_id: str,
+    ) -> dict[str, Any]: ...
+
     def get_service_config(
         self, bot_id: str, *, actor_id: str, owner_id: str
     ) -> dict[str, Any]: ...

--- a/src/backend/src/agentclaw/community/core/service_bot/services/service_publication_facade.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/service_publication_facade.py
@@ -59,6 +59,10 @@ from agentclaw.community.core.service_bot.errors import (
 from agentclaw.community.core.service_bot.services.bot_publish_service import (
     BotPublishService,
 )
+from agentclaw.community.core.service_bot.services.publish_exceptions import (
+    PublishNotFoundError,
+    PublishStatusInvalidError,
+)
 from agentclaw.community.core.service_bot.services.baas_service import BaasServiceError
 from agentclaw.community.core.service_bot.services.publish_approval_service import (
     PublishApprovalService,
@@ -282,10 +286,27 @@ class ServicePublicationFacade:
         elif record.status == PublishStatus.VALIDATING.value:
             actions.extend(("publish_online", "restart_publish", "cancel_staging"))
         elif record.status == PublishStatus.SUCCESS.value:
+            if level >= PermissionLevel.ADMIN and self._can_upgrade_from_records(
+                record, all_records
+            ):
+                actions.append("upgrade")
             actions.extend(("restart_publish", "offline"))
         elif record.status == PublishStatus.FAILED.value:
             actions.append("retry")
         return actions
+
+    @staticmethod
+    def _can_upgrade_from_records(
+        record: BotPublishRecord,
+        all_records: Iterable[BotPublishRecord],
+    ) -> bool:
+        """Project the legacy can-upgrade rule without per-card repository reads."""
+        if record.status != PublishStatus.SUCCESS.value:
+            return False
+        successors = [item for item in all_records if item.last_pub_id == record.id]
+        return not successors or all(
+            item.status == PublishStatus.FAILED.value for item in successors
+        )
 
     def _project(
         self,
@@ -484,6 +505,47 @@ class ServicePublicationFacade:
         return self.get_publication(
             bot_id,
             record.id,
+            actor_id=actor_id,
+            owner_id=owner_id,
+        )
+
+    def upgrade_publication(
+        self,
+        bot_id: str,
+        publication_id: int,
+        *,
+        actor_id: str,
+        owner_id: str,
+    ) -> dict[str, Any]:
+        """Create the next draft from one live service-Bot publication."""
+        bot, record, _ = self._resolve_publication(
+            bot_id,
+            publication_id,
+            actor_id=actor_id,
+            owner_id=owner_id,
+            required_level=PermissionLevel.ADMIN,
+        )
+        if (
+            record.status != PublishStatus.SUCCESS.value
+            or not self._publish_service.can_upgrade_publish(record.id)
+        ):
+            raise ServicePublicationConflictError("publication cannot be upgraded")
+
+        try:
+            created = self._publish_service.upgrade_publish(
+                publish_id=record.id,
+                owner_id=bot["owner_id"],
+            )
+        except (PublishNotFoundError, PublishStatusInvalidError) as exc:
+            # The record may have changed between the projection check and the
+            # domain write. Expose that race as the same stable state conflict.
+            raise ServicePublicationConflictError(
+                "publication cannot be upgraded"
+            ) from exc
+
+        return self.get_publication(
+            bot_id,
+            created.id,
             actor_id=actor_id,
             owner_id=owner_id,
         )

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
@@ -101,6 +101,10 @@ _OWNER_ADDRESSED_ELSEWHERE = {
     ("get", "/openapi/v1/bots/{bot_id}/chats"),
     ("get", "/openapi/v1/bots/{bot_id}/chats/{trace_id}"),
     ("post", "/openapi/v1/bots/{bot_id}/lifecycle/upgrade"),
+    (
+        "post",
+        "/openapi/v1/bots/{bot_id}/lifecycle/{publication_id}/upgrade",
+    ),
     ("get", "/openapi/v1/bots/{bot_id}/lifecycle"),
     ("delete", "/openapi/v1/bots/{bot_id}/lifecycle"),
     ("get", "/openapi/v1/bots/{bot_id}/lifecycle/approval"),

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -386,7 +386,7 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: publish-to-users route moved from /bots/{bot_id}/public-bcs to the external
 #: /collaboration/bots/{bot_uuid}/public, so one path-addressed {bot_id}
 #: operation became a {bot_uuid}-named one: path -1, none +1.
-_BOT_ID_PLACEMENT = {"path": 140, "query": 1, "none": 62}
+_BOT_ID_PLACEMENT = {"path": 141, "query": 1, "none": 62}
 
 
 def _schema() -> dict:
@@ -489,7 +489,8 @@ def test_the_pinned_number_of_operations_take_it():
     # /collaboration/bots/{bot_uuid}/public (same op count, {bot_uuid} not {bot_id}).
     # The task public surface adds one more: GET .../collaboration/tasks/list
     # (execute/dashboard have no user dimension — see _NO_USER_DIMENSION).
-    assert len(taking) == 181
+    # Service publication version upgrade adds one Bot-addressed operation.
+    assert len(taking) == 182
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_service_publication_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_service_publication_endpoints.py
@@ -25,6 +25,7 @@ from agentclaw.community.adapters.http.openapi_v1.service_publications.router im
     retry_lifecycle,
     steal_edit_lock,
     update_approval_config,
+    upgrade_publication,
     upgrade_to_service,
 )
 from agentclaw.community.adapters.http.openapi_v1.service_publications.schemas import (
@@ -86,6 +87,30 @@ async def test_upgrade_and_lifecycle_handlers():
     assert upgraded.data.publication_id == 7
     assert lifecycle.data.items[0].card_id == "service:bot-1:7"
     assert lifecycle.request_id == "trace-1"
+
+
+@pytest.mark.asyncio
+async def test_upgrade_publication_handler():
+    facade = Mock()
+    facade.upgrade_publication.return_value = publication()
+
+    response = await upgrade_publication(
+        "bot-1",
+        7,
+        request(),
+        "actor",
+        "owner",
+        facade,
+    )
+
+    assert response.code == 200000
+    assert response.data.publication_id == 7
+    facade.upgrade_publication.assert_called_once_with(
+        "bot-1",
+        7,
+        actor_id="actor",
+        owner_id="owner",
+    )
 
 
 @pytest.mark.asyncio
@@ -255,6 +280,10 @@ def test_routes_follow_component_first_contract():
 
     assert "/openapi/v1/bots/{bot_id}/lifecycle" in lifecycle_paths
     assert "/openapi/v1/bots/{bot_id}/lifecycle/advance" in lifecycle_paths
+    assert (
+        "/openapi/v1/bots/{bot_id}/lifecycle/{publication_id}/upgrade"
+        in lifecycle_paths
+    )
     assert "/openapi/v1/bots/{bot_id}/lifecycle/cancel-staging" in lifecycle_paths
     assert all(
         path.startswith("/openapi/v1/bots/{bot_id}/lifecycle")

--- a/src/backend/tests/community/core/service_bot/services/test_service_publication_facade.py
+++ b/src/backend/tests/community/core/service_bot/services/test_service_publication_facade.py
@@ -35,6 +35,10 @@ from agentclaw.community.core.devices.services.device_instance_service import (
 from agentclaw.community.core.service_bot.services.service_publication_facade import (
     ServicePublicationFacade,
 )
+from agentclaw.community.core.service_bot.services.publish_exceptions import (
+    PublishNotFoundError,
+    PublishStatusInvalidError,
+)
 
 
 NOW = datetime(2026, 8, 17, 12, 0, 0)
@@ -91,6 +95,7 @@ def deps():
         PermissionLevel.OWNER
     )
     values.publish_repo.list_by_source_bot.return_value = []
+    values.publish_service.can_upgrade_publish.return_value = True
     values.lock_service.get_lock_info.return_value = SimpleNamespace(
         lock=None,
         holder_name=None,
@@ -285,7 +290,11 @@ def test_restart_container_normalizes_runtime_failures(deps, failure, expected):
             ["publish_online", "restart_publish", "cancel_staging"],
         ),
         (PublishStatus.ONLINE_PUB, "deploying", []),
-        (PublishStatus.SUCCESS, "running", ["restart_publish", "offline"]),
+        (
+            PublishStatus.SUCCESS,
+            "running",
+            ["upgrade", "restart_publish", "offline"],
+        ),
         (PublishStatus.RELEASED, "offline", []),
         (PublishStatus.FAILED, "deploying", ["retry"]),
     ],
@@ -334,6 +343,230 @@ def test_draft_delete_is_blocked_while_an_online_version_exists(deps):
         level=PermissionLevel.OWNER,
         all_records=[draft, online],
     ) == ["publish_staging"]
+
+
+def test_running_upgrade_is_hidden_when_a_non_failed_successor_exists(deps):
+    online = record(1, PublishStatus.SUCCESS, version=1)
+    successor = record(2, PublishStatus.DRAFT, version=2)
+    successor.last_pub_id = online.id
+
+    assert deps.facade._actions(
+        online,
+        level=PermissionLevel.ADMIN,
+        all_records=[online, successor],
+    ) == ["restart_publish", "offline"]
+
+
+def test_running_upgrade_remains_available_after_a_failed_successor(deps):
+    online = record(1, PublishStatus.SUCCESS, version=1)
+    failed = record(2, PublishStatus.FAILED, version=2)
+    failed.last_pub_id = online.id
+
+    assert deps.facade._actions(
+        online,
+        level=PermissionLevel.ADMIN,
+        all_records=[online, failed],
+    ) == ["upgrade", "restart_publish", "offline"]
+
+
+def test_running_upgrade_is_hidden_from_members(deps):
+    online = record(1, PublishStatus.SUCCESS, version=1)
+
+    assert deps.facade._actions(
+        online,
+        level=PermissionLevel.MEMBER,
+        all_records=[online],
+    ) == ["restart_publish", "offline"]
+
+
+def test_upgrade_publication_creates_and_projects_the_next_draft(deps, monkeypatch):
+    monkeypatch.setattr(
+        "agentclaw.community.core.service_bot.services.service_publication_facade.get_current_env",
+        lambda: "dev",
+    )
+    online = record(1, PublishStatus.SUCCESS, version=1)
+    created = record(2, PublishStatus.DRAFT, version=2)
+    created.last_pub_id = online.id
+    deps.collaborator_service.get_permission_level.return_value = PermissionLevel.ADMIN
+    deps.publish_repo.get_by_id.side_effect = [online, created]
+    deps.publish_repo.list_by_source_bot.side_effect = [[online], [online, created]]
+    deps.publish_service.upgrade_publish.return_value = created
+
+    result = deps.facade.upgrade_publication(
+        "bot-1",
+        online.id,
+        actor_id="admin",
+        owner_id="owner",
+    )
+
+    assert result["publication_id"] == created.id
+    assert result["version"] == 2
+    assert result["status"] == "draft"
+    deps.publish_service.upgrade_publish.assert_called_once_with(
+        publish_id=online.id,
+        owner_id="owner",
+    )
+
+
+def test_upgrade_publication_rejects_a_publication_from_another_bot(deps, monkeypatch):
+    monkeypatch.setattr(
+        "agentclaw.community.core.service_bot.services.service_publication_facade.get_current_env",
+        lambda: "dev",
+    )
+    deps.publish_repo.get_by_id.return_value = record(
+        1,
+        PublishStatus.SUCCESS,
+        source_bot_pk=99,
+    )
+
+    with pytest.raises(ServicePublicationNotFoundError):
+        deps.facade.upgrade_publication(
+            "bot-1",
+            1,
+            actor_id="admin",
+            owner_id="owner",
+        )
+
+    deps.publish_service.upgrade_publish.assert_not_called()
+
+
+def test_upgrade_publication_rejects_member_permission(deps):
+    deps.collaborator_service.get_permission_level.return_value = PermissionLevel.MEMBER
+
+    with pytest.raises(ServicePublicationNotFoundError):
+        deps.facade.upgrade_publication(
+            "bot-1",
+            1,
+            actor_id="member",
+            owner_id="owner",
+        )
+
+    deps.publish_repo.get_by_id.assert_not_called()
+    deps.publish_service.upgrade_publish.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "status",
+    [
+        PublishStatus.DRAFT,
+        PublishStatus.VALIDATING,
+        PublishStatus.RELEASED,
+        PublishStatus.FAILED,
+    ],
+)
+def test_upgrade_publication_requires_a_running_source(deps, monkeypatch, status):
+    monkeypatch.setattr(
+        "agentclaw.community.core.service_bot.services.service_publication_facade.get_current_env",
+        lambda: "dev",
+    )
+    source = record(1, status, version=1)
+    deps.publish_repo.get_by_id.return_value = source
+    deps.publish_repo.list_by_source_bot.return_value = [source]
+
+    with pytest.raises(ServicePublicationConflictError):
+        deps.facade.upgrade_publication(
+            "bot-1",
+            source.id,
+            actor_id="admin",
+            owner_id="owner",
+        )
+
+    deps.publish_service.upgrade_publish.assert_not_called()
+
+
+def test_upgrade_publication_rejects_when_a_non_failed_successor_exists(
+    deps, monkeypatch
+):
+    monkeypatch.setattr(
+        "agentclaw.community.core.service_bot.services.service_publication_facade.get_current_env",
+        lambda: "dev",
+    )
+    online = record(1, PublishStatus.SUCCESS, version=1)
+    successor = record(2, PublishStatus.DRAFT, version=2)
+    successor.last_pub_id = online.id
+    deps.publish_repo.get_by_id.return_value = online
+    deps.publish_repo.list_by_source_bot.return_value = [online, successor]
+    deps.publish_service.can_upgrade_publish.return_value = False
+
+    with pytest.raises(ServicePublicationConflictError):
+        deps.facade.upgrade_publication(
+            "bot-1",
+            online.id,
+            actor_id="admin",
+            owner_id="owner",
+        )
+
+    deps.publish_service.upgrade_publish.assert_not_called()
+
+
+def test_upgrade_publication_preserves_legacy_failed_successor_retry(
+    deps, monkeypatch
+):
+    monkeypatch.setattr(
+        "agentclaw.community.core.service_bot.services.service_publication_facade.get_current_env",
+        lambda: "dev",
+    )
+    online = record(1, PublishStatus.SUCCESS, version=1)
+    failed = record(2, PublishStatus.FAILED, version=2)
+    failed.last_pub_id = online.id
+    deps.collaborator_service.get_permission_level.return_value = PermissionLevel.ADMIN
+    deps.publish_repo.get_by_id.side_effect = [online, failed]
+    deps.publish_repo.list_by_source_bot.side_effect = [
+        [online, failed],
+        [online, failed],
+    ]
+    deps.publish_service.upgrade_publish.return_value = failed
+
+    result = deps.facade.upgrade_publication(
+        "bot-1",
+        online.id,
+        actor_id="admin",
+        owner_id="owner",
+    )
+
+    assert result["publication_id"] == failed.id
+    assert result["internal_status"] == PublishStatus.FAILED.value
+    assert result["available_actions"] == ["retry"]
+    deps.publish_service.upgrade_publish.assert_called_once_with(
+        publish_id=online.id,
+        owner_id="owner",
+    )
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [PublishNotFoundError("gone"), PublishStatusInvalidError("changed")],
+)
+def test_upgrade_publication_normalizes_concurrent_state_changes(
+    deps, monkeypatch, failure
+):
+    monkeypatch.setattr(
+        "agentclaw.community.core.service_bot.services.service_publication_facade.get_current_env",
+        lambda: "dev",
+    )
+    online = record(1, PublishStatus.SUCCESS, version=1)
+    deps.publish_repo.get_by_id.return_value = online
+    deps.publish_repo.list_by_source_bot.return_value = [online]
+    deps.publish_service.upgrade_publish.side_effect = failure
+
+    with pytest.raises(ServicePublicationConflictError):
+        deps.facade.upgrade_publication(
+            "bot-1",
+            online.id,
+            actor_id="admin",
+            owner_id="owner",
+        )
+
+
+def test_version_upgrade_keeps_the_legacy_admin_authorization_bar():
+    key = (
+        "POST",
+        "/openapi/v1/bots/{bot_id}/lifecycle/{publication_id}/upgrade",
+    )
+    rule = AUTHORIZATION[key]
+
+    assert isinstance(rule, Check)
+    assert rule.level is PermissionLevel.ADMIN
 
 
 def test_failed_projection_sanitizes_error_and_uses_source_status(deps, monkeypatch):

--- a/src/backend/tests/community/endpoints/test_openapi_service_publications.py
+++ b/src/backend/tests/community/endpoints/test_openapi_service_publications.py
@@ -56,6 +56,7 @@ _OWNER = "lifecycle-owner"
 _BOT_ID = "lifecycle-bot"
 _KEY = "service-publications-framework-signing-key-32b"
 _LIFECYCLE = "/openapi/v1/bots/{bot_id}/lifecycle"
+_LIFECYCLE_UPGRADE = f"{_LIFECYCLE}/{{publication_id}}/upgrade"
 _EDIT_LOCK = "/openapi/v1/bots/{bot_id}/edit-lock"
 _PATH_PARAMS = {"bot_id": _BOT_ID}
 #: Timestamps as a string, the shape the facade's own projection emits and the
@@ -168,6 +169,12 @@ def _seed_happy_services(world) -> None:
     def convert_to_service(_self, bot_id, **_kwargs):
         return _publication(bot_id)
 
+    def upgrade_publication(_self, bot_id, publication_id, **_kwargs):
+        result = _publication(bot_id)
+        result["publication_id"] = publication_id
+        result["card_id"] = f"service:{bot_id}:{publication_id}"
+        return result
+
     def get_service_config(_self, bot_id, **_kwargs):
         return {"bot_id": bot_id, "should_approval": False}
 
@@ -211,6 +218,7 @@ def _seed_happy_services(world) -> None:
         {
             "list_publications": list_publications,
             "convert_to_service": convert_to_service,
+            "upgrade_publication": upgrade_publication,
             "get_service_config": get_service_config,
             "update_service_config": update_service_config,
             "advance": advance,
@@ -260,6 +268,17 @@ _HAPPY_CASES = (
         "POST",
         f"{_LIFECYCLE}/upgrade",
         _case(),
+        200,
+        {"code": 200000, "data": {"card_id": _CARD_ID, "status": "draft"}},
+    ),
+    (
+        "POST",
+        _LIFECYCLE_UPGRADE,
+        CaseInput(
+            path_params={**_PATH_PARAMS, "publication_id": _PUBLICATION_ID},
+            query_params=_QUERY,
+            headers=_HEADERS,
+        ),
         200,
         {"code": 200000, "data": {"card_id": _CARD_ID, "status": "draft"}},
     ),
@@ -367,7 +386,7 @@ for _method, _path, _input, _status, _contains in _HAPPY_CASES:
         path=_path,
         scenario="forbidden_user_scope",
         input=CaseInput(
-            path_params=_PATH_PARAMS,
+            path_params=_input.path_params,
             query_params=_FORBIDDEN_QUERY,
             headers=_HEADERS,
             json_body=_input.json_body,


### PR DESCRIPTION
## Summary

- expose an OpenAPI endpoint for upgrading a running service-Bot publication into its next draft version
- preserve the legacy upgrade eligibility contract, including allowing upgrade when the successor publication is `FAILED`
- publish `upgrade` through lifecycle actions for ADMIN-or-higher callers without introducing per-card repository queries
- register authorization/admission policy and update the global OpenAPI operation inventories

## API

`POST /openapi/v1/bots/{bot_id}/lifecycle/{publication_id}/upgrade`

## Compatibility

- successful upgrade remains HTTP 200
- delegates write eligibility and idempotency to the existing `BotPublishService.can_upgrade_publish()` / `upgrade_publish()` flow
- existing personal-to-service `POST /lifecycle/upgrade` behavior is unchanged
- edit-lock behavior remains the refactored draft-only model

## Delivery

This PR targets `dev` for a later release and replaces the closed iteration PR #1479.

## Tests

- `177 passed`: service publication facade, endpoint handlers, full HTTP cases, authorization/admission inventories, OpenAPI schema gates, explicit user-id invariants, and owner/stage addressing invariants
- focused Ruff checks passed
- `git diff --check` passed
- pre-push Python SAST gate passed against `origin/dev`