### PR TITLE
feat: exclude aicoding workspace artifacts

### DIFF
--- a/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
+++ b/src/backend/src/agentclaw/community/core/workspace/engines/aicoding.py
@@ -40,6 +40,8 @@ _AICODING_RSYNC_EXCLUDES = [
     "workspace/skills/skills-center",
     "workspace/skills-pool/skills-repo",
     "workspace/skills-pool/.skills-repo*",
+    "workspace/.repos",
+    "workspace/.prewarm/ready.json",
     "skills/*/.git/",
     "memory/",
     "logs/",

--- a/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
+++ b/src/backend/tests/community/core/workspace/test_engine_sandbox_providers.py
@@ -189,6 +189,8 @@ class TestAICodingProvider:
         assert plan.workspace_subdir == "workspace"
         assert plan.skill_source_relpath == "workspace/skills"
         assert plan.skill_target_relpath == "workspace/skills"
+        assert "workspace/.repos" in plan.rsync_excludes
+        assert "workspace/.prewarm/ready.json" in plan.rsync_excludes
 
     def test_build_plan_keeps_extra_sync_from_claude(self):
         provider = AICodingSandboxProvider(workspace=_workspace())


### PR DESCRIPTION
Add rsync excludes for workspace/.repos and workspace/.prewarm/ready.json.