### PR TITLE
New renew digest

### DIFF
--- a/src/baas/src/secbaas/community/core/service/health_check/sandbox/_sandbox_device_router.py
+++ b/src/baas/src/secbaas/community/core/service/health_check/sandbox/_sandbox_device_router.py
@@ -12,6 +12,14 @@ from uuid import uuid4
 from secbaas.community.api.health_check.sandbox import (
     SandboxDeviceRouter as SandboxDeviceRouterProtocol,
 )
+
+# 兼容别名：digest 三件套已抽离到 core/utils/_renewal_digest.py 中立模块，
+# 此处 re-export 是为第三方 import 与 Phase 3 过渡（删除 legacy router 类）保留。
+from secbaas.community.core.utils._renewal_digest import (  # isort: skip
+    RENEWAL_DIGEST_LOGGER as arca_renew_digest_logger,  # noqa: N811, F401
+    log_renew_digest as _log_renew_digest,
+    ttl_for_digest as _ttl_for_digest,  # noqa: F401
+)
 from secbaas.community.logger import get_logger
 
 if TYPE_CHECKING:
@@ -19,9 +27,6 @@ if TYPE_CHECKING:
     from secbaas.community.core.service.paas import PaasServiceFacade
 
 logger = get_logger("core-service")
-
-# 专用 digest 日志器：独立命名便于 monitor/采集按 logger 名过滤
-arca_renew_digest_logger = get_logger("arca-renew-digest")
 
 # ---------------------------------------------------------------------------
 # 常量
@@ -166,50 +171,6 @@ def _log_threshold_reached_warning(
         f"reached warning threshold ({fail_count} >= {WARNING_THRESHOLD}), "
         f"device will be escalated to STOPPED status"
     )
-
-
-def _log_renew_digest(
-    *,
-    run_uuid: str,
-    table_id: int,
-    table_type: str,
-    arca_device_id: str,
-    result: str,
-    ttl_before: str | None,
-    ttl_after: str | None,
-) -> None:
-    """续期结果 digest（monitor 用，逗号分隔字段，便于采集/告警）。
-
-    首字段为 run_uuid 用于区分不同轮次/请求；不含 error 详情（可能很长/带换行，
-    会破坏 monitor 格式），错误详情由各分支已有的 warning 日志记录。
-    best-effort，日志失败不影响续期流程。
-
-    ttl 时间去掉空格（``2026-05-27 21:15:05`` -> ``2026-05-27-21:15:05``），
-    缺失/空值置为 ``-``，避免破坏逗号分隔格式。
-    """
-    try:
-        before = _ttl_for_digest(ttl_before)
-        after = _ttl_for_digest(ttl_after)
-        arca_renew_digest_logger.info(
-            "ttl_renew_digest,%s,%s,%s,%s,%s,%s,%s,%s",
-            run_uuid,
-            "renew",
-            table_id,
-            table_type,
-            arca_device_id,
-            result,
-            before,
-            after,
-        )
-    except Exception as e:  # pragma: no cover - defensive
-        logger.warning("[ttl_renew_digest] log failed (non-fatal): %s", e)
-
-
-def _ttl_for_digest(ttl: str | None) -> str:
-    """把 TTL 时间规整为 monitor 友好格式：去空格、缺省置 ``-``。"""
-    if not ttl:
-        return "-"
-    return ttl.replace(" ", "-")
 
 
 # ---------------------------------------------------------------------------

