### PR TITLE
fix(aicoding): trigger restart resync after template update

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/bot_management/router.py
@@ -2775,7 +2775,16 @@ async def restart_bot(
                 else None
             )
             if isinstance(candidate, dict):
-                extra_configs = candidate
+                extra_configs = dict(candidate)
+            if (
+                isinstance(request_body, dict)
+                and "confirmed_template_update" in request_body
+            ):
+                if extra_configs is None:
+                    extra_configs = {}
+                extra_configs["confirmed_template_update"] = request_body.get(
+                    "confirmed_template_update"
+                )
         except Exception:
             # Empty/non-JSON request bodies remain valid for legacy callers.
             extra_configs = None

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -580,6 +580,12 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             template_type=ctx.template_type,
             active_engine=ctx.active_engine,
         )
+        # The persisted newer snapshot is the durable proof that this restart
+        # accepted a template update. Some callers send only
+        # extra_configs.template_config (or put confirmed_template_update at the
+        # body top level), so stamp the engine envelope here for the later
+        # refresh_restart_authorization hook in the same restart flow.
+        extra_configs["confirmed_template_update"] = True
         logger.info(
             "[aicoding.restart] persisted newer template snapshot: "
             "bot_id=%s old_version=%s new_version=%s",

--- a/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
+++ b/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
@@ -220,6 +220,38 @@ def test_aicoding_refresh_swallows_skill_sync_exception() -> None:
 
     factory.create.assert_called_once()
 
+
+def test_apply_restart_extra_configs_marks_confirmed_after_persisting_new_snapshot() -> None:
+    strategy = AicodingProvisioningStrategy("claude_code")
+    extra_configs = {"template_config": {"template_version_id": 2}}
+    template_service = MagicMock()
+    template_service.get_template_config.return_value = {"template_version_id": 1}
+
+    strategy.apply_restart_extra_configs(
+        _ctx(active_engine="claude_code"),
+        extra_configs,
+        template_service=template_service,
+    )
+
+    template_service.update_template.assert_called_once()
+    assert extra_configs["confirmed_template_update"] is True
+
+
+def test_apply_restart_extra_configs_does_not_mark_when_snapshot_not_newer() -> None:
+    strategy = AicodingProvisioningStrategy("claude_code")
+    extra_configs = {"template_config": {"template_version_id": 1}}
+    template_service = MagicMock()
+    template_service.get_template_config.return_value = {"template_version_id": 1}
+
+    strategy.apply_restart_extra_configs(
+        _ctx(active_engine="claude_code"),
+        extra_configs,
+        template_service=template_service,
+    )
+
+    template_service.update_template.assert_not_called()
+    assert "confirmed_template_update" not in extra_configs
+
 def test_default_strategy_always_returns_false() -> None:
     strategy = DefaultProvisioningStrategy("openclaw")
     assert (


### PR DESCRIPTION
## Summary
- Preserve top-level confirmed_template_update from restart request into extra_configs.
- When AICoding restart persists a newer template snapshot, mark the same restart envelope as confirmed so refresh_restart_authorization runs MCP detail resync and ~/.claude/skills symlink sync.
- Add unit coverage for the persisted-template signal.

## Why
Prepub logs showed the newer template snapshot was persisted, then restart resync was skipped because confirmed_template_update was missing from extra_configs:
- [aicoding.restart] persisted newer template snapshot ... old_version=2600008 new_version=2600011
- [aicoding.restart] skip authorization/runtime resync: confirmed_template_update is not set

This left mcporter MCP runtime config and ~/.claude/skills symlinks stale after confirmed template restart.

## Tests
- cd src/backend && .venv/bin/python -m pytest tests/community/core/bot_management/services/test_restart_authorization_refresh.py tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py::TestRestartAuthorizationResyncWiring -q
