### PR TITLE
fix(backend): lock BCS bot publish response to declared fields

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/collaboration_bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/collaboration_bots/schemas.py
@@ -45,16 +45,18 @@ class BcsPublicRequest(BaseModel):
 class BcsPublishResult(BaseModel):
     """The approval-start result returned by public_bcs_bot.
 
-    Mirrors the ApprovalWorkflowPlugin.start_approval return shape; extra fields
-    are kept (forward-compat) so the response surface stays stable as the prod
-    approval reply adds keys.
+    Limited to the declared fields. The upstream approval reply and the publish
+    service carry keys that are not part of the public contract — the
+    last-operate marker (in either casing) and the private-path visibility
+    fields — so the model drops unknown keys rather than surfacing them. Track
+    the open ticket via puid and approval_url; read state for an immediate
+    outcome and error_msg when success is false.
     """
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="ignore")
 
     success: bool = Field(description="Whether submitting the approval ticket (or the private direct BCS PATCH) succeeded.")
     puid: Optional[str] = Field(default=None, description="The approval ticket's global-unique id (None on the private direct-update path).")
     approval_url: Optional[str] = Field(default=None, description="The approval ticket's review URL (None on the private direct-update path).")
     state: Optional[str] = Field(default=None, description="The ticket's state at submit (PROCESSING / COMPLETED).")
-    last_operate: Optional[str] = Field(default=None, description="The ticket's last-operate marker on COMPLETED (AGREE / DISAGREE / CANCEL).")
     error_msg: Optional[str] = Field(default=None, description="Error message when success is False.")

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_collaboration_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_collaboration_bots_endpoints.py
@@ -104,3 +104,45 @@ def test_publish_endpoint_rejects_invalid_public_scope(make_client):
     )
 
     assert response.status_code == 422, response.text  # pydantic validation Envelope
+
+
+def test_publish_response_locks_to_declared_fields_drops_extras(make_client):
+    """The public BcsPublishResult is locked to its declared fields.
+
+    Across public_bcs_bot's three return paths the raw service dict carries
+    keys the response must NOT surface: the prod approval reply uses camelCase
+    ``lastOperate``, the no-workflow synthesis uses snake ``last_operate``, and
+    the private direct path adds ``visibility`` / ``visibility_field``. None of
+    these are declared on BcsPublishResult — and ``last_operate`` is removed from
+    the contract altogether — so the response must drop every casing/extra and
+    keep only {success, puid, approval_url, state, error_msg}.
+    """
+    result = {
+        "success": True,
+        "puid": "p1",
+        "approval_url": "u1",
+        "state": "COMPLETED",
+        "error_msg": None,
+        "last_operate": "agree",          # snake (no-workflow synthesis path)
+        "lastOperate": "AGREE",            # camel (prod approval reply contract)
+        "visibility": "private",          # private direct path
+        "visibility_field": "user_visibility",
+    }
+    client, _svc = make_client(result)
+
+    response = client.post(
+        "/openapi/v1/collaboration/bots/b1:entity1/public",
+        json={"public_scope": "user", "visibility": "public"},
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    # declared fields survive
+    assert data["success"] is True, data
+    assert data["puid"] == "p1", data
+    assert data["state"] == "COMPLETED", data
+    # last_operate (removed) and lastOperate (camel leak) are both absent
+    assert "last_operate" not in data, data
+    assert "lastOperate" not in data, data
+    # no extras surface at all — the response is locked to the declared fields
+    assert set(data) <= {"success", "puid", "approval_url", "state", "error_msg"}, data


### PR DESCRIPTION
## Problem

  `POST /openapi/v1/collaboration/bots/{bot_uuid}/public` returned a stray
  camelCase `lastOperate` key alongside the declared snake_case `last_operate`.
  The upstream approval reply (`ApprovalWorkflowPlugin.start_approval`) emits
  `lastOperate` (camelCase, per the plugin contract), but `BcsPublishResult`
  declared `last_operate` with `extra="allow"`. As a result the declared field
  stayed `null` while `lastOperate` leaked through as a stray extra key. The
  private direct path additionally leaked `visibility` / `visibility_field`.
  Callers could not reliably read the last-operate marker, and the response
  carried implementation keys that are no part of the public contract.

  ## Solution

  Lock `BcsPublishResult` to its declared fields:
  - Remove the `last_operate` field — it is no longer part of the public
    contract; callers track the ticket via `puid` / `approval_url` / `state`.
  - Switch `extra="allow"` → `extra="ignore"` so any undeclared key the upstream
    reply or the service emits (camelCase `lastOperate`, snake `last_operate`,
    `visibility` / `visibility_field`) is silently dropped rather than surfaced.

  The router is unchanged — enforcement lives on the model, so all three service
  return paths (prod approval, no-workflow, private direct) are covered
  uniformly. The class docstring was rewritten to match the locked surface and
  to satisfy the schema-docs gate (the model docstring becomes the OpenAPI
  schema `description`, which forbids RST/inline-markup markers).

  Rejected alternatives:
  - Normalizing the key in the router while keeping `extra="allow"` — would
    still forward-compat-leak any other key the prod approval reply adds later;
    the lock belongs on the response model.
  - `extra="forbid"` — would raise on the upstream/service keys instead of
    dropping them; the lock should be transparent, not a 500.

  ## Validation

  - New regression `test_publish_response_locks_to_declared_fields_drops_extras`
    in `tests/community/adapters/http/openapi_v1/test_collaboration_bots_endpoints.py`:
    feeds the service a dict carrying both casings of `last_operate` plus
    `visibility` / `visibility_field`, and asserts the response `data` keeps only
    `{success, puid, approval_url, state, error_msg}`. Watched it fail RED before
    the fix (`last_operate` leaked via `extra="allow"`), GREEN after.
  - Ran `tests/community/core/bot_public/`,
    `tests/community/adapters/http/openapi_v1/`, and
    `tests/community/endpoints/`: **2783 passed, 2 skipped**. Service-level
    assertions on `result["last_operate"]` / `result["visibility"]` stay green
    (the service return shape is untouched; only the HTTP response is locked).
  - `test_schema_docs.py::test_the_published_document_contains_nothing_internal`
    caught a backtick in the model docstring (surfaced as the OpenAPI schema
    `description`); rewrote the docstring marker-free and re-verified the gate.

  Not run: `bots.openapi.json` regeneration — the published gateway contract
  snapshot still carries the old `BcsPublishResult` block. Left for a follow-up
  so this change stays scoped to the backend model + test.

  ## Compatibility and risk

  Contract change: the public response no longer carries `last_operate`,
  `lastOperate`, `visibility`, or `visibility_field`. Callers should read
  `puid` / `approval_url` for the open ticket and `state` for an immediate
  outcome; `error_msg` is set when `success` is false. Surface narrowing only —
  no migration. Rollback: revert this two-file change.