### PR TITLE
feat(openapi): batch edit locks in bot inventory

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -223,6 +223,17 @@ def _to_inventory_item(item: CoreItem) -> BotInventoryItem:
             "name": item.space.name,
             "kind": item.space.kind,
         }
+    edit_lock = None
+    if item.edit_lock is not None:
+        edit_lock = {
+            "locked": item.edit_lock.locked,
+            "acquired": None,
+            "holder_user_id": item.edit_lock.holder_user_id,
+            "holder_name": item.edit_lock.holder_name,
+            "has_collaborators": item.edit_lock.has_collaborators,
+            "is_owner_holder": item.edit_lock.is_owner_holder,
+            "need_lock": item.edit_lock.need_lock,
+        }
     return BotInventoryItem(
         bot_id=item.bot_id,
         card_id=item.card_id,
@@ -246,6 +257,7 @@ def _to_inventory_item(item: CoreItem) -> BotInventoryItem:
         passport_id=item.passport_id,
         actions=[a.value for a in item.actions],
         disabled_actions=dict(item.disabled_actions) if item.disabled_actions else None,
+        edit_lock=edit_lock,
     )
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -13,6 +13,9 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 
 from agentclaw.community.adapters.http.openapi_v1.clusters import ClusterName
+from agentclaw.community.adapters.http.openapi_v1.service_publications.schemas import (
+    EditLock,
+)
 
 # Request bodies reject unknown keys. Pydantic's default is to *ignore* them,
 # which on a public API means a typo'd or immutable field (``engine`` on update)
@@ -713,6 +716,10 @@ class BotInventoryItem(BaseModel):
     disabled_actions: dict[str, str] | None = Field(
         default=None,
         description="Unavailable actions mapped to caller-facing reasons, when any.",
+    )
+    edit_lock: EditLock | None = Field(
+        default=None,
+        description="Current Bot-level collaborative edit lock for an operable service Bot; null for other cards.",
     )
 
 

