### PR TITLE
fix(backend): preserve MCP config on set deactivation

### DIFF
--- a/src/backend/specs/2026-08-27-mcp-effective-retained-projection/plan.md
+++ b/src/backend/specs/2026-08-27-mcp-effective-retained-projection/plan.md
@@ -1,0 +1,49 @@
+# Plan — MCP mutation scope 最小修复
+
+## Baseline and seams
+
+- Base: 最新 `REL20260828`。
+- Service seam: `SkillSetManagementService` 与 `DirectActivationService` 的公开命令。
+- Repository seam: `CapabilityDesiredStateRepository` 返回的 `DesiredStateMutation`。
+- Runtime seam: `BotRuntimeProjectorProtocol.project(..., scope=...)`。
+- Adapter、DeviceActivated、Dispatcher 与 Plugin 不改动，只做回归验证。
+
+## Vertical slices
+
+### 1. SkillSet deactivate 不释放 MCP 配置
+
+Red：repository result 带 MCP code，断言 projector 收到空 claimed/released。
+
+Green：deactivate 改为固定 `ProjectionScope(skills=True, mcp=True)`。
+
+### 2. SkillSet MCP no-op 不产生 delta
+
+Red：add/remove 返回 `changed=False, mcp_codes=empty`，断言 scope 为空。
+
+Green：add/remove 由 `scope_from_result` 构造 scope。
+
+### 3. Repository 只返回实际 MCP delta
+
+Red：真实 UoW 覆盖 ordinary Set、Default exclusion 和 Direct MCP 的 changed/no-op 结果。
+
+Green：changed mutation 返回对应 code，no-op 保持空集合；不做全局引用查询。
+
+### 4. Direct MCP no-op 不产生 delta
+
+Red：Direct activate/deactivate no-op 时断言 scope 为空。
+
+Green：Direct commands 使用与 SkillSet MCP 相同的 result-to-scope helper。
+
+## Verification
+
+1. 每个 slice 执行对应单测 red→green。
+2. 运行两个 Service 测试文件和 repository UoW 测试文件。
+3. 运行 Python format/lint/type/static checks。
+4. 运行受影响 Backend 测试套件。
+5. 对 `REL20260828...HEAD` 执行 Standards 与本 Spec 双轴 review。
+6. 修复阻断发现、复验、提交并更新现有 PR。
+
+## Deliberate non-work
+
+不实现全局 Retained 查询、跨 SkillSet release guard、inactive cleanup、async delete、
+DeviceActivated inactive hydration、provider/engine 分叉或额外运行时协议。

