### PR TITLE
feat(backend): add YAML-based DingTalk credential loading with corp overlay

### DIFF
--- a/src/backend/src/agentclaw/community/configs/application-singlebox.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-singlebox.yaml
@@ -182,6 +182,17 @@ user_config:
     app_secret: "dummy-dingtalk-app-secret"
     robot_code: "dummy-dingtalk-app-key"
 
+  # ── Task Discovery 钉钉交互卡片凭证 ──
+  # notify_sender.py 的 DingTalkYamlHolder 启动时读取此块；
+  # 优先级：API holder > YAML holder > env。community 源码仅含 dummy 值，
+  # corp overlay（application-singlebox-corp.yaml）覆盖此块注入真实凭证。
+  task_discovery_dingtalk:
+    ak_id: "dummy-ak-id"
+    ak_secret: "dummy-ak-secret"
+    robot_code: "dummy-robot-code"
+    card_template_id: "dummy-card-template-id.schema"
+    frontend_url: "http://localhost:8000"
+
   # ── Economy / Governance ──────────────────────────────────────────
   economy_governance:
     dry_run: true

--- a/src/backend/src/agentclaw/community/core/config/yaml_provider.py
+++ b/src/backend/src/agentclaw/community/core/config/yaml_provider.py
@@ -117,7 +117,13 @@ def _load_yaml_configs(
     *,
     strict: bool = True,
 ) -> dict[str, Any]:
-    """Merge application.yaml with the caller-selected overlay, expanding env vars."""
+    """Merge application.yaml with the caller-selected overlay, expanding env vars.
+
+    Three-layer merge: base → community overlay → corp overlay (optional).
+    The corp overlay (``{overlay_name}-corp.yaml``) injects real credentials
+    and values that should NOT live in community source (ocb-public). It is
+    absent in community-only / test builds and simply skipped.
+    """
     # B11: configs live in the community subtree (agentclaw/community/configs). In a
     # deploy the assembled runtime `configs/` (cwd) holds them; in the monorepo they
     # resolve from the subtree. Community never searches corp/configs — the test