--- a/src/backend/src/agentclaw/community/core/bot_inventory/adapters/service_edit_lock.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/adapters/service_edit_lock.py
@@ -1,0 +1,91 @@
+"""Batch service-Bot edit-lock projection for the unified inventory."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from typing import Any, Mapping
+
+from agentclaw.community.core.bot_inventory.protocols import ServiceEditLockPort
+from agentclaw.community.core.bot_inventory.types import ServiceEditLockState
+from agentclaw.community.core.repository.protocols.bot import (
+    BotCollabLockRepositoryProtocol,
+    CollaboratorRepositoryProtocol,
+)
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+class ServiceEditLockView(ServiceEditLockPort):
+    """Read collaborator and lock rows in two queries for a page of Bots."""
+
+    def __init__(
+        self,
+        collaborator_repo: CollaboratorRepositoryProtocol,
+        lock_repo: BotCollabLockRepositoryProtocol,
+    ) -> None:
+        self._collaborator_repo = collaborator_repo
+        self._lock_repo = lock_repo
+
+    @staticmethod
+    def _lock_key(bot_id: str, owner_id: str) -> str:
+        return f"{bot_id}:{owner_id}"
+
+    def states_for_bots(
+        self, *, bots: Sequence[Mapping[str, Any]]
+    ) -> Mapping[tuple[str, str], ServiceEditLockState]:
+        bots_by_pair: dict[tuple[str, str], Mapping[str, Any]] = {}
+        for bot in bots:
+            bot_id = str(bot.get("bot_id") or "")
+            owner_id = str(bot.get("owner_id") or "")
+            if bot_id and owner_id:
+                bots_by_pair[(bot_id, owner_id)] = bot
+        if not bots_by_pair:
+            return {}
+
+        pairs = list(bots_by_pair)
+        collaborators_by_pair: dict[tuple[str, str], list[Any]] = defaultdict(list)
+        for collaborator in self._collaborator_repo.list_by_bot_owner_pairs(
+            pairs, get_current_env()
+        ):
+            collaborators_by_pair[
+                (collaborator.bot_id, collaborator.owner_id)
+            ].append(collaborator)
+
+        locks_by_key = {
+            lock.lock_key: lock
+            for lock in self._lock_repo.list_by_keys(
+                [self._lock_key(bot_id, owner_id) for bot_id, owner_id in pairs]
+            )
+        }
+
+        states: dict[tuple[str, str], ServiceEditLockState] = {}
+        for pair, bot in bots_by_pair.items():
+            bot_id, owner_id = pair
+            collaborators = collaborators_by_pair[pair]
+            has_collaborators = bool(collaborators)
+            lock = (
+                locks_by_key.get(self._lock_key(bot_id, owner_id))
+                if has_collaborators
+                else None
+            )
+            holder_user_id = lock.holder_user_id if lock else None
+            holder_name = None
+            if holder_user_id == owner_id:
+                holder_name = str(bot.get("owner_name") or "") or None
+            elif holder_user_id:
+                holder_name = next(
+                    (
+                        collaborator.user_name
+                        for collaborator in collaborators
+                        if collaborator.user_id == holder_user_id
+                    ),
+                    None,
+                )
+            states[pair] = ServiceEditLockState(
+                locked=lock is not None,
+                holder_user_id=holder_user_id,
+                holder_name=holder_name,
+                has_collaborators=has_collaborators,
+                is_owner_holder=holder_user_id == owner_id,
+            )
+        return states

--- a/src/backend/src/agentclaw/community/core/bot_inventory/adapters/service_lifecycle.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/adapters/service_lifecycle.py
@@ -168,6 +168,9 @@ class ServiceLifecycleView(ServiceLifecyclePort):
         for bot_id, bot in bots_by_id.items():
             bot_pk = bot.get("id")
             records = records_by_pk[bot_pk] if isinstance(bot_pk, int) else []
+            has_draft = any(
+                record.status == PublishStatus.DRAFT.value for record in records
+            )
             live = max(
                 (
                     record
@@ -186,6 +189,7 @@ class ServiceLifecycleView(ServiceLifecyclePort):
                     internal_status=record.status,
                     actions=self._record_actions(record, records),
                     live_version=live.version if live else None,
+                    has_draft=has_draft,
                 )
                 for record in self._visible(records)
             )

--- a/src/backend/src/agentclaw/community/core/bot_inventory/protocols.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/protocols.py
@@ -9,6 +9,7 @@ from agentclaw.community.core.bot_inventory.types import (
     BotAction,
     BusinessSpaceRef,
     DisplayState,
+    ServiceEditLockState,
     ServiceLifecycleCard,
 )
 
@@ -145,3 +146,12 @@ class ServiceLifecyclePort(Protocol):
     def cards_for_bots(
         self, *, bots: Sequence[Mapping[str, Any]]
     ) -> Mapping[str, Sequence[ServiceLifecycleCard]]: ...
+
+
+@runtime_checkable
+class ServiceEditLockPort(Protocol):
+    """Batch service-Bot edit-lock projection consumed by inventory."""
+
+    def states_for_bots(
+        self, *, bots: Sequence[Mapping[str, Any]]
+    ) -> Mapping[tuple[str, str], ServiceEditLockState]: ...

--- a/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from typing import Any, Mapping
 
 from agentclaw.community.core.bot_inventory.errors import (
@@ -14,6 +15,7 @@ from agentclaw.community.core.bot_inventory.protocols import (
     BotInventoryBotPort,
     BusinessSpaceContextProtocol,
     DesktopBotInventoryPort,
+    ServiceEditLockPort,
 )
 from agentclaw.community.core.bot_inventory.services.lifecycle_view import (
     BotLifecycleView,
@@ -27,6 +29,10 @@ from agentclaw.community.core.bot_inventory.types import (
     ServiceLifecycleCard,
 )
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
+from agentclaw.community.log import get_logger
+
+
+logger = get_logger()
 
 
 class BotInventoryService:
@@ -38,12 +44,14 @@ class BotInventoryService:
         access_service: BotInventoryAccessPort,
         business_space: BusinessSpaceContextProtocol,
         lifecycle_view: BotLifecycleView,
+        edit_lock_view: ServiceEditLockPort,
     ) -> None:
         self._bot = bot_service
         self._desktop = desktop_service
         self._access = access_service
         self._business_space = business_space
         self._lifecycle = lifecycle_view
+        self._edit_locks = edit_lock_view
 
     def list_items(
         self,
@@ -59,6 +67,9 @@ class BotInventoryService:
         page_size: int,
     ) -> tuple[list[BotInventoryItem], int]:
         cards: list[BotInventoryItem] = []
+        service_rows_by_pair: dict[tuple[str, str], Mapping[str, Any]] = {}
+        service_levels_by_pair: dict[tuple[str, str], PermissionLevel] = {}
+        service_draft_pairs: set[tuple[str, str]] = set()
         if deploy_mode in (None, DeployMode.CLOUD):
             cloud_rows = self._list_cloud_rows(
                 owner_id=owner_id,
@@ -94,15 +105,23 @@ class BotInventoryService:
             service_cards = self._lifecycle.service_cards(bots=service_rows)
             for row in service_rows:
                 bot_id = str(row.get("bot_id") or "")
+                bot_owner_id = str(row.get("owner_id") or owner_id)
+                pair = (bot_id, bot_owner_id)
+                level = levels.get(int(row.get("id") or 0), PermissionLevel.NONE)
+                service_rows_by_pair[pair] = row
+                service_levels_by_pair[pair] = level
+                lifecycle_cards = service_cards.get(bot_id, ())
+                if any(card.has_draft for card in lifecycle_cards):
+                    service_draft_pairs.add(pair)
                 cards.extend(
                     self._to_service_item(
                         row,
                         owner_id,
                         lifecycle_card,
                         space,
-                        levels.get(int(row.get("id") or 0), PermissionLevel.NONE),
+                        level,
                     )
-                    for lifecycle_card in service_cards.get(bot_id, ())
+                    for lifecycle_card in lifecycle_cards
                 )
         if (
             is_service is not True
@@ -128,7 +147,61 @@ class BotInventoryService:
         )
         total = len(cards)
         start = (page - 1) * page_size
-        return cards[start : start + page_size], total
+        page_cards = cards[start : start + page_size]
+        page_cards = self._attach_edit_locks(
+            cards=page_cards,
+            service_rows_by_pair=service_rows_by_pair,
+            service_levels_by_pair=service_levels_by_pair,
+            service_draft_pairs=service_draft_pairs,
+        )
+        return page_cards, total
+
+    def _attach_edit_locks(
+        self,
+        *,
+        cards: list[BotInventoryItem],
+        service_rows_by_pair: Mapping[tuple[str, str], Mapping[str, Any]],
+        service_levels_by_pair: Mapping[tuple[str, str], PermissionLevel],
+        service_draft_pairs: set[tuple[str, str]],
+    ) -> list[BotInventoryItem]:
+        pairs = sorted(
+            {
+                (card.bot_id, card.owner_entity_id)
+                for card in cards
+                if card.kind == BotInventoryKind.SERVICE
+                and service_levels_by_pair.get(
+                    (card.bot_id, card.owner_entity_id), PermissionLevel.NONE
+                )
+                >= PermissionLevel.MEMBER
+            }
+        )
+        if not pairs:
+            return cards
+        try:
+            states = self._edit_locks.states_for_bots(
+                bots=[service_rows_by_pair[pair] for pair in pairs]
+            )
+        except Exception:
+            # Lock information enriches the inventory but must not make the
+            # whole Bot list unavailable if its optional read path is degraded.
+            logger.warning(
+                "[bot_inventory] failed to batch-load edit locks",
+                exc_info=True,
+            )
+            return cards
+
+        enriched: list[BotInventoryItem] = []
+        for card in cards:
+            pair = (card.bot_id, card.owner_entity_id)
+            state = states.get(pair)
+            if state is not None:
+                state = replace(
+                    state,
+                    need_lock=(state.has_collaborators and pair in service_draft_pairs),
+                )
+                card = replace(card, edit_lock=state)
+            enriched.append(card)
+        return enriched
 
     def _list_cloud_rows(
         self,

--- a/src/backend/src/agentclaw/community/core/bot_inventory/types.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/types.py
@@ -83,6 +83,19 @@ class ServiceLifecycleCard:
     actions: tuple[BotAction, ...]
     internal_status: str | None = None
     live_version: int | None = None
+    has_draft: bool = False
+
+
+@dataclass(frozen=True)
+class ServiceEditLockState:
+    """Bot-level collaborative edit-lock state used by inventory cards."""
+
+    locked: bool
+    holder_user_id: str | None
+    holder_name: str | None
+    has_collaborators: bool
+    is_owner_holder: bool
+    need_lock: bool = False
 
 
 @dataclass(frozen=True)
@@ -109,6 +122,7 @@ class BotInventoryItem:
     publication_version: int | None = None
     live_version: int | None = None
     internal_status: str | None = None
+    edit_lock: ServiceEditLockState | None = None
 
 
 @dataclass(frozen=True)

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/collab_lock.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/collab_lock.py
@@ -92,6 +92,23 @@ class BotCollabLockRepository(
             )
             return row.to_record() if row else None
 
+    def list_by_keys(self, lock_keys: List[str]) -> List[BotCollabLockRecord]:
+        """批量查询当前环境下的协作锁记录。"""
+        keys = list(dict.fromkeys(key for key in lock_keys if key))
+        if not keys:
+            return []
+        env = get_current_env()
+        with self._db.orm_session() as db:
+            rows = (
+                db.query(self._Lock)
+                .filter(
+                    self._Lock.lock_key.in_(keys),
+                    self._Lock.env == env,
+                )
+                .all()
+            )
+            return [row.to_record() for row in rows]
+
     def is_locked(self, lock_key: str) -> bool:
         """检查锁是否存在。"""
         env = get_current_env()

--- a/src/backend/src/agentclaw/community/core/repository/implementations/bot/collaborator.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/bot/collaborator.py
@@ -124,6 +124,32 @@ class CollaboratorRepository(
             rows = query.order_by(self._Collaborator.gmt_create.asc()).all()
             return [r.to_record() for r in rows]
 
+    def list_by_bot_owner_pairs(
+        self,
+        pairs: List[tuple[str, str]],
+        env: str,
+    ) -> List[CollaboratorRecord]:
+        """List collaborators for multiple exact Bot/Owner pairs."""
+        wanted = set(pairs)
+        if not wanted:
+            return []
+        with self._db.orm_session() as db:
+            rows = (
+                db.query(self._Collaborator)
+                .filter(
+                    self._Collaborator.bot_id.in_({bot_id for bot_id, _ in wanted}),
+                    self._Collaborator.owner_id.in_(
+                        {owner_id for _, owner_id in wanted}
+                    ),
+                    self._Collaborator.env == env,
+                )
+                .order_by(self._Collaborator.gmt_create.asc())
+                .all()
+            )
+            return [
+                row.to_record() for row in rows if (row.bot_id, row.owner_id) in wanted
+            ]
+
     def list_by_user(
         self,
         user_id: str,

--- a/src/backend/src/agentclaw/community/core/repository/protocols/bot/collaborator.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/bot/collaborator.py
@@ -110,6 +110,15 @@ class CollaboratorRepositoryProtocol(Protocol):
         ...
 
     @abstractmethod
+    def list_by_bot_owner_pairs(
+        self,
+        pairs: List[tuple[str, str]],
+        env: str,
+    ) -> List[CollaboratorRecord]:
+        """批量获取指定 Bot/Owner 组合的协作者。"""
+        ...
+
+    @abstractmethod
     def list_by_user(
         self,
         user_id: str,
@@ -316,6 +325,11 @@ class BotCollabLockRepositoryProtocol(Protocol):
         Returns:
             BotCollabLockRecord，不存在返回None
         """
