### PR TITLE
feat(openapi): add GET /openapi/v1/sessions bot session listing

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
@@ -209,3 +209,52 @@ class SessionMessagesResponse(ApiResponse[SessionMessagesResponseData]):
     data: SessionMessagesResponseData | None = Field(
         default=None, description="Session message data"
     )
+
+
+class SessionListItem(BaseModel):
+    """Session list item.
+
+    Only exposes fields common to all engines' `list()` returns and the
+    response contract; engine-specific fields (runtime, ext_info, etc.) are
+    not surfaced. `bot_id` is filled in by the service/runner layer from the
+    resolved binding (the adapter `SessionInfo` does not carry it).
+    """
+
+    session_id: str = Field(..., description="Session ID")
+    bot_id: str = Field(..., description="Bot ID (resolved binding bot_id)")
+    title: str | None = Field(default=None, description="Session title")
+    user_id: str | None = Field(default=None, description="User ID")
+    agent_id: str | None = Field(default=None, description="Agent ID")
+    model: str | None = Field(default=None, description="Model name")
+    created_at: str | None = Field(
+        default=None, description="Session creation time (ISO 8601)"
+    )
+    updated_at: str | None = Field(
+        default=None, description="Session last update time (ISO 8601)"
+    )
+    message_count: int = Field(default=0, description="Message count in session")
+
+
+class SessionListResponseData(BaseModel):
+    """Session list response data.
+
+    `total` is the count of items in the current page (the engine
+    `/api/sessions` endpoint does not return a global total), i.e.
+    `total == len(items)`. Callers can infer `has_more` via
+    `len(items) == limit`.
+    """
+
+    items: list[SessionListItem] = Field(
+        default_factory=list, description="Session list for the current page"
+    )
+    total: int = Field(default=0, description="Item count in the current page")
+    limit: int = Field(default=20, description="Page size used for this query")
+    offset: int = Field(default=0, description="Offset used for this query")
+
+
+class SessionListResponse(ApiResponse[SessionListResponseData]):
+    """Session list standard response"""
+
+    data: SessionListResponseData | None = Field(
+        default=None, description="Session list data"
+    )

--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/session_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/session_router.py
@@ -14,6 +14,9 @@ from secbaas.community.adapters.web.routers.open_api.dependencies import (
 )
 from secbaas.community.adapters.web.routers.open_api.model import (
     MessageItem,
+    SessionListItem,
+    SessionListResponse,
+    SessionListResponseData,
     SessionMessagesResponse,
     SessionMessagesResponseData,
     SessionQueryResponse,
@@ -49,6 +52,165 @@ def _check_app_type(api_key_record: APIKeyRecord) -> None:
                 "code": OpenAPICode.FORBIDDEN,
                 "message": get_code_message(OpenAPICode.FORBIDDEN),
             },
