### PR TITLE
feat(backend): push manager_worker coop-group events and structure ClawMind execution_graph

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/task/translator.py
+++ b/src/backend/src/agentclaw/community/adapters/http/task/translator.py
@@ -6,11 +6,12 @@ SSOT TaskCallbackData 不扩;ext_info/goal/未登记 str id 塞进 result["_ext_
 """
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Any, Literal
 
 from agentclaw.community.core.errors import NotFound
-from agentclaw.community.core.task.domain.models import TaskCallbackData
+from agentclaw.community.core.task.domain.models import Status, TaskCallbackData
 from agentclaw.community.core.task.task_runner.callback_correlation import (
     CallbackCorrelationRegistry,
 )
@@ -148,11 +149,186 @@ def translate_claw_mind(raw: dict, disposition: Literal["start", "result"]) -> T
             "workflow_source": "claw_mind",
             "workflow_instance_id": (flow_runs.get("origin_session_id") or ""),
             "status": low_status,
-            "execution_graph": ext,
+            "execution_graph": _build_claw_mind_execution_graph(ext, run_status=low_status),
             "_raw_callback_body": raw,
             "result": result,
         }),
     )
+
+
+# ===== ClawMind ext_info → TaskExecutionGraph(graph_to_dict 形状)执行图快照 =====
+# adapter 层不 import repository serializers(避免跨层),此处手写与
+# core/task/repository/serializers.py:graph_to_dict 同型的 dict;若 graph_to_dict
+# 形状变更需同步。落 task_callback.execution_graph 只读投影。
+
+# 底层 status → TaskExecutionGraph 7 态:succeeded/done→DONE、failed→FAILED、
+# cancelled/aborted→CANCELLED、running/started→RUNNING,余缺省 PENDING。
+_CLAW_MIND_TO_TASK_STATUS: dict[str, Status] = {
+    "succeeded": Status.DONE, "completed": Status.DONE, "done": Status.DONE,
+    "node_succeeded": Status.DONE, "success": Status.DONE,
+    "failed": Status.FAILED, "node_failed": Status.FAILED,
+    "cancelled": Status.CANCELLED, "canceled": Status.CANCELLED, "aborted": Status.CANCELLED,
+    "running": Status.RUNNING, "started": Status.RUNNING, "in_progress": Status.RUNNING,
+    "active": Status.RUNNING,
+    "pending": Status.PENDING, "queued": Status.PENDING, "waiting": Status.PENDING,
+    "planning": Status.PLANNING,
+}
+
+
+def _claw_mind_status_to_task(low_status: Any) -> Status:
+    return _CLAW_MIND_TO_TASK_STATUS.get(str(low_status or "").lower(), Status.PENDING)
+
+
+def _parse_json(value: Any, default: Any = None) -> Any:
+    """容错解析 *_json 字段:dict 原样、str→ json.loads、None/异常 → default。"""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except (ValueError, TypeError):
+            return default
+    return default
+
+
+def _parse_dict(value: Any) -> dict[str, Any]:
+    parsed = _parse_json(value, {})
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _to_ms(value: Any) -> int | None:
+    """ClawMind 秒级时间戳 → 毫秒(对齐 RuntimeInfo.start_time/end_time 约定)。
+    探测值 < 1e12 视为秒(×1000)、已毫秒保持;非法/None → None。"""
+    if value is None:
+        return None
+    try:
+        v = int(value)
+    except (TypeError, ValueError):
+        return None
+    return v * 1000 if v < 1_000_000_000_000 else v
+
+
+# 图级 extend_props 白名单(workflow 标识/运行指标);credentials_json/identity_key/
+# plugin_version 等密钥·摘要·版本,以及图级 node_count/succeeded_count(节点为权威源)均不入。
+_CLAW_MIND_GRAPH_KEEP = (
+    "workflow_id", "workflow_title", "flow_id", "origin_session_id",
+    "total_duration_ms", "total_token_usage", "triggered_by",
+    "current_phase", "started_at", "completed_at",
+)
+_CLAW_MIND_NODE_KEEP = (
+    "session_id", "session_key", "embedded_session_key",
+    "branch_id", "progress_message", "triggered_by",
+)
+
+
+def _build_claw_mind_execution_graph(ext: dict, *, run_status: Any) -> dict[str, Any] | None:
+    """ClawMind ext_info(flow_runs + node_executions)→ graph_to_dict 形状执行图快照。
+
+    - ``run_id`` = int(flow_runs.id)(非法 → 0);图级 status 由底层 status 映射 7 态;
+      ``output`` = 解析 flow_runs.result_json;
+    - extend_props 白名单取 flow_runs 的 workflow 标识/运行指标;
+    - nodes 取 node_executions:task_spec.metadata.title ← node_title(缺则 node_id),
+      run_info.{start,end}_time 秒→毫秒;output = 解析 output_json;token_usage/input/
+      system_context/timing/error 等富字段折叠进 run_info.extend_props;
+    - relations 由各节点 input_json.nodeOutputKeys(params 的兄弟字段)派生(多父 DAG),
+      两端须都在节点集内,过滤悬挂边(默认 DEPENDENCY)。
+    无 flow_runs 且无 node_executions → None。
+    """
+    flow_runs = ext.get("flow_runs") if isinstance(ext, dict) else None
+    flow_runs = flow_runs if isinstance(flow_runs, dict) else {}
+    node_execs = ext.get("node_executions") if isinstance(ext, dict) else None
+    node_execs = node_execs if isinstance(node_execs, list) else []
+    if not flow_runs and not node_execs:
+        return None
+
+    node_ids = {ne.get("node_id") for ne in node_execs
+                if isinstance(ne, dict) and ne.get("node_id")}
+
+    tasks: list[dict[str, Any]] = []
+    relations: list[dict[str, Any]] = []
+    for ne in node_execs:
+        if not isinstance(ne, dict) or not ne.get("node_id"):
+            continue
+        node_id = ne["node_id"]
+        status = _claw_mind_status_to_task(ne.get("status") or run_status)
+        input_doc = _parse_dict(ne.get("input_json"))
+        ik_raw = input_doc.get("nodeOutputKeys")
+        input_keys = ik_raw if isinstance(ik_raw, list) else []
+
+        ep: dict[str, Any] = {}
+        if ne.get("executor_type"):
+            ep["executor_type"] = ne["executor_type"]
+        if ne.get("attempt") is not None:
+            ep["attempt"] = ne["attempt"]
+        tok = _parse_dict(ne.get("token_usage_json"))
+        if tok:
+            ep["token_usage"] = tok
+        if input_doc:
+            ep["input"] = input_doc
+        sc = _parse_dict(ne.get("system_context_json"))
+        if sc:
+            ep["system_context"] = sc
+        if ne.get("duration_ms") is not None:
+            ep["duration_ms"] = ne["duration_ms"]
+        if ne.get("started_at") is not None:
+            ep["started_at"] = ne["started_at"]          # 原始秒
+        if ne.get("completed_at") is not None:
+            ep["completed_at"] = ne["completed_at"]
+        if ne.get("error_text"):
+            ep["error_text"] = ne["error_text"]
+        for k in _CLAW_MIND_NODE_KEEP:
+            if ne.get(k):
+                ep[k] = ne[k]
+
+        for src in input_keys:
+            if isinstance(src, str) and src in node_ids and src != node_id:
+                relations.append({"src_id": src, "dst_id": node_id,
+                                  "type": "DEPENDENCY", "extend_props": {}})
+
+        title = ne.get("node_title") or node_id
+        tasks.append({
+            "node_id": node_id,
+            "task_id": "",
+            "status": status.value,
+            "task_spec": {
+                "metadata": {"task_id": node_id, "title": title, "instruction": ""},
+                "context": {"background": "", "extend_props": {}},
+                "goal": {"objective": "", "acceptances": []},
+            },
+            "run_info": {
+                "run_mode": None,
+                "assignee": None,
+                "start_time": _to_ms(ne.get("started_at")),
+                "end_time": _to_ms(ne.get("completed_at")),
+                "output": _parse_dict(ne.get("output_json")),
+                "acceptance_result": None,
+                "extend_props": ep,
+            },
+        })
+
+    graph_ep: dict[str, Any] = {}
+    for k in _CLAW_MIND_GRAPH_KEEP:
+        if flow_runs.get(k) is not None:
+            graph_ep[k] = flow_runs[k]
+    graph_params = _parse_dict(flow_runs.get("params_json"))
+    if graph_params:
+        graph_ep["params"] = graph_params
+
+    try:
+        run_id = int(flow_runs["id"]) if flow_runs.get("id") is not None else 0
+    except (TypeError, ValueError):
+        run_id = 0
+
+    return {
+        "run_id": run_id,
+        "task_id": "",
+        "loop_round": 0,
+        "status": _claw_mind_status_to_task(run_status).value,
+        "output": _parse_dict(flow_runs.get("result_json")),
+        "extend_props": graph_ep,
+        "tasks": tasks,
+        "relations": relations,
+    }
 
 
 # ===== BCN(BCS Group)CloudEvent 回调解析(语雀《BCS Group 回调接入说明》) =====

--- a/src/backend/src/agentclaw/community/core/task/task_center/engine.py
+++ b/src/backend/src/agentclaw/community/core/task/task_center/engine.py
@@ -67,7 +67,7 @@ class ExecutionEngine:
     测试可经 facade/engine 子类覆写 ``_build_*`` 注入 stub 策略/投递(测试 seam)。"""
 
     def __init__(self, graph, *, bot=None, bcs=None, discover=None, bcn: BcnService | None = None,
-                 bcs_identity=None, api_base_url: str = "") -> None:
+                 bcs_identity=None, api_base_url: str = "", bot_token_provider=None) -> None:
         """graph: TaskGraphService;bot: OpenApiBotPort;bcs: BcsClientPort;discover: BotDiscoverServiceProtocol。
         端口由 DI 从配置注入(local/prod/double 只换端口实现,引擎代码不变)。prod 必传;测试子类覆写
         ``_build_*`` 注入 stub 策略/投递时可省略(走 super 路径默认 berth)。
@@ -83,6 +83,7 @@ class ExecutionEngine:
         self._bcn = bcn
         self._bcs_identity = bcs_identity
         self._api_base_url = api_base_url
+        self._bot_token_provider = bot_token_provider  # driver-bot session_token 取数(直读 bcs_bots);None→不发 Bearer
         self._bg_tasks: set[asyncio.Task] = set()
         self._locks: dict[str, threading.RLock] = {}
         self._locks_guard = threading.RLock()
@@ -139,6 +140,7 @@ class ExecutionEngine:
             bot=self._bot, bcs=self._bcs, formatter=PromptFormatterImpl(),
             context=self, sink=self, poller=poller, identity_resolver=self._bcs_identity,
             graph=self._graph, api_base_url=self._api_base_url, bcn=self._bcn,
+            bot_token_provider=self._bot_token_provider,
         )
         import threading as _t
         self._poller_thread = _t.Thread(target=poller.run_poll_loop, daemon=True, name="task-exec-poller")

--- a/src/backend/src/agentclaw/community/core/task/task_center/task_service.py
+++ b/src/backend/src/agentclaw/community/core/task/task_center/task_service.py
@@ -39,6 +39,24 @@ from agentclaw.community.core.task.task_runner.callback_adapter import (
 logger = logging.getLogger("task.service")
 
 
+def _resolve_coop_collab_mode(has_yaml: bool, group_kind: str | None) -> str:
+    """由 execution_config.group_kind(补充字段)+ 是否带 yaml 推导协作群 collab_mode(group_strategy)。
+
+    既有「有 yaml → state_machine」判断**不变**(group_kind 不介入);group_kind 只在无 yaml 时补充:
+    chat(新增)/manager_worker(默认)。state_machine 需 yaml 定义;未知值 → ValueError。
+    对齐 BCS collaboration.strategy 取值:chat / manager_worker / state_machine(参见语雀《BCS Group 回调接入说明》§4)。
+    """
+    if has_yaml:
+        return "state_machine"
+    if group_kind in ("chat", "manager_worker"):
+        return group_kind
+    if group_kind is None:
+        return "manager_worker"
+    if group_kind == "state_machine":
+        raise ValueError("group_kind=state_machine 需要 yaml 定义")
+    raise ValueError(f"未知 group_kind: {group_kind!r}")
+
+
 # TaskService 结构化实现 api.task.task_service.TaskServiceProtocol —— 依 api/README 四层
 # 契约,core/ 不 import api/(见 test_service_api_conformance.py:core 服务不继承 api Protocol,
 # 由 @runtime_checkable 的 isinstance/issubclass 做结构化一致性校验)。此处置空基类即可。
@@ -182,7 +200,7 @@ class TaskService:
         _task_context = ((_ts.goal.objective or _ts.metadata.instruction or _ts.metadata.title) or "").strip()
         gf = GroupFormation(
             bot_ids=[request.owner_bot_id, *ec.get("participant_bot_ids", [])],
-            collab_mode="state_machine" if has_yaml else "manager_worker",
+            collab_mode=_resolve_coop_collab_mode(has_yaml, ec.get("group_kind")),
             group_name=ec.get("group_name", f"task-{task_id}"),
             members_info=[],
             extend_props={

--- a/src/backend/src/agentclaw/community/core/task/task_center/task_service.py
+++ b/src/backend/src/agentclaw/community/core/task/task_center/task_service.py
@@ -55,7 +55,8 @@ class TaskService:
                  task_node_repo: TaskNodeRepositoryProtocol | None = None,
                  task_node_run_info_repo: TaskNodeRunInfoRepositoryProtocol | None = None,
                  bot_service=None,
-                 api_base_url: str | None = None) -> None:
+                 api_base_url: str | None = None,
+                 bot_token_provider=None) -> None:
         """graph: TaskGraphService;harness: TaskHarness | None(旁路复位,可选);
         bot/bcs/discover: 传输端口(DI 从配置注入 local/prod/double 实现传给引擎;省略=stub 路径/纯内核单测)。
         BBS 候选通过注入的 BcnService.list_bots_by_task_modes(复用统一 provider 身份)查询。
@@ -77,6 +78,7 @@ class TaskService:
         self._callback_repo = callback_repo
         self._bot_service = bot_service
         self._api_base_url = api_base_url
+        self._bot_token_provider = bot_token_provider  # driver-bot session_token 取数(直读 bcs_bots);经 _build_engine 透传给 TaskExecutor
         self._engine = self._build_engine(bot=bot, bcs=bcs, discover=discover)
         # fire-and-forget 后台推进任务跟踪(防 GC + 异常可见 + drain seam)
         self._bg_tasks: set[asyncio.Task] = set()
@@ -96,6 +98,7 @@ class TaskService:
             self._graph, bot=bot, bcs=bcs, discover=discover, bcn=self._bcn,
             bcs_identity=self._bcs_identity,
             api_base_url=self._api_base_url,
+            bot_token_provider=self._bot_token_provider,
         )
 
     @property

