### PR TITLE
feat(backend): admit delegated application callers to public harness APIs

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -528,33 +528,33 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     ("GET", "/openapi/v1/bots/{bot_id}/models/{model_id:path}"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     ("GET", "/openapi/v1/bots/{bot_id}/connection"): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     # harness — bot-scoped diagnostics and patching under the addressed bot.
-    # These operations are intentionally user-only for now: harness access is
-    # checked against the verified user's owner/collaborator relationship, and
-    # app-only delegation is not part of this public contract.
+    # These operations now go through the addressed-bot grant seam so that both
+    # human collaborators and delegated application callers can reach the bot,
+    # with the owner resolved by the harness access dependency itself.
     (
         "POST",
         "/openapi/v1/bots/{bot_id}/harness/diagnose",
-    ): AdmissionMode.REFUSED,
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
         "POST",
         "/openapi/v1/bots/{bot_id}/harness/preview",
-    ): AdmissionMode.REFUSED,
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
         "POST",
         "/openapi/v1/bots/{bot_id}/harness/apply",
-    ): AdmissionMode.REFUSED,
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
         "POST",
         "/openapi/v1/bots/{bot_id}/harness/rollback",
-    ): AdmissionMode.REFUSED,
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
         "GET",
         "/openapi/v1/bots/{bot_id}/harness/dim-report",
-    ): AdmissionMode.REFUSED,
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
         "GET",
         "/openapi/v1/bots/{bot_id}/harness/dim-history",
-    ): AdmissionMode.REFUSED,
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     # ── B: returns a set of bots, narrowed to the granted ones ───────────────
     ("GET", "/openapi/v1/bots"): AdmissionMode.GRANT_FILTERED,
     # The application's own view, and the **complete** one: a granted bot the
@@ -794,15 +794,19 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
 #: make any future handler-level grant exception visible in review.
 SKILL_SCOPED_OPERATIONS = frozenset()
 
-#: No current harness operation self-checks an app-only grant. Harness is a
-#: user-only surface for now, so app-only callers are refused before the
-#: harness owner/collaborator access dependency runs.
-HARNESS_SCOPED_OPERATIONS = frozenset()
-
-#: No current harness operation self-checks an app-only grant. Harness is a
-#: user-only surface for now, so app-only callers are refused before the
-#: harness owner/collaborator access dependency runs.
-HARNESS_SCOPED_OPERATIONS = frozenset()
+#: Harness operations resolve the bot owner from the repository record rather
+#: than from an ``owner_id`` query parameter. This preserves the existing wire
+#: contract (``bot_id`` on the path, ``user_id`` in the query) while still
+#: running an addressed-bot grant check for application callers inside the
+#: handler's own ``require_harness_bot_access`` dependency.
+HARNESS_SCOPED_OPERATIONS = frozenset({
+    ("POST", "/openapi/v1/bots/{bot_id}/harness/diagnose"),
+    ("POST", "/openapi/v1/bots/{bot_id}/harness/preview"),
+    ("POST", "/openapi/v1/bots/{bot_id}/harness/apply"),
+    ("POST", "/openapi/v1/bots/{bot_id}/harness/rollback"),
+    ("GET", "/openapi/v1/bots/{bot_id}/harness/dim-report"),
+    ("GET", "/openapi/v1/bots/{bot_id}/harness/dim-history"),
+})
 
 #: The modes that admit a caller naming no end user. Everything else refuses at
 #: ``require_principal``, which is what a route inherits by saying nothing.
