### PR TITLE
feat(backend): sync task_discovery changes from dev to REL20260826

### DIFF
--- a/src/backend/specs/2026-08-25-task-discovery-taskspec-align-and-notify-channels/design.md
+++ b/src/backend/specs/2026-08-25-task-discovery-taskspec-align-and-notify-channels/design.md
@@ -1,0 +1,617 @@
+# 技术设计 — DiscoveredTask 对齐 TaskSpec + 发现流程双通知通道
+
+## 1. 改动范围
+
+```
+源码：
+├── core/task/task_discovery/
+│   ├── models.py             (修改)  DiscoveredTask 字段 + to_discovery_prompt 4 维度
+│   ├── task_reader.py        (修改)  DDL/SELECT/_row_to_task/init DROP+CREATE 重命名
+│   ├── session_initiator.py  (修改)  URL helper 环境感知 + 4 维度 prompt + DreamMode-任务发现 标题
+│   ├── session_creator.py    (修改)  body["title"] = task.title
+│   └── discovery_service.py  (修改)  __init__ +work_order_service；_send_notification(session)；
+│                                    新增 _send_work_order_event；双通道并发
+├── core/work_orders/models.py     (修改)  WorkOrderEventType.TASK_DISCOVERED + NOTICE 注册
+├── di/modules/infrastructure/community/notify.py  (修改)  条件绑定 DingTalkNotifySender
+├── di/modules/task_discovery_module.py            (修改)  注入 work_order_service
+├── plugins/community/notify_sender.py             (修改)  新增 DingTalkNotifySender
+├── adapters/http/task/router.py                   (修改)  /discover / /status 字段名兼容
+└── docs/task-discovery-api.zh-CN.md               (修改)  删除 work_item_url 行
+
+测试：
+├── core/task/test_task_discovery_unit.py          (修改)  mock dict 新键 + DB 往返断言
+├── endpoints/test_task_discovery_router.py        (修改)  _status_task + 显式 DiscoveredTask 映射
+└── core/task/singlebox_e2e/
+    ├── test_cron_scheduler_e2e.py                  (修改)  mock 新键 + 删除 TestDingTalkCardE2E
+    ├── test_cron_timed_fire_e2e.py                  (修改)  mock 新键 + 删除 Phase6 钉钉
+    ├── test_discover_and_notify_e2e.py              (删除)  独立钉钉 standalone 脚本，已下沉
+    ├── test_task_discovery_e2e.py                   (修改)  mock 新键 + status 断言
+    └── test_cron_timed_fire_workorder_e2e.py         (新增)  workorder NOTICE e2e
+```
+
+## 2. DiscoveredTask 字段对齐 TaskSpec
+
+### Before
+
+```python
+@dataclass
+class DiscoveredTask:
+    task_id: str
+    bot_id: str
+    owner_id: str
+    dt: str
+    project_name: str           # ~ TaskSpec.metadata.title
+    description: str           # ~ TaskSpec.metadata.instruction
+    business_scenario: str     # ~ TaskSpec.context.background
+    discovery_basis: str
+    work_item_url: Optional[str] = None
+    priority: str = "medium"
+    discovered_at: Optional[str] = None
+    status: str = "pending_confirmation"
+```
+
+### After
+
+```python
+@dataclass
+class DiscoveredTask:
+    task_id: str
+    bot_id: str
+    owner_id: str
+    dt: str
+    title: str                  # 对齐 TaskSpec.metadata.title
+    instruction: str            # 对齐 TaskSpec.metadata.instruction
+    background: str            # 对齐 TaskSpec.context.background
+    discovery_basis: str
+    priority: str = "medium"
+    discovered_at: Optional[str] = None
+    status: str = "pending_confirmation"
+    # 执行层衔接字段（不落 discovered_tasks.db；确认后用于 to_task_info_request）
+    objective: str = ""                                              # ~ TaskSpec.goal.objective
+    acceptances: list[dict] = field(default_factory=list)           # ~ TaskSpec.goal.acceptances
+```
+
+- `to_session_ext_info` 仍输出旧键名（`project_name` / `description` / `business_scenario`），值取自 `title` / `instruction` / `background` → engine 兼容不破。
+
+## 3. discovered_tasks.db schema 同步
+
+### DDL
+
+```sql
+CREATE TABLE IF NOT EXISTS discovered_tasks (
+    task_id            TEXT PRIMARY KEY,
+    bot_id             TEXT NOT NULL,
+    owner_id           TEXT NOT NULL,
+    dt                 TEXT NOT NULL,
+    title              TEXT NOT NULL,    -- was: project_name
+    instruction        TEXT,             -- was: description
+    background         TEXT,             -- was: business_scenario
+    discovery_basis    TEXT,
+    priority           TEXT DEFAULT 'medium',
+    discovered_at      TEXT,
+    status             TEXT DEFAULT 'pending_confirmation',
+    objective          TEXT,             -- 新增
+    acceptances        TEXT               -- 新增（JSON 字符串）
+);
+CREATE INDEX IF NOT EXISTS idx_discovered_tasks_bot_owner_dt
+    ON discovered_tasks(bot_id, owner_id, dt);
+```
+
+### init_discovered_tasks_db — DROP+CREATE
+
+```python
+def init_discovered_tasks_db(db_path: str | Path, tasks: list[dict]) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    try:
+        # DROP+CREATE：每次初始化使用最新 schema
+        # （CREATE TABLE IF NOT EXISTS 不会给已存在的旧库加 objective/acceptances）
+        conn.executescript("DROP TABLE IF EXISTS discovered_tasks;\n" + _CREATE_TABLE_SQL)
+        conn.executemany(
+            "INSERT INTO discovered_tasks "
+            "(task_id, bot_id, owner_id, dt, title, instruction, "
+            " background, discovery_basis, priority, "
+            " discovered_at, status, objective, acceptances) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+            [
+                (
+                    t["task_id"], t.get("bot_id", ""), t.get("owner_id", ""),
+                    t.get("dt", ""),
+                    t.get("title", ""), t.get("instruction", ""),
+                    t.get("background", ""),
+                    t.get("discovery_basis", ""),
+                    t.get("priority", "medium"),
+                    t.get("discovered_at"),
+                    t.get("status", "pending_confirmation"),
+                    t.get("objective", ""),
+                    json.dumps(t.get("acceptances", []), ensure_ascii=False),
+                )
+                for t in tasks
+            ],
+        )
+        conn.commit()
+```
+
+### _row_to_task — 防御性读 objective/acceptances
+
+```python
+def _row_to_task(row: sqlite3.Row) -> DiscoveredTask:
+    keys = set(row.keys())
+    raw_acceptances = row["acceptances"] if "acceptances" in keys else None
+    try:
+        acceptances = json.loads(raw_acceptances) if raw_acceptances else []
+    except (TypeError, ValueError):
+        acceptances = []
+    return DiscoveredTask(
+        task_id=row["task_id"], bot_id=row["bot_id"], owner_id=row["owner_id"], dt=row["dt"],
+        title=row["title"], instruction=row["instruction"] or "", background=row["background"] or "",
+        discovery_basis=row["discovery_basis"] or "",
+        priority=row["priority"] or "medium",
+        discovered_at=row["discovered_at"],
+        status=row["status"] or "pending_confirmation",
+        objective=row["objective"] if "objective" in keys and row["objective"] else "",
+        acceptances=acceptances if isinstance(acceptances, list) else [],
+    )
+```
+
+- `_SELECT_ALL_SQL` / `_SELECT_PENDING_FOR_BOT_SQL` 改为 `SELECT *`，由 `_row_to_task` 处理列缺失场景，旧库降级读取。
+
+## 4. 发现提示词 — 4 维度（对齐 TaskSpec Goal/Context）
+
+### 单任务 `to_discovery_prompt`
+
+```python
+def to_discovery_prompt(self) -> str:
+    lines = [
+        f"/task 我为您发现了以下可能有意义的事情：\n",
+        f"【{self.title}】",
+        f"目标：{self.objective or self.title}",
+        f"预期交付物：{self.instruction}",
+    ]
+    if self.acceptances:
+        lines.append("验收标准：")
+        for a in self.acceptances:
+            lines.append(f"  - [{a.get('id', '')}] {a.get('description', '')}")
+    else:
+        lines.append("验收标准：（确认时可由你补充）")
+    lines.append(f"约束：{self.background}")
+    lines.append("\n是否确认执行？请在下方回复确认或拒绝。")
+    return "\n".join(lines)
+```
+
+### 多任务 `_build_discovery_prompt`
+
+```python
+def _build_discovery_prompt(self, tasks: list[DiscoveredTask]) -> str:
+    lines = ["/task 我为您发现了以下可能有意义的事情，请确认是否执行：\n"]
+    for i, task in enumerate(tasks, 1):
+        lines.append(f"{i}. 【{task.title}】")
+        lines.append(f"   目标：{task.objective or task.title}")
+        lines.append(f"   预期交付物：{task.instruction}")
+        if task.acceptances:
+            lines.append("   验收标准：")
+            for a in task.acceptances:
+                lines.append(f"     - [{a.get('id', '')}] {a.get('description', '')}")
+        else:
+            lines.append("   验收标准：（确认时可由你补充）")
+        lines.append(f"   约束：{task.background}")
+        lines.append("")
+    lines.append("请向用户展示以上任务，并询问是否确认执行。")
+    return "\n".join(lines)
+```
+
+### session title
+
+```python
+title = (
+    f"[DreamMode-任务发现] 发现 {task_count} 件可能有意义的事情"
+    if task_count > 1
+    else f"[DreamMode-任务发现] {first_task.title}"
+)
+```
+
+- 仍按 `2026-08-24-discover-session-url-fix-and-dingtalk-notify-enhance` 的 Step 2.5 单独 update title（engine `POST /api/sessions/{id}/update?title=xxx`）；update 失败不阻断。
+
+## 5. session URL / backend URL 环境感知解析
+
+```python
+_DEFAULT_BACKEND_URL = "http://localhost:8888"
+_DEFAULT_FRONTEND_URL = "http://localhost:8000"
+_SINGLEBOX_HOST = "agentclaw-local.stable.alipay.net"
+
+
+def _resolve_frontend_url() -> str:
+    url = os.environ.get("FRONTEND_URL")
+    if url:
+        return url
+    if os.environ.get("DEPLOY_PROFILE", "").strip().lower() == "singlebox":
+        return f"http://{_SINGLEBOX_HOST}:8000"
+    return _DEFAULT_FRONTEND_URL
+
+
+def _resolve_backend_url() -> str:
+    url = os.environ.get("BACKEND_URL")
+    if url:
+        return url
+    if os.environ.get("DEPLOY_PROFILE", "").strip().lower() == "singlebox":
+        return os.environ.get(
+            "SINGLEBOX_BACKEND_URL", f"http://{_SINGLEBOX_HOST}:8888"
+        )
+    return _DEFAULT_BACKEND_URL
+
+
+class CronRelaySessionInitiator:
+    def __init__(self, cron_relay, frontend_url=None, ...):
+        self._frontend_url = frontend_url or _resolve_frontend_url()
+        self._backend_url = _resolve_backend_url()
+        ...
+```
+
+- singlebox 启动时 `/etc/hosts` 已配 `agentclaw-local.stable.alipay.net → 127.0.0.1`，本地域名让前端 / 钉钉卡片可达。
+
+## 6. DiscoveryService 双通知通道
+
+### 类图
+
+```
+            ┌─────────────────────────── DiscoveryService ───────────────────────────┐
+            │                                                                          │
+            │   reader    session_initiator  bot_service  discovery_lock_repo          │
+            │       \           \                |              /                     │
+            │        \   ─────────────────────────────────────────                    │
+            │         \                                                          │
+            │      notify_sender (NotifySenderPlugin seam)                      work_order_service
+            │                │                                                          │
+            │   ┌────────────┴─────────────┐                                create_work_order_event
+            │   │  CommunityNotifySender   │   ← inner                       (event_category=NOTICE,
+            │   │   日志通道               │                                    event_type=TASK_DISCOVERED)
+            │   └────────────▲─────────────┘
+            │                │ wraps
+            │   ┌────────────┴─────────────┐ if DingTalkNotifySender._configured()
+            │   │ DingTalkNotifySender      │ else: CommunityNotifySender 单独
+            │   │  (装饰 inner)             │
+            │   └───────────────────────────┘
+            └──────────────────────────────────────────────────────────────────────────┘
+```
+
+### `_discover_single` 双通道并发
+
+```python
+card_sent = self._send_notification(task, owner_id, session, len(all_tasks))
+work_order_sent = self._send_work_order_event(task, owner_id, session)
+notification_sent = card_sent or work_order_sent
+
+logger.info(
+    "[task_discovery] task %s → session %s "
+    "(card_sent=%s, work_order_sent=%s, notified=%s)",
+    task.task_id, session.session_id,
+    card_sent, work_order_sent, notification_sent,
+)
+```
+
+### `_send_notification` — 钉钉卡片通道
+
+签名变化：`session_url: str → session: DiscoverySession`；`card_data` 额外补 `click=""` 和 `session_url`：
+
+```python
+def _send_notification(self, task, user_id, session, task_count) -> bool:
+    session_url = session.session_url
+    message = NotifyMessage(
+        title="发现待确认任务",
+        body=task.to_notification_body(task_count),
+        recipient=user_id,
+        extra={
+            "card_template_id": os.environ.get("TASK_DISCOVERY_CARD_TEMPLATE_ID", ""),
+            "card_biz_id": f"discover_things_{task.task_id}",
+            "card_data": json.dumps(
+                {"click": "", **task.to_card_data(), "session_url": session_url}
+            ),
+            "session_url": session_url,
+        },
+    )
+    try:
+        msg_id = self._notify_sender.send(message, channel="markdown")
+        logger.info("[task_discovery] external card sent for task %s (msg_id=%s)",
+                    task.task_id, msg_id)
+        return True
+    except Exception as exc:
+        logger.warning("[task_discovery] external notify failed for task %s: %s",
+                       task.task_id, exc)
+        return False
+```
+
+### `_send_work_order_event` — 工单 NOTICE 通道
+
+```python
+def _send_work_order_event(self, task, user_id, session) -> bool:
+    svc = self._work_order_service
+    if svc is None:
+        return False
+    try:
+        result = svc.create_work_order_event(
+            event_category=NotificationCategory.NOTICE,
+            biz_type="task_discovery",
+            biz_id=task.task_id,
+            event_type=WorkOrderEventType.TASK_DISCOVERED.value,
+            applicant_user_id=None,        # NOTICE 约束
+            approver_user_ids=[],
+            recipient_user_ids=[user_id],
+            title=task.title,
+            content={
+                **task.to_card_data(),
+                "session_url": session.session_url,
+                "task_id": task.task_id,
+            },
+            apply_reason=None,
+            biz_data={
+                "task_id": task.task_id,
+                "bot_id": task.bot_id,
+                "owner_id": task.owner_id,
+                "session_id": session.session_id,
+                "session_url": session.session_url,
+            },
+            actor_id=user_id,
+        )
+        logger.info(
+            "[task_discovery] work-order event created for task %s "
+            "(notification_ids=%s, work_order_id=%s)",
+            task.task_id,
+            getattr(result, "notification_ids", None),
+            getattr(result, "work_order_id", None),
+        )
+        return True
+    except Exception as exc:
+        logger.warning(
+            "[task_discovery] work-order event failed for task %s: %s",
+            task.task_id, exc,
+        )
+        return False
+```
+
+- **NOTICE 约束**：`applicant_user_id=None` + `approver_user_ids=[]` + `recipient_user_ids` 非空；否则 `WorkOrderService` 返回 400 / 400201 `event_type not registered`。
+- `biz_data` 把 `task_id` / `session_id` 等放进去，便于后续从工单反向查询发现记录。
+
+### 工单事件类型注册
+
+```python
+class WorkOrderEventType(StrEnum):
+    HUMAN2BOT_PUBLIC_ORDER_CREATED = "HUMAN2BOT_PUBLIC_ORDER_CREATED"
+    HUMAN2BOT_PUBLIC_ORDER_COMPLETED = "HUMAN2BOT_PUBLIC_ORDER_COMPLETED"
+    BOT2BOT_PUBLIC_ORDER_CREATED = "BOT2BOT_PUBLIC_ORDER_CREATED"
+    BOT2BOT_PUBLIC_ORDER_COMPLETED = "BOT2BOT_PUBLIC_ORDER_COMPLETED"
+    TASK_DISCOVERED = "TASK_DISCOVERED"        # 新增
+
+EVENT_CATEGORIES: dict[WorkOrderEventType, NotificationCategory] = {
+    ...
+    WorkOrderEventType.TASK_DISCOVERED: NotificationCategory.NOTICE,
+}
+```
+
+- NOTICE 工单不创建 `WorkOrder` 行（`work_order_id=null`），仅写入 `ac_work_order_notification` + `recipient_user_ids` 一行收件人记录。
+
+## 7. DingTalkNotifySender — NotifySenderPlugin seam
+
+```python
+class DingTalkNotifySender(NotifySenderPlugin):
+    def __init__(self, inner: NotifySenderPlugin) -> None:
+        self._inner = inner
+
+    @property
+    def channels(self) -> frozenset[str]:
+        return self._inner.channels
+
+    def send(self, message, *, channel="markdown") -> str | None:
+        # 先照常走 inner 通道（日志/兜底），再额外投递钉钉卡片。两者同时进行。
+        msg_id = self._inner.send(message, channel=channel)
+        try:
+            self._send_dingtalk_card(message)
+        except Exception as exc:
+            log.warning("[DingTalkNotifySender] dingtalk card failed (recipient=%s): %s",
+                        message.recipient, exc)
+        return msg_id
+
+    @staticmethod
+    def _configured() -> bool:
+        return all([
+            _env("TASK_DISCOVERY_DINGTALK_AK_ID", "SINGLEBOX_DINGTALK_AK_ID"),
+            _env("TASK_DISCOVERY_DINGTALK_AK_SECRET", "SINGLEBOX_DINGTALK_AK_SECRET"),
+            _env("TASK_DISCOVERY_DINGTALK_ROBOT_CODE", "SINGLEBOX_DINGTALK_ROBOT_CODE"),
+            _env("TASK_DISCOVERY_CARD_TEMPLATE_ID",
+                 "SINGLEBOX_DINGTALK_CARD_TEMPLATE_ID"),
+        ])
+
+    def _send_dingtalk_card(self, message) -> None:
+        if not self._configured():
+            return
+        ak_id = _env("TASK_DISCOVERY_DINGTALK_AK_ID", "SINGLEBOX_DINGTALK_AK_ID")
+        ak_secret = _env("TASK_DISCOVERY_DINGTALK_AK_SECRET",
+                         "SINGLEBOX_DINGTALK_AK_SECRET")
+        robot_code = _env("TASK_DISCOVERY_DINGTALK_ROBOT_CODE",
+                          "SINGLEBOX_DINGTALK_ROBOT_CODE")
+        template_id = _env("TASK_DISCOVERY_CARD_TEMPLATE_ID",
+                           "SINGLEBOX_DINGTALK_CARD_TEMPLATE_ID")
+        account_id = (
+            _env("TASK_DISCOVERY_DINGTALK_ACCOUNT_ID",
+                 "SINGLEBOX_DINGTALK_ACCOUNT_ID")
+            or message.recipient
+        )
+        extra = message.extra or {}
+        card_biz_id = extra.get("card_biz_id") or f"discover_things_{int(time.time())}"
+        card_data = extra.get("card_data")
+        if not card_data:
+            return
+
+        # corp 钉钉 SDK 惰性导入
+        from alibabacloud_tea_openapi import models as open_api_models  # type: ignore[import-not-found]
+        from alibabacloud_tea_util import models as util_models  # type: ignore[import-not-found]
+        from alipay_antdingopensdk_client import models as antding_models
+        from alipay_antdingopensdk_client.client import Client as AntDingClient
+
+        config = open_api_models.Config()
+        config.access_key_id = ak_id
+        config.access_key_secret = ak_secret
+        client = AntDingClient(config)
+        headers = antding_models.HttpHeader()
+        headers.account_context = antding_models.AccountContext(account_id=account_id)
+        req = antding_models.SendRobotInteractiveCardRequest()
+        req.card_template_id = template_id
+        req.robot_code = robot_code
+        req.card_biz_id = card_biz_id
+        req.card_data = card_data
+        req.user_id = account_id
+        resp = client.send_robot_interactive_card_with_options(
+            req, headers, util_models.RuntimeOptions()
+        )
+        biz = resp.body
+        resp_map = biz.to_map() if hasattr(biz, "to_map") else {"raw": str(biz)}
+        log.info(
+            "[DingTalkNotifySender] card sent (recipient=%s, template=%s, "
+            "robot=%s, card_biz_id=%s) -> %s",
+            account_id, template_id, robot_code, card_biz_id,
+            json.dumps(resp_map, ensure_ascii=False),
+        )
+```
+
+### DI 条件绑定
+
+```python
+class CommunityNotifyModule(Module):
+    @singleton
+    @provider
+    def _notify_sender(self) -> NotifySenderPlugin:
+        from agentclaw.community.plugins.community.notify_sender import (
+            CommunityNotifySender, DingTalkNotifySender,
+        )
+        inner = CommunityNotifySender()
+        if DingTalkNotifySender._configured():
+            logger.info(
+                "[community.notify] Binding DingTalkNotifySender(CommunityNotifySender) "
+                "(log + dingtalk interactive card)",
+            )
+            return DingTalkNotifySender(inner)
+        logger.info(
+            "[community.notify] Binding CommunityNotifySender (log-only; no real delivery)"
+        )
+        return inner
+```
+
+- 与 `2026-08-24-discover-session-url-fix-and-dingtalk-notify-enhance` 中"钉钉下沉 DingTalkNotifySender"的 TODO 呼应完成。
+
+## 8. WorkOrderService 注入
+
+```python
+class TaskDiscoveryModule(Module):
+    @singleton
+    @provider
+    def provide_discovery_service(
+        self,
+        reader: TaskReader,
+        session_initiator: SessionInitiator,
+        notify_sender: NotifySenderPlugin,
+        bot_service: _TaskDiscoveryBotServiceProtocol,
+        discovery_lock_repo: TaskDiscoveryLockRepositoryProtocol,
+        work_order_service: WorkOrderServiceProtocol,    # 新增
+    ) -> DiscoveryService:
+        return DiscoveryService(
+            reader=reader,
+            session_initiator=session_initiator,
+            notify_sender=notify_sender,
+            bot_service=bot_service,
+            discovery_lock_repo=discovery_lock_repo,
+            work_order_service=work_order_service,
+        )
+```
+
+- `WorkOrderService` 由 `WorkOrderModule` 单独提供（不在本 spec 范围）。
+
+## 9. router /discover 与 /status 字段名兼容
+
+```python
+# router.py /discovery/discover
+"tasks": [
+    {
+        "task_id": r.task.task_id,
+        "project_name": r.task.title,   # 仍输出 project_name（前端兼容），值取 title
+        "success": r.success,
+        "session_id": r.session.session_id if r.session else None,
+        ...
+    }
+    ...
+]
+
+# router.py /discovery/status
+{
+    "bot_id": t.bot_id,
+    "owner_id": t.owner_id,
+    "dt": t.dt,
+    "project_name": t.title,           # 仍输出 project_name，值取 title
+    "status": t.status,
+    "priority": t.priority,
+    ...
+}
+```
+
+- 前端契约保持不变；`DiscoveredTask.title` 仅是后端领域字段重命名，API 兼容层在 router 完成。
+
+## 10. 测试改动
+
+### 单元 `test_task_discovery_unit.py`
+
+```python
+_TASK = {
+    "task_id": "task-001",
+    "bot_id": "bot-001",
+    "owner_id": "user-001",
+    "dt": "2026-08-19",
+    "title": "...",                          # was: project_name
+    "instruction": "...",                    # was: description
+    "background": "...",                     # was: business_scenario
+    "discovery_basis": "...",
+    "objective": "...",                       # 新增
+    "acceptances": [                          # 新增
+        {"id": "1", "description": "..."},
+    ],
+    "priority": "high",
+    "discovered_at": "2026-08-17T10:00:00Z",
+    "status": "pending_confirmation",
+}
+
+# test_read_pending_for_bot 新增断言：
+#   objective / acceptances 通过 init→INSERT→SELECT 往返不丢
+```
+
+### Router `test_task_discovery_router.py`
+
+`_status_task` 字典同样改为新键；构造 `DiscoveredTask(...)` 时**显式映射**避免 `**kwargs` 解包 `work_item_url` 引发 TypeError（如旧 dict 含 work_item_url 但 DiscoveredTask 已无该字段）。
+
+### E2E — `test_cron_timed_fire_e2e.py` / `test_cron_scheduler_e2e.py`
+
+- mock dict 改新键 + objective + acceptances
+- session title 前缀断言改为 `[DreamMode-任务发现]`
+- **删除独立钉钉 SDK Phase6**（`TestDingTalkCardE2E`、Phase6 standalone `_send_dingtalk_card` 等）：钉钉卡片现由 `DingTalkNotifySender` 集成投递，由 `DiscoveryService._discover_single` 触发；e2e 只设环境变量 + 验证 channel sent 即可。
+
+### E2E — `test_discover_and_notify_e2e.py`
+
+整文件删除。该脚本是首个钉钉 standalone 验证脚本，钉钉正式下沉到 `DingTalkNotifySender` 后该路径不再有用。
+
+### E2E — `test_cron_timed_fire_workorder_e2e.py`（新增）
+
+- 流程：setUp bot → 写 mock 待确认任务 → `POST /api/v1/collaboration/tasks/discovery/scheduled-trigger` → `GET /api/v1/collaboration/tasks/discovery/status`（断言 `[DreamMode-任务发现]` + session_id）→ `POST /openapi/v1/bots/work-orders/events` 构造 NOTICE 工单事件（在 discovery 不自动落库时改为手动单点验证，或下一步迁移到自动断言）
+- mock dict 新键 + objective + acceptances 样例
+- 与 e2e 之前定下的 workorder NOTICE 约束参数对齐：`applicant_user_id=None`、`approver_user_ids=[]`、`recipient_user_ids=[user_id]`、`event_type=TASK_DISCOVERED`
+- 后端必须注入 `AGENTCLAW_SECRET_GATEWAY_PRINCIPAL_SIGNING_KEY_VALUE` 才能放行 `/openapi/v1/*`，否则 401
+
+## 11. 已踩过的坑（避免后续重蹈）
+
+| 坑 | 表现 | 修复方式 |
+|---|---|---|
+| 装错 `tea-openapi` 版本（0.4.6） | 钉钉签名阶段 `sign.verify.error` | 固定 `alibabacloud-tea-openapi==0.3.10`；缺 `darabonba-core` / `credentials-api` 同步装上 |
+| `init_discovered_tasks_db` 用 `CREATE TABLE IF NOT EXISTS` 旧库不升级 | `_row_to_task` 缺 `objective` / `acceptances` 列，`row["objective"]` 抛 KeyError | DROP+CREATE 重置；`_row_to_task` 同时防御性读 |
+| `DiscoveredTask(**_status_task)` 解包旧 `work_item_url` | `TypeError: __init__() got an unexpected keyword argument 'work_item_url'` | 改显式键值映射 |
+| 后端 `AGENTCLAW_SECRET_GATEWAY_PRINCIPAL_SIGNING_KEY_VALUE` 未注入 | `/openapi/v1/*` 401 | 部署 / 联调时记得 export 并 restart |
+| 后端进程 `_discoveries` 缓存跨 run 残留 | 同一 task_id 第二次 discover 走 `_discovery_status()` 直接读到上次 in-memory 结果判定已发现 | 单测过程重启后端清缓存；生产一般单 task_id 一次性触发不复发 |
+| 后端 `bot 丢失`（重启擦 db） | 创建 bot → 重启 backend → bots 列表为 0 | singlebox 模式 SQLite 持久化层级不强，重新 POST `/api/bots` |
+| `test_discover_and_notify_e2e.py` 假阳性钉钉卡片 | 测试污染 superbot 重启再跑仍看到旧卡片 | 删除文件下沉到 `DingTalkNotifySender` 后，只验证 channel sent，不依赖手动 SDK 调用 |
+| `sed "description":→"instruction":` 误触 `acceptances` 内 `description` | mock 数据中 `{"id": "1", "instruction": "..."}` 应为 `description` | 改用上下文相关 regex（只在工作项 context 内替换，acceptances 内 description 不动） |
+| `scripts/modules/backend.sh` 注释在 nohup 命令块内 | restart backend 启动失败 | 把注释放在命令块外（已恢复） |
+| `WorkOrderListItem.work_order_no: str` 拒绝 `None` | `GET /openapi/v1/bots/work-orders` 因 NOTICE 工单无 work_order_no 返回 500 | **本 spec 未修复**，TODO 留下个 spec 改为 `str | None` |