--- a/src/backend/src/agentclaw/community/core/task/task_runner/integration/bcs_bot_token_provider.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/integration/bcs_bot_token_provider.py
@@ -1,0 +1,80 @@
+"""BcsBotTokenProvider:driver-bot 的 BCS session_token 取数端口(参考 ocb ``ZdasBotTokenProvider``)。
+
+为什么需要:BCS 建群(``POST /groups``)在带 ``event_subscriptions`` 时走 ``require_human``,拒 Bot token;
+去掉订阅后虽可 HMAC-only 匿名建群,但参考 ocb,把 driver-bot 的 session_token 作为 ``Authorization: Bearer``
+携带,让 BCS ``resolve_group_create_caller`` 把 caller 解析成 driver/originator bot(带归属、统一个 caller 身份)。
+
+token 来源:BCS 没有"取 bot token"的 HTTP 接口 —— token 在 bot 经 ``/ws/bot`` 首连时由服务端
+``new_session_token()`` 签发(``provider_core.rs``),写库表 ``bcs_bots.session_token``,只在 connect 帧回给该 bot。
+唯一既存取法 = 直读 ``bcs_bots.session_token`` 库表(ocb 同款,经 ZDAS ``agentclawdb_ds``)。
+
+本模块只提供端口 + TTL 缓存包装 + 空实现;真实 ``SELECT session_token FROM bcs_bots WHERE bot_uuid=%s``
+的 ZDAS resolver 由 corp 覆写注入(prod 经 ``agentclawdb_ds``),本地/singlebox/double 用 ``NullBcsBotTokenProvider``。
+"""
+from __future__ import annotations
+
+import time
+from typing import Callable, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class BcsBotTokenProvider(Protocol):
+    """``bcs_bot_uuid -> session_token`` 解析端口(带缓存由实现负责)。"""
+
+    def get_token(self, bcs_bot_uuid: str) -> str | None: ...
+
+
+class NullBcsBotTokenProvider:
+    """无 token 实现(本地/singlebox/double/未配置):恒返回 None。
+
+    搭配"去掉 event_subscriptions"建群走 no-sub 分支,无需 token;本实现下 ``caller_bot_token`` 不发,
+    行为同未配置 provider(向后兼容)。
+    """
+
+    def get_token(self, bcs_bot_uuid: str) -> str | None:
+        return None
+
+
+# 未命中时短缓存(秒):避免对 DB 反复打同一条不存在的 bot。对齐 ocb ZdasBotTokenProvider("查失败也缓存短 TTL")。
+_DEFAULT_FAIL_TTL_S: float = 60.0
+
+
+class CachingBcsBotTokenProvider:
+    """对 ``resolver`` 包一层进程内 TTL 缓存,命中/未命中分别缓存。
+
+    ``resolver`` 是真实查数闭包(``bcs_bot_uuid -> session_token 或 None``);prod 由 corp 覆写注入
+    直读 ``bcs_bots.session_token``(ZDAS ``agentclawdb_ds``),测试/本地注入桩。不把 token 明文写日志。
+
+    Args:
+        resolver: 真实查数闭包。
+        ttl_s: 命中缓存有效期(秒),默认 300(5 分钟,对齐 ocb)。
+        clock: 可注入的单调时钟(默认 ``time.monotonic``),便于测试不依赖真睡。
+    """
+
+    def __init__(
+        self,
+        resolver: Callable[[str], str | None],
+        *,
+        ttl_s: float = 300.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._resolver = resolver
+        self._ttl_s = ttl_s
+        self._clock = clock
+        # _cache: bot_uuid -> (token or "", expire_at)。空串哨兵表示一次未命中的短缓存。
+        self._cache: dict[str, tuple[str, float]] = {}
+
+    def get_token(self, bcs_bot_uuid: str) -> str | None:
+        now = self._clock()
+        cached = self._cache.get(bcs_bot_uuid)
+        if cached is not None:
+            token, expire_at = cached
+            if now < expire_at:
+                return token or None
+        token = self._resolver(bcs_bot_uuid)
+        if token:
+            self._cache[bcs_bot_uuid] = (token, now + self._ttl_s)
+            return token
+        # 未命中也短缓存,避免反复查库打爆 DB。
+        self._cache[bcs_bot_uuid] = ("", now + min(self._ttl_s, _DEFAULT_FAIL_TTL_S))
+        return None

--- a/src/backend/src/agentclaw/community/core/task/task_runner/integration/bcs_bot_token_provider.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/integration/bcs_bot_token_provider.py
@@ -13,8 +13,15 @@ token 来源:BCS 没有"取 bot token"的 HTTP 接口 —— token 在 bot 经 `
 """
 from __future__ import annotations
 
+import logging
 import time
-from typing import Callable, Protocol, runtime_checkable
+from typing import Any, Callable, Protocol, runtime_checkable
+
+from sqlalchemy import text
+
+from agentclaw.community.plugin_api.database import DatabasePlugin
+
+logger = logging.getLogger(__name__)
 
 
 @runtime_checkable
@@ -78,3 +85,54 @@ class CachingBcsBotTokenProvider:
         # 未命中也短缓存,避免反复查库打爆 DB。
         self._cache[bcs_bot_uuid] = ("", now + min(self._ttl_s, _DEFAULT_FAIL_TTL_S))
         return None
+
+
+class ZdasBcsBotTokenProvider:
+    """经 ZDAS ``agentclawdb_ds``(本仓 prod ``DatabasePlugin``,即 ``bcs_bots`` 所在库)直读
+    ``bcs_bots.session_token``(对齐 ocb ``ZdasBotTokenProvider``),套 ``CachingBcsBotTokenProvider`` 做 TTL 缓存。
+
+    prod corp ``DatabasePlugin.orm_session()`` 连到 ``agentclawdb_ds``,``bcs_bots`` 在同库 → 可查;
+    本地 SQLite 无 ``bcs_bots`` 表 → 查询抛错被吞 → 返 None(不发 Bearer,本地 BCS 忽略鉴权,无害)。
+
+    Args:
+        database_plugin: ``DatabasePlugin``(DI 注入;corp=真实 ZDAS,本地=SQLite)。``orm_session()`` 出 SQLAlchemy Session。
+        env: 可选环境列过滤(对齐 ocb 的 ``bcs_bots.env``);省略只按 ``bot_uuid`` 查。
+        ttl_s: 命中缓存有效期(秒),默认 300。
+        clock: 可注入单调时钟(默认 ``time.monotonic``),便于测试。
+    """
+
+    def __init__(
+        self,
+        database_plugin: DatabasePlugin,
+        *,
+        env: str | None = None,
+        ttl_s: float = 300.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._db = database_plugin
+        self._env = env
+        self._caching = CachingBcsBotTokenProvider(self._query_token, ttl_s=ttl_s, clock=clock)
+
+    def get_token(self, bcs_bot_uuid: str) -> str | None:
+        return self._caching.get_token(bcs_bot_uuid)
+
+    def _query_token(self, bcs_bot_uuid: str) -> str | None:
+        sql = "SELECT session_token FROM bcs_bots WHERE bot_uuid = :uuid"
+        params: dict[str, str] = {"uuid": bcs_bot_uuid}
+        if self._env:
+            sql += " AND env = :env"
+            params["env"] = self._env
+        sql += " LIMIT 1"
+        try:
+            with self._db.orm_session() as session:
+                row: Any = session.execute(text(sql), params).first()
+        except Exception:  # noqa: BLE001 本地无 bcs_bots 表 / 查询失败 → None(不发 Bearer,降级不阻断建群)
+            logger.warning(
+                "[task][bcs_bot_token] 读 bcs_bots.session_token 失败 bot_uuid=%s(本地无此表属正常)",
+                bcs_bot_uuid, exc_info=True,
+            )
+            return None
+        if row is None:
+            return None
+        token = row[0]
+        return str(token) if token else None

--- a/src/backend/src/agentclaw/community/core/task/task_runner/integration/bcs_bot_token_provider.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/integration/bcs_bot_token_provider.py
@@ -1,27 +1,17 @@
-"""BcsBotTokenProvider:driver-bot 的 BCS session_token 取数端口(参考 ocb ``ZdasBotTokenProvider``)。
+"""BcsBotTokenProvider:driver-bot 的 BCS session_token 取数端口(core 只含中性端口 + 缓存包装 + 空实现)。
 
-为什么需要:BCS 建群(``POST /groups``)在带 ``event_subscriptions`` 时走 ``require_human``,拒 Bot token;
-去掉订阅后虽可 HMAC-only 匿名建群,但参考 ocb,把 driver-bot 的 session_token 作为 ``Authorization: Bearer``
-携带,让 BCS ``resolve_group_create_caller`` 把 caller 解析成 driver/originator bot(带归属、统一个 caller 身份)。
+为什么需要:BCS 建群(``POST /groups``)带 ``event_subscriptions`` 时走 ``require_human``,拒 Bot token;
+参考 ocb 把 driver-bot 的 session_token 作为 ``Authorization: Bearer`` 携带,让 BCS 把 caller 解析成
+driver/originator bot(带归属、统一个 caller 身份)。core 不挂厂商数据基建名;具体读法(DB 直读
+``bcs_bots.session_token`` 等)属 corp/数据源具体实现,放在 community/plugins(见 ``DbBcsBotTokenProvider``)。
 
-token 来源:BCS 没有"取 bot token"的 HTTP 接口 —— token 在 bot 经 ``/ws/bot`` 首连时由服务端
-``new_session_token()`` 签发(``provider_core.rs``),写库表 ``bcs_bots.session_token``,只在 connect 帧回给该 bot。
-唯一既存取法 = 直读 ``bcs_bots.session_token`` 库表(ocb 同款,经 ZDAS ``agentclawdb_ds``)。
-
-本模块只提供端口 + TTL 缓存包装 + 空实现;真实 ``SELECT session_token FROM bcs_bots WHERE bot_uuid=%s``
-的 ZDAS resolver 由 corp 覆写注入(prod 经 ``agentclawdb_ds``),本地/singlebox/double 用 ``NullBcsBotTokenProvider``。
+core 只暴露中性 ``BcsBotTokenProvider`` 端口 + ``CachingBcsBotTokenProvider`` 缓存包装 +
+``NullBcsBotTokenProvider``;联调/部署侧经 DI bind ``BcsBotTokenProvider`` 覆写默认提供方(见 task_module)。
 """
 from __future__ import annotations
 
-import logging
 import time
-from typing import Any, Callable, Protocol, runtime_checkable
-
-from sqlalchemy import text
-
-from agentclaw.community.plugin_api.database import DatabasePlugin
-
-logger = logging.getLogger(__name__)
+from typing import Callable, Protocol, runtime_checkable
 
 
 @runtime_checkable
@@ -34,7 +24,7 @@ class BcsBotTokenProvider(Protocol):
 class NullBcsBotTokenProvider:
     """无 token 实现(本地/singlebox/double/未配置):恒返回 None。
 
-    搭配"去掉 event_subscriptions"建群走 no-sub 分支,无需 token;本实现下 ``caller_bot_token`` 不发,
+    搭配建群不挂订阅/无 token 时走 no-sub 分支,无需 token;本实现下 ``caller_bot_token`` 不发,
     行为同未配置 provider(向后兼容)。
     """
 
@@ -42,7 +32,7 @@ class NullBcsBotTokenProvider:
         return None
 
 
-# 未命中时短缓存(秒):避免对 DB 反复打同一条不存在的 bot。对齐 ocb ZdasBotTokenProvider("查失败也缓存短 TTL")。
+# 未命中时短缓存(秒):避免对 DB 反复打同一条不存在的 bot。对齐 ocb("查失败也缓存短 TTL")。
 _DEFAULT_FAIL_TTL_S: float = 60.0
 
 
@@ -50,7 +40,7 @@ class CachingBcsBotTokenProvider:
     """对 ``resolver`` 包一层进程内 TTL 缓存,命中/未命中分别缓存。
 
     ``resolver`` 是真实查数闭包(``bcs_bot_uuid -> session_token 或 None``);prod 由 corp 覆写注入
-    直读 ``bcs_bots.session_token``(ZDAS ``agentclawdb_ds``),测试/本地注入桩。不把 token 明文写日志。
+    直读 ``bcs_bots.session_token`` 的 resolver(放在 community/plugins),测试/本地注入桩。不把 token 明文写日志。
 
     Args:
         resolver: 真实查数闭包。
@@ -85,54 +75,3 @@ class CachingBcsBotTokenProvider:
         # 未命中也短缓存,避免反复查库打爆 DB。
         self._cache[bcs_bot_uuid] = ("", now + min(self._ttl_s, _DEFAULT_FAIL_TTL_S))
         return None
-
-
-class ZdasBcsBotTokenProvider:
-    """经 ZDAS ``agentclawdb_ds``(本仓 prod ``DatabasePlugin``,即 ``bcs_bots`` 所在库)直读
-    ``bcs_bots.session_token``(对齐 ocb ``ZdasBotTokenProvider``),套 ``CachingBcsBotTokenProvider`` 做 TTL 缓存。
-
-    prod corp ``DatabasePlugin.orm_session()`` 连到 ``agentclawdb_ds``,``bcs_bots`` 在同库 → 可查;
-    本地 SQLite 无 ``bcs_bots`` 表 → 查询抛错被吞 → 返 None(不发 Bearer,本地 BCS 忽略鉴权,无害)。
-
-    Args:
-        database_plugin: ``DatabasePlugin``(DI 注入;corp=真实 ZDAS,本地=SQLite)。``orm_session()`` 出 SQLAlchemy Session。
-        env: 可选环境列过滤(对齐 ocb 的 ``bcs_bots.env``);省略只按 ``bot_uuid`` 查。
-        ttl_s: 命中缓存有效期(秒),默认 300。
-        clock: 可注入单调时钟(默认 ``time.monotonic``),便于测试。
-    """
-
-    def __init__(
-        self,
-        database_plugin: DatabasePlugin,
-        *,
-        env: str | None = None,
-        ttl_s: float = 300.0,
-        clock: Callable[[], float] = time.monotonic,
-    ) -> None:
-        self._db = database_plugin
-        self._env = env
-        self._caching = CachingBcsBotTokenProvider(self._query_token, ttl_s=ttl_s, clock=clock)
-
-    def get_token(self, bcs_bot_uuid: str) -> str | None:
-        return self._caching.get_token(bcs_bot_uuid)
-
-    def _query_token(self, bcs_bot_uuid: str) -> str | None:
-        sql = "SELECT session_token FROM bcs_bots WHERE bot_uuid = :uuid"
-        params: dict[str, str] = {"uuid": bcs_bot_uuid}
-        if self._env:
-            sql += " AND env = :env"
-            params["env"] = self._env
-        sql += " LIMIT 1"
-        try:
-            with self._db.orm_session() as session:
-                row: Any = session.execute(text(sql), params).first()
-        except Exception:  # noqa: BLE001 本地无 bcs_bots 表 / 查询失败 → None(不发 Bearer,降级不阻断建群)
-            logger.warning(
-                "[task][bcs_bot_token] 读 bcs_bots.session_token 失败 bot_uuid=%s(本地无此表属正常)",
-                bcs_bot_uuid, exc_info=True,
-            )
-            return None
-        if row is None:
-            return None
-        token = row[0]
-        return str(token) if token else None

--- a/src/backend/src/agentclaw/community/core/task/task_runner/integration/bcs_http_adapter.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/integration/bcs_http_adapter.py
@@ -64,6 +64,7 @@ class BcsCreateGroupRequest:
     visibility: str | None = None
     opening_message: dict[str, Any] | None = None
     event_subscriptions: list[dict[str, Any]] | None = None    # 内联事件订阅(回调 webhook);BCS 把 CloudEvent 推到 sink.url
+    caller_bot_token: str | None = None                        # driver-bot 的 session token(直读 bcs_bots.session_token);参考 ocb:作为 Authorization: Bearer 做 caller 身份
 
 
 @dataclass
@@ -186,7 +187,13 @@ class BcsHttpAdapter:  # pragma: no cover — live BCS HTTP client (HMAC signing
             v = getattr(req, opt)
             if v is not None:
                 body[opt] = v
-        r = await self._req("POST", "/groups", json=body, idempotency_key=uuid.uuid4().hex)
+        # 参考 ocb(http_client.py:254-257):driver-bot 的 session token 经 Authorization: Bearer 做 caller 身份,
+        # BCS resolve_group_create_caller 据此把 caller 解析成 driver/originator bot(仅 HMAC X-ECB-* 无 caller)。
+        extra_headers: dict[str, str] | None = None
+        if req.caller_bot_token:
+            extra_headers = {"Authorization": f"Bearer {req.caller_bot_token}"}
+        r = await self._req("POST", "/groups", json=body, idempotency_key=uuid.uuid4().hex,
+                           extra_headers=extra_headers)
         data = r.json()
         return BcsCreateGroupResult(
             group_id=data["group_id"], session_id=data.get("session_id"),

--- a/src/backend/src/agentclaw/community/core/task/task_runner/integration/singlebox_bcs_adapter.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/integration/singlebox_bcs_adapter.py
@@ -50,7 +50,12 @@ class SingleboxBcsAdapter(BcsHttpAdapter):  # pragma: no cover — live singlebo
             v = getattr(req, opt)
             if v is not None:
                 body[opt] = v
-        r = await self._req("POST", "/groups", json=body, idempotency_key=uuid.uuid4().hex)
+        # 与 BcsHttpAdapter.create_group 一致:透传 driver-bot Bearer(参考 ocb);本地 BCS 忽略鉴权,无害。
+        extra_headers: dict[str, str] | None = None
+        if req.caller_bot_token:
+            extra_headers = {"Authorization": f"Bearer {req.caller_bot_token}"}
+        r = await self._req("POST", "/groups", json=body, idempotency_key=uuid.uuid4().hex,
+                           extra_headers=extra_headers)
         data = r.json()
         # 本地用 "id";生产用 "group_id"。取其一,向后兼容 prod。
         group_id = data.get("group_id") or data.get("id")

--- a/src/backend/src/agentclaw/community/core/task/task_runner/integration/task_executor.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/integration/task_executor.py
@@ -240,6 +240,23 @@ class TaskExecutor:
             req_kwargs["participants"] = [
                 {"bot_uuid": bcs_uuid(mgr), "role": "manager"}] + [
                 {"bot_uuid": bcs_uuid(b), "role": "worker"} for b in bot_ids if b != mgr]
+            # §4 任务协作群事件:内联挂 event_subscriptions,BCS 主动推 §4 事件回 Avernet 回调路由,
+            # 激活既有 apply_manager_worker_event → task_callback.execution_graph(audit 快照)+ converge_by_session。
+            # 鉴权 = HMAC + 既有 caller_bot_token(Bearer driver-bot);require_human 由 Bearer(+HMAC) 兜,无 cookie
+            # (见 specs/2026-08-26-task-execute-group-kind-and-manager-worker-event-push/spec.md §4.3)。
+            if self._api_base_url:
+                req_kwargs["event_subscriptions"] = [{
+                    "name": "avernet-manager-worker",
+                    "event_filters": ["group.created", "session.created",
+                                      "task.assigned", "task.completed", "session.completed"],
+                    "payload": {"mode": "full"},
+                    "sink": {"type": "webhook",
+                             "url": f"{self._api_base_url}/api/v1/collaboration/tasks/callback/report",
+                             "request_timeout_ms": 10000},
+                }]
+            else:
+                logger.warning(
+                    "[task][manager_worker] _api_base_url 未配,跳过 event_subscriptions(sink.url 需绝对地址);poller 兜底收敛")
         elif mode == "state_machine":
             req_kwargs["group_strategy"] = "state_machine"
             # GroupFormation.extend_props["definition_yaml"] → BCS collaboration_definition_yaml
@@ -283,10 +300,10 @@ class TaskExecutor:
         service_spec = gf.extend_props.get("service_spec")
         if service_spec:
             req_kwargs["service_spec"] = service_spec
-        # 不再内联挂 event_subscriptions:带订阅会让 BCS 建 groups 走 create_group_with_inline_subscriptions
-        # → require_human,对 HMAC-only / HTTP bot token(Bearer→Bot)分别 401 / 403。改为参考 ocb:以 driver-bot
-        # session_token 作 caller 身份(``Authorization: Bearer``),BCS 走 no-sub 分支建群;BCN 终态收敛由
-        # result poller 轮询 get_state_machine_run / get_group 承担(task_executor_result_poller)。
+        # event_subscriptions:仅 manager_worker 分支(上方)内联挂 §4 订阅推回;state_machine/chat 不挂。
+        # 鉴权:driver-bot session_token 作 caller 身份(``Authorization: Bearer``);manager_worker 挂订阅时 BCS 走
+        # require_human,由 Bearer(+HMAC) 兜过(无 cookie,见 spec §4.3);state_machine/chat 走 no-sub 分支建群。
+        # 终态收敛:result poller 轮询 get_state_machine_run / get_group 兜底(与 §4 推送双兜底,同进 on_report 幂等)。
         if self._bot_token_provider is not None:
             req_kwargs["caller_bot_token"] = self._bot_token_provider.get_token(
                 req_kwargs.get("driver_bot") or "")

--- a/src/backend/src/agentclaw/community/core/task/task_runner/integration/task_executor.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/integration/task_executor.py
@@ -28,18 +28,12 @@ logger = logging.getLogger(__name__)
 _DISPATCH_CONCURRENCY = 8
 _BCS_PARTICIPANT_ROLES = {"driver", "consultant", "manager", "worker", "observer"}
 
-# BCN 协作群事件回调投递路径:投到 task 模块的 `/api/v1/collaboration/tasks/callback/report`
-# (主 router 的 report 回投路由),该路由 ``callback.report_result`` → ``on_report`` 驱动图态(收口 DONE)。
-# 注:该路由按 ``TaskCallbackDataDTO``(loop_task_id + result{success,...})校验 body;BCS event_subscriptions
-# 推的是 CloudEvent(event_type/scope/data,无 loop_task_id)。要让 CloudEvent 真能走通,需在 /callback/report
-# 侧把 CloudEvent 适配成 TaskCallbackDataDTO(或让该路由兼容 CloudEvent),否则会 422。
-_BCN_EVENT_CALLBACK_PATH = "/api/v1/collaboration/tasks/callback/report"
-
 
 class TaskExecutor:
     def __init__(self, *, bot, bcs, formatter, context, sink, poller,
                  identity_resolver=None, graph=None,
-                 api_base_url: str = "", bcn: BcnService | None = None) -> None:
+                 api_base_url: str = "", bcn: BcnService | None = None,
+                 bot_token_provider=None) -> None:
         """bot: OpenApiBotPort|None; bcs: BcsClientPort|None; formatter: PromptFormatter|None;
         context: TaskContextBuilder|None; sink: ResultSink|None; poller: TaskExecutorResultPoller|None。
         graph: TaskGraphService|None,动态派发后把 group_id/session_id/run_id 落节点 run_info.extend_props
@@ -54,6 +48,7 @@ class TaskExecutor:
         self._sink = sink
         self._poller = poller
         self._identity_resolver = identity_resolver
+        self._bot_token_provider = bot_token_provider  # driver-bot session_token 取数(直读 bcs_bots);None→不发 Bearer
         self._graph = graph
         self._api_base_url = api_base_url
         self._group_meta: dict[str, dict[str, Any]] = {}  # group_id -> {collab_mode, gf, definition_ref, session_id}
@@ -288,25 +283,13 @@ class TaskExecutor:
         service_spec = gf.extend_props.get("service_spec")
         if service_spec:
             req_kwargs["service_spec"] = service_spec
-        # BCN 事件回调订阅(创建协作群入参 event_subscriptions):BCS 把协作事件 CloudEvent 推到本后端
-        # task 模块回调路径。sink.url = api_base_url + 回调路径(api_base_url 去尾斜杠)。
-        # event_filters 按 collab_mode 分流:state_machine 订阅 state_machine.*;manager_worker/chat
-        # 无状态机 run,去 state_machine.*、保留 group/session/task/message(§4 生命周期事件)。
-        _api_base = gf.extend_props.get("api_base_url")
-        if _api_base:
-            _event_filters = (["group.*", "session.*", "task.*", "state_machine.*", "message.created"]
-                              if mode == "state_machine"
-                              else ["group.*", "session.*", "task.*", "message.created"])
-            req_kwargs["event_subscriptions"] = [{
-                "name": "group-webhook",
-                "event_filters": _event_filters,
-                "payload": {"mode": "metadata_only"},
-                "sink": {
-                    "type": "webhook",
-                    "url": str(_api_base).rstrip("/") + _BCN_EVENT_CALLBACK_PATH,
-                    "request_timeout_ms": 2000,
-                },
-            }]
+        # 不再内联挂 event_subscriptions:带订阅会让 BCS 建 groups 走 create_group_with_inline_subscriptions
+        # → require_human,对 HMAC-only / HTTP bot token(Bearer→Bot)分别 401 / 403。改为参考 ocb:以 driver-bot
+        # session_token 作 caller 身份(``Authorization: Bearer``),BCS 走 no-sub 分支建群;BCN 终态收敛由
+        # result poller 轮询 get_state_machine_run / get_group 承担(task_executor_result_poller)。
+        if self._bot_token_provider is not None:
+            req_kwargs["caller_bot_token"] = self._bot_token_provider.get_token(
+                req_kwargs.get("driver_bot") or "")
         # 任务描述(目标)→ BCS 创建群的 context 字段。BCS ``resolve_session_topic`` 把 group.context
         # 兜底注入 <GroupContext> 的 `目标` 行(session input 为空时,如建群 BotJoined)。
         _task_context = gf.extend_props.get("task_context")

--- a/src/backend/src/agentclaw/community/di/modules/task_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/task_module.py
@@ -180,19 +180,20 @@ class TaskModule(Module):
             gov = None
         # driver-bot session_token 取数(参考 ocb 直读 bcs_bots.session_token):
         # 1) corp 可经 DI 显式 bind BcsBotTokenProvider 覆写(优先);
-        # 2) 默认 ZdasBcsBotTokenProvider(DatabasePlugin),corp 连到 agentclawdb_ds(bcs_bots 同库)→ 读 token 作 caller 身份 Bearer;
-        # 3) DatabasePlugin 未绑(纯内核/轻量测试)→ NullBcsBotTokenProvider(去 event_subscriptions 后 HMAC 匿名建群亦成,不阻断)。
+        # 2) 默认 DbBcsBotTokenProvider(DatabasePlugin)(community/plugins),读 bcs_bots.session_token 作 caller 身份 Bearer;
+        # 3) DatabasePlugin 未绑(纯内核/轻量测试)→ NullBcsBotTokenProvider(HMAC 匿名建群,不阻断)。
         from agentclaw.community.core.task.task_runner.integration.bcs_bot_token_provider import (
-            BcsBotTokenProvider, NullBcsBotTokenProvider, ZdasBcsBotTokenProvider,
+            BcsBotTokenProvider, NullBcsBotTokenProvider,
         )
+        from agentclaw.community.plugins.community.bcs_bot_token_provider import DbBcsBotTokenProvider
         try:
             bot_token_provider = injector.get(BcsBotTokenProvider)  # corp 显式覆写优先
-        except Exception:  # noqa: BLE101 未绑定 → 走默认 ZDAS
+        except Exception:  # noqa: BLE101 未绑定 → 走默认 DbBcsBotTokenProvider
             bot_token_provider = None
         if bot_token_provider is None:
             try:
                 from agentclaw.community.plugin_api.database import DatabasePlugin
-                bot_token_provider = ZdasBcsBotTokenProvider(injector.get(DatabasePlugin))
+                bot_token_provider = DbBcsBotTokenProvider(injector.get(DatabasePlugin))
             except Exception:  # noqa: BLE101 DatabasePlugin 未绑(纯内核/轻量测试)→ Null
                 bot_token_provider = NullBcsBotTokenProvider()
         return TaskService(

--- a/src/backend/src/agentclaw/community/di/modules/task_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/task_module.py
@@ -178,18 +178,23 @@ class TaskModule(Module):
             gov = injector.get(EconomyGovernanceConfig)
         except Exception:  # noqa: BLE101 EconomyGovernanceModule 未装(纯内核/轻量测试列) → 取不到
             gov = None
-        # driver-bot session_token 取数(参考 ocb 直读 bcs_bots.session_token):corp overlay 经 DI 绑定
-        # BcsBotTokenProvider(ZDAS 真实实现);community 未绑 → NullBcsBotTokenProvider(去 event_subscriptions
-        # 后 HMAC 匿名建群亦成,不依赖 token;有则作 caller 身份 Bearer,带归属)。
+        # driver-bot session_token 取数(参考 ocb 直读 bcs_bots.session_token):
+        # 1) corp 可经 DI 显式 bind BcsBotTokenProvider 覆写(优先);
+        # 2) 默认 ZdasBcsBotTokenProvider(DatabasePlugin),corp 连到 agentclawdb_ds(bcs_bots 同库)→ 读 token 作 caller 身份 Bearer;
+        # 3) DatabasePlugin 未绑(纯内核/轻量测试)→ NullBcsBotTokenProvider(去 event_subscriptions 后 HMAC 匿名建群亦成,不阻断)。
         from agentclaw.community.core.task.task_runner.integration.bcs_bot_token_provider import (
-            BcsBotTokenProvider, NullBcsBotTokenProvider,
+            BcsBotTokenProvider, NullBcsBotTokenProvider, ZdasBcsBotTokenProvider,
         )
         try:
-            bot_token_provider = injector.get(BcsBotTokenProvider)
-            if bot_token_provider is None:
+            bot_token_provider = injector.get(BcsBotTokenProvider)  # corp 显式覆写优先
+        except Exception:  # noqa: BLE101 未绑定 → 走默认 ZDAS
+            bot_token_provider = None
+        if bot_token_provider is None:
+            try:
+                from agentclaw.community.plugin_api.database import DatabasePlugin
+                bot_token_provider = ZdasBcsBotTokenProvider(injector.get(DatabasePlugin))
+            except Exception:  # noqa: BLE101 DatabasePlugin 未绑(纯内核/轻量测试)→ Null
                 bot_token_provider = NullBcsBotTokenProvider()
-        except Exception:  # noqa: BLE101 未绑定 → Null(本地/singlebox/纯内核测试)
-            bot_token_provider = NullBcsBotTokenProvider()
         return TaskService(
             graph, harness=harness, bot=bot, bcs=bcs, discover=discover_port,
             bcn=bcn, bcs_identity=bcs_identity, task_info_repo=task_info_repo,

--- a/src/backend/src/agentclaw/community/di/modules/task_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/task_module.py
@@ -178,6 +178,18 @@ class TaskModule(Module):
             gov = injector.get(EconomyGovernanceConfig)
         except Exception:  # noqa: BLE101 EconomyGovernanceModule 未装(纯内核/轻量测试列) → 取不到
             gov = None
+        # driver-bot session_token 取数(参考 ocb 直读 bcs_bots.session_token):corp overlay 经 DI 绑定
+        # BcsBotTokenProvider(ZDAS 真实实现);community 未绑 → NullBcsBotTokenProvider(去 event_subscriptions
+        # 后 HMAC 匿名建群亦成,不依赖 token;有则作 caller 身份 Bearer,带归属)。
+        from agentclaw.community.core.task.task_runner.integration.bcs_bot_token_provider import (
+            BcsBotTokenProvider, NullBcsBotTokenProvider,
+        )
+        try:
+            bot_token_provider = injector.get(BcsBotTokenProvider)
+            if bot_token_provider is None:
+                bot_token_provider = NullBcsBotTokenProvider()
+        except Exception:  # noqa: BLE101 未绑定 → Null(本地/singlebox/纯内核测试)
+            bot_token_provider = NullBcsBotTokenProvider()
         return TaskService(
             graph, harness=harness, bot=bot, bcs=bcs, discover=discover_port,
             bcn=bcn, bcs_identity=bcs_identity, task_info_repo=task_info_repo,
@@ -185,6 +197,7 @@ class TaskModule(Module):
             task_node_run_info_repo=task_node_run_info_repo,
             bot_service=bot_service,
             api_base_url=self._resolve_api_base_url(gov.iframe_callback_url if gov else ""),
+            bot_token_provider=bot_token_provider,
         )
 
     @singleton

--- a/src/backend/src/agentclaw/community/plugins/community/bcs_bot_token_provider.py
+++ b/src/backend/src/agentclaw/community/plugins/community/bcs_bot_token_provider.py
@@ -1,0 +1,75 @@
+"""community profile 默认的 BcsBotTokenProvider:经 prod ``DatabasePlugin`` 直读
+``bcs_bots.session_token`` 作建群 driver-bot 的 ``Authorization: Bearer`` caller 身份。
+
+core 只留中性端口 + 缓存包装 + 空实现(见 ``core/task/task_runner/integration/bcs_bot_token_provider``);
+本处放 corp/数据源的具体读法(具体读哪张库表)。BCS 无"取 token"HTTP 接口——token 在 bot 经 ``/ws/bot`` 首连时由服务端
+``new_session_token()`` 签发、写库表 ``bcs_bots.session_token``、只在 connect 帧回该 bot;
+corp prod ``DatabasePlugin.orm_session()`` 连到 ``bcs_bots`` 所在数据源 → 可查,
+本地/singlebox 无该表 → 查询抛错被吞 → None(不发 Bearer,本地 BCS 忽略鉴权,无害,不阻断建群)。
+本类不提厂商数据基建名(仅描述能力:经 DatabasePlugin 读 bcs_bots.session_token)。
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable
+
+from sqlalchemy import text
+
+from agentclaw.community.core.task.task_runner.integration.bcs_bot_token_provider import (
+    CachingBcsBotTokenProvider,
+)
+from agentclaw.community.plugin_api.database import DatabasePlugin
+
+logger = logging.getLogger(__name__)
+
+
+class DbBcsBotTokenProvider:
+    """经 prod ``DatabasePlugin`` 直读 ``bcs_bots.session_token``,套 ``CachingBcsBotTokenProvider`` 做 TTL 缓存。
+
+    corp prod ``DatabasePlugin.orm_session()`` 连到 ``bcs_bots`` 所在数据源 → 可查;
+    本地 SQLite 无 ``bcs_bots`` 表 → 查询抛错被吞 → 返 None(不发 Bearer,本地 BCS 忽略鉴权,无害)。
+
+    Args:
+        database_plugin: ``DatabasePlugin``(DI 注入;corp=真实数据源,本地=SQLite)。
+            ``orm_session()`` 出 SQLAlchemy Session。
+        env: 可选环境列过滤(``bcs_bots.env``);省略只按 ``bot_uuid`` 查。
+        ttl_s: 命中缓存有效期(秒),默认 300。
+        clock: 可注入单调时钟(默认 ``time.monotonic``),便于测试。
+    """
+
+    def __init__(
+        self,
+        database_plugin: DatabasePlugin,
+        *,
+        env: str | None = None,
+        ttl_s: float = 300.0,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._db = database_plugin
+        self._env = env
+        self._caching = CachingBcsBotTokenProvider(self._query_token, ttl_s=ttl_s, clock=clock)
+
+    def get_token(self, bcs_bot_uuid: str) -> str | None:
+        return self._caching.get_token(bcs_bot_uuid)
+
+    def _query_token(self, bcs_bot_uuid: str) -> str | None:
+        sql = "SELECT session_token FROM bcs_bots WHERE bot_uuid = :uuid"
+        params: dict[str, str] = {"uuid": bcs_bot_uuid}
+        if self._env:
+            sql += " AND env = :env"
+            params["env"] = self._env
+        sql += " LIMIT 1"
+        try:
+            with self._db.orm_session() as session:
+                row: Any = session.execute(text(sql), params).first()
+        except Exception:  # noqa: BLE001 本地无 bcs_bots 表 / 查询失败 → None(不发 Bearer,降级不阻断建群)
+            logger.warning(
+                "[task][bcs_bot_token] 读 bcs_bots.session_token 失败 bot_uuid=%s(本地无此表属正常)",
+                bcs_bot_uuid, exc_info=True,
+            )
+            return None
+        if row is None:
+            return None
+        token = row[0]
+        return str(token) if token else None

--- a/src/backend/tests/community/adapters/http/task/test_translator.py
+++ b/src/backend/tests/community/adapters/http/task/test_translator.py
@@ -140,7 +140,18 @@ class TestClawMind:
         assert d["status"] == "succeeded"                # 从底层 flow_runs.status 推(非顶层 node_succeeded)
         assert d["result"]["success"] is True
         assert d["result"]["data"] == {"answer": 42}
-        assert d["execution_graph"] == self._BODY["ext_info"]   # 全量 ext_info → execution_graph
+        # execution_graph 转结构化 TaskExecutionGraph(graph_to_dict 形状),非原始 ext 透传
+        eg = d["execution_graph"]
+        assert eg["run_id"] == 0                           # flow_runs.id="fr1" 非整 → 0
+        assert eg["status"] == "DONE"                       # succeeded → DONE
+        assert eg["output"] == {}                           # 无 result_json
+        assert eg["extend_props"]["flow_id"] == "flow-abc-123"
+        assert len(eg["tasks"]) == 1
+        assert eg["tasks"][0]["node_id"] == "N1"
+        assert eg["tasks"][0]["status"] == "DONE"
+        assert eg["tasks"][0]["task_spec"]["metadata"]["title"] == "N1"  # 无 node_title → 退 node_id
+        assert eg["tasks"][0]["run_info"]["output"] == {"answer": 42}
+        assert eg["relations"] == []                        # N1 无 nodeOutputKeys
         assert d["_raw_callback_body"] == self._BODY            # 原始 body → orig_callback_data
         assert "_ext_info" not in d["result"]                    # 不再重复进 result
 
@@ -172,6 +183,165 @@ class TestClawMind:
         body = {"workflow_id": "w", "flow_id": "f", "status": "succeeded",
                 "ext_info": {"flow_runs": {"status": "succeeded"}}}
         assert translate_claw_mind(body, "result").data.data["workflow_instance_id"] == ""
+
+    # 真实 ClawMind 回投 shape:flow_runs/node_executions 在 ext_info 下,*_json 为 JSON 字符串,
+    # 节点 DAG 由各节点 input_json.params.nodeOutputKeys 表达(report 多父)。
+    _REAL_BODY = {
+        "workflow_id": "tech-research-pipeline-simple-pre-2",
+        "flow_id": "c5d77c99-f299-42d8-98ce-ead330f0dfd6",
+        "status": "node_succeeded",
+        "ext_info": {
+            "flow_runs": {
+                "id": 36018,
+                "flow_id": "c5d77c99-f299-42d8-98ce-ead330f0dfd6",
+                "workflow_id": "tech-research-pipeline-simple-pre-2",
+                "workflow_title": "技术调研工作流（精简离线版）",
+                "status": "succeeded",
+                "params_json": '{"topic":"大模型"}',
+                "input_json": '{"message":null,"params":{"topic":"大模型"},"digest":"x","fileCount":0}',
+                "result_json": '{"status":"succeeded","flowId":"c5d77","workflowId":"tech-research-pipeline-simple-pre-2","phase":"P3","durationMs":237223,"nodeSummary":"succeeded=3","lastNodeOutput":{"nodeId":"report"},"outputs":{"report_path":"runs/x/report.md","conclusions":["结论1"]}}',
+                "node_count": 3,
+                "succeeded_count": 4,   # 脏数据(实为 3 节点),不应原样进快照
+                "failed_count": 0,
+                "total_duration_ms": 237223,
+                "total_token_usage": None,
+                "triggered_by": "facade:tech-research-pipeline-simple-pre-2",
+                "current_phase": None,
+                "started_at": 1787719147,
+                "completed_at": 1787719384,
+                "origin_session_id": "1ccf28e2-1155-4e36-9a97-5c9d2db2c3c4",
+                "credentials_json": '{"TOKEN":"DEVICE-xxxx"}',   # 鉴权密钥,不进快照
+                "identity_key": "f526...c274",                     # 输入摘要,不进快照
+                "plugin_version": "0.9.0",                         # 不进快照
+                "origin_session_key": "agent:main:session:1ccf:user:35983",
+                "origin_bot_id": "20260824_nwlj25w6:35983",
+                "user_id": "35983",
+            },
+            "node_executions": [
+                {"id": 464121, "node_id": "report", "executor_type": "embedded-agent",
+                 "status": "succeeded", "attempt": 1,
+                 "input_json": '{"params":{"topic":"大模型","sessionKey":"s","ownerId":"35983"},"nodeOutputKeys":["scope-decompose","analysis"]}',
+                 "error_text": None, "duration_ms": 118282,
+                 "token_usage_json": '{"input":54521,"output":4024,"cacheRead":20608,"totalTokens":27121,"toolCalls":2}',
+                 "node_title": "调研报告",
+                 "system_context_json": '{"outputContractValidated":true,"outputContractIssues":0}',
+                 "embedded_session_key": "agent:main:embedded:report:c5d77",
+                 "session_key": "agent:main:session:1ccf:user:35983",
+                 "session_id": "1ccf28e2-1155-4e36-9a97-5c9d2db2c3c4",
+                 "started_at": 1787719266, "completed_at": 1787719384},
+                {"id": 464086, "node_id": "analysis", "executor_type": "embedded-agent",
+                 "status": "succeeded", "attempt": 1,
+                 "input_json": '{"params":{"topic":"大模型"},"nodeOutputKeys":["scope-decompose"]}',
+                 "error_text": None, "duration_ms": 82179,
+                 "token_usage_json": '{"input":1761,"output":2728,"cacheRead":16064,"totalTokens":20553}',
+                 "node_title": "综合分析",
+                 "system_context_json": '{"outputContractValidated":true,"outputContractIssues":0}',
+                 "started_at": 1787719184, "completed_at": 1787719266},
+                {"id": 464047, "node_id": "scope-decompose", "executor_type": "embedded-agent",
+                 "status": "succeeded", "attempt": 1,
+                 "input_json": '{"params":{"topic":"大模型"},"nodeOutputKeys":[]}',
+                 "error_text": None, "duration_ms": 33361,
+                 "token_usage_json": '{"input":6255,"output":1117,"cacheRead":10304,"totalTokens":17676}',
+                 "node_title": "调研拆题",
+                 "system_context_json": '{"outputContractValidated":true,"outputContractIssues":0}',
+                 "started_at": 1787719150, "completed_at": 1787719183},
+            ],
+        },
+    }
+
+    def test_execution_graph_is_structured_task_graph_real_payload(self):
+        g = translate_claw_mind(self._REAL_BODY, "result").data.data["execution_graph"]
+        assert g is not None
+        # 图级
+        assert g["run_id"] == 36018
+        assert g["task_id"] == ""
+        assert g["loop_round"] == 0
+        assert g["status"] == "DONE"
+        assert g["output"]["phase"] == "P3"
+        assert g["output"]["nodeSummary"] == "succeeded=3"
+        assert g["extend_props"]["workflow_id"] == "tech-research-pipeline-simple-pre-2"
+        assert g["extend_props"]["workflow_title"] == "技术调研工作流（精简离线版）"
+        assert g["extend_props"]["flow_id"] == "c5d77c99-f299-42d8-98ce-ead330f0dfd6"
+        assert g["extend_props"]["params"] == {"topic": "大模型"}
+        assert g["extend_props"]["total_duration_ms"] == 237223
+        assert g["extend_props"]["triggered_by"] == "facade:tech-research-pipeline-simple-pre-2"
+        assert g["extend_props"]["origin_session_id"] == "1ccf28e2-1155-4e36-9a97-5c9d2db2c3c4"
+        # 密钥/摘要/版本/脏计数不进快照
+        for forbidden in ("credentials_json", "identity_key", "plugin_version",
+                          "succeeded_count", "failed_count", "node_count"):
+            assert forbidden not in g["extend_props"], f"{forbidden} 不应进 execution_graph"
+        # 节点
+        nodes = {n["node_id"]: n for n in g["tasks"]}
+        assert set(nodes) == {"report", "analysis", "scope-decompose"}
+        report = nodes["report"]
+        assert report["task_id"] == ""
+        assert report["status"] == "DONE"
+        assert report["task_spec"]["metadata"]["task_id"] == "report"
+        assert report["task_spec"]["metadata"]["title"] == "调研报告"
+        assert report["task_spec"]["metadata"]["instruction"] == ""
+        assert report["task_spec"]["goal"]["acceptances"] == []
+        assert report["run_info"]["start_time"] == 1787719266000   # 秒 → 毫秒
+        assert report["run_info"]["end_time"] == 1787719384000
+        assert report["run_info"]["run_mode"] is None
+        assert report["run_info"]["output"] == {}                    # 真实 payload 节点无 output_json
+        rep = report["run_info"]["extend_props"]
+        assert rep["executor_type"] == "embedded-agent"
+        assert rep["attempt"] == 1
+        assert rep["token_usage"]["input"] == 54521
+        assert rep["token_usage"]["totalTokens"] == 27121
+        assert rep["duration_ms"] == 118282
+        assert rep["started_at"] == 1787719266                       # 原始秒保留
+        assert rep["input"]["nodeOutputKeys"] == ["scope-decompose", "analysis"]   # input_json 顶层
+        assert rep["input"]["params"]["topic"] == "大模型"
+        assert rep["system_context"] == {"outputContractValidated": True, "outputContractIssues": 0}
+        # 多父 DAG(nodeOutputKeys)→ relations 全保留
+        edges = {(e["src_id"], e["dst_id"]) for e in g["relations"]}
+        assert edges == {("scope-decompose", "analysis"),
+                         ("scope-decompose", "report"),
+                         ("analysis", "report")}
+        assert all(e["type"] == "DEPENDENCY" for e in g["relations"])
+
+    def test_execution_graph_status_mapping(self):
+        cases = {
+            "succeeded": "DONE", "completed": "DONE", "node_succeeded": "DONE", "success": "DONE",
+            "failed": "FAILED", "node_failed": "FAILED",
+            "cancelled": "CANCELLED", "canceled": "CANCELLED", "aborted": "CANCELLED",
+            "running": "RUNNING", "started": "RUNNING", "in_progress": "RUNNING",
+            "": "PENDING", "unknown_xyz": "PENDING",
+        }
+        for src, want in cases.items():
+            body = {"workflow_id": "w", "flow_id": "f", "status": src,
+                    "ext_info": {"flow_runs": {"id": 1, "status": src,
+                                               "result_json": "{}", "params_json": "{}"},
+                                 "node_executions": []}}
+            g = translate_claw_mind(body, "result").data.data["execution_graph"]
+            assert g["status"] == want, f"{src!r} → {g['status']!r}, want {want!r}"
+            assert g["run_id"] == 1
+
+    def test_execution_graph_node_failed_status_and_error(self):
+        body = {"workflow_id": "w", "flow_id": "f", "status": "node_failed",
+                "ext_info": {"flow_runs": {"origin_session_id": "S-1", "status": "failed"},
+                             "node_executions": [{"node_id": "N1", "status": "failed",
+                                                  "error_text": "boom", "node_title": "调研拆题"}]}}
+        g = translate_claw_mind(body, "result").data.data["execution_graph"]
+        assert g["status"] == "FAILED"
+        assert g["tasks"][0]["status"] == "FAILED"
+        assert g["tasks"][0]["task_spec"]["metadata"]["title"] == "调研拆题"
+        assert g["tasks"][0]["run_info"]["extend_props"]["error_text"] == "boom"
+
+    def test_execution_graph_filters_dangling_edges(self):
+        # nodeOutputKeys 引用未执行的节点 → 悬挂边被过滤
+        body = {"workflow_id": "w", "flow_id": "f", "status": "succeeded",
+                "ext_info": {"flow_runs": {"status": "succeeded"},
+                             "node_executions": [{"node_id": "n", "status": "succeeded",
+                                 "input_json": '{"params":{},"nodeOutputKeys":["ghost","n2"]}'}]}}
+        g = translate_claw_mind(body, "result").data.data["execution_graph"]
+        assert g["relations"] == []
+        assert len(g["tasks"]) == 1
+
+    def test_execution_graph_empty_ext_returns_none(self):
+        body = {"workflow_id": "w", "flow_id": "f", "status": "started", "ext_info": {}}
+        assert translate_claw_mind(body, "start").data.data["execution_graph"] is None
 
 
 class TestBCN:

--- a/src/backend/tests/community/core/task/e2e/test_writing_qc_state_machine_pre_e2e_chat.py
+++ b/src/backend/tests/community/core/task/e2e/test_writing_qc_state_machine_pre_e2e_chat.py
@@ -14,7 +14,7 @@ gated by ``AVERNET_PRE_TASK_E2E=1``;无需起 singlebox,直接打预发:
   [AVERNET_E2E_COOKIE=<cookie文件路径 或 整段Cookie原文>] \\
   [AVERNET_PRE_TASK_E2E_TIMEOUT=2000] \\
   src/backend/.venv/bin/python -m pytest \\
-    src/backend/tests/community/core/task/e2e/test_writing_qc_state_machine_pre_e2e.py -s
+    src/backend/tests/community/core/task/e2e/test_writing_qc_state_machine_pre_e2e_yaml.py -s
 
 # 场景
 

--- a/src/backend/tests/community/core/task/e2e/test_writing_qc_state_machine_pre_e2e_ms.py
+++ b/src/backend/tests/community/core/task/e2e/test_writing_qc_state_machine_pre_e2e_ms.py
@@ -1,0 +1,221 @@
+"""预发环境 e2e — 写作质检协同(state_machine),直连预发后端。
+
+参考 ``singlebox_e2e/yaml/test_writing_qc_state_machine_e2e.py`` 的回路
+(execute → 轮询 dashboard → DONE),但打**预发**:backend URL / 鉴权 / 预置 bot id 全走
+环境变量,空缺即 skip(CI 安全)。
+
+gated by ``AVERNET_PRE_TASK_E2E=1``;无需起 singlebox,直接打预发:
+
+  AVERNET_PRE_TASK_E2E=1 \\
+  AVERNET_PRE_BACKEND_URL=https://<预发host> \\
+  AVERNET_E2E_USER_ID=<uid> \\
+  AVERNET_E2E_WRITER_BOT_ID=<预置 writer bot id> \\
+  AVERNET_E2E_EDITOR_BOT_ID=<预置 editor bot id> \\
+  [AVERNET_E2E_COOKIE=<cookie文件路径 或 整段Cookie原文>] \\
+  [AVERNET_PRE_TASK_E2E_TIMEOUT=2000] \\
+  src/backend/.venv/bin/python -m pytest \\
+    src/backend/tests/community/core/task/e2e/test_writing_qc_state_machine_pre_e2e_yaml.py -s
+
+# 场景
+
+复刻参考测的 yaml 协同模板(state_machine):draft → polish → finalize 线性。
+经 ``POST /api/v1/collaboration/tasks/execute`` 提交 yaml 协同模板 + ``participant_bindings``
+→ 预发 BCS 收群自动跑状态机 → 终态经回调 POST 回预发本后端
+``/api/v1/collaboration/tasks/callback/report``(预发 ``api_base_url`` = corp overlay
+``economy_governance.iframe_callback_url_pre`` 的 origin)→ ``TaskLoopCallback.report_result``
+→ ``on_report`` → 图收敛。用例只做:提交 + 轮询 dashboard 观察 + 校验(与 singlebox 参考测同口径)。
+
+# 预发接入默认(已确认)
+
+- ``owner_bot_id`` / ``participant_bindings`` 用**纯 bot_id**(不带 singlebox 的 ``:user_id``
+  透传 —— 那是 singlebox adapter 专属;预发真 BCS 走纯 id,后端解析身份)。
+- bot 由预发预置,测试不自建(预发能否 ``create_bot`` 未知),id 走环境变量。
+- 鉴权:``x-user_id`` 必填(且作 execute 体里 ``owner_user_id``);预发走 **cookie** 鉴权而非 bearer。
+  ``AVERNET_E2E_COOKIE`` 值若指向一个**已存在文件**,从该文件读 cookie 内容(单行,去末尾换行);
+  否则把值当 cookie 原文(``name1=v1; name2=v2``)。非空则加 ``Cookie`` 头。
+- yaml 协同模板从 singlebox 参考测 import(单一信源,免漂移/免转抄)。
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import unittest
+
+import httpx
+
+# 复刻同一份 yaml 协同模板(单一信源):与 singlebox 参考测同源,免转抄/免漂移。
+from tests.community.core.task.singlebox_e2e.yaml.test_writing_qc_state_machine_e2e import (
+    WRITING_QC_YAML,
+)
+
+_LIVE = os.environ.get("AVERNET_PRE_TASK_E2E", "").strip() in {"1", "true"}
+_BACKEND = os.environ.get("AVERNET_PRE_BACKEND_URL", "").strip().rstrip("/")
+_USER_ID = os.environ.get("AVERNET_E2E_USER_ID", "").strip()
+_COOKIE_IN = os.environ.get("AVERNET_E2E_COOKIE", "").strip()
+# 支持两种:AVERNET_E2E_COOKIE 指向已存在文件 → 从该文件读 cookie(单行,去末尾换行);
+# 否则把值当 cookie 原文(name1=v1; name2=v2)。读失败兜底为空,不让 cookie 文件问题破坏测试收集。
+if _COOKIE_IN and os.path.isfile(_COOKIE_IN):
+    try:
+        with open(_COOKIE_IN, "r", encoding="utf-8") as _f:
+            _COOKIE = _f.read().strip()
+        _COOKIE_SRC = "file"
+    except OSError:
+        _COOKIE = ""
+        _COOKIE_SRC = "file-read-error"
+elif _COOKIE_IN:
+    _COOKIE = _COOKIE_IN
+    _COOKIE_SRC = "inline"
+else:
+    _COOKIE = ""
+    _COOKIE_SRC = "none"
+_WRITER_ID = os.environ.get("AVERNET_E2E_WRITER_BOT_ID", "").strip()
+_EDITOR_ID = os.environ.get("AVERNET_E2E_EDITOR_BOT_ID", "").strip()
+_TIMEOUT = float(os.environ.get("AVERNET_PRE_TASK_E2E_TIMEOUT", "2000"))
+
+_READY = bool(_LIVE and _BACKEND and _USER_ID and _WRITER_ID and _EDITOR_ID)
+
+_HDRS: dict[str, str] = {"x-user-id": _USER_ID, "accept": "application/json"}
+if _COOKIE:
+    _HDRS["Cookie"] = _COOKIE
+
+
+def _execute_body(writer_id: str, editor_id: str) -> dict:
+    """``POST /api/v1/collaboration/tasks/execute`` 请求体(预发版:纯 bot_id,无 :user_id 透传)。
+
+    与 singlebox 参考测同构,但 ``owner_bot_id`` / ``participant_bindings`` 用纯 bot_id
+    (预发真 BCS 由后端解析身份,不像 singlebox adapter 走 ``bot_id:user_id`` 透传)。
+    """
+    return {
+        "task_spec": {
+            "metadata": {
+                "title": "写作质检协同",
+                "instruction": "请按写作质检协同流程产出最终回复。",
+            },
+            "context": {
+                "background": "写作质检协同预发 e2e:writer 产出初稿→editor 润色→editor 生成最终回复(线性)。",
+                "extend_props": {},
+            },
+            "goal": {
+                "objective": "就「远程办公协作工具的发展趋势」写一篇短文,经写作质检协同后产出最终回复。",
+                "acceptances": [
+                    {"id": "ac1", "acceptance": "最终回复包含结论、依据、风险和下一步建议"},
+                    {"id": "ac2", "acceptance": "最终回复经质检通过且已润色"},
+                ],
+            },
+        },
+        "source_type": "bot",
+        "owner_user_id": _USER_ID,
+        # 纯 bot_id(预发真 BCS 解析身份,无 singlebox :user_id 透传)。
+        "owner_bot_id": writer_id,
+        "execution_config": {
+            "task_type": "yaml",
+            "yaml": WRITING_QC_YAML,
+            "participant_bot_ids": [editor_id],
+            "participant_bindings": {
+                "writer": [writer_id],
+                "editor": [editor_id],
+            },
+            "group_name": "写作质检协同群(预发e2e)",
+        },
+    }
+
+
+@unittest.skipUnless(
+    _READY,
+    "设置 AVERNET_PRE_TASK_E2E=1 + AVERNET_PRE_BACKEND_URL + AVERNET_E2E_USER_ID + "
+    "AVERNET_E2E_WRITER_BOT_ID + AVERNET_E2E_EDITOR_BOT_ID 启用预发 e2e",
+)
+class TestWritingQcStateMachinePreE2E(unittest.TestCase):
+    def test_execute_yaml_state_machine_runs_to_done(self) -> None:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(self._run())
+        finally:
+            loop.close()
+
+    async def _run(self) -> None:
+        print(
+            f"[pre-e2e] backend={_BACKEND} user={_USER_ID} "
+            f"writer={_WRITER_ID} editor={_EDITOR_ID} cookie={_COOKIE_SRC}"
+        )
+        g: dict = {}
+        async with httpx.AsyncClient(timeout=300.0, headers=_HDRS) as cli:
+            # 1) POST /execute → TaskService.execute → _run_yaml成立 BCS 协作群(预发自动跑状态机)
+            r = await cli.post(
+                f"{_BACKEND}/api/v1/collaboration/tasks/execute",
+                json=_execute_body(_WRITER_ID, _EDITOR_ID),
+            )
+            r.raise_for_status()
+            body = r.json()
+            data = body.get("data") or {}
+            print(f"[execute] message={body.get('message')} data={data}")
+            self.assertTrue(data.get("success"), f"execute 未成功:{data}")
+            task_id = data.get("task_id")
+            self.assertTrue(task_id, f"execute 响应缺 task_id:{data}")
+
+            # 2) 轮询 dashboard(回调服务收到的执行进度落图)直到任务结束 / 超时
+            deadline = time.monotonic() + _TIMEOUT
+            while time.monotonic() < deadline:
+                pr = await cli.get(
+                    f"{_BACKEND}/api/v1/collaboration/tasks/dashboard",
+                    params={"task_id": task_id},
+                )
+                pr.raise_for_status()
+                g = pr.json().get("data") or {}
+                tasks = g.get("tasks") or []
+                snap = []
+                for t in tasks:
+                    ri = t.get("run_info") or {}
+                    snap.append({
+                        "node_id": t.get("node_id"),
+                        "status": t.get("status"),
+                        "run_mode": ri.get("run_mode") or "",
+                        "assignee": str(ri.get("assignee") or "")[:32],
+                        "extend_props": ri.get("extend_props") or {},
+                        "exec_error": ri.get("exec_error"),
+                        "verdict": (ri.get("acceptance_result") or {}).get("verdict"),
+                    })
+                print(f"[snapshot] graph={g.get('status')} loop={g.get('loop_round')} nodes={snap}")
+                if g.get("status") in ("DONE", "HUNG"):
+                    break
+                await asyncio.sleep(6.0)
+
+        # 3) 输出 + 校验执行结果(与 singlebox 参考测同口径)
+        print(f"[final] graph={g.get('status')} tasks={len(g.get('tasks') or [])}")
+        nodes = {t.get("node_id"): t for t in g.get("tasks") or []}
+        root = nodes.get(task_id)
+        for nid, nd in nodes.items():
+            ri = nd.get("run_info") or {}
+            print(
+                f"  - {str(nid):28} {str(nd.get('status')):8} "
+                f"mode={ri.get('run_mode') or '-':11} "
+                f"assignee={str(ri.get('assignee') or '-')[:24]} "
+                f"verdict={(ri.get('acceptance_result') or {}).get('verdict')}"
+            )
+
+        self.assertEqual(
+            g.get("status"), "DONE",
+            f"全图未闭环 DONE:status={g.get('status')} (BCS 未自动运行状态机/未回投?)",
+        )
+        self.assertIsNotNone(root, "根节点(task_id)未出现")
+        self.assertEqual(root.get("status"), "DONE", "根未 DONE")
+        ri = root.get("run_info") or {}
+        self.assertEqual(ri.get("run_mode"), "coop_group", "根非 coop_group")
+        # 群 id 前缀容忍:真 BCS 产 bcs_grp_<uuid>;本地 stub/double 产 grp_<8hex>。
+        self.assertTrue(
+            str(ri.get("assignee") or "").startswith(("grp_", "bcs_grp_")),
+            f"根 assignee 非群 id:{ri.get('assignee')!r}",
+        )
+        acceptance = ri.get("acceptance_result") or {}
+        self.assertEqual(
+            acceptance.get("verdict"), "PASS",
+            f"根验收未 PASS:{acceptance} (BCS 回投 success=false?)",
+        )
+        output = ri.get("output")
+        self.assertTrue(output, "根无最终输出(output 为空)")
+        print(f"[result] output={str(output)!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/backend/tests/community/core/task/e2e/test_writing_qc_state_machine_pre_e2e_yaml.py
+++ b/src/backend/tests/community/core/task/e2e/test_writing_qc_state_machine_pre_e2e_yaml.py
@@ -1,0 +1,221 @@
+"""预发环境 e2e — 写作质检协同(state_machine),直连预发后端。
+
+参考 ``singlebox_e2e/yaml/test_writing_qc_state_machine_e2e.py`` 的回路
+(execute → 轮询 dashboard → DONE),但打**预发**:backend URL / 鉴权 / 预置 bot id 全走
+环境变量,空缺即 skip(CI 安全)。
+
+gated by ``AVERNET_PRE_TASK_E2E=1``;无需起 singlebox,直接打预发:
+
+  AVERNET_PRE_TASK_E2E=1 \\
+  AVERNET_PRE_BACKEND_URL=https://<预发host> \\
+  AVERNET_E2E_USER_ID=<uid> \\
+  AVERNET_E2E_WRITER_BOT_ID=<预置 writer bot id> \\
+  AVERNET_E2E_EDITOR_BOT_ID=<预置 editor bot id> \\
+  [AVERNET_E2E_COOKIE=<cookie文件路径 或 整段Cookie原文>] \\
+  [AVERNET_PRE_TASK_E2E_TIMEOUT=2000] \\
+  src/backend/.venv/bin/python -m pytest \\
+    src/backend/tests/community/core/task/e2e/test_writing_qc_state_machine_pre_e2e_yaml.py -s
+
+# 场景
+
+复刻参考测的 yaml 协同模板(state_machine):draft → polish → finalize 线性。
+经 ``POST /api/v1/collaboration/tasks/execute`` 提交 yaml 协同模板 + ``participant_bindings``
+→ 预发 BCS 收群自动跑状态机 → 终态经回调 POST 回预发本后端
+``/api/v1/collaboration/tasks/callback/report``(预发 ``api_base_url`` = corp overlay
+``economy_governance.iframe_callback_url_pre`` 的 origin)→ ``TaskLoopCallback.report_result``
+→ ``on_report`` → 图收敛。用例只做:提交 + 轮询 dashboard 观察 + 校验(与 singlebox 参考测同口径)。
+
+# 预发接入默认(已确认)
+
+- ``owner_bot_id`` / ``participant_bindings`` 用**纯 bot_id**(不带 singlebox 的 ``:user_id``
+  透传 —— 那是 singlebox adapter 专属;预发真 BCS 走纯 id,后端解析身份)。
+- bot 由预发预置,测试不自建(预发能否 ``create_bot`` 未知),id 走环境变量。
+- 鉴权:``x-user_id`` 必填(且作 execute 体里 ``owner_user_id``);预发走 **cookie** 鉴权而非 bearer。
+  ``AVERNET_E2E_COOKIE`` 值若指向一个**已存在文件**,从该文件读 cookie 内容(单行,去末尾换行);
+  否则把值当 cookie 原文(``name1=v1; name2=v2``)。非空则加 ``Cookie`` 头。
+- yaml 协同模板从 singlebox 参考测 import(单一信源,免漂移/免转抄)。
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+import unittest
+
+import httpx
+
+# 复刻同一份 yaml 协同模板(单一信源):与 singlebox 参考测同源,免转抄/免漂移。
+from tests.community.core.task.singlebox_e2e.yaml.test_writing_qc_state_machine_e2e import (
+    WRITING_QC_YAML,
+)
+
+_LIVE = os.environ.get("AVERNET_PRE_TASK_E2E", "").strip() in {"1", "true"}
+_BACKEND = os.environ.get("AVERNET_PRE_BACKEND_URL", "").strip().rstrip("/")
+_USER_ID = os.environ.get("AVERNET_E2E_USER_ID", "").strip()
+_COOKIE_IN = os.environ.get("AVERNET_E2E_COOKIE", "").strip()
+# 支持两种:AVERNET_E2E_COOKIE 指向已存在文件 → 从该文件读 cookie(单行,去末尾换行);
+# 否则把值当 cookie 原文(name1=v1; name2=v2)。读失败兜底为空,不让 cookie 文件问题破坏测试收集。
+if _COOKIE_IN and os.path.isfile(_COOKIE_IN):
+    try:
+        with open(_COOKIE_IN, "r", encoding="utf-8") as _f:
+            _COOKIE = _f.read().strip()
+        _COOKIE_SRC = "file"
+    except OSError:
+        _COOKIE = ""
+        _COOKIE_SRC = "file-read-error"
+elif _COOKIE_IN:
+    _COOKIE = _COOKIE_IN
+    _COOKIE_SRC = "inline"
+else:
+    _COOKIE = ""
+    _COOKIE_SRC = "none"
+_WRITER_ID = os.environ.get("AVERNET_E2E_WRITER_BOT_ID", "").strip()
+_EDITOR_ID = os.environ.get("AVERNET_E2E_EDITOR_BOT_ID", "").strip()
+_TIMEOUT = float(os.environ.get("AVERNET_PRE_TASK_E2E_TIMEOUT", "2000"))
+
+_READY = bool(_LIVE and _BACKEND and _USER_ID and _WRITER_ID and _EDITOR_ID)
+
+_HDRS: dict[str, str] = {"x-user-id": _USER_ID, "accept": "application/json"}
+if _COOKIE:
+    _HDRS["Cookie"] = _COOKIE
+
+
+def _execute_body(writer_id: str, editor_id: str) -> dict:
+    """``POST /api/v1/collaboration/tasks/execute`` 请求体(预发版:纯 bot_id,无 :user_id 透传)。
+
+    与 singlebox 参考测同构,但 ``owner_bot_id`` / ``participant_bindings`` 用纯 bot_id
+    (预发真 BCS 由后端解析身份,不像 singlebox adapter 走 ``bot_id:user_id`` 透传)。
+    """
+    return {
+        "task_spec": {
+            "metadata": {
+                "title": "写作质检协同",
+                "instruction": "请按写作质检协同流程产出最终回复。",
+            },
+            "context": {
+                "background": "写作质检协同预发 e2e:writer 产出初稿→editor 润色→editor 生成最终回复(线性)。",
+                "extend_props": {},
+            },
+            "goal": {
+                "objective": "就「远程办公协作工具的发展趋势」写一篇短文,经写作质检协同后产出最终回复。",
+                "acceptances": [
+                    {"id": "ac1", "acceptance": "最终回复包含结论、依据、风险和下一步建议"},
+                    {"id": "ac2", "acceptance": "最终回复经质检通过且已润色"},
+                ],
+            },
+        },
+        "source_type": "bot",
+        "owner_user_id": _USER_ID,
+        # 纯 bot_id(预发真 BCS 解析身份,无 singlebox :user_id 透传)。
+        "owner_bot_id": writer_id,
+        "execution_config": {
+            "task_type": "yaml",
+            "yaml": WRITING_QC_YAML,
+            "participant_bot_ids": [editor_id],
+            "participant_bindings": {
+                "writer": [writer_id],
+                "editor": [editor_id],
+            },
+            "group_name": "写作质检协同群(预发e2e)",
+        },
+    }
+
+
+@unittest.skipUnless(
+    _READY,
+    "设置 AVERNET_PRE_TASK_E2E=1 + AVERNET_PRE_BACKEND_URL + AVERNET_E2E_USER_ID + "
+    "AVERNET_E2E_WRITER_BOT_ID + AVERNET_E2E_EDITOR_BOT_ID 启用预发 e2e",
+)
+class TestWritingQcStateMachinePreE2E(unittest.TestCase):
+    def test_execute_yaml_state_machine_runs_to_done(self) -> None:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(self._run())
+        finally:
+            loop.close()
+
+    async def _run(self) -> None:
+        print(
+            f"[pre-e2e] backend={_BACKEND} user={_USER_ID} "
+            f"writer={_WRITER_ID} editor={_EDITOR_ID} cookie={_COOKIE_SRC}"
+        )
+        g: dict = {}
+        async with httpx.AsyncClient(timeout=300.0, headers=_HDRS) as cli:
+            # 1) POST /execute → TaskService.execute → _run_yaml成立 BCS 协作群(预发自动跑状态机)
+            r = await cli.post(
+                f"{_BACKEND}/api/v1/collaboration/tasks/execute",
+                json=_execute_body(_WRITER_ID, _EDITOR_ID),
+            )
+            r.raise_for_status()
+            body = r.json()
+            data = body.get("data") or {}
+            print(f"[execute] message={body.get('message')} data={data}")
+            self.assertTrue(data.get("success"), f"execute 未成功:{data}")
+            task_id = data.get("task_id")
+            self.assertTrue(task_id, f"execute 响应缺 task_id:{data}")
+
+            # 2) 轮询 dashboard(回调服务收到的执行进度落图)直到任务结束 / 超时
+            deadline = time.monotonic() + _TIMEOUT
+            while time.monotonic() < deadline:
+                pr = await cli.get(
+                    f"{_BACKEND}/api/v1/collaboration/tasks/dashboard",
+                    params={"task_id": task_id},
+                )
+                pr.raise_for_status()
+                g = pr.json().get("data") or {}
+                tasks = g.get("tasks") or []
+                snap = []
+                for t in tasks:
+                    ri = t.get("run_info") or {}
+                    snap.append({
+                        "node_id": t.get("node_id"),
+                        "status": t.get("status"),
+                        "run_mode": ri.get("run_mode") or "",
+                        "assignee": str(ri.get("assignee") or "")[:32],
+                        "extend_props": ri.get("extend_props") or {},
+                        "exec_error": ri.get("exec_error"),
+                        "verdict": (ri.get("acceptance_result") or {}).get("verdict"),
+                    })
+                print(f"[snapshot] graph={g.get('status')} loop={g.get('loop_round')} nodes={snap}")
+                if g.get("status") in ("DONE", "HUNG"):
+                    break
+                await asyncio.sleep(6.0)
+
+        # 3) 输出 + 校验执行结果(与 singlebox 参考测同口径)
+        print(f"[final] graph={g.get('status')} tasks={len(g.get('tasks') or [])}")
+        nodes = {t.get("node_id"): t for t in g.get("tasks") or []}
+        root = nodes.get(task_id)
+        for nid, nd in nodes.items():
+            ri = nd.get("run_info") or {}
+            print(
+                f"  - {str(nid):28} {str(nd.get('status')):8} "
+                f"mode={ri.get('run_mode') or '-':11} "
+                f"assignee={str(ri.get('assignee') or '-')[:24]} "
+                f"verdict={(ri.get('acceptance_result') or {}).get('verdict')}"
+            )
+
+        self.assertEqual(
+            g.get("status"), "DONE",
+            f"全图未闭环 DONE:status={g.get('status')} (BCS 未自动运行状态机/未回投?)",
+        )
+        self.assertIsNotNone(root, "根节点(task_id)未出现")
+        self.assertEqual(root.get("status"), "DONE", "根未 DONE")
+        ri = root.get("run_info") or {}
+        self.assertEqual(ri.get("run_mode"), "coop_group", "根非 coop_group")
+        # 群 id 前缀容忍:真 BCS 产 bcs_grp_<uuid>;本地 stub/double 产 grp_<8hex>。
+        self.assertTrue(
+            str(ri.get("assignee") or "").startswith(("grp_", "bcs_grp_")),
+            f"根 assignee 非群 id:{ri.get('assignee')!r}",
+        )
+        acceptance = ri.get("acceptance_result") or {}
+        self.assertEqual(
+            acceptance.get("verdict"), "PASS",
+            f"根验收未 PASS:{acceptance} (BCS 回投 success=false?)",
+        )
+        output = ri.get("output")
+        self.assertTrue(output, "根无最终输出(output 为空)")
+        print(f"[result] output={str(output)!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/backend/tests/community/core/task/task_center/test_execute_task_type_branching.py
+++ b/src/backend/tests/community/core/task/task_center/test_execute_task_type_branching.py
@@ -174,3 +174,76 @@ def test_execute_yaml_forwards_participant_bindings_to_group():
     assert ep.get("participant_bindings") == bindings
     # 任务描述(目标)从 task_spec.goal.objective 透传进 extend_props(→ BCS 建群 context → <GroupContext> 目标)
     assert ep.get("task_context") == "o"
+
+
+# ===== execution_config.group_kind(补充,不破坏既有 has_yaml→state_machine 判断) =====
+
+def _start_recording(eng):
+    async def start(gf):
+        eng.calls.append(("yaml", gf.collab_mode))
+        return eng.group_start
+    eng.start_coop_group = start
+
+
+def test_execute_yaml_group_kind_chat_without_yaml():
+    """group_kind=chat + 无 yaml → collab_mode=chat(新增口子)。"""
+    eng = _FakeEngine(graph=None)
+    _start_recording(eng)
+    svc, _, _ = _service(eng)
+    asyncio.new_event_loop().run_until_complete(
+        svc.execute(_request(TaskType.YAML, group_kind="chat")))
+    assert ("yaml", "chat") in eng.calls
+
+
+def test_execute_yaml_group_kind_explicit_manager_worker_without_yaml():
+    """group_kind=manager_worker + 无 yaml → collab_mode=manager_worker(显式确认,现有默认)。"""
+    eng = _FakeEngine(graph=None)
+    _start_recording(eng)
+    svc, _, _ = _service(eng)
+    asyncio.new_event_loop().run_until_complete(
+        svc.execute(_request(TaskType.YAML, group_kind="manager_worker")))
+    assert ("yaml", "manager_worker") in eng.calls
+
+
+def test_execute_yaml_group_kind_absent_without_yaml_still_manager_worker():
+    """group_kind 缺省 + 无 yaml → manager_worker(既有默认不变)。"""
+    eng = _FakeEngine(graph=None)
+    _start_recording(eng)
+    svc, _, _ = _service(eng)
+    asyncio.new_event_loop().run_until_complete(svc.execute(_request(TaskType.YAML)))
+    assert ("yaml", "manager_worker") in eng.calls
+
+
+def test_execute_yaml_group_kind_state_machine_without_yaml_raises():
+    """group_kind=state_machine 但无 yaml 定义 → ValueError(没定义跑不了 state_machine)。"""
+    eng = _FakeEngine(graph=None)
+    _start_recording(eng)
+    svc, _, _ = _service(eng)
+    with pytest.raises(ValueError):
+        asyncio.new_event_loop().run_until_complete(
+            svc.execute(_request(TaskType.YAML, group_kind="state_machine")))
+    assert not any(c[0] == "yaml" for c in eng.calls)   # 没建群
+
+
+def test_execute_yaml_group_kind_unknown_raises():
+    """group_kind 未知值 → ValueError。"""
+    eng = _FakeEngine(graph=None)
+    _start_recording(eng)
+    svc, _, _ = _service(eng)
+    with pytest.raises(ValueError):
+        asyncio.new_event_loop().run_until_complete(
+            svc.execute(_request(TaskType.YAML, group_kind="nonsense")))
+
+
+def test_execute_yaml_with_yaml_ignores_group_kind_chat():
+    """有 yaml → state_machine(既有 has_yaml 判断不变;group_kind=chat 被忽略,不介入)。"""
+    eng = _FakeEngine(graph=None)
+
+    async def start(gf):
+        eng.calls.append(("yaml", gf.collab_mode, gf.extend_props.get("definition_yaml")))
+        return eng.group_start
+    eng.start_coop_group = start
+    svc, _, _ = _service(eng)
+    asyncio.new_event_loop().run_until_complete(
+        svc.execute(_request(TaskType.YAML, yaml="def: x", group_kind="chat")))
+    assert ("yaml", "state_machine", "def: x") in eng.calls

--- a/src/backend/tests/community/core/task/task_runner/integration/test_bcs_bot_token_provider.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_bcs_bot_token_provider.py
@@ -1,12 +1,13 @@
 """BcsBotTokenProvider:driver-bot 的 BCS session_token 取数(参考 ocb ZdasBotTokenProvider)。
 
-prod 经 ZDAS ``agentclawdb_ds`` 直读 ``bcs_bots.session_token WHERE bot_uuid=?``(corp 覆写注入 resolver);
-本测只验证 TTL 缓存与降级行为(resolver 可替换为桩),不触真实 DB。
+prod 经 ZDAS ``agentclawdb_ds``(本仓 prod DatabasePlugin,即 bcs_bots 所在库)直读
+``bcs_bots.session_token WHERE bot_uuid=?``;本测用伪 DatabasePlugin 验证 SQL/缓存/降级,不触真实 DB。
 """
 from __future__ import annotations
 
 from agentclaw.community.core.task.task_runner.integration.bcs_bot_token_provider import (
     BcsBotTokenProvider, CachingBcsBotTokenProvider, NullBcsBotTokenProvider,
+    ZdasBcsBotTokenProvider,
 )
 
 
@@ -53,3 +54,88 @@ def test_caching_provider_none_result_short_caches_to_avoid_db_hammer():
 def test_caching_provider_is_a_bcs_bot_token_provider():
     p = CachingBcsBotTokenProvider(resolver=lambda _u: None)
     assert isinstance(p, BcsBotTokenProvider)
+
+
+# ===== ZdasBcsBotTokenProvider:经 DatabasePlugin.orm_session() 直读 bcs_bots.session_token + TTL 缓存 =====
+
+class _FakeRow:  # 模拟 sqlalchemy Row:row[0] = session_token
+    def __init__(self, value):
+        self._value = value
+
+    def __getitem__(self, idx):
+        return self._value
+
+
+class _FakeResult:
+    def __init__(self, row):
+        self._row = row  # Row 或 None(未命中)
+
+    def first(self):
+        return self._row
+
+
+class _FakeSession:
+    def __init__(self, value=None, *, raises=False, execute_calls=None):
+        self._value = value
+        self._raises = raises
+        self._execute_calls = execute_calls
+
+    def execute(self, sql, params):
+        if self._execute_calls is not None:
+            self._execute_calls.append(params.get("uuid"))
+            assert "bcs_bots" in str(sql), "应直读 bcs_bots 表"
+        if self._raises:
+            raise RuntimeError("no such table: bcs_bots")
+        return _FakeResult(_FakeRow(self._value) if self._value is not None else None)
+
+
+class _FakeCm:
+    def __init__(self, session):
+        self._session = session
+
+    def __enter__(self):
+        return self._session
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeDbPlugin:
+    def __init__(self, session):
+        self._session = session
+
+    def orm_session(self):
+        return _FakeCm(self._session)
+
+
+def test_zdas_provider_reads_session_token_and_caches():
+    calls = []
+    now = [0.0]
+    p = ZdasBcsBotTokenProvider(
+        _FakeDbPlugin(_FakeSession("tok-drv", execute_calls=calls)),
+        ttl_s=300, clock=lambda: now[0],
+    )
+    assert p.get_token("drv:35983") == "tok-drv"
+    assert p.get_token("drv:35983") == "tok-drv"   # 命中缓存
+    assert calls == ["drv:35983"]                   # 只查一次
+    now[0] = 301                                    # 超过 TTL
+    assert p.get_token("drv:35983") == "tok-drv"
+    assert calls == ["drv:35983", "drv:35983"]      # 过期重查
+
+
+def test_zdas_provider_returns_none_when_not_found():
+    calls = []
+    p = ZdasBcsBotTokenProvider(_FakeDbPlugin(_FakeSession(None, execute_calls=calls)))
+    assert p.get_token("ghost") is None             # .first() 返 None → None
+    assert calls == ["ghost"]
+
+
+def test_zdas_provider_returns_none_when_db_errors():
+    p = ZdasBcsBotTokenProvider(_FakeDbPlugin(_FakeSession(raises=True)))  # 本地 SQLite 无 bcs_bots 表 → 抛错
+    assert p.get_token("drv:35983") is None         # 吞错降级,不发 Bearer
+
+
+def test_zdas_provider_is_a_bcs_bot_token_provider():
+    p = ZdasBcsBotTokenProvider(_FakeDbPlugin(_FakeSession(None)))
+    assert isinstance(p, BcsBotTokenProvider)
+

--- a/src/backend/tests/community/core/task/task_runner/integration/test_bcs_bot_token_provider.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_bcs_bot_token_provider.py
@@ -1,0 +1,55 @@
+"""BcsBotTokenProvider:driver-bot 的 BCS session_token 取数(参考 ocb ZdasBotTokenProvider)。
+
+prod 经 ZDAS ``agentclawdb_ds`` 直读 ``bcs_bots.session_token WHERE bot_uuid=?``(corp 覆写注入 resolver);
+本测只验证 TTL 缓存与降级行为(resolver 可替换为桩),不触真实 DB。
+"""
+from __future__ import annotations
+
+from agentclaw.community.core.task.task_runner.integration.bcs_bot_token_provider import (
+    BcsBotTokenProvider, CachingBcsBotTokenProvider, NullBcsBotTokenProvider,
+)
+
+
+def test_null_provider_returns_none():
+    p = NullBcsBotTokenProvider()
+    assert p.get_token("any_bot") is None
+    assert isinstance(p, BcsBotTokenProvider)  # 结构化满足端口
+
+
+def test_caching_provider_returns_and_caches_within_ttl():
+    calls = {"n": 0}
+
+    def resolver(bot_uuid: str) -> str | None:
+        calls["n"] += 1
+        return "tok-" + bot_uuid
+
+    now = [0.0]
+    p = CachingBcsBotTokenProvider(resolver=resolver, ttl_s=300, clock=lambda: now[0])
+    assert p.get_token("botA") == "tok-botA"
+    assert p.get_token("botA") == "tok-botA"   # 命中缓存
+    assert calls["n"] == 1                     # resolver 只调一次
+    now[0] = 301                               # 超过 TTL
+    assert p.get_token("botA") == "tok-botA"
+    assert calls["n"] == 2                     # 过期后重新查询
+
+
+def test_caching_provider_none_result_short_caches_to_avoid_db_hammer():
+    calls = {"n": 0}
+
+    def resolver(bot_uuid: str) -> str | None:
+        calls["n"] += 1
+        return None
+
+    now = [0.0]
+    p = CachingBcsBotTokenProvider(resolver=resolver, ttl_s=300, clock=lambda: now[0])
+    assert p.get_token("ghost") is None
+    assert p.get_token("ghost") is None        # 未命中结果短缓存
+    assert calls["n"] == 1                      # 不重复打 DB
+    now[0] = 61                                  # 超过 fail-TTL(≤60)
+    assert p.get_token("ghost") is None
+    assert calls["n"] == 2                       # 过期后重新查
+
+
+def test_caching_provider_is_a_bcs_bot_token_provider():
+    p = CachingBcsBotTokenProvider(resolver=lambda _u: None)
+    assert isinstance(p, BcsBotTokenProvider)

--- a/src/backend/tests/community/core/task/task_runner/integration/test_bcs_bot_token_provider.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_bcs_bot_token_provider.py
@@ -1,14 +1,15 @@
-"""BcsBotTokenProvider:driver-bot 的 BCS session_token 取数(参考 ocb ZdasBotTokenProvider)。
+"""BcsBotTokenProvider:driver-bot 的 BCS session_token 取数(参考 ocb)。
 
-prod 经 ZDAS ``agentclawdb_ds``(本仓 prod DatabasePlugin,即 bcs_bots 所在库)直读
-``bcs_bots.session_token WHERE bot_uuid=?``;本测用伪 DatabasePlugin 验证 SQL/缓存/降级,不触真实 DB。
+中性端口 + Null + Caching 在 core;DB-backed 默认 provider(``DbBcsBotTokenProvider``)
+在 community/plugins,经 prod ``DatabasePlugin`` 直读 ``bcs_bots.session_token``。
+本测用伪 DatabasePlugin 验证 SQL/缓存/降级,不触真实 DB。
 """
 from __future__ import annotations
 
 from agentclaw.community.core.task.task_runner.integration.bcs_bot_token_provider import (
     BcsBotTokenProvider, CachingBcsBotTokenProvider, NullBcsBotTokenProvider,
-    ZdasBcsBotTokenProvider,
 )
+from agentclaw.community.plugins.community.bcs_bot_token_provider import DbBcsBotTokenProvider
 
 
 def test_null_provider_returns_none():
@@ -56,7 +57,7 @@ def test_caching_provider_is_a_bcs_bot_token_provider():
     assert isinstance(p, BcsBotTokenProvider)
 
 
-# ===== ZdasBcsBotTokenProvider:经 DatabasePlugin.orm_session() 直读 bcs_bots.session_token + TTL 缓存 =====
+# ===== DbBcsBotTokenProvider:经 DatabasePlugin.orm_session() 直读 bcs_bots.session_token + TTL 缓存 =====
 
 class _FakeRow:  # 模拟 sqlalchemy Row:row[0] = session_token
     def __init__(self, value):
@@ -108,10 +109,10 @@ class _FakeDbPlugin:
         return _FakeCm(self._session)
 
 
-def test_zdas_provider_reads_session_token_and_caches():
+def test_db_provider_reads_session_token_and_caches():
     calls = []
     now = [0.0]
-    p = ZdasBcsBotTokenProvider(
+    p = DbBcsBotTokenProvider(
         _FakeDbPlugin(_FakeSession("tok-drv", execute_calls=calls)),
         ttl_s=300, clock=lambda: now[0],
     )
@@ -123,19 +124,18 @@ def test_zdas_provider_reads_session_token_and_caches():
     assert calls == ["drv:35983", "drv:35983"]      # 过期重查
 
 
-def test_zdas_provider_returns_none_when_not_found():
+def test_db_provider_returns_none_when_not_found():
     calls = []
-    p = ZdasBcsBotTokenProvider(_FakeDbPlugin(_FakeSession(None, execute_calls=calls)))
+    p = DbBcsBotTokenProvider(_FakeDbPlugin(_FakeSession(None, execute_calls=calls)))
     assert p.get_token("ghost") is None             # .first() 返 None → None
     assert calls == ["ghost"]
 
 
-def test_zdas_provider_returns_none_when_db_errors():
-    p = ZdasBcsBotTokenProvider(_FakeDbPlugin(_FakeSession(raises=True)))  # 本地 SQLite 无 bcs_bots 表 → 抛错
+def test_db_provider_returns_none_when_db_errors():
+    p = DbBcsBotTokenProvider(_FakeDbPlugin(_FakeSession(raises=True)))  # 本地无 bcs_bots 表 → 抛错
     assert p.get_token("drv:35983") is None         # 吞错降级,不发 Bearer
 
 
-def test_zdas_provider_is_a_bcs_bot_token_provider():
-    p = ZdasBcsBotTokenProvider(_FakeDbPlugin(_FakeSession(None)))
+def test_db_provider_is_a_bcs_bot_token_provider():
+    p = DbBcsBotTokenProvider(_FakeDbPlugin(_FakeSession(None)))
     assert isinstance(p, BcsBotTokenProvider)
-

--- a/src/backend/tests/community/core/task/task_runner/integration/test_bcs_http_adapter.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_bcs_http_adapter.py
@@ -107,6 +107,37 @@ def test_client_4xx_raises():
         _run(_adapter(h).get_group("g1"))
 
 
+# ===== BCS 建群参考 ocb:可选带 driver-bot Bearer(Authorization)做 caller 身份;HMAC X-ECB-* 照常 =====
+def test_create_group_forwards_caller_bot_token_as_bearer():
+    seen = {}
+
+    def h(req):
+        seen["auth"] = req.headers.get("authorization")
+        seen["token"] = req.headers.get("X-ECB-Token")
+        seen["sig"] = req.headers.get("X-ECB-Signature")
+        return httpx.Response(200, json={"group_id": "g_bearer"})
+
+    req = BcsCreateGroupRequest(driver_bot="drv", participants=[{"bot_uuid": "drv"}],
+                                caller_bot_token="drv-session-token")
+    res = _run(_adapter(h).create_group(req))
+    assert res.group_id == "g_bearer"
+    assert seen["auth"] == "Bearer drv-session-token"
+    assert seen["token"] == "drv"          # HMAC X-ECB-* 照常签发
+    assert seen["sig"] is not None
+
+
+def test_create_group_omits_bearer_when_no_caller_bot_token():
+    seen = {}
+
+    def h(req):
+        seen["auth"] = req.headers.get("authorization")
+        return httpx.Response(200, json={"group_id": "g_no_bearer"})
+
+    req = BcsCreateGroupRequest(driver_bot="drv", participants=[{"bot_uuid": "drv"}])
+    _run(_adapter(h).create_group(req))
+    assert seen["auth"] is None             # 无 token 不发 Authorization
+
+
 def test_owned_client_isolated_when_event_loop_changes(monkeypatch):
     import agentclaw.community.core.task.task_runner.integration.bcs_http_adapter as module
 

--- a/src/backend/tests/community/core/task/task_runner/integration/test_executor_e2e.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_executor_e2e.py
@@ -194,6 +194,50 @@ class TestCoopGroupManagerWorkerE2E:
         _stop_poller(eng)
 
 
+# ===== Test 2b: manager_worker 群建群内联挂 §4 event_subscriptions(execute→engine→form_coop_group→create_group) =====
+class _RecordingDoubleBcsClient(_DoubleBcsClient):
+    """记录所有 create_group 请求(供断言 manager_worker 群挂了 §4 订阅)。"""
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.created_reqs: list = []
+
+    async def create_group(self, req):
+        self.created_reqs.append(req)
+        return await super().create_group(req)
+
+
+class TestManagerWorkerEventSubscriptionsE2E:
+    def test_execute_manager_worker_group_attaches_event_subscriptions(self):
+        """execute(on_execute)→动态派发 manager_worker 群→form_coop_group→create_group 内联挂 §4 订阅。
+        鉴权走既有 Bearer(+HMAC),无 cookie(见 spec §4.3);sink.url 用 api_base_url 拼 Avernet 回调路由。"""
+        svc = TaskGraphService()
+        svc.initialize_graph(_task_info())
+        bcs = _RecordingDoubleBcsClient(poll_once_then_terminal=False)   # 建群即可断言,不靠终态
+        eng = ExecutionEngine(svc, bot=_PhaseBot(), bcs=bcs, discover=_DiscoverStub(),
+                              bcs_identity=_DoubleBcsBotIdentityResolver(),
+                              api_base_url="https://api.example.com")
+        _run(eng.on_execute("t_phase"))
+        _wait_for(lambda: any(r.group_strategy == "manager_worker" for r in bcs.created_reqs),
+                  timeout=10.0)
+        mw = next(r for r in bcs.created_reqs if r.group_strategy == "manager_worker")
+        subs = mw.event_subscriptions
+        assert subs and len(subs) == 1
+        s = subs[0]
+        assert s["name"] == "avernet-manager-worker"
+        assert s["payload"] == {"mode": "full"}
+        assert set(s["event_filters"]) == {
+            "group.created", "session.created",
+            "task.assigned", "task.completed", "session.completed",   # §4
+        }
+        assert s["sink"]["type"] == "webhook"
+        assert s["sink"]["url"] == "https://api.example.com/api/v1/collaboration/tasks/callback/report"
+        assert s["sink"]["request_timeout_ms"] == 10000
+        # 同批 state_machine 群不挂订阅(只有 manager_worker 挂)
+        sm_reqs = [r for r in bcs.created_reqs if r.group_strategy == "state_machine"]
+        assert sm_reqs and all(not r.event_subscriptions for r in sm_reqs)
+        _stop_poller(eng)
+
+
 # ===== Test 3: state_machine 模态拉群 + poll =====
 class TestCoopGroupStateMachineE2E:
     def test_state_machine_group(self):

--- a/src/backend/tests/community/core/task/task_runner/integration/test_singlebox_bcs_wiring.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_singlebox_bcs_wiring.py
@@ -106,3 +106,18 @@ def test_create_group_state_machine_body_sets_start_initial_run_false():
     assert seen["body"]["group_strategy"] == "state_machine"
     assert seen["body"]["start_initial_run"] is False
     assert seen["body"]["collaboration_definition_yaml"] == "states: [s1, s2]"
+
+
+def test_create_group_forwards_caller_bot_token_as_bearer():
+    """SingleboxBcsAdapter 手写镜像 BcsHttpAdapter.create_group,须同样透传 caller_bot_token 为 Authorization: Bearer。"""
+    seen: dict = {}
+
+    def h(req: httpx.Request) -> httpx.Response:
+        seen["auth"] = req.headers.get("authorization")
+        return httpx.Response(200, json={"id": "g_b", "session_id": None})
+
+    _run(_adapter(httpx.MockTransport(h)).create_group(BcsCreateGroupRequest(
+        driver_bot="bot_ceo", participants=[{"bot_uuid": "bot_p"}],
+        caller_bot_token="drv-tok",
+    )))
+    assert seen["auth"] == "Bearer drv-tok"

--- a/src/backend/tests/community/core/task/task_runner/integration/test_state_machine.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_state_machine.py
@@ -202,6 +202,59 @@ def test_form_coop_group_does_not_attach_event_subscriptions():
     assert not bcs.created_req.event_subscriptions
 
 
+def test_form_coop_group_manager_worker_attaches_event_subscriptions():
+    """manager_worker 群内联挂 §4 event_subscriptions(BCS 主动推回 /callback/report,激活既有
+    apply_manager_worker_event → execution_graph audit 快照 + converge_by_session)。鉴权用既有
+    caller_bot_token(Bearer)+ HMAC,无 cookie(见 spec §4.3)。"""
+    bcs = _Bcs()
+    exe = TaskExecutor(bot=None, bcs=bcs, formatter=PromptFormatterImpl(), context=_Ctx(), sink=None,
+                       poller=_Poller(), identity_resolver=_DoubleBcsBotIdentityResolver(),
+                       api_base_url="https://api.example.com")
+    _run(exe.form_coop_group(GroupFormation(
+        bot_ids=["mgr", "worker"],
+        collab_mode="manager_worker",
+        members_info=[{"bot_id": "mgr", "role": "manager"}, {"bot_id": "worker", "role": "worker"}],
+    )))
+    subs = bcs.created_req.event_subscriptions
+    assert subs and len(subs) == 1
+    s = subs[0]
+    assert s["name"] == "avernet-manager-worker"
+    assert s["payload"] == {"mode": "full"}
+    assert set(s["event_filters"]) == {
+        "group.created", "session.created",
+        "task.assigned", "task.completed", "session.completed",   # §4
+    }
+    assert s["sink"]["type"] == "webhook"
+    assert s["sink"]["url"] == "https://api.example.com/api/v1/collaboration/tasks/callback/report"
+    assert s["sink"]["request_timeout_ms"] == 10000
+    # manager/worker 参与者照常
+    assert sorted(p["role"] for p in bcs.created_req.participants) == ["manager", "worker"]
+
+
+def test_form_coop_group_manager_worker_without_api_base_url_skips_subscriptions():
+    """_api_base_url 未配(sink.url 不能空/相对)→ 跳过 event_subscriptions + warn;manager_worker 群照常建,poller 兜底。"""
+    bcs = _Bcs()
+    exe = TaskExecutor(bot=None, bcs=bcs, formatter=PromptFormatterImpl(), context=_Ctx(), sink=None,
+                       poller=_Poller(), identity_resolver=_DoubleBcsBotIdentityResolver())  # api_base_url 缺省 ""
+    _run(exe.form_coop_group(GroupFormation(
+        bot_ids=["mgr", "worker"], collab_mode="manager_worker",
+        members_info=[{"bot_id": "mgr", "role": "manager"}, {"bot_id": "worker", "role": "worker"}],
+    )))
+    assert not bcs.created_req.event_subscriptions
+
+
+def test_form_coop_group_chat_does_not_attach_event_subscriptions():
+    """chat 群不挂订阅(本次不给 chat 事件流);既有 state_machine 否定测试 + chat 不挂,确保只有 manager_worker 挂。"""
+    bcs = _Bcs()
+    exe = TaskExecutor(bot=None, bcs=bcs, formatter=PromptFormatterImpl(), context=_Ctx(), sink=None,
+                       poller=_Poller(), identity_resolver=_DoubleBcsBotIdentityResolver(),
+                       api_base_url="https://api.example.com")
+    _run(exe.form_coop_group(GroupFormation(
+        bot_ids=["b1", "b2"], collab_mode="chat", members_info=[],
+    )))
+    assert not bcs.created_req.event_subscriptions
+
+
 def test_form_coop_group_passes_caller_bot_token_from_provider():
     """注入 BcsBotTokenProvider 时,form_coop_group 取 driver_bot(BCS uuid)的 token 填 caller_bot_token(参考 ocb Bearer)。"""
     captured = {}

--- a/src/backend/tests/community/core/task/task_runner/integration/test_state_machine.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_state_machine.py
@@ -10,9 +10,7 @@ from agentclaw.community.core.task.task_runner.integration.bcs_http_adapter impo
     BcsCreateGroupResult, BcsHttpAdapter,
 )
 from agentclaw.community.core.task.task_runner.integration.prompt_formatter import PromptFormatterImpl
-from agentclaw.community.core.task.task_runner.integration.task_executor import (
-    TaskExecutor, _BCN_EVENT_CALLBACK_PATH,
-)
+from agentclaw.community.core.task.task_runner.integration.task_executor import TaskExecutor
 from agentclaw.community.core.task.task_runner.integration.double.double_bcs_bot_identity_resolver import (
     _DoubleBcsBotIdentityResolver,
 )
@@ -188,8 +186,10 @@ def test_get_group_session_reads_latest_running_session_id_not_create():
     assert not bcs.create_called
 
 
-def test_form_coop_group_subscribes_bcn_event_callback_with_api_base_url():
-    """form_coop_group 用 api_base_url + task 回调路径订阅 BCN 事件 webhook(event_subscriptions.sink.url)。"""
+def test_form_coop_group_does_not_attach_event_subscriptions():
+    """event_subscriptions 触发 BCS require_human(拒 Bot/HMAC-only → 401/403),故不再内联挂 BCN webhook;
+    建群走 no-sub 分支(HMAC/Bearer 匿名或 driver-bot caller),终结态收敛交 result poller。
+    即便 extend_props 带 api_base_url,也不得挂 event_subscriptions。"""
     bcs = _Bcs()
     exe = TaskExecutor(bot=None, bcs=bcs, formatter=PromptFormatterImpl(), context=_Ctx(), sink=None,
                        poller=_Poller(), identity_resolver=_DoubleBcsBotIdentityResolver())
@@ -199,16 +199,43 @@ def test_form_coop_group_subscribes_bcn_event_callback_with_api_base_url():
         extend_props={"collaboration_definition_yaml": "kind: collab",
                       "api_base_url": "https://cb.example.com/"},
     )))
-    subs = bcs.created_req.event_subscriptions
-    assert subs and len(subs) == 1
-    sub = subs[0]
-    assert sub["name"] == "group-webhook"
-    assert sub["sink"]["type"] == "webhook"
-    # api_base_url 去尾斜杠 + 回调路径
-    assert sub["sink"]["url"] == "https://cb.example.com" + _BCN_EVENT_CALLBACK_PATH
-    assert sub["sink"]["url"].endswith("/api/v1/collaboration/tasks/callback/report")
-    assert sub["payload"] == {"mode": "metadata_only"}
-    assert "state_machine.*" in sub["event_filters"]
+    assert not bcs.created_req.event_subscriptions
+
+
+def test_form_coop_group_passes_caller_bot_token_from_provider():
+    """注入 BcsBotTokenProvider 时,form_coop_group 取 driver_bot(BCS uuid)的 token 填 caller_bot_token(参考 ocb Bearer)。"""
+    captured = {}
+
+    class _TokProvider:
+        def get_token(self, bcs_bot_uuid):
+            captured["queried"] = bcs_bot_uuid
+            return f"tok-for-{bcs_bot_uuid}"
+
+    bcs = _Bcs()
+    exe = TaskExecutor(bot=None, bcs=bcs, formatter=PromptFormatterImpl(), context=_Ctx(), sink=None,
+                       poller=_Poller(), identity_resolver=_DoubleBcsBotIdentityResolver(),
+                       bot_token_provider=_TokProvider())
+    _run(exe.form_coop_group(GroupFormation(
+        bot_ids=["drv"], collab_mode="state_machine",
+        members_info=[{"bot_id": "drv", "role": "manager"}],
+        extend_props={"collaboration_definition_yaml": "kind: collab"},
+    )))
+    # driver_bot 经 _DoubleBcsBotIdentityResolver 解析为 BCS uuid `drv:double-owner`
+    assert captured["queried"] == "drv:double-owner"
+    assert bcs.created_req.caller_bot_token == "tok-for-drv:double-owner"
+
+
+def test_form_coop_group_without_provider_omits_caller_bot_token():
+    """未注入 provider(默认)→ caller_bot_token=None(去订阅后 HMAC 匿名建群亦成,不依赖 token)。"""
+    bcs = _Bcs()
+    exe = TaskExecutor(bot=None, bcs=bcs, formatter=PromptFormatterImpl(), context=_Ctx(), sink=None,
+                       poller=_Poller(), identity_resolver=_DoubleBcsBotIdentityResolver())
+    _run(exe.form_coop_group(GroupFormation(
+        bot_ids=["drv"], collab_mode="state_machine",
+        members_info=[{"bot_id": "drv", "role": "manager"}],
+        extend_props={"collaboration_definition_yaml": "kind: collab"},
+    )))
+    assert bcs.created_req.caller_bot_token is None
 
 
 def test_form_coop_group_opening_message_params_is_object():

--- a/src/backend/tests/community/core/task/task_runner/test_callback_adapter.py
+++ b/src/backend/tests/community/core/task/task_runner/test_callback_adapter.py
@@ -243,7 +243,17 @@ class TestPersist:
         assert rec.result_success is True
         assert rec.exec_error is None
         assert rec.result == {"success": True, "data": {"answer": 42}}
-        assert rec.execution_graph == raw["ext_info"]              # 全量 ext_info 快照
+        # execution_graph 已转结构化 TaskExecutionGraph(graph_to_dict 形状),非原始 ext_info 透传
+        eg = rec.execution_graph
+        assert eg["run_id"] == 0 and eg["task_id"] == "" and eg["status"] == "DONE"
+        assert eg["output"] == {}
+        assert eg["extend_props"] == {"origin_session_id": "S-9"}
+        assert len(eg["tasks"]) == 1
+        assert eg["tasks"][0]["node_id"] == "N1"
+        assert eg["tasks"][0]["status"] == "DONE"
+        assert eg["tasks"][0]["task_spec"]["metadata"]["title"] == "N1"   # 无 node_title → 退 node_id
+        assert eg["tasks"][0]["run_info"]["output"] == {"answer": 42}
+        assert eg["relations"] == []
         assert rec.extend_props is None                            # claw_mind 无额外扩展
         assert _json.loads(rec.orig_callback_data) == raw          # 原始 body
 

--- a/src/backend/tests/community/core/task/task_runner/test_task_callback_report.py
+++ b/src/backend/tests/community/core/task/task_runner/test_task_callback_report.py
@@ -343,7 +343,16 @@ class TestClawMind:
         assert rec.result_success is True
         assert rec.result == {"success": True, "data": {"answer": 42}}
         assert rec.exec_error is None
-        assert rec.execution_graph == _CLAW_MIND_BODY["ext_info"]  # 全量 ext_info 快照
+        # execution_graph 已转结构化 TaskExecutionGraph(graph_to_dict 形状),非原始 ext_info 透传
+        eg = rec.execution_graph
+        assert eg["run_id"] == 0 and eg["status"] == "DONE"
+        assert eg["extend_props"] == {"flow_id": "flow-abc-123", "origin_session_id": "S-9"}
+        assert len(eg["tasks"]) == 1
+        assert eg["tasks"][0]["node_id"] == "N1"
+        assert eg["tasks"][0]["status"] == "DONE"
+        assert eg["tasks"][0]["task_spec"]["metadata"]["title"] == "N1"   # 无 node_title → 退 node_id
+        assert eg["tasks"][0]["run_info"]["output"] == {"answer": 42}
+        assert eg["relations"] == []
         assert rec.extend_props is None               # claw_mind 无额外扩展
         assert json.loads(rec.orig_callback_data) == _CLAW_MIND_BODY  # 原始 body
 


### PR DESCRIPTION
 ## Problem
  - The ClawMind callback's `execution_graph` was a raw passthrough of `ext_info` (`{flow_runs, node_executions}`), not a structured `TaskExecutionGraph`. The DAG encoded in each node's
  `input_json.nodeOutputKeys` was never turned into relations/edges, so the dashboard received the raw envelope, and the bogus `succeeded_count` was surfaced verbatim.
  - `manager_worker` collaboration groups had no event stream: the group was created without subscribing, so §4 events were never pushed back, `apply_manager_worker_event` was dormant, the dashboard had
  no audit snapshot, and terminal convergence relied solely on the result poller (the state after commit `fa6c1f067` removed inline subscriptions). The manager_worker group event stream is now required.
  - The collaboration-group type could only be derived implicitly from `has_yaml` (`state_machine`/`manager_worker`); there was no way to explicitly select `chat`/`manager_worker`.
  - Creating a group needs the driver-bot's Bearer token as caller identity (per the ocb model), but BCS exposes no "fetch token" HTTP API, so a production-grade token provider was missing.

  ## Solution
  Across two commits:

  **1. `fe0f2bbff`**
  - **ClawMind `execution_graph` → `graph_to_dict`-shaped `TaskExecutionGraph`**: new `_build_claw_mind_execution_graph` converts `flow_runs`/`node_executions` into `{run_id, task_id, loop_round, status,
  output, extend_props, tasks[], relations[]}`. `relations` are derived from each node's `input_json.nodeOutputKeys` (multi-parent DAG, dangling edges filtered out); the low-level status is mapped to
  the 7-state `Status` enum; rich fields (token_usage/timing/executor_type/input) are folded into `run_info.extend_props`. Secrets/digests/version (`credentials_json`/`identity_key`/`plugin_version`) are
  excluded, and the bogus graph-level `succeeded_count` is dropped (nodes are the authoritative source). The adapter does not import repository serializers — it hand-writes the same dict shape
  (comment-marked to keep in sync) and only reuses the domain `Status` enum.
  - **`ZdasBcsBotTokenProvider`**: reads `bcs_bots.session_token` directly via the prod `DatabasePlugin` (ZDAS `agentclawdb_ds`, same DB as `bcs_bots`), wrapped in `CachingBcsBotTokenProvider` (TTL), and
  wired as the default in `task_module`. This supplies the `caller_bot_token` (`Authorization: Bearer`) driver-bot caller identity for `create_group`. Locally there is no `bcs_bots` table → the query
  error is swallowed → `None` (no Bearer sent; local BCS ignores auth, harmless).
  - Updated the previously locked-in assertion `execution_graph == ext_info` in `test_callback_adapter` / `test_task_callback_report` to the structured-shape assertion.

  **2. `3831eb7b7`**
  - **`execution_config.group_kind` (additive, non-breaking)**: `_run_yaml` derives `collab_mode` as: yaml body present → `state_machine` (`group_kind` not consulted, existing logic unchanged); no yaml →
  `group_kind=chat` (new exit), `None`/`manager_worker` → `manager_worker` (unchanged), `state_machine` without yaml / unknown value → `ValueError`.
  - **`manager_worker` groups now always inline-attach a §4 `event_subscriptions`** (in the `manager_worker` branch of `form_coop_group`): `event_filters =
  group.created/session.created/task.assigned/task.completed/session.completed`, `payload.mode = full`, `sink.url = {api_base_url}/api/v1/collaboration/tasks/callback/report`. BCS pushes these back,
  activating the existing `apply_manager_worker_event` → `task_callback.execution_graph` audit snapshot + `converge_by_session` terminal convergence. `state_machine`/`chat` do not attach (the existing
  negative test `test_form_coop_group_does_not_attach_event_subscriptions` is untouched and still passes). Auth stays HMAC + existing `caller_bot_token` (Bearer), no cookie; if `_api_base_url` is unset,
  subscriptions are skipped with a warning and the poller remains the convergence fallback.

  ## Validation
  - Directly-relevant suites: **132 passed** (translator, execute_task_type_branching, test_state_machine, test_executor_e2e, callback_adapter, task_callback_report, bcs_bot_token_provider).
  - Wider scope (task_center + task_runner + adapters/http/task + dashboard): **356 passed, 5 skipped**.
  - New/changed tests green (TDD red→green): 6 `group_kind` cases; `manager_worker` subscriptions (attached / skipped without `api_base_url` / not attached for `chat`); end-to-end `execute → engine →
  form_coop_group → create_group` attaching the §4 subscription; existing `state_machine` negative test still green.
  - SAST (ruff blocklist-equivalent: E902/E117/F405/E712/E701/E702/F821/F822/F823) clean on all changed files.

  ## Compatibility and risk
  - **ClawMind `execution_graph` shape change**: from raw `{flow_runs, node_executions}` to a structured `TaskExecutionGraph` dict. The only consumer today is the dashboard passthrough
  (`graph.execution_graph = rec.execution_graph`) with no hard parser downstream, so there is no breaking consumer.
  - **`manager_worker` group creation now attaches a subscription + triggers `require_human`**: the auth assumption is that `Bearer` (+HMAC) satisfies `require_human` without a cookie. This contradicts
  the older memory `bcs-create-group-auth-model` finding (Bearer→403). **Live BCS validation is required**; if rejected, the fallback is to add a cookie path for `manager_worker` (deliberately not done
  here).
  - **Event stream depends on an absolute `sink.url`**: if `_api_base_url` is unset, subscriptions are skipped (poller convergence fallback, no audit snapshot).
  - **`group_kind` is non-breaking**: existing `has_yaml → state_machine/manager_worker` callers are unaffected; it only adds a `chat` exit and explicit selection when no yaml is present.
  - The subscription attaches for **all** `manager_worker` groups (both the `group_kind` explicit path and dynamic dispatch), decided by `mode` in `form_coop_group`; `chat`/`state_machine` do not attach.

  ## Related
  - Reference: 语雀《BCS Group 回调接入说明》`zeodup/vh3397/yt7ekehen7dpuyeq` (§1 create-group subscriptions, §4 manager_worker events).
  - Note: for `manager_worker` this effectively rolls back commit `fa6c1f067`'s "remove inline subscriptions"; `state_machine`/`chat` are unchanged.