@@ -959,6 +963,7 @@ class ActingCaller:
 __all__ = [
     "ADMISSION",
     "ADMITTING_MODES",
+    "HARNESS_SCOPED_OPERATIONS",
     "SKILL_SCOPED_OPERATIONS",
     "ActingCaller",
     "AdmissionMode",

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/harness/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/harness/router.py
@@ -8,8 +8,8 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
 
 from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope, ERROR_RESPONSES
 from agentclaw.community.adapters.http.openapi_v1.principal import (
+    ActingCallerDep,
     UserIdDep,
-    refuse_app_only_caller,
 )
 from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope,
@@ -70,26 +70,29 @@ logger = get_logger()
 router = APIRouter(
     prefix="/openapi/v1/bots/{bot_id}/harness",
     tags=["harness"],
-    dependencies=[Depends(refuse_app_only_caller)],
     route_class=PublicAPIRoute,
 )
 
 
 async def require_harness_bot_access(
-    user_id: UserIdDep,
+    caller: ActingCallerDep,
     bot_id: Annotated[str, Path(..., description="Bot ID")],
     bot_repo: BotRepository = Injected(BotRepository),
     collaborator_service: CollaboratorServiceProtocol = Injected(CollaboratorServiceProtocol),
 ) -> str:
     """Ensure the caller may operate on *bot_id* in harness context.
 
-    Resolves the bot owner and either:
-    - returns silently if the caller is the owner, or
-    - checks collaborator permission via CollaboratorService.
+    The harness surface now participates in the addressed-bot grant seam: an
+    application calling alone must hold a live grant for ``(app_id, bot_id,
+    owner_id, user_id)``. Once the grant resolves, the owner is read from the
+    resolved bot record and the usual owner/collaborator check is applied.
 
-    Raises HTTPException 404 (not 403) on failure, matching the public surface
-    convention that existence and authorization are indistinguishable.
+    This keeps the wire contract unchanged: callers still supply only ``bot_id``
+    on the path and ``user_id`` as the query parameter; the owner is resolved
+    from the repository rather than demanded as a parameter.
     """
+    user_id = caller.user_id
+
     if bot_id == "default":
         return user_id
 
@@ -100,6 +103,22 @@ async def require_harness_bot_access(
     owner_id = bot.get("owner_id") if isinstance(bot, dict) else getattr(bot, "owner_id", None)
     if not owner_id:
         raise HTTPException(status_code=404, detail="Not found")
+
+    if caller.is_application:
+        if caller.grants is None:
+            raise HTTPException(status_code=404, detail="Not found")
+        try:
+            record = caller.grants.find(
+                bot_id=bot_id,
+                owner_id=owner_id,
+                user_id=user_id,
+                app_id=caller.app_id,
+            )
+        except Exception as exc:
+            logger.warning("[harness] grant lookup failed: %s", exc)
+            raise HTTPException(status_code=404, detail="Not found") from exc
+        if record is None:
+            raise HTTPException(status_code=404, detail="Not found")
 
     if user_id == owner_id:
         return user_id

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_admission_inventory.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_admission_inventory.py
@@ -35,6 +35,7 @@ from agentclaw.community.adapters.http.openapi_v1.deprecated import (
 from agentclaw.community.adapters.http.openapi_v1.admission import (
     ADMISSION,
     ADMITTING_MODES,
+    HARNESS_SCOPED_OPERATIONS,
     SKILL_SCOPED_OPERATIONS,
     AdmissionMode,
 )
@@ -181,17 +182,21 @@ def test_every_grant_checked_operation_declares_its_modes_dependency(mode):
     valid grant on a shared bot. Neither is a smaller mistake than a missing
     check.
 
-    Two named sets are excluded, for the same underlying reason and with
+    Three named sets are excluded, for the same underlying reason and with
     different lifetimes. ``SKILL_SCOPED_OPERATIONS`` — the four current
     ``{skill_id}`` operations — resolve the bot's owner from the skill record,
     so there is nothing for a dependency to look a grant up against until the
-    handler has read it. The retiring addresses in ``SELF_CHECKED_ROUTES`` are
-    the same problem in the old contract's shape: their bot is in a request body
-    or behind a skill id, and mounting them under a dependency would refuse an
-    application outright rather than defer, turning a working legacy call into a
-    404. Both check it themselves, first, before acting; the second set is empty
-    the day the deprecated package goes. ``test_only_the_named_operations_
-    check_their_own_grant`` is what stops either from growing quietly.
+    handler has read it. ``HARNESS_SCOPED_OPERATIONS`` keep the existing
+    harness wire contract (bot id on the path, user id in the query) by
+    resolving the bot owner from the repository record and checking the grant
+    inside ``require_harness_bot_access``. The retiring addresses in
+    ``SELF_CHECKED_ROUTES`` are the same problem in the old contract's shape:
+    their bot is in a request body or behind a skill id, and mounting them
+    under a dependency would refuse an application outright rather than defer,
+    turning a working legacy call into a 404. All check it themselves, first,
+    before acting; the third set is empty the day the deprecated package goes.
+    ``test_only_the_named_operations_check_their_own_grant`` is what stops any
+    of them from growing quietly.
     """
     dependency = _GRANT_DEPENDENCY_BY_MODE[mode]
     expected = {
@@ -200,6 +205,7 @@ def test_every_grant_checked_operation_declares_its_modes_dependency(mode):
         if table_mode is mode
         and key not in SELF_CHECKED_ROUTES
         and key not in SKILL_SCOPED_OPERATIONS
+        and key not in HARNESS_SCOPED_OPERATIONS
     }
     actual = {
         key
@@ -253,7 +259,7 @@ def test_only_the_named_operations_check_their_own_grant():
         and not _depends_on(_dependant_of(ctx), require_granted_addressed_bot)
         and key not in LEGACY_ROUTES
     }
-    named = SKILL_SCOPED_OPERATIONS
+    named = SKILL_SCOPED_OPERATIONS | HARNESS_SCOPED_OPERATIONS
     assert self_checking == named, (
         "the set of operations checking their grant in a handler has changed. "
         "Adding one is an edit to admission.SKILL_SCOPED_OPERATIONS and "
@@ -269,7 +275,7 @@ def test_the_self_checking_operations_are_still_grant_checked():
     """Self-checking is about *where* the check runs, never *whether*."""
     wrong_mode = sorted(
         f"{m} {p}"
-        for m, p in SKILL_SCOPED_OPERATIONS
+        for m, p in SKILL_SCOPED_OPERATIONS | HARNESS_SCOPED_OPERATIONS
         if ADMISSION.get((m, p)) not in _GRANT_CHECKED_MODES
     )
     assert not wrong_mode, wrong_mode

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_self_checked_routes_refuse.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_self_checked_routes_refuse.py
@@ -44,12 +44,17 @@ from injector import Injector, Module
 
 from agentclaw.community.adapters.http.openapi_v1 import build_public_router
 from agentclaw.community.adapters.http.openapi_v1.admission import (
+    HARNESS_SCOPED_OPERATIONS,
     SKILL_SCOPED_OPERATIONS,
 )
 from agentclaw.community.adapters.http.openapi_v1.deprecated import SELF_CHECKED_ROUTES
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.api.bot_app_grant_service import BotAppGrantServiceProtocol
 from agentclaw.community.api.cron_relay_service import CronRelayServiceProtocol
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.api.collaborator_service import (
+    CollaboratorServiceProtocol,
+)
 from agentclaw.community.api.local_skill_delete_service import (
     LocalSkillDeleteServiceProtocol,
 )
@@ -100,6 +105,39 @@ class _NoGrants:
 
     def list_for_app(self, **_kwargs):
         return []
+
+
+class _NoBot:
+    """The harness surface resolves the owner from the repository record."""
+
+    def get_by_id(self, bot_id: str):
+        return {
+            "id": 1,
+            "bot_id": bot_id,
+            "owner_id": USER,
+            "bot_name": "stub-bot",
+            "status": "ACTIVE",
+            "bot_type": "personal",
+        }
+
+
+class _NoCollaborators:
+    """No live collaborator relationship."""
+
+    def list_collaborators(self, **_kwargs):
+        return []
+
+    def check_collaborator_permission(self, **_kwargs):
+        return {"has_permission": False}
+
+    def get_permission_level(self, *_args, **_kwargs):
+        return "none"
+
+    def get_operable_permission_level(self, **_kwargs):
+        return "none"
+
+    def on_collaboration_changed(self, **_kwargs):
+        return None
 
 
 class _Services:
@@ -183,6 +221,8 @@ def client(services):
     class _M(Module):
         def configure(self, binder):
             binder.bind(BotAppGrantServiceProtocol, to=_NoGrants())
+            binder.bind(BotRepository, to=_NoBot())
+            binder.bind(CollaboratorServiceProtocol, to=_NoCollaborators())
             binder.bind(CronRelayServiceProtocol, to=services)
             for protocol in (
                 SkillQueryServiceProtocol,
@@ -201,11 +241,13 @@ def client(services):
 
 
 def _concrete(path: str) -> str:
-    """A callable URL for a route template, with the bot named in the query.
+    """A callable URL for a route template.
 
-    ``bot_id`` is appended unconditionally: the retiring collection addresses
-    require it there, and on a route that does not declare it an extra query
-    parameter is ignored — so one spelling serves every row.
+    Path parameters are interpolated directly. ``user_id`` and an extra
+    ``bot_id`` query parameter are appended for routes that need them:
+    the retiring collection addresses require ``bot_id`` in the query, and
+    on a route that does not declare it an extra query parameter is ignored.
+    Harness paths already carry ``bot_id`` in the path.
     """
     filled = "/".join(
         {"{skill_id}": SKILL, "{routine_id}": "r-1", "{bot_id}": BOT}.get(
@@ -213,13 +255,19 @@ def _concrete(path: str) -> str:
         )
         for segment in path.split("/")
     )
-    return f"{filled}?user_id={USER}&bot_id={BOT}"
+    query = f"?user_id={USER}"
+    if "{bot_id}" not in path:
+        query += f"&bot_id={BOT}"
+    return f"{filled}{query}"
 
 
-#: Both sets, because they are the same risk with different lifetimes: the
-#: retiring addresses go with the deprecated package, the four skill-addressed
-#: ones are the current contract.
-SELF_CHECKED = sorted(set(SELF_CHECKED_ROUTES) | set(SKILL_SCOPED_OPERATIONS))
+#: All three sets, because they are the same risk with different lifetimes:
+#: the retiring addresses go with the deprecated package, the four skill-
+#: addressed ones are the current contract, and the harness operations resolve
+#: the bot owner from the repository record rather than from a wire parameter.
+SELF_CHECKED = sorted(
+    set(SELF_CHECKED_ROUTES) | set(SKILL_SCOPED_OPERATIONS) | set(HARNESS_SCOPED_OPERATIONS)
+)
 
 #: What each write needs on the wire to get past validation and reach the point
 #: where a missing grant check would show. A row that 422s would pass this test
@@ -232,6 +280,18 @@ BODIES: dict[tuple[str, str], dict] = {
             "command": "echo hi",
             "trigger": {"cron": "0 0 * * *"},
         }
+    },
+    ("POST", "/openapi/v1/bots/{bot_id}/harness/diagnose"): {
+        "json": {"entity_type": "staff", "entity_id": USER},
+    },
+    ("POST", "/openapi/v1/bots/{bot_id}/harness/preview"): {
+        "json": {"entity_type": "staff", "entity_id": USER, "patch_id_list": [1]},
+    },
+    ("POST", "/openapi/v1/bots/{bot_id}/harness/apply"): {
+        "json": {"entity_type": "staff", "entity_id": USER, "patch_id_list": [1]},
+    },
+    ("POST", "/openapi/v1/bots/{bot_id}/harness/rollback"): {
+        "json": {"entity_type": "staff", "entity_id": USER, "patch_id": 1},
     },
     ("POST", "/openapi/v1/bots/skills/upload"): {
         "content": b"PK\x03\x04",

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_self_checked_routes_refuse.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_self_checked_routes_refuse.py
@@ -107,6 +107,16 @@ class _NoGrants:
         return []
 
 
+class _GrantLookupFails:
+    """The grant service itself fails while looking up the authorization."""
+
+    def find(self, **_kwargs):
+        raise RuntimeError("grant store unavailable")
+
+    def list_for_app(self, **_kwargs):
+        return []
+
+
 class _NoBot:
     """The harness surface resolves the owner from the repository record."""
 
@@ -216,11 +226,11 @@ def services():
     return _Services()
 
 
-@pytest.fixture
-def client(services):
+def _make_client(services, grant_service):
     class _M(Module):
         def configure(self, binder):
-            binder.bind(BotAppGrantServiceProtocol, to=_NoGrants())
+            if grant_service is not None:
+                binder.bind(BotAppGrantServiceProtocol, to=grant_service)
             binder.bind(BotRepository, to=_NoBot())
             binder.bind(CollaboratorServiceProtocol, to=_NoCollaborators())
             binder.bind(CronRelayServiceProtocol, to=services)
@@ -238,6 +248,21 @@ def client(services):
     attach_injector(app, Injector([_M()]))
     mount_public_error_handlers(app)
     return user_scoped_client(app, USER)
+
+
+@pytest.fixture
+def client(services):
+    return _make_client(services, _NoGrants())
+
+
+@pytest.fixture
+def client_without_grant_service(services):
+    return _make_client(services, None)
+
+
+@pytest.fixture
+def client_with_failing_grant_lookup(services):
+    return _make_client(services, _GrantLookupFails())
 
 
 def _concrete(path: str) -> str:
@@ -259,6 +284,36 @@ def _concrete(path: str) -> str:
     if "{bot_id}" not in path:
         query += f"&bot_id={BOT}"
     return f"{filled}{query}"
+
+
+def test_harness_refuses_application_when_grant_service_is_unbound(
+    client_without_grant_service, services
+) -> None:
+    """ ``require_harness_bot_access`` fails closed when no grant reader is wired."""
+    response = client_without_grant_service.request(
+        "POST",
+        _concrete("/openapi/v1/bots/{bot_id}/harness/diagnose"),
+        json={"entity_type": "staff", "entity_id": USER},
+    )
+    assert response.status_code == 404, response.text
+    assert not services.acted, (
+        "refusing an application with no grant reader must not reach the operation"
+    )
+
+
+def test_harness_refuses_application_when_grant_lookup_raises(
+    client_with_failing_grant_lookup, services
+) -> None:
+    """An unexpected grant-store failure is mapped to the same masked 404."""
+    response = client_with_failing_grant_lookup.request(
+        "POST",
+        _concrete("/openapi/v1/bots/{bot_id}/harness/diagnose"),
+        json={"entity_type": "staff", "entity_id": USER},
+    )
+    assert response.status_code == 404, response.text
+    assert not services.acted, (
+        "refusing an application when grant lookup raises must not reach the operation"
+    )
 
 
 #: All three sets, because they are the same risk with different lifetimes:

--- a/src/backend/tests/community/endpoints/test_openapi_harness.py
+++ b/src/backend/tests/community/endpoints/test_openapi_harness.py
@@ -33,6 +33,9 @@ from agentclaw.community.core.harness.models import (
     Layer,
     PatchDefinition,
 )
+from agentclaw.community.api.bot_app_grant_service import (
+    BotAppGrantServiceProtocol,
+)
 from agentclaw.community.core.repository.protocols.bot import (
     BotAppGrantRepositoryProtocol,
     BotRepository,
@@ -201,6 +204,20 @@ def _seed_collaborator_grant(world, caller_id: str = _COLLABORATOR) -> None:
             "user_id": caller_id,
             "owner_id": _OWNER,
         }
+    )
+
+
+def _seed_grant_reader_error(world, caller_id: str = _COLLABORATOR) -> None:
+    """Seed the bot/patch and stand in a grant service whose lookup raises."""
+    _seed_patch_with_engine(world)
+    bind_overrides(
+        world,
+        BotAppGrantServiceProtocol,
+        {
+            "find": lambda *_a, **_kw: (_ for _ in ()).throw(
+                RuntimeError("grant lookup failure")
+            ),
+        },
     )
 
 
@@ -419,6 +436,26 @@ def apply_application_with_grant_is_allowed():
 )
 def apply_application_without_grant_is_refused():
     """An app-only caller holding no grant is refused before the engine runs."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/harness/apply",
+    scenario="application_grant_lookup_error_is_refused",
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID},
+        query_params={"user_id": _COLLABORATOR},
+        headers=_APP_HEADERS,
+        json_body={**_BODY_ENTITY, "entity_id": _COLLABORATOR, "patch_id_list": [_PATCH_ID]},
+    ),
+    seed=_seed_grant_reader_error,
+    expect=ExpectError(
+        status=404,
+        json_contains={"code": 404000, "message": "Not Found", "data": None},
+    ),
+)
+def apply_application_grant_lookup_error_is_refused():
+    """An app-only caller whose grant lookup raises is refused, not 500."""
 
 
 @endpoint_test(

--- a/src/backend/tests/community/endpoints/test_openapi_harness.py
+++ b/src/backend/tests/community/endpoints/test_openapi_harness.py
@@ -33,7 +33,11 @@ from agentclaw.community.core.harness.models import (
     Layer,
     PatchDefinition,
 )
-from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.repository.protocols.bot import (
+    BotAppGrantRepositoryProtocol,
+    BotRepository,
+    CollaboratorRepositoryProtocol,
+)
 from agentclaw.community.core.repository.protocols.harness import (
     HarnessPatchRepository,
     HarnessScanRecordRepository,
@@ -57,6 +61,8 @@ _ENTITY_TYPE = "staff"
 # The per-test SQLite database is fresh for every case, so the first row in
 # ac_harness_patch is always id 1 — the same convention the skills cases use
 # for their first seeded Skill.
+_APP_ID = 99
+_COLLABORATOR = "harness-collaborator"
 _PATCH_ID = 1
 _PATCH_CONTENT = json.dumps(
     [
@@ -100,7 +106,42 @@ def _principal() -> str:
     )
 
 
+def _app_principal(caller_id: str = _COLLABORATOR) -> str:
+    """A gateway-signed principal naming an application and a delegating user."""
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 3600,
+            "principals": [
+                {
+                    "type": "app",
+                    "tenant": "teamclaw",
+                    "app": {
+                        "app_id": _APP_ID,
+                        "app_name": "harness-partner",
+                        "owners": "platform-team",
+                        "tenant": "teamclaw",
+                    },
+                },
+                {
+                    "type": "user",
+                    "subject": {
+                        "id": caller_id,
+                        "username": f"{caller_id}@example.test",
+                    },
+                },
+            ],
+        },
+        _KEY,
+        algorithm="HS256",
+    )
+
+
 _HEADERS = {PRINCIPAL_HEADER: _principal()}
+_APP_HEADERS = {PRINCIPAL_HEADER: _app_principal()}
 _QUERY = {"user_id": _OWNER}
 _BODY_ENTITY = {"entity_type": _ENTITY_TYPE, "entity_id": _OWNER}
 
@@ -125,6 +166,42 @@ def _seed_bot(world) -> None:
 
 def _seed_no_bot(world) -> None:
     init_principal_verifier_config(_Resolver(), "test-key", strict=False)
+
+
+def _seed_collaborator_grant(world, caller_id: str = _COLLABORATOR) -> None:
+    """Seed the bot, an admin collaborator, and a live app grant for them."""
+    _seed_bot(world)
+    bot = world.get(BotRepository).get_by_id(_BOT_ID)
+    world.get(CollaboratorRepositoryProtocol).insert(
+        {
+            "bot_pk": bot["id"],
+            "bot_id": _BOT_ID,
+            "owner_id": _OWNER,
+            "user_id": caller_id,
+            "user_name": caller_id,
+            "role": "admin",
+            "operator_id": _OWNER,
+        }
+    )
+    _insert_patch(world)
+    bind_overrides(
+        world,
+        PatchEngineProtocol,
+        {
+            "preview": _preview_ok,
+            "apply": _apply_ok,
+            "rollback_by_patch": _rollback_ok,
+        },
+    )
+    world.get(BotAppGrantRepositoryProtocol).grant(
+        {
+            "app_id": _APP_ID,
+            "app_name": "harness-partner",
+            "bot_id": _BOT_ID,
+            "user_id": caller_id,
+            "owner_id": _OWNER,
+        }
+    )
 
 
 def _insert_patch(world) -> None:
@@ -302,6 +379,46 @@ def preview_missing_patch_is_404():
 )
 def apply_marks_the_patch_applied():
     """With no prior record the handler plans one, applies, and flags the patch."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/harness/apply",
+    scenario="application_with_grant_applies_patch",
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID},
+        query_params={"user_id": _COLLABORATOR},
+        headers=_APP_HEADERS,
+        json_body={**_BODY_ENTITY, "entity_id": _COLLABORATOR, "patch_id_list": [_PATCH_ID]},
+    ),
+    seed=_seed_collaborator_grant,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={"code": 200000, "data": {"success": True}},
+    ),
+)
+def apply_application_with_grant_is_allowed():
+    """An app-only caller with a live grant is admitted and controls the bot."""
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/harness/apply",
+    scenario="application_without_grant_is_refused",
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID},
+        query_params={"user_id": _COLLABORATOR},
+        headers=_APP_HEADERS,
+        json_body={**_BODY_ENTITY, "entity_id": _COLLABORATOR, "patch_id_list": [_PATCH_ID]},
+    ),
+    seed=_seed_patch_with_engine,
+    expect=ExpectError(
+        status=404,
+        json_contains={"code": 404000, "message": "Not Found", "data": None},
+    ),
+)
+def apply_application_without_grant_is_refused():
+    """An app-only caller holding no grant is refused before the engine runs."""
 
 
 @endpoint_test(

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -420,10 +420,13 @@ user_config:
 
 # The harness operations sit beneath the addressed bot, so the wide
     # "/openapi/v1/bots/**" rule above would otherwise admit them with no user
-    # on the wire. They diagnose and patch a bot's live config files — a human
-    # stays on the boundary, and the extra literal segment outranks the prefix.
+    # on the wire. They now participate in the addressed-bot grant seam and
+    # accept delegated application callers in addition to human operators; the
+    # extra literal segment outranks the prefix, and backend admission checks
+    # the grant once the request reaches it.
     "/openapi/v1/bots/{bot_id}/harness/**":
-      user: required
+      user: optional
+      app: optional
 
     # HarnessFlow (task escort) — served by clawweb. Authz is delegated to
     # clawweb; the gateway passes through both identities when present.

--- a/src/gateway/tests/unit/core/forwarding/test_domain_map.py
+++ b/src/gateway/tests/unit/core/forwarding/test_domain_map.py
@@ -311,8 +311,9 @@ def test_shipped_config_routes_harness_to_backend() -> None:
     )
     assert harness.schema.location == "schemas/bots.openapi.json"
 
