### PR TITLE
fix(skillset): batch active-set skill projection

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skill_sets/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skill_sets/router.py
@@ -281,14 +281,16 @@ async def remove_skill(
         SkillSetManagementServiceProtocol
     ),
 ) -> Envelope[SkillSetMembershipResult]:
-    result = await service.remove_skill(
+    (result,) = await service.remove_skills(
         bot_id=bot_id,
         owner_id=owner_id,
         user_id=user_id,
         set_id=set_id,
-        skill_id=skill_id,
+        skill_ids=[skill_id],
     )
-    return envelope(SkillSetMembershipResult(**result), request)
+    if result.error is not None:
+        raise result.error
+    return envelope(SkillSetMembershipResult(changed=result.changed), request)
 
 
 @router.get("/{set_id}/mcps", response_model=Envelope[list[SkillSetMcpItem]])

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skill_sets/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skill_sets/router.py
@@ -57,6 +57,7 @@ McpServerCodePath = Annotated[
     Path(description="Opaque MCP server identifier."),
 ]
 
+
 def _set(item: dict[str, Any]) -> SkillSetItem:
     return SkillSetItem(
         id=str(item["id"]),
@@ -252,14 +253,16 @@ async def add_skill(
         SkillSetManagementServiceProtocol
     ),
 ) -> Envelope[SkillSetMembershipResult]:
-    result = await service.add_skill(
+    (result,) = await service.add_skills(
         bot_id=bot_id,
         owner_id=owner_id,
         user_id=user_id,
         set_id=set_id,
-        skill_id=skill_id,
+        skill_ids=[skill_id],
     )
-    return envelope(SkillSetMembershipResult(**result), request)
+    if result.error is not None:
+        raise result.error
+    return envelope(SkillSetMembershipResult(changed=result.changed), request)
 
 
 @router.delete(

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
@@ -889,14 +889,16 @@ async def remove_skill_from_set(
         control_plane=control_plane,
     )
 
-    result = await control_plane.remove_skill(
+    (result,) = await control_plane.remove_skills(
         bot_id=effective_bot_id,
         owner_id=effective_entity_id,
         user_id=_legacy_actor(ctx, user_id or entity_id),
         set_id=skill_set_id,
-        skill_id=skill_id,
+        skill_ids=[skill_id],
     )
-    if not result.get("changed"):
+    if result.error is not None:
+        raise result.error
+    if not result.changed:
         raise SkillSetControlPlaneNotFoundError("Skill not found in skill set")
     return MessageResponse(success=True, message="Skill removed from skill set")
 

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
@@ -189,7 +189,14 @@ def _get_path_params(
             e,
         )
 
-    return effective_entity_id, effective_bot_id, effective_engine, runtime_engine, effective_entity_type, is_desktop
+    return (
+        effective_entity_id,
+        effective_bot_id,
+        effective_engine,
+        runtime_engine,
+        effective_entity_type,
+        is_desktop,
+    )
 
 
 def _get_skill_set_path_params(
@@ -752,8 +759,9 @@ async def add_skills_to_set(
         control_plane=control_plane,
     )
 
-    # Historical batch wire permits partial success.  Each member remains
-    # an atomic control-plane command; the adapter only serializes results.
+    # Historical batch wire permits partial success.  Resolve its loose
+    # identifiers here, then pass every durable ID through one control-plane
+    # batch so an active Set gets one final runtime projection.
     results: dict[str, list] = {
         "success": [],
         "failed": [],
@@ -771,6 +779,7 @@ async def add_skills_to_set(
     )
     if target_set.get("is_default"):
         raise SkillSetControlPlaneConflictError("SYSTEM_DEFAULT_IMMUTABLE")
+    resolved: list[tuple[str, str]] = []
     for skill_id in request.skill_ids:
         try:
             stable_skill_id = control_plane.resolve_legacy_skill_id(
@@ -779,16 +788,7 @@ async def add_skills_to_set(
                 actor_id=actor_id,
                 identifier=skill_id,
             )
-            await control_plane.add_skill(
-                bot_id=effective_bot_id,
-                owner_id=effective_entity_id,
-                user_id=actor_id,
-                set_id=skill_set_id,
-                skill_id=stable_skill_id,
-            )
-            results["success"].append(
-                {"skill_id": str(stable_skill_id), "name": str(skill_id)}
-            )
+            resolved.append((str(skill_id), stable_skill_id))
         except (
             LocalSkillNotFoundError,
             SkillSetControlPlaneNotFoundError,
@@ -801,6 +801,40 @@ async def add_skills_to_set(
             }:
                 raise
             results["failed"].append({"skill_id": skill_id, "error": str(exc)})
+    if resolved:
+        outcomes = await control_plane.add_skills(
+            bot_id=effective_bot_id,
+            owner_id=effective_entity_id,
+            user_id=actor_id,
+            set_id=skill_set_id,
+            skill_ids=[stable_skill_id for _, stable_skill_id in resolved],
+        )
+        for (legacy_skill_id, stable_skill_id), outcome in zip(resolved, outcomes):
+            if outcome.succeeded:
+                results["success"].append(
+                    {"skill_id": stable_skill_id, "name": legacy_skill_id}
+                )
+                continue
+            assert outcome.error is not None
+            if isinstance(
+                outcome.error,
+                (LocalSkillNotFoundError, SkillSetControlPlaneNotFoundError),
+            ):
+                results["failed"].append(
+                    {"skill_id": legacy_skill_id, "error": str(outcome.error)}
+                )
+                continue
+            if isinstance(outcome.error, SkillSetControlPlaneConflictError) and str(
+                outcome.error
+            ) in {
+                "RESOURCE_DIRECT_ACTIVE",
+                "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET",
+            }:
+                results["failed"].append(
+                    {"skill_id": legacy_skill_id, "error": str(outcome.error)}
+                )
+                continue
+            raise outcome.error
     success_count = len(results["success"])
     failed_count = len(results["failed"])
     return AddSkillsResponse(

--- a/src/backend/src/agentclaw/community/api/skill_set_management_service.py
+++ b/src/backend/src/agentclaw/community/api/skill_set_management_service.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any, Protocol, runtime_checkable
 
 from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import (
     LegacySkillSetScope,
+)
+from agentclaw.community.core.skill_center.skill_set_batch import (
+    SkillSetAddOutcome,
 )
 
 
@@ -62,15 +66,15 @@ class SkillSetManagementServiceProtocol(Protocol):
         self, *, bot_id: str, owner_id: str, user_id: str, set_id: str
     ) -> list[dict[str, Any]]: ...
 
-    async def add_skill(
+    async def add_skills(
         self,
         *,
         bot_id: str,
         owner_id: str,
         user_id: str,
         set_id: str,
-        skill_id: str,
-    ) -> dict[str, Any]: ...
+        skill_ids: Sequence[str],
+    ) -> list[SkillSetAddOutcome]: ...
 
     async def remove_skill(
         self,

--- a/src/backend/src/agentclaw/community/api/skill_set_management_service.py
+++ b/src/backend/src/agentclaw/community/api/skill_set_management_service.py
@@ -9,7 +9,7 @@ from agentclaw.community.core.skill_center.legacy_skill_set_compatibility import
     LegacySkillSetScope,
 )
 from agentclaw.community.core.skill_center.skill_set_batch import (
-    SkillSetAddOutcome,
+    SkillSetSkillOutcome,
 )
 
 
@@ -74,17 +74,17 @@ class SkillSetManagementServiceProtocol(Protocol):
         user_id: str,
         set_id: str,
         skill_ids: Sequence[str],
-    ) -> list[SkillSetAddOutcome]: ...
+    ) -> list[SkillSetSkillOutcome]: ...
 
-    async def remove_skill(
+    async def remove_skills(
         self,
         *,
         bot_id: str,
         owner_id: str,
         user_id: str,
         set_id: str,
-        skill_id: str,
-    ) -> dict[str, Any]: ...
+        skill_ids: Sequence[str],
+    ) -> list[SkillSetSkillOutcome]: ...
 
     def list_mcps(
         self, *, bot_id: str, owner_id: str, user_id: str, set_id: str

--- a/src/backend/src/agentclaw/community/core/skill_center/services/_mutation_flow.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/_mutation_flow.py
@@ -110,6 +110,7 @@ class MutationProjectionFlow:
         scope_from_result: (
             Callable[[DesiredStateMutation], ProjectionScope] | None
         ) = None,
+        skip_projection_when_unchanged: bool = False,
     ) -> dict:
         """Run the command; return ``{**item, "changed": ..., **details}``.
 
@@ -133,9 +134,7 @@ class MutationProjectionFlow:
         installed.
         """
         if (scope is None) == (scope_from_result is None):
-            raise ValueError(
-                "exactly one of scope / scope_from_result is required"
-            )
+            raise ValueError("exactly one of scope / scope_from_result is required")
         if not runtime_required:
             result = mutation()
             return {**result.item, "changed": result.changed, **result.details}
@@ -147,6 +146,8 @@ class MutationProjectionFlow:
             owner_id=owner_id,
         )
         result = mutation()
+        if skip_projection_when_unchanged and not result.changed:
+            return {**result.item, "changed": False, **result.details}
         effective_scope = (
             scope_from_result(result) if scope_from_result is not None else scope
         )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 from injector import inject
@@ -47,6 +47,9 @@ from agentclaw.community.core.skill_center.services._mutation_flow import (
     mcp_release_scope,
     skill_claim_scope,
     skill_release_scope,
+)
+from agentclaw.community.core.skill_center.skill_set_batch import (
+    SkillSetAddOutcome,
 )
 from agentclaw.community.core.workspace.skill_layout import (
     runtime_layout_engine_for_bot,
@@ -174,7 +177,9 @@ class SkillSetManagementService:
     def get_set(self, *, bot_id: str, owner_id: str, user_id: str, set_id: str) -> dict:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
         return self._repository.get_set(
-            bot_id=bot_id, owner_id=str(bot["owner_id"]), set_id=set_id,
+            bot_id=bot_id,
+            owner_id=str(bot["owner_id"]),
+            set_id=set_id,
             engine_type=self._engine(bot),
             default_engine_types=self._default_engine_types(bot),
         )
@@ -235,7 +240,9 @@ class SkillSetManagementService:
     ) -> None:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
         self._repository.delete_set(
-            bot_id=bot_id, owner_id=str(bot["owner_id"]), set_id=set_id,
+            bot_id=bot_id,
+            owner_id=str(bot["owner_id"]),
+            set_id=set_id,
             engine_type=self._engine(bot),
             default_engine_types=self._default_engine_types(bot),
         )
@@ -251,7 +258,9 @@ class SkillSetManagementService:
     ) -> list[dict]:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
         return self._repository.list_skills(
-            bot_id=bot_id, owner_id=str(bot["owner_id"]), set_id=set_id,
+            bot_id=bot_id,
+            owner_id=str(bot["owner_id"]),
+            set_id=set_id,
             engine_type=self._engine(bot),
             default_engine_types=self._default_engine_types(bot),
         )
@@ -269,9 +278,7 @@ class SkillSetManagementService:
         requests never call this method and therefore never create assets from
         a name/path.
         """
-        bot = self._legacy_bot(
-            bot_id=bot_id, owner_id=owner_id, actor_id=actor_id
-        )
+        bot = self._legacy_bot(bot_id=bot_id, owner_id=owner_id, actor_id=actor_id)
         try:
             return self._repository.resolve_legacy_skill_id(
                 bot_id=bot_id, identifier=identifier
@@ -293,61 +300,128 @@ class SkillSetManagementService:
         except ValueError as exc:
             raise SkillSetControlPlaneNotFoundError() from exc
 
-    async def add_skill(
+    async def add_skills(
         self,
         *,
         bot_id: str,
         owner_id: str,
         user_id: str,
         set_id: str,
-        skill_id: str,
-    ) -> dict:
-        # Scope comes from the mutation result, not from up here: a Skill can
-        # carry ``mcp_dependencies``, and those codes join the Bot's MCP set
-        # along with the Skill. The repository reads them under the row lock it
-        # already holds, so the scope names what was actually installed rather
-        # than what a second, unlocked query happened to see.
+        skill_ids: Sequence[str],
+    ) -> list[SkillSetAddOutcome]:
+        """Add one or more members, then project their final combined state.
+
+        The BFF's published body has always accepted ``skill_ids`` and permits
+        per-member conflicts to be reported as partial success.  The canonical
+        Gateway single-member route is the batch-of-one consumer.  One command
+        owns the batch so an active Set has exactly one runtime projection,
+        never one complete Artifact delivery per member.
+        """
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
         target = self._target_set(bot=bot, bot_id=bot_id, set_id=set_id)
-        if target["is_default"]:
-            # Adding to the Default Set is the restored opt-out's other half:
-            # it can only remove an existing exclusion. The membership itself
-            # stays immutable.
-            self._require_excluded_default_skill(
-                owner_id=str(bot["owner_id"]), bot_id=bot_id,
-                set_id=str(target["id"]), skill_id=skill_id,
-            )
-            return await self._mutate(
-                bot=bot,
-                bot_id=bot_id,
-                actor_id=user_id,
-                action="default_set_unexclude_skill",
-                scope_from_result=skill_claim_scope,
-                mutation=lambda: self._repository.unexclude_default_skill(
-                    bot_id=bot_id,
-                    owner_id=str(bot["owner_id"]),
-                    set_id=set_id,
-                    skill_id=skill_id,
-                    engine_type=self._engine(bot),
-                    default_engine_types=self._default_engine_types(bot),
+        if not skill_ids:
+            return []
+
+        outcomes: list[SkillSetAddOutcome] = []
+        previous_state = None
+        claimed_mcp_codes: set[str] = set()
+
+        def mutation() -> DesiredStateMutation:
+            nonlocal previous_state
+            try:
+                for skill_id in skill_ids:
+                    try:
+                        if target["is_default"]:
+                            # Default membership remains immutable.  Its only add
+                            # semantic is restoring an individually excluded
+                            # member, which batch-of-one Gateway calls already
+                            # exposed before this refactor.
+                            self._require_excluded_default_skill(
+                                owner_id=str(bot["owner_id"]),
+                                bot_id=bot_id,
+                                set_id=str(target["id"]),
+                                skill_id=skill_id,
+                            )
+                            result = self._repository.unexclude_default_skill(
+                                bot_id=bot_id,
+                                owner_id=str(bot["owner_id"]),
+                                set_id=set_id,
+                                skill_id=skill_id,
+                                engine_type=self._engine(bot),
+                                default_engine_types=self._default_engine_types(bot),
+                            )
+                        else:
+                            result = self._repository.add_skill(
+                                bot_id=bot_id,
+                                owner_id=str(bot["owner_id"]),
+                                set_id=set_id,
+                                skill_id=skill_id,
+                                engine_type=self._engine(bot),
+                                default_engine_types=self._default_engine_types(bot),
+                            )
+                    except SkillSetControlPlaneNotFoundError as error:
+                        outcomes.append(
+                            SkillSetAddOutcome(skill_id=skill_id, error=error)
+                        )
+                        continue
+                    except SkillSetControlPlaneConflictError as error:
+                        if str(error) not in {
+                            "RESOURCE_DIRECT_ACTIVE",
+                            "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET",
+                        }:
+                            raise
+                        outcomes.append(
+                            SkillSetAddOutcome(skill_id=skill_id, error=error)
+                        )
+                        continue
+
+                    if previous_state is None:
+                        previous_state = result.previous_state
+                    if result.changed:
+                        claimed_mcp_codes.update(result.mcp_codes)
+                    outcomes.append(
+                        SkillSetAddOutcome(skill_id=skill_id, changed=result.changed)
+                    )
+            except Exception:
+                # Individual repository writes commit desired state before the
+                # batch reaches its single projection.  A later infrastructure
+                # failure is therefore still pre-projection, but must restore
+                # every earlier successful member before surfacing the error.
+                if previous_state is not None:
+                    self._repository.restore_desired_state(
+                        bot_id=bot_id,
+                        owner_id=str(bot["owner_id"]),
+                        state=previous_state,
+                        engine_type=self._engine(bot),
+                    )
+                raise
+
+            return DesiredStateMutation(
+                item=target,
+                changed=any(outcome.changed for outcome in outcomes),
+                previous_state=(
+                    previous_state
+                    if previous_state is not None
+                    else self._repository.snapshot_desired_state(
+                        bot_id=bot_id,
+                        owner_id=str(bot["owner_id"]),
+                        engine_type=self._engine(bot),
+                    )
                 ),
+                mcp_codes=frozenset(claimed_mcp_codes),
             )
-        return await self._mutate(
+
+        await self._mutate(
             bot=bot,
             bot_id=bot_id,
             actor_id=user_id,
             action="skill_set_add_skill",
-            runtime_required=bool(target.get("is_active")),
+            runtime_required=bool(target.get("is_active") or target["is_default"]),
             scope_from_result=skill_claim_scope,
-            mutation=lambda: self._repository.add_skill(
-                bot_id=bot_id,
-                owner_id=str(bot["owner_id"]),
-                set_id=set_id,
-                skill_id=skill_id,
-                engine_type=self._engine(bot),
-                default_engine_types=self._default_engine_types(bot),
-            ),
+            mutation=mutation,
+            skip_projection_when_unchanged=True,
         )
+        return outcomes
 
     async def remove_skill(
         self,
@@ -401,7 +475,9 @@ class SkillSetManagementService:
     ) -> list[dict]:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
         return self._repository.list_mcps(
-            bot_id=bot_id, owner_id=str(bot["owner_id"]), set_id=set_id,
+            bot_id=bot_id,
+            owner_id=str(bot["owner_id"]),
+            set_id=set_id,
             engine_type=self._engine(bot),
             default_engine_types=self._default_engine_types(bot),
         )
@@ -470,7 +546,8 @@ class SkillSetManagementService:
             # The MCP twin of add_skill's opt-out half: only an existing
             # exclusion can be removed; the membership stays immutable.
             codes = self._repository.excluded_default_mcp_codes(
-                bot_id=bot_id, owner_id=str(bot["owner_id"]),
+                bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
                 set_id=str(target["id"]),
             )
             if server_code not in codes:
@@ -563,7 +640,9 @@ class SkillSetManagementService:
     ) -> dict:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
         target = self._repository.get_set(
-            bot_id=bot_id, owner_id=str(bot["owner_id"]), set_id=set_id,
+            bot_id=bot_id,
+            owner_id=str(bot["owner_id"]),
+            set_id=set_id,
             engine_type=self._engine(bot),
             default_engine_types=self._default_engine_types(bot),
         )
@@ -616,9 +695,7 @@ class SkillSetManagementService:
         self, *, bot_id: str, owner_id: str, actor_id: str, set_id: str
     ) -> dict:
         """Compatibility command that adds this Set without disabling peers."""
-        bot = self._legacy_bot(
-            bot_id=bot_id, owner_id=owner_id, actor_id=actor_id
-        )
+        bot = self._legacy_bot(bot_id=bot_id, owner_id=owner_id, actor_id=actor_id)
         return await self._mutate(
             bot=bot,
             bot_id=bot_id,
@@ -705,7 +782,9 @@ class SkillSetManagementService:
         mutation,
         runtime_required: bool = True,
         scope: ProjectionScope | None = None,
-        scope_from_result: Callable[[DesiredStateMutation], ProjectionScope] | None = None,
+        scope_from_result: Callable[[DesiredStateMutation], ProjectionScope]
+        | None = None,
+        skip_projection_when_unchanged: bool = False,
     ) -> dict:
         """Apply one desired-state mutation and synchronously reconcile runtime.
 
@@ -727,6 +806,7 @@ class SkillSetManagementService:
             runtime_required=runtime_required,
             scope=scope,
             scope_from_result=scope_from_result,
+            skip_projection_when_unchanged=skip_projection_when_unchanged,
         )
         self._audit(
             bot_id=bot_id,
@@ -785,7 +865,9 @@ class SkillSetManagementService:
         self, *, bot_id: str, actor_id: str, set_id: str, bot: dict
     ) -> None:
         for mcp in self._repository.list_mcps(
-            bot_id=bot_id, owner_id=str(bot["owner_id"]), set_id=set_id,
+            bot_id=bot_id,
+            owner_id=str(bot["owner_id"]),
+            set_id=set_id,
             engine_type=self._engine(bot),
             default_engine_types=self._default_engine_types(bot),
         ):

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_management_service.py
@@ -49,7 +49,7 @@ from agentclaw.community.core.skill_center.services._mutation_flow import (
     skill_release_scope,
 )
 from agentclaw.community.core.skill_center.skill_set_batch import (
-    SkillSetAddOutcome,
+    SkillSetSkillOutcome,
 )
 from agentclaw.community.core.workspace.skill_layout import (
     runtime_layout_engine_for_bot,
@@ -308,7 +308,7 @@ class SkillSetManagementService:
         user_id: str,
         set_id: str,
         skill_ids: Sequence[str],
-    ) -> list[SkillSetAddOutcome]:
+    ) -> list[SkillSetSkillOutcome]:
         """Add one or more members, then project their final combined state.
 
         The BFF's published body has always accepted ``skill_ids`` and permits
@@ -322,65 +322,171 @@ class SkillSetManagementService:
         if not skill_ids:
             return []
 
-        outcomes: list[SkillSetAddOutcome] = []
+        return await self._mutate_skills_batch(
+            bot=bot,
+            bot_id=bot_id,
+            actor_id=user_id,
+            target=target,
+            skill_ids=skill_ids,
+            action="skill_set_add_skill",
+            runtime_required=bool(target.get("is_active") or target["is_default"]),
+            scope_from_result=skill_claim_scope,
+            partial_conflict_codes=frozenset(
+                {
+                    "RESOURCE_DIRECT_ACTIVE",
+                    "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET",
+                }
+            ),
+            mutation_for_skill=lambda skill_id: self._add_skill_membership(
+                bot=bot,
+                bot_id=bot_id,
+                target=target,
+                set_id=set_id,
+                skill_id=skill_id,
+            ),
+        )
+
+    async def remove_skills(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        user_id: str,
+        set_id: str,
+        skill_ids: Sequence[str],
+    ) -> list[SkillSetSkillOutcome]:
+        """Remove one or more members, then project their final combined state."""
+        bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
+        target = self._target_set(bot=bot, bot_id=bot_id, set_id=set_id)
+        return await self._mutate_skills_batch(
+            bot=bot,
+            bot_id=bot_id,
+            actor_id=user_id,
+            target=target,
+            skill_ids=skill_ids,
+            action=(
+                "default_set_exclude_skill"
+                if target["is_default"]
+                else "skill_set_remove_skill"
+            ),
+            runtime_required=bool(target.get("is_active") or target["is_default"]),
+            scope_from_result=skill_release_scope,
+            partial_conflict_codes=frozenset(),
+            mutation_for_skill=lambda skill_id: self._remove_skill_membership(
+                bot=bot,
+                bot_id=bot_id,
+                target=target,
+                set_id=set_id,
+                skill_id=skill_id,
+            ),
+        )
+
+    def _add_skill_membership(
+        self,
+        *,
+        bot: dict,
+        bot_id: str,
+        target: dict,
+        set_id: str,
+        skill_id: str,
+    ) -> DesiredStateMutation:
+        if target["is_default"]:
+            self._require_excluded_default_skill(
+                owner_id=str(bot["owner_id"]),
+                bot_id=bot_id,
+                set_id=str(target["id"]),
+                skill_id=skill_id,
+            )
+            return self._repository.unexclude_default_skill(
+                bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
+                set_id=set_id,
+                skill_id=skill_id,
+                engine_type=self._engine(bot),
+                default_engine_types=self._default_engine_types(bot),
+            )
+        return self._repository.add_skill(
+            bot_id=bot_id,
+            owner_id=str(bot["owner_id"]),
+            set_id=set_id,
+            skill_id=skill_id,
+            engine_type=self._engine(bot),
+            default_engine_types=self._default_engine_types(bot),
+        )
+
+    def _remove_skill_membership(
+        self,
+        *,
+        bot: dict,
+        bot_id: str,
+        target: dict,
+        set_id: str,
+        skill_id: str,
+    ) -> DesiredStateMutation:
+        if target["is_default"]:
+            return self._repository.exclude_default_skill(
+                bot_id=bot_id,
+                owner_id=str(bot["owner_id"]),
+                set_id=set_id,
+                skill_id=skill_id,
+                engine_type=self._engine(bot),
+                default_engine_types=self._default_engine_types(bot),
+            )
+        return self._repository.remove_skill(
+            bot_id=bot_id,
+            owner_id=str(bot["owner_id"]),
+            set_id=set_id,
+            skill_id=skill_id,
+            engine_type=self._engine(bot),
+            default_engine_types=self._default_engine_types(bot),
+        )
+
+    async def _mutate_skills_batch(
+        self,
+        *,
+        bot: dict,
+        bot_id: str,
+        actor_id: str,
+        target: dict,
+        skill_ids: Sequence[str],
+        action: str,
+        runtime_required: bool,
+        scope_from_result: Callable[[DesiredStateMutation], ProjectionScope],
+        partial_conflict_codes: frozenset[str],
+        mutation_for_skill: Callable[[str], DesiredStateMutation],
+    ) -> list[SkillSetSkillOutcome]:
+        if not skill_ids:
+            return []
+
+        outcomes: list[SkillSetSkillOutcome] = []
         previous_state = None
-        claimed_mcp_codes: set[str] = set()
+        affected_mcp_codes: set[str] = set()
 
         def mutation() -> DesiredStateMutation:
             nonlocal previous_state
             try:
                 for skill_id in skill_ids:
                     try:
-                        if target["is_default"]:
-                            # Default membership remains immutable.  Its only add
-                            # semantic is restoring an individually excluded
-                            # member, which batch-of-one Gateway calls already
-                            # exposed before this refactor.
-                            self._require_excluded_default_skill(
-                                owner_id=str(bot["owner_id"]),
-                                bot_id=bot_id,
-                                set_id=str(target["id"]),
-                                skill_id=skill_id,
-                            )
-                            result = self._repository.unexclude_default_skill(
-                                bot_id=bot_id,
-                                owner_id=str(bot["owner_id"]),
-                                set_id=set_id,
-                                skill_id=skill_id,
-                                engine_type=self._engine(bot),
-                                default_engine_types=self._default_engine_types(bot),
-                            )
-                        else:
-                            result = self._repository.add_skill(
-                                bot_id=bot_id,
-                                owner_id=str(bot["owner_id"]),
-                                set_id=set_id,
-                                skill_id=skill_id,
-                                engine_type=self._engine(bot),
-                                default_engine_types=self._default_engine_types(bot),
-                            )
+                        result = mutation_for_skill(skill_id)
                     except SkillSetControlPlaneNotFoundError as error:
                         outcomes.append(
-                            SkillSetAddOutcome(skill_id=skill_id, error=error)
+                            SkillSetSkillOutcome(skill_id=skill_id, error=error)
                         )
                         continue
                     except SkillSetControlPlaneConflictError as error:
-                        if str(error) not in {
-                            "RESOURCE_DIRECT_ACTIVE",
-                            "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET",
-                        }:
+                        if str(error) not in partial_conflict_codes:
                             raise
                         outcomes.append(
-                            SkillSetAddOutcome(skill_id=skill_id, error=error)
+                            SkillSetSkillOutcome(skill_id=skill_id, error=error)
                         )
                         continue
 
                     if previous_state is None:
                         previous_state = result.previous_state
                     if result.changed:
-                        claimed_mcp_codes.update(result.mcp_codes)
+                        affected_mcp_codes.update(result.mcp_codes)
                     outcomes.append(
-                        SkillSetAddOutcome(skill_id=skill_id, changed=result.changed)
+                        SkillSetSkillOutcome(skill_id=skill_id, changed=result.changed)
                     )
             except Exception:
                 # Individual repository writes commit desired state before the
@@ -408,67 +514,20 @@ class SkillSetManagementService:
                         engine_type=self._engine(bot),
                     )
                 ),
-                mcp_codes=frozenset(claimed_mcp_codes),
+                mcp_codes=frozenset(affected_mcp_codes),
             )
 
         await self._mutate(
             bot=bot,
             bot_id=bot_id,
-            actor_id=user_id,
-            action="skill_set_add_skill",
-            runtime_required=bool(target.get("is_active") or target["is_default"]),
-            scope_from_result=skill_claim_scope,
+            actor_id=actor_id,
+            action=action,
+            runtime_required=runtime_required,
+            scope_from_result=scope_from_result,
             mutation=mutation,
             skip_projection_when_unchanged=True,
         )
         return outcomes
-
-    async def remove_skill(
-        self,
-        *,
-        bot_id: str,
-        owner_id: str,
-        user_id: str,
-        set_id: str,
-        skill_id: str,
-    ) -> dict:
-        # Scope from the result, mirroring ``add_skill``.
-        bot = self._bot(bot_id=bot_id, owner_id=owner_id, user_id=user_id)
-        target = self._target_set(bot=bot, bot_id=bot_id, set_id=set_id)
-        if target["is_default"]:
-            # A Default Set is always active and its membership immutable:
-            # removing a member is the per-Bot exclusion (spec E.11).
-            return await self._mutate(
-                bot=bot,
-                bot_id=bot_id,
-                actor_id=user_id,
-                action="default_set_exclude_skill",
-                scope_from_result=skill_release_scope,
-                mutation=lambda: self._repository.exclude_default_skill(
-                    bot_id=bot_id,
-                    owner_id=str(bot["owner_id"]),
-                    set_id=set_id,
-                    skill_id=skill_id,
-                    engine_type=self._engine(bot),
-                    default_engine_types=self._default_engine_types(bot),
-                ),
-            )
-        return await self._mutate(
-            bot=bot,
-            bot_id=bot_id,
-            actor_id=user_id,
-            action="skill_set_remove_skill",
-            runtime_required=bool(target.get("is_active")),
-            scope_from_result=skill_release_scope,
-            mutation=lambda: self._repository.remove_skill(
-                bot_id=bot_id,
-                owner_id=str(bot["owner_id"]),
-                set_id=set_id,
-                skill_id=skill_id,
-                engine_type=self._engine(bot),
-                default_engine_types=self._default_engine_types(bot),
-            ),
-        )
 
     def list_mcps(
         self, *, bot_id: str, owner_id: str, user_id: str, set_id: str

--- a/src/backend/src/agentclaw/community/core/skill_center/skill_set_batch.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/skill_set_batch.py
@@ -1,0 +1,24 @@
+"""Typed outcomes for one ordered SkillSet member-add batch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SkillSetAddOutcome:
+    """One requested Skill's desired-state result.
+
+    The legacy BFF contract deliberately permits a batch to have both
+    successful and rejected members.  Keeping the domain exception here lets
+    each HTTP adapter apply its own established error wire without making the
+    control plane depend on HTTP response models.
+    """
+
+    skill_id: str
+    changed: bool = False
+    error: Exception | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        return self.error is None

--- a/src/backend/src/agentclaw/community/core/skill_center/skill_set_batch.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/skill_set_batch.py
@@ -1,4 +1,4 @@
-"""Typed outcomes for one ordered SkillSet member-add batch."""
+"""Typed outcomes for one ordered SkillSet Skill-membership batch."""
 
 from __future__ import annotations
 
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
-class SkillSetAddOutcome:
-    """One requested Skill's desired-state result.
+class SkillSetSkillOutcome:
+    """One requested Skill membership mutation's desired-state result.
 
     The legacy BFF contract deliberately permits a batch to have both
     successful and rejected members.  Keeping the domain exception here lets

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skill_sets_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skill_sets_endpoints.py
@@ -12,6 +12,9 @@ from agentclaw.community.adapters.http.openapi_v1.skill_sets.router import route
 from agentclaw.community.api.skill_set_management_service import (
     SkillSetManagementServiceProtocol,
 )
+from agentclaw.community.core.skill_center.skill_set_batch import (
+    SkillSetAddOutcome,
+)
 from tests.community.adapters.http.openapi_v1.conftest import (
     bind_bot_access_seam,
     mount_public_error_handlers,
@@ -22,6 +25,7 @@ from tests.community.adapters.http.openapi_v1.conftest import (
 class _ControlPlane:
     def __init__(self) -> None:
         self.created: dict | None = None
+        self.added: dict | None = None
 
     def list_sets(self, **_kwargs):
         return [
@@ -62,8 +66,9 @@ class _ControlPlane:
     def list_skills(self, **_kwargs):
         return []
 
-    async def add_skill(self, **_kwargs):
-        return {"changed": True}
+    async def add_skills(self, **kwargs):
+        self.added = kwargs
+        return [SkillSetAddOutcome(skill_id="9", changed=True)]
 
     async def remove_skill(self, **_kwargs):
         return {"changed": False}
@@ -130,13 +135,21 @@ def test_create_is_inactive_without_an_idempotency_key():
 
 
 def test_membership_and_activation_are_bot_scoped():
-    client = _client(_ControlPlane())
+    control = _ControlPlane()
+    client = _client(control)
 
     member = client.put("/openapi/v1/bots/bot-1/skill-sets/2/skills/9")
     active = client.post("/openapi/v1/bots/bot-1/skill-sets/2/activate")
 
     assert member.status_code == 200
     assert member.json()["data"] == {"changed": True}
+    assert control.added == {
+        "bot_id": "bot-1",
+        "owner_id": "actor",
+        "user_id": "actor",
+        "set_id": "2",
+        "skill_ids": ["9"],
+    }
     assert active.status_code == 200
     assert active.json()["data"]["is_active"] is True
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skill_sets_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skill_sets_endpoints.py
@@ -13,7 +13,7 @@ from agentclaw.community.api.skill_set_management_service import (
     SkillSetManagementServiceProtocol,
 )
 from agentclaw.community.core.skill_center.skill_set_batch import (
-    SkillSetAddOutcome,
+    SkillSetSkillOutcome,
 )
 from tests.community.adapters.http.openapi_v1.conftest import (
     bind_bot_access_seam,
@@ -26,6 +26,7 @@ class _ControlPlane:
     def __init__(self) -> None:
         self.created: dict | None = None
         self.added: dict | None = None
+        self.removed: dict | None = None
 
     def list_sets(self, **_kwargs):
         return [
@@ -68,10 +69,11 @@ class _ControlPlane:
 
     async def add_skills(self, **kwargs):
         self.added = kwargs
-        return [SkillSetAddOutcome(skill_id="9", changed=True)]
+        return [SkillSetSkillOutcome(skill_id="9", changed=True)]
 
-    async def remove_skill(self, **_kwargs):
-        return {"changed": False}
+    async def remove_skills(self, **kwargs):
+        self.removed = kwargs
+        return [SkillSetSkillOutcome(skill_id="9", changed=False)]
 
     async def activate(self, **_kwargs):
         return {
@@ -144,6 +146,16 @@ def test_membership_and_activation_are_bot_scoped():
     assert member.status_code == 200
     assert member.json()["data"] == {"changed": True}
     assert control.added == {
+        "bot_id": "bot-1",
+        "owner_id": "actor",
+        "user_id": "actor",
+        "set_id": "2",
+        "skill_ids": ["9"],
+    }
+    removed = client.delete("/openapi/v1/bots/bot-1/skill-sets/2/skills/9")
+    assert removed.status_code == 200
+    assert removed.json()["data"] == {"changed": False}
+    assert control.removed == {
         "bot_id": "bot-1",
         "owner_id": "actor",
         "user_id": "actor",

--- a/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
+++ b/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
@@ -35,6 +35,9 @@ from agentclaw.community.core.skill_center.errors import (
     SkillSetControlPlaneConflictError,
     SkillSetControlPlaneNotFoundError,
 )
+from agentclaw.community.core.skill_center.skill_set_batch import (
+    SkillSetAddOutcome,
+)
 
 
 class _Bots:
@@ -307,10 +310,15 @@ async def test_legacy_skill_set_batch_keeps_domain_partial_success() -> None:
         def resolve_legacy_skill_id(self, **kwargs):
             return kwargs["identifier"]
 
-        async def add_skill(self, **_kwargs):
-            raise SkillSetControlPlaneConflictError(
-                "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET"
-            )
+        async def add_skills(self, **_kwargs):
+            return [
+                SkillSetAddOutcome(
+                    skill_id="7",
+                    error=SkillSetControlPlaneConflictError(
+                        "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET"
+                    ),
+                )
+            ]
 
     response = await add_skills_to_set(
         "set-1",
@@ -347,18 +355,22 @@ async def test_legacy_skill_set_batch_uses_body_owner_for_collaborator() -> None
             assert kwargs["actor_id"] == "collaborator"
             return kwargs["identifier"]
 
-        async def add_skill(self, **kwargs):
+        async def add_skills(self, **kwargs):
             assert kwargs == {
                 "bot_id": "bot",
                 "owner_id": "owner",
                 "user_id": "collaborator",
                 "set_id": "set-1",
-                "skill_id": "7",
+                "skill_ids": ["7", "8"],
             }
+            return [
+                SkillSetAddOutcome(skill_id="7", changed=True),
+                SkillSetAddOutcome(skill_id="8", changed=True),
+            ]
 
     response = await add_skills_to_set(
         "set-1",
-        AddSkillsRequest(skill_ids=["7"], user_id="owner", bot_id="bot"),
+        AddSkillsRequest(skill_ids=["7", "8"], user_id="owner", bot_id="bot"),
         entity_id=None,
         entity_type=None,
         bot_id=None,
@@ -369,7 +381,10 @@ async def test_legacy_skill_set_batch_uses_body_owner_for_collaborator() -> None
     )
 
     assert response.success is True
-    assert response.data["success"] == [{"skill_id": "7", "name": "7"}]
+    assert response.data["success"] == [
+        {"skill_id": "7", "name": "7"},
+        {"skill_id": "8", "name": "8"},
+    ]
     assert response.data["failed"] == []
 
 
@@ -524,7 +539,7 @@ async def test_legacy_skill_set_batch_propagates_infrastructure_failure() -> Non
         def resolve_legacy_skill_id(self, **kwargs):
             return kwargs["identifier"]
 
-        async def add_skill(self, **_kwargs):
+        async def add_skills(self, **_kwargs):
             raise RuntimeError("database unavailable")
 
     # The route used to catch this and return a 500 reading "Skill set
@@ -555,7 +570,7 @@ async def test_legacy_skill_set_batch_does_not_hide_mutation_busy() -> None:
         def resolve_legacy_skill_id(self, **kwargs):
             return kwargs["identifier"]
 
-        async def add_skill(self, **_kwargs):
+        async def add_skills(self, **_kwargs):
             raise SkillSetControlPlaneConflictError("BOT_MUTATION_BUSY")
 
     # A busy fence is not one of the two per-skill conflicts the batch records
@@ -646,13 +661,16 @@ async def test_legacy_remove_reaches_the_default_set_exclusion_wire() -> None:
         "success": True,
         "message": "Skill removed from skill set",
     }
-    assert ("remove_skill", {
-        "bot_id": "persisted-bot",
-        "owner_id": "owner",
-        "user_id": "owner",
-        "set_id": "set-1",
-        "skill_id": "7",
-    }) in control_plane.calls
+    assert (
+        "remove_skill",
+        {
+            "bot_id": "persisted-bot",
+            "owner_id": "owner",
+            "user_id": "owner",
+            "set_id": "set-1",
+            "skill_id": "7",
+        },
+    ) in control_plane.calls
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
+++ b/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
@@ -36,7 +36,7 @@ from agentclaw.community.core.skill_center.errors import (
     SkillSetControlPlaneNotFoundError,
 )
 from agentclaw.community.core.skill_center.skill_set_batch import (
-    SkillSetAddOutcome,
+    SkillSetSkillOutcome,
 )
 
 
@@ -312,7 +312,7 @@ async def test_legacy_skill_set_batch_keeps_domain_partial_success() -> None:
 
         async def add_skills(self, **_kwargs):
             return [
-                SkillSetAddOutcome(
+                SkillSetSkillOutcome(
                     skill_id="7",
                     error=SkillSetControlPlaneConflictError(
                         "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET"
@@ -364,8 +364,8 @@ async def test_legacy_skill_set_batch_uses_body_owner_for_collaborator() -> None
                 "skill_ids": ["7", "8"],
             }
             return [
-                SkillSetAddOutcome(skill_id="7", changed=True),
-                SkillSetAddOutcome(skill_id="8", changed=True),
+                SkillSetSkillOutcome(skill_id="7", changed=True),
+                SkillSetSkillOutcome(skill_id="8", changed=True),
             ]
 
     response = await add_skills_to_set(
@@ -430,9 +430,9 @@ async def test_legacy_exact_set_routes_keep_the_target_owner_for_collaborators()
             self.operations.append(("list_skills", kwargs))
             return []
 
-        async def remove_skill(self, **kwargs):
-            self.operations.append(("remove_skill", kwargs))
-            return {"changed": True}
+        async def remove_skills(self, **kwargs):
+            self.operations.append(("remove_skills", kwargs))
+            return [SkillSetSkillOutcome(skill_id="7", changed=True)]
 
         def list_mcps(self, **kwargs):
             self.operations.append(("list_mcps", kwargs))
@@ -487,7 +487,7 @@ async def test_legacy_exact_set_routes_keep_the_target_owner_for_collaborators()
         "update_set",
         "delete_set",
         "list_skills",
-        "remove_skill",
+        "remove_skills",
         "get_set",
         "list_mcps",
     ]
@@ -639,9 +639,9 @@ async def test_legacy_remove_reaches_the_default_set_exclusion_wire() -> None:
             self.calls.append(("get_set", kwargs))
             return {"id": "set-1", "is_default": True}
 
-        async def remove_skill(self, **kwargs):
-            self.calls.append(("remove_skill", kwargs))
-            return {"id": "set-1", "is_default": True, "changed": True}
+        async def remove_skills(self, **kwargs):
+            self.calls.append(("remove_skills", kwargs))
+            return [SkillSetSkillOutcome(skill_id="7", changed=True)]
 
     control_plane = _ControlPlane()
     response = await remove_skill_from_set(
@@ -662,15 +662,40 @@ async def test_legacy_remove_reaches_the_default_set_exclusion_wire() -> None:
         "message": "Skill removed from skill set",
     }
     assert (
-        "remove_skill",
+        "remove_skills",
         {
             "bot_id": "persisted-bot",
             "owner_id": "owner",
             "user_id": "owner",
             "set_id": "set-1",
-            "skill_id": "7",
+                "skill_ids": ["7"],
         },
     ) in control_plane.calls
+
+
+@pytest.mark.asyncio
+async def test_legacy_remove_keeps_the_historical_missing_member_404() -> None:
+    from agentclaw.community.adapters.http.skill_center.skillsets import (
+        remove_skill_from_set,
+    )
+
+    class _ControlPlane(_LegacySetScopeControlPlane):
+        async def remove_skills(self, **_kwargs):
+            return [SkillSetSkillOutcome(skill_id="7", changed=False)]
+
+    with pytest.raises(SkillSetControlPlaneNotFoundError, match="Skill not found"):
+        await remove_skill_from_set(
+            "set-1",
+            "7",
+            user_id="owner",
+            entity_id=None,
+            entity_type=None,
+            bot_id=None,
+            engine_type=None,
+            ctx=SimpleNamespace(user_id="owner", bot_id="default"),
+            bot_repo=_AddressedBots(),
+            control_plane=_ControlPlane(),
+        )
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -33,6 +33,9 @@ from agentclaw.community.core.skill_center.errors import (
 from agentclaw.community.core.skill_center.services.skill_set_management_service import (
     SkillSetManagementService,
 )
+from agentclaw.community.core.skill_center.skill_set_batch import (
+    SkillSetAddOutcome,
+)
 from agentclaw.community.core.skill_center.services.bot_capability_state_reader import (
     BotCapabilityStateReader,
 )
@@ -822,9 +825,7 @@ async def test_collaborator_command_restores_desired_state_and_uses_true_owner()
     # runtime failed. deactivate declares its scope rather than reconciling,
     # and the compensating call carries scope.inverted() — released and
     # claimed swap, exactly as retired_mappings swap alongside them.
-    _deactivate_scope = ProjectionScope(
-        skills=True, mcp=True, released_mcp=frozenset()
-    )
+    _deactivate_scope = ProjectionScope(skills=True, mcp=True, released_mcp=frozenset())
     assert runtime.reconcile_calls == [
         {
             "bot_id": "bot-1",
@@ -1137,7 +1138,7 @@ def test_inactive_set_metadata_updates_do_not_require_runtime_readiness() -> Non
 @pytest.mark.parametrize(
     ("method_name", "resource_kwargs"),
     [
-        ("add_skill", {"skill_id": "skill-1"}),
+        ("add_skills", {"skill_ids": ["skill-1"]}),
         ("remove_skill", {"skill_id": "skill-1"}),
         ("add_mcp", {"server_code": "mcp.weather"}),
         ("remove_mcp", {"server_code": "mcp.weather"}),
@@ -1169,8 +1170,13 @@ async def test_inactive_set_membership_does_not_require_runtime_readiness(
         **resource_kwargs,
     )
 
-    assert result["is_active"] is False
-    assert repository.membership_calls[0][0] == method_name
+    if method_name == "add_skills":
+        assert result == [SkillSetAddOutcome(skill_id="skill-1", changed=True)]
+    else:
+        assert result["is_active"] is False
+    assert repository.membership_calls[0][0] == (
+        "add_skill" if method_name == "add_skills" else method_name
+    )
     assert runtime.snapshot_calls == []
     assert runtime.reconcile_calls == []
 
@@ -1192,12 +1198,12 @@ async def test_active_set_membership_still_requires_runtime_readiness() -> None:
     )
 
     with pytest.raises(LocalSkillNotReadyError):
-        await service.add_skill(
+        await service.add_skills(
             bot_id="bot-1",
             owner_id="true-owner",
             user_id="true-owner",
             set_id="set-1",
-            skill_id="skill-1",
+            skill_ids=["skill-1"],
         )
 
     assert repository.membership_calls == []
@@ -1250,10 +1256,10 @@ async def test_legacy_sync_activates_additively_without_replacing_other_sets():
         {
             "bot_id": "bot-1",
             "owner_id": "true-owner",
-                "set_id": "set-1",
-                "active": True,
-                "engine_type": "openclaw",
-                "default_engine_types": ("openclaw",),
+            "set_id": "set-1",
+            "active": True,
+            "engine_type": "openclaw",
+            "default_engine_types": ("openclaw",),
         }
     ]
 
@@ -1320,9 +1326,9 @@ def test_skill_set_acl_denial_is_adjudicated_at_both_gates():
         and ("/skill-sets" in key[1] or key[1].endswith("/mcps"))
     }
     assert adjudicated, "the skill-set operations are no longer adjudicated"
-    assert all(
-        rule.level is PermissionLevel.MEMBER for rule in adjudicated.values()
-    ), "the bar moved off MEMBER, which can_manage_bot enforced before the seam"
+    assert all(rule.level is PermissionLevel.MEMBER for rule in adjudicated.values()), (
+        "the bar moved off MEMBER, which can_manage_bot enforced before the seam"
+    )
 
 
 def test_the_control_plane_check_the_legacy_surface_relies_on_still_exists():
@@ -1395,7 +1401,10 @@ def _ungated_control_plane_routes(text: str) -> list[str]:
     for index, (line_no, method, path) in enumerate(starts):
         end = starts[index + 1][0] if index + 1 < len(starts) else len(lines)
         block = "\n".join(lines[line_no:end])
-        if "control_plane." in block and "CollaboratorPermissionInterceptor" not in block:
+        if (
+            "control_plane." in block
+            and "CollaboratorPermissionInterceptor" not in block
+        ):
             ungated.append(f"{method} {path}")
     return ungated
 
@@ -1475,15 +1484,18 @@ def test_resources_forwards_resolved_bot_owner_to_owner_scoped_set_listing():
         ext_info_provider=lambda _bot_id: None,
     )
 
-    assert service.list_resources(
-        bot_id="bot-1", owner_id="true-owner", user_id="true-owner"
-    ) == []
+    assert (
+        service.list_resources(
+            bot_id="bot-1", owner_id="true-owner", user_id="true-owner"
+        )
+        == []
+    )
     assert repository.list_set_calls == [
         {
-                "bot_id": "bot-1",
-                "owner_id": "true-owner",
-                "engine_type": "openclaw",
-                "default_engine_types": ("openclaw",),
+            "bot_id": "bot-1",
+            "owner_id": "true-owner",
+            "engine_type": "openclaw",
+            "default_engine_types": ("openclaw",),
         }
     ]
 
@@ -1503,15 +1515,18 @@ def test_list_sets_uses_aicoding_default_then_claude_code_fallback_for_coding_im
         ext_info_provider=lambda _bot_id: None,
     )
 
-    assert service.list_sets(
-        bot_id="bot-1", owner_id="true-owner", user_id="true-owner"
-    ) == []
-    assert repository.list_set_calls == [{
-        "bot_id": "bot-1",
-        "owner_id": "true-owner",
-        "engine_type": "claude_code",
-        "default_engine_types": ("aicoding", "claude_code"),
-    }]
+    assert (
+        service.list_sets(bot_id="bot-1", owner_id="true-owner", user_id="true-owner")
+        == []
+    )
+    assert repository.list_set_calls == [
+        {
+            "bot_id": "bot-1",
+            "owner_id": "true-owner",
+            "engine_type": "claude_code",
+            "default_engine_types": ("aicoding", "claude_code"),
+        }
+    ]
 
 
 def test_update_set_uses_runtime_default_candidates_for_coding_image():
@@ -1538,15 +1553,17 @@ def test_update_set_uses_runtime_default_candidates_for_coding_image():
         description="ignored by the repository fake",
     )
 
-    assert repository.update_calls == [{
-        "bot_id": "bot-1",
-        "owner_id": "true-owner",
-        "set_id": "default-id",
-        "name": None,
-        "description": "ignored by the repository fake",
-        "engine_type": "claude_code",
-        "default_engine_types": ("aicoding", "claude_code"),
-    }]
+    assert repository.update_calls == [
+        {
+            "bot_id": "bot-1",
+            "owner_id": "true-owner",
+            "set_id": "default-id",
+            "name": None,
+            "description": "ignored by the repository fake",
+            "engine_type": "claude_code",
+            "default_engine_types": ("aicoding", "claude_code"),
+        }
+    ]
 
 
 def test_resources_reads_global_default_mcp_projection_for_collaborator_owner_scope():
@@ -1573,12 +1590,14 @@ def test_resources_reads_global_default_mcp_projection_for_collaborator_owner_sc
     # See above: the collaborator adjudication moved to the seam, so there
     # is no hook call left to observe here.
     assert repository.list_mcp_calls == []
-    assert legacy.service.default_mcp_calls == [{
-        "skill_set_id": "global-default",
-        "user_id": "true-owner",
-        "bot_id": "bot-1",
-        "engine_type": "openclaw",
-    }]
+    assert legacy.service.default_mcp_calls == [
+        {
+            "skill_set_id": "global-default",
+            "user_id": "true-owner",
+            "bot_id": "bot-1",
+            "engine_type": "openclaw",
+        }
+    ]
 
 
 def test_resources_keeps_ordinary_mcp_membership_on_canonical_repository_path():
@@ -1603,13 +1622,15 @@ def test_resources_keeps_ordinary_mcp_membership_on_canonical_repository_path():
 
     assert result[0]["mcps"] == [{"server_code": "legacy-default-mcp"}]
     assert result[1]["mcps"] == [{"server_code": "ordinary-set-mcp"}]
-    assert repository.list_mcp_calls == [{
-        "bot_id": "bot-1",
-        "owner_id": "true-owner",
-        "set_id": "ordinary-set",
-        "engine_type": "openclaw",
-        "default_engine_types": ("openclaw",),
-    }]
+    assert repository.list_mcp_calls == [
+        {
+            "bot_id": "bot-1",
+            "owner_id": "true-owner",
+            "set_id": "ordinary-set",
+            "engine_type": "openclaw",
+            "default_engine_types": ("openclaw",),
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -1672,10 +1693,10 @@ async def test_existing_claude_code_skill_set_deactivate_uses_full_projection():
         {
             "bot_id": "bot-1",
             "owner_id": "true-owner",
-                "set_id": "set-1",
-                "active": False,
-                "engine_type": "claude_code",
-                "default_engine_types": ("claude_code",),
+            "set_id": "set-1",
+            "active": False,
+            "engine_type": "claude_code",
+            "default_engine_types": ("claude_code",),
         }
     ]
     assert runtime.reconcile_calls == [
@@ -1686,9 +1707,7 @@ async def test_existing_claude_code_skill_set_deactivate_uses_full_projection():
             # deactivate declares what it released rather than reconciling:
             # the Set's MCP codes come back on the mutation result, resolved
             # under the row lock that uninstalled them.
-            "scope": ProjectionScope(
-                skills=True, mcp=True, released_mcp=frozenset()
-            ),
+            "scope": ProjectionScope(skills=True, mcp=True, released_mcp=frozenset()),
         }
     ]
 
@@ -1826,9 +1845,7 @@ async def test_runtime_mapping_snapshot_has_no_runtime_side_effects():
 
     assert snapshot == (
         PoolSkillMapping(corpus="local", relative_path="qa", link_name="qa"),
-        PoolSkillMapping(
-            corpus="repo", relative_path="business/eva", link_name="eva"
-        ),
+        PoolSkillMapping(corpus="repo", relative_path="business/eva", link_name="eva"),
     )
     # The reader's DB-side flush runs on every read; what a snapshot must
     # never do is touch the engine.
@@ -1851,7 +1868,8 @@ async def test_runtime_projection_flushes_installations_first():
     )
 
     await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope.everything(),
     )
 
@@ -1883,7 +1901,8 @@ async def test_projection_flush_prefers_the_layout_engine_for_default_sets():
     )
 
     await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope.everything(),
     )
 
@@ -1913,9 +1932,10 @@ async def test_runtime_projection_fails_before_engine_writes_when_flush_fails():
 
     with pytest.raises(RuntimeError, match="installation persistence unavailable"):
         await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
-        scope=ProjectionScope.everything(),
-    )
+            bot_id="bot-1",
+            owner_id="true-owner",
+            scope=ProjectionScope.everything(),
+        )
 
 
 @pytest.mark.asyncio
@@ -1934,9 +1954,10 @@ async def test_runtime_projection_fails_closed_when_default_mcp_policy_is_unavai
 
     with pytest.raises(SkillSetRuntimeReconcileError):
         await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
-        scope=ProjectionScope.everything(),
-    )
+            bot_id="bot-1",
+            owner_id="true-owner",
+            scope=ProjectionScope.everything(),
+        )
 
     assert factory.service.mcp_codes is None
     assert passport.calls == []
@@ -1960,7 +1981,8 @@ async def test_runtime_projection_mcp_inputs_agree_when_the_union_overlaps():
     )
 
     await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope.everything(),
     )
 
@@ -1986,7 +2008,8 @@ async def test_runtime_reconcile_projects_full_mcp_desired_state():
     )
 
     await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope.everything(),
     )
 
