### PR TITLE
fix(aicoding): 应用 Bot 多工作流完整物化 AIX_DEVFLOW_INFO_LIST 到容器

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -326,15 +326,16 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         if template_type and ctx.bot_type != "service":
             envs["BOT_TYPE"] = LEGACY_BOT_TYPE_ENV_MAP.get(template_type, template_type)
 
-        devflow_workflow = template_config.get("devflow_workflow", "")
-        if isinstance(devflow_workflow, dict):
-            aix_devflow_info = devflow_workflow.get("path", "")
-        elif isinstance(devflow_workflow, str):
-            aix_devflow_info = devflow_workflow
-        else:
-            aix_devflow_info = ""
-        if aix_devflow_info:
-            envs["AIX_DEVFLOW_INFO"] = aix_devflow_info
+        devflow_paths = self._resolve_devflow_paths(template_config)
+        if devflow_paths:
+            # ``AIX_DEVFLOW_INFO`` keeps the single-valued contract old engine
+            # versions read (first selected workflow). ``AIX_DEVFLOW_INFO_LIST``
+            # carries the full ordered selection as a JSON array so a new
+            # engine materializes every bound workflow (RFC 220 UQ-16a).
+            envs["AIX_DEVFLOW_INFO"] = devflow_paths[0]
+            envs["AIX_DEVFLOW_INFO_LIST"] = json.dumps(
+                devflow_paths, ensure_ascii=False
+            )
 
         legacy_repo_keys = ("backend_repo", "frontend_repo", "lib_repo")
         repo_keys = list(legacy_repo_keys)
@@ -385,6 +386,43 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                 return None
             value = value.get(key)
         return value