-    # One rule beneath /openapi/v1/bots/** keeps a user on the wire for every
-    # harness operation, outranking the wide prefix on literal segments.
+    # The harness-specific rule now allows both human operators and delegated
+    # application callers, outranking the wide ``/openapi/v1/bots/**`` prefix on
+    # literal segments. The backend admission check enforces the live grant.
     for method, path in [
         ("POST", "/openapi/v1/bots/bot-1/harness/diagnose"),
         ("POST", "/openapi/v1/bots/bot-1/harness/preview"),
@@ -323,7 +324,8 @@ def test_shipped_config_routes_harness_to_backend() -> None:
     ]:
         requirement = security.resolve(method, path)
         assert requirement is not None, path
-        assert requirement[PrincipalType.USER] is Presence.REQUIRED, path
+        assert requirement[PrincipalType.USER] is Presence.OPTIONAL, path
+        assert requirement[PrincipalType.APP] is Presence.OPTIONAL, path
 
     # The old shape is unrouted: with the harness domain gone, no domain claims
     # /openapi/v1/harness/** and the gateway refuses it rather than forwarding.

--- a/src/gateway/tests/unit/core/forwarding/test_served_openapi.py
+++ b/src/gateway/tests/unit/core/forwarding/test_served_openapi.py
@@ -34,7 +34,7 @@ _BCN_INTERNAL_ARTIFACT = (
 )
 _SHIPPED_CONFIG = Path(__file__).resolve().parents[4] / "configs" / "application.yaml"
 _METHODS = {"get", "post", "put", "delete", "patch"}
