### PR TITLE
fix(backend): complete effective MCP artifact projection

### DIFF
--- a/src/backend/specs/2026-08-28-effective-mcp-artifact-completeness/plan.md
+++ b/src/backend/specs/2026-08-28-effective-mcp-artifact-completeness/plan.md
@@ -1,0 +1,33 @@
+# Plan — Effective MCP Artifact 完备性修复
+
+## Baseline and seams
+
+- Base: 最新 `REL20260828`。
+- Domain seam: `RuntimeProjectionResolver` 的 Effective MCP union。
+- Query seam: `SkillSetService.collect_bot_active_mcps()`。
+- Artifact seam: `ConfigComposerInputCollector.mcps()`。
+- Installation、Dispatcher、DeviceSync 和 Teclaw wire 不修改。
+
+## Vertical slices
+
+### 1. Skill dependency 进入 Artifact Effective MCP
+
+Red：真实 Installation 数据中只有 Skill Installation 和 dependency，断言
+`collect_bot_active_mcps()` 返回 dependency，同时 MCP Installation 仍为空。
+
+Green：抽取 Resolver 已有的 Effective MCP union，让 Runtime Projection 与查询链路共用；
+查询链路从 `BotCapabilityStateReader.active_skill_assets()` 读取已安装 Skill 声明。
+
+### 2. 完整 Artifact 使用 strict policy context
+
+Red：断言 Artifact collector 调用 Effective MCP 查询时声明 strict policy context。
+
+Green：`ConfigComposerInputCollector.mcps()` 固定传入 `strict_policy_context=True`。
+
+## Verification
+
+1. 每个 slice 单文件执行 red -> green。
+2. 运行 Runtime resolver、Effective MCP union、Collector 和 Teclaw DeviceSync 测试。
+3. 运行受影响 Skill Center、Config Compose 与 Backend 测试套件。
+4. 运行 Backend lint/static/type gates；无法运行的门禁精确记录原因。
+5. 对 `REL20260828...HEAD` 执行 Standards 与本 Spec 双轴 review，修复阻断发现后提交。

--- a/src/backend/specs/2026-08-28-effective-mcp-artifact-completeness/spec.md
+++ b/src/backend/specs/2026-08-28-effective-mcp-artifact-completeness/spec.md
@@ -1,0 +1,61 @@
+# Effective MCP Artifact 完备性修复
+
+## Status
+
+本文件记录 2026-08-28 owner review 后批准的独立 follow-up。它不改变
+`2026-08-27-mcp-effective-retained-projection` 已交付的 mutation scope 语义，只补齐完整
+Artifact 消费者读取 Effective MCP 时遗漏的 Skill dependency，并收紧完整 Artifact 的
+policy context 失败行为。
+
+## Problem
+
+`RuntimeProjectionResolver` 已将显式 MCP Installation、System Default MCP 和已安装 Skill
+声明的 `mcp_dependencies` 合并为 Effective MCP。但
+`SkillSetService.collect_bot_active_mcps()` 只返回 Default policy 与显式 MCP
+Installation，导致 `ConfigComposer` 生成的 Artifact 遗漏 Skill dependency。
+
+`ConfigComposerInputCollector.mcps()` 同时使用宽松的 policy context 查询。完整 Artifact
+是覆盖式输出；若模板或 Default policy 上下文查询失败并降级为空，继续投递会把暂时无法
+读取误解释为删除。
+
+## Required semantics
+
+```text
+Effective MCP
+  = Explicit MCP Installation
+  ∪ Dependencies(Installed Skills)
+  ∪ Effective Default MCP
+```
+
+- `BotMCPInstallation` 只保存显式安装事实；Skill dependency 是从
+  `BotSkillInstallation -> ac_skill.mcp_dependencies` 派生的供应，不物化为 MCP
+  Installation。
+- `RuntimeProjectionResolver` 与 `collect_bot_active_mcps()` 必须共用同一 Effective MCP
+  union 算法。
+- Default exclusion 只移除 Default 供应；同 code 仍由显式 Installation 或 Skill
+  dependency 供应时继续 Effective。
+- `ConfigComposer` 收集完整 Artifact 时必须使用 strict policy context。必要 policy
+  上下文读取失败时 compose 失败，不产生或投递缩水 Artifact。
+- 同一 code 来自多个供应时只输出一次，并保留现有 metadata precedence。
+
+## Compatibility
+
+- 不新增或修改数据库表、字段、迁移和 Installation provenance。
+- 不修改 HTTP、Service API、Plugin API、Dispatcher 或 Teclaw `/api/v1/bot/apply` wire。
+- 不增加 provider/engine 业务分叉；strict policy context 适用于所有完整 Artifact compose。
+- 现有 Default row、Default policy、ordinary SkillSet metadata precedence 保持不变。
+
+## Explicitly out of scope
+
+- Local Skill 和 Center/Phase 2 Skill 投影。
+- Teclaw 一次 mutation 的重复 whole-artifact delivery；由独立工作处理。
+- Retained MCP 持久化模型、inactive cleanup、DeviceActivated 扩展。
+- 并发、性能、task queue 和完整协作者权限模型。
+
+## Acceptance criteria
+
+1. 已安装 Skill 的 MCP dependency 出现在 `collect_bot_active_mcps()` 和最终 Artifact 输入中。
+2. dependency 不创建 `BotMCPInstallation` 行。
+3. dependency 与显式 Installation 或 Default 重合时去重，任一剩余供应可保持其 Effective。
+4. Runtime Projection 与 Artifact collection 使用同一个 dependency decoder 和 union 算法。
+5. 完整 Artifact policy context 查询失败时 compose 失败，不继续投递部分结果。

