### PR TITLE
feat(openapi): expose caller identity configuration

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -182,6 +182,7 @@ from .bots.engine_config import router as engine_config_router
 from .org import dept_router as org_dept_router
 from .org import router as org_router
 from .channels import router as channels_router
+from .caller_identity import router as caller_identity_router
 from .containers import router as containers_router
 from .diagnostics import router as diagnostics_router
 from .editors import router as editors_router
@@ -326,6 +327,7 @@ _ADDRESSED_BOT_SUBGROUPS = [
     containers_router,
     diagnostics_router,
     channels_router,
+    caller_identity_router,
     skill_sets_router,
     bot_mcp_router,
 ]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -197,6 +197,14 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
         "/openapi/v1/bots/{bot_id}/mcps",
     ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
     (
+        "GET",
+        "/openapi/v1/bots/{bot_id}/caller-context",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
+        "PATCH",
+        "/openapi/v1/bots/{bot_id}/mcps/{server_code}/call-type",
+    ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,
+    (
         "POST",
         "/openapi/v1/bots/{bot_id}/mcps/{server_code}/activate",
     ): AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
@@ -211,6 +211,7 @@ AUTHORIZATION: dict[tuple[str, str], Authorization] = {
     ("GET", "/openapi/v1/bots/{bot_id}/channels/{channel_id}"): Check(PermissionLevel.MEMBER),
     ("PATCH", "/openapi/v1/bots/{bot_id}/channels/{channel_id}"): Check(PermissionLevel.ADMIN, EDIT_LOCK),
     ("PUT", "/openapi/v1/bots/{bot_id}/channels/{channel_id}/status"): Check(PermissionLevel.ADMIN, EDIT_LOCK),
+    ("GET", "/openapi/v1/bots/{bot_id}/caller-context"): Check(PermissionLevel.MEMBER),
     ("GET", "/openapi/v1/bots/{bot_id}/chats"):
         ServiceChecked(PermissionLevel.MEMBER, "…core.bot_chat.service"),
     ("GET", "/openapi/v1/bots/{bot_id}/chats/{trace_id}"):
@@ -272,6 +273,7 @@ AUTHORIZATION: dict[tuple[str, str], Authorization] = {
     ("GET", "/openapi/v1/bots/{bot_id}/mcps"): Check(PermissionLevel.MEMBER),
     ("POST", "/openapi/v1/bots/{bot_id}/mcps/{server_code}/activate"): Check(PermissionLevel.MEMBER),
     ("POST", "/openapi/v1/bots/{bot_id}/mcps/{server_code}/deactivate"): Check(PermissionLevel.MEMBER),
+    ("PATCH", "/openapi/v1/bots/{bot_id}/mcps/{server_code}/call-type"): Check(PermissionLevel.OWNER, EDIT_LOCK),
     ("GET", "/openapi/v1/bots/{bot_id}/models"): Check(PermissionLevel.MEMBER),
     ("GET", "/openapi/v1/bots/{bot_id}/models/{model_id:path}"): Check(PermissionLevel.MEMBER),
     ("GET", "/openapi/v1/bots/{bot_id}/nodes"): Check(PermissionLevel.MEMBER),

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/caller_identity/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/caller_identity/__init__.py
@@ -1,0 +1,5 @@
+"""Public Caller identity configuration endpoints."""
+
+from .router import router
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/caller_identity/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/caller_identity/router.py
@@ -1,0 +1,167 @@
+"""Public Caller identity context and per-MCP identity configuration."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated
+
+from fastapi import APIRouter, Path, Query, Request
+
+from agentclaw.community.adapters.http.openapi_v1.authorization import PublicAPIRoute
+from agentclaw.community.adapters.http.openapi_v1.contracts import BotIdPath, Envelope
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.params import (
+    OwnerIdDep,
+)
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.enums import (
+    RuntimeStage,
+)
+from agentclaw.community.adapters.http.openapi_v1.errors import (
+    CallerIdentityInvalidError,
+)
+from agentclaw.community.adapters.http.openapi_v1.principal import UserIdDep
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    envelope,
+    envelope_errors,
+)
+from agentclaw.community.api.caller_identity_service import (
+    CallerIdentityServiceProtocol,
+    CallerIdentityStage as CoreCallerIdentityStage,
+    McpCallType as CoreMcpCallType,
+)
+from agentclaw.community.api.collaborator_lock_service import (
+    CollaboratorLockServiceProtocol,
+)
+from agentclaw.community.di import Injected
+
+from .schemas import (
+    CallerCallType,
+    CallerContext,
+    McpCallTypeResult,
+    McpCallTypeUpdate,
+)
+
+
+router = APIRouter(
+    prefix="/openapi/v1/bots/{bot_id}",
+    tags=["Caller identity"],
+    route_class=PublicAPIRoute,
+)
+
+
+def _validate_stage(stage: RuntimeStage, publish_id: int | None) -> None:
+    if stage is RuntimeStage.DRAFT:
+        if publish_id is not None:
+            raise CallerIdentityInvalidError("draft stage does not accept publish_id")
+        return
+    if publish_id is None:
+        raise CallerIdentityInvalidError("published stages require publish_id")
+
+
+async def _current_lock_epoch(
+    locks: CollaboratorLockServiceProtocol,
+    *,
+    bot_id: str,
+    owner_id: str,
+    user_id: str,
+) -> int | None:
+    """Carry the lock validated by ``Check(..., EDIT_LOCK)`` into the write."""
+    info = await asyncio.to_thread(
+        locks.get_lock_info,
+        bot_id=bot_id,
+        owner_id=owner_id,
+        user_id=user_id,
+    )
+    lock = info.lock
+    if lock is None or lock.holder_user_id != user_id:
+        return None
+    epoch = lock.id
+    return epoch if isinstance(epoch, int) and not isinstance(epoch, bool) else None
+
+
+@router.get("/caller-context", response_model=Envelope[CallerContext])
+@envelope_errors
+async def get_caller_context(
+    bot_id: BotIdPath,
+    request: Request,
+    user_id: UserIdDep,
+    owner_id: OwnerIdDep,
+    stage: RuntimeStage = Query(
+        default=RuntimeStage.DRAFT,
+        description="Bot runtime stage whose Caller identity context to read.",
+    ),
+    publish_id: Annotated[
+        int | None,
+        Query(
+            gt=0,
+            description="Required publication id for verify and online; omitted for draft.",
+        ),
+    ] = None,
+    service: CallerIdentityServiceProtocol = Injected(CallerIdentityServiceProtocol),
+) -> Envelope[CallerContext]:
+    """Return aggregate and per-MCP Caller identity for one Bot runtime."""
+    _validate_stage(stage, publish_id)
+    result = await asyncio.to_thread(
+        service.get_context,
+        bot_id=bot_id,
+        actor_id=user_id,
+        stage=CoreCallerIdentityStage(stage.value),
+        publish_id=publish_id,
+        entity_id=owner_id,
+    )
+    return envelope(
+        CallerContext(
+            capability=result.capability,
+            stage=RuntimeStage(result.stage.value),
+            publish_id=result.publish_id,
+            bot_call_type=CallerCallType(result.bot_call_type.value),
+            mcp_call_types={
+                code: CallerCallType(call_type.value)
+                for code, call_type in result.mcp_call_types.items()
+            },
+            editable=result.editable,
+        ),
+        request,
+    )
+
+
+@router.patch(
+    "/mcps/{server_code}/call-type",
+    response_model=Envelope[McpCallTypeResult],
+)
+@envelope_errors
+async def update_mcp_call_type(
+    bot_id: BotIdPath,
+    server_code: Annotated[str, Path(description="Opaque MCP server identifier.")],
+    body: McpCallTypeUpdate,
+    request: Request,
+    user_id: UserIdDep,
+    owner_id: OwnerIdDep,
+    service: CallerIdentityServiceProtocol = Injected(CallerIdentityServiceProtocol),
+    locks: CollaboratorLockServiceProtocol = Injected(CollaboratorLockServiceProtocol),
+) -> Envelope[McpCallTypeResult]:
+    """Update one active draft MCP's Caller identity mode."""
+    lock_epoch = await _current_lock_epoch(
+        locks,
+        bot_id=bot_id,
+        owner_id=owner_id,
+        user_id=user_id,
+    )
+    result = await service.update_mcp_call_type(
+        bot_id=bot_id,
+        server_code=server_code,
+        call_type=CoreMcpCallType(body.call_type.value),
+        actor_id=user_id,
+        lock_epoch=lock_epoch,
+        entity_id=owner_id,
+    )
+    return envelope(
+        McpCallTypeResult(
+            server_code=result.server_code,
+            call_type=CallerCallType(result.call_type.value),
+            bot_call_type=CallerCallType(result.bot_call_type.value),
+        ),
+        request,
+    )
+
+
+__all__ = ["router"]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/caller_identity/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/caller_identity/schemas.py
@@ -1,0 +1,75 @@
+"""Published request and response models for Caller identity configuration."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agentclaw.community.adapters.http.openapi_v1.engine_runtime.enums import (
+    RuntimeStage,
+)
+from agentclaw.community.adapters.http.openapi_v1.enums import _DocumentedEnum
+
+
+class CallerCallType(_DocumentedEnum):
+    """Whose identity an MCP uses when it executes."""
+
+    OWNER = "owner"
+    CALLER = "caller"
+
+    __descriptions__ = {
+        "owner": "Execute with the Bot owner's identity.",
+        "caller": "Execute with the identity of the user currently calling the Bot.",
+    }
+
+
+class CallerContext(BaseModel):
+    """Caller execution identity configured for one Bot runtime."""
+
+    capability: Literal["caller_identity.v1"] = Field(
+        description="Caller identity capability version supported by the Bot."
+    )
+    stage: RuntimeStage = Field(
+        description="Runtime stage whose Caller identity context was requested."
+    )
+    publish_id: int | None = Field(
+        description="Publication addressed by verify/online, or null for draft."
+    )
+    bot_call_type: CallerCallType = Field(
+        description="Aggregate Bot identity: caller when any active MCP uses caller."
+    )
+    mcp_call_types: dict[str, CallerCallType] = Field(
+        description="Explicit Caller identity mode keyed by active MCP server code."
+    )
+    editable: bool = Field(
+        description="Whether the current caller may edit the draft Caller identity."
+    )
+
+
+class McpCallTypeUpdate(BaseModel):
+    """Select the execution identity for one active MCP on the draft Bot."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    call_type: CallerCallType = Field(
+        description="owner executes as the Bot owner; caller executes as the chat caller."
+    )
+
+
+class McpCallTypeResult(BaseModel):
+    """Applied MCP identity and the resulting aggregate Bot identity."""
+
+    server_code: str = Field(description="Updated MCP server code.")
+    call_type: CallerCallType = Field(description="Applied execution identity.")
+    bot_call_type: CallerCallType = Field(
+        description="Aggregate Bot identity after applying the update."
+    )
+
+
+__all__ = [
+    "CallerCallType",
+    "CallerContext",
+    "McpCallTypeResult",
+    "McpCallTypeUpdate",
+]

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -139,6 +139,17 @@ from agentclaw.community.core.cron.errors import (
     CronApiTimeoutError,
     CronRelayError,
 )
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerCallTypeInvalidError,
+    CallerIdentityAmbiguousError,
+    CallerIdentityIrreversibleError,
+    CallerIdentityNotFoundError,
+    CallerIdentityPermissionError,
+    CallerIdentityReadOnlyError,
+    CallerLockEpochError,
+    CallerMcpNotFoundError,
+    CallerMcpSyncError,
+)
 from agentclaw.community.core.engine_runtime.errors import (
     EngineBotTypeNotSupportedError,
     EngineHistoryDepthExceededError,
@@ -323,6 +334,15 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
     CallerIdentityForbiddenError: (403, "Forbidden"),
     CallerIdentityConflictError: (409, "Caller identity target is ambiguous"),
     CallerIdentityOpenApiError: (502, "Caller identity operation failed"),
+    CallerIdentityPermissionError: (404, "Not found"),
+    CallerIdentityNotFoundError: (404, "Not found"),
+    CallerIdentityAmbiguousError: (409, "Caller identity target is ambiguous"),
+    CallerIdentityIrreversibleError: (409, "Caller identity cannot be reverted"),
+    CallerIdentityReadOnlyError: (409, "Caller identity configuration is read-only"),
+    CallerLockEpochError: (423, "Edit lock required"),
+    CallerMcpNotFoundError: (404, "Not found"),
+    CallerMcpSyncError: (502, "Caller identity synchronization failed"),
+    CallerCallTypeInvalidError: (500, "Internal error"),
     MissingPrincipalError: (401, "Unauthorized"),
     # Byte-identical to the line above, deliberately. "You sent no principal" and
     # "your principal did not verify" must be indistinguishable, or the response

--- a/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/engine_runtime/test_stage_addressing.py
@@ -72,6 +72,7 @@ def _is_engine_runtime(path: str) -> bool:
 #: assertion below is what proves.
 _STAGE_ADDRESSED_ELSEWHERE = {
     ("post", "/openapi/v1/bots/{bot_id}/iam-token"),
+    ("get", "/openapi/v1/bots/{bot_id}/caller-context"),
     ("get", "/openapi/v1/bots/{bot_id}/engine/config"),
     ("put", "/openapi/v1/bots/{bot_id}/engine/config"),
     ("get", "/openapi/v1/bots/{bot_id}/identity"),
@@ -86,6 +87,8 @@ _STAGE_ADDRESSED_ELSEWHERE = {
 #: **not** take ``stage``: there is no runtime in question when you are
 #: recording who may reach a bot, or listing a bot's stored skills.
 _OWNER_ADDRESSED_ELSEWHERE = {
+    ("get", "/openapi/v1/bots/{bot_id}/caller-context"),
+    ("patch", "/openapi/v1/bots/{bot_id}/mcps/{server_code}/call-type"),
     ("get", "/openapi/v1/bots/{bot_id}/authorized-apps"),
     ("post", "/openapi/v1/bots/{bot_id}/authorized-apps"),
     ("delete", "/openapi/v1/bots/{bot_id}/authorized-apps/{app_id}"),

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_authorization_inventory.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_authorization_inventory.py
@@ -492,6 +492,18 @@ def test_existing_service_level_edit_lock_defences_are_preserved():
     )
 
 
+def test_caller_identity_keeps_legacy_read_and_write_permission_levels():
+    read = AUTHORIZATION[("GET", "/openapi/v1/bots/{bot_id}/caller-context")]
+    write = AUTHORIZATION[
+        ("PATCH", "/openapi/v1/bots/{bot_id}/mcps/{server_code}/call-type")
+    ]
+
+    assert read.level is PermissionLevel.MEMBER
+    assert read.edit_lock is None
+    assert write.level is PermissionLevel.OWNER
+    assert write.edit_lock is EDIT_LOCK
+
+
 def test_edit_lock_operations_exactly_match_the_migrated_check_surface():
     expected = {
         ("POST", "/openapi/v1/bots/{bot_id}/channels"),
@@ -508,6 +520,7 @@ def test_edit_lock_operations_exactly_match_the_migrated_check_surface():
         ("POST", "/openapi/v1/bots/{bot_id}/lifecycle/retry"),
         ("POST", "/openapi/v1/bots/{bot_id}/lifecycle/upgrade"),
         ("POST", "/openapi/v1/bots/{bot_id}/lifecycle/{publication_id}/upgrade"),
+        ("PATCH", "/openapi/v1/bots/{bot_id}/mcps/{server_code}/call-type"),
         ("POST", "/openapi/v1/bots/{bot_id}/skill-sets"),
         ("DELETE", "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}"),
         ("POST", "/openapi/v1/bots/{bot_id}/skill-sets/{set_id}/activate"),

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_caller_identity_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_caller_identity_endpoints.py
@@ -1,0 +1,113 @@
+"""Caller identity OpenAPI handler and lock hand-off coverage."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import FastAPI
+from starlette.requests import Request
+
+from agentclaw.community.adapters.http.openapi_v1.caller_identity.router import (
+    router,
+    update_mcp_call_type,
+)
+from agentclaw.community.adapters.http.openapi_v1.caller_identity.schemas import (
+    McpCallTypeUpdate,
+)
+from agentclaw.community.api.caller_identity_service import (
+    McpCallType,
+    McpCallTypeUpdateResult,
+)
+
+
+def _request() -> Request:
+    request = Request({"type": "http", "method": "PATCH", "path": "/"})
+    request.state.trace_id = "trace-caller"
+    return request
+
+
+def test_public_contract_replaces_legacy_ctoken_entity_and_lock_parameters():
+    app = FastAPI()
+    app.include_router(router)
+    document = app.openapi()
+
+    read = document["paths"]["/openapi/v1/bots/{bot_id}/caller-context"]["get"]
+    write = document["paths"]["/openapi/v1/bots/{bot_id}/mcps/{server_code}/call-type"][
+        "patch"
+    ]
+    read_params = {item["name"] for item in read["parameters"]}
+    write_params = {item["name"] for item in write["parameters"]}
+    body_ref = write["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+    body_name = body_ref.rsplit("/", 1)[-1]
+    body_fields = set(document["components"]["schemas"][body_name]["properties"])
+
+    assert {"bot_id", "user_id", "owner_id", "stage", "publish_id"} <= read_params
+    assert {"bot_id", "server_code", "user_id", "owner_id"} <= write_params
+    assert "ctoken" not in read_params | write_params
+    assert "entity_id" not in read_params | write_params
+    assert body_fields == {"call_type"}
+    assert "423" in write["responses"]
+
+
+@pytest.mark.asyncio
+async def test_update_passes_the_server_resolved_lock_epoch_to_the_service():
+    service = AsyncMock()
+    service.update_mcp_call_type.return_value = McpCallTypeUpdateResult(
+        server_code="mcp.weather",
+        call_type=McpCallType.CALLER,
+        bot_call_type=McpCallType.CALLER,
+    )
+    locks = Mock()
+    locks.get_lock_info.return_value = SimpleNamespace(
+        lock=SimpleNamespace(id=37, holder_user_id="owner")
+    )
+
+    response = await update_mcp_call_type(
+        "bot-1",
+        "mcp.weather",
+        McpCallTypeUpdate(call_type=McpCallType.CALLER),
+        _request(),
+        "owner",
+        "owner",
+        service,
+        locks,
+    )
+
+    assert response.data.call_type.value == McpCallType.CALLER.value
+    service.update_mcp_call_type.assert_awaited_once_with(
+        bot_id="bot-1",
+        server_code="mcp.weather",
+        call_type=McpCallType.CALLER,
+        actor_id="owner",
+        lock_epoch=37,
+        entity_id="owner",
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_does_not_forward_another_users_lock_epoch():
+    service = AsyncMock()
+    service.update_mcp_call_type.return_value = McpCallTypeUpdateResult(
+        server_code="mcp.weather",
+        call_type=McpCallType.OWNER,
+        bot_call_type=McpCallType.OWNER,
+    )
+    locks = Mock()
+    locks.get_lock_info.return_value = SimpleNamespace(
+        lock=SimpleNamespace(id=37, holder_user_id="another-user")
+    )
+
+    await update_mcp_call_type(
+        "bot-1",
+        "mcp.weather",
+        McpCallTypeUpdate(call_type=McpCallType.OWNER),
+        _request(),
+        "owner",
+        "owner",
+        service,
+        locks,
+    )
+
+    assert service.update_mcp_call_type.await_args.kwargs["lock_epoch"] is None

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -398,7 +398,7 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: publish-to-users route moved from /bots/{bot_id}/public-bcs to the external
 #: /collaboration/bots/{bot_uuid}/public, so one path-addressed {bot_id}
 #: operation became a {bot_uuid}-named one: path -1, none +1.
-_BOT_ID_PLACEMENT = {"path": 141, "query": 1, "none": 62}
+_BOT_ID_PLACEMENT = {"path": 143, "query": 1, "none": 62}
 
 
 def _schema() -> dict:
@@ -489,7 +489,8 @@ def test_the_pinned_number_of_operations_take_it():
     version reads/actions and edit-lock operations all act for an explicit user.
     The five bot-first Editors operations bring the total to 119, and the four
     render-screen operations bring the total to 123, and the read-only Node
-    inventory brings the current total to 124.
+    inventory brings the current total to 124. Caller identity context and MCP
+    call-type configuration add two more Bot-addressed, user-scoped operations.
     """
     taking = [
         1
@@ -519,7 +520,8 @@ def test_the_pinned_number_of_operations_take_it():
     # moved to _USER_ID_FILTER_ONLY (asserted by its own test) and left this
     # count: 182 → 181. execute/dashboard take no user_id at all — see
     # _NO_USER_DIMENSION.
-    assert len(taking) == 181
+    # Caller identity context and call-type update add two operations.
+    assert len(taking) == 183
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_responses.py
@@ -27,6 +27,12 @@ from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
     BotPermissionError,
 )
+from agentclaw.community.core.caller_identity.contracts import (
+    CallerIdentityNotFoundError,
+    CallerIdentityReadOnlyError,
+    CallerLockEpochError,
+    CallerMcpSyncError,
+)
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillEditBusyError,
     LocalSkillEditLockUnavailableError,
@@ -346,6 +352,25 @@ def _lookup(exc: Exception) -> tuple[int, str]:
     ],
 )
 def test_local_skill_edit_errors_have_distinct_public_responses(error, expected):
+    assert _lookup(error) == expected
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (CallerIdentityNotFoundError(), (404, "Not found")),
+        (
+            CallerIdentityReadOnlyError(),
+            (409, "Caller identity configuration is read-only"),
+        ),
+        (CallerLockEpochError(), (423, "Edit lock required")),
+        (
+            CallerMcpSyncError(),
+            (502, "Caller identity synchronization failed"),
+        ),
+    ],
+)
+def test_caller_identity_errors_have_stable_public_responses(error, expected):
     assert _lookup(error) == expected
 
 

--- a/src/backend/tests/community/endpoints/test_caller_identity_router.py
+++ b/src/backend/tests/community/endpoints/test_caller_identity_router.py
@@ -7,12 +7,22 @@ transaction, lock, and Agent Principal synchronization branches.
 
 from __future__ import annotations
 
+import time
+
+import jwt
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.bot_collaborator.services.collaborator_lock_service import (
     CollaboratorLockService,
 )
-from agentclaw.community.core.repository.protocols.skill_center import SkillSetRepository
+from agentclaw.community.core.repository.protocols.skill_center import (
+    SkillSetRepository,
+)
 from agentclaw.community.utils.env_utils import get_current_env
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+)
 from tests.community.factories.access import make_staff_user
 from tests.community.factories.bot_collaborator import make_bot
 from tests.community.framework import (
@@ -26,6 +36,47 @@ from tests.community.framework import (
 _OWNER_ID = "caller_identity_owner"
 _BOT_ID = "caller_identity_bot"
 _SERVER_CODE = "mcp.caller.identity"
+_PRINCIPAL_KEY = "caller-identity-openapi-signing-key-32b"
+
+
+class _Secret:
+    secret_user = "test"
+    secret_value = _PRINCIPAL_KEY
+
+
+class _Resolver:
+    def get_secret(self, _secret_name: str) -> _Secret:
+        return _Secret()
+
+
+def _principal() -> str:
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 3600,
+            "principals": [
+                {
+                    "type": "user",
+                    "subject": {
+                        "id": _OWNER_ID,
+                        "username": "caller-identity@example.test",
+                    },
+                }
+            ],
+        },
+        _PRINCIPAL_KEY,
+        algorithm="HS256",
+    )
+
+
+_OPENAPI_HEADERS = {PRINCIPAL_HEADER: _principal()}
+
+
+def _enable_openapi_principal() -> None:
+    init_principal_verifier_config(_Resolver(), "test-key", strict=False)
 
 
 def _seed_owner(world) -> None:
