### PR TITLE
fix(aicoding): resync MCP and skills on confirmed restart

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -8,6 +8,7 @@ services.
 from __future__ import annotations
 
 import json
+import threading
 import uuid
 from typing import Any, Dict
 
@@ -24,6 +25,7 @@ from agentclaw.community.core.workspace.runtime_identity import (
 
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.utils import secret_utils
+from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 from agentclaw.community.log import get_logger
 
 from ..provisioning import (
@@ -52,7 +54,6 @@ LEGACY_BOT_TYPE_ENV_MAP = {
 }
 _THETA_KEY_PATH = ("bot_template_config", "ext_config", "thetaKey")
 _ENCRYPTED_VALUE_PREFIX = "enc:v1:"
-
 logger = get_logger()
 
 
@@ -593,128 +594,116 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         bot: Dict[str, Any],
         extra_configs: Dict[str, Any] | None,
         *,
-        passport_plugin: Any,
-        skill_set_factory: Any,
-        template_service: Any,
-        caller_identity_repo: Any,
-    ) -> None:
-        """Refresh this bot's Passport authorization scope on restart.
+        mcp_sync: Any = None,
+        skill_set_factory: Any = None,
+    ) -> bool:
+        """Refresh AICoding restart authorization and runtime skill symlinks.
 
-        Mirrors the create-time passport scope (``create_flow._apply_passport``)
-        so an ``aicoding`` / ``claude_code`` bot keeps the same MCP + CLI grants
-        after a restart: recompute the passport MCP codes and the engine default
-        CLI items, then push them to Passport via ``update_passport`` as a full
-        ``resource_scope`` snapshot (Passport treats each resource list as a
-        full replacement). Best-effort: failures are logged by the caller and
-        must not block the restart.
-
-        Opt-in: only runs when ``extra_configs['confirmed_template_update']`` is
-        truthy — a plain restart must never silently rewrite the Passport
-        authorization scope. Anything falsy (missing key, None, false) no-ops.
-
-        The pushed scope carries each MCP's execution identity, not just its
-        code: ``resource_scope`` replaces the MCP resource list wholesale, so a
-        code-only snapshot would assert Owner for every MCP and drop the Bot's
-        Caller grants on every confirmed template update. An *unreadable*
-        identity therefore skips the refresh, leaving the existing scope
-        standing rather than replacing it with an owner-only snapshot. An
-        absent repository is not a case this handles: it is required.
+        This is intentionally AICoding-owned: only a confirmed template update
+        opts in. The refresh is fire-and-forget and best-effort so restart is
+        never blocked.
         """
-        if not (
+        should_resync = (
             isinstance(extra_configs, dict)
-            and extra_configs.get("confirmed_template_update")
-        ):
+            and bool(extra_configs.get("confirmed_template_update"))
+        )
+        if not should_resync:
             logger.info(
-                "[aicoding.restart] skip passport refresh: "
+                "[aicoding.restart] skip authorization/runtime resync: "
                 "confirmed_template_update is not set for bot_id=%s",
                 ctx.bot_id,
             )
-            return
-        # Imported lazily: create_flow imports this module's registry, so a
-        # module-level import would cycle.
-        from agentclaw.community.core.bot_management.create_flow import (
-            _get_bot_mcp_codes,
-        )
-        from agentclaw.community.core.mcp.errors import McpIdentityUnresolvedError
-        from agentclaw.community.core.mcp.services._defaults import (
-            get_default_cli_items,
-        )
-        from agentclaw.community.core.mcp.services.passport_scope import (
-            passport_mcp_items_from_codes,
-            resolve_mcp_identity_modes,
-        )
+            return False
 
-        stored_config: Dict[str, Any] = (
-            template_service.get_template_config(ctx.bot_id) or {}
-        )
-        engine_type = ctx.active_engine or self.engine_type
-        entity_id = str(bot.get("entity_id") or "")
-        entity_type = str(bot.get("entity_type") or "staff")
-        owner_id = ctx.owner_id
+        effective_entity_id = str(bot.get("entity_id") or ctx.owner_id or "")
+        effective_entity_type = str(bot.get("entity_type") or "staff")
+        effective_engine = ctx.active_engine or self.engine_type
 
-        mcp_codes = _get_bot_mcp_codes(
-            skill_set_factory,
-            owner_id,
-            ctx.bot_id,
-            entity_id,
-            entity_type,
-            engine_type,
-        )
-        cli_items = get_default_cli_items(
-            engine_type,
-            ctx.template_type,
-            ext_info={"template_config": stored_config}
-            if stored_config
-            else None,
-        )
+        def _run() -> None:
+            import asyncio
 
-        try:
-            identity_modes = resolve_mcp_identity_modes(
-                caller_identity_repo,
-                bot_pk=bot.get("id"),
-                engine_type=engine_type,
-                bot_id=ctx.bot_id,
-            )
-            mcp_items = passport_mcp_items_from_codes(
-                mcp_codes, identity_modes=identity_modes
-            )
-        except (McpIdentityUnresolvedError, ValueError):
-            logger.warning(
-                "[aicoding.restart] skip passport refresh: MCP execution "
-                "identity unresolved for bot_id=%s; leaving the existing "
-                "scope in place",
-                ctx.bot_id,
-                exc_info=True,
-            )
-            return
+            if mcp_sync is not None:
+                try:
+                    async def _do_mcp_sync() -> tuple[dict, dict | None]:
+                        scope_result = await mcp_sync.refresh_mcp_scope(
+                            user_id=effective_entity_id,
+                            entity_id=effective_entity_id,
+                            bot_id=ctx.bot_id,
+                            entity_type=effective_entity_type,
+                            engine_type=effective_engine,
+                        )
+                        if not scope_result.get("success"):
+                            return scope_result, None
 
-        passport_plugin.update_passport(
-            bot_id=ctx.bot_id,
-            user_id=owner_id,
-            bot_name=bot.get("bot_name"),
-            bot_desc=bot.get("bot_desc"),
-            engine_type=engine_type,
-            resource_scope={
-                # Derived from the items: ``unpack_resource_scope`` ignores
-                # ``mcp_codes`` once ``mcp_items`` is present, so two
-                # independent lists could only ever drift apart.
-                "mcp_codes": [item["mcp_code"] for item in mcp_items],
-                "mcp_items": mcp_items,
-                "cli_items": cli_items,
-            },
-        )
-        caller_count = sum(
-            1 for item in mcp_items if item.get("identity_mode") == "caller"
-        )
-        logger.info(
-            "[aicoding.restart] refreshed passport authorization scope: "
-            "bot_id=%s mcp_codes=%s caller=%s owner=%s cli_items=%s",
-            ctx.bot_id,
-            mcp_codes,
-            caller_count,
-            len(mcp_items) - caller_count,
-            cli_items,
-        )
+                        detail_result = await mcp_sync.sync_mcp_details(
+                            user_id=effective_entity_id,
+                            entity_id=effective_entity_id,
+                            bot_id=ctx.bot_id,
+                            entity_type=effective_entity_type,
+                            engine_type=effective_engine,
+                        )
+                        return scope_result, detail_result
+
+                    scope_result, detail_result = asyncio.run(_do_mcp_sync())
+                    if not scope_result.get("success"):
+                        logger.error(
+                            "[aicoding.restart] MCP scope resync failed: "
+                            "bot_id=%s, engine_type=%s, error=%s",
+                            ctx.bot_id, effective_engine, scope_result.get("error"),
+                        )
+                    elif detail_result and not detail_result.get("success"):
+                        logger.error(
+                            "[aicoding.restart] MCP detail resync failed: "
+                            "bot_id=%s, engine_type=%s, error=%s",
+                            ctx.bot_id, effective_engine, detail_result.get("error"),
+                        )
+                    else:
+                        logger.info(
+                            "[aicoding.restart] MCP resync succeeded: "
+                            "bot_id=%s, engine_type=%s",
+                            ctx.bot_id, effective_engine,
+                        )
+                except Exception as mcp_error:
+                    logger.error(
+                        "[aicoding.restart] MCP resync error: "
+                        "bot_id=%s, engine_type=%s, error=%s",
+                        ctx.bot_id, effective_engine, mcp_error,
+                        exc_info=True,
+                    )
+
+            if skill_set_factory is not None:
+                try:
+                    skill_set_service = skill_set_factory.create(
+                        user_id=effective_entity_id,
+                        entity_id=effective_entity_id,
+                        bot_id=ctx.bot_id,
+                        entity_type=effective_entity_type,
+                        engine_type=effective_engine,
+                    )
+                    if skill_set_service.sync_runtime():
+                        logger.info(
+                            "[aicoding.restart] skill symlink sync succeeded: "
+                            "bot_id=%s, engine_type=%s",
+                            ctx.bot_id, effective_engine,
+                        )
+                    else:
+                        logger.error(
+                            "[aicoding.restart] skill symlink sync failed: "
+                            "bot_id=%s, engine_type=%s",
+                            ctx.bot_id, effective_engine,
+                        )
+                except Exception as skill_error:
+                    logger.error(
+                        "[aicoding.restart] skill symlink sync error: "
+                        "bot_id=%s, engine_type=%s, error=%s",
+                        ctx.bot_id, effective_engine, skill_error,
+                        exc_info=True,
+                    )
+
+        threading.Thread(
+            target=bind_current_avernet_tenant(_run), daemon=True
+        ).start()
+        return True
 
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:
         # Application-only hooks (DIMA workspace/memory/cron) intentionally stay

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
@@ -116,12 +116,10 @@ class DefaultProvisioningStrategy(EngineProvisioningStrategy):
         bot: dict[str, object],
         extra_configs: dict[str, object] | None,
         *,
-        passport_plugin: object,
-        skill_set_factory: object,
-        template_service: object,
-        caller_identity_repo: object,
-    ) -> None:
-        return None
+        mcp_sync: object = None,
+        skill_set_factory: object = None,
+    ) -> bool:
+        return False
 
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:
         return None

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
@@ -231,33 +231,14 @@ class EngineProvisioningStrategy(ABC):
         bot: Dict[str, Any],
         extra_configs: Dict[str, Any] | None,
         *,
-        passport_plugin: Any,
-        skill_set_factory: Any,
-        template_service: Any,
-        caller_identity_repo: Any,
-    ) -> None:
-        """Re-sync engine-owned external authorization on restart.
+        mcp_sync: Any = None,
+        skill_set_factory: Any = None,
+    ) -> bool:
+        """Optionally refresh engine-owned restart authorization/runtime state.
 
-        Engines that mint/provision external credentials at create time (e.g.
-        the AICoding Passport MCP/CLI grants from ``create_flow._apply_passport``)
-        recompute and push the same grants here so a restart does not silently
-        drop the authorization scope the bot was created with. Engines without
-        such external authorization should no-op.
-
-        ``extra_configs`` is the restart extension envelope from the caller; a
-        strategy may require an opt-in flag (e.g. ``confirmed_template_update``)
-        before performing any side effect so a plain restart never silently
-        rewrites authorization.
-
-        ``caller_identity_repo`` reads each MCP's stored execution identity.
-        A strategy that republishes an overwrite-style MCP scope needs it:
-        without identity the scope asserts Owner for every MCP and discards
-        the Bot's Caller grants. Required rather than defaulted — the caller
-        always has it, and an accidental omission would otherwise be a silent
-        privilege change rather than a type error.
-
-        Failures must not block the restart: the call site wraps this in the
-        same try/except as the restart extension envelope.
+        Engines own their opt-in keys and side effects. Implementations must be
+        best-effort: failures should be logged/swallowed so restart success is
+        not blocked. Return value only records whether the engine opted in.
         """
 
     @abstractmethod

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     from agentclaw.community.core.cron.services.aicoding.cron_auto_setup import CronAutoSetupService
     from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
     from agentclaw.community.core.common_config.service import CommonConfigService
