### PR TITLE
refactor(bcs): remove dead run_blocking_chat path

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/tests/bot_chat_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bot_chat_contract.rs
@@ -12,7 +12,7 @@ use bcs_http::{
 };
 use bcs_service_api::{
     A2aChatCommand, A2aChatOutcome, A2aChatRunService, A2aChatService, A2aRunStatus,
-    AsyncA2aChatAccepted, AsyncA2aChatCommand, BlockingA2aChatCommand, BlockingA2aChatOutcome,
+    AsyncA2aChatAccepted, AsyncA2aChatCommand,
     BotCapabilities, BotDeliveryCommand, BotDeliveryPort, BotDeliveryResult,
     BotDeliveryTarget, BotRegistryCoreService, CallerContext, ChatResponseMode, ChatRunCancelCommand,
     ChatRunQueryCommand, ServiceError, ServiceResult,
@@ -39,8 +39,6 @@ struct RecordingA2aChat {
     not_connected_bot_id: Mutex<Option<String>>,
     not_friends_bot_ids: Mutex<Option<Vec<String>>>,
     blocking_content: Mutex<String>,
-    blocking_failure: Mutex<Option<String>>,
-    blocking_returns_error: Mutex<bool>,
     async_unauthorized: Mutex<bool>,
     async_forbidden: Mutex<bool>,
 }
@@ -198,56 +196,6 @@ impl A2aChatService for RecordingA2aChat {
 
 #[async_trait::async_trait]
 impl A2aChatRunService for RecordingA2aChat {
-    async fn run_blocking_chat(
-        &self,
-        cmd: BlockingA2aChatCommand,
-    ) -> ServiceResult<BlockingA2aChatOutcome> {
-        if let Some(bot_id) = self.not_connected_bot_id.lock().await.clone() {
-            return Err(ServiceError::BotNotConnected(bot_id));
-        }
-        if let Some(bot_ids) = self.not_friends_bot_ids.lock().await.clone() {
-            return Err(ServiceError::NotFriends(bot_ids));
-        }
-        self.commands.lock().await.push(A2aChatCommand {
-            caller: cmd.caller,
-            target_bot_id: cmd.target_bot_id.clone(),
-            message: cmd.message,
-            from_actor_id: cmd.from_actor_id,
-            authenticated_staff_id: cmd.authenticated_staff_id,
-            run_id: Some(cmd.run_id.clone()),
-            async_mode: false,
-            session_key: Some(cmd.session_key.clone()),
-            timeout_ms: Some(cmd.timeout_ms),
-            client: cmd.client,
-            tags: cmd.tags,
-            response_mode: cmd.response_mode,
-            caller_wait_mode: None,
-            organization_code: cmd.organization_code,
-            provider_bypass_headers: cmd.provider_bypass_headers,
-        });
-        self.run_channel_froms
-            .lock()
-            .await
-            .push(cmd.run_channel_from);
-
-        if let Some(error) = self.blocking_failure.lock().await.clone() {
-            self.failed_runs
-                .lock()
-                .await
-                .push((cmd.run_id.clone(), error.clone()));
-            if *self.blocking_returns_error.lock().await {
-                return Err(ServiceError::InternalError(error));
-            }
-        }
-
-        Ok(BlockingA2aChatOutcome {
-            delivered: true,
-            bot_uuid: cmd.target_bot_id,
-            session_id: cmd.session_key,
-            content: self.blocking_content.lock().await.clone(),
-        })
-    }
-
     async fn start_async_chat(
         &self,
         cmd: AsyncA2aChatCommand,
@@ -448,11 +396,7 @@ async fn build_chat_app_with_events_and_bypass(
         .unwrap();
 
     let a2a = Arc::new(RecordingA2aChat::default());
-    let (blocking_content, blocking_failure, blocking_returns_error) =
-        blocking_mode_from_events(&events, keep_open_after_send);
-    *a2a.blocking_content.lock().await = blocking_content;
-    *a2a.blocking_failure.lock().await = blocking_failure;
-    *a2a.blocking_returns_error.lock().await = blocking_returns_error;
+    *a2a.blocking_content.lock().await = blocking_content_from_events(&events);
     let run_events = Arc::new(RecordingChatRunEvents {
         events,
         keep_open_after_send,
@@ -476,30 +420,11 @@ async fn build_chat_app_with_events_and_bypass(
     (app, a2a, run_events)
 }
 
-fn blocking_mode_from_events(
-    events: &[String],
-    keep_open_after_send: bool,
-) -> (String, Option<String>, bool) {
-    if events.is_empty() && !keep_open_after_send {
-        return (
-            String::new(),
-            Some("Bot channel closed without response".to_string()),
-            true,
-        );
-    }
-    let content = events
+fn blocking_content_from_events(events: &[String]) -> String {
+    events
         .iter()
         .filter_map(|event| content_text(event))
-        .collect::<String>();
-    if keep_open_after_send {
-        (
-            content,
-            Some("Timeout waiting for bot response".to_string()),
-            false,
-        )
-    } else {
-        (content, None, false)
-    }
+        .collect()
 }
 
 fn final_event(text: &str) -> String {

--- a/src/bcs/crates/adapters/http/bcs-http/tests/route_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/route_contract.rs
@@ -22,7 +22,7 @@ use bcs_http::{
 use bcs_service_api::{
     A2aChatCommand, A2aChatOutcome, A2aChatRunService, A2aChatService, A2aRunStatus,
     ActorDirectoryService, ActorStatus, AsyncA2aChatAccepted, AsyncA2aChatCommand,
-    BlockingA2aChatCommand, BlockingA2aChatOutcome, BotCapabilities, BotOnboardingService,
+    BotCapabilities, BotOnboardingService,
     BotRegistryCoreService, CallerContext, ChatRunCancelCommand, ChatRunQueryCommand,
     FriendCoreService, Group, GroupCoreService, GroupKind, GroupStatus,
     GroupStrategy, HumanActorService, Participant, ParticipantRole, RelationCoreService,
@@ -51,13 +51,6 @@ impl RecordingA2aChat {
 
 #[async_trait::async_trait]
 impl A2aChatRunService for RecordingA2aChat {
-    async fn run_blocking_chat(
-        &self,
-        _cmd: BlockingA2aChatCommand,
-    ) -> ServiceResult<BlockingA2aChatOutcome> {
-        unreachable!("run_blocking_chat is not used by route contract tests")
-    }
-
     async fn start_async_chat(
         &self,
         _cmd: AsyncA2aChatCommand,

--- a/src/bcs/crates/bootstrap/bcs/src/metrics.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/metrics.rs
@@ -16,7 +16,7 @@ use bcs_ws::{bot::BOT_WS_ENDPOINT, web::FRONTEND_WS_ENDPOINT};
 #[cfg(feature = "prometheus-metrics")]
 use bcs_service_api::{
     A2aChatRunService, A2aRunStatus, ActorKind, ActorStatus, AsyncA2aChatAccepted, AsyncA2aChatCommand,
-    BlockingA2aChatCommand, BlockingA2aChatOutcome, BotDeliveryCommand, BotDeliveryKind,
+    BotDeliveryCommand, BotDeliveryKind,
     BotDeliveryPort, BotDeliveryResult, BotDeliveryTarget, BotEventCommand, BotEventOutcome,
     BotMetricCount, BotMetricsSnapshotPort,
     ChatAbortCommand, ChatAbortOutcome, ChatRunCancelCommand, ChatRunMetricCount, ChatRunQueryCommand,
@@ -901,15 +901,6 @@ impl InstrumentedA2aChatRunService {
 #[cfg(feature = "prometheus-metrics")]
 #[async_trait::async_trait]
 impl A2aChatRunService for InstrumentedA2aChatRunService {
-    async fn run_blocking_chat(
-        &self,
-        cmd: BlockingA2aChatCommand,
-    ) -> ServiceResult<BlockingA2aChatOutcome> {
-        let result = self.inner.run_blocking_chat(cmd).await;
-        self.record(result.is_ok());
-        result
-    }
-
     async fn start_async_chat(
         &self,
         cmd: AsyncA2aChatCommand,

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -5603,13 +5603,6 @@ mod tests {
 
     #[async_trait]
     impl A2aChatRunService for AdminRunTestA2aRuns {
-        async fn run_blocking_chat(
-            &self,
-            _cmd: bcs_service_api::BlockingA2aChatCommand,
-        ) -> bcs_service_api::ServiceResult<bcs_service_api::BlockingA2aChatOutcome> {
-            unreachable!("admin run test only uses async chat")
-        }
-
         async fn start_async_chat(
             &self,
             cmd: bcs_service_api::AsyncA2aChatCommand,

--- a/src/bcs/crates/bootstrap/bcs/tests/metrics_wrappers.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/metrics_wrappers.rs
@@ -64,12 +64,13 @@ async fn metrics_wrappers_record_expected_labels_and_preserve_results() {
 
     let direct = Arc::new(A2aRunFake);
     let direct = InstrumentedA2aChatRunService::new(direct, env.clone());
-    assert!(
+    assert_eq!(
         direct
-            .run_blocking_chat(blocking_chat_cmd())
+            .start_async_chat(async_chat_cmd())
             .await
             .unwrap()
-            .delivered
+            .status,
+        "pending"
     );
 
     let bot_delivery = MetricsBotDeliveryPort::new(Arc::new(BotDeliveryFake {
@@ -392,26 +393,14 @@ struct A2aRunFake;
 
 #[async_trait]
 impl A2aChatRunService for A2aRunFake {
-    async fn run_blocking_chat(
-        &self,
-        _cmd: BlockingA2aChatCommand,
-    ) -> ServiceResult<BlockingA2aChatOutcome> {
-        Ok(BlockingA2aChatOutcome {
-            delivered: true,
-            bot_uuid: "bot-target".to_string(),
-            session_id: "session-wrapper".to_string(),
-            content: "ok".to_string(),
-        })
-    }
-
     async fn start_async_chat(
         &self,
-        _cmd: AsyncA2aChatCommand,
+        cmd: AsyncA2aChatCommand,
     ) -> ServiceResult<AsyncA2aChatAccepted> {
         Ok(AsyncA2aChatAccepted {
-            run_id: "run-wrapper".to_string(),
-            bot_uuid: "bot-target".to_string(),
-            session_id: "session-wrapper".to_string(),
+            run_id: cmd.run_id,
+            bot_uuid: cmd.target_bot_id,
+            session_id: cmd.session_key,
             status: "pending".to_string(),
             expires_at_ms: 1,
         })
@@ -420,7 +409,7 @@ impl A2aChatRunService for A2aRunFake {
     async fn get_run(&self, _cmd: ChatRunQueryCommand) -> ServiceResult<A2aRunStatus> {
         Ok(A2aRunStatus {
             run_id: "run-wrapper".to_string(),
-            status: "completed".to_string(),
+            status: "running".to_string(),
             response: None,
         })
     }
@@ -431,6 +420,26 @@ impl A2aChatRunService for A2aRunFake {
             status: "cancelled".to_string(),
             response: None,
         })
+    }
+}
+
+fn async_chat_cmd() -> AsyncA2aChatCommand {
+    AsyncA2aChatCommand {
+        caller: CallerContext::Public,
+        target_bot_id: "bot-target".to_string(),
+        message: "hello".to_string(),
+        from_actor_id: None,
+        run_channel_from: None,
+        authenticated_staff_id: None,
+        run_id: "run-wrapper".to_string(),
+        session_key: "session-wrapper".to_string(),
+        timeout_ms: 1,
+        client: None,
+        tags: Vec::new(),
+        response_mode: ChatResponseMode::Full,
+        caller_wait_mode: None,
+        organization_code: None,
+        provider_bypass_headers: Vec::new(),
     }
 }
 
@@ -645,25 +654,6 @@ fn task_complete_cmd() -> TaskCompleteCommand {
         bot_id: "bot-target".to_string(),
         via_echo: false,
         payload: serde_json::json!({}),
-    }
-}
-
-fn blocking_chat_cmd() -> BlockingA2aChatCommand {
-    BlockingA2aChatCommand {
-        caller: CallerContext::Public,
-        target_bot_id: "bot-target".to_string(),
-        message: "hello".to_string(),
-        from_actor_id: None,
-        run_channel_from: None,
-        authenticated_staff_id: None,
-        tags: Vec::new(),
-        run_id: "run-wrapper".to_string(),
-        session_key: "session-wrapper".to_string(),
-        timeout_ms: 1,
-        client: None,
-        response_mode: ChatResponseMode::Full,
-        organization_code: None,
-        provider_bypass_headers: Vec::new(),
     }
 }
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/a2a_chat.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/a2a_chat.rs
@@ -54,35 +54,6 @@ pub struct A2aChatOutcome {
 }
 
 #[derive(Debug, Clone)]
-pub struct BlockingA2aChatCommand {
-    pub caller: CallerContext,
-    pub target_bot_id: String,
-    pub message: String,
-    pub from_actor_id: Option<String>,
-    /// Metadata used only when registering the response event channel.
-    /// Legacy HTTP chat defaults the delivered frame sender to "user" when
-    /// omitted, but leaves this channel metadata absent.
-    pub run_channel_from: Option<String>,
-    pub authenticated_staff_id: Option<String>,
-    pub run_id: String,
-    pub session_key: String,
-    pub timeout_ms: u64,
-    pub client: Option<String>,
-    pub tags: Vec<String>,
-    pub response_mode: ChatResponseMode,
-    pub organization_code: Option<String>,
-    pub provider_bypass_headers: Vec<(String, String)>,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct BlockingA2aChatOutcome {
-    pub delivered: bool,
-    pub bot_uuid: String,
-    pub session_id: String,
-    pub content: String,
-}
-
-#[derive(Debug, Clone)]
 pub struct AsyncA2aChatCommand {
     pub caller: CallerContext,
     pub target_bot_id: String,
@@ -150,11 +121,6 @@ pub trait A2aChatService: Send + Sync {
 
 #[async_trait]
 pub trait A2aChatRunService: Send + Sync {
-    async fn run_blocking_chat(
-        &self,
-        cmd: BlockingA2aChatCommand,
-    ) -> ServiceResult<BlockingA2aChatOutcome>;
-
     async fn start_async_chat(
         &self,
         cmd: AsyncA2aChatCommand,

--- a/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
@@ -145,7 +145,7 @@ pub use human_actors::{
 };
 pub use message_flow::{
     A2aChatCommand, A2aChatOutcome, A2aChatRunService, A2aChatService, A2aRunStatus,
-    AsyncA2aChatAccepted, AsyncA2aChatCommand, BlockingA2aChatCommand, BlockingA2aChatOutcome,
+    AsyncA2aChatAccepted, AsyncA2aChatCommand,
     BotEventCommand, BotEventOutcome, ChatAbortCommand, ChatAbortOutcome, ChatEventState,
     ChatResponseMode, ChatRunCancelCommand, ChatRunQueryCommand, Conflict, ConflictPosition,
     FusionRequest, FusionResponse, GroupCallbackCommand, GroupCallbackOutcome, GroupChatCommand,

--- a/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
@@ -12,7 +12,6 @@ use bcs_protocol::{
 use bcs_service_api::{
     A2aChatCommand, A2aChatOutcome, A2aChatRunService, A2aChatService, A2aRunStatus,
     ActorStatus, AsyncA2aChatAccepted, AsyncA2aChatCommand,
-    BlockingA2aChatCommand, BlockingA2aChatOutcome,
     BotDeliveryCommand, BotDeliveryKind, BotDeliveryPort,
     BotRegistryCoreService, BotRunContext, BotRunContextPort, CallerContext,
     ChatRunCancelCommand, ChatRunCleanupPort,
@@ -276,59 +275,6 @@ impl DirectChatRunSnapshotPort for A2aChat {
 
 #[async_trait]
 impl A2aChatRunService for A2aChat {
-    async fn run_blocking_chat(
-        &self,
-        cmd: BlockingA2aChatCommand,
-    ) -> ServiceResult<BlockingA2aChatOutcome> {
-        let (response_tx, mut response_rx) = mpsc::channel::<String>(16);
-        self.chat_run_events
-            .register(
-                cmd.run_id.clone(),
-                cmd.session_key.clone(),
-                response_tx,
-                Some("http-chat".to_string()),
-                cmd.run_channel_from.clone(),
-            )
-            .await;
-        self.register_bot_run_context(&cmd.run_id, &cmd.target_bot_id, &cmd.session_key, cmd.timeout_ms)
-            .await;
-
-        let chat_result = self
-            .chat(A2aChatCommand {
-                caller: cmd.caller.clone(),
-                target_bot_id: cmd.target_bot_id.clone(),
-                message: cmd.message,
-                from_actor_id: cmd.from_actor_id,
-                authenticated_staff_id: cmd.authenticated_staff_id,
-                run_id: Some(cmd.run_id.clone()),
-                async_mode: false,
-                session_key: Some(cmd.session_key.clone()),
-                timeout_ms: Some(cmd.timeout_ms),
-                client: cmd.client.or_else(|| Some("http-chat".to_string())),
-                tags: cmd.tags,
-                response_mode: cmd.response_mode,
-                caller_wait_mode: None,
-                organization_code: cmd.organization_code,
-                provider_bypass_headers: cmd.provider_bypass_headers,
-            })
-            .await;
-
-        if let Err(err) = chat_result {
-            self.chat_run_events.unregister(&cmd.run_id).await;
-            return Err(err);
-        }
-
-        self.drain_blocking_run(
-            cmd.caller,
-            &cmd.run_id,
-            &cmd.target_bot_id,
-            &cmd.session_key,
-            cmd.timeout_ms,
-            &mut response_rx,
-        )
-        .await
-    }
-
     async fn start_async_chat(
         &self,
         cmd: AsyncA2aChatCommand,
@@ -916,93 +862,6 @@ impl A2aChatService for A2aChat {
 }
 
 impl A2aChat {
-    async fn drain_blocking_run(
-        &self,
-        caller: CallerContext,
-        run_id: &str,
-        target_bot_id: &str,
-        session_key: &str,
-        timeout_ms: u64,
-        response_rx: &mut mpsc::Receiver<String>,
-    ) -> ServiceResult<BlockingA2aChatOutcome> {
-        let timeout_duration = Duration::from_millis(timeout_ms);
-
-        loop {
-            match tokio::time::timeout(timeout_duration, response_rx.recv()).await {
-                Ok(Some(event_str)) => {
-                    let terminal = match self.record_run_event(run_id, &event_str).await {
-                        Ok(terminal) => terminal,
-                        Err(error) => {
-                            self.chat_run_events.unregister(run_id).await;
-                            return Err(error);
-                        }
-                    };
-                    if terminal {
-                        break;
-                    }
-                }
-                Ok(None) => {
-                    let status = A2aChatService::get_run(self, caller.clone(), run_id).await?;
-                    let content = run_content(&status);
-                    let _ = self
-                        .fail_run_if_open_with_reason(
-                            run_id,
-                            "Bot channel closed without response",
-                            DirectChatRunReason::BotNotConnected,
-                        )
-                        .await;
-                    if content.is_empty() {
-                        self.chat_run_events.unregister(run_id).await;
-                        return Err(ServiceError::InternalError(
-                            "Bot channel closed without response".to_string(),
-                        ));
-                    }
-                    break;
-                }
-                Err(_) => {
-                    let status = A2aChatService::get_run(self, caller.clone(), run_id).await?;
-                    if run_content(&status).is_empty() {
-                        let _ = self
-                            .fail_run_if_open_with_reason(
-                                run_id,
-                                "Timeout waiting for bot response",
-                                DirectChatRunReason::Timeout,
-                            )
-                            .await;
-                        self.chat_run_events.unregister(run_id).await;
-                        return Err(ServiceError::InternalError(
-                            "Timeout waiting for bot response".to_string(),
-                        ));
-                    }
-                    let _ = self
-                        .fail_run_if_open_with_reason(
-                            run_id,
-                            "Timeout waiting for bot response",
-                            DirectChatRunReason::Timeout,
-                        )
-                        .await;
-                    break;
-                }
-            }
-        }
-
-        self.chat_run_events.unregister(run_id).await;
-        let status = A2aChatService::get_run(self, caller, run_id).await?;
-        if status.status == "failed" {
-            return Err(ServiceError::InternalError(format!(
-                "Bot error: {}",
-                run_error_message(&status)
-            )));
-        }
-
-        Ok(BlockingA2aChatOutcome {
-            delivered: true,
-            bot_uuid: target_bot_id.to_string(),
-            session_id: session_key.to_string(),
-            content: run_content(&status),
-        })
-    }
-
     async fn drain_async_run(
         &self,
         run_id: String,
@@ -1236,26 +1095,6 @@ fn run_status(record: &ChatRunRecord, cancelled: Option<bool>) -> A2aRunStatus {
         status: record.state.as_str().to_string(),
         response: Some(response),
     }
-}
-
-fn run_content(status: &A2aRunStatus) -> String {
-    status
-        .response
-        .as_ref()
-        .and_then(|response| response.get("content"))
-        .and_then(|content| content.as_str())
-        .unwrap_or("")
-        .to_string()
-}
-
-fn run_error_message(status: &A2aRunStatus) -> String {
-    status
-        .response
-        .as_ref()
-        .and_then(|response| response.get("error_message"))
-        .and_then(|message| message.as_str())
-        .unwrap_or("Unknown error")
-        .to_string()
 }
 
 fn build_chat_send_frame(

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_a2a_chat.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_a2a_chat.rs
@@ -5,7 +5,7 @@ use bcs_protocol::BcsFrame;
 use bcs_domain::{Organization, OrganizationMember};
 use bcs_service_api::{
     A2aChatCommand, A2aChatRunService, A2aChatService, ActorKind, ActorStatus, AgentCredentials,
-    AsyncA2aChatCommand, BlockingA2aChatCommand, BotActor, BotCapabilities, BotDeliveryCommand,
+    AsyncA2aChatCommand, BotActor, BotCapabilities, BotDeliveryCommand,
     BotDeliveryKind, BotDeliveryPort, BotDeliveryResult, BotDeliveryTarget, BotDynamicStatus,
     BotRegistryCoreService, CallerContext, ChatResponseMode, ChatRunCancelCommand, ChatRunCleanupPort, ChatRunEventPort, ChatRunQueryCommand,
     AuthorizedOrganizationPair, DirectChatClientKind, DirectChatRunSnapshotPort, FriendCoreService, OrganizationCoreService, RegisteredBot,
@@ -131,17 +131,6 @@ fn chat_event(state: &str, text: &str) -> String {
     .to_string()
 }
 
-fn chat_event_state(state: &str) -> String {
-    serde_json::json!({
-        "type": "event",
-        "event": "chat.event",
-        "payload": {
-            "state": state
-        }
-    })
-    .to_string()
-}
-
 fn chat_delta_text(text: &str) -> String {
     serde_json::json!({
         "type": "event",
@@ -239,27 +228,6 @@ async fn direct_chat_run_snapshot_maps_http_client_kinds() {
         build_run_service(vec![chat_event("final", "pong")], false).await;
 
     service
-        .run_blocking_chat(BlockingA2aChatCommand {
-            caller: CallerContext::Bot(BotActor {
-                bot_uuid: "bot-source".to_string(),
-            }),
-            target_bot_id: "bot-target".to_string(),
-            message: "hello".to_string(),
-            from_actor_id: Some("api-user".to_string()),
-            run_channel_from: Some("api-user".to_string()),
-            authenticated_staff_id: Some("owner-1".to_string()),
-            tags: Vec::new(),
-            run_id: "http-client-kind-run".to_string(),
-            session_key: "http-client-kind-session".to_string(),
-            timeout_ms: 1_000,
-            client: None,
-            response_mode: ChatResponseMode::Full,
-            organization_code: None,
-            provider_bypass_headers: Vec::new(),
-        })
-        .await
-        .unwrap();
-    service
         .start_async_chat(AsyncA2aChatCommand {
             caller: CallerContext::Bot(BotActor {
                 bot_uuid: "bot-source".to_string(),
@@ -288,9 +256,6 @@ async fn direct_chat_run_snapshot_maps_http_client_kinds() {
     let counts = DirectChatRunSnapshotPort::direct_chat_run_counts(service.as_ref())
         .await
         .unwrap();
-    assert!(counts.iter().any(|count| {
-        count.client_kind == DirectChatClientKind::HttpChat && count.count > 0
-    }));
     assert!(counts.iter().any(|count| {
         count.client_kind == DirectChatClientKind::HttpChatAsync && count.count > 0
     }));
@@ -397,96 +362,6 @@ async fn bcs_cli_a2a_chat_requests_callback_provider_transport() {
     assert_eq!(
         bot_delivery.provider_transports().await,
         vec![ProviderTransportPreference::Callback]
-    );
-}
-
-#[tokio::test]
-async fn blocking_run_service_records_final_event_and_unregisters_run() {
-    let (service, run_port, run_store) = build_run_service(
-        vec![chat_event("delta", "po"), chat_event("final", "ng")],
-        false,
-    )
-    .await;
-
-    let outcome = service
-        .run_blocking_chat(BlockingA2aChatCommand {
-            caller: CallerContext::Bot(BotActor {
-                bot_uuid: "bot-source".to_string(),
-            }),
-            target_bot_id: "bot-target".to_string(),
-            message: "hello".to_string(),
-            from_actor_id: Some("api-user".to_string()),
-            run_channel_from: Some("api-user".to_string()),
-            authenticated_staff_id: Some("owner-1".to_string()),
-            tags: Vec::new(),
-            run_id: "blocking-run".to_string(),
-            session_key: "blocking-session".to_string(),
-            timeout_ms: 1_000,
-            client: Some("contract-test".to_string()),
-            response_mode: ChatResponseMode::Full,
-            organization_code: None,
-            provider_bypass_headers: Vec::new(),
-        })
-        .await
-        .unwrap();
-
-    assert!(outcome.delivered);
-    assert_eq!(outcome.bot_uuid, "bot-target");
-    assert_eq!(outcome.session_id, "blocking-session");
-    assert_eq!(outcome.content, "pong");
-    assert_eq!(
-        run_store.get("blocking-run").await.unwrap().state.as_str(),
-        "completed"
-    );
-    assert_eq!(run_port.event_unregistered().await, vec!["blocking-run"]);
-}
-
-#[tokio::test]
-async fn blocking_run_service_keeps_delta_text_when_final_is_empty() {
-    let (service, run_port, run_store) = build_run_service(
-        vec![
-            chat_delta_text("streaming "),
-            chat_delta_text("result"),
-            chat_event_state("final"),
-        ],
-        false,
-    )
-    .await;
-
-    let outcome = service
-        .run_blocking_chat(BlockingA2aChatCommand {
-            caller: CallerContext::Bot(BotActor {
-                bot_uuid: "bot-source".to_string(),
-            }),
-            target_bot_id: "bot-target".to_string(),
-            message: "hello".to_string(),
-            from_actor_id: Some("api-user".to_string()),
-            run_channel_from: Some("api-user".to_string()),
-            authenticated_staff_id: Some("owner-1".to_string()),
-            tags: Vec::new(),
-            run_id: "delta-empty-final-run".to_string(),
-            session_key: "delta-empty-final-session".to_string(),
-            timeout_ms: 1_000,
-            client: Some("contract-test".to_string()),
-            response_mode: ChatResponseMode::Full,
-            organization_code: None,
-            provider_bypass_headers: Vec::new(),
-        })
-        .await
-        .unwrap();
-
-    assert_eq!(outcome.content, "streaming result");
-    assert_eq!(
-        run_store
-            .get("delta-empty-final-run")
-            .await
-            .unwrap()
-            .accumulated_content,
-        "streaming result"
-    );
-    assert_eq!(
-        run_port.event_unregistered().await,
-        vec!["delta-empty-final-run"]
     );
 }
 
@@ -658,89 +533,6 @@ async fn detached_run_fails_when_error_is_the_first_event() {
     let run = run_store.get("detach-error-first").await.unwrap();
     assert_eq!(run.state.as_str(), "failed");
     assert_eq!(run.error_message.as_deref(), Some("provider failed"));
-}
-
-#[tokio::test]
-async fn blocking_run_service_unregisters_when_recording_event_fails() {
-    let (service, run_port, run_store) = build_run_service(Vec::new(), true).await;
-    let task = {
-        let service = service.clone();
-        tokio::spawn(async move {
-            service
-                .run_blocking_chat(BlockingA2aChatCommand {
-                    caller: CallerContext::Bot(BotActor {
-                        bot_uuid: "bot-source".to_string(),
-                    }),
-                    target_bot_id: "bot-target".to_string(),
-                    message: "hello".to_string(),
-                    from_actor_id: Some("api-user".to_string()),
-                    run_channel_from: Some("api-user".to_string()),
-                    authenticated_staff_id: Some("owner-1".to_string()),
-                    tags: Vec::new(),
-                    run_id: "record-error-run".to_string(),
-                    session_key: "record-error-session".to_string(),
-                    timeout_ms: 1_000,
-                    client: None,
-                    response_mode: ChatResponseMode::Full,
-                    organization_code: None,
-                    provider_bypass_headers: Vec::new(),
-                })
-                .await
-        })
-    };
-
-    for _ in 0..50 {
-        if run_store.get("record-error-run").await.is_some() {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
-    assert!(run_store.mark_completed("record-error-run", None).await);
-    run_store.cleanup_expired(u64::MAX, 0).await;
-    run_port
-        .send_event("record-error-run", chat_event("final", "late"))
-        .await;
-
-    assert!(matches!(task.await.unwrap(), Err(ServiceError::BotNotFound(_))));
-    assert_eq!(run_port.event_unregistered().await, vec!["record-error-run"]);
-}
-
-#[tokio::test]
-async fn run_service_preserves_omitted_from_as_run_channel_metadata_none() {
-    let (service, run_port, _run_store) =
-        build_run_service(vec![chat_event("final", "pong")], false).await;
-
-    service
-        .run_blocking_chat(BlockingA2aChatCommand {
-            caller: CallerContext::Bot(BotActor {
-                bot_uuid: "bot-source".to_string(),
-            }),
-            target_bot_id: "bot-target".to_string(),
-            message: "hello".to_string(),
-            from_actor_id: Some("user".to_string()),
-            run_channel_from: None,
-            authenticated_staff_id: Some("owner-1".to_string()),
-            tags: Vec::new(),
-            run_id: "metadata-run".to_string(),
-            session_key: "metadata-session".to_string(),
-            timeout_ms: 1_000,
-            client: None,
-            response_mode: ChatResponseMode::Full,
-            organization_code: None,
-            provider_bypass_headers: Vec::new(),
-        })
-        .await
-        .unwrap();
-
-    assert_eq!(
-        run_port.registrations().await,
-        vec![(
-            "metadata-run".to_string(),
-            "metadata-session".to_string(),
-            Some("http-chat".to_string()),
-            None,
-        )]
-    );
 }
 
 #[tokio::test]
@@ -2145,7 +1937,6 @@ impl RecordingDelivery {
 struct RecordingRunPort {
     events: Vec<String>,
     keep_open_after_send: bool,
-    registrations: Mutex<Vec<(String, String, Option<String>, Option<String>)>>,
     event_unregistered: Mutex<Vec<String>>,
     cleanup_unregistered: Mutex<Vec<String>>,
     open_senders: RwLock<HashMap<String, mpsc::Sender<String>>>,
@@ -2157,7 +1948,6 @@ impl RecordingRunPort {
         Self {
             events,
             keep_open_after_send,
-            registrations: Mutex::new(Vec::new()),
             event_unregistered: Mutex::new(Vec::new()),
             cleanup_unregistered: Mutex::new(Vec::new()),
             open_senders: RwLock::new(HashMap::new()),
@@ -2165,16 +1955,8 @@ impl RecordingRunPort {
         }
     }
 
-    async fn event_unregistered(&self) -> Vec<String> {
-        self.event_unregistered.lock().await.clone()
-    }
-
     async fn cleanup_unregistered(&self) -> Vec<String> {
         self.cleanup_unregistered.lock().await.clone()
-    }
-
-    async fn registrations(&self) -> Vec<(String, String, Option<String>, Option<String>)> {
-        self.registrations.lock().await.clone()
     }
 
     async fn send_event(&self, run_id: &str, event: String) {
@@ -2214,15 +1996,11 @@ impl ChatRunEventPort for RecordingRunPort {
     async fn register(
         &self,
         run_id: String,
-        session_key: String,
+        _session_key: String,
         sender: mpsc::Sender<String>,
-        source: Option<String>,
-        from: Option<String>,
+        _source: Option<String>,
+        _from: Option<String>,
     ) {
-        self.registrations
-            .lock()
-            .await
-            .push((run_id.clone(), session_key, source, from));
         for event_json in &self.events {
             sender.send(event_json.clone()).await.unwrap();
         }

--- a/src/bcs/crates/test-support/bcs-test-support/src/noop.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/noop.rs
@@ -1705,13 +1705,6 @@ pub struct NoopA2aChatRunService;
 
 #[async_trait]
 impl A2aChatRunService for NoopA2aChatRunService {
-    async fn run_blocking_chat(
-        &self,
-        _cmd: BlockingA2aChatCommand,
-    ) -> ServiceResult<BlockingA2aChatOutcome> {
-        Err(service_not_configured("a2a chat run service"))
-    }
-
     async fn start_async_chat(
         &self,
         _cmd: AsyncA2aChatCommand,


### PR DESCRIPTION
## Summary

`A2aChatRunService::run_blocking_chat` — the synchronous blocking A2A chat entry point — had **no production caller**. This PR removes it and everything that only existed to support it: the trait method, the two `Blocking*` command/outcome types, the `A2aChat` impl, the private `drain_blocking_run`, the metrics/noop/route-contract test stubs, and the five blocking contract tests.

The HTTP adapter and `bcs-cli` already exclusively use the **async submit + poll** flow (`start_async_chat` → `get_run`/`cancel_run`). The blocking path was dead surface area.

## Why it's safe to delete

- **HTTP routes** consume `services.a2a_chat_runs` via only `start_async_chat` (`routes/bot_chat.rs`, `routes/admin_invocations.rs`), `get_run`, and `cancel_run` (`routes/messages.rs`) — never `run_blocking_chat`.
- **`bcs-cli`** "blocking" semantics are purely client-side long-polling (`POST /bots/{id}/chat-async` + `GET /chat/runs/{id}`); the server side calls `start_async_chat`.
- The three other impls deliberately stubbed it: `route_contract.rs` (`unreachable!("run_blocking_chat is not used by route contract tests")`), `server.rs` `AdminRunTestA2aRuns` (`unreachable!("admin run test only uses async chat")`), and `noop.rs` (returns `service_not_configured`, never called).
- The only real `.run_blocking_chat(` call sites were **all tests**.

## Changes

`+41 / −573` across 10 files (net −532 lines).

- `bcs-service-api`: drop the `run_blocking_chat` trait method and the `BlockingA2aChatCommand` / `BlockingA2aChatOutcome` types; remove their re-exports.
- `bcs-message-flow` (`mod.rs`): delete `A2aChat::run_blocking_chat` and the private `drain_blocking_run` method (which was its only caller). `drain_async_run`, which shared the same `impl A2aChat` block, is **retained intact**. Two helpers that `drain_blocking_run` was the sole user of (`run_content`, `run_error_message`) were also pruned once the compiler flagged them dead.
- `bootstrap/metrics.rs`, `server.rs`, `test-support/noop.rs`: remove the `run_blocking_chat` stubs (the impls keep their surviving three methods).

### Test changes

- `contract_a2a_chat.rs`: 4 blocking-only test functions deleted outright; the mixed `direct_chat_run_snapshot_maps_http_client_kinds` test got a surgical edit — its `run_blocking_chat` call removed and the now-baseless `HttpChat` snapshot assertion dropped, keeping the `HttpChatAsync` assertion.
- HTTP test fakes (`route_contract.rs`, `bot_chat_contract.rs`): drop the `run_blocking_chat` stub methods; in `bot_chat_contract.rs` the two blocking-only recorder fields (`blocking_failure`, `blocking_returns_error`) are removed and the `blocking_mode_from_events` helper simplified to a content-only `blocking_content_from_events`.
- `metrics_wrappers.rs`: instead of just deleting the blocking producer (which would have left the `direct_chat` metric assertion unsourced), the test now exercises `InstrumentedA2aChatRunService` through **`start_async_chat`** — the same `DirectChat` metric record path that remains live in production — preserving the metric coverage with a minimal 3-method fake.

## Verification

- `cargo build --workspace --tests` — clean; **no warnings introduced** by this change.
- Touched tests all green:

  | suite | result |
  | --- | --- |
  | `contract_a2a_chat` | 34 passed |
  | `metrics_wrappers` | 1 passed |
  | `route_contract` | 43 passed |
  | `bot_chat_contract` | 10 passed |
  | `bcs` lib | 212 passed |
  | `bcs-message-flow` lib | 33 passed |
  | `contract_message_flow` / `contract_bot_event` / `contract_group_fusion` / `conformance` | 68 / 93 / 2 / 4 passed |
  | `bcs-services-container` | all green |
  | `bcs-test-support` | 17 / 3 / 3 passed |

- A residual-symbol grep across the tree (excluding `docs/`) finds **zero** references to `run_blocking_chat`, `BlockingA2aChatCommand`, or `BlockingA2aChatOutcome`.

### Known pre-existing failures (unrelated)

Three tests in `bcs::integration_http_api` (`bcs_http_health`, `bcs_http_bots_endpoint`, `bcs_http_bot_detail_endpoint_requires_caller`) fail. These are **environmental** — they bootstrap a live BCS server on a port and fail with `BCS server did not start on port N`. They fail identically on the **pre-change base** commit (`c2ce99161`), confirming the regression is not from this change.

## Risk & Rollback

- **Risk: low.** The removed trait and types are workspace-internal with no external consumers, and no production path called the method.
- **Rollback:** `git revert d73958022`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)