### PR TITLE
feat(baas): best-effort chat.abort on AsyncChatClient send_message timeout

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py
@@ -38,6 +38,10 @@ from ._session_state import SessionState
 
 logger = get_logger("core-bot-run")
 
+# Best-effort chat.abort 自身超时预算：超时后截断 abort，确保 TimeoutError 及时上抛。
+# 落在 _send_request 默认 30s 超时之内，留充足余量。
+_ABORT_TIMEOUT_SECONDS: float = 3.0
+
 
 def _public_interaction_envelope(
     envelope: JsonObject,
@@ -440,7 +444,17 @@ class AsyncChatClient:
 
                 # 5. 等待主对话事件完成
                 if timeout:
-                    await asyncio.wait_for(state.chat_complete.wait(), timeout=timeout)
+                    try:
+                        await asyncio.wait_for(
+                            state.chat_complete.wait(), timeout=timeout
+                        )
+                    except TimeoutError:
+                        # 主对话超时：best-effort 终止 engine 侧会话，再裸 raise
+                        # 原 TimeoutError（不 raise ... from，保持异常链与类型不变，
+                        # 维护 _baas_service/_claw_service/_executor 的 except TimeoutError
+                        # 契约）。
+                        await self._abort_session(session_key)
+                        raise
                 else:
                     # 无超时等待
                     await state.chat_complete.wait()
@@ -690,6 +704,34 @@ class AsyncChatClient:
                 return
 
     # ── 私有方法 ──────────────────────────────────────────────────────────
+
+    async def _abort_session(self, session_key: str) -> None:
+        """Best-effort 发送 chat.abort 终止 engine 侧会话。
+
+        在 send_message 主对话超时后调用：
+        - 断连时直接跳过（不触发网络调用）；
+        - 自身受 _ABORT_TIMEOUT_SECONDS 硬上限截断，避免延迟 TimeoutError 上抛；
+        - 任何异常（包括 TimeoutError）只记 warning 并吞掉，保证不影响
+          外层裸 raise 的原 TimeoutError 类型与异常链。
+        """
+        if not self.is_connected:
+            return
+        assert self._client is not None
+        try:
+            await asyncio.wait_for(
+                self._client.chat_abort(session_key=session_key),
+                timeout=_ABORT_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "[abort] chat.abort timed out: session_key=%s", session_key
+            )
+        except Exception as e:  # noqa: BLE001 — best-effort，吞掉所有异常
+            logger.warning(
+                "[abort] chat.abort failed: session_key=%s, error=%s",
+                session_key,
+                e,
+            )
 
     def _get_session(self, session_key: str) -> SessionState | None:
         """获取指定 sessionKey 的状态（支持模糊匹配）。"""

--- a/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py
@@ -49,6 +49,7 @@ def mock_bot_ws_instance(mock_bot_ws):
     instance.close = AsyncMock()
     instance.chat_send = AsyncMock()
     instance.chat_inject = AsyncMock()
+    instance.chat_abort = AsyncMock()
     instance.connected = True
     return instance
 
@@ -402,6 +403,166 @@ class TestSendMessage:
         assert content == "new content"
         assert agent_payloads == []
         assert sk not in client._sessions
+
+    @pytest.mark.asyncio
+    async def test_send_message_timeout_triggers_chat_abort(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """超时后应 best-effort 调用 chat.abort，且 sessionKey 与 chat_send 一致。"""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        # chat_send 不触发 chat_complete → 主对话超时
+        with pytest.raises(TimeoutError):
+            await client.send_message("Hi", session_key="abort-session", timeout=0.01)
+
+        # chat.abort 被调用一次，且 session_key 与 chat_send 一致
+        mock_bot_ws_instance.chat_abort.assert_awaited_once()
+        abort_kwargs = mock_bot_ws_instance.chat_abort.await_args.kwargs
+        send_kwargs = mock_bot_ws_instance.chat_send.await_args.kwargs
+        assert abort_kwargs["session_key"] == send_kwargs["session_key"]
+        assert abort_kwargs["session_key"] == "abort-session"
+
+    @pytest.mark.asyncio
+    async def test_send_message_timeout_abort_failure_still_propagates_timeout(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """chat.abort 抛异常时应被吞掉，仍抛原 TimeoutError（而非 RuntimeError）。"""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+        mock_bot_ws_instance.chat_abort.side_effect = RuntimeError("abort failed")
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        with pytest.raises(TimeoutError):
+            await client.send_message("Hi", timeout=0.01)
+
+        mock_bot_ws_instance.chat_abort.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_message_timeout_abort_self_timeout_still_propagates(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """chat.abort 自身阻塞过久时应被 _ABORT_TIMEOUT_SECONDS 截断，仍抛 TimeoutError。"""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+        # chat_abort 阻塞远超 _ABORT_TIMEOUT_SECONDS（3.0s）
+        mock_bot_ws_instance.chat_abort.side_effect = asyncio.sleep(100)
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        import time
+
+        start = time.monotonic()
+        with pytest.raises(TimeoutError):
+            await client.send_message("Hi", timeout=0.01)
+        elapsed = time.monotonic() - start
+        # abort 被截断，整体不应超过 _ABORT_TIMEOUT_SECONDS + 少量余量
+        assert elapsed < 5.0
+        mock_bot_ws_instance.chat_abort.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_send_message_timeout_skips_abort_when_disconnected(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """断连时 _abort_session 应跳过 chat.abort，仍抛 TimeoutError。"""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        # chat_send 成功返回后、主对话等待超时前，将连接标记为断开。
+        # 这样 send_message 顶层 is_connected 检查通过，而 _abort_session
+        # 内部 is_connected=False，应跳过 chat.abort。
+        def _drop_connection(*args, **kwargs):
+            mock_bot_ws_instance.connected = False
+
+        mock_bot_ws_instance.chat_send.side_effect = _drop_connection
+
+        with pytest.raises(TimeoutError):
+            await client.send_message("Hi", timeout=0.01)
+
+        mock_bot_ws_instance.chat_abort.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_message_wait_result_false_does_not_abort(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """wait_result=False 不等待、不触发 abort。"""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        await client.send_message("Hi", wait_result=False, timeout=1.0)
+
+        mock_bot_ws_instance.chat_abort.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_message_timeout_none_does_not_abort(
+        self, mock_bot_ws, mock_bot_ws_instance
+    ):
+        """timeout=None 正常完成时不触发 abort。"""
+        from secbaas.community.core.service.bot_run._async_chat_client import (
+            AsyncChatClient,
+        )
+
+        mock_bot_ws_instance.connect.return_value = {
+            "server": {"host": "srv"},
+            "features": {},
+        }
+
+        client = AsyncChatClient(uri="ws://host/ws")
+        await client.connect()
+
+        async def fire_chat_complete(*args, **kwargs):
+            sk = kwargs["session_key"]
+            state = client._sessions.get(sk)
+            if state:
+                state.chat_complete.set()
+
+        mock_bot_ws_instance.chat_send.side_effect = fire_chat_complete
+
+        await client.send_message("Hi", timeout=None)
+
+        mock_bot_ws_instance.chat_abort.assert_not_awaited()
 
 
 # ==================== close tests ====================


### PR DESCRIPTION
## Summary

When `AsyncChatClient.send_message` times out waiting for the main
conversation event, it now best-effort sends a `chat.abort` to terminate
the engine-side session before re-raising the original `TimeoutError`.

This prevents leaked in-flight sessions on the engine side after a
client-side timeout, while preserving the existing
`except TimeoutError` contract used by `_baas_service`, `_claw_service`
and `_executor`.

## Changes

- `src/baas/src/secbaas/community/core/service/bot_run/_async_chat_client.py`
  - Add module-level constant `_ABORT_TIMEOUT_SECONDS = 3.0` bounding the
    best-effort abort call.
  - Wrap the main `asyncio.wait_for(state.chat_complete.wait(), timeout)`
    in a `try/except TimeoutError` that awaits `self._abort_session(session_key)`
    and then bare-`raise`s to keep the original exception type and chain.
  - Add `_abort_session`:
    - No-op when `not self.is_connected`.
    - Bounded by `asyncio.wait_for(..., timeout=_ABORT_TIMEOUT_SECONDS)` so a
      hanging abort cannot delay the propagated `TimeoutError`.
    - Swallows `TimeoutError` and any other exception with a warning log;
      never mutates the outer raised exception.
  - Reuses the local `session_key` from `send_message` (same key passed to
    `chat_send`) so abort targets the same session and does not read
    `_sessions` or the server-side long key.

- `src/baas/tests/unit/core/service/bot_run/test_async_chat_client.py`
  - `test_send_message_timeout_triggers_chat_abort`: abort is called once
    and `session_key` matches the `chat_send` `session_key`.
  - `test_send_message_timeout_abort_failure_still_propagates_timeout`:
    abort raising `RuntimeError` is swallowed, original `TimeoutError`
    still propagates.
  - `test_send_message_timeout_abort_self_timeout_still_propagates`:
    blocking abort is truncated by `_ABORT_TIMEOUT_SECONDS`; overall
    elapsed stays below the test upper bound and `TimeoutError` propagates.
  - `test_send_message_timeout_skips_abort_when_disconnected`: abort is
    skipped when the connection drops between `chat_send` and the wait.

## Behavior contracts preserved

- `_baas_service` / `_claw_service` / `_executor` `except TimeoutError: raise`
  contract unchanged — abort is best-effort and the raised exception is the
  original `TimeoutError` (no `raise ... from`, no exception chain mutation).
- `abort` `sessionKey` equals `chat_send` `sessionKey` (reuses the same
  local variable; does not consult `_sessions` or the server-side long key).
- `_ABORT_TIMEOUT_SECONDS = 3.0` hard upper bound keeps abort from delaying
  the propagated `TimeoutError`.

## Test plan

- `pytest tests/unit/core/service/bot_run/test_async_chat_client.py`
- `pytest tests/unit/core/service/bot_run/test_baas_service.py tests/unit/core/service/bot_run/test_claw_service.py tests/unit/core/service/bot_run/test_bot_run_executor.py tests/unit/core/service/bot_run/test_async_chat_client_pool.py`
- `ruff check src/secbaas/community/core/service/bot_run/_async_chat_client.py tests/unit/core/service/bot_run/test_async_chat_client.py`

All 285 unit tests pass; ruff clean. No blocking review findings
(2 non-blocking P3 notes on configurability/observability and test
timing margin, documented in the review summary).

## Privacy

Public diff privacy scan: no introduced or preexisting secrets leakage;
scan status passed against the delivery base commit.