### PR TITLE
fix(backend): preserve BCS catalog total

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/catalog_metadata.py
@@ -51,6 +51,14 @@ class BotCatalogMetadata:
     user_visibility: Any = None
 
 
+@dataclass(frozen=True)
+class BotCatalogMetadataPage:
+    """One BCS page, retaining BCS pagination metadata for the public result."""
+
+    total: int
+    items: Sequence[BotCatalogMetadata]
+
+
 class BotCatalogMetadataUnavailableError(Exception):
     """The catalog metadata port cannot make an authoritative decision."""
 
@@ -68,7 +76,7 @@ class BotCatalogMetadataServiceProtocol(Protocol):
         filters: BotCatalogSearchFilters | None,
         caller: BotCatalogCaller,
         request_id: str,
-    ) -> Sequence[BotCatalogMetadata]: ...
+    ) -> BotCatalogMetadataPage: ...
 
 
 class BotCatalogSearchUnavailableError(Exception):

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_catalog_metadata_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 
 import httpx
 
@@ -11,6 +11,7 @@ from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogCaller,
     BotCatalogMetadata,
     BotCatalogMetadataUnavailableError,
+    BotCatalogMetadataPage,
     BotCatalogSearchFilters,
 )
 from agentclaw.community.log import get_logger
@@ -35,7 +36,7 @@ class BcsBotCatalogMetadataService:
         filters: BotCatalogSearchFilters | None = None,
         caller: BotCatalogCaller,
         request_id: str,
-    ) -> Sequence[BotCatalogMetadata]:
+    ) -> BotCatalogMetadataPage:
         """Read one BCS result page without exposing BCS response data."""
         del caller
         params: dict[str, str | int] = {
@@ -69,6 +70,9 @@ class BcsBotCatalogMetadataService:
             if not isinstance(payload, Mapping) or not isinstance(
                 payload.get("items"), list
             ):
+                raise BotCatalogMetadataUnavailableError()
+            total = payload.get("total")
+            if isinstance(total, bool) or not isinstance(total, int) or total < 0:
                 raise BotCatalogMetadataUnavailableError()
 
             seen: set[BotCatalogAddress] = set()
@@ -133,7 +137,7 @@ class BcsBotCatalogMetadataService:
             self._filter_count(filters),
             filters is not None and filters.viewer_actor_id is not None,
         )
-        return metadata
+        return BotCatalogMetadataPage(total=total, items=metadata)
 
     @staticmethod
     def _filter_count(filters: BotCatalogSearchFilters | None) -> int:

--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -1461,9 +1461,10 @@ class BotPublicService:
             }
             if filters is not None:
                 metadata_kwargs["filters"] = filters
-            metadata = self._catalog_metadata_service.search_public_bot_metadata(
+            metadata_page = self._catalog_metadata_service.search_public_bot_metadata(
                 **metadata_kwargs
             )
+            metadata = metadata_page.items
             addresses = self._validated_catalog_addresses(metadata)
             metadata_by_address = {item.address: item for item in metadata}
         except BotCatalogMetadataUnavailableError as exc:
@@ -1531,12 +1532,13 @@ class BotPublicService:
                     if key in ext:
                         ext[key] = None
                 bot["ext"] = ext
-        total = len(items)
+        total = metadata_page.total
         logger.info(
             "[BotPublicService.catalog_search] request_id=%s bcs_count=%s "
-            "joined_count=%s",
+            "joined_count=%s total=%s",
             request_id,
             len(addresses),
+            len(items),
             total,
         )
         return {"total": total, "items": items}

--- a/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_catalog_metadata_service.py
@@ -14,6 +14,7 @@ from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogMetadata,
     BotCatalogMetadataServiceProtocol,
     BotCatalogMetadataUnavailableError,
+    BotCatalogMetadataPage,
     BotCatalogSearchFilters,
 )
 from agentclaw.community.di.container import build_injector
@@ -71,14 +72,17 @@ def test_bcs_catalog_search_maps_current_page_and_parses_exact_address() -> None
         search="agent", page=2, page_size=20, caller=_caller(), request_id="trace-1"
     )
 
