### PR TITLE
fix(task): forward cookie/referer and validate business code in OpenApiBotAdapter

### DIFF
--- a/src/backend/src/agentclaw/community/core/task/task_runner/integration/open_api_bot_adapter.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/integration/open_api_bot_adapter.py
@@ -95,6 +95,7 @@ class OpenApiBotAdapter(OpenApiBotPort):  # pragma: no cover — live BaaS OpenA
         return h
 
     async def ensure_grant(self, bot_id: str) -> None:
+        logger.info("[task][openapi_bot] ensure_grant bot_id=%s")
         prefix = self._k.api_key_prefix or self._k.api_key[:_DEFAULT_KEY_PREFIX_LEN]
         logger.info("[task][openapi_bot] >>> ensure_grant GET /api/v1/api-keys/%s/allowed-bots bot_id=%s base_url=%s",
                     prefix, bot_id, self._k.base_url)
@@ -169,6 +170,7 @@ class OpenApiBotAdapter(OpenApiBotPort):  # pragma: no cover — live BaaS OpenA
         终态返回 get_run 的 data dict;超时(默认 180s=3 分钟)抛 OpenApiTimeoutError;
         grant 403 → OpenApiAuthError、5xx → OpenApiServerError 透传给同步调用方。
         """
+        logger.info("[task][openapi_bot] <<< send_and_wait, bot_id=%s", bot_id)
         loop = asyncio.new_event_loop()
         try:
             return loop.run_until_complete(
@@ -180,6 +182,7 @@ class OpenApiBotAdapter(OpenApiBotPort):  # pragma: no cover — live BaaS OpenA
     async def send_and_wait_async(self, *, bot_id: str, message: str,
                                    metadata: dict[str, Any] | None = None, timeout: float = 180.0,
                                    poll_interval: float = 2.0) -> dict[str, Any]:
+        logger.info("[task][openapi_bot] >>> send_and_wait_async bot_id=%s base_url=%s", bot_id, self._k.base_url)
         await self.ensure_grant(bot_id)
         sent = await self.send_message(bot_id=bot_id, message=message, metadata=metadata or {})
         run_id = sent.run_id

--- a/src/backend/src/agentclaw/community/core/task/task_runner/integration/open_api_bot_adapter.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/integration/open_api_bot_adapter.py
@@ -80,12 +80,26 @@ class OpenApiBotAdapter(OpenApiBotPort):  # pragma: no cover — live BaaS OpenA
     async def _aclose(self) -> None:
         await self._client.aclose()
 
+    def _headers(self) -> dict[str, str]:
+        """请求头:Bearer + 可选 Cookie/Referer。
+
+        真实 ACE 网关后的 host(``agentclaw-*`` / ``secbaas-*``)除 Bearer 外还需登录 Cookie(+ Referer)
+        才能过 ACE;否则 ACE 回 HTTP 200 的 USER_NOT_LOGIN 登录门(无业务 data),被误当成功而 run_id=None。
+        本地 singlebox 与 service-to-service(``CorpApiKeyProvider`` cookie/referer 空)不加 → 行为不变。
+        """
+        h: dict[str, str] = {"Authorization": f"Bearer {self._k.api_key}"}
+        if self._k.cookie:
+            h["Cookie"] = self._k.cookie
+        if self._k.referer:
+            h["Referer"] = self._k.referer
+        return h
+
     async def ensure_grant(self, bot_id: str) -> None:
         prefix = self._k.api_key_prefix or self._k.api_key[:_DEFAULT_KEY_PREFIX_LEN]
         logger.info("[task][openapi_bot] >>> ensure_grant GET /api/v1/api-keys/%s/allowed-bots bot_id=%s base_url=%s",
                     prefix, bot_id, self._k.base_url)
         r = await self._client.get(f"/api/v1/api-keys/{prefix}/allowed-bots",
-                                   headers={"Authorization": f"Bearer {self._k.api_key}"})
+                                   headers=self._headers())
         logger.info("[task][openapi_bot] <<< ensure_grant GET allowed-bots status=%s body=%s",
                     r.status_code, _resp_summary(r))
         _map_status(r)
@@ -109,23 +123,35 @@ class OpenApiBotAdapter(OpenApiBotPort):  # pragma: no cover — live BaaS OpenA
                     bot_id, self._k.base_url, len(message or ""))
         r = await self._client.post("/openapi/v1/messages",
                                     json={"bot_id": bot_id, "message": message},
-                                    headers={"Authorization": f"Bearer {self._k.api_key}"})
+                                    headers=self._headers())
         logger.info("[task][openapi_bot] <<< send_message status=%s body=%s",
                     r.status_code, _resp_summary(r))
         _map_status(r)
-        data = r.json().get("data") or {}
-        # message_id 即 run_id;session_id 前向兼容——当前 BaaS 回包未提供时为 None,将来 BaaS 补字段自动落库。
+        payload = r.json()
+        data = payload.get("data") or {}
+        message_id = data.get("message_id")
+        code = payload.get("code")
+        # 业务信封校验:HTTP 200 但 code!=0 或无 message_id(如 ACE 登录门/未授权),若不拦截会 run_id=None,
+        # 后续 get_run(None) 报误导 404 "Message not found: None"。校验后直抛,带 code/payload 便于定位。
+        if (code is not None and code != 0) or not message_id:
+            raise OpenApiError(
+                f"send_message 业务失败 code={code} message_id={message_id!r} payload={payload}"
+            )
         logger.info("[task][openapi_bot] send_message 结果 message_id(run_id)=%s session_id=%s",
-                    data.get("message_id"), data.get("session_id"))
-        return BotSendResult(run_id=data.get("message_id"), session_id=data.get("session_id"))
+                    message_id, data.get("session_id"))
+        return BotSendResult(run_id=message_id, session_id=data.get("session_id"))
 
     async def get_run(self, run_id: str) -> dict[str, Any]:
         logger.info("[task][openapi_bot] >>> get_run GET /openapi/v1/messages/%s base_url=%s", run_id, self._k.base_url)
         r = await self._client.get(f"/openapi/v1/messages/{run_id}",
-                                   headers={"Authorization": f"Bearer {self._k.api_key}"})
+                                   headers=self._headers())
         logger.info("[task][openapi_bot] <<< get_run status=%s body=%s", r.status_code, _resp_summary(r))
         _map_status(r)
-        return r.json().get("data") or {}
+        payload = r.json()
+        code = payload.get("code")
+        if code is not None and code != 0:
+            raise OpenApiError(f"get_run 业务失败 code={code} payload={payload}")
+        return payload.get("data") or {}
 
     async def cancel_run(self, run_id: str) -> None:
         """Best-effort stop tracking hook.

