### PR TITLE
fix(backend): log Passport update payloads

### DIFF
--- a/src/backend/src/agentclaw/community/core/mcp/services/passport_scope.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/passport_scope.py
@@ -5,7 +5,29 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 from agentclaw.community.core.mcp.services.local_mcp_registry import LocalMCPRegistry
-from agentclaw.community.plugin_api.passport import McpScopeItem
+from agentclaw.community.plugin_api.passport import CliItem, McpScopeItem
+
+
+def merge_passport_cli_items(
+    current: list[CliItem] | None,
+    defaults: list[CliItem] | None,
+) -> list[CliItem]:
+    """Merge Passport CLI scope and defaults, de-duplicated by cli_code.
+
+    Passport replaces the complete resource manifest. Existing CLI items win
+    over defaults so a scope refresh cannot clear a user's CLI metadata.
+    """
+    merged: list[CliItem] = []
+    seen: set[str] = set()
+    for item in (current or []) + (defaults or []):
+        if not isinstance(item, dict):
+            continue
+        cli_code = item.get("cli_code")
+        if not cli_code or cli_code in seen:
+            continue
+        seen.add(cli_code)
+        merged.append(dict(item))
+    return merged
 
 
 def filter_passport_mcp_codes(

--- a/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
@@ -26,6 +26,7 @@ from agentclaw.community.core.mcp.services.detail_fanout import (
     server_code_of,
 )
 from agentclaw.community.core.mcp.services.passport_scope import (
+    merge_passport_cli_items,
     passport_mcp_codes_from_entries,
     passport_mcp_items_from_entries,
 )
@@ -33,7 +34,7 @@ from agentclaw.community.core.mcp.services.repositories import BotMCPProvider
 from agentclaw.community.core.repository.protocols.bot import UserMCPConfigRepository
 from agentclaw.community.plugin_api.device_sync import DeviceSyncPlugin
 from agentclaw.community.plugin_api.mcp_center import MCPCenterPlugin
-from agentclaw.community.plugin_api.passport import CliItem, PassportPlugin
+from agentclaw.community.plugin_api.passport import PassportPlugin
 from agentclaw.community.log import get_logger
 
 if TYPE_CHECKING:
@@ -48,32 +49,6 @@ logger = get_logger()
 # 一个:desired state 投递(caller 给定列表)与 collect 后投递,可能并发打同一台设备。
 _DESIRED_STATE_DETAIL_CONCURRENCY = 10
 _COLLECTED_DETAIL_CONCURRENCY = 5
-
-
-def _merge_cli_items(
-    current: list[CliItem] | None,
-    defaults: list[CliItem] | None,
-) -> list[CliItem]:
-    """Merge passport CLI scope with default CLI items, de-duped by cli_code.
-
-    The passport update API treats resourceManifest as an overwrite. During MCP
-    sync we must send the complete CLI scope as well as MCPs. If the passport
-    service returns a temporarily-empty CLI list right after bot creation,
-    preserving the engine defaults here prevents a later MCP sync from clearing
-    them. Existing passport values win on duplicate cli_code so user/provider
-    metadata is not overwritten by static defaults.
-    """
-    merged: list[CliItem] = []
-    seen: set[str] = set()
-    for item in (current or []) + (defaults or []):
-        if not isinstance(item, dict):
-            continue
-        cli_code = item.get("cli_code")
-        if not cli_code or cli_code in seen:
-            continue
-        seen.add(cli_code)
-        merged.append(dict(item))
-    return merged
 
 
 @dataclass
@@ -963,7 +938,7 @@ class MCPSyncService:
             if template_config
             else None,
         )
-        cli_items = _merge_cli_items(current_cli_items, default_cli_items)
+        cli_items = merge_passport_cli_items(current_cli_items, default_cli_items)
         if default_cli_items:
             logger.info(
                 "[MCPSyncService] 合并默认 CLI 范围: bot_id=%s, current_clis=%s, "

--- a/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
@@ -511,6 +511,15 @@ class MCPSyncService:
                 active_mcps,
                 identity_modes=identity_modes,
             )
+            # 当前 Passport MCP 参数不含 token；保留完整条目以定位 TCAuth 前置校验失败值。
+            logger.info(
+                "[MCPSyncService] Passport update request: "
+                "operation=caller_mcp_identity_sync, bot_id=%s, user_id=%s, "
+                "mcp_items=%s",
+                bot_id,
+                user_id,
+                mcp_items,
+            )
             self.passport_update.update_mcp_identity_to_agent_principal(
                 bot_id=bot_id,
                 user_id=user_id,
@@ -969,14 +978,27 @@ class MCPSyncService:
 
         try:
             # resource_scope 是完整快照：MCP 身份与 CLI 都必须回传，避免覆盖丢失授权。
+            resource_scope = {
+                "mcp_codes": synced_server_codes,
+                "mcp_items": mcp_items,
+                "cli_items": cli_items,
+            }
+            # 当前 Passport MCP 参数不含 token；保留完整请求以定位 TCAuth 前置校验失败值。
+            logger.info(
+                "[MCPSyncService] Passport update request: "
+                "operation=mcp_scope_refresh, bot_id=%s, user_id=%s, "
+                "resource_scope=%s, bot_name=%s, bot_desc=%s, engine_type=%s",
+                bot_id,
+                user_id,
+                resource_scope,
+                bot_name,
+                bot_desc,
+                engine_type,
+            )
             self.passport_update.update_passport(
                 bot_id=bot_id,
                 user_id=user_id,
-                resource_scope={
-                    "mcp_codes": synced_server_codes,
-                    "mcp_items": mcp_items,
-                    "cli_items": cli_items,
-                },
+                resource_scope=resource_scope,
                 bot_name=bot_name,
                 bot_desc=bot_desc,
                 engine_type=engine_type,

--- a/src/backend/tests/community/core/mcp/services/test_caller_identity_principal_sync.py
+++ b/src/backend/tests/community/core/mcp/services/test_caller_identity_principal_sync.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -52,3 +52,61 @@ async def test_identity_sync_replaces_complete_non_local_mcp_manifest() -> None:
             }
         ],
     )