@@ -51,6 +102,11 @@ def _seed_service_bot(world, *, acquire_lock: bool) -> None:
 
 def _seed_editable_service_bot(world) -> None:
     _seed_service_bot(world, acquire_lock=True)
+
+
+def _seed_openapi_editable_service_bot(world) -> None:
+    _enable_openapi_principal()
+    _seed_editable_service_bot(world)
 
 
 def _seed_mutable_caller_identity(world, *, acquire_lock: bool = True) -> None:
@@ -82,6 +138,16 @@ def _seed_mutable_caller_identity(world, *, acquire_lock: bool = True) -> None:
 
 def _seed_unlocked_mutable_caller_identity(world) -> None:
     _seed_mutable_caller_identity(world, acquire_lock=False)
+
+
+def _seed_openapi_unlocked_mutable_caller_identity(world) -> None:
+    _enable_openapi_principal()
+    _seed_unlocked_mutable_caller_identity(world)
+
+
+def _seed_openapi_owner(world) -> None:
+    _enable_openapi_principal()
+    _seed_owner(world)
 
 
 def _seed_ambiguous_default_bots(world) -> None:
@@ -306,3 +372,99 @@ def update_mcp_call_type_rejects_unknown_query_parameter():
 )
 def update_mcp_call_type_forbidden():
     """Only an owner of an existing service bot can change MCP call type."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/{bot_id}/caller-context",
+    scenario="happy",
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID},
+        query_params={"user_id": _OWNER_ID, "stage": "draft"},
+        headers=_OPENAPI_HEADERS,
+    ),
+    seed=_seed_openapi_editable_service_bot,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": {
+                "capability": "caller_identity.v1",
+                "stage": "draft",
+                "bot_call_type": "owner",
+                "editable": True,
+            },
+        },
+    ),
+)
+def get_openapi_caller_context_happy():
+    """The public endpoint wraps an authorized draft context in an Envelope."""
+
+
+@endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/{bot_id}/caller-context",
+    scenario="error",
+    input=CaseInput(
+        path_params={"bot_id": "missing_caller_identity_bot"},
+        query_params={"user_id": _OWNER_ID, "stage": "draft"},
+        headers=_OPENAPI_HEADERS,
+    ),
+    seed=_seed_openapi_owner,
+    expect=ExpectError(
+        status=404,
+        json_contains={"code": 404000, "message": "Not found", "data": None},
+    ),
+)
+def get_openapi_caller_context_not_found():
+    """An absent addressed Bot is returned as the public masked 404."""
+
+
+@endpoint_test(
+    method="PATCH",
+    path="/openapi/v1/bots/{bot_id}/mcps/{server_code}/call-type",
+    scenario="happy",
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID, "server_code": _SERVER_CODE},
+        query_params={"user_id": _OWNER_ID},
+        headers=_OPENAPI_HEADERS,
+        json_body={"call_type": "caller"},
+    ),
+    seed=_seed_openapi_unlocked_mutable_caller_identity,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "data": {
+                "server_code": _SERVER_CODE,
+                "call_type": "caller",
+                "bot_call_type": "caller",
+            },
+        },
+    ),
+)
+def update_openapi_mcp_call_type_happy():
+    """A sole owner updates an active MCP without a client-supplied lock epoch."""
+
+
+@endpoint_test(
+    method="PATCH",
+    path="/openapi/v1/bots/{bot_id}/mcps/{server_code}/call-type",
+    scenario="error",
+    input=CaseInput(
+        path_params={
+            "bot_id": "missing_caller_identity_bot",
+            "server_code": _SERVER_CODE,
+        },
+        query_params={"user_id": _OWNER_ID},
+        headers=_OPENAPI_HEADERS,
+        json_body={"call_type": "caller"},
+    ),
+    seed=_seed_openapi_owner,
+    expect=ExpectError(
+        status=404,
+        json_contains={"code": 404000, "message": "Not found", "data": None},
+    ),
+)
+def update_openapi_mcp_call_type_not_found():
+    """The owner-only mutation masks an absent Bot behind the standard 404."""


### PR DESCRIPTION
## Summary
- add Bot caller identity context OpenAPI for draft, verify, and online stages
- add owner-only MCP call-type update OpenAPI with declarative edit-lock enforcement
- publish response/error contracts and register admission/authorization inventories
- cover handler mapping, authorization, explicit user/owner addressing, and OpenAPI schema contracts

## Tests
- `DEPLOY_PROFILE=test uv run pytest tests/community/adapters/http/openapi_v1 -q`
  - 1385 passed, 2 skipped
- targeted caller identity and contract tests
  - 108 passed
- scoped Ruff checks passed
- pre-push SAST gate passed