--- a/src/backend/specs/2026-08-27-mcp-effective-retained-projection/spec.md
+++ b/src/backend/specs/2026-08-27-mcp-effective-retained-projection/spec.md
@@ -1,0 +1,60 @@
+# MCP mutation scope 最小修复
+
+## Status
+
+本文件是 2026-08-28 owner review 后的权威范围，取代此前“建立完整 Effective / Retained
+双投影”的宽版方案。实现以 `REL20260828` 为基线，只修正 mutation scope 的声明与透传。
+
+## Problem
+
+`SkillSetManagementService.deactivate()` 将 mutation result 中的 MCP code 当作
+`released_mcp` 传给 runtime projector。Set 变为 inactive 时 membership 仍然存在，因此
+这些 code 只应退出 callable/Effective 状态，不应被当作物理配置删除候选。
+
+MCP add/remove、Default exclusion/unexclusion 和 Direct activate/deactivate 还存在另一类
+scope 问题：它们从请求参数直接构造 delta。即使 repository 返回 `changed=False`，请求中的
+code 仍会被错误声明为 claimed/released。
+
+## Required semantics
+
+| Command | Runtime projection scope |
+| --- | --- |
+| SkillSet activate | `skills=True, mcp=True, claimed_mcp=result.mcp_codes` |
+| SkillSet deactivate | `skills=True, mcp=True`，claimed/released 均为空 |
+| MCP add / Default unexclude / Direct activate | 从 mutation result 构造 claimed delta |
+| MCP remove / Default exclude / Direct deactivate | 从 mutation result 构造 released delta |
+| MCP mutation `changed=False` | 空 MCP delta |
+| inactive ordinary Set membership add/remove | 保持 REL 行为：只写 DB，不访问 runtime |
+| inactive Set delete | 保持 REL 行为：同步 Service API，只写 DB |
+| DeviceActivated | 保持 REL 行为，不扩大到 inactive configuration references |
+
+Repository 只在 mutation 实际改变 MCP desired state 时，将对应 code 放入
+`DesiredStateMutation.mcp_codes`；no-op 返回空集合。`scope_from_result` 只负责把该结果翻译为
+`ProjectionScope`，不重新查询数据库，也不引入新的持久化状态。
+
+## Compatibility
+
+- HTTP 路由、状态码和响应结构不变。
+- `SkillSetManagementService.delete_set()` 保持同步，不向 adapter 传播 async。
+- 现有 mutate-project-compensate 合同不变。
+- Service API、Plugin API 和 Dispatcher 边界不变。
+- 不增加表、字段、迁移、provider/engine 分叉或 task queue。
+
+## Explicitly out of scope
+
+- 同一个 MCP 被多个 SkillSet 引用后的全局 release 计算。当前 ownership policy 已阻止同一
+  MCP 加入不同 SkillSet；本次不修复历史异常数据或 Skill dependency 交叉引用。
+- 全局 Retained resolver/read projection。
+- `McpConfigurationQueries` 或任何 `DesiredStateDeletion`/Retained 持久化模型。
+- inactive remove/delete 的 best-effort runtime cleanup。
+- DeviceActivated 对 inactive MCP configuration 的额外恢复。
+- Teclaw whole-artifact、并发、性能、队列及完整协作者权限模型扩展。
+
+## Acceptance criteria
+
+1. deactivate mutation 即使返回 MCP codes，projector 收到的 claimed/released 仍为空。
+2. changed MCP add/remove、Default exclusion/unexclusion、Direct activate/deactivate 只声明实际
+   changed code。
+3. 上述 MCP mutation no-op 时，projector 收到空 MCP delta。
+4. inactive membership mutation 与 delete 保持 `REL20260828` 的 runtime 行为。
+5. DeviceActivated 和所有 delivery adapter 相对 `REL20260828` 无行为变化。

