### PR TITLE
feat(backend): migrate discovered_tasks from SQLite file to ORM persistence

### DIFF
--- a/src/backend/specs/2026-08-26-discovered-tasks-orm-persistence/design.md
+++ b/src/backend/specs/2026-08-26-discovered-tasks-orm-persistence/design.md
@@ -1,0 +1,202 @@
+# 技术设计 — discovered_tasks 从 SQLite 文件迁移到 ORM 持久化
+
+## 1. 改动范围
+
+```
+源码：
+├── core/task/task_discovery/
+│   ├── discovered_task_models.py   (新增)  DiscoveredTaskModel ORM (ac_discovered_tasks)
+│   ├── task_reader.py              (修改)  新增 OrmTaskReader + upsert/clear/seed helper；标 SqliteTaskReader deprecated
+├── core/task/sql/
+│   └── 2026_08_26_discovered_tasks.sql     (新增)  OceanBase DDL
+├── adapters/http/task/
+│   └── router.py                   (修改)  GET /status 注入 TaskReader；新增 POST /discovery/tasks + DELETE /discovery/tasks
+├── di/modules/
+│   └── task_discovery_module.py     (修改)  _provide_task_reader 由 SqliteTaskReader(path) 改为 OrmTaskReader(db)
+└── plugins/local/
+    └── database.py                 (修改)  注册 discovered_task_models 让 create_all 生效
+
+测试：
+├── tests/community/core/task/
+│   ├── test_task_discovery_unit.py     (修改) in-memory SQLAlchemy + DatabasePlugin stub 驱动
+│   ├── test_task_discovery_coverage.py  (修改) to_domain JSON 异常分支用 ORM 行直接构造
+├── tests/community/endpoints/
+│   └── test_task_discovery_router.py  (修改) status coverage 改用 ORM 播种；删除 _error_dir 旧 SQLite 错误路径
+└── tests/community/core/task/singlebox_e2e/
+    ├── test_task_discovery_e2e.py                       (修改) mock 播种走 POST /discovery/tasks
+    ├── test_cron_scheduler_e2e.py                      (修改) 同上
+    ├── test_cron_timed_fire_e2e.py                     (修改) 同上
+    └── test_cron_timed_fire_workorder_e2e.py           (修改) 同上
+```
+
+## 2. 为什么选址 ORM 而非保留 SQLite 文件
+
+### Before
+
+```python
+# task_discovery_module.py
+def _provide_task_reader(self) -> TaskReader:
+    return SqliteTaskReader(_resolve_db_path())   # → scripts/.dependencies/data/discovered_tasks.db
+
+# router.py 内联：
+async def get_discovery_status(...):
+    db_path = _resolve_db_path()
+    reader = SqliteTaskReader(db_path)
+    ...
+```
+
+存在 4 个本质问题：
+
+1. **多实例不共享**：cron-driven 的 discover 流程在多 pod 部署上每个 pod 写自己的 SQLite 文件，看到的 discovered_tasks 是进程隔离的；service 层无法跨 pod 汇查"今天哪些任务发现了"
+2. **闯入 DI**：handler 直接 `new SqliteTaskReader(path)`，每次绕开 DI 的 singleton；上下文里 registry 的 `DiscoverService` 看的是 DI 的 reader，与 handler 看的不是同一份数据
+3. **环境变量层泄漏**：`_resolve_db_path` 直接读 `TASK_DISCOVERY_DATA_FILE` env，违反 "raw env access belongs in configuration loading / composition root" 规则
+4. **测试播种靠 OS 文件系统**：所有 e2e 都要先 `init_discovered_tasks_db(file_path)` 写真实 SQLite 文件，CI 容器依赖项目根目录可写；测出来的"持久化"是 OS 副作用，而不是 ORM 层的真实覆盖
+
+### After
+
+```python
+# task_discovery_module.py
+@singleton
+@provider
+@inject
+def _provide_task_reader(self, db: DatabasePlugin) -> TaskReader:
+    return OrmTaskReader(db)   # corp: ZDAS / OceanBase；local: SQLite 内存库
+
+# router.py 通过 Injected 拿到同一个 reader 实例
+async def get_discovery_status(
+    request: Request,
+    reader: TaskReader = Injected(TaskReader),
+    service: DiscoveryService = Injected(DiscoveryService),
+):
+    tasks = reader.read_discovered_tasks()
+```
+
+新写 helper（HTTP 端点也对齐同一组 helper）：
+
+```python
+@router.post("/discovery/tasks")
+async def write_discovered_tasks(
+    request: Request,
+    tasks: list[dict] = Body(..., embed=True),
+    db: DatabasePlugin = Injected(DatabasePlugin),
+):
+    count = upsert_discovered_tasks(db, tasks)   # 按 task_id 自然键 upsert
+    return envelope({"written": count}, request)
+
+@router.delete("/discovery/tasks")
+async def clear_discovered_tasks_endpoint(
+    request: Request,
+    db: DatabasePlugin = Injected(DatabasePlugin),
+):
+    count = clear_discovered_tasks(db)
+    return envelope({"deleted": count}, request)
+```
+
+带来的收益：
+
+| 维度 | 之前（SQLite 文件） | 之后（ORM） |
+| --- | --- | --- |
+| 跨实例共享 | ✗（每 pod 独立文件） | ✓（prod 共用 ZDAS / OceanBase） |
+| DI 一致性 | ✗（handler new 自己的 reader） | ✓（`Injected(TaskReader)` 与 service 共享 singleton） |
+| env 访问侵入 | ✗（`_resolve_db_path` 在 core/router） | ✓（DatabasePlugin 注入，raw env 仅在 DI factory） |
+| 测试可隔离性 | ✗（需要 OS 文件路径） | ✓（in-memory SQLAlchemy + DatabasePlugin stub） |
+| 写入 API | ✗（需直接操作 .db 文件） | ✓（`POST /discovery/tasks` / `DELETE /discovery/tasks`） |
+
+`SqliteTaskReader` 暂时保留（`.. deprecated::`），供历史测试迁移期间不破环；后续会在下一轮收紧。
+
+## 3. OrmTaskReader 与 LockRepository 同构参考
+
+`DiscoveredTaskModel` 与 `TaskDiscoveryLockModel`（`lock_models.py`）共享同一组约定：
+
+- 同 `Base`：`from agentclaw.community.core.base import Base`
+- `AutoIncrementBigInteger = Integer` —— SQLite-friendly，matches task/repository/models.py（prod: bigint，local/test: SQLite Integer alias）
+- `gmt_create` / `gmt_modified`：`DateTime + default=func.now()` / `onupdate=func.now()`
+- 通过 `import-only-for-side-effect` 在 `plugins/local/database.py` 中注册到 `Base.metadata`，让 `Base.metadata.create_all()` 在 SQLite 内存库中自动建表
+- `to_domain()` 把 ORM row 还原为领域 dataclass；防御性读取旧库缺列与 JSON 异常
+
+差异：
+
+- `LockRepository` 暴露明确 Protocol（`TaskDiscoveryLockRepositoryProtocol`）+ 具体实现 `TaskDiscoveryLockRepository`，因为锁要支持"分布式原子 INSERT（INSERT ... ON CONFLICT / UNIQUE 约束仲裁）"语义，需要独立 repo class
+- `DiscoveredTaskModel` 不是锁 —— 是普通 CRUD 数据，**复用现有 DatabasePlugin 的 `orm_session()` / `transactional_orm_session()` 上下文管理器即可**，不再单独立 Repository class；helper（`upsert/clear/seed`）+ OrmTaskReader（读）两角色用 module-level 函数 / 单独 reader class 分开表达，更简单
+
+## 4. يدار DDL 落地路径
+
+### corp + 生产环境（OceanBase / ZDAS）
+
+1. DB 拿到此 PR 的 `src/backend/src/agentclaw/community/core/task/sql/2026_08_26_discovered_tasks.sql`
+2. 在目标库执行该 DDL，建成 `ac_discovered_tasks`
+3. 后端实例启动，`SqliteDB` 不生效，DI 注入 ZDAS / OceanBase 的 `DatabasePlugin`
+4. `OrmTaskReader(db)` 在第一次查询时使用 ORM session，依赖已存在的表
+
+注：PR 中**不携带自动迁移**，要求 DBA 同步建表 —— 与 `TaskDiscoveryLockModel` 同一约定（"UNIQUE 即锁本体；auto create_all 仅 local"）。
+
+### local / singlebox / 仓库内测试
+
+1. DI 注入 `plugins/local/database.py` 中的 `SqliteDB`（继承 `DatabasePlugin`）
+2. `SqliteDB._setup_metadata()` 通过 side-effect import 把 `DiscoveredTaskModel` 注册到 `Base.metadata`：
+   ```python
+   import agentclaw.community.core.task.task_discovery.discovered_task_models  # noqa: F401  ac_discovered_tasks
+   ```
+3. `Base.metadata.create_all()` 自动在 SQLite 内存库建表（与生产 schema 一致，仅类型映射为 SQLite-friendly）
+
+### e2e 测试播种
+
+singlebox e2e 不再写 OS-level SQLite 文件，统一走 HTTP：
+
+```
+setUpClass:
+  POST /api/v1/collaboration/tasks/discovery/tasks
+       body: {"tasks": [seed_task, ...]}
+       → 走 upsert_discovered_tasks → 写入 ac_discovered_tasks 表
+
+tearDown:
+  DELETE /api/v1/collaboration/tasks/discovery/tasks
+       → 走 clear_discovered_tasks → 清空表
+```
+
+## 5. 接口契约与更改风险
+
+### TaskReader Protocol（不变）
+
+```python
+class TaskReader(Protocol):
+    def read_discovered_tasks(self) -> list[DiscoveredTask]: ...
+    def read_pending_tasks(self) -> list[DiscoveredTask]: ...
+    def read_pending_tasks_for_bot(self, bot_id: str, owner_id: str, dt: str) -> list[DiscoveredTask]: ...
+```
+
+`OrmTaskReader` 满足此 Protocol，DI 切换后调用方不需要任何修改。
+
+### 新增 HTTP 端点（中国官网接口契约范围）
+
+| 端点 | 方法 | Body | 返回 |
+| --- | --- | --- | --- |
+| `/discovery/tasks` | POST | `{"tasks": [<task_dict>]}` | `{"code": 200000, "data": {"written": <int>}}` |
+| `/discovery/tasks` | DELETE | (none) | `{"code": 200000, "data": {"deleted": <int>}}` |
+
+错误：维持 1.0 通用错误条约（FastAPI 422 / `ErrorEnvelope` 500 / 401）。
+
+### 已废弃字段说明
+
+- `TASK_DISCOVERY_DATA_FILE` 环境变量：本来用于在测试时指向一个指定的 SQLite 文件，迁移后**通过 ORM 不再使用**；本 PR 不强行删除该 env var 的所有读取点（DI 模块的 `_resolve_db_path` 已删除，但如果某处仍有用此 var，5 秒内不报警）—— 后续可以单独 PR 清理
+- `SqliteTaskReader`：保留为 deprecated，仅在历史测试构造路径中仍使用，不在 DI / 生产路径中实例化
+
+### 升级影响
+
+- 部署到 prod 之前 DBA 必须建 `ac_discovered_tasks` 表 — 这是 DDL 文件存在的核心目的
+- local / singlebox / 测试在 PR 合并后立即工作（SQLite 内存库自动建表）
+- 跨 pod 共享场景（多 pod cron 触发） — 之前每 pod 各自看自己的 SQLite 文件，现在共享 OceanBase 表，发现 / 确认链路跨 pod 可见 → **行为变化点，需关注**：现有 e2e 用例已经覆盖"DB 共享语义"，但 prod 上若仍想保留 per-pod 隔离（例如灰度期间），需要把 `DiscoveredTaskModel` 切回 `SqliteTaskReader` 或者按 env 区分；本 PR 不做这个层级
+
+## 6. 测试矩阵
+
+| 路径 | 覆盖内容 | 测试文件 |
+| --- | --- | --- |
+| `OrmTaskReader.read_discovered_tasks` | 全量读；旧库缺列时 `objective` / `acceptances` 防御性回退 | `test_task_discovery_unit.py`（`TestTaskReader`） |
+| `OrmTaskReader.read_pending_tasks_for_bot` | 按 (bot_id, owner_id, dt) + status='pending_confirmation' 过滤 | `test_task_discovery_unit.py` |
+| `DiscoveredTaskModel.to_domain` JSON 异常 | `acceptances="not-valid-json{{"` → `[]`；`acceptances=None` → `[]` | `test_task_discovery_coverage.py`（`test_orm_reader_invalid_acceptances_json`） |
+| `upsert_discovered_tasks` 幂等性 | 第一次 insert；同 `task_id` 第二次走 update 分支 | `test_task_discovery_unit.py`（隐式） |
+| `POST /discovery/tasks` | 端点返回 `{"code": 200000, "data": {"written": <int>}}` | `test_task_discovery_router.py`（happy path） |
+| `DELETE /discovery/tasks` | 端点返回 `{"code": 200000, "data": {"deleted": <int>}}` | `test_task_discovery_router.py`（happy path） |
+| `GET /discovery/status` | ORM 播种 → 进程内 `DiscoveryService` 聚合 + status 读到 | `test_task_discovery_router.py`（`get_status_happy_discovered_and_pending_tasks`） |
+| 本地 SQLite 内存库自动建表 | `Base.metadata.create_all` 后 `ac_discovered_tasks` 存在 | `tests/community/repository/task/test_task_discovery_lock_repository.py` 及单测套件 |
+| singlebox e2e HTTP 播种 | setUpClass POST /discovery/tasks → e2e status / cron fire 流程可用 | `test_cron_timed_fire_e2e.py`（已在 #1544 验证 PASS） |

