### PR TITLE
feat(bcs): support bot identity for group and session APIs

### DIFF
--- a/src/bcs/api-contracts/v1/openapi/groups.yaml
+++ b/src/bcs/api-contracts/v1/openapi/groups.yaml
@@ -102,8 +102,10 @@ GroupsPath:
     tags: ["Collaboration / Groups"]
     summary: Create a collaboration group or direct-message group.
     x-avernet-security:
-      user: required
+      user: optional
       app: required
+      bot: optional
+    x-bcn-identity-policy: human_or_owned_bot
     requestBody:
       required: true
       content:
@@ -152,7 +154,10 @@ GroupsPath:
             schema:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
-        description: A selected Bot is not collaboration-eligible.
+        description: >-
+          No Human or Bot Actor is available, the authenticated User/Bot
+          ownership claims conflict, or a selected Bot is not
+          collaboration-eligible.
         x-error-codes:
           - forbidden
         content:
@@ -250,8 +255,10 @@ GroupPath:
     tags: ["Collaboration / Groups"]
     summary: Get target-independent group detail.
     x-avernet-security:
-      user: required
+      user: optional
       app: required
+      bot: optional
+    x-bcn-identity-policy: human_or_owned_bot
     parameters:
       - $ref: ../shared.yaml#/GroupIdPath
     responses:
@@ -279,9 +286,9 @@ GroupPath:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
         description: >-
-          Neither the authenticated User's Human Actor nor a Bot created by
-          that Human is a Group Participant. Public groups are exempt from
-          this check and are readable by any authenticated caller.
+          The selected HumanOrOwnedBot Principal has no authorized participant
+          relation to the Group and is not the authenticated Bot management
+          actor. Public groups are exempt from this resource check.
         x-error-codes:
           - forbidden
         content:
@@ -311,8 +318,10 @@ GroupPath:
     tags: ["Collaboration / Groups"]
     summary: Update the explicitly mutable group properties.
     x-avernet-security:
-      user: required
+      user: optional
       app: required
+      bot: optional
+    x-bcn-identity-policy: human_or_owned_bot
     parameters:
       - $ref: ../shared.yaml#/GroupIdPath
     requestBody:
@@ -347,13 +356,10 @@ GroupPath:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
         description: >-
-          Principal cannot manage the group. A Human Principal may manage when
-          it can act as at least one Group management actor: the driver,
-          originator, or ManagerWorker manager participant. Human-to-actor authority is
-          checked only against these target actors: direct human_{user.id}, a
-          Bot whose created_by equals the Human user id, or a creator relation
-          edge from human_{user.id} to that Bot. The server does not enumerate
-          every Bot created by the Human for this authorization decision.
+          Principal cannot manage the group. A Bot Principal must itself be a
+          Group management actor: the driver, originator, or ManagerWorker
+          manager participant. A Human Principal may act directly or through
+          ownership or a creator relation to one of those actors.
         x-error-codes:
           - forbidden
         content:
@@ -386,8 +392,10 @@ GroupPath:
     tags: ["Collaboration / Groups"]
     summary: Delete a group using the authenticated Principal as caller.
     x-avernet-security:
-      user: required
+      user: optional
       app: required
+      bot: optional
+    x-bcn-identity-policy: human_or_owned_bot
     parameters:
       - $ref: ../shared.yaml#/GroupIdPath
       - $ref: ../shared.yaml#/ActingBotIdQuery
@@ -416,11 +424,9 @@ GroupPath:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
         description: >-
-          Principal cannot delete the group. A Human Principal may delete when
-          it can act as at least one Group management actor: the driver,
-          originator, or ManagerWorker manager participant. Human-to-actor authority is
-          checked only against these target actors rather than by enumerating
-          all Bots created by the Human.
+          Principal cannot delete the group. A Bot Principal must itself be a
+          Group management actor. A Human Principal may act directly or
+          through ownership or a creator relation to a management actor.
         x-error-codes:
           - forbidden
         content:
@@ -597,14 +603,13 @@ CreateCollaborationGroup:
     originator:
       type: string
       description: >
-        Optional caller-designated originator. Omitted (or set to the
-        authenticated user `human_<staff_no>`) sets the originator to the
-        calling user. When set to any other value, it must identify either
-        the caller-self or a registered Bot the caller owns (`created_by`
-        matches the caller); otherwise the request is rejected. When it is
-        a caller-owned Bot distinct from the driver, the driver must be
-        reachable from that originator (public visibility, or a friend of
-        it). The `dm` group kind does not carry an originator.
+        Optional caller-designated originator. When omitted, the selected
+        HumanOrOwnedBot Principal becomes the originator. A Human Principal
+        may instead select a registered Bot it owns (`created_by` matches the
+        caller). A Bot Principal may select only itself. When a Human selects
+        an owned Bot distinct from the driver, the driver must be reachable
+        from that originator (public visibility, or a friend of it). The `dm`
+        group kind does not carry an originator.
     event_subscriptions:
       type: array
       maxItems: 32

--- a/src/bcs/api-contracts/v1/openapi/sessions.yaml
+++ b/src/bcs/api-contracts/v1/openapi/sessions.yaml
@@ -125,7 +125,7 @@ GroupSessionsPath:
     summary: Create a Session under a Group.
     x-avernet-security:
       user: optional
-      app: optional
+      app: required
       bot: optional
     x-bcn-identity-policy: human_or_owned_bot
     parameters:
@@ -271,8 +271,10 @@ SessionPath:
     tags: ["Collaboration / Sessions"]
     summary: Get session detail.
     x-avernet-security:
-      user: required
+      user: optional
       app: required
+      bot: optional
+    x-bcn-identity-policy: human_or_owned_bot
     parameters:
       - $ref: ../shared.yaml#/SessionIdPath
     responses:
@@ -300,8 +302,7 @@ SessionPath:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
         description: >-
-          Neither the authenticated User's Human Actor nor a Bot created by
-          that Human is a Session Participant.
+          The selected HumanOrOwnedBot Principal is not a Session Participant.
         x-error-codes:
           - forbidden
         content:
@@ -323,8 +324,10 @@ SessionPath:
     tags: ["Collaboration / Sessions"]
     summary: Update the explicitly mutable session properties.
     x-avernet-security:
-      user: required
+      user: optional
       app: required
+      bot: optional
+    x-bcn-identity-policy: human_or_owned_bot
     parameters:
       - $ref: ../shared.yaml#/SessionIdPath
     requestBody:
@@ -358,14 +361,10 @@ SessionPath:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
         description: >-
-          Principal cannot manage the session. A Human Principal may manage
-          when it can act as the Session creator or at least one parent Group
-          management actor: the driver, originator, or ManagerWorker manager participant.
-          Human-to-actor authority is checked only against these target actors:
-          direct human_{user.id}, a Bot whose created_by equals the Human user
-          id, or a creator relation edge from human_{user.id} to that Bot. The
-          server does not enumerate every Bot created by the Human for this
-          authorization decision.
+          Principal cannot manage the session. A Bot Principal must itself be
+          the Session creator or a parent Group management actor. A Human
+          Principal may act directly or through ownership or a creator
+          relation to one of those actors.
         x-error-codes:
           - forbidden
         content:
@@ -395,8 +394,10 @@ SessionPath:
     tags: ["Collaboration / Sessions"]
     summary: Delete a session using the authenticated Principal as caller.
     x-avernet-security:
-      user: required
+      user: optional
       app: required
+      bot: optional
+    x-bcn-identity-policy: human_or_owned_bot
     parameters:
       - $ref: ../shared.yaml#/SessionIdPath
       - $ref: ../shared.yaml#/ActingBotIdQuery
@@ -425,11 +426,10 @@ SessionPath:
               $ref: ../shared.yaml#/ErrorEnvelope
       "403":
         description: >-
-          Principal cannot delete the session. A Human Principal may delete
-          when it can act as the Session creator or at least one parent Group
-          management actor. Human-to-actor authority is checked only against
-          those target actors rather than by enumerating all Bots created by
-          the Human.
+          Principal cannot delete the session. A Bot Principal must itself be
+          the Session creator or a parent Group management actor. A Human
+          Principal may act directly or through ownership or a creator
+          relation to one of those actors.
         x-error-codes:
           - forbidden
         content:

--- a/src/bcs/api-contracts/v1/shared.yaml
+++ b/src/bcs/api-contracts/v1/shared.yaml
@@ -61,7 +61,10 @@ ActingBotIdQuery:
   name: acting_bot_id
   in: query
   required: false