--- a/src/backend/src/agentclaw/community/core/repository/capability_desired_state_types.py
+++ b/src/backend/src/agentclaw/community/core/repository/capability_desired_state_types.py
@@ -35,12 +35,14 @@ class DesiredStateMutation:
     mcp_codes: frozenset[str] = frozenset()
     """MCP codes this mutation claimed or released, if it touched any.
 
-    Two kinds of command fill it, for the same reason: neither can name its
-    MCP scope before the mutation runs. Activation learns the Set's member
-    codes; a Skill mutation learns the Skill's ``mcp_dependencies``, which
-    join or leave the projected MCP set along with the Skill. Both are read
-    under the row lock the transaction already holds, so the scope names what
-    was actually installed rather than what a second, unlocked query saw.
+    Commands fill it when the committed mutation actually moves MCP state.
+    Explicit MCP and Direct commands name their changed code; activation learns
+    the Set's member codes; a Skill mutation learns the Skill's
+    ``mcp_dependencies``. No-op mutations leave it empty, so callers do not
+    synthesize a runtime delta from request parameters alone. The values are
+    resolved under the row lock the transaction already holds, so the scope
+    names what was actually installed rather than what a second, unlocked
+    query saw.
 
     Candidates, not a verdict — the projector intersects them with the set it
     resolved, so a claim that does not survive projection is never delivered

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
@@ -120,7 +120,10 @@ class McpSkillSetControlPlaneCommands:
                     env=get_current_env(), server_code=server_code,
                 )
             session.flush()
-            return DesiredStateMutation(self._as_item(row), True, old)
+            return DesiredStateMutation(
+                self._as_item(row), True, old,
+                mcp_codes=frozenset({server_code}),
+            )
 
     def remove_mcp(
         self, *, bot_id: str, owner_id: str, set_id: str, server_code: str,
@@ -144,7 +147,7 @@ class McpSkillSetControlPlaneCommands:
                     .first()
                 )
                 if existing is not None:
-                    return SkillSetMutation(self._as_item(row), False, old)
+                    return DesiredStateMutation(self._as_item(row), False, old)
                 session.add(
                     DefaultSkillsetMcpExclusion(
                         user_id=owner_id,
@@ -155,7 +158,7 @@ class McpSkillSetControlPlaneCommands:
                     )
                 )
                 session.flush()
-                return SkillSetMutation(self._as_item(row), True, old)
+                return DesiredStateMutation(self._as_item(row), True, old)
             self._ordinary(row)
             membership = (
                 self._scope(session.query(SkillSetMCPServer), SkillSetMCPServer)
@@ -171,7 +174,10 @@ class McpSkillSetControlPlaneCommands:
                     env=get_current_env(), server_codes={server_code},
                 )
             session.flush()
-            return DesiredStateMutation(self._as_item(row), True, old)
+            return DesiredStateMutation(
+                self._as_item(row), True, old,
+                mcp_codes=frozenset({server_code}),
+            )
 
     def exclude_default_mcp(
         self, *, bot_id: str, owner_id: str, set_id: str, server_code: str,
@@ -221,7 +227,10 @@ class McpSkillSetControlPlaneCommands:
             if not created and removed_installation == 0:
                 return DesiredStateMutation(self._as_item(row), False, old)
             session.flush()
-            return DesiredStateMutation(self._as_item(row), True, old)
+            return DesiredStateMutation(
+                self._as_item(row), True, old,
+                mcp_codes=frozenset({server_code}),
+            )
 
     def unexclude_default_mcp(
         self, *, bot_id: str, owner_id: str, set_id: str, server_code: str,
@@ -249,7 +258,10 @@ class McpSkillSetControlPlaneCommands:
                     env=get_current_env(), server_code=server_code,
                 )
             session.flush()
-            return DesiredStateMutation(self._as_item(row), True, old)
+            return DesiredStateMutation(
+                self._as_item(row), True, old,
+                mcp_codes=frozenset({server_code}),
+            )
 
     def excluded_default_mcp_codes(
         self, *, bot_id: str, owner_id: str, set_id: str
@@ -289,7 +301,9 @@ class McpSkillSetControlPlaneCommands:
                 env=get_current_env(), server_code=server_code,
             )
             session.flush()
-            return DesiredStateMutation({}, True, old)
+            return DesiredStateMutation(
+                {}, True, old, mcp_codes=frozenset({server_code})
+            )
 
     def uninstall_mcp(
         self, *, bot_id: str, owner_id: str, server_code: str,
@@ -318,7 +332,10 @@ class McpSkillSetControlPlaneCommands:
                 env=get_current_env(), server_codes={server_code},
             ) > 0
             session.flush()
-            return DesiredStateMutation({}, changed, old)
+            return DesiredStateMutation(
+                {}, changed, old,
+                mcp_codes=frozenset({server_code}) if changed else frozenset(),
+            )
 
     def list_installed_mcps(self, *, bot_id: str, owner_id: str, engine_type: str | None = None) -> set[str]:
         with self._db.orm_session() as session:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/_mutation_flow.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/_mutation_flow.py
@@ -65,6 +65,22 @@ def skill_release_scope(result: DesiredStateMutation) -> ProjectionScope:
     )
 
 
+def mcp_claim_scope(result: DesiredStateMutation) -> ProjectionScope:
+    """Project only the MCP codes the committed mutation actually claimed."""
+    return ProjectionScope(
+        mcp=bool(result.mcp_codes),
+        claimed_mcp=result.mcp_codes,
+    )
+
+
+def mcp_release_scope(result: DesiredStateMutation) -> ProjectionScope:
+    """Project only the MCP codes the committed mutation actually released."""
+    return ProjectionScope(
+        mcp=bool(result.mcp_codes),
+        released_mcp=result.mcp_codes,
+    )
+
+
 class MutationProjectionFlow:
     """Apply one desired-state mutation and synchronously project the runtime.
 
