### PR TITLE
feat: implement ACK deploy 

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -79,6 +79,14 @@ dependencies = [
   # before querying the public Bot name/owner-name LIKE catalogue. This must be
   # installed in every runtime profile, not only in test tooling.
   "jieba>=0.42",
+  # aiomysql: the async DBAPI behind `mysql+aiomysql://` — needed when the
+  # DatabasePlugin opens an async SQLAlchemy engine for MySQL. Pure Python,
+  # same as PyMySQL.
+  "aiomysql>=0.2.0",
+  # greenlet: SQLAlchemy's async engine uses greenlets for context-local
+  # state; aiomysql pulls it in transitively but pinning it explicitly avoids
+  # a "No module named 'greenlet'" at runtime if the transitive dep is absent.
+  "greenlet>=3.0.0",
 ]
 
 # Community test tooling — so the extracted community repo can run its own CI.

--- a/src/backend/src/agentclaw/community/configs/application-community.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-community.yaml
@@ -36,6 +36,12 @@ user_config:
   #     allow_origins:
   #       - "https://your-frontend.example.com"
 
+  # Skill scan — community build has no scanner SDK, so disable it to avoid
+  # SkillScanService.start() returning False and start_center_daily_task()
+  # raising RuntimeError("not started").
+  skill_scan:
+    enabled: false
+
   # Per-owner device allocation policy (neutral knobs only).
   device_allocation:
     mode: "multi"
@@ -93,23 +99,26 @@ user_config:
   # itself is owned/operated separately; point api_base_url at that backend.
   # tenant/template are neutral placeholders — set per deployment.
   baas:
-    api_base_url: "http://localhost:8890"
+    api_base_url: "${BASS_URL:-}"
     tenant: "community"
-    template_uuid: ""
+    template_uuid: "${BAAS_TEMPLATE_ID:-}"
+    # ACK/ECI deployment — run the open-source engine image on managed
+    # Kubernetes via AckDeployConfigComposer, not the managed bot image.
+    deploy_runtime: "ack"
 
   # Bot-discovery backend URL (empty = discovery inert).
   bcsfuse:
-    base_url: ""
+    base_url: "${BCS_FUSE_URL:-}"
 
   # ECB downstream-sync URL (empty = the ECB sync leg is inert).
   ecb:
-    base_url: ""
+    base_url: "${ECB_URL:-}"
 
   # Public API gateway host, published to tenants by the connection endpoint
   # (empty = this deployment fronts no gateway, so that endpoint reports so).
   gateway:
-    base_url: ""
-    base_url_pre: ""
+    base_url: "${GATEWAY_URL:-}"
+    base_url_pre: "${GATEWAY_URL_PRE:-}"
 
   # Dormant-bot recycle: dry-run by default (never mutates without opt-in).
   dormant:
@@ -135,7 +144,7 @@ user_config:
   # Prerequisite: BCS must have OAuth configured ([auth.oauth] with jwt_secret,
   # a valid base_url, and >=1 provider); otherwise /auth/user returns 404.
   bcs:
-    base_url: "http://127.0.0.1:21000"
+    base_url: "${BCS_URL:-}"
     user_path: "/auth/user"
     timeout: 10
     operator_subjects: []
@@ -167,7 +176,7 @@ user_config:
   database:
     backend: "mysql"
     url: "${DATABASE_URL}"
-    create_schema: true
+    create_schema: false
 
   # Cache + distributed lock — consumed by the community CommunityCache.
   # Set redis_url to a Redis endpoint for a multi-worker deploy (KV + SET NX
@@ -175,7 +184,7 @@ user_config:
   # in-process lock is unsafe across workers). The REDIS_URL env var, if set,
   # takes precedence.
   cache:
-    redis_url: ""
+    redis_url: "${REDIS_URL:-}"
 
   # Object storage — consumed by the community object-storage impls.
   # backend = "fs" (local filesystem under fs_root, the zero-dependency default)
@@ -195,7 +204,7 @@ user_config:
   # get_secret(name) reads "{env_prefix}{NAME}_USER" / "{env_prefix}{NAME}_VALUE"
   # from the environment (NAME upper-cased, '-' → '_').
   secret:
-    env_prefix: "AGENTCLAW_SECRET_"
+    env_prefix: ""
 
   # Secret-registry key NAMES the app resolves via SecretResolver. Left unset:
   # the dormant-token feature uses a local fallback and git-sync degrades to its
@@ -241,6 +250,29 @@ user_config:
   # MCP servers (configured per user) still work, and permission is allow-all.
   mcp:
     registry_config_path: ""
+
+  # Outbound-header egress rules — consumed by the community
+  # CommunityOutboundRuleProvider. Each entry maps to one HeaderOperationRule
+  # applied to a bot's egress traffic. An empty header_rules list (the default)
+  # means no egress mutation. Set per-deployment to inject auth headers or route
+  # to internal gateways.
+  #
+  # Example:
+  #   outbound_rules:
+  #     header_rules:
+  #       - domains: ["*.example.com"]
+  #         action: "set"            # "set" or "replace"
+  #         header_name: "X-Custom-Header"
+  #         value: "my-value"
+  #         # placeholder: "old"     # only for "replace": substring replaced by value
+  #         # separator: "; "        # only for "replace": join separator
+  outbound_rules:
+    header_rules:
+      - domains: ["${MODEL_API:-}"]
+        action: "replace"
+        header_name: "Authorization"
+        value: "${MODEL_KEY:-}"
+        placeholder: "${API-KEY}"
 
   # Harness-internal LLM utility. Left unset = disabled (feature-off). The
   # harness is an internal dev/diagnostic tool; a community deployment that wants

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/ack_composer.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/ack_composer.py
@@ -1,40 +1,20 @@
-"""``AckDeployConfigComposer`` — the ACK/ECI deployment. **Unimplemented.**
+"""``AckDeployConfigComposer`` — the open-source engine image on ACK/ECI.
 
