### PR TITLE
feat(baas): cap bot_run stream chunk size by byte threshold

### DIFF
--- a/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_executor.py
@@ -256,6 +256,7 @@ class BotRunRequestExecutor:
         cache_plugin: CachePlugin,
         api_key_repository: APIKeyRepository,
         stream_flush_interval_seconds: float = 0.2,
+        stream_flush_max_content_bytes: int = 65536,
     ) -> None:
         self._repo = run_repository
         self._bot_service_plugin = bot_service_plugin
@@ -264,6 +265,9 @@ class BotRunRequestExecutor:
         self._cache_plugin = cache_plugin
         self._api_key_repository = api_key_repository
         self._stream_flush_interval = stream_flush_interval_seconds
+        # 单条 chunk content 的字节上界：超过阈值时提前 flush，避免在 ZDAS tracer
+        # 等非参数化内联 SQL 路径下因单条 payload 过大触发 1064 转义断裂。
+        self._stream_flush_max_content_bytes = stream_flush_max_content_bytes
 
     async def execute(self, record: BotRunQueueRecord) -> None:
         run = self._repo.get_by_run_id(record.run_id)
@@ -429,9 +433,11 @@ class BotRunRequestExecutor:
     ) -> None:
         """流式发送：消费 bot_service.send_message_stream，逐 chunk 写 chunk 表 + ZCache watermark。
 
-        200ms 批量窗口合并 delta / agent chunks：
-        - delta chunks 先缓冲，200ms 或非 delta/agent 事件触发 flush
-        - agent chunks 先缓冲到独立 buffer，200ms 或非 delta/agent 事件触发 flush（JSON array 合并）
+        200ms 批量窗口合并 delta / agent chunks，并由 ``stream_flush_max_content_bytes``
+        字节阈值提前 flush，避免单条 chunk content 在 ZDAS tracer 等非参数化内联
+        SQL 路径下过大触发 1064：
+        - delta chunks 先缓冲，200ms / 字节阈值 / 非 delta/agent 事件触发 flush
+        - agent chunks 先缓冲到独立 buffer，200ms / 字节阈值 / 非 delta/agent 事件触发 flush（JSON array 合并）
         - 非 delta/agent（final/error）先 flush 两个缓冲，再立即写入
         - ZCache watermark: cache.set(f"run:{run_id}:seq", f"{seq}:{chunk_type}", ttl=120)
         """
@@ -439,17 +445,20 @@ class BotRunRequestExecutor:
         seq = 0
         delta_buffer: list[str] = []
         delta_engine_type: str | None = None
+        delta_buffer_bytes: int = 0
         agent_buffer: list[dict] = []
         agent_engine_type: str | None = None
+        agent_buffer_bytes: int = 0
         cache_key = f"run:{run.run_id}:seq"
 
         def _flush_delta() -> None:
             """将缓冲的 delta 合并为一条 chunk 写入。"""
-            nonlocal seq, delta_buffer, delta_engine_type
+            nonlocal seq, delta_buffer, delta_engine_type, delta_buffer_bytes
             if not delta_buffer:
                 return
             merged = "".join(delta_buffer)
             delta_buffer.clear()
+            delta_buffer_bytes = 0
             metadata_json = None
             if delta_engine_type:
                 metadata_json = json.dumps({"engine_type": delta_engine_type})
@@ -465,11 +474,12 @@ class BotRunRequestExecutor:
 
         def _flush_agent() -> None:
             """将缓冲的 agent 事件合并为一条 chunk（JSON array）写入。"""
-            nonlocal seq, agent_buffer, agent_engine_type
+            nonlocal seq, agent_buffer, agent_engine_type, agent_buffer_bytes
             if not agent_buffer:
                 return
             merged = json.dumps(agent_buffer, ensure_ascii=False)
             agent_buffer.clear()
+            agent_buffer_bytes = 0
             metadata_json = None
             if agent_engine_type:
                 metadata_json = json.dumps({"engine_type": agent_engine_type})
@@ -522,16 +532,26 @@ class BotRunRequestExecutor:
             ):
                 if chunk.type == "delta":
                     delta_buffer.append(chunk.content)
+                    delta_buffer_bytes += len(chunk.content or "")
                     if chunk.engine_type:
                         delta_engine_type = chunk.engine_type
-                    if time.monotonic() - last_flush_ts >= self._stream_flush_interval:
+                    if (
+                        time.monotonic() - last_flush_ts >= self._stream_flush_interval
+                        or delta_buffer_bytes >= self._stream_flush_max_content_bytes
+                    ):
                         _flush_buffers()
                         last_flush_ts = time.monotonic()
                 elif chunk.type == "agent":
                     agent_buffer.append(chunk.metadata or {})