@@ -110,11 +126,11 @@ class MutationProjectionFlow:
         ``ProjectionScope.everything()`` and says so out loud.
 
         ``scope_from_result`` covers the commands that cannot name their scope
-        up front: activate, deactivate, and the Skill commands learn which
-        MCPs they claimed or released only from the mutation result, which the
-        repository fills in under the row lock it already holds. Building the
-        scope from a second, unlocked query instead could disagree with what
-        was actually installed.
+        up front: activate and membership commands learn which MCPs they
+        claimed or released only from the mutation result, which the repository
+        fills in under the row lock it already holds. Building the scope from a
+        second, unlocked query instead could disagree with what was actually
+        installed.
         """
         if (scope is None) == (scope_from_result is None):
             raise ValueError(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/direct_activation_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/direct_activation_service.py
@@ -44,10 +44,11 @@ from agentclaw.community.core.skill_center.policies.platform_default_mcp import 
 )
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     BotRuntimeProjectorProtocol,
-    ProjectionScope,
 )
 from agentclaw.community.core.skill_center.services._mutation_flow import (
     MutationProjectionFlow,
+    mcp_claim_scope,
+    mcp_release_scope,
     skill_claim_scope,
     skill_release_scope,
 )
@@ -213,10 +214,7 @@ class DirectActivationService:
                 engine_type=bot_engine_type(bot),
                 default_engine_types=bot_default_engine_types(bot),
             ),
-            # One MCP in, no Skill touched.
-            scope=ProjectionScope(
-                mcp=True, claimed_mcp=frozenset({server_code})
-            ),
+            scope_from_result=mcp_claim_scope,
         )
         self._audit(
             bot_id=bot_id, owner_id=str(bot["owner_id"]), actor_id=actor_id,
@@ -241,12 +239,7 @@ class DirectActivationService:
                 engine_type=bot_engine_type(bot),
                 default_engine_types=bot_default_engine_types(bot),
             ),
-            # One MCP out, no Skill touched. The projector subtracts the
-            # projected set before deleting, so a code the default policy or a
-            # Skill dependency still supplies survives.
-            scope=ProjectionScope(
-                mcp=True, released_mcp=frozenset({server_code})
-            ),
+            scope_from_result=mcp_release_scope,
         )
         self._audit(
             bot_id=bot_id, owner_id=str(bot["owner_id"]), actor_id=actor_id,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
@@ -43,6 +43,8 @@ from agentclaw.community.core.skill_center.runtime_projection_contract import (
 )
 from agentclaw.community.core.skill_center.services._mutation_flow import (
     MutationProjectionFlow,
+    mcp_claim_scope,
+    mcp_release_scope,
     skill_claim_scope,
     skill_release_scope,
 )
@@ -478,9 +480,7 @@ class SkillSetManagementService:
                 bot_id=bot_id,
                 actor_id=user_id,
                 action="default_set_unexclude_mcp",
-                scope=ProjectionScope(
-                    mcp=True, claimed_mcp=frozenset({server_code})
-                ),
+                scope_from_result=mcp_claim_scope,
                 mutation=lambda: self._repository.unexclude_default_mcp(
                     bot_id=bot_id,
                     owner_id=str(bot["owner_id"]),
@@ -497,7 +497,7 @@ class SkillSetManagementService:
             actor_id=user_id,
             action="skill_set_add_mcp",
             runtime_required=bool(target.get("is_active")),
-            scope=ProjectionScope(mcp=True, claimed_mcp=frozenset({server_code})),
+            scope_from_result=mcp_claim_scope,
             mutation=lambda: self._repository.add_mcp(
                 bot_id=bot_id,
                 owner_id=str(bot["owner_id"]),
@@ -528,9 +528,7 @@ class SkillSetManagementService:
                 bot_id=bot_id,
                 actor_id=user_id,
                 action="default_set_exclude_mcp",
-                scope=ProjectionScope(
-                    mcp=True, released_mcp=frozenset({server_code})
-                ),
+                scope_from_result=mcp_release_scope,
                 mutation=lambda: self._repository.exclude_default_mcp(
                     bot_id=bot_id,
                     owner_id=str(bot["owner_id"]),
@@ -549,7 +547,7 @@ class SkillSetManagementService:
             actor_id=user_id,
             action="skill_set_remove_mcp",
             runtime_required=bool(target.get("is_active")),
-            scope=ProjectionScope(mcp=True, released_mcp=frozenset({server_code})),
+            scope_from_result=mcp_release_scope,
             mutation=lambda: self._repository.remove_mcp(
                 bot_id=bot_id,
                 owner_id=str(bot["owner_id"]),
@@ -600,9 +598,10 @@ class SkillSetManagementService:
             bot_id=bot_id,
             actor_id=user_id,
             action="skill_set_deactivate",
-            scope_from_result=lambda result: ProjectionScope(
-                skills=True, mcp=True, released_mcp=result.mcp_codes
-            ),
+            # Deactivation withdraws callable state but keeps the Set and its
+            # configuration. Re-project both inventories without claiming or
+            # physically releasing MCP details.
+            scope=ProjectionScope(skills=True, mcp=True),
             mutation=lambda: self._repository.set_skill_set_active(
                 bot_id=bot_id,
                 owner_id=str(bot["owner_id"]),

--- a/src/backend/tests/community/core/skill_center/test_direct_activation_service.py
+++ b/src/backend/tests/community/core/skill_center/test_direct_activation_service.py
@@ -52,11 +52,15 @@ class _Repository:
 
     def install_mcp(self, **kwargs) -> DesiredStateMutation:
         self.install_mcp_calls.append(kwargs)
-        return self._mutation()
+        return replace(
+            self._mutation(), mcp_codes=frozenset({kwargs["server_code"]})
+        )
 
     def uninstall_mcp(self, **kwargs) -> DesiredStateMutation:
         self.uninstall_mcp_calls.append(kwargs)
-        return self._mutation()
+        return replace(
+            self._mutation(), mcp_codes=frozenset({kwargs["server_code"]})
+        )
 
     def install_skill(self, **kwargs) -> DesiredStateMutation:
         self.install_skill_calls.append(kwargs)
@@ -541,6 +545,38 @@ async def test_deactivating_one_mcp_releases_only_that_code():
     assert scope.skills is False
     assert scope.released_mcp == frozenset({"mcp.weather"})
     assert scope.claimed_mcp == frozenset()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method_name", ["activate_mcp", "deactivate_mcp"])
+async def test_an_unchanged_direct_mcp_command_declares_no_runtime_delta(
+    method_name: str,
+) -> None:
+    class _UnchangedMcpRepository(_Repository):
+        def install_mcp(self, **kwargs) -> DesiredStateMutation:
+            self.install_mcp_calls.append(kwargs)
+            return DesiredStateMutation(
+                {}, False, CapabilityDesiredState(set(), {}, {})
+            )
+
+        def uninstall_mcp(self, **kwargs) -> DesiredStateMutation:
+            self.uninstall_mcp_calls.append(kwargs)
+            return DesiredStateMutation(
+                {}, False, CapabilityDesiredState(set(), {}, {})
+            )
+
+    runtime = _ScopeRecordingRuntime()
+    service = _service(repository=_UnchangedMcpRepository(), runtime=runtime)
+
+    result = await getattr(service, method_name)(
+        server_code="mcp.weather",
+        bot_id="bot-1",
+        owner_id="true-owner",
+        actor_id="true-owner",
+    )
+
+    assert result["changed"] is False
+    assert runtime.scopes == [ProjectionScope()]
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import pathlib
 import re
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -75,6 +76,7 @@ class _Repository:
             item={"server_code": kwargs["server_code"]},
             changed=True,
             previous_state=CapabilityDesiredState(set(), {}, {}),
+            mcp_codes=frozenset({kwargs["server_code"]}),
         )
 
     def list_mcps(self, **_kwargs):
@@ -819,7 +821,15 @@ async def test_collaborator_command_restores_desired_state_and_uses_true_owner()
 
 @pytest.mark.asyncio
 async def test_deactivate_retires_mappings_removed_from_the_runtime_projection():
-    repository = _Repository()
+    class _McpSetRepository(_Repository):
+        def set_skill_set_active(self, **kwargs) -> DesiredStateMutation:
+            mutation = super().set_skill_set_active(**kwargs)
+            return replace(
+                mutation,
+                mcp_codes=frozenset({"mcp.weather"}),
+            )
+
+    repository = _McpSetRepository()
     runtime = _Runtime(snapshots=[_Runtime._skill_mappings(), ()], fail_first=False)
     service = SkillSetManagementService(
         repository=repository,
@@ -846,12 +856,10 @@ async def test_deactivate_retires_mappings_removed_from_the_runtime_projection()
             "bot_id": "bot-1",
             "owner_id": "true-owner",
             "retired_mappings": _Runtime._skill_mappings(),
-            # deactivate declares what it released rather than reconciling:
-            # the Set's MCP codes come back on the mutation result, resolved
-            # under the row lock that uninstalled them.
-            "scope": ProjectionScope(
-                skills=True, mcp=True, released_mcp=frozenset()
-            ),
+            # Deactivation withdraws callable state but retains the Set's MCP
+            # configuration. The mutation result deliberately carries the
+            # Set's code to prove it is not treated as a physical release.
+            "scope": ProjectionScope(skills=True, mcp=True),
         }
     ]
 
@@ -2198,6 +2206,42 @@ async def test_compensation_inverts_the_declared_mcp_delta():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("method_name", ["add_mcp", "remove_mcp"])
+async def test_an_unchanged_mcp_membership_declares_no_runtime_delta(
+    method_name: str,
+) -> None:
+    class _UnchangedMcpRepository(_Repository):
+        @staticmethod
+        def _unchanged(server_code: str) -> DesiredStateMutation:
+            return DesiredStateMutation(
+                item={"server_code": server_code},
+                changed=False,
+                previous_state=CapabilityDesiredState(set(), {}, {}),
+            )
+
+        def add_mcp(self, **kwargs) -> DesiredStateMutation:
+            return self._unchanged(kwargs["server_code"])
+
+        def remove_mcp(self, **kwargs) -> DesiredStateMutation:
+            return self._unchanged(kwargs["server_code"])
+
+    runtime = _Runtime(fail_first=False)
+    service = _skill_service(_UnchangedMcpRepository(), runtime)
+
+    result = await getattr(service, method_name)(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="true-owner",
+        set_id="set-1",
+        server_code="mcp.weather",
+    )
+
+    assert result["changed"] is False
+    (call,) = runtime.reconcile_calls
+    assert call["scope"] == ProjectionScope()
+
+
+@pytest.mark.asyncio
 async def test_reconcile_scope_claims_every_projected_code():
     """A restart or upload has no mutation to ask, so nothing is assumed.
 
