### PR TITLE
revert(backend): drop corp overlay layer from yaml_provider

### DIFF
--- a/src/backend/src/agentclaw/community/core/config/yaml_provider.py
+++ b/src/backend/src/agentclaw/community/core/config/yaml_provider.py
@@ -117,13 +117,7 @@ def _load_yaml_configs(
     *,
     strict: bool = True,
 ) -> dict[str, Any]:
-    """Merge application.yaml with the caller-selected overlay, expanding env vars.
-
-    Three-layer merge: base → community overlay → corp overlay (optional).
-    The corp overlay (``{overlay_name}-corp.yaml``) injects real credentials
-    and values that should NOT live in community source (ocb-public). It is
-    absent in community-only / test builds and simply skipped.
-    """
+    """Merge application.yaml with the caller-selected overlay, expanding env vars."""
     # B11: configs live in the community subtree (agentclaw/community/configs). In a
     # deploy the assembled runtime `configs/` (cwd) holds them; in the monorepo they
     # resolve from the subtree. Community never searches corp/configs — the test
@@ -131,15 +125,6 @@ def _load_yaml_configs(
     config_dirs = [
         Path.cwd() / "configs",
         Path(__file__).resolve().parents[2] / "configs",  # agentclaw/community/configs
-    ]
-
-    # Corp overlay search dirs (local monorepo + deployed configs/).
-    # Filename: application-singlebox-corp.yaml (derived from overlay name).
-    stem = overlay_name.removesuffix(".yaml")
-    corp_overlay_name = f"{stem}-corp.yaml"
-    corp_config_dirs = [
-        Path.cwd() / "configs",
-        Path(__file__).resolve().parents[8] / "src" / "backend" / "src" / "agentclaw" / "corp" / "configs",
     ]
 
     for config_dir in config_dirs:
@@ -153,17 +138,6 @@ def _load_yaml_configs(
             overlay_config = yaml.safe_load(file) or {}
         logger.info("YamlConfigProvider loaded overlay: %s", overlay_path)
         merged = _deep_merge(base_config, overlay_config)
-
-        # Third layer: corp overlay (optional, absent in community-only builds).
-        for cdir in corp_config_dirs:
-            corp_path = cdir / corp_overlay_name
-            if corp_path.exists():
-                with open(corp_path, "r", encoding="utf-8") as f:
-                    corp_config = yaml.safe_load(f) or {}
-                logger.info("YamlConfigProvider loaded corp overlay: %s", corp_path)
-                merged = _deep_merge(merged, corp_config)
-                break
-
         # Expand after the merge so an overlay can introduce a placeholder the
         # base does not carry, and before AppConfig so every consumer — typed
         # dataclass providers included — reads resolved values.

--- a/src/backend/tests/community/local/test_load_yaml_configs.py
+++ b/src/backend/tests/community/local/test_load_yaml_configs.py
@@ -108,41 +108,6 @@ class TestLoadYamlConfigsOverlaySelection:
         assert str(first_configs) in str(error.value)
         assert str(fallback_configs) in str(error.value)
 
-    def test_corp_overlay_merges_on_top(self, monkeypatch, tmp_path):
-        """Three-layer merge: base + community overlay + corp overlay.
-
-        The corp overlay (``{stem}-corp.yaml``) injects real credentials that
-        must not live in community source. When present alongside the config
-        pair, ``_load_yaml_configs`` deep-merges it on top.
-        """
-        overlay_name = "application-test.yaml"
-        configs = tmp_path / "configs"
-        configs.mkdir()
-        (configs / "application.yaml").write_text("user_config:\n  base: base-val\n")
-        (configs / overlay_name).write_text("user_config:\n  overlay: overlay-val\n")
-        corp_name = "application-test-corp.yaml"
-        (configs / corp_name).write_text(
-            "user_config:\n  overlay: corp-override\n  corp_secret: real-secret\n"
-        )
-
-        community_root = tmp_path / "community"
-        community_configs = community_root / "configs"
-        community_configs.mkdir(parents=True)
-        (community_configs / "application.yaml").write_text("user_config:\n  base: base-val\n")
-        (community_configs / overlay_name).write_text("user_config:\n  overlay: overlay-val\n")
-
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setattr(
-            yaml_provider,
-            "__file__",
-            str(community_root / "core" / "config" / "yaml_provider.py"),
-        )
-
-        result = _load_yaml_configs(overlay_name)
-        assert result["user_config"]["base"] == "base-val"
-        assert result["user_config"]["overlay"] == "corp-override"
-        assert result["user_config"]["corp_secret"] == "real-secret"
-
 
 @pytest.fixture(autouse=True)
 def _community_database_url(monkeypatch):


### PR DESCRIPTION
## Problem

#1589 (2943b6d) added an optional third YAML merge layer to the community `yaml_provider.py`: after base → community overlay, `_load_yaml_configs` also searched for `{overlay_name}-corp.yaml` under `cwd/configs` and `agentclaw/corp/configs` and deep-merged it on top.

That contradicts the B11 invariant stated in the comment directly above the loader — community never searches `corp/configs`; the test suite reads only community overlays, and corp prod reads its config via sofapy. It also reaches out of the community subtree with a `parents[8]` path walk, which is brittle and only resolves in the monorepo layout.

## Solution

Revert the `yaml_provider.py` portion of #1589. `_load_yaml_configs` is back to the two-layer merge (base ⊕ community overlay), with its original one-line docstring. The corp-overlay unit test added by the same commit (`test_corp_overlay_merges_on_top`) is removed with it.

Scoped revert rather than a full `git revert` of #1589: the rest of that commit — `DingTalkYamlHolder`, the `task_discovery_dingtalk` config block, and the `CommunityNotifyModule` wiring — is untouched. The corp overlay was optional and absent in community-only/test builds, so nothing in those paths depended on it. A grep confirms no other reference to `-corp.yaml` / `corp_overlay` remains outside the reverted code.

No commit after 2943b6d touched either file, so this restores them to their exact pre-#1589 content.

## Validation

- `pytest tests/community/config tests/community/local tests/community/core/task/test_task_discovery_coverage.py` — **96 passed**. This covers the golden singlebox config snapshot and the task-discovery DingTalk tests added by #1589, both still green without the corp layer.
- `ruff check` on both touched files — all checks passed.
- Dependencies had to be resolved from pypi.org because the pinned `mirrors.aliyun.com` index is unreachable from this environment; `uv.lock` was restored afterwards and is not part of this diff.
- Not run locally: full CI suite, coverage, E2E — these run in CI on this PR.

## Compatibility and risk

- Behaviour is unchanged for every community-only, singlebox and test build, where the corp overlay file never existed and the layer was a no-op.
- The one behavioural loss: a deployment that shipped an `application-PROFILE-corp.yaml` alongside its configs would no longer have it merged. No such file exists in this repository.
- Rollback: revert this commit.

## Related issues

Reverts the `yaml_provider.py` change from #1589.