+                    agent_buffer_bytes += len(
+                        json.dumps(chunk.metadata or {}, ensure_ascii=False)
+                    )
                     if chunk.engine_type:
                         agent_engine_type = chunk.engine_type
-                    if time.monotonic() - last_flush_ts >= self._stream_flush_interval:
+                    if (
+                        time.monotonic() - last_flush_ts >= self._stream_flush_interval
+                        or agent_buffer_bytes >= self._stream_flush_max_content_bytes
+                    ):
                         _flush_buffers()
                         last_flush_ts = time.monotonic()
                 elif chunk.type == "final":

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
@@ -759,6 +759,182 @@ async def test_executor_stream_engine_type_in_error_with_metadata():
     assert meta["engine_type"] == "dify"
 
 
+# ----------------------------- stream 字节阈值提前 flush（规避 ZDAS 1064） -----------------------------
+
+
+async def test_executor_stream_agent_byte_threshold_splits_chunks():
+    """stream 模式：agent buffer 累积字节 >= 阈值时提前 flush，拆为多条 agent chunk，
+    每条 content 仍是合法 JSON array，回放侧按 seq 顺序 json.loads 拼接后等于原始事件。"""
+    repo = MagicMock()
+    plugin = MagicMock()
+    selector = MagicMock()
+
+    repo.get_by_run_id.return_value = _run(
+        run_id="r-ag-thr",
+        bot_id="bot-1:ent",
+        metadata={"request_type": "chat", "stream": "true"},
+    )
+    plugin.get_binding = AsyncMock(return_value=_binding_data())
+
+    # 构造 N 个 agent 事件，使合并 content 字节超过阈值（默认 64KB）。
+    # 每个 metadata 约 100B，N=800 -> ~80KB > 64KB，应触发至少一次字节阈值 flush。
+    per_frame = {"engine_frame": {"stream": "tool", "phase": "x"}, "data": "x" * 80}
+    n_frames = 800
+    chunks = [StreamChunk(type="agent", content="", metadata=per_frame) for _ in range(n_frames)]
+    chunks.append(StreamChunk(type="final", content="done"))
+
+    async def _stream_gen(*a, **kw):
+        for c in chunks:
+            yield c
+
+    bot_svc = MagicMock()
+    bot_svc.send_message_stream = _stream_gen
+    selector.select.return_value = bot_svc
+
+    chunk_repo = MagicMock()
+    executor = BotRunRequestExecutor(
+        repo, plugin, selector, chunk_repo, MagicMock(), _api_key_repo(),
+        stream_flush_max_content_bytes=4096,
+    )
+    await executor.execute(
+        _queue_rec(run_id="r-ag-thr", bot_id="bot-1:ent", session_id="sess-a")
+    )
+
+    insert_calls = chunk_repo.insert_chunk.call_args_list
+    agent_calls = [c for c in insert_calls if c[1]["chunk_type"] == "agent"]
+    final_calls = [c for c in insert_calls if c[1]["chunk_type"] == "final"]
+
+    # 字节阈值触发拆分：agent chunk 数 > 1
+    assert len(agent_calls) > 1, "agent buffer should be split by byte threshold"
+    # final 仍为 1 行
+    assert len(final_calls) == 1
+
+    # 每条 agent chunk content 仍是合法 JSON array
+    all_frames = []
+    for ac in agent_calls:
+        frames = json.loads(ac[1]["content"])
+        assert isinstance(frames, list)
+        all_frames.extend(frames)
+
+    # 按 seq 顺序拼接的帧等于原始事件集合
+    assert len(all_frames) == n_frames
+
+    # seq 严格递增
+    seqs = [ac[1]["seq"] for ac in agent_calls] + [final_calls[0][1]["seq"]]
+    assert seqs == sorted(seqs)
+    assert len(set(seqs)) == len(seqs)
+
+
+async def test_executor_stream_delta_byte_threshold_splits_chunks():
+    """stream 模式：delta buffer 累积字节 >= 阈值时提前 flush，拆为多条 delta chunk。"""
+    repo = MagicMock()
+    plugin = MagicMock()
+    selector = MagicMock()
+
+    repo.get_by_run_id.return_value = _run(
+        run_id="r-dl-thr",
+        bot_id="bot-1:ent",
+        metadata={"request_type": "chat", "stream": "true"},
+    )
+    plugin.get_binding = AsyncMock(return_value=_binding_data())
+
+    # 构造连续 delta 事件，累积字节超过阈值。
+    piece = "x" * 1024
+    n_pieces = 10  # 10KB > 4KB 阈值
+    chunks = [StreamChunk(type="delta", content=piece) for _ in range(n_pieces)]
+    chunks.append(StreamChunk(type="final", content="done"))
+
+    async def _stream_gen(*a, **kw):
+        for c in chunks:
+            yield c
+
+    bot_svc = MagicMock()
+    bot_svc.send_message_stream = _stream_gen
+    selector.select.return_value = bot_svc
+
+    chunk_repo = MagicMock()
+    executor = BotRunRequestExecutor(
+        repo, plugin, selector, chunk_repo, MagicMock(), _api_key_repo(),
+        stream_flush_max_content_bytes=4096,
+    )
+    await executor.execute(
+        _queue_rec(run_id="r-dl-thr", bot_id="bot-1:ent", session_id="sess-d")
+    )
+
+    insert_calls = chunk_repo.insert_chunk.call_args_list
+    delta_calls = [c for c in insert_calls if c[1]["chunk_type"] == "delta"]
+    final_calls = [c for c in insert_calls if c[1]["chunk_type"] == "final"]
+
+    # 字节阈值触发拆分：delta chunk 数 > 1
+    assert len(delta_calls) > 1, "delta buffer should be split by byte threshold"
+    assert len(final_calls) == 1
+
+    # 各 delta chunk content 拼接后等于原始 delta 内容
+    merged = "".join(c[1]["content"] for c in delta_calls)
+    assert merged == piece * n_pieces
+
+
+async def test_executor_stream_byte_threshold_not_triggered_preserves_merge():
+    """累积字节 < 阈值时不触发拆分，既有 agent/delta 合并语义不变。"""
+    repo = MagicMock()
+    plugin = MagicMock()
+    selector = MagicMock()
+
+    repo.get_by_run_id.return_value = _run(
+        run_id="r-no-thr",
+        bot_id="bot-1:ent",
+        metadata={"request_type": "chat", "stream": "true"},
+    )
+    plugin.get_binding = AsyncMock(return_value=_binding_data())
+
+    chunks = [
+        StreamChunk(
+            type="agent",
+            content="",
+            metadata={"engine_frame": {"stream": "tool", "phase": "start"}},
+        ),
+        StreamChunk(
+            type="agent",
+            content="",
+            metadata={"engine_frame": {"stream": "tool", "phase": "result"}},
+        ),
+        StreamChunk(type="delta", content="hel"),
+        StreamChunk(type="delta", content="lo"),
+        StreamChunk(type="final", content="hello world"),
+    ]
+
+    async def _stream_gen(*a, **kw):
+        for c in chunks:
+            yield c
+
+    bot_svc = MagicMock()
+    bot_svc.send_message_stream = _stream_gen
+    selector.select.return_value = bot_svc
+
+    chunk_repo = MagicMock()
+    # 阈值足够大，这批小 payload 不会触发字节 flush
+    executor = BotRunRequestExecutor(
+        repo, plugin, selector, chunk_repo, MagicMock(), _api_key_repo(),
+        stream_flush_max_content_bytes=1 << 20,
+    )
+    await executor.execute(
+        _queue_rec(run_id="r-no-thr", bot_id="bot-1:ent", session_id="sess-n")
+    )
+
+    insert_calls = chunk_repo.insert_chunk.call_args_list
+    agent_calls = [c for c in insert_calls if c[1]["chunk_type"] == "agent"]
+    delta_calls = [c for c in insert_calls if c[1]["chunk_type"] == "delta"]
+    final_calls = [c for c in insert_calls if c[1]["chunk_type"] == "final"]
+
+    # 与既有 test_executor_stream_agent_merge 行为一致：不拆分
+    assert len(agent_calls) == 1
+    assert len(delta_calls) == 1
+    assert len(final_calls) == 1
+    agent_data = json.loads(agent_calls[0][1]["content"])
+    assert len(agent_data) == 2
+    assert delta_calls[0][1]["content"] == "hello"
+
+
 # ----------------------------- 背压（队列深度 → 429） -----------------------------
 
 


