### PR TITLE
fix(ci): render reachable ports and probe paths for every deployed service

### DIFF
--- a/docker/kube-deploy.sh
+++ b/docker/kube-deploy.sh
@@ -11,11 +11,17 @@
 #       [--namespace avernet] \
 #       [--apply]                 # apply with kubectl (default: dry-run print)
 #
-# Supported services (with default port):
-#   baas       — SecBaaS platform service (port 8888)
-#   gateway    — API gateway (port 8080)
-#   bcs        — BCS coordination service (port 21000)
-#   backend    — Backend service (port 8090)
+# Supported services (default port, probe path):
+#   baas       — SecBaaS platform service   (8888,  /health)
+#   gateway    — API gateway                (8888,  /health)
+#   proxy      — Sandbox proxy              (8888,  /health)
+#   bcs        — BCS coordination service   (21000, /health)
+#   backend    — Backend service            (8888,  /api/health)
+#
+# Each default is the port that service actually listens on out of the box, and
+# the path it actually serves. Override the port with PORT=... in the
+# environment; see the note on DEFAULT_PORT below for which services can honour
+# that inside the container.
 #
 # The script renders docker/services/service-deployment.yaml via
 # envsubst, then optionally applies it with kubectl.
@@ -60,13 +66,45 @@ APPLY=0
 ENV_VARS=()
 ENV_FILE=""
 
-# Service-specific defaults
+# Service-specific defaults.
+#
+# These were all 8080, which no service listens on: baas/gateway/proxy default
+# module_config.web.port to 8888, bcs's toml sets 21000, and the backend's
+# main.py defaults to 8888. Every rendered manifest therefore published a port
+# with no listener behind it. Each entry below is the service's real default.
 declare -A DEFAULT_PORT=(
-    [baas]=8080
-    [gateway]=8080
-    [proxy]=8080
-    [bcs]=8080
-    [backend]=8080
+    [baas]=8888
+    [gateway]=8888
+    [proxy]=8888
+    [bcs]=21000
+    [backend]=8888
+)
+
+# The HTTP path each service answers health probes on. The backend mounts its
+# routes under /api and serves /api/health; the rest serve /health at the root.
+# A wrong path here is silent and fatal: readiness never turns true and liveness
+# restarts an otherwise healthy pod on a loop.
+declare -A DEFAULT_PROBE_PATH=(
+    [baas]=/health
+    [gateway]=/health
+    [proxy]=/health
+    [bcs]=/health
+    [backend]=/api/health
+)
+
+# The env var (if any) through which a service lets the environment override the
+# port from its config file. gateway, proxy and backend each read one and let it
+# win; injecting it below keeps the container's listener on the port this
+# manifest publishes, so PORT=... moves both together instead of only
+# relabelling the Service. baas and bcs have no such override — their port comes
+# from the mounted config / toml alone, so overriding PORT for them means
+# editing that config to match.
+declare -A PORT_ENV_VAR=(
+    [baas]=""
+    [gateway]=GATEWAY_PORT
+    [proxy]=SANDBOXPROXY_PORT
+    [bcs]=""
+    [backend]=BACKEND_PORT
 )
 
 # All services default to 4 CPU / 8Gi spec, 2 replicas.
@@ -79,7 +117,11 @@ DEFAULT_MEM_LIMIT="8Gi"
 # --- Parse arguments ---
 
 usage() {
-    sed -n '2,/^# ====/p; /^# ====/q' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+    # Print the header comment block: everything between the opening and closing
+    # banner, with the leading "# " stripped. The previous sed quit on the first
+    # /^# ====/ line, which is the opening banner itself, so --help emitted that
+    # single line and nothing else. Same shape as docker/build-image.sh.
+    awk 'NR>2 { if ($0 ~ /^# ====/) exit; sub(/^# ?/,""); print }' "${BASH_SOURCE[0]}"
     exit 0
 }
 
@@ -126,6 +168,7 @@ if [[ -z "${DEFAULT_PORT[$SERVICE]:-}" ]]; then
 fi
 
 PORT="${PORT:-${DEFAULT_PORT[$SERVICE]}}"
+PROBE_PATH="${PROBE_PATH:-${DEFAULT_PROBE_PATH[$SERVICE]}}"
 REPLICAS="${REPLICAS:-$DEFAULT_REPLICAS}"
 CPU_REQUEST="${CPU_REQUEST:-$DEFAULT_CPU_REQUEST}"
 CPU_LIMIT="${CPU_LIMIT:-$DEFAULT_CPU_LIMIT}"
@@ -153,6 +196,35 @@ fi
 
 ENV_VARS+=("DEPLOY_TIME=$(date '+%Y-%m-%dT%H:%M:%S%z')")
 