-  description: Optional Bot identity perspective for the delete decision. Omit to evaluate the authenticated Human perspective.
+  description: >-
+    Optional Bot identity perspective for the delete decision. A Human caller
+    may select an owned Bot; a Bot caller may select only itself. Omit to use
+    the selected HumanOrOwnedBot Principal.
   schema:
     type: string
     minLength: 1

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
@@ -40,7 +40,9 @@ use serde_json::Value;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::error::HttpAdapterError;
-use crate::routes::group_messages::{application_caller, resolve_group_chat_caller};
+use crate::routes::group_messages::{
+    GroupChatCaller, application_caller, resolve_group_chat_caller,
+};
 use crate::state::HttpAppState;
 
 use super::{
@@ -445,9 +447,15 @@ async fn create_group_with_inline_subscriptions(
     req: CreateGroupRequest,
 ) -> Response {
     let caller = match resolve_group_chat_caller(&state, &headers, &uri).await {
-        Ok(caller) => application_caller(&caller),
+        Ok(caller) => caller,
         Err(error) => return error.into_response(),
     };
+    if let GroupChatCaller::Bot { bot_uuid } = &caller
+        && let Err(error) = validate_container_header(&state, &headers, bot_uuid)
+    {
+        return error.into_response();
+    }
+    let caller = application_caller(&caller);
     if let Err(error) = validate_legacy_opening_message(&req) {
         return error.into_response();
     }
@@ -968,9 +976,15 @@ pub async fn patch_group(
         }
     };
     let caller = match resolve_group_chat_caller(&state, &headers, &uri).await {
-        Ok(caller) => application_caller(&caller),
+        Ok(caller) => caller,
         Err(error) => return error.into_response(),
     };
+    if let GroupChatCaller::Bot { bot_uuid } = &caller
+        && let Err(error) = validate_container_header(&state, &headers, bot_uuid)
+    {
+        return error.into_response();
+    }
+    let caller = application_caller(&caller);
     let Some(application) = state.group_application.as_ref() else {
         return legacy_group_error_response(
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/legacy_group_event_subscription_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/legacy_group_event_subscription_contract.rs
@@ -5,7 +5,7 @@ use axum::{
     body::{Body, to_bytes},
     http::{Request, StatusCode},
 };
-use bcs_auth_api::{AuthPluginChain, AuthPrincipal};
+use bcs_auth_api::{AuthConfig, AuthPluginChain, AuthPrincipal};
 use bcs_auth_local::StaticAuthPlugin;
 use bcs_http::{
     router::build_router,
@@ -133,6 +133,45 @@ fn test_router(service: Arc<RecordingGroupService>) -> axum::Router {
     build_router(state)
 }
 
+fn bot_test_router(service: Arc<RecordingGroupService>) -> axum::Router {
+    let principal = AuthPrincipal {
+        bot_uuid: Some("caller-bot".to_string()),
+        ..Default::default()
+    };
+    let auth_chain = Arc::new(AuthPluginChain::new(vec![Box::new(
+        StaticAuthPlugin::with_principal(principal),
+    )]));
+    let state = HttpAppState::new(Services::builder().build_for_test())
+        .with_group_application(service)
+        .with_auth_chain(auth_chain.clone(), AuthConfig::default())
+        .with_user_identity(Arc::new(ChainUserIdentityPort::new(auth_chain)))
+        .with_strict_container_validation(true);
+    build_router(state)
+}
+
+fn inline_subscription_body() -> Body {
+    Body::from(
+        json!({
+            "label": "Webhook group",
+            "driver_bot": "driver-bot",
+            "participants": [{
+                "bot_uuid": "driver-bot",
+                "role": "driver"
+            }],
+            "group_strategy": "chat",
+            "event_subscriptions": [{
+                "name": "group-webhook",
+                "event_filters": ["group.*"],
+                "sink": {
+                    "type": "webhook",
+                    "url": "http://127.0.0.1:28082/events"
+                }
+            }]
+        })
+        .to_string(),
+    )
+}
+
 #[tokio::test]
 async fn legacy_create_group_delegates_inline_subscriptions_to_v1_application() {
     let service = Arc::new(RecordingGroupService::default());
@@ -203,4 +242,57 @@ async fn legacy_create_group_delegates_inline_subscriptions_to_v1_application() 
         }
         CreateGroupSpec::DirectMessage(_) => panic!("expected collaboration group"),
     }
+}
+
+#[tokio::test]
+async fn legacy_bot_create_with_inline_subscriptions_preserves_container_validation() {
+    let service = Arc::new(RecordingGroupService::default());
+    let response = bot_test_router(service.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/groups")
+                .header("content-type", "application/json")
+                .header("X-BCS-Bot-Token", "valid-bot-token")
+                .header("x-agentclaw-bolt-id", "caller-bot")
+                .body(inline_subscription_body())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let (command, subscriptions) = service
+        .create
+        .lock()
+        .expect("create lock")
+        .take()
+        .expect("create command");
+    assert_eq!(
+        command.caller.bot.as_ref().map(|bot| bot.bot_uuid.as_str()),
+        Some("caller-bot")
+    );
+    assert!(command.caller.user.is_none());
+    assert_eq!(subscriptions.len(), 1);
+}
+
+#[tokio::test]
+async fn legacy_bot_create_with_inline_subscriptions_rejects_mismatched_container() {
+    let service = Arc::new(RecordingGroupService::default());
+    let response = bot_test_router(service.clone())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/groups")
+                .header("content-type", "application/json")
+                .header("X-BCS-Bot-Token", "valid-bot-token")
+                .header("x-agentclaw-bolt-id", "different-container")
+                .body(inline_subscription_body())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert!(service.create.lock().expect("create lock").is_none());
 }

--- a/src/bcs/crates/adapters/http/bcs-http/tests/legacy_group_patch_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/legacy_group_patch_contract.rs
@@ -5,7 +5,7 @@ use axum::{
     body::{Body, to_bytes},
     http::{Request, StatusCode},
 };
-use bcs_auth_api::{AuthPluginChain, AuthPrincipal};
+use bcs_auth_api::{AuthConfig, AuthPluginChain, AuthPrincipal};
 use bcs_auth_local::StaticAuthPlugin;
 use bcs_http::{
     router::build_router,
@@ -124,6 +124,22 @@ fn test_router(service: Arc<RecordingGroupService>) -> axum::Router {
     build_router(state)
 }
 
+fn bot_test_router(service: Arc<RecordingGroupService>) -> axum::Router {
+    let principal = AuthPrincipal {
+        bot_uuid: Some("caller-bot".to_string()),
+        ..Default::default()
+    };
+    let auth_chain = Arc::new(AuthPluginChain::new(vec![Box::new(
+        StaticAuthPlugin::with_principal(principal),
+    )]));
+    let state = HttpAppState::new(Services::builder().build_for_test())
+        .with_group_application(service)
+        .with_auth_chain(auth_chain.clone(), AuthConfig::default())
+        .with_user_identity(Arc::new(ChainUserIdentityPort::new(auth_chain)))
+        .with_strict_container_validation(true);
+    build_router(state)
+}
+
 fn service_returning(error: ApplicationError) -> Arc<RecordingGroupService> {
     Arc::new(RecordingGroupService {
         update: Mutex::new(None),
@@ -201,6 +217,58 @@ async fn legacy_patch_group_delegates_to_v1_group_application() {
             .bot_final_delivery,
         BotFinalDelivery::InjectObservers
     );
+}
+
+#[tokio::test]
+async fn legacy_bot_patch_group_preserves_container_validation() {
+    let service = Arc::new(RecordingGroupService::default());
+    let response = bot_test_router(service.clone())
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri("/groups/group-1")
+                .header("content-type", "application/json")
+                .header("X-BCS-Bot-Token", "valid-bot-token")
+                .header("x-agentclaw-bolt-id", "caller-bot")
+                .body(Body::from(json!({"name": "Renamed"}).to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let command = service
+        .update
+        .lock()
+        .expect("update lock")
+        .take()
+        .expect("update command");
+    assert_eq!(
+        command.caller.bot.as_ref().map(|bot| bot.bot_uuid.as_str()),
+        Some("caller-bot")
+    );
+    assert!(command.caller.user.is_none());
+}
+
+#[tokio::test]
+async fn legacy_bot_patch_group_rejects_mismatched_container() {
+    let service = Arc::new(RecordingGroupService::default());
+    let response = bot_test_router(service.clone())
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri("/groups/group-1")
+                .header("content-type", "application/json")
+                .header("X-BCS-Bot-Token", "valid-bot-token")
+                .header("x-agentclaw-bolt-id", "different-container")
+                .body(Body::from(json!({"name": "Renamed"}).to_string()))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert!(service.update.lock().expect("update lock").is_none());
 }
 
 #[tokio::test]

--- a/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
@@ -12,12 +12,13 @@ use bcs_service_api::application::v1::{
     DeleteGroup, DeleteGroupParticipant, DeleteResult, DirectMessageGroupDetail,
     DirectMessageGroupSummary, GetGroup, GroupDetail, GroupEventSubscriptionProvisioner,
     GroupKindFilter, GroupService, GroupStatus, GroupStrategy as V1GroupStrategy, GroupSummary,
-    GroupVisibility, HumanPrincipal, InlineGroupEventSubscriptionRequest, ListGroups,
-    ListPublicGroups, ManagerWorkerConfiguration, Membership, MembershipFilter, NormalGroupSummary, Page,
-    Participant as V1Participant, PreparedGroupEventSubscriptions, Principal,
+    GroupVisibility, HumanPrincipal, IdentityPolicy, InlineGroupEventSubscriptionRequest,
+    ListGroups, ListPublicGroups, ManagerWorkerConfiguration, Membership, MembershipFilter,
+    NormalGroupSummary, Page, Participant as V1Participant, PreparedGroupEventSubscriptions,
+    Principal,
     StateMachineConfiguration, StateMachineDefinition, StateMachineDefinitionReference,
     StateMachineParticipantBinding, UpdateGroup, UpdateGroupParticipant,
-    require_authenticated_user, require_human,
+    require_authenticated_user, require_human, select_principal,
 };
 use bcs_service_api::core::{GroupMutationCommand, GroupMutationKind};
 use bcs_service_api::types::{EventActor, EventActorType};
@@ -444,41 +445,6 @@ impl GroupServiceImpl {
         }
     }
 
-    async fn can_read_group_detail(
-        &self,
-        caller: &bcs_service_api::application::v1::AuthenticatedCaller,
-        group: &DomainGroup,
-    ) -> Result<bool, ApplicationError> {
-        let user = require_authenticated_user(caller)?;
-        let human_actor_id = format!("human_{}", user.id);
-        if group
-            .participants
-            .iter()
-            .any(|participant| {
-                participant.actor_kind == ActorKind::Human
-                    && participant.bot_uuid == human_actor_id
-            })
-        {
-            return Ok(true);
-        }
-        let owned_bot_ids = self
-            .registry
-            .try_list_bots_by_creator(&user.id)
-            .await
-            .map_err(map_service_error)?
-            .into_iter()
-            .filter(|bot| bot.actor_kind == ActorKind::Bot)
-            .map(|bot| bot.bot_uuid)
-            .collect::<HashSet<_>>();
-        Ok(group
-            .participants
-            .iter()
-            .any(|participant| {
-                participant.actor_kind == ActorKind::Bot
-                    && owned_bot_ids.contains(&participant.bot_uuid)
-            }))
-    }
-
     async fn ensure_collaboration_eligible(
         &self,
         principal: &Principal,
@@ -530,10 +496,46 @@ impl GroupServiceImpl {
         )))
     }
 
-    /// The authenticated human caller may act as itself or as an owned Bot
-    /// originator. Anything else is forbidden. This is stricter than legacy
-    /// `authorize_originator` (which lets any human designate any originator);
-    /// it is a V1 gate and legacy `POST /groups` is unaffected.
+    async fn can_read_group_detail(
+        &self,
+        principal: &Principal,
+        group: &DomainGroup,
+    ) -> Result<bool, ApplicationError> {
+        let principal_actor_id = principal.actor_id();
+        if group
+            .participants
+            .iter()
+            .any(|participant| participant.bot_uuid == principal_actor_id)
+        {
+            return Ok(true);
+        }
+        match principal {
+            Principal::Bot(_) => Ok(Self::group_management_actor_ids(group)
+                .iter()
+                .any(|actor_id| actor_id == &principal_actor_id)),
+            Principal::Human(human) => {
+                let owned_bot_ids = self
+                    .registry
+                    .try_list_bots_by_creator(&human.subject.id)
+                    .await
+                    .map_err(map_service_error)?
+                    .into_iter()
+                    .filter(|bot| bot.actor_kind == ActorKind::Bot)
+                    .map(|bot| bot.bot_uuid)
+                    .collect::<HashSet<_>>();
+                Ok(group.participants.iter().any(|participant| {
+                    participant.actor_kind == ActorKind::Bot
+                        && owned_bot_ids.contains(&participant.bot_uuid)
+                }))
+            }
+        }
+    }
+
+    /// The effective Human principal may act as itself or as an owned Bot
+    /// originator. The effective Bot principal may act only as itself. Anything
+    /// else is forbidden. This is stricter than legacy `authorize_originator`
+    /// (which lets any human designate any originator); it is a V1 gate and
+    /// legacy `POST /groups` is unaffected.
     async fn authorize_originator(
         &self,
         principal: &Principal,
@@ -544,7 +546,7 @@ impl GroupServiceImpl {
         }
         let bot = self.load_bot(originator).await.map_err(|error| match error {
             ApplicationError::NotFound { .. } => ApplicationError::forbidden(format!(
-                "Authenticated User cannot act as originator '{originator}'"
+                "Authenticated Principal cannot act as originator '{originator}'"
             )),
             other => other,
         })?;
@@ -560,7 +562,7 @@ impl GroupServiceImpl {
             }
         }
         Err(ApplicationError::forbidden(format!(
-            "Authenticated User cannot act as originator '{originator}'"
+            "Authenticated Principal cannot act as originator '{originator}'"
         )))
     }
 
@@ -794,6 +796,7 @@ impl GroupServiceImpl {
         caller: &bcs_service_api::application::v1::AuthenticatedCaller,
         group_id: &str,
     ) -> Result<DomainGroup, ApplicationError> {
+        let principal = select_principal(caller, IdentityPolicy::HumanOrOwnedBot)?;
         let group = self
             .groups
             .try_get(group_id)
@@ -812,10 +815,10 @@ impl GroupServiceImpl {
             ));
         }
         if group.visibility != visibility_name(GroupVisibility::Public)
-            && !self.can_read_group_detail(caller, &group).await?
+            && !self.can_read_group_detail(&principal, &group).await?
         {
             return Err(ApplicationError::forbidden(
-                "Neither the Human Actor nor an owned Bot is a Group Participant",
+                "The selected Principal has no readable relation to this Group",
             ));
         }
         Ok(group)
@@ -1599,8 +1602,8 @@ impl GroupServiceImpl {
     async fn create_without_eventing(
         &self,
         command: CreateGroup,
+        principal: Principal,
     ) -> Result<CreateGroupOutcome, ApplicationError> {
-        let principal = require_human(&command.caller)?;
         match command.group {
             CreateGroupSpec::Collaboration(request) => Ok(CreateGroupOutcome {
                 group: self
@@ -1816,16 +1819,16 @@ impl GroupService for GroupServiceImpl {
         command: CreateGroup,
         event_subscriptions: Vec<InlineGroupEventSubscriptionRequest>,
     ) -> Result<CreateGroupOutcome, ApplicationError> {
+        let principal = select_principal(&command.caller, IdentityPolicy::HumanOrOwnedBot)?;
         let Some(provisioner) = self.event_subscription_provisioner.as_ref().cloned() else {
             if event_subscriptions.is_empty() {
-                return self.create_without_eventing(command).await;
+                return self.create_without_eventing(command, principal).await;
             }
             return Err(ApplicationError::internal(
                 "Group Event Subscription provisioning is not configured",
             ));
         };
         let CreateGroup { caller, group } = command;
-        let principal = require_human(&caller)?;
         let state_machine = matches!(
             &group,
             CreateGroupSpec::Collaboration(CreateCollaborationGroup {
@@ -2016,7 +2019,7 @@ impl GroupService for GroupServiceImpl {
     }
 
     async fn update(&self, command: UpdateGroup) -> Result<GroupDetail, ApplicationError> {
-        let principal = require_human(&command.caller)?;
+        let principal = select_principal(&command.caller, IdentityPolicy::HumanOrOwnedBot)?;
         let mutation_actor = event_actor_for_principal(&principal);
         if command.patch.is_empty() {
             return Err(ApplicationError::invalid(
@@ -2127,7 +2130,7 @@ impl GroupService for GroupServiceImpl {
     }
 
     async fn delete(&self, command: DeleteGroup) -> Result<DeleteResult, ApplicationError> {
-        let principal = require_human(&command.caller)?;
+        let principal = select_principal(&command.caller, IdentityPolicy::HumanOrOwnedBot)?;
         let Some(group) = self
             .groups
             .try_get(&command.group_id)
@@ -2166,10 +2169,18 @@ impl GroupService for GroupServiceImpl {
                 deleted: false,
             });
         };
-        let manage_actor_id = if command.acting_bot_id.is_some() {
-            let acting_actor_id = self
-                .resolve_view_actor(&command.caller, command.acting_bot_id.as_deref())
-                .await?;
+        let manage_actor_id = if let Some(requested) = command.acting_bot_id.as_deref() {
+            let acting_actor_id = match &principal {
+                Principal::Human(_) => {
+                    self.resolve_view_actor(&command.caller, Some(requested)).await?
+                }
+                Principal::Bot(bot) if requested == bot.bot_uuid => requested.to_string(),
+                Principal::Bot(_) => {
+                    return Err(ApplicationError::forbidden(
+                        "The explicit acting Bot must identify the authenticated Bot",
+                    ));
+                }
+            };
             let management_actor_ids = Self::group_management_actor_ids(&group);
             if !management_actor_ids
                 .iter()

--- a/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
@@ -15,8 +15,8 @@ use bcs_group::{GroupConfig, GroupCore, GroupManagement, MemoryGroupRepo};
 use bcs_group_store::MySqlGroupStore;
 use bcs_relation::RelationCore;
 use bcs_service_api::application::v1::{
-    ApplicationError, AuthenticatedCaller, AuthenticatedUserIdentity, BotFinalDelivery,
-    ChatConfiguration, CollaborationConfiguration, CreateCollaborationGroup,
+    ApplicationError, AuthenticatedBotIdentity, AuthenticatedCaller, AuthenticatedUserIdentity,
+    BotFinalDelivery, ChatConfiguration, CollaborationConfiguration, CreateCollaborationGroup,
     CreateDirectMessageGroup, CreateGroup, CreateGroupSpec, CreateParticipant, DeleteGroup,
     EventSinkInput, GetGroup, GroupDeliveryPolicy, GroupDetail, GroupEventSubscriptionProvisioner,
     GroupKindFilter, GroupPatch, GroupService, GroupStrategy as V1GroupStrategy, GroupSummary,
@@ -714,6 +714,21 @@ impl CollaborationRuntimeService for RecordingRuntime {
 
 fn bot_principal(bot_uuid: &str) -> AuthenticatedCaller {
     human_principal_with_profile(bot_uuid, bot_uuid, None, None)
+}
+
+fn authenticated_bot_principal(bot_uuid: &str, owner_id: &str) -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: Some("tenant-a".into()),
+        user: None,
+        bot: Some(AuthenticatedBotIdentity {
+            bot_uuid: bot_uuid.into(),
+            owner_id: owner_id.into(),
+            app_id: 7,
+            agent_code: format!("agent-{bot_uuid}"),
+        }),
+        app: None,
+        access_key: None,
+    }
 }
 
 fn inline_group_subscription() -> InlineGroupEventSubscriptionRequest {
@@ -1485,6 +1500,186 @@ async fn eventing_enabled_create_without_inline_subscription_still_finalizes_eve
         .expect("provisioner lock");
     assert_eq!(prepared.len(), 1);
     assert_eq!(finalized.as_slice(), prepared.as_slice());
+}
+
+#[tokio::test]
+async fn bot_caller_creates_reads_updates_and_deletes_group() {
+    let fixture = Fixture::new().await;
+    fixture.add_public_bot("caller-bot").await;
+    fixture.add_public_bot("driver").await;
+    let caller = authenticated_bot_principal("caller-bot", "owner-1");
+    let mut command = collaboration_create_command();
+    command.caller = caller.clone();
+
+    let detail = fixture
+        .service
+        .create(command)
+        .await
+        .expect("Bot Principal creates Group");
+
+    let GroupDetail::Collaboration(detail) = detail else {
+        panic!("expected collaboration Group");
+    };
+    assert_eq!(detail.originator_actor_id, "caller-bot");
+    let group_id = detail.group_id;
+
+    let read = fixture
+        .service
+        .get(GetGroup {
+            caller: caller.clone(),
+            group_id: group_id.clone(),
+        })
+        .await
+        .expect("Bot Principal reads its Group");
+    let GroupDetail::Collaboration(read) = read else {
+        panic!("expected collaboration Group");
+    };
+    assert_eq!(read.group_id, group_id);
+
+    let updated = fixture
+        .service
+        .update(UpdateGroup {
+            caller: caller.clone(),
+            group_id: group_id.clone(),
+            patch: GroupPatch {
+                name: Some("Bot managed".into()),
+                context: None,
+                opening_message: None,
+                visibility: None,
+                delivery_policy: None,
+            },
+        })
+        .await
+        .expect("Bot Principal updates its Group");
+    let GroupDetail::Collaboration(updated) = updated else {
+        panic!("expected collaboration Group");
+    };
+    assert_eq!(updated.name.as_deref(), Some("Bot managed"));
+
+    let deleted = fixture
+        .service
+        .delete(DeleteGroup {
+            caller,
+            group_id,
+            acting_bot_id: Some("caller-bot".into()),
+        })
+        .await
+        .expect("Bot Principal deletes its Group");
+    assert!(deleted.deleted);
+}
+
+#[tokio::test]
+async fn unrelated_bot_cannot_read_update_or_delete_group() {
+    let fixture = Fixture::new().await;
+    fixture.add_public_bot("caller-bot").await;
+    fixture.add_public_bot("driver").await;
+    let mut command = collaboration_create_command();
+    command.caller = authenticated_bot_principal("caller-bot", "owner-1");
+    let created = fixture
+        .service
+        .create(command)
+        .await
+        .expect("create Group as Bot");
+    let GroupDetail::Collaboration(created) = created else {
+        panic!("expected collaboration Group");
+    };
+    let group_id = created.group_id;
+
+    let read = fixture
+        .service
+        .get(GetGroup {
+            caller: authenticated_bot_principal("outsider", "owner-2"),
+            group_id: group_id.clone(),
+        })
+        .await;
+    assert!(matches!(read, Err(ApplicationError::Forbidden { .. })));
+
+    let update = fixture
+        .service
+        .update(UpdateGroup {
+            caller: authenticated_bot_principal("outsider", "owner-2"),
+            group_id: group_id.clone(),
+            patch: GroupPatch {
+                name: Some("forged".into()),
+                context: None,
+                opening_message: None,
+                visibility: None,
+                delivery_policy: None,
+            },
+        })
+        .await;
+    assert!(matches!(update, Err(ApplicationError::Forbidden { .. })));
+
+    let delete = fixture
+        .service
+        .delete(DeleteGroup {
+            caller: authenticated_bot_principal("outsider", "owner-2"),
+            group_id,
+            acting_bot_id: None,
+        })
+        .await;
+    assert!(matches!(delete, Err(ApplicationError::Forbidden { .. })));
+}
+
+#[tokio::test]
+async fn bot_caller_creates_group_when_eventing_is_enabled() {
+    let fixture = Fixture::new().await;
+    fixture.add_public_bot("caller-bot").await;
+    fixture.add_public_bot("driver").await;
+    let provisioner = Arc::new(RecordingGroupProvisioner::new(fixture.groups.clone()));
+    let fixture = fixture.with_event_subscription_provisioner(provisioner.clone());
+    let mut command = collaboration_create_command();
+    command.caller = authenticated_bot_principal("caller-bot", "owner-1");
+
+    let outcome = fixture
+        .service
+        .create_with_event_subscriptions(command, vec![inline_group_subscription()])
+        .await
+        .expect("Bot Principal creates Group with inline Subscription");
+
+    let GroupDetail::Collaboration(detail) = outcome.group else {
+        panic!("expected collaboration Group");
+    };
+    assert_eq!(detail.originator_actor_id, "caller-bot");
+    assert_eq!(
+        provisioner
+            .prepared_group_ids
+            .lock()
+            .expect("provisioner lock")
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn mismatched_human_and_bot_caller_is_rejected_before_provisioning() {
+    let fixture = Fixture::new().await;
+    fixture.add_public_bot("driver").await;
+    let provisioner = Arc::new(RecordingGroupProvisioner::new(fixture.groups.clone()));
+    let fixture = fixture.with_event_subscription_provisioner(provisioner.clone());
+    let mut command = collaboration_create_command();
+    command.caller = authenticated_bot_principal("caller-bot", "another-owner");
+    command.caller.user = Some(AuthenticatedUserIdentity {
+        id: "owner-1".into(),
+        username: "owner-1".into(),
+        display_name: None,
+        full_name: None,
+    });
+
+    let error = fixture
+        .service
+        .create(command)
+        .await
+        .expect_err("mismatched User/Bot ownership must be rejected");
+
+    assert!(matches!(error, ApplicationError::Forbidden { .. }));
+    assert!(
+        provisioner
+            .prepared_group_ids
+            .lock()
+            .expect("provisioner lock")
+            .is_empty()
+    );
 }
 
 #[tokio::test]

--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -5,9 +5,9 @@
 //! while delegating the legacy session lifecycle to
 //! [`SessionManagementService`]. No HTTP type crosses this boundary.
 //!
-//! All current V1 operations are Human-facing. Detail reads, actor-relative
-//! lists, message history, and mutations intentionally use separate
-//! authorization rules defined by the V1 contract.
+//! V1 operations select their effective Actor according to the route contract.
+//! Detail reads, actor-relative lists, message history, and mutations retain
+//! separate resource-authorization rules.
 
 mod connection;
 mod file;
@@ -22,9 +22,10 @@ use async_trait::async_trait;
 use bcs_service_api::application::session::{SessionManagementService, SessionUseCaseError};
 use bcs_service_api::application::system_message::SystemMessageService;
 use bcs_service_api::application::v1::{
-    ApplicationError, AuthenticatedCaller, DeleteResult, HumanPrincipal, Page, Principal,
+    ApplicationError, AuthenticatedCaller, DeleteResult, HumanPrincipal, IdentityPolicy, Page,
+    Principal,
     message::{ListSessionMessages, SessionMessageService},
-    require_authenticated_user, require_human,
+    require_authenticated_user, require_human, select_principal,
     session::{
         AddSessionParticipant, CollectSession, CompleteSession, CreateSession, CreateSessionOutcome,
         DeleteSession, DeleteSessionParticipant, GetSession, ListSessions, SessionCollectionResult,
@@ -210,7 +211,6 @@ impl SessionServiceImpl {
     async fn authorize_human_self_mode_update(
         &self,
         principal: &Principal,
-        caller: &AuthenticatedCaller,
         session: &Session,
         actor_id: &str,
     ) -> Result<(), ApplicationError> {
@@ -219,7 +219,7 @@ impl SessionServiceImpl {
                 "A Human participant may only update its own mode",
             ));
         }
-        if !self.can_read_session_detail(caller, session).await? {
+        if !self.can_read_session_detail(principal, session).await? {
             return Err(ApplicationError::forbidden(
                 "The authenticated Human cannot access this Session",
             ));
@@ -388,19 +388,22 @@ impl SessionServiceImpl {
 
     async fn can_read_session_detail(
         &self,
-        caller: &AuthenticatedCaller,
+        principal: &Principal,
         session: &Session,
     ) -> Result<bool, ApplicationError> {
-        let user = require_authenticated_user(caller)?;
-        let human_actor_id = format!("human_{}", user.id);
-        if session.participants.iter().any(|participant| {
-            participant.actor_kind == ActorKind::Human && participant.bot_uuid == human_actor_id
-        }) {
+        if session
+            .participants
+            .iter()
+            .any(|participant| participant.bot_uuid == principal.actor_id())
+        {
             return Ok(true);
         }
+        let Principal::Human(human) = principal else {
+            return Ok(false);
+        };
         let owned_bot_ids = self
             .registry
-            .try_list_bots_by_creator(&user.id)
+            .try_list_bots_by_creator(&human.subject.id)
             .await
             .map_err(map_service_error)?
             .into_iter()
@@ -418,11 +421,12 @@ impl SessionServiceImpl {
         caller: &AuthenticatedCaller,
         session_id: &str,
     ) -> Result<Session, ApplicationError> {
+        let principal = select_principal(caller, IdentityPolicy::HumanOrOwnedBot)?;
         let session = self.load_session(session_id).await?;
         self.load_group(&session.group_id).await?;
-        if !self.can_read_session_detail(caller, &session).await? {
+        if !self.can_read_session_detail(&principal, &session).await? {
             return Err(ApplicationError::forbidden(
-                "Neither the Human Actor nor an owned Bot is a Session Participant",
+                "The selected Principal is not a Session Participant",
             ));
         }
         Ok(session)
@@ -694,7 +698,7 @@ impl SessionService for SessionServiceImpl {
     }
 
     async fn update(&self, command: UpdateSession) -> Result<SessionDetail, ApplicationError> {
-        let principal = require_human(&command.caller)?;
+        let principal = select_principal(&command.caller, IdentityPolicy::HumanOrOwnedBot)?;
         // Only `title` is mutable in phase one; a request carrying no field is
         // rejected (mirrors the sibling Group V1 facade).
         if command.title.is_none() {
@@ -714,7 +718,7 @@ impl SessionService for SessionServiceImpl {
     }
 
     async fn delete(&self, command: DeleteSession) -> Result<DeleteResult, ApplicationError> {
-        let principal = require_human(&command.caller)?;
+        let principal = select_principal(&command.caller, IdentityPolicy::HumanOrOwnedBot)?;
         // Idempotent: a missing session yields `deleted: false` rather than a
         // 404 so repeat deletes converge. Non-managers still get 403.
         let session = match self
@@ -727,10 +731,18 @@ impl SessionService for SessionServiceImpl {
             None => return Ok(DeleteResult { deleted: false }),
         };
         let group = self.load_group(&session.group_id).await?;
-        let can_delete = if command.acting_bot_id.is_some() {
-            let acting_actor_id = self
-                .resolve_view_actor(&command.caller, command.acting_bot_id.as_deref())
-                .await?;
+        let can_delete = if let Some(requested) = command.acting_bot_id.as_deref() {
+            let acting_actor_id = match &principal {
+                Principal::Human(_) => {
+                    self.resolve_view_actor(&command.caller, Some(requested)).await?
+                }
+                Principal::Bot(bot) if requested == bot.bot_uuid => requested.to_string(),
+                Principal::Bot(_) => {
+                    return Err(ApplicationError::forbidden(
+                        "The explicit acting Bot must identify the authenticated Bot",
+                    ));
+                }
+            };
             let management_actor_ids = Self::group_management_actor_ids(&group);
             management_actor_ids
                 .iter()
@@ -999,7 +1011,6 @@ impl SessionService for SessionServiceImpl {
                 ActorKind::Human => {
                     self.authorize_human_self_mode_update(
                         &principal,
-                        &command.caller,
                         &session,
                         &command.bot_uuid,
                     )
@@ -1019,7 +1030,6 @@ impl SessionService for SessionServiceImpl {
             // the authenticated Human and the existing V1 read boundary.
             self.authorize_human_self_mode_update(
                 &principal,
-                &command.caller,
                 &session,
                 &command.bot_uuid,
             )

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -23,8 +23,9 @@ use bcs_group::{GroupCore, MemoryGroupRepo};
 use bcs_relation::RelationCore;
 use bcs_service_api::application::system_message::SystemMessageService;
 use bcs_service_api::application::v1::{
-    AddSessionParticipant, AuthenticatedAppIdentity, AuthenticatedBotIdentity, AuthenticatedCaller,
-    AuthenticatedUserIdentity, CollectSession, CompleteSession, CreateSession, DeleteSession,
+    AddSessionParticipant, ApplicationError as V1ApplicationError, AuthenticatedAppIdentity,
+    AuthenticatedBotIdentity, AuthenticatedCaller, AuthenticatedUserIdentity, CollectSession,
+    CompleteSession, CreateSession, DeleteSession,
     DeleteSessionParticipant, GetSession, ListSessionMessages, ListSessions, SessionMessageService,
     SessionParticipantInput, SessionService,
     SessionStatus as V1SessionStatus, UncollectSession, UpdateSession, UpdateSessionParticipant,
@@ -996,7 +997,7 @@ async fn session_detail_propagates_owned_bot_lookup_database_failure() {
 }
 
 #[tokio::test]
-async fn session_v1_rejects_a_caller_without_user_identity() {
+async fn session_list_still_rejects_a_caller_without_user_identity() {
     let fixture = Fixture::new().await;
     fixture.add_bot("driver").await;
     fixture.store_group("g1", "driver", None).await;
@@ -1012,7 +1013,7 @@ async fn session_v1_rejects_a_caller_without_user_identity() {
         },
     )
     .await
-    .expect_err("current V1 operations require an authenticated User");
+    .expect_err("the actor-relative list still requires an authenticated User");
     assert!(matches!(
         error,
         bcs_service_api::application::v1::ApplicationError::Forbidden(_)
@@ -1160,6 +1161,108 @@ async fn delete_is_idempotent() {
         .expect("second delete");
     // Idempotent: a missing session yields deleted=false, not a 404.
     assert!(!second.deleted);
+}
+
+#[tokio::test]
+async fn bot_caller_creates_reads_updates_and_deletes_session() {
+    let fixture = Fixture::new().await;
+    for bot in ["driver", "expert"] {
+        fixture.add_bot(bot).await;
+    }
+    fixture.store_group("g1", "driver", None).await;
+    let caller = bot_only_caller("driver");
+    let outcome = create_session(
+        &fixture,
+        caller.clone(),
+        "g1",
+        "driver",
+        vec![participant_input("expert", None)],
+        None,
+        Some("Bot session"),
+    )
+    .await;
+    let session_id = outcome.session.session_id;
+
+    let detail = fixture
+        .service
+        .get(GetSession {
+            caller: caller.clone(),
+            session_id: session_id.clone(),
+        })
+        .await
+        .expect("Bot Principal reads its Session");
+    assert_eq!(detail.session_id, session_id);
+
+    let updated = fixture
+        .service
+        .update(UpdateSession {
+            caller: caller.clone(),
+            session_id: session_id.clone(),
+            title: Some("Bot updated".into()),
+        })
+        .await
+        .expect("Bot Principal updates its Session");
+    assert_eq!(updated.title.as_deref(), Some("Bot updated"));
+
+    let deleted = fixture
+        .service
+        .delete(DeleteSession {
+            caller,
+            session_id,
+            acting_bot_id: Some("driver".into()),
+        })
+        .await
+        .expect("Bot Principal deletes its Session");
+    assert!(deleted.deleted);
+}
+
+#[tokio::test]
+async fn unrelated_bot_cannot_read_update_or_delete_session() {
+    let fixture = Fixture::new().await;
+    for bot in ["driver", "expert"] {
+        fixture.add_bot(bot).await;
+    }
+    fixture.store_group("g1", "driver", None).await;
+    let outcome = create_session(
+        &fixture,
+        bot_only_caller("driver"),
+        "g1",
+        "driver",
+        vec![participant_input("expert", None)],
+        None,
+        None,
+    )
+    .await;
+    let session_id = outcome.session.session_id;
+
+    let read = fixture
+        .service
+        .get(GetSession {
+            caller: bot_only_caller("outsider"),
+            session_id: session_id.clone(),
+        })
+        .await;
+    assert!(matches!(read, Err(V1ApplicationError::Forbidden(_))));
+
+    let update = fixture
+        .service
+        .update(UpdateSession {
+            caller: bot_only_caller("outsider"),
+            session_id: session_id.clone(),
+            title: Some("forged".into()),
+        })
+        .await;
+    assert!(matches!(update, Err(V1ApplicationError::Forbidden(_))));
+
+    let delete = fixture
+        .service
+        .delete(DeleteSession {
+            caller: bot_only_caller("outsider"),
+            session_id,
+            acting_bot_id: None,
+        })
+        .await;
+    assert!(matches!(delete, Err(V1ApplicationError::Forbidden(_))));
 }
 
 #[tokio::test]

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/group.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/group.rs
@@ -454,6 +454,8 @@ pub struct UpdateGroup {
 pub struct DeleteGroup {
     pub caller: AuthenticatedCaller,
     pub group_id: String,
+    /// Optional management perspective. Human callers may select an owned Bot;
+    /// Bot callers may select only themselves.
     pub acting_bot_id: Option<String>,
 }
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session.rs
@@ -108,7 +108,8 @@ pub struct CreateSession {
     pub title: Option<String>,
     pub kind: Option<SessionKind>,
     /// Optional explicit creator Actor ID supplied through V1
-    /// `acting_bot_id`; Human callers may select themselves or an owned Bot.
+    /// `acting_bot_id`; Human callers may select themselves or an owned Bot,
+    /// while Bot callers may select only themselves.
     pub acting_bot_id: Option<String>,
     pub creator_role: Option<ParticipantRole>,
     pub input: Option<Value>,
@@ -143,6 +144,8 @@ pub struct UpdateSession {
 pub struct DeleteSession {
     pub caller: AuthenticatedCaller,
     pub session_id: String,
+    /// Optional management perspective. Human callers may select an owned Bot;
+    /// Bot callers may select only themselves.
     pub acting_bot_id: Option<String>,
 }
 

--- a/src/bcs/crates/services/bcs-eventing/src/subscription.rs
+++ b/src/bcs/crates/services/bcs-eventing/src/subscription.rs
@@ -12,10 +12,11 @@ use bcs_service_api::application::v1::{
     EventDeliverySummary, EventSinkInput, EventSinkView, EventSubscription,
     EventSubscriptionDesiredStatus, EventSubscriptionService, EventSubscriptionTestResult,
     EventWebhookEndpointView, GetEventDelivery, GetEventSubscription,
-    GroupEventSubscriptionProvisioner, InlineGroupEventSubscriptionRequest, ListEventDeliveries,
-    ListEventSubscriptions, PatchEventSinkInput, PatchEventSubscription,
-    PendingGroupEventSubscriptions, PreparedGroupEventSubscriptions, ReplayEventDelivery,
+    GroupEventSubscriptionProvisioner, IdentityPolicy, InlineGroupEventSubscriptionRequest,
+    ListEventDeliveries, ListEventSubscriptions, PatchEventSinkInput, PatchEventSubscription,
+    PendingGroupEventSubscriptions, PreparedGroupEventSubscriptions, Principal, ReplayEventDelivery,
     ReplayEventDeliveryResult, SkipEventDelivery, SkipEventDeliveryResult, TestEventSubscription,
+    select_principal,
 };
 use bcs_service_api::port::repo::{
     AppendEventRecord, CancelPendingEventSubscriptions, CreateEventReplayTarget,
@@ -843,14 +844,18 @@ impl GroupEventSubscriptionProvisioner for EventSubscriptionApplicationService {
         requests: Vec<InlineGroupEventSubscriptionRequest>,
     ) -> Result<PreparedGroupEventSubscriptions, ApplicationError> {
         self.ensure_enabled()?;
-        let user = caller
-            .user
-            .as_ref()
-            .ok_or(ApplicationError::Unauthenticated)?;
-        let actor = EventActor {
-            actor_type: EventActorType::Human,
-            id: format!("human_{}", user.id),
-            display_name: user.display_name.clone().or_else(|| user.full_name.clone()),
+        let principal = select_principal(caller, IdentityPolicy::HumanOrOwnedBot)?;
+        let actor = match principal {
+            Principal::Human(human) => EventActor {
+                actor_type: EventActorType::Human,
+                id: format!("human_{}", human.subject.id),
+                display_name: human.subject.display_name.or(human.subject.full_name),
+            },
+            Principal::Bot(bot) => EventActor {
+                actor_type: EventActorType::Bot,
+                id: bot.bot_uuid,
+                display_name: None,
+            },
         };
         let grant = AuthorizedEventSubscriptionScope {
             actor: actor.clone(),

--- a/src/bcs/crates/services/bcs-eventing/tests/subscription_service.rs
+++ b/src/bcs/crates/services/bcs-eventing/tests/subscription_service.rs
@@ -34,7 +34,8 @@ use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
 use support::{
-    NOW_MS, caller, create_command, group_scope, harness, harness_with_eventing_config,
+    NOW_MS, bot_caller, caller, create_command, group_scope, harness,
+    harness_with_eventing_config,
 };
 
 fn inline_subscription(name: &str, filters: Vec<&str>) -> InlineGroupEventSubscriptionRequest {
@@ -87,6 +88,31 @@ async fn inline_group_prepare_fixes_scope_and_cancellation_never_activates() {
         .expect("load cancelled subscription")
         .expect("cancelled subscription");
     assert_eq!(cancelled.status, EventSubscriptionStatus::Deleted);
+}
+
+#[tokio::test]
+async fn inline_group_prepare_projects_a_bot_caller_as_the_event_actor() {
+    let harness = harness(true);
+
+    let prepared = harness
+        .service
+        .prepare(
+            &bot_caller(),
+            "server-group-id",
+            vec![inline_subscription("inline", vec!["group.*"])],
+        )
+        .await
+        .expect("prepare inline subscription as Bot");
+
+    assert_eq!(prepared.actor.actor_type, EventActorType::Bot);
+    assert_eq!(prepared.actor.id, "bot-owner");
+    let (record, _) = harness
+        .repo
+        .get_subscription(&prepared.subscription_ids[0], "test")
+        .await
+        .expect("load pending subscription")
+        .expect("pending subscription");
+    assert_eq!(record.created_by, prepared.actor);
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-eventing/tests/support/mod.rs
+++ b/src/bcs/crates/services/bcs-eventing/tests/support/mod.rs
@@ -14,8 +14,8 @@ use bcs_eventing::{
 };
 use bcs_group::{GroupCore, MemoryGroupRepo};
 use bcs_service_api::application::v1::{
-    ApplicationError, AuthenticatedCaller, AuthenticatedUserIdentity, CreateEventSubscription,
-    CreateEventSubscriptionRequest, EventPayload, EventSinkInput,
+    ApplicationError, AuthenticatedBotIdentity, AuthenticatedCaller, AuthenticatedUserIdentity,
+    CreateEventSubscription, CreateEventSubscriptionRequest, EventPayload, EventSinkInput,
 };
 use bcs_service_api::port::{
     EventDeliveryAttemptMetric, EventDeliveryDisposition, EventDeliveryError, EventDeliveryPort,
@@ -197,6 +197,21 @@ pub fn caller() -> AuthenticatedCaller {
             full_name: None,
         }),
         bot: None,
+        app: None,
+        access_key: None,
+    }
+}
+
+pub fn bot_caller() -> AuthenticatedCaller {
+    AuthenticatedCaller {
+        tenant: Some("tenant-1".to_string()),
+        user: None,
+        bot: Some(AuthenticatedBotIdentity {
+            bot_uuid: "bot-owner".to_string(),
+            owner_id: "owner".to_string(),
+            app_id: 7,
+            agent_code: "agent-bot-owner".to_string(),
+        }),
         app: None,
         access_key: None,
     }

--- a/src/bcs/docs/event-webhook-integration-guide.md
+++ b/src/bcs/docs/event-webhook-integration-guide.md
@@ -121,6 +121,34 @@ Body 示例：
 - 未可靠接收时返回非 `2xx`，BCS 会按投递策略处理失败；
 - 如果依赖事件顺序，按 `stream.key` 分区，并按 `stream.sequence` 处理。
 
+### 2.1 正文是否包含 Bot 实际输出
+
+Event Subscription 的 `payload.mode` 默认为 `metadata_only`。该模式下，`output`、`result`、
+`summary`、`content` 等正文投影字段仍然存在，但 `included=false`，且不包含 `text` 或 `json`。
+需要接收 Bot 实际输出正文时，创建订阅时必须显式配置：
+
+```json
+{
+  "payload": {
+    "mode": "full"
+  }
+}
+```
+
+不同完成事件没有统一的 `output` 字段，接入方应按 `event_type` 读取：
+
+| 协作场景 | 完成事件 | `full` 模式的正文路径 | 正文语义 |
+| --- | --- | --- | --- |
+| 自定义协作群的单个节点 | `state_machine.node.completed` | `data.output.json` | 该节点本次成功 attempt 的 Bot 输出产物 |
+| 自定义协作群的整个 Run | `state_machine.run.completed` | `data.output.json` | 标记为 `final_output` 的节点产物；没有该标记时回退为最后一个有产物的节点 |
+| 任务协作群的单个 Worker 子任务 | `task.completed` | `data.result.text` | Worker 返回并被 BCS 接收的 final result |
+| 任务协作群的整个 Session | `session.completed` | `data.summary.json` | Manager 调用 `bcs_task_complete` 时提交的 `summary`，不保证等于 Manager 的原始 assistant 消息 |
+
+当前状态机生产方把文本产物编码为 `content_type=application/json` 的 JSON string，因此实际文本位于
+`json`；Task 生产方使用 `content_type=text/plain`，因此 Worker 结果位于 `text`。为了兼容后续生产方，
+接入方应先检查 `included` 和 `content_type`，再读取 `text` 或 `json`，不要假设所有正文都使用同一字段。
+即使使用 `full`，正文仍会经过敏感信息过滤和事件大小限制。
+
 ## 3. 自定义协作群执行一次状态机的事件链
 
 当创建 `collaboration.strategy=state_machine` 的自定义协作群、配置内联
@@ -196,6 +224,27 @@ state_machine.node.started          (attempt=n+1)
 示例配置使用 `payload.mode=metadata_only`，因此 `input`、`output` 等内容字段只包含
 `included`、`content_type`、`size_bytes`、`truncated` 等元数据，不包含正文。
 
+如果订阅配置为 `payload.mode=full`，`state_machine.run.completed.data` 示例为：
+
+```json
+{
+  "completed_at": "2026-08-18T10:09:00.000Z",
+  "output": {
+    "included": true,
+    "content_type": "application/json",
+    "size_bytes": 21,
+    "delivered_bytes": 21,
+    "json": "Release is approved",
+    "sha256": "b3a5821ebb0666e48177847ae100a95663b9ce786f5d4ba61c73b1ae5016e40f",
+    "truncated": false
+  },
+  "duration_ms": 540000
+}
+```
+
+这里的 `data.output.json` 是整个 Run 的最终对外产物，不是所有节点输出的拼接。需要每个节点的实际
+输出时，同时订阅并读取各个 `state_machine.node.completed.data.output`。
+
 ## 4. 任务协作群的事件
 
 任务协作群指 `collaboration.strategy=manager_worker` 的 Group。一次协作可以包含多个由 Manager
@@ -253,6 +302,41 @@ session.completed             (Manager 完成整个协作 Session 时一次)
     "truncated": false
   },
   "completed_at": "2026-08-18T10:02:00.000Z"
+}
+```
+
+订阅配置为 `payload.mode=full` 时，同一个 `task.completed.data.result` 会包含 Worker 的实际结果文本：
+
+```json
+{
+  "result": {
+    "included": true,
+    "content_type": "text/plain",
+    "size_bytes": 19,
+    "delivered_bytes": 19,
+    "text": "Worker final result",
+    "sha256": "4291e81b36766968b73a9c9268fbb4b73644b31f3d7e796ce3de5665319b2e78",
+    "truncated": false
+  }
+}
+```
+
+Manager 完成整个任务协作 Session 时产生的是 `session.completed`。它没有 `data.output`，最终汇总位于
+`data.summary`；`full` 模式示例为：
+
+```json
+{
+  "completed_by": "bcs-system",
+  "reason": "completed",
+  "summary": {
+    "included": true,
+    "content_type": "application/json",
+    "size_bytes": 59,
+    "delivered_bytes": 59,
+    "json": "All workers completed; publish the reviewed release plan.",
+    "sha256": "90c81b570bbdc08637ff28688d5af1bafb888fb5c3455dc89048e401bec97940",
+    "truncated": false
+  }
 }
 ```
 

--- a/src/bcs/tests/openapi/test_contract.py
+++ b/src/bcs/tests/openapi/test_contract.py
@@ -100,6 +100,16 @@ def test_all_operations_share_the_collaboration_ownership_prefix() -> None:
 
 def test_operations_use_the_approved_gateway_security_boundary() -> None:
     contract = load_contract(CONTRACT_ROOT)
+    human_or_owned_bot = {
+        ("post", "/openapi/v1/collaboration/groups"),
+        ("get", "/openapi/v1/collaboration/groups/{group_id}"),
+        ("patch", "/openapi/v1/collaboration/groups/{group_id}"),
+        ("delete", "/openapi/v1/collaboration/groups/{group_id}"),
+        ("post", "/openapi/v1/collaboration/groups/{group_id}/sessions"),
+        ("get", "/openapi/v1/collaboration/sessions/{session_id}"),
+        ("patch", "/openapi/v1/collaboration/sessions/{session_id}"),
+        ("delete", "/openapi/v1/collaboration/sessions/{session_id}"),
+    }
 
     for path, path_item in contract["paths"].items():
         for method, operation in path_item.items():
@@ -107,11 +117,8 @@ def test_operations_use_the_approved_gateway_security_boundary() -> None:
                 continue
             if path == "/openapi/v1/collaboration/messages/ws":
                 expected = {}
-            elif (method, path) == (
-                "post",
-                "/openapi/v1/collaboration/groups/{group_id}/sessions",
-            ):
-                expected = {"user": "optional", "app": "optional", "bot": "optional"}
+            elif (method, path) in human_or_owned_bot:
+                expected = {"user": "optional", "app": "required", "bot": "optional"}
             else:
                 expected = {"user": "required", "app": "required"}
             assert operation["x-avernet-security"] == expected, (

--- a/src/bcs/tests/openapi/test_group_v1_contract.py
+++ b/src/bcs/tests/openapi/test_group_v1_contract.py
@@ -229,7 +229,7 @@ def test_group_create_inline_event_subscriptions_cannot_supply_scope() -> None:
         assert "event_subscriptions" not in response_variant["required"]
 
 
-def test_group_detail_uses_implicit_human_or_owned_bot_participant_access() -> None:
+def test_group_detail_uses_human_or_owned_bot_resource_access() -> None:
     contract = load_contract(CONTRACT_ROOT)
     operation = contract["paths"][GROUP_PATH]["get"]
 
@@ -241,9 +241,9 @@ def test_group_detail_uses_implicit_human_or_owned_bot_participant_access() -> N
     forbidden = operation["responses"]["403"]
     assert forbidden["x-error-codes"] == ["forbidden"]
     description = forbidden["description"]
-    assert "Human Actor" in description
-    assert "created by that Human" in description
-    assert "Group Participant" in description
+    assert "HumanOrOwnedBot Principal" in description
+    assert "participant relation" in description
+    assert "Bot management actor" in description
 
 
 def test_contract_bundles_to_a_deterministic_document(
@@ -353,15 +353,34 @@ def test_delete_group_accepts_optional_acting_bot_id_query() -> None:
             "name": "acting_bot_id",
             "in": "query",
             "required": False,
-            "description": "Optional Bot identity perspective for the delete decision. Omit to evaluate the authenticated Human perspective.",
+            "description": "Optional Bot identity perspective for the delete decision. A Human caller may select an owned Bot; a Bot caller may select only itself. Omit to use the selected HumanOrOwnedBot Principal.",
             "schema": {"type": "string", "minLength": 1},
         }
     }
 
 
+def test_group_detail_and_mutations_use_human_or_owned_bot() -> None:
+    contract = load_contract(CONTRACT_ROOT)
+
+    for method in ("get", "patch", "delete"):
+        operation = contract["paths"][GROUP_PATH][method]
+        assert operation["x-avernet-security"] == {
+            "user": "optional",
+            "app": "required",
+            "bot": "optional",
+        }
+        assert operation["x-bcn-identity-policy"] == "human_or_owned_bot"
+
+
 def test_create_group_request_defaults_private_visibility_and_chat_delivery() -> None:
     contract = load_contract(CONTRACT_ROOT)
     operation = contract["paths"][GROUPS_PATH]["post"]
+    assert operation["x-avernet-security"] == {
+        "user": "optional",
+        "app": "required",
+        "bot": "optional",
+    }
+    assert operation["x-bcn-identity-policy"] == "human_or_owned_bot"
     request_schema = operation["requestBody"]["content"]["application/json"]["schema"]
     create_group_schema = next(
         schema

--- a/src/bcs/tests/openapi/test_session_v1_contract.py
+++ b/src/bcs/tests/openapi/test_session_v1_contract.py
@@ -142,11 +142,20 @@ def test_view_actor_failures_are_forbidden_without_a_bot_not_found_response() ->
         }
 
 
-def test_session_detail_uses_implicit_human_or_owned_bot_participant_access() -> None:
+def test_session_resource_operations_use_human_or_owned_bot() -> None:
     contract = load_contract(CONTRACT_ROOT)
-    operation = contract["paths"][
-        "/openapi/v1/collaboration/sessions/{session_id}"
-    ]["get"]
+    path = contract["paths"]["/openapi/v1/collaboration/sessions/{session_id}"]
+
+    for method in ("get", "patch", "delete"):
+        operation = path[method]
+        assert operation["x-avernet-security"] == {
+            "user": "optional",
+            "app": "required",
+            "bot": "optional",
+        }
+        assert operation["x-bcn-identity-policy"] == "human_or_owned_bot"
+
+    operation = path["get"]
 
     assert "view_bot_id" not in {
         parameter["name"]
@@ -156,8 +165,7 @@ def test_session_detail_uses_implicit_human_or_owned_bot_participant_access() ->
     forbidden = operation["responses"]["403"]
     assert forbidden["x-error-codes"] == ["forbidden"]
     description = forbidden["description"]
-    assert "Human Actor" in description
-    assert "created by that Human" in description
+    assert "HumanOrOwnedBot Principal" in description
     assert "Session Participant" in description
 
 
@@ -321,10 +329,24 @@ def test_delete_session_accepts_optional_acting_bot_id_query() -> None:
             "name": "acting_bot_id",
             "in": "query",
             "required": False,
-            "description": "Optional Bot identity perspective for the delete decision. Omit to evaluate the authenticated Human perspective.",
+            "description": "Optional Bot identity perspective for the delete decision. A Human caller may select an owned Bot; a Bot caller may select only itself. Omit to use the selected HumanOrOwnedBot Principal.",
             "schema": {"type": "string", "minLength": 1},
         }
     }
+
+
+def test_create_session_uses_human_or_owned_bot() -> None:
+    contract = load_contract(CONTRACT_ROOT)
+    operation = contract["paths"][
+        "/openapi/v1/collaboration/groups/{group_id}/sessions"
+    ]["post"]
+
+    assert operation["x-avernet-security"] == {
+        "user": "optional",
+        "app": "required",
+        "bot": "optional",
+    }
+    assert operation["x-bcn-identity-policy"] == "human_or_owned_bot"
 
 
 def test_create_group_session_does_not_accept_driver_or_participants() -> None:

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -365,6 +365,31 @@ user_config:
       user: required
       app: required
 
+    # Group creation selects either the Human or an authenticated Bot as its
+    # effective Actor. App remains required as the integration credential;
+    # BCN rejects missing actors and mismatched User/Bot ownership claims.
+    "POST /openapi/v1/collaboration/groups":
+      user: optional
+      app: required
+      bot: optional
+
+    # Resource-level authorization stays in BCN: the selected Bot must have a
+    # readable or management relation to the target Group/Session.
+    "/openapi/v1/collaboration/groups/{group_id}":
+      user: optional
+      app: required
+      bot: optional
+
+    "POST /openapi/v1/collaboration/groups/{group_id}/sessions":
+      user: optional
+      app: required
+      bot: optional
+
+    "/openapi/v1/collaboration/sessions/{session_id}":
+      user: optional
+      app: required
+      bot: optional
+
     # New-version publish-to-users: served by the backend (the antprocess
     # approval + bcs_pub callback live there), pulled out of the
     # collaboration→bcs domain by the `collaboration-publish` match upstream. A

--- a/src/gateway/tests/unit/core/authn/test_route_security.py
+++ b/src/gateway/tests/unit/core/authn/test_route_security.py
@@ -33,6 +33,53 @@ def test_shipped_config_admits_a_machine_caller_on_the_public_api() -> None:
     assert req[PrincipalType.APP] is Presence.OPTIONAL
 
 
+def test_shipped_config_uses_human_or_owned_bot_for_group_creation() -> None:
+    raw = yaml.safe_load(_CONFIG.read_text())
+    rs = RouteSecurity.from_table(raw["user_config"]["route_security"])
+
+    requirement = rs.resolve("POST", "/openapi/v1/collaboration/groups")
+
+    assert requirement == {
+        PrincipalType.USER: Presence.OPTIONAL,
+        PrincipalType.APP: Presence.REQUIRED,
+        PrincipalType.BOT: Presence.OPTIONAL,
+    }
+
+    # The exact POST override must not relax other Group operations.
+    sibling = rs.resolve("GET", "/openapi/v1/collaboration/groups")
+    assert sibling == {
+        PrincipalType.USER: Presence.REQUIRED,
+        PrincipalType.APP: Presence.REQUIRED,
+    }
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", "/openapi/v1/collaboration/groups/group-1"),
+        ("PATCH", "/openapi/v1/collaboration/groups/group-1"),
+        ("DELETE", "/openapi/v1/collaboration/groups/group-1"),
+        ("POST", "/openapi/v1/collaboration/groups/group-1/sessions"),
+        ("GET", "/openapi/v1/collaboration/sessions/session-1"),
+        ("PATCH", "/openapi/v1/collaboration/sessions/session-1"),
+        ("DELETE", "/openapi/v1/collaboration/sessions/session-1"),
+    ],
+)
+def test_shipped_config_uses_human_or_owned_bot_for_resource_operations(
+    method: str, path: str
+) -> None:
+    raw = yaml.safe_load(_CONFIG.read_text())
+    requirement = RouteSecurity.from_table(
+        raw["user_config"]["route_security"]
+    ).resolve(method, path)
+
+    assert requirement == {
+        PrincipalType.USER: Presence.OPTIONAL,
+        PrincipalType.APP: Presence.REQUIRED,
+        PrincipalType.BOT: Presence.OPTIONAL,
+    }
+
+
 @pytest.mark.parametrize(
     ("method", "path"),
     [
@@ -274,8 +321,11 @@ def test_shipped_config_collects_all_optional_file_identities_and_keeps_share_pu
         == {}
     )
     sibling = rs.resolve("GET", "/openapi/v1/collaboration/sessions/session-1")
-    assert sibling is not None
-    assert sibling[PrincipalType.USER] is Presence.REQUIRED
+    assert sibling == {
+        PrincipalType.USER: Presence.OPTIONAL,
+        PrincipalType.APP: Presence.REQUIRED,
+        PrincipalType.BOT: Presence.OPTIONAL,
+    }
     assert sibling[PrincipalType.APP] is Presence.REQUIRED
 
 

--- a/src/gateway/tests/unit/core/forwarding/test_domain_map.py
+++ b/src/gateway/tests/unit/core/forwarding/test_domain_map.py
@@ -130,8 +130,11 @@ def test_shipped_config_routes_collaboration_verbatim_to_bcs() -> None:
 
     security = RouteSecurity.from_table(raw["user_config"]["route_security"])
     requirement = security.resolve("GET", "/openapi/v1/collaboration/groups/group-1")
-    assert requirement is not None
-    assert requirement[PrincipalType.USER] is Presence.REQUIRED
+    assert requirement == {
+        PrincipalType.USER: Presence.OPTIONAL,
+        PrincipalType.APP: Presence.REQUIRED,
+        PrincipalType.BOT: Presence.OPTIONAL,
+    }
 
     friend_requirement = security.resolve(
         "POST", "/openapi/v1/collaboration/friend-connections/requests"


### PR DESCRIPTION
## Problem

BCS Group and Session OpenAPI operations only accepted Human identity for several create, read, update, and delete flows. This prevented Bots from managing collaboration resources they participate in or own.

Legacy Group routes also needed to accept Bot tokens consistently, including inline event subscriptions, while preserving strict container validation.

## Solution

- Apply the `HumanOrOwnedBot` identity policy to:
  - Group create, detail, update, and delete operations
  - Session create, detail, update, and delete operations
  - Inline Group Event Subscription provisioning
- Preserve resource-level authorization:
  - Bots may only access or manage Groups and Sessions for which they are an authorized participant, originator, driver, or creator as applicable.
  - Human callers retain owned-Bot delegation behavior.
- Update Gateway route policies so Application identity remains required while Human or Bot identity can be supplied as the effective caller.
- Allow Legacy `POST /groups` requests with a Bot token to include inline event subscriptions.
- Allow Legacy `PATCH /groups/{id}` requests to use Bot identity.
- Preserve strict `x-agentclaw-bolt-id` container validation for both Legacy Bot write paths.
- Update OpenAPI contracts, event subscription documentation, and identity-policy descriptions.
- Add Group, Session, Eventing, Gateway, OpenAPI, and Legacy route regression coverage.

## Validation

- Group V1 application tests: 82 passed
- Session V1 application tests: 71 passed
- Gateway route-security tests: 68 passed
- Event subscription tests: passed
- Targeted OpenAPI contract tests: passed
- `cargo test -p bcs-http --test legacy_group_event_subscription_contract`: 3 passed
- `cargo test -p bcs-http --test legacy_group_patch_contract`: 6 passed
- `git diff --check`: passed

The full historical OpenAPI test set still reports two pre-existing schema-drift failures unrelated to this change. Repository-wide `cargo fmt --check` is also blocked by existing formatting drift in unrelated Rust files.

## Compatibility and risk

This is an authorization-contract expansion: existing Human behavior remains supported, while authorized Bot callers gain access to the affected operations.

Application identity remains required by the Gateway OpenAPI routes. Bot identity does not bypass Group or Session resource authorization, and Legacy Bot writes continue to enforce strict container validation when enabled.

No persistence schema or data migration is required. The change can be rolled back by reverting commit `00701ffb7`.