### PR TITLE
bcs-http: remove deprecated Provider Stream gray HTTP APIs

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/router.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/router.rs
@@ -69,11 +69,6 @@ fn build_api_routes() -> Router<HttpAppState> {
             post(routes::providers::resolve_agentpass_bot),
         )
         .route(
-            "/providers/stream-gray",
-            get(routes::providers::get_provider_stream_gray)
-                .put(routes::providers::put_provider_stream_gray),
-        )
-        .route(
             "/providers/{provider_id}",
             get(routes::providers::get_provider).patch(routes::providers::patch_provider),
         )

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
@@ -29,18 +29,6 @@ use tracing::{info, warn};
 use crate::mapping::capabilities::{to_core_skill, to_wire_skill};
 use crate::state::HttpAppState;
 
-#[derive(Debug, serde::Deserialize)]
-pub struct ProviderStreamGrayRequest {
-    pub enabled: Option<bool>,
-    pub created_by: Option<Vec<String>>,
-}
-
-#[derive(Debug, serde::Serialize)]
-pub struct ProviderStreamGrayResponse {
-    pub enabled: bool,
-    pub created_by: Vec<String>,
-}
-
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PatchProviderBotAttributesRequest {
@@ -135,37 +123,6 @@ pub async fn register_provider(
         provider_id: outcome.provider_id,
         provider_admin_token: outcome.provider_admin_token,
         bcs_to_provider_token: outcome.bcs_to_provider_token,
-    }))
-}
-
-pub async fn get_provider_stream_gray(
-    State(state): State<HttpAppState>,
-) -> Result<Json<ProviderStreamGrayResponse>, ProviderRouteError> {
-    let snapshot = state.provider_stream_gray_list.snapshot();
-    Ok(Json(ProviderStreamGrayResponse {
-        enabled: snapshot.enabled,
-        created_by: snapshot.created_by,
-    }))
-}
-
-pub async fn put_provider_stream_gray(
-    State(state): State<HttpAppState>,
-    Json(req): Json<ProviderStreamGrayRequest>,
-) -> Result<Json<ProviderStreamGrayResponse>, ProviderRouteError> {
-    let old = state.provider_stream_gray_list.snapshot();
-    let updated = state
-        .provider_stream_gray_list
-        .update(req.enabled, req.created_by);
-    info!(
-        old_enabled = old.enabled,
-        new_enabled = updated.enabled,
-        old_created_by = ?old.created_by,
-        new_created_by = ?updated.created_by,
-        "provider stream gray list updated"
-    );
-    Ok(Json(ProviderStreamGrayResponse {
-        enabled: updated.enabled,
-        created_by: updated.created_by,
     }))
 }
 

--- a/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
@@ -13,7 +13,7 @@ use bcs_bot_store::{MemoryBotRepo, MemoryProviderStore};
 use bcs_config::resolve_env_str;
 use bcs_http::{
     router::build_router,
-    service_key::{ApiKeyEntry, ApiKeyRegistry, sha256_hex},
+    service_key::{ApiKeyEntry, ApiKeyRegistry},
     state::{ChainUserIdentityPort, HttpAppState, HttpUserIdentity, UserIdentityPort},
 };
 use bcs_service_api::application::v1::ApplicationError;
@@ -23,7 +23,7 @@ use bcs_service_api::{
     BotRegistryCoreService, EnsureOwnerEdgesResult, FriendCheckInStrategy,
     InternalBotAttributesService, PatchBotInternalAttributes, ProviderBotBindingRepoPort,
     ProviderBotCoreService, ProviderCoreService, ProviderCredential, ProviderCredentialRepoPort,
-    ProviderRecord, ProviderRepoPort, ProviderStreamGrayList, RelationCoreService, RelationEdge,
+    ProviderRecord, ProviderRepoPort, RelationCoreService, RelationEdge,
     ServiceResult, UserVisibility,
 };
 use bcs_services_container::Services;
@@ -35,7 +35,6 @@ struct TestApp {
     app: Router,
     provider_repo: Arc<dyn ProviderRepoPort>,
     provider_credentials: Arc<dyn ProviderCredentialRepoPort>,
-    provider_stream_gray_list: Arc<ProviderStreamGrayList>,
     registry: Arc<BotCore>,
     relation: Arc<RecordingRelationCoreService>,
     control_plane: Arc<BotControlPlaneCore>,
@@ -105,16 +104,6 @@ fn test_app_with_allowed_switch_provider_ids(allowed_provider_ids: Vec<String>) 
     )
 }
 