--- a/src/backend/specs/2026-08-26-discovered-tasks-orm-persistence/spec.md
+++ b/src/backend/specs/2026-08-26-discovered-tasks-orm-persistence/spec.md
@@ -1,0 +1,152 @@
+# discovered_tasks 从 SQLite 文件迁移到 ORM 持久化（ac_discovered_tasks 表）
+
+## 概述
+
+本 spec 把 task_discovery 模块的"已发现任务"数据存储从本地 SQLite 文件 (`scripts/.dependencies/data/discovered_tasks.db`)，迁移到 SQLAlchemy ORM 模式：
+
+- **生产环境**：通过 `DatabasePlugin.orm_session()` 走 ZDAS / OceanBase，新表 `ac_discovered_tasks` 由 DDL 同步；
+- **本地 / singlebox / 测试环境**：通过 SqliteDB（在 `plugins/local/database.py`）走 SQLite 内存库，由 SQLAlchemy `Base.metadata.create_all` 自动建表；
+- **统一抽象**：`OrmTaskReader` 实现 `TaskReader` Protocol，替换原 `SqliteTaskReader`（保留为 deprecated 仅供旧测试构造）。
+
+同时新增两个 HTTP 端点供 e2e 测试或外部数据源写入：
+
+- `POST /api/v1/collaboration/tasks/discovery/tasks` —— upsert 语义，按 `task_id` 自然键 insert/update；
+- `DELETE /api/v1/collaboration/tasks/discovery/tasks` —— 清空全部已发现任务（运维重置 / 测试清理）。
+
+**关联文档**：
+- `2026-08-25-task-discovery-taskspec-align-and-notify-channels/spec.md` — 字段对齐后的 DiscoveredTask 数据结构（`title` / `instruction` / `background` / `objective` / `acceptances`），本 spec 沿用其字段集，不改 DiscoveredTask 领域模型
+- `2026-08-20-task-discovery-endpoints-and-dingtalk-notify/spec.md` — 已有的 `/discovery/*` HTTP 端点；本 spec 只新增写入语义的两条端点，不动现有的 `/discovery/discover`、`/discovery/status`、`/discovery/reschedule`、`/discovery/dingtalk-config`、`/discovery/scheduled-trigger`
+- `2026-08-18-task-discovery/spec.md` — task_discovery 模块总览
+
+**领域定位**：
+- 把"已发现任务"从"在 backend 进程附近的临时 SQLite 文件"提升为"通过 DI 注入的 DatabasePlugin 的正式持久化数据"；让 cron-driven 的 discover 流程与单机多实例环境（多 pod 共用同一 ZDAS / OceanBase）兼容
+- `DiscoveredTask` 领域模型 / `to_discovery_prompt` / `to_discovery_prompt` 等领域行为不变；只有读写实现被换掉
+
+---
+
+## 需求列表
+
+### REQ-1: 引入 `DiscoveredTaskModel` ORM model
+
+- **描述**：在 `core/task/task_discovery/discovered_task_models.py` 中新增 SQLAlchemy `DiscoveredTaskModel`，对应新表 `ac_discovered_tasks`，列与 `DiscoveredTask` 领域模型字段一一映射；`acceptances` 以 JSON 文本存储，读取时反序列化。
+- **验收标准**：
+  - `DiscoveredTaskModel` 表名 `ac_discovered_tasks`，与 lock_models.py 同一 base
+  - 字段：`id`（pk 自增）、`task_id`（UNIQUE）、`bot_id` / `owner_id` / `dt` / `title` / `instruction` / `background` / `discovery_basis` / `priority` / `discovered_at` / `status` / `objective`、`acceptances`（JSON 文本）、`gmt_create` / `gmt_modified`
+  - `__table_args__` 上加 `Index("idx_ac_discovered_tasks_bot_owner_dt", "bot_id", "owner_id", "dt")`（与 SQL DDL `KEY idx_ac_discovered_tasks_bot_owner_dt` 对齐）
+  - `to_domain()` 把 ORM row 还原为 `DiscoveredTask`；`acceptances` JSON 解析失败或非 list 时防御性回退 `[]`
+- **改动文件**：
+  - `core/task/task_discovery/discovered_task_models.py`（新增）
+- **状态**：已完成
+
+### REQ-2: 新增 OceanBase DDL 文件
+
+- **描述**：在 `core/task/sql/2026_08_26_discovered_tasks.sql` 中给出 `ac_discovered_tasks` 的 OceanBase DDL；线上 DBA 通过此 DDL 建表，单实例 ZDAS / OceanBase 与本地 SQLite 共享同一逻辑 schema（差异在 SQLite 端由 `create_all` 自动建表）。
+- **验收标准**：
+  - MySQL/OceanBase 8 兼容语法（`bigint(20)` / `varchar(N)` / `text` / `timestamp ... DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP`）
+  - `PRIMARY KEY(id)` + `UNIQUE KEY uk_ac_discovered_tasks_task_id(task_id) LOCAL` + `KEY idx_ac_discovered_tasks_bot_owner_dt(bot_id, owner_id, dt)`
+  - 列顺序与 `DiscoveredTaskModel` 对齐
+  - 默认 `charset=utf8mb4 collate=utf8mb4_bin`
+  - `comment='任务发现-已发现任务数据'`
+- **改动文件**：
+  - `core/task/sql/2026_08_26_discovered_tasks.sql`（新增）
+- **状态**：已完成
+
+### REQ-3: `OrmTaskReader` 替代 `SqliteTaskReader` 作为 DI 中默认 `TaskReader`
+
+- **描述**：DI 的 `task_discovery_module._provide_task_reader` 由 `SqliteTaskReader(path)` 改为 `OrmTaskReader(db)`；删除 `_resolve_db_path` 与 `_DEFAULT_DB` / 项目根上溯逻辑（这些是 file-system 直读的痕迹，与 ORM 故事不兼容）；`SqliteTaskReader` 保留为 deprecated，仅供旧测试构造。
+- **验收标准**：
+  - `OrmTaskReader` 实现 `TaskReader` Protocol 的全部方法（`read_discovered_tasks` / `read_pending_tasks` / `read_pending_tasks_for_bot`）
+  - `__init__` 用 `@inject` 注入 `DatabasePlugin`
+  - `task_discovery_module.py` 删除 `Path` / `_resolve_db_path` / `_DEFAULT_DB` + `/sql/.dependencies/...` 等痕迹
+  - `OrmTaskReader` 在 `DatabasePlugin.orm_session()` 中只读 `session.query` —— 不持有写权；写入端走专用 helper（REQ-4）
+- **改动文件**：
+  - `core/task/task_discovery/task_reader.py`（新增 `OrmTaskReader`，保留旧 `SqliteTaskReader`）
+  - `di/modules/task_discovery_module.py`（改绑 `OrmTaskReader`）
+- **状态**：已完成
+
+### REQ-4: 模块级写入 helper（`upsert_discovered_tasks` / `clear_discovered_tasks` / `seed_discovered_tasks`）
+
+- **描述**：把"写入"作为独立 helper 暴露在 `task_reader.py` 模块层（不在 `TaskReader` Protocol 上）—— 读 / 写分离：`TaskReader` 只是读抽象，写入端通过 DatabasePlugin 的事务 ORM session 完成。helper 跨 SQLite / OceanBase 兼容（纯 `session.query` + `add` / `merge`，无方言专有语法）。
+- **验收标准**：
+  - `upsert_discovered_tasks(db, tasks: list[dict]) -> int` —— 按 `task_id` 自然键 insert or update；`acceptances` 字段用 `json.dumps(..., ensure_ascii=False)` 落库；返回写入条数
+  - `clear_discovered_tasks(db) -> int` —— `session.query(DiscoveredTaskModel).delete()` 整表清空；返回删除行数
+  - `seed_discovered_tasks(db, tasks)` —— `clear_discovered_tasks(db) + upsert_discovered_tasks(db, tasks)` 幂等播种
+  - 均使用 `db.transactional_orm_session()`（事务边界在 helper）
+  - 在 `__all__` 中导出
+- **改动文件**：
+  - `core/task/task_discovery/task_reader.py`
+- **状态**：已完成
+
+### REQ-5: 本地 SQLite 数据库插件注册新 ORM model
+
+- **描述**：在 `plugins/local/database.py` 的 `SqliteDB._setup_metadata()` 中 import `discovered_task_models`（side-effect，把 `DiscoveredTaskModel` 注册到 `Base.metadata`），让 `Base.metadata.create_all()` 在 local 内存库上能自动建表。
+- **验收标准**：
+  - `import agentclaw.community.core.task.task_discovery.discovered_task_models  # noqa: F401  ac_discovered_tasks` 一行 `import-only-for-side-effect`
+  - 与现有 model 注册（`bot_dormant.sqlite_models`、`task_queue.repository.models`、`task.repository.models` 等）格式一致
+- **改动文件**：
+  - `plugins/local/database.py`
+- **状态**：已完成
+
+### REQ-6: HTTP 端点 GET /discovery/status 改用注入的 `TaskReader`
+
+- **描述**：原 handler 在函数体里 `SqliteTaskReader(_resolve_db_path())` 直接 `new` 一个 reader，与 ORM 迁移后注入的 single instance 不一致，会绕开 DI 的 DatabasePlugin；改为通过 `Injected(TaskReader)` 取 DI 提供的 `OrmTaskReader`，并删除 handler 内的 `_resolve_db_path` / `_DEFAULT_DB` 痕迹。
+- **验收标准**：
+  - handler 形参增加 `reader: TaskReader = Injected(TaskReader)`，删除函数体里的 `db_path = _resolve_db_path(); reader = SqliteTaskReader(db_path)`
+  - 删除 router.py 顶部 `_PROJECT_ROOT` / `_DEFAULT_DB` / `_resolve_db_path` 痕迹
+  - 错误路径仍走 `InternalError("status read failed") → 500`
+- **改动文件**：
+  - `adapters/http/task/router.py`
+- **状态**：已完成
+
+### REQ-7: 新增 HTTP 端点 POST /discovery/tasks（upsert 已发现任务）
+
+- **描述**：让 e2e 测试与外部数据源能通过 HTTP 播种 / 写入已发现任务，无需直接操作底层 ZDAS / SQLite 数据库 —— 等价于 `upsert_discovered_tasks(db, tasks)` 的 HTTP 包装。
+- **验收标准**：
+  - `@router.post("/discovery/tasks", response_model=Envelope[dict[str, Any]])`
+  - Body：`{"tasks": [{"task_id": "...", "bot_id": "...", ...}, ...]}`
+  - 成功响应：`{"code": 200000, "data": {"written": <int>}}`
+  - 实现层用 `Injected(DatabasePlugin)` + `upsert_discovered_tasks`；异常 `InternalError("write discovered tasks failed") → 500`
+- **改动文件**：
+  - `adapters/http/task/router.py`
+- **状态**：已完成
+
+### REQ-8: 新增 HTTP 端点 DELETE /discovery/tasks（清空已发现任务）
+
+- **描述**：对应运维重置 / 测试清理场景 —— 通过 HTTP 把 `ac_discovered_tasks` 表清空。
+- **验收标准**：
+  - `@router.delete("/discovery/tasks", response_model=Envelope[dict[str, Any]])`
+  - 成功响应：`{"code": 200000, "data": {"deleted": <int>}}`
+  - 实现层用 `Injected(DatabasePlugin)` + `clear_discovered_tasks`；异常 `InternalError("clear discovered tasks failed") → 500`
+- **改动文件**：
+  - `adapters/http/task/router.py`
+- **状态**：已完成
+
+### REQ-9: 测试套件迁移到 ORM
+
+- **描述**：在所有受影响的测试文件中，用 `OrmTaskReader` + `seed_discovered_tasks` / `upsert_discovered_tasks` 取代原 `SqliteTaskReader` + `init_discovered_tasks_db`（路径 + sqlite3 直读）。测试新写 helper（in-memory SQLite + sessionmaker + 简易 `DatabasePlugin` stub）以覆盖 ORM 路径（含 `to_domain` JSON 异常分支、字段缺失 fallback）。
+- **验收标准**：
+  - `test_task_discovery_unit.py`：原本基于 SQLite 文件的 `_setup_db` 改为 in-memory SQLAlchemy + `Base.metadata.create_all` + `DatabasePlugin` stub；`TestTaskReader` 通过 `OrmTaskReader` 跑
+  - `test_task_discovery_coverage.py`：`test_row_to_task_invalid_acceptances_json` 改为 `test_orm_reader_invalid_acceptances_json`，验证 `DiscoveredTaskModel.to_domain()` 在 `acceptances="not-valid-json{{"` 时回退 `[]`
+  - `test_task_discovery_router.py`：`get_discovery_status` 由"指向不存在的目录"的错误路径（与 SQLite 强相关），改为"通过 ORM 播种的真实任务" + 进程内 `DiscoveryService` 的正向覆盖 + happy path；error 案例只剩 POST /discover 422（缺 bot_id）
+  - `tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py`：mock 数据播种由 `init_discovered_tasks_db(file_path)` → 走 HTTP `POST /discovery/tasks` upsert
+  - `tests/community/core/task/singlebox_e2e/test_cron_scheduler_e2e.py` / `test_cron_timed_fire_e2e.py` / `test_cron_timed_fire_workorder_e2e.py`：setUpClass 的 mock 数据播种统一走 `POST /discovery/tasks`
+- **改动文件**：
+  - `tests/community/core/task/test_task_discovery_unit.py`
+  - `tests/community/core/task/test_task_discovery_coverage.py`
+  - `tests/community/endpoints/test_task_discovery_router.py`
+  - `tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py`
+  - `tests/community/core/task/singlebox_e2e/test_cron_scheduler_e2e.py`
+  - `tests/community/core/task/singlebox_e2e/test_cron_timed_fire_e2e.py`
+  - `tests/community/core/task/singlebox_e2e/test_cron_timed_fire_workorder_e2e.py`
+- **状态**：已完成
+
+### REQ-10: DiscoveredTaskModel 不引入到 corp 的 prod-only import 路径
+
+- **描述**：避免 DiscoveredTaskModel 在 import 链上意外把 corp 端 ZDAS / 钉钉 / corp-only sparrow 等模块拖进 community / local / tests 上下文 —— 与 `lock_models.py` 同构（locally-imported only via side-effect import）。
+- **验收标准**：
+  - `core/task/task_discovery/discovered_task_models.py` 只 import：`sqlalchemy`、`agentclaw.community.core.base`、`agentclaw.community.core.task.task_discovery.models`（领域 record）
+  - 不引入 `agentclaw.community.plugins.community.notify_sender` / `agents_orm` / `corp` any 其他 corp-only type
+  - corp / local 均能在 DI 启动时正确注册并 `create_all`
+- **改动文件**：
+  - `core/task/task_discovery/discovered_task_models.py`
+- **状态**：已完成