--- a/src/baas/src/secbaas/community/core/service/health_check/sandbox/_sandbox_device_router.py
+++ b/src/baas/src/secbaas/community/core/service/health_check/sandbox/_sandbox_device_router.py
@@ -15,7 +15,7 @@ from secbaas.community.api.health_check.sandbox import (
 
 # 兼容别名：digest 三件套已抽离到 core/utils/_renewal_digest.py 中立模块，
 # 此处 re-export 是为第三方 import 与 Phase 3 过渡（删除 legacy router 类）保留。
-from secbaas.community.core.utils._renewal_digest import (  # isort: skip
+from secbaas.community.core.utils import (  # isort: skip
     RENEWAL_DIGEST_LOGGER as arca_renew_digest_logger,  # noqa: N811, F401
     log_renew_digest as _log_renew_digest,
     ttl_for_digest as _ttl_for_digest,  # noqa: F401

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
@@ -39,6 +39,22 @@ _DIGEST_TABLE_TYPE = {"baas_device": "baas", "ac_entity_device_binding": "ac_bin
 _DIGEST_RESULT = {"stopped": "failure"}
 
 
+def _digest_ttl(ms: int | None) -> str | None:
+    """Format an epoch-ms TTL for the digest stream, never raising.
+
+    Digest emission is best-effort by contract: a value that cannot be
+    formatted (numeric garbage from a device API passthrough) degrades to
+    the legacy "-" placeholder instead of interrupting the renewal flow.
+    """
+    if ms is None:
+        return None
+    try:
+        return format_ttl_expiration_time(float(ms))
+    except (TypeError, ValueError, OSError, OverflowError):
+        log.warning("[DeadlineRenewalScheduler] digest ttl format failed for %r", ms)
+        return None
+
+
 class DeadlineRenewalScheduler:
     """Deadline-driven ARCA container TTL renewal scheduler.
 
@@ -479,16 +495,8 @@ class DeadlineRenewalScheduler:
         Best-effort by design: log_renew_digest swallows its own logging
         failures, so digest emission can never affect the renewal flow.
         """
-        before = (
-            format_ttl_expiration_time(float(ttl_before_ms))
-            if ttl_before_ms is not None
-            else None
-        )
-        after = (
-            format_ttl_expiration_time(float(ttl_after_ms))
-            if ttl_after_ms is not None
-            else None
-        )
+        before = _digest_ttl(ttl_before_ms)
+        after = _digest_ttl(ttl_after_ms)
         log_renew_digest(
             run_uuid=run_uuid or str(uuid4()),
             table_id=record.get("source_id", 0),

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
@@ -16,7 +16,9 @@ from uuid import uuid4
 from secbaas.community.core.repository.arca_ttl import TtlRenewalScheduleRepository
 from secbaas.community.core.service.distributed_lock import DistributedLockService
 from secbaas.community.core.service.paas import PaasServiceFacade
+from secbaas.community.core.utils._renewal_digest import log_renew_digest
 from secbaas.community.core.utils.time_utils import (
+    format_ttl_expiration_time,
     naive_cst_fromtimestamp,
     naive_cst_now,
     renewal_window,
@@ -29,6 +31,12 @@ from ._deadline_renewal_report import GapDetectionResult, RenewalRunReport
 log = get_logger("core-scheduler")
 
 _DISCOVERY_SIDES = ("baas_device", "ac_entity_device_binding")
+
+# ttl_renew_digest field mapping: the digest CSV keeps the legacy table_type
+# vocabulary (baas / ac_binding) and folds the transient "stopped" outcome
+# into the monitor's "failure" bucket; every other result passes through.
+_DIGEST_TABLE_TYPE = {"baas_device": "baas", "ac_entity_device_binding": "ac_binding"}
+_DIGEST_RESULT = {"stopped": "failure"}
 
 
 class DeadlineRenewalScheduler:
@@ -285,7 +293,7 @@ class DeadlineRenewalScheduler:
         async def _process_one(record: dict) -> str:
             async with sem:
                 try:
-                    return await self._renew_one(record)
+                    return await self._renew_one(record, run_uuid=report.run_uuid)
                 except Exception:
                     log.exception(
                         "[DeadlineRenewalScheduler] record renewal raised, "
@@ -294,13 +302,18 @@ class DeadlineRenewalScheduler:
                         record.get("source_id"),
                     )
                     try:
-                        return await self._handle_failure(record)
+                        r = await self._handle_failure(record)
+                        self._emit_renew_digest(record, r, run_uuid=report.run_uuid)
+                        return r
                     except Exception:
                         log.exception(
                             "[DeadlineRenewalScheduler] failure accounting "
                             "failed for %s:%s — record retried next round",
                             record.get("source_table"),
                             record.get("source_id"),
+                        )
+                        self._emit_renew_digest(
+                            record, "failed", run_uuid=report.run_uuid
                         )
                         return "failed"
 
@@ -444,10 +457,65 @@ class DeadlineRenewalScheduler:
     # Step 2 helpers
     # ------------------------------------------------------------------
 
-    async def _renew_one(self, record: dict) -> str:
+    def _emit_renew_digest(
+        self,
+        record: dict,
+        result: str,
+        *,
+        ttl_before_ms: int | None = None,
+        ttl_after_ms: int | None = None,
+        run_uuid: str | None = None,
+    ) -> None:
+        """Emit one ttl_renew_digest CSV line for a terminal renewal outcome.
+
+        Threads the run uuid from _run_once's report (uuid4 fallback for
+        direct invocation — same behavior as the legacy renew_ttl path),
+        maps source_table to the legacy digest table_type vocabulary and
+        the transient "stopped" outcome to "failure", and formats platform
+        epoch-ms TTLs via the fixed +08:00 wall clock so the digest stream
+        is homogeneous with the health_check scanner's — dash placeholder
+        when a TTL is unknown.
+
+        Best-effort by design: log_renew_digest swallows its own logging
+        failures, so digest emission can never affect the renewal flow.
+        """
+        before = (
+            format_ttl_expiration_time(float(ttl_before_ms))
+            if ttl_before_ms is not None
+            else None
+        )
+        after = (
+            format_ttl_expiration_time(float(ttl_after_ms))
+            if ttl_after_ms is not None
+            else None
+        )
+        log_renew_digest(
+            run_uuid=run_uuid or str(uuid4()),
+            table_id=record.get("source_id", 0),
+            table_type=_DIGEST_TABLE_TYPE.get(
+                record.get("source_table", ""), record.get("source_table", "")
+            ),
+            arca_device_id=record.get("sandbox_id", ""),
+            result=_DIGEST_RESULT.get(result, result),
+            ttl_before=before,
+            ttl_after=after,
+        )
+
+    async def _renew_one(self, record: dict, run_uuid: str | None = None) -> str:
         """Execute a single renewal decision (Step 3 in design doc §8.2).
 
         Returns one of: "success" | "skipped" | "failed" | "stopped"
+
+        Every terminal branch emits a ttl_renew_digest CSV line on the
+        arca-renew-digest logger (via _emit_renew_digest) so the monitor
+        pipeline sees the same renewal digest stream as the legacy
+        SandboxDeviceRouter path.
+
+        Args:
+            record: The schedule record (dict from list_due_for_renewal).
+            run_uuid: Run identifier threaded from _run_once's report for
+                the digest emission; falls back to a fresh uuid4 when
+                omitted (direct invocation, tests).
 
         Decision branches (a—h):
           (a) Get authoritative TTL from Arca via facade.get_device_info()
@@ -471,7 +539,9 @@ class DeadlineRenewalScheduler:
                 "[DeadlineRenewalScheduler] get_device_info failed sandbox_id=%s",
                 sandbox_id,
             )
-            return await self._handle_failure(record)
+            outcome = await self._handle_failure(record)
+            self._emit_renew_digest(record, outcome, run_uuid=run_uuid)
+            return outcome
 
         # ---- Step 3(b): Extract ttl_timestamp ----
         ttl_ms = device_info.ttl_timestamp if device_info else None
@@ -481,7 +551,9 @@ class DeadlineRenewalScheduler:
                 "[DeadlineRenewalScheduler] ttl_timestamp empty for sandbox_id=%s",
                 sandbox_id,
             )
-            return await self._handle_failure(record)
+            outcome = await self._handle_failure(record)
+            self._emit_renew_digest(record, outcome, run_uuid=run_uuid)
+            return outcome
 
         # Normalize to a numeric epoch-ms value: SDK plugins pass the wire
         # value through verbatim (enterprise _arca_sdk.py uses
@@ -497,7 +569,9 @@ class DeadlineRenewalScheduler:
                 sandbox_id,
                 ttl_ms,
             )
-            return await self._handle_failure(record)
+            outcome = await self._handle_failure(record)
+            self._emit_renew_digest(record, outcome, run_uuid=run_uuid)
+            return outcome
 
         # ---- Step 3(c-d): Compute remaining_hours ----
         now_ts = time.time()
@@ -517,7 +591,11 @@ class DeadlineRenewalScheduler:
                 sandbox_id,
                 remaining_hours,
             )
-            return await self._handle_failure(record)
+            outcome = await self._handle_failure(record)
+            self._emit_renew_digest(
+                record, outcome, ttl_before_ms=ttl_ms, run_uuid=run_uuid
+            )
+            return outcome
 
         # ---- Step 3(f): remaining > 24h — cannot renew (API constraint) ----
         if remaining_hours > 24:
@@ -535,6 +613,9 @@ class DeadlineRenewalScheduler:
                 sandbox_id,
                 remaining_hours,
                 next_renew.isoformat(),
+            )
+            self._emit_renew_digest(
+                record, "skipped", ttl_before_ms=ttl_ms, run_uuid=run_uuid
             )
             return "skipped"
 
@@ -555,6 +636,9 @@ class DeadlineRenewalScheduler:
                 remaining_hours,
                 self._config.renew_threshold_hours,
                 next_renew.isoformat(),
+            )
+            self._emit_renew_digest(
+                record, "skipped", ttl_before_ms=ttl_ms, run_uuid=run_uuid
             )
             return "skipped"
 
@@ -580,7 +664,11 @@ class DeadlineRenewalScheduler:
                 sandbox_id,
                 ttl_minutes,
             )
-            return await self._handle_failure(record)
+            outcome = await self._handle_failure(record)
+            self._emit_renew_digest(
+                record, outcome, ttl_before_ms=ttl_ms, run_uuid=run_uuid
+            )
+            return outcome
 
         if not renewed:
             # Rejected extension (SDK returned a literal False / success=False)
@@ -592,7 +680,11 @@ class DeadlineRenewalScheduler:
                 sandbox_id,
                 ttl_minutes,
             )
-            return await self._handle_failure(record)
+            outcome = await self._handle_failure(record)
+            self._emit_renew_digest(
+                record, outcome, ttl_before_ms=ttl_ms, run_uuid=run_uuid
+            )
+            return outcome
 
         # Renewal success — WR-03: derive next_renew from the authoritative
         # post-extend TTL instead of assuming now + renewal_window. Arca
@@ -642,6 +734,16 @@ class DeadlineRenewalScheduler:
             sandbox_id,
             ttl_minutes,
             next_renew.isoformat(),
+        )
+        # h3 digest: success with the pre-renewal platform TTL as before and
+        # the clamped post-extend TTL as after (dash placeholder when the
+        # re-read failed and new_expiration_ms stayed None).
+        self._emit_renew_digest(
+            record,
+            "success",
+            ttl_before_ms=ttl_ms,
+            ttl_after_ms=new_expiration_ms,
+            run_uuid=run_uuid,
         )
         return "success"
 

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
@@ -16,7 +16,7 @@ from uuid import uuid4
 from secbaas.community.core.repository.arca_ttl import TtlRenewalScheduleRepository
 from secbaas.community.core.service.distributed_lock import DistributedLockService
 from secbaas.community.core.service.paas import PaasServiceFacade
-from secbaas.community.core.utils._renewal_digest import log_renew_digest
+from secbaas.community.core.utils import log_renew_digest
 from secbaas.community.core.utils.time_utils import (
     format_ttl_expiration_time,
     naive_cst_fromtimestamp,

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
@@ -33,10 +33,12 @@ log = get_logger("core-scheduler")
 _DISCOVERY_SIDES = ("baas_device", "ac_entity_device_binding")
 
 # ttl_renew_digest field mapping: the digest CSV keeps the legacy table_type
-# vocabulary (baas / ac_binding) and folds the transient "stopped" outcome
-# into the monitor's "failure" bucket; every other result passes through.
+# vocabulary (baas / ac_binding) and the digest result column projects
+# strictly into the legacy alarm vocabulary {success, skipped, failure} —
+# both the transient "stopped" outcome and the ordinary "failed" outcome
+# fold into the monitor's "failure" bucket.
 _DIGEST_TABLE_TYPE = {"baas_device": "baas", "ac_entity_device_binding": "ac_binding"}
-_DIGEST_RESULT = {"stopped": "failure"}
+_DIGEST_RESULT = {"stopped": "failure", "failed": "failure"}
 
 
 def _digest_ttl(ms: int | None) -> str | None:
@@ -487,7 +489,8 @@ class DeadlineRenewalScheduler:
         Threads the run uuid from _run_once's report (uuid4 fallback for
         direct invocation — same behavior as the legacy renew_ttl path),
         maps source_table to the legacy digest table_type vocabulary and
-        the transient "stopped" outcome to "failure", and formats platform
+        the "stopped"/"failed" outcomes to the legacy "failure" bucket,
+        and formats platform
         epoch-ms TTLs via the fixed +08:00 wall clock so the digest stream
         is homogeneous with the health_check scanner's — dash placeholder
         when a TTL is unknown.
@@ -513,6 +516,7 @@ class DeadlineRenewalScheduler:
         """Execute a single renewal decision (Step 3 in design doc §8.2).
 
         Returns one of: "success" | "skipped" | "failed" | "stopped"
+        (digest result column folds "failed"/"stopped" into legacy "failure").
 
         Every terminal branch emits a ttl_renew_digest CSV line on the
         arca-renew-digest logger (via _emit_renew_digest) so the monitor

--- a/src/baas/src/secbaas/community/core/utils/__init__.py
+++ b/src/baas/src/secbaas/community/core/utils/__init__.py
@@ -3,3 +3,7 @@
 These utilities have zero internal dependencies and are safe for use
 by any layer including the open-source secbaas-core.
 """
+
+from ._renewal_digest import RENEWAL_DIGEST_LOGGER, log_renew_digest, ttl_for_digest
+
+__all__ = ["RENEWAL_DIGEST_LOGGER", "log_renew_digest", "ttl_for_digest"]

--- a/src/baas/src/secbaas/community/core/utils/_renewal_digest.py
+++ b/src/baas/src/secbaas/community/core/utils/_renewal_digest.py
@@ -1,0 +1,66 @@
+"""Renewal result digest logging — the single surviving home of ttl_renew_digest.
+
+monitor/采集按 logger 名 ``arca-renew-digest`` 过滤并解析 CSV 行进行
+续期成功率/失败率告警。该 logger 名与 CSV 字段顺序是监控采集契约，
+必须保持原样不变。
+
+历史：digest 三件套（logger、``_log_renew_digest``、``_ttl_for_digest``）原本
+定义在 ``core/service/health_check/sandbox/_sandbox_device_router.py``。
+为让新版 ``DeadlineRenewalScheduler`` 复用同一条告警链路，三件套被抽离到
+本中立模块，router 改为 re-export 兼容层。Phase 3 删除 legacy router 类后，
+本模块是 digest 的唯一存活点 — 请勿将 digest 逻辑迁回或复制到别处。
+"""
+
+from __future__ import annotations
+
+from secbaas.community.logger import get_logger
+
+# 专用 digest 日志器：独立命名便于 monitor/采集按 logger 名过滤
+RENEWAL_DIGEST_LOGGER = get_logger("arca-renew-digest")
+
+# 仅用于 digest 日志失败时的防御性 warning（不进入 arca-renew-digest 采集流）
+_MODULE_LOGGER = get_logger(__name__)
+
+
+def ttl_for_digest(ttl: str | None) -> str:
+    """把 TTL 时间规整为 monitor 友好格式：去空格、缺省置 ``-``。"""
+    if not ttl:
+        return "-"
+    return ttl.replace(" ", "-")
+
+
+def log_renew_digest(
+    *,
+    run_uuid: str,
+    table_id: int,
+    table_type: str,
+    arca_device_id: str,
+    result: str,
+    ttl_before: str | None,
+    ttl_after: str | None,
+) -> None:
+    """续期结果 digest（monitor 用，逗号分隔字段，便于采集/告警）。
+
+    首字段为 run_uuid 用于区分不同轮次/请求；不含 error 详情（可能很长/带换行，
+    会破坏 monitor 格式），错误详情由各分支已有的 warning 日志记录。
+    best-effort，日志失败不影响续期流程。
+
+    ttl 时间去掉空格（``2026-05-27 21:15:05`` -> ``2026-05-27-21:15:05``），
+    缺失/空值置为 ``-``，避免破坏逗号分隔格式。
+    """
+    try:
+        before = ttl_for_digest(ttl_before)
+        after = ttl_for_digest(ttl_after)
+        RENEWAL_DIGEST_LOGGER.info(
+            "ttl_renew_digest,%s,%s,%s,%s,%s,%s,%s,%s",
+            run_uuid,
+            "renew",
+            table_id,
+            table_type,
+            arca_device_id,
+            result,
+            before,
+            after,
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        _MODULE_LOGGER.warning("[ttl_renew_digest] log failed (non-fatal): %s", e)

--- a/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
@@ -1683,7 +1683,7 @@ class TestRenewalDigestLogging:
 
     @pytest.mark.asyncio
     async def test_get_device_info_failure_branch_emits_digest_line(self, caplog):
-        """a-failure below max_fail_count: ..., failed, -, -."""
+        """a-failure below max_fail_count: ..., failure, -, -."""
         scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
         mock_facade.get_device_info = AsyncMock(side_effect=Exception("timeout"))
         mock_repo.update_after_failure = MagicMock()
@@ -1695,7 +1695,8 @@ class TestRenewalDigestLogging:
         lines = self._digest_lines(caplog)
         assert len(lines) == 1
         fields = lines[0].split(",")
-        assert fields[6] == "failed"
+        # Strict legacy vocabulary: the "failed" outcome projects to "failure".
+        assert fields[6] == "failure"
         assert fields[7] == "-"
         assert fields[8] == "-"
 
@@ -1734,7 +1735,8 @@ class TestRenewalDigestLogging:
         lines = self._digest_lines(caplog)
         assert len(lines) == 1
         fields = lines[0].split(",")
-        assert fields[6] == "failed"
+        # Strict legacy vocabulary: the "failed" outcome projects to "failure".
+        assert fields[6] == "failure"
         assert fields[7] == "-"
         assert fields[8] == "-"
         # The formatter failure is warned on core-scheduler, never emitted
@@ -1820,7 +1822,8 @@ class TestRenewalDigestLogging:
     @pytest.mark.asyncio
     async def test_process_one_routes_renewal_raise_to_failed_digest(self, caplog):
         """A _renew_one raise routed to failure accounting still emits a
-        failed digest line — no silent terminal path."""
+        digest line projecting the failed outcome to "failure" — no silent
+        terminal path."""
         scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
         mock_repo.count_active.return_value = 1
         mock_repo.count_hot_arca_devices.return_value = 1
@@ -1845,7 +1848,8 @@ class TestRenewalDigestLogging:
         lines = self._digest_lines(caplog)
         assert len(lines) == 1
         fields = lines[0].split(",")
-        assert fields[6] == "failed"
+        # Strict legacy vocabulary: the "failed" outcome projects to "failure".
+        assert fields[6] == "failure"
         assert fields[7] == "-"
         assert fields[8] == "-"
 
@@ -1853,8 +1857,9 @@ class TestRenewalDigestLogging:
     async def test_process_one_failure_accounting_raise_still_emits_failed_digest(
         self, caplog
     ):
-        """Even failure accounting raising still emits a failed digest line —
-        the second-level fallback is not silent."""
+        """Even failure accounting raising still emits a digest line
+        projecting the failed outcome to "failure" — the second-level
+        fallback is not silent."""
         scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
         mock_repo.count_active.return_value = 1
         mock_repo.count_hot_arca_devices.return_value = 1
@@ -1874,6 +1879,7 @@ class TestRenewalDigestLogging:
         lines = self._digest_lines(caplog)
         assert len(lines) == 1
         fields = lines[0].split(",")
-        assert fields[6] == "failed"
+        # Strict legacy vocabulary: the "failed" outcome projects to "failure".
+        assert fields[6] == "failure"
         assert fields[7] == "-"
         assert fields[8] == "-"

--- a/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
@@ -14,6 +14,7 @@ the community TtlRenewalScheduleRepository Protocol.
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -27,6 +28,7 @@ from secbaas.community.core.service.scheduler import (
     RenewalRunReport,
 )
 from secbaas.community.core.utils.env_utils import get_current_env
+from secbaas.community.core.utils.time_utils import format_ttl_expiration_time
 
 
 def _acquired_lock():
@@ -1079,7 +1081,7 @@ class TestStep5ReportAndMetrics:
         # Override _renew_one to return known results
         call_count = 0
 
-        async def _mock_renew_one(record):
+        async def _mock_renew_one(record, run_uuid=None):
             nonlocal call_count
             call_count += 1
             return ["success", "skipped", "failed"][call_count - 1]
@@ -1599,3 +1601,237 @@ class TestStoppedTransitionMetric:
         assert "stopped_transition=1" in msg
         assert "sandbox_id=sb-1" in msg
         assert "fail_count=10" in msg
+
+
+class TestRenewalDigestLogging:
+    """REN-07: ttl_renew_digest CSV emission from every terminal branch.
+
+    The deadline engine shares the arca-renew-digest logger and CSV contract
+    with the legacy SandboxDeviceRouter digest, so the monitor pipeline sees
+    a homogeneous renewal digest stream across both engines during the
+    pre-gray-release window. Assertions split message by comma and check
+    the field positions of the 9-field contract line.
+    """
+
+    @staticmethod
+    def _digest_lines(caplog):
+        return [
+            r.getMessage()
+            for r in caplog.records
+            if r.name == "arca-renew-digest"
+            and r.getMessage().startswith("ttl_renew_digest,")
+        ]
+
+    @pytest.mark.asyncio
+    async def test_success_branch_emits_digest_line(self, caplog):
+        """h3 success: fields [1..9] = ttl_renew_digest, uuid, renew, 1,
+        baas, sb-1, success, formatted ttl_before, formatted ttl_after."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+
+        ttl_before_ms = _ttl_ms(10)
+        ttl_after_ms = ttl_before_ms + 839 * 60 * 1000  # WR-03 post-extend re-read
+        mock_facade.get_device_info = AsyncMock(
+            side_effect=[
+                MagicMock(ttl_timestamp=ttl_before_ms),
+                MagicMock(ttl_timestamp=ttl_after_ms),
+            ]
+        )
+        mock_facade.extend_ttl = AsyncMock(return_value=True)
+        mock_repo.update_after_success = MagicMock()
+
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        result = await scheduler._renew_one(_renewal_record())
+
+        assert result == "success"
+        lines = self._digest_lines(caplog)
+        assert len(lines) == 1
+        fields = lines[0].split(",")
+        assert len(fields) == 9
+        assert fields[0] == "ttl_renew_digest"
+        assert fields[1]  # auto-generated uuid when run_uuid omitted
+        assert fields[2] == "renew"
+        assert fields[3] == "1"
+        assert fields[4] == "baas"
+        assert fields[5] == "sb-1"
+        assert fields[6] == "success"
+        # Digest contract normalizes spaces to dashes inside TTL fields.
+        assert fields[7] == format_ttl_expiration_time(ttl_before_ms).replace(" ", "-")
+        assert fields[8] == format_ttl_expiration_time(ttl_after_ms).replace(" ", "-")
+
+    @pytest.mark.asyncio
+    async def test_over_24h_skip_branch_emits_digest_line(self, caplog):
+        """f-skip: ..., skipped, ttl_before formatted, ttl_after dash."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+        ttl_ms = _ttl_ms(25)
+        mock_facade.get_device_info = AsyncMock(
+            return_value=MagicMock(ttl_timestamp=ttl_ms)
+        )
+        mock_facade.extend_ttl = AsyncMock()
+
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        result = await scheduler._renew_one(_renewal_record())
+
+        assert result == "skipped"
+        mock_facade.extend_ttl.assert_not_awaited()
+        lines = self._digest_lines(caplog)
+        assert len(lines) == 1
+        fields = lines[0].split(",")
+        assert fields[6] == "skipped"
+        # Digest contract normalizes spaces to dashes inside TTL fields.
+        assert fields[7] == format_ttl_expiration_time(ttl_ms).replace(" ", "-")
+        assert fields[8] == "-"
+
+    @pytest.mark.asyncio
+    async def test_get_device_info_failure_branch_emits_digest_line(self, caplog):
+        """a-failure below max_fail_count: ..., failed, -, -."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+        mock_facade.get_device_info = AsyncMock(side_effect=Exception("timeout"))
+        mock_repo.update_after_failure = MagicMock()
+
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        result = await scheduler._renew_one(_renewal_record())
+
+        assert result == "failed"
+        lines = self._digest_lines(caplog)
+        assert len(lines) == 1
+        fields = lines[0].split(",")
+        assert fields[6] == "failed"
+        assert fields[7] == "-"
+        assert fields[8] == "-"
+
+    @pytest.mark.asyncio
+    async def test_stopped_outcome_maps_to_failure_digest_result(self, caplog):
+        """Threshold STOPPED maps the digest result to "failure" (not
+        "stopped") — monitor vocabulary stays two-valued success/failure."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(
+            enabled=True, config_overrides={"max_fail_count": 1}
+        )
+        mock_facade.get_device_info = AsyncMock(
+            return_value=MagicMock(ttl_timestamp=None)
+        )
+        mock_repo.set_status = MagicMock()
+
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        result = await scheduler._renew_one(_renewal_record(renew_fail_count=0))
+
+        assert result == "stopped"
+        lines = self._digest_lines(caplog)
+        assert len(lines) == 1
+        assert lines[0].split(",")[6] == "failure"
+
+    @pytest.mark.asyncio
+    async def test_ac_binding_source_table_maps_to_ac_binding_table_type(self, caplog):
+        """ac_entity_device_binding maps digest table_type to ac_binding."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+        ttl_before_ms = _ttl_ms(10)
+        mock_facade.get_device_info = AsyncMock(
+            side_effect=[
+                MagicMock(ttl_timestamp=ttl_before_ms),
+                MagicMock(ttl_timestamp=ttl_before_ms + 839 * 60 * 1000),
+            ]
+        )
+        mock_facade.extend_ttl = AsyncMock(return_value=True)
+        mock_repo.update_after_success = MagicMock()
+
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        result = await scheduler._renew_one(
+            _renewal_record(source_table="ac_entity_device_binding")
+        )
+
+        assert result == "success"
+        lines = self._digest_lines(caplog)
+        assert len(lines) == 1
+        assert lines[0].split(",")[4] == "ac_binding"
+
+    @pytest.mark.asyncio
+    async def test_run_uuid_threaded_into_digest_second_field(self, caplog):
+        """An explicit run_uuid becomes the digest second field verbatim."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+        mock_facade.get_device_info = AsyncMock(side_effect=Exception("timeout"))
+        mock_repo.update_after_failure = MagicMock()
+
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        await scheduler._renew_one(_renewal_record(), run_uuid="u-mr")
+
+        lines = self._digest_lines(caplog)
+        assert len(lines) == 1
+        assert lines[0].split(",")[1] == "u-mr"
+
+    @pytest.mark.asyncio
+    async def test_missing_run_uuid_falls_back_to_fresh_uuid(self, caplog):
+        """Direct invocation without run_uuid falls back to a fresh uuid4
+        (byte-identical behavior to the legacy renew_ttl path)."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+        mock_facade.get_device_info = AsyncMock(
+            return_value=MagicMock(ttl_timestamp=None)
+        )
+        mock_repo.update_after_failure = MagicMock()
+
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        await scheduler._renew_one(_renewal_record())
+
+        lines = self._digest_lines(caplog)
+        assert len(lines) == 1
+        second = lines[0].split(",")[1]
+        assert second and second != "None"
+
+    @pytest.mark.asyncio
+    async def test_process_one_routes_renewal_raise_to_failed_digest(self, caplog):
+        """A _renew_one raise routed to failure accounting still emits a
+        failed digest line — no silent terminal path."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+        mock_repo.count_active.return_value = 1
+        mock_repo.count_hot_arca_devices.return_value = 1
+        mock_repo.count_hot_arca_bindings.return_value = 0
+        mock_repo.find_unregistered.return_value = []
+        mock_repo.update_after_failure = MagicMock()
+        # update_after_success raises → _renew_one raises out of the h3 path
+        mock_repo.update_after_success = MagicMock(side_effect=Exception("DB down"))
+
+        mock_facade.get_device_info = AsyncMock(
+            return_value=MagicMock(ttl_timestamp=_ttl_ms(10))
+        )
+        mock_facade.extend_ttl = AsyncMock(return_value=True)
+
+        mock_repo.list_due_for_renewal.side_effect = [[_renewal_record()], []]
+
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        scheduler._round_count = 0
+        report = await scheduler._run_once()
+
+        assert report.failure == 1
+        lines = self._digest_lines(caplog)
+        assert len(lines) == 1
+        fields = lines[0].split(",")
+        assert fields[6] == "failed"
+        assert fields[7] == "-"
+        assert fields[8] == "-"
+
+    @pytest.mark.asyncio
+    async def test_process_one_failure_accounting_raise_still_emits_failed_digest(
+        self, caplog
+    ):
+        """Even failure accounting raising still emits a failed digest line —
+        the second-level fallback is not silent."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+        mock_repo.count_active.return_value = 1
+        mock_repo.count_hot_arca_devices.return_value = 1
+        mock_repo.count_hot_arca_bindings.return_value = 0
+        mock_repo.find_unregistered.return_value = []
+        mock_repo.update_after_failure = MagicMock(side_effect=Exception("DB down"))
+
+        mock_facade.get_device_info = AsyncMock(side_effect=Exception("timeout"))
+
+        mock_repo.list_due_for_renewal.side_effect = [[_renewal_record()], []]
+
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        scheduler._round_count = 0
+        report = await scheduler._run_once()
+
+        assert report.failure == 1
+        lines = self._digest_lines(caplog)
+        assert len(lines) == 1
+        fields = lines[0].split(",")
+        assert fields[6] == "failed"
+        assert fields[7] == "-"
+        assert fields[8] == "-"

--- a/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
@@ -1700,6 +1700,48 @@ class TestRenewalDigestLogging:
         assert fields[8] == "-"
 
     @pytest.mark.asyncio
+    async def test_pathological_ttl_digest_format_failure_uses_placeholder(self, caplog):
+        """ME-01: a numeric-but-pathological ttl_timestamp (huge negative
+        epoch overflowing the datetime range) flows through failure
+        accounting exactly once; the digest TTL formatter's failure
+        degrades to the legacy "-" placeholders instead of raising out of
+        _renew_one."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+
+        pathological_ms = -(10**19)
+        # Setup guard: the chosen value really does raise when formatted
+        # (the concrete exception class varies by platform).
+        with pytest.raises((OverflowError, OSError, ValueError)):
+            format_ttl_expiration_time(float(pathological_ms))
+
+        mock_facade.get_device_info = AsyncMock(
+            return_value=MagicMock(ttl_timestamp=pathological_ms)
+        )
+        mock_facade.extend_ttl = AsyncMock()
+        mock_repo.update_after_failure = MagicMock()
+
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        result = await scheduler._renew_one(_renewal_record())
+
+        # (a) The pathological TTL never propagates an exception.
+        assert result == "failed"
+        # (b) No double accounting: failure handling ran exactly once — the
+        # guarded digest formatting did not re-route the record through
+        # _process_one's failure fallback.
+        mock_facade.extend_ttl.assert_not_awaited()
+        mock_repo.update_after_failure.assert_called_once()
+        # (c) The digest row exists with legacy "-" TTL placeholders.
+        lines = self._digest_lines(caplog)
+        assert len(lines) == 1
+        fields = lines[0].split(",")
+        assert fields[6] == "failed"
+        assert fields[7] == "-"
+        assert fields[8] == "-"
+        # The formatter failure is warned on core-scheduler, never emitted
+        # into the digest stream.
+        assert any("digest ttl format failed" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
     async def test_stopped_outcome_maps_to_failure_digest_result(self, caplog):
         """Threshold STOPPED maps the digest result to "failure" (not
         "stopped") — monitor vocabulary stays two-valued success/failure."""

--- a/src/baas/tests/unit/core/utils/test_renewal_digest.py
+++ b/src/baas/tests/unit/core/utils/test_renewal_digest.py
@@ -12,9 +12,9 @@ import logging
 
 import pytest
 
-from secbaas.community.core.utils import _renewal_digest
-from secbaas.community.core.utils._renewal_digest import (
+from secbaas.community.core.utils import (
     RENEWAL_DIGEST_LOGGER,
+    _renewal_digest,
     log_renew_digest,
     ttl_for_digest,
 )

--- a/src/baas/tests/unit/core/utils/test_renewal_digest.py
+++ b/src/baas/tests/unit/core/utils/test_renewal_digest.py
@@ -1,0 +1,128 @@
+"""Contract tests for the neutral renewal digest module (``_renewal_digest.py``).
+
+The ``arca-renew-digest`` CSV line is a monitoring contract: the logger name,
+field order and separators must stay byte-identical to the legacy
+``_sandbox_device_router`` emission, otherwise the monitor pipeline can no
+longer parse the renewal success/failure stream. These tests pin that
+contract together with the re-export compatibility layer that keeps legacy
+imports working until Phase 3 removes the router class.
+"""
+
+import logging
+
+import pytest
+
+from secbaas.community.core.utils import _renewal_digest
+from secbaas.community.core.utils._renewal_digest import (
+    RENEWAL_DIGEST_LOGGER,
+    log_renew_digest,
+    ttl_for_digest,
+)
+
+_MODULE_LOGGER_NAME = _renewal_digest.__name__
+
+_EXPECTED_FULL_LINE = (
+    "ttl_renew_digest,u-001,renew,42,baas,ARCA-SANDBOX-xxx@10,success,"
+    "2026-05-27-21:15:05,2026-05-27-23:15:05"
+)
+
+
+def test_logger_name_is_the_monitor_collection_contract():
+    assert RENEWAL_DIGEST_LOGGER.name == "arca-renew-digest"
+
+
+@pytest.mark.parametrize(
+    ("ttl", "expected"),
+    [
+        (None, "-"),
+        ("", "-"),
+        ("2026-05-27 21:15:05", "2026-05-27-21:15:05"),
+    ],
+)
+def test_ttl_for_digest_normalization(ttl, expected):
+    assert ttl_for_digest(ttl) == expected
+
+
+def test_digest_line_format_contract(caplog):
+    caplog.set_level(logging.INFO, logger="arca-renew-digest")
+    log_renew_digest(
+        run_uuid="u-001",
+        table_id=42,
+        table_type="baas",
+        arca_device_id="ARCA-SANDBOX-xxx@10",
+        result="success",
+        ttl_before="2026-05-27 21:15:05",
+        ttl_after="2026-05-27 23:15:05",
+    )
+    # Exactly one record on the digest logger and it is byte-identical to the
+    # legacy CSV contract (spaces normalized to hyphens inside TTL fields).
+    assert len(caplog.messages) == 1
+    assert caplog.messages[0] == _EXPECTED_FULL_LINE
+    record = caplog.records[0]
+    assert record.name == "arca-renew-digest"
+    assert record.levelno == logging.INFO
+    # Exactly 9 comma-separated fields, no stray spaces anywhere in the line.
+    assert len(caplog.messages[0].split(",")) == 9
+    assert " " not in caplog.messages[0]
+
+
+def test_digest_line_uses_dash_placeholder_for_missing_ttl(caplog):
+    caplog.set_level(logging.INFO, logger="arca-renew-digest")
+    log_renew_digest(
+        run_uuid="u-002",
+        table_id=42,
+        table_type="baas",
+        arca_device_id="ARCA-SANDBOX-xxx@10",
+        result="success",
+        ttl_before=None,
+        ttl_after="",
+    )
+    assert len(caplog.messages) == 1
+    assert caplog.messages[0] == (
+        "ttl_renew_digest,u-002,renew,42,baas,ARCA-SANDBOX-xxx@10,success,-,-"
+    )
+
+
+def test_digest_log_is_best_effort_on_logger_failure(monkeypatch, caplog):
+    caplog.set_level(logging.INFO, logger="arca-renew-digest")
+    caplog.set_level(logging.WARNING, logger=_MODULE_LOGGER_NAME)
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated logging backend failure")
+
+    monkeypatch.setattr(_renewal_digest.RENEWAL_DIGEST_LOGGER, "info", boom)
+
+    # Must not propagate the logging failure to the renewal flow.
+    log_renew_digest(
+        run_uuid="u-003",
+        table_id=1,
+        table_type="baas",
+        arca_device_id="ARCA-SANDBOX-xxx@10",
+        result="success",
+        ttl_before=None,
+        ttl_after=None,
+    )
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and "ttl_renew_digest" in r.getMessage()
+    ]
+    assert warnings, "expected a defensive warning for the failed digest log"
+    assert all(r.name == _MODULE_LOGGER_NAME for r in warnings)
+
+
+def test_router_reexport_keeps_legacy_import_compatible():
+    from secbaas.community.core.service.health_check.sandbox._sandbox_device_router import (
+        _log_renew_digest,
+        _ttl_for_digest,
+        arca_renew_digest_logger,
+    )
+
+    # Legacy names resolve to the neutral-module objects — same logger, same
+    # functions, so pre-existing importers keep working byte-identically.
+    assert _log_renew_digest is log_renew_digest
+    assert _ttl_for_digest is ttl_for_digest
+    assert arca_renew_digest_logger is RENEWAL_DIGEST_LOGGER
+    assert arca_renew_digest_logger.name == "arca-renew-digest"
+    assert _ttl_for_digest("2026-05-27 21:15:05") == "2026-05-27-21:15:05"


### PR DESCRIPTION
feat(baas): emit legacy ttl_renew_digest alarm log from deadline renewal scheduler

  ## Problem

  The new deadline-driven renewal engine (`DeadlineRenewalScheduler`, driven by the
  `baas_bot_ttl_renewal_schedule` cold table) is replacing the legacy
  `SandboxDeviceRouter` renewal path, and production configs have already flipped
  `renewal_scheduler.engine = "deadline"`. The renewal success/failure alarms are
  configured on the monitor platform against the legacy `ttl_renew_digest` CSV log
  (collected by logger name `arca-renew-digest`). The new engine emitted none of
  these rows, so after the flip the renewal failure-rate alarm silently goes blind.
  Reusing the legacy log — not inventing a new one — keeps the existing alerting
  in effect with zero monitor-side reconfiguration.

  ## Solution

  - Extract the digest trio (logger, `log_renew_digest`, `ttl_for_digest`) from
    `_sandbox_device_router.py` into a neutral module
    `core/utils/_renewal_digest.py`; the router re-exports them under the legacy
    names, so legacy output is byte-identical (behavior-neutral refactor, pinned by
    identity tests).
  - Instrument every terminal branch of `DeadlineRenewalScheduler._renew_one`
    (9 branches) plus both `_process_one` fallback paths with exactly one
    `ttl_renew_digest` row each — no silently unlogged termination.
  - Result vocabulary is projected strictly into the legacy enum
    `{success, skipped, failure}`; the new engine's internal outcomes
    `stopped`/`failed` both fold into `failure`. `source_table` maps to the legacy
    `table_type` vocabulary (`baas_device→baas`, `ac_entity_device_binding→ac_binding`).
    TTL epoch-ms values are formatted with the fixed +08:00 wall clock, empty values
    fall back to the `-` placeholder — same shape as the legacy stream.
  - Digest emission is hard best-effort: a guarded `_digest_ttl` helper wraps the
    float/format calls so pathological TTL values degrade to the `-` placeholder
    instead of raising; logging can never re-route the renewal control flow (a
    raise after `_handle_failure` accounting would have triggered double failure
    accounting via `_process_one`'s fallback).

  Rejected alternative: a new digest topic or report format for the new engine —
  would require new monitor configuration and a heterogeneous alert stream during
  the gray window. The whole point is continuity of the existing alarm contract.

  ## Validation

  - Unit tests: `tests/unit/core/service/scheduler/test_deadline_renewal_task.py` +
    `tests/unit/core/utils/test_renewal_digest.py` — 73 passed (includes the new
    `TestRenewalDigestLogging` class and the pathological-TTL placeholder test;
    all pre-existing scheduler tests pass unchanged).
  - New contract tests pin: logger name `arca-renew-digest`, exact 9-field CSV
    order, space→dash TTL normalization, `-` placeholders, both mapping tables,
    run_uuid threading with uuid4 fallback, single-row emission per branch.
  - `ruff check` passes on all changed files.
  - Could not run locally: full pytest collection in the dev venv fails on a
    pre-existing pydantic/dependency_injector incompatibility (unrelated to this
    change); full suite and coverage gates run in CI.

  ## Compatibility and risk

  - Monitoring contract preserved: logger name and CSV shape byte-identical to
    legacy; result column strictly within the legacy vocabulary. No monitor
    reconfiguration needed.
  - Legacy `SandboxDeviceRouter` behavior unchanged (pure re-export refactor);
    Phase 3 can later delete the router class without losing the digest.
  - `_renew_one(record)` callable without run_uuid (uuid4 fallback) — existing
    call sites and tests unaffected.
  - No new dependencies, no schema/config change. Rollback: revert the commits;
    the refactor is behavior-neutral and the legacy path keeps emitting as before.