### PR TITLE
feat(bcs): add bcs aliyun docker image and ${VAR} config env expansion

### DIFF
--- a/docker/services/bcs.dockerfile
+++ b/docker/services/bcs.dockerfile
@@ -1,0 +1,81 @@
+########## Builder ##########
+FROM rust:1.91-bookworm AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    CARGO_TERM_COLOR=never \
+    CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
+WORKDIR /build
+
+# Aliyun apt mirror (matches the gateway/baas builder convention).
+# native-tls (tokio-tungstenite/mysql_async) needs OpenSSL; rusqlite is *not*
+# bundled, so both need their dev headers at build time.
+RUN sed -i "s|deb.debian.org|mirrors.aliyun.com|g" /etc/apt/sources.list.d/debian.sources \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        pkg-config libssl-dev libsqlite3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# "Pull code": the BCS Rust workspace is brought in from the build context
+# (repo root). docker/build-image.sh sends the repo root as the context, so
+# this COPY is the code-fetch step — there is no in-image git clone. The
+# workspace is self-contained under src/bcs (no path deps outside it).
+COPY src/bcs /build/src/bcs
+
+# Fetch dependencies into the registry cache first, so source-only changes
+# reuse the downloaded crates.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo fetch --locked --manifest-path /build/src/bcs/Cargo.toml
+
+# Build the `bcs` server binary (release, pinned to the checked-in Cargo.lock).
+# The target dir is a cache mount, which is NOT retained in the layer after the
+# RUN — so copy the produced binary to a stable path and strip it within the
+# same RUN while the cache mount is still mounted.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/build/src/bcs/target \
+    cargo build --release --locked --manifest-path /build/src/bcs/Cargo.toml --bin bcs \
+    && cp /build/src/bcs/target/release/bcs /build/bcs \
+    && strip /build/bcs
+
+########## Runtime ##########
+FROM debian:bookworm-slim AS runtime
+
+# BCS_CONFIG_DIR points the binary at its config directory (clap reads this env
+# directly). SERVER_ENV selects the bcs-config-{env}.toml overlay; leave it to
+# the deployment to set a value whose matching config exists in /app/configs.
+ENV DEBIAN_FRONTEND=noninteractive \
+    HOME=/home/admin \
+    BCS_CONFIG_DIR=/app/configs
+
+WORKDIR /app
+
+RUN sed -i "s|deb.debian.org|mirrors.aliyun.com|g" /etc/apt/sources.list.d/debian.sources \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl libssl3 libsqlite3-0 \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 10001 admin \
+    && useradd --uid 10001 --gid admin --create-home --shell /bin/bash admin
+
+COPY --from=builder /build/bcs /usr/local/bin/bcs
+COPY src/bcs/configs /app/configs
+
+# Persistence: bots_base_dir and the session-file data_dir must live on a
+# writable volume. The shipped example config uses /var/lib/bcs; mount a
+# PVC/emptyDir here and point the config's data paths at it.
+RUN mkdir -p /app/tmp /var/lib/bcs /home/admin/logs \
+    && chown -R admin:admin /app /var/lib/bcs /home/admin
+
+USER admin
+
+EXPOSE 21000
+
+# BCS reads its listen address from the mounted config (`bind`/`port`), not
+# from an env var. The healthcheck targets 21000 — keep it in sync with the
+# config's port.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=60s --retries=6 \
+    CMD curl -fsS "http://127.0.0.1:21000/health" >/dev/null || exit 1
+
+# clap picks up BCS_CONFIG_DIR from the environment; override SERVER_ENV /
+# BCS_CONFIG_DIR via the deployment to select the config overlay.
+ENTRYPOINT ["bcs"]

--- a/docker/services/bcs.dockerfile
+++ b/docker/services/bcs.dockerfile
@@ -22,8 +22,9 @@ RUN sed -i "s|deb.debian.org|mirrors.aliyun.com|g" /etc/apt/sources.list.d/debia
 # workspace is self-contained under src/bcs (no path deps outside it).
 COPY src/bcs /build/src/bcs
 
-# Fetch dependencies into the registry cache first, so source-only changes
-# reuse the downloaded crates.
+# Prefetch dependencies into the registry cache mount. BuildKit retains the
+# cache across builds, so repeated builds reuse already-downloaded crates even
+# though the `COPY src/bcs` layer above busts on any source change.
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo fetch --locked --manifest-path /build/src/bcs/Cargo.toml
 