+        )
+
+
+@router.get(
+    "/sessions",
+    response_model=SessionListResponse,
+    summary="List sessions of a bot",
+    description="List sessions of a specific bot using a Bearer Token-authenticated API Key. "
+    "Only sessions the caller is permitted to access are returned.",
+    responses={
+        200: {"description": "Query successful"},
+        401: {"description": "Authentication failed"},
+        403: {"description": "Access denied"},
+        404: {"description": "Bot not found"},
+        500: {"description": "Internal server error"},
+    },
+)
+@inject
+async def list_bot_sessions(
+    bot_id: str | None = Query(
+        default=None,
+        description="Bot ID, format: bot_id or default:staff_no. If omitted, resolved from the API Key.",
+    ),
+    user_id: str | None = Query(
+        default=None,
+        description="Optional user ID to scope the listed sessions.",
+    ),
+    limit: int = Query(
+        default=20, ge=1, le=100, description="Page size, range 1-100. Default 20."
+    ),
+    offset: int = Query(default=0, ge=0, description="Pagination offset. Default 0."),
+    lifecycle_stage: str = Query(
+        default="online",
+        description="Bot lifecycle stage. Options: online, verify, draft, all",
+    ),
+    api_key_record: APIKeyRecord = Depends(validate_api_key),
+    context: BotChatContext = Depends(get_bot_chat_context),
+    bot_runner: BotRunner = Depends(Provide[ApplicationContainer.services.bot_runner]),
+) -> SessionListResponse:
+    """List sessions endpoint
+
+    Returns sessions for the resolved bot_id. `total` is the count of items in
+    the current page (the engine ``/api/sessions`` endpoint does not return a
+    global total); callers can infer ``has_more`` via ``len(items) == limit``.
+
+    Args:
+        bot_id: Bot ID, format: bot_id or default:staff_no. If omitted, resolved from the API Key.
+        user_id: Optional user ID to scope the listed sessions.
+        limit: Page size, range 1-100. Default 20.
+        offset: Pagination offset. Default 0.
+        lifecycle_stage: Bot lifecycle stage. Options: online, verify, draft, all. Default: online
+        api_key_record: Record obtained from API Key validation
+        context: Request context (authentication, caller identity, etc.)
+        bot_runner: BotRunner instance
+
+    Returns:
+        SessionListResponse: Session list response
+    """
+    # Only app_type=bot can resolve bot_id from the API Key; other types must pass it explicitly
+    if bot_id:
+        resolved_bot_id = bot_id
+    elif api_key_record.app_type == "bot":
+        resolved_bot_id = resolve_bot_id_from_api_key(api_key_record)
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": OpenAPICode.BUSINESS_ERROR,
+                "message": "bot_id is a required parameter",
+            },
+        )
+
+    _check_app_type(api_key_record)
+    if api_key_record.app_type != "bot":
+        resolved_bot_id = validate_policy(api_key_record, resolved_bot_id)
+
+    logger.info(
+        f"list_bot_sessions: bot_id={resolved_bot_id}, user_id={user_id}, "
+        f"limit={limit}, offset={offset}, lifecycle_stage={lifecycle_stage}, "
+        f"api_key_prefix={api_key_record.api_key_prefix}"
+    )
+
+    try:
+        sessions = await bot_runner.list_sessions(
+            bot_id=resolved_bot_id,
+            context=context,
+            metadata={"bot_options": {"lifecycle_stage": lifecycle_stage}},
+            user_id=user_id,
+            limit=limit,
+            offset=offset,
+        )
+
+        # Build response items. The adapter-level SessionInfo (from
+        # AsyncSessionClient) carries title/user_id/agent_id/model/
+        # created_at/updated_at/message_count; `bot_id` is injected from the
+        # resolved binding (adapter SessionInfo has no bot_id field).
+        items = [
+            SessionListItem(
+                session_id=getattr(s, "id", None) or getattr(s, "session_id", ""),
+                bot_id=resolved_bot_id,
+                title=getattr(s, "title", None),
+                user_id=getattr(s, "user_id", None),
+                agent_id=getattr(s, "agent_id", None),
+                model=getattr(s, "model", None),
+                created_at=getattr(s, "created_at", None),
+                updated_at=getattr(s, "updated_at", None),
+                message_count=getattr(s, "message_count", 0) or 0,
+            )
+            for s in sessions
+        ]
+
+        logger.info(
+            f"list_bot_sessions success: bot_id={resolved_bot_id}, "
+            f"returned={len(items)}, limit={limit}, offset={offset}"
+        )
+
+        return SessionListResponse(
+            code=0,
+            message="success",
+            data=SessionListResponseData(
+                items=items,
+                total=len(items),
+                limit=limit,
+                offset=offset,
+            ),
+        )
+
+    except BotBindingNotFoundError as e:
+        logger.warning(
+            f"list_bot_sessions binding not found: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": 60001, "message": str(e)},
+        )
+    except BotNotFoundError as e:
+        logger.warning(
+            f"list_bot_sessions bot not found: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": 60001, "message": str(e)},
+        )
+    except BotServiceError as e:
+        logger.error(
+            f"list_bot_sessions bot service error: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": OpenAPICode.BUSINESS_ERROR, "message": str(e)},
+        )
+    except Exception as e:
+        logger.error(
+            f"list_bot_sessions unexpected error: bot_id={resolved_bot_id}, error={e}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"code": 50001, "message": f"Internal server error: {str(e)}"},
         )
 
 

