### PR TITLE
ci(bcs): publish panel package with npm OIDC

### DIFF
--- a/.github/workflows/publish-bcs-panel.yml
+++ b/.github/workflows/publish-bcs-panel.yml
@@ -1,0 +1,64 @@
+name: Publish BCS panel
+
+on:
+  push:
+    tags:
+      - 'bcs-panel-v*'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: publish-bcs-panel-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: src/bcs/assets/panel
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify tagged commit is on dev
+        shell: bash
+        run: |
+          if ! git merge-base --is-ancestor HEAD refs/remotes/origin/dev; then
+            echo "The release tag must point to a commit that has been merged into dev."
+            exit 1
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Verify tag matches package version
+        shell: bash
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          expected_tag="bcs-panel-v${package_version}"
+
+          if [[ "${GITHUB_REF_NAME}" != "${expected_tag}" ]]; then
+            echo "Expected tag ${expected_tag}, but workflow was triggered by ${GITHUB_REF_NAME}."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Inspect package contents
+        run: npm pack --dry-run
+
+      - name: Publish package
+        run: npm publish

--- a/src/bcs/assets/panel/PUBLISHING.md
+++ b/src/bcs/assets/panel/PUBLISHING.md
@@ -1,0 +1,155 @@
+# Publishing the BCS Panel Package
+
+The `@avernet-assets/bcs-panel` package is published from this directory by
+the `publish-bcs-panel.yml` GitHub Actions workflow. A tag named
+`bcs-panel-v<version>` starts the workflow. For example, package version
+`1.2.1` must be released with tag `bcs-panel-v1.2.1`. The tagged commit must
+already be part of the `dev` branch.
+
+Publishing uses npm trusted publishing (OIDC). Do not create an npm publish
+token or add `NPM_TOKEN` to the GitHub repository.
+
+## Configure npm OIDC
+
+As an owner of `@avernet-assets/bcs-panel`, open the package settings on
+npmjs.com, add a **Trusted Publisher**, and enter these values:
+
+| Field | Value |
+| --- | --- |
+| Publisher | GitHub Actions |
+| Organization or user | `inclusionAI` |
+| Repository | `Avernet` |
+| Workflow filename | `publish-bcs-panel.yml` |
+| Environment name | Leave empty |
+| Allowed action | `npm publish` |
+
+The workflow filename is case-sensitive. Enter only the filename, not
+`.github/workflows/publish-bcs-panel.yml`.
+
+The workflow runs on a GitHub-hosted runner and grants only `contents: read`
+and `id-token: write`. npm exchanges the workflow's short-lived OIDC identity
+for publish access and automatically records package provenance for a public
+repository and public package.
+
+## Package metadata
+
+Keep these fields in `package.json` when changing the package metadata:
+
+```json
+{
+  "name": "@avernet-assets/bcs-panel",
+  "version": "<version>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/inclusionAI/Avernet.git",
+    "directory": "src/bcs/assets/panel"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "files": [
+    "dist/index.umd.js",
+    "README.md",
+    "PUBLISHING.md",
+    "LICENSE"
+  ]
+}
+```
+
+- `name` must be the npm package configured with the trusted publisher.
+- `version` must exactly match the version in the release tag.
+- `repository.url` must exactly match the public GitHub repository. The
+  `repository.directory` field identifies this package inside the monorepo.
+- `publishConfig` makes the scoped package public and prevents accidental
+  publication to another registry.
+- `files` is the public-package allowlist. Add a file only when npm consumers
+  need it.
+
+Trusted publishing does not require an auth token, an `.npmrc` file, or a
+`provenance` field in `package.json`. Provenance is automatic for this OIDC
+workflow.
+
+## Prepare a release
+
+Install the locked dependencies from the package directory:
+
+```bash
+cd src/bcs/assets/panel
+npm ci
+```
+
+Then update the package version. Choose exactly one of `patch`, `minor`, or
+`major` according to the release's compatibility impact:
+
+```bash
+npm version patch --no-git-tag-version
+```
+
+This updates both `package.json` and `package-lock.json`. Verify the updated
+version and inspect its package archive:
+
+```bash
+npm run verify
+npm pack --dry-run
+```
+
+Review the dry-run file list and confirm that it contains the intended UMD
+bundle, documentation, and license without source files, credentials, or local
+build state. Commit the version files with the package changes and open the
+normal release pull request:
+
+```bash
+panel_version="$(node -p "require('./package.json').version")"
+git add package.json package-lock.json
+git commit -m "chore(bcs): release panel v${panel_version}"
+```
+
+Target the release pull request to `dev`. Do not create the release tag before
+the version change is reviewed and merged.
+
+## Publish the merged version
+
+After the release pull request is merged, check out the merged commit, read its
+package version, and create the matching annotated tag:
+
+```bash
+cd src/bcs/assets/panel
+panel_version="$(node -p "require('./package.json').version")"
+cd ../../../..
+git tag -a "bcs-panel-v${panel_version}" -m "Release BCS panel v${panel_version}"
+git push origin "bcs-panel-v${panel_version}"
+```
+
+The workflow checks that the tagged commit is part of `dev` and that the tag is
+exactly `bcs-panel-v<package version>`. It then installs dependencies with
+`npm ci`, runs the package dry run (which triggers the `prepack` verification),
+and publishes from `src/bcs/assets/panel`. `npm publish` runs the same `prepack`
+verification again before uploading.
+
+Follow the **Publish BCS panel** run in GitHub Actions. After it succeeds,
+verify the registry version:
+
+```bash
+npm view @avernet-assets/bcs-panel version
+```
+
+## Troubleshooting
+
+- **Tag/version mismatch:** delete the incorrect local tag without pushing it,
+  or create a new version commit and tag. Never change a published version's
+  contents.
+- **Tagged commit is not on `dev`:** merge the release pull request into `dev`,
+  then create the tag on the merged commit.
+- **`ENEEDAUTH`:** confirm that the npm trusted publisher uses organization
+  `inclusionAI`, repository `Avernet`, and the exact workflow filename
+  `publish-bcs-panel.yml`. Also confirm the job still has `id-token: write`.
+- **Version already exists:** npm versions are immutable. Increment the package
+  version, merge that change, and create a new matching tag.
+- **Bad published release:** publish a corrected patch version. If consumers
+  must be warned, a package owner can deprecate the affected version on npm.
+
+## References
+
+- [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/)
+- [GitHub Actions OIDC](https://docs.github.com/en/actions/concepts/security/openid-connect)

--- a/src/bcs/assets/panel/README.md
+++ b/src/bcs/assets/panel/README.md
@@ -5,7 +5,7 @@ Open-source side-panel components bundled as a UMD asset for BCS.
 ## Install From npm
 
 ```bash
-npm install @avernet-assets/bcs-panel@1.2.0
+npm install @avernet-assets/bcs-panel
 ```
 
 The prebuilt UMD bundle is installed at:
@@ -24,7 +24,7 @@ reproducible and can be rolled back safely:
 [[manifest.bundles]]
 name = "bcsPanel"
 type = "url"
-url = "https://cdn.jsdelivr.net/npm/@avernet-assets/bcs-panel@1.2.0/dist/index.umd.js"
+url = "https://cdn.jsdelivr.net/npm/@avernet-assets/bcs-panel@<exact-version>/dist/index.umd.js"
 ```
 
 Do not use an unversioned URL or the `latest` dist-tag in production.
@@ -73,13 +73,21 @@ which is the entry name used by `bcsPanel.StateMachineRunView`.
 
 ## Publishing
 
-Review the package contents before publishing a public release:
+Releases are published by GitHub Actions when a maintainer pushes a tag named
+`bcs-panel-v<version>`. The tag version must exactly match the `version` in
+`package.json`.
+
+Configure `@avernet-assets/bcs-panel` with the `publish-bcs-panel.yml` trusted
+publisher on npm. The workflow uses OIDC and does not require an npm token.
+
+Review the package contents locally before opening a release pull request:
 
 ```bash
+npm ci
+npm run verify
 npm pack --dry-run
-npm publish --access public
 ```
 
-The `prepack` lifecycle runs type checking, creates a fresh UMD bundle, verifies
-its runtime export contract, and scans the public package content before either
-command creates the package archive.
+The `prepack` lifecycle also runs verification before the GitHub Action creates
+or publishes the package archive. See [PUBLISHING.md](PUBLISHING.md) for the
+OIDC configuration, versioning, tag, verification, and troubleshooting steps.

--- a/src/bcs/assets/panel/package.json
+++ b/src/bcs/assets/panel/package.json
@@ -19,6 +19,7 @@
   "files": [
     "dist/index.umd.js",
     "README.md",
+    "PUBLISHING.md",
     "LICENSE"
   ],
   "scripts": {

--- a/src/bcs/assets/panel/scripts/public-scan.mjs
+++ b/src/bcs/assets/panel/scripts/public-scan.mjs
@@ -5,6 +5,7 @@ const root = process.cwd();
 const targets = [
   'src',
   'README.md',
+  'PUBLISHING.md',
   'package.json',
   'package-lock.json',
   'vite.config.ts',


### PR DESCRIPTION
## Problem

The `@avernet-assets/bcs-panel` package did not have an automated, package-specific npm release workflow. Publishing relied on manual commands and lacked enforced tag/version consistency, reviewed-commit checks, and a documented npm Trusted Publisher setup.

## Solution

- Add a GitHub Actions workflow triggered by `bcs-panel-v*` tags.
- Publish to npm through Trusted Publishing with OIDC, without an npm token.
- Require the release tag version to match `package.json`.
- Reject tags whose commits have not been merged into `dev`.
- Run `npm ci` and `npm pack --dry-run` before publishing.
- Add an OIDC release guide covering npm configuration, versioning, tagging, verification, and troubleshooting.
- Include the publishing guide in the npm package and public-content scan.
- Remove version-specific install examples that would become stale after releases.

## Validation

- `npm ci` — passed.
- `npm pack --dry-run` — passed.
  - TypeScript type check passed.
  - Vite production build passed.
  - UMD export contract test passed.
  - Public-content scan passed.
  - Package contents contained the expected five files.
- GitHub Actions workflow YAML parsing — passed.
- Tag/package-version match and mismatch checks — passed.
- Tagged-commit ancestry check against `origin/dev` — passed.
- `git diff --check` — passed.

The final `npm publish` step was not executed locally because it would create an immutable public package version. It will be exercised by the release tag workflow after the npm Trusted Publisher is configured.

## Compatibility and risk

This change does not modify BCS runtime behavior, service contracts, or the panel bundle API.

Publishing now requires the npm Trusted Publisher configuration to match:

- Organization: `inclusionAI`
- Repository: `Avernet`
- Workflow: `publish-bcs-panel.yml`

Tags with a mismatched version or commits outside `dev` fail before publication. Published npm versions are immutable; a faulty release must be corrected with a new patch version and, when necessary, the affected version should be deprecated.