@@ -2922,19 +2966,25 @@ class _DefaultTargetRepository(_Repository):
 
     def exclude_default_mcp(self, **kwargs) -> DesiredStateMutation:
         self.exclusion_calls.append(("exclude_default_mcp", kwargs))
-        return self._mutation()
+        return replace(
+            self._mutation(), mcp_codes=frozenset({kwargs["server_code"]})
+        )
 
     def unexclude_default_mcp(self, **kwargs) -> DesiredStateMutation:
         self.exclusion_calls.append(("unexclude_default_mcp", kwargs))
-        return self._mutation()
+        return replace(
+            self._mutation(), mcp_codes=frozenset({kwargs["server_code"]})
+        )
 
 
 class _ProjectionCountingRuntime(_SuccessfulRuntime):
     def __init__(self) -> None:
         self.projections = 0
+        self.scopes: list[ProjectionScope] = []
 
-    async def project(self, **_kwargs) -> None:
+    async def project(self, *, scope: ProjectionScope, **_kwargs) -> None:
         self.projections += 1
+        self.scopes.append(scope)
 
 
 def _default_wire_service(
@@ -3091,6 +3141,10 @@ async def test_default_mcp_exclusion_wire_mirrors_the_skill_wire():
         "unexclude_default_mcp",
     ]
     assert runtime.projections == 2