-    assert result == [
-        BotCatalogMetadata(
-            BotCatalogAddress("bot-1", "owner-1"),
-            "bot",
-            bot_uuid=" bot-1 : owner-1 ",
-            actor_kind="bot",
-        )
-    ]
+    assert result == BotCatalogMetadataPage(
+        total=21,
+        items=[
+            BotCatalogMetadata(
+                BotCatalogAddress("bot-1", "owner-1"),
+                "bot",
+                bot_uuid=" bot-1 : owner-1 ",
+                actor_kind="bot",
+            )
+        ],
+    )
     call = http.calls_to("get")[0]
     assert call.args[0] == "/bots/search"
     assert call.kwargs["params"] == {
@@ -96,9 +100,10 @@ def test_bcs_catalog_search_preserves_optional_is_friend_false() -> None:
     http.set_response(
         "get",
         _response(
-            200,
-            {
-                "items": [
+                200,
+                {
+                    "total": 1,
+                    "items": [
                     {
                         "bot_uuid": "bot-1:owner-1",
                         "actor_kind": "bot",
@@ -113,7 +118,8 @@ def test_bcs_catalog_search_preserves_optional_is_friend_false() -> None:
         search=None, page=1, page_size=20, caller=_caller(), request_id="trace-friend"
     )
 
-    assert getattr(result[0], "is_friend", None) is False
+    assert result.total == 1
+    assert getattr(result.items[0], "is_friend", None) is False
 
 
 def test_bcs_catalog_search_preserves_requested_optional_metadata_fields() -> None:
@@ -129,9 +135,10 @@ def test_bcs_catalog_search_preserves_requested_optional_metadata_fields() -> No
     http.set_response(
         "get",
         _response(
-            200,
-            {
-                "items": [
+                200,
+                {
+                    "total": 1,
+                    "items": [
                     {
                         "bot_uuid": "bot-1:owner-1",
                         "actor_kind": "bot",
@@ -151,20 +158,23 @@ def test_bcs_catalog_search_preserves_requested_optional_metadata_fields() -> No
         search=None, page=1, page_size=20, caller=_caller(), request_id="trace-metadata"
     )
 
-    assert result == [
-        BotCatalogMetadata(
-            BotCatalogAddress("bot-1", "owner-1"),
-            "bot",
-            bot_uuid="bot-1:owner-1",
-            is_friend=False,
-            visibility="protected",
-            is_online=False,
-            actor_kind="bot",
-            friend_ext=friend_ext,
-            friend_check_in_strategy=friend_check_in_strategy,
-            user_visibility="private",
-        )
-    ]
+    assert result == BotCatalogMetadataPage(
+        total=1,
+        items=[
+            BotCatalogMetadata(
+                BotCatalogAddress("bot-1", "owner-1"),
+                "bot",
+                bot_uuid="bot-1:owner-1",
+                is_friend=False,
+                visibility="protected",
+                is_online=False,
+                actor_kind="bot",
+                friend_ext=friend_ext,
+                friend_check_in_strategy=friend_check_in_strategy,
+                user_visibility="private",
+            )
+        ],
+    )
 
 
 def test_bcs_catalog_search_omits_blank_query_and_keeps_page_boundary() -> None:
@@ -176,12 +186,23 @@ def test_bcs_catalog_search_omits_blank_query_and_keeps_page_boundary() -> None:
         search=" ", page=3, page_size=10, caller=_caller(), request_id="trace-2"
     )
 
-    assert result == []
+    assert result == BotCatalogMetadataPage(total=0, items=[])
     assert http.calls_to("get")[0].kwargs["params"] == {
         "offset": 20,
         "limit": 10,
         "tc_bot": True,
     }
+
+
+@pytest.mark.parametrize("total", [True, -1, "1", None])
+def test_bcs_catalog_search_rejects_invalid_total(total: object) -> None:
+    service, http = _make_service()
+    http.set_response("get", _response(200, {"total": total, "items": []}))
+
+    with pytest.raises(BotCatalogMetadataUnavailableError):
+        service.search_public_bot_metadata(
+            search=None, page=1, page_size=20, caller=_caller(), request_id="trace-total"
+        )
 
 
 def test_bcs_catalog_search_forwards_only_supplied_frontend_filters() -> None:
@@ -205,7 +226,7 @@ def test_bcs_catalog_search_forwards_only_supplied_frontend_filters() -> None:
         request_id="trace-filters",
     )
 
-    assert result == []
+    assert result == BotCatalogMetadataPage(total=0, items=[])
     call = http.calls_to("get")[0]
     assert call.args[0] == "/bots/search"
     assert call.kwargs["params"] == {

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -11,6 +11,7 @@ from agentclaw.community.core.bot_public.catalog_metadata import (
     BotCatalogAddress,
     BotCatalogCaller,
     BotCatalogMetadata,
+    BotCatalogMetadataPage,
     BotCatalogMetadataUnavailableError,
     BotCatalogSearchUnavailableError,
 )
@@ -62,6 +63,13 @@ def _make_operator(staff_id="op_user", nick_name="Operator") -> OperatorContext:
     op.nick_name = nick_name
     op.operator_name = nick_name
     return op
+
+
+def _metadata_page(items, total=None):
+    return BotCatalogMetadataPage(
+        total=len(items) if total is None else total,
+        items=items,
+    )
 
 
 def _make_bot(bot_id="bot1", owner_id="owner1", public="0", ext=None):
@@ -1326,10 +1334,13 @@ class TestSearchPublicBotsByKeyword:
 
     def test_catalog_search_joins_only_the_current_bcs_page_and_reports_its_count(self):
         metadata = MagicMock()
-        metadata.search_public_bot_metadata.return_value = [
-            BotCatalogMetadata(BotCatalogAddress("bot-1", "entity-1"), "bot"),
-            BotCatalogMetadata(BotCatalogAddress("missing", "entity-2"), "bot"),
-        ]
+        metadata.search_public_bot_metadata.return_value = _metadata_page(
+            [
+                BotCatalogMetadata(BotCatalogAddress("bot-1", "entity-1"), "bot"),
+                BotCatalogMetadata(BotCatalogAddress("missing", "entity-2"), "bot"),
+            ],
+            total=2,
+        )
         repository = MagicMock()
         non_public = _make_catalog_bot("bot-1", "entity-1")
         non_public["public"] = "0"
@@ -1346,7 +1357,7 @@ class TestSearchPublicBotsByKeyword:
             request_id="trace-1",
         )
 
-        assert result["total"] == 1
+        assert result["total"] == 2
         assert [bot["bot_id"] for bot in result["items"]] == ["bot-1"]
         assert [bot["bot_uuid"] for bot in result["items"]] == ["bot-1:entity-1"]
         metadata.search_public_bot_metadata.assert_called_once_with(
@@ -1362,15 +1373,41 @@ class TestSearchPublicBotsByKeyword:
             page_size=2,
         )
 
+    def test_catalog_search_preserves_bcs_total_when_join_has_fewer_items(self):
+        metadata = MagicMock()
+        metadata.search_public_bot_metadata.return_value = _metadata_page(
+            [BotCatalogMetadata(BotCatalogAddress("bot-1", "entity-1"), "bot")],
+            total=21,
+        )
+        repository = MagicMock()
+        repository.list_bots_by_owner_bot_pairs.return_value = (
+            1,
+            [_make_catalog_bot("bot-1", "entity-1")],
+        )
+        svc = _make_service(
+            bot_repository=repository, catalog_metadata_service=metadata
+        )
+
+        result = svc.search_catalog_public_bots_by_keyword(
+            caller=BotCatalogCaller("tenant-1", "user-1", None),
+            request_id="trace-bcs-total",
+        )
+
+        assert result["total"] == 21
+        assert len(result["items"]) == 1
+
     def test_catalog_search_prefers_validated_bcs_bot_uuid(self):
         metadata = MagicMock()
-        metadata.search_public_bot_metadata.return_value = [
-            BotCatalogMetadata(
-                BotCatalogAddress("bot-1", "entity-1"),
-                "bot",
-                bot_uuid=" bot-1 : entity-1 ",
-            )
-        ]
+        metadata.search_public_bot_metadata.return_value = _metadata_page(
+            [
+                BotCatalogMetadata(
+                    BotCatalogAddress("bot-1", "entity-1"),
+                    "bot",
+                    bot_uuid=" bot-1 : entity-1 ",
+                )
+            ],
+            total=1,
+        )
         repository = MagicMock()
         repository.list_bots_by_owner_bot_pairs.return_value = (
             1,
@@ -1392,7 +1429,9 @@ class TestSearchPublicBotsByKeyword:
         bcs_item = BotCatalogMetadata(
             BotCatalogAddress("shared", "entity-a"), "bot", is_friend=False
         )
-        metadata.search_public_bot_metadata.return_value = [bcs_item]
+        metadata.search_public_bot_metadata.return_value = _metadata_page(
+            [bcs_item], total=1
+        )
         repository = MagicMock()
         repository.list_bots_by_owner_bot_pairs.return_value = (
             1,
@@ -1429,7 +1468,9 @@ class TestSearchPublicBotsByKeyword:
             friend_check_in_strategy={},
             user_visibility="private",
         )
-        metadata.search_public_bot_metadata.return_value = [bcs_item]
+        metadata.search_public_bot_metadata.return_value = _metadata_page(
+            [bcs_item], total=1
+        )
         repository = MagicMock()
         repository.list_bots_by_owner_bot_pairs.return_value = (
             2,
@@ -1463,10 +1504,13 @@ class TestSearchPublicBotsByKeyword:
 
     def test_catalog_search_restores_bcs_order_and_isolates_same_bot_id_by_entity(self):
         metadata = MagicMock()
-        metadata.search_public_bot_metadata.return_value = [
-            BotCatalogMetadata(BotCatalogAddress("shared", "entity-a"), "bot"),
-            BotCatalogMetadata(BotCatalogAddress("shared", "entity-b"), "bot"),
-        ]
+        metadata.search_public_bot_metadata.return_value = _metadata_page(
+            [
+                BotCatalogMetadata(BotCatalogAddress("shared", "entity-a"), "bot"),
+                BotCatalogMetadata(BotCatalogAddress("shared", "entity-b"), "bot"),
+            ],
+            total=3,
+        )
         repository = MagicMock()
         repository.list_bots_by_owner_bot_pairs.return_value = (
             3,
@@ -1484,7 +1528,7 @@ class TestSearchPublicBotsByKeyword:
             caller=BotCatalogCaller("tenant-1", None, 7), request_id="trace-2"
         )
 
-        assert result["total"] == 2
+        assert result["total"] == 3
         assert [bot["entity_id"] for bot in result["items"]] == [
             "entity-a",
             "entity-b",
@@ -1542,14 +1586,17 @@ class TestSearchPublicBotsByKeyword:
             }
         )
         metadata = MagicMock()
-        metadata.search_public_bot_metadata.return_value = [
-            BotCatalogMetadata(
-                BotCatalogAddress("malformed", "entity-malformed"), "bot"
-            ),
-            BotCatalogMetadata(
-                BotCatalogAddress("sensitive", "entity-sensitive"), "bot"
-            ),
-        ]
+        metadata.search_public_bot_metadata.return_value = _metadata_page(
+            [
+                BotCatalogMetadata(
+                    BotCatalogAddress("malformed", "entity-malformed"), "bot"
+                ),
+                BotCatalogMetadata(
+                    BotCatalogAddress("sensitive", "entity-sensitive"), "bot"
+                ),
+            ],
+            total=2,
+        )
         repository = MagicMock()
         repository.list_bots_by_owner_bot_pairs.return_value = (2, [malformed, sensitive])
         svc = _make_service(


### PR DESCRIPTION
## Problem

Catalog Search currently replaces the BCS `/bots/search` total with the number of Backend records that survive the exact `(bot_id, entity_id)` join. When the BCS page contains records that are temporarily unavailable in Backend, the public response no longer reflects the authoritative BCS pagination total.

## Solution

- Preserve the validated non-negative integer `total` from the BCS catalog page in a transport-neutral page result.
- Keep the existing exact composite-address join, BCS metadata projection, sensitive-field sanitization, and response item ordering unchanged.
- Return the BCS total unchanged from Catalog Search; Backend no longer recomputes it from joined items.
- Fail closed when the BCS total is missing or malformed, and add regression coverage for totals larger than the joined item count.

## Validation

- `DEPLOY_PROFILE=test uv run pytest tests/community/adapters/http/openapi_v1/bot_public/test_bot_public_router.py tests/community/core/bot_public/test_bot_catalog_metadata_service.py tests/community/core/bot_public/test_bot_public_service.py -q` — 180 passed.
- `DEPLOY_PROFILE=test uv run pytest tests/community/architecture/test_repository_contracts.py tests/community/architecture/test_http_adapter_layer_is_http_only.py tests/community/architecture/test_no_fastapi_in_core.py -q` — 15 passed.
- Targeted `ruff check` — passed.
- Gateway OpenAPI schema JSON parse — passed.
- `git diff --check` against `REL20260826` — passed.

## Compatibility and risk

The public route, query parameters, BCS path, exact join key, item projection, and error mapping remain unchanged. The only response behavior change is that `data.total` now follows BCS rather than the post-join Backend item count.

## Spec

`spec/pipeline/catalog-search-bcs-total-rel20260826/001-spec-output.md` (local task artifact; intentionally not committed).
