### PR TITLE
feat(baas): add device_id to bot http-info and ws-info responses

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/bot_service/http_conn_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bot_service/http_conn_router.py
@@ -37,6 +37,7 @@ class BotHttpConnectionInfoResponse(BaseModel):
     target: str = Field(
         ..., description="Target identifier (format: {platform}_{device_id}:{port})"
     )
+    device_id: str = Field(..., description="PaaS device id of the selected device")
 
 
 class BotHttpConnectionErrorResponse(BaseModel):
@@ -139,6 +140,7 @@ async def get_bot_http_connection_info(
                 http_url=conn_info.http_url,
                 token=conn_info.token,
                 target=conn_info.target,
+                device_id=conn_info.device_id,
             )
         )
 

--- a/src/baas/src/secbaas/community/adapters/web/routers/bot_service/wss_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/bot_service/wss_router.py
@@ -39,6 +39,7 @@ class BotWsConnectionInfoResponse(BaseModel):
         ..., description="Target identifier (format: {platform}_{device_id}:{port})"
     )
     expires_at: datetime = Field(..., description="Token expiration timestamp (UTC)")
+    device_id: str = Field(..., description="PaaS device id of the selected device")
 
 
 class BotWsConnectionErrorResponse(BaseModel):
@@ -151,6 +152,7 @@ async def get_bot_ws_connection_info(
                 token=conn_info.token,
                 target=conn_info.target,
                 expires_at=conn_info.expires_at,
+                device_id=conn_info.device_id,
             )
         )
 

--- a/src/baas/src/secbaas/community/api/bot_runtime/_http_connection_info.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/_http_connection_info.py
@@ -15,8 +15,12 @@ class HttpConnectionInfo:
         target: Target identifier for the connection
             (e.g., "antclaw-a1b2c3.inc.example.net:9999:12345").
             Empty string for platforms that don't populate it.
+        device_id: PaaS device id of the selected device
+            (e.g., "antclaw-a1b2c3"). Empty string until the dispatcher
+            backfills it on the success path.
     """
 
     http_url: str
     token: str
     target: str = ""
+    device_id: str = ""

--- a/src/baas/src/secbaas/community/api/bot_runtime/_ws_connection_info.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/_ws_connection_info.py
@@ -14,9 +14,13 @@ class WsConnectionInfo:
         token: JWT proxypass token for authentication at the gateway
         target: Target identifier (format: ARCA_{sandbox_id}:{port})
         expires_at: Token expiration timestamp (UTC)
+        device_id: PaaS device id of the selected device
+            (e.g., "ARCA_SANDBOX-abc"). Empty string until the dispatcher
+            backfills it on the success path.
     """
 
     ws_url: str
     token: str
     target: str
     expires_at: datetime
+    device_id: str = ""

--- a/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_http_conn_info_dispatcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_http_conn_info_dispatcher.py
@@ -90,6 +90,7 @@ class DefaultBotHttpConnInfoDispatcher(BotBaseDispatcher, BotHttpConnInfoDispatc
             port=port,
             path=path,
         )
+        conn_info.device_id = paas_device_id
 
         logger.info(f"Dispatched HTTP conn info: http_url={conn_info.http_url}")
 
@@ -176,6 +177,7 @@ class DefaultBotHttpConnInfoDispatcher(BotBaseDispatcher, BotHttpConnInfoDispatc
             port=port,
             path=path,
         )
+        conn_info.device_id = paas_device_id
 
         logger.info(
             f"Dispatched HTTP connection for specific device: "

--- a/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_wss_dispatcher.py
+++ b/src/baas/src/secbaas/community/core/service/bot_runtime/dispatcher/_wss_dispatcher.py
@@ -91,6 +91,7 @@ class DefaultBotWssDispatcher(BotBaseDispatcher, BotWssDispatcher):
             path=path,
             ws_conn_mode=ws_conn_mode,
         )
+        conn_info.device_id = paas_device_id
 
         logger.info(
             f"Dispatched WS connection: ws_url={conn_info.ws_url}, "
@@ -178,6 +179,7 @@ class DefaultBotWssDispatcher(BotBaseDispatcher, BotWssDispatcher):
             path=path,
             ws_conn_mode=ws_conn_mode,
         )
