### PR TITLE
fix(openapi): expose service upgrade inventory action

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -632,6 +632,7 @@ BotAction = Literal[
     "publish_staging",
     "publish_online",
     "cancel_staging",
+    "upgrade",
     "offline",
     "retry",
 ]

--- a/src/backend/src/agentclaw/community/core/bot_inventory/adapters/service_lifecycle.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/adapters/service_lifecycle.py
@@ -19,6 +19,9 @@ from agentclaw.community.core.service_bot.repository.models import (
     BotPublishRecord,
     PublishStatus,
 )
+from agentclaw.community.core.service_bot.types import (
+    can_upgrade_publication_from_records,
+)
 from agentclaw.community.utils.env_utils import get_current_env
 
 
@@ -124,7 +127,10 @@ class ServiceLifecycleView(ServiceLifecyclePort):
                 BotAction.CANCEL_STAGING,
             )
         elif record.status == PublishStatus.SUCCESS.value:
-            add(BotAction.CHAT, BotAction.RESTART, BotAction.OFFLINE)
+            add(BotAction.CHAT, BotAction.RESTART)
+            if can_upgrade_publication_from_records(record, all_records):
+                add(BotAction.UPGRADE)
+            add(BotAction.OFFLINE)
         elif record.status == PublishStatus.FAILED.value:
             add(BotAction.RETRY)
         return tuple(actions)

--- a/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
@@ -355,10 +355,21 @@ class BotInventoryService:
         if level >= PermissionLevel.OWNER:
             return actions, disabled
         if kind is BotInventoryKind.SERVICE and level >= PermissionLevel.MEMBER:
-            allowed = tuple(action for action in actions if action is not BotAction.DELETE)
+            allowed = tuple(
+                action
+                for action in actions
+                if action is not BotAction.DELETE
+                and not (
+                    action is BotAction.UPGRADE and level < PermissionLevel.ADMIN
+                )
+            )
             if BotAction.DELETE in actions:
                 disabled.setdefault(
                     BotAction.DELETE.value, "Bot Owner permission required"
+                )
+            if BotAction.UPGRADE in actions and level < PermissionLevel.ADMIN:
+                disabled.setdefault(
+                    BotAction.UPGRADE.value, "Bot Admin permission required"
                 )
             return allowed, disabled
         # MEMBER is defined as "edit content only": editing (skills/skill-sets,

--- a/src/backend/src/agentclaw/community/core/bot_inventory/types.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/types.py
@@ -53,6 +53,7 @@ class BotAction(StrEnum):
     PUBLISH_STAGING = "publish_staging"
     PUBLISH_ONLINE = "publish_online"
     CANCEL_STAGING = "cancel_staging"
+    UPGRADE = "upgrade"
     OFFLINE = "offline"
     RETRY = "retry"
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/service_publication_facade.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/service_publication_facade.py
@@ -70,6 +70,9 @@ from agentclaw.community.core.service_bot.services.publish_approval_service impo
 from agentclaw.community.core.service_bot.services.publish_flow_service import (
     PublishFlowService,
 )
+from agentclaw.community.core.service_bot.types import (
+    can_upgrade_publication_from_records,
+)
 from agentclaw.community.utils.env_utils import get_current_env
 
 
@@ -286,7 +289,7 @@ class ServicePublicationFacade:
         elif record.status == PublishStatus.VALIDATING.value:
             actions.extend(("publish_online", "restart_publish", "cancel_staging"))
         elif record.status == PublishStatus.SUCCESS.value:
