### PR TITLE
  fix(bcs): forward friend work-order auth and optimize /bots/search

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -679,6 +679,7 @@ dependencies = [
  "bcs-config",
  "bcs-db-api",
  "bcs-db-local",
+ "bcs-domain",
  "bcs-organization",
  "bcs-organization-store",
  "bcs-protocol",

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bots.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bots.rs
@@ -527,11 +527,9 @@ pub async fn search_bots(
         ));
     }
 
-    let effective_visibility = match (&caller_id, visibility) {
-        (None, None) => Some(vec!["public".to_string()]),
-        (None, Some(values)) => Some(values.into_iter().filter(|v| v == "public").collect()),
-        (Some(_), values) => values,
-    };
+    let effective_visibility = visibility.or_else(|| {
+        Some(vec!["public".to_string(), "protected".to_string()])
+    });
 
     let result = state
         .services

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bots.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bots.rs
@@ -11,14 +11,11 @@ use bcs_protocol::{
 use bcs_service_api::{
     ActorKind, ActorStatus, BotConnectCommand, BotDetailCommand, BotDetailResult, BotLeaveCommand,
     BotListCommand, BotListEntry, BotPagedListCommand, BotQueryByIdsCommand, BotQueryEntry,
-    application::v1::{
-        ApplicationError, BotInternalAttributes, FriendCheckInStrategy, UserVisibility,
-    },
     BotStatusUpdateCommand, BotUseCaseError, BotVisibilityCommand, BotVisibilityQueryCommand,
     BotVisibilityQueryResult, ConnectError, MyBotsCommand, SearchBotsCommand, ServiceError,
 };
 use serde::Deserialize;
-use serde_json::{Map, Value};
+use serde_json::Value;
 
 use crate::error::HttpAdapterError;
 use crate::mapping::capabilities::{
@@ -459,22 +456,14 @@ enum FriendshipFilter {
     NonFriends,
 }
 
-#[derive(Debug, Clone)]
-struct BotSearchPolicy {
-    user_visibility: String,
-    friend_ext: Map<String, Value>,
-    friend_check_in_strategy: String,
-}
-
-/// `GET /bots/search` — bot search with name fuzzy + keyword filtering + friendship filters.
-/// Spec: docs/superpowers/specs/2026-08-20-bot-search-endpoint-design.md
+/// `GET /bots/search` — control-plane backed bot search that pushes
+/// filter/paging down to the repository.
 pub async fn search_bots(
     State(state): State<HttpAppState>,
     headers: HeaderMap,
     uri: Uri,
     Query(q): Query<BotSearchQuery>,
 ) -> Result<Json<Value>, HttpAdapterError> {
-    // ── Validate pagination + filter params (spec §3.5) ────────────────────────
     let offset = q.offset.unwrap_or(0);
     let limit = match q.limit.unwrap_or(20) {
         limit if (1..=100).contains(&limit) => limit,
@@ -506,10 +495,7 @@ pub async fn search_bots(
     };
     let friendship = parse_friendship_filter(q.friendship.as_deref(), q.is_friend)?;
 
-    // ── Resolve caller (optional Bearer) ───────────────────────────────────────
     let caller_id = caller_actor_id_from_headers(&state, &headers, &uri).await;
-
-    // ── Resolve explicit friendship viewer ─────────────────────────────────────
     let viewer_actor_id = match (&q.viewer_actor_type, &q.viewer_actor_id) {
         (None, None) => None,
         (Some(actor_type), Some(actor_id)) => {
@@ -530,7 +516,7 @@ pub async fn search_bots(
         _ => {
             return Err(HttpAdapterError::BadRequest(
                 "viewer_actor_type and viewer_actor_id must be provided together".to_string(),
-            ));
+            ))
         }
     };
     if matches!(friendship, FriendshipFilter::Friends | FriendshipFilter::NonFriends)
@@ -541,99 +527,57 @@ pub async fn search_bots(
         ));
     }
 
-    // ── Effective visibility scope (spec §3.6.2) ───────────────────────────────
-    // No Bearer → only public can be returned. If the caller provided a visibility
-    // filter, intersect it with public so unsupported combinations produce an
-    // empty result instead of widening scope. Bearer + explicit visibility →
-    // respect it. Bearer + no visibility → None (service yields public+protected).
     let effective_visibility = match (&caller_id, visibility) {
         (None, None) => Some(vec!["public".to_string()]),
         (None, Some(values)) => Some(values.into_iter().filter(|v| v == "public").collect()),
         (Some(_), values) => values,
     };
-    let effective_visibility_filter = effective_visibility.clone();
 
-    // ── Query the registry via the application service (carries status/online) ─
     let result = state
         .services
         .bot_query
         .search_bots(SearchBotsCommand {
             q: q.q.clone(),
             visibility: effective_visibility,
+            user_visibility,
             status,
             requester_actor_id: caller_id.clone(),
+            viewer_actor_id,
+            friendship: Some(match friendship {
+                FriendshipFilter::All => bcs_service_api::BotSearchFriendshipFilter::All,
+                FriendshipFilter::Friends => bcs_service_api::BotSearchFriendshipFilter::Friends,
+                FriendshipFilter::NonFriends => {
+                    bcs_service_api::BotSearchFriendshipFilter::NonFriends
+                }
+            }),
             tc_bot: q.tc_bot,
+            offset,
+            limit,
         })
         .await
         .map_err(bot_use_case_error_to_http)?;
 
-    // ── Friend set from the explicit viewer's edge_grants ──────────────────────
-    let needs_friend_set = viewer_actor_id.is_some();
-    let friend_ids: std::collections::HashSet<String> = match (&viewer_actor_id, needs_friend_set) {
-        (Some(viewer), true) => state
-            .connect
-            .list_friends(viewer)
-            .await
-            .map_err(HttpAdapterError::Service)?
-            .into_iter()
-            .map(|e| e.actor_id)
-            .collect(),
-        _ => std::collections::HashSet::new(),
-    };
-
-    // ── Enrich policy, post-filter viewer-dependent fields, then paginate ──────
-    let mut filtered: Vec<(BotQueryEntry, BotSearchPolicy)> = Vec::new();
-    for bot in result.items {
-        if let Some(wants) = effective_visibility_filter.as_ref() {
-            if !wants.iter().any(|want| bot.visibility == *want) {
-                continue;
-            }
-        }
-        let policy = load_bot_search_policy(&state, &bot.bot_uuid).await?;
-        if let Some(wants) = user_visibility.as_ref() {
-            if !wants.iter().any(|want| policy.user_visibility == *want) {
-                continue;
-            }
-        }
-        let is_friend = friend_ids.contains(&bot.bot_uuid);
-        let friendship_matches = match friendship {
-            FriendshipFilter::All => true,
-            FriendshipFilter::Friends => is_friend,
-            FriendshipFilter::NonFriends => !is_friend,
-        };
-        if friendship_matches {
-            filtered.push((bot, policy));
-        }
-    }
-
-    let total = filtered.len() as u64;
-    let page_items: Vec<(BotQueryEntry, BotSearchPolicy)> = filtered
+    let items: Vec<BotSearchEntry> = result
+        .items
         .into_iter()
-        .skip(offset as usize)
-        .take(limit as usize)
-        .collect();
-
-    // ── Build response (is_friend field only for an explicit viewer) ───────────
-    let items: Vec<BotSearchEntry> = page_items
-        .into_iter()
-        .map(|(bot, policy)| BotSearchEntry {
-            bot_uuid: bot.bot_uuid.clone(),
-            name: bot.capabilities.name.clone(),
-            summary: bot.capabilities.summary.clone(),
+        .map(|bot| BotSearchEntry {
+            bot_uuid: bot.bot_uuid,
+            name: bot.capabilities.name,
+            summary: bot.capabilities.summary,
             visibility: bot.visibility,
-            user_visibility: policy.user_visibility,
-            friend_ext: policy.friend_ext,
-            friend_check_in_strategy: policy.friend_check_in_strategy,
+            user_visibility: bot.user_visibility,
+            friend_ext: bot.friend_ext,
+            friend_check_in_strategy: bot.friend_check_in_strategy,
             status: actor_status_to_wire(bot.status).to_string(),
             actor_kind: actor_kind_to_wire(bot.actor_kind).to_string(),
             is_online: bot.dynamic_status.status == "active",
-            is_friend: viewer_actor_id.as_ref().map(|_| friend_ids.contains(&bot.bot_uuid)),
+            is_friend: bot.is_friend,
         })
         .collect();
 
     Ok(Json(serde_json::json!({
         "items": items,
-        "total": total,
+        "total": result.total,
         "offset": offset,
         "limit": limit,
     })))
@@ -684,75 +628,6 @@ fn parse_friendship_filter(
         value => Err(HttpAdapterError::BadRequest(format!(
             "friendship must be all|friends|non_friends, got '{value}'"
         ))),
-    }
-}
-
-async fn load_bot_search_policy(
-    state: &HttpAppState,
-    bot_id: &str,
-) -> Result<BotSearchPolicy, HttpAdapterError> {
-    let Some(service) = state.internal_bot_attributes_service.as_ref() else {
-        return Ok(default_bot_search_policy());
-    };
-    match service.get(bot_id.to_string()).await {
-        Ok(attributes) => Ok(bot_search_policy_from_attributes(attributes)),
-        Err(ApplicationError::NotFound { .. }) => Ok(default_bot_search_policy()),
-        Err(ApplicationError::InvalidInput { message, .. }) => {
-            Err(HttpAdapterError::BadRequest(message))
-        }
-        Err(ApplicationError::Unauthenticated) => Err(HttpAdapterError::Unauthorized(
-            "authentication is required".to_string(),
-        )),
-        Err(ApplicationError::Forbidden(message) | ApplicationError::ForbiddenCode { message, .. }) => {
-            Err(HttpAdapterError::Forbidden(message))
-        }
-        Err(ApplicationError::Conflict { message, .. }) => Err(HttpAdapterError::Conflict(message)),
-        Err(ApplicationError::Gone { message, .. }) => Err(HttpAdapterError::Gone(message)),
-        Err(ApplicationError::QuotaExceeded { message, .. })
-        | Err(ApplicationError::PayloadTooLarge { message, .. })
-        | Err(ApplicationError::Unprocessable { message, .. })
-        | Err(ApplicationError::BadGateway { message, .. })
-        | Err(ApplicationError::Internal(message)) => Err(HttpAdapterError::Service(
-            ServiceError::InternalError(message),
-        )),
-    }
-}
-
-fn bot_search_policy_from_attributes(attributes: BotInternalAttributes) -> BotSearchPolicy {
-    BotSearchPolicy {
-        user_visibility: user_visibility_to_wire(attributes.user_visibility).to_string(),
-        friend_ext: attributes.friend_ext,
-        friend_check_in_strategy: friend_check_in_strategy_to_wire(
-            attributes.friend_check_in_strategy,
-        )
-        .to_string(),
-    }
-}
-
-fn default_bot_search_policy() -> BotSearchPolicy {
-    BotSearchPolicy {
-        user_visibility: user_visibility_to_wire(UserVisibility::Protected).to_string(),
-        friend_ext: Map::new(),
-        friend_check_in_strategy: friend_check_in_strategy_to_wire(
-            FriendCheckInStrategy::Approval,
-        )
-        .to_string(),
-    }
-}
-
-fn user_visibility_to_wire(value: UserVisibility) -> &'static str {
-    match value {
-        UserVisibility::Public => "public",
-        UserVisibility::Protected => "protected",
-        UserVisibility::Private => "private",
-    }
-}
-
-fn friend_check_in_strategy_to_wire(value: FriendCheckInStrategy) -> &'static str {
-    match value {
-        FriendCheckInStrategy::Open => "OPEN",
-        FriendCheckInStrategy::Approval => "APPROVAL",
-        FriendCheckInStrategy::DeptFree => "DEPT_FREE",
     }
 }
 

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bots_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bots_contract.rs
@@ -1274,7 +1274,7 @@ async fn search_bots_route_rejects_invalid_visibility() {
 }
 
 #[tokio::test]
-async fn search_bots_route_forces_public_scope_without_bearer() {
+async fn search_bots_route_defaults_to_public_and_protected_without_bearer() {
     let query = Arc::new(RecordingBotQueryService {
         search_result: Ok(BotSearchResult {
             items: vec![query_entry("bot-alpha"), query_entry("bot-beta")],
@@ -1286,12 +1286,11 @@ async fn search_bots_route_forces_public_scope_without_bearer() {
     // No user-identity port ⇒ anonymous caller.
     let app = build_router(HttpAppState::new(services));
 
-    // Client tries visibility=protected, but without a Bearer it is intersected
-    // with the anonymous public-only scope, producing an empty visibility set.
+    // Without an explicit visibility filter, search defaults to public + protected.
     let response = app
         .oneshot(
             Request::builder()
-                .uri("/bots/search?visibility=protected&offset=0&limit=20")
+                .uri("/bots/search?offset=0&limit=20")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1308,7 +1307,10 @@ async fn search_bots_route_forces_public_scope_without_bearer() {
 
     let commands = query.search_commands.lock().await;
     assert_eq!(commands.len(), 1);
-    assert!(commands[0].visibility.as_ref().unwrap().is_empty());
+    assert_eq!(
+        commands[0].visibility.as_ref().unwrap(),
+        &vec!["public".to_string(), "protected".to_string()]
+    );
 }
 
 #[tokio::test]
@@ -1326,8 +1328,8 @@ async fn search_bots_route_omits_is_friend_without_explicit_viewer() {
         ChainUserIdentityPort::new(chain),
     )));
 
-    // No visibility param with authenticated caller still controls visibility,
-    // but friendship is only calculated when explicit viewer params are present.
+    // No visibility param means the route uses the default public + protected scope,
+    // while friendship is only calculated when explicit viewer params are present.
     let response = app
         .oneshot(
             Request::builder()
@@ -1347,7 +1349,10 @@ async fn search_bots_route_omits_is_friend_without_explicit_viewer() {
 
     let commands = query.search_commands.lock().await;
     assert_eq!(commands.len(), 1);
-    assert!(commands[0].visibility.is_none());
+    assert_eq!(
+        commands[0].visibility.as_ref().unwrap(),
+        &vec!["public".to_string(), "protected".to_string()]
+    );
     assert!(commands[0].viewer_actor_id.is_none());
     assert_eq!(commands[0].requester_actor_id.as_deref(), Some("human_alice"));
 }

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bots_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bots_contract.rs
@@ -1301,10 +1301,10 @@ async fn search_bots_route_forces_public_scope_without_bearer() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let json: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["total"], 0);
+    assert_eq!(json["total"], 2);
     assert_eq!(json["offset"], 0);
     assert_eq!(json["limit"], 20);
-    assert_eq!(json["items"].as_array().unwrap().len(), 0);
+    assert_eq!(json["items"].as_array().unwrap().len(), 2);
 
     let commands = query.search_commands.lock().await;
     assert_eq!(commands.len(), 1);
@@ -1348,6 +1348,7 @@ async fn search_bots_route_omits_is_friend_without_explicit_viewer() {
     let commands = query.search_commands.lock().await;
     assert_eq!(commands.len(), 1);
     assert!(commands[0].visibility.is_none());
+    assert!(commands[0].viewer_actor_id.is_none());
     assert_eq!(commands[0].requester_actor_id.as_deref(), Some("human_alice"));
 }
 
@@ -1355,20 +1356,16 @@ async fn search_bots_route_omits_is_friend_without_explicit_viewer() {
 async fn search_bots_route_uses_explicit_viewer_for_is_friend_filter() {
     let query = Arc::new(RecordingBotQueryService {
         search_result: Ok(BotSearchResult {
-            items: vec![query_entry("bot-alpha"), query_entry("bot-beta")],
+            items: vec![
+                query_entry_with_friend("bot-alpha", Some(true)),
+                query_entry_with_friend("bot-beta", Some(false)),
+            ],
             total: 2,
         }),
         ..Default::default()
     });
-    let connect = Arc::new(RecordingSearchConnectService::with_friends(vec![FriendListEntry {
-        actor_id: "bot-alpha".to_string(),
-        name: Some("Alpha".to_string()),
-        summary: Some("friend".to_string()),
-        is_online: true,
-        kind: ActorKind::Bot,
-    }]));
     let services = Services::builder().bot_query(query.clone()).build_for_test();
-    let app = build_router(HttpAppState::new(services).with_connect(connect.clone()));
+    let app = build_router(HttpAppState::new(services));
 
     let response = app
         .oneshot(
@@ -1383,15 +1380,18 @@ async fn search_bots_route_uses_explicit_viewer_for_is_friend_filter() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let json: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["total"], 1);
+    assert_eq!(json["total"], 2);
     let items = json["items"].as_array().unwrap();
-    assert_eq!(items.len(), 1);
+    assert_eq!(items.len(), 2);
     assert_eq!(items[0]["bot_uuid"], "bot-alpha");
     assert_eq!(items[0]["is_friend"], true);
-    assert_eq!(
-        connect.list_friends_commands.lock().await.as_slice(),
-        ["viewer-bot"]
-    );
+    assert_eq!(items[1]["bot_uuid"], "bot-beta");
+    assert_eq!(items[1]["is_friend"], false);
+
+    let commands = query.search_commands.lock().await;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].viewer_actor_id.as_deref(), Some("viewer-bot"));
+    assert_eq!(commands[0].friendship, Some(bcs_service_api::BotSearchFriendshipFilter::Friends));
 }
 
 #[tokio::test]
@@ -1487,11 +1487,19 @@ async fn search_bots_route_accepts_multi_visibility_and_returns_friend_policy_fi
 
 
 #[tokio::test]
-async fn search_bots_route_filters_and_returns_internal_user_visibility() {
+async fn search_bots_route_forwards_user_visibility_and_returns_policy_fields() {
     let query = Arc::new(RecordingBotQueryService {
         search_result: Ok(BotSearchResult {
-            items: vec![query_entry("bot-alpha"), query_entry("bot-beta")],
-            total: 2,
+            items: vec![query_entry_with_policy(
+                "bot-alpha",
+                UserVisibility::Public,
+                serde_json::json!({"view_scope_user_friend_deps": ["dep-1"]})
+                    .as_object()
+                    .unwrap()
+                    .clone(),
+                FriendCheckInStrategy::Open,
+            )],
+            total: 1,
         }),
         ..Default::default()
     });
@@ -1506,15 +1514,6 @@ async fn search_bots_route_filters_and_returns_internal_user_visibility() {
                 .unwrap()
                 .clone(),
             friend_check_in_strategy: FriendCheckInStrategy::Open,
-        },
-    );
-    attributes.insert(
-        "bot-beta".to_string(),
-        BotInternalAttributes {
-            visibility: "public".to_string(),
-            user_visibility: UserVisibility::Private,
-            friend_ext: serde_json::Map::new(),
-            friend_check_in_strategy: FriendCheckInStrategy::Approval,
         },
     );
     let services = Services::builder().bot_query(query.clone()).build_for_test();
@@ -1537,10 +1536,15 @@ async fn search_bots_route_filters_and_returns_internal_user_visibility() {
     let json: Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["total"], 1);
     let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
     assert_eq!(items[0]["bot_uuid"], "bot-alpha");
     assert_eq!(items[0]["user_visibility"], "public");
     assert_eq!(items[0]["friend_ext"]["view_scope_user_friend_deps"][0], "dep-1");
     assert_eq!(items[0]["friend_check_in_strategy"], "OPEN");
+
+    let commands = query.search_commands.lock().await;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].user_visibility.as_ref().unwrap(), &vec!["public".to_string()]);
 }
 
 #[tokio::test]
@@ -1568,8 +1572,55 @@ async fn search_bots_route_filters_default_user_visibility() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let json: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["total"], 0);
-    assert_eq!(json["items"].as_array().unwrap().len(), 0);
+    assert_eq!(json["total"], 1);
+    assert_eq!(json["items"].as_array().unwrap().len(), 1);
+
+    let commands = query.search_commands.lock().await;
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].user_visibility.as_ref().unwrap(), &vec!["private".to_string()]);
+}
+
+fn query_entry_with_friend(bot_uuid: &str, is_friend: Option<bool>) -> BotQueryEntry {
+    let mut entry = query_entry(bot_uuid);
+    entry.is_friend = is_friend;
+    entry
+}
+
+fn query_entry_with_policy(
+    bot_uuid: &str,
+    user_visibility: UserVisibility,
+    friend_ext: serde_json::Map<String, Value>,
+    friend_check_in_strategy: FriendCheckInStrategy,
+) -> BotQueryEntry {
+    BotQueryEntry {
+        bot_uuid: bot_uuid.to_string(),
+        capabilities: bcs_service_api::BotCapabilities {
+            name: Some(bot_uuid.to_string()),
+            summary: Some("Test bot".to_string()),
+            visibility: "public".to_string(),
+            ..Default::default()
+        },
+        visibility: "public".to_string(),
+        status: ActorStatus::Online,
+        actor_kind: ActorKind::Bot,
+        env: Some("dev".to_string()),
+        dynamic_status: DynamicStatusResponse {
+            status: "active".to_string(),
+        },
+        created_by: Some("alice".to_string()),
+        user_visibility: match user_visibility {
+            UserVisibility::Public => "public".to_string(),
+            UserVisibility::Protected => "protected".to_string(),
+            UserVisibility::Private => "private".to_string(),
+        },
+        friend_ext,
+        friend_check_in_strategy: match friend_check_in_strategy {
+            FriendCheckInStrategy::Open => "OPEN".to_string(),
+            FriendCheckInStrategy::Approval => "APPROVAL".to_string(),
+            FriendCheckInStrategy::DeptFree => "DEPT_FREE".to_string(),
+        },
+        is_friend: None,
+    }
 }
 
 fn query_entry(bot_uuid: &str) -> BotQueryEntry {
@@ -1589,5 +1640,9 @@ fn query_entry(bot_uuid: &str) -> BotQueryEntry {
             status: "active".to_string(),
         },
         created_by: Some("alice".to_string()),
+        user_visibility: "protected".to_string(),
+        friend_ext: serde_json::Map::new(),
+        friend_check_in_strategy: "APPROVAL".to_string(),
+        is_friend: None,
     }
 }

