### PR TITLE
Fix/agent public

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -12,7 +12,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
-from agentclaw.community.plugin_api.approval_workflow import ApprovalWorkflowPlugin
+from agentclaw.community.plugin_api.approval_workflow import (
+    NO_WORKFLOW_MARKER,
+    ApprovalWorkflowPlugin,
+)
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.bot_management.services.bot_service import BotService
 from agentclaw.community.core.bot_management.services.bcn_service import BcnService
@@ -66,6 +69,14 @@ def _resolve_access_mode(public: str, friend_approval: str) -> str:
     if public == "1" and friend_approval == "0":
         return "OPEN"
     return "RESTRICTED"
+
+
+def _is_workflow_unavailable(result: Dict[str, Any]) -> bool:
+    """True when ``start_approval`` returned "no approval capability" rather
+    than a real rejection. No-workflow impls prepend ``NO_WORKFLOW_MARKER`` to
+    ``error_msg`` (see ``plugin_api/approval_workflow.py``); callers must treat
+    this as a fall-through to direct publish, not a failure."""
+    return (result.get("error_msg") or "").startswith(NO_WORKFLOW_MARKER)
 
 
 # BCS-publish destination label for the approval prompt, keyed by public_scope.
@@ -587,10 +598,35 @@ class BotPublicService:
             biz_type="botpublic",
             context=context,
         )
+        # The protocol promises no-workflow callers fall through to direct
+        # publish (NOT a failure). In the community build NoApprovalWorkflow
+        # (and local LocalAntProcessService) report "no approval capability" —
+        # distinguished from a real rejection by the NO_WORKFLOW_MARKER prefix
+        # on error_msg. We treat that as auto-approved (AGREE): synthesize a
+        # COMPLETED result so the persist + inline-callback path below drives
+        # the BCS friend_ext update (status AGREE + visibility flip) exactly
+        # like corp's auto-completed tenant, instead of raising (which the old
+        # code did for any success=False — turning every community publish into
+        # a 500). No real ticket was created, so puid stays None;
+        # _apply_callback_decision keys the BCS write off public_scope, not
+        # puid. The returned state is reported SKIPPED (the approval step was
+        # skipped) even though the BCS update did run — see the
+        # ``workflow_unavailable`` handling before the return.
+        workflow_unavailable = False
         if not approval_result.get("success"):
-            raise BotPublicServiceError(
-                f"创建审批失败: {approval_result.get('error_msg')}"
-            )
+            if not _is_workflow_unavailable(approval_result):
+                raise BotPublicServiceError(
+                    f"创建审批失败: {approval_result.get('error_msg')}"
+                )
+            workflow_unavailable = True
+            approval_result = {
+                "success": True,
+                "state": "COMPLETED",
+                "lastOperate": "AGREE",
+                "puid": None,
+                "approval_url": None,
+                "error_msg": approval_result.get("error_msg"),
+            }
         # 记录工单信息到 BCS friend_ext.public_user_approval (PROCESSING):
         # GET→merge→PATCH (Provider 管理 API, 同 BcnService 鉴权). 失败不中断已建工单.
         try:
@@ -624,6 +660,18 @@ class BotPublicService:
                 logger.warning(
                     "[public_bcs_bot] COMPLETED inline callback failed: %s", exc
                 )
+        # The no-workflow fall-through reused the persist + AGREE inline-callback
+        # path above to drive the BCS update; surface the *approval* outcome as
+        # SKIPPED (no approval step ran) rather than the synthesized COMPLETED.
+        if workflow_unavailable:
+            return {
+                "success": True,
+                "state": "SKIPPED",
+                "puid": None,
+                "approval_url": None,
+                "last_operate": "agree",
+                "error_msg": approval_result.get("error_msg"),
+            }
         return approval_result
 
     def _publish_callbacks(self) -> BotPublishCallbacks:
@@ -862,10 +910,16 @@ class BotPublicService:
         public/protected 仍走工单, 见 public_bcs_bot 主流程。
         """
         field = _BCS_VISIBILITY_FIELD_BY_SCOPE[public_scope]
-        self._bcn_service.patch_attributes(bot_uuid=bot_uid, body={field: "private"})
+        patched = self._bcn_service.patch_attributes(
+            bot_uuid=bot_uid, body={field: "private"}
+        )
+        # patch_attributes returns {"skipped": True} when community has no BCS
+        # provider creds (non prod/pre); report that truthfully as SKIPPED
+        # instead of faking COMPLETED.
+        skipped = isinstance(patched, dict) and bool(patched.get("skipped"))
         return {
             "success": True,
-            "state": "COMPLETED",
+            "state": "SKIPPED" if skipped else "COMPLETED",
             "puid": None,
             "approval_url": None,
             "visibility": "private",

--- a/src/backend/src/agentclaw/community/plugin_api/approval_workflow.py
+++ b/src/backend/src/agentclaw/community/plugin_api/approval_workflow.py
@@ -13,6 +13,14 @@ from agentclaw.community.plugin_api.base import Plugin
 
 DEFAULT_PROCESS_CODE = "agentclaw_bot_publish"
 
+# Marker prepended to ``error_msg`` by no-workflow impls (community
+# ``NoApprovalWorkflow``, local ``LocalAntProcessService``) so callers can tell
+# "this profile has no approval capability" apart from "the workflow service
+# rejected this request". The protocol's contract promises the former case is a
+# fall-through to direct publish, not a failure; ``BotPublicService.public_bcs_bot``
+# relies on matching this prefix to avoid raising 500 in the community build.
+NO_WORKFLOW_MARKER = "[no-approval-workflow] "
+
 
 @runtime_checkable
 class ApprovalWorkflowPlugin(Plugin, Protocol):
@@ -42,6 +50,10 @@ class ApprovalWorkflowPlugin(Plugin, Protocol):
                                        "approval_url": None, "error_msg": <reason>}``.
             - No workflow available: ``{"success": False, "puid": None,
                         "approval_url": None, "error_msg": <reason-unavailable>}``.
+                        Implementations with no workflow prepend
+                        ``NO_WORKFLOW_MARKER`` to ``error_msg`` so callers can
+                        treat "capability unavailable" as a fall-through, not
+                        a failure.
         """
         ...
 

