### PR TITLE
fix(skillset): activate newly created sets by default

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_set_control_plane.py
@@ -161,7 +161,7 @@ class SkillSetControlPlaneRepository(
                 user_id=owner_id,
                 is_default=False,
                 is_builtin=False,
-                is_active=False,
+                is_active=True,
                 env=get_current_env(),
                 avernet_tenant=get_current_avernet_tenant(),
                 engine_type=engine_type,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -141,9 +141,10 @@ class SkillSetControlPlaneService:
         description: str | None,
     ) -> dict:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
-        # Creating an inactive SkillSet is metadata-only: it neither changes
-        # the effective capability projection nor has a compensating runtime
-        # action, so it does not enter the Pool edit boundary.
+        # A newly created empty SkillSet is active by default, matching the
+        # legacy create semantics. With no members it does not change the
+        # effective capability projection, so it does not enter the Pool edit
+        # boundary or require a runtime action.
         item = self._repository.create_set(
             bot_id=bot_id,
             owner_id=str(bot["owner_id"]),

--- a/src/backend/tests/community/acceptance/harness/test_diagnose_tools_mcp_format.py
+++ b/src/backend/tests/community/acceptance/harness/test_diagnose_tools_mcp_format.py
@@ -2,7 +2,7 @@
 
 Companion to ``test_diagnose_llm_disabled_smoke.py``. That story pins the
 empty-config guard on a fresh bot; this one pins that a bot with a non-empty
-TOOLS.md plus an activated, schema-bearing MCP drives
+TOOLS.md plus a schema-bearing MCP association drives
 ``ToolsMcpFormatDiagnostic.analyze`` through the prompt-slimming helpers
 (``_compact_tool_for_prompt`` / ``_compact_mcp_tools_for_prompt`` /
 ``_format_mcp_block``) — the code that keeps MCP-heavy bots under antchat's
@@ -72,8 +72,10 @@ def test_diagnose_tools_mcp_format_runs_prompt_helpers(
         )
         assert write.status_code == 200, write.text
 
-        # Activate the schema-bearing fixture MCP on the bot via a skill-set, so
-        # bot_profile.get_activated_mcps returns it during the scan.
+        # Register the schema-bearing fixture MCP through a deliberately
+        # inactive SkillSet. This test covers prompt construction from persisted
+        # MCP metadata, not runtime projection; create defaults to active, so
+        # the fixture must opt out before mutating membership.
         skillset = assert_success(
             client.post(
                 "/api/skillsets",
@@ -86,6 +88,12 @@ def test_diagnose_tools_mcp_format_runs_prompt_helpers(
             )
         )
         skill_set_id = skillset["data"]["id"]
+        deactivate = client.post(
+            "/api/skillsets/admin/set-skillset-active",
+            json={"env": "dev", "skillset_id": skill_set_id, "is_active": 0},
+        )
+        assert deactivate.status_code == 200, deactivate.text
+        assert deactivate.json().get("success") is True, deactivate.json()
         add_mcp = client.post(
             f"/api/skillsets/{skill_set_id}/mcps",
             params={

--- a/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_control_plane_service.py
@@ -79,7 +79,7 @@ class _CreateRepository(_Repository):
             "name": kwargs["name"],
             "bolt_id": kwargs["bot_id"],
             "is_default": False,
-            "is_active": False,
+            "is_active": True,
         }
 
 
@@ -923,7 +923,7 @@ def test_addressed_create_persists_metadata_without_runtime_reconcile() -> None:
     ]
 
 
-def test_create_inactive_set_does_not_require_runtime_readiness() -> None:
+def test_create_active_empty_set_does_not_require_runtime_readiness() -> None:
     repository = _CreateRepository()
     service = SkillSetControlPlaneService(
         repository=repository,
@@ -945,7 +945,7 @@ def test_create_inactive_set_does_not_require_runtime_readiness() -> None:
         description=None,
     )
 
-    assert result["is_active"] is False
+    assert result["is_active"] is True
     assert repository.create_calls[0]["engine_type"] == "claude_code"
 
 

--- a/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
@@ -251,6 +251,18 @@ def _assert_default_mcp_excluded(_response, world) -> None:
             )
 
 
+def _seed_inactive(world) -> None:
+    _seed(world)
+    with avernet_tenant_scope(_TENANT):
+        world.get(SkillSetControlPlaneRepositoryProtocol).set_active(
+            bot_id=_BOT_ID,
+            owner_id=_OWNER,
+            set_id="1",
+            active=False,
+            engine_type="openclaw",
+        )
+
+
 def _assert_reconciled(_response, world) -> None:
     assert world.get(SkillSetControlPlaneServiceProtocol)._runtime.calls == [
         (_BOT_ID, _OWNER)
@@ -312,8 +324,8 @@ def list_sets_error():
 @_case(
     "POST",
     "/openapi/v1/bots/{bot_id}/skill-sets",
-    "creates_inactive_set",
-    ExpectSuccess(status=201, json_contains={"data": {"is_active": False}}),
+    "creates_active_set",
+    ExpectSuccess(status=201, json_contains={"data": {"is_active": True}}),
     json_body={"name": "Created"},
     headers={**_HEADERS, "Idempotency-Key": "create-set"},
 )
@@ -410,6 +422,7 @@ def update_set_error():
     "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}",
     "deletes_inactive_set",
     ExpectSuccess(status=200, json_contains={"data": {"deleted": True}}),
+    seed=_seed_inactive,
 )
 def delete_set_happy():
     pass

--- a/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
@@ -725,6 +725,7 @@ def test_create_rejects_a_duplicate_name_without_a_durable_replay_record():
         description="description",
     )
     assert first["name"] == "set"
+    assert first["is_active"] is True
     with pytest.raises(SkillSetControlPlaneConflictError, match="SKILL_SET_NAME_CONFLICT"):
         repository.create_set(
             bot_id="bot", owner_id="owner", name="set", description="description"


### PR DESCRIPTION
## Summary
- Restore historical behavior: newly created skill sets start active.
- Keep empty-set creation free of runtime projection changes.
- Add persistence and service-level regression coverage.

## Validation
- `uv run pytest tests/community/repository/skill_center/test_skill_set_control_plane_uow.py tests/community/core/skill_center/test_skill_set_control_plane_service.py -q`
- 93 passed