### PR TITLE
fix(bcs): update existing provider bot storage only

### DIFF
--- a/src/bcs/crates/services/bcs-bot-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/lib.rs
@@ -1379,11 +1379,7 @@ impl BotRepoPort for PersistentBotRepo {
         let exists_in_db = self.exists_in_db(bot_id).await;
         if exists_in_db {
             self.save_to_db(bot_id, &capabilities, session_token.as_deref(), None)
-                .await
-                .map_err(|e| {
-                    warn!(bot_id = %bot_id, error = %e, "Failed to save bot to database during update_capabilities");
-                    e
-                })?;
+                .await?;
         }
 
         // Wholesale in-memory replacement (no `is_empty` skip, unlike

--- a/src/bcs/crates/services/bcs-bot-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/lib.rs
@@ -1376,24 +1376,38 @@ impl BotRepoPort for PersistentBotRepo {
             let bots = self.bots.read().await;
             bots.get(bot_id).and_then(|b| b.session_token.clone())
         };
-        // `save_to_db` writes the capability arrays (domains/skills/scopes) to
-        // the DB verbatim, so a cleared (empty) array persists correctly there.
-        self.save_to_db(bot_id, &capabilities, session_token.as_deref(), None)
-            .await
-            .map_err(|e| {
-                warn!(bot_id = %bot_id, error = %e, "Failed to save bot to database during update_capabilities");
-                e
-            })?;
+        let exists_in_db = self.exists_in_db(bot_id).await;
+        if exists_in_db {
+            self.save_to_db(bot_id, &capabilities, session_token.as_deref(), None)
+                .await
+                .map_err(|e| {
+                    warn!(bot_id = %bot_id, error = %e, "Failed to save bot to database during update_capabilities");
+                    e
+                })?;
+        }
+
         // Wholesale in-memory replacement (no `is_empty` skip, unlike
         // `register`) so a PATCH that clears a field also takes effect in the
         // live registry and runtime discovery, not only in the database.
         // Session token / created_by / runtime state are on `RegisteredBotInner`
         // and are left untouched here.
-        let mut bots = self.bots.write().await;
-        if let Some(existing) = bots.get_mut(bot_id) {
-            existing.last_heartbeat = Instant::now();
-            existing.capabilities = capabilities;
-            info!(bot_id = %bot_id, "update_capabilities: replaced capabilities in memory");
+        let updated_in_memory = {
+            let mut bots = self.bots.write().await;
+            if let Some(existing) = bots.get_mut(bot_id) {
+                existing.last_heartbeat = Instant::now();
+                existing.capabilities = capabilities;
+                info!(bot_id = %bot_id, "update_capabilities: replaced capabilities in memory");
+                true
+            } else {
+                info!(
+                    bot_id = %bot_id,
+                    "update_capabilities: skipped in-memory update because bot is not loaded"
+                );
+                false
+            }
+        };
+
+        if updated_in_memory || exists_in_db {
             Ok(())
         } else {
             Err(ServiceError::BotNotFound(bot_id.to_string()))

--- a/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_repo.rs
+++ b/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_repo.rs
@@ -466,7 +466,7 @@ async fn connect_or_promote_streaming_refuses_real_token_connected_with_already_
 async fn persistent_repo_update_capabilities_replaces_in_memory_and_db() {
     let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
-    let repo = PersistentBotRepo::with_plugins(cache, db);
+    let repo = PersistentBotRepo::with_plugins(cache, db.clone());
 
     repo.register(
         "update-cap-bot".to_string(),
@@ -515,13 +515,155 @@ async fn persistent_repo_update_capabilities_replaces_in_memory_and_db() {
         vec!["after_skill".to_string()]
     );
     assert_eq!(stored.capabilities.visibility, "protected");
+
+    let db_reader = PersistentBotRepo::with_plugins(
+        Arc::new(InMemoryCachePlugin::new()),
+        db,
+    );
+    let persisted = db_reader
+        .get("update-cap-bot")
+        .await
+        .expect("bot persisted");
+    assert!(persisted.capabilities.domains.is_empty());
+    assert!(persisted.capabilities.scopes.is_empty());
+    assert_eq!(persisted.capabilities.visibility, "protected");
+}
+
+#[tokio::test]
+async fn persistent_repo_update_capabilities_updates_db_when_memory_is_absent() {
+    let db = sqlite_db().await;
+    let registering_repo = PersistentBotRepo::with_plugins(
+        Arc::new(InMemoryCachePlugin::new()),
+        db.clone(),
+    );
+    registering_repo
+        .register(
+            "db-only-update-cap-bot".to_string(),
+            BotCapabilities {
+                name: Some("Before DB-only Update".to_string()),
+                domains: vec!["before".to_string()],
+                visibility: "private".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("register bot in database");
+
+    // A separate repository instance models a pod that shares the database
+    // but has never loaded this bot into its process-local registry.
+    let updating_repo = PersistentBotRepo::with_plugins(
+        Arc::new(InMemoryCachePlugin::new()),
+        db.clone(),
+    );
+    updating_repo
+        .update_capabilities(
+            "db-only-update-cap-bot",
+            BotCapabilities {
+                name: Some("After DB-only Update".to_string()),
+                domains: vec![],
+                skills: vec![Skill::new("after_skill")],
+                visibility: "protected".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("database-only capability update must succeed");
+
+    let verifying_repo = PersistentBotRepo::with_plugins(
+        Arc::new(InMemoryCachePlugin::new()),
+        db,
+    );
+    let stored = verifying_repo
+        .get("db-only-update-cap-bot")
+        .await
+        .expect("updated bot remains in database");
+    assert_eq!(
+        stored.capabilities.name.as_deref(),
+        Some("After DB-only Update")
+    );
+    assert!(stored.capabilities.domains.is_empty());
+    assert_eq!(
+        stored
+            .capabilities
+            .skills
+            .iter()
+            .map(|skill| skill.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["after_skill"]
+    );
+    assert_eq!(stored.capabilities.visibility, "protected");
+}
+
+#[tokio::test]
+async fn persistent_repo_update_capabilities_updates_memory_without_inserting_db_row() {
+    let db = sqlite_db().await;
+    let repo = PersistentBotRepo::with_plugins(
+        Arc::new(InMemoryCachePlugin::new()),
+        db.clone(),
+    );
+    repo.register(
+        "memory-only-update-cap-bot".to_string(),
+        BotCapabilities {
+            name: Some("Before Memory-only Update".to_string()),
+            domains: vec!["before".to_string()],
+            visibility: "private".to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("register bot");
+    db.execute(DbStatement::with_params(
+        "DELETE FROM bcs_bots WHERE bot_uuid = ? AND env = ?",
+        vec![
+            Value::from("memory-only-update-cap-bot"),
+            Value::from(bcs_config::resolve_env_str()),
+        ],
+    ))
+    .await
+    .expect("remove only the database representation");
+
+    repo.update_capabilities(
+        "memory-only-update-cap-bot",
+        BotCapabilities {
+            name: Some("After Memory-only Update".to_string()),
+            domains: vec![],
+            skills: vec![Skill::new("memory_after_skill")],
+            visibility: "protected".to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("memory-only capability update must succeed");
+
+    let stored = repo
+        .get("memory-only-update-cap-bot")
+        .await
+        .expect("bot remains in memory");
+    assert_eq!(
+        stored.capabilities.name.as_deref(),
+        Some("After Memory-only Update")
+    );
+    assert!(stored.capabilities.domains.is_empty());
+    assert_eq!(stored.capabilities.visibility, "protected");
+
+    let rows = db
+        .query(DbStatement::with_params(
+            "SELECT 1 FROM bcs_bots WHERE bot_uuid = ? AND env = ?",
+            vec![
+                Value::from("memory-only-update-cap-bot"),
+                Value::from(bcs_config::resolve_env_str()),
+            ],
+        ))
+        .await
+        .expect("query database representation");
+    assert!(rows.is_empty(), "update must not recreate a missing DB row");
 }
 
 #[tokio::test]
 async fn persistent_repo_update_capabilities_returns_not_found_for_unknown_bot() {
     let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
-    let repo = PersistentBotRepo::with_plugins(cache, db);
+    let repo = PersistentBotRepo::with_plugins(cache, db.clone());
 
     let err = repo
         .update_capabilities(
@@ -534,6 +676,18 @@ async fn persistent_repo_update_capabilities_returns_not_found_for_unknown_bot()
         .await
         .expect_err("unknown bot must error");
     assert!(matches!(err, ServiceError::BotNotFound(id) if id == "never-registered"));
+
+    let rows = db
+        .query(DbStatement::with_params(
+            "SELECT 1 FROM bcs_bots WHERE bot_uuid = ? AND env = ?",
+            vec![
+                Value::from("never-registered"),
+                Value::from(bcs_config::resolve_env_str()),
+            ],
+        ))
+        .await
+        .expect("query unknown bot");
+    assert!(rows.is_empty(), "unknown bot update must not insert a DB row");
 }
 
 async fn sqlite_db() -> Arc<dyn DbPlugin> {


### PR DESCRIPTION
## Problem

Provider Bot Update persisted capability changes before updating the process-local registry. When the bot existed in the database but was not loaded in the current pod, the database write succeeded and the repository then returned `BotNotFound`, causing the new Provider Bot PATCH endpoint to respond with 404.

The same upsert path could also create a database row for a bot that existed only in memory.

## Solution

- Update only storage representations in which the bot already exists.
- Update DB-only bots without requiring a process-local registry entry.
- Update memory-only bots without inserting a database row.
- Return `BotNotFound` only when neither database nor memory representation exists.
- Add conformance coverage for the four database/memory presence combinations.

## Validation

- `cargo test -p bcs-bot-store --test conformance_bot_repo update_capabilities` — 4 passed.
- Repository pre-push hook — passed in its default lint-only mode.

## Compatibility and risk

No HTTP route, DTO, schema, or plugin protocol changes. The only current production caller of registry capability replacement is Provider Core's new `PATCH /providers/{provider_id}/bots/{provider_bot_ref}` flow. Future callers of the shared repository method will inherit the update-existing-only semantics.