+        conn_info.device_id = paas_device_id
 
         logger.info(
             f"Dispatched WS connection for specific device: "

--- a/src/baas/tests/unit/adapters/web/test_bot_http_conn_router.py
+++ b/src/baas/tests/unit/adapters/web/test_bot_http_conn_router.py
@@ -119,6 +119,7 @@ async def test_get_http_info_response_fields_complete(mock_dispatcher):
         http_url="http://gw/proxypass/X:1/p",
         token="tok",
         target="TECLAW_b_abc@4:1",
+        device_id="TECLAW_device-abc",
     )
 
     transport = ASGITransport(app=app)
@@ -129,10 +130,12 @@ async def test_get_http_info_response_fields_complete(mock_dispatcher):
 
     assert resp.status_code == 200
     data = resp.json()["data"]
-    assert set(data.keys()) == {"http_url", "token", "target"}
+    assert set(data.keys()) == {"http_url", "token", "target", "device_id"}
     assert isinstance(data["http_url"], str)
     assert isinstance(data["token"], str)
+    assert isinstance(data["device_id"], str)
     assert data["target"] == "TECLAW_b_abc@4:1"
+    assert data["device_id"] == "TECLAW_device-abc"
 
 
 @pytest.mark.asyncio

--- a/src/baas/tests/unit/adapters/web/test_bot_wss_router.py
+++ b/src/baas/tests/unit/adapters/web/test_bot_wss_router.py
@@ -131,6 +131,7 @@ async def test_get_ws_info_response_fields_complete(mock_dispatcher):
         token="tok",
         target="X:1",
         expires_at=now,
+        device_id="ARCA_device-xyz",
     )
 
     transport = ASGITransport(app=app)
@@ -141,11 +142,13 @@ async def test_get_ws_info_response_fields_complete(mock_dispatcher):
 
     assert resp.status_code == 200
     data = resp.json()["data"]
-    assert set(data.keys()) == {"ws_url", "token", "target", "expires_at"}
+    assert set(data.keys()) == {"ws_url", "token", "target", "expires_at", "device_id"}
     assert isinstance(data["ws_url"], str)
     assert isinstance(data["token"], str)
     assert isinstance(data["target"], str)
     assert isinstance(data["expires_at"], str)
+    assert isinstance(data["device_id"], str)
+    assert data["device_id"] == "ARCA_device-xyz"
 
 
 @pytest.mark.asyncio

--- a/src/baas/tests/unit/api/bot_runtime/test_http_connection_info.py
+++ b/src/baas/tests/unit/api/bot_runtime/test_http_connection_info.py
@@ -20,6 +20,7 @@ class TestHttpConnectionInfo:
 
         assert info.http_url == "http://antclaw-a1b2c3.inc.service.test:9999"
         assert info.token == "abc123"
+        assert info.device_id == ""
 
     def test_fields_are_positional_no_defaults(self) -> None:
         """HttpConnectionInfo fields should be positional-only (no default values)."""
@@ -45,3 +46,24 @@ class TestHttpConnectionInfo:
         )
         assert isinstance(info.http_url, str)
         assert isinstance(info.token, str)
+
+    def test_device_id_defaults_to_empty_and_is_writable(self) -> None:
+        """device_id defaults to empty string and can be backfilled by the dispatcher."""
+        info = HttpConnectionInfo(
+            http_url="http://antclaw-a1b2c3.inc.service.test:9999",
+            token="abc123",
+        )
+        assert info.device_id == ""
+
+        info.device_id = "antclaw-a1b2c3"
+        assert info.device_id == "antclaw-a1b2c3"
+
+    def test_create_with_explicit_device_id(self) -> None:
+        """device_id can be provided explicitly at construction time."""
+        info = HttpConnectionInfo(
+            http_url="http://antclaw-a1b2c3.inc.service.test:9999",
+            token="abc123",
+            target="antclaw-a1b2c3:9999:12345",
+            device_id="antclaw-a1b2c3",
+        )
+        assert info.device_id == "antclaw-a1b2c3"

--- a/src/baas/tests/unit/api/bot_runtime/test_ws_connection_info.py
+++ b/src/baas/tests/unit/api/bot_runtime/test_ws_connection_info.py
@@ -31,6 +31,22 @@ class TestWsConnectionInfo:
         assert info.token == "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test"
         assert info.target == "ARCA_SANDBOX-123:8080"
         assert info.expires_at == expires
