### PR TITLE
feat(proxy): resolve ARCA sandbox targets by direct pod IP lookup

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/paas_service/device_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/paas_service/device_router.py
@@ -13,7 +13,11 @@ from fastapi import APIRouter, Depends, HTTPException, Path
 from pydantic import BaseModel, Field
 
 from secbaas.community.api import ApiResponse
-from secbaas.community.api.device_manage import DeviceResponse, DeviceService
+from secbaas.community.api.device_manage import (
+    DeviceResponse,
+    DeviceService,
+    ProviderDevicePropsResponse,
+)
 from secbaas.community.bootstrap import ApplicationContainer, Provide
 from secbaas.community.logger import get_logger
 
@@ -95,5 +99,63 @@ async def get_device_info(
                 "error": "INTERNAL_ERROR",
                 "message": str(e),
                 "device_uuid": device_uuid,
+            },
+        )
+
+
+@router.get(
+    "/provider-device/{provider_device_id}/props",
+    response_model=ApiResponse[ProviderDevicePropsResponse],
+    responses={
+        404: {"model": DeviceNotFoundResponse, "description": "Device not found"},
+        500: {"model": DeviceNotFoundResponse, "description": "Internal server error"},
+    },
+    summary="Get provider device props by provider_device_id",
+    description="Get the stored provider_device_props for a device by its PaaS provider device ID.",
+)
+@inject
+async def get_provider_device_props(
+    provider_device_id: Annotated[
+        str,
+        Path(description="PaaS provider device ID (e.g., ALIYUN_ACK_DEFAULT-abc@0)"),
+    ],
+    device_service: DeviceService = Depends(
+        Provide[ApplicationContainer.services.device_service]
+    ),
+) -> ApiResponse[ProviderDevicePropsResponse]:
+    logger.info(
+        f"Getting provider device props via device router: "
+        f"provider_device_id={provider_device_id}"
+    )
+
+    try:
+        result = device_service.get_provider_device_props(
+            provider_device_id=provider_device_id
+        )
+
+        if result is None:
+            logger.info(f"Provider device not found: {provider_device_id}")
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "error": "DEVICE_NOT_FOUND",
+                    "message": f"Provider device not found: {provider_device_id}",
+                    "device_uuid": None,
+                },
+            )
+
+        return ApiResponse(data=result)
+
+    except HTTPException:
+        raise
+
+    except Exception as e:
+        logger.error(f"Unexpected error getting provider device props: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": "INTERNAL_ERROR",
+                "message": str(e),
+                "device_uuid": None,
             },
         )

