### PR TITLE
fix(di): add eval_template_uuid to BaasConfig

### DIFF
--- a/src/backend/src/agentclaw/community/configs/application-singlebox.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-singlebox.yaml
@@ -143,6 +143,7 @@ user_config:
     # Relocated from di/config.py neutral defaults (C1).
     desktop_template_uuid: "TEMPLATE-f996ecc77d224ef7bd80757d8d2bcd0d"
     teclaw_template_uuid: "TEMPLATE-3106e731ffb04e0285e27c387e153737"
+    eval_template_uuid: "TEMPLATE-2e3192faa8994fe8bb8bc7be8671b431"
     personal_bot_template_uuid: "TEMPLATE-54942a40aa794eaaae2be166f94890ed"
 
   # BCN host — singlebox points at the local BCS (relocated from the hardcoded

--- a/src/backend/src/agentclaw/community/di/config.py
+++ b/src/backend/src/agentclaw/community/di/config.py
@@ -332,6 +332,8 @@ class BaasConfig:
     default_ttl_minutes: int = 10080
     # Teclaw (pull-based external container) template uuid — deploy supplies it.
     teclaw_template_uuid: str = ""
+    # Eval (sandbox) ARCA template uuid for evaluation environment — deploy supplies it.
+    eval_template_uuid: str = ""
     # Personal bot via BaaS (poolab template) — deploy supplies it.
     personal_bot_template_uuid: str = ""
 

--- a/src/backend/src/agentclaw/community/di/modules/config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/config_module.py
@@ -400,6 +400,9 @@ class ConfigModule(Module):
             teclaw_template_uuid=block.get(
                 "teclaw_template_uuid", defaults.teclaw_template_uuid
             ),
+            eval_template_uuid=block.get(
+                "eval_template_uuid", defaults.eval_template_uuid
+            ),
             personal_bot_template_uuid=block.get(
                 "personal_bot_template_uuid", defaults.personal_bot_template_uuid
             ),

--- a/src/backend/tests/community/config/golden/community.json
+++ b/src/backend/tests/community/config/golden/community.json
@@ -134,6 +134,7 @@
       "desktop_ttl_minutes": 0,
       "personal_bot_template_uuid": "",
       "teclaw_template_uuid": "",
+      "eval_template_uuid": "",
       "template_uuid": "",
       "tenant": "community"
     },

--- a/src/backend/tests/community/config/golden/singlebox.json
+++ b/src/backend/tests/community/config/golden/singlebox.json
@@ -56,6 +56,7 @@
       "desktop_template_uuid": "TEMPLATE-f996ecc77d224ef7bd80757d8d2bcd0d",
       "personal_bot_template_uuid": "TEMPLATE-54942a40aa794eaaae2be166f94890ed",
       "teclaw_template_uuid": "TEMPLATE-3106e731ffb04e0285e27c387e153737",
+      "eval_template_uuid": "",
       "template_uuid": "TEMPLATE-4d0e2849d7004111836333de782b95d8",
       "tenant": "team_claw"
     },
@@ -235,6 +236,7 @@
       "desktop_ttl_minutes": 0,
       "personal_bot_template_uuid": "TEMPLATE-54942a40aa794eaaae2be166f94890ed",
       "teclaw_template_uuid": "TEMPLATE-3106e731ffb04e0285e27c387e153737",
+      "eval_template_uuid": "",
       "template_uuid": "TEMPLATE-4d0e2849d7004111836333de782b95d8",
       "tenant": "team_claw"
     },

--- a/src/backend/tests/community/config/golden/singlebox.json
+++ b/src/backend/tests/community/config/golden/singlebox.json
@@ -56,7 +56,7 @@
       "desktop_template_uuid": "TEMPLATE-f996ecc77d224ef7bd80757d8d2bcd0d",
       "personal_bot_template_uuid": "TEMPLATE-54942a40aa794eaaae2be166f94890ed",
       "teclaw_template_uuid": "TEMPLATE-3106e731ffb04e0285e27c387e153737",
