### PR TITLE
feat(backend): make the community profile deployable on a managed MySQL

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -66,6 +66,10 @@ dependencies = [
   # to match the 3.x API (BackgroundScheduler, CronTrigger.from_crontab);
   # APScheduler 4.x is a breaking rewrite with a different API surface.
   "apscheduler>=3.10.0,<4.0.0",
+  # PyMySQL: the DBAPI behind `database.backend: mysql` (mysql+pymysql://…), the
+  # community path for a managed MySQL instance. Pure Python, so it needs no
+  # libmysqlclient in the runtime image. SQLite deployments never import it.
+  "pymysql>=1.1.0",
 ]
 
 # Community test tooling — so the extracted community repo can run its own CI.

--- a/src/backend/scripts/community_selftest.py
+++ b/src/backend/scripts/community_selftest.py
@@ -59,6 +59,16 @@ def verify_boot() -> tuple[bool, str]:
     env.pop("REAL_SERVER_ENV", None)
     env.pop("ALIPAY_APP_ENV", None)
     env["PYTHONPATH"] = str(_SRC)
+    # The community overlay's database.url is `${DATABASE_URL}` with no inline
+    # default — the deployed profile requires a real DSN and fails the boot
+    # without one. This gate proves "corp is absent and the app still wires up",
+    # not "a database is reachable", so it supplies the DSN a deployment would.
+    # Nothing here connects: the proof below builds the injector, and
+    # create_engine does not open a socket. Schema DDL only runs under the
+    # lifespan, which the proof never enters.
+    env.setdefault(
+        "DATABASE_URL", "mysql+pymysql://selftest:selftest@127.0.0.1:3306/agentclaw"
+    )
     rc, out = _run([sys.executable, "-c", _BOOT_PROOF], env, timeout=120)
     return rc == 0 and "COMMUNITY_BOOT_OK" in out, out
 

--- a/src/backend/src/agentclaw/community/configs/application-community.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-community.yaml
@@ -115,6 +115,11 @@ user_config:
   # Keep passwords out of this file: the URL is an env placeholder, expanded at
   # config load. A managed-MySQL deployment sets DATABASE_URL from a Secret, e.g.
   #   mysql+pymysql://user:pass@rds-host:3306/agentclaw?charset=utf8mb4
+  # ...and must ALSO set `backend: "mysql"` below. Changing only one of the two
+  # is rejected at boot with a ValueError naming the mismatch — that guard is
+  # deliberate (a silent fall back to the SQLite default would write production
+  # traffic to a file inside the container), but it is easier to read here than
+  # to discover from the error.
   #
   # `create_schema: true` lets the app emit its own DDL at boot — a container
   # deployment has nobody to run CREATE TABLE between `kubectl apply` and the

--- a/src/backend/src/agentclaw/community/configs/application-community.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-community.yaml
@@ -106,11 +106,24 @@ user_config:
     operator_subjects: []
 
   # Relational store — consumed by the community CommunityDatabase.
-  # SQLAlchemy URL (SQLite file / Postgres / MySQL). The DATABASE_URL env var,
-  # if set, takes precedence (keep passwords out of this file). The schema is
-  # operator-provisioned — the app does not create tables.
+  #
+  # `backend` is the single field that switches stores: "sqlite" for a local or
+  # single-node run, "mysql" for a managed instance (Aliyun RDS and friends).
+  # `url` must name the same store — the provider rejects a mismatch rather than
+  # silently falling back to the SQLite default.
+  #
+  # Keep passwords out of this file: the URL is an env placeholder, expanded at
+  # config load. A managed-MySQL deployment sets DATABASE_URL from a Secret, e.g.
+  #   mysql+pymysql://user:pass@rds-host:3306/agentclaw?charset=utf8mb4
+  #
+  # `create_schema: true` lets the app emit its own DDL at boot — a container
+  # deployment has nobody to run CREATE TABLE between `kubectl apply` and the
+  # first request. Set it false if you provision the schema out of band or run
+  # migrations yourself.
   database:
-    url: "sqlite:///./data/agentclaw.db"
+    backend: "sqlite"
+    url: "${DATABASE_URL:-sqlite:///./data/agentclaw.db}"
+    create_schema: true
 
   # Cache + distributed lock — consumed by the community CommunityCache.
   # Set redis_url to a Redis endpoint for a multi-worker deploy (KV + SET NX

--- a/src/backend/src/agentclaw/community/configs/application-community.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-community.yaml
@@ -107,27 +107,31 @@ user_config:
 
   # Relational store — consumed by the community CommunityDatabase.
   #
-  # `backend` is the single field that switches stores: "sqlite" for a local or
-  # single-node run, "mysql" for a managed instance (Aliyun RDS and friends).
-  # `url` must name the same store — the provider rejects a mismatch rather than
-  # silently falling back to the SQLite default.
+  # The community profile IS the deployed configuration, and that deployment runs
+  # on Aliyun against OceanBase — so this block names a real managed store rather
+  # than a local convenience default.
   #
-  # Keep passwords out of this file: the URL is an env placeholder, expanded at
-  # config load. A managed-MySQL deployment sets DATABASE_URL from a Secret, e.g.
-  #   mysql+pymysql://user:pass@rds-host:3306/agentclaw?charset=utf8mb4
-  # ...and must ALSO set `backend: "mysql"` below. Changing only one of the two
-  # is rejected at boot with a ValueError naming the mismatch — that guard is
-  # deliberate (a silent fall back to the SQLite default would write production
-  # traffic to a file inside the container), but it is easier to read here than
-  # to discover from the error.
+  # `backend` selects the store and drives engine setup (pooling, pragmas):
+  # "mysql" covers OceanBase, which speaks the MySQL wire protocol in MySQL mode
+  # — the same target `src/gateway/migrations/mysql/` is written against. "sqlite"
+  # and "postgresql" are also accepted. `url` must name the same store; the
+  # provider rejects a mismatch at boot rather than falling back silently.
+  #
+  # `url` has NO inline default on purpose. DATABASE_URL is deployment-supplied
+  # (a k8s Secret), and strict expansion makes a missing one fail the boot
+  # loudly instead of quietly writing production traffic somewhere else:
+  #   DATABASE_URL=mysql+pymysql://user:pass@ob-host:3306/agentclaw?charset=utf8mb4
+  # Anything that merely loads this overlay without deploying — the OSS boot
+  # self-test, the OpenAPI dump — must therefore supply a DSN too; no connection
+  # is opened by config resolution alone.
   #
   # `create_schema: true` lets the app emit its own DDL at boot — a container
   # deployment has nobody to run CREATE TABLE between `kubectl apply` and the
   # first request. Set it false if you provision the schema out of band or run
   # migrations yourself.
   database:
-    backend: "sqlite"
-    url: "${DATABASE_URL:-sqlite:///./data/agentclaw.db}"
+    backend: "mysql"
+    url: "${DATABASE_URL}"
     create_schema: true
 
   # Cache + distributed lock — consumed by the community CommunityCache.