+    assert runtime.scopes == [
+        ProjectionScope(mcp=True, released_mcp=frozenset({"mcp.gone"})),
+        ProjectionScope(mcp=True, claimed_mcp=frozenset({"mcp.back"})),
+    ]
 
     with pytest.raises(
         SkillSetControlPlaneConflictError, match="SYSTEM_DEFAULT_IMMUTABLE"
@@ -3123,4 +3177,3 @@ async def test_unexcluding_a_default_mcp_still_requires_marketplace_permission()
             set_id="9", server_code="mcp.back",
         )
     assert repository.exclusion_calls == []
-

--- a/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
@@ -531,6 +531,14 @@ def test_active_skill_set_mutates_mcp_membership_and_installation_atomically():
         icon="https://example.test/weather.png",
     )
     assert added.changed is True
+    assert added.mcp_codes == frozenset({"mcp.weather"})
+    unchanged_add = repository.add_mcp(
+        bot_id="bot", owner_id="owner", set_id=str(skill_set.id),
+        server_code="mcp.weather", name="Weather MCP",
+        description="Weather tools", icon="https://example.test/weather.png",
+    )
+    assert unchanged_add.changed is False
+    assert unchanged_add.mcp_codes == frozenset()
     with db.orm_session() as session:
         membership = session.query(SkillSetMCPServer).one()
         assert (membership.name, membership.description, membership.icon) == (
@@ -544,6 +552,13 @@ def test_active_skill_set_mutates_mcp_membership_and_installation_atomically():
         bot_id="bot", owner_id="owner", set_id=str(skill_set.id), server_code="mcp.weather"
     )
     assert removed.changed is True
