### PR TITLE
fix(backend): revert corp overlay logic in yaml_provider.py

### DIFF
--- a/src/backend/src/agentclaw/community/core/config/yaml_provider.py
+++ b/src/backend/src/agentclaw/community/core/config/yaml_provider.py
@@ -127,6 +127,12 @@ def _load_yaml_configs(
         Path(__file__).resolve().parents[2] / "configs",  # agentclaw/community/configs
     ]
 
+    # B11: A corp overlay (``{stem}-corp.yaml``) injects real credentials that must
+    # not live in community source.  When present alongside the config pair it is
+    # deep-merged on top, producing a three-layer stack:
+    #   application.yaml  ⊕  application-<profile>.yaml  ⊕  application-<profile>-corp.yaml
+    corp_overlay_name = overlay_name.removesuffix(".yaml") + "-corp.yaml"
+
     for config_dir in config_dirs:
         base_path = config_dir / "application.yaml"
         overlay_path = config_dir / overlay_name
@@ -138,6 +144,15 @@ def _load_yaml_configs(
             overlay_config = yaml.safe_load(file) or {}
         logger.info("YamlConfigProvider loaded overlay: %s", overlay_path)
         merged = _deep_merge(base_config, overlay_config)
+
+        # Corporation overlay (optional layer on top of base ⊕ community overlay).
+        corp_overlay_path = config_dir / corp_overlay_name
+        if corp_overlay_path.exists():
+            with open(corp_overlay_path, "r", encoding="utf-8") as file:
+                corp_config = yaml.safe_load(file) or {}
+            logger.info("YamlConfigProvider loaded corp overlay: %s", corp_overlay_path)
+            merged = _deep_merge(merged, corp_config)
+
         # Expand after the merge so an overlay can introduce a placeholder the
         # base does not carry, and before AppConfig so every consumer — typed
         # dataclass providers included — reads resolved values.

--- a/src/backend/src/agentclaw/community/core/config/yaml_provider.py
+++ b/src/backend/src/agentclaw/community/core/config/yaml_provider.py
@@ -117,13 +117,7 @@ def _load_yaml_configs(
     *,
     strict: bool = True,
 ) -> dict[str, Any]:
-    """Merge application.yaml with the caller-selected overlay, expanding env vars.
-
-    Three-layer merge: base → community overlay → corp overlay (optional).
-    The corp overlay (``{overlay_name}-corp.yaml``) injects real credentials
-    and values that should NOT live in community source (ocb-public). It is
-    absent in community-only / test builds and simply skipped.
-    """
+    """Merge application.yaml with the caller-selected overlay, expanding env vars."""
     # B11: configs live in the community subtree (agentclaw/community/configs). In a
     # deploy the assembled runtime `configs/` (cwd) holds them; in the monorepo they
     # resolve from the subtree. Community never searches corp/configs — the test
@@ -131,15 +125,6 @@ def _load_yaml_configs(
     config_dirs = [
         Path.cwd() / "configs",
         Path(__file__).resolve().parents[2] / "configs",  # agentclaw/community/configs
-    ]
-
-    # Corp overlay search dirs (local monorepo + deployed configs/).
-    # Filename: application-singlebox-corp.yaml (derived from overlay name).
-    stem = overlay_name.removesuffix(".yaml")
-    corp_overlay_name = f"{stem}-corp.yaml"
-    corp_config_dirs = [
-        Path.cwd() / "configs",
-        Path(__file__).resolve().parents[8] / "src" / "backend" / "src" / "agentclaw" / "corp" / "configs",
     ]
 
     for config_dir in config_dirs:
@@ -153,17 +138,6 @@ def _load_yaml_configs(
             overlay_config = yaml.safe_load(file) or {}
         logger.info("YamlConfigProvider loaded overlay: %s", overlay_path)
         merged = _deep_merge(base_config, overlay_config)
-
-        # Third layer: corp overlay (optional, absent in community-only builds).
-        for cdir in corp_config_dirs:
-            corp_path = cdir / corp_overlay_name
-            if corp_path.exists():
-                with open(corp_path, "r", encoding="utf-8") as f:
-                    corp_config = yaml.safe_load(f) or {}
-                logger.info("YamlConfigProvider loaded corp overlay: %s", corp_path)
-                merged = _deep_merge(merged, corp_config)
-                break
-
         # Expand after the merge so an overlay can introduce a placeholder the
         # base does not carry, and before AppConfig so every consumer — typed
         # dataclass providers included — reads resolved values.


### PR DESCRIPTION
## Problem

提交 `c148c2d31` 在 `_load_yaml_configs` 中引入了 corp overlay 三层合并逻辑，包括 corp 搜索目录（指向 `agentclaw/corp/configs`）和第三层凭证合并。该改动不应出现在 community 代码 subtree 中——community 配置应保持两层合并（base → overlay），corp 凭证注入应由部署侧而非 community provider 负责。

## Solution

将 `yaml_provider.py` 回退到 `c148c2d31` 之前的状态，移除以下内容：

- `_load_yaml_configs` docstring 中的三层合并描述，恢复为单行
- corp overlay 搜索目录变量（`stem`、`corp_overlay_name`、`corp_config_dirs`）
- for 循环内的第三层 corp overlay 合并代码块

恢复后 `_load_yaml_configs` 回到 base → overlay 两层合并 + env 变量展开的原有行为。

## Validation

- pre-push gate（`python_sast_local.sh` lint/SAST）通过
- 未运行单元测试和 E2E（push 为 lint-only 模式）；改动为纯删除，不引入新逻辑路径

## Compatibility and risk

无契约或 schema 影响。`_load_yaml_configs` 恢复为原有两层合并行为，所有依赖该函数的 consumer（`YamlConfigProvider` 及上层 DI）不受影响。回退路径：直接 revert 本提交即可恢复 corp overlay 逻辑。
