### PR TITLE
feat(baas): add GET /openapi/v1/sessions list endpoint

### DIFF
--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py
@@ -209,3 +209,55 @@ class SessionMessagesResponse(ApiResponse[SessionMessagesResponseData]):
     data: SessionMessagesResponseData | None = Field(
         default=None, description="Session message data"
     )
+
+
+class SessionListItem(BaseModel):
+    """Session list item.
+
+    Field set is aligned with the api-level ``SessionInfo`` returned by
+    ``BotRunner.list_sessions``. ``title`` / ``user_id`` / ``agent_id`` /
+    ``model`` / ``message_count`` are optional: the upstream
+    ``AsyncSessionClient.list_sessions`` carries them, but they are not
+    surfaced through the api-level ``SessionInfo`` mapping today, so they are
+    surfaced as ``None`` rather than fabricated.
+    """
+
+    session_id: str = Field(..., description="Session ID")
+    bot_id: str | None = Field(default=None, description="Bot ID")
+    status: str | None = Field(default=None, description="Session status")
+    title: str | None = Field(default=None, description="Session title")
+    user_id: str | None = Field(default=None, description="User ID")
+    agent_id: str | None = Field(default=None, description="Agent ID")
+    model: str | None = Field(default=None, description="Model name")
+    message_count: int | None = Field(
+        default=None, description="Number of messages in the session"
+    )
+    created_at: datetime | None = Field(default=None, description="Creation time")
+    updated_at: datetime | None = Field(default=None, description="Update time")
+
+
+class SessionListResponseData(BaseModel):
+    """Session list response data.
+
+    ``total`` and ``has_more`` are derived from the returned ``items`` list
+    because ``AsyncSessionClient.list_sessions`` does not return a total count.
+    ``has_more = len(items) == limit`` is a conservative hint, not a precise
+    indicator — see spec §3.1.
+    """
+
+    items: list[SessionListItem] = Field(
+        default_factory=list, description="Session list"
+    )
+    total: int = Field(default=0, description="Number of sessions in this response")
+    has_more: bool = Field(
+        default=False,
+        description="Conservative hint: True when the returned page is full",
+    )
+
+
+class SessionListResponse(ApiResponse[SessionListResponseData]):
+    """Session list standard response"""
+
+    data: SessionListResponseData | None = Field(
+        default=None, description="Session list data"
+    )

--- a/src/baas/src/secbaas/community/adapters/web/routers/open_api/session_router.py
+++ b/src/baas/src/secbaas/community/adapters/web/routers/open_api/session_router.py
@@ -14,6 +14,9 @@ from secbaas.community.adapters.web.routers.open_api.dependencies import (
 )
 from secbaas.community.adapters.web.routers.open_api.model import (
     MessageItem,
+    SessionListItem,
+    SessionListResponse,
+    SessionListResponseData,
     SessionMessagesResponse,
     SessionMessagesResponseData,
     SessionQueryResponse,
@@ -49,6 +52,180 @@ def _check_app_type(api_key_record: APIKeyRecord) -> None:
                 "code": OpenAPICode.FORBIDDEN,
                 "message": get_code_message(OpenAPICode.FORBIDDEN),
             },