+        ...
+
+    @abstractmethod
+    def list_by_keys(self, lock_keys: List[str]) -> List[BotCollabLockRecord]:
+        """批量查询当前环境下的协作锁记录。"""
         ...
 
     @abstractmethod

--- a/src/backend/src/agentclaw/community/di/modules/bot_inventory_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_inventory_module.py
@@ -14,11 +14,15 @@ from agentclaw.community.adapters.bot_space_context import (
 from agentclaw.community.core.bot_inventory.adapters.service_lifecycle import (
     ServiceLifecycleView,
 )
+from agentclaw.community.core.bot_inventory.adapters.service_edit_lock import (
+    ServiceEditLockView,
+)
 from agentclaw.community.core.bot_inventory.protocols import (
     BotInventoryAccessPort,
     BotInventoryBotPort,
     BusinessSpaceContextProtocol,
     DesktopBotInventoryPort,
+    ServiceEditLockPort,
     ServiceLifecyclePort,
 )
 from agentclaw.community.core.bot_inventory.services.bot_inventory_service import (
@@ -39,6 +43,10 @@ from agentclaw.community.core.desktop_bot.services.desktop_bot_service import (
 )
 from agentclaw.community.core.repository.protocols.publishing import (
     BotPublishRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.bot import (
+    BotCollabLockRepositoryProtocol,
+    CollaboratorRepositoryProtocol,
 )
 from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipPlugin
 from agentclaw.community.plugin_api.passport import PassportPlugin
@@ -73,6 +81,16 @@ class BotInventoryModule(Module):
     @singleton
     @provider
     @inject
+    def service_edit_lock_view(
+        self,
+        collaborator_repo: CollaboratorRepositoryProtocol,
+        lock_repo: BotCollabLockRepositoryProtocol,
+    ) -> ServiceEditLockPort:
+        return ServiceEditLockView(collaborator_repo, lock_repo)
+
+    @singleton
+    @provider
+    @inject
     def inventory_bot_port(self, service: BotService) -> BotInventoryBotPort:
         return service
 
@@ -102,6 +120,7 @@ class BotInventoryModule(Module):
         access_service: BotInventoryAccessPort,
         business_space: BusinessSpaceContextProtocol,
         lifecycle_view: BotLifecycleView,
+        edit_lock_view: ServiceEditLockPort,
     ) -> BotInventoryService:
         return BotInventoryService(
             bot_service=bot_service,
@@ -109,6 +128,7 @@ class BotInventoryModule(Module):
             access_service=access_service,
             business_space=business_space,
             lifecycle_view=lifecycle_view,
+            edit_lock_view=edit_lock_view,
         )
 
     @singleton

--- a/src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py
@@ -84,6 +84,7 @@ def client(bot_service, desktop_service):
                 access_service=access,
                 business_space=space,
                 lifecycle_view=BotLifecycleView(NoopServiceLifecyclePort()),
+                edit_lock_view=MagicMock(states_for_bots=MagicMock(return_value={})),
             )
             binder.bind(BotInventoryBotPort, to=bot_service)
             binder.bind(DesktopBotInventoryPort, to=desktop_service)
@@ -117,6 +118,16 @@ def test_inventory_openapi_declares_upgrade_action(client):
     schema = client.app.openapi()["components"]["schemas"]["BotInventoryItem"]
 
     assert "upgrade" in schema["properties"]["actions"]["items"]["enum"]
+
+
+def test_inventory_openapi_reuses_edit_lock_contract(client):
+    schemas = client.app.openapi()["components"]["schemas"]
+
+    edit_lock = schemas["BotInventoryItem"]["properties"]["edit_lock"]
+    assert {item.get("$ref") for item in edit_lock["anyOf"]} == {
+        "#/components/schemas/EditLock",
+        None,
+    }
 
 
 def test_list_inventory_filters_non_service_bots(client):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
@@ -70,6 +70,7 @@ from agentclaw.community.core.bot_inventory.types import (
     BotInventoryKind,
     DeployMode,
     DisplayState,
+    ServiceEditLockState,
 )
 from agentclaw.community.core.bot_management.services.bot_service import (
     BotNotFoundError,
@@ -371,6 +372,54 @@ def test_workshop_inventory_does_not_widen_from_a_shared_bot_grant(make_client):
 
     assert listed["items"] == [] and listed["total"] == 0
     inventory.list_items.assert_not_called()
+
+
+def test_workshop_inventory_serializes_batched_edit_lock(make_client):
+    inventory = MagicMock()
+    inventory.list_items.return_value = (
+        [
+            BotInventoryItem(
+                bot_id=GRANTED,
+                bot_name="service",
+                bot_desc="",
+                engine="openclaw",
+                bot_type="service",
+                kind=BotInventoryKind.SERVICE,
+                deploy_mode=DeployMode.CLOUD,
+                display_state=DisplayState.SERVICE_DRAFT,
+                status="draft",
+                owner_entity_id=USER,
+                space=None,
+                card_id=f"service:{GRANTED}:1",
+                edit_lock=ServiceEditLockState(
+                    locked=True,
+                    holder_user_id="editor-1",
+                    holder_name="Editor One",
+                    has_collaborators=True,
+                    is_owner_holder=False,
+                    need_lock=True,
+                ),
+            )
+        ],
+        1,
+    )
+    client = make_client(
+        GRANTED,
+        inventory_service=inventory,
+        space_context=NoopBusinessSpaceContext(),
+    )
+
+    item = _data(client.get("/openapi/v1/bots/all"))["items"][0]
+
+    assert item["edit_lock"] == {
+        "locked": True,
+        "acquired": None,
+        "holder_user_id": "editor-1",
+        "holder_name": "Editor One",
+        "has_collaborators": True,
+        "is_owner_holder": False,
+        "need_lock": True,
+    }
 
 
 def test_local_listing_passes_owned_grants_before_pagination(make_client):

--- a/src/backend/tests/community/core/bot_inventory/adapters/test_service_edit_lock.py
+++ b/src/backend/tests/community/core/bot_inventory/adapters/test_service_edit_lock.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.core.bot_collaborator.models import (
+    BotCollabLockRecord,
+    CollaboratorRecord,
+)
+from agentclaw.community.core.bot_inventory.adapters.service_edit_lock import (
+    ServiceEditLockView,
+)
+
+
+@pytest.mark.unit
+def test_states_for_bots_reads_collaborators_and_locks_once(monkeypatch) -> None:
+    monkeypatch.setenv("SERVER_ENV", "dev")
+    collaborator_repo = MagicMock()
+    collaborator_repo.list_by_bot_owner_pairs.return_value = [
+        CollaboratorRecord(
+            bot_pk=1,
+            bot_id="service-1",
+            owner_id="owner-1",
+            user_id="editor-1",
+            user_name="Editor One",
+            operator_id="owner-1",
+        ),
+        CollaboratorRecord(
+            bot_pk=2,
+            bot_id="service-2",
+            owner_id="owner-2",
+            user_id="editor-2",
+            user_name="Editor Two",
+            operator_id="owner-2",
+        ),
+    ]
+    lock_repo = MagicMock()
+    lock_repo.list_by_keys.return_value = [
+        BotCollabLockRecord(
+            lock_key="service-1:owner-1",
+            holder_user_id="editor-1",
+        ),
+        BotCollabLockRecord(
+            lock_key="service-2:owner-2",
+            holder_user_id="owner-2",
+        ),
+    ]
+    view = ServiceEditLockView(collaborator_repo, lock_repo)
+
+    states = view.states_for_bots(
+        bots=[
+            {
+                "bot_id": "service-1",
+                "owner_id": "owner-1",
+                "owner_name": "Owner One",
+            },
+            {
+                "bot_id": "service-2",
+                "owner_id": "owner-2",
+                "owner_name": "Owner Two",
+            },
+        ]
+    )
+
+    collaborator_repo.list_by_bot_owner_pairs.assert_called_once_with(
+        [("service-1", "owner-1"), ("service-2", "owner-2")], "dev"
+    )
+    lock_repo.list_by_keys.assert_called_once_with(
+        ["service-1:owner-1", "service-2:owner-2"]
+    )
+    assert states[("service-1", "owner-1")].holder_name == "Editor One"
+    assert states[("service-1", "owner-1")].is_owner_holder is False
+    assert states[("service-2", "owner-2")].holder_name == "Owner Two"
+    assert states[("service-2", "owner-2")].is_owner_holder is True
+
+
+@pytest.mark.unit
+def test_states_for_bots_ignores_stale_lock_without_collaborators() -> None:
+    collaborator_repo = MagicMock()
+    collaborator_repo.list_by_bot_owner_pairs.return_value = []
+    lock_repo = MagicMock()
+    lock_repo.list_by_keys.return_value = [
+        BotCollabLockRecord(
+            lock_key="service-1:owner-1",
+            holder_user_id="owner-1",
+        )
+    ]
+    view = ServiceEditLockView(collaborator_repo, lock_repo)
+
+    state = view.states_for_bots(
+        bots=[{"bot_id": "service-1", "owner_id": "owner-1"}]
+    )[("service-1", "owner-1")]
+
+    assert state.has_collaborators is False
+    assert state.locked is False
+    assert state.holder_user_id is None

--- a/src/backend/tests/community/core/bot_inventory/adapters/test_service_lifecycle.py
+++ b/src/backend/tests/community/core/bot_inventory/adapters/test_service_lifecycle.py
@@ -76,10 +76,12 @@ def test_cards_are_batched_and_expand_each_service_bot(monkeypatch) -> None:
     assert result["service-1"][0].display_state is DisplayState.SERVICE_DRAFT
     assert result["service-1"][0].status == "draft"
     assert result["service-1"][0].internal_status == PublishStatus.DRAFT.value
+    assert all(card.has_draft for card in result["service-1"])
     assert BotAction.DELETE in result["service-1"][0].actions
     assert result["service-2"][0].display_state is DisplayState.SERVICE_ONLINE
     assert result["service-2"][0].status == "running"
     assert result["service-2"][0].live_version == 7
+    assert result["service-2"][0].has_draft is False
 
 
 @pytest.mark.unit
@@ -114,6 +116,7 @@ def test_missing_publish_rows_keep_a_safe_read_only_card(monkeypatch) -> None:
     assert cards[0].status == "draft"
     assert cards[0].internal_status == "ACTIVE"
     assert cards[0].actions == (BotAction.VIEW,)
+    assert cards[0].has_draft is False
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
+++ b/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
@@ -28,6 +28,7 @@ from agentclaw.community.core.bot_inventory.types import (
     BusinessSpaceRef,
     DeployMode,
     DisplayState,
+    ServiceEditLockState,
     ServiceLifecycleCard,
 )
 
@@ -54,6 +55,12 @@ LOCAL = {
 }
 
 
+def _no_edit_locks():
+    view = MagicMock()
+    view.states_for_bots.return_value = {}
+    return view
+
+
 @pytest.fixture
 def service():
     bot = MagicMock()
@@ -72,6 +79,7 @@ def service():
             access_service=access,
             business_space=NoopBusinessSpaceContext(),
             lifecycle_view=BotLifecycleView(NoopServiceLifecyclePort()),
+            edit_lock_view=_no_edit_locks(),
         ),
         bot,
         desktop,
@@ -184,7 +192,9 @@ def test_service_bot_expands_to_publication_cards_before_pagination() -> None:
                 display_state=DisplayState.SERVICE_DRAFT,
                 status="draft",
                 actions=(BotAction.VIEW, BotAction.PUBLISH_STAGING),
+                internal_status="draft",
                 live_version=3,
+                has_draft=True,
             ),
             ServiceLifecycleCard(
                 publication_id=3,
@@ -192,6 +202,7 @@ def test_service_bot_expands_to_publication_cards_before_pagination() -> None:
                 display_state=DisplayState.SERVICE_OFFLINE,
                 status="released",
                 actions=(BotAction.VIEW,),
+                internal_status="released",
                 live_version=3,
             ),
         )