### PR DESCRIPTION
## Summary

`BotRunRequestExecutor` streams delta/agent events into
`baas_bot_run_queue_chunk` rows. Previously the executor flushed
buffers only on a time window (`stream_flush_interval_seconds`,
default 0.2s), so a busy stream could accumulate an arbitrarily large
payload in a single flush window and persist it as one chunk. Under
large sessions this produced oversized inline INSERT payloads that
could exceed the persistence backend's safe per-statement payload
bound and fail the stream write.

This change bounds the accumulated content of each streamed
delta/agent chunk by a configurable byte threshold, in addition to
the existing time-window flush. Each persisted chunk now stays well
under the configured limit, while normal sessions keep the original
merge behavior.

## Changes

- `src/baas/src/secbaas/community/core/service/bot_run/_executor.py`
  - Add constructor parameter
    `stream_flush_max_content_bytes: int = 65536`, stored as
    `self._stream_flush_max_content_bytes`. Default 64KB:
    - far below the observed oversized-payload failure point,
      covering the failure window;
    - far above normal single delta/agent frames, so normal sessions
      almost never trigger the threshold and behavior stays close to
      the original time-window semantics;
    - callers can tune it smaller (more aggressive splitting) or
      larger (higher merge factor).
  - In `_do_send_stream`, maintain `delta_buffer_bytes` and
    `agent_buffer_bytes` accumulators (nonlocal) alongside the
    existing `delta_buffer` / `agent_buffer`:
    - delta event: `delta_buffer_bytes += len(chunk.content or "")`
      — exact for the joined `"".join(delta_buffer)` payload size.
    - agent event:
      `agent_buffer_bytes += len(json.dumps(chunk.metadata or {}, ensure_ascii=False))`
      — a tight lower bound of the merged
      `json.dumps(agent_buffer, ensure_ascii=False)` size (omits only
      array separators and `[]` wrapping; sub-frame error at a 64KB
      threshold is negligible).
    - reset the matching counter after each flush; never cross-clear.
  - Extend the per-event flush trigger from "time window" to
    "time window OR byte threshold". The flush still calls
    `_flush_buffers()` = `_flush_delta()` + `_flush_agent()` in the
    original order with the original semantics.
  - Update the `_do_send_stream` docstring to describe the byte
    threshold trigger.