@@ -2062,7 +2085,8 @@ async def test_projection_preserves_caller_identity_for_configured_mcp():
     )
 
     await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope.everything(),
     )
 
@@ -2089,7 +2113,8 @@ async def test_projection_defaults_to_owner_without_a_call_config_row():
     )
 
     await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope.everything(),
     )
 
@@ -2125,7 +2150,8 @@ async def test_projection_scope_is_the_projected_codes_not_the_config_rows():
     )
 
     await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope.everything(),
     )
 
@@ -2166,9 +2192,10 @@ async def test_projection_fails_closed_without_a_bot_primary_key():
 
     with pytest.raises(SkillSetRuntimeReconcileError):
         await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
-        scope=ProjectionScope.everything(),
-    )
+            bot_id="bot-1",
+            owner_id="true-owner",
+            scope=ProjectionScope.everything(),
+        )
 
     # Closed means nothing was written, not merely that it stopped: the
     # device allow-list and the symlink sync both precede the Passport call,
@@ -2278,11 +2305,12 @@ async def test_reconcile_scope_claims_every_projected_code():
     )
 
     await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope.everything(),
     )
 
-    (claimed, released), = factory.service.deliveries
+    ((claimed, released),) = factory.service.deliveries
     assert claimed == frozenset(factory.service.mcp_codes)
     assert released == frozenset()
 