--- a/src/baas/src/secbaas/community/api/device_manage/__init__.py
+++ b/src/baas/src/secbaas/community/api/device_manage/__init__.py
@@ -32,6 +32,7 @@ from ._device import (
     DeviceNotFoundError,
     DeviceResponse,
     DeviceStatus,
+    ProviderDevicePropsResponse,
 )
 from ._device_config import (
     ArcaCreateConfig,
@@ -170,6 +171,7 @@ __all__ = [
     "PoolabInstanceSummary",
     "ProxyExecRequest",
     "ProxyHealthRequest",
+    "ProviderDevicePropsResponse",
     "SigmaCreateConfig",
     "SigmaCreationResult",
     "SigmaCredentials",

--- a/src/baas/src/secbaas/community/api/device_manage/_device.py
+++ b/src/baas/src/secbaas/community/api/device_manage/_device.py
@@ -95,6 +95,14 @@ class DeviceResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
 
+class ProviderDevicePropsResponse(BaseModel):
+    """provider_device_props for a device looked up by provider_device_id."""
+
+    provider_device_id: str
+    status: str
+    provider_device_props: dict[str, Any] | None
+
+
 class DeviceInfo(BaseModel):
     """Lightweight device model for bot embed (subset of DeviceResponse fields)."""
 

--- a/src/baas/src/secbaas/community/api/device_manage/_protocols.py
+++ b/src/baas/src/secbaas/community/api/device_manage/_protocols.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
     from ._command_result import CommandResult
     from ._credentials import PaasCredentials
-    from ._device import DeviceInfo
+    from ._device import DeviceInfo, ProviderDevicePropsResponse
     from ._device_config import DeviceCreateConfig
     from ._device_creation_result import DeviceCreationResult
     from ._device_facade_config import (
@@ -107,6 +107,13 @@ class DeviceService(Protocol):
         device_uuid: str,
     ) -> DeviceResponse | None:
         """Get device information by UUID."""
+        ...
+
+    def get_provider_device_props(
+        self,
+        provider_device_id: str,
+    ) -> ProviderDevicePropsResponse | None:
+        """Get provider_device_props by exact provider_device_id."""
         ...
 
 

--- a/src/baas/src/secbaas/community/core/repository/device/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/device/_orm_repository.py
@@ -263,6 +263,25 @@ class OrmDeviceRepository(OrmConnectionMixin, DeviceRepository):
         return record
 
     @with_orm_session
+    def get_by_provider_device_id(self, provider_device_id: str) -> DeviceRecord | None:
+        log.info("get_by_provider_device_id: provider_device_id=%s", provider_device_id)
+        row = (
+            self._session.query(DeviceModel)
+            .filter(
+                DeviceModel.provider_device_id == provider_device_id,
+                DeviceModel.is_deleted == 0,
+            )
+            .order_by(DeviceModel.id.desc())
+            .first()
+        )
+        record = row.to_record() if row else None
+        log.info(
+            "[device:get_by_provider_device_id] result: %s",
+            record.id if record else "None",
+        )
+        return record
+
+    @with_orm_session
     def get_by_provider_device_id_like(
         self, provider_device_id_prefix: str
     ) -> DeviceRecord | None:

--- a/src/baas/src/secbaas/community/core/repository/device/_protocol.py
+++ b/src/baas/src/secbaas/community/core/repository/device/_protocol.py
@@ -91,6 +91,14 @@ class DeviceRepository(Protocol):
         """
         ...
 
+    def get_by_provider_device_id(self, provider_device_id: str) -> DeviceRecord | None:
+        """Get device by exact provider_device_id (any status except deleted).
+
+        Uses the indexed provider_device_id column. Returns the most recent
+        match (ORDER BY id DESC LIMIT 1) or None.
+        """
+        ...
+
     def get_by_provider_device_id_like(
         self, provider_device_id_prefix: str
     ) -> DeviceRecord | None:

--- a/src/baas/src/secbaas/community/core/service/device_manage/_device_service.py
+++ b/src/baas/src/secbaas/community/core/service/device_manage/_device_service.py
@@ -22,6 +22,7 @@ from secbaas.community.api.device_manage import (
     EncryptableHeaderRule,
     EncryptableOutBoundRule,
     OutBoundOperationRule,
+    ProviderDevicePropsResponse,
     TeClawCreateConfig,  # noqa: F401 used in update_device TECLAW branch
 )
 from secbaas.community.api.template_manage import (
@@ -2333,3 +2334,38 @@ class DefaultDeviceService(DeviceService):
             f"tenant={record.tenant}, env={record.env}"
         )
         return device_record_to_response(record)
+
+    def get_provider_device_props(
+        self,
+        provider_device_id: str,
+    ) -> ProviderDevicePropsResponse | None:
+        """Get provider_device_props by exact provider_device_id.
+
+        Queries the baas_device record by the indexed provider_device_id
+        column. Returns None when no matching, non-deleted record exists.
+
+        Args:
+            provider_device_id: PaaS provider device ID (e.g. ``ALIYUN_ACK_DEFAULT-abc@0``)
+
+        Returns:
+            ProviderDevicePropsResponse, or None if not found/deleted
+        """
+        logger.info(
+            f"Getting provider device props: provider_device_id={provider_device_id}"
+        )
+
+        record = self._repository.get_by_provider_device_id(
+            provider_device_id=provider_device_id
+        )
+
+        if not record:
+            logger.info(f"Provider device not found: {provider_device_id}")
+            return None
+
+        return ProviderDevicePropsResponse(
+            provider_device_id=record.provider_device_id
+            if record.provider_device_id
+            else provider_device_id,
+            status=record.status,
+            provider_device_props=record.provider_device_props or None,
+        )

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox.py
@@ -94,16 +94,25 @@ class AliyunAckSandbox(ArcaSandbox):
             ttl_in_minutes = self._ttl_in_minutes
             ttl_timestamp = self._derive_ttl_timestamp(pod, ttl_in_minutes)
 
+            pod_ip = getattr(status, "pod_ip", None)
+            if not pod_ip:
+                raise RuntimeError(
+                    f"get_info failed for sandbox {self._sandbox_id}: pod has no status.pod_ip"
+                )
+
+            metadata: dict[str, Any] = {
+                "pod_name": self._pod_name,
+                "namespace": self._namespace,
+                "ip_addr": pod_ip,
+            }
+
             return ArcaSandboxInfo(
                 sandbox_id=self._sandbox_id,
                 status=getattr(status, "phase", None) or "UNKNOWN",
                 template_id=self._template_id,
                 ttl_in_minutes=ttl_in_minutes,
                 ttl_timestamp=ttl_timestamp,
-                metadata={
-                    "pod_name": self._pod_name,
-                    "namespace": self._namespace,
-                },
+                metadata=metadata,
             )
         except ApiException as e:
             raise RuntimeError(

--- a/src/baas/tests/e2e/asgi/baseline/test_device_api.py
+++ b/src/baas/tests/e2e/asgi/baseline/test_device_api.py
@@ -28,6 +28,51 @@ class TestDeviceApi:
         assert resp.status_code == 404
 
     @pytest.mark.asyncio
+    async def test_get_provider_device_props_not_found(self, api, unique_id: str):
+        """Test getting props for a non-existent provider_device_id returns 404."""
+        provider_device_id = f"nonexistent-provider-{unique_id}"
+        resp = await api.client.get(
+            f"/api/v1/devices/provider-device/{provider_device_id}/props"
+        )
+        assert resp.status_code == 404
+        detail = resp.json()["detail"]
+        assert detail["error"] == "DEVICE_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_get_provider_device_props_found(self, api, created_bot):
+        """Test getting props for a real provider_device_id returns the stored props."""
+        bot_uuid = created_bot["bot_uuid"]
+
+        devices_resp = await api.client.get(
+            api.bot_devices_url(bot_uuid),
+            params=api.params(),
+        )
+        assert devices_resp.status_code == 200
+        device_lists = devices_resp.json()["data"]
+        items = (
+            device_lists["items"]
+            if isinstance(device_lists, dict)
+            else device_lists[0]["items"]
+        )
+        assert len(items) > 0, "Created bot has no devices"
+        device_uuid = items[0]["device_uuid"]
+
+        device_resp = await api.client.get(api.device_url(device_uuid))
+        assert device_resp.status_code == 200
+        device = device_resp.json()["data"]
+        provider_device_id = device["provider_device_id"]
+        assert provider_device_id, "Device has no provider_device_id"
+
+        props_resp = await api.client.get(
+            f"/api/v1/devices/provider-device/{provider_device_id}/props"
+        )
+        assert props_resp.status_code == 200
+        props_data = props_resp.json()["data"]
+        assert props_data["provider_device_id"] == provider_device_id
+        assert props_data["status"] == device["status"]
+        assert props_data["provider_device_props"] == device["provider_device_props"]
+
+    @pytest.mark.asyncio
     async def test_get_device_by_bot_device_uuid(self, api, created_bot):
         """Test getting device info using the device UUID from a created bot."""
         bot_uuid = created_bot["bot_uuid"]

--- a/src/baas/tests/unit/adapters/web/test_device_router.py
+++ b/src/baas/tests/unit/adapters/web/test_device_router.py
@@ -15,10 +15,14 @@ from fastapi import HTTPException
 from secbaas.community.adapters.web.routers.paas_service.device_router import (
     DeviceNotFoundResponse,
     get_device_info,
+    get_provider_device_props,
     router,
 )
 from secbaas.community.api import ApiResponse
-from secbaas.community.api.device_manage import DeviceResponse
+from secbaas.community.api.device_manage import (
+    DeviceResponse,
+    ProviderDevicePropsResponse,
+)
 
 # ==================== Helpers ====================
 
@@ -322,3 +326,94 @@ class TestGetDeviceInfo:
         assert result.data.provider_type is None
         assert result.data.provider_device_id is None
         assert result.data.provider_device_props is None
+
+
+# ==================== GET get_provider_device_props ====================
+
+
+class TestGetProviderDeviceProps:
+    """Tests for get_provider_device_props endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_found_returns_200(self) -> None:
+        """Test that a found device returns ApiResponse with props data."""
+        provider_device_id = "ALIYUN_ACK_DEFAULT-abc@0"
+        expected = ProviderDevicePropsResponse(
+            provider_device_id=provider_device_id,
+            status="ACTIVE",
+            provider_device_props={
+                "sandbox_id": "sb-001",
+                "metadata": {"ip_addr": "10.0.0.7"},
+            },
+        )
+        mock_svc = MagicMock()
+        mock_svc.get_provider_device_props.return_value = expected
+
+        result = await get_provider_device_props(
+            provider_device_id=provider_device_id,
+            device_service=mock_svc,
+        )
+
+        assert isinstance(result, ApiResponse)
+        assert result.code == 0
+        assert result.data is not None
+        assert result.data.provider_device_id == provider_device_id
+        assert result.data.status == "ACTIVE"
+        assert result.data.provider_device_props["metadata"]["ip_addr"] == "10.0.0.7"
+        mock_svc.get_provider_device_props.assert_called_once_with(
+            provider_device_id=provider_device_id
+        )
+
+    @pytest.mark.asyncio
+    async def test_not_found_raises_404(self) -> None:
+        """Test that a missing provider device raises HTTPException 404."""
+        mock_svc = MagicMock()
+        mock_svc.get_provider_device_props.return_value = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_provider_device_props(
+                provider_device_id="nonexistent-provider",
+                device_service=mock_svc,
+            )
+
+        assert exc_info.value.status_code == 404
+        detail = exc_info.value.detail
+        assert detail["error"] == "DEVICE_NOT_FOUND"
+        assert "nonexistent-provider" in detail["message"]
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_raises_500(self) -> None:
+        """Test that unexpected errors raise HTTPException 500."""
+        mock_svc = MagicMock()
+        mock_svc.get_provider_device_props.side_effect = RuntimeError(
+            "Database connection lost"
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_provider_device_props(
+                provider_device_id="ALIYUN_ACK_DEFAULT-abc@0",
+                device_service=mock_svc,
+            )
+
+        assert exc_info.value.status_code == 500
+        detail = exc_info.value.detail
+        assert detail["error"] == "INTERNAL_ERROR"
+        assert "Database connection lost" in detail["message"]
+
+    @pytest.mark.asyncio
+    async def test_http_exception_re_raised_as_is(self) -> None:
+        """Test that HTTPException raised by service is re-raised directly."""
+        mock_svc = MagicMock()
+        mock_svc.get_provider_device_props.side_effect = HTTPException(
+            status_code=429,
+            detail={"error": "RATE_LIMITED", "message": "Too many requests"},
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_provider_device_props(
+                provider_device_id="ALIYUN_ACK_DEFAULT-abc@0",
+                device_service=mock_svc,
+            )
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.detail["error"] == "RATE_LIMITED"

--- a/src/baas/tests/unit/api/device_manage/test_protocols.py
+++ b/src/baas/tests/unit/api/device_manage/test_protocols.py
@@ -34,6 +34,7 @@ class TestDeviceServiceProtocol:
             "destroy_device_by_uuid",
             "stop_device_by_uuid",
             "get_device_info",
+            "get_provider_device_props",
         }
         protocol_methods = {
             name

--- a/src/baas/tests/unit/core/repository/device/test_orm_device_repository.py
+++ b/src/baas/tests/unit/core/repository/device/test_orm_device_repository.py
@@ -445,6 +445,27 @@ class TestGetByProviderDeviceIdLike:
         assert result is None
 
 
+# ==================== get_by_provider_device_id (exact) ====================
+
+
+class TestGetByProviderDeviceId:
+    def test_found(self, repository, mock_session):
+        model = _make_mock_device_model(id_val=8, provider_device_id="sandbox-abc-123")
+        mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = model
+
+        result = repository.get_by_provider_device_id("sandbox-abc-123")
+
+        assert result is not None
+        assert result.provider_device_id == "sandbox-abc-123"
+        model.to_record.assert_called_once()
+
+    def test_not_found(self, repository, mock_session):
+        mock_session.query.return_value.filter.return_value.order_by.return_value.first.return_value = None
+
+        result = repository.get_by_provider_device_id("nonexistent")
+        assert result is None
+
+
 # ==================== get_by_provider_device_id_prefix ====================
 
 

--- a/src/baas/tests/unit/core/service/device_manage/test_device_manage.py
+++ b/src/baas/tests/unit/core/service/device_manage/test_device_manage.py
@@ -571,6 +571,34 @@ class TestDefaultDeviceService:
 
         assert result is None
 
+    # ---- get_provider_device_props ----
+
+    def test_get_provider_device_props_found(self, service, mock_repo, mock_env):
+        record = MagicMock(spec=DeviceRecord)
+        record.provider_device_id = "ALIYUN_ACK_DEFAULT-abc@0"
+        record.status = "ACTIVE"
+        record.provider_device_props = {
+            "sandbox_id": "ALIYUN_ACK_DEFAULT-abc@0",
+            "metadata": {"ip_addr": "10.0.0.7"},
+        }
+        mock_repo.get_by_provider_device_id.return_value = record
+
+        result = service.get_provider_device_props(
+            provider_device_id="ALIYUN_ACK_DEFAULT-abc@0"
+        )
+
+        assert result is not None
+        assert result.provider_device_id == "ALIYUN_ACK_DEFAULT-abc@0"
+        assert result.status == "ACTIVE"
+        assert result.provider_device_props["metadata"]["ip_addr"] == "10.0.0.7"
+
+    def test_get_provider_device_props_not_found(self, service, mock_repo, mock_env):
+        mock_repo.get_by_provider_device_id.return_value = None
+
+        result = service.get_provider_device_props(provider_device_id="nonexistent")
+
+        assert result is None
+
     # ---- destroy_device_by_uuid ----
 
     @pytest.mark.asyncio

--- a/src/baas/tests/unit/plugins/sandbox/arca/aliyun_ack/test_sandbox_plugin.py
+++ b/src/baas/tests/unit/plugins/sandbox/arca/aliyun_ack/test_sandbox_plugin.py
@@ -65,9 +65,11 @@ class _FakePod:
         self,
         phase: str = "Running",
         name: str = "openclaw-ack-test-pod",
+        pod_ip: str | None = "10.0.0.7",
     ) -> None:
         self.status = MagicMock()
         self.status.phase = phase
+        self.status.pod_ip = pod_ip
         self.metadata = MagicMock()
         self.metadata.name = name
         self.metadata.labels = {"avernet.arcasandbox/template": TEMPLATE_ID}
@@ -234,6 +236,28 @@ class TestSandbox:
         assert isinstance(info, ArcaSandboxInfo)
         assert info.sandbox_id == "aliyun-ack-1"
         assert info.status == "Running"
+
+    def test_get_info_reports_ip_addr(self) -> None:
+        with _CoreHarness() as h:
+            pod = _FakePod(pod_ip="10.0.0.7")
+            h.core.read_namespaced_pod.return_value = pod
+            sb = AliyunAckSandbox(
+                "aliyun-ack-1", "ns", TEMPLATE_ID, MagicMock(), pod_name="aliyun-ack-1"
+            )
+            info = sb.get_info()
+        assert info.metadata["ip_addr"] == "10.0.0.7"
+        assert info.metadata["pod_name"] == "aliyun-ack-1"
+        assert info.metadata["namespace"] == "ns"
+
+    def test_get_info_raises_when_ip_missing(self) -> None:
+        with _CoreHarness() as h:
+            pod = _FakePod(pod_ip=None)
+            h.core.read_namespaced_pod.return_value = pod
+            sb = AliyunAckSandbox(
+                "aliyun-ack-1", "ns", TEMPLATE_ID, MagicMock(), pod_name="aliyun-ack-1"
+            )
+            with pytest.raises(RuntimeError, match="no status.pod_ip"):
+                sb.get_info()
 
     def test_get_info_echoes_ttl_in_minutes(self) -> None:
         with _CoreHarness() as h:

--- a/src/proxy/configs/application-prod.yaml
+++ b/src/proxy/configs/application-prod.yaml
@@ -14,6 +14,7 @@ user_config:
 
   baas:
     host: ${SANDBOXPROXY_BAAS_HOST:-http://baas.avernet-inc.com}
+    device_props_path: ${SANDBOXPROXY_BAAS_DEVICE_PROPS_PATH:-/api/v1/devices/provider-device/{provider_device_id}/props}
 
   teclaw:
     host: ${SANDBOXPROXY_TECLAW_HOST:-http://teclaw.avernet-inc.com}

--- a/src/proxy/configs/application.yaml
+++ b/src/proxy/configs/application.yaml
@@ -25,6 +25,7 @@ user_config:
 
   baas:
     host: http://baas.internal.example
+    device_props_path: /api/v1/devices/provider-device/{provider_device_id}/props
 
   teclaw:
     host: http://teclaw.internal.example

--- a/src/proxy/src/sandboxproxy/community/adapters/web/app.py
+++ b/src/proxy/src/sandboxproxy/community/adapters/web/app.py
@@ -71,14 +71,21 @@ def build_app(container: ApplicationContainer, loaded: Config) -> FastAPI:
         relay_client = container.relay_client()
         relay_server = container.relay_server()
         forwarding = container.forwarding()
+        target_resolver = container.target_resolver()
 
         await relay_client.start()
         await forwarding.start()
         await relay_server.start()
+        resolver_start = getattr(target_resolver, "start", None)
+        if resolver_start is not None:
+            await resolver_start()
         logger.info("app started")
         try:
             yield
         finally:
+            resolver_shutdown = getattr(target_resolver, "shutdown", None)
+            if resolver_shutdown is not None:
+                await resolver_shutdown()
             await relay_server.shutdown()
             await forwarding.shutdown()
             await relay_client.shutdown()

--- a/src/proxy/src/sandboxproxy/community/adapters/web/routes.py
+++ b/src/proxy/src/sandboxproxy/community/adapters/web/routes.py
@@ -53,7 +53,7 @@ def build_router(container: ApplicationContainer, loaded: Config) -> APIRouter:
         target_path = "/" + path if sep else "/"
 
         try:
-            resolved = resolver.resolve(target_hostport)
+            resolved = await resolver.resolve(target_hostport)
         except ValueError as exc:
             return JSONResponse({"detail": str(exc)}, status_code=400)
         except RuntimeError as exc:
@@ -77,7 +77,7 @@ def build_router(container: ApplicationContainer, loaded: Config) -> APIRouter:
         target_hostport, sep, path = target.partition("/")
         target_path = "/" + path if sep else "/"
         try:
-            resolved = resolver.resolve(target_hostport)
+            resolved = await resolver.resolve(target_hostport)
         except (ValueError, RuntimeError):
             await websocket.close(code=1008)
             return
@@ -157,6 +157,14 @@ def build_router(container: ApplicationContainer, loaded: Config) -> APIRouter:
 
 
 def _upstream_url(resolved: dict[str, str]) -> str:
+    pod_ip = resolved.get("pod_ip")
+    if pod_ip:
+        port = resolved.get("pod_port", "")
+        host = f"{pod_ip}:{port}" if port else pod_ip
+        scheme = resolved.get("pod_scheme", "http")
+        if host.startswith(("http://", "https://")):
+            return host
+        return f"{scheme}://{host}"
     host = (
         resolved.get("arca_host")
         or resolved.get("teclaw_host")

--- a/src/proxy/src/sandboxproxy/community/plugins/resolver/arca/_resolver.py
+++ b/src/proxy/src/sandboxproxy/community/plugins/resolver/arca/_resolver.py
@@ -1,95 +1,153 @@
-"""ARCA target resolver — resolves ``ARCA_`` targets into an Aliyun ACK pod upstream host.
+"""ARCA target resolver — resolves ``ARCA_`` targets into a sandbox pod IP.
 
-Target format: ``ARCA_{sandbox_id}[@{tenant}][:{port}]``.
+Target format: ``ARCA_{provider_device_id}[:{port}]``.
 
-The resolved upstream is a stable gateway that fronts the ACK pods. The
-sandbox is selected by injecting ``x-agent-sandbox-id``/``x-agent-sandbox-port``
-headers plus the per-tenant ``x-agent-sandbox-api-key`` credential (read straight
-from config in the community build — no Mist/SM4).
+The ``provider_device_id`` (e.g. ``ALIYUN_ACK_DEFAULT-46a7115b08ab@0``) is looked
+up against the upstream BaaS ``provider_device_props`` to obtain the sandbox
+pod's ``ip_addr``. The resolved upstream forwards directly to
+``http(s)://<ip_addr>:<port>``, skipping the cluster gateway.
 """
 
 from __future__ import annotations
 
+import time
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
-from sandboxproxy.community.config import AliyunAckClusterConfig, UserConfig
+import httpx
+
+from sandboxproxy.community.config import UserConfig
+from sandboxproxy.community.logger import get_logger
+
+logger = get_logger("resolver-arca")
 
 _DEFAULT_PORT = "8080"
-_DEFAULT_TENANT = "0"
+_DEFAULT_PROPS_PATH = "/api/v1/devices/provider-device/{provider_device_id}/props"
+_DEFAULT_SCHEME = "http"
+_CACHE_TTL_SECONDS = 60.0
+
+_CacheEntry = tuple[float, str | None]
 
 
 class ArcaTargetResolver:
-    """Resolve ``ARCA_`` targets into an Aliyun ACK pod upstream host."""
+    """Resolve ``ARCA_`` targets into a direct sandbox pod-IP upstream."""
 
     prefix = "arca"
 
-    def __init__(self, config: UserConfig | Mapping[str, Any]) -> None:
+    def __init__(
+        self,
+        config: UserConfig | Mapping[str, Any],
+        *,
+        cache_ttl: float = _CACHE_TTL_SECONDS,
+    ) -> None:
         self._config = (
             config
             if isinstance(config, UserConfig)
             else UserConfig.model_validate(config)
         )
+        self._cache_ttl = cache_ttl
+        self._client: httpx.AsyncClient | None = None
+        self._cache: dict[str, _CacheEntry] = {}
 
-    def resolve(self, target_host: str) -> dict[str, str]:
+    async def start(self) -> None:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=10.0)
+
+    async def shutdown(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def resolve(self, target_host: str) -> dict[str, str]:
         if not target_host.startswith("ARCA_"):
             raise ValueError(f"Not an ARCA_ target: {target_host!r}")
         rest = target_host[len("ARCA_") :]
         if not rest:
-            raise ValueError("ARCA_ target has no sandbox id")
+            raise ValueError("ARCA_ target has no provider device id")
 
-        sandbox_id, sandbox_port, tenant = _parse_rest(rest)
+        provider_device_id, sandbox_port = _parse_rest(rest)
 
-        cluster: AliyunAckClusterConfig = self._config.aliyun_ack_cluster
-        api_server = cluster.api_server.strip()
-        if not api_server:
+        baas_host = self._config.baas.get("host", "")
+        if not baas_host:
             raise RuntimeError(
-                "aliyun_ack_cluster.api_server is not configured; "
-                "cannot resolve ARCA target"
+                "baas host is not configured; cannot resolve ARCA target"
             )
-        if not api_server.startswith(("http://", "https://")):
-            api_server = "https://" + api_server
+        props_path = self._config.baas.get("device_props_path", _DEFAULT_PROPS_PATH)
+
+        ip_addr = await self._lookup_ip(baas_host, props_path, provider_device_id)
+        if not ip_addr:
+            raise RuntimeError(f"no ip_addr for provider device {provider_device_id!r}")
+
+        scheme = self._config.baas.get("device_scheme", _DEFAULT_SCHEME)
 
         return {
-            "arca_host": api_server,
-            "sandbox_id": sandbox_id,
-            "sandbox_port": sandbox_port,
-            "x-agent-sandbox-id": sandbox_id,
-            "x-agent-sandbox-port": sandbox_port,
-            "x-agent-sandbox-api-key": cluster.api_key_for(tenant),
+            "pod_ip": ip_addr,
+            "pod_port": sandbox_port,
+            "provider_device_id": provider_device_id,
+            "pod_scheme": scheme,
         }
 
+    async def _lookup_ip(
+        self,
+        baas_host: str,
+        props_path: str,
+        provider_device_id: str,
+    ) -> str:
+        cached = self._cache.get(provider_device_id)
+        if cached is not None:
+            timestamp, ip_addr = cached
+            if time.monotonic() - timestamp < self._cache_ttl:
+                return ip_addr or ""
+            del self._cache[provider_device_id]
 
-def _parse_rest(rest: str) -> tuple[str, str, str]:
-    """Parse the portion after ``ARCA_`` into ``(sandbox_id, port, tenant)``.
+        if self._client is None:
+            await self.start()
+
+        assert self._client is not None
+        url = baas_host.rstrip("/") + props_path.format(
+            provider_device_id=provider_device_id
+        )
+        ip_addr = ""
+        try:
+            resp = await self._client.get(url)
+            if resp.status_code < 400:
+                try:
+                    data = cast(dict[str, Any], resp.json())
+                except (ValueError, AttributeError) as exc:
+                    logger.warning("provider-device props malformed response: %s", exc)
+                    data = {}
+                body = cast(dict[str, Any], data.get("data")) or {}
+                props = cast(dict[str, Any], body.get("provider_device_props")) or {}
+                metadata = cast(dict[str, Any], props.get("metadata")) or {}
+                candidate = metadata.get("ip_addr")
+                ip_addr = candidate if isinstance(candidate, str) else ""
+            else:
+                logger.warning(
+                    "provider-device props lookup %s returned %s",
+                    url,
+                    resp.status_code,
+                )
+        except httpx.HTTPError as exc:
+            logger.warning("provider-device props lookup failed: %s", exc)
+            raise RuntimeError(
+                f"provider-device lookup failed for {provider_device_id!r}"
+            ) from exc
+
+        self._cache[provider_device_id] = (time.monotonic(), ip_addr or None)
+        return ip_addr
+
+
+def _parse_rest(rest: str) -> tuple[str, str]:
+    """Parse the portion after ``ARCA_`` into ``(provider_device_id, port)``.
 
     Supported shapes:
-        ``12345``          → id=12345, port=8080, tenant=0
-        ``12345:9090``     → id=12345, port=9090, tenant=0
-        ``12345@1``        → id=12345, port=8080, tenant=1
-        ``12345@1:9090``   → id=12345, port=9090, tenant=1
+        ``ALIYUN_ACK_DEFAULT-abc@0``          → id=..., port=8080
+        ``ALIYUN_ACK_DEFAULT-abc@0:9090``     → id=..., port=9090
     """
-    head = rest
-    tail = ""
-    tenant = _DEFAULT_TENANT
-
-    # Split off the @tenant suffix first: {head}@{tenant}[:{port}]
-    if "@" in rest:
-        head, _, suffix = rest.partition("@")
-        if suffix:
-            tenant, _, port_part = suffix.partition(":")
-            tail = port_part if port_part else tail
-            if not tenant:
-                tenant = _DEFAULT_TENANT
-
-    # head is now {sandbox_id} or {sandbox_id}:{port}
-    sid, sep, port = head.partition(":")
-    if not sid:
-        raise ValueError("ARCA_ target has no sandbox id")
-
-    sandbox_id = sid
-    sandbox_port = port if sep and port else (tail or _DEFAULT_PORT)
-    if not sandbox_port:
+    provider_device_id, sep, port = rest.partition(":")
+    if not provider_device_id:
+        raise ValueError("ARCA_ target has no provider device id")
+    if sep and not port:
         raise ValueError("ARCA_ target has an empty port")
-
-    return sandbox_id, sandbox_port, tenant
+    sandbox_port = port if sep else _DEFAULT_PORT
+    return provider_device_id, sandbox_port

--- a/src/proxy/src/sandboxproxy/community/plugins/resolver/local/_resolver.py
+++ b/src/proxy/src/sandboxproxy/community/plugins/resolver/local/_resolver.py
@@ -20,7 +20,7 @@ class LocalTargetResolver:
             else UserConfig.model_validate(config)
         )
 
-    def resolve(self, target_host: str) -> dict[str, str]:
+    async def resolve(self, target_host: str) -> dict[str, str]:
         if not target_host.startswith("LOCAL_"):
             raise ValueError(f"Not a LOCAL_ target: {target_host!r}")
         rest = target_host[len("LOCAL_") :]

--- a/src/proxy/src/sandboxproxy/community/plugins/resolver/prefix/_resolver.py
+++ b/src/proxy/src/sandboxproxy/community/plugins/resolver/prefix/_resolver.py
@@ -34,8 +34,20 @@ class PrefixTargetResolver:
             "LOCAL_": LocalTargetResolver(normalized),
         }
 
-    def resolve(self, target_host: str) -> dict[str, str]:
+    async def start(self) -> None:
+        for resolver in self._resolvers.values():
+            start = getattr(resolver, "start", None)
+            if start is not None:
+                await start()
+
+    async def shutdown(self) -> None:
+        for resolver in self._resolvers.values():
+            shutdown = getattr(resolver, "shutdown", None)
+            if shutdown is not None:
+                await shutdown()
+
+    async def resolve(self, target_host: str) -> dict[str, str]:
         for prefix, resolver in self._resolvers.items():
             if target_host.startswith(prefix):
-                return resolver.resolve(target_host)
+                return await resolver.resolve(target_host)
         raise ValueError(f"Unsupported proxypass target: {target_host!r}")

--- a/src/proxy/src/sandboxproxy/community/plugins/resolver/stub/_resolver.py
+++ b/src/proxy/src/sandboxproxy/community/plugins/resolver/stub/_resolver.py
@@ -14,5 +14,5 @@ class StubTargetResolver:
 
     prefix = "stub"
 
-    def resolve(self, target_host: str) -> dict[str, str]:
+    async def resolve(self, target_host: str) -> dict[str, str]:
         return dict(STUB_DESTINATION)

--- a/src/proxy/src/sandboxproxy/community/plugins/resolver/teclaw/_resolver.py
+++ b/src/proxy/src/sandboxproxy/community/plugins/resolver/teclaw/_resolver.py
@@ -20,7 +20,7 @@ class TeclawTargetResolver:
             else UserConfig.model_validate(config)
         )
 
-    def resolve(self, target_host: str) -> dict[str, str]:
+    async def resolve(self, target_host: str) -> dict[str, str]:
         if not target_host.startswith("TECLAW_"):
             raise ValueError(f"Not a TECLAW_ target: {target_host!r}")
         rest = target_host[len("TECLAW_") :]

--- a/src/proxy/src/sandboxproxy/community/spi/__init__.py
+++ b/src/proxy/src/sandboxproxy/community/spi/__init__.py
@@ -21,11 +21,12 @@ class TargetResolver(Protocol):
 
     prefix: str
 
-    def resolve(self, target_host: str) -> dict[str, str]:
+    async def resolve(self, target_host: str) -> dict[str, str]:
         """Return a dict describing the resolved upstream.
 
         Expected keys vary by resolver:
-        - ``ARCA_``  → ``arca_host`` (upstream host)
+        - ``ARCA_``  → ``pod_ip`` + ``pod_port`` + ``provider_device_id``
+          (direct pod-IP upstream)
         - ``TECLAW_`` → ``teclaw_host`` + ``x-target-bot-id`` + extra headers
         - ``LOCAL_`` → ``baas_host`` + ``local_path_prefix``
 

--- a/src/proxy/tests/architecture/test_lint_static.py
+++ b/src/proxy/tests/architecture/test_lint_static.py
@@ -1,0 +1,58 @@
+"""Architecture enforcement: lint, format, and static type gates.
+
+Runs the same gates as ``just check-*`` so regressions are caught in CI
+(``test-arch``) rather than only through ad-hoc invocations:
+
+- **Lint** (``ruff check .``) — rules in ``pyproject.toml`` (E, F, I, N, UP, ASYNC)
+- **Import sort + format** (``ruff check --select I . && ruff format --check .``)
+- **Static type check** (``mypy src``) — strict typing on the ``src`` tree
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run(cmd: list[str], label: str) -> None:
+    """Run ``cmd`` from the project root and raise on non-zero exit."""
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=PROJECT_ROOT,
+    )
+    if result.returncode != 0:
+        diagnostics = (result.stdout or "").strip() or (result.stderr or "").strip()
+        raise AssertionError(
+            f"{label} failed (exit code {result.returncode}):\n{diagnostics}"
+        )
+
+
+class TestLintAndFormat:
+    def test_ruff_lint_passes(self) -> None:
+        """``ruff check .`` — project-wide lint enforcement."""
+        _run([sys.executable, "-m", "ruff", "check", "."], "ruff check")
+
+    def test_ruff_import_sort_passes(self) -> None:
+        """``ruff check --select I .`` — import ordering enforcement."""
+        _run(
+            [sys.executable, "-m", "ruff", "check", "--select", "I", "."],
+            "ruff import-sort (select I)",
+        )
+
+    def test_ruff_format_passes(self) -> None:
+        """``ruff format --check .`` — formatting drift enforcement."""
+        _run(
+            [sys.executable, "-m", "ruff", "format", "--check", "."],
+            "ruff format",
+        )
+
+
+class TestStaticTyping:
+    def test_mypy_src_passes(self) -> None:
+        """``mypy src`` — strict type check on the source tree."""
+        _run([sys.executable, "-m", "mypy", "src"], "mypy src")

--- a/src/proxy/tests/conftest.py
+++ b/src/proxy/tests/conftest.py
@@ -1,0 +1,35 @@
+"""Shared pytest fixtures for the sandbox-proxy tests.
+
+The proxy consumes HS256 JWTs that BaaS signs with a shared secret resolved from
+``configs/application.yaml`` via ``${SANDBOXPROXY_JWT_SECRET:-}``. Rather than
+have each test file hardcode its own secret, we establish a single default and
+expose it through the ``jwt_secret`` fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+_DEFAULT_JWT_SECRET = "test-jwt-secret"
+
+
+@pytest.fixture
+def jwt_secret() -> str:
+    """The shared HS256 secret used to sign/verify proxypass JWTs.
+
+    Tests that build an app from a generated config should write this same value
+    into their ``user_config.jwt.secret``. Tests that load the repo's
+    ``configs/application.yaml`` get it for free via the autouse env fixture.
+    """
+    return _DEFAULT_JWT_SECRET
+
+
+@pytest.fixture(autouse=True)
+def _default_jwt_secret_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set a default ``SANDBOXPROXY_JWT_SECRET`` for the whole test process.
+
+    ``monkeypatch`` restores the previous value after each test, so a test may
+    still override the secret with its own ``monkeypatch.setenv`` or by writing
+    an explicit ``jwt.secret`` into a generated config.
+    """
+    monkeypatch.setenv("SANDBOXPROXY_JWT_SECRET", _DEFAULT_JWT_SECRET)

--- a/src/proxy/tests/e2e/asgi/baseline/test_baseline.py
+++ b/src/proxy/tests/e2e/asgi/baseline/test_baseline.py
@@ -6,14 +6,11 @@ import base64
 import hashlib
 import hmac
 import json
-import os
 import time
 
 import pytest
 
 from sandboxproxy.community.api.identity import resolve_instance_id
-
-_SECRET = "e2e-baseline-secret"
 
 
 def _sign(secret: str, payload: dict) -> str:
@@ -29,8 +26,7 @@ def _sign(secret: str, payload: dict) -> str:
 
 
 @pytest.fixture
-def app():
-    os.environ["SANDBOXPROXY_JWT_SECRET"] = _SECRET
+def app(jwt_secret: str):
     from sandboxproxy.community.adapters.web import build_app
     from sandboxproxy.community.bootstrap import (
         ApplicationContainer,
@@ -70,8 +66,8 @@ class TestBaselineLifecycle:
     def test_proxypass_requires_auth(self, client) -> None:
         assert client.get("/proxypass/ARCA_1").status_code == 401
 
-    def test_proxypass_accepts_valid_token(self, client) -> None:
-        token = _sign(_SECRET, {"sub": "u1", "exp": time.time() + 3600})
+    def test_proxypass_accepts_valid_token(self, client, jwt_secret: str) -> None:
+        token = _sign(jwt_secret, {"sub": "u1", "exp": time.time() + 3600})
         resp = client.get(
             "/proxypass/ARCA_1", headers={"Authorization": f"Bearer {token}"}
         )

--- a/src/proxy/tests/e2e/asgi/forward/test_forward.py
+++ b/src/proxy/tests/e2e/asgi/forward/test_forward.py
@@ -16,8 +16,6 @@ import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
-_SECRET = "e2e-forward-secret"
-
 
 def _sign(secret: str, payload: dict) -> str:
     def _b64(data: bytes) -> str:
@@ -41,6 +39,26 @@ def _upstream_app():
                 "path": "/" + path,
                 "method": request.method,
                 "query": dict(request.query_params),
+            }
+        )
+
+    return app
+
+
+def _baas_app(pod_ip: str):
+    app = FastAPI()
+
+    @app.get("/api/v1/devices/provider-device/{provider_device_id}/props")
+    async def props(provider_device_id: str):
+        return JSONResponse(
+            {
+                "code": 0,
+                "message": "success",
+                "data": {
+                    "provider_device_id": provider_device_id,
+                    "status": "ACTIVE",
+                    "provider_device_props": {"metadata": {"ip_addr": pod_ip}},
+                },
             }
         )
 
@@ -73,22 +91,57 @@ class _UpstreamServer:
         raise RuntimeError("upstream did not start")
 
 
+class _BaasServer:
+    def __init__(self, port: int, pod_ip: str):
+        self.port = port
+        self.pod_ip = pod_ip
+        self.thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        self.thread = threading.Thread(
+            target=uvicorn.run,
+            kwargs={
+                "app": _baas_app(self.pod_ip),
+                "host": "127.0.0.1",
+                "port": self.port,
+                "log_level": "error",
+            },
+            daemon=True,
+        )
+        self.thread.start()
+        for _ in range(50):
+            try:
+                httpx.get(f"http://127.0.0.1:{self.port}/health")
+                return
+            except httpx.HTTPError:
+                time.sleep(0.1)
+        raise RuntimeError("baas did not start")
+
+
 @pytest.fixture
 def upstream_port():
     return 18765
 
 
+@pytest.fixture
+def baas_port():
+    return 18766
+
+
 @pytest.mark.e2e
 class TestProxypassForward:
-    def test_forward_to_live_upstream(self, upstream_port: int) -> None:
+    def test_forward_to_live_upstream(
+        self, upstream_port: int, baas_port: int, jwt_secret: str
+    ) -> None:
         import tempfile
         from pathlib import Path
 
-        secret = _SECRET
-        os.environ["SANDBOXPROXY_JWT_SECRET"] = secret
+        secret = jwt_secret
 
         upstream = _UpstreamServer(upstream_port)
         upstream.start()
+        baas = _BaasServer(baas_port, pod_ip="127.0.0.1")
+        baas.start()
         try:
             with tempfile.TemporaryDirectory() as tmp:
                 cfg = Path(tmp) / "application.yaml"
@@ -100,8 +153,8 @@ class TestProxypassForward:
                     "    relay_client: stub\n"
                     "  jwt:\n"
                     f"    secret: {secret}\n"
-                    "  aliyun_ack_cluster:\n"
-                    f"    api_server: http://127.0.0.1:{upstream_port}\n"
+                    "  baas:\n"
+                    f"    host: http://127.0.0.1:{baas_port}\n"
                 )
                 os.environ["SANDBOXPROXY_CONFIG_PATH"] = str(cfg)
 
