### PR TITLE
fix(backend): keep render-screen list read open for group viewers

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_render_screen/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_render_screen/router.py
@@ -50,10 +50,16 @@ async def list_render_screens(
     service: RenderScreenServiceProtocol = Depends(get_render_screen_service),
     user: AuthenticatedUser = Depends(get_current_user),
 ) -> RenderScreenApiResponse:
-    """查询 Bot 的 CDN 链接列表。"""
+    """查询 Bot 的 CDN 链接列表。
+
+    副屏 CDN 配置（库名 → CDN URL 映射）是非敏感资源。协作群/分享页的查看者
+    并非 Bot 归属者，若强制 owner/协作者校验会导致群聊等场景查不到副屏配置，
+    副屏渲染报「组件库不存在」。故读接口不做身份校验：coding bot 按 bot 维度
+    返回全部配置，普通 bot 按 owner_id（或当前用户兜底）过滤。
+    写操作（POST/PUT/DELETE）仍走 authorize_* 校验，读放开不影响写权限。
+    """
     user_id = user.staffId
     try:
-        service.authorize_render_screen_bot(bot_id=bot_id, user_id=user_id)
         records = service.list_render_screens(
             bot_id=bot_id,
             owner_id=owner_id,

--- a/src/backend/src/agentclaw/community/core/bot_management/render_screen/services/render_screen_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/render_screen/services/render_screen_service.py
@@ -109,9 +109,11 @@ class RenderScreenService:
 
         scope = resolve_render_screen_scope(bot)
         if scope == "bot":
-            user_id = current_user_id or owner_id or ""
-            if not user_id or not self._bot_has_collaborative_access(bot_id, user_id):
-                raise PermissionError(f"无权查看此 Bot 的 CDN 配置: {bot_id}")
+            # 读放开：副屏 CDN 配置（库名 → CDN URL 映射）是非敏感渲染资源。
+            # 群聊/分享页/协作场景的查看者并非 Bot 归属者或协作者，但都需要
+            # 这份映射来渲染副屏面板，否则前端会报「组件库不存在」。
+            # 写操作（create/update/delete）仍走 authorize_* 严格校验，
+            # 读放开不影响写权限。
             return self._repo.list_by_bot_id(bot_id=bot_id, owner_id=None)
 
         effective_owner_id = owner_id or current_user_id or ""

--- a/src/backend/tests/community/api/bot_render_screen/test_router.py
+++ b/src/backend/tests/community/api/bot_render_screen/test_router.py
@@ -68,7 +68,8 @@ class TestListRenderScreens:
         data = resp.json()
         assert data["success"] is True
         assert data["data"] == []
-        mock_service.authorize_render_screen_bot.assert_called_once_with(bot_id="bot_001", user_id="testuser")
+        # 读放开：list 不再走 bot 级鉴权，写操作仍校验
+        mock_service.authorize_render_screen_bot.assert_not_called()
         mock_service.list_render_screens.assert_called_once_with(
             bot_id="bot_001",
             owner_id=None,

--- a/src/backend/tests/community/core/bot_render_screen/services/test_render_screen_service.py
+++ b/src/backend/tests/community/core/bot_render_screen/services/test_render_screen_service.py
@@ -121,14 +121,20 @@ class TestListRenderScreens:
         assert len(result) == 1
         mock_repo.list_by_bot_id.assert_called_once_with(bot_id="bot_001", owner_id=None)
 
-    def test_shared_coding_bot_denies_non_collaborator(self, service, mock_repo, mock_bot_repo):
+    def test_shared_coding_bot_list_open_to_group_viewers(self, service, mock_repo, mock_bot_repo):
+        # 读放开：群聊/分享场景的非协作查看者也能读到共享 bot 的副屏配置，
+        # 否则前端渲染副屏会报「组件库不存在」。写权限不受影响。
         mock_bot_repo.get_by_id.return_value = _bot(template_type="applicationCoding", active_engine="claude_code")
-        with pytest.raises(PermissionError):
-            service.list_render_screens(
-                bot_id="bot_001",
-                owner_id="owner_001",
-                current_user_id="stranger",
-            )
+        mock_repo.list_by_bot_id.return_value = [_record(id=1, owner_id="owner_001")]
+
+        result = service.list_render_screens(
+            bot_id="bot_001",
+            owner_id="owner_001",
+            current_user_id="stranger",
+        )
+
+        assert len(result) == 1
+        mock_repo.list_by_bot_id.assert_called_once_with(bot_id="bot_001", owner_id=None)
 
 
     def test_missing_bot_fails_closed(self, service, mock_bot_repo):


### PR DESCRIPTION
## Problem

在开启成员协作的 coding bot 中，副屏（render-screen）CDN 配置按「上传者 owner_id」隔离：

- 成员 A 在 Bot 配置抽屉的副屏配置里上传了一条 CDN 地址后，**只有 A 自己能看到**，Bot Owner 和其他协作者查询列表时按各自的 owner_id 过滤，互相看不到对方的配置。
- 更新、删除接口按 `record.owner_id == 当前用户` 校验，协作者之间无法互相编辑、删除对方的 CDN 配置。
- 前端曾尝试通过传 bot 的 owner_id 绕过，但该参数只是查询过滤条件，无法解决「同一 bot 多人各自上传、互相可见可编辑」的协作诉求，反而会把 owner 自己的记录藏起来。

根因：CDN 配置的权限作用域（scope）被硬编码为「按 owner 隔离」，没有任何机制让「支持成员协作的 bot」切换到「按 bot 共享」。

此外，首版共享改造误将**读接口**也加入了协作者强制校验，导致群协作回归：群成员把 coding bot 加为好友后对话，前端拉取副屏配置渲染面板时 `GET /api/bot-render-screens` 返回 403「无权操作此 Bot 的 CDN 配置」，副屏报「组件库不存在」。群查看者既不是 owner 也不在 collaborator 表中，不应被读接口拦截（该问题由 `bf0ca0c60` 修复）。

## Solution

引入按 bot 身份动态解析作用域的机制：**Agent Coding Bot 走 bot 维度共享，其余 bot 维持 owner 维度隔离**，互不影响。读写权限分离：

- **读（list）：放开**。CDN 配置（库名 → CDN URL 映射）是非敏感渲染资源，群聊/分享页/协作场景的查看者都需要它来渲染副屏，不做身份校验。
- **写（create/update/delete）：收紧**。仅 Bot Owner 与协作者可操作，协作者之间可互相编辑、删除。

作用域判定规则（最终实现，`render_screen/scope.py`）：

> `active_engine == "claude_code"` 且 `template_type` 不是普通 CC（非空、非 `normal`、非 `normalCC`），即判定为 Agent Coding Bot，走 `bot` 共享作用域；其余一律 `owner` 隔离作用域。

| active_engine | template_type | 判定 | 说明 |
| --- | --- | --- | --- |
| `claude_code` | 空 / `None` / `normal` / `normalCC` | `owner` | 普通 CC |
| `claude_code` | `applicationCoding` / `personalCoding` | `bot` | 老版 Coding Bot |
| `claude_code` | 其他任意值（如 `architect`） | `bot` | 动态模板 Agent Coding Bot |
| 其他引擎 | 任意 | `owner` | 非 CC Bot |

各层改动：

- **新增 `render_screen/scope.py`**：纯函数作用域判定，零外部依赖，只用 `ac_bots` 本表的 `active_engine` / `template_type` 两个字段，每次请求基于最新 bot 记录实时解析，无静态固化、无需数据迁移。
- **`RenderScreenService`**：
  - 新增 `authorize_render_screen_bot`（bot 级：owner 或协作者）与 `authorize_render_screen_record`（记录级）鉴权收口，仅服务于写操作；
  - 共享 bot 的 list 查询去掉 owner 过滤、不做身份校验（读放开）；create 时记录统一归属 bot owner（`creator_id` 记录实际上传者）；update/delete 对协作者放开，实现成员间互相编辑删除；
  - 非共享 bot 行为完全不变（list 按 owner 过滤、写操作按 owner 校验）。
- **Repository**：`list_by_bot_id` 的 owner 过滤改为可选参数（`None` = 不按 owner 过滤）。
- **两个 router**（`bot_render_screen` + `openapi_v1/render_screens`）：list 不走鉴权；写操作统一走新的 `authorize_*` 收口；list 接口的 `owner_id` query 参数保留以兼容旧调用方（普通 bot 仍按它过滤，coding bot 忽略）。
- **测试**：`test_scope.py` 覆盖全部 template_type 边界（空/None/normal/normalCC/applicationCoding/personalCoding/动态模板/非 CC 引擎）；服务层补齐共享场景 list / create / authorize 用例，含「群查看者可读、非协作者不可写」的读写分离断言。

**演进过程与被拒绝的方案：**

1. ~~前端上传/查询时都传 bot 的 owner_id~~ —— 只能解决「查得到」，解决不了成员互相编辑/删除；且 bot owner 变更后历史记录归属错乱。
2. ~~通过 `MemberManagementCapabilityService` + 模板 `member_management` 能力位判定~~（`c67f91e5a` 曾实现）—— 需要跨表查 `ac_templates` 并解析多种嵌套 JSON 格式，依赖重、链路长；且模板能力位与「是否是 coding bot」的口径会随模板体系演进分叉。最终被 `5b3b25646` 简化为 template_type 直判。
3. ~~让所有 claude_code bot 都走共享~~ —— 会把普通 CC（normalCC / normal）也放开，破坏非协作场景的隔离性。
4. ~~读接口也做协作者校验~~ —— 拦截了群聊/分享场景的非协作查看者，导致副屏无法渲染；读必须放开，写保持收紧。

## Validation

```bash
cd src/backend
uv run pytest -q \
  tests/community/core/bot_management/render_screen/test_scope.py \
  tests/community/core/bot_render_screen/services/test_render_screen_service.py \
  tests/community/api/bot_render_screen/test_router.py \
  tests/community/adapters/http/openapi_v1/render_screens/test_render_screens_handlers.py \
  tests/community/architecture/test_no_module_level_service_instances.py \
  tests/community/core/bot_collaborator/
```

结果：**242 passed**（含 scope 判定 9 例、共享 list/create/authorize 服务层用例、协作域回归、架构规则）。

曾修复的 CI/回归问题（均含在上述提交中）：

- `test_member_management_flag_return_true` 等 3 例：能力判定不得给模板显式开关强加 `claude_code` 引擎门槛（协作域既有契约是引擎无关的）——已随简化方案一并移除该耦合。
- `test_no_module_level_service_instances`：scope.py 曾存在模块级 service 实例——已随简化方案移除该依赖。
- 群聊 403 回归：读接口误加协作者校验——`bf0ca0c60` 恢复读放开语义并补充读写分离测试。

未运行：完整 CI（singlebox coverage 等），推送时由远端流水线执行。

## Compatibility and risk

- **接口兼容**：list 接口的 `owner_id` query 参数保留，旧调用方不会 400；共享 bot 上该参数不再起过滤作用（这是本次需求的目标行为）。前端无需任何改动：管理界面不传 owner_id、消费链路（群聊/私聊/单 bot）传 owner_id 的现有行为均兼容。
- **数据兼容**：无 schema 变更；存量记录无需迁移。协作开启前由 owner 上传的记录在共享模式下立即可见（bot 维度查询天然覆盖）；作用域按请求实时解析，bot 模板类型变更后行为自动跟随。
- **影响面控制**：共享判定只认 `claude_code` + 非普通 CC 模板，普通 CC、其他引擎 bot 的读写路径完全不变；判定逻辑为纯函数，无跨服务/跨表调用。
- **安全边界**：读放开仅限 CDN 映射这类非敏感渲染资源（与原设计一致，openapi_v1 侧本就对查看者放行）；写操作仍严格校验 owner/协作者身份，且记录 id 会回绑 bot_id + env 防跨域猜测。
- **回滚**：按序 revert `bf0ca0c60`、`5b3b25646`、`c67f91e5a`、`0a01beae7` 即可恢复按 owner 隔离的旧行为，无数据残留风险。

## Spec

`open-claw` 仓库：`docs/specs/2026-08-24-bot-render-screen-collab-shared-scope.md`（coding bot 副屏 CDN 配置协作共享方案，随前端改动另行提交）。

## Related issues

N/A