+
+
+@pytest.mark.asyncio
+async def test_logs_identity_payload_before_agent_principal_update() -> None:
+    passport = MagicMock()
+    expected_mcp_items = [
+        {
+            "mcp_code": "calendar",
+            "mcp_name": "Calendar",
+            "mcp_desc": "calendar access",
+            "identity_mode": "caller",
+        }
+    ]
+    service = MCPSyncService(
+        mcp_provider_factory=MagicMock(),
+        mcp_center=MagicMock(),
+        user_mcp_config_repo=MagicMock(),
+        passport_update=passport,
+        mcp_config_service=MagicMock(),
+        bot_repository=MagicMock(),
+        caller_identity_repository=MagicMock(),
+        resolver_provider=MagicMock(),
+        device_sync_dispatcher_provider=MagicMock(),
+    )
+
+    with patch(
+        "agentclaw.community.core.mcp.services.sync_service.logger.info"
+    ) as log_info:
+        def verify_log_before_passport_call(**_: object) -> None:
+            log_info.assert_any_call(
+                "[MCPSyncService] Passport update request: "
+                "operation=caller_mcp_identity_sync, bot_id=%s, user_id=%s, "
+                "mcp_items=%s",
+                "bot-1",
+                "owner-1",
+                expected_mcp_items,
+            )
+
+        passport.update_mcp_identity_to_agent_principal.side_effect = (
+            verify_log_before_passport_call
+        )
+        result = await service.sync_mcp_identity_to_agent_principal(
+            user_id="owner-1",
+            entity_id="entity-1",
+            bot_id="bot-1",
+            entity_type="staff",
+            engine_type="openclaw",
+            active_mcps=[
+                {
+                    "server_code": "calendar",
+                    "name": "Calendar",
+                    "description": "calendar access",
+                }
+            ],
+            identity_modes={"calendar": "caller"},
+        )
+
+    assert result == {"success": True}

--- a/src/backend/tests/community/core/mcp/services/test_sync_service.py
+++ b/src/backend/tests/community/core/mcp/services/test_sync_service.py
@@ -13,7 +13,7 @@ delivery failure is NOT best-effort).
 The plugin's MCP methods are **synchronous** (the service wraps them in
 ``asyncio.to_thread``), so the doubles use plain ``MagicMock``.
 """
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -171,6 +171,59 @@ class TestRefreshMcpScope:
                 "identity_mode": "owner",
             },
         ]
+
+    @pytest.mark.asyncio
+    async def test_logs_scope_payload_before_passport_update(self):
+        passport_update = MagicMock()
+        passport_update.query_passport_clis.return_value = []
+        expected_resource_scope = {
+            "mcp_codes": ["mcp.deepinsight"],
+            "mcp_items": [
+                {
+                    "mcp_code": "mcp.deepinsight",
+                    "mcp_name": "DeepInsight",
+                    "mcp_desc": None,
+                    "identity_mode": "owner",
+                }
+            ],
+            "cli_items": [],
+        }
+        bot_repository = MagicMock()
+        bot_repository.get_by_id_and_owner.return_value = None
+        service = _make_sync_service(
+            mcp_provider=_make_mcp_provider(mcps=[
+                {"server_code": "mcp.deepinsight", "name": "DeepInsight"},
+            ]),
+            passport_update=passport_update,
+            bot_repository=bot_repository,
+        )
+
+        with patch(
+            "agentclaw.community.core.mcp.services.sync_service.logger.info"
+        ) as log_info:
+            def verify_log_before_passport_call(**_: object) -> None:
+                log_info.assert_any_call(
+                    "[MCPSyncService] Passport update request: "
+                    "operation=mcp_scope_refresh, bot_id=%s, user_id=%s, "
+                    "resource_scope=%s, bot_name=%s, bot_desc=%s, engine_type=%s",
+                    "bot-1",
+                    "user-1",
+                    expected_resource_scope,
+                    None,
+                    None,
+                    "openclaw",
+                )
+
+            passport_update.update_passport.side_effect = verify_log_before_passport_call
+            result = await service.refresh_mcp_scope(
+                user_id="user-1",
+                entity_id="owner-1",
+                bot_id="bot-1",
+                entity_type="staff",
+                engine_type="openclaw",
+            )
+
+        assert result == {"success": True}
 
     @pytest.mark.asyncio
     async def test_updates_virtual_default_bot_without_caller_identity_lookup(self):


### PR DESCRIPTION
## Problem

TCAuth validates MCP identity values before its request-start log, so a rejected Caller/Owner sync cannot identify the offending payload entry.

## Solution

- Log the complete non-token Passport scope immediately before normal MCP scope refreshes.
- Log the complete non-token MCP item list immediately before Caller identity synchronization.
- Add ordering regressions that assert each log exists when the Passport port is invoked.

## Validation

- `uv run pytest tests/community/core/mcp/services/test_caller_identity_principal_sync.py tests/community/core/mcp/services/test_sync_service.py -q` (42 passed)
- `uv run ruff check ...`
- `uv run python -m compileall -q ...`
- `git diff --check`