+        )
+
+
+@router.get(
+    "/sessions",
+    response_model=SessionListResponse,
+    summary="List sessions for a Bot",
+    description="List sessions accessible to the caller under a specific Bot using a Bearer Token-authenticated API Key",
+    responses={
+        200: {"description": "Query successful"},
+        400: {"description": "Bad request"},
+        401: {"description": "Authentication failed"},
+        403: {"description": "Access denied"},
+        404: {"description": "Bot or binding not found"},
+        500: {"description": "Internal server error"},
+    },
+)
+@inject
+async def list_sessions(
+    bot_id: str | None = Query(
+        default=None,
+        description="Bot ID, format: bot_id or default:staff_no. If omitted, resolved from the API Key.",
+    ),
+    lifecycle_stage: str = Query(
+        default="online",
+        description="Bot lifecycle stage. Options: online, verify, draft, all",
+    ),
+    limit: int = Query(
+        default=20, ge=1, le=100, description="Maximum number of sessions to return"
+    ),
+    offset: int = Query(default=0, ge=0, description="Pagination offset"),
+    user_id: str | None = Query(
+        default=None, description="Filter by upstream user_id (passed through to list_sessions)"
+    ),
+    agent_id: str | None = Query(
+        default=None, description="Filter by upstream agent_id (passed through to list_sessions)"
+    ),
+    api_key_record: APIKeyRecord = Depends(validate_api_key),
+    context: BotChatContext = Depends(get_bot_chat_context),
+    bot_runner: BotRunner = Depends(Provide[ApplicationContainer.services.bot_runner]),
+) -> SessionListResponse:
+    """List sessions endpoint
+
+    Args:
+        bot_id: Bot ID, format: bot_id or default:staff_no. If omitted, resolved from the API Key.
+        lifecycle_stage: Bot lifecycle stage. Options: online, verify, draft, all. Default: online
+        limit: Maximum number of sessions to return. Default 20, range 1-100
+        offset: Pagination offset. Default 0
+        user_id: Optional upstream user_id filter, passed through to list_sessions
+        agent_id: Optional upstream agent_id filter, passed through to list_sessions
+        api_key_record: Record obtained from API Key validation
+        context: Request context (authentication, caller identity, etc.)
+        bot_runner: BotRunner instance
+
+    Returns:
+        SessionListResponse: Session list response
+
+    Note:
+        ``total`` and ``has_more`` are derived from the returned ``items`` list
+        because the upstream ``AsyncSessionClient.list_sessions`` does not return
+        a total count. ``has_more = len(items) == limit`` is a conservative hint,
+        not a precise indicator.
+    """
+    # Only app_type=bot can resolve bot_id from the API Key; other types must pass it explicitly
+    if bot_id:
+        resolved_bot_id = bot_id
+    elif api_key_record.app_type == "bot":
+        resolved_bot_id = resolve_bot_id_from_api_key(api_key_record)
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": OpenAPICode.BUSINESS_ERROR,
+                "message": "bot_id is a required parameter",
+            },
+        )
+
+    _check_app_type(api_key_record)
+    if api_key_record.app_type != "bot":
+        resolved_bot_id = validate_policy(api_key_record, resolved_bot_id)
+
+    logger.info(
+        f"list_sessions: bot_id={resolved_bot_id}, "
+        f"lifecycle_stage={lifecycle_stage}, limit={limit}, offset={offset}, "
+        f"user_id={user_id}, agent_id={agent_id}, "
+        f"api_key_prefix={api_key_record.api_key_prefix}"
+    )
+
+    try:
+        session_infos = await bot_runner.list_sessions(
+            bot_id=resolved_bot_id,
+            context=context,
+            metadata={
+                "bot_options": {"lifecycle_stage": lifecycle_stage},
+                "list_options": {
+                    "user_id": user_id,
+                    "agent_id": agent_id,
+                    "limit": limit,
+                    "offset": offset,
+                },
+            },
+        )
+
+        items = [
+            SessionListItem(
+                session_id=info.session_id,
+                bot_id=info.bot_id,
+                status=info.status,
+                created_at=info.created_at,
+                updated_at=info.updated_at,
+            )
+            for info in session_infos
+        ]
+        total = len(items)
+        has_more = len(items) == limit
+
+        logger.info(
+            f"list_sessions success: bot_id={resolved_bot_id}, "
+            f"total={total}, has_more={has_more}"
+        )
+
+        return SessionListResponse(
+            code=0,
+            message="success",
+            data=SessionListResponseData(
+                items=items,
+                total=total,
+                has_more=has_more,
+            ),
+        )
+
+    except SessionNotFoundError as e:
+        logger.warning(
+            f"list_sessions session not found: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": OpenAPICode.BUSINESS_ERROR,
+                "message": str(e),
+            },
+        )
+    except BotBindingNotFoundError as e:
+        logger.warning(
+            f"list_sessions binding not found: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": 60001, "message": str(e)},
+        )
+    except BotNotFoundError as e:
+        logger.warning(
+            f"list_sessions bot not found: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": 60001, "message": str(e)},
+        )
+    except BotServiceError as e:
+        logger.error(
+            f"list_sessions bot service error: bot_id={resolved_bot_id}, error={e}"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": OpenAPICode.BUSINESS_ERROR, "message": str(e)},
+        )
+    except Exception as e:
+        logger.error(
+            f"list_sessions unexpected error: bot_id={resolved_bot_id}, error={e}",
+            exc_info=True,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"code": 50001, "message": f"Internal server error: {str(e)}"},
         )
 
 