--- a/src/backend/specs/2026-08-25-task-discovery-taskspec-align-and-notify-channels/spec.md
+++ b/src/backend/specs/2026-08-25-task-discovery-taskspec-align-and-notify-channels/spec.md
@@ -1,0 +1,378 @@
+# DiscoveredTask 对齐 TaskSpec + 发现流程接入双通知通道（钉钉 NotifySender seam + 工单 NOTICE）
+
+## 概述
+
+本 spec 汇总 2026-08-24 到 2026-08-25 期间在 `task_discovery` 模块内的两类改动：
+
+1. **DiscoveredTask 对齐执行层 TaskSpec**：把 `DiscoveredTask` 的 `project_name` / `description` / `business_scenario` 三个领域字段改名为 `title` / `instruction` / `background`，并新增 TaskSpec.goal 维度的 `objective` / `acceptances`；同步同步 `discovered_tasks.db` 列名、`to_discovery_prompt` 改为按 4 个维度（目标 / 预期交付物 / 验收标准 / 约束）组织，session 标题前缀 `[DreamMode]` → `[DreamMode-任务发现]`，移除已废弃的 `work_item_url` 字段。
+2. **发现流程接通知双通道**：
+   - **钉钉交互卡**：通过 `NotifySenderPlugin` seam 注入 `DingTalkNotifySender`（装饰 `CommunityNotifySender`），由 DI 在凭证就绪时绑定；`DiscoveryService` 仍只依赖 `notify_sender` 抽象，钉钉 SDK 不漏进发现主流程。
+   - **工单 NOTICE 通知**：`DiscoveryService` 新增 `work_order_service` 依赖，发现成功后直接调用 `WorkOrderService.create_work_order_event`（`event_category=NOTICE`，`event_type=TASK_DISCOVERED`），把"待确认任务"写入 `ac_work_order_notification`，作为通知中心一个独立通道。
+
+**关联文档**：
+- `2026-08-24-discover-session-url-fix-and-dingtalk-notify-enhance/spec.md` — 前置 spec（session_url / [DreamMode] 标题 / e2e 钉钉卡片）
+- `2026-08-20-task-discovery-endpoints-and-dingtalk-notify/spec.md` — 钉钉 SDK 首次接入
+- `2026-08-18-task-discovery/spec.md` — task_discovery 模块总览
+
+**领域定位**：
+- `DiscoveredTask` 是任务**发现阶段**的领域对象，对应执行前 `(task_id, title, instruction, background, objective, acceptances, ...)` 元组。
+- 执行层 `TaskSpec` 由 `Metadata{task_id, title, instruction}` + `Context{background, extend_props}` + `Goal{objective, acceptances[AcceptanceCriteria{id, description}]}` 三块组成；本 spec 让 `DiscoveredTask` 字段名与其语义对齐（不直接变成 `TaskInfoRequest`）。
+- "动态任务消息指令"对应 `DiscoveredTask`；"task 发起"用 `POST /openapi/v1/collaboration/tasks/execute`，传 `TaskInfoRequest`，关联由确认后 `to_*` 适配完成。
+
+---
+
+## 需求列表
+
+### REQ-1: DiscoveredTask 字段对齐 TaskSpec（重命名 + 新增 objective/acceptances）
+
+- **描述**：`DiscoveredTask` 字段名不对齐执行层 TaskSpec 语义，发现 → 执行衔接需要手工映射。改为直接对齐：`project_name→title`、`description→instruction`、`business_scenario→background`，并新增 TaskSpec.goal 维度 `objective: str` / `acceptances: list[dict]`（每条 `{"id","description"}`）。
+- **验收标准**：
+  - `DiscoveredTask` 字段名变为 `title` / `instruction` / `background` / `objective` / `acceptances`
+  - `to_session_ext_info` 仍保留旧键名（`project_name` / `description` / `business_scenario`，值取自新字段），保证 engine 兼容
+  - `to_card_data` 中 `workitem_name=title`、`workitem_bg=instruction`
+  - `to_notification_body` 用 `title` / `instruction`
+  - `acceptances` 默认 `field(default_factory=list)`，`objective` 默认 `""`
+  - 字段顺序与 TaskSpec 三块语义一致（title/instruction/background 为 metadata/context，objective/acceptances 在末尾）
+- **改动文件**：
+  - `src/agentclaw/community/core/task/task_discovery/models.py` — 字段重命名 + 新增 `objective` / `acceptances` + 类 docstring 更新 + `to_notification_body` / `to_card_data` / `to_session_ext_info` 同步
+- **状态**：已完成
+
+### REQ-2: 移除 DiscoveredTask.work_item_url
+
+- **描述**：`work_item_url` 字段未在执行链路实际使用，从模型 / DB 列 / e2e mock / API 文档中统一移除。
+- **验收标准**：
+  - `DiscoveredTask` 不再有 `work_item_url` 字段
+  - `discovered_tasks.db` DDL 不再有 `work_item_url` 列
+  - `init_discovered_tasks_db` 的 INSERT SQL 不再写该列
+  - `docs/task-discovery-api.zh-CN.md` 表格中 `work_item_url` 行删除
+  - `_build_discovery_prompt` / `to_card_data` 删除对 `work_item_url` 的引用
+- **改动文件**：
+  - `core/task/task_discovery/models.py`、`core/task/task_discovery/task_reader.py`、`core/task/task_discovery/session_initiator.py`、`docs/task-discovery-api.zh-CN.md`
+- **状态**：已完成
+
+### REQ-3: discovered_tasks.db schema 同步重命名 + init DROP+CREATE
+
+- **描述**：DB 表列名沿用旧 `project_name` / `description` / `business_scenario` / `work_item_url`，与模型不匹配；`CREATE TABLE IF NOT EXISTS` 也不会给已存在的旧库加列。
+- **验收标准**：
+  - DDL 列改为 `title TEXT NOT NULL` / `instruction TEXT` / `background TEXT` / `objective TEXT` / `acceptances TEXT`，不再有 `work_item_url`
+  - `init_discovered_tasks_db` 改为 `DROP TABLE IF EXISTS` + `CREATE TABLE`，保证每次初始化使用最新 schema
+  - `_SELECT_ALL_SQL` / `_SELECT_PENDING_FOR_BOT_SQL` 改为 `SELECT *`，由 `_row_to_task` 防御性读取
+  - `_row_to_task` 对 `objective` / `acceptances` 缺列容错（旧库读取），`acceptances` JSON 解析失败回退 `[]`
+  - INSERT 列名同步为 `title` / `instruction` / `background` / `objective` / `acceptances`（acceptances 用 `json.dumps(..., ensure_ascii=False)` 落库）
+- **改动文件**：
+  - `core/task/task_discovery/task_reader.py` — DDL / SELECT / `_row_to_task` / `init_discovered_tasks_db` / MockTaskReader mock 数据 + 构造同步
+- **状态**：已完成
+
+### REQ-4: 发现提示词按 TaskSpec 4 维度组织
+
+- **描述**：单任务 / 多任务的发现提示词原为"简介 + 业务场景"二维，应按执行层 TaskSpec 的 4 个维度（目标 / 预期交付物 / 验收标准 / 约束）重组，让 session 内 bot 直接看到 TaskSpec 语义。
+- **验收标准**：
+  - `DiscoveredTask.to_discovery_prompt()`（单任务）输出：
+    ```
+    /task 我为您发现了以下可能有意义的事情：
+    【{title}】
+    目标：{objective or title}
+    预期交付物：{instruction}
+    验收标准：
+      - [{id}] {description}
+    约束：{background}
+    是否确认执行？请在下方回复确认或拒绝。
+    ```
+  - `SessionInitiator._build_discovery_prompt()`（多任务）输出每条任务带编号 `1.` / `2.`，4 维度同上，末行 "请向用户展示以上任务，并询问是否确认执行。"
+  - `acceptances` 为空时打印 `验收标准：（确认时可由你补充）`
+- **改动文件**：
+  - `core/task/task_discovery/models.py` — `to_discovery_prompt`
+  - `core/task/task_discovery/session_initiator.py` — `_build_discovery_prompt`
+- **状态**：已完成
+
+### REQ-5: session 标题前缀 [DreamMode] → [DreamMode-任务发现]
+
+- **描述**：发现创建的 session title 前缀改为 `[DreamMode-任务发现]`，与普通工作 session 区分更明确。
+- **验收标准**：
+  - 单任务：`[DreamMode-任务发现] {first_task.title}`
+  - 多任务：`[DreamMode-任务发现] 发现 {task_count} 件可能有意义的事情`
+  - 仍按 `2026-08-24-discover-session-url-fix-and-dingtalk-notify-enhance` 的 Step 2.5 单独 update title 流程（engine 创建时 title 不生效）
+- **改动文件**：
+  - `core/task/task_discovery/session_initiator.py` — title 构造两处分支 + `first_task.project_name → first_task.title`
+- **状态**：已完成
+
+### REQ-6: session_initiator URL 解析环境感知化（_resolve_frontend_url / _resolve_backend_url）
+
+- **描述**：硬编码 `http://localhost:8888` / `http://localhost:8000` 在 singlebox 本地域名场景下会绕过 `/etc/hosts`，导致 session_url 不可外发。改为环境感知解析。
+- **验收标准**：
+  - 新增 `_resolve_frontend_url()` 优先级：`FRONTEND_URL` env > `DEPLOY_PROFILE=singlebox` → `http://agentclaw-local.stable.alipay.net:8000` > fallback `http://localhost:8000`
+  - 新增 `_resolve_backend_url()` 优先级：`BACKEND_URL` env > `SINGLEBOX_BACKEND_URL` env > singlebox 模式 → `http://agentclaw-local.stable.alipay.net:8888` > fallback `http://localhost:8888`
+  - `CronRelaySessionInitiator.__init__` 用上述两个 helper，移除原内联 `os.environ.get("FRONTEND_URL", ...)` 逻辑
+  - 常量从 `_DEFAULT_FRONTEND_PORT="8000"` / `_DEFAULT_BACKEND_URL` 调整为 `_DEFAULT_FRONTEND_URL` / `_DEFAULT_BACKEND_URL` + `_SINGLEBOX_HOST`
+- **改动文件**：
+  - `core/task/task_discovery/session_initiator.py` — 新增两个 helper + `__init__` 调用
+- **状态**：已完成
+
+### REQ-7: 钉钉通知集成到 DiscoveryService（NotifySenderPlugin seam → DingTalkNotifySender）
+
+- **描述**：钉钉 SDK 此前仅在 e2e 测试脚本中手动调用；下沉到 `DingTalkNotifySender` 实现 `NotifySenderPlugin`，作为 `CommunityNotifySender` 的装饰器，由 DI 在凭证就绪时绑定。`DiscoveryService` 仍只依赖 `notify_sender`，钉钉 SDK 不漏进发现主流程。
+- **验收标准**：
+  - 新增 `DingTalkNotifySender(NotifySenderPlugin)` 接收一个 `inner` 通道，`send()` 先走 inner（日志/兜底），再 `_send_dingtalk_card()` 投递钉钉交互卡片，**永不抛异常**（钉钉失败仅 warning）
+  - 静态 `_configured()` 要求四项齐全：`TASK_DISCOVERY_DINGTALK_AK_ID`（回退 `SINGLEBOX_DINGTALK_AK_ID`）、`_AK_SECRET`（回退 `SINGLEBOX_DINGTALK_AK_SECRET`）、`_ROBOT_CODE`（回退 `SINGLEBOX_DINGTALK_ROBOT_CODE`）、`TASK_DISCOVERY_CARD_TEMPLATE_ID`（回退 `SINGLEBOX_DINGTALK_CARD_TEMPLATE_ID`）
+  - `account_id` 取 `TASK_DISCOVERY_DINGTALK_ACCOUNT_ID`（回退 `SINGLEBOX_DINGTALK_ACCOUNT_ID`），再回退 `message.recipient`
+  - corp 钉钉 SDK（`alipay_antdingopensdk_client`、`alibabacloud_tea_openapi` / `alibabacloud_tea_util`）**惰性导入**（在 `_send_dingtalk_card` 内），凭证缺失时根本不导入
+  - 卡片载荷来自 `NotifyMessage.extra`：`card_template_id` / `card_biz_id` / `card_data` / `session_url`，由 `DiscoveryService._send_notification` 填入
+  - 凭证未注入时 `_configured()=False`，`send()` 静默只走 inner，钉钉侧 no-op
+- **改动文件**：
+  - `plugins/community/notify_sender.py` — 新增 `DingTalkNotifySender` + `_env()` 兼容回退
+  - `di/modules/infrastructure/community/notify.py` — `CommunityNotifyModule._notify_sender` 条件分支：`DingTalkNotifySender._configured()` 为 True → `DingTalkNotifySender(CommunityNotifySender())`，否则 `CommunityNotifySender()`
+- **状态**：已完成
+
+### REQ-8: DiscoveryService 集成 WorkOrderService（直接调用 NOTICE 工单事件）
+
+- **描述**：除钉钉卡片外，发现流程需要把"待确认任务"作为一条 NOTICE 通知写入工单收件箱（`ac_work_order_notification`），供工单/通知中心展示。`DiscoveryService` 直接调用 `WorkOrderService.create_work_order_event`，不通过 NotifySender seam。
+- **验收标准**：
+  - `DiscoveryService.__init__` 新增 `work_order_service: WorkOrderServiceProtocol | None = None` 参数（`TYPE_CHECKING` only，运行期按鸭子类型调用）
+  - DI 模块 `TaskDiscoveryModule` 注入 `WorkOrderServiceProtocol` 到 `DiscoveryService`
+  - 新增 `_send_work_order_event(task, user_id, session) -> bool`，调用 `create_work_order_event`：
+    - `event_category=NotificationCategory.NOTICE`
+    - `event_type=WorkOrderEventType.TASK_DISCOVERED.value`
+    - `applicant_user_id=None`（NOTICE 约束）
+    - `approver_user_ids=[]`
+    - `recipient_user_ids=[user_id]`
+    - `biz_type="task_discovery"`、`biz_id=task.task_id`
+    - `title=task.title`，`content` 含 `to_card_data()` + `session_url` + `task_id`
+    - `biz_data` 含 `task_id` / `bot_id` / `owner_id` / `session_id` / `session_url`
+    - `actor_id=user_id`
+  - 失败永不抛异常，仅 warning + 返回 False
+  - `_work_order_service` 未注入（None）时 returns False（向后兼容）
+  - `_discover_single` 同时跑两个通道：`card_sent = self._send_notification(...)`（接收 `session` 而非 `session_url`）+ `work_order_sent = self._send_work_order_event(...)`，`notification_sent = card_sent or work_order_sent`
+- **改动文件**：
+  - `core/task/task_discovery/discovery_service.py` — `__init__` 加 `work_order_service` 参数；`_send_notification` 签名 `session_url` → `session`（内部取 `session_url`，extra.card_data 补 `click` / `session_url`）；新增 `_send_work_order_event`
+  - `core/work_orders/models.py` — `WorkOrderEventType.TASK_DISCOVERED = "TASK_DISCOVERED"` + 在 `EVENT_CATEGORIES` 注册为 `NotificationCategory.NOTICE`
+  - `di/modules/task_discovery_module.py` — `provide_discovery_service` 新增 `work_order_service: WorkOrderServiceProtocol` 参数并注入
+- **状态**：已完成
+
+### REQ-9: HTTP /discovery/discover 与 /discovery/status 响应字段名兼容
+
+- **描述**：模型字段重命名后，router 仍以旧 `project_name` 为 JSON key 输出给前端，与 DB / 模型名不一致。
+- **验收标准**：
+  - `/discovery/discover` 返回的每个 task 仍以 `project_name` 为 key（保持前端兼容），值取自 `r.task.title`
+  - `/discovery/status` 返回的每个 task 同样以 `project_name` 为 key，值取自 `t.title`
+- **改动文件**：
+  - `adapters/http/task/router.py` — 两处 `r.task.project_name → r.task.title` / `t.project_name → t.title`
+- **状态**：已完成
+
+### REQ-10: session_creator title 使用新字段
+
+- **描述**：session 创建请求体的 `title` 原 `task.project_name`，需要随模型字段重命名同步。
+- **验收标准**：
+  - `HttpSessionCreator.create_session` 的 `body["title"] = task.project_name` → `task.title`
+- **改动文件**：
+  - `core/task/task_discovery/session_creator.py`
+- **状态**：已完成
+
+### REQ-11: 单元 / e2e 测试 mock 数据全量对齐新字段名 + objective + acceptances
+
+- **描述**：DB 列改名后，所有 mock 数据字典需要从 `project_name` / `description` / `business_scenario` / `work_item_url` 改为 `title` / `instruction` / `background` + 新增 `objective` / `acceptances` 样例；测试中的 `DiscoveredTask` 显式构造（防 `**kwargs` TypeError）也要同步。
+- **验收标准**：
+  - `test_task_discovery_unit.py`：`_TASK` dict + `init_discovered_tasks_db` 入参改为新键 + `objective` / `acceptances` 样例；`test_read_pending_for_bot` 断言 `objective` / `acceptances` 在 DB 往返不丢
+  - `test_task_discovery_router.py`：`_status_task` dict 新键；`DiscoveredTask(...)` 显式键值映射
+  - `singlebox_e2e/test_cron_scheduler_e2e.py` / `.../test_cron_timed_fire_e2e.py`：mock dict 新键 + 前缀 `[DreamMode-任务发现]` 断言；钉钉 Phase6（独立 SDK 调用）从测试脚本中删除（已下沉到 DingTalkNotifySender）
+  - `singlebox_e2e/test_discover_and_notify_e2e.py`：整文件删除（纯独立钉钉 standalone 脚本，已被 DingTalkNotifySender 集成取代）
+  - `singlebox_e2e/test_task_discovery_e2e.py`：mock 任务字段 + /discovery/status 断言新键
+  - 新增 `singlebox_e2e/test_cron_timed_fire_workorder_e2e.py` — workorder 通道 e2e（discover → 工单 NOTICE 通知落库），mock dict 新键
+- **改动文件**：
+  - `tests/community/core/task/test_task_discovery_unit.py`
+  - `tests/community/endpoints/test_task_discovery_router.py`
+  - `tests/community/core/task/singlebox_e2e/test_cron_scheduler_e2e.py`
+  - `tests/community/core/task/singlebox_e2e/test_cron_timed_fire_e2e.py`
+  - `tests/community/core/task/singlebox_e2e/test_discover_and_notify_e2e.py`（删除）
+  - `tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py`
+  - `tests/community/core/task/singlebox_e2e/test_cron_timed_fire_workorder_e2e.py`（新增）
+- **状态**：已完成
+
+---
+
+## 改动文件清单
+
+### 源码
+
+| 文件 | 改动 |
+|---|---|
+| `core/task/task_discovery/models.py` | 字段对齐 TaskSpec（title/instruction/background + objective/acceptances）；`to_discovery_prompt` 4 维度；`to_session_ext_info` 保留旧键名兼容 engine；移除 `work_item_url` |
+| `core/task/task_discovery/task_reader.py` | DDL 列重命名 + 新增 objective/acceptances 列；`init_discovered_tasks_db` DROP+CREATE；`SELECT *` + 防御性 `_row_to_task`；MockTaskReader 同步 |
+| `core/task/task_discovery/session_initiator.py` | 4 维度 `_build_discovery_prompt`；`_build_session_url` 用 `_resolve_frontend_url`；`_resolve_backend_url`；title 前缀 `[DreamMode-任务发现]` + `first_task.title` |
+| `core/task/task_discovery/session_creator.py` | `body["title"] = task.title` |
+| `core/task/task_discovery/discovery_service.py` | `__init__` + `work_order_service`；`_send_notification` 签名 `session_url → session`；新增 `_send_work_order_event`；`_discover_single` 双通道 card_sent + work_order_sent |
+| `core/work_orders/models.py` | `WorkOrderEventType.TASK_DISCOVERED` + `EVENT_CATEGORIES[TASK_DISCOVERED] = NOTICE` |
+| `di/modules/infrastructure/community/notify.py` | `_notify_sender` 条件分支：DingTalkNotifySender vs CommunityNotifySender |
+| `di/modules/task_discovery_module.py` | `provide_discovery_service` 注入 `work_order_service` |
+| `plugins/community/notify_sender.py` | 新增 `DingTalkNotifySender` + `_env()` 兼容回退；惰性导入 corp SDK |
+| `adapters/http/task/router.py` | `/discovery/discover` / `/discovery/status` 返回 `project_name` 字段取自 `r.task.title` / `t.title` |
+| `docs/task-discovery-api.zh-CN.md` | 表格移除 `work_item_url` 行 |
+
+### 测试
+
+| 文件 | 改动 |
+|---|---|
+| `tests/.../test_task_discovery_unit.py` | mock dict 新键 + objective/acceptances；`test_read_pending_for_bot` 断言 DB 往返 |
+| `tests/.../test_task_discovery_router.py` | `_status_task` 新键；`DiscoveredTask(...)` 显式映射 |
+| `tests/.../singlebox_e2e/test_cron_scheduler_e2e.py` | mock dict 新键；删除独立钉钉 SDK Phase6（TestDingTalkCardE2E） |
+| `tests/.../singlebox_e2e/test_cron_timed_fire_e2e.py` | mock dict 新键；删除独立钉钉 Phase6（DingTalkNotifySender 接管） |
+| `tests/.../singlebox_e2e/test_discover_and_notify_e2e.py` | 整文件删除 |
+| `tests/.../singlebox_e2e/test_task_discovery_e2e.py` | mock dict 新键 + status 断言 |
+| `tests/.../singlebox_e2e/test_cron_timed_fire_workorder_e2e.py` | **新增**：workorder 通道 e2e（discover → 工单 NOTICE 落库），mock dict 新键 |
+
+### 外层单仓（非 ocb-public，仅在 spec 中记录依赖关系）
+
+| 文件 | 改动 |
+|---|---|
+| `src/backend/pyproject.toml`（外层单仓） | `corp` 组新增钉钉 SDK 依赖（运行期 corp 集群才用到） |
+| `src/backend/uv.lock`（外层单仓） | 重新生成（含钉钉 SDK transitive 依赖） |
+| `scripts/modules/backend.sh`（外层单仓） | 新增注释（说明钉钉凭证经 env 注入，不硬编码到脚本） |
+
+---
+
+## SDK 依赖（钉钉 NotifySender）
+
+需在 `pyproject.toml` 的 `corp` 组固化（singlebox 测试时也需手动 `uv pip install`）：
+
+| 包 | 版本 | 用途 |
+|---|---|---|
+| `antdingopensdk` | 1.0.47（或 1.0.46） | antding opensdk client |
+| `alibabacloud-tea-openapi` | 0.3.10 | openapi models（**版本必须 0.3.x，不要用最新的 0.4.6 — 签名方法不兼容**） |
+| `alibabacloud-tea-util` | 0.3.15 | RuntimeOptions |
+| `alibabacloud-openapi-util` | 0.2.2 | 签名 util |
+| `alibabacloud-endpoint-util` | 0.0.3 | endpoint 解析 |
+| `alibabacloud-credentials` | 0.3.6 | 凭证 |
+| `alibabacloud-credentials-api` | 1.0.1 | credentials API |
+| `darabonba-core` | 1.0.8 | tea core |
+
+---
+
+## 环境变量
+
+### 钉钉 NotifySender（DingTalkNotifySender）
+
+| 环境变量 | 兼容回退 | 备注 |
+|---|---|---|
+| `TASK_DISCOVERY_DINGTALK_AK_ID` | `SINGLEBOX_DINGTALK_AK_ID` | 钉钉 AK ID |
+| `TASK_DISCOVERY_DINGTALK_AK_SECRET` | `SINGLEBOX_DINGTALK_AK_SECRET` | 钉钉 AK Secret |
+| `TASK_DISCOVERY_DINGTALK_ROBOT_CODE` | `SINGLEBOX_DINGTALK_ROBOT_CODE` | 机器人 code |
+| `TASK_DISCOVERY_CARD_TEMPLATE_ID` | `SINGLEBOX_DINGTALK_CARD_TEMPLATE_ID` | 卡片模板 ID |
+| `TASK_DISCOVERY_DINGTALK_ACCOUNT_ID` | `SINGLEBOX_DINGTALK_ACCOUNT_ID`（再回退 `message.recipient`） | 通知目标 user |
+
+### session URL 解析（SessionInitiator）
+
+| 环境变量 | 默认 | 备注 |
+|---|---|---|
+| `FRONTEND_URL` | singlebox 模式下 `http://agentclaw-local.stable.alipay.net:8000`，否则 `http://localhost:8000` | 前端 workbench 地址 |
+| `BACKEND_URL` / `SINGLEBOX_BACKEND_URL` | singlebox 模式下 `http://agentclaw-local.stable.alipay.net:8888`，否则 `http://localhost:8888` | backend 自身地址 |
+| `DEPLOY_PROFILE` | — | 值为 `singlebox` 时启用本地域名 |
+
+### 工单 notice（NOTICE 工单事件）
+
+后端需有 `AGENTCLAW_SECRET_GATEWAY_PRINCIPAL_SIGNING_KEY_VALUE` 才能放行 `POST /openapi/v1/bots/work-orders/events` 等 `/openapi/v1/*` 请求；工单创建的 NOTICE 路径由 `WorkOrderEventType.TASK_DISCOVERED` 在 `EVENT_CATEGORIES` 注册为 `NotificationCategory.NOTICE` 触发。
+
+---
+
+## 验证命令
+
+### 单元测试
+
+```bash
+cd ocb-public/src/backend
+
+# task_discovery 单元（含 DiscoveredTask 新字段 + DB 往返）
+.venv/bin/python -m pytest tests/community/core/task/test_task_discovery_unit.py -s -v
+
+# router 单元（status 响应字段名）
+.venv/bin/python -m pytest tests/community/endpoints/test_task_discovery_router.py -s -v
+```
+
+### E2E — 钉钉 NotifySender 通道（singlebox 启动后）
+
+```bash
+cd ocb-public/src/backend
+
+# 重启后端带上钉钉凭证
+#   ocb-public/scripts/singlebox.sh restart backend
+# 或手动 export：
+#   export TASK_DISCOVERY_DINGTALK_AK_ID=... \
+#           TASK_DISCOVERY_DINGTALK_AK_SECRET=... \
+#           TASK_DISCOVERY_DINGTALK_ROBOT_CODE=... \
+#           TASK_DISCOVERY_CARD_TEMPLATE_ID=... \
+#           TASK_DISCOVERY_DINGTALK_ACCOUNT_ID=440718
+
+SINGLEBOX_CRON_E2E=1 SINGLEBOX_USER_ID=440718 \
+  .venv/bin/python -m pytest \
+    tests/community/core/task/singlebox_e2e/test_cron_timed_fire_e2e.py -s -v
+```
+
+### E2E — 工单 NOTICE 通道
+
+```bash
+# 后端必须注入 principal signing key（dev key），否则 /openapi/v1 返回 401
+#   ocb-public/scripts/singlebox.sh restart backend
+
+SINGLEBOX_CRON_E2E=1 SINGLEBOX_USER_ID=440718 \
+  .venv/bin/python -m pytest \
+    tests/community/core/task/singlebox_e2e/test_cron_timed_fire_workorder_e2e.py -s -v
+```
+
+### 通道运行验证要点
+
+- 钉钉：发现成功后 `processQueryKey` 返回，session title 前缀 `[DreamMode-任务发现]`
+- 工单：`ac_work_order_notification` 出现 `event_type=TASK_DISCOVERED` 行，`notification_ids` 非空
+- 两通道并发，任一失败仅在日志 warning，不影响发现主流程
+
+---
+
+## TODO
+
+- **修复 `WorkOrderListItem.work_order_no: str` → `str | None`**：`GET /openapi/v1/bots/work-orders` 当前因 NOTICE 工单无 `work_order_no`，pydantic 校验阶段返回 500（与发现流程不冲突，但已观察到）。建议下次 bugfix spec 单独修复。
+- **`test_cron_timed_fire_workorder_e2e.py` Phase6 改为自动断言**：目前 `discovery` 阶段不直接断言 `TASK_DISCOVERED` 通知自动创建，仍走手动 POST；可改为依赖 `DiscoveryService._send_work_order_event` 自动落库，仅断言 `ac_work_order_notification` 行。
+- **`acceptances` 单一 mock 样例**：当前 e2e mock 仅一套 objective/acceptances 样例，可补一套 variant run 验证 `ext_info` / `card_data` 多样性。
+- **`WorkOrderNotifySender` 路径（已废弃）**：早期讨论过把工单也做成 `NotifySenderPlugin` seam，最终采纳"直接领域调用 WorkOrderService"方案；本 spec 不再涵盖该废弃路径。
+- **凭证管控**：钉钉凭证在生产环境应由部署平台注入 `TASK_DISCOVERY_DINGTALK_*`，不要硬编码到 `scripts/modules/backend.sh`；singlebox 联调时可手动 export 后 `restart backend`。
+
+---
+
+## 技术决策
+
+### 为什么 DiscoveredTask 不直接变成 TaskInfoRequest？
+
+`DiscoveredTask` 是发现阶段的领域对象，承载"被发现状态 / 待确认状态 / 优先级 / 挖掘依据"等发现特有字段；执行层 `TaskInfoRequest`（`POST /openapi/v1/collaboration/tasks/execute`）只关心执行所需的 TaskSpec 三块（Metadata / Context / Goal）。两者通过字段名对齐让"确认 → 执行"的适配变成纯字段映射（如 `to_session_ext_info` 内部就保留旧 key 兼容 engine），但**保留两个对象**避免发现侧状态污染执行侧契约。
+
+### 为什么钉钉用 NotifySender seam、工单用直接领域调用？
+
+- **钉钉**：`NotifySenderPlugin` 是"消息外发通道"抽象，本就该用一个 plugin 把"日志/兜底通道"和"真正外发通道"组合。`CommunityNotifySender` 是日志通道，`DingTalkNotifySender` 是装饰它的钉钉通道；`DiscoveryService` 不感知钉钉存在。这种 seam 模式让未来可平滑增加其他外发通道（飞书 / 企业微信）。
+- **工单 NOTICE**：`ac_work_order_notification` 是**领域内**的工单收件箱，不是消息外发通道。工单事件创建涉及 `event_category` / `event_type` / `applicant_user_id` / `approver_user_ids` / `recipient_user_ids` / `biz_data` 等领域语义，硬塞进 NotifySender 会让 seam 越界。最终选择 `DiscoveryService` 直接持 `WorkOrderService` 引用并调用 `create_work_order_event`，📟 与 `notify_sender` 平行作为发现流程的"两条通知通道"。
+
+### 为什么 init_discovered_tasks_db 改为 DROP+CREATE？
+
+`CREATE TABLE IF NOT EXISTS` 在已存在旧 schema 时不会添加新列（`objective` / `acceptances`），导致测试初始化后字段不齐。e2e / 单测场景下 `init_discovered_tasks_db` 是"清零 + 重灌"语义，DROP+CREATE 既清空旧数据又保证新 schema 就位，语义更清晰。生产 reader（`SqliteTaskReader.add_task`）走 `INSERT OR IGNORE`，与 `init_discovered_tasks_db` 互不影响。
+
+### 为什么 `_SELECT_ALL_SQL` 改为 `SELECT *`？
+
+旧版 SELECT 显式列出字段名，schema 升级时必须同步 SQL；改 `SELECT *` 后，增加列无需改 SQL，只需在 `_row_to_task` 做防御性读取（`keys = set(row.keys())` 判断 `objective` / `acceptances` 是否存在）。旧库（缺这两列）也能降级读取，向后兼容。
+
+### 为什么 `_row_to_task` 要防御性读 `objective` / `acceptances`？
+
+如上线后 reader 拿到一个旧 schema 的 `discovered_tasks.db`（如生产环境未 DROP），`SELECT *` 只会返回旧列，没有 `objective` / `acceptances`。直接 `row["objective"]` 会 `IndexError`。防御性访问 `row["objective"] if "objective" in keys and row["objective"] else ""`，缺列回退默认值。`acceptances` 还要防 JSON 解析错误回退 `[]`，避免脏数据让 reader 崩。
+
+### 为什么 `_send_notification` 签名从 `session_url: str` 改为 `session: DiscoverySession`？
+
+`_send_work_order_event` 同样需要 `session.session_url` / `session.session_id`，传 `session` 而非 `session_url` 让两个通道用同一接口，并在 `_send_notification` 内部把 `session_url` 补到 `card_data` 的 `click` 和 `session_url` 字段（钉钉卡片模板按这些字段渲染"CTA + 直达链接"），减少参数传递层级。
+
+### 为什么钉钉 SDK 必须**惰性导入**？
+
+corp 钉钉 SDK（`alipay_antdingopensdk_client` 等）只在生产 / 预发 / singlebox 联调时可用。社区 / 开发 profile 没装这些包，模块顶层 import 会让后端启动直接 `ModuleNotFoundError`。`send()` 内部惰性导入配合 `_configured()` 前置判断，保证未配置凭证时根本不触发 import 路径。
+
+### 为什么钉钉 SDK 必须 `tea-openapi==0.3.10` 而非 0.4.6？
+
+`alipay_antdingopensdk_client 1.0.46` 依赖 `tea-openapi 0.3.x` 的签名实现。若被 pip 解析为 0.4.6，`send_robot_interactive_card_with_options` 在签名阶段抛 `sign.verify.error`（请求签名与钉钉验证不匹配）。`pyproject.toml` 必须固定 `alibabacloud-tea-openapi==0.3.10`。同时需要 `alibabacloud-openapi-util==0.2.2` + `darabonba-core==1.0.8` 提供底层签名 / tea core。
+
+---
+
+## 变更记录
+
+| 日期 | 变更 |
+|---|---|
+| 2026-08-25 | 初始创建 — 汇总 08-24 → 08-25 期间 task_discovery 模块 DiscoveredTask 对齐 TaskSpec、发现流程接入钉钉 NotifySender seam + 工单 NOTICE 双通道、DreamMode-任务发现 标题、4 维度发现提示词、DB schema 同步重命名等全部改动 |

