### PR TITLE
feat(backend): scope ac_task_queue claims by owning app

### DIFF
--- a/src/backend/src/agentclaw/community/configs/application.yaml
+++ b/src/backend/src/agentclaw/community/configs/application.yaml
@@ -168,6 +168,19 @@ user_config:
     apply_owner_whitelist: []
     global_dry_run: false
 
+  # Which application owns this deployment's rows in the shared ac_task_queue
+  # table. Another, independently deployed backend now runs against the same
+  # table; every row carries its owner, enqueue stamps this value, and every
+  # query that selects work matches it — so neither fleet claims the other's
+  # tasks and fails them for a task_type its registry never saw. Each deployment
+  # needs its own value — two deployments sharing one name are back to fighting
+  # over the same rows — and a deployment must be given its name before it starts
+  # enqueueing, since the name is what its own claims will look for. An empty,
+  # padded, or over-32-character value fails the boot rather than falling back
+  # (see ConfigModule.task_queue).
+  task_queue:
+    app: "agentclaw"
+
   # In-process durable task-queue worker (one per pod). Enabled by default so the
   # publish flow's stage advances (build/release/progress-poll) run as persisted,
   # crash-safe tasks. The test profile overrides this to false so unit tests don't

--- a/src/backend/src/agentclaw/community/configs/application.yaml
+++ b/src/backend/src/agentclaw/community/configs/application.yaml
@@ -1,4 +1,12 @@
 # 基础配置
+# app_name also names this deployment's rows in the shared ac_task_queue table:
+# another, independently deployed backend runs against the same table, every row
+# carries its owner, and each fleet claims only its own — so neither runs the
+# other's tasks and fails them for a task_type its registry never saw. Two
+# deployments must therefore not share an app_name, and a deployment needs its
+# own name before it starts enqueueing, since that name is what its own claims
+# will look for. Empty, padded, or over 32 characters fails the boot rather than
+# falling back (see ConfigModule.task_queue).
 app_name: "agentclaw"
 enable_sidecar: true
 workers: 6
@@ -167,19 +175,6 @@ user_config:
     enabled: true
     apply_owner_whitelist: []
     global_dry_run: false
-
-  # Which application owns this deployment's rows in the shared ac_task_queue
-  # table. Another, independently deployed backend now runs against the same
-  # table; every row carries its owner, enqueue stamps this value, and every
-  # query that selects work matches it — so neither fleet claims the other's
-  # tasks and fails them for a task_type its registry never saw. Each deployment
-  # needs its own value — two deployments sharing one name are back to fighting
-  # over the same rows — and a deployment must be given its name before it starts
-  # enqueueing, since the name is what its own claims will look for. An empty,
-  # padded, or over-32-character value fails the boot rather than falling back
-  # (see ConfigModule.task_queue).
-  task_queue:
-    app: "agentclaw"
 
   # In-process durable task-queue worker (one per pod). Enabled by default so the
   # publish flow's stage advances (build/release/progress-poll) run as persisted,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/platform/task_queue.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/platform/task_queue.py
@@ -91,9 +91,10 @@ logger = get_logger()
 #:
 #: There are two because the deployed table still carries the pre-``app`` index
 #: alongside the one that scopes dedup by ``app``. Either can reject an INSERT,