+    assert removed.mcp_codes == frozenset({"mcp.weather"})
+    unchanged_remove = repository.remove_mcp(
+        bot_id="bot", owner_id="owner", set_id=str(skill_set.id),
+        server_code="mcp.weather",
+    )
+    assert unchanged_remove.changed is False
+    assert unchanged_remove.mcp_codes == frozenset()
     with db.orm_session() as session:
         assert session.query(SkillSetMCPServer).count() == 0
         assert session.query(BotMCPInstallation).count() == 0
@@ -623,6 +638,32 @@ def test_direct_mcp_installation_isolated_by_owner_for_shared_bot_id():
         assert [(row.owner_id, row.bot_id, row.server_code) for row in rows] == [
             ("owner-b", "default", "mcp.weather")
         ]
+
+
+def test_direct_mcp_mutations_name_only_the_code_they_changed():
+    repository = CapabilityDesiredStateRepository(_Database())
+
+    installed = repository.install_mcp(
+        bot_id="bot", owner_id="owner", server_code="mcp.weather",
+        platform_default_codes=frozenset(),
+    )
+    unchanged_install = repository.install_mcp(
+        bot_id="bot", owner_id="owner", server_code="mcp.weather",
+        platform_default_codes=frozenset(),
+    )
+    uninstalled = repository.uninstall_mcp(
+        bot_id="bot", owner_id="owner", server_code="mcp.weather",
+        platform_default_codes=frozenset(),
+    )
+    unchanged_uninstall = repository.uninstall_mcp(
+        bot_id="bot", owner_id="owner", server_code="mcp.weather",
+        platform_default_codes=frozenset(),
+    )
+
+    assert installed.mcp_codes == frozenset({"mcp.weather"})
+    assert unchanged_install.mcp_codes == frozenset()
+    assert uninstalled.mcp_codes == frozenset({"mcp.weather"})
+    assert unchanged_uninstall.mcp_codes == frozenset()
 
 
 def test_skill_set_control_plane_sql_only_adds_owner_scoped_mcp_installation():
