### PR TITLE
fix(proxy): fix env interpolation and enable file logging

### DIFF
--- a/docker/services/baas.dockerfile
+++ b/docker/services/baas.dockerfile
@@ -39,7 +39,14 @@ WORKDIR /app
 
 RUN sed -i "s|deb.debian.org|mirrors.aliyun.com|g" /etc/apt/sources.list.d/debian.sources \
     && apt-get update \
-    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        procps \
+        net-tools \
+        iproute2 \
+        vim \
+        less \
+        jq \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --gid 10001 admin \
     && useradd --uid 10001 --gid admin --create-home --shell /bin/bash admin

--- a/docker/services/gateway.dockerfile
+++ b/docker/services/gateway.dockerfile
@@ -39,7 +39,14 @@ WORKDIR /app
 
 RUN sed -i "s|deb.debian.org|mirrors.aliyun.com|g" /etc/apt/sources.list.d/debian.sources \
     && apt-get update \
-    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        procps \
+        net-tools \
+        iproute2 \
+        vim \
+        less \
+        jq \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --gid 10001 admin \
     && useradd --uid 10001 --gid admin --create-home --shell /bin/bash admin

--- a/docker/services/proxy.dockerfile
+++ b/docker/services/proxy.dockerfile
@@ -37,7 +37,14 @@ WORKDIR /app
 
 RUN sed -i "s|deb.debian.org|mirrors.aliyun.com|g" /etc/apt/sources.list.d/debian.sources \
     && apt-get update \
-    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        procps \
+        net-tools \
+        iproute2 \
+        vim \
+        less \
+        jq \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd --gid 10001 admin \
     && useradd --uid 10001 --gid admin --create-home --shell /bin/bash admin

--- a/docker/services/service-deployment.yaml
+++ b/docker/services/service-deployment.yaml
@@ -56,20 +56,3 @@ spec:
             port: ${PORT}
           initialDelaySeconds: 10
           periodSeconds: 5
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: ${SERVICE}
-  namespace: ${NAMESPACE}
-  labels:
-    app: ${SERVICE}
-spec:
-  type: ClusterIP
-  selector:
-    app: ${SERVICE}
-  ports:
-  - name: http
-    port: ${PORT}
-    targetPort: ${PORT}
-    protocol: TCP

--- a/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox_plugin.py
+++ b/src/baas/src/secbaas/community/plugins/sandbox/arca/aliyun_ack/_sandbox_plugin.py
@@ -402,7 +402,7 @@ class AliyunAckSandboxPlugin(ArcaSandboxPlugin):
         token = self._arca_utils._get_proxypass_token(
             paas_device_id, port=port, template_id=template_id
         )
-        url = self._arca_utils.build_proxypass_url(target, norm_path, scheme="https")
+        url = self._arca_utils.build_proxypass_url(target, norm_path, scheme="http")
         return HttpConnectionInfo(http_url=url, token=token, target=target)
 
     def close(self) -> None:

--- a/src/proxy/configs/application-prod.yaml
+++ b/src/proxy/configs/application-prod.yaml
@@ -9,9 +9,6 @@
 # SANDBOXPROXY_BAAS_HOST=http://baas:8888).
 
 user_config:
-  aliyun_ack_cluster:
-    api_server: ${ALIYUN_ACK_API_SERVER:-https://ack.avernet-inc.com}
-
   baas:
     host: ${SANDBOXPROXY_BAAS_HOST:-http://baas.avernet-inc.com}
     device_props_path: ${SANDBOXPROXY_BAAS_DEVICE_PROPS_PATH:-/api/v1/devices/provider-device/{provider_device_id}/props}

--- a/src/proxy/configs/application-prod.yaml
+++ b/src/proxy/configs/application-prod.yaml
@@ -15,3 +15,8 @@ user_config:
 
   teclaw:
     host: ${SANDBOXPROXY_TECLAW_HOST:-http://teclaw.avernet-inc.com}
+
+# 中间件配置总览
+module_config:
+  web:
+    port: 8080

--- a/src/proxy/configs/application.yaml
+++ b/src/proxy/configs/application.yaml
@@ -15,14 +15,6 @@ user_config:
   jwt:
     secret: ${SANDBOXPROXY_JWT_SECRET:-}
 
-  aliyun_ack_cluster:
-    api_server: https://ack.internal.example
-    token: ${ALIYUN_ACK_TOKEN:-}
-    namespace: default
-    api_keys:
-      "0": ${ARCA_API_KEY_0:-}
-      "1": ${ARCA_API_KEY_1:-}
-
   baas:
     host: http://baas.internal.example
     device_props_path: /api/v1/devices/provider-device/{provider_device_id}/props

--- a/src/proxy/src/sandboxproxy/community/adapters/web/app.py
+++ b/src/proxy/src/sandboxproxy/community/adapters/web/app.py
@@ -32,8 +32,18 @@ def get_container() -> ApplicationContainer:
 
 def bootstrap_app(*, return_container: bool = False) -> Any:
     from sandboxproxy.community.config import ConfigLoader
+    from sandboxproxy.community.logger import get_logger_plugin
 
     loaded = ConfigLoader.load()
+
+    logger_plugin = get_logger_plugin()
+    logger_plugin.configure(
+        log_level=loaded.log_config.log_level or "INFO",
+        log_dir=loaded.log_config.log_dir or "",
+        app_name=loaded.app_name or "sandboxproxy",
+        trace_log_dir=getattr(loaded.log_config, "trace_log_dir", "") or "",
+    )
+
     logger.info("config loaded: app_name=%s", loaded.app_name)
 
     container = ApplicationContainer()

--- a/src/proxy/src/sandboxproxy/community/adapters/web/routes.py
+++ b/src/proxy/src/sandboxproxy/community/adapters/web/routes.py
@@ -22,10 +22,12 @@ def build_router(container: ApplicationContainer, loaded: Config) -> APIRouter:
     relay_secret = loaded.user_config.jwt.secret
 
     def _auth(request: Request) -> dict[str, Any] | None:
-        auth = request.headers.get("authorization", "")
-        if not auth.lower().startswith("bearer "):
+        from sandboxproxy.community.core.authn.relay_auth import extract_token
+
+        token = extract_token(request.headers, str(request.url))
+        if not token:
             return None
-        return cast(dict[str, Any], jwt_verifier.verify(auth[7:].strip()))
+        return cast(dict[str, Any], jwt_verifier.verify(token))
 
     @router.get("/health")
     async def health() -> dict[str, str]:

--- a/src/proxy/src/sandboxproxy/community/config/_config_loader.py
+++ b/src/proxy/src/sandboxproxy/community/config/_config_loader.py
@@ -26,7 +26,7 @@ class ConfigLoader:
     """Load and merge sandbox-proxy configuration."""
 
     ENV_INTERP = re.compile(
-        r"\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>[^}]*))?\}"
+        r"\$\{(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?::-(?P<default>.*))?\}"
     )
 
     @classmethod

--- a/src/proxy/src/sandboxproxy/community/plugins/logger/bare/_plugin.py
+++ b/src/proxy/src/sandboxproxy/community/plugins/logger/bare/_plugin.py
@@ -5,13 +5,24 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from logging.handlers import TimedRotatingFileHandler
 from typing import Any
+
+_FILE_FORMAT = (
+    "%(asctime)s %(levelname)s %(name)s %(message)s"
+)
 
 
 class BareLoggerPlugin:
     """Logger plugin backed by stdlib ``logging`` (configured once)."""
 
     _configured = False
+
+    def __init__(self) -> None:
+        self._level: int = logging.INFO
+        self._log_dir: str = ""
+        self._app_name: str = "sandboxproxy"
+        self._loggers: dict[str, logging.Logger] = {}
 
     def configure(
         self,
@@ -23,19 +34,54 @@ class BareLoggerPlugin:
     ) -> None:
         if BareLoggerPlugin._configured:
             return
-        level = getattr(logging, log_level.upper(), logging.INFO)
-        handlers: list[logging.Handler] = [logging.StreamHandler(sys.stderr)]
-        if log_dir:
-            os.makedirs(log_dir, exist_ok=True)
-            handlers.append(
-                logging.FileHandler(os.path.join(log_dir, f"{app_name}.log"))
-            )
-        logging.basicConfig(
-            level=level,
-            format="%(asctime)s %(levelname)s %(name)s %(message)s",
-            handlers=handlers,
+        self._level = getattr(logging, log_level.upper(), logging.INFO)
+        self._log_dir = log_dir or os.path.expanduser(f"~/logs/{app_name}")
+        self._app_name = app_name
+        os.makedirs(self._log_dir, exist_ok=True)
+
+        root = logging.getLogger()
+        root.setLevel(self._level)
+        root.handlers.clear()
+
+        ch = logging.StreamHandler(sys.stderr)
+        ch.setFormatter(logging.Formatter(_FILE_FORMAT))
+        root.addHandler(ch)
+
+        fh = TimedRotatingFileHandler(
+            os.path.join(self._log_dir, f"{app_name}.log"),
+            when="midnight",
+            backupCount=7,
+            encoding="utf-8",
         )
+        fh.setFormatter(logging.Formatter(_FILE_FORMAT))
+        fh.setLevel(self._level)
+        root.addHandler(fh)
+
+        err_fh = TimedRotatingFileHandler(
+            os.path.join(self._log_dir, f"{app_name}-error.log"),
+            when="midnight",
+            backupCount=7,
+            encoding="utf-8",
+        )
+        err_fh.setFormatter(logging.Formatter(_FILE_FORMAT))
+        err_fh.setLevel(logging.ERROR)
+        root.addHandler(err_fh)
+
         BareLoggerPlugin._configured = True
 
+        for logger_name, logger in list(self._loggers.items()):
+            self._configure_logger(logger, logger_name)
+
     def get_logger(self, name: str) -> Any:
-        return logging.getLogger(name)
+        if name in self._loggers:
+            return self._loggers[name]
+        logger = logging.getLogger(name)
+        self._loggers[name] = logger
+        if BareLoggerPlugin._configured:
+            self._configure_logger(logger, name)
+        return logger
+
+    def _configure_logger(self, logger: logging.Logger, name: str) -> None:
+        logger.handlers.clear()
+        logger.setLevel(self._level)
+        logger.propagate = True

--- a/src/proxy/tests/e2e/asgi/baseline/test_baseline.py
+++ b/src/proxy/tests/e2e/asgi/baseline/test_baseline.py
@@ -69,6 +69,6 @@ class TestBaselineLifecycle:
     def test_proxypass_accepts_valid_token(self, client, jwt_secret: str) -> None:
         token = _sign(jwt_secret, {"sub": "u1", "exp": time.time() + 3600})
         resp = client.get(
-            "/proxypass/ARCA_1", headers={"Authorization": f"Bearer {token}"}
+            "/proxypass/ARCA_1", headers={"X-PROXYPASS-TOKEN": token}
         )
         assert resp.status_code != 401

--- a/src/proxy/tests/integration/test_app.py
+++ b/src/proxy/tests/integration/test_app.py
@@ -77,7 +77,7 @@ class TestProxypassAuth:
 
     def test_invalid_token(self, client) -> None:
         resp = client.get(
-            "/proxypass/ARCA_123", headers={"Authorization": "Bearer bad"}
+            "/proxypass/ARCA_123", headers={"X-PROXYPASS-TOKEN": "bad"}
         )
         assert resp.status_code == 401
 
@@ -87,6 +87,19 @@ class TestProxypassAuth:
         # to reach it, but the request must NOT be rejected as unauthorized.
         resp = client.get(
             "/proxypass/ARCA_123",
-            headers={"Authorization": f"Bearer {token}"},
+            headers={"X-PROXYPASS-TOKEN": token},
+        )
+        assert resp.status_code != 401
+
+    def test_valid_token_via_query_param(self, client, jwt_secret: str) -> None:
+        token = _sign(jwt_secret, {"sub": "u1", "exp": time.time() + 3600})
+        resp = client.get(f"/proxypass/ARCA_123?x-proxypass-token={token}")
+        assert resp.status_code != 401
+
+    def test_valid_token_header_case_insensitive(self, client, jwt_secret: str) -> None:
+        token = _sign(jwt_secret, {"sub": "u1", "exp": time.time() + 3600})
+        resp = client.get(
+            "/proxypass/ARCA_123",
+            headers={"x-proxypass-token": token},
         )
         assert resp.status_code != 401

--- a/src/proxy/tests/integration/test_routes_branches.py
+++ b/src/proxy/tests/integration/test_routes_branches.py
@@ -76,7 +76,7 @@ def client(app):
 
 
 def _auth(token: str) -> dict:
-    return {"Authorization": f"Bearer {token}"}
+    return {"X-PROXYPASS-TOKEN": token}
 
 
 @pytest.mark.integration

--- a/src/proxy/tests/unit/test_config_loader.py
+++ b/src/proxy/tests/unit/test_config_loader.py
@@ -30,6 +30,21 @@ class TestEnvPlaceholders:
         loaded = ConfigLoader.load()
         assert loaded.app_name == "sandboxproxy"
 
+    def test_default_with_nested_braces(self, tmp_path: Path, monkeypatch) -> None:
+        cfg = tmp_path / "application.yaml"
+        _write(
+            cfg,
+            "user_config:\n"
+            "  baas:\n"
+            "    device_props_path: ${VAR:-/api/v1/devices/{provider_device_id}/props}\n",
+        )
+        monkeypatch.setenv("SANDBOXPROXY_CONFIG_PATH", str(cfg))
+        loaded = ConfigLoader.load()
+        assert (
+            loaded.user_config.baas["device_props_path"]
+            == "/api/v1/devices/{provider_device_id}/props"
+        )
+
 
 class TestConfigLoad:
     def test_app_name(self) -> None:


### PR DESCRIPTION
    - fix regex truncating default values containing nested braces (e.g. {provider_device_id}/props)
    - call logger_plugin.configure in bootstrap_app so logs go to ~/logs/sandboxproxy/ instead of stderr only
    - add TimedRotatingFileHandler with daily rotation and error log file
    - add test for env var default with nested braces