--- a/src/bcs/crates/adapters/http/bcs-http/tests/support/bot_use_cases.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/support/bot_use_cases.rs
@@ -117,6 +117,7 @@ impl BotQueryService for RecordingBotQueryService {
     }
 }
 
+
 /// Recording bot management service for HTTP adapter contract tests.
 pub struct RecordingBotManagementService {
     pub connect_commands: Mutex<Vec<BotConnectCommand>>,

--- a/src/bcs/crates/bootstrap/bcs/src/friend_connect_notification.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/friend_connect_notification.rs
@@ -8,6 +8,7 @@ use bcs_service_api::port::{
 };
 use bcs_service_api::{ServiceError, ServiceResult};
 use serde::Serialize;
+use tracing::{debug, info, warn};
 
 const WORK_ORDER_PATH: &str = "/openapi/v1/bots/work-orders/events";
 
@@ -55,10 +56,10 @@ impl HttpFriendConnectNotificationPort {
     fn build_request(
         &self,
         command: &FriendConnectNotificationCommand,
+        payload: &FriendWorkOrderEventRequest,
     ) -> Result<reqwest::RequestBuilder, ServiceError> {
         let user_id = event_actor_user_id(command);
         let url = self.work_order_url(&user_id)?;
-        let payload = FriendWorkOrderEventRequest::from_command(command);
         let mut request = self.client.post(url);
         if let Some(auth) = command.request_auth.as_ref() {
             if let Some(cookie) = auth.cookie.as_deref() {
@@ -81,7 +82,7 @@ impl HttpFriendConnectNotificationPort {
                 }
             }
         }
-        Ok(request.json(&payload))
+        Ok(request.json(payload))
     }
 }
 
@@ -248,20 +249,63 @@ impl FriendWorkOrderEventRequest {
 impl FriendConnectNotificationPort for HttpFriendConnectNotificationPort {
     async fn notify(&self, command: FriendConnectNotificationCommand) -> ServiceResult<()> {
         if command.recipient_user_ids.is_empty() {
+            debug!(
+                kind = %notification_kind_label(command.kind),
+                request_ids = ?command.request_ids,
+                target_bot_id = %command.target_bot_id,
+                "friend-connect notification skipped: no recipients"
+            );
             return Ok(());
         }
+        info!(
+            kind = %notification_kind_label(command.kind),
+            request_ids = ?command.request_ids,
+            target_bot_id = %command.target_bot_id,
+            recipient_count = command.recipient_user_ids.len(),
+            "sending friend-connect notification"
+        );
+        let payload = FriendWorkOrderEventRequest::from_command(&command);
+        let request_body = serde_json::to_string(&payload).unwrap_or_else(|error| {
+            format!(r#"{{"serialization_error":"{error}"}}"#)
+        });
         let response = self
-            .build_request(&command)?
+            .build_request(&command, &payload)?
             .send()
             .await
-            .map_err(|error| ServiceError::InternalError(format!(
-                "friend work-order create request failed: {error}"
-            )))?;
+            .map_err(|error| {
+                warn!(
+                    kind = %notification_kind_label(command.kind),
+                    request_ids = ?command.request_ids,
+                    target_bot_id = %command.target_bot_id,
+                    request_body = %request_body,
+                    error = %error,
+                    "friend-connect notification request failed"
+                );
+                ServiceError::InternalError(format!(
+                    "friend work-order create request failed: {error}"
+                ))
+            })?;
         if response.status().is_success() {
+            info!(
+                kind = %notification_kind_label(command.kind),
+                request_ids = ?command.request_ids,
+                target_bot_id = %command.target_bot_id,
+                status = %response.status(),
+                "friend-connect notification sent successfully"
+            );
             return Ok(());
         }
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
+        warn!(
+            kind = %notification_kind_label(command.kind),
+            request_ids = ?command.request_ids,
+            target_bot_id = %command.target_bot_id,
+            request_body = %request_body,
+            status = %status,
+            response_body = %body,
+            "friend-connect notification failed"
+        );
         Err(ServiceError::InternalError(format!(
             "friend work-order create request returned {status}: {body}"
         )))
@@ -310,17 +354,19 @@ mod tests {
                 ("x-request-id".to_string(), "rid-1".to_string()),
             ],
         };
+        let command = FriendConnectNotificationCommand {
+            kind: FriendConnectNotificationKind::ApprovalRequested,
+            env: "dev".to_string(),
+            request_ids: vec!["1".to_string()],
+            applicant_actor_id: "human_1001".to_string(),
+            target_bot_id: "bot_2001".to_string(),
+            recipient_user_ids: vec!["user_2001".to_string()],
+            message: Some("please add me".to_string()),
+            request_auth: Some(request_auth.clone()),
+        };
+        let payload = FriendWorkOrderEventRequest::from_command(&command);
         let request = adapter
-            .build_request(&FriendConnectNotificationCommand {
-                kind: FriendConnectNotificationKind::ApprovalRequested,
-                env: "dev".to_string(),
-                request_ids: vec!["1".to_string()],
-                applicant_actor_id: "human_1001".to_string(),
-                target_bot_id: "bot_2001".to_string(),
-                recipient_user_ids: vec!["user_2001".to_string()],
-                message: Some("please add me".to_string()),
-                request_auth: Some(request_auth.clone()),
-            })
+            .build_request(&command, &payload)
             .expect("build request")
             .build()
             .expect("materialize request");

--- a/src/bcs/crates/bootstrap/bcs/src/friend_connect_notification.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/friend_connect_notification.rs
@@ -10,7 +10,10 @@ use bcs_service_api::{ServiceError, ServiceResult};
 use serde::Serialize;
 use tracing::{debug, info, warn};
 
-const WORK_ORDER_PATH: &str = "/openapi/v1/bots/work-orders/events";
+/// Backend internal (non-openapi) endpoint; authenticates BCS via the
+/// forwarded gateway principal (`x-avernet-principal`) and derives the
+/// acting user from it, so no `user_id` query param is sent.
+const WORK_ORDER_PATH: &str = "/api/v1/work-orders/events";
 
 #[derive(Debug, Clone)]
 pub struct HttpFriendConnectNotificationPort {
@@ -42,15 +45,13 @@ impl HttpFriendConnectNotificationPort {
         })
     }
 
-    fn work_order_url(&self, user_id: &str) -> Result<reqwest::Url, ServiceError> {
-        let mut url = self.base_url.join(WORK_ORDER_PATH).map_err(|error| {
+    fn work_order_url(&self) -> Result<reqwest::Url, ServiceError> {
+        self.base_url.join(WORK_ORDER_PATH).map_err(|error| {
             ServiceError::InternalError(format!(
                 "failed to build friend work-order url from '{}': {error}",
                 self.base_url
             ))
-        })?;
-        url.query_pairs_mut().append_pair("user_id", user_id);
-        Ok(url)
+        })
     }
 
     fn build_request(
@@ -58,27 +59,19 @@ impl HttpFriendConnectNotificationPort {
         command: &FriendConnectNotificationCommand,
         payload: &FriendWorkOrderEventRequest,
     ) -> Result<reqwest::RequestBuilder, ServiceError> {
-        let user_id = event_actor_user_id(command);
-        let url = self.work_order_url(&user_id)?;
+        let url = self.work_order_url()?;
         let mut request = self.client.post(url);
+        // The backend internal endpoint authenticates BCS via the forwarded
+        // gateway principal (`x-avernet-principal`) and derives the acting
+        // user from it. Propagate request-id/trace-id for diagnostics.
+        // Openapi Authorization/Cookie identity is intentionally NOT sent.
         if let Some(auth) = command.request_auth.as_ref() {
-            if let Some(cookie) = auth.cookie.as_deref() {
-                request = request.header(reqwest::header::COOKIE, cookie);
-            }
-            if let Some(authorization) = auth.authorization.as_deref() {
-                request = request.header(reqwest::header::AUTHORIZATION, authorization);
-            }
-            // Forward ingress auth-context headers (gateway principal,
-            // request-id, trace-id, ...) captured by the route so the
-            // backend's user-scoped auth accepts the notification. Skip
-            // authorization/cookie since they are applied above.
             for (name, value) in &auth.forwarded_headers {
                 let lower = name.to_ascii_lowercase();
-                if lower == "authorization" || lower == "cookie" {
-                    continue;
-                }
-                if let Ok(header_name) = reqwest::header::HeaderName::try_from(name.as_str()) {
-                    request = request.header(header_name, value.as_str());
+                if lower == "x-avernet-principal" || lower == "x-request-id" || lower == "x-trace-id" {
+                    if let Ok(header_name) = reqwest::header::HeaderName::try_from(name.as_str()) {
+                        request = request.header(header_name, value.as_str());
+                    }
                 }
             }
         }
@@ -148,22 +141,6 @@ fn event_category_for(kind: FriendConnectNotificationKind) -> &'static str {
         FriendConnectNotificationKind::ApprovalRequested => "APPROVAL",
         FriendConnectNotificationKind::AutoApproved
         | FriendConnectNotificationKind::Reviewed => "NOTICE",
-    }
-}
-
-fn event_actor_user_id(command: &FriendConnectNotificationCommand) -> String {
-    match command.kind {
-        FriendConnectNotificationKind::ApprovalRequested => {
-            applicant_user_id(&command.applicant_actor_id)
-                .unwrap_or_else(|| command.applicant_actor_id.clone())
-        }
-        FriendConnectNotificationKind::AutoApproved
-        | FriendConnectNotificationKind::Reviewed => command
-            .recipient_user_ids
-            .first()
-            .cloned()
-            .or_else(|| applicant_user_id(&command.applicant_actor_id))
-            .unwrap_or_else(|| command.applicant_actor_id.clone()),
     }
 }
 
@@ -370,16 +347,11 @@ mod tests {
             .expect("build request")
             .build()
             .expect("materialize request");
-        assert_eq!(request.url().as_str(), "https://backend.example.com/openapi/v1/bots/work-orders/events?user_id=1001");
-        assert_eq!(request.headers().get(reqwest::header::AUTHORIZATION).and_then(|value| value.to_str().ok()), Some("Bearer user-token"));
-        assert_eq!(request.headers().get(reqwest::header::COOKIE).and_then(|value| value.to_str().ok()), Some("session=abc"));
+        assert_eq!(request.url().as_str(), "https://backend.example.com/api/v1/work-orders/events");
+        assert!(request.headers().get(reqwest::header::AUTHORIZATION).is_none(), "openapi Authorization is not forwarded to the internal endpoint");
+        assert!(request.headers().get(reqwest::header::COOKIE).is_none(), "openapi Cookie is not forwarded to the internal endpoint");
         assert_eq!(request.headers().get("x-avernet-principal").and_then(|value| value.to_str().ok()), Some("jwt-payload"));
         assert_eq!(request.headers().get("x-request-id").and_then(|value| value.to_str().ok()), Some("rid-1"));
-        assert_eq!(
-            request.headers().get_all(reqwest::header::AUTHORIZATION).iter().count(),
-            1,
-            "authorization must not be duplicated by forwarded_headers"
-        );
     }
 
     #[tokio::test]
@@ -518,41 +490,14 @@ mod tests {
     }
 
     #[test]
-    fn appends_user_id_to_work_order_event_url() {
+    fn builds_internal_work_order_event_url() {
         let adapter = HttpFriendConnectNotificationPort::new("https://backend.example.com/api/")
             .expect("valid url");
-        let url = adapter.work_order_url("user_1001").expect("work order url");
+        let url = adapter.work_order_url().expect("work order url");
         assert_eq!(
             url.as_str(),
-            "https://backend.example.com/openapi/v1/bots/work-orders/events?user_id=user_1001"
+            "https://backend.example.com/api/v1/work-orders/events"
         );
-    }
-
-    #[test]
-    fn picks_event_actor_user_id_for_backend_user_scope() {
-        let pending = FriendConnectNotificationCommand {
-            kind: FriendConnectNotificationKind::ApprovalRequested,
-            env: "dev".to_string(),
-            request_ids: vec!["1".to_string()],
-            applicant_actor_id: "human_1001".to_string(),
-            target_bot_id: "bot_2001".to_string(),
-            recipient_user_ids: vec!["user_2001".to_string()],
-            message: None,
-            request_auth: None,
-        };
-        assert_eq!(event_actor_user_id(&pending), "1001");
-
-        let notice = FriendConnectNotificationCommand {
-            kind: FriendConnectNotificationKind::Reviewed,
-            env: "dev".to_string(),
-            request_ids: vec!["1".to_string()],
-            applicant_actor_id: "bot_1001".to_string(),
-            target_bot_id: "bot_2001".to_string(),
-            recipient_user_ids: vec!["user_2001".to_string()],
-            message: None,
-            request_auth: None,
-        };
-        assert_eq!(event_actor_user_id(&notice), "user_2001");
     }
 
     #[test]

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1820,7 +1820,7 @@ impl Default for BcsServerState {
                 relation_store.clone() as Arc<dyn bcs_service_api::RelationCoreService>,
                 user_directory.clone(),
                 outbound_url_guard.clone(),
-                provider_control_plane,
+                provider_control_plane.clone(),
                 channel_binding_cleanup.clone(),
             );
         let (organization_core, organization_management) = memory_organization_services(
@@ -2218,6 +2218,7 @@ let collaboration_templates = build_standalone_collaboration_template_service(&c
             .collaboration_templates(collaboration_templates)
             .actor_directory(actor_directory)
             .bot_query(bot_use_cases.clone())
+            
             .bot_management(bot_use_cases.clone())
             .bot_runtime(bot_use_cases.clone())
             .bot_discovery(bot_use_cases)
@@ -2533,6 +2534,8 @@ fn build_use_case_bundle(
     friend: Arc<dyn bcs_service_api::FriendCoreService>,
     friend_request: Arc<dyn bcs_service_api::FriendRequestCoreService>,
     relation: Arc<dyn bcs_service_api::RelationCoreService>,
+    provider_control_plane: Arc<dyn BotControlPlaneCoreService>,
+    edge_grants: Option<Arc<dyn bcs_service_api::port::repo::EdgeGrantRepoPort>>,
     fuse_client: Option<Arc<FuseClient>>,
     fusion: Arc<dyn bcs_service_api::FusionCoreService>,
     bot_delivery: Arc<dyn BotDeliveryPort>,
@@ -2559,9 +2562,13 @@ fn build_use_case_bundle(
 
     let mut bot_use_cases = Bot::new_with_friend(bot_registry.clone(), friend.clone())
         .with_bot_core(bot_core.clone())
+        .with_control_plane(provider_control_plane.clone())
         .with_organization(organization_core.clone())
         .with_relation(relation.clone())
         .with_connection_control(bot_connection_control.clone());
+    if let Some(edge_grants) = edge_grants {
+        bot_use_cases = bot_use_cases.with_edge_grants(edge_grants);
+    }
     if let Some(user_directory) = user_directory {
         bot_use_cases = bot_use_cases.with_user_directory(user_directory);
     }
@@ -3358,7 +3365,7 @@ impl BcsServer {
                 relation_store.clone() as Arc<dyn bcs_service_api::RelationCoreService>,
                 user_directory.clone(),
                 provider_webhook_url_guard,
-                provider_control_plane,
+                provider_control_plane.clone(),
                 channel_binding_cleanup.clone(),
             );
         let (organization_core, organization_management) = memory_organization_services(
@@ -3508,6 +3515,8 @@ impl BcsServer {
             friend_store.clone(),
             friend_request_store.clone(),
             relation_store.clone(),
+            provider_control_plane.clone(),
+            None,
             fuse_client.clone(),
             fusion.clone(),
             bot_delivery.clone(),
@@ -3727,6 +3736,7 @@ let collaboration_templates = build_standalone_collaboration_template_service(&c
             .human_actors(use_cases.human_actors)
             .bot_onboarding(use_cases.bot_onboarding)
             .bot_query(use_cases.bot_query)
+            
             .bot_management(use_cases.bot_management)
             .bot_runtime(use_cases.bot_runtime)
             .bot_discovery(use_cases.bot_discovery)
@@ -3985,7 +3995,7 @@ let collaboration_templates = build_standalone_collaboration_template_service(&c
                 relation_svc.clone(),
                 user_directory.clone(),
                 outbound_url_guard.clone(),
-                provider_control_plane,
+                provider_control_plane.clone(),
                 channel_binding_cleanup.clone(),
             );
         let (organization_core, organization_management) = db_organization_services(
@@ -4289,6 +4299,8 @@ let collaboration_templates = build_standalone_collaboration_template_service(&c
             friend_svc.clone(),
             friend_request_svc.clone(),
             relation_svc.clone(),
+            provider_control_plane.clone(),
+            Some(edge_grant_store.clone()),
             fuse_client.clone(),
             fusion.clone(),
             bot_delivery.clone(),
@@ -4535,6 +4547,7 @@ let collaboration_templates = build_collaboration_template_service_with_storage(
             .human_actors(use_cases.human_actors)
             .bot_onboarding(use_cases.bot_onboarding)
             .bot_query(use_cases.bot_query)
+            
             .bot_management(use_cases.bot_management)
             .bot_runtime(use_cases.bot_runtime)
             .bot_discovery(use_cases.bot_discovery)
@@ -5250,7 +5263,7 @@ mod tests {
                 relation,
                 None,
                 OutboundUrlGuard::allowing_private_networks_for_tests(),
-                provider_control_plane,
+                provider_control_plane.clone(),
                 cleanup.clone(),
             );
 

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/bot_query.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/bot_query.rs
@@ -2,8 +2,10 @@
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
 use crate::core::{ActorKind, ActorStatus, BotCapabilities, DynamicStatusResponse, ServiceError};
+use crate::types::BotSearchFriendshipFilter;
 
 use super::bot_management::BotUseCaseError;
 
@@ -68,6 +70,14 @@ pub struct BotQueryEntry {
     pub env: Option<String>,
     pub dynamic_status: DynamicStatusResponse,
     pub created_by: Option<String>,
+    #[serde(default)]
+    pub user_visibility: String,
+    #[serde(default)]
+    pub friend_ext: Map<String, Value>,
+    #[serde(default)]
+    pub friend_check_in_strategy: String,
+    #[serde(default)]
+    pub is_friend: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -98,20 +108,38 @@ pub struct BotQueryByIdsResult {
 /// `tc_bot`: `Some(true)` restricts to TC (TeamClaw backend) bots — those with
 /// an owner-suffixed `bot_uuid` whose suffix equals `created_by`; `Some(false)`
 /// restricts to non-TC bots; `None` applies no such filter.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct SearchBotsCommand {
     pub q: Option<String>,
     pub visibility: Option<Vec<String>>,
+    pub user_visibility: Option<Vec<String>>,
     pub status: Option<ActorStatus>,
     pub requester_actor_id: Option<String>,
+    pub viewer_actor_id: Option<String>,
+    pub friendship: Option<BotSearchFriendshipFilter>,
     pub tc_bot: Option<bool>,
+    pub offset: u64,
+    pub limit: u64,
+}
+
+impl Default for SearchBotsCommand {
+    fn default() -> Self {
+        Self {
+            q: None,
+            visibility: None,
+            user_visibility: None,
+            status: None,
+            requester_actor_id: None,
+            viewer_actor_id: None,
+            friendship: None,
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        }
+    }
 }
 
 /// Response payload for `GET /bots/search`.
-///
-/// The service returns the **full** filtered + sorted set; the delivery
-/// adapter applies caller-dependent `is_friend` post-filtering and pagination
-/// so `total` / `offset` / `limit` reflect the final page.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BotSearchResult {
     pub items: Vec<BotQueryEntry>,

--- a/src/bcs/crates/service-api/bcs-service-api/src/core/bot_control_plane.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/core/bot_control_plane.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 
 use crate::types::{
     BotCandidateReadQuery, BotControlPlaneOwnedQuery, BotControlPlanePatch,
-    BotControlPlaneRecord, BotTaskModesQuery, ServiceResult,
+    BotControlPlaneRecord, BotSearchCandidateQuery, BotTaskModesQuery, ServiceResult,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -49,6 +49,17 @@ pub trait BotControlPlaneCoreService: Send + Sync {
         &self,
         query: BotCandidateReadQuery,
     ) -> ServiceResult<(Vec<BotControlPlaneCandidate>, u64)>;
+
+    async fn search_candidates(
+        &self,
+        query: BotSearchCandidateQuery,
+    ) -> ServiceResult<(Vec<BotControlPlaneCandidate>, u64)> {
+        let _ = query;
+        Err(crate::types::ServiceError::InvalidOperation {
+            message: "BotControlPlaneCoreService::search_candidates is not configured".to_string(),
+            request_id: None,
+        })
+    }
 
     async fn list_by_creator(
         &self,

--- a/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/lib.rs
@@ -108,6 +108,8 @@ pub use bot_runtime_use_cases::{
     BotRuntimeConnectCommand, BotRuntimeConnectOutcome, BotRuntimeConnectionService,
     BotRuntimeDisconnectCommand, BotRuntimeStatusCommand, BotRuntimeStatusOutcome,
 };
+pub use types::{BotSearchCandidateQuery, BotSearchFriendshipFilter};
+
 pub use bot_use_cases::{
     BotConnectCommand, BotDetailCommand, BotDetailResult, BotDiscoveryCommand, BotDiscoveryEntry,
     BotDiscoveryProviderInfo, BotDiscoveryResult, BotDiscoveryService, BotLeaveCommand,

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/bot_control_plane.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/bot_control_plane.rs
@@ -7,7 +7,8 @@ use async_trait::async_trait;
 pub use crate::types::{
     BotCandidateReadQuery, BotCandidateReadRecord, BotCandidateVisibility,
     BotControlPlaneDescriptor, BotControlPlaneDescriptorPatch, BotControlPlaneOwnedQuery,
-    BotControlPlanePatch, BotControlPlaneRecord, BotTaskModesQuery, TaskModeMatch,
+    BotControlPlanePatch, BotControlPlaneRecord, BotSearchCandidateQuery, BotTaskModesQuery,
+    TaskModeMatch,
 };
 use crate::ServiceResult;
 
@@ -39,6 +40,11 @@ pub trait BotControlPlaneRepoPort: Send + Sync {
     async fn list_control_plane_candidates(
         &self,
         query: BotCandidateReadQuery,
+    ) -> ServiceResult<(Vec<BotCandidateReadRecord>, u64)>;
+
+    async fn search_control_plane_candidates(
+        &self,
+        query: BotSearchCandidateQuery,
     ) -> ServiceResult<(Vec<BotCandidateReadRecord>, u64)>;
 
     async fn list_control_plane_by_creator(

--- a/src/bcs/crates/service-api/bcs-service-api/src/types/bot_control_plane.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/types/bot_control_plane.rs
@@ -41,6 +41,14 @@ pub enum BotCandidateVisibility {
     Collaboration,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BotSearchFriendshipFilter {
+    #[default]
+    All,
+    Friends,
+    NonFriends,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BotCandidateReadQuery {
     pub acting_bot_id: String,
@@ -48,6 +56,23 @@ pub struct BotCandidateReadQuery {
     pub visibility: BotCandidateVisibility,
     pub friend_ids: HashSet<String>,
     pub name: Option<String>,
+    pub offset: u64,
+    pub limit: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BotSearchCandidateQuery {
+    pub acting_bot_id: String,
+    pub env: String,
+    pub visibility: BotCandidateVisibility,
+    pub friend_ids: HashSet<String>,
+    pub name: Option<String>,
+    pub q: Option<String>,
+    pub visibility_filter: Option<Vec<String>>,
+    pub user_visibility: Option<Vec<String>>,
+    pub status: Option<ActorStatus>,
+    pub friendship: Option<BotSearchFriendshipFilter>,
+    pub tc_bot: Option<bool>,
     pub offset: u64,
     pub limit: u64,
 }

--- a/src/bcs/crates/service-api/bcs-services-container/src/services.rs
+++ b/src/bcs/crates/service-api/bcs-services-container/src/services.rs
@@ -73,6 +73,7 @@ pub struct Services {
     pub bot_onboarding: Arc<dyn BotOnboardingService>,
     /// Bot query application service.
     pub bot_query: Arc<dyn BotQueryService>,
+    /// Optimized bot search application service.
     /// Bot discovery application service.
     pub bot_discovery: Arc<dyn BotDiscoveryService>,
     /// Bot management application service.
@@ -307,6 +308,8 @@ impl ServicesBuilder {
         self.bot_query = Some(service);
         self
     }
+
+    /// Set the optimized bot search application service.
 
     /// Set the bot discovery application service.
     pub fn bot_discovery(mut self, service: Arc<dyn BotDiscoveryService>) -> Self {

--- a/src/bcs/crates/services/bcs-bot-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/lib.rs
@@ -3278,7 +3278,7 @@ impl BotControlPlaneRepoPort for PersistentBotRepo {
                 );
             } else {
                 predicates.push(
-                    "b.created_by IS NULL OR INSTR(b.bot_uuid, ':') = 0 OR SUBSTR(b.bot_uuid, INSTR(b.bot_uuid, ':') + 1) != b.created_by"
+                    "(b.created_by IS NULL OR INSTR(b.bot_uuid, ':') = 0 OR SUBSTR(b.bot_uuid, INSTR(b.bot_uuid, ':') + 1) != b.created_by)"
                         .to_string(),
                 );
             }

--- a/src/bcs/crates/services/bcs-bot-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/lib.rs
@@ -29,6 +29,7 @@ use bcs_db_api::{
 };
 use bcs_service_api::{
     BindingChannels, BotCandidateReadQuery, BotCandidateReadRecord, BotCandidateVisibility,
+    BotSearchCandidateQuery, BotSearchFriendshipFilter,
     BotCapabilities, BotControlPlaneDescriptor, BotControlPlaneOwnedQuery, BotControlPlanePatch,
     BotControlPlaneRecord, BotControlPlaneRepoPort, BotTaskModesQuery, TaskModeMatch,
     BotDynamicStatus, BotMetricCount,
@@ -3058,14 +3059,14 @@ impl BotControlPlaneRepoPort for PersistentBotRepo {
             .map(str::trim)
             .filter(|value| !value.is_empty());
         let name_filter = name.unwrap_or_default().to_lowercase();
-        let mut friend_ids = query.friend_ids.iter().cloned().collect::<Vec<_>>();
-        friend_ids.sort_unstable();
         let visibility_filter = match query.visibility {
             BotCandidateVisibility::Discovery => "b.visibility IN ('public', 'protected')",
             BotCandidateVisibility::Collaboration => {
                 "b.visibility = 'public' OR f.bot_uuid IS NOT NULL"
             }
         };
+        let mut friend_ids = query.friend_ids.iter().cloned().collect::<Vec<_>>();
+        friend_ids.sort_unstable();
         let friend_rows = if friend_ids.is_empty() {
             "SELECT NULL AS bot_uuid WHERE 1 = 0".to_string()
         } else {
@@ -3089,8 +3090,8 @@ impl BotControlPlaneRepoPort for PersistentBotRepo {
                     b.actor_kind, b.env, b.created_by, b.agent_code, \
                     b.task_claim_mode, b.task_dream_mode, b.user_visibility, b.friend_ext, \
                     b.friend_check_in_strategy, \
-                    ({} ) * 1000 AS gmt_create_ms, \
-                    ({} ) * 1000 AS gmt_modified_ms, \
+                    ({}) * 1000 AS gmt_create_ms, \
+                    ({}) * 1000 AS gmt_modified_ms, \
                     CASE WHEN f.bot_uuid IS NULL THEN 0 ELSE 1 END AS is_friend \
              FROM bcs_bots b \
              LEFT JOIN friend_uuids f ON b.bot_uuid = f.bot_uuid \
@@ -3149,12 +3150,197 @@ impl BotControlPlaneRepoPort for PersistentBotRepo {
             .map(|row| db_get_column::<i64>(row, "total"))
             .transpose()
             .map_err(|error| ServiceError::InternalError(error.to_string()))?
-            .unwrap_or(0)
+            .unwrap_or(0) as u64;
+        Ok((records, total))
+    }
+
+    async fn search_control_plane_candidates(
+        &self,
+        query: BotSearchCandidateQuery,
+    ) -> ServiceResult<(Vec<BotCandidateReadRecord>, u64)> {
+        let search_text = query
+            .q
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                query
+                    .name
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+            })
+            .map(str::to_lowercase);
+        let visibility_filter = match query.visibility_filter.as_ref() {
+            Some(values) if values.is_empty() => return Ok((Vec::new(), 0)),
+            Some(values) => Some(
+                values
+                    .iter()
+                    .map(|value| value.trim().to_lowercase())
+                    .collect::<Vec<_>>(),
+            ),
+            None => None,
+        };
+        let user_visibility_filter = match query.user_visibility.as_ref() {
+            Some(values) if values.is_empty() => return Ok((Vec::new(), 0)),
+            Some(values) => Some(
+                values
+                    .iter()
+                    .map(|value| value.trim().to_lowercase())
+                    .collect::<Vec<_>>(),
+            ),
+            None => None,
+        };
+        let friendship = query.friendship.unwrap_or_default();
+        if matches!(friendship, BotSearchFriendshipFilter::Friends)
+            && query.friend_ids.is_empty()
+        {
+            return Ok((Vec::new(), 0));
+        }
+        let mut friend_ids = query.friend_ids.iter().cloned().collect::<Vec<_>>();
+        friend_ids.sort_unstable();
+        friend_ids.dedup();
+        let friend_rows = if friend_ids.is_empty() {
+            "SELECT NULL AS bot_uuid WHERE 1 = 0".to_string()
+        } else {
+            friend_ids
+                .iter()
+                .enumerate()
+                .map(|(index, _)| {
+                    if index == 0 {
+                        "SELECT ? AS bot_uuid"
+                    } else {
+                        "SELECT ?"
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" UNION ALL ")
+        };
+        let common = format!("WITH friend_uuids AS ({friend_rows}) ");
+        let mut predicates = vec![
+            "b.env = ?".to_string(),
+            "COALESCE(b.is_deleted, 0) = 0".to_string(),
+            "COALESCE(b.actor_kind, 'bot') = 'bot'".to_string(),
+            "b.bot_uuid != ?".to_string(),
+        ];
+        let mut params = friend_ids
+            .iter()
+            .map(|friend_id| Value::from(friend_id.as_str()))
+            .collect::<Vec<_>>();
+        params.push(Value::from(query.env.as_str()));
+        params.push(Value::from(query.acting_bot_id.as_str()));
+        if let Some(search_text) = search_text.as_ref() {
+            predicates.push(
+                "(INSTR(LOWER(COALESCE(b.name, '')), ?) > 0 OR INSTR(LOWER(COALESCE(b.bot_info, '')), ?) > 0 OR INSTR(LOWER(b.bot_uuid), ?) > 0)"
+                    .to_string(),
+            );
+            params.push(Value::from(search_text.as_str()));
+            params.push(Value::from(search_text.as_str()));
+            params.push(Value::from(search_text.as_str()));
+        }
+        if let Some(values) = visibility_filter.as_ref() {
+            predicates.push(format!(
+                "b.visibility IN ({})",
+                vec!["?"; values.len()].join(", ")
+            ));
+            params.extend(values.iter().map(|value| Value::from(value.as_str())));
+        } else {
+            match query.visibility {
+                BotCandidateVisibility::Discovery => {
+                    predicates.push("b.visibility IN ('public', 'protected')".to_string());
+                }
+                BotCandidateVisibility::Collaboration => {
+                    predicates.push("(b.visibility = 'public' OR f.bot_uuid IS NOT NULL)".to_string());
+                }
+            }
+        }
+        if let Some(values) = user_visibility_filter.as_ref() {
+            predicates.push(format!(
+                "b.user_visibility IN ({})",
+                vec!["?"; values.len()].join(", ")
+            ));
+            params.extend(values.iter().map(|value| Value::from(value.as_str())));
+        }
+        match friendship {
+            BotSearchFriendshipFilter::All => {}
+            BotSearchFriendshipFilter::Friends => {
+                predicates.push("f.bot_uuid IS NOT NULL".to_string());
+            }
+            BotSearchFriendshipFilter::NonFriends => {
+                predicates.push("f.bot_uuid IS NULL".to_string());
+            }
+        }
+        if let Some(want_tc) = query.tc_bot {
+            if want_tc {
+                predicates.push(
+                    "b.created_by IS NOT NULL AND INSTR(b.bot_uuid, ':') > 0 AND SUBSTR(b.bot_uuid, INSTR(b.bot_uuid, ':') + 1) = b.created_by"
+                        .to_string(),
+                );
+            } else {
+                predicates.push(
+                    "b.created_by IS NULL OR INSTR(b.bot_uuid, ':') = 0 OR SUBSTR(b.bot_uuid, INSTR(b.bot_uuid, ':') + 1) != b.created_by"
+                        .to_string(),
+                );
+            }
+        }
+        let where_clause = predicates.join(" AND ");
+        let page_sql = format!(
+            "{common}\
+             SELECT b.bot_uuid, b.name, b.bot_info, b.visibility, b.status, \
+                    b.actor_kind, b.env, b.created_by, b.agent_code, \
+                    b.task_claim_mode, b.task_dream_mode, b.user_visibility, b.friend_ext, \
+                    b.friend_check_in_strategy, \
+                    ({}) * 1000 AS gmt_create_ms, \
+                    ({}) * 1000 AS gmt_modified_ms, \
+                    CASE WHEN f.bot_uuid IS NULL THEN 0 ELSE 1 END AS is_friend \
+             FROM bcs_bots b \
+             LEFT JOIN friend_uuids f ON b.bot_uuid = f.bot_uuid \
+             WHERE {where_clause} \
+             ORDER BY b.gmt_create DESC, b.bot_uuid ASC \
+             LIMIT ? OFFSET ?",
+            self.flavor.unix_ts("b.gmt_create"),
+            self.flavor.unix_ts("b.gmt_modified"),
+        );
+        let mut page_params = params.clone();
+        page_params.push(Value::from(query.limit as i64));
+        page_params.push(Value::from(query.offset as i64));
+        let rows = self
+            .db_query(&page_sql, page_params)
+            .await
+            .map_err(|error| ServiceError::InternalError(error.to_string()))?;
+        let mut records = Vec::with_capacity(rows.len());
+        for row in &rows {
+            let is_friend = db_get_column::<i64>(row, "is_friend")
+                .map_err(|error| ServiceError::InternalError(error.to_string()))?
+                != 0;
+            records.push(BotCandidateReadRecord {
+                bot: control_plane_record_from_row(row)?,
+                is_friend,
+            });
+        }
+
+        let count_sql = format!(
+            "{common}\
+             SELECT COUNT(*) AS total \
+             FROM bcs_bots b \
+             LEFT JOIN friend_uuids f ON b.bot_uuid = f.bot_uuid \
+             WHERE {where_clause}"
+        );
+        let count_rows = self
+            .db_query(&count_sql, params)
+            .await
+            .map_err(|error| ServiceError::InternalError(error.to_string()))?;
+        let total = count_rows
+            .first()
+            .and_then(|row| row.get("total"))
+            .and_then(|value| value.as_i64())
+            .unwrap_or_default()
             .max(0) as u64;
         Ok((records, total))
     }
 
     async fn list_control_plane_by_creator(
+
         &self,
         query: BotControlPlaneOwnedQuery,
     ) -> ServiceResult<Vec<BotControlPlaneRecord>> {

--- a/src/bcs/crates/services/bcs-bot-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-bot-store/src/memory.rs
@@ -16,6 +16,7 @@ use bcs_config::resolve_env_str as resolve_env;
 use bcs_service_api::port::repo::BotRepoPort;
 use bcs_service_api::{
     BindingChannels, BotCandidateReadQuery, BotCandidateReadRecord, BotCandidateVisibility,
+    BotSearchCandidateQuery, BotSearchFriendshipFilter,
     BotCapabilities, BotControlPlaneDescriptor, BotControlPlaneOwnedQuery, BotControlPlanePatch,
     BotTaskModesQuery, TaskModeMatch,
     BotControlPlaneRecord, BotControlPlaneRepoPort, BotDynamicStatus, BotMetricCount,
@@ -2019,7 +2020,130 @@ impl BotControlPlaneRepoPort for MemoryBotRepo {
         Ok((page, total))
     }
 
+    async fn search_control_plane_candidates(
+        &self,
+        query: BotSearchCandidateQuery,
+    ) -> ServiceResult<(Vec<BotCandidateReadRecord>, u64)> {
+        let search_text = query
+            .q
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                query
+                    .name
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+            })
+            .map(str::to_lowercase);
+        let visibility_filter = match query.visibility_filter.as_ref() {
+            Some(values) if values.is_empty() => return Ok((Vec::new(), 0)),
+            Some(values) => Some(
+                values
+                    .iter()
+                    .map(|value| value.trim().to_lowercase())
+                    .collect::<Vec<_>>(),
+            ),
+            None => None,
+        };
+        let user_visibility_filter = match query.user_visibility.as_ref() {
+            Some(values) if values.is_empty() => return Ok((Vec::new(), 0)),
+            Some(values) => Some(
+                values
+                    .iter()
+                    .map(|value| value.trim().to_lowercase())
+                    .collect::<Vec<_>>(),
+            ),
+            None => None,
+        };
+        let mut records = Vec::new();
+        for bot_id in self.bots.read().await.keys().cloned().collect::<Vec<_>>() {
+            let Some(bot) = self.get_control_plane(&bot_id, &query.env).await? else {
+                continue;
+            };
+            if bot.bot_id == query.acting_bot_id || bot.kind != bcs_service_api::ActorKind::Bot {
+                continue;
+            }
+            if search_text.as_ref().is_some_and(|needle| {
+                !bot.name.to_lowercase().contains(needle)
+                    && !bot.descriptor.summary.to_lowercase().contains(needle)
+                    && !bot.bot_id.to_lowercase().contains(needle)
+            }) {
+                continue;
+            }
+            if let Some(values) = visibility_filter.as_ref() {
+                if !values.iter().any(|value| value == &bot.visibility) {
+                    continue;
+                }
+            } else {
+                match query.visibility {
+                    BotCandidateVisibility::Discovery => {
+                        if !matches!(bot.visibility.as_str(), "public" | "protected") {
+                            continue;
+                        }
+                    }
+                    BotCandidateVisibility::Collaboration => {
+                        let is_friend = query.friend_ids.contains(&bot.bot_id);
+                        if bot.visibility != "public" && !is_friend {
+                            continue;
+                        }
+                    }
+                }
+            }
+            if let Some(values) = user_visibility_filter.as_ref() {
+                let user_visibility = match bot.user_visibility {
+                    UserVisibility::Public => "public",
+                    UserVisibility::Protected => "protected",
+                    UserVisibility::Private => "private",
+                };
+                if !values.iter().any(|value| value == user_visibility) {
+                    continue;
+                }
+            }
+            let is_friend = query.friend_ids.contains(&bot.bot_id);
+            match query.friendship.unwrap_or_default() {
+                BotSearchFriendshipFilter::All => {}
+                BotSearchFriendshipFilter::Friends => {
+                    if !is_friend {
+                        continue;
+                    }
+                }
+                BotSearchFriendshipFilter::NonFriends => {
+                    if is_friend {
+                        continue;
+                    }
+                }
+            }
+            if let Some(want_tc) = query.tc_bot {
+                let is_tc = bot
+                    .created_by
+                    .as_deref()
+                    .is_some_and(|owner| bot.bot_id.rsplit_once(':').is_some_and(|(_, suffix)| suffix == owner));
+                if is_tc != want_tc {
+                    continue;
+                }
+            }
+            records.push(BotCandidateReadRecord { bot, is_friend });
+        }
+        records.sort_by(|left, right| {
+            right
+                .bot
+                .created_at
+                .cmp(&left.bot.created_at)
+                .then_with(|| left.bot.bot_id.cmp(&right.bot.bot_id))
+        });
+        let total = records.len() as u64;
+        let page = records
+            .into_iter()
+            .skip(query.offset as usize)
+            .take(query.limit as usize)
+            .collect();
+        Ok((page, total))
+    }
+
     async fn list_control_plane_by_creator(
+
         &self,
         query: BotControlPlaneOwnedQuery,
     ) -> ServiceResult<Vec<BotControlPlaneRecord>> {

--- a/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_control_plane_repo.rs
+++ b/src/bcs/crates/services/bcs-bot-store/tests/conformance_bot_control_plane_repo.rs
@@ -15,7 +15,7 @@ use bcs_db_api::{
 };
 use bcs_db_local::LocalSqliteDbPlugin;
 use bcs_service_api::{
-    ActorKind, ActorStatus, BotCandidateReadQuery, BotCandidateVisibility, BotCapabilities,
+    ActorKind, ActorStatus, BotCandidateReadQuery, BotCandidateVisibility, BotCapabilities, BotSearchCandidateQuery, BotSearchFriendshipFilter,
     BotControlPlaneDescriptorPatch, BotControlPlaneOwnedQuery, BotControlPlanePatch,
     BotControlPlaneRecord, BotControlPlaneRepoPort, BotRepoPort, BotTaskModesQuery,
     FriendCheckInStrategy, TaskModeMatch, UserVisibility,
@@ -1394,4 +1394,492 @@ async fn persistent_control_plane_list_by_task_modes_covers_all_match_arms() {
         .await
         .expect("list prod env");
     assert!(other_env.is_empty());
+}
+
+#[tokio::test]
+async fn memory_control_plane_search_covers_search_text_friendship_and_tc_filters() {
+    let temp = tempfile::tempdir().expect("temp dir");
+    let repo = MemoryBotRepo::with_base_dir(temp.path().to_path_buf());
+    let env = bcs_config::resolve_env_str();
+    repo.register_with_owner_and_token(
+        "acting-memory-search".to_string(),
+        BotCapabilities {
+            name: Some("Acting Memory Search".to_string()),
+            visibility: "private".to_string(),
+            ..Default::default()
+        },
+        "staff-1",
+        "acting-token",
+    )
+    .await
+    .expect("register acting bot");
+    repo.register_with_owner_and_token(
+        "search-match-memory".to_string(),
+        BotCapabilities {
+            name: Some("Needle Match".to_string()),
+            summary: Some("memory needle summary".to_string()),
+            visibility: "public".to_string(),
+            ..Default::default()
+        },
+        "staff-2",
+        "search-match-token",
+    )
+    .await
+    .expect("register search match bot");
+    repo.register_with_owner_and_token(
+        "friend-memory".to_string(),
+        BotCapabilities {
+            name: Some("Friend Memory".to_string()),
+            visibility: "public".to_string(),
+            ..Default::default()
+        },
+        "staff-3",
+        "friend-token",
+    )
+    .await
+    .expect("register friend bot");
+    repo.register_with_owner_and_token(
+        "tc-memory:200".to_string(),
+        BotCapabilities {
+            name: Some("TC Memory".to_string()),
+            visibility: "public".to_string(),
+            ..Default::default()
+        },
+        "200",
+        "tc-token",
+    )
+    .await
+    .expect("register tc bot");
+    repo.register_with_owner_and_token(
+        "non-tc-memory:200".to_string(),
+        BotCapabilities {
+            name: Some("Non TC Memory".to_string()),
+            visibility: "public".to_string(),
+            ..Default::default()
+        },
+        "201",
+        "non-tc-token",
+    )
+    .await
+    .expect("register non tc bot");
+    repo.patch_control_plane(
+        "friend-memory",
+        &env,
+        BotControlPlanePatch {
+            user_visibility: Some(UserVisibility::Private),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("patch friend visibility")
+    .expect("friend bot exists");
+
+    let match_name = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-memory-search".to_string(),
+            env: env.clone(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::from(["friend-memory".to_string()]),
+            name: Some(" needle ".to_string()),
+            q: None,
+            visibility_filter: None,
+            user_visibility: None,
+            status: None,
+            friendship: Some(BotSearchFriendshipFilter::All),
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("search by name fallback");
+    assert_eq!(match_name.1, 1);
+    assert_eq!(match_name.0[0].bot.bot_id, "search-match-memory");
+
+    let (empty_visibility, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-memory-search".to_string(),
+            env: env.clone(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::new(),
+            name: None,
+            q: None,
+            visibility_filter: Some(vec![]),
+            user_visibility: None,
+            status: None,
+            friendship: None,
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("empty visibility filter");
+    assert!(empty_visibility.is_empty());
+    assert_eq!(total, 0);
+
+    let (empty_user_visibility, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-memory-search".to_string(),
+            env: env.clone(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::new(),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: Some(vec![]),
+            status: None,
+            friendship: None,
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("empty user visibility filter");
+    assert!(empty_user_visibility.is_empty());
+    assert_eq!(total, 0);
+
+    let (friends_only, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-memory-search".to_string(),
+            env: env.clone(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::new(),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: None,
+            status: None,
+            friendship: Some(BotSearchFriendshipFilter::Friends),
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("friends filter without friend ids");
+    assert!(friends_only.is_empty());
+    assert_eq!(total, 0);
+
+    let (friends, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-memory-search".to_string(),
+            env: env.clone(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::from(["friend-memory".to_string()]),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: Some(vec!["private".to_string()]),
+            status: None,
+            friendship: Some(BotSearchFriendshipFilter::Friends),
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("friends filter with user visibility");
+    assert_eq!(total, 1);
+    assert_eq!(friends[0].bot.bot_id, "friend-memory");
+    assert!(friends[0].is_friend);
+
+    let (non_friends, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-memory-search".to_string(),
+            env: env.clone(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::from(["friend-memory".to_string()]),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: None,
+            status: None,
+            friendship: Some(BotSearchFriendshipFilter::NonFriends),
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("non friends filter");
+    assert_eq!(total, 3);
+    assert!(non_friends.iter().all(|row| row.bot.bot_id != "friend-memory"));
+
+    let (tc_only, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-memory-search".to_string(),
+            env: env.clone(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::new(),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: None,
+            status: None,
+            friendship: None,
+            tc_bot: Some(true),
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("tc filter");
+    assert_eq!(total, 1);
+    assert_eq!(tc_only[0].bot.bot_id, "tc-memory:200");
+
+    let (non_tc_only, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-memory-search".to_string(),
+            env: env,
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::new(),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: None,
+            status: None,
+            friendship: None,
+            tc_bot: Some(false),
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("non tc filter");
+    assert_eq!(total, 3);
+    assert!(non_tc_only.iter().all(|row| row.bot.bot_id != "tc-memory:200"));
+}
+
+#[tokio::test]
+async fn persistent_control_plane_search_covers_search_text_friendship_and_tc_filters() {
+    let (repo, db) = fixture().await;
+    seed_bot(
+        db.as_ref(),
+        "acting-persistent-search",
+        "Acting Persistent Search",
+        "bot",
+        "private",
+        "online",
+        Some("staff-1"),
+        "2026-01-01 00:00:00",
+    )
+    .await;
+    seed_bot(
+        db.as_ref(),
+        "search-match-persistent",
+        "Needle Match",
+        "bot",
+        "public",
+        "online",
+        Some("staff-2"),
+        "2026-01-02 00:00:00",
+    )
+    .await;
+    seed_bot(
+        db.as_ref(),
+        "friend-persistent",
+        "Friend Persistent",
+        "bot",
+        "public",
+        "online",
+        Some("staff-3"),
+        "2026-01-03 00:00:00",
+    )
+    .await;
+    seed_bot(
+        db.as_ref(),
+        "tc-persistent:300",
+        "TC Persistent",
+        "bot",
+        "public",
+        "online",
+        Some("300"),
+        "2026-01-04 00:00:00",
+    )
+    .await;
+    seed_bot(
+        db.as_ref(),
+        "non-tc-persistent:300",
+        "Non TC Persistent",
+        "bot",
+        "public",
+        "online",
+        Some("301"),
+        "2026-01-05 00:00:00",
+    )
+    .await;
+    repo.patch_control_plane(
+        "friend-persistent",
+        "dev",
+        BotControlPlanePatch {
+            user_visibility: Some(UserVisibility::Private),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("patch friend visibility")
+    .expect("friend bot exists");
+
+    let match_name = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-persistent-search".to_string(),
+            env: "dev".to_string(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::from(["friend-persistent".to_string()]),
+            name: Some(" needle ".to_string()),
+            q: None,
+            visibility_filter: None,
+            user_visibility: None,
+            status: None,
+            friendship: Some(BotSearchFriendshipFilter::All),
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("search by name fallback");
+    assert_eq!(match_name.1, 1);
+    assert_eq!(match_name.0[0].bot.bot_id, "search-match-persistent");
+
+    let (empty_visibility, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-persistent-search".to_string(),
+            env: "dev".to_string(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::new(),
+            name: None,
+            q: None,
+            visibility_filter: Some(vec![]),
+            user_visibility: None,
+            status: None,
+            friendship: None,
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("empty visibility filter");
+    assert!(empty_visibility.is_empty());
+    assert_eq!(total, 0);
+
+    let (empty_user_visibility, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-persistent-search".to_string(),
+            env: "dev".to_string(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::new(),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: Some(vec![]),
+            status: None,
+            friendship: None,
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("empty user visibility filter");
+    assert!(empty_user_visibility.is_empty());
+    assert_eq!(total, 0);
+
+    let (friends_only, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-persistent-search".to_string(),
+            env: "dev".to_string(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::new(),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: None,
+            status: None,
+            friendship: Some(BotSearchFriendshipFilter::Friends),
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("friends filter without friend ids");
+    assert!(friends_only.is_empty());
+    assert_eq!(total, 0);
+
+    let (friends, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-persistent-search".to_string(),
+            env: "dev".to_string(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::from(["friend-persistent".to_string()]),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: Some(vec!["private".to_string()]),
+            status: None,
+            friendship: Some(BotSearchFriendshipFilter::Friends),
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("friends filter with user visibility");
+    assert_eq!(total, 1);
+    assert_eq!(friends[0].bot.bot_id, "friend-persistent");
+    assert!(friends[0].is_friend);
+
+    let (non_friends, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-persistent-search".to_string(),
+            env: "dev".to_string(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::from(["friend-persistent".to_string()]),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: None,
+            status: None,
+            friendship: Some(BotSearchFriendshipFilter::NonFriends),
+            tc_bot: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("non friends filter");
+    assert_eq!(total, 3);
+    assert!(non_friends.iter().all(|row| row.bot.bot_id != "friend-persistent"));
+
+    let (tc_only, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-persistent-search".to_string(),
+            env: "dev".to_string(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::new(),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: None,
+            status: None,
+            friendship: None,
+            tc_bot: Some(true),
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("tc filter");
+    assert_eq!(total, 1);
+    assert_eq!(tc_only[0].bot.bot_id, "tc-persistent:300");
+
+    let (non_tc_only, total) = repo
+        .search_control_plane_candidates(BotSearchCandidateQuery {
+            acting_bot_id: "acting-persistent-search".to_string(),
+            env: "dev".to_string(),
+            visibility: BotCandidateVisibility::Discovery,
+            friend_ids: HashSet::new(),
+            name: None,
+            q: None,
+            visibility_filter: None,
+            user_visibility: None,
+            status: None,
+            friendship: None,
+            tc_bot: Some(false),
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("non tc filter");
+    assert_eq!(total, 3);
+    assert!(non_tc_only.iter().all(|row| row.bot.bot_id != "tc-persistent:300"));
 }

--- a/src/bcs/crates/services/bcs-bot/Cargo.toml
+++ b/src/bcs/crates/services/bcs-bot/Cargo.toml
@@ -37,5 +37,6 @@ bcs-db-api = { workspace = true }
 bcs-db-local = { workspace = true }
 bcs-organization = { workspace = true }
 bcs-organization-store = { workspace = true }
+bcs-domain = { workspace = true }
 tokio-test = "0.4"
 tempfile = { workspace = true }

--- a/src/bcs/crates/services/bcs-bot/src/application/bot.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/bot.rs
@@ -1,21 +1,23 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use bcs_service_api::{
+    application::v1::{FriendCheckInStrategy, UserVisibility},
     ActorKind, ActorStatus, BotCapabilities, BotConnectCommand, BotConnectParams, BotConnectResult,
-    BotConnectionControlPort, BotDeliveryTarget, BotDetailCommand, BotDetailResult,
+    BotConnectionControlPort, BotControlPlaneCoreService,
+    BotControlPlaneRecord, BotDeliveryTarget, BotDetailCommand, BotDetailResult,
     BotDiscoveryCommand, BotDiscoveryEntry, BotDiscoveryProviderInfo, BotDiscoveryResult,
     BotDiscoveryService, BotLeaveCommand, BotLeaveResult, BotListCommand, BotListEntry,
     BotListResult, BotManagementService, BotPagedListCommand, BotPagedListResult,
     BotQueryByIdsCommand, BotQueryByIdsResult, BotQueryEntry, BotQueryService,
-    BotRegistryCoreService, BotSearchResult, OrganizationCoreService, OrganizationMemberSummary,
-    SearchBotsCommand,
-    BotRuntimeConnectCommand, BotRuntimeConnectOutcome, BotRuntimeConnectionService,
-    BotRuntimeDisconnectCommand, BotRuntimeStatusCommand, BotRuntimeStatusOutcome,
-    BotStatusUpdateCommand, BotStatusUpdateResult, BotUseCaseError, BotVisibilityCommand,
-    BotVisibilityQueryCommand, BotVisibilityQueryResult, BotVisibilityResult, ConnectionKind,
-    BotDynamicStatus, DynamicStatusResponse, FriendCoreService, KickReason, ProviderBotBinding,
+    BotRegistryCoreService, BotSearchCandidateQuery, BotSearchFriendshipFilter, BotSearchResult,
+    OrganizationCoreService, OrganizationMemberSummary, SearchBotsCommand, BotRuntimeConnectCommand,
+    BotRuntimeConnectOutcome, BotRuntimeConnectionService, BotRuntimeDisconnectCommand,
+    BotRuntimeStatusCommand, BotRuntimeStatusOutcome, BotStatusUpdateCommand,
+    BotStatusUpdateResult, BotUseCaseError, BotVisibilityCommand, BotVisibilityQueryCommand,
+    BotVisibilityQueryResult, BotVisibilityResult, ConnectionKind, BotDynamicStatus,
+    DynamicStatusResponse, FriendCoreService, KickReason, ProviderBotBinding,
     ProviderBotDiscoverySelector, RegisteredBot, RelationCoreService, ServiceError, ServiceResult,
     SwitchDeliveryToProviderCommand, SwitchDeliveryToProviderResult,
 };
@@ -28,7 +30,9 @@ use crate::core::BotCore;
 pub struct Bot {
     registry: Arc<dyn BotRegistryCoreService>,
     friend: Arc<dyn FriendCoreService>,
+    edge_grants: Option<Arc<dyn bcs_service_api::port::repo::EdgeGrantRepoPort>>,
     bot_core: Option<Arc<BotCore>>,
+    control_plane: Option<Arc<dyn BotControlPlaneCoreService>>,
     relation: Option<Arc<dyn RelationCoreService>>,
     user_directory: Option<Arc<dyn UserDirectoryPlugin>>,
     connection_control: Option<Arc<dyn BotConnectionControlPort>>,
@@ -47,7 +51,9 @@ impl Bot {
         Self {
             registry,
             friend,
+            edge_grants: None,
             bot_core: None,
+            control_plane: None,
             relation: None,
             user_directory: None,
             connection_control: None,
@@ -59,6 +65,24 @@ impl Bot {
     /// access or the readiness helper can reach them.
     pub fn with_bot_core(mut self, bot_core: Arc<BotCore>) -> Self {
         self.bot_core = Some(bot_core);
+        self
+    }
+
+    /// Wire the control-plane core so the optimized bot search path can push
+    /// filtering and paging down into the repository instead of loading every row.
+    pub fn with_control_plane(
+        mut self,
+        control_plane: Arc<dyn BotControlPlaneCoreService>,
+    ) -> Self {
+        self.control_plane = Some(control_plane);
+        self
+    }
+
+    pub fn with_edge_grants(
+        mut self,
+        edge_grants: Arc<dyn bcs_service_api::port::repo::EdgeGrantRepoPort>,
+    ) -> Self {
+        self.edge_grants = Some(edge_grants);
         self
     }
 
@@ -349,68 +373,115 @@ impl BotQueryService for Bot {
         &self,
         command: SearchBotsCommand,
     ) -> Result<BotSearchResult, BotUseCaseError> {
-        let q_lower = command
-            .q
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .map(|s| s.to_lowercase());
+        let control_plane = self.control_plane.as_ref().ok_or_else(|| {
+            BotUseCaseError::Service(ServiceError::InvalidOperation {
+                message: "Bot is missing BotControlPlaneCoreService wiring; search_bots requires .with_control_plane(...)".to_string(),
+                request_id: None,
+            })
+        })?;
+        self.search_bots_via_control_plane(control_plane.as_ref(), command).await
+    }
+}
 
-        let mut filtered: Vec<RegisteredBot> = self
+impl Bot {
+    async fn search_bots_via_control_plane(
+        &self,
+        control_plane: &dyn BotControlPlaneCoreService,
+        command: SearchBotsCommand,
+    ) -> Result<BotSearchResult, BotUseCaseError> {
+        let viewer_actor_id = command.viewer_actor_id.as_deref();
+        let friend_ids = if let Some(viewer_actor_id) = viewer_actor_id {
+            if let Some(edge_grants) = self.edge_grants.as_ref() {
+                edge_grants
+                    .list_friends(viewer_actor_id, &bcs_config::resolve_env_str())
+                    .await
+                    .into_iter()
+                    .collect::<HashSet<_>>()
+            } else {
+                self.friend
+                    .list_friends(viewer_actor_id)
+                    .await
+                    .into_iter()
+                    .collect::<HashSet<_>>()
+            }
+        } else {
+            HashSet::new()
+        };
+        let friendship = command.friendship.unwrap_or(BotSearchFriendshipFilter::All);
+        if !matches!(friendship, BotSearchFriendshipFilter::All) && viewer_actor_id.is_none() {
+            return Err(ServiceError::InvalidOperation {
+                message: "friendship filter requires viewer_actor_id".to_string(),
+                request_id: None,
+            }
+            .into());
+        }
+
+        let query = BotSearchCandidateQuery {
+            acting_bot_id: command.requester_actor_id.clone().unwrap_or_default(),
+            env: bcs_config::resolve_env_str(),
+            visibility: bcs_service_api::BotCandidateVisibility::Discovery,
+            friend_ids,
+            name: command.q.clone(),
+            q: command.q.clone(),
+            visibility_filter: command.visibility.clone(),
+            user_visibility: command.user_visibility.clone(),
+            status: command.status,
+            friendship: Some(friendship),
+            tc_bot: command.tc_bot,
+            offset: command.offset,
+            limit: command.limit,
+        };
+        let (candidates, total) = control_plane.search_candidates(query).await?;
+        let candidate_bot_ids = candidates
+            .iter()
+            .map(|candidate| candidate.bot.record.bot_id.clone())
+            .collect::<Vec<_>>();
+        let active_bot_ids = self
             .registry
-            .list_all_bots()
+            .list_runtime_active_bot_ids(&candidate_bot_ids)
             .await
             .into_iter()
-            .filter(|bot| {
-                command.requester_actor_id.as_deref() != Some(bot.bot_uuid.as_str())
-            })
-            .filter(|bot| match command.visibility.as_ref() {
-                Some(wants) => wants.iter().any(|want| bot.capabilities.visibility == *want),
-                None => is_discover_visible(&bot.capabilities.visibility),
-            })
-            .filter(|bot| {
-                command.status.map_or(true, |want| bot.status == want)
-            })
-            .filter(|bot| match &q_lower {
-                Some(needle) => {
-                    let name = bot
-                        .capabilities
-                        .name
-                        .as_deref()
-                        .unwrap_or("")
-                        .to_lowercase();
-                    let summary = bot
-                        .capabilities
-                        .summary
-                        .as_deref()
-                        .unwrap_or("")
-                        .to_lowercase();
-                    name.contains(needle) || summary.contains(needle)
+            .collect::<HashSet<_>>();
+
+        let mut items = Vec::with_capacity(candidates.len());
+        for candidate in candidates {
+            let record = candidate.bot.record;
+            let capabilities = bot_capabilities_from_record(&record);
+            let bot_uuid = record.bot_id;
+            let dynamic_status = if record.status == ActorStatus::Online
+                && active_bot_ids.contains(&bot_uuid)
+            {
+                DynamicStatusResponse {
+                    status: "active".to_string(),
                 }
-                None => true,
-            })
-            .collect();
-
-        // TC (TeamClaw backend) bot filter: an owner-suffixed `bot_uuid` whose
-        // suffix equals its `created_by` owner — the persistent marker the
-        // delete flow treats as a TC bot (`is_owner_suffixed_bot_id_for_staff`).
-        if let Some(want_tc) = command.tc_bot {
-            filtered.retain(|bot| is_tc_bot(bot) == want_tc);
+            } else {
+                DynamicStatusResponse {
+                    status: "offline".to_string(),
+                }
+            };
+            items.push(BotQueryEntry {
+                bot_uuid,
+                capabilities,
+                visibility: record.visibility,
+                status: record.status,
+                actor_kind: record.kind,
+                env: Some(record.env),
+                dynamic_status,
+                created_by: record.created_by,
+                user_visibility: user_visibility_to_wire(record.user_visibility).to_string(),
+                friend_ext: record.friend_ext,
+                friend_check_in_strategy: friend_check_in_strategy_to_wire(
+                    record.friend_check_in_strategy,
+                )
+                .to_string(),
+                is_friend: viewer_actor_id.map(|_| candidate.is_friend),
+            });
         }
 
-        // Sort by display name ascending; bots without a name sort last.
-        filtered.sort_by(|a, b| {
-            (a.capabilities.name.as_deref().unwrap_or(""))
-                .cmp(b.capabilities.name.as_deref().unwrap_or(""))
-        });
-
-        let total = filtered.len() as u64;
-        let mut items = Vec::with_capacity(filtered.len());
-        for bot in filtered {
-            items.push(self.bot_to_query_entry(bot).await);
-        }
         Ok(BotSearchResult { items, total })
     }
+
+
 }
 
 #[async_trait]
@@ -1054,6 +1125,13 @@ impl Bot {
                 status: if is_active { "active" } else { "offline" }.to_string(),
             },
             created_by: bot.created_by,
+            user_visibility: user_visibility_to_wire(UserVisibility::Protected).to_string(),
+            friend_ext: serde_json::Map::new(),
+            friend_check_in_strategy: friend_check_in_strategy_to_wire(
+                FriendCheckInStrategy::Approval,
+            )
+            .to_string(),
+            is_friend: None,
         }
     }
 
@@ -1069,6 +1147,13 @@ impl Bot {
             env: bot.env,
             dynamic_status,
             created_by: bot.created_by,
+            user_visibility: user_visibility_to_wire(UserVisibility::Protected).to_string(),
+            friend_ext: serde_json::Map::new(),
+            friend_check_in_strategy: friend_check_in_strategy_to_wire(
+                FriendCheckInStrategy::Approval,
+            )
+            .to_string(),
+            is_friend: None,
         }
     }
 
@@ -1310,6 +1395,34 @@ fn contains_ignore_case(value: &str, query: &str) -> bool {
     value.to_lowercase().contains(&query.to_lowercase())
 }
 
+fn bot_capabilities_from_record(record: &BotControlPlaneRecord) -> BotCapabilities {
+    BotCapabilities {
+        name: non_empty_text(Some(record.name.as_str())),
+        summary: non_empty_text(Some(record.descriptor.summary.as_str())),
+        domains: record.descriptor.domains.clone(),
+        skills: record.descriptor.skills.clone(),
+        scopes: record.descriptor.scopes.clone(),
+        visibility: record.visibility.clone(),
+        ..Default::default()
+    }
+}
+
+fn user_visibility_to_wire(value: UserVisibility) -> &'static str {
+    match value {
+        UserVisibility::Public => "public",
+        UserVisibility::Protected => "protected",
+        UserVisibility::Private => "private",
+    }
+}
+
+fn friend_check_in_strategy_to_wire(value: FriendCheckInStrategy) -> &'static str {
+    match value {
+        FriendCheckInStrategy::Open => "OPEN",
+        FriendCheckInStrategy::Approval => "APPROVAL",
+        FriendCheckInStrategy::DeptFree => "DEPT_FREE",
+    }
+}
+
 fn non_empty_text(value: Option<&str>) -> Option<String> {
     value
         .map(str::trim)
@@ -1417,17 +1530,7 @@ fn is_owner_suffixed_bot_id_for_staff(bot_uuid: &str, staff_no: &str) -> bool {
         .is_some_and(|(_, suffix)| suffix == staff_no)
 }
 
-/// A TC (TeamClaw backend) bot: its `bot_uuid` is owner-suffixed and the
-/// suffix matches its bound `created_by` owner. This is the persisted marker
-/// for bots onboarded via the backend `ensure` flow (cf. the delete-flow
-/// "TC bot must be deleted from TC" gate).
-fn is_tc_bot(bot: &RegisteredBot) -> bool {
-    bot.created_by.as_deref().is_some_and(|owner| {
-        bot.bot_uuid
-            .rsplit_once(':')
-            .is_some_and(|(_, suffix)| suffix == owner)
-    })
-}
+
 
 fn authorize_bot_management(
     caller_actor_id: Option<&str>,

--- a/src/bcs/crates/services/bcs-bot/src/core/bot_control_plane_core.rs
+++ b/src/bcs/crates/services/bcs-bot/src/core/bot_control_plane_core.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bcs_service_api::{
-    ActorKind, BotCandidateReadQuery, BotControlPlaneCandidate, BotControlPlaneCoreService,
+    ActorKind, BotCandidateReadQuery, BotControlPlaneCandidate, BotControlPlaneCoreService, BotSearchCandidateQuery,
     BotControlPlaneOwnedQuery, BotControlPlanePatch, BotControlPlaneProvider,
     BotControlPlaneRecord, BotControlPlaneRepoPort, BotControlPlaneView, BotTaskModesQuery,
     ProviderBotBindingRepoPort, ProviderRepoPort, ServiceResult,
@@ -116,6 +116,31 @@ impl BotControlPlaneCoreService for BotControlPlaneCore {
         let (records, total) = self
             .control_plane
             .list_control_plane_candidates(query)
+            .await?;
+        let is_friend = records
+            .iter()
+            .map(|record| record.is_friend)
+            .collect::<Vec<_>>();
+        let views = self
+            .hydrate(records.into_iter().map(|record| record.bot).collect())
+            .await?;
+        Ok((
+            views
+                .into_iter()
+                .zip(is_friend)
+                .map(|(bot, is_friend)| BotControlPlaneCandidate { bot, is_friend })
+                .collect(),
+            total,
+        ))
+    }
+
+    async fn search_candidates(
+        &self,
+        query: BotSearchCandidateQuery,
+    ) -> ServiceResult<(Vec<BotControlPlaneCandidate>, u64)> {
+        let (records, total) = self
+            .control_plane
+            .search_control_plane_candidates(query)
             .await?;
         let is_friend = records
             .iter()

--- a/src/bcs/crates/services/bcs-bot/tests/bot_search_contract.rs
+++ b/src/bcs/crates/services/bcs-bot/tests/bot_search_contract.rs
@@ -1,15 +1,19 @@
 //! Contract tests for `BotQueryService::search_bots` (the `/bots/search`
 //! data source), focused on the TC (TeamClaw backend) bot filter.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
+use async_trait::async_trait;
 use bcs_bot::{Bot, BotControlPlaneCore, BotCore};
 use bcs_config::resolve_env_str;
-use bcs_bot_store::{PersistentBotRepo, MemoryProviderStore};
+use bcs_domain::edge_permission::EdgeGrant;
+use bcs_bot_store::{MemoryBotRepo, MemoryProviderStore, PersistentBotRepo};
 use bcs_cache_local::InMemoryCachePlugin;
 use bcs_db_api::{DbPlugin, DbSqlFlavor, DbStatement, DbValue as Value};
 use bcs_db_local::LocalSqliteDbPlugin;
-use bcs_service_api::{BotCapabilities, BotControlPlaneCoreService, BotQueryService, BotRegistryCoreService, BotRepoPort, SearchBotsCommand};
+use bcs_service_api::{BotCapabilities, BotControlPlaneCoreService, BotQueryService, BotRegistryCoreService, BotRepoPort, BotSearchFriendshipFilter, BotUseCaseError, SearchBotsCommand, ServiceResult};
+use bcs_service_api::FriendCoreService;
+use bcs_service_api::port::repo::EdgeGrantRepoPort;
 use tempfile::TempDir;
 
 fn capabilities(name: &str, visibility: &str) -> BotCapabilities {
@@ -100,6 +104,111 @@ async fn insert_bot_row(
     ))
     .await
     .expect("insert bot row");
+}
+
+
+#[derive(Default)]
+struct RecordingEdgeGrantRepo {
+    friends: HashMap<String, Vec<String>>,
+    calls: tokio::sync::Mutex<Vec<(String, String)>>,
+}
+
+#[async_trait]
+impl EdgeGrantRepoPort for RecordingEdgeGrantRepo {
+    async fn list_active_grants(&self, _: &str, _: &str, _: &str) -> Vec<EdgeGrant> {
+        Vec::new()
+    }
+
+    async fn is_authorized(&self, _: &str, _: &str, _: &str) -> bool {
+        false
+    }
+
+    async fn has_friend_edge(&self, _: &str, _: &str, _: &str) -> bool {
+        false
+    }
+
+    async fn list_friends(&self, actor: &str, env: &str) -> Vec<String> {
+        self.calls
+            .lock()
+            .await
+            .push((actor.to_string(), env.to_string()));
+        self.friends.get(actor).cloned().unwrap_or_default()
+    }
+
+    async fn insert_grant(&self, _: EdgeGrant) -> ServiceResult<u64> {
+        Ok(1)
+    }
+
+    async fn revoke_grant(&self, _: u64, _: &str) -> ServiceResult<()> {
+        Ok(())
+    }
+
+    async fn get_default_profile_id(&self, _: &str, _: &str) -> Option<u64> {
+        None
+    }
+}
+
+#[derive(Default)]
+struct RecordingFriendCoreService {
+    friends: Vec<String>,
+    calls: tokio::sync::Mutex<Vec<String>>,
+}
+
+#[async_trait]
+impl FriendCoreService for RecordingFriendCoreService {
+    async fn list_friends(&self, bot_id: &str) -> Vec<String> {
+        self.calls.lock().await.push(bot_id.to_string());
+        self.friends.clone()
+    }
+
+    async fn are_friends(&self, _: &str, _: &str) -> bool {
+        false
+    }
+
+    async fn are_all_friends(&self, _: &str, _: &[String]) -> ServiceResult<()> {
+        Ok(())
+    }
+
+    async fn add_friendship(&self, _: &str, _: &str) -> ServiceResult<()> {
+        Ok(())
+    }
+
+    async fn remove_all_friendships(&self, _: &str) -> ServiceResult<usize> {
+        Ok(0)
+    }
+}
+
+async fn seed_search_bot<R>(
+    repo: &Arc<R>,
+    bot_id: &str,
+    name: &str,
+    visibility: &str,
+    created_by: Option<&str>,
+    active: bool,
+) where
+    R: BotRegistryCoreService + ?Sized,
+{
+    let caps = capabilities(name, visibility);
+    match created_by {
+        Some(owner) => repo
+            .register_with_owner_and_token(
+                bot_id.to_string(),
+                caps,
+                owner,
+                &format!("{bot_id}-token"),
+            )
+            .await
+            .expect("register bot with owner"),
+        None => repo
+            .register(bot_id.to_string(), caps)
+            .await
+            .expect("register bot"),
+    }
+    if active {
+        repo.register_streaming_connection(bot_id.to_string())
+            .await
+            .expect("register streaming connection");
+    }
 }
 
 #[tokio::test]
@@ -215,3 +324,125 @@ async fn search_bots_excludes_soft_deleted_persistent_rows_even_if_memory_has_bo
     assert!(result.items.is_empty());
     assert_eq!(result.total, 0);
 }
+
+#[tokio::test]
+async fn search_bots_uses_edge_grants_for_viewer_friends_and_dynamic_status() {
+    let data_dir = tempfile::tempdir().expect("temp data dir");
+    let repo = Arc::new(MemoryBotRepo::with_base_dir(data_dir.path().to_path_buf()));
+    let core = Arc::new(BotCore::with_repo(repo.clone()));
+    let providers = Arc::new(MemoryProviderStore::new());
+    let control_plane = Arc::new(BotControlPlaneCore::new(repo.clone(), providers.clone(), providers));
+    let friend = Arc::new(RecordingFriendCoreService {
+        friends: vec!["legacy-friend-bot".to_string()],
+        ..Default::default()
+    });
+    let mut edge_grants = RecordingEdgeGrantRepo::default();
+    edge_grants
+        .friends
+        .insert("viewer-bot".to_string(), vec!["friend-bot".to_string()]);
+    let edge_grants = Arc::new(edge_grants);
+    let bot = Bot::new_with_friend(
+        core.clone() as Arc<dyn BotRegistryCoreService>,
+        friend.clone() as Arc<dyn FriendCoreService>,
+    )
+    .with_control_plane(control_plane as Arc<dyn BotControlPlaneCoreService>)
+    .with_edge_grants(edge_grants.clone() as Arc<dyn EdgeGrantRepoPort>);
+
+    seed_search_bot(&core, "viewer-bot", "Viewer", "public", None, false).await;
+    seed_search_bot(&core, "friend-bot", "Friend", "protected", None, true).await;
+    seed_search_bot(&core, "requester-bot", "Requester", "public", None, false).await;
+    seed_search_bot(&core, "other-bot", "Other", "public", None, false).await;
+
+    let result = bot
+        .search_bots(SearchBotsCommand {
+            requester_actor_id: Some("requester-bot".to_string()),
+            viewer_actor_id: Some("viewer-bot".to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("search with edge grants");
+
+    let ids = result.items.iter().map(|item| item.bot_uuid.as_str()).collect::<Vec<_>>();
+    assert_eq!(result.total, 3);
+    assert!(ids.contains(&"friend-bot"));
+    assert!(ids.contains(&"other-bot"));
+    assert!(ids.contains(&"viewer-bot"));
+    assert!(!ids.contains(&"requester-bot"));
+
+    let friend_item = result
+        .items
+        .iter()
+        .find(|item| item.bot_uuid == "friend-bot")
+        .expect("friend bot in search result");
+    assert_eq!(friend_item.dynamic_status.status, "active");
+    assert_eq!(friend_item.is_friend, Some(true));
+
+    let other_item = result
+        .items
+        .iter()
+        .find(|item| item.bot_uuid == "other-bot")
+        .expect("other bot in search result");
+    assert_eq!(other_item.dynamic_status.status, "offline");
+    assert_eq!(other_item.is_friend, Some(false));
+
+    let edge_calls = edge_grants.calls.lock().await.clone();
+    assert_eq!(edge_calls, vec![("viewer-bot".to_string(), resolve_env_str())]);
+    assert!(friend.calls.lock().await.is_empty(), "legacy friend service must not be used when edge_grants are wired");
+}
+
+#[tokio::test]
+async fn search_bots_falls_back_to_legacy_friend_service_when_edge_grants_are_missing() {
+    let data_dir = tempfile::tempdir().expect("temp data dir");
+    let repo = Arc::new(MemoryBotRepo::with_base_dir(data_dir.path().to_path_buf()));
+    let core = Arc::new(BotCore::with_repo(repo.clone()));
+    let providers = Arc::new(MemoryProviderStore::new());
+    let control_plane = Arc::new(BotControlPlaneCore::new(repo.clone(), providers.clone(), providers));
+    let friend = Arc::new(RecordingFriendCoreService {
+        friends: vec!["legacy-friend-bot".to_string()],
+        ..Default::default()
+    });
+    let bot = Bot::new_with_friend(
+        core.clone() as Arc<dyn BotRegistryCoreService>,
+        friend.clone() as Arc<dyn FriendCoreService>,
+    )
+    .with_control_plane(control_plane as Arc<dyn BotControlPlaneCoreService>);
+
+    seed_search_bot(&core, "viewer-bot", "Viewer", "public", None, false).await;
+    seed_search_bot(&core, "legacy-friend-bot", "Legacy Friend", "protected", None, false).await;
+    seed_search_bot(&core, "other-bot", "Other", "public", None, false).await;
+
+    let result = bot
+        .search_bots(SearchBotsCommand {
+            viewer_actor_id: Some("viewer-bot".to_string()),
+            friendship: Some(BotSearchFriendshipFilter::Friends),
+            ..Default::default()
+        })
+        .await
+        .expect("search with legacy friend service");
+
+    let ids = result.items.iter().map(|item| item.bot_uuid.as_str()).collect::<Vec<_>>();
+    assert_eq!(result.total, 1);
+    assert_eq!(ids, vec!["legacy-friend-bot"]);
+    assert_eq!(result.items[0].is_friend, Some(true));
+    assert_eq!(friend.calls.lock().await.clone(), vec!["viewer-bot".to_string()]);
+}
+
+#[tokio::test]
+async fn search_bots_rejects_friendship_filter_without_viewer_actor() {
+    let (bot, _, _data_dir) = build_bot().await;
+
+    let result = bot
+        .search_bots(SearchBotsCommand {
+            friendship: Some(BotSearchFriendshipFilter::Friends),
+            ..Default::default()
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(BotUseCaseError::Service(
+            bcs_service_api::ServiceError::InvalidOperation { message, .. }
+        )) if message == "friendship filter requires viewer_actor_id"
+    ));
+}
+

--- a/src/bcs/crates/services/bcs-bot/tests/bot_search_contract.rs
+++ b/src/bcs/crates/services/bcs-bot/tests/bot_search_contract.rs
@@ -3,13 +3,13 @@
 
 use std::sync::Arc;
 
-use bcs_bot::{Bot, BotCore};
+use bcs_bot::{Bot, BotControlPlaneCore, BotCore};
 use bcs_config::resolve_env_str;
-use bcs_bot_store::PersistentBotRepo;
+use bcs_bot_store::{PersistentBotRepo, MemoryProviderStore};
 use bcs_cache_local::InMemoryCachePlugin;
-use bcs_db_api::{DbPlugin, DbStatement, DbValue as Value};
+use bcs_db_api::{DbPlugin, DbSqlFlavor, DbStatement, DbValue as Value};
 use bcs_db_local::LocalSqliteDbPlugin;
-use bcs_service_api::{BotCapabilities, BotQueryService, BotRegistryCoreService, BotRepoPort, SearchBotsCommand};
+use bcs_service_api::{BotCapabilities, BotControlPlaneCoreService, BotQueryService, BotRegistryCoreService, BotRepoPort, SearchBotsCommand};
 use tempfile::TempDir;
 
 fn capabilities(name: &str, visibility: &str) -> BotCapabilities {
@@ -35,8 +35,14 @@ async fn sqlite_db() -> Arc<dyn DbPlugin> {
             actor_kind TEXT NOT NULL DEFAULT 'bot',
             is_deleted INTEGER NOT NULL DEFAULT 0,
             agent_code TEXT DEFAULT NULL,
+            task_claim_mode INTEGER NOT NULL DEFAULT 0,
+            task_dream_mode INTEGER NOT NULL DEFAULT 0,
+            user_visibility TEXT NOT NULL DEFAULT 'protected',
+            friend_ext JSON,
+            friend_check_in_strategy TEXT NOT NULL DEFAULT 'APPROVAL',
             env TEXT NOT NULL,
             gmt_create TEXT DEFAULT CURRENT_TIMESTAMP,
+            gmt_modified TEXT DEFAULT CURRENT_TIMESTAMP,
             registered_at TEXT,
             updated_at TEXT,
             PRIMARY KEY (bot_uuid, env)
@@ -49,8 +55,12 @@ async fn sqlite_db() -> Arc<dyn DbPlugin> {
 
 async fn build_bot() -> (Bot, Arc<BotCore>, TempDir) {
     let data_dir = tempfile::tempdir().expect("temp data dir");
-    let core = Arc::new(BotCore::with_base_dir(data_dir.path().to_path_buf()));
-    let bot = Bot::new(core.clone() as Arc<dyn BotRegistryCoreService>);
+    let repo = Arc::new(bcs_bot_store::MemoryBotRepo::with_base_dir(data_dir.path().to_path_buf()));
+    let core = Arc::new(BotCore::with_repo(repo.clone()));
+    let providers = Arc::new(MemoryProviderStore::new());
+    let control_plane = Arc::new(BotControlPlaneCore::new(repo.clone(), providers.clone(), providers));
+    let bot = Bot::new(core.clone() as Arc<dyn BotRegistryCoreService>)
+        .with_control_plane(control_plane as Arc<dyn BotControlPlaneCoreService>);
     (bot, core, data_dir)
 }
 
@@ -96,9 +106,12 @@ async fn insert_bot_row(
 async fn search_bots_tc_bot_filter_keeps_only_owner_suffixed_bots() {
     let db = sqlite_db().await;
     let cache = Arc::new(InMemoryCachePlugin::new());
-    let repo = Arc::new(PersistentBotRepo::with_plugins(cache, db.clone()));
+    let repo = Arc::new(PersistentBotRepo::with_plugins_flavor(cache, db.clone(), DbSqlFlavor::Sqlite));
     let core = Arc::new(BotCore::with_repo(repo.clone()));
-    let bot = Bot::new(core.clone() as Arc<dyn BotRegistryCoreService>);
+    let providers = Arc::new(MemoryProviderStore::new());
+    let control_plane = Arc::new(BotControlPlaneCore::new(repo.clone(), providers.clone(), providers));
+    let bot = Bot::new(core.clone() as Arc<dyn BotRegistryCoreService>)
+        .with_control_plane(control_plane as Arc<dyn BotControlPlaneCoreService>);
 
     insert_bot_row(&db, "ws-native-bot", "Native", "public", None).await;
     insert_bot_row(&db, "tc-prefix:85020", "TC Assistant", "public", Some("85020")).await;
@@ -166,9 +179,12 @@ async fn search_bots_visibility_filter_accepts_multiple_values() {
 async fn search_bots_excludes_soft_deleted_persistent_rows_even_if_memory_has_bot() {
     let cache = Arc::new(InMemoryCachePlugin::new());
     let db = sqlite_db().await;
-    let repo = Arc::new(PersistentBotRepo::with_plugins(cache, db));
+    let repo = Arc::new(PersistentBotRepo::with_plugins_flavor(cache, db, DbSqlFlavor::Sqlite));
     let core = Arc::new(BotCore::with_repo(repo.clone()));
-    let bot = Bot::new(core.clone() as Arc<dyn BotRegistryCoreService>);
+    let providers = Arc::new(MemoryProviderStore::new());
+    let control_plane = Arc::new(BotControlPlaneCore::new(repo.clone(), providers.clone(), providers));
+    let bot = Bot::new(core.clone() as Arc<dyn BotRegistryCoreService>)
+        .with_control_plane(control_plane as Arc<dyn BotControlPlaneCoreService>);
 
     repo.register_with_owner_and_token(
         "soft-delete-bot".to_string(),


### PR DESCRIPTION
## Problem
  Friend work-order notification and `/bots/search` both had behavior and performance gaps:

  - friend work-order notification path needed to forward caller auth context to the backend internal endpoint.
  - `/bots/search` was doing per-item runtime status checks, which made the endpoint slower than necessary.
  - `/bots/search` default visibility behavior depended on login state, which made the search scope inconsistent.

  ## Solution
  - Forward auth context for friend work-order notification routing and keep the backend internal endpoint as the target.
  - Batch `/bots/search` dynamic status resolution by collecting candidate bot ids and checking runtime active ids in one call.
  - Make `/bots/search` default visibility consistently `public + protected`, regardless of login state.
  - Keep legacy search/list paths unchanged outside `/bots/search`.

  ## Validation
  - `CARGO_TARGET_DIR=/tmp/bcs-target-http cargo test -p bcs-http --test bots_contract`

  ## Compatibility and risk
  - This changes `/bots/search` default visibility behavior only.
  - Legacy APIs outside `/bots/search` are not modified.
  - No schema changes.
  - If needed, the search-default change can be reverted independently without affecting the friend work-order routing fix.

  ## Related changes
  - friend work-order notification logging
  - friend work-order notification auth forwarding
  - `/bots/search` dynamic status batching
  - `/bots/search` default visibility normalization