--- a/src/backend/specs/2026-08-25-task-discovery-taskspec-align-and-notify-channels/tasks.md
+++ b/src/backend/specs/2026-08-25-task-discovery-taskspec-align-and-notify-channels/tasks.md
@@ -1,0 +1,184 @@
+# 任务清单 — DiscoveredTask 对齐 TaskSpec + 发现流程双通知通道
+
+## 已完成
+
+### DiscoveredTask 对齐 TaskSpec
+
+- [x] T1: `DiscoveredTask` 字段重命名 — `project_name→title`、`description→instruction`、`business_scenario→background`
+  - 文件: `core/task/task_discovery/models.py`
+  - 同步 `to_notification_body` / `to_card_data`（`workitem_name=title`、`workitem_bg=instruction`） / `to_session_ext_info`（保留旧 key 兼容 engine）
+
+- [x] T2: `DiscoveredTask` 新增 `objective: str = ""` + `acceptances: list[dict] = field(default_factory=list)`
+  - 文件: `core/task/task_discovery/models.py`
+  - docstring 说明对齐 TaskSpec.goal.objective / acceptances[AcceptanceCriteria{id, description}]
+
+- [x] T3: 移除 `DiscoveredTask.work_item_url`
+  - 文件: `core/task/task_discovery/models.py`、`task_reader.py`、`session_initiator.py`、`docs/task-discovery-api.zh-CN.md`
+
+- [x] T4: `to_discovery_prompt`（单任务）4 维度 — 目标/预期交付物/验收标准/约束
+  - 文件: `core/task/task_discovery/models.py`
+
+- [x] T5: `_build_discovery_prompt`（多任务）4 维度 — 同上，编号 `1.` `2.`，末尾"请向用户展示..."
+  - 文件: `core/task/task_discovery/session_initiator.py`
+
+- [x] T6: session title 前缀 `[DreamMode] → [DreamMode-任务发现]`
+  - 文件: `core/task/task_discovery/session_initiator.py` (2 处分支)
+  - 单任务：`[DreamMode-任务发现] {first_task.title}`；多任务：`[DreamMode-任务发现] 发现 {task_count} 件...`
+
+### discovered_tasks.db schema 同步
+
+- [x] T7: DDL 列重命名 + 新增 `objective` / `acceptances` 列
+  - 文件: `core/task/task_discovery/task_reader.py`
+
+- [x] T8: `init_discovered_tasks_db` 改 `DROP TABLE IF EXISTS` + `CREATE TABLE`，保证新 schema 就位
+  - 文件: `core/task/task_discovery/task_reader.py`
+
+- [x] T9: `_SELECT_ALL_SQL` / `_SELECT_PENDING_FOR_BOT_SQL` 改 `SELECT *`，`_row_to_task` 防御性读 `objective` / `acceptances`
+  - 文件: `core/task/task_discovery/task_reader.py`
+  - 防御点：列缺失降级为默认值（`objective=""`、`acceptances=[]`），`acceptances` 非 list 回退 `[]`，JSON 解析失败回退 `[]`
+
+- [x] T10: `init_discovered_tasks_db` INSERT 列名同步 + `acceptances` 用 `json.dumps(..., ensure_ascii=False)`
+  - 文件: `core/task/task_discovery/task_reader.py`
+
+- [x] T11: `MockTaskReader` mock 数据 + 构造同步新字段名
+  - 文件: `core/task/task_discovery/task_reader.py`
+
+### session_initiator URL 解析增强
+
+- [x] T12: 新增 `_resolve_frontend_url()` — `FRONTEND_URL` env > singlebox → `http://agentclaw-local.stable.alipay.net:8000` > `http://localhost:8000`
+  - 文件: `core/task/task_discovery/session_initiator.py`
+
+- [x] T13: 新增 `_resolve_backend_url()` — `BACKEND_URL` env > `SINGLEBOX_BACKEND_URL` env > singlebox 模式 → `http://agentclaw-local.stable.alipay.net:8888` > `http://localhost:8888`
+  - 文件: `core/task/task_discovery/session_initiator.py`
+
+- [x] T14: `CronRelaySessionInitiator.__init__` 用两个 helper，移除内联 `os.environ.get`
+  - 文件: `core/task/task_discovery/session_initiator.py`
+
+### 钉钉通知集成到 DiscoveryService（NotifySender seam）
+
+- [x] T15: 新增 `DingTalkNotifySender(NotifySenderPlugin)` — 装饰 `CommunityNotifySender`，`send()` 先 inner 后钉钉卡片，永不抛异常
+  - 文件: `plugins/community/notify_sender.py`
+
+- [x] T16: `DingTalkNotifySender._configured()` — 四项凭证齐全判断，带 `SINGLEBOX_*` 兼容回退
+  - 文件: `plugins/community/notify_sender.py`
+
+- [x] T17: `DingTalkNotifySender._send_dingtalk_card` — corp 钉钉 SDK 惰性导入，发 `send_robot_interactive_card_with_options`
+  - 文件: `plugins/community/notify_sender.py`
+  - 惰性导入：`alipay_antdingopensdk_client`、`alibabacloud_tea_openapi`、`alibabacloud_tea_util`
+
+- [x] T18: `CommunityNotifyModule._notify_sender` 条件分支 — `_configured()` True → `DingTalkNotifySender(inner)`，否则 `inner`
+  - 文件: `di/modules/infrastructure/community/notify.py`
+
+### DiscoveryService 集成 WorkOrderService（NOTICE 工单事件）
+
+- [x] T19: `WorkOrderEventType.TASK_DISCOVERED = "TASK_DISCOVERED"` + 在 `EVENT_CATEGORIES` 注册为 `NotificationCategory.NOTICE`
+  - 文件: `core/work_orders/models.py`
+
+- [x] T20: `DiscoveryService.__init__` 加 `work_order_service: WorkOrderServiceProtocol | None = None`
+  - 文件: `core/task/task_discovery/discovery_service.py`
+  - `TYPE_CHECKING` only import；运行期按鸭子类型调用
+
+- [x] T21: 新增 `_send_work_order_event(task, user_id, session) -> bool` — 直接调用 `create_work_order_event`
+  - 文件: `core/task/task_discovery/discovery_service.py`
+  - 参数：`event_category=NOTICE` / `event_type=TASK_DISCOVERED` / `applicant_user_id=None` / `approver_user_ids=[]` / `recipient_user_ids=[user_id]` / `biz_type="task_discovery"` / `biz_id=task_id` / `biz_data` 含 session_id/session_url
+  - 失败永不抛；`work_order_service is None` returns False（向后兼容）
+
+- [x] T22: `_send_notification` 签名 `session_url: str → session: DiscoverySession`，`card_data` 补 `click=""` + `session_url`
+  - 文件: `core/task/task_discovery/discovery_service.py`
+
+- [x] T23: `_discover_single` 双通道并发 — `card_sent = _send_notification(...)` + `work_order_sent = _send_work_order_event(...)`，`notification_sent = card_sent or work_order_sent`
+  - 文件: `core/task/task_discovery/discovery_service.py`
+  - 日志：`card_sent=%s, work_order_sent=%s, notified=%s`
+
+- [x] T24: `TaskDiscoveryModule.provide_discovery_service` 注入 `WorkOrderServiceProtocol`
+  - 文件: `di/modules/task_discovery_module.py`
+
+### HTTP API 兼容
+
+- [x] T25: `/discovery/discover` / `/discovery/status` 用 `r.task.title` / `t.title` 填 `project_name` 输出字段（前端契约保持）
+  - 文件: `adapters/http/task/router.py` (2 处)
+
+- [x] T26: `session_creator.create_session` 的 `body["title"] = task.title`
+  - 文件: `core/task/task_discovery/session_creator.py`
+
+### 测试同步
+
+- [x] T27: 单元 `test_task_discovery_unit.py` — `_TASK` dict + init 入参改新键 + objective + acceptances 样例
+  - 文件: `tests/community/core/task/test_task_discovery_unit.py`
+  - `test_read_pending_for_bot` 断言 `objective` / `acceptances` 在 init→INSERT→SELECT 往返不丢
+
+- [x] T28: Router 单元 `test_task_discovery_router.py` — `_status_task` dict 新键 + 显式 `DiscoveredTask(...)` 映射
+  - 文件: `tests/community/endpoints/test_task_discovery_router.py`
+  - 显式映射避免 `**kwargs` 解包旧 `work_item_url` TypeError
+
+- [x] T29: E2E `test_cron_scheduler_e2e.py` — mock dict 新键 + 删除独立 `TestDingTalkCardE2E` Phase6（钉钉下沉 DingTalkNotifySender）
+  - 文件: `tests/community/core/task/singlebox_e2e/test_cron_scheduler_e2e.py`
+
+- [x] T30: E2E `test_cron_timed_fire_e2e.py` — mock dict 新键 + 删除 Phase6 独立钉钉 SDK
+  - 文件: `tests/community/core/task/singlebox_e2e/test_cron_timed_fire_e2e.py`
+
+- [x] T31: 删除 `test_discover_and_notify_e2e.py` — 独立钉钉 standalone 脚本，已下沉到 DingTalkNotifySender
+  - 文件: `tests/community/core/task/singlebox_e2e/test_discover_and_notify_e2e.py`（delete）
+
+- [x] T32: E2E `test_task_discovery_e2e.py` — mock 任务新键 + `/discovery/status` 断言新键 + `[DreamMode-任务发现]`
+  - 文件: `tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py`
+
+- [x] T33: 新增 `test_cron_timed_fire_workorder_e2e.py` — 工单 NOTICE 通道 e2e 流程
+  - 文件: `tests/community/core/task/singlebox_e2e/test_cron_timed_fire_workorder_e2e.py`
+  - 流程：setUp bot → 写 mock 待确认 → scheduled-trigger → status 断言 → POST `/openapi/v1/bots/work-orders/events` 手动验证
+  - mock dict 新键 + objective + acceptances 样例
+
+### 外层单仓（非 ocb-public，仅记录依赖关系）
+
+- [x] T34: `src/backend/pyproject.toml` `corp` 组新增钉钉 SDK 依赖（`antdingopensdk` / `alibabacloud-tea-openapi==0.3.10` / `darabonba-core==1.0.8` 等）
+  - 外层 monorepo，非本 submodule
+  - 注：作为 spec 边界之外的依赖固化记录在此，便于后续追溯
+
+- [x] T35: `src/backend/uv.lock` 重新生成（`--index-strategy unsafe-best-match`）
+  - 外层 monorepo
+
+- [x] T36: `scripts/modules/backend.sh` 新增注释 — 说明钉钉凭证经 env 注入，不硬编码
+  - 外层 monorepo
+
+---
+
+## 验证
+
+### 单元测试
+
+- [x] `test_task_discovery_unit.py` 全 26 个 case 通过 — 含 DiscoveredTask 新字段、init DB 往返、`objective`/`acceptances` 不丢
+  - 命令: `cd ocb-public/src/backend && .venv/bin/python -m pytest tests/community/core/task/test_task_discovery_unit.py -s -v`
+
+- [x] `test_task_discovery_router.py` 通过 — status 输出 `project_name` key 取自 `t.title`
+
+### E2E — 钉钉通道（singlebox 启动 + 钉钉凭证注入后）
+
+- [x] `test_cron_timed_fire_e2e.py` 通过 — Phase 4 real cron fired + `[DreamMode-任务发现]` title + DingTalkNotifySender card sent
+  - 输入 env: `TASK_DISCOVERY_DINGTALK_AK_ID` / `_AK_SECRET` / `_ROBOT_CODE` / `TASK_DISCOVERY_CARD_TEMPLATE_ID`
+  - 关键日志：`[DingTalkNotifySender] card sent (... processQueryKey=...)`
+  - 关键日志：`[task_discovery] task ... → session ... (card_sent=True, work_order_sent=<bool>, notified=True)`
+
+### E2E — 工单 NOTICE 通道
+
+- [x] `test_cron_timed_fire_workorder_e2e.py` 通过 — `POST /openapi/v1/bots/work-orders/events` 返回 201 + `notification_ids` 非空
+  - 后端注入 `AGENTCLAW_SECRET_GATEWAY_PRINCIPAL_SIGNING_KEY_VALUE` 否则 401
+  - DB `/ac_work_order_notification` 出现 `event_type=TASK_DISCOVERED` 行（手动 POST 验证自动落库约束）
+
+### 整体 unregression
+
+- [x] 后端进程内存 `_discoveries` 缓存跨 run 残留 — Phase 4 假阳性；重启后端清缓存后 cron 可真实触发
+- [x] 模型字段重命名后 `DiscoveredTask(**_status_task)` TypeError 已在 `test_task_discovery_router.py` 显式映射解决
+- [x] `init_discovered_tasks_db` DROP+CREATE 解决旧 schema 升级 — `objective` / `acceptances` 列就位
+- [x] 测试 mock `acceptances` 中 `description` 不被 sed 误改为 `instruction`（上下文敏感 regex 修复）
+- [x] `scripts/modules/backend.sh` 注释移到命令块外，backend 启动恢复
+
+---
+
+## TODO（下个 spec 处理）
+
+- [ ] **修复 `WorkOrderListItem.work_order_no: str` → `str | None`**：`GET /openapi/v1/bots/work-orders` 当前因 NOTICE 工单无 work_order_no 返回 500
+  - 文件: `src/agentclaw/community/adapters/http/task/schemas.py`
+  - 改后重启后端验证 list 返回 200
+- [ ] `test_cron_timed_fire_workorder_e2e.py` Phase 6 改为自动断言 — depend on `DiscoveryService._send_work_order_event` 自动落库，仅断言 `ac_work_order_notification` 行而非手动 POST
+- [ ] `acceptances` 多套 mock variant run 验证 `ext_info` / `card_data` 多样性
+- [ ] 钉钉凭证在生产环境的注入路径文档化（部署平台 → `TASK_DISCOVERY_DINGTALK_*` env）