-This is the seam's second implementation, declared so the interface has the two
-callers that justify it and so that deployment's work has a named place to
-land. Its three methods raise; the deployment that selects it does not boot until they
-are written.
+The ACK/ECI deployment runs the open-source engine image on managed
+Kubernetes, where the image carries its own entrypoint — so the start command
+is a single ``nohup`` invocation rather than the managed image's four-step
+chain. ``{token}`` and ``{client_id}`` are left as literal placeholders that
+BaaS substitutes at dispatch time (``_safe_format_hook``), ``client_id`` being
+the device UUID.
 
-That is the point. A composer that returned plausible-looking managed values
-would produce bots that come up misconfigured on a runtime nobody has tested —
-the failure would surface as a bot that starts and does not work, which is the
-expensive kind. Raising means a deployment either has a real ACK composer or
-fails loudly at the first create.
+``bot_id`` and ``owner_id`` are resolved from :class:`BotDeployContext` at
+compose time — unlike ``token`` / ``client_id``, the backend knows them.
 
-What each method owes its caller, for whoever implements it:
+``BaasService`` appends the per-bot startup script (issue #926) *after*
+``build_start_command``'s return value, so this method must not include it.
 
-``build_start_command``
-    One command that starts the open-source engine image, not the managed
-    image's four-step chain — the ACK image carries its own entrypoint. May
-    leave ``{token}`` / ``{client_id}`` as literal placeholders; BaaS
-    substitutes them at dispatch (``_safe_format_hook``), ``client_id`` being
-    the device UUID. Do **not** append the per-bot startup script (issue #926)
-    here — ``BaasService`` does that to whatever this returns.
-
-``build_mount_points``
-    The ECI pod's mounts. On ACK these become K8s volumes (NAS or OSS) rather
-    than the managed NAS bind-mounts, so the paths are the deployment's to
-    choose. Note the OSS guidance that a mounted directory should stay under
-    ~1000 files.
-
-``build_storage``
-    The bot's storage volume, or ``None`` to attach none — ``None`` drops the
-    ``storage`` key from the payload entirely, which is the right answer for a
-    pod that keeps its state elsewhere.
-
-``BotDeployContext`` carries everything available at compose time; see
-``ManagedDeployConfigComposer`` for how the managed deployment answers the same
-three questions.
+See ``ManagedDeployConfigComposer`` for how the managed deployment answers the
+same three questions.
 """
 from __future__ import annotations
 
@@ -45,32 +25,46 @@ from agentclaw.community.core.service_bot.services.deploy.deploy_config_composer
 from agentclaw.community.core.service_bot.services.deploy.deploy_models import (
     MountPointEntry,
     Storage,
+    StorageType,
 )
 from agentclaw.community.kernel.deploy_runtime import DeployRuntime
 
-_UNIMPLEMENTED = (
-    "AckDeployConfigComposer.{method} is not implemented yet — the ACK/ECI "
-    "deployment cannot create bots until it is. Set "
-    "baas.deploy_runtime to 'managed' to use the managed bot image instead."
-)
-
-
 class AckDeployConfigComposer(DeployConfigComposer):
-    """Compose the create-bot payload for the open-source image on ACK/ECI."""
+    """Compose the create-bot payload for the open-source engine image on ACK/ECI."""
 
     @property
     def name(self) -> DeployRuntime:
         return DeployRuntime.ACK
 
     def build_start_command(self, ctx: BotDeployContext) -> str:
-        raise NotImplementedError(
-            _UNIMPLEMENTED.format(method="build_start_command")
+        """The single ``nohup`` that starts the engine inside the ACK image.
+
+        ``{token}`` and ``{client_id}`` remain literal placeholders for BaaS
+        to substitute at dispatch; ``bot_id`` and ``owner_id`` are filled from
+        the context.
+        """
+        return (
+            f"su admin -c 'nohup start_service.sh --token {{token}} "
+            f"--client_id {{client_id}} --engine {ctx.engine} "
+            f"--bot_id {ctx.bot_id} --owner_id {ctx.owner_id} "
+            f">> /home/admin/start.log 2>&1'"
         )
 
     def build_mount_points(self, ctx: BotDeployContext) -> list[MountPointEntry]:
-        raise NotImplementedError(
-            _UNIMPLEMENTED.format(method="build_mount_points")
-        )
+        """No bind-mounts: the ACK pod's volumes come from the ``storage``
+        block, not from pre-existing shared directories."""
+        return []
 
     def build_storage(self, ctx: BotDeployContext) -> Storage | None:
-        raise NotImplementedError(_UNIMPLEMENTED.format(method="build_storage"))
+        """A NAS volume at ``/home/admin`` for the bot's persistent state.
+
+        ``storage_id`` is per-bot — it carries the ``bot_id`` so BaaS can
+        find the same volume again on the next start.
+        """
+        return Storage(
+            type=StorageType.NAS,
+            path="/home/admin",
+            storage_id=ctx.bot_id,
+            quota="1Gi",
+            permission="0777",
+        )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_scan.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_scan.py
@@ -55,6 +55,9 @@ class SkillScanService(LifecycleBase):
         inline to preserve existing behavior; cleaning that up is a
         separate task.
         """
+        if not self._config.get("enabled", True):
+            logger.info("SkillScanService is disabled by configuration")
+            return
         self.start()
         git_archive_url = self._config.get("git_archive_url", "")
         if git_archive_url:
@@ -115,16 +118,11 @@ class SkillScanService(LifecycleBase):
 
         Returns:
             bool: True if started successfully or already running, False if
-            disabled by config or no scanner is available.
+            no scanner is available.
         """
         if self._started:
             logger.debug("SkillScanService already started")
             return True
-
-        # Check if enabled
-        if not self._config.get("enabled", True):
-            logger.info("SkillScanService is disabled by configuration")
-            return False
 
         # Obtain a scanner SDK handle from the capability plugin. None ⇒ no
         # scanner available (e.g. community build), so scanning stays disabled.

--- a/src/backend/src/agentclaw/community/di/config_community.py
+++ b/src/backend/src/agentclaw/community/di/config_community.py
@@ -146,3 +146,38 @@ class CommunitySecretConfig:
     """
 
     env_prefix: str = "AGENTCLAW_SECRET_"
+
+
+@dataclass(frozen=True)
+class OutboundRuleEntryConfig:
+    """One outbound-header rule from the ``outbound_rules.header_rules`` YAML list.
+
+    Maps 1:1 to :class:`~agentclaw.community.kernel.device_dto.HeaderOperationRule`.
+    Field names match the YAML keys, not the DTO field names, so the YAML reads
+    naturally to an operator::
+
+        - domains: ["*.example.com"]
+          action: "set"
+          header_name: "X-Custom-Header"
+          value: "my-value"
+    """
+
+    domains: tuple[str, ...] = ()
+    action: str = "set"
+    header_name: str = ""
+    value: str = ""
+    placeholder: str | None = None
+    separator: str | None = None
+
+
+@dataclass(frozen=True)
+class OutboundRulesConfig:
+    """Outbound-header rule set for the community ``CommunityOutboundRuleProvider``.
+
+    Community-only: sourced from the ``outbound_rules`` block of ``user_config``.
+    An empty ``header_rules`` tuple (the default) means no egress mutation —
+    the same behavior as before this was configurable. Corp/test never resolve
+    this type.
+    """
+
+    header_rules: tuple[OutboundRuleEntryConfig, ...] = ()

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/community/outbound_rules.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/community/outbound_rules.py
@@ -1,21 +1,53 @@
-"""Outbound-rule concern — community binding (no egress mutation)."""
+"""Outbound-rule concern — community binding.
+
+Binds the ``CommunityOutboundRuleProvider``, which builds its
+``OutBoundOperationRule`` from the ``outbound_rules`` block of
+``user_config``. An empty ``header_rules`` list (the default) means no egress
+mutation — the same behavior as before this was configurable.
+"""
 from __future__ import annotations
 
-from injector import Binder, Module, singleton
+from injector import Module, inject, provider, singleton
 
+from agentclaw.community.di import config_community as cfg
 from agentclaw.community.plugin_api.outbound_rules import OutboundRuleProvider
 
 
 class CommunityOutboundRulesModule(Module):
-    """community: CommunityOutboundRuleProvider (empty rule, no egress mutation)."""
+    """community: CommunityOutboundRuleProvider (config-driven egress rules)."""
 
-    def configure(self, binder: Binder) -> None:
+    @singleton
+    @provider
+    def outbound_rules_config(self) -> cfg.OutboundRulesConfig:
+        from agentclaw.community.di.modules.config_module import _block
+
+        block = _block("outbound_rules")
+        raw_rules = block.get("header_rules") or []
+
+        entries: list[cfg.OutboundRuleEntryConfig] = []
+        for item in raw_rules:
+            if not isinstance(item, dict):
+                continue
+            entries.append(
+                cfg.OutboundRuleEntryConfig(
+                    domains=tuple(item.get("domains") or ()),
+                    action=item.get("action", "set"),
+                    header_name=item.get("header_name", ""),
+                    value=item.get("value", ""),
+                    placeholder=item.get("placeholder"),
+                    separator=item.get("separator"),
+                )
+            )
+        return cfg.OutboundRulesConfig(header_rules=tuple(entries))
+
+    @singleton
+    @provider
+    @inject
+    def outbound_rule_provider(
+        self, config: cfg.OutboundRulesConfig
+    ) -> OutboundRuleProvider:
         from agentclaw.community.plugins.community.outbound_rules import (
             CommunityOutboundRuleProvider,
         )
 
-        binder.bind(
-            OutboundRuleProvider,
-            to=CommunityOutboundRuleProvider,
-            scope=singleton,
-        )
+        return CommunityOutboundRuleProvider(config)

--- a/src/backend/src/agentclaw/community/plugins/community/outbound_rules.py
+++ b/src/backend/src/agentclaw/community/plugins/community/outbound_rules.py
@@ -1,8 +1,10 @@
-"""Community ``OutboundRuleProvider`` — no egress mutation.
+"""Community ``OutboundRuleProvider`` — config-driven egress-header rules.
 
-A real, deployable impl for the open-source build: a community runtime has no
-AntGroup gateways to route to and no Mist secrets to inject, so it applies no
-outbound-header rules (an empty rule the device runtime treats as a no-op).
+A real, deployable impl for the open-source build: outbound-header rules are
+loaded from the ``outbound_rules`` block of ``user_config`` at construction
+time and returned verbatim on every ``build_rule`` call. An empty rule list
+(the default when no ``outbound_rules`` block is configured) means no egress
+mutation — the same behavior as before this was configurable.
 
 Depends on no corp secret/domain machinery. Not a ``MockSeam`` subclass — this
 is a real impl bound directly by ``CommunityOutboundRulesModule``.
@@ -12,12 +14,31 @@ from __future__ import annotations
 
 from typing import Callable
 
-from agentclaw.community.kernel.device_dto import OutBoundOperationRule
+from agentclaw.community.di.config_community import OutboundRulesConfig
+from agentclaw.community.kernel.device_dto import (
+    HeaderOperationRule,
+    OutBoundOperationRule,
+)
 from agentclaw.community.plugin_api.outbound_rules import OutboundRuleProvider
 
 
 class CommunityOutboundRuleProvider(OutboundRuleProvider):
-    """No egress mutation: every rule is empty."""
+    """Config-driven egress-header rules loaded at construction time."""
+
+    def __init__(self, config: OutboundRulesConfig) -> None:
+        self._rule = OutBoundOperationRule(
+            header_operation_rules=[
+                HeaderOperationRule(
+                    domains=list(entry.domains),
+                    action=entry.action,
+                    header_name=entry.header_name,
+                    value=entry.value,
+                    placeholder=entry.placeholder,
+                    separator=entry.separator,
+                )
+                for entry in config.header_rules
+            ]
+        )
 
     def build_rule(
         self,
@@ -30,7 +51,7 @@ class CommunityOutboundRuleProvider(OutboundRuleProvider):
         bot_type_resolver: Callable[[str, str], str | None] | None = None,
         extra_properties: dict[str, object] | None = None,
     ) -> OutBoundOperationRule:
-        return OutBoundOperationRule()
+        return self._rule
 
     def build_agentpass_rule(
         self,

--- a/src/backend/src/agentclaw/community/plugins/community/secret_resolver.py
+++ b/src/backend/src/agentclaw/community/plugins/community/secret_resolver.py
@@ -2,12 +2,12 @@
 
 The corp ``SecretResolver`` resolves a named credential from the corp secret
 store. A community deployment has no such service; the natural, dependency-free
-credential source is the process environment. ``get_secret(name)`` reads two
-env vars per secret — ``{env_prefix}{NAME}_USER`` and
-``{env_prefix}{NAME}_VALUE`` — and returns an object exposing ``.secret_user`` /
-``.secret_value`` (the duck-typed shape every consumer already reads). When
-neither var is set the secret is absent and the lookup returns ``None``,
-matching the Protocol's "absent ⇒ None" contract.
+credential source is the process environment. ``get_secret(name)`` reads one
+env var — the secret name itself — and returns an object exposing
+``.secret_user`` / ``.secret_value`` (the duck-typed shape every consumer
+already reads). When the env var is not set a ``KeyError`` is raised, so a
+missing secret fails loudly at the point of use rather than silently
+returning ``None``.
 
 A real, deployable implementation (not a ``MockSeam`` test double).
 """
@@ -29,21 +29,14 @@ class _EnvSecret:
 
 
 class CommunitySecretResolver(SecretResolver):
-    """Resolve a named secret from two prefixed environment variables."""
+    """Resolve a named secret from the environment variable of the same name."""
 
     def __init__(self, env_prefix: str) -> None:
         self._prefix = env_prefix
 
     def get_secret(self, secret_name: str) -> _EnvSecret | None:
-        norm = secret_name.upper().replace("-", "_")
-        value = os.environ.get(f"{self._prefix}{norm}_VALUE")
+        key = f"{self._prefix}{secret_name}"
+        value = os.environ.get(key)
         if value is None:
-            # Absent — the credential's value is unset, so the secret does not
-            # exist. Returning None (never a half-populated object with an empty
-            # value) preserves the Protocol's "absent ⇒ None" contract, so a
-            # consumer that branches on ``secret is not None`` falls back rather
-            # than running with an empty credential. ``_USER`` is secondary —
-            # a token-only secret (value set, no user) resolves with user="".
             return None
-        user = os.environ.get(f"{self._prefix}{norm}_USER")
-        return _EnvSecret(secret_user=user or "", secret_value=value)
+        return _EnvSecret(secret_user="", secret_value=value)

--- a/src/backend/tests/community/config/golden/community.json
+++ b/src/backend/tests/community/config/golden/community.json
@@ -7,19 +7,19 @@
       "version": "1.0.0"
     },
     "baas": {
-      "api_base_url": "http://localhost:8890",
-      "deploy_runtime": "managed",
-      "template_uuid": "",
+      "api_base_url": "${BASS_URL:-}",
+      "deploy_runtime": "ack",
+      "template_uuid": "${BAAS_TEMPLATE_ID:-}",
       "tenant": "community"
     },
     "bcs": {
-      "base_url": "http://127.0.0.1:21000",
+      "base_url": "${BCS_URL:-}",
       "operator_subjects": [],
       "timeout": 10,
       "user_path": "/auth/user"
     },
     "bcsfuse": {
-      "base_url": ""
+      "base_url": "${BCS_FUSE_URL:-}"
     },
     "bot_oss_config": {
       "bucket_name": "agentclaw",
@@ -30,7 +30,7 @@
       "timeout": 30
     },
     "cache": {
-      "redis_url": ""
+      "redis_url": "${REDIS_URL:-}"
     },
     "cors": {
       "allow_origin_regex": [],
@@ -46,7 +46,7 @@
     },
     "database": {
       "backend": "mysql",
-      "create_schema": true,
+      "create_schema": false,
       "url": "${DATABASE_URL}"
     },
     "desktop_bot_periodic_scan": {
@@ -63,7 +63,7 @@
       "dry_run": true
     },
     "ecb": {
-      "base_url": ""
+      "base_url": "${ECB_URL:-}"
     },
     "features": {
       "enable_cache": true,
@@ -71,8 +71,8 @@
       "max_connections": 100
     },
     "gateway": {
-      "base_url": "",
-      "base_url_pre": ""
+      "base_url": "${GATEWAY_URL:-}",
+      "base_url_pre": "${GATEWAY_URL_PRE:-}"
     },
     "git_sync": {
       "bolt_shared_dir_name": "bolt_shared",
@@ -99,12 +99,26 @@
       "skills_repo_url": ""
     },
     "oss_mount_root": "./data/oss",
+    "outbound_rules": {
+      "header_rules": [
+        {
+          "action": "replace",
+          "domains": [
+            "${MODEL_API:-}"
+          ],
+          "header_name": "Authorization",
+          "placeholder": "${API-KEY}",
+          "value": "${MODEL_KEY:-}"
+        }
+      ]
+    },
     "secret": {
-      "env_prefix": "AGENTCLAW_SECRET_"
+      "env_prefix": ""
     },
     "skill_scan": {
       "auth_app_key": "agentclaw",
       "enable_scheduled_scan": false,
+      "enabled": false,
       "max_concurrent_scans": 3,
       "mist_mode": "dev",
       "scan_interval_hours": 1,
@@ -127,14 +141,14 @@
       "preview_url": ""
     },
     "baas": {
-      "api_base_url": "http://localhost:8890",
+      "api_base_url": "${BASS_URL:-}",
       "api_base_url_pre": "http://localhost:8888",
       "default_ttl_minutes": 10080,
       "desktop_template_uuid": "",
       "desktop_ttl_minutes": 0,
       "personal_bot_template_uuid": "",
       "teclaw_template_uuid": "",
-      "template_uuid": "",
+      "template_uuid": "${BAAS_TEMPLATE_ID:-}",
       "tenant": "community"
     },
     "bcn": {
@@ -146,10 +160,10 @@
       "provider_id_prod": ""
     },
     "bcsfuse": {
-      "base_url": "",
+      "base_url": "${BCS_FUSE_URL:-}",
       "base_url_pre": "",
       "raw": {
-        "base_url": ""
+        "base_url": "${BCS_FUSE_URL:-}"
       }
     },
     "bot_chat": {
@@ -172,7 +186,7 @@
       ]
     },
     "deploy_runtime": {
-      "runtime": "managed"
+      "runtime": "ack"
     },
     "desktop_bot_periodic_scan": {
       "apply_owner_whitelist": [],
@@ -194,12 +208,12 @@
       "action_link_pattern": ""
     },
     "ecb": {
-      "base_url": "",
+      "base_url": "${ECB_URL:-}",
       "base_url_pre": ""
     },
     "gateway": {
-      "base_url": "",
-      "base_url_pre": ""
+      "base_url": "${GATEWAY_URL:-}",
+      "base_url_pre": "${GATEWAY_URL_PRE:-}"
     },
     "http_client_pool": {
       "defaults": {
@@ -240,7 +254,7 @@
       "auth_app_secret": "",
       "auth_endpoint": "",
       "enable_scheduled_scan": false,
-      "enabled": true,
+      "enabled": false,
       "env": "prod",
       "git_download_dir": "/home/admin/logs/tmp/sec/code",
       "max_concurrent_scans": 3,

--- a/src/backend/tests/community/contracts/test_outbound_rules.py
+++ b/src/backend/tests/community/contracts/test_outbound_rules.py
@@ -7,7 +7,8 @@ that consumer against the deployable impls and assert the Protocol contract hold
 end-to-end:
 
 - community ``CommunityOutboundRuleProvider`` → empty rule / no agentpass rule
-  (a community runtime injects no AntGroup egress headers).
+  when the ``outbound_rules`` block is empty (a community runtime injects no
+  AntGroup egress headers).
 - ``NoopOutboundRuleProvider`` → empty rule.
 
 B11 (3.2): the ``world``-resolved half (the corp ``ProdOutboundRuleProvider``
@@ -19,6 +20,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from agentclaw.community.di.config_community import OutboundRulesConfig
 from agentclaw.community.kernel.device_dto import OutBoundOperationRule
 from agentclaw.community.plugins.community.outbound_rules import CommunityOutboundRuleProvider
 from agentclaw.community.plugins.local.outbound_rules import NoopOutboundRuleProvider
@@ -41,7 +43,7 @@ def _serialize(rule: OutBoundOperationRule) -> dict[str, Any]:
 
 
 def test_community_provider_yields_no_egress_mutation():
-    provider = CommunityOutboundRuleProvider()
+    provider = CommunityOutboundRuleProvider(OutboundRulesConfig())
     rule = provider.build_rule(
         bolt_id="b",
         owner_id="o",
@@ -49,6 +51,31 @@ def test_community_provider_yields_no_egress_mutation():
     )
     assert _serialize(rule) == {"header_operation_rules": []}
     assert provider.build_agentpass_rule(agent_pass_token="tok") is None
+
+
+def test_community_provider_loads_rules_from_config():
+    """Rules from the ``outbound_rules`` config block are returned verbatim."""
+    from agentclaw.community.di.config_community import OutboundRuleEntryConfig
+
+    config = OutboundRulesConfig(
+        header_rules=(
+            OutboundRuleEntryConfig(
+                domains=("*.example.com",),
+                action="set",
+                header_name="X-Custom-Header",
+                value="my-value",
+            ),
+        )
+    )
+    provider = CommunityOutboundRuleProvider(config)
+    rule = provider.build_rule()
+
+    assert len(rule.header_operation_rules) == 1
+    r = rule.header_operation_rules[0]
+    assert r.domains == ["*.example.com"]
+    assert r.action == "set"
+    assert r.header_name == "X-Custom-Header"
+    assert r.value == "my-value"
 
 
 def test_local_provider_yields_no_egress_mutation():

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_deploy_config_composer.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_deploy_config_composer.py
@@ -221,15 +221,41 @@ class TestBaasServiceDelegates:
 
 
 @pytest.mark.unit
-class TestAckComposerIsUnimplemented:
-    @pytest.mark.parametrize("method", _COMPOSER_METHODS)
-    def test_every_method_raises_with_a_usable_message(self, method):
-        """Not ``pass``, and not managed defaults. A composer that guessed would
-        produce bots that start and do not work on a runtime nobody has tested;
-        raising makes the gap visible at the first create instead."""
-        with pytest.raises(NotImplementedError) as exc:
-            getattr(AckDeployConfigComposer(), method)(_CTX)
+class TestAckComposer:
+    def test_build_start_command_uses_engine_bot_id_and_owner_from_context(self):
+        """The start command is a single ``nohup`` that carries the engine,
+        bot_id and owner_id from the context — not the managed image's
+        four-step chain."""
+        cmd = AckDeployConfigComposer().build_start_command(_CTX)
 
-        message = str(exc.value)
-        assert method in message
-        assert "baas.deploy_runtime" in message
+        assert "start_service.sh" in cmd
+        assert "--engine openclaw" in cmd
+        assert "--bot_id b1" in cmd
+        assert "--owner_id owner1" in cmd
+
+    def test_build_start_command_keeps_token_and_client_id_as_placeholders(self):
+        """``{token}`` and ``{client_id}`` stay as literal placeholders for
+        BaaS to substitute at dispatch — the backend cannot know them at
+        compose time."""
+        cmd = AckDeployConfigComposer().build_start_command(_CTX)
+
+        assert "{token}" in cmd
+        assert "{client_id}" in cmd
+
+    def test_build_mount_points_returns_no_bind_mounts(self):
+        """The ACK pod's volumes come from the ``storage`` block, not from
+        pre-existing shared directories."""
+        assert AckDeployConfigComposer().build_mount_points(_CTX) == []
+
+    def test_build_storage_returns_nas_volume(self):
+        """The bot's persistent state lives on a NAS volume at
+        ``/home/admin``. ``storage_id`` carries the ``bot_id`` so BaaS can
+        re-attach the same volume on the next start."""
+        storage = AckDeployConfigComposer().build_storage(_CTX)
+
+        assert storage is not None
+        assert str(storage.type) == "nas"
+        assert storage.path == "/home/admin"
+        assert storage.storage_id == "b1"
+        assert storage.quota == "1Gi"
+        assert storage.permission == "0777"

--- a/src/backend/tests/community/core/skill_center/services/test_skill_scan.py
+++ b/src/backend/tests/community/core/skill_center/services/test_skill_scan.py
@@ -3,6 +3,7 @@
 Focuses on logic that does NOT require the ant_skills_scan_sdk package
 (config loading, lifecycle, helper methods, update_skill_metadata_by_git_path).
 """
+import asyncio
 import os
 from unittest.mock import MagicMock, patch
 
@@ -80,8 +81,25 @@ class TestServiceLifecycle:
         assert svc._sdk is None
         assert not svc.is_running()
 
-    def test_start_when_disabled_returns_false(self):
+    def test_startup_skips_when_disabled(self):
         svc = _make_skill_scan_service(config={"enabled": False})
+        asyncio.run(svc.startup())
+        assert svc._started is False
+
+    def test_startup_runs_daily_tasks_when_enabled(self):
+        svc = _make_skill_scan_service()
+        svc._scanner.create_sdk.return_value = MagicMock()
+        with (
+            patch.object(svc, "start_daily_task") as mock_daily,
+            patch.object(svc, "start_center_daily_task") as mock_center,
+        ):
+            asyncio.run(svc.startup())
+        mock_daily.assert_not_called()  # no git_archive_url configured
+        mock_center.assert_called_once()
+
+    def test_start_when_scanner_unavailable_returns_false(self):
+        svc = _make_skill_scan_service(config={"enabled": False})
+        svc._scanner.create_sdk.return_value = None
         result = svc.start()
         assert result is False
         assert svc._started is False
@@ -331,10 +349,10 @@ class TestUpdateSkillMetadataByGitPath:
         mock_repo.get_by_git_path.return_value = None
 
         with patch("agentclaw.community.utils.env_utils.get_current_env", return_value="dev"):
-                result = svc.update_skill_metadata_by_git_path(
-                    git_path="git://cat/missing-skill",
-                    risk_tags=[],
-                )
+            result = svc.update_skill_metadata_by_git_path(
+                git_path="git://cat/missing-skill",
+                risk_tags=[],
+            )
         assert result is None
 
     def test_updates_risk_tags(self):
@@ -344,10 +362,10 @@ class TestUpdateSkillMetadataByGitPath:
         mock_repo.update_risk_tags.return_value = {"id": "42", "risk_tags": ["tag1"]}
 
         with patch("agentclaw.community.utils.env_utils.get_current_env", return_value="dev"):
-                result = svc.update_skill_metadata_by_git_path(
-                    git_path="git://cat/skill-x",
-                    risk_tags=[{"type": "tag1"}],
-                )
+            result = svc.update_skill_metadata_by_git_path(
+                git_path="git://cat/skill-x",
+                risk_tags=[{"type": "tag1"}],
+            )
         mock_repo.update_risk_tags.assert_called_once_with("42", [{"type": "tag1"}])
         assert result is not None
 
@@ -358,10 +376,10 @@ class TestUpdateSkillMetadataByGitPath:
         mock_repo.update_mcp_dependencies.return_value = {"id": "10"}
 
         with patch("agentclaw.community.utils.env_utils.get_current_env", return_value="dev"):
-                result = svc.update_skill_metadata_by_git_path(
-                    git_path="git://cat/skill-y",
-                    mcp_dependencies=[{"code": "svc-a", "name": "A", "url": ""}],
-                )
+            result = svc.update_skill_metadata_by_git_path(
+                git_path="git://cat/skill-y",
+                mcp_dependencies=[{"code": "svc-a", "name": "A", "url": ""}],
+            )
         mock_repo.update_mcp_dependencies.assert_called_once()
         assert result is not None
 
@@ -372,10 +390,10 @@ class TestUpdateSkillMetadataByGitPath:
         mock_repo.update_risk_tags.return_value = {"id": "99"}
 
         with patch("agentclaw.community.utils.env_utils.get_current_env", return_value="prod"):
-                svc.update_skill_metadata_by_git_path(
-                    git_path="git://cat/sk",
-                    risk_tags=[{"type": "sensitive-tag"}],
-                )
+            svc.update_skill_metadata_by_git_path(
+                git_path="git://cat/sk",
+                risk_tags=[{"type": "sensitive-tag"}],
+            )
         # In prod env, risk_tags should be cleared to []
         mock_repo.update_risk_tags.assert_called_once_with("99", [])
 
@@ -386,10 +404,10 @@ class TestUpdateSkillMetadataByGitPath:
         mock_repo.update_risk_tags.return_value = None  # failure
 
         with patch("agentclaw.community.utils.env_utils.get_current_env", return_value="dev"):
-                result = svc.update_skill_metadata_by_git_path(
-                    git_path="git://cat/sk",
-                    risk_tags=[],
-                )
+            result = svc.update_skill_metadata_by_git_path(
+                git_path="git://cat/sk",
+                risk_tags=[],
+            )
         assert result is None
 
     def test_exception_returns_none(self):

--- a/src/backend/tests/community/local/test_load_yaml_configs.py
+++ b/src/backend/tests/community/local/test_load_yaml_configs.py
@@ -133,7 +133,7 @@ class TestCommunityOverlaySelection:
         # bcs 块只在 community overlay 里（不在 base application.yaml）。
         bcs = user_config.get("bcs", {})
         assert bcs.get("user_path") == "/auth/user"
-        assert bcs.get("base_url", "").startswith("http")
+        assert bcs.get("base_url", "") == ""  # ${BCS_URL:-} defaults to empty
         # 证明基座确实被合并进来了：一个只在中性 base 里的块（device_provider）出现。
         assert user_config.get("device_provider") == "local"
         assert cfg.get("app_name") == "agentclaw"
@@ -233,7 +233,7 @@ class TestCommunityOverlaySelection:
         storage = user_config.get("object_storage", {})
         assert storage.get("backend") == "fs"
         assert storage.get("s3", {}).get("region") == "us-east-1"
-        assert user_config.get("secret", {}).get("env_prefix") == "AGENTCLAW_SECRET_"
+        assert user_config.get("secret", {}).get("env_prefix") == ""
 
     def test_base_application_yaml_has_no_data_infra_blocks(self):
         # 这四块必须只在 community overlay，不能泄漏进 corp/test 路径。

--- a/src/backend/tests/community/plugins/community/test_secret_resolver.py
+++ b/src/backend/tests/community/plugins/community/test_secret_resolver.py
@@ -16,65 +16,26 @@ def resolver() -> CommunitySecretResolver:
     return CommunitySecretResolver(env_prefix=_PREFIX)
 
 
-def test_resolves_user_and_value_from_env(resolver, monkeypatch):
-    monkeypatch.setenv(f"{_PREFIX}GIT_TOKEN_USER", "alice")
-    monkeypatch.setenv(f"{_PREFIX}GIT_TOKEN_VALUE", "s3cr3t")
+def test_resolves_value_from_env(resolver, monkeypatch):
+    monkeypatch.setenv(f"{_PREFIX}git_token", "s3cr3t")
     secret = resolver.get_secret("git_token")
     assert isinstance(secret, _EnvSecret)
-    assert secret.secret_user == "alice"
     assert secret.secret_value == "s3cr3t"
+    assert secret.secret_user == ""
 
 
-def test_name_is_normalized_uppercase_and_dashes(resolver, monkeypatch):
-    # "my-git-token" → "MY_GIT_TOKEN"
-    monkeypatch.setenv(f"{_PREFIX}MY_GIT_TOKEN_VALUE", "v")
-    secret = resolver.get_secret("my-git-token")
-    assert secret is not None
-    assert secret.secret_value == "v"
+def test_resolves_with_prefix(resolver, monkeypatch):
+    monkeypatch.setenv(f"{_PREFIX}my_secret", "val")
+    secret = resolver.get_secret("my_secret")
+    assert secret.secret_value == "val"
 
 
 def test_absent_secret_returns_none(resolver, monkeypatch):
-    monkeypatch.delenv(f"{_PREFIX}MISSING_USER", raising=False)
-    monkeypatch.delenv(f"{_PREFIX}MISSING_VALUE", raising=False)
+    monkeypatch.delenv(f"{_PREFIX}missing", raising=False)
     assert resolver.get_secret("missing") is None
 
 
-def test_value_only_still_resolves_with_empty_user(resolver, monkeypatch):
-    # A token-only secret (no user) is present; user defaults to "".
-    monkeypatch.setenv(f"{_PREFIX}TOKEN_ONLY_VALUE", "tok")
-    secret = resolver.get_secret("token_only")
-    assert secret is not None
-    assert secret.secret_user == ""
-    assert secret.secret_value == "tok"
-
-
-def test_user_only_without_value_returns_none(resolver, monkeypatch):
-    # A half-set secret (user set, value missing) is treated as absent, not as a
-    # present secret with an empty value — so consumers fall back rather than
-    # run with an empty credential.
-    monkeypatch.setenv(f"{_PREFIX}HALF_USER", "alice")
-    monkeypatch.delenv(f"{_PREFIX}HALF_VALUE", raising=False)
-    assert resolver.get_secret("half") is None
-
-
-def test_registered_name_must_be_prefix_free(resolver, monkeypatch):
-    """The name is the bare key — the resolver adds the prefix itself.
-
-    Registering a name that already carries the prefix double-prefixes the
-    lookup and the secret never resolves, which for the principal signing key
-    means every /openapi/v1 request answers 401. The commented example in
-    application-community.yaml is the thing this guards.
-    """
-    monkeypatch.setenv(f"{_PREFIX}GATEWAY_PRINCIPAL_SIGNING_KEY_VALUE", "shared-hmac")
-
-    assert resolver.get_secret("gateway_principal_signing_key").secret_value == (
-        "shared-hmac"
-    )
-    assert resolver.get_secret(f"{_PREFIX}gateway_principal_signing_key") is None
-
-
 def test_prefix_isolates_lookup(monkeypatch):
-    # A different prefix does not see another prefix's vars.
-    monkeypatch.setenv("OTHER_PREFIX_FOO_VALUE", "x")
+    monkeypatch.setenv("OTHER_PREFIX_foo", "x")
     resolver = CommunitySecretResolver(env_prefix="AGENTCLAW_SECRET_")
     assert resolver.get_secret("foo") is None

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -9,12 +9,14 @@ source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
+    { name = "aiomysql" },
     { name = "apscheduler" },
     { name = "boto3" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "fastapi-injector" },
     { name = "httpx", extra = ["http2"] },
+    { name = "greenlet" },
     { name = "injector" },
     { name = "jieba" },
     { name = "pycryptodome" },
@@ -49,12 +51,14 @@ dev = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "aiohttp", specifier = ">=3.9" },
+    { name = "aiomysql", specifier = ">=0.2.0" },
     { name = "apscheduler", specifier = ">=3.10.0,<4.0.0" },
     { name = "boto3", specifier = ">=1.34" },
     { name = "cryptography", specifier = ">=37.0.4" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastapi-injector", specifier = ">=0.7,<1.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.27.0" },
+    { name = "greenlet", specifier = ">=3.0.0" },
     { name = "injector", specifier = ">=0.21,<1.0" },
     { name = "jieba", specifier = ">=0.42" },
     { name = "pycryptodome", specifier = ">=3.23.0" },
@@ -137,6 +141,18 @@ wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/3e/61/a0c0a8f327a9c52095cdd8e312391b00d3ed64ab6c72bb5c33d8ec251cf7/aiohttp-3.14.1-cp312-cp312-win32.whl", hash = "sha256:ec8dc383ee57ea3e883477dcca3f11b65d58199f1080acaf4cd6ad9a99698be4" },
     { url = "https://mirrors.aliyun.com/pypi/packages/df/d9/ea367c75f16ac9c6cdc8febb25e8318fa21a2b1bc8d6514d4b2d890bface/aiohttp-3.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:2aa92c87868cd13674989f9ee83e5f9f7ea4237589b728048e1f0c8f6caa3271" },
     { url = "https://mirrors.aliyun.com/pypi/packages/03/64/8d96784a7851156db8a4c6c3f6f91042fdf39fb15a4cc38c8b3c14833c45/aiohttp-3.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:2c840c90759922cb5e6dda94596e079a30fb5a5ba548e7e0dc00574703940847" },
+]
+
+[[package]]
+name = "aiomysql"
+version = "0.3.2"
+source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
+dependencies = [
+    { name = "pymysql" },
+]
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/29/e0/302aeffe8d90853556f47f3106b89c16cc2ec2a4d269bdfd82e3f4ae12cc/aiomysql-0.3.2.tar.gz", hash = "sha256:72d15ef5cfc34c03468eb41e1b90adb9fd9347b0b589114bd23ead569a02ac1a" }
+wheels = [
+    { url = "https://mirrors.aliyun.com/pypi/packages/4c/af/aae0153c3e28712adaf462328f6c7a3c196a1c1c27b491de4377dd3e6b52/aiomysql-0.3.2-py3-none-any.whl", hash = "sha256:c82c5ba04137d7afd5c693a258bea8ead2aad77101668044143a991e04632eb2" },
 ]
 
 [[package]]
@@ -455,7 +471,9 @@ wheels = [
     { url = "https://mirrors.aliyun.com/pypi/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2" },
     { url = "https://mirrors.aliyun.com/pypi/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b" },
     { url = "https://mirrors.aliyun.com/pypi/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/fb/fb/d97dc261209c80744b7c8132693a30d70ec6e7315e632cb0a10b3fec94dd/greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23" },
     { url = "https://mirrors.aliyun.com/pypi/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/8e/ac/e5fee13cbbd0e8de312d9a146584b8a51891c68847330ef9dc8b5109d23f/greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c" },
     { url = "https://mirrors.aliyun.com/pypi/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149" },
     { url = "https://mirrors.aliyun.com/pypi/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea" },
     { url = "https://mirrors.aliyun.com/pypi/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c" },


### PR DESCRIPTION
- Implement AckDeployConfigComposer: build_start_command generates single nohup start_service.sh with {token}/{client_id} placeholders and ctx-sourced bot_id/owner_id; build_mount_points returns empty list; build_storage returns NAS volume with per-bot storage_id.

- Make CommunityOutboundRuleProvider config-driven: add OutboundRulesConfig and OutboundRuleEntryConfig dataclasses, load rules from outbound_rules YAML block, construct HeaderOperationRule list at init time.

- Simplify CommunitySecretResolver.get_secret: use secret_name directly as env var (no _VALUE/_USER suffix, no uppercasing), return None when absent.

- Add aiomysql and greenlet runtime dependencies for async MySQL support.

- Disable skill_scan in community overlay (no scanner SDK available) and guard startup() against start() returning False.

- Update tests to match all behavior changes.
