### PR TITLE
feat(bcs): use no-auth share link in upload completion notification

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/internal/routes/session_file.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/internal/routes/session_file.rs
@@ -280,16 +280,12 @@ async fn complete_file(
     authorize_identity(&caller, policy).map_err(|e| error(&request_id, e))?;
     let Path((session_id, file_id)) =
         path.map_err(|e| invalid_request(&request_id, e.body_text()))?;
-    let notification_content_url = projector(&state)
-        .map_err(|e| error(&request_id, e))?
-        .content_url(&session_id, &file_id);
     let result = service(&state)
         .map_err(|e| error(&request_id, e))?
         .complete(CompleteSessionFile {
             caller,
             session_id,
             file_id,
-            notification_content_url,
         })
         .await
         .map_err(|e| error(&request_id, e))?;

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/session_file_url.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/session_file_url.rs
@@ -72,3 +72,11 @@ impl SessionFileUrlProjector {
         target
     }
 }
+
+impl bcs_service_api::application::v1::SessionFileSharedContentUrlProjector
+    for SessionFileUrlProjector
+{
+    fn shared_content_url(&self, token: &str) -> String {
+        SessionFileUrlProjector::shared_content_url(self, token)
+    }
+}

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/session_files.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/session_files.rs
@@ -518,7 +518,6 @@ pub async fn complete_upload(
         caller: application_caller(&caller),
         session_id: sid.clone(),
         file_id: file_id.clone(),
-        notification_content_url: file_download_url(&state, &sid, &file_id),
     };
     match application.complete(command).await {
         Ok(file) => (
@@ -788,23 +787,6 @@ pub async fn shared_file_content(
 }
 
 // ---------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------
-
-fn file_download_url(state: &HttpAppState, sid: &str, file_id: &str) -> String {
-    let base = state
-        .bcs_endpoint
-        .clone()
-        .unwrap_or_else(|| format!("http://{}:{}", state.bind, state.port));
-    format!(
-        "{}/sessions/{}/files/{}/content",
-        base,
-        urlencoding::encode(sid),
-        file_id,
-    )
-}
-
-// ---------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------
 
@@ -890,28 +872,15 @@ mod tests {
         }
     }
 
-    #[test]
-    fn file_download_url_uses_bcs_endpoint_when_set() {
-        let mut state = HttpAppState::new(Services::builder().build_for_test());
-        state.bcs_endpoint = Some("https://bcn.alipay.com".into());
-        let url = file_download_url(&state, "g1:abcd1234", "fid-1");
-        assert_eq!(
-            url,
-            "https://bcn.alipay.com/sessions/g1%3Aabcd1234/files/fid-1/content"
-        );
-    }
-
-    #[test]
-    fn file_download_url_falls_back_to_bind_port() {
-        let mut state = HttpAppState::new(Services::builder().build_for_test());
-        state.bcs_endpoint = None;
-        state.bind = "127.0.0.1".into();
-        state.port = 21000;
-        let url = file_download_url(&state, "g1:abcd1234", "fid-1");
-        assert_eq!(
-            url,
-            "http://127.0.0.1:21000/sessions/g1%3Aabcd1234/files/fid-1/content"
-        );
+    /// Test no-auth shared-content URL projector used by the upload-completion
+    /// notification assertions.
+    struct CompletionShareProjector;
+    impl bcs_service_api::application::v1::SessionFileSharedContentUrlProjector
+        for CompletionShareProjector
+    {
+        fn shared_content_url(&self, token: &str) -> String {
+            format!("http://test.local/sessions/shared-file/content?token={token}")
+        }
     }
 
     fn group_participant(bot_uuid: &str) -> Participant {
@@ -1059,6 +1028,7 @@ mod tests {
                 group_core.clone(),
                 registry.clone(),
                 system_messages.clone(),
+                Arc::new(CompletionShareProjector),
             ),
         );
         let services = Services::builder()
@@ -1606,15 +1576,13 @@ mod tests {
         // bot-a uploads; the session also has bot-b, so receivers must be [bot-b].
         let (file_id, _status) = upload_complete(&app, "hello.txt", b"hello").await;
 
-        // HttpAppState::new leaves bcs_endpoint=None -> http://127.0.0.1:21000.
-        let expected_url = format!(
-            "http://127.0.0.1:21000/sessions/{}/files/{}/content",
-            urlencoding::encode(&app.sid),
-            file_id,
+        // The download link in the notification is a no-auth share link (15-day
+        // TTL) instead of the authenticated content endpoint.
+        let expected_prefix = format!(
+            "Bot test-bot 上传了一个文件 hello.txt ({file_id}，5 B)，下载链接：",
         );
-        let expected_message = format!(
-            "Bot test-bot 上传了一个文件 hello.txt ({file_id}，5 B)，下载链接：{expected_url}"
-        );
+        let expected_share_prefix =
+            "http://test.local/sessions/shared-file/content?token=";
 
         let notifications = app.system_messages.notifications.lock().await;
         assert_eq!(notifications.len(), 1, "expected exactly one system message");
@@ -1625,7 +1593,14 @@ mod tests {
                 receivers,
             } => {
                 assert_eq!(group_id, "g1");
-                assert_eq!(message, &expected_message);
+                assert!(
+                    message.starts_with(&expected_prefix),
+                    "unexpected message: {message}",
+                );
+                assert!(
+                    message[expected_prefix.len()..].starts_with(expected_share_prefix),
+                    "expected a share link, got: {message}",
+                );
                 let receiver_ids: Vec<String> =
                     receivers.iter().map(|p| p.bot_uuid.clone()).collect();
                 assert_eq!(receiver_ids, vec!["bot-b".to_string()]);

--- a/src/bcs/crates/application/v1/bcs-app-session/src/file.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/file.rs
@@ -16,9 +16,11 @@ use bcs_service_api::application::v1::{
     ApplicationError, CompleteSessionFile, DeleteResult, DeleteSessionFile,
     DownloadSessionFile, DownloadSharedSessionFile, GetSessionFile, IdentityPolicy,
     ListSessionFiles, PrepareSessionFile, PrepareSessionFileResult, Principal,
-    SessionFileActor, SessionFileActorKind, SessionFileApplicationService, SessionFileContent,
-    SessionFilePage, SessionFileStatus, SessionFileView, ShareSessionFile,
-    ShareSessionFileResult, UploadSessionFileContent, UploadSessionFileResult, select_principal,
+    SessionFileActor, SessionFileActorKind, SessionFileApplicationService,
+    SessionFileContent, SessionFilePage, SessionFileSharedContentUrlProjector,
+    SessionFileStatus, SessionFileView, ShareSessionFile, ShareSessionFileResult,
+    UPLOAD_COMPLETION_SHARE_TTL_SECONDS, UploadSessionFileContent,
+    UploadSessionFileResult, select_principal,
 };
 use bcs_service_api::{
     BotRegistryCoreService, GroupCoreService, ServiceError, SystemMessageService,
@@ -30,6 +32,7 @@ pub struct SessionFileApplicationServiceImpl {
     groups: Arc<dyn GroupCoreService>,
     registry: Arc<dyn BotRegistryCoreService>,
     system_message: Arc<dyn SystemMessageService>,
+    shared_content_projector: Arc<dyn SessionFileSharedContentUrlProjector>,
 }
 
 impl SessionFileApplicationServiceImpl {
@@ -39,6 +42,7 @@ impl SessionFileApplicationServiceImpl {
         groups: Arc<dyn GroupCoreService>,
         registry: Arc<dyn BotRegistryCoreService>,
         system_message: Arc<dyn SystemMessageService>,
+        shared_content_projector: Arc<dyn SessionFileSharedContentUrlProjector>,
     ) -> Self {
         Self {
             files,
@@ -46,6 +50,7 @@ impl SessionFileApplicationServiceImpl {
             groups,
             registry,
             system_message,
+            shared_content_projector,
         }
     }
 
@@ -218,6 +223,60 @@ impl SessionFileApplicationServiceImpl {
         })
     }
 
+    /// Mints a no-auth share link for the just-completed file and returns the
+    /// public shared-content URL to embed in the upload-completion notification.
+    /// Returns `None` on any failure (logged) so the caller can skip the
+    /// notification instead of sending an unusable link.
+    async fn mint_completion_share_url(
+        &self,
+        principal: &Principal,
+        session: &Session,
+        file: &SessionFile,
+    ) -> Option<String> {
+        let caller_identities = match self.caller_identities(principal).await {
+            Ok(identities) => identities,
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %session.id,
+                    file_id = %file.file_id,
+                    error = %error,
+                    "failed to resolve caller identities for upload completion share link",
+                );
+                return None;
+            }
+        };
+        match self
+            .files
+            .share_mint(ShareMintCommand {
+                session_id: session.id.clone(),
+                file_id: file.file_id.clone(),
+                caller: actor_ref(principal),
+                ttl_seconds: Some(UPLOAD_COMPLETION_SHARE_TTL_SECONDS),
+                caller_identities,
+                session_participants: session
+                    .participants
+                    .iter()
+                    .map(|participant| participant.bot_uuid.clone())
+                    .collect(),
+            })
+            .await
+        {
+            Ok(result) => Some(
+                self.shared_content_projector
+                    .shared_content_url(&result.share_token),
+            ),
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %session.id,
+                    file_id = %file.file_id,
+                    error = %error,
+                    "failed to mint share link for upload completion notification",
+                );
+                None
+            }
+        }
+    }
+
     async fn notify_completed(
         &self,
         principal: &Principal,
@@ -359,13 +418,18 @@ impl SessionFileApplicationService for SessionFileApplicationServiceImpl {
             .complete_upload(&command.session_id, &command.file_id)
             .await
             .map_err(map_file_error)?;
-        self.notify_completed(
-            &principal,
-            &session,
-            &file,
-            &command.notification_content_url,
-        )
-        .await;
+        // The system-message download URL points at a no-auth share link instead
+        // of the authenticated content endpoint, so every receiver (including
+        // other bots) can fetch the file. The link is minted with the
+        // upload-completion TTL (15 days). Minting is best-effort: on failure we
+        // log and skip the notification rather than advertising a broken link.
+        if let Some(share_url) = self
+            .mint_completion_share_url(&principal, &session, &file)
+            .await
+        {
+            self.notify_completed(&principal, &session, &file, &share_url)
+                .await;
+        }
         Ok(project_file(file))
     }
 

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/session_file_facade.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/session_file_facade.rs
@@ -45,6 +45,16 @@ impl SystemMessageService for RecordingSystemMessage {
     }
 }
 
+/// Test no-auth shared-content URL projector for upload-completion notifications.
+struct CompletionShareProjector;
+impl bcs_service_api::application::v1::SessionFileSharedContentUrlProjector
+    for CompletionShareProjector
+{
+    fn shared_content_url(&self, token: &str) -> String {
+        format!("http://share.test/sessions/shared-file/content?token={token}")
+    }
+}
+
 struct Fixture {
     service: SessionFileApplicationServiceImpl,
     bots: Arc<BotCore>,
@@ -94,6 +104,7 @@ impl Fixture {
             groups.clone(),
             bots.clone(),
             notifications.clone(),
+            Arc::new(CompletionShareProjector),
         );
         Self {
             service,
@@ -259,7 +270,6 @@ async fn human_creator_can_upload_and_complete_an_owned_bots_file() {
             caller: human_caller("alice"),
             session_id: "group-1:abcd1234".into(),
             file_id,
-            notification_content_url: "https://gateway.test/openapi/v1/collaboration/content".into(),
         })
         .await
         .expect("owner Human completes");
@@ -272,7 +282,10 @@ async fn human_creator_can_upload_and_complete_an_owned_bots_file() {
             message, receivers, ..
         } => {
             assert!(message.starts_with("用户 alice 上传了一个文件 report.txt"));
-            assert!(message.contains("gateway.test"));
+            assert!(
+                message.contains("http://share.test/sessions/shared-file/content?token="),
+                "expected a share link in the notification, got: {message}",
+            );
             let mut receiver_ids = receivers
                 .iter()
                 .map(|participant| participant.bot_uuid.as_str())
@@ -333,7 +346,6 @@ async fn completion_skips_notification_when_uploader_is_the_only_bot() {
             caller,
             session_id: session_id.into(),
             file_id: prepared.file.file_id,
-            notification_content_url: "http://legacy.test/content".into(),
         })
         .await
         .expect("complete file");

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1545,13 +1545,6 @@ fn build_openapi_v1_state(
         system_message.clone(),
         SessionServiceConfig { relation_env },
     ));
-    let session_file_service = Arc::new(SessionFileApplicationServiceImpl::new(
-        session_files,
-        sessions.clone(),
-        groups.clone(),
-        registry.clone(),
-        system_message.clone(),
-    ));
     let session_file_url_projector = SessionFileUrlProjector::new(
         config
             .openapi_v1
@@ -1559,6 +1552,14 @@ fn build_openapi_v1_state(
             .expect("OpenAPI V1 public collaboration URL was validated at config load"),
     )
     .expect("validated OpenAPI V1 public collaboration URL");
+    let session_file_service = Arc::new(SessionFileApplicationServiceImpl::new(
+        session_files,
+        sessions.clone(),
+        groups.clone(),
+        registry.clone(),
+        system_message.clone(),
+        Arc::new(session_file_url_projector.clone()),
+    ));
     let invitation_groups = groups.clone();
     let invitation_sessions = sessions.clone();
     let invite: Arc<dyn InviteService> =

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session_file.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session_file.rs
@@ -6,6 +6,23 @@ use serde::{Deserialize, Serialize};
 
 use super::{ApplicationError, AuthenticatedCaller, DeleteResult};
 
+/// Default time-to-live (15 days) for the no-auth share link minted when an
+/// upload completes. The system-message download URL points at this share link.
+pub const UPLOAD_COMPLETION_SHARE_TTL_SECONDS: u64 = 15 * 86_400;
+
+/// Builds no-auth shared-content download URLs for session files.
+///
+/// The upload-completion notification links to a share link instead of the
+/// authenticated content endpoint so message receivers (including other bots)
+/// can fetch the file without credentials. Core logic stays transport-agnostic:
+/// the concrete public-facing base is supplied by the delivery adapter that
+/// implements this trait.
+pub trait SessionFileSharedContentUrlProjector: Send + Sync {
+    /// Returns the full public URL for consuming the shared file content
+    /// behind `token`.
+    fn shared_content_url(&self, token: &str) -> String;
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SessionFileActorKind {
@@ -82,9 +99,6 @@ pub struct CompleteSessionFile {
     pub caller: AuthenticatedCaller,
     pub session_id: String,
     pub file_id: String,
-    /// Server-constructed URL used only by the best-effort upload
-    /// notification. It is never populated from request JSON.
-    pub notification_content_url: String,
 }
 
 #[derive(Debug, Clone)]

--- a/src/bcs/crates/services/bcs-session-file/src/service.rs
+++ b/src/bcs/crates/services/bcs-session-file/src/service.rs
@@ -43,9 +43,10 @@ const PROXY_PART_SIZE: u64 = 10 * 1024 * 1024;
 const MAX_PART_COUNT: u64 = 65535;
 
 /// TTL bounds for share-token expiry (seconds). Clamped on mint so a single
-/// misconfigured request cannot mint a 1-second or 10-year link.
+/// misconfigured request cannot mint a 1-second or 10-year link. The upper
+/// bound covers the 15-day upload-completion share link.
 const SHARE_TTL_MIN: u64 = 60;
-const SHARE_TTL_MAX: u64 = 604_800;
+const SHARE_TTL_MAX: u64 = 15 * 86_400;
 
 /// Configuration for [`SessionFileServiceImpl`]. Built by bootstrap; the
 /// service clones fields it needs from this struct in [`SessionFileServiceImpl::new`].


### PR DESCRIPTION
## Problem

The download URL embedded in the upload-completion system message used the authenticated `/sessions/{sid}/files/{file_id}/content` endpoint. Other bots and users in the session cannot fetch the file from that link without carrying caller credentials, which limits both the experience and the capability.

## Solution

Switch the download URL in the system messages produced by both the new endpoint (`bcs_api_http::v1::internal::routes::session_file::complete_file`) and the legacy endpoint (`bcs_http::routes::session_files::complete_upload`) to the no-auth share endpoint:

- Add a transport-agnostic `SessionFileSharedContentUrlProjector` trait and an `UPLOAD_COMPLETION_SHARE_TTL_SECONDS = 15 * 86_400` (15 days) constant in `service-api`.
- `SessionFileApplicationServiceImpl::complete()` now mints a 15-day share link after upload completion and projects the public shared-content URL via the new trait into the system message. On mint failure it logs and skips the notification instead of advertising a broken link.
- `SessionFileUrlProjector` implements the trait; the URL path is `/api/v1/collaboration/sessions/shared-file/content?token=...`.
- Raise `SHARE_TTL_MAX` from 7 days to 15 days to admit the completion share.
- Remove the now-unused `notification_content_url` field from `CompleteSessionFile` and from both complete routes, and delete the dead `file_download_url` helper plus its two unit tests.

Core logic stays transport-agnostic: the public base URL is injected by the delivery adapter through the new trait, with no hardcoded URLs.

## Validation

- `cargo test -p bcs-app-session`: 69 passed
- `cargo test -p bcs-session-file`: 58 passed
- `cargo test -p bcs-api-http`: 34 passed
- `cargo test -p bcs-http --lib routes::session_files`: 16 passed
- `cargo test -p bcs-service-api`: 3 passed

Not run: a full `cargo check -p bcs` is blocked by pre-existing compile errors in `bcs-edge-permission` and `bcs-app-invitation`, unrelated to this change. The `bcs-http` `admin_invocation_terminal` test fails in the sandbox with `PermissionDenied`, also unrelated.

## Compatibility and risk

- Removing `notification_content_url` from `CompleteSessionFile` is a breaking change to that internal command, but all call sites (both HTTP routes) are updated in the same change.
- The notification download URL changes from an authenticated content URL to a share URL; downstream bots that parse the message must switch to the no-auth download path. The existing authenticated download endpoint is unaffected.
- Expanding `SHARE_TTL_MAX` to 15 days only applies to newly minted share tokens; existing tokens are not affected.
- Rollback: revert this commit to restore the original authenticated content URL.