+        assert info.device_id == ""
+
+    def test_device_id_defaults_to_empty_and_is_writable(self) -> None:
+        """device_id defaults to empty string and can be backfilled by the dispatcher."""
+        expires = datetime.now(UTC) + timedelta(seconds=300)
+
+        info = WsConnectionInfo(
+            ws_url="wss://test.com/ws",
+            token="token123",
+            target="ARCA_TEST:8080",
+            expires_at=expires,
+        )
+        assert info.device_id == ""
+
+        info.device_id = "ARCA_TEST"
+        assert info.device_id == "ARCA_TEST"
 
     def test_ws_connection_info_immutable_by_default(self) -> None:
         """Dataclass should be immutable by default (frozen)."""

--- a/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_bot_http_conn_info_dispatcher.py
+++ b/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_bot_http_conn_info_dispatcher.py
@@ -146,6 +146,7 @@ class TestDispatchBotHttpConnInfo:
         # Verify result
         assert result.http_url.startswith("http://")
         assert result.token == "test-jwt-token"
+        assert result.device_id == "ARCA-SANDBOX-test-001"
 
         # Verify facade was called with provider_device_id directly
         mock_paas_facade.resolve_invoke_http_info.assert_awaited_once()
@@ -537,6 +538,7 @@ class TestDispatchBotHttpConnInfoWithDeviceUuid:
 
         assert result.http_url.startswith("http://")
         assert result.token == "test-jwt-token"
+        assert result.device_id == "ARCA-SANDBOX-test-001"
         mock_paas_facade.resolve_invoke_http_info.assert_awaited_once_with(
             paas_device_id="ARCA-SANDBOX-test-001",
             port=20003,

--- a/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_bot_wss_dispatcher.py
+++ b/src/baas/tests/unit/core/service/bot_runtime/dispatcher/test_bot_wss_dispatcher.py
@@ -382,6 +382,7 @@ class TestDispatchBotWsConnInfo:
         assert result.ws_url.startswith("wss://")
         assert result.token == "test-jwt-token"
         assert "20003" in result.target
+        assert result.device_id == "ARCA-SANDBOX-test-001"
 
         # Verify facade was called with provider_device_id directly
         mock_paas_facade.resolve_ws_conn_info.assert_awaited_once()
@@ -790,6 +791,7 @@ class TestDispatchBotWsConnInfoWithDeviceUuid:
 
         assert result.ws_url.startswith("wss://")
         assert result.token == "test-jwt-token"
+        assert result.device_id == "ARCA-SANDBOX-test-001"
         # Verify facade was called with the correct device's provider_device_id
         mock_paas_facade.resolve_ws_conn_info.assert_awaited_once_with(
             paas_device_id="ARCA-SANDBOX-test-001",


### PR DESCRIPTION
## What
Adds a required `device_id` string field to the 200 success responses of the bot connection-info endpoints, carrying the PaaS device id selected for the request.

## Endpoints
- GET `/api/v1/bots/{bot_uuid}/http-info`
- GET `/api/v1/bots/{bot_uuid}/ws-info`

## Why
The selected device's PaaS device id was only embedded inside the composite `target` field (format `{platform}_{device_id}:{port}`). Callers had to re-parse `target` with an unstable contract to obtain the underlying device id. Exposing a dedicated field makes device-targeted operations, observability, and auditing reliable.

## Changes
- `HttpConnectionInfo` and `WsConnectionInfo` dataclasses gain a `device_id` field with an empty-string default, preserving the ~87 existing construction sites (sandbox plugins, PaaS services, internal consumers, tests) that do not pass it.
- The HTTP and WS dispatchers backfill the resolved PaaS device id into `device_id` on both the auto-select and `device_uuid`-specified branches (4 convergence points).
- The `BotHttpConnectionInfoResponse` and `BotWsConnectionInfoResponse` Pydantic models expose a required `device_id` string; the routers map it from the connection info. Per the repo convention, a required value is not widened to `T | None` for defensive programming, since the success path always resolves a non-empty device id.

## Backward compatibility
Additive only. Existing fields (http_url/ws_url, token, target, expires_at), status codes, and error structures are unchanged. Existing JSON callers ignore the new unknown field. The dataclass field carries a default so plugin/service/test construction sites need no changes.

## Tests
- Unit tests for both dataclasses cover the default empty value, writability, and explicit construction.
- Dispatcher unit tests assert `device_id` equals the resolved PaaS device id on both the auto-select and specific-device branches, for HTTP and WS.
- Router unit tests assert the response key set includes `device_id` with the correct value, for HTTP and WS.
- Adjacent module suites (api/bot_runtime, dispatcher, bot_run, paas) pass with no regression (2326 passed, 8 xpassed).

## Risk / rollback
Risk is low (additive response field). Rollback is reverting the commit; no config, schema, or data migration is involved.