### PR TITLE
feat(backend): add owner-level routines aggregate to the public API

### DIFF
--- a/docs/superpowers/plans/2026-08-27-owner-routines-aggregate.md
+++ b/docs/superpowers/plans/2026-08-27-owner-routines-aggregate.md
@@ -1,0 +1,658 @@
+# Owner 级定时任务聚合列表 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增公开面端点 `GET /openapi/v1/bots/routines/all`，返回认证用户名下所有 bot（含协作参与）的全部运行态定时任务，每条带 `bot_name`。
+
+**Architecture:** 服务层 `list_all_crons`（`core/cron/services/cron_relay.py`）已完整具备 owner 级 fan-out、bot_name 装饰、按 (bot, stage, task) 去重、部分失败容忍——本计划只是公开面薄适配：扩展 `Routine` schema（纯加法可选字段）、新增一个不含 bot 寻址的小 router、在 admission/authorization 两张表声明、挂进 `_SUBGROUPS`（先于 legacy shim，避免 `/routines/{routine_id}` 吞掉字面量 `all`）、重新生成网关契约。
+
+**Tech Stack:** FastAPI + Pydantic（openapi_v1 公开面）、pytest（handler 直调模式）、`scripts/dump_openapi.py`（契约再生成）。
+
+**Spec:** `docs/superpowers/specs/2026-08-27-owner-routines-aggregate-openapi-design.md`
+
+**设计修正（相对 spec §5/§7 的两处，实现以本计划为准）：**
+1. **准入模式 = `USER_GATED`（非 spec 草案里的 GRANT_FILTERED）**：GRANT_FILTERED 承诺"结果按应用授权过滤"，但 `list_all_crons` 不按授权过滤，声明它即是撒谎。对齐最近似兄弟路由 `GET /bots/ceiling` 的 USER_GATED 模式：app-only 调用者须持有该用户至少一个实时 delegation（handler 内检查 `caller.granted_bot_ids()`），无 delegation 时以 `BotNotFoundError`（404 信封）拒答。人类调用者不受影响。gateway 侧无需任何改动（宽泛 `/openapi/v1/bots/**` 规则已覆盖，REFUSED 才需要双写 route_security）。
+2. **三个新字段统一由 `_map_routine` 映射**（不做按路由的条件映射）：服务层 `_decorate_runtime_item` 对所有出参都装饰 `bot_id/bot_name/owner_id`（服务型 bot 另加 `runtime_stage`），per-bot 路由免费获得 bot_name 回填，无需分支。
+
+**测试命令目录约定：** 所有 pytest 命令在 `/Users/rongzhi/PycharmProjects/Avernet/src/backend` 下执行，用 `.venv/bin/python -m pytest`（uv venv；不存在则先 `uv sync --frozen`）。
+
+---
+
+### Task 1: `Routine` schema 扩展 + `_map_routine` 映射三个新字段
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/schemas.py`（`Routine` 模型，约 52-97 行）
+- Modify: `src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/router.py`（`_map_routine`，约 73-94 行）
+- Test: `src/backend/tests/community/adapters/http/openapi_v1/routines/test_routines_handlers.py`（在 `_map_routine` 测试节追加）
+
+- [ ] **Step 1: 写失败测试**（追加到 `test_routines_handlers.py` 的 `_map_routine` 测试节之后）
+
+```python
+def test_map_routine_carries_bot_metadata():
+    """The aggregate listing decorates every adapter item with bot/owner/stage.
+
+    ``cron_runtime_targets.py`` decorates ``bot_id``/``bot_name``/``owner_id``
+    on every item and ``runtime_stage`` on a service bot's — the owner-level
+    listing needs all of them mapped, and the per-bot route answers
+    ``bot_name`` from the same dict for free.
+    """
+    adapter = _adapter_dict(
+        bot_name="TicketBot",
+        owner_id="209800",
+        runtime_stage="online",
+    )
+    r = _map_routine(adapter)
+    assert r.bot_name == "TicketBot"
+    assert r.owner_id == "209800"
+    assert r.runtime_stage == "online"
+
+
+def test_map_routine_bot_metadata_defaults_to_none():
+    """Absent or empty decoration maps to None, never to an empty string.
+
+    The three metadata fields are optional additions; a producer that reports
+    none (e.g. a draft-stage item has no ``runtime_stage``) must surface as
+    null, which is what the schema documents.
+    """
+    r = _map_routine({})
+    assert r.bot_name is None
+    assert r.owner_id is None
+    assert r.runtime_stage is None
+    r_blank = _map_routine({"bot_name": "", "owner_id": "", "runtime_stage": ""})
+    assert r_blank.bot_name is None
+    assert r_blank.owner_id is None
+    assert r_blank.runtime_stage is None
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `.venv/bin/python -m pytest tests/community/adapters/http/openapi_v1/routines/test_routines_handlers.py -v -k "carries_bot_metadata or bot_metadata_defaults"`
+Expected: FAIL —— `Routine` 无 `bot_name` 属性（`AttributeError` / pydantic 校验错）
+
+- [ ] **Step 3: 扩展 `Routine` schema**
+
+在 `schemas.py` `Routine` 的 `bot_id` 字段后插入（保持字段顺序：身份字段聚在一起）：
+
+```python
+    bot_name: str | None = Field(
+        default=None,
+        description="Name of the bot the routine belongs to; null when the "
+        "engine reports none.",
+    )
+    owner_id: str | None = Field(
+        default=None,
+        description="The bot owner's staff id; null when the engine reports "
+        "none.",
+    )
+    runtime_stage: str | None = Field(
+        default=None,
+        description="Which runtime holds this definition — 'draft', 'verify' "
+        "or 'online' for a service bot, null otherwise. The same definition "
+        "can exist in several runtimes; on a cross-bot list treat the pair "
+        "(routine_id, runtime_stage) as the distinct row.",
+    )
+```
+
+并在 `model_config` 的 `example` 里补三行（`"bot_id": ...` 之后）：
+
+```python
+                "bot_name": "TicketBot",
+                "owner_id": "209800",
+                "runtime_stage": "draft",
+```
+
+- [ ] **Step 4: 扩展 `_map_routine` 映射**
+
+`router.py` `_map_routine` 的 `Routine(...)` 构造里，`bot_id=...` 行后追加：
+
+```python
+        bot_name=str(data.get("bot_name", "")) or None,
+        owner_id=str(data.get("owner_id", "")) or None,
+        runtime_stage=str(data.get("runtime_stage", "")) or None,
+```
+
+（`"" → None` 归一化：字段 schema 是 `str | None`，描述写的是 "null when the engine reports none"。`bot_id` 保持原有 `""` 约定不动——它是 required，语义是 "may be empty on the detail read"。）
+
+- [ ] **Step 5: 跑全文件测试确认通过、无回归**
+
+Run: `.venv/bin/python -m pytest tests/community/adapters/http/openapi_v1/routines/test_routines_handlers.py -v`
+Expected: PASS（全绿；既有测试的 `_adapter_dict` 基字典无新键 → 映射为 None，不影响旧断言）
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/schemas.py \
+        src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/router.py \
+        src/backend/tests/community/adapters/http/openapi_v1/routines/test_routines_handlers.py
+git commit -m "feat(backend): extend Routine schema with bot_name/owner_id/runtime_stage"
+```
+
+---
+
+### Task 2: owner 聚合路由 `owner_router.py`（handler TDD）
+
+**Files:**
+- Create: `src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/owner_router.py`
+- Modify: `src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py`（NoCheck 表，约 378-381 行 "Operations that address no bot" 节）
+- Modify: `src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py`（ADMISSION 表，约 250 行 routines 节）
+- Test: `src/backend/tests/community/adapters/http/openapi_v1/routines/test_owner_routines.py`（新建）
+
+- [ ] **Step 1: 写失败测试**（新文件 `test_owner_routines.py`，handler 直调模式与 `test_routines_handlers.py` 一致）
+
+```python
+"""openapi_v1 owner-level routine listing handler unit tests."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    CODE_OK,
+    Envelope,
+    Page,
+    PageParams,
+)
+from agentclaw.community.adapters.http.openapi_v1.admission import ActingCaller
+from agentclaw.community.adapters.http.openapi_v1.routines.owner_router import (
+    list_owner_routines,
+)
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotNotFoundError,
+)
+
+
+def _human(user_id: str) -> ActingCaller:
+    """A caller with a person on the wire — no grant governs the request."""
+    return ActingCaller(user_id=user_id, app_id=None)
+
+
+def _app_with_delegations(user_id: str, *bot_ids: str) -> ActingCaller:
+    """An application caller holding one live delegation per named bot.
+
+    ``granted_bot_ids()`` reads the grant protocol; a stub returning the
+    records inline keeps the handler test off the database.
+    """
+
+    class _Grants:
+        def list_for_app(self, *, app_id, user_id):
+            return [
+                SimpleNamespace(bot_id=b, owner_id=user_id) for b in bot_ids
+            ]
+
+    return ActingCaller(
+        user_id=user_id, app_id=7, grants=_Grants()
+    )
+
+
+def _request_without_trace() -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace())
+
+
+class _StubCronService:
+    """Minimal stub satisfying the CronRelayServiceProtocol list_all_crons seam."""
+
+    def __init__(self, payload):
+        self._payload = payload
+        self.last_call_kwargs: dict = {}
+
+    async def list_all_crons(self, *args, **kwargs):
+        self.last_call_kwargs = dict(kwargs)
+        return {"success": True, "data": self._payload, "total": len(self._payload)}
+
+
+def _adapter_dict(**overrides):
+    base = {
+        "id": "t1",
+        "bot_id": "bot-x",
+        "bot_name": "Bot X",
+        "owner_id": "u1",
+        "runtime_stage": "online",
+        "name": "cron1",
+        "enabled": True,
+        "schedule": {"expr": "0 9 * * *", "tz": "Asia/Shanghai"},
+        "payload": {"message": "echo hi"},
+        "created_at_ms": 1722165600000,
+        "updated_at_ms": 1722165600000,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_returns_envelope_page_with_bot_metadata():
+    service = _StubCronService([_adapter_dict()])
+
+    env = await list_owner_routines(
+        page=PageParams(page=1, page_size=20),
+        owner_id="u1",
+        caller=_human("u1"),
+        factory=service,
+        request=_request_without_trace(),
+    )
+
+    assert isinstance(env, Envelope)
+    assert env.code == CODE_OK
+    assert env.message == "OK"
+    assert env.data is not None
+    assert isinstance(env.data, Page)
+    assert env.data.total == 1
+    item = env.data.items[0]
+    assert item.bot_id == "bot-x"
+    assert item.bot_name == "Bot X"
+    assert item.owner_id == "u1"
+    assert item.runtime_stage == "online"
+
+
+@pytest.mark.asyncio
+async def test_asks_for_the_user_whole_fleet_all_stages():
+    """The aggregate names no bot and no runtime stage.
+
+    ``bot_id=None`` is the service's all-bots mode and ``runtime_stage=None``
+    aggregates draft, verify and online — the opposite of the per-bot draft
+    workspace the rest of the routines group serves.
+    """
+    service = _StubCronService([])
+
+    await list_owner_routines(
+        page=PageParams(page=1, page_size=20),
+        owner_id="u1",
+        caller=_human("u1"),
+        factory=service,
+        request=_request_without_trace(),
+    )
+
+    assert service.last_call_kwargs.get("user_id") == "u1"
+    assert service.last_call_kwargs.get("nick_name") == "u1"
+    assert service.last_call_kwargs.get("bot_id") is None
+    assert service.last_call_kwargs.get("runtime_stage") is None
+
+
+@pytest.mark.asyncio
+async def test_paginates_items():
+    service = _StubCronService(
+        [_adapter_dict(id="t1"), _adapter_dict(id="t2"), _adapter_dict(id="t3")]
+    )
+
+    env = await list_owner_routines(
+        page=PageParams(page=2, page_size=1),
+        owner_id="u1",
+        caller=_human("u1"),
+        factory=service,
+        request=_request_without_trace(),
+    )
+
+    assert env.data.total == 3
+    assert [i.routine_id for i in env.data.items] == ["t2"]
+
+
+@pytest.mark.asyncio
+async def test_empty_fleet_answers_an_empty_page():
+    service = _StubCronService([])
+
+    env = await list_owner_routines(
+        page=PageParams(page=1, page_size=20),
+        owner_id="u1",
+        caller=_human("u1"),
+        factory=service,
+        request=_request_without_trace(),
+    )
+
+    assert env.code == CODE_OK
+    assert env.data.total == 0
+    assert env.data.items == []
+
+
+@pytest.mark.asyncio
+async def test_refuses_an_application_with_no_delegation():
+    """An app naming a user it holds no delegation from learns nothing.
+
+    Same gate and same answer as the ceiling: the refusal is a 404 shaped by
+    ``envelope_errors`` from ``BotNotFoundError``, so it is indistinguishable
+    from a user who does not exist.
+    """
+    service = _StubCronService([_adapter_dict()])
+    # granted_bot_ids(): app_id set, grants None → frozenset() → refused.
+    stranger = ActingCaller(user_id="u1", app_id=7)
+
+    with pytest.raises(BotNotFoundError):
+        await list_owner_routines(
+            page=PageParams(page=1, page_size=20),
+            owner_id="u1",
+            caller=stranger,
+            factory=service,
+            request=_request_without_trace(),
+        )
+    assert service.last_call_kwargs == {}
+
+
+@pytest.mark.asyncio
+async def test_admits_an_application_with_a_delegation():
+    service = _StubCronService([_adapter_dict()])
+
+    env = await list_owner_routines(
+        page=PageParams(page=1, page_size=20),
+        owner_id="u1",
+        caller=_app_with_delegations("u1", "bot-x"),
+        factory=service,
+        request=_request_without_trace(),
+    )
+
+    assert env.code == CODE_OK
+    assert env.data.total == 1
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_returns_the_successes():
+    """A dict-shaped ``data`` envelope unwraps to its ``items``.
+
+    The service may answer ``{"data": {"items": [...]}}`` on partial failure
+    paths; the listing keeps the succeeded rows like the per-bot route does,
+    and never surfaces ``failed_targets`` on the public face.
+    """
+    service = _StubCronService({"items": [_adapter_dict(id="t1")]})
+
+    env = await list_owner_routines(
+        page=PageParams(page=1, page_size=20),
+        owner_id="u1",
+        caller=_human("u1"),
+        factory=service,
+        request=_request_without_trace(),
+    )
+
+    assert env.data.total == 1
+    assert env.data.items[0].routine_id == "t1"
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `.venv/bin/python -m pytest tests/community/adapters/http/openapi_v1/routines/test_owner_routines.py -v`
+Expected: FAIL —— `ModuleNotFoundError: No module named '...routines.owner_router'`
+
+- [ ] **Step 3: 创建 `owner_router.py`**
+
+```python
+"""Owner-level routine listing — ``GET /openapi/v1/bots/routines/all``.
+
+The per-bot group lists one bot's draft workspace; this route aggregates the
+named user's whole fleet — bots owned or collaborated on — across every
+runtime stage, the way the legacy ``/api/cron`` listing always did. The
+service layer owns the fan-out, the bot_name decoration, the per-stage dedup
+and the partial-failure tolerance; this is the public-face adapter over it.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    Envelope,
+    Page,
+    PageParamsDep,
+)
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    ActingCallerDep,
+    UserIdDep,
+)
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    envelope_errors,
+    page as page_envelope,
+)
+from agentclaw.community.adapters.http.openapi_v1.authorization import (
+    PublicAPIRoute,
+)
+from agentclaw.community.adapters.http.openapi_v1.log_safe import for_log
+from agentclaw.community.api.cron_relay_service import (
+    CronRelayServiceProtocol,
+)
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotNotFoundError,
+)
+from agentclaw.community.di import Injected
+from agentclaw.community.log import get_logger
+
+from .router import _map_routine
+from .schemas import Routine
+
+router = APIRouter(
+    prefix="/openapi/v1/bots/routines/all",
+    tags=["routines"],
+    route_class=PublicAPIRoute,
+)
+
+logger = get_logger()
+
+
+@router.get("", response_model=Envelope[Page[Routine]])
+@envelope_errors
+async def list_owner_routines(
+    page: PageParamsDep,
+    owner_id: UserIdDep,
+    caller: ActingCallerDep,
+    request: Request,
+    factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
+) -> Envelope[Page[Routine]]:
+    """List the named user's routines across all their bots (paginated).
+
+    Every runtime stage is aggregated — draft, verify and online — so a
+    service bot's published runtimes appear alongside its draft workspace,
+    and one definition can answer more than one row, differing by
+    ``runtime_stage``. Bots the user collaborates on are included, matching
+    the listing the internal console has always shown.
+    """
+    # Names no bot, so there is no grant to check against one — but the
+    # answer is still about a person's fleet, and a stranger application must
+    # not read it by naming a user id. Gated like the ceiling: an application
+    # needs at least one live delegation from the named user; without one the
+    # user is answered as if they did not exist.
+    granted = caller.granted_bot_ids()
+    if granted is not None and not granted:
+        logger.warning(
+            "[owner routines] app holds no delegation from user=%s; "
+            "refusing the listing",
+            for_log(owner_id),
+        )
+        raise BotNotFoundError("no authorization from the named user")
+    result = await factory.list_all_crons(
+        user_id=owner_id,
+        nick_name=owner_id,
+        bot_id=None,
+        runtime_stage=None,
+    )
+    data = result.get("data") if isinstance(result, dict) else None
+    if isinstance(data, list):
+        items_list = data
+    elif isinstance(data, dict):
+        items_list = data.get("items", [])
+    else:
+        items_list = []
+    mapped = [_map_routine(d) for d in items_list if isinstance(d, dict)]
+    start = (page.page - 1) * page.page_size
+    end = start + page.page_size
+    page_items = mapped[start:end]
+    return page_envelope(len(mapped), page_items, request)
+```
+
+- [ ] **Step 4: 声明 authorization NoCheck 条目**
+
+`authorization.py` 的 "── Operations that address no bot ──" 节（`("GET", "/openapi/v1/bots/all")` 行附近）追加：
+
+```python
+    ("GET", "/openapi/v1/bots/routines/all"):
+        NoCheck("a collection, not one addressed bot"),
+```
+
+- [ ] **Step 5: 声明 admission 条目**
+
+`admission.py` ADMISSION 表 routines 节（`("GET", "/openapi/v1/bots/{bot_id}/routines")` 行附近，250 行区域）追加：
+
+```python
+    # The owner-level aggregate lists the named user's fleet, not one bot —
+    # gated on a live delegation like the ceiling (see owner_router).
+    ("GET", "/openapi/v1/bots/routines/all"): AdmissionMode.USER_GATED,
+```
+
+- [ ] **Step 6: 跑 Task 2 测试确认通过**
+
+Run: `.venv/bin/python -m pytest tests/community/adapters/http/openapi_v1/routines/test_owner_routines.py -v`
+Expected: PASS（7 条全绿）
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/owner_router.py \
+        src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py \
+        src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py \
+        src/backend/tests/community/adapters/http/openapi_v1/routines/test_owner_routines.py
+git commit -m "feat(backend): add GET /openapi/v1/bots/routines/all owner aggregate"
+```
+
+---
+
+### Task 3: 挂载进 `_SUBGROUPS` + 库存/次序测试验证
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py`（import 区约 220 行 + `_SUBGROUPS` 约 285 行）
+
+- [ ] **Step 1: 加 import**
+
+`from .routines import router as routines_router` 后追加：
+
+```python
+from .routines.owner_router import router as routines_owner_router
+```
+
+- [ ] **Step 2: 挂进 `_SUBGROUPS`**
+
+`_SUBGROUPS = [` 列表追加（带次序注释）：
+
+```python
+    # The owner-level routine aggregate is a literal under `bots/routines` —
+    # it must mount before the *legacy* routines shim's `/{routine_id}`
+    # wildcard (which the legacy groups, mounted later, contribute) or that
+    # route captures a literal "all" as a routine id.
+    routines_owner_router,
+```
+
+（`_SUBGROUPS` 挂载点只有 `_PUBLIC_AUTH` + USER_SCOPED 错误表——正对该路由"集合、无被寻址 bot"的形状；grant 检查不需要。）
+
+- [ ] **Step 3: 跑库存与次序测试**
+
+Run: `.venv/bin/python -m pytest tests/community/adapters/http/openapi_v1/test_admission_inventory.py tests/community/adapters/http/openapi_v1/test_authorization_inventory.py -v`
+Expected: PASS（两表与路由面完全一致；这说明新路由的两条声明被看见了，且挂载的依赖形状与声明的模式相符）
+
+Run: `.venv/bin/python -m pytest tests/community/adapters/http/openapi_v1/ tests/community/endpoints/test_openapi_routines.py tests/community/endpoints/test_openapi_legacy_routines_resources.py -v`
+Expected: PASS（路由包全量 + 既有 routines endpoint 测试 + legacy parity 测试全部不回归）
+
+- [ ] **Step 4: 手动冒烟确认路由次序（防 `all` 被吞）**
+
+Run: `.venv/bin/python -c "
+from agentclaw.community.adapters.http.openapi_v1 import build_public_router
+r = build_public_router()
+paths = [route.path for route in r.routes if getattr(route, 'path', '')]
+idx_all = paths.index('/openapi/v1/bots/routines/all')
+idx_legacy = paths.index('/openapi/v1/bots/routines/{routine_id}')
+assert idx_all < idx_legacy, (idx_all, idx_legacy)
+print('ordering ok: routines/all at', idx_all, 'before legacy {routine_id} at', idx_legacy)
+"`
+Expected: 输出 `ordering ok: ...`（若 `paths.index` 抛 ValueError，说明路由没挂上）
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+git commit -m "feat(backend): mount owner routines aggregate before legacy shim"
+```
+
+---
+
+### Task 4: 网关契约再生成 + README 记录
+
+**Files:**
+- Regenerate: `src/gateway/configs/schemas/bots.openapi.json`
+- Modify: `src/backend/docs/openapi-v1/README.zh-CN.md`（变更记录节）
+
+- [ ] **Step 1: 重新生成契约**
+
+Run（在 `src/backend` 下）:
+```bash
+.venv/bin/python scripts/dump_openapi.py ../gateway/configs/schemas/bots.openapi.json
+```
+Expected: `wrote public OpenAPI to ../gateway/configs/schemas/bots.openapi.json`
+
+- [ ] **Step 2: 核对 diff**
+
+Run: `cd /Users/rongzhi/PycharmProjects/Avernet && git diff --stat src/gateway/configs/schemas/bots.openapi.json && git diff src/gateway/configs/schemas/bots.openapi.json | grep -c '"bot_name"'`
+Expected: diff 只含新 path `/openapi/v1/bots/routines/all`、`Routine` 三新字段及关联 required/example 变化；`"bot_name"` 计数 ≥5（schema 字段定义 + example）
+
+- [ ] **Step 3: 跑 gateway 侧 schema 相关测试**
+
+Run: `cd /Users/rongzhi/PycharmProjects/Avernet/src/gateway && .venv/bin/python -m pytest tests/unit/core/forwarding/ tests/integration/baseline/test_startup.py -v 2>/dev/null || uv run --frozen python -m pytest tests/unit/core/forwarding/ tests/integration/baseline/test_startup.py -v`
+Expected: PASS（pinned 契约与转发目录测试均绿；若 gateway venv 结构不同，按其 README/CI 惯例命令跑）
+
+- [ ] **Step 4: README 变更记录**
+
+`src/backend/docs/openapi-v1/README.zh-CN.md` 变更记录节（倒序，最新在上）加条目：
+
+```markdown
+- **2026-08-27** —— **Owner 级定时任务聚合列表。** 新增
+  `GET /openapi/v1/bots/routines/all`：按认证用户聚合其名下（含协作参与）所有 Bot
+  的定时任务，全部运行态（draft/verify/online）平铺，同一配置跨运行态可多行并以
+  `runtime_stage` 区分；`Routine` 纯加法扩展可选字段
+  `bot_name`/`owner_id`/`runtime_stage`（per-bot 列表同享 `bot_name` 回填）。
+  机器调用者按 `USER_GATED` 接纳（同 `/bots/ceiling`：须持有该用户至少一个实时
+  delegation，否则 404 掩蔽）；服务层复用 `list_all_crons` 的 fan-out/去重/部分失败
+  容忍，`failed_targets` 不出公开面。地址为字面量 `all`，挂载先于 legacy
+  `/{routine_id}` shim 以免被通配捕获。Gateway `bots.openapi.json` 已重新生成，需
+  同步独立维护的 OCB/Sofapy 副本；转发与鉴权由既有宽泛 `/openapi/v1/bots/**` 规则
+  覆盖。
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/gateway/configs/schemas/bots.openapi.json src/backend/docs/openapi-v1/README.zh-CN.md
+git commit -m "feat(gateway): publish owner routines aggregate in bots.openapi.json"
+```
+
+---
+
+### Task 5: 覆盖率门禁 + 收尾验证
+
+- [ ] **Step 1: 本地跑 CI 门禁**（changed-line coverage ≥80% 只能本地复现）
+
+Run: `cd /Users/rongzhi/PycharmProjects/Avernet/src/backend && bash scripts/ci_test.sh`
+Expected: 通过（pre-push hook 只有 lint，看不到 coverage；这个才有）
+
+- [ ] **Step 2: 若 coverage 不足**，回到 Task 1/2 补测试（优先补：`_map_routine` 新字段分支、owner_router 的 dict/data None 分支、app caller 两个分支），再跑
+
+- [ ] **Step 3: 最终确认提交链**
+
+Run: `git log --oneline origin/dev..HEAD`
+Expected: 4 个提交（schema 扩展、owner 路由、挂载、契约+README）+ 已有 spec 提交
+
+---
+
+### Task 6: OCB 双写同步
+
+**Files:**
+- Modify: `~/IdeaProjects/ocb` 仓库内的 gateway `bots.openapi.json` 副本（执行时先 `find ~/IdeaProjects/ocb -name "bots.openapi.json"` 定位实际路径）
+
+- [ ] **Step 1: 定位 ocb 侧契约文件**
+
+Run: `find ~/IdeaProjects/ocb -name "bots.openapi.json" -not -path "*/node_modules/*"`
+Expected: 找到网关侧副本路径（记忆约定：avernet/ocb 两侧 `bots.openapi.json` 要同步）
+
+- [ ] **Step 2: 用 avernet 再生成的文件覆盖 ocb 副本**（若两侧文件此前完全一致则直接 `cp`；若历史上已有差异，先 `diff` 确认差异仅本次新增内容再覆盖——发现不一致要向用户报告，不要盲目覆盖）
+
+- [ ] **Step 3: 检查 ocb gateway `application.yaml` 的 route_security**——本路由为 USER_GATED（非 REFUSED），预期**无需**任何 route_security 变更（宽泛 `/openapi/v1/bots/**` user/app optional 规则已覆盖）；若发现 ocb 侧有独立 REFUSED 清单需同步，停下来向用户确认
+
+- [ ] **Step 4: ocb 侧提交由用户决定**（oen 仓库的提交节奏遵循 ocb 侧团队约定；完成后向用户报告 diff 摘要）
+
+---
+
+## Self-Review 记录
+
+- **Spec 覆盖**：契约(§4)→Task 1/2；实现与挂载(§5)→Task 2/3；错误处理(§6)→Task 2 代码+测试；契约同步(§7)→Task 4/6；测试(§8)→各 Task + Task 5。准入模式两处修正已在计划头部声明理由。
+- **占位符扫描**：无 TBD/TODO；所有代码步骤带完整代码。
+- **类型一致性**：`list_owner_routines(page, owner_id, caller, factory, request)` 签名与测试直调一致；`_map_routine` 新字段名与 `Routine` schema 字段一致（bot_name/owner_id/runtime_stage）；`ActingCallerDep`/`UserIdDep`/`PageParamsDep` 的 import 路径均已按现行源码核实（principal.py:339 / contracts / admission）。

--- a/docs/superpowers/specs/2026-08-27-owner-routines-aggregate-openapi-design.md
+++ b/docs/superpowers/specs/2026-08-27-owner-routines-aggregate-openapi-design.md
@@ -1,0 +1,135 @@
+# Owner 级定时任务聚合列表 OpenAPI 接口设计
+
+- **日期**: 2026-08-27
+- **整理人**: rongzhi（A 线）
+- **需求来源**: 前端功能页面需要"查询当前用户（owner）名下所有 bot 的定时任务"平铺列表
+- **本文性质**: 新增单端点的技术设计（方案已与需求方口头对齐收敛）
+
+---
+
+## 1. 背景与动机
+
+定时任务（routine）配置存储在**每个 bot 自己的引擎侧**，后端不落库；查询必须 fan-out 到各 bot
+的 runtime target。现有公开面 OpenAPI 只有 per-bot 列表：
+
+```
+GET /openapi/v1/bots/{bot_id}/routines        # 单 bot、仅 draft 运行态、Routine 无 bot_name
+```
+
+前端页面要展示"我的所有定时任务"时面临两个缺口：
+
+1. 没有 owner 级聚合入口（要么前端 N+1 逐 bot 查，要么走 legacy `/api/cron`，违反
+   "工坊交互全走 `/openapi/v1` 新接口"的刚性口径）；
+2. `Routine` 响应结构**没有 `bot_name`**，聚合列表无法标注任务归属。
+
+### 1.1 现状能力盘点（复用基础）
+
+| 层 | 现状 | 位置 |
+|---|---|---|
+| 服务层 | `list_all_crons(user_id, nick_name, bot_id, runtime_stage)` 已支持 owner 级聚合：拉 owner-or-collaborator 全部 bot（上限 100）→ 并发 fan-out 各 runtime target → 每条装饰 `bot_id`/`bot_name`/`owner_id`/`runtime_stage` → 同 bot+stage+task 去重 → 部分失败容忍（`failed_targets`，warning 日志） | `core/cron/services/cron_relay.py:95` |
+| legacy HTTP | `GET /api/cron?bot_id=all` 即 owner 级平铺列表（全运行态、不分页、原始 cron dict、响应含 `failed_targets`） | `adapters/http/cron/router.py:118` |
+| 公开面 | 仅 per-bot 路由，`runtime_stage=DRAFT`，内存分页 | `adapters/http/openapi_v1/routines/router.py:120` |
+
+**结论**：服务层零新逻辑，本次工作 = 把既有聚合能力按公开面契约暴露。
+
+## 2. 需求口径（已收敛）
+
+| 决策点 | 结论 |
+|---|---|
+| 调用面 | 新 TC / 门户前端，走 gateway 的 `/openapi/v1/bots/...` OpenAPI 契约 |
+| owner 语义 | **查自己**：owner = 认证的当前用户（`user_id` query 惯例），不收 `owner_id` |
+| 运行态范围 | **全运行态聚合**（draft+verify+online），对齐 legacy；同一配置可多行，靠 `runtime_stage` 区分 |
+| 归属范围 | 服务层 `list_bots_by_owner_or_collaborator` 行为保持——用户**协作参与的他人 bot 的任务也出现**（legacy 页面现状） |
+| bot_name | 必须返回（本需求的直接动因之一） |
+
+## 3. 方案选型
+
+- **选定方案 1**：新增 `GET /openapi/v1/bots/routines/all`，复用 `list_all_crons`。
+  新地址干净，不动 deprecated 迁移故事；"all" 用词与 legacy `bot_id="all"` 一致。
+- 否决方案 2（复活 deprecated 地址 `GET /openapi/v1/bots/routines`、`bot_id` 改可选）：
+  deprecated 地址计划删除，改参数语义搅乱迁移故事（本仓库"地址即契约"立场见
+  `deprecated/routines.py` 注释）。
+- 否决方案 3（前端先拉 `/bots/all` 再逐 bot 查）：N+1 且无法分页。
+
+## 4. 接口契约
+
+```
+GET /openapi/v1/bots/routines/all?user_id=xxx&page=1&page_size=20
+→ 200 Envelope[Page[Routine]]
+```
+
+- `user_id`（必填 query，`UserIdDep`）：owner = 当前用户
+- `page` / `page_size`（`PageParamsDep`）：**内存分页**（服务层一次性全量返回后切片，与
+  per-bot 路由同款实现）
+- 服务端不做过滤/排序：`status` 等过滤由前端按 `enabled` / `runtime_stage` 自行完成
+  （与 per-bot 路由现状立场一致）
+
+### 4.1 `Routine` 结构扩展（纯加法）
+
+新增三个**可选**字段（默认 `None`，不破坏既有契约与 required 集合）：
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `bot_name` | `str \| None` | 任务归属 bot 的名称（服务层已装饰） |
+| `owner_id` | `str \| None` | bot 的 owner 工号 |
+| `runtime_stage` | `str \| None` | `draft` / `verify` / `online`（仅 service bot 有意义）同时给 per-bot 路由的 `_map_routine` 回填 `bot_name`（该路由仅有 `bot_id`，场景上 bot 身份已知）。`owner_id` / `runtime_stage` 仅聚合路由映射。
+
+## 5. 后端实现
+
+1. **新路由模块**：`openapi_v1/routines/` 下新增 owner 级小 router（单条 `GET ""`，
+   prefix 即完整路径 `/openapi/v1/bots/routines/all`），不挂在既有
+   `{bot_id}/routines` 前缀下（寻址语义不同）。
+2. Handler 流程：`list_all_crons(user_id=user_id, nick_name=user_id, bot_id=None,
+   runtime_stage=None)` → `_map_routine` 逐条映射（含三个新字段）→ 内存分页 →
+   `page_envelope`。
+3. `_map_routine` 由 per-bot 路由模块与聚合路由共享（同包内引用，避免复制漂移）。
+
+### 5.1 鉴权、准入与挂载
+
+- `admission.py`：声明 `("GET", "/openapi/v1/bots/routines/all"): AdmissionMode.GRANT_FILTERED`
+  ——与 `GET /openapi/v1/bots/all` 同模式（owner 范围集合：授权应用见自己被委托范围内的结果，
+  无授权拿空页）。
+- `authorization.py`：加 `NoCheck` 条目（collection，非被寻址单 bot）。
+- **挂载顺序**：挂进常规组（`_SUBGROUPS` / 相关组之后、`_LEGACY_*` 之前）。已核实
+  `openapi_v1/__init__.py`：常规组先于 legacy shim 挂载，因此 deprecated 的
+  `/openapi/v1/bots/routines/{routine_id}` 不会把字面量 `all` 当 `routine_id` 吞掉。
+  （`{"routine_id": "all"}` 的 deprecated 详情请求仍按原语义 404/按实现处理，互不影响。）
+
+## 6. 错误处理
+
+- **部分失败**：个别 bot 引擎查询失败时，服务层返回成功部分 + `failed_targets`（已打
+  warning 日志）；聚合路由只返回成功部分，**不暴露 `failed_targets`**（与 legacy 的差异，
+  页面不需要，YAGNI）。
+- `@envelope_errors` + `_PUBLIC_AUTH` 统一 401/403 错误信封。
+- `user_id` 与认证 principal 不一致等场景沿用公开面统一 403 处理。
+
+## 7. 契约与网关同步
+
+1. 重新生成 `src/gateway/configs/schemas/bots.openapi.json`（新增 path + `Routine` 扩展字段）；
+2. OCB/Sofapy Gateway 侧同步 schema（`~/IdeaProjects/ocb`，双写约定）；
+3. 转发与鉴权：现有宽泛 `/openapi/v1/bots/**` 规则已覆盖，**无需新增网关路由规则**。
+
+## 8. 测试
+
+| 类型 | 内容 |
+|---|---|
+| Handler 单测 | 三新字段映射、分页切片、空 owner（无 bot → 空页 200）、多运行态多行（同 bot 同配置 draft+online 两条） |
+| per-bot 回归 | per-bot 路由 `_map_routine` 回填 `bot_name` 的断言；既有测试不回归 |
+| 准入清单 | `test_admission_inventory.py` 机制强制新路由在 admission 表中声明（漏声明直接红） |
+| legacy parity | 不动 deprecated 地址，既有 parity 测试不受影响 |
+| 覆盖率 | changed-line ≥80%，本地 `ci_test.sh` 验证（pre-push 只查 lint，看不到 coverage 门禁） |
+
+## 9. 非目标（本次不做）
+
+- 不支持查询他人（`owner_id` 参数）——协作者/管理员视角另议；
+- 不解决服务层 100-bot 上限（`page_size=100` 封顶，个人场景够用）；
+- 不做跨运行态去重（同 bot 同配置保留多行）；
+- 不做服务端排序/`status` 服务端过滤；
+- 不改 legacy `/api/cron` 行为。
+
+## 10. 已知限制与后续
+
+- 全运行态 = 同一配置多行，**前端必须用 `runtime_stage` 标注**（草稿/已发布），否则用户会
+  认为"重复"；这是 legacy 页面已有的语义，接口不做隐藏。
+- 内存分页 = 每次全量 fan-out，owner 名下 bot 多时 RT 放大；100-bot 上限内可接受，
+  若后续页面有性能诉求再评估缓存或游标化。

--- a/src/backend/docs/openapi-v1/README.zh-CN.md
+++ b/src/backend/docs/openapi-v1/README.zh-CN.md
@@ -1148,6 +1148,17 @@ domain —— `bots` 未声明 `protocols`，因此只服务 HTTP 平面 —— 
 
 ## Changelog（变更记录）（每次挪动看板时追加一条带日期的记录）
 
+- **2026-08-27** —— **Owner 级定时任务聚合列表。** 新增
+  `GET /openapi/v1/bots/routines/all`：按认证用户聚合其名下（含协作参与）所有 Bot
+  的定时任务，全部运行态（draft/verify/online）平铺，同一配置跨运行态可多行并以
+  `runtime_stage` 区分；`Routine` 纯加法扩展可选字段
+  `bot_name`/`owner_id`/`runtime_stage`（per-bot 列表同享 `bot_name` 回填）。
+  机器调用者按 `USER_GATED` 接纳（同 `/bots/ceiling`：须持有该用户至少一个实时
+  delegation，否则 404 掩蔽）；服务层复用 `list_all_crons` 的 fan-out/去重/部分失败
+  容忍，`failed_targets` 不出公开面。地址为字面量 `all`，挂载先于 legacy
+  `/{routine_id}` shim 以免被通配捕获。Gateway `bots.openapi.json` 已重新生成，需
+  同步独立维护的 OCB/Sofapy 副本；转发与鉴权由既有宽泛 `/openapi/v1/bots/**` 规则
+  覆盖。
 - **2026-08-20** —— **新增认证 Bot Catalog 查询。** 提供
   `GET /openapi/v1/bots/catalog/search` 与 `/discover`；User 和 App 身份读取
   相同的公开白名单投影，不再接受 `user_id` 或返回用户 `friendship`。

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/__init__.py
@@ -219,6 +219,7 @@ from .resources import router as resources_router
 from .render_screens import router as render_screens_router
 from .repository_catalog import router as repository_catalog_router
 from .routines import router as routines_router
+from .routines.owner_router import router as routines_owner_router
 from .skills import publish_status_router as skill_publish_status_router
 from .skills import router as skills_router
 from .skill_sets import router as skill_sets_router
@@ -309,6 +310,11 @@ _SUBGROUPS = [
     # check via `HarnessBotAccessDep`, so it joins the plain subgroups with
     # only `_PUBLIC_AUTH` + the user-scoped error table.
     harness_router,
+    # The owner-level routine aggregate is a literal under `bots/routines` —
+    # it must mount before the *legacy* routines shim's `/{routine_id}`
+    # wildcard (which the legacy groups, mounted later, contribute) or that
+    # route captures a literal "all" as a routine id.
+    routines_owner_router,
 ]
 
 # These groups may address a shared Bot. ``OwnerIdDep`` performs the same grant

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -257,6 +257,9 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     # path, so the shared dependency checks it like every other operation.
     ("GET", "/openapi/v1/bots/{bot_id}/routines"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
     ("POST", "/openapi/v1/bots/{bot_id}/routines"): AdmissionMode.GRANT_CHECKED_OWN_BOT,
+    # The owner-level aggregate lists the named user's fleet, not one bot —
+    # gated on a live delegation like the ceiling (see owner_router).
+    ("GET", "/openapi/v1/bots/routines/all"): AdmissionMode.USER_GATED,
     (
         "GET",
         "/openapi/v1/bots/{bot_id}/routines/{routine_id}",

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
@@ -381,6 +381,8 @@ AUTHORIZATION: dict[tuple[str, str], Authorization] = {
     ("GET", "/openapi/v1/bots/all"): NoCheck("a collection, not one addressed bot"),
     ("GET", "/openapi/v1/bots/authorized"):
         NoCheck("a collection, not one addressed bot"),
+    ("GET", "/openapi/v1/bots/routines/all"):
+        NoCheck("a collection, not one addressed bot"),
     ("GET", "/openapi/v1/bots/catalog/discover"): NoCheck("tenant-identical catalogue"),
     ("GET", "/openapi/v1/bots/catalog/search"): NoCheck("tenant-identical catalogue"),
     ("GET", "/openapi/v1/bots/ceiling"):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/owner_router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/owner_router.py
@@ -1,0 +1,99 @@
+"""Owner-level routine listing — ``GET /openapi/v1/bots/routines/all``.
+
+The per-bot group lists one bot's draft workspace; this route aggregates the
+named user's whole fleet — bots owned or collaborated on — across every
+runtime stage, the way the legacy ``/api/cron`` listing always did. The
+service layer owns the fan-out, the bot_name decoration, the per-stage dedup
+and the partial-failure tolerance; this is the public-face adapter over it.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    Envelope,
+    Page,
+    PageParamsDep,
+)
+from agentclaw.community.adapters.http.openapi_v1.principal import (
+    ActingCallerDep,
+    UserIdDep,
+)
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    envelope_errors,
+    page as page_envelope,
+)
+from agentclaw.community.adapters.http.openapi_v1.authorization import (
+    PublicAPIRoute,
+)
+from agentclaw.community.adapters.http.openapi_v1.log_safe import for_log
+from agentclaw.community.api.cron_relay_service import (
+    CronRelayServiceProtocol,
+)
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotNotFoundError,
+)
+from agentclaw.community.di import Injected
+from agentclaw.community.log import get_logger
+
+from .router import _map_routine
+from .schemas import Routine
+
+router = APIRouter(
+    prefix="/openapi/v1/bots/routines/all",
+    tags=["routines"],
+    route_class=PublicAPIRoute,
+)
+
+logger = get_logger()
+
+
+@router.get("", response_model=Envelope[Page[Routine]])
+@envelope_errors
+async def list_owner_routines(
+    page: PageParamsDep,
+    owner_id: UserIdDep,
+    caller: ActingCallerDep,
+    request: Request,
+    factory: CronRelayServiceProtocol = Injected(CronRelayServiceProtocol),
+) -> Envelope[Page[Routine]]:
+    """List the named user's routines across all their bots (paginated).
+
+    Every runtime stage is aggregated — draft, verify and online — so a
+    service bot's published runtimes appear alongside its draft workspace,
+    and one definition can answer more than one row, differing by
+    `runtime_stage`. Bots the user collaborates on are included, matching
+    the listing the internal console has always shown.
+    """
+    # Names no bot, so there is no grant to check against one — but the
+    # answer is still about a person's fleet, and a stranger application must
+    # not read it by naming a user id. Gated like the ceiling: an application
+    # needs at least one live delegation from the named user; without one the
+    # user is answered as if they did not exist.
+    granted = caller.granted_bot_ids()
+    if granted is not None and not granted:
+        logger.warning(
+            "[owner routines] app holds no delegation from user=%s; "
+            "refusing the listing",
+            for_log(owner_id),
+        )
+        raise BotNotFoundError("no authorization from the named user")
+    result = await factory.list_all_crons(
+        user_id=owner_id,
+        nick_name=owner_id,
+        bot_id=None,
+        runtime_stage=None,
+    )
+    data = result.get("data") if isinstance(result, dict) else None
+    if isinstance(data, list):
+        items_list = data
+    elif isinstance(data, dict):
+        items_list = data.get("items", [])
+    else:
+        items_list = []
+    mapped = [_map_routine(d) for d in items_list if isinstance(d, dict)]
+    start = (page.page - 1) * page.page_size
+    end = start + page.page_size
+    page_items = mapped[start:end]
+    return page_envelope(len(mapped), page_items, request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/router.py
@@ -84,6 +84,9 @@ def _map_routine(data: dict) -> Routine:
     return Routine(
         routine_id=str(data.get("id", "")),
         bot_id=str(data.get("bot_id", "")),
+        bot_name=str(data.get("bot_name", "")) or None,
+        owner_id=str(data.get("owner_id", "")) or None,
+        runtime_stage=str(data.get("runtime_stage", "")) or None,
         name=str(data.get("name", "") or ""),
         trigger=ScheduleTrigger(type="schedule", cron=str(sched.get("expr", ""))),
         command=str(payload.get("message", "") or ""),

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/routines/schemas.py
@@ -60,6 +60,9 @@ class Routine(BaseModel):
                 # routine, not a way of addressing it, and the model requires
                 # it. Only the create *body* lost it, to the path.
                 "bot_id": "20260813_a7k2m9p1",
+                "bot_name": "TicketBot",
+                "owner_id": "209800",
+                "runtime_stage": "draft",
                 "name": "morning-brief",
                 "trigger": {"type": "schedule", "cron": "0 9 * * 1-5"},
                 "command": "Summarize yesterday's tickets and post the brief.",
@@ -78,6 +81,23 @@ class Routine(BaseModel):
     bot_id: str = Field(
         description="The bot the routine belongs to; may be empty on the "
         "detail read — keep the bot_id you queried with."
+    )
+    bot_name: str | None = Field(
+        default=None,
+        description="Name of the bot the routine belongs to; null when the "
+        "engine reports none.",
+    )
+    owner_id: str | None = Field(
+        default=None,
+        description="The bot owner's staff id; null when the engine reports "
+        "none.",
+    )
+    runtime_stage: str | None = Field(
+        default=None,
+        description="Which runtime holds this definition — 'draft', 'verify' "
+        "or 'online' for a service bot, null otherwise. The same definition "
+        "can exist in several runtimes; on a cross-bot list treat the pair "
+        "(routine_id, runtime_stage) as the distinct row.",
     )
     name: str = Field(description="Human-readable routine name.")
     trigger: ScheduleTrigger = Field(description="When the routine fires.")

--- a/src/backend/tests/community/adapters/http/openapi_v1/routines/test_owner_routines.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/routines/test_owner_routines.py
@@ -1,0 +1,219 @@
+"""openapi_v1 owner-level routine listing handler unit tests."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentclaw.community.adapters.http.openapi_v1.contracts import (
+    CODE_OK,
+    Envelope,
+    Page,
+    PageParams,
+)
+from agentclaw.community.adapters.http.openapi_v1.admission import ActingCaller
+from agentclaw.community.adapters.http.openapi_v1.routines.owner_router import (
+    list_owner_routines,
+)
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotNotFoundError,
+)
+
+
+def _human(user_id: str) -> ActingCaller:
+    """A caller with a person on the wire — no grant governs the request."""
+    return ActingCaller(user_id=user_id, app_id=None)
+
+
+def _app_with_delegations(user_id: str, *bot_ids: str) -> ActingCaller:
+    """An application caller holding one live delegation per named bot.
+
+    ``granted_bot_ids()`` reads the grant protocol; a stub returning the
+    records inline keeps the handler test off the database.
+    """
+
+    class _Grants:
+        def list_for_app(self, *, app_id, user_id):
+            return [
+                SimpleNamespace(bot_id=b, owner_id=user_id) for b in bot_ids
+            ]
+
+    return ActingCaller(user_id=user_id, app_id=7, grants=_Grants())
+
+
+def _request_without_trace() -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace())
+
+
+class _StubCronService:
+    """Minimal stub satisfying the CronRelayServiceProtocol list_all_crons seam."""
+
+    def __init__(self, payload):
+        self._payload = payload
+        self.last_call_kwargs: dict = {}
+
+    async def list_all_crons(self, *args, **kwargs):
+        self.last_call_kwargs = dict(kwargs)
+        return {"success": True, "data": self._payload, "total": len(self._payload)}
+
+
+def _adapter_dict(**overrides):
+    base = {
+        "id": "t1",
+        "bot_id": "bot-x",
+        "bot_name": "Bot X",
+        "owner_id": "u1",
+        "runtime_stage": "online",
+        "name": "cron1",
+        "enabled": True,
+        "schedule": {"expr": "0 9 * * *", "tz": "Asia/Shanghai"},
+        "payload": {"message": "echo hi"},
+        "created_at_ms": 1722165600000,
+        "updated_at_ms": 1722165600000,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_returns_envelope_page_with_bot_metadata():
+    service = _StubCronService([_adapter_dict()])
+
+    env = await list_owner_routines(
+        page=PageParams(page=1, page_size=20),
+        owner_id="u1",
+        caller=_human("u1"),
+        factory=service,
+        request=_request_without_trace(),
+    )
+
+    assert isinstance(env, Envelope)
+    assert env.code == CODE_OK
+    assert env.message == "OK"
+    assert env.data is not None
+    assert isinstance(env.data, Page)
+    assert env.data.total == 1
+    item = env.data.items[0]
+    assert item.bot_id == "bot-x"
+    assert item.bot_name == "Bot X"
+    assert item.owner_id == "u1"
+    assert item.runtime_stage == "online"
+
+
+@pytest.mark.asyncio
+async def test_asks_for_the_user_whole_fleet_all_stages():
+    """The aggregate names no bot and no runtime stage.
+
+    ``bot_id=None`` is the service's all-bots mode and ``runtime_stage=None``
+    aggregates draft, verify and online — the opposite of the per-bot draft
+    workspace the rest of the routines group serves.
+    """
+    service = _StubCronService([])
+
+    await list_owner_routines(
+        page=PageParams(page=1, page_size=20),
+        owner_id="u1",
+        caller=_human("u1"),
+        factory=service,
+        request=_request_without_trace(),
+    )
+
+    assert service.last_call_kwargs.get("user_id") == "u1"
+    assert service.last_call_kwargs.get("nick_name") == "u1"
+    assert service.last_call_kwargs.get("bot_id") is None
+    assert service.last_call_kwargs.get("runtime_stage") is None
+
+
+@pytest.mark.asyncio
+async def test_paginates_items():
+    service = _StubCronService(
+        [_adapter_dict(id="t1"), _adapter_dict(id="t2"), _adapter_dict(id="t3")]
+    )
+
+    env = await list_owner_routines(
+        page=PageParams(page=2, page_size=1),
+        owner_id="u1",
+        caller=_human("u1"),
+        factory=service,
+        request=_request_without_trace(),
+    )
+
+    assert env.data.total == 3
+    assert [i.routine_id for i in env.data.items] == ["t2"]
+
+
+@pytest.mark.asyncio
+async def test_empty_fleet_answers_an_empty_page():
+    service = _StubCronService([])
+
+    env = await list_owner_routines(
+        page=PageParams(page=1, page_size=20),
+        owner_id="u1",
+        caller=_human("u1"),
+        factory=service,
+        request=_request_without_trace(),
+    )
+
+    assert env.code == CODE_OK
+    assert env.data.total == 0
+    assert env.data.items == []
+
+
+@pytest.mark.asyncio
+async def test_refuses_an_application_with_no_delegation():
+    """An app naming a user it holds no delegation from learns nothing.
+
+    Same gate and same answer as the ceiling: the refusal is a 404 shaped by
+    ``envelope_errors`` from ``BotNotFoundError``, so it is indistinguishable
+    from a user who does not exist.
+    """
+    service = _StubCronService([_adapter_dict()])
+    # granted_bot_ids(): app_id set, grants None → frozenset() → refused.
+    stranger = ActingCaller(user_id="u1", app_id=7)
+
+    with pytest.raises(BotNotFoundError):
+        await list_owner_routines(
+            page=PageParams(page=1, page_size=20),
+            owner_id="u1",
+            caller=stranger,
+            factory=service,
+            request=_request_without_trace(),
+        )
+    assert service.last_call_kwargs == {}
+
+
+@pytest.mark.asyncio
+async def test_admits_an_application_with_a_delegation():
+    service = _StubCronService([_adapter_dict()])
+
+    env = await list_owner_routines(
+        page=PageParams(page=1, page_size=20),
+        owner_id="u1",
+        caller=_app_with_delegations("u1", "bot-x"),
+        factory=service,
+        request=_request_without_trace(),
+    )
+
+    assert env.code == CODE_OK
+    assert env.data.total == 1
+
+
+@pytest.mark.asyncio
+async def test_partial_failure_returns_the_successes():
+    """A dict-shaped ``data`` envelope unwraps to its ``items``.
+
+    The service may answer ``{"data": {"items": [...]}}`` on partial failure
+    paths; the listing keeps the succeeded rows like the per-bot route does,
+    and never surfaces ``failed_targets`` on the public face.
+    """
+    service = _StubCronService({"items": [_adapter_dict(id="t1")]})
+
+    env = await list_owner_routines(
+        page=PageParams(page=1, page_size=20),
+        owner_id="u1",
+        caller=_human("u1"),
+        factory=service,
+        request=_request_without_trace(),
+    )
+
+    assert env.data.total == 1
+    assert env.data.items[0].routine_id == "t1"

--- a/src/backend/tests/community/adapters/http/openapi_v1/routines/test_routines_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/routines/test_routines_handlers.py
@@ -132,6 +132,42 @@ def test_map_routine_invalid_ms_returns_empty_string():
     assert r.gmt_modified == ""
 
 
+def test_map_routine_carries_bot_metadata():
+    """The aggregate listing decorates every adapter item with bot/owner/stage.
+
+    ``cron_runtime_targets.py`` decorates ``bot_id``/``bot_name``/``owner_id``
+    on every item and ``runtime_stage`` on a service bot's — the owner-level
+    listing needs all of them mapped, and the per-bot route answers
+    ``bot_name`` from the same dict for free.
+    """
+    adapter = _adapter_dict(
+        bot_name="TicketBot",
+        owner_id="209800",
+        runtime_stage="online",
+    )
+    r = _map_routine(adapter)
+    assert r.bot_name == "TicketBot"
+    assert r.owner_id == "209800"
+    assert r.runtime_stage == "online"
+
+
+def test_map_routine_bot_metadata_defaults_to_none():
+    """Absent or empty decoration maps to None, never to an empty string.
+
+    The three metadata fields are optional additions; a producer that reports
+    none (e.g. a draft-stage item has no ``runtime_stage``) must surface as
+    null, which is what the schema documents.
+    """
+    r = _map_routine({})
+    assert r.bot_name is None
+    assert r.owner_id is None
+    assert r.runtime_stage is None
+    r_blank = _map_routine({"bot_name": "", "owner_id": "", "runtime_stage": ""})
+    assert r_blank.bot_name is None
+    assert r_blank.owner_id is None
+    assert r_blank.runtime_stage is None
+
+
 # ── list_routines handler wiring (Phase 1 Task 2) ──────────────────────
 #
 # Direct handler invocation (退路 B per task spec): bypasses FastAPI's

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
@@ -32,6 +32,9 @@ from agentclaw.community.adapters.http.openapi_v1.authorized_apps import (
 )
 from agentclaw.community.adapters.http.openapi_v1.bots import router as bots_router
 from agentclaw.community.adapters.http.openapi_v1.local import router as local_router
+from agentclaw.community.adapters.http.openapi_v1.routines.owner_router import (
+    router as routines_owner_router,
+)
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.adapters.http.openapi_v1.spaces import router as spaces_router
 from agentclaw.community.adapters.http.openapi_v1.work_orders import (
@@ -40,6 +43,9 @@ from agentclaw.community.adapters.http.openapi_v1.work_orders import (
 from agentclaw.community.adapters.http.openapi_v1.deprecated import LEGACY_ROUTES
 from agentclaw.community.api.bot_app_grant_service import BotAppGrantServiceProtocol
 from agentclaw.community.api.bot_inventory_service import BotInventoryServiceProtocol
+from agentclaw.community.api.cron_relay_service import (
+    CronRelayServiceProtocol,
+)
 from agentclaw.community.api.local_bot_workflow_service import (
     LocalBotWorkflowServiceProtocol,
 )
@@ -217,6 +223,7 @@ def make_client(bots):
                 binder.bind(BotServiceProtocol, to=bots)
                 binder.bind(BotAppGrantServiceProtocol, to=_Grants(*grant_ids))
                 unexpected = _UnexpectedService()
+                binder.bind(CronRelayServiceProtocol, to=unexpected)
                 binder.bind(SpaceServiceProtocol, to=unexpected)
                 binder.bind(SpaceMemberServiceProtocol, to=unexpected)
                 binder.bind(SpaceSkillQueryServiceProtocol, to=unexpected)
@@ -241,6 +248,8 @@ def make_client(bots):
         # mounts them: ``/openapi/v1/bots/{bot_id}`` would otherwise claim
         # ``/openapi/v1/bots/authorized`` as "the bot named authorized".
         app.include_router(app_view_router)
+        # Same rule for the owner-routines literal: ``routines`` is not a bot id.
+        app.include_router(routines_owner_router)
         app.include_router(local_router)
         app.include_router(bots_router)
         app.include_router(spaces_router)
@@ -647,6 +656,15 @@ _UNGRANTED_APP_CASES = {
         "request": lambda client: client.get("/openapi/v1/bots/ceiling"),
         # USER_GATED: no delegation, no relationship — masked as not-found, so
         # a stranger app cannot read a person's quota by naming them.
+        "assert_starved": lambda response: response.status_code == 404,
+    },
+    ("GET", "/openapi/v1/bots/routines/all"): {
+        "request": lambda client: client.get("/openapi/v1/bots/routines/all"),
+        # USER_GATED, the ceiling's exact shape: the aggregate reads the named
+        # user's whole routine fleet, so an app with no delegation from them is
+        # answered as if the user did not exist. The cron service stays
+        # untouched — it is bound to `_UnexpectedService` in the fixture, so a
+        # regression that asks it anyway fails here rather than leaking rows.
         "assert_starved": lambda response: response.status_code == 404,
     },
     ("GET", "/openapi/v1/bots/spaces"): {

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -398,7 +398,11 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: publish-to-users route moved from /bots/{bot_id}/public-bcs to the external
 #: /collaboration/bots/{bot_uuid}/public, so one path-addressed {bot_id}
 #: operation became a {bot_uuid}-named one: path -1, none +1.
-_BOT_ID_PLACEMENT = {"path": 143, "query": 1, "none": 62}
+#:
+#: ``none`` then moved 62 → 63 with the owner-level routines aggregate
+#: (``GET /openapi/v1/bots/routines/all``): it lists the named user's whole
+#: fleet, so it addresses no single bot.
+_BOT_ID_PLACEMENT = {"path": 143, "query": 1, "none": 63}
 
 
 def _schema() -> dict:
@@ -521,7 +525,9 @@ def test_the_pinned_number_of_operations_take_it():
     # count: 182 → 181. execute/dashboard take no user_id at all — see
     # _NO_USER_DIMENSION.
     # Caller identity context and call-type update add two operations.
-    assert len(taking) == 183
+    # The owner-level routines aggregate (GET /bots/routines/all) adds one
+    # account-level operation: 183 → 184.
+    assert len(taking) == 184
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_path_convention.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_path_convention.py
@@ -106,6 +106,11 @@ _BOT_FREE = frozenset(
         "market",
         "metadata",
         "mcp",
+        # `routines/all` is the owner-level aggregate: it lists the named
+        # user's fleet across every bot, so the first segment names the
+        # component namespace, not one bot — the same literal the retiring
+        # routines shim already keeps there.
+        "routines",
         "spaces",
         # Repo catalog is tenant-wide but follows the Skill namespace as
         # requested by its public contract: /bots/skills/repository/... .

--- a/src/backend/tests/community/endpoints/test_openapi_routines.py
+++ b/src/backend/tests/community/endpoints/test_openapi_routines.py
@@ -289,3 +289,71 @@ for _method, _path, _input, _status, _body in _HAPPY_CASES:
         seed=_seed_verifier,
         expect=ExpectError(status=403, json_contains={"data": None}),
     )(lambda: None)
+
+
+# ── The owner-level aggregate: GET /openapi/v1/bots/routines/all ─────────────
+#
+# Same household, different shape: no ``{bot_id}`` to address, all runtime
+# stages at once, and ``bot_name`` on every row — the decoration the aggregate
+# adds over the per-bot listing. The relay stub answers with one routine
+# decorated the way ``cron_runtime_targets.py`` decorates it in production.
+
+
+def _decorated_routine() -> dict:
+    """One routine as the aggregate receives it, with the fleet metadata."""
+    return {
+        **_routine(),
+        "bot_name": "Routine Bot",
+        "owner_id": _OWNER,
+        "runtime_stage": "online",
+    }
+
+
+def _seed_aggregate_services(world) -> None:
+    _seed_verifier(world)
+
+    async def list_all_crons(_self, **_kwargs):
+        return {"success": True, "data": [_decorated_routine()]}
+
+    bind_overrides(
+        world,
+        CronRelayServiceProtocol,
+        {"list_all_crons": list_all_crons},
+    )
+
+
+endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/routines/all",
+    scenario="happy",
+    input=CaseInput(query_params=_QUERY, headers=_HEADERS),
+    seed=_seed_aggregate_services,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "data": {
+                "total": 1,
+                "items": [
+                    {
+                        "routine_id": _ROUTINE_ID,
+                        "bot_id": _BOT_ID,
+                        "bot_name": "Routine Bot",
+                        "runtime_stage": "online",
+                    }
+                ],
+            }
+        },
+    ),
+)(lambda: None)
+
+
+# The refusal every user-scoped operation on this surface owes — see the
+# per-bot cases above for why no service is seeded.
+endpoint_test(
+    method="GET",
+    path="/openapi/v1/bots/routines/all",
+    scenario="forbidden_user_scope",
+    input=CaseInput(query_params=_FORBIDDEN_QUERY, headers=_HEADERS),
+    seed=_seed_verifier,
+    expect=ExpectError(status=403, json_contains={"data": None}),
+)(lambda: None)

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -13394,7 +13394,10 @@
           "trigger": {
             "cron": "0 9 * * 1-5",
             "type": "schedule"
-          }
+          },
+          "bot_name": "TicketBot",
+          "owner_id": "209800",
+          "runtime_stage": "draft"
         },
         "properties": {
           "bot_id": {
@@ -13447,6 +13450,42 @@
           "trigger": {
             "$ref": "#/components/schemas/ScheduleTrigger",
             "description": "When the routine fires."
+          },
+          "bot_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Name of the bot the routine belongs to; null when the engine reports none.",
+            "title": "Bot Name"
+          },
+          "owner_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The bot owner's staff id; null when the engine reports none.",
+            "title": "Owner Id"
+          },
+          "runtime_stage": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Which runtime holds this definition — 'draft', 'verify' or 'online' for a service bot, null otherwise. The same definition can exist in several runtimes; on a cross-bot list treat the pair (routine_id, runtime_stage) as the distinct row.",
+            "title": "Runtime Stage"
           }
         },
         "required": [
@@ -65365,6 +65404,189 @@
         "summary": "Get User Identity",
         "tags": [
           "org"
+        ]
+      }
+    },
+    "/openapi/v1/bots/routines/all": {
+      "get": {
+        "description": "List the named user's routines across all their bots (paginated).\n\nEvery runtime stage is aggregated — draft, verify and online — so a\nservice bot's published runtimes appear alongside its draft workspace,\nand one definition can answer more than one row, differing by\n`runtime_stage`. Bots the user collaborates on are included, matching\nthe listing the internal console has always shown.",
+        "operationId": "list_owner_routines_openapi_v1_bots_routines_all_get",
+        "parameters": [
+          {
+            "description": "1-based page number.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "description": "1-based page number.",
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Items per page (max 100).",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Items per page (max 100).",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_Page_Routine__"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The user_id names a user the authenticated caller may not act for"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "List Owner Routines",
+        "tags": [
+          "routines"
         ]
       }
     }


### PR DESCRIPTION
## Problem

前端功能页需要展示"当前用户名下所有 Bot 的定时任务"。公开面现有能力不满足：

- `GET /openapi/v1/bots/{bot_id}/routines` 只列单 Bot，且只查 draft 运行态，`Routine` 响应结构没有 `bot_name`——聚合页无法标注任务归属；
- 要么前端先拉 `/bots/all` 再逐 Bot N+1 查询（无法分页、RT 放大），要么走 legacy `/api/cron`（违反"工坊交互全走 `/openapi/v1` 新接口"的刚性口径）。

服务层 `CronRelayService.list_all_crons` 其实已具备 owner 级聚合全部能力（fleet fan-out、bot_name 装饰、同 bot+stage+task 去重、`failed_targets` 部分失败容忍），缺的只是公开面的薄适配。

## Solution

新增 `GET /openapi/v1/bots/routines/all?user_id=&page=&page_size=` → `Envelope[Page[Routine]]`：

- **全运行态聚合**（draft/verify/online），同一配置跨运行态可多行、以 `runtime_stage` 区分；范围含 owner-or-collaborator 的 Bot（对齐 legacy 页面行为）；不支持查他人（不收 `owner_id`）。
- **`Routine` 纯加法扩展**可选字段 `bot_name` / `owner_id` / `runtime_stage`：required 集合不变、既有调用方零破坏；per-bot 列表同享 `bot_name` 回填（`_map_routine` 统一从服务层装饰的 dict 映射）。
- **机器调用者按 `USER_GATED` 接纳**（对齐 `/bots/ceiling` 的既有模式）：应用须持有该用户至少一个实时 delegation，否则以 `BotNotFoundError` 404 掩蔽。刻意不用 `GRANT_FILTERED`——cron 服务不做按授权过滤，声明它是不诚实的契约。网关侧零改动（USER_GATED 非 REFUSED，宽泛 `/openapi/v1/bots/**` 规则已覆盖）。
- **挂载次序**：挂进 `_SUBGROUPS`（先于 legacy shim），字面量 `all` 不会被 deprecated 的 `/routines/{routine_id}` 通配捕获（已冒烟验证 route 序 581 < 711）。
- **契约**：`bots.openapi.json` 外科手术式增量（新 path block + Routine 三字段，纯追加），沿用 #1431 以来该文件手工编辑的事实惯例，不夹带仓库契约对 dev 的 5 个 path 存量漂移（那是各 owner 的再生成欠账）。
- 部分（个别 Bot 引擎失败）只返回成功部分，`failed_targets` 不出公开面；admission/authorization 两表按 fail-closed 默认声明（`USER_GATED` + `NoCheck` collection 条目），`test_admission_inventory` / `test_authorization_inventory` 强制一致。

设计文档与实现计划随 PR 提交（`docs/superpowers/specs/` + `docs/superpowers/plans/`），README 变更记录已更新。

## Validation

- [x] 后端全量 CI（`scripts/ci_test.sh`）：**14699 passed / 55 skipped**，case 通过率 100%
- [x] changed-line coverage **97.37%**（门槛 ≥80%）
- [x] 路由次序冒烟：`routines/all` 注册在 legacy `{routine_id}` 之前
- [x] endpoint coverage gate：新路由补 `happy` + `forbidden_user_scope` 用例（真 DI 装配/挂载/信封上线断言 `bot_name`/`runtime_stage`）
- [x] gateway 侧契约相关测试（forwarding/startup/contracts）：325 passed
- [x] admission/authorization 库存、path convention、user_id 计数钉住等表面级测试全量通过
- [x] OCB/Sofapy 副本双写同步（增量已应用，提交随 ocb 侧节奏）

## Notes

- 无 DB 变更、无网关路由/鉴权配置变更。
- 已知语义：多行同配置（跨运行态）是 legacy 页面既有行为，前端需以 `runtime_stage` 标注，接口不做隐藏。
- 服务层 100-bot 上限（`page_size=100`）为既有约束，本次不解决。