### PR TITLE
refactor(backend): drop name field from teclaw default MCP entries

### DIFF
--- a/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
@@ -47,20 +47,23 @@ _DEFAULT_MCP_SERVERS_BY_ENGINE: Dict[str, List[dict]] = {
     ],
     "moltis": [],
     "teclaw": [
-        {"server_code": "mcp.ant.lwawchat.cogmessagemcp", "name": "蚂蚁钉协作群消息相关-MCP服务"},
-        {"server_code": "mcp.ant.antdingopenapi.antdingreportmcpserver", "name": "蚂蚁钉日志服务"},
-        {"server_code": "mcp.ant.antdingopenapi.antdinggroupmcpserver", "name": "蚂蚁钉群服务"},
-        {"server_code": "mcp.ant.lwawchat.cogdocumentmcp", "name": "蚂蚁钉协作群文档相关-MCP服务"},
-        {"server_code": "mcp.ant.antdingopenapi.antdingeventmcpserver", "name": "蚂蚁钉日程相关-MCP服务"},
-        {"server_code": "mcp.ant.antdingopenapi.antdingrobotmcpserver", "name": "蚂蚁钉机器人相关-MCP服务"},
-        {"server_code": "mcp.ant.antdingopenapi.antdingmessagemcpserver", "name": "蚂蚁钉消息相关-MCP服务"},
-        {"server_code": "mcp.ant.antdingopenapi.antdingtodomcpserver", "name": "蚂蚁钉待办服务"},
-        {"server_code": "mcp.ant.faas.skylarkmcpserver.skylarkmcpserver", "name": "语雀 MCP"},
-        {"server_code": "mcp.ant.arkai.dimamcpserver", "name": "Dima-MCP服务"},
-        {"server_code": "mcp.ant.homistudio.recordmcp", "name": "会中会话记录查询服务"},
-        {"server_code": "mcp.ant.rpc.dcanttouch.adminservice", "name": "行政小宝MCP服务"},
+        {"server_code": "mcp.ant.lwawchat.cogmessagemcp"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingreportmcpserver"},
+        {"server_code": "mcp.ant.antdingopenapi.antdinggroupmcpserver"},
+        {"server_code": "mcp.ant.lwawchat.cogdocumentmcp"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingeventmcpserver"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingrobotmcpserver"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingmessagemcpserver"},
+        {"server_code": "mcp.ant.antdingopenapi.antdingtodomcpserver"},
+        {"server_code": "mcp.ant.faas.skylarkmcpserver.skylarkmcpserver"},
+        {"server_code": "mcp.ant.arkai.dimamcpserver"},
+        {"server_code": "mcp.ant.homistudio.recordmcp"},
+        {"server_code": "mcp.ant.rpc.dcanttouch.adminservice"},
         # Local/stdio; resolved through LocalMCPRegistry, not MCP Center. Kept
-        # last to match the other engines' lists.
+        # last to match the other engines' lists, and the only entry here that
+        # still carries a ``name``: the codes above are catalogued upstream, so
+        # their display label comes from MCP Center, while this one has no
+        # catalogue entry to be named from.
         {"server_code": "hitl", "name": "HITL"},
     ],
     "claude_code": [


### PR DESCRIPTION
## Problem

`_DEFAULT_MCP_SERVERS_BY_ENGINE` in `src/backend/src/agentclaw/community/core/mcp/services/_defaults.py` holds one roster per engine, and teclaw is the odd one out in shape:

- `openclaw` / `hermes` — `server_code` only
- `claude_code` / `aicoding` — `server_code` + `name` + `description`
- `teclaw` — `server_code` + a bare `name`, on every entry

The hardcoded names are display labels for codes that MCP Center already catalogues, so they are a second copy of upstream metadata that nothing keeps in sync — a renamed MCP shows its old name to teclaw bots only.

## Solution

Drop `name` from the twelve MCP Center-hosted teclaw entries, leaving `server_code` alone as in the openclaw/hermes rosters. Their display labels now resolve from the catalogue like every other engine's.

The local/stdio `hitl` entry keeps `name: "HITL"`: it is not in MCP Center, so there is no catalogue entry for a label to come from. The list comment says so, next to the existing note on why the entry sits last.

No caller changes. `get_default_mcp_config` returns the config dict whether or not it declares a name, and consumers already fall back to a code-derived label on the openclaw/hermes path — `default_cfg.get("name") or code.split(".")[-1]` in `skill_set_service.get_set_mcp_servers`, `config.get("name") or server_code` elsewhere.

## Validation

Run in this environment against the rebased branch tip:

- `pytest tests/community/core/mcp tests/community/core/skill_center` — 1108 passed, 25 skipped
- `pytest tests/community/core/service_bot` — 979 passed, 2 failed

The two failures are `test_bot_build_service_skill_artifact.py::test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_write_nfs[openclaw|claude_code]`; both reproduce identically on a clean tree (`git stash`), so they are not from this change.

Dependencies had to be installed from pypi.org rather than the pinned lockfile — the mirror the lock points at is unreachable from this environment — so the runs above used freshly resolved versions rather than exact locked ones. `uv.lock` was not modified.

## Compatibility and risk

Data shape only, no schema or contract change: the affected entries lose a key that the read paths already treat as optional. Teclaw default MCPs previously rendered with the roster's hardcoded Chinese names; they now render with whatever MCP Center returns for the same codes. Rollback is reverting the commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_015Lq55kCZP9KvhMuUbWj6YJ)_