@@ -133,9 +186,15 @@ class TestProxypassForward:
                 from starlette.testclient import TestClient
 
                 with TestClient(app) as client:
-                    token = _sign(secret, {"sub": "u1", "exp": time.time() + 3600})
+                    token = _sign(
+                        secret,
+                        {
+                            "target": f"ARCA_ALIYUN_ACK_DEFAULT-abc@1:{upstream_port}",
+                            "exp": int(time.time()) + 3600,
+                        },
+                    )
                     resp = client.get(
-                        "/proxypass/ARCA_12345:8080/echo?x=1",
+                        f"/proxypass/ARCA_ALIYUN_ACK_DEFAULT-abc@1:{upstream_port}/echo?x=1",
                         headers={"Authorization": f"Bearer {token}"},
                     )
                     assert resp.status_code == 200

--- a/src/proxy/tests/e2e/asgi/relay/test_relay.py
+++ b/src/proxy/tests/e2e/asgi/relay/test_relay.py
@@ -2,18 +2,13 @@
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from sandboxproxy.community.api.identity import resolve_instance_id
 
-_SECRET = "e2e-relay-secret"
-
 
 @pytest.fixture
-def app():
-    os.environ["SANDBOXPROXY_JWT_SECRET"] = _SECRET
+def app(jwt_secret: str):
     from sandboxproxy.community.adapters.web import build_app
     from sandboxproxy.community.bootstrap import (
         ApplicationContainer,

--- a/src/proxy/tests/integration/test_app.py
+++ b/src/proxy/tests/integration/test_app.py
@@ -6,7 +6,6 @@ import base64
 import hashlib
 import hmac
 import json
-import os
 import time
 
 import pytest
@@ -25,13 +24,7 @@ def _sign(secret: str, payload: dict) -> str:
 
 
 @pytest.fixture
-def secret() -> str:
-    return "integration-secret"
-
-
-@pytest.fixture
-def app(secret: str):
-    os.environ["SANDBOXPROXY_JWT_SECRET"] = secret
+def app(jwt_secret: str):
     from sandboxproxy.community.adapters.web import build_app
     from sandboxproxy.community.api.identity import resolve_instance_id
     from sandboxproxy.community.bootstrap import (
@@ -88,8 +81,8 @@ class TestProxypassAuth:
         )
         assert resp.status_code == 401
 
-    def test_valid_token(self, client, secret: str) -> None:
-        token = _sign(secret, {"sub": "u1", "exp": time.time() + 3600})
+    def test_valid_token(self, client, jwt_secret: str) -> None:
+        token = _sign(jwt_secret, {"sub": "u1", "exp": time.time() + 3600})
         # stub resolver returns a fixed local destination; forward will fail
         # to reach it, but the request must NOT be rejected as unauthorized.
         resp = client.get(

--- a/src/proxy/tests/integration/test_ws_routes.py
+++ b/src/proxy/tests/integration/test_ws_routes.py
@@ -93,3 +93,6 @@ class TestHelpers:
 
         assert _upstream_url({"arca_host": "h1"}) == "https://h1"
         assert _upstream_url({"arca_host": "http://h1"}) == "http://h1"
+        assert _upstream_url({"pod_ip": "10.0.0.7", "pod_port": "20003"}) == (
+            "http://10.0.0.7:20003"
+        )

--- a/src/proxy/tests/unit/test_coverage_gaps.py
+++ b/src/proxy/tests/unit/test_coverage_gaps.py
@@ -21,16 +21,20 @@ class TestResolverErrorBranches:
         return PrefixTargetResolver(UserConfig.model_validate(base))
 
     def test_teclaw_empty_id(self) -> None:
+        import asyncio
+
         r = self._resolver()
         try:
-            r.resolve("TECLAW_@tmpl:8080")
+            asyncio.run(r.resolve("TECLAW_@tmpl:8080"))
         except ValueError:
             pass
 
     def test_local_no_port(self) -> None:
+        import asyncio
+
         r = self._resolver()
         try:
-            r.resolve("LOCAL_dev1@42")
+            asyncio.run(r.resolve("LOCAL_dev1@42"))
         except ValueError:
             pass
 

--- a/src/proxy/tests/unit/test_jwt_verifier.py
+++ b/src/proxy/tests/unit/test_jwt_verifier.py
@@ -25,6 +25,16 @@ def _sign(secret: str, payload: dict) -> str:
     return f"{header_b64}.{payload_b64}.{_b64(sig)}"
 
 
+def _baas_generate_jwt_token(target: str, secret: str, ttl: int = 300) -> str:
+    """Mirror ``secbaas.core.utils.secret_utils.generate_jwt_token``.
+
+    BaaS signs proxypass tokens exactly like this, and the proxy must accept
+    them unchanged: HS256 over ``header.payload`` with a ``target`` claim and an
+    integer ``exp`` claim.
+    """
+    return _sign(secret, {"target": target, "exp": int(time.time()) + ttl})
+
+
 class TestJwtVerifier:
     def test_valid_token(self) -> None:
         v = JwtVerifier.from_secret("secret")
@@ -50,3 +60,29 @@ class TestJwtVerifier:
     def test_empty_secret_rejected(self) -> None:
         with pytest.raises(ValueError):
             JwtVerifier.from_secret("")
+
+
+class TestBaaSJwtInterop:
+    """The proxy must verify tokens as issued by BaaS ``secret_utils``."""
+
+    def test_accepts_baas_signed_token(self) -> None:
+        v = JwtVerifier.from_secret("shared-secret")
+        token = _baas_generate_jwt_token(
+            "ARCA_ALIYUN_ACK_DEFAULT-31ebaaf6ca00@1:20003", "shared-secret"
+        )
+        payload = v.verify(token)
+        assert payload is not None
+        assert payload["target"] == "ARCA_ALIYUN_ACK_DEFAULT-31ebaaf6ca00@1:20003"
+        assert isinstance(payload["exp"], int)
+
+    def test_rejects_baas_token_with_wrong_secret(self) -> None:
+        v = JwtVerifier.from_secret("shared-secret")
+        token = _baas_generate_jwt_token("ARCA_ALIYUN_ACK_DEFAULT-abc@1", "other")
+        assert v.verify(token) is None
+
+    def test_rejects_baas_token_after_expiry(self) -> None:
+        v = JwtVerifier.from_secret("shared-secret")
+        token = _sign(
+            "shared-secret", {"target": "ARCA_ALIYUN_ACK_DEFAULT-abc@1", "exp": -1}
+        )
+        assert v.verify(token) is None

--- a/src/proxy/tests/unit/test_plugins_and_entrypoint.py
+++ b/src/proxy/tests/unit/test_plugins_and_entrypoint.py
@@ -134,5 +134,16 @@ class TestRunnerPlugin:
 
         monkeypatch.setattr(uvicorn, "run", fake_run)
         plugin = BareAppRunnerPlugin()
-        plugin.run(config_path=str(cfg))
+        try:
+            plugin.run(config_path=str(cfg))
+        finally:
+            # ``plugin.run`` mutates the process environment directly (not via
+            # monkeypatch); undo it immediately so later tests that load config
+            # from the working directory are not redirected to a deleted temp
+            # path.
+            import os
+
+            os.environ.pop("SANDBOXPROXY_RUN_MODE", None)
+            os.environ.pop("SANDBOXPROXY_CONFIG_PATH", None)
+
         assert captured["app"] == "sandboxproxy.community.adapters.web.app:app"

--- a/src/proxy/tests/unit/test_resolver.py
+++ b/src/proxy/tests/unit/test_resolver.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
+from typing import Any
+
 import pytest
 
 from sandboxproxy.community.config import UserConfig
 from sandboxproxy.community.plugins.resolver.arca import ArcaTargetResolver
+from sandboxproxy.community.plugins.resolver.arca._resolver import _parse_rest
 from sandboxproxy.community.plugins.resolver.local import LocalTargetResolver
 from sandboxproxy.community.plugins.resolver.prefix import PrefixTargetResolver
 from sandboxproxy.community.plugins.resolver.stub import StubTargetResolver
@@ -35,67 +39,335 @@ def resolver(config: UserConfig) -> PrefixTargetResolver:
 
 
 class TestArcaResolution:
-    def test_default_port(self, resolver: PrefixTargetResolver) -> None:
-        result = resolver.resolve("ARCA_12345")
-        assert result["sandbox_id"] == "12345"
-        assert result["sandbox_port"] == "8080"
-        assert "arca_host" in result
-
-    def test_explicit_port(self, resolver: PrefixTargetResolver) -> None:
-        result = resolver.resolve("ARCA_12345:9090")
-        assert result["sandbox_id"] == "12345"
-        assert result["sandbox_port"] == "9090"
-
-    def test_no_sandbox_id(self, resolver: PrefixTargetResolver) -> None:
-        with pytest.raises(ValueError):
-            resolver.resolve("ARCA_")
-
-    def test_default_tenant_headers(self, resolver: PrefixTargetResolver) -> None:
-        result = resolver.resolve("ARCA_12345")
-        assert result["x-agent-sandbox-id"] == "12345"
-        assert result["x-agent-sandbox-port"] == "8080"
-        assert result["x-agent-sandbox-api-key"] == "key-zero"
-
-    def test_tenant_selects_api_key(self, resolver: PrefixTargetResolver) -> None:
-        result = resolver.resolve("ARCA_12345@1:9090")
-        assert result["sandbox_id"] == "12345"
-        assert result["sandbox_port"] == "9090"
-        assert result["x-agent-sandbox-api-key"] == "key-one"
-
-    def test_no_api_key_when_unconfigured(self) -> None:
-        cfg = UserConfig.model_validate(
-            {"aliyun_ack_cluster": {"api_server": "https://ack"}}
+    def _resolver(self, config: UserConfig | None = None) -> PrefixTargetResolver:
+        cfg = config or UserConfig.model_validate(
+            {"baas": {"host": "http://baas.internal.example"}}
         )
-        result = PrefixTargetResolver(cfg).resolve("ARCA_12345")
-        assert result["x-agent-sandbox-api-key"] == ""
+        return PrefixTargetResolver(cfg)
 
-    def test_missing_host(self) -> None:
-        cfg = UserConfig.model_validate({"aliyun_ack_cluster": {}})
+    def _patch_lookup(
+        self, monkeypatch: pytest.MonkeyPatch, ip_addr: str = "10.0.0.7"
+    ) -> None:
+        async def _lookup(
+            self: ArcaTargetResolver,
+            baas_host: str,
+            props_path: str,
+            provider_device_id: str,
+        ) -> str:
+            return ip_addr
+
+        monkeypatch.setattr(ArcaTargetResolver, "_lookup_ip", _lookup)
+
+    async def test_default_port(
+        self, resolver: PrefixTargetResolver, monkeypatch
+    ) -> None:
+        self._patch_lookup(monkeypatch)
+        result = await resolver.resolve("ARCA_ALIYUN_ACK_DEFAULT-abc@0")
+        assert result["provider_device_id"] == "ALIYUN_ACK_DEFAULT-abc@0"
+        assert result["pod_port"] == "8080"
+        assert result["pod_ip"] == "10.0.0.7"
+
+    async def test_explicit_port(
+        self, resolver: PrefixTargetResolver, monkeypatch
+    ) -> None:
+        self._patch_lookup(monkeypatch)
+        result = await resolver.resolve("ARCA_ALIYUN_ACK_DEFAULT-abc@0:9090")
+        assert result["provider_device_id"] == "ALIYUN_ACK_DEFAULT-abc@0"
+        assert result["pod_port"] == "9090"
+
+    async def test_no_provider_device_id(self, resolver: PrefixTargetResolver) -> None:
+        with pytest.raises(ValueError):
+            await resolver.resolve("ARCA_")
+
+    async def test_empty_port(self, resolver: PrefixTargetResolver) -> None:
+        with pytest.raises(ValueError):
+            await resolver.resolve("ARCA_ALIYUN_ACK_DEFAULT-abc@0:")
+
+    def test_parse_rest_empty(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_rest("")
+
+    async def test_no_ip_addr(
+        self, resolver: PrefixTargetResolver, monkeypatch
+    ) -> None:
+        self._patch_lookup(monkeypatch, ip_addr="")
+        with pytest.raises(RuntimeError, match="no ip_addr"):
+            await resolver.resolve("ARCA_ALIYUN_ACK_DEFAULT-abc@0")
+
+    async def test_missing_baas_host(self, monkeypatch) -> None:
+        cfg = UserConfig.model_validate({})
         resolver = PrefixTargetResolver(cfg)
         with pytest.raises(RuntimeError):
-            resolver.resolve("ARCA_12345")
+            await resolver.resolve("ARCA_12345")
+
+
+class TestArcaLookupIp:
+    """Exercise the real ``_lookup_ip`` HTTP path via ``httpx.MockTransport``."""
+
+    _PROPS_PATH = "/api/v1/devices/provider-device/{provider_device_id}/props"
+
+    def _make_resolver(self, handler: Any) -> ArcaTargetResolver:
+        import httpx
+
+        transport = httpx.MockTransport(handler)
+        config = UserConfig.model_validate(
+            {"baas": {"host": "http://baas.internal.example"}}
+        )
+        resolver = ArcaTargetResolver(config)
+        resolver._client = httpx.AsyncClient(transport=transport)  # noqa: SLF001
+        return resolver
+
+    async def _lookup(self, body: Any = None, status_code: int = 200) -> str:
+        import httpx
+
+        def handler(request):
+            return httpx.Response(status_code, json=body)
+
+        resolver = self._make_resolver(handler)
+        try:
+            return await resolver._lookup_ip(  # noqa: SLF001
+                "http://baas.internal.example",
+                self._PROPS_PATH,
+                "ALIYUN_ACK_DEFAULT-abc@1",
+            )
+        finally:
+            await resolver.shutdown()
+
+    async def test_lookup_success(self) -> None:
+        ip_addr = await self._lookup(
+            {"data": {"provider_device_props": {"metadata": {"ip_addr": "10.1.2.3"}}}}
+        )
+        assert ip_addr == "10.1.2.3"
+
+    async def test_lookup_no_ip_addr(self) -> None:
+        assert (
+            await self._lookup({"data": {"provider_device_props": {"metadata": {}}}})
+            == ""
+        )
+
+    async def test_lookup_missing_metadata(self) -> None:
+        assert await self._lookup({"data": {"provider_device_props": {}}}) == ""
+
+    async def test_lookup_404(self) -> None:
+        assert await self._lookup({}, status_code=404) == ""
+
+    async def test_lookup_500(self) -> None:
+        assert await self._lookup({}, status_code=500) == ""
+
+    async def test_lookup_malformed_response(self) -> None:
+        import httpx
+
+        def handler(request):
+            return httpx.Response(200, content=b"not-json")
+
+        resolver = self._make_resolver(handler)
+        try:
+            ip_addr = await resolver._lookup_ip(  # noqa: SLF001
+                "http://baas.internal.example",
+                self._PROPS_PATH,
+                "ALIYUN_ACK_DEFAULT-abc@1",
+            )
+        finally:
+            await resolver.shutdown()
+        assert ip_addr == ""
+
+    async def test_lookup_non_string_ip_addr(self) -> None:
+        assert (
+            await self._lookup(
+                {"data": {"provider_device_props": {"metadata": {"ip_addr": 123}}}}
+            )
+            == ""
+        )
+
+    async def test_lookup_network_error(self) -> None:
+        import httpx
+
+        def handler(request):
+            raise httpx.ConnectError("boom")
+
+        resolver = self._make_resolver(handler)
+        try:
+            with pytest.raises(RuntimeError, match="lookup failed"):
+                await resolver._lookup_ip(  # noqa: SLF001
+                    "http://baas.internal.example",
+                    self._PROPS_PATH,
+                    "ALIYUN_ACK_DEFAULT-abc@1",
+                )
+        finally:
+            await resolver.shutdown()
+
+    async def test_default_props_path_used(self) -> None:
+        import httpx
+
+        seen_urls: dict[str, object] = {}
+
+        def handler(request):
+            seen_urls["url"] = str(request.url)
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "provider_device_props": {"metadata": {"ip_addr": "10.9.9.9"}}
+                    }
+                },
+            )
+
+        resolver = self._make_resolver(handler)
+        try:
+            result = await resolver.resolve("ARCA_ALIYUN_ACK_DEFAULT-abc@1")
+        finally:
+            await resolver.shutdown()
+        assert result["pod_ip"] == "10.9.9.9"
+        assert seen_urls["url"] == (
+            "http://baas.internal.example/api/v1/devices/"
+            "provider-device/ALIYUN_ACK_DEFAULT-abc@1/props"
+        )
+
+
+class TestArcaResolveViaTransport:
+    """Drive ``resolve()`` end to end with a mocked ``httpx.AsyncClient``."""
+
+    def _resolver(
+        self, body: Any = None, status_code: int = 200
+    ) -> PrefixTargetResolver:
+        import httpx
+
+        def handler(request):
+            return httpx.Response(status_code, json=body)
+
+        transport = httpx.MockTransport(handler)
+        config = UserConfig.model_validate(
+            {"baas": {"host": "http://baas.internal.example"}}
+        )
+        resolver = PrefixTargetResolver(config)
+        arca = resolver._resolvers["ARCA_"]  # noqa: SLF001
+        arca._client = httpx.AsyncClient(transport=transport)  # noqa: SLF001
+        return resolver
+
+    async def test_resolve_returns_ip_and_port(self) -> None:
+        resolver = self._resolver(
+            {"data": {"provider_device_props": {"metadata": {"ip_addr": "10.2.3.4"}}}},
+        )
+        result = await resolver.resolve("ARCA_ALIYUN_ACK_DEFAULT-abc@1:20003")
+        assert result["pod_ip"] == "10.2.3.4"
+        assert result["pod_port"] == "20003"
+        assert result["provider_device_id"] == "ALIYUN_ACK_DEFAULT-abc@1"
+        assert "sandbox_id" not in result
+
+    async def test_resolve_404_raises(self) -> None:
+        resolver = self._resolver({}, status_code=404)
+        with pytest.raises(RuntimeError, match="no ip_addr"):
+            await resolver.resolve("ARCA_ALIYUN_ACK_DEFAULT-abc@1:20003")
+
+    async def test_resolve_caches_ip(self) -> None:
+        import httpx
+
+        calls: list[str] = []
+
+        def handler(request):
+            calls.append(str(request.url))
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "provider_device_props": {"metadata": {"ip_addr": "10.3.3.3"}}
+                    }
+                },
+            )
+
+        transport = httpx.MockTransport(handler)
+        config = UserConfig.model_validate(
+            {"baas": {"host": "http://baas.internal.example"}}
+        )
+        resolver = PrefixTargetResolver(config)
+        arca = resolver._resolvers["ARCA_"]  # noqa: SLF001
+        arca._client = httpx.AsyncClient(transport=transport)  # noqa: SLF001
+
+        await resolver.resolve("ARCA_ALIYUN_ACK_DEFAULT-abc@1:20003")
+        await resolver.resolve("ARCA_ALIYUN_ACK_DEFAULT-abc@1:20003")
+        assert len(calls) == 1
+
+    async def test_resolve_refetches_after_ttl_expiry(self) -> None:
+        import httpx
+
+        calls: list[str] = []
+
+        def handler(request):
+            calls.append(str(request.url))
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "provider_device_props": {"metadata": {"ip_addr": "10.4.4.4"}}
+                    }
+                },
+            )
+
+        transport = httpx.MockTransport(handler)
+        config = UserConfig.model_validate(
+            {"baas": {"host": "http://baas.internal.example"}}
+        )
+        resolver = PrefixTargetResolver(config)
+        arca = resolver._resolvers["ARCA_"]  # noqa: SLF001
+        arca._cache_ttl = -1.0
+        arca._client = httpx.AsyncClient(transport=transport)  # noqa: SLF001
+
+        await resolver.resolve("ARCA_ALIYUN_ACK_DEFAULT-abc@1:20003")
+        await resolver.resolve("ARCA_ALIYUN_ACK_DEFAULT-abc@1:20003")
+        assert len(calls) == 2
+
+    async def test_resolve_lazily_starts_client(self, monkeypatch) -> None:
+        import httpx
+
+        def handler(request):
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "provider_device_props": {"metadata": {"ip_addr": "10.5.5.5"}}
+                    }
+                },
+            )
+
+        transport = httpx.MockTransport(handler)
+        config = UserConfig.model_validate(
+            {"baas": {"host": "http://baas.internal.example"}}
+        )
+        resolver = PrefixTargetResolver(config)
+        arca = resolver._resolvers["ARCA_"]  # noqa: SLF001
+
+        async def fake_start(self):
+            self._client = httpx.AsyncClient(transport=transport)  # noqa: SLF001
+
+        monkeypatch.setattr(ArcaTargetResolver, "start", fake_start)
+        try:
+            result = await resolver.resolve("ARCA_ALIYUN_ACK_DEFAULT-abc@1:20003")
+        finally:
+            await arca.shutdown()
+
+        assert result["pod_ip"] == "10.5.5.5"
 
 
 class TestTeclawResolution:
     def test_bot_id_extracted(self, resolver: PrefixTargetResolver) -> None:
