### PR TITLE
 fix(task): skip OpenApiBotAdapter.ensure_grant by default (OOB pre-grant model)

### DIFF
--- a/src/backend/src/agentclaw/community/core/task/task_runner/integration/open_api_bot_adapter.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/integration/open_api_bot_adapter.py
@@ -73,9 +73,14 @@ def _map_status(resp: httpx.Response) -> None:
 
 
 class OpenApiBotAdapter(OpenApiBotPort):  # pragma: no cover — live BaaS OpenApi HTTP client; exercised by singlebox/corp acceptance / 联调, not CI LOCAL line coverage
-    def __init__(self, keys: ApiKeyProvider, *, http_client: httpx.AsyncClient | None = None) -> None:
+    def __init__(self, keys: ApiKeyProvider, *, http_client: httpx.AsyncClient | None = None,
+                 ensure_grant: bool = False) -> None:
         self._k = keys
         self._client = http_client or httpx.AsyncClient(base_url=keys.base_url)
+        # ensure_grant=False(默认):OOB 预授权模式,跳过 allowed-bots GET/grant,直进 send_message。
+        # admin allowed-bots 端点只认 Human Cookie,corp 无 cookie 时 Bearer-only 打它会被 BaaS 判 500;
+        # prod 假定 bot 已 OOB 预授权 → 默认跳过。需自查/grant 的(测试/联调)显式传 ensure_grant=True。
+        self._ensure_grant = ensure_grant
 
     async def _aclose(self) -> None:
         await self._client.aclose()
@@ -95,7 +100,10 @@ class OpenApiBotAdapter(OpenApiBotPort):  # pragma: no cover — live BaaS OpenA
         return h
 
     async def ensure_grant(self, bot_id: str) -> None:
-        logger.info("[task][openapi_bot] ensure_grant bot_id=%s")
+        if not self._ensure_grant:
+            logger.info("[task][openapi_bot] ensure_grant 跳过(OOB 预授权模式) bot_id=%s", bot_id)
+            return
+        logger.info("[task][openapi_bot] ensure_grant bot_id=%s", bot_id)
         prefix = self._k.api_key_prefix or self._k.api_key[:_DEFAULT_KEY_PREFIX_LEN]
         logger.info("[task][openapi_bot] >>> ensure_grant GET /api/v1/api-keys/%s/allowed-bots bot_id=%s base_url=%s",
                     prefix, bot_id, self._k.base_url)

--- a/src/backend/tests/community/core/task/task_runner/integration/test_open_api_bot_adapter.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_open_api_bot_adapter.py
@@ -19,7 +19,7 @@ class _Key:
 def _adapter(handler):
     transport = httpx.MockTransport(handler)
     client = httpx.AsyncClient(transport=transport, base_url="http://b:8890")
-    return OpenApiBotAdapter(_Key(), http_client=client)
+    return OpenApiBotAdapter(_Key(), http_client=client, ensure_grant=True)
 
 
 def _run(coro):
@@ -50,7 +50,7 @@ def test_ensure_grant_falls_back_to_api_key_prefix_when_unset():
 
     transport = httpx.MockTransport(h)
     client = httpx.AsyncClient(transport=transport, base_url="http://b:8890")
-    a = OpenApiBotAdapter(_KeyNoPrefix(), http_client=client)
+    a = OpenApiBotAdapter(_KeyNoPrefix(), http_client=client, ensure_grant=True)
     _run(a.ensure_grant("bot9:ent1"))  # 已 allowed → 不走 grant
     assert seen["get_path"] == "/api/v1/api-keys/ak123456/allowed-bots"
 
@@ -248,3 +248,19 @@ def test_send_message_raises_on_nonzero_business_code():
 
     with pytest.raises(OpenApiError):
         _run(_adapter(h).send_message(bot_id="bot9:ent1", message="hi", metadata={}))
+
+
+def test_ensure_grant_skipped_by_default():
+    # 默认 ensure_grant=False(OOB 预授权模式):不发 allowed-bots GET/grant,直接 return。
+    # admin allowed-bots 端点只认 Human Cookie,corp 无 cookie 时 Bearer-only 会 500;
+    # prod 假定 bot 已 OOB 预授权 → ensure_grant 默认跳过,直进 send_message(dispatch 端点认 Bearer)。
+    seen: dict = {}
+
+    def h(req):
+        seen["path"] = req.url.path
+        return httpx.Response(200, json={"data": {"allowed_bots": []}})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(h), base_url="http://b:8890")
+    a = OpenApiBotAdapter(_Key(), http_client=client)  # 默认 ensure_grant=False
+    _run(a.ensure_grant("bot9:ent1"))
+    assert "allowed-bots" not in seen.get("path", ""), f"默认应跳过 ensure_grant,却发了 {seen.get('path')!r}"


