### PR TITLE
feat: add user api

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/app.py
+++ b/src/backend/src/agentclaw/community/adapters/http/app.py
@@ -107,6 +107,7 @@ from agentclaw.community.adapters.http.devices.router import router as device_ro
 from agentclaw.community.adapters.http.access.router import access_router as whitelist_router  # noqa: E402
 from agentclaw.community.adapters.http.access.router import user_list_router  # noqa: E402
 from agentclaw.community.adapters.http.access.router import user_router  # noqa: E402
+from agentclaw.community.adapters.http.org.router import router as org_user_router  # noqa: E402
 from agentclaw.community.adapters.http.expert_chat import router as expert_chats_router  # noqa: E402
 from agentclaw.community.adapters.http.bot_chat import router as bot_chat_router  # noqa: E402
 from agentclaw.community.adapters.http.bot_chat.otel_router import router as bot_chat_otel_router  # noqa: E402
@@ -915,6 +916,7 @@ app.include_router(bot_chat_relation_router)  # bot-chat 业务任务关系写�
 app.include_router(whitelist_router)
 app.include_router(user_list_router)
 app.include_router(user_router)
+app.include_router(org_user_router)  # GET /api/v1/org/user?user_id=<work_no>: directory identity, signed-principal auth
 app.include_router(system_config_router)
 app.include_router(common_config_router)
 app.include_router(skills_pool_ops_router)

--- a/src/backend/src/agentclaw/community/adapters/http/org/__init__.py
+++ b/src/backend/src/agentclaw/community/adapters/http/org/__init__.py
@@ -1,0 +1,7 @@
+"""``GET /api/v1/org/user`` — directory-identity read by ``?user_id=``.
+
+A sibling of ``GET /openapi/v1/org/user`` at a separate prefix, with its own
+access seam (``dependencies.require_org_user_caller`` over the cached,
+signature-verified ``resolve_caller``). Any verified principal may look a user
+up; an app-only caller is admitted (no ``refuse_app_only_caller`` here).
+"""

--- a/src/backend/src/agentclaw/community/adapters/http/org/dependencies.py
+++ b/src/backend/src/agentclaw/community/adapters/http/org/dependencies.py
@@ -1,0 +1,40 @@
+"""Access seam for ``GET /api/v1/org/user`` — verify the gateway's forwarded
+principal, refusing uniformly when there is no caller we can trust.
+
+The gateway authenticates the caller and forwards the identity set it resolved
+as a signed ``X-Avernet-Principal`` token; this module is the access end of
+that contract for the ``/api/v1/org/user`` surface.
+
+It reuses the cached, signature-verified :func:`resolve_caller` — the same seam
+the ``/openapi/v1/*`` surface and the access log read — rather than
+re-implementing verification, so signature verification stays in one place.
+``None`` (absent header, a bad/expired/wrong-audience token, or an unconfigured
+verifier) yields no caller and a uniform ``401``; the specific reason is
+logged, never returned.
+
+Policy difference from the ``/openapi/v1/org/user`` sibling: an app-only caller
+is **not** refused here. Any verified principal may look a user up; the
+``user_id`` parameter names the directory subject, not the actor.
+"""
+
+from __future__ import annotations
+
+from starlette.requests import HTTPConnection
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import resolve_caller
+from agentclaw.community.adapters.http.openapi_v1.errors import MissingPrincipalError
+from agentclaw.community.core.gateway_principal import VerifiedCaller
+
+
+async def require_org_user_caller(connection: HTTPConnection) -> VerifiedCaller:
+    """Return the verified caller, or refuse with the surface's uniform ``401``.
+
+    Delegates the signature verification to :func:`resolve_caller` (cached per
+    request) and owns only the access decision: a request with no verified
+    caller answers ``401``, indistinguishable by reason — missing header or a
+    forged token look the same from outside, by design.
+    """
+    caller = resolve_caller(connection)
+    if caller is None:
+        raise MissingPrincipalError("no verified caller for /api/v1/org/user")
+    return caller

