### PR TITLE
feat(bcs): forward channel sender identity

### DIFF
--- a/docs/bot-integration.md
+++ b/docs/bot-integration.md
@@ -242,6 +242,13 @@ Versioning policy:
 - Removing fields, changing semantics, or adding required fields bumps the
   version.
 
+An opted-in Human Channel-to-Bot message may include
+`channel.identity_forwarding: true` together with `channel.user_id` and
+`channel.actor_name`. OpenClaw integrations should project those values to the
+standard inbound `SenderId` and `SenderName` metadata. If the marker is absent
+or false, integrations must retain their existing sender resolver. This
+metadata is not an authentication or authorization signal.
+
 When the engine receives `deprecation`, it should log a reminder for developers
 to upgrade:
 

--- a/docs/bot-provider-integration.md
+++ b/docs/bot-provider-integration.md
@@ -109,6 +109,22 @@ Core downstream body fields:
 | `message` | `chat.send` / `chat.inject` | Current downstream message. |
 | `timeout_ms` | `chat.send` / `chat.inject` / `chat.history` | Downstream operation timeout. For direct A2A `chat.send` submitted by `bcs-cli chat`, BCS sends a fixed 2-hour execution budget (`7200000` ms), independent of the CLI polling timeout. |
 
+For an ordinary Human message received through a Channel whose Bot binding has
+`forward_sender_identity: true`, BCS prepends the following JSON line to the
+Provider request copy of the textual `message`, followed by one blank line:
+
+```text
+{"sender":{"id":"410025","name":"张三"}}
+
+original message
+```
+
+The `from` and Provider request field contracts do not change. The prefix is
+not emitted for Group bindings, Channel commands such as `/new`, HumanInput
+replies, or non-Channel entry points. It is model attribution and observability
+data only, never authentication or authorization input. Sender values are JSON
+serialized, and retries rebuild the request from the unchanged BCS frame.
+
 ## Protocol 2.0 `chat.send` transport negotiation
 
 For every Provider registered with `protocol_version = "2.0"`, BCS sends every

--- a/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
+++ b/src/bcs/crates/adapters/http/bcs-provider-http/src/lib.rs
@@ -825,7 +825,7 @@ fn provider_request_from_frame(
             tags: provider_tags_from_params(&params),
         },
         from: provider_sender_from_params(&params),
-        message: params.get("message").cloned(),
+        message: provider_message_for_method(&request.method, &params),
         attachments,
         before: params.get("before").and_then(Value::as_u64),
         after: params.get("after").and_then(Value::as_u64),
@@ -876,6 +876,79 @@ fn provider_sender_from_params(params: &Value) -> Option<ProviderWebhookSender> 
         name: name.to_string(),
         actor_id: actor_id.map(str::to_string),
     })
