### PR TITLE
fix(backend): map MCP permission denials to forbidden

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -363,6 +363,7 @@ from agentclaw.community.core.caller_identity.contracts import (  # noqa: E402
     CallerMcpSyncError,
 )
 from agentclaw.community.core.skill_center.errors import (  # noqa: E402
+    McpPermissionDeniedError,
     SkillSetAccessDeniedError,
     SkillSetControlPlaneConflictError,
     SkillSetControlPlaneLockUnavailableError,
@@ -400,6 +401,7 @@ _DOMAIN_ERROR_STATUS_MAP: dict[type[DomainError], int] = {
     # decides the wire, exactly as every other domain error already works.
     SkillSetControlPlaneNotFoundError: 404,
     SkillSetAccessDeniedError: 403,
+    McpPermissionDeniedError: 403,
     # 400, not 409: the published wire echoes the reason code as a rejected
     # request and clients already parse it that way. Kept as-is deliberately.
     SkillSetControlPlaneConflictError: 400,

--- a/src/backend/src/agentclaw/community/core/skill_center/errors.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/errors.py
@@ -174,5 +174,8 @@ class SkillSetManagedResourceError(Exception):
     """A Direct command targets a resource managed by an ordinary SkillSet."""
 
 
-class McpPermissionDeniedError(Exception):
+class McpPermissionDeniedError(DomainError):
     """The actor cannot install or activate the addressed MCP server."""
+
+    def __init__(self, detail: str = "MCP permission denied") -> None:
+        super().__init__(detail)

--- a/src/backend/tests/community/adapters/http/skill_center/test_skillset_error_status_mapping.py
+++ b/src/backend/tests/community/adapters/http/skill_center/test_skillset_error_status_mapping.py
@@ -21,6 +21,7 @@ from fastapi.testclient import TestClient
 
 from agentclaw.community.core.errors import DomainError
 from agentclaw.community.core.skill_center.errors import (
+    McpPermissionDeniedError,
     SkillSetAccessDeniedError,
     SkillSetControlPlaneConflictError,
     SkillSetControlPlaneLockUnavailableError,
@@ -29,6 +30,7 @@ from agentclaw.community.core.skill_center.errors import (
 )
 
 _ROUTE_MAP: dict[str, type[DomainError]] = {
+    "mcp-denied": McpPermissionDeniedError,
     "notfound": SkillSetControlPlaneNotFoundError,
     "denied": SkillSetAccessDeniedError,
     "conflict": SkillSetControlPlaneConflictError,
@@ -92,6 +94,7 @@ def client() -> TestClient:
 @pytest.mark.parametrize(
     "which,expected_status,expected_detail",
     [
+        ("mcp-denied", 403, "MCP permission denied"),
         ("notfound", 404, "Skill set not found"),
         ("denied", 403, "Forbidden"),
         ("conflict", 400, "Skill set operation conflict"),


### PR DESCRIPTION
## Problem
Legacy `/api/skillsets/{id}/mcps` requests surfaced `McpPermissionDeniedError` through the generic exception handler, returning HTTP 500 for an authorization denial. The Gateway surface already maps the same domain outcome to HTTP 403 with code `403202`.

## Solution
Make `McpPermissionDeniedError` a transport-agnostic `DomainError` with a stable default detail and map it to HTTP 403 in the shared HTTP adapter. Legacy BFF keeps its existing `{"detail": ...}` envelope while Gateway keeps its existing public error mapping.

## Validation
- Red/green regression: legacy app handler returned 500 before the change and 403 after it.
- `57 passed`: SkillSet HTTP status mapping and OpenAPI response mapping suites.
- `9 passed`: domain-error completeness and MCP control-plane focused tests.
- `ruff` passed for the changed domain-error and regression-test files. `app.py` retains four unrelated pre-existing lint findings (duplicate task imports and duplicate callback map keys).
- `git diff --check` passed.

## Compatibility and risk
No request schema, database schema, or Gateway error code changes. The only wire change is the legacy BFF permission-denied response status from 500 to 403.