-      "eval_template_uuid": "",
+      "eval_template_uuid": "TEMPLATE-2e3192faa8994fe8bb8bc7be8671b431",
       "template_uuid": "TEMPLATE-4d0e2849d7004111836333de782b95d8",
       "tenant": "team_claw"
     },
@@ -236,7 +236,7 @@
       "desktop_ttl_minutes": 0,
       "personal_bot_template_uuid": "TEMPLATE-54942a40aa794eaaae2be166f94890ed",
       "teclaw_template_uuid": "TEMPLATE-3106e731ffb04e0285e27c387e153737",
-      "eval_template_uuid": "",
+      "eval_template_uuid": "TEMPLATE-2e3192faa8994fe8bb8bc7be8671b431",
       "template_uuid": "TEMPLATE-4d0e2849d7004111836333de782b95d8",
       "tenant": "team_claw"
     },

--- a/src/backend/tests/community/config/golden/test.json
+++ b/src/backend/tests/community/config/golden/test.json
@@ -104,6 +104,7 @@
       "default_ttl_minutes": 10080,
       "desktop_template_uuid": "",
       "desktop_ttl_minutes": 0,
+      "eval_template_uuid": "",
       "personal_bot_template_uuid": "",
       "teclaw_template_uuid": "",
       "template_uuid": "",


### PR DESCRIPTION
Problem                                                                                                                                                                                                                  
                                                                                                                                                                                                                           
  OCB corp-side DI modules reference baas_config.eval_template_uuid, but the community BaasConfig dataclass lacks this field, causing AttributeError: 'BaasConfig' object has no attribute 'eval_template_uuid' at runtime.
                                                                                                                                                                                                                           
  This field is required for the eval environment scenarios: when creating persistent eval sandboxes (Scene 2) and ephemeral eval containers (Scene 3), the eval-specific ARCA template UUID must be passed to the BaaS    
  publish API. BaasConfig already has template_uuid (production) and teclaw_template_uuid (TeClaw), but is missing the eval template field, preventing corp-side code from routing to the correct eval template.           
                                                                                                                                                                                                                           
 ## Solution                                                                                                                                                                                                                 
  Add eval_template_uuid: str = "" to the BaasConfig dataclass, positioned between teclaw_template_uuid and personal_bot_template_uuid. Sync ConfigModule.baas() provider to read eval_template_uuid from the YAML config  
  block.                                                                                                                                                                                                                   
                                                                                                                                                                                                                           
  - Default value is an empty string (""), consistent with existing teclaw_template_uuid / personal_bot_template_uuid.                                                                                                     
  - Non-breaking: pure field addition with a safe default. Community deployments that don't configure this field get an empty string; corp overlays inject the actual value.                                               
  - Rejected alternative: subclassing BaasConfig on the corp side — violates Microkernel Architecture Rule 14 (all DI wiring must be configuration-driven, no if is_local_mode() branches). Corp modules                   
  (SingleboxDefaultEnvBotModule, CorpDefaultEnvBotModule) already reference baas_config.eval_template_uuid directly, so the community class must expose the attribute.                                                     
                                                                                                                                                                                                                           
  ## Validation                                                                                                                                                                                                               
  - OCB singlebox end-to-end: after updating ocb-public pointer, POST /api/service-bot/default-env/create no longer throws AttributeError; switch validation and business logic return correctly.                          
  - OCB corp DI unit tests: test_default_env_bot_di.py — 16/16 passed.                                                                                                                                                     
  - Community CI: unaffected — pure field addition with default value.                                                                                                                                                     
                                                                                                                                                                                                                           
  ## Compatibility and risk                                                                                                                                                                                                   
  - Backward-compatible: new field has a default value; existing configs and deployments are unaffected.                                                                                                                   
  - Config migration: corp deployments that need the eval environment must add eval_template_uuid under user_config.baas (no change if already present).                                                                   
  - Rollback: remove the config entry; the field defaults to empty, causing eval template routing to fail gracefully rather than crash.                                                                                    
                                                                                                                                                                                                                           
  ## Related issues (optional)                                                                                                                                                                                                
Required by OCB eval environment infrastructure (Scene 2: persistent eval sandbox; Scene 3: ephemeral eval container).