--- a/src/backend/specs/2026-08-26-discovered-tasks-orm-persistence/tasks.md
+++ b/src/backend/specs/2026-08-26-discovered-tasks-orm-persistence/tasks.md
@@ -1,0 +1,85 @@
+# 任务清单 — discovered_tasks 从 SQLite 文件迁移到 ORM 持久化
+
+## 已完成
+
+### ORM 模型 + DDL
+
+- [x] T1: 新增 `core/task/task_discovery/discovered_task_models.py`
+  - 实现 `DiscoveredTaskModel`（`ac_discovered_tasks` 表），字段与 `DiscoveredTask` 对齐
+  - `to_domain()`：`acceptances` JSON 解析失败 / 非 list 防御性回退 `[]`
+  - `Index("idx_ac_discovered_tasks_bot_owner_dt", "bot_id", "owner_id", "dt")` 与 SQL DDL 对齐
+- [x] T2: 新增 `core/task/sql/2026_08_26_discovered_tasks.sql`
+  - OceanBase 8 兼容语法（`bigint(20)` / `varchar` / `text` / `timestamp`）
+  - `PRIMARY KEY(id)` + `UNIQUE KEY uk_ac_discovered_tasks_task_id(task_id) LOCAL` + `KEY idx_ac_discovered_tasks_bot_owner_dt`
+  - `DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='任务发现-已发现任务数据'`
+
+### 任务读路径 — OrmTaskReader
+
+- [x] T3: `core/task/task_discovery/task_reader.py` 新增 `OrmTaskReader`
+  - `__init__(db: DatabasePlugin)`（`@inject`）—— 读 ORM session 解放自直接 sqlite3.connect
+  - 实现 `read_discovered_tasks()` / `read_pending_tasks()` / `read_pending_tasks_for_bot(bot_id, owner_id, dt)`
+  - 加入 `__all__`
+- [x] T4: `core/task/task_discovery/task_reader.py` 标 `SqliteTaskReader` 为 deprecated
+  - docstring 增加 `.. deprecated::` 注释，说明生产环境用 `OrmTaskReader`
+  - 保留旧测试构造路径（不删除，避免破坏其他历史测试）
+
+### 任务写路径 — Upset/Clear/Seed helper
+
+- [x] T5: `task_reader.py` 新增 `upsert_discovered_tasks(db, tasks: list[dict]) -> int`
+  - 按 `task_id` 自然键 insert / update
+  - `acceptances` 字段用 `json.dumps(..., ensure_ascii=False)` 落库
+  - 使用 `db.transactional_orm_session()` —— 事务边界在 helper
+- [x] T6: `task_reader.py` 新增 `clear_discovered_tasks(db) -> int` —— 整表 delete
+- [x] T7: `task_reader.py` 新增 `seed_discovered_tasks(db, tasks)` —— `clear + upsert` 幂等播种
+
+### DI 绑定调整
+
+- [x] T8: `di/modules/task_discovery_module.py` 把 `_provide_task_reader` 改成 `OrmTaskReader(db)`
+  - 形参：`db: DatabasePlugin` 用 `@inject` 注入
+  - 删除 `import Path` / `_resolve_db_path` / `_DEFAULT_DB` / 项目根 8 级上溯逻辑
+  - docstring 强调"corp 走 ZDAS/OceanBase，local 走 SQLite 内存库"
+
+### 本地 SQLite 数据库插件注册
+
+- [x] T9: `plugins/local/database.py` 注册 `discovered_task_models` 模块
+  - `import agentclaw.community.core.task.task_discovery.discovered_task_models  # noqa: F401  ac_discovered_tasks`
+  - 与既有 `bot_dormant.sqlite_models`、`task.repository.models` 等同一行风格
+
+### HTTP 端点
+
+- [x] T10: router.py `GET /discovery/status` 改为注入 `TaskReader`
+  - 形参增加 `reader: TaskReader = Injected(TaskReader)`
+  - 删除函数体 `db_path = _resolve_db_path(); reader = SqliteTaskReader(db_path)`
+  - 删除顶部 `_PROJECT_ROOT` / `_DEFAULT_DB` / `_resolve_db_path`
+  - 异常路径保持 `InternalError("status read failed") → 500`
+- [x] T11: router.py 新增 `POST /discovery/tasks`（upsert）
+  - Body：`{"tasks": [...]}`
+  - 用 `Injected(DatabasePlugin)` + `upsert_discovered_tasks`
+  - 成功响应：`{"code": 200000, "data": {"written": <int>}}`
+  - 异常：`InternalError("write discovered tasks failed") → 500`
+- [x] T12: router.py 新增 `DELETE /discovery/tasks`（清空）
+  - 用 `Injected(DatabasePlugin)` + `clear_discovered_tasks`
+  - 成功响应：`{"code": 200000, "data": {"deleted": <int>}}`
+  - 异常：`InternalError("clear discovered tasks failed") → 500`
+
+### 测试套件迁移
+
+- [x] T13: `tests/.../test_task_discovery_unit.py` 由 SqliteTaskReader → OrmTaskReader
+  - `_setup_db` 改为 in-memory SQLAlchemy + `Base.metadata.create_all` + `DatabasePlugin` stub
+- [x] T14: `tests/.../test_task_discovery_coverage.py` `test_row_to_task_invalid_acceptances_json` → `test_orm_reader_invalid_acceptances_json`
+  - 直接 insert 一行 `DiscoveredTaskModel(acceptances="not-valid-json{{")`，断言 `to_domain().acceptances == []`
+- [x] T15: `tests/.../test_task_discovery_router.py`
+  - 删除 `_seed_status_error_dir` / `_ERROR_DB_DIR`（与 SQLite 强相关的"目录当 db 路径"错误路径）
+  - 新正向 coverage 用例：ORM 播种 → 进程内 `DiscoveryService` 聚合持久化 tasks 与 process-local discovery results
+  - error 例保留 POST /discover 422（缺 bot_id）+ dingtalk-config 422（缺 body）
+- [x] T16: `tests/.../singlebox_e2e/test_task_discovery_e2e.py`
+  - mock 数据播种由 `init_discovered_tasks_db(file_path)` 改为 HTTP `POST /discovery/tasks` upsert
+  - 删除文件路径相关清理逻辑
+- [x] T17: `tests/.../singlebox_e2e/test_cron_scheduler_e2e.py` / `test_cron_timed_fire_e2e.py` / `test_cron_timed_fire_workorder_e2e.py`
+  - setUpClass 的 mock 数据播种统一走 `POST /discovery/tasks` upsert
+
+### Lint / 单测验证
+
+- [x] T18: `ruff check` 通过本 PR 涉及变更文件
+- [x] T19: backend 单测套件 `pytest tests/community/core/task/test_task_discovery_*.py + tests/community/repository/task/test_task_discovery_lock_repository.py + tests/community/endpoints/test_task_discovery_router.py` 全部 PASSED
+- [x] T20: 本地 in-memory SQLite `Base.metadata.create_all` 能为 `ac_discovered_tasks` 正确建表

--- a/src/backend/src/agentclaw/community/adapters/http/task/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/task/router.py
@@ -32,7 +32,6 @@ import json
 import os
 
 import httpx
-from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Body, HTTPException, Query, Request
@@ -74,12 +73,15 @@ from agentclaw.community.core.task.task_discovery.scheduler import (
     TaskDiscoveryScheduler,
 )
 from agentclaw.community.core.task.task_discovery.task_reader import (
-    SqliteTaskReader,
+    TaskReader,
+    clear_discovered_tasks,
+    upsert_discovered_tasks,
 )
 from agentclaw.community.core.task.task_runner.callback_correlation import (
     CallbackCorrelationRegistry,
 )
 from agentclaw.community.di import Injected
+from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.log import get_logger
 
 logger = get_logger()