--- a/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
@@ -197,6 +197,7 @@ class ConfigComposerInputCollector(ComposeInputCollector):
             user_id=req.user_id,
             entity_type=req.entity_type,
             engine_type=req.engine_type,
+            strict_policy_context=True,
         )
         # ``collect_bot_active_mcps`` returns only the skill-set association fields
         # (server_code/name/…) — it deliberately does NOT call MCP Center. The

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -21,6 +21,7 @@ provides:
   - "BotCapabilityAuthorizationHookProtocol"
   - "SkillSetManagementService"
   - "RuntimeProjectionResolver"
+  - "resolve_effective_mcp_server_codes"
   - "BotCapabilityStateReader"
   - "BotRuntimeProjector"
   - "BotRuntimeProjectorProtocol"

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_resolver.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_resolver.py
@@ -65,6 +65,30 @@ class RuntimeNamePolicy:
         return name
 
 
+def resolve_effective_mcp_server_codes(
+    state: RuntimeDesiredState,
+) -> tuple[str, ...]:
+    """Resolve every MCP supply selected by one desired-state snapshot.
+
+    Explicit MCP Installation, system defaults, and dependencies declared by
+    installed Skills are distinct facts. They meet only in this derived
+    Effective projection; dependency supply is never materialized as an
+    explicit MCP Installation row.
+    """
+    mcp_codes = set(state.installed_mcp_server_codes)
+    mcp_codes.update(state.system_default_mcp_server_codes)
+    for asset in state.skills:
+        try:
+            mcp_codes.update(mcp_dependency_codes(asset.mcp_dependencies))
+        except ValueError as exc:
+            raise ValueError(
+                "invalid Skill MCP dependency in runtime projection"
+            ) from exc
+    if any(not isinstance(code, str) or not code for code in mcp_codes):
+        raise ValueError("invalid MCP server code in runtime projection")
+    return tuple(sorted(mcp_codes))
+
+
 class RuntimeProjectionResolver:
     """Build the deduplicated Local/Repo/Center/MCP/CLI snapshot."""
 
@@ -80,23 +104,10 @@ class RuntimeProjectionResolver:
             mappings = build_logical_skill_mappings(list(assets))
         except RuntimeMappingNameConflictError as exc:
             raise RuntimeNameConflictError() from exc
-        mcp_codes = set(state.installed_mcp_server_codes)
-        mcp_codes.update(state.system_default_mcp_server_codes)
-        for asset in assets:
-            try:
-                # Shared with the command that scopes a Skill mutation, so the
-                # set a mutation declares is the set this resolves.
-                mcp_codes.update(mcp_dependency_codes(asset.mcp_dependencies))
-            except ValueError as exc:
-                raise ValueError(
-                    "invalid Skill MCP dependency in runtime projection"
-                ) from exc
-        if any(not isinstance(code, str) or not code for code in mcp_codes):
-            raise ValueError("invalid MCP server code in runtime projection")
         return RuntimeProjection(
             skill_mappings=tuple(mappings),
             skill_assets=assets,
-            mcp_server_codes=tuple(sorted(mcp_codes)),
+            mcp_server_codes=resolve_effective_mcp_server_codes(state),
             cli_commands=tuple(dict.fromkeys(state.system_default_cli_commands)),
         )
 