@@ -201,12 +212,23 @@ def test_service_bot_expands_to_publication_cards_before_pagination() -> None:
         1: PermissionLevel.OWNER,
         10: PermissionLevel.OWNER,
     }
+    edit_lock_view = MagicMock()
+    edit_lock_view.states_for_bots.return_value = {
+        ("s1", "u1"): ServiceEditLockState(
+            locked=True,
+            holder_user_id="editor-1",
+            holder_name="Editor One",
+            has_collaborators=True,
+            is_owner_holder=False,
+        )
+    }
     inventory = BotInventoryService(
         bot_service=bot,
         desktop_service=desktop,
         access_service=access,
         business_space=NoopBusinessSpaceContext(),
         lifecycle_view=BotLifecycleView(lifecycle_port),
+        edit_lock_view=edit_lock_view,
     )
 
     items, total = inventory.list_items(
@@ -227,7 +249,89 @@ def test_service_bot_expands_to_publication_cards_before_pagination() -> None:
     service_items = [item for item in items if item.bot_id == "s1"]
     assert [item.publication_id for item in service_items] == [4, 3]
     assert [item.card_id for item in service_items] == ["service:s1:4", "service:s1:3"]
+    assert [item.edit_lock.need_lock for item in service_items] == [True, True]
+    assert [item.edit_lock.holder_name for item in service_items] == [
+        "Editor One",
+        "Editor One",
+    ]
+    edit_lock_view.states_for_bots.assert_called_once_with(bots=[service_row])
     lifecycle_port.cards_for_bots.assert_called_once_with(bots=[service_row])
+
+
+@pytest.mark.unit
+def test_edit_lock_batch_reads_only_service_bots_on_current_page() -> None:
+    first = {
+        **CLOUD,
+        "id": 10,
+        "bot_id": "service-1",
+        "bot_name": "A Service",
+        "bot_type": "service",
+    }
+    second = {
+        **first,
+        "id": 11,
+        "bot_id": "service-2",
+        "bot_name": "B Service",
+    }
+    bot = MagicMock()
+    bot.list_bots_by_conditions.return_value = {
+        "total": 2,
+        "items": [first, second],
+    }
+    desktop = MagicMock()
+    desktop.list_user_bots.return_value = []
+    access = MagicMock()
+    access.get_operable_permission_levels.return_value = {
+        10: PermissionLevel.OWNER,
+        11: PermissionLevel.OWNER,
+    }
+    lifecycle_port = MagicMock()
+    lifecycle_port.cards_for_bots.return_value = {
+        row["bot_id"]: (
+            ServiceLifecycleCard(
+                publication_id=row["id"],
+                version=1,
+                display_state=DisplayState.SERVICE_ONLINE,
+                status="running",
+                actions=(BotAction.VIEW,),
+            ),
+        )
+        for row in (first, second)
+    }
+    edit_lock_view = MagicMock()
+    edit_lock_view.states_for_bots.return_value = {
+        ("service-1", "u1"): ServiceEditLockState(
+            locked=False,
+            holder_user_id=None,
+            holder_name=None,
+            has_collaborators=False,
+            is_owner_holder=False,
+        )
+    }
+    inventory = BotInventoryService(
+        bot_service=bot,
+        desktop_service=desktop,
+        access_service=access,
+        business_space=NoopBusinessSpaceContext(),
+        lifecycle_view=BotLifecycleView(lifecycle_port),
+        edit_lock_view=edit_lock_view,
+    )
+
+    items, total = inventory.list_items(
+        owner_id="u1",
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
+        keyword=None,
+        engine=None,
+        deploy_mode=DeployMode.CLOUD,
+        page=1,
+        page_size=1,
+    )
+
+    assert total == 2
+    assert [item.bot_id for item in items] == ["service-1"]
+    edit_lock_view.states_for_bots.assert_called_once_with(bots=[first])
 
 
 @pytest.mark.unit
@@ -411,12 +515,30 @@ def test_team_space_lists_all_owners_and_scopes_actions_by_bot_permission() -> N
         )
         for row in rows
     }