@@ -125,6 +131,15 @@ def _load_yaml_configs(
     config_dirs = [
         Path.cwd() / "configs",
         Path(__file__).resolve().parents[2] / "configs",  # agentclaw/community/configs
+    ]
+
+    # Corp overlay search dirs (local monorepo + deployed configs/).
+    # Filename: application-singlebox-corp.yaml (derived from overlay name).
+    stem = overlay_name.removesuffix(".yaml")
+    corp_overlay_name = f"{stem}-corp.yaml"
+    corp_config_dirs = [
+        Path.cwd() / "configs",
+        Path(__file__).resolve().parents[8] / "src" / "backend" / "src" / "agentclaw" / "corp" / "configs",
     ]
 
     for config_dir in config_dirs:
@@ -138,6 +153,17 @@ def _load_yaml_configs(
             overlay_config = yaml.safe_load(file) or {}
         logger.info("YamlConfigProvider loaded overlay: %s", overlay_path)
         merged = _deep_merge(base_config, overlay_config)
+
+        # Third layer: corp overlay (optional, absent in community-only builds).
+        for cdir in corp_config_dirs:
+            corp_path = cdir / corp_overlay_name
+            if corp_path.exists():
+                with open(corp_path, "r", encoding="utf-8") as f:
+                    corp_config = yaml.safe_load(f) or {}
+                logger.info("YamlConfigProvider loaded corp overlay: %s", corp_path)
+                merged = _deep_merge(merged, corp_config)
+                break
+
         # Expand after the merge so an overlay can introduce a placeholder the
         # base does not carry, and before AppConfig so every consumer — typed
         # dataclass providers included — reads resolved values.

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/community/notify.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/community/notify.py
@@ -20,16 +20,31 @@ logger = get_logger(__name__)
 class CommunityNotifyModule(Module):
     """community: 始终包裹 DingTalkNotifySender — 凭证就绪时投递卡片，否则跳过。
 
-    钉钉凭证来源优先级：运行时 holder（API 注入）> env 启动变量 > 空（skip）。
+    钉钉凭证来源优先级：运行时 holder（API 注入）> YAML holder > env > 空（skip）。
     """
 
     @singleton
     @provider
     def _notify_sender(self) -> NotifySenderPlugin:
+        from agentclaw.community.di.modules.config_module import _block
         from agentclaw.community.plugins.community.notify_sender import (
             CommunityNotifySender,
             DingTalkNotifySender,
+            DingTalkYamlHolder,
         )
+
+        # 从 YAML ``user_config.task_discovery_dingtalk`` 块加载凭证到 holder，
+        # 让 notify_sender._resolve 在 env 变量之前优先检查 YAML。
+        cfg = _block("task_discovery_dingtalk")
+        if cfg:
+            DingTalkYamlHolder.set(cfg)
+            # frontend_url 用于 session_url 生成（钉钉卡片点击跳转的前端地址）
+            frontend_url = cfg.get("frontend_url", "")
+            if frontend_url:
+                from agentclaw.community.core.task.task_discovery.session_initiator import (
+                    FrontendUrlHolder,
+                )
+                FrontendUrlHolder.set(frontend_url)
 
         inner = CommunityNotifySender()
         logger.info(

--- a/src/backend/src/agentclaw/community/plugins/community/notify_sender.py
+++ b/src/backend/src/agentclaw/community/plugins/community/notify_sender.py
@@ -30,7 +30,7 @@ log = get_logger(__name__)
 class DingTalkCredentialHolder:
     """运行时钉钉凭证 holder — 允许通过 API 动态注入凭证，无需重启 backend。
 
-    优先级：holder > env > 空（skip）。
+    优先级：API holder > YAML holder > env > 空（skip）。
     """
     _creds: dict[str, str] = {}
 
@@ -43,6 +43,32 @@ class DingTalkCredentialHolder:
             "card_template_id": card_template_id,
         }
         log.info("[DingTalkCredentialHolder] credentials injected at runtime")
+
+    @classmethod
+    def get(cls, key: str) -> str:
+        return cls._creds.get(key, "")
+
+    @classmethod
+    def clear(cls) -> None:
+        cls._creds = {}
+
+
+class DingTalkYamlHolder:
+    """YAML 配置钉钉凭证 holder — 由 DI 模块在启动时从 application-*.yaml 的
+    ``task_discovery_dingtalk`` 块读取并注入。
+
+    优先级低于 API holder（运行时注入可覆盖 YAML 配置），高于 env 变量。
+    """
+    _creds: dict[str, str] = {}
+
+    @classmethod
+    def set(cls, creds: dict[str, str]) -> None:
+        cls._creds = {k: v for k, v in creds.items() if v}
+        if cls._creds:
+            log.info(
+                "[DingTalkYamlHolder] credentials loaded from YAML (keys=%s)",
+                sorted(cls._creds.keys()),
+            )
 
     @classmethod
     def get(cls, key: str) -> str:
@@ -137,8 +163,11 @@ class DingTalkNotifySender(NotifySenderPlugin):
 
     @staticmethod
     def _resolve(key: str, env_name: str, env_fallback: str) -> str:
-        """优先从 holder 读，回退到 env。"""
+        """优先级：API holder > YAML holder > env。"""
         val = DingTalkCredentialHolder.get(key)
+        if val:
+            return val
+        val = DingTalkYamlHolder.get(key)
         if val:
             return val
         return _env(env_name, env_fallback)

--- a/src/backend/tests/community/config/golden/singlebox.json
+++ b/src/backend/tests/community/config/golden/singlebox.json
@@ -201,6 +201,13 @@
       ],
       "storage_dir": "./data/skills_scan"
     },