-_RULES = RouteSecurity.from_table({"/**": {"user": "required"}})
+_RULES = RouteSecurity.from_table({"/**": {"user": "optional", "app": "optional"}})
 _SHIPPED_RULES = RouteSecurity.from_yaml(_SHIPPED_CONFIG)
 
 

--- a/src/gateway/tests/unit/core/forwarding/test_served_openapi.py
+++ b/src/gateway/tests/unit/core/forwarding/test_served_openapi.py
@@ -89,9 +89,10 @@ def test_every_served_operation_carries_security() -> None:
     for path, item in _served()["paths"].items():
         for method, operation in item.items():
             if method in _METHODS:
-                assert operation["x-avernet-security"] == {"user": "required"}, (
-                    f"{method} {path}"
-                )
+                assert operation["x-avernet-security"] == {
+                    "user": "optional",
+                    "app": "optional",
+                }, f"{method} {path}"
 
 
 def test_components_pruned_to_referenced() -> None:
@@ -355,8 +356,8 @@ def test_harness_paths_served_with_user_security() -> None:
     They live under ``/openapi/v1/bots/{bot_id}/harness/…`` now, so the bots
     domain routes and documents them: no separate domain can pin a match behind
     the ``{bot_id}`` parameter, and the bots artifact carries their description.