--- a/src/backend/src/agentclaw/community/adapters/http/task/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/task/router.py
@@ -35,7 +35,7 @@ import httpx
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Body, HTTPException, Query, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
 from agentclaw.community.adapters.http.openapi_v1.responses import envelope, envelope_errors
@@ -272,7 +272,7 @@ async def discover_tasks(
             "tasks": [
                 {
                     "task_id": r.task.task_id,
-                    "project_name": r.task.project_name,
+                    "project_name": r.task.title,
                     "success": r.success,
                     "session_id": r.session.session_id if r.session else None,
                     "notification_sent": r.notification_sent,
@@ -311,7 +311,7 @@ async def get_discovery_status(
             "bot_id": t.bot_id,
             "owner_id": t.owner_id,
             "dt": t.dt,
-            "project_name": t.project_name,
+            "project_name": t.title,
             "status": t.status,
             "priority": t.priority,
         }
@@ -408,6 +408,83 @@ async def run_scheduled_trigger(
         "total_discovered": len(payload),
         "results": payload,
     }
+
+
+@router.post("/discovery/reschedule")
+async def reschedule_cron(
+    cron: str = Query(..., description="新的 5 字段 cron 表达式, e.g. '30 14 * * *'"),
+    timezone: str | None = Query(None, description="时区, 默认沿用当前时区"),
+    scheduler: TaskDiscoveryScheduler = Injected(TaskDiscoveryScheduler),  # noqa: B008
+) -> dict[str, Any]:
+    """运行时修改 cron 触发时间 — 无需重启 backend。
+
+    使用 APScheduler ``reschedule_job()`` 原地替换 job 的 trigger，
+    新 cron 立即生效，旧的下一次执行计划被丢弃。
+
+    扁平 JSON 响应（与 scheduler-status / scheduled-trigger 一致）。
+    """
+    logger.info("[task_discovery] reschedule received: cron='%s' tz='%s'", cron, timezone)
+    try:
+        ok = scheduler.reschedule(cron, timezone=timezone)
+    except Exception as exc:
+        logger.error(
+            "[task_discovery] reschedule failed: %s", exc, exc_info=True,
+        )
+        return {"success": False, "message": str(exc)}
+    if not ok:
+        return {"success": False, "message": "scheduler not running"}
+
+    status = scheduler.get_status()
+    jobs = status.get("jobs") or []
+    next_run = jobs[0].get("next_run_time") if jobs else None
+    return {
+        "success": True,
+        "cron": cron,
+        "timezone": status.get("timezone"),
+        "next_run_time": next_run,
+    }
+
+
+@router.post("/discovery/dingtalk-config")
+async def set_dingtalk_config(
+    body: dict = Body(...),
+) -> dict[str, Any]:
+    """运行时注入钉钉凭证 + 前端 URL — 无需重启 backend。
+
+    测试/e2e 可通过本端点注入 AK/Robot/Template 和可选的 frontend_url，
+    随后的 cron fire 即用这些凭证投递卡片，card_data 内的 session_url 也用注入的 frontend_url。
+    凭证仅存于进程内存，重启后失效。
+    """
+    from agentclaw.community.plugins.community.notify_sender import (
+        DingTalkCredentialHolder,
+    )
+
+    ak_id = (body.get("ak_id") or "").strip()
+    ak_secret = (body.get("ak_secret") or "").strip()
+    robot_code = (body.get("robot_code") or "").strip()
+    card_template_id = (body.get("card_template_id") or "").strip()
+    frontend_url = (body.get("frontend_url") or "").strip()
+
+    if not all([ak_id, ak_secret, robot_code, card_template_id]):
+        return {"success": False, "message": "钉钉字段必填: ak_id, ak_secret, robot_code, card_template_id"}
+
+    DingTalkCredentialHolder.set(ak_id, ak_secret, robot_code, card_template_id)
+    injected = ["dingtalk credentials"]
+
+    if frontend_url:
+        from agentclaw.community.core.task.task_discovery.session_initiator import (
+            FrontendUrlHolder,
+        )
+        FrontendUrlHolder.set(frontend_url)
+        injected.append(f"frontend_url={frontend_url}")
+
+    logger.info(
+        "[task_discovery] injected via API: %s (robot=%s, template=%s)",
+        ", ".join(injected),
+        robot_code,
+        card_template_id,
+    )
+    return {"success": True, "message": "; ".join(injected) + " injected"}
 
 
 # ===== task_loop inbound PUSH callback router(单 bot workflow / bcn 协作群)=====

--- a/src/backend/src/agentclaw/community/core/repository/README.md
+++ b/src/backend/src/agentclaw/community/core/repository/README.md
@@ -140,6 +140,7 @@ provides:
   - TaskNodeRunInfoRepositoryProtocol
   - TaskNodeRelationRepositoryProtocol
   - TaskCallbackRepositoryProtocol
+  - TaskDiscoveryLockRepositoryProtocol
   # publishing
   - BotPublishRepositoryProtocol
   - PublishOperationRepository    # an ABC, not a Protocol — same role, same surface
@@ -208,6 +209,7 @@ provides:
   - TaskNodeRunInfoRepository
   - TaskNodeRelationRepository
   - TaskCallbackRepository
+  - TaskDiscoveryLockRepository
 consumes:
   - DatabasePlugin                # the per-profile session seam, injected into every implementation
   - get_current_env               # environment scoping (utils.env_utils)

--- a/src/backend/src/agentclaw/community/core/repository/implementations/task/discovery_lock.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/task/discovery_lock.py
@@ -1,0 +1,202 @@
+"""任务发现 per-bot 分布式锁 Repository (prod OceanBase + local SQLite).
+
+One ORM implementation behind the ``TaskDiscoveryLockRepositoryProtocol``.
+The only per-environment difference is the injected :class:`DatabasePlugin`:
+``orm_session()`` yields a SQLAlchemy ``Session`` in both runtimes, so this
+single body runs unchanged on OceanBase (prod) and SQLite (local).
+
+Behavior:
+- The UNIQUE constraint on (env, bot_id, discovery_date) *is* the lock:
+  ``acquire`` inserts a row and lets the DB arbitrate concurrent callers —
+  exactly one INSERT wins, the rest hit ``IntegrityError`` and are treated
+  as "lock held".
+- ``release`` hard-deletes the row (no soft delete).
+- Staleness (``get_if_stale``) is judged on the DB clock only: both the row's
+  ``gmt_create`` and "now" are sourced from the database, so app/DB clock skew
+  cannot mis-judge the TTL.
+
+Structurally identical to ``BotRestartLockRepository``, differing only in the
+lock key dimensions (``discovery_date`` replaces ``entity_id``, ``holder``
+replaces ``holder_user_id``).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from injector import inject
+from sqlalchemy import DateTime, func, select, type_coerce
+from sqlalchemy.exc import IntegrityError
+
+from agentclaw.community.core.repository.protocols.task import (
+    TaskDiscoveryLockRepositoryProtocol,
+)
+from agentclaw.community.core.task.task_discovery.lock_models import (
+    TaskDiscoveryLockModel,
+    TaskDiscoveryLockRecord,
+)
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.database import DatabasePlugin
+
+
+logger = get_logger()
+
+
+def _as_naive(dt: datetime) -> datetime:
+    """Drop tzinfo so two DB-clock timestamps can always be subtracted.
+
+    ``gmt_create`` and ``func.now()`` share the same DB clock/timezone, but a
+    driver may return one tz-aware and the other tz-naive. Stripping tzinfo
+    from both is safe (identical tz semantics) and avoids a TypeError.
+    """
+    return dt.replace(tzinfo=None) if dt.tzinfo is not None else dt
+
+
+class TaskDiscoveryLockRepository(TaskDiscoveryLockRepositoryProtocol):
+    """任务发现 per-bot 分布式锁 Repository 实现。"""
+
+    @inject
+    def __init__(self, db: DatabasePlugin) -> None:
+        """Initialize with DatabasePlugin instance.
+
+        Args:
+            db: DatabasePlugin providing orm_session() context manager.
+        """
+        self._db = db
+        self._Lock = TaskDiscoveryLockModel
+
+    # ========================================================================
+    # Acquire / Release
+    # ========================================================================
+
+    def acquire(
+        self,
+        env: str,
+        bot_id: str,
+        discovery_date: str,
+        holder: str,
+    ) -> Optional[TaskDiscoveryLockRecord]:
+        """获取发现锁（INSERT 一行，UNIQUE 冲突即返回 None）。"""
+        with self._db.orm_session() as db:
+            row = self._Lock(
+                env=env,
+                bot_id=bot_id,
+                discovery_date=discovery_date,
+                holder=holder,
+                lock_token=uuid.uuid4().hex,
+            )
+            db.add(row)
+            try:
+                db.flush()
+                db.refresh(row)
+                logger.info(
+                    "[discovery_lock.acquire] acquired, id=%s, env=%s, bot_id=%s, "
+                    "date=%s, holder=%s, token=%s",
+                    row.id, env, bot_id, discovery_date, holder, row.lock_token,
+                )
+                return row.to_record()
+            except IntegrityError:
+                # 并发冲突：其他机器已持有该 bot 当日的发现锁。
+                # NOTE: deliberately swallowed (return None) rather than
+                # re-raised — the Protocol's acquire() contract is
+                # Optional[record], so "lock held" is a None return, not an
+                # exception the caller must catch. The rollback resets the
+                # failed transaction; orm_session()'s subsequent commit on
+                # clean exit is then a harmless no-op.
+                db.rollback()
+                logger.info(
+                    "[discovery_lock.acquire] already held, env=%s, bot_id=%s, "
+                    "date=%s",
+                    env, bot_id, discovery_date,
+                )
+                return None
+
+    def release(
+        self,
+        env: str,
+        bot_id: str,
+        discovery_date: str,
+        lock_token: str,
+    ) -> bool:
+        """释放发现锁（比对令牌后硬删除）。
+
+        仅当行的 ``lock_token`` 与传入令牌一致时才删除，避免误删他人在本锁
+        被回收后重新获取的新锁（stale-reaper 与超时后异步释放两种竞态）。
+        """
+        with self._db.orm_session() as db:
+            result = (
+                db.query(self._Lock)
+                .filter(
+                    self._Lock.env == env,
+                    self._Lock.bot_id == bot_id,
+                    self._Lock.discovery_date == discovery_date,
+                    self._Lock.lock_token == lock_token,
+                )
+                .delete(synchronize_session=False)
+            )
+            if result > 0:
+                logger.info(
+                    "[discovery_lock.release] released, env=%s, bot_id=%s, "
+                    "date=%s, token=%s",
+                    env, bot_id, discovery_date, lock_token,
+                )
+            else:
+                logger.info(
+                    "[discovery_lock.release] no-op (token mismatch or already "
+                    "gone), env=%s, bot_id=%s, date=%s, token=%s",
+                    env, bot_id, discovery_date, lock_token,
+                )
+            return result > 0
+
+    # ========================================================================
+    # Query
+    # ========================================================================
+
+    def get_if_stale(
+        self,
+        env: str,
+        bot_id: str,
+        discovery_date: str,
+        ttl_seconds: int,
+    ) -> Optional[TaskDiscoveryLockRecord]:
+        """仅当锁存在且已超过 ttl_seconds 时返回记录，否则返回 None。
+
+        过期判定完全基于数据库时钟：``gmt_create`` 与 "now" 都取自 DB，
+        因此不受应用与数据库之间的时钟漂移影响。
+        """
+        with self._db.orm_session() as db:
+            row = (
+                db.query(self._Lock)
+                .filter(
+                    self._Lock.env == env,
+                    self._Lock.bot_id == bot_id,
+                    self._Lock.discovery_date == discovery_date,
+                )
+                .first()
+            )
+            if row is None or row.gmt_create is None:
+                return None
+
+            # type_coerce ensures both SQLite and MySQL/OceanBase yield a
+            # Python datetime for the DB-side "now".
+            db_now = db.execute(
+                select(type_coerce(func.now(), DateTime))
+            ).scalar()
+            if db_now is None:
+                return None
+
+            # Both timestamps come from the DB clock with identical timezone
+            # semantics, but some drivers return TIMESTAMP columns tz-aware
+            # while ``func.now()`` coerces tz-naive. Normalize both to naive so
+            # the subtraction can't raise "can't subtract offset-naive and
+            # offset-aware datetimes" on any driver.
+            elapsed = (_as_naive(db_now) - _as_naive(row.gmt_create)).total_seconds()
+            if elapsed >= ttl_seconds:
+                logger.info(
+                    "[discovery_lock.get_if_stale] stale lock, env=%s, bot_id=%s, "
+                    "date=%s, elapsed=%.1fs, ttl=%ss",
+                    env, bot_id, discovery_date, elapsed, ttl_seconds,
+                )
+                return row.to_record()
+            return None

--- a/src/backend/src/agentclaw/community/core/repository/protocols/task.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/task.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
         TaskNodeRunInfoRecord,
         TaskNodeRunInfoUpdate,
     )
+    from agentclaw.community.core.task.task_discovery.lock_models import (
+        TaskDiscoveryLockRecord,
+    )
 
 
 @runtime_checkable
@@ -364,4 +367,71 @@ class TaskActionLogRepositoryProtocol(Protocol):
         offset: int = 0,
     ) -> list["TaskActionLogRecord"]:
         """Return bounded diagnostic action history."""
+        ...
+
+
+@runtime_checkable
+class TaskDiscoveryLockRepositoryProtocol(Protocol):
+    """Protocol for the task-discovery per-bot distributed lock repository.
+
+    The lock is keyed on ``(env, bot_id, discovery_date)`` and backed by a
+    UNIQUE constraint on ``ac_task_discovery_lock`` — that constraint is the
+    guard. A single unified ORM body
+    (``TaskDiscoveryLockRepository``) runs on both prod OceanBase and local
+    SQLite via the injected DatabasePlugin.
+
+    This is structurally identical to ``BotRestartLockRepositoryProtocol``,
+    differing only in the lock key dimensions: ``discovery_date`` replaces
+    ``entity_id``, and ``holder`` (hostname) replaces ``holder_user_id``.
+    """
+
+    @abstractmethod
+    def acquire(
+        self,
+        env: str,
+        bot_id: str,
+        discovery_date: str,
+        holder: str,
+    ) -> Optional["TaskDiscoveryLockRecord"]:
+        """Acquire the lock by inserting a row.
+
+        Stamps a random ``lock_token`` (fencing token) on the row and returns
+        the inserted record (carrying that token) on success, or ``None`` if a
+        row for ``(env, bot_id, discovery_date)`` already exists (UNIQUE
+        violation). The caller must keep the token and pass it to ``release``
+        so a delete only ever removes the exact row it acquired.
+        """
+        ...
+
+    @abstractmethod
+    def get_if_stale(
+        self,
+        env: str,
+        bot_id: str,
+        discovery_date: str,
+        ttl_seconds: int,
+    ) -> Optional["TaskDiscoveryLockRecord"]:
+        """Return the lock row only if it is older than ``ttl_seconds``.
+
+        Staleness is evaluated DB-side (comparing ``gmt_create`` against the
+        database clock) to avoid app/DB clock-skew. Returns ``None`` when no
+        row exists or the existing row is still fresh.
+        """
+        ...
+
+    @abstractmethod
+    def release(
+        self,
+        env: str,
+        bot_id: str,
+        discovery_date: str,
+        lock_token: str,
+    ) -> bool:
+        """Release the lock by hard-deleting the row — only if it's still ours.
+
+        Compare-and-delete: ``DELETE WHERE (env, bot_id, discovery_date)
+        matches AND lock_token = :lock_token``. The token guard prevents
+        deleting a row that was reaped and re-acquired by another instance
+        after this holder lost interest.
+        """
         ...

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/discovery_service.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/discovery_service.py
@@ -25,16 +25,24 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
+from agentclaw.community.core.repository.protocols.task import (
+    TaskDiscoveryLockRepositoryProtocol,
+)
+from agentclaw.community.core.task.task_discovery.lock_models import (
+    TaskDiscoveryLockRecord,
+)
 from agentclaw.community.core.task.task_discovery.models import (
     DiscoveredTask,
     DiscoverySession,
 )
 from agentclaw.community.core.task.task_discovery.protocols import (
     BotServiceProtocol,
+    WorkOrderServiceProtocol,
 )
 from agentclaw.community.core.task.task_discovery.session_initiator import (
     SessionInitiator,
@@ -43,13 +51,22 @@ from agentclaw.community.core.task.task_discovery.task_reader import (
     TaskReader,
     SqliteTaskReader,
 )
+from agentclaw.community.core.work_orders.models import (
+    NotificationCategory,
+    WorkOrderEventType,
+)
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.notify_sender import (
     NotifyMessage,
     NotifySenderPlugin,
 )
+from agentclaw.community.utils.env_utils import get_current_env
 
 logger = get_logger()
+
+#: discover() 单次调用（session 创建 + WebSocket + 通知）的预估耗时上限。
+#: per-bot 锁 TTL 应略大于该值，使崩机时 stale reaper 能在当前 cron 周期内恢复。
+DISCOVERY_LOCK_TTL_SECONDS = 600
 
 
 @dataclass
@@ -80,14 +97,61 @@ class DiscoveryService:
         session_initiator: SessionInitiator,
         notify_sender: NotifySenderPlugin,
         bot_service: BotServiceProtocol | None = None,
+        discovery_lock_repo: TaskDiscoveryLockRepositoryProtocol | None = None,
+        work_order_service: WorkOrderServiceProtocol | None = None,
     ):
         self._reader = reader
         self._session_initiator = session_initiator
         self._notify_sender = notify_sender
         self._bot_service = bot_service
+        self._lock_repo = discovery_lock_repo
+        #: 工单通知投递（直接领域调用 WorkOrderService）。注入时在发现流程里额外
+        #: 把"待确认任务"写成一条 NOTICE 工单事件，落 ac_work_order_notification。
+        self._work_order_service = work_order_service
 
         #: 最近的发现结果 (task_id → DiscoveryResult)，供外部查询
         self._discoveries: dict[str, DiscoveryResult] = {}
+
+    def _try_acquire_lock(
+        self, bot_id: str
+    ) -> Optional[TaskDiscoveryLockRecord]:
+        """尝试获取该 bot 当日的发现锁（与 _try_acquire_restart_lock 逻辑同构）。
+
+        多机器 cron 同时 fire 时，所有机器都进入 ``discover_all_bots()``，
+        在 per-bot 循环里竞争 ``acquire()``：
+        恰好一台机器的 INSERT 成功 -> 调用 discover()
+        其余机器拿到 None -> 跳过该 bot
+
+        1. ``INSERT`` — 成功即持锁
+        2. 冲突 -> 检查 stale -> stale 则 reap 并重新 INSERT
+        3. 仍冲突 -> None（其他机器正在处理，或当日锁仍有效）
+
+        Lock key: ``(env, bot_id, discovery_date)`` 每日唯一。
+        Holder: ``HOSTNAME`` 环境变量或 ``socket.gethostname()``。
+        TTL: ``DISCOVERY_LOCK_TTL_SECONDS`` (600s) — 崩机后 stale reaper 恢复。
+        """
+        env = get_current_env()
+        today = datetime.now().strftime("%Y-%m-%d")
+        holder = os.environ.get("HOSTNAME", socket.gethostname())
+
+        rec = self._lock_repo.acquire(env, bot_id, today, holder)
+        if rec is not None:
+            return rec
+
+        # acquire/check/acquire 不是事务性的，分层处理 stale 和已释放的锁。
+        stale = self._lock_repo.get_if_stale(
+            env, bot_id, today, DISCOVERY_LOCK_TTL_SECONDS
+        )
+        if stale is not None:
+            logger.warning(
+                "[task_discovery] Reaping stale discovery lock: env=%s, bot=%s, "
+                "date=%s, created=%s",
+                env, bot_id, today, stale.gmt_create,
+            )
+            # compare-and-delete：token 不匹配说明已被其他机器 reap+reacquire
+            self._lock_repo.release(env, bot_id, today, stale.lock_token)
+
+        return self._lock_repo.acquire(env, bot_id, today, holder)
 
     async def discover_all_bots(self) -> list[DiscoveryResult]:
         """遍历 db 中有待确认任务的 bot，为每个 bot 执行发现流程。
@@ -149,6 +213,21 @@ class DiscoveryService:
 
         all_results: list[DiscoveryResult] = []
         for bot_id, owner_id in bots_to_discover:
+            # ---- Per-bot 分布式锁（多机器竞争占有）----
+            # 多机器 cron 同时 fire，各自逐 bot 遍历。每个 bot 的 INSERT
+            # 由 DB UNIQUE 约束原子仲裁：恰好一台机器成功 -> discover()
+            # 其余 None -> 跳过该 bot。discover 完成后 finally 释放锁。
+            lock: Optional[TaskDiscoveryLockRecord] = None
+            if self._lock_repo is not None:
+                lock = self._try_acquire_lock(bot_id)
+                if lock is None:
+                    logger.info(
+                        "[task_discovery] bot=%s already being discovered by "
+                        "another instance, skipping",
+                        bot_id,
+                    )
+                    continue
+
             try:
                 results = await self.discover(
                     bot_id=bot_id,
@@ -161,6 +240,14 @@ class DiscoveryService:
                     "[task_discovery] bot=%s failed: %s",
                     bot_id, exc, exc_info=True,
                 )
+            finally:
+                if lock is not None:
+                    self._lock_repo.release(
+                        lock.env,
+                        lock.bot_id,
+                        lock.discovery_date,
+                        lock.lock_token,
+                    )
 
         logger.info(
             "[task_discovery] discovery complete: %d task(s) discovered across %d bot(s)",
@@ -233,14 +320,20 @@ class DiscoveryService:
                 model=model,
             )
 
-            notification_sent = self._send_notification(
-                task, owner_id, session.session_url, len(all_tasks),
+            # 通知走两个通道：外发卡片（NotifySender）+ 工单通知（WorkOrderService）。
+            card_sent = self._send_notification(
+                task, owner_id, session, len(all_tasks),
             )
+            work_order_sent = self._send_work_order_event(task, owner_id, session)
+            notification_sent = card_sent or work_order_sent
 
             logger.info(
-                "[task_discovery] task %s → session %s (notified=%s)",
+                "[task_discovery] task %s → session %s "
+                "(card_sent=%s, work_order_sent=%s, notified=%s)",
                 task.task_id,
                 session.session_id,
+                card_sent,
+                work_order_sent,
                 notification_sent,
             )
 
@@ -260,7 +353,7 @@ class DiscoveryService:
         self,
         task: DiscoveredTask,
         user_id: str,
-        session_url: str,
+        session: DiscoverySession,
         task_count: int,
     ) -> bool:
         """通过 NotifySenderPlugin 投递通知，返回是否发送成功。
@@ -271,6 +364,7 @@ class DiscoveryService:
         deep_link 指向 session，用户点击后进入 session 确认。
         extra 携带通用交互卡片参数（不绑定具体服务商）。
         """
+        session_url = session.session_url
         message = NotifyMessage(
             title="发现待确认任务",
             body=task.to_notification_body(task_count),
@@ -282,7 +376,9 @@ class DiscoveryService:
                     "TASK_DISCOVERY_CARD_TEMPLATE_ID", ""
                 ),
                 "card_biz_id": f"discover_things_{task.task_id}",
-                "card_data": json.dumps(task.to_card_data()),
+                "card_data": json.dumps(
+                    {"click": "", **task.to_card_data(), "session_url": session_url}
+                ),
                 "session_url": session_url,
             },
         )
@@ -298,6 +394,64 @@ class DiscoveryService:
             logger.warning(
                 "[task_discovery] notification send returned None for task %s",
                 task.task_id,
+            )
+            return False
+
+    def _send_work_order_event(
+        self,
+        task: DiscoveredTask,
+        user_id: str,
+        session: DiscoverySession,
+    ) -> bool:
+        """通过 WorkOrderService 投递一条 NOTICE 工单事件，落工单通知收件箱。
+
+        与 ``_send_notification``（外发卡片）并存：把"发现到的待确认任务"作为一条
+        NOTICE 通知写入 ``ac_work_order_notification``，供工单/通知中心展示。
+        ``work_order_service`` 未注入时直接返回 False（no-op，保持向后兼容）。
+        失败不抛异常 — 仅记 warning 并返回 False，不影响发现主流程。
+        """
+        svc = self._work_order_service
+        if svc is None:
+            return False
+        try:
+            result = svc.create_work_order_event(
+                event_category=NotificationCategory.NOTICE,
+                biz_type="task_discovery",
+                biz_id=task.task_id,
+                event_type=WorkOrderEventType.TASK_DISCOVERED.value,
+                # NOTICE 约束：applicant 必须为 None，否则 400201
+                applicant_user_id=None,
+                approver_user_ids=[],
+                recipient_user_ids=[user_id],
+                title=task.title,
+                content={
+                    **task.to_card_data(),
+                    "session_url": session.session_url,
+                    "task_id": task.task_id,
+                },
+                apply_reason=None,
+                biz_data={
+                    "task_id": task.task_id,
+                    "bot_id": task.bot_id,
+                    "owner_id": task.owner_id,
+                    "session_id": session.session_id,
+                    "session_url": session.session_url,
+                },
+                actor_id=user_id,
+            )
+            logger.info(
+                "[task_discovery] work-order event created for task %s "
+                "(notification_ids=%s, work_order_id=%s)",
+                task.task_id,
+                getattr(result, "notification_ids", None),
+                getattr(result, "work_order_id", None),
+            )
+            return True
+        except Exception as exc:
+            logger.warning(
+                "[task_discovery] work-order event failed for task %s: %s",
+                task.task_id,
+                exc,
             )
             return False
 

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/lock_models.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/lock_models.py
@@ -1,0 +1,107 @@
+"""任务发现 per-bot 分布式锁的领域记录与 ORM 模型。
+
+锁键为 ``(env, bot_id, discovery_date)``，由 UNIQUE 约束保证分布式互斥：
+INSERT 成功即持锁，冲突即被去重。与 ``BotRestartLockModel`` 同构，差异仅在
+锁键维度（discovery_date 替代 entity_id）。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Column, DateTime, Integer, String, UniqueConstraint
+from sqlalchemy.sql import func
+
+from agentclaw.community.core.base import Base
+from agentclaw.community.utils.env_utils import get_current_env
+
+AutoIncrementBigInteger = Integer  # SQLite-friendly; matches task/repository/models.py
+
+
+@dataclass
+class TaskDiscoveryLockRecord:
+    """任务发现锁业务记录。
+
+    对应 ``ac_task_discovery_lock`` 表。锁键为 (env, bot_id, discovery_date)，
+    由 UNIQUE 约束保证分布式互斥：INSERT 成功即持锁，冲突即被去重。
+
+    Attributes:
+        id:              主键 ID。
+        env:             环境标识。
+        bot_id:          Bot ID。
+        discovery_date:  发现日期 (YYYY-MM-DD)。
+        holder:          持锁者标识 (HOSTNAME 或 socket.gethostname)。
+        lock_token:      持锁令牌（fencing token，释放时比对）。
+        gmt_create:      创建时间。
+        gmt_modified:    修改时间。
+    """
+
+    id: Optional[int] = None
+    env: str = ""
+    bot_id: str = ""
+    discovery_date: str = ""
+    holder: str = ""
+    lock_token: str = ""
+    gmt_create: Optional[datetime] = None
+    gmt_modified: Optional[datetime] = None
+
+
+class TaskDiscoveryLockModel(Base):
+    """SQLAlchemy ORM model for ``ac_task_discovery_lock`` table."""
+
+    __tablename__ = "ac_task_discovery_lock"
+
+    id = Column(
+        AutoIncrementBigInteger,
+        primary_key=True,
+        autoincrement=True,
+        nullable=False,
+    )
+    env = Column(
+        String(20),
+        nullable=False,
+        default=get_current_env,
+        comment="环境标识: prod/pre/dev",
+    )
+    bot_id = Column(String(256), nullable=False, comment="Bot ID")
+    discovery_date = Column(
+        String(10), nullable=False, comment="发现日期 YYYY-MM-DD"
+    )
+    holder = Column(
+        String(256), nullable=False, comment="持锁者 (hostname)"
+    )
+    lock_token = Column(
+        String(256), nullable=False, comment="持锁令牌（fencing token，释放时比对）"
+    )
+    gmt_create = Column(
+        DateTime, default=func.now(), nullable=False, comment="创建时间"
+    )
+    gmt_modified = Column(
+        DateTime,
+        default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+        comment="修改时间",
+    )
+
+    __table_args__ = (
+        # UNIQUE 约束即为锁本体：同一 (env, bot_id, discovery_date) 只能存在一行。
+        UniqueConstraint(
+            "env", "bot_id", "discovery_date",
+            name="uk_env_bot_id_discovery_date",
+        ),
+    )
+
+    def to_record(self) -> TaskDiscoveryLockRecord:
+        """Convert to dataclass record."""
+        return TaskDiscoveryLockRecord(
+            id=self.id,
+            env=self.env,
+            bot_id=self.bot_id,
+            discovery_date=self.discovery_date,
+            holder=self.holder,
+            lock_token=self.lock_token,
+            gmt_create=self.gmt_create,
+            gmt_modified=self.gmt_modified,
+        )

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/models.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/models.py
@@ -19,11 +19,10 @@ class DiscoveredTask:
         bot_id:             所属 bot ID。
         owner_id:           bot 所有者 ID。
         dt:                 日期 YYYY-MM-DD。
-        project_name:       项目名称（同时用作 engine session title）。
-        description:        项目简介。
-        business_scenario:  业务场景描述。
+        title:              任务标题（对齐 TaskSpec.metadata.title；同时用作 engine session title）。
+        instruction:        核心执行指令（对齐 TaskSpec.metadata.instruction）。
+        background:         背景信息（对齐 TaskSpec.context.background）。
         discovery_basis:    挖掘依据 — 行为节点演进链路，说明为何发现此任务。
-        work_item_url:      关联的需求/工作项 URL（执行时传给 engine）。
         priority:           优先级 (high / medium / low)。
         discovered_at:      被发现的时间戳。
         status:             当前状态：
@@ -31,20 +30,25 @@ class DiscoveredTask:
             - ``confirmed``           — 用户已确认，待执行
             - ``executing``           — 已提交 engine 执行
             - ``ignored``             — 用户忽略
+        objective:          任务目标（对应 TaskSpec.goal.objective）；缺省回退 title。
+        acceptances:        验收标准列表（每条 ``{"id","description"}``，对应
+                            TaskSpec.goal.acceptances）；留位/空时由确认阶段 bot 澄清补全。
     """
 
     task_id: str
     bot_id: str
     owner_id: str
     dt: str
-    project_name: str
-    description: str
-    business_scenario: str
+    title: str
+    instruction: str
+    background: str
     discovery_basis: str
-    work_item_url: Optional[str] = None
     priority: str = "medium"
     discovered_at: Optional[str] = None
     status: str = "pending_confirmation"
+    # 执行层衔接字段（不落 discovered_tasks.db；确认后用于 to_task_info_request）
+    objective: str = ""
+    acceptances: list[dict] = field(default_factory=list)
 
     @property
     def needs_confirmation(self) -> bool:
@@ -58,14 +62,15 @@ class DiscoveredTask:
             "bot_id": self.bot_id,
             "owner_id": self.owner_id,
             "dt": self.dt,
-            "project_name": self.project_name,
-            "description": self.description,
-            "business_scenario": self.business_scenario,
+            "project_name": self.title,
+            "description": self.instruction,
+            "business_scenario": self.background,
             "discovery_basis": self.discovery_basis,
-            "work_item_url": self.work_item_url,
             "priority": self.priority,
             "discovered_at": self.discovered_at,
             "status": self.status,
+            "objective": self.objective,
+            "acceptances": list(self.acceptances),
             "source": "task_discovery",
         }
 