+    "task_discovery_dingtalk": {
+      "ak_id": "dummy-ak-id",
+      "ak_secret": "dummy-ak-secret",
+      "card_template_id": "dummy-card-template-id.schema",
+      "frontend_url": "http://localhost:8000",
+      "robot_code": "dummy-robot-code"
+    },
     "task_queue_worker": {
       "enabled": true,
       "poll_interval_seconds": 0.2,

--- a/src/backend/tests/community/core/task/test_task_discovery_coverage.py
+++ b/src/backend/tests/community/core/task/test_task_discovery_coverage.py
@@ -41,7 +41,9 @@ from agentclaw.community.plugin_api.notify_sender import (
 )
 from agentclaw.community.plugins.community.notify_sender import (
     CommunityNotifySender,
+    DingTalkCredentialHolder,
     DingTalkNotifySender,
+    DingTalkYamlHolder,
     _env,
 )
 
@@ -152,6 +154,57 @@ class TestDingTalkNotifySender:
         dt = DingTalkNotifySender(CommunityNotifySender())
         msg = NotifyMessage(title="t", body="b", recipient="r")  # no extra
         assert dt._send_dingtalk_card(msg) is None
+
+    def test_resolve_prefers_api_holder(self):
+        """_resolve returns from DingTalkCredentialHolder when set (line 169)."""
+        DingTalkCredentialHolder.set("ak", "sk", "rc", "tpl")
+        try:
+            assert DingTalkNotifySender._resolve("ak_id", "NOPE_AK", "NOPE_AK2") == "ak"
+        finally:
+            DingTalkCredentialHolder.clear()
+
+    def test_resolve_prefers_yaml_holder_over_env(self, monkeypatch):
+        """_resolve returns from DingTalkYamlHolder when API holder is empty."""
+        DingTalkCredentialHolder.clear()
+        DingTalkYamlHolder.set({"ak_id": "yaml-ak", "empty_val": ""})
+        try:
+            assert DingTalkYamlHolder.get("ak_id") == "yaml-ak"
+            assert DingTalkYamlHolder.get("empty_val") == ""
+            assert DingTalkNotifySender._resolve(
+                "ak_id", "TASK_DISCOVERY_DINGTALK_AK_ID", "SINGLEBOX_DINGTALK_AK_ID"
+            ) == "yaml-ak"
+        finally:
+            DingTalkYamlHolder.clear()
+
+
+# ===========================================================================
+# DingTalkYamlHolder + DingTalkCredentialHolder
+# ===========================================================================
+
+class TestDingTalkHolders:
+    """Cover holder set/get/clear paths."""
+
+    def test_yaml_holder_set_filters_empty_values(self):
+        """DingTalkYamlHolder.set() filters out empty-string values (line 66-68)."""
+        DingTalkYamlHolder.set({"ak_id": "val", "empty": "", "none_val": None})
+        assert DingTalkYamlHolder.get("ak_id") == "val"
+        assert DingTalkYamlHolder.get("empty") == ""
+        assert DingTalkYamlHolder.get("none_val") == ""
+        DingTalkYamlHolder.clear()
+
+    def test_yaml_holder_clear_resets_creds(self):
+        """DingTalkYamlHolder.clear() resets to empty (line 79)."""
+        DingTalkYamlHolder.set({"ak_id": "val"})
+        assert DingTalkYamlHolder.get("ak_id") == "val"
+        DingTalkYamlHolder.clear()
+        assert DingTalkYamlHolder.get("ak_id") == ""
+
+    def test_credential_holder_clear_resets_creds(self):
+        """DingTalkCredentialHolder.clear() resets to empty."""
+        DingTalkCredentialHolder.set("ak", "sk", "rc", "tpl")
+        assert DingTalkCredentialHolder.get("ak_id") == "ak"
+        DingTalkCredentialHolder.clear()
+        assert DingTalkCredentialHolder.get("ak_id") == ""
 
 
 # ===========================================================================
@@ -389,6 +442,78 @@ class TestCommunityNotifyModule:
         )
         DingTalkCredentialHolder.clear()
         assert DingTalkNotifySender._configured() is False
+
+    def test_notify_sender_loads_yaml_creds_and_frontend_url(self, monkeypatch):
+        """DI reads task_discovery_dingtalk block from YAML config and sets
+        DingTalkYamlHolder + FrontendUrlHolder (notify.py lines 40-47)."""
+        from agentclaw.community.di.modules.infrastructure.community.notify import (
+            CommunityNotifyModule,
+        )
+        from agentclaw.community.di.modules import config_module
+        from agentclaw.community.core.task.task_discovery.session_initiator import (
+            FrontendUrlHolder,
+        )
+
+        DingTalkYamlHolder.clear()
+        FrontendUrlHolder.set("")
+
+        fake_cfg = {
+            "ak_id": "yaml-ak",
+            "ak_secret": "yaml-sk",
+            "frontend_url": "http://fe.example.com",
+        }
+        with patch.object(config_module, "_block", return_value=fake_cfg):
+            mod = CommunityNotifyModule()
+            sender = mod._notify_sender()
+
+        assert isinstance(sender, DingTalkNotifySender)
+        assert DingTalkYamlHolder.get("ak_id") == "yaml-ak"
+        assert DingTalkYamlHolder.get("ak_secret") == "yaml-sk"
+        assert FrontendUrlHolder.get() == "http://fe.example.com"
+
+        DingTalkYamlHolder.clear()
+        FrontendUrlHolder.set("")
+
+    def test_notify_sender_skips_frontend_url_when_absent(self, monkeypatch):
+        """DI sets DingTalkYamlHolder but skips FrontendUrlHolder when
+        frontend_url is absent (notify.py line 43 if-branch not taken)."""
+        from agentclaw.community.di.modules.infrastructure.community.notify import (
+            CommunityNotifyModule,
+        )
+        from agentclaw.community.di.modules import config_module
+        from agentclaw.community.core.task.task_discovery.session_initiator import (
+            FrontendUrlHolder,
+        )
+
+        DingTalkYamlHolder.clear()
+        FrontendUrlHolder.set("")
+
+        fake_cfg = {"ak_id": "yaml-ak"}
+        with patch.object(config_module, "_block", return_value=fake_cfg):
+            mod = CommunityNotifyModule()
+            sender = mod._notify_sender()
+
+        assert isinstance(sender, DingTalkNotifySender)
+        assert DingTalkYamlHolder.get("ak_id") == "yaml-ak"
+        assert FrontendUrlHolder.get() == ""
+
+        DingTalkYamlHolder.clear()
+
+    def test_notify_sender_skips_yaml_when_block_empty(self, monkeypatch):
+        """DI skips DingTalkYamlHolder.set when _block returns empty (line 39
+        if-branch not taken)."""
+        from agentclaw.community.di.modules.infrastructure.community.notify import (
+            CommunityNotifyModule,
+        )
+        from agentclaw.community.di.modules import config_module
+
+        DingTalkYamlHolder.clear()
+        with patch.object(config_module, "_block", return_value={}):
+            mod = CommunityNotifyModule()
+            sender = mod._notify_sender()
+
+        assert isinstance(sender, DingTalkNotifySender)
+        assert DingTalkYamlHolder.get("ak_id") == ""
 
 
 # ===========================================================================