-    Their rule is the one thing that stays their own — a user on the wire,
-    outranking the wide optional rule the rest of the bots surface admits.
+    Their rule is the one thing that stays their own — both user and app are
+    optional, with the backend admission check enforcing the live grant.
     """
     dm = DomainMap.from_yaml(_SHIPPED_CONFIG, variables=_BCSFUSE_VARS)
     mount_prefixes = {name: domain.mount_prefix for name, domain in dm.domains.items()}
@@ -387,6 +388,7 @@ def test_harness_paths_served_with_user_security() -> None:
     for path in harness_paths:
         for method, operation in document["paths"][path].items():
             if method in _METHODS:
-                assert operation["x-avernet-security"] == {"user": "required"}, (
-                    f"{method} {path}"
-                )
+                assert operation["x-avernet-security"] == {
+                    "user": "optional",
+                    "app": "optional",
+                }, f"{method} {path}"


### PR DESCRIPTION
 ## Problem

  The public harness API (`/openapi/v1/bots/{bot_id}/harness/*`) was the only backend surface that still refused application-only callers. The rest of the public API has been unified on an addressed-bot identity model where:

  - `bot_id` is carried on the path
  - `user_id` is carried in the query string
  - the caller is either a human or an application acting under a live bot-app grant

  Harness was left out of that unification, so both the collaborator path and the delegated-application path were unavailable for it.

  ## Solution

  Move the six public harness operations from `AdmissionMode.REFUSED` to `AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT` and perform the grant check inside the existing `require_harness_bot_access` dependency.

  Key points:

  - The wire contract is unchanged: callers still send `bot_id` on the path and `user_id` as the only query parameter; no `owner_id` parameter is introduced.
  - For human callers, behavior is unchanged.
  - For application-only callers, `require_harness_bot_access` now looks up a live grant for `(app_id, bot_id, owner_id, user_id)` and then applies the same owner/collaborator check as for humans.
  - The owner is resolved from the repository record, preserving the current harness contract.
  - The gateway `route_security` entry is widened from `user: required` to `user: optional + app: optional` so the application identity reaches the backend.
  - A new `HARNESS_SCOPED_OPERATIONS` set documents that harness resolves its own grant check and is excluded from the normal structural grant-dependency assertion, mirroring the existing `SKILL_SCOPED_OPERATIONS` mechanism.

  ## Validation

  - `test_admission_inventory.py` — 14 passed
  - `test_app_only_refusals.py` — 30 passed
  - `test_self_checked_routes_refuse.py` — 14 passed (includes the six harness routes)
  - `test_endpoint_runner.py -k harness` — 18 passed (includes new app-only granted/refused cases)
  - `test_app_only_listings.py` + `test_skills_shared_bot_grant.py` — 114 passed combined
  - `src/gateway/tests/unit/core/authn/test_route_security.py` — 60 passed

  The local pre-push gate passed in lint-only mode.

  ## Compatibility and risk

  - Existing human callers (owner or collaborators) are unaffected: the request shape, status codes, and responses are unchanged.
  - Application callers that previously received a 401/404 are now admitted if they hold a valid grant.
  - No `owner_id` query parameter is added, so this deliberately does not fully migrate harness to the standard `engine_runtime` addressed-bot shape; that broader migration is left for a later change if needed.
  - The harness owner/collaborator gate keeps its existing ADMIN-level requirement.