### PR TITLE
fix(backend): preserve SkillSet owner for collaborator batches

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
@@ -725,6 +725,9 @@ async def add_skills_to_set(
     ),
 ) -> AddSkillsResponse:
     """Add skills to a skill set."""
+    # The published batch body carries the addressed Bot owner in ``user_id``;
+    # the authenticated actor still comes exclusively from ``ctx`` below.
+    owner_id_hint = request.user_id or entity_id
     # Preserve omission so the legacy resolver can recover a non-default Bot.
     bot_id_hint = request.bot_id or bot_id
     (
@@ -737,7 +740,7 @@ async def add_skills_to_set(
     ) = _get_skill_set_path_params(
         ctx,
         set_id=skill_set_id,
-        entity_id=entity_id,
+        entity_id=owner_id_hint,
         entity_type=entity_type,
         bot_id=bot_id_hint,
         engine_type=engine_type,

--- a/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
+++ b/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
@@ -324,6 +324,50 @@ async def test_legacy_skill_set_batch_keeps_domain_partial_success() -> None:
 
 
 @pytest.mark.asyncio
+async def test_legacy_skill_set_batch_uses_body_owner_for_collaborator() -> None:
+    class _ControlPlane:
+        def get_set(self, **kwargs):
+            assert kwargs == {
+                "bot_id": "bot",
+                "owner_id": "owner",
+                "user_id": "collaborator",
+                "set_id": "set-1",
+            }
+            return {"id": "set-1", "is_default": False}
+
+        def resolve_legacy_skill_id(self, **kwargs):
+            assert kwargs["bot_id"] == "bot"
+            assert kwargs["owner_id"] == "owner"
+            assert kwargs["actor_id"] == "collaborator"
+            return kwargs["identifier"]
+
+        async def add_skill(self, **kwargs):
+            assert kwargs == {
+                "bot_id": "bot",
+                "owner_id": "owner",
+                "user_id": "collaborator",
+                "set_id": "set-1",
+                "skill_id": "7",
+            }
+
+    response = await add_skills_to_set(
+        "set-1",
+        AddSkillsRequest(skill_ids=["7"], user_id="owner", bot_id="bot"),
+        entity_id=None,
+        entity_type=None,
+        bot_id=None,
+        engine_type=None,
+        ctx=SimpleNamespace(user_id="collaborator", bot_id="default"),
+        bot_repo=_Bots(),
+        control_plane=_ControlPlane(),
+    )
+
+    assert response.success is True
+    assert response.data["success"] == [{"skill_id": "7", "name": "7"}]
+    assert response.data["failed"] == []
+
+
+@pytest.mark.asyncio
 async def test_legacy_skill_set_batch_validates_target_before_materialising_asset() -> (
     None
 ):


### PR DESCRIPTION
## Problem

The legacy `POST /api/skillsets/{skill_set_id}/skills` batch route accepts the addressed Bot owner and Bot ID in its JSON body. For collaborator calls, the permission interceptor correctly checked the authenticated actor against `request.user_id` and `request.bot_id`, but the handler only forwarded the optional query `entity_id` into SkillSet scope resolution.

When the body supplied an explicit non-default Bot and the query omitted `entity_id`, scope recovery preserved the explicit Bot, the owner fell back to the authenticated collaborator, and the strict Bot-scoped Set lookup returned `404 Skill set not found` for an existing Set. This was reproduced in pre-production trace `0b446a1f17878965695465022e946d`.

## Solution

- Restore the published legacy body mapping by deriving the owner hint from `request.user_id` before the optional query `entity_id`.
- Keep the authenticated actor sourced exclusively from the request context.
- Preserve strict explicit-Bot behavior and the existing omitted-Bot Set-ID recovery seam.
- Add a regression test where an authenticated collaborator operates an owner-qualified Bot using only the legacy JSON body address.

## Validation

- Regression test failed before the fix with `owner_id='collaborator'` and passed after the fix.
- 112 passed: legacy SkillSet adapter, error mapping, Rule 15 BFF contract, and SkillSet management service suites.
- Complete Backend architecture suite passed.
- Ruff passed for both changed Python files.
- Backend local Python SAST block scan passed (exit code 0).
- `git diff --check` passed.

OpenAPI dump/publish scripts were not required: this change does not modify a public `/openapi/v1` route, parameter, or schema.

## Compatibility and risk

No route, response, database, runtime-projection, or public OpenAPI contract changes are introduced. Owner-operated requests retain the existing fallback behavior. Collaborator requests now use the same owner+Bot address for authorization and strict business lookup. Explicit Bot IDs are never redirected to another Bot.