@@ -2314,7 +2342,9 @@ async def test_a_declared_claim_delivers_only_that_code():
     assert factory.service.deliveries == [(frozenset({"mcp.weather"}), frozenset())]
     # Declaration stays total even though delivery did not.
     assert factory.service.mcp_codes == {
-        "mcp.weather", "mcp.template-preset", "hitl",
+        "mcp.weather",
+        "mcp.template-preset",
+        "hitl",
     }
 
 
@@ -2392,9 +2422,10 @@ async def test_runtime_reconcile_fails_closed_when_effective_cli_scope_cannot_be
 
     with pytest.raises(SkillSetRuntimeReconcileError):
         await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
-        scope=ProjectionScope.everything(),
-    )
+            bot_id="bot-1",
+            owner_id="true-owner",
+            scope=ProjectionScope.everything(),
+        )
 
     assert passport.calls == []
 
@@ -2414,7 +2445,8 @@ async def test_runtime_reconcile_requires_and_uses_mapping_v3_for_center():
     )
 
     await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope.everything(),
     )
 
@@ -2446,7 +2478,8 @@ async def test_coding_template_uses_aicoding_for_center_probe_but_keeps_logical_
     )
 
     await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope.everything(),
     )
 
@@ -2480,7 +2513,8 @@ async def test_existing_coding_runtime_uses_its_resolved_layout(
     )
 
     await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope.everything(),
     )
 