-fn test_app_with_service_keys(service_keys: Vec<ApiKeyEntry>) -> TestApp {
-    let chain = static_auth_chain("197262", "Admin");
-    test_app_with_options(
-        Arc::new(ChainUserIdentityPort::new(chain)),
-        None,
-        Vec::new(),
-        service_keys,
-    )
-}
-
 fn test_app_with_options(
     user_identity: Arc<dyn UserIdentityPort>,
     user_directory: Option<Arc<dyn UserDirectoryPlugin>>,
@@ -126,7 +115,6 @@ fn test_app_with_options(
     let provider_repo: Arc<dyn ProviderRepoPort> = provider_store.clone();
     let provider_credentials: Arc<dyn ProviderCredentialRepoPort> = provider_store.clone();
     let provider_bindings: Arc<dyn ProviderBotBindingRepoPort> = provider_store.clone();
-    let provider_stream_gray_list = Arc::new(ProviderStreamGrayList::default());
     let internal_bot_attributes = Arc::new(RecordingInternalBotAttributesService::default());
     let bot_repo = Arc::new(MemoryBotRepo::with_base_dir(temp_dir.path().to_path_buf()));
     let control_plane = Arc::new(BotControlPlaneCore::new(
@@ -175,12 +163,10 @@ fn test_app_with_options(
                 .with_user_identity(user_identity)
                 .with_allowed_switch_provider_ids(allowed_provider_ids)
                 .with_internal_bot_attributes_service(internal_bot_attributes.clone())
-                .with_service_api_keys(Arc::new(ApiKeyRegistry::new(service_keys)))
-                .with_provider_stream_gray_list(provider_stream_gray_list.clone()),
+                .with_service_api_keys(Arc::new(ApiKeyRegistry::new(service_keys))),
         ),
         provider_repo,
         provider_credentials,
-        provider_stream_gray_list,
         registry,
         relation,
         control_plane,
@@ -189,186 +175,9 @@ fn test_app_with_options(
     }
 }
 
-fn admin_service_key() -> (&'static str, ApiKeyEntry) {
-    let raw_key = "stream-gray-admin-key";
-    (
-        raw_key,
-        ApiKeyEntry {
-            name: "stream-gray-admin".to_string(),
-            sha256: sha256_hex(raw_key),
-            bound_groups: Vec::new(),
-        },
-    )
-}
-
-fn bound_service_key() -> (&'static str, ApiKeyEntry) {
-    let raw_key = "stream-gray-bound-key";
-    (
-        raw_key,
-        ApiKeyEntry {
-            name: "stream-gray-bound".to_string(),
-            sha256: sha256_hex(raw_key),
-            bound_groups: vec!["group-1".to_string()],
-        },
-    )
-}
-
 #[derive(Default)]
 struct RecordingRelationCoreService {
     owner_edges: tokio::sync::Mutex<Vec<(String, String, String)>>,
-}
-
-#[tokio::test]
-async fn stream_gray_get_returns_current_created_by_list() {
-    let (raw_key, entry) = admin_service_key();
-    let app = test_app_with_service_keys(vec![entry]);
-    app.provider_stream_gray_list.replace(vec![
-        " 197262 ".to_string(),
-        "alice".to_string(),
-        "197262".to_string(),
-    ]);
-
-    let response = app
-        .app
-        .oneshot(
-            Request::builder()
-                .method("GET")
-                .uri("/providers/stream-gray")
-                .header("X-BCS-Service-Key", raw_key)
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = response_json(response).await;
-    assert_eq!(body["enabled"], json!(false));
-    assert_eq!(body["created_by"], json!(["197262", "alice"]));
-}
-
-#[tokio::test]
-async fn stream_gray_put_replaces_and_normalizes_created_by_list() {
-    let (raw_key, entry) = admin_service_key();
-    let app = test_app_with_service_keys(vec![entry]);
-    app.provider_stream_gray_list
-        .replace(vec!["old".to_string()]);
-
-    let response = app
-        .app
-        .oneshot(
-            Request::builder()
-                .method("PUT")
-                .uri("/providers/stream-gray")
-                .header("content-type", "application/json")
-                .header("X-BCS-Service-Key", raw_key)
-                .body(Body::from(
-                    json!({
-                        "enabled": true,
-                        "created_by": [" bob ", "", "alice", "bob"]
-                    })
-                    .to_string(),
-                ))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = response_json(response).await;
-    assert_eq!(body["enabled"], json!(true));
-    assert_eq!(body["created_by"], json!(["alice", "bob"]));
-    assert!(app.provider_stream_gray_list.is_enabled());
-    assert_eq!(
-        app.provider_stream_gray_list.list(),
-        vec!["alice".to_string(), "bob".to_string()]
-    );
-    assert!(!app.provider_stream_gray_list.contains(Some("missing")));
-}
-
-#[tokio::test]
-async fn stream_gray_put_can_disable_gray_mode_without_replacing_created_by_list() {
-    let app = test_app_with_service_keys(vec![]);
-    app.provider_stream_gray_list.update(
-        Some(true),
-        Some(vec!["alice".to_string()]),
-    );
-
-    let response = app
-        .app
-        .oneshot(
-            Request::builder()
-                .method("PUT")
-                .uri("/providers/stream-gray")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({ "enabled": false }).to_string()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = response_json(response).await;
-    assert_eq!(body["enabled"], json!(false));
-    assert_eq!(body["created_by"], json!(["alice"]));
-    assert!(!app.provider_stream_gray_list.is_enabled());
-    assert_eq!(
-        app.provider_stream_gray_list.list(),
-        vec!["alice".to_string()]
-    );
-    assert!(app.provider_stream_gray_list.contains(Some("missing")));
-}
-
-#[tokio::test]
-async fn stream_gray_put_works_without_admin_service_key() {
-    let app = test_app_with_service_keys(vec![]);
-
-    let response = app
-        .app
-        .oneshot(
-            Request::builder()
-                .method("PUT")
-                .uri("/providers/stream-gray")
-                .header("content-type", "application/json")
-                .body(Body::from(json!({ "created_by": ["alice"] }).to_string()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = response_json(response).await;
-    assert_eq!(body["created_by"], json!(["alice"]));
-    assert_eq!(
-        app.provider_stream_gray_list.list(),
-        vec!["alice".to_string()]
-    );
-}
-
-#[tokio::test]
-async fn stream_gray_put_ignores_service_key_header() {
-    let (raw_key, _entry) = bound_service_key();
-    let app = test_app_with_service_keys(vec![]);
-
-    let response = app
-        .app
-        .oneshot(
-            Request::builder()
-                .method("PUT")
-                .uri("/providers/stream-gray")
-                .header("content-type", "application/json")
-                .header("X-BCS-Service-Key", raw_key)
-                .body(Body::from(json!({ "created_by": ["alice"] }).to_string()))
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(
-        app.provider_stream_gray_list.list(),
-        vec!["alice".to_string()]
-    );
 }
 
 #[async_trait::async_trait]

--- a/src/bcs/scripts/e2e-test/stories.sh
+++ b/src/bcs/scripts/e2e-test/stories.sh
@@ -1347,15 +1347,15 @@ print(json.dumps({
 # User story: A provider operator publishes, governs, and retires a provider-backed agent.
 #
 # Flow:
-#   Register a provider -> configure stream rollout -> inspect and update metadata
+#   Register a provider -> inspect and update metadata
 #   -> publish and list an agent -> exercise runtime callbacks and guardrails
-#   -> disable and re-enable the provider -> retire the agent -> restore rollout state.
+#   -> disable and re-enable the provider -> retire the agent.
 #
 # Critical assertions:
 #   - Provider registration returns admin, callback, and runtime credentials as applicable.
 #   - Provider and agent identities remain stable across update and list operations.
 #   - Unknown callbacks and unauthorized delivery takeover fail with precise errors.
-#   - Disable/enable and retirement are observable, and temporary rollout state is restored.
+#   - Disable/enable and retirement are observable.
 story_provider_operator_publishes_agent() {
     info "Story: provider operator registers a provider, publishes an agent, and retires it"
 
@@ -1370,16 +1370,6 @@ story_provider_operator_publishes_agent() {
     assert_not_empty "provider registration returns admin token" "$admin_token"
     assert_not_empty "provider registration returns BCS callback token" "$bcs_token"
     [[ -n "$provider_id" && -n "$admin_token" ]] || return
-
-    api_get "/providers/stream-gray"
-    require_status "operator reads provider streaming rollout" "200" || return
-    assert_json_not_empty "stream rollout exposes enabled flag" "$RESPONSE" "enabled"
-
-    api_put "/providers/stream-gray" \
-        "{\"enabled\":true,\"created_by\":[\"${BCS_MOCK_USER_ID}\"]}"
-    require_status "operator enables streaming for the current owner" "200" || return
-    assert_json_eq "stream rollout is enabled" "$RESPONSE" "enabled" "true"
-    assert_json_array_contains "stream rollout contains current owner" "$RESPONSE" "created_by" "$BCS_MOCK_USER_ID"
 
     api_request_headers GET "/providers/${provider_id}" "" \
         "Authorization: Bearer ${admin_token}"
@@ -1503,11 +1493,6 @@ print("1" if any(i.get("bot_uuid") == target for i in d.get("items", [])) else "
         "Authorization: Bearer ${admin_token}"
     require_status "operator verifies provider agent retirement" "200" || return
     assert_json_eq "provider agent list is empty after retirement" "$RESPONSE" "items" "[]"
-
-    api_put "/providers/stream-gray" '{"enabled":false,"created_by":[]}'
-    require_status "operator restores provider streaming rollout" "200" || return
-    assert_json_eq "stream rollout is restored to disabled" "$RESPONSE" "enabled" "false"
-    assert_json_eq "stream rollout owner list is cleared" "$RESPONSE" "created_by" "[]"
 }
 
 _story_provider_manages_organization() {


### PR DESCRIPTION
## Summary

Remove the two deprecated public BCS HTTP endpoints `GET /providers/stream-gray` and
`PUT /providers/stream-gray` from the `bcs-http` delivery adapter: route registration,
handler functions, request/response DTOs, and their exclusive contract tests.

These endpoints were `public` + `deprecated`, were not part of any recorded public
contract (`openapi.yaml`/`internal.yaml`, Gateway schemas, `bcs-cli`, docs), and had no
in-repo callers. Their handlers were the only HTTP read/write surface over the
`ProviderStreamGrayList` registry.

## Changes

All under `src/bcs/crates/adapters/http/bcs-http`:

- `src/router.rs` — removed the `.route("/providers/stream-gray", get(...).put(...))` block.
- `src/routes/providers.rs` — removed `ProviderStreamGrayRequest` / `ProviderStreamGrayResponse`
  DTOs and the `get_provider_stream_gray` / `put_provider_stream_gray` handlers.
- `tests/provider_routes_contract.rs` — removed the five `stream_gray_*` contract tests and
  the now-exclusive `provider_stream_gray_list` test assembly plus the `test_app_with_service_keys`
  / `admin_service_key` / `bound_service_key` helpers they used. The shared `test_app_with_options`
  builder, its `service_keys` plumbing, and all other provider route tests are kept.

Also under `src/bcs/scripts/e2e-test/stories.sh`:

- `story_provider_operator_publishes_agent` no longer exercises `/providers/stream-gray`.
  Removed the post-registration `GET` + `PUT` (enable) calls, the final restore `PUT`, and the
  header-comment mentions of stream-rollout configure/restore. The story's metadata read, agent
  publish/patch/retire, callback, and disable/enable steps are unchanged. This keeps the BCS e2e
  endpoint-coverage gate whole after the route deletion.

## Behavior

| Case | Before | After |
| --- | --- | --- |
| `GET /providers/stream-gray` | 200 `enabled`/`created_by` snapshot | 404 (route removed) |
| `PUT /providers/stream-gray` | 200 toggle/normalize | 404 (route removed) |
| Other `/providers/*` and BCS routes | unchanged | unchanged |

## Out of scope

The `ProviderStreamGrayList` port, its config fields (`provider_stream_gray_enabled` /
`provider_stream_gray_created_by`), the `state.rs` default wiring and the
bootstrap/server/message-flow/group_flow assembly are intentionally retained. Full
retirement of that registry and its plumbing belongs to a separate follow-up.

## Verification

- `cargo build -p bcs-http` — clean (0 errors), with the removal applied.
- `cargo test -p bcs-http` — full suite green: **461 passed, 0 failed** across all test
  targets. `provider_routes_contract` now reports 46 passed (was 51 before removing the 5
  `stream_gray_*` cases) with no `stream_gray` tests remaining; every other provider/bot/
  group/session route contract suite passes unchanged.
- Repo-wide search confirms no residual references to `/providers/stream-gray`,
  `get_provider_stream_gray`, `put_provider_stream_gray`, `ProviderStreamGrayRequest`, or
  `ProviderStreamGrayResponse`, and that all `ProviderStreamGrayList`/config/assembly
  references remain intact.

## Compatibility / risk / rollback

Low risk: removed endpoints are `deprecated`, undocumented, and have no in-repo or
contract-recorded consumers. No config, data, or migration changes. Reverting this
commit restores the two endpoints exactly.

No `cargo fmt` was run, per the crate convention; only the lines required for the removal
were changed.