### PR TITLE
fix(bcs): wire prod config secret backends (principal + group-session-ws)

### DIFF
--- a/src/bcs/configs/bcs-config-prod.toml
+++ b/src/bcs/configs/bcs-config-prod.toml
@@ -5,6 +5,7 @@
 
 bind = "0.0.0.0"
 port = 21000
+bots_base_dir = "./data/bots"
 
 max_history_per_session = 1000
 store_messages = false
@@ -67,7 +68,7 @@ enabled = false
 type = "mysql"
 
 [database.mysql]
-database = "bcs"
+database = "${BCS_DB_NAME}"
 pool_size = 20
 min_pool_size = 5
 timeout_secs = 30
@@ -210,3 +211,18 @@ schema_version = 1
 name = "bcsPanel"
 type = "file"
 file = "assets/panel/dist/index.umd.js"
+
+[gateway_principal]
+issuer = "gateway"
+audience = "bcs"
+key_id = "bare"
+signing_key_env = "PRINCIPAL_SIGNING_KEY"
+
+[secret]
+provider = "env"
+
+[group_session_ws]
+# EnvSecretAccess resolves this as env BCS_SECRET_BCN_GROUP_SESSION_WS_JWT
+# (prefix "BCS_SECRET_" + name uppercased, '-' -> '_'). Use the logical name,
+# not the env-var name, or the lookup double-prefixes and fails.
+signing_key_secret = "bcn-group-session-ws-jwt"


### PR DESCRIPTION
## Problem

The Aliyun prod deployment of BCS failed to boot with `Error: Invalid session configuration: Gateway Principal signing key is required` (and would then hit `group_session_ws.signing_key_secret '...' is required`). `configs/bcs-config-prod.toml` was missing the secret backends the bootstrap resolves at startup:

- `[gateway_principal]` — without it, `signing_key_env` defaulted to `AVERNET_SECRET_PRINCIPAL_SIGNING_KEY_VALUE`, while the gateway (after the community secret-resolver change) signs principals with the env var `PRINCIPAL_SIGNING_KEY`. The two names mismatched, so BCS could not verify gateway-signed principals.
- `[secret] provider = "env"` — without it the secret backend defaulted to `noop`, so `group_session_ws.signing_key_secret` could never resolve.

## Solution

Add three blocks to `configs/bcs-config-prod.toml` (additive; no behavior change for other environments):

```toml
[gateway_principal]
issuer = "gateway"
audience = "bcs"
key_id = "bare"
signing_key_env = "PRINCIPAL_SIGNING_KEY"   # matches the gateway's community secret-resolver env var

[secret]
provider = "env"                            # EnvSecretAccess, default prefix "BCS_SECRET_"

[group_session_ws]
# EnvSecretAccess resolves this as env BCS_SECRET_BCN_GROUP_SESSION_WS_JWT
# (prefix "BCS_SECRET_" + name uppercased, '-' -> '_'). Use the logical name,
# not the env-var name, or the lookup double-prefixes and fails.
signing_key_secret = "bcn-group-session-ws-jwt"
```

`signing_key_secret` deliberately uses the **logical** name `bcn-group-session-ws-jwt`; the `EnvSecretAccess` lookup prepends the `BCS_SECRET_` prefix, so writing the full env-var name there would double-prefix and fail to resolve.

## Validation

- Code-path verified against source: `signing_key_secret = "bcn-group-session-ws-jwt"` → `EnvSecretAccess::get_secret` → env key `BCS_SECRET_BCN_GROUP_SESSION_WS_JWT` (`bcs-secret-local/src/lib.rs:139-148`), read from the boot-time process-env snapshot.
- `gateway_principal.signing_key_env = "PRINCIPAL_SIGNING_KEY"` matches the gateway community `CommunitySecretResolver` (`secret_resolver/community/_plugin.py:29-31`, `secret_name.upper()` → env `PRINCIPAL_SIGNING_KEY`), so both sides share one env var.
- Required deployment env vars: `SERVER_ENV=prod` (selects the `-prod` overlay), `PRINCIPAL_SIGNING_KEY` (gateway + BCS, same value), `BCS_SECRET_BCN_GROUP_SESSION_WS_JWT` (BCS), `BCS_DB_NAME=bcs`.

## Compatibility and risk

- Config-only, additive; changes nothing for dev/local/other environments.
- No secret material is committed; all signing keys are injected as env vars by the deployment.
- If `SERVER_ENV` is unset the binary still falls back to `bcs-config-local.toml`, so this prod overlay only applies where the deployment explicitly opts in.