+    from agentclaw.community.core.devices.protocols import McpSyncProtocol
     from agentclaw.community.core.bot_app_grant.protocols import (
         BotAppGrantSweepProtocol,
     )
@@ -335,6 +336,7 @@ class BotService:
         baas_service_provider: "Callable[[], BaasService] | None" = None,
         task_queue_service: "TaskQueueService | None" = None,
         common_config_service: "CommonConfigService | None" = None,
+        mcp_sync: "McpSyncProtocol | None" = None,
     ) -> None:
         self._repository = repository
         self._allocation_config = allocation_config
@@ -397,6 +399,7 @@ class BotService:
         self._baas_template_resolver = baas_template_resolver
         self._task_queue_service = task_queue_service
         self._common_config_service = common_config_service
+        self._mcp_sync = mcp_sync
 
     def _service_bot_image_policy_enabled(self) -> bool:
         """Whether draft create/restart should opt into image policy."""
@@ -1937,7 +1940,7 @@ class BotService:
                             refresh_ctx,
                             bot_record or {},
                             extra_configs,
-                            mcp_sync=service.mcp_sync,
+                            mcp_sync=self._mcp_sync,
                             skill_set_factory=self._skill_set_factory,
                         )
                     except Exception as exc:
@@ -4520,7 +4523,7 @@ class BotService:
                         refresh_ctx,
                         bot,
                         extra_configs,
-                        mcp_sync=self._device_service_provider().mcp_sync,
+                        mcp_sync=self._mcp_sync,
                         skill_set_factory=self._skill_set_factory,
                     )
                 except Exception as exc:

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -328,10 +328,6 @@ class BotService:
         device_status_client: "DeviceStatusClient",
         cron_auto_setup_service_provider: "Callable[[], CronAutoSetupService]",
         drm_reader: DRMReaderPlugin,
-        # Required, not defaulted: the restart authorization refresh
-        # republishes an overwrite-style Passport MCP scope, and a missing
-        # identity source there is a silent privilege change rather than a
-        # degraded mode. The DI provider always supplies it.
         caller_identity_repo: "CallerIdentityRepositoryProtocol",
         workspace_hosting_config: "cfg.WorkspaceHostingConfig | None" = None,
         policy_service: "PolicyServiceProtocol | None" = None,
