### PR TITLE
feat(baas): add expire-sandbox whitelist via system_config

### DIFF
--- a/src/baas/src/secbaas/community/bootstrap/_container.py
+++ b/src/baas/src/secbaas/community/bootstrap/_container.py
@@ -190,6 +190,7 @@ class ApplicationContainer(containers.DeclarativeContainer):
         bot_repo=repository.bot_repository,
         bot_device_rel_repo=repository.bot_device_rel_repository,
         arca_ttl_schedule_repository=repository.arca_ttl_schedule_repository,
+        system_config_service=services.system_config_service,
     )
 
     cron_lifecycle = providers.Singleton(

--- a/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
@@ -39,6 +39,7 @@ class CoreTaskContainer(containers.DeclarativeContainer):
     bot_repo = providers.Dependency()
     bot_device_rel_repo = providers.Dependency()
     arca_ttl_schedule_repository = providers.Dependency()
+    system_config_service = providers.Dependency()
 
     # ── DeviceTtlTimer task ──────────────────────────────────────────────────
 
@@ -166,4 +167,5 @@ class CoreTaskContainer(containers.DeclarativeContainer):
         bot_manage_service=bot_manage_service,
         bot_repo=bot_repo,
         bot_device_rel_repo=bot_device_rel_repo,
+        system_config_service=system_config_service,
     )

--- a/src/baas/src/secbaas/community/core/service/config/_constants.py
+++ b/src/baas/src/secbaas/community/core/service/config/_constants.py
@@ -88,3 +88,14 @@ class SystemConfigKey(StrEnum):
     关闭此开关使 eval 生命周期阶段的请求降级走 online 生产路由，
     避免 eval 路由指向不可用的评测容器。
     """
+
+    # ── Expired sandbox whitelist configuration ─────────────────────────────
+
+    EXPIRE_SANDBOX_WHITELIST_BOT_UUIDS = "expire_sandbox.whitelist_bot_uuids"
+    """Whitelist for the expired ACK pod sweep (ExpireSandboxTimer).
+
+    Value: comma- and/or newline-separated list of bot_uuid (plain text).
+    Usage: read at the start of each sweep (env-scoped); a matching bot skips
+    the stop-bot / pod-destroy, exempting long-running demos, canaries, and key
+    accounts that must not be reclaimed by expiry.
+    """

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_expire_sandbox_timer_task.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_expire_sandbox_timer_task.py
@@ -25,20 +25,38 @@ bounded concurrency 停 bot。依赖通过构造方法注入，由 DI 容器管�
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from uuid import uuid4
 
 from secbaas.community.api.bot_manage import BotManageService
+from secbaas.community.api.config_manage import SystemConfigManageService
 from secbaas.community.core.repository.bot import BotRepository
 from secbaas.community.core.repository.bot_device_rel import BotDeviceRelRepository
 from secbaas.community.core.repository.device import DeviceRepository
+from secbaas.community.core.service.config import SystemConfigKey
 from secbaas.community.core.service.distributed_lock import DistributedLockService
 from secbaas.community.core.utils.env_utils import get_current_env
 from secbaas.community.logger import get_logger
 
 log = get_logger("core-scheduler")
+
+#: Delimiters for the whitelist conf_value: comma or newline (incl. CR).
+_WHITELIST_DELIMITERS = re.compile(r"[,\n\r]+")
+
+
+def parse_whitelist_bot_uuids(conf_value: str | None) -> set[str]:
+    """Parse ``conf_value`` into a set of trimmed, non-empty bot_uuids.
+
+    Delimiters are commas or newlines (mixable); each token is stripped; empty
+    tokens are ignored. ``None`` / whitespace / no valid tokens -> empty set.
+    """
+    if not conf_value:
+        return set()
+    tokens = _WHITELIST_DELIMITERS.split(conf_value)
+    return {token.strip() for token in tokens if token.strip()}
 
 
 @dataclass
@@ -118,6 +136,7 @@ class ExpireSandboxTimerTask:
         bot_manage_service: BotManageService,
         bot_repo: BotRepository,
         bot_device_rel_repo: BotDeviceRelRepository,
+        system_config_service: SystemConfigManageService,
     ) -> None:
         self._config = config
         self._lock_service = lock_service
@@ -125,6 +144,7 @@ class ExpireSandboxTimerTask:
         self._bot_manage_service = bot_manage_service
         self._bot_repo = bot_repo
         self._bot_device_rel_repo = bot_device_rel_repo
+        self._system_config_service = system_config_service
         self._running = False
 
     @property
@@ -198,6 +218,8 @@ class ExpireSandboxTimerTask:
         effective_batch = self._config.batch_size
         sem = asyncio.Semaphore(self._config.max_page_concurrency)
 
+        whitelist = self._load_whitelist()
+
         last_id: int = 0
         page_count: int = 0
         scanned: int = 0
@@ -267,6 +289,13 @@ class ExpireSandboxTimerTask:
                             )
                             _mark_skip("no_bot")
                             return
+                        if bot_uuid in whitelist:
+                            log.info(
+                                "[ExpireSandbox] bot %s whitelisted, skip expire",
+                                bot_uuid,
+                            )
+                            _mark_skip("whitelisted")
+                            return
                         await self._bot_manage_service.stop_bot(
                             tenant=tenant,
                             bot_uuid=bot_uuid,
@@ -313,3 +342,18 @@ class ExpireSandboxTimerTask:
         if bot is None:
             return None
         return bot.bot_uuid
+
+    def _load_whitelist(self) -> set[str]:
+        """Read this run's whitelist from system_config (env-scoped); treat failures as empty (fail open)."""
+        try:
+            resp = self._system_config_service.get_config(
+                SystemConfigKey.EXPIRE_SANDBOX_WHITELIST_BOT_UUIDS
+            )
+        except Exception as e:
+            log.warning(
+                "[ExpireSandbox] read whitelist config failed, treating as empty: %s", e
+            )
+            return set()
+        if resp is None:
+            return set()
+        return parse_whitelist_bot_uuids(resp.conf_value)

