### PR TITLE
fix(backend): preserve SkillSet MCP catalog metadata

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
@@ -63,6 +63,7 @@ class McpSkillSetControlPlaneCommands:
 
     def add_mcp(
         self, *, bot_id: str, owner_id: str, set_id: str, server_code: str,
+        name: str, description: str | None, icon: str | None,
         engine_type: str | None = None,
         default_engine_types: tuple[str, ...] | None = None,
     ) -> SkillSetMutation:
@@ -93,7 +94,8 @@ class McpSkillSetControlPlaneCommands:
             if owner is not None:
                 raise SkillSetControlPlaneConflictError("RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET")
             session.add(SkillSetMCPServer(
-                skill_set_id=row.id, server_code=server_code, name=server_code,
+                skill_set_id=row.id, server_code=server_code, name=name,
+                description=description, icon=icon,
                 user_id=row.user_id, env=get_current_env(),
                 avernet_tenant=get_current_avernet_tenant(),
             ))

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_set_control_plane.py
@@ -137,6 +137,9 @@ class SkillSetControlPlaneRepositoryProtocol(Protocol):
         owner_id: str,
         set_id: str,
         server_code: str,
+        name: str,
+        description: str | None,
+        icon: str | None,
         engine_type: str | None = None,
         default_engine_types: tuple[str, ...] | None = None,
     ) -> SkillSetMutation: ...

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_control_plane.py
@@ -411,6 +411,11 @@ class SkillSetControlPlaneService:
         runtime_required = self._set_is_active(
             bot=bot, bot_id=bot_id, set_id=set_id
         )
+        detail = self._mcp_center.get_mcp_detail(server_code)
+        if detail is None:
+            raise SkillSetControlPlaneNotFoundError(
+                f"MCP server '{server_code}' not found"
+            )
         return await self._mutate(
             bot=bot,
             bot_id=bot_id,
@@ -422,6 +427,9 @@ class SkillSetControlPlaneService:
                 owner_id=str(bot["owner_id"]),
                 set_id=set_id,
                 server_code=server_code,
+                name=str(detail.get("name") or server_code),
+                description=detail.get("description"),
+                icon=detail.get("icon"),
                 engine_type=self._engine(bot),
                 default_engine_types=self._default_engine_types(bot),
             ),

--- a/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_sets.py
@@ -556,8 +556,52 @@ def _seed_mcp_member(world) -> None:
             owner_id=_OWNER,
             set_id="1",
             server_code="mcp.test",
+            name="Test MCP",
+            description=None,
+            icon=None,
             engine_type="openclaw",
         )
+
+
+def _seed_mcp_catalog(world) -> None:
+    world.get(MCPCenterPlugin).set_override(
+        "get_mcp_detail",
+        lambda server_code: {
+            "serverCode": server_code,
+            "name": "Dima MCP",
+            "description": "Dima workflow tools",
+            "icon": "https://example.test/dima.png",
+        },
+    )
+    _seed(world)
+
+
+def _assert_mcp_catalog_metadata_persisted(_response, world) -> None:
+    with avernet_tenant_scope(_TENANT):
+        assert world.get(SkillSetControlPlaneServiceProtocol).list_mcps(
+            bot_id=_BOT_ID,
+            owner_id=_OWNER,
+            user_id=_OWNER,
+            set_id="1",
+        ) == [
+            {
+                "id": "1",
+                "server_code": "mcp.test",
+                "name": "Dima MCP",
+                "description": "Dima workflow tools",
+                "icon": "https://example.test/dima.png",
+            }
+        ]
+
+
+def _assert_no_mcp_membership(_response, world) -> None:
+    with avernet_tenant_scope(_TENANT):
+        assert world.get(SkillSetControlPlaneServiceProtocol).list_mcps(
+            bot_id=_BOT_ID,
+            owner_id=_OWNER,
+            user_id=_OWNER,
+            set_id="1",
+        ) == []
 
 
 @_case("GET", "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps", "lists_mcps", ExpectSuccess(status=200, json_contains={"data": []}))
@@ -570,8 +614,31 @@ def list_mcps_error():
     pass
 
 
