### PR TITLE
fix(bcs): allow attributes for unbound provider bots

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
@@ -617,7 +617,7 @@ async fn require_provider_bot_attributes_access(
         .map_err(provider_error)?;
 
     // COSEC: Attribute access is fail-closed: only an authenticated Provider
-    // explicitly listed for backend operations may reach its own active Bot.
+    // explicitly listed for backend operations may manage BCS Bot attributes.
     if !state
         .allowed_switch_provider_ids
         .iter()
@@ -635,35 +635,6 @@ async fn require_provider_bot_attributes_access(
         });
     }
 
-    let binding = state
-        .services
-        .provider_bot_core
-        .get_provider_bot_binding_by_bot_uuid(bot_uuid)
-        .await
-        .map_err(provider_error)?
-        .ok_or_else(|| ProviderRouteError {
-            status: StatusCode::NOT_FOUND,
-            message: format!("bot not found: {bot_uuid}"),
-        })?;
-    if binding.disabled {
-        return Err(ProviderRouteError {
-            status: StatusCode::NOT_FOUND,
-            message: format!("bot not found: {bot_uuid}"),
-        });
-    }
-    if binding.provider_id != provider_id {
-        warn!(
-            provider_id,
-            bot_uuid,
-            binding_provider_id = binding.provider_id,
-            failure = "provider_bot_binding_mismatch",
-            "Provider Bot attributes access rejected"
-        );
-        return Err(ProviderRouteError {
-            status: StatusCode::FORBIDDEN,
-            message: "provider does not own bot".to_string(),
-        });
-    }
     Ok(())
 }
 

--- a/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
@@ -2079,7 +2079,7 @@ async fn register_provider_bot_reuses_provider_ref_as_bot_uuid_for_allowed_switc
 }
 
 #[tokio::test]
-async fn provider_bot_attributes_require_an_allowlisted_provider_admin_and_bound_bot() {
+async fn provider_bot_attributes_allow_an_allowlisted_provider_admin_to_manage_unbound_plugin_bots() {
     let provider_id = "prv_internal_attributes".to_string();
     let admin_token = "admin-token";
     let TestApp {
@@ -2135,7 +2135,8 @@ async fn provider_bot_attributes_require_an_allowlisted_provider_admin_and_bound
                     json!({
                         "name": "Teamclaw Bot",
                         "owners": ["alice"],
-                        "provider_bot_ref": "teamclaw-bot:alice"
+                        "provider_bot_ref": "teamclaw-bot:alice",
+                        "connection_mode": "plugin"
                     })
                     .to_string(),
                 ))

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/internal_bot_attributes.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/internal_bot_attributes.rs
@@ -34,17 +34,6 @@ pub struct BotInternalAttributes {
     pub friend_check_in_strategy: FriendCheckInStrategy,
 }
 
-impl Default for BotInternalAttributes {
-    fn default() -> Self {
-        Self {
-            visibility: default_visibility(),
-            user_visibility: UserVisibility::default(),
-            friend_ext: Map::new(),
-            friend_check_in_strategy: FriendCheckInStrategy::default(),
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct PatchBotInternalAttributes {
     pub bot_id: String,

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/internal_bot_attributes.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/internal_bot_attributes.rs
@@ -34,6 +34,17 @@ pub struct BotInternalAttributes {
     pub friend_check_in_strategy: FriendCheckInStrategy,
 }
 
+impl Default for BotInternalAttributes {
+    fn default() -> Self {
+        Self {
+            visibility: default_visibility(),
+            user_visibility: UserVisibility::default(),
+            friend_ext: Map::new(),
+            friend_check_in_strategy: FriendCheckInStrategy::default(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct PatchBotInternalAttributes {
     pub bot_id: String,


### PR DESCRIPTION
## Problem

BCN Plugin provider bots are registered upstream in BCS but intentionally do not create a `bcs_provider_bot_bindings` row. The provider attribute endpoints required that downlink binding before reaching the attribute service, so valid Backend requests for those bots returned 404.

## Solution

- Remove the binding existence, disabled-state, and binding-provider ownership checks from the provider attribute access helper.
- Keep Provider Admin Token validation, active Provider validation, and the configured Backend Provider allowlist.
- Cover GET and PATCH for an allowlisted Provider's unbound Plugin bot.

## Validation

- `cargo test -p bcs-http --test provider_routes_contract` — 46 passed.
- `cargo test -p bcs-http` — 459 passed.
- `git diff --check origin/dev...HEAD` — passed.

## Compatibility and risk

An allowlisted Provider Admin Token can now manage attributes for any existing BCS Bot in the same environment, instead of only bots with a Provider Binding. This is the intended trusted Backend authorization model; Provider registration and downlink Binding behavior remain unchanged.