--- a/src/backend/src/agentclaw/community/plugins/community/approval_workflow.py
+++ b/src/backend/src/agentclaw/community/plugins/community/approval_workflow.py
@@ -12,11 +12,12 @@ from __future__ import annotations
 from typing import Any, Optional
 
 from agentclaw.community.plugin_api.approval_workflow import (
+    NO_WORKFLOW_MARKER,
     ApprovalWorkflowPlugin,
     DEFAULT_PROCESS_CODE,
 )
 
-_NO_WORKFLOW = "no approval workflow in the community build"
+_NO_WORKFLOW = NO_WORKFLOW_MARKER + "no approval workflow in the community build"
 
 
 class NoApprovalWorkflow(ApprovalWorkflowPlugin):

--- a/src/backend/src/agentclaw/community/plugins/local/antprocess.py
+++ b/src/backend/src/agentclaw/community/plugins/local/antprocess.py
@@ -16,6 +16,7 @@ from typing import Any, Optional
 
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.approval_workflow import (
+    NO_WORKFLOW_MARKER,
     ApprovalWorkflowPlugin,
     DEFAULT_PROCESS_CODE,
 )
@@ -31,7 +32,7 @@ _LOCAL_NOT_STARTED: dict[str, Any] = {
     "approval_url": None,
     "state": None,
     "lastOperate": None,
-    "error_msg": "local mode — antprocess unavailable",
+    "error_msg": NO_WORKFLOW_MARKER + "local mode — antprocess unavailable",
 }
 
 

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -7,6 +7,7 @@ from agentclaw.community.core.bot_public.services.bot_public_service import (
     BotNotFoundError,
     BotPublicServiceError,
 )
+from agentclaw.community.plugin_api.approval_workflow import NO_WORKFLOW_MARKER
 from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogAddress,
     BotCatalogCaller,
@@ -210,6 +211,46 @@ class TestPublicBcsBot:
                 bot_uid="b1", owner_id="u1", public_scope="user",
                 operator=_make_operator(),
             )
+
+    def test_no_workflow_falls_through_to_skipped_with_agree_callback(self):
+        # community/local NoApprovalWorkflow reports "no approval capability"
+        # (NO_WORKFLOW_MARKER prefix) rather than a real rejection. The protocol
+        # promises callers fall through to direct publish, NOT fail — and the
+        # fall-through is treated as auto-approved (AGREE): public_bcs_bot runs
+        # the same persist + inline-callback path as corp's COMPLETED tenant so
+        # BCS friend_ext still gets an AGREE update, surfacing the *approval*
+        # outcome as state=SKIPPED (no approval step ran) instead of raising
+        # (which the old code did for any success=False — a 500 every community
+        # publish).
+        process = MagicMock()
+        process.start_approval.return_value = {
+            "success": False,
+            "error_msg": NO_WORKFLOW_MARKER + "no approval workflow in the community build",
+        }
+        bot_repo = MagicMock()
+        bot_repo.get_by_id_and_owner.return_value = _make_bot(bot_id="b1", owner_id="u1")
+        svc = _make_service(process_service=process, bot_repository=bot_repo)
+
+        with patch.object(svc, "handle_public_approval_callback") as cb:
+            result = svc.public_bcs_bot(
+                bot_uid="b1", owner_id="u1", public_scope="user",
+                operator=_make_operator(staff_id="op_user"),
+            )
+
+        process.start_approval.assert_called_once()
+        # Fall-through (NOT raise): approval step skipped, AGREE callback fired.
+        assert result["success"] is True
+        assert result["state"] == "SKIPPED"
+        assert result["puid"] is None
+        assert result["last_operate"] == "agree"
+        assert result["error_msg"].startswith(NO_WORKFLOW_MARKER)
+        cb.assert_called_once()
+        ckw = cb.call_args.kwargs
+        assert ckw["bot_id"] == "b1"
+        assert ckw["owner_id"] == "u1"
+        assert ckw["puid"] is None
+        assert ckw["last_operate"] == "agree"
+        assert ckw["public_scope"] == "user"
 
     def test_rejects_empty_owner_id(self):
         svc = _make_service()