--- a/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
@@ -404,6 +404,42 @@ class BotRunner(Protocol):
         """
         ...
 
+    async def list_sessions(
+        self,
+        *,
+        bot_id: str,
+        context: "BotChatContext",
+        metadata: dict[str, Any],
+        user_id: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list["SessionInfo"]:
+        """查询指定 bot 下的会话列表（只读）
+
+        复用 ``_resolve_bot_route(bot_id, metadata)`` 的 binding 解析与
+        service 选择链路，调用 ``BotService.list_sessions`` 经
+        AsyncSessionClient 访问 engine `GET /api/sessions`。
+
+        Args:
+            bot_id: Bot 唯一标识，格式为 <real_bot_id>:<entity_id>。
+                可省略 entity 部分；与 ``get_session_info`` 同语义。
+            context: 请求上下文（身份认证、调用者信息等）
+            metadata: 元数据，支持 bot_options.lifecycle_stage 指定生命周期阶段
+            user_id: 可选，限定特定 user 的会话；不传则列出该 bot 全部会话
+            limit: 分页大小，范围 1-100，默认 20
+            offset: 分页偏移，默认 0
+
+        Returns:
+            SessionInfo 列表（adapter 层 SessionInfo；`bot_id` 由
+            router 层基于 binding 回填）
+
+        Raises:
+            BotBindingNotFoundError: binding 不存在
+            BotNotFoundError: bot 不存在
+            BotServiceError: 上游 engine 不可用或未实现 SESSION_LIST capability
+        """
+        ...
+
     def get_result(self, run_id: str) -> Any:
         """获取执行结果
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -659,6 +659,76 @@ class BaasBotService(BotService):
                 f"Failed to get session: {_safe_client_msg(e)}"
             ) from e
 
+    async def list_sessions(
+        self,
+        *,
+        agent_id: str,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        user_id: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionInfo]:
+        """查询指定 bot 下的会话列表（只读）
+
+        复用 ``_resolve_ws_connection_for_binding`` + ``_create_session_client``
+        链路，调用 ``AsyncSessionClient.list_sessions`` 访问 engine
+        `GET /api/sessions`，按 ``agent_id`` 过滤。返回 adapter 层
+        ``SessionInfo`` 列表（``bot_id`` 由 router 层基于 binding 注入）。
+
+        Args:
+            agent_id: 路由后的 bot_id，作为 engine 侧 ``agent_id`` 过滤项
+            binding_info: 已解析的 binding 信息
+            context: 可选请求上下文（用于提取 tenant）
+            user_id: 可选，限定特定 user 的会话
+            limit: 分页大小（已由 router 收紧至 1-100）
+            offset: 分页偏移
+
+        Returns:
+            adapter 层 SessionInfo 列表（携带 title/user_id/agent_id/model/
+            created_at/updated_at/message_count；``bot_id`` 由 router 层基于
+            ``resolved_bot_id`` 注入，因为 adapter ``SessionInfo`` 无 bot_id 字段）
+
+        Raises:
+            BotServiceError: 上游 engine 返回 503/warning 或请求失败
+        """
+        try:
+            conn_info = await self._resolve_ws_connection_for_binding(
+                binding_info, context=context
+            )
+        except Exception as e:
+            logger.warning("Failed to resolve WS connection: %s", e)
+            raise BotServiceError(
+                f"Failed to resolve WS connection: {_safe_client_msg(e)}"
+            ) from e
+
+        session_client = self._create_session_client(
+            conn_info, binding_info.engine_type
+        )
+        try:
+            async with session_client:
+                return await session_client.list_sessions(
+                    user_id=user_id,
+                    agent_id=agent_id,
+                    limit=limit,
+                    offset=offset,
+                    engine=binding_info.engine_type,
+                )
+        except BotServiceError:
+            raise
+        except aiohttp.ClientResponseError as e:
+            # engine 未实现 SESSION_LIST capability 时返回 503/warning，
+            # 不 silent：透传为 BotServiceError → router 映射 400
+            logger.warning("Failed to list sessions: %s", e)
+            raise BotServiceError(
+                f"Failed to list sessions: {_safe_client_msg(e)}"
+            ) from e
+        except Exception as e:
+            logger.warning("Failed to list sessions: %s", e)
+            raise BotServiceError(
+                f"Failed to list sessions: {_safe_client_msg(e)}"
+            ) from e
+
     # ── 私有方法 ─────────────────────────────────────────────────────────────
 
     def _adapter_for(self, engine_type: str | None) -> BotEngineAdapter | None:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_claw_service.py