--- a/src/baas/tests/integration/core/service/scheduler/test_expire_sandbox_timer_task.py
+++ b/src/baas/tests/integration/core/service/scheduler/test_expire_sandbox_timer_task.py
@@ -50,6 +50,7 @@ def _build_task(container) -> ExpireSandboxTimerTask:
         bot_manage_service=container.services.bot_management_service(),
         bot_repo=container.repository.bot_repository(),
         bot_device_rel_repo=container.repository.bot_device_rel_repository(),
+        system_config_service=container.services.system_config_service(),
     )
 
 
@@ -182,3 +183,95 @@ class TestExpireSandboxStopsBot:
         device = device_repository.get_by_id(device_id, tenant=tenant, env=TEST_ENV)
         assert device is not None
         assert device.status == DeviceStatus.ACTIVE.value
+
+
+class TestExpireSandboxWhitelist:
+    @pytest.mark.asyncio
+    async def test_whitelisted_bot_is_skipped(
+        self,
+        bot_repository,
+        device_repository,
+        rel_repository,
+        system_config_repository,
+        created_bot_ids,
+        created_device_ids,
+        created_rel_ids,
+        created_config_ids,
+    ):
+        tenant = f"t-{uuid4().hex[:8]}"
+
+        bot_uuid = uuid4().hex
+        bot_id = bot_repository.insert_bot(
+            bot_uuid=bot_uuid,
+            tenant=tenant,
+            env=TEST_ENV,
+            domain="test",
+            creator="tester",
+            modifier="tester",
+            status=BotStatus.ACTIVE.value,
+            name="whitelisted-bot",
+            description=None,
+            template_uuid=None,
+            replica_desired=1,
+            replica_minimum=1,
+            replica_maximum=10,
+            auto_scaling_enabled=0,
+            sla_grade="standard",
+            extra_config={},
+        )
+        created_bot_ids.append(bot_id)
+
+        device_uuid = uuid4().hex
+        device_id = device_repository.insert_device(
+            device_uuid=device_uuid,
+            tenant=tenant,
+            env=TEST_ENV,
+            domain="test",
+            creator="tester",
+            modifier="tester",
+            status=DeviceStatus.ACTIVE.value,
+            provider_type="ARCA",
+            provider_device_id="sbx-whitelisted",
+            provider_device_props={
+                "sandbox_id": "sbx-whitelisted",
+                "ttl_expiration_timestamp": int((time.time() - 3600) * 1000),
+            },
+            extra_config={"deploy_config": {"ttl_in_minutes": 10080}},
+        )
+        created_device_ids.append(device_id)
+
+        rel_id = rel_repository.insert_rel(
+            bot_id=bot_id,
+            device_uuid=device_uuid,
+            tenant=tenant,
+            env=TEST_ENV,
+            domain="test",
+            creator="tester",
+            modifier="tester",
+        )
+        created_rel_ids.append(rel_id)
+
+        config_id = system_config_repository.insert_config(
+            conf_key="expire_sandbox.whitelist_bot_uuids",
+            conf_value=bot_uuid,
+            env=TEST_ENV,
+            name="expire whitelist",
+            description=None,
+            creator="tester",
+            modifier="tester",
+        )
+        created_config_ids.append(config_id)
+
+        container = get_container()
+        task = _build_task(container)
+        report = await task.run()
+
+        assert report is not None
+        assert report.scanned >= 1
+        assert report.skipped >= 1
+        assert report.skipped_reasons.get("whitelisted", 0) >= 1
+        assert report.stopped == 0
+
+        bot = bot_repository.get_by_id(bot_id, tenant=tenant, env=TEST_ENV)
+        assert bot is not None
+        assert bot.status == BotStatus.ACTIVE.value

