### PR TITLE
feat(baas): add GET /openapi/v1/sessions list sessions endpoint

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
@@ -209,3 +209,37 @@ class SessionMessagesResponse(ApiResponse[SessionMessagesResponseData]):
     data: SessionMessagesResponseData | None = Field(
         default=None, description="Session message data"
     )
+
+
+class SessionListItem(BaseModel):
+    """Session list item"""
+
+    session_id: str = Field(..., description="Session ID")
+    bot_id: str = Field(..., description="Bot ID")
+    title: str = Field(default="", description="Session title")
+    status: str = Field(default="active", description="Session status")
+    model: str | None = Field(default=None, description="Model name")
+    created_at: datetime | None = Field(default=None, description="Creation time")
+    updated_at: datetime | None = Field(default=None, description="Update time")
+    message_count: int = Field(default=0, description="Message count in session")
+    last_message: dict[str, Any] | None = Field(
+        default=None, description="Last message summary"
+    )
+
+
+class SessionListResponseData(BaseModel):
+    """Session list response data"""
+
+    items: list[SessionListItem] = Field(
+        default_factory=list, description="Session list"
+    )
+    total: int = Field(default=0, description="Total sessions in current page")
+    has_more: bool = Field(default=False, description="Whether there are more sessions")
+
+
+class SessionListResponse(ApiResponse[SessionListResponseData]):
+    """Session list standard response"""
+
+    data: SessionListResponseData | None = Field(
+        default=None, description="Session list data"
+    )

--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/session_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/session_router.py
@@ -14,6 +14,9 @@ from secbaas.community.adapters.web.routers.open_api.dependencies import (
 )
 from secbaas.community.adapters.web.routers.open_api.model import (
     MessageItem,
+    SessionListItem,
+    SessionListResponse,
+    SessionListResponseData,
     SessionMessagesResponse,
     SessionMessagesResponseData,
     SessionQueryResponse,
@@ -49,6 +52,155 @@ def _check_app_type(api_key_record: APIKeyRecord) -> None:
                 "code": OpenAPICode.FORBIDDEN,
                 "message": get_code_message(OpenAPICode.FORBIDDEN),
             },
+        )
+
+
+@router.get(
+    "/sessions",
+    response_model=SessionListResponse,
+    summary="List sessions of a bot",
+    description="List sessions belonging to a specific bot using a Bearer Token-authenticated API Key",
+    responses={
+        200: {"description": "Query successful"},
+        401: {"description": "Authentication failed"},
+        403: {"description": "Access denied"},
+        404: {"description": "Bot not found"},
+        500: {"description": "Internal server error"},
+    },
+)
+@inject
+async def list_sessions(
+    bot_id: str | None = Query(
+        default=None,
+        description="Bot ID, format: bot_id or default:staff_no. If omitted, resolved from the API Key.",
+    ),
+    limit: int = Query(
+        default=20, ge=1, le=100, description="Maximum number of sessions to return"
+    ),
+    offset: int = Query(default=0, ge=0, description="Number of sessions to skip"),
+    lifecycle_stage: str = Query(
+        default="online",
+        description="Bot lifecycle stage. Options: online, verify, draft, all",
+    ),
+    api_key_record: APIKeyRecord = Depends(validate_api_key),
+    context: BotChatContext = Depends(get_bot_chat_context),
+    bot_runner: BotRunner = Depends(Provide[ApplicationContainer.services.bot_runner]),
+) -> SessionListResponse:
+    """List sessions endpoint
+
+    Args:
+        bot_id: Bot ID, format: bot_id or default:staff_no. If omitted, resolved from the API Key.
+        limit: Maximum number of sessions to return. Default 20, range 1-100
+        offset: Number of sessions to skip. Default 0
+        lifecycle_stage: Bot lifecycle stage. Options: online, verify, draft, all. Default: online
+        api_key_record: Record obtained from API Key validation
+        context: Request context (authentication, caller identity, etc.)
+        bot_runner: BotRunner instance
+
+    Returns:
+        SessionListResponse: Session list response
+    """
+    # Only app_type=bot can resolve bot_id from the API Key; other types must pass it explicitly
+    if bot_id:
+        resolved_bot_id = bot_id
+    elif api_key_record.app_type == "bot":
+        resolved_bot_id = resolve_bot_id_from_api_key(api_key_record)
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": OpenAPICode.BUSINESS_ERROR,
+                "message": "bot_id is a required parameter",
+            },
+        )
+
+    _check_app_type(api_key_record)
+    if api_key_record.app_type != "bot":
+        resolved_bot_id = validate_policy(api_key_record, resolved_bot_id)
+
+    logger.info(
+        f"list_sessions: bot_id={resolved_bot_id}, "
+        f"lifecycle_stage={lifecycle_stage}, limit={limit}, offset={offset}, "
+        f"api_key_prefix={api_key_record.api_key_prefix}"
+    )
+
+    try:
+        sessions = await bot_runner.list_sessions(
+            bot_id=resolved_bot_id,
+            context=context,
+            metadata={"bot_options": {"lifecycle_stage": lifecycle_stage}},
+            limit=limit,
+            offset=offset,
+        )
+
+        items = [
+            SessionListItem(
+                session_id=s.session_id,
+                bot_id=s.bot_id,
+                title=s.title,
+                status=s.status,
+                model=s.model,
+                created_at=s.created_at,
+                updated_at=s.updated_at,
+                message_count=s.message_count,
+                last_message=s.last_message,
+            )
+            for s in sessions
+        ]
+        total = len(items)
+        # limit/offset 已下推到上游 AsyncSessionClient.list_sessions，上游按 limit
+        # 截断本页。当本页返回数达到 limit 时，按游标分页惯例判定“可能还有更多”
+        # （下一页可能为空，客户端据此停止）。原 `total > limit` 在上游严格遵守
+        # limit 的真实路径下恒为 False，会让非末页也返回 has_more=false。
+        has_more = total >= limit
+
+        logger.info(
+            f"list_sessions success: bot_id={resolved_bot_id}, "
+            f"returned={total}, has_more={has_more}"
+        )
+
+        return SessionListResponse(
+            code=0,
+            message="success",
+            data=SessionListResponseData(
+                items=items,
+                total=total,
+                has_more=has_more,
+            ),
+        )
+
+    except BotBindingNotFoundError as e:
+        logger.warning(
+            f"list_sessions binding not found: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": 60001, "message": str(e)},
+        )
+    except BotNotFoundError as e:
+        logger.warning(
+            f"list_sessions bot not found: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": 60001, "message": str(e)},
+        )
+    except BotServiceError as e:
+        logger.error(
+            f"list_sessions bot service error: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": OpenAPICode.BUSINESS_ERROR, "message": str(e)},
+        )
+    except Exception as e:
+        logger.error(
+            f"list_sessions unexpected error: bot_id={resolved_bot_id}, error={e}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"code": 50001, "message": f"Internal server error: {str(e)}"},
         )
 
 