-#: and a rejection by the older one is not a duplicate *for this app* — see
-#: :meth:`TaskQueueRepository.enqueue`. The names are not substrings of one
-#: another, so matching them is unambiguous.
+#: so both have to be recognised; the names are not substrings of one another,
+#: so matching them is unambiguous. Dropping the legacy index is the last step of
+#: the app migration (see ``models.py`` and README "Provisioning"), and its
+#: spelling comes out of this tuple then.
 _ACTIVE_IDEM_INDEXES = (
     "uk_env_app_task_type_active_idempotency_key",
     "uk_env_task_type_active_idempotency_key",
@@ -258,9 +259,8 @@ def _is_active_idem_conflict(exc: IntegrityError) -> bool:
 
       ``active_idempotency_key`` appears in both indexes and in no other
       constraint, so the column form identifies the violation without having to
-      tell the two apart — which is right, because the branch that does care
-      (a rejection by the pre-``app`` index) is decided by looking up the holder,
-      not by parsing the message.
+      tell the two apart — which is all :meth:`enqueue` needs, since it resolves
+      the holder by querying for it rather than by parsing the message.
 
     A pure function over the exception so it is unit-testable against both
     message forms without a MySQL instance.
@@ -458,45 +458,6 @@ class TaskQueueRepository(
             )
             return row[0] if row else None
 
-    def _find_foreign_app_key_holder(
-        self, *, env: str, app: str, task_type: str, idempotency_key: str
-    ) -> Optional[tuple[int, str]]:
-        """``(id, app)`` of a row belonging to a **different** app that holds
-        ``idempotency_key`` in this ``(env, task_type)``, or ``None``.
-
-        Reachable only while the pre-``app`` dedup index is still on the table
-        (see ``models.py``): that index is unique on ``(env, task_type,
-        active_idempotency_key)`` regardless of app, so it rejects an INSERT for
-        a key another deployment happens to be using — even though, in this
-        app's scope, the key is free.
-
-        It is checked because the two live cases it separates want opposite
-        responses, and both look identical from :meth:`enqueue`'s side ("the
-        index rejected us, and no holder is visible in our scope"):
-
-        - **The key was released mid-race** — retrying is correct and normally
-          succeeds.
-        - **Another app holds it** — retrying can never succeed while that row
-          is live, and no amount of budget changes that.
-
-        Without the distinction the second case burns every attempt and reports
-        sustained churn, which points at the wrong thing entirely: the fix is to
-        drop the legacy index (the last step of the app migration), not to look
-        for a hot key. The message says so and names the row.
-        """
-        with self._db.orm_session() as db:
-            row = (
-                db.query(self.Model.id, self.Model.app)
-                .filter(
-                    self.Model.env == env,
-                    self.Model.app != app,
-                    self.Model.task_type == task_type,
-                    self.Model.active_idempotency_key == idempotency_key,
-                )
-                .first()
-            )
-            return (row[0], row[1]) if row else None
-
     def enqueue(
         self,
         *,
@@ -558,8 +519,9 @@ class TaskQueueRepository(
                         idempotency_key,
                     )
                     return EnqueueResult(existing, False)
-                # No live holder of ours, yet an index rejected us. Three very
-                # different situations, and retrying is right for only one.
+                # No live holder of ours, yet an index rejected us. Two very
+                # different situations, and retrying is right for only one of
+                # them.
                 stranded_id = self._find_stranded_key_holder(
                     env=env,
                     app=app,
@@ -577,27 +539,6 @@ class TaskQueueRepository(
                         "without clearing active_idempotency_key; clear that "
                         "column on the row to free the key"
                     )
-                # Still no holder in our scope: the rejection can only have
-                # come from the legacy index, which does not look at app.
-                foreign = self._find_foreign_app_key_holder(
-                    env=env,
-                    app=app,
-                    task_type=task_type,
-                    idempotency_key=idempotency_key,
-                )
-                if foreign is not None:
-                    foreign_id, foreign_app = foreign
-                    raise RuntimeError(
-                        f"[task_queue.enqueue] key={idempotency_key!r} "
-                        f"type={task_type} env={env} app={app} is free for this "
-                        f"app but held by task id={foreign_id} of app="
-                        f"{foreign_app!r}. The pre-app unique index "
-                        "uk_env_task_type_active_idempotency_key is still on the "
-                        "table and ignores app, so it rejects the insert. "
-                        "Retrying cannot help while that task is live; drop that "
-                        "index (the last step of the app migration) so dedup is "
-                        "scoped per app"
-                    )
                 # Otherwise the holder reached a terminal state between our
                 # INSERT and this lookup, releasing the key — it is free again,
                 # so retry.
@@ -605,16 +546,20 @@ class TaskQueueRepository(
             self._log_enqueued(record, delay_seconds, deadline_seconds, created=True)
             return EnqueueResult(record, True)
 
-        # Every attempt lost the insert *and* found the key free again straight
-        # after — i.e. a fresh holder claimed and released it inside each
-        # window. That is contention, not corruption (the permanent case raises
-        # above), so reaching here means the key is being churned faster than
-        # this loop can win rather than that anything is wrong.
+        # Every attempt lost the insert and found no holder of ours. Usually
+        # contention rather than corruption (the permanent case raises above):
+        # a fresh holder claimed and released the key inside each window, so it
+        # is being churned faster than this loop can win. The other way to reach
+        # here is the legacy unique index, which ignores app and so rejects a key
+        # a *different* deployment holds — named in the message because retrying
+        # can never clear that one.
         raise RuntimeError(
             "[task_queue.enqueue] could not insert or resolve a holder for "
             f"key={idempotency_key!r} type={task_type} env={env} app={app} after "
-            f"{_KEYED_INSERT_ATTEMPTS} attempts; the key was taken and released "
-            "by other callers on every attempt"
+            f"{_KEYED_INSERT_ATTEMPTS} attempts; either the key was taken and "
+            "released by other callers on every attempt, or another app holds it "
+            "and the pre-app index uk_env_task_type_active_idempotency_key (which "
+            "ignores app) is still on the table"
         )
 
     @staticmethod

--- a/src/backend/src/agentclaw/community/core/repository/implementations/platform/task_queue.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/platform/task_queue.py
@@ -21,10 +21,20 @@ already ``RUNNING`` with a live lease → ``affected == 0``). No ``SELECT ... FO
 UPDATE``. The same CAS shape guards ``complete`` / ``reschedule`` / ``fail`` on
 ``claimed_by == worker_id AND status == RUNNING``.
 
+**App scoping.** The table is shared with a second, independently deployed
+backend, so every row names its owning ``app`` and every statement that *selects
+work* matches it: the claim scan and its CAS, the deadline retirement inside that
+scan, the enqueue dedup lookups, and ``list_by_status``. Callers pass ``app``
+alongside ``env`` and take both from deployment config, never from a per-call
+argument. Without it each fleet claims the other's rows and fails them for a
+``task_type`` its registry never saw. ``get_by_id`` is deliberately unscoped —
+it is a primary-key read used for diagnosis and for reading back an insert this
+process just made.
+
 **Enqueue-time idempotency** is opt-in and *active-only*: at most one **live**
-task per ``idempotency_key`` within an ``(env, task_type)``. A ``None`` key opts
-out entirely and can never collide (engines treat NULLs as distinct in a unique
-index) — so un-keyed callers behave exactly as they always have.
+task per ``idempotency_key`` within an ``(env, app, task_type)``. A ``None`` key
+opts out entirely and can never collide (engines treat NULLs as distinct in a
+unique index) — so un-keyed callers behave exactly as they always have.
 
 The scope is active-only rather than all-time because several call sites
 legitimately re-enqueue the same logical key after the previous task went
@@ -75,10 +85,19 @@ from agentclaw.community.core.repository.protocols.platform import TaskQueueRepo
 
 logger = get_logger()
 
-#: The unique index backing active-only enqueue dedup. Named here because the
-#: two engines report a violation of it differently and both spellings must be
+#: The unique indexes backing active-only enqueue dedup. Named here because the
+#: two engines report a violation differently and both spellings must be
 #: recognised — see :func:`_is_active_idem_conflict`.
-_ACTIVE_IDEM_INDEX = "uk_env_task_type_active_idempotency_key"
+#:
+#: There are two because the deployed table still carries the pre-``app`` index
+#: alongside the one that scopes dedup by ``app``. Either can reject an INSERT,
+#: and a rejection by the older one is not a duplicate *for this app* — see
+#: :meth:`TaskQueueRepository.enqueue`. The names are not substrings of one
+#: another, so matching them is unambiguous.
+_ACTIVE_IDEM_INDEXES = (
+    "uk_env_app_task_type_active_idempotency_key",
+    "uk_env_task_type_active_idempotency_key",
+)
 
 #: How many times :meth:`TaskQueueRepository.enqueue` will try to insert a keyed
 #: task. A further attempt is only ever reached when the conflicting row went
@@ -226,8 +245,10 @@ def _is_active_idem_conflict(exc: IntegrityError) -> bool:
     The two engines name the violation differently, so both spellings are
     matched:
 
-    - MySQL / OceanBase report the **index**::
+    - MySQL / OceanBase report the **index** — either of the two the table
+      carries::
 
+          Duplicate entry 'dev-agentclaw-demo-k1' for key 'uk_env_app_task_type_active_idempotency_key'
           Duplicate entry 'dev-demo-k1' for key 'uk_env_task_type_active_idempotency_key'
 
     - SQLite reports the **columns**::
@@ -235,11 +256,17 @@ def _is_active_idem_conflict(exc: IntegrityError) -> bool:
           UNIQUE constraint failed: ac_task_queue.env, ac_task_queue.task_type,
           ac_task_queue.active_idempotency_key
 
+      ``active_idempotency_key`` appears in both indexes and in no other
+      constraint, so the column form identifies the violation without having to
+      tell the two apart — which is right, because the branch that does care
+      (a rejection by the pre-``app`` index) is decided by looking up the holder,
+      not by parsing the message.
+
     A pure function over the exception so it is unit-testable against both
     message forms without a MySQL instance.
     """
     message = str(getattr(exc, "orig", None) or exc)
-    if _ACTIVE_IDEM_INDEX in message:
+    if any(index in message for index in _ACTIVE_IDEM_INDEXES):
         return True
     # SQLite names the columns instead of the index. active_idempotency_key
     # appears in no other constraint on this table, so it alone identifies it.
@@ -276,13 +303,20 @@ class TaskQueueRepository(
         # mysql / oceanbase
         return func.date_add(func.now(), text(f"INTERVAL {n} SECOND"))
 
-    def _eligible(self, env: str):
-        """Eligibility predicate: due, env-scoped, and either PENDING or a
-        RUNNING row whose lease has expired (abandoned by a crashed worker).
-        All compared against the DB clock."""
+    def _eligible(self, env: str, app: str):
+        """Eligibility predicate: due, scoped to this ``(env, app)``, and either
+        PENDING or a RUNNING row whose lease has expired (abandoned by a crashed
+        worker). All compared against the DB clock.
+
+        The ``app`` term is what keeps two backends sharing this table off each
+        other's rows. It is part of the predicate rather than a pre-filter
+        because the predicate is reused verbatim as the claim CAS's WHERE: a row
+        that stopped being ours between the candidate read and the UPDATE must
+        fail the CAS, not be taken anyway."""
         now = func.now()
         return and_(
             self.Model.env == env,
+            self.Model.app == app,
             self.Model.run_at <= now,
             or_(
                 self.Model.status == TaskStatus.PENDING.value,
@@ -310,10 +344,15 @@ class TaskQueueRepository(
         delay_seconds: int,
         deadline_seconds: int,
         env: str,
+        app: str,
         idempotency_key: Optional[str],
     ) -> TaskRecord:
         """INSERT one PENDING row and return it. Raises ``IntegrityError`` when
-        a keyed insert loses to a live holder of the same key."""
+        a keyed insert loses to a live holder of the same key.
+
+        ``app`` is written explicitly rather than left to the column default:
+        the default names one particular deployment, and any other one would
+        insert rows it could never claim."""
         with self._db.orm_session() as db:
             row = self.Model(
                 task_type=task_type,
@@ -323,6 +362,7 @@ class TaskQueueRepository(
                 deadline_at=self._now_plus(db, deadline_seconds),
                 attempts=0,
                 env=env,
+                app=app,
                 idempotency_key=idempotency_key,
                 # Mirrors the key while the task is live; nulled on terminal.
                 active_idempotency_key=idempotency_key,
@@ -335,9 +375,14 @@ class TaskQueueRepository(
         return record
 
     def _find_active_by_key(
-        self, *, env: str, task_type: str, idempotency_key: str
+        self, *, env: str, app: str, task_type: str, idempotency_key: str
     ) -> Optional[TaskRecord]:
-        """The **live** holder of ``idempotency_key``, or ``None``.
+        """The **live** holder of ``idempotency_key`` in this app, or ``None``.
+
+        Scoped to ``app`` because that is the scope the caller is promised, and
+        because handing back another app's task would be worse than raising:
+        the caller would get ``created=False`` for work that this fleet can
+        never claim, so the work would simply never run.
 
         Filtering on ``active_idempotency_key`` alone *should* be enough:
         terminal transitions null it, so terminal rows drop out by
@@ -364,6 +409,7 @@ class TaskQueueRepository(
                 db.query(self.Model)
                 .filter(
                     self.Model.env == env,
+                    self.Model.app == app,
                     self.Model.task_type == task_type,
                     self.Model.active_idempotency_key == idempotency_key,
                     self.Model.status.notin_([s.value for s in TERMINAL_STATUSES]),
@@ -373,9 +419,10 @@ class TaskQueueRepository(
             return row.to_record() if row else None
 
     def _find_stranded_key_holder(
-        self, *, env: str, task_type: str, idempotency_key: str
+        self, *, env: str, app: str, task_type: str, idempotency_key: str
     ) -> Optional[int]:
-        """Id of a **terminal** row still holding ``idempotency_key``, or ``None``.
+        """Id of a **terminal** row of this app still holding ``idempotency_key``,
+        or ``None``.
 
         This should always be ``None``: every terminal transition releases the
         key in the same ``UPDATE`` as the status change, so a terminal row
@@ -402,6 +449,7 @@ class TaskQueueRepository(
                 db.query(self.Model.id)
                 .filter(
                     self.Model.env == env,
+                    self.Model.app == app,
                     self.Model.task_type == task_type,
                     self.Model.active_idempotency_key == idempotency_key,
                     self.Model.status.in_([s.value for s in TERMINAL_STATUSES]),
@@ -409,6 +457,45 @@ class TaskQueueRepository(
                 .first()
             )
             return row[0] if row else None
+
+    def _find_foreign_app_key_holder(
+        self, *, env: str, app: str, task_type: str, idempotency_key: str
+    ) -> Optional[tuple[int, str]]:
+        """``(id, app)`` of a row belonging to a **different** app that holds
+        ``idempotency_key`` in this ``(env, task_type)``, or ``None``.
+
+        Reachable only while the pre-``app`` dedup index is still on the table
+        (see ``models.py``): that index is unique on ``(env, task_type,
+        active_idempotency_key)`` regardless of app, so it rejects an INSERT for
+        a key another deployment happens to be using — even though, in this
+        app's scope, the key is free.
+
+        It is checked because the two live cases it separates want opposite
+        responses, and both look identical from :meth:`enqueue`'s side ("the
+        index rejected us, and no holder is visible in our scope"):
+
+        - **The key was released mid-race** — retrying is correct and normally
+          succeeds.
+        - **Another app holds it** — retrying can never succeed while that row
+          is live, and no amount of budget changes that.
+
+        Without the distinction the second case burns every attempt and reports
+        sustained churn, which points at the wrong thing entirely: the fix is to
+        drop the legacy index (the last step of the app migration), not to look
+        for a hot key. The message says so and names the row.
+        """
+        with self._db.orm_session() as db:
+            row = (
+                db.query(self.Model.id, self.Model.app)
+                .filter(
+                    self.Model.env == env,
+                    self.Model.app != app,
+                    self.Model.task_type == task_type,
+                    self.Model.active_idempotency_key == idempotency_key,
+                )
+                .first()
+            )
+            return (row[0], row[1]) if row else None
 
     def enqueue(
         self,
@@ -418,6 +505,7 @@ class TaskQueueRepository(
         delay_seconds: int,
         deadline_seconds: int,
         env: str,
+        app: str,
         idempotency_key: Optional[str] = None,
     ) -> EnqueueResult:
         # Validate before any work: neither a key the column cannot hold
@@ -435,6 +523,7 @@ class TaskQueueRepository(
             delay_seconds=delay_seconds,
             deadline_seconds=deadline_seconds,
             env=env,
+            app=app,
             idempotency_key=idempotency_key,
         )
 
@@ -456,7 +545,10 @@ class TaskQueueRepository(
                 if not _is_active_idem_conflict(exc):
                     raise  # unrelated constraint — never read as a duplicate
                 existing = self._find_active_by_key(
-                    env=env, task_type=task_type, idempotency_key=idempotency_key
+                    env=env,
+                    app=app,
+                    task_type=task_type,
+                    idempotency_key=idempotency_key,
                 )
                 if existing is not None:
                     logger.info(
@@ -466,21 +558,45 @@ class TaskQueueRepository(
                         idempotency_key,
                     )
                     return EnqueueResult(existing, False)
-                # No live holder, yet the index rejected us. Two very different
-                # situations, and retrying is right for only one of them.
+                # No live holder of ours, yet an index rejected us. Three very
+                # different situations, and retrying is right for only one.
                 stranded_id = self._find_stranded_key_holder(
-                    env=env, task_type=task_type, idempotency_key=idempotency_key
+                    env=env,
+                    app=app,
+                    task_type=task_type,
+                    idempotency_key=idempotency_key,
                 )
                 if stranded_id is not None:
                     raise RuntimeError(
                         f"[task_queue.enqueue] key={idempotency_key!r} "
-                        f"type={task_type} env={env} is held by task id="
-                        f"{stranded_id}, which is terminal but never released "
+                        f"type={task_type} env={env} app={app} is held by task "
+                        f"id={stranded_id}, which is terminal but never released "
                         "it. Retrying cannot help — the key is occupied "
                         "forever. Most likely a worker running code from "
                         "before enqueue idempotency wrote the terminal status "
                         "without clearing active_idempotency_key; clear that "
                         "column on the row to free the key"
+                    )
+                # Still no holder in our scope: the rejection can only have
+                # come from the legacy index, which does not look at app.
+                foreign = self._find_foreign_app_key_holder(
+                    env=env,
+                    app=app,
+                    task_type=task_type,
+                    idempotency_key=idempotency_key,
+                )
+                if foreign is not None:
+                    foreign_id, foreign_app = foreign
+                    raise RuntimeError(
+                        f"[task_queue.enqueue] key={idempotency_key!r} "
+                        f"type={task_type} env={env} app={app} is free for this "
+                        f"app but held by task id={foreign_id} of app="
+                        f"{foreign_app!r}. The pre-app unique index "
+                        "uk_env_task_type_active_idempotency_key is still on the "
+                        "table and ignores app, so it rejects the insert. "
+                        "Retrying cannot help while that task is live; drop that "
+                        "index (the last step of the app migration) so dedup is "
+                        "scoped per app"
                     )
                 # Otherwise the holder reached a terminal state between our
                 # INSERT and this lookup, releasing the key — it is free again,
@@ -496,7 +612,7 @@ class TaskQueueRepository(
         # this loop can win rather than that anything is wrong.
         raise RuntimeError(
             "[task_queue.enqueue] could not insert or resolve a holder for "
-            f"key={idempotency_key!r} type={task_type} env={env} after "
+            f"key={idempotency_key!r} type={task_type} env={env} app={app} after "
             f"{_KEYED_INSERT_ATTEMPTS} attempts; the key was taken and released "
             "by other callers on every attempt"
         )
@@ -506,9 +622,10 @@ class TaskQueueRepository(
         record: TaskRecord, delay_seconds: int, deadline_seconds: int, *, created: bool
     ) -> None:
         logger.info(
-            "[task_queue.enqueue] type=%s id=%s delay=%ss deadline=%ss key=%s created=%s",
+            "[task_queue.enqueue] type=%s id=%s app=%s delay=%ss deadline=%ss key=%s created=%s",
             record.task_type,
             record.id,
+            record.app,
             delay_seconds,
             deadline_seconds,
             record.idempotency_key,
@@ -522,6 +639,7 @@ class TaskQueueRepository(
         *,
         worker_id: str,
         env: str,
+        app: str,
         limit: int,
         lease_seconds: int,
     ) -> List[TaskRecord]:
@@ -534,7 +652,7 @@ class TaskQueueRepository(
             candidate_ids = [
                 row_id
                 for (row_id,) in db.query(self.Model.id)
-                .filter(self._eligible(env))
+                .filter(self._eligible(env, app))
                 .order_by(self.Model.run_at.asc())
                 .limit(limit)
                 .all()
@@ -548,7 +666,7 @@ class TaskQueueRepository(
                     db.query(self.Model)
                     .filter(
                         self.Model.id == task_id,
-                        self._eligible(env),
+                        self._eligible(env, app),
                         self.Model.deadline_at > func.now(),
                     )
                     .update(
@@ -579,7 +697,7 @@ class TaskQueueRepository(
                 #     it, this matches nothing — harmless.)
                 db.query(self.Model).filter(
                     self.Model.id == task_id,
-                    self._eligible(env),
+                    self._eligible(env, app),
                     self.Model.deadline_at <= func.now(),
                 ).update(
                     {
@@ -594,8 +712,9 @@ class TaskQueueRepository(
                 )
         if won:
             logger.info(
-                "[task_queue.claim] worker=%s claimed %d/%d candidates",
+                "[task_queue.claim] worker=%s app=%s claimed %d/%d candidates",
                 worker_id,
+                app,
                 len(won),
                 len(candidate_ids),
             )
@@ -709,6 +828,12 @@ class TaskQueueRepository(
     # ── diagnosis / tests ───────────────────────────────────────────────
 
     def get_by_id(self, task_id: int) -> Optional[TaskRecord]:
+        # Deliberately not app-scoped: an id is already unique across apps, and
+        # this is both the read-back of an insert this process just made and the
+        # diagnostic entry point for "what happened to task 71544?" — which is
+        # asked precisely when the row's owner is what you are trying to find
+        # out. ``TaskRecord.app`` carries it, so a caller that needs the scope
+        # can still check it.
         with self._db.orm_session() as db:
             row = (
                 db.query(self.Model)
@@ -717,13 +842,16 @@ class TaskQueueRepository(
             )
             return row.to_record() if row else None
 
-    def list_by_status(self, *, status: TaskStatus, env: str) -> List[TaskRecord]:
+    def list_by_status(
+        self, *, status: TaskStatus, env: str, app: str
+    ) -> List[TaskRecord]:
         with self._db.orm_session() as db:
             rows = (
                 db.query(self.Model)
                 .filter(
                     self.Model.status == status.value,
                     self.Model.env == env,
+                    self.Model.app == app,
                 )
                 .order_by(self.Model.run_at.asc())
                 .all()

--- a/src/backend/src/agentclaw/community/core/repository/protocols/platform.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/platform.py
@@ -31,6 +31,7 @@ class TaskQueueRepositoryProtocol(Protocol):
         delay_seconds: int,
         deadline_seconds: int,
         env: str,
+        app: str,
         idempotency_key: Optional[str] = None,
     ) -> EnqueueResult:
         """Persist a ``PENDING`` task and return ``(record, created)``.
@@ -39,24 +40,35 @@ class TaskQueueRepositoryProtocol(Protocol):
         ``now() + deadline_seconds``, both computed DB-side. ``payload`` is
         JSON-serialized on write.
 
+        ``app`` names the deployment that owns the row. The table is shared with
+        an independently deployed backend, and only that app's own worker will
+        ever claim it, so this must be the same value that deployment's
+        :meth:`claim_batch` passes — it comes from deployment config, like
+        ``env``, and is not a per-call choice.
+
         **Without a key** (the default) every enqueue creates a distinct row —
         insert-time dedup is opt-in, so un-keyed callers are unaffected by it.
 
         **With a key** dedup is *active-only*: at most one **live** task per
-        ``idempotency_key`` within an ``(env, task_type)``. If a live task
+        ``idempotency_key`` within an ``(env, app, task_type)``. If a live task
         already holds the key, no row is inserted and that task is returned with
         ``created=False``; otherwise a new row is created with ``created=True``.
-        Never raises for a plain duplicate.
+        Never raises for a plain duplicate. The returned task is always one of
+        this app's own — another app's row is never handed back, since the
+        caller could not claim it and its work would silently never run.
 
         Nor for the race around one: if the holder goes terminal between the
         insert losing and the holder being looked up, the key is free again and
         the insert is simply retried. Losing that race repeatedly is bad luck
         rather than an error, and the retry budget is sized so it is not
-        mistaken for one. Two cases *do* raise ``RuntimeError`` — both mean the
-        enqueue could not be honoured, so neither can be reported as a
+        mistaken for one. Three cases *do* raise ``RuntimeError`` — each means
+        the enqueue could not be honoured, so none can be reported as a
         duplicate: a key held by a **terminal** row that never released it
-        (an inconsistent row; the message names it), and the key being taken and
-        released by other callers on every attempt (sustained churn).
+        (an inconsistent row; the message names it), a key held by a live row of
+        a **different app** (only possible while the pre-``app`` unique index is
+        still on the table, which ignores app; the message names the index to
+        drop), and the key being taken and released by other callers on every
+        attempt (sustained churn).
 
         A terminal transition (``SUCCEEDED`` / ``FAILED`` / ``TIMED_OUT``)
         **releases** the key, so the same key may legitimately be re-enqueued
@@ -116,13 +128,19 @@ class TaskQueueRepositoryProtocol(Protocol):
         *,
         worker_id: str,
         env: str,
+        app: str,
         limit: int,
         lease_seconds: int,
     ) -> List[TaskRecord]:
         """Atomically claim up to ``limit`` due tasks for ``worker_id``.
 
-        Eligible = ``env`` matches, ``run_at <= now()``, and the row is either
-        ``PENDING`` or a ``RUNNING`` row whose ``lease_expires_at <= now()``.
+        Eligible = ``env`` and ``app`` match, ``run_at <= now()``, and the row is
+        either ``PENDING`` or a ``RUNNING`` row whose ``lease_expires_at <=
+        now()``.
+
+        ``app`` is what keeps two backends sharing this table apart: a row
+        belonging to another app is never claimed, never retired ``TIMED_OUT``,
+        and never returned, whatever its state.
         A claimed row is flipped to ``RUNNING`` with ``claimed_by = worker_id``,
         ``lease_expires_at = now() + lease_seconds`` and ``attempts += 1``.
 
@@ -185,12 +203,18 @@ class TaskQueueRepositoryProtocol(Protocol):
     # ── diagnosis / tests ───────────────────────────────────────────────
     @abstractmethod
     def get_by_id(self, task_id: int) -> Optional[TaskRecord]:
-        """Return the task by id, or ``None``."""
+        """Return the task by id, or ``None``.
+
+        Not app-scoped — an id is unique across apps, and the owner is on the
+        returned :class:`TaskRecord` for a caller that needs to check it."""
         ...
 
     @abstractmethod
-    def list_by_status(self, *, status: TaskStatus, env: str) -> List[TaskRecord]:
-        """Return all tasks in ``status`` for ``env`` (diagnosis / tests)."""
+    def list_by_status(
+        self, *, status: TaskStatus, env: str, app: str
+    ) -> List[TaskRecord]:
+        """Return all tasks in ``status`` for this ``(env, app)`` (diagnosis /
+        tests)."""
         ...
 
 

--- a/src/backend/src/agentclaw/community/core/repository/protocols/platform.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/platform.py
@@ -61,14 +61,13 @@ class TaskQueueRepositoryProtocol(Protocol):
         insert losing and the holder being looked up, the key is free again and
         the insert is simply retried. Losing that race repeatedly is bad luck
         rather than an error, and the retry budget is sized so it is not
-        mistaken for one. Three cases *do* raise ``RuntimeError`` — each means
-        the enqueue could not be honoured, so none can be reported as a
+        mistaken for one. Two cases *do* raise ``RuntimeError`` — both mean the
+        enqueue could not be honoured, so neither can be reported as a
         duplicate: a key held by a **terminal** row that never released it
-        (an inconsistent row; the message names it), a key held by a live row of
-        a **different app** (only possible while the pre-``app`` unique index is
-        still on the table, which ignores app; the message names the index to
-        drop), and the key being taken and released by other callers on every
-        attempt (sustained churn).
+        (an inconsistent row; the message names it), and the key being taken and
+        released by other callers on every attempt (sustained churn). While the
+        pre-``app`` unique index is still on the table it can also reject a key
+        another *app* holds, which surfaces as the second of those.
 
         A terminal transition (``SUCCEEDED`` / ``FAILED`` / ``TIMED_OUT``)
         **releases** the key, so the same key may legitimately be re-enqueued

--- a/src/backend/src/agentclaw/community/core/task_queue/README.md
+++ b/src/backend/src/agentclaw/community/core/task_queue/README.md
@@ -22,6 +22,45 @@ a handler that reschedules itself until done, bounded by a wall-clock deadline.
 - `services/worker.py` — `TaskWorker`, the Lifecycle that polls, claims, runs handlers, and applies outcomes.
 - `examples.py` — `NoopTaskHandler` + `PollUntilTerminalExampleHandler` (not wired in prod).
 
+## App scoping
+
+The `ac_task_queue` table is shared with a second, independently deployed
+backend. Every row therefore carries an `app` naming its owner, and every
+statement that *selects work* matches it — the claim scan and its CAS, the
+deadline retirement inside that scan, the enqueue dedup lookups, and
+`list_by_status`. Without it both fleets claim each other's rows and fail them
+for a `task_type` their registry never saw.
+
+The value comes from deployment config, never from a caller:
+
+```yaml
+user_config:
+  task_queue:
+    app: "agentclaw"
+```
+
+`TaskQueueService` stamps it on enqueue and `TaskWorker` claims with it, both
+reading the one `TaskQueueConfig`, so the two sides cannot disagree within a
+process. Two *deployments* must not share a name — that is back to fighting over
+the same rows — and a deployment has to be given its name before it starts
+enqueueing, since the name is what its own claims will look for.
+
+An `app` the column cannot hold faithfully (empty, whitespace-padded, or over 32
+characters) **fails the boot** rather than falling back to the default. The
+fallback is exactly the accident worth preventing: the default is the *other*
+deployment's name as often as not. `container.py` resolves `TaskQueueConfig`
+eagerly for that reason, the same way it resolves `HttpClientPoolConfig`.
+
+`get_by_id` is deliberately *not* scoped: an id is unique across apps, it is how
+an insert is read back, and "what happened to task 71544?" is asked precisely
+when the owner is what you are trying to establish. `TaskRecord.app` carries the
+owner for a caller that needs to check it.
+
+The column keeps the table's default collation, like `env` and unlike the key
+columns — it matches the deployed DDL, which declares none. On MySQL/OceanBase
+that means two app names differing only by case are one app, so give deployments
+names that differ by more than that.
+
 ## How idempotency works
 
 Two independent guarantees, answering two different questions.
@@ -36,8 +75,8 @@ exactly one. A crashed worker's task is reclaimed after its lease expires. No
 ### Enqueue time — "should this row exist at all?"
 
 **Opt-in.** Pass an `idempotency_key` to `enqueue(...)` and at most one **live**
-task will exist for that key within its `(env, task_type)`. A duplicate enqueue
-inserts nothing and returns the existing task:
+task will exist for that key within its `(env, app, task_type)`. A duplicate
+enqueue inserts nothing and returns the existing task:
 
 ```python
 record, created = task_queue_service.enqueue(
@@ -95,7 +134,7 @@ rejects, it never trims.
 
 **Mechanism.** A second column, `active_idempotency_key`, mirrors the key while
 the task is live and is nulled by every terminal transition; the unique index is
-over `(env, task_type, active_idempotency_key)`. MySQL/OceanBase have no partial
+over `(env, app, task_type, active_idempotency_key)`. MySQL/OceanBase have no partial
 indexes, so nulling a plain column is the portable way to say "unique among live
 rows only". The opt-out works because **both engines treat NULLs as distinct in
 a unique index** — that is a *relied-upon* property, not an incidental one, and
@@ -220,16 +259,26 @@ the ORM model — column types, nullability, collations, and the index are all
 declared there with the reasoning inline.
 
 **The schema change must be applied before deploying the release that contains
-it** — not merely before the first call site passes a key. The ORM maps both new
-columns unconditionally, so every `SELECT` projects them and every `INSERT`
-writes them even for an un-keyed enqueue; against a table without them the whole
-queue fails with "unknown column".
+it** — for `app` as much as for the key columns, and not merely before the first
+call site passes a key. The ORM maps every one of them unconditionally, so each
+`SELECT` projects them and each `INSERT` writes them even for an un-keyed
+enqueue; against a table without them the whole queue fails with "unknown
+column".
 
 That applies to **any** deployment that has provisioned `ac_task_queue`, not just
 prod. `CommunityDatabase` is a pure connection provider and never runs
 `create_all`, so a community schema is operator-provisioned and does not pick the
 columns up automatically. What has to exist:
 
+- `app` — `varchar(32) NOT NULL DEFAULT 'agentclaw'`, no collation clause (it
+  takes the table default, like `env`). The default is what an INSERT naming no
+  app lands on; it must equal `TaskQueueConfig`'s default, and a test pins the
+  two together.
+- `UNIQUE (env, app, task_type, active_idempotency_key)` and the two app-scoped
+  scan indexes `idx_env_app_status_run_at` / `idx_env_app_lease_expires_at` —
+  every claim and reclaim query now carries an `app` term, so the indexes have to
+  lead with it. The unique index is **`GLOBAL` on OceanBase** for the same reason
+  as its predecessor below.
 - `idempotency_key` and `active_idempotency_key` — nullable, matching the width
   in `models.py`, both pinning `utf8mb4_bin` on MySQL/OceanBase.
 - `task_type` also pinning `utf8mb4_bin` there — it is the index's other scope
@@ -243,13 +292,29 @@ columns up automatically. What has to exist:
 - `env` deliberately left on the table default — see the index comment in
   `models.py` for why widening it is a much larger change.
 
+**The legacy dedup index is still on the table and is the last step to remove.**
+`uk_env_task_type_active_idempotency_key` predates `app` and is unique on
+`(env, task_type, active_idempotency_key)` regardless of app, so while it exists
+two deployments cannot use the same key for the same `task_type` in the same
+`env` — the second one's INSERT is rejected even though the key is free in its
+own scope. `enqueue` recognises that case and raises naming the index, rather
+than joining a row this deployment could never claim or reporting contention.
+Drop it once every app writes its own `app`, and delete its declaration from
+`models.py` in the same change.
+
 On SQLite none of the collation clauses apply: it compares `TEXT` as `BINARY`
 natively, which is already the semantics the key contract needs.
 
-**No backfill.** Both columns are new and nullable, every existing row takes
+**No backfill.** Both key columns are new and nullable, every existing row takes
 `NULL`, and all supported engines treat `NULL`s as distinct in a unique index —
 so no two existing rows can collide however many duplicate enqueues the table
 already holds, and the index can be created alongside the columns.
+
+`app` needs no backfill either: it is `NOT NULL DEFAULT 'agentclaw'`, so every
+existing row takes the default, which is exactly the deployment that wrote them.
+The order matters in the other direction, though — a deployment that is *not*
+the default must be given its `task_queue.app` before it starts enqueueing, or
+it will file rows under the default name and never claim them back.
 
 **PostgreSQL is not a supported store for this component.** `CommunityDatabase`
 will connect to it, but `_now_plus` branches on SQLite and treats every other
@@ -275,6 +340,7 @@ provides:
   - "TaskQueueRepositoryProtocol"
 consumes:
   - "DatabasePlugin (via the repository impl in plugins/)"
+  - "TaskQueueConfig"
   - "TaskQueueWorkerConfig"
 internal_dependencies:
   - agentclaw.community.core.repository.protocols.platform    # repository contracts consumed by this module

--- a/src/backend/src/agentclaw/community/core/task_queue/README.md
+++ b/src/backend/src/agentclaw/community/core/task_queue/README.md
@@ -31,25 +31,29 @@ deadline retirement inside that scan, the enqueue dedup lookups, and
 `list_by_status`. Without it both fleets claim each other's rows and fail them
 for a `task_type` their registry never saw.
 
-The value comes from deployment config, never from a caller:
+The value is the deployment's own identity — the top-level `app_name` — never a
+caller's argument:
 
 ```yaml
-user_config:
-  task_queue:
-    app: "agentclaw"
+app_name: "agentclaw"
 ```
 
-`TaskQueueService` stamps it on enqueue and `TaskWorker` claims with it, both
-reading the one `TaskQueueConfig`, so the two sides cannot disagree within a
-process. Two *deployments* must not share a name — that is back to fighting over
-the same rows — and a deployment has to be given its name before it starts
-enqueueing, since the name is what its own claims will look for.
+`ConfigModule.task_queue` reads it into `TaskQueueConfig`; `TaskQueueService`
+stamps it on enqueue and `TaskWorker` claims with it, both from that one object,
+so the two sides cannot disagree within a process. Reusing `app_name` rather than
+a queue-specific key is deliberate: the owner *is* the deployment, and a second
+independently settable name would only create a way for the two to drift. Two
+deployments must not share a name — that is back to fighting over the same rows —
+and a deployment has to be given its name before it starts enqueueing, since the
+name is what its own claims will look for.
 
-An `app` the column cannot hold faithfully (empty, whitespace-padded, or over 32
+A name the column cannot hold faithfully (empty, whitespace-padded, or over 32
 characters) **fails the boot** rather than falling back to the default. The
 fallback is exactly the accident worth preventing: the default is the *other*
 deployment's name as often as not. `container.py` resolves `TaskQueueConfig`
-eagerly for that reason, the same way it resolves `HttpClientPoolConfig`.
+eagerly for that reason, the same way it resolves `HttpClientPoolConfig`. With no
+config at all (local mode, ad-hoc tests) there is nothing to read and the default
+stands.
 
 `get_by_id` is deliberately *not* scoped: an id is unique across apps, it is how
 an insert is read back, and "what happened to task 71544?" is asked precisely
@@ -297,10 +301,10 @@ columns up automatically. What has to exist:
 `(env, task_type, active_idempotency_key)` regardless of app, so while it exists
 two deployments cannot use the same key for the same `task_type` in the same
 `env` — the second one's INSERT is rejected even though the key is free in its
-own scope. `enqueue` recognises that case and raises naming the index, rather
-than joining a row this deployment could never claim or reporting contention.
-Drop it once every app writes its own `app`, and delete its declaration from
-`models.py` in the same change.
+own scope. `enqueue` never joins that row — it belongs to another app and this
+deployment could not claim it — so the enqueue fails loudly once its retries are
+spent. Drop the index once every app writes its own `app`, and delete its
+declaration from `models.py` in the same change.
 
 On SQLite none of the collation clauses apply: it compares `TEXT` as `BINARY`
 natively, which is already the semantics the key contract needs.
@@ -312,9 +316,9 @@ already holds, and the index can be created alongside the columns.
 
 `app` needs no backfill either: it is `NOT NULL DEFAULT 'agentclaw'`, so every
 existing row takes the default, which is exactly the deployment that wrote them.
-The order matters in the other direction, though — a deployment that is *not*
-the default must be given its `task_queue.app` before it starts enqueueing, or
-it will file rows under the default name and never claim them back.
+The order matters in the other direction, though — a deployment whose `app_name`
+is *not* the default must carry it before it starts enqueueing, or it will file
+rows under the default name and never claim them back.
 
 **PostgreSQL is not a supported store for this component.** `CommunityDatabase`
 will connect to it, but `_now_plus` branches on SQLite and treats every other

--- a/src/backend/src/agentclaw/community/core/task_queue/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/task_queue/repository/models.py
@@ -152,8 +152,9 @@ class TaskQueueModel(Base):
     # this table, and without this column both fleets claim each other's tasks —
     # each running a ``task_type`` its registry never heard of. Every query that
     # selects work (claim, the dedup lookups, list_by_status) filters on it, and
-    # the value comes from deployment config (``TaskQueueConfig.app``), never
-    # from a per-call argument, exactly like ``env``.
+    # the value comes from deployment config (``TaskQueueConfig.app``, read off
+    # the top-level ``app_name``), never from a per-call argument, exactly like
+    # ``env``.
     #
     # ``server_default`` mirrors the deployed DDL so an INSERT that predates this
     # column still lands on the owning app rather than failing NOT NULL. It is a
@@ -239,7 +240,8 @@ class TaskQueueModel(Base):
         # Leaving it out of the ORM would hide that case from SQLite entirely and
         # let it surface first in production, which is precisely the divergence
         # the collation notes above exist to avoid. ``enqueue`` recognises the
-        # rejection and names the index; see ``_find_foreign_app_key_holder``.
+        # rejection as a dedup conflict, finds no holder of its own, and ends up
+        # raising once its retries are spent.
         #
         # It is redundant once every app writes its own ``app``, and dropping it
         # is the last step of this migration — drop it there and here in the same

--- a/src/backend/src/agentclaw/community/core/task_queue/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/task_queue/repository/models.py
@@ -22,7 +22,12 @@ from sqlalchemy.dialects import mysql
 from sqlalchemy.sql import func
 
 from agentclaw.community.core.base import Base
-from agentclaw.community.core.task_queue.types import TaskRecord, TaskStatus
+from agentclaw.community.core.task_queue.types import (
+    DEFAULT_APP,
+    MAX_APP_LEN,
+    TaskRecord,
+    TaskStatus,
+)
 from agentclaw.community.utils.env_utils import get_current_env
 
 # SQLite only auto-increments columns declared as exactly "INTEGER PRIMARY
@@ -136,12 +141,30 @@ class TaskQueueModel(Base):
         comment="enforcement copy of idempotency_key; NULLed on terminal transitions",
     )
 
-    # ── env scoping / audit ─────────────────────────────────────────────
+    # ── env / app scoping / audit ───────────────────────────────────────
     env = Column(
         String(20),
         nullable=False,
         default=get_current_env,
         comment="环境标识: prod/pre/dev; all queries filter by env",
+    )
+    # Which application owns the row. A second, independent backend now shares
+    # this table, and without this column both fleets claim each other's tasks —
+    # each running a ``task_type`` its registry never heard of. Every query that
+    # selects work (claim, the dedup lookups, list_by_status) filters on it, and
+    # the value comes from deployment config (``TaskQueueConfig.app``), never
+    # from a per-call argument, exactly like ``env``.
+    #
+    # ``server_default`` mirrors the deployed DDL so an INSERT that predates this
+    # column still lands on the owning app rather than failing NOT NULL. It is a
+    # compatibility floor, not the source of the value: the repository always
+    # writes ``app`` explicitly, because a deployment whose configured app is not
+    # the default would otherwise enqueue rows it can never claim.
+    app = Column(
+        String(MAX_APP_LEN),
+        nullable=False,
+        server_default=DEFAULT_APP,
+        comment="app who owns the task; all queries that select work filter by app",
     )
     gmt_create = Column(DateTime, default=func.now(), nullable=False, comment="first-enqueue audit time")
     gmt_modified = Column(
@@ -157,8 +180,14 @@ class TaskQueueModel(Base):
         Index("idx_env_status_run_at", "env", "status", "run_at"),
         # Reclaim scan: env-scoped lookup of expired RUNNING leases.
         Index("idx_env_lease_expires_at", "env", "lease_expires_at"),
+        # The same two scans once the table is shared with another backend:
+        # every claim/reclaim query now also filters on app, so the leading
+        # columns have to match or the scan degrades to a full partition read on
+        # the busiest statement the component runs.
+        Index("idx_env_app_status_run_at", "env", "app", "status", "run_at"),
+        Index("idx_env_app_lease_expires_at", "env", "app", "lease_expires_at"),
         # Active-only enqueue dedup: at most one *live* task per key within an
-        # (env, task_type). Terminal rows null their active key and drop out.
+        # (env, app, task_type). Terminal rows null their active key and drop out.
         # A NULL active key is the opt-out — both MySQL/OceanBase and SQLite
         # treat NULLs as distinct in a unique index, so un-keyed enqueues never
         # collide with each other. That property is relied upon, not incidental.
@@ -176,6 +205,14 @@ class TaskQueueModel(Base):
         # _find_active_by_key and appears in no other index, so pinning it costs
         # nothing elsewhere.
         #
+        # app keeps the table default for the same reason as env, and matches the
+        # deployed DDL, which declares no collation for it either. It reads on the
+        # ci collation as "two app names that differ only by case are one app" —
+        # accepted deliberately, since both the enqueue and the claim side take
+        # the name from the same config value. It does mean two deployments must
+        # not be told apart by case alone; give them names that differ by more
+        # than that.
+        #
         # utf8mb4_bin is PAD SPACE, so it settles case but not trailing spaces;
         # enqueue and HandlerRegistry.register reject values carrying any.
         #
@@ -187,6 +224,26 @@ class TaskQueueModel(Base):
         # active key once per partition and defeat dedup, so anyone provisioning
         # the table by hand has to know it — do not read this declaration as the
         # complete specification of the index.
+        Index(
+            "uk_env_app_task_type_active_idempotency_key",
+            "env",
+            "app",
+            "task_type",
+            "active_idempotency_key",
+            unique=True,
+        ),
+        # The pre-app dedup index, still present on the deployed table. It is
+        # declared here because it is *there*: it enforces a scope wider than the
+        # code's — one live key per (env, task_type) across every app — so a keyed
+        # enqueue can be rejected by it while this app holds no such key at all.
+        # Leaving it out of the ORM would hide that case from SQLite entirely and
+        # let it surface first in production, which is precisely the divergence
+        # the collation notes above exist to avoid. ``enqueue`` recognises the
+        # rejection and names the index; see ``_find_foreign_app_key_holder``.
+        #
+        # It is redundant once every app writes its own ``app``, and dropping it
+        # is the last step of this migration — drop it there and here in the same
+        # change (README "Provisioning").
         Index(
             "uk_env_task_type_active_idempotency_key",
             "env",
@@ -210,6 +267,7 @@ class TaskQueueModel(Base):
             attempts=self.attempts,
             last_error=self.last_error,
             env=self.env,
+            app=self.app,
             idempotency_key=self.idempotency_key,
             gmt_create=self.gmt_create,
             gmt_modified=self.gmt_modified,

--- a/src/backend/src/agentclaw/community/core/task_queue/services/task_queue_service.py
+++ b/src/backend/src/agentclaw/community/core/task_queue/services/task_queue_service.py
@@ -3,7 +3,12 @@
 Thin wrapper over the repository. Timing is owned by the database: this service
 just forwards the relative ``delay_seconds`` / ``deadline_seconds`` durations
 (the repository turns them into absolute ``run_at`` / ``deadline_at`` with the
-DB clock) and stamps the current ``env``.
+DB clock) and stamps the current ``env`` and ``app``.
+
+``app`` names the deployment that owns the row in the shared ``ac_task_queue``
+table and comes from config (:class:`TaskQueueConfig`), never from the caller —
+it must match what this deployment's :class:`TaskWorker` claims with, and an
+adopter has no way to know that.
 
 It also carries the one piece of policy the repository has no business knowing:
 whether an enqueue should wake the in-process worker immediately (see
@@ -20,6 +25,7 @@ from agentclaw.community.core.repository.protocols.platform import TaskQueueRepo
 from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
 from agentclaw.community.core.task_queue.services.wakeup import WorkerWakeup
 from agentclaw.community.core.task_queue.types import EnqueueResult
+from agentclaw.community.di.config import TaskQueueConfig
 from agentclaw.community.utils.env_utils import get_current_env
 
 
@@ -32,10 +38,12 @@ class TaskQueueService:
         repo: TaskQueueRepositoryProtocol,
         registry: HandlerRegistry,
         wakeup: WorkerWakeup,
+        config: TaskQueueConfig,
     ) -> None:
         self._repo = repo
         self._registry = registry
         self._wakeup = wakeup
+        self._config = config
 
     def enqueue(
         self,
@@ -55,7 +63,7 @@ class TaskQueueService:
         - ``delay_seconds`` — how long until the task first becomes eligible
           (``run_at = now + delay``); ``0`` (default) means immediately.
         - ``idempotency_key`` — opt-in submission dedup. With a key, at most one
-          **live** task exists per key within this ``(env, task_type)``: a
+          **live** task exists per key within this ``(env, app, task_type)``: a
           duplicate enqueue inserts nothing and returns the live task with
           ``created=False``. Terminal tasks release their key, so a retry or a
           later re-run of the same logical work is *not* suppressed. Omit it
@@ -84,6 +92,7 @@ class TaskQueueService:
             delay_seconds=delay_seconds,
             deadline_seconds=deadline_seconds,
             env=get_current_env(),
+            app=self._config.app,
             idempotency_key=idempotency_key,
         )
         if self._should_wake(result, task_type=task_type, delay_seconds=delay_seconds):

--- a/src/backend/src/agentclaw/community/core/task_queue/services/worker.py
+++ b/src/backend/src/agentclaw/community/core/task_queue/services/worker.py
@@ -4,7 +4,9 @@ A ``Lifecycle`` singleton: ``startup()`` launches an asyncio loop,
 ``shutdown()`` cancels it (same shape as ``DesktopBotLifecycle``). The loop:
 
 1. claims a small batch of due tasks (``repo.claim_batch`` — the DB-level
-   single-winner CAS), off the event loop via ``asyncio.to_thread``;
+   single-winner CAS), off the event loop via ``asyncio.to_thread``. The claim
+   is scoped to this deployment's ``app`` as well as its ``env``, so a second
+   backend sharing the table is invisible to this worker;
 2. runs each claimed task's handler concurrently, bounded by a semaphore;
 3. maps the handler's :class:`TaskOutcome` back to a repository transition;
 4. **greedy re-poll** when the batch came back full (a backlog likely exists)
@@ -47,7 +49,7 @@ from agentclaw.community.core.task_queue.types import (
     Retry,
     TaskRecord,
 )
-from agentclaw.community.di.config import TaskQueueWorkerConfig
+from agentclaw.community.di.config import TaskQueueConfig, TaskQueueWorkerConfig
 from agentclaw.community.kernel.lifecycle import LifecycleBase
 from agentclaw.community.log import get_logger
 from agentclaw.community.utils.env_utils import get_current_env
@@ -71,6 +73,7 @@ class TaskWorker(LifecycleBase):
         registry: HandlerRegistry,
         config: TaskQueueWorkerConfig,
         wakeup: WorkerWakeup,
+        queue_config: TaskQueueConfig,
     ) -> None:
         self._repo = repo
         self._registry = registry
@@ -78,6 +81,10 @@ class TaskWorker(LifecycleBase):
         self._wakeup = wakeup
         self._worker_id = _make_worker_id()
         self._env = get_current_env()
+        # The owning app, from deployment config — the same value the enqueue
+        # side stamps. Read once here rather than per poll: a mid-life change
+        # would orphan everything this worker had already claimed.
+        self._app = queue_config.app
         self._running = False
         self._task: Optional[asyncio.Task] = None
         self._sem = asyncio.Semaphore(max(1, config.max_concurrency))
@@ -103,9 +110,10 @@ class TaskWorker(LifecycleBase):
         self._wakeup.bind(asyncio.get_running_loop())
         self._task = asyncio.create_task(self._loop())
         logger.info(
-            "[TaskWorker] started worker_id=%s env=%s batch=%d poll=%.1fs lease=%ds",
+            "[TaskWorker] started worker_id=%s env=%s app=%s batch=%d poll=%.1fs lease=%ds",
             self._worker_id,
             self._env,
+            self._app,
             self._config.batch_size,
             self._config.poll_interval_seconds,
             self._config.lease_seconds,
@@ -183,6 +191,7 @@ class TaskWorker(LifecycleBase):
             self._repo.claim_batch,
             worker_id=self._worker_id,
             env=self._env,
+            app=self._app,
             limit=self._config.batch_size,
             lease_seconds=self._config.lease_seconds,
         )

--- a/src/backend/src/agentclaw/community/core/task_queue/types.py
+++ b/src/backend/src/agentclaw/community/core/task_queue/types.py
@@ -25,12 +25,12 @@ from typing import NamedTuple, Optional, Union
 #: its own work, so the two defaults are pinned together by a test.
 DEFAULT_APP = "agentclaw"
 
-#: Stored width of the ``app`` column. Enforced where the value enters (the
-#: config provider) rather than only in the schema, because the engines disagree
-#: about overflow exactly as they do for the dedup key: SQLite ignores the bound,
-#: a strict MySQL/OceanBase raises, and a non-strict one **silently truncates** —
-#: filing every row under a name the claim filter then never matches, so the work
-#: is enqueued and never runs.
+#: Stored width of the ``app`` column. Enforced where the value enters — the
+#: config provider, which reads the deployment's ``app_name`` — rather than only
+#: in the schema, because the engines disagree about overflow exactly as they do
+#: for the dedup key: SQLite ignores the bound, a strict MySQL/OceanBase raises,
+#: and a non-strict one **silently truncates** — filing every row under a name
+#: the claim filter then never matches, so the work is enqueued and never runs.
 MAX_APP_LEN = 32
 
 

--- a/src/backend/src/agentclaw/community/core/task_queue/types.py
+++ b/src/backend/src/agentclaw/community/core/task_queue/types.py
@@ -17,6 +17,23 @@ from enum import Enum
 from typing import NamedTuple, Optional, Union
 
 
+#: The ``app`` an ``ac_task_queue`` row belongs to when nothing names one — the
+#: deployed table's column default (``app varchar(32) NOT NULL DEFAULT
+#: 'agentclaw'``) and, so the two can never disagree, the default of
+#: :class:`~agentclaw.community.di.config.TaskQueueConfig` as well. A deployment
+#: that enqueued under one app and claimed under another would simply never run
+#: its own work, so the two defaults are pinned together by a test.
+DEFAULT_APP = "agentclaw"
+
+#: Stored width of the ``app`` column. Enforced where the value enters (the
+#: config provider) rather than only in the schema, because the engines disagree
+#: about overflow exactly as they do for the dedup key: SQLite ignores the bound,
+#: a strict MySQL/OceanBase raises, and a non-strict one **silently truncates** —
+#: filing every row under a name the claim filter then never matches, so the work
+#: is enqueued and never runs.
+MAX_APP_LEN = 32
+
+
 class TaskStatus(str, Enum):
     """Status of an ``ac_task_queue`` row.
 
@@ -69,6 +86,10 @@ class TaskRecord:
     attempts: int
     last_error: Optional[str]
     env: str
+    #: The application that owns this task. Set from deployment config at
+    #: enqueue and matched by every query that selects work, so one backend
+    #: never claims another's rows out of the shared table.
+    app: str
     #: The caller-supplied enqueue dedup key, or ``None`` when the caller opted
     #: out. Retained after the task goes terminal (it is the audit value), so
     #: "which task handled key X?" stays answerable. The separate enforcement

--- a/src/backend/src/agentclaw/community/di/config.py
+++ b/src/backend/src/agentclaw/community/di/config.py
@@ -17,6 +17,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
+from agentclaw.community.core.task_queue.types import DEFAULT_APP
 from agentclaw.community.kernel.deploy_runtime import DeployRuntime
 
 
@@ -620,6 +621,30 @@ class DormantNotifyConfig:
     """
 
     action_link_pattern: str = ""
+
+
+@dataclass(frozen=True)
+class TaskQueueConfig:
+    """Which application owns this deployment's ``ac_task_queue`` rows.
+
+    Sourced from the ``task_queue`` block of ``user_config``.
+
+    One table is shared by more than one independent backend, so a row carries
+    an ``app`` naming its owner: enqueue stamps it, and every query that selects
+    work matches it. Without that, each fleet claims the other's tasks and fails
+    them for an unregistered ``task_type``.
+
+    It is deliberately *not* part of ``TaskQueueWorkerConfig``: the same value
+    has to be used by the enqueue path, which has nothing to do with worker
+    policy, and turning the worker off must not stop enqueued rows from being
+    stamped with their owner.
+
+    ``app`` is validated where it is read (see ``ConfigModule.task_queue``) —
+    it is a scope column, and a value the column cannot hold faithfully would
+    file rows under a name the claim filter never matches.
+    """
+
+    app: str = DEFAULT_APP
 
 
 @dataclass(frozen=True)

--- a/src/backend/src/agentclaw/community/di/config.py
+++ b/src/backend/src/agentclaw/community/di/config.py
@@ -627,7 +627,7 @@ class DormantNotifyConfig:
 class TaskQueueConfig:
     """Which application owns this deployment's ``ac_task_queue`` rows.
 
-    Sourced from the ``task_queue`` block of ``user_config``.
+    Sourced from the **top-level** ``app_name`` — the deployment's own identity.
 
     One table is shared by more than one independent backend, so a row carries
     an ``app`` naming its owner: enqueue stamps it, and every query that selects

--- a/src/backend/src/agentclaw/community/di/container.py
+++ b/src/backend/src/agentclaw/community/di/container.py
@@ -16,7 +16,7 @@ from collections.abc import Iterable
 
 from injector import Injector, Module
 
-from agentclaw.community.di.config import HttpClientPoolConfig
+from agentclaw.community.di.config import HttpClientPoolConfig, TaskQueueConfig
 
 from agentclaw.community.di.modules.access_module import AccessModule
 from agentclaw.community.di.modules.aicoding_module import AICodingModule
@@ -167,6 +167,13 @@ def build_injector(
     # column. It is a pure dict read with no I/O, so it costs nothing when the
     # config is valid, which is the only case that reaches production.
     _app_injector.get(HttpClientPoolConfig)
+
+    # Same reasoning for the task-queue owner: `task_queue.app` rejects a name
+    # the column cannot hold faithfully by raising, and a raise that only
+    # surfaced inside `discover_lifecycle_participants` would silently drop the
+    # TaskWorker binding — an app that boots clean and never runs a queued task.
+    # Resolving it here makes a bad owner name fail the boot on every profile.
+    _app_injector.get(TaskQueueConfig)
 
     return _app_injector
 

--- a/src/backend/src/agentclaw/community/di/container.py
+++ b/src/backend/src/agentclaw/community/di/container.py
@@ -168,7 +168,7 @@ def build_injector(
     # config is valid, which is the only case that reaches production.
     _app_injector.get(HttpClientPoolConfig)
 
-    # Same reasoning for the task-queue owner: `task_queue.app` rejects a name
+    # Same reasoning for the task-queue owner: `task_queue` rejects an `app_name`
     # the column cannot hold faithfully by raising, and a raise that only
     # surfaced inside `discover_lifecycle_participants` would silently drop the
     # TaskWorker binding — an app that boots clean and never runs a queued task.

--- a/src/backend/src/agentclaw/community/di/modules/config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/config_module.py
@@ -25,6 +25,7 @@ from typing import Any
 
 from injector import Module, inject, provider, singleton
 
+from agentclaw.community.core.task_queue.types import MAX_APP_LEN
 from agentclaw.community.di import config as cfg
 from agentclaw.community.kernel.deploy_runtime import DeployRuntime
 from agentclaw.community.plugin_api.http_client import (
@@ -834,6 +835,66 @@ class ConfigModule(Module):
                 "action_link_pattern", defaults.action_link_pattern
             ),
         )
+
+    @singleton
+    @provider
+    def task_queue(self) -> cfg.TaskQueueConfig:
+        """Which application owns this deployment's ``ac_task_queue`` rows.
+
+        YAML shape under ``user_config.task_queue``::
+
+            task_queue:
+              app: "agentclaw"          # owner stamped on enqueue and matched
+                                        #   by every query that selects work
+
+        Omitted ⇒ ``TaskQueueConfig``'s default, which is the column default on
+        the deployed table, so a deployment that never heard of this block keeps
+        owning exactly the rows it already owned.
+
+        An unusable value **raises** rather than falling back, and the fallback
+        is the reason: the default is the *other* deployment's app name as often
+        as not, so quietly substituting it is how one backend starts claiming and
+        failing another's tasks — the failure this block exists to prevent. Three
+        rejections, each a value the ``app`` column cannot carry faithfully:
+
+        - empty or whitespace-only — names no application at all;
+        - leading or trailing whitespace — MySQL/OceanBase compare with a PAD
+          SPACE collation, so ``"claw "`` and ``"claw"`` are one app there and
+          two on SQLite, which is a divergence no test on SQLite can see;
+        - longer than the stored width — a non-strict server truncates, and the
+          rows are then filed under a name the claim filter never matches, so
+          the work is enqueued and simply never runs.
+
+        ``container.py`` resolves ``TaskQueueConfig`` eagerly at build time (as
+        it does ``HttpClientPoolConfig``) so this raise stops the boot on every
+        profile instead of being swallowed by lifecycle discovery — which would
+        leave the app running with no worker and no explanation.
+        """
+        block = _block("task_queue")
+        defaults = cfg.TaskQueueConfig()
+        raw = block.get("app", defaults.app)
+        app = "" if raw is None else str(raw)
+        if not app.strip():
+            raise ValueError(
+                "task_queue.app must name the application that owns this "
+                "deployment's ac_task_queue rows; it is empty"
+            )
+        if app != app.strip():
+            raise ValueError(
+                f"task_queue.app must not have leading or trailing whitespace "
+                f"({app!r}); MySQL/OceanBase compare with a PAD SPACE collation, "
+                "so such a name would be a different app on SQLite than in "
+                "production"
+            )
+        if len(app) > MAX_APP_LEN:
+            raise ValueError(
+                f"task_queue.app exceeds {MAX_APP_LEN} chars ({len(app)}); it is "
+                f"stored in a VARCHAR({MAX_APP_LEN}), and a non-strict "
+                "MySQL/OceanBase would truncate it — this deployment would then "
+                "enqueue rows under the truncated name and claim under the full "
+                "one, so none of its own work would ever run"
+            )
+        return cfg.TaskQueueConfig(app=app)
 
     @singleton
     @provider

--- a/src/backend/src/agentclaw/community/di/modules/config_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/config_module.py
@@ -64,6 +64,24 @@ def _block(name: str) -> dict[str, Any]:
     return dict(raw) if isinstance(raw, dict) else {}
 
 
+def _app_name() -> str | None:
+    """The **top-level** ``app_name``, or ``None`` when there is no config.
+
+    Same defensiveness as :func:`_user_config` — local mode and ad-hoc tests
+    often have no sofa config at all — but the two outcomes are kept apart on
+    purpose: ``None`` means "nothing to read", while ``""`` means an app config
+    that names itself nothing. Only the consumer knows which of those is a
+    misconfiguration worth refusing (see :meth:`ConfigModule.task_queue`).
+    """
+    try:
+        from agentclaw.community.core.config import sofa
+
+        return str(getattr(sofa.sofa_config, "app_name", "") or "")
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("ConfigModule: sofa app_name unavailable (%s)", exc)
+        return None
+
+
 # The closed set of HttpClient bindings an ``overrides`` entry may name. Taken
 # from the qualifier constants themselves so the config surface cannot drift
 # from the injector keys.
@@ -841,21 +859,23 @@ class ConfigModule(Module):
     def task_queue(self) -> cfg.TaskQueueConfig:
         """Which application owns this deployment's ``ac_task_queue`` rows.
 
-        YAML shape under ``user_config.task_queue``::
+        Read from the **top-level** ``app_name`` — the name the deployment
+        already goes by — rather than from a queue-specific key. Two backends
+        share the table and each claims only its own rows, so the owner is the
+        deployment's identity; giving it a second, independently settable name
+        would only create a way for the two to disagree.
 
-            task_queue:
-              app: "agentclaw"          # owner stamped on enqueue and matched
-                                        #   by every query that selects work
+        No config at all (local mode, ad-hoc tests) ⇒ ``TaskQueueConfig``'s
+        default, which is the column default on the deployed table, so a
+        deployment that never set ``app_name`` keeps owning exactly the rows it
+        already owned.
 
-        Omitted ⇒ ``TaskQueueConfig``'s default, which is the column default on
-        the deployed table, so a deployment that never heard of this block keeps
-        owning exactly the rows it already owned.
-
-        An unusable value **raises** rather than falling back, and the fallback
-        is the reason: the default is the *other* deployment's app name as often
-        as not, so quietly substituting it is how one backend starts claiming and
-        failing another's tasks — the failure this block exists to prevent. Three
-        rejections, each a value the ``app`` column cannot carry faithfully:
+        A *present* but unusable value **raises** rather than falling back, and
+        the fallback is the reason: the default is the *other* deployment's name
+        as often as not, so quietly substituting it is how one backend starts
+        claiming and failing another's tasks — the failure this column exists to
+        prevent. Three rejections, each a value the ``app`` column cannot carry
+        faithfully:
 
         - empty or whitespace-only — names no application at all;
         - leading or trailing whitespace — MySQL/OceanBase compare with a PAD
@@ -870,29 +890,29 @@ class ConfigModule(Module):
         profile instead of being swallowed by lifecycle discovery — which would
         leave the app running with no worker and no explanation.
         """
-        block = _block("task_queue")
         defaults = cfg.TaskQueueConfig()
-        raw = block.get("app", defaults.app)
-        app = "" if raw is None else str(raw)
+        app = _app_name()
+        if app is None:
+            return defaults
         if not app.strip():
             raise ValueError(
-                "task_queue.app must name the application that owns this "
-                "deployment's ac_task_queue rows; it is empty"
+                "app_name must name the application; it also owns this "
+                "deployment's ac_task_queue rows, and it is empty"
             )
         if app != app.strip():
             raise ValueError(
-                f"task_queue.app must not have leading or trailing whitespace "
-                f"({app!r}); MySQL/OceanBase compare with a PAD SPACE collation, "
-                "so such a name would be a different app on SQLite than in "
-                "production"
+                f"app_name must not have leading or trailing whitespace "
+                f"({app!r}); it is stored on every ac_task_queue row, and "
+                "MySQL/OceanBase compare with a PAD SPACE collation, so such a "
+                "name would be a different app on SQLite than in production"
             )
         if len(app) > MAX_APP_LEN:
             raise ValueError(
-                f"task_queue.app exceeds {MAX_APP_LEN} chars ({len(app)}); it is "
-                f"stored in a VARCHAR({MAX_APP_LEN}), and a non-strict "
-                "MySQL/OceanBase would truncate it — this deployment would then "
-                "enqueue rows under the truncated name and claim under the full "
-                "one, so none of its own work would ever run"
+                f"app_name exceeds {MAX_APP_LEN} chars ({len(app)}); it is "
+                f"stored on every ac_task_queue row in a VARCHAR({MAX_APP_LEN}), "
+                "and a non-strict MySQL/OceanBase would truncate it — this "
+                "deployment would then enqueue rows under the truncated name and "
+                "claim under the full one, so none of its own work would ever run"
             )
         return cfg.TaskQueueConfig(app=app)
 

--- a/src/backend/tests/community/config/effective_config.py
+++ b/src/backend/tests/community/config/effective_config.py
@@ -89,6 +89,7 @@ _PROVIDER_METHODS = (
     "desktop_bot_periodic_scan",
     "dormant_config",
     "dormant_notify",
+    "task_queue",
     "task_queue_worker",
 )
 

--- a/src/backend/tests/community/config/golden/community.json
+++ b/src/backend/tests/community/config/golden/community.json
@@ -110,6 +110,9 @@
       "scan_interval_hours": 1,
       "storage_dir": "./data/skills_scan"
     },
+    "task_queue": {
+      "app": "agentclaw"
+    },
     "task_queue_worker": {
       "enabled": true
     },
@@ -132,9 +135,9 @@
       "default_ttl_minutes": 10080,
       "desktop_template_uuid": "",
       "desktop_ttl_minutes": 0,
+      "eval_template_uuid": "",
       "personal_bot_template_uuid": "",
       "teclaw_template_uuid": "",
-      "eval_template_uuid": "",
       "template_uuid": "",
       "tenant": "community"
     },
@@ -249,6 +252,9 @@
       "scan_interval_hours": 1,
       "scan_interval_minutes": 0,
       "storage_dir": "./data/skills_scan"
+    },
+    "task_queue": {
+      "app": "agentclaw"
     },
     "task_queue_worker": {
       "batch_size": 10,

--- a/src/backend/tests/community/config/golden/community.json
+++ b/src/backend/tests/community/config/golden/community.json
@@ -110,9 +110,6 @@
       "scan_interval_hours": 1,
       "storage_dir": "./data/skills_scan"
     },
-    "task_queue": {
-      "app": "agentclaw"
-    },
     "task_queue_worker": {
       "enabled": true
     },

--- a/src/backend/tests/community/config/golden/singlebox.json
+++ b/src/backend/tests/community/config/golden/singlebox.json
@@ -209,9 +209,6 @@
       "frontend_url": "http://localhost:8000",
       "robot_code": "dummy-robot-code"
     },
-    "task_queue": {
-      "app": "agentclaw"
-    },
     "task_queue_worker": {
       "enabled": true,
       "poll_interval_seconds": 0.2,

--- a/src/backend/tests/community/config/golden/singlebox.json
+++ b/src/backend/tests/community/config/golden/singlebox.json
@@ -54,9 +54,9 @@
       "arca_template_id_pre": "ARCA-TEMPLATE-000000001403860d",
       "deploy_runtime": "managed",
       "desktop_template_uuid": "TEMPLATE-f996ecc77d224ef7bd80757d8d2bcd0d",
+      "eval_template_uuid": "TEMPLATE-2e3192faa8994fe8bb8bc7be8671b431",
       "personal_bot_template_uuid": "TEMPLATE-54942a40aa794eaaae2be166f94890ed",
       "teclaw_template_uuid": "TEMPLATE-3106e731ffb04e0285e27c387e153737",
-      "eval_template_uuid": "TEMPLATE-2e3192faa8994fe8bb8bc7be8671b431",
       "template_uuid": "TEMPLATE-4d0e2849d7004111836333de782b95d8",
       "tenant": "team_claw"
     },
@@ -209,6 +209,9 @@
       "frontend_url": "http://localhost:8000",
       "robot_code": "dummy-robot-code"
     },
+    "task_queue": {
+      "app": "agentclaw"
+    },
     "task_queue_worker": {
       "enabled": true,
       "poll_interval_seconds": 0.2,
@@ -241,9 +244,9 @@
       "default_ttl_minutes": 1440,
       "desktop_template_uuid": "TEMPLATE-f996ecc77d224ef7bd80757d8d2bcd0d",
       "desktop_ttl_minutes": 0,
+      "eval_template_uuid": "TEMPLATE-2e3192faa8994fe8bb8bc7be8671b431",
       "personal_bot_template_uuid": "TEMPLATE-54942a40aa794eaaae2be166f94890ed",
       "teclaw_template_uuid": "TEMPLATE-3106e731ffb04e0285e27c387e153737",
-      "eval_template_uuid": "TEMPLATE-2e3192faa8994fe8bb8bc7be8671b431",
       "template_uuid": "TEMPLATE-4d0e2849d7004111836333de782b95d8",
       "tenant": "team_claw"
     },
@@ -358,6 +361,9 @@
       "scan_interval_hours": 1,
       "scan_interval_minutes": 0,
       "storage_dir": "./data/skills_scan"
+    },
+    "task_queue": {
+      "app": "agentclaw"
     },
     "task_queue_worker": {
       "batch_size": 10,

--- a/src/backend/tests/community/config/golden/test.json
+++ b/src/backend/tests/community/config/golden/test.json
@@ -79,6 +79,9 @@
       "scan_interval_hours": 1,
       "storage_dir": "./data/skills_scan"
     },
+    "task_queue": {
+      "app": "agentclaw"
+    },
     "task_queue_worker": {
       "enabled": true
     },
@@ -219,6 +222,9 @@
       "scan_interval_hours": 1,
       "scan_interval_minutes": 0,
       "storage_dir": "./data/skills_scan"
+    },
+    "task_queue": {
+      "app": "agentclaw"
     },
     "task_queue_worker": {
       "batch_size": 10,

--- a/src/backend/tests/community/config/golden/test.json
+++ b/src/backend/tests/community/config/golden/test.json
@@ -79,9 +79,6 @@
       "scan_interval_hours": 1,
       "storage_dir": "./data/skills_scan"
     },
-    "task_queue": {
-      "app": "agentclaw"
-    },
     "task_queue_worker": {
       "enabled": true
     },

--- a/src/backend/tests/community/core/skill_center/test_skill_activation_sync_task.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_activation_sync_task.py
@@ -41,7 +41,8 @@ from agentclaw.community.core.task_queue.services.task_queue_service import (
     TaskQueueService,
 )
 from agentclaw.community.core.task_queue.services.wakeup import WorkerWakeup
-from agentclaw.community.core.task_queue.types import Fail, TaskStatus
+from agentclaw.community.core.task_queue.types import DEFAULT_APP, Fail, TaskStatus
+from agentclaw.community.di.config import TaskQueueConfig
 
 ENV = "dev"
 ACTION = SkillActivationSyncAction.PLACEHOLDER
@@ -336,6 +337,7 @@ def queue(monkeypatch):
         TaskQueueRepository(_InMemorySqliteDB(engine)),
         HandlerRegistry(),
         WorkerWakeup(),
+        TaskQueueConfig(),
     )
 
 
@@ -375,7 +377,9 @@ def test_a_different_bot_is_not_deduped(queue):
 def test_a_terminal_task_releases_the_bot_for_the_next_operation(queue, monkeypatch):
     first, _ = enqueue_skill_activation_sync(queue, scope=_scope(), action=ACTION)
     repo = queue._repo
-    claimed = repo.claim_batch(worker_id="w-1", env=ENV, limit=1, lease_seconds=60)
+    claimed = repo.claim_batch(
+        worker_id="w-1", env=ENV, app=DEFAULT_APP, limit=1, lease_seconds=60
+    )
     assert [task.id for task in claimed] == [first.id]
     assert repo.complete(task_id=first.id, worker_id="w-1") is True
 

--- a/src/backend/tests/community/core/task_queue/test_task_worker.py
+++ b/src/backend/tests/community/core/task_queue/test_task_worker.py
@@ -57,7 +57,7 @@ class InMemorySqliteDB:
 
 
 class _World:
-    def __init__(self, config: TaskQueueWorkerConfig, queue_config: TaskQueueConfig = None):
+    def __init__(self, config: TaskQueueWorkerConfig):
         engine = create_engine(
             "sqlite:///:memory:",
             connect_args={"check_same_thread": False},
@@ -72,7 +72,7 @@ class _World:
         # The owning app, shared by both sides exactly as DI shares it: the
         # enqueue path stamps it and the worker claims with it, so a mismatch
         # here would show up as a worker that claims nothing.
-        self.queue_config = queue_config or TaskQueueConfig(app=APP)
+        self.queue_config = TaskQueueConfig(app=APP)
         # One latch, shared by the enqueue path and the worker — same wiring
         # the DI module provides in production.
         self.wakeup = WorkerWakeup()

--- a/src/backend/tests/community/core/task_queue/test_task_worker.py
+++ b/src/backend/tests/community/core/task_queue/test_task_worker.py
@@ -29,13 +29,14 @@ from agentclaw.community.core.task_queue.services.registry import HandlerRegistr
 from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
 from agentclaw.community.core.task_queue.services.wakeup import WorkerWakeup
 from agentclaw.community.core.task_queue.services.worker import TaskWorker
-from agentclaw.community.core.task_queue.types import Complete, TaskStatus
-from agentclaw.community.di.config import TaskQueueWorkerConfig
+from agentclaw.community.core.task_queue.types import DEFAULT_APP, Complete, TaskStatus
+from agentclaw.community.di.config import TaskQueueConfig, TaskQueueWorkerConfig
 from agentclaw.community.core.repository.implementations.platform.task_queue import TaskQueueRepository
 
 pytestmark = pytest.mark.integration
 
 ENV = "dev"
+APP = DEFAULT_APP
 
 
 class InMemorySqliteDB:
@@ -56,7 +57,7 @@ class InMemorySqliteDB:
 
 
 class _World:
-    def __init__(self, config: TaskQueueWorkerConfig):
+    def __init__(self, config: TaskQueueWorkerConfig, queue_config: TaskQueueConfig = None):
         engine = create_engine(
             "sqlite:///:memory:",
             connect_args={"check_same_thread": False},
@@ -68,11 +69,19 @@ class _World:
         self.repo = TaskQueueRepository(InMemorySqliteDB(engine))
         self.registry = HandlerRegistry()
         self.config = config
+        # The owning app, shared by both sides exactly as DI shares it: the
+        # enqueue path stamps it and the worker claims with it, so a mismatch
+        # here would show up as a worker that claims nothing.
+        self.queue_config = queue_config or TaskQueueConfig(app=APP)
         # One latch, shared by the enqueue path and the worker — same wiring
         # the DI module provides in production.
         self.wakeup = WorkerWakeup()
-        self.service = TaskQueueService(self.repo, self.registry, self.wakeup)
-        self.worker = TaskWorker(self.repo, self.registry, config, self.wakeup)
+        self.service = TaskQueueService(
+            self.repo, self.registry, self.wakeup, self.queue_config
+        )
+        self.worker = TaskWorker(
+            self.repo, self.registry, config, self.wakeup, self.queue_config
+        )
 
     def enqueue(
         self,
@@ -129,6 +138,28 @@ def test_missing_handler_marks_failed():
     stored = w.repo.get_by_id(rec.id)
     assert stored.status == TaskStatus.FAILED
     assert "no handler registered" in stored.last_error
+
+
+def test_worker_leaves_another_apps_task_alone():
+    """End to end over the seam that matters once the table is shared: a second
+    backend's row is enqueued with its own app, and this worker must not touch
+    it — the two tests above show what would otherwise happen to it, since its
+    ``task_type`` is not in this process's registry and the worker would fail it
+    terminally."""
+    w = _world()
+    w.registry.register(NoopTaskHandler())
+    theirs = w.repo.enqueue(
+        task_type="noop",
+        payload={},
+        delay_seconds=0,
+        deadline_seconds=3600,
+        env=ENV,
+        app="teclaw",
+        idempotency_key=None,
+    ).record
+
+    assert asyncio.run(w.worker.run_once()) == 0
+    assert w.status_of(theirs.id) == TaskStatus.PENDING
 
 
 # ── poll-until-terminal (the motivating shape) ──────────────────────────────
@@ -244,7 +275,7 @@ def test_full_batch_returns_batch_size_so_loop_repolls():
 
     counts = asyncio.run(drive())
     assert counts == [3, 3, 1]
-    assert len(w.repo.list_by_status(status=TaskStatus.SUCCEEDED, env=ENV)) == 7
+    assert len(w.repo.list_by_status(status=TaskStatus.SUCCEEDED, env=ENV, app=APP)) == 7
 
 
 def test_disabled_worker_startup_is_noop():
@@ -257,7 +288,7 @@ def test_disabled_worker_startup_is_noop():
         await w.worker.shutdown()
 
     asyncio.run(boot())
-    assert len(w.repo.list_by_status(status=TaskStatus.SUCCEEDED, env=ENV)) == 0
+    assert len(w.repo.list_by_status(status=TaskStatus.SUCCEEDED, env=ENV, app=APP)) == 0
 
 
 # ── lease-renewal heartbeat ─────────────────────────────────────────────────
@@ -329,12 +360,15 @@ def test_teclaw_publish_task_is_reclaimed_after_worker_restart():
     abandoned = w.repo.claim_batch(
         worker_id="dead-worker",
         env=ENV,
+        app=APP,
         limit=1,
         lease_seconds=0,
     )
     assert [task.id for task in abandoned] == [record.id]
 
-    restarted_worker = TaskWorker(w.repo, w.registry, w.config, w.wakeup)
+    restarted_worker = TaskWorker(
+        w.repo, w.registry, w.config, w.wakeup, w.queue_config
+    )
     asyncio.run(restarted_worker.run_once())
 
     assert w.status_of(record.id) == TaskStatus.SUCCEEDED
@@ -365,7 +399,7 @@ class _RecordingWakeup:
 
 def _service_with(world, wakeup):
     """A service over ``world``'s repo/registry but a countable latch."""
-    return TaskQueueService(world.repo, world.registry, wakeup)
+    return TaskQueueService(world.repo, world.registry, wakeup, world.queue_config)
 
 
 def test_registry_defaults_to_not_waking_on_enqueue():

--- a/src/backend/tests/community/di/test_task_queue_app_config_provider.py
+++ b/src/backend/tests/community/di/test_task_queue_app_config_provider.py
@@ -1,14 +1,17 @@
 """Unit tests for ``ConfigModule.task_queue`` — the owning-app config boundary.
 
-``app`` decides which rows of the shared ``ac_task_queue`` table this deployment
-enqueues into and claims from. Both sides read this one value, so the risk is not
-the two disagreeing within a process; it is a value the column cannot carry
-faithfully, which makes the *stored* name differ from the one the claim filter
-looks for. That is silent: work is enqueued and simply never runs.
+The owner is the deployment's own identity, the top-level ``app_name``. It
+decides which rows of the shared ``ac_task_queue`` table this deployment enqueues
+into and claims from. Both sides read this one value, so the risk is not the two
+disagreeing within a process; it is a value the column cannot carry faithfully,
+which makes the *stored* name differ from the one the claim filter looks for.
+That is silent: work is enqueued and simply never runs.
 
-Hence the provider rejects rather than falls back. Falling back is the specific
-accident worth preventing — the default is the *other* deployment's name as often
-as not, so substituting it turns a typo into one backend claiming another's work.
+Hence the provider rejects rather than falls back on a name that is present but
+unusable. Falling back is the specific accident worth preventing — the default is
+the *other* deployment's name as often as not, so substituting it turns a typo
+into one backend claiming another's work. Absent config is the one case that does
+fall back: there is nothing to have got wrong.
 """
 from __future__ import annotations
 
@@ -20,61 +23,86 @@ from agentclaw.community.di.modules.config_module import ConfigModule
 
 
 @pytest.fixture
-def stub_user_config(monkeypatch):
-    def _set(user_config: dict) -> None:
-        monkeypatch.setattr(config_module, "_user_config", lambda: dict(user_config))
+def stub_app_name(monkeypatch):
+    def _set(app_name: str | None) -> None:
+        monkeypatch.setattr(config_module, "_app_name", lambda: app_name)
 
     return _set
 
 
-def test_absent_block_keeps_the_column_default(stub_user_config):
-    """A deployment that never heard of this block keeps owning exactly the rows
-    it already owned — the dataclass default is the table's column default."""
-    stub_user_config({})
+def test_absent_config_keeps_the_column_default(stub_app_name):
+    """``None`` is "there is no config to read" — local mode, ad-hoc tests. The
+    dataclass default is the table's column default, so a deployment that never
+    set ``app_name`` keeps owning exactly the rows it already owned."""
+    stub_app_name(None)
     assert ConfigModule().task_queue().app == DEFAULT_APP
 
 
-def test_configured_app_is_used_verbatim(stub_user_config):
-    stub_user_config({"task_queue": {"app": "teclaw"}})
+def test_app_name_is_used_verbatim(stub_app_name):
+    stub_app_name("teclaw")
     assert ConfigModule().task_queue().app == "teclaw"
 
 
-def test_app_at_the_length_limit_is_accepted(stub_user_config):
+def test_app_at_the_length_limit_is_accepted(stub_app_name):
     """The bound is inclusive — the boundary value must not be rejected."""
     name = "a" * MAX_APP_LEN
-    stub_user_config({"task_queue": {"app": name}})
+    stub_app_name(name)
     assert ConfigModule().task_queue().app == name
 
 
-@pytest.mark.parametrize("blank", ["", "   ", "\t", None])
-def test_blank_app_is_rejected(stub_user_config, blank):
-    stub_user_config({"task_queue": {"app": blank}})
-    with pytest.raises(ValueError, match="task_queue.app must name"):
+@pytest.mark.parametrize("blank", ["", "   ", "\t"])
+def test_blank_app_name_is_rejected(stub_app_name, blank):
+    """Distinct from ``None``: a config that is present and names the app
+    nothing is a misconfiguration, not an absence."""
+    stub_app_name(blank)
+    with pytest.raises(ValueError, match="app_name must name"):
         ConfigModule().task_queue()
 
 
 @pytest.mark.parametrize("padded", ["claw ", " claw", "claw\t"])
-def test_padded_app_is_rejected(stub_user_config, padded):
+def test_padded_app_name_is_rejected(stub_app_name, padded):
     """Not tidiness: MySQL/OceanBase compare with a PAD SPACE collation, so
     ``"claw "`` and ``"claw"`` are one app there and two on SQLite — a
     divergence no test running on SQLite could observe."""
-    stub_user_config({"task_queue": {"app": padded}})
+    stub_app_name(padded)
     with pytest.raises(ValueError, match="leading or trailing whitespace"):
         ConfigModule().task_queue()
 
 
-def test_over_length_app_is_rejected(stub_user_config):
+def test_over_length_app_name_is_rejected(stub_app_name):
     """A non-strict server truncates it, so rows are filed under a name the
     claim filter never matches and none of this deployment's work ever runs."""
-    stub_user_config({"task_queue": {"app": "a" * (MAX_APP_LEN + 1)}})
+    stub_app_name("a" * (MAX_APP_LEN + 1))
     with pytest.raises(ValueError, match="exceeds"):
         ConfigModule().task_queue()
 
 
-def test_rejection_is_not_a_silent_fallback_to_the_default(stub_user_config):
+def test_rejection_is_not_a_silent_fallback_to_the_default(stub_app_name):
     """The behaviour this whole boundary exists for. Were a bad value to fall
     back, a deployment named ``teclaw`` with a typo would boot as ``agentclaw``
     and start claiming the other backend's tasks."""
-    stub_user_config({"task_queue": {"app": "teclaw " * 20}})
+    stub_app_name("teclaw " * 20)
     with pytest.raises(ValueError):
         ConfigModule().task_queue()
+
+
+def test_the_owner_is_read_off_the_real_top_level_app_name(stub_app_name):
+    """``_app_name`` is stubbed everywhere above, so pin once that it reads the
+    top-level key rather than a ``user_config`` block — the reason this provider
+    has no config surface of its own to get out of step with ``app_name``."""
+    from agentclaw.community.core.config.provider import AppConfig, set_config_provider
+    from agentclaw.community.core.config import provider as config_provider
+
+    class _Static:
+        def load(self):
+            return AppConfig(
+                user_config={}, raw={}, app_name="teclaw", delegate=None
+            )
+
+    saved_provider, saved_cached = config_provider._provider, config_provider._cached
+    set_config_provider(_Static())
+    try:
+        assert config_module._app_name() == "teclaw"
+    finally:
+        config_provider._provider = saved_provider
+        config_provider._cached = saved_cached

--- a/src/backend/tests/community/di/test_task_queue_app_config_provider.py
+++ b/src/backend/tests/community/di/test_task_queue_app_config_provider.py
@@ -1,0 +1,80 @@
+"""Unit tests for ``ConfigModule.task_queue`` — the owning-app config boundary.
+
+``app`` decides which rows of the shared ``ac_task_queue`` table this deployment
+enqueues into and claims from. Both sides read this one value, so the risk is not
+the two disagreeing within a process; it is a value the column cannot carry
+faithfully, which makes the *stored* name differ from the one the claim filter
+looks for. That is silent: work is enqueued and simply never runs.
+
+Hence the provider rejects rather than falls back. Falling back is the specific
+accident worth preventing — the default is the *other* deployment's name as often
+as not, so substituting it turns a typo into one backend claiming another's work.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.task_queue.types import DEFAULT_APP, MAX_APP_LEN
+from agentclaw.community.di.modules import config_module
+from agentclaw.community.di.modules.config_module import ConfigModule
+
+
+@pytest.fixture
+def stub_user_config(monkeypatch):
+    def _set(user_config: dict) -> None:
+        monkeypatch.setattr(config_module, "_user_config", lambda: dict(user_config))
+
+    return _set
+
+
+def test_absent_block_keeps_the_column_default(stub_user_config):
+    """A deployment that never heard of this block keeps owning exactly the rows
+    it already owned — the dataclass default is the table's column default."""
+    stub_user_config({})
+    assert ConfigModule().task_queue().app == DEFAULT_APP
+
+
+def test_configured_app_is_used_verbatim(stub_user_config):
+    stub_user_config({"task_queue": {"app": "teclaw"}})
+    assert ConfigModule().task_queue().app == "teclaw"
+
+
+def test_app_at_the_length_limit_is_accepted(stub_user_config):
+    """The bound is inclusive — the boundary value must not be rejected."""
+    name = "a" * MAX_APP_LEN
+    stub_user_config({"task_queue": {"app": name}})
+    assert ConfigModule().task_queue().app == name
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t", None])
+def test_blank_app_is_rejected(stub_user_config, blank):
+    stub_user_config({"task_queue": {"app": blank}})
+    with pytest.raises(ValueError, match="task_queue.app must name"):
+        ConfigModule().task_queue()
+
+
+@pytest.mark.parametrize("padded", ["claw ", " claw", "claw\t"])
+def test_padded_app_is_rejected(stub_user_config, padded):
+    """Not tidiness: MySQL/OceanBase compare with a PAD SPACE collation, so
+    ``"claw "`` and ``"claw"`` are one app there and two on SQLite — a
+    divergence no test running on SQLite could observe."""
+    stub_user_config({"task_queue": {"app": padded}})
+    with pytest.raises(ValueError, match="leading or trailing whitespace"):
+        ConfigModule().task_queue()
+
+
+def test_over_length_app_is_rejected(stub_user_config):
+    """A non-strict server truncates it, so rows are filed under a name the
+    claim filter never matches and none of this deployment's work ever runs."""
+    stub_user_config({"task_queue": {"app": "a" * (MAX_APP_LEN + 1)}})
+    with pytest.raises(ValueError, match="exceeds"):
+        ConfigModule().task_queue()
+
+
+def test_rejection_is_not_a_silent_fallback_to_the_default(stub_user_config):
+    """The behaviour this whole boundary exists for. Were a bad value to fall
+    back, a deployment named ``teclaw`` with a typo would boot as ``agentclaw``
+    and start claiming the other backend's tasks."""
+    stub_user_config({"task_queue": {"app": "teclaw " * 20}})
+    with pytest.raises(ValueError):
+        ConfigModule().task_queue()

--- a/src/backend/tests/community/repository/platform/test_task_queue_repository.py
+++ b/src/backend/tests/community/repository/platform/test_task_queue_repository.py
@@ -446,12 +446,13 @@ def test_same_key_under_different_app_is_rejected_while_the_legacy_index_lives(r
     task_type, key)`` and ignores app, so the second app's INSERT is rejected
     even though the key is free in its own scope.
 
-    The failure is loud and names the index to drop rather than joining the
-    other app's task (which this deployment could never claim) or reporting
-    contention (which points at the wrong fix)."""
+    What matters is that it fails rather than silently doing the wrong thing:
+    the other app's live task is never handed back (see the test below), and no
+    row is inserted. Dropping that index is the last step of the migration and
+    makes this case disappear."""
     first = _enqueue_result(repo, app=APP, idempotency_key="k1")
 
-    with pytest.raises(RuntimeError, match="uk_env_task_type_active_idempotency_key"):
+    with pytest.raises(RuntimeError):
         _enqueue_result(repo, app=OTHER_APP, idempotency_key="k1")
 
     assert len(_all_rows(repo)) == 1  # nothing inserted for the second app

--- a/src/backend/tests/community/repository/platform/test_task_queue_repository.py
+++ b/src/backend/tests/community/repository/platform/test_task_queue_repository.py
@@ -17,16 +17,21 @@ from sqlalchemy.pool import StaticPool
 # Side-effect import: registers TaskQueueModel on Base.metadata so
 # create_all() builds the ac_task_queue table.
 from agentclaw.community.core.task_queue.repository.models import TaskQueueModel  # noqa: F401
-from agentclaw.community.core.task_queue.types import TaskStatus
+from agentclaw.community.core.task_queue.types import DEFAULT_APP, MAX_APP_LEN, TaskStatus
 from agentclaw.community.core.task_queue.services.registry import HandlerRegistry
 from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
 from agentclaw.community.core.task_queue.services.wakeup import WorkerWakeup
-from agentclaw.community.core.repository.implementations.platform.task_queue import _ACTIVE_IDEM_INDEX, _KEYED_INSERT_ATTEMPTS, _MAX_IDEMPOTENCY_KEY_LEN, _MAX_TASK_TYPE_LEN
+from agentclaw.community.di.config import TaskQueueConfig
+from agentclaw.community.core.repository.implementations.platform.task_queue import _ACTIVE_IDEM_INDEXES, _KEYED_INSERT_ATTEMPTS, _MAX_IDEMPOTENCY_KEY_LEN, _MAX_TASK_TYPE_LEN
 from agentclaw.community.core.repository.implementations.platform.task_queue import TaskQueueRepository, _is_active_idem_conflict
 
 pytestmark = pytest.mark.integration
 
 ENV = "dev"
+#: This deployment's app. A second, independently deployed backend shares the
+#: table under its own name; ``OTHER_APP`` stands in for it.
+APP = DEFAULT_APP
+OTHER_APP = "teclaw"
 
 
 class InMemorySqliteDB:
@@ -70,6 +75,7 @@ def _enqueue_result(
     delay_seconds=0,
     deadline_seconds=3600,
     env=ENV,
+    app=APP,
     task_type="demo",
     idempotency_key=None,
 ):
@@ -80,6 +86,7 @@ def _enqueue_result(
         delay_seconds=delay_seconds,
         deadline_seconds=deadline_seconds,
         env=env,
+        app=app,
         idempotency_key=idempotency_key,
     )
 
@@ -91,8 +98,10 @@ def _enqueue(repo, **kwargs):
     return _enqueue_result(repo, **kwargs).record
 
 
-def _claim(repo, worker, *, limit=10, lease=60, env=ENV):
-    return repo.claim_batch(worker_id=worker, env=env, limit=limit, lease_seconds=lease)
+def _claim(repo, worker, *, limit=10, lease=60, env=ENV, app=APP):
+    return repo.claim_batch(
+        worker_id=worker, env=env, app=app, limit=limit, lease_seconds=lease
+    )
 
 
 # ── enqueue ─────────────────────────────────────────────────────────────────
@@ -124,6 +133,71 @@ def test_claim_respects_env_scoping(repo):
     _enqueue(repo, env="pre")
     won = _claim(repo, "W", env="dev")
     assert len(won) == 1 and won[0].env == "dev"
+
+
+def test_claim_respects_app_scoping(repo):
+    """The reason the column exists: two backends share this table, and a worker
+    must never claim the other's row — it would run a ``task_type`` its registry
+    never saw and fail it."""
+    mine = _enqueue(repo, app=APP)
+    _enqueue(repo, app=OTHER_APP)
+
+    won = _claim(repo, "W", app=APP)
+
+    assert [t.id for t in won] == [mine.id]
+    assert won[0].app == APP
+
+
+def test_claim_leaves_another_apps_expired_lease_alone(repo):
+    """Reclaim is scoped too. An abandoned row of another app looks exactly like
+    work waiting to be rescued — it is not ours to rescue, and taking it would
+    double-run it the moment that app's own worker comes back."""
+    theirs = _enqueue(repo, app=OTHER_APP)
+    assert _claim(repo, "T", app=OTHER_APP)  # their worker holds it
+    with repo._db.orm_session() as db:
+        db.query(TaskQueueModel).filter(TaskQueueModel.id == theirs.id).update(
+            {TaskQueueModel.lease_expires_at: func.datetime("now", "-1 minute")},
+            synchronize_session=False,
+        )
+
+    assert _claim(repo, "W", app=APP) == []
+    stored = repo.get_by_id(theirs.id)
+    assert stored.claimed_by == "T" and stored.status == TaskStatus.RUNNING
+
+
+def test_claim_does_not_time_out_another_apps_past_deadline_task(repo):
+    """The claim scan's other write. Retiring a past-deadline row is a terminal
+    transition, so doing it to another app's row would end work this deployment
+    has no business ending — and release a dedup key it does not own."""
+    theirs = _enqueue(repo, app=OTHER_APP, deadline_seconds=0)
+
+    assert _claim(repo, "W", app=APP) == []
+
+    assert repo.get_by_id(theirs.id).status == TaskStatus.PENDING
+
+
+def test_enqueue_stamps_the_owning_app(repo):
+    """Written explicitly, not left to the column default — a deployment whose
+    app is not the default would otherwise enqueue rows it can never claim."""
+    rec = _enqueue(repo, app=OTHER_APP)
+    assert rec.app == OTHER_APP
+    assert repo.get_by_id(rec.id).app == OTHER_APP
+
+
+def test_list_by_status_is_app_scoped(repo):
+    mine = _enqueue(repo, app=APP)
+    _enqueue(repo, app=OTHER_APP)
+
+    listed = repo.list_by_status(status=TaskStatus.PENDING, env=ENV, app=APP)
+
+    assert [t.id for t in listed] == [mine.id]
+
+
+def test_get_by_id_is_deliberately_not_app_scoped(repo):
+    """It is a primary-key read used for diagnosis and for reading back an
+    insert; the owner is on the record for a caller that needs to check it."""
+    theirs = _enqueue(repo, app=OTHER_APP)
+    assert repo.get_by_id(theirs.id).app == OTHER_APP
 
 
 def test_claim_honors_limit(repo):
@@ -289,8 +363,8 @@ def test_list_by_status_filters(repo):
     a = _enqueue(repo)
     b = _enqueue(repo)
     _claim(repo, "W", limit=1)
-    pending = repo.list_by_status(status=TaskStatus.PENDING, env=ENV)
-    running = repo.list_by_status(status=TaskStatus.RUNNING, env=ENV)
+    pending = repo.list_by_status(status=TaskStatus.PENDING, env=ENV, app=APP)
+    running = repo.list_by_status(status=TaskStatus.RUNNING, env=ENV, app=APP)
     assert {t.id for t in pending} | {t.id for t in running} == {a.id, b.id}
     assert len(running) == 1
 
@@ -361,6 +435,54 @@ def test_same_key_under_different_env_does_not_collide(repo):
 
     assert (a.created, b.created) == (True, True)
     assert a.record.id != b.record.id
+
+
+def test_same_key_under_different_app_is_rejected_while_the_legacy_index_lives(repo):
+    """Not the end state, and asserted as the intermediate one on purpose.
+
+    Dedup is scoped ``(env, app, task_type, key)`` in the code and in the new
+    unique index, so two apps using one key ought to be two rows. The deployed
+    table still carries the pre-``app`` index, which is unique on ``(env,
+    task_type, key)`` and ignores app, so the second app's INSERT is rejected
+    even though the key is free in its own scope.
+
+    The failure is loud and names the index to drop rather than joining the
+    other app's task (which this deployment could never claim) or reporting
+    contention (which points at the wrong fix)."""
+    first = _enqueue_result(repo, app=APP, idempotency_key="k1")
+
+    with pytest.raises(RuntimeError, match="uk_env_task_type_active_idempotency_key"):
+        _enqueue_result(repo, app=OTHER_APP, idempotency_key="k1")
+
+    assert len(_all_rows(repo)) == 1  # nothing inserted for the second app
+    assert repo.get_by_id(first.record.id).app == APP
+
+
+def test_a_foreign_app_key_is_free_again_once_its_holder_goes_terminal(repo):
+    """The contrast case: the rejection above is about a *live* holder, not
+    about the other app having ever used the key. A terminal row releases it,
+    and the second app then enqueues normally."""
+    first = _enqueue_result(repo, app=APP, idempotency_key="k1")
+    _claim(repo, "W", app=APP)
+    assert repo.complete(task_id=first.record.id, worker_id="W") is True
+
+    second = _enqueue_result(repo, app=OTHER_APP, idempotency_key="k1")
+
+    assert second.created is True
+    assert second.record.app == OTHER_APP
+
+
+def test_a_live_key_is_never_joined_across_apps(repo):
+    """The silent failure the app-scoped lookup rules out. Returning the other
+    app's live task with ``created=False`` would tell this deployment its work
+    was already in flight, while the row can only ever be claimed by the app
+    that owns it — so the work would simply never run."""
+    first = _enqueue_result(repo, app=APP, idempotency_key="k1")
+
+    with pytest.raises(RuntimeError):
+        _enqueue_result(repo, app=OTHER_APP, idempotency_key="k1")
+
+    assert repo.get_by_id(first.record.id).app == APP
 
 
 # ── enqueue idempotency: key release across terminal transitions ────────────
@@ -489,7 +611,7 @@ def test_repo_is_usable_after_a_caught_integrity_error(repo):
     assert _enqueue_result(repo, idempotency_key="k1").created is False  # conflict
 
     # Reads and writes both still work afterwards.
-    assert len(repo.list_by_status(status=TaskStatus.PENDING, env=ENV)) == 1
+    assert len(repo.list_by_status(status=TaskStatus.PENDING, env=ENV, app=APP)) == 1
     assert _enqueue_result(repo, idempotency_key="k2").created is True
     assert _enqueue(repo).id is not None
 
@@ -549,7 +671,7 @@ def test_three_consecutive_benign_races_still_enqueue(repo):
             raise IntegrityError(
                 "INSERT ...",
                 {},
-                Exception(f"Duplicate entry 'x' for key '{_ACTIVE_IDEM_INDEX}'"),
+                Exception(f"Duplicate entry 'x' for key '{_ACTIVE_IDEM_INDEXES[0]}'"),
             )
         return real_insert(**kwargs)
 
@@ -635,7 +757,9 @@ def test_key_is_stored_verbatim_without_stripping(repo):
 def test_validation_also_applies_through_the_service_facade(repo):
     """Adopters call TaskQueueService, so the guard must hold on that path too;
     it delegates to the repository, which is where the check lives."""
-    service = TaskQueueService(repo, HandlerRegistry(), WorkerWakeup())
+    service = TaskQueueService(
+        repo, HandlerRegistry(), WorkerWakeup(), TaskQueueConfig(app=APP)
+    )
     with pytest.raises(ValueError, match="exceeds"):
         service.enqueue(
             "demo", {}, 3600, idempotency_key="k" * (_MAX_IDEMPOTENCY_KEY_LEN + 1)
@@ -668,6 +792,54 @@ def test_key_columns_pin_binary_collation_on_mysql():
     for column in ("idempotency_key", "active_idempotency_key", "task_type"):
         line = next(ln for ln in ddl.splitlines() if ln.strip().startswith(column))
         assert "COLLATE utf8mb4_bin" in line, f"{column} lost its binary collation: {line}"
+
+
+def test_app_column_mirrors_the_deployed_ddl():
+    """The two literals that have to agree with the shipped table, and with each
+    other: the column default is what an INSERT naming no app lands on, and
+    ``TaskQueueConfig``'s default is what an un-configured deployment enqueues
+    *and* claims with. Were they to drift, that deployment would stamp one name
+    and look for another, and none of its own work would ever run."""
+    column = TaskQueueModel.__table__.c.app
+    # The literals are spelled out rather than taken from the constants: the
+    # deployed table says `app varchar(32) NOT NULL DEFAULT 'agentclaw'`, and a
+    # test that echoed the constants back would pass after either had been
+    # changed away from it.
+    assert column.type.length == 32 == MAX_APP_LEN
+    assert column.nullable is False
+    assert column.server_default.arg == "agentclaw" == DEFAULT_APP
+    assert TaskQueueConfig().app == DEFAULT_APP
+
+
+def test_app_scoped_indexes_lead_with_the_columns_every_query_filters_on():
+    """The claim scan and the reclaim scan both gained an ``app`` term, so the
+    indexes have to lead with it — otherwise the busiest statement the component
+    runs degrades to a scan. Asserted as column order, which is the part that
+    matters and the part an edit can silently break."""
+    by_name = {index.name: [c.name for c in index.columns] for index in TaskQueueModel.__table__.indexes}
+    assert by_name["idx_env_app_status_run_at"] == ["env", "app", "status", "run_at"]
+    assert by_name["idx_env_app_lease_expires_at"] == ["env", "app", "lease_expires_at"]
+    assert by_name["uk_env_app_task_type_active_idempotency_key"] == [
+        "env",
+        "app",
+        "task_type",
+        "active_idempotency_key",
+    ]
+
+
+def test_app_deliberately_keeps_the_default_collation():
+    """Same decision as ``env``, recorded for the same reason. ``app`` is a scope
+    column of the new unique index, but it comes from deployment config rather
+    than per-call input and the deployed DDL declares no collation for it — so
+    the ORM must not pin one either, or the two definitions diverge. The cost is
+    that app names differing only by case are one app on MySQL/OceanBase; give
+    deployments names that differ by more than that."""
+    from sqlalchemy.dialects import mysql
+    from sqlalchemy.schema import CreateTable
+
+    ddl = str(CreateTable(TaskQueueModel.__table__).compile(dialect=mysql.dialect()))
+    line = next(ln for ln in ddl.splitlines() if ln.strip().startswith("app "))
+    assert "COLLATE" not in line, f"app collation changed deliberately? {line}"
 
 
 def test_env_deliberately_keeps_the_default_collation():
@@ -806,7 +978,9 @@ def test_unkeyed_enqueue_still_accepts_any_task_type(repo, task_type):
 
 def test_padded_task_type_is_rejected_through_the_service_facade(repo):
     """Adopters call the service, so the guard has to hold on that path too."""
-    service = TaskQueueService(repo, HandlerRegistry(), WorkerWakeup())
+    service = TaskQueueService(
+        repo, HandlerRegistry(), WorkerWakeup(), TaskQueueConfig(app=APP)
+    )
     with pytest.raises(ValueError, match="leading or trailing whitespace"):
         service.enqueue("job ", {}, 3600, idempotency_key="k1")
     assert _all_rows(repo) == []


### PR DESCRIPTION
## Problem

A second, independently deployed backend now runs against the same `ac_task_queue` table. Both fleets' workers match only on `env`, so each claims the other's rows, finds no handler registered for the `task_type`, and fails the task terminally. Work that belongs to one deployment is destroyed by the other.

The table has already gained the owning-app column out of band:

```sql
`app` varchar(32) NOT NULL DEFAULT 'agentclaw' COMMENT 'app who owns the task'
```

along with `uk_env_app_task_type_active_idempotency_key`, `idx_env_app_status_run_at` and `idx_env_app_lease_expires_at`. This change teaches the queue to write that column and to match on it.

## Solution

**Config.** The owner is the deployment's own identity, so `ConfigModule.task_queue` reads the existing top-level `app_name` into a `TaskQueueConfig` — no queue-specific key, and therefore no second name that could drift from the first. `TaskQueueConfig` is deliberately not a field of `TaskQueueWorkerConfig`: the enqueue path needs the same value and has nothing to do with worker policy, and turning the worker off must not stop rows from being stamped with their owner.

A name that is *present* but unusable — empty, whitespace-padded, or over 32 characters — **raises** rather than falling back. The fallback is the accident worth preventing: the default is the *other* deployment's name as often as not, so a quiet substitution is precisely how one backend starts claiming another's work. `container.py` resolves `TaskQueueConfig` eagerly at build time (the treatment `HttpClientPoolConfig` already gets, for the same reason) so that raise stops the boot on every profile instead of being swallowed by lifecycle discovery, which would leave a running app with no worker and no explanation. No config at all — local mode, ad-hoc tests — falls back to the column default, since there is nothing there to have got wrong.

**Plumbing.** `TaskQueueService` stamps `app` on enqueue; `TaskWorker` claims with it. Both read the one config object, so the two sides cannot disagree within a process. `TaskQueueService.enqueue`'s public signature is unchanged, so no adopter call site changes.

**Repository.** `app` joins `env` in the claim eligibility predicate — and therefore in the claim CAS and in the deadline retirement inside the claim scan — in both dedup lookups, and in `list_by_status`. `get_by_id` stays unscoped: an id is unique across apps, it is how an insert is read back, and "what happened to task 71544?" is asked precisely when the owner is the question. `TaskRecord` now carries `app` for a caller that needs to check it.

**Dedup scope** becomes `(env, app, task_type, active_idempotency_key)`. The pre-app unique index is still on the deployed table and ignores `app`, so it can reject a keyed insert whose key is free in this app's own scope. Both index names are recognised as dedup conflicts; the rejection finds no holder in this app (another app's live task is never handed back — the caller could not claim it, so its work would silently never run) and ends in the existing exhausted-retries `RuntimeError`, whose message names the legacy index as the other possible cause. The case disappears when that index is dropped.

**ORM** mirrors the deployed DDL — the column, the app-scoped unique index, and the two app-scoped scan indexes, plus the legacy index the table still carries. Declaring the legacy index is deliberate: leaving it out would hide the cross-app rejection from SQLite and let it surface first in production. `app` keeps the table's default collation, like `env` and unlike the key columns, matching the DDL.

Rejected alternative: relying on the column's `DEFAULT 'agentclaw'` instead of writing `app` on insert. That works only for the one deployment whose name happens to be the default; any other would enqueue rows it could never claim.

## Validation

Run in this container with `uv`-installed deps (SQLite backing the integration tests, as the suite is designed). After the review round:

- `pytest tests/community/config tests/community/di tests/community/core/task_queue tests/community/repository tests/community/architecture` — **1326 passed, 5 skipped**
- `pytest tests/community/core/skill_center tests/community/core/skills_pool tests/community/core/session_resources tests/community/endpoints tests/community/e2e` — **2592 passed, 25 skipped**
- `flake8 --select E999,E902,E117,F405,E712,E701,E702,F821,F822,F823,F831` over the changed Python files (the `python_sast_local.sh` block rules) — clean.

Before the review round, `pytest tests/community/core tests/community/endpoints tests/community/adapters` gave **11470 passed, 55 skipped, 2 failed**; both failures are `test_bot_build_service_skill_artifact.py::test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_write_nfs[openclaw|claude_code]`, failing on `exec: rsync: not found` — environmental and unrelated to this diff. CI's Backend unit tests and Singlebox coverage were green on the first head.

New tests cover: claim ignores another app's pending row, its expired lease, and its past-deadline row (no cross-app `TIMED_OUT`); enqueue stamps the owner; `list_by_status` is scoped and `get_by_id` is not; the worker leaves another app's task alone end to end; the cross-app dedup rejection and its release once the holder goes terminal; the config provider's accept/reject cases plus a pin that it really reads the top-level `app_name`; and schema pins for the column's DDL literals, the app-scoped index column order, and the collation decision.

Golden effective-config snapshots regenerated with `tests.community.config.regen_golden`. That run also re-sorted `baas.eval_template_uuid` in `community.json` / `singlebox.json`, which a previous hand-edit had left out of the generator's key order; the snapshot test compares parsed JSON, so this is cosmetic.

Not run: the acceptance suites, which need a product stack this container cannot start.

## Compatibility and risk

**Schema:** already applied — the column and the three new indexes exist on the deployed table. No backfill: `app` is `NOT NULL DEFAULT 'agentclaw'`, so every pre-existing row takes the default, which is exactly the deployment that wrote it.

**Ordering that matters:** a deployment whose `app_name` is *not* the default must carry it **before** it starts enqueueing, since that name is what its own claims will look for. Two deployments must never share an `app_name` — that is back to fighting over the same rows — and, because the column takes the table's case-insensitive collation on MySQL/OceanBase, names must differ by more than case.

**`app_name` now re-scopes the queue.** Changing it after a deployment has enqueued leaves those rows under the old name, and that fleet stops claiming them. `application.yaml` records this next to the key.

**Config:** nothing new to set; a deployment that already has `app_name` keeps owning exactly the rows it already owned. A malformed value fails the boot by design.

**Follow-up, not in this PR:** drop `uk_env_task_type_active_idempotency_key` once every app writes its own `app`, and delete its declaration from `models.py` in the same change. Until then, two apps cannot use the same idempotency key for the same `task_type` in the same `env`; the second gets a `RuntimeError` naming the index. The README's Provisioning section records this.

**Rollback:** revert the commits. The column and indexes can stay — rows keep their `app` and pre-change code simply ignores it.