+# --- Keep the container's listener on the port this manifest publishes ---
+
+# For a service that reads a port env var, inject it set to PORT. Without this a
+# PORT override renamed the Service's target while the process kept listening
+# where its config said, which is the same dead port the old uniform 8080
+# produced. An explicit --env for the same key wins: the operator asked for it by
+# name, so we leave it alone and only warn if it disagrees with what we publish.
+PORT_ENV="${PORT_ENV_VAR[$SERVICE]:-}"
+if [[ -n "$PORT_ENV" ]]; then
+    explicit=""
+    for entry in "${ENV_VARS[@]}"; do
+        if [[ "${entry%%=*}" == "$PORT_ENV" ]]; then
+            explicit="${entry#*=}"
+            break
+        fi
+    done
+    if [[ -z "$explicit" ]]; then
+        ENV_VARS+=("${PORT_ENV}=${PORT}")
+    elif [[ "$explicit" != "$PORT" ]]; then
+        echo "warning: --env ${PORT_ENV}=${explicit} disagrees with the published port ${PORT};" >&2
+        echo "         the Service and probes will target ${PORT} while the container listens on ${explicit}." >&2
+        echo "         Set PORT=${explicit} to move both together." >&2
+    fi
+elif [[ "${PORT}" != "${DEFAULT_PORT[$SERVICE]}" ]]; then
+    echo "warning: ${SERVICE} takes its port from its mounted config, not the environment;" >&2
+    echo "         PORT=${PORT} only changes the manifest. Edit that config to match, or the" >&2
+    echo "         Service and probes will target a port with no listener." >&2
+fi
+
 # --- Render env vars into YAML ---
 
 ENV_YAML=""
@@ -170,7 +242,7 @@ fi
 # --- Render template ---
 
 # envsubst first for ${...} placeholders (won't touch __ENV_VARS__)
-export SERVICE NAMESPACE IMAGE PORT REPLICAS CPU_REQUEST CPU_LIMIT MEMORY_REQUEST MEMORY_LIMIT
+export SERVICE NAMESPACE IMAGE PORT PROBE_PATH REPLICAS CPU_REQUEST CPU_LIMIT MEMORY_REQUEST MEMORY_LIMIT
 RENDERED="$(cat "$TEMPLATE" | envsubst)"
 
 # Then replace __ENV_VARS__ with the env block (or remove if empty)
@@ -179,7 +251,7 @@ if [[ -n "$ENV_YAML" ]]; then
 else
     RENDERED="${RENDERED//        __ENV_VARS__/}"
 fi
-export SERVICE NAMESPACE IMAGE PORT REPLICAS CPU_REQUEST CPU_LIMIT MEMORY_REQUEST MEMORY_LIMIT
+export SERVICE NAMESPACE IMAGE PORT PROBE_PATH REPLICAS CPU_REQUEST CPU_LIMIT MEMORY_REQUEST MEMORY_LIMIT
 RENDERED="$(echo "$RENDERED" | envsubst)"
 
 # --- Output or apply ---
@@ -188,6 +260,7 @@ if [[ "$APPLY" -eq 1 ]]; then
     echo "==> Deploying $SERVICE to namespace $NAMESPACE"
     echo "    image: $IMAGE"
     echo "    port:  $PORT"
