### PR TITLE
refactor(backend): remove duplicate default MCP exclusion path

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
@@ -20,7 +20,6 @@ from agentclaw.community.core.skill_center.policies.capability_ownership import 
     require_direct_mcp_control_allowed,
     require_can_join_set,
 )
-from agentclaw.community.core.skill_center.orm import DefaultSkillsetMcpExclusion
 from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
 
@@ -132,34 +131,8 @@ class McpSkillSetControlPlaneCommands:
     ) -> DesiredStateMutation:
         with self._db.transactional_orm_session() as session:
             row = self._set(session, bot_id=bot_id, owner_id=owner_id, set_id=set_id, engine_type=engine_type, default_engine_types=default_engine_types, locked=True)
-            old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
-            if row.is_default:
-                existing = (
-                    session.query(DefaultSkillsetMcpExclusion)
-                    .filter(
-                        DefaultSkillsetMcpExclusion.avernet_tenant
-                        == get_current_avernet_tenant(),
-                        DefaultSkillsetMcpExclusion.user_id == owner_id,
-                        DefaultSkillsetMcpExclusion.bot_id == bot_id,
-                        DefaultSkillsetMcpExclusion.skill_set_id == int(row.id),
-                        DefaultSkillsetMcpExclusion.server_code == server_code,
-                    )
-                    .first()
-                )
-                if existing is not None:
-                    return DesiredStateMutation(self._as_item(row), False, old)
-                session.add(
-                    DefaultSkillsetMcpExclusion(
-                        user_id=owner_id,
-                        bot_id=bot_id,
-                        skill_set_id=int(row.id),
-                        server_code=server_code,
-                        avernet_tenant=get_current_avernet_tenant(),
-                    )
-                )
-                session.flush()
-                return DesiredStateMutation(self._as_item(row), True, old)
             self._ordinary(row)
+            old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
             membership = (
                 self._scope(session.query(SkillSetMCPServer), SkillSetMCPServer)
                 .filter(SkillSetMCPServer.skill_set_id == row.id, SkillSetMCPServer.server_code == server_code)

--- a/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
@@ -2406,6 +2406,27 @@ def test_mcp_exclusion_mirrors_the_skill_pair():
         ] == ["mcp.member"]
 
 
+def test_ordinary_remove_mcp_refuses_a_default_set_address() -> None:
+    """Default opt-out has one command; membership removal must not duplicate it."""
+    db = _Database()
+    repository = CapabilityDesiredStateRepository(db)
+    default, _skill = _seed_default_with_member(db)
+
+    with pytest.raises(
+        SkillSetControlPlaneConflictError, match="SYSTEM_DEFAULT_IMMUTABLE"
+    ):
+        repository.remove_mcp(
+            set_id=str(default.id), server_code="mcp.member", **_DEFAULT_SCOPE
+        )
+
+    assert (
+        repository.excluded_default_mcp_codes(
+            bot_id="bot", owner_id="owner", set_id=str(default.id)
+        )
+        == set()
+    )
+
+
 def test_exclusion_commands_refuse_an_ordinary_set_address():
     db = _Database()
     repository = CapabilityDesiredStateRepository(db)


### PR DESCRIPTION
## Problem

`McpSkillSetControlPlaneCommands.remove_mcp()` duplicated a partial Default-SkillSet exclusion path even though `SkillSetManagementService.remove_mcp()` already routes Default Sets to `exclude_default_mcp()`. The duplicate branch did not validate platform-default policy, retire stale Installation rows, or return the changed MCP code for projection.

This is the follow-up cleanup requested in the review of #1608.

## Solution

- Keep Default/ordinary routing at the `SkillSetManagementService` seam, where engine/template default policy is available.
- Make repository `remove_mcp()` ordinary-membership-only, matching `add_mcp()`, by enforcing `_ordinary(row)` under the Set row lock.
- Remove the unreachable duplicate Default exclusion implementation and its unused ORM import.
- Add a repository contract regression proving ordinary membership removal rejects a Default Set address without creating an exclusion.

## Validation

- TDD red: focused regression failed with `DID NOT RAISE SkillSetControlPlaneConflictError`.
- TDD green: focused regression passed (`1 passed`).
- Repository UoW + `SkillSetManagementService`: `150 passed`.
- Affected Skill Center core/repository suites: `1075 passed, 27 skipped`.
- Backend architecture suite: `201 passed`.
- Ruff lint on changed files: passed.
- Backend local SAST block scan against `github/REL20260828...HEAD`: passed.
- Full Backend suite was not run locally because this is an isolated repository refactor; GitHub CI remains the full-suite gate.
- Whole-file `ruff format --check` reports existing formatting drift in both touched legacy files; they were not bulk-formatted to avoid an unrelated large diff.

## Compatibility and risk

No HTTP, Service API, Plugin API, database schema, or runtime projection behavior changes for supported callers. Default MCP opt-out continues through `exclude_default_mcp()`; ordinary membership removal continues through `remove_mcp()`. Direct repository misuse of `remove_mcp()` with a Default Set now fails closed with `SYSTEM_DEFAULT_IMMUTABLE` instead of executing the incomplete duplicate path.

## Related issues

Follow-up to #1608 and its Default MCP exclusion review comments.