### PR DESCRIPTION
  ## Problem
  `OpenApiBotAdapter.ensure_grant` 之前**默认总会先 GET `/api/v1/api-keys/{prefix}/allowed-bots`**（判断 bot 是否已授权 → 是否跳过 grant）。但该 admin 端点**只认
  Human（登录）Cookie**（`create_api_key.py` 的 create/grant/list 都走 Cookie+Referer、不带 Bearer），而 corp/pre/prod 部署里 `OpenApiBotAdapter` 的 cookie/referer 为空（`CorpApiKeyProvider`
  默认留空，prod 假定 service-to-service + OOB 预授权）。于是：

  - `ensure_grant` 的 GET 用 **Bearer-only** 打一个只认 Human Cookie 的 admin 端点 → BaaS 拿不到登录用户上下文 → **500 `INTERNAL_ERROR`**（线上实测：`<<< ensure_grant GET allowed-bots status=500
  INTERNAL_ERROR`，一路上抛到 `on_execute` 500）。
  - 即便 bot 已被外部 OOB grant 过也没用：`ensure_grant` 总在“判断是否已授权→跳过 grant”**之前**就 GET，GET 自己崩了，根本到不了 skip 分支。

  这与 corp 一直声称的“api_key 已 OOB 预授权 bot，ensure_grant 是 no-op”假设矛盾——该假设依赖 GET 能跑通，而 GET 在无 cookie 的 prod/corp 上跑不通 → 真实 BaaS 上单 bot 派发直接断（prod 之前可能没真跑
  single_bot 才没暴露）。

  ## Solution
  `open_api_bot_adapter.py`：
  1. `__init__` 新增 `ensure_grant: bool = False`（默认**跳过**）。
  2. `ensure_grant` 顶部：`if not self._ensure_grant: 日志 + return` —— 默认不发 allowed-bots GET、不 grant，直进 `send_message`（dispatch 端点 `/openapi/v1/messages` 认 Bearer，正常）。
  3. 顺带修 `ensure_grant` 入口 `logger.info("...bot_id=%s")` **缺 `bot_id` 参数**的 bug（opt-in 模式否则 `TypeError`）。

  测试 `test_open_api_bot_adapter.py`：
  - 新增 `test_ensure_grant_skipped_by_default`：默认构造 → ensure_grant → 断言不发 allowed-bots GET。
  - `_adapter` helper + prefix 回落用例显式 `ensure_grant=True`（保留对 GET/grant/prefix/cookie 透传的覆盖）。

  行为：corp/prod/pre（`CorpTaskIntegrationModule` 构造 `OpenApiBotAdapter(keys)` 不传 flag）→ ensure_grant 跳过、直接派发；需要自查/grant 的（单测/联调）显式 `ensure_grant=True`。bot 由外部 OOB
  预授权（prod 既定模型）。

  ## Validation
  - TDD 红→绿：`test_ensure_grant_skipped_by_default` 先 RED（默认原先会 GET）、改源码后 GREEN。
  - `test_open_api_bot_adapter.py`：**18 passed**（17 既有 + 1 新增），无回归（opt-in 用例继续覆盖 GET/grant/cookie 透传/业务 code 校验）。
  - 集成目录 `task_runner/integration`：**114 passed, 5 skipped**，无回归。
  - SAST（block 规则集，源码 + 测试）exit 0。
  - 线上实证：改前 `ensure_grant GET allowed-bots status=500 INTERNAL_ERROR` → `on_execute` 500；改后默认跳过该 GET、直进 send_message，500 消失。

  ## Compatibility and risk
  - **默认行为变更**：`ensure_grant` 由“默认执行 GET/grant”改为“默认跳过”。prod 假定 bot 已 OOB 预授权 → 跳过是正确姿势；**前提是部署侧确实已对目标 bot 做 OOB grant**（`create_api_key.py --action grant`
  或 BaaS 控制台）。若某部署未预授权、仍想让 adapter 自查/grant，需显式 `ensure_grant=True` 且配 Human Cookie（admin 端点要 Cookie）。
  - 不影响 singlebox（用 `SingleboxEngineAdapter`，非本 adapter）。
  - 不影响 dispatch 端点（`/openapi/v1/messages`、`get_run`）——它们认 Bearer，与 ensure_grant 无关。

  ## Related issues
  - 直接起因：线上 `OpenApiBotAdapter.ensure_grant` GET `/api/v1/api-keys/{prefix}/allowed-bots` 返回 500 `INTERNAL_ERROR`（Bearer-only 打只认 Human Cookie 的 admin 端点），即便 bot 已 OOB grant
  也复现（卡在 GET，到不了 skip 分支）。
  - 关联已合入的 `fix(task): forward cookie/referer and validate business code in OpenApiBotAdapter`：那条解决 dispatch 端点的 ACE/信封问题；本条解决 admin `ensure_grant` 在无 cookie 部署下的
  500（改为默认不调）。