@@ -1744,6 +1740,7 @@ class BotService:
         device_provider: Optional[str] = None,
         restart_lock_key: Optional[Tuple[str, str, str, str]] = None,
         bot_ext_override: Optional[Dict[str, Any]] = None,
+        extra_configs: Optional[Dict[str, Any]] = None,
     ):
         """
         Allocate device asynchronously in background thread.
@@ -1921,6 +1918,36 @@ class BotService:
 
                 logger.info(f"[bot_service._allocate_device_async] Device allocated for bot {bot_id}: "
                            f"binding_id={binding_id}, device_id={device_id}, provider={allocated_device_provider}, status={device_status}")
+
+                if restart_lock_key is not None:
+                    try:
+                        from agentclaw.community.core.bot_management.engines import (
+                            resolve_provisioning,
+                        )
+
+                        refresh_ctx, refresh_strategy = resolve_provisioning(
+                            bot_id=str(bot_id),
+                            owner_id=str((bot_record or {}).get("owner_id") or owner_id or user_id),
+                            bot_type=str((bot_record or {}).get("bot_type") or resolved_bot_type or ""),
+                            active_engine=(bot_record or {}).get("active_engine") or active_engine,
+                            template_type=(bot_record or {}).get("template_type") or bot_template_type,
+                            template_config=None,
+                        )
+                        refresh_strategy.refresh_restart_authorization(
+                            refresh_ctx,
+                            bot_record or {},
+                            extra_configs,
+                            mcp_sync=service.mcp_sync,
+                            skill_set_factory=self._skill_set_factory,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "[bot_service._allocate_device_async] restart authorization refresh failed; "
+                            "continue allocation: bot_id=%s error=%s",
+                            bot_id,
+                            exc,
+                            exc_info=True,
+                        )
 
                 # Map device status to bot status
                 # Device status can be: PENDING, ACTIVE, RELEASED
@@ -4083,6 +4110,7 @@ class BotService:
         device_provider: Optional[str] = None,
         restart_lock_key: Optional[Tuple[str, str, str, str]] = None,
         bot_ext_override: Optional[Dict[str, Any]] = None,
+        extra_configs: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Start a bot by triggering async device allocation.
 
@@ -4192,6 +4220,7 @@ class BotService:
             device_provider=device_provider,
             restart_lock_key=restart_lock_key,
             bot_ext_override=bot_ext_override,
+            extra_configs=extra_configs,
         )
 
         # The allocation thread is now spawned and (for the restart flow) owns
@@ -4310,18 +4339,9 @@ class BotService:
                 extra_configs,
                 template_service=self._template_service,
             )
-            # Re-sync the engine's external authorization scope (e.g. the
-            # aicoding Passport MCP/CLI grants) to match what was provisioned
-            # at create time, so a restart does not silently drop grants.
-            strategy.refresh_restart_authorization(
-                ctx,
-                bot,
-                extra_configs,
-                passport_plugin=self._passport_plugin,
-                skill_set_factory=self._skill_set_factory,
-                template_service=self._template_service,
-                caller_identity_repo=self._caller_identity_repo,
-            )
+            # confirmed_template_update 的 MCP/软链刷新由 engine 自己在
+            # refresh_restart_authorization 里判断并执行；replacement restart
+            # 等新设备 apply 成功后再 resolve 并调用，避免写到旧设备上。
         except Exception as exc:
             # Optional engine extensions must never block the existing restart path.
             logger.warning(
@@ -4483,6 +4503,34 @@ class BotService:
                 updated_bot = self._restart_bot_baas(
                     bot_id=bot_id, user_id=user_id, binding_id=binding_id, bot=bot,
                 )
+                try:
+                    from agentclaw.community.core.bot_management.engines import (
+                        resolve_provisioning,
+                    )
+
+                    refresh_ctx, refresh_strategy = resolve_provisioning(
+                        bot_id=bot_id,
+                        owner_id=str(bot.get("owner_id") or user_id),
+                        bot_type=str(bot.get("bot_type") or ""),
+                        active_engine=bot.get("active_engine"),
+                        template_type=bot.get("template_type"),
+                        template_config=None,
+                    )
+                    refresh_strategy.refresh_restart_authorization(
+                        refresh_ctx,
+                        bot,
+                        extra_configs,
+                        mcp_sync=self._device_service_provider().mcp_sync,
+                        skill_set_factory=self._skill_set_factory,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "[bot_service.restart_bot] restart authorization refresh failed; "
+                        "continue restart: bot_id=%s error=%s",
+                        bot_id,
+                        exc,
+                        exc_info=True,
+                    )
                 logger.info(f"[bot_service.restart_bot] Bot {bot_id} in-place restart via BaaS, binding preserved")
                 return updated_bot
             release_ok = True
@@ -4520,6 +4568,7 @@ class BotService:
                     and (bot.get("ext") or {}).get("sbot_use_default_image") is True
                     else None
                 ),
+                extra_configs=extra_configs,
             )
             handed_off = True
 

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -132,6 +132,11 @@ class DeviceService:
         self._task_queue_service = task_queue_service
         logger.info("[DeviceService] Initialized")
 
+    @property
+    def mcp_sync(self) -> "McpSyncProtocol":
+        """Expose the MCP sync service for callers that must drive it directly."""
+        return self._mcp_sync
+
     # =========================================================================
     # Helper methods (from former BaseDeviceService)
     # =========================================================================

--- a/src/backend/src/agentclaw/community/core/devices/services/device_service.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_service.py
@@ -132,11 +132,6 @@ class DeviceService:
         self._task_queue_service = task_queue_service
         logger.info("[DeviceService] Initialized")
 
-    @property
-    def mcp_sync(self) -> "McpSyncProtocol":
-        """Expose the MCP sync service for callers that must drive it directly."""
-        return self._mcp_sync
-
     # =========================================================================
     # Helper methods (from former BaseDeviceService)
     # =========================================================================

--- a/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
@@ -17,7 +17,7 @@ they pick up the swapped repositories transparently.
 
 from __future__ import annotations
 
-from typing import Annotated, Callable
+from typing import Annotated, Callable, cast
 
 from injector import (
     Binder,
@@ -78,6 +78,8 @@ from agentclaw.community.core.bot_management.services.bot_service import BotServ
 from agentclaw.community.core.repository.protocols.identity import (
     CallerIdentityRepositoryProtocol,
 )
+from agentclaw.community.core.devices.protocols import McpSyncProtocol
+from agentclaw.community.core.mcp.services.sync_service import MCPSyncService
 from agentclaw.community.core.bot_management.services.bot_space_service import (
     BotSpaceService,
 )
@@ -346,6 +348,7 @@ class BotManagementModule(Module):
         task_queue_service: TaskQueueService,
         common_config_service: CommonConfigService,
         caller_identity_repo: CallerIdentityRepositoryProtocol,
+        mcp_sync_service: MCPSyncService,
         injector: Injector,
     ) -> BotService:
         # Explicit provider: ``BotService.__init__`` types several
@@ -390,10 +393,8 @@ class BotManagementModule(Module):
             baas_service_provider=lambda: injector.get(BaasService),
             task_queue_service=task_queue_service,
             common_config_service=common_config_service,
-            # Read only by the restart authorization refresh, which republishes
-            # an overwrite-style Passport MCP scope and must carry each MCP's
-            # execution identity rather than asserting Owner for all of them.
             caller_identity_repo=caller_identity_repo,
+            mcp_sync=cast(McpSyncProtocol, mcp_sync_service),
         )
 
     @singleton

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timedelta
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -2110,3 +2110,190 @@ class TestRestartBaasPendingAndQueue:
         )
         task_queue_service.enqueue.assert_called_once()
         assert "publish_id" not in task_queue_service.enqueue.call_args.args[1]
+
+
+# ===========================================================================
+# restart authorization refresh wiring.
+# BotService only carries the resolved strategy/ctx to the point where the
+# restart target device is ready; AICoding decides opt-in and performs MCP +
+# skill symlink refresh inside refresh_restart_authorization.
+# ===========================================================================
+class TestRestartAuthorizationResyncWiring:
+    def test_restart_passes_strategy_to_async_allocation_after_extra_config_apply(self):
+        repo = FakeRestartLockRepo()
+        device_service = MagicMock()
+        svc = _make_service(repo, device_provider=device_service)
+        bot = _make_bot(
+            status="ACTIVE",
+            active_engine="claude_code",
+            template_type="normalCC",
+            entity_id="staff_user001",
+        )
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        with patch.object(svc, "stop_bot", return_value=True) as stop, \
+                patch.object(svc, "start_bot", return_value=bot) as start:
+            result = svc.restart_bot(
+                bot_id="bot001",
+                user_id="user001",
+                extra_configs={"confirmed_template_update": True},
+            )
+
+        assert result == bot
+        stop.assert_called_once()
+        start.assert_called_once()
+        # No restart-specific DeviceService API is involved; the existing
+        # strategy hook owns the opt-in decision and MCP/skill refresh.
+        assert "restart_authorization_strategy" not in start.call_args.kwargs
+        assert "restart_authorization_ctx" not in start.call_args.kwargs
+        assert start.call_args.kwargs["extra_configs"] == {
+            "confirmed_template_update": True
+        }
+
+    def test_plain_restart_passes_no_extra_configs(self):
+        repo = FakeRestartLockRepo()
+        device_service = MagicMock()
+        svc = _make_service(repo, device_provider=device_service)
+        bot = _make_bot(
+            status="ACTIVE", active_engine="claude_code", template_type="normalCC"
+        )
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        with patch.object(svc, "stop_bot", return_value=True), \
+                patch.object(svc, "start_bot", return_value=bot) as start:
+            svc.restart_bot(bot_id="bot001", user_id="user001")
+
+        assert "restart_authorization_strategy" not in start.call_args.kwargs
+        assert "restart_authorization_ctx" not in start.call_args.kwargs
+        assert start.call_args.kwargs["extra_configs"] is None
+
+    def test_default_engine_restart_does_not_pass_strategy_objects(self):
+        repo = FakeRestartLockRepo()
+        device_service = MagicMock()
+        svc = _make_service(repo, device_provider=device_service)
+        bot = _make_bot(status="ACTIVE", active_engine="moltis")
+        svc._repository.get_by_id_and_owner.return_value = bot
+
+        with patch.object(svc, "stop_bot", return_value=True), \
+                patch.object(svc, "start_bot", return_value=bot) as start:
+            svc.restart_bot(
+                bot_id="bot001",
+                user_id="user001",
+                extra_configs={"confirmed_template_update": True},
+            )
+
+        assert "restart_authorization_strategy" not in start.call_args.kwargs
+        assert "restart_authorization_ctx" not in start.call_args.kwargs
+
+    def test_async_replacement_refreshes_after_device_apply(self):
+        repo = FakeRestartLockRepo()
+        device_service = MagicMock()
+        device_service.mcp_sync = object()
+        device_service.apply_device.return_value = SimpleNamespace(
+            id=42,
+            device_id="dev-42",
+            device_provider="arca",
+            status=DeviceBindingStatus.ACTIVE.value,
+        )
+        svc = _make_service(repo, device_provider=device_service)
+        bot = _make_bot(
+            owner_id="owner001",
+            status="PENDING",
+            active_engine="claude_code",
+            template_type="normalCC",
+        )
+        svc._repository.get_by_id_and_owner.return_value = bot
+        svc._repository.update_by_owner.return_value = {**bot, "binding_id": 42}
+        svc._skill_set_factory.create.return_value.get_symlink_mappings.return_value = []
+        svc._template_service.get_template_config.return_value = {}
+        refresh_strategy = MagicMock()
+
+        with patch(
+            "agentclaw.community.core.bot_management.services.bot_service.threading.Thread",
+            _SyncThread,
+        ), patch(
+            "agentclaw.community.core.bot_management.engines.resolve_provisioning",
+            return_value=(object(), refresh_strategy),
+        ), patch.object(svc, "_is_new_bot_use_nas", return_value=False), \
+                patch.object(svc, "_build_engine_extra_envs", return_value={}), \
+                patch.object(svc, "_query_admin_worknos", return_value=[]), \
+                patch.object(svc, "_attach_template_uid_context", return_value={}):
+            svc._allocate_device_async(
+                bot_id="bot001",
+                user_id="user001",
+                nick_name="nick",
+                entity_id="staff_user001",
+                entity_type="staff",
+                engine_types=["claude_code"],
+                active_engine="claude_code",
+                owner_id="owner001",
+                restart_lock_key=("test", "staff_user001", "bot001", "token"),
+                extra_configs={"confirmed_template_update": True},
+            )
+
+        refresh_strategy.refresh_restart_authorization.assert_called_once_with(
+            ANY,
+            bot,
+            {"confirmed_template_update": True},
+            mcp_sync=device_service.mcp_sync,
+            skill_set_factory=svc._skill_set_factory,
+        )
+        assert repo.release_calls == 1
+
+    def test_baas_in_place_restart_refreshes_after_restart(self):
+        repo = FakeRestartLockRepo()
+        device_service = MagicMock()
+        device_service.mcp_sync = object()
+        device_service.get_device.return_value = SimpleNamespace(
+            id=42,
+            device_provider="baas",
+            device_id="BOT-uuid-9",
+            status=DeviceBindingStatus.ACTIVE,
+        )
+        svc = _make_service(
+            repo,
+            device_provider=device_service,
+            baas_service_provider=lambda: MagicMock(),
+        )
+        bot = _make_bot(
+            status="ACTIVE",
+            binding_id=42,
+            active_engine="claude_code",
+            template_type="normalCC",
+        )
+        svc._repository.get_by_id_and_owner.return_value = bot
+        refresh_strategy = MagicMock()
+
+        with patch.object(svc, "_restart_bot_baas", return_value=bot), patch(
+            "agentclaw.community.core.bot_management.engines.resolve_provisioning",
+            return_value=(object(), refresh_strategy),
+        ):
+            result = svc.restart_bot(
+                bot_id="bot001",
+                user_id="user001",
+                extra_configs={"confirmed_template_update": True},
+            )
+
+        assert result == bot
+        refresh_strategy.refresh_restart_authorization.assert_called_once_with(
+            ANY,
+            bot,
+            {"confirmed_template_update": True},
+            mcp_sync=device_service.mcp_sync,
+            skill_set_factory=svc._skill_set_factory,
+        )
+
+
+def test_device_service_exposes_existing_mcp_sync_collaborator():
+    from agentclaw.community.core.devices.services.device_service import DeviceService
+
+    mcp_sync = object()
+    service = DeviceService(
+        MagicMock(),
+        bot_query=MagicMock(),
+        bot_sync=MagicMock(),
+        oss_record_repo=MagicMock(),
+        mcp_sync=mcp_sync,
+    )
+
+    assert service.mcp_sync is mcp_sync

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -145,6 +145,7 @@ def _make_service(
     baas_template_resolver: MagicMock | None = None,
     task_queue_service: MagicMock | None = None,
     common_config_service: MagicMock | None = None,
+    mcp_sync: object | None = None,
 ) -> BotService:
     if lock_repo is None:
         lock_repo = FakeRestartLockRepo()
@@ -163,6 +164,7 @@ def _make_service(
     svc._baas_template_resolver = baas_template_resolver
     svc._task_queue_service = task_queue_service or MagicMock()
     svc._common_config_service = common_config_service
+    svc._mcp_sync = mcp_sync if mcp_sync is not None else MagicMock()
     svc._teclaw_provision_provider = lambda: SimpleNamespace(
         is_teclaw=lambda active_engine: active_engine == "teclaw"
     )
@@ -2188,14 +2190,14 @@ class TestRestartAuthorizationResyncWiring:
     def test_async_replacement_refreshes_after_device_apply(self):
         repo = FakeRestartLockRepo()
         device_service = MagicMock()
-        device_service.mcp_sync = object()
+        mcp_sync = object()
         device_service.apply_device.return_value = SimpleNamespace(
             id=42,
             device_id="dev-42",
             device_provider="arca",
             status=DeviceBindingStatus.ACTIVE.value,
         )
-        svc = _make_service(repo, device_provider=device_service)
+        svc = _make_service(repo, device_provider=device_service, mcp_sync=mcp_sync)
         bot = _make_bot(
             owner_id="owner001",
             status="PENDING",
@@ -2235,7 +2237,7 @@ class TestRestartAuthorizationResyncWiring:
             ANY,
             bot,
             {"confirmed_template_update": True},
-            mcp_sync=device_service.mcp_sync,
+            mcp_sync=mcp_sync,
             skill_set_factory=svc._skill_set_factory,
         )
         assert repo.release_calls == 1
@@ -2243,7 +2245,7 @@ class TestRestartAuthorizationResyncWiring:
     def test_baas_in_place_restart_refreshes_after_restart(self):
         repo = FakeRestartLockRepo()
         device_service = MagicMock()
-        device_service.mcp_sync = object()
+        mcp_sync = object()
         device_service.get_device.return_value = SimpleNamespace(
             id=42,
             device_provider="baas",
@@ -2254,6 +2256,7 @@ class TestRestartAuthorizationResyncWiring:
             repo,
             device_provider=device_service,
             baas_service_provider=lambda: MagicMock(),
+            mcp_sync=mcp_sync,
         )
         bot = _make_bot(
             status="ACTIVE",
@@ -2279,21 +2282,6 @@ class TestRestartAuthorizationResyncWiring:
             ANY,
             bot,
             {"confirmed_template_update": True},
-            mcp_sync=device_service.mcp_sync,
+            mcp_sync=mcp_sync,
             skill_set_factory=svc._skill_set_factory,
         )
-
-
-def test_device_service_exposes_existing_mcp_sync_collaborator():
-    from agentclaw.community.core.devices.services.device_service import DeviceService
-
-    mcp_sync = object()
-    service = DeviceService(
-        MagicMock(),
-        bot_query=MagicMock(),
-        bot_sync=MagicMock(),
-        oss_record_repo=MagicMock(),
-        mcp_sync=mcp_sync,
-    )
-
-    assert service.mcp_sync is mcp_sync

--- a/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
+++ b/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
@@ -1,21 +1,19 @@
-"""Unit tests for ``AicodingProvisioningStrategy.refresh_restart_authorization``.
+"""Unit tests for AICoding restart authorization refresh.
 
-These mirror the create-time passport scope (``create_flow._apply_passport``)
-so an ``aicoding`` / ``claude_code`` bot keeps the same MCP + CLI grants after a
-restart. The strategy is opt-in: only when the caller passes
-``extra_configs['confirmed_template_update']`` truthy does it recompute the
-passport MCP codes + engine default CLI items and push them to Passport as a
-full ``resource_scope`` snapshot (full replacement).
-
-Because that snapshot replaces the MCP resource list wholesale, it must carry
-each MCP's execution identity: a code-only scope asserts ``owner`` for every
-MCP and silently drops the bot's caller grants. Identity therefore gates the
-refresh: an unreadable identity declines the refresh and leaves the existing
-scope alone. The repository itself is a required argument, so "absent" is a
-type error rather than a runtime branch.
+``refresh_restart_authorization`` now owns both the opt-in decision and the
+AICoding-specific side effects:
+  * refresh MCP scope;
+  * push MCP details to runtime;
+  * resync ~/.claude/skills symlinks via SkillSetService.sync_runtime().
+All side effects are best-effort/fire-and-forget.
 """
 