--- a/src/backend/tests/community/core/task/task_runner/integration/test_open_api_bot_adapter.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_open_api_bot_adapter.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 
 from agentclaw.community.core.task.task_runner.integration.open_api_bot_adapter import (
-    OpenApiAuthError, OpenApiBotAdapter, OpenApiServerError, OpenApiTimeoutError, parse_bot_id,
+    OpenApiAuthError, OpenApiBotAdapter, OpenApiError, OpenApiServerError, OpenApiTimeoutError, parse_bot_id,
 )
 
 
@@ -182,3 +182,69 @@ def test_send_and_wait_failed_returns_run():
     run = a.send_and_wait(bot_id="bot9:ent1", message="hi", timeout=2.0, poll_interval=0.001)
     assert run["status"] == "FAILED"
     assert run["error"] == "boom"
+
+
+# ===== ACE 网关后的真实 host 需在 Bearer 之外带 Cookie/Referer;adapter 各请求须透传 key 的 cookie/referer =====
+def test_send_message_forwards_cookie_and_referer():
+    seen: dict = {}
+
+    def h(req):
+        if req.url.path == "/openapi/v1/messages":
+            seen["cookie"] = req.headers.get("cookie")
+            seen["referer"] = req.headers.get("referer")
+            return httpx.Response(200, json={"data": {"message_id": "mid_ck"}})
+        return httpx.Response(404)
+
+    rid = _run(_adapter(h).send_message(bot_id="bot9:ent1", message="hi", metadata={}))
+    assert rid.run_id == "mid_ck"
+    assert seen["cookie"] == "sess=1"
+    assert seen["referer"] == "http://b/"
+
+
+def test_get_run_forwards_cookie_and_referer():
+    seen: dict = {}
+
+    def h(req):
+        if req.url.path == "/openapi/v1/messages/mid_77":
+            seen["cookie"] = req.headers.get("cookie")
+            seen["referer"] = req.headers.get("referer")
+            return httpx.Response(200, json={"data": {"status": "COMPLETED"}})
+        return httpx.Response(404)
+
+    _run(_adapter(h).get_run("mid_77"))
+    assert seen["cookie"] == "sess=1"
+    assert seen["referer"] == "http://b/"
+
+
+def test_ensure_grant_get_forwards_cookie_and_referer():
+    seen: dict = {}
+
+    def h(req):
+        if req.method == "GET" and req.url.path.endswith("/allowed-bots"):
+            seen["cookie"] = req.headers.get("cookie")
+            seen["referer"] = req.headers.get("referer")
+            return httpx.Response(200, json={"data": {"allowed_bots": ["bot9:ent1"]}})
+        return httpx.Response(404)
+
+    _run(_adapter(h).ensure_grant("bot9:ent1"))
+    assert seen["cookie"] == "sess=1"
+    assert seen["referer"] == "http://b/"
+
+
+# ===== 业务信封校验:HTTP 200 但 code!=0 / 无 message_id 不可当成功吞成 run_id=None(否则 get_run(None) 报误导 404) =====
+def test_send_message_raises_when_no_message_id():
+    def h(req):
+        # HTTP 200 但无 message_id(模拟 ACE 登录门回 USER_NOT_LOGIN、或未授权回空 data)
+        return httpx.Response(200, json={"code": 0, "data": {}})
+
+    with pytest.raises(OpenApiError):
+        _run(_adapter(h).send_message(bot_id="bot9:ent1", message="hi", metadata={}))
+
+
+def test_send_message_raises_on_nonzero_business_code():
+    def h(req):
+        # HTTP 200 但业务 code 非 0(如 bot 未在 allowed_bots → 403 业务信封)
+        return httpx.Response(200, json={"code": 40301, "message": "bot not in allowed_bots", "data": None})
+
+    with pytest.raises(OpenApiError):
+        _run(_adapter(h).send_message(bot_id="bot9:ent1", message="hi", metadata={}))


