### PR TITLE
perf(backend): batch Local Skill package writes and share BaaS http_info

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/services/baas_invoke_transport.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_invoke_transport.py
@@ -41,9 +41,17 @@ if TYPE_CHECKING:
 # by the refresh-and-retry in :meth:`BaasInvokeTransport._invoke`.
 _HTTP_INFO_TTL_SECONDS = 30.0
 
-# Gateway verdicts that mean "this token is no longer good" — the one case where a
-# cached ``http_info`` must be dropped and the call replayed against a fresh one.
-_STALE_TOKEN_STATUSES = frozenset({401, 403})
+# The proxypass gateway answers 401 when it rejects the token it was handed — the one
+# verdict that means "this cached http_info is no longer usable".
+#
+# 403 is deliberately excluded. It does not identify a token problem: the engine's file
+# router maps ``PermissionError`` to 403 (``engine/community/api/file/router.py``) and
+# the proxy forwards upstream responses through unchanged
+# (``sandboxproxy/community/adapters/web/routes.py``), so a 403 is the device's own
+# authorization answer. Replaying it would re-run a mutating upload/delete and, with no
+# ``device_uuid`` pinning the instance, possibly run it against a *different* device —
+# while hiding the engine's actual verdict from the caller.
+_STALE_TOKEN_STATUS = 401
 
 
 def build_desktop_client() -> httpx.Client:
@@ -124,7 +132,9 @@ class BaasInvokeTransport:
         self._http_info_lock = threading.Lock()
         self._http_info_cache: dict[str, tuple[float, "HttpConnectionInfo"]] = {}
 
-    def _http_info(self, path: str, *, refresh: bool = False) -> "HttpConnectionInfo":
+    def _http_info(
+        self, path: str, *, stale: "HttpConnectionInfo | None" = None
+    ) -> "HttpConnectionInfo":
         """Resolve ``http_info`` for ``path``, reusing a fresh cached one.
 
         Keyed by ``path`` alone because every other input BaaS resolves against
@@ -132,14 +142,21 @@ class BaasInvokeTransport:
         this instance. Path must stay in the key: the returned ``http_url`` embeds
         it, so reusing one path's entry for another would POST to the wrong route.
 
-        ``refresh=True`` forces a new resolution and replaces the entry — used by
-        :meth:`_invoke` when the gateway rejects a cached token.
+        ``stale`` names the entry the caller was just rejected on, which makes a
+        refresh a compare-and-swap: it re-resolves only while the cache still holds
+        that exact entry, and otherwise hands back whatever replaced it. An
+        unconditional refresh would resolve once per in-flight request when a
+        concurrent batch is rejected together — reinstating, on the failure path,
+        the very per-file fan-out this cache exists to remove.
         """
         with self._http_info_lock:
