### PR TITLE
fix(backend): preserve owner across legacy SkillSet routes

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/schemas.py
@@ -148,7 +148,10 @@ class AddSkillsToSetRequest(BaseModel):
 # AddSkillsRequest is the skillsets router version (same shape, kept for clarity)
 class AddSkillsRequest(BaseModel):
     skill_ids: List[str] = Field(..., description="List of skill IDs to add")
-    user_id: Optional[str] = Field(None, description="User ID for permission check")
+    user_id: Optional[str] = Field(
+        None,
+        description="Target Bot owner ID for legacy routing and permission checks",
+    )
     bot_id: Optional[str] = Field(None, description="Bot ID (optional, default: default)")
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
@@ -499,6 +499,7 @@ async def get_skill_set(
     ),
 ) -> SkillSetDetailResponse:
     """Get a skill set by ID."""
+    owner_id_hint = user_id or entity_id
     # Get effective path parameters
     (
         effective_entity_id,
@@ -510,7 +511,7 @@ async def get_skill_set(
     ) = _get_skill_set_path_params(
         ctx,
         set_id=skill_set_id,
-        entity_id=entity_id,
+        entity_id=owner_id_hint,
         entity_type=entity_type,
         bot_id=bot_id,
         engine_type=engine_type,
@@ -550,6 +551,7 @@ async def update_skill_set(
     ),
 ) -> SkillSetDetailResponse:
     """Update a skill set."""
+    owner_id_hint = request.user_id or entity_id
     # Preserve omission so the legacy resolver can recover a non-default Bot.
     bot_id_hint = bot_id or request.bot_id
     (
@@ -562,7 +564,7 @@ async def update_skill_set(
     ) = _get_skill_set_path_params(
         ctx,
         set_id=skill_set_id,
-        entity_id=entity_id,
+        entity_id=owner_id_hint,
         entity_type=entity_type,
         bot_id=bot_id_hint,
         engine_type=engine_type,
@@ -609,6 +611,7 @@ async def delete_skill_set(
     ),
 ) -> MessageResponse:
     """Delete a skill set."""
+    owner_id_hint = user_id or entity_id
     (
         effective_entity_id,
         effective_bot_id,
@@ -619,7 +622,7 @@ async def delete_skill_set(
     ) = _get_skill_set_path_params(
         ctx,
         set_id=skill_set_id,
-        entity_id=entity_id,
+        entity_id=owner_id_hint,
         entity_type=entity_type,
         bot_id=bot_id,
         engine_type=engine_type,
@@ -658,6 +661,7 @@ async def get_skill_set_skills(
     ),
 ) -> SkillSetSkillsResponse:
     """Get all skills in a skill set."""
+    owner_id_hint = user_id or entity_id
     # Get effective path parameters
     (
         effective_entity_id,
@@ -669,7 +673,7 @@ async def get_skill_set_skills(
     ) = _get_skill_set_path_params(
         ctx,
         set_id=skill_set_id,
-        entity_id=entity_id,
+        entity_id=owner_id_hint,
         entity_type=entity_type,
         bot_id=bot_id,
         engine_type=engine_type,
@@ -832,6 +836,7 @@ async def remove_skill_from_set(
     ),
 ) -> MessageResponse:
     """Remove a skill from a skill set."""
+    owner_id_hint = user_id or entity_id
     (
         effective_entity_id,
         effective_bot_id,
@@ -842,7 +847,7 @@ async def remove_skill_from_set(
     ) = _get_skill_set_path_params(
         ctx,
         set_id=skill_set_id,
-        entity_id=entity_id,
+        entity_id=owner_id_hint,
         entity_type=entity_type,
         bot_id=bot_id,
         engine_type=engine_type,
@@ -1767,6 +1772,7 @@ async def get_skill_set_mcps(
     ),
 ) -> SkillSetMCPsResponse:
     """Get all MCP servers in a skill set."""
+    owner_id_hint = user_id or entity_id
     # Get effective path parameters
     (
         effective_entity_id,
@@ -1778,7 +1784,7 @@ async def get_skill_set_mcps(
     ) = _get_skill_set_path_params(
         ctx,
         set_id=skill_set_id,
-        entity_id=entity_id,
+        entity_id=owner_id_hint,
         entity_type=entity_type,
         bot_id=bot_id,
         engine_type=engine_type,
@@ -1789,7 +1795,7 @@ async def get_skill_set_mcps(
     legacy_set = control_plane.get_set(
         bot_id=effective_bot_id,
         owner_id=effective_entity_id,
-        user_id=_legacy_actor(ctx, entity_id),
+        user_id=_legacy_actor(ctx, owner_id_hint),
         set_id=skill_set_id,
     )
     if legacy_set.get("is_default"):
@@ -1804,7 +1810,7 @@ async def get_skill_set_mcps(
         mcps = control_plane.list_mcps(
             bot_id=effective_bot_id,
             owner_id=effective_entity_id,
-            user_id=_legacy_actor(ctx, entity_id),
+            user_id=_legacy_actor(ctx, owner_id_hint),
             set_id=skill_set_id,
         )
     return SkillSetMCPsResponse(

--- a/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
+++ b/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
@@ -10,11 +10,17 @@ from agentclaw.community.adapters.http.skill_center.schemas import (
     AddSkillsRequest,
     DeactivateSkillSetRequest,
     SearchRequest,
+    UpdateSkillSetRequest,
 )
 from agentclaw.community.adapters.http.skill_center.skillsets import (
     add_skills_to_set,
+    delete_skill_set,
     get_default_skill_set,
+    get_skill_set,
     get_skill_set_mcps,
+    get_skill_set_skills,
+    remove_skill_from_set,
+    update_skill_set,
 )
 from agentclaw.community.adapters.http.skill_center.skills import (
     deactivate_skill_set,
@@ -145,7 +151,7 @@ async def test_legacy_mcp_read_recovers_non_default_bot_from_exact_set_id() -> N
         {
             "set_id": "set-1",
             "actor_id": "owner",
-            "owner_id_hint": None,
+            "owner_id_hint": "owner",
         },
     )
 
@@ -365,6 +371,115 @@ async def test_legacy_skill_set_batch_uses_body_owner_for_collaborator() -> None
     assert response.success is True
     assert response.data["success"] == [{"skill_id": "7", "name": "7"}]
     assert response.data["failed"] == []
+
+
+@pytest.mark.asyncio
+async def test_legacy_exact_set_routes_keep_the_target_owner_for_collaborators() -> None:
+    class _ControlPlane:
+        def __init__(self) -> None:
+            self.operations: list[tuple[str, dict]] = []
+
+        def resolve_legacy_set_scope(self, **_kwargs):
+            raise AssertionError("an explicit bot_id must stay strictly scoped")
+
+        def get_set(self, **kwargs):
+            self.operations.append(("get_set", kwargs))
+            return {
+                "id": "set-1",
+                "name": "tools",
+                "description": None,
+                "is_default": False,
+                "is_builtin": False,
+                "user_id": "owner",
+                "gmt_created": "",
+                "gmt_modified": "",
+            }
+
+        def update_set(self, **kwargs):
+            self.operations.append(("update_set", kwargs))
+            return {
+                "id": "set-1",
+                "name": "tools",
+                "description": kwargs["description"],
+                "is_default": False,
+                "is_builtin": False,
+                "user_id": "owner",
+                "gmt_created": "",
+                "gmt_modified": "",
+            }
+
+        def delete_set(self, **kwargs):
+            self.operations.append(("delete_set", kwargs))
+
+        def list_skills(self, **kwargs):
+            self.operations.append(("list_skills", kwargs))
+            return []
+
+        async def remove_skill(self, **kwargs):
+            self.operations.append(("remove_skill", kwargs))
+            return {"changed": True}
+
+        def list_mcps(self, **kwargs):
+            self.operations.append(("list_mcps", kwargs))
+            return []
+
+    control_plane = _ControlPlane()
+    common = {
+        "entity_type": None,
+        "engine_type": None,
+        "ctx": SimpleNamespace(user_id="collaborator", bot_id="default"),
+        "bot_repo": _Bots(),
+        "control_plane": control_plane,
+    }
+
+    await get_skill_set(
+        "set-1", user_id="owner", entity_id=None, bot_id="bot", **common
+    )
+    await update_skill_set(
+        "set-1",
+        UpdateSkillSetRequest(
+            description="updated", user_id="owner", bot_id="bot"
+        ),
+        entity_id=None,
+        bot_id=None,
+        **common,
+    )
+    await inspect.unwrap(delete_skill_set)(
+        "set-1", user_id="owner", entity_id=None, bot_id="bot", **common
+    )
+    await get_skill_set_skills(
+        "set-1", user_id="owner", entity_id=None, bot_id="bot", **common
+    )
+    await inspect.unwrap(remove_skill_from_set)(
+        "set-1",
+        "7",
+        user_id="owner",
+        entity_id=None,
+        bot_id="bot",
+        **common,
+    )
+    await get_skill_set_mcps(
+        "set-1",
+        user_id="owner",
+        entity_id=None,
+        bot_id="bot",
+        skill_set_service_factory=object(),
+        **common,
+    )
+
+    assert [operation for operation, _kwargs in control_plane.operations] == [
+        "get_set",
+        "update_set",
+        "delete_set",
+        "list_skills",
+        "remove_skill",
+        "get_set",
+        "list_mcps",
+    ]
+    for _operation, kwargs in control_plane.operations:
+        assert kwargs["bot_id"] == "bot"
+        assert kwargs["owner_id"] == "owner"
+        assert kwargs["user_id"] == "collaborator"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

PR #1640 fixed the observed collaborator failure on POST /api/skillsets/{skill_set_id}/skills. A follow-up audit found the same owner-alias loss on six other exact-Set legacy routes.

For a collaborator request carrying an explicit Bot and the target owner only in the published legacy user_id field, those handlers passed only entity_id into strict scope resolution. When entity_id was omitted, the Bot lookup used the authenticated collaborator as owner and returned 404 for an existing Set. The affected operations were Set detail, update, delete, Skill list, Skill removal, and MCP list.

## Solution

- Normalize the legacy target-owner alias as user_id first, then entity_id, before exact SkillSet scope resolution on all affected routes.
- Keep the authenticated actor sourced exclusively from RequestContext and pass it separately to Control Plane authorization.
- Preserve strict explicit-Bot behavior and omitted-Bot exact-set recovery.
- Clarify the AddSkillsRequest user_id schema description as the target Bot owner rather than the authenticated actor.
- Add a regression matrix covering collaborator reads and mutations across the six routes.

MCP add/remove write routes retain their existing entity_id contract; this PR does not broaden or reinterpret that wire.

## Validation

- Regression test failed before the fix with owner_id=collaborator and passed after the fix.
- 100 passed: legacy SkillSet adapter, SkillSet management service, and Rule 15 Gateway contract suites.
- 201 passed: complete Backend architecture suite.
- Ruff passed for all changed Python files.
- Backend local Python SAST block scan exited 0; its output contains only existing environment/baseline findings outside this diff.
- git diff --check passed.

OpenAPI dump/publish scripts were not required because no public /openapi/v1 route, parameter, or schema changed.

## Compatibility and risk

No response, database, runtime projection, canonical OpenAPI, or route-shape change is introduced. Owner-operated requests behave as before. Collaborator requests now use one owner+Bot address for both authorization and business lookup, while explicit Bot IDs are never redirected to another Bot.

This is a follow-up to #1640, which merged while this audit was running.