--- a/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
+++ b/src/baas/src/secbaas/community/api/bot_runtime/_protocols.py
@@ -404,6 +404,30 @@ class BotRunner(Protocol):
         """
         ...
 
+    async def list_sessions(
+        self,
+        *,
+        bot_id: str,
+        context: "BotChatContext",
+        metadata: dict[str, Any],
+    ) -> list["SessionInfo"]:
+        """查询指定 Bot 下的会话列表（只读）
+
+        复用 ``get_session_info`` 的 binding 解析与 BotService 链路，
+        调用上游 ``AsyncSessionClient.list_sessions``，不创建新会话。
+
+        Args:
+            bot_id: Bot 唯一标识，格式为 <real_bot_id>:<entity_id>
+            context: 请求上下文
+            metadata: 元数据，支持 ``bot_options.lifecycle_stage`` 指定生命周期阶段，
+                ``list_options`` 携带 ``user_id`` / ``agent_id`` / ``limit`` /
+                ``offset`` 透传给底层 ``AsyncSessionClient.list_sessions``
+
+        Returns:
+            SessionInfo 列表
+        """
+        ...
+
     def get_result(self, run_id: str) -> Any:
         """获取执行结果
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py
@@ -659,6 +659,84 @@ class BaasBotService(BotService):
                 f"Failed to get session: {_safe_client_msg(e)}"
             ) from e
 