--- a/src/backend/tests/community/local/test_load_yaml_configs.py
+++ b/src/backend/tests/community/local/test_load_yaml_configs.py
@@ -108,6 +108,41 @@ class TestLoadYamlConfigsOverlaySelection:
         assert str(first_configs) in str(error.value)
         assert str(fallback_configs) in str(error.value)
 
+    def test_corp_overlay_merges_on_top(self, monkeypatch, tmp_path):
+        """Three-layer merge: base + community overlay + corp overlay.
+
+        The corp overlay (``{stem}-corp.yaml``) injects real credentials that
+        must not live in community source. When present alongside the config
+        pair, ``_load_yaml_configs`` deep-merges it on top.
+        """
+        overlay_name = "application-test.yaml"
+        configs = tmp_path / "configs"
+        configs.mkdir()
+        (configs / "application.yaml").write_text("user_config:\n  base: base-val\n")
+        (configs / overlay_name).write_text("user_config:\n  overlay: overlay-val\n")
+        corp_name = "application-test-corp.yaml"
+        (configs / corp_name).write_text(
+            "user_config:\n  overlay: corp-override\n  corp_secret: real-secret\n"
+        )
+
+        community_root = tmp_path / "community"
+        community_configs = community_root / "configs"
+        community_configs.mkdir(parents=True)
+        (community_configs / "application.yaml").write_text("user_config:\n  base: base-val\n")
+        (community_configs / overlay_name).write_text("user_config:\n  overlay: overlay-val\n")
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            yaml_provider,
+            "__file__",
+            str(community_root / "core" / "config" / "yaml_provider.py"),
+        )
+
+        result = _load_yaml_configs(overlay_name)
+        assert result["user_config"]["base"] == "base-val"
+        assert result["user_config"]["overlay"] == "corp-override"
+        assert result["user_config"]["corp_secret"] == "real-secret"
+
 
 @pytest.fixture(autouse=True)
 def _community_database_url(monkeypatch):


### PR DESCRIPTION
## Problem

Task Discovery 的钉钉通知功能此前只能通过 API 动态注入凭证或环境变量获取凭证。
community 源码中缺少一个结构化的 YAML 凭证配置块，
也没有办法在不向社区源码泄露真实密钥的情况下让 corp 部署注入真实凭证。
此外，钉钉卡片点击跳转所需的 `frontend_url`（session_url 生成）也缺少配置来源。

## Solution

1. **新增 `DingTalkYamlHolder`** — 在 `notify_sender.py` 中增加 YAML 凭证 holder，
   凭证优先级变为：API holder > YAML holder > env > 空（skip）。
2. **新增 `task_discovery_dingtalk` 配置块** — 在 `application-singlebox.yaml` 中添加
   `ak_id`/`ak_secret`/`robot_code`/`card_template_id`/`frontend_url`，仅含 dummy 值。
3. **三层 YAML 合并** — `yaml_provider.py` 在 base → community overlay 之后增加可选的
   corp overlay 层（`{overlay_name}-corp.yaml`），corp overlay 注入真实凭证，
   在 community-only / test 构建中不存在该文件时自动跳过。
4. **DI 接线** — `CommunityNotifyModule` 启动时从 `task_discovery_dingtalk` 块读取凭证写入
   `DingTalkYamlHolder`，并将 `frontend_url` 写入 `FrontendUrlHolder`。

## Validation

-  pre-push gate（lint-only 模式）通过 — python-sast 本地扫描无新违规。
- 未运行 CI 测试套件 / coverage / E2E（需设置 `OCB_PRE_PUSH_RUN_CI=1`）。

## Compatibility and risk

- 纯增量改动：新增 holder 与配置块，不修改既有 API holder 行为。
- corp overlay 为可选层，缺失时行为与改动前完全一致，向后兼容。
- community 源码中仅含 dummy 凭证，不泄露真实密钥。