-from unittest.mock import MagicMock, patch
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
     AicodingProvisioningStrategy,
@@ -27,14 +25,20 @@ from agentclaw.community.core.bot_management.engines.provisioning import (
     BotProvisioningContext,
 )
 
-# Patch targets for the function-local imports inside
-# ``refresh_restart_authorization`` (kept local to avoid the create_flow ->
-# bot_service import cycle).
-_MCP_CODES_PATH = "agentclaw.community.core.bot_management.create_flow._get_bot_mcp_codes"
-_CLI_ITEMS_PATH = "agentclaw.community.core.mcp.services._defaults.get_default_cli_items"
+_AICODING_THREADING = "agentclaw.community.core.bot_management.engines.aicoding.strategy.threading"
 
 
-def _ctx(active_engine="claude_code"):
+class _InlineThread:
+    def __init__(self, target=None, **kwargs) -> None:
+        self.target = target
+        self.daemon = kwargs.get("daemon")
+
+    def start(self) -> None:
+        assert self.target is not None
+        self.target()
+
+
+def _ctx(active_engine: str = "claude_code") -> BotProvisioningContext:
     return BotProvisioningContext(
         bot_id="bot-1",
         owner_id="owner-1",
@@ -44,364 +48,186 @@ def _ctx(active_engine="claude_code"):
     )
 
 
