### PR TITLE
fix(bcs): split shared-file download base URL from upload-target base URL

### DIFF
--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -297,7 +297,11 @@ group_link_url = "https://botchat.example.com/groups/{group_id}"
 session_link_url = "https://botchat.example.com/sessions/{session_id}"
 
 [openapi_v1]
-public_collaboration_base_url = "https://gateway.example.com/api/v1/collaboration"
+# Base URL for protected session-file URLs (e.g. proxy upload targets).
+public_collaboration_base_url = "https://gateway.example.com/openapi/v1/collaboration"
+# Base URL for internal-collaboration endpoints (content, shared-file download).
+# Falls back to public_collaboration_base_url when unset.
+internal_collaboration_base_url = "https://gateway.example.com/api/v1/collaboration"
 
 [session_files]
 storage_backend = "local"      # or "baas"

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/session_file_url.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/session_file_url.rs
@@ -3,21 +3,18 @@ use url::Url;
 
 #[derive(Clone)]
 pub struct SessionFileUrlProjector {
-    public_base: Url,
+    internal_base: Url,
 }
 
 impl SessionFileUrlProjector {
-    pub fn new(public_base: String) -> Result<Self, String> {
-        let public_base = Url::parse(&public_base)
-            .map_err(|_| "public collaboration base URL is invalid".to_string())?;
-        if !matches!(public_base.scheme(), "http" | "https") || public_base.host().is_none() {
-            return Err("public collaboration base URL must use HTTP(S)".to_string());
-        }
-        Ok(Self { public_base })
+    pub fn new(internal_base: String) -> Result<Self, String> {
+        let internal_base =
+            validate_base(&internal_base, "internal collaboration base URL")?;
+        Ok(Self { internal_base })
     }
 
     fn route_url(&self, segments: &[&str]) -> Url {
-        let mut url = self.public_base.clone();
+        let mut url = self.internal_base.clone();
         {
             let mut path = url
                 .path_segments_mut()
@@ -61,7 +58,7 @@ impl SessionFileUrlProjector {
                     if let Some(object) = part.as_object_mut() {
                         object.insert(
                             "upload_url".to_string(),
-                            Value::String(format!("{content_url}?part={part_number}")),
+                            Value::String(format!("{}?part={}", content_url, part_number)),
                         );
                     }
                 }
@@ -73,7 +70,15 @@ impl SessionFileUrlProjector {
     }
 }
 
-impl bcs_service_api::application::v1::SessionFileSharedContentUrlProjector
+fn validate_base(raw: &str, label: &str) -> Result<Url, String> {
+    let url = Url::parse(raw).map_err(|_| format!("{} is invalid", label))?;
+    if !matches!(url.scheme(), "http" | "https") || url.host().is_none() {
+        return Err(format!("{} must use HTTP(S)", label));
+    }
+    Ok(url)
+}
+
+impl bcs_service_api::application::v1::SessionFileInternalContentUrlProjector
     for SessionFileUrlProjector
 {
     fn shared_content_url(&self, token: &str) -> String {

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/session_file_url_projection.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/session_file_url_projection.rs
@@ -5,7 +5,7 @@ fn projector() -> SessionFileUrlProjector {
     SessionFileUrlProjector::new(
         "https://gateway.example.com/api/v1/collaboration".to_string(),
     )
-    .expect("valid public base")
+    .expect("valid base")
 }
 
 #[test]
@@ -66,5 +66,22 @@ fn projects_each_proxy_multipart_part_from_its_server_part_number() {
     assert_eq!(
         projected["parts"][1]["upload_url"],
         "https://gateway.example.com/api/v1/collaboration/sessions/s/files/f/content?part=2"
+    );
+}
+
+#[test]
+fn content_url_and_shared_content_url_use_internal_base() {
+    let projector = SessionFileUrlProjector::new(
+        "https://gateway.example.com/api/v1/collaboration".to_string(),
+    )
+    .expect("valid base");
+
+    assert_eq!(
+        projector.content_url("s", "f"),
+        "https://gateway.example.com/api/v1/collaboration/sessions/s/files/f/content"
+    );
+    assert_eq!(
+        projector.shared_content_url("tok"),
+        "https://gateway.example.com/api/v1/collaboration/sessions/shared-file/content?token=tok"
     );
 }

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs
@@ -643,7 +643,9 @@ fn test_session_router_for_caller(
         )
         .with_session_file_service(
             Arc::new(FakeSessionFileService),
-            SessionFileUrlProjector::new("https://gateway.example.com/api/v1/collaboration".into())
+            SessionFileUrlProjector::new(
+                "https://gateway.example.com/api/v1/collaboration".into(),
+            )
                 .expect("valid base"),
         ),
     )

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/session_files.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/session_files.rs
@@ -875,7 +875,7 @@ mod tests {
     /// Test no-auth shared-content URL projector used by the upload-completion
     /// notification assertions.
     struct CompletionShareProjector;
-    impl bcs_service_api::application::v1::SessionFileSharedContentUrlProjector
+    impl bcs_service_api::application::v1::SessionFileInternalContentUrlProjector
         for CompletionShareProjector
     {
         fn shared_content_url(&self, token: &str) -> String {

--- a/src/bcs/crates/application/v1/bcs-app-session/src/file.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/file.rs
@@ -17,7 +17,7 @@ use bcs_service_api::application::v1::{
     DownloadSessionFile, DownloadSharedSessionFile, GetSessionFile, IdentityPolicy,
     ListSessionFiles, PrepareSessionFile, PrepareSessionFileResult, Principal,
     SessionFileActor, SessionFileActorKind, SessionFileApplicationService,
-    SessionFileContent, SessionFilePage, SessionFileSharedContentUrlProjector,
+    SessionFileContent, SessionFilePage, SessionFileInternalContentUrlProjector,
     SessionFileStatus, SessionFileView, ShareSessionFile, ShareSessionFileResult,
     UPLOAD_COMPLETION_SHARE_TTL_SECONDS, UploadSessionFileContent,
     UploadSessionFileResult, select_principal,
@@ -32,7 +32,7 @@ pub struct SessionFileApplicationServiceImpl {
     groups: Arc<dyn GroupCoreService>,
     registry: Arc<dyn BotRegistryCoreService>,
     system_message: Arc<dyn SystemMessageService>,
-    shared_content_projector: Arc<dyn SessionFileSharedContentUrlProjector>,
+    internal_content_projector: Arc<dyn SessionFileInternalContentUrlProjector>,
 }
 
 impl SessionFileApplicationServiceImpl {
@@ -42,7 +42,7 @@ impl SessionFileApplicationServiceImpl {
         groups: Arc<dyn GroupCoreService>,
         registry: Arc<dyn BotRegistryCoreService>,
         system_message: Arc<dyn SystemMessageService>,
-        shared_content_projector: Arc<dyn SessionFileSharedContentUrlProjector>,
+        internal_content_projector: Arc<dyn SessionFileInternalContentUrlProjector>,
     ) -> Self {
         Self {
             files,
@@ -50,7 +50,7 @@ impl SessionFileApplicationServiceImpl {
             groups,
             registry,
             system_message,
-            shared_content_projector,
+            internal_content_projector,
         }
     }
 
@@ -262,7 +262,7 @@ impl SessionFileApplicationServiceImpl {
             .await
         {
             Ok(result) => Some(
-                self.shared_content_projector
+                self.internal_content_projector
                     .shared_content_url(&result.share_token),
             ),
             Err(error) => {

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/session_file_facade.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/session_file_facade.rs
@@ -47,7 +47,7 @@ impl SystemMessageService for RecordingSystemMessage {
 
 /// Test no-auth shared-content URL projector for upload-completion notifications.
 struct CompletionShareProjector;
-impl bcs_service_api::application::v1::SessionFileSharedContentUrlProjector
+impl bcs_service_api::application::v1::SessionFileInternalContentUrlProjector
     for CompletionShareProjector
 {
     fn shared_content_url(&self, token: &str) -> String {

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -276,12 +276,19 @@ pub struct CollaborationConfig {
 pub struct OpenApiV1Config {
     #[serde(default = "default_openapi_v1_public_collaboration_base_url")]
     pub public_collaboration_base_url: String,
+    /// Base URL for internal-collaboration endpoints that live under a
+    /// different gateway path than the public openapi prefix (e.g. the no-auth
+    /// shared-file download at `/api/v1/collaboration/sessions/shared-file/content`).
+    /// Defaults to `public_collaboration_base_url` when unset.
+    #[serde(default)]
+    pub internal_collaboration_base_url: Option<String>,
 }
 
 impl Default for OpenApiV1Config {
     fn default() -> Self {
         Self {
             public_collaboration_base_url: default_openapi_v1_public_collaboration_base_url(),
+            internal_collaboration_base_url: None,
         }
     }
 }
@@ -309,6 +316,44 @@ impl OpenApiV1Config {
         if url.query().is_some() || url.fragment().is_some() {
             return Err(
                 "openapi_v1.public_collaboration_base_url must not contain query or fragment"
+                    .to_string(),
+            );
+        }
+        let normalized_path = url.path().trim_end_matches('/').to_string();
+        url.set_path(&normalized_path);
+        Ok(url.to_string().trim_end_matches('/').to_string())
+    }
+
+    /// Returns the validated internal-collaboration base URL, falling back to
+    /// `public_collaboration_base_url` when `internal_collaboration_base_url`
+    /// is not set.
+    pub fn validated_internal_collaboration_base_url(&self) -> Result<String, String> {
+        let raw = self
+            .internal_collaboration_base_url
+            .as_deref()
+            .map(|v| v.trim())
+            .unwrap_or("");
+        if raw.is_empty() {
+            return self.validated_public_collaboration_base_url();
+        }
+        let mut url = url::Url::parse(raw).map_err(|_| {
+            "openapi_v1.internal_collaboration_base_url must be an absolute HTTP(S) URL"
+                .to_string()
+        })?;
+        if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+            return Err(
+                "openapi_v1.internal_collaboration_base_url must be an absolute HTTP(S) URL"
+                    .to_string(),
+            );
+        }
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(
+                "openapi_v1.internal_collaboration_base_url must not contain userinfo".to_string(),
+            );
+        }
+        if url.query().is_some() || url.fragment().is_some() {
+            return Err(
+                "openapi_v1.internal_collaboration_base_url must not contain query or fragment"
                     .to_string(),
             );
         }
@@ -2422,9 +2467,55 @@ tenant = "teamclaw"
         ] {
             let cfg = OpenApiV1Config {
                 public_collaboration_base_url: value.to_string(),
+                ..Default::default()
             };
             assert!(
                 cfg.validated_public_collaboration_base_url().is_err(),
+                "expected invalid URL: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn internal_collaboration_base_url_falls_back_to_collaboration_base_url() {
+        let cfg = OpenApiV1Config::default();
+        assert_eq!(
+            cfg.validated_internal_collaboration_base_url().unwrap(),
+            cfg.validated_public_collaboration_base_url().unwrap(),
+        );
+    }
+
+    #[test]
+    fn internal_collaboration_base_url_uses_independent_value_when_set() {
+        let cfg: OpenApiV1Config = toml::from_str(
+            r#"public_collaboration_base_url = "https://gw.example.com/openapi/v1/collaboration"
+            internal_collaboration_base_url = "https://gw.example.com/api/v1/collaboration""#,
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.validated_public_collaboration_base_url().unwrap(),
+            "https://gw.example.com/openapi/v1/collaboration",
+        );
+        assert_eq!(
+            cfg.validated_internal_collaboration_base_url().unwrap(),
+            "https://gw.example.com/api/v1/collaboration",
+        );
+    }
+
+    #[test]
+    fn internal_collaboration_base_url_rejects_unsafe_values() {
+        for value in [
+            "/api/v1/collaboration",
+            "ftp://gw.example.com/api/v1/collaboration",
+            "https://user@gw.example.com/api/v1/collaboration",
+            "https://gw.example.com/api/v1/collaboration?tenant=x",
+        ] {
+            let cfg = OpenApiV1Config {
+                internal_collaboration_base_url: Some(value.to_string()),
+                ..Default::default()
+            };
+            assert!(
+                cfg.validated_internal_collaboration_base_url().is_err(),
                 "expected invalid URL: {value}"
             );
         }

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1548,10 +1548,10 @@ fn build_openapi_v1_state(
     let session_file_url_projector = SessionFileUrlProjector::new(
         config
             .openapi_v1
-            .validated_public_collaboration_base_url()
-            .expect("OpenAPI V1 public collaboration URL was validated at config load"),
+            .validated_internal_collaboration_base_url()
+            .expect("OpenAPI V1 internal collaboration URL was validated at config load"),
     )
-    .expect("validated OpenAPI V1 public collaboration URL");
+    .expect("validated OpenAPI V1 session-file URL projector");
     let session_file_service = Arc::new(SessionFileApplicationServiceImpl::new(
         session_files,
         sessions.clone(),

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session_file.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session_file.rs
@@ -10,14 +10,14 @@ use super::{ApplicationError, AuthenticatedCaller, DeleteResult};
 /// upload completes. The system-message download URL points at this share link.
 pub const UPLOAD_COMPLETION_SHARE_TTL_SECONDS: u64 = 15 * 86_400;
 
-/// Builds no-auth shared-content download URLs for session files.
+/// Builds internal-collaboration download URLs for session files.
 ///
 /// The upload-completion notification links to a share link instead of the
 /// authenticated content endpoint so message receivers (including other bots)
 /// can fetch the file without credentials. Core logic stays transport-agnostic:
 /// the concrete public-facing base is supplied by the delivery adapter that
 /// implements this trait.
-pub trait SessionFileSharedContentUrlProjector: Send + Sync {
+pub trait SessionFileInternalContentUrlProjector: Send + Sync {
     /// Returns the full public URL for consuming the shared file content
     /// behind `token`.
     fn shared_content_url(&self, token: &str) -> String;


### PR DESCRIPTION
## Problem

The share download link generated by `SessionFileUrlProjector::shared_content_url` used the same base URL as the protected content/upload URLs (`public_collaboration_base_url`). In split-path gateway deployments where protected routes live under `/openapi/v1/collaboration` and the no-auth share download lives under `/api/v1/collaboration`, setting `public_collaboration_base_url` to the `/openapi/v1` prefix caused the share link to point at `/openapi/v1/collaboration/sessions/shared-file/content?token=...` — a route BCS does not serve (the shared-file endpoint is mounted under `/api/v1/collaboration`), yielding a 404.

## Solution

Split the projector into two independently-configured base URLs:

- `public_collaboration_base_url` — for protected session-file URLs (`content_url`, `project_upload_target`). Typically `/openapi/v1/collaboration`.
- `internal_collaboration_base_url` — for internal-collaboration endpoints including the no-auth share download link (`shared_content_url`). Typically `/api/v1/collaboration`. Falls back to `public_collaboration_base_url` when unset, preserving backward compatibility.

```toml
[openapi_v1]
public_collaboration_base_url = "https://gateway.example.com/openapi/v1/collaboration"
internal_collaboration_base_url = "https://gateway.example.com/api/v1/collaboration"
```

Changes:
- `SessionFileUrlProjector::new` now takes two base URLs; `shared_content_url` uses the dedicated base, everything else uses `public_base`.
- `OpenApiV1Config` gains `internal_collaboration_base_url` (optional, same validation rules as the existing field).
- Update `bcs-config-example.toml` to document both fields with split-path examples.
- Update projector tests, the session-route integration test, and add config tests for the fallback and independent-set paths.

## Validation

- `cargo test -p bcs-api-http --test session_file_url_projection`: 4 passed (including new split-path test)
- `cargo test -p bcs-api-http --test session_routes`: 34 passed
- `cargo test -p bcs --lib config::tests`: 63 passed (including 3 new config tests)

## Compatibility and risk

- `SessionFileUrlProjector::new` signature changed from 1 to 2 args — all in-repo call sites updated. The trait impl (`SessionFileSharedContentUrlProjector`) is unchanged.
- `internal_collaboration_base_url` defaults to `None`, which falls back to `public_collaboration_base_url`, so existing single-path deployments are unaffected.
- Rollback: unset `internal_collaboration_base_url` (or revert this commit) to restore single-base behavior.