- `src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py`
  - `test_executor_stream_agent_byte_threshold_splits_chunks`: 800
    agent events with a 4096B threshold assert `chunk_type=="agent"`
    is flushed more than once, each emitted content is a valid JSON
    array, frames decode in seq order to the original event count,
    and seqs are strictly increasing without duplicates.
  - `test_executor_stream_delta_byte_threshold_splits_chunks`: ten 1KB
    delta events with a 4KB threshold assert `chunk_type=="delta"` is
    flushed more than once and the concatenated content equals the
    original delta content.
  - `test_executor_stream_byte_threshold_not_triggered_preserves_merge`:
    a 1MB threshold with small payloads asserts agent merges to one
    row and delta merges to one row, matching the existing
    `test_executor_stream_agent_merge` behavior.

## Behavior contracts preserved

- No DB schema change; no new `chunk_type`; chunk protocol
  (run_id+seq unique, seq-ordered consumption, agent content as JSON
  array) is unchanged.
- `_write_chunk` (final/error/interaction) path is untouched; the
  threshold only governs accumulated delta/agent buffers.
- Default 64KB threshold keeps existing small-payload merge behavior
  (`test_executor_stream_agent_merge`,
  `test_executor_stream_error_flushes_agent_buffer`,
  `test_executor_stream_error_chunk_marks_failed`, engine_type
  pass-through) unchanged.
- Downstream replay (`_queue_task_message_dispatcher.py`) already
  `json.loads` each agent chunk independently and yields frames in
  seq order, so multiple consecutive agent chunks produced by the
  threshold split replay correctly.

## Known limitations (non-blocking, documented in plan risks)

- The byte counters are character/serialization approximations of the
  UTF-8 encoded wire size, not exact byte lengths; the approximation
  is conservative for a mitigation whose goal is capping chunk size
  from above and is documented in the change manifest.
- A single delta/agent event larger than the threshold is not sliced;
  single-event size is bounded upstream. Splitting oversized single
  payloads is explicitly out of scope for this work item.

## Test plan

- `pytest tests/unit/core/service/bot_run/test_bot_run_executor.py`
- `ruff check src/secbaas/community/core/service/bot_run/_executor.py tests/unit/core/service/bot_run/test_bot_run_executor.py`

All 40 unit tests pass; ruff clean. Review found 6 non-blocking P3
notes (byte-counter approximation, single-chunk over-threshold
handling, positional-parameter drift, per-event json.dumps cost,
very-small-threshold write amplification, missing per-chunk upper-bound
test assertion) — none blocking, all documented in the review summary.