+}
+
+fn provider_message_from_params(params: &Value) -> Option<Value> {
+    let mut message = params.get("message")?.clone();
+    let Some(sender_json) = provider_sender_json(params) else {
+        return Some(message);
+    };
+    prepend_provider_sender(&mut message, &sender_json);
+    Some(message)
+}
+
+fn provider_message_for_method(method: &str, params: &Value) -> Option<Value> {
+    if !matches!(method, "chat.send" | "chat.inject") {
+        return params.get("message").cloned();
+    }
+    provider_message_from_params(params)
+}
+
+fn provider_sender_json(params: &Value) -> Option<String> {
+    let channel = params.get("channel")?;
+    if channel.get("identity_forwarding").and_then(Value::as_bool) != Some(true) {
+        return None;
+    }
+    let id = channel
+        .get("user_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let name = channel
+        .get("actor_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    // COSEC: serialize untrusted identity fields as JSON rather than interpolating
+    // them into a JSON-shaped string.
+    Some(serde_json::json!({ "sender": { "id": id, "name": name } }).to_string())
+}
+
+fn prepend_provider_sender(message: &mut Value, sender_json: &str) {
+    if let Some(text) = message.as_str() {
+        *message = Value::String(format!("{sender_json}\n\n{text}"));
+        return;
+    }
+    let Some(object) = message.as_object_mut() else {
+        return;
+    };
+    if let Some(text) = object.get("text").and_then(Value::as_str) {
+        let combined = format!("{sender_json}\n\n{text}");
+        object.insert("text".to_string(), Value::String(combined));
+        return;
+    }
+    if let Some(content) = object.get_mut("content") {
+        if let Some(text) = content.as_str() {
+            *content = Value::String(format!("{sender_json}\n\n{text}"));
+            return;
+        }
+        if let Some(blocks) = content.as_array_mut() {
+            if let Some(text_block) = blocks.iter_mut().find(|block| {
+                block.get("type").and_then(Value::as_str) == Some("text")
+                    && block.get("text").and_then(Value::as_str).is_some()
+            }) {
+                if let Some(text) = text_block.get("text").and_then(Value::as_str) {
+                    let combined = format!("{sender_json}\n\n{text}");
+                    text_block["text"] = Value::String(combined);
+                }
+                return;
+            }
+            blocks.insert(
+                0,
+                serde_json::json!({ "type": "text", "text": sender_json }),
+            );
+        }
+    }
 }
 
 fn provider_session_id(params: &Value, bcs_group_id: &str) -> String {
@@ -2003,6 +2076,89 @@ mod client_policy_tests {
     use super::*;
     use bcs_domain::RedactedToken;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[test]
+    fn provider_message_prepends_opted_in_sender_json_without_mutating_frame_params() {
+        let params = serde_json::json!({
+            "channel": {
+                "identity_forwarding": true,
+                "user_id": "410025",
+                "actor_id": "human_410025",
+                "actor_name": "张\"三"
+            },
+            "message": {
+                "role": "user",
+                "content": [{ "type": "text", "text": "hello" }],
+                "timestamp": 1710960000000_u64
+            }
+        });
+
+        let first = provider_message_for_method("chat.send", &params).unwrap();
+        let retry = provider_message_for_method("chat.send", &params).unwrap();
+        assert_eq!(first, retry, "retry must rebuild from the unchanged frame");
+        assert_eq!(
+            first["content"][0]["text"],
+            "{\"sender\":{\"id\":\"410025\",\"name\":\"张\\\"三\"}}\n\nhello"
+        );
+        assert_eq!(params["message"]["content"][0]["text"], "hello");
+    }
+
+    #[test]
+    fn provider_message_limits_sender_prefix_to_chat_methods() {
+        let params = serde_json::json!({
+            "channel": {
+                "identity_forwarding": true,
+                "user_id": "410025",
+                "actor_name": "张三"
+            },
+            "message": {
+                "role": "user",
+                "content": [{ "type": "text", "text": "hello" }],
+                "timestamp": 1710960000000_u64
+            }
+        });
+
+        let send = provider_message_for_method("chat.send", &params).unwrap();
+        let inject = provider_message_for_method("chat.inject", &params).unwrap();
+        assert_eq!(send, inject);
+        assert_ne!(send, params["message"]);
+        assert_eq!(
+            provider_message_for_method("chat.history", &params),
+            params.get("message").cloned()
+        );
+        assert_eq!(
+            provider_message_for_method("task.dispatch", &params),
+            params.get("message").cloned()
+        );
+    }
+
+    #[test]
+    fn provider_message_ignores_legacy_channel_identity_and_supports_content_blocks() {
+        let legacy = serde_json::json!({
+            "channel": { "user_id": "410025", "actor_name": "张三" },
+            "message": { "text": "hello" }
+        });
+        assert_eq!(provider_message_from_params(&legacy), legacy.get("message").cloned());
+
+        let opted_in = serde_json::json!({
+            "channel": {
+                "identity_forwarding": true,
+                "user_id": "410025",
+                "actor_name": "张三"
+            },
+            "message": {
+                "content": [
+                    { "type": "image", "url": "https://example.invalid/image" },
+                    { "type": "text", "text": "hello" }
+                ]
+            }
+        });
+        let message = provider_message_from_params(&opted_in).unwrap();
+        assert_eq!(
+            message["content"][1]["text"],
+            "{\"sender\":{\"id\":\"410025\",\"name\":\"张三\"}}\n\nhello"
+        );
+    }
 
     async fn spawn_http1_server() -> std::net::SocketAddr {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/src/web/dispatcher.rs
@@ -798,6 +798,7 @@ async fn handle_chat_send(
             thinking: params.thinking,
             idempotency_key: params.idempotency_key,
             source_im_message_id: None,
+            channel_sender_identity: None,
             sender_conn_id,
             provider_bypass_headers: Vec::new(),
         })

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -513,6 +513,7 @@ impl StateMachineResultPublisherPort for MessageFlowStateMachineResultPublisher 
                 thinking: None,
                 idempotency_key: Some(idempotency_key),
                 source_im_message_id: None,
+                channel_sender_identity: None,
                 sender_conn_id: None,
                 provider_bypass_headers: Vec::new(),
             })

--- a/src/bcs/crates/bootstrap/bcs/tests/metrics_wrappers.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/metrics_wrappers.rs
@@ -578,6 +578,7 @@ fn web_send_cmd() -> WebSendCommand {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     }

--- a/src/bcs/crates/contracts/bcs-protocol/CONTEXT.md
+++ b/src/bcs/crates/contracts/bcs-protocol/CONTEXT.md
@@ -34,6 +34,11 @@
 
 The crate owns stable wire contract objects only. It does not own application commands, core business models, or runtime clients.
 
+`ChannelInfo.identity_forwarding` is an optional compatibility field. When it
+is `true`, `user_id` and `actor_name` carry an opted-in Human Channel sender for
+model attribution. Consumers must not use these fields for authentication or
+authorization. Absence preserves the legacy sender resolver.
+
 ## Tests
 
 - `cargo test --package bcs-protocol --manifest-path src/bcs/Cargo.toml`

--- a/src/bcs/crates/contracts/bcs-protocol/src/lib.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/lib.rs
@@ -76,7 +76,7 @@ pub use ws::{
     ToolResultContent, UsageInfo, WsBotCapabilities, CONTRACT_VERSION,
     MAGIC_KEY, TOOL_ASSIGN_TASK, TOOL_SEND_TASK_MESSAGE, TOOL_TASK_COMPLETE,
     GROUP_ID_PREFIX, build_session_key,
-    apply_sender_display_name, build_chat_inject_frame, build_chat_send_frame,
+    apply_channel_info, apply_sender_display_name, build_chat_inject_frame, build_chat_send_frame,
     build_direct_chat_inject_frame, build_direct_chat_send_frame,
     build_recipient_group_context,
     now_ms, response_directive_for_delivery,

--- a/src/bcs/crates/contracts/bcs-protocol/src/ws/mod.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/ws/mod.rs
@@ -15,7 +15,7 @@ pub use protocol::{
     ProtocolDeprecation, RequestFrame, RequestSource, ResponseDirective, ResponseFrame,
     ResponseMode, RouteSelectorWire, ToolEventData, ToolPhase, ToolResult,
     ToolResultContent, UsageInfo, WsBotCapabilities, GROUP_ID_PREFIX, build_session_key,
-    apply_sender_display_name, build_chat_inject_frame, build_chat_send_frame,
+    apply_channel_info, apply_sender_display_name, build_chat_inject_frame, build_chat_send_frame,
     build_direct_chat_inject_frame, build_direct_chat_send_frame,
     build_recipient_group_context,
     now_ms, response_directive_for_delivery,

--- a/src/bcs/crates/contracts/bcs-protocol/src/ws/protocol.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/ws/protocol.rs
@@ -394,6 +394,26 @@ pub struct ChannelInfo {
     pub actor_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thread_id: Option<String>,
+    /// True only when the originating Channel binding opted into exposing the
+    /// external Human identity to downstream agents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub identity_forwarding: Option<bool>,
+}
+
+/// Replace the request frame's Channel projection with an explicitly resolved
+/// per-message identity. Non-request or malformed frames are left unchanged.
+pub fn apply_channel_info(frame: &mut BcsFrame, channel: ChannelInfo) {
+    let BcsFrame::Request(request) = frame else {
+        return;
+    };
+    let Some(params) = request.params.as_mut().and_then(Value::as_object_mut) else {
+        return;
+    };
+    let channel = serde_json::to_value(channel).unwrap_or_else(|error| {
+        tracing::warn!(%error, "failed to serialize channel info");
+        Value::Null
+    });
+    params.insert("channel".to_string(), channel);
 }
 
 /// Group context injected by BCS when routing messages to bots.
@@ -964,6 +984,7 @@ pub fn build_chat_inject_frame(
             actor_id: Some(from_bot_id.to_string()),
             actor_name: Some(from_bot_name.to_string()),
             thread_id: Some(session_id.to_string()),
+            identity_forwarding: None,
         },
         session_context: group_context,
         bcs_session_id: if supports_session_field {
@@ -1046,6 +1067,7 @@ pub fn build_chat_send_frame(
             actor_id: Some(from_bot_id.to_string()),
             actor_name: Some(from_bot_name.to_string()),
             thread_id: Some(session_id.to_string()),
+            identity_forwarding: None,
         },
         session_context: group_context,
         timeout_ms: None,
@@ -1119,6 +1141,7 @@ pub fn build_direct_chat_send_frame(
             actor_id: Some(from_actor_id.to_string()),
             actor_name: Some(from_actor_name.to_string()),
             thread_id: Some(session_id.to_string()),
+            identity_forwarding: None,
         },
         session_context: group_context,
         timeout_ms: None,
@@ -1188,6 +1211,7 @@ pub fn build_direct_chat_inject_frame(
             actor_id: Some(from_actor_id.to_string()),
             actor_name: Some(from_actor_name.to_string()),
             thread_id: Some(session_id.to_string()),
+            identity_forwarding: None,
         },
         session_context: group_context,
         bcs_session_id: if supports_session_field {

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/inbound-handler.ts
@@ -176,7 +176,9 @@ export function resolveInboundSender(
     strippedText: string;
   } {
   const { senderName: prefixedSenderName, text: strippedText } = extractFromPrefix(rawText);
-  const fromDisplayName = prefixedSenderName
+  const identityForwarding = channel?.identity_forwarding === true;
+  const fromDisplayName = (identityForwarding ? nonEmptyString(channel?.actor_name) : undefined)
+    || prefixedSenderName
     || channel?.user_id
     || sessionContext?.from
     || 'bcs-bot';
@@ -185,7 +187,8 @@ export function resolveInboundSender(
     || nonEmptyString(channel?.user_id)
     || nonEmptyString(sessionContext?.from)
     || 'bcs-bot';
-  const senderId = nonEmptyString(channel?.actor_id)
+  const senderId = (identityForwarding ? nonEmptyString(channel?.user_id) : undefined)
+    || nonEmptyString(channel?.actor_id)
     || nonEmptyString(sessionContext?.from_bot_id);
   return { fromDisplayName, senderName, senderId, strippedText };
 }

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/src/types.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/src/types.ts
@@ -128,6 +128,7 @@ export interface ChannelInfo {
   actor_id?: string;
   actor_name?: string;
   thread_id?: string;
+  identity_forwarding?: boolean;
 }
 
 export type SessionMode = 'agent' | 'fusion' | 'composite';

--- a/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
+++ b/src/bcs/crates/plugins/openclaw-channel-bcn/test/index.test.ts
@@ -329,6 +329,38 @@ describe('openclaw-channel-bcn', () => {
     );
   });
 
+  it('uses opted-in Channel user identity for OpenClaw sender metadata', () => {
+    assert.deepEqual(
+      resolveInboundSender(
+        'hello',
+        {
+          source: 'dingtalk',
+          user_id: '410025',
+          actor_id: 'human_410025',
+          actor_name: '张三',
+          identity_forwarding: true,
+        },
+      ),
+      {
+        fromDisplayName: '张三',
+        senderName: '张三',
+        senderId: '410025',
+        strippedText: 'hello',
+      },
+    );
+
+    assert.equal(
+      resolveInboundSender('hello', {
+        source: 'dingtalk',
+        user_id: '410025',
+        actor_id: 'human_410025',
+        actor_name: '张三',
+        identity_forwarding: false,
+      }).senderId,
+      'human_410025',
+    );
+  });
+
   it('uses legacy from_bot_id as the Bot SenderId', () => {
     assert.deepEqual(
       resolveInboundSender(

--- a/src/bcs/crates/service-api/bcs-service-api/CONTEXT.md
+++ b/src/bcs/crates/service-api/bcs-service-api/CONTEXT.md
@@ -12,6 +12,10 @@
 - Session-scoped Workbench connection-token use cases, exact-session connect
   reauthorization contracts, and the outbound token signing/verification port.
 - Channel conversation mapping lookup by BCS session id, with optional channel-type filtering.
+- An optional `ChannelSenderIdentity` on Human WebSend commands. The Channel
+  service may populate it only for an opted-in Bot binding after commands and
+  HumanInput replies have been consumed; other application entry points leave
+  it absent.
 - Transport-neutral Session launch commands that receive adapter-normalized
   Human or Bot identity while keeping credential parsing and protocol response
   projection outside the application boundary.

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/message_flow.rs
@@ -1,7 +1,7 @@
 //! Message-flow use-case contracts.
 
 use async_trait::async_trait;
-use bcs_domain::Attachment;
+use bcs_domain::{Attachment, ChannelType};
 use serde_json::Value;
 
 use crate::{
@@ -10,6 +10,19 @@ use crate::{
 };
 
 use super::principal::CallerContext;
+
+/// Opt-in external Channel identity for one Human-authored inbound message.
+///
+/// The Channel application service is the only production caller that should
+/// populate this value. Message flow treats its presence as authorization to
+/// expose the external user id and display name to the target Bot.
+#[derive(Debug, Clone)]
+pub struct ChannelSenderIdentity {
+    pub channel_type: ChannelType,
+    pub user_id: String,
+    pub actor_id: String,
+    pub display_name: String,
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -36,6 +49,8 @@ pub struct WebSendCommand {
     pub idempotency_key: Option<String>,
     /// Original IM message id when this command came from a channel ingress.
     pub source_im_message_id: Option<String>,
+    /// External sender attribution explicitly enabled by the resolved Bot binding.
+    pub channel_sender_identity: Option<ChannelSenderIdentity>,
     pub sender_conn_id: Option<u64>,
     pub provider_bypass_headers: Vec<(String, String)>,
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
@@ -154,7 +154,7 @@ pub use message_flow::{
     PersistentGroupSendOutcome, ProviderEventIngestCommand, ProviderEventSource,
     TaskCompleteCommand, TaskCompleteOutcome, TaskDispatchCommand,
     TaskDispatchOutcome, TaskMessageCommand, TaskMessageOutcome, TaskRunAliasRegistration,
-    WebSendCommand, WebSendOutcome,
+    ChannelSenderIdentity, WebSendCommand, WebSendOutcome,
 };
 pub use onboard::{
     AdminBotOnboardCommand, BotOnboardCommand, BotOnboardResult, BotOnboardingService,

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -14,10 +14,9 @@ use bcs_channel_api::{ChannelInboundSink, ChannelProvider, ChannelProviderRegist
 use bcs_domain::{
     ActorKind, Attachment, AttachmentType, BindingStatus, BindingTarget, ChannelBinding,
     ChannelType, ConversationSessionMap, Group, GroupChatScope, GroupKind, GroupStrategy,
-    HumanInputNotificationMode,
-    HumanInputRequest, HumanInputRequestStatus, ImParticipantMap, Participant, ParticipantMode,
-    ParticipantRole, Session, SessionKind, SessionScope, SessionStatus, SystemMessageEvent,
-    Visibility, channel_group_id,
+    HumanInputNotificationMode, HumanInputRequest, HumanInputRequestStatus, ImParticipantMap,
+    Participant, ParticipantMode, ParticipantRole, Session, SessionKind, SessionScope,
+    SessionStatus, SystemMessageEvent, Visibility, channel_group_id,
 };
 use bcs_service_api::application::channel::{
     ChannelInboundError, ChannelInboundFailureKind, ChannelService, ChannelUseCaseError,
@@ -26,13 +25,11 @@ use bcs_service_api::application::channel::{
 use bcs_service_api::application::collaboration_runtime::{
     AuthenticatedHumanCaller, StartStateMachineRunCommand,
 };
-use bcs_service_api::application::message_flow::WebSendCommand;
+use bcs_service_api::application::message_flow::{ChannelSenderIdentity, WebSendCommand};
 use bcs_service_api::application::principal::{CallerContext, HumanActor};
 use bcs_service_api::core::DmActorSpec;
-use bcs_service_api::port::channel_delivery::{
-    ChannelBindingRef, ChannelOutboundEvent,
-};
 use bcs_service_api::port::ChannelBindingCleanupPort;
+use bcs_service_api::port::channel_delivery::{ChannelBindingRef, ChannelOutboundEvent};
 use bcs_service_api::port::repo::{
     ChannelBindingRepoPort, ConversationSessionRepoPort, HumanInputEnqueueDisposition,
     HumanInputRequestRepoPort, ImParticipantRepoPort, NewSessionParams, SessionRepoPort,
@@ -41,14 +38,15 @@ use bcs_service_api::{
     BotRegistryCoreService, ChannelOutboundEventKind, ChannelOutboundPurpose, ChannelRenderHint,
     CollaborationRuntimeService, GroupCoreService, HumanInputReadyEvent, HumanResponseSource,
     MessageFlowService, RespondHumanNodeCommand, ServiceError, ServiceResult,
-    SessionChannelDeliveryOutcome, SessionChannelOutboundPort,
-    StateMachineTerminalEvent, StateMachineTerminalStatus, SystemMessageService,
+    SessionChannelDeliveryOutcome, SessionChannelOutboundPort, StateMachineTerminalEvent,
+    StateMachineTerminalStatus, SystemMessageService,
 };
 
 pub use visibility::visibility_allows;
 
 const DEFAULT_INBOUND_DEDUP_LIMIT: usize = 4096;
 const CHANNEL_START_STALE_MS: u64 = 30_000;
+const FORWARD_SENDER_IDENTITY_CONFIG: &str = "forward_sender_identity";
 
 /// Channel application service implementation.
 pub struct BcsChannelService {
@@ -222,11 +220,8 @@ impl BcsChannelService {
         msg: &InboundMessage,
         actor_id: &str,
     ) -> Result<String, ChannelUseCaseError> {
-        let group_id = channel_owned_group_id(
-            &binding.channel_type,
-            GroupKind::Dm,
-            &(self.new_id)(),
-        )?;
+        let group_id =
+            channel_owned_group_id(&binding.channel_type, GroupKind::Dm, &(self.new_id)())?;
         let label = msg
             .im_user_nick
             .as_ref()
@@ -259,11 +254,8 @@ impl BcsChannelService {
         binding: &ChannelBinding,
         bot_id: &str,
     ) -> Result<String, ChannelUseCaseError> {
-        let group_id = channel_owned_group_id(
-            &binding.channel_type,
-            GroupKind::Normal,
-            &binding.id,
-        )?;
+        let group_id =
+            channel_owned_group_id(&binding.channel_type, GroupKind::Normal, &binding.id)?;
         if self.groups.get(&group_id).await.is_some() {
             return Ok(group_id);
         }
@@ -625,11 +617,7 @@ impl BcsChannelService {
         actor_id: &str,
     ) -> Result<bool, ChannelUseCaseError> {
         let reply_scope_key = match msg.conversation_type.as_str() {
-            "2" => fixed_group_reply_scope(
-                &binding.id,
-                &msg.im_conversation_id,
-                actor_id,
-            ),
+            "2" => fixed_group_reply_scope(&binding.id, &msg.im_conversation_id, actor_id),
             "1" => direct_reply_scope(&binding.id, &msg.im_user_id, actor_id),
             _ => return Ok(false),
         };
@@ -701,13 +689,17 @@ impl BcsChannelService {
                     )));
                 }
                 if outcome.run.status != bcs_domain::StateMachineRunStatus::Completed {
-                    if let Err(error) = self.deliver_human_input_event(
-                        &request,
-                        ChannelOutboundPurpose::HumanInputAck,
-                        format!("【输入已接收】{}\n\n流程继续执行。", request.node_display_name),
-                        Some(&msg.msg_id),
-                    )
-                    .await
+                    if let Err(error) = self
+                        .deliver_human_input_event(
+                            &request,
+                            ChannelOutboundPurpose::HumanInputAck,
+                            format!(
+                                "【输入已接收】{}\n\n流程继续执行。",
+                                request.node_display_name
+                            ),
+                            Some(&msg.msg_id),
+                        )
+                        .await
                     {
                         warn!(
                             request_id = %request.request_id,
@@ -802,13 +794,13 @@ impl BcsChannelService {
             })
             .await?;
         if !result.delivered {
-            return Err(ChannelUseCaseError::Internal(
-                result.error.unwrap_or_else(|| {
+            return Err(ChannelUseCaseError::Internal(result.error.unwrap_or_else(
+                || {
                     ServiceError::InternalError(
                         "HumanInput channel delivery was not confirmed".to_string(),
                     )
-                }),
-            ));
+                },
+            )));
         }
         Ok(result.provider_message_ref)
     }
@@ -1175,13 +1167,15 @@ impl ChannelService for BcsChannelService {
             let dispatch_session_id = session_id.clone();
             let dispatch_actor_id = actor_id.clone();
             let dispatch_msg_id = msg.msg_id.clone();
+            let caller = CallerContext::Human(HumanActor {
+                actor_id: actor_id.clone(),
+                staff_no: msg.im_user_id.trim().to_string(),
+            });
+            let channel_sender_identity = channel_sender_identity(&binding, &msg, &caller);
             let outcome = self
                 .message_flow
                 .handle_web_send(WebSendCommand {
-                    caller: CallerContext::Human(HumanActor {
-                        actor_id: actor_id.clone(),
-                        staff_no: msg.im_user_id.trim().to_string(),
-                    }),
+                    caller,
                     group_id: dispatch_group_id.clone(),
                     session_id: Some(dispatch_session_id.clone()),
                     from_actor_id: dispatch_actor_id.clone(),
@@ -1192,6 +1186,7 @@ impl ChannelService for BcsChannelService {
                     thinking: None,
                     idempotency_key: Some(dispatch_msg_id.clone()),
                     source_im_message_id: Some(dispatch_msg_id.clone()),
+                    channel_sender_identity,
                     sender_conn_id: None,
                     provider_bypass_headers: Vec::new(),
                 })
@@ -1426,6 +1421,7 @@ impl ChannelService for BcsChannelService {
         provider
             .validate_config(&cmd.config)
             .map_err(provider_error)?;
+        validate_forward_sender_identity_config(&target, &cmd.config)?;
         let binding_id = (self.new_id)();
         if matches!(&target, BindingTarget::Bot { .. }) {
             channel_owned_group_id(&cmd.channel_type, GroupKind::Dm, &binding_id)?;
@@ -1536,6 +1532,7 @@ impl ChannelService for BcsChannelService {
         };
         let provider = self.provider_for(&binding.channel_type)?;
         provider.validate_config(&config).map_err(provider_error)?;
+        validate_forward_sender_identity_config(&binding.target, &config)?;
         self.bindings.set_config(id, config).await?;
         Ok(())
     }
@@ -1552,7 +1549,10 @@ impl ChannelService for BcsChannelService {
 
 fn validate_inbound_content(msg: &InboundMessage) -> Result<(), ChannelInboundError> {
     let attachments = msg.attachments.as_deref().unwrap_or_default();
-    if attachments.iter().any(|attachment| !valid_attachment(attachment)) {
+    if attachments
+        .iter()
+        .any(|attachment| !valid_attachment(attachment))
+    {
         return Err(ChannelInboundError::new(
             ChannelInboundFailureKind::InvalidInbound,
             false,
@@ -1585,16 +1585,13 @@ fn has_temporary_file_attachment(attachments: Option<&[Attachment]>) -> bool {
 
 #[async_trait]
 impl ChannelBindingCleanupPort for BcsChannelService {
-    async fn delete_bindings_for_group(
-        &self,
-        group_id: &str,
-    ) -> ServiceResult<u64> {
+    async fn delete_bindings_for_group(&self, group_id: &str) -> ServiceResult<u64> {
         let _guard = self.binding_admin_lock.lock().await;
         let bindings = self
             .bindings
             .list_by_target(
                 &BindingTarget::Group {
-                group_id: group_id.to_string(),
+                    group_id: group_id.to_string(),
                 },
                 None,
             )
@@ -1607,16 +1604,13 @@ impl ChannelBindingCleanupPort for BcsChannelService {
         Ok(deleted)
     }
 
-    async fn delete_bindings_for_bot(
-        &self,
-        bot_id: &str,
-    ) -> ServiceResult<u64> {
+    async fn delete_bindings_for_bot(&self, bot_id: &str) -> ServiceResult<u64> {
         let _guard = self.binding_admin_lock.lock().await;
         let bindings = self
             .bindings
             .list_by_target(
                 &BindingTarget::Bot {
-                bot_id: bot_id.to_string(),
+                    bot_id: bot_id.to_string(),
                 },
                 None,
             )
@@ -1734,13 +1728,13 @@ impl SessionChannelOutboundPort for BcsChannelService {
                 )));
             }
         };
-        let provider = self
-            .providers
-            .get(channel_type)
-            .ok_or_else(|| ServiceError::InvalidOperation {
-                message: format!("channel provider '{channel_type}' is not available"),
-                request_id: None,
-            })?;
+        let provider =
+            self.providers
+                .get(channel_type)
+                .ok_or_else(|| ServiceError::InvalidOperation {
+                    message: format!("channel provider '{channel_type}' is not available"),
+                    request_id: None,
+                })?;
         let binding_ref = ChannelBindingRef {
             channel_type: binding.channel_type.clone(),
             account_ref: binding.account_ref.clone(),
@@ -1829,9 +1823,7 @@ impl SessionChannelOutboundPort for BcsChannelService {
                             message: error.to_string(),
                             request_id: Some(event.event_id.clone()),
                         })?
-                        .filter(|value| {
-                            !value.is_empty() && value.trim().len() == value.len()
-                        })
+                        .filter(|value| !value.is_empty() && value.trim().len() == value.len())
                         .ok_or_else(|| ServiceError::InvalidOperation {
                             message: format!(
                                 "channel provider '{}' cannot resolve HumanInput assignee {}",
@@ -1843,11 +1835,7 @@ impl SessionChannelOutboundPort for BcsChannelService {
                         im_user_id.clone(),
                         "1".to_string(),
                         Some(im_user_id.clone()),
-                        direct_reply_scope(
-                            &binding.id,
-                            &im_user_id,
-                            &event.assignee_actor_id,
-                        ),
+                        direct_reply_scope(&binding.id, &im_user_id, &event.assignee_actor_id),
                     )
                 }
             };
@@ -1877,12 +1865,13 @@ impl SessionChannelOutboundPort for BcsChannelService {
             HumanInputNotificationMode::DirectAssignee => "请直接回复本会话。".to_string(),
         });
         let text = sections.join("\n\n");
-        let deadline_ms = event
-            .timeout_deadline_ms
-            .ok_or_else(|| ServiceError::InvalidOperation {
-                message: "HumanInput notification requires a deadline".to_string(),
-                request_id: Some(event.event_id.clone()),
-            })?;
+        let deadline_ms =
+            event
+                .timeout_deadline_ms
+                .ok_or_else(|| ServiceError::InvalidOperation {
+                    message: "HumanInput notification requires a deadline".to_string(),
+                    request_id: Some(event.event_id.clone()),
+                })?;
         let request = HumanInputRequest {
             request_id: event.event_id,
             session_id: event.session_id,
@@ -1970,11 +1959,7 @@ impl SessionChannelOutboundPort for BcsChannelService {
                 .collect::<HashSet<_>>();
             for (run_id, node_id) in run_nodes {
                 self.human_input_requests
-                    .close_for_run_node(
-                        &run_id,
-                        &node_id,
-                        HumanInputRequestStatus::Cancelled,
-                    )
+                    .close_for_run_node(&run_id, &node_id, HumanInputRequestStatus::Cancelled)
                     .await?;
             }
         }
@@ -1997,7 +1982,10 @@ impl SessionChannelOutboundPort for BcsChannelService {
         let (purpose, text) = match event.status {
             StateMachineTerminalStatus::Completed => {
                 let mut text = format!("【协同已完成】{}", event.workflow_name);
-                if let Some(output) = event.output.as_deref().filter(|value| !value.trim().is_empty())
+                if let Some(output) = event
+                    .output
+                    .as_deref()
+                    .filter(|value| !value.trim().is_empty())
                 {
                     text.push_str("\n\n");
                     text.push_str(&truncate_chars(output, 2_000));
@@ -2156,6 +2144,63 @@ fn binding_target_kind(target: &BindingTarget) -> &'static str {
     }
 }
 
+fn validate_forward_sender_identity_config(
+    target: &BindingTarget,
+    config: &serde_json::Value,
+) -> Result<(), ChannelUseCaseError> {
+    let enabled = match config.get(FORWARD_SENDER_IDENTITY_CONFIG) {
+        None => false,
+        Some(value) => value.as_bool().ok_or_else(|| {
+            ChannelUseCaseError::InvalidParams(format!(
+                "{FORWARD_SENDER_IDENTITY_CONFIG} must be a boolean"
+            ))
+        })?,
+    };
+    if enabled && !matches!(target, BindingTarget::Bot { .. }) {
+        return Err(ChannelUseCaseError::InvalidParams(format!(
+            "{FORWARD_SENDER_IDENTITY_CONFIG} can only be enabled for a Bot binding"
+        )));
+    }
+    Ok(())
+}
+
+fn channel_sender_identity(
+    binding: &ChannelBinding,
+    msg: &InboundMessage,
+    caller: &CallerContext,
+) -> Option<ChannelSenderIdentity> {
+    // COSEC: external Human attribution is disclosed only after the resolved
+    // Bot binding explicitly opts in; message text never controls this gate.
+    if !matches!(binding.target, BindingTarget::Bot { .. })
+        || binding
+            .config
+            .get(FORWARD_SENDER_IDENTITY_CONFIG)
+            .and_then(serde_json::Value::as_bool)
+            != Some(true)
+    {
+        return None;
+    }
+    let CallerContext::Human(human) = caller else {
+        return None;
+    };
+    let user_id = human.staff_no.trim();
+    if user_id.is_empty() {
+        return None;
+    }
+    let display_name = msg
+        .im_user_nick
+        .as_deref()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .unwrap_or(user_id);
+    Some(ChannelSenderIdentity {
+        channel_type: msg.channel_type.clone(),
+        user_id: user_id.to_string(),
+        actor_id: human.actor_id.clone(),
+        display_name: display_name.to_string(),
+    })
+}
+
 fn binding_relevant_to_group(binding: &ChannelBinding, group_id: &str, session: &Session) -> bool {
     match &binding.target {
         BindingTarget::Group {
@@ -2287,12 +2332,12 @@ mod tests {
         MemoryImParticipantRepo,
     };
     use bcs_domain::{
-        ActorKind, BindingStatus, BindingTarget, BotCapabilities, BotDynamicStatus,
-        ChannelBinding, ChannelConfig, ChannelType, Group, GroupChatScope, GroupKind, Participant,
-        ParticipantMode, ParticipantRole, RegisteredBot, Session, SessionKind, SessionScope,
-        SessionStatus, Skill, StateMachineNodeRun, StateMachineNodeStatus, StateMachineRun,
-        StateMachineRunStatus, SystemMessageEvent, Visibility, HumanInputNotificationMode,
-        HumanInputRequestStatus,
+        ActorKind, BindingStatus, BindingTarget, BotCapabilities, BotDynamicStatus, ChannelBinding,
+        ChannelConfig, ChannelType, Group, GroupChatScope, GroupKind, HumanInputNotificationMode,
+        HumanInputRequestStatus, Participant, ParticipantMode, ParticipantRole, RegisteredBot,
+        Session, SessionKind, SessionScope, SessionStatus, Skill, StateMachineNodeRun,
+        StateMachineNodeStatus, StateMachineRun, StateMachineRunStatus, SystemMessageEvent,
+        Visibility,
     };
     use bcs_service_api::application::channel::{
         ChannelInboundError, ChannelInboundFailureKind, ChannelService, ChannelUseCaseError,
@@ -2317,10 +2362,6 @@ mod tests {
         AgentCredentials, BotDeliveryTarget, BotRegistryCoreService, EnsureHumanResult,
         GroupCoreService, ServiceError, ServiceResult,
     };
-    use bcs_service_api::{
-        ChannelBindingCleanupPort, ChannelOutboundPurpose, CollaborationRuntimeService,
-        SystemMessageService,
-    };
     use bcs_service_api::lifecycle::ServiceLifecycle;
     use bcs_service_api::port::channel_delivery::{
         ChannelBindingRef, ChannelDeliveryPort, ChannelDeliveryResult, ChannelOutboundEvent,
@@ -2331,10 +2372,17 @@ mod tests {
         ImParticipantRepoPort, NewSessionParams, SessionRepoPort,
     };
     use bcs_service_api::{
+        ChannelBindingCleanupPort, ChannelOutboundPurpose, CollaborationRuntimeService,
+        SystemMessageService,
+    };
+    use bcs_service_api::{
         HumanInputReadyEvent, SessionChannelDeliveryOutcome, SessionChannelOutboundPort,
     };
 
-    use crate::{BcsChannelService, ResolvedInboundContext, channel_meta, channel_owned_group_id};
+    use crate::{
+        BcsChannelService, FORWARD_SENDER_IDENTITY_CONFIG, ResolvedInboundContext, channel_meta,
+        channel_owned_group_id,
+    };
 
     type TestResult = Result<(), Box<dyn std::error::Error + Send + Sync>>;
 
@@ -2431,10 +2479,7 @@ mod tests {
             unreachable!("inbound binding lookup test only calls find_active_by_account")
         }
 
-        async fn delete_by_target(
-            &self,
-            _target: &BindingTarget,
-        ) -> ServiceResult<u64> {
+        async fn delete_by_target(&self, _target: &BindingTarget) -> ServiceResult<u64> {
             unreachable!("inbound binding lookup test only calls find_active_by_account")
         }
 
@@ -2974,7 +3019,10 @@ mod tests {
                 .len(),
             1
         );
-        assert_eq!(harness.binding_repo.list_by_target(&bot, None).await?.len(), 1);
+        assert_eq!(
+            harness.binding_repo.list_by_target(&bot, None).await?.len(),
+            1
+        );
 
         Ok(())
     }
@@ -3047,7 +3095,11 @@ mod tests {
             1
         );
         assert_eq!(
-            harness.binding_repo.list_by_target(&group, None).await?.len(),
+            harness
+                .binding_repo
+                .list_by_target(&group, None)
+                .await?
+                .len(),
             1
         );
 
@@ -3102,7 +3154,12 @@ mod tests {
             Some("channel_binding_deleted")
         );
         assert_eq!(
-            harness.collaboration_runtime.cancelled_sessions.lock().await.as_slice(),
+            harness
+                .collaboration_runtime
+                .cancelled_sessions
+                .lock()
+                .await
+                .as_slice(),
             &[(session.id, "channel_binding_deleted".to_string())]
         );
 
@@ -3110,7 +3167,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_binding_keeps_cleanup_state_retryable_when_run_cancellation_fails() -> TestResult {
+    async fn delete_binding_keeps_cleanup_state_retryable_when_run_cancellation_fails() -> TestResult
+    {
         let harness = TestHarness::new(manager_group("group_1")).await?;
         harness
             .binding_repo
@@ -3142,7 +3200,11 @@ mod tests {
         *harness.collaboration_runtime.cancel_error.lock().await =
             Some("cancel failed".to_string());
 
-        let error = harness.service.delete_binding("binding_1").await.unwrap_err();
+        let error = harness
+            .service
+            .delete_binding("binding_1")
+            .await
+            .unwrap_err();
 
         assert!(error.to_string().contains("cancel failed"));
         assert_eq!(
@@ -3168,10 +3230,7 @@ mod tests {
     #[tokio::test]
     async fn delete_binding_preserves_session_used_by_another_binding() -> TestResult {
         let harness = TestHarness::new(manager_group("group_1")).await?;
-        for (binding_id, account_ref) in [
-            ("binding_1", "robot_1"),
-            ("binding_2", "robot_2"),
-        ] {
+        for (binding_id, account_ref) in [("binding_1", "robot_1"), ("binding_2", "robot_2")] {
             harness
                 .binding_repo
                 .create(active_binding(
@@ -3266,11 +3325,8 @@ mod tests {
 
     #[tokio::test]
     async fn create_direct_bot_binding_canonicalizes_long_internal_owner_id() -> TestResult {
-        let harness = TestHarness::new_with_generated_id(
-            manager_group("group_1"),
-            "x".repeat(55),
-        )
-        .await?;
+        let harness =
+            TestHarness::new_with_generated_id(manager_group("group_1"), "x".repeat(55)).await?;
 
         let binding = harness
             .service
@@ -3288,11 +3344,7 @@ mod tests {
             })
             .await?;
 
-        let group_id = channel_owned_group_id(
-            &binding.channel_type,
-            GroupKind::Dm,
-            &binding.id,
-        )?;
+        let group_id = channel_owned_group_id(&binding.channel_type, GroupKind::Dm, &binding.id)?;
         assert!(format!("{group_id}:abcdef12").chars().count() <= 64);
         assert_eq!(harness.binding_repo.list().await?.len(), 1);
 
@@ -3596,10 +3648,7 @@ mod tests {
 
         let mappings = harness
             .service
-            .list_conversations_by_session(
-                " group_1:session_1 ",
-                Some(" dingtalk ".to_string()),
-            )
+            .list_conversations_by_session(" group_1:session_1 ", Some(" dingtalk ".to_string()))
             .await?;
 
         assert_eq!(mappings.len(), 1);
@@ -3694,6 +3743,162 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sender_identity_config_is_boolean_and_bot_binding_only() -> TestResult {
+        for value in [serde_json::json!(false), serde_json::json!(true)] {
+            let harness = TestHarness::new(manager_group("group_1")).await?;
+            let mut config = dingtalk_config("robot_1");
+            config[FORWARD_SENDER_IDENTITY_CONFIG] = value;
+            harness
+                .service
+                .create_binding(CreateBindingCommand {
+                    channel_type: channel_type(),
+                    account_ref: "robot_1".to_string(),
+                    target: BindingTarget::Bot {
+                        bot_id: "target_bot".to_string(),
+                    },
+                    group_chat_scope: None,
+                    outbound_visibility: Visibility::FullTranscript,
+                    env: "dev".to_string(),
+                    created_by: Some("creator".to_string()),
+                    config,
+                })
+                .await?;
+        }
+
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        let mut invalid_type = dingtalk_config("robot_1");
+        invalid_type[FORWARD_SENDER_IDENTITY_CONFIG] = serde_json::json!("true");
+        let error = harness
+            .service
+            .create_binding(CreateBindingCommand {
+                channel_type: channel_type(),
+                account_ref: "robot_1".to_string(),
+                target: BindingTarget::Bot {
+                    bot_id: "target_bot".to_string(),
+                },
+                group_chat_scope: None,
+                outbound_visibility: Visibility::FullTranscript,
+                env: "dev".to_string(),
+                created_by: Some("creator".to_string()),
+                config: invalid_type,
+            })
+            .await
+            .expect_err("non-boolean sender identity config must fail");
+        assert!(matches!(error, ChannelUseCaseError::InvalidParams(_)));
+
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        let mut group_config = dingtalk_config("robot_1");
+        group_config[FORWARD_SENDER_IDENTITY_CONFIG] = serde_json::json!(true);
+        let error = harness
+            .service
+            .create_binding(CreateBindingCommand {
+                channel_type: channel_type(),
+                account_ref: "robot_1".to_string(),
+                target: BindingTarget::Group {
+                    group_id: "group_1".to_string(),
+                },
+                group_chat_scope: Some(GroupChatScope::ConversationShared),
+                outbound_visibility: Visibility::FullTranscript,
+                env: "dev".to_string(),
+                created_by: Some("creator".to_string()),
+                config: group_config,
+            })
+            .await
+            .expect_err("group binding must reject sender identity forwarding");
+        assert!(matches!(error, ChannelUseCaseError::InvalidParams(_)));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sender_identity_update_applies_to_next_ordinary_bot_channel_message() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        harness
+            .binding_repo
+            .create(active_binding(
+                "binding_bot_identity",
+                "robot_1",
+                BindingTarget::Bot {
+                    bot_id: "target_bot".to_string(),
+                },
+                Visibility::FullTranscript,
+            ))
+            .await?;
+
+        harness
+            .service
+            .handle_inbound(inbound("conv_dm", "410025", Some("张三"), "msg_before"))
+            .await?;
+        assert!(
+            harness.message_flow.web_sends.lock().await[0]
+                .channel_sender_identity
+                .is_none()
+        );
+
+        let mut enabled = dingtalk_config("robot_1");
+        enabled[FORWARD_SENDER_IDENTITY_CONFIG] = serde_json::json!(true);
+        harness
+            .service
+            .update_binding_config("binding_bot_identity", enabled)
+            .await?;
+
+        harness
+            .service
+            .handle_inbound(group_inbound(
+                "conv_group",
+                "410025",
+                Some("张三"),
+                "msg_zhang",
+                true,
+            ))
+            .await?;
+        harness
+            .service
+            .handle_inbound(group_inbound(
+                "conv_group",
+                "410026",
+                Some("李四"),
+                "msg_li",
+                true,
+            ))
+            .await?;
+        harness
+            .service
+            .handle_inbound(group_inbound(
+                "conv_group",
+                "410027",
+                None,
+                "msg_no_nick",
+                true,
+            ))
+            .await?;
+        harness
+            .service
+            .handle_inbound(group_inbound(
+                "conv_group",
+                "410028",
+                Some("   "),
+                "msg_blank_nick",
+                true,
+            ))
+            .await?;
+
+        let sends = harness.message_flow.web_sends.lock().await;
+        let zhang = sends[1].channel_sender_identity.as_ref().unwrap();
+        assert_eq!(zhang.user_id, "410025");
+        assert_eq!(zhang.display_name, "张三");
+        let li = sends[2].channel_sender_identity.as_ref().unwrap();
+        assert_eq!(li.user_id, "410026");
+        assert_eq!(li.display_name, "李四");
+        let no_nick = sends[3].channel_sender_identity.as_ref().unwrap();
+        assert_eq!(no_nick.user_id, "410027");
+        assert_eq!(no_nick.display_name, "410027");
+        let blank_nick = sends[4].channel_sender_identity.as_ref().unwrap();
+        assert_eq!(blank_nick.user_id, "410028");
+        assert_eq!(blank_nick.display_name, "410028");
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn inbound_manager_worker_materializes_human_and_isolates_dm_conversations() -> TestResult
     {
         let harness = TestHarness::new(manager_group("group_1")).await?;
@@ -3760,22 +3965,27 @@ mod tests {
             .await?
             .ok_or_else(|| ServiceError::InternalError("missing conv_b".to_string()))?;
         assert_ne!(conv_a.bcs_session_id, conv_b.bcs_session_id);
-        assert!(conv_a.bcs_session_id.starts_with("group_1:channel_dingtalk_"));
-        assert!(conv_b.bcs_session_id.starts_with("group_1:channel_dingtalk_"));
+        assert!(
+            conv_a
+                .bcs_session_id
+                .starts_with("group_1:channel_dingtalk_")
+        );
+        assert!(
+            conv_b
+                .bcs_session_id
+                .starts_with("group_1:channel_dingtalk_")
+        );
 
         let web_sends = harness.message_flow.web_sends.lock().await;
         assert_eq!(web_sends.len(), 2);
         assert_eq!(web_sends[0].from_actor_id, "human_u1");
-        assert_eq!(web_sends[0].session_id.as_deref(), Some(conv_a.bcs_session_id.as_str()));
+        assert_eq!(
+            web_sends[0].session_id.as_deref(),
+            Some(conv_a.bcs_session_id.as_str())
+        );
         assert_eq!(web_sends[0].idempotency_key.as_deref(), Some("msg_a"));
-        assert_eq!(
-            web_sends[0].source_im_message_id.as_deref(),
-            Some("msg_a")
-        );
-        assert_eq!(
-            web_sends[1].source_im_message_id.as_deref(),
-            Some("msg_b")
-        );
+        assert_eq!(web_sends[0].source_im_message_id.as_deref(), Some("msg_a"));
+        assert_eq!(web_sends[1].source_im_message_id.as_deref(), Some("msg_b"));
 
         let added = harness.session_repo.added_participants.lock().await;
         assert_eq!(added.len(), 2);
@@ -3813,10 +4023,7 @@ mod tests {
         assert_eq!(web_sends.len(), 1);
         assert_eq!(web_sends[0].group_id, "group_chat");
         assert_eq!(web_sends[0].from_actor_id, "human_u1");
-        assert_eq!(
-            web_sends[0].idempotency_key.as_deref(),
-            Some("msg_chat")
-        );
+        assert_eq!(web_sends[0].idempotency_key.as_deref(), Some("msg_chat"));
 
         Ok(())
     }
@@ -5207,8 +5414,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn direct_human_input_resolves_actor_without_mapping_and_queues_same_scope(
-    ) -> TestResult {
+    async fn direct_human_input_resolves_actor_without_mapping_and_queues_same_scope() -> TestResult
+    {
         let harness = TestHarness::new(state_machine_group("group_sm")).await?;
         harness
             .service
@@ -5226,16 +5433,12 @@ mod tests {
             })
             .await?;
 
-        let mut invalid_actor = human_input_ready_event(
-            "direct-invalid",
-            HumanInputNotificationMode::DirectAssignee,
-        );
+        let mut invalid_actor =
+            human_input_ready_event("direct-invalid", HumanInputNotificationMode::DirectAssignee);
         invalid_actor.assignee_actor_id = "bot_u1".to_string();
-        let invalid_result = SessionChannelOutboundPort::publish_human_input_ready(
-            &harness.service,
-            invalid_actor,
-        )
-        .await;
+        let invalid_result =
+            SessionChannelOutboundPort::publish_human_input_ready(&harness.service, invalid_actor)
+                .await;
         assert!(matches!(
             invalid_result,
             Err(ServiceError::InvalidOperation { .. })
@@ -5245,10 +5448,7 @@ mod tests {
             assert_eq!(
                 SessionChannelOutboundPort::publish_human_input_ready(
                     &harness.service,
-                    human_input_ready_event(
-                        event_id,
-                        HumanInputNotificationMode::DirectAssignee,
-                    ),
+                    human_input_ready_event(event_id, HumanInputNotificationMode::DirectAssignee,),
                 )
                 .await?,
                 SessionChannelDeliveryOutcome::Delivered
@@ -5324,10 +5524,7 @@ mod tests {
 
         let result = SessionChannelOutboundPort::publish_human_input_ready(
             &harness.service,
-            human_input_ready_event(
-                "delivery-failed",
-                HumanInputNotificationMode::FixedGroup,
-            ),
+            human_input_ready_event("delivery-failed", HumanInputNotificationMode::FixedGroup),
         )
         .await;
         assert!(matches!(result, Err(ServiceError::InternalError(_))));
@@ -5525,11 +5722,8 @@ mod tests {
             })
             .await?;
 
-        let mut consultant_msg = outbound(
-            "group_chat:00000001",
-            ParticipantRole::Consultant,
-            false,
-        );
+        let mut consultant_msg =
+            outbound("group_chat:00000001", ParticipantRole::Consultant, false);
         consultant_msg.group_id = "group_chat".to_string();
         harness.service.try_outbound(consultant_msg).await?;
         assert!(harness.delivery.events.lock().await.is_empty());
@@ -6919,6 +7113,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sender_identity_forwarding_does_not_change_new_command_routing() -> TestResult {
+        let harness = TestHarness::new(manager_group("group_1")).await?;
+        let mut binding = active_binding(
+            "binding_bot_identity",
+            "robot_1",
+            BindingTarget::Bot {
+                bot_id: "target_bot".to_string(),
+            },
+            Visibility::FullTranscript,
+        );
+        binding.config[FORWARD_SENDER_IDENTITY_CONFIG] = serde_json::json!(true);
+        harness.binding_repo.create(binding).await?;
+
+        let mut command = new_command("conv_1", "410025", "msg_new");
+        command.text = "  /new  ".to_string();
+        harness.service.handle_inbound(command).await?;
+        assert!(harness.message_flow.web_sends.lock().await.is_empty());
+
+        let mut ordinary = new_command("conv_1", "410025", "msg_new_foo");
+        ordinary.text = "/new foo".to_string();
+        harness.service.handle_inbound(ordinary).await?;
+        let sends = harness.message_flow.web_sends.lock().await;
+        assert_eq!(sends.len(), 1);
+        assert_eq!(sends[0].message, "/new foo");
+        assert_eq!(
+            sends[0]
+                .channel_sender_identity
+                .as_ref()
+                .map(|identity| identity.user_id.as_str()),
+            Some("410025")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn new_command_without_session_replies_nothing_to_reset() -> TestResult {
         let harness = TestHarness::new(manager_group("group_1")).await?;
         create_group_binding(&harness, "group_1", GroupChatScope::ConversationShared).await?;
@@ -7175,13 +7404,23 @@ mod tests {
             .await?;
         let session_u1 = harness
             .conversation_repo
-            .get("generated_id", "conv_1", SessionScope::PerSender, Some("u1"))
+            .get(
+                "generated_id",
+                "conv_1",
+                SessionScope::PerSender,
+                Some("u1"),
+            )
             .await?
             .expect("u1 mapping")
             .bcs_session_id;
         let session_u2 = harness
             .conversation_repo
-            .get("generated_id", "conv_1", SessionScope::PerSender, Some("u2"))
+            .get(
+                "generated_id",
+                "conv_1",
+                SessionScope::PerSender,
+                Some("u2"),
+            )
             .await?
             .expect("u2 mapping")
             .bcs_session_id;
@@ -7312,7 +7551,13 @@ mod tests {
         create_group_binding(&harness, "group_sm", GroupChatScope::ConversationShared).await?;
         harness
             .service
-            .handle_inbound(group_inbound("conv_sm", "u1", Some("张三"), "msg_start", true))
+            .handle_inbound(group_inbound(
+                "conv_sm",
+                "u1",
+                Some("张三"),
+                "msg_start",
+                true,
+            ))
             .await?;
         let session_id = harness.collaboration_runtime.starts.lock().await[0]
             .session_id
@@ -7417,7 +7662,13 @@ mod tests {
         create_group_binding(&harness, "group_sm", GroupChatScope::ConversationShared).await?;
         harness
             .service
-            .handle_inbound(group_inbound("conv_sm", "u1", Some("张三"), "msg_start", true))
+            .handle_inbound(group_inbound(
+                "conv_sm",
+                "u1",
+                Some("张三"),
+                "msg_start",
+                true,
+            ))
             .await?;
         let session_id = harness.collaboration_runtime.starts.lock().await[0]
             .session_id
@@ -7578,7 +7829,10 @@ mod tests {
         );
 
         // bot 假死、终态事件不到达：超过兜底阈值后由下一条消息顺带执行。
-        clock.store(42 + crate::commands::PENDING_RESET_STALE_MS + 1, Ordering::SeqCst);
+        clock.store(
+            42 + crate::commands::PENDING_RESET_STALE_MS + 1,
+            Ordering::SeqCst,
+        );
         harness
             .service
             .handle_inbound(inbound("conv_1", "u1", Some("张三"), "msg_2"))

--- a/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
@@ -1126,6 +1126,7 @@ fn build_chat_send_frame(
             actor_id: Some(from_bot_id.to_string()),
             actor_name: Some(from_bot_name.to_string()),
             thread_id: None,
+            identity_forwarding: None,
         },
         session_context: GroupContext {
             session_id: session_key.to_string(),

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -4,9 +4,9 @@ use std::sync::{Arc, OnceLock};
 use async_trait::async_trait;
 use bcs_domain::{Attachment, NewMessage, SenderType};
 use bcs_protocol::{
-    Attachment as WireAttachment, BcsFrame, RequestFrame, build_chat_inject_frame,
-    build_chat_send_frame, build_direct_chat_inject_frame, build_direct_chat_send_frame,
-    build_session_key, now_ms,
+    Attachment as WireAttachment, BcsFrame, ChannelInfo, ChannelSource, RequestFrame,
+    apply_channel_info, build_chat_inject_frame, build_chat_send_frame,
+    build_direct_chat_inject_frame, build_direct_chat_send_frame, build_session_key, now_ms,
 };
 use bcs_service_api::{
     ActorKind, ActorStatus, BotDeliveryCommand, BotDeliveryKind, BotDeliveryPort,
@@ -24,10 +24,9 @@ use bcs_service_api::{
     PersistentGroupSendCommand, PersistentGroupSendOutcome, ProviderStreamGrayList,
     RouteParticipantOverlay, RoutingCoreService, RoutingDecision, RoutingTarget, ServiceError,
     ServiceResult, SessionManagementService, SessionStatus, SystemMessageEvent,
-    SystemMessageService,
-    TaskCompleteCommand, TaskCompleteOutcome, TaskDispatchCommand, TaskDispatchOutcome,
-    TaskMessageCommand, TaskMessageOutcome, TaskRunAliasRegistration, WebSendCommand,
-    WebSendOutcome, backfill_bot_names,
+    SystemMessageService, TaskCompleteCommand, TaskCompleteOutcome, TaskDispatchCommand,
+    TaskDispatchOutcome, TaskMessageCommand, TaskMessageOutcome, TaskRunAliasRegistration,
+    WebSendCommand, WebSendOutcome, backfill_bot_names,
     interceptor::{
         BlockReason, InterceptorChain, InterceptorDecision, MessageInterceptor, OutboundMessage,
     },
@@ -311,18 +310,17 @@ pub(crate) async fn try_persist_group_message(
         return Ok(None);
     };
     let created_at = now_ms();
-    let strategy_supports_message_event = if flow.event_record_factory.is_some()
-        && message_type == "chat"
-    {
-        flow.group.try_get(group_id).await?.is_some_and(|group| {
-            matches!(
-                group.group_strategy,
-                GroupStrategy::Chat | GroupStrategy::ManagerWorker
-            )
-        })
-    } else {
-        false
-    };
+    let strategy_supports_message_event =
+        if flow.event_record_factory.is_some() && message_type == "chat" {
+            flow.group.try_get(group_id).await?.is_some_and(|group| {
+                matches!(
+                    group.group_strategy,
+                    GroupStrategy::Chat | GroupStrategy::ManagerWorker
+                )
+            })
+        } else {
+            false
+        };
     let effective_session_id = if strategy_supports_message_event {
         match session_id.filter(|session_id| !session_id.is_empty()) {
             Some(session_id) => session_id.to_string(),
@@ -543,11 +541,8 @@ mod attachment_persistence_tests {
 
     #[test]
     fn mention_text_is_persisted_verbatim_with_structured_mentions() {
-        let persisted = persisted_inbound_content(
-            "@Driver please review",
-            None,
-            &["bot-driver".to_string()],
-        );
+        let persisted =
+            persisted_inbound_content("@Driver please review", None, &["bot-driver".to_string()]);
 
         assert_eq!(persisted["text"], "@Driver please review");
         assert_eq!(persisted["mentions"][0], "bot-driver");
@@ -558,7 +553,10 @@ mod attachment_persistence_tests {
     fn plain_text_without_attachments_or_mentions_stays_a_string() {
         let persisted = persisted_inbound_content("plain chat", None, &[]);
 
-        assert_eq!(persisted, serde_json::Value::String("plain chat".to_string()));
+        assert_eq!(
+            persisted,
+            serde_json::Value::String("plain chat".to_string())
+        );
     }
 }
 
@@ -570,7 +568,9 @@ pub(crate) async fn manager_worker_self_owner(
 ) -> Option<String> {
     let group = flow.group.get(group_id).await?;
     if group.group_strategy == GroupStrategy::ManagerWorker {
-        if let (Some(session_id), Some(session_mgmt)) = (session_id, flow.session_management.as_ref()) {
+        if let (Some(session_id), Some(session_mgmt)) =
+            (session_id, flow.session_management.as_ref())
+        {
             if let Ok(Some(session)) = session_mgmt.get(session_id).await {
                 if session.group_id == group_id {
                     if let Some(participant) = session
@@ -578,7 +578,8 @@ pub(crate) async fn manager_worker_self_owner(
                         .iter()
                         .find(|participant| participant.bot_uuid == sender_id)
                     {
-                        return (participant.is_bot() && participant.role == ParticipantRole::Worker)
+                        return (participant.is_bot()
+                            && participant.role == ParticipantRole::Worker)
                             .then(|| sender_id.to_string());
                     }
                 }
@@ -681,7 +682,12 @@ pub async fn handle_web_send(
         build_explicit_mention_decision(&group, &cmd.mentions, &cmd.message, &overlay)
     };
 
-    log_routing_digest(&cmd, &decision, MessageLogMode::FreeChat, route_source_for_web_send(&group, &cmd));
+    log_routing_digest(
+        &cmd,
+        &decision,
+        MessageLogMode::FreeChat,
+        route_source_for_web_send(&group, &cmd),
+    );
 
     let sender_display_name = preferred_sender_display_name(flow, &cmd).await;
     let from_bot_owner = from_bot_owner(flow, &cmd.from_actor_id).await;
@@ -724,40 +730,36 @@ pub async fn handle_web_send(
             metadata: None,
             attachments: None,
         };
-        let outbound_message = match apply_outbound_interceptors(
-            flow,
-            &cmd.group_id,
-            &outbound_candidate,
-            target,
-        )
-        .await
-        {
-            Ok(message) => message,
-            Err(reason) => {
-                log_bot_deliver_result(
-                    &cmd.group_id,
-                    cmd.session_id.as_deref(),
-                    &run_id,
-                    &target_bot_id,
-                    delivery_type,
-                    false,
-                    Some(reason.message.as_str()),
-                    Some("interceptor"),
-                );
-                delivery_results.push(delivery_result_summary(
-                    &target_bot_id,
-                    delivery_type,
-                    false,
-                    Some(reason.message.clone()),
-                ));
-                bot_deliveries.push(BotDeliveryResult {
-                    target_bot_id,
-                    delivered: false,
-                    error: Some(ServiceError::Unauthorized(reason.message)),
-                });
-                continue;
-            }
-        };
+        let outbound_message =
+            match apply_outbound_interceptors(flow, &cmd.group_id, &outbound_candidate, target)
+                .await
+            {
+                Ok(message) => message,
+                Err(reason) => {
+                    log_bot_deliver_result(
+                        &cmd.group_id,
+                        cmd.session_id.as_deref(),
+                        &run_id,
+                        &target_bot_id,
+                        delivery_type,
+                        false,
+                        Some(reason.message.as_str()),
+                        Some("interceptor"),
+                    );
+                    delivery_results.push(delivery_result_summary(
+                        &target_bot_id,
+                        delivery_type,
+                        false,
+                        Some(reason.message.clone()),
+                    ));
+                    bot_deliveries.push(BotDeliveryResult {
+                        target_bot_id,
+                        delivered: false,
+                        error: Some(ServiceError::Unauthorized(reason.message)),
+                    });
+                    continue;
+                }
+            };
         let delivery_target = match flow.registry.resolve_delivery_target(&target_bot_id).await {
             Ok(target) => target,
             Err(error) => {
@@ -805,12 +807,9 @@ pub async fn handle_web_send(
         // in the Phase-5 follow-up list (Modify semantics completeness).
 
         let delivery_kind = bot_delivery_kind(delivery_type);
-        let source_im_message_id = cmd
-            .source_im_message_id
-            .as_deref()
-            .filter(|message_id| {
-                delivery_type == DeliveryType::Send && !message_id.trim().is_empty()
-            });
+        let source_im_message_id = cmd.source_im_message_id.as_deref().filter(|message_id| {
+            delivery_type == DeliveryType::Send && !message_id.trim().is_empty()
+        });
         if let Some(message_id) = source_im_message_id {
             // Cache before delivery: a fast bot may emit its first response
             // before the delivery call itself has returned.
@@ -995,8 +994,7 @@ pub async fn handle_web_send(
             .targets
             .iter()
             .filter(|t| {
-                t.delivery_type == DeliveryType::Inject
-                    && decision.mentions.contains(&t.bot_uuid)
+                t.delivery_type == DeliveryType::Inject && decision.mentions.contains(&t.bot_uuid)
             })
             .filter_map(|t| {
                 overlay
@@ -1104,6 +1102,7 @@ pub async fn handle_group_chat(
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
+            channel_sender_identity: None,
             sender_conn_id: None,
             provider_bypass_headers: cmd.provider_bypass_headers,
         },
@@ -1231,28 +1230,33 @@ pub async fn handle_persistent_group_send(
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     };
     for target in &decision.targets {
-        let outbound = match apply_outbound_interceptors(flow, &cmd.group_id, &message, target).await
-        {
-            Ok(message) => message,
-            Err(reason) => {
-                warn!(
-                    session_id = %cmd.group_id,
-                    bot_uuid = %target.bot_uuid,
-                    interceptor = %reason.interceptor_id,
-                    code = %reason.code,
-                    "outbound message blocked by interceptor"
-                );
-                continue;
-            }
-        };
+        let outbound =
+            match apply_outbound_interceptors(flow, &cmd.group_id, &message, target).await {
+                Ok(message) => message,
+                Err(reason) => {
+                    warn!(
+                        session_id = %cmd.group_id,
+                        bot_uuid = %target.bot_uuid,
+                        interceptor = %reason.interceptor_id,
+                        code = %reason.code,
+                        "outbound message blocked by interceptor"
+                    );
+                    continue;
+                }
+            };
         routed_to.push(target.bot_uuid.clone());
 
         let run_id = uuid::Uuid::new_v4().to_string();
-        let delivery_target = match flow.registry.resolve_delivery_target(&target.bot_uuid).await {
+        let delivery_target = match flow
+            .registry
+            .resolve_delivery_target(&target.bot_uuid)
+            .await
+        {
             Ok(delivery_target) => delivery_target,
             Err(error) => {
                 warn!(
@@ -1597,6 +1601,7 @@ pub async fn handle_group_callback(
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     };
@@ -1623,32 +1628,37 @@ pub async fn handle_group_callback(
             metadata: cmd.metadata.clone(),
             attachments: None,
         };
-        let outbound_message =
-            match apply_outbound_interceptors(flow, &cmd.group_id, &synthetic_message, target).await
-            {
-                Ok(message) => message,
-                Err(reason) => {
-                    warn!(
-                        group_id = %cmd.group_id,
-                        target_bot_id = %target_bot_id,
-                        interceptor = %reason.interceptor_id,
-                        code = %reason.code,
-                        "group callback delivery blocked by interceptor chain"
-                    );
-                    delivery_results.push(delivery_result_summary(
-                        &target_bot_id,
-                        delivery_type,
-                        false,
-                        Some(reason.message.clone()),
-                    ));
-                    bot_deliveries.push(BotDeliveryResult {
-                        target_bot_id,
-                        delivered: false,
-                        error: Some(ServiceError::Forbidden(reason.message)),
-                    });
-                    continue;
-                }
-            };
+        let outbound_message = match apply_outbound_interceptors(
+            flow,
+            &cmd.group_id,
+            &synthetic_message,
+            target,
+        )
+        .await
+        {
+            Ok(message) => message,
+            Err(reason) => {
+                warn!(
+                    group_id = %cmd.group_id,
+                    target_bot_id = %target_bot_id,
+                    interceptor = %reason.interceptor_id,
+                    code = %reason.code,
+                    "group callback delivery blocked by interceptor chain"
+                );
+                delivery_results.push(delivery_result_summary(
+                    &target_bot_id,
+                    delivery_type,
+                    false,
+                    Some(reason.message.clone()),
+                ));
+                bot_deliveries.push(BotDeliveryResult {
+                    target_bot_id,
+                    delivered: false,
+                    error: Some(ServiceError::Forbidden(reason.message)),
+                });
+                continue;
+            }
+        };
 
         let delivery_target = match flow.registry.resolve_delivery_target(&target_bot_id).await {
             Ok(target) => target,
@@ -2145,10 +2155,8 @@ fn build_explicit_mention_decision(
     message: &str,
     overlay: &[RouteParticipantOverlay],
 ) -> RoutingDecision {
-    let overlay_map: std::collections::HashMap<&str, &RouteParticipantOverlay> = overlay
-        .iter()
-        .map(|o| (o.bot_uuid.as_str(), o))
-        .collect();
+    let overlay_map: std::collections::HashMap<&str, &RouteParticipantOverlay> =
+        overlay.iter().map(|o| (o.bot_uuid.as_str(), o)).collect();
 
     let mut valid_mentions: Vec<String> = Vec::new();
     let mut hidden_mentions: Vec<HiddenMentionInfo> = Vec::new();
@@ -2312,7 +2320,10 @@ pub(crate) fn apply_overlay_to_decision(
                 if target.delivery_type == DeliveryType::Send && forced_inject {
                     target.delivery_type = DeliveryType::Inject;
                     if row.status == ActorStatus::Hidden {
-                        let bot_name = row.bot_name.clone().unwrap_or_else(|| target.bot_uuid.clone());
+                        let bot_name = row
+                            .bot_name
+                            .clone()
+                            .unwrap_or_else(|| target.bot_uuid.clone());
                         decision.hidden_mentions.push(HiddenMentionInfo {
                             hidden_bot_id: target.bot_uuid.clone(),
                             hidden_bot_name: bot_name,
@@ -2324,7 +2335,12 @@ pub(crate) fn apply_overlay_to_decision(
         })
         .collect();
 
-    decision.mentions.retain(|m| !decision.hidden_mentions.iter().any(|h| h.hidden_bot_id == *m));
+    decision.mentions.retain(|m| {
+        !decision
+            .hidden_mentions
+            .iter()
+            .any(|h| h.hidden_bot_id == *m)
+    });
 
     decision
 }
@@ -2414,10 +2430,10 @@ async fn frame_for_target(
     } else {
         &[]
     };
-    match target.delivery_type {
+    let mut frame = match target.delivery_type {
         DeliveryType::Send => {
             if context_projection == ContextProjection::DirectBot {
-                return build_direct_chat_send_frame(
+                build_direct_chat_send_frame(
                     run_id,
                     &cmd.group_id,
                     content,
@@ -2429,31 +2445,32 @@ async fn frame_for_target(
                     &cmd.thinking,
                     protocol_version,
                     cmd.session_id.as_deref(),
-                );
+                )
+            } else {
+                let protocol_group = group_context_input(group);
+                build_chat_send_frame(
+                    run_id,
+                    &cmd.group_id,
+                    &protocol_group,
+                    content,
+                    &cmd.from_actor_id,
+                    sender_display_name,
+                    &decision.mentions,
+                    &target.bot_uuid,
+                    provider_tags,
+                    &wire_attachments,
+                    &cmd.thinking,
+                    is_self,
+                    protocol_version,
+                    from_bot_owner,
+                    group_type_wire(group.group_strategy),
+                    cmd.session_id.as_deref(),
+                )
             }
-            let protocol_group = group_context_input(group);
-            build_chat_send_frame(
-                run_id,
-                &cmd.group_id,
-                &protocol_group,
-                content,
-                &cmd.from_actor_id,
-                sender_display_name,
-                &decision.mentions,
-                &target.bot_uuid,
-                provider_tags,
-                &wire_attachments,
-                &cmd.thinking,
-                is_self,
-                protocol_version,
-                from_bot_owner,
-                group_type_wire(group.group_strategy),
-                cmd.session_id.as_deref(),
-            )
         }
         DeliveryType::Inject => {
             if context_projection == ContextProjection::DirectBot {
-                return build_direct_chat_inject_frame(
+                build_direct_chat_inject_frame(
                     run_id,
                     &cmd.group_id,
                     content,
@@ -2464,28 +2481,48 @@ async fn frame_for_target(
                     &wire_attachments,
                     protocol_version,
                     cmd.session_id.as_deref(),
-                );
+                )
+            } else {
+                let protocol_group = group_context_input(group);
+                build_chat_inject_frame(
+                    run_id,
+                    &cmd.group_id,
+                    &protocol_group,
+                    content,
+                    &cmd.from_actor_id,
+                    sender_display_name,
+                    &decision.mentions,
+                    &target.bot_uuid,
+                    provider_tags,
+                    &wire_attachments,
+                    is_self,
+                    protocol_version,
+                    from_bot_owner,
+                    group_type_wire(group.group_strategy),
+                    cmd.session_id.as_deref(),
+                )
             }
-            let protocol_group = group_context_input(group);
-            build_chat_inject_frame(
-                run_id,
-                &cmd.group_id,
-                &protocol_group,
-                content,
-                &cmd.from_actor_id,
-                sender_display_name,
-                &decision.mentions,
-                &target.bot_uuid,
-                provider_tags,
-                &wire_attachments,
-                is_self,
-                protocol_version,
-                from_bot_owner,
-                group_type_wire(group.group_strategy),
-                cmd.session_id.as_deref(),
-            )
         }
+    };
+    if let Some(identity) = cmd.channel_sender_identity.as_ref() {
+        let source = match identity.channel_type.as_str() {
+            "dingtalk" => ChannelSource::DingTalk,
+            "webui" => ChannelSource::WebUi,
+            _ => ChannelSource::Api,
+        };
+        apply_channel_info(
+            &mut frame,
+            ChannelInfo {
+                source,
+                user_id: Some(identity.user_id.clone()),
+                actor_id: Some(identity.actor_id.clone()),
+                actor_name: Some(identity.display_name.clone()),
+                thread_id: Some(cmd.group_id.clone()),
+                identity_forwarding: Some(true),
+            },
+        );
     }
+    frame
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2756,7 +2793,9 @@ fn echo_event_attachments(attachments: Option<&[Attachment]>) -> Option<Value> {
 }
 
 fn effective_message_log_session_id<'a>(group_id: &'a str, session_id: Option<&'a str>) -> &'a str {
-    session_id.filter(|value| !value.is_empty()).unwrap_or(group_id)
+    session_id
+        .filter(|value| !value.is_empty())
+        .unwrap_or(group_id)
 }
 
 fn delivery_type_slug(delivery_type: DeliveryType) -> &'static str {
@@ -2810,9 +2849,11 @@ fn log_routing_digest(
     let targets_summary: Vec<MessageLogTargetSummary> = decision
         .targets
         .iter()
-        .map(|target| MessageLogTargetSummary::new(&target.bot_uuid)
-            .with_delivery_type(delivery_type_slug(target.delivery_type))
-            .with_route_source(route_source))
+        .map(|target| {
+            MessageLogTargetSummary::new(&target.bot_uuid)
+                .with_delivery_type(delivery_type_slug(target.delivery_type))
+                .with_route_source(route_source)
+        })
         .collect();
 
     info!(

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -1,16 +1,15 @@
 use bcs_message_flow::{BcsGroupMessageHistory, BcsMessageFlow, MemoryBotRunContextStore};
 use bcs_protocol::BcsFrame;
 use bcs_service_api::{
-    ActorKind, BotActor, BotDeliveryKind, BotDeliveryTarget, BotEventCommand, BotRegistryCoreService,
-    BotRunContextPort,
-    CallerContext, ChatAbortCommand, ChatEventState, GroupCallbackCommand, GroupChatCommand, GroupHistoryBotRequestPort,
-    FrontendDeliveryTarget, Group, GroupHistoryCommand, GroupKind, GroupMessage, GroupMessageHistoryService, GroupMessageType,
-    GroupCoreService, GroupStatus, GroupStrategy, HumanActor, MessageFlowService, MessageRole, Participant,
-    ParticipantMode, ParticipantRole, PersistentGroupSendCommand, ProviderStreamGrayList,
-    RedactedToken, ServiceError, WebSendCommand,
-    ServiceResult, Session, SessionHistoryCommand, SessionKind, SessionManagementService,
-    SessionStatus, SessionUseCaseError,
-    SystemMessageEvent, SystemMessageService,
+    ActorKind, BotActor, BotDeliveryKind, BotDeliveryTarget, BotEventCommand,
+    BotRegistryCoreService, BotRunContextPort, CallerContext, ChannelSenderIdentity,
+    ChatAbortCommand, ChatEventState, FrontendDeliveryTarget, Group, GroupCallbackCommand,
+    GroupChatCommand, GroupCoreService, GroupHistoryBotRequestPort, GroupHistoryCommand, GroupKind,
+    GroupMessage, GroupMessageHistoryService, GroupMessageType, GroupStatus, GroupStrategy,
+    HumanActor, MessageFlowService, MessageRole, Participant, ParticipantMode, ParticipantRole,
+    PersistentGroupSendCommand, ProviderStreamGrayList, RedactedToken, ServiceError, ServiceResult,
+    Session, SessionHistoryCommand, SessionKind, SessionManagementService, SessionStatus,
+    SessionUseCaseError, SystemMessageEvent, SystemMessageService, WebSendCommand,
     interceptor::{BlockReason, InterceptorDecision, MessageInterceptor, OutboundMessage},
     port::{EventRecordFactoryPort, NewEvent},
 };
@@ -166,12 +165,10 @@ impl GroupHistoryBotRequestPort for RecordingHistoryBotRequest {
         timeout_ms: u64,
     ) -> Result<serde_json::Value, String> {
         let bot_uuid = target.bot_id().to_string();
-        self.calls.write().await.push((
-            bot_uuid.clone(),
-            method.to_string(),
-            params,
-            timeout_ms,
-        ));
+        self.calls
+            .write()
+            .await
+            .push((bot_uuid.clone(), method.to_string(), params, timeout_ms));
         if bot_uuid == "bot-observer" {
             return Err("request_failed: disconnected".to_string());
         }
@@ -372,7 +369,9 @@ impl SessionManagementService for StaticSessionManagement {
     ) -> Result<Vec<String>, SessionUseCaseError> {
         unimplemented!("not needed by this test")
     }
-    async fn delete(&self, _session_id: &str) -> Result<bool, SessionUseCaseError> { Ok(false) }
+    async fn delete(&self, _session_id: &str) -> Result<bool, SessionUseCaseError> {
+        Ok(false)
+    }
 }
 
 fn test_session(session_id: &str, group_id: &str, participants: Vec<Participant>) -> Session {
@@ -487,10 +486,7 @@ impl GroupHistoryBotRequestPort for RecordingTargetHistoryBotRequest {
         _params: serde_json::Value,
         _timeout_ms: u64,
     ) -> Result<serde_json::Value, String> {
-        self.calls
-            .write()
-            .await
-            .push((target, method.to_string()));
+        self.calls.write().await.push((target, method.to_string()));
         Ok(json!({
             "messages": [
                 {"id": "provider-hist-1", "role": "assistant", "content": "provider history", "timestamp": 1}
@@ -503,7 +499,9 @@ impl GroupHistoryBotRequestPort for RecordingTargetHistoryBotRequest {
 async fn session_history_allows_human_who_is_only_session_participant() {
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
     let mut group = support.group.get("group-1").await.unwrap();
-    group.participants.retain(|participant| participant.is_bot());
+    group
+        .participants
+        .retain(|participant| participant.is_bot());
     support.group.upsert(group).await.unwrap();
 
     let mut responses = HashMap::new();
@@ -815,7 +813,9 @@ async fn session_history_denies_non_participant_bot() {
 async fn session_history_resolves_from_prefix_using_session_participants() {
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
     let mut group = support.group.get("group-1").await.unwrap();
-    group.participants.retain(|participant| participant.is_bot());
+    group
+        .participants
+        .retain(|participant| participant.is_bot());
     support.group.upsert(group).await.unwrap();
 
     let mut responses = HashMap::new();
@@ -1039,7 +1039,10 @@ async fn group_history_falls_back_to_driver_and_normalizes_bot_history() {
     let calls = history_request.calls.read().await.clone();
     assert_eq!(calls.len(), 2);
 
-    let observer_call = calls.iter().find(|c| c.0 == "bot-observer").expect("observer call");
+    let observer_call = calls
+        .iter()
+        .find(|c| c.0 == "bot-observer")
+        .expect("observer call");
     assert_eq!(observer_call.1, "chat.history");
     assert_eq!(
         observer_call.2,
@@ -1047,7 +1050,10 @@ async fn group_history_falls_back_to_driver_and_normalizes_bot_history() {
     );
     assert_eq!(observer_call.3, 30_000);
 
-    let driver_call = calls.iter().find(|c| c.0 == "bot-driver").expect("driver call");
+    let driver_call = calls
+        .iter()
+        .find(|c| c.0 == "bot-driver")
+        .expect("driver call");
     assert_eq!(driver_call.1, "chat.history");
     assert_eq!(
         driver_call.2,
@@ -1260,6 +1266,7 @@ async fn web_send_resets_message_count_routes_and_delivers() {
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
+            channel_sender_identity: None,
             sender_conn_id: None,
             provider_bypass_headers: Vec::new(),
         })
@@ -1325,6 +1332,7 @@ async fn web_send_persists_public_human_owner_for_manager_worker() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -1364,6 +1372,7 @@ async fn web_send_persists_public_human_owner_for_manager_worker() {
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
+            channel_sender_identity: None,
             sender_conn_id: None,
             provider_bypass_headers: Vec::new(),
         })
@@ -1408,6 +1417,7 @@ async fn accepted_chat_send_records_run_context_for_callback() {
             thinking: None,
             idempotency_key: Some("idempotency-1".to_string()),
             source_im_message_id: Some("source-msg-1".to_string()),
+            channel_sender_identity: None,
             sender_conn_id: None,
             provider_bypass_headers: Vec::new(),
         })
@@ -1430,14 +1440,8 @@ async fn accepted_chat_send_records_run_context_for_callback() {
             .as_deref(),
         Some("source-msg-1")
     );
-    assert!(
-        context.deadline_ms
-            >= before_send_ms.saturating_add(CONFIGURED_TIMEOUT_MS)
-    );
-    assert!(
-        context.deadline_ms
-            <= after_send_ms.saturating_add(CONFIGURED_TIMEOUT_MS)
-    );
+    assert!(context.deadline_ms >= before_send_ms.saturating_add(CONFIGURED_TIMEOUT_MS));
+    assert!(context.deadline_ms <= after_send_ms.saturating_add(CONFIGURED_TIMEOUT_MS));
 }
 
 #[tokio::test]
@@ -1497,6 +1501,7 @@ async fn web_send_delivers_to_registered_provider_target_without_ws_connection()
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
+            channel_sender_identity: None,
             sender_conn_id: None,
             provider_bypass_headers: Vec::new(),
         })
@@ -1540,6 +1545,7 @@ async fn failed_provider_web_send_uses_unified_system_message() {
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
+            channel_sender_identity: None,
             sender_conn_id: None,
             provider_bypass_headers: Vec::new(),
         })
@@ -1585,6 +1591,7 @@ async fn deprecated_provider_stream_gray_match_keeps_provider_delivery_target() 
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -1624,6 +1631,7 @@ async fn deprecated_provider_stream_gray_miss_keeps_provider_delivery_target() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -1663,6 +1671,7 @@ async fn deprecated_provider_stream_gray_disabled_keeps_provider_delivery_target
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -1720,6 +1729,7 @@ async fn deprecated_provider_stream_gray_does_not_change_inject_delivery_target(
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -1732,10 +1742,7 @@ async fn deprecated_provider_stream_gray_does_not_change_inject_delivery_target(
     assert!(targets[1].is_http_provider());
 }
 
-async fn install_provider_driver_group(
-    support: &support::FlowTestSupport,
-    created_by: &str,
-) {
+async fn install_provider_driver_group(support: &support::FlowTestSupport, created_by: &str) {
     support
         .registry
         .insert_named_actor("bot-provider", "Provider")
@@ -1843,6 +1850,7 @@ async fn web_send_explicit_mentions_do_not_inject_manager_worker_workers() {
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
+            channel_sender_identity: None,
             sender_conn_id: None,
             provider_bypass_headers: Vec::new(),
         })
@@ -1889,6 +1897,7 @@ async fn web_send_in_human_bot_dm_uses_dm_routing_and_keeps_frontend_echo() {
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
+            channel_sender_identity: None,
             sender_conn_id: None,
             provider_bypass_headers: Vec::new(),
         })
@@ -1940,6 +1949,7 @@ async fn web_send_in_human_bot_dm_omits_group_context_by_default() -> ServiceRes
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -1947,7 +1957,9 @@ async fn web_send_in_human_bot_dm_omits_group_context_by_default() -> ServiceRes
 
     let frames = support.bot_delivery.frames().await;
     let Some(BcsFrame::Request(req)) = frames.first() else {
-        return Err(ServiceError::InternalError("expected request frame".to_string()));
+        return Err(ServiceError::InternalError(
+            "expected request frame".to_string(),
+        ));
     };
     let Some(params) = req.params.as_ref() else {
         return Err(ServiceError::InternalError("expected params".to_string()));
@@ -1957,12 +1969,73 @@ async fn web_send_in_human_bot_dm_omits_group_context_by_default() -> ServiceRes
     };
     assert_eq!(text, "hello direct");
     let Some(participants) = params["session_context"]["participants"].as_array() else {
-        return Err(ServiceError::InternalError("expected participants".to_string()));
+        return Err(ServiceError::InternalError(
+            "expected participants".to_string(),
+        ));
     };
     assert_eq!(participants.len(), 0);
     assert!(params["session_context"].get("group_type").is_none());
     assert!(params["session_context"].get("routing_mode").is_none());
     assert!(params["session_context"].get("recipient_role").is_none());
+    Ok(())
+}
+
+#[tokio::test]
+async fn opted_in_channel_sender_identity_is_projected_to_bot_frame() -> ServiceResult<()> {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    support.registry.set_protocol_version("bot-driver", 3).await;
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    );
+
+    flow.handle_web_send(WebSendCommand {
+        caller: CallerContext::Human(HumanActor {
+            actor_id: "human_410025".to_string(),
+            staff_no: "410025".to_string(),
+        }),
+        group_id: "group-1".to_string(),
+        session_id: None,
+        from_actor_id: "human_410025".to_string(),
+        from_name: Some("张三".to_string()),
+        message: "hello direct".to_string(),
+        mentions: Vec::new(),
+        attachments: None,
+        thinking: None,
+        idempotency_key: None,
+        source_im_message_id: None,
+        channel_sender_identity: Some(ChannelSenderIdentity {
+            channel_type: "dingtalk".to_string(),
+            user_id: "410025".to_string(),
+            actor_id: "human_410025".to_string(),
+            display_name: "张三".to_string(),
+        }),
+        sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
+    })
+    .await?;
+
+    let frames = support.bot_delivery.frames().await;
+    assert!(frames.iter().any(
+        |frame| matches!(frame, BcsFrame::Request(request) if request.method == "chat.send")
+    ));
+    assert!(frames.iter().any(
+        |frame| matches!(frame, BcsFrame::Request(request) if request.method == "chat.inject")
+    ));
+    for frame in frames {
+        let BcsFrame::Request(request) = frame else {
+            continue;
+        };
+        let channel = &request.params.as_ref().unwrap()["channel"];
+        assert_eq!(channel["source"], "dingtalk");
+        assert_eq!(channel["user_id"], "410025");
+        assert_eq!(channel["actor_id"], "human_410025");
+        assert_eq!(channel["actor_name"], "张三");
+        assert_eq!(channel["identity_forwarding"], true);
+    }
     Ok(())
 }
 
@@ -1994,6 +2067,7 @@ async fn web_send_blocking_interceptor_prevents_bot_delivery() {
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
+            channel_sender_identity: None,
             sender_conn_id: None,
             provider_bypass_headers: Vec::new(),
         })
@@ -2037,6 +2111,7 @@ async fn web_send_delivery_frame_contains_recipient_group_context() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -2075,14 +2150,11 @@ async fn web_send_with_session_id_routes_v2_by_substituting_wire_group_id() {
     let session = test_session(
         session_id,
         "group-1",
-        vec![
-            Participant::bot("bot-driver", ParticipantRole::Driver),
-            {
-                let mut human = Participant::human("human_1", ParticipantRole::Observer);
-                human.mode = Some(ParticipantMode::Present);
-                human
-            },
-        ],
+        vec![Participant::bot("bot-driver", ParticipantRole::Driver), {
+            let mut human = Participant::human("human_1", ParticipantRole::Observer);
+            human.mode = Some(ParticipantMode::Present);
+            human
+        }],
     );
     let flow = BcsMessageFlow::new(
         support.group.clone(),
@@ -2108,6 +2180,7 @@ async fn web_send_with_session_id_routes_v2_by_substituting_wire_group_id() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -2115,7 +2188,11 @@ async fn web_send_with_session_id_routes_v2_by_substituting_wire_group_id() {
     .unwrap();
 
     let frames = support.bot_delivery.frames().await;
-    assert_eq!(frames.len(), 1, "session participants should exclude bot-observer");
+    assert_eq!(
+        frames.len(),
+        1,
+        "session participants should exclude bot-observer"
+    );
     let frontend_commands = support.frontend_delivery.commands().await;
     assert_eq!(
         frontend_commands[0].target,
@@ -2143,14 +2220,11 @@ async fn web_send_with_legacy_session_id_routes_v2_with_group_wire_id() {
     let session = test_session(
         session_id,
         "group-1",
-        vec![
-            Participant::bot("bot-driver", ParticipantRole::Driver),
-            {
-                let mut human = Participant::human("human_1", ParticipantRole::Observer);
-                human.mode = Some(ParticipantMode::Present);
-                human
-            },
-        ],
+        vec![Participant::bot("bot-driver", ParticipantRole::Driver), {
+            let mut human = Participant::human("human_1", ParticipantRole::Observer);
+            human.mode = Some(ParticipantMode::Present);
+            human
+        }],
     );
     let flow = BcsMessageFlow::new(
         support.group.clone(),
@@ -2176,6 +2250,7 @@ async fn web_send_with_legacy_session_id_routes_v2_with_group_wire_id() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -2201,14 +2276,11 @@ async fn web_send_with_session_id_routes_v3_with_explicit_bcs_session_id() {
     let session = test_session(
         session_id,
         "group-1",
-        vec![
-            Participant::bot("bot-driver", ParticipantRole::Driver),
-            {
-                let mut human = Participant::human("human_1", ParticipantRole::Observer);
-                human.mode = Some(ParticipantMode::Present);
-                human
-            },
-        ],
+        vec![Participant::bot("bot-driver", ParticipantRole::Driver), {
+            let mut human = Participant::human("human_1", ParticipantRole::Observer);
+            human.mode = Some(ParticipantMode::Present);
+            human
+        }],
     );
     let flow = BcsMessageFlow::new(
         support.group.clone(),
@@ -2234,6 +2306,7 @@ async fn web_send_with_session_id_routes_v3_with_explicit_bcs_session_id() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -2268,7 +2341,11 @@ async fn web_send_to_provider_with_session_id_uses_explicit_bcs_session_id() {
         .find(|participant| participant.bot_uuid == "bot-observer")
         .expect("observer participant")
         .tags = vec!["stale-observer-tag".to_string()];
-    support.group.upsert(group).await.expect("update group tags");
+    support
+        .group
+        .upsert(group)
+        .await
+        .expect("update group tags");
     support
         .registry
         .set_delivery_target(
@@ -2290,15 +2367,11 @@ async fn web_send_to_provider_with_session_id_uses_explicit_bcs_session_id() {
     let session = test_session(
         session_id,
         "group-1",
-        vec![
-            provider,
-            observer,
-            {
-                let mut human = Participant::human("human_1", ParticipantRole::Observer);
-                human.mode = Some(ParticipantMode::Present);
-                human
-            },
-        ],
+        vec![provider, observer, {
+            let mut human = Participant::human("human_1", ParticipantRole::Observer);
+            human.mode = Some(ParticipantMode::Present);
+            human
+        }],
     );
     let flow = BcsMessageFlow::new(
         support.group.clone(),
@@ -2324,6 +2397,7 @@ async fn web_send_to_provider_with_session_id_uses_explicit_bcs_session_id() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -2332,12 +2406,14 @@ async fn web_send_to_provider_with_session_id_uses_explicit_bcs_session_id() {
 
     let frames = support.bot_delivery.frames().await;
     assert_eq!(frames.len(), 2);
-    assert!(support
-        .bot_delivery
-        .targets()
-        .await
-        .iter()
-        .all(BotDeliveryTarget::is_http_provider));
+    assert!(
+        support
+            .bot_delivery
+            .targets()
+            .await
+            .iter()
+            .all(BotDeliveryTarget::is_http_provider)
+    );
     let send = frames
         .iter()
         .find(|frame| matches!(frame, BcsFrame::Request(req) if req.method == "chat.send"))
@@ -2371,15 +2447,12 @@ async fn web_send_direct_bot_projection_hides_bcs_group_context() -> ServiceResu
     let mut session = test_session(
         session_id,
         "group-1",
-        vec![
-            Participant::bot("bot-driver", ParticipantRole::Driver),
-            {
-                let mut human = Participant::human("human_1", ParticipantRole::Observer);
-                human.mode = Some(ParticipantMode::Present);
-                human.bot_name = Some("张三".to_string());
-                human
-            },
-        ],
+        vec![Participant::bot("bot-driver", ParticipantRole::Driver), {
+            let mut human = Participant::human("human_1", ParticipantRole::Observer);
+            human.mode = Some(ParticipantMode::Present);
+            human.bot_name = Some("张三".to_string());
+            human
+        }],
     );
     session.meta = Some(json!({
         "channel": {
@@ -2411,6 +2484,7 @@ async fn web_send_direct_bot_projection_hides_bcs_group_context() -> ServiceResu
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -2418,7 +2492,9 @@ async fn web_send_direct_bot_projection_hides_bcs_group_context() -> ServiceResu
 
     let frames = support.bot_delivery.frames().await;
     let Some(BcsFrame::Request(req)) = frames.first() else {
-        return Err(ServiceError::InternalError("expected request frame".to_string()));
+        return Err(ServiceError::InternalError(
+            "expected request frame".to_string(),
+        ));
     };
     let Some(params) = req.params.as_ref() else {
         return Err(ServiceError::InternalError("expected params".to_string()));
@@ -2429,7 +2505,9 @@ async fn web_send_direct_bot_projection_hides_bcs_group_context() -> ServiceResu
     assert_eq!(text, "帮我查一下");
     assert_eq!(params["session_context"]["session_id"], session_id);
     let Some(participants) = params["session_context"]["participants"].as_array() else {
-        return Err(ServiceError::InternalError("expected participants".to_string()));
+        return Err(ServiceError::InternalError(
+            "expected participants".to_string(),
+        ));
     };
     assert_eq!(participants.len(), 0);
     assert!(params["session_context"].get("group_type").is_none());
@@ -2472,6 +2550,7 @@ async fn web_send_prefers_human_from_name_in_delivered_frame() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -2525,6 +2604,7 @@ async fn web_send_inject_delivery_uses_event_frame() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })
@@ -2580,6 +2660,7 @@ async fn web_send_delivers_to_private_group_targets() {
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
+            channel_sender_identity: None,
             sender_conn_id: None,
             provider_bypass_headers: Vec::new(),
         })
@@ -2588,16 +2669,20 @@ async fn web_send_delivers_to_private_group_targets() {
 
     assert_eq!(outcome.delivered_count, 2);
     assert_eq!(outcome.failed_count, 0);
-    assert!(outcome
-        .delivery_results
-        .iter()
-        .any(|result| result.bot_uuid == "bot-observer" && result.success));
+    assert!(
+        outcome
+            .delivery_results
+            .iter()
+            .any(|result| result.bot_uuid == "bot-observer" && result.success)
+    );
     assert_eq!(support.bot_delivery.frames().await.len(), 2);
-    assert!(support
-        .bot_delivery
-        .kinds()
-        .await
-        .contains(&BotDeliveryKind::Inject));
+    assert!(
+        support
+            .bot_delivery
+            .kinds()
+            .await
+            .contains(&BotDeliveryKind::Inject)
+    );
 }
 
 #[tokio::test]
@@ -2628,6 +2713,7 @@ async fn web_send_partial_delivery_failure_is_represented_in_outcome() {
             thinking: None,
             idempotency_key: None,
             source_im_message_id: None,
+            channel_sender_identity: None,
             sender_conn_id: None,
             provider_bypass_headers: Vec::new(),
         })
@@ -2748,10 +2834,7 @@ async fn group_chat_rejects_bot_that_is_not_a_session_participant() {
     let session = test_session(
         session_id,
         "group-1",
-        vec![Participant::bot(
-            "bot-driver",
-            ParticipantRole::Driver,
-        )],
+        vec![Participant::bot("bot-driver", ParticipantRole::Driver)],
     );
     let flow = BcsMessageFlow::new(
         support.group.clone(),
@@ -2789,10 +2872,7 @@ async fn group_chat_rejects_session_from_another_group() {
     let session = test_session(
         session_id,
         "other-group",
-        vec![Participant::bot(
-            "bot-driver",
-            ParticipantRole::Driver,
-        )],
+        vec![Participant::bot("bot-driver", ParticipantRole::Driver)],
     );
     let flow = BcsMessageFlow::new(
         support.group.clone(),
@@ -3667,7 +3747,9 @@ async fn group_history_prefers_high_priority_even_when_low_priority_finishes_fir
         })),
     );
 
-    let bot_request = Arc::new(ControllableHistoryBotRequest::with_delays(delays, responses));
+    let bot_request = Arc::new(ControllableHistoryBotRequest::with_delays(
+        delays, responses,
+    ));
     let history = BcsGroupMessageHistory::new(
         support.group.clone(),
         support.registry.clone(),
@@ -3720,7 +3802,9 @@ async fn group_history_falls_back_to_driver_when_view_bot_fails() {
         })),
     );
 
-    let bot_request = Arc::new(ControllableHistoryBotRequest::with_delays(delays, responses));
+    let bot_request = Arc::new(ControllableHistoryBotRequest::with_delays(
+        delays, responses,
+    ));
     let history = BcsGroupMessageHistory::new(
         support.group.clone(),
         support.registry.clone(),
@@ -3764,12 +3848,11 @@ async fn group_history_falls_back_to_store_when_all_bots_fail() {
         "bot-observer".to_string(),
         Err("observer_timeout".to_string()),
     );
-    responses.insert(
-        "bot-driver".to_string(),
-        Err("driver_timeout".to_string()),
-    );
+    responses.insert("bot-driver".to_string(), Err("driver_timeout".to_string()));
 
-    let bot_request = Arc::new(ControllableHistoryBotRequest::with_delays(delays, responses));
+    let bot_request = Arc::new(ControllableHistoryBotRequest::with_delays(
+        delays, responses,
+    ));
     let history = BcsGroupMessageHistory::new(
         support.group.clone(),
         support.registry.clone(),
@@ -3832,7 +3915,10 @@ fn file_attachment() -> bcs_domain::Attachment {
     }
 }
 
-fn human_web_send(message: &str, attachments: Option<Vec<bcs_domain::Attachment>>) -> WebSendCommand {
+fn human_web_send(
+    message: &str,
+    attachments: Option<Vec<bcs_domain::Attachment>>,
+) -> WebSendCommand {
     WebSendCommand {
         caller: CallerContext::Human(HumanActor {
             actor_id: "human_1".to_string(),
@@ -3848,6 +3934,7 @@ fn human_web_send(message: &str, attachments: Option<Vec<bcs_domain::Attachment>
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     }
@@ -3915,7 +4002,9 @@ async fn temporary_file_attachment_is_sent_only_to_active_chat_send() {
     let inject = frames
         .iter()
         .find_map(|frame| match frame {
-            BcsFrame::Request(request) if request.method == "chat.inject" => request.params.as_ref(),
+            BcsFrame::Request(request) if request.method == "chat.inject" => {
+                request.params.as_ref()
+            }
             _ => None,
         })
         .expect("chat.inject params");
@@ -4009,6 +4098,7 @@ async fn web_send_persists_raw_mention_text_while_bots_receive_cleaned_text() {
         thinking: None,
         idempotency_key: None,
         source_im_message_id: None,
+        channel_sender_identity: None,
         sender_conn_id: None,
         provider_bypass_headers: Vec::new(),
     })


### PR DESCRIPTION
## Problem

Human messages entering through a Channel did not carry sender attribution to downstream bots and HTTP Providers. Agents therefore could not reliably tell which person sent a message, and ClawMind could not collect that identity from the final prompt.

## Solution

- Add the opt-in Bot binding setting `forward_sender_identity`, defaulting to `false`; reject non-boolean values and reject enabling it on Group bindings.
- For ordinary Human Channel messages, project the trusted staff number and current inbound nickname into the BCS frame after slash-command and HumanInput handling.
- Map opted-in identity into OpenClaw standard sender metadata.
- Prefix only HTTP Provider `chat.send`/`chat.inject` request-copy text with serialized `{"sender":{"id":"...","name":"..."}}` JSON, without changing Provider parameters or persisted message content.
- Keep slash commands, HumanInput replies, Group bindings, non-Channel entry points, outbound flows, synthetic messages, and legacy resolver behavior unchanged.
- Fall back to the trusted staff number when the inbound nickname is absent or blank.

## Validation

- `cargo test -p bcs-protocol -p bcs-channel -p bcs-message-flow -p bcs-provider-http --no-fail-fast`
- `npm run lint`
- `npm run prepublishOnly`
- `npm run test-local` — 61 passing
- `git diff --check origin/dev...HEAD`
- Rebased onto latest `origin/dev` (`8182e771dd`) and reran the tests above successfully.
- Commit and push used `--no-verify`; the relevant gates were run explicitly as listed above.

## Compatibility and risk

The setting is off by default and requires no binding migration. Existing bindings and sender resolvers keep their current behavior unless a Bot binding opts in. Forwarded sender data is attribution metadata only and must not be used for authentication or authorization.