### PR TITLE
Fix sidecar conf

### DIFF
--- a/docker/agent/avernet-sidecar/iptables-setup.sh
+++ b/docker/agent/avernet-sidecar/iptables-setup.sh
@@ -93,6 +93,10 @@ setup_chains() {
     # 放行 80/443 (已被 nat 重定向到 Envoy)
     iptables -A ${SIDECAR_FILTER} -p tcp -m multiport --dports 80,443 -j ACCEPT
 
+    # 放行已建立连接的响应流量 (入站请求的响应包目标端口是客户端随机端口, 不在 80/443)
+    # 必须在 REJECT 之前, 否则响应包被 RST 导致入站请求超时
+    iptables -A ${SIDECAR_FILTER} -p tcp -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
     # 拒绝其他所有出站 TCP (REJECT 发送 RST)
     iptables -A ${SIDECAR_FILTER} -p tcp -j REJECT --reject-with tcp-reset
 }

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox.py
@@ -145,31 +145,46 @@ class AliyunAckSandbox(ArcaSandbox):
         return int((created_epoch_s + ttl * 60) * 1000)
 
     def destroy(self) -> bool:
-        """Delete the backing Deployment. Idempotent on 404.
+        """Delete the backing Deployment and associated resources. Idempotent on 404.
 
-        The PVC is NOT deleted here — it is an independent resource so data
-        survives Deployment deletion.
+        Removes the Deployment, ConfigMap, and NetworkPolicy created from
+        the template. The PVC is NOT deleted — it is an independent resource
+        so data survives Deployment deletion.
         """
         logger.info(
             "[aliyun_ack] destroy sandbox_id=%s deployment=%s",
             self._sandbox_id,
             self._deployment_name,
         )
-        try:
-            apps_api = AppsV1Api(self._client)
-            apps_api.delete_namespaced_deployment(
-                name=self._deployment_name,
-                namespace=self._namespace,
-            )
-            return True
-        except ApiException as e:
-            if e.status == 404:
-                logger.info(
-                    "[aliyun_ack] destroy: deployment %s already gone (404), idempotent",
-                    self._deployment_name,
-                )
-                return True
-            raise RuntimeError(f"destroy failed ({e.status})") from e
+        uid = self._deployment_name.removeprefix("avernet-agent-")
+        core_api = CoreV1Api(self._client)
+        for name, delete_fn in (
+            (
+                self._deployment_name,
+                lambda: AppsV1Api(self._client).delete_namespaced_deployment(
+                    name=self._deployment_name, namespace=self._namespace
+                ),
+            ),
+            (
+                f"envoy-header-rules-{uid}",
+                lambda: core_api.delete_namespaced_config_map(
+                    name=f"envoy-header-rules-{uid}", namespace=self._namespace
+                ),
+            ),
+            (
+                f"avernet-agent-netpol-{uid}",
+                lambda: core_api.delete_namespaced_network_policy(
+                    name=f"avernet-agent-netpol-{uid}", namespace=self._namespace
+                ),
+            ),
+        ):
+            try:
+                delete_fn()
+            except ApiException as e:
+                if e.status != 404:
+                    raise RuntimeError(f"destroy failed ({e.status})") from e
+                logger.info("[aliyun_ack] destroy: %s already gone (404)", name)
+        return True
 
     def exec_command(
         self,

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/template/ALIYUN_ACK_DEFAULT.yaml
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/template/ALIYUN_ACK_DEFAULT.yaml
@@ -80,18 +80,3 @@ spec:
       - name: header-rules
         configMap:
           name: envoy-header-rules-${UID}
----
-# ===== 3. NetworkPolicy (deny all ingress) =====
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: avernet-agent-netpol-${UID}
-  namespace: ${NAMESPACE}
-spec:
-  podSelector:
-    matchLabels:
-      app: avernet-agent
-      biz-id: "${UID}"
-  policyTypes:
-  - Ingress
-  ingress: []


### PR DESCRIPTION
    RESPONSE packets from inbound connections (e.g. agent responding on
    port 20003 to an external client) go through OUTPUT → SIDECAR_FILTER.
    Their destination port is the client's random port (not 80/443), so
    they hit the REJECT rule, causing timeouts for anyone accessing the
    agent pod.
    
    Fix: add conntrack --ctstate ESTABLISHED,RELATED ACCEPT before REJECT.
    New outbound connections to non-HTTP ports are still blocked; only
    packets belonging to already-established connections pass through.