--- a/src/backend/src/agentclaw/community/adapters/http/org/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/org/router.py
@@ -1,0 +1,121 @@
+"""``GET /api/v1/org/user`` — directory-identity read keyed on ``?user_id=``.
+
+A verified caller names a ``user_id`` and gets that user's directory entry;
+the answer comes from the staff directory (the gateway signs only the caller,
+so another user's identity is read off HR, not the principal), and the tenant
+comes from the verified caller.
+
+Mirrors ``GET /openapi/v1/org/user``'s directory-lookup branch at a separate
+prefix; the differences are: the access dep is this module's own
+:func:`require_org_user_caller` (over the cached, signature-verified
+:func:`resolve_caller`), and an app-only caller is admitted — any verified
+principal may look a user up. ``user_id`` is a REQUIRED directory filter with
+no absent-param fall-back to the caller's own identity.
+
+Failure contract (same split the sibling makes): no reader wired ⇒ null
+identity+dept (``200``); directory unreachable (``DeptLookupError``) ⇒ ``5xx``;
+no or invalid principal ⇒ the surface's uniform ``401``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, Request
+
+from agentclaw.community.adapters.http.org.dependencies import (
+    require_org_user_caller,
+)
+from agentclaw.community.adapters.http.openapi_v1.contracts import Envelope
+from agentclaw.community.adapters.http.openapi_v1.org.schemas import OrgUserIdentity
+from agentclaw.community.adapters.http.openapi_v1.responses import (
+    envelope,
+    envelope_errors,
+)
+from agentclaw.community.core.gateway_principal import VerifiedCaller
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.staff_dept import StaffDeptPlugin
+
+logger = get_logger()
+
+# A plain APIRouter (not PublicAPIRoute): this surface owns its access seam via
+# ``require_org_user_caller`` rather than the openapi_v1 admission machinery, so
+# it must not inherit ``_PUBLIC_AUTH`` (which would apply ``require_principal``
+# and the table-driven end-user/app-only adjudication the public surface wants).
+router = APIRouter(prefix="/api/v1/org/user", tags=["org"])
+
+
+def _staff_dept_reader(request: Request) -> StaffDeptPlugin | None:
+    """The staff-dept service for this caller, or ``None`` when not wired.
+
+    Mirrors ``openapi_v1/org/router.py``'s reader: resolved off the request
+    injector so an app with one yields the service and an app without (a bare
+    ``FastAPI()`` test app, or a community/local profile that does not bind it)
+    yields ``None`` — leaving the looked-up fields null (``200``) rather than
+    the service becoming a hard requirement of the route.
+    """
+    injector = getattr(request.app.state, "injector", None)
+    if injector is None:
+        return None
+    try:
+        return injector.get(StaffDeptPlugin)
+    except Exception:  # noqa: BLE001 — any resolution failure is "not wired"
+        logger.warning("no %s bound; org/user fields stay null", StaffDeptPlugin.__name__)
+        return None
+
+
+@router.get("", response_model=Envelope[OrgUserIdentity])
+@envelope_errors
+async def get_org_user(
+    request: Request,
+    caller: Annotated[VerifiedCaller, Depends(require_org_user_caller)],
+    user_id: Annotated[
+        str,
+        Query(
+            alias="user_id",
+            # min_length only (mirrors the sibling): a blank value names nobody
+            # and is a 422. No upper bound — the identity boundary has none
+            # (GatewayUser.id is unconstrained).
+            min_length=1,
+            description=(
+                "Required directory filter — the work number of the user whose "
+                "identity+department to return. The answer comes from the staff "
+                "directory, not the verified caller. Any authenticated caller may "
+                "name any user; there is no self-only restriction here."
+            ),
+        ),
+    ],
+) -> Envelope[OrgUserIdentity]:
+    """Return the identity+department of the user named by ``user_id``.
+
+    A directory lookup, not a whoami: ``user_id`` is required and
+    authoritative, and that user's identity **and** department come from the
+    staff directory (the gateway signs only the caller, so another user's
+    identity is read off HR, not the principal). There is no absent-param
+    fall-back to the caller's own identity.
+
+    A reader that is not wired leaves the looked-up fields null (``200``); a
+    real reader returns them, or an all-null info when the person has no
+    record / no dept. A reader that fails (directory down) raises and surfaces
+    as 5xx — so "no record" and "directory down" stay distinguishable.
+    """
+    info = None
+    reader = _staff_dept_reader(request)
+    if reader is not None:
+        # ``DeptLookupError`` deliberately not caught — infra failure surfaces
+        # as 5xx, distinct from the all-None "no record" 200, like the sibling.
+        info = await asyncio.to_thread(reader.get_user_by_work_no, work_no=user_id)
+    return envelope(
+        OrgUserIdentity(
+            user_id=user_id,
+            username=info.username if info else None,
+            display_name=info.display_name if info else None,
+            full_name=info.full_name if info else None,
+            tenant=caller.tenant,
+            dept_no=info.dept_no if info else None,
+            dept_name=info.dept_name if info else None,
+            dept_path=info.dept_path if info else None,
+        ),
+        request,
+    )

--- a/src/backend/tests/community/adapters/http/org/test_org_user.py
+++ b/src/backend/tests/community/adapters/http/org/test_org_user.py
@@ -1,0 +1,240 @@
+"""Endpoint-level coverage for ``GET /api/v1/org/user?user_id=``.
+
+A sibling of ``GET /openapi/v1/org/user`` at a separate prefix with its own
+access seam: ``require_org_user_caller`` wraps the cached, signature-verified
+``resolve_caller`` and raises ``MissingPrincipalError`` when there is no
+verified caller. ``user_id`` is a REQUIRED directory filter; the answer comes
+from the staff directory, the tenant from the verified caller. No reader
+wired (singlebox/community) ⇒ null fields + ``200``; directory unreachable
+(``DeptLookupError``) ⇒ ``5xx``; no or invalid principal ⇒ ``401``.
+
+Unlike the openapi_v1 sibling this route is a plain ``APIRouter``
+(``route_class=PublicAPIRoute`` is *not* used — that would force ADMISSION-table
+rows and the end-user/app-only adjudication the decoupled surface deliberately
+avoids), so a dependency-raised ``MissingPrincipalError`` is not folded into the
+public Envelope at the route layer. It surfaces to the app-level
+``_principal_error_handler``, which (per its own docstring) routes an internal
+``/api`` path reaching the verifier directly to a ``401`` carrying the
+``{"detail": "Unauthorized"}`` shape internal callers parse — *not* the
+Envelope. Success and the ``DeptLookupError`` ``5xx`` are still the Envelope,
+because those are produced in the handler body under ``@envelope_errors``.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
+from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
+from agentclaw.community.adapters.http.openapi_v1.errors import (
+    DeptLookupError,
+    MissingPrincipalError,
+)
+from agentclaw.community.plugin_api.staff_dept import (
+    StaffDeptPlugin,
+    UserIdentityInfo,
+)
+from agentclaw.community.utils.avernet_tenant import DEFAULT_AVERNET_TENANT
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+    reset_principal_verifier_config_cache,
+)
+
+# Mounts the route under test (it is a standalone router, not built by
+# ``build_public_router``) — imported last so the docstring/read order is stable.
+from agentclaw.community.adapters.http.org.router import router as org_user_router  # noqa: E402
+
+KEY = "org-user-api-test-shared-secret-32-bytes-min"
+USER = "caller-u-1"
+LOOKED_UP = "302992"
+
+
+class _Secret:
+    secret_user = "gateway"
+
+    def __init__(self, value: str) -> None:
+        self.secret_value = value
+
+
+@pytest.fixture(autouse=True)
+def signing_key():
+    """Boot the verifier with the shared key both cases are judged against.
+
+    The refusal case needs it as much as the happy one: without a booted
+    verifier a 401 could come from an unconfigured seam rather than from the
+    missing/invalid principal.
+    """
+
+    class _Resolver:
+        def get_secret(self, _secret_name: str) -> _Secret:
+            return _Secret(KEY)
+
+    init_principal_verifier_config(_Resolver(), "org_user_signing_key", strict=False)
+    yield
+    reset_principal_verifier_config_cache()
+
+
+def _user() -> dict:
+    """The user principal's subject — ``username`` is REQUIRED by the verifier."""
+    return {"id": USER, "username": "caller@example.com"}
+
+
+def _token(user: dict | None) -> str:
+    now = int(time.time())
+    principals: list[dict] = []
+    if user is not None:
+        principals.append({"type": "user", "subject": user})
+    return jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 60,
+            "principals": principals,
+        },
+        KEY,
+        algorithm="HS256",
+    )
+
+
+def _auth(user: dict | None = None) -> dict[str, str]:
+    return {PRINCIPAL_HEADER: _token(user=user)}
+
+
+def _make_app(staff_dept: StaffDeptPlugin | None = None) -> FastAPI:
+    # Mirror the prod app's exception handlers for the exceptions this route can
+    # surface: ``_principal_error_handler`` maps a dependency-raised
+    # ``MissingPrincipalError`` to the internal-``/api`` 401 (``{"detail": ...}``,
+    # not the Envelope); ``_unhandled_exception_handler`` is the catch-all.
+    from agentclaw.community.adapters.http.app import (
+        _principal_error_handler,
+        _unhandled_exception_handler,
+    )
+
+    app = FastAPI()
+    app.add_middleware(AvernetTenantMiddleware)
+    app.include_router(org_user_router)
+    app.add_exception_handler(MissingPrincipalError, _principal_error_handler)
+    app.add_exception_handler(Exception, _unhandled_exception_handler)
+    if staff_dept is not None:
+        # The handler resolves the reader off ``app.state.injector``; a stub
+        # injector binding ``StaffDeptPlugin`` to ``staff_dept`` is enough.
+        app.state.injector = _StubInjector(staff_dept)
+    return app
+
+
+class _StubInjector:
+    """Duck injector: ``get(StaffDeptPlugin)`` returns the bound reader."""
+
+    def __init__(self, staff_dept: StaffDeptPlugin) -> None:
+        self._staff_dept = staff_dept
+
+    def get(self, interface, scope=None):  # noqa: ARG002
+        if interface is StaffDeptPlugin:
+            return self._staff_dept
+        raise LookupError(interface)
+
+
+class _Reader:
+    """A ``StaffDeptPlugin`` stub returning a fixed record, by work number.
+
+    Only ``get_user_by_work_no`` is exercised by the handler, so the other
+    Protocol methods are not implemented — duck typing, not conformance.
+    """
+
+    def __init__(
+        self,
+        info_by_work_no: dict[str, UserIdentityInfo] | None = None,
+        raise_on: set[str] | None = None,
+    ) -> None:
+        self._by = info_by_work_no or {}
+        self._raise_on = raise_on or set()
+
+    def get_user_by_work_no(self, *, work_no: str) -> UserIdentityInfo:
+        if work_no in self._raise_on:
+            raise DeptLookupError("directory down")
+        return self._by.get(work_no, UserIdentityInfo(work_no=work_no))
+
+
+def test_missing_user_id_is_a_validation_failure():
+    """``?user_id=`` is required — its absence is a 422, never a directory read."""
+    client = TestClient(_make_app(), raise_server_exceptions=False)
+    resp = client.get("/api/v1/org/user", headers=_auth(_user()))
+    assert resp.status_code == 422, resp.text
+
+
+def test_no_principal_is_the_surface_uniform_refusal():
+    """No ``X-Avernet-Principal`` — no answer.
+
+    A decoupled ``/api`` route reaching the verifier directly is answered with
+    the internal ``401`` ``{"detail": "Unauthorized"}`` shape (the app-level
+    ``_principal_error_handler``), not the public Envelope.
+    """
+    client = TestClient(_make_app(), raise_server_exceptions=False)
+    resp = client.get("/api/v1/org/user", params={"user_id": LOOKED_UP})
+    assert resp.status_code == 401, resp.text
+    assert resp.json()["detail"] == "Unauthorized"
+
+
+def test_unwired_lookup_returns_null_fields_200():
+    """No reader bound ⇒ identity+dept null; ``user_id`` echoes, tenant from caller."""
+    client = TestClient(_make_app(), raise_server_exceptions=False)
+    resp = client.get(
+        "/api/v1/org/user",
+        headers=_auth(_user()),
+        params={"user_id": LOOKED_UP},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+    assert data["user_id"] == LOOKED_UP
+    assert data["username"] is None
+    assert data["tenant"] == DEFAULT_AVERNET_TENANT
+    assert data["dept_no"] is None
+    assert data["dept_name"] is None
+    assert data["dept_path"] is None
+
+
+def test_wired_reader_returns_lookup_result_200():
+    """With a reader, the directory's identity+dept are returned for the id."""
+    info = UserIdentityInfo(
+        work_no=LOOKED_UP,
+        username="alice@example.com",
+        display_name="Alice",
+        full_name="Alice Zhang",
+        dept_no="D-1",
+        dept_name="Platform",
+        dept_path="Ant/Platform",
+    )
+    reader = _Reader(info_by_work_no={LOOKED_UP: info})
+    client = TestClient(_make_app(staff_dept=reader), raise_server_exceptions=False)
+    resp = client.get(
+        "/api/v1/org/user",
+        headers=_auth(_user()),
+        params={"user_id": LOOKED_UP},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+    assert data["user_id"] == LOOKED_UP
+    assert data["username"] == "alice@example.com"
+    assert data["display_name"] == "Alice"
+    assert data["full_name"] == "Alice Zhang"
+    assert data["dept_no"] == "D-1"
+    assert data["dept_name"] == "Platform"
+    assert data["dept_path"] == "Ant/Platform"
+
+
+def test_directory_unreachable_surfaces_5xx():
+    """``DeptLookupError`` is not caught — infra failure, distinct from no-record 200."""
+    reader = _Reader(raise_on={LOOKED_UP})
+    client = TestClient(_make_app(staff_dept=reader), raise_server_exceptions=False)
+    resp = client.get(
+        "/api/v1/org/user",
+        headers=_auth(_user()),
+        params={"user_id": LOOKED_UP},
+    )
+    assert resp.status_code >= 500, resp.text

--- a/src/backend/tests/community/endpoints/test_org_user.py
+++ b/src/backend/tests/community/endpoints/test_org_user.py
@@ -1,0 +1,119 @@
+"""Framework coverage for ``GET /api/v1/org/user?user_id=`` — the decoupled
+directory-identity read.
+
+Two cases satisfy the coverage gate (happy + error): a verified caller names a
+``user_id`` and gets the directory entry (identity null with no reader wired —
+the framework app binds no ``StaffDeptPlugin`` for this surface), and no signed
+principal is answered the surface's ``401``.
+
+Adapter-level behaviour — lookup with a wired reader, ``DeptLookupError`` →
+``5xx``, app-only admittance — lives in the adapter suite at
+``adapters/http/org/test_org_user.py``. This file exists because the coverage
+gate reads the ``@endpoint_test`` registry, not that file.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+
+from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_HEADER
+from agentclaw.community.utils.gateway_principal_config import (
+    init_principal_verifier_config,
+)
+from tests.community.framework import (
+    CaseInput,
+    ExpectError,
+    ExpectSuccess,
+    endpoint_test,
+)
+
+_PATH = "/api/v1/org/user"
+_CALLER = "org-user-framework-caller"
+_KEY = "org-user-framework-signing-key-32b"
+
+
+class _Secret:
+    secret_user = "test"
+    secret_value = _KEY
+
+
+class _Resolver:
+    def get_secret(self, _secret_name: str) -> _Secret:
+        return _Secret()
+
+
+def _principal() -> str:
+    """A user-only identity set — the caller shape this endpoint exists for."""
+    now = int(time.time())
+    return jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 3600,
+            "principals": [
+                {
+                    "type": "user",
+                    "subject": {
+                        "id": _CALLER,
+                        "username": f"{_CALLER}@example.test",
+                        "display_name": "Caller",
+                    },
+                }
+            ],
+        },
+        _KEY,
+        algorithm="HS256",
+    )
+
+
+def _boot_verifier(_world) -> None:
+    """Install the shared key both cases are judged against.
+
+    The refusal case needs it as much as the happy one: without a booted
+    verifier the 401 could come from an unconfigured seam rather than the
+    missing header, and the case would pass for the wrong reason.
+    """
+    init_principal_verifier_config(_Resolver(), "test-key", strict=False)
+
+
+@endpoint_test(
+    method="GET",
+    path=_PATH,
+    scenario="directory_lookup_by_user_id",
+    input=CaseInput(
+        headers={PRINCIPAL_HEADER: _principal()},
+        query_params={"user_id": _CALLER},
+    ),
+    seed=_boot_verifier,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "code": 200000,
+            "message": "OK",
+            "data": {"user_id": _CALLER, "username": None},
+        },
+    ),
+)
+def org_user_directory_lookup_ok():
+    """Body intentionally empty — the framework owns invocation."""
+
+
+@endpoint_test(
+    method="GET",
+    path=_PATH,
+    scenario="unauthenticated",
+    input=CaseInput(),
+    seed=_boot_verifier,
+    # A decoupled ``/api`` route reaching the verifier directly is answered with
+    # the internal ``401`` ``{"detail": ...}`` shape (the app-level
+    # ``_principal_error_handler``), not the public Envelope.
+    expect=ExpectError(
+        status=401,
+        json_contains={"detail": "Unauthorized"},
+    ),
+)
+def org_user_requires_a_principal():
+    """No ``X-Avernet-Principal`` — the internal-``/api`` uniform 401."""


### PR DESCRIPTION
Problem

  Internal services need to obtain an employee's identity and department information through a gateway-signed JWT (X-Avernet-Principal); if the caller cannot be verified, a 401 is returned (fail-closed principle). The
  existing /openapi/v1/org/user?user_id= performs the same lookup but sits on the public interface (cookie + openapi_v1 admission table), which does not suit internal direct calls. The _principal_error_handler in
  app.py already preserves the 401 {detail} fallback principle, dedicated to "internal /api routes that reach the validator directly" — but no route currently exposes this capability.

  Solution

  Add the route GET /api/v1/org/user?user_id=<work_no> (a plain APIRouter under the community module, not a PublicAPIRoute):

  - org/dependencies.py::require_org_user_caller wraps resolve_caller (the cached signature-verification seam); when the caller is None, it raises MissingPrincipalError → 401.
  - org/router.py::get_org_user mirrors /openapi/v1/org/user: user_id remains mandatory (missing → 422), an unconfigured reader → 200 + null, calls StaffDeptPlugin.get_user_by_work_no, the tenant comes from the
  caller, DeptLookupError → 5xx, returns Envelope[OrgUserIdentity]. Only application callers are permitted.
  - app.py: import + include_router. The 401 returns {"detail":"Unauthorized"} (not an Envelope), via the application-level _principal_error_handler; PublicAPIRoute is rejected by authorization.py (no ADMISSION row).

  Verification

  - Adapter suite (tests/community/adapters/http/org/test_org_user.py, 5 cases): 422 / 401 / 200-null / 200-with-data / 5xx — all pass.
  - Framework coverage gate (tests/community/endpoints/test_org_user.py, 2 cases): passes; the route is covered.
  - Regression tests adapters/http/openapi_v1 + adapters/http/org: 1392 passed, 2 skipped, 0 failed.
  - Not run: gateway-side e2e tests (injecting X-Avernet-Principal into /api/v1/org/user belongs to the infrastructure side and is out of scope for this PR).

  Compatibility & Risk

  - Purely additive: only 2 lines changed in app.py; existing behavior is unchanged.
  - The gateway must inject X-Avernet-Principal at /api/v1/org/user, otherwise every call returns 401.
  - The 401 returns {detail} (not an Envelope), consistent with the internal /api route contract (see app.py:726-731). Rollback: delete the include_router line and remove adapters/http/org/.

  Related Issues (optional)

  - ocb (corp) is a separate repository; once the community→ocb-public mirror completes, it will serve this route.