-            if level >= PermissionLevel.ADMIN and self._can_upgrade_from_records(
+            if level >= PermissionLevel.ADMIN and can_upgrade_publication_from_records(
                 record, all_records
             ):
                 actions.append("upgrade")
@@ -294,19 +297,6 @@ class ServicePublicationFacade:
         elif record.status == PublishStatus.FAILED.value:
             actions.append("retry")
         return actions
-
-    @staticmethod
-    def _can_upgrade_from_records(
-        record: BotPublishRecord,
-        all_records: Iterable[BotPublishRecord],
-    ) -> bool:
-        """Project the legacy can-upgrade rule without per-card repository reads."""
-        if record.status != PublishStatus.SUCCESS.value:
-            return False
-        successors = [item for item in all_records if item.last_pub_id == record.id]
-        return not successors or all(
-            item.status == PublishStatus.FAILED.value for item in successors
-        )
 
     def _project(
         self,

--- a/src/backend/src/agentclaw/community/core/service_bot/types.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/types.py
@@ -2,7 +2,26 @@
 
 共享的类型定义和常量。
 """
+from collections.abc import Iterable
 from enum import Enum
+
+from agentclaw.community.core.service_bot.repository.models import (
+    BotPublishRecord,
+    PublishStatus,
+)
+
+
+def can_upgrade_publication_from_records(
+    record: BotPublishRecord,
+    all_records: Iterable[BotPublishRecord],
+) -> bool:
+    """Return the legacy Vn -> Vn+1 eligibility from an in-memory record set."""
+    if record.status != PublishStatus.SUCCESS.value:
+        return False
+    successors = [item for item in all_records if item.last_pub_id == record.id]
+    return not successors or all(
+        item.status == PublishStatus.FAILED.value for item in successors
+    )
 
 
 class PublishStage(str, Enum):

--- a/src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py
@@ -113,6 +113,12 @@ def test_list_inventory_combines_personal_cloud_and_local(client):
     assert ids == {"c1", "l1"}
 
 
+def test_inventory_openapi_declares_upgrade_action(client):
+    schema = client.app.openapi()["components"]["schemas"]["BotInventoryItem"]
+
+    assert "upgrade" in schema["properties"]["actions"]["items"]["enum"]
+
+
 def test_list_inventory_filters_non_service_bots(client):
     data = _ok(
         client.get("/openapi/v1/bots/all", params={"is_service": "false"})

--- a/src/backend/tests/community/core/bot_inventory/adapters/test_service_lifecycle.py
+++ b/src/backend/tests/community/core/bot_inventory/adapters/test_service_lifecycle.py
@@ -26,6 +26,8 @@ def record(
     source_bot_id: str,
     status: PublishStatus,
     version: int,
+    *,
+    last_pub_id: int = 0,
 ) -> BotPublishRecord:
     return BotPublishRecord(
         id=record_id,
@@ -36,6 +38,7 @@ def record(
         owner_id="owner",
         status=status.value,
         version=version,
+        last_pub_id=last_pub_id,
         env="dev",
         permission_owner="owner",
         gmt_create=NOW,
@@ -138,7 +141,13 @@ def test_missing_publish_rows_keep_a_safe_read_only_card(monkeypatch) -> None:
         ),
         (
             PublishStatus.SUCCESS,
-            (BotAction.VIEW, BotAction.CHAT, BotAction.RESTART, BotAction.OFFLINE),
+            (
+                BotAction.VIEW,
+                BotAction.CHAT,
+                BotAction.RESTART,
+                BotAction.UPGRADE,
+                BotAction.OFFLINE,
+            ),
         ),
         (PublishStatus.FAILED, (BotAction.VIEW, BotAction.RETRY)),
         (PublishStatus.RELEASED, (BotAction.VIEW,)),
@@ -158,3 +167,31 @@ def test_draft_delete_is_blocked_while_an_online_version_exists() -> None:
     actions = ServiceLifecycleView._record_actions(draft, [draft, online])
 
     assert BotAction.DELETE not in actions
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("successor_status", "upgrade_available"),
+    [
+        (PublishStatus.FAILED, True),
+        (PublishStatus.DRAFT, False),
+        (PublishStatus.VALIDATING, False),
+    ],
+)
+def test_online_upgrade_action_follows_legacy_successor_rule(
+    successor_status: PublishStatus,
+    upgrade_available: bool,
+) -> None:
+    online = record(1, 10, "service-1", PublishStatus.SUCCESS, 1)
+    successor = record(
+        2,
+        10,
+        "service-1",
+        successor_status,
+        2,
+        last_pub_id=online.id,
+    )
+
+    actions = ServiceLifecycleView._record_actions(online, [online, successor])
+
+    assert (BotAction.UPGRADE in actions) is upgrade_available

--- a/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
+++ b/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
@@ -485,3 +485,28 @@ def test_actions_for_level_keeps_edit_for_non_service_editors() -> None:
         "restart": "Bot editor permission required",
         "delete": "Bot editor permission required",
     }
+
+
+def test_service_upgrade_action_requires_admin() -> None:
+    actions = (BotAction.VIEW, BotAction.UPGRADE, BotAction.DELETE)
+
+    member_actions, member_disabled = BotInventoryService._actions_for_level(
+        kind=BotInventoryKind.SERVICE,
+        actions=actions,
+        disabled={},
+        level=PermissionLevel.MEMBER,
+    )
+    assert member_actions == (BotAction.VIEW,)
+    assert member_disabled == {
+        "delete": "Bot Owner permission required",
+        "upgrade": "Bot Admin permission required",
+    }
+
+    admin_actions, admin_disabled = BotInventoryService._actions_for_level(
+        kind=BotInventoryKind.SERVICE,
+        actions=actions,
+        disabled={},
+        level=PermissionLevel.ADMIN,
+    )
+    assert admin_actions == (BotAction.VIEW, BotAction.UPGRADE)
+    assert admin_disabled == {"delete": "Bot Owner permission required"}


### PR DESCRIPTION
## Summary
- expose `upgrade` in `/openapi/v1/bots/all` actions when a service bot is eligible
- share the publication upgrade eligibility rule between inventory and lifecycle views
- preserve legacy behavior where a failed upgrade remains retryable via upgrade

## Validation
- 100 targeted tests passed
- Ruff passed for all changed Python files
- `git diff --check origin/dev...HEAD` passed
- pre-push SAST/lint gate passed against `origin/dev`