### PR DESCRIPTION
## Problem

  `BotPublicService.public_bcs_bot` calls `ApprovalWorkflowPlugin.start_approval` directly and raises `BotPublicServiceError` for any `success=False`; the route's `@envelope_errors` maps that to `500 "Publish
  failed"`. The community build binds `ApprovalWorkflowPlugin` to `NoApprovalWorkflow` (`plugins/community/approval_workflow.py`), which always returns `success=False`. Result: **every `public`/`protected` publish in
  the community build returns 500.**

  This contradicts the protocol's stated intent — `plugin_api/approval_workflow.py` documents "the community implementation reports 'no workflow' so callers fall through to direct publish." The legacy `public_bot`
  delegates to `BotPublishApprovalPlugin.publish`, and community's `DirectPublishApproval` relies on that exact fall-through to publish without an approval service. Only `public_bcs_bot` bypasses the strategy and
  treats "capability unavailable" as "rejected."

  ## Solution

  Add a unified sentinel and branch on it inside `public_bcs_bot` — no existing interface/protocol changes.

  - New `NO_WORKFLOW_MARKER = "[no-approval-workflow] "` (`plugin_api/approval_workflow.py`), with the protocol docstring documenting the fall-through convention that relies on it.
  - Prepend the marker in both no-workflow plugins: `plugins/community/approval_workflow.py` (`NoApprovalWorkflow`) and `plugins/local/antprocess.py` (`LocalAntProcessService`).
  - `public_bcs_bot` (`core/bot_public/services/bot_public_service.py`) now has three branches after `start_approval`:
    - `success=True` (corp real ticket) → unchanged.
    - **unavailable** (marker prefix) → synthesize `COMPLETED/AGREE` and reuse the existing `_persist_public_approval` + inline `handle_public_approval_callback` path, driving the BCS `friend_ext` AGREE update +
  visibility flip exactly like corp's auto-completed tenant; return `state=SKIPPED` (the approval step was skipped, but the BCS update did run).
    - real rejection (no marker) → still raises.
  - hygiene: `_apply_visibility_direct` reports `state=SKIPPED` when `patch_attributes` returned `skipped` (no provider creds) instead of faking `COMPLETED`.

  Rejected: (a) a fully direct-BCS "no-op" return — would silently skip the BCS visibility flip the publish is supposed to apply; (b) an explicit `available` capability flag on the `ApprovalWorkflowPlugin` return
  shape — would require synchronizing the change across community/local/corp workflow impls; (c) `isinstance`-checking against `NoApprovalWorkflow` — couples the service to a concrete impl. The sentinel-prefix
  approach changes neither any protocol's return shape nor the corp path, and the two tests asserting the sentinel tolerate a prefix (truthiness / substring), so no existing test changed.

  ## Validation

  - `pytest tests/community/core/bot_public/test_bot_public_service.py::TestPublicBcsBot tests/community/contracts/test_approval_workflow.py` → 34 passed.
  - `pytest tests/community/endpoints/test_openapi_public_bcs.py tests/community/adapters/http/openapi_v1/test_collaboration_bots_endpoints.py tests/community/core/bot_public
  tests/community/adapters/http/openapi_v1/bot_public` → 180 passed.
  - community-profile injector smoke (real `NoApprovalWorkflow` via `build_injector(DeployProfile.COMMUNITY)`, non-mocked BCS) → 2 GET / 2 PATCH; the AGREE patch carries the `visibility` field and
  `friend_ext.public_agent_approval.status=AGREE`; returns `state=SKIPPED`, no raise. ✅
  - Could not run: end-to-end corp/real-antprocess path (corp workflow impl is not in this community checkout).

  ## Compatibility and risk (optional)

  - Wire shape: `BcsPublishResult` (`adapters/http/openapi_v1/collaboration_bots/schemas.py`) already carries `state`/`error_msg` with `extra="allow"`, so the new `SKIPPED` value and the carried `error_msg` survive
  `model_validate`; response surface stable.
  - No protocol/interface changes; no schema/config/migration impact; no rollback path needed beyond reverting the commit.
  - Behavior changes: community `public`/`protected` publishes now succeed with `state=SKIPPED` (previously 500); `visibility=private` direct path now reports `SKIPPED` when BCS is skipped (previously misleading
  `COMPLETED`). corp real-antprocess path is unchanged on all branches.

  ## Spec (optional)

  `public_bcs_bot` contract: `core/bot_public/services/bot_public_service.py:436`. BCS field/scope maps: `_BCS_VISIBILITY_FIELD_BY_SCOPE`, `_BCS_APPROVAL_KEY_BY_SCOPE`, `_BCS_VIEW_SCOPE_DEPS_KEY_BY_SCOPE`. Callback
  decision path: `_apply_callback_decision`.

  ## Related issues (optional)

  Follow-ups tracked out of scope (separate PRs): `biz_id` second-granularity collision (`public_bcs_bot:520`); `handle_public_approval_callback` legacy retry comment vs `max_retries=1` mismatch (`:909-911`, unrelated
  non-`public_scope` path).