### PR TITLE
fix(backend): preserve render-screen compatibility for external BCN bots

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_render_screen/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_render_screen/router.py
@@ -65,8 +65,6 @@ async def list_render_screens(
             owner_id=owner_id,
             current_user_id=user_id,
         )
-    except PermissionError as e:
-        return RenderScreenApiResponse(success=False, message=str(e), error_code=403, data=None)
     except Exception as e:
         logger.exception("[RenderScreen] list_render_screens error: %s", e)
         return RenderScreenApiResponse(success=False, message=str(e), error_code=500, data=None)

--- a/src/backend/src/agentclaw/community/core/bot_management/render_screen/services/render_screen_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/render_screen/services/render_screen_service.py
@@ -102,10 +102,13 @@ class RenderScreenService:
         current_user_id: str | None = None,
     ) -> list[RenderScreenRecord]:
         """查询某 Bot 下所有 CDN 配置（未删除）。"""
-        try:
-            bot = self._require_bot(bot_id)
-        except PermissionError as exc:
-            raise PermissionError(f"无权查看此 Bot 的 CDN 配置: {bot_id}") from exc
+        # BCN can contain externally onboarded bots that do not have a matching
+        # ac_bot management record. They can still participate in group chat, but
+        # they have no Avernet-managed CDN configuration. Treat that as an empty
+        # list rather than an authorization failure.
+        bot = self._bot_repo.get_by_id(bot_id)
+        if not bot:
+            return []
 
         scope = resolve_render_screen_scope(bot)
         if scope == "bot":

--- a/src/backend/src/agentclaw/community/core/bot_management/render_screen/services/render_screen_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/render_screen/services/render_screen_service.py
@@ -66,7 +66,9 @@ class RenderScreenService:
         return collaborator is not None
 
     def _resolve_scope(self, bot_id: str) -> str:
-        return resolve_render_screen_scope(self._require_bot(bot_id))
+        # Bots externally onboarded through BCN may not have an ac_bot record.
+        # Keep their historical behavior by falling back to owner scope.
+        return resolve_render_screen_scope(self._bot_repo.get_by_id(bot_id))
 
     def authorize_render_screen_bot(self, *, bot_id: str, user_id: str) -> str:
         """Resolve the scope and enforce collaborative access for coding bots."""
@@ -102,14 +104,7 @@ class RenderScreenService:
         current_user_id: str | None = None,
     ) -> list[RenderScreenRecord]:
         """查询某 Bot 下所有 CDN 配置（未删除）。"""
-        # BCN can contain externally onboarded bots that do not have a matching
-        # ac_bot management record. They can still participate in group chat, but
-        # they have no Avernet-managed CDN configuration. Treat that as an empty
-        # list rather than an authorization failure.
         bot = self._bot_repo.get_by_id(bot_id)
-        if not bot:
-            return []
-
         scope = resolve_render_screen_scope(bot)
         if scope == "bot":
             # 读放开：副屏 CDN 配置（库名 → CDN URL 映射）是非敏感渲染资源。
@@ -147,9 +142,9 @@ class RenderScreenService:
         if any(r.cdn_url == cdn_url for r in existing):
             raise ValueError(f"Duplicate cdn_url '{cdn_url}' for bot_id={bot_id}")
 
-        bot = self._require_bot(bot_id)
         record_owner_id = owner_id or creator_id
         if scope == "bot":