@@ -74,11 +79,11 @@ class DiscoveredTask:
         lines = [
             "🔔 发现待执行任务",
             "",
-            f"项目名称：{self.project_name}",
+            f"项目名称：{self.title}",
             "",
-            f"项目简介：{self.description}",
+            f"项目简介：{self.instruction}",
             "",
-            f"业务场景：{self.business_scenario}",
+            f"业务场景：{self.background}",
             "",
             f"挖掘依据：{self.discovery_basis}",
             "",
@@ -90,26 +95,36 @@ class DiscoveredTask:
         return "\n".join(lines)
 
     def to_discovery_prompt(self) -> str:
-        """生成给 bot 的发现提示消息。
+        """生成给 bot 的发现提示消息（单任务版，按 4 维度组织）。
 
-        此消息通过 WebSocket ``chat.send`` 发送到 session，
-        bot 收到后主动呈现发现任务并询问用户确认。
+        维度对齐执行层 TaskSpec：
+          目标 ← objective（缺省回退 title）
+          预期交付物 ← instruction
+          验收标准 ← acceptances（为空则提示补充）
+          约束 ← background
         """
-        return (
-            f"/task 我为您发现了以下可能有意义的事情：\n\n"
-            f"【{self.project_name}】\n"
-            f"简介：{self.description}\n"
-            f"业务场景：{self.business_scenario}\n"
-            f"发现依据：{self.discovery_basis}\n\n"
-            f"是否确认执行？请在下方回复确认或拒绝。"
-        )
+        lines = [
+            f"/task 我为您发现了以下可能有意义的事情：\n",
+            f"【{self.title}】",
+            f"目标：{self.objective or self.title}",
+            f"预期交付物：{self.instruction}",
+        ]
+        if self.acceptances:
+            lines.append("验收标准：")
+            for a in self.acceptances:
+                lines.append(f"  - [{a.get('id', '')}] {a.get('description', '')}")
+        else:
+            lines.append("验收标准：（确认时可由你补充）")
+        lines.append(f"约束：{self.background}")
+        lines.append("\n是否确认执行？请在下方回复确认或拒绝。")
+        return "\n".join(lines)
 
     def to_notification_body(self, task_count: int) -> str:
         """生成通知消息体 — 包含发现摘要和确认引导。"""
         return (
             f"我为您发现了 {task_count} 件可能有意义的事情，"
             f"是否确认执行？\n\n"
-            f"1. {self.project_name}：{self.description[:50]}...\n"
+            f"1. {self.title}：{self.instruction[:50]}...\n"
             f"\n请点击进入会话查看详情并确认。"
         )
 
@@ -117,8 +132,8 @@ class DiscoveredTask:
         """生成交互卡片数据（通用抽象，不绑定服务商）。"""
         return {
             "card_name": "为你发现以下任务",
-            "workitem_name": self.project_name,
-            "workitem_bg": self.description,
+            "workitem_name": self.title,
+            "workitem_bg": self.instruction,
         }
 
 

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/protocols.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/protocols.py
@@ -7,6 +7,7 @@
 本模块依赖：
   - BotService — list_bots() 遍历所有用户 bot，get_bot() 校验 ownership
   - CronRelayService — forward_request() 创建 session，list_all_crons() 查 cron
+  - WorkOrderService — create_work_order_event() 投递工单通知
 
 参考：core/bot_dormant/protocols.py
 """
@@ -38,4 +39,19 @@ class CronRelayServiceProtocol(Protocol):
     async def list_all_crons(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
-__all__ = ["BotServiceProtocol", "CronRelayServiceProtocol"]
+@runtime_checkable
+class WorkOrderServiceProtocol(Protocol):
+    """工单服务接口 — 供 task_discovery 投递 NOTICE 工单通知事件。
+
+    DI 桥接 api/ 层的 WorkOrderServiceProtocol 到本协议（structurally
+    satisfied），避免 core/ 直接 import api/。
+    """
+
+    def create_work_order_event(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+__all__ = [
+    "BotServiceProtocol",
+    "CronRelayServiceProtocol",
+    "WorkOrderServiceProtocol",
+]

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/scheduler.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/scheduler.py
@@ -142,6 +142,26 @@ class TaskDiscoveryScheduler(LifecycleBase):
                 bot_id, owner_id,
             )
 
+    def reschedule(self, cron_expr: str, *, timezone: str | None = None) -> bool:
+        """运行时修改 cron 触发时间 — 无需重启 backend。
+
+        使用 APScheduler ``reschedule_job()`` 原地替换 job 的 trigger，
+        新 cron 立即生效，旧的下一次执行计划被丢弃。
+
+        Returns:
+            True 如果 reschedule 成功；False 如果调度器未运行。
+        """
+        if self._scheduler is None or not self._scheduler.running:
+            logger.warning("[task_discovery] reschedule called but scheduler not running")
+            return False
+
+        tz = timezone or os.environ.get("TASK_DISCOVERY_TIMEZONE", _DEFAULT_TIMEZONE)
+        trigger = CronTrigger.from_crontab(cron_expr, timezone=tz)
+        self._scheduler.reschedule_job("task_discovery_daily", trigger=trigger)
+        os.environ["TASK_DISCOVERY_CRON"] = cron_expr
+        logger.info("[task_discovery] reschedule done — cron='%s' tz='%s'", cron_expr, tz)
+        return True
+
     def get_status(self) -> dict:
         """返回 APScheduler 当前调度状态 — 供 HTTP 端点查询。
 

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/session_creator.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/session_creator.py
@@ -58,26 +58,18 @@ class HttpSessionCreator:
     def __init__(
         self,
         *,
-        backend_url: str | None = None,
-        frontend_url: str | None = None,
+        backend_url: str = "http://localhost:8888",
+        frontend_url: str = "http://localhost:8000",
     ):
         """初始化。
 
         Args:
             backend_url: Backend API 地址（用于查 bot connection）。
-                若为 ``None`` 则从环境变量 ``BACKEND_URL`` 读取，
-                默认 ``http://localhost:8888``。
             frontend_url: 前端 workbench 地址（用于构建 session_url）。
-                若为 ``None`` 则从环境变量 ``FRONTEND_URL`` 读取，
-                默认 ``http://localhost:8000``。
+                运行时可通过 FrontendUrlHolder (API 注入) 覆盖。
         """
-        self._backend_url = backend_url or os.environ.get(
-            "BACKEND_URL", _DEFAULT_BACKEND_URL,
-        )
-        self._frontend_url = frontend_url or os.environ.get(
-            "FRONTEND_URL",
-            f"http://localhost:{_DEFAULT_FRONTEND_PORT}",
-        )
+        self._backend_url = backend_url
+        self._frontend_url = frontend_url
 
     async def _resolve_engine_target(
         self, bot_id: str, owner_id: str, user_id: str,
@@ -153,7 +145,7 @@ class HttpSessionCreator:
         target = await self._resolve_engine_target(bot_id, owner_id, user_id)
 
         body: dict[str, Any] = {
-            "title": task.project_name,
+            "title": task.title,
             "user_id": user_id,
             "agent_id": agent_id,
             "extInfo": task.to_session_ext_info(),
@@ -199,13 +191,20 @@ class HttpSessionCreator:
     def _build_session_url(self, session_id: str, agent_id: str) -> str:
         """构建用户可访问的前端 workbench session URL。
 
-        格式: ``{frontend_url}/bcn/chat/session?bot_uuid={agent_id}&id={agent_id}&session={session_id}``
+        格式: ``{frontend_url}/assistant?botId={bot_id}&sessionId={session_key}``
+        其中 session_key 为 ``agent:main:{raw_session_id}`` URL-encoded。
+
+        动态解析 frontend URL — 支持运行时 API 注入（FrontendUrlHolder）。
         """
-        base = self._frontend_url.rstrip("/")
-        return (
-            f"{base}/bcn/chat/session"
-            f"?bot_uuid={agent_id}&id={agent_id}&session={session_id}"
+        from urllib.parse import quote
+
+        from agentclaw.community.core.task.task_discovery.session_initiator import (
+            FrontendUrlHolder,
         )
+        base = (FrontendUrlHolder.get() or self._frontend_url).rstrip("/")
+        full_session_key = f"agent:main:{session_id}"
+        encoded_sid = quote(full_session_key, safe="")
+        return f"{base}/assistant?botId={agent_id}&sessionId={encoded_sid}"
 
 
 __all__ = ["SessionCreator", "HttpSessionCreator"]

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/session_initiator.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/session_initiator.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from typing import Any, Protocol
 
 import httpx
@@ -28,11 +27,23 @@ from agentclaw.community.log import get_logger
 
 logger = get_logger()
 
-#: 默认 backend 地址（用于查 bot connection 解析 engine target）
-_DEFAULT_BACKEND_URL = "http://localhost:8888"
 
-#: 默认前端 workbench 端口
-_DEFAULT_FRONTEND_PORT = "8000"
+class FrontendUrlHolder:
+    """运行时前端 URL holder — 允许通过 API 动态注入，无需重启 backend。
+
+    优先级：holder > 构造注入值 > 默认值。
+    这是一个纯类变量 holder，不读取环境变量 — env 解析在 DI factory 完成。
+    """
+    _url: str = ""
+
+    @classmethod
+    def set(cls, url: str) -> None:
+        cls._url = url.rstrip("/")
+        logger.info("[FrontendUrlHolder] frontend url injected at runtime: %s", cls._url)
+
+    @classmethod
+    def get(cls) -> str:
+        return cls._url
 
 #: WebSocket 协议常量
 _WS_PROTOCOL = 3
@@ -75,17 +86,13 @@ class CronRelaySessionInitiator:
     def __init__(
         self,
         cron_relay: Any,
-        frontend_url: str | None = None,
+        frontend_url: str = "http://localhost:8000",
+        backend_url: str = "http://localhost:8888",
         wait_for_reply: bool = False,
     ):
         self._cron_relay = cron_relay
-        self._frontend_url = frontend_url or os.environ.get(
-            "FRONTEND_URL",
-            f"http://localhost:{_DEFAULT_FRONTEND_PORT}",
-        )
-        self._backend_url = os.environ.get(
-            "BACKEND_URL", _DEFAULT_BACKEND_URL,
-        )
+        self._frontend_url = frontend_url
+        self._backend_url = backend_url
         self._wait_for_reply = wait_for_reply
 
     async def initiate_session(
@@ -108,9 +115,9 @@ class CronRelaySessionInitiator:
         first_task = tasks[0]
         task_count = len(tasks)
         title = (
-            f"[DreamMode] 发现 {task_count} 件可能有意义的事情"
+            f"[DreamMode-任务发现] 发现 {task_count} 件可能有意义的事情"
             if task_count > 1
-            else f"[DreamMode] {first_task.project_name}"
+            else f"[DreamMode-任务发现] {first_task.title}"
         )
 
         # ── Step 1: 创建 session ──────────────────────────────
@@ -347,14 +354,28 @@ class CronRelaySessionInitiator:
     # ── 辅助方法 ──────────────────────────────────────────────
 
     def _build_discovery_prompt(self, tasks: list[DiscoveredTask]) -> str:
-        """构造发现提示消息 — 作为 chat.send 的 message 发送给 bot。"""
+        """构造发现提示消息 — 作为 chat.send 的 message 发送给 bot。
+
+        直接按 4 个维度组织（对齐执行层 TaskSpec 语义）：
+          目标       ← task.objective（缺省回退 title）
+          预期交付物 ← task.instruction
+          验收标准   ← task.acceptances（为空则提示确认时补充）
+          约束       ← task.background
+        """
         lines = ["/task 我为您发现了以下可能有意义的事情，请确认是否执行：\n"]
         for i, task in enumerate(tasks, 1):
-            lines.append(f"{i}. 【{task.project_name}】")
-            lines.append(f"   简介：{task.description}")
-            lines.append(f"   业务场景：{task.business_scenario}")
-            if task.work_item_url:
-                lines.append(f"   关联需求：{task.work_item_url}")
+            lines.append(f"{i}. 【{task.title}】")
+            lines.append(f"   目标：{task.objective or task.title}")
+            lines.append(f"   预期交付物：{task.instruction}")
+            if task.acceptances:
+                lines.append("   验收标准：")
+                for a in task.acceptances:
+                    lines.append(
+                        f"     - [{a.get('id', '')}] {a.get('description', '')}"
+                    )
+            else:
+                lines.append("   验收标准：（确认时可由你补充）")
+            lines.append(f"   约束：{task.background}")
             lines.append("")
         lines.append("请向用户展示以上任务，并询问是否确认执行。")
         return "\n".join(lines)
@@ -363,12 +384,20 @@ class CronRelaySessionInitiator:
         """构建前端 workbench session URL。
 
         前端路由格式: ``/assistant?botId={bot_id}&sessionId={session_id}``
-        sessionId 需 URL encode（如 ``agent:main:main`` 含冒号）。
+        sessionId 需 URL encode（如 ``agent:main:xxx`` 含冒号）。
+
+        engine 返回的 raw session_id 需要加 ``agent:main:`` 前缀构成
+        前端所需的完整 session key，这样 session_url 可直接被钉钉卡片 /
+        通知 / 测试脚本消费，无需外部拼装。
+
+        动态解析 frontend URL — 支持运行时 API 注入（FrontendUrlHolder）。
         """
         from urllib.parse import quote
 
-        base = self._frontend_url.rstrip("/")
-        encoded_sid = quote(session_id, safe="")
+        base = FrontendUrlHolder.get() or self._frontend_url
+        base = base.rstrip("/")
+        full_session_key = f"agent:main:{session_id}"
+        encoded_sid = quote(full_session_key, safe="")
         return f"{base}/assistant?botId={agent_id}&sessionId={encoded_sid}"
 
 

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/task_reader.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/task_reader.py
@@ -24,51 +24,57 @@ CREATE TABLE IF NOT EXISTS discovered_tasks (
     bot_id             TEXT NOT NULL,
     owner_id           TEXT NOT NULL,
     dt                 TEXT NOT NULL,
-    project_name       TEXT NOT NULL,
-    description        TEXT,
-    business_scenario  TEXT,
+    title              TEXT NOT NULL,
+    instruction        TEXT,
+    background         TEXT,
     discovery_basis    TEXT,
-    work_item_url      TEXT,
     priority           TEXT DEFAULT 'medium',
     discovered_at      TEXT,
-    status             TEXT DEFAULT 'pending_confirmation'
+    status             TEXT DEFAULT 'pending_confirmation',
+    objective          TEXT,
+    acceptances        TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_discovered_tasks_bot_owner_dt
     ON discovered_tasks(bot_id, owner_id, dt);
 """
 
-#: 查询全量任务的 SQL
-_SELECT_ALL_SQL = (
-    "SELECT task_id, bot_id, owner_id, dt, project_name, description, "
-    "business_scenario, discovery_basis, work_item_url, priority, "
-    "discovered_at, status FROM discovered_tasks;"
-)
+#: 查询全量任务的 SQL（SELECT *：容纳可能新增的列，_row_to_task 防御性读）
+_SELECT_ALL_SQL = "SELECT * FROM discovered_tasks;"
 
 #: 按 (bot_id, owner_id, dt) 查询待确认任务的 SQL
 _SELECT_PENDING_FOR_BOT_SQL = (
-    "SELECT task_id, bot_id, owner_id, dt, project_name, description, "
-    "business_scenario, discovery_basis, work_item_url, priority, "
-    "discovered_at, status FROM discovered_tasks "
+    "SELECT * FROM discovered_tasks "
     "WHERE bot_id = ? AND owner_id = ? AND dt = ? "
     "AND status = 'pending_confirmation';"
 )
 
 
 def _row_to_task(row: sqlite3.Row) -> DiscoveredTask:
-    """将 sqlite3.Row 映射为 DiscoveredTask。"""
+    """将 sqlite3.Row 映射为 DiscoveredTask。
+
+    ``objective`` / ``acceptances`` 为后加的列，对旧库（缺这两列）防御性读取：
+    无则以缺省值/空回退，与 DiscoveredTask 字段默认一致。
+    """
+    keys = set(row.keys())
+    raw_acceptances = row["acceptances"] if "acceptances" in keys else None
+    try:
+        acceptances = json.loads(raw_acceptances) if raw_acceptances else []
+    except (TypeError, ValueError):
+        acceptances = []
     return DiscoveredTask(
         task_id=row["task_id"],
         bot_id=row["bot_id"],
         owner_id=row["owner_id"],
         dt=row["dt"],
-        project_name=row["project_name"],
-        description=row["description"] or "",
-        business_scenario=row["business_scenario"] or "",
+        title=row["title"],
+        instruction=row["instruction"] or "",
+        background=row["background"] or "",
         discovery_basis=row["discovery_basis"] or "",
-        work_item_url=row["work_item_url"],
         priority=row["priority"] or "medium",
         discovered_at=row["discovered_at"],
         status=row["status"] or "pending_confirmation",
+        objective=row["objective"] if "objective" in keys and row["objective"] else "",
+        acceptances=acceptances if isinstance(acceptances, list) else [],
     )
 
 
@@ -86,28 +92,30 @@ def init_discovered_tasks_db(db_path: str | Path, tasks: list[dict]) -> None:
     conn = sqlite3.connect(str(path))
     conn.row_factory = sqlite3.Row
     try:
-        conn.executescript(_CREATE_TABLE_SQL)
-        conn.execute("DELETE FROM discovered_tasks;")
+        # DROP+CREATE：每次初始化重建建表，保证 objective/acceptances 等新列就位
+        # （CREATE TABLE IF NOT EXISTS 不会给已存在的旧库加列）。
+        conn.executescript("DROP TABLE IF EXISTS discovered_tasks;\n" + _CREATE_TABLE_SQL)
         conn.executemany(
             "INSERT INTO discovered_tasks "
-            "(task_id, bot_id, owner_id, dt, project_name, description, "
-            " business_scenario, discovery_basis, work_item_url, priority, "
-            " discovered_at, status) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
+            "(task_id, bot_id, owner_id, dt, title, instruction, "
+            " background, discovery_basis, priority, "
+            " discovered_at, status, objective, acceptances) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",
             [
                 (
                     t["task_id"],
                     t.get("bot_id", ""),
                     t.get("owner_id", ""),
                     t.get("dt", ""),
-                    t["project_name"],
-                    t.get("description", ""),
-                    t.get("business_scenario", ""),
+                    t.get("title", ""),
+                    t.get("instruction", ""),
+                    t.get("background", ""),
                     t.get("discovery_basis", ""),
-                    t.get("work_item_url"),
                     t.get("priority", "medium"),
                     t.get("discovered_at"),
                     t.get("status", "pending_confirmation"),
+                    t.get("objective", ""),
+                    json.dumps(t.get("acceptances", []), ensure_ascii=False),
                 )
                 for t in tasks
             ],
@@ -214,11 +222,10 @@ class MockTaskReader:
               "bot_id": "bot-001",
               "owner_id": "user-001",
               "dt": "2026-08-19",
-              "project_name": "...",
-              "description": "...",
-              "business_scenario": "...",
+              "title": "...",
+              "instruction": "...",
+              "background": "...",
               "discovery_basis": "...",
-              "work_item_url": "...",
               "priority": "high",
               "discovered_at": "2026-08-17T10:00:00Z",
               "status": "pending_confirmation"
@@ -259,14 +266,15 @@ class MockTaskReader:
                         bot_id=item.get("bot_id", ""),
                         owner_id=item.get("owner_id", ""),
                         dt=item.get("dt", ""),
-                        project_name=item["project_name"],
-                        description=item.get("description", ""),
-                        business_scenario=item.get("business_scenario", ""),
+                        title=item["title"],
+                        instruction=item.get("instruction", ""),
+                        background=item.get("background", ""),
                         discovery_basis=item.get("discovery_basis", ""),
-                        work_item_url=item.get("work_item_url"),
                         priority=item.get("priority", "medium"),
                         discovered_at=item.get("discovered_at"),
                         status=item.get("status", "pending_confirmation"),
+                        objective=item.get("objective", ""),
+                        acceptances=item.get("acceptances", []),
                     )
                 )
             except KeyError as exc:

--- a/src/backend/src/agentclaw/community/core/work_orders/models.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/models.py
@@ -72,6 +72,7 @@ class WorkOrderEventType(StrEnum):
     HUMAN2BOT_PUBLIC_ORDER_COMPLETED = "HUMAN2BOT_PUBLIC_ORDER_COMPLETED"
     BOT2BOT_PUBLIC_ORDER_CREATED = "BOT2BOT_PUBLIC_ORDER_CREATED"
     BOT2BOT_PUBLIC_ORDER_COMPLETED = "BOT2BOT_PUBLIC_ORDER_COMPLETED"
+    TASK_DISCOVERED = "TASK_DISCOVERED"
 
 
 EVENT_CATEGORIES: dict[WorkOrderEventType, NotificationCategory] = {
@@ -93,6 +94,7 @@ EVENT_CATEGORIES: dict[WorkOrderEventType, NotificationCategory] = {
     WorkOrderEventType.HUMAN2BOT_PUBLIC_ORDER_COMPLETED: NotificationCategory.NOTICE,
     WorkOrderEventType.BOT2BOT_PUBLIC_ORDER_CREATED: NotificationCategory.NOTICE,
     WorkOrderEventType.BOT2BOT_PUBLIC_ORDER_COMPLETED: NotificationCategory.NOTICE,
+    WorkOrderEventType.TASK_DISCOVERED: NotificationCategory.NOTICE,
 }
 
 # Approval events are extracted from the single classification table so new

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/community/notify.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/community/notify.py
@@ -1,7 +1,10 @@
 """Notify-sender concern — community binding.
 
 Binds ``CommunityNotifySender`` (log-only, no real delivery) for the
-community/singlebox profile. Corp deployments bind ``DingTalkNotifySender``
+community/singlebox profile. 当钉钉凭证就绪（``TASK_DISCOVERY_DINGTALK_*`` /
+回退 ``SINGLEBOX_DINGTALK_*`` + ``TASK_DISCOVERY_CARD_TEMPLATE_ID``）时，
+绑定 ``DingTalkNotifySender``（装饰 ``CommunityNotifySender``：先日志再投递
+钉钉交互卡片，两者同时进行）。Corp deployments bind ``DingTalkNotifySender``
 via ``CorpNotifyModule`` instead.
 """
 from __future__ import annotations
@@ -15,17 +18,22 @@ logger = get_logger(__name__)
 
 
 class CommunityNotifyModule(Module):
-    """community: log-only sender (no external channel)."""
+    """community: 始终包裹 DingTalkNotifySender — 凭证就绪时投递卡片，否则跳过。
+
+    钉钉凭证来源优先级：运行时 holder（API 注入）> env 启动变量 > 空（skip）。
+    """
 
     @singleton
     @provider
     def _notify_sender(self) -> NotifySenderPlugin:
         from agentclaw.community.plugins.community.notify_sender import (
             CommunityNotifySender,
+            DingTalkNotifySender,
         )
 
+        inner = CommunityNotifySender()
         logger.info(
-            "[community.notify] Binding CommunityNotifySender "
-            "(log-only; no real delivery)",
+            "[community.notify] Binding DingTalkNotifySender(CommunityNotifySender) "
+            "(log + dingtalk interactive card if creds available)",
         )
-        return CommunityNotifySender()
+        return DingTalkNotifySender(inner)

--- a/src/backend/src/agentclaw/community/di/modules/task_discovery_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/task_discovery_module.py
@@ -3,6 +3,7 @@
 参考 ``CronModule`` 和 ``BotDormantModule`` 的模式：
 - 绑定 ``TaskDiscoveryScheduler`` 为 singleton（Lifecycle 参与者自动发现）
 - 绑定 ``DiscoveryService`` 为 singleton
+- 绑定 ``TaskDiscoveryLockRepository`` 为 singleton（per-bot 分布式锁）
 - 提供 ``SessionInitiator``（注入 CronRelayServiceProtocol）
 - 提供 ``TaskReader``（注入 SQLite path）
 - 桥接 API 层的 BotServiceProtocol 和 CronRelayServiceProtocol
@@ -26,12 +27,22 @@ from agentclaw.community.api.bot_service import (
 from agentclaw.community.api.cron_relay_service import (
     CronRelayServiceProtocol as _ApiCronRelayServiceProtocol,
 )
+from agentclaw.community.api.work_order_service import (
+    WorkOrderServiceProtocol as _ApiWorkOrderServiceProtocol,
+)
+from agentclaw.community.core.repository.implementations.task.discovery_lock import (
+    TaskDiscoveryLockRepository,
+)
+from agentclaw.community.core.repository.protocols.task import (
+    TaskDiscoveryLockRepositoryProtocol,
+)
 from agentclaw.community.core.task.task_discovery.discovery_service import (
     DiscoveryService,
 )
 from agentclaw.community.core.task.task_discovery.protocols import (
     BotServiceProtocol as _TaskDiscoveryBotServiceProtocol,
     CronRelayServiceProtocol as _TaskDiscoveryCronRelayProtocol,
+    WorkOrderServiceProtocol as _TaskDiscoveryWorkOrderServiceProtocol,
 )
 from agentclaw.community.core.task.task_discovery.scheduler import (
     TaskDiscoveryScheduler,
@@ -60,6 +71,20 @@ def _resolve_db_path() -> str:
     return os.environ.get("TASK_DISCOVERY_DATA_FILE", _DEFAULT_DB)
 
 
+_DEFAULT_BACKEND_URL = "http://localhost:8888"
+_DEFAULT_FRONTEND_URL = "http://localhost:8000"
+
+
+def _resolve_frontend_url() -> str:
+    """Resolve frontend workbench URL from env (DI factory — config lives here, not in core/)."""
+    return os.environ.get("FRONTEND_URL", _DEFAULT_FRONTEND_URL)
+
+
+def _resolve_backend_url() -> str:
+    """Resolve backend self URL from env (DI factory — config lives here, not in core/)."""
+    return os.environ.get("BACKEND_URL", _DEFAULT_BACKEND_URL)
+
+
 class TaskDiscoveryModule(Module):
     """DI bindings for task discovery."""
 
@@ -70,6 +95,14 @@ class TaskDiscoveryModule(Module):
         # 的 @provider @singleton 已处理绑定，binder.bind 会遮盖 provider 导致
         # injector 直接调 __init__() 但无法注入 reader/initiator/notify_sender。
         binder.bind(TaskDiscoveryScheduler, to=TaskDiscoveryScheduler, scope=singleton)
+        # Per-bot 分布式锁：单一 ORM 实现，同时运行于 OceanBase (prod) 和
+        # SQLite (local)，差异仅在注入的 DatabasePlugin。UNIQUE(env, bot_id,
+        # discovery_date) 即锁本体——多机器并发 INSERT 由 DB 原子仲裁。
+        binder.bind(
+            TaskDiscoveryLockRepositoryProtocol,
+            to=TaskDiscoveryLockRepository,
+            scope=singleton,
+        )
 
     @singleton
     @provider
@@ -80,13 +113,17 @@ class TaskDiscoveryModule(Module):
         session_initiator: SessionInitiator,
         notify_sender: NotifySenderPlugin,
         bot_service: _TaskDiscoveryBotServiceProtocol,
+        discovery_lock_repo: TaskDiscoveryLockRepositoryProtocol,
+        work_order_service: _TaskDiscoveryWorkOrderServiceProtocol,
     ) -> DiscoveryService:
-        """构建 DiscoveryService（注入 reader + initiator + notify + bot_service）。"""
+        """构建 DiscoveryService（注入 reader + initiator + notify + bot_service + lock + work_order）。"""
         return DiscoveryService(
             reader=reader,
             session_initiator=session_initiator,
             notify_sender=notify_sender,
             bot_service=bot_service,
+            discovery_lock_repo=discovery_lock_repo,
+            work_order_service=work_order_service,
         )
 
     @singleton
@@ -96,8 +133,12 @@ class TaskDiscoveryModule(Module):
         self,
         cron_relay: _ApiCronRelayServiceProtocol,
     ) -> SessionInitiator:
-        """构建 CronRelaySessionInitiator（注入 cron relay）。"""
-        return CronRelaySessionInitiator(cron_relay=cron_relay)
+        """构建 CronRelaySessionInitiator（注入 cron relay + resolved URLs）。"""
+        return CronRelaySessionInitiator(
+            cron_relay=cron_relay,
+            frontend_url=_resolve_frontend_url(),
+            backend_url=_resolve_backend_url(),
+        )
 
     @singleton
     @provider
@@ -128,3 +169,18 @@ class TaskDiscoveryModule(Module):
     ) -> _TaskDiscoveryCronRelayProtocol:
         """Adapt the API cron relay to the task_discovery module's local contract."""
         return cron_relay  # type: ignore[return-value]
+
+    @singleton
+    @provider
+    @inject
+    def _bridge_work_order_protocol(
+        self,
+        work_order_service: _ApiWorkOrderServiceProtocol,
+    ) -> _TaskDiscoveryWorkOrderServiceProtocol:
+        """Adapt the API work-order service to the task_discovery local contract.
+
+        WorkOrderService structurally satisfies the local Protocol (has
+        create_work_order_event), so no adapter wrapper is needed — just
+        return the instance directly.
+        """
+        return work_order_service  # type: ignore[return-value]

--- a/src/backend/src/agentclaw/community/plugins/community/notify_sender.py
+++ b/src/backend/src/agentclaw/community/plugins/community/notify_sender.py
@@ -13,6 +13,9 @@ and ``NoApprovalWorkflow`` (unavailable, tells callers so). Not a
 """
 from __future__ import annotations
 
+import json
+import os
+import time
 import uuid
 
 from agentclaw.community.log import get_logger
@@ -22,6 +25,37 @@ from agentclaw.community.plugin_api.notify_sender import (
 )
 
 log = get_logger(__name__)
+
+
+class DingTalkCredentialHolder:
+    """运行时钉钉凭证 holder — 允许通过 API 动态注入凭证，无需重启 backend。
+
+    优先级：holder > env > 空（skip）。
+    """
+    _creds: dict[str, str] = {}
+
+    @classmethod
+    def set(cls, ak_id: str, ak_secret: str, robot_code: str, card_template_id: str) -> None:
+        cls._creds = {
+            "ak_id": ak_id,
+            "ak_secret": ak_secret,
+            "robot_code": robot_code,
+            "card_template_id": card_template_id,
+        }
+        log.info("[DingTalkCredentialHolder] credentials injected at runtime")
+
+    @classmethod
+    def get(cls, key: str) -> str:
+        return cls._creds.get(key, "")
+
+    @classmethod
+    def clear(cls) -> None:
+        cls._creds = {}
+
+
+def _env(name: str, fallback: str = "") -> str:
+    """读取 env，带 SINGLEBOX_* 兼容回退（便于复用 e2e 既有的钉钉凭证）。"""
+    return (os.environ.get(name) or os.environ.get(fallback) or "").strip()
 
 
 class CommunityNotifySender(NotifySenderPlugin):
@@ -57,3 +91,124 @@ class CommunityNotifySender(NotifySenderPlugin):
             message.body[:500] if message.body else "",
         )
         return msg_id
+
+
+class DingTalkNotifySender(NotifySenderPlugin):
+    """钉钉交互卡片通道 —— 装饰一个 ``inner`` 通道再额外投递一张钉钉交互卡片。
+
+    设计要点：
+      - 这是 ``NotifySenderPlugin`` 的一个通道实现。``DiscoveryService`` 仍只依赖
+        ``notify_sender``，由 DI 在钉钉凭证就绪时绑定本类（凭证缺失则回退到纯
+        ``CommunityNotifySender``）—— 不把钉钉 SDK 漏进 ``DiscoveryService``。
+      - 复用 e2e 既有的钉钉凭证 env（``TASK_DISCOVERY_DINGTALK_*``，回退
+        ``SINGLEBOX_DINGTALK_*``）；``card_template_id`` 复用
+        ``TASK_DISCOVERY_CARD_TEMPLATE_ID``（回退 ``SINGLEBOX_DINGTALK_CARD_TEMPLATE_ID``）。
+      - corp 钉钉 SDK ``alipay_antdingopensdk_client`` **惰性导入**（在 ``send`` 内），
+        未配置凭证时根本不导入；满足 ``send()`` 永不抛异常的 Protocol 约定。
+      - 卡片载荷来自 ``NotifyMessage.extra``（``card_template_id`` / ``card_biz_id`` /
+        ``card_data`` / ``session_url``），由 ``DiscoveryService._send_notification`` 填好。
+    """
+
+    def __init__(self, inner: NotifySenderPlugin) -> None:
+        self._inner = inner
+
+    @property
+    def channels(self) -> frozenset[str]:
+        return self._inner.channels
+
+    def send(
+        self,
+        message: NotifyMessage,
+        *,
+        channel: str = "markdown",
+    ) -> str | None:
+        # 先照常走 inner 通道（日志/兜底），再额外投递钉钉卡片。两者同时进行。
+        msg_id = self._inner.send(message, channel=channel)
+        try:
+            self._send_dingtalk_card(message)
+        except Exception as exc:  # 永不抛异常 —— 钉钉失败不影响通知主流程
+            log.warning(
+                "[DingTalkNotifySender] dingtalk card failed "
+                "(recipient=%s): %s",
+                message.recipient,
+                exc,
+            )
+        return msg_id
+
+    @staticmethod
+    def _resolve(key: str, env_name: str, env_fallback: str) -> str:
+        """优先从 holder 读，回退到 env。"""
+        val = DingTalkCredentialHolder.get(key)
+        if val:
+            return val
+        return _env(env_name, env_fallback)
+
+    @classmethod
+    def _configured(cls) -> bool:
+        return all(
+            [
+                cls._resolve("ak_id", "TASK_DISCOVERY_DINGTALK_AK_ID", "SINGLEBOX_DINGTALK_AK_ID"),
+                cls._resolve("ak_secret", "TASK_DISCOVERY_DINGTALK_AK_SECRET", "SINGLEBOX_DINGTALK_AK_SECRET"),
+                cls._resolve("robot_code", "TASK_DISCOVERY_DINGTALK_ROBOT_CODE", "SINGLEBOX_DINGTALK_ROBOT_CODE"),
+                cls._resolve("card_template_id", "TASK_DISCOVERY_CARD_TEMPLATE_ID", "SINGLEBOX_DINGTALK_CARD_TEMPLATE_ID"),
+            ]
+        )
+
+    def _send_dingtalk_card(self, message: NotifyMessage) -> None:
+        if not self._configured():
+            return  # 未配置凭证 → 跳过，仅 inner 通道（ CommunityNotifySender 日志）
+        ak_id = self._resolve("ak_id", "TASK_DISCOVERY_DINGTALK_AK_ID", "SINGLEBOX_DINGTALK_AK_ID")
+        ak_secret = self._resolve("ak_secret", "TASK_DISCOVERY_DINGTALK_AK_SECRET", "SINGLEBOX_DINGTALK_AK_SECRET")
+        robot_code = self._resolve("robot_code", "TASK_DISCOVERY_DINGTALK_ROBOT_CODE", "SINGLEBOX_DINGTALK_ROBOT_CODE")
+        template_id = self._resolve("card_template_id", "TASK_DISCOVERY_CARD_TEMPLATE_ID", "SINGLEBOX_DINGTALK_CARD_TEMPLATE_ID")
+        extra = message.extra or {}
+        # account_id 默认用 recipient（owner），可用 env 单独覆盖
+        account_id = _env(
+            "TASK_DISCOVERY_DINGTALK_ACCOUNT_ID", "SINGLEBOX_DINGTALK_ACCOUNT_ID"
+        ) or message.recipient
+        card_biz_id = extra.get("card_biz_id") or f"discover_things_{int(time.time())}"
+        # card_data 由 _send_notification 填好（已含 click/session_url/workitem_*…）
+        card_data = extra.get("card_data")
+        if not card_data:
+            return
+
+        # 惰性导入 corp 钉钉 SDK
+        from alibabacloud_tea_openapi import models as open_api_models  # type: ignore[import-not-found]
+        from alibabacloud_tea_util import models as util_models  # type: ignore[import-not-found]
+        from alipay_antdingopensdk_client import (  # type: ignore[import-not-found]
+            models as antding_models,
+        )
+        from alipay_antdingopensdk_client.client import (  # type: ignore[import-not-found]
+            Client as AntDingClient,
+        )
+        # alibabacloud-tea 包不提供 Tea.__version__，但 UtilClient 拼 User-Agent 时读它
+        import Tea  # type: ignore[import-not-found]
+        if not hasattr(Tea, "__version__"):
+            Tea.__version__ = "0.4.3"
+
+        config = open_api_models.Config()
+        config.access_key_id = ak_id
+        config.access_key_secret = ak_secret
+        client = AntDingClient(config)
+        headers = antding_models.HttpHeader()
+        headers.account_context = antding_models.AccountContext(account_id=account_id)
+        req = antding_models.SendRobotInteractiveCardRequest()
+        req.card_template_id = template_id
+        req.robot_code = robot_code
+        req.card_biz_id = card_biz_id
+        req.card_data = card_data
+        req.user_id = account_id
+        resp = client.send_robot_interactive_card_with_options(
+            req, headers, util_models.RuntimeOptions()
+        )
+        biz = resp.body
+        resp_map = biz.to_map() if hasattr(biz, "to_map") else {"raw": str(biz)}
+        log.info(
+            "[DingTalkNotifySender] card sent (recipient=%s, template=%s, "
+            "robot=%s, card_biz_id=%s) -> %s",
+            account_id,
+            template_id,
+            robot_code,
+            card_biz_id,
+            json.dumps(resp_map, ensure_ascii=False),
+        )

--- a/src/backend/tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py
+++ b/src/backend/tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py
@@ -61,21 +61,25 @@ _MOCK_TASKS: list[dict] = [
         "bot_id": "e2e-bot",  # discover 时用 bot_id 参数匹配
         "owner_id": _USER_ID,
         "dt": _TODAY,
-        "project_name": "存储行业尽调报告",
-        "description": "AI 基础设施驱动下,企业级与数据中心存储行业的最新变化、竞争格局与进入机会分析。",
-        "business_scenario": "投资尽调 — 通过行业信息抓取、竞品分析、客户访谈等手段,产出系统性的投资判断报告。",
+        "title": "存储行业尽调报告",
+        "instruction": "AI 基础设施驱动下,企业级与数据中心存储行业的最新变化、竞争格局与进入机会分析。",
+        "background": "投资尽调 — 通过行业信息抓取、竞品分析、客户访谈等手段,产出系统性的投资判断报告。",
         "discovery_basis": "用户近一周频繁搜索存储行业相关信息,行为节点链路表明用户已在自发调研但尚未系统化。",
-        "work_item_url": "https://project.alipay.com/workitem/123456",
         "priority": "high",
         "discovered_at": f"{_TODAY}T10:00:00Z",
         "status": "pending_confirmation",
+        "objective": "产出系统性的存储行业投资判断报告。",
+        "acceptances": [
+            {"id": "a1", "description": "覆盖存储行业 6 条核心结论"},
+            {"id": "a2", "description": "报告包含数据与逻辑链路"},
+        ],
     },
 ]
 
 # 从内联数据派生断言常量
 _EXPECTED_TASK_COUNT = len(_MOCK_TASKS)
 _EXPECTED_TASK_IDS = {t["task_id"] for t in _MOCK_TASKS}
-_EXPECTED_PROJECT_NAMES = {t["project_name"] for t in _MOCK_TASKS}
+_EXPECTED_PROJECT_NAMES = {t["title"] for t in _MOCK_TASKS}
 
 # 默认 db 文件路径:上溯到项目根 → scripts/.dependencies/data/discovered_tasks.db
 _DATA_FILE = Path(__file__).resolve()

--- a/src/backend/tests/community/core/task/test_task_discovery_coverage.py
+++ b/src/backend/tests/community/core/task/test_task_discovery_coverage.py
@@ -1,0 +1,413 @@
+"""Coverage tests for task-discovery new code paths.
+
+Covers lines not exercised by test_task_discovery_unit.py:
+  - DingTalkNotifySender (decorator send + _configured + _send_dingtalk_card)
+  - DiscoveryService._try_acquire_lock (acquire/stale-reap/all-fail paths)
+  - DiscoveryService._send_work_order_event (success/None/exception)
+  - DiscoveryService.discover_all_bots lock integration
+  - DiscoveredTask.to_discovery_prompt with empty acceptances
+  - CronRelaySessionInitiator._build_discovery_prompt empty acceptances
+  - _row_to_task with invalid JSON acceptances
+  - CommunityNotifyModule DI binding (both branches)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agentclaw.community.core.task.task_discovery.discovery_service import (
+    DiscoveryService,
+    DISCOVERY_LOCK_TTL_SECONDS,
+)
+from agentclaw.community.core.task.task_discovery.lock_models import (
+    TaskDiscoveryLockRecord,
+)
+from agentclaw.community.core.task.task_discovery.models import (
+    DiscoveredTask,
+    DiscoverySession,
+)
+from agentclaw.community.core.task.task_discovery.session_initiator import (
+    CronRelaySessionInitiator,
+)
+from agentclaw.community.core.task.task_discovery.task_reader import (
+    SqliteTaskReader,
+    init_discovered_tasks_db,
+)
+from agentclaw.community.plugin_api.notify_sender import (
+    NotifyMessage,
+)
+from agentclaw.community.plugins.community.notify_sender import (
+    CommunityNotifySender,
+    DingTalkNotifySender,
+    _env,
+)
+
+_DT = datetime.now().strftime("%Y-%m-%d")
+
+
+def _make_task(**overrides) -> DiscoveredTask:
+    defaults = dict(
+        task_id="t1",
+        bot_id="bot-1",
+        owner_id="owner-1",
+        dt=_DT,
+        title="Test Task",
+        instruction="Do something",
+        background="Testing",
+        discovery_basis="unit test",
+    )
+    defaults.update(overrides)
+    return DiscoveredTask(**defaults)
+
+
+def _make_session() -> DiscoverySession:
+    return DiscoverySession(
+        task_id="t1",
+        session_id="sess-1",
+        session_url="http://localhost:8000/assistant?sessionId=sess-1",
+    )
+
+
+# ===========================================================================
+# DingTalkNotifySender
+# ===========================================================================
+
+class TestDingTalkNotifySender:
+    """Cover DingTalkNotifySender — the decorator channel."""
+
+    def test_init_and_channels(self):
+        inner = CommunityNotifySender()
+        dt = DingTalkNotifySender(inner)
+        assert dt.channels == inner.channels
+
+    def test_configured_false_without_env(self):
+        assert DingTalkNotifySender._configured() is False
+
+    def test_configured_true_with_all_env(self, monkeypatch):
+        monkeypatch.setenv("TASK_DISCOVERY_DINGTALK_AK_ID", "ak")
+        monkeypatch.setenv("TASK_DISCOVERY_DINGTALK_AK_SECRET", "sk")
+        monkeypatch.setenv("TASK_DISCOVERY_DINGTALK_ROBOT_CODE", "rc")
+        monkeypatch.setenv("TASK_DISCOVERY_CARD_TEMPLATE_ID", "tpl")
+        assert DingTalkNotifySender._configured() is True
+
+    def test_configured_true_with_singlebox_fallback(self, monkeypatch):
+        monkeypatch.delenv("TASK_DISCOVERY_DINGTALK_AK_ID", raising=False)
+        monkeypatch.setenv("SINGLEBOX_DINGTALK_AK_ID", "ak")
+        monkeypatch.setenv("SINGLEBOX_DINGTALK_AK_SECRET", "sk")
+        monkeypatch.setenv("SINGLEBOX_DINGTALK_ROBOT_CODE", "rc")
+        monkeypatch.setenv("SINGLEBOX_DINGTALK_CARD_TEMPLATE_ID", "tpl")
+        assert DingTalkNotifySender._configured() is True
+
+    def test_env_helper_falls_back_to_singlebox(self, monkeypatch):
+        monkeypatch.delenv("MY_VAR", raising=False)
+        monkeypatch.setenv("SINGLEBOX_MY_VAR", "fallback-val")
+        assert _env("MY_VAR", "SINGLEBOX_MY_VAR") == "fallback-val"
+
+    def test_env_helper_empty_when_neither_set(self, monkeypatch):
+        monkeypatch.delenv("NOPE", raising=False)
+        monkeypatch.delenv("SINGLEBOX_NOPE", raising=False)
+        assert _env("NOPE", "SINGLEBOX_NOPE") == ""
+
+    def test_send_calls_inner_and_skips_dingtalk_when_unconfigured(self):
+        """When creds are missing, send() delegates to inner and skips dingtalk."""
+        inner = MagicMock()
+        inner.send.return_value = "msg-123"
+        inner.channels = frozenset({"markdown"})
+        dt = DingTalkNotifySender(inner)
+        msg = NotifyMessage(
+            title="t", body="b", recipient="r", deep_link="dl",
+        )
+        result = dt.send(msg)
+        assert result == "msg-123"
+        inner.send.assert_called_once_with(msg, channel="markdown")
+
+    def test_send_swallows_dingtalk_failure(self):
+        """send() never raises — dingtalk errors are caught and logged."""
+        inner = MagicMock()
+        inner.send.return_value = "ok"
+        inner.channels = frozenset({"markdown"})
+        dt = DingTalkNotifySender(inner)
+        # Force _send_dingtalk_card to raise.
+        with patch.object(dt, "_send_dingtalk_card", side_effect=RuntimeError("boom")):
+            msg = NotifyMessage(title="t", body="b", recipient="r")
+            result = dt.send(msg)
+        assert result == "ok"  # inner result returned despite dingtalk failure
+
+    def test_send_dingtalk_card_returns_early_when_unconfigured(self):
+        """_send_dingtalk_card does nothing when _configured() is False."""
+        dt = DingTalkNotifySender(CommunityNotifySender())
+        msg = NotifyMessage(title="t", body="b", recipient="r")
+        # Should return None without raising (no SDK import).
+        assert dt._send_dingtalk_card(msg) is None
+
+    def test_send_dingtalk_card_returns_early_when_no_card_data(self, monkeypatch):
+        """Even when configured, no card_data in extra → early return."""
+        monkeypatch.setenv("TASK_DISCOVERY_DINGTALK_AK_ID", "ak")
+        monkeypatch.setenv("TASK_DISCOVERY_DINGTALK_AK_SECRET", "sk")
+        monkeypatch.setenv("TASK_DISCOVERY_DINGTALK_ROBOT_CODE", "rc")
+        monkeypatch.setenv("TASK_DISCOVERY_CARD_TEMPLATE_ID", "tpl")
+        dt = DingTalkNotifySender(CommunityNotifySender())
+        msg = NotifyMessage(title="t", body="b", recipient="r")  # no extra
+        assert dt._send_dingtalk_card(msg) is None
+
+
+# ===========================================================================
+# DiscoveryService._try_acquire_lock
+# ===========================================================================
+
+class TestTryAcquireLock:
+    """Cover _try_acquire_lock — acquire / stale-reap / all-fail paths."""
+
+    def _make_service(self, lock_repo):
+        return DiscoveryService(
+            reader=MagicMock(),
+            session_initiator=MagicMock(),
+            notify_sender=MagicMock(),
+            bot_service=None,
+            discovery_lock_repo=lock_repo,
+        )
+
+    def test_first_acquire_succeeds(self):
+        lock_repo = MagicMock()
+        expected = TaskDiscoveryLockRecord(env="dev", bot_id="b1", discovery_date=_DT, lock_token="tok")
+        lock_repo.acquire.return_value = expected
+        svc = self._make_service(lock_repo)
+        rec = svc._try_acquire_lock("b1")
+        assert rec is not None
+        assert rec.lock_token == "tok"
+        assert lock_repo.acquire.call_count == 1
+
+    def test_conflict_then_stale_reap_then_reacquire(self):
+        """First acquire fails, stale lock found, reaped, second acquire succeeds."""
+        lock_repo = MagicMock()
+        stale = TaskDiscoveryLockRecord(env="dev", bot_id="b1", discovery_date=_DT, lock_token="stale-tok")
+        # First acquire → None (conflict)
+        # Then get_if_stale → returns stale record
+        # Then release (reap)
+        # Then second acquire → succeeds
+        lock_repo.acquire.side_effect = [None, TaskDiscoveryLockRecord(env="dev", bot_id="b1", discovery_date=_DT, lock_token="new-tok")]
+        lock_repo.get_if_stale.return_value = stale
+        svc = self._make_service(lock_repo)
+        rec = svc._try_acquire_lock("b1")
+        assert rec is not None
+        assert rec.lock_token == "new-tok"
+        lock_repo.get_if_stale.assert_called_once()
+        lock_repo.release.assert_called_once_with("dev", "b1", _DT, "stale-tok")
+
+    def test_conflict_no_stale_then_still_fails(self):
+        """First acquire fails, no stale lock, second acquire also fails → None."""
+        lock_repo = MagicMock()
+        lock_repo.acquire.side_effect = [None, None]
+        lock_repo.get_if_stale.return_value = None
+        svc = self._make_service(lock_repo)
+        rec = svc._try_acquire_lock("b1")
+        assert rec is None
+        lock_repo.get_if_stale.assert_called_once()
+
+    def test_no_lock_repo_returns_none(self):
+        """When discovery_lock_repo is None, _try_acquire_lock is not called
+        (discover_all_bots handles this, but verify the service doesn't crash)."""
+        svc = DiscoveryService(
+            reader=MagicMock(),
+            session_initiator=MagicMock(),
+            notify_sender=MagicMock(),
+        )
+        assert svc._lock_repo is None
+
+
+# ===========================================================================
+# DiscoveryService._send_work_order_event
+# ===========================================================================
+
+class TestSendWorkOrderEvent:
+    """Cover _send_work_order_event — success / None / exception."""
+
+    def test_none_service_returns_false(self):
+        svc = DiscoveryService(
+            reader=MagicMock(),
+            session_initiator=MagicMock(),
+            notify_sender=MagicMock(),
+            work_order_service=None,
+        )
+        task = _make_task()
+        assert svc._send_work_order_event(task, "user-1", _make_session()) is False
+
+    def test_success_returns_true(self):
+        wo = MagicMock()
+        wo.create_work_order_event.return_value = MagicMock(
+            notification_ids=[1, 2], work_order_id=99,
+        )
+        svc = DiscoveryService(
+            reader=MagicMock(),
+            session_initiator=MagicMock(),
+            notify_sender=MagicMock(),
+            work_order_service=wo,
+        )
+        task = _make_task()
+        result = svc._send_work_order_event(task, "user-1", _make_session())
+        assert result is True
+        wo.create_work_order_event.assert_called_once()
+        # Verify key kwargs.
+        kwargs = wo.create_work_order_event.call_args.kwargs
+        assert kwargs["event_type"] == "TASK_DISCOVERED"
+        assert kwargs["recipient_user_ids"] == ["user-1"]
+        assert kwargs["applicant_user_id"] is None
+
+    def test_exception_returns_false(self):
+        wo = MagicMock()
+        wo.create_work_order_event.side_effect = RuntimeError("boom")
+        svc = DiscoveryService(
+            reader=MagicMock(),
+            session_initiator=MagicMock(),
+            notify_sender=MagicMock(),
+            work_order_service=wo,
+        )
+        task = _make_task()
+        assert svc._send_work_order_event(task, "user-1", _make_session()) is False
+
+
+# ===========================================================================
+# DiscoveredTask.to_discovery_prompt with empty acceptances
+# ===========================================================================
+
+def test_to_discovery_prompt_empty_acceptances():
+    """to_discovery_prompt includes the 'confirm to supplement' branch when acceptances is empty."""
+    task = _make_task(acceptances=[])
+    prompt = task.to_discovery_prompt()
+    assert "（确认时可由你补充）" in prompt
+    assert "Test Task" in prompt
+
+
+# ===========================================================================
+# CronRelaySessionInitiator._build_discovery_prompt empty acceptances
+# ===========================================================================
+
+def test_build_discovery_prompt_empty_acceptances():
+    """_build_discovery_prompt covers the empty-acceptances branch (multi-task)."""
+    initiator = CronRelaySessionInitiator(
+        cron_relay=MagicMock(),
+        frontend_url="http://localhost:8000",
+        backend_url="http://localhost:8888",
+    )
+    task = _make_task(acceptances=[])
+    prompt = initiator._build_discovery_prompt([task])
+    assert "（确认时可由你补充）" in prompt
+
+
+# ===========================================================================
+# _row_to_task with invalid JSON acceptances
+# ===========================================================================
+
+def test_row_to_task_invalid_acceptances_json(tmp_path):
+    """_row_to_task falls back to [] when acceptances is not valid JSON."""
+    db_path = str(tmp_path / "test_bad_acceptances.db")
+    init_discovered_tasks_db(db_path, [
+        {
+            "task_id": "t-bad",
+            "bot_id": "bot-1",
+            "owner_id": "owner-1",
+            "dt": _DT,
+            "title": "BadTask",
+            "instruction": "desc",
+            "background": "bg",
+            "discovery_basis": "basis",
+            "acceptances": "not-valid-json{{",
+        }
+    ])
+    reader = SqliteTaskReader(db_path)
+    tasks = reader.read_pending_tasks_for_bot("bot-1", "owner-1", _DT)
+    assert len(tasks) == 1
+    assert tasks[0].acceptances == []
+
+
+# ===========================================================================
+# CommunityNotifyModule DI binding
+# ===========================================================================
+
+class TestCommunityNotifyModule:
+    """Cover the DI binding logic — always wraps DingTalkNotifySender."""
+
+    def test_always_wraps_dingtalk(self, monkeypatch):
+        """DI always returns DingTalkNotifySender(CommunityNotifySender) —
+        creds are checked at send time, not bind time."""
+        from agentclaw.community.di.modules.infrastructure.community.notify import (
+            CommunityNotifyModule,
+        )
+        mod = CommunityNotifyModule()
+        sender = mod._notify_sender()
+        assert isinstance(sender, DingTalkNotifySender)
+        # Inner is CommunityNotifySender.
+        assert isinstance(sender._inner, CommunityNotifySender)
+
+    def test_dingtalk_configured_with_creds(self, monkeypatch):
+        """_configured() returns True when creds are available via env."""
+        monkeypatch.setenv("TASK_DISCOVERY_DINGTALK_AK_ID", "ak")
+        monkeypatch.setenv("TASK_DISCOVERY_DINGTALK_AK_SECRET", "sk")
+        monkeypatch.setenv("TASK_DISCOVERY_DINGTALK_ROBOT_CODE", "rc")
+        monkeypatch.setenv("TASK_DISCOVERY_CARD_TEMPLATE_ID", "tpl")
+        from agentclaw.community.plugins.community.notify_sender import (
+            DingTalkCredentialHolder,
+        )
+        DingTalkCredentialHolder.clear()
+        assert DingTalkNotifySender._configured() is True
+
+    def test_dingtalk_not_configured_without_creds(self, monkeypatch):
+        """_configured() returns False when no creds available."""
+        monkeypatch.delenv("TASK_DISCOVERY_DINGTALK_AK_ID", raising=False)
+        monkeypatch.delenv("SINGLEBOX_DINGTALK_AK_ID", raising=False)
+        from agentclaw.community.plugins.community.notify_sender import (
+            DingTalkCredentialHolder,
+        )
+        DingTalkCredentialHolder.clear()
+        assert DingTalkNotifySender._configured() is False
+
+
+# ===========================================================================
+# POST /discovery/reschedule endpoint — direct handler test
+# ===========================================================================
+
+class TestRescheduleEndpoint:
+    """Cover the reschedule_cron handler (success / not-running / exception)."""
+
+    def test_reschedule_success(self):
+        from agentclaw.community.adapters.http.task.router import reschedule_cron
+        scheduler = MagicMock()
+        scheduler.reschedule.return_value = True
+        scheduler.get_status.return_value = {
+            "timezone": "Asia/Shanghai",
+            "jobs": [{"next_run_time": "2026-08-26 11:00"}],
+        }
+        result = asyncio.run(reschedule_cron(cron="30 14 * * *", timezone=None, scheduler=scheduler))
+        assert result["success"] is True
+        assert result["cron"] == "30 14 * * *"
+        assert result["timezone"] == "Asia/Shanghai"
+        assert result["next_run_time"] == "2026-08-26 11:00"
+
+    def test_reschedule_scheduler_not_running(self):
+        from agentclaw.community.adapters.http.task.router import reschedule_cron
+        scheduler = MagicMock()
+        scheduler.reschedule.return_value = False
+        result = asyncio.run(reschedule_cron(cron="30 14 * * *", timezone=None, scheduler=scheduler))
+        assert result["success"] is False
+        assert result["message"] == "scheduler not running"
+
+    def test_reschedule_exception(self):
+        from agentclaw.community.adapters.http.task.router import reschedule_cron
+        scheduler = MagicMock()
+        scheduler.reschedule.side_effect = ValueError("bad cron")
+        result = asyncio.run(reschedule_cron(cron="bad", timezone=None, scheduler=scheduler))
+        assert result["success"] is False
+        assert "bad cron" in result["message"]
+
+    def test_reschedule_no_jobs(self):
+        from agentclaw.community.adapters.http.task.router import reschedule_cron
+        scheduler = MagicMock()
+        scheduler.reschedule.return_value = True
+        scheduler.get_status.return_value = {"timezone": "UTC", "jobs": []}
+        result = asyncio.run(reschedule_cron(cron="0 12 * * *", timezone="UTC", scheduler=scheduler))
+        assert result["success"] is True
+        assert result["next_run_time"] is None

--- a/src/backend/tests/community/core/task/test_task_discovery_unit.py
+++ b/src/backend/tests/community/core/task/test_task_discovery_unit.py
@@ -47,13 +47,14 @@ _TASK = DiscoveredTask(
     bot_id="test-bot",
     owner_id="test-owner",
     dt=_DT,
-    project_name="TestSkill",
-    description="A test task",
-    business_scenario="testing",
+    title="TestSkill",
+    instruction="A test task",
+    background="testing",
     discovery_basis="unit test",
-    work_item_url="http://example.com/123",
     priority="high",
     status="pending_confirmation",
+    objective="Unit-test discovery objective",
+    acceptances=[{"id": "a1", "description": "acceptance one"}],
 )
 
 _SESSION = DiscoverySession(
@@ -111,20 +112,24 @@ class TestTaskReader:
         init_discovered_tasks_db(db, [
             {
                 "task_id": "t1", "bot_id": "bot-001", "owner_id": "user-001",
-                "dt": _DT, "project_name": "Task1", "description": "d1",
-                "business_scenario": "s1", "discovery_basis": "b1",
+                "dt": _DT, "title": "Task1", "instruction": "d1",
+                "background": "s1", "discovery_basis": "b1",
                 "status": "pending_confirmation",
+                "objective": "Objective-1",
+                "acceptances": [{"id": "ac1", "description": "acc-1"}],
             },
             {
                 "task_id": "t2", "bot_id": "bot-002", "owner_id": "user-001",
-                "dt": _DT, "project_name": "Task2", "description": "d2",
-                "business_scenario": "s2", "discovery_basis": "b2",
+                "dt": _DT, "title": "Task2", "instruction": "d2",
+                "background": "s2", "discovery_basis": "b2",
                 "status": "pending_confirmation",
+                "objective": "",
+                "acceptances": [],
             },
             {
                 "task_id": "t3", "bot_id": "bot-001", "owner_id": "user-001",
-                "dt": _DT, "project_name": "Task3", "description": "d3",
-                "business_scenario": "s3", "discovery_basis": "b3",
+                "dt": _DT, "title": "Task3", "instruction": "d3",
+                "background": "s3", "discovery_basis": "b3",
                 "status": "confirmed",  # not pending
             },
         ])
@@ -136,7 +141,9 @@ class TestTaskReader:
         tasks = reader.read_pending_tasks_for_bot("bot-001", "user-001", _DT)
         assert len(tasks) == 1
         assert tasks[0].bot_id == "bot-001"
-        assert tasks[0].project_name == "Task1"
+        assert tasks[0].title == "Task1"
+        assert tasks[0].objective == "Objective-1"
+        assert tasks[0].acceptances == [{"id": "ac1", "description": "acc-1"}]
 
     def test_read_pending_for_wrong_bot(self, tmp_path):
         db = self._setup_db(tmp_path)
@@ -300,7 +307,6 @@ class TestCronRelaySessionInitiatorHelpers:
         inst = self._make_initiator()
         prompt = inst._build_discovery_prompt([_TASK])
         assert "TestSkill" in prompt
-        assert "http://example.com/123" in prompt
         assert "是否确认执行" in prompt
 
     def test_build_session_url(self):
@@ -364,7 +370,7 @@ class TestCronRelaySessionInitiatorTitleUpdate:
         mock_cli.post.assert_awaited_once()
         call_kwargs = mock_cli.post.call_args
         assert "/api/sessions/cron_001/update" in call_kwargs.args[0]
-        assert call_kwargs.kwargs["params"]["title"] == "[DreamMode] TestSkill"
+        assert call_kwargs.kwargs["params"]["title"] == "[DreamMode-任务发现] TestSkill"
         # WebSocket injection also ran (Step 3)
         inst._ws_send_message.assert_awaited_once()
 
@@ -429,7 +435,7 @@ class TestCronRelaySessionInitiatorTitleUpdate:
         inst._ws_send_message.assert_not_called()
 
     def test_title_format_single_task(self):
-        """Single task title: [DreamMode] {project_name}."""
+        """Single task title: [DreamMode-任务发现] {title}."""
         inst = self._make_initiator()
         inst._extract_engine_target = AsyncMock(return_value=None)
 
@@ -443,10 +449,10 @@ class TestCronRelaySessionInitiatorTitleUpdate:
         asyncio.run(_capture_title())
         forward_call = inst._cron_relay.forward_request.call_args
         body = forward_call.kwargs["body"]
-        assert body["title"] == "[DreamMode] TestSkill"
+        assert body["title"] == "[DreamMode-任务发现] TestSkill"
 
     def test_title_format_multi_task(self):
-        """Multiple tasks title: [DreamMode] 发现 N 件可能有意义的事情."""
+        """Multiple tasks title: [DreamMode-任务发现] 发现 N 件可能有意义的事情."""
         inst = self._make_initiator()
         inst._extract_engine_target = AsyncMock(return_value=None)
 
@@ -458,7 +464,7 @@ class TestCronRelaySessionInitiatorTitleUpdate:
 
         forward_call = inst._cron_relay.forward_request.call_args
         body = forward_call.kwargs["body"]
-        assert body["title"] == "[DreamMode] 发现 2 件可能有意义的事情"
+        assert body["title"] == "[DreamMode-任务发现] 发现 2 件可能有意义的事情"
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/community/endpoints/test_task_discovery_router.py
+++ b/src/backend/tests/community/endpoints/test_task_discovery_router.py
@@ -137,12 +137,14 @@ def _status_task(task_id: str) -> dict:
         "bot_id": "status-bot",
         "owner_id": "status-owner",
         "dt": "2026-08-20",
-        "project_name": task_id,
-        "description": "status coverage",
-        "business_scenario": "testing",
+        "title": task_id,
+        "instruction": "status coverage",
+        "background": "testing",
         "discovery_basis": "changed-line coverage",
         "priority": "medium",
         "status": "pending_confirmation",
+        "objective": f"目标:{task_id}",
+        "acceptances": [{"id": "c1", "description": "验收-1"}],
     }
 
 
@@ -156,7 +158,21 @@ def _seed_status_with_discovered_and_pending_tasks(world) -> None:
     )
     os.environ["TASK_DISCOVERY_DATA_FILE"] = str(_STATUS_COVERAGE_DB)
     service = world.get(DiscoveryService)
