### PR TITLE
Feat/user dept search

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/org/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/org/router.py
@@ -47,7 +47,6 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import (
     Principal,
     require_principal,
 )
-from agentclaw.community.adapters.http.openapi_v1.errors import MissingPrincipalError
 from agentclaw.community.adapters.http.openapi_v1.principal import (
     refuse_app_only_caller,
     USER_ID_QUERY,
@@ -110,87 +109,39 @@ async def get_user_identity(
     request: Request,
     principal: PrincipalDep,
     user_id: Annotated[
-        str | None,
+        str,
         Query(
             alias=USER_ID_QUERY,
-            # min_length only (mirrors require_user_id): a blank value must not
-            # read as whoami — it names nobody and is a 422. No upper bound: the
-            # identity boundary has none (GatewayUser.id is unconstrained).
+            # min_length only (mirrors require_user_id): a blank value names
+            # nobody and is a 422. No upper bound: the identity boundary has
+            # none (GatewayUser.id is unconstrained).
             min_length=1,
             description=(
-                "Optional directory filter — whose identity+department to "
-                "return. ABSENT means whoami: return the verified caller's own "
-                "identity, as before. PRESENT switches to a directory lookup of "
-                "that user; any authenticated human caller may name any user — "
-                "this is the OPPOSITE contract to the `user_id` on every other "
-                "operation (which is who the call acts for and must equal the "
-                "caller, 403 otherwise). There is no self-only 403 here. An "
-                "app-only caller is still refused."
+                "Required directory filter — the work number of the user whose "
+                "identity+department to return. The answer comes from the staff "
+                "directory, not the verified principal. Any authenticated human "
+                "caller may name any user — this is the OPPOSITE contract to the "
+                "`user_id` on every other operation (which is who the call acts "
+                "for and must equal the caller, 403 otherwise); there is no "
+                "self-only 403 here. An app-only caller is refused."
             ),
         ),
-    ] = None,
+    ],
 ) -> Envelope[OrgUserIdentity]:
-    """Return the end user the caller's credential names, or — when
-    `user_id` is present — the identity+dept of the user it names.
+    """Return the identity+department of the user named by `user_id`.
 