+    edit_lock_view = MagicMock()
+    edit_lock_view.states_for_bots.return_value = {
+        ("service-owner", "u1"): ServiceEditLockState(
+            locked=False,
+            holder_user_id=None,
+            holder_name=None,
+            has_collaborators=False,
+            is_owner_holder=False,
+        ),
+        ("service-editor", "other-owner"): ServiceEditLockState(
+            locked=True,
+            holder_user_id="u1",
+            holder_name="Current User",
+            has_collaborators=True,
+            is_owner_holder=False,
+        ),
+    }
     inventory = BotInventoryService(
         bot_service=bot,
         desktop_service=desktop,
         access_service=access,
         business_space=business_space,
         lifecycle_view=BotLifecycleView(lifecycle_port),
+        edit_lock_view=edit_lock_view,
     )
 
     items, total = inventory.list_items(
@@ -465,6 +587,10 @@ def test_team_space_lists_all_owners_and_scopes_actions_by_bot_permission() -> N
         "edit": "Bot editor permission required",
         "delete": "Bot editor permission required",
     }
+    assert by_id["service-owner"].edit_lock is not None
+    assert by_id["service-editor"].edit_lock is not None
+    assert by_id["service-viewer"].edit_lock is None
+    edit_lock_view.states_for_bots.assert_called_once_with(bots=[editor_bot, owner_bot])
     assert all(item.space == team_space for item in items)
 
 

