### PR TITLE
update MCP APIs and validate duplicate spaces

### DIFF
--- a/src/backend/docs/openapi-v1/README.md
+++ b/src/backend/docs/openapi-v1/README.md
@@ -1585,6 +1585,36 @@ internal router so both surfaces answer identically); owner-scoped via
 | GET | `/openapi/v1/bots/mcp/servers/{server_code}/config` | Read caller's unified server config | `Envelope[McpConfig]` |
 | PUT | `/openapi/v1/bots/mcp/servers/{server_code}/config` | Write config (pushed to devices) | `Envelope[McpConfig]` |
 
+The unified marketplace search also exposes
+`POST /openapi/v1/bots/market/mcp-servers`. Its JSON request supports the full
+legacy catalogue filter set: `keyword`, `page_num`, `page_size`, `server_codes`,
+`platform_server_codes`, `run_modes`, `statuses`, `transport_protocols`,
+`host_platforms`, `owners`, `network_types`, `categories`, `tenants`, and
+`tags`. Requested network types are intersected with the public allowlist
+(`INTERNET`, `OFFICE`); a request containing only hidden network types returns
+an empty page. Each `McpMarketItem` is a lossless snake-case equivalent of the
+corresponding legacy `GET /api/mcp/market/list` item, including tags and future
+catalogue extension fields, while retaining the same `extInfo` removal rule.
+
+`McpServerDetail` is the snake-case equivalent of the legacy
+`GET /api/mcp/market/detail` business payload. In addition to the lightweight
+list fields and `tools`, its explicit schema covers the legacy catalogue fields,
+including `source`, `icon`, `docs`, `endpoints`, `vendor`, `status`, `run_mode`,
+`host_platform`, `platform_server_code`, `host_app_name`, `category`, `site`,
+marketplace `tenant`, `access_level`, `stdio_configs`, business/domain codes,
+ownership records, tags, repository metadata, and launch channels.
+
+Compatibility is lossless: endpoint `headers`, identity `user_id`, endpoint
+records on every network present in an otherwise visible server, malformed
+legacy values, and future catalogue extension fields are retained. Known
+catalogue object keys are translated from camelCase to snake_case; opaque maps
+such as endpoint headers, environment-variable names, and tool declarations keep
+their original keys. As on the legacy route, tool input-schema `extInfo` is
+removed, and a server whose declared network types are all outside the API's
+allowlist still resolves as not found. The permissions operation remains the
+authoritative caller-specific permission check even though catalogue
+`access_level` is also retained in detail for legacy payload compatibility.
+
 _Delivered decisions (PR #610): paths stay nested (`/openapi/v1/bots/mcp/...`);
 `sync_mode` dropped from the write body (no single-device push path — `extra=
 "forbid"` makes it a 422); a failed device push rolls the write back and answers

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -894,6 +894,28 @@ Bot 范围的 draft 钉钉渠道配置。每个操作都显式要求 `user_id`�
 | GET | `/openapi/v1/bots/mcp/servers/{server_code}/config` | 读取调用者的统一服务器配置 | `Envelope[McpConfig]` |
 | PUT | `/openapi/v1/bots/mcp/servers/{server_code}/config` | 写入配置（下发到设备） | `Envelope[McpConfig]` |
 
+统一市场搜索还提供 `POST /openapi/v1/bots/market/mcp-servers`。JSON 请求支持老市场
+列表的完整筛选集合：`keyword`、`page_num`、`page_size`、`server_codes`、
+`platform_server_codes`、`run_modes`、`statuses`、`transport_protocols`、
+`host_platforms`、`owners`、`network_types`、`categories`、`tenants` 和 `tags`。
+请求的网络类型会与公共允许范围（`INTERNET`、`OFFICE`）取交集；如果只请求不可见网络，
+直接返回空页。每个 `McpMarketItem` 都是老接口 `GET /api/mcp/market/list` 对应条目的
+无损 snake_case 等价数据，标签和未来市场扩展字段均保留，同时继续执行相同的 `extInfo`
+删除规则。
+
+`McpServerDetail` 是老接口 `GET /api/mcp/market/detail` 业务数据的 snake_case
+等价响应。除轻量列表字段和 `tools` 外，显式契约覆盖老市场详情的 `source`、`icon`、
+`docs`、`endpoints`、`vendor`、`status`、`run_mode`、`host_platform`、
+`platform_server_code`、`host_app_name`、`category`、`site`、市场 `tenant`、
+`access_level`、`stdio_configs`、业务/架构编码、负责人、标签、代码仓库和启动渠道等字段。
+
+兼容要求是不丢业务内容：endpoint `headers`、人员 `user_id`、可见 MCP 中的所有 endpoint、
+历史异常值以及未来市场扩展字段都会保留。已知市场对象字段从 camelCase 转为 snake_case；
+endpoint header 名、环境变量名和 tool 声明等不透明映射保持原始 key。与老接口一致，tool
+input schema 中的 `extInfo` 仍会删除；如果 MCP 声明的所有网络类型均不在允许范围内，详情
+仍按不存在处理。permissions 操作仍是调用者权限判断的权威接口，但为保持老详情数据兼容，
+市场记录中的 `access_level` 也会在详情中保留。
+
 _已定案的决策（PR #610）：路径保持嵌套（`/openapi/v1/bots/mcp/...`）；写入体去掉了
 `sync_mode`（不存在单设备下发路径 —— `extra="forbid"` 让它变成 422）；下发设备失败会回滚
 写入并返回 502（与内部界面一致）；`endpoint_env`/`transport_protocol` 为严格枚举

--- a/src/backend/src/agentclaw/community/adapters/http/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/mcp/router.py
@@ -88,6 +88,7 @@ async def list_mcp_servers(
     network_types: Optional[list[str]] = Query(None, description="网络类型列表，默认只允许 INTERNET/OFFICE"),
     categories: Optional[list[str]] = Query(None, description="类目列表"),
     tenants: Optional[list[str]] = Query(None, description="租户列表"),
+    tags: Optional[list[str]] = Query(None, description="标签列表"),
     market_service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
 ) -> MCPListResponse:
     """Get MCP list from market."""
@@ -114,6 +115,7 @@ async def list_mcp_servers(
         network_types=effective_network_types,
         categories=categories,
         tenants=tenants,
+        tags=tags,
     )
     if not result.get("success"):
         raise HTTPException(status_code=500, detail=result.get("message", "Failed to fetch MCP list"))

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/market/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/market/router.py
@@ -9,7 +9,7 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
     Page,
 )
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
-from agentclaw.community.adapters.http.openapi_v1.mcp.router import _to_server
+from agentclaw.community.adapters.http.openapi_v1.mcp.router import _to_server_detail
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
     envelope_errors,
@@ -22,6 +22,7 @@ from agentclaw.community.api.skill_market_service import (
 )
 from agentclaw.community.core.mcp.config_flow import list_marketplace_servers
 from agentclaw.community.core.mcp.presentation import ALLOWED_NETWORK_TYPES
+from agentclaw.community.core.mcp.presentation import strip_ext_info
 from agentclaw.community.di import Injected
 from agentclaw.community.plugin_api.skill_center_client import (
     SkillCenterClient,
@@ -69,6 +70,7 @@ async def search_skills(
 @router.post(
     "/mcp-servers",
     response_model=Envelope[Page[McpMarketItem]],
+    response_model_exclude_unset=True,
     dependencies=_AUTH,
 )
 @envelope_errors
@@ -77,16 +79,37 @@ async def search_mcp_servers(
     request: Request,
     service: MCPMarketServiceProtocol = Injected(MCPMarketServiceProtocol),
 ) -> Envelope[Page[McpMarketItem]]:
-    """Search the MCP marketplace without changing the existing MCP API."""
+    """Search the MCP marketplace with the legacy catalogue filters."""
+    requested_network_types = body.network_types or list(ALLOWED_NETWORK_TYPES)
+    effective_network_types = tuple(
+        network_type
+        for network_type in requested_network_types
+        if network_type in ALLOWED_NETWORK_TYPES
+    )
+    if not effective_network_types:
+        return page(0, [], request)
+
     result = list_marketplace_servers(
         page=body.page_num,
         page_size=body.page_size,
         keyword=body.keyword,
-        network_types=ALLOWED_NETWORK_TYPES,
+        network_types=effective_network_types,
         market_service=service,
+        server_codes=body.server_codes,
+        platform_server_codes=body.platform_server_codes,
+        run_modes=body.run_modes,
+        statuses=body.statuses,
+        transport_protocols=body.transport_protocols,
+        host_platforms=body.host_platforms,
+        owners=body.owners,
+        categories=body.categories,
+        tenants=body.tenants,
+        tags=body.tags,
     )
     items = [
-        McpMarketItem.model_validate(_to_server(item).model_dump())
+        McpMarketItem.model_validate(
+            _to_server_detail(strip_ext_info(item)).model_dump(exclude_unset=True)
+        )
         for item in (result.get("data") or [])
         if isinstance(item, dict)
     ]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/market/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/market/schemas.py
@@ -6,6 +6,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from agentclaw.community.adapters.http.openapi_v1.mcp.schemas import McpServerDetail
+
 _STRICT = ConfigDict(extra="forbid", populate_by_name=True)
 _UPSTREAM_ITEM = ConfigDict(extra="allow", populate_by_name=True)
 
@@ -25,7 +27,7 @@ class SkillMarketSearchRequest(BaseModel):
 
 
 class McpMarketSearchRequest(BaseModel):
-    """Search the MCP marketplace."""
+    """Search the MCP marketplace with the legacy catalogue filters."""
 
     model_config = _STRICT
 
@@ -37,6 +39,39 @@ class McpMarketSearchRequest(BaseModel):
     page_num: int = Field(default=1, ge=1, description="One-based page number.")
     page_size: int = Field(
         default=20, ge=1, le=100, description="Maximum MCP servers returned per page."
+    )
+    server_codes: list[str] | None = Field(
+        default=None, max_length=100, description="Filter by MCP server codes."
+    )
+    platform_server_codes: list[str] | None = Field(
+        default=None, max_length=100, description="Filter by platform MCP server codes."
+    )
+    run_modes: list[str] | None = Field(
+        default=None, max_length=20, description="Filter by MCP run modes."
+    )
+    statuses: list[str] | None = Field(
+        default=None, max_length=20, description="Filter by publication statuses."
+    )
+    transport_protocols: list[str] | None = Field(
+        default=None, max_length=20, description="Filter by supported transport protocols."
+    )
+    host_platforms: list[str] | None = Field(
+        default=None, max_length=50, description="Filter by host platforms."
+    )
+    owners: list[str] | None = Field(
+        default=None, max_length=100, description="Filter by owner user or employee identifiers."
+    )
+    network_types: list[str] | None = Field(
+        default=None, max_length=20, description="Filter by visible network types (INTERNET or OFFICE)."
+    )
+    categories: list[str] | None = Field(
+        default=None, max_length=100, description="Filter by marketplace categories."
+    )
+    tenants: list[str] | None = Field(
+        default=None, max_length=100, description="Filter by tenant codes."
+    )
+    tags: list[str] | None = Field(
+        default=None, max_length=100, description="Filter by marketplace tags."
     )
 
 
@@ -154,21 +189,8 @@ class SkillMarketItem(BaseModel):
     )
 
 
-class McpMarketItem(BaseModel):
-    """An MCP server visible in the public marketplace."""
-
-    server_code: str = Field(description="Stable marketplace code of the MCP server.")
-    name: str = Field(description="Display name of the MCP server.")
-    description: str | None = Field(
-        default=None, description="Human-readable purpose of the MCP server."
-    )
-    network_types: list[str] = Field(
-        default_factory=list,
-        description="Network environments supported by the server.",
-    )
-    transport_protocol: str | None = Field(
-        default=None, description="Transport protocol advertised by the MCP server."
-    )
+class McpMarketItem(McpServerDetail):
+    """A lossless snake-case equivalent of one legacy MCP market-list item."""
 
 
 class SkillCenterMarketItem(BaseModel):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
@@ -20,6 +20,7 @@ bots slice took).
 
 from __future__ import annotations
 