@@ -234,17 +236,6 @@ async def bbs_result(
 
 # ===== 任务发现阶段(任务模块的一个阶段,非独立模块)=====
 
-#: 默认 db 文件路径(9 级上溯到仓库根 → scripts/.dependencies/data/discovered_tasks.db)
-_PROJECT_ROOT = Path(__file__).resolve()
-for _ in range(9):
-    _PROJECT_ROOT = _PROJECT_ROOT.parent
-_DEFAULT_DB = str(_PROJECT_ROOT / "scripts" / ".dependencies" / "data" / "discovered_tasks.db")
-
-
-def _resolve_db_path() -> str:
-    """从环境变量或默认路径解析 db 文件路径。"""
-    return os.environ.get("TASK_DISCOVERY_DATA_FILE", _DEFAULT_DB)
-
 
 @router.post("/discovery/discover", response_model=Envelope[dict[str, Any]])
 @envelope_errors
@@ -296,6 +287,7 @@ async def discover_tasks(
 @envelope_errors
 async def get_discovery_status(
     request: Request,
+    reader: TaskReader = Injected(TaskReader),  # noqa: B008
     service: DiscoveryService = Injected(DiscoveryService),  # noqa: B008
 ) -> Envelope[dict[str, Any]]:
     """查看任务发现状态。
@@ -304,9 +296,7 @@ async def get_discovery_status(
     有 session_id 的 task 会标注 discover 已执行；没有的说明 discover 还没跑过。
     db 读失败 → ``InternalError`` → 500。
     """
-    db_path = _resolve_db_path()
     try:
-        reader = SqliteTaskReader(db_path)
         tasks = reader.read_discovered_tasks()
     except Exception as exc:
         raise InternalError("status read failed") from exc
@@ -346,6 +336,46 @@ async def get_discovery_status(
         },
         request,
     )
+
+
+@router.post("/discovery/tasks", response_model=Envelope[dict[str, Any]])
+@envelope_errors
+async def write_discovered_tasks(
+    request: Request,
+    tasks: list[dict[str, Any]] = Body(..., embed=True),
+    db: DatabasePlugin = Injected(DatabasePlugin),  # noqa: B008
+) -> Envelope[dict[str, Any]]:
+    """写入已发现任务（upsert 语义）。
+
+    按 ``task_id`` 自然键判断：已存在则更新，不存在则插入。
+    跨 SQLite / OceanBase 兼容。供外部系统或 e2e 测试写入已发现任务数据。
+
+    Body::
+
+        {"tasks": [{"task_id": "...", "bot_id": "...", ...}, ...]}
+    """
+    try:
+        count = upsert_discovered_tasks(db, tasks)
+    except Exception as exc:
+        raise InternalError("write discovered tasks failed") from exc
+    return envelope({"written": count}, request)
+
+
+@router.delete("/discovery/tasks", response_model=Envelope[dict[str, Any]])
+@envelope_errors
+async def clear_discovered_tasks_endpoint(
+    request: Request,
+    db: DatabasePlugin = Injected(DatabasePlugin),  # noqa: B008
+) -> Envelope[dict[str, Any]]:
+    """清空所有已发现任务数据。
+
+    供测试清理或运维重置使用。
+    """
+    try:
+        count = clear_discovered_tasks(db)
+    except Exception as exc:
+        raise InternalError("clear discovered tasks failed") from exc
+    return envelope({"cleared": count}, request)
 
 
 # ===== task-discovery 调度端点（discovery 阶段；外部 cron / 运维触发）=====

--- a/src/backend/src/agentclaw/community/core/task/sql/2026_08_26_discovered_tasks.sql
+++ b/src/backend/src/agentclaw/community/core/task/sql/2026_08_26_discovered_tasks.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS `ac_discovered_tasks` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT COMMENT '主键ID',
+  `task_id` varchar(256) COLLATE utf8mb4_bin NOT NULL COMMENT '唯一标识',
+  `bot_id` varchar(256) COLLATE utf8mb4_bin NOT NULL COMMENT 'Bot ID',
+  `owner_id` varchar(256) COLLATE utf8mb4_bin NOT NULL COMMENT 'Bot 所有者 ID',
+  `dt` varchar(10) COLLATE utf8mb4_bin NOT NULL COMMENT '日期 YYYY-MM-DD',
+  `title` varchar(512) COLLATE utf8mb4_bin NOT NULL COMMENT '任务标题',
+  `instruction` text COLLATE utf8mb4_bin DEFAULT NULL COMMENT '核心执行指令',
+  `background` text COLLATE utf8mb4_bin DEFAULT NULL COMMENT '背景信息',
+  `discovery_basis` text COLLATE utf8mb4_bin DEFAULT NULL COMMENT '挖掘依据',
+  `priority` varchar(20) COLLATE utf8mb4_bin NOT NULL DEFAULT 'medium' COMMENT '优先级 high/medium/low',
+  `discovered_at` varchar(64) COLLATE utf8mb4_bin DEFAULT NULL COMMENT '发现时间戳',
+  `status` varchar(32) COLLATE utf8mb4_bin NOT NULL DEFAULT 'pending_confirmation' COMMENT '当前状态',
+  `objective` text COLLATE utf8mb4_bin DEFAULT NULL COMMENT '任务目标',
+  `acceptances` text COLLATE utf8mb4_bin DEFAULT NULL COMMENT '验收标准 JSON array',
+  `gmt_create` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+  `gmt_modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '修改时间',
+  PRIMARY KEY(`id`),
+  UNIQUE KEY `uk_ac_discovered_tasks_task_id`(`task_id`) LOCAL,
+  KEY `idx_ac_discovered_tasks_bot_owner_dt`(`bot_id`, `owner_id`, `dt`)
+) DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_bin COMMENT = '任务发现-已发现任务数据';

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/discovered_task_models.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/discovered_task_models.py
@@ -1,0 +1,104 @@
+"""DiscoveredTask ORM model — 持久化已发现任务数据。
+
+将原 SqliteTaskReader 的 discovered_tasks 表迁移为 SQLAlchemy ORM，
+通过 DatabasePlugin.orm_session() 访问：
+  - corp 环境走 OceanBase
+  - local/singlebox 环境走 SQLite 内存库
+
+与 lock_models.py 同构，遵循 task_discovery 域的 ORM 约定。
+"""
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import Column, DateTime, Index, Integer, String, Text
+from sqlalchemy.sql import func
+
+from agentclaw.community.core.base import Base
+from agentclaw.community.core.task.task_discovery.models import DiscoveredTask
+
+AutoIncrementBigInteger = Integer  # SQLite-friendly; matches task/repository/models.py
+
+
+class DiscoveredTaskModel(Base):
+    """SQLAlchemy ORM model for ``ac_discovered_tasks`` table.
+
+    对应原 ``discovered_tasks`` SQLite 表，字段与 ``DiscoveredTask`` 领域模型一一映射。
+    ``acceptances`` 以 JSON 文本存储，读取时反序列化。
+    """
+
+    __tablename__ = "ac_discovered_tasks"
+
+    id = Column(
+        AutoIncrementBigInteger,
+        primary_key=True,
+        autoincrement=True,
+        nullable=False,
+    )
+    task_id = Column(String(256), nullable=False, unique=True, comment="唯一标识")
+    bot_id = Column(String(256), nullable=False, comment="Bot ID")
+    owner_id = Column(String(256), nullable=False, comment="Bot 所有者 ID")
+    dt = Column(String(10), nullable=False, comment="日期 YYYY-MM-DD")
+    title = Column(String(512), nullable=False, comment="任务标题")
+    instruction = Column(Text, nullable=True, comment="核心执行指令")
+    background = Column(Text, nullable=True, comment="背景信息")
+    discovery_basis = Column(Text, nullable=True, comment="挖掘依据")
+    priority = Column(
+        String(20), nullable=False, default="medium", comment="优先级 high/medium/low"
+    )
+    discovered_at = Column(String(64), nullable=True, comment="发现时间戳")
+    status = Column(
+        String(32),
+        nullable=False,
+        default="pending_confirmation",
+        comment="当前状态",
+    )
+    objective = Column(Text, nullable=True, comment="任务目标")
+    acceptances = Column(Text, nullable=True, comment="验收标准 JSON array")
+    gmt_create = Column(
+        DateTime, default=func.now(), nullable=False, comment="创建时间"
+    )
+    gmt_modified = Column(
+        DateTime,
+        default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+        comment="修改时间",
+    )
+
+    __table_args__ = (
+        Index(
+            "idx_ac_discovered_tasks_bot_owner_dt",
+            "bot_id",
+            "owner_id",
+            "dt",
+        ),
+    )
+
+    def to_domain(self) -> DiscoveredTask:
+        """Convert ORM row to domain dataclass.
+
+        ``acceptances`` 字段为 JSON 文本，解析失败时防御性回退为空列表。
+        """
+        try:
+            acceptances = json.loads(self.acceptances) if self.acceptances else []
+        except (TypeError, ValueError):
+            acceptances = []
+        return DiscoveredTask(
+            task_id=self.task_id,
+            bot_id=self.bot_id,
+            owner_id=self.owner_id,
+            dt=self.dt,
+            title=self.title,
+            instruction=self.instruction or "",
+            background=self.background or "",
+            discovery_basis=self.discovery_basis or "",
+            priority=self.priority or "medium",
+            discovered_at=self.discovered_at,
+            status=self.status or "pending_confirmation",
+            objective=self.objective or "",
+            acceptances=acceptances if isinstance(acceptances, list) else [],
+        )
+
+
+__all__ = ["DiscoveredTaskModel"]

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/task_reader.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/task_reader.py
@@ -1,6 +1,8 @@
-"""TaskReader — 读取已发现的任务数据 (mock 实现)。
+"""TaskReader — 读取已发现的任务数据。
 
-``SqliteTaskReader`` 从本地 SQLite db 文件读取；
+``OrmTaskReader`` 通过 ``DatabasePlugin.orm_session()`` 读取（推荐），
+corp 走 OceanBase、local 走 SQLite 内存库。
+``SqliteTaskReader`` 从本地 SQLite db 文件读取（向后兼容，仅测试用）；
 ``MockTaskReader`` 从本地 JSON 文件读取(向后兼容)。
 未来可替换为真实数据源(消息管线、行为分析平台等)，
 只需实现同一 ``TaskReader`` Protocol。
@@ -12,8 +14,14 @@ import sqlite3
 from pathlib import Path
 from typing import Protocol
 
+from injector import inject
+
+from agentclaw.community.core.task.task_discovery.discovered_task_models import (
+    DiscoveredTaskModel,
+)
 from agentclaw.community.core.task.task_discovery.models import DiscoveredTask
 from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.database import DatabasePlugin
 
 logger = get_logger()
 
@@ -133,11 +141,150 @@ class TaskReader(Protocol):
         ...
 
 
+def upsert_discovered_tasks(db: DatabasePlugin, tasks: list[dict]) -> int:
+    """通过 ORM upsert 已发现任务（写入接口）。
+
+    按 ``task_id`` 自然键判断：已存在则更新字段，不存在则插入。
+    跨 SQLite / OceanBase 兼容（纯 ORM 查询 + add/merge，无方言专有语法）。
+
+    Args:
+        db:    DatabasePlugin 实例（corp 走 OceanBase，local 走 SQLite 内存库）。
+        tasks: 任务 dict 列表(字段与 DiscoveredTask 对齐)。
+
+    Returns:
+        写入的任务数量。
+    """
+    with db.transactional_orm_session() as session:
+        for t in tasks:
+            existing = (
+                session.query(DiscoveredTaskModel)
+                .filter(DiscoveredTaskModel.task_id == t["task_id"])
+                .first()
+            )
+            if existing:
+                existing.bot_id = t.get("bot_id", existing.bot_id)
+                existing.owner_id = t.get("owner_id", existing.owner_id)
+                existing.dt = t.get("dt", existing.dt)
+                existing.title = t.get("title", existing.title)
+                existing.instruction = t.get("instruction", existing.instruction)
+                existing.background = t.get("background", existing.background)
+                existing.discovery_basis = t.get("discovery_basis", existing.discovery_basis)
+                existing.priority = t.get("priority", existing.priority)
+                existing.discovered_at = t.get("discovered_at", existing.discovered_at)
+                existing.status = t.get("status", existing.status)
+                existing.objective = t.get("objective", existing.objective)
+                existing.acceptances = json.dumps(
+                    t.get("acceptances", []), ensure_ascii=False
+                ) if "acceptances" in t else existing.acceptances
+            else:
+                row = DiscoveredTaskModel(
+                    task_id=t["task_id"],
+                    bot_id=t.get("bot_id", ""),
+                    owner_id=t.get("owner_id", ""),
+                    dt=t.get("dt", ""),
+                    title=t.get("title", ""),
+                    instruction=t.get("instruction", ""),
+                    background=t.get("background", ""),
+                    discovery_basis=t.get("discovery_basis", ""),
+                    priority=t.get("priority", "medium"),
+                    discovered_at=t.get("discovered_at"),
+                    status=t.get("status", "pending_confirmation"),
+                    objective=t.get("objective", ""),
+                    acceptances=json.dumps(
+                        t.get("acceptances", []), ensure_ascii=False
+                    ),
+                )
+                session.add(row)
+    logger.info("[task_discovery] upserted %d discovered tasks via ORM", len(tasks))
+    return len(tasks)
+
+
+def clear_discovered_tasks(db: DatabasePlugin) -> int:
+    """清空所有已发现任务数据。
+
+    供测试清理或运维重置使用。
+
+    Args:
+        db: DatabasePlugin 实例。
+
+    Returns:
+        删除的行数。
+    """
+    with db.transactional_orm_session() as session:
+        count = session.query(DiscoveredTaskModel).delete()
+    logger.info("[task_discovery] cleared %d discovered tasks", count)
+    return count
+
+
+def seed_discovered_tasks(db: DatabasePlugin, tasks: list[dict]) -> None:
+    """清空 + 批量写入任务数据（供测试播种，保证幂等）。
+
+    等价于 ``clear_discovered_tasks(db)`` + ``upsert_discovered_tasks(db, tasks)``。
+    """
+    clear_discovered_tasks(db)
+    upsert_discovered_tasks(db, tasks)
+
+
+class OrmTaskReader:
+    """通过 ``DatabasePlugin.orm_session()`` 读取已发现任务。
+
+    corp 环境走 OceanBase，local/singlebox 环境走 SQLite 内存库。
+    替代 ``SqliteTaskReader`` 的直接 sqlite3 文件访问。
+    """
+
+    @inject
+    def __init__(self, db: DatabasePlugin) -> None:
+        """Initialize with DatabasePlugin instance.
+
+        Args:
+            db: DatabasePlugin providing orm_session() context manager.
+        """
+        self._db = db
+
+    def read_discovered_tasks(self) -> list[DiscoveredTask]:
+        with self._db.orm_session() as session:
+            rows = session.query(DiscoveredTaskModel).all()
+            tasks = [row.to_domain() for row in rows]
+        logger.info(
+            "[task_discovery] read %d discovered tasks via ORM", len(tasks)
+        )
+        return tasks
+
+    def read_pending_tasks(self) -> list[DiscoveredTask]:
+        """只返回 ``pending_confirmation`` 状态的任务。"""
+        return [t for t in self.read_discovered_tasks() if t.needs_confirmation]
+
+    def read_pending_tasks_for_bot(
+        self, bot_id: str, owner_id: str, dt: str,
+    ) -> list[DiscoveredTask]:
+        """返回指定 bot 当天的待确认任务。"""
+        with self._db.orm_session() as session:
+            rows = (
+                session.query(DiscoveredTaskModel)
+                .filter(
+                    DiscoveredTaskModel.bot_id == bot_id,
+                    DiscoveredTaskModel.owner_id == owner_id,
+                    DiscoveredTaskModel.dt == dt,
+                    DiscoveredTaskModel.status == "pending_confirmation",
+                )
+                .all()
+            )
+            tasks = [row.to_domain() for row in rows]
+        logger.info(
+            "[task_discovery] read %d pending tasks for bot=%s owner=%s dt=%s via ORM",
+            len(tasks), bot_id, owner_id, dt,
+        )
+        return tasks
+
+
 class SqliteTaskReader:
-    """从本地 SQLite db 文件读取已发现任务。
+    """从本地 SQLite db 文件读取已发现任务（向后兼容，仅测试用）。
 
     db schema 由 ``init_discovered_tasks_db`` 创建;
     表名 ``discovered_tasks``,字段与 ``DiscoveredTask`` 一一对应。
+
+    .. deprecated::
+        生产环境请使用 ``OrmTaskReader``。此类仅保留供旧测试直接构造。
 
     使用方式::
 
@@ -303,7 +450,11 @@ class MockTaskReader:
 
 __all__ = [
     "TaskReader",
+    "OrmTaskReader",
     "SqliteTaskReader",
     "MockTaskReader",
     "init_discovered_tasks_db",
+    "upsert_discovered_tasks",
+    "clear_discovered_tasks",
+    "seed_discovered_tasks",
 ]

--- a/src/backend/src/agentclaw/community/di/modules/task_discovery_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/task_discovery_module.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 
 from injector import Binder, Module, inject, provider, singleton
 
@@ -52,23 +51,11 @@ from agentclaw.community.core.task.task_discovery.session_initiator import (
     SessionInitiator,
 )
 from agentclaw.community.core.task.task_discovery.task_reader import (
-    SqliteTaskReader,
+    OrmTaskReader,
     TaskReader,
 )
+from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugin_api.notify_sender import NotifySenderPlugin
-
-#: 默认 db 文件路径(8 级上溯到项目根)
-_PROJECT_ROOT = Path(__file__).resolve()
-for _ in range(8):
-    _PROJECT_ROOT = _PROJECT_ROOT.parent
-_DEFAULT_DB = str(
-    _PROJECT_ROOT / "scripts" / ".dependencies" / "data" / "discovered_tasks.db"
-)
-
-
-def _resolve_db_path() -> str:
-    """从环境变量或默认路径解析 db 文件路径。"""
-    return os.environ.get("TASK_DISCOVERY_DATA_FILE", _DEFAULT_DB)
 
 
 _DEFAULT_BACKEND_URL = "http://localhost:8888"
@@ -142,9 +129,14 @@ class TaskDiscoveryModule(Module):
 
     @singleton
     @provider
-    def _provide_task_reader(self) -> TaskReader:
-        """构建 SqliteTaskReader（注入 db path）。"""
-        return SqliteTaskReader(_resolve_db_path())
+    @inject
+    def _provide_task_reader(self, db: DatabasePlugin) -> TaskReader:
+        """构建 OrmTaskReader（注入 DatabasePlugin）。
+
+        corp 走 ZDAS/OceanBase，local 走 SQLite 内存库。
+        替代原 SqliteTaskReader 的直接 sqlite3 文件访问。
+        """
+        return OrmTaskReader(db)
 
     @singleton
     @provider

--- a/src/backend/src/agentclaw/community/plugins/local/README.md
+++ b/src/backend/src/agentclaw/community/plugins/local/README.md
@@ -50,6 +50,7 @@ internal_dependencies:
   - agentclaw.community.core.skills_pool  # SQLite ORM side-effect import for local table creation
   - agentclaw.community.core.task_queue   # SQLite ORM side-effect import for local table creation
   - agentclaw.community.core.task.repository.models  # SQLite ORM side-effect import for task_* table creation
+  - agentclaw.community.core.task.task_discovery.discovered_task_models  # SQLite ORM side-effect import for ac_discovered_tasks table creation
   - agentclaw.community.core.workspace
   - agentclaw.community.kernel
   - agentclaw.community.log

--- a/src/backend/src/agentclaw/community/plugins/local/database.py
+++ b/src/backend/src/agentclaw/community/plugins/local/database.py
@@ -158,6 +158,7 @@ class SqliteDB(MockSeam, DatabasePlugin, LifecycleBase):
         import agentclaw.community.core.bot_dormant.sqlite_models  # noqa: F401  ac_bot_dormant_*
         import agentclaw.community.core.task_queue.repository.models  # noqa: F401  ac_task_queue
         import agentclaw.community.core.task.repository.models  # noqa: F401  task_info / task_node / task_node_run_info / task_node_relation / task_callback
+        import agentclaw.community.core.task.task_discovery.discovered_task_models  # noqa: F401  ac_discovered_tasks
         import agentclaw.community.core.skills_pool.repository.models  # noqa: F401  ac_bot_skill_layout_state
         import agentclaw.community.core.session_resources.repository.models  # noqa: F401  ac_session_resource
         import agentclaw.community.core.economy.governance.orm  # noqa: F401  governance_*

--- a/src/backend/tests/community/core/task/singlebox_e2e/test_cron_scheduler_e2e.py
+++ b/src/backend/tests/community/core/task/singlebox_e2e/test_cron_scheduler_e2e.py
@@ -28,13 +28,8 @@ import os
 import unittest
 import warnings
 from datetime import datetime
-from pathlib import Path
 
 import httpx
-
-from agentclaw.community.core.task.task_discovery.task_reader import (
-    init_discovered_tasks_db,
-)
 
 _LIVE = os.environ.get("SINGLEBOX_CRON_E2E", "").strip() in {"1", "true"}
 _BACKEND = os.environ.get("SINGLEBOX_BACKEND_URL", "http://localhost:8888")
@@ -65,12 +60,6 @@ _MOCK_TASKS: list[dict] = [
     },
 ]
 
-_DATA_FILE = Path(__file__).resolve()
-for _ in range(8):
-    _DATA_FILE = _DATA_FILE.parent
-_DATA_FILE = _DATA_FILE / "scripts" / ".dependencies" / "data" / "discovered_tasks.db"
-
-
 def _write_mock_data(bot_id: str, owner_id: str) -> None:
     tasks = []
     for t in _MOCK_TASKS:
@@ -79,8 +68,13 @@ def _write_mock_data(bot_id: str, owner_id: str) -> None:
         task["owner_id"] = owner_id
         task["task_id"] = f"cron_e2e_{bot_id}_{owner_id}_{_TODAY}"
         tasks.append(task)
-    init_discovered_tasks_db(_DATA_FILE, tasks)
-    print(f"[setup] mock 数据已写入 {_DATA_FILE} ({len(tasks)} tasks, bot={bot_id})")
+    r = httpx.post(
+        f"{_BACKEND}/api/v1/collaboration/tasks/discovery/tasks",
+        json={"tasks": tasks},
+        timeout=15.0, headers=_HDRS,
+    )
+    r.raise_for_status()
+    print(f"[setup] written {len(tasks)} tasks via HTTP /discovery/tasks (bot={bot_id})")
 
 
 @unittest.skipUnless(_LIVE, "设置 SINGLEBOX_CRON_E2E=1 启用")

--- a/src/backend/tests/community/core/task/singlebox_e2e/test_cron_timed_fire_e2e.py
+++ b/src/backend/tests/community/core/task/singlebox_e2e/test_cron_timed_fire_e2e.py
@@ -40,13 +40,8 @@ import time
 import unittest
 import warnings
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 import httpx
-
-from agentclaw.community.core.task.task_discovery.task_reader import (
-    init_discovered_tasks_db,
-)
 
 # ---------------------------------------------------------------------------
 # 钉钉 SDK 依赖自检安装
@@ -73,7 +68,6 @@ def _ensure_dingtalk_sdk() -> None:
         pass
 
     venv_python = sys.executable
-    venv_dir = str(Path(venv_python).parent.parent)
 
     # 检测可用的安装方式
     if shutil.which("uv"):
@@ -149,12 +143,6 @@ _MOCK_TASKS: list[dict] = [
     },
 ]
 
-_DATA_FILE = Path(__file__).resolve()
-for _ in range(8):
-    _DATA_FILE = _DATA_FILE.parent
-_DATA_FILE = _DATA_FILE / "scripts" / ".dependencies" / "data" / "discovered_tasks.db"
-
-
 def _write_mock_data(bot_id: str, owner_id: str) -> None:
     tasks = []
     for t in _MOCK_TASKS:
@@ -163,8 +151,13 @@ def _write_mock_data(bot_id: str, owner_id: str) -> None:
         task["owner_id"] = owner_id
         task["task_id"] = f"timed_fire_{bot_id}_{owner_id}_{_TODAY}"
         tasks.append(task)
-    init_discovered_tasks_db(_DATA_FILE, tasks)
-    print(f"[setup] mock 数据已写入 {_DATA_FILE} ({len(tasks)} tasks, bot={bot_id})")
+    r = httpx.post(
+        f"{_BACKEND}/api/v1/collaboration/tasks/discovery/tasks",
+        json={"tasks": tasks},
+        timeout=15.0, headers=_HDRS,
+    )
+    r.raise_for_status()
+    print(f"[setup] written {len(tasks)} tasks via HTTP /discovery/tasks (bot={bot_id})")
 
 
 # ---------------------------------------------------------------------------
@@ -445,7 +438,7 @@ class TestCronTimedFireE2E(unittest.TestCase):
 
         print("\n[SUCCESS] cron 定时触发 e2e 验证通过！")
         print(f"  - cron='{cron_expr}' 在 {next_run} 自动 fire")
-        print(f"  - 任务发现执行，session 创建成功")
+        print("  - 任务发现执行，session 创建成功")
         print("  - 钉钉交互卡片 / 工单通知由 DiscoveryService 在发现时投递"
               "（钉钉需后端启动时配置凭证 env）")
 

--- a/src/backend/tests/community/core/task/singlebox_e2e/test_cron_timed_fire_workorder_e2e.py
+++ b/src/backend/tests/community/core/task/singlebox_e2e/test_cron_timed_fire_workorder_e2e.py
@@ -47,13 +47,8 @@ import time
 import unittest
 import warnings
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 
 import httpx
-
-from agentclaw.community.core.task.task_discovery.task_reader import (
-    init_discovered_tasks_db,
-)
 
 # ---------------------------------------------------------------------------
 # 配置
@@ -117,12 +112,6 @@ _MOCK_TASKS: list[dict] = [
     },
 ]
 
-_DATA_FILE = Path(__file__).resolve()
-for _ in range(8):
-    _DATA_FILE = _DATA_FILE.parent
-_DATA_FILE = _DATA_FILE / "scripts" / ".dependencies" / "data" / "discovered_tasks.db"
-
-
 def _write_mock_data(bot_id: str, owner_id: str) -> None:
     tasks = []
     for t in _MOCK_TASKS:
@@ -131,8 +120,13 @@ def _write_mock_data(bot_id: str, owner_id: str) -> None:
         task["owner_id"] = owner_id
         task["task_id"] = f"timed_fire_{bot_id}_{owner_id}_{_TODAY}"
         tasks.append(task)
-    init_discovered_tasks_db(_DATA_FILE, tasks)
-    print(f"[setup] mock 数据已写入 {_DATA_FILE} ({len(tasks)} tasks, bot={bot_id})")
+    r = httpx.post(
+        f"{_BACKEND}/api/v1/collaboration/tasks/discovery/tasks",
+        json={"tasks": tasks},
+        timeout=15.0, headers=_HDRS,
+    )
+    r.raise_for_status()
+    print(f"[setup] written {len(tasks)} tasks via HTTP /discovery/tasks (bot={bot_id})")
 
 
 # ---------------------------------------------------------------------------
@@ -474,7 +468,7 @@ class TestCronTimedFireWorkOrderE2E(unittest.TestCase):
 
         print("\n[SUCCESS] cron 定时触发 e2e 验证通过！")
         print(f"  - cron='{cron_expr}' 在 {next_run} 自动 fire")
-        print(f"  - 任务发现执行，session 创建成功")
+        print("  - 任务发现执行，session 创建成功")
 
         # ================================================================
         # Phase 6: 工单事件通知（可选 — 需 SINGLEBOX_WORKORDER_E2E=1 + 签名 key）
@@ -533,7 +527,7 @@ class TestCronTimedFireWorkOrderE2E(unittest.TestCase):
 
         print("\n[SUCCESS] 完整 e2e 验证通过！")
         print(f"  - cron='{cron_expr}' 在 {next_run} 自动 fire")
-        print(f"  - 任务发现执行，session 创建成功")
+        print("  - 任务发现执行，session 创建成功")
         print("  - 工单事件 NOTICE 投递成功 "
               f"(notification_ids={notification_ids})")
 

--- a/src/backend/tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py
+++ b/src/backend/tests/community/core/task/singlebox_e2e/test_task_discovery_e2e.py
@@ -24,11 +24,9 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import json
 import os
 import unittest
 from datetime import datetime
-from pathlib import Path
 
 import httpx
 
@@ -38,10 +36,6 @@ from agentclaw.community.core.task.task_discovery.discovery_service import (
 from agentclaw.community.core.task.task_discovery.models import DiscoveredTask
 from agentclaw.community.core.task.task_discovery.session_initiator import (
     CronRelaySessionInitiator,
-)
-from agentclaw.community.core.task.task_discovery.task_reader import (
-    SqliteTaskReader,
-    init_discovered_tasks_db,
 )
 from agentclaw.community.plugin_api.notify_sender import NotifyMessage
 
@@ -81,18 +75,58 @@ _EXPECTED_TASK_COUNT = len(_MOCK_TASKS)
 _EXPECTED_TASK_IDS = {t["task_id"] for t in _MOCK_TASKS}
 _EXPECTED_PROJECT_NAMES = {t["title"] for t in _MOCK_TASKS}
 
-# 默认 db 文件路径:上溯到项目根 → scripts/.dependencies/data/discovered_tasks.db
-_DATA_FILE = Path(__file__).resolve()
-for _ in range(8):
-    _DATA_FILE = _DATA_FILE.parent
-_DATA_FILE = _DATA_FILE / "scripts" / ".dependencies" / "data" / "discovered_tasks.db"
+class _InMemoryTaskReader:
+    """轻量内存 reader — 供直接构造 DiscoveryService 的 e2e 测试使用。
 
-
-def _write_mock_data(bot_id: str, owner_id: str) -> None:
-    """将内联测试数据写入 SQLite db,供 backend SqliteTaskReader 读取。
-
-    动态填充 bot_id/owner_id 与实际 bot 匹配。
+    返回预设的 DiscoveredTask 列表，替代旧 SqliteTaskReader 的文件读取。
     """
+
+    def __init__(self, tasks: list[DiscoveredTask]) -> None:
+        self._tasks = tasks
+
+    def read_discovered_tasks(self) -> list[DiscoveredTask]:
+        return list(self._tasks)
+
+    def read_pending_tasks(self) -> list[DiscoveredTask]:
+        return [t for t in self._tasks if t.needs_confirmation]
+
+    def read_pending_tasks_for_bot(
+        self, bot_id: str, owner_id: str, dt: str,
+    ) -> list[DiscoveredTask]:
+        return [
+            t for t in self.read_pending_tasks()
+            if t.bot_id == bot_id and t.owner_id == owner_id and t.dt == dt
+        ]
+
+
+def _build_mock_tasks(bot_id: str, owner_id: str) -> list[DiscoveredTask]:
+    """构建内联测试 DiscoveredTask 对象，动态填充 bot_id/owner_id。"""
+    tasks = []
+    for t in _MOCK_TASKS:
+        task = dict(t)
+        task["bot_id"] = bot_id
+        task["owner_id"] = owner_id
+        task["task_id"] = f"discover_task_{bot_id}_{owner_id}_{_TODAY}"
+        tasks.append(DiscoveredTask(
+            task_id=task["task_id"],
+            bot_id=task["bot_id"],
+            owner_id=task["owner_id"],
+            dt=task["dt"],
+            title=task["title"],
+            instruction=task.get("instruction", ""),
+            background=task.get("background", ""),
+            discovery_basis=task.get("discovery_basis", ""),
+            priority=task.get("priority", "medium"),
+            discovered_at=task.get("discovered_at"),
+            status=task.get("status", "pending_confirmation"),
+            objective=task.get("objective", ""),
+            acceptances=list(task.get("acceptances", [])),
+        ))
+    return tasks
+
+
+def _seed_backend(bot_id: str, owner_id: str) -> list[dict]:
+    """通过 HTTP /discovery/tasks 向 backend 写入 mock 数据。"""
     tasks = []
     for t in _MOCK_TASKS:
         task = dict(t)
@@ -100,8 +134,14 @@ def _write_mock_data(bot_id: str, owner_id: str) -> None:
         task["owner_id"] = owner_id
         task["task_id"] = f"discover_task_{bot_id}_{owner_id}_{_TODAY}"
         tasks.append(task)
-    init_discovered_tasks_db(_DATA_FILE, tasks)
-    print(f"[setup] mock 数据已写入 {_DATA_FILE} ({len(tasks)} tasks, bot={bot_id})")
+    r = httpx.post(
+        f"{_BACKEND}/api/v1/collaboration/tasks/discovery/tasks",
+        json={"tasks": tasks},
+        timeout=15.0, headers=_HDRS,
+    )
+    r.raise_for_status()
+    print(f"[setup] written {len(tasks)} tasks via HTTP /discovery/tasks (bot={bot_id})")
+    return tasks
 
 
 class _HttpCronRelay:
@@ -213,8 +253,9 @@ class TestTaskDiscoveryE2E(unittest.TestCase):
         owner_id = bot.get("owner_id", _USER_ID)
         print(f"[bot] 使用已有 bot: bot_id={bot_id} owner_id={owner_id}")
 
-        # 准备 mock 数据（动态填充 bot_id/owner_id）
-        _write_mock_data(bot_id, owner_id)
+        # 准备 mock 数据 — 向 backend 播种 + 本地内存 reader
+        _seed_backend(bot_id, owner_id)
+        self._mock_tasks = _build_mock_tasks(bot_id, owner_id)
 
         loop = asyncio.new_event_loop()
         try:
@@ -225,7 +266,7 @@ class TestTaskDiscoveryE2E(unittest.TestCase):
     async def _run(self, loop: asyncio.AbstractEventLoop, bot_id: str, owner_id: str) -> None:
         # ===== 直接构造 DiscoveryService（绕过 HTTP /discover 端点）=====
 
-        reader = SqliteTaskReader(str(_DATA_FILE))
+        reader = _InMemoryTaskReader(self._mock_tasks)
         relay = _HttpCronRelay(_BACKEND, _USER_ID)
         initiator = CronRelaySessionInitiator(cron_relay=relay)
         notifier = _MockNotifySender()
@@ -272,7 +313,7 @@ class TestTaskDiscoveryE2E(unittest.TestCase):
             self.assertIsNotNone(surl, f"任务 {tid} session_url 为空")
             self.assertTrue(notified, f"任务 {tid} 通知未发送")
 
-        # 3) 通过 SqliteTaskReader 直接验证任务状态（绕过 HTTP /status 端点）
+        # 3) 通过内存 reader 直接验证任务状态（绕过 HTTP /status 端点）
         all_tasks = reader.read_discovered_tasks()
         status_tasks = [
             t for t in all_tasks
@@ -285,8 +326,8 @@ class TestTaskDiscoveryE2E(unittest.TestCase):
             self.assertIn(t.bot_id, [bot_id], f"task {t.task_id} bot_id 不匹配")
             self.assertIn(t.owner_id, [owner_id], f"task {t.task_id} owner_id 不匹配")
             self.assertIsNotNone(t.dt, f"task {t.task_id} dt 为空")
-            self.assertIsNotNone(t.status, f"task status 为空")
-            self.assertIsNotNone(t.priority, f"task priority 为空")
+            self.assertIsNotNone(t.status, "task status 为空")
+            self.assertIsNotNone(t.priority, "task priority 为空")
 
         # 4) 验证 engine session 实际存在
         first_sid = results[0].session.session_id
@@ -381,7 +422,7 @@ class TestDiscoveryStatusE2E(unittest.TestCase):
         bot = active_bots[0] if active_bots else bots[0]
         self._bot_id = bot["bot_id"]
         self._owner_id = bot.get("owner_id", _USER_ID)
-        _write_mock_data(self._bot_id, self._owner_id)
+        _seed_backend(self._bot_id, self._owner_id)
         print(f"[setup] bot_id={self._bot_id} owner_id={self._owner_id}")
 
     def test_discover_then_status(self) -> None:

--- a/src/backend/tests/community/core/task/test_task_discovery_coverage.py
+++ b/src/backend/tests/community/core/task/test_task_discovery_coverage.py
@@ -13,15 +13,12 @@ Covers lines not exercised by test_task_discovery_unit.py:
 from __future__ import annotations
 
 import asyncio
-import json
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from agentclaw.community.core.task.task_discovery.discovery_service import (
     DiscoveryService,
-    DISCOVERY_LOCK_TTL_SECONDS,
 )
 from agentclaw.community.core.task.task_discovery.lock_models import (
     TaskDiscoveryLockRecord,
@@ -34,8 +31,7 @@ from agentclaw.community.core.task.task_discovery.session_initiator import (
     CronRelaySessionInitiator,
 )
 from agentclaw.community.core.task.task_discovery.task_reader import (
-    SqliteTaskReader,
-    init_discovered_tasks_db,
+    OrmTaskReader,
 )
 from agentclaw.community.plugin_api.notify_sender import (
     NotifyMessage,
@@ -299,26 +295,52 @@ def test_build_discovery_prompt_empty_acceptances():
 
 
 # ===========================================================================
-# _row_to_task with invalid JSON acceptances
+# DiscoveredTaskModel.to_domain with invalid JSON acceptances
 # ===========================================================================
 
-def test_row_to_task_invalid_acceptances_json(tmp_path):
-    """_row_to_task falls back to [] when acceptances is not valid JSON."""
-    db_path = str(tmp_path / "test_bad_acceptances.db")
-    init_discovered_tasks_db(db_path, [
-        {
-            "task_id": "t-bad",
-            "bot_id": "bot-1",
-            "owner_id": "owner-1",
-            "dt": _DT,
-            "title": "BadTask",
-            "instruction": "desc",
-            "background": "bg",
-            "discovery_basis": "basis",
-            "acceptances": "not-valid-json{{",
-        }
-    ])
-    reader = SqliteTaskReader(db_path)
+def test_orm_reader_invalid_acceptances_json():
+    """to_domain falls back to [] when acceptances column has non-JSON text."""
+    from contextlib import contextmanager
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from agentclaw.community.core.base import Base
+    from agentclaw.community.core.task.task_discovery.discovered_task_models import (  # noqa: F401
+        DiscoveredTaskModel,
+    )
+
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, autoflush=False)
+
+    # Insert a row with invalid JSON in acceptances column directly
+    db_session = factory()
+    row = DiscoveredTaskModel(
+        task_id="t-bad",
+        bot_id="bot-1",
+        owner_id="owner-1",
+        dt=_DT,
+        title="BadTask",
+        instruction="desc",
+        background="bg",
+        discovery_basis="basis",
+        acceptances="not-valid-json{{",
+    )
+    db_session.add(row)
+    db_session.commit()
+    db_session.close()
+
+    class _TestDB:
+        @contextmanager
+        def orm_session(self):
+            s = factory()
+            try:
+                yield s
+                s.commit()
+            finally:
+                s.close()
+
+    reader = OrmTaskReader(_TestDB())
     tasks = reader.read_pending_tasks_for_bot("bot-1", "owner-1", _DT)
     assert len(tasks) == 1
     assert tasks[0].acceptances == []

--- a/src/backend/tests/community/core/task/test_task_discovery_unit.py
+++ b/src/backend/tests/community/core/task/test_task_discovery_unit.py
@@ -2,7 +2,7 @@
 
 Covers:
   - DiscoveredTask new fields and methods (to_discovery_prompt, to_notification_body, to_card_data)
-  - SqliteTaskReader.read_pending_tasks_for_bot
+  - OrmTaskReader.read_pending_tasks_for_bot
   - DiscoveryService with SessionInitiator (mocked)
   - CronRelaySessionInitiator._build_discovery_prompt / _build_session_url
   - CronRelaySessionInitiator.initiate_session Step 2.5 title update (success/fail/exception)
@@ -12,10 +12,16 @@ from __future__ import annotations
 
 import asyncio
 import os
+from contextlib import contextmanager
 from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
+from agentclaw.community.core.task.task_discovery.discovered_task_models import (  # noqa: F401
+    DiscoveredTaskModel,
+)
 from agentclaw.community.core.task.task_discovery.discovery_service import (
     DiscoveryResult,
     DiscoveryService,
@@ -28,8 +34,8 @@ from agentclaw.community.core.task.task_discovery.session_initiator import (
     CronRelaySessionInitiator,
 )
 from agentclaw.community.core.task.task_discovery.task_reader import (
-    SqliteTaskReader,
-    init_discovered_tasks_db,
+    OrmTaskReader,
+    seed_discovered_tasks,
 )
 from agentclaw.community.plugin_api.notify_sender import (
     NotifyMessage,
@@ -103,41 +109,78 @@ class TestDiscoveredTask:
 
 
 # ---------------------------------------------------------------------------
-# SqliteTaskReader.read_pending_tasks_for_bot
+# OrmTaskReader.read_pending_tasks_for_bot
 # ---------------------------------------------------------------------------
 
-class TestTaskReader:
-    def _setup_db(self, tmpdir):
-        db = os.path.join(str(tmpdir), "test.db")
-        init_discovered_tasks_db(db, [
-            {
-                "task_id": "t1", "bot_id": "bot-001", "owner_id": "user-001",
-                "dt": _DT, "title": "Task1", "instruction": "d1",
-                "background": "s1", "discovery_basis": "b1",
-                "status": "pending_confirmation",
-                "objective": "Objective-1",
-                "acceptances": [{"id": "ac1", "description": "acc-1"}],
-            },
-            {
-                "task_id": "t2", "bot_id": "bot-002", "owner_id": "user-001",
-                "dt": _DT, "title": "Task2", "instruction": "d2",
-                "background": "s2", "discovery_basis": "b2",
-                "status": "pending_confirmation",
-                "objective": "",
-                "acceptances": [],
-            },
-            {
-                "task_id": "t3", "bot_id": "bot-001", "owner_id": "user-001",
-                "dt": _DT, "title": "Task3", "instruction": "d3",
-                "background": "s3", "discovery_basis": "b3",
-                "status": "confirmed",  # not pending
-            },
-        ])
-        return db
+class _InMemoryDB:
+    """In-memory SQLite database for unit testing (mimics DatabasePlugin)."""
 
-    def test_read_pending_for_bot(self, tmp_path):
-        db = self._setup_db(tmp_path)
-        reader = SqliteTaskReader(db)
+    def __init__(self):
+        self._engine = create_engine(
+            "sqlite:///:memory:", connect_args={"check_same_thread": False}
+        )
+        from agentclaw.community.core.base import Base
+        Base.metadata.create_all(self._engine)
+        self._session_factory = sessionmaker(bind=self._engine, autoflush=False)
+
+    @contextmanager
+    def orm_session(self):
+        db = self._session_factory()
+        try:
+            yield db
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+    @contextmanager
+    def transactional_orm_session(self):
+        db = self._session_factory()
+        try:
+            yield db
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+
+class TestTaskReader:
+    _MOCK_TASKS = [
+        {
+            "task_id": "t1", "bot_id": "bot-001", "owner_id": "user-001",
+            "dt": _DT, "title": "Task1", "instruction": "d1",
+            "background": "s1", "discovery_basis": "b1",
+            "status": "pending_confirmation",
+            "objective": "Objective-1",
+            "acceptances": [{"id": "ac1", "description": "acc-1"}],
+        },
+        {
+            "task_id": "t2", "bot_id": "bot-002", "owner_id": "user-001",
+            "dt": _DT, "title": "Task2", "instruction": "d2",
+            "background": "s2", "discovery_basis": "b2",
+            "status": "pending_confirmation",
+            "objective": "",
+            "acceptances": [],
+        },
+        {
+            "task_id": "t3", "bot_id": "bot-001", "owner_id": "user-001",
+            "dt": _DT, "title": "Task3", "instruction": "d3",
+            "background": "s3", "discovery_basis": "b3",
+            "status": "confirmed",  # not pending
+        },
+    ]
+
+    def _make_reader(self):
+        db = _InMemoryDB()
+        seed_discovered_tasks(db, self._MOCK_TASKS)
+        return OrmTaskReader(db)
+
+    def test_read_pending_for_bot(self):
+        reader = self._make_reader()
         tasks = reader.read_pending_tasks_for_bot("bot-001", "user-001", _DT)
         assert len(tasks) == 1
         assert tasks[0].bot_id == "bot-001"
@@ -145,22 +188,19 @@ class TestTaskReader:
         assert tasks[0].objective == "Objective-1"
         assert tasks[0].acceptances == [{"id": "ac1", "description": "acc-1"}]
 
-    def test_read_pending_for_wrong_bot(self, tmp_path):
-        db = self._setup_db(tmp_path)
-        reader = SqliteTaskReader(db)
+    def test_read_pending_for_wrong_bot(self):
+        reader = self._make_reader()
         tasks = reader.read_pending_tasks_for_bot("wrong-bot", "user-001", _DT)
         assert tasks == []
 
-    def test_read_pending_excludes_non_pending(self, tmp_path):
-        db = self._setup_db(tmp_path)
-        reader = SqliteTaskReader(db)
+    def test_read_pending_excludes_non_pending(self):
+        reader = self._make_reader()
         tasks = reader.read_pending_tasks_for_bot("bot-001", "user-001", _DT)
         # Task3 is "confirmed", not included
         assert all(t.needs_confirmation for t in tasks)
 
-    def test_read_all_backward_compat(self, tmp_path):
-        db = self._setup_db(tmp_path)
-        reader = SqliteTaskReader(db)
+    def test_read_all_backward_compat(self):
+        reader = self._make_reader()
         all_tasks = reader.read_discovered_tasks()
         assert len(all_tasks) == 3
 

--- a/src/backend/tests/community/endpoints/test_task_discovery_router.py
+++ b/src/backend/tests/community/endpoints/test_task_discovery_router.py
@@ -2,25 +2,20 @@
 
 Covers:
 - POST /api/v1/collaboration/tasks/discovery/discover (happy + error)
-- GET  /api/v1/collaboration/tasks/discovery/status  (happy + error)
+- GET  /api/v1/collaboration/tasks/discovery/status  (happy + coverage)
 
 Happy cases assert only ``{"code": 200000}`` — the handler returns the
 unified success ``Envelope`` when the discovery flow runs end-to-end,
-regardless of whether the DB file exists or individual task sessions
-fail (session-creation errors are captured per-task, not at the top
-level).  This makes the cases robust in both CI (no DB file → empty
-discoveries) and local dev (DB file present with seed data).
+regardless of whether any tasks are found in the DB (session-creation
+errors are captured per-task, not at the top level).  This makes the
+cases robust in both CI (empty DB → empty discoveries) and local dev
+(seeded DB with test data).
 
 The POST error case is a FastAPI 422 (missing required bot_id).
-The GET error case points the DB path at a directory, which makes
-sqlite3.connect() raise OperationalError outside the reader's inner
-try/except; the handler re-raises it as ``InternalError`` → the app's
-``DomainError`` handler answers a 500 ``ErrorEnvelope``.
+The status coverage case seeds tasks via ORM and verifies the
+aggregation of persisted tasks with process-local discovery results.
 """
 from __future__ import annotations
-
-import os
-from pathlib import Path
 
 from agentclaw.community.core.task.task_discovery.discovery_service import (
     DiscoveryResult,
@@ -31,8 +26,9 @@ from agentclaw.community.core.task.task_discovery.models import (
     DiscoverySession,
 )
 from agentclaw.community.core.task.task_discovery.task_reader import (
-    init_discovered_tasks_db,
+    seed_discovered_tasks,
 )
+from agentclaw.community.plugin_api.database import DatabasePlugin
 from tests.community.framework import (
     CaseInput,
     ExpectError,
@@ -82,51 +78,8 @@ def get_status_happy_ok():
     """Happy path: status endpoint returns success envelope."""
 
 
-# The error case for GET /status: point TASK_DISCOVERY_DATA_FILE at a
-# directory. Path.exists() returns True for a directory, so
-# SqliteTaskReader proceeds to sqlite3.connect() — which is OUTSIDE
-# the reader's inner try/except. connect() on a directory raises
-# sqlite3.OperationalError, propagating to the handler's except-Exception,
-# which re-raises it as InternalError → 500 ErrorEnvelope.
-_ERROR_DB_DIR = os.path.join(
-    os.environ.get("TMPDIR", "/tmp"),
-    "td_status_err_dir",
-)
-
-
-def _seed_status_error_dir(world) -> None:
-    """Create a directory at the error DB path and set the env var."""
-    os.makedirs(_ERROR_DB_DIR, exist_ok=True)
-    os.environ["TASK_DISCOVERY_DATA_FILE"] = _ERROR_DB_DIR
-
-
-def _cleanup_status_error_env(response, world) -> None:
-    """Restore TASK_DISCOVERY_DATA_FILE and remove the temp directory."""
-    os.environ.pop("TASK_DISCOVERY_DATA_FILE", None)
-    try:
-        os.rmdir(_ERROR_DB_DIR)
-    except OSError:
-        pass
-
-
-@endpoint_test(
-    method="GET",
-    path="/api/v1/collaboration/tasks/discovery/status",
-    scenario="err_db_path_is_directory",
-    seed=_seed_status_error_dir,
-    extra_assertions=(_cleanup_status_error_env,),
-    expect=ExpectError(status=500),
-)
-def get_status_err_db_path_is_directory():
-    """Error path: DB path is a directory -> sqlite3.connect raises -> InternalError -> 500."""
-
-
 # Exercise the status aggregation loop with both a task that has an in-memory
 # discovery result and one that has not been discovered in this process.
-_STATUS_COVERAGE_DB = Path(
-    os.environ.get("TMPDIR", "/tmp"),
-    "task_discovery_status_coverage.db",
-)
 _STATUS_DISCOVERED_TASK_ID = "status-discovered"
 _STATUS_PENDING_TASK_ID = "status-pending"
 
@@ -149,14 +102,11 @@ def _status_task(task_id: str) -> dict:
 
 
 def _seed_status_with_discovered_and_pending_tasks(world) -> None:
-    init_discovered_tasks_db(
-        _STATUS_COVERAGE_DB,
-        [
-            _status_task(_STATUS_DISCOVERED_TASK_ID),
-            _status_task(_STATUS_PENDING_TASK_ID),
-        ],
-    )
-    os.environ["TASK_DISCOVERY_DATA_FILE"] = str(_STATUS_COVERAGE_DB)
+    db = world.get(DatabasePlugin)
+    seed_discovered_tasks(db, [
+        _status_task(_STATUS_DISCOVERED_TASK_ID),
+        _status_task(_STATUS_PENDING_TASK_ID),
+    ])
     service = world.get(DiscoveryService)
     _task_dto = _status_task(_STATUS_DISCOVERED_TASK_ID)
     task = DiscoveredTask(
@@ -185,8 +135,12 @@ def _seed_status_with_discovered_and_pending_tasks(world) -> None:
 
 
 def _cleanup_status_coverage(response, world) -> None:
-    os.environ.pop("TASK_DISCOVERY_DATA_FILE", None)
-    _STATUS_COVERAGE_DB.unlink(missing_ok=True)
+    db = world.get(DatabasePlugin)
+    with db.transactional_orm_session() as session:
+        from agentclaw.community.core.task.task_discovery.discovered_task_models import (
+            DiscoveredTaskModel,
+        )
+        session.query(DiscoveredTaskModel).delete()
 
 
 @endpoint_test(
@@ -277,3 +231,126 @@ def dingtalk_config_happy():
 )
 def dingtalk_config_err_missing_body():
     """Error path: missing required body -> FastAPI 422."""
+
+
+# ---- GET /api/v1/collaboration/tasks/discovery/status ---- (error case)
+
+def _seed_status_reader_error(world) -> None:
+    """Override DatabasePlugin.orm_session to raise — OrmTaskReader propagates
+    a RuntimeError → handler catches → InternalError → 500 ErrorEnvelope."""
+    def _fail(*_args, **_kwargs):
+        raise RuntimeError("status read failed (gate)")
+
+    world.get(DatabasePlugin).set_override("orm_session", _fail)
+
+
+@endpoint_test(
+    method="GET",
+    path="/api/v1/collaboration/tasks/discovery/status",
+    scenario="error",
+    seed=_seed_status_reader_error,
+    expect=ExpectError(status=500),
+)
+def get_status_err_reader_failure():
+    """Error path: DatabasePlugin.orm_session raises → handler InternalError → 500."""
+
+
+# ---- POST /api/v1/collaboration/tasks/discovery/tasks ----
+
+def _seed_write_tasks_ok(world) -> None:
+    """Pre-clean ac_discovered_tasks so the upsert happy path runs against an empty table."""
+    db = world.get(DatabasePlugin)
+    from agentclaw.community.core.task.task_discovery.discovered_task_models import (
+        DiscoveredTaskModel,
+    )
+    with db.transactional_orm_session() as session:
+        session.query(DiscoveredTaskModel).delete()
+
+
+def _seed_write_tasks_error(world) -> None:
+    """Override DatabasePlugin.transactional_orm_session to raise → handler InternalError → 500."""
+    def _fail(*_args, **_kwargs):
+        raise RuntimeError("upsert failed (gate)")
+
+    world.get(DatabasePlugin).set_override("transactional_orm_session", _fail)
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/v1/collaboration/tasks/discovery/tasks",
+    scenario="happy",
+    input=CaseInput(json_body={
+        "tasks": [
+            {
+                "task_id": "td-write-1",
+                "bot_id": "td-bot-1",
+                "owner_id": "td-owner-1",
+                "dt": "2026-08-26",
+                "title": "Write-happy task",
+                "instruction": "instruction",
+                "background": "background",
+                "discovery_basis": "basis",
+                "priority": "medium",
+                "status": "pending_confirmation",
+                "objective": "",
+                "acceptances": [],
+            }
+        ]
+    }),
+    seed=_seed_write_tasks_ok,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"code": 200000},
+    ),
+)
+def write_tasks_happy():
+    """Happy path: upsert one task → returns Envelope with code=200000, written=1."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/api/v1/collaboration/tasks/discovery/tasks",
+    scenario="error",
+    seed=_seed_write_tasks_error,
+    input=CaseInput(json_body={"tasks": [
+        {"task_id": "td-err-1", "bot_id": "b", "owner_id": "o", "dt": "2026-08-26",
+         "title": "x", "instruction": "y", "background": "z"}
+    ]}),
+    expect=ExpectError(status=500),
+)
+def write_tasks_err_db_unavailable():
+    """Error path: DatabasePlugin.transactional_orm_session raises → InternalError → 500."""
+
+
+# ---- DELETE /api/v1/collaboration/tasks/discovery/tasks ----
+
+def _seed_clear_tasks_error(world) -> None:
+    """Override DatabasePlugin.transactional_orm_session to raise → handler InternalError → 500."""
+    def _fail(*_args, **_kwargs):
+        raise RuntimeError("clear failed (gate)")
+
+    world.get(DatabasePlugin).set_override("transactional_orm_session", _fail)
+
+
+@endpoint_test(
+    method="DELETE",
+    path="/api/v1/collaboration/tasks/discovery/tasks",
+    scenario="happy",
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"code": 200000},
+    ),
+)
+def clear_tasks_happy():
+    """Happy path: DELETE removes all rows (0 or more) → Envelope with code=200000."""
+
+
+@endpoint_test(
+    method="DELETE",
+    path="/api/v1/collaboration/tasks/discovery/tasks",
+    scenario="error",
+    seed=_seed_clear_tasks_error,
+    expect=ExpectError(status=500),
+)
+def clear_tasks_err_db_unavailable():
+    """Error path: DatabasePlugin.transactional_orm_session raises → InternalError → 500."""


### PR DESCRIPTION
## Problem

`origin/REL20260826` 上 task_discovery 模块的"已发现任务"数据存放在本地 SQLite 文件 `scripts/.dependencies/data/discovered_tasks.db`。这个方案在生产环境存在 4 个本质问题：

1. **多 pod 不共享**：cron-driven 的 discover 流程在每个 pod 自己的 SQLite 文件上跑，跨 pod 无法汇查"今天哪些任务被发现了"。
2. **闯入 DI**：`router.py` 中 `get_discovery_status` 直接 `new SqliteTaskReader(_resolve_db_path())`，绕开 DI 的 `TaskReader` singleton；handler 与 service 看到的不是同一份数据。
3. **env 访问侵入**：`_resolve_db_path()` 直接读 `TASK_DISCOVERY_DATA_FILE` env，违反 `docs/arch/arch.rules.md`"raw env access belongs in configuration loading / composition root"规则。
4. **测试靠 OS 文件系统**：所有 e2e 都要先 `init_discovered_tasks_db(file_path)`，CI 容器需要项目根可写；测出来的"持久化"是 OS 副作用，而不是 ORM 层覆盖。

## Solution

把任务数据持久化层从 SQLite 文件迁移到 SQLAlchemy ORM，由 DI 注入的 `DatabasePlugin` 统一提供 session：

- **prod**：通过 `DatabasePlugin.orm_session()` 走 ZDAS/OceanBase 上的新表 `ac_discovered_tasks`；DDL 由 PR 自带，DBA 建表即可生效
- **local / singlebox / test**：通过 `SqliteDB`（`plugins/local/database.py`）走 SQLite 内存库；`Base.metadata.create_all` 在新 ORM model 注册后自动建表

### 具体改动（16 文件 (+1012/−236)）

**新增**
- `core/task/task_discovery/discovered_task_models.py` — `DiscoveredTaskModel` ORM（表 `ac_discovered_tasks`），`to_domain()` 防御性解析 `acceptances` JSON
- `core/task/sql/2026_08_26_discovered_tasks.sql` — OceanBase DDL（`PRIMARY KEY(id)` + `UNIQUE KEY uk_ac_discovered_tasks_task_id(task_id) LOCAL` + `KEY idx_ac_discovered_tasks_bot_owner_dt`）
- `specs/2026-08-26-discovered-tasks-orm-persistence/{design,spec,tasks}.md` — 10 条 REQ + 20 项任务 + 改动范围/对比/契约/测试矩阵 

**修改**
- `core/task/task_discovery/task_reader.py` — 新增 `OrmTaskReader` 实现 `TaskReader` Protocol；新增 `upsert_discovered_tasks` / `clear_discovered_tasks` / `seed_discovered_tasks` 三只 helper；标 `SqliteTaskReader` 为 `.. deprecated::`
- `di/modules/task_discovery_module.py` — `_provide_task_reader` 改绑 `OrmTaskReader(db)`，删除 `_resolve_db_path` / `_DEFAULT_DB` 与 8 级上溯项目根逻辑
- `plugins/local/database.py` — `SqliteDB._setup_metadata` 加 side-effect `import …discovered_task_models  # noqa: F401  ac_discovered_tasks`，让 `create_all()` 覆盖新表
- `adapters/http/task/router.py` — `GET /discovery/status` 改为 `Injected(TaskReader)`，删除 handler 内联 `SqliteTaskReader(path)`；新增两条端点：
  - `POST /api/v1/collaboration/tasks/discovery/tasks` — upsert（按 `task_id` 自然键 insert/update），返回 `{"written": <int>}`
  - `DELETE /api/v1/collaboration/tasks/discovery/tasks` — 整表清空，返回 `{"deleted": <int>}`
- 测试：4 个 unit/coverage/router 测试改用 `OrmTaskReader` + in-memory SQLAlchemy + `DatabasePlugin` stub；4 个 singlebox e2e 测试改用 HTTP `POST /discovery/tasks` 播种 mock 数据；并删掉了与 SQLite 强绑定（指向 directory 触发 `OperationalError`）的旧错误路径

**拒绝的备选方案**
- 不引入"任务 Repository class"：`DiscoveredTaskModel` 是普通 CRUD 数据，没有锁 / 分布式原子操作语义，复用 `DatabasePlugin.orm_session()` 即可，与 `TaskDiscoveryLockRepository` 不同（后者要 ON CONFLICT 唯一约束仲裁，独立 Repository class）
- 不引入自动 migration（如 alembic）：OCB 后端历史上 DDL 走 DBA 人工建表（与 `lock_models.py` 同款）；本 PR 沿用此约定，让 PR 自然附 DDL 文件
- 不删除 `SqliteTaskReader`：保留为 deprecated 仅供旧测试构造，避免本轮 PR 影响范围扩大化（后续 PR 收紧）

## Validation

依照 `.github/workflows/unit-tests.yml` 的 `backend` job 范围（`pytest + coverage`，line_coverage_min=75），跑了 `src/backend` 下相关单测：

| 测试文件 | 结果 |
|---|---|
| `tests/community/core/task/test_task_discovery_unit.py` | 23 passed |
| `tests/community/core/task/test_task_discovery_coverage.py` | 27 passed |
| `tests/community/repository/task/test_task_discovery_lock_repository.py` | 11 passed |
| `tests/community/endpoints/test_task_discovery_router.py` | 3 passed |
| **合计** | **64 passed, 0 failed** |

| Lint | 结果 |
|---|---|
| `ruff check` 在所有改动文件上 | **All checks passed!**（自动修掉一批 unused import / f-string without placeholders；手动修复了 `test_task_discovery_e2e.py` 里 1 个 `F821 undefined name _write_mock_data`，改为同文件已有的 `_seed_backend`；删除 1 个 unused local `venv_dir`） |

**未运行的检查**：
- 完整 CI `ci_test.sh` 含覆盖率 + 通过率门槛需要在 ubuntu-latest + Python 3.12 上跑，依赖 PR 触发；本 PR 已确认 `ruff` + 相关单测全绿
- singlebox e2e（`SINGLEBOX_CRON_E2E=1 …`）依赖 baas / mosn / sofa-registry，本地默认 skip；**`test_cron_timed_fire_e2e.py` 已在另一环境本地 PASS（75.9 秒）**，验证 `POST /discovery/tasks` 播种 + `POST /discovery/reschedule` 运行时改 cron + 自然 fire 的整链路

## Compatibility and risk

- **生产环境部署前** DBA 必须建表 `ac_discovered_tasks`（由 `core/task/sql/2026_08_26_discovered_tasks.sql` 同步）；否则 `OrmTaskReader.read_discovered_tasks()` 会因表不存在 ORM 抛错
- **跨 pod 行为变化点**：之前每 pod 独立 SQLite 文件，现在共享 OceanBase 表 —— **discover / 确认链路跨 pod 可见**；prod 若仍想保留 per-pod 隔离（如灰度期间），需按 env 区分（本 PR 不做）
- **`TASK_DISCOVERY_DATA_FILE` env 在 DI 模块的读取点已删除**；如果有外部脚本/部署文档仍引用此 env，需要更新
- **`SqliteTaskReader` 仍保留为 deprecated**（仅旧测试构造路径使用），未从代码库删除，留给后续 PR 收紧
- **`POST /discovery/tasks` / `DELETE /discovery/tasks` 是新的写入端点**，鉴权沿用现有 task router；面向 e2e 测试与外部数据源写入，需 review 同意对外暴露面
- **回滚路径**：revert 该 commit 即可在生产回到 SQLite 文件版本；但前端 / e2e 已改为用 HTTP `POST /discovery/tasks` 播种，回滚后 e2e 需随之回滚（同步两个 PR 即可，无外部不可逆状态）

## Spec

- `src/backend/specs/2026-08-26-discovered-tasks-orm-persistence/design.md` — 改动范围对比 / 选址理由 / OrmTaskReader 与 LockRepository 同构参考 / DDL 落地路径 / 接口契约 / 测试矩阵
- `src/backend/specs/2026-08-26-discovered-tasks-orm-persistence/spec.md` — 10 条 REQ（DiscoveredTaskModel + DDL + OrmTaskReader + upsert/clear/seed helper + DI 绑定 + 数据库插件注册 + router 三个端点 + 测试迁移 + import 约束）
- `src/backend/specs/2026-08-26-discovered-tasks-orm-persistence/tasks.md` — 20 项任务清单（T1-T20）全部已勾选 ✓

## Related issues (optional)

延续 task_discovery 工作的落地链路：
- 前置 PR #1536（DiscoveredTask 字段对齐 TaskSpec + 双通知通道）—— 本 PR 沿用其字段集，不改 DiscoveredTask 领域模型
- 前置 PR #1538（list_tasks 按 user_id 过滤）—— 本 PR 不碰 list_tasks，无影响
- 前置 PR #1544（singlebox e2e 测试结构重构）—— 本 PR 的 e2e 改动在 #1544 拆分的 focused timed-fire + workorder suites 上做 mock 数据播种迁移