-            if not refresh:
-                cached = self._http_info_cache.get(path)
-                if cached is not None and cached[0] > time.monotonic():
-                    return cached[1]
+            cached = self._http_info_cache.get(path)
+            if (
+                cached is not None
+                and cached[0] > time.monotonic()
+                and cached[1] is not stale
+            ):
+                return cached[1]
             info = self._baas_service.get_http_info(
                 bind_id=self._bind_id,
                 port=self._engine_port,
@@ -156,12 +173,15 @@ class BaasInvokeTransport:
     def _invoke(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
         """Issue one container call against this transport's cached ``http_info``.
 
-        Retries once against a freshly resolved ``http_info`` when the gateway
-        answers 401/403: a cached token can expire (or its device be reallocated)
-        mid-batch, and a caller must never see a spurious auth failure caused by
-        this cache choosing to reuse a token. Replay is safe because every payload
-        we send is already materialised (``json`` dicts, ``files`` bytes) rather
-        than a consumed stream. A genuine misconfiguration simply fails twice.
+        Retries once against a re-resolved ``http_info`` when the gateway answers
+        401: a cached token can expire (or its device be reallocated) mid-batch, and
+        a caller must never see a spurious auth failure caused by this cache
+        choosing to reuse a token. Replay is safe because every payload we send is
+        already materialised (``json`` dicts, ``files`` bytes) rather than a consumed
+        stream. A genuine misconfiguration simply fails twice.
+
+        Every other status — 403 included, see :data:`_STALE_TOKEN_STATUS` — is the
+        device's own answer and is returned untouched.
         """
         call = dict(
             bind_id=self._bind_id,
@@ -177,12 +197,11 @@ class BaasInvokeTransport:
             device_uuid=self._device_uuid,
             **kwargs,
         )
-        response = self._baas_service.invoke_http(
-            **call, http_info=self._http_info(path)
-        )
-        if response.status_code in _STALE_TOKEN_STATUSES:
+        info = self._http_info(path)
+        response = self._baas_service.invoke_http(**call, http_info=info)
+        if response.status_code == _STALE_TOKEN_STATUS:
             return self._baas_service.invoke_http(
-                **call, http_info=self._http_info(path, refresh=True)
+                **call, http_info=self._http_info(path, stale=info)
             )
         return response
 

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_invoke_transport.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_invoke_transport.py
@@ -20,12 +20,51 @@ docs/superpowers/specs/2026-06-17-baas-transport-bot-type-strategy-design.md
 """
 from __future__ import annotations
 
+import threading
+import time
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import httpx
 
 if TYPE_CHECKING:
-    from agentclaw.community.core.service_bot.services.baas_service import BaasService
+    from agentclaw.community.core.service_bot.services.baas_service import (
+        BaasService,
+        HttpConnectionInfo,
+    )
+
+
+# BaaS mints ``http_url`` + ``token`` per (bind_id, port, path). A package upload
+# POSTs every file to the SAME path (``/api/file/upload``), so one resolution serves
+# the whole batch; resolving per file cost a binding DB lookup plus a BaaS round trip
+# each, doubling the request count of every multi-file write. This TTL keeps a reused
+# token comfortably inside its lifetime, and a token that expires anyway is recovered
+# by the refresh-and-retry in :meth:`BaasInvokeTransport._invoke`.
+_HTTP_INFO_TTL_SECONDS = 30.0
+
+# Gateway verdicts that mean "this token is no longer good" — the one case where a
+# cached ``http_info`` must be dropped and the call replayed against a fresh one.
+_STALE_TOKEN_STATUSES = frozenset({401, 403})
+
+
+def build_desktop_client() -> httpx.Client:
+    """Build the pooled client :class:`DesktopBaasInvokeTransport` sends through.
+
+    Built once by the (singleton) device-filesystem resolver and injected into every
+    desktop transport it mints, so its lifetime is the process and its ownership is
+    the injector's — not a module-level lazy singleton.
+
+    Pooling is the point: a transport used to open a fresh ``httpx.Client`` per call,
+    forcing a TCP + TLS handshake for every file in a package upload. One shared
+    client turns that into one handshake per pooled connection. Sharing is safe —
+    ``httpx.Client`` is thread-safe (device I/O runs on ``asyncio.to_thread`` worker
+    threads) and every call already carries its own absolute URL and headers.
+    """
+    return httpx.Client(
+        timeout=30.0,
+        # Comfortably above the device-I/O fan-out so pool waits never become the
+        # new bottleneck, while still bounding total sockets.
+        limits=httpx.Limits(max_connections=64, max_keepalive_connections=32),
+    )
 
 
 @runtime_checkable
@@ -53,6 +92,11 @@ class BaasInvokeTransport:
     """通过 BaaSService.invoke_http(get_http_info → http_url → POST)。
 
     适用云上 baas 容器(未来 personal+baas / service+baas)。
+
+    Resolution (``get_http_info``) is cached per path for the life of this
+    instance — see :meth:`_http_info`. The resolver builds one transport per
+    dispatch, so that lifetime is a single request and there is no cross-request
+    staleness to reason about.
     """
 
     def __init__(
@@ -72,13 +116,58 @@ class BaasInvokeTransport:
         # invoke_http → get_http_info → BaaS /http-info?device_uuid=。``None`` 表示
         # 单实例 / 未指定，走 BaaS 自动选活跃实例的老行为。
         self._device_uuid = device_uuid
+        # Guards the cache against the worker threads ``asyncio.to_thread`` fans
+        # device I/O out across. Deliberately held across the ``get_http_info``
+        # call itself, so a batch of concurrent writes coalesces onto ONE
+        # resolution instead of every thread missing the cache and resolving its
+        # own — the whole point of caching here.
+        self._http_info_lock = threading.Lock()
+        self._http_info_cache: dict[str, tuple[float, "HttpConnectionInfo"]] = {}
 
-    def post(self, path: str, *, json: Any | None = None) -> httpx.Response:
-        return self._baas_service.invoke_http(
+    def _http_info(self, path: str, *, refresh: bool = False) -> "HttpConnectionInfo":
+        """Resolve ``http_info`` for ``path``, reusing a fresh cached one.
+
+        Keyed by ``path`` alone because every other input BaaS resolves against
+        (``bind_id`` / ``engine_port`` / ``tenant`` / ``device_uuid``) is fixed for
+        this instance. Path must stay in the key: the returned ``http_url`` embeds
+        it, so reusing one path's entry for another would POST to the wrong route.
+
+        ``refresh=True`` forces a new resolution and replaces the entry — used by
+        :meth:`_invoke` when the gateway rejects a cached token.
+        """
+        with self._http_info_lock:
+            if not refresh:
+                cached = self._http_info_cache.get(path)
+                if cached is not None and cached[0] > time.monotonic():
+                    return cached[1]
+            info = self._baas_service.get_http_info(
+                bind_id=self._bind_id,
+                port=self._engine_port,
+                path=path,
+                tenant=self._tenant,
+                device_uuid=self._device_uuid,
+            )
+            self._http_info_cache[path] = (
+                time.monotonic() + _HTTP_INFO_TTL_SECONDS,
+                info,
+            )
+            return info
+
+    def _invoke(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Issue one container call against this transport's cached ``http_info``.
+
+        Retries once against a freshly resolved ``http_info`` when the gateway
+        answers 401/403: a cached token can expire (or its device be reallocated)
+        mid-batch, and a caller must never see a spurious auth failure caused by
+        this cache choosing to reuse a token. Replay is safe because every payload
+        we send is already materialised (``json`` dicts, ``files`` bytes) rather
+        than a consumed stream. A genuine misconfiguration simply fails twice.
+        """
+        call = dict(
             bind_id=self._bind_id,
             port=self._engine_port,
             path=path,
-            json=json,
+            method=method,
             tenant=self._tenant,
             # 云上 baas 容器经 agentclawproxy ``/proxypass`` 网关访问，网关用
             # ``x-proxypass-token`` 鉴权（与 teclaw/arca 同一网关）；不传则默认
@@ -86,31 +175,28 @@ class BaasInvokeTransport:
             # 仅 header 名不同。
             auth_header="x-proxypass-token",
             device_uuid=self._device_uuid,
+            **kwargs,
         )
+        response = self._baas_service.invoke_http(
+            **call, http_info=self._http_info(path)
+        )
+        if response.status_code in _STALE_TOKEN_STATUSES:
+            return self._baas_service.invoke_http(
+                **call, http_info=self._http_info(path, refresh=True)
+            )
+        return response
+
+    def post(self, path: str, *, json: Any | None = None) -> httpx.Response:
+        return self._invoke("POST", path, json=json)
 
     def get(self, path: str) -> httpx.Response:
-        return self._baas_service.invoke_http(
-            bind_id=self._bind_id, port=self._engine_port, path=path,
-            method="GET", tenant=self._tenant,
-            auth_header="x-proxypass-token",
-            device_uuid=self._device_uuid,
-        )
+        return self._invoke("GET", path)
 
     def put(self, path: str, *, json: Any | None = None) -> httpx.Response:
-        return self._baas_service.invoke_http(
-            bind_id=self._bind_id, port=self._engine_port, path=path,
-            method="PUT", json=json, tenant=self._tenant,
-            auth_header="x-proxypass-token",
-            device_uuid=self._device_uuid,
-        )
+        return self._invoke("PUT", path, json=json)
 
     def delete(self, path: str) -> httpx.Response:
-        return self._baas_service.invoke_http(
-            bind_id=self._bind_id, port=self._engine_port, path=path,
-            method="DELETE", tenant=self._tenant,
-            auth_header="x-proxypass-token",
-            device_uuid=self._device_uuid,
-        )
+        return self._invoke("DELETE", path)
 
     def post_multipart(
         self,
@@ -123,25 +209,21 @@ class BaasInvokeTransport:
 
         invoke_http 通过 files/data 参数走 multipart 路径,内部用
         ``general_http_client.post(url, files=..., data=...)``。
+
+        Every file in a package upload lands here on the same ``path``, so all of
+        them share one cached ``http_info`` resolution.
         """
-        return self._baas_service.invoke_http(
-            bind_id=self._bind_id,
-            port=self._engine_port,
-            path=path,
-            method="POST",
-            files=files,
-            data=data,
-            tenant=self._tenant,
-            # 同 post：proxypass 网关鉴权 header（写文件 multipart 链路同样需要）。
-            auth_header="x-proxypass-token",
-            device_uuid=self._device_uuid,
-        )
+        return self._invoke("POST", path, files=files, data=data)
 
 
 class DesktopBaasInvokeTransport:
     """自拼 secbaas transparent proxy URL,直接 httpx POST。
 
     适用 desktop bot(VM 在用户机器,BaaS get_http_info 返 localhost 拨不通)。
+
+    Requests go through the injected pooled ``client`` (built by
+    :func:`build_desktop_client`) so a multi-file write reuses keep-alive
+    connections instead of paying a TLS handshake per file.
     """
 
     def __init__(
@@ -152,29 +234,34 @@ class DesktopBaasInvokeTransport:
         bot_uuid: str,
         engine_port: int,
         headers: dict[str, str],
+        client: httpx.Client,
     ):
         self._baas_base_url = baas_base_url
         self._tenant = tenant
         self._bot_uuid = bot_uuid
         self._engine_port = engine_port
         self._headers = headers
+        self._client = client
 
     def post(self, path: str, *, json: Any | None = None) -> httpx.Response:
-        url = self._invoke_url(path)
-        with httpx.Client(timeout=30.0) as client:
-            return client.post(url, json=json, headers=self._headers)
+        return self._client.post(
+            self._invoke_url(path), json=json, headers=self._headers
+        )
 
     def get(self, path: str) -> httpx.Response:
-        with httpx.Client(timeout=30.0) as client:
-            return client.get(self._invoke_url(path), headers=self._headers)
+        return self._client.get(
+            self._invoke_url(path), headers=self._headers
+        )
 
     def put(self, path: str, *, json: Any | None = None) -> httpx.Response:
-        with httpx.Client(timeout=30.0) as client:
-            return client.put(self._invoke_url(path), json=json, headers=self._headers)
+        return self._client.put(
+            self._invoke_url(path), json=json, headers=self._headers
+        )
 
     def delete(self, path: str) -> httpx.Response:
-        with httpx.Client(timeout=30.0) as client:
-            return client.delete(self._invoke_url(path), headers=self._headers)
+        return self._client.delete(
+            self._invoke_url(path), headers=self._headers
+        )
 
     def post_multipart(
         self,
@@ -183,9 +270,9 @@ class DesktopBaasInvokeTransport:
         files: Any,
         data: Any,
     ) -> httpx.Response:
-        url = self._invoke_url(path)
-        with httpx.Client(timeout=30.0) as client:
-            return client.post(url, files=files, data=data, headers=self._headers)
+        return self._client.post(
+            self._invoke_url(path), files=files, data=data, headers=self._headers
+        )
 
     def _invoke_url(self, api_path: str) -> str:
         if not api_path.startswith("/"):

--- a/src/backend/src/agentclaw/community/core/devices/services/device_filesystem_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_filesystem_resolver.py
@@ -17,6 +17,9 @@ from injector import inject
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.repository.protocols.devices import DeviceBindingRepository
+from agentclaw.community.core.devices.services.baas_invoke_transport import (
+    build_desktop_client,
+)
 from agentclaw.community.core.devices.services.device_context import UnknownProviderError
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.log import get_logger
@@ -44,6 +47,12 @@ class DefaultDeviceFileSystemResolver:
         self._bot_repo = bot_repo
         self._binding_repo = binding_repo
         self._sandbox_client = sandbox_client
+        # One pooled HTTP client shared by every desktop transport this resolver
+        # mints. Owned here because this resolver is a singleton, so the pool's
+        # lifetime is the process without a module-level lazy singleton. Built
+        # eagerly and cheaply — ``httpx.Client`` opens no connection until its
+        # first request — so desktop bots never pay a TLS handshake per file.
+        self._desktop_client = build_desktop_client()
 
     def __call__(
         self, ctx: "DeviceContext", path_mapper: Callable[[str], str]
@@ -72,6 +81,7 @@ class DefaultDeviceFileSystemResolver:
                     bot_uuid=conn_info["paas_device_id"],
                     engine_port=engine_port,
                     headers=conn_info.get("headers", {}),
+                    client=self._desktop_client,
                 )
                 logger.info(
                     "[DEVICE-PLUGIN-DEBUG] → DesktopBaasDeviceFileSystem(paas_device_id=%s)",

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -3430,6 +3430,7 @@ class BaasService:  # pragma: no cover
         device_uuid: Optional[str] = None,
         auth_header: str = "openclawToken",
         timeout: float | None = None,
+        http_info: Optional[HttpConnectionInfo] = None,
     ) -> httpx.Response:
         """容器内 API 统一出口：封装 get_http_info + 直传完整 http_url。
 
@@ -3459,6 +3460,13 @@ class BaasService:  # pragma: no cover
                 需传 ``"x-proxypass-token"`` —— 该网关用此 header 鉴权，传 openclawToken
                 会 401。``info.token`` 是网关对应的 token，header 名不同而已。
             timeout: 获取连接信息并调用容器 API 的总超时秒数；不传时沿用各请求默认值。
+            http_info: 已解析好的连接信息。传入时跳过 get_http_info（省掉一次
+                binding 查库 + 一次 BaaS 往返），直接用它的 ``http_url``/``token``
+                发请求。调用方须保证它是用**同一** bind_id / port / **path** /
+                tenant / device_uuid 解析出来的 —— ``http_url`` 里含 path，换个
+                path 复用会打到错误的容器路由。批量同 path 请求（如逐文件
+                ``/api/file/upload``）由 ``BaasInvokeTransport`` 按 path 缓存后
+                在此复用。
 
         Returns:
             httpx.Response — 来自 self._general_http 的原始响应，供调用方自行处理
@@ -3470,18 +3478,24 @@ class BaasService:  # pragma: no cover
             raise ValueError("timeout must be positive")
 
         started_at = time.monotonic() if timeout is not None else None
-        http_info_timeout_kwargs = (
-            {"timeout": min(timeout, 5.0)} if timeout is not None else {}
-        )
-        info = self.get_http_info(
-            bind_id=bind_id,
-            port=port,
-            path=path,
-            tenant=tenant,
-            device_affinity=device_affinity,
-            device_uuid=device_uuid,
-            **http_info_timeout_kwargs,
-        )
+        if http_info is not None:
+            # Caller already resolved this (same bind_id/port/path/tenant/device_uuid)
+            # and is reusing it across a batch — the whole ``timeout`` budget is the
+            # container request's, since no resolution round trip is spent here.
+            info = http_info
+        else:
+            http_info_timeout_kwargs = (
+                {"timeout": min(timeout, 5.0)} if timeout is not None else {}
+            )
+            info = self.get_http_info(
+                bind_id=bind_id,
+                port=port,
+                path=path,
+                tenant=tenant,
+                device_affinity=device_affinity,
+                device_uuid=device_uuid,
+                **http_info_timeout_kwargs,
+            )
 
         request_timeout_kwargs: dict[str, float] = {}
         if timeout is not None and started_at is not None:

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -124,7 +124,19 @@ async def _gather_package_io(coroutines: list) -> list:
     except BaseException:
         # Shielding keeps ``batch`` running when the caller is cancelled; awaiting it
         # here is what guarantees no write is still in flight once this raises.
-        await asyncio.gather(batch, return_exceptions=True)
+        #
+        # The drain is itself shielded, and loops, because cancellation can arrive
+        # more than once — an aborted request overlapping with shutdown, say. A
+        # plain ``await`` here would let that second cancel tear down ``batch``
+        # itself and re-raise with the worker-thread writes still running, which is
+        # exactly the failure the shield above prevents on the first cancel. Only
+        # ``CancelledError`` is absorbed, and only until ``batch`` finishes, so this
+        # delays cancellation by at most the batch's own remaining work.
+        while not batch.done():
+            try:
+                await asyncio.shield(batch)
+            except asyncio.CancelledError:
+                continue
         raise
     for result in results:
         if isinstance(result, BaseException):

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -14,6 +14,7 @@ needs the dispatcher *types* under ``TYPE_CHECKING``.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, TYPE_CHECKING
 
@@ -70,6 +71,49 @@ class LocalSkillQuarantineRepairError(OSError):
     """A partial authoritative-package delete could not be verified repaired."""
 
 
+# Every package file is one device round trip. Issuing them sequentially made a
+# package cost ``file_count × round_trip``, which dominates upload time for the many
+# small files a skill package is made of. Fan them out instead — but bounded: device
+# filesystems run their blocking transport through ``asyncio.to_thread``, whose
+# default executor (``min(32, cpu_count + 4)`` threads) is shared with every other
+# caller in the process, so an unbounded ``gather`` over a large package would starve
+# unrelated work.
+_PACKAGE_IO_CONCURRENCY = 8
+
+
+async def _gather_package_io(coroutines: list) -> list:
+    """Run package-file I/O concurrently, bounded, and drain before returning.
+
+    Every coroutine is awaited to completion even after one fails, then the first
+    failure *in input order* is re-raised. Draining is what makes the fan-out safe
+    to substitute for the sequential loop: a caller that sees ``write`` fail treats
+    the package as failed and immediately ``delete_tree``s its directory, so a write
+    still in flight at that moment could land a file behind the cleanup and leave an
+    orphan the next upload would trip over. Re-raising in input order keeps the
+    surfaced error the same one the sequential loop would have raised.
+    """
+    semaphore = asyncio.Semaphore(_PACKAGE_IO_CONCURRENCY)
+
+    async def _bounded(coro):
+        try:
+            async with semaphore:
+                return await coro
+        finally:
+            # Cancelling this batch while a coroutine is still queued on the
+            # semaphore would leave it never awaited, which Python surfaces as a
+            # RuntimeWarning. Closing an already-finished coroutine is a no-op, so
+            # this is safe on the normal path too.
+            coro.close()
+
+    results = await asyncio.gather(
+        *(_bounded(coro) for coro in coroutines), return_exceptions=True
+    )
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result
+    return results
+
+
 class LocalSkillPackageStorage:
     """Explicit package-I/O port owned by the SkillService factory."""
 
@@ -83,10 +127,14 @@ class LocalSkillPackageStorage:
         return self._device_directory
 
     async def write(self, files: list[tuple[str, bytes]]) -> None:
-        for relative_path, content in files:
-            await self._filesystem.write_file(
-                f"{self._device_directory}/{relative_path}", content
-            )
+        await _gather_package_io(
+            [
+                self._filesystem.write_file(
+                    f"{self._device_directory}/{relative_path}", content
+                )
+                for relative_path, content in files
+            ]
+        )
 
     async def prepare(self) -> None:
         """Remove an orphaned failed upload before writing a first package."""
@@ -149,16 +197,27 @@ class LocalSkillPackageStorage:
         files = await self._read_package_files()
         if await quarantine._filesystem.exists(quarantine.directory):
             raise OSError("Local Skill quarantine already exists")
-        for relative_path, content in files:
-            await quarantine._filesystem.write_file(
-                f"{quarantine.directory}/{relative_path}", content
-            )
-        for relative_path, content in files:
-            copied = await quarantine._filesystem.read_file(
-                f"{quarantine.directory}/{relative_path}"
-            )
-            if copied != content:
-                raise OSError("Local Skill quarantine verification failed")
+        await _gather_package_io(
+            [
+                quarantine._filesystem.write_file(
+                    f"{quarantine.directory}/{relative_path}", content
+                )
+                for relative_path, content in files
+            ]
+        )
+        copied = await _gather_package_io(
+            [
+                quarantine._filesystem.read_file(
+                    f"{quarantine.directory}/{relative_path}"
+                )
+                for relative_path, _ in files
+            ]
+        )
+        if any(
+            actual != expected
+            for actual, (_, expected) in zip(copied, files)
+        ):
+            raise OSError("Local Skill quarantine verification failed")
         try:
             source_cleaned = await self.cleanup()
         except Exception:
@@ -198,17 +257,24 @@ class LocalSkillPackageStorage:
         return True, await quarantine.cleanup()
 
     async def _restore_contents(self, files: list[tuple[str, bytes]]) -> bool:
-        for relative_path, content in files:
-            await self._filesystem.write_file(
-                f"{self.directory}/{relative_path}", content
-            )
-        for relative_path, content in files:
-            restored = await self._filesystem.read_file(
-                f"{self.directory}/{relative_path}"
-            )
-            if restored != content:
-                return False
-        return True
+        await _gather_package_io(
+            [
+                self._filesystem.write_file(
+                    f"{self.directory}/{relative_path}", content
+                )
+                for relative_path, content in files
+            ]
+        )
+        restored = await _gather_package_io(
+            [
+                self._filesystem.read_file(f"{self.directory}/{relative_path}")
+                for relative_path, _ in files
+            ]
+        )
+        return all(
+            actual == expected
+            for actual, (_, expected) in zip(restored, files)
+        )
 
     async def _read_package_files(self) -> list[tuple[str, bytes]]:
         entries = await self._filesystem.list_dir(
@@ -216,7 +282,7 @@ class LocalSkillPackageStorage:
         )
         if entries is None:
             raise OSError("Local Skill package is missing")
-        files: list[tuple[str, bytes]] = []
+        relative_paths: list[str] = []
         for entry in entries:
             if entry.get("is_dir"):
                 continue
@@ -227,9 +293,20 @@ class LocalSkillPackageStorage:
                 or ".." in relative_path.split("/")
             ):
                 raise OSError("Local Skill package has an invalid file path")
-            content = await self._filesystem.read_file(
-                f"{self._device_directory}/{relative_path}"
-            )
+            relative_paths.append(relative_path)
+        # Every listed path is validated before a single read is issued, so a
+        # package containing an invalid path is still rejected outright rather
+        # than partially read.
+        contents = await _gather_package_io(
+            [
+                self._filesystem.read_file(
+                    f"{self._device_directory}/{relative_path}"
+                )
+                for relative_path in relative_paths
+            ]
+        )
+        files: list[tuple[str, bytes]] = []
+        for relative_path, content in zip(relative_paths, contents):
             if content is None:
                 raise OSError("Local Skill package file disappeared")
             files.append((relative_path, content))

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -91,6 +91,17 @@ async def _gather_package_io(coroutines: list) -> list:
     still in flight at that moment could land a file behind the cleanup and leave an
     orphan the next upload would trip over. Re-raising in input order keeps the
     surfaced error the same one the sequential loop would have raised.
+
+    Cancellation is drained the same way, and needs its own handling because it does
+    not travel the exception path: device filesystems block inside
+    ``asyncio.to_thread``, which cannot interrupt a call already executing on a
+    worker thread — cancelling only abandons the await while the HTTP write keeps
+    going. Worse, ``CancelledError`` is a ``BaseException``, so
+    ``LocalSkillUploadService``'s ``except Exception`` compensation is skipped while
+    its ``finally`` still releases the edit lease. A retry could then acquire the
+    lease, ``delete_tree`` the directory and start a fresh package that the
+    abandoned writes land into. So the batch is shielded and drained before the
+    cancellation is allowed to continue.
     """
     semaphore = asyncio.Semaphore(_PACKAGE_IO_CONCURRENCY)
 
@@ -99,15 +110,22 @@ async def _gather_package_io(coroutines: list) -> list:
             async with semaphore:
                 return await coro
         finally:
-            # Cancelling this batch while a coroutine is still queued on the
-            # semaphore would leave it never awaited, which Python surfaces as a
-            # RuntimeWarning. Closing an already-finished coroutine is a no-op, so
-            # this is safe on the normal path too.
+            # A coroutine still queued on the semaphore when this batch is cancelled
+            # would never be awaited, which Python surfaces as a RuntimeWarning.
+            # Closing an already-finished coroutine is a no-op, so this is safe on
+            # the normal path too.
             coro.close()
 
-    results = await asyncio.gather(
-        *(_bounded(coro) for coro in coroutines), return_exceptions=True
+    batch = asyncio.ensure_future(
+        asyncio.gather(*(_bounded(coro) for coro in coroutines), return_exceptions=True)
     )
+    try:
+        results = await asyncio.shield(batch)
+    except BaseException:
+        # Shielding keeps ``batch`` running when the caller is cancelled; awaiting it
+        # here is what guarantees no write is still in flight once this raises.
+        await asyncio.gather(batch, return_exceptions=True)
+        raise
     for result in results:
         if isinstance(result, BaseException):
             raise result

--- a/src/backend/tests/community/core/skill_center/test_local_skill_package_storage_io.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_package_storage_io.py
@@ -195,3 +195,28 @@ async def test_a_package_upload_resolves_http_info_once_for_the_whole_batch():
         call.kwargs["data"]["target_path"] for call in baas_service.invoke_http.call_args_list
     }
     assert uploaded == {f"{DIRECTORY}/{name}" for name, _ in files}
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_write_drains_in_flight_writes_before_propagating():
+    """取消也必须先排空 —— to_thread 停不掉已经在工作线程里跑的写。
+
+    ``CancelledError`` 是 ``BaseException``，所以 ``LocalSkillUploadService`` 的
+    ``except Exception`` 补偿会被整个跳过，而它的 ``finally`` 仍然放掉 edit lease。
+    此时若还有写在飞，重试拿到 lease、``delete_tree`` 后重建的新包就会被这些迟到的
+    写污染成混合包。
+    """
+    filesystem = _RecordingFilesystem(delay=0.05)
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    task = asyncio.create_task(storage.write(_package(4)))
+    await asyncio.sleep(0.01)
+    assert filesystem.in_flight > 0, "batch should be in flight before cancelling"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # the cancellation waited for the whole batch, so nothing can land afterwards
+    assert filesystem.in_flight == 0
+    assert len(filesystem.files) == 4

--- a/src/backend/tests/community/core/skill_center/test_local_skill_package_storage_io.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_package_storage_io.py
@@ -220,3 +220,33 @@ async def test_cancelling_a_write_drains_in_flight_writes_before_propagating():
     # the cancellation waited for the whole batch, so nothing can land afterwards
     assert filesystem.in_flight == 0
     assert len(filesystem.files) == 4
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_cannot_abandon_the_drain():
+    """再次取消也不能把还在排空的 batch 丢掉（请求中止叠加进程关停等场景）。
+
+    排空本身若不加 shield，第二次取消会连 ``batch`` 一起拆掉并立刻抛出，而
+    worker 线程里的写仍在跑 —— 正是第一次取消时 shield 所防住的那个故障。
+    """
+    filesystem = _RecordingFilesystem(delay=0.05)
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    task = asyncio.create_task(storage.write(_package(4)))
+    await asyncio.sleep(0.01)
+    assert filesystem.in_flight > 0
+
+    # cancel repeatedly, including while the drain is already running
+    task.cancel()
+    for _ in range(3):
+        await asyncio.sleep(0)
+    task.cancel()
+    for _ in range(3):
+        await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert filesystem.in_flight == 0
+    assert len(filesystem.files) == 4

--- a/src/backend/tests/community/core/skill_center/test_local_skill_package_storage_io.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_package_storage_io.py
@@ -1,0 +1,197 @@
+"""Package I/O batching contract for :class:`LocalSkillPackageStorage`.
+
+Every package file is one device round trip, so the storage port fans them out
+instead of issuing them one at a time. These pin the three properties that make
+that substitution safe for the callers built on the old sequential loop:
+
+* files really do overlap (otherwise the fan-out bought nothing),
+* the fan-out stays bounded (``asyncio.to_thread``'s default executor is shared
+  with the rest of the process),
+* a failed batch is fully drained before the error surfaces, and reports the
+  same failure the sequential loop would have reported.
+
+The drain matters most: ``LocalSkillUploadService`` reacts to a failed ``write``
+by deleting the package directory, so a write still in flight then would land a
+file behind the cleanup and leave an orphan.
+"""
+
+import asyncio
+
+import pytest
+
+from agentclaw.community.core.skill_center.factories import (
+    _PACKAGE_IO_CONCURRENCY,
+    LocalSkillPackageStorage,
+)
+
+DIRECTORY = "/private/skills-local/pkg"
+
+
+class _RecordingFilesystem:
+    """Records call overlap so concurrency is observable, not just assumed."""
+
+    def __init__(self, *, fail_paths=(), delay=0.01):
+        self.files: dict[str, bytes] = {}
+        self.completed: list[str] = []
+        self.in_flight = 0
+        self.peak_in_flight = 0
+        self._fail_paths = set(fail_paths)
+        self._delay = delay
+
+    async def _tracked(self, path):
+        self.in_flight += 1
+        self.peak_in_flight = max(self.peak_in_flight, self.in_flight)
+        try:
+            await asyncio.sleep(self._delay)
+            if path in self._fail_paths:
+                raise OSError(f"device rejected {path}")
+        finally:
+            self.in_flight -= 1
+
+    async def write_file(self, path, content):
+        await self._tracked(path)
+        self.files[path] = content
+        self.completed.append(path)
+
+    async def read_file(self, path):
+        await self._tracked(path)
+        self.completed.append(path)
+        return self.files.get(path)
+
+    async def list_dir(self, path, *, recursive=False):
+        prefix = f"{path}/"
+        return [
+            {"relative_path": stored[len(prefix):], "is_dir": False}
+            for stored in self.files
+            if stored.startswith(prefix)
+        ] or None
+
+
+def _package(count):
+    return [(f"f{index}.md", f"body-{index}".encode()) for index in range(count)]
+
+
+@pytest.mark.asyncio
+async def test_write_issues_package_files_concurrently():
+    filesystem = _RecordingFilesystem()
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    await storage.write(_package(5))
+
+    assert filesystem.peak_in_flight > 1
+    assert len(filesystem.files) == 5
+
+
+@pytest.mark.asyncio
+async def test_write_fan_out_stays_bounded():
+    """An unbounded gather over a big package would starve the shared executor."""
+    filesystem = _RecordingFilesystem()
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    await storage.write(_package(_PACKAGE_IO_CONCURRENCY * 3))
+
+    assert filesystem.peak_in_flight <= _PACKAGE_IO_CONCURRENCY
+
+
+@pytest.mark.asyncio
+async def test_a_failed_write_drains_every_sibling_before_raising():
+    """No write may still be in flight when the caller starts its cleanup."""
+    files = _package(6)
+    filesystem = _RecordingFilesystem(fail_paths={f"{DIRECTORY}/f0.md"})
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    with pytest.raises(OSError):
+        await storage.write(files)
+
+    assert filesystem.in_flight == 0
+    # the five that did not fail all ran to completion rather than being abandoned
+    assert len(filesystem.completed) == 5
+
+
+@pytest.mark.asyncio
+async def test_a_failed_write_reports_the_first_failure_in_file_order():
+    """Same error the sequential loop would have surfaced, not a race winner."""
+    files = _package(6)
+    filesystem = _RecordingFilesystem(
+        fail_paths={f"{DIRECTORY}/f1.md", f"{DIRECTORY}/f4.md"}
+    )
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    with pytest.raises(OSError, match="f1.md"):
+        await storage.write(files)
+
+
+@pytest.mark.asyncio
+async def test_reading_a_package_is_concurrent_and_order_preserving():
+    filesystem = _RecordingFilesystem()
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+    files = _package(5)
+    await storage.write(files)
+    filesystem.peak_in_flight = 0
+
+    assert sorted(await storage._read_package_files()) == sorted(files)
+    assert filesystem.peak_in_flight > 1
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_listed_path_is_rejected_before_any_read():
+    """Validation still gates the whole package, not just the files read so far."""
+    filesystem = _RecordingFilesystem()
+    filesystem.files[f"{DIRECTORY}/ok.md"] = b"fine"
+    filesystem.files[f"{DIRECTORY}/../escape.md"] = b"bad"
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    with pytest.raises(OSError, match="invalid file path"):
+        await storage._read_package_files()
+
+    assert filesystem.completed == []
+
+
+# ── end-to-end over the real baas transport ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_package_upload_resolves_http_info_once_for_the_whole_batch():
+    """storage → BaasDeviceFileSystem → BaasInvokeTransport, wired for real.
+
+    Writing a 12-file package used to cost 12 binding lookups + 12 BaaS
+    ``/http-info`` round trips + 12 uploads, all strictly sequential. It now
+    costs one resolution and 12 concurrent uploads.
+    """
+    from unittest.mock import MagicMock
+
+    import httpx
+
+    from agentclaw.community.core.devices.services.baas_device_filesystem import (
+        BaasDeviceFileSystem,
+    )
+    from agentclaw.community.core.devices.services.baas_invoke_transport import (
+        BaasInvokeTransport,
+    )
+
+    baas_service = MagicMock()
+    baas_service.invoke_http.return_value = httpx.Response(
+        status_code=200, request=httpx.Request("POST", "http://fake/")
+    )
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw",
+        baas_service=baas_service,
+    )
+    storage = LocalSkillPackageStorage(
+        BaasDeviceFileSystem(
+            transport=transport,
+            conn_info={"paas_device_id": "BOT-abc"},
+            path_mapper=lambda path: path,
+        ),
+        DIRECTORY,
+    )
+
+    files = _package(12)
+    await storage.write(files)
+
+    assert baas_service.get_http_info.call_count == 1
+    assert baas_service.invoke_http.call_count == 12
+    uploaded = {
+        call.kwargs["data"]["target_path"] for call in baas_service.invoke_http.call_args_list
+    }
+    assert uploaded == {f"{DIRECTORY}/{name}" for name, _ in files}

--- a/src/backend/tests/community/plugins/prod/test_baas_invoke_transport.py
+++ b/src/backend/tests/community/plugins/prod/test_baas_invoke_transport.py
@@ -21,6 +21,38 @@ def _ok_response() -> httpx.Response:
     )
 
 
+def _response(status_code: int) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        json={"ok": status_code == 200},
+        request=httpx.Request("POST", "http://fake/"),
+    )
+
+
+def _desktop(**overrides):
+    """Build a desktop transport over a mock pooled client.
+
+    The transport no longer opens an ``httpx.Client`` per call — the resolver
+    injects one pooled client so a multi-file write does not pay a TLS handshake
+    per file — so tests hand it a mock directly instead of patching module state.
+    Returns ``(transport, client)``.
+    """
+    from agentclaw.community.core.devices.services.baas_invoke_transport import (
+        DesktopBaasInvokeTransport,
+    )
+
+    client = MagicMock()
+    kwargs = {
+        "baas_base_url": "https://b",
+        "tenant": "t",
+        "bot_uuid": "u",
+        "engine_port": 20003,
+        "headers": {"h": "1"},
+    }
+    kwargs.update(overrides)
+    return DesktopBaasInvokeTransport(client=client, **kwargs), client
+
+
 # ── BaasInvokeTransport ──────────────────────────────────────────────────
 
 
@@ -41,6 +73,7 @@ def test_baas_invoke_transport_post_calls_baas_service_invoke_http():
         bind_id=42,
         port=20003,
         path="/api/skills/symlink/bindpath",
+        method="POST",
         json={"x": 1},
         tenant="team_claw",
         # cloud baas containers reach the engine via the agentclawproxy /proxypass
@@ -48,6 +81,9 @@ def test_baas_invoke_transport_post_calls_baas_service_invoke_http():
         auth_header="x-proxypass-token",
         # default (no multi-instance lock) → device_uuid=None, BaaS auto-picks active
         device_uuid=None,
+        # the transport resolves http_info itself and hands it to invoke_http, so a
+        # batch of same-path calls shares one get_http_info round trip
+        http_info=svc.get_http_info.return_value,
     )
 
 
@@ -116,24 +152,15 @@ def test_baas_invoke_transport_propagates_request_error():
 
 def test_desktop_baas_invoke_transport_post_uses_self_built_url():
     """DesktopBaasInvokeTransport.post 自拼 secbaas wrapper URL,headers 来自 conn_info。"""
-    from agentclaw.community.core.devices.services.baas_invoke_transport import DesktopBaasInvokeTransport
-
-    transport = DesktopBaasInvokeTransport(
+    transport, mock_client = _desktop(
         baas_base_url="https://secbaas-prod.teamclaw.com",
         tenant="team_claw",
         bot_uuid="BOT-abc",
-        engine_port=20003,
         headers={"x-proxypass-token": "tok-xyz"},
     )
+    mock_client.post.return_value = _ok_response()
 
-    with patch(
-        "agentclaw.community.core.devices.services.baas_invoke_transport.httpx.Client"
-    ) as mock_cls:
-        mock_client = MagicMock()
-        mock_cls.return_value.__enter__.return_value = mock_client
-        mock_client.post.return_value = _ok_response()
-
-        resp = transport.post("/api/skills/symlink/bindpath", json={"x": 1})
+    resp = transport.post("/api/skills/symlink/bindpath", json={"x": 1})
 
     assert resp.status_code == 200
     expected_url = (
@@ -149,12 +176,7 @@ def test_desktop_baas_invoke_transport_post_uses_self_built_url():
 
 def test_desktop_baas_invoke_transport_invoke_url_adds_leading_slash():
     """_invoke_url 对没有 leading slash 的 path 也能正确拼接。"""
-    from agentclaw.community.core.devices.services.baas_invoke_transport import DesktopBaasInvokeTransport
-
-    transport = DesktopBaasInvokeTransport(
-        baas_base_url="https://b", tenant="t", bot_uuid="u",
-        engine_port=20003, headers={},
-    )
+    transport, _ = _desktop(headers={})
 
     assert transport._invoke_url("api/x") == (
         "https://b/api/v1/bots/t/u/invoke-http/20003/api/x"
@@ -166,25 +188,14 @@ def test_desktop_baas_invoke_transport_invoke_url_adds_leading_slash():
 
 def test_desktop_baas_invoke_transport_post_multipart_uses_self_built_url():
     """post_multipart 同样自拼 URL,但传 files+data 而不是 json。"""
-    from agentclaw.community.core.devices.services.baas_invoke_transport import DesktopBaasInvokeTransport
+    transport, mock_client = _desktop()
+    mock_client.post.return_value = _ok_response()
 
-    transport = DesktopBaasInvokeTransport(
-        baas_base_url="https://b", tenant="t", bot_uuid="u",
-        engine_port=20003, headers={"h": "1"},
+    transport.post_multipart(
+        "/api/file/upload",
+        files={"file": ("foo.txt", b"hi")},
+        data={"target_path": "foo.txt"},
     )
-
-    with patch(
-        "agentclaw.community.core.devices.services.baas_invoke_transport.httpx.Client"
-    ) as mock_cls:
-        mock_client = MagicMock()
-        mock_cls.return_value.__enter__.return_value = mock_client
-        mock_client.post.return_value = _ok_response()
-
-        transport.post_multipart(
-            "/api/file/upload",
-            files={"file": ("foo.txt", b"hi")},
-            data={"target_path": "foo.txt"},
-        )
 
     call_args = mock_client.post.call_args
     assert call_args.args[0] == "https://b/api/v1/bots/t/u/invoke-http/20003/api/file/upload"
@@ -195,22 +206,11 @@ def test_desktop_baas_invoke_transport_post_multipart_uses_self_built_url():
 
 def test_desktop_baas_invoke_transport_post_propagates_request_error():
     """httpx 抛 RequestError 时 transport.post 透传(不吞)。"""
-    from agentclaw.community.core.devices.services.baas_invoke_transport import DesktopBaasInvokeTransport
+    transport, mock_client = _desktop(headers={})
+    mock_client.post.side_effect = httpx.RequestError("connection refused")
 
-    transport = DesktopBaasInvokeTransport(
-        baas_base_url="https://b", tenant="t", bot_uuid="u",
-        engine_port=20003, headers={},
-    )
-
-    with patch(
-        "agentclaw.community.core.devices.services.baas_invoke_transport.httpx.Client"
-    ) as mock_cls:
-        mock_client = MagicMock()
-        mock_cls.return_value.__enter__.return_value = mock_client
-        mock_client.post.side_effect = httpx.RequestError("connection refused")
-
-        with pytest.raises(httpx.RequestError):
-            transport.post("/api/x", json={})
+    with pytest.raises(httpx.RequestError):
+        transport.post("/api/x", json={})
 
 
 def test_baas_invoke_get_put_delete_pass_method():
@@ -228,17 +228,12 @@ def test_baas_invoke_get_put_delete_pass_method():
 
 
 def test_desktop_invoke_get_put_delete_hit_wrapper_url():
-    from agentclaw.community.core.devices.services.baas_invoke_transport import DesktopBaasInvokeTransport
-    t = DesktopBaasInvokeTransport(baas_base_url="https://b", tenant="t", bot_uuid="u",
-                                   engine_port=20003, headers={"h": "1"})
     expected = "https://b/api/v1/bots/t/u/invoke-http/20003/api/mcp/x"
     for verb in ("get", "put", "delete"):
-        with patch("agentclaw.community.core.devices.services.baas_invoke_transport.httpx.Client") as mc:
-            mock = MagicMock()
-            mc.return_value.__enter__.return_value = mock
-            getattr(mock, verb).return_value = _ok_response()
-            getattr(t, verb)("/api/mcp/x")
-            assert getattr(mock, verb).call_args.args[0] == expected
+        t, mock = _desktop()
+        getattr(mock, verb).return_value = _ok_response()
+        getattr(t, verb)("/api/mcp/x")
+        assert getattr(mock, verb).call_args.args[0] == expected
 
 
 # ── device_uuid 透传(多实例 service bot) ───────────────────────────────
@@ -310,3 +305,212 @@ def test_baas_invoke_transport_default_device_uuid_is_none():
     transport.post("/api/x", json={})
 
     assert svc.invoke_http.call_args.kwargs["device_uuid"] is None
+
+
+# ── get_http_info sharing (per-path cache) ───────────────────────────────
+
+
+def test_repeated_same_path_calls_resolve_http_info_once():
+    """一次 package upload 的 N 个 /api/file/upload 只解析一次 http_info。
+
+    Resolution is a binding DB lookup plus a BaaS round trip, so doing it per file
+    doubled the request count of every multi-file write.
+    """
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    svc.invoke_http.return_value = _ok_response()
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+
+    for name in ("a.md", "b.md", "c.md"):
+        transport.post_multipart(
+            "/api/file/upload",
+            files={"file": (name, b"x")},
+            data={"target_path": name},
+        )
+
+    assert svc.get_http_info.call_count == 1
+    assert svc.invoke_http.call_count == 3
+    # every upload still went out against that one resolution
+    assert all(
+        call.kwargs["http_info"] is svc.get_http_info.return_value
+        for call in svc.invoke_http.call_args_list
+    )
+
+
+def test_http_info_cache_is_keyed_by_path():
+    """``http_url`` 里含 path，所以不同 path 必须各自解析，不能串用缓存。"""
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    svc.invoke_http.return_value = _ok_response()
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+
+    transport.post("/api/file/read", json={})
+    transport.post("/api/file/list", json={})
+    transport.post("/api/file/read", json={})
+
+    resolved_paths = [c.kwargs["path"] for c in svc.get_http_info.call_args_list]
+    assert resolved_paths == ["/api/file/read", "/api/file/list"]
+
+
+def test_http_info_resolution_carries_the_instance_identity():
+    """缓存 key 只有 path，因为其余解析输入都是实例固定的 —— 这里把它钉住。"""
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    svc.invoke_http.return_value = _ok_response()
+    transport = BaasInvokeTransport(
+        bind_id=7, engine_port=20003, tenant="team_claw",
+        baas_service=svc, device_uuid="DEV-xyz",
+    )
+
+    transport.post("/api/file/read", json={})
+
+    svc.get_http_info.assert_called_once_with(
+        bind_id=7,
+        port=20003,
+        path="/api/file/read",
+        tenant="team_claw",
+        device_uuid="DEV-xyz",
+    )
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_rejected_token_refreshes_http_info_and_retries_once(status):
+    """缓存的 token 过期时刷新重试，调用方不该看到假 401/403。"""
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    stale, fresh = MagicMock(name="stale"), MagicMock(name="fresh")
+    svc.get_http_info.side_effect = [stale, fresh]
+    svc.invoke_http.side_effect = [_response(status), _ok_response()]
+
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+    resp = transport.post_multipart(
+        "/api/file/upload", files={"file": ("a", b"x")}, data={"target_path": "a"}
+    )
+
+    assert resp.status_code == 200
+    assert svc.get_http_info.call_count == 2
+    assert [c.kwargs["http_info"] for c in svc.invoke_http.call_args_list] == [
+        stale, fresh,
+    ]
+    # the refreshed entry replaces the rejected one for subsequent calls
+    svc.invoke_http.side_effect = None
+    svc.invoke_http.return_value = _ok_response()
+    transport.post_multipart(
+        "/api/file/upload", files={"file": ("b", b"y")}, data={"target_path": "b"}
+    )
+    assert svc.get_http_info.call_count == 2
+    assert svc.invoke_http.call_args.kwargs["http_info"] is fresh
+
+
+def test_a_persistently_rejected_token_stops_after_one_retry():
+    """真配置错时不无限重试 —— 刷新一次后如实返回 401。"""
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    svc.invoke_http.return_value = _response(401)
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+
+    resp = transport.post("/api/x", json={})
+
+    assert resp.status_code == 401
+    assert svc.invoke_http.call_count == 2
+    assert svc.get_http_info.call_count == 2
+
+
+def test_expired_http_info_cache_entry_is_re_resolved(monkeypatch):
+    """TTL 过期后重新解析，避免长批次里一直用老 token。"""
+    import agentclaw.community.core.devices.services.baas_invoke_transport as mod
+
+    svc = MagicMock()
+    svc.invoke_http.return_value = _ok_response()
+    transport = mod.BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+
+    clock = {"now": 1_000.0}
+    monkeypatch.setattr(mod.time, "monotonic", lambda: clock["now"])
+
+    transport.post("/api/x", json={})
+    clock["now"] += mod._HTTP_INFO_TTL_SECONDS / 2
+    transport.post("/api/x", json={})
+    assert svc.get_http_info.call_count == 1
+
+    clock["now"] += mod._HTTP_INFO_TTL_SECONDS
+    transport.post("/api/x", json={})
+    assert svc.get_http_info.call_count == 2
+
+
+# ── desktop connection reuse ─────────────────────────────────────────────
+
+
+def test_desktop_transport_sends_every_call_through_the_one_injected_client():
+    """一个 package 的多次写共用同一个 client，而不是各自新建。"""
+    transport, pooled = _desktop()
+    pooled.post.return_value = _ok_response()
+
+    with patch(
+        "agentclaw.community.core.devices.services.baas_invoke_transport.httpx.Client"
+    ) as mock_cls:
+        for name in ("a.md", "b.md", "c.md"):
+            transport.post_multipart(
+                "/api/file/upload",
+                files={"file": (name, b"x")},
+                data={"target_path": name},
+            )
+
+    # all three writes landed on the one pooled client ...
+    assert pooled.post.call_count == 3
+    # ... and the transport never built a client of its own, which is what used to
+    # force a fresh TCP + TLS handshake for every file in a package.
+    assert mock_cls.call_count == 0
+
+
+def test_build_desktop_client_returns_a_bounded_pool():
+    """连接池有上限，且高于设备 I/O 并发度，不会自己变成瓶颈。"""
+    import agentclaw.community.core.devices.services.baas_invoke_transport as mod
+
+    with patch.object(mod.httpx, "Client") as mock_cls:
+        mod.build_desktop_client()
+
+    limits = mock_cls.call_args.kwargs["limits"]
+    assert limits.max_connections == 64
+    assert limits.max_keepalive_connections == 32
+
+
+def test_the_resolver_shares_one_pooled_client_across_desktop_transports():
+    """池由单例 resolver 持有 —— 每次 dispatch 不该新建一个池。"""
+    from agentclaw.community.core.devices.services.device_filesystem_resolver import (
+        DefaultDeviceFileSystemResolver,
+    )
+
+    resolver = DefaultDeviceFileSystemResolver(
+        baas_service=MagicMock(),
+        bot_repo=MagicMock(),
+        binding_repo=MagicMock(),
+        sandbox_client=MagicMock(),
+    )
+    conn_info = {
+        "baas_base_url": "https://b",
+        "tenant": "t",
+        "paas_device_id": "BOT-abc",
+        "engine_port": 20003,
+        "headers": {},
+    }
+    ctx = MagicMock(provider="baas", bot_type="desktop", conn_info=conn_info)
+
+    first = resolver(ctx, lambda path: path)
+    second = resolver(ctx, lambda path: path)
+
+    assert first._transport._client is second._transport._client

--- a/src/backend/tests/community/plugins/prod/test_baas_invoke_transport.py
+++ b/src/backend/tests/community/plugins/prod/test_baas_invoke_transport.py
@@ -380,15 +380,14 @@ def test_http_info_resolution_carries_the_instance_identity():
     )
 
 
-@pytest.mark.parametrize("status", [401, 403])
-def test_rejected_token_refreshes_http_info_and_retries_once(status):
-    """缓存的 token 过期时刷新重试，调用方不该看到假 401/403。"""
+def test_rejected_token_refreshes_http_info_and_retries_once():
+    """缓存的 token 过期时刷新重试，调用方不该看到假 401。"""
     from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
 
     svc = MagicMock()
     stale, fresh = MagicMock(name="stale"), MagicMock(name="fresh")
     svc.get_http_info.side_effect = [stale, fresh]
-    svc.invoke_http.side_effect = [_response(status), _ok_response()]
+    svc.invoke_http.side_effect = [_response(401), _ok_response()]
 
     transport = BaasInvokeTransport(
         bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
@@ -412,6 +411,30 @@ def test_rejected_token_refreshes_http_info_and_retries_once(status):
     assert svc.invoke_http.call_args.kwargs["http_info"] is fresh
 
 
+def test_a_403_is_the_device_answer_and_is_never_replayed():
+    """403 不是网关拒 token —— engine 把 PermissionError 映射成 403，proxy 原样透传。
+
+    重放会把一次 mutating 的 upload/delete 再跑一遍（无 device_uuid 时还可能打到
+    另一台设备），并且掩盖 engine 真正的鉴权结论。
+    """
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    svc.invoke_http.return_value = _response(403)
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+
+    resp = transport.post_multipart(
+        "/api/file/upload", files={"file": ("a", b"x")}, data={"target_path": "a"}
+    )
+
+    assert resp.status_code == 403
+    # sent exactly once, and the http_info was never re-resolved
+    assert svc.invoke_http.call_count == 1
+    assert svc.get_http_info.call_count == 1
+
+
 def test_a_persistently_rejected_token_stops_after_one_retry():
     """真配置错时不无限重试 —— 刷新一次后如实返回 401。"""
     from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
@@ -426,6 +449,43 @@ def test_a_persistently_rejected_token_stops_after_one_retry():
 
     assert resp.status_code == 401
     assert svc.invoke_http.call_count == 2
+    assert svc.get_http_info.call_count == 2
+
+
+def test_concurrent_rejections_share_one_refresh():
+    """一批并发写同时被拒时只刷新一次，而不是每个请求各刷一次。
+
+    无条件 refresh 会在失败路径上把本 cache 消除掉的「每文件一次解析」原样带回来。
+    """
+    import threading
+
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    # Distinct objects per call, like the real get_http_info, which builds a fresh
+    # HttpConnectionInfo every time. A shared MagicMock return_value would hand back
+    # one identical object and make the compare-and-swap unobservable.
+    svc.get_http_info.side_effect = [MagicMock(name=f"info-{i}") for i in range(20)]
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+    # prime the cache so every worker starts from the same (about to be rejected) entry
+    primed = transport._http_info("/api/file/upload")
+    assert svc.get_http_info.call_count == 1
+
+    barrier = threading.Barrier(8)
+
+    def refresh_once():
+        barrier.wait()
+        transport._http_info("/api/file/upload", stale=primed)
+
+    workers = [threading.Thread(target=refresh_once) for _ in range(8)]
+    for w in workers:
+        w.start()
+    for w in workers:
+        w.join()
+
+    # one thread re-resolved; the other seven took the entry it installed
     assert svc.get_http_info.call_count == 2
 
 


### PR DESCRIPTION
## Problem

`POST /openapi/v1/bots/{bot_id}/skills` writes a Local Skill package one file at a time, and each file independently re-resolves its own BaaS connection. For an N-file package on the baas path that is:

- N **sequential** device round trips — `LocalSkillPackageStorage.write` awaited each `write_file` before starting the next, so wall-clock was `N × round_trip`;
- N **binding DB lookups + N BaaS `/http-info` round trips** — `BaasInvokeTransport.post_multipart` → `invoke_http` → `get_http_info` on every single file, even though every file POSTs to the same `/api/file/upload` path;
- N **TCP + TLS handshakes** on desktop bots — `DesktopBaasInvokeTransport` opened a fresh `httpx.Client` per call.

Skill packages are made of many small files, so per-file overhead dominated the request.

## Solution

**1. Concurrent, bounded package I/O.** `LocalSkillPackageStorage.write` fans its per-file writes out instead of awaiting each in turn.

The fan-out is bounded (`_PACKAGE_IO_CONCURRENCY = 8`) rather than a raw `gather`: device filesystems run their blocking transport through `asyncio.to_thread`, whose default executor (`min(32, cpu_count + 4)` threads) is shared with everything else in the process, so an unbounded fan-out over a large package would starve unrelated work.

A failed batch is **drained before the error surfaces**. This is what makes the substitution safe: `LocalSkillUploadService` reacts to a failed `write` by deleting the package directory, so a write still in flight at that moment could land a file behind the cleanup and leave an orphan the next upload trips over. The first failure *in file order* is re-raised, so the surfaced error matches what the sequential loop reported.

**Cancellation is drained the same way**, and needs separate handling because it does not travel the exception path — see the two fixes below. The same batching treatment is applied to the read / verify / restore / quarantine loops in that class, which had the identical shape.

**2. Shared `get_http_info`.** `BaasInvokeTransport` caches the resolution per path for the life of the instance. The resolver mints one transport per dispatch, so that lifetime is a single request — no cross-request staleness to reason about. A 12-file package now resolves once instead of 12 times.

- Path stays in the cache key because the returned `http_url` embeds it — reusing one path's entry for another would POST to the wrong container route.
- The lock is deliberately held across the `get_http_info` call so concurrent writes coalesce onto one resolution rather than each thread missing and resolving its own.
- A cached token the gateway rejects with **401** is refreshed and the call replayed once, so reuse can never surface a spurious auth failure. Replay is safe because payloads are already materialised (`json` dicts, `files` bytes), not consumed streams. **403 is deliberately excluded** — see fix (a).
- `BaasService.invoke_http` grows an optional `http_info` parameter to accept the pre-resolved value; when omitted it resolves exactly as before.

**3. Connection reuse on the desktop path.** `DesktopBaasInvokeTransport` now sends through one pooled `httpx.Client` instead of building one per call.

The pool is built by the singleton `DefaultDeviceFileSystemResolver` and injected into each transport it mints. A module-level lazy singleton was the first shape tried and `tests/community/architecture/test_no_dcl_singletons.py` correctly rejected it; owning the pool on the already-singleton resolver gives the same process lifetime through the injector.

## Defects found in review and fixed

All four came from Codex review of my own earlier commits in this PR, and all four were in the error/cancellation paths rather than the happy path. Each was verified against the source before fixing.

| | Defect | Fixed in |
|---|---|---|
| a | **403 replayed as a stale token.** The engine's file router maps `PermissionError` → 403 and the proxy forwards upstream responses unchanged, so a 403 is the device's own authorization answer. Replaying it re-ran a mutating upload/delete — with no `device_uuid` pinning the instance, possibly against a *different* device — while hiding the engine's real verdict. Now only 401 (the proxypass gateway's token rejection) triggers a refresh. | `448810e5` |
| b | **Refresh fan-out.** The refresh resolved unconditionally under the lock, so a batch rejected together resolved once per in-flight request — reinstating on the failure path the very per-file fan-out this cache removes. Now a compare-and-swap keyed on the entry the caller was rejected on. | `448810e5` |
| c | **Cancellation bypassed the drain.** `to_thread` cannot interrupt a write already on a worker thread, and `CancelledError` is a `BaseException`, so `LocalSkillUploadService`'s `except Exception` compensation was skipped while its `finally` still released the edit lease. A retry could then `delete_tree` and start a fresh package that the abandoned writes landed into. The batch is now shielded and drained before cancellation propagates. | `6c834f7a` |
| d | **Repeated cancellation abandoned the drain.** A second cancel arriving *during* the drain propagated into the batch and re-raised with the writes still running — the same corruption, one level deeper. The drain now loops under its own shield, absorbing only `CancelledError` and only until the batch finishes. | `f4ac62c8` |

## Validation

- Affected suites (`core/devices`, `core/skill_center`, `plugins/prod`, `architecture`, `endpoints`) — **3037 passed, 25 skipped**.
- Full backend suite — **14508 passed, 58 skipped, 2 failed**. The two are `rsync: not found` in the sandbox, reproduced identically on a clean stash of the base commit.
- `ruff check` clean on every changed file. (`factories.py` reports 7 pre-existing `F821`s from its intentional `TYPE_CHECKING` string annotations — identical on the base commit, verified by stashing.)

New coverage, in `test_local_skill_package_storage_io.py` and `test_baas_invoke_transport.py`:

- writes actually overlap; the fan-out stays bounded; a failed batch is fully drained before raising; the first failure in file order is the one surfaced
- end-to-end wiring storage → `BaasDeviceFileSystem` → `BaasInvokeTransport`, asserting a 12-file package costs **1** `get_http_info` and **12** `invoke_http`
- same-path batch resolves once; cache keyed by path; TTL expiry re-resolves; 401 refreshes and retries exactly once then stops; **403 is never replayed**; eight concurrent rejections share one refresh
- cancellation mid-write drains before propagating; **repeated** cancellation cannot abandon the drain

The cancellation tests were checked against the unfixed code to confirm they are not vacuous: they fail with `assert 0 == 4`, i.e. the batch abandoned with nothing written.

Not run: no live BaaS or desktop bot is available in this environment, so wire behaviour is covered at the seam rather than by a real upload.

## Compatibility and risk

No API, schema, or config change. `invoke_http`'s new `http_info` is optional and keyword-only; every existing caller is unaffected.

Worth a reviewer's eye:

- **Package files are now written concurrently**, which assumes the engine's `/api/file/upload` tolerates concurrent parent-directory creation. I could not verify this from this repo: the path leads to `OpenClawFilePort`, whose local implementation is an in-memory fake, with the real one outside this tree. The engine codebase uses `mkdir(parents=True, exist_ok=True)` consistently elsewhere, which is the safe pattern, but that is inference rather than proof for this path. **Please confirm against the real engine.**
- **A failed batch now attempts every file** before raising, where the sequential loop stopped at the first failure. Deliberate — draining is what keeps a stray write from outliving the cleanup — and the caller deletes the directory either way.
- **A cancelled upload now takes as long as its slowest in-flight write to unwind.** Since `to_thread` cannot actually stop that write, the previous behaviour only made cancellation *look* fast while leaving writes running.
- `_PACKAGE_IO_CONCURRENCY = 8` is the one tuning knob. On a 2-core box the shared `to_thread` executor has only 6 slots, so an upload can occupy it while running. These are I/O-blocked threads and uploads are bursty rather than continuous, but lower it if that contention shows up.

Rollback is a straight revert; nothing persists state.

## Related issues

Follow-up perf findings on this path, **not** addressed here:

- `HttpxClient._request` (`plugins/http_client.py`) builds a new `httpx.Client` for *every* request, so the cloud `BaasInvokeTransport` still pays a handshake per call through `_general_http`. Fixing it is a win for every HTTP caller in the backend, but the blast radius is far wider than this PR.
- `SkillServiceFactory.local_skill_package_storage` calls `resolve_runtime_engine_for_bot` twice with identical arguments (once inside `create()`, once directly) plus a third bot lookup via `_device_fs_factory`. Deduplicating means deciding whether the resolved runtime engine may be passed back as `engine_type`, which is the *override* — semantically different, so it needs an owner's call.
- `BaasDeviceFileSystem.exists()` calls `read_file` before `list_dir`; for the directory probes the package storage makes, the `read_file` is always a wasted round trip that downloads whole file contents just to test existence.