-        result = resolver.resolve("TECLAW_bot123@tmpl456:8080")
+        result = asyncio.run(resolver.resolve("TECLAW_bot123@tmpl456:8080"))
         assert result["x-target-bot-id"] == "bot123"
         assert result["teclaw_host"] == "http://teclaw.internal.example"
 
     def test_empty_remainder(self, resolver: PrefixTargetResolver) -> None:
         with pytest.raises(ValueError):
-            resolver.resolve("TECLAW_")
+            asyncio.run(resolver.resolve("TECLAW_"))
 
     def test_missing_host(self) -> None:
         cfg = UserConfig.model_validate({"teclaw": {}})
         resolver = PrefixTargetResolver(cfg)
         with pytest.raises(RuntimeError):
-            resolver.resolve("TECLAW_bot1@tmpl:8080")
+            asyncio.run(resolver.resolve("TECLAW_bot1@tmpl:8080"))
 
 
 class TestLocalResolution:
     def test_http_target(self, resolver: PrefixTargetResolver) -> None:
-        result = resolver.resolve("LOCAL_dev1@42:20003")
+        result = asyncio.run(resolver.resolve("LOCAL_dev1@42:20003"))
         assert result["device_id"] == "dev1"
         assert result["template_id"] == "42"
         assert result["port"] == "20003"