@@ -2504,9 +2538,10 @@ async def test_teclaw_v4_rejects_center_without_any_center_runtime_request():
 
     with pytest.raises(SkillSetRuntimeReconcileError):
         await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
-        scope=ProjectionScope.everything(),
-    )
+            bot_id="bot-1",
+            owner_id="true-owner",
+            scope=ProjectionScope.everything(),
+        )
 
     assert pool.probe_calls == []
     assert pool.publish_calls == []
@@ -2528,7 +2563,8 @@ async def test_teclaw_v4_repo_projection_uses_artifact_runtime_not_pool_mapping(
     )
 
     await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope.everything(),
     )
 
@@ -2560,7 +2596,8 @@ async def test_non_skill_projection_never_writes_skill_mappings():
     )
 
     await runtime.project_mcp_and_cli(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope(mcp=True, claim_all_mcp=True),
     )
 
@@ -3046,12 +3083,12 @@ async def test_add_skill_claims_the_skill_s_mcp_dependencies():
     repository = _SkillRepository({"mcp.weather"})
     runtime = _Runtime(fail_first=False)
 
-    await _skill_service(repository, runtime).add_skill(
+    await _skill_service(repository, runtime).add_skills(
         bot_id="bot-1",
         owner_id="true-owner",
         user_id="true-owner",
         set_id="set-1",
-        skill_id="7",
+        skill_ids=["7"],
     )
 
     (call,) = runtime.reconcile_calls
@@ -3071,17 +3108,114 @@ async def test_add_skill_without_dependencies_leaves_the_mcp_half_alone():
     repository = _SkillRepository()
     runtime = _Runtime(fail_first=False)
 
-    await _skill_service(repository, runtime).add_skill(
+    await _skill_service(repository, runtime).add_skills(
         bot_id="bot-1",
         owner_id="true-owner",
         user_id="true-owner",
         set_id="set-1",
-        skill_id="7",
+        skill_ids=["7"],
     )
 
     (call,) = runtime.reconcile_calls
     assert call["scope"].skills is True
     assert call["scope"].mcp is False
+
+
+@pytest.mark.asyncio
+async def test_batch_add_to_an_active_set_projects_the_final_state_once():
+    """A legacy batch must not publish one runtime artifact per member."""
+    repository = _SkillRepository({"mcp.weather"})
+    runtime = _ProjectionCountingRuntime()
+
+    outcomes = await _skill_service(repository, runtime).add_skills(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="true-owner",
+        set_id="set-1",
+        skill_ids=["7", "8"],
+    )
+
+    assert outcomes == [
+        SkillSetAddOutcome(skill_id="7", changed=True),
+        SkillSetAddOutcome(skill_id="8", changed=True),
+    ]
+    assert [call["skill_id"] for call in repository.skill_calls] == ["7", "8"]
+    assert runtime.projections == 1
+    assert runtime.scopes == [
+        ProjectionScope(
+            skills=True,
+            mcp=True,
+            claimed_mcp=frozenset({"mcp.weather"}),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_batch_add_keeps_legacy_partial_success_and_projects_once():
+    class _PartialRepository(_SkillRepository):
+        def add_skill(self, **kwargs) -> DesiredStateMutation:
+            if kwargs["skill_id"] == "missing":
+                raise SkillSetControlPlaneNotFoundError()
+            return super().add_skill(**kwargs)
+
+    repository = _PartialRepository()
+    runtime = _ProjectionCountingRuntime()
+
+    outcomes = await _skill_service(repository, runtime).add_skills(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="true-owner",
+        set_id="set-1",
+        skill_ids=["7", "missing"],
+    )
+
+    assert outcomes[0] == SkillSetAddOutcome(skill_id="7", changed=True)
+    assert outcomes[1].skill_id == "missing"
+    assert isinstance(outcomes[1].error, SkillSetControlPlaneNotFoundError)
+    assert runtime.projections == 1
+
+
+@pytest.mark.asyncio
+async def test_batch_add_runtime_failure_restores_the_whole_batch_once():
+    repository = _SkillRepository({"mcp.weather"})
+    runtime = _Runtime()
+
+    with pytest.raises(SkillSetRuntimeReconcileError):
+        await _skill_service(repository, runtime).add_skills(
+            bot_id="bot-1",
+            owner_id="true-owner",
+            user_id="true-owner",
+            set_id="set-1",
+            skill_ids=["7", "8"],
+        )
+
+    assert [call["skill_id"] for call in repository.skill_calls] == ["7", "8"]
+    assert len(repository.restore_calls) == 1
+    assert len(runtime.reconcile_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_batch_add_restores_prior_members_when_a_later_write_fails():
+    class _FailingSecondWriteRepository(_SkillRepository):
+        def add_skill(self, **kwargs) -> DesiredStateMutation:
+            if kwargs["skill_id"] == "8":
+                raise RuntimeError("database unavailable")
+            return super().add_skill(**kwargs)
+
+    repository = _FailingSecondWriteRepository()
+    runtime = _ProjectionCountingRuntime()
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await _skill_service(repository, runtime).add_skills(
+            bot_id="bot-1",
+            owner_id="true-owner",
+            user_id="true-owner",
+            set_id="set-1",
+            skill_ids=["7", "8"],
+        )
+
+    assert len(repository.restore_calls) == 1
+    assert runtime.projections == 0
 
 
 @pytest.mark.asyncio
@@ -3113,12 +3247,12 @@ async def test_a_failed_skill_projection_withdraws_the_dependencies_it_claimed()
     runtime = _Runtime()
 
     with pytest.raises(SkillSetRuntimeReconcileError):
-        await _skill_service(repository, runtime).add_skill(
+        await _skill_service(repository, runtime).add_skills(
             bot_id="bot-1",
             owner_id="true-owner",
             user_id="true-owner",
             set_id="set-1",
-            skill_id="7",
+            skill_ids=["7"],
         )
 
     forward, compensating = runtime.reconcile_calls
@@ -3138,12 +3272,12 @@ async def test_an_inactive_set_still_skips_projection_entirely():
     repository = _InactiveSetRepository({"mcp.weather"})
     runtime = _Runtime(fail_first=False)
 
-    await _skill_service(repository, runtime).add_skill(
+    await _skill_service(repository, runtime).add_skills(
         bot_id="bot-1",
         owner_id="true-owner",
         user_id="true-owner",
         set_id="set-1",
-        skill_id="7",
+        skill_ids=["7"],
     )
 
     assert runtime.reconcile_calls == []
@@ -3257,7 +3391,8 @@ async def test_a_reconcile_scope_still_projects_both_halves():
     runtime = _scoped_projector(passport=passport, factory=factory)
 
     await runtime.project(
-        bot_id="bot-1", owner_id="true-owner",
+        bot_id="bot-1",
+        owner_id="true-owner",
         scope=ProjectionScope.everything(),
     )
 
@@ -3342,15 +3477,11 @@ class _DefaultTargetRepository(_Repository):
 
     def exclude_default_mcp(self, **kwargs) -> DesiredStateMutation:
         self.exclusion_calls.append(("exclude_default_mcp", kwargs))
-        return replace(
-            self._mutation(), mcp_codes=frozenset({kwargs["server_code"]})
-        )
+        return replace(self._mutation(), mcp_codes=frozenset({kwargs["server_code"]}))
 
     def unexclude_default_mcp(self, **kwargs) -> DesiredStateMutation:
         self.exclusion_calls.append(("unexclude_default_mcp", kwargs))
-        return replace(
-            self._mutation(), mcp_codes=frozenset({kwargs["server_code"]})
-        )
+        return replace(self._mutation(), mcp_codes=frozenset({kwargs["server_code"]}))
 
 
 class _ProjectionCountingRuntime(_SuccessfulRuntime):
@@ -3377,9 +3508,7 @@ def _default_wire_service(
         mcp_center=_McpCenter(allowed=True),
         mcp_auth=_McpAuth(allowed=True),
         ext_info_provider=(
-            ext_info_provider
-            if ext_info_provider is not None
-            else lambda _bot_id: None
+            ext_info_provider if ext_info_provider is not None else lambda _bot_id: None
         ),
     )
 
@@ -3391,14 +3520,15 @@ async def test_removing_a_default_member_performs_the_exclusion_and_reconciles()
     service = _default_wire_service(repository, runtime)
 
     result = await service.remove_skill(
-        bot_id="bot-1", owner_id="true-owner", user_id="true-owner",
-        set_id="9", skill_id="7",
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="true-owner",
+        set_id="9",
+        skill_id="7",
     )
 
     assert result["changed"] is True
-    assert [name for name, _ in repository.exclusion_calls] == [
-        "exclude_default_skill"
-    ]
+    assert [name for name, _ in repository.exclusion_calls] == ["exclude_default_skill"]
     assert repository.exclusion_calls[0][1]["skill_id"] == "7"
     assert runtime.projections == 1
 
@@ -3408,12 +3538,15 @@ async def test_adding_back_an_excluded_default_member_unexcludes():
     repository = _DefaultTargetRepository(excluded_ids={7})
     service = _default_wire_service(repository)
 
-    result = await service.add_skill(
-        bot_id="bot-1", owner_id="true-owner", user_id="true-owner",
-        set_id="9", skill_id="7",
+    (result,) = await service.add_skills(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="true-owner",
+        set_id="9",
+        skill_ids=["7"],
     )
 
-    assert result["changed"] is True
+    assert result.changed is True
     assert [name for name, _ in repository.exclusion_calls] == [
         "unexclude_default_skill"
     ]
@@ -3443,8 +3576,11 @@ async def test_default_mcp_exclusion_passes_the_platform_default_policy():
     service = _default_wire_service(repository, ext_info_provider=_ext)
 
     await service.remove_mcp(
-        bot_id="bot-1", owner_id="true-owner", user_id="true-owner",
-        set_id="9", server_code="mcp.gone",
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="true-owner",
+        set_id="9",
+        server_code="mcp.gone",
     )
 
     assert ext_calls == ["bot-1"]
@@ -3475,8 +3611,11 @@ async def test_default_mcp_exclusion_propagates_a_template_context_failure():
 
     with pytest.raises(RuntimeError, match="template service unavailable"):
         await service.remove_mcp(
-            bot_id="bot-1", owner_id="true-owner", user_id="true-owner",
-            set_id="9", server_code="mcp.gone",
+            bot_id="bot-1",
+            owner_id="true-owner",
+            user_id="true-owner",
+            set_id="9",
+            server_code="mcp.gone",
         )
     assert repository.exclusion_calls == []
 
@@ -3489,9 +3628,12 @@ async def test_adding_a_new_member_to_the_default_stays_immutable():
     with pytest.raises(
         SkillSetControlPlaneConflictError, match="SYSTEM_DEFAULT_IMMUTABLE"
     ):
-        await service.add_skill(
-            bot_id="bot-1", owner_id="true-owner", user_id="true-owner",
-            set_id="9", skill_id="7",
+        await service.add_skills(
+            bot_id="bot-1",
+            owner_id="true-owner",
+            user_id="true-owner",
+            set_id="9",
+            skill_ids=["7"],
         )
     assert repository.exclusion_calls == []
 
@@ -3503,12 +3645,18 @@ async def test_default_mcp_exclusion_wire_mirrors_the_skill_wire():
     service = _default_wire_service(repository, runtime)
 
     removed = await service.remove_mcp(
-        bot_id="bot-1", owner_id="true-owner", user_id="true-owner",
-        set_id="9", server_code="mcp.gone",
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="true-owner",
+        set_id="9",
+        server_code="mcp.gone",
     )
     added = await service.add_mcp(
-        bot_id="bot-1", owner_id="true-owner", user_id="true-owner",
-        set_id="9", server_code="mcp.back",
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="true-owner",
+        set_id="9",
+        server_code="mcp.back",
     )
 
     assert removed["changed"] is True and added["changed"] is True
@@ -3526,8 +3674,11 @@ async def test_default_mcp_exclusion_wire_mirrors_the_skill_wire():
         SkillSetControlPlaneConflictError, match="SYSTEM_DEFAULT_IMMUTABLE"
     ):
         await service.add_mcp(
-            bot_id="bot-1", owner_id="true-owner", user_id="true-owner",
-            set_id="9", server_code="mcp.never-member",
+            bot_id="bot-1",
+            owner_id="true-owner",
+            user_id="true-owner",
+            set_id="9",
+            server_code="mcp.never-member",
         )
 
 
@@ -3549,7 +3700,10 @@ async def test_unexcluding_a_default_mcp_still_requires_marketplace_permission()
 
     with pytest.raises(McpPermissionDeniedError):
         await service.add_mcp(
-            bot_id="bot-1", owner_id="true-owner", user_id="true-owner",
-            set_id="9", server_code="mcp.back",
+            bot_id="bot-1",
+            owner_id="true-owner",
+            user_id="true-owner",
+            set_id="9",
+            server_code="mcp.back",
         )
     assert repository.exclusion_calls == []

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -34,7 +34,7 @@ from agentclaw.community.core.skill_center.services.skill_set_management_service
     SkillSetManagementService,
 )
 from agentclaw.community.core.skill_center.skill_set_batch import (
-    SkillSetAddOutcome,
+    SkillSetSkillOutcome,
 )
 from agentclaw.community.core.skill_center.services.bot_capability_state_reader import (
     BotCapabilityStateReader,
@@ -1139,7 +1139,7 @@ def test_inactive_set_metadata_updates_do_not_require_runtime_readiness() -> Non
     ("method_name", "resource_kwargs"),
     [
         ("add_skills", {"skill_ids": ["skill-1"]}),
-        ("remove_skill", {"skill_id": "skill-1"}),
+        ("remove_skills", {"skill_ids": ["skill-1"]}),
         ("add_mcp", {"server_code": "mcp.weather"}),
         ("remove_mcp", {"server_code": "mcp.weather"}),
     ],
@@ -1170,12 +1170,18 @@ async def test_inactive_set_membership_does_not_require_runtime_readiness(
         **resource_kwargs,
     )
 
-    if method_name == "add_skills":
-        assert result == [SkillSetAddOutcome(skill_id="skill-1", changed=True)]
+    if method_name in {"add_skills", "remove_skills"}:
+        assert result == [SkillSetSkillOutcome(skill_id="skill-1", changed=True)]
     else:
         assert result["is_active"] is False
     assert repository.membership_calls[0][0] == (
-        "add_skill" if method_name == "add_skills" else method_name
+        (
+            "add_skill"
+            if method_name == "add_skills"
+            else "remove_skill"
+            if method_name == "remove_skills"
+            else method_name
+        )
     )
     assert runtime.snapshot_calls == []
     assert runtime.reconcile_calls == []
@@ -3136,8 +3142,8 @@ async def test_batch_add_to_an_active_set_projects_the_final_state_once():
     )
 
     assert outcomes == [
-        SkillSetAddOutcome(skill_id="7", changed=True),
-        SkillSetAddOutcome(skill_id="8", changed=True),
+        SkillSetSkillOutcome(skill_id="7", changed=True),
+        SkillSetSkillOutcome(skill_id="8", changed=True),
     ]
     assert [call["skill_id"] for call in repository.skill_calls] == ["7", "8"]
     assert runtime.projections == 1
@@ -3169,7 +3175,7 @@ async def test_batch_add_keeps_legacy_partial_success_and_projects_once():
         skill_ids=["7", "missing"],
     )
 
-    assert outcomes[0] == SkillSetAddOutcome(skill_id="7", changed=True)
+    assert outcomes[0] == SkillSetSkillOutcome(skill_id="7", changed=True)
     assert outcomes[1].skill_id == "missing"
     assert isinstance(outcomes[1].error, SkillSetControlPlaneNotFoundError)
     assert runtime.projections == 1
@@ -3219,16 +3225,63 @@ async def test_batch_add_restores_prior_members_when_a_later_write_fails():
 
 
 @pytest.mark.asyncio
-async def test_remove_skill_releases_the_skill_s_mcp_dependencies():
+async def test_batch_remove_from_an_active_set_projects_the_final_state_once():
     repository = _SkillRepository({"mcp.weather"})
-    runtime = _Runtime(fail_first=False)
+    runtime = _ProjectionCountingRuntime()
 
-    await _skill_service(repository, runtime).remove_skill(
+    outcomes = await _skill_service(repository, runtime).remove_skills(
         bot_id="bot-1",
         owner_id="true-owner",
         user_id="true-owner",
         set_id="set-1",
-        skill_id="7",
+        skill_ids=["7", "8"],
+    )
+
+    assert outcomes == [
+        SkillSetSkillOutcome(skill_id="7", changed=True),
+        SkillSetSkillOutcome(skill_id="8", changed=True),
+    ]
+    assert runtime.projections == 1
+    assert runtime.scopes == [
+        ProjectionScope(
+            skills=True,
+            mcp=True,
+            released_mcp=frozenset({"mcp.weather"}),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_batch_remove_runtime_failure_restores_the_whole_batch_once():
+    repository = _SkillRepository({"mcp.weather"})
+    runtime = _Runtime()
+
+    with pytest.raises(SkillSetRuntimeReconcileError):
+        await _skill_service(repository, runtime).remove_skills(
+            bot_id="bot-1",
+            owner_id="true-owner",
+            user_id="true-owner",
+            set_id="set-1",
+            skill_ids=["7", "8"],
+        )
+
+    assert len(repository.restore_calls) == 1
+    forward, compensating = runtime.reconcile_calls
+    assert forward["scope"].released_mcp == frozenset({"mcp.weather"})
+    assert compensating["scope"].claimed_mcp == frozenset({"mcp.weather"})
+
+
+@pytest.mark.asyncio
+async def test_remove_skill_releases_the_skill_s_mcp_dependencies():
+    repository = _SkillRepository({"mcp.weather"})
+    runtime = _Runtime(fail_first=False)
+
+    await _skill_service(repository, runtime).remove_skills(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        user_id="true-owner",
+        set_id="set-1",
+        skill_ids=["7"],
     )
 
     (call,) = runtime.reconcile_calls
@@ -3519,15 +3572,15 @@ async def test_removing_a_default_member_performs_the_exclusion_and_reconciles()
     runtime = _ProjectionCountingRuntime()
     service = _default_wire_service(repository, runtime)
 
-    result = await service.remove_skill(
+    (result,) = await service.remove_skills(
         bot_id="bot-1",
         owner_id="true-owner",
         user_id="true-owner",
         set_id="9",
-        skill_id="7",
+        skill_ids=["7"],
     )
 
-    assert result["changed"] is True
+    assert result.changed is True
     assert [name for name, _ in repository.exclusion_calls] == ["exclude_default_skill"]
     assert repository.exclusion_calls[0][1]["skill_id"] == "7"
     assert runtime.projections == 1


### PR DESCRIPTION
## Problem
The legacy BFF batch SkillSet add endpoint iterated the single-member control-plane command. For an active Set, each member triggered a complete runtime projection, producing intermediate artifacts and repeated BaaS connection setup. The Control Plane also exposed an asymmetric single-member remove command.

## Solution
- Replace the Control Plane Skill membership interface with `add_skills(skill_ids)` and `remove_skills(skill_ids)`.
- Keep the published BFF batch-add wire and both Gateway single-member URLs/responses unchanged.
- Resolve legacy add identifiers in the BFF adapter, then execute one final combined projection.
- Preserve per-member partial success for legacy add; retain the legacy BFF remove 404 for a missing member.
- Restore pre-batch desired state if a later persistence write or final runtime projection fails.

## Validation
- `uv run --project src/backend pytest -q ...`
- Result: 265 passed.
- `ruff check` and `git diff --check` passed.

## Compatibility and risk
- Gateway `PUT` and `DELETE /openapi/v1/bots/{bot_id}/skill-sets/{set_id}/skills/{skill_id}` remain unchanged; each invokes the batch-of-one Service API.
- Legacy BFF `POST /api/skillsets/{id}/skills` retains its batch and partial-success response shape.
- Legacy BFF `DELETE /api/skillsets/{id}/skills/{skill_id}` keeps its response and missing-member 404 behavior.
- No new public batch-delete Router is introduced.
- Service API consumers in this repository were migrated from singular to batch membership commands.