@@ -433,6 +433,57 @@ class ClawBotService(BotService):
         except Exception as e:
             raise BotServiceError(f"Failed to get session: {e}") from e
 
+    async def list_sessions(
+        self,
+        *,
+        agent_id: str,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        user_id: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionInfo]:
+        """查询指定 bot 下的会话列表（只读）
+
+        通过 AsyncSessionClient 调用 engine `GET /api/sessions`，按
+        ``agent_id`` 过滤。返回 adapter 层 SessionInfo 列表（``bot_id``
+        由 router 层基于 ``resolved_bot_id`` 注入）。
+
+        Args:
+            agent_id: 路由后的 bot_id，作为 engine 侧 ``agent_id`` 过滤项
+            binding_info: 已解析的 binding 信息
+            context: 可选请求上下文（ClawBotService 未使用）
+            user_id: 可选，限定特定 user 的会话
+            limit: 分页大小
+            offset: 分页偏移
+
+        Returns:
+            adapter 层 SessionInfo 列表
+
+        Raises:
+            BotServiceError: 请求失败
+        """
+        sandbox_id = binding_info.sandbox_id
+        if sandbox_id is None:
+            raise BotServiceError("ClawBotService requires sandbox_id in binding_info.")
+
+        session_client = self._create_session_client(sandbox_id)
+        try:
+            async with session_client:
+                return await session_client.list_sessions(
+                    user_id=user_id,
+                    agent_id=agent_id,
+                    limit=limit,
+                    offset=offset,
+                )
+        except aiohttp.ClientResponseError as e:
+            # engine 未实现 SESSION_LIST capability 时返回 503/warning
+            raise BotServiceError(f"Failed to list sessions: {e}") from e
+        except BotServiceError:
+            raise
+        except Exception as e:
+            raise BotServiceError(f"Failed to list sessions: {e}") from e
+
     # ── 私有方法 ─────────────────────────────────────────────────────────────
 
     def _adapter_for(self, engine_type: str | None) -> BotEngineAdapter | None:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