--- a/src/backend/tests/community/repository/bot/test_collaborator_repository_batch.py
+++ b/src/backend/tests/community/repository/bot/test_collaborator_repository_batch.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.base import Base
+from agentclaw.community.core.repository.implementations.bot.collaborator import (
+    CollaboratorRepository,
+)
+from agentclaw.community.core.repository.implementations.bot.collab_lock import (
+    BotCollabLockRepository,
+)
+
+
+class _InMemorySqliteDB:
+    def __init__(self, engine) -> None:
+        self._session_factory = sessionmaker(bind=engine, autoflush=False)
+
+    @contextmanager
+    def orm_session(self):
+        db = self._session_factory()
+        try:
+            yield db
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        finally:
+            db.close()
+
+
+@pytest.fixture
+def repo():
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    return CollaboratorRepository(_InMemorySqliteDB(engine))
+
+
+@pytest.fixture
+def lock_repo():
+    engine = create_engine(
+        "sqlite:///:memory:", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    return BotCollabLockRepository(_InMemorySqliteDB(engine))
+
+
+def _insert(repo, *, bot_pk: int, bot_id: str, owner_id: str, user_id: str):
+    return repo.insert(
+        {
+            "bot_pk": bot_pk,
+            "bot_id": bot_id,
+            "owner_id": owner_id,
+            "user_id": user_id,
+            "user_name": user_id,
+            "operator_id": owner_id,
+            "env": "dev",
+        }
+    )
+
+
+def test_list_by_bot_owner_pairs_filters_cross_product_matches(repo) -> None:
+    _insert(
+        repo,
+        bot_pk=1,
+        bot_id="shared-id",
+        owner_id="owner-1",
+        user_id="editor-1",
+    )
+    _insert(
+        repo,
+        bot_pk=2,
+        bot_id="service-2",
+        owner_id="owner-2",
+        user_id="editor-2",
+    )
+    _insert(
+        repo,
+        bot_pk=3,
+        bot_id="shared-id",
+        owner_id="owner-2",
+        user_id="cross-product-only",
+    )
+
+    records = repo.list_by_bot_owner_pairs(
+        [("shared-id", "owner-1"), ("service-2", "owner-2")],
+        "dev",
+    )
+
+    assert {(record.bot_id, record.owner_id, record.user_id) for record in records} == {
+        ("shared-id", "owner-1", "editor-1"),
+        ("service-2", "owner-2", "editor-2"),
+    }
+
+
+def test_list_by_bot_owner_pairs_skips_database_for_empty_input(repo) -> None:
+    assert repo.list_by_bot_owner_pairs([], "dev") == []
+
+
+def test_list_by_keys_returns_only_requested_locks(lock_repo, monkeypatch) -> None:
+    monkeypatch.setenv("SERVER_ENV", "dev")
+    lock_repo.acquire("lock-key-001", "user-001")
+    lock_repo.acquire("lock-key-002", "user-002")
+    lock_repo.acquire("lock-key-003", "user-003")
+
+    records = lock_repo.list_by_keys(["lock-key-001", "lock-key-003"])
+
+    assert {record.lock_key for record in records} == {
+        "lock-key-001",
+        "lock-key-003",
+    }
+
+
+def test_list_by_keys_skips_database_for_empty_input(lock_repo) -> None:
+    assert lock_repo.list_by_keys([]) == []


### PR DESCRIPTION
## Problem

The workshop inventory had to issue one edit-lock request per service Bot after loading `/openapi/v1/bots/all`, delaying complete card rendering and multiplying gateway/database work.

## Solution

- Add optional `edit_lock` data to service Bot inventory cards while reusing the existing public `EditLock` contract.
- Enrich only the paginated page and deduplicate `(bot_id, owner_id)` across publication versions.
- Batch collaborator rows and lock records in two repository queries.
- Return lock information only for callers with at least MEMBER access; visibility-only cards and non-service Bots remain `null`.
- Preserve the standalone edit-lock endpoints for mutations and explicit refreshes.

## Validation

- Backend CI: 14,960 passed, 57 skipped.
- Total line coverage: 87.56%.
- Changed-line coverage: 96.75% (119/123).
- Pre-push Python SAST gate passed.
- Focused inventory/lock suite passed after rebasing onto the latest `dev`.

## Compatibility and risk

The response change is additive. Repository additions are read-only batch methods; existing legacy routes and edit-lock mutation semantics are unchanged. If batch enrichment fails, `/all` still returns cards with `edit_lock: null`.