@@ -2340,20 +2381,24 @@ def test_mcp_exclusion_mirrors_the_skill_pair():
         set_id=str(default.id), server_code="mcp.member", **_DEFAULT_SCOPE
     )
     assert excluded.changed is True
+    assert excluded.mcp_codes == frozenset({"mcp.member"})
     with db.orm_session() as session:
         assert session.query(DefaultSkillsetMcpExclusion).count() == 1
         assert session.query(BotMCPInstallation).count() == 0
     assert repository.excluded_default_mcp_codes(
         bot_id="bot", owner_id="owner", set_id=str(default.id)
     ) == {"mcp.member"}
-    assert not repository.exclude_default_mcp(
+    unchanged_exclusion = repository.exclude_default_mcp(
         set_id=str(default.id), server_code="mcp.member", **_DEFAULT_SCOPE
-    ).changed
+    )
+    assert unchanged_exclusion.changed is False
+    assert unchanged_exclusion.mcp_codes == frozenset()
 
     restored = repository.unexclude_default_mcp(
         set_id=str(default.id), server_code="mcp.member", **_DEFAULT_SCOPE
     )
     assert restored.changed is True
+    assert restored.mcp_codes == frozenset({"mcp.member"})
     with db.orm_session() as session:
         assert session.query(DefaultSkillsetMcpExclusion).count() == 0
         assert [
@@ -2564,6 +2609,12 @@ def test_excluding_a_platform_default_mcp_retires_a_legacy_direct_row():
         assert {
             row.server_code for row in session.query(BotMCPInstallation).all()
         } == {"mcp.member"}
+
+    restored = repository.unexclude_default_mcp(
+        set_id=str(default.id), server_code="mcp.platform", **_DEFAULT_SCOPE
+    )
+    assert restored.changed is True
+    assert restored.mcp_codes == frozenset({"mcp.platform"})
 
 
 def test_restore_desired_state_preserves_mcp_membership_metadata():


### PR DESCRIPTION
## Problem

SkillSet deactivation passed the Set's MCP codes as `released_mcp`. Deactivation removes callable state but keeps the Set membership, so the runtime could physically delete configuration that must remain available for a later activation. MCP commands also built deltas from request parameters, allowing a `changed=false` no-op to declare a false claim or release.

## Solution

- Give SkillSet deactivation a fixed `ProjectionScope(skills=True, mcp=True)` with no MCP claim or release.
- Build MCP claim/release scopes from the committed `DesiredStateMutation` result for ordinary Set, Default exclusion, and Direct commands.
- Return an MCP code from the repository only when the mutation actually changed that code; no-op mutations return an empty delta.
- Keep `REL20260828` behavior for inactive membership changes, synchronous delete, and DeviceActivated recovery.
- Do not introduce a Retained resolver/state model, global cross-SkillSet queries, inactive cleanup, async adapter changes, or lifecycle expansion.

## Validation

- TDD red/green at `SkillSetManagementService`, `DirectActivationService`, and `CapabilityDesiredStateRepository` seams.
- Focused Service + repository suite: `170 passed`.
- Affected Skill Center/API/Gateway suite: `940 passed, 22 skipped`.
- Backend architecture suite: passed.
- Python SAST block scan: passed.
- Full Backend suite: `15097 passed, 57 skipped`.
- Final Backend CI gate: case pass rate `100%`; line coverage `87.61%`; changed-line coverage `83.33%`.
- Standards review: PASS after fixing the platform-default unexclude candidate.
- Spec review: PASS after the same fix.

## Compatibility and risk

No HTTP, Service API, Plugin API, database schema, adapter, Dispatcher, provider, or engine contract changes. The current ownership policy prevents one MCP from joining multiple SkillSets; global historical cross-reference cleanup remains intentionally out of scope.

## Spec

- `src/backend/specs/2026-08-27-mcp-effective-retained-projection/spec.md`
- `src/backend/specs/2026-08-27-mcp-effective-retained-projection/plan.md`