-    task = DiscoveredTask(**_status_task(_STATUS_DISCOVERED_TASK_ID))
+    _task_dto = _status_task(_STATUS_DISCOVERED_TASK_ID)
+    task = DiscoveredTask(
+        task_id=_task_dto["task_id"],
+        bot_id=_task_dto["bot_id"],
+        owner_id=_task_dto["owner_id"],
+        dt=_task_dto["dt"],
+        title=_task_dto["title"],
+        instruction=_task_dto["instruction"],
+        background=_task_dto["background"],
+        discovery_basis=_task_dto["discovery_basis"],
+        priority=_task_dto["priority"],
+        status=_task_dto["status"],
+        objective=_task_dto.get("objective", ""),
+        acceptances=list(_task_dto.get("acceptances", [])),
+    )
     service._discoveries[_STATUS_DISCOVERED_TASK_ID] = DiscoveryResult(
         task=task,
         session=DiscoverySession(
@@ -207,3 +223,57 @@ def _cleanup_status_coverage(response, world) -> None:
 )
 def get_status_happy_discovered_and_pending():
     """Status joins persisted tasks with process-local discovery results."""
+
+
+# ---- POST /api/v1/collaboration/tasks/discovery/reschedule ----
+
+@endpoint_test(
+    method="POST",
+    path="/api/v1/collaboration/tasks/discovery/reschedule",
+    scenario="happy",
+    input=CaseInput(query_params={"cron": "30 14 * * *"}),
+    expect=ExpectSuccess(status=200),
+)
+def reschedule_happy():
+    """Happy path: valid cron expression accepted (scheduler may or may not be running)."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/v1/collaboration/tasks/discovery/reschedule",
+    scenario="error",
+    expect=ExpectError(status=422),
+)
+def reschedule_err_missing_cron():
+    """Error path: missing required cron query param -> FastAPI 422."""
+
+
+# ---- POST /api/v1/collaboration/tasks/discovery/dingtalk-config ----
+
+@endpoint_test(
+    method="POST",
+    path="/api/v1/collaboration/tasks/discovery/dingtalk-config",
+    scenario="happy",
+    input=CaseInput(json_body={
+        "ak_id": "test-ak-id",
+        "ak_secret": "test-ak-secret",
+        "robot_code": "test-robot",
+        "card_template_id": "test-template.schema",
+    }),
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"success": True},
+    ),
+)
+def dingtalk_config_happy():
+    """Happy path: valid credentials injected successfully."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/v1/collaboration/tasks/discovery/dingtalk-config",
+    scenario="error",
+    expect=ExpectError(status=422),
+)
+def dingtalk_config_err_missing_body():
+    """Error path: missing required body -> FastAPI 422."""