+    echo "    probe: $PROBE_PATH"
     if [[ ${#ENV_VARS[@]} -gt 0 ]]; then
         echo "    env:   ${#ENV_VARS[@]} vars"
     fi

--- a/docker/services/service-deployment.yaml
+++ b/docker/services/service-deployment.yaml
@@ -5,11 +5,12 @@
 # manifest. Uses envsubst-compatible ${...} placeholders.
 #
 # Placeholders:
-#   SERVICE     — service name (baas | gateway | bcs | backend)
-#   SERVICE     — service name (baas | gateway | bcs | backend)
+#   SERVICE     — service name (baas | gateway | proxy | bcs | backend)
 #   NAMESPACE   — K8s namespace
 #   IMAGE       — container image with tag
 #   PORT        — container + service port
+#   PROBE_PATH  — HTTP path both probes GET. Per-service, because the backend
+#                 serves /api/health while the others serve /health.
 #   REPLICAS    — number of pod replicas (default 2)
 #   CPU_REQUEST, CPU_LIMIT, MEMORY_REQUEST, MEMORY_LIMIT — resource spec
 #   ENV_VARS    — rendered env var entries (one "- name: ..." block per line)
@@ -46,13 +47,13 @@ spec:
             memory: "${MEMORY_LIMIT}"
         livenessProbe:
           httpGet:
-            path: /health
+            path: ${PROBE_PATH}
             port: ${PORT}
           initialDelaySeconds: 30
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /health
+            path: ${PROBE_PATH}
             port: ${PORT}
           initialDelaySeconds: 10
           periodSeconds: 5


### PR DESCRIPTION
## Problem

`docker/kube-deploy.sh` rendered a manifest no service could serve. Both faults hit all five services, not just the backend — they surfaced while reviewing #1555, which added `backend.dockerfile`, but neither is introduced by it.

**Every rendered Service targeted a port with no listener.** `DEFAULT_PORT` was 8080 for baas, gateway, proxy, bcs and backend alike. None of them listens there:

| service | real default | source |
| --- | --- | --- |
| baas | 8888 | `configs/application.yaml` `module_config.web.port`; `WebConfig.port` default |
| gateway | 8888 | `configs/application.yaml`; `_config_loader.py` default |
| proxy | 8888 | `WebConfig.port` default (its configs set no port) |
| bcs | 21000 | `configs/bcs-config-*.toml` |
| backend | 8888 | `main.py` `BACKEND_PORT` default |

The script's own header disagreed with its `DEFAULT_PORT` array as well, listing gateway at 8080 and backend at 8090 — three different answers, none of them right.

**The shared template hardcoded `/health` for both probes.** The backend mounts its routes under `/api` and registers only `/api/health` (`adapters/http/app.py:898`), so a backend pod rendered from this template would never pass readiness, and liveness would restart a healthy pod on a loop.

## Solution

Per-service tables in `kube-deploy.sh`, and a `${PROBE_PATH}` placeholder in `service-deployment.yaml`.

`DEFAULT_PORT` now carries each service's real default, and `DEFAULT_PROBE_PATH` gives `/health` to baas/gateway/proxy/bcs — unchanged behavior for all four — and `/api/health` to backend.

A third fault surfaced while fixing the first: **a `PORT` override only relabelled the Service** while the process kept listening where its config said, reproducing the same dead port. gateway, proxy and backend each read a port env var (`GATEWAY_PORT`, `SANDBOXPROXY_PORT`, `BACKEND_PORT`) that wins over the config file, so `PORT_ENV_VAR` now injects it set to `PORT` and the two move together. An explicit `--env` for the same key still wins — the operator asked for it by name — and warns if it disagrees with the published port rather than silently emitting a duplicate. baas and bcs have no such override, so overriding `PORT` for them warns that the mounted config has to be edited to match.

Rejected: adding a `/health` alias to the backend. That puts a route in the app to satisfy a deployment template — the dependency pointing the wrong way — and still leaves the template unable to describe any service whose probe path differs.

**One drive-by**, called out so it can be dropped if unwanted: `usage()` quit on the first `/^# ====/` line, which is the opening banner, so `--help` printed that single line and nothing else. Since the header block is exactly where this change documents the per-service ports, leaving it unreachable would have hidden the fix's own documentation. Now `awk`-based, matching `docker/build-image.sh`.

## Validation

`envsubst` was installed locally (`gettext-base`) and the script run for real; there is no cluster here, so everything below is the rendered manifest, not an applied one. `kubectl apply` was never invoked.

- **All five services render correctly** — port, probe path, and injected env var each checked against the table above: baas `8888 /health`, gateway `8888 /health`, proxy `8888 /health`, bcs `21000 /health`, backend `8888 /api/health`.
- **Rendered YAML parses** as exactly two documents (Deployment + Service) for all five, with an assertion that `livenessProbe.httpGet.port == containerPort == Service.targetPort` and that both probes carry the same path. No unsubstituted placeholder survives — the one `${...}` remaining in the output is literal text inside the template's own YAML comment, pre-existing.
- **`PORT=9000 --service backend`** → `containerPort: 9000` *and* `BACKEND_PORT=9000`, moving together.
- **`--env BACKEND_PORT=9999`** → operator's value kept, exactly one `BACKEND_PORT` entry (no duplicate), and a warning naming both ports.
- **`PORT=9000 --service baas`** → warns that baas takes its port from its mounted config and that `PORT` alone only changes the manifest.
- **Regressions checked:** `--env-file` still loads and renders, the no-`--env` path still renders a valid manifest, unknown `--service` still exits 2 with the supported list, and `--help` now prints 50 lines instead of 1.
- `bash -n` clean.

**Not verified:** no Kubernetes cluster was available, so no pod was actually scheduled and no probe was observed passing against a running container. The port and path values are verified against each service's config and route registration, not against a live deployment.

## Compatibility and risk

**No behavior change for baas, gateway, proxy or bcs probes** — all four keep `/health`. What does change for them is the rendered port, from 8080 to the port they actually listen on. Any deployment currently relying on the 8080 value was pointing at a dead port, so there is nothing working today that this breaks; a deployment that overrode `PORT` to compensate should drop the override.

`PROBE_PATH` and `PORT` both remain overridable from the environment, so an operator can still name either explicitly.

Rollback is a revert; no schema, API, or data migration.

## Related issues

Clears the two follow-ups #1533 left open and #1555's description carries forward, both also raised by automated review on #1555 (inclusionAI/Avernet#1555 threads on the probe path and the port). The third item from that PR — the `sudo`-prefixed publish path in `BotBuildService._migrate_bot_instance` — is deliberately **not** here; it is a backend change in `core/service_bot/`, tracked separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9dvuxJaszNm4bJxq2vxGa)_