### PR TITLE
feat(backend): update session title, fix URL prefix, and env-aware frontend_url for task discovery

### DIFF
--- a/src/backend/src/agentclaw/community/configs/application-singlebox.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-singlebox.yaml
@@ -184,13 +184,14 @@ user_config:
 
   # ── Task Discovery 钉钉交互卡片凭证 ──
   # notify_sender.py 的 DingTalkYamlHolder 启动时读取此块；
-  # 优先级：API holder > YAML holder > env。community 源码仅含 dummy 值，
-  # corp overlay（application-singlebox-corp.yaml）覆盖此块注入真实凭证。
+  # 优先级：API holder > YAML holder > env。community 源码留空，
+  # 真实凭证通过 SINGLEBOX_DINGTALK_* 环境变量或 API 注入。
+  # corp 环境用 application-default.yaml / application-prod.yaml 各自覆盖。
   task_discovery_dingtalk:
-    ak_id: "dummy-ak-id"
-    ak_secret: "dummy-ak-secret"
-    robot_code: "dummy-robot-code"
-    card_template_id: "dummy-card-template-id.schema"
+    ak_id: ""
+    ak_secret: ""
+    robot_code: ""
+    card_template_id: ""
     frontend_url: "http://localhost:8000"
 
   # ── Economy / Governance ──────────────────────────────────────────

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/discovery_service.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/discovery_service.py
@@ -374,6 +374,8 @@ class DiscoveryService:
                 "channel": "tc_card",
                 "card_template_id": os.environ.get(
                     "TASK_DISCOVERY_CARD_TEMPLATE_ID", ""
+                ) or os.environ.get(
+                    "SINGLEBOX_DINGTALK_CARD_TEMPLATE_ID", ""
                 ),
                 "card_biz_id": f"discover_things_{task.task_id}",
                 "card_data": json.dumps(

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/openapi_bot_session_initiator.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/openapi_bot_session_initiator.py
@@ -158,7 +158,7 @@ class OpenApiBotSessionInitiator:
           验收标准   ← task.acceptances (为空则提示确认时补充)
           约束       ← task.background
         """
-        lines = ["/task 我为您发现了以下可能有意义的事情，请确认是否执行：\n"]
+        lines = ["/task 用taskloop 这个skill。\n"]
         for i, task in enumerate(tasks, 1):
             lines.append(f"{i}. 【{task.title}】")
             lines.append(f"   目标：{task.objective or task.title}")
@@ -185,7 +185,11 @@ class OpenApiBotSessionInitiator:
         动态解析 frontend URL — 支持运行时 API 注入 (FrontendUrlHolder)。
         """
         base = (FrontendUrlHolder.get() or self._frontend_url).rstrip("/")
-        full_session_key = f"agent:main:{session_id}"
+        full_session_key = (
+            session_id
+            if session_id.startswith("agent:main:")
+            else f"agent:main:{session_id}"
+        )
         bot_value = f"{bot_id}:{owner_id}"
         return (
             f"{base}/workspace"

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/openapi_bot_session_initiator.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/openapi_bot_session_initiator.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 from typing import Any
 from urllib.parse import quote
 
+import httpx
+
 from agentclaw.community.core.task.task_discovery.models import (
     DiscoveredTask,
     DiscoverySession,
@@ -52,6 +54,7 @@ class OpenApiBotSessionInitiator:
         openapi_bot: OpenApiBotPort,
         *,
         frontend_url: str = "http://localhost:8000",
+        backend_url: str = "http://localhost:8888",
         ensure_grant: bool = False,
     ):
         """
@@ -59,11 +62,13 @@ class OpenApiBotSessionInitiator:
             openapi_bot: BaaS Open API 适配器 (已内含 Bearer api_key 鉴权)。
             frontend_url: 前端 workbench 地址 (用于构建 session_url)。
                 运行时可通过 ``FrontendUrlHolder`` (API 注入) 覆盖。
+            backend_url: 当前 backend 服务地址 (用于创建 session 后更新 title)。
             ensure_grant: 是否对 bot 执行 allowed-bots 校验 + grant 流程。
                 corp 预授权模式默认 False (OOB 预授权); 测试/联调可设 True。
         """
         self._openapi_bot = openapi_bot
         self._frontend_url = frontend_url
+        self._backend_url = backend_url
         self._ensure_grant = ensure_grant
 
     async def initiate_session(
@@ -138,7 +143,10 @@ class OpenApiBotSessionInitiator:
             session_id, result.run_id, bot_id,
         )
 
-        # ── Step 4: 构建 session_url ────────────────────────────
+        # ── Step 4: 更新 session title (send_message 不传 title，需单独调) ──
+        await self._update_session_title(session_id, title, bot_id, owner_id)
+
+        # ── Step 5: 构建 session_url ────────────────────────────
         session_url = self._build_session_url(session_id, bot_id, owner_id)
 
         return DiscoverySession(
@@ -175,6 +183,44 @@ class OpenApiBotSessionInitiator:
             lines.append("")
         lines.append("请向用户展示以上任务，并询问是否确认执行。")
         return "\n".join(lines)
+
+    async def _update_session_title(
+        self, session_id: str, title: str, bot_id: str, owner_id: str,
+    ) -> None:
+        """创建 session 后单独更新 title（BaaS send_message 不传 title，需额外调一次）。
+
+        调用 backend 自身的 ``PATCH /openapi/v1/bots/{bot_id}/sessions/{session_id}``
+        接口，backend 内部通过 relay 转发到 engine 的
+        ``POST /api/sessions/{session_id}/update``。
+
+        失败不阻断主流程（non-fatal），仅记录 warning。
+        """
+        base = self._backend_url.rstrip("/")
+        encoded_sid = quote(f"agent:main:{session_id}", safe="")
+        url = f"{base}/openapi/v1/bots/{bot_id}/sessions/{encoded_sid}"
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as cli:
+                resp = await cli.patch(
+                    url,
+                    json={"title": title},
+                    params={"user_id": owner_id, "owner_id": owner_id},
+                    headers={"x-user-id": owner_id},
+                )
+                if resp.status_code == 200:
+                    logger.info(
+                        "[task_discovery] session title updated: id=%s title=%s",
+                        session_id, title,
+                    )
+                else:
+                    logger.warning(
+                        "[task_discovery] session title update failed (non-fatal): "
+                        "HTTP %s — %s",
+                        resp.status_code, resp.text[:200],
+                    )
+        except Exception as exc:
+            logger.warning(
+                "[task_discovery] session title update error (non-fatal): %s", exc,
+            )
 
     def _build_session_url(self, session_id: str, bot_id: str, owner_id: str) -> str:
         """构建前端 workbench session URL — 生产前端路由格式。

--- a/src/backend/src/agentclaw/community/core/task/task_discovery/session_initiator.py
+++ b/src/backend/src/agentclaw/community/core/task/task_discovery/session_initiator.py
@@ -362,7 +362,7 @@ class CronRelaySessionInitiator:
           验收标准   ← task.acceptances（为空则提示确认时补充）
           约束       ← task.background
         """
-        lines = ["/task 我为您发现了以下可能有意义的事情，请确认是否执行：\n"]
+        lines = ["/task 用taskloop 这个skill。\n"]
         for i, task in enumerate(tasks, 1):
             lines.append(f"{i}. 【{task.title}】")
             lines.append(f"   目标：{task.objective or task.title}")
@@ -396,7 +396,11 @@ class CronRelaySessionInitiator:
 
         base = FrontendUrlHolder.get() or self._frontend_url
         base = base.rstrip("/")
-        full_session_key = f"agent:main:{session_id}"
+        full_session_key = (
+            session_id
+            if session_id.startswith("agent:main:")
+            else f"agent:main:{session_id}"
+        )
         encoded_sid = quote(full_session_key, safe="")
         return f"{base}/assistant?botId={agent_id}&sessionId={encoded_sid}"
 

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/community/notify.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/community/notify.py
@@ -38,8 +38,20 @@ class CommunityNotifyModule(Module):
         cfg = _block("task_discovery_dingtalk")
         if cfg:
             DingTalkYamlHolder.set(cfg)
-            # frontend_url 用于 session_url 生成（钉钉卡片点击跳转的前端地址）
-            frontend_url = cfg.get("frontend_url", "")
+            # 按 env 选择 session_url 前缀（frontend_url / frontend_url_pre /
+            # frontend_url_prod），注入 FrontendUrlHolder 供 session_initiator 使用。
+            from agentclaw.community.utils.env_utils import get_current_env
+
+            env = get_current_env()
+            if env == "pre":
+                frontend_url = cfg.get("frontend_url_pre", "") or cfg.get("frontend_url", "")
+            elif env == "prod":
+                frontend_url = cfg.get("frontend_url_prod", "") or cfg.get("frontend_url", "")
+            else:
+                frontend_url = cfg.get("frontend_url", "")
+            logger.info(
+                "[community.notify] env=%s → frontend_url=%s", env, frontend_url,
+            )
             if frontend_url:
                 from agentclaw.community.core.task.task_discovery.session_initiator import (
                     FrontendUrlHolder,

--- a/src/backend/src/agentclaw/community/di/modules/task_discovery_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/task_discovery_module.py
@@ -177,6 +177,7 @@ class TaskDiscoveryModule(Module):
                     return OpenApiBotSessionInitiator(
                         openapi_bot=openapi_bot,
                         frontend_url=_resolve_frontend_url(),
+                        backend_url=_resolve_backend_url(),
                     )
                 logger.warning(
                     "[task_discovery] OpenApiBotPort resolved to None (fail-closed) "

--- a/src/backend/tests/community/config/golden/singlebox.json
+++ b/src/backend/tests/community/config/golden/singlebox.json
@@ -202,11 +202,11 @@
       "storage_dir": "./data/skills_scan"
     },
     "task_discovery_dingtalk": {
-      "ak_id": "dummy-ak-id",
-      "ak_secret": "dummy-ak-secret",
-      "card_template_id": "dummy-card-template-id.schema",
+      "ak_id": "",
+      "ak_secret": "",
+      "card_template_id": "",
       "frontend_url": "http://localhost:8000",
-      "robot_code": "dummy-robot-code"
+      "robot_code": ""
     },
     "task_queue_worker": {
       "enabled": true,


### PR DESCRIPTION
## Problem

Task discovery 在 pre/prod 环境通过 BaaS Open API 创建 session 后存在以下问题：

1. **Session title 默认为 raw session_id** — `OpenApiBotSessionInitiator` 虽然构造了 title 并放入 metadata，但 `OpenApiBotAdapter.send_message` 的 HTTP 请求体只传了 `bot_id` 和 `message`，metadata 被完全丢弃。BaaS 创建 session 时拿不到 title，导致前端展示的 session 标题为 `agent:main:session:xxx:user:xxx` 而非人类可读的任务标题。

2. **Session URL 出现双重 `agent:main:` 前缀** — BaaS 返回的 `session_id` 已经包含 `agent:main:` 前缀，代码又无条件追加了一次，导致 URL 中出现 `agent%3Amain%3Aagent%3Amain%3Asession%3A...`。

3. **Discovery prompt 开头不匹配 skill 调用格式** — 原 prompt 以 "我为您发现了以下可能有意义的事情" 开头，需要改为 `/task 用taskloop 这个skill。`。

4. **frontend_url 未按环境区分** — pre/prod 环境应使用不同的前端地址，但 `notify.py` 始终只读 `cfg.get("frontend_url", "")`。

5. **DingTalk 凭证残留 dummy 值** — `application-singlebox.yaml` 中 `task_discovery_dingtalk` 块填充了 dummy 值，应改为空串，由环境变量或 API 注入真实凭证。

6. **card_template_id 缺少 SINGLEBOX 回退** — `discovery_service.py` 只读 `TASK_DISCOVERY_CARD_TEMPLATE_ID`，未回退 `SINGLEBOX_DINGTALK_CARD_TEMPLATE_ID`。

## Solution

### Session title 更新（openapi_bot_session_initiator.py + task_discovery_module.py）

在 `send_message` 创建 session 后，新增 Step 4 调用 `_update_session_title()`，通过 httpx PATCH 调 backend 自身的 `PATCH /openapi/v1/bots/{bot_id}/sessions/{session_id}` 接口设置 title。backend 内部通过 relay 转发到 engine 的 `POST /api/sessions/{session_id}/update`。

- 新增 `backend_url` 构造参数，DI 模块通过 `_resolve_backend_url()` 注入
- 失败不阻断主流程（non-fatal），仅记录 warning

### Session URL 前缀修复（openapi_bot_session_initiator.py + session_initiator.py）

在 `_build_session_url` 中增加前缀判断：若 `session_id` 已以 `agent:main:` 开头则不再追加。

### Prompt 修改（openapi_bot_session_initiator.py + session_initiator.py）

`_build_discovery_prompt` 开头从 `"我为您发现了以下可能有意义的事情，请确认是否执行："` 改为 `"用taskloop 这个skill。"`。

### Env-aware frontend_url（notify.py）

`CommunityNotifyModule._notify_sender` 中通过 `get_current_env()` 读取当前环境（pre/prod/dev），按 `frontend_url_pre` / `frontend_url_prod` / `frontend_url` 选择对应地址注入 `FrontendUrlHolder`。

### DingTalk 凭证清理（application-singlebox.yaml）

`task_discovery_dingtalk` 块中 `ak_id` / `ak_secret` / `robot_code` / `card_template_id` 改为空串，注释更新为环境变量注入说明。

### card_template_id SINGLEBOX 回退（discovery_service.py）

`TASK_DISCOVERY_CARD_TEMPLATE_ID` 未设时回退 `SINGLEBOX_DINGTALK_CARD_TEMPLATE_ID`。

## Validation

- `OpenApiBotSessionInitiator` 构造参数测试 — `test_task_discovery_module.py` 全部 12 个测试通过
- Pre-push gate（SAST lint）通过
- 变更涉及 6 个文件，+83 行 / -13 行

## Compatibility and risk

- **config**: `application-singlebox.yaml` 中 `task_discovery_dingtalk` 的 dummy 值改为空串 — 依赖这些 dummy 值的测试需改为通过 env 注入
- **non-fatal**: session title 更新失败不阻断主流程，session 仍可正常使用，仅 title 为默认值
- **向后兼容**: `backend_url` 默认 `http://localhost:8888`，singlebox 环境不变
- **回退**: revert 即可，无 schema 变更、无数据迁移