+
+    @staticmethod
+    def _resolve_devflow_paths(template_config: dict[str, Any] | None) -> list[str]:
+        """Selected workflow yaml paths — ordered, de-duplicated.
+
+        Reads the plural ``devflow_workflows`` (full selection) when present,
+        otherwise falls back to the legacy singular ``devflow_workflow``
+        (which the frontend双写s as the first item). Each item may be a
+        ``{"path": "..."}`` dict (the persisted shape) or a bare string —
+        the same two shapes the singular reader historically accepted. The
+        plural key wins outright when set; it is never mixed with the
+        singular (the singular is always its first item, so mixing would
+        only duplicate what de-dup already handles — taking the plural
+        keeps the contract clean).
+        """
+        cfg = template_config or {}
+        paths: list[str] = []
+
+        def _extract(value: Any) -> None:
+            items = value if isinstance(value, list) else [value]
+            for item in items:
+                if isinstance(item, dict):
+                    path = item.get("path")
+                elif isinstance(item, str):
+                    path = item
+                else:
+                    path = None
+                if isinstance(path, str):
+                    path = path.strip()
+                    if path and path not in paths:
+                        paths.append(path)
+
+        if cfg.get("devflow_workflows") is not None:
+            _extract(cfg.get("devflow_workflows"))
+        else:
+            _extract(cfg.get("devflow_workflow"))
+        return paths
 
     def build_extra_properties(
         self,

--- a/src/backend/tests/community/core/bot_management/test_build_aix_extra_envs.py
+++ b/src/backend/tests/community/core/bot_management/test_build_aix_extra_envs.py
@@ -106,3 +106,111 @@ class TestRelayDefaultRuntime:
     def test_none_template_config_no_runtime(self):
         envs = build_aix_extra_envs(None, template_type="applicationCoding")
         assert envs == {"BOT_TYPE": "application"}
+
+
+class TestDevflowWorkflows:
+    """``AIX_DEVFLOW_INFO``（兼容首项单值）+ ``AIX_DEVFLOW_INFO_LIST``（全量 JSON 数组）—— RFC 220 UQ-16a。"""
+
+    def test_plural_list_emits_single_value_and_list(self):
+        cfg = {"devflow_workflows": ["workflows/a/workflow.yaml", "workflows/b/workflow.yaml"]}
+        envs = build_aix_extra_envs(cfg, template_type="applicationCoding")
+        assert envs["AIX_DEVFLOW_INFO"] == "workflows/a/workflow.yaml"
+        assert json.loads(envs["AIX_DEVFLOW_INFO_LIST"]) == [
+            "workflows/a/workflow.yaml",
+            "workflows/b/workflow.yaml",
+        ]
+
+    def test_plural_dict_items(self):
+        """前端把每条选择持久化成 ``{"path": ...}``；要抽 path 而非整 dict 透传。"""
+        cfg = {
+            "devflow_workflows": [
+                {"path": "workflows/a/workflow.yaml"},
+                {"path": "workflows/b/workflow.yaml"},
+            ]
+        }
+        envs = build_aix_extra_envs(cfg, template_type="applicationCoding")
+        assert envs["AIX_DEVFLOW_INFO"] == "workflows/a/workflow.yaml"
+        assert json.loads(envs["AIX_DEVFLOW_INFO_LIST"]) == [
+            "workflows/a/workflow.yaml",
+            "workflows/b/workflow.yaml",
+        ]
+
+    def test_plural_dedupes_preserving_order(self):
+        cfg = {
+            "devflow_workflows": [
+                "workflows/a/workflow.yaml",
+                "workflows/b/workflow.yaml",
+                "  workflows/a/workflow.yaml  ",
+            ]
+        }
+        envs = build_aix_extra_envs(cfg, template_type="applicationCoding")
+        assert json.loads(envs["AIX_DEVFLOW_INFO_LIST"]) == [
+            "workflows/a/workflow.yaml",
+            "workflows/b/workflow.yaml",
+        ]
+
+    def test_plural_single_selection_still_emits_list(self):
+        cfg = {"devflow_workflows": ["workflows/a/workflow.yaml"]}
+        envs = build_aix_extra_envs(cfg, template_type="applicationCoding")
+        assert envs["AIX_DEVFLOW_INFO"] == "workflows/a/workflow.yaml"
+        assert json.loads(envs["AIX_DEVFLOW_INFO_LIST"]) == ["workflows/a/workflow.yaml"]
+
+    def test_singular_string_falls_back(self):
+        """无复数 key → 旧单数字符串仍可用；list 带这一条。"""
+        cfg = {"devflow_workflow": "devflow/app.yaml"}
+        envs = build_aix_extra_envs(cfg, template_type="applicationCoding")
+        assert envs["AIX_DEVFLOW_INFO"] == "devflow/app.yaml"
+        assert json.loads(envs["AIX_DEVFLOW_INFO_LIST"]) == ["devflow/app.yaml"]
+
+    def test_singular_dict_extracts_path(self):
+        cfg = {"devflow_workflow": {"path": "devflow/v2/app.yaml"}}
+        envs = build_aix_extra_envs(cfg, template_type="applicationCoding")
+        assert envs["AIX_DEVFLOW_INFO"] == "devflow/v2/app.yaml"
+        assert json.loads(envs["AIX_DEVFLOW_INFO_LIST"]) == ["devflow/v2/app.yaml"]
+
+    def test_plural_wins_over_singular(self):
+        """前端双写（复数全量 + 单数首项）→ 取复数，单数忽略不重复。"""
+        cfg = {
+            "devflow_workflows": ["workflows/a/workflow.yaml", "workflows/b/workflow.yaml"],
+            "devflow_workflow": "workflows/a/workflow.yaml",
+        }
+        envs = build_aix_extra_envs(cfg, template_type="applicationCoding")
+        assert json.loads(envs["AIX_DEVFLOW_INFO_LIST"]) == [
+            "workflows/a/workflow.yaml",
+            "workflows/b/workflow.yaml",
+        ]
+
+    def test_empty_selection_emits_nothing(self):
+        envs = build_aix_extra_envs({"devflow_workflows": []}, template_type="applicationCoding")
+        assert "AIX_DEVFLOW_INFO" not in envs
+        assert "AIX_DEVFLOW_INFO_LIST" not in envs
+
+    def test_no_devflow_keys_emits_nothing(self):
+        envs = build_aix_extra_envs({"model": "m1"}, template_type="applicationCoding")
+        assert "AIX_DEVFLOW_INFO" not in envs
+        assert "AIX_DEVFLOW_INFO_LIST" not in envs
+
+    def test_personal_coding_multiselect(self):
+        """personalCoding 与 applicationCoding 同口径享多选契约。"""
+        cfg = {"devflow_workflows": ["workflows/a/workflow.yaml", "workflows/b/workflow.yaml"]}
+        envs = build_aix_extra_envs(cfg, template_type="personalCoding")
+        assert envs["BOT_TYPE"] == "personal"
+        assert json.loads(envs["AIX_DEVFLOW_INFO_LIST"]) == [
+            "workflows/a/workflow.yaml",
+            "workflows/b/workflow.yaml",
+        ]
+
+    def test_multiselect_coexists_with_git_and_model(self):
+        cfg = {
+            "devflow_workflows": ["workflows/a/workflow.yaml", "workflows/b/workflow.yaml"],
+            "backend_repo": [{"repo_url": "git@x/y.git"}],
+            "model": "m1",
+        }
+        envs = build_aix_extra_envs(cfg, template_type="applicationCoding")
+        assert envs["AIX_DEVFLOW_INFO"] == "workflows/a/workflow.yaml"
+        assert json.loads(envs["AIX_DEVFLOW_INFO_LIST"]) == [
+            "workflows/a/workflow.yaml",
+            "workflows/b/workflow.yaml",
+        ]
+        assert json.loads(envs["GIT_ADDRESSES"]) == ["git@x/y.git"]
+        assert envs["RELAY_DEFAULT_MODEL"] == "m1"

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -279,6 +279,7 @@ async def test_verify_first_release_injects_engine_extra_envs_without_bot_type_f
     assert build_service.release_async.await_args.kwargs["extra_envs"] == {
         "AGENTCLAW_SKILLS_LAYOUT": "legacy",
         "AIX_DEVFLOW_INFO": "devflow/app.yaml",
+        "AIX_DEVFLOW_INFO_LIST": '["devflow/app.yaml"]',
         "GIT_ADDRESSES": '["git@x/y.git"]',
         "RELAY_DEFAULT_MODEL": "antchat/Ling-2.6-1T",
         "RELAY_DEFAULT_RUNTIME": "python",


### PR DESCRIPTION
## 背景

应用 Bot 已绑定多个 DevFlow 工作流（`template_config.devflow_workflows`），但 OCB AICoding provisioning strategy 只读单数 `devflow_workflow`，多选被截断成首条 —— 容器 `.aix/workflows/` 只物化首条工作流，`aix workflow list` 发现不了后续条目。

## 改动（仅 OCB 后端 community 层）

`agentclaw/community/core/bot_management/engines/aicoding/strategy.py`

- 新增 `AicodingProvisioningStrategy._resolve_devflow_paths`：**复数 `devflow_workflows` 优先、单数 `devflow_workflow` 回退**；保序去重；每项兼容 `{"path": ...}` dict（前端持久化形态）与裸 string。
- `build_extra_envs` 下发：
  - `AIX_DEVFLOW_INFO` = 首条（**保留单值契约，旧 engine 不受影响**）
  - `AIX_DEVFLOW_INFO_LIST` = 全量 JSON 数组（RFC 220 UQ-16a，对齐 `GIT_ADDRESSES` 风格）

`build_extra_envs` 是 OCB 的唯一漏斗，create / restart / update / service-publish / baas 全路径自动一致（无需逐路径改）。

## 兼容性

| OCB | engine | 预期 |
|---|---|---|
| 旧 | 旧 | 单条，现状不变 |
| 新 | 旧 | 旧 engine 忽略 `AIX_DEVFLOW_INFO_LIST`，读 `AIX_DEVFLOW_INFO` 首条 → 不影响启动 |
| 旧 | 新 | list 缺失 → engine 回退单值 |
| 新 | 新 | 完整物化全部工作流 |

## 测试

- 新增 `TestDevflowWorkflows` 11 用例（多选/单选/旧单值/dict/string/双写取复数/去重/空选/coexist）。
- 更新 `test_publish_flow_service.py` 一处等值断言补 `AIX_DEVFLOW_INFO_LIST`。
- 聚焦套件（create/restart/update/publish/device/provisioning）**386 passed**。

## 说明

- engine 侧（`aix-engine-workspace` `init_bootstrap.rs` 读 `AIX_DEVFLOW_INFO_LIST` 逐条物化）另起 PR，与本 PR 独立、可并行（兼容矩阵保证任一方向先合都优雅降级）。
- 前端 `open-claw` 已双写 `devflow_workflows`（全量）+ `devflow_workflow`（首项），本 PR 不涉及前端。