### PR TITLE
perf(backend): batch device I/O across every Skills, Skill Sets and MCP API

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/device_io_batch.py
+++ b/src/backend/src/agentclaw/community/core/devices/device_io_batch.py
@@ -26,7 +26,9 @@ import asyncio
 DEVICE_IO_CONCURRENCY = 8
 
 
-async def gather_device_io(coroutines: list) -> list:
+async def gather_device_io(
+    coroutines: list, *, return_exceptions: bool = False
+) -> list:
     """Run per-file device I/O concurrently, bounded, and drain before returning.
 
     Every coroutine is awaited to completion even after one fails, then the first
@@ -36,6 +38,13 @@ async def gather_device_io(coroutines: list) -> list:
     still in flight at that moment could land a file behind the cleanup and leave an
     orphan the next upload would trip over. Re-raising in input order keeps the
     surfaced error the same one the sequential loop would have raised.
+
+    ``return_exceptions=True`` hands the failures back in place instead, for the
+    callers that report a per-item outcome (which skill activated, which bot took
+    the config) rather than failing the request as a whole. The bound and the drain
+    are unaffected — that flag chooses only what happens *after* the batch is
+    complete. It is the same name and meaning ``asyncio.gather`` gives it, and the
+    reason those callers can move onto this helper at all.
 
     Cancellation is drained the same way, and needs its own handling because it does
     not travel the exception path: device filesystems block inside
@@ -83,9 +92,10 @@ async def gather_device_io(coroutines: list) -> list:
             except asyncio.CancelledError:
                 continue
         raise
-    for result in results:
-        if isinstance(result, BaseException):
-            raise result
+    if not return_exceptions:
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
     return results
 
 

--- a/src/backend/src/agentclaw/community/core/devices/device_io_batch.py
+++ b/src/backend/src/agentclaw/community/core/devices/device_io_batch.py
@@ -1,0 +1,92 @@
+"""Bounded, drained fan-out for the per-file I/O every device backend makes.
+
+Device filesystems address one file per call — a read, a write, a delete is a
+round trip to the container. Issuing them in a loop made an N-file operation cost
+``N × round_trip``, which dominates every Skill / Skill Set request that touches a
+package: the upload paths, the read-back verifies, the restore and quarantine
+copies, and the switcher's directory sweep.
+
+:func:`gather_device_io` is the one substitution those loops make. It is not a
+plain ``gather``: it is bounded, and it drains before it lets anything out — the
+two properties that make it safe to swap in for a sequential loop whose caller
+compensates on failure. Both are spelled out on the function.
+"""
+from __future__ import annotations
+
+import asyncio
+
+
+# Every package file is one device round trip. Issuing them sequentially made a
+# package cost ``file_count × round_trip``, which dominates upload time for the many
+# small files a skill package is made of. Fan them out instead — but bounded: device
+# filesystems run their blocking transport through ``asyncio.to_thread``, whose
+# default executor (``min(32, cpu_count + 4)`` threads) is shared with every other
+# caller in the process, so an unbounded ``gather`` over a large package would starve
+# unrelated work.
+DEVICE_IO_CONCURRENCY = 8
+
+
+async def gather_device_io(coroutines: list) -> list:
+    """Run per-file device I/O concurrently, bounded, and drain before returning.
+
+    Every coroutine is awaited to completion even after one fails, then the first
+    failure *in input order* is re-raised. Draining is what makes the fan-out safe
+    to substitute for the sequential loop: a caller that sees ``write`` fail treats
+    the package as failed and immediately ``delete_tree``s its directory, so a write
+    still in flight at that moment could land a file behind the cleanup and leave an
+    orphan the next upload would trip over. Re-raising in input order keeps the
+    surfaced error the same one the sequential loop would have raised.
+
+    Cancellation is drained the same way, and needs its own handling because it does
+    not travel the exception path: device filesystems block inside
+    ``asyncio.to_thread``, which cannot interrupt a call already executing on a
+    worker thread — cancelling only abandons the await while the HTTP write keeps
+    going. Worse, ``CancelledError`` is a ``BaseException``, so
+    an ``except Exception`` compensation (``LocalSkillUploadService``'s, say) is
+    skipped while its ``finally`` still releases the edit lease. A retry could then
+    acquire the lease, ``delete_tree`` the directory and start a fresh package that
+    the abandoned writes land into. So the batch is shielded and drained before the
+    cancellation is allowed to continue.
+    """
+    semaphore = asyncio.Semaphore(DEVICE_IO_CONCURRENCY)
+
+    async def _bounded(coro):
+        try:
+            async with semaphore:
+                return await coro
+        finally:
+            # A coroutine still queued on the semaphore when this batch is cancelled
+            # would never be awaited, which Python surfaces as a RuntimeWarning.
+            # Closing an already-finished coroutine is a no-op, so this is safe on
+            # the normal path too.
+            coro.close()
+
+    batch = asyncio.ensure_future(
+        asyncio.gather(*(_bounded(coro) for coro in coroutines), return_exceptions=True)
+    )
+    try:
+        results = await asyncio.shield(batch)
+    except BaseException:
+        # Shielding keeps ``batch`` running when the caller is cancelled; awaiting it
+        # here is what guarantees no write is still in flight once this raises.
+        #
+        # The drain is itself shielded, and loops, because cancellation can arrive
+        # more than once — an aborted request overlapping with shutdown, say. A
+        # plain ``await`` here would let that second cancel tear down ``batch``
+        # itself and re-raise with the worker-thread writes still running, which is
+        # exactly the failure the shield above prevents on the first cancel. Only
+        # ``CancelledError`` is absorbed, and only until ``batch`` finishes, so this
+        # delays cancellation by at most the batch's own remaining work.
+        while not batch.done():
+            try:
+                await asyncio.shield(batch)
+            except asyncio.CancelledError:
+                continue
+        raise
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result
+    return results
+
+
+__all__ = ["DEVICE_IO_CONCURRENCY", "gather_device_io"]

--- a/src/backend/src/agentclaw/community/core/devices/device_io_batch.py
+++ b/src/backend/src/agentclaw/community/core/devices/device_io_batch.py
@@ -58,14 +58,23 @@ async def gather_device_io(
     cancellation is allowed to continue.
     """
     semaphore = asyncio.Semaphore(DEVICE_IO_CONCURRENCY)
+    # Set when the caller is cancelled, to stop the batch admitting anything new.
+    # Only calls already running need draining; see the ``except`` below.
+    aborted = False
 
     async def _bounded(coro):
         try:
             async with semaphore:
+                if aborted:
+                    # Queued behind the bound when the cancellation landed, so this
+                    # call never reached the device and has nothing to leave behind.
+                    # Returning here is what keeps the unwind bounded by the slowest
+                    # call in flight rather than by every remaining wave.
+                    return None
                 return await coro
         finally:
-            # A coroutine still queued on the semaphore when this batch is cancelled
-            # would never be awaited, which Python surfaces as a RuntimeWarning.
+            # A coroutine that never ran — this one, or one still queued when the
+            # batch was torn down — would otherwise surface as a RuntimeWarning.
             # Closing an already-finished coroutine is a no-op, so this is safe on
             # the normal path too.
             coro.close()
@@ -77,15 +86,28 @@ async def gather_device_io(
         results = await asyncio.shield(batch)
     except BaseException:
         # Shielding keeps ``batch`` running when the caller is cancelled; awaiting it
-        # here is what guarantees no write is still in flight once this raises.
+        # here is what guarantees no call is still in flight once this raises.
         #
+        # Draining is only owed to calls that have already started: ``to_thread``
+        # cannot interrupt one that is executing on a worker thread, so abandoning
+        # it would let the write land after the caller's compensation. A call still
+        # queued on the semaphore has touched nothing, so it is simply dropped —
+        # ``aborted`` makes each remaining entry take the fast path above instead of
+        # issuing its device call. Without that, cancelling a 100-file upload ran the
+        # other 92 files to completion first, which is neither needed for safety nor
+        # what a caller asking to stop expects.
+        #
+        # Assignment before the drain is what makes this ordering hold: nothing
+        # between here and the first ``await`` yields, so no queued entry can slip
+        # past the flag.
+        aborted = True
         # The drain is itself shielded, and loops, because cancellation can arrive
         # more than once — an aborted request overlapping with shutdown, say. A
         # plain ``await`` here would let that second cancel tear down ``batch``
         # itself and re-raise with the worker-thread writes still running, which is
         # exactly the failure the shield above prevents on the first cancel. Only
         # ``CancelledError`` is absorbed, and only until ``batch`` finishes, so this
-        # delays cancellation by at most the batch's own remaining work.
+        # delays cancellation by at most the work already in flight.
         while not batch.done():
             try:
                 await asyncio.shield(batch)

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_http_info.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_http_info.py
@@ -1,0 +1,174 @@
+"""Shared BaaS ``get_http_info`` resolution for the per-file device transports.
+
+Every device transport that reaches a container through ``BaasService`` resolves
+an ``http_url`` + token before each call. That resolution costs a binding DB
+lookup plus a BaaS ``/http-info`` round trip, and the transports issue their
+calls **per file** — so a package of N files paid N resolutions on top of its N
+writes.
+
+The batching those callers now do makes that worse rather than better: the files
+go out concurrently, so the redundant resolutions arrive as a burst instead of a
+queue. Sharing one resolution across a batch is what turns the fan-out into an
+actual saving.
+
+This module owns that sharing once, for both transports that need it:
+
+- :class:`~agentclaw.community.core.devices.services.baas_invoke_transport.BaasInvokeTransport`
+  — cloud baas containers;
+- :class:`~agentclaw.community.core.devices.services.teclaw_device_filesystem.TeclawDeviceFileSystem`
+  — teclaw containers, which call ``invoke_http`` directly rather than through a
+  transport object.
+
+Both reach their container through the **agentclawproxy** ``/proxypass`` gateway
+and authenticate with ``x-proxypass-token``, so the header default lives here too.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.service_bot.services.baas_service import (
+        BaasService,
+        HttpConnectionInfo,
+    )
+
+
+# BaaS mints ``http_url`` + ``token`` per (bind_id, port, path). A package upload
+# POSTs every file to the SAME path (``/api/file/upload``), so one resolution serves
+# the whole batch; resolving per file cost a binding DB lookup plus a BaaS round trip
+# each, doubling the request count of every multi-file write. This TTL keeps a reused
+# token comfortably inside its lifetime, and a token that expires anyway is recovered
+# by the refresh-and-retry in :meth:`SharedHttpInfo.invoke`.
+_HTTP_INFO_TTL_SECONDS = 30.0
+
+# The proxypass gateway answers 401 when it rejects the token it was handed — the one
+# verdict that means "this cached http_info is no longer usable".
+#
+# 403 is deliberately excluded. It does not identify a token problem: the engine's file
+# router maps ``PermissionError`` to 403 (``engine/community/api/file/router.py``) and
+# the proxy forwards upstream responses through unchanged
+# (``sandboxproxy/community/adapters/web/routes.py``), so a 403 is the device's own
+# authorization answer. Replaying it would re-run a mutating upload/delete and, with no
+# ``device_uuid`` pinning the instance, possibly run it against a *different* device —
+# while hiding the engine's actual verdict from the caller.
+_STALE_TOKEN_STATUS = 401
+
+#: The agentclawproxy ``/proxypass`` gateway authenticates with this header, not the
+#: secbaas invoke-http tunnel's ``openclawToken`` (which it answers 401 to).
+PROXYPASS_AUTH_HEADER = "x-proxypass-token"
+
+
+class SharedHttpInfo:
+    """One ``get_http_info`` resolution per path, reused by every call on an owner.
+
+    The owner supplies the resolution inputs that are fixed for its lifetime
+    (``bind_id`` / ``engine_port`` / ``tenant`` / ``device_uuid``); only ``path``
+    varies per call, so only ``path`` is in the cache key.
+
+    Instances are built per device-filesystem dispatch, and a dispatch serves one
+    request, so a cached entry never outlives the request that resolved it — there
+    is no cross-request staleness to reason about.
+    """
+
+    def __init__(
+        self,
+        *,
+        baas_service: "BaasService",
+        bind_id: int,
+        engine_port: int,
+        tenant: str,
+        device_uuid: str | None = None,
+        auth_header: str = PROXYPASS_AUTH_HEADER,
+    ) -> None:
+        self._baas_service = baas_service
+        self._bind_id = bind_id
+        self._engine_port = engine_port
+        self._tenant = tenant
+        # 多实例 service bot 场景，caller 通过 device_uuid 锁定具体实例；透传给
+        # invoke_http → get_http_info → BaaS /http-info?device_uuid=。``None`` 表示
+        # 单实例 / 未指定，走 BaaS 自动选活跃实例的老行为。
+        self._device_uuid = device_uuid
+        self._auth_header = auth_header
+        # Guards the cache against the worker threads ``asyncio.to_thread`` fans
+        # device I/O out across. Deliberately held across the ``get_http_info``
+        # call itself, so a batch of concurrent writes coalesces onto ONE
+        # resolution instead of every thread missing the cache and resolving its
+        # own — the whole point of caching here.
+        self._lock = threading.Lock()
+        self._cache: dict[str, tuple[float, "HttpConnectionInfo"]] = {}
+
+    def resolve(
+        self, path: str, *, stale: "HttpConnectionInfo | None" = None
+    ) -> "HttpConnectionInfo":
+        """Resolve ``http_info`` for ``path``, reusing a fresh cached one.
+
+        Keyed by ``path`` alone because every other input BaaS resolves against
+        (``bind_id`` / ``engine_port`` / ``tenant`` / ``device_uuid``) is fixed for
+        this instance. Path must stay in the key: the returned ``http_url`` embeds
+        it, so reusing one path's entry for another would POST to the wrong route.
+
+        ``stale`` names the entry the caller was just rejected on, which makes a
+        refresh a compare-and-swap: it re-resolves only while the cache still holds
+        that exact entry, and otherwise hands back whatever replaced it. An
+        unconditional refresh would resolve once per in-flight request when a
+        concurrent batch is rejected together — reinstating, on the failure path,
+        the very per-file fan-out this cache exists to remove.
+        """
+        with self._lock:
+            cached = self._cache.get(path)
+            if (
+                cached is not None
+                and cached[0] > time.monotonic()
+                and cached[1] is not stale
+            ):
+                return cached[1]
+            info = self._baas_service.get_http_info(
+                bind_id=self._bind_id,
+                port=self._engine_port,
+                path=path,
+                tenant=self._tenant,
+                device_uuid=self._device_uuid,
+            )
+            self._cache[path] = (time.monotonic() + _HTTP_INFO_TTL_SECONDS, info)
+            return info
+
+    def invoke(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Issue one container call against this owner's cached ``http_info``.
+
+        Retries once against a re-resolved ``http_info`` when the gateway answers
+        401: a cached token can expire (or its device be reallocated) mid-batch, and
+        a caller must never see a spurious auth failure caused by this cache
+        choosing to reuse a token. Replay is safe because every payload we send is
+        already materialised (``json`` dicts, ``files`` bytes) rather than a consumed
+        stream. A genuine misconfiguration simply fails twice.
+
+        Every other status — 403 included, see :data:`_STALE_TOKEN_STATUS` — is the
+        device's own answer and is returned untouched.
+        """
+        call = dict(
+            bind_id=self._bind_id,
+            port=self._engine_port,
+            path=path,
+            method=method,
+            tenant=self._tenant,
+            auth_header=self._auth_header,
+            device_uuid=self._device_uuid,
+            **kwargs,
+        )
+        info = self.resolve(path)
+        response = self._baas_service.invoke_http(**call, http_info=info)
+        if response.status_code == _STALE_TOKEN_STATUS:
+            return self._baas_service.invoke_http(
+                **call, http_info=self.resolve(path, stale=info)
+            )
+        return response
+
+
+__all__ = [
+    "PROXYPASS_AUTH_HEADER",
+    "SharedHttpInfo",
+]

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_invoke_transport.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_invoke_transport.py
@@ -20,38 +20,19 @@ docs/superpowers/specs/2026-06-17-baas-transport-bot-type-strategy-design.md
 """
 from __future__ import annotations
 
-import threading
-import time
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import httpx
 
+from agentclaw.community.core.devices.services.baas_http_info import (
+    PROXYPASS_AUTH_HEADER,
+    SharedHttpInfo,
+)
+
 if TYPE_CHECKING:
-    from agentclaw.community.core.service_bot.services.baas_service import (
-        BaasService,
-        HttpConnectionInfo,
-    )
+    from agentclaw.community.core.service_bot.services.baas_service import BaasService
 
 
-# BaaS mints ``http_url`` + ``token`` per (bind_id, port, path). A package upload
-# POSTs every file to the SAME path (``/api/file/upload``), so one resolution serves
-# the whole batch; resolving per file cost a binding DB lookup plus a BaaS round trip
-# each, doubling the request count of every multi-file write. This TTL keeps a reused
-# token comfortably inside its lifetime, and a token that expires anyway is recovered
-# by the refresh-and-retry in :meth:`BaasInvokeTransport._invoke`.
-_HTTP_INFO_TTL_SECONDS = 30.0
-
-# The proxypass gateway answers 401 when it rejects the token it was handed — the one
-# verdict that means "this cached http_info is no longer usable".
-#
-# 403 is deliberately excluded. It does not identify a token problem: the engine's file
-# router maps ``PermissionError`` to 403 (``engine/community/api/file/router.py``) and
-# the proxy forwards upstream responses through unchanged
-# (``sandboxproxy/community/adapters/web/routes.py``), so a 403 is the device's own
-# authorization answer. Replaying it would re-run a mutating upload/delete and, with no
-# ``device_uuid`` pinning the instance, possibly run it against a *different* device —
-# while hiding the engine's actual verdict from the caller.
-_STALE_TOKEN_STATUS = 401
 
 
 def build_desktop_client() -> httpx.Client:
@@ -102,9 +83,9 @@ class BaasInvokeTransport:
     适用云上 baas 容器(未来 personal+baas / service+baas)。
 
     Resolution (``get_http_info``) is cached per path for the life of this
-    instance — see :meth:`_http_info`. The resolver builds one transport per
-    dispatch, so that lifetime is a single request and there is no cross-request
-    staleness to reason about.
+    instance by the shared :class:`SharedHttpInfo`. The resolver builds one
+    transport per dispatch, so that lifetime is a single request and there is no
+    cross-request staleness to reason about.
     """
 
     def __init__(
@@ -116,94 +97,30 @@ class BaasInvokeTransport:
         baas_service: "BaasService",
         device_uuid: str | None = None,
     ):
-        self._bind_id = bind_id
-        self._engine_port = engine_port
-        self._tenant = tenant
-        self._baas_service = baas_service
+        # 云上 baas 容器经 agentclawproxy ``/proxypass`` 网关访问，网关用
+        # ``x-proxypass-token`` 鉴权（与 teclaw/arca 同一网关）；不传则默认
+        # ``openclawToken``，proxypass 网关会 401。``info.token`` 即网关 token，
+        # 仅 header 名不同。
+        #
         # 多实例 service bot 场景，caller 通过 device_uuid 锁定具体实例；透传给
         # invoke_http → get_http_info → BaaS /http-info?device_uuid=。``None`` 表示
         # 单实例 / 未指定，走 BaaS 自动选活跃实例的老行为。
-        self._device_uuid = device_uuid
-        # Guards the cache against the worker threads ``asyncio.to_thread`` fans
-        # device I/O out across. Deliberately held across the ``get_http_info``
-        # call itself, so a batch of concurrent writes coalesces onto ONE
-        # resolution instead of every thread missing the cache and resolving its
-        # own — the whole point of caching here.
-        self._http_info_lock = threading.Lock()
-        self._http_info_cache: dict[str, tuple[float, "HttpConnectionInfo"]] = {}
-
-    def _http_info(
-        self, path: str, *, stale: "HttpConnectionInfo | None" = None
-    ) -> "HttpConnectionInfo":
-        """Resolve ``http_info`` for ``path``, reusing a fresh cached one.
-
-        Keyed by ``path`` alone because every other input BaaS resolves against
-        (``bind_id`` / ``engine_port`` / ``tenant`` / ``device_uuid``) is fixed for
-        this instance. Path must stay in the key: the returned ``http_url`` embeds
-        it, so reusing one path's entry for another would POST to the wrong route.
-
-        ``stale`` names the entry the caller was just rejected on, which makes a
-        refresh a compare-and-swap: it re-resolves only while the cache still holds
-        that exact entry, and otherwise hands back whatever replaced it. An
-        unconditional refresh would resolve once per in-flight request when a
-        concurrent batch is rejected together — reinstating, on the failure path,
-        the very per-file fan-out this cache exists to remove.
-        """
-        with self._http_info_lock:
-            cached = self._http_info_cache.get(path)
-            if (
-                cached is not None
-                and cached[0] > time.monotonic()
-                and cached[1] is not stale
-            ):
-                return cached[1]
-            info = self._baas_service.get_http_info(
-                bind_id=self._bind_id,
-                port=self._engine_port,
-                path=path,
-                tenant=self._tenant,
-                device_uuid=self._device_uuid,
-            )
-            self._http_info_cache[path] = (
-                time.monotonic() + _HTTP_INFO_TTL_SECONDS,
-                info,
-            )
-            return info
+        self._http_info = SharedHttpInfo(
+            baas_service=baas_service,
+            bind_id=bind_id,
+            engine_port=engine_port,
+            tenant=tenant,
+            device_uuid=device_uuid,
+            auth_header=PROXYPASS_AUTH_HEADER,
+        )
 
     def _invoke(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
-        """Issue one container call against this transport's cached ``http_info``.
+        """Issue one container call against this transport's shared resolution.
 
-        Retries once against a re-resolved ``http_info`` when the gateway answers
-        401: a cached token can expire (or its device be reallocated) mid-batch, and
-        a caller must never see a spurious auth failure caused by this cache
-        choosing to reuse a token. Replay is safe because every payload we send is
-        already materialised (``json`` dicts, ``files`` bytes) rather than a consumed
-        stream. A genuine misconfiguration simply fails twice.
-
-        Every other status — 403 included, see :data:`_STALE_TOKEN_STATUS` — is the
-        device's own answer and is returned untouched.
+        Resolution, its TTL and the refresh-and-retry on a rejected token all live
+        in :class:`SharedHttpInfo`, which the teclaw filesystem shares.
         """
-        call = dict(
-            bind_id=self._bind_id,
-            port=self._engine_port,
-            path=path,
-            method=method,
-            tenant=self._tenant,
-            # 云上 baas 容器经 agentclawproxy ``/proxypass`` 网关访问，网关用
-            # ``x-proxypass-token`` 鉴权（与 teclaw/arca 同一网关）；不传则默认
-            # ``openclawToken``，proxypass 网关会 401。``info.token`` 即网关 token，
-            # 仅 header 名不同。
-            auth_header="x-proxypass-token",
-            device_uuid=self._device_uuid,
-            **kwargs,
-        )
-        info = self._http_info(path)
-        response = self._baas_service.invoke_http(**call, http_info=info)
-        if response.status_code == _STALE_TOKEN_STATUS:
-            return self._baas_service.invoke_http(
-                **call, http_info=self._http_info(path, stale=info)
-            )
-        return response
+        return self._http_info.invoke(method, path, **kwargs)
 
     def post(self, path: str, *, json: Any | None = None) -> httpx.Response:
         return self._invoke("POST", path, json=json)

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_invoke_transport.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_invoke_transport.py
@@ -20,12 +20,59 @@ docs/superpowers/specs/2026-06-17-baas-transport-bot-type-strategy-design.md
 """
 from __future__ import annotations
 
+import threading
+import time
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import httpx
 
 if TYPE_CHECKING:
-    from agentclaw.community.core.service_bot.services.baas_service import BaasService
+    from agentclaw.community.core.service_bot.services.baas_service import (
+        BaasService,
+        HttpConnectionInfo,
+    )
+
+
+# BaaS mints ``http_url`` + ``token`` per (bind_id, port, path). A package upload
+# POSTs every file to the SAME path (``/api/file/upload``), so one resolution serves
+# the whole batch; resolving per file cost a binding DB lookup plus a BaaS round trip
+# each, doubling the request count of every multi-file write. This TTL keeps a reused
+# token comfortably inside its lifetime, and a token that expires anyway is recovered
+# by the refresh-and-retry in :meth:`BaasInvokeTransport._invoke`.
+_HTTP_INFO_TTL_SECONDS = 30.0
+
+# The proxypass gateway answers 401 when it rejects the token it was handed — the one
+# verdict that means "this cached http_info is no longer usable".
+#
+# 403 is deliberately excluded. It does not identify a token problem: the engine's file
+# router maps ``PermissionError`` to 403 (``engine/community/api/file/router.py``) and
+# the proxy forwards upstream responses through unchanged
+# (``sandboxproxy/community/adapters/web/routes.py``), so a 403 is the device's own
+# authorization answer. Replaying it would re-run a mutating upload/delete and, with no
+# ``device_uuid`` pinning the instance, possibly run it against a *different* device —
+# while hiding the engine's actual verdict from the caller.
+_STALE_TOKEN_STATUS = 401
+
+
+def build_desktop_client() -> httpx.Client:
+    """Build the pooled client :class:`DesktopBaasInvokeTransport` sends through.
+
+    Built once by the (singleton) device-filesystem resolver and injected into every
+    desktop transport it mints, so its lifetime is the process and its ownership is
+    the injector's — not a module-level lazy singleton.
+
+    Pooling is the point: a transport used to open a fresh ``httpx.Client`` per call,
+    forcing a TCP + TLS handshake for every file in a package upload. One shared
+    client turns that into one handshake per pooled connection. Sharing is safe —
+    ``httpx.Client`` is thread-safe (device I/O runs on ``asyncio.to_thread`` worker
+    threads) and every call already carries its own absolute URL and headers.
+    """
+    return httpx.Client(
+        timeout=30.0,
+        # Comfortably above the device-I/O fan-out so pool waits never become the
+        # new bottleneck, while still bounding total sockets.
+        limits=httpx.Limits(max_connections=64, max_keepalive_connections=32),
+    )
 
 
 @runtime_checkable
@@ -53,6 +100,11 @@ class BaasInvokeTransport:
     """通过 BaaSService.invoke_http(get_http_info → http_url → POST)。
 
     适用云上 baas 容器(未来 personal+baas / service+baas)。
+
+    Resolution (``get_http_info``) is cached per path for the life of this
+    instance — see :meth:`_http_info`. The resolver builds one transport per
+    dispatch, so that lifetime is a single request and there is no cross-request
+    staleness to reason about.
     """
 
     def __init__(
@@ -72,13 +124,70 @@ class BaasInvokeTransport:
         # invoke_http → get_http_info → BaaS /http-info?device_uuid=。``None`` 表示
         # 单实例 / 未指定，走 BaaS 自动选活跃实例的老行为。
         self._device_uuid = device_uuid
+        # Guards the cache against the worker threads ``asyncio.to_thread`` fans
+        # device I/O out across. Deliberately held across the ``get_http_info``
+        # call itself, so a batch of concurrent writes coalesces onto ONE
+        # resolution instead of every thread missing the cache and resolving its
+        # own — the whole point of caching here.
+        self._http_info_lock = threading.Lock()
+        self._http_info_cache: dict[str, tuple[float, "HttpConnectionInfo"]] = {}
 
-    def post(self, path: str, *, json: Any | None = None) -> httpx.Response:
-        return self._baas_service.invoke_http(
+    def _http_info(
+        self, path: str, *, stale: "HttpConnectionInfo | None" = None
+    ) -> "HttpConnectionInfo":
+        """Resolve ``http_info`` for ``path``, reusing a fresh cached one.
+
+        Keyed by ``path`` alone because every other input BaaS resolves against
+        (``bind_id`` / ``engine_port`` / ``tenant`` / ``device_uuid``) is fixed for
+        this instance. Path must stay in the key: the returned ``http_url`` embeds
+        it, so reusing one path's entry for another would POST to the wrong route.
+
+        ``stale`` names the entry the caller was just rejected on, which makes a
+        refresh a compare-and-swap: it re-resolves only while the cache still holds
+        that exact entry, and otherwise hands back whatever replaced it. An
+        unconditional refresh would resolve once per in-flight request when a
+        concurrent batch is rejected together — reinstating, on the failure path,
+        the very per-file fan-out this cache exists to remove.
+        """
+        with self._http_info_lock:
+            cached = self._http_info_cache.get(path)
+            if (
+                cached is not None
+                and cached[0] > time.monotonic()
+                and cached[1] is not stale
+            ):
+                return cached[1]
+            info = self._baas_service.get_http_info(
+                bind_id=self._bind_id,
+                port=self._engine_port,
+                path=path,
+                tenant=self._tenant,
+                device_uuid=self._device_uuid,
+            )
+            self._http_info_cache[path] = (
+                time.monotonic() + _HTTP_INFO_TTL_SECONDS,
+                info,
+            )
+            return info
+
+    def _invoke(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Issue one container call against this transport's cached ``http_info``.
+
+        Retries once against a re-resolved ``http_info`` when the gateway answers
+        401: a cached token can expire (or its device be reallocated) mid-batch, and
+        a caller must never see a spurious auth failure caused by this cache
+        choosing to reuse a token. Replay is safe because every payload we send is
+        already materialised (``json`` dicts, ``files`` bytes) rather than a consumed
+        stream. A genuine misconfiguration simply fails twice.
+
+        Every other status — 403 included, see :data:`_STALE_TOKEN_STATUS` — is the
+        device's own answer and is returned untouched.
+        """
+        call = dict(
             bind_id=self._bind_id,
             port=self._engine_port,
             path=path,
-            json=json,
+            method=method,
             tenant=self._tenant,
             # 云上 baas 容器经 agentclawproxy ``/proxypass`` 网关访问，网关用
             # ``x-proxypass-token`` 鉴权（与 teclaw/arca 同一网关）；不传则默认
@@ -86,31 +195,27 @@ class BaasInvokeTransport:
             # 仅 header 名不同。
             auth_header="x-proxypass-token",
             device_uuid=self._device_uuid,
+            **kwargs,
         )
+        info = self._http_info(path)
+        response = self._baas_service.invoke_http(**call, http_info=info)
+        if response.status_code == _STALE_TOKEN_STATUS:
+            return self._baas_service.invoke_http(
+                **call, http_info=self._http_info(path, stale=info)
+            )
+        return response
+
+    def post(self, path: str, *, json: Any | None = None) -> httpx.Response:
+        return self._invoke("POST", path, json=json)
 
     def get(self, path: str) -> httpx.Response:
-        return self._baas_service.invoke_http(
-            bind_id=self._bind_id, port=self._engine_port, path=path,
-            method="GET", tenant=self._tenant,
-            auth_header="x-proxypass-token",
-            device_uuid=self._device_uuid,
-        )
+        return self._invoke("GET", path)
 
     def put(self, path: str, *, json: Any | None = None) -> httpx.Response:
-        return self._baas_service.invoke_http(
-            bind_id=self._bind_id, port=self._engine_port, path=path,
-            method="PUT", json=json, tenant=self._tenant,
-            auth_header="x-proxypass-token",
-            device_uuid=self._device_uuid,
-        )
+        return self._invoke("PUT", path, json=json)
 
     def delete(self, path: str) -> httpx.Response:
-        return self._baas_service.invoke_http(
-            bind_id=self._bind_id, port=self._engine_port, path=path,
-            method="DELETE", tenant=self._tenant,
-            auth_header="x-proxypass-token",
-            device_uuid=self._device_uuid,
-        )
+        return self._invoke("DELETE", path)
 
     def post_multipart(
         self,
@@ -123,25 +228,21 @@ class BaasInvokeTransport:
 
         invoke_http 通过 files/data 参数走 multipart 路径,内部用
         ``general_http_client.post(url, files=..., data=...)``。
+
+        Every file in a package upload lands here on the same ``path``, so all of
+        them share one cached ``http_info`` resolution.
         """
-        return self._baas_service.invoke_http(
-            bind_id=self._bind_id,
-            port=self._engine_port,
-            path=path,
-            method="POST",
-            files=files,
-            data=data,
-            tenant=self._tenant,
-            # 同 post：proxypass 网关鉴权 header（写文件 multipart 链路同样需要）。
-            auth_header="x-proxypass-token",
-            device_uuid=self._device_uuid,
-        )
+        return self._invoke("POST", path, files=files, data=data)
 
 
 class DesktopBaasInvokeTransport:
     """自拼 secbaas transparent proxy URL,直接 httpx POST。
 
     适用 desktop bot(VM 在用户机器,BaaS get_http_info 返 localhost 拨不通)。
+
+    Requests go through the injected pooled ``client`` (built by
+    :func:`build_desktop_client`) so a multi-file write reuses keep-alive
+    connections instead of paying a TLS handshake per file.
     """
 
     def __init__(
@@ -152,29 +253,34 @@ class DesktopBaasInvokeTransport:
         bot_uuid: str,
         engine_port: int,
         headers: dict[str, str],
+        client: httpx.Client,
     ):
         self._baas_base_url = baas_base_url
         self._tenant = tenant
         self._bot_uuid = bot_uuid
         self._engine_port = engine_port
         self._headers = headers
+        self._client = client
 
     def post(self, path: str, *, json: Any | None = None) -> httpx.Response:
-        url = self._invoke_url(path)
-        with httpx.Client(timeout=30.0) as client:
-            return client.post(url, json=json, headers=self._headers)
+        return self._client.post(
+            self._invoke_url(path), json=json, headers=self._headers
+        )
 
     def get(self, path: str) -> httpx.Response:
-        with httpx.Client(timeout=30.0) as client:
-            return client.get(self._invoke_url(path), headers=self._headers)
+        return self._client.get(
+            self._invoke_url(path), headers=self._headers
+        )
 
     def put(self, path: str, *, json: Any | None = None) -> httpx.Response:
-        with httpx.Client(timeout=30.0) as client:
-            return client.put(self._invoke_url(path), json=json, headers=self._headers)
+        return self._client.put(
+            self._invoke_url(path), json=json, headers=self._headers
+        )
 
     def delete(self, path: str) -> httpx.Response:
-        with httpx.Client(timeout=30.0) as client:
-            return client.delete(self._invoke_url(path), headers=self._headers)
+        return self._client.delete(
+            self._invoke_url(path), headers=self._headers
+        )
 
     def post_multipart(
         self,
@@ -183,9 +289,9 @@ class DesktopBaasInvokeTransport:
         files: Any,
         data: Any,
     ) -> httpx.Response:
-        url = self._invoke_url(path)
-        with httpx.Client(timeout=30.0) as client:
-            return client.post(url, files=files, data=data, headers=self._headers)
+        return self._client.post(
+            self._invoke_url(path), files=files, data=data, headers=self._headers
+        )
 
     def _invoke_url(self, api_path: str) -> str:
         if not api_path.startswith("/"):

--- a/src/backend/src/agentclaw/community/core/devices/services/device_filesystem_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_filesystem_resolver.py
@@ -17,6 +17,9 @@ from injector import inject
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.repository.protocols.devices import DeviceBindingRepository
+from agentclaw.community.core.devices.services.baas_invoke_transport import (
+    build_desktop_client,
+)
 from agentclaw.community.core.devices.services.device_context import UnknownProviderError
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.log import get_logger
@@ -44,6 +47,12 @@ class DefaultDeviceFileSystemResolver:
         self._bot_repo = bot_repo
         self._binding_repo = binding_repo
         self._sandbox_client = sandbox_client
+        # One pooled HTTP client shared by every desktop transport this resolver
+        # mints. Owned here because this resolver is a singleton, so the pool's
+        # lifetime is the process without a module-level lazy singleton. Built
+        # eagerly and cheaply — ``httpx.Client`` opens no connection until its
+        # first request — so desktop bots never pay a TLS handshake per file.
+        self._desktop_client = build_desktop_client()
 
     def __call__(
         self, ctx: "DeviceContext", path_mapper: Callable[[str], str]
@@ -72,6 +81,7 @@ class DefaultDeviceFileSystemResolver:
                     bot_uuid=conn_info["paas_device_id"],
                     engine_port=engine_port,
                     headers=conn_info.get("headers", {}),
+                    client=self._desktop_client,
                 )
                 logger.info(
                     "[DEVICE-PLUGIN-DEBUG] → DesktopBaasDeviceFileSystem(paas_device_id=%s)",

--- a/src/backend/src/agentclaw/community/core/devices/services/teclaw_device_filesystem.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/teclaw_device_filesystem.py
@@ -24,6 +24,12 @@ auth_header="x-proxypass-token")``, which resolves the proxypass ``http_url`` +
 proxy token via ``get_http_info`` (from the teclaw ``conn_info``'s ``bind_id`` +
 ``engine_port`` + ``tenant``). ``invoke_http`` is synchronous, so calls run on a
 thread.
+
+That resolution is shared across calls by :class:`SharedHttpInfo`, the same seam
+:class:`BaasDeviceFileSystem`'s transport uses. It matters most here: callers
+write a Skill package by fanning its files out concurrently, so resolving per
+file would send a *burst* of identical binding lookups and BaaS round trips
+rather than the queue of them the sequential loop used to send.
 """
 from __future__ import annotations
 
@@ -33,6 +39,10 @@ from typing import TYPE_CHECKING, Any, Callable
 import httpx
 
 from agentclaw.community.log import get_logger
+from agentclaw.community.core.devices.services.baas_http_info import (
+    PROXYPASS_AUTH_HEADER,
+    SharedHttpInfo,
+)
 from agentclaw.community.core.devices.services.device_filesystem import DeviceFileSystem
 
 if TYPE_CHECKING:
@@ -69,12 +79,17 @@ class TeclawDeviceFileSystem(DeviceFileSystem):
                 transport :class:`BaasDeviceFileSystem` uses.
         """
         self._path_mapper = path_mapper
-        self._baas_service = baas_service
         # BaaS invoke-http fields for reads (same as BaasDeviceFileSystem; teclaw
         # conn_info is build_baas_conn_info_for_http output, so it carries bind_id).
-        self._bind_id: int = conn_info["bind_id"]
-        self._engine_port: int = conn_info["engine_port"]
-        self._tenant: str = conn_info.get("tenant", "default")
+        # They are fixed for this filesystem's lifetime, so the resolution they
+        # produce is shared per path rather than redone per call.
+        self._http_info = SharedHttpInfo(
+            baas_service=baas_service,
+            bind_id=conn_info["bind_id"],
+            engine_port=conn_info["engine_port"],
+            tenant=conn_info.get("tenant", "default"),
+            auth_header=PROXYPASS_AUTH_HEADER,
+        )
         # for log lines only
         self._bot_uuid: str = conn_info.get("paas_device_id", "")
 
@@ -137,26 +152,24 @@ class TeclawDeviceFileSystem(DeviceFileSystem):
         self, path: str, *, json: Any = None, files: Any = None, data: Any = None
     ) -> httpx.Response:
         """Synchronous ``invoke_http`` call (wrap in ``asyncio.to_thread`` for
-        async use) — resolves the container ``http_url`` + token via
-        ``get_http_info`` and POSTs (json body, or ``files``+``data`` multipart
-        for upload).
+        async use) — POSTs a json body, or ``files``+``data`` multipart for upload,
+        against this filesystem's shared container resolution.
 
         The teclaw container is reached through the **agentclawproxy** gateway
         (``http_url`` is ``{base}/proxypass/{target}{path}``, same gateway ARCA
         uses), which authenticates with ``x-proxypass-token`` — NOT the
-        ``openclawToken`` the secbaas invoke-http tunnel uses. So we pass
-        ``auth_header="x-proxypass-token"`` (sending ``openclawToken`` here 401s).
-        ``info.token`` is the gateway's proxy_token; only the header name differs.
+        ``openclawToken`` the secbaas invoke-http tunnel uses. So the resolver is
+        built with ``auth_header=PROXYPASS_AUTH_HEADER`` (sending ``openclawToken``
+        here 401s); ``info.token`` is the gateway's proxy_token, only the header
+        name differs.
+
+        Every file of a package upload POSTs the same ``/api/v1/file/upload`` path,
+        so the whole batch shares one ``get_http_info`` — and a token the gateway
+        rejects mid-batch is refreshed and the call replayed once, so reuse can
+        never surface a spurious 401 to the caller.
         """
-        return self._baas_service.invoke_http(
-            bind_id=self._bind_id,
-            port=self._engine_port,
-            path=path,
-            tenant=self._tenant,
-            json=json,
-            files=files,
-            data=data,
-            auth_header="x-proxypass-token",
+        return self._http_info.invoke(
+            "POST", path, json=json, files=files, data=data
         )
 
     async def read_file(

--- a/src/backend/src/agentclaw/community/core/mcp/services/passport_writer.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/passport_writer.py
@@ -1,0 +1,207 @@
+"""Writing a bot's MCP identity and scope into Passport.
+
+The other half of an MCP sync. ``MCPSyncService`` pushes MCP configuration to a
+bot's **device**; these two write what the bot is *allowed* to reach into
+**Passport**, for the frontend's permission checks and for TCAuth. They share
+that trigger and nothing else: no device is resolved, dispatched to, or touched
+here, and neither function is on the request's device round-trip path.
+
+They take their collaborators as arguments rather than holding them, so a caller
+that swaps ``passport_update`` (or either repository) after construction still
+has that swap honoured — which is how ``MCPSyncService``'s own callers and tests
+address these dependencies.
+
+The pure entry-shaping helpers these build on live next door in
+:mod:`passport_scope`.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional, TYPE_CHECKING
+
+from agentclaw.community.core.mcp.services._defaults import get_default_cli_items
+from agentclaw.community.core.mcp.services.passport_scope import (
+    merge_passport_cli_items,
+    passport_mcp_items_from_entries,
+)
+from agentclaw.community.log import get_logger
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.repository.protocols.bot import BotRepository
+    from agentclaw.community.core.repository.protocols.identity import (
+        CallerIdentityRepositoryProtocol,
+    )
+    from agentclaw.community.plugin_api.passport import PassportPlugin
+
+logger = get_logger()
+
+
+async def update_agent_principal_identity(
+    *,
+    passport_update: "PassportPlugin",
+    user_id: str,
+    entity_id: str,
+    bot_id: str,
+    entity_type: str,
+    engine_type: str,
+    active_mcps: list[dict[str, Any]],
+    identity_modes: Mapping[str, object],
+) -> dict[str, Any]:
+    """Replace Agent Principal MCP identity metadata without device sync."""
+    del entity_id, entity_type, engine_type
+    try:
+        mcp_items = passport_mcp_items_from_entries(
+            active_mcps,
+            identity_modes=identity_modes,
+        )
+        # 当前 Passport MCP 参数不含 token；保留完整条目以定位 TCAuth 前置校验失败值。
+        logger.info(
+            "[MCPSyncService] Passport update request: "
+            "operation=caller_mcp_identity_sync, bot_id=%s, user_id=%s, "
+            "mcp_items=%s",
+            bot_id,
+            user_id,
+            mcp_items,
+        )
+        passport_update.update_mcp_identity_to_agent_principal(
+            bot_id=bot_id,
+            user_id=user_id,
+            mcp_items=mcp_items,
+        )
+    except Exception as exc:
+        logger.warning(
+            "caller_agent_principal_sync_failed bot_id=%s error_type=%s",
+            bot_id,
+            type(exc).__name__,
+        )
+        return {"success": False, "error": "Agent Principal update failed"}
+
+    logger.info(
+        "caller_agent_principal_sync_succeeded bot_id=%s mcp_count=%s",
+        bot_id,
+        len(mcp_items),
+    )
+    return {"success": True}
+
+
+async def update_mcp_scope(
+    *,
+    passport_update: "PassportPlugin",
+    bot_repository: "BotRepository",
+    caller_identity_repository: "CallerIdentityRepositoryProtocol",
+    bot_id: str,
+    user_id: str,
+    owner_id: str,
+    synced_mcps: list[dict[str, Any]],
+    engine_type: Optional[str] = None,
+) -> dict[str, Any]:
+    """更新完整 MCP scope；身份或 bot 元数据不可读取时中止覆盖。"""
+    bot_name: Optional[str] = None
+    bot_desc: Optional[str] = None
+    template_type: Optional[str] = None
+    template_config: Optional[Mapping[str, Any]] = None
+    try:
+        bot = bot_repository.get_by_id_and_owner(bot_id, owner_id)
+        if bot:
+            bot_name = bot.get("bot_name")
+            bot_desc = bot.get("bot_desc")
+            template_type = bot.get("template_type")
+            raw_template_config = bot.get("template_config")
+            template_config = raw_template_config if isinstance(raw_template_config, Mapping) else None
+            engine_type = bot.get("active_engine") or bot.get("engine_type") or engine_type
+    except Exception as e:
+        error = f"获取 bot 信息失败，无法安全解析默认 CLI 范围: {e}"
+        logger.error("[MCPSyncService] %s, bot_id=%s", error, bot_id)
+        return {"success": False, "error": error}
+
+    identity_modes: Mapping[str, object] = {}
+    try:
+        if bot:
+            identity_modes = caller_identity_repository.list_draft_call_types(int(bot["id"]), str(engine_type))
+        else:
+            logger.info("[MCPSyncService] 未找到持久化 bot，按 owner 刷新 MCP scope: bot_id=%s", bot_id)
+        mcp_items = passport_mcp_items_from_entries(synced_mcps, identity_modes=identity_modes)
+    except Exception as e:
+        error = f"查询 MCP 调用身份失败: {e}"
+        logger.error("[MCPSyncService] %s, bot_id=%s", error, bot_id)
+        return {"success": False, "error": error}
+
+    synced_server_codes = [item["mcp_code"] for item in mcp_items]
+    caller_mcp_codes = [
+        item["mcp_code"] for item in mcp_items if item["identity_mode"] == "caller"
+    ]
+
+    # MCP 同步触发 resourceManifest 更新时，要回填当前 CLI，避免覆盖式更新丢失 CLI 授权。
+    try:
+        current_cli_items = passport_update.query_passport_clis(bot_id, user_id)
+    except Exception as e:
+        error = f"查询 CLI 范围失败: {e}"
+        logger.error("[MCPSyncService] %s", error)
+        return {"success": False, "error": error}
+
+    default_cli_items = get_default_cli_items(
+        engine_type,
+        template_type,
+        ext_info={"template_config": template_config}
+        if template_config
+        else None,
+    )
+    cli_items = merge_passport_cli_items(current_cli_items, default_cli_items)
+    if default_cli_items:
+        logger.info(
+            "[MCPSyncService] 合并默认 CLI 范围: bot_id=%s, current_clis=%s, "
+            "default_clis=%s, merged_clis=%s, engine_type=%s, template_type=%s",
+            bot_id,
+            current_cli_items,
+            default_cli_items,
+            cli_items,
+            engine_type,
+            template_type,
+        )
+
+    try:
+        # resource_scope 是完整快照：MCP 身份与 CLI 都必须回传，避免覆盖丢失授权。
+        resource_scope = {
+            "mcp_codes": synced_server_codes,
+            "mcp_items": mcp_items,
+            "cli_items": cli_items,
+        }
+        # 当前 Passport MCP 参数不含 token；保留完整请求以定位 TCAuth 前置校验失败值。
+        logger.info(
+            "[MCPSyncService] Passport update request: "
+            "operation=mcp_scope_refresh, bot_id=%s, user_id=%s, "
+            "resource_scope=%s, bot_name=%s, bot_desc=%s, engine_type=%s",
+            bot_id,
+            user_id,
+            resource_scope,
+            bot_name,
+            bot_desc,
+            engine_type,
+        )
+        passport_update.update_passport(
+            bot_id=bot_id,
+            user_id=user_id,
+            resource_scope=resource_scope,
+            bot_name=bot_name,
+            bot_desc=bot_desc,
+            engine_type=engine_type,
+        )
+        logger.info(
+            "[MCPSyncService] updatePassport 成功: "
+            "bot_id=%s, user_id=%s, mcps=%s, caller_mcps=%s, clis=%s, "
+            "engine_type=%s, bot_name=%s",
+            bot_id,
+            user_id,
+            synced_server_codes,
+            caller_mcp_codes,
+            cli_items,
+            engine_type,
+            bot_name,
+        )
+        return {"success": True}
+    except Exception as e:
+        error = f"更新 passport 失败: {e}"
+        logger.error("[MCPSyncService] %s", error)
+        return {"success": False, "error": error}
+
+
+__all__ = ["update_agent_principal_identity", "update_mcp_scope"]

--- a/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
@@ -19,6 +19,7 @@ from agentclaw.community.core.devices.services.device_context import (
     DeviceNotBoundError,
     UnknownProviderError,
 )
+from agentclaw.community.core.devices.device_io_batch import gather_device_io
 from agentclaw.community.core.mcp.services._defaults import get_default_cli_items
 from agentclaw.community.core.mcp.services.config_service import MCPConfigService
 from agentclaw.community.core.mcp.services.detail_fanout import (
@@ -550,22 +551,30 @@ class MCPSyncService:
             logger.info("[MCPSyncService] 未找到 bot，无需同步")
             return {"success": True, "sync_results": [], "error": None}
 
-        sync_results: list[dict[str, Any]] = []
-        any_success = False
-        has_mcp_devices = 0
-
-        for bot_id in bot_ids:
+        # 每台 bot 都是一台**不同**的设备，逐台 await 让本次配置改动的耗时变成
+        # ``bot_count × (解析 + 探测 + 投递)``——一个实体最多取 100 台。而且
+        # ``resolve_for_bot`` 是同步的（内含阻塞 ws-info HTTP 加若干 DB 查询），
+        # 直接 await 会把 event loop 占住，连带拖住其他请求；``sync_mcp_details_for_bot``
+        # 早就为此把它放进了线程池，这里跟上。
+        #
+        # 扇出是有界的，理由与 ``fan_out_mcp_details`` 一致；并且在放行前排空：
+        # ``config_flow.write_unified_config`` 会在失败时回滚刚落库的凭据，若此刻
+        # 还有投递在途，它会把新凭据推到已回滚的配置之后。
+        async def _sync_one(bot_id: str) -> tuple[bool, dict[str, Any]]:
+            """投递到单台 bot。返回 (是否计入回滚判定, 该 bot 的结果)。"""
             # per-bot 投递插件由 resolver+dispatcher 按容器类型路由；无可投递设备→跳过(不计入回滚判定)。
             try:
-                ctx = self._resolver_provider().resolve_for_bot(bot_id, entity_id)
+                ctx = await asyncio.to_thread(
+                    self._resolver_provider().resolve_for_bot, bot_id, entity_id
+                )
             except (DeviceNotBoundError, UnknownProviderError):
                 logger.warning("[MCPSyncService] 跳过 bot=%s: 缺少连接信息", bot_id)
-                sync_results.append({
+                return False, {
                     "bot_id": bot_id, "synced": False, "reason": "缺少设备连接信息",
-                })
-                continue
+                }
             plugin = self._device_sync_dispatcher_provider().dispatch(ctx)
 
+            counted = False
             try:
                 # 探测设备是否已装该 MCP；arca/baas 真实探测，未装则跳过（不计入）。
                 # 整产物设备（teclaw）的 has_mcp 恒为 True：始终投递并计入回滚判定，
@@ -579,12 +588,11 @@ class MCPSyncService:
                     logger.warning(
                         "[MCPSyncService] bot=%s 设备上未找到 MCP %s", bot_id, server_code
                     )
-                    sync_results.append({
+                    return False, {
                         "bot_id": bot_id, "synced": False, "reason": "设备上未找到该 MCP",
-                    })
-                    continue
+                    }
 
-                has_mcp_devices += 1
+                counted = True
                 logger.info("[MCPSyncService] 正在同步 MCP %s 到 bot=%s", server_code, bot_id)
 
                 sync_success = await self._sync_mcp_detail(
@@ -599,20 +607,27 @@ class MCPSyncService:
 
                 if sync_success:
                     logger.info("[MCPSyncService] bot=%s 同步成功", bot_id)
-                    any_success = True
                 else:
                     logger.error("[MCPSyncService] bot=%s 同步失败", bot_id)
 
-                sync_results.append({
+                return counted, {
                     "bot_id": bot_id,
                     "synced": sync_success,
                     "error": None if sync_success else "设备同步返回失败",
-                })
+                }
             except Exception as e:
                 logger.error("[MCPSyncService] 同步到 bot=%s 异常: %s", bot_id, e)
-                sync_results.append({
+                # 探测阶段就抛的异常说明这台设备装没装该 MCP 未知，与逐台循环一样
+                # 不计入回滚判定；探测通过之后抛的才计入。
+                return counted, {
                     "bot_id": bot_id, "synced": False, "error": str(e),
-                })
+                }
+
+        outcomes = await gather_device_io([_sync_one(bot_id) for bot_id in bot_ids])
+        # 顺序与 bot_ids 一致，与逐台循环产出的 sync_results 完全相同。
+        sync_results: list[dict[str, Any]] = [result for _, result in outcomes]
+        has_mcp_devices = sum(1 for counted, _ in outcomes if counted)
+        any_success = any(result.get("synced") for result in sync_results)
 
         # 只有"确实有该 MCP 的设备全部失败"时才整体报错；
         # 如果设备上没有该 MCP 或者根本没有设备，不算失败。

--- a/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/sync_service.py
@@ -20,16 +20,14 @@ from agentclaw.community.core.devices.services.device_context import (
     UnknownProviderError,
 )
 from agentclaw.community.core.devices.device_io_batch import gather_device_io
-from agentclaw.community.core.mcp.services._defaults import get_default_cli_items
 from agentclaw.community.core.mcp.services.config_service import MCPConfigService
 from agentclaw.community.core.mcp.services.detail_fanout import (
     fan_out_mcp_details,
     server_code_of,
 )
+from agentclaw.community.core.mcp.services import passport_writer
 from agentclaw.community.core.mcp.services.passport_scope import (
-    merge_passport_cli_items,
     passport_mcp_codes_from_entries,
-    passport_mcp_items_from_entries,
 )
 from agentclaw.community.core.mcp.services.repositories import BotMCPProvider
 from agentclaw.community.core.repository.protocols.bot import UserMCPConfigRepository
@@ -480,41 +478,23 @@ class MCPSyncService:
         active_mcps: list[dict[str, Any]],
         identity_modes: Mapping[str, object],
     ) -> dict[str, Any]:
-        """Replace Agent Principal MCP identity metadata without device sync."""
-        del entity_id, entity_type, engine_type
-        try:
-            mcp_items = passport_mcp_items_from_entries(
-                active_mcps,
-                identity_modes=identity_modes,
-            )
-            # 当前 Passport MCP 参数不含 token；保留完整条目以定位 TCAuth 前置校验失败值。
-            logger.info(
-                "[MCPSyncService] Passport update request: "
-                "operation=caller_mcp_identity_sync, bot_id=%s, user_id=%s, "
-                "mcp_items=%s",
-                bot_id,
-                user_id,
-                mcp_items,
-            )
-            self.passport_update.update_mcp_identity_to_agent_principal(
-                bot_id=bot_id,
-                user_id=user_id,
-                mcp_items=mcp_items,
-            )
-        except Exception as exc:
-            logger.warning(
-                "caller_agent_principal_sync_failed bot_id=%s error_type=%s",
-                bot_id,
-                type(exc).__name__,
-            )
-            return {"success": False, "error": "Agent Principal update failed"}
+        """Replace Agent Principal MCP identity metadata without device sync.
 
-        logger.info(
-            "caller_agent_principal_sync_succeeded bot_id=%s mcp_count=%s",
-            bot_id,
-            len(mcp_items),
+        The write itself lives in :mod:`passport_writer` — it touches no device,
+        which is the whole of what this service otherwise does. The dependency is
+        read off ``self`` at call time so a caller that swaps it after
+        construction still has that swap honoured.
+        """
+        return await passport_writer.update_agent_principal_identity(
+            passport_update=self.passport_update,
+            user_id=user_id,
+            entity_id=entity_id,
+            bot_id=bot_id,
+            entity_type=entity_type,
+            engine_type=engine_type,
+            active_mcps=active_mcps,
+            identity_modes=identity_modes,
         )
-        return {"success": True}
 
     async def sync_mcp_detail_to_all_bots(
         self,
@@ -902,111 +882,18 @@ class MCPSyncService:
         synced_mcps: list[dict[str, Any]],
         engine_type: Optional[str] = None,
     ) -> dict[str, Any]:
-        """更新完整 MCP scope；身份或 bot 元数据不可读取时中止覆盖。"""
-        bot_name: Optional[str] = None
-        bot_desc: Optional[str] = None
-        template_type: Optional[str] = None
-        template_config: Optional[Mapping[str, Any]] = None
-        try:
-            bot = self.bot_repository.get_by_id_and_owner(bot_id, owner_id)
-            if bot:
-                bot_name = bot.get("bot_name")
-                bot_desc = bot.get("bot_desc")
-                template_type = bot.get("template_type")
-                raw_template_config = bot.get("template_config")
-                template_config = raw_template_config if isinstance(raw_template_config, Mapping) else None
-                engine_type = bot.get("active_engine") or bot.get("engine_type") or engine_type
-        except Exception as e:
-            error = f"获取 bot 信息失败，无法安全解析默认 CLI 范围: {e}"
-            logger.error("[MCPSyncService] %s, bot_id=%s", error, bot_id)
-            return {"success": False, "error": error}
+        """更新完整 MCP scope；身份或 bot 元数据不可读取时中止覆盖。
 
-        identity_modes: Mapping[str, object] = {}
-        try:
-            if bot:
-                identity_modes = self.caller_identity_repository.list_draft_call_types(int(bot["id"]), str(engine_type))
-            else:
-                logger.info("[MCPSyncService] 未找到持久化 bot，按 owner 刷新 MCP scope: bot_id=%s", bot_id)
-            mcp_items = passport_mcp_items_from_entries(synced_mcps, identity_modes=identity_modes)
-        except Exception as e:
-            error = f"查询 MCP 调用身份失败: {e}"
-            logger.error("[MCPSyncService] %s, bot_id=%s", error, bot_id)
-            return {"success": False, "error": error}
-
-        synced_server_codes = [item["mcp_code"] for item in mcp_items]
-        caller_mcp_codes = [
-            item["mcp_code"] for item in mcp_items if item["identity_mode"] == "caller"
-        ]
-
-        # MCP 同步触发 resourceManifest 更新时，要回填当前 CLI，避免覆盖式更新丢失 CLI 授权。
-        try:
-            current_cli_items = self.passport_update.query_passport_clis(bot_id, user_id)
-        except Exception as e:
-            error = f"查询 CLI 范围失败: {e}"
-            logger.error("[MCPSyncService] %s", error)
-            return {"success": False, "error": error}
-
-        default_cli_items = get_default_cli_items(
-            engine_type,
-            template_type,
-            ext_info={"template_config": template_config}
-            if template_config
-            else None,
+        实现在 :mod:`passport_writer`——它不碰设备，与本服务其余部分不是一个关注点。
+        依赖在调用时从 ``self`` 上取，构造后替换依然生效。
+        """
+        return await passport_writer.update_mcp_scope(
+            passport_update=self.passport_update,
+            bot_repository=self.bot_repository,
+            caller_identity_repository=self.caller_identity_repository,
+            bot_id=bot_id,
+            user_id=user_id,
+            owner_id=owner_id,
+            synced_mcps=synced_mcps,
+            engine_type=engine_type,
         )
-        cli_items = merge_passport_cli_items(current_cli_items, default_cli_items)
-        if default_cli_items:
-            logger.info(
-                "[MCPSyncService] 合并默认 CLI 范围: bot_id=%s, current_clis=%s, "
-                "default_clis=%s, merged_clis=%s, engine_type=%s, template_type=%s",
-                bot_id,
-                current_cli_items,
-                default_cli_items,
-                cli_items,
-                engine_type,
-                template_type,
-            )
-
-        try:
-            # resource_scope 是完整快照：MCP 身份与 CLI 都必须回传，避免覆盖丢失授权。
-            resource_scope = {
-                "mcp_codes": synced_server_codes,
-                "mcp_items": mcp_items,
-                "cli_items": cli_items,
-            }
-            # 当前 Passport MCP 参数不含 token；保留完整请求以定位 TCAuth 前置校验失败值。
-            logger.info(
-                "[MCPSyncService] Passport update request: "
-                "operation=mcp_scope_refresh, bot_id=%s, user_id=%s, "
-                "resource_scope=%s, bot_name=%s, bot_desc=%s, engine_type=%s",
-                bot_id,
-                user_id,
-                resource_scope,
-                bot_name,
-                bot_desc,
-                engine_type,
-            )
-            self.passport_update.update_passport(
-                bot_id=bot_id,
-                user_id=user_id,
-                resource_scope=resource_scope,
-                bot_name=bot_name,
-                bot_desc=bot_desc,
-                engine_type=engine_type,
-            )
-            logger.info(
-                "[MCPSyncService] updatePassport 成功: "
-                "bot_id=%s, user_id=%s, mcps=%s, caller_mcps=%s, clis=%s, "
-                "engine_type=%s, bot_name=%s",
-                bot_id,
-                user_id,
-                synced_server_codes,
-                caller_mcp_codes,
-                cli_items,
-                engine_type,
-                bot_name,
-            )
-            return {"success": True}
-        except Exception as e:
-            error = f"更新 passport 失败: {e}"
-            logger.error("[MCPSyncService] %s", error)
-            return {"success": False, "error": error}

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -3900,6 +3900,7 @@ class BaasService:  # pragma: no cover
         device_uuid: Optional[str] = None,
         auth_header: str = "openclawToken",
         timeout: float | None = None,
+        http_info: Optional[HttpConnectionInfo] = None,
     ) -> httpx.Response:
         """容器内 API 统一出口：封装 get_http_info + 直传完整 http_url。
 
@@ -3929,6 +3930,13 @@ class BaasService:  # pragma: no cover
                 需传 ``"x-proxypass-token"`` —— 该网关用此 header 鉴权，传 openclawToken
                 会 401。``info.token`` 是网关对应的 token，header 名不同而已。
             timeout: 获取连接信息并调用容器 API 的总超时秒数；不传时沿用各请求默认值。
+            http_info: 已解析好的连接信息。传入时跳过 get_http_info（省掉一次
+                binding 查库 + 一次 BaaS 往返），直接用它的 ``http_url``/``token``
+                发请求。调用方须保证它是用**同一** bind_id / port / **path** /
+                tenant / device_uuid 解析出来的 —— ``http_url`` 里含 path，换个
+                path 复用会打到错误的容器路由。批量同 path 请求（如逐文件
+                ``/api/file/upload``）由 ``BaasInvokeTransport`` 按 path 缓存后
+                在此复用。
 
         Returns:
             httpx.Response — 来自 self._general_http 的原始响应，供调用方自行处理
@@ -3940,18 +3948,24 @@ class BaasService:  # pragma: no cover
             raise ValueError("timeout must be positive")
 
         started_at = time.monotonic() if timeout is not None else None
-        http_info_timeout_kwargs = (
-            {"timeout": min(timeout, 5.0)} if timeout is not None else {}
-        )
-        info = self.get_http_info(
-            bind_id=bind_id,
-            port=port,
-            path=path,
-            tenant=tenant,
-            device_affinity=device_affinity,
-            device_uuid=device_uuid,
-            **http_info_timeout_kwargs,
-        )
+        if http_info is not None:
+            # Caller already resolved this (same bind_id/port/path/tenant/device_uuid)
+            # and is reusing it across a batch — the whole ``timeout`` budget is the
+            # container request's, since no resolution round trip is spent here.
+            info = http_info
+        else:
+            http_info_timeout_kwargs = (
+                {"timeout": min(timeout, 5.0)} if timeout is not None else {}
+            )
+            info = self.get_http_info(
+                bind_id=bind_id,
+                port=port,
+                path=path,
+                tenant=tenant,
+                device_affinity=device_affinity,
+                device_uuid=device_uuid,
+                **http_info_timeout_kwargs,
+            )
 
         request_timeout_kwargs: dict[str, float] = {}
         if timeout is not None and started_at is not None:

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -14,6 +14,7 @@ needs the dispatcher *types* under ``TYPE_CHECKING``.
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, TYPE_CHECKING
 
@@ -70,6 +71,79 @@ class LocalSkillQuarantineRepairError(OSError):
     """A partial authoritative-package delete could not be verified repaired."""
 
 
+# Every package file is one device round trip. Issuing them sequentially made a
+# package cost ``file_count × round_trip``, which dominates upload time for the many
+# small files a skill package is made of. Fan them out instead — but bounded: device
+# filesystems run their blocking transport through ``asyncio.to_thread``, whose
+# default executor (``min(32, cpu_count + 4)`` threads) is shared with every other
+# caller in the process, so an unbounded ``gather`` over a large package would starve
+# unrelated work.
+_PACKAGE_IO_CONCURRENCY = 8
+
+
+async def _gather_package_io(coroutines: list) -> list:
+    """Run package-file I/O concurrently, bounded, and drain before returning.
+
+    Every coroutine is awaited to completion even after one fails, then the first
+    failure *in input order* is re-raised. Draining is what makes the fan-out safe
+    to substitute for the sequential loop: a caller that sees ``write`` fail treats
+    the package as failed and immediately ``delete_tree``s its directory, so a write
+    still in flight at that moment could land a file behind the cleanup and leave an
+    orphan the next upload would trip over. Re-raising in input order keeps the
+    surfaced error the same one the sequential loop would have raised.
+
+    Cancellation is drained the same way, and needs its own handling because it does
+    not travel the exception path: device filesystems block inside
+    ``asyncio.to_thread``, which cannot interrupt a call already executing on a
+    worker thread — cancelling only abandons the await while the HTTP write keeps
+    going. Worse, ``CancelledError`` is a ``BaseException``, so
+    ``LocalSkillUploadService``'s ``except Exception`` compensation is skipped while
+    its ``finally`` still releases the edit lease. A retry could then acquire the
+    lease, ``delete_tree`` the directory and start a fresh package that the
+    abandoned writes land into. So the batch is shielded and drained before the
+    cancellation is allowed to continue.
+    """
+    semaphore = asyncio.Semaphore(_PACKAGE_IO_CONCURRENCY)
+
+    async def _bounded(coro):
+        try:
+            async with semaphore:
+                return await coro
+        finally:
+            # A coroutine still queued on the semaphore when this batch is cancelled
+            # would never be awaited, which Python surfaces as a RuntimeWarning.
+            # Closing an already-finished coroutine is a no-op, so this is safe on
+            # the normal path too.
+            coro.close()
+
+    batch = asyncio.ensure_future(
+        asyncio.gather(*(_bounded(coro) for coro in coroutines), return_exceptions=True)
+    )
+    try:
+        results = await asyncio.shield(batch)
+    except BaseException:
+        # Shielding keeps ``batch`` running when the caller is cancelled; awaiting it
+        # here is what guarantees no write is still in flight once this raises.
+        #
+        # The drain is itself shielded, and loops, because cancellation can arrive
+        # more than once — an aborted request overlapping with shutdown, say. A
+        # plain ``await`` here would let that second cancel tear down ``batch``
+        # itself and re-raise with the worker-thread writes still running, which is
+        # exactly the failure the shield above prevents on the first cancel. Only
+        # ``CancelledError`` is absorbed, and only until ``batch`` finishes, so this
+        # delays cancellation by at most the batch's own remaining work.
+        while not batch.done():
+            try:
+                await asyncio.shield(batch)
+            except asyncio.CancelledError:
+                continue
+        raise
+    for result in results:
+        if isinstance(result, BaseException):
+            raise result
+    return results
+
+
 class LocalSkillPackageStorage:
     """Explicit package-I/O port owned by the SkillService factory."""
 
@@ -83,10 +157,14 @@ class LocalSkillPackageStorage:
         return self._device_directory
 
     async def write(self, files: list[tuple[str, bytes]]) -> None:
-        for relative_path, content in files:
-            await self._filesystem.write_file(
-                f"{self._device_directory}/{relative_path}", content
-            )
+        await _gather_package_io(
+            [
+                self._filesystem.write_file(
+                    f"{self._device_directory}/{relative_path}", content
+                )
+                for relative_path, content in files
+            ]
+        )
 
     async def prepare(self) -> None:
         """Remove an orphaned failed upload before writing a first package."""
@@ -149,16 +227,27 @@ class LocalSkillPackageStorage:
         files = await self._read_package_files()
         if await quarantine._filesystem.exists(quarantine.directory):
             raise OSError("Local Skill quarantine already exists")
-        for relative_path, content in files:
-            await quarantine._filesystem.write_file(
-                f"{quarantine.directory}/{relative_path}", content
-            )
-        for relative_path, content in files:
-            copied = await quarantine._filesystem.read_file(
-                f"{quarantine.directory}/{relative_path}"
-            )
-            if copied != content:
-                raise OSError("Local Skill quarantine verification failed")
+        await _gather_package_io(
+            [
+                quarantine._filesystem.write_file(
+                    f"{quarantine.directory}/{relative_path}", content
+                )
+                for relative_path, content in files
+            ]
+        )
+        copied = await _gather_package_io(
+            [
+                quarantine._filesystem.read_file(
+                    f"{quarantine.directory}/{relative_path}"
+                )
+                for relative_path, _ in files
+            ]
+        )
+        if any(
+            actual != expected
+            for actual, (_, expected) in zip(copied, files)
+        ):
+            raise OSError("Local Skill quarantine verification failed")
         try:
             source_cleaned = await self.cleanup()
         except Exception:
@@ -198,17 +287,24 @@ class LocalSkillPackageStorage:
         return True, await quarantine.cleanup()
 
     async def _restore_contents(self, files: list[tuple[str, bytes]]) -> bool:
-        for relative_path, content in files:
-            await self._filesystem.write_file(
-                f"{self.directory}/{relative_path}", content
-            )
-        for relative_path, content in files:
-            restored = await self._filesystem.read_file(
-                f"{self.directory}/{relative_path}"
-            )
-            if restored != content:
-                return False
-        return True
+        await _gather_package_io(
+            [
+                self._filesystem.write_file(
+                    f"{self.directory}/{relative_path}", content
+                )
+                for relative_path, content in files
+            ]
+        )
+        restored = await _gather_package_io(
+            [
+                self._filesystem.read_file(f"{self.directory}/{relative_path}")
+                for relative_path, _ in files
+            ]
+        )
+        return all(
+            actual == expected
+            for actual, (_, expected) in zip(restored, files)
+        )
 
     async def _read_package_files(self) -> list[tuple[str, bytes]]:
         entries = await self._filesystem.list_dir(
@@ -216,7 +312,7 @@ class LocalSkillPackageStorage:
         )
         if entries is None:
             raise OSError("Local Skill package is missing")
-        files: list[tuple[str, bytes]] = []
+        relative_paths: list[str] = []
         for entry in entries:
             if entry.get("is_dir"):
                 continue
@@ -227,9 +323,20 @@ class LocalSkillPackageStorage:
                 or ".." in relative_path.split("/")
             ):
                 raise OSError("Local Skill package has an invalid file path")
-            content = await self._filesystem.read_file(
-                f"{self._device_directory}/{relative_path}"
-            )
+            relative_paths.append(relative_path)
+        # Every listed path is validated before a single read is issued, so a
+        # package containing an invalid path is still rejected outright rather
+        # than partially read.
+        contents = await _gather_package_io(
+            [
+                self._filesystem.read_file(
+                    f"{self._device_directory}/{relative_path}"
+                )
+                for relative_path in relative_paths
+            ]
+        )
+        files: list[tuple[str, bytes]] = []
+        for relative_path, content in zip(relative_paths, contents):
             if content is None:
                 raise OSError("Local Skill package file disappeared")
             files.append((relative_path, content))

--- a/src/backend/src/agentclaw/community/core/skill_center/factories.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/factories.py
@@ -14,7 +14,6 @@ needs the dispatcher *types* under ``TYPE_CHECKING``.
 
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 from typing import Any, Callable, Mapping, Optional, TYPE_CHECKING
 
@@ -26,6 +25,9 @@ from agentclaw.community.core.config_compose.teclaw_paths import (
     to_local_skill_engine_path,
 )
 from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
+from agentclaw.community.core.devices.device_io_batch import (
+    gather_device_io as _gather_package_io,
+)
 from agentclaw.community.core.mcp.services.config_service import MCPConfigService
 from agentclaw.community.core.mcp.services.sync_service import MCPSyncService
 from agentclaw.community.core.repository.protocols.bot import BotRepository
@@ -69,79 +71,6 @@ logger = get_logger()
 
 class LocalSkillQuarantineRepairError(OSError):
     """A partial authoritative-package delete could not be verified repaired."""
-
-
-# Every package file is one device round trip. Issuing them sequentially made a
-# package cost ``file_count × round_trip``, which dominates upload time for the many
-# small files a skill package is made of. Fan them out instead — but bounded: device
-# filesystems run their blocking transport through ``asyncio.to_thread``, whose
-# default executor (``min(32, cpu_count + 4)`` threads) is shared with every other
-# caller in the process, so an unbounded ``gather`` over a large package would starve
-# unrelated work.
-_PACKAGE_IO_CONCURRENCY = 8
-
-
-async def _gather_package_io(coroutines: list) -> list:
-    """Run package-file I/O concurrently, bounded, and drain before returning.
-
-    Every coroutine is awaited to completion even after one fails, then the first
-    failure *in input order* is re-raised. Draining is what makes the fan-out safe
-    to substitute for the sequential loop: a caller that sees ``write`` fail treats
-    the package as failed and immediately ``delete_tree``s its directory, so a write
-    still in flight at that moment could land a file behind the cleanup and leave an
-    orphan the next upload would trip over. Re-raising in input order keeps the
-    surfaced error the same one the sequential loop would have raised.
-
-    Cancellation is drained the same way, and needs its own handling because it does
-    not travel the exception path: device filesystems block inside
-    ``asyncio.to_thread``, which cannot interrupt a call already executing on a
-    worker thread — cancelling only abandons the await while the HTTP write keeps
-    going. Worse, ``CancelledError`` is a ``BaseException``, so
-    ``LocalSkillUploadService``'s ``except Exception`` compensation is skipped while
-    its ``finally`` still releases the edit lease. A retry could then acquire the
-    lease, ``delete_tree`` the directory and start a fresh package that the
-    abandoned writes land into. So the batch is shielded and drained before the
-    cancellation is allowed to continue.
-    """
-    semaphore = asyncio.Semaphore(_PACKAGE_IO_CONCURRENCY)
-
-    async def _bounded(coro):
-        try:
-            async with semaphore:
-                return await coro
-        finally:
-            # A coroutine still queued on the semaphore when this batch is cancelled
-            # would never be awaited, which Python surfaces as a RuntimeWarning.
-            # Closing an already-finished coroutine is a no-op, so this is safe on
-            # the normal path too.
-            coro.close()
-
-    batch = asyncio.ensure_future(
-        asyncio.gather(*(_bounded(coro) for coro in coroutines), return_exceptions=True)
-    )
-    try:
-        results = await asyncio.shield(batch)
-    except BaseException:
-        # Shielding keeps ``batch`` running when the caller is cancelled; awaiting it
-        # here is what guarantees no write is still in flight once this raises.
-        #
-        # The drain is itself shielded, and loops, because cancellation can arrive
-        # more than once — an aborted request overlapping with shutdown, say. A
-        # plain ``await`` here would let that second cancel tear down ``batch``
-        # itself and re-raise with the worker-thread writes still running, which is
-        # exactly the failure the shield above prevents on the first cancel. Only
-        # ``CancelledError`` is absorbed, and only until ``batch`` finishes, so this
-        # delays cancellation by at most the batch's own remaining work.
-        while not batch.done():
-            try:
-                await asyncio.shield(batch)
-            except asyncio.CancelledError:
-                continue
-        raise
-    for result in results:
-        if isinstance(result, BaseException):
-            raise result
-    return results
 
 
 class LocalSkillPackageStorage:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -12,7 +12,6 @@ Replaces: SkillService class (lines 535-2625)
 """
 from __future__ import annotations
 
-import asyncio
 import io
 import json
 import os
@@ -807,8 +806,13 @@ class SkillService:
         # activate_skill picks the right DeviceFileSystem plugin (BAAS vs ARCA
         # vs Local). Otherwise inner calls land on LocalDeviceFileSystem
         # fallback regardless of the bot's actual device binding.
-        activations = await asyncio.gather(
-            *[
+        #
+        # Bounded rather than a raw ``gather``: each activation blocks a worker in
+        # the shared ``asyncio.to_thread`` executor (``min(32, cpu_count + 4)``
+        # threads for the whole process), so an unbounded fan-out over a large
+        # market selection starves every other caller until it drains.
+        activations = await gather_device_io(
+            [
                 self.activate_skill(skill_path, user_id=user_id, bolt_id=bolt_id)
                 for skill_path in skill_paths
             ],
@@ -854,10 +858,24 @@ class SkillService:
         """停用所有技能"""
         results = {"success": [], "failed": []}
 
-        for skill in self.get_active_skills():
-            if await self.deactivate_skill(skill.id):
+        # Each deactivation removes one independent entry under ``active_dir``, one
+        # device round trip each — so doing them in turn made this cost
+        # ``active_count × round_trip``. They touch no shared device state, so they
+        # go out together (bounded, like every other device fan-out here).
+        active = list(self.get_active_skills())
+        outcomes = await gather_device_io(
+            [self.deactivate_skill(skill.id) for skill in active],
+            return_exceptions=True,
+        )
+        for skill, outcome in zip(active, outcomes):
+            if outcome is True:
                 results["success"].append(skill.id)
             else:
+                if isinstance(outcome, BaseException):
+                    logger.warning(
+                        "[SkillService.deactivate_all_skills] %s failed: %s",
+                        skill.id, outcome,
+                    )
                 results["failed"].append(skill.id)
 
         return results

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -1862,7 +1862,21 @@ class SkillService:
         skill_md_file = skill_md_files[0]
         skill_md_path = skill_md_file["relative_path"]
         skill_root = os.path.dirname(skill_md_path)
-        processed_files: list[dict[str, Any]] = []
+        # Keyed by destination path, so a request naming the same path twice
+        # yields one write rather than two. Nothing upstream rejects that: the
+        # request is a flat multipart list and two parts can carry one path.
+        # The sequential writer used to let the later entry overwrite the
+        # earlier, so the last one deterministically won; writing them
+        # concurrently would instead let whichever call finished last win, and
+        # the installed Skill would differ run to run. Assigning into a dict
+        # keeps that last-one-wins outcome and makes it a single write.
+        #
+        # Deduplicating rather than rejecting keeps this legacy address
+        # accepting exactly the requests it accepted before. The OpenAPI upload
+        # is stricter — ``LocalSkillUploadService._unpack`` answers
+        # ``duplicate_file_path`` — but tightening a retiring address is a
+        # product call, not a fix for this.
+        by_path: dict[str, dict[str, Any]] = {}
 
         for file_info in candidates:
             relative_path = file_info["relative_path"]
@@ -1876,10 +1890,11 @@ class SkillService:
 
             if not relative_path_without_root:
                 continue
-            processed_files.append({
+            by_path[relative_path_without_root] = {
                 "relative_path": relative_path_without_root,
                 "content": file_info["content"],
-            })
+            }
+        processed_files: list[dict[str, Any]] = list(by_path.values())
 
         raw_bytes = skill_md_file.get("content", b"")
         try:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_service.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
     from agentclaw.community.core.skill_center.services.git_sync import GitSyncService
 
 from agentclaw.community.core.access.admin_scopes import skill_admin
+from agentclaw.community.core.devices.device_io_batch import (
+    gather_device_io,
+)
 from agentclaw.community.core.skill_center.errors import (
     SkillDeleteConsistencyError,
     SkillReferencedBySkillSetError,
@@ -505,26 +508,32 @@ class SkillService:
         if entries is None:
             return []
 
-        skills: list[SkillInfo] = []
-        for entry in entries:
-            name = entry.get("name")
-            if (
-                not isinstance(name, str)
-                or not name
-                or name in {".", ".."}
-                or Path(name).name != name
-                or name in self.RESERVED_SKILL_NAMES
-            ):
-                continue
+        names = [
+            name
+            for entry in entries
+            if isinstance(name := entry.get("name"), str)
+            and name
+            and name not in {".", ".."}
+            and Path(name).name == name
+            and name not in self.RESERVED_SKILL_NAMES
+        ]
+        # One read per entry, all in flight at once. Two things were paid per entry
+        # before: an ``exists`` probe *and* a read — and on the baas backend
+        # ``exists`` is itself a ``read_file``, so a bot's active Skills cost two
+        # full downloads each, issued one after another. A single read answers both
+        # questions: a missing entry and a directory in an entry's place both read
+        # back as ``None``, which is exactly what the probe used to filter out.
+        contents = await gather_device_io([
+            device_fs.read_file(str(active_root / name / "SKILL.md"))
+            for name in names
+        ])
 
-            active_path = active_root / name
-            content = None
-            skill_file = active_path / "SKILL.md"
-            if not await device_fs.exists(str(skill_file)):
-                continue
-            content = await device_fs.read_file(str(skill_file))
+        skills: list[SkillInfo] = []
+        for name, content in zip(names, contents):
             if content is None:
                 continue
+            active_path = active_root / name
+            skill_file = active_path / "SKILL.md"
 
             try:
                 text = SkillParser.decode_content(content)
@@ -2016,13 +2025,22 @@ class SkillService:
             # 先清理已存在的目录
             await device_fs.delete_tree(engine_skill_dir_str)
 
-            # 逐文件写入（DeviceFileSystem 自动创建父目录）
-            for file_info in processed_files:
-                relative_path = file_info["relative_path"]
-                content = file_info["content"]
-                file_path = f"{engine_skill_dir_str}/{relative_path}"
-                await device_fs.write_file(file_path, content)
-                logger.debug(f"[SkillService.upload_skill] Saved file: {file_path}")
+            # 并发写入（DeviceFileSystem 自动创建父目录）。每个文件都是一次设备
+            # 往返，逐个 await 让一个包的耗时变成 ``文件数 × 单次往返`` —— 而本地
+            # 技能包正是由许多小文件组成的。``gather_device_io`` 有界扇出并在放行
+            # 前排空：下面的 ``except`` 会 ``delete_tree`` 整个目录，若此刻还有写
+            # 在途，它会落在清理之后，给下一次上传留下孤儿文件。
+            await gather_device_io([
+                device_fs.write_file(
+                    f"{engine_skill_dir_str}/{file_info['relative_path']}",
+                    file_info["content"],
+                )
+                for file_info in processed_files
+            ])
+            logger.debug(
+                "[SkillService.upload_skill] Saved %d files under %s",
+                len(processed_files), engine_skill_dir_str,
+            )
 
             logger.info(f"[SkillService.upload_skill] Using skill name from SKILL.md: '{skill_name}'")
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, List, Mapping, Optional
 
+from agentclaw.community.core.devices.device_io_batch import gather_device_io
 from agentclaw.community.core.devices.models import SynlinkMappingInfo
 from agentclaw.community.core.devices.services.device_accessor import DeviceAccessor
 
@@ -2752,20 +2753,36 @@ class SkillSetSwitcher(_DeviceSyncMixin):
                     f"[SkillSetSwitcher] skills_dir does not exist (plugin returned None): {skills_dir}"
                 )
                 return []
-            local_cleaned: list[str] = []
+            targets: list[tuple[str, str]] = []
             for entry in entries:
                 name = entry.get("name", "")
                 if name in reserved_names:
                     logger.debug(f"[SkillSetSwitcher] Skipping reserved item: {name}")
                     continue
-                entry_path = entry.get("path") or f"{skills_dir}/{name}"
+                targets.append((name, entry.get("path") or f"{skills_dir}/{name}"))
+
+            # Each removal is one device round trip, and a switch sweeps every
+            # non-reserved entry under skills_dir — so a bot with many Skills paid
+            # ``entry_count × round_trip`` before the new set could be laid down.
+            # Fan them out instead. Every entry is still attempted and reported
+            # exactly as before: the per-entry failure is caught *inside* the
+            # coroutine, so one device rejecting a directory neither hides the
+            # others' results nor stops them.
+            async def _remove(name: str, entry_path: str) -> bool:
                 try:
-                    ok = await device_fs.delete_tree(entry_path)
-                    if ok:
-                        local_cleaned.append(name)
-                        logger.info(f"[SkillSetSwitcher] Removed: {name}")
+                    return bool(await device_fs.delete_tree(entry_path))
                 except Exception as e:
                     logger.warning(f"[SkillSetSwitcher] Failed to remove {name}: {e}")
+                    return False
+
+            removed = await gather_device_io(
+                [_remove(name, entry_path) for name, entry_path in targets]
+            )
+            local_cleaned: list[str] = []
+            for (name, _), ok in zip(targets, removed):
+                if ok:
+                    local_cleaned.append(name)
+                    logger.info(f"[SkillSetSwitcher] Removed: {name}")
             return local_cleaned
 
         try:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -955,8 +955,12 @@ class SkillSetService:
                 owner_id = self.entity_id or user_id
 
                 # Activate all concurrently with proper device routing
-                activation_results = await asyncio.gather(
-                    *[
+                # Bounded rather than a raw ``gather``: each activation blocks a
+                # worker in the shared ``asyncio.to_thread`` executor, so an
+                # unbounded fan-out over a large set starves the rest of the
+                # process until it drains.
+                activation_results = await gather_device_io(
+                    [
                         self.skill_service.activate_skill(
                             gp,
                             user_id=owner_id,
@@ -964,7 +968,7 @@ class SkillSetService:
                         )
                         for gp in git_paths
                     ],
-                    return_exceptions=True
+                    return_exceptions=True,
                 )
                 # 收集激活失败的信息，让调用方可见
                 activation_failed = []
@@ -2861,8 +2865,10 @@ class SkillSetSwitcher(_DeviceSyncMixin):
 
         skill_infos = [(skill.get('id'), skill.get('git_path')) for skill in new_skills]
         if skill_infos:
-            activations = await asyncio.gather(
-                *[
+            # Bounded: see ``gather_device_io``. A skill set can carry dozens of
+            # skills and each activation occupies a shared executor worker.
+            activations = await gather_device_io(
+                [
                     self.skill_set_service.skill_service.activate_skill(
                         git_path,
                         user_id=owner_id,
@@ -2871,7 +2877,7 @@ class SkillSetSwitcher(_DeviceSyncMixin):
                     for _, git_path in skill_infos
                     if git_path
                 ],
-                return_exceptions=True
+                return_exceptions=True,
             )
             # Pair results with skill_ids, handling cases where git_path was None
             idx = 0
@@ -2970,17 +2976,28 @@ class SkillSetSwitcher(_DeviceSyncMixin):
             result.message = "No active skills to deactivate"
             return result
 
-        for skill_id in current_active:
-            try:
-                success = await self.skill_set_service.skill_service.deactivate_skill(
-                    skill_id, bolt_id=self.skill_set_service.bot_id, user_id=self.skill_set_service.entity_id
+        # One device round trip per skill, and the entries are independent, so they
+        # go out together instead of in turn — bounded and drained like every other
+        # device fan-out here. Results are still paired back to ``current_active``
+        # in order, so ``deactivated`` / ``failed`` read exactly as before.
+        outcomes = await gather_device_io(
+            [
+                self.skill_set_service.skill_service.deactivate_skill(
+                    skill_id,
+                    bolt_id=self.skill_set_service.bot_id,
+                    user_id=self.skill_set_service.entity_id,
                 )
-                if success:
-                    result.deactivated.append(skill_id)
-                else:
-                    result.failed.append({"skill_id": skill_id, "action": "deactivate", "error": "Failed to deactivate"})
-            except Exception as e:
-                result.failed.append({"skill_id": skill_id, "action": "deactivate", "error": str(e)})
+                for skill_id in current_active
+            ],
+            return_exceptions=True,
+        )
+        for skill_id, outcome in zip(current_active, outcomes):
+            if isinstance(outcome, BaseException):
+                result.failed.append({"skill_id": skill_id, "action": "deactivate", "error": str(outcome)})
+            elif outcome:
+                result.deactivated.append(skill_id)
+            else:
+                result.failed.append({"skill_id": skill_id, "action": "deactivate", "error": "Failed to deactivate"})
 
         if len(result.failed) == 0:
             # 清除数据库中的激活状态
@@ -3059,8 +3076,9 @@ class SkillSetSwitcher(_DeviceSyncMixin):
 
         # Activate all concurrently
         if tasks:
-            activations = await asyncio.gather(
-                *[
+            # Bounded: see ``gather_device_io``.
+            activations = await gather_device_io(
+                [
                     self.skill_set_service.skill_service.activate_skill(
                         skill_path,
                         user_id=owner_id,
@@ -3068,7 +3086,7 @@ class SkillSetSwitcher(_DeviceSyncMixin):
                     )
                     for _, skill_path, _ in tasks
                 ],
-                return_exceptions=True
+                return_exceptions=True,
             )
             for (skill_id, skill_path, source_path), act_result in zip(tasks, activations):
                 if isinstance(act_result, Exception):

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_symlink_verify_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_symlink_verify_service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
+from agentclaw.community.core.devices.device_io_batch import gather_device_io
 from agentclaw.community.log import get_logger
 
 
@@ -105,7 +106,14 @@ class SkillSymlinkVerifyService:
         else:
             logger.warning("[verify] list_arca_directory returned None: bot_id=%s sandbox=%s", bot_id, sandbox_id)
 
-        # 3. 逐条验证
+        # 3. 逐条验证。NAS 探测是每条一次设备往返，串起来就是
+        #    ``skill_count × round_trip``，装了几十个 Skill 的 bot 验证一次要等上
+        #    好几秒。先按原顺序判掉不需要探测的（软链缺失 / git:// 目标在容器内），
+        #    把要探 NAS 的记成一个占位，再一次性并发探完回填 —— failures 的顺序和
+        #    内容与逐条循环完全一致。
+        pending: list[tuple[str, str, str, str, str]] = []
+        # Either a decided failure, or the index of the probe that decides it.
+        slots: list[VerifyFailure | int] = []
         for skill in skills:
             skill_id = str(skill.get("id", ""))
             skill_name = skill.get("name", "")
@@ -113,7 +121,7 @@ class SkillSymlinkVerifyService:
             link_name = skill.get("link_name", skill_name)
 
             if link_name not in symlink_names:
-                failures.append(VerifyFailure(
+                slots.append(VerifyFailure(
                     skill_id=skill_id, skill_name=skill_name, git_path=git_path,
                     link_name=link_name, reason="symlink_not_found", expected=link_name,
                 ))
@@ -124,14 +132,26 @@ class SkillSymlinkVerifyService:
                 # 软链 source 真实路径：<SKILLS_CENTER_IN_NAS>/<uuid>/current/<skill_name>
                 uuid = git_path[9:]
                 nas_target = f"{self.SKILLS_CENTER_IN_NAS}/{uuid}/current/{skill_name}"
-                exists = await device_fs.exists(nas_target)
-                if not exists:
-                    failures.append(VerifyFailure(
-                        skill_id=skill_id, skill_name=skill_name, git_path=git_path,
-                        link_name=link_name, reason="nas_target_missing", expected=nas_target,
-                    ))
+                slots.append(len(pending))
+                pending.append(
+                    (skill_id, skill_name, git_path, link_name, nas_target)
+                )
             elif git_path.startswith("git://"):
                 pass  # git:// 目标在容器内，不单独验证 NAS
+
+        found = await gather_device_io(
+            [device_fs.exists(nas_target) for *_, nas_target in pending]
+        )
+        for slot in slots:
+            if isinstance(slot, VerifyFailure):
+                failures.append(slot)
+                continue
+            skill_id, skill_name, git_path, link_name, nas_target = pending[slot]
+            if not found[slot]:
+                failures.append(VerifyFailure(
+                    skill_id=skill_id, skill_name=skill_name, git_path=git_path,
+                    link_name=link_name, reason="nas_target_missing", expected=nas_target,
+                ))
 
         passed = len(skills) - len(failures)
         return VerifyReport(

--- a/src/backend/tests/community/core/mcp/services/test_sync_service.py
+++ b/src/backend/tests/community/core/mcp/services/test_sync_service.py
@@ -13,6 +13,8 @@ delivery failure is NOT best-effort).
 The plugin's MCP methods are **synchronous** (the service wraps them in
 ``asyncio.to_thread``), so the doubles use plain ``MagicMock``.
 """
+import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -959,6 +961,128 @@ class TestSyncMcpDetailToAllBots:
 
         assert result["success"] is True
         assert result["sync_results"][0]["reason"] == "缺少设备连接信息"
+
+    # ── fan-out across bots ───────────────────────────────────────────
+    #
+    # Each bot is a *different* device, and the batch used to walk them one at a
+    # time — so one credential change cost ``bot_count × (resolve + probe + push)``
+    # for an entity of up to 100 bots. Worse, ``resolve_for_bot`` is synchronous
+    # with a blocking ws-info round trip inside, so every one of those resolutions
+    # also sat on the event loop and stalled unrelated requests.
+
+    def _service_with_bots(self, bot_ids, *, resolver, dispatcher):
+        bot_repo = MagicMock()
+        bot_repo.list_by_entity.return_value = (
+            len(bot_ids), [{"bot_id": b} for b in bot_ids],
+        )
+        return _make_sync_service(
+            bot_repository=bot_repo, resolver=resolver, dispatcher=dispatcher,
+        )
+
+    @pytest.mark.asyncio
+    async def test_bots_are_pushed_concurrently(self):
+        state = {"in_flight": 0, "peak": 0}
+        lock = threading.Lock()
+
+        def _sync_single_mcp(*_args, **_kwargs):
+            # Runs on a ``to_thread`` worker, so the counters need a lock.
+            with lock:
+                state["in_flight"] += 1
+                state["peak"] = max(state["peak"], state["in_flight"])
+            try:
+                time.sleep(0.01)
+                return True
+            finally:
+                with lock:
+                    state["in_flight"] -= 1
+
+        plugin = _make_plugin(sync_single_mcp=MagicMock(side_effect=_sync_single_mcp))
+        resolver, dispatcher, _ = _make_resolver_and_dispatcher(plugin=plugin)
+        bot_ids = [f"bot{i}" for i in range(6)]
+        service = self._service_with_bots(
+            bot_ids, resolver=resolver, dispatcher=dispatcher
+        )
+
+        result = await service.sync_mcp_detail_to_all_bots(
+            user_id="u1", server_code="mcp.x", mcp_data={"server_code": "mcp.x"},
+            entity_id="100", entity_type="staff",
+        )
+
+        assert result["success"] is True
+        assert state["peak"] > 1
+
+    @pytest.mark.asyncio
+    async def test_results_keep_the_bot_list_order(self):
+        """并发不改变结果顺序：sync_results 仍按 bot 列表排列。"""
+        plugin = _make_plugin()
+        resolver, dispatcher, _ = _make_resolver_and_dispatcher(plugin=plugin)
+        bot_ids = [f"bot{i}" for i in range(5)]
+        service = self._service_with_bots(
+            bot_ids, resolver=resolver, dispatcher=dispatcher
+        )
+
+        result = await service.sync_mcp_detail_to_all_bots(
+            user_id="u1", server_code="mcp.x", mcp_data={"server_code": "mcp.x"},
+            entity_id="100", entity_type="staff",
+        )
+
+        assert [r["bot_id"] for r in result["sync_results"]] == bot_ids
+
+    @pytest.mark.asyncio
+    async def test_resolution_does_not_run_on_the_event_loop(self):
+        """resolve_for_bot 同步且内含阻塞 ws-info HTTP，必须在线程池里跑。"""
+        loop_thread = threading.get_ident()
+        seen: list[int] = []
+
+        def _resolve(bot_id, entity_id):
+            seen.append(threading.get_ident())
+            return _make_ctx(bot_id=bot_id)
+
+        resolver = MagicMock()
+        resolver.resolve_for_bot.side_effect = _resolve
+        dispatcher = MagicMock()
+        dispatcher.dispatch.return_value = _make_plugin()
+        service = self._service_with_bots(
+            ["bot1", "bot2"], resolver=resolver, dispatcher=dispatcher
+        )
+
+        await service.sync_mcp_detail_to_all_bots(
+            user_id="u1", server_code="mcp.x", mcp_data={"server_code": "mcp.x"},
+            entity_id="100", entity_type="staff",
+        )
+
+        assert seen and all(tid != loop_thread for tid in seen)
+
+    @pytest.mark.asyncio
+    async def test_one_bot_raising_neither_stops_nor_hides_the_others(self):
+        """一台设备抛异常既不中止其余投递，也不改变它们的结果——与逐台循环一致。"""
+        good = _make_plugin()
+        bad = _make_plugin(
+            sync_single_mcp=MagicMock(side_effect=RuntimeError("device blew up"))
+        )
+        resolver = MagicMock()
+        resolver.resolve_for_bot.side_effect = lambda bot_id, entity_id: _make_ctx(
+            bot_id=bot_id
+        )
+        dispatcher = MagicMock()
+        dispatcher.dispatch.side_effect = lambda ctx: (
+            bad if ctx.bot_id == "bot2" else good
+        )
+        service = self._service_with_bots(
+            ["bot1", "bot2", "bot3"], resolver=resolver, dispatcher=dispatcher
+        )
+
+        result = await service.sync_mcp_detail_to_all_bots(
+            user_id="u1", server_code="mcp.x", mcp_data={"server_code": "mcp.x"},
+            entity_id="100", entity_type="staff",
+        )
+
+        # a device that has the MCP and succeeded keeps the batch out of rollback
+        assert result["success"] is True
+        assert [(r["bot_id"], r["synced"]) for r in result["sync_results"]] == [
+            ("bot1", True), ("bot2", False), ("bot3", True),
+        ]
+        assert result["sync_results"][1]["error"] == "device blew up"
 
 
 class TestSyncMcpDetailsForBot:

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service.py
@@ -800,13 +800,15 @@ class TestSkillServiceGetActiveSkills:
             ]
         )
         device_fs.exists = AsyncMock(
-            side_effect=lambda path: path.endswith("direct-skill/SKILL.md")
+            side_effect=AssertionError("the read answers existence; do not probe")
         )
 
         async def _read_file(path, **_kwargs):
             if path.endswith("direct-skill/SKILL.md"):
                 return b"---\nname: direct-skill\n---\n"
-            raise AssertionError(f"must not read missing metadata: {path}")
+            # What the DeviceFileSystem contract returns for a file the device
+            # does not have — an entry with no SKILL.md is skipped on that alone.
+            return None
 
         device_fs.read_file = AsyncMock(side_effect=_read_file)
         svc = SkillService(
@@ -826,9 +828,13 @@ class TestSkillServiceGetActiveSkills:
         )
 
         assert [skill.id for skill in skills] == ["direct-skill"]
-        device_fs.read_file.assert_awaited_once_with(
-            f"{active_root}/direct-skill/SKILL.md"
-        )
+        # One read per entry — no ``exists`` probe ahead of it, which on the baas
+        # backend is itself a full ``read_file`` and doubled the cost of the list.
+        assert [c.args[0] for c in device_fs.read_file.await_args_list] == [
+            f"{active_root}/mcporter/SKILL.md",
+            f"{active_root}/direct-skill/SKILL.md",
+        ]
+        device_fs.exists.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_missing_device_active_root_is_empty(

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_device_io.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_device_io.py
@@ -289,3 +289,30 @@ async def test_deactivate_all_removes_entries_concurrently(tmp_path):
     assert results["success"] == ["skill-0", "skill-1", "skill-3", "skill-4"]
     assert results["failed"] == ["skill-2"]
     assert state["peak"] > 1
+
+
+@pytest.mark.asyncio
+async def test_duplicate_upload_paths_collapse_to_one_deterministic_write(tmp_path):
+    """两个 part 指向同一路径时只写一次，且内容是最后那个——与逐个写入一致。
+
+    The request is a flat multipart list, so nothing upstream stops two parts
+    from naming one path. Writing them concurrently would let whichever call
+    finished last win, making the installed Skill differ run to run.
+    """
+    device_fs = _RecordingDeviceFilesystem(delay=0)
+    service = _service(tmp_path, device_fs)
+
+    files = [
+        {"filename": "SKILL.md", "content": _MANIFEST, "relative_path": "SKILL.md"},
+        {"filename": "a.txt", "content": b"first", "relative_path": "assets/a.txt"},
+        {"filename": "b.txt", "content": b"other", "relative_path": "assets/b.txt"},
+        {"filename": "a.txt", "content": b"last", "relative_path": "assets/a.txt"},
+    ]
+    await service.upload_skill(files, user_id="user1", bolt_id="bot1")
+
+    written = [e for e in device_fs.events if e.startswith("write:")]
+    collided = [e for e in written if e.endswith("assets/a.txt")]
+    assert len(collided) == 1, f"one write per destination, got {written}"
+    assert len(written) == 3
+    # last part wins, exactly as the sequential overwrite left it
+    assert device_fs.files[collided[0][len("write:"):]] == b"last"

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_device_io.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_device_io.py
@@ -1,0 +1,212 @@
+"""Device-I/O batching contract for the legacy Skills API surface.
+
+``SkillService`` backs the legacy addresses — ``POST /skills/upload`` and
+``GET /skills/active/list`` — and both used to address the device one file at a
+time, so a request cost ``file_count × round_trip``. These pin the two
+substitutions that removed that, and the properties that make each safe.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentclaw.community.core.devices.device_io_batch import DEVICE_IO_CONCURRENCY
+from agentclaw.community.core.skill_center.services.skill_service import SkillService
+
+
+class _RecordingDeviceFilesystem:
+    """Records overlap and completion order so both are observable, not assumed."""
+
+    def __init__(self, *, fail_paths=(), delay=0.01):
+        self.files: dict[str, bytes] = {}
+        self.events: list[str] = []
+        self.in_flight = 0
+        self.peak_in_flight = 0
+        self._fail_paths = set(fail_paths)
+        self._delay = delay
+
+    async def write_file(self, path, content):
+        self.in_flight += 1
+        self.peak_in_flight = max(self.peak_in_flight, self.in_flight)
+        try:
+            await asyncio.sleep(self._delay)
+            if path in self._fail_paths:
+                raise OSError(f"device rejected {path}")
+            self.files[path] = content
+            self.events.append(f"write:{path}")
+        finally:
+            self.in_flight -= 1
+
+    async def read_file(self, path, **_kwargs):
+        self.in_flight += 1
+        self.peak_in_flight = max(self.peak_in_flight, self.in_flight)
+        try:
+            await asyncio.sleep(self._delay)
+            self.events.append(f"read:{path}")
+            return self.files.get(path)
+        finally:
+            self.in_flight -= 1
+
+    async def list_dir(self, path, *, recursive=False):
+        return None
+
+    async def delete_tree(self, path):
+        self.events.append(f"delete_tree:{path}")
+        return True
+
+    async def exists(self, path):
+        raise AssertionError(f"the read answers existence; do not probe {path}")
+
+
+def _repo():
+    repo = MagicMock()
+    repo.list_skills.return_value = []
+    repo.list_skill_set_references.return_value = []
+    repo.get_bot_local_by_name.return_value = None
+    repo.get_by_name_global.return_value = None
+    repo.create.side_effect = lambda data: {"id": "1", **data}
+    return repo
+
+
+def _service(tmp_path, device_fs, *, active_dir=None):
+    return SkillService(
+        skill_repo=_repo(),
+        skill_repo_sync=MagicMock(),
+        market_cache=MagicMock(),
+        category_repo=MagicMock(),
+        active_dir=active_dir or (tmp_path / "skills"),
+        repo_dir=tmp_path / "skills-repo",
+        local_dir=tmp_path / "skills-local",
+        device_fs_factory=lambda bolt_id, user_id: device_fs,
+        git_sync_service_factory=MagicMock(),
+    )
+
+
+_MANIFEST = b"---\nname: test-skill\ndescription: test\n---\n# Test"
+
+
+def _upload_files(count):
+    """A SKILL.md plus ``count`` sibling files — the shape of a real package."""
+    files = [
+        {"filename": "SKILL.md", "content": _MANIFEST, "relative_path": "SKILL.md"}
+    ]
+    files += [
+        {
+            "filename": f"asset{index}.txt",
+            "content": f"body-{index}".encode(),
+            "relative_path": f"assets/asset{index}.txt",
+        }
+        for index in range(count)
+    ]
+    return files
+
+
+# ── POST /skills/upload ───────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_upload_writes_package_files_concurrently(tmp_path):
+    device_fs = _RecordingDeviceFilesystem()
+    service = _service(tmp_path, device_fs)
+
+    await service.upload_skill(_upload_files(5), user_id="user1", bolt_id="bot1")
+
+    assert device_fs.peak_in_flight > 1
+    assert len(device_fs.files) == 6
+
+
+@pytest.mark.asyncio
+async def test_upload_fan_out_stays_bounded(tmp_path):
+    """The blocking device transport shares one ``to_thread`` executor process-wide."""
+    device_fs = _RecordingDeviceFilesystem()
+    service = _service(tmp_path, device_fs)
+
+    await service.upload_skill(
+        _upload_files(DEVICE_IO_CONCURRENCY * 3), user_id="user1", bolt_id="bot1"
+    )
+
+    assert device_fs.peak_in_flight <= DEVICE_IO_CONCURRENCY
+
+
+@pytest.mark.asyncio
+async def test_failed_upload_is_drained_before_the_rollback_deletes_the_tree(tmp_path):
+    """A write still in flight during the rollback would outlive it as an orphan.
+
+    ``upload_skill`` compensates a failure by deleting the whole skill directory,
+    so every write must have finished — succeeded or failed — before that delete
+    is issued. The fan-out drains for exactly this reason.
+    """
+    files = _upload_files(7)
+    device_fs = _RecordingDeviceFilesystem(delay=0)
+    # Fail the first file in order; the rest keep running and must all land first.
+    service = _service(tmp_path, device_fs)
+    failing = str(
+        service._local_skill_path_adapter(
+            str(service.local_dir / "test-skill")
+        )
+    ) + "/SKILL.md"
+    device_fs._fail_paths = {failing}
+
+    with pytest.raises(ValueError):
+        await service.upload_skill(files, user_id="user1", bolt_id="bot1")
+
+    deletes = [i for i, e in enumerate(device_fs.events) if e.startswith("delete_tree:")]
+    writes = [i for i, e in enumerate(device_fs.events) if e.startswith("write:")]
+    # events[0] is the pre-write delete_tree; the rollback delete is the last one.
+    assert len(deletes) == 2
+    assert device_fs.in_flight == 0
+    assert writes, "the surviving files should still have been attempted"
+    assert max(writes) < deletes[-1]
+
+
+# ── GET /skills/active/list ───────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_active_list_reads_every_entry_concurrently(tmp_path):
+    active_root = tmp_path / "skills"
+    device_fs = _RecordingDeviceFilesystem()
+    names = [f"skill-{index}" for index in range(5)]
+    for name in names:
+        device_fs.files[str(active_root / name / "SKILL.md")] = (
+            f"---\nname: {name}\n---\n".encode()
+        )
+    device_fs.list_dir = AsyncMock(
+        return_value=[
+            {"name": name, "path": str(active_root / name), "is_dir": True}
+            for name in names
+        ]
+    )
+    service = _service(tmp_path, device_fs, active_dir=active_root)
+    service.get_skill_by_link_name = MagicMock(return_value=None)
+
+    skills = await service.get_active_skills_from_device(
+        bot_id="bot1", owner_id="user1"
+    )
+
+    assert sorted(skill.id for skill in skills) == sorted(names)
+    assert device_fs.peak_in_flight > 1
+    # One read per entry: ``exists`` is itself a read on the baas backend, so the
+    # probe it replaces was a second full download of every SKILL.md.
+    assert len([e for e in device_fs.events if e.startswith("read:")]) == len(names)
+
+
+@pytest.mark.asyncio
+async def test_active_list_skips_entries_whose_manifest_is_absent(tmp_path):
+    """A missing SKILL.md reads back as ``None`` — that is the whole check."""
+    active_root = tmp_path / "skills"
+    device_fs = _RecordingDeviceFilesystem()
+    device_fs.files[str(active_root / "real" / "SKILL.md")] = b"---\nname: real\n---\n"
+    device_fs.list_dir = AsyncMock(
+        return_value=[
+            {"name": "dangling", "path": str(active_root / "dangling"), "is_dir": True},
+            {"name": "real", "path": str(active_root / "real"), "is_dir": True},
+        ]
+    )
+    service = _service(tmp_path, device_fs, active_dir=active_root)
+    service.get_skill_by_link_name = MagicMock(return_value=None)
+
+    skills = await service.get_active_skills_from_device(
+        bot_id="bot1", owner_id="user1"
+    )
+
+    assert [skill.id for skill in skills] == ["real"]

--- a/src/backend/tests/community/core/skill_center/services/test_skill_service_device_io.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_service_device_io.py
@@ -210,3 +210,82 @@ async def test_active_list_skips_entries_whose_manifest_is_absent(tmp_path):
     )
 
     assert [skill.id for skill in skills] == ["real"]
+
+
+# ── activate / deactivate batches ─────────────────────────────────────
+#
+# These already ran concurrently, but through a raw ``asyncio.gather`` — every
+# activation blocks a worker in the ``asyncio.to_thread`` executor, which is
+# shared process-wide (``min(32, cpu_count + 4)`` threads), so a large market
+# selection or skill set starved every other caller until it drained.
+
+@pytest.mark.asyncio
+async def test_activate_batch_stays_bounded(tmp_path):
+    state = {"in_flight": 0, "peak": 0}
+
+    async def _activate(skill_path, **_kwargs):
+        state["in_flight"] += 1
+        state["peak"] = max(state["peak"], state["in_flight"])
+        try:
+            await asyncio.sleep(0.005)
+            return True
+        finally:
+            state["in_flight"] -= 1
+
+    service = _service(tmp_path, _RecordingDeviceFilesystem())
+    service.activate_skill = _activate
+
+    paths = [f"git://biz/skill-{index}" for index in range(DEVICE_IO_CONCURRENCY * 3)]
+    results = await service.activate_skills_batch(paths, user_id="u1", bolt_id="bot1")
+
+    assert len(results["success"]) == len(paths)
+    assert state["peak"] > 1
+    assert state["peak"] <= DEVICE_IO_CONCURRENCY
+
+
+@pytest.mark.asyncio
+async def test_activate_batch_still_reports_each_failure_against_its_path(tmp_path):
+    async def _activate(skill_path, **_kwargs):
+        if skill_path.endswith("-1"):
+            raise RuntimeError("device refused")
+        return not skill_path.endswith("-2")
+
+    service = _service(tmp_path, _RecordingDeviceFilesystem())
+    service.activate_skill = _activate
+
+    paths = [f"git://biz/skill-{index}" for index in range(4)]
+    results = await service.activate_skills_batch(paths, user_id="u1", bolt_id="bot1")
+
+    assert [entry["path"] for entry in results["success"]] == [
+        "git://biz/skill-0",
+        "git://biz/skill-3",
+    ]
+    assert [(f["path"], f["error"]) for f in results["failed"]] == [
+        ("git://biz/skill-1", "device refused"),
+        ("git://biz/skill-2", "Failed to activate skill"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_deactivate_all_removes_entries_concurrently(tmp_path):
+    state = {"in_flight": 0, "peak": 0}
+
+    async def _deactivate(skill_id, **_kwargs):
+        state["in_flight"] += 1
+        state["peak"] = max(state["peak"], state["in_flight"])
+        try:
+            await asyncio.sleep(0.005)
+            return skill_id != "skill-2"
+        finally:
+            state["in_flight"] -= 1
+
+    service = _service(tmp_path, _RecordingDeviceFilesystem())
+    active = [MagicMock(id=f"skill-{index}") for index in range(5)]
+    service.get_active_skills = MagicMock(return_value=active)
+    service.deactivate_skill = _deactivate
+
+    results = await service.deactivate_all_skills()
+
+    assert results["success"] == ["skill-0", "skill-1", "skill-3", "skill-4"]
+    assert results["failed"] == ["skill-2"]
+    assert state["peak"] > 1

--- a/src/backend/tests/community/core/skill_center/services/test_skill_set_switcher_cleanup.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_set_switcher_cleanup.py
@@ -209,3 +209,95 @@ def test_cleanup_delete_failure_continues_and_logs(tmp_path, caplog):
     cleaned = switcher._cleanup_all_non_reserved_items()
     assert cleaned == ["good"]  # bad 未被记入 cleaned（失败）
     assert len(delete_calls) == 2  # 两条都尝试调
+
+
+def _switcher_over(tmp_path, plugin, reserved=frozenset()):
+    """A SkillSetSwitcher whose cleanup runs against ``plugin``."""
+    from agentclaw.community.core.skill_center.services.skill_set_service import (
+        SkillSetSwitcher,
+    )
+
+    dispatcher = MagicMock()
+    dispatcher.dispatch.return_value = plugin
+    skill_set_factory = MagicMock()
+    skill_set_service_mock = MagicMock()
+    skill_set_service_mock.skill_service.RESERVED_SKILL_NAMES = set(reserved)
+    skill_set_factory.create.return_value = skill_set_service_mock
+    path_factory = MagicMock()
+    skills_root = tmp_path / "skills"
+    path_factory.get_bot_skills_dir.return_value = skills_root
+    path_factory.get_bot_skills_repo_dir.return_value = skills_root / "skills-repo"
+    path_factory.get_bot_skills_local_dir.return_value = skills_root / "skills-local"
+    return SkillSetSwitcher(
+        skill_set_factory=skill_set_factory,
+        resolver=MagicMock(),
+        device_sync_dispatcher=MagicMock(),
+        device_plugin=MagicMock(),
+        path_factory=path_factory,
+        device_fs_dispatcher=dispatcher,
+        edit_guard=_edit_guard(),
+        skills_dir=skills_root,
+        bot_id="bot-1",
+        user_id="staff_u001",
+    )
+
+
+def _entries(names, root):
+    return [
+        {"name": name, "path": f"{root}/{name}", "is_dir": True, "relative_path": name}
+        for name in names
+    ]
+
+
+def test_cleanup_removes_entries_concurrently(tmp_path):
+    """每次删除都是一次设备往返；逐个 await 让一次切换 = ``entry_count × 往返``。"""
+    import asyncio
+
+    state = {"in_flight": 0, "peak": 0}
+    names = [f"stale-{index}" for index in range(6)]
+
+    async def _delete_tree(path):
+        state["in_flight"] += 1
+        state["peak"] = max(state["peak"], state["in_flight"])
+        try:
+            await asyncio.sleep(0.01)
+            return True
+        finally:
+            state["in_flight"] -= 1
+
+    plugin = MagicMock()
+
+    async def _list_dir(path, *, recursive=False):
+        return _entries(names, path)
+
+    plugin.list_dir = _list_dir
+    plugin.delete_tree = _delete_tree
+
+    switcher = _switcher_over(tmp_path, plugin)
+    cleaned = switcher._cleanup_all_non_reserved_items()
+
+    assert sorted(cleaned) == sorted(names)
+    assert state["peak"] > 1
+
+
+def test_cleanup_reports_every_entry_even_when_one_device_call_fails(tmp_path):
+    """一个条目删除失败既不隐藏其他条目的结果，也不中止它们 —— 与逐条循环一致。"""
+
+    async def _delete_tree(path):
+        if path.endswith("/boom"):
+            raise OSError("device rejected boom")
+        return not path.endswith("/refused")
+
+    plugin = MagicMock()
+
+    async def _list_dir(path, *, recursive=False):
+        return _entries(["ok-1", "boom", "refused", "ok-2"], path)
+
+    plugin.list_dir = _list_dir
+    plugin.delete_tree = _delete_tree
+
+    switcher = _switcher_over(tmp_path, plugin)
+    cleaned = switcher._cleanup_all_non_reserved_items()
+
+    # order follows the listing, and only the genuinely removed entries are named
+    assert cleaned == ["ok-1", "ok-2"]

--- a/src/backend/tests/community/core/skill_center/test_local_skill_package_storage_io.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_package_storage_io.py
@@ -1,0 +1,252 @@
+"""Package I/O batching contract for :class:`LocalSkillPackageStorage`.
+
+Every package file is one device round trip, so the storage port fans them out
+instead of issuing them one at a time. These pin the three properties that make
+that substitution safe for the callers built on the old sequential loop:
+
+* files really do overlap (otherwise the fan-out bought nothing),
+* the fan-out stays bounded (``asyncio.to_thread``'s default executor is shared
+  with the rest of the process),
+* a failed batch is fully drained before the error surfaces, and reports the
+  same failure the sequential loop would have reported.
+
+The drain matters most: ``LocalSkillUploadService`` reacts to a failed ``write``
+by deleting the package directory, so a write still in flight then would land a
+file behind the cleanup and leave an orphan.
+"""
+
+import asyncio
+
+import pytest
+
+from agentclaw.community.core.skill_center.factories import (
+    _PACKAGE_IO_CONCURRENCY,
+    LocalSkillPackageStorage,
+)
+
+DIRECTORY = "/private/skills-local/pkg"
+
+
+class _RecordingFilesystem:
+    """Records call overlap so concurrency is observable, not just assumed."""
+
+    def __init__(self, *, fail_paths=(), delay=0.01):
+        self.files: dict[str, bytes] = {}
+        self.completed: list[str] = []
+        self.in_flight = 0
+        self.peak_in_flight = 0
+        self._fail_paths = set(fail_paths)
+        self._delay = delay
+
+    async def _tracked(self, path):
+        self.in_flight += 1
+        self.peak_in_flight = max(self.peak_in_flight, self.in_flight)
+        try:
+            await asyncio.sleep(self._delay)
+            if path in self._fail_paths:
+                raise OSError(f"device rejected {path}")
+        finally:
+            self.in_flight -= 1
+
+    async def write_file(self, path, content):
+        await self._tracked(path)
+        self.files[path] = content
+        self.completed.append(path)
+
+    async def read_file(self, path):
+        await self._tracked(path)
+        self.completed.append(path)
+        return self.files.get(path)
+
+    async def list_dir(self, path, *, recursive=False):
+        prefix = f"{path}/"
+        return [
+            {"relative_path": stored[len(prefix):], "is_dir": False}
+            for stored in self.files
+            if stored.startswith(prefix)
+        ] or None
+
+
+def _package(count):
+    return [(f"f{index}.md", f"body-{index}".encode()) for index in range(count)]
+
+
+@pytest.mark.asyncio
+async def test_write_issues_package_files_concurrently():
+    filesystem = _RecordingFilesystem()
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    await storage.write(_package(5))
+
+    assert filesystem.peak_in_flight > 1
+    assert len(filesystem.files) == 5
+
+
+@pytest.mark.asyncio
+async def test_write_fan_out_stays_bounded():
+    """An unbounded gather over a big package would starve the shared executor."""
+    filesystem = _RecordingFilesystem()
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    await storage.write(_package(_PACKAGE_IO_CONCURRENCY * 3))
+
+    assert filesystem.peak_in_flight <= _PACKAGE_IO_CONCURRENCY
+
+
+@pytest.mark.asyncio
+async def test_a_failed_write_drains_every_sibling_before_raising():
+    """No write may still be in flight when the caller starts its cleanup."""
+    files = _package(6)
+    filesystem = _RecordingFilesystem(fail_paths={f"{DIRECTORY}/f0.md"})
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    with pytest.raises(OSError):
+        await storage.write(files)
+
+    assert filesystem.in_flight == 0
+    # the five that did not fail all ran to completion rather than being abandoned
+    assert len(filesystem.completed) == 5
+
+
+@pytest.mark.asyncio
+async def test_a_failed_write_reports_the_first_failure_in_file_order():
+    """Same error the sequential loop would have surfaced, not a race winner."""
+    files = _package(6)
+    filesystem = _RecordingFilesystem(
+        fail_paths={f"{DIRECTORY}/f1.md", f"{DIRECTORY}/f4.md"}
+    )
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    with pytest.raises(OSError, match="f1.md"):
+        await storage.write(files)
+
+
+@pytest.mark.asyncio
+async def test_reading_a_package_is_concurrent_and_order_preserving():
+    filesystem = _RecordingFilesystem()
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+    files = _package(5)
+    await storage.write(files)
+    filesystem.peak_in_flight = 0
+
+    assert sorted(await storage._read_package_files()) == sorted(files)
+    assert filesystem.peak_in_flight > 1
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_listed_path_is_rejected_before_any_read():
+    """Validation still gates the whole package, not just the files read so far."""
+    filesystem = _RecordingFilesystem()
+    filesystem.files[f"{DIRECTORY}/ok.md"] = b"fine"
+    filesystem.files[f"{DIRECTORY}/../escape.md"] = b"bad"
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    with pytest.raises(OSError, match="invalid file path"):
+        await storage._read_package_files()
+
+    assert filesystem.completed == []
+
+
+# ── end-to-end over the real baas transport ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_a_package_upload_resolves_http_info_once_for_the_whole_batch():
+    """storage → BaasDeviceFileSystem → BaasInvokeTransport, wired for real.
+
+    Writing a 12-file package used to cost 12 binding lookups + 12 BaaS
+    ``/http-info`` round trips + 12 uploads, all strictly sequential. It now
+    costs one resolution and 12 concurrent uploads.
+    """
+    from unittest.mock import MagicMock
+
+    import httpx
+
+    from agentclaw.community.core.devices.services.baas_device_filesystem import (
+        BaasDeviceFileSystem,
+    )
+    from agentclaw.community.core.devices.services.baas_invoke_transport import (
+        BaasInvokeTransport,
+    )
+
+    baas_service = MagicMock()
+    baas_service.invoke_http.return_value = httpx.Response(
+        status_code=200, request=httpx.Request("POST", "http://fake/")
+    )
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw",
+        baas_service=baas_service,
+    )
+    storage = LocalSkillPackageStorage(
+        BaasDeviceFileSystem(
+            transport=transport,
+            conn_info={"paas_device_id": "BOT-abc"},
+            path_mapper=lambda path: path,
+        ),
+        DIRECTORY,
+    )
+
+    files = _package(12)
+    await storage.write(files)
+
+    assert baas_service.get_http_info.call_count == 1
+    assert baas_service.invoke_http.call_count == 12
+    uploaded = {
+        call.kwargs["data"]["target_path"] for call in baas_service.invoke_http.call_args_list
+    }
+    assert uploaded == {f"{DIRECTORY}/{name}" for name, _ in files}
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_write_drains_in_flight_writes_before_propagating():
+    """取消也必须先排空 —— to_thread 停不掉已经在工作线程里跑的写。
+
+    ``CancelledError`` 是 ``BaseException``，所以 ``LocalSkillUploadService`` 的
+    ``except Exception`` 补偿会被整个跳过，而它的 ``finally`` 仍然放掉 edit lease。
+    此时若还有写在飞，重试拿到 lease、``delete_tree`` 后重建的新包就会被这些迟到的
+    写污染成混合包。
+    """
+    filesystem = _RecordingFilesystem(delay=0.05)
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    task = asyncio.create_task(storage.write(_package(4)))
+    await asyncio.sleep(0.01)
+    assert filesystem.in_flight > 0, "batch should be in flight before cancelling"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # the cancellation waited for the whole batch, so nothing can land afterwards
+    assert filesystem.in_flight == 0
+    assert len(filesystem.files) == 4
+
+
+@pytest.mark.asyncio
+async def test_repeated_cancellation_cannot_abandon_the_drain():
+    """再次取消也不能把还在排空的 batch 丢掉（请求中止叠加进程关停等场景）。
+
+    排空本身若不加 shield，第二次取消会连 ``batch`` 一起拆掉并立刻抛出，而
+    worker 线程里的写仍在跑 —— 正是第一次取消时 shield 所防住的那个故障。
+    """
+    filesystem = _RecordingFilesystem(delay=0.05)
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    task = asyncio.create_task(storage.write(_package(4)))
+    await asyncio.sleep(0.01)
+    assert filesystem.in_flight > 0
+
+    # cancel repeatedly, including while the drain is already running
+    task.cancel()
+    for _ in range(3):
+        await asyncio.sleep(0)
+    task.cancel()
+    for _ in range(3):
+        await asyncio.sleep(0)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert filesystem.in_flight == 0
+    assert len(filesystem.files) == 4

--- a/src/backend/tests/community/core/skill_center/test_local_skill_package_storage_io.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_package_storage_io.py
@@ -250,3 +250,32 @@ async def test_repeated_cancellation_cannot_abandon_the_drain():
 
     assert filesystem.in_flight == 0
     assert len(filesystem.files) == 4
+
+
+@pytest.mark.asyncio
+async def test_cancelling_drops_writes_still_queued_behind_the_bound():
+    """排空只欠给「已经开始」的写：还卡在信号量后面的根本没碰过设备。
+
+    Draining is owed to a write already executing on a worker thread, because
+    ``to_thread`` cannot interrupt it and abandoning it would let the write land
+    after the caller's compensation. A write still queued behind the bound has
+    touched nothing, so running it anyway buys no safety — it only makes the
+    unwind take every remaining wave instead of the one in flight.
+    """
+    total = DEVICE_IO_CONCURRENCY * 4
+    filesystem = _RecordingFilesystem(delay=0.05)
+    storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
+
+    task = asyncio.create_task(storage.write(_package(total)))
+    await asyncio.sleep(0.01)
+    assert filesystem.in_flight == DEVICE_IO_CONCURRENCY, "first wave should be in flight"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # the in-flight wave was still drained — nothing can land after this returns
+    assert filesystem.in_flight == 0
+    # ...but the three waves that had not started were dropped, not run
+    assert len(filesystem.files) <= DEVICE_IO_CONCURRENCY
+    assert len(filesystem.files) < total

--- a/src/backend/tests/community/core/skill_center/test_local_skill_package_storage_io.py
+++ b/src/backend/tests/community/core/skill_center/test_local_skill_package_storage_io.py
@@ -19,10 +19,10 @@ import asyncio
 
 import pytest
 
-from agentclaw.community.core.skill_center.factories import (
-    _PACKAGE_IO_CONCURRENCY,
-    LocalSkillPackageStorage,
+from agentclaw.community.core.devices.device_io_batch import (
+    DEVICE_IO_CONCURRENCY,
 )
+from agentclaw.community.core.skill_center.factories import LocalSkillPackageStorage
 
 DIRECTORY = "/private/skills-local/pkg"
 
@@ -88,9 +88,9 @@ async def test_write_fan_out_stays_bounded():
     filesystem = _RecordingFilesystem()
     storage = LocalSkillPackageStorage(filesystem, DIRECTORY)
 
-    await storage.write(_package(_PACKAGE_IO_CONCURRENCY * 3))
+    await storage.write(_package(DEVICE_IO_CONCURRENCY * 3))
 
-    assert filesystem.peak_in_flight <= _PACKAGE_IO_CONCURRENCY
+    assert filesystem.peak_in_flight <= DEVICE_IO_CONCURRENCY
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/plugins/prod/test_baas_invoke_transport.py
+++ b/src/backend/tests/community/plugins/prod/test_baas_invoke_transport.py
@@ -470,14 +470,14 @@ def test_concurrent_rejections_share_one_refresh():
         bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
     )
     # prime the cache so every worker starts from the same (about to be rejected) entry
-    primed = transport._http_info("/api/file/upload")
+    primed = transport._http_info.resolve("/api/file/upload")
     assert svc.get_http_info.call_count == 1
 
     barrier = threading.Barrier(8)
 
     def refresh_once():
         barrier.wait()
-        transport._http_info("/api/file/upload", stale=primed)
+        transport._http_info.resolve("/api/file/upload", stale=primed)
 
     workers = [threading.Thread(target=refresh_once) for _ in range(8)]
     for w in workers:
@@ -491,11 +491,12 @@ def test_concurrent_rejections_share_one_refresh():
 
 def test_expired_http_info_cache_entry_is_re_resolved(monkeypatch):
     """TTL 过期后重新解析，避免长批次里一直用老 token。"""
-    import agentclaw.community.core.devices.services.baas_invoke_transport as mod
+    import agentclaw.community.core.devices.services.baas_http_info as mod
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
 
     svc = MagicMock()
     svc.invoke_http.return_value = _ok_response()
-    transport = mod.BaasInvokeTransport(
+    transport = BaasInvokeTransport(
         bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
     )
 

--- a/src/backend/tests/community/plugins/prod/test_baas_invoke_transport.py
+++ b/src/backend/tests/community/plugins/prod/test_baas_invoke_transport.py
@@ -21,6 +21,38 @@ def _ok_response() -> httpx.Response:
     )
 
 
+def _response(status_code: int) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        json={"ok": status_code == 200},
+        request=httpx.Request("POST", "http://fake/"),
+    )
+
+
+def _desktop(**overrides):
+    """Build a desktop transport over a mock pooled client.
+
+    The transport no longer opens an ``httpx.Client`` per call — the resolver
+    injects one pooled client so a multi-file write does not pay a TLS handshake
+    per file — so tests hand it a mock directly instead of patching module state.
+    Returns ``(transport, client)``.
+    """
+    from agentclaw.community.core.devices.services.baas_invoke_transport import (
+        DesktopBaasInvokeTransport,
+    )
+
+    client = MagicMock()
+    kwargs = {
+        "baas_base_url": "https://b",
+        "tenant": "t",
+        "bot_uuid": "u",
+        "engine_port": 20003,
+        "headers": {"h": "1"},
+    }
+    kwargs.update(overrides)
+    return DesktopBaasInvokeTransport(client=client, **kwargs), client
+
+
 # ── BaasInvokeTransport ──────────────────────────────────────────────────
 
 
@@ -41,6 +73,7 @@ def test_baas_invoke_transport_post_calls_baas_service_invoke_http():
         bind_id=42,
         port=20003,
         path="/api/skills/symlink/bindpath",
+        method="POST",
         json={"x": 1},
         tenant="team_claw",
         # cloud baas containers reach the engine via the agentclawproxy /proxypass
@@ -48,6 +81,9 @@ def test_baas_invoke_transport_post_calls_baas_service_invoke_http():
         auth_header="x-proxypass-token",
         # default (no multi-instance lock) → device_uuid=None, BaaS auto-picks active
         device_uuid=None,
+        # the transport resolves http_info itself and hands it to invoke_http, so a
+        # batch of same-path calls shares one get_http_info round trip
+        http_info=svc.get_http_info.return_value,
     )
 
 
@@ -116,24 +152,15 @@ def test_baas_invoke_transport_propagates_request_error():
 
 def test_desktop_baas_invoke_transport_post_uses_self_built_url():
     """DesktopBaasInvokeTransport.post 自拼 secbaas wrapper URL,headers 来自 conn_info。"""
-    from agentclaw.community.core.devices.services.baas_invoke_transport import DesktopBaasInvokeTransport
-
-    transport = DesktopBaasInvokeTransport(
+    transport, mock_client = _desktop(
         baas_base_url="https://secbaas-prod.teamclaw.com",
         tenant="team_claw",
         bot_uuid="BOT-abc",
-        engine_port=20003,
         headers={"x-proxypass-token": "tok-xyz"},
     )
+    mock_client.post.return_value = _ok_response()
 
-    with patch(
-        "agentclaw.community.core.devices.services.baas_invoke_transport.httpx.Client"
-    ) as mock_cls:
-        mock_client = MagicMock()
-        mock_cls.return_value.__enter__.return_value = mock_client
-        mock_client.post.return_value = _ok_response()
-
-        resp = transport.post("/api/skills/symlink/bindpath", json={"x": 1})
+    resp = transport.post("/api/skills/symlink/bindpath", json={"x": 1})
 
     assert resp.status_code == 200
     expected_url = (
@@ -149,12 +176,7 @@ def test_desktop_baas_invoke_transport_post_uses_self_built_url():
 
 def test_desktop_baas_invoke_transport_invoke_url_adds_leading_slash():
     """_invoke_url 对没有 leading slash 的 path 也能正确拼接。"""
-    from agentclaw.community.core.devices.services.baas_invoke_transport import DesktopBaasInvokeTransport
-
-    transport = DesktopBaasInvokeTransport(
-        baas_base_url="https://b", tenant="t", bot_uuid="u",
-        engine_port=20003, headers={},
-    )
+    transport, _ = _desktop(headers={})
 
     assert transport._invoke_url("api/x") == (
         "https://b/api/v1/bots/t/u/invoke-http/20003/api/x"
@@ -166,25 +188,14 @@ def test_desktop_baas_invoke_transport_invoke_url_adds_leading_slash():
 
 def test_desktop_baas_invoke_transport_post_multipart_uses_self_built_url():
     """post_multipart 同样自拼 URL,但传 files+data 而不是 json。"""
-    from agentclaw.community.core.devices.services.baas_invoke_transport import DesktopBaasInvokeTransport
+    transport, mock_client = _desktop()
+    mock_client.post.return_value = _ok_response()
 
-    transport = DesktopBaasInvokeTransport(
-        baas_base_url="https://b", tenant="t", bot_uuid="u",
-        engine_port=20003, headers={"h": "1"},
+    transport.post_multipart(
+        "/api/file/upload",
+        files={"file": ("foo.txt", b"hi")},
+        data={"target_path": "foo.txt"},
     )
-
-    with patch(
-        "agentclaw.community.core.devices.services.baas_invoke_transport.httpx.Client"
-    ) as mock_cls:
-        mock_client = MagicMock()
-        mock_cls.return_value.__enter__.return_value = mock_client
-        mock_client.post.return_value = _ok_response()
-
-        transport.post_multipart(
-            "/api/file/upload",
-            files={"file": ("foo.txt", b"hi")},
-            data={"target_path": "foo.txt"},
-        )
 
     call_args = mock_client.post.call_args
     assert call_args.args[0] == "https://b/api/v1/bots/t/u/invoke-http/20003/api/file/upload"
@@ -195,22 +206,11 @@ def test_desktop_baas_invoke_transport_post_multipart_uses_self_built_url():
 
 def test_desktop_baas_invoke_transport_post_propagates_request_error():
     """httpx 抛 RequestError 时 transport.post 透传(不吞)。"""
-    from agentclaw.community.core.devices.services.baas_invoke_transport import DesktopBaasInvokeTransport
+    transport, mock_client = _desktop(headers={})
+    mock_client.post.side_effect = httpx.RequestError("connection refused")
 
-    transport = DesktopBaasInvokeTransport(
-        baas_base_url="https://b", tenant="t", bot_uuid="u",
-        engine_port=20003, headers={},
-    )
-
-    with patch(
-        "agentclaw.community.core.devices.services.baas_invoke_transport.httpx.Client"
-    ) as mock_cls:
-        mock_client = MagicMock()
-        mock_cls.return_value.__enter__.return_value = mock_client
-        mock_client.post.side_effect = httpx.RequestError("connection refused")
-
-        with pytest.raises(httpx.RequestError):
-            transport.post("/api/x", json={})
+    with pytest.raises(httpx.RequestError):
+        transport.post("/api/x", json={})
 
 
 def test_baas_invoke_get_put_delete_pass_method():
@@ -228,17 +228,12 @@ def test_baas_invoke_get_put_delete_pass_method():
 
 
 def test_desktop_invoke_get_put_delete_hit_wrapper_url():
-    from agentclaw.community.core.devices.services.baas_invoke_transport import DesktopBaasInvokeTransport
-    t = DesktopBaasInvokeTransport(baas_base_url="https://b", tenant="t", bot_uuid="u",
-                                   engine_port=20003, headers={"h": "1"})
     expected = "https://b/api/v1/bots/t/u/invoke-http/20003/api/mcp/x"
     for verb in ("get", "put", "delete"):
-        with patch("agentclaw.community.core.devices.services.baas_invoke_transport.httpx.Client") as mc:
-            mock = MagicMock()
-            mc.return_value.__enter__.return_value = mock
-            getattr(mock, verb).return_value = _ok_response()
-            getattr(t, verb)("/api/mcp/x")
-            assert getattr(mock, verb).call_args.args[0] == expected
+        t, mock = _desktop()
+        getattr(mock, verb).return_value = _ok_response()
+        getattr(t, verb)("/api/mcp/x")
+        assert getattr(mock, verb).call_args.args[0] == expected
 
 
 # ── device_uuid 透传(多实例 service bot) ───────────────────────────────
@@ -310,3 +305,272 @@ def test_baas_invoke_transport_default_device_uuid_is_none():
     transport.post("/api/x", json={})
 
     assert svc.invoke_http.call_args.kwargs["device_uuid"] is None
+
+
+# ── get_http_info sharing (per-path cache) ───────────────────────────────
+
+
+def test_repeated_same_path_calls_resolve_http_info_once():
+    """一次 package upload 的 N 个 /api/file/upload 只解析一次 http_info。
+
+    Resolution is a binding DB lookup plus a BaaS round trip, so doing it per file
+    doubled the request count of every multi-file write.
+    """
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    svc.invoke_http.return_value = _ok_response()
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+
+    for name in ("a.md", "b.md", "c.md"):
+        transport.post_multipart(
+            "/api/file/upload",
+            files={"file": (name, b"x")},
+            data={"target_path": name},
+        )
+
+    assert svc.get_http_info.call_count == 1
+    assert svc.invoke_http.call_count == 3
+    # every upload still went out against that one resolution
+    assert all(
+        call.kwargs["http_info"] is svc.get_http_info.return_value
+        for call in svc.invoke_http.call_args_list
+    )
+
+
+def test_http_info_cache_is_keyed_by_path():
+    """``http_url`` 里含 path，所以不同 path 必须各自解析，不能串用缓存。"""
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    svc.invoke_http.return_value = _ok_response()
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+
+    transport.post("/api/file/read", json={})
+    transport.post("/api/file/list", json={})
+    transport.post("/api/file/read", json={})
+
+    resolved_paths = [c.kwargs["path"] for c in svc.get_http_info.call_args_list]
+    assert resolved_paths == ["/api/file/read", "/api/file/list"]
+
+
+def test_http_info_resolution_carries_the_instance_identity():
+    """缓存 key 只有 path，因为其余解析输入都是实例固定的 —— 这里把它钉住。"""
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    svc.invoke_http.return_value = _ok_response()
+    transport = BaasInvokeTransport(
+        bind_id=7, engine_port=20003, tenant="team_claw",
+        baas_service=svc, device_uuid="DEV-xyz",
+    )
+
+    transport.post("/api/file/read", json={})
+
+    svc.get_http_info.assert_called_once_with(
+        bind_id=7,
+        port=20003,
+        path="/api/file/read",
+        tenant="team_claw",
+        device_uuid="DEV-xyz",
+    )
+
+
+def test_rejected_token_refreshes_http_info_and_retries_once():
+    """缓存的 token 过期时刷新重试，调用方不该看到假 401。"""
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    stale, fresh = MagicMock(name="stale"), MagicMock(name="fresh")
+    svc.get_http_info.side_effect = [stale, fresh]
+    svc.invoke_http.side_effect = [_response(401), _ok_response()]
+
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+    resp = transport.post_multipart(
+        "/api/file/upload", files={"file": ("a", b"x")}, data={"target_path": "a"}
+    )
+
+    assert resp.status_code == 200
+    assert svc.get_http_info.call_count == 2
+    assert [c.kwargs["http_info"] for c in svc.invoke_http.call_args_list] == [
+        stale, fresh,
+    ]
+    # the refreshed entry replaces the rejected one for subsequent calls
+    svc.invoke_http.side_effect = None
+    svc.invoke_http.return_value = _ok_response()
+    transport.post_multipart(
+        "/api/file/upload", files={"file": ("b", b"y")}, data={"target_path": "b"}
+    )
+    assert svc.get_http_info.call_count == 2
+    assert svc.invoke_http.call_args.kwargs["http_info"] is fresh
+
+
+def test_a_403_is_the_device_answer_and_is_never_replayed():
+    """403 不是网关拒 token —— engine 把 PermissionError 映射成 403，proxy 原样透传。
+
+    重放会把一次 mutating 的 upload/delete 再跑一遍（无 device_uuid 时还可能打到
+    另一台设备），并且掩盖 engine 真正的鉴权结论。
+    """
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    svc.invoke_http.return_value = _response(403)
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+
+    resp = transport.post_multipart(
+        "/api/file/upload", files={"file": ("a", b"x")}, data={"target_path": "a"}
+    )
+
+    assert resp.status_code == 403
+    # sent exactly once, and the http_info was never re-resolved
+    assert svc.invoke_http.call_count == 1
+    assert svc.get_http_info.call_count == 1
+
+
+def test_a_persistently_rejected_token_stops_after_one_retry():
+    """真配置错时不无限重试 —— 刷新一次后如实返回 401。"""
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    svc.invoke_http.return_value = _response(401)
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+
+    resp = transport.post("/api/x", json={})
+
+    assert resp.status_code == 401
+    assert svc.invoke_http.call_count == 2
+    assert svc.get_http_info.call_count == 2
+
+
+def test_concurrent_rejections_share_one_refresh():
+    """一批并发写同时被拒时只刷新一次，而不是每个请求各刷一次。
+
+    无条件 refresh 会在失败路径上把本 cache 消除掉的「每文件一次解析」原样带回来。
+    """
+    import threading
+
+    from agentclaw.community.core.devices.services.baas_invoke_transport import BaasInvokeTransport
+
+    svc = MagicMock()
+    # Distinct objects per call, like the real get_http_info, which builds a fresh
+    # HttpConnectionInfo every time. A shared MagicMock return_value would hand back
+    # one identical object and make the compare-and-swap unobservable.
+    svc.get_http_info.side_effect = [MagicMock(name=f"info-{i}") for i in range(20)]
+    transport = BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+    # prime the cache so every worker starts from the same (about to be rejected) entry
+    primed = transport._http_info("/api/file/upload")
+    assert svc.get_http_info.call_count == 1
+
+    barrier = threading.Barrier(8)
+
+    def refresh_once():
+        barrier.wait()
+        transport._http_info("/api/file/upload", stale=primed)
+
+    workers = [threading.Thread(target=refresh_once) for _ in range(8)]
+    for w in workers:
+        w.start()
+    for w in workers:
+        w.join()
+
+    # one thread re-resolved; the other seven took the entry it installed
+    assert svc.get_http_info.call_count == 2
+
+
+def test_expired_http_info_cache_entry_is_re_resolved(monkeypatch):
+    """TTL 过期后重新解析，避免长批次里一直用老 token。"""
+    import agentclaw.community.core.devices.services.baas_invoke_transport as mod
+
+    svc = MagicMock()
+    svc.invoke_http.return_value = _ok_response()
+    transport = mod.BaasInvokeTransport(
+        bind_id=42, engine_port=20003, tenant="team_claw", baas_service=svc
+    )
+
+    clock = {"now": 1_000.0}
+    monkeypatch.setattr(mod.time, "monotonic", lambda: clock["now"])
+
+    transport.post("/api/x", json={})
+    clock["now"] += mod._HTTP_INFO_TTL_SECONDS / 2
+    transport.post("/api/x", json={})
+    assert svc.get_http_info.call_count == 1
+
+    clock["now"] += mod._HTTP_INFO_TTL_SECONDS
+    transport.post("/api/x", json={})
+    assert svc.get_http_info.call_count == 2
+
+
+# ── desktop connection reuse ─────────────────────────────────────────────
+
+
+def test_desktop_transport_sends_every_call_through_the_one_injected_client():
+    """一个 package 的多次写共用同一个 client，而不是各自新建。"""
+    transport, pooled = _desktop()
+    pooled.post.return_value = _ok_response()
+
+    with patch(
+        "agentclaw.community.core.devices.services.baas_invoke_transport.httpx.Client"
+    ) as mock_cls:
+        for name in ("a.md", "b.md", "c.md"):
+            transport.post_multipart(
+                "/api/file/upload",
+                files={"file": (name, b"x")},
+                data={"target_path": name},
+            )
+
+    # all three writes landed on the one pooled client ...
+    assert pooled.post.call_count == 3
+    # ... and the transport never built a client of its own, which is what used to
+    # force a fresh TCP + TLS handshake for every file in a package.
+    assert mock_cls.call_count == 0
+
+
+def test_build_desktop_client_returns_a_bounded_pool():
+    """连接池有上限，且高于设备 I/O 并发度，不会自己变成瓶颈。"""
+    import agentclaw.community.core.devices.services.baas_invoke_transport as mod
+
+    with patch.object(mod.httpx, "Client") as mock_cls:
+        mod.build_desktop_client()
+
+    limits = mock_cls.call_args.kwargs["limits"]
+    assert limits.max_connections == 64
+    assert limits.max_keepalive_connections == 32
+
+
+def test_the_resolver_shares_one_pooled_client_across_desktop_transports():
+    """池由单例 resolver 持有 —— 每次 dispatch 不该新建一个池。"""
+    from agentclaw.community.core.devices.services.device_filesystem_resolver import (
+        DefaultDeviceFileSystemResolver,
+    )
+
+    resolver = DefaultDeviceFileSystemResolver(
+        baas_service=MagicMock(),
+        bot_repo=MagicMock(),
+        binding_repo=MagicMock(),
+        sandbox_client=MagicMock(),
+    )
+    conn_info = {
+        "baas_base_url": "https://b",
+        "tenant": "t",
+        "paas_device_id": "BOT-abc",
+        "engine_port": 20003,
+        "headers": {},
+    }
+    ctx = MagicMock(provider="baas", bot_type="desktop", conn_info=conn_info)
+
+    first = resolver(ctx, lambda path: path)
+    second = resolver(ctx, lambda path: path)
+
+    assert first._transport._client is second._transport._client

--- a/src/backend/tests/community/plugins/prod/test_teclaw_device_filesystem.py
+++ b/src/backend/tests/community/plugins/prod/test_teclaw_device_filesystem.py
@@ -186,3 +186,81 @@ async def test_exists_true_when_read_succeeds():
     fs, baas = _fs()
     baas.invoke_http.return_value = _FakeResponse(content=b"x")
     assert await fs.exists(_DEVICE_PATH) is True
+
+
+# ── shared container resolution (one get_http_info per path) ──────────
+#
+# Callers write a Skill package by fanning its files out concurrently. Resolving
+# per call would turn that fan-out into a *burst* of identical binding lookups and
+# BaaS round trips, so these pin that the whole batch shares one resolution — and
+# that reuse can never surface a spurious auth failure.
+
+@pytest.mark.asyncio
+async def test_package_writes_share_one_http_info_resolution():
+    """一个 package 的多文件写共用一次 get_http_info，而不是每文件解析一次。"""
+    fs, baas = _fs()
+    baas.invoke_http.return_value = _FakeResponse()
+
+    for name in ("SKILL.md", "README.md", "scripts/run.sh", "assets/logo.png"):
+        await fs.write_file(f"{_DEVICE_DIR}/{name}", b"x")
+
+    assert baas.get_http_info.call_count == 1
+    assert baas.invoke_http.call_count == 4
+    # every upload went out against that one resolution
+    assert all(
+        call.kwargs["http_info"] is baas.get_http_info.return_value
+        for call in baas.invoke_http.call_args_list
+    )
+    resolved = baas.get_http_info.call_args.kwargs
+    assert resolved["bind_id"] == 4242
+    assert resolved["port"] == 20003
+    assert resolved["path"] == "/api/v1/file/upload"
+    assert resolved["tenant"] == "team_claw"
+
+
+@pytest.mark.asyncio
+async def test_http_info_is_resolved_per_engine_path():
+    """``http_url`` 里含 path，所以 upload / read / list 必须各自解析。"""
+    fs, baas = _fs()
+    baas.invoke_http.return_value = _FakeResponse(json_data={"data": {"files": []}})
+
+    await fs.write_file(_DEVICE_PATH, b"x")
+    await fs.read_file(_DEVICE_PATH)
+    await fs.list_dir(_DEVICE_DIR)
+    await fs.write_file(_DEVICE_PATH, b"y")
+
+    assert [c.kwargs["path"] for c in baas.get_http_info.call_args_list] == [
+        "/api/v1/file/upload",
+        "/api/v1/file/read",
+        "/api/v1/file/list",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rejected_token_refreshes_and_replays_the_write_once():
+    """缓存的 proxy token 中途过期时刷新重试，调用方不该看到假 401。"""
+    fs, baas = _fs()
+    stale, fresh = MagicMock(name="stale"), MagicMock(name="fresh")
+    baas.get_http_info.side_effect = [stale, fresh]
+    baas.invoke_http.side_effect = [_FakeResponse(status_code=401), _FakeResponse()]
+
+    await fs.write_file(_DEVICE_PATH, b"hello")
+
+    assert baas.get_http_info.call_count == 2
+    assert [c.kwargs["http_info"] for c in baas.invoke_http.call_args_list] == [
+        stale,
+        fresh,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_forbidden_is_the_engines_own_answer_and_is_never_replayed():
+    """403 是引擎自己的授权结论（PermissionError），重放会重跑一次变更写。"""
+    fs, baas = _fs()
+    baas.invoke_http.return_value = _FakeResponse(status_code=403)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await fs.write_file(_DEVICE_PATH, b"hello")
+
+    assert baas.invoke_http.call_count == 1
+    assert baas.get_http_info.call_count == 1

--- a/src/backend/tests/community/unit/skill_center/test_skill_symlink_verify_service.py
+++ b/src/backend/tests/community/unit/skill_center/test_skill_symlink_verify_service.py
@@ -118,3 +118,88 @@ class TestSkillSymlinkVerifyService:
         assert report.passed == 0
         assert report.failed == 1
         assert report.failures[0].reason == "nas_target_missing"
+
+
+class TestVerifyProbesConcurrently:
+    """NAS 探测每条一次设备往返，逐条 await 让验证耗时 = ``skill_count × round_trip``。"""
+
+    @staticmethod
+    def _service(*, symlinks, skills, exists):
+        device_fs = MagicMock()
+        device_fs.list_dir = AsyncMock(
+            return_value=[{"name": name, "is_link": True} for name in symlinks]
+        )
+        device_fs.exists = exists
+        dispatcher = MagicMock()
+        dispatcher.for_bot.return_value = device_fs
+        repo = MagicMock()
+        repo.get_active_skills_by_bot = MagicMock(return_value=skills)
+        return (
+            SkillSymlinkVerifyService(
+                skill_repo=repo, device_fs_dispatcher=dispatcher, bot_repo=MagicMock()
+            ),
+            device_fs,
+        )
+
+    @pytest.mark.asyncio
+    async def test_nas_probes_overlap(self):
+        import asyncio
+
+        state = {"in_flight": 0, "peak": 0}
+
+        async def _exists(path):
+            state["in_flight"] += 1
+            state["peak"] = max(state["peak"], state["in_flight"])
+            try:
+                await asyncio.sleep(0.01)
+                return True
+            finally:
+                state["in_flight"] -= 1
+
+        names = [f"skill-{i}" for i in range(6)]
+        svc, _ = self._service(
+            symlinks=names,
+            skills=[
+                {"id": str(i), "name": n, "git_path": f"center://uuid-{i}", "link_name": n}
+                for i, n in enumerate(names)
+            ],
+            exists=_exists,
+        )
+
+        with patch(
+            "agentclaw.community.core.devices.services.device_info.get_device_info_by_bot_id",
+            return_value=("arca", "sandbox-123"),
+        ):
+            report = await svc.verify_bot("bot-123", "staff", "owner-456", env="prod")
+
+        assert report.passed == 6
+        assert state["peak"] > 1
+
+    @pytest.mark.asyncio
+    async def test_failure_order_still_follows_the_skill_list(self):
+        """并发探测不改变报告顺序：failures 仍按 skill 顺序排列。"""
+        skills = [
+            # missing symlink → decided without a probe
+            {"id": "1", "name": "a", "git_path": "center://uuid-a", "link_name": "a"},
+            # linked, NAS target missing → decided by a probe
+            {"id": "2", "name": "b", "git_path": "center://uuid-b", "link_name": "b"},
+            {"id": "3", "name": "c", "git_path": "center://uuid-c", "link_name": "c"},
+        ]
+
+        async def _exists(path):
+            return path.endswith("/uuid-c/current/c")
+
+        svc, _ = self._service(symlinks=["b", "c"], skills=skills, exists=_exists)
+
+        with patch(
+            "agentclaw.community.core.devices.services.device_info.get_device_info_by_bot_id",
+            return_value=("arca", "sandbox-123"),
+        ):
+            report = await svc.verify_bot("bot-123", "staff", "owner-456", env="prod")
+
+        assert [(f.skill_name, f.reason) for f in report.failures] == [
+            ("a", "symlink_not_found"),
+            ("b", "nas_target_missing"),
+        ]
+        assert report.total == 3
+        assert report.passed == 1


### PR DESCRIPTION
## Problem

inclusionAI/Avernet#1535 landed on `dev`, not on the release branch. It fixed one address — `POST /openapi/v1/bots/{bot_id}/skills` — where a Local Skill package was written one file at a time and every file re-resolved its own BaaS connection.

The release needs that fix. It also needs the rest of the surface, because the same two shapes are everywhere on it:

- **Per-item device I/O in a loop.** Every device filesystem addresses one file per call, so a loop costs `N × round_trip`. This was still true on the legacy skills upload and active-list, the Skill Set switch sweep, the symlink verify probes, the deactivation paths, and the MCP credential push across an entity's bots.
- **The mirror-image defect: unbounded concurrency.** Four activation sites already used a raw `asyncio.gather`. Each activation blocks a worker in the `asyncio.to_thread` executor, which is shared process-wide (`min(32, cpu_count + 4)` threads), so activating a large market selection or switching into a big skill set starved every other caller in the backend until it drained.

Two of them were actively made worse by inclusionAI/Avernet#1535 alone: with package writes now concurrent, a **teclaw** bot resolved `get_http_info` per file as a *burst* rather than a queue, and the MCP push still ran its synchronous `resolve_for_bot` directly on the event loop, once per bot.

## Solution

inclusionAI/Avernet#1535 is cherry-picked unchanged (`889002f4`). Five commits then extend it to the whole surface.

**One batching helper, shared.** `_gather_package_io` moves out of `skill_center/factories.py` to `core/devices/device_io_batch.py` as `gather_device_io`. It is not a plain `gather`: it is bounded, and it drains before it lets anything out. It sits directly under `core/devices` rather than `core/devices/services` because that package's `__init__` pulls in the DI container, which imports the skill center back.

It grows one flag, `return_exceptions`, for the callers that report a per-item outcome (which skill activated, which bot took the config) rather than failing the request whole. It names exactly what `asyncio.gather` means by it and changes only what happens *after* the batch completes — never the bound or the drain.

**One resolution cache, shared.** The `get_http_info` cache, its TTL and the refresh-and-retry on a rejected token move to `SharedHttpInfo` (`core/devices/services/baas_http_info.py`). `BaasInvokeTransport` behaves identically — same per-path keying, same compare-and-swap refresh, same deliberate exclusion of 403, which is the engine's own authorization answer and whose replay would re-run a mutating upload or delete. `TeclawDeviceFileSystem` now uses it too: it reaches its container through the same agentclawproxy gateway but called `BaasService.invoke_http` directly, so every read and write re-resolved.

**Call sites, by surface:**

| Surface | Was | Now |
|---|---|---|
| legacy `POST /skills/upload` | sequential per-file writes | bounded fan-out, drained |
| legacy `GET /skills/active/list` | `exists` **then** `read_file` per entry, in turn | one read per entry, all at once |
| Skill Set switch / activate | one `delete_tree` per entry, in turn | bounded fan-out |
| `GET /verify-symlinks` | one NAS `exists` per skill, in turn | probes go out together |
| market batch activate, add-skills auto-activate, both switch activations | unbounded `gather` | bounded, drained |
| `POST /skills/deactivate-all`, switch clear-out | sequential | bounded fan-out |
| OpenAPI + legacy MCP config write | per-bot resolve+probe+push in turn, resolve **on the event loop** | resolve on a thread, per-bot work fanned out |

**Behaviour is preserved at every one.** Outcomes are paired back to their inputs in order, so `sync_results`, `success`/`failed`, `deactivated` and the verify report's failure list read exactly as the loops produced them. Per-item failures are caught inside each coroutine where the loop caught them, so one device rejecting a directory neither hides the others' results nor stops them.

The active-list collapse deserves its own note: `exists` on the baas backend is *itself* a `read_file`, so listing a bot's active Skills downloaded every SKILL.md twice. A single read answers both questions — a missing entry and a directory in an entry's place both read back as `None`, which is precisely what the probe filtered on.

**Deliberately left alone.** `get_skill_readme`'s SKILL.md-then-README.md lookup stays sequential: it is preference-ordered and short-circuits, so batching would add a wasted read in the common case rather than remove one. `git_sync`'s subtree gather fans out over a small fixed config list, not per-skill device I/O. `harness/patch_engine` and `service_bot/deploy/teclaw_file_promotion` have the same loop shape but are not on this surface — the latter does pick up the teclaw resolution sharing for free.

**One split, forced by the size cap.** The MCP fan-out pushed `core/mcp/services/sync_service.py` to 1012 lines, over the 1000-line cap `test_no_new_oversized_files` enforces; that guard's allowlist covers pre-existing debt only and must shrink, so the answer is a split. `sync_mcp_identity_to_agent_principal` and `_update_passport` move to `passport_writer.py` — the other half of an MCP sync, writing what a bot may *reach* into Passport rather than pushing config to its **device**, and touching no device at all. They are module-level functions taking their collaborators as arguments, because callers and tests assign those onto the service after construction and a writer holding them would ignore the swap.

## Defects found in review and fixed

Both from Codex review of this PR, both in the concurrency substitution rather than the happy path, and each verified against the source before fixing.

| | Defect | Fixed in |
|---|---|---|
| a | **Duplicate upload destinations raced.** The legacy request is a flat multipart list, so two parts can name one `relative_path`, and `_prepare_upload_plan` accepted both. Harmless while the writer was sequential — the later entry overwrote the earlier, last-one-wins deterministically — but concurrently it left whichever write finished last, so the installed Skill differed run to run. The plan is now keyed by destination, collapsing the collision to one write with the same last-one-wins content. Deduplicating rather than rejecting keeps this retiring address accepting exactly what it accepted before; the OpenAPI upload was never exposed, since every one of its paths funnels through `LocalSkillUploadService._unpack`'s `duplicate_file_path`. | `df1d4b1c` |
| b | **A cancelled batch still ran everything queued.** Shielding the whole gather meant `batch` was never cancelled, so every coroutine parked on the semaphore acquired it and issued its device call: cancelling a 100-file upload ran the other 92 before propagating. The drain's justification does not reach those — it is owed to a call already on a worker thread, which `to_thread` cannot interrupt and whose write would land after the caller's compensation; a queued call has touched nothing. An `aborted` flag, set before the drain, now takes each remaining entry out after it acquires the semaphore. This also restored the claim below, which was false as written. | `37815d6e` |

## Validation

- Affected suites (`core/skill_center`, `core/mcp`, `core/devices`, `core/caller_identity`, `unit/skill_center`, `plugins/prod`, `services`, `architecture`, `di`, `adapters`, `endpoints`) — all green.
- Full backend suite — **14580 passed, 58 skipped**. Two further failures in this sandbox are `rsync: not found`, reproduced identically on the base commit and passing in CI, which has rsync.
- `ruff check` clean on every changed file. `factories.py` reports 7 pre-existing `F821`s from its intentional `TYPE_CHECKING` string annotations — identical on the base commit, verified by reverting.

**Every new behaviour test was checked against the unchanged source and fails there** — none are vacuous. Twelve fail on the pre-change tree; the ones that pass on both are deliberate regression guards on the preserved semantics (result ordering, per-item failure isolation, the drain).

New coverage:

- teclaw: a package's writes resolve once and thread that one `http_info` through every upload; upload / read / list each resolve their own path; a 401 refreshes and replays exactly once; a 403 is never replayed
- legacy upload: writes overlap, stay bounded, and a failed batch is fully drained before the rollback `delete_tree` — the case where a straggler would land behind the cleanup and orphan a file; duplicate destinations collapse to one write with the last entry's content
- active list: entries read concurrently, once each, with no `exists` probe; an entry with no manifest skipped on the read alone
- switch sweep and verify probes: both overlap; the switcher still reports every entry when one device raises and another refuses; the verify report's failures still follow the skill list rather than the probe order
- activation: overlaps but never exceeds the bound, and still reports each failure against its own path; deactivate-all overlaps and keeps its per-skill verdicts
- MCP: pushes overlap; resolution never touches the loop thread; results keep the bot-list order; one device raising neither stops nor hides the others
- cancellation: the in-flight wave is drained before anything propagates, repeated cancellation cannot abandon that drain, and waves that had not started are dropped rather than run

Not run: no live BaaS, teclaw or desktop bot is available in this environment, so wire behaviour is covered at the seam rather than by a real upload or push.

## Compatibility and risk

No API, schema, or config change. `gather_device_io`'s `return_exceptions` is keyword-only and defaults to the existing behaviour.

Worth a reviewer's eye:

- **Package files are written concurrently**, which assumes the engine's `/api/file/upload` tolerates concurrent parent-directory creation. Carried over from inclusionAI/Avernet#1535 and still unverified from this repo — the path leads to `OpenClawFilePort`, whose local implementation is an in-memory fake. **Please confirm against the real engine.** The teclaw upload path (`/api/v1/file/upload`) now inherits the same assumption.
- **The active-list read collapse changes which call answers "does this entry have a manifest".** Argued above to be exactly equivalent, including the directory-in-an-entry's-place case, and both calls propagate non-404 failures identically. It is the one place a *behaviour* was substituted rather than a schedule.
- **A cancelled batch takes as long as its slowest in-flight call to unwind** — not longer, since fix (b), and not shorter, since `to_thread` cannot actually stop that call. The previous behaviour only made cancellation *look* fast while leaving work running.
- **`DEVICE_IO_CONCURRENCY = 8` is the one tuning knob**, now shared by every fan-out here. On a 2-core box the `to_thread` executor has only 6 slots. These are I/O-blocked threads and the operations are bursty, but lower it if contention shows up.

Rollback is a straight revert; nothing persists state.

## Related issues

Follow-up findings on this path, **not** addressed here:

- **`httpx` in `core/`.** Codex flagged (P1) that `baas_http_info.py` imports `httpx` and interprets 401, against AGENTS.md's "core logic must stay transport-agnostic". The rule is right, but this file adds none of that coupling — it is a straight extraction, and at the merge base **20 modules under `core/` already import `httpx`**, including the whole device-transport cluster and `BaasService.invoke_http`, whose `httpx.Response` five modules read `.status_code`/`.content` off. Fixing it means a transport-agnostic result type, a changed `invoke_http` signature, and relocating the Protocol and both transports out of core — its own PR against `dev`, with an owner's call on that signature first.
- `HttpxClient._request` (`plugins/http_client.py`) builds a new `httpx.Client` for *every* request, so the cloud `BaasInvokeTransport` still pays a handshake per call through `_general_http`. Fixing it wins for every HTTP caller in the backend, but the blast radius is far wider than this PR.
- `SkillServiceFactory.local_skill_package_storage` calls `resolve_runtime_engine_for_bot` twice with identical arguments plus a third bot lookup via `_device_fs_factory`. Deduplicating means deciding whether the resolved runtime engine may be passed back as `engine_type`, which is the *override* — semantically different, so it needs an owner's call.
- `BaasDeviceFileSystem.exists()` calls `read_file` before `list_dir`. This PR removes the one hot caller that paid for it; the probe itself is still a wasted round trip for every directory check that remains.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4rrDaaxoKWYEVpjr1crSm