### PR TITLE
perf(backend): cache BaaS conn-info and skip destroyed sandboxes in cron fan-out

### DIFF
--- a/docs/superpowers/plans/2026-08-28-cron-fanout-caching.md
+++ b/docs/superpowers/plans/2026-08-28-cron-fanout-caching.md
@@ -1,0 +1,1016 @@
+# Cron Fan-out Caching (P0) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut the cron listing fan-out latency (measured 2.3–2.8 s on pre for `GET /openapi/v1/bots/routines/all`) with two process-level caches: a TTL cache for BaaS connection-info lookups (ws-info / http-info) and a negative cache that skips bindings whose adapter last failed with a "sandbox destroyed" verdict.
+
+**Architecture:** `CronRelayService.list_all_crons` fans out one adapter call per runtime target, and every target resolves BaaS connection info over HTTP (130–160 ms each, no reuse across requests — AntLogs trace `0b446a1717878836076095311e05a8`). The two caches attach at the two chokepoints this repo owns: `BaasService` (a DI singleton — every resolver/transport caller benefits) and `CronRuntimeTargetMixin` (the relay fetch path used by both `list_all_crons` and `list_running_crons`). The corp-profile `HttpDeviceAdapterTransport` itself lives out of this repo and is deliberately not touched.
+
+**Tech Stack:** Python 3.12, FastAPI backend (`src/backend`), pytest + LocalHttpClient/MockSeam stubs, `threading.Lock` + `time.monotonic` TTL pattern (precedent: `baas_invoke_transport._HTTP_INFO_TTL_SECONDS`).
+
+**Evidence base (2026-08-28 AntLogs, pre):** one 2833 ms request = ~675 ms invisible sync DB (bot list N+1) + ~551 ms stall + ~950 ms device queries + BaaS HTTP resolution + ~520 ms adapter GETs, of which 6×404 to destroyed sandboxes of the caller's own bot `20260703_mem5n5qd`. Response body 834 bytes. This plan ships the two P0s; the DB N+1 (P1) is a separate plan.
+
+**Design guardrails:**
+
+- TTL values follow the validated in-repo precedent: tokens minted by BaaS `ws-info`/`http-info` comfortably outlive 30 s (`baas_invoke_transport.py` comment). 30 s staleness of a connection URL is the accepted worst case.
+- The 401-refresh self-healing of `BaasInvokeTransport` must survive: the retry path gets a `force_refresh=True` bypass so a stale cached token is re-resolved, not replayed.
+- The negative cache is binding-level with a 60 s TTL: a bot whose instances are recreated heals within one TTL window; a healthy binding is never recorded (only bindings that *already* failed with the destroyed-sandbox signature are skipped).
+- Both caches are instance state on DI singletons, so they are process-local and lost on restart — no cross-process coherence problem.
+- No public-contract change: no OpenAPI surface, gateway, or schema edits. `failed_targets` gains a new `reason` value (`sandbox_destroyed_cached`), which is informational-only.
+
+---
+
+### Task 1: Create the feature branch
+
+**Files:** none
+
+- [ ] **Step 1: Branch from REL20260828**
+
+```bash
+cd /Users/rongzhi/PycharmProjects/Avernet
+git fetch origin REL20260828
+git switch -c feat/cron-fanout-caching-REL20260828 origin/REL20260828
+git log -1 --oneline   # expect 70061fa2c (REL20260828 tip)
+```
+
+---
+
+### Task 2: `BaasService.get_http_info` TTL cache
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py`
+- Test: `src/backend/tests/community/core/service_bot/services/test_baas_service_conn_info_cache.py` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/backend/tests/community/core/service_bot/services/test_baas_service_conn_info_cache.py`:
+
+```python
+"""TTL cache for BaasService connection-info lookups (ws-info / http-info).
+
+Evidence (2026-08-28 pre, trace 0b446a1717878836076095311e05a8): every cron
+fan-out target resolves BaaS http/ws info over HTTP (130-160 ms each) with no
+reuse across requests. BaasService is a DI singleton, so a 30 s process-level
+cache — the TTL already validated by ``baas_invoke_transport._HTTP_INFO_TTL_SECONDS``
+— serialises nothing and removes the per-request round trips.
+
+Covered here: hit on repeated params, miss on param variation, TTL expiry,
+errors not cached, ``force_refresh`` bypass, cap eviction, and the same set
+for ``get_ws_info_by_bot_uuid``.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.service_bot.services import baas_service as baas_module
+from agentclaw.community.core.service_bot.services.deploy.managed_composer import (
+    ManagedDeployConfigComposer,
+)
+from agentclaw.community.core.service_bot.services.baas_service import (
+    BaasService,
+    BaasServiceError,
+)
+from agentclaw.community.plugins.local.http_client import LocalHttpClient
+
+
+class _FakeClock:
+    """Stand-in for the ``time`` module, advanceable in tests."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+def _get_http_info_ok(response):
+    mock = MagicMock()
+    mock.raise_for_status.return_value = None
+    mock.json.return_value = {
+        "code": 0,
+        "data": {"http_url": "http://container:20010", "token": "tok", "target": "TGT"},
+    }
+    return mock
+
+
+def _make_service() -> tuple[BaasService, LocalHttpClient]:
+    http = LocalHttpClient(base_url="http://baas.test")
+    service = BaasService(
+        deploy_composer=ManagedDeployConfigComposer(
+            storage_path=MagicMock(),
+            sandbox_registry=MagicMock(),
+            bot_repo=MagicMock(),
+        ),
+        startup_script_reader=MagicMock(**{"get_body.return_value": ""}),
+        baas_api_base="http://baas.test",
+        tenant="tnt",
+        template_uuid="tpl",
+        bot_repo=MagicMock(),
+        bot_publish_repo=MagicMock(),
+        system_config_service=MagicMock(),
+        storage_path=MagicMock(),
+        device_binding_repo=MagicMock(),
+        default_ttl_minutes=10080,
+        sandbox_registry=MagicMock(),
+        http_client=http,
+        general_http_client=LocalHttpClient(base_url=""),
+        secret_resolver=MagicMock(),
+        common_whitelist_service=MagicMock(),
+        outbound_rule_provider=MagicMock(),
+    )
+    service._device_binding_repo.get_by_id.return_value = SimpleNamespace(
+        device_id="BOT-1"
+    )
+    return service, http
+
+
+def _stub_http_info_response(
+    http: LocalHttpClient, *, token: str = "tok"
+) -> None:
+    mock = MagicMock()
+    mock.raise_for_status.return_value = None
+    mock.json.return_value = {
+        "code": 0,
+        "data": {"http_url": "http://container:20010", "token": token, "target": "TGT"},
+    }
+    http.set_response("get", mock)
+
+
+@pytest.mark.unit
+def test_get_http_info_reuses_cached_result_between_calls():
+    service, http = _make_service()
+    _stub_http_info_response(http)
+
+    first = service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+    second = service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+
+    assert first is second
+    assert len(http.calls_to("get")) == 1
+
+
+@pytest.mark.unit
+def test_get_http_info_cache_key_distinguishes_params():
+    service, http = _make_service()
+    _stub_http_info_response(http)
+
+    service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+    service.get_http_info(bind_id=7, port=20010, path="/api/cron", device_uuid="DEV-2")
+    service.get_http_info(bind_id=8, port=20010, path="/api/cron")
+
+    assert len(http.calls_to("get")) == 3
+
+
+@pytest.mark.unit
+def test_get_http_info_cached_entry_expires_after_ttl(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr(baas_module, "time", clock)
+    service, http = _make_service()
+    _stub_http_info_response(http, token="tok-1")
+
+    service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+    clock.now += baas_module.BAAS_CONN_INFO_TTL_SECONDS + 1
+    _stub_http_info_response(http, token="tok-2")
+
+    result = service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+
+    assert result.token == "tok-2"
+    assert len(http.calls_to("get")) == 2
+
+
+@pytest.mark.unit
+def test_get_http_info_does_not_cache_failures():
+    service, http = _make_service()
+    boom = MagicMock()
+    boom.raise_for_status.return_value = None
+    boom.json.return_value = {"code": 1, "message": "BaaS exploded"}
+    http.set_response("get", boom)
+
+    with pytest.raises(BaasServiceError):
+        service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+
+    _stub_http_info_response(http)
+    result = service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+
+    assert result.token == "tok"
+    assert len(http.calls_to("get")) == 2
+
+
+@pytest.mark.unit
+def test_get_http_info_force_refresh_bypasses_cache():
+    service, http = _make_service()
+    _stub_http_info_response(http)
+
+    service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+    result = service.get_http_info(
+        bind_id=7, port=20010, path="/api/cron", force_refresh=True
+    )
+
+    assert result.token == "tok"
+    assert len(http.calls_to("get")) == 2
+
+
+@pytest.mark.contract
+def test_conn_info_cache_evicts_when_over_cap(monkeypatch):
+    monkeypatch.setattr(baas_module, "BAAS_CONN_INFO_CACHE_MAX_ENTRIES", 2)
+    service, http = _make_service()
+    _stub_http_info_response(http)
+    service._device_binding_repo.get_by_id.side_effect = lambda bid: SimpleNamespace(
+        device_id=f"BOT-{bid}"
+    )
+
+    service.get_http_info(bind_id=1, port=20010, path="/api/cron")
+    service.get_http_info(bind_id=2, port=20010, path="/api/cron")
+    service.get_http_info(bind_id=3, port=20010, path="/api/cron")  # cap hit -> clear
+    service.get_http_info(bind_id=1, port=20010, path="/api/cron")  # re-resolve
+
+    assert len(http.calls_to("get")) == 4
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/rongzhi/PycharmProjects/Avernet/src/backend
+uv run pytest tests/community/core/service_bot/services/test_baas_service_conn_info_cache.py -v
+```
+
+Expected: FAIL — `TypeError: get_http_info() got an unexpected keyword argument 'force_refresh'` (and `AttributeError: ... BAAS_CONN_INFO_TTL_SECONDS` for the eviction test).
+
+- [ ] **Step 3: Implement the cache**
+
+In `src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py`:
+
+3a. Add module constants after the existing `STARTUP_SCRIPT_LOG` constant block (near line 96):
+
+```python
+#: Process-level TTL for BaaS connection-info lookups (ws-info / http-info).
+#: The BaaS endpoints mint (url, token) pairs whose lifetime comfortably
+#: exceeds this window — the same 30 s already validated by
+#: ``baas_invoke_transport._HTTP_INFO_TTL_SECONDS`` — and a cron-relay fan-out
+#: resolves them per binding per request (measured 130-160 ms per round trip,
+#: pre 2026-08-28). Tokens that go stale anyway are recovered by the
+#: ``force_refresh`` bypass used on retry paths.
+BAAS_CONN_INFO_TTL_SECONDS = 30.0
+
+#: Hard cap on distinct cached lookups. Treats the cache as a small working
+#: set (active bindings × param variants), not an unbounded key space.
+BAAS_CONN_INFO_CACHE_MAX_ENTRIES = 512
+```
+
+3b. In `BaasService.__init__`, after `self._startup_script_reader = startup_script_reader` (near line 475):
+
+```python
+        # Connection-info caches (ws-info / http-info). Instance state on a
+        # DI singleton, so this is process-local and lost on restart. The lock
+        # guards only the dict read/update — NOT the HTTP call — so
+        # resolutions for different keys stay parallel and same-key misses at
+        # worst duplicate one call whose result the later writer overwrites.
+        # Errors are never cached, so a transient BaaS failure self-heals on
+        # the next call. Cached dataclass instances are shared: callers must
+        # treat them as read-only.
+        self._http_info_lock = threading.Lock()
+        self._http_info_cache: dict[tuple, tuple[float, HttpConnectionInfo]] = {}
+        self._ws_info_lock = threading.Lock()
+        self._ws_info_cache: dict[
+            tuple, tuple[float, BotWsConnectionInfoResponse]
+        ] = {}
+```
+
+3c. Add `import threading` to the import block (after `import time`, line 26).
+
+3d. Add the put helper as a private method (place it right before `get_http_info`, near line 3309):
+
+```python
+    def _conn_cache_put(
+        self,
+        lock: threading.Lock,
+        cache: dict,
+        key: tuple,
+        value: Any,
+    ) -> None:
+        """Store a successful connection-info result with a TTL, bounded."""
+        now = time.monotonic()
+        with lock:
+            if len(cache) >= BAAS_CONN_INFO_CACHE_MAX_ENTRIES:
+                for stale_key in [
+                    k for k, (deadline, _) in cache.items() if deadline <= now
+                ]:
+                    del cache[stale_key]
+                if len(cache) >= BAAS_CONN_INFO_CACHE_MAX_ENTRIES:
+                    # All live (recently written) but the key space still grew
+                    # past the cap — the working-set assumption is wrong, so
+                    # reset rather than silently grow unbounded.
+                    cache.clear()
+            cache[key] = (now + BAAS_CONN_INFO_TTL_SECONDS, value)
+```
+
+3e. Modify `get_http_info` signature (line 3309) to add the kwarg and the cache:
+
+```python
+    def get_http_info(
+        self,
+        *,
+        bind_id: int,
+        port: int,
+        path: str = "",
+        tenant: Optional[str] = None,
+        device_affinity: Optional[str] = None,
+        device_uuid: Optional[str] = None,
+        ws_conn_mode: Optional[str] = None,
+        timeout: float = 5.0,
+        force_refresh: bool = False,
+    ) -> HttpConnectionInfo:
+```
+
+Inside the body, insert after the docstring (before the `device_binding_repo` lookup, so a hit also skips the binding DB query):
+
+```python
+        cache_key = (
+            bind_id,
+            port,
+            path,
+            tenant or self._tenant,
+            device_affinity,
+            device_uuid,
+            ws_conn_mode,
+        )
+        if not force_refresh:
+            with self._http_info_lock:
+                cached = self._http_info_cache.get(cache_key)
+            if cached is not None and cached[0] > time.monotonic():
+                logger.info(
+                    "[BaasService.get_http_info] cache hit: bind_id=%s, "
+                    "expires_in=%.1fs",
+                    bind_id,
+                    cached[0] - time.monotonic(),
+                )
+                return cached[1]
+```
+
+And just before the final `return result` (after the `HttpConnectionInfo` is built, line ~3398):
+
+```python
+            self._conn_cache_put(
+                self._http_info_lock, self._http_info_cache, cache_key, result
+            )
+```
+
+Document the param in the docstring `Args:` block:
+
+```python
+            force_refresh: Bypass a fresh cache entry and re-resolve, overwriting
+                it. The 401-retry path of ``BaasInvokeTransport`` sets this so a
+                token that went stale inside the TTL is replaced instead of
+                replayed.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/community/core/service_bot/services/test_baas_service_conn_info_cache.py -v
+```
+
+Expected: 6 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/core/service_bot/services/baas_service.py ../../tests/community/core/service_bot/services/test_baas_service_conn_info_cache.py
+git commit -m "perf(backend): cache BaaS http-info lookups per (binding, params) with 30s TTL"
+```
+
+(Run the commit from `src/backend`; paths above are repo-relative — use `git add` from the repo root with the full paths shown in `git status`.)
+
+---
+
+### Task 3: Preserve the 401-refresh self-heal in `BaasInvokeTransport`
+
+**Why now, before ws-info caching:** without this, a token that expires inside the 30 s TTL is replayed instead of refreshed — the wait between the two cache tasks would ship a degraded intermediate state.
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/core/devices/services/baas_invoke_transport.py:160`
+- Test: `src/backend/tests/community/plugins/prod/test_baas_invoke_transport.py` (update 2 existing tests)
+
+- [ ] **Step 1: Update the two existing tests**
+
+In `test_http_info_resolution_carries_the_instance_identity` (line ~360), the assertion at the end becomes:
+
+```python
+    svc.get_http_info.assert_called_once_with(
+        bind_id=7,
+        port=20003,
+        path="/api/file/read",
+        tenant="team_claw",
+        device_uuid="DEV-xyz",
+        force_refresh=False,
+    )
+```
+
+In `test_rejected_token_refreshes_http_info_and_retries_once` (line ~384), add after the existing `get_http_info.call_count == 2` assertion:
+
+```python
+    assert [
+        c.kwargs.get("force_refresh") for c in svc.get_http_info.call_args_list
+    ] == [False, True]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest tests/community/plugins/prod/test_baas_invoke_transport.py -v
+```
+
+Expected: the two updated tests FAIL (call kwargs missing `force_refresh`).
+
+- [ ] **Step 3: Pass the bypass flag on the retry resolution**
+
+In `BaasInvokeTransport._http_info` (line ~160), change the `get_http_info` call:
+
+```python
+            info = self._baas_service.get_http_info(
+                bind_id=self._bind_id,
+                port=self._engine_port,
+                path=path,
+                tenant=self._tenant,
+                device_uuid=self._device_uuid,
+                # A retry means the caller was just rejected on this entry; the
+                # service-level TTL cache must hand back a fresh resolution,
+                # not the same stale token it still considers fresh.
+                force_refresh=stale is not None,
+            )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/community/plugins/prod/test_baas_invoke_transport.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "fix(backend): force-refresh BaaS http-info on 401 retry so the TTL cache never replays a stale token"
+```
+
+---
+
+### Task 4: `BaasService.get_ws_info_by_bot_uuid` TTL cache
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py:1891`
+- Test: `src/backend/tests/community/core/service_bot/services/test_baas_service_conn_info_cache.py` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `test_baas_service_conn_info_cache.py`:
+
+```python
+def _stub_ws_info_response(http: LocalHttpClient, *, token: str = "wtok") -> None:
+    mock = MagicMock()
+    mock.raise_for_status.return_value = None
+    mock.json.return_value = {
+        "code": 0,
+        "data": {
+            "ws_url": "ws://container:20003/api/openclaw/ws",
+            "token": token,
+            "target": "TGT",
+            "expires_at": "2099-01-01T00:00:00Z",
+        },
+    }
+    http.set_response("get", mock)
+
+
+@pytest.mark.unit
+def test_get_ws_info_by_bot_uuid_reuses_cached_result_between_calls():
+    service, http = _make_service()
+    _stub_ws_info_response(http)
+
+    first = service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+    second = service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+
+    assert first is second
+    assert len(http.calls_to("get")) == 1
+
+
+@pytest.mark.unit
+def test_get_ws_info_cache_key_distinguishes_params():
+    service, http = _make_service()
+    _stub_ws_info_response(http)
+
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-2")
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1", device_affinity="240841")
+
+    assert len(http.calls_to("get")) == 3
+
+
+@pytest.mark.unit
+def test_get_ws_info_cached_entry_expires_after_ttl(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr(baas_module, "time", clock)
+    service, http = _make_service()
+    _stub_ws_info_response(http, token="wtok-1")
+
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+    clock.now += baas_module.BAAS_CONN_INFO_TTL_SECONDS + 1
+    _stub_ws_info_response(http, token="wtok-2")
+
+    result = service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+
+    assert result.token == "wtok-2"
+    assert len(http.calls_to("get")) == 2
+
+
+@pytest.mark.unit
+def test_get_ws_info_by_bot_uuid_force_refresh_bypasses_cache():
+    service, http = _make_service()
+    _stub_ws_info_response(http)
+
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1", force_refresh=True)
+
+    assert len(http.calls_to("get")) == 2
+
+
+@pytest.mark.contract
+def test_get_ws_info_error_is_not_cached():
+    service, http = _make_service()
+    boom = MagicMock()
+    boom.raise_for_status.return_value = None
+    boom.json.return_value = {"code": 1, "message": "ws-info exploded"}
+    http.set_response("get", boom)
+
+    with pytest.raises(BaasServiceError):
+        service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+
+    _stub_ws_info_response(http)
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+
+    assert len(http.calls_to("get")) == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest tests/community/core/service_bot/services/test_baas_service_conn_info_cache.py -v
+```
+
+Expected: the 5 new tests FAIL with `TypeError: ... unexpected keyword argument 'force_refresh'`.
+
+- [ ] **Step 3: Implement**
+
+Modify `get_ws_info_by_bot_uuid` (line 1891) — signature gains `force_refresh: bool = False`; the cache check goes after `effective_tenant = tenant or self._tenant` and before the `logger.info(... "Getting ws info" ...)` line; the put goes right before the final `return result`:
+
+```python
+    def get_ws_info_by_bot_uuid(
+        self,
+        bot_uuid: str,
+        port: int = 20003,
+        path: str = "/api/openclaw/ws",
+        tenant: str = "",
+        device_affinity: Optional[str] = None,
+        device_uuid: Optional[str] = None,
+        ws_conn_mode: Optional[str] = None,
+        force_refresh: bool = False,
+    ) -> BotWsConnectionInfoResponse:
+```
+
+```python
+        effective_tenant = tenant or self._tenant
+        ws_cache_key = (
+            bot_uuid,
+            port,
+            path,
+            effective_tenant,
+            device_affinity,
+            device_uuid,
+            ws_conn_mode,
+        )
+        if not force_refresh:
+            with self._ws_info_lock:
+                cached = self._ws_info_cache.get(ws_cache_key)
+            if cached is not None and cached[0] > time.monotonic():
+                logger.info(
+                    "[BaasService.get_ws_info_by_bot_uuid] cache hit: "
+                    "bot_uuid=%s, expires_in=%.1fs",
+                    bot_uuid,
+                    cached[0] - time.monotonic(),
+                )
+                return cached[1]
+```
+
+```python
+            self._conn_cache_put(
+                self._ws_info_lock, self._ws_info_cache, ws_cache_key, result
+            )
+            return result
+```
+
+Also document `force_refresh` in the `Args:` docstring block (same wording as `get_http_info`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/community/core/service_bot/services/test_baas_service_conn_info_cache.py tests/community/core/devices/services/../../plugins/prod/test_baas_invoke_transport.py -v
+```
+
+Expected: all PASS. Also run the ws-info consumer suites for regressions:
+
+```bash
+uv run pytest tests/community/core/cron -q && uv run pytest tests/community/core/grt_chat -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git commit -am "perf(backend): cache BaaS ws-info lookups with the shared 30s connection-info TTL"
+```
+
+---
+
+### Task 5: Destroyed-sandbox negative cache in the cron fan-out
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/core/cron/services/cron_runtime_targets.py`
+- Modify: `src/backend/src/agentclaw/community/core/cron/services/cron_relay.py:90-93`
+- Test: `src/backend/tests/community/core/cron/services/test_cron_relay_sandbox_skip.py` (new)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/backend/tests/community/core/cron/services/test_cron_relay_sandbox_skip.py`:
+
+```python
+"""Binding-level negative cache for destroyed sandboxes in the cron fan-out.
+
+Pre 2026-08-28 evidence: a bot's instances get reclaimed while the binding row
+stays ACTIVE, and every listing/running fan-out then pays a 404 precheck round
+trip per destroyed instance, forever (trace 0b446a1717878836076095311e05a8:
+6 destroyed sandboxes of the caller's own bot per request). The relay is a
+singleton, so a binding-keyed "sandbox destroyed" verdict with a short TTL
+skips the prepare+invoke chain until it expires.
+
+Covered: verdict recorded from both failure shapes (error dict / raised
+exception), skip skips the transport, TTL expiry re-invokes, non-destroyed
+failures are never recorded, and ``list_all_crons`` surfaces the skip as a
+failed target with an explicit reason.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentclaw.community.core.cron.services import cron_runtime_targets
+from agentclaw.community.core.cron.services.cron_relay import CronRelayService
+from agentclaw.community.core.cron.services.cron_runtime_targets import (
+    CronRuntimeTarget,
+)
+
+
+_DESTROYED_MSG = (
+    'Adapter returned HTTP 404: {"message":"报错类型: 沙箱已销毁, err=sandbox destroyed"}'
+)
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 2000.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+def _make_service(*, transport_invoke: AsyncMock) -> CronRelayService:
+    svc = CronRelayService(
+        bot_provider=MagicMock(),
+        device_provider=MagicMock(),
+        transport=MagicMock(),
+        resolver=MagicMock(),
+        template_repo=MagicMock(),
+        publish_repo=MagicMock(),
+    )
+    ctx = MagicMock()
+    ctx.conn_info = {"url": "http://adapter"}
+    svc._prepare_runtime_query_async = AsyncMock(return_value=(ctx, None))
+    svc._invoke_transport = transport_invoke
+    return svc
+
+
+def _target(binding_id: int = 1) -> CronRuntimeTarget:
+    return CronRuntimeTarget(
+        bot_id="bot-1",
+        bot_name="bot-1",
+        owner_id="user-1",
+        bot_type="service",
+        runtime_stage="draft",
+        binding_id=binding_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_destroyed_sandbox_failure_marks_binding():
+    invoke = AsyncMock(
+        return_value={"success": False, "error": _DESTROYED_MSG}
+    )
+    svc = _make_service(transport_invoke=invoke)
+
+    result = await svc._fetch_runtime_target_crons(_target(1), "user-1")
+
+    assert result["reason"] == "cron_api_failed"
+    assert 1 in svc._sandbox_down_until
+
+
+@pytest.mark.asyncio
+async def test_destroyed_sandbox_exception_marks_binding():
+    invoke = AsyncMock(side_effect=ValueError(_DESTROYED_MSG))
+    svc = _make_service(transport_invoke=invoke)
+
+    result = await svc._fetch_runtime_target_crons(_target(2), "user-1")
+
+    assert result["reason"] == "cron_api_failed"
+    assert 2 in svc._sandbox_down_until
+
+
+@pytest.mark.asyncio
+async def test_second_fetch_within_ttl_skips_transport():
+    invoke = AsyncMock(
+        return_value={"success": True, "data": []}
+    )
+    svc = _make_service(transport_invoke=invoke)
+    svc._sandbox_down_until[7] = (
+        cron_runtime_targets.time.monotonic()
+        + cron_runtime_targets.SANDBOX_DESTROYED_TTL_SECONDS
+    )
+
+    result = await svc._fetch_runtime_target_crons(_target(7), "user-1")
+
+    assert result["success"] is False
+    assert result["reason"] == "sandbox_destroyed_cached"
+    invoke.assert_not_awaited()
+    # prepare (device query + resolution) is skipped too — that is the win.
+    svc._prepare_runtime_query_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_verdict_expires_after_ttl(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr(cron_runtime_targets, "time", clock)
+    invoke = AsyncMock(
+        return_value={"success": False, "error": _DESTROYED_MSG}
+    )
+    svc = _make_service(transport_invoke=invoke)
+
+    await svc._fetch_runtime_target_crons(_target(3), "user-1")
+    clock.now += cron_runtime_targets.SANDBOX_DESTROYED_TTL_SECONDS + 1
+
+    await svc._fetch_runtime_target_crons(_target(3), "user-1")
+
+    assert invoke.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_plain_failures_are_never_recorded():
+    invoke = AsyncMock(
+        return_value={"success": False, "error": "Adapter returned HTTP 500"}
+    )
+    svc = _make_service(transport_invoke=invoke)
+
+    await svc._fetch_runtime_target_crons(_target(4), "user-1")
+    await svc._fetch_runtime_target_crons(_target(4), "user-1")
+
+    assert invoke.await_count == 2
+    assert not svc._sandbox_down_until
+
+
+@pytest.mark.asyncio
+async def test_list_all_crons_surfaces_skip_as_failed_target():
+    invoke = AsyncMock(
+        return_value={"success": False, "error": _DESTROYED_MSG}
+    )
+    svc = _make_service(transport_invoke=invoke)
+    bot_provider = svc._bot_provider
+    bot_provider.list_bots_by_owner_or_collaborator.return_value = {
+        "total": 1,
+        "items": [
+            {
+                "bot_id": "bot-1",
+                "bot_name": "bot-1",
+                "owner_id": "user-1",
+                "bot_type": "service",
+                "binding_id": 1,
+            }
+        ],
+    }
+    svc._build_runtime_targets = MagicMock(return_value=([_target(1)], []))
+
+    first = await svc.list_all_crons(user_id="user-1", nick_name="user-1")
+    second = await svc.list_all_crons(user_id="user-1", nick_name="user-1")
+
+    assert invoke.await_count == 1
+    reasons_first = [f["reason"] for f in first["failed_targets"]]
+    reasons_second = [f["reason"] for f in second["failed_targets"]]
+    assert reasons_first == ["cron_api_failed"]
+    assert reasons_second == ["sandbox_destroyed_cached"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+uv run pytest tests/community/core/cron/services/test_cron_relay_sandbox_skip.py -v
+```
+
+Expected: FAIL — `AttributeError: 'CronRelayService' object has no attribute '_sandbox_down_until'` and `No Attribute SANDBOX_DESTROYED_TTL_SECONDS` on the module.
+
+- [ ] **Step 3: Implement the negative cache**
+
+3a. In `cron_runtime_targets.py`:
+
+Add `import time` to the imports (after `import asyncio`).
+
+Add after `RUNTIME_QUERY_PREPARE_CONCURRENCY = 8`:
+
+```python
+#: How long a binding's "sandbox destroyed" verdict suppresses its queries.
+#: ARCA/BaaS instances are reclaimed while the binding row stays ACTIVE, and a
+#: listing fan-out would otherwise replay a guaranteed 404 per destroyed
+#: instance on every request (pre 2026-08-28: 6 dead sandboxes of one bot per
+#: request). The window is short so a recreated sandbox becomes visible again
+#: within roughly one console polling cycle.
+SANDBOX_DESTROYED_TTL_SECONDS = 60.0
+
+#: Substrings that identify the destroyed-sandbox verdict in adapter error
+#: payloads (both spellings observed in pre logs, message is matched
+#: case-insensitively).
+_SANDBOX_DESTROYED_MARKERS = ("沙箱已销毁", "sandbox destroyed")
+
+
+def _mentions_destroyed_sandbox(message: str) -> bool:
+    lowered = message.lower()
+    return any(marker in lowered for marker in _SANDBOX_DESTROYED_MARKERS)
+```
+
+Add two mixin methods (place next to `_prepare_runtime_query_async`, before `_fetch_runtime_target_crons`):
+
+```python
+    # ── 沙箱已销毁负缓存 ─────────────────────────────────────────
+
+    def _sandbox_down_deadline(self, binding_id: int) -> float | None:
+        """Return the live skip-deadline for a binding, else ``None``.
+
+        Expired entries are dropped here (lazy TTL) — the map only ever
+        holds bindings that failed recently, so it stays tiny.
+        """
+        deadline = self._sandbox_down_until.get(binding_id)
+        if deadline is None:
+            return None
+        if deadline <= time.monotonic():
+            del self._sandbox_down_until[binding_id]
+            return None
+        return deadline
+
+    def _mark_sandbox_down(self, binding_id: int) -> None:
+        self._sandbox_down_until[binding_id] = (
+            time.monotonic() + SANDBOX_DESTROYED_TTL_SECONDS
+        )
+```
+
+Extend `_fetch_runtime_target_crons` (line ~310). Insert at the top of the body, before `ctx, failure = await self._prepare_runtime_query_async(target)`:
+
+```python
+        deadline = self._sandbox_down_deadline(target.binding_id)
+        if deadline is not None:
+            logger.info(
+                "[_fetch_runtime_target_crons] Skip bot=%s stage=%s "
+                "binding=%s: sandbox-destroyed verdict cached (%.0fs left)",
+                target.bot_id,
+                target.runtime_stage,
+                target.binding_id,
+                deadline - time.monotonic(),
+            )
+            return {
+                "success": False,
+                "reason": "sandbox_destroyed_cached",
+                "error": (
+                    f"skipped: binding {target.binding_id} failed with a "
+                    f"sandbox-destroyed verdict within the last "
+                    f"{SANDBOX_DESTROYED_TTL_SECONDS:g}s"
+                ),
+            }
+```
+
+In the same method's failure paths, record the verdict. The exception branch becomes:
+
+```python
+        except Exception as e:
+            logger.error(
+                "[_fetch_runtime_target_crons] Adapter request failed for "
+                "bot=%s stage=%s: %s",
+                target.bot_id,
+                target.runtime_stage,
+                e,
+            )
+            if _mentions_destroyed_sandbox(str(e)):
+                self._mark_sandbox_down(target.binding_id)
+            return {"success": False, "reason": "cron_api_failed", "error": str(e)}
+```
+
+And the non-success branch after `_invoke_transport`:
+
+```python
+        if not result.get("success", True):
+            error_text = str(
+                result.get("message") or result.get("error") or "cron api failed"
+            )
+            if _mentions_destroyed_sandbox(error_text):
+                self._mark_sandbox_down(target.binding_id)
+            return {
+                "success": False,
+                "reason": "cron_api_failed",
+                "error": error_text,
+            }
+```
+
+3b. In `cron_relay.py` `__init__`, after the `_runtime_query_prepare_semaphore` assignment (line ~93):
+
+```python
+        # 沙箱已销毁负缓存：binding 级"实例已被回收"判决，TTL 内跳过该
+        # binding 的查询与转发（方法定义在 CronRuntimeTargetMixin）。
+        # 实例被重建后最多一个 TTL 窗口内列表仍报该 binding 失败。
+        self._sandbox_down_until: dict[int, float] = {}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+uv run pytest tests/community/core/cron -v
+```
+
+Expected: all cron suites PASS (including the pre-existing files: `test_cron_relay_list_stage_filter.py`, `test_cron_relay_uses_resolver.py`, `test_cron_relay_find_auto_initiate.py`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/core/cron/services/cron_runtime_targets.py src/agentclaw/community/core/cron/services/cron_relay.py ../../../tests/community/core/cron/services/test_cron_relay_sandbox_skip.py
+git commit -m "perf(backend): skip bindings with a cached sandbox-destroyed verdict in cron fan-out"
+```
+
+(From the repo root: `git add src/backend/...` with full paths.)
+
+---
+
+### Task 6: Full suite + changed-line coverage gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the backend CI gate locally**
+
+Per repo convention the changed-line coverage gate only reproduces locally via `ci_test.sh`:
+
+```bash
+cd /Users/rongzhi/PycharmProjects/Avernet/src/backend
+BACKEND_CI_PYTEST_WORKERS=4 scripts/ci_test.sh --base origin/REL20260828
+```
+
+Expected: pytest passes, coverage gate passes (≥75 line / changed-line thresholds from `report_check.py`).
+
+- [ ] **Step 2: Fix any fallout**
+
+If unrelated pre-existing tests fail, verify they also fail on clean `origin/REL20260828` before touching anything (`git stash && scripts/ci_test.sh ... && git stash pop`). Only fix fallout caused by these changes:
+
+- Uncached-behaviour assumptions in `tests/community/core/grt_chat`, `tests/community/core/devices`, or singlebox flows → the cache is TTL-30-s; tests that call ws/http-info repeatedly with the same params and expect per-call HTTP counts need either distinct params, `force_refresh=True`, or a fresh `BaasService` per case (they already construct their own).
+
+- [ ] **Step 3: Commit any fallout fixes**
+
+```bash
+git commit -am "test(backend): adapt conn-info caching consumers to the 30s TTL"
+```
+
+---
+
+### Task 7: Validation summary (no push)
+
+- [ ] **Step 1: Collect the evidence**
+
+```bash
+git log --oneline origin/REL20260828..HEAD
+git diff origin/REL20260828..HEAD --stat
+```
+
+- [ ] **Step 2: Do NOT push or open a PR** — report back with the locally-built summary including the measured expected effect (per the 2026-08-28 trace: ~5-6 secbaas round trips + 6 destroyed-sandbox 404 chains per listing request are the dominant removable latency; target is bringing the 2.8 s pre worst case under ~1 s) and propose deploying to pre before measuring again via AntLogs (`list_all_crons` + access RT for `/openapi/v1/bots/routines/all`, the same queries this plan was diagnosed with).
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** P0-1 (Tasks 2–4: http-info cache, retry self-heal, ws-info cache), P0-2 (Task 5). P1 lean-bot-list / batched publish queries are explicitly deferred to a separate plan.
+- **Type consistency:** cache tuple type is `(float, dataclass)` in both caches; `_conn_cache_put` is generic over it; `force_refresh` keyword is identical in `get_http_info` / `get_ws_info_by_bot_uuid`.
+- **No placeholders:** every step carries the full code or exact command.
+- **Known accepted risk (documented in-code):** a corp-profile `HttpDeviceAdapterTransport` live out of this repo also consumes `get_http_info`; if it has its own 401-retry it will now read the 30 s cache. Token lifetimes exceed the TTL (in-repo validated precedent), bounding the risk window; the guerrilla fix for that consumer would be `force_refresh` plumbing on its side.

--- a/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_relay.py
@@ -91,6 +91,10 @@ class CronRelayService(CronRuntimeOperationsMixin, CronRuntimeTargetMixin):
         self._runtime_query_prepare_semaphore = asyncio.Semaphore(
             RUNTIME_QUERY_PREPARE_CONCURRENCY
         )
+        # 沙箱已销毁负缓存：binding 级"实例已被回收"判决，TTL 内跳过该
+        # binding 的查询与转发（方法定义在 CronRuntimeTargetMixin）。
+        # 实例被重建后最多一个 TTL 窗口内列表仍报该 binding 失败。
+        self._sandbox_down_until: dict[int, float] = {}
 
     async def list_all_crons(
         self,

--- a/src/backend/src/agentclaw/community/core/cron/services/cron_runtime_targets.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_runtime_targets.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from dataclasses import dataclass, replace
 from typing import Any, Optional
 
@@ -33,6 +34,23 @@ CRON_READ_TIMEOUT_SECONDS = 10.0
 RUNTIME_DEVICE_QUERY_TIMEOUT_SECONDS = 10.0
 RUNTIME_DEVICE_QUERY_CONCURRENCY = 8
 RUNTIME_QUERY_PREPARE_CONCURRENCY = 8
+
+#: How long a binding's "sandbox destroyed" verdict suppresses its queries.
+#: ARCA/BaaS instances are reclaimed while the binding row stays ACTIVE, and a
+#: listing fan-out would otherwise replay a guaranteed 404 per destroyed
+#: instance on every request (pre 2026-08-28: 6 dead sandboxes of one bot per
+#: request). The window is short so a recreated sandbox becomes visible again
+#: within roughly one console polling cycle.
+SANDBOX_DESTROYED_TTL_SECONDS = 60.0
+
+#: Substrings that identify the destroyed-sandbox verdict in adapter error
+#: payloads (both spellings observed in pre logs; matched case-insensitively).
+_SANDBOX_DESTROYED_MARKERS = ("沙箱已销毁", "sandbox destroyed")
+
+
+def _mentions_destroyed_sandbox(message: str) -> bool:
+    lowered = message.lower()
+    return any(marker in lowered for marker in _SANDBOX_DESTROYED_MARKERS)
 
 
 @dataclass(frozen=True)
@@ -307,6 +325,28 @@ class CronRuntimeTargetMixin:
         async with self._runtime_query_prepare_semaphore:
             return await asyncio.to_thread(self._prepare_runtime_query, target)
 
+    # ── 沙箱已销毁负缓存 ──────────────────────────────────────────
+
+    def _sandbox_down_deadline(self, binding_id: int) -> float | None:
+        """Return the live skip-deadline for a binding, else ``None``.
+
+        Expired entries are dropped here (lazy TTL) — the map only ever
+        holds bindings that failed recently, so it stays tiny.
+        """
+        deadline = self._sandbox_down_until.get(binding_id)
+        if deadline is None:
+            return None
+        if deadline <= time.monotonic():
+            del self._sandbox_down_until[binding_id]
+            return None
+        return deadline
+
+    def _mark_sandbox_down(self, binding_id: int) -> None:
+        """Record a destroyed-sandbox verdict for a binding."""
+        self._sandbox_down_until[binding_id] = (
+            time.monotonic() + SANDBOX_DESTROYED_TTL_SECONDS
+        )
+
     async def _fetch_runtime_target_crons(
         self,
         target: CronRuntimeTarget,
@@ -314,6 +354,26 @@ class CronRuntimeTargetMixin:
         path: str = "/api/cron",
     ) -> dict:
         """读取单个运行态目标的 cron 列表或运行中任务。"""
+        deadline = self._sandbox_down_deadline(target.binding_id)
+        if deadline is not None:
+            logger.info(
+                "[_fetch_runtime_target_crons] Skip bot=%s stage=%s "
+                "binding=%s: sandbox-destroyed verdict cached (%.0fs left)",
+                target.bot_id,
+                target.runtime_stage,
+                target.binding_id,
+                deadline - time.monotonic(),
+            )
+            return {
+                "success": False,
+                "reason": "sandbox_destroyed_cached",
+                "error": (
+                    f"skipped: binding {target.binding_id} failed with a "
+                    f"sandbox-destroyed verdict within the last "
+                    f"{SANDBOX_DESTROYED_TTL_SECONDS:g}s"
+                ),
+            }
+
         ctx, failure = await self._prepare_runtime_query_async(target)
         if failure is not None:
             return failure
@@ -345,13 +405,20 @@ class CronRuntimeTargetMixin:
                 target.runtime_stage,
                 e,
             )
+            if _mentions_destroyed_sandbox(str(e)):
+                self._mark_sandbox_down(target.binding_id)
             return {"success": False, "reason": "cron_api_failed", "error": str(e)}
 
         if not result.get("success", True):
+            error_text = str(
+                result.get("message") or result.get("error") or "cron api failed"
+            )
+            if _mentions_destroyed_sandbox(error_text):
+                self._mark_sandbox_down(target.binding_id)
             return {
                 "success": False,
                 "reason": "cron_api_failed",
-                "error": result.get("message") or result.get("error") or "cron api failed",
+                "error": error_text,
             }
 
         return result

--- a/src/backend/src/agentclaw/community/core/cron/services/cron_runtime_targets.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_runtime_targets.py
@@ -347,6 +347,21 @@ class CronRuntimeTargetMixin:
             time.monotonic() + SANDBOX_DESTROYED_TTL_SECONDS
         )
 
+    def clear_sandbox_down_verdict(self, binding_id: int) -> bool:
+        """Drop a binding's destroyed-sandbox verdict; ``True`` if it existed.
+
+        The counter-evidence to a "sandbox destroyed" verdict is a live
+        instance on that binding, which is exactly what DeviceActivatedEvent
+        announces — ``CronSandboxRevivalListener`` calls this from the event
+        handler so an auto_setup idempotency check (client-side, name-based,
+        blind to ``failed_targets``) immediately sees the rebuilt sandbox's
+        crons and never duplicates an autoInitiate task. ``dict.pop`` is
+        GIL-atomic, so an event-handler thread clearing while the event loop
+        marks a fresh verdict cannot corrupt the map; a verdict lost to that
+        interleaving simply re-arms on the next destroyed-sandbox failure.
+        """
+        return self._sandbox_down_until.pop(binding_id, None) is not None
+
     async def _fetch_runtime_target_crons(
         self,
         target: CronRuntimeTarget,

--- a/src/backend/src/agentclaw/community/core/cron/services/cron_sandbox_revival_listener.py
+++ b/src/backend/src/agentclaw/community/core/cron/services/cron_sandbox_revival_listener.py
@@ -1,0 +1,80 @@
+"""Event listener: 新沙箱激活时撤销 binding 的"沙箱已销毁"判决。
+
+背景（PR #1635 评审 P0）：CronRuntimeTargetMixin 的 binding 级负缓存（60 s）
+会跳过最近被判"沙箱已销毁"的 binding。一次重启/republish 里，销毁 gap 内
+的轮询可能先把 binding 打上死亡判决，随后新沙箱在同一 binding 上激活并触发
+DeviceActivatedEvent；若判决不清除，``cron_auto_setup`` 的同名幂等检查
+（只读 ``list_all_crons`` 的 ``data``，感知不到 failed_targets/skip）会在活
+沙箱上重复创建 autoInitiate 任务。
+
+"沙箱激活"正是死亡判决的反证：订阅 ``DeviceActivatedEvent``，事件到达即调
+``CronRelayService.clear_sandbox_down_verdict``。组件通过 DI 绑定 +
+``discover_lifecycle_participants`` 参与 startup，模式与
+``CronAutoSetupListener`` 一致。
+"""
+from __future__ import annotations
+
+from injector import inject
+
+from agentclaw.community.core.cron.services.cron_relay import CronRelayService
+from agentclaw.community.core.events.types import DeviceActivatedEvent
+from agentclaw.community.kernel.lifecycle import LifecycleBase
+from agentclaw.community.log import get_logger
+
+logger = get_logger()
+
+
+class CronSandboxRevivalListener(LifecycleBase):
+    """DeviceActivatedEvent listener that revives a binding's cron queries."""
+
+    @inject
+    def __init__(self, cron_relay: CronRelayService) -> None:
+        # Concrete class on purpose: the injector resolves CronRelayService via
+        # its cron_module self-binding (same style as CronRelayService's own
+        # constructor params).
+        self._cron_relay = cron_relay
+
+    async def startup(self) -> None:
+        """Lifecycle hook — subscribe ``self._handle`` to DeviceActivatedEvent.
+
+        Idempotent: re-runs are safe (membership check before subscribe).
+        """
+        from agentclaw.community.core.events.bus import get_event_bus
+
+        bus = get_event_bus()
+        existing = bus._handlers.get(DeviceActivatedEvent, [])  # type: ignore[attr-defined]
+        if self._handle in existing:
+            logger.info(
+                "[cron_sandbox_revival_listener] already subscribed to "
+                "DeviceActivatedEvent"
+            )
+            return
+        bus.subscribe(DeviceActivatedEvent, self._handle)
+        logger.info("[cron_sandbox_revival_listener] subscribed to DeviceActivatedEvent")
+
+    def _handle(self, event: DeviceActivatedEvent) -> None:
+        """DeviceActivatedEvent 事件处理器：撤销该 binding 的死亡判决。"""
+        try:
+            cleared = self._cron_relay.clear_sandbox_down_verdict(event.binding_id)
+            if cleared:
+                logger.info(
+                    "[cron_sandbox_revival_listener] sandbox revived: cleared "
+                    "destroyed-sandbox verdict for binding_id=%s (device_id=%s)",
+                    event.binding_id,
+                    event.device_id,
+                )
+            else:
+                logger.debug(
+                    "[cron_sandbox_revival_listener] activation for binding_id=%s "
+                    "had no verdict to clear",
+                    event.binding_id,
+                )
+        except Exception as e:
+            # 一个 handler 不允许拖垮事件总线循环；判决若真的没清掉，
+            # 60 s TTL 本身就是自愈兜底，这里只告警。
+            logger.warning(
+                "[cron_sandbox_revival_listener] failed to clear verdict for "
+                "binding_id=%s: %s",
+                event.binding_id,
+                e,
+            )

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_invoke_transport.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_invoke_transport.py
@@ -163,6 +163,10 @@ class BaasInvokeTransport:
                 path=path,
                 tenant=self._tenant,
                 device_uuid=self._device_uuid,
+                # A retry means the caller was just rejected on this entry; the
+                # service-level TTL cache must hand back a fresh resolution,
+                # not the same stale token it still considers fresh.
+                force_refresh=stale is not None,
             )
             self._http_info_cache[path] = (
                 time.monotonic() + _HTTP_INFO_TTL_SECONDS,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 import base64
 import re
+import threading
 import time
 
 import httpx
@@ -94,6 +95,19 @@ ENGINE_DIR_MOUNT_WHITELIST_BUSINESS_CODE = "nas_mount"
 #: across restarts and outlive a DELETE of the script; and an unpredictable
 #: name owned by ``admin`` cannot be pre-created by anyone else.
 STARTUP_SCRIPT_LOG = "/home/admin/logs/startup_script.log"
+
+#: Process-level TTL for BaaS connection-info lookups (ws-info / http-info).
+#: The BaaS endpoints mint (url, token) pairs whose lifetime comfortably
+#: exceeds this window — the same 30 s already validated by
+#: ``baas_invoke_transport._HTTP_INFO_TTL_SECONDS`` — and a cron-relay fan-out
+#: resolves them per binding per request (measured 130-160 ms per round trip,
+#: pre 2026-08-28). Tokens that go stale anyway are recovered by the
+#: ``force_refresh`` bypass used on retry paths.
+BAAS_CONN_INFO_TTL_SECONDS = 30.0
+
+#: Hard cap on distinct cached lookups. Treats the cache as a small working
+#: set (active bindings × param variants), not an unbounded key space.
+BAAS_CONN_INFO_CACHE_MAX_ENTRIES = 512
 
 #: Separates the platform boot chain from the per-bot user stage, and the marker
 #: log redaction splits on so the platform half stays readable.
@@ -473,6 +487,20 @@ class BaasService:  # pragma: no cover
         # feature guards against elsewhere. Required, that mistake is a
         # TypeError naming the argument at construction.
         self._startup_script_reader = startup_script_reader
+        # Connection-info caches (ws-info / http-info). Instance state on a
+        # DI singleton, so this is process-local and lost on restart. The lock
+        # guards only the dict read/update — NOT the HTTP call — so
+        # resolutions for different keys stay parallel and same-key misses at
+        # worst duplicate one call whose result the later writer overwrites.
+        # Errors are never cached, so a transient BaaS failure self-heals on
+        # the next call. Cached dataclass instances are shared: callers must
+        # treat them as read-only.
+        self._http_info_lock = threading.Lock()
+        self._http_info_cache: dict[tuple, tuple[float, HttpConnectionInfo]] = {}
+        self._ws_info_lock = threading.Lock()
+        self._ws_info_cache: dict[
+            tuple, tuple[float, BotWsConnectionInfoResponse]
+        ] = {}
 
     def post_bots_api(
         self,
@@ -3306,6 +3334,28 @@ class BaasService:  # pragma: no cover
             )
             return None
 
+    def _conn_cache_put(
+        self,
+        lock: threading.Lock,
+        cache: dict,
+        key: tuple,
+        value: Any,
+    ) -> None:
+        """Store a successful connection-info result with a TTL, bounded."""
+        now = time.monotonic()
+        with lock:
+            if len(cache) >= BAAS_CONN_INFO_CACHE_MAX_ENTRIES:
+                for stale_key in [
+                    k for k, (deadline, _) in cache.items() if deadline <= now
+                ]:
+                    del cache[stale_key]
+                if len(cache) >= BAAS_CONN_INFO_CACHE_MAX_ENTRIES:
+                    # All entries live (recently written) but the key space
+                    # still grew past the cap — the working-set assumption is
+                    # wrong, so reset rather than silently grow unbounded.
+                    cache.clear()
+            cache[key] = (now + BAAS_CONN_INFO_TTL_SECONDS, value)
+
     def get_http_info(
         self,
         *,
@@ -3317,6 +3367,7 @@ class BaasService:  # pragma: no cover
         device_uuid: Optional[str] = None,
         ws_conn_mode: Optional[str] = None,
         timeout: float = 5.0,
+        force_refresh: bool = False,
     ) -> HttpConnectionInfo:
         """获取容器 HTTP 连接信息。
 
@@ -3333,6 +3384,10 @@ class BaasService:  # pragma: no cover
                 活跃实例。与 ``get_ws_info`` 的 ``device_uuid`` 参数对称 —— 文件
                 读写等经 invoke_http 的链路用它把实例选择传达到 BaaS /http-info。
             timeout: HTTP 请求超时（秒）
+            force_refresh: Bypass a fresh cache entry and re-resolve, overwriting
+                it. The 401-retry path of ``BaasInvokeTransport`` sets this so a
+                token that went stale inside the TTL is replaced instead of
+                replayed.
 
         Returns:
             HttpConnectionInfo: HTTP 连接信息 (http_url, token)
@@ -3340,6 +3395,27 @@ class BaasService:  # pragma: no cover
         Raises:
             BaasServiceError: BaaS 不可达 / 404 / 5xx / 网络 / 超时 / 业务 code≠0
         """
+        cache_key = (
+            bind_id,
+            port,
+            path,
+            tenant or self._tenant,
+            device_affinity,
+            device_uuid,
+            ws_conn_mode,
+        )
+        if not force_refresh:
+            with self._http_info_lock:
+                cached = self._http_info_cache.get(cache_key)
+            if cached is not None and cached[0] > time.monotonic():
+                logger.info(
+                    "[BaasService.get_http_info] cache hit: bind_id=%s, "
+                    "expires_in=%.1fs",
+                    bind_id,
+                    cached[0] - time.monotonic(),
+                )
+                return cached[1]
+
         # 从 DeviceBindingRepository 获取 device_id
         device_binding_repo = self._device_binding_repo
         binding = device_binding_repo.get_by_id(bind_id)
@@ -3395,6 +3471,9 @@ class BaasService:  # pragma: no cover
                 f"http_url={result.http_url}"
             )
 
+            self._conn_cache_put(
+                self._http_info_lock, self._http_info_cache, cache_key, result
+            )
             return result
 
         except httpx.HTTPStatusError as e:

--- a/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/baas_service.py
@@ -1925,6 +1925,7 @@ class BaasService:  # pragma: no cover
         device_affinity: Optional[str] = None,
         device_uuid: Optional[str] = None,
         ws_conn_mode: Optional[str] = None,
+        force_refresh: bool = False,
     ) -> BotWsConnectionInfoResponse:
         """获取 WebSocket 连接信息（通过 bot_uuid 直接查询）.
 
@@ -1939,6 +1940,8 @@ class BaasService:  # pragma: no cover
             device_affinity: 设备亲和性标识，用于指定目标设备（可选）
             device_uuid: 多实例场景锁定特定实例（可选）；不传则 BaaS 自动选活跃实例
             ws_conn_mode: WebSocket 连接模式透传（可选）；不传则不覆盖
+            force_refresh: Bypass a fresh cache entry and re-resolve, overwriting
+                it（语义同 :meth:`get_http_info`）。
 
         Returns:
             BotWsConnectionInfoResponse: WebSocket 连接信息
@@ -1947,6 +1950,27 @@ class BaasService:  # pragma: no cover
             BaasServiceError: 获取失败
         """
         effective_tenant = tenant or self._tenant
+        ws_cache_key = (
+            bot_uuid,
+            port,
+            path,
+            effective_tenant,
+            device_affinity,
+            device_uuid,
+            ws_conn_mode,
+        )
+        if not force_refresh:
+            with self._ws_info_lock:
+                cached = self._ws_info_cache.get(ws_cache_key)
+            if cached is not None and cached[0] > time.monotonic():
+                logger.info(
+                    "[BaasService.get_ws_info_by_bot_uuid] cache hit: "
+                    "bot_uuid=%s, expires_in=%.1fs",
+                    bot_uuid,
+                    cached[0] - time.monotonic(),
+                )
+                return cached[1]
+
         logger.info(
             f"[BaasService.get_ws_info_by_bot_uuid] "
             f"Getting ws info: bot_uuid={bot_uuid}, tenant={effective_tenant}, "
@@ -1999,6 +2023,9 @@ class BaasService:  # pragma: no cover
                 f"Got ws info: bot_uuid={bot_uuid}, target={result.target}"
             )
 
+            self._conn_cache_put(
+                self._ws_info_lock, self._ws_info_cache, ws_cache_key, result
+            )
             return result
 
         except httpx.HTTPStatusError as e:

--- a/src/backend/src/agentclaw/community/di/modules/cron_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/cron_module.py
@@ -23,6 +23,9 @@ from agentclaw.community.core.cron.services.cron_auto_setup_listener import (
     CronAutoSetupListener,
 )
 from agentclaw.community.core.cron.services.cron_relay import CronRelayService
+from agentclaw.community.core.cron.services.cron_sandbox_revival_listener import (
+    CronSandboxRevivalListener,
+)
 
 
 class CronModule(Module):
@@ -37,6 +40,13 @@ class CronModule(Module):
         # singlebox); community leaves it unbound (no container runtime).
         # Lifecycle participant — subscribes to DeviceActivatedEvent in startup()
         binder.bind(CronAutoSetupListener, to=CronAutoSetupListener, scope=singleton)
+        # Lifecycle participant — same event, opposite verdict: an activation
+        # revives a binding whose destroyed-sandbox verdict would otherwise
+        # keep its cron queries (and the auto_setup idempotency check) in a
+        # 60 s blind window across a sandbox rebuild.
+        binder.bind(
+            CronSandboxRevivalListener, to=CronSandboxRevivalListener, scope=singleton
+        )
 
     @singleton
     @provider

--- a/src/backend/tests/community/core/cron/services/test_cron_relay_sandbox_skip.py
+++ b/src/backend/tests/community/core/cron/services/test_cron_relay_sandbox_skip.py
@@ -1,0 +1,171 @@
+"""Binding-level negative cache for destroyed sandboxes in the cron fan-out.
+
+Pre 2026-08-28 evidence: a bot's instances get reclaimed while the binding row
+stays ACTIVE, and every listing/running fan-out then pays a 404 precheck round
+trip per destroyed instance, forever (trace 0b446a1717878836076095311e05a8:
+6 destroyed sandboxes of the caller's own bot per request). The relay is a
+singleton, so a binding-keyed "sandbox destroyed" verdict with a short TTL
+skips the prepare+invoke chain until it expires.
+
+Covered: verdict recorded from both failure shapes (error dict / raised
+exception), skip skips the transport, TTL expiry re-invokes, non-destroyed
+failures are never recorded, and ``list_all_crons`` surfaces the skip as a
+failed target with an explicit reason.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentclaw.community.core.cron.services import cron_runtime_targets
+from agentclaw.community.core.cron.services.cron_relay import CronRelayService
+from agentclaw.community.core.cron.services.cron_runtime_targets import (
+    CronRuntimeTarget,
+)
+
+
+_DESTROYED_MSG = (
+    'Adapter returned HTTP 404: {"message":"报错类型: 沙箱已销毁, err=sandbox destroyed"}'
+)
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 2000.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+def _make_service(*, transport_invoke: AsyncMock) -> CronRelayService:
+    svc = CronRelayService(
+        bot_provider=MagicMock(),
+        device_provider=MagicMock(),
+        transport=MagicMock(),
+        resolver=MagicMock(),
+        template_repo=MagicMock(),
+        publish_repo=MagicMock(),
+    )
+    ctx = SimpleNamespace(conn_info={"url": "http://adapter"})
+    svc._prepare_runtime_query_async = AsyncMock(return_value=(ctx, None))
+    svc._invoke_transport = transport_invoke
+    return svc
+
+
+def _target(binding_id: int) -> CronRuntimeTarget:
+    return CronRuntimeTarget(
+        bot_id="bot-1",
+        bot_name="bot-1",
+        owner_id="user-1",
+        bot_type="service",
+        runtime_stage="draft",
+        binding_id=binding_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_destroyed_sandbox_failure_marks_binding():
+    invoke = AsyncMock(
+        return_value={"success": False, "error": _DESTROYED_MSG}
+    )
+    svc = _make_service(transport_invoke=invoke)
+
+    result = await svc._fetch_runtime_target_crons(_target(1), "user-1")
+
+    assert result["reason"] == "cron_api_failed"
+    assert 1 in svc._sandbox_down_until
+
+
+@pytest.mark.asyncio
+async def test_destroyed_sandbox_exception_marks_binding():
+    invoke = AsyncMock(side_effect=ValueError(_DESTROYED_MSG))
+    svc = _make_service(transport_invoke=invoke)
+
+    result = await svc._fetch_runtime_target_crons(_target(2), "user-1")
+
+    assert result["reason"] == "cron_api_failed"
+    assert 2 in svc._sandbox_down_until
+
+
+@pytest.mark.asyncio
+async def test_second_fetch_within_ttl_skips_transport():
+    invoke = AsyncMock(
+        return_value={"success": True, "data": []}
+    )
+    svc = _make_service(transport_invoke=invoke)
+    svc._sandbox_down_until[7] = (
+        cron_runtime_targets.time.monotonic()
+        + cron_runtime_targets.SANDBOX_DESTROYED_TTL_SECONDS
+    )
+
+    result = await svc._fetch_runtime_target_crons(_target(7), "user-1")
+
+    assert result["success"] is False
+    assert result["reason"] == "sandbox_destroyed_cached"
+    invoke.assert_not_awaited()
+    # prepare (device query + resolution) is skipped too — that is the win.
+    svc._prepare_runtime_query_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_verdict_expires_after_ttl(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr(cron_runtime_targets, "time", clock)
+    invoke = AsyncMock(
+        return_value={"success": False, "error": _DESTROYED_MSG}
+    )
+    svc = _make_service(transport_invoke=invoke)
+
+    await svc._fetch_runtime_target_crons(_target(3), "user-1")
+    clock.now += cron_runtime_targets.SANDBOX_DESTROYED_TTL_SECONDS + 1
+
+    await svc._fetch_runtime_target_crons(_target(3), "user-1")
+
+    assert invoke.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_plain_failures_are_never_recorded():
+    invoke = AsyncMock(
+        return_value={"success": False, "error": "Adapter returned HTTP 500"}
+    )
+    svc = _make_service(transport_invoke=invoke)
+
+    await svc._fetch_runtime_target_crons(_target(4), "user-1")
+    await svc._fetch_runtime_target_crons(_target(4), "user-1")
+
+    assert invoke.await_count == 2
+    assert not svc._sandbox_down_until
+
+
+@pytest.mark.asyncio
+async def test_list_all_crons_surfaces_skip_as_failed_target():
+    invoke = AsyncMock(
+        return_value={"success": False, "error": _DESTROYED_MSG}
+    )
+    svc = _make_service(transport_invoke=invoke)
+    bot_provider = svc._bot_provider
+    bot_provider.list_bots_by_owner_or_collaborator.return_value = {
+        "total": 1,
+        "items": [
+            {
+                "bot_id": "bot-1",
+                "bot_name": "bot-1",
+                "owner_id": "user-1",
+                "bot_type": "service",
+                "binding_id": 1,
+            }
+        ],
+    }
+    svc._build_runtime_targets = MagicMock(return_value=([_target(1)], []))
+
+    first = await svc.list_all_crons(user_id="user-1", nick_name="user-1")
+    second = await svc.list_all_crons(user_id="user-1", nick_name="user-1")
+
+    assert invoke.await_count == 1
+    reasons_first = [f["reason"] for f in first["failed_targets"]]
+    reasons_second = [f["reason"] for f in second["failed_targets"]]
+    assert reasons_first == ["cron_api_failed"]
+    assert reasons_second == ["sandbox_destroyed_cached"]

--- a/src/backend/tests/community/core/cron/services/test_cron_sandbox_revival_listener.py
+++ b/src/backend/tests/community/core/cron/services/test_cron_sandbox_revival_listener.py
@@ -1,0 +1,134 @@
+"""DeviceActivatedEvent clears a binding's sandbox-destroyed verdict.
+
+PR #1635 review (P0): a sandbox rebuild under the same binding fires
+DeviceActivatedEvent, and the old destroyed verdict must not blind the
+auto_setup idempotency check (``cron_auto_setup.py`` reads only
+``list_all_crons``'s ``data`` — skips are invisible) or the listings.
+
+Covered: clearing removes the verdict and un-skips fetches; clearing an
+unknown binding is a no-op; the listener subscribes exactly once; an event
+clears the matching verdict; relay errors are swallowed (an event handler
+must never break the bus).
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agentclaw.community.core.cron.services.cron_relay import CronRelayService
+from agentclaw.community.core.cron.services.cron_runtime_targets import (
+    SANDBOX_DESTROYED_TTL_SECONDS,
+    CronRuntimeTarget,
+)
+from agentclaw.community.core.cron.services.cron_sandbox_revival_listener import (
+    CronSandboxRevivalListener,
+)
+from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
+from agentclaw.community.core.events.types import DeviceActivatedEvent
+
+
+def _make_service() -> CronRelayService:
+    svc = CronRelayService(
+        bot_provider=MagicMock(),
+        device_provider=MagicMock(),
+        transport=MagicMock(),
+        resolver=MagicMock(),
+        template_repo=MagicMock(),
+        publish_repo=MagicMock(),
+    )
+    invoke = AsyncMock(return_value={"success": True, "data": []})
+    ctx = SimpleNamespace(conn_info={"url": "http://adapter"})
+    svc._prepare_runtime_query_async = AsyncMock(return_value=(ctx, None))
+    svc._invoke_transport = invoke
+    return svc
+
+
+def _target(binding_id: int) -> CronRuntimeTarget:
+    return CronRuntimeTarget(
+        bot_id="bot-1",
+        bot_name="bot-1",
+        owner_id="user-1",
+        bot_type="service",
+        runtime_stage="draft",
+        binding_id=binding_id,
+    )
+
+
+def _event(binding_id: int) -> DeviceActivatedEvent:
+    return DeviceActivatedEvent(
+        device_id="BOT-1",
+        binding_id=binding_id,
+        entity_id="staff-u1",
+        entity_type="staff",
+        device_provider="baas",
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_verdict_un_skips_subsequent_fetch():
+    svc = _make_service()
+    svc._sandbox_down_until[9] = time.monotonic() + SANDBOX_DESTROYED_TTL_SECONDS
+
+    cleared = svc.clear_sandbox_down_verdict(9)
+
+    assert cleared is True
+    assert 9 not in svc._sandbox_down_until
+    # binding is fetchable again — transport invoked
+    result = await svc._fetch_runtime_target_crons(_target(9), "user-1")
+    assert result["success"] is True
+    svc._invoke_transport.assert_awaited_once()
+
+
+def test_clear_unknown_binding_is_noop():
+    svc = _make_service()
+
+    assert svc.clear_sandbox_down_verdict(404) is False
+    assert svc._sandbox_down_until == {}
+
+
+@pytest.mark.asyncio
+async def test_startup_subscribes_exactly_once():
+    reset_event_bus()
+    relay = _make_service()
+    listener = CronSandboxRevivalListener(cron_relay=relay)
+
+    await listener.startup()
+    await listener.startup()
+
+    from agentclaw.community.core.events.types import DeviceActivatedEvent as E
+
+    assert get_event_bus()._handlers[E] == [listener._handle]
+    reset_event_bus()
+
+
+def test_event_clears_matching_verdict():
+    relay = _make_service()
+    relay._sandbox_down_until[11] = time.monotonic() + SANDBOX_DESTROYED_TTL_SECONDS
+    listener = CronSandboxRevivalListener(cron_relay=relay)
+
+    listener._handle(_event(11))
+
+    assert 11 not in relay._sandbox_down_until
+
+
+def test_event_for_unmarked_binding_is_noop():
+    relay = _make_service()
+    listener = CronSandboxRevivalListener(cron_relay=relay)
+
+    listener._handle(_event(12))
+
+    assert relay._sandbox_down_until == {}
+
+
+def test_handle_swallows_relay_errors():
+    relay = _make_service()
+    relay.clear_sandbox_down_verdict = MagicMock(
+        side_effect=RuntimeError("relay exploded")
+    )
+    listener = CronSandboxRevivalListener(cron_relay=relay)
+
+    # must not raise — one broken handler must never break the bus loop
+    listener._handle(_event(13))

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_conn_info_cache.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_conn_info_cache.py
@@ -169,3 +169,90 @@ def test_conn_info_cache_evicts_when_over_cap(monkeypatch):
     service.get_http_info(bind_id=1, port=20010, path="/api/cron")  # re-resolve
 
     assert len(http.calls_to("get")) == 4
+
+
+# ── get_ws_info_by_bot_uuid ──────────────────────────────────────────────
+
+
+def _stub_ws_info_response(http: LocalHttpClient, *, token: str = "wtok") -> None:
+    mock = MagicMock()
+    mock.raise_for_status.return_value = None
+    mock.json.return_value = {
+        "code": 0,
+        "data": {
+            "ws_url": "ws://container:20003/api/openclaw/ws",
+            "token": token,
+            "target": "TGT",
+            "expires_at": "2099-01-01T00:00:00Z",
+        },
+    }
+    http.set_response("get", mock)
+
+
+@pytest.mark.unit
+def test_get_ws_info_by_bot_uuid_reuses_cached_result_between_calls():
+    service, http = _make_service()
+    _stub_ws_info_response(http)
+
+    first = service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+    second = service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+
+    assert first is second
+    assert len(http.calls_to("get")) == 1
+
+
+@pytest.mark.unit
+def test_get_ws_info_cache_key_distinguishes_params():
+    service, http = _make_service()
+    _stub_ws_info_response(http)
+
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-2")
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1", device_affinity="240841")
+
+    assert len(http.calls_to("get")) == 3
+
+
+@pytest.mark.unit
+def test_get_ws_info_cached_entry_expires_after_ttl(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr(baas_module, "time", clock)
+    service, http = _make_service()
+    _stub_ws_info_response(http, token="wtok-1")
+
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+    clock.now += baas_module.BAAS_CONN_INFO_TTL_SECONDS + 1
+    _stub_ws_info_response(http, token="wtok-2")
+
+    result = service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+
+    assert result.token == "wtok-2"
+    assert len(http.calls_to("get")) == 2
+
+
+@pytest.mark.unit
+def test_get_ws_info_by_bot_uuid_force_refresh_bypasses_cache():
+    service, http = _make_service()
+    _stub_ws_info_response(http)
+
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1", force_refresh=True)
+
+    assert len(http.calls_to("get")) == 2
+
+
+@pytest.mark.unit
+def test_get_ws_info_error_is_not_cached():
+    service, http = _make_service()
+    boom = MagicMock()
+    boom.raise_for_status.return_value = None
+    boom.json.return_value = {"code": 1, "message": "ws-info exploded"}
+    http.set_response("get", boom)
+
+    with pytest.raises(BaasServiceError):
+        service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+
+    _stub_ws_info_response(http)
+    service.get_ws_info_by_bot_uuid(bot_uuid="BOT-1")
+
+    assert len(http.calls_to("get")) == 2

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_conn_info_cache.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_conn_info_cache.py
@@ -1,0 +1,171 @@
+"""TTL cache for BaasService connection-info lookups (ws-info / http-info).
+
+Evidence (2026-08-28 pre, trace 0b446a1717878836076095311e05a8): every cron
+fan-out target resolves BaaS http/ws info over HTTP (130-160 ms each) with no
+reuse across requests. BaasService is a DI singleton, so a 30 s process-level
+cache — the TTL already validated by ``baas_invoke_transport._HTTP_INFO_TTL_SECONDS``
+— serialises nothing and removes the per-request round trips.
+
+Covered here: hit on repeated params, miss on param variation, TTL expiry,
+errors not cached, ``force_refresh`` bypass, cap eviction, and the same set
+for ``get_ws_info_by_bot_uuid``.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.service_bot.services import baas_service as baas_module
+from agentclaw.community.core.service_bot.services.deploy.managed_composer import (
+    ManagedDeployConfigComposer,
+)
+from agentclaw.community.core.service_bot.services.baas_service import (
+    BaasService,
+    BaasServiceError,
+)
+from agentclaw.community.plugins.local.http_client import LocalHttpClient
+
+
+class _FakeClock:
+    """Stand-in for the ``time`` module, advanceable in tests."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+def _make_service() -> tuple[BaasService, LocalHttpClient]:
+    http = LocalHttpClient(base_url="http://baas.test")
+    service = BaasService(
+        deploy_composer=ManagedDeployConfigComposer(
+            storage_path=MagicMock(),
+            sandbox_registry=MagicMock(),
+            bot_repo=MagicMock(),
+        ),
+        startup_script_reader=MagicMock(**{"get_body.return_value": ""}),
+        baas_api_base="http://baas.test",
+        tenant="tnt",
+        template_uuid="tpl",
+        bot_repo=MagicMock(),
+        bot_publish_repo=MagicMock(),
+        system_config_service=MagicMock(),
+        storage_path=MagicMock(),
+        device_binding_repo=MagicMock(),
+        default_ttl_minutes=10080,
+        sandbox_registry=MagicMock(),
+        http_client=http,
+        general_http_client=LocalHttpClient(base_url=""),
+        secret_resolver=MagicMock(),
+        common_whitelist_service=MagicMock(),
+        outbound_rule_provider=MagicMock(),
+    )
+    service._device_binding_repo.get_by_id.return_value = SimpleNamespace(
+        device_id="BOT-1"
+    )
+    return service, http
+
+
+def _stub_http_info_response(
+    http: LocalHttpClient, *, token: str = "tok"
+) -> None:
+    mock = MagicMock()
+    mock.raise_for_status.return_value = None
+    mock.json.return_value = {
+        "code": 0,
+        "data": {"http_url": "http://container:20010", "token": token, "target": "TGT"},
+    }
+    http.set_response("get", mock)
+
+
+@pytest.mark.unit
+def test_get_http_info_reuses_cached_result_between_calls():
+    service, http = _make_service()
+    _stub_http_info_response(http)
+
+    first = service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+    second = service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+
+    assert first is second
+    assert len(http.calls_to("get")) == 1
+
+
+@pytest.mark.unit
+def test_get_http_info_cache_key_distinguishes_params():
+    service, http = _make_service()
+    _stub_http_info_response(http)
+
+    service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+    service.get_http_info(bind_id=7, port=20010, path="/api/cron", device_uuid="DEV-2")
+    service.get_http_info(bind_id=8, port=20010, path="/api/cron")
+
+    assert len(http.calls_to("get")) == 3
+
+
+@pytest.mark.unit
+def test_get_http_info_cached_entry_expires_after_ttl(monkeypatch):
+    clock = _FakeClock()
+    monkeypatch.setattr(baas_module, "time", clock)
+    service, http = _make_service()
+    _stub_http_info_response(http, token="tok-1")
+
+    service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+    clock.now += baas_module.BAAS_CONN_INFO_TTL_SECONDS + 1
+    _stub_http_info_response(http, token="tok-2")
+
+    result = service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+
+    assert result.token == "tok-2"
+    assert len(http.calls_to("get")) == 2
+
+
+@pytest.mark.unit
+def test_get_http_info_does_not_cache_failures():
+    service, http = _make_service()
+    boom = MagicMock()
+    boom.raise_for_status.return_value = None
+    boom.json.return_value = {"code": 1, "message": "BaaS exploded"}
+    http.set_response("get", boom)
+
+    with pytest.raises(BaasServiceError):
+        service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+
+    _stub_http_info_response(http)
+    result = service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+
+    assert result.token == "tok"
+    assert len(http.calls_to("get")) == 2
+
+
+@pytest.mark.unit
+def test_get_http_info_force_refresh_bypasses_cache():
+    service, http = _make_service()
+    _stub_http_info_response(http)
+
+    service.get_http_info(bind_id=7, port=20010, path="/api/cron")
+    result = service.get_http_info(
+        bind_id=7, port=20010, path="/api/cron", force_refresh=True
+    )
+
+    assert result.token == "tok"
+    assert len(http.calls_to("get")) == 2
+
+
+@pytest.mark.unit
+def test_conn_info_cache_evicts_when_over_cap(monkeypatch):
+    monkeypatch.setattr(baas_module, "BAAS_CONN_INFO_CACHE_MAX_ENTRIES", 2)
+    service, http = _make_service()
+    _stub_http_info_response(http)
+    service._device_binding_repo.get_by_id.side_effect = lambda bid: SimpleNamespace(
+        device_id=f"BOT-{bid}"
+    )
+
+    service.get_http_info(bind_id=1, port=20010, path="/api/cron")
+    service.get_http_info(bind_id=2, port=20010, path="/api/cron")
+    service.get_http_info(bind_id=3, port=20010, path="/api/cron")  # cap hit -> clear
+    service.get_http_info(bind_id=1, port=20010, path="/api/cron")  # re-resolve
+
+    assert len(http.calls_to("get")) == 4

--- a/src/backend/tests/community/plugins/prod/test_baas_invoke_transport.py
+++ b/src/backend/tests/community/plugins/prod/test_baas_invoke_transport.py
@@ -377,6 +377,7 @@ def test_http_info_resolution_carries_the_instance_identity():
         path="/api/file/read",
         tenant="team_claw",
         device_uuid="DEV-xyz",
+        force_refresh=False,
     )
 
 
@@ -398,6 +399,11 @@ def test_rejected_token_refreshes_http_info_and_retries_once():
 
     assert resp.status_code == 200
     assert svc.get_http_info.call_count == 2
+    # The retry resolution must bypass the service-level 30s TTL cache so a
+    # token that went stale inside the TTL is replaced, not replayed.
+    assert [
+        c.kwargs.get("force_refresh") for c in svc.get_http_info.call_args_list
+    ] == [False, True]
     assert [c.kwargs["http_info"] for c in svc.invoke_http.call_args_list] == [
         stale, fresh,
     ]

--- a/src/backend/tests/community/plugins/prod/test_baas_ws_info_response_fields.py
+++ b/src/backend/tests/community/plugins/prod/test_baas_ws_info_response_fields.py
@@ -1,4 +1,5 @@
 """BAAS ws_info response 必须暴露 paas_device_id / baas_base_url / engine_port 供 invoke-http 链路使用。"""
+import threading
 from unittest.mock import MagicMock
 
 from agentclaw.community.plugins.local.http_client import LocalHttpClient
@@ -39,6 +40,10 @@ def test_get_ws_info_returns_paas_device_id_baas_base_url_engine_port():
     svc._http = http
     svc._tenant = "team_claw"
     svc._device_binding_repo = fake_repo
+    # get_ws_info now consults the connection-info TTL cache; this __new__
+    # construction bypasses __init__, so seed the cache attrs by hand.
+    svc._ws_info_lock = threading.Lock()
+    svc._ws_info_cache = {}
 
     result = svc.get_ws_info(bind_id=42, port=20003)
 


### PR DESCRIPTION
## Problem

`GET /openapi/v1/bots/routines/all` measured 2.3–2.8 s on pre (AntLogs, 2026-08-28, trace `0b446a1717878836076095311e05a8`; RT 2308/2494/2833 ms for a ~800-byte response). Phase breakdown of the 2833 ms request:

- ~950 ms resolving BaaS `ws-info`/`http-info` per binding over HTTP (130–160 ms each) — re-resolved on every request by every caller (resolver + transports), no cross-request reuse
- ~520 ms adapter `GET /api/cron`, of which 6 calls were guaranteed 404s against destroyed sandboxes of the caller's own bot — replayed on every request and never marked dead
- The same relay (`CronRelayService.list_all_crons`) also serves the internal console's cron listing, so console polling pays the same cost and contends with the public surface on the same workers

## Solution

Three changes at the two chokepoints this repo owns (the corp-profile `HttpDeviceAdapterTransport` is out of repo and untouched):

1. `BaasService` (DI singleton): process-level 30 s TTL cache for `get_http_info` and `get_ws_info_by_bot_uuid`, keyed on the full parameter tuple, capped at 512 entries with expired-first-then-clear eviction. Errors are never cached. The TTL matches the token-lifetime precedent already validated in `baas_invoke_transport._HTTP_INFO_TTL_SECONDS`, so a stale-token window is bounded and small.
2. `BaasInvokeTransport._http_info`: the 401-stale-token retry now passes `force_refresh=stale is not None`, so a token that expires inside the TTL is re-resolved instead of replayed — the existing self-heal semantics are preserved on top of the cache.
3. `CronRuntimeTargetMixin` (cron relay fetch path): binding-level negative cache (60 s TTL). A failure whose error text matches the destroyed-sandbox signature (`沙箱已销毁` / `sandbox destroyed`, case-insensitive) marks the binding; subsequent fetches skip device resolution + transport entirely and surface `reason: sandbox_destroyed_cached` in `failed_targets`. Non-destroyed failures are never recorded; the verdict self-heals after the TTL.

## Validation

- Full backend CI gate, rebased on dev and run against `--base origin/dev`: **14968 passed / 0 failed**, line coverage 87.55%, **changed-line coverage 100% (29/29)**
- 13 new cache behavior tests (hit / param-variation / TTL expiry / errors-not-cached / force-refresh bypass / cap eviction, for both endpoints) and 6 new sandbox-skip tests (both failure shapes mark the binding, skip skips prepare+transport, TTL expiry re-invokes, non-destroyed failures never recorded, `list_all_crons` surfaces the skip as a failed target)
- Existing transport 401-retry tests updated to pin `force_refresh=[False, True]` on the refresh path
- Review checklist verified: no caller mutates the returned cached dataclasses (shared instances safe); the mixin has a single consumer; both listing merge loops consume the skip result shape

Test plan:
- [ ] After pre deploy, re-measure the same route via AntLogs (`list_all_crons` + access RT) — target P50 < 1 s. Remaining headroom is the bot-listing DB N+1 (measured ~675 ms of invisible serial queries), tracked separately as P1.

## Compatibility and risk

- No OpenAPI surface change (no `bots.openapi.json` / gateway edits); `failed_targets` gains one new informational `reason` value
- Worst case 30 s staleness of a connection URL, bounded by the token lifetime; self-heals via the 401 force-refresh on our transport. An out-of-repo transport consuming `BaasService` also benefits from the cache; if it carries its own 401 retry it would read the cached entry within the TTL — same bounded window
- A false-positive destroyed-sandbox match would hide one binding's crons for at most 60 s (console polls faster than that); instance collection mid-creation surfaces as 503/other errors and does not match the markers
- Cache state is process-local on DI singletons — lost on restart, no cross-process coherence to reason about

## Spec

- `docs/superpowers/plans/2026-08-28-cron-fanout-caching.md` (diagnosis evidence, task breakdown, TTL rationale)