@@ -107,4 +118,5 @@ __all__ = [
     "RuntimeNamePolicy",
     "RuntimeProjection",
     "RuntimeProjectionResolver",
+    "resolve_effective_mcp_server_codes",
 ]

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
         DeviceContextResolver,
     )
     from agentclaw.community.plugin_api.device_sync_dispatcher import DeviceSyncDispatcher
+    from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
 from agentclaw.community.core.mcp.services._defaults import (
     get_default_mcp_config,
     get_default_mcp_server_codes,
@@ -36,6 +37,10 @@ from agentclaw.community.core.skill_center.policies.default_skill_set_selection 
 )
 from agentclaw.community.core.skill_center.path_resolution import (
     canonical_pool_local_path,
+)
+from agentclaw.community.core.skill_center.runtime_resolver import (
+    RuntimeDesiredState,
+    resolve_effective_mcp_server_codes,
 )
 from agentclaw.community.core.skill_center.utils.skill_metadata_writer import SkillSetMetadataWriter
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE  # noqa: E402
@@ -1588,7 +1593,7 @@ class SkillSetService:
         *,
         strict_policy_context: bool = False,
     ) -> List[dict]:
-        """Effective MCPs = default policy ∪ installed.
+        """Effective MCPs = default policy ∪ installed ∪ Skill dependencies.
 
         The Default half keeps its proven projection: static engine/template
         defaults plus Default-Set rows, minus this Bot's exclusions. Ordinary
@@ -1655,11 +1660,19 @@ class SkillSetService:
                 seen_server_codes=seen_server_codes,
             )
         )