@@ -104,7 +376,7 @@ class TestLocalResolution:
         )
 
     def test_ws_target_strips_session(self, resolver: PrefixTargetResolver) -> None:
-        result = resolver.resolve("LOCAL_dev1@42:20003:sess-abc")
+        result = asyncio.run(resolver.resolve("LOCAL_dev1@42:20003:sess-abc"))
         assert result["port"] == "20003"
         assert result["local_path_prefix"] == (
             "/api/v1/paas/devices/dev1@42/invoke-http/20003"
@@ -112,37 +384,37 @@ class TestLocalResolution:
 
     def test_no_at_separator(self, resolver: PrefixTargetResolver) -> None:
         with pytest.raises(ValueError):
-            resolver.resolve("LOCAL_dev1")
+            asyncio.run(resolver.resolve("LOCAL_dev1"))
 
     def test_multiple_at(self, resolver: PrefixTargetResolver) -> None:
         with pytest.raises(ValueError):
-            resolver.resolve("LOCAL_dev1@42@20003")
+            asyncio.run(resolver.resolve("LOCAL_dev1@42@20003"))
 
     def test_missing_host(self) -> None:
         cfg = UserConfig.model_validate({"baas": {}})
         resolver = PrefixTargetResolver(cfg)
         with pytest.raises(RuntimeError):
-            resolver.resolve("LOCAL_dev1@42:20003")
+            asyncio.run(resolver.resolve("LOCAL_dev1@42:20003"))
 
 
 class TestUnsupportedTarget:
     def test_unknown_prefix(self, resolver: PrefixTargetResolver) -> None:
         with pytest.raises(ValueError):
-            resolver.resolve("FOO_123")
+            asyncio.run(resolver.resolve("FOO_123"))
 
 
 class TestIndividualResolvers:
     def test_arca_rejects_non_arca(self, config: UserConfig) -> None:
         with pytest.raises(ValueError):
-            ArcaTargetResolver(config).resolve("TECLAW_bot@t:1")
+            asyncio.run(ArcaTargetResolver(config).resolve("TECLAW_bot@t:1"))
 
     def test_teclaw_rejects_non_teclaw(self, config: UserConfig) -> None:
         with pytest.raises(ValueError):
-            TeclawTargetResolver(config).resolve("ARCA_1")
+            asyncio.run(TeclawTargetResolver(config).resolve("ARCA_1"))
 
     def test_local_rejects_non_local(self, config: UserConfig) -> None:
         with pytest.raises(ValueError):
-            LocalTargetResolver(config).resolve("ARCA_1")
+            asyncio.run(LocalTargetResolver(config).resolve("ARCA_1"))
 
     def test_prefix_attributes(self) -> None:
         assert ArcaTargetResolver.prefix == "arca"
@@ -154,6 +426,6 @@ class TestIndividualResolvers:
 class TestStubResolver:
     def test_fixed_destination(self) -> None:
         resolver = StubTargetResolver()
-        result = resolver.resolve("ARCA_anything")
+        result = asyncio.run(resolver.resolve("ARCA_anything"))
         assert result["sandbox_id"] == "stub"
         assert "arca_host" in result


### PR DESCRIPTION
## Problem
ARCA_ proxypass targets resolved to a stable cluster gateway, requiring the gateway to front the ACK pods and injecting per-tenant sandbox headers. This added an unnecessary hop and required the cluster gateway to stay in sync with pod state.

## Solution
Resolve ARCA_ targets to the sandbox pod's direct IP. The proxy:
- Calls a new BaaS endpoint `GET /api/v1/devices/provider-device/{provider_device_id}/props` (exact indexed lookup) to obtain the pod's `ip_addr`.
- Emits `pod_ip` + `pod_port` upstream and forwards to `http://<ip>:<port>`, skipping the cluster gateway.

Supporting changes:
- BaaS device repository/service/API: `get_by_provider_device_id` exact lookup (replaces `_like`), `get_provider_device_props` service method, and the new HTTP endpoint (404 when not found).
- aliyun_ack sandbox `get_info` now reports `pod_ip` in metadata (raises if missing).
- `device_props_path` config added to proxy `application*.yaml` and `baas` config.

## Validation
- Unit tests for BaaS repository/service/protocol and proxy resolver (parse, lookup via `httpx.MockTransport`, forward URL).
- E2E: forward test spins a stub BaaS returning `ip_addr`, jwt interop tests confirm BaaS-signed tokens verify.
- Pre-push gate (lint-only) passed; full CI (tests/coverage/E2E) not run locally — set `OCB_PRE_PUSH_RUN_CI=1`.

## Compatibility and risk
- `aliyun_ack_cluster` config is no longer consumed by the ARCA resolver; it now reads `baas.host` + `baas.device_props_path`.
- Token shape unchanged; proxy continues to verify BaaS `secret_utils`-signed HS256 JWTs (with `target` + integer `exp` claims).