### PR TITLE
fix(backend): enforce platform default MCP ownership

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -766,6 +766,10 @@ ENVELOPE_ERROR_CODES: dict[type[Exception], int] = {
 _SKILL_SET_CONFLICT_CODES: dict[str, tuple[int, str]] = {
     "RESOURCE_DIRECT_ACTIVE": (409201, "Resource is directly active"),
     "RESOURCE_MANAGED_BY_SKILL_SET": (409202, "Resource is managed by a SkillSet"),
+    "RESOURCE_MANAGED_BY_PLATFORM_POLICY": (
+        409210,
+        "Resource is managed by the platform Default policy",
+    ),
     "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET": (409203, "Resource belongs to another SkillSet"),
     "SYSTEM_DEFAULT_IMMUTABLE": (409204, "System Default SkillSet is immutable"),
     "SKILL_SET_ACTIVE": (409205, "Active SkillSet cannot be deleted"),

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/CLAUDE.md
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/CLAUDE.md
@@ -219,7 +219,7 @@ device 层正处于 agentbox/arca 双链路拆分迁移中（背景见 `docs/sup
 | `adapters/http/skill_center/skills.py` | 遗留 `/api/skills` 路由（读走 `SkillQueryService`，激活/去激活走 `DirectActivationService`） |
 | `adapters/http/skill_center/skillsets.py` | 遗留 `/api/skillsets` 路由（写走 `SkillSetManagementService` 控制面） |
 | `core/skill_center/services/skill_set_management_service.py` | `SkillSetManagementService` — Set 范围的期望态命令服务（Default-Set 编辑落为 per-Bot 排除行） |
-| `core/skill_center/services/direct_activation_service.py` | `DirectActivationService` — 单能力（skill/MCP）直接激活命令服务 |
+| `core/skill_center/services/direct_activation_service.py` | `DirectActivationService` — 单能力（skill/MCP）直接激活命令服务；Platform Default MCP 拒绝 Direct，只能走 Default exclusion |
 | `core/skill_center/services/skill_query_service.py` | `SkillQueryService` — Bot skill 的唯一查询缝（列表/详情/内容/参数，读前先 flush） |
 | `core/skill_center/services/bot_capability_state_reader.py` | `BotCapabilityStateReader` — flush-then-read 的唯一激活态读模型 |
 | `core/skill_center/policies/capability_ownership.py` | `CapabilityOwnershipPolicy` — R1/R2/R3 所有权规则的唯一裁决点 |

--- a/src/backend/src/agentclaw/community/api/direct_activation_service.py
+++ b/src/backend/src/agentclaw/community/api/direct_activation_service.py
@@ -9,9 +9,10 @@ from typing import Any, Protocol, runtime_checkable
 class DirectActivationServiceProtocol(Protocol):
     """Activate/deactivate ONE capability (skill or MCP) for a Bot, directly.
 
-    Legal only when no Set governs the capability (ownership rule R1 — decided
-    inside the write transaction). Same authorization, same UoW write, same
-    compensation as the Set service: one pattern, two scopes.
+    Legal only when no Set or platform Default policy governs the capability.
+    Platform Default MCPs are controlled only by Default exclusion/un-exclusion.
+    Same authorization, same UoW write, same compensation as the Set service:
+    one pattern, two scopes.
     """
 
     async def activate_skill(

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
@@ -239,7 +239,8 @@ class McpSkillSetControlPlaneCommands:
     ) -> DesiredStateMutation:
         with self._db.transactional_orm_session() as session:
             require_direct_mcp_control_allowed(
-                is_platform_default=server_code in platform_default_codes
+                server_code=server_code,
+                platform_default_codes=platform_default_codes,
             )
             old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
             self._require_not_set_managed(
@@ -269,7 +270,8 @@ class McpSkillSetControlPlaneCommands:
     ) -> DesiredStateMutation:
         with self._db.transactional_orm_session() as session:
             require_direct_mcp_control_allowed(
-                is_platform_default=server_code in platform_default_codes
+                server_code=server_code,
+                platform_default_codes=platform_default_codes,
             )
             old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
             self._require_not_set_managed(

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
@@ -17,6 +17,7 @@ from agentclaw.community.core.repository.capability_desired_state_types import (
     DesiredStateMutation,
 )
 from agentclaw.community.core.skill_center.policies.capability_ownership import (
+    require_direct_mcp_control_allowed,
     require_can_join_set,
 )
 from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
@@ -152,11 +153,11 @@ class McpSkillSetControlPlaneCommands:
         """The MCP twin of ``exclude_default_skill``: exclusion row +
         Installation delta in one transaction.
 
-        A Default Set's effective MCP membership has two halves: the
+        A Default Set's effective MCP projection has two inputs: the
         association rows this transaction can read, and the platform's
-        engine/template default codes — a read-time policy input the caller
-        resolves and passes in as ``platform_default_codes`` (spec A.2 keeps
-        that config unmaterialized). A code in neither half is the MCP twin
+        engine/template default policy — a read-time input the caller resolves
+        and passes in as ``platform_default_codes`` (spec A.2 keeps that config
+        unmaterialized). A code in neither input is the MCP twin
         of the skill command's never-member gate: refused without writing,
         because a stray code must not leave a dangling row that would
         pre-exclude the server if the platform ever adds it.
@@ -180,13 +181,16 @@ class McpSkillSetControlPlaneCommands:
                 session, bot_id=bot_id, owner_id=owner_id,
                 set_id=int(row.id), server_code=server_code,
             )
-            if not created:
+            # Neither a Set member nor a platform-policy code can be
+            # Direct-controlled. Retire any legacy Installation row even when
+            # the exclusion already existed; otherwise the installed half of
+            # the runtime union would bypass policy indefinitely.
+            removed_installation = mcp_installations.uninstall(
+                session, bot_id=bot_id, owner_id=owner_id,
+                env=get_current_env(), server_codes={server_code},
+            )
+            if not created and removed_installation == 0:
                 return DesiredStateMutation(self._as_item(row), False, old)
-            if server_code in member_codes:
-                mcp_installations.uninstall(
-                    session, bot_id=bot_id, owner_id=owner_id,
-                    env=get_current_env(), server_codes={server_code},
-                )
             session.flush()
             return DesiredStateMutation(self._as_item(row), True, old)
 
@@ -229,10 +233,14 @@ class McpSkillSetControlPlaneCommands:
 
     def install_mcp(
         self, *, bot_id: str, owner_id: str, server_code: str,
+        platform_default_codes: frozenset[str],
         engine_type: str | None = None,
         default_engine_types: tuple[str, ...] | None = None,
     ) -> DesiredStateMutation:
         with self._db.transactional_orm_session() as session:
+            require_direct_mcp_control_allowed(
+                is_platform_default=server_code in platform_default_codes
+            )
             old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
             self._require_not_set_managed(
                 session,
@@ -255,10 +263,14 @@ class McpSkillSetControlPlaneCommands:
 
     def uninstall_mcp(
         self, *, bot_id: str, owner_id: str, server_code: str,
+        platform_default_codes: frozenset[str],
         engine_type: str | None = None,
         default_engine_types: tuple[str, ...] | None = None,
     ) -> DesiredStateMutation:
         with self._db.transactional_orm_session() as session:
+            require_direct_mcp_control_allowed(
+                is_platform_default=server_code in platform_default_codes
+            )
             old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
             self._require_not_set_managed(
                 session,

--- a/src/backend/src/agentclaw/community/core/repository/protocols/capability_desired_state.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/capability_desired_state.py
@@ -205,14 +205,21 @@ class CapabilityDesiredStateRepositoryProtocol(Protocol):
     @abstractmethod
     def install_mcp(
         self, *, bot_id: str, owner_id: str, server_code: str,
+        platform_default_codes: frozenset[str],
         engine_type: str | None = None,
         default_engine_types: tuple[str, ...] | None = None,
     ) -> DesiredStateMutation:
-        """The MCP twin of :meth:`install_skill`, same R1 rule."""
+        """The MCP twin of :meth:`install_skill`, plus platform-policy ownership.
+
+        ``platform_default_codes`` is resolved strictly from the Bot's
+        engine/template context. A matching code refuses Direct control; only
+        Default exclusion/un-exclusion may change its effective state.
+        """
         ...
     @abstractmethod
     def uninstall_mcp(
         self, *, bot_id: str, owner_id: str, server_code: str,
+        platform_default_codes: frozenset[str],
         engine_type: str | None = None,
         default_engine_types: tuple[str, ...] | None = None,
     ) -> DesiredStateMutation: ...

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -128,8 +128,11 @@ that way:
 - **One rule book.** `policies/capability_ownership.py` owns the ownership
   rules: R1 a Set-held capability (Default included, excluded or not) refuses
   direct control; R2 a directly-active capability refuses joining a Set; R3 a
-  capability lives in at most one Set. Command services consult the policy
-  inside the write transaction; nothing else re-derives those decisions.
+  capability lives in at most one Set. Engine/template Default MCPs are a
+  separate platform policy input rather than Set membership; they likewise
+  refuse Direct control and change only through Default exclusion/un-exclusion.
+  Command services consult these policies before and inside the write
+  transaction; nothing else re-derives those decisions.
 
 Writes go through two command services, one per scope, with identical shape —
 authorize, mutate desired state in one UoW transaction, project the complete
@@ -157,6 +160,13 @@ active-only desired-state and compensation boundary as Skills.  The MCP
 catalogue, user configuration, and permission grant remain separate facts;
 the control plane consults the MCP authorization Service API before any MCP
 membership or Direct-installation write.
+
+Engine/template Default MCPs never become Installation provenance: Direct
+commands reject them, while exclusion removes any legacy Direct row left by an
+older process so the installed union cannot bypass policy. Runtime projection
+resolves template Default MCP context strictly; a provider failure aborts the
+projection and enters command compensation rather than becoming an empty
+Default policy.
 
 `RuntimeProjectionResolver` is the only source of a mutation/restart runtime
 snapshot. It receives Installation, active ordinary SkillSet membership,

--- a/src/backend/src/agentclaw/community/core/skill_center/policies/capability_ownership.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/policies/capability_ownership.py
@@ -69,6 +69,19 @@ def require_can_join_set(
         )
 
 
+def require_direct_mcp_control_allowed(*, is_platform_default: bool) -> None:
+    """Refuse Direct control of an engine/template Default MCP.
+
+    Platform Default MCPs are code policy rather than Set membership, so R1's
+    membership walk cannot see them. They remain policy-managed even after a
+    Bot excludes them; exclusion/un-exclusion is their only control surface.
+    """
+    if is_platform_default:
+        raise SkillSetControlPlaneConflictError(
+            "RESOURCE_MANAGED_BY_PLATFORM_POLICY"
+        )
+
+
 def _set_belongs_to_bot(
     skill_set: Mapping[str, Any],
     *,
@@ -108,4 +121,8 @@ def _set_belongs_to_bot(
     return engine_type is None or str(skill_set.get("engine_type") or "") == engine_type
 
 
-__all__ = ["is_set_managed", "require_can_join_set"]
+__all__ = [
+    "is_set_managed",
+    "require_can_join_set",
+    "require_direct_mcp_control_allowed",
+]

--- a/src/backend/src/agentclaw/community/core/skill_center/policies/capability_ownership.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/policies/capability_ownership.py
@@ -69,14 +69,18 @@ def require_can_join_set(
         )
 
 
-def require_direct_mcp_control_allowed(*, is_platform_default: bool) -> None:
+def require_direct_mcp_control_allowed(
+    *,
+    server_code: str,
+    platform_default_codes: frozenset[str],
+) -> None:
     """Refuse Direct control of an engine/template Default MCP.
 
     Platform Default MCPs are code policy rather than Set membership, so R1's
     membership walk cannot see them. They remain policy-managed even after a
     Bot excludes them; exclusion/un-exclusion is their only control surface.
     """
-    if is_platform_default:
+    if server_code in platform_default_codes:
         raise SkillSetControlPlaneConflictError(
             "RESOURCE_MANAGED_BY_PLATFORM_POLICY"
         )

--- a/src/backend/src/agentclaw/community/core/skill_center/policies/platform_default_mcp.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/policies/platform_default_mcp.py
@@ -1,0 +1,43 @@
+"""Platform-owned Default MCP policy for one Bot.
+
+These engine/template defaults are code policy, not SkillSet membership and
+not Installation provenance.  Direct commands therefore cannot control them;
+the Bot's only control is the Default exclusion/un-exclusion path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from agentclaw.community.core.mcp.services._defaults import (
+    get_default_mcp_server_codes,
+)
+
+
+class PlatformDefaultMcpPolicy:
+    """Resolve the platform-owned MCP codes for an exact Bot context.
+
+    The context provider is deliberately strict.  A lookup failure is not the
+    same fact as "this Bot has no template defaults" and must propagate to
+    both command and runtime-projection callers.
+    """
+
+    def __init__(
+        self,
+        ext_info_provider: Callable[[str], Mapping[str, Any] | None],
+    ) -> None:
+        self._ext_info_provider = ext_info_provider
+
+    def server_codes_for(self, bot: Mapping[str, Any]) -> frozenset[str]:
+        bot_id = str(bot["bot_id"])
+        return frozenset(
+            get_default_mcp_server_codes(
+                str(bot.get("active_engine") or ""),
+                bot.get("template_type"),
+                ext_info=self._ext_info_provider(bot_id),
+            )
+        )
+
+
+__all__ = ["PlatformDefaultMcpPolicy"]

--- a/src/backend/src/agentclaw/community/core/skill_center/policies/platform_default_mcp.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/policies/platform_default_mcp.py
@@ -13,6 +13,9 @@ from typing import Any
 from agentclaw.community.core.mcp.services._defaults import (
     get_default_mcp_server_codes,
 )
+from agentclaw.community.core.skill_center.policies.capability_ownership import (
+    require_direct_mcp_control_allowed,
+)
 
 
 class PlatformDefaultMcpPolicy:
@@ -38,6 +41,25 @@ class PlatformDefaultMcpPolicy:
                 ext_info=self._ext_info_provider(bot_id),
             )
         )
+
+    def require_direct_control_allowed(
+        self,
+        *,
+        bot: Mapping[str, Any],
+        server_code: str,
+    ) -> frozenset[str]:
+        """Validate ownership and return the immutable per-Bot snapshot.
+
+        The snapshot is passed into the persistence UoW so the transactional
+        boundary rechecks the same decision without resolving mutable template
+        context again inside the database transaction.
+        """
+        platform_default_codes = self.server_codes_for(bot)
+        require_direct_mcp_control_allowed(
+            server_code=server_code,
+            platform_default_codes=platform_default_codes,
+        )
+        return platform_default_codes
 
 
 __all__ = ["PlatformDefaultMcpPolicy"]

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
@@ -242,13 +242,20 @@ class BotRuntimeProjector:
         # System Defaults during Phase 1.  It resolves template presets and
         # applies ac_default_skillset_mcp_exclusion; rebuilding defaults from
         # static constants here would silently resurrect user exclusions.
-        effective_mcp_entries = service.collect_bot_active_mcps(
-            entity_id=str(bot.get("entity_id") or owner_id),
-            bot_id=bot_id,
-            user_id=owner_id,
-            entity_type=bot.get("entity_type") or "staff",
-            engine_type=engine,
-        )
+        try:
+            effective_mcp_entries = service.collect_bot_active_mcps(
+                entity_id=str(bot.get("entity_id") or owner_id),
+                bot_id=bot_id,
+                user_id=owner_id,
+                entity_type=bot.get("entity_type") or "staff",
+                engine_type=engine,
+                strict_policy_context=True,
+            )
+        except Exception as exc:
+            # A failed policy-context lookup is not an empty Default policy.
+            # Fail before any overwrite-style MCP or Passport projection so a
+            # transient dependency outage cannot remove template-only MCPs.
+            raise SkillSetRuntimeReconcileError() from exc
         effective_default_mcp_codes = frozenset(
             str(item.get("server_code") or item.get("serverCode") or "").strip()
             for item in effective_mcp_entries

--- a/src/backend/src/agentclaw/community/core/skill_center/services/direct_activation_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/direct_activation_service.py
@@ -39,6 +39,12 @@ from agentclaw.community.core.skill_center.errors import (
     SkillSetControlPlaneNotFoundError,
     SkillSetRuntimeReconcileError,
 )
+from agentclaw.community.core.skill_center.policies.capability_ownership import (
+    require_direct_mcp_control_allowed,
+)
+from agentclaw.community.core.skill_center.policies.platform_default_mcp import (
+    PlatformDefaultMcpPolicy,
+)
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectorProtocol,
 )
@@ -68,6 +74,7 @@ class DirectActivationService:
         audit_log_repo: BotCollabLogRepositoryProtocol,
         mcp_center: MCPCenterPlugin,
         reader: BotCapabilityStateReaderProtocol,
+        platform_default_mcp_policy: PlatformDefaultMcpPolicy,
     ) -> None:
         self._repository = repository
         self._bot_repo = bot_repo
@@ -76,6 +83,7 @@ class DirectActivationService:
         self._audit_log_repo = audit_log_repo
         self._mcp_center = mcp_center
         self._reader = reader
+        self._platform_default_mcp_policy = platform_default_mcp_policy
         self._flow = MutationProjectionFlow(repository=repository, runtime=runtime)
 
     # ── Skills ──────────────────────────────────────────────────────
@@ -182,6 +190,7 @@ class DirectActivationService:
         self, *, server_code: str, bot_id: str, owner_id: str, actor_id: str
     ) -> dict[str, Any]:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, actor_id=actor_id)
+        platform_default_codes = self._platform_default_codes(bot, server_code)
         self._require_mcp_permission(actor_id=actor_id, server_code=server_code)
         result = await self._flow.apply(
             bot=bot,
@@ -191,6 +200,7 @@ class DirectActivationService:
                 bot_id=bot_id,
                 owner_id=str(bot["owner_id"]),
                 server_code=server_code,
+                platform_default_codes=platform_default_codes,
                 engine_type=bot_engine_type(bot),
                 default_engine_types=bot_default_engine_types(bot),
             ),
@@ -205,6 +215,7 @@ class DirectActivationService:
         self, *, server_code: str, bot_id: str, owner_id: str, actor_id: str
     ) -> dict[str, Any]:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, actor_id=actor_id)
+        platform_default_codes = self._platform_default_codes(bot, server_code)
         result = await self._flow.apply(
             bot=bot,
             bot_id=bot_id,
@@ -213,6 +224,7 @@ class DirectActivationService:
                 bot_id=bot_id,
                 owner_id=str(bot["owner_id"]),
                 server_code=server_code,
+                platform_default_codes=platform_default_codes,
                 engine_type=bot_engine_type(bot),
                 default_engine_types=bot_default_engine_types(bot),
             ),
@@ -234,6 +246,15 @@ class DirectActivationService:
         )
 
     # ── Shared ──────────────────────────────────────────────────────
+
+    def _platform_default_codes(
+        self, bot: dict, server_code: str
+    ) -> frozenset[str]:
+        codes = self._platform_default_mcp_policy.server_codes_for(bot)
+        require_direct_mcp_control_allowed(
+            is_platform_default=server_code in codes
+        )
+        return codes
 
     def _bot(self, *, bot_id: str, owner_id: str, actor_id: str) -> dict:
         """Resolve the exact addressed Bot; the MCP wire's error vocabulary."""

--- a/src/backend/src/agentclaw/community/core/skill_center/services/direct_activation_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/direct_activation_service.py
@@ -39,9 +39,6 @@ from agentclaw.community.core.skill_center.errors import (
     SkillSetControlPlaneNotFoundError,
     SkillSetRuntimeReconcileError,
 )
-from agentclaw.community.core.skill_center.policies.capability_ownership import (
-    require_direct_mcp_control_allowed,
-)
 from agentclaw.community.core.skill_center.policies.platform_default_mcp import (
     PlatformDefaultMcpPolicy,
 )
@@ -250,11 +247,10 @@ class DirectActivationService:
     def _platform_default_codes(
         self, bot: dict, server_code: str
     ) -> frozenset[str]:
-        codes = self._platform_default_mcp_policy.server_codes_for(bot)
-        require_direct_mcp_control_allowed(
-            is_platform_default=server_code in codes
+        return self._platform_default_mcp_policy.require_direct_control_allowed(
+            bot=bot,
+            server_code=server_code,
         )
-        return codes
 
     def _bot(self, *, bot_id: str, owner_id: str, actor_id: str) -> dict:
         """Resolve the exact addressed Bot; the MCP wire's error vocabulary."""

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
@@ -724,7 +724,7 @@ class SkillSetManagementService:
             )
 
     def _platform_default_mcp_codes(self, bot: dict, bot_id: str) -> frozenset[str]:
-        """The unmaterialized half of Default-Set MCP membership (spec A.2).
+        """The unmaterialized platform Default MCP policy (spec A.2).
 
         Resolved at write time with the same context the read-side union
         uses — engine, template, ext info. A provider failure propagates

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -394,50 +394,78 @@ class SkillSetService:
         self,
         engine_type: Optional[str],
         bot_id: Optional[str] = None,
+        *,
+        strict: bool = False,
     ) -> Mapping[str, Any] | None:
-        """Best-effort extra context lookup for engine-specific default capabilities."""
+        """Resolve extra context for engine-specific default capabilities.
+
+        Display/read callers keep their historical best-effort behavior.
+        Runtime projection passes ``strict=True`` because a dependency failure
+        must not be interpreted as removal of template-only Default MCPs.
+        """
         provider = self._ext_info_provider
         if provider is None:
+            if strict:
+                raise RuntimeError("Default MCP policy provider is unavailable")
             return None
         target_bot_id = bot_id or self.bot_id
         if not target_bot_id:
             return None
-        try:
+        if strict:
             ext_info = provider(str(target_bot_id))
-        except Exception as exc:
-            logger.warning(
-                "[SkillSetService] default capabilities ext_info lookup failed for "
-                "engine_type=%s bot_id=%s: %s",
-                engine_type,
-                target_bot_id,
-                exc,
-            )
-            return None
+        else:
+            try:
+                ext_info = provider(str(target_bot_id))
+            except Exception as exc:
+                logger.warning(
+                    "[SkillSetService] default capabilities ext_info lookup failed for "
+                    "engine_type=%s bot_id=%s: %s",
+                    engine_type,
+                    target_bot_id,
+                    exc,
+                )
+                return None
         return ext_info if isinstance(ext_info, Mapping) else None
 
     def _get_default_capabilities_template_type(
         self,
         bot_id: Optional[str] = None,
+        *,
+        strict: bool = False,
     ) -> str | None:
-        """Best-effort template_type lookup for default-capability bucket routing."""
+        """Resolve template routing context for Default capabilities.
+
+        Runtime projection uses strict mode for the same reason as ext info:
+        a repository failure is not evidence that the Bot has no template.
+        """
         target_bot_id = bot_id or self.bot_id
         if not target_bot_id or not self.entity_id:
+            if strict:
+                raise RuntimeError("Default MCP template context is unavailable")
             return None
-        try:
+        if strict:
             bot = self._bot_repo.get_by_id_and_owner(
                 str(target_bot_id), str(self.entity_id)
             )
-            if isinstance(bot, dict):
-                template_type = bot.get("template_type")
-                if isinstance(template_type, str):
-                    return template_type
-        except Exception as exc:
-            logger.warning(
-                "[SkillSetService] default capabilities template_type lookup failed for "
-                "bot_id=%s: %s",
-                target_bot_id,
-                exc,
-            )
+            if not isinstance(bot, dict):
+                raise RuntimeError("Default MCP template context is unavailable")
+        else:
+            try:
+                bot = self._bot_repo.get_by_id_and_owner(
+                    str(target_bot_id), str(self.entity_id)
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[SkillSetService] default capabilities template_type lookup failed for "
+                    "bot_id=%s: %s",
+                    target_bot_id,
+                    exc,
+                )
+                return None
+        if isinstance(bot, dict):
+            template_type = bot.get("template_type")
+            if isinstance(template_type, str):
+                return template_type
         return None
 
     def _sync_symlinks_to_device_if_needed(
@@ -1455,6 +1483,8 @@ class SkillSetService:
         user_id: str,
         entity_type: str = "staff",
         engine_type: Optional[str] = None,
+        *,
+        strict_policy_context: bool = False,
     ) -> List[dict]:
         """Effective MCPs = default policy ∪ installed.
 
@@ -1479,8 +1509,12 @@ class SkillSetService:
         effective_ext_info = self._get_default_capabilities_ext_info(
             effective_engine,
             bot_id,
+            strict=strict_policy_context,
         )
-        effective_template_type = self._get_default_capabilities_template_type(bot_id)
+        effective_template_type = self._get_default_capabilities_template_type(
+            bot_id,
+            strict=strict_policy_context,
+        )
         active_skill_sets = self._get_all_active_skill_sets_with_default_fallback(
             user_id=entity_id,
             bolt_id=bot_id,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -405,6 +405,9 @@ class SkillSetService:
         """
         provider = self._ext_info_provider
         if provider is None:
+            # Runtime DI always supplies this provider. In strict mode a
+            # missing provider means the service was constructed incorrectly;
+            # it is not evidence that this Bot has no template defaults.
             if strict:
                 raise RuntimeError("Default MCP policy provider is unavailable")
             return None
@@ -443,30 +446,26 @@ class SkillSetService:
             if strict:
                 raise RuntimeError("Default MCP template context is unavailable")
             return None
-        if strict:
+        try:
             bot = self._bot_repo.get_by_id_and_owner(
                 str(target_bot_id), str(self.entity_id)
             )
-            if not isinstance(bot, dict):
+        except Exception as exc:
+            if strict:
+                raise
+            logger.warning(
+                "[SkillSetService] default capabilities template_type lookup failed for "
+                "bot_id=%s: %s",
+                target_bot_id,
+                exc,
+            )
+            return None
+        if not isinstance(bot, dict):
+            if strict:
                 raise RuntimeError("Default MCP template context is unavailable")
-        else:
-            try:
-                bot = self._bot_repo.get_by_id_and_owner(
-                    str(target_bot_id), str(self.entity_id)
-                )
-            except Exception as exc:
-                logger.warning(
-                    "[SkillSetService] default capabilities template_type lookup failed for "
-                    "bot_id=%s: %s",
-                    target_bot_id,
-                    exc,
-                )
-                return None
-        if isinstance(bot, dict):
-            template_type = bot.get("template_type")
-            if isinstance(template_type, str):
-                return template_type
-        return None
+            return None
+        template_type = bot.get("template_type")
+        return template_type if isinstance(template_type, str) else None
 
     def _sync_symlinks_to_device_if_needed(
         self, user_id: str | None = None, desired_skills: list[dict] | None = None

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -113,6 +113,9 @@ from agentclaw.community.core.skill_center.capability_state_contract import (
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectorProtocol as CoreBotRuntimeProjectorProtocol,
 )
+from agentclaw.community.core.skill_center.policies.platform_default_mcp import (
+    PlatformDefaultMcpPolicy,
+)
 from agentclaw.community.core.skill_center.services.bot_capability_state_reader import (
     BotCapabilityStateReader,
 )
@@ -367,6 +370,15 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
     ) -> ApiBotRuntimeProjectorProtocol:
         """Expose that same singleton through the public Service API."""
         return service
+
+    @singleton
+    @provider
+    @inject
+    def platform_default_mcp_policy(
+        self, injector: Injector
+    ) -> PlatformDefaultMcpPolicy:
+        """Strict engine/template Default MCP policy shared by Direct writes."""
+        return PlatformDefaultMcpPolicy(_build__ext_info_provider(injector))
 
     @singleton
     @provider

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
@@ -593,6 +593,28 @@ async def test_mcp_errors_map_to_status_and_fixed_message():
 
 
 @pytest.mark.asyncio
+async def test_platform_default_mcp_direct_conflict_has_a_stable_public_error():
+    import json
+
+    from agentclaw.community.core.skill_center.errors import (
+        SkillSetControlPlaneConflictError,
+    )
+
+    @envelope_errors
+    async def handler(request: Request):
+        raise SkillSetControlPlaneConflictError(
+            "RESOURCE_MANAGED_BY_PLATFORM_POLICY"
+        )
+
+    response = await handler(request=_request())
+    body = json.loads(bytes(response.body))
+
+    assert response.status_code == 409
+    assert body["code"] == 409210
+    assert body["message"] == "Resource is managed by the platform Default policy"
+
+
+@pytest.mark.asyncio
 async def test_mcp_not_found_is_indistinguishable_from_bots_not_found():
     """A missing MCP server and a masked bot 404 answer byte-identical bodies."""
     import json

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -67,6 +67,9 @@ from agentclaw.community.core.skill_center.services.skill_query_service import (
 from agentclaw.community.core.skill_center.services.direct_activation_service import (
     DirectActivationService,
 )
+from agentclaw.community.core.skill_center.policies.platform_default_mcp import (
+    PlatformDefaultMcpPolicy,
+)
 from agentclaw.community.plugin_api.models import BotModel
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
@@ -999,6 +1002,7 @@ async def test_state_command_cannot_cross_the_real_tenant_guard(tmp_path):
         object(),
         object(),
         object(),
+        PlatformDefaultMcpPolicy(lambda _bot_id: None),
     )
     with avernet_tenant_scope("tenant-b"):
         with pytest.raises(LocalSkillNotFoundError):

--- a/src/backend/tests/community/core/skill_center/policies/test_platform_default_mcp.py
+++ b/src/backend/tests/community/core/skill_center/policies/test_platform_default_mcp.py
@@ -6,6 +6,9 @@ from agentclaw.community.core.skill_center.policies import platform_default_mcp
 from agentclaw.community.core.skill_center.policies.platform_default_mcp import (
     PlatformDefaultMcpPolicy,
 )
+from agentclaw.community.core.skill_center.errors import (
+    SkillSetControlPlaneConflictError,
+)
 
 
 def test_resolves_defaults_from_the_exact_bot_context(monkeypatch) -> None:
@@ -60,3 +63,31 @@ def test_policy_context_failure_propagates() -> None:
                 "template_type": "personalCoding",
             }
         )
+
+
+def test_policy_owns_the_direct_control_decision(monkeypatch) -> None:
+    monkeypatch.setattr(
+        platform_default_mcp,
+        "get_default_mcp_server_codes",
+        lambda *_args, **_kwargs: ["mcp.platform"],
+    )
+    policy = PlatformDefaultMcpPolicy(lambda _bot_id: None)
+    bot = {
+        "bot_id": "bot-1",
+        "active_engine": "claude_code",
+        "template_type": "personalCoding",
+    }
+
+    with pytest.raises(
+        SkillSetControlPlaneConflictError,
+        match="RESOURCE_MANAGED_BY_PLATFORM_POLICY",
+    ):
+        policy.require_direct_control_allowed(
+            bot=bot,
+            server_code="mcp.platform",
+        )
+
+    assert policy.require_direct_control_allowed(
+        bot=bot,
+        server_code="mcp.direct",
+    ) == frozenset({"mcp.platform"})

--- a/src/backend/tests/community/core/skill_center/policies/test_platform_default_mcp.py
+++ b/src/backend/tests/community/core/skill_center/policies/test_platform_default_mcp.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.skill_center.policies import platform_default_mcp
+from agentclaw.community.core.skill_center.policies.platform_default_mcp import (
+    PlatformDefaultMcpPolicy,
+)
+
+
+def test_resolves_defaults_from_the_exact_bot_context(monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def resolve(engine_type, template_type, *, ext_info):
+        calls.append(
+            {
+                "engine_type": engine_type,
+                "template_type": template_type,
+                "ext_info": ext_info,
+            }
+        )
+        return ["mcp.platform", "mcp.template"]
+
+    monkeypatch.setattr(
+        platform_default_mcp,
+        "get_default_mcp_server_codes",
+        resolve,
+    )
+    policy = PlatformDefaultMcpPolicy(
+        lambda bot_id: {"template_config": {"bot_id": bot_id}}
+    )
+
+    assert policy.server_codes_for(
+        {
+            "bot_id": "bot-1",
+            "active_engine": "claude_code",
+            "template_type": "personalCoding",
+        }
+    ) == frozenset({"mcp.platform", "mcp.template"})
+    assert calls == [
+        {
+            "engine_type": "claude_code",
+            "template_type": "personalCoding",
+            "ext_info": {"template_config": {"bot_id": "bot-1"}},
+        }
+    ]
+
+
+def test_policy_context_failure_propagates() -> None:
+    def fail(_bot_id: str):
+        raise RuntimeError("template service unavailable")
+
+    policy = PlatformDefaultMcpPolicy(fail)
+
+    with pytest.raises(RuntimeError, match="template service unavailable"):
+        policy.server_codes_for(
+            {
+                "bot_id": "bot-1",
+                "active_engine": "claude_code",
+                "template_type": "personalCoding",
+            }
+        )

--- a/src/backend/tests/community/core/skill_center/services/test_collect_bot_active_mcps_union.py
+++ b/src/backend/tests/community/core/skill_center/services/test_collect_bot_active_mcps_union.py
@@ -68,7 +68,7 @@ class _Bots:
         }
 
 
-def _service(db: _Database, tmp_path) -> SkillSetService:
+def _service(db: _Database, tmp_path, *, ext_info_provider=None) -> SkillSetService:
     skills = SkillRepository(db)
     return SkillSetService(
         skill_repo=skills,
@@ -80,7 +80,10 @@ def _service(db: _Database, tmp_path) -> SkillSetService:
         skills_dir=tmp_path / "skills",
         repo_dir=tmp_path / "skills-repo",
         local_dir=tmp_path / "skills-local",
+        entity_id="owner",
+        bot_id="bot",
         engine_type=_ENGINE,
+        ext_info_provider=ext_info_provider,
         path_factory=MagicMock(),
         reader=BotCapabilityStateReader(
             repository=CapabilityDesiredStateRepository(db),
@@ -206,3 +209,36 @@ def test_a_direct_installation_appears_with_minimal_metadata(tmp_path):
             "is_default": False,
         }
     ]
+
+
+def test_strict_runtime_policy_context_propagates_provider_failure(tmp_path):
+    db = _Database()
+
+    def broken_provider(_bot_id: str):
+        raise RuntimeError("template policy unavailable")
+
+    service = _service(db, tmp_path, ext_info_provider=broken_provider)
+
+    with pytest.raises(RuntimeError, match="template policy unavailable"):
+        service.collect_bot_active_mcps(
+            entity_id="owner",
+            bot_id="bot",
+            user_id="owner",
+            strict_policy_context=True,
+        )
+
+
+def test_strict_runtime_policy_context_propagates_template_lookup_failure(tmp_path):
+    db = _Database()
+    service = _service(db, tmp_path, ext_info_provider=lambda _bot_id: None)
+    service._bot_repo.get_by_id_and_owner.side_effect = RuntimeError(
+        "bot repository unavailable"
+    )
+
+    with pytest.raises(RuntimeError, match="bot repository unavailable"):
+        service.collect_bot_active_mcps(
+            entity_id="owner",
+            bot_id="bot",
+            user_id="owner",
+            strict_policy_context=True,
+        )

--- a/src/backend/tests/community/core/skill_center/services/test_collect_bot_active_mcps_union.py
+++ b/src/backend/tests/community/core/skill_center/services/test_collect_bot_active_mcps_union.py
@@ -242,3 +242,17 @@ def test_strict_runtime_policy_context_propagates_template_lookup_failure(tmp_pa
             user_id="owner",
             strict_policy_context=True,
         )
+
+
+def test_display_read_still_degrades_when_template_lookup_fails(tmp_path):
+    db = _Database()
+    service = _service(db, tmp_path, ext_info_provider=lambda _bot_id: None)
+    service._bot_repo.get_by_id_and_owner.side_effect = RuntimeError(
+        "bot repository unavailable"
+    )
+
+    assert service.collect_bot_active_mcps(
+        entity_id="owner",
+        bot_id="bot",
+        user_id="owner",
+    ) == []

--- a/src/backend/tests/community/core/skill_center/test_direct_activation_service.py
+++ b/src/backend/tests/community/core/skill_center/test_direct_activation_service.py
@@ -170,8 +170,14 @@ class _PlatformDefaultMcpPolicy:
         self.codes = frozenset(codes)
         self.bots: list[dict] = []
 
-    def server_codes_for(self, bot: dict) -> frozenset[str]:
+    def require_direct_control_allowed(
+        self, *, bot: dict, server_code: str
+    ) -> frozenset[str]:
         self.bots.append(bot)
+        if server_code in self.codes:
+            raise SkillSetControlPlaneConflictError(
+                "RESOURCE_MANAGED_BY_PLATFORM_POLICY"
+            )
         return self.codes
 
 

--- a/src/backend/tests/community/core/skill_center/test_direct_activation_service.py
+++ b/src/backend/tests/community/core/skill_center/test_direct_activation_service.py
@@ -14,6 +14,7 @@ from agentclaw.community.core.skill_center.errors import (
     LocalSkillRuntimeSyncError,
     McpPermissionDeniedError,
     SkillSetAccessDeniedError,
+    SkillSetControlPlaneConflictError,
 )
 from agentclaw.community.core.skill_center.services.direct_activation_service import (
     DirectActivationService,
@@ -164,6 +165,16 @@ class _Reader:
         return frozenset({"mcp.weather"})
 
 
+class _PlatformDefaultMcpPolicy:
+    def __init__(self, *codes: str) -> None:
+        self.codes = frozenset(codes)
+        self.bots: list[dict] = []
+
+    def server_codes_for(self, bot: dict) -> frozenset[str]:
+        self.bots.append(bot)
+        return self.codes
+
+
 def _service(
     *,
     repository=None,
@@ -172,6 +183,7 @@ def _service(
     mcp_center=None,
     reader=None,
     audit=None,
+    platform_default_mcp_policy=None,
 ) -> DirectActivationService:
     return DirectActivationService(
         repository if repository is not None else _Repository(),
@@ -182,6 +194,9 @@ def _service(
         audit if audit is not None else _Audit(),
         mcp_center if mcp_center is not None else _McpCenter(allowed=True),
         reader if reader is not None else _Reader(),
+        platform_default_mcp_policy
+        if platform_default_mcp_policy is not None
+        else _PlatformDefaultMcpPolicy(),
     )
 
 
@@ -202,6 +217,7 @@ async def test_mcp_direct_activation_checks_permission_before_writing():
             "bot_id": "bot-1",
             "owner_id": "true-owner",
             "server_code": "mcp.weather",
+            "platform_default_codes": frozenset(),
             **_SCOPE,
         }
     ]
@@ -237,9 +253,39 @@ async def test_mcp_direct_deactivation_needs_no_marketplace_permission():
             "bot_id": "bot-1",
             "owner_id": "true-owner",
             "server_code": "mcp.weather",
+            "platform_default_codes": frozenset(),
             **_SCOPE,
         }
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method_name", ["activate_mcp", "deactivate_mcp"])
+async def test_platform_default_mcp_refuses_direct_control(method_name: str):
+    repository = _Repository()
+    mcp_center = _McpCenter(allowed=True)
+    policy = _PlatformDefaultMcpPolicy("mcp.policy")
+    service = _service(
+        repository=repository,
+        mcp_center=mcp_center,
+        platform_default_mcp_policy=policy,
+    )
+
+    with pytest.raises(
+        SkillSetControlPlaneConflictError,
+        match="RESOURCE_MANAGED_BY_PLATFORM_POLICY",
+    ):
+        await getattr(service, method_name)(
+            bot_id="bot-1",
+            owner_id="true-owner",
+            actor_id="true-owner",
+            server_code="mcp.policy",
+        )
+
+    assert policy.bots[0]["bot_id"] == "bot-1"
+    assert repository.install_mcp_calls == []
+    assert repository.uninstall_mcp_calls == []
+    assert mcp_center.calls == []
 
 
 @pytest.mark.asyncio
@@ -347,6 +393,7 @@ async def test_a_not_ready_bot_refuses_before_any_write():
     service = DirectActivationService(
         repository, _PendingBots(), _Skills(), _SuccessfulRuntime(),
         _Authorization(), _Audit(), _McpCenter(allowed=True), _Reader(),
+        _PlatformDefaultMcpPolicy(),
     )
 
     with pytest.raises(LocalSkillNotReadyError):
@@ -375,6 +422,7 @@ async def test_a_space_asset_and_a_mismatched_local_row_are_masked_as_not_found(
     service = DirectActivationService(
         repository, _Bots(), _MoreSkills(), _SuccessfulRuntime(),
         _Authorization(), _Audit(), _McpCenter(allowed=True), _Reader(),
+        _PlatformDefaultMcpPolicy(),
     )
 
     # A Space (center://) asset has no direct-activation wire.

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -498,6 +498,19 @@ class _OverlappingCollectFactory(_RuntimeFactory):
         self.service = _OverlappingCollectService()
 
 
+class _FailingPolicyCollectService(_RuntimeFactoryService):
+    def collect_bot_active_mcps(self, **kwargs) -> list[dict]:
+        self.collect_calls.append(kwargs)
+        assert kwargs["strict_policy_context"] is True
+        raise RuntimeError("template policy unavailable")
+
+
+class _FailingPolicyCollectFactory(_RuntimeFactory):
+    def __init__(self) -> None:
+        super().__init__()
+        self.service = _FailingPolicyCollectService()
+
+
 class _RuntimeBots:
     def get_by_id_and_owner(self, bot_id: str, owner_id: str) -> dict:
         assert (bot_id, owner_id) == ("bot-1", "true-owner")
@@ -1768,6 +1781,27 @@ async def test_runtime_projection_fails_before_engine_writes_when_flush_fails():
 
 
 @pytest.mark.asyncio
+async def test_runtime_projection_fails_closed_when_default_mcp_policy_is_unavailable():
+    factory = _FailingPolicyCollectFactory()
+    passport = _RuntimePassport()
+    runtime = BotRuntimeProjector(
+        factory=factory,
+        bot_repo=_RuntimeBots(),
+        repository=_McpInstallations(),
+        reader=_reader(_RuntimeSkills()),
+        pool_runtime=_RuntimePool(),
+        pool_layouts=_RuntimeLayouts(),
+        passport=passport,
+    )
+
+    with pytest.raises(SkillSetRuntimeReconcileError):
+        await runtime.project(bot_id="bot-1", owner_id="true-owner")
+
+    assert factory.service.mcp_codes is None
+    assert passport.calls == []
+
+
+@pytest.mark.asyncio
 async def test_runtime_projection_mcp_inputs_agree_when_the_union_overlaps():
     """installed ∪ effective_default: a code arriving through both inputs —
     the repo's installed listing and the collect union that now contains
@@ -1828,6 +1862,7 @@ async def test_runtime_reconcile_projects_full_mcp_desired_state():
             "user_id": "true-owner",
             "entity_type": "staff",
             "engine_type": "openclaw",
+            "strict_policy_context": True,
         }
     ]
     assert passport.calls == [
@@ -2302,5 +2337,4 @@ async def test_unexcluding_a_default_mcp_still_requires_marketplace_permission()
             set_id="9", server_code="mcp.back",
         )
     assert repository.exclusion_calls == []
-
 

--- a/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
@@ -24,6 +24,9 @@ from agentclaw.community.core.skill_center.capability_state_contract import (
 from agentclaw.community.core.skill_center.services.direct_activation_service import (
     DirectActivationService,
 )
+from agentclaw.community.core.skill_center.policies.platform_default_mcp import (
+    PlatformDefaultMcpPolicy,
+)
 from agentclaw.community.core.skill_center.authorization_hook import (
     BotCapabilityAuthorizationHookProtocol,
 )
@@ -188,6 +191,7 @@ def _seed(world, *, member: bool = False) -> None:
         world.get(BotCollabLogRepositoryProtocol),
         world.get(MCPCenterPlugin),
         world.get(BotCapabilityStateReaderProtocol),
+        PlatformDefaultMcpPolicy(lambda _bot_id: None),
     )
     world.injector.binder.bind(
         DirectActivationServiceProtocol, to=direct, scope=None

--- a/src/backend/tests/community/endpoints/test_openapi_skill_state.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_state.py
@@ -29,6 +29,9 @@ from agentclaw.community.core.skill_center.authorization_hook import (
 from agentclaw.community.core.skill_center.services.direct_activation_service import (
     DirectActivationService,
 )
+from agentclaw.community.core.skill_center.policies.platform_default_mcp import (
+    PlatformDefaultMcpPolicy,
+)
 from agentclaw.community.plugin_api.mcp_center import MCPCenterPlugin
 from agentclaw.community.core.repository.protocols.skill_center import (
     SkillSetRepository,
@@ -185,6 +188,7 @@ def _seed_state(world, *, runtime_success: bool) -> None:
                 bot_repo=world.get(BotRepository),
                 pool_skills=world.get(SkillRepository),
             ),
+            PlatformDefaultMcpPolicy(lambda _bot_id: None),
         ),
         scope=None,
     )

--- a/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
@@ -549,7 +549,8 @@ def test_mcp_direct_and_skill_set_ownership_conflicts_are_enforced():
         session.flush()
 
     assert repository.install_mcp(
-        bot_id="bot", owner_id="owner", server_code="mcp.weather"
+        bot_id="bot", owner_id="owner", server_code="mcp.weather",
+        platform_default_codes=frozenset(),
     ).changed
     with pytest.raises(
         SkillSetControlPlaneConflictError, match="RESOURCE_DIRECT_ACTIVE"
@@ -558,7 +559,8 @@ def test_mcp_direct_and_skill_set_ownership_conflicts_are_enforced():
             bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather"
         )
     assert repository.uninstall_mcp(
-        bot_id="bot", owner_id="owner", server_code="mcp.weather"
+        bot_id="bot", owner_id="owner", server_code="mcp.weather",
+        platform_default_codes=frozenset(),
     ).changed
     assert repository.add_mcp(
         bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather"
@@ -567,8 +569,25 @@ def test_mcp_direct_and_skill_set_ownership_conflicts_are_enforced():
         SkillSetControlPlaneConflictError, match="RESOURCE_MANAGED_BY_SKILL_SET"
     ):
         repository.install_mcp(
-            bot_id="bot", owner_id="owner", server_code="mcp.weather"
+            bot_id="bot", owner_id="owner", server_code="mcp.weather",
+            platform_default_codes=frozenset(),
         )
+
+
+def test_platform_default_mcp_refuses_direct_install_and_uninstall():
+    repository = CapabilityDesiredStateRepository(_Database())
+
+    for command in (repository.install_mcp, repository.uninstall_mcp):
+        with pytest.raises(
+            SkillSetControlPlaneConflictError,
+            match="RESOURCE_MANAGED_BY_PLATFORM_POLICY",
+        ):
+            command(
+                bot_id="bot",
+                owner_id="owner",
+                server_code="mcp.policy",
+                platform_default_codes=frozenset({"mcp.policy"}),
+            )
 
 
 def test_direct_mcp_installation_isolated_by_owner_for_shared_bot_id():
@@ -576,13 +595,16 @@ def test_direct_mcp_installation_isolated_by_owner_for_shared_bot_id():
     repository = CapabilityDesiredStateRepository(db)
 
     assert repository.install_mcp(
-        bot_id="default", owner_id="owner-a", server_code="mcp.weather"
+        bot_id="default", owner_id="owner-a", server_code="mcp.weather",
+        platform_default_codes=frozenset(),
     ).changed
     assert repository.install_mcp(
-        bot_id="default", owner_id="owner-b", server_code="mcp.weather"
+        bot_id="default", owner_id="owner-b", server_code="mcp.weather",
+        platform_default_codes=frozenset(),
     ).changed
     assert repository.uninstall_mcp(
-        bot_id="default", owner_id="owner-a", server_code="mcp.weather"
+        bot_id="default", owner_id="owner-a", server_code="mcp.weather",
+        platform_default_codes=frozenset(),
     ).changed
 
     with db.orm_session() as session:
@@ -2135,8 +2157,14 @@ def test_an_excluded_default_member_refuses_direct_control_for_skills_and_mcps()
     for command, address in [
         (repository.install_skill, dict(skill_id=str(skill.id))),
         (repository.uninstall_skill, dict(skill_id=str(skill.id))),
-        (repository.install_mcp, dict(server_code="mcp.member")),
-        (repository.uninstall_mcp, dict(server_code="mcp.member")),
+        (
+            repository.install_mcp,
+            dict(server_code="mcp.member", platform_default_codes=frozenset()),
+        ),
+        (
+            repository.uninstall_mcp,
+            dict(server_code="mcp.member", platform_default_codes=frozenset()),
+        ),
     ]:
         with pytest.raises(
             SkillSetControlPlaneConflictError, match="RESOURCE_MANAGED_BY_SKILL_SET"
@@ -2469,17 +2497,25 @@ def test_excluding_a_stray_mcp_code_owns_neither_half():
         assert session.query(BotMCPInstallation).count() == 1
 
 
-def test_excluding_a_platform_default_mcp_without_membership_writes_the_row():
-    """The half a membership-only guard would break (spec A.2).
+def test_excluding_a_platform_default_mcp_retires_a_legacy_direct_row():
+    """Policy exclusion converges rows written before Direct control was banned.
 
     Engine/template default MCPs are policy, not association rows, so the
     caller names them; excluding one writes the exclusion row — that row is
-    exactly how a Bot opts out of a platform default — with no Installation
-    delta, because policy defaults were never installed rows.
+    exactly how a Bot opts out of a platform default. Any Installation row for
+    the same code is a legacy Direct-control artifact and must be removed or it
+    would immediately bypass the exclusion through the installed union half.
     """
     db = _Database()
     repository = CapabilityDesiredStateRepository(db)
     default, _skill = _seed_default_with_member(db)
+    with db.transactional_orm_session() as session:
+        session.add(
+            BotMCPInstallation(
+                bot_id="bot", owner_id="owner",
+                server_code="mcp.platform", env="dev",
+            )
+        )
 
     excluded = repository.exclude_default_mcp(
         set_id=str(default.id), server_code="mcp.platform",
@@ -2489,10 +2525,31 @@ def test_excluding_a_platform_default_mcp_without_membership_writes_the_row():
     assert excluded.changed is True
     with db.orm_session() as session:
         assert session.query(DefaultSkillsetMcpExclusion).count() == 1
-        assert session.query(BotMCPInstallation).count() == 1
+        assert {
+            row.server_code for row in session.query(BotMCPInstallation).all()
+        } == {"mcp.member"}
     assert repository.excluded_default_mcp_codes(
         bot_id="bot", owner_id="owner", set_id=str(default.id)
     ) == {"mcp.platform"}
+
+    # Idempotent exclusion is also a repair point for a row written by an old
+    # process racing this deployment.
+    with db.transactional_orm_session() as session:
+        session.add(
+            BotMCPInstallation(
+                bot_id="bot", owner_id="owner",
+                server_code="mcp.platform", env="dev",
+            )
+        )
+    repaired = repository.exclude_default_mcp(
+        set_id=str(default.id), server_code="mcp.platform",
+        platform_default_codes=frozenset({"mcp.platform"}), **_DEFAULT_SCOPE
+    )
+    assert repaired.changed is True
+    with db.orm_session() as session:
+        assert {
+            row.server_code for row in session.query(BotMCPInstallation).all()
+        } == {"mcp.member"}
 
 
 def test_restore_desired_state_preserves_mcp_membership_metadata():


### PR DESCRIPTION
## Problem

PR #1437 established Installation as the Bot effective-capability fact, while engine/template Default MCPs remain an unmaterialized platform policy input. Two gaps could violate that boundary:

- Direct MCP activate/deactivate could control a platform Default MCP, even though Installation has no provenance for safely separating Direct state from platform policy.
- Runtime projection treated a failed template/ext-context lookup as an empty or narrower Default policy and could overwrite the runtime with missing MCPs.

Existing exclusion rows could also leave legacy same-code Installation rows behind, allowing the Installation half of the runtime union to bypass the exclusion.

## Solution

- Add a strict `PlatformDefaultMcpPolicy` that resolves engine/template Default MCP codes for the exact Bot context.
- Reject Direct activation and deactivation for platform Default MCPs in both the command service and transactional repository boundary. Default exclusion/un-exclusion remains their only control surface.
- Make Default MCP exclusion retire legacy same-code Installation rows even when the exclusion row already exists.
- Make Runtime projection resolve both ext info and template type strictly, and fail before overwrite-style MCP or Passport delivery when policy context is unavailable.
- Add a stable HTTP conflict mapping for platform-policy-owned resources and document the ownership boundary.

## Validation

- `uv run --project src/backend pytest src/backend/tests/community/core/skill_center src/backend/tests/community/repository/skill_center src/backend/tests/community/adapters/http/openapi_v1/test_mcp_control_endpoints.py src/backend/tests/community/architecture/test_installation_table_write_ownership.py src/backend/tests/community/architecture/test_no_legacy_activation_writers.py src/backend/tests/community/architecture/test_service_api_conformance.py -q`
  - 1053 passed, 27 skipped.
- Focused P1 regression suite: 187 passed.
- Blocking SAST rules over every changed Python file: passed.
- `git diff --check`: passed.
- The repository-wide source scan still reports seven pre-existing F821 findings in `core/skill_center/factories.py`; that file is unchanged by this PR.

## Compatibility and risk

- No schema or migration changes.
- Direct operations on engine/template Default MCPs now return conflict code `409210`; callers must use Default exclusion/un-exclusion instead.
- Internal desired-state repository MCP methods now require the already-resolved platform Default code set, ensuring the transactional boundary rechecks ownership.
- Rollback is the single commit in this PR.

## Spec

- Implements the approved Platform Default MCP ownership semantics on top of the Installation single-source-of-truth design: https://github.com/inclusionAI/Avernet/blob/c69b62ea60a0416733a536b296a09e7fab140872/src/backend/specs/2026-08-24-installation-single-source-of-truth/spec.md

## Related issues

- Follow-up to #1437.