--- a/src/backend/tests/community/repository/task/test_task_discovery_lock_repository.py
+++ b/src/backend/tests/community/repository/task/test_task_discovery_lock_repository.py
@@ -1,0 +1,164 @@
+"""Unit tests for TaskDiscoveryLockRepository.
+
+Tests the repository behavior with in-memory SQLite — the same single ORM
+body that runs on prod OceanBase, so the UNIQUE guard, token-fenced release,
+and DB-side staleness are exercised against a real database.
+
+Follows the same pattern as test_bot_restart_lock_repository.py.
+"""
+import pytest
+from contextlib import contextmanager
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.repository.implementations.task.discovery_lock import (
+    TaskDiscoveryLockRepository,
+)
+# Imported for side effect: registers TaskDiscoveryLockModel on Base.metadata
+# so create_all() builds the ac_task_discovery_lock table.
+from agentclaw.community.core.task.task_discovery.lock_models import (  # noqa: F401
+    TaskDiscoveryLockModel,
+    TaskDiscoveryLockRecord,
+)
+
+
+class InMemorySqliteDB:
+    """In-memory SQLite DB for unit testing."""
+
+    def __init__(self, engine):
+        self._engine = engine
+        self._session_factory = sessionmaker(bind=self._engine, autoflush=False)
+
+    @contextmanager
+    def orm_session(self):
+        db = self._session_factory()
+        try:
+            yield db
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+
+@pytest.fixture
+def repo():
+    """Create a repository with in-memory SQLite database."""
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    from agentclaw.community.core.base import Base
+    Base.metadata.create_all(engine)
+    db = InMemorySqliteDB(engine)
+    return TaskDiscoveryLockRepository(db)
+
+
+# --- acquire / UNIQUE guard -------------------------------------------------
+
+def test_acquire_persists_and_returns_record(repo):
+    rec = repo.acquire("dev", "bot_c1", "2026-08-25", "host-1")
+    assert rec is not None
+    assert rec.id is not None
+    assert rec.lock_token  # a fencing token was minted
+    assert rec.env == "dev"
+    assert rec.bot_id == "bot_c1"
+    assert rec.discovery_date == "2026-08-25"
+    assert rec.holder == "host-1"
+
+
+def test_acquire_returns_none_on_duplicate(repo):
+    first = repo.acquire("dev", "bot_c2", "2026-08-25", "host-1")
+    assert first is not None
+    # Duplicate INSERT on the same (env, bot_id, discovery_date) is swallowed
+    # as None — the UNIQUE constraint is the guard.
+    assert repo.acquire("dev", "bot_c2", "2026-08-25", "host-2") is None
+
+
+def test_acquire_different_dates_both_succeed(repo):
+    """Lock key includes discovery_date — different dates are not a conflict."""
+    r1 = repo.acquire("dev", "bot_c3", "2026-08-25", "host-1")
+    r2 = repo.acquire("dev", "bot_c3", "2026-08-26", "host-2")
+    assert r1 is not None
+    assert r2 is not None
+
+
+# --- release / token fence --------------------------------------------------
+
+def test_release_deletes_matching_token(repo):
+    rec = repo.acquire("dev", "bot_r1", "2026-08-25", "host-1")
+    assert rec is not None
+    assert repo.release("dev", "bot_r1", "2026-08-25", rec.lock_token) is True
+    # After release, a new acquire for the same key should succeed.
+    rec2 = repo.acquire("dev", "bot_r1", "2026-08-25", "host-2")
+    assert rec2 is not None
+
+
+def test_release_wrong_token_is_noop(repo):
+    rec = repo.acquire("dev", "bot_r2", "2026-08-25", "host-1")
+    assert rec is not None
+    # Wrong token → no delete, returns False.
+    assert repo.release("dev", "bot_r2", "2026-08-25", "wrong-token") is False
+    # Lock is still held — a new acquire still fails.
+    assert repo.acquire("dev", "bot_r2", "2026-08-25", "host-2") is None
+
+
+def test_release_nonexistent_key_is_noop(repo):
+    assert repo.release("dev", "nope", "2026-08-25", "any-token") is False
+
+
+# --- get_if_stale / TTL -----------------------------------------------------
+
+def test_get_if_stale_returns_none_when_no_row(repo):
+    assert repo.get_if_stale("dev", "bot_s1", "2026-08-25", 600) is None
+
+
+def test_get_if_stale_returns_none_when_fresh(repo):
+    """A freshly acquired lock is not stale."""
+    repo.acquire("dev", "bot_s2", "2026-08-25", "host-1")
+    # TTL of 0 seconds — everything is stale immediately, but even a
+    # generous TTL should return None for a just-created row on a fast
+    # in-memory DB. Use a very large TTL to confirm freshness.
+    assert repo.get_if_stale("dev", "bot_s2", "2026-08-25", 999999) is None
+
+
+def test_get_if_stale_returns_record_when_expired(repo):
+    """A lock older than the TTL is stale and returned for reaping."""
+    repo.acquire("dev", "bot_s3", "2026-08-25", "host-1")
+    # TTL of 0 seconds — the lock is immediately stale.
+    stale = repo.get_if_stale("dev", "bot_s3", "2026-08-25", 0)
+    assert stale is not None
+    assert stale.bot_id == "bot_s3"
+
+
+# --- _as_naive helper ------------------------------------------------------
+
+def test_as_naive_strips_tzinfo():
+    """_as_naive drops tzinfo so two DB-clock timestamps can be subtracted."""
+    from datetime import datetime, timezone
+    from agentclaw.community.core.repository.implementations.task.discovery_lock import (
+        _as_naive,
+    )
+    aware = datetime(2026, 8, 25, 12, 0, 0, tzinfo=timezone.utc)
+    naive = _as_naive(aware)
+    assert naive.tzinfo is None
+    # Already-naive passthrough.
+    bare = datetime(2026, 8, 25, 12, 0, 0)
+    assert _as_naive(bare) is bare
+
+
+# --- to_record --------------------------------------------------------------
+
+def test_to_record_round_trip(repo):
+    """to_record() converts the ORM model to the dataclass record."""
+    from agentclaw.community.core.task.task_discovery.lock_models import (
+        TaskDiscoveryLockRecord,
+    )
+    rec = repo.acquire("dev", "bot_tr", "2026-08-25", "host-1")
+    assert isinstance(rec, TaskDiscoveryLockRecord)
+    assert rec.env == "dev"
+    assert rec.bot_id == "bot_tr"
+    assert rec.discovery_date == "2026-08-25"
+    assert rec.holder == "host-1"
+    assert rec.lock_token
+    assert rec.gmt_create is not None


