### PR TITLE
feat(bcs): ensure human actor when listing owned bots

### DIFF
--- a/src/bcs/crates/application/v1/bcs-app-bot/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-bot/src/lib.rs
@@ -5,11 +5,12 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bcs_service_api::application::v1::{
-    ApplicationError, Bot, BotCandidate, BotCandidatePurpose, BotCandidateSearchItem,
-    BotCandidateSearchMode, BotCandidateSearchResult, BotDescriptor, BotKind, BotProvider,
-    BotReachability, BotService, BotSkill, BotStatus, BotVisibility, GetBot, HumanBot,
-    InternalBotAttributesService, ListBotCandidates, ListMyBots, Page, PatchBotInternalAttributes,
-    PhysicalBot, QueryBots, SearchBotCandidates, UpdateBot, require_authenticated_user,
+    ApplicationError, AuthenticatedUserIdentity, Bot, BotCandidate, BotCandidatePurpose,
+    BotCandidateSearchItem, BotCandidateSearchMode, BotCandidateSearchResult, BotDescriptor,
+    BotKind, BotProvider, BotReachability, BotService, BotSkill, BotStatus, BotVisibility, GetBot,
+    HumanBot, InternalBotAttributesService, ListBotCandidates, ListMyBots, Page,
+    PatchBotInternalAttributes, PhysicalBot, QueryBots, SearchBotCandidates, UpdateBot,
+    require_authenticated_user,
 };
 use bcs_service_api::{
     ActorKind, ActorStatus, BotCandidateReadQuery, BotCandidateSearchCoreService,
@@ -152,6 +153,27 @@ impl BotServiceImpl {
         caller: &bcs_service_api::application::v1::AuthenticatedCaller,
     ) -> Result<String, ApplicationError> {
         Ok(require_authenticated_user(caller)?.id.clone())
+    }
+
+    fn human_display_name(human: &AuthenticatedUserIdentity) -> String {
+        human
+            .display_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .or_else(|| {
+                human
+                    .full_name
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|name| !name.is_empty())
+            })
+            .or_else(|| {
+                let username = human.username.trim();
+                (!username.is_empty()).then_some(username)
+            })
+            .unwrap_or(human.id.as_str())
+            .to_string()
     }
 
     fn validate_pagination(offset: u64, limit: u64) -> Result<(), ApplicationError> {
@@ -589,8 +611,14 @@ impl BotService for BotServiceImpl {
     }
 
     async fn list_mine(&self, command: ListMyBots) -> Result<Page<Bot>, ApplicationError> {
-        let staff_no = Self::human_staff_no(&command.caller)?;
+        let human = require_authenticated_user(&command.caller)?;
         Self::validate_pagination(command.offset, command.limit)?;
+        let staff_no = human.id.clone();
+        let display_name = Self::human_display_name(human);
+        self.registry
+            .ensure_human_actor(&staff_no, &display_name)
+            .await
+            .map_err(map_service_error)?;
         let records = self
             .control_plane
             .list_by_creator(BotControlPlaneOwnedQuery {

--- a/src/bcs/crates/application/v1/bcs-app-bot/tests/v1_bot_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-bot/tests/v1_bot_service.rs
@@ -1108,6 +1108,118 @@ async fn update_requires_created_by_and_rejects_descriptor_for_human() {
 }
 
 #[tokio::test]
+async fn mine_materializes_the_current_human_before_listing() {
+    let fixture = Fixture::new();
+    assert!(fixture.repo.get("human_staff-1").await.is_none());
+
+    let mut caller = human_caller("staff-1");
+    let user = caller.user.as_mut().expect("human caller");
+    user.display_name = Some(" Display Name ".to_string());
+    user.full_name = Some("Full Name".to_string());
+
+    let page = fixture
+        .service
+        .list_mine(ListMyBots {
+            caller,
+            kind: Some(BotKind::Human),
+            name: None,
+            status: None,
+            reachability: None,
+            offset: 0,
+            limit: 20,
+        })
+        .await
+        .expect("list mine");
+
+    assert_eq!(page.total, 1);
+    let Bot::Human(human) = &page.items[0] else {
+        panic!("expected human actor");
+    };
+    assert_eq!(human.bot_id, "human_staff-1");
+    assert_eq!(human.name, "Display Name");
+}
+
+#[tokio::test]
+async fn mine_uses_non_empty_identity_name_fallbacks_for_materialized_humans() {
+    let fixture = Fixture::new();
+    let cases = [
+        (
+            "staff-display",
+            Some(" Display "),
+            Some("Full"),
+            "username",
+            "Display",
+        ),
+        (
+            "staff-full",
+            Some("   "),
+            Some(" Full "),
+            "username",
+            "Full",
+        ),
+        (
+            "staff-username",
+            None,
+            Some("   "),
+            " username ",
+            "username",
+        ),
+        ("staff-id", None, None, "   ", "staff-id"),
+    ];
+
+    for (staff_no, display_name, full_name, username, expected_name) in cases {
+        let mut caller = human_caller(staff_no);
+        let user = caller.user.as_mut().expect("human caller");
+        user.display_name = display_name.map(str::to_string);
+        user.full_name = full_name.map(str::to_string);
+        user.username = username.to_string();
+
+        fixture
+            .service
+            .list_mine(ListMyBots {
+                caller,
+                kind: Some(BotKind::Human),
+                name: None,
+                status: None,
+                reachability: None,
+                offset: 0,
+                limit: 20,
+            })
+            .await
+            .expect("list mine");
+
+        let stored = fixture
+            .repo
+            .get(&format!("human_{staff_no}"))
+            .await
+            .expect("materialized human actor");
+        assert_eq!(stored.capabilities.name.as_deref(), Some(expected_name));
+    }
+}
+
+#[tokio::test]
+async fn mine_validates_pagination_before_materializing_the_human() {
+    let fixture = Fixture::new();
+
+    let error = fixture
+        .service
+        .list_mine(ListMyBots {
+            caller: human_caller("invalid"),
+            kind: None,
+            name: None,
+            status: None,
+            reachability: None,
+            offset: 0,
+            limit: 0,
+        })
+        .await
+        .expect_err("invalid pagination must fail");
+
+    assert_eq!(error.code(), "invalid_request");
+    assert!(fixture.repo.get("human_invalid").await.is_none());
+}
+
+#[tokio::test]
 async fn mine_accepts_tenantless_users_and_callers_without_user_are_forbidden() {
     let fixture = Fixture::new();
     fixture

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/bot.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/bot.rs
@@ -278,5 +278,7 @@ pub trait BotService: Send + Sync {
 
     async fn update(&self, command: UpdateBot) -> Result<Bot, ApplicationError>;
 
+    /// Materializes the authenticated Human Actor, then lists actors owned by it.
+    /// Human materialization is idempotent and does not bind physical Bot ownership.
     async fn list_mine(&self, command: ListMyBots) -> Result<Page<Bot>, ApplicationError>;
 }


### PR DESCRIPTION
## Problem

`GET /openapi/v1/collaboration/bots/mine` listed actors owned by the authenticated Human but did not ensure that the Human Actor existed first. A newly authenticated user could therefore query the endpoint without being materialized in the BCS actor registry.

## Solution

- Materialize the authenticated Human through the existing idempotent `ensure_human_actor` core contract before running the owned-actor query.
- Resolve the initial Human name from the first non-empty value in `display_name`, `full_name`, `username`, and user ID.
- Validate authentication and pagination before materialization so invalid requests do not write registry state.
- Keep the change in the V1 Bot application service; the HTTP adapter remains transport-only.
- Do not scan legacy Bots, mutate physical Bot ownership, create default profiles, or create owner/relation bindings.
- Document the new `BotService::list_mine` application contract and add regression coverage for materialization, name fallback, and validation order.

## Validation

- Prior to the requested code-only history rewrite, `cargo test --manifest-path src/bcs/Cargo.toml --package bcs-app-bot` passed all 24 tests.
- Prior to the requested code-only history rewrite, `cargo check --manifest-path src/bcs/Cargo.toml --package bcs-app-bot --all-targets` passed.
- No additional tests or build checks were rerun after the history rewrite, as requested.
- The push hook completed in its default lint-only mode; BCS tests, coverage, and E2E were skipped by that mode.

## Compatibility and risk

- No HTTP request or response schema changes.
- Valid `bots/mine` requests now have an idempotent registry side effect and may include the Human Actor when response filters allow Human actors.
- Existing Human Actor fields remain governed by `ensure_human_actor`; repeated calls preserve the stored name.
- Registry materialization failures propagate through the existing application error mapping instead of returning a partial success.
- No relation binding or physical Bot `created_by` mutation is introduced.