### PR TITLE
fix(bcs): surface provider delivery failures in group chat

### DIFF
--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -588,6 +588,7 @@ async fn relay_final_chat_event(
     }
     let mut bot_deliveries = Vec::new();
     let mut delivery_results = Vec::new();
+    let mut provider_send_failed = false;
 
     // Finalize the run's open chat segment: flush the buffered streaming text
     // as ONE row, using the final frame's complete text. (Final-only runs with
@@ -696,6 +697,8 @@ async fn relay_final_chat_event(
             flow.registry.get_protocol_version(&target.bot_uuid).await,
             &delivery_target,
         );
+        let is_provider_send = delivery_target.is_http_provider()
+            && target.delivery_type == DeliveryType::Send;
         let provider_tags = if delivery_target.is_http_provider() {
             group
                 .participants
@@ -755,6 +758,9 @@ async fn relay_final_chat_event(
             .await;
         match delivery {
             Ok(result) => {
+                if is_provider_send && !result.delivered {
+                    provider_send_failed = true;
+                }
                 log_relay_deliver_result(
                     cmd,
                     &run_id,
@@ -783,6 +789,9 @@ async fn relay_final_chat_event(
                 bot_deliveries.push(result);
             }
             Err(error) => {
+                if is_provider_send {
+                    provider_send_failed = true;
+                }
                 let error_text = error.to_string();
                 log_relay_deliver_result(
                     cmd,
@@ -811,6 +820,26 @@ async fn relay_final_chat_event(
 
     if bot_deliveries.iter().any(|delivery| delivery.delivered) {
         flow.group.increment_message_count(&cmd.group_id).await?;
+    }
+
+    if provider_send_failed {
+        if let Some(ref system_message) = flow.system_message {
+            let session_id = cmd.bcs_session_id.as_deref().unwrap_or(&cmd.group_id);
+            let receivers = group
+                .participants
+                .iter()
+                .filter(|participant| participant.is_bot() && participant.bot_uuid != cmd.bot_id)
+                .cloned()
+                .collect();
+            let event = SystemMessageEvent::GenericNotification {
+                group_id: cmd.group_id.clone(),
+                message: "消息投递失败，请稍后重试。".to_string(),
+                receivers,
+            };
+            let _ = system_message
+                .notify(&cmd.group_id, event, session_id, &group.participants)
+                .await;
+        }
     }
 
     if !decision.hidden_mentions.is_empty() {

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -920,7 +920,7 @@ pub async fn handle_web_send(
             .collect();
 
         let mut offline_bot_names: Vec<String> = Vec::new();
-        let mut failed_bot_names: Vec<String> = Vec::new();
+        let mut delivery_failed = false;
         for t in &failed_targets {
             let name = group
                 .get_participant(&t.bot_uuid)
@@ -931,7 +931,7 @@ pub async fn handle_web_send(
                 Err(_) => false,
             };
             if is_online {
-                failed_bot_names.push(name);
+                delivery_failed = true;
             } else {
                 offline_bot_names.push(name);
             }
@@ -959,12 +959,10 @@ pub async fn handle_web_send(
                     .await;
             }
 
-            if !failed_bot_names.is_empty() {
-                let names = failed_bot_names.join("、");
-                let message = format!("消息投递给 Bot {} 失败，请稍后重试", names);
+            if delivery_failed {
                 let event = SystemMessageEvent::GenericNotification {
                     group_id: cmd.group_id.clone(),
-                    message,
+                    message: "消息投递失败，请稍后重试。".to_string(),
                     receivers,
                 };
                 let _ = system_message

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -1187,6 +1187,63 @@ async fn bot_final_event_relays_through_bot_delivery_port() {
 }
 
 #[tokio::test]
+async fn failed_provider_bot_event_send_uses_unified_system_message() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    support
+        .registry
+        .set_delivery_target(
+            "bot-driver",
+            support::FakeRegistryService::provider_target("bot-driver"),
+        )
+        .await;
+    support.bot_delivery.fail_for("bot-driver").await;
+    let mut group = support.group.get("group-1").await.unwrap();
+    group.routing_policy = Some(RoutingPolicy {
+        mode: RoutingMode::Structured,
+        default_bot_final_delivery: DefaultDelivery::SendToDriver,
+        ..RoutingPolicy::default()
+    });
+    support.group.upsert(group).await.unwrap();
+    let system_message = Arc::new(RecordingSystemMessage::default());
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_system_message(system_message.clone());
+
+    let outcome = flow
+        .handle_bot_event(BotEventCommand {
+            bot_id: "bot-observer".to_string(),
+            run_id: "run-provider-failure".to_string(),
+            group_id: "group-1".to_string(),
+            event_type: "chat".to_string(),
+            event_payload: json!({
+                "state": "final",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "done"}],
+                },
+            }),
+            state: ChatEventState::Final,
+            bcs_session_id: Some("group-1:abcdef12".to_string()),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.bot_deliveries.len(), 1);
+    assert!(!outcome.bot_deliveries[0].delivered);
+    let notifications = system_message.notifications.lock().await;
+    assert_eq!(notifications.len(), 1);
+    let SystemMessageEvent::GenericNotification { message, .. } = &notifications[0].event else {
+        panic!("expected generic notification");
+    };
+    assert_eq!(message, "消息投递失败，请稍后重试。");
+}
+
+#[tokio::test]
 async fn bot_final_event_relay_uses_each_provider_targets_session_tags() {
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
     support

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -10,17 +10,37 @@ use bcs_service_api::{
     RedactedToken, ServiceError, WebSendCommand,
     ServiceResult, Session, SessionHistoryCommand, SessionKind, SessionManagementService,
     SessionStatus, SessionUseCaseError,
+    SystemMessageEvent, SystemMessageService,
     interceptor::{BlockReason, InterceptorDecision, MessageInterceptor, OutboundMessage},
     port::{EventRecordFactoryPort, NewEvent},
 };
 use serde_json::json;
 use std::{collections::HashMap, sync::Arc};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 #[path = "../../../test-support/message_flow_contract_support.rs"]
 mod support;
 
 struct BlockingInterceptor;
+
+#[derive(Default)]
+struct RecordingSystemMessage {
+    events: Mutex<Vec<SystemMessageEvent>>,
+}
+
+#[async_trait::async_trait]
+impl SystemMessageService for RecordingSystemMessage {
+    async fn notify(
+        &self,
+        _group_id: &str,
+        event: SystemMessageEvent,
+        _session_id: &str,
+        _session_participants: &[Participant],
+    ) -> ServiceResult<usize> {
+        self.events.lock().await.push(event);
+        Ok(1)
+    }
+}
 
 #[async_trait::async_trait]
 impl MessageInterceptor for BlockingInterceptor {
@@ -1487,6 +1507,52 @@ async fn web_send_delivers_to_registered_provider_target_without_ws_connection()
     let targets = support.bot_delivery.targets().await;
     assert_eq!(targets.len(), 1);
     assert!(targets[0].is_http_provider());
+}
+
+#[tokio::test]
+async fn failed_provider_web_send_uses_unified_system_message() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    install_provider_driver_group(&support, "provider-owner").await;
+    support.bot_delivery.fail_for("bot-provider").await;
+    let system_message = Arc::new(RecordingSystemMessage::default());
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_system_message(system_message.clone());
+
+    let outcome = flow
+        .handle_web_send(WebSendCommand {
+            caller: CallerContext::Human(HumanActor {
+                actor_id: "human_1".to_string(),
+                staff_no: "1".to_string(),
+            }),
+            group_id: "group-provider".to_string(),
+            session_id: Some("group-provider:abcdef12".to_string()),
+            from_actor_id: "human_1".to_string(),
+            from_name: Some("Human One".to_string()),
+            message: "hello".to_string(),
+            mentions: vec![],
+            attachments: None,
+            thinking: None,
+            idempotency_key: None,
+            source_im_message_id: None,
+            sender_conn_id: None,
+            provider_bypass_headers: Vec::new(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.failed_count, 1);
+    let events = system_message.events.lock().await;
+    assert_eq!(events.len(), 1);
+    let SystemMessageEvent::GenericNotification { message, .. } = &events[0] else {
+        panic!("expected generic notification");
+    };
+    assert_eq!(message, "消息投递失败，请稍后重试。");
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher.rs
@@ -316,16 +316,17 @@ impl SystemMessageDispatcherService for SystemMessageDispatcherImpl {
         let delivery = self.delivery.clone();
         let bot_run_context = self.bot_run_context.clone();
         let provider_chat_run_timeout_ms = self.provider_chat_run_timeout_ms;
-        results.extend(join_all(commands.into_iter().map(|cmd| {
+        let delivery_outcomes = join_all(commands.into_iter().map(|cmd| {
             let recipient = cmd.recipient_id.clone();
             let delivery = delivery.clone();
             let bot_run_context = bot_run_context.clone();
             async move {
-                let delivered = match delivery.deliver(cmd.cmd).await {
-                    Ok(r) => r.delivered,
+                let is_provider_send = cmd.record_run_context;
+                let (delivered, mut error) = match delivery.deliver(cmd.cmd).await {
+                    Ok(r) => (r.delivered, r.error),
                     Err(e) => {
                         tracing::warn!(%recipient, error = %e, "system message delivery failed");
-                        false
+                        (false, Some(e))
                     }
                 };
                 if delivered && cmd.record_run_context {
@@ -343,19 +344,25 @@ impl SystemMessageDispatcherService for SystemMessageDispatcherImpl {
                             .await;
                     }
                 }
-                let error = if delivered {
-                    None
-                } else {
-                    Some(ServiceError::InternalError("delivery failed".to_string()))
-                };
-                SystemMessageRecipientResult {
-                    recipient_id: recipient,
-                    delivered,
-                    error,
+                if !delivered && error.is_none() {
+                    error = Some(ServiceError::InternalError("delivery failed".to_string()));
                 }
+                let provider_delivery_failed = is_provider_send && !delivered;
+                (
+                    SystemMessageRecipientResult {
+                        recipient_id: recipient,
+                        delivered,
+                        error,
+                    },
+                    provider_delivery_failed,
+                )
             }
         }))
-        .await);
+        .await;
+        let provider_delivery_failed = delivery_outcomes
+            .iter()
+            .any(|(_, provider_delivery_failed)| *provider_delivery_failed);
+        results.extend(delivery_outcomes.into_iter().map(|(result, _)| result));
 
         for r in &results {
             if r.delivered {
@@ -381,6 +388,23 @@ impl SystemMessageDispatcherService for SystemMessageDispatcherImpl {
                 tracing::warn!(
                     group_id = %group.id, %session_id, error = %e,
                     "system message frontend delivery failed"
+                );
+            }
+        }
+        if provider_delivery_failed {
+            let content = "消息投递失败，请稍后重试。";
+            let event_json = build_frontend_system_event_frame(&group.id, content, session_id);
+            let target = FrontendDeliveryTarget::Session { session_id: session_id.to_string() };
+            if let Err(e) = self.frontend_delivery.publish(FrontendDeliveryCommand {
+                target,
+                event_json,
+                delivery_kind: FrontendDeliveryKind::WorkbenchEvent,
+                run_fallback: None,
+                exclude_conn_id: None,
+            }).await {
+                tracing::warn!(
+                    group_id = %group.id, %session_id, error = %e,
+                    "provider delivery failure notice delivery failed"
                 );
             }
         }

--- a/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/dispatcher_test.rs
@@ -1105,7 +1105,7 @@ async fn dispatch_failed_send_system_message_does_not_record_run_context() {
 }
 
 #[tokio::test]
-async fn dispatch_errored_send_system_message_does_not_record_run_context() {
+async fn dispatch_failed_provider_send_notifies_frontend_without_run_context() {
     let group = Group {
         id: "group-provider".into(),
         label: None,
@@ -1149,13 +1149,13 @@ async fn dispatch_errored_send_system_message_does_not_record_run_context() {
         delivered: true,
         fail: true,
     });
-    let frontend_delivery = Arc::new(NoopFrontendDeliveryPort);
+    let frontend_delivery = Arc::new(RecordingFrontendDeliveryPort::default());
     let run_context = Arc::new(RecordingRunContext::default());
 
     let dispatcher = SystemMessageDispatcherImpl::builder()
         .with_registry(registry)
         .with_delivery(delivery.clone())
-        .with_frontend_delivery(frontend_delivery)
+        .with_frontend_delivery(frontend_delivery.clone())
         .with_bot_run_context(run_context.clone())
         .register(FixedSendProducer)
         .build()
@@ -1178,6 +1178,13 @@ async fn dispatch_errored_send_system_message_does_not_record_run_context() {
     assert_eq!(params["bcs_group_id"], "group-provider");
     assert_eq!(params["bcs_session_id"], "session-provider");
     assert_eq!(run_context.len(), 0);
+    let published = frontend_delivery.published.lock().unwrap();
+    assert_eq!(published.len(), 1);
+    let frame: serde_json::Value = serde_json::from_str(&published[0].event_json).unwrap();
+    assert_eq!(
+        frame["payload"]["message"]["content"][0]["text"],
+        "消息投递失败，请稍后重试。"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem
Provider `chat.send` failures could leave a group or session with no visible feedback, especially during initialization and Bot-event relay.

## Solution
- Publish the existing system message “消息投递失败，请稍后重试。” when Provider `chat.send` delivery fails.
- Cover normal group sends, initialization/system-message sends, and Bot-event relay.
- Keep `chat.inject` failures logs-only to avoid noisy duplicate prompts.
- Preserve delivery error details internally without exposing raw Provider error bodies to the frontend.

## Validation
- `cd src/bcs && cargo test -p bcs-message-flow -p bcs-system-message` — passed.
- `git diff --check origin/dev...HEAD` — passed.
- Push hooks were skipped with `--no-verify` per the Avernet PR workflow; the affected test suites were run explicitly.

## Compatibility and risk
No wire protocol or schema change. This reuses the existing `role=system` event. The behavioral risk is an additional visible notice when Provider send delivery fails; rollback is reverting this commit.