@@ -183,6 +183,40 @@ class BotService(Protocol):
         """
         ...
 
+    async def list_sessions(
+        self,
+        *,
+        agent_id: str,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        user_id: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionInfo]:
+        """查询指定 bot 下的会话列表（只读）
+
+        通过 AsyncSessionClient 调用 engine `GET /api/sessions`，按
+        ``agent_id``（即 route_bot_id）过滤，可选按 ``user_id`` 收窄。
+        不创建新会话。
+
+        Args:
+            agent_id: 路由后的 bot_id，作为 engine 侧 ``agent_id`` 过滤项
+            binding_info: 已解析的 binding 信息（用于创建底层连接）
+            context: 可选的请求上下文（用于提取 tenant）
+            user_id: 可选，限定特定 user 的会话；不传则列出该 bot 全部会话
+            limit: 分页大小，范围 1-100
+            offset: 分页偏移
+
+        Returns:
+            SessionInfo 列表（adapter 层 SessionInfo，由上层映射为
+            OpenAPI 响应；bot_id 由调用方注入）
+
+        Raises:
+            BotServiceError: 上游 engine 返回 503/warning（如未实现
+                SESSION_LIST capability）或请求失败
+        """
+        ...
+
 
 @runtime_checkable
 class MessageDispatcher(Protocol):

--- a/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
@@ -440,6 +440,32 @@ class BotRunner:
             context=context,
         )
 
+    async def list_sessions(
+        self,
+        *,
+        bot_id: str,
+        context: BotChatContext,
+        metadata: dict[str, Any],
+        user_id: str | None = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[SessionInfo]:
+        """查询指定 bot 下的会话列表（只读）
+
+        复用 ``_resolve_bot_route`` 的 binding 解析与 service 选择链路，
+        委托 ``BotService.list_sessions`` 调用 engine `GET /api/sessions`。
+        ``route_bot_id`` 作为 engine 侧 ``agent_id`` 过滤项。
+        """
+        route = await self._resolve_bot_route(bot_id, metadata)
+        return await route.bot_service.list_sessions(
+            agent_id=route.route_bot_id,
+            binding_info=route.binding_info,
+            context=context,
+            user_id=user_id,
+            limit=limit,
+            offset=offset,
+        )
+
     def get_result(self, run_id: str) -> Any:
         """获取执行结果
 