+import re
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Path, Query, Request
@@ -81,7 +82,9 @@ from .schemas import (
 )
 from agentclaw.community.adapters.http.openapi_v1.authorization import PublicAPIRoute
 
-router = APIRouter(prefix="/openapi/v1/bots/mcp", tags=["mcp"], route_class=PublicAPIRoute)
+router = APIRouter(
+    prefix="/openapi/v1/bots/mcp", tags=["mcp"], route_class=PublicAPIRoute
+)
 _GRANT_CHECKED_ADDRESSED_BOT = [Depends(require_granted_addressed_bot)]
 
 bot_mcp_router = APIRouter(
@@ -198,21 +201,78 @@ def _to_server(data: dict[str, Any]) -> McpServer:
     )
 
 
+def _optional_text(value: Any) -> str | None:
+    """Return an upstream text value without stringifying structured data."""
+    return value if isinstance(value, str) and value else None
+
+
+def _display_label(value: Any) -> str | None:
+    """Read a display label from either a string or a catalogue object."""
+    if isinstance(value, dict):
+        return _optional_text(value.get("name") or value.get("code"))
+    return _optional_text(value)
+
+
+def _snake_key(value: Any) -> Any:
+    """Convert one legacy camelCase object key to the OpenAPI snake_case form."""
+    if not isinstance(value, str):
+        return value
+    first_pass = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", value)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", first_pass).lower()
+
+
+def _legacy_detail_to_openapi(value: Any) -> Any:
+    """Translate legacy key casing without dropping any marketplace content.
+
+    Tool declarations and endpoint header maps are opaque protocol payloads:
+    their nested keys are preserved exactly, matching the legacy detail route.
+    Every other catalogue mapping is recursively converted to snake_case. If
+    two differently-cased upstream keys collide with different values, retain
+    the later value under its original key as an allowed extension rather than
+    silently losing either value.
+    """
+    if isinstance(value, list):
+        return [_legacy_detail_to_openapi(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    projected: dict[Any, Any] = {}
+    source_keys: dict[Any, Any] = {}
+    for key, item in value.items():
+        public_key = _snake_key(key)
+        if public_key in {"tools", "headers", "input_schema", "env_variables"}:
+            public_value = item
+        else:
+            public_value = _legacy_detail_to_openapi(item)
+        if public_key in projected and projected[public_key] != public_value:
+            previous_key = source_keys[public_key]
+            if previous_key != public_key:
+                projected[previous_key] = projected[public_key]
+            projected[key] = public_value
+        else:
+            projected[public_key] = public_value
+        source_keys[public_key] = key
+    return projected
+
+
 def _to_server_detail(data: dict[str, Any]) -> McpServerDetail:
-    """Map an MCP Center detail record (with tools) to :class:`McpServerDetail`."""
-    base = _to_server(data)
-    tools = data.get("tools")
-    return McpServerDetail(
-        **base.model_dump(),
-        tools=tools if isinstance(tools, list) else [],
+    """Return a lossless snake_case equivalent of the legacy market detail."""
+    projected = _legacy_detail_to_openapi(data)
+    if not isinstance(projected, dict):
+        projected = {}
+    projected.setdefault(
+        "server_code", data.get("serverCode") or data.get("server_code") or ""
     )
+    projected.setdefault("name", data.get("name") or "")
+    projected.setdefault("description", data.get("description"))
+    projected.setdefault("network_types", normalize_network_types(data))
+    projected.setdefault("transport_protocol", primary_transport_protocol(data))
+    return McpServerDetail.model_validate(projected)
 
 
 def _category_label(category: Any) -> str:
     """A category's display string, tolerating dict or plain-string shapes."""
-    if isinstance(category, dict):
-        return category.get("name") or category.get("code") or ""
-    return str(category)
+    return _display_label(category) or ""
 
 
 def _to_tenant(data: dict[str, Any]) -> McpTenant:
@@ -315,6 +375,7 @@ async def list_mcp_tenants(
 @router.get(
     "/servers/{server_code}",
     response_model=Envelope[McpServerDetail],
+    response_model_exclude_unset=True,
     # Authenticated, not user-scoped — see /servers.
     dependencies=[Depends(require_principal)],
 )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/schemas.py
@@ -74,43 +74,152 @@ class McpServer(BaseModel):
     )
 
 
+class McpDocs(BaseModel):
+    """Marketplace documentation, preserving legacy detail fields."""
+
+    model_config = ConfigDict(extra="allow")
+
+    overview: Any | None = Field(
+        default=None,
+        description="The server overview as published by the marketplace.",
+    )
+
+
+class McpVendor(BaseModel):
+    """Marketplace vendor object, preserving legacy extension fields."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: Any | None = Field(default=None, description="The vendor display name.")
+
+
+class McpEndpoint(BaseModel):
+    """A marketplace endpoint equivalent to the legacy detail response."""
+
+    model_config = ConfigDict(extra="allow")
+
+    network_type: Any | None = Field(
+        default=None, description="The endpoint network type."
+    )
+    network_types: Any | None = Field(
+        default=None, description="All endpoint network types when supplied."
+    )
+    transport_protocol: Any | None = Field(
+        default=None, description=_TRANSPORT_RESPONSE_DESC
+    )
+    env: Any | None = Field(default=None, description="The endpoint environment.")
+    url: Any | None = Field(default=None, description="The endpoint URL.")
+    headers: Any | None = Field(
+        default=None,
+        description="Endpoint headers exactly as returned by the legacy market detail.",
+    )
+
+
+class McpPerson(BaseModel):
+    """Marketplace identity equivalent to the legacy detail response."""
+
+    model_config = ConfigDict(extra="allow")
+
+    user_id: Any | None = Field(default=None, description="Marketplace user id.")
+    user_name: Any | None = Field(default=None, description="Marketplace display name.")
+
+
 class McpServerDetail(McpServer):
-    """An MCP server's detail, including its tools."""
+    """MCP marketplace detail preserving legacy business content."""
 
     model_config = ConfigDict(
+        extra="allow",
         json_schema_extra={
             "example": {
                 "server_code": "mcp.example.weather",
+                "source": "internal",
                 "name": "Weather",
+                "icon": "",
                 "description": "Forecasts and current conditions.",
+                "status": "ONLINE",
+                "run_mode": "remote",
+                "host_platform": "",
+                "platform_server_code": "",
+                "host_app_name": "",
+                "site": "",
+                "tenant": "",
+                "category": "",
+                "access_level": "PUBLIC",
                 "network_types": ["INTERNET"],
                 "transport_protocol": "STREAMABLE_HTTP",
-                "tools": [
+                "docs": {"overview": "# Weather"},
+                "endpoints": [
                     {
-                        "name": "getForecast",
-                        "description": "Forecast for a city and date range",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "city": {"type": "string"},
-                                "days": {"type": "integer"},
-                            },
-                            "required": ["city"],
-                        },
+                        "network_type": "INTERNET",
+                        "transport_protocol": "STREAMABLE_HTTP",
+                        "env": "PROD",
+                        "url": "https://mcp.example.invalid/mcp",
+                        "headers": {},
                     }
                 ],
+                "stdio_configs": None,
+                "bu_code": "",
+                "product_code": "",
+                "arch_domain_code": "",
+                "creator": {"user_id": "1001", "user_name": "Creator"},
+                "owner": {"user_id": "1002", "user_name": "Owner"},
+                "owners_info": [],
+                "tools": [],
+                "tags": [],
+                "code_repo_url": "",
+                "launch_channels": [],
+                "vendor": "",
             }
-        }
+        },
     )
 
-    tools: list[dict[str, Any]] = Field(
-        default_factory=list,
-        description="The server's tools as the catalogue publishes them. Each "
-        "entry is one MCP tool declaration — typically 'name' (the callable "
-        "name), 'description', and 'inputSchema' (a JSON Schema for the "
-        "tool's arguments); any further catalogue keys pass through "
-        "unchanged.",
+    server_code: Any = Field(default="", description=_SERVER_CODE_DESC)
+    name: Any = Field(default="", description="The server display name.")
+    description: Any | None = Field(
+        default=None, description="The marketplace server description."
     )
+    network_types: Any = Field(
+        default_factory=list, description="The legacy marketplace network types."
+    )
+    transport_protocol: Any | None = Field(
+        default=None, description=_TRANSPORT_RESPONSE_DESC
+    )
+    source: Any | None = None
+    icon: Any | None = None
+    status: Any | None = None
+    run_mode: Any | None = None
+    host_platform: Any | None = None
+    platform_server_code: Any | None = None
+    host_app_name: Any | None = None
+    site: Any | None = None
+    tenant: Any | None = None
+    category: Any | None = None
+    access_level: Any | None = None
+    docs: McpDocs | str | list[Any] | int | float | bool | None = None
+    endpoints: (
+        list[McpEndpoint | str | int | float | bool | None]
+        | dict[str, Any]
+        | str
+        | int
+        | float
+        | bool
+        | None
+    ) = Field(default_factory=list)
+    stdio_configs: Any | None = None
+    bu_code: Any | None = None
+    product_code: Any | None = None
+    arch_domain_code: Any | None = None
+    creator: McpPerson | str | list[Any] | int | float | bool | None = None
+    owner: McpPerson | str | list[Any] | int | float | bool | None = None
+    owners_info: Any | None = None
+    tools: Any = Field(
+        default_factory=list,
+        description="Legacy tool declarations with internal extInfo removed.",
+    )
+    tags: Any = Field(default_factory=list)
+    code_repo_url: Any | None = None
+    launch_channels: Any = Field(default_factory=list)
+    vendor: McpVendor | str | list[Any] | int | float | bool | None = None
 
 
 class McpPermission(BaseModel):
@@ -278,4 +387,6 @@ class BotMcpItem(BaseModel):
     """An MCP server in one Bot's desired-state projection."""
 
     server_code: str = Field(description=_SERVER_CODE_DESC)
-    active: bool = Field(description="Whether the MCP has a desired-state installation.")
+    active: bool = Field(
+        description="Whether the MCP has a desired-state installation."
+    )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/schemas.py
@@ -184,18 +184,18 @@ class McpServerDetail(McpServer):
     transport_protocol: Any | None = Field(
         default=None, description=_TRANSPORT_RESPONSE_DESC
     )
-    source: Any | None = None
-    icon: Any | None = None
-    status: Any | None = None
-    run_mode: Any | None = None
-    host_platform: Any | None = None
-    platform_server_code: Any | None = None
-    host_app_name: Any | None = None
-    site: Any | None = None
-    tenant: Any | None = None
-    category: Any | None = None
-    access_level: Any | None = None
-    docs: McpDocs | str | list[Any] | int | float | bool | None = None
+    source: Any | None = Field(default=None, description="The marketplace source of the server.")
+    icon: Any | None = Field(default=None, description="The server icon or icon reference.")
+    status: Any | None = Field(default=None, description="The publication or availability status.")
+    run_mode: Any | None = Field(default=None, description="The execution mode published by the marketplace.")
+    host_platform: Any | None = Field(default=None, description="The host platform for the server.")
+    platform_server_code: Any | None = Field(default=None, description="The platform-specific server identifier.")
+    host_app_name: Any | None = Field(default=None, description="The host application name.")
+    site: Any | None = Field(default=None, description="The marketplace site associated with the server.")
+    tenant: Any | None = Field(default=None, description="The marketplace tenant associated with the server.")
+    category: Any | None = Field(default=None, description="The marketplace category of the server.")
+    access_level: Any | None = Field(default=None, description="The access level published by the marketplace.")
+    docs: McpDocs | str | list[Any] | int | float | bool | None = Field(default=None, description="The server documentation published by the marketplace.")
     endpoints: (
         list[McpEndpoint | str | int | float | bool | None]
         | dict[str, Any]
@@ -204,22 +204,22 @@ class McpServerDetail(McpServer):
         | float
         | bool
         | None
-    ) = Field(default_factory=list)
-    stdio_configs: Any | None = None
-    bu_code: Any | None = None
-    product_code: Any | None = None
-    arch_domain_code: Any | None = None
-    creator: McpPerson | str | list[Any] | int | float | bool | None = None
-    owner: McpPerson | str | list[Any] | int | float | bool | None = None
-    owners_info: Any | None = None
+    ) = Field(default_factory=list, description="The server endpoints published by the marketplace.")
+    stdio_configs: Any | None = Field(default=None, description="Local stdio launch configuration, when supplied.")
+    bu_code: Any | None = Field(default=None, description="The business unit code.")
+    product_code: Any | None = Field(default=None, description="The product code.")
+    arch_domain_code: Any | None = Field(default=None, description="The architecture domain code.")
+    creator: McpPerson | str | list[Any] | int | float | bool | None = Field(default=None, description="The creator identity published by the marketplace.")
+    owner: McpPerson | str | list[Any] | int | float | bool | None = Field(default=None, description="The owner identity published by the marketplace.")
+    owners_info: Any | None = Field(default=None, description="Additional owner information published by the marketplace.")
     tools: Any = Field(
         default_factory=list,
         description="Legacy tool declarations with internal extInfo removed.",
     )
-    tags: Any = Field(default_factory=list)
-    code_repo_url: Any | None = None
-    launch_channels: Any = Field(default_factory=list)
-    vendor: McpVendor | str | list[Any] | int | float | bool | None = None
+    tags: Any = Field(default_factory=list, description="The marketplace tags assigned to the server.")
+    code_repo_url: Any | None = Field(default=None, description="The source repository URL, when supplied.")
+    launch_channels: Any = Field(default_factory=list, description="The channels through which the server can be launched.")
+    vendor: McpVendor | str | list[Any] | int | float | bool | None = Field(default=None, description="The vendor information published by the marketplace.")
 
 
 class McpPermission(BaseModel):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/schemas.py
@@ -177,6 +177,7 @@ class WorkOrderEventType(_DocumentedEnum):
     SPACE_JOIN_APPLIED = "SPACE_JOIN_APPLIED"
     SPACE_JOIN_REVIEWED = "SPACE_JOIN_REVIEWED"
     SPACE_MEMBER_ADDED = "SPACE_MEMBER_ADDED"
+    SPACE_MEMBER_REMOVED = "SPACE_MEMBER_REMOVED"
     BOT_COLLABORATOR_APPLIED = "BOT_COLLABORATOR_APPLIED"
     BOT_COLLABORATOR_REVIEWED = "BOT_COLLABORATOR_REVIEWED"
     BOT_MEMBER_ADDED = "BOT_MEMBER_ADDED"
@@ -196,6 +197,7 @@ class WorkOrderEventType(_DocumentedEnum):
         "SPACE_JOIN_APPLIED": "A user submitted a request to join a Space.",
         "SPACE_JOIN_REVIEWED": "A Space join request received a review decision.",
         "SPACE_MEMBER_ADDED": "A user was directly added to a Space.",
+        "SPACE_MEMBER_REMOVED": "A user was removed from a Space.",
         "BOT_COLLABORATOR_APPLIED": "A bot collaborator request was submitted.",
         "BOT_COLLABORATOR_REVIEWED": "A bot collaborator request was reviewed.",
         "BOT_MEMBER_ADDED": "A member was directly added to a bot.",

--- a/src/backend/src/agentclaw/community/core/mcp/config_flow.py
+++ b/src/backend/src/agentclaw/community/core/mcp/config_flow.py
@@ -228,6 +228,16 @@ def list_marketplace_servers(
     keyword: str | None,
     network_types: tuple[str, ...],
     market_service: Any,
+    server_codes: list[str] | None = None,
+    platform_server_codes: list[str] | None = None,
+    run_modes: list[str] | None = None,
+    statuses: list[str] | None = None,
+    transport_protocols: list[str] | None = None,
+    host_platforms: list[str] | None = None,
+    owners: list[str] | None = None,
+    categories: list[str] | None = None,
+    tenants: list[str] | None = None,
+    tags: list[str] | None = None,
 ) -> dict[str, Any]:
     """List marketplace servers, raising on an upstream failure.
 
@@ -238,7 +248,17 @@ def list_marketplace_servers(
         page_num=page,
         page_size=page_size,
         search_key=keyword,
+        server_codes=server_codes,
+        platform_server_codes=platform_server_codes,
+        run_modes=run_modes,
+        statuses=statuses,
+        transport_protocols=transport_protocols,
+        host_platforms=host_platforms,
+        owners=owners,
         network_types=list(network_types),
+        categories=categories,
+        tenants=tenants,
+        tags=tags,
     )
     if not result.get("success"):
         raise McpMarketUnavailableError(result.get("message") or "marketplace error")

--- a/src/backend/src/agentclaw/community/core/mcp/services/local_mcp_registry.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/local_mcp_registry.py
@@ -46,6 +46,7 @@ class LocalMCPRegistry:
         network_types: list[str] | None = None,
         categories: list[str] | None = None,
         tenants: list[str] | None = None,
+        tags: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         items = self._load_servers()
         filtered = [
@@ -64,6 +65,7 @@ class LocalMCPRegistry:
                 network_types=network_types,
                 categories=categories,
                 tenants=tenants,
+                tags=tags,
             )
         ]
         return copy.deepcopy(filtered)
@@ -204,6 +206,7 @@ class LocalMCPRegistry:
         network_types: list[str] | None,
         categories: list[str] | None,
         tenants: list[str] | None,
+        tags: list[str] | None,
     ) -> bool:
         if server_codes and item.get("serverCode") not in set(server_codes):
             return False
@@ -226,6 +229,8 @@ class LocalMCPRegistry:
         if not self._field_in(item, ("category", "categoryCode", "category_code"), categories):
             return False
         if not self._field_in(item, ("tenantCode", "tenant_code", "tenant"), tenants):
+            return False
+        if not self._field_in(item, ("tags", "tagList", "tag_list"), tags):
             return False
         return True
 

--- a/src/backend/src/agentclaw/community/core/mcp/services/market_service.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/market_service.py
@@ -35,6 +35,7 @@ class MCPMarketService:
         network_types: Optional[list[str]] = None,
         categories: Optional[list[str]] = None,
         tenants: Optional[list[str]] = None,
+        tags: Optional[list[str]] = None,
     ) -> dict[str, Any]:
         """Query MCP server list from MCP Center."""
         return self.mcp_center.get_mcp_list(
@@ -51,6 +52,7 @@ class MCPMarketService:
             network_types=network_types,
             categories=categories,
             tenants=tenants,
+            tags=tags,
         )
 
     def get_mcp_detail(

--- a/src/backend/src/agentclaw/community/core/repository/implementations/spaces/space.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/spaces/space.py
@@ -150,6 +150,21 @@ class SpaceRepository(SpaceRepositoryProtocol):
             space.sc_team_id = record.sc_team_id
             db.flush()
 
+    def get_team_space_by_name(self, *, creator_id: str, name: str, env: str):
+        with self._db.orm_session() as db:
+            row = (
+                db.query(self._Space)
+                .filter(
+                    self._Space.created_by == creator_id,
+                    self._Space.name == name,
+                    self._Space.space_type == SpaceType.TEAM.value,
+                    self._Space.env == env,
+                    self._Space.deleted_at.is_(None),
+                )
+                .first()
+            )
+            return row.to_record() if row is not None else None
+
     @contextmanager
     def create_team_transaction(
         self,

--- a/src/backend/src/agentclaw/community/core/repository/protocols/spaces.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/spaces.py
@@ -37,6 +37,11 @@ class SpaceRepositoryProtocol(Protocol):
     ) -> ContextManager[SpaceRecord]: ...
 
     @abstractmethod
+    def get_team_space_by_name(
+        self, *, creator_id: str, name: str, env: str
+    ) -> SpaceRecord | None: ...
+
+    @abstractmethod
     def create_team_transaction(
         self, *,
         name: str,

--- a/src/backend/src/agentclaw/community/core/spaces/README.md
+++ b/src/backend/src/agentclaw/community/core/spaces/README.md
@@ -29,6 +29,7 @@ consumes:
   - "SpaceRepositoryProtocol (core.repository) — transactional persistence for spaces and members"
   - "SkillCenterClient (plugin_api) — mirrors a pending team-space creation to SC before local commit"
   - "StaffDeptPlugin (plugin_api) — resolves trusted creator and member nickname snapshots"
+  - "WorkOrderServiceProtocol (api) — creates member lifecycle notifications"
 consumed_by:
   - "adapters/http/openapi_v1/spaces — public Space and member operations"
   - "core/market_favorites — Space membership authorization"
@@ -40,6 +41,7 @@ internal_dependencies:
   - agentclaw.community.log
   - agentclaw.community.plugin_api.skill_center_client
   - agentclaw.community.plugin_api.staff_dept
+  - agentclaw.community.api.work_order_service
   - agentclaw.community.utils.avernet_tenant_guard
   - agentclaw.community.utils.env_utils
 ```

--- a/src/backend/src/agentclaw/community/core/spaces/services/space_member_service.py
+++ b/src/backend/src/agentclaw/community/core/spaces/services/space_member_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from injector import inject
 
+from agentclaw.community.api.work_order_service import WorkOrderServiceProtocol
 from agentclaw.community.core.repository.protocols.spaces import SpaceRepositoryProtocol
 from agentclaw.community.core.spaces.errors import (
     PersonalSpaceInvariantError,
@@ -20,6 +21,12 @@ from agentclaw.community.core.spaces.models import (
 )
 from agentclaw.community.core.spaces.services.space_access_service import (
     SpaceAccessService,
+)
+from agentclaw.community.core.work_orders.models import (
+    NotificationCategory,
+    WorkOrderEventType,
+    WorkOrderMessageContent,
+    WorkOrderMessageTitle,
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.staff_dept import (
@@ -46,10 +53,12 @@ class SpaceMemberService:
         repository: SpaceRepositoryProtocol,
         access: SpaceAccessService,
         staff_dept: StaffDeptPlugin,
+        work_orders: WorkOrderServiceProtocol,
     ) -> None:
         self._repository = repository
         self._access = access
         self._staff_dept = staff_dept
+        self._work_orders = work_orders
 
     def _resolve_member_user_name(self, *, user_id: str) -> str:
         try:
@@ -122,6 +131,24 @@ class SpaceMemberService:
         )
         if not deleted:
             raise SpaceMemberNotFoundError("space member not found")
+        self._work_orders.create_work_order_event(
+            event_category=NotificationCategory.NOTICE,
+            biz_type="SPACE",
+            biz_id=str(space_id),
+            event_type=WorkOrderEventType.SPACE_MEMBER_REMOVED.value,
+            applicant_user_id=None,
+            approver_user_ids=[],
+            recipient_user_ids=[normalized],
+            title=WorkOrderMessageTitle.SPACE_MEMBER_REMOVED.value,
+            content={
+                "legacy_value": WorkOrderMessageContent.SPACE_MEMBER_REMOVED.format(
+                    space_name=space.name
+                )
+            },
+            apply_reason=None,
+            biz_data=None,
+            actor_id=actor_id,
+        )
         return True
 
     def update_role(

--- a/src/backend/src/agentclaw/community/core/spaces/services/space_member_service.py
+++ b/src/backend/src/agentclaw/community/core/spaces/services/space_member_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from injector import inject
 
-from agentclaw.community.api.work_order_service import WorkOrderServiceProtocol
+from agentclaw.community.core.work_orders.protocols import WorkOrderEventServiceProtocol
 from agentclaw.community.core.repository.protocols.spaces import SpaceRepositoryProtocol
 from agentclaw.community.core.spaces.errors import (
     PersonalSpaceInvariantError,
@@ -53,7 +53,7 @@ class SpaceMemberService:
         repository: SpaceRepositoryProtocol,
         access: SpaceAccessService,
         staff_dept: StaffDeptPlugin,
-        work_orders: WorkOrderServiceProtocol,
+        work_orders: WorkOrderEventServiceProtocol,
     ) -> None:
         self._repository = repository
         self._access = access

--- a/src/backend/src/agentclaw/community/core/spaces/services/space_service.py
+++ b/src/backend/src/agentclaw/community/core/spaces/services/space_service.py
@@ -154,12 +154,22 @@ class SpaceService:
         normalized = name.strip()
         if not normalized or len(normalized) > 128:
             raise SpaceNameInvalidError("space name must contain 1-128 characters")
+        env = get_current_env()
+        if (
+            self._repository.get_team_space_by_name(
+                creator_id=creator_id, name=normalized, env=env
+            )
+            is not None
+        ):
+            raise SpaceAlreadyExistsError(
+                "a team space with the same name already exists for this creator"
+            )
         creator_user_name = self._get_creator_user_name(user_id=creator_id)
         with self._repository.create_team_transaction(
             name=normalized,
             creator_id=creator_id,
             creator_user_name=creator_user_name,
-            env=get_current_env(),
+            env=env,
         ) as record:
             result = self._skill_center_client.create_team(
                 SkillCenterTeamCreateRequest(

--- a/src/backend/src/agentclaw/community/core/work_orders/README.md
+++ b/src/backend/src/agentclaw/community/core/work_orders/README.md
@@ -96,6 +96,7 @@ under `legacy_value` so the response remains object-shaped without losing data.
 | Approved | `SPACE_JOIN_REVIEWED` | `NOTICE` | `SPACE_JOIN_APPROVED` | `空间加入申请已通过` | `你加入空间「{space_name}」的申请已通过。` |
 | Rejected | `SPACE_JOIN_REVIEWED` | `NOTICE` | `SPACE_JOIN_REJECTED` | `空间加入申请未通过` | `你加入空间「{space_name}」的申请未通过。拒绝原因：{review_remark}` |
 | Added directly | `SPACE_MEMBER_ADDED` | `NOTICE` | `你已被添加到空间` | `你已被添加到空间` | `你已被添加到空间「{space_name}」。` |
+| Removed from Space | `SPACE_MEMBER_REMOVED` | `NOTICE` | `你已被移出空间` | `你已被移出空间` | `你已被移出空间「{space_name}」。` |
 
 `SPACE_JOIN_REVIEWED` deliberately uses one event value for both outcomes;
 the associated work-order status selects the approved or rejected template.

--- a/src/backend/src/agentclaw/community/core/work_orders/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/models.py
@@ -57,6 +57,7 @@ class WorkOrderEventType(StrEnum):
     SPACE_JOIN_APPLIED = "SPACE_JOIN_APPLIED"
     SPACE_JOIN_REVIEWED = "SPACE_JOIN_REVIEWED"
     SPACE_MEMBER_ADDED = "SPACE_MEMBER_ADDED"
+    SPACE_MEMBER_REMOVED = "SPACE_MEMBER_REMOVED"
     BOT_COLLABORATOR_APPLIED = "BOT_COLLABORATOR_APPLIED"
     BOT_COLLABORATOR_REVIEWED = "BOT_COLLABORATOR_REVIEWED"
     BOT_MEMBER_ADDED = "BOT_MEMBER_ADDED"
@@ -77,6 +78,7 @@ EVENT_CATEGORIES: dict[WorkOrderEventType, NotificationCategory] = {
     WorkOrderEventType.SPACE_JOIN_APPLIED: NotificationCategory.APPROVAL,
     WorkOrderEventType.SPACE_JOIN_REVIEWED: NotificationCategory.NOTICE,
     WorkOrderEventType.SPACE_MEMBER_ADDED: NotificationCategory.NOTICE,
+    WorkOrderEventType.SPACE_MEMBER_REMOVED: NotificationCategory.NOTICE,
     WorkOrderEventType.BOT_COLLABORATOR_APPLIED: NotificationCategory.APPROVAL,
     WorkOrderEventType.BOT_COLLABORATOR_REVIEWED: NotificationCategory.NOTICE,
     WorkOrderEventType.BOT_MEMBER_ADDED: NotificationCategory.NOTICE,
@@ -127,6 +129,7 @@ class WorkOrderMessageTitle(StrEnum):
     SPACE_JOIN_APPROVED = "空间加入申请已通过"
     SPACE_JOIN_REJECTED = "空间加入申请未通过"
     SPACE_MEMBER_ADDED = "你已被添加到空间"
+    SPACE_MEMBER_REMOVED = "你已被移出空间"
     BOT_COLLABORATOR_PENDING = "Bot 共同编辑申请待审批"
     BOT_COLLABORATOR_APPROVED = "Bot 共同编辑申请已通过"
     BOT_COLLABORATOR_REJECTED = "Bot 共同编辑申请未通过"
@@ -141,6 +144,7 @@ class WorkOrderMessageContent(StrEnum):
         "你加入空间「{space_name}」的申请未通过。拒绝原因：{review_remark}"
     )
     SPACE_MEMBER_ADDED = "你已被添加到空间「{space_name}」。"
+    SPACE_MEMBER_REMOVED = "你已被移出空间「{space_name}」。"
     BOT_COLLABORATOR_PENDING = (
         "用户「{applicant_name}」申请共同编辑 Bot「{bot_name}」，请及时处理。"
     )

--- a/src/backend/src/agentclaw/community/core/work_orders/protocols.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/protocols.py
@@ -1,0 +1,35 @@
+"""Core-facing contracts for work-order integrations."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Protocol, TYPE_CHECKING, runtime_checkable
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.work_orders.models import (
+        NotificationCategory,
+        WorkOrderEventCreatedResult,
+    )
+
+
+@runtime_checkable
+class WorkOrderEventServiceProtocol(Protocol):
+    """Minimal work-order contract required by core domain services."""
+
+    @abstractmethod
+    def create_work_order_event(
+        self,
+        *,
+        event_category: NotificationCategory,
+        biz_type: str,
+        biz_id: str,
+        event_type: str,
+        applicant_user_id: str | None,
+        approver_user_ids: list[str],
+        recipient_user_ids: list[str],
+        title: str,
+        content: dict[str, object] | None,
+        apply_reason: str | None,
+        biz_data: dict[str, object] | None,
+        actor_id: str,
+    ) -> WorkOrderEventCreatedResult: ...

--- a/src/backend/src/agentclaw/community/di/modules/work_orders_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/work_orders_module.py
@@ -12,6 +12,7 @@ from agentclaw.community.core.repository.implementations.work_orders import (
 from agentclaw.community.core.repository.protocols.work_orders import (
     WorkOrderRepositoryProtocol,
 )
+from agentclaw.community.core.work_orders.protocols import WorkOrderEventServiceProtocol
 from agentclaw.community.core.work_orders.services import (
     WorkOrderNotificationService,
     WorkOrderService,
@@ -24,6 +25,7 @@ class WorkOrdersModule(Module):
             WorkOrderRepositoryProtocol, to=WorkOrderRepository, scope=singleton
         )
         binder.bind(WorkOrderServiceProtocol, to=WorkOrderService, scope=singleton)
+        binder.bind(WorkOrderEventServiceProtocol, to=WorkOrderService, scope=singleton)
         binder.bind(
             WorkOrderNotificationServiceProtocol,
             to=WorkOrderNotificationService,

--- a/src/backend/src/agentclaw/community/plugin_api/mcp_center.py
+++ b/src/backend/src/agentclaw/community/plugin_api/mcp_center.py
@@ -42,6 +42,7 @@ class MCPCenterPlugin(Plugin, Protocol):
         network_types: list[str] | None = None,
         categories: list[str] | None = None,
         tenants: list[str] | None = None,
+        tags: list[str] | None = None,
     ) -> dict[str, Any]:
         """Query MCP server list with filters.
 
@@ -59,6 +60,7 @@ class MCPCenterPlugin(Plugin, Protocol):
             network_types: Filter by network type (INTERNET/OFFICE/INTRANET).
             categories: Filter by category.
             tenants: Filter by tenant.
+            tags: Filter by marketplace tag.
 
         Returns:
             Dict with keys: success, data (list of MCP dicts), total, page_num, page_size.

--- a/src/backend/src/agentclaw/community/plugins/community/mcp_center.py
+++ b/src/backend/src/agentclaw/community/plugins/community/mcp_center.py
@@ -62,6 +62,7 @@ class CommunityMCPCenter(MCPCenterPlugin):
         network_types: list[str] | None = None,
         categories: list[str] | None = None,
         tenants: list[str] | None = None,
+        tags: list[str] | None = None,
     ) -> dict[str, Any]:
         items = (
             self._registry.list_mcp_details(
@@ -76,6 +77,7 @@ class CommunityMCPCenter(MCPCenterPlugin):
                 network_types=network_types,
                 categories=categories,
                 tenants=tenants,
+                tags=tags,
             )
             if self._registry is not None
             else []

--- a/src/backend/src/agentclaw/community/plugins/local/mcp_center.py
+++ b/src/backend/src/agentclaw/community/plugins/local/mcp_center.py
@@ -37,6 +37,7 @@ class NoopMCPCenterPlugin(MockSeam, MCPCenterPlugin):
         network_types: list[str] | None = None,
         categories: list[str] | None = None,
         tenants: list[str] | None = None,
+        tags: list[str] | None = None,
     ) -> dict[str, Any]:
         return {
             "success": True,

--- a/src/backend/tests/community/adapters/http/openapi_v1/market/test_market_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/market/test_market_contract.py
@@ -50,8 +50,30 @@ class _McpMarket:
                 {
                     "serverCode": "mcp.calendar",
                     "name": "Calendar MCP",
+                    "category": "office",
+                    "tags": ["calendar", "productivity"],
                     "networkTypes": ["INTERNET"],
                     "transportProtocol": "STREAMABLE_HTTP",
+                    "endpoints": [
+                        {
+                            "networkType": "INTERNET",
+                            "transportProtocol": "STREAMABLE_HTTP",
+                            "headers": {"X-Custom-Header": "opaque"},
+                        }
+                    ],
+                    "tools": [
+                        {
+                            "name": "create_event",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    "title": {"type": "string"},
+                                    "extInfo": {"internal": True},
+                                },
+                            },
+                        }
+                    ],
+                    "futureCatalogueField": {"nestedValue": "retained"},
                 }
             ],
         }
@@ -161,7 +183,89 @@ def test_mcp_market_reuses_market_service_mapping():
     assert mcp.kwargs["page_num"] == 3
     assert mcp.kwargs["page_size"] == 10
     assert mcp.kwargs["search_key"] == "calendar"
-    assert response.json()["data"]["items"][0]["server_code"] == "mcp.calendar"
+    item = response.json()["data"]["items"][0]
+    assert item["server_code"] == "mcp.calendar"
+    assert item["category"] == "office"
+    assert item["tags"] == ["calendar", "productivity"]
+    assert item["endpoints"][0]["headers"] == {"X-Custom-Header": "opaque"}
+    assert item["tools"][0]["inputSchema"]["properties"] == {
+        "title": {"type": "string"}
+    }
+    assert item["future_catalogue_field"] == {"nested_value": "retained"}
+
+
+def test_mcp_market_forwards_legacy_filters_including_tags():
+    client, _, mcp, _ = _client()
+
+    response = client.post(
+        "/openapi/v1/bots/market/mcp-servers",
+        params={"user_id": "user-1"},
+        json={
+            "keyword": "calendar",
+            "page_num": 2,
+            "page_size": 5,
+            "server_codes": ["mcp.calendar"],
+            "platform_server_codes": ["platform.calendar"],
+            "run_modes": ["REMOTE"],
+            "statuses": ["ONLINE"],
+            "transport_protocols": ["STREAMABLE_HTTP"],
+            "host_platforms": ["serverless"],
+            "owners": ["10001"],
+            "network_types": ["INTERNET", "INTRANET"],
+            "categories": ["office"],
+            "tenants": ["default"],
+            "tags": ["calendar", "productivity"],
+        },
+    )
+
+    assert response.status_code == 200
+    assert mcp.kwargs == {
+        "page_num": 2,
+        "page_size": 5,
+        "search_key": "calendar",
+        "server_codes": ["mcp.calendar"],
+        "platform_server_codes": ["platform.calendar"],
+        "run_modes": ["REMOTE"],
+        "statuses": ["ONLINE"],
+        "transport_protocols": ["STREAMABLE_HTTP"],
+        "host_platforms": ["serverless"],
+        "owners": ["10001"],
+        "network_types": ["INTERNET"],
+        "categories": ["office"],
+        "tenants": ["default"],
+        "tags": ["calendar", "productivity"],
+    }
+
+    request_schema = client.app.openapi()["components"]["schemas"][
+        "McpMarketSearchRequest"
+    ]
+    assert {
+        "server_codes",
+        "platform_server_codes",
+        "run_modes",
+        "statuses",
+        "transport_protocols",
+        "host_platforms",
+        "owners",
+        "network_types",
+        "categories",
+        "tenants",
+        "tags",
+    } <= request_schema["properties"].keys()
+
+
+def test_mcp_market_returns_empty_page_when_requested_network_is_not_visible():
+    client, _, mcp, _ = _client()
+
+    response = client.post(
+        "/openapi/v1/bots/market/mcp-servers",
+        params={"user_id": "user-1"},
+        json={"network_types": ["INTRANET"]},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"] == {"total": 0, "items": []}
+    assert mcp.kwargs is None
 
 
 def test_skill_center_market_forces_public_scope_and_hides_team_id():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_mcp_endpoints.py
@@ -41,7 +41,10 @@ def _server(**ov):
         "networkTypes": ["INTERNET"],
         "transportProtocol": "SSE",
         "tools": [
-            {"name": "get", "inputSchema": {"properties": {"extInfo": {"z": 1}, "q": 2}}}
+            {
+                "name": "get",
+                "inputSchema": {"properties": {"extInfo": {"z": 1}, "q": 2}},
+            }
         ],
     }
     base.update(ov)
@@ -163,6 +166,264 @@ def test_server_detail_strips_ext_info(client):
     assert "extInfo" not in props and props["q"] == 2
 
 
+def test_server_detail_preserves_legacy_business_content(client, market):
+    market.get_mcp_detail.return_value = _server(
+        source="internal",
+        icon="icon.svg",
+        hostPlatform="MARKET",
+        platformServerCode="platform.weather",
+        hostAppName="Weather App",
+        accessLevel="PUBLIC",
+        docs={"overview": "# Weather\nMarkdown overview", "internal": "keep-me"},
+        endpoints=[
+            {
+                "networkType": "INTERNET",
+                "transportProtocol": "STREAMABLE_HTTP",
+                "env": "PROD",
+                "url": "https://mcp.example.invalid/mcp",
+                "headers": {"Authorization": "Bearer legacy-value"},
+            },
+            {
+                "networkType": "SECRET",
+                "transportProtocol": "SSE",
+                "env": "PRE",
+                "url": "https://secret.example.invalid/sse",
+                "headers": {"x-api-key": "legacy-value"},
+            },
+            {
+                "networkTypes": ["SECRET", "OFFICE"],
+                "transportProtocol": "SSE",
+                "env": "PROD",
+                "url": "https://office.example.invalid/sse",
+            },
+            "malformed",
+        ],
+        stdioConfigs=[
+            {
+                "command": "node",
+                "arguments": ["server.js"],
+                "envVariables": {"API_TOKEN": "legacy-value"},
+            }
+        ],
+        vendor={"name": "Example Vendor", "internalId": "vendor-7"},
+        status="ONLINE",
+        runMode="REMOTE",
+        category={"code": "DEV", "name": "Developer Tools"},
+        site="global",
+        tenant={"code": "community", "name": "Community"},
+        buCode="BU-1",
+        productCode="PRODUCT-1",
+        archDomainCode="DOMAIN-1",
+        tags=["weather", {"name": "structured-tag"}, "forecast"],
+        owner={"userId": "1001", "userName": "Owner"},
+        creator={"userId": "1002", "userName": "Creator"},
+        ownersInfo=[
+            {"userId": "1003", "userName": "Maintainer"},
+            {"userId": "1004"},
+            "malformed",
+        ],
+        codeRepoUrl="https://code.example.invalid/weather",
+        launchChannels=["WEB"],
+        futureField={"nestedFuture": "retained"},
+    )
+
+    data = _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather"))
+
+    assert data["source"] == "internal"
+    assert data["icon"] == "icon.svg"
+    assert data["host_platform"] == "MARKET"
+    assert data["platform_server_code"] == "platform.weather"
+    assert data["host_app_name"] == "Weather App"
+    assert data["access_level"] == "PUBLIC"
+    assert data["docs"] == {
+        "overview": "# Weather\nMarkdown overview",
+        "internal": "keep-me",
+    }
+    assert data["endpoints"] == [
+        {
+            "network_type": "INTERNET",
+            "transport_protocol": "STREAMABLE_HTTP",
+            "env": "PROD",
+            "url": "https://mcp.example.invalid/mcp",
+            "headers": {"Authorization": "Bearer legacy-value"},
+        },
+        {
+            "network_type": "SECRET",
+            "transport_protocol": "SSE",
+            "env": "PRE",
+            "url": "https://secret.example.invalid/sse",
+            "headers": {"x-api-key": "legacy-value"},
+        },
+        {
+            "network_types": ["SECRET", "OFFICE"],
+            "transport_protocol": "SSE",
+            "env": "PROD",
+            "url": "https://office.example.invalid/sse",
+        },
+        "malformed",
+    ]
+    assert data["stdio_configs"] == [
+        {
+            "command": "node",
+            "arguments": ["server.js"],
+            "env_variables": {"API_TOKEN": "legacy-value"},
+        }
+    ]
+    assert data["vendor"] == {"name": "Example Vendor", "internal_id": "vendor-7"}
+    assert data["status"] == "ONLINE"
+    assert data["run_mode"] == "REMOTE"
+    assert data["category"] == {"code": "DEV", "name": "Developer Tools"}
+    assert data["site"] == "global"
+    assert data["tenant"] == {"code": "community", "name": "Community"}
+    assert data["bu_code"] == "BU-1"
+    assert data["product_code"] == "PRODUCT-1"
+    assert data["arch_domain_code"] == "DOMAIN-1"
+    assert data["tags"] == ["weather", {"name": "structured-tag"}, "forecast"]
+    assert data["owner"] == {"user_id": "1001", "user_name": "Owner"}
+    assert data["creator"] == {"user_id": "1002", "user_name": "Creator"}
+    assert data["owners_info"] == [
+        {"user_id": "1003", "user_name": "Maintainer"},
+        {"user_id": "1004"},
+        "malformed",
+    ]
+    assert data["code_repo_url"] == "https://code.example.invalid/weather"
+    assert data["launch_channels"] == ["WEB"]
+    assert data["future_field"] == {"nested_future": "retained"}
+
+
+def test_server_detail_accepts_legacy_and_snake_case_metadata_shapes(client, market):
+    market.get_mcp_detail.return_value = _server(
+        docs="Legacy Markdown",
+        endpoints=[
+            {
+                "transport_protocol": "SSE",
+                "env": "PRE",
+                "url": "https://legacy.example.invalid/sse",
+            }
+        ],
+        vendor="Legacy Vendor",
+        runMode=None,
+        run_mode="LOCAL",
+        category={"code": "TOOLS"},
+        site={"code": "cn"},
+        tenant={"code": "tenant-1"},
+        bu_code="BU-SNAKE",
+        product_code="PRODUCT-SNAKE",
+        arch_domain_code="DOMAIN-SNAKE",
+        ownersInfo={"name": "Single Maintainer", "userId": "private-id"},
+        owner="malformed",
+        creator={"user_name": "Snake Creator"},
+        tags="malformed",
+        tools="malformed",
+    )
+
+    data = _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather"))
+
+    assert data["docs"] == "Legacy Markdown"
+    assert data["endpoints"] == [
+        {
+            "transport_protocol": "SSE",
+            "env": "PRE",
+            "url": "https://legacy.example.invalid/sse",
+        }
+    ]
+    assert data["vendor"] == "Legacy Vendor"
+    assert data["runMode"] is None
+    assert data["run_mode"] == "LOCAL"
+    assert data["category"] == {"code": "TOOLS"}
+    assert data["site"] == {"code": "cn"}
+    assert data["tenant"] == {"code": "tenant-1"}
+    assert data["bu_code"] == "BU-SNAKE"
+    assert data["product_code"] == "PRODUCT-SNAKE"
+    assert data["arch_domain_code"] == "DOMAIN-SNAKE"
+    assert data["owner"] == "malformed"
+    assert data["creator"] == {"user_name": "Snake Creator"}
+    assert data["owners_info"] == {
+        "name": "Single Maintainer",
+        "user_id": "private-id",
+    }
+    assert data["tags"] == "malformed"
+    assert data["tools"] == "malformed"
+
+
+def test_server_detail_preserves_malformed_legacy_values(client, market):
+    market.get_mcp_detail.return_value = _server(
+        docs={"overview": {"not": "markdown"}},
+        endpoints={"not": "a-list"},
+        vendor={"name": ""},
+        status={"not": "text"},
+        runMode={"not": "text"},
+        category=[],
+        site=None,
+        tenant=7,
+        buCode=1,
+        productCode=[],
+        archDomainCode={},
+        tags=None,
+        owner={"userName": ""},
+        creator=None,
+        ownersInfo=None,
+    )
+
+    data = _ok(client.get("/openapi/v1/bots/mcp/servers/mcp.weather"))
+
+    assert data["docs"] == {"overview": {"not": "markdown"}}
+    assert data["endpoints"] == {"not": "a-list"}
+    assert data["vendor"] == {"name": ""}
+    assert data["status"] == {"not": "text"}
+    assert data["run_mode"] == {"not": "text"}
+    assert data["category"] == []
+    assert data["site"] is None
+    assert data["tenant"] == 7
+    assert data["bu_code"] == 1
+    assert data["product_code"] == []
+    assert data["arch_domain_code"] == {}
+    assert data["tags"] is None
+    assert data["owner"] == {"user_name": ""}
+    assert data["creator"] is None
+    assert data["owners_info"] is None
+
+
+def test_server_detail_openapi_schema_covers_legacy_detail_fields(client):
+    schemas = client.app.openapi()["components"]["schemas"]
+    detail_properties = schemas["McpServerDetail"]["properties"]
+
+    assert {
+        "server_code",
+        "name",
+        "description",
+        "network_types",
+        "transport_protocol",
+        "source",
+        "icon",
+        "docs",
+        "endpoints",
+        "vendor",
+        "status",
+        "run_mode",
+        "host_platform",
+        "platform_server_code",
+        "host_app_name",
+        "category",
+        "site",
+        "tenant",
+        "access_level",
+        "stdio_configs",
+        "bu_code",
+        "product_code",
+        "arch_domain_code",
+        "tags",
+        "owner",
+        "creator",
+        "owners_info",
+        "code_repo_url",
+        "launch_channels",
+        "tools",
+    } <= detail_properties.keys()
+    assert "headers" in schemas["McpEndpoint"]["properties"]
+    assert "user_id" in schemas["McpPerson"]["properties"]
+
+
 def test_unknown_server_is_404_not_found(client, market):
     market.get_mcp_detail.return_value = None
     resp = client.get("/openapi/v1/bots/mcp/servers/nope")
@@ -201,8 +462,12 @@ def test_projection_reads_transport_protocol_from_endpoints(client, market):
     rec = _server()
     rec.pop("transportProtocol")
     rec["endpoints"] = [
-        {"env": "PRE", "networkType": "INTERNET",
-         "transportProtocol": "STREAMABLE_HTTP", "url": "https://x"}
+        {
+            "env": "PRE",
+            "networkType": "INTERNET",
+            "transportProtocol": "STREAMABLE_HTTP",
+            "url": "https://x",
+        }
     ]
     market.get_mcp_detail.return_value = rec
     market.get_mcp_list.return_value = {"success": True, "data": [rec], "total": 1}

--- a/src/backend/tests/community/api/mcp/routers/test_mcp.py
+++ b/src/backend/tests/community/api/mcp/routers/test_mcp.py
@@ -105,6 +105,20 @@ class TestListMCPServers:
         ]
         assert "extInfo" in original_properties
 
+    def test_forwards_tag_filter(self, client, mock_market_service):
+        mock_market_service.get_mcp_list.return_value = {
+            "success": True,
+            "data": [],
+            "total": 0,
+            "page_num": 1,
+            "page_size": 10,
+        }
+
+        resp = client.get("/api/mcp/market/list", params={"tags": ["calendar"]})
+
+        assert resp.status_code == 200
+        assert mock_market_service.get_mcp_list.call_args.kwargs["tags"] == ["calendar"]
+
 
 # ==================== GET /api/mcp/market/detail ====================
 

--- a/src/backend/tests/community/contracts/test_mcp_center.py
+++ b/src/backend/tests/community/contracts/test_mcp_center.py
@@ -14,6 +14,8 @@ the consumer reached the plugin.
 from __future__ import annotations
 
 from agentclaw.community.core.mcp.services.auth_service import MCPAuthService
+from agentclaw.community.core.mcp.services.market_service import MCPMarketService
+from agentclaw.community.plugin_api.mcp_center import MCPCenterPlugin
 from agentclaw.community.plugins.local.mcp_center import NoopMCPCenterPlugin
 
 
@@ -66,3 +68,16 @@ def test_local_mcp_center_detail_can_be_driven_by_mock_seam() -> None:
     assert detail["serverCode"] == server_code
     assert detail["endpoints"][0]["env"] == "PRE"
     assert detail["endpoints"][0]["transportProtocol"] == "STREAMABLE_HTTP"
+
+
+def test_market_consumer_forwards_tag_filter_to_plugin(world) -> None:
+    service = world.get(MCPMarketService)
+    plugin = world.get(MCPCenterPlugin)
+    plugin.reset_mock()
+
+    result = service.get_mcp_list(tags=["calendar"])
+
+    assert result["success"] is True
+    calls = plugin.calls_to("get_mcp_list")
+    assert len(calls) == 1
+    assert calls[0].kwargs["tags"] == ["calendar"]

--- a/src/backend/tests/community/core/mcp/services/test_market_service.py
+++ b/src/backend/tests/community/core/mcp/services/test_market_service.py
@@ -17,7 +17,9 @@ class TestMCPMarketService:
             "page_size": 20,
         }
         svc = MCPMarketService(mcp_center=mock_center)
-        result = svc.get_mcp_list(page_num=1, page_size=10, search_key="test")
+        result = svc.get_mcp_list(
+            page_num=1, page_size=10, search_key="test", tags=["productivity"]
+        )
         assert result["success"] is True
         mock_center.get_mcp_list.assert_called_once_with(
             page_num=1,
@@ -33,6 +35,7 @@ class TestMCPMarketService:
             network_types=None,
             categories=None,
             tenants=None,
+            tags=["productivity"],
         )
 
     def test_get_mcp_detail_delegates_to_plugin(self):

--- a/src/backend/tests/community/core/repository/implementations/test_space_repository.py
+++ b/src/backend/tests/community/core/repository/implementations/test_space_repository.py
@@ -36,11 +36,11 @@ def db():
     reset_for_tests()
 
 
-def _team(spaces: SpaceRepository, name="Team", creator="owner-1"):
+def _team(spaces: SpaceRepository, name="Team", creator="owner-1", suffix=""):
     with spaces.create_team_transaction(
         name=name, creator_id=creator, creator_user_name=None, env="dev"
     ) as row:
-        row.sc_team_id = f"sc-{name}-{creator}"
+        row.sc_team_id = f"sc-{name}-{creator}{suffix}"
         return row
 
 
@@ -140,6 +140,45 @@ def test_space_creation_persists_creator_user_name_and_lists_it(db) -> None:
         user_id="team-owner", env="dev", keyword=None, space_type=None, offset=0, limit=20
     )
     assert next(item for item in summaries if item.space.id == team.id).creator_user_name == "Team Creator"
+
+
+def test_get_team_space_by_name_filters_creator_environment_type_and_deleted_rows(db) -> None:
+    repository = SpaceRepository(db)
+    matching = _team(repository, name="Same", creator="owner-1")
+    _team(repository, name="Same", creator="owner-2")
+    _team(repository, name="Same", creator="owner-1", suffix="-duplicate")
+
+    with repository.create_personal_transaction(
+        user_id="owner-1", creator_user_name=None, env="dev"
+    ) as personal:
+        personal.sc_team_id = "sc-personal"
+
+    with repository.create_team_transaction(
+        name="Same", creator_id="owner-1", creator_user_name=None, env="pre"
+    ) as other_env:
+        other_env.sc_team_id = "sc-pre"
+
+    with db.transactional_orm_session() as session:
+        session.query(SpaceModel).filter(SpaceModel.id == matching.id).update(
+            {SpaceModel.deleted_at: datetime(2026, 8, 25, 12, 0, 0)}
+        )
+
+    result = repository.get_team_space_by_name(
+        creator_id="owner-1", name="Same", env="dev"
+    )
+    assert result is not None
+    assert result.created_by == "owner-1"
+    assert result.name == "Same"
+    assert result.space_type is SpaceType.TEAM
+    assert repository.get_team_space_by_name(
+        creator_id="owner-1", name="Same", env="pre"
+    ).id == other_env.id
+    assert repository.get_team_space_by_name(
+        creator_id="missing", name="Same", env="dev"
+    ) is None
+    assert repository.get_team_space_by_name(
+        creator_id="owner-1", name="个人空间", env="dev"
+    ) is None
 
 
 def test_space_repository_full_member_lifecycle(db) -> None:

--- a/src/backend/tests/community/core/spaces/test_space_member_service.py
+++ b/src/backend/tests/community/core/spaces/test_space_member_service.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from agentclaw.community.api.work_order_service import WorkOrderServiceProtocol
 from agentclaw.community.core.spaces.errors import (
     PersonalSpaceInvariantError,
     SpaceCreatorInvariantError,
@@ -20,6 +21,7 @@ from agentclaw.community.core.spaces.models import (
     SpaceRecord,
     SpaceType,
 )
+from agentclaw.community.core.work_orders.models import NotificationCategory
 from agentclaw.community.core.spaces.services.space_member_service import (
     SpaceMemberService,
 )
@@ -76,21 +78,23 @@ def _service(
     repository = MagicMock()
     access = MagicMock()
     access.require_space_owner.return_value = (space or _space(), MagicMock())
+    work_orders = MagicMock(spec=WorkOrderServiceProtocol)
     if staff_dept is None:
         staff_dept = MagicMock(spec=StaffDeptPlugin)
         staff_dept.get_profile_by_work_no.return_value = StaffProfileInfo(
             work_no="member-1", nick_name=None
         )
     return (
-        SpaceMemberService(repository, access, staff_dept),
+        SpaceMemberService(repository, access, staff_dept, work_orders),
         repository,
         access,
         staff_dept,
+        work_orders,
     )
 
 
 def test_list_members_checks_membership_and_normalizes_pagination() -> None:
-    service, repository, access, _ = _service()
+    service, repository, access, _, _ = _service()
     repository.list_members.return_value = (0, [])
 
     assert service.list_members(
@@ -108,7 +112,7 @@ def test_list_members_checks_membership_and_normalizes_pagination() -> None:
 
 
 def test_list_members_turns_blank_keyword_into_none() -> None:
-    service, repository, _, _ = _service()
+    service, repository, _, _, _ = _service()
     repository.list_members.return_value = (0, [])
 
     service.list_members(
@@ -123,7 +127,7 @@ def test_add_member_resolves_nickname_and_propagates_requested_role() -> None:
     staff_dept.get_profile_by_work_no.return_value = StaffProfileInfo(
         work_no="owner-2", nick_name="  Owner Two  "
     )
-    service, repository, _, _ = _service(staff_dept=staff_dept)
+    service, repository, _, _, _ = _service(staff_dept=staff_dept)
     repository.get_member.return_value = None
     repository.add_member.return_value = _member(
         user_id="owner-2", user_name="Owner Two", role=SpaceRole.OWNER
@@ -156,7 +160,7 @@ def test_add_member_falls_back_to_user_id_when_nickname_is_missing(
     staff_dept.get_profile_by_work_no.return_value = StaffProfileInfo(
         work_no="member-1", nick_name=nickname
     )
-    service, repository, _, _ = _service(staff_dept=staff_dept)
+    service, repository, _, _, _ = _service(staff_dept=staff_dept)
     repository.get_member.return_value = None
     repository.add_member.return_value = _member()
 
@@ -173,7 +177,7 @@ def test_add_member_falls_back_to_user_id_when_nickname_is_missing(
 def test_add_member_falls_back_to_user_id_when_staff_lookup_fails() -> None:
     staff_dept = MagicMock(spec=StaffDeptPlugin)
     staff_dept.get_profile_by_work_no.side_effect = StaffProfileLookupError("down")
-    service, repository, _, _ = _service(staff_dept=staff_dept)
+    service, repository, _, _, _ = _service(staff_dept=staff_dept)
     repository.get_member.return_value = None
 
     service.add_member(
@@ -191,7 +195,7 @@ def test_add_member_truncates_staff_nickname_to_128_characters() -> None:
     staff_dept.get_profile_by_work_no.return_value = StaffProfileInfo(
         work_no="member-1", nick_name="花" * 129
     )
-    service, repository, _, _ = _service(staff_dept=staff_dept)
+    service, repository, _, _, _ = _service(staff_dept=staff_dept)
     repository.get_member.return_value = None
 
     service.add_member(
@@ -206,7 +210,7 @@ def test_add_member_truncates_staff_nickname_to_128_characters() -> None:
 
 @pytest.mark.parametrize("user_id", ["", "   "])
 def test_add_member_rejects_blank_user_id(user_id: str) -> None:
-    service, _, _, staff_dept = _service()
+    service, _, _, staff_dept, _ = _service()
 
     with pytest.raises(SpaceMemberInvalidError, match="user id is empty"):
         service.add_member(
@@ -220,7 +224,7 @@ def test_add_member_rejects_blank_user_id(user_id: str) -> None:
 
 
 def test_add_member_rejects_personal_space() -> None:
-    service, _, _, staff_dept = _service(
+    service, _, _, staff_dept, _ = _service(
         space=_space(space_type=SpaceType.PERSONAL)
     )
 
@@ -236,7 +240,7 @@ def test_add_member_rejects_personal_space() -> None:
 
 
 def test_add_member_rejects_existing_member() -> None:
-    service, repository, _, staff_dept = _service()
+    service, repository, _, staff_dept, _ = _service()
     repository.get_member.return_value = _member()
 
     with pytest.raises(SpaceMemberAlreadyExistsError, match="already exists"):
@@ -251,7 +255,7 @@ def test_add_member_rejects_existing_member() -> None:
 
 
 def test_delete_member_returns_true_for_existing_non_creator() -> None:
-    service, repository, _, _ = _service()
+    service, repository, _, _, work_orders = _service()
     repository.delete_member.return_value = True
 
     assert (
@@ -261,10 +265,45 @@ def test_delete_member_returns_true_for_existing_non_creator() -> None:
     repository.delete_member.assert_called_once_with(
         space_id=7, user_id="member-1", env="dev"
     )
+    work_orders.create_work_order_event.assert_called_once_with(
+        event_category=NotificationCategory.NOTICE,
+        biz_type="SPACE",
+        biz_id="7",
+        event_type="SPACE_MEMBER_REMOVED",
+        applicant_user_id=None,
+        approver_user_ids=[],
+        recipient_user_ids=["member-1"],
+        title="你已被移出空间",
+        content={"legacy_value": "你已被移出空间「Team」。"},
+        apply_reason=None,
+        biz_data=None,
+        actor_id="owner-1",
+    )
+
+
+def test_delete_member_does_not_notify_when_target_is_missing() -> None:
+    service, repository, _, _, work_orders = _service()
+    repository.delete_member.return_value = False
+
+    with pytest.raises(SpaceMemberNotFoundError, match="not found"):
+        service.delete_member(space_id=7, actor_id="owner-1", user_id="member-1")
+
+    work_orders.create_work_order_event.assert_not_called()
+
+
+def test_delete_member_propagates_notification_failure() -> None:
+    service, repository, _, _, work_orders = _service()
+    repository.delete_member.return_value = True
+    work_orders.create_work_order_event.side_effect = RuntimeError("notification failed")
+
+    with pytest.raises(RuntimeError, match="notification failed"):
+        service.delete_member(space_id=7, actor_id="owner-1", user_id="member-1")
+
+    work_orders.create_work_order_event.assert_called_once()
 
 
 def test_delete_member_rejects_creator() -> None:
-    service, repository, _, _ = _service()
+    service, repository, _, _, _ = _service()
 
     with pytest.raises(SpaceCreatorInvariantError, match="cannot be removed"):
         service.delete_member(space_id=7, actor_id="owner-1", user_id="owner-1")
@@ -273,7 +312,7 @@ def test_delete_member_rejects_creator() -> None:
 
 
 def test_delete_member_reports_missing_target() -> None:
-    service, repository, _, _ = _service()
+    service, repository, _, _, _ = _service()
     repository.delete_member.return_value = False
 
     with pytest.raises(SpaceMemberNotFoundError, match="not found"):
@@ -281,7 +320,7 @@ def test_delete_member_reports_missing_target() -> None:
 
 
 def test_update_role_returns_summary_and_creator_flag() -> None:
-    service, repository, _, _ = _service()
+    service, repository, _, _, _ = _service()
     repository.update_member_role.return_value = _member(
         user_id="owner-1", role=SpaceRole.OWNER
     )
@@ -298,7 +337,7 @@ def test_update_role_returns_summary_and_creator_flag() -> None:
 
 
 def test_update_role_rejects_personal_space() -> None:
-    service, _, _, _ = _service(space=_space(space_type=SpaceType.PERSONAL))
+    service, _, _, _, _ = _service(space=_space(space_type=SpaceType.PERSONAL))
 
     with pytest.raises(PersonalSpaceInvariantError, match="immutable"):
         service.update_role(
@@ -310,7 +349,7 @@ def test_update_role_rejects_personal_space() -> None:
 
 
 def test_update_role_rejects_creator_demotion() -> None:
-    service, repository, _, _ = _service()
+    service, repository, _, _, _ = _service()
 
     with pytest.raises(SpaceCreatorInvariantError, match="cannot be demoted"):
         service.update_role(
@@ -324,7 +363,7 @@ def test_update_role_rejects_creator_demotion() -> None:
 
 
 def test_update_role_reports_missing_member() -> None:
-    service, repository, _, _ = _service()
+    service, repository, _, _, _ = _service()
     repository.update_member_role.return_value = None
 
     with pytest.raises(SpaceMemberNotFoundError, match="not found"):

--- a/src/backend/tests/community/core/spaces/test_space_service.py
+++ b/src/backend/tests/community/core/spaces/test_space_service.py
@@ -34,6 +34,8 @@ def _make_service(repository, skill_center, staff_dept=None):
         staff_dept.get_profile_by_work_no.return_value = StaffProfileInfo(
             work_no="owner-1", nick_name=None
         )
+    if isinstance(repository, MagicMock):
+        repository.get_team_space_by_name.return_value = None
     return SpaceService(repository, skill_center, staff_dept)
 
 
@@ -64,6 +66,11 @@ class _TransactionRepository:
         self.committed = False
         self.rolled_back = False
         self.arguments: dict[str, str] = {}
+
+    def get_team_space_by_name(
+        self, *, creator_id: str, name: str, env: str
+    ) -> SpaceRecord | None:
+        return None
 
     @contextmanager
     def create_team_transaction(
@@ -106,6 +113,39 @@ def test_create_team_pushes_to_sc_before_transaction_commit() -> None:
     assert record.sc_team_id == "sc-team-9001"
     assert repository.committed is True
     assert repository.rolled_back is False
+
+
+def test_create_team_rejects_same_creator_and_name() -> None:
+    repository = MagicMock()
+    skill_center = MagicMock()
+    service = _make_service(repository, skill_center)
+    repository.get_team_space_by_name.return_value = _space()
+
+    with pytest.raises(SpaceAlreadyExistsError, match="same name"):
+        service.create_team(name="  Demo Team  ", creator_id="owner-1")
+
+    repository.get_team_space_by_name.assert_called_once_with(
+        creator_id="owner-1", name="Demo Team", env="dev"
+    )
+    repository.create_team_transaction.assert_not_called()
+    skill_center.create_team.assert_not_called()
+
+
+def test_create_team_allows_same_name_for_different_creator() -> None:
+    repository = _TransactionRepository(_space())
+    repository.get_team_space_by_name = MagicMock(return_value=None)
+    skill_center = MagicMock()
+    skill_center.create_team.return_value = SkillCenterTeamCreateResult(
+        team_id="sc-team-9001"
+    )
+    service = _make_service(repository, skill_center)
+
+    service.create_team(name="Demo Team", creator_id="owner-2")
+
+    repository.get_team_space_by_name.assert_called_once_with(
+        creator_id="owner-2", name="Demo Team", env="dev"
+    )
+    assert repository.arguments["creator_id"] == "owner-2"
 
 
 def test_create_team_rolls_back_when_sc_creation_fails() -> None:

--- a/src/backend/tests/community/plugins/community/test_mcp_center.py
+++ b/src/backend/tests/community/plugins/community/test_mcp_center.py
@@ -99,6 +99,26 @@ def test_list_filters_by_server_codes(tmp_path):
     assert result["data"][0]["serverCode"] == "mcp.beta"
 
 
+def test_list_filters_by_tags(tmp_path):
+    path = _write_registry(
+        tmp_path,
+        [
+            {"serverCode": "mcp.alpha", "name": "Alpha", "tags": ["search"]},
+            {
+                "serverCode": "mcp.beta",
+                "name": "Beta",
+                "tags": ["calendar", "productivity"],
+            },
+        ],
+    )
+    center = CommunityMCPCenter(registry_config_path=path)
+
+    result = center.get_mcp_list(tags=["calendar"])
+
+    assert result["total"] == 1
+    assert result["data"][0]["serverCode"] == "mcp.beta"
+
+
 def test_list_paginates(tmp_path):
     path = _write_registry(
         tmp_path,


### PR DESCRIPTION
  1. 完善 MCP、MCP 市场、本地注册相关接口和 Schema；
  2. 更新 OpenAPI 文档及相关测试；
  3. 创建团队空间时校验：
      - 当前环境；
      - 创建人；
      - 归一化后的空间名称；

  4. 同一用户不能重复创建同名团队空间，返回 409；
  5. 不同用户仍允许创建同名空间；
  6. 补充空间和 MCP 测试。