### PR DESCRIPTION

PR desc

  ## Problem
  预发/线上 `agentclaw-*` / `secbaas-*` 这类 ACE 网关后的真实 host 上，`OpenApiBotAdapter` 的 `send_message` / `get_run` / `ensure_grant` GET **只发 `Authorization:
  Bearer`**，既不随请求带登录 Cookie/Referer，也不校验响应业务 `code`。后果：

  - Bearer-only 被 ACE 当未登录 → 回 **HTTP 200 的 `USER_NOT_LOGIN` 登录门**（body 无 `data.message_id`）；
  - adapter 只看 HTTP 状态、不校验 `code`，把“无 `message_id`”当成功 → `run_id=None`；
  - `send_and_wait` 接着 `get_run(None)` → 误导性 `404 "Message not found: None"`，真实根因（ACE 登录门）被掩盖。

  对照工具 `send_bot_message.py`（带 Cookie + Referer）同入参可成功拿到 `message_id`，印证问题在 adapter 这一侧。

  ## Solution
  `open_api_bot_adapter.py`：
  1. 新增 `_headers()`：返回 `Bearer + 可选 Cookie/Referer`（key 有才加）。
  2. `ensure_grant` GET / `send_message` / `get_run` 三处请求头由 Bearer-only 改为 `self._headers()`（`grant` POST 本就带 Cookie/Referer，未动）。
  3. `send_message` 业务信封校验：HTTP 200 但 `code!=0` 或无 `message_id` → 直接 `raise OpenApiError(带 code/payload)`，不再吞成 `run_id=None`。
  4. `get_run`：`code!=0` → `raise OpenApiError`。
  5. 给 `ensure_grant` / `send_and_wait` / `send_and_wait_async` 入口加 3 行 debug `logger.info`，便于联调定位。

  行为：`CorpApiKeyProvider` / singlebox 的 cookie/referer 为空 → 不加头、行为不变（prod 走 service-to-service、不经 ACE）；带 cookie 的调用方（预发 e2e/联调）→ 过 ACE → 拿到真
  `message_id`。

  ## Validation
  - 单测 `test_open_api_bot_adapter.py`：新增 5 条（cookie/referer 透传 3 + 业务信封校验 2），TDD 红→绿；整文件 **17 passed**。
  - 集成目录 `task_runner/integration`：**113 passed, 5 skipped**（预发 e2e 等 skip-by-default），无回归。
  - SAST（block 规则集，源码 + 测试）exit 0。
  - A/B 印证：同 key/url/bot/cookie 下 `send_bot_message.py` 成功拿到 `message_id`（改前 adapter 失败；改后 adapter 透传 cookie → 对齐工具）。
  - pre-push gate（lint-only SAST）passed。

  ## Compatibility and risk
  - 改动为**加法**：cookie/referer 非空才加头，空则行为不变，不影响 prod/singlebox。
  - 业务 `code` 校验是新行为：此前 HTTP 200 + `code!=0` 会被当成功（返 `run_id=None`），现会抛 `OpenApiError`；旧行为本身即 bug，无合理依赖方。
  - ⚠ `ensure_grant` 入口的 `logger.info("[task][openapi_bot] ensure_grant bot_id=%s")` 缺格式化参数（`%s` 无对应 arg）；若该 logger 在 INFO 级启用，`"...%s" % ()` 会抛
  `TypeError` 使 `ensure_grant` 入口崩溃。建议补成 `..., bot_id)` 或删除该行（另两行 `send_and_wait`/`send_and_wait_async` 的 log 已带参数，不受影响）。

  ## Related issues
  - 预发 e2e `test_open_api_bot_adapter_pre_e2e.py` 此前报 `404 "Message not found: None"`，根因即本题；改后 adapter 透传 cookie/Referer 过 ACE，可跑通。