### PR DESCRIPTION
## Problem

REL20260826 基线上的 task_discovery 模块缺少 dev 分支已落地的多项能力，会阻碍后续基于 REL20260826 的发布线引入这些改进：

- 多机 cron 并发时缺少 per-bot 分布式锁，导致同一 bot 可能被多台机器重复发现
- 缺少工单 NOTICE 通道，发现通知仅依赖外发卡片，单通道有漏达风险
- `DiscoveredTask` 字段未对齐执行层 `TaskSpec` 语义（`project_name`/`description`/`business_scenario`/`work_item_url` vs `title`/`instruction`/`background`/`objective`/`acceptances`），下游确认链路需要二次映射
- 缺少运行时 cron reschedule 与前端 URL 动态注入能力，调整触发时间或前端地址需重启 backend
- 缺少 `/discovery/reschedule`、`/discovery/dingtalk-config` 两个 HTTP 端点

需要在 REL20260826 之上新建 `REL20260826_lz` 分支，将上述 task_discovery 相关变更以最小代价同步过来。

## Solution

基于 `origin/REL20260826` 创建本地分支 `REL20260826_lz`，使用 `git checkout origin/dev -- <file>` 将 dev 上与 task_discovery 相关的源码/测试/文档一次性搬到该分支，整合为一个干净的 commit。

**同步范围（与 dev 完全一致）**：
1. task_discovery 核心：`discovery_service.py`、`lock_models.py`(新)、`models.py`、`protocols.py`、`scheduler.py`、`session_creator.py`、`session_initiator.py`、`task_reader.py`
2. DI 模块：`task_discovery_module.py`、`infrastructure/community/notify.py`
3. Repository 协议/实现：`protocols/task.py`、`implementations/task/discovery_lock.py`(新)
4. HTTP Router：`adapters/http/task/router.py`（新增 `/discovery/reschedule` 与 `/discovery/dingtalk-config`）
5. 通知插件：`plugins/community/notify_sender.py`（新增 `DingTalkCredentialHolder` + `DingTalkNotifySender`）
6. 测试：5 个测试文件，含新增的 `test_task_discovery_coverage.py` 与 `test_task_discovery_lock_repository.py`
7. Spec 文档：`specs/2026-08-25-task-discovery-taskspec-align-and-notify-channels/{design,spec,tasks}.md`

**有意不同步的内容**（避免引入无关重构）：
- `core/work_orders/models.py`：仅手工添加 `TASK_DISCOVERED` 枚举值 + `EVENT_CATEGORIES` 条目；dev 中把 `SPACE_MEMBER_REMOVED` 移到末尾的纯位置重排未同步（无功能差异）
- `core/repository/README.md`：仅添加 `TaskDiscoveryLockRepositoryProtocol` / `TaskDiscoveryLockRepository` 两行清单；dev 中 skill_center 重构相关条目未同步（与 task_discovery 无关）

**拒绝的备选方案**：
- 直接 merge dev：会带入 dev 比 REL20260826 多出的全部其他模块改动，超出"只同步 task_discovery"的范围
- cherry-pick dev 上的 commit：task_discovery 改动散落在多次 commit，与 skill_center 等其他重构交织，无法干净隔离

## Validation

`src/backend/` 下用 `uv run pytest` 跑相关测试：

| 测试文件 | 结果 |
| --- | --- |
| `tests/community/core/task/test_task_discovery_unit.py` | 23 passed |
| `tests/community/core/task/test_task_discovery_coverage.py` | 27 passed |
| `tests/community/repository/task/test_task_discovery_lock_repository.py` | 11 passed |
| `tests/community/endpoints/test_task_discovery_router.py` | 3 passed |
| `tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py` | 2 skipped（需要 singlebox 全栈基础设施） |
| **合计** | **64 passed, 2 skipped** |

**Diff 一致性验证**（`git diff origin/dev -- <path>`）：
- task_discovery 核心、DI、Repository、Router、插件、Spec、测试 — 与 dev 完全一致（diff 为空）
- `work_orders/models.py` 与 dev 仅有 `SPACE_MEMBER_REMOVED` 位置差异，task_discovery 相关条目已对齐
- `repository/README.md` 与 dev 仅有 skill_center 相关条目差异，task_discovery 条目已对齐

**未能运行的检查**：
- e2e 测试依赖 baas / mosn / sofa-registry，本地环境不具备（按 `pytest.ini` 注释需 `RUN_ACCEPTANCE=1` + CI 容器）
- `docs/arch/ci.enforce.md` 描述的完整 CI 门禁（依赖边界检查 / 配置 schema 校验 / 协议契约测试 / 红旗检测）依赖 CI 执行，本地未跑全

## Compatibility and risk

- **`DiscoveredTask` 字段重命名**：`project_name`/`description`/`business_scenario`/`work_item_url` → `title`/`instruction`/`background`(+`objective`+`acceptances`)。`task_reader.py` 通过 `DROP+CREATE` 重建 `discovered_tasks` 表，**旧库数据会被清空**；该表为 task_discovery 独立 SQLite，不影响其他持久化表
- **新增数据库表 `ac_task_discovery_lock`**：UNIQUE 约束 `(env, bot_id, discovery_date)` 即锁本体。需确认 REL20260826 部署环境上 `Base.metadata.create_all` 能正确建表，或已有对应 DDL 迁移
- **新增两个 HTTP 端点**：`POST /api/v1/collaboration/tasks/discovery/reschedule`、`POST /api/v1/collaboration/tasks/discovery/dingtalk-config`。无破坏性，鉴权沿用现有 task router
- **回滚路径**：直接 revert 该 commit；无外部不可逆状态需要清理（除已落地的 lock 表行外，按日 TTL 自动失效）

## Spec

- `src/backend/specs/2026-08-25-task-discovery-taskspec-align-and-notify-channels/design.md` — 技术设计：DiscoveredTask 对齐 TaskSpec + 发现流程双通知通道
- `src/backend/specs/2026-08-25-task-discovery-taskspec-align-and-notify-channels/spec.md` — 规范定义
- `src/backend/specs/2026-08-25-task-discovery-taskspec-align-and-notify-channels/tasks.md` — 任务跟踪

## Related issues (optional)

无显式 issue 关联。本 PR 即把 `origin/dev` 上已落地的任务发现能力回填到 REL20260826 基线，便于发布线集成。
