### PR TITLE
fix(backend): log the envelope's request_id on every /openapi/v1 access line

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -546,6 +546,57 @@ wrong half of the system.
 
 ---
 
+## Tracing one request from a caller's `request_id`
+
+Every response on this surface carries a `request_id` in its envelope and the
+same value in an `X-Trace-ID` header. It is the **server's** trace id — minted
+per request by the bound `TracerPlugin` (community: a uuid4; corp: the tracing
+system's id), never an echo of anything the caller sent. That id is the handle a
+bug report quotes, so the access log writes it under exactly that name:
+
+```text
+openapi_access method=GET path=/openapi/v1/bots/b-42 route=/openapi/v1/bots/{bot_id}
+  status=200 duration_ms=31.4 tenant=acme caller=user:u-1+app:7 query=page=2
+  request_id=b0a6d2f4e8c94b1a9f3d5e7c60218a4d trace_id=b0a6d2f4e8c94b1a9f3d5e7c60218a4d
+  client_request_id=- client=10.0.0.9 ua=acme-sdk/1.2
+```
+
+So the whole diagnosis is one grep for the id the caller quoted, and `route=` is
+the answer to "which endpoint was this against?" — the **template**, not the
+concrete path, so a thousand bot ids aggregate to one line shape. `route` is
+absent (`-`) exactly when nothing matched, which is itself the finding.
+
+One line is emitted per request, on success and on failure alike, including a
+request that left the layer as an exception (`status=-` plus an `error=` field).
+There is a matching `openapi_request_start` at DEBUG, which carries no
+`request_id`: the tracer runs *inside* the access-log middleware — it has to,
+so the log can see the status that actually reached the wire — so the id does
+not exist yet on the way in.
+
+**`request_id` and `client_request_id` are different ids; do not mix them up.**
+
+| Field | Whose id | Where the caller sees it |
+| --- | --- | --- |
+| `request_id` / `trace_id` | ours, server-minted | the response envelope's `request_id`, and the `X-Trace-ID` header |
+| `client_request_id` | the caller's, echoed | the `X-Request-ID` header they sent us |
+
+`request_id` and `trace_id` are deliberately the same value written twice, one
+per name a reader may already hold it by; a search for either finds the line.
+`client_request_id` is a *different* id and never occupies the `request_id`
+field — a line that spelled it `request_id` would answer "which endpoint did
+this id hit?" with the wrong request, and do it silently.
+
+Not logged, on purpose: request and response bodies. They carry bot
+configuration, skill payloads and user content, they are unbounded, and nothing
+about "which endpoint was this" needs them. Query strings *are* logged, with any
+credential-looking parameter's value replaced — see `redact_query` in
+`openapi_v1/access_log.py`.
+
+Scope: `/openapi/v1` only. The internal `/api` surface has its own clients and
+no principal for this line to name.
+
+---
+
 ## Recipe — extend Track A to a new data category (e.g. resources)
 
 1. Find the model(s)/table(s) (e.g. `ResourceModel`, `ac_resource`) and every

--- a/src/backend/src/agentclaw/community/adapters/http/middleware.py
+++ b/src/backend/src/agentclaw/community/adapters/http/middleware.py
@@ -193,11 +193,16 @@ class TraceIdMappingMiddleware(BaseHTTPMiddleware):
         trace_id = self._tracer.current_trace_id()
         request.state.trace_id = trace_id
 
-        request_id = request.headers.get("X-Request-ID")
-        if trace_id and request_id:
+        # ``client_request_id``, not ``request_id``: the caller's header is a
+        # different id from the trace id, and the trace id is what every public
+        # envelope calls ``request_id``. Naming the header field ``request_id``
+        # here would make a search for an envelope's ``request_id`` land on a
+        # line about some other request. Same naming as the public access log.
+        client_request_id = request.headers.get("X-Request-ID")
+        if trace_id and client_request_id:
             logger.info(
-                "trace_mapping request_id=%s trace_id=%s path=%s",
-                request_id, trace_id, request.url.path,
+                "trace_mapping client_request_id=%s trace_id=%s path=%s",
+                client_request_id, trace_id, request.url.path,
             )
 
         response = await call_next(request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/access_log.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/access_log.py
@@ -32,11 +32,21 @@ What one line carries, and why each field earns its place:
     verified set (``user:u-42+app:7``). A request whose principal did not verify
     logs ``tenant=- caller=-``: it is about to be answered ``401``, and *why* it
     failed is already on its own line from the verifier.
-``trace_id`` / ``request_id``
-    The correlation handles. ``trace_id`` ties this line to the rest of the
-    request's logs and to the ``X-Trace-ID`` the client got back; ``request_id``
-    is the caller's own ``X-Request-ID``, which is what a client can quote in a
-    bug report.
+``request_id`` / ``trace_id``
+    The handle a caller can quote back, under the name they know it by. Every
+    public response carries ``request_id`` in its envelope and ``X-Trace-ID`` in
+    its headers, and both are the server's trace id — so this line writes that
+    one value twice, once under each name. That redundancy is the point: the
+    question this middleware exists to answer is "a caller sent me a
+    ``request_id``, which endpoint did it hit?", and the answer has to be a grep
+    for whichever field name the person asking already has in front of them.
+    Reading the two side by side is also how an operator learns they are the
+    same id.
+``client_request_id``
+    The caller's own ``X-Request-ID``, echoed back untouched. A *different* id
+    from the one above — the client's, not ours — which is why it does not share
+    the ``request_id`` name: a line that called this one ``request_id`` would
+    answer the question above with the wrong request, silently.
 ``client`` / ``ua``
     Which peer and which client build. Behind the gateway the peer is the
     gateway, so ``ua`` is usually the more informative of the two.
@@ -114,7 +124,7 @@ _MAX_QUERY = 512
 #: cheapest to reach: the header is caller-supplied, the line is written even for
 #: a request answered ``401``, and a correlation handle that does not fit a uuid
 #: several times over is not a correlation handle.
-_MAX_REQUEST_ID = 128
+_MAX_CLIENT_REQUEST_ID = 128
 
 
 def redact_query(raw: str) -> str:
@@ -187,9 +197,25 @@ def _header(scope: Scope, name: str) -> str:
     return ""
 
 
-def _request_id(scope: Scope) -> str:
+def _client_request_id(scope: Scope) -> str:
     """The caller's ``X-Request-ID``, capped."""
-    return _header(scope, "x-request-id")[:_MAX_REQUEST_ID]
+    return _header(scope, "x-request-id")[:_MAX_CLIENT_REQUEST_ID]
+
+
+def _trace_id(scope: Scope) -> str:
+    """The server's trace id — the same value the envelope calls ``request_id``.
+
+    Read off the ASGI scope's ``state``, where ``TraceIdMappingMiddleware``
+    stashed it and where ``responses._trace_id`` reads it to stamp the envelope.
+    One source, so the line and the body cannot name different ids for the same
+    request.
+
+    Empty until that middleware has run. This middleware is installed *outside*
+    it — it has to be, to see the status that reaches the wire — so the value
+    exists on the way out and not on the way in, which is why only the
+    completion line carries it.
+    """
+    return (scope.get("state") or {}).get("trace_id") or ""
 
 
 def _client(scope: Scope) -> str:
@@ -311,7 +337,11 @@ class PublicApiAccessLogMiddleware:
             _kv("query", _query(scope)),
             _kv("client", _client(scope)),
             _kv("ua", _header(scope, "user-agent")[:_MAX_UA]),
-            _kv("request_id", _request_id(scope)),
+            # No ``request_id``: the tracer runs *inside* this middleware, so
+            # the trace id does not exist yet on the way in. An arrival line is
+            # correlated by its ``client_request_id``, or by the completion line
+            # that follows it.
+            _kv("client_request_id", _client_request_id(scope)),
         ]
 
     def _log_completion(
@@ -328,7 +358,7 @@ class PublicApiAccessLogMiddleware:
         """
         duration_ms = (time.perf_counter() - started) * 1000
         try:
-            state = scope.get("state") or {}
+            trace_id = _trace_id(scope)
             # Self-sufficient on purpose: the start line above is DEBUG and off
             # in every normal deployment, so this line repeats what it said
             # rather than being readable only next to it.
@@ -340,8 +370,11 @@ class PublicApiAccessLogMiddleware:
                 _kv("duration_ms", f"{duration_ms:.1f}"),
                 *_identity_fields(scope),
                 _kv("query", _query(scope)),
-                _kv("trace_id", state.get("trace_id") or ""),
-                _kv("request_id", _request_id(scope)),
+                # Same value, twice, under both names a caller may hold it by.
+                # See the module docstring.
+                _kv("request_id", trace_id),
+                _kv("trace_id", trace_id),
+                _kv("client_request_id", _client_request_id(scope)),
                 _kv("client", _client(scope)),
                 _kv("ua", _header(scope, "user-agent")[:_MAX_UA]),
             ]

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_access_log.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_access_log.py
@@ -11,6 +11,11 @@ operator actually reads the line for:
   rather than guessing a tenant;
 - an unhandled exception produces a line too, and does not change what the
   request answers;
+- the line names the route the request matched, under the same ``request_id``
+  the caller was handed in the response envelope — the property that makes
+  "a caller quoted this id, which endpoint did they hit?" a single grep;
+- the caller's own ``X-Request-ID`` is logged as ``client_request_id``, never as
+  ``request_id``, so the two ids cannot be confused for one another;
 - the internal ``/api`` surface is untouched;
 - a credential in the query string never reaches the log.
 
@@ -184,6 +189,151 @@ def test_unhandled_exception_is_logged_and_still_raised(client, caplog):
     assert field(line, "tenant") == TENANT
 
 
+@pytest.fixture
+def traced_app() -> FastAPI:
+    """The same probe routes, with the trace-id stack wired in production order.
+
+    The default ``app`` fixture omits the tracer, so ``request.state.trace_id``
+    is never set there and every id below would be empty. This one adds the
+    pieces the real ``install_middleware`` adds, in the order it adds them:
+    ``TraceIdMappingMiddleware`` reads the tracer and stashes the id, the
+    tracer's own middleware is installed after it (so it runs *outside*, minting
+    the id first), and the access log is added last of all so it is outside both
+    — which is exactly why it can read the id on the way out.
+
+    ``CommunityTracer`` is the real community binding, not a stub: the id this
+    test correlates on is the one a community deployment actually mints.
+    """
+    from agentclaw.community.adapters.http.app import (
+        _principal_error_handler,
+        _unhandled_exception_handler,
+    )
+    from agentclaw.community.adapters.http.middleware import TraceIdMappingMiddleware
+    from agentclaw.community.core.gateway_principal import PrincipalVerificationError
+    from agentclaw.community.plugins.community.tracer import CommunityTracer
+
+    app = FastAPI()
+    tracer = CommunityTracer()
+    app.add_middleware(AvernetTenantMiddleware)
+    app.add_middleware(TraceIdMappingMiddleware, tracer=tracer)
+    tracer.install(app)
+    app.add_middleware(PublicApiAccessLogMiddleware)
+    # The same handlers, in the same places, as the ``app`` fixture above — a
+    # 401 has to be a *response* here, not an escaping exception, or the error
+    # envelope whose ``request_id`` the last test correlates on is never built.
+    app.add_exception_handler(MissingPrincipalError, _principal_error_handler)
+    app.add_exception_handler(PrincipalVerificationError, _principal_error_handler)
+    app.add_exception_handler(Exception, _unhandled_exception_handler)
+
+    @app.get("/openapi/v1/bots/{bot_id}")
+    @envelope_errors
+    async def get_bot(
+        request: Request,
+        bot_id: str,
+        principal: Principal = Depends(require_principal),
+    ):
+        return envelope({"bot_id": bot_id}, request)
+
+    return app
+
+
+@pytest.fixture
+def traced_client(traced_app: FastAPI) -> TestClient:
+    return TestClient(traced_app, raise_server_exceptions=False)
+
+
+def test_request_id_in_the_line_is_the_one_the_caller_was_given(
+    traced_client, caplog
+):
+    """The whole point: an id from a response envelope finds its endpoint.
+
+    A caller quotes the ``request_id`` their response carried. That one string
+    has to appear on the access line, under that name, next to the route it
+    matched — otherwise answering "which endpoint was this?" means knowing that
+    the envelope's ``request_id`` is really the trace id and searching for a
+    field with a different name, which is knowledge nobody reading a bug report
+    has.
+    """
+    with caplog.at_level(logging.INFO):
+        response = traced_client.get(
+            "/openapi/v1/bots/bot-7", headers={PRINCIPAL_HEADER: mint()}
+        )
+
+    quoted = response.json()["request_id"]
+    assert quoted  # the tracer is wired; an empty id would make this vacuous
+
+    line = access_lines(caplog)[0]
+    assert field(line, "request_id") == quoted
+    assert field(line, "route") == "/openapi/v1/bots/{bot_id}"
+    assert field(line, "method") == "GET"
+
+
+def test_the_three_names_for_the_id_agree(traced_client, caplog):
+    """Envelope body, ``X-Trace-ID`` header, and both log fields: one value.
+
+    A caller may quote any of the three, and each is produced by a different
+    piece of code — the envelope builder, the trace middleware's response
+    header, and this log line. Pinned together because a drift between any two
+    of them is invisible until an incident, when the id someone quotes matches
+    nothing.
+    """
+    with caplog.at_level(logging.INFO):
+        response = traced_client.get(
+            "/openapi/v1/bots/bot-7", headers={PRINCIPAL_HEADER: mint()}
+        )
+
+    line = access_lines(caplog)[0]
+    assert (
+        response.json()["request_id"]
+        == response.headers["X-Trace-ID"]
+        == field(line, "request_id")
+        == field(line, "trace_id")
+    )
+
+
+def test_client_request_id_is_the_callers_header_and_not_the_trace_id(
+    traced_client, caplog
+):
+    """The caller's ``X-Request-ID`` is logged, and kept distinct.
+
+    Both ids are worth having — ours answers "which endpoint", theirs is what a
+    client quotes from its *own* logs — but they are different ids, and the
+    regression this guards is the one where the caller's value occupies the
+    ``request_id`` field: a search for an envelope's id would then either miss
+    the line or, if a client ever sent that string, hit the wrong request.
+    """
+    with caplog.at_level(logging.INFO):
+        response = traced_client.get(
+            "/openapi/v1/bots/bot-7",
+            headers={PRINCIPAL_HEADER: mint(), "X-Request-ID": "caller-abc-123"},
+        )
+
+    line = access_lines(caplog)[0]
+    assert field(line, "client_request_id") == "caller-abc-123"
+    assert field(line, "request_id") == response.json()["request_id"]
+    assert field(line, "request_id") != "caller-abc-123"
+
+
+def test_a_failed_request_is_searchable_by_its_error_envelopes_request_id(
+    traced_client, caplog
+):
+    """An error envelope's ``request_id`` finds its line too.
+
+    The failing call is the one anyone actually quotes an id from, and an error
+    body is built by a different path (``_error_response``) than a success. If
+    only the success path stamped the id the correlation would work for exactly
+    the requests nobody needs to look up.
+    """
+    with caplog.at_level(logging.INFO):
+        response = traced_client.get("/openapi/v1/bots/bot-7")  # no principal
+
+    assert response.status_code == 401
+    line = access_lines(caplog)[0]
+    assert field(line, "request_id") == response.json()["request_id"]
+    assert field(line, "route") == "/openapi/v1/bots/{bot_id}"
+    assert field(line, "status") == "401"
+
+
 def test_internal_api_is_not_logged(client, caplog):
     with caplog.at_level(logging.INFO):
         assert client.get("/api/bots/internal").status_code == 200
@@ -210,7 +360,7 @@ def test_caller_controlled_fields_are_capped(client, caplog):
     having verified anyone first.
     """
     from agentclaw.community.adapters.http.openapi_v1.access_log import (
-        _MAX_REQUEST_ID,
+        _MAX_CLIENT_REQUEST_ID,
         _MAX_UA,
     )
 
@@ -222,7 +372,7 @@ def test_caller_controlled_fields_are_capped(client, caplog):
 
     assert response.status_code == 401  # no principal: the line still gets written
     line = access_lines(caplog)[0]
-    assert len(field(line, "request_id")) == _MAX_REQUEST_ID
+    assert len(field(line, "client_request_id")) == _MAX_CLIENT_REQUEST_ID
     assert len(field(line, "ua")) == _MAX_UA
 
 


### PR DESCRIPTION
## Problem

Every `/openapi/v1` response carries a `request_id` in its envelope (and the same value as `X-Trace-ID`). It is the server-minted trace id, and it is the handle a caller quotes in a bug report. The intended workflow is: take that id, grep the logs, learn which endpoint the call was against.

`PublicApiAccessLogMiddleware` already emitted one line per request naming the matched route, so the information was there — but not under the name the caller holds it by:

```text
openapi_access ... route=/openapi/v1/bots/{bot_id} status=200 ...
  trace_id=62f5a61b041b411781396ee057ece692 request_id=client-supplied-123
```

The envelope's `request_id` was written as `trace_id`, while the `request_id` field was spent on the caller's *inbound* `X-Request-ID` — a different id entirely. Searching the logs for an envelope's `request_id` therefore returned nothing, or, if a client ever sent that string as its own header, matched the wrong request silently. `trace_mapping` in `middleware.py` had the same collision.

## Solution

The access line now writes the trace id under **both** `request_id` and `trace_id` — one value, once per name a reader may already hold it by (envelope field, or trace tooling) — and moves the caller's inbound header to `client_request_id`:

```text
openapi_access method=GET path=/openapi/v1/bots/b-42 route=/openapi/v1/bots/{bot_id}
  status=200 duration_ms=31.4 tenant=acme caller=user:u-1+app:7 query=page=2
  request_id=b0a6d2f4e8c94b1a9f3d5e7c60218a4d trace_id=b0a6d2f4e8c94b1a9f3d5e7c60218a4d
  client_request_id=- client=10.0.0.9 ua=acme-sdk/1.2
```

Whichever field name the person asking already has, one grep lands on the line, and `route=` answers "which endpoint?" as a template rather than a concrete path. Reading the two identical values side by side is also how an operator learns they are the same id.

Rejected: renaming only the header field and leaving `trace_id` as the sole carrier. That removes the ambiguity but still requires the searcher to know that the envelope's `request_id` is really the trace id — knowledge nobody reading a bug report has. The 40 duplicated characters buy that away.

`trace_mapping` in `middleware.py` is renamed the same way for the same reason. The DEBUG `openapi_request_start` line deliberately carries no `request_id`: the tracer runs *inside* the access-log middleware (it has to, so the log can see the status that reaches the wire), so the id does not exist yet on the way in.

`docs/openapi-v1/README.md` gains a "Tracing one request from a caller's `request_id`" section next to the existing 401-diagnosis runbook, with the field table and the scope/redaction caveats.

## Validation

- `tests/community/adapters/http/openapi_v1/test_access_log.py` — 17 passed. Four new tests wire the real `CommunityTracer` plus `TraceIdMappingMiddleware` in production order (not a stub), and pin: the line's `request_id` equals the one the caller was handed and sits next to the right `route`; envelope body, `X-Trace-ID` header and both log fields all agree; `client_request_id` carries the inbound header and never occupies `request_id`; and an **error** envelope's `request_id` is searchable too (that path builds the body through `_error_response`, not the success builder). The existing cap test now reads the renamed field.
- `tests/community/adapters/http/` — 1752 passed, 2 skipped.
- `tests/community/api/test_install_middleware_tracer.py`, `tests/community/contracts/test_tracer.py`, `tests/community/api/test_domain_error_handler.py` — 32 passed.
- Confirmed the original defect first by printing a real request's envelope, headers and log line side by side before changing anything.
- Not run: the full `tests/community` suite. Backend deps could not be installed from the lockfile in this environment (it pins mirror URLs that are unreachable here), so the venv was rebuilt from PyPI at the locked `fastapi==0.138.2` / `starlette==1.3.1`. Backend CI does not run `ruff`; pre-existing lint findings in the touched files are unchanged.

## Compatibility and risk

No wire-contract change — the envelope, the `X-Trace-ID` header and every status code are untouched. The change is to **log field names only**, on two lines (`openapi_access`, `trace_mapping`) that nothing in the repo parses. Any external dashboard or saved query keyed on `openapi_access ... request_id=` would now match the trace id instead of the client's header; `trace_id=` keeps its exact meaning. Rollback is a revert of this commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sd9uhNnAvQo8oSGELQd9tb)_