-    Without the parameter this is the whoami: the identity the gateway resolved
-    and signed (the id to use as `user_id` elsewhere), with dept looked up
-    through the staff-dept service by the caller's work number. With the
-    parameter it is a directory lookup: that user's identity **and** dept come
-    from the staff directory (the gateway signs only the caller, so another
-    user's identity is read off HR, not the principal). The two branches read
-    different sources by design and are not asserted equal even for `self`.
+    A directory lookup, not a whoami: `user_id` is required and authoritative,
+    and that user's identity **and** department come from the staff directory
+    (the gateway signs only the caller, so another user's identity is read off
+    HR, not the principal). There is no absent-param fall-back to the caller's
+    own identity.
 
     A reader that is not wired leaves the looked-up fields null (200); a real
     reader returns them, or an all-null info when the person has no record/no
     dept. A reader that fails (directory down) raises and surfaces as 5xx — so
     "no record" and "directory down" stay distinguishable, the same split the
-    whoami dept read makes.
+    `org/dept` search makes.
     """
-    if user_id is None:
-        # whoami — UNCHANGED. Identity off the verified principal; dept via
-        # get_dept_by_work_no(work_no=user.id). ``getattr`` so a bare FastAPI()
-        # test app with no injector + a hand-constructed principal lands in the
-        # fail-closed branch rather than on an AttributeError.
-        user = getattr(principal, "user", None)
-        if user is None:
-            # Unreachable behind ``refuse_app_only_caller`` for a verified caller;
-            # kept as the fail-closed answer for a hand-constructed principal.
-            raise MissingPrincipalError("principal names no end user")
-
-        dept_no = None
-        dept_name = None
-        dept_path = None
-        reader = _staff_dept_reader(request)
-        if reader is not None:
-            # ``get_dept_by_work_no`` is a sync Plugin method (mirrors antprocess's
-            # sync surface); bridge to the async handler via ``asyncio.to_thread``.
-            # ``DeptLookupError`` is deliberately not caught — infra failure
-            # surfaces as a 5xx distinct from the all-``None`` "no dept" return.
-            info = await asyncio.to_thread(
-                reader.get_dept_by_work_no, work_no=user.id
-            )
-            dept_no = info.dept_no
-            dept_name = info.dept_name
-            dept_path = info.dept_path
-
-        return envelope(
-            OrgUserIdentity(
-                user_id=user.id,
-                username=user.username,
-                display_name=user.display_name,
-                full_name=user.full_name,
-                tenant=principal.tenant,
-                # Optional profile data off the staff directory, null when the
-                # reader is unwired or the person has no dept (200); a directory
-                # failure raised above rather than landing null here.
-                dept_no=dept_no,
-                dept_name=dept_name,
-                dept_path=dept_path,
-            ),
-            request,
-        )
-
     # directory lookup — relaxed: a human caller may name any user. Identity
     # AND dept come from the staff directory (the gateway signs only the
     # caller). No self-only 403: this is the opposite-contract user_id, carved
@@ -200,7 +151,7 @@ async def get_user_identity(
     reader = _staff_dept_reader(request)
     if reader is not None:
         # ``DeptLookupError`` deliberately not caught — infra failure surfaces as
-        # 5xx, distinct from the all-None "no record" 200, like the whoami read.
+        # 5xx, distinct from the all-None "no record" 200, like the org/dept read.
         info = await asyncio.to_thread(reader.get_user_by_work_no, work_no=user_id)
     return envelope(
         OrgUserIdentity(

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/org/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/org/router.py
@@ -50,6 +50,7 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import (
 from agentclaw.community.adapters.http.openapi_v1.errors import MissingPrincipalError
 from agentclaw.community.adapters.http.openapi_v1.principal import (
     refuse_app_only_caller,
+    USER_ID_QUERY,
 )
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
@@ -108,59 +109,109 @@ def _staff_dept_reader(request: Request) -> StaffDeptPlugin | None:
 async def get_user_identity(
     request: Request,
     principal: PrincipalDep,
+    user_id: Annotated[
+        str | None,
+        Query(
+            alias=USER_ID_QUERY,
+            # min_length only (mirrors require_user_id): a blank value must not
+            # read as whoami — it names nobody and is a 422. No upper bound: the
+            # identity boundary has none (GatewayUser.id is unconstrained).
+            min_length=1,
+            description=(
+                "Optional directory filter — whose identity+department to "
+                "return. ABSENT means whoami: return the verified caller's own "
+                "identity, as before. PRESENT switches to a directory lookup of "
+                "that user; any authenticated human caller may name any user — "
+                "this is the OPPOSITE contract to the `user_id` on every other "
+                "operation (which is who the call acts for and must equal the "
+                "caller, 403 otherwise). There is no self-only 403 here. An "
+                "app-only caller is still refused."
+            ),
+        ),
+    ] = None,
 ) -> Envelope[OrgUserIdentity]:
-    """Return the end user the caller's credential names.
+    """Return the end user the caller's credential names, or — when
+    `user_id` is present — the identity+dept of the user it names.
 
-    The identity the gateway resolved and signed: the id to use as `user_id`
-    on delegable user-scoped operations, and the identity non-delegable
-    self-service operations derive directly. Call it once per session and
-    cache the result — the values only change when the session's credential
-    does.
+    Without the parameter this is the whoami: the identity the gateway resolved
+    and signed (the id to use as `user_id` elsewhere), with dept looked up
+    through the staff-dept service by the caller's work number. With the
+    parameter it is a directory lookup: that user's identity **and** dept come
+    from the staff directory (the gateway signs only the caller, so another
+    user's identity is read off HR, not the principal). The two branches read
+    different sources by design and are not asserted equal even for `self`.
 
-    Department attributes are not in that identity; they are looked up by the
-    caller's work number through the staff-dept service. A reader that is not
-    wired leaves them null; a real reader returns them, or an all-null info
-    when the person has no dept. A reader that fails (directory down) raises
-    an error which propagates to a 5xx — so "no dept" and "directory down"
-    stay distinguishable.
+    A reader that is not wired leaves the looked-up fields null (200); a real
+    reader returns them, or an all-null info when the person has no record/no
+    dept. A reader that fails (directory down) raises and surfaces as 5xx — so
+    "no record" and "directory down" stay distinguishable, the same split the
+    whoami dept read makes.
     """
-    # ``getattr`` for the same reason ``principal.py``'s helpers read
-    # tolerantly: production always supplies a ``VerifiedCaller``, and a test
-    # stand-in that models no user must land in the fail-closed branch below
-    # rather than on an AttributeError.
-    user = getattr(principal, "user", None)
-    if user is None:
-        # Unreachable behind ``refuse_app_only_caller`` for a verified caller;
-        # kept as the fail-closed answer for a hand-constructed principal.
-        raise MissingPrincipalError("principal names no end user")
+    if user_id is None:
+        # whoami — UNCHANGED. Identity off the verified principal; dept via
+        # get_dept_by_work_no(work_no=user.id). ``getattr`` so a bare FastAPI()
+        # test app with no injector + a hand-constructed principal lands in the
+        # fail-closed branch rather than on an AttributeError.
+        user = getattr(principal, "user", None)
+        if user is None:
+            # Unreachable behind ``refuse_app_only_caller`` for a verified caller;
+            # kept as the fail-closed answer for a hand-constructed principal.
+            raise MissingPrincipalError("principal names no end user")
 
-    dept_no = None
-    dept_name = None
-    dept_path = None
+        dept_no = None
+        dept_name = None
+        dept_path = None
+        reader = _staff_dept_reader(request)
+        if reader is not None:
+            # ``get_dept_by_work_no`` is a sync Plugin method (mirrors antprocess's
+            # sync surface); bridge to the async handler via ``asyncio.to_thread``.
+            # ``DeptLookupError`` is deliberately not caught — infra failure
+            # surfaces as a 5xx distinct from the all-``None`` "no dept" return.
+            info = await asyncio.to_thread(
+                reader.get_dept_by_work_no, work_no=user.id
+            )
+            dept_no = info.dept_no
+            dept_name = info.dept_name
+            dept_path = info.dept_path
+
+        return envelope(
+            OrgUserIdentity(
+                user_id=user.id,
+                username=user.username,
+                display_name=user.display_name,
+                full_name=user.full_name,
+                tenant=principal.tenant,
+                # Optional profile data off the staff directory, null when the
+                # reader is unwired or the person has no dept (200); a directory
+                # failure raised above rather than landing null here.
+                dept_no=dept_no,
+                dept_name=dept_name,
+                dept_path=dept_path,
+            ),
+            request,
+        )
+
+    # directory lookup — relaxed: a human caller may name any user. Identity
+    # AND dept come from the staff directory (the gateway signs only the
+    # caller). No self-only 403: this is the opposite-contract user_id, carved
+    # out of the explicit-user-id rule (see _DIRECTORY_USER_ID in
+    # test_explicit_user_id.py).
+    info = None
     reader = _staff_dept_reader(request)
     if reader is not None:
-        # ``get_dept_by_work_no`` is a sync Plugin method (mirrors antprocess's
-        # sync surface); bridge to the async handler via ``asyncio.to_thread``.
-        # ``DeptLookupError`` is deliberately not caught — infra failure
-        # surfaces as a 5xx distinct from the all-``None`` "no dept" return.
-        info = await asyncio.to_thread(reader.get_dept_by_work_no, work_no=user.id)
-        dept_no = info.dept_no
-        dept_name = info.dept_name
-        dept_path = info.dept_path
-
+        # ``DeptLookupError`` deliberately not caught — infra failure surfaces as
+        # 5xx, distinct from the all-None "no record" 200, like the whoami read.
+        info = await asyncio.to_thread(reader.get_user_by_work_no, work_no=user_id)
     return envelope(
         OrgUserIdentity(
-            user_id=user.id,
-            username=user.username,
-            display_name=user.display_name,
-            full_name=user.full_name,
+            user_id=user_id,
+            username=info.username if info else None,
+            display_name=info.display_name if info else None,
+            full_name=info.full_name if info else None,
             tenant=principal.tenant,
-            # Optional profile data off the staff directory, null when the
-            # reader is unwired or the person has no dept (200); a directory
-            # failure raised above rather than landing null here.
-            dept_no=dept_no,
-            dept_name=dept_name,
-            dept_path=dept_path,
+            dept_no=info.dept_no if info else None,
+            dept_name=info.dept_name if info else None,
+            dept_path=info.dept_path if info else None,
         ),
         request,
     )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/org/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/org/schemas.py
@@ -1,4 +1,4 @@
-"""Schemas for the org group — the verified caller's own identity."""
+"""Schemas for the org group — directory-identity lookups by `?user_id=`."""
 
 from __future__ import annotations
 
@@ -6,14 +6,16 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class OrgUserIdentity(BaseModel):
-    """The end user the caller's credential names, as resolved at the gateway.
+    """The identity+department of the user named by `?user_id=`, from the staff
+    directory.
 
-    Every field is read off the verified principal — nothing is taken from the
-    request, so the answer cannot be steered. The display attributes are
-    optional because absence is a real state of the identity contract: an
-    identity provider may not supply them, and they are null rather than
-    invented when absent. The department attributes are optional the same way:
-    they are null until the identity provider supplies them.
+    A directory lookup, not a whoami: the response is the user whose work
+    number was passed, resolved off the staff directory (the gateway signs only
+    the caller, so another user's identity is read off HR, not the principal).
+    The identity and department attributes are optional because absence is a
+    real state — the directory may supply no value (or no record at all), and
+    they are null rather than invented when absent. `tenant` is the caller's,
+    scoped off the verified principal.
     """
 
     # The docstring above is published verbatim as the schema's description
@@ -35,15 +37,12 @@ class OrgUserIdentity(BaseModel):
     )
 
     user_id: str = Field(
-        description="The caller's end-user id — the exact value to pass as the "
-        "`user_id` query parameter on delegable user-scoped operations of this "
-        "API. Non-delegable self-service operations derive it from this "
-        "verified identity instead."
+        description="The work number this lookup was for — the `?user_id=` "
+        "value the caller passed to name whose identity+department to return."
     )
     username: str | None = Field(
-        description="The login name, when the identity/directory source "
-        "supplied one; null otherwise (whoami off the signed principal; a "
-        "directory lookup off the staff directory)."
+        description="The login name, when the staff directory supplied one; "
+        "null otherwise (e.g. the reader is unwired or the user has no record)."
     )
     display_name: str | None = Field(
         description="Short display name, when the identity provider supplied "

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/org/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/org/schemas.py
@@ -40,9 +40,10 @@ class OrgUserIdentity(BaseModel):
         "API. Non-delegable self-service operations derive it from this "
         "verified identity instead."
     )
-    username: str = Field(
-        description="The login name the identity provider resolved for the "
-        "caller."
+    username: str | None = Field(
+        description="The login name, when the identity/directory source "
+        "supplied one; null otherwise (whoami off the signed principal; a "
+        "directory lookup off the staff directory)."
     )
     display_name: str | None = Field(
         description="Short display name, when the identity provider supplied "

--- a/src/backend/src/agentclaw/community/plugin_api/staff_dept.py
+++ b/src/backend/src/agentclaw/community/plugin_api/staff_dept.py
@@ -52,6 +52,31 @@ class StaffDeptInfo:
     dept_path: Optional[str] = None
 
 
+@dataclass(frozen=True)
+class UserIdentityInfo:
+    """A person's identity + department, read from the staff directory for an
+    arbitrary work number.
+
+    Every field except ``work_no`` is ``str | None``: ``None`` is an
+    intentional contract state (the directory genuinely supplies no value),
+    null rather than invented when absent. An all-``None`` info (identity and
+    dept all null) means "looked up, no record" — the ``200`` + null answer,
+    distinct from a :class:`DeptLookupError` ("directory down", 5xx). Used by
+    the ``GET /openapi/v1/org/user?user_id=`` directory-lookup branch to return
+    another user's identity + dept; the whoami no-param branch still reads
+    identity off the verified principal and uses ``get_dept_by_work_no`` for
+    dept only (self identity is authoritative from the signed principal).
+    """
+
+    work_no: str
+    username: Optional[str] = None
+    display_name: Optional[str] = None
+    full_name: Optional[str] = None
+    dept_no: Optional[str] = None
+    dept_name: Optional[str] = None
+    dept_path: Optional[str] = None
+
+
 class DeptSearchItem(BaseModel):
     """One department returned by a keyword search of the directory.
 
@@ -92,6 +117,19 @@ class StaffDeptPlugin(Plugin, Protocol):
         ``StaffDeptInfo()`` — "no dept", not a failure. A real impl that reached
         the service and found no record / a record with no dept returns the same
         all-``None`` shape. Only an unreachable or erroring service raises.
+        """
+        ...
+
+    def get_user_by_work_no(self, *, work_no: str) -> UserIdentityInfo:
+        """Return the identity+department for ``work_no``, or an all-``None`` info.
+
+        Implementations with no staff service (community / local) return
+        ``UserIdentityInfo(work_no=work_no)`` — "no record", not a failure. A
+        real impl that reached the service and found no record returns the same
+        all-``None`` shape. Only an unreachable or erroring service raises
+        :class:`DeptLookupError` — so the caller answers "no record" (200 +
+        null) apart from "directory down" (5xx), the same split
+        ``get_dept_by_work_no`` makes.
         """
         ...
 

--- a/src/backend/src/agentclaw/community/plugins/community/staff_dept.py
+++ b/src/backend/src/agentclaw/community/plugins/community/staff_dept.py
@@ -13,6 +13,7 @@ from agentclaw.community.plugin_api.staff_dept import (
     StaffDeptInfo,
     StaffProfileInfo,
     StaffDeptPlugin,
+    UserIdentityInfo,
 )
 
 
@@ -24,6 +25,9 @@ class NoStaffDept(StaffDeptPlugin):
 
     def get_dept_by_work_no(self, *, work_no: str) -> StaffDeptInfo:
         return StaffDeptInfo()
+
+    def get_user_by_work_no(self, *, work_no: str) -> UserIdentityInfo:
+        return UserIdentityInfo(work_no=work_no)
 
     def search_depts(self, *, keyword: str) -> list[DeptSearchItem]:
         return []

--- a/src/backend/src/agentclaw/community/plugins/local/staff_dept.py
+++ b/src/backend/src/agentclaw/community/plugins/local/staff_dept.py
@@ -14,6 +14,7 @@ from agentclaw.community.plugin_api.staff_dept import (
     StaffDeptInfo,
     StaffProfileInfo,
     StaffDeptPlugin,
+    UserIdentityInfo,
 )
 from agentclaw.community.plugins.local._mock_seam import MockSeam
 
@@ -45,6 +46,13 @@ class LocalStaffDeptService(MockSeam, StaffDeptPlugin):
             work_no,
         )
         return StaffDeptInfo()
+
+    def get_user_by_work_no(self, *, work_no: str) -> UserIdentityInfo:
+        logger.info(
+            "[LocalStaffDeptService.get_user_by_work_no] noop — work_no=%s",
+            work_no,
+        )
+        return UserIdentityInfo(work_no=work_no)
 
     def search_depts(self, *, keyword: str) -> list[DeptSearchItem]:
         logger.info(

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -268,12 +268,6 @@ def _without_request_id(response) -> dict:
 #: between "this operation has no user dimension" and "somebody found the
 #: parameter inconvenient".
 _NO_USER_DIMENSION = {
-    # The user-identity read is how a client LEARNS the id it must thread
-    # everywhere else — requiring the parameter here would make the id a
-    # precondition of discovering it. The answer is read off the verified
-    # principal, so there is no caller-supplied user to compare against and no
-    # 403 to answer.
-    ("get", f"{PUBLIC_API_PREFIX}/org/user"),
     # Name uniqueness is checked across the tenant, not within one user's bots.
     ("get", f"{PUBLIC_API_PREFIX}/bots/check-name"),
     # The marketplace catalogue is identical for every caller in the tenant.
@@ -302,6 +296,18 @@ _NO_USER_DIMENSION = {
     ("post", f"{PUBLIC_API_PREFIX}/collaboration/tasks/execute"),
     ("get", f"{PUBLIC_API_PREFIX}/collaboration/tasks/dashboard"),
 }
+
+#: Operations whose ``user_id`` is a directory filter, not the self-confirm
+#: seam. Same spelling, opposite contract: elsewhere ``user_id`` is *who this
+#: call acts for* and must be the caller (403 otherwise); here it is *whose
+#: identity to return*, and any authenticated human caller may name any user.
+#: So it is OPTIONAL, carries no 403, and stays out of both _NO_USER_DIMENSION
+#: (it takes the param) and the user-scoped-required rule (the param is not
+#: self-confirm). Mirrors /bots/logs/traces' carve-out (the first opposite-
+#: contract spelling). The whoami no-param branch is unchanged: the param's
+#: *absence* is still today's discover-your-id flow; only its *presence* is
+#: the directory lookup.
+_DIRECTORY_USER_ID = {("get", f"{PUBLIC_API_PREFIX}/org/user")}
 
 # Operations that are user-scoped but deliberately non-delegable. They derive
 # the actor from the verified human principal and therefore publish no
@@ -430,6 +436,7 @@ def _user_scoped(path: str, method: str) -> bool:
         not path.startswith(_LOGS_PREFIX)
         and (method, path) not in _NO_USER_DIMENSION
         and (method, path) not in _AUTHENTICATED_SELF
+        and (method, path) not in _DIRECTORY_USER_ID
     )
 
 
@@ -530,6 +537,25 @@ def test_bot_logs_keeps_its_own_meaning_of_user_id():
     assert _param(traces, USER_ID_QUERY) is not None, (
         "the filter is part of that operation's contract, not this rule's"
     )
+
+
+def test_org_user_directory_filter_is_optional_without_403():
+    """``GET /org/user`` may take an OPTIONAL ``user_id`` — opposite contract.
+
+    Same spelling, opposite meaning: elsewhere ``user_id`` is *who this call
+    acts for* and must be the caller (403 otherwise); here it is *whose
+    identity to return*, a directory filter any authenticated human caller may
+    name any user for — so it is OPTIONAL and carries no 403. The whoami
+    no-param branch is unchanged. Mirrors the /bots/logs/traces carve-out, the
+    first opposite-contract spelling.
+    """
+    schema = _schema()
+    operation = schema["paths"][f"{PUBLIC_API_PREFIX}/org/user"]["get"]
+    parameter = _param(operation, USER_ID_QUERY)
+    assert parameter is not None, "GET /org/user carries the optional user_id"
+    assert parameter["in"] == "query"
+    assert parameter["required"] is False
+    assert "403" not in operation["responses"]
 
 
 def test_user_id_is_never_a_body_field_or_a_path_segment():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -301,12 +301,11 @@ _NO_USER_DIMENSION = {
 #: seam. Same spelling, opposite contract: elsewhere ``user_id`` is *who this
 #: call acts for* and must be the caller (403 otherwise); here it is *whose
 #: identity to return*, and any authenticated human caller may name any user.
-#: So it is OPTIONAL, carries no 403, and stays out of both _NO_USER_DIMENSION
+#: So it is REQUIRED, carries no 403, and stays out of both _NO_USER_DIMENSION
 #: (it takes the param) and the user-scoped-required rule (the param is not
 #: self-confirm). Mirrors /bots/logs/traces' carve-out (the first opposite-
-#: contract spelling). The whoami no-param branch is unchanged: the param's
-#: *absence* is still today's discover-your-id flow; only its *presence* is
-#: the directory lookup.
+#: contract spelling). There is no whoami fall-back: the param names whose
+#: identity to return, and its absence is a 422.
 _DIRECTORY_USER_ID = {("get", f"{PUBLIC_API_PREFIX}/org/user")}
 
 # Operations that are user-scoped but deliberately non-delegable. They derive
@@ -539,22 +538,22 @@ def test_bot_logs_keeps_its_own_meaning_of_user_id():
     )
 
 
-def test_org_user_directory_filter_is_optional_without_403():
-    """``GET /org/user`` may take an OPTIONAL ``user_id`` — opposite contract.
+def test_org_user_directory_filter_is_required_without_403():
+    """``GET /org/user`` takes a REQUIRED ``user_id`` — opposite contract.
 
     Same spelling, opposite meaning: elsewhere ``user_id`` is *who this call
     acts for* and must be the caller (403 otherwise); here it is *whose
     identity to return*, a directory filter any authenticated human caller may
-    name any user for — so it is OPTIONAL and carries no 403. The whoami
-    no-param branch is unchanged. Mirrors the /bots/logs/traces carve-out, the
+    name any user for — so it is REQUIRED (no whoami fall-back; absence is a
+    422) and carries no 403. Mirrors the /bots/logs/traces carve-out, the
     first opposite-contract spelling.
     """
     schema = _schema()
     operation = schema["paths"][f"{PUBLIC_API_PREFIX}/org/user"]["get"]
     parameter = _param(operation, USER_ID_QUERY)
-    assert parameter is not None, "GET /org/user carries the optional user_id"
+    assert parameter is not None, "GET /org/user carries the required user_id"
     assert parameter["in"] == "query"
-    assert parameter["required"] is False
+    assert parameter["required"] is True
     assert "403" not in operation["responses"]
 
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_org_user_identity.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_org_user_identity.py
@@ -1,21 +1,15 @@
-"""``GET /openapi/v1/org/user`` — the user-identity read, by behaviour.
+"""``GET /openapi/v1/org/user`` — the directory-identity read, by behaviour.
 
-The one operation whose answer *is* the end user, so the properties worth
-pinning are about where that answer comes from and who gets one at all:
-
-- a caller naming an end user gets **the principal's** identity back — the
-  subject id, username and profile attributes the gateway signed, never
-  anything the request supplied;
-- the tenant in the answer is the tenant the request was scoped by: the
-  internal default for a first-party user-only set, the asserted one when a
-  machine principal rides along;
-- an application acting alone is refused with the same ``401`` an
-  unauthenticated caller gets (the sweep in ``test_app_only_refusals.py``
-  covers this operation too; the test here pins the byte-identity).
+A REQUIRED ``?user_id=`` names the work number whose identity+department to
+return; the answer comes from the staff directory (the gateway signs only the
+caller, so another user's identity is read off HR, not the principal). A human
+caller may name any user — there is no self-only 403; an app-only caller is
+refused (byte-identical 401 to an unauthenticated caller, pinned below).
 
 Wiring-level properties — the ``REFUSED`` table entry, the
-``refuse_app_only_caller`` declaration, the absent ``user_id`` parameter —
-are held by ``test_admission_inventory.py`` and ``test_explicit_user_id.py``.
+``refuse_app_only_caller`` declaration, the REQUIRED ``user_id`` parameter and
+its "opposite contract" carve-out — are held by ``test_admission_inventory.py``
+and ``test_explicit_user_id.py``.
 """
 
 from __future__ import annotations
@@ -104,9 +98,9 @@ def client():
     """The whole public surface, with no services bound.
 
     No injector is attached, so the staff-dept reader resolves to ``None`` and
-    the dept fields stay null — the unwired/singlebox shape. Mounting the full
-    surface rather than the one group means the route answers behind exactly
-    the dependencies production mounts it behind.
+    the looked-up identity+dept fields stay null — the unwired/singlebox shape.
+    Mounting the full surface rather than the one group means the route answers
+    behind exactly the dependencies production mounts it behind.
     """
     from agentclaw.community.adapters.http.app import _unhandled_exception_handler
 
@@ -117,84 +111,25 @@ def client():
     return TestClient(app, raise_server_exceptions=False)
 
 
-def test_a_user_reads_the_identity_the_gateway_signed(client):
-    """The full subject comes back, off the principal and nothing else."""
-    token = _token(
-        user={
-            "id": USER,
-            "username": "alice@example.com",
-            "display_name": "Alice",
-            "full_name": "Alice Zhang",
-        }
-    )
+def test_a_missing_user_id_is_a_validation_failure(client):
+    """``?user_id=`` is required — its absence is a 422, never a whoami.
 
-    response = client.get("/openapi/v1/org/user", headers={PRINCIPAL_HEADER: token})
-
-    assert response.status_code == 200, response.text
-    data = response.json()["data"]
-    assert data == {
-        "user_id": USER,
-        "username": "alice@example.com",
-        "display_name": "Alice",
-        "full_name": "Alice Zhang",
-        # A user-only set asserts no tenant and scopes to the internal default.
-        "tenant": DEFAULT_AVERNET_TENANT,
-        # Department is not on the signed principal; the staff-dept reader is
-        # ``None`` here (no injector), so the fields answer null — the unwired
-        # shape. The wired case is covered in test_staff_dept.py.
-        "dept_no": None,
-        "dept_name": None,
-        "dept_path": None,
-    }
-
-
-def test_absent_profile_attributes_answer_null_not_invented(client):
-    """The optional fields are the contract's absence, not a fabrication."""
+    The endpoint is a directory lookup keyed on the passed id; there is no
+    absent-param fall-back to the verified principal's own identity.
+    """
     token = _token(user={"id": USER, "username": "alice@example.com"})
 
     response = client.get("/openapi/v1/org/user", headers={PRINCIPAL_HEADER: token})
 
-    assert response.status_code == 200, response.text
-    data = response.json()["data"]
-    assert data["display_name"] is None
-    assert data["full_name"] is None
+    assert response.status_code == 422, response.text
 
 
-def test_an_app_riding_along_does_not_change_whose_identity_it_is(client):
-    """A human request with an App on the wire is still the human's whoami —
-    and it lands in the App's asserted tenant, like every request it rides."""
-    token = _token(
-        user={"id": USER, "username": "alice@example.com"}, include_app=True
-    )
+def test_a_user_id_param_drives_a_directory_lookup_of_that_user(client):
+    """The passed ``user_id`` is authoritative — not ignored, and not a 403.
 
-    response = client.get("/openapi/v1/org/user", headers={PRINCIPAL_HEADER: token})
-
-    assert response.status_code == 200, response.text
-    data = response.json()["data"]
-    assert data["user_id"] == USER
-    assert data["tenant"] == TENANT
-
-
-def test_an_app_alone_is_refused_like_an_unauthenticated_caller(client):
-    """Byte for byte: no oracle for 'right credential, wrong identity type'."""
-    refused = client.get(
-        "/openapi/v1/org/user",
-        headers={PRINCIPAL_HEADER: _token(user=None, include_app=True)},
-    )
-    unauthenticated = client.get("/openapi/v1/org/user")
-
-    assert refused.status_code == 401, refused.text
-    assert unauthenticated.status_code == 401, unauthenticated.text
-    assert refused.json()["message"] == unauthenticated.json()["message"]
-    assert refused.json()["code"] == unauthenticated.json()["code"]
-
-
-def test_a_user_id_param_triggers_a_directory_lookup_of_that_user(client):
-    """``?user_id=X`` is a directory lookup, not ignored — and it is NOT a 403.
-
-    The relaxation: a human caller may name any user. Unwired (no injector),
-    the reader resolves to None, so the looked-up user's identity+dept answer
-    null — but ``user_id`` echoes the requested id, and the call is 200, never 403.
+    The relaxation: a human caller may name any user. Unwired (no injector), the
+    reader resolves to None, so the looked-up user's identity+dept answer null —
+    but ``user_id`` echoes the requested id and the call is 200, never 403.
     """
     token = _token(user={"id": USER, "username": "alice@example.com"})
 
@@ -208,12 +143,13 @@ def test_a_user_id_param_triggers_a_directory_lookup_of_that_user(client):
     data = response.json()["data"]
     assert data["user_id"] == "someone-else"
     assert data["username"] is None
+    assert data["tenant"] == DEFAULT_AVERNET_TENANT
     assert data["dept_no"] is None
     assert data["dept_name"] is None
     assert data["dept_path"] is None
 
 
-def test_with_user_id_equal_self_still_returns_200_not_403(client):
+def test_with_user_id_equal_self_returns_200_not_403(client):
     """Naming yourself is accepted — the param is a directory filter, not a
     self-confirm seam, so there is no mismatch-403 path on this operation."""
     token = _token(user={"id": USER, "username": "alice@example.com"})
@@ -226,3 +162,23 @@ def test_with_user_id_equal_self_still_returns_200_not_403(client):
 
     assert response.status_code == 200, response.text
     assert response.json()["data"]["user_id"] == USER
+
+
+def test_an_app_alone_is_refused_like_an_unauthenticated_caller(client):
+    """Byte for byte: no oracle for 'right credential, wrong identity type'.
+
+    ``?user_id=`` is passed so the only thing refusing the call is the
+    principal — the param is required, but auth outranks it: an unauthenticated
+    or app-only caller is 401 either way.
+    """
+    refused = client.get(
+        "/openapi/v1/org/user",
+        headers={PRINCIPAL_HEADER: _token(user=None, include_app=True)},
+        params={"user_id": USER},
+    )
+    unauthenticated = client.get("/openapi/v1/org/user", params={"user_id": USER})
+
+    assert refused.status_code == 401, refused.text
+    assert unauthenticated.status_code == 401, unauthenticated.text
+    assert refused.json()["message"] == unauthenticated.json()["message"]
+    assert refused.json()["code"] == unauthenticated.json()["code"]

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_org_user_identity.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_org_user_identity.py
@@ -189,11 +189,12 @@ def test_an_app_alone_is_refused_like_an_unauthenticated_caller(client):
     assert refused.json()["code"] == unauthenticated.json()["code"]
 
 
-def test_the_answer_ignores_a_user_id_smuggled_into_the_query(client):
-    """The operation takes no ``user_id`` — one supplied anyway changes nothing.
+def test_a_user_id_param_triggers_a_directory_lookup_of_that_user(client):
+    """``?user_id=X`` is a directory lookup, not ignored — and it is NOT a 403.
 
-    Not a 422: an undeclared query parameter is ignored on this surface, and
-    the identity comes off the signed principal either way.
+    The relaxation: a human caller may name any user. Unwired (no injector),
+    the reader resolves to None, so the looked-up user's identity+dept answer
+    null — but ``user_id`` echoes the requested id, and the call is 200, never 403.
     """
     token = _token(user={"id": USER, "username": "alice@example.com"})
 
@@ -201,6 +202,26 @@ def test_the_answer_ignores_a_user_id_smuggled_into_the_query(client):
         "/openapi/v1/org/user",
         headers={PRINCIPAL_HEADER: token},
         params={"user_id": "someone-else"},
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    assert data["user_id"] == "someone-else"
+    assert data["username"] is None
+    assert data["dept_no"] is None
+    assert data["dept_name"] is None
+    assert data["dept_path"] is None
+
+
+def test_with_user_id_equal_self_still_returns_200_not_403(client):
+    """Naming yourself is accepted — the param is a directory filter, not a
+    self-confirm seam, so there is no mismatch-403 path on this operation."""
+    token = _token(user={"id": USER, "username": "alice@example.com"})
+
+    response = client.get(
+        "/openapi/v1/org/user",
+        headers={PRINCIPAL_HEADER: token},
+        params={"user_id": USER},
     )
 
     assert response.status_code == 200, response.text

--- a/src/backend/tests/community/contracts/test_staff_dept.py
+++ b/src/backend/tests/community/contracts/test_staff_dept.py
@@ -37,7 +37,6 @@ from agentclaw.community.plugin_api.staff_dept import (
     StaffDeptInfo,
     StaffDeptPlugin,
 )
-from agentclaw.community.utils.avernet_tenant import DEFAULT_AVERNET_TENANT
 from agentclaw.community.utils.gateway_principal_config import (
     init_principal_verifier_config,
     reset_principal_verifier_config_cache,
@@ -93,37 +92,6 @@ def _app_bound_to(staff_dept: StaffDeptPlugin) -> FastAPI:
     return app
 
 
-def test_local_whoami_is_present_with_null_dept(app_with_testing_modules) -> None:
-    """Local impl: all-``None`` dept → 200, identity still returned, plugin hit."""
-    init_principal_verifier_config(
-        _SecretResolver(), "gateway_principal_signing_key", strict=False
-    )
-    try:
-        client = _http_client(app_with_testing_modules)
-        resp = client.get("/openapi/v1/org/user", headers={PRINCIPAL_HEADER: _token()})
-        assert resp.status_code == 200, resp.text
-        data = resp.json()["data"]
-        assert data["user_id"] == _USER["id"]
-        assert data["username"] == _USER["username"]
-        assert data["tenant"] == DEFAULT_AVERNET_TENANT
-        # local/community impl returns "no dept" — null, but present, not a failure.
-        assert data["dept_no"] is None
-        assert data["dept_name"] is None
-        assert data["dept_path"] is None
-
-        # Plugin-hit: the local ``MockSeam`` impl recorded the lookup. Resolve it
-        # off the attached injector and assert the call was made for our workNo.
-        injector = getattr(app_with_testing_modules.state, "injector", None)
-        assert injector is not None
-        local = injector.get(StaffDeptPlugin)
-        assert any(
-            getattr(c, "kwargs", {}).get("work_no") == _USER["id"]
-            for c in local.calls_to("get_dept_by_work_no")
-        )
-    finally:
-        reset_principal_verifier_config_cache()
-
-
 def test_community_staff_dept_reports_no_dept(community_world) -> None:
     """The community column wires a real ``NoStaffDept`` → all-``None``."""
     plugin = community_world.get(StaffDeptPlugin)
@@ -132,58 +100,6 @@ def test_community_staff_dept_reports_no_dept(community_world) -> None:
     assert info.dept_no is None
     assert info.dept_name is None
     assert info.dept_path is None
-
-
-def test_wired_real_dept_propagates() -> None:
-    """A wired impl that returns dept values — they reach the whoami response."""
-
-    class _Real:
-        def get_dept_by_work_no(self, *, work_no: str) -> StaffDeptInfo:
-            return StaffDeptInfo(
-                dept_no="D-7",
-                dept_name="Platform Engineering",
-                dept_path="Ant Group/Platform",
-            )
-
-    init_principal_verifier_config(
-        _SecretResolver(), "gateway_principal_signing_key", strict=False
-    )
-    try:
-        client = _http_client(_app_bound_to(_Real()))
-        resp = client.get("/openapi/v1/org/user", headers={PRINCIPAL_HEADER: _token()})
-        assert resp.status_code == 200, resp.text
-        data = resp.json()["data"]
-        assert data["dept_no"] == "D-7"
-        assert data["dept_name"] == "Platform Engineering"
-        assert data["dept_path"] == "Ant Group/Platform"
-    finally:
-        reset_principal_verifier_config_cache()
-
-
-def test_directory_down_surfaces_5xx() -> None:
-    """Infra failure (``DeptLookupError``) → 5xx, identity NOT returned.
-
-    The failure mode the contract most needs pinned: "directory down" must stay
-    distinct from "no dept" (200 + null) and from auth failure (401).
-    """
-
-    class _Down:
-        def get_dept_by_work_no(self, *, work_no: str) -> StaffDeptInfo:
-            raise DeptLookupError("master-data service unreachable")
-
-    init_principal_verifier_config(
-        _SecretResolver(), "gateway_principal_signing_key", strict=False
-    )
-    try:
-        client = _http_client(_app_bound_to(_Down()))
-        resp = client.get("/openapi/v1/org/user", headers={PRINCIPAL_HEADER: _token()})
-        assert resp.status_code == 502, resp.text
-        # Fixed message, no identity leaked, no dept values invented.
-        body = resp.json()
-        assert body.get("data") is None
-        assert "unavailable" in body.get("message", "").lower()
-    finally:
-        reset_principal_verifier_config_cache()
 
 
 class _SecretResolver:

--- a/src/backend/tests/community/contracts/test_staff_dept.py
+++ b/src/backend/tests/community/contracts/test_staff_dept.py
@@ -314,3 +314,20 @@ def test_local_profile_lookup_is_recorded_and_returns_null_name(
         getattr(call, "kwargs", {}).get("work_no") == "work-42"
         for call in local.calls_to("get_profile_by_work_no")
     )
+
+
+def test_community_directory_lookup_reports_null(community_world) -> None:
+    """The community column wires ``NoStaffDept`` ⇒ all-``None`` identity+dept."""
+    from agentclaw.community.plugin_api.staff_dept import UserIdentityInfo
+
+    info = community_world.get(StaffDeptPlugin).get_user_by_work_no(
+        work_no="anyone"
+    )
+    assert isinstance(info, UserIdentityInfo)
+    assert info.work_no == "anyone"
+    assert info.username is None
+    assert info.display_name is None
+    assert info.full_name is None
+    assert info.dept_no is None
+    assert info.dept_name is None
+    assert info.dept_path is None

--- a/src/backend/tests/community/contracts/test_staff_dept.py
+++ b/src/backend/tests/community/contracts/test_staff_dept.py
@@ -331,3 +331,109 @@ def test_community_directory_lookup_reports_null(community_world) -> None:
     assert info.dept_no is None
     assert info.dept_name is None
     assert info.dept_path is None
+
+
+def test_local_directory_lookup_is_present_with_null_identity(
+    app_with_testing_modules,
+) -> None:
+    """Local impl: ``?user_id=X`` → 200, identity null, plugin hit recorded."""
+    init_principal_verifier_config(
+        _SecretResolver(), "gateway_principal_signing_key", strict=False
+    )
+    try:
+        client = _http_client(app_with_testing_modules)
+        resp = client.get(
+            "/openapi/v1/org/user",
+            headers={PRINCIPAL_HEADER: _token()},
+            params={"user_id": "u-lookup-1"},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()["data"]
+        assert data["user_id"] == "u-lookup-1"
+        assert data["username"] is None
+        assert data["display_name"] is None
+        assert data["full_name"] is None
+        assert data["dept_no"] is None
+        assert data["dept_name"] is None
+        assert data["dept_path"] is None
+
+        injector = getattr(app_with_testing_modules.state, "injector", None)
+        assert injector is not None
+        local = injector.get(StaffDeptPlugin)
+        assert any(
+            getattr(c, "kwargs", {}).get("work_no") == "u-lookup-1"
+            for c in local.calls_to("get_user_by_work_no")
+        )
+    finally:
+        reset_principal_verifier_config_cache()
+
+
+def test_wired_directory_lookup_propagates_identity() -> None:
+    """A wired impl returns identity+dept values → they reach the ?user_id response."""
+
+    class _Real:
+        def get_dept_by_work_no(self, *, work_no: str) -> StaffDeptInfo:
+            return StaffDeptInfo()
+
+        def get_user_by_work_no(self, *, work_no: str):
+            from agentclaw.community.plugin_api.staff_dept import UserIdentityInfo
+
+            return UserIdentityInfo(
+                work_no=work_no,
+                username="cara@example.com",
+                display_name="Cara",
+                full_name="Cara Lin",
+                dept_no="D-9",
+                dept_name="Platform Reliability",
+                dept_path="Ant Group/Platform/Reliability",
+            )
+
+    init_principal_verifier_config(
+        _SecretResolver(), "gateway_principal_signing_key", strict=False
+    )
+    try:
+        client = _http_client(_app_bound_to(_Real()))
+        resp = client.get(
+            "/openapi/v1/org/user",
+            headers={PRINCIPAL_HEADER: _token()},
+            params={"user_id": "u-lookup-1"},
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()["data"]
+        assert data["user_id"] == "u-lookup-1"
+        assert data["username"] == "cara@example.com"
+        assert data["display_name"] == "Cara"
+        assert data["full_name"] == "Cara Lin"
+        assert data["dept_no"] == "D-9"
+        assert data["dept_name"] == "Platform Reliability"
+        assert data["dept_path"] == "Ant Group/Platform/Reliability"
+    finally:
+        reset_principal_verifier_config_cache()
+
+
+def test_directory_lookup_directory_down_surfaces_5xx() -> None:
+    """Infra failure during ``get_user_by_work_no`` → 5xx, no identity leaked."""
+
+    class _Down:
+        def get_dept_by_work_no(self, *, work_no: str) -> StaffDeptInfo:
+            return StaffDeptInfo()
+
+        def get_user_by_work_no(self, *, work_no: str):
+            raise DeptLookupError("master-data service unreachable")
+
+    init_principal_verifier_config(
+        _SecretResolver(), "gateway_principal_signing_key", strict=False
+    )
+    try:
+        client = _http_client(_app_bound_to(_Down()))
+        resp = client.get(
+            "/openapi/v1/org/user",
+            headers={PRINCIPAL_HEADER: _token()},
+            params={"user_id": "u-lookup-1"},
+        )
+        assert resp.status_code == 502, resp.text
+        body = resp.json()
+        assert body.get("data") is None
+        assert "unavailable" in body.get("message", "").lower()
+    finally:
+        reset_principal_verifier_config_cache()

--- a/src/backend/tests/community/endpoints/test_openapi_org_user_identity.py
+++ b/src/backend/tests/community/endpoints/test_openapi_org_user_identity.py
@@ -1,14 +1,14 @@
-"""Endpoint-framework coverage for the user-identity read.
+"""Endpoint-framework coverage for the directory-identity read.
 
 The framework owns invocation, so these two cases are what makes
-``GET /openapi/v1/org/user`` *covered* rather than merely tested: the happy path
-— a verified user reads the identity the gateway signed — and the refusal the
-operation most needs pinned, because its whole answer is an identity: no
-signed principal, no answer.
+``GET /openapi/v1/org/user?user_id=`` *covered* rather than merely tested: the
+happy path — a verified caller names a ``user_id`` and gets that user's
+directory entry (``user_id`` echoed; identity null with no reader wired) — and
+the refusal the operation most needs pinned: no signed principal, no answer.
 
 ``test_org_user_identity.py`` covers the same outcomes plus the app-only refusal
-and the tenant rules in the adapter's own suite. The duplication is the
-coverage gate's design: it reads this registry, not that file.
+and the missing-``user_id``→422 behaviour in the adapter's own suite. The
+duplication is the coverage gate's design: it reads this registry, not that file.
 """
 
 from __future__ import annotations
@@ -81,19 +81,18 @@ def _boot_verifier(_world) -> None:
 @endpoint_test(
     method="GET",
     path=_PATH,
-    scenario="returns_the_verified_identity",
-    input=CaseInput(headers={PRINCIPAL_HEADER: _principal()}),
+    scenario="directory_lookup_by_passed_user_id",
+    input=CaseInput(
+        headers={PRINCIPAL_HEADER: _principal()},
+        query_params={"user_id": _CALLER},
+    ),
     seed=_boot_verifier,
     expect=ExpectSuccess(
         status=200,
         json_contains={
             "code": 200000,
             "message": "OK",
-            "data": {
-                "user_id": _CALLER,
-                "username": "caller@example.test",
-                "display_name": "Caller",
-            },
+            "data": {"user_id": _CALLER, "username": None},
         },
     ),
 )


### PR DESCRIPTION
Problem

  GET /openapi/v1/org/user could only echo the caller's own (principal-sourced) identity + department; there was no way to resolve another user by a specified user_id. Requirement: support looking up a user by
  user_id; the response is keyed on the passed user_id (以传的user_id为准).

  Solution

  GET /openapi/v1/org/user takes a required ?user_id= query and is always a directory lookup of that user_id — StaffDeptPlugin.get_user_by_work_no(work_no) -> UserIdentityInfo returns that user's identity
  (username/display_name/full_name) + department, read from HR Emp360Info. No whoami fall-back: user_id is required (absent → 422). Authorization stays relaxed: any authenticated human caller may name any user_id (no
  self-only 403); app-only is still refused. With no HR reader wired → 200 + null fields; HR infra failure → 5xx.

  user_id on this route is the second "same-spelling, opposite-contract" parameter (after /bots/logs/traces), carved into _DIRECTORY_USER_ID: elsewhere user_id is who this call acts for and must equal the caller, here
  it is whose identity to return — required, but not a self-confirm seam.

  The corp impl (ProdStaffDeptService.get_user_by_work_no) reuses the existing getBatchEmpInfoList RPC (no new upstream call, zero edits to the generated hrorg_facades SDK), matches the result by workNo, and maps
  buMail→username, nickName→display_name, name→full_name, deptNo/Name/Path→dept_*.

  Contract evolution: the initial implementation was "optional ?user_id=, absent falls back to whoami"; per a follow-up requirement it became required + always keyed on the passed user_id. The whoami branch is
  removed; OrgUserIdentity.username stays str | None (the directory branch yields null when the reader is unwired / there's no record).

  Deviations from the original plan (all recorded in commit messages):
  1. OrgUserIdentity.username made str | None — the schema had it as required str, and the directory branch returning null tripped a Pydantic ValidationError; mirrored display_name/full_name.
  2. RST double-backticks (``) → markdown single-backticks in the route docstring / username description — the published-document gate test_schema_docs bans ``.
  3. The corp impl mirrors get_dept_by_work_no's structure + a workNo-match + success=False treated as infra-fail; a secret-resolution failure propagates DeptLookupError raw (no __cause__ — the dept family, unlike the
  profile family).
  4. Contract revision (commit b62e85be6): user_id flipped from optional to required; the whoami branch dropped.

  Rejected: the require_user_id self-confirm seam (it 403s any non-self user_id — the opposite of this requirement); a {user_id} path segment (the design rule rejects it).

  Validation

  Avernet (DEPLOY_PROFILE=test): affected suites 42 passed (test_org_user_identity / test_explicit_user_id / test_staff_dept Rule-25 conformance / endpoints/test_openapi_org_user_identity / test_schema_docs);
  regression gates test_app_only_refusals + test_openapi_error_schema 44 passed; gateway/test_public_namespace 2 passed. Covers missing-user_id → 422, ?user_id=other → 200 + null (unwired), ?user_id=self → 200 not
  403, app-only 401.

  ocb (DEPLOY_PROFILE=corp_test): test_prod_staff_dept_service 24 passed (the corp impl is unchanged by this revision; its 6 new unit tests cover it). Nothing on the ocb side changed in this revision.

  Not run: real-HR e2e — the corp username → buMail mapping is unverified against a real Emp360Info sample (may need loginAccount; the contract str | None is fixed). The ocb-public submodule pointer was not bumped
  (corp_test reads community from ocb-public, which must be re-pointed to Avernet feat/user_dept_search or dev before/at PR time).

  Commits

  Avernet feat/user_dept_search → dev (6):
  3ec5c9476 Protocol get_user_by_work_no+UserIdentityInfo+community noop+conformance · fa57d5d8d local noop+3 directory conformance tests · d4e075bcf route optional ?user_id=+adapter tests+username nullable ·
  e4fe57b01 _DIRECTORY_USER_ID carve-out · b62e85be6 required rewrite (dropping whoami).

  ocb feat/user_dept_search → dev (1):
  7ad06108c0 ProdStaffDeptService.get_user_by_work_no + corp unit tests.

  Compatibility and risk

  - OrgUserIdentity.username changed from required str to str | None (OpenAPI: required → nullable). Backward-compatible (the directory branch can now return null; with no whoami, a populated username is no longer
  guaranteed). Front-end / SDK consumers must tolerate a nullable username.
  - Contract change (please review): ?user_id= is now required; the previous "absent user_id → whoami" behavior is removed (no param → 422). Callers relying on the whoami must now pass ?user_id=<their own id>.
  - Security posture: a human caller can resolve any user_id's name + work email + department (any authenticated human; app-only unchanged) — an enterprise address-book-style read, but it surfaces another person's PII
  (email + full name).
  - Gateway: the user: required policy is unchanged; no routing change → no gateway edit, no checked-in OpenAPI JSON to sync.
  - Rollback: revert the 6 Avernet + 1 ocb commits; reset the ocb-public pointer if it was bumped.

  Spec

  - Design + implementation: Avernet src/backend/specs/2026-08-25-org-user-lookup-by-user-id/{spec.md, plan.md} (Draft). Note the spec describes the initial "optional + whoami-fallback" contract; the final
  implementation was changed to required per the follow-up requirement (the spec/plan were not re-synced to this delta).

  Related issues

  - Extends the /openapi/v1/org/user department fields (StaffDeptPlugin Protocol; corp Employee360Service via Mist secret other_manual_agentclaw_hr_master_secret).
  - No workitem bound.