--- a/src/baas/tests/e2e/asgi/baseline/test_open_api_sessions.py
+++ b/src/baas/tests/e2e/asgi/baseline/test_open_api_sessions.py
@@ -1,8 +1,8 @@
 """E2E tests for Open API Session endpoints.
 
 Tests cover:
-- GET /openapi/v1/sessions - list sessions → 200/404 (no list endpoint)
-- GET /openapi/v1/sessions - pagination with page and page_size params
+- GET /openapi/v1/sessions - list sessions for a bot → 401 without auth, 200/400/401 with auth
+- GET /openapi/v1/sessions - pagination with limit and offset params
 - GET /openapi/v1/sessions/{session_id} - valid session ID → 200
 - GET /openapi/v1/sessions/{session_id} - not found → 404
 - GET /openapi/v1/sessions/{session_id} - invalid session ID format
@@ -18,7 +18,7 @@ pytestmark = [pytest.mark.e2e_asgi]
 
 
 class TestListSessions:
-    """GET /openapi/v1/sessions — session listing endpoint."""
+    """GET /openapi/v1/sessions — list sessions for a bot."""
 
     @pytest.mark.asyncio
     async def test_list_sessions_no_auth(self, api: APITestHelper) -> None:
@@ -32,47 +32,59 @@ class TestListSessions:
 
     @pytest.mark.asyncio
     async def test_list_sessions_with_auth_header(self, api: APITestHelper) -> None:
-        """GET /openapi/v1/sessions with auth header."""
+        """GET /openapi/v1/sessions with auth header.
+
+        The endpoint exists; with a test/invalid key → 401, with a valid key
+        and bot_id → 200 with `data.items` structure.
+        """
         response = await api.client.get(
             api.open_api_session_url(),
+            params={"bot_id": "test-bot"},
             headers={"Authorization": "Bearer test-key"},
         )
 
-        # No dedicated list endpoint exists; expect 404 or 401 (invalid key)
-        assert response.status_code in (200, 401, 404)
+        # Invalid test key → 401; valid key → 200 with items list
+        assert response.status_code in (200, 400, 401, 403, 404)
+        if response.status_code == 200:
+            body = response.json()
+            assert "data" in body
+            assert "items" in body["data"]
+            assert "total" in body["data"]
 
     @pytest.mark.asyncio
     async def test_list_sessions_with_pagination(self, api: APITestHelper) -> None:
-        """GET /openapi/v1/sessions with pagination params → 401/404."""
+        """GET /openapi/v1/sessions with limit/offset params."""
         response = await api.client.get(
             api.open_api_session_url(),
-            params={"page": 1, "page_size": 5},
+            params={"bot_id": "test-bot", "limit": 5, "offset": 0},
             headers={"Authorization": "Bearer test-key"},
         )
 
-        assert response.status_code in (200, 401, 404)
+        assert response.status_code in (200, 400, 401, 403, 404)
 
     @pytest.mark.asyncio
-    async def test_list_sessions_page_out_of_range(self, api: APITestHelper) -> None:
-        """GET /openapi/v1/sessions with page=99999 → 401/404."""
+    async def test_list_sessions_limit_exceeds_max(self, api: APITestHelper) -> None:
+        """GET /openapi/v1/sessions with limit=200 (>100) → 422."""
         response = await api.client.get(
             api.open_api_session_url(),
-            params={"page": 99999, "page_size": 10},
+            params={"bot_id": "test-bot", "limit": 200},
             headers={"Authorization": "Bearer test-key"},
         )
 
-        assert response.status_code in (200, 401, 404)
+        # limit has ge=1, le=100 constraint → 422 for out of range (or 401
+        # if auth runs before validation)
+        assert response.status_code in (200, 400, 401, 403, 404, 422)
 
     @pytest.mark.asyncio
-    async def test_list_sessions_zero_page_size(self, api: APITestHelper) -> None:
-        """GET /openapi/v1/sessions with page_size=0 → 401/422/404."""
+    async def test_list_sessions_zero_limit(self, api: APITestHelper) -> None:
+        """GET /openapi/v1/sessions with limit=0 → 422 (ge=1 constraint)."""
         response = await api.client.get(
             api.open_api_session_url(),
-            params={"page": 1, "page_size": 0},
+            params={"bot_id": "test-bot", "limit": 0},
             headers={"Authorization": "Bearer test-key"},
         )
 
-        assert response.status_code in (200, 401, 422, 404)
+        assert response.status_code in (200, 400, 401, 403, 404, 422)
 
 
 class TestGetSessionById:

--- a/src/baas/tests/unit/adapters/web/open_api/test_session_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_session_router.py
@@ -19,6 +19,7 @@ from secbaas.community.adapters.web.routers.open_api.session_router import (
     _check_app_type,
     get_session,
     get_session_messages,
+    list_bot_sessions,
 )
 from secbaas.community.api.api_gateway import APIKeyRecord
 from secbaas.community.api.bot_runtime import (
@@ -31,6 +32,9 @@ from secbaas.community.api.bot_runtime import (
 )
 from secbaas.community.api.open_api import OpenAPICode
 from secbaas.community.core.service.bot_run import BotBindingNotFoundError, BotRunner
+from secbaas.community.core.service.bot_run._async_session_client import (
+    SessionInfo as AdapterSessionInfo,
+)
 
 # ── helpers ──────────────────────────────────────────────────
 
@@ -932,3 +936,337 @@ class TestGetSessionMessages:
         assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
         assert exc.value.detail["code"] == 50001
         assert "Internal server error" in exc.value.detail["message"]
+
+
+# ── list_bot_sessions ────────────────────────────────────────
+
+
+def _make_adapter_session_info(**overrides):
+    """Build an adapter-level SessionInfo (from AsyncSessionClient) as
+    returned by BotService.list_sessions / BotRunner.list_sessions."""
+    defaults = {
+        "id": "sess-list-001",
+        "title": "My Session",
+        "user_id": "user-1",
+        "agent_id": "bot-1",
+        "model": "gpt-test",
+        "created_at": "2025-01-15T10:30:00Z",
+        "updated_at": "2025-01-15T11:00:00Z",
+        "message_count": 3,
+    }
+    defaults.update(overrides)
+    return AdapterSessionInfo(**defaults)
+
+
+# Default Query-parameter values for list_bot_sessions
+DEFAULT_LIST_LIMIT = 20
+DEFAULT_LIST_OFFSET = 0
+
+
+class TestListBotSessionsBotIdResolution:
+    """bot_id 解析逻辑：显式传入优先，bot 类型自动解析，其余必填。"""
+
+    @pytest.mark.asyncio
+    async def test_explicit_bot_id_used_directly(self):
+        api_key = _make_api_key_record(app_type="bot", app_id="bot-default:entity-1")
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            await list_bot_sessions(
+                bot_id="bot-explicit:entity-1",
+                user_id=None,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        mock_runner.list_sessions.assert_called_once()
+        assert (
+            mock_runner.list_sessions.call_args[1]["bot_id"] == "bot-explicit:entity-1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bot_app_type_resolves_from_api_key(self):
+        api_key = _make_api_key_record(app_type="bot", app_id="bot-1:entity-1")
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with (
+            patch(RESOLVE_PATH, return_value=BOT_ID) as mock_resolve,
+            patch(POLICY_PATH),
+        ):
+            await list_bot_sessions(
+                bot_id=None,
+                user_id=None,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_resolve.assert_called_once_with(api_key)
+
+    @pytest.mark.asyncio
+    async def test_system_app_type_without_bot_id_returns_400(self):
+        api_key = _make_api_key_record(app_type="system")
+        mock_runner = AsyncMock(spec=BotRunner)
+
+        with pytest.raises(HTTPException) as exc:
+            await list_bot_sessions(
+                bot_id=None,
+                user_id=None,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+        assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert exc.value.detail["code"] == OpenAPICode.BUSINESS_ERROR
+
+    @pytest.mark.asyncio
+    async def test_non_allowed_app_type_returns_403(self):
+        api_key = _make_api_key_record(app_type="user")
+        mock_runner = AsyncMock(spec=BotRunner)
+
+        with pytest.raises(HTTPException) as exc:
+            await list_bot_sessions(
+                bot_id=BOT_ID,
+                user_id=None,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+class TestListBotSessionsCore:
+    """list_bot_sessions 端点核心逻辑测试。"""
+
+    @pytest.mark.asyncio
+    async def test_success_returns_session_list(self):
+        sessions = [
+            _make_adapter_session_info(
+                id="s-1", title="T1", user_id="u1", message_count=2
+            ),
+            _make_adapter_session_info(
+                id="s-2", title="T2", user_id="u2", message_count=5
+            ),
+        ]
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=sessions)
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_bot_sessions(
+                bot_id=BOT_ID,
+                user_id=None,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.code == 0
+        assert result.message == "success"
+        assert result.data.total == 2
+        assert result.data.limit == DEFAULT_LIST_LIMIT
+        assert result.data.offset == DEFAULT_LIST_OFFSET
+        assert len(result.data.items) == 2
+        assert result.data.items[0].session_id == "s-1"
+        assert result.data.items[0].bot_id == BOT_ID
+        assert result.data.items[0].title == "T1"
+        assert result.data.items[0].user_id == "u1"
+        assert result.data.items[0].message_count == 2
+        assert result.data.items[1].session_id == "s-2"
+
+    @pytest.mark.asyncio
+    async def test_success_empty_list(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_bot_sessions(
+                bot_id=BOT_ID,
+                user_id=None,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.data.total == 0
+        assert result.data.items == []
+
+    @pytest.mark.asyncio
+    async def test_limit_offset_passthrough(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            await list_bot_sessions(
+                bot_id=BOT_ID,
+                user_id="u-1",
+                limit=50,
+                offset=10,
+                lifecycle_stage="draft",
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        mock_runner.list_sessions.assert_called_once_with(
+            bot_id=BOT_ID,
+            context=_make_context(),
+            metadata={"bot_options": {"lifecycle_stage": "draft"}},
+            user_id="u-1",
+            limit=50,
+            offset=10,
+        )
+
+    @pytest.mark.asyncio
+    async def test_lifecycle_stage_default_online(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            await list_bot_sessions(
+                bot_id=BOT_ID,
+                user_id=None,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage="online",
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert (
+            mock_runner.list_sessions.call_args[1]["metadata"]["bot_options"][
+                "lifecycle_stage"
+            ]
+            == "online"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bot_binding_not_found_returns_404(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotBindingNotFoundError(BOT_ID),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_bot_sessions(
+                    bot_id=BOT_ID,
+                    user_id=None,
+                    limit=DEFAULT_LIST_LIMIT,
+                    offset=DEFAULT_LIST_OFFSET,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+        assert exc.value.detail["code"] == 60001
+
+    @pytest.mark.asyncio
+    async def test_bot_not_found_returns_404(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotNotFoundError("bot-1"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_bot_sessions(
+                    bot_id=BOT_ID,
+                    user_id=None,
+                    limit=DEFAULT_LIST_LIMIT,
+                    offset=DEFAULT_LIST_OFFSET,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+        assert exc.value.detail["code"] == 60001
+
+    @pytest.mark.asyncio
+    async def test_bot_service_error_returns_400(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotServiceError("service unavailable"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_bot_sessions(
+                    bot_id=BOT_ID,
+                    user_id=None,
+                    limit=DEFAULT_LIST_LIMIT,
+                    offset=DEFAULT_LIST_OFFSET,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert exc.value.detail["code"] == OpenAPICode.BUSINESS_ERROR
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_returns_500(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=RuntimeError("unexpected failure"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_bot_sessions(
+                    bot_id=BOT_ID,
+                    user_id=None,
+                    limit=DEFAULT_LIST_LIMIT,
+                    offset=DEFAULT_LIST_OFFSET,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert exc.value.detail["code"] == 50001
+        assert "Internal server error" in exc.value.detail["message"]
+
+    @pytest.mark.asyncio
+    async def test_bot_type_skips_validate_policy(self):
+        api_key = _make_api_key_record(app_type="bot", app_id=BOT_ID)
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with (
+            patch(POLICY_PATH) as mock_policy,
+            patch(RESOLVE_PATH, return_value=BOT_ID),
+        ):
+            await list_bot_sessions(
+                bot_id=None,
+                user_id=None,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_policy.assert_not_called()


### PR DESCRIPTION
# feat(openapi): add GET /openapi/v1/sessions bot session listing

## Summary

Introduces a new public OpenAPI route `GET /openapi/v1/sessions` that lists
the sessions a bot is permitted to access, authenticated by a Bearer-token
API key.

## Changes

- **Router models** (`adapters/web/routers/open_api/model.py`): add
  `SessionListItem`, `SessionListResponseData`, and `SessionListResponse`.
- **Session router** (`adapters/web/routers/open_api/session_router.py`):
  add `list_bot_sessions` with `bot_id` resolution (defaults to the API
  key's bot), optional `user_id` scoping, and `limit`/`offset` pagination
  (`limit` 1-100, default 20; `offset` default 0).
- **Bot runtime protocols** (`api/bot_runtime/_protocols.py`): extend
  `BotRunner` / `BotChatContext` with a session-list capability.
- **Bot run services** (`core/service/bot_run/_baas_service.py`,
  `_claw_service.py`, `_internal_protocols.py`, `_runner.py`): wire the
  session-list capability through the baas and claw implementations.
- **Tests**: add unit tests for the session router and refresh the e2e
  ASGI baseline covering the new sessions listing route.

## Behavior

- Returns only sessions the caller is permitted to access.
- `total` reflects the count of items in the current page (the backing
  engine `/api/sessions` endpoint does not return a global total);
  callers can infer `has_more` via `len(items) == limit`.
- Authentication / authorization handled via the existing API key
  validation dependency; standard 401/403/404/500 responses documented.

## Verification

- Unit tests for the session router added/updated.
- E2E ASGI baseline test refreshed for the new route.