+            bot = self._require_bot(bot_id)
             record_owner_id = str(bot.get("owner_id") or record_owner_id)
 
         record_id = self._repo.insert(

--- a/src/backend/tests/community/core/bot_render_screen/services/test_render_screen_service.py
+++ b/src/backend/tests/community/core/bot_render_screen/services/test_render_screen_service.py
@@ -137,14 +137,19 @@ class TestListRenderScreens:
         mock_repo.list_by_bot_id.assert_called_once_with(bot_id="bot_001", owner_id=None)
 
 
-    def test_missing_bot_fails_closed(self, service, mock_bot_repo):
+    def test_external_bcn_bot_without_management_record_returns_empty_list(
+        self, service, mock_repo, mock_bot_repo
+    ):
         mock_bot_repo.get_by_id.return_value = None
-        with pytest.raises(PermissionError, match="无权查看此 Bot 的 CDN 配置"):
-            service.list_render_screens(
-                bot_id="bot_missing",
-                owner_id="owner_001",
-                current_user_id="user_001",
-            )
+
+        result = service.list_render_screens(
+            bot_id="bot_1eff6708",
+            owner_id=None,
+            current_user_id="user_001",
+        )
+
+        assert result == []
+        mock_repo.list_by_bot_id.assert_not_called()
 
 
 class TestCreateRenderScreen:

--- a/src/backend/tests/community/core/bot_render_screen/services/test_render_screen_service.py
+++ b/src/backend/tests/community/core/bot_render_screen/services/test_render_screen_service.py
@@ -137,10 +137,13 @@ class TestListRenderScreens:
         mock_repo.list_by_bot_id.assert_called_once_with(bot_id="bot_001", owner_id=None)
 
 
-    def test_external_bcn_bot_without_management_record_returns_empty_list(
+    def test_external_bcn_bot_without_management_record_uses_owner_scope(
         self, service, mock_repo, mock_bot_repo
     ):
         mock_bot_repo.get_by_id.return_value = None
+        mock_repo.list_by_bot_id.return_value = [
+            _record(bot_id="bot_1eff6708", owner_id="user_001")
+        ]
 
         result = service.list_render_screens(
             bot_id="bot_1eff6708",
@@ -148,8 +151,25 @@ class TestListRenderScreens:
             current_user_id="user_001",
         )
 
-        assert result == []
-        mock_repo.list_by_bot_id.assert_not_called()
+        assert len(result) == 1
+        mock_repo.list_by_bot_id.assert_called_once_with(
+            bot_id="bot_1eff6708",
+            owner_id="user_001",
+        )
+
+
+class TestAuthorizeRenderScreenBot:
+    def test_external_bcn_bot_without_management_record_uses_owner_scope(
+        self, service, mock_bot_repo
+    ):
+        mock_bot_repo.get_by_id.return_value = None
+
+        scope = service.authorize_render_screen_bot(
+            bot_id="bot_1eff6708",
+            user_id="user_001",
+        )
+
+        assert scope == "owner"
 
 
 class TestCreateRenderScreen:
@@ -250,17 +270,34 @@ class TestCreateRenderScreen:
             )
 
 
-    def test_create_missing_bot_fails_closed(self, service, mock_bot_repo):
+    def test_create_external_bcn_bot_uses_owner_scope(
+        self, service, mock_repo, mock_bot_repo
+    ):
         mock_bot_repo.get_by_id.return_value = None
-        with pytest.raises(PermissionError, match="无权操作此 Bot 的 CDN 配置"):
-            service.create_render_screen(
-                bot_id="bot_missing",
-                owner_id="user_001",
-                name="看板",
-                cdn_url="https://cdn.example.com/v1/index.js",
-                creator_id="user_001",
-                current_user_id="user_001",
-            )
+        mock_repo.list_by_bot_id.return_value = []
+        mock_repo.insert.return_value = 45
+
+        record_id = service.create_render_screen(
+            bot_id="bot_1eff6708",
+            owner_id="user_001",
+            name="看板",
+            cdn_url="https://cdn.example.com/v1/index.js",
+            creator_id="user_001",
+            current_user_id="user_001",
+        )
+
+        assert record_id == 45
+        mock_repo.list_by_bot_id.assert_called_once_with(
+            bot_id="bot_1eff6708",
+            owner_id="user_001",
+        )
+        mock_repo.insert.assert_called_once_with(
+            bot_id="bot_1eff6708",
+            owner_id="user_001",
+            name="看板",
+            cdn_url="https://cdn.example.com/v1/index.js",
+            creator_id="user_001",
+        )
 
 
 class TestUpdateRenderScreen:
@@ -306,7 +343,26 @@ class TestAuthorizeRenderScreenRecord:
             service.authorize_render_screen_record(record_id=1, user_id="stranger")
 
 
-    def test_authorize_record_missing_bot_fails_closed(self, service, mock_repo, mock_bot_repo):
+    def test_authorize_external_bcn_record_allows_record_owner(
+        self, service, mock_repo, mock_bot_repo
+    ):
+        mock_repo.get_by_id.return_value = _record(
+            id=1,
+            bot_id="bot_1eff6708",
+            owner_id="user_001",
+        )
+        mock_bot_repo.get_by_id.return_value = None
+
+        record = service.authorize_render_screen_record(
+            record_id=1,
+            user_id="user_001",
+        )
+
+        assert record.id == 1
+
+    def test_authorize_external_bcn_record_denies_non_owner(
+        self, service, mock_repo, mock_bot_repo
+    ):
         mock_repo.get_by_id.return_value = _record(id=1, owner_id="owner_001")
         mock_bot_repo.get_by_id.return_value = None
         with pytest.raises(PermissionError, match="无权操作此 Bot 的 CDN 配置"):


### PR DESCRIPTION
## Problem

部分通过 BCN 外部接入的 Bot 可以正常加入群聊并参与对话，但不一定存在于 Avernet 的 `ac_bot` 管理表中。

群聊前端为了渲染副屏，会调用：

```http
GET /api/bot-render-screens?bot_id=<bot_id>&owner_id=<owner_id>
```

Coding Bot 副屏协作共享改造引入了基于 Bot 管理记录解析 render-screen scope 的逻辑。外部 BCN Bot 缺少 `ac_bot` 记录时，如果直接通过 `_require_bot(bot_id)` 获取 Bot，会被错误地解释为无权限并返回 403，导致群聊副屏初始化失败。

此外，在 coding bot 协作改造之前，外部 BCN Bot 不需要存在于 `ac_bot` 管理表中，也可以按当前用户的 `owner_id` 上传、查询、编辑和删除自己的 CDN 配置。如果仅修复查询接口，上传、编辑和删除仍会发生历史行为回归。

典型错误响应：

```json
{
  "success": false,
  "message": "无权操作此 Bot 的 CDN 配置: <bot_id>",
  "error_code": 403,
  "data": null
}
```

Bot 不在 Avernet 管理表中，只表示当前服务没有该 Bot 的托管元数据，并不等同于当前用户无权与其交互。

## Solution

从远端最新 `origin/dev` 创建全新分支 `devtianxun_0830`，只重新迁移副屏接口相关的外部 BCN Bot 兼容改动，不携带原开发分支中的其他无关提交。

将 render-screen 作用域规则收敛为：

```text
托管 Agent Coding Bot → bot scope
其他所有 Bot          → owner scope
```

具体改动：

- `_resolve_scope(bot_id)` 不再通过 `_require_bot()` 强制要求 Bot 管理记录存在，而是将 `bot_repo.get_by_id(bot_id)` 的结果交给 `resolve_render_screen_scope()`。
- `resolve_render_screen_scope(None)` 返回 `owner`，因此没有 `ac_bot` 记录的外部 BCN Bot 自动回退到历史 owner 作用域。
- list：
  - Agent Coding Bot 按 `bot_id` 查询，不带 owner 过滤；
  - 普通托管 Bot 和外部 BCN Bot 按 `owner_id` 查询；
  - 没有 CDN 记录时自然返回空数组，不再因缺少 Bot 管理记录返回 403。
- create：
  - 只有 bot scope 的 Agent Coding Bot 才要求存在 Bot 管理记录，并将记录归属到 Bot Owner；
  - owner scope 的 Bot，包括外部 BCN Bot，不要求存在 Bot 管理记录，记录归属当前上传用户。
- update/delete：
  - bot scope 继续允许 Bot Owner 与协作者共同管理；
  - owner scope 继续按 `record.owner_id == current_user_id` 鉴权，外部 BCN Bot 用户只能编辑、删除自己名下的配置。
- 删除列表 Router 中不再需要的 `PermissionError -> 403` 捕获分支。
- 增加外部 BCN Bot owner-scope 查询、上传和记录权限的回归测试。

最终行为：

| Bot 类型 | 作用域 | 查询 | 上传 | 编辑、删除 |
| --- | --- | --- | --- | --- |
| 托管 Agent Coding Bot（`claude_code` + 非普通 CC 模板） | `bot` | 查询 Bot 下全部 CDN 配置 | Owner、协作者可上传，记录归 Bot Owner | Owner、协作者可共同管理 |
| 普通 CC、其他引擎的托管 Bot | `owner` | 查询指定/当前 Owner 的配置 | 记录归当前上传用户 | 仅记录 Owner 可管理 |
| 外部 BCN Bot，无 `ac_bot` 记录 | `owner` | 查询指定/当前 Owner 的配置；无记录返回 `[]` | 恢复历史上传能力，记录归当前上传用户 | 仅记录 Owner 可管理 |

## Validation

在新分支、最新 `origin/dev` 基线上运行副屏相关定向测试：

```bash
cd src/backend
uv run pytest -q \
  tests/community/core/bot_management/render_screen/test_scope.py \
  tests/community/core/bot_render_screen/services/test_render_screen_service.py \
  tests/community/api/bot_render_screen/test_router.py \
  tests/community/adapters/http/openapi_v1/render_screens/test_render_screens_handlers.py \
  tests/community/architecture/test_no_module_level_service_instances.py
```

结果：

```text
60 passed, 18 warnings in 1.97s
```

验证覆盖：

- Agent Coding Bot 继续使用 bot scope。
- 普通 CC 和其他引擎 Bot 继续使用 owner scope。
- 群聊/分享场景查看 Coding Bot CDN 配置时不做协作者读权限拦截。
- 外部 BCN Bot 没有管理记录时回退到 owner scope。
- 外部 BCN Bot 可以查询、上传自己名下的 CDN 配置。
- 外部 BCN Bot 的记录 Owner 可以通过鉴权，非 Owner 被拒绝。
- Router 及模块级依赖架构规则无回归。

同时执行 `git diff --check`，结果通过。

未运行完整后端测试与完整 CI；完整流水线由远端 PR 检查执行。

## Compatibility and risk

- **Coding Bot 兼容**：不修改 Agent Coding Bot 按 bot 维度共享的规则；Owner 和协作者仍可共同查看、上传、编辑和删除 CDN 配置。
- **普通 Bot 兼容**：普通 CC、其他引擎 Bot 仍按 owner 维度隔离，不扩大访问范围。
- **外部 BCN Bot 兼容**：恢复 coding bot 协作改造前按 owner 维度查询和管理 CDN 配置的历史行为。
- **接口兼容**：接口路径、请求参数和响应结构均无变化；`owner_id` 参数继续保留。
- **权限边界**：外部 BCN Bot 不会获得 bot 级协作权限，只恢复 owner 级能力；用户不能编辑或删除其他 Owner 的记录。
- **数据兼容**：无数据库 Schema、Repository 协议或数据迁移变更。
- **影响范围**：仅涉及 render-screen CDN 列表、创建及已有记录鉴权对外部 BCN Bot 的处理；不影响其他 Bot 的作用域判定。
- **回滚**：按逆序 revert `68afe0ecb`、`4b76aa009` 即可回滚本次分支中的副屏兼容改动，无数据迁移回滚要求。

## Spec

本次实现沿用 Avernet 中已有的 Coding Bot 副屏协作共享方案：

- Agent Coding Bot 使用 bot 维度共享；
- 普通 Bot 使用 owner 维度隔离；
- 无法获取托管 Bot 元数据的外部 BCN Bot 回退到 owner 维度，保持历史兼容。

## Related issues

N/A