--- a/src/baas/src/secbaas/community/api/bot_runtime/__init__.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/__init__.py
@@ -35,6 +35,7 @@ from ._models import (
     MessageDeliverRequest,
     MessageInfo,
     SessionInfo,
+    SessionListItem,
 )
 from ._protocols import (
     BotCmdDispatcher,
@@ -71,6 +72,7 @@ __all__ = [
     "MessageDeliverRequest",
     "MessageInfo",
     "SessionInfo",
+    "SessionListItem",
     "WsConnectionInfo",
     "HttpConnectionInfo",
     # Protocols

--- a/src/baas/src/secbaas/community/api/bot_runtime/_models.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/_models.py
@@ -97,6 +97,39 @@ class SessionInfo:
 
 
 @dataclass(slots=True)
+class SessionListItem:
+    """会话列表项
+
+    承载 `GET /openapi/v1/sessions` 列表接口每条会话的丰富字段，对齐
+    适配层 `AsyncSessionClient.SessionInfo`。相比 `SessionInfo`（单会话
+    查询，信息较贫乏），本模型保留 title / model / message_count /
+    last_message 等列表场景所需信息。
+
+    Attributes:
+        session_id: 会话 ID
+        bot_id: Bot ID（bare，不含 entity_id）
+        title: 会话标题
+        status: 会话状态（"active" 等）
+        model: 模型名称，适配层未返回时为 None（intentional optional）
+        created_at: 创建时间
+        updated_at: 更新时间，未返回时为 None
+        message_count: 会话内消息数
+        last_message: 最近一条消息摘要，仅在适配层确实返回时携带，
+                      None 为 intentional optional 状态
+    """
+
+    session_id: str
+    bot_id: str
+    title: str = ""
+    status: str = "active"
+    model: str | None = None
+    created_at: datetime = field(default_factory=datetime.now)
+    updated_at: datetime | None = None
+    message_count: int = 0
+    last_message: dict[str, Any] | None = None
+
+
+@dataclass(slots=True)
 class BotResponse:
     """Bot 响应
 

--- a/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
@@ -26,6 +26,7 @@ from ._models import (
     BotChatContext,
     MessageInfo,
     SessionInfo,
+    SessionListItem,
 )
 
 if TYPE_CHECKING:
@@ -401,6 +402,37 @@ class BotRunner(Protocol):
 
         Returns:
             消息信息列表
+        """
+        ...
+
+    async def list_sessions(
+        self,
+        *,
+        bot_id: str,
+        context: "BotChatContext",
+        metadata: dict[str, Any],
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list["SessionListItem"]:
+        """查询指定 Bot 下的会话列表（只读）
+
+        复用 get_session_info 的鉴权 / 策略 / Bot 路由解析链路，底层调用
+        `AsyncSessionClient.list_sessions`。仅返回调用方有权限访问的会话。
+
+        Args:
+            bot_id: Bot 唯一标识，格式为 <real_bot_id>:<entity_id>
+            context: 请求上下文（身份认证、调用者信息等）
+            metadata: 元数据，支持 bot_options.lifecycle_stage 指定生命周期阶段
+            limit: 返回条数上限，默认 20
+            offset: 偏移量，默认 0
+
+        Returns:
+            SessionListItem 列表，按适配层返回顺序排列
+
+        Raises:
+            BotBindingNotFoundError: Bot 绑定不存在
+            BotNotFoundError: Bot 不存在
+            BotServiceError: 上游服务请求失败
         """
         ...
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -35,6 +35,7 @@ from secbaas.community.api.bot_runtime import (
     NoActiveDevicesError,
     NoDevicesFoundError,
     SessionInfo,
+    SessionListItem,
     SessionNotFoundError,
     WsConnectionInfo,
 )
@@ -659,6 +660,71 @@ class BaasBotService(BotService):
                 f"Failed to get session: {_safe_client_msg(e)}"
             ) from e
 
+    async def list_sessions(
+        self,
+        *,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionListItem]:
+        """查询指定 Bot 下的会话列表（只读）
+
+        镜像 get_session 的连接解析与 client 创建链路，底层调用
+        `AsyncSessionClient.list_sessions`。user_id 由 resolve_user_id 派生，
+        agent_id 取 binding_info.bot_id（real bot id）。
+
+        Args:
+            binding_info: 已解析的 binding 信息（用于创建底层连接）
+            context: 可选的请求上下文
+            limit: 返回条数上限
+            offset: 偏移量
+
+        Returns:
+            SessionListItem 列表
+
+        Raises:
+            BotServiceError: 上游服务请求失败
+        """
+        try:
+            conn_info = await self._resolve_ws_connection_for_binding(
+                binding_info, context
+            )
+        except Exception as e:
+            logger.warning("Failed to resolve WS connection: %s", e)
+            raise BotServiceError(
+                f"Failed to resolve WS connection: {_safe_client_msg(e)}"
+            ) from e
+
+        session_client = self._create_session_client(
+            conn_info, binding_info.engine_type
+        )
+        # agent_id 取 real bot id（binding_info.bot_id），user_id 经
+        # resolve_user_id 派生；解析错误将静默返回空列表，故沿用 create_session
+        # 的派生路径（context.app_id / entity_id）。
+        metadata: dict[str, Any] = {}
+        user_id = resolve_user_id(metadata, binding_info, context, binding_info.bot_id)
+        try:
+            async with session_client:
+                adapter_sessions = await session_client.list_sessions(
+                    user_id=user_id,
+                    agent_id=binding_info.bot_id,
+                    limit=limit,
+                    offset=offset,
+                    engine=binding_info.engine_type,
+                )
+                return [
+                    _map_adapter_session_list_item(item, binding_info.bot_id)
+                    for item in adapter_sessions
+                ]
+        except BotServiceError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to list sessions: %s", e)
+            raise BotServiceError(
+                f"Failed to list sessions: {_safe_client_msg(e)}"
+            ) from e
+
     # ── 私有方法 ─────────────────────────────────────────────────────────────
 
     def _adapter_for(self, engine_type: str | None) -> BotEngineAdapter | None:
@@ -1063,4 +1129,26 @@ def _map_adapter_session_info(
         status="active",
         created_at=_parse_datetime(adapter_session.created_at) or datetime.now(),
         updated_at=_parse_datetime(adapter_session.updated_at),
+    )
+
+
+def _map_adapter_session_list_item(
+    adapter_session: AdapterSessionInfo,
+    bot_id: str,
+) -> SessionListItem:
+    """Map adapter-layer SessionInfo to api-level SessionListItem (list endpoint).
+
+    Preserves title / model / message_count / last_message, which the single
+    SessionInfo mapping drops. Used by BaasBotService.list_sessions.
+    """
+    return SessionListItem(
+        session_id=adapter_session.id,
+        bot_id=bot_id,
+        title=adapter_session.title or "",
+        status="active",
+        model=adapter_session.model,
+        created_at=_parse_datetime(adapter_session.created_at) or datetime.now(),
+        updated_at=_parse_datetime(adapter_session.updated_at),
+        message_count=adapter_session.message_count,
+        last_message=adapter_session.last_message,
     )

--- a/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
@@ -26,6 +26,7 @@ from secbaas.community.api.bot_runtime import (
     BotServiceError,
     MessageInfo,
     SessionInfo,
+    SessionListItem,
     SessionNotFoundError,
 )
 from secbaas.community.api.sse import StreamChunk
@@ -433,6 +434,60 @@ class ClawBotService(BotService):
         except Exception as e:
             raise BotServiceError(f"Failed to get session: {e}") from e
 
+    async def list_sessions(
+        self,
+        *,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionListItem]:
+        """查询指定 Bot 下的会话列表（只读）
+
+        镜像 get_session 的 sandbox/客户端链路，底层调用
+        `AsyncSessionClient.list_sessions`。user_id 由 resolve_user_id 派生
+        （与 create_session 一致，fallback 为 entity_id），agent_id 取
+        binding_info.bot_id（real bot id）。
+
+        Args:
+            binding_info: 已解析的 binding 信息（用于创建底层连接）
+            context: 可选的请求上下文（ClawBotService 未使用，保留以对齐协议）
+            limit: 返回条数上限
+            offset: 偏移量
+
+        Returns:
+            SessionListItem 列表
+
+        Raises:
+            BotServiceError: 上游服务请求失败
+        """
+        sandbox_id = binding_info.sandbox_id
+        if sandbox_id is None:
+            raise BotServiceError("ClawBotService requires sandbox_id in binding_info.")
+
+        session_client = self._create_session_client(sandbox_id)
+        # agent_id 取 real bot id；user_id 派生与 create_session 一致（entity_id 优先）。
+        metadata: dict[str, Any] = {}
+        user_id = resolve_user_id(
+            metadata, binding_info, context, binding_info.entity_id
+        )
+        try:
+            async with session_client:
+                adapter_sessions = await session_client.list_sessions(
+                    user_id=user_id,
+                    agent_id=binding_info.bot_id,
+                    limit=limit,
+                    offset=offset,
+                )
+                return [
+                    _map_adapter_session_list_item(item, binding_info.bot_id)
+                    for item in adapter_sessions
+                ]
+        except BotServiceError:
+            raise
+        except Exception as e:
+            raise BotServiceError(f"Failed to list sessions: {e}") from e
+
     # ── 私有方法 ─────────────────────────────────────────────────────────────
 
     def _adapter_for(self, engine_type: str | None) -> BotEngineAdapter | None:
@@ -590,4 +645,26 @@ def _map_adapter_session_info(
         status="active",
         created_at=_parse_datetime(adapter_session.created_at) or datetime.now(),
         updated_at=_parse_datetime(adapter_session.updated_at),
+    )
+
+
+def _map_adapter_session_list_item(
+    adapter_session: AdapterSessionInfo,
+    bot_id: str,
+) -> SessionListItem:
+    """Map adapter-layer SessionInfo to api-level SessionListItem (list endpoint).
+
+    Preserves title / model / message_count / last_message. Used by
+    ClawBotService.list_sessions.
+    """
+    return SessionListItem(
+        session_id=adapter_session.id,
+        bot_id=bot_id,
+        title=adapter_session.title or "",
+        status="active",
+        model=adapter_session.model,
+        created_at=_parse_datetime(adapter_session.created_at) or datetime.now(),
+        updated_at=_parse_datetime(adapter_session.updated_at),
+        message_count=adapter_session.message_count,
+        last_message=adapter_session.last_message,
     )

--- a/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
@@ -18,6 +18,7 @@ from secbaas.community.api.bot_runtime import (
     BotResponse,
     MessageInfo,
     SessionInfo,
+    SessionListItem,
 )
 from secbaas.community.api.sse import StreamChunk
 from secbaas.community.core.repository.bot_run_queue import BotRunQueueRecord
@@ -180,6 +181,34 @@ class BotService(Protocol):
 
         Returns:
             消息信息列表
+        """
+        ...
+
+    async def list_sessions(
+        self,
+        *,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionListItem]:
+        """查询指定 Bot 下的会话列表（只读）
+
+        形状镜像 get_session：解析 WS 连接 → 创建 AsyncSessionClient →
+        调用上游 list_sessions。user_id 由 resolve_user_id 派生，
+        agent_id 取 binding_info.bot_id（real bot id）。
+
+        Args:
+            binding_info: 已解析的 binding 信息（用于创建底层连接）
+            context: 可选的请求上下文（身份认证、调用者信息等）
+            limit: 返回条数上限，默认 20
+            offset: 偏移量，默认 0
+
+        Returns:
+            SessionListItem 列表
+
+        Raises:
+            BotServiceError: 上游服务请求失败
         """
         ...
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
@@ -34,6 +34,7 @@ from secbaas.community.api.bot_runtime import (
     BotChatContext,
     MessageInfo,
     SessionInfo,
+    SessionListItem,
 )
 from secbaas.community.api.device_manage import ErrorCode, PaasError
 from secbaas.community.api.sse import StreamChunk
@@ -438,6 +439,30 @@ class BotRunner:
             session_id=session_id,
             binding_info=route.binding_info,
             context=context,
+        )
+
+    async def list_sessions(
+        self,
+        *,
+        bot_id: str,
+        context: BotChatContext,
+        metadata: dict[str, Any],
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionListItem]:
+        """查询指定 Bot 下的会话列表（只读）
+
+        复用 get_session_info 的 Bot 路由解析链路，委派 BotService.list_sessions
+        调用上游 list_sessions。异常映射沿用 get_session_info（SessionNotFoundError
+        一般不适用于列表，但保留 BotBindingNotFoundError/BotNotFoundError→404、
+        BotServiceError→400 由路由层处理）。
+        """
+        route = await self._resolve_bot_route(bot_id, metadata)
+        return await route.bot_service.list_sessions(
+            binding_info=route.binding_info,
+            context=context,
+            limit=limit,
+            offset=offset,
         )
 
     def get_result(self, run_id: str) -> Any:

--- a/src/baas/tests/e2e/asgi/baseline/test_open_api_dependencies.py
+++ b/src/baas/tests/e2e/asgi/baseline/test_open_api_dependencies.py
@@ -85,6 +85,16 @@ class TestOpenAPIDependencies:
         assert response.status_code == 401
 
     @pytest.mark.asyncio
+    async def test_list_sessions_without_api_key(self, api: APITestHelper) -> None:
+        """GET /openapi/v1/sessions without Authorization → 401."""
+        response = await api.client.get(
+            api.open_api_session_url(),
+        )
+
+        # The auth dependency fires before bot_id validation
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
     async def test_run_result_without_api_key(self, api: APITestHelper) -> None:
         """GET /openapi/v1/runs/xxx without Authorization → 401."""
         response = await api.client.get(

--- a/src/baas/tests/e2e/asgi/baseline/test_open_api_sessions.py
+++ b/src/baas/tests/e2e/asgi/baseline/test_open_api_sessions.py
@@ -22,57 +22,62 @@ class TestListSessions:
 
     @pytest.mark.asyncio
     async def test_list_sessions_no_auth(self, api: APITestHelper) -> None:
-        """GET /openapi/v1/sessions without auth → 401."""
+        """GET /openapi/v1/sessions without auth → 401.
+
+        The list endpoint now exists; validate_api_key requires a Bearer token.
+        """
         response = await api.client.get(
             api.open_api_session_url(),
         )
 
         # Requires Bearer token; without it → 401
-        assert response.status_code in (401, 404)
+        assert response.status_code == 401
 
     @pytest.mark.asyncio
     async def test_list_sessions_with_auth_header(self, api: APITestHelper) -> None:
-        """GET /openapi/v1/sessions with auth header."""
+        """GET /openapi/v1/sessions with an invalid auth header → 401."""
         response = await api.client.get(
             api.open_api_session_url(),
             headers={"Authorization": "Bearer test-key"},
         )
 
-        # No dedicated list endpoint exists; expect 404 or 401 (invalid key)
-        assert response.status_code in (200, 401, 404)
+        # Invalid API key → 401 (endpoint exists, key rejected by validate_api_key)
+        assert response.status_code == 401
 
     @pytest.mark.asyncio
     async def test_list_sessions_with_pagination(self, api: APITestHelper) -> None:
-        """GET /openapi/v1/sessions with pagination params → 401/404."""
+        """GET /openapi/v1/sessions with limit/offset params → 401 (invalid key)."""
         response = await api.client.get(
             api.open_api_session_url(),
-            params={"page": 1, "page_size": 5},
+            params={"limit": 5, "offset": 0},
             headers={"Authorization": "Bearer test-key"},
         )
 
-        assert response.status_code in (200, 401, 404)
+        assert response.status_code == 401
 
     @pytest.mark.asyncio
-    async def test_list_sessions_page_out_of_range(self, api: APITestHelper) -> None:
-        """GET /openapi/v1/sessions with page=99999 → 401/404."""
+    async def test_list_sessions_limit_out_of_range(self, api: APITestHelper) -> None:
+        """GET /openapi/v1/sessions with limit > 100 → 422 (validation) or 401."""
         response = await api.client.get(
             api.open_api_session_url(),
-            params={"page": 99999, "page_size": 10},
+            params={"limit": 999, "offset": 0},
             headers={"Authorization": "Bearer test-key"},
         )
 
-        assert response.status_code in (200, 401, 404)
+        # limit has le=100 constraint; invalid key may 401 before validation,
+        # otherwise FastAPI returns 422.
+        assert response.status_code in (401, 422)
 
     @pytest.mark.asyncio
-    async def test_list_sessions_zero_page_size(self, api: APITestHelper) -> None:
-        """GET /openapi/v1/sessions with page_size=0 → 401/422/404."""
+    async def test_list_sessions_zero_limit(self, api: APITestHelper) -> None:
+        """GET /openapi/v1/sessions with limit=0 → 422 (ge=1) or 401."""
         response = await api.client.get(
             api.open_api_session_url(),
-            params={"page": 1, "page_size": 0},
+            params={"limit": 0, "offset": 0},
             headers={"Authorization": "Bearer test-key"},
         )
 
-        assert response.status_code in (200, 401, 422, 404)
+        assert response.status_code in (401, 422)
 
 
 class TestGetSessionById:

--- a/src/baas/tests/unit/adapters/web/open_api/test_session_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_session_router.py
@@ -19,6 +19,7 @@ from secbaas.community.adapters.web.routers.open_api.session_router import (
     _check_app_type,
     get_session,
     get_session_messages,
+    list_sessions,
 )
 from secbaas.community.api.api_gateway import APIKeyRecord
 from secbaas.community.api.bot_runtime import (
@@ -27,6 +28,7 @@ from secbaas.community.api.bot_runtime import (
     BotServiceError,
     MessageInfo,
     SessionInfo,
+    SessionListItem,
     SessionNotFoundError,
 )
 from secbaas.community.api.open_api import OpenAPICode
@@ -45,6 +47,8 @@ SESSION_ID = "sess-001"
 # FastAPI Query defaults are NOT applied on direct invocation.
 DEFAULT_LIFECYCLE_STAGE = "online"
 DEFAULT_LIMIT = 1000
+DEFAULT_LIST_LIMIT = 20
+DEFAULT_LIST_OFFSET = 0
 
 
 def _make_api_key_record(app_type="system", app_id="bot-1:entity-1", tenant="t1"):
@@ -104,6 +108,22 @@ def _make_message_info(**overrides):
     }
     defaults.update(overrides)
     return MessageInfo(**defaults)
+
+
+def _make_session_list_item(**overrides):
+    defaults = {
+        "session_id": SESSION_ID,
+        "bot_id": BOT_ID,
+        "title": "session-title",
+        "status": "active",
+        "model": "gpt-test",
+        "created_at": datetime(2025, 1, 15, 10, 30, 0),
+        "updated_at": datetime(2025, 1, 15, 11, 0, 0),
+        "message_count": 3,
+        "last_message": None,
+    }
+    defaults.update(overrides)
+    return SessionListItem(**defaults)
 
 
 # ── _check_app_type ──────────────────────────────────────────
@@ -932,3 +952,360 @@ class TestGetSessionMessages:
         assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert exc.value.detail["code"] == 50001
         assert "Internal server error" in exc.value.detail["message"]
+
+
+# ── list_sessions ────────────────────────────────────────────
+
+
+class TestListSessions:
+    """list_sessions 端点核心逻辑测试。"""
+
+    @pytest.mark.asyncio
+    async def test_success_returns_items(self):
+        sessions = [
+            _make_session_list_item(session_id="sess-001", message_count=2),
+            _make_session_list_item(session_id="sess-002", title="another"),
+        ]
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=sessions)
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.code == 0
+        assert result.message == "success"
+        assert len(result.data.items) == 2
+        assert result.data.items[0].session_id == "sess-001"
+        assert result.data.items[1].title == "another"
+        assert result.data.items[0].message_count == 2
+        assert result.data.items[0].model == "gpt-test"
+        assert result.data.total == 2
+        assert result.data.has_more is False
+
+    @pytest.mark.asyncio
+    async def test_success_empty_list(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.data.items == []
+        assert result.data.total == 0
+        assert result.data.has_more is False
+
+    @pytest.mark.asyncio
+    async def test_has_more_when_count_exceeds_limit(self):
+        sessions = [
+            _make_session_list_item(session_id=f"sess-{i:03d}") for i in range(5)
+        ]
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=sessions)
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                limit=2,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert len(result.data.items) == 5
+        assert result.data.total == 5
+        assert result.data.has_more is True
+
+    @pytest.mark.asyncio
+    async def test_has_more_true_when_page_full_at_limit(self):
+        """A full page (returned count == limit) signals has_more=True.
+
+        Upstream AsyncSessionClient.list_sessions caps the returned page at
+        `limit`, so the realistic non-final page has len(items) == limit.
+        The router must signal has_more=True in that case so clients fetch the
+        next page; the previous `total > limit` formula returned False here.
+        """
+        limit = 5
+        sessions = [
+            _make_session_list_item(session_id=f"sess-{i:03d}") for i in range(limit)
+        ]
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=sessions)
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                limit=limit,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert len(result.data.items) == limit
+        assert result.data.total == limit
+        assert result.data.has_more is True
+
+    @pytest.mark.asyncio
+    async def test_has_more_false_when_page_below_limit(self):
+        """A partial page (returned count < limit) signals has_more=False."""
+        sessions = [
+            _make_session_list_item(session_id=f"sess-{i:03d}") for i in range(3)
+        ]
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=sessions)
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                limit=20,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.data.total == 3
+        assert result.data.has_more is False
+
+    @pytest.mark.asyncio
+    async def test_bot_app_type_resolves_from_api_key(self):
+        api_key = _make_api_key_record(app_type="bot", app_id="bot-1:entity-1")
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with (
+            patch(RESOLVE_PATH, return_value=BOT_ID) as mock_resolve,
+            patch(POLICY_PATH),
+        ):
+            await list_sessions(
+                bot_id=None,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_resolve.assert_called_once_with(api_key)
+
+    @pytest.mark.asyncio
+    async def test_system_without_bot_id_returns_400(self):
+        api_key = _make_api_key_record(app_type="system")
+        mock_runner = AsyncMock(spec=BotRunner)
+
+        with pytest.raises(HTTPException) as exc:
+            await list_sessions(
+                bot_id=None,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+        assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert exc.value.detail["code"] == OpenAPICode.BUSINESS_ERROR
+
+    @pytest.mark.asyncio
+    async def test_non_allowed_app_type_returns_403(self):
+        api_key = _make_api_key_record(app_type="user")
+        mock_runner = AsyncMock(spec=BotRunner)
+
+        with pytest.raises(HTTPException) as exc:
+            await list_sessions(
+                bot_id=BOT_ID,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_stage_passthrough(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            await list_sessions(
+                bot_id=BOT_ID,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage="draft",
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        mock_runner.list_sessions.assert_called_once_with(
+            bot_id=BOT_ID,
+            context=_make_context(),
+            metadata={"bot_options": {"lifecycle_stage": "draft"}},
+            limit=DEFAULT_LIST_LIMIT,
+            offset=DEFAULT_LIST_OFFSET,
+        )
+
+    @pytest.mark.asyncio
+    async def test_limit_offset_forwarded(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            await list_sessions(
+                bot_id=BOT_ID,
+                limit=50,
+                offset=10,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert mock_runner.list_sessions.call_args[1]["limit"] == 50
+        assert mock_runner.list_sessions.call_args[1]["offset"] == 10
+
+    @pytest.mark.asyncio
+    async def test_bot_binding_not_found_returns_404(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotBindingNotFoundError(BOT_ID),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    limit=DEFAULT_LIST_LIMIT,
+                    offset=DEFAULT_LIST_OFFSET,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+        assert exc.value.detail["code"] == 60001
+
+    @pytest.mark.asyncio
+    async def test_bot_not_found_returns_404(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotNotFoundError("bot-1"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    limit=DEFAULT_LIST_LIMIT,
+                    offset=DEFAULT_LIST_OFFSET,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+        assert exc.value.detail["code"] == 60001
+
+    @pytest.mark.asyncio
+    async def test_bot_service_error_returns_400(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotServiceError("service unavailable"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    limit=DEFAULT_LIST_LIMIT,
+                    offset=DEFAULT_LIST_OFFSET,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert exc.value.detail["code"] == OpenAPICode.BUSINESS_ERROR
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_returns_500(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=RuntimeError("unexpected failure"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    limit=DEFAULT_LIST_LIMIT,
+                    offset=DEFAULT_LIST_OFFSET,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert exc.value.detail["code"] == 50001
+        assert "Internal server error" in exc.value.detail["message"]
+
+    @pytest.mark.asyncio
+    async def test_system_type_calls_validate_policy(self):
+        api_key = _make_api_key_record(app_type="system")
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID) as mock_policy:
+            await list_sessions(
+                bot_id=BOT_ID,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_policy.assert_called_once_with(api_key, BOT_ID)
+
+    @pytest.mark.asyncio
+    async def test_bot_type_skips_validate_policy(self):
+        api_key = _make_api_key_record(app_type="bot", app_id=BOT_ID)
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with (
+            patch(POLICY_PATH) as mock_policy,
+            patch(RESOLVE_PATH, return_value=BOT_ID),
+        ):
+            await list_sessions(
+                bot_id=None,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_policy.assert_not_called()

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -642,6 +642,97 @@ class TestGetMessages:
             assert result[0].content == "hello"
 
 
+# ==================== list_sessions Tests ====================
+
+
+class TestListSessions:
+    """list_sessions tests."""
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_success(self, service):
+        from secbaas.community.core.service.bot_run._async_session_client import (
+            SessionInfo as AdapterSessionInfo,
+        )
+
+        binding = _make_binding_info(bot_type="personal")
+        adapter_session = AdapterSessionInfo(
+            id="sess-1",
+            title="t1",
+            model="m",
+            created_at="2025-01-15T10:30:00Z",
+            updated_at="2025-01-15T11:00:00Z",
+            message_count=4,
+        )
+
+        session_client = AsyncMock()
+        session_client.list_sessions.return_value = [adapter_session]
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch.object(
+                service,
+                "_resolve_ws_connection_for_binding",
+                return_value=_make_conn_info(),
+            ),
+            patch.object(
+                service, "_create_session_client", return_value=session_client
+            ),
+        ):
+            result = await service.list_sessions(
+                binding_info=binding,
+                limit=10,
+                offset=0,
+            )
+
+        assert len(result) == 1
+        assert result[0].session_id == "sess-1"
+        assert result[0].bot_id == BOT_UUID
+        assert result[0].title == "t1"
+        assert result[0].model == "m"
+        assert result[0].message_count == 4
+        session_client.list_sessions.assert_called_once()
+        kw = session_client.list_sessions.call_args.kwargs
+        assert kw["agent_id"] == BOT_UUID
+        assert kw["engine"] == binding.engine_type
+        assert kw["limit"] == 10
+        assert kw["offset"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_resolve_failure_wrapped(self, service):
+        binding = _make_binding_info()
+
+        with patch.object(
+            service,
+            "_resolve_ws_connection_for_binding",
+            side_effect=RuntimeError("ws down"),
+        ):
+            with pytest.raises(BotServiceError, match="Failed to resolve WS connection"):
+                await service.list_sessions(binding_info=binding)
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_upstream_error_wrapped(self, service):
+        binding = _make_binding_info(bot_type="personal")
+
+        session_client = AsyncMock()
+        session_client.list_sessions.side_effect = RuntimeError("boom")
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch.object(
+                service,
+                "_resolve_ws_connection_for_binding",
+                return_value=_make_conn_info(),
+            ),
+            patch.object(
+                service, "_create_session_client", return_value=session_client
+            ),
+        ):
+            with pytest.raises(BotServiceError, match="Failed to list sessions"):
+                await service.list_sessions(binding_info=binding)
+
+
 # ==================== TestMarkSessionLifecycle ====================
 
 

--- a/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_claw_service.py
@@ -516,6 +516,68 @@ class TestGetMessages:
         assert result[0].content == "hello"
 
 
+# ==================== list_sessions Tests ====================
+
+
+class TestListSessions:
+    @pytest.mark.asyncio
+    async def test_list_sessions_no_sandbox_id_raises_error(self, service, baas_binding):
+        with pytest.raises(BotServiceError, match="requires sandbox_id"):
+            await service.list_sessions(binding_info=baas_binding)
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_success(self, service, arca_binding, monkeypatch):
+        from secbaas.community.core.service.bot_run._async_session_client import (
+            SessionInfo as AdapterSessionInfo,
+        )
+
+        adapter_session = AdapterSessionInfo(
+            id="sess-1",
+            title="t1",
+            model="m",
+            created_at="2025-01-15T10:30:00Z",
+            updated_at="2025-01-15T11:00:00Z",
+            message_count=4,
+        )
+
+        session_client = AsyncMock()
+        session_client.list_sessions.return_value = [adapter_session]
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+
+        monkeypatch.setattr(service, "_create_session_client", lambda x: session_client)
+
+        result = await service.list_sessions(
+            binding_info=arca_binding,
+            limit=10,
+            offset=0,
+        )
+
+        assert len(result) == 1
+        assert result[0].session_id == "sess-1"
+        assert result[0].bot_id == BOT_ID
+        assert result[0].title == "t1"
+        assert result[0].model == "m"
+        assert result[0].message_count == 4
+        session_client.list_sessions.assert_called_once()
+        kw = session_client.list_sessions.call_args.kwargs
+        assert kw["agent_id"] == BOT_ID
+        assert kw["limit"] == 10
+        assert kw["offset"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_error_wrapped(self, service, arca_binding, monkeypatch):
+        session_client = AsyncMock()
+        session_client.list_sessions.side_effect = RuntimeError("boom")
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+
+        monkeypatch.setattr(service, "_create_session_client", lambda x: session_client)
+
+        with pytest.raises(BotServiceError, match="Failed to list sessions"):
+            await service.list_sessions(binding_info=arca_binding)
+
+
 # ==================== Create Session Comprehensive Tests ====================
 
 

--- a/src/baas/tests/unit/core/service/bot_run/test_runner.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_runner.py
@@ -435,6 +435,49 @@ class TestContextPassthrough:
         assert call_kw["api_key_prefix"] == API_KEY_PREFIX
 
 
+# ==================== Tests: list_sessions (read-only) ====================
+
+
+class TestListSessions:
+    """BotRunner.list_sessions delegates to BotService.list_sessions."""
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_delegates_to_service(
+        self,
+        mock_selector,
+        mock_bot_service,
+        mock_run_repo,
+        mock_bot_service_plugin,
+        arca_binding_data,
+        context,
+    ):
+        from secbaas.community.api.bot_runtime import SessionListItem
+
+        mock_bot_service_plugin.get_binding.return_value = arca_binding_data
+        expected = [
+            SessionListItem(session_id="s1", bot_id=BOT_ID, title="t1"),
+            SessionListItem(session_id="s2", bot_id=BOT_ID, title="t2"),
+        ]
+        mock_bot_service.list_sessions = AsyncMock(return_value=expected)
+
+        runner = _make_runner(mock_selector, mock_run_repo, mock_bot_service_plugin)
+        result = await runner.list_sessions(
+            bot_id=f"{BOT_ID}:{ENTITY_ID}",
+            context=context,
+            metadata={},
+            limit=10,
+            offset=0,
+        )
+
+        assert result == expected
+        mock_bot_service.list_sessions.assert_called_once()
+        kw = mock_bot_service.list_sessions.call_args.kwargs
+        assert kw["limit"] == 10
+        assert kw["offset"] == 0
+        assert isinstance(kw["binding_info"], BotBindingInfo)
+        assert kw["context"] is context
+
+
 # ==================== Tests: send_message flow ====================
 
 

--- a/src/gateway/configs/schemas/baas.openapi.json
+++ b/src/gateway/configs/schemas/baas.openapi.json
@@ -586,6 +586,152 @@
         "title": "RunResultResponseData",
         "type": "object"
       },
+      "SessionListItem": {
+        "description": "Session list item",
+        "properties": {
+          "session_id": {
+            "description": "Session ID",
+            "title": "Session Id",
+            "type": "string"
+          },
+          "bot_id": {
+            "description": "Bot ID",
+            "title": "Bot Id",
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "description": "Session title",
+            "title": "Title",
+            "type": "string"
+          },
+          "status": {
+            "default": "active",
+            "description": "Session status",
+            "title": "Status",
+            "type": "string"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Model name",
+            "title": "Model"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Creation time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Update time",
+            "title": "Updated At"
+          },
+          "message_count": {
+            "default": 0,
+            "description": "Message count in session",
+            "title": "Message Count",
+            "type": "integer"
+          },
+          "last_message": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Last message summary",
+            "title": "Last Message"
+          }
+        },
+        "required": [
+          "session_id",
+          "bot_id"
+        ],
+        "title": "SessionListItem",
+        "type": "object"
+      },
+      "SessionListResponse": {
+        "description": "Session list standard response",
+        "properties": {
+          "code": {
+            "default": 0,
+            "description": "响应码，0 表示成功",
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SessionListResponseData"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Session list data"
+          },
+          "message": {
+            "default": "success",
+            "description": "响应消息",
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "title": "SessionListResponse",
+        "type": "object"
+      },
+      "SessionListResponseData": {
+        "description": "Session list response data",
+        "properties": {
+          "items": {
+            "description": "Session list",
+            "items": {
+              "$ref": "#/components/schemas/SessionListItem"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "default": 0,
+            "description": "Total sessions in current page",
+            "title": "Total",
+            "type": "integer"
+          },
+          "has_more": {
+            "default": false,
+            "description": "Whether there are more sessions",
+            "title": "Has More",
+            "type": "boolean"
+          }
+        },
+        "title": "SessionListResponseData",
+        "type": "object"
+      },
       "SessionMessagesResponse": {
         "description": "Session message list standard response",
         "properties": {
@@ -1175,6 +1321,125 @@
         "summary": "Query conversation result",
         "tags": [
           "runs"
+        ]
+      }
+    },
+    "/openapi/v1/sessions": {
+      "get": {
+        "description": "List sessions belonging to a specific bot using a Bearer Token-authenticated API Key",
+        "operationId": "list_sessions_openapi_v1_sessions_get",
+        "parameters": [
+          {
+            "description": "Bot ID, format: bot_id or default:staff_no. If omitted, resolved from the API Key.",
+            "in": "query",
+            "name": "bot_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Bot ID, format: bot_id or default:staff_no. If omitted, resolved from the API Key.",
+              "title": "Bot Id"
+            }
+          },
+          {
+            "description": "Maximum number of sessions to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Maximum number of sessions to return",
+              "exclusiveMinimum": 0,
+              "maximum": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of sessions to skip",
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "description": "Number of sessions to skip",
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Bot lifecycle stage. Options: online, verify, draft, all",
+            "in": "query",
+            "name": "lifecycle_stage",
+            "required": false,
+            "schema": {
+              "default": "online",
+              "description": "Bot lifecycle stage. Options: online, verify, draft, all",
+              "title": "Lifecycle Stage",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SessionListResponse"
+                }
+              }
+            },
+            "description": "Query successful"
+          },
+          "401": {
+            "description": "Authentication failed"
+          },
+          "403": {
+            "description": "Access denied"
+          },
+          "404": {
+            "description": "Bot not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "summary": "List sessions of a bot",
+        "tags": [
+          "sessions"
         ]
       }
     },


### PR DESCRIPTION
# Add list sessions endpoint to open api

## Summary

Adds `GET /openapi/v1/sessions` to list bot sessions bound to an API key,
with paginated `SessionListResponseData` (limit/offset, has_more).

- Extends the `bot_runtime` protocol with `list_sessions`; `BotService`,
  `BotRunner`, `BaasBotService`, and `ClawBotService` implementations
  derive `user_id` via `resolve_user_id` and route engine/binding info
  consistently with `get_session`.
- `AsyncSessionClient.list_sessions` queries the upstream
  `/api/sessions` endpoint.
- Router caps `limit` at 100 and computes `has_more = total >= limit` so
  clients detect non-final pages (the original `>` formula always
  returned false because upstream caps a page at `limit`).
- Gateway `baas.openapi.json` schema is synced with the new sessions
  path and the `SessionListItem` / `SessionListResponseData` models.

## Changed files (16)

- `src/baas/src/secbaas/community/api/bot_runtime/_models.py`
- `src/baas/src/secbaas/community/api/bot_runtime/_protocols.py`
- `src/baas/src/secbaas/community/api/bot_runtime/__init__.py`
- `src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py`
- `src/baas/src/secbaas/community/core/service/bot_run/_runner.py`
- `src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py`
- `src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py`
- `src/baas/src/secbaas/community/adapters/web/routers/open_api/session_router.py`
- `src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py`
- `src/baas/tests/unit/adapters/web/open_api/test_session_router.py`
- `src/baas/tests/unit/core/service/bot_run/test_baas_service.py`
- `src/baas/tests/unit/core/service/bot_run/test_claw_service.py`
- `src/baas/tests/unit/core/service/bot_run/test_runner.py`
- `src/baas/tests/unit/core/service/bot_run/test_engine_dispatch_integration.py`
- `src/baas/tests/e2e/asgi/baseline/test_open_api_sessions.py`
- `src/baas/tests/e2e/asgi/baseline/test_open_api_dependencies.py`
- `src/gateway/configs/schemas/baas.openapi.json`

## Verification

7 verification groups pass under the local build cache, including the
session router, service/runner `TestListSessions`, architecture and
protocol contract tests, full baas/claw/runner suites, e2e ASGI
sessions+dependencies, and gateway served OpenAPI. The has_more
regression (boundary `total == limit`) is covered by added tests.

## Privacy

Public-diff privacy scan reports no introduced markers; one
pre-existing internal marker in baseline test content is unchanged by
this patch.

## Notes

- `SessionListResponseData.total` describes the current page count;
  `has_more` drives pagination. Naming flagged for API reviewer as
  non-blocking.
- Bot-type key policy handling mirrors the existing `get_session`
  pattern; cross-endpoint hardening is tracked separately.