--- a/src/backend/src/agentclaw/community/core/config/yaml_provider.py
+++ b/src/backend/src/agentclaw/community/core/config/yaml_provider.py
@@ -1,7 +1,7 @@
 """Community-safe YAML configuration provider (B2).
 
 Reads ``configs/application.yaml`` plus the overlay owned by a semantic deploy
-profile and deep-merges them into an
+profile, deep-merges them, expands ``${ENV_VAR}`` placeholders, and returns an
 :class:`~agentclaw.community.core.config.provider.AppConfig`. This is the default
 provider (community / test / local) and the body of the loader the local-mode
 monkeypatch used to carry inline.
@@ -13,6 +13,8 @@ with no company packages installed.
 from __future__ import annotations
 
 import logging
+import os
+import re
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -28,6 +30,13 @@ _OVERLAY_BY_PROFILE = {
     "corp_test": "application-test.yaml",
     "singlebox": "application-singlebox.yaml",
 }
+
+# Placeholder syntax: ${NAME} or ${NAME:-default} (shell / k8s / envsubst style),
+# matching the loaders in baas, gateway and proxy so one deployment spells its
+# config the same way for every service. ``${NAME:-}`` yields an empty string.
+_ENV_INTERP = re.compile(
+    r"\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>[^}]*))?\}"
+)
 
 
 class DeployProfileLike(Protocol):
@@ -54,10 +63,61 @@ def _overlay_for_profile(profile: DeployProfileLike) -> str:
         ) from exc
 
 
+def _expand_env_placeholders(data: Any, *, strict: bool = True) -> Any:
+    """Recursively expand ``${NAME}`` placeholders in a merged config tree.
+
+    Walks dict and list nodes; for string leaves, replaces every ``${NAME}`` (or
+    ``${NAME:-default}``) occurrence with the value of environment variable
+    ``NAME``. Non-string values are returned as-is.
+
+    Resolution order for a placeholder:
+
+    1. environment variable ``NAME`` if set (an empty string counts as set);
+    2. the default given via ``:-default`` if present;
+    3. when *strict* is True (the default, matching BaaS) it raises
+       ``KeyError`` — a referenced env var that is neither set nor defaulted is a
+       configuration error, and a deployment that forgot to wire a Secret should
+       fail at boot rather than serve a half-configured surface. When *strict* is
+       False the placeholder is left unchanged.
+
+    Anything that must still boot bare therefore needs a default in the YAML
+    (``${DATABASE_URL:-sqlite:///./data/agentclaw.db}``), not a naked
+    ``${DATABASE_URL}``.
+
+    This runs inside config loading — an approved site for raw environment access
+    per AGENTS.md — and before the typed config providers read the tree, so they
+    see resolved values and never reach for ``os.environ`` themselves.
+    """
+
+    def _env_replacer(match: re.Match[str]) -> str:
+        name = match.group("name")
+        if name in os.environ:
+            return os.environ[name]
+        default = match.group("default")
+        if default is not None:
+            return default
+        if not strict:
+            return match.group(0)
+        raise KeyError(
+            f"Environment variable {name!r} referenced by ${{{name}}} in config "
+            "is not set and has no default"
+        )
+
+    if isinstance(data, dict):
+        return {k: _expand_env_placeholders(v, strict=strict) for k, v in data.items()}
+    if isinstance(data, list):
+        return [_expand_env_placeholders(v, strict=strict) for v in data]
+    if isinstance(data, str):
+        return _ENV_INTERP.sub(_env_replacer, data)
+    return data
+
+
 def _load_yaml_configs(
     overlay_name: str = "application-dev.yaml",
+    *,
+    strict: bool = True,
 ) -> dict[str, Any]:
-    """Merge application.yaml with the caller-selected overlay."""
+    """Merge application.yaml with the caller-selected overlay, expanding env vars."""
     # B11: configs live in the community subtree (agentclaw/community/configs). In a
     # deploy the assembled runtime `configs/` (cwd) holds them; in the monorepo they
     # resolve from the subtree. Community never searches corp/configs — the test
@@ -77,7 +137,11 @@ def _load_yaml_configs(
         with open(overlay_path, "r", encoding="utf-8") as file:
             overlay_config = yaml.safe_load(file) or {}
         logger.info("YamlConfigProvider loaded overlay: %s", overlay_path)
-        return _deep_merge(base_config, overlay_config)
+        merged = _deep_merge(base_config, overlay_config)
+        # Expand after the merge so an overlay can introduce a placeholder the
+        # base does not carry, and before AppConfig so every consumer — typed
+        # dataclass providers included — reads resolved values.
+        return _expand_env_placeholders(merged, strict=strict)
 
     candidates = ", ".join(str(config_dir) for config_dir in config_dirs)
     raise FileNotFoundError(

--- a/src/backend/src/agentclaw/community/core/schema.py
+++ b/src/backend/src/agentclaw/community/core/schema.py
@@ -1,0 +1,188 @@
+"""Dialect-neutral relational schema bootstrap.
+
+One place that knows how to turn an empty database into the backend's schema,
+shared by every ``DatabasePlugin`` that owns its own store:
+
+- :func:`import_all_models` — force every ORM class to be registered on the
+  metadata, so ``create_all`` is complete rather than dependent on whichever
+  modules the router chain happened to import first.
+- :func:`create_all` — emit the DDL for both declarative bases.
+- :func:`prepare_for_mysql` — MySQL-only DDL adjustments (index key lengths).
+
+This body used to live inline in ``plugins/local/database.py``'s ``SqliteDB``,
+where only the ``test`` and ``singlebox`` profiles could reach it. The community
+plugin needs the same bootstrap against a real store (a deployment does not run
+DDL by hand before the pods start), so it lives in ``core/`` and both plugins
+call it. ``core/`` is the lowest layer; ``plugins/`` depends on it, never the
+reverse.
+"""
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import Index, MetaData, String, UniqueConstraint
+from sqlalchemy.engine import Engine
+
+logger = logging.getLogger(__name__)
+
+
+def import_all_models() -> None:
+    """Register every ORM class on its declarative metadata.
+
+    Eagerly imports each model module so its ``class`` statement runs and
+    SQLAlchemy's declarative metaclass attaches a ``Table`` to the shared
+    ``MetaData``. Without this, ``create_all`` would only emit DDL for tables
+    whose class was already transitively imported via the router chain — and the
+    method-level lazy imports in many repositories make that set
+    non-deterministic. The first request would hit ``no such table: ac_xxx``.
+
+    ``noqa: F401`` throughout: the names are intentionally unused, only the
+    import side effect matters.
+    """
+    import agentclaw.community.plugin_api.models  # noqa: F401  ac_bots / ac_resource / ac_channel_config
+    import agentclaw.community.core.models  # noqa: F401  ac_skill* / ac_skill_set_mcp / ac_user_mcp_config / propagation_log / center_sync_log
+    import agentclaw.community.core.skill_center.orm  # noqa: F401  ac_default_skillset_*
+    import agentclaw.community.core.access.sqlite_models  # noqa: F401  ac_access_control_policy / ac_user_info
+    import agentclaw.community.core.service_bot.repository.models  # noqa: F401  ac_bot_publish
+    import agentclaw.community.core.bot_public.repository.models  # noqa: F401  ac_bot_friend
+    import agentclaw.community.core.expert_chat.sqlite_models  # noqa: F401  ac_expert_chat_bot_sessions
+    import agentclaw.community.core.devices.repository.models  # noqa: F401  ac_entity_device_binding
+    import agentclaw.community.core.bot_management.repository.models  # noqa: F401  ac_templates / ac_bot_restart_lock
+    import agentclaw.community.core.bot_startup_script.repository.models  # noqa: F401  ac_bot_startup_script
+    import agentclaw.community.core.bot_management.render_screen.sqlite_models  # noqa: F401  ac_bot_render_screen
+    import agentclaw.community.core.system_config.orm  # noqa: F401  ac_config_*
+    import agentclaw.community.core.harness.sqlite_models  # noqa: F401  ac_harness_*
+    import agentclaw.community.core.bot_chat.models  # noqa: F401  bot_chat private-Base tables
+    import agentclaw.community.core.bot_dormant.sqlite_models  # noqa: F401  ac_bot_dormant_*
+    import agentclaw.community.core.task_queue.repository.models  # noqa: F401  ac_task_queue
+    import agentclaw.community.core.task.repository.models  # noqa: F401  task_info / task_node / task_node_run_info / task_node_relation / task_callback
+    import agentclaw.community.core.skills_pool.repository.models  # noqa: F401  ac_bot_skill_layout_state
+    import agentclaw.community.core.session_resources.repository.models  # noqa: F401  ac_session_resource
+    import agentclaw.community.core.economy.governance.orm  # noqa: F401  governance_*
+    import agentclaw.community.core.caller_identity.models  # noqa: F401  caller identity tables
+    import agentclaw.community.core.bot_app_grant.models  # noqa: F401  ac_bot_app_grant / ac_bot_app_grant_log
+    import agentclaw.community.core.user_list.models  # noqa: F401  ac_entity_user_list
+    import agentclaw.community.core.spaces.repository.models  # noqa: F401  ac_space / ac_space_member
+    import agentclaw.community.core.market_favorites.repository.models  # noqa: F401  ac_market_favorite
+    import agentclaw.community.core.work_orders.repository.models  # noqa: F401  ac_work_order / ac_work_order_notification
+
+
+def _metadatas() -> list[MetaData]:
+    """Both declarative registries the schema spans.
+
+    ``core/bot_chat/models.py`` declares a private ``Base`` instead of the
+    canonical ``core/base.py`` one, so its tables (``aw_langfuse_traces``, and a
+    second ``ac_bots``) live on a separate ``MetaData``. SQLAlchemy permits the
+    same table name across different registries and ``create_all`` is idempotent
+    (``checkfirst=True``), so emitting both is safe in either order. Without the
+    private one, ``/api/v1/bot-chats`` crashes with ``no such table:
+    aw_langfuse_traces``.
+    """
+    import agentclaw.community.core.bot_chat.models as bot_chat_models
+    from agentclaw.community.core.base import Base
+
+    return [Base.metadata, bot_chat_models.Base.metadata]
+
+
+# InnoDB caps an index key at 3072 bytes (MySQL 8, DYNAMIC row format), and
+# utf8mb4 bills 4 bytes per character — so a single VARCHAR(1024) column blows
+# the budget on its own.
+_INNODB_MAX_KEY_BYTES = 3072
+_UTF8MB4_BYTES_PER_CHAR = 4
+
+
+def _effective_widths(columns, existing: dict[str, int] | None) -> dict[str, int]:
+    """Each string column's indexed width, honouring any prefix already applied."""
+    existing = existing or {}
+    return {
+        col.name: existing.get(col.name, col.type.length)
+        for col in columns
+        if isinstance(col.type, String) and col.type.length
+    }
+
+
+def _prefix_lengths(
+    columns, existing: dict[str, int] | None = None
+) -> dict[str, int] | None:
+    """Shrink the widest string columns until the key fits InnoDB's cap.
+
+    Returns a ``{column_name: prefix_chars}`` map for ``mysql_length``, or
+    ``None`` if the key already fits. Narrow columns are left whole and the
+    widest are cut first, so a key made of one wide column and several small
+    ones only loses precision on the wide one.
+
+    ``existing`` is the prefix map already on the index, so a second pass over
+    the same metadata is a no-op rather than halving the prefix again.
+    """
+    widths = _effective_widths(columns, existing)
+    budget_chars = _INNODB_MAX_KEY_BYTES // _UTF8MB4_BYTES_PER_CHAR
+    if sum(widths.values()) <= budget_chars:
+        return None
+
+    prefixes = dict(widths)
+    # Repeatedly halve the widest column until the total fits. Converges quickly
+    # and keeps the result deterministic (no float arithmetic, no ordering
+    # dependence beyond "widest first, ties by name").
+    while sum(prefixes.values()) > budget_chars:
+        widest = max(sorted(prefixes), key=lambda name: prefixes[name])
+        prefixes[widest] = max(1, prefixes[widest] // 2)
+    return {name: length for name, length in prefixes.items() if length < widths[name]}
+
+
+def prepare_for_mysql(metadata: MetaData) -> list[str]:
+    """Make ``metadata``'s DDL emittable on MySQL. Returns what was adjusted.
+
+    Every index whose key exceeds InnoDB's 3072-byte cap gets per-column prefix
+    lengths. A ``UniqueConstraint`` cannot carry prefix lengths in SQLAlchemy, so
+    an over-long one is replaced by an equivalent unique ``Index``, which can —
+    the two are the same object in MySQL.
+
+    **Semantic caveat for the unique keys.** A prefixed unique index enforces
+    uniqueness on the prefix, which is *stricter* than on the whole value: two
+    rows whose ids agree for the first N characters and differ later would now
+    collide. The columns involved hold ids and short type discriminators, so this
+    is not reachable in practice — but it is a real narrowing, and the reason the
+    convention for *new* tables (see ``bot_startup_script``) is a bounded sha256
+    surrogate column instead. Retrofitting a surrogate onto these six tables
+    means changing their write paths, which is a bigger change than making the
+    schema deployable.
+
+    MySQL-only, and applied in-process at bootstrap: SQLite ignores prefix
+    lengths, and corp never runs this code (its DDL is applied out of band).
+    """
+    adjusted: list[str] = []
+
+    for table in metadata.sorted_tables:
+        for constraint in list(table.constraints):
+            if not isinstance(constraint, UniqueConstraint):
+                continue
+            prefixes = _prefix_lengths(list(constraint.columns))
+            if prefixes is None:
+                continue
+            columns = list(constraint.columns)
+            name = constraint.name or f"uk_{table.name}_{'_'.join(c.name for c in columns)}"
+            table.constraints.discard(constraint)
+            Index(name, *columns, unique=True, mysql_length=prefixes)
+            adjusted.append(f"{table.name}.{name} (unique constraint → prefixed unique index)")
+
+        for index in table.indexes:
+            already = index.dialect_options["mysql"].get("length") or {}
+            prefixes = _prefix_lengths(list(index.columns), already)
+            if prefixes is None:
+                continue
+            index.dialect_options["mysql"]["length"] = {**already, **prefixes}
+            adjusted.append(f"{table.name}.{index.name} (prefixed)")
+
+    return adjusted
+
+
+def create_all(engine: Engine, *, mysql: bool = False) -> None:
+    """Create every table on ``engine``. Idempotent (``checkfirst=True``)."""
+    import_all_models()
+    for metadata in _metadatas():
+        if mysql:
+            adjusted = prepare_for_mysql(metadata)
+            for entry in adjusted:
+                logger.info("schema: MySQL index key capped — %s", entry)
+        metadata.create_all(engine)
+    logger.info("schema: create_all complete")

--- a/src/backend/src/agentclaw/community/di/config_community.py
+++ b/src/backend/src/agentclaw/community/di/config_community.py
@@ -39,13 +39,20 @@ class CommunityDatabaseConfig:
     Corp/test never resolve this type.
 
     ``backend`` is the one field a deployment flips to change stores — ``sqlite``
-    for a local or single-node run, ``mysql`` for a managed instance. It selects
-    engine setup (pooling, pragmas), and the provider rejects a ``url`` whose
-    scheme disagrees with it, so the two can never drift into a confusing
-    half-configured state.
+    for a local or single-node run, ``mysql`` for a managed instance (including
+    OceanBase, which speaks the MySQL protocol). It selects engine setup
+    (pooling, pragmas), and the provider rejects a ``url`` whose scheme disagrees
+    with it, so the two can never drift into a confusing half-configured state.
 
-    ``url`` is a SQLAlchemy URL. Point it at an env var from the YAML
-    (``${DATABASE_URL:-...}``) rather than writing a password into the file.
+    ``url`` is a SQLAlchemy URL, sourced from the YAML's env placeholder rather
+    than written into the file, so no password is ever committed.
+
+    **These field defaults are the no-block fallback, not what community
+    deploys.** The shipped ``application-community.yaml`` sets ``mysql`` with a
+    required ``${DATABASE_URL}``, because the community profile is the deployed
+    Aliyun/OceanBase configuration. The SQLite values below apply only if the
+    ``database`` block is absent entirely — a DSN cannot be a literal default,
+    since host and credentials are per-deployment.
 
     ``create_schema`` lets the app emit its own DDL at boot, which is what a
     container deployment needs — nobody runs ``CREATE TABLE`` between

--- a/src/backend/src/agentclaw/community/di/config_community.py
+++ b/src/backend/src/agentclaw/community/di/config_community.py
@@ -35,14 +35,37 @@ class BcsAuthConfig:
 class CommunityDatabaseConfig:
     """Relational-store connection for the community ``CommunityDatabase``.
 
-    Community-only: sourced from the ``database`` block of ``user_config``
-    (overridable by the ``DATABASE_URL`` env var in the provider). ``url`` is a
-    SQLAlchemy URL — SQLite file / Postgres / MySQL. The default is a local
-    SQLite file so a bare community boot works; a real deploy points it at a
-    pre-provisioned store. Corp/test never resolve this type.
+    Community-only: sourced from the ``database`` block of ``user_config``.
+    Corp/test never resolve this type.
+
+    ``backend`` is the one field a deployment flips to change stores — ``sqlite``
+    for a local or single-node run, ``mysql`` for a managed instance. It selects
+    engine setup (pooling, pragmas), and the provider rejects a ``url`` whose
+    scheme disagrees with it, so the two can never drift into a confusing
+    half-configured state.
+
+    ``url`` is a SQLAlchemy URL. Point it at an env var from the YAML
+    (``${DATABASE_URL:-...}``) rather than writing a password into the file.
+
+    ``create_schema`` lets the app emit its own DDL at boot, which is what a
+    container deployment needs — nobody runs ``CREATE TABLE`` between
+    ``kubectl apply`` and the first request. Set it false when the schema is
+    provisioned out of band or managed by migrations.
     """
 
+    backend: str = "sqlite"
     url: str = "sqlite:///./data/agentclaw.db"
+    create_schema: bool = True
+
+
+#: Accepted ``database.backend`` values mapped to the SQLAlchemy URL scheme each
+#: one requires. Adding a backend means adding its engine setup to
+#: ``plugins/community/database.py`` at the same time.
+DATABASE_BACKEND_SCHEMES: dict[str, str] = {
+    "sqlite": "sqlite",
+    "mysql": "mysql",
+    "postgresql": "postgresql",
+}
 
 
 @dataclass(frozen=True)

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/community/database.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/community/database.py
@@ -2,12 +2,15 @@
 
 Capability: relational store connection. B3 binds the configured-URL
 ``CommunityDatabase``. The ``CommunityDatabaseConfig`` provider lives here
-(community-only) and reads the ``database`` block of ``user_config``, with the
-``DATABASE_URL`` env var taking precedence — corp/test never resolve it.
+(community-only) and reads the ``database`` block of ``user_config`` —
+corp/test never resolve it.
+
+The block's ``url`` is expected to carry an env placeholder
+(``${DATABASE_URL:-sqlite:///./data/agentclaw.db}``); the YAML provider expands
+it during config loading, which is where AGENTS.md puts raw environment access.
+This module therefore reads no environment variable of its own.
 """
 from __future__ import annotations
-
-import os
 
 from injector import Module, inject, provider, singleton
 
@@ -25,14 +28,41 @@ class CommunityDatabaseModule(Module):
     @singleton
     @provider
     def database_config(self) -> cfg.CommunityDatabaseConfig:
-        """Resolve the database URL: ``DATABASE_URL`` env wins, else the
-        ``database`` block, else the dataclass default (a local SQLite file)."""
+        """Read the ``database`` block, falling back to the dataclass defaults.
+
+        Validates ``backend`` against the URL scheme rather than inferring one
+        from the other: a deployment that flips ``backend`` to ``mysql`` and
+        forgets to point ``url`` at the instance would otherwise boot happily on
+        the default SQLite file and quietly write real traffic to a scratch file
+        inside the container.
+        """
         from agentclaw.community.di.modules.config_module import _block
 
         block = _block("database")
         defaults = cfg.CommunityDatabaseConfig()
-        url = os.environ.get("DATABASE_URL") or block.get("url") or defaults.url
-        return cfg.CommunityDatabaseConfig(url=url)
+
+        backend = str(block.get("backend") or defaults.backend).strip().lower()
+        url = block.get("url") or defaults.url
+        create_schema = block.get("create_schema")
+        if create_schema is None:
+            create_schema = defaults.create_schema
+
+        expected_scheme = cfg.DATABASE_BACKEND_SCHEMES.get(backend)
+        if expected_scheme is None:
+            supported = ", ".join(sorted(cfg.DATABASE_BACKEND_SCHEMES))
+            raise ValueError(
+                f"Unknown database.backend {backend!r}; supported: {supported}"
+            )
+        if not url.startswith(expected_scheme):
+            raise ValueError(
+                f"database.backend is {backend!r} but database.url is not a "
+                f"{expected_scheme} URL (got scheme {url.split(':', 1)[0]!r}); "
+                "set both to the same store"
+            )
+
+        return cfg.CommunityDatabaseConfig(
+            backend=backend, url=url, create_schema=bool(create_schema)
+        )
 
     @singleton
     @provider
@@ -42,11 +72,16 @@ class CommunityDatabaseModule(Module):
 
         from agentclaw.community.plugins.community.database import CommunityDatabase
 
-        # Mask any inline credentials — a Postgres/MySQL URL embeds the password
-        # (postgresql://user:pass@host/db); never log it in the clear.
+        # Mask any inline credentials — a MySQL/Postgres URL embeds the password
+        # (mysql+pymysql://user:pass@host/db); never log it in the clear.
         try:
             safe_url = make_url(config.url).render_as_string(hide_password=True)
         except Exception:  # pragma: no cover — malformed URL surfaces on connect
             safe_url = "<unparseable>"
-        logger.info("DatabasePlugin: CommunityDatabase (url=%s)", safe_url)
-        return CommunityDatabase(config.url)
+        logger.info(
+            "DatabasePlugin: CommunityDatabase (backend=%s, url=%s, create_schema=%s)",
+            config.backend,
+            safe_url,
+            config.create_schema,
+        )
+        return CommunityDatabase(config.url, create_schema=config.create_schema)

--- a/src/backend/src/agentclaw/community/main.py
+++ b/src/backend/src/agentclaw/community/main.py
@@ -97,12 +97,7 @@ if __name__ == "__main__":  # pragma: no cover - entrypoint wiring; profile gate
                 f"{_loopback_bypass},{_existing}" if _existing else _loopback_bypass
             )
 
-        # 1. Install the local infrastructure stubs BEFORE any other agentclaw
-        # imports (the community/local stub installer for the company runtime).
-        from agentclaw.community.local import patch_sofapy_for_local
-        patch_sofapy_for_local()
-
-        # 2. Select the Profile-owned YAML overlay before the first config read.
+        # 1. Select the Profile-owned YAML overlay before the first config read.
         # The HTTP composition root repeats this registration when it is imported
         # so direct ASGI imports keep the same bootstrap contract.
         from agentclaw.community.di.config_bootstrap import register_config_provider
@@ -112,15 +107,22 @@ if __name__ == "__main__":  # pragma: no cover - entrypoint wiring; profile gate
         logger.info("runtime config (local)")
         logger.info(json.dumps(config.model_dump(), ensure_ascii=False, indent=2))
 
-        # 3. Start uvicorn directly.
+        # 2. Start uvicorn directly.
         # Schema bootstrap, event-listener subscription, and every other
         # startup hook run through the Lifecycle Protocol dispatched by
         # ``_app_lifespan`` in adapters/http/app.py (R11). Nothing to
         # register here.
+        #
+        # The listen address is env-driven so a container can be told which port
+        # to serve without a rebuild; the defaults are what the local scripts and
+        # every existing launch site already use, so an unset environment behaves
+        # exactly as before.
         import uvicorn
         from agentclaw.community.adapters.http.app import app
-        logger.info("Starting uvicorn on 0.0.0.0:8888")
-        uvicorn.run(app, host="0.0.0.0", port=8888)
+        _host = os.getenv("BACKEND_HOST") or "0.0.0.0"
+        _port = int(os.getenv("BACKEND_PORT") or 8888)
+        logger.info("Starting uvicorn on %s:%d", _host, _port)
+        uvicorn.run(app, host=_host, port=_port)
     else:
         # Corp / prod profiles boot via the company runner from the corp
         # entrypoint, which is not part of the community distribution. Fail fast

--- a/src/backend/src/agentclaw/community/plugins/community/database.py
+++ b/src/backend/src/agentclaw/community/plugins/community/database.py
@@ -1,12 +1,16 @@
 """CommunityDatabase — community DatabasePlugin over a configured SQLAlchemy URL.
 
-A pure connection provider: it builds a SQLAlchemy engine from the configured
-database URL (SQLite file / Postgres / MySQL) and hands out sessions. It does
-**not** create tables and is **not** a lifecycle participant — in a community
-deployment the schema is operator-provisioned (the operator runs their own DDL /
-migrations before the app boots). The local SQLite impl's ``create_all`` exists
-only because its in-memory database is recreated empty on every process start;
-that does not apply to a persistent community store.
+Builds a SQLAlchemy engine from the configured database URL (SQLite file /
+MySQL / Postgres) and hands out sessions. Which backend it talks to is one YAML
+field — ``user_config.database.backend`` — with the DSN in
+``user_config.database.url``; see ``di/config_community.py``.
+
+Owns its schema when asked to. ``create_schema`` (default on) makes the plugin a
+Lifecycle participant that runs ``core/schema.py``'s ``create_all`` at boot, the
+same bootstrap the local SQLite plugin runs, because a container deployment has
+nobody to apply DDL by hand before the pods start. An operator who provisions the
+schema out of band (or runs migrations) sets ``create_schema: false`` and the
+plugin becomes a pure connection provider again.
 
 ``session()`` does not auto-commit; ``orm_session()`` commits on clean exit
 (write-persistence parity with corp's ``AUTOCOMMIT`` and the local impl).
@@ -20,17 +24,27 @@ from contextlib import contextmanager
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
+from agentclaw.community.kernel.lifecycle import LifecycleBase
+from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.database import DatabasePlugin
+
+logger = get_logger()
 
 
 def _is_sqlite(url: str) -> bool:
     return url.startswith("sqlite")
 
 
-class CommunityDatabase(DatabasePlugin):
+def _is_mysql(url: str) -> bool:
+    return url.startswith("mysql")
+
+
+class CommunityDatabase(DatabasePlugin, LifecycleBase):
     """DatabasePlugin backed by a configured SQLAlchemy engine."""
 
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, *, create_schema: bool = True) -> None:
+        self._url = url
+        self._create_schema = create_schema
         self._engine = self._make_engine(url)
         self._session_factory = sessionmaker(
             autocommit=False, autoflush=False, bind=self._engine
@@ -54,8 +68,35 @@ class CommunityDatabase(DatabasePlugin):
                 cursor.close()
 
             return engine
-        # Postgres / MySQL / etc.: default pooling is appropriate.
+
+        if _is_mysql(url):
+            # A managed MySQL (Aliyun RDS and friends) closes idle connections
+            # server-side — the default wait_timeout is 8h but proxies and
+            # failovers cut them far sooner. Without these two the first request
+            # after an idle period dies on a stale socket:
+            #   pool_pre_ping — cheap liveness check on checkout, retries once;
+            #   pool_recycle  — retire connections before the server does.
+            return create_engine(
+                url,
+                pool_pre_ping=True,
+                pool_recycle=3600,
+            )
+
+        # Postgres / etc.: default pooling is appropriate.
         return create_engine(url)
+
+    async def bootstrap(self) -> None:
+        """Lifecycle hook — create the schema unless the operator owns it."""
+        if not self._create_schema:
+            logger.info(
+                "CommunityDatabase: create_schema=false — schema is operator-provisioned"
+            )
+            return
+
+        from agentclaw.community.core.schema import create_all
+
+        create_all(self._engine, mysql=_is_mysql(self._url))
+        logger.info("CommunityDatabase: schema bootstrap complete")
 
     @contextmanager
     def session(self):

--- a/src/backend/src/agentclaw/community/plugins/local/README.md
+++ b/src/backend/src/agentclaw/community/plugins/local/README.md
@@ -20,6 +20,7 @@ internal_dependencies:
   - agentclaw.community.core.access
   - agentclaw.community.core.auth
   - agentclaw.community.core.base
+  - agentclaw.community.core.schema   # shared schema bootstrap (model registration + create_all)
   - agentclaw.community.core.bot_chat
   - agentclaw.community.core.bot_app_grant.models  # SQLite ORM side-effect import for bot→app authorization tables
   - agentclaw.community.core.bot_dormant   # SQLite ORM side-effect import for local table creation

--- a/src/backend/src/agentclaw/community/plugins/local/database.py
+++ b/src/backend/src/agentclaw/community/plugins/local/database.py
@@ -117,15 +117,11 @@ class SqliteDB(MockSeam, DatabasePlugin, LifecycleBase):
     """DatabasePlugin implementation for local mode (SQLite via SQLAlchemy)."""
 
     async def bootstrap(self) -> None:
-        """Lifecycle hook — populate ``Base.metadata`` and CREATE TABLE.
+        """Lifecycle hook — populate the ORM metadata and CREATE TABLE.
 
-        Eagerly imports every ORM model so its ``class`` statement runs
-        and SQLAlchemy's declarative metaclass registers a ``Table`` on
-        ``Base.metadata``. Without this, ``create_all`` would only emit
-        DDL for tables whose class was already transitively imported via
-        the router chain — and method-level lazy imports in many
-        repositories make that set non-deterministic. First request would
-        hit ``no such table: ac_xxx``.
+        The model registration and DDL themselves live in
+        ``core/schema.py`` so the community plugin runs the identical
+        bootstrap against a real store.
 
         Order matters: we resolve ``_get_session_factory`` *before*
         ``create_all`` so the TestingDatabaseModule's first-resolution
@@ -134,60 +130,10 @@ class SqliteDB(MockSeam, DatabasePlugin, LifecycleBase):
         about to be wiped, and the next request would lazy-init a fresh
         empty one.
         """
-        from agentclaw.community.core.base import Base
-
-        # Side-effect imports — register each ORM class on ``Base.metadata``
-        # (the class statement runs, the declarative metaclass attaches a
-        # ``Table`` to the shared ``MetaData``). ``noqa: F401`` because the
-        # name itself is intentionally unused — only the import side effect
-        # matters.
-        import agentclaw.community.plugin_api.models  # noqa: F401  ac_bots / ac_resource / ac_channel_config
-        import agentclaw.community.core.models  # noqa: F401  ac_skill* / ac_skill_set_mcp / ac_user_mcp_config / propagation_log / center_sync_log
-        import agentclaw.community.core.skill_center.orm  # noqa: F401  ac_default_skillset_*
-        import agentclaw.community.core.access.sqlite_models  # noqa: F401  ac_access_control_policy / ac_user_info
-        import agentclaw.community.core.service_bot.repository.models  # noqa: F401  ac_bot_publish
-        import agentclaw.community.core.bot_public.repository.models  # noqa: F401  ac_bot_friend
-        import agentclaw.community.core.expert_chat.sqlite_models  # noqa: F401  ac_expert_chat_bot_sessions
-        import agentclaw.community.core.devices.repository.models  # noqa: F401  ac_entity_device_binding
-        import agentclaw.community.core.bot_management.repository.models  # noqa: F401  ac_templates / ac_bot_restart_lock
-        import agentclaw.community.core.bot_startup_script.repository.models  # noqa: F401  ac_bot_startup_script
-        import agentclaw.community.core.bot_management.render_screen.sqlite_models  # noqa: F401  ac_bot_render_screen
-        import agentclaw.community.core.system_config.orm  # noqa: F401  ac_config_*
-        import agentclaw.community.core.harness.sqlite_models  # noqa: F401  ac_harness_*
-        import agentclaw.community.core.bot_chat.models  # noqa: F401  bot_chat private-Base tables
-        import agentclaw.community.core.bot_dormant.sqlite_models  # noqa: F401  ac_bot_dormant_*
-        import agentclaw.community.core.task_queue.repository.models  # noqa: F401  ac_task_queue
-        import agentclaw.community.core.task.repository.models  # noqa: F401  task_info / task_node / task_node_run_info / task_node_relation / task_callback
-        import agentclaw.community.core.skills_pool.repository.models  # noqa: F401  ac_bot_skill_layout_state
-        import agentclaw.community.core.session_resources.repository.models  # noqa: F401  ac_session_resource
-        import agentclaw.community.core.economy.governance.orm  # noqa: F401  governance_*
-        import agentclaw.community.core.caller_identity.models  # noqa: F401  caller identity tables
-        import agentclaw.community.core.bot_app_grant.models  # noqa: F401  ac_bot_app_grant / ac_bot_app_grant_log
-        import agentclaw.community.core.user_list.models  # noqa: F401  ac_entity_user_list
-        import agentclaw.community.core.spaces.repository.models  # noqa: F401  ac_space / ac_space_member
-        import agentclaw.community.core.market_favorites.repository.models  # noqa: F401  ac_market_favorite
-        import agentclaw.community.core.work_orders.repository.models  # noqa: F401  ac_work_order / ac_work_order_notification
-
-        # bot_chat uses a private ``Base = declarative_base()`` instead of
-        # the canonical ``agentclaw.community.core.base.Base``. Side-effect import
-        # registers ``AwLangfuseTrace`` + ``AcBot`` on the private metadata;
-        # the canonical ``create_all`` below won't see them, so we call
-        # ``create_all`` on the private Base too. ``ac_bots`` is also
-        # defined on the canonical Base (BotModel) — SQLAlchemy permits the
-        # same table name across different MetaData objects, and
-        # ``create_all`` is idempotent (``checkfirst=True`` skips already-
-        # existing tables), so the order of the two calls doesn't matter
-        # for correctness; we still register canonical ``ac_bots`` first
-        # for clarity. Without this block, ``/api/v1/bot-chats`` list/get
-        # crashes at runtime with ``sqlite3.OperationalError: no such
-        # table: aw_langfuse_traces``.
-        # Any future ORM class added to core/bot_chat/models.py is picked up
-        # automatically via the same create_all — no further bootstrap edits needed.
-        import agentclaw.community.core.bot_chat.models as _bot_chat_models  # noqa: F401  bot_chat private Base
+        from agentclaw.community.core.schema import create_all
 
         _get_session_factory()
-        Base.metadata.create_all(_engine)
-        _bot_chat_models.Base.metadata.create_all(_engine)
+        create_all(_engine)
 
     @contextmanager
     def session(self):

--- a/src/backend/tests/community/config/effective_config.py
+++ b/src/backend/tests/community/config/effective_config.py
@@ -11,6 +11,13 @@ Two layers are captured per profile:
   the same merge the loaders perform. This catches relocation of **every** yaml
   block, including corp-only blocks (``arca_sandbox`` …) that the neutral
   ``ConfigModule`` does not type.
+
+  Deliberately **not** env-expanded: a ``${DATABASE_URL:-…}`` placeholder is
+  snapshotted verbatim rather than resolved. Expanding here would make the
+  golden depend on whatever the runner happens to export, which is the same
+  determinism problem ``DORMANT_DRY_RUN`` is neutralized for below. So this
+  layer pins the shipped yaml *text*; the expansion itself is covered by
+  ``tests/community/local/test_load_yaml_configs.py``.
 - ``typed`` — every neutral ``ConfigModule`` dataclass, resolved against the
   merged config. This additionally catches ``di/config.py`` **code-default**
   changes (folded in by the providers), which the raw layer cannot see.

--- a/src/backend/tests/community/config/golden/community.json
+++ b/src/backend/tests/community/config/golden/community.json
@@ -45,9 +45,9 @@
       "adapter_service_port": 20003
     },
     "database": {
-      "backend": "sqlite",
+      "backend": "mysql",
       "create_schema": true,
-      "url": "${DATABASE_URL:-sqlite:///./data/agentclaw.db}"
+      "url": "${DATABASE_URL}"
     },
     "desktop_bot_periodic_scan": {
       "apply_owner_whitelist": [],

--- a/src/backend/tests/community/config/golden/community.json
+++ b/src/backend/tests/community/config/golden/community.json
@@ -45,7 +45,9 @@
       "adapter_service_port": 20003
     },
     "database": {
-      "url": "sqlite:///./data/agentclaw.db"
+      "backend": "sqlite",
+      "create_schema": true,
+      "url": "${DATABASE_URL:-sqlite:///./data/agentclaw.db}"
     },
     "desktop_bot_periodic_scan": {
       "apply_owner_whitelist": [],

--- a/src/backend/tests/community/core/test_schema.py
+++ b/src/backend/tests/community/core/test_schema.py
@@ -1,0 +1,193 @@
+"""Schema bootstrap — model registration and MySQL DDL adjustments.
+
+``core/schema.py`` is what turns an empty database into the backend's schema. The
+local SQLite plugin and the community plugin both run it, so a community
+deployment gets the same tables a singlebox boot does — and, on MySQL, a schema
+that InnoDB will actually accept.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+from sqlalchemy.schema import CreateIndex, CreateTable
+
+from agentclaw.community.core import schema
+
+
+#: InnoDB's index key cap (MySQL 8, DYNAMIC row format) and utf8mb4's cost per
+#: character — the budget every key has to fit inside.
+MAX_KEY_BYTES = 3072
+BYTES_PER_CHAR = 4
+
+
+def _key_bytes(columns, prefixes: dict[str, int] | None = None) -> int:
+    prefixes = prefixes or {}
+    return sum(
+        (prefixes.get(col.name, col.type.length) or 0) * BYTES_PER_CHAR
+        for col in columns
+        if isinstance(col.type, sa.String)
+    )
+
+
+def _oversized_keys(metadata: sa.MetaData) -> list[tuple[str, str]]:
+    """Every index/unique key on ``metadata`` that MySQL would reject."""
+    offenders = []
+    for table in metadata.sorted_tables:
+        for constraint in table.constraints:
+            if isinstance(constraint, sa.UniqueConstraint):
+                if _key_bytes(list(constraint.columns)) > MAX_KEY_BYTES:
+                    offenders.append((table.name, str(constraint.name)))
+        for index in table.indexes:
+            prefixes = index.dialect_options["mysql"].get("length") or {}
+            if _key_bytes(list(index.columns), prefixes) > MAX_KEY_BYTES:
+                offenders.append((table.name, str(index.name)))
+    return offenders
+
+
+class TestPrepareForMysql:
+    def test_leaves_a_key_that_already_fits_untouched(self):
+        metadata = sa.MetaData()
+        table = sa.Table(
+            "fits",
+            metadata,
+            sa.Column("a", sa.String(64)),
+            sa.Column("b", sa.String(64)),
+            sa.Index("idx_fits", "a", "b"),
+        )
+
+        assert schema.prepare_for_mysql(metadata) == []
+        index = next(iter(table.indexes))
+        assert not index.dialect_options["mysql"].get("length")
+
+    def test_prefixes_an_oversized_index(self):
+        metadata = sa.MetaData()
+        table = sa.Table(
+            "wide",
+            metadata,
+            sa.Column("big", sa.String(2048)),
+            sa.Index("idx_wide", "big"),
+        )
+
+        adjusted = schema.prepare_for_mysql(metadata)
+
+        assert adjusted, "an 8192-byte key must be adjusted"
+        index = next(iter(table.indexes))
+        prefixes = index.dialect_options["mysql"]["length"]
+        assert prefixes["big"] < 2048
+        assert _key_bytes(list(index.columns), prefixes) <= MAX_KEY_BYTES
+
+    def test_cuts_the_widest_column_and_leaves_narrow_ones_whole(self):
+        metadata = sa.MetaData()
+        table = sa.Table(
+            "mixed",
+            metadata,
+            sa.Column("wide", sa.String(1024)),
+            sa.Column("narrow", sa.String(20)),
+            sa.Index("idx_mixed", "wide", "narrow"),
+        )
+
+        schema.prepare_for_mysql(metadata)
+
+        prefixes = next(iter(table.indexes)).dialect_options["mysql"]["length"]
+        assert "narrow" not in prefixes
+        assert prefixes["wide"] < 1024
+
+    def test_converts_an_oversized_unique_constraint_to_a_prefixed_index(self):
+        # SQLAlchemy's UniqueConstraint cannot carry prefix lengths; a unique
+        # Index can, and MySQL treats the two as the same object.
+        metadata = sa.MetaData()
+        table = sa.Table(
+            "uniq",
+            metadata,
+            sa.Column("a", sa.String(1024)),
+            sa.Column("b", sa.String(1024)),
+            sa.UniqueConstraint("a", "b", name="uk_uniq_a_b"),
+        )
+
+        schema.prepare_for_mysql(metadata)
+
+        assert not [
+            c for c in table.constraints if isinstance(c, sa.UniqueConstraint)
+        ], "the oversized UniqueConstraint should have been replaced"
+        index = next(i for i in table.indexes if i.name == "uk_uniq_a_b")
+        assert index.unique is True
+        assert _key_bytes(list(index.columns), index.dialect_options["mysql"]["length"]) <= MAX_KEY_BYTES
+
+    def test_is_idempotent(self):
+        metadata = sa.MetaData()
+        sa.Table(
+            "again",
+            metadata,
+            sa.Column("big", sa.String(2048)),
+            sa.UniqueConstraint("big", name="uk_again_big"),
+        )
+
+        schema.prepare_for_mysql(metadata)
+        assert schema.prepare_for_mysql(metadata) == []
+        assert _oversized_keys(metadata) == []
+
+    def test_emits_valid_mysql_ddl(self):
+        metadata = sa.MetaData()
+        table = sa.Table(
+            "ddl",
+            metadata,
+            sa.Column("entity_id", sa.String(1024)),
+            sa.Column("env", sa.String(20)),
+            sa.UniqueConstraint("entity_id", "env", name="uk_ddl_scope"),
+        )
+        schema.prepare_for_mysql(metadata)
+        dialect = mysql.dialect()
+
+        CreateTable(table).compile(dialect=dialect)
+        index = next(iter(table.indexes))
+        statement = str(CreateIndex(index).compile(dialect=dialect))
+
+        assert "CREATE UNIQUE INDEX" in statement
+        assert "entity_id(" in statement, "the wide column should carry a prefix"
+        assert "env(" not in statement, "the narrow column should stay whole"
+
+
+class TestRealSchema:
+    def test_every_shipped_key_fits_innodb_after_preparation(self):
+        """The real metadata must be MySQL-deployable, not just the synthetic cases.
+
+        These models were written for a store whose DDL is applied out of band, so
+        a number of keys are far past InnoDB's cap as declared. Guarding the
+        prepared result here is what makes ``database.backend: mysql`` with
+        ``create_schema: true`` a supported configuration.
+        """
+        schema.import_all_models()
+        metadatas = schema._metadatas()
+
+        assert _oversized_keys(metadatas[0]), (
+            "expected the shipped models to declare keys past InnoDB's cap — "
+            "if this is no longer true the preparation step may be unnecessary"
+        )
+
+        for metadata in metadatas:
+            schema.prepare_for_mysql(metadata)
+            assert _oversized_keys(metadata) == []
+
+    def test_real_schema_compiles_as_mysql_ddl(self):
+        schema.import_all_models()
+        dialect = mysql.dialect()
+
+        for metadata in schema._metadatas():
+            schema.prepare_for_mysql(metadata)
+            for table in metadata.sorted_tables:
+                CreateTable(table).compile(dialect=dialect)
+                for index in table.indexes:
+                    CreateIndex(index).compile(dialect=dialect)
+
+    def test_create_all_builds_the_full_schema_on_a_fresh_database(self, tmp_path):
+        engine = sa.create_engine(f"sqlite:///{tmp_path / 'fresh.db'}")
+
+        schema.create_all(engine)
+
+        tables = sa.inspect(engine).get_table_names()
+        # The exact count moves with the models; what matters is that the
+        # bootstrap is comprehensive rather than whatever the import graph
+        # happened to pull in, and that the core tables are present.
+        assert len(tables) > 50
+        assert "ac_bots" in tables
+        assert "aw_langfuse_traces" in tables, "the private bot_chat Base must be emitted too"

--- a/src/backend/tests/community/di/test_community_data_infra_wiring.py
+++ b/src/backend/tests/community/di/test_community_data_infra_wiring.py
@@ -51,11 +51,64 @@ def test_community_binds_database(community_injector):
     assert not isinstance(resolved, MockSeam)
 
 
-def test_database_url_env_overrides_yaml(monkeypatch):
-    # DATABASE_URL takes precedence over the yaml ``database.url`` block.
-    monkeypatch.setenv("DATABASE_URL", "sqlite:///tmp/override-b3.db")
+def test_database_config_reads_the_yaml_block_verbatim(monkeypatch):
+    # DATABASE_URL no longer reaches the provider directly: the shipped overlay
+    # spells the url as ``${DATABASE_URL:-...}`` and the YAML loader expands it
+    # during config loading (AGENTS.md puts raw env access there). The provider
+    # is therefore a pure reader of the resolved block.
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///tmp/ignored-by-the-provider.db")
+    monkeypatch.setattr(
+        "agentclaw.community.di.modules.config_module._block",
+        lambda name: {"backend": "sqlite", "url": "sqlite:///tmp/from-yaml.db"},
+    )
     config = CommunityDatabaseModule().database_config()
-    assert config.url == "sqlite:///tmp/override-b3.db"
+    assert config.url == "sqlite:///tmp/from-yaml.db"
+
+
+def test_database_config_defaults_are_sqlite_with_schema_creation():
+    config = CommunityDatabaseModule().database_config()
+    assert config.backend == "sqlite"
+    assert config.url.startswith("sqlite")
+    # A container deployment has nobody to run DDL before the first request.
+    assert config.create_schema is True
+
+
+def test_database_config_rejects_backend_url_mismatch(monkeypatch):
+    # Flipping backend to mysql but leaving the sqlite url behind must fail loudly
+    # rather than quietly writing production traffic to a file in the container.
+    monkeypatch.setattr(
+        "agentclaw.community.di.modules.config_module._block",
+        lambda name: {"backend": "mysql", "url": "sqlite:///./data/agentclaw.db"},
+    )
+    with pytest.raises(ValueError, match="database.backend is 'mysql'"):
+        CommunityDatabaseModule().database_config()
+
+
+def test_database_config_rejects_unknown_backend(monkeypatch):
+    monkeypatch.setattr(
+        "agentclaw.community.di.modules.config_module._block",
+        lambda name: {"backend": "oracle", "url": "oracle://host/db"},
+    )
+    with pytest.raises(ValueError, match="Unknown database.backend"):
+        CommunityDatabaseModule().database_config()
+
+
+def test_mysql_backend_builds_a_pooled_engine(monkeypatch):
+    # mysql+pymysql is lazy — create_engine opens no socket — so this pins the
+    # engine setup (pre-ping / recycle) without needing a server.
+    monkeypatch.setattr(
+        "agentclaw.community.di.modules.config_module._block",
+        lambda name: {
+            "backend": "mysql",
+            "url": "mysql+pymysql://u:p@db.example:3306/agentclaw?charset=utf8mb4",
+            "create_schema": False,
+        },
+    )
+    config = CommunityDatabaseModule().database_config()
+    plugin = CommunityDatabaseModule().database(config)
+    assert isinstance(plugin, CommunityDatabase)
+    assert plugin._engine.pool._pre_ping is True
+    assert plugin._engine.pool._recycle == 3600
 
 
 def test_community_binds_cache(community_injector):

--- a/src/backend/tests/community/local/test_load_yaml_configs.py
+++ b/src/backend/tests/community/local/test_load_yaml_configs.py
@@ -109,6 +109,20 @@ class TestLoadYamlConfigsOverlaySelection:
         assert str(fallback_configs) in str(error.value)
 
 
+@pytest.fixture(autouse=True)
+def _community_database_url(monkeypatch):
+    """The community overlay requires a deployment-supplied ``DATABASE_URL``.
+
+    It is the Aliyun/OceanBase profile, so its ``database.url`` placeholder has
+    no inline default and strict expansion raises without one. These tests are
+    about overlay *merging*, not the DSN, so they supply what a deployment would.
+    The tests that assert the requirement itself set or clear it explicitly.
+    """
+    monkeypatch.setenv(
+        "DATABASE_URL", "mysql+pymysql://t:t@127.0.0.1:3306/agentclaw"
+    )
+
+
 class TestCommunityOverlaySelection:
     """DEPLOY_PROFILE=community 加载中性基座 application.yaml + community overlay
     （application.yaml 已中性化，可安全合并 —— B6/OSS-0 #3）。"""
@@ -213,7 +227,8 @@ class TestCommunityOverlaySelection:
     def test_community_overlay_exposes_data_infra_blocks(self):
         # B3：database/cache/object_storage/secret 四块只在 community overlay。
         user_config = _load_yaml_configs("application-community.yaml").get("user_config", {})
-        assert user_config.get("database", {}).get("url", "").startswith("sqlite:///")
+        assert user_config.get("database", {}).get("backend") == "mysql"
+        assert user_config.get("database", {}).get("url", "").startswith("mysql+")
         assert user_config.get("cache", {}).get("redis_url") == ""
         storage = user_config.get("object_storage", {})
         assert storage.get("backend") == "fs"
@@ -290,17 +305,20 @@ class TestEnvPlaceholderExpansion:
         user_config = _load_yaml_configs("application-community.yaml")["user_config"]
         assert user_config["database"]["url"] == "mysql+pymysql://u:p@rds:3306/agentclaw"
 
-    def test_community_overlay_database_url_defaults_to_sqlite(self, monkeypatch):
+    def test_community_overlay_requires_database_url(self, monkeypatch):
+        # No inline default: community is the deployed Aliyun/OceanBase profile,
+        # so a missing Secret must fail the boot rather than silently pointing
+        # production traffic at a local file.
         monkeypatch.delenv("DATABASE_URL", raising=False)
-        user_config = _load_yaml_configs("application-community.yaml")["user_config"]
-        assert user_config["database"]["url"] == "sqlite:///./data/agentclaw.db"
+        with pytest.raises(KeyError, match="DATABASE_URL"):
+            _load_yaml_configs("application-community.yaml")
 
-    def test_shipped_overlays_all_load_under_strict_expansion(self):
-        # Guard: every placeholder shipped in a community overlay must carry a
-        # default, or a bare boot breaks. Strict expansion is what enforces it.
-        for overlay in (
-            "application-community.yaml",
-            "application-singlebox.yaml",
-            "application-test.yaml",
-        ):
+    def test_local_overlays_load_bare_under_strict_expansion(self, monkeypatch):
+        # Guard: the local-facing overlays must boot with nothing exported, so
+        # every placeholder they ship carries a default. Strict expansion
+        # enforces it. `application-community.yaml` is deliberately NOT in this
+        # list — it is the deployed profile and requires DATABASE_URL (see
+        # test_community_overlay_requires_database_url).
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        for overlay in ("application-singlebox.yaml", "application-test.yaml"):
             assert _load_yaml_configs(overlay)

--- a/src/backend/tests/community/local/test_load_yaml_configs.py
+++ b/src/backend/tests/community/local/test_load_yaml_configs.py
@@ -225,3 +225,82 @@ class TestCommunityOverlaySelection:
         user_config = _load_yaml_configs("application-test.yaml").get("user_config", {})
         for block in ("database", "cache", "object_storage", "secret"):
             assert block not in user_config
+
+
+class TestEnvPlaceholderExpansion:
+    """``${NAME}`` / ``${NAME:-default}`` expansion, matching baas/gateway/proxy.
+
+    Config loading is the approved site for raw environment access, so a
+    deployment injects its DSNs and secrets here rather than through bespoke
+    ``os.environ`` reads scattered across DI providers.
+    """
+
+    def test_expands_a_set_variable(self, monkeypatch):
+        monkeypatch.setenv("AC_TEST_HOST", "db.internal")
+        result = yaml_provider._expand_env_placeholders({"url": "${AC_TEST_HOST}"})
+        assert result == {"url": "db.internal"}
+
+    def test_falls_back_to_the_inline_default(self, monkeypatch):
+        monkeypatch.delenv("AC_TEST_MISSING", raising=False)
+        result = yaml_provider._expand_env_placeholders(
+            {"url": "${AC_TEST_MISSING:-sqlite:///./data/agentclaw.db}"}
+        )
+        assert result == {"url": "sqlite:///./data/agentclaw.db"}
+
+    def test_set_but_empty_beats_the_default(self, monkeypatch):
+        # An operator who exports NAME= means empty, not "use the default".
+        monkeypatch.setenv("AC_TEST_EMPTY", "")
+        result = yaml_provider._expand_env_placeholders({"k": "${AC_TEST_EMPTY:-fallback}"})
+        assert result == {"k": ""}
+
+    def test_strict_rejects_an_unset_variable_with_no_default(self, monkeypatch):
+        # Strict is the default: a deployment that forgot to wire a Secret fails
+        # at boot instead of serving a half-configured surface.
+        monkeypatch.delenv("AC_TEST_MISSING", raising=False)
+        with pytest.raises(KeyError, match="AC_TEST_MISSING"):
+            yaml_provider._expand_env_placeholders({"k": "${AC_TEST_MISSING}"})
+
+    def test_lenient_leaves_an_unresolvable_placeholder_intact(self, monkeypatch):
+        monkeypatch.delenv("AC_TEST_MISSING", raising=False)
+        result = yaml_provider._expand_env_placeholders(
+            {"k": "${AC_TEST_MISSING}"}, strict=False
+        )
+        assert result == {"k": "${AC_TEST_MISSING}"}
+
+    def test_walks_nested_dicts_lists_and_leaves_non_strings_alone(self, monkeypatch):
+        monkeypatch.setenv("AC_TEST_V", "x")
+        tree = {"a": [{"b": "${AC_TEST_V}"}], "n": 7, "t": True, "none": None}
+        assert yaml_provider._expand_env_placeholders(tree) == {
+            "a": [{"b": "x"}],
+            "n": 7,
+            "t": True,
+            "none": None,
+        }
+
+    def test_expands_several_placeholders_in_one_string(self, monkeypatch):
+        monkeypatch.setenv("AC_TEST_H", "host")
+        monkeypatch.setenv("AC_TEST_P", "3306")
+        result = yaml_provider._expand_env_placeholders({"u": "mysql://${AC_TEST_H}:${AC_TEST_P}/db"})
+        assert result == {"u": "mysql://host:3306/db"}
+
+    def test_community_overlay_database_url_honours_the_env(self, monkeypatch):
+        # End-to-end through the real overlay: the shipped `${DATABASE_URL:-...}`
+        # placeholder is what a deployment overrides.
+        monkeypatch.setenv("DATABASE_URL", "mysql+pymysql://u:p@rds:3306/agentclaw")
+        user_config = _load_yaml_configs("application-community.yaml")["user_config"]
+        assert user_config["database"]["url"] == "mysql+pymysql://u:p@rds:3306/agentclaw"
+
+    def test_community_overlay_database_url_defaults_to_sqlite(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        user_config = _load_yaml_configs("application-community.yaml")["user_config"]
+        assert user_config["database"]["url"] == "sqlite:///./data/agentclaw.db"
+
+    def test_shipped_overlays_all_load_under_strict_expansion(self):
+        # Guard: every placeholder shipped in a community overlay must carry a
+        # default, or a bare boot breaks. Strict expansion is what enforces it.
+        for overlay in (
+            "application-community.yaml",
+            "application-singlebox.yaml",
+            "application-test.yaml",
+        ):
+            assert _load_yaml_configs(overlay)

--- a/src/backend/tests/community/plugins/community/test_database.py
+++ b/src/backend/tests/community/plugins/community/test_database.py
@@ -1,7 +1,13 @@
 """Unit tests for the community CommunityDatabase (B3).
 
-CommunityDatabase is a pure connection provider — it does NOT create tables, so
-these tests provision the schema themselves (as a community operator would).
+CommunityDatabase owns the real schema by default: ``bootstrap()`` runs
+``core/schema.py``'s ``create_all`` unless ``create_schema=False``. The
+session-level tests below are about connection and transaction behaviour rather
+than the app schema, so they provision their own throwaway tables from a
+private ``Base`` — ``bootstrap()`` would emit the *real* metadata, which these
+tests do not need. The bootstrap wiring itself is covered separately at the
+bottom of this file.
+
 Tests run against a temp on-disk SQLite file (a real persistent store, unlike
 the in-memory local impl).
 """
@@ -34,7 +40,9 @@ class _Child(Base):
 def db(tmp_path) -> CommunityDatabase:
     url = f"sqlite:///{tmp_path}/b3.db"
     database = CommunityDatabase(url)
-    # Operator-provisioned schema — the impl does not create tables.
+    # These tests exercise session/transaction behaviour against throwaway
+    # tables, so the private Base is provisioned directly instead of going
+    # through bootstrap() (which would emit the real application schema).
     Base.metadata.create_all(database._engine)
     return database
 
@@ -115,3 +123,72 @@ def test_sqlite_foreign_key_cascade_fires(db):
     with db.session() as s:
         assert s.query(_Child).filter_by(id=50).first() is None
 
+
+
+class TestBootstrapSchemaOwnership:
+    """``bootstrap()`` is what makes a container deployment self-provisioning.
+
+    The DDL itself lives in ``core/schema.py`` and is tested there; what matters
+    here is the wiring — that the plugin calls it at all, honours
+    ``create_schema``, and passes the dialect flag matching its own URL.
+    """
+
+    @staticmethod
+    def _record_create_all(monkeypatch) -> list[dict]:
+        """Capture core.schema.create_all calls without emitting real DDL."""
+        calls: list[dict] = []
+
+        def _fake_create_all(engine, *, mysql: bool = False) -> None:
+            calls.append({"engine": engine, "mysql": mysql})
+
+        monkeypatch.setattr(
+            "agentclaw.community.core.schema.create_all", _fake_create_all
+        )
+        return calls
+
+    @pytest.mark.asyncio
+    async def test_creates_the_schema_by_default(self, tmp_path, monkeypatch):
+        calls = self._record_create_all(monkeypatch)
+        database = CommunityDatabase(f"sqlite:///{tmp_path}/boot.db")
+
+        await database.bootstrap()
+
+        assert len(calls) == 1
+        assert calls[0]["engine"] is database._engine
+
+    @pytest.mark.asyncio
+    async def test_skips_ddl_when_the_operator_owns_the_schema(
+        self, tmp_path, monkeypatch
+    ):
+        calls = self._record_create_all(monkeypatch)
+        database = CommunityDatabase(
+            f"sqlite:///{tmp_path}/boot.db", create_schema=False
+        )
+
+        await database.bootstrap()
+
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_sqlite_url_does_not_request_the_mysql_ddl_pass(
+        self, tmp_path, monkeypatch
+    ):
+        calls = self._record_create_all(monkeypatch)
+        database = CommunityDatabase(f"sqlite:///{tmp_path}/boot.db")
+
+        await database.bootstrap()
+
+        assert calls[0]["mysql"] is False
+
+    @pytest.mark.asyncio
+    async def test_mysql_url_requests_the_mysql_ddl_pass(self, monkeypatch):
+        # create_engine is lazy, so this needs no reachable server. Without the
+        # flag the index keys would exceed InnoDB's cap and CREATE INDEX fails.
+        calls = self._record_create_all(monkeypatch)
+        database = CommunityDatabase(
+            "mysql+pymysql://u:p@db.example:3306/agentclaw?charset=utf8mb4"
+        )
+
+        await database.bootstrap()
+
+        assert calls[0]["mysql"] is True

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -18,6 +18,7 @@ dependencies = [
     { name = "injector" },
     { name = "pycryptodome" },
     { name = "pyjwt" },
+    { name = "pymysql" },
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "redis" },
@@ -57,6 +58,7 @@ requires-dist = [
     { name = "injector", specifier = ">=0.21,<1.0" },
     { name = "pycryptodome", specifier = ">=3.23.0" },
     { name = "pyjwt", specifier = ">=2.8.0" },
+    { name = "pymysql", specifier = ">=1.1.0" },
     { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "redis", specifier = "==7.4.0" },
@@ -793,6 +795,15 @@ source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 sdist = { url = "https://mirrors.aliyun.com/pypi/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423" }
 wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728" },
+]
+
+[[package]]
+name = "pymysql"
+version = "1.2.0"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/c9/bc/1c6a92f385940f727daeecf3bacaf186e03875dff57197801046c583bcf0/pymysql-1.2.0.tar.gz", hash = "sha256:6c7b17ca686988104d7426c27895b455cdeea3e9d3ceb1270f0c3704fead8c33" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/c4/bd/2534e130295c8cfd4f0a2e31623baab7502278f1e97bcfe61db75656a77f/pymysql-1.2.0-py3-none-any.whl", hash = "sha256:62169ce6d5510f08e140c5e7990ee884a9764024e4a9a27b2cc11f1099322ae0" },
 ]
 
 [[package]]

--- a/src/gateway/scripts/dump_and_publish.sh
+++ b/src/gateway/scripts/dump_and_publish.sh
@@ -73,7 +73,11 @@ _upstream_dir() {
 
 _upstream_env() {
     case "$1" in
-        backend) echo "DEPLOY_PROFILE=community" ;;
+        # The community overlay requires a deployment-supplied DATABASE_URL (it is
+        # the Aliyun/OceanBase profile, so its url placeholder has no default).
+        # Dumping the schema only imports the app; no connection is opened, so a
+        # placeholder DSN is enough to get past config resolution.
+        backend) echo "DEPLOY_PROFILE=community DATABASE_URL=mysql+pymysql://dump:dump@127.0.0.1:3306/agentclaw" ;;
         baas)    echo "SECBAAS_RUN_MODE=bare" ;;
         bcn)     echo "" ;;
         bcn-internal) echo "" ;;


### PR DESCRIPTION
## Problem

The `community` profile is the deployed profile, and that deployment runs on Aliyun against OceanBase. Three things stood in the way:

1. **No way to get a DSN in from the environment.** `YamlConfigProvider` did no env interpolation, unlike the loaders baas, gateway and proxy already ship. A k8s Secret had no route into the config.
2. **The profile did not own its schema.** `CommunityDatabase` explicitly did not create tables — "the schema is operator-provisioned". Booting `DEPLOY_PROFILE=community` against an empty database failed during *startup*:
   ```
   sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: ac_bots
   ```
   The `create_all` that makes `singlebox` work lived inside the local SQLite plugin, reachable only from `test`/`singlebox`.
3. **No MySQL-family support.** No driver was declared, and the shipped models do not survive `create_all` on MySQL as declared — 30 index keys exceed InnoDB's 3072-byte cap once utf8mb4 bills 4 bytes per character. Corp never hits this because its DDL is applied out of band.

Pods on ACK are ephemeral and replicated, so SQLite is not an option, and nobody runs DDL between `kubectl apply` and the first request.

## Solution

**Env placeholders in YAML.** `${NAME}` / `${NAME:-default}` expanded after the base⊕overlay merge, same regex and syntax as the other three services. Strict by default (matching baas): a variable that is neither set nor defaulted fails the boot rather than serving a half-configured surface. This replaces the bespoke `os.environ` read in the database DI provider — raw env access now happens only in config loading, where AGENTS.md puts it.

**The community overlay now names the real store.**

```yaml
database:
  backend: "mysql"          # OceanBase speaks the MySQL protocol in MySQL mode
  url: "${DATABASE_URL}"    # no inline default — deployment-supplied
  create_schema: true
```

`backend` selects the store (`sqlite` | `mysql` | `postgresql`) and drives engine setup; the provider rejects a `url` whose scheme disagrees with it rather than silently falling back. MySQL gets `pool_pre_ping` + `pool_recycle`, without which the first request after an idle period dies on a connection the managed instance already closed.

The URL has no default on purpose: a DSN cannot be a literal, and strict expansion makes a missing `DATABASE_URL` fail the boot loudly instead of quietly pointing production traffic at a file inside the container.

**Schema ownership.** Model registration and `create_all` move from the local SQLite plugin to `core/schema.py`; both plugins call it, so a community deployment gets the same tables a singlebox boot does. `create_schema: false` returns the plugin to a pure connection provider for operators who run their own migrations. `create_all` uses `checkfirst=True`, so re-boots issue no CREATEs for tables that already exist.

`prepare_for_mysql` caps over-long index keys with per-column prefix lengths, cutting the widest column first and leaving narrow ones whole. **It changes no column and truncates no data** — only what goes into the index:

```sql
CREATE UNIQUE INDEX uk_bot_id_entity_id_env_tenant ON ac_bots (bot_id, entity_id(512), env, avernet_tenant)
```

**Two judgement calls worth review.**

*Prefix-uniqueness.* Six of the 30 over-long keys are `UniqueConstraint`s, which SQLAlchemy cannot prefix, so they become equivalent unique `Index`es — the same object in MySQL. That narrows those keys to *prefix*-uniqueness: two ids agreeing for the first N characters would now collide. The columns hold ids and short type discriminators so it is not reachable in practice, but it is a real narrowing. The convention for *new* tables (`bot_startup_script`) is a bounded sha256 surrogate column instead; retrofitting that onto six existing tables means changing their write paths.

*The 3072 figure is InnoDB's, not OceanBase's.* `src/gateway/migrations/mysql/001_init_schema.sql` applies the same number to the same "MySQL/OceanBase" target, so this is consistent with the house assumption — but it has not been checked against a live cluster. If OceanBase's limit differs, `_INNODB_MAX_KEY_BYTES` is the single constant to retune.

**Boot path.** `main.py` no longer installs the `sofapy_base` / `layotto` / `arca` stubs — no community code imports any of them any more (only docstrings mention them), and the app boots with all three blocked at `sys.meta_path`. Listen address is now `BACKEND_HOST` / `BACKEND_PORT`, defaulting to the previous `0.0.0.0:8888`.

## Validation

All 8 CI checks green on the current head `b545d70` (and on `1581c75` before it).

Full community suite locally: **14,518 passed, 58 skipped**. The 2 failures in `test_bot_build_service_skill_artifact.py` are pre-existing and environmental (`rsync` is not installed in my sandbox) — confirmed on a stashed clean tree, and CI runs them green.

End-to-end boot, both profiles, with `sofapy_base`/`layotto`/`arca` blocked at `sys.meta_path`:

```
community: health=200 tables=83
singlebox: health=200 tables=83
```

OSS boot gate after the overlay change: `COMMUNITY BOOT GATE: PASS`. OpenAPI dump under the community profile with a placeholder DSN and no database running: `DUMP OK — paths: 191`.

MySQL DDL, verified by compiling the real metadata against the MySQL dialect (no server needed):

```
over-limit keys BEFORE: 30
over-limit keys AFTER:  0
MySQL DDL compile failures: 0 | indexes: 312
```

New tests: 10 for env expansion, 5 for the DB config surface (mismatch rejection, defaults, MySQL pooling), 10 for `core/schema.py`, 4 for the `bootstrap()` wiring (verified non-vacuous by mutating the dialect flag). `ruff check` clean on every changed file.

**Not verified:** no connection to a real MySQL or OceanBase instance was made — the sandbox has none. The DDL is proven to compile and to fit InnoDB's cap, but a first boot against a real cluster is untested, and the index-limit caveat above rides on it. Also, `uv.lock` was regenerated against pypi and normalized back to the pinned aliyun mirror URLs (the mirror is unreachable from the sandbox), so the pymysql entry's fetch from that mirror is unverified — the diff is 11 added lines, pymysql only.

## Compatibility and risk

- **No corp impact:** `corp` installs a different module column and never runs this code.
- **No singlebox/test impact:** same `SqliteDB` binding, same tables; only the `create_all` body moved.
- **The community overlay no longer loads bare.** `database.url` went from a literal to a required `${DATABASE_URL}`, so anything that reads this overlay must now supply a DSN. Two call sites use the profile without deploying it and were updated with a placeholder DSN and a comment: `scripts/community_selftest.py` (the OSS gate proving the tree boots with corp absent) and `src/gateway/scripts/dump_and_publish.sh` (OpenAPI dump). Both only import the app; config resolution opens no connection, and schema DDL runs under the lifespan, which neither enters — both verified to still pass.
- **The `community` profile was carrying two jobs** — the corp-free OSS distribution profile *and* the deployed configuration. Those want opposite defaults and this change picks the deployment, so an open-source checkout can no longer boot it without a DSN. Deliberate; if the OSS bare-boot story matters later, the clean fix is a separate overlay rather than softening this one.
- `CommunityDatabaseConfig`'s SQLite field defaults remain, now documented as the no-block fallback rather than what community deploys. They are what `DEPLOY_PROFILE=test` resolves, since `application-test.yaml` carries no `database` block.
- The golden config snapshot was regenerated; it deliberately does not expand placeholders, which is now documented in `effective_config.py`.
- Rollback is a revert; no data migration.

## Still open for the Aliyun deployment (not in this PR)

- No `backend.dockerfile` in `docker/services/` (baas, gateway, proxy have one).
- `docker/kube-deploy.sh` registers backend at port 8080 while its own header comment says 8090; `BACKEND_PORT` now makes either reachable, but the script needs picking.
- `docker/services/service-deployment.yaml` probes `/health`; the backend serves `/api/health`, so a backend pod rendered from that shared template would never pass readiness. Fixing it needs a per-service probe path, which touches the other three services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2TjVaVUgAmpt8F3kZyrK6