--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -2,9 +2,21 @@
 #
 # Copy this file, replace every example.com host and replace-with-* value,
 # then run. Do not commit real credentials.
+#
+# Environment variable references in quoted string values:
+#   key = "${VAR}"            -> value of env var VAR; startup fails if VAR is unset
+#   key = "${VAR:-default}"   -> default when VAR is unset or empty
+# Only quoted strings are expanded (bare key = ${VAR} is not valid TOML).
+# There is NO generic BCS_* substitution — only the specific variables the
+# DB/Redis loaders read hardcoded override the [database.mysql.connection]
+# and [cache.redis.connection] fields (BCS_DB_HOST/PORT/USER/PASSWORD/...,
+# BCS_REDIS_HOST/PORT/PASSWORD/...); those parse the env string into the
+# right type, so they are how numeric fields such as port get env-injected.
+# There is no escape for a literal "${" — avoid real "${...}" in string
+# values unless it is an env reference.
 
 bind = "0.0.0.0"
-port = 21000
+port = 21000  # Dockerfile healthcheck targets 21000; keep in sync if you change this.
 bots_base_dir = "/var/lib/bcs/bots"
 
 max_history_per_session = 1000

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -1445,7 +1445,21 @@ impl BcsConfig {
         let mut config = match ext.to_lowercase().as_str() {
             "json" => parse_and_expand("json")?,
             "toml" => parse_and_expand("toml")?,
-            _ => parse_and_expand("json").or_else(|_| parse_and_expand("toml"))?,
+            // Unknown extension: try JSON first, then TOML. Only fall through to
+            // TOML when the content fails to *parse* as JSON — a valid JSON
+            // document must surface its own expansion/deserialize errors instead
+            // of being retried (and mis-reported) as a TOML parse error.
+            _ => match crate::config_loader::parse_config_content(
+                "json",
+                &content,
+                &path_display,
+            ) {
+                Ok(mut value) => {
+                    crate::config_loader::expand_env_vars(&mut value)?;
+                    serde_json::from_value(value)?
+                }
+                Err(_) => parse_and_expand("toml")?,
+            },
         };
 
         let local_path_base_dir = local_path_base_dir_for_config_file(path);
@@ -1638,6 +1652,31 @@ botchat_url = "${BCS_TEST_FROM_FILE_MISSING}"
         assert!(
             err.contains("BCS_TEST_FROM_FILE_MISSING"),
             "error should name the missing var: {err}"
+        );
+    }
+
+    #[test]
+    fn from_file_unknown_ext_json_with_unset_env_reports_env_error_not_toml() {
+        // A valid JSON document with an unset `${VAR}` must surface the env
+        // error directly, not be retried as TOML and mis-reported. Guards the
+        // `_` (unknown extension) branch swallowing expansion errors.
+        safe_remove_var("BCS_TEST_UNKNOWN_EXT_VAR");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bcs-config"); // no extension -> unknown-ext branch
+        std::fs::write(
+            &path,
+            r#"{"bots_base_dir":"/bots","botchat_url":"${BCS_TEST_UNKNOWN_EXT_VAR}"}"#,
+        )
+        .unwrap();
+
+        let err = BcsConfig::from_file(&path).unwrap_err().to_string();
+        assert!(
+            err.contains("BCS_TEST_UNKNOWN_EXT_VAR"),
+            "should surface the unset env-var error, got: {err}"
+        );
+        assert!(
+            !err.to_lowercase().contains("toml"),
+            "should not misreport as a TOML parse error, got: {err}"
         );
     }
 

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -1430,49 +1430,31 @@ impl BcsConfig {
     pub fn from_file(path: &PathBuf) -> Result<Self, Box<dyn std::error::Error>> {
         let content = std::fs::read_to_string(path)?;
         let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        let path_display = path.display().to_string();
 
-        match ext.to_lowercase().as_str() {
-            "json" => {
-                let mut config: Self = serde_json::from_str(&content)?;
-                let local_path_base_dir = local_path_base_dir_for_config_file(path);
-                normalize_local_paths(&mut config, &local_path_base_dir);
-                validate_loaded_config_for_environment(
-                    &config,
-                    crate::config_loader::Environment::resolve(),
-                )?;
-                Ok(config)
-            }
-            "toml" => {
-                let mut config: Self = toml::from_str(&content)?;
-                let local_path_base_dir = local_path_base_dir_for_config_file(path);
-                normalize_local_paths(&mut config, &local_path_base_dir);
-                validate_loaded_config_for_environment(
-                    &config,
-                    crate::config_loader::Environment::resolve(),
-                )?;
-                Ok(config)
-            }
-            _ => {
-                // Try JSON first, then TOML
-                if let Ok(mut config) = serde_json::from_str::<Self>(&content) {
-                    let local_path_base_dir = local_path_base_dir_for_config_file(path);
-                    normalize_local_paths(&mut config, &local_path_base_dir);
-                    validate_loaded_config_for_environment(
-                        &config,
-                        crate::config_loader::Environment::resolve(),
-                    )?;
-                    return Ok(config);
-                }
-                let mut config: Self = toml::from_str(&content)?;
-                let local_path_base_dir = local_path_base_dir_for_config_file(path);
-                normalize_local_paths(&mut config, &local_path_base_dir);
-                validate_loaded_config_for_environment(
-                    &config,
-                    crate::config_loader::Environment::resolve(),
-                )?;
-                Ok(config)
-            }
-        }
+        // Parse to a JSON `Value`, expand `${VAR}` references, then deserialize.
+        // Routing through `Value` (instead of parsing straight into `Self`) keeps
+        // env-reference expansion consistent with the multi-env loader path and
+        // applies it to standalone/single-file configs too.
+        let parse_and_expand = |fmt: &str| -> Result<Self, Box<dyn std::error::Error>> {
+            let mut value = crate::config_loader::parse_config_content(fmt, &content, &path_display)?;
+            crate::config_loader::expand_env_vars(&mut value)?;
+            Ok(serde_json::from_value(value)?)
+        };
+
+        let mut config = match ext.to_lowercase().as_str() {
+            "json" => parse_and_expand("json")?,
+            "toml" => parse_and_expand("toml")?,
+            _ => parse_and_expand("json").or_else(|_| parse_and_expand("toml"))?,
+        };
+
+        let local_path_base_dir = local_path_base_dir_for_config_file(path);
+        normalize_local_paths(&mut config, &local_path_base_dir);
+        validate_loaded_config_for_environment(
+            &config,
+            crate::config_loader::Environment::resolve(),
+        )?;
+        Ok(config)
     }
 
     /// Validate `api_keys` (Part B Task 3, spec §9.6.2):
@@ -1616,6 +1598,47 @@ mod tests {
         unsafe {
             std::env::remove_var(key);
         }
+    }
+
+    #[test]
+    fn from_file_expands_env_references_in_string_fields() {
+        safe_set_var("BCS_TEST_FROM_FILE_TOKEN", "expanded-via-from-file");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bcs-config.toml");
+        std::fs::write(
+            &path,
+            r#"
+bots_base_dir = "/bots"
+botchat_url = "${BCS_TEST_FROM_FILE_TOKEN}"
+"#,
+        )
+        .unwrap();
+
+        let config = BcsConfig::from_file(&path).unwrap();
+        assert_eq!(config.botchat_url.as_deref(), Some("expanded-via-from-file"));
+        safe_remove_var("BCS_TEST_FROM_FILE_TOKEN");
+    }
+
+    #[test]
+    fn from_file_errors_when_a_required_env_reference_is_unset() {
+        safe_remove_var("BCS_TEST_FROM_FILE_MISSING");
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bcs-config.toml");
+        std::fs::write(
+            &path,
+            r#"
+bots_base_dir = "/bots"
+botchat_url = "${BCS_TEST_FROM_FILE_MISSING}"
+"#,
+        )
+        .unwrap();
+
+        let result = BcsConfig::from_file(&path);
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("BCS_TEST_FROM_FILE_MISSING"),
+            "error should name the missing var: {err}"
+        );
     }
 
     #[test]