-def _bot(entity_id="ent-1", entity_type="staff", bot_name="my-bot", bot_desc="d"):
+def _bot(entity_id: str = "ent-1", entity_type: str = "staff") -> dict:
     return {
-        # The primary key the identity lookup is keyed by. Every persisted bot
-        # carries one; the strategy declines rather than guessing when it does not.
-        "id": 42,
         "entity_id": entity_id,
         "entity_type": entity_type,
-        "bot_name": bot_name,
-        "bot_desc": bot_desc,
+        "bot_name": "my-bot",
+        "bot_desc": "d",
     }
 
 
-def _identity_repo(modes=None):
-    """A caller-identity repository answering with ``modes`` (default: none)."""
-    repo = MagicMock(name="caller_identity_repo")
-    repo.list_draft_call_types.return_value = modes or {}
-    return repo
-
-
-def _owner_items(*codes):
-    return [{"mcp_code": code, "identity_mode": "owner"} for code in codes]
-
-
-def _template_service(stored_config):
-    service = MagicMock()
-    service.get_template_config.return_value = stored_config
-    return service
-
-
-def _assert_skip(extra_configs):
-    """Run refresh with ``extra_configs`` and assert a complete no-op.
-
-    A no-op must not touch the template service, the MCP/CLI collectors, nor the
-    passport plugin — the gate returns before any of them are touched.
-    """
-    template_service = _template_service({"template_key": "architect"})
-    passport_plugin = MagicMock()
-    skill_set_factory = MagicMock(name="skill_set_factory")
-    strategy = AicodingProvisioningStrategy("claude_code")
-
-    with patch(_MCP_CODES_PATH) as mcp_mock, patch(_CLI_ITEMS_PATH) as cli_mock:
-        strategy.refresh_restart_authorization(
-            _ctx(),
-            _bot(),
-            extra_configs,
-            passport_plugin=passport_plugin,
-            skill_set_factory=skill_set_factory,
-            template_service=template_service,
-            caller_identity_repo=_identity_repo(),
-        )
-        template_service.get_template_config.assert_not_called()
-        mcp_mock.assert_not_called()
-        cli_mock.assert_not_called()
-        passport_plugin.update_passport.assert_not_called()
-
-
-# --------------------------------------------------------------------------- #
-# Gate / no-op branch                                                         #
-# --------------------------------------------------------------------------- #
-def test_skip_when_extra_configs_is_none():
-    _assert_skip(None)
-
-
-def test_skip_when_extra_configs_is_empty_dict():
-    _assert_skip({})
-
-
-def test_skip_when_confirmed_template_update_key_missing():
-    _assert_skip({"unrelated_key": True})
-
-
-def test_skip_when_confirmed_template_update_is_false():
-    _assert_skip({"confirmed_template_update": False})
-
-
-def test_skip_when_confirmed_template_update_is_none():
-    _assert_skip({"confirmed_template_update": None})
-
-
-def test_skip_when_extra_configs_is_not_a_dict():
-    # A non-dict envelope (str / list / bool) must also no-op without raising.
-    for extra_configs in ("confirmed_template_update=true", ["confirmed"], True):
-        _assert_skip(extra_configs)
-
-
-# --------------------------------------------------------------------------- #
-# Active branch: opt-in confirmed                                             #
-# --------------------------------------------------------------------------- #
-def _do_refresh(
-    stored_config,
-    active_engine="claude_code",
-    strategy_engine="claude_code",
-    identity_repo=None,
-):
-    """Run refresh with the opt-in flag set; return all collaborators + mocks."""
-    ctx = _ctx(active_engine=active_engine)
-    bot = _bot()
-    template_service = _template_service(stored_config)
-    passport_plugin = MagicMock()
-    skill_set_factory = MagicMock(name="skill_set_factory")
-    caller_identity_repo = identity_repo or _identity_repo()
-    strategy = AicodingProvisioningStrategy(strategy_engine)
-
-    with patch(_MCP_CODES_PATH, return_value=["mcp-a", "mcp-b"]) as mcp_mock, \
-            patch(_CLI_ITEMS_PATH, return_value=["cli-1"]) as cli_mock:
-        strategy.refresh_restart_authorization(
-            ctx,
-            bot,
-            {"confirmed_template_update": True},
-            passport_plugin=passport_plugin,
-            skill_set_factory=skill_set_factory,
-            template_service=template_service,
-            caller_identity_repo=caller_identity_repo,
-        )
-    return {
-        "ctx": ctx,
-        "bot": bot,
-        "template_service": template_service,
-        "passport_plugin": passport_plugin,
-        "skill_set_factory": skill_set_factory,
-        "caller_identity_repo": caller_identity_repo,
-        "mcp_mock": mcp_mock,
-        "cli_mock": cli_mock,
-    }
-
-
-def test_active_updates_passport_with_full_resource_scope():
-    r = _do_refresh({"template_key": "architect"})
-
-    r["template_service"].get_template_config.assert_called_once_with("bot-1")
-    r["mcp_mock"].assert_called_once_with(
-        r["skill_set_factory"], "owner-1", "bot-1", "ent-1", "staff", "claude_code"
-    )
-    r["cli_mock"].assert_called_once_with(
-        "claude_code", "architect",
-        ext_info={"template_config": {"template_key": "architect"}},
-    )
-    r["passport_plugin"].update_passport.assert_called_once_with(
-        bot_id="bot-1",
-        user_id="owner-1",
-        bot_name="my-bot",
-        bot_desc="d",
-        engine_type="claude_code",
-        resource_scope={
-            "mcp_codes": ["mcp-a", "mcp-b"],
-            "mcp_items": _owner_items("mcp-a", "mcp-b"),
-            "cli_items": ["cli-1"],
-        },
-    )
-
-
-def test_active_passes_ext_info_none_when_stored_config_is_none():
-    # template_service.get_template_config -> None  =>  stored_config = {}
-    r = _do_refresh(None)
-    r["cli_mock"].assert_called_once_with(
-        "claude_code", "architect", ext_info=None,
-    )
-    r["passport_plugin"].update_passport.assert_called_once()
-
-
-def test_active_passes_ext_info_none_when_stored_config_is_empty_dict():
-    r = _do_refresh({})
-    r["cli_mock"].assert_called_once_with(
-        "claude_code", "architect", ext_info=None,
-    )
-    r["passport_plugin"].update_passport.assert_called_once()
-
-
-def test_active_uses_strategy_engine_type_when_ctx_active_engine_is_none():
-    r = _do_refresh(
-        {"template_key": "architect"},
-        active_engine=None,
-        strategy_engine="aicoding",
-    )
-    r["mcp_mock"].assert_called_once_with(
-        r["skill_set_factory"], "owner-1", "bot-1", "ent-1", "staff", "aicoding"
-    )
-    r["cli_mock"].assert_called_once_with(
-        "aicoding", "architect", ext_info={"template_config": {"template_key": "architect"}},
-    )
-    r["passport_plugin"].update_passport.assert_called_once_with(
-        bot_id="bot-1",
-        user_id="owner-1",
-        bot_name="my-bot",
-        bot_desc="d",
-        engine_type="aicoding",
-        resource_scope={
-            "mcp_codes": ["mcp-a", "mcp-b"],
-            "mcp_items": _owner_items("mcp-a", "mcp-b"),
-            "cli_items": ["cli-1"],
-        },
-    )
-
-
-def test_active_defaults_entity_type_when_bot_missing_entity_type():
-    bot = {"id": 42, "entity_id": "ent-9", "bot_name": "b", "bot_desc": "x"}  # no entity_type
-    ctx = _ctx()
-    template_service = _template_service({})
-    passport_plugin = MagicMock()
-    skill_set_factory = MagicMock(name="skill_set_factory")
-    strategy = AicodingProvisioningStrategy("claude_code")
-
-    with patch(_MCP_CODES_PATH, return_value=[]) as mcp_mock, \
-            patch(_CLI_ITEMS_PATH, return_value=[]) as cli_mock:
-        strategy.refresh_restart_authorization(
-            ctx, bot, {"confirmed_template_update": True},
-            passport_plugin=passport_plugin,
-            skill_set_factory=skill_set_factory,
-            template_service=template_service,
-            caller_identity_repo=_identity_repo(),
-        )
-    mcp_mock.assert_called_once_with(
-        skill_set_factory, "owner-1", "bot-1", "ent-9", "staff", "claude_code"
-    )
-    passport_plugin.update_passport.assert_called_once_with(
-        bot_id="bot-1",
-        user_id="owner-1",
-        bot_name="b",
-        bot_desc="x",
-        engine_type="claude_code",
-        resource_scope={"mcp_codes": [], "mcp_items": [], "cli_items": []},
-    )
-
-
-# --------------------------------------------------------------------------- #
-# MCP execution identity                                                      #
-# --------------------------------------------------------------------------- #
-def test_active_carries_caller_identity_into_the_passport_scope():
-    """A caller-mode MCP survives the refresh instead of being demoted.
-
-    This is the regression the whole identity path exists for: the scope is a
-    full replacement, so pushing ``mcp-b`` without ``identity_mode`` would
-    rewrite it to owner and revoke the caller grant.
-    """
-    r = _do_refresh(
-        {"template_key": "architect"},
-        identity_repo=_identity_repo({"mcp-b": "caller"}),
-    )
-
-    r["caller_identity_repo"].list_draft_call_types.assert_called_once_with(
-        42, "claude_code"
-    )
-    scope = r["passport_plugin"].update_passport.call_args.kwargs["resource_scope"]
-    assert scope["mcp_items"] == [
-        {"mcp_code": "mcp-a", "identity_mode": "owner"},
-        {"mcp_code": "mcp-b", "identity_mode": "caller"},
-    ]
-    # Derived from the items, never assembled independently.
-    assert scope["mcp_codes"] == ["mcp-a", "mcp-b"]
-
-
-def test_skip_when_identity_lookup_fails():
-    """An unreadable identity row declines the refresh rather than defaulting."""
-    repo = _identity_repo()
-    repo.list_draft_call_types.side_effect = RuntimeError("identity store down")
-    passport_plugin = MagicMock()
-    strategy = AicodingProvisioningStrategy("claude_code")
-
-    with patch(_MCP_CODES_PATH, return_value=["mcp-a"]), \
-            patch(_CLI_ITEMS_PATH, return_value=[]):
-        strategy.refresh_restart_authorization(
-            _ctx(),
-            _bot(),
-            {"confirmed_template_update": True},
-            passport_plugin=passport_plugin,
-            skill_set_factory=MagicMock(name="skill_set_factory"),
-            template_service=_template_service({}),
-            caller_identity_repo=repo,
-        )
-    passport_plugin.update_passport.assert_not_called()
-
-
-def test_skip_when_bot_record_has_no_primary_key():
-    """A bot without a primary key cannot be keyed for identity — decline."""
-    bot = _bot()
-    del bot["id"]
-    repo = _identity_repo()
-    passport_plugin = MagicMock()
-    strategy = AicodingProvisioningStrategy("claude_code")
-
-    with patch(_MCP_CODES_PATH, return_value=["mcp-a"]), \
-            patch(_CLI_ITEMS_PATH, return_value=[]):
-        strategy.refresh_restart_authorization(
-            _ctx(),
-            bot,
-            {"confirmed_template_update": True},
-            passport_plugin=passport_plugin,
-            skill_set_factory=MagicMock(name="skill_set_factory"),
-            template_service=_template_service({}),
-            caller_identity_repo=repo,
-        )
-    repo.list_draft_call_types.assert_not_called()
-    passport_plugin.update_passport.assert_not_called()
-
-
-# --------------------------------------------------------------------------- #
-# Failure propagation                                                         #
-# --------------------------------------------------------------------------- #
-def test_passport_failure_propagates_and_is_not_swallowed():
-    """The strategy must let update_passport raise so the caller's try/except
-    can log-and-continue; it must not swallow authorization errors itself."""
-
-    ctx = _ctx()
-    bot = _bot()
-    template_service = _template_service({})
-    passport_plugin = MagicMock()
-    passport_plugin.update_passport.side_effect = RuntimeError("passport down")
-    skill_set_factory = MagicMock(name="skill_set_factory")
-    strategy = AicodingProvisioningStrategy("claude_code")
-
-    with patch(_MCP_CODES_PATH, return_value=["mcp-a"]), \
-            patch(_CLI_ITEMS_PATH, return_value=[]):
-        raised = False
-        try:
-            strategy.refresh_restart_authorization(
-                ctx, bot, {"confirmed_template_update": True},
-                passport_plugin=passport_plugin,
-                skill_set_factory=skill_set_factory,
-                template_service=template_service,
-                caller_identity_repo=_identity_repo(),
-            )
-        except RuntimeError:
-            raised = True
-        assert raised, "update_passport failure must propagate to the caller"
-
-
-# --------------------------------------------------------------------------- #
-# Default engine strategy: no-op                                              #
-# --------------------------------------------------------------------------- #
-def test_default_strategy_no_op_does_not_touch_passport():
-    template_service = MagicMock()
-    passport_plugin = MagicMock()
-    skill_set_factory = MagicMock(name="skill_set_factory")
-    strategy = DefaultProvisioningStrategy("openclaw")
-
-    # Even an opt-in request on a default engine must not authorize anything.
-    strategy.refresh_restart_authorization(
-        _ctx(),
-        _bot(),
-        {"confirmed_template_update": True},
-        passport_plugin=passport_plugin,
-        skill_set_factory=skill_set_factory,
-        template_service=template_service,
-        caller_identity_repo=_identity_repo(),
-    )
-    passport_plugin.update_passport.assert_not_called()
-    template_service.get_template_config.assert_not_called()
-
-
-def test_default_strategy_no_op_returns_none():
-    strategy = DefaultProvisioningStrategy("openclaw")
-    result = strategy.refresh_restart_authorization(
-        _ctx(),
-        _bot(),
+@pytest.mark.parametrize(
+    "extra_configs",
+    [
         None,
-        passport_plugin=MagicMock(),
-        skill_set_factory=MagicMock(),
-        template_service=MagicMock(),
-        caller_identity_repo=_identity_repo(),
+        {},
+        {"unrelated_key": True},
+        {"confirmed_template_update": False},
+        {"confirmed_template_update": None},
+        "confirmed_template_update=true",
+        ["confirmed"],
+        True,
+    ],
+)
+def test_aicoding_refresh_is_noop_without_opt_in(extra_configs) -> None:
+    strategy = AicodingProvisioningStrategy("claude_code")
+    mcp_sync = MagicMock()
+    factory = MagicMock()
+
+    assert (
+        strategy.refresh_restart_authorization(
+            _ctx(), _bot(), extra_configs,
+            mcp_sync=mcp_sync,
+            skill_set_factory=factory,
+        )
+        is False
     )
-    assert result is None
+    mcp_sync.refresh_mcp_scope.assert_not_called()
+    factory.create.assert_not_called()
+
+
+@pytest.mark.parametrize("flag", [True, 1, "yes"], ids=["true", "one", "truthy-str"])
+def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    mcp_sync = MagicMock()
+    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
+    mcp_sync.sync_mcp_details = AsyncMock(return_value={"success": True})
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.sync_runtime.return_value = True
+    factory.create.return_value = skill_set_service
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(entity_id="ent-9", entity_type="staff"),
+            {"confirmed_template_update": flag},
+            mcp_sync=mcp_sync,
+            skill_set_factory=factory,
+        ) is True
+
+    mcp_sync.refresh_mcp_scope.assert_awaited_once()
+    scope_kwargs = mcp_sync.refresh_mcp_scope.await_args.kwargs
+    assert scope_kwargs["user_id"] == "ent-9"
+    assert scope_kwargs["entity_id"] == "ent-9"
+    assert scope_kwargs["bot_id"] == "bot-1"
+    assert scope_kwargs["entity_type"] == "staff"
+    assert scope_kwargs["engine_type"] == "aicoding"
+    assert "extra_cli_items" not in scope_kwargs
+    mcp_sync.sync_mcp_details.assert_awaited_once_with(
+        user_id="ent-9",
+        entity_id="ent-9",
+        bot_id="bot-1",
+        entity_type="staff",
+        engine_type="aicoding",
+    )
+    factory.create.assert_called_once_with(
+        user_id="ent-9",
+        entity_id="ent-9",
+        bot_id="bot-1",
+        entity_type="staff",
+        engine_type="aicoding",
+    )
+    skill_set_service.sync_runtime.assert_called_once_with()
+
+
+def test_aicoding_refresh_is_best_effort_and_keeps_skill_sync_on_mcp_error() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    mcp_sync = MagicMock()
+    mcp_sync.refresh_mcp_scope = AsyncMock(side_effect=RuntimeError("scope down"))
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.sync_runtime.return_value = True
+    factory.create.return_value = skill_set_service
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=mcp_sync,
+            skill_set_factory=factory,
+        ) is True
+    factory.create.assert_called_once()
+    skill_set_service.sync_runtime.assert_called_once_with()
+
+
+
+def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    mcp_sync = MagicMock()
+    mcp_sync.refresh_mcp_scope = AsyncMock(
+        return_value={"success": False, "error": "scope denied"}
+    )
+    mcp_sync.sync_mcp_details = AsyncMock()
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.sync_runtime.return_value = True
+    factory.create.return_value = skill_set_service
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=mcp_sync,
+            skill_set_factory=factory,
+        ) is True
+
+    mcp_sync.sync_mcp_details.assert_not_called()
+    skill_set_service.sync_runtime.assert_called_once_with()
+
+
+def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    mcp_sync = MagicMock()
+    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
+    mcp_sync.sync_mcp_details = AsyncMock(
+        return_value={"success": False, "error": "detail down"}
+    )
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.sync_runtime.return_value = False
+    factory.create.return_value = skill_set_service
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=mcp_sync,
+            skill_set_factory=factory,
+        ) is True
+
+    mcp_sync.sync_mcp_details.assert_awaited_once()
+    skill_set_service.sync_runtime.assert_called_once_with()
+
+
+def test_aicoding_refresh_swallows_skill_sync_exception() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    factory = MagicMock()
+    factory.create.side_effect = RuntimeError("skill unavailable")
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=None,
+            skill_set_factory=factory,
+        ) is True
+
+    factory.create.assert_called_once()
+
+def test_default_strategy_always_returns_false() -> None:
+    strategy = DefaultProvisioningStrategy("openclaw")
+    assert (
+        strategy.refresh_restart_authorization(
+            _ctx(), _bot(), {"confirmed_template_update": True},
+            mcp_sync=MagicMock(),
+            skill_set_factory=MagicMock(),
+        )
+        is False
+    )
+    assert strategy.refresh_restart_authorization(_ctx(), _bot(), None) is False