-        active_mcps.extend(
-            self._installed_only_mcp_entries(
-                installed_codes=self._installed_mcp_codes(
+        effective_non_default_codes = resolve_effective_mcp_server_codes(
+            RuntimeDesiredState(
+                skills=self._active_skill_assets(
                     entity_id=entity_id, bot_id=bot_id, user_id=user_id
                 ),
+                installed_mcp_server_codes=self._installed_mcp_codes(
+                    entity_id=entity_id, bot_id=bot_id, user_id=user_id
+                ),
+            )
+        )
+        active_mcps.extend(
+            self._non_default_effective_mcp_entries(
+                effective_codes=effective_non_default_codes,
                 active_skill_sets=active_skill_sets,
                 seen_server_codes=seen_server_codes,
             )
@@ -1766,21 +1779,44 @@ class SkillSetService:
             )
             return frozenset()
 
-    def _installed_only_mcp_entries(
+    def _active_skill_assets(
+        self, *, entity_id: str, bot_id: str, user_id: str
+    ) -> tuple["RegisteredSkillAsset", ...]:
+        """Installed Skill assets whose declarations supply derived MCP codes."""
+        try:
+            return self._reader.active_skill_assets(
+                bot_id=bot_id, owner_id=user_id
+            )
+        except LocalSkillNotFoundError:
+            bot = self._bot_repo.get_by_id_and_entity(bot_id, entity_id)
+            owner = str(bot.get("owner_id") or "") if bot else ""
+            if bot is not None and owner and owner != user_id:
+                return self._reader.active_skill_assets(
+                    bot_id=bot_id, owner_id=owner, bot=bot
+                )
+            logger.warning(
+                "[collect_bot_active_mcps] Bot not found while reading Skill "
+                "dependencies: user_id=%s, bot_id=%s",
+                user_id,
+                bot_id,
+            )
+            return ()
+
+    def _non_default_effective_mcp_entries(
         self,
         *,
-        installed_codes,
+        effective_codes,
         active_skill_sets: List[dict],
         seen_server_codes: set,
     ) -> List[dict]:
-        """Installed codes no Default entry covered, with membership metadata.
+        """Non-default Effective codes, enriched from membership when possible.
 
         An ordinary Set's association row is the best metadata an installed
-        code can have; a direct installation has none, so its entry is
-        minimal.
+        code can have. Direct Installation and Skill dependency supply have no
+        membership row, so their entries are minimal.
         """
         missing_codes = [
-            code for code in sorted(installed_codes)
+            code for code in sorted(effective_codes)
             if code not in seen_server_codes
         ]
         if not missing_codes:

--- a/src/backend/tests/community/core/config_compose/test_collector.py
+++ b/src/backend/tests/community/core/config_compose/test_collector.py
@@ -174,6 +174,23 @@ def test_mcps_run_collect_then_per_server_merge():
     assert mcp_cfg.build_mcp_sync_payload.call_count == 2
 
 
+@pytest.mark.unit
+def test_mcps_require_strict_policy_context_for_a_complete_artifact():
+    svc = MagicMock()
+    svc.collect_bot_active_mcps.return_value = []
+
+    assert _collector(skill_set_service=svc).mcps(_req()) == []
+
+    svc.collect_bot_active_mcps.assert_called_once_with(
+        entity_id="staff_u1",
+        bot_id="bot1",
+        user_id="u1",
+        entity_type="staff",
+        engine_type="openclaw",
+        strict_policy_context=True,
+    )
+
+
 _HITL_CATALOG = {
     "hitl": {
         "command": "python3",

--- a/src/backend/tests/community/core/skill_center/services/test_collect_bot_active_mcps_union.py
+++ b/src/backend/tests/community/core/skill_center/services/test_collect_bot_active_mcps_union.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.base import Base
 from agentclaw.community.core.models.mcp import BotMCPInstallation, SkillSetMCPServer
-from agentclaw.community.core.models.skill import SkillSet
+from agentclaw.community.core.models.skill import BotSkillInstallation, Skill, SkillSet
 from agentclaw.community.core.repository.implementations.skill_center.capability_desired_state import (
     CapabilityDesiredStateRepository,
 )
@@ -209,6 +209,39 @@ def test_a_direct_installation_appears_with_minimal_metadata(tmp_path):
             "is_default": False,
         }
     ]
+
+
+def test_an_installed_skills_mcp_dependency_is_effective_without_mcp_installation(
+    tmp_path,
+):
+    """Skill Installation supplies its declared MCP dependency without turning
+    that derived supply into an explicit MCP Installation fact."""
+    db = _Database()
+    with db.transactional_orm_session() as session:
+        skill = Skill(
+            name="weather-skill",
+            git_path="git://team/weather-skill",
+            mcp_dependencies='["mcp.weather"]',
+            env="dev",
+        )
+        session.add(skill)
+        session.flush()
+        session.add(
+            BotSkillInstallation(
+                bot_id="bot",
+                owner_id="owner",
+                skill_id=skill.id,
+                env="dev",
+            )
+        )
+
+    result = _service(db, tmp_path).collect_bot_active_mcps(
+        entity_id="owner", bot_id="bot", user_id="owner"
+    )
+
+    assert [entry["server_code"] for entry in result] == ["mcp.weather"]
+    with db.orm_session() as session:
+        assert session.query(BotMCPInstallation).all() == []
 
 
 def test_strict_runtime_policy_context_propagates_provider_failure(tmp_path):


### PR DESCRIPTION
## Problem

RuntimeProjectionResolver already included MCP dependencies declared by installed Skills, but SkillSetService.collect_bot_active_mcps only returned Default policy and explicit MCP Installation. ConfigComposer therefore produced a narrower whole Artifact that could omit a Skill dependency. Artifact composition also used fail-open policy-context reads, which could turn a temporary Default-policy lookup failure into an incomplete overwrite.

## Solution

- Extract one Effective MCP union shared by RuntimeProjectionResolver and collect_bot_active_mcps.
- Derive Skill MCP dependencies from installed Skill assets without materializing BotMCPInstallation rows.
- Preserve existing Default and membership metadata precedence while deduplicating codes from multiple supplies.
- Require strict policy context for complete Artifact composition so lookup failures abort before delivery.
- Keep Local Skill, Center/Phase 2 Skill, Dispatcher, database schema, and the Teclaw /api/v1/bot/apply wire unchanged.

## Validation

- TDD regression: verified the dependency case failed before implementation and passed afterward.
- Focused seams: 95 passed.
- Affected Skill Center, Config Compose, MCP and Teclaw suites: 1211 passed, 22 skipped.
- Full Backend community suite: 15116 passed, 57 skipped.
- Backend CI gate: passed; line coverage 87.62%, changed-line coverage 91.04%.
- Backend Python SAST: passed.
- Ruff lint on changed Python files: passed.
- Standards review: 0 hard violations; one non-blocking duplicated owner-fallback judgement call retained to keep this fix minimal.
- Spec review: 0 findings.

## Compatibility and risk

No HTTP, Service API, Plugin API, Dispatcher, database schema, migration, or external Teclaw contract change. Skill dependencies remain derived Effective supply rather than explicit Installation provenance. Strict Artifact composition intentionally turns policy-context uncertainty into a failed projection instead of delivering a smaller overwrite. Rollback is a single commit revert.

Singlebox was not run because this change does not modify HTTP/device wire or acceptance paths; the complete Backend CI gate was run locally.

## Spec

- src/backend/specs/2026-08-28-effective-mcp-artifact-completeness/spec.md
- src/backend/specs/2026-08-28-effective-mcp-artifact-completeness/plan.md