+    async def list_sessions(
+        self,
+        *,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> list[SessionInfo]:
+        """查询绑定 Bot 下的会话列表（只读）
+
+        复用 ``get_session`` 的连接解析链路（``_resolve_ws_connection_for_binding``
+        + ``_create_session_client``），调用上游 ``AsyncSessionClient.list_sessions``。
+        ``metadata["list_options"]`` 携带 ``user_id`` / ``agent_id`` / ``limit`` /
+        ``offset`` 透传给底层；默认 ``limit=20``、``offset=0``。每个 adapter
+        ``SessionInfo`` 经 ``_map_adapter_session_info`` 映射为 api-level
+        ``SessionInfo``。
+
+        Args:
+            binding_info: 已解析的 binding 信息（用于创建底层连接）
+            context: 可选的请求上下文（用于提取 tenant）
+            metadata: 可选元数据，``list_options`` 子字典透传给底层
+
+        Returns:
+            SessionInfo 列表
+
+        Raises:
+            BotServiceError: 请求失败
+        """
+        try:
+            conn_info = await self._resolve_ws_connection_for_binding(
+                binding_info, context
+            )
+        except Exception as e:
+            logger.warning("Failed to resolve WS connection: %s", e)
+            raise BotServiceError(
+                f"Failed to resolve WS connection: {_safe_client_msg(e)}"
+            ) from e
+
+        session_client = self._create_session_client(
+            conn_info, binding_info.engine_type
+        )
+
+        list_options: dict[str, Any] = {}
+        if metadata:
+            raw_options = metadata.get("list_options")
+            if isinstance(raw_options, dict):
+                list_options = raw_options
+
+        user_id = list_options.get("user_id")
+        agent_id = list_options.get("agent_id")
+        limit = list_options.get("limit", 20)
+        offset = list_options.get("offset", 0)
+
+        try:
+            async with session_client:
+                adapter_sessions = await session_client.list_sessions(
+                    user_id=user_id,
+                    agent_id=agent_id,
+                    limit=limit,
+                    offset=offset,
+                    engine=binding_info.engine_type,
+                )
+                return [
+                    _map_adapter_session_info(item, binding_info.bot_id)
+                    for item in adapter_sessions
+                ]
+        except aiohttp.ClientResponseError as e:
+            logger.warning("Failed to list sessions: %s", e)
+            raise BotServiceError(
+                f"Failed to list sessions: {_safe_client_msg(e)}"
+            ) from e
+        except BotServiceError:
+            raise
+        except Exception as e:
+            logger.warning("Failed to list sessions: %s", e)
+            raise BotServiceError(
+                f"Failed to list sessions: {_safe_client_msg(e)}"
+            ) from e
+
     # ── 私有方法 ─────────────────────────────────────────────────────────────
 
     def _adapter_for(self, engine_type: str | None) -> BotEngineAdapter | None:

--- a/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
@@ -183,6 +183,34 @@ class BotService(Protocol):
         """
         ...
 
+    async def list_sessions(
+        self,
+        *,
+        binding_info: BotBindingInfo,
+        context: BotChatContext | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> list[SessionInfo]:
+        """查询绑定 Bot 下的会话列表（只读）
+
+        复用 ``get_session`` 的连接解析链路（``_resolve_ws_connection_for_binding``
+        + ``_create_session_client``）调用上游 ``AsyncSessionClient.list_sessions``，
+        不创建新会话。
+
+        Args:
+            binding_info: 已解析的 binding 信息（用于创建底层连接）
+            context: 可选的请求上下文（身份认证、调用者信息等，用于提取 tenant）
+            metadata: 可选元数据，``metadata["list_options"]`` 携带
+                ``user_id`` / ``agent_id`` / ``limit`` / ``offset`` 透传给
+                ``AsyncSessionClient.list_sessions``
+
+        Returns:
+            SessionInfo 列表
+
+        Raises:
+            BotServiceError: 请求失败
+        """
+        ...
+
 
 @runtime_checkable
 class MessageDispatcher(Protocol):

--- a/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_runner.py
@@ -440,6 +440,26 @@ class BotRunner:
             context=context,
         )
 
+    async def list_sessions(
+        self,
+        *,
+        bot_id: str,
+        context: BotChatContext,
+        metadata: dict[str, Any],
+    ) -> list[SessionInfo]:
+        """查询指定 Bot 下的会话列表（只读）
+
+        复用 ``get_session_info`` 的 binding 解析链路，委托 ``BotService.list_sessions``
+        调用上游 ``AsyncSessionClient.list_sessions``。``metadata["list_options"]``
+        携带 ``user_id`` / ``agent_id`` / ``limit`` / ``offset`` 透传给底层。
+        """
+        route = await self._resolve_bot_route(bot_id, metadata)
+        return await route.bot_service.list_sessions(
+            binding_info=route.binding_info,
+            context=context,
+            metadata=metadata,
+        )
+
     def get_result(self, run_id: str) -> Any:
         """获取执行结果
 

--- a/src/baas/tests/unit/adapters/web/open_api/test_session_router.py
+++ b/src/baas/tests/unit/adapters/web/open_api/test_session_router.py
@@ -19,6 +19,7 @@ from secbaas.community.adapters.web.routers.open_api.session_router import (
     _check_app_type,
     get_session,
     get_session_messages,
+    list_sessions,
 )
 from secbaas.community.api.api_gateway import APIKeyRecord
 from secbaas.community.api.bot_runtime import (
@@ -45,6 +46,8 @@ SESSION_ID = "sess-001"
 # FastAPI Query defaults are NOT applied on direct invocation.
 DEFAULT_LIFECYCLE_STAGE = "online"
 DEFAULT_LIMIT = 1000
+DEFAULT_LIST_LIMIT = 20
+DEFAULT_LIST_OFFSET = 0
 
 
 def _make_api_key_record(app_type="system", app_id="bot-1:entity-1", tenant="t1"):
@@ -925,6 +928,354 @@ class TestGetSessionMessages:
                     limit=DEFAULT_LIMIT,
                     bot_id=BOT_ID,
                     lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert exc.value.detail["code"] == 50001
+        assert "Internal server error" in exc.value.detail["message"]
+
+
+# ── list_sessions ─────────────────────────────────────────────
+
+
+class TestListSessions:
+    """list_sessions 端点核心逻辑测试。"""
+
+    @pytest.mark.asyncio
+    async def test_bot_app_type_resolves_from_api_key(self):
+        """app_type='bot' 不传 bot_id 时从 API Key 解析。"""
+        api_key = _make_api_key_record(app_type="bot", app_id="bot-1:entity-1")
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with (
+            patch(RESOLVE_PATH, return_value=BOT_ID) as mock_resolve,
+            patch(POLICY_PATH),
+        ):
+            await list_sessions(
+                bot_id=None,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                user_id=None,
+                agent_id=None,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_resolve.assert_called_once_with(api_key)
+
+    @pytest.mark.asyncio
+    async def test_system_app_type_without_bot_id_returns_400(self):
+        """app_type='system' 不传 bot_id 返回 400。"""
+        api_key = _make_api_key_record(app_type="system")
+        mock_runner = AsyncMock(spec=BotRunner)
+
+        with pytest.raises(HTTPException) as exc:
+            await list_sessions(
+                bot_id=None,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                user_id=None,
+                agent_id=None,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+        assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert exc.value.detail["code"] == OpenAPICode.BUSINESS_ERROR
+
+    @pytest.mark.asyncio
+    async def test_explicit_bot_id_used_directly(self):
+        """显式传入 bot_id 时直接使用。"""
+        api_key = _make_api_key_record(app_type="bot", app_id="bot-default:entity-1")
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            await list_sessions(
+                bot_id="bot-explicit:entity-1",
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                user_id=None,
+                agent_id=None,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        mock_runner.list_sessions.assert_called_once()
+        assert (
+            mock_runner.list_sessions.call_args[1]["bot_id"]
+            == "bot-explicit:entity-1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_bot_type_skips_validate_policy(self):
+        """app_type='bot' 时跳过 validate_policy。"""
+        api_key = _make_api_key_record(app_type="bot", app_id=BOT_ID)
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with (
+            patch(POLICY_PATH) as mock_policy,
+            patch(RESOLVE_PATH, return_value=BOT_ID),
+        ):
+            await list_sessions(
+                bot_id=None,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                user_id=None,
+                agent_id=None,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_policy.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_system_type_calls_validate_policy(self):
+        """app_type='system' 调用 validate_policy。"""
+        api_key = _make_api_key_record(app_type="system")
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID) as mock_policy:
+            await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                user_id=None,
+                agent_id=None,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+            mock_policy.assert_called_once_with(api_key, BOT_ID)
+
+    @pytest.mark.asyncio
+    async def test_success_returns_items_total_has_more(self):
+        """成功返回 items/total/has_more。"""
+        sessions = [
+            _make_session_info(session_id="sess-001"),
+            _make_session_info(session_id="sess-002"),
+        ]
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=sessions)
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                user_id=None,
+                agent_id=None,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.code == 0
+        assert result.message == "success"
+        assert len(result.data.items) == 2
+        assert result.data.total == 2
+        assert result.data.has_more is False
+        assert result.data.items[0].session_id == "sess-001"
+        assert result.data.items[1].session_id == "sess-002"
+
+    @pytest.mark.asyncio
+    async def test_success_has_more_when_full_page(self):
+        """返回满页 (len==limit) 时 has_more=True。"""
+        sessions = [
+            _make_session_info(session_id=f"sess-{i:03d}") for i in range(5)
+        ]
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=sessions)
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            result = await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=5,
+                offset=DEFAULT_LIST_OFFSET,
+                user_id=None,
+                agent_id=None,
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        assert result.data.total == 5
+        assert result.data.has_more is True
+
+    @pytest.mark.asyncio
+    async def test_limit_offset_passthrough_to_metadata(self):
+        """limit/offset/user_id/agent_id 透传至 metadata.list_options。"""
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(return_value=[])
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage="verify",
+                limit=15,
+                offset=30,
+                user_id="u-1",
+                agent_id="a-1",
+                api_key_record=_make_api_key_record(),
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+
+        mock_runner.list_sessions.assert_called_once_with(
+            bot_id=BOT_ID,
+            context=_make_context(),
+            metadata={
+                "bot_options": {"lifecycle_stage": "verify"},
+                "list_options": {
+                    "user_id": "u-1",
+                    "agent_id": "a-1",
+                    "limit": 15,
+                    "offset": 30,
+                },
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_allowed_app_type_returns_403(self):
+        """app_type 不在 ('system','app','bot') -> 403。"""
+        api_key = _make_api_key_record(app_type="user")
+        mock_runner = AsyncMock(spec=BotRunner)
+
+        with pytest.raises(HTTPException) as exc:
+            await list_sessions(
+                bot_id=BOT_ID,
+                lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                limit=DEFAULT_LIST_LIMIT,
+                offset=DEFAULT_LIST_OFFSET,
+                user_id=None,
+                agent_id=None,
+                api_key_record=api_key,
+                context=_make_context(),
+                bot_runner=mock_runner,
+            )
+        assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.asyncio
+    async def test_session_not_found_returns_404(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=SessionNotFoundError(SESSION_ID),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    limit=DEFAULT_LIST_LIMIT,
+                    offset=DEFAULT_LIST_OFFSET,
+                    user_id=None,
+                    agent_id=None,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+        assert exc.value.detail["code"] == OpenAPICode.BUSINESS_ERROR
+
+    @pytest.mark.asyncio
+    async def test_bot_binding_not_found_returns_404(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotBindingNotFoundError(BOT_ID),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    limit=DEFAULT_LIST_LIMIT,
+                    offset=DEFAULT_LIST_OFFSET,
+                    user_id=None,
+                    agent_id=None,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+        assert exc.value.detail["code"] == 60001
+
+    @pytest.mark.asyncio
+    async def test_bot_not_found_returns_404(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotNotFoundError("bot-1"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    limit=DEFAULT_LIST_LIMIT,
+                    offset=DEFAULT_LIST_OFFSET,
+                    user_id=None,
+                    agent_id=None,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+        assert exc.value.detail["code"] == 60001
+
+    @pytest.mark.asyncio
+    async def test_bot_service_error_returns_400(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=BotServiceError("service unavailable"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    limit=DEFAULT_LIST_LIMIT,
+                    offset=DEFAULT_LIST_OFFSET,
+                    user_id=None,
+                    agent_id=None,
+                    api_key_record=_make_api_key_record(),
+                    context=_make_context(),
+                    bot_runner=mock_runner,
+                )
+        assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert exc.value.detail["code"] == OpenAPICode.BUSINESS_ERROR
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_returns_500(self):
+        mock_runner = AsyncMock(spec=BotRunner)
+        mock_runner.list_sessions = AsyncMock(
+            side_effect=RuntimeError("unexpected failure"),
+        )
+
+        with patch(POLICY_PATH, return_value=BOT_ID):
+            with pytest.raises(HTTPException) as exc:
+                await list_sessions(
+                    bot_id=BOT_ID,
+                    lifecycle_stage=DEFAULT_LIFECYCLE_STAGE,
+                    limit=DEFAULT_LIST_LIMIT,
+                    offset=DEFAULT_LIST_OFFSET,
+                    user_id=None,
+                    agent_id=None,
                     api_key_record=_make_api_key_record(),
                     context=_make_context(),
                     bot_runner=mock_runner,

--- a/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_baas_service.py
@@ -2154,6 +2154,213 @@ class TestSendMessageWaitResult:
             assert call_kwargs["wait_result"] is False
 
 
+# ==================== TestListSessions ====================
+
+
+class TestListSessions:
+    """list_sessions tests.
+
+    Covers connection resolution passthrough, AsyncSessionClient.list_sessions
+    argument forwarding, _map_adapter_session_info mapping and error wrapping.
+    """
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_success_maps_adapter_sessions(
+        self, service, wss_resolver
+    ):
+        """list_sessions maps each adapter SessionInfo via _map_adapter_session_info."""
+        from secbaas.community.core.service.bot_run._async_session_client import (
+            SessionInfo as AdapterSessionInfo,
+        )
+
+        adapter_sessions = [
+            AdapterSessionInfo(
+                id="sess-001",
+                title="t1",
+                user_id="u1",
+                agent_id=BOT_UUID,
+                created_at="2025-01-01T00:00:00Z",
+                updated_at="2025-01-02T00:00:00Z",
+            ),
+            AdapterSessionInfo(id="sess-002", title="t2"),
+        ]
+
+        session_client = AsyncMock()
+        session_client.list_sessions.return_value = adapter_sessions
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+
+        binding = _make_binding_info()
+
+        with (
+            patch.object(
+                service,
+                "_resolve_ws_connection_for_binding",
+                return_value=_make_conn_info(),
+            ),
+            patch.object(
+                service, "_create_session_client", return_value=session_client
+            ),
+        ):
+            result = await service.list_sessions(binding_info=binding)
+
+        assert len(result) == 2
+        assert result[0].session_id == "sess-001"
+        assert result[0].bot_id == BOT_UUID
+        assert result[0].status == "active"
+        assert result[1].session_id == "sess-002"
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_forwards_list_options(self, service, wss_resolver):
+        """list_options (user_id/agent_id/limit/offset/engine) are forwarded."""
+        session_client = AsyncMock()
+        session_client.list_sessions.return_value = []
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+
+        binding = _make_binding_info(engine_type="openclaw")
+
+        with (
+            patch.object(
+                service,
+                "_resolve_ws_connection_for_binding",
+                return_value=_make_conn_info(),
+            ),
+            patch.object(
+                service, "_create_session_client", return_value=session_client
+            ),
+        ):
+            await service.list_sessions(
+                binding_info=binding,
+                metadata={
+                    "list_options": {
+                        "user_id": "u-1",
+                        "agent_id": "a-1",
+                        "limit": 7,
+                        "offset": 9,
+                    }
+                },
+            )
+
+        session_client.list_sessions.assert_called_once_with(
+            user_id="u-1",
+            agent_id="a-1",
+            limit=7,
+            offset=9,
+            engine="openclaw",
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_defaults_when_no_list_options(
+        self, service, wss_resolver
+    ):
+        """Without list_options, defaults limit=20 offset=0 are forwarded."""
+        session_client = AsyncMock()
+        session_client.list_sessions.return_value = []
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+
+        binding = _make_binding_info(engine_type="openclaw")
+
+        with (
+            patch.object(
+                service,
+                "_resolve_ws_connection_for_binding",
+                return_value=_make_conn_info(),
+            ),
+            patch.object(
+                service, "_create_session_client", return_value=session_client
+            ),
+        ):
+            await service.list_sessions(binding_info=binding)
+
+        session_client.list_sessions.assert_called_once_with(
+            user_id=None,
+            agent_id=None,
+            limit=20,
+            offset=0,
+            engine="openclaw",
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_ws_connection_failure_wraps_bot_service_error(
+        self, service, wss_resolver
+    ):
+        """WS resolution failure is wrapped as BotServiceError."""
+        binding = _make_binding_info()
+
+        with patch.object(
+            service,
+            "_resolve_ws_connection_for_binding",
+            side_effect=RuntimeError("conn down"),
+        ):
+            with pytest.raises(BotServiceError) as exc:
+                await service.list_sessions(binding_info=binding)
+
+        assert "Failed to resolve WS connection" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_client_response_error_wraps_bot_service_error(
+        self, service, wss_resolver
+    ):
+        """aiohttp.ClientResponseError from list_sessions is wrapped as BotServiceError."""
+        import aiohttp
+
+        session_client = AsyncMock()
+        session_client.list_sessions.side_effect = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=500,
+            message="upstream error",
+        )
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+
+        binding = _make_binding_info()
+
+        with (
+            patch.object(
+                service,
+                "_resolve_ws_connection_for_binding",
+                return_value=_make_conn_info(),
+            ),
+            patch.object(
+                service, "_create_session_client", return_value=session_client
+            ),
+        ):
+            with pytest.raises(BotServiceError) as exc:
+                await service.list_sessions(binding_info=binding)
+
+        assert "Failed to list sessions" in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_generic_error_wraps_bot_service_error(
+        self, service, wss_resolver
+    ):
+        """Generic exceptions are wrapped as BotServiceError."""
+        session_client = AsyncMock()
+        session_client.list_sessions.side_effect = RuntimeError("boom")
+        session_client.__aenter__ = AsyncMock(return_value=session_client)
+        session_client.__aexit__ = AsyncMock(return_value=False)
+
+        binding = _make_binding_info()
+
+        with (
+            patch.object(
+                service,
+                "_resolve_ws_connection_for_binding",
+                return_value=_make_conn_info(),
+            ),
+            patch.object(
+                service, "_create_session_client", return_value=session_client
+            ),
+        ):
+            with pytest.raises(BotServiceError) as exc:
+                await service.list_sessions(binding_info=binding)
+
+        assert "Failed to list sessions" in str(exc.value)
+
+
 # ==================== ANY matcher for mock assertions ====================
 
 


### PR DESCRIPTION
# Summary

Adds a `GET /openapi/v1/sessions` list endpoint to the BaaS OpenAPI adapter, allowing callers authenticated with a Bearer-token API key to list sessions for a bot with pagination and optional upstream filters (user_id, agent_id, lifecycle_stage).

The change is isolated to the `baas` module; the engine is unchanged.

## Scope

Planned files (8):
- `src/baas/src/secbaas/community/adapters/web/routers/open_api/session_router.py` — new `list_sessions` route
- `src/baas/src/secbaas/community/adapters/web/routers/open_api/model.py` — `SessionListItem`, `SessionListResponse`, `SessionListResponseData` models
- `src/baas/src/secbaas/community/api/bot_runtime/_protocols.py` — `list_sessions` protocol method
- `src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py` — internal session-client list contract
- `src/baas/src/secbaas/community/core/service/bot_run/_baas_service.py` — `BaasBotService.list_sessions` delegation
- `src/baas/src/secbaas/community/core/service/bot_run/_runner.py` — runner wiring
- `src/baas/tests/unit/adapters/web/open_api/test_session_router.py` — router unit tests
- `src/baas/tests/unit/core/service/bot_run/test_baas_service.py` — service unit tests

## Behavior

- `bot_id` resolution: resolved from the API key for `app_type=bot`; required explicitly for other app types.
- Filters `lifecycle_stage` (online/verify/draft/all), `limit` (1-100, default 20), `offset` (>=0), `user_id`, `agent_id` are forwarded to the upstream `AsyncSessionClient.list_sessions`.
- `total` and `has_more` are derived from the returned `items`: `has_more = len(items) == limit` (conservative hint, since the upstream list API returns no count).
- Error mapping follows the existing `get_session` convention (400/401/403/404/500).

## Testing

- `uv sync --frozen`
- `python -m pytest tests/unit/adapters/web/open_api/test_session_router.py tests/unit/core/service/bot_run/test_baas_service.py -q` — 152 passed, 0 failed.
- `python -m ruff check <changed files>` — clean.

## Privacy

Public-diff privacy scan completed. No introduced markers; the one preexisting internal-marker is baseline content in a test file, unrelated to this change.

## Review

Code review completed with 0 blocking findings. Two P3 observations (dead-defensive `SessionNotFoundError` branch on the list path; internal-error echo in the generic 500 handler matching existing `get_session` parity) noted as optional, no change required.