-@_case("PUT", "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps/{server_code}", "adds_mcp", ExpectSuccess(status=200, json_contains={"data": {"changed": True}}))
+@_case(
+    "PUT",
+    "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps/{server_code}",
+    "adds_mcp_with_catalog_metadata",
+    ExpectSuccess(status=200, json_contains={"data": {"changed": True}}),
+    seed=_seed_mcp_catalog,
+    extra=(_assert_mcp_catalog_metadata_persisted,),
+)
 def add_mcp_happy():
+    pass
+
+
+@_case(
+    "PUT",
+    "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/mcps/{server_code}",
+    "rejects_missing_mcp_catalog_entry",
+    ExpectError(status=404),
+    path_params={
+        "bot_id": _BOT_ID,
+        "set_id": "1",
+        "server_code": "mcp.unknown",
+    },
+    extra=(_assert_no_mcp_membership,),
+)
+def add_missing_mcp_error():
     pass
 
 

--- a/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_set_control_plane_uow.py
@@ -638,6 +638,9 @@ def test_mcp_membership_is_independent_for_two_owners_sharing_default_bot_id():
         owner_id="owner-a",
         set_id=str(owner_a.id),
         server_code="mcp.weather",
+        name="Weather",
+        description=None,
+        icon=None,
     )
 
     assert result.changed is True
@@ -816,11 +819,16 @@ def test_active_skill_set_mutates_mcp_membership_and_installation_atomically():
         session.flush()
 
     added = repository.add_mcp(
-        bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather"
+        bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather",
+        name="Weather MCP", description="Weather tools",
+        icon="https://example.test/weather.png",
     )
     assert added.changed is True
     with db.orm_session() as session:
-        assert session.query(SkillSetMCPServer).count() == 1
+        membership = session.query(SkillSetMCPServer).one()
+        assert (membership.name, membership.description, membership.icon) == (
+            "Weather MCP", "Weather tools", "https://example.test/weather.png",
+        )
         assert {
             row.server_code for row in session.query(BotMCPInstallation).all()
         } == {"mcp.weather"}
@@ -849,13 +857,15 @@ def test_mcp_direct_and_skill_set_ownership_conflicts_are_enforced():
         SkillSetControlPlaneConflictError, match="RESOURCE_DIRECT_ACTIVE"
     ):
         repository.add_mcp(
-            bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather"
+            bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather",
+            name="Weather", description=None, icon=None,
         )
     assert repository.deactivate_mcp_direct(
         bot_id="bot", owner_id="owner", server_code="mcp.weather"
     ).changed
     assert repository.add_mcp(
-        bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather"
+        bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather",
+        name="Weather", description=None, icon=None,
     ).changed
     with pytest.raises(
         SkillSetControlPlaneConflictError, match="RESOURCE_MANAGED_BY_SKILL_SET"


### PR DESCRIPTION
## Problem

After the SkillSet control-plane refactor, adding an MCP persisted `ac_skill_set_mcp.name` as the raw `server_code` and dropped description/icon. Both the legacy BFF and OpenAPI Gateway list paths therefore displayed identifiers such as `mcp.ant.arkai.dimamcpserver` instead of the MCP Center display name.

## Solution

- Resolve MCP Center detail after permission and SkillSet-scope validation.
- Pass name, description, and icon through the repository contract.
- Persist the catalog metadata in the same membership transaction.
- Fail closed with 404 when the catalog entry no longer exists, without creating a membership.

## Validation

- Regression loop first failed with persisted `name=mcp.test`, then passed with `name=Dima MCP` plus description/icon.
- Gateway endpoint cases: 3 passed.
- Control-plane, repository, and legacy BFF adapter tests: 114 passed.
- Repository/module-boundary/protocol architecture tests: 13 passed.
- Changed-file Python SAST block scan: passed.

## Compatibility and risk

No HTTP request or response schema changes. BFF and Gateway share the same control-plane implementation and now restore the pre-refactor metadata snapshot semantics. Existing malformed rows are intentionally not changed by this PR; they require a separately reviewed DB correction after deployment.