### PR DESCRIPTION
## Summary
- refresh AICoding MCP scope/details on restart when `confirmed_template_update` is set
- actively resync runtime skill symlinks after confirmed template restart
- keep restart refresh logic inside AICoding strategy and avoid CLI grant changes
- inject MCP sync into `BotService` from the DI composition root instead of exposing it through `DeviceService`

## Compatibility and risk
- Scope is gated by `extra_configs["confirmed_template_update"]`; plain restart keeps existing behavior and does not resync MCP/skills.
- Affected call sites are the restart paths that can reach a ready device:
  - replacement restart: `_allocate_device_async` calls `refresh_restart_authorization` after `apply_device` succeeds, so the refresh targets the new runtime instead of the old binding.
  - BaaS in-place restart: `restart_bot` calls `refresh_restart_authorization` after `_restart_bot_baas` succeeds.
  - pre-allocation restart extension handling only applies config; runtime refresh is intentionally deferred to the ready-device points above.
- `refresh_restart_authorization` return value means "engine opted into async best-effort refresh"; it does not mean MCP/skill sync succeeded.
- The previous restart Passport scope rewrite is intentionally not reused for this AICoding path: this change syncs latest MCP runtime configuration and refreshes `~/.claude/skills` symlinks, without modeling `mcporter` or `la ~/.claude/skills/` as CLI grants.
- `caller_identity_repo` remains in `BotService` construction for release-branch DI/API compatibility, but is no longer used by this restart-runtime refresh path.

## Tests
- `.venv/bin/python -m py_compile src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py src/agentclaw/community/core/bot_management/engines/default.py src/agentclaw/community/core/bot_management/engines/provisioning.py src/agentclaw/community/core/bot_management/services/bot_service.py src/agentclaw/community/core/devices/services/device_service.py src/agentclaw/community/di/modules/bot_management_module.py tests/community/core/bot_management/services/test_restart_authorization_refresh.py tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py`
- `.venv/bin/python -m pytest tests/community/core/bot_management/services/test_restart_authorization_refresh.py tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py::TestRestartAuthorizationResyncWiring tests/community/core/mcp/services/test_sync_service.py tests/community/core/mcp/test_defaults_per_engine.py -q` (`97 passed, 17 warnings`)