--- a/src/baas/tests/unit/core/service/scheduler/test_expire_sandbox_timer_task.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_expire_sandbox_timer_task.py
@@ -12,6 +12,7 @@ import pytest
 from secbaas.community.core.service.scheduler._tasks._expire_sandbox_timer_task import (
     ExpireSandboxTimerTask,
     ExpireSandboxTimerTaskConfig,
+    parse_whitelist_bot_uuids,
 )
 
 
@@ -65,6 +66,7 @@ def _task(
     bot_repo=None,
     rel_repo=None,
     lock_service=None,
+    system_config_service=None,
 ):
     if config is None:
         config = ExpireSandboxTimerTaskConfig(enabled=True, arca_provider="aliyun_ack")
@@ -73,6 +75,9 @@ def _task(
         # so normalize it to the eligible provider unless a non-ack variant is
         # explicitly requested.
         config.arca_provider = "aliyun_ack"
+    if system_config_service is None:
+        system_config_service = MagicMock()
+        system_config_service.get_config.return_value = None
     return ExpireSandboxTimerTask(
         config=config,
         lock_service=lock_service or _lock(),
@@ -80,6 +85,7 @@ def _task(
         bot_manage_service=bot_manage or MagicMock(),
         bot_repo=bot_repo or MagicMock(),
         bot_device_rel_repo=rel_repo or MagicMock(),
+        system_config_service=system_config_service,
     )
 
 
@@ -400,3 +406,104 @@ class TestRun:
         task._running = True
         report = await task.run()
         assert report is None
+
+
+class TestWhitelist:
+    def _cfg(self, value):
+        return SimpleNamespace(conf_value=value)
+
+    def _whitelisted_task(self, conf_value):
+        repo = MagicMock()
+        repo.list_expired_paginated.side_effect = _pages([_row(1)])
+        bot_manage = MagicMock()
+        bot_manage.stop_bot = AsyncMock(return_value=MagicMock())
+        rel_repo = MagicMock()
+        rel_repo.get_by_device_uuid.return_value = _bot_rel(7)
+        bot_repo = MagicMock()
+        bot_repo.get_by_id.return_value = _bot_record("BOT-UUID-1")
+        svc = MagicMock()
+        svc.get_config.return_value = self._cfg(conf_value)
+        task = _task(
+            ExpireSandboxTimerTaskConfig(enabled=True),
+            repo=repo,
+            bot_manage=bot_manage,
+            bot_repo=bot_repo,
+            rel_repo=rel_repo,
+            system_config_service=svc,
+        )
+        return task, bot_manage
+
+    @pytest.mark.asyncio
+    async def test_whitelisted_bot_skipped(self):
+        task, bot_manage = self._whitelisted_task("BOT-UUID-1")
+        report = await task.run()
+        assert report.stopped == 0
+        assert report.skipped == 1
+        assert report.skipped_reasons["whitelisted"] == 1
+        bot_manage.stop_bot.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_whitelisted_bot_stopped(self):
+        task, bot_manage = self._whitelisted_task("OTHER-UUID")
+        report = await task.run()
+        assert report.stopped == 1
+        assert report.skipped == 0
+        bot_manage.stop_bot.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_missing_config_empty_whitelist(self):
+        task, bot_manage = self._whitelisted_task(None)
+        # overridden to return None (missing row)
+        task._system_config_service.get_config.return_value = None
+        report = await task.run()
+        assert report.stopped == 1
+        bot_manage.stop_bot.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_whitespace_config_empty_whitelist(self):
+        task, bot_manage = self._whitelisted_task("")
+        report = await task.run()
+        assert report.stopped == 1
+        bot_manage.stop_bot.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_malformed_config_empty_whitelist(self):
+        task, bot_manage = self._whitelisted_task(" , \n,,  \r\n ")
+        report = await task.run()
+        assert report.stopped == 1
+        bot_manage.stop_bot.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_multiple_delimiters(self):
+        task, bot_manage = self._whitelisted_task("A1, B2\nC3\r\n D4 ,")
+        # bot is BOT-UUID-1, not in list → stopped
+        report = await task.run()
+        assert report.stopped == 1
+        bot_manage.stop_bot.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_read_error_fails_open(self):
+        task, bot_manage = self._whitelisted_task("BOT-UUID-1")
+        task._system_config_service.get_config.side_effect = RuntimeError("db down")
+        report = await task.run()
+        assert report.stopped == 1
+        bot_manage.stop_bot.assert_awaited_once()
+
+
+class TestParseWhitelist:
+    def test_none(self):
+        assert parse_whitelist_bot_uuids(None) == set()
+
+    def test_empty_string(self):
+        assert parse_whitelist_bot_uuids("") == set()
+
+    def test_comma_and_newline(self):
+        assert parse_whitelist_bot_uuids("a1, b2\nc3\r\n d4 ,") == {
+            "a1",
+            "b2",
+            "c3",
+            "d4",
+        }
+
+    def test_whitespace_only(self):
+        assert parse_whitelist_bot_uuids(" , \n, \r\n ") == set()


### PR DESCRIPTION
## Problem

The `ExpireSandboxTimer` cron task reclaims expired Aliyun ACK sandbox pods by destroying the pod and stopping the bound bot. Some `baas_bot` instances must be kept alive past their derived TTL deadline (long-running demos, canaries, key accounts), but there was no way to exempt them. The whitelist also needed to be updatable at runtime without a reboot.

## Solution

Store the whitelist in `baas_system_config` (key `expire_sandbox.whitelist_bot_uuids`, comma/newline-separated `bot_uuid` list). The `ExpireSandboxTimer` reads it fresh each run via `SystemConfigManageService.get_config`, so operator edits apply on the next sweep with no restart.

- Inject `SystemConfigManageService` into `ExpireSandboxTimerTask`.
- Skip whitelisted bots before `stop_bot`, counted as a distinct `whitelisted` skip reason.
- Missing/empty/unreadable config → empty whitelist (fail open, logged on read error).
- Lenient parsing (comma + newline, trim, drop empties).

## Validation

- `tests/unit/core/service/scheduler/test_expire_sandbox_timer_task.py`: 32 passed
- `tests/integration/core/service/scheduler/test_expire_sandbox_timer_task.py`: 3 passed
- `tests/architecture/test_no_private_imports.py`: passed
- `ruff check` on all changed files: clean
- Changed-line coverage: 100%

## Compatibility and risk

Additive; no schema/migration. Missing config row preserves existing behavior. Rollback = delete the config row.

## Spec

`openspec/changes/baas-ack-expire-whitelist/` (proposal, design, specs, tasks)