--- a/src/bcs/crates/bootstrap/bcs/src/config_loader.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config_loader.rs
@@ -169,6 +169,122 @@ fn is_sensitive_config_key(key: &str) -> bool {
         || lower.ends_with("_token")
 }
 
+/// Parse raw config file content (TOML or JSON) into a JSON `Value`.
+///
+/// TOML is converted through `toml::Value` so the result is merge-compatible
+/// with JSON configs. `path_display` is used only for error messages.
+pub(crate) fn parse_config_content(
+    ext: &str,
+    content: &str,
+    path_display: &str,
+) -> Result<Value, ConfigLoadError> {
+    match ext.to_lowercase().as_str() {
+        "json" => serde_json::from_str(content)
+            .map_err(|e| ConfigLoadError::Parse(path_display.to_string(), e.to_string())),
+        "toml" => {
+            // Convert TOML to JSON Value for merge compatibility
+            let toml_value: toml::Value = toml::from_str(content)
+                .map_err(|e| ConfigLoadError::Parse(path_display.to_string(), e.to_string()))?;
+            serde_json::to_value(toml_value)
+                .map_err(|e| ConfigLoadError::Parse(path_display.to_string(), e.to_string()))
+        }
+        _ => Err(ConfigLoadError::UnsupportedFormat(path_display.to_string())),
+    }
+}
+
+/// Recursively expand `${VAR}` / `${VAR:-default}` references in every string
+/// value of a parsed config tree.
+///
+/// This runs after the env-overlay deep-merge and before deserialization, so
+/// only final (env-overridden) string values are resolved from the process
+/// environment, and the typed config struct receives the expanded values.
+/// Non-string values (numbers, booleans, null) are left untouched, which means
+/// `${VAR}` only works for string-typed fields; numeric/boolean fields must
+/// continue to use the typed `BCS_*` env overrides (e.g. `BCS_REDIS_PORT`).
+/// No nested expansion is performed on substituted values.
+pub(crate) fn expand_env_vars(value: &mut Value) -> Result<(), ConfigLoadError> {
+    match value {
+        Value::Object(map) => {
+            for (_, child) in map.iter_mut() {
+                expand_env_vars(child)?;
+            }
+            Ok(())
+        }
+        Value::Array(items) => {
+            for item in items.iter_mut() {
+                expand_env_vars(item)?;
+            }
+            Ok(())
+        }
+        Value::String(s) => {
+            *s = expand_env_string(s)?;
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Expand `${VAR}` / `${VAR:-default}` tokens within a single string.
+///
+/// - `${VAR}` resolves to the env var's value. A missing variable is a hard
+///   error (fail fast) so a missing secret aborts startup instead of silently
+///   becoming an empty string.
+/// - `${VAR:-default}` uses `default` when the variable is unset or empty,
+///   providing the opt-out for optional values.
+/// - An empty-but-set variable with no default expands to the empty string
+///   (the variable is explicitly set).
+/// - A literal `${` that is not a well-formed reference (`${NAME}` or
+///   `${NAME:-...}`) is a hard error.
+fn expand_env_string(input: &str) -> Result<String, ConfigLoadError> {
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(start) = rest.find("${") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start + 2..];
+        let end = after
+            .find('}')
+            .ok_or_else(|| ConfigLoadError::EnvExpansion(format!(
+                "config value has an unterminated environment reference: {rest:?}"
+            )))?;
+        let token = &after[..end];
+        let remaining = &after[end + 1..];
+        let (name, default) = match token.split_once(":-") {
+            Some((n, d)) => (n, Some(d)),
+            None => (token, None),
+        };
+        if !is_valid_env_name(name) {
+            return Err(ConfigLoadError::EnvExpansion(format!(
+                "invalid environment variable name `{name}` in config reference"
+            )));
+        }
+        let segment = match std::env::var(name) {
+            Ok(v) if !v.is_empty() => v,
+            Ok(v) => match default {
+                Some(d) => d.to_string(),
+                None => v, // empty-but-set variable with no default
+            },
+            Err(_) => match default {
+                Some(d) => d.to_string(),
+                None => {
+                    return Err(ConfigLoadError::EnvExpansion(format!(
+                        "environment variable `{name}` referenced in config is not set"
+                    )))
+                }
+            },
+        };
+        out.push_str(&segment);
+        rest = remaining;
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+fn is_valid_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 /// Configuration loader with multi-environment support.
 pub struct ConfigLoader {
     config_dir: PathBuf,
@@ -245,7 +361,7 @@ impl ConfigLoader {
 
         // 2. Load environment-specific config (optional)
         let env_path = self.find_env_config();
-        let (merged_value, env_config_path) = if env_path.exists() {
+        let (mut merged_value, env_config_path) = if env_path.exists() {
             let env_value = self.load_config_value(&env_path)?;
             let mut merged = base_value;
             deep_merge(&mut merged, &env_value);
@@ -253,6 +369,11 @@ impl ConfigLoader {
         } else {
             (base_value, None)
         };
+
+        // Expand `${VAR}` / `${VAR:-default}` references in string values after
+        // the env-overlay merge, so only the final resolved values are read
+        // from the process environment.
+        expand_env_vars(&mut merged_value)?;
 
         // 3. Deserialize to target type
         let config = serde_json::from_value(merged_value.clone())
@@ -307,18 +428,7 @@ impl ConfigLoader {
             .and_then(|e| e.to_str())
             .unwrap_or("toml");
 
-        match ext.to_lowercase().as_str() {
-            "json" => serde_json::from_str(&content)
-                .map_err(|e| ConfigLoadError::Parse(path.display().to_string(), e.to_string())),
-            "toml" => {
-                // Convert TOML to JSON Value for merge compatibility
-                let toml_value: toml::Value = toml::from_str(&content)
-                    .map_err(|e| ConfigLoadError::Parse(path.display().to_string(), e.to_string()))?;
-                serde_json::to_value(toml_value)
-                    .map_err(|e| ConfigLoadError::Parse(path.display().to_string(), e.to_string()))
-            }
-            _ => Err(ConfigLoadError::UnsupportedFormat(path.display().to_string())),
-        }
+        parse_config_content(ext, &content, &path.display().to_string())
     }
 }
 
@@ -344,6 +454,10 @@ pub enum ConfigLoadError {
     /// Unsupported config format
     #[error("Unsupported config format: {0}")]
     UnsupportedFormat(String),
+
+    /// Failed to expand a `${VAR}` environment reference in config values
+    #[error("Config environment reference expansion failed: {0}")]
+    EnvExpansion(String),
 }
 
 impl ConfigLoadError {
@@ -654,6 +768,149 @@ mod tests {
 
         let result: Result<serde_json::Value, _> = loader.load();
         assert!(result.is_err());
+    }
+
+    // =========================================================================
+    // ${VAR} environment-reference expansion tests
+    // =========================================================================
+
+    #[test]
+    fn expand_env_string_resolves_a_present_variable() {
+        unsafe { std::env::set_var("BCS_TEST_CFG_TOKEN", "super-secret"); }
+        assert_eq!(
+            expand_env_string("prefix-${BCS_TEST_CFG_TOKEN}-suffix").unwrap(),
+            "prefix-super-secret-suffix"
+        );
+        unsafe { std::env::remove_var("BCS_TEST_CFG_TOKEN"); }
+    }
+
+    #[test]
+    fn expand_env_string_resolves_multiple_tokens_and_keeps_literal_text() {
+        unsafe {
+            std::env::set_var("BCS_TEST_CFG_HOST", "example.com");
+            std::env::set_var("BCS_TEST_CFG_PORT", "8443");
+        }
+        assert_eq!(
+            expand_env_string("https://${BCS_TEST_CFG_HOST}:${BCS_TEST_CFG_PORT}/path").unwrap(),
+            "https://example.com:8443/path"
+        );
+        unsafe {
+            std::env::remove_var("BCS_TEST_CFG_HOST");
+            std::env::remove_var("BCS_TEST_CFG_PORT");
+        }
+    }
+
+    #[test]
+    fn expand_env_string_uses_default_when_unset() {
+        unsafe { std::env::remove_var("BCS_TEST_CFG_ABSENT"); }
+        assert_eq!(
+            expand_env_string("${BCS_TEST_CFG_ABSENT:-fallback}").unwrap(),
+            "fallback"
+        );
+    }
+
+    #[test]
+    fn expand_env_string_uses_env_over_default_when_set() {
+        unsafe { std::env::set_var("BCS_TEST_CFG_PRESENT", "real"); }
+        assert_eq!(
+            expand_env_string("${BCS_TEST_CFG_PRESENT:-fallback}").unwrap(),
+            "real"
+        );
+        unsafe { std::env::remove_var("BCS_TEST_CFG_PRESENT"); }
+    }
+
+    #[test]
+    fn expand_env_string_errors_on_unset_without_default() {
+        unsafe { std::env::remove_var("BCS_TEST_CFG_REQUIRED"); }
+        let err = expand_env_string("${BCS_TEST_CFG_REQUIRED}").unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("BCS_TEST_CFG_REQUIRED"), "error should name the missing var: {message}");
+    }
+
+    #[test]
+    fn expand_env_string_errors_on_invalid_name() {
+        // Names must start with a letter or underscore.
+        let err = expand_env_string("${1INVALID}").unwrap_err();
+        assert!(err.to_string().contains("invalid environment variable name"));
+    }
+
+    #[test]
+    fn expand_env_string_errors_on_unterminated_reference() {
+        let err = expand_env_string("prefix-${NO_CLOSE").unwrap_err();
+        assert!(err.to_string().contains("unterminated"));
+    }
+
+    #[test]
+    fn expand_env_string_leaves_text_without_references_untouched() {
+        assert_eq!(
+            expand_env_string("plain value with no reference").unwrap(),
+            "plain value with no reference"
+        );
+    }
+
+    #[test]
+    fn expand_env_vars_walks_objects_and_arrays_and_skips_non_strings() {
+        unsafe { std::env::set_var("BCS_TEST_CFG_VAL", "expanded"); }
+        let mut value = serde_json::json!({
+            "url": "https://${BCS_TEST_CFG_VAL}/api",
+            "keys": ["${BCS_TEST_CFG_VAL}", "literal"],
+            "port": 21000,
+            "nested": { "deep": "${BCS_TEST_CFG_VAL}" },
+        });
+        expand_env_vars(&mut value).unwrap();
+        assert_eq!(value["url"], "https://expanded/api");
+        assert_eq!(value["keys"][0], "expanded");
+        assert_eq!(value["keys"][1], "literal");
+        assert_eq!(value["port"], 21000); // numeric values are untouched
+        assert_eq!(value["nested"]["deep"], "expanded");
+        unsafe { std::env::remove_var("BCS_TEST_CFG_VAL"); }
+    }
+
+    #[test]
+    #[serial]
+    fn loader_expands_references_in_loaded_string_fields() {
+        unsafe { std::env::set_var("BCS_TEST_CFG_BOTCHAT", "https://botchat.example.com"); }
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("bcs-config.toml"),
+            r#"
+                bind = "0.0.0.0"
+                port = 21000
+                bots_base_dir = "/bots"
+                botchat_url = "${BCS_TEST_CFG_BOTCHAT}"
+            "#,
+        )
+        .unwrap();
+
+        let loader = ConfigLoader::new(dir.path().to_path_buf())
+            .with_environment(Environment::Prod);
+        let config: serde_json::Value = loader.load().unwrap();
+
+        assert_eq!(config["botchat_url"], "https://botchat.example.com");
+        unsafe { std::env::remove_var("BCS_TEST_CFG_BOTCHAT"); }
+    }
+
+    #[test]
+    #[serial]
+    fn loader_errors_when_a_required_reference_is_unset() {
+        unsafe { std::env::remove_var("BCS_TEST_CFG_MISSING"); }
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("bcs-config.toml"),
+            r#"
+                bind = "0.0.0.0"
+                port = 21000
+                bots_base_dir = "/bots"
+                botchat_url = "${BCS_TEST_CFG_MISSING}"
+            "#,
+        )
+        .unwrap();
+
+        let loader = ConfigLoader::new(dir.path().to_path_buf())
+            .with_environment(Environment::Prod);
+        let result: Result<serde_json::Value, _> = loader.load();
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("BCS_TEST_CFG_MISSING"), "error should name the missing var: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Deploying bcs on Aliyun k8s needs two things that did not exist:

1. **A container image** that builds and runs the bcs server binary on Aliyun ACK.
2. **A way to inject per-environment secrets/credentials into the TOML config at runtime** without baking them into the image. `bcs-config` had no generic environment interpolation — only specific typed overrides (`BCS_DB_*`, `BCS_REDIS_*`) and `*_env` indirection fields — leaving plain-literal secret fields (`auth.oauth.jwt_secret`, OAuth `client_secret`, `dingtalk_accounts`, `api_keys`, `botchat_url`, `bcs_endpoint`) unable to read from env at all.

## Solution

**`docker/services/bcs.dockerfile`** — multi-stage image mirroring `gateway.dockerfile`/`baas.dockerfile`:
- Builder: `rust:1.91-bookworm` (MSRV 1.91) + `pkg-config`/`libssl-dev`/`libsqlite3-dev` (native-tls → OpenSSL; `rusqlite` is not bundled). `cargo build --release --locked --bin bcs` with registry/target BuildKit cache mounts; the produced binary is `cp`'d to a stable path and `strip`'d within the same `RUN` (cache-mount contents don't survive the layer).
- Runtime: `debian:bookworm-slim` + `libssl3`/`libsqlite3-0` (bookworm in both stages to keep the ABI matched), non-root `admin` (10001), `COPY src/bcs/configs /app/configs`, `EXPOSE 21000`, `/health` healthcheck, `ENTRYPOINT ["bcs"]` reading `BCS_CONFIG_DIR`. Code comes from the build context (`COPY src/bcs`) — no in-image git clone; `docker/build-image.sh services/bcs.dockerfile` sends the repo root as context.

**Config `${VAR}` env expansion (string values only)** — after the env-overlay `deep_merge` and before deserialization, walk the merged `serde_json::Value` tree and expand `${VAR}` / `${VAR:-default}` in every string leaf:
- `${VAR}` resolves from the process env; a missing variable is a **hard error** (fail fast) so a missing secret aborts startup instead of silently becoming empty. `${VAR:-default}` is the opt-out for optional values.
- Quoted strings only (`key = "${VAR}"`); bare `key = ${VAR}` is not valid TOML. Non-string values are untouched, so `${VAR}` works only for string-typed fields; numeric/boolean fields keep using the typed `BCS_*` overrides (e.g. `BCS_REDIS_PORT`), which parse the env string into the right type. No nested expansion; format-agnostic (TOML and JSON both route through `serde_json::Value`).
- `config_loader.rs`: add `expand_env_vars`/`expand_env_string`, `ConfigLoadError::EnvExpansion`, extract `parse_config_content` for reuse, wire expansion into `load_with_info`. `config.rs`: route `BcsConfig::from_file` through `parse_config_content` → `expand_env_args` → `serde_json::from_value` so standalone/single-file configs expand too.

Draft because the bcs dockerfile still has an unresolved runtime-config caveat (see below) that I want to settle before merge.

## Validation

- `cargo build -p bcs` ✅
- `cargo test -p bcs --lib config::` — 65 passed (incl. 2 new `from_file` expansion tests).
- `cargo test -p bcs --lib config_loader::` — 34 passed (incl. 11 new env-expansion unit/loader-integration tests covering present/var-with-default/unset-error/multi-token/invalid-name/unterminated/non-string-skipped).
- `cargo clippy -p bcs --lib` — clean on the edited files (remaining findings are pre-existing in dependency crates).
- The 2 `migrations::tests` failures are pre-existing and unrelated (this host's older SQLite rejects `ALTER TABLE … DEFAULT (expr)` and `DROP COLUMN`); confirmed by re-running on clean `dev` with these changes stashed.

## Compatibility and risk

- Config: **additive**. Existing configs have no `${...}`, so expansion is a no-op for them — zero regression risk. Only configs that opt into `${...}` are affected, and a missing required var now fails loudly at startup (safer than a silent empty secret).
- Image: `bcs.dockerfile` ships `src/bcs/configs` as-is. The checked-in configs (`bcs-config-local.toml` binds `127.0.0.1`; `bcs-config-example.toml` has placeholders) are **not container-runnable as-is** — a real `bcs-config-{env}.toml` (with `bind = "0.0.0.0"`) must be present in `/app/configs`, either added to the repo or mounted via k8s. With the new `${VAR}` expansion, secrets/endpoints can now be injected via k8s Secret → env → `${VAR}` in that config, keeping secrets out of the image. healthcheck port is hardcoded to 21000 (bcs reads its port from config, not env — keep in sync).
- Persistence: `bots_base_dir` / session-file `data_dir` need a writable volume mount (the example config uses `/var/lib/bcs`).

## Open question for review

Should a runnable `bcs-config-prod.toml` (or a k8s ConfigMap/Secret spec) be added in this PR, or is the Dockerfile + `${VAR}` expansion enough and the runtime config handled by the deploy manifests? Leaning toward the latter (manifests own the real config); the image + expansion are the reusable pieces.