### PR TITLE
refactor(backend): route SkillCenter market through Gateway

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/market/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/market/router.py
@@ -11,6 +11,7 @@ from agentclaw.community.adapters.http.openapi_v1.contracts import (
 from agentclaw.community.adapters.http.openapi_v1.dependencies import require_principal
 from agentclaw.community.adapters.http.openapi_v1.mcp.router import _to_server_detail
 from agentclaw.community.adapters.http.openapi_v1.responses import (
+    SkillCenterMarketplaceUnavailableError,
     envelope,
     envelope_errors,
     page,
@@ -20,13 +21,20 @@ from agentclaw.community.api.skill_market_service import (
     SkillMarketSearchQuery,
     SkillMarketServiceProtocol,
 )
+from agentclaw.community.api.skill_center_gateway_service import (
+    SkillCenterGatewayServiceProtocol,
+)
 from agentclaw.community.core.mcp.config_flow import list_marketplace_servers
 from agentclaw.community.core.mcp.presentation import ALLOWED_NETWORK_TYPES
 from agentclaw.community.core.mcp.presentation import strip_ext_info
 from agentclaw.community.di import Injected
-from agentclaw.community.plugin_api.skill_center_client import (
-    SkillCenterClient,
-    SkillCenterMarketSearchRequest as SkillCenterPluginSearchRequest,
+from agentclaw.community.plugin_api.skill_center_gateway import (
+    SkillCenterBelongTo,
+    SkillCenterGatewayError,
+    SkillCenterPublicSkillSearchRequest,
+    SkillCenterSkill,
+    SkillCenterSortOrder,
+    SkillCenterTag as GatewaySkillCenterTag,
 )
 
 from .schemas import (
@@ -34,14 +42,70 @@ from .schemas import (
     McpMarketSearchRequest,
     SkillCenterMarketItem,
     SkillCenterMarketSearchRequest,
-    SkillCenterTag,
+    SkillCenterTag as SkillCenterTagResponse,
     SkillMarketItem,
     SkillMarketSearchRequest,
 )
 from agentclaw.community.adapters.http.openapi_v1.authorization import PublicAPIRoute
 
-router = APIRouter(prefix="/openapi/v1/bots/market", tags=["market"], route_class=PublicAPIRoute)
+router = APIRouter(
+    prefix="/openapi/v1/bots/market",
+    tags=["market"],
+    route_class=PublicAPIRoute,
+)
 _AUTH = [Depends(require_principal)]
+
+
+def _to_skill_center_market_item(skill: SkillCenterSkill) -> SkillCenterMarketItem:
+    optional_fields = {
+        "creatorId": skill.creator_id,
+        "latestVersionNumber": skill.latest_version_number,
+        "officialVersionNumber": skill.official_version_number,
+        "updatedAt": skill.updated_at,
+        "iconUrl": skill.icon_url,
+        "ownerName": skill.owner_name,
+        "homepageUrl": skill.homepage_url,
+        "officeDownloadUrl": skill.office_download_url,
+        "intranetDownloadUrl": skill.intranet_download_url,
+        "sha256": skill.sha256,
+        "favoriteCount": skill.favorite_count,
+        "downloadCount": skill.download_count,
+        "isOfficial": skill.is_official,
+        "isRecommended": skill.is_recommended,
+        "isTest": skill.is_test,
+        "antcodeUrl": skill.antcode_url,
+    }
+    payload: dict[str, object] = {
+        "skillId": skill.skill_id,
+        "skillCode": skill.skill_code,
+        "skillName": skill.skill_name,
+        "description": skill.description,
+        "creatorName": skill.creator_name,
+        "creatorWorkNo": skill.creator_work_no,
+        "accessLevel": skill.access_level.value,
+        "belongTo": skill.belong_to.value if skill.belong_to is not None else None,
+        "tagList": list(skill.tags),
+    }
+    payload.update(
+        {key: value for key, value in optional_fields.items() if value is not None}
+    )
+    if skill.network_types:
+        payload["networkTypes"] = list(skill.network_types)
+    return SkillCenterMarketItem.model_validate(payload)
+
+
+def _to_skill_center_tag(tag: GatewaySkillCenterTag) -> SkillCenterTagResponse:
+    return SkillCenterTagResponse.model_validate(
+        {
+            "id": int(tag.tag_id),
+            "name": tag.name,
+            "description": tag.description,
+            "iconUrl": tag.icon_url,
+            "parentId": int(tag.parent_id) if tag.parent_id is not None else None,
+            "tagLevel": tag.level,
+            "children": [_to_skill_center_tag(child) for child in tag.children],
+        }
+    )
 
 
 @router.post(
@@ -125,40 +189,52 @@ async def search_mcp_servers(
 async def search_skill_center_skills(
     body: SkillCenterMarketSearchRequest,
     request: Request,
-    client: SkillCenterClient = Injected(SkillCenterClient),
+    service: SkillCenterGatewayServiceProtocol = Injected(
+        SkillCenterGatewayServiceProtocol
+    ),
 ) -> Envelope[Page[SkillCenterMarketItem]]:
     """Search public Skill Center Skills using server-managed credentials."""
-    result = client.search_market_skills(
-        SkillCenterPluginSearchRequest(
-            keyword=body.keyword,
-            page_num=body.page_num,
-            page_size=body.page_size,
-            is_official=body.is_official,
-            is_recommended=body.is_recommended,
-            tag_list=tuple(body.tag_list),
-            sort_by=body.sort_by,
-            creator_name=body.creator_name,
-            creator_work_no=body.creator_work_no,
-            team_id=None,
-            access_level="PUBLIC",
-            belong_to=body.belong_to,
+    try:
+        result = service.search_public_skills(
+            SkillCenterPublicSkillSearchRequest(
+                keyword=body.keyword,
+                page_num=body.page_num,
+                page_size=body.page_size,
+                official_only=body.is_official,
+                recommended_only=body.is_recommended,
+                tags=tuple(body.tag_list),
+                sort_by=SkillCenterSortOrder(body.sort_by),
+                creator_name=body.creator_name,
+                creator_work_no=body.creator_work_no,
+                belong_to=(
+                    SkillCenterBelongTo(body.belong_to)
+                    if body.belong_to is not None
+                    else None
+                ),
+            )
         )
-    )
-    items = [SkillCenterMarketItem.model_validate(item) for item in result.items]
+    except SkillCenterGatewayError as exc:
+        raise SkillCenterMarketplaceUnavailableError from exc
+    items = [_to_skill_center_market_item(item) for item in result.items]
     return page(result.total, items, request)
 
 
 @router.get(
     "/skill-center/tags",
-    response_model=Envelope[list[SkillCenterTag]],
+    response_model=Envelope[list[SkillCenterTagResponse]],
     dependencies=_AUTH,
 )
 @envelope_errors
 async def list_skill_center_tags(
     request: Request,
-    client: SkillCenterClient = Injected(SkillCenterClient),
-) -> Envelope[list[SkillCenterTag]]:
+    service: SkillCenterGatewayServiceProtocol = Injected(
+        SkillCenterGatewayServiceProtocol
+    ),
+) -> Envelope[list[SkillCenterTagResponse]]:
     """List Skill Center tags for marketplace filter initialization."""
-    result = client.get_market_tags()
-    items = [SkillCenterTag.model_validate(item) for item in result]
+    try:
+        result = service.list_public_tags()
+    except SkillCenterGatewayError as exc:
+        raise SkillCenterMarketplaceUnavailableError from exc
+    items = [_to_skill_center_tag(item) for item in result]
     return envelope(items, request)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -280,8 +280,11 @@ from agentclaw.community.plugin_api.skill_center_client import (
     SkillCenterPublishStatusError,
     SkillCenterTeamCreateError,
 )
-
 T = TypeVar("T")
+
+
+class SkillCenterMarketplaceUnavailableError(RuntimeError):
+    """A public Skill Center marketplace read could not be served."""
 
 
 def _trace_id(request: Request) -> str:
@@ -374,6 +377,10 @@ ENVELOPE_ERRORS: dict[type[Exception], tuple[int, str]] = {
         SpacePublicErrorMessage.SKILL_CENTER_TEAM_CREATE_FAILED,
     ),
     SkillCenterMarketSearchError: (502, "Skill Center marketplace unavailable"),
+    SkillCenterMarketplaceUnavailableError: (
+        502,
+        "Skill Center marketplace unavailable",
+    ),
     SkillCenterPublishStatusError: (502, "Skill Center publish status unavailable"),
     # Staff directory infra failure (master-data service unreachable/errored).
     # 502, not 200-null: "directory down" must stay distinct from "no dept" so an

--- a/src/backend/src/agentclaw/community/api/README.md
+++ b/src/backend/src/agentclaw/community/api/README.md
@@ -119,6 +119,7 @@ internal_dependencies:
   - agentclaw.community.kernel.device_dto            # OutBoundOperationRule — typed in baas_service.py Protocol (B6)
   - agentclaw.community.plugin_api.auth              # AuthRequestContext — typed in caller_iam_token_service.py
   - agentclaw.community.plugin_api.passport          # PassportPlugin — typed in caller_identity_service.py
+  - agentclaw.community.plugin_api.skill_center_gateway # Public catalogue request/result DTOs typed in skill_center_gateway_service.py
 ```
 
 ### Change impact

--- a/src/backend/src/agentclaw/community/api/skill_center_gateway_service.py
+++ b/src/backend/src/agentclaw/community/api/skill_center_gateway_service.py
@@ -1,0 +1,22 @@
+"""Service API for validated public Skill Center catalogue reads."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.plugin_api.skill_center_gateway import (
+    SkillCenterPublicSkillSearchRequest,
+    SkillCenterSkillPage,
+    SkillCenterTag,
+)
+
+
+@runtime_checkable
+class SkillCenterGatewayServiceProtocol(Protocol):
+    """Public catalogue subset consumed by HTTP delivery adapters."""
+
+    def search_public_skills(
+        self, request: SkillCenterPublicSkillSearchRequest
+    ) -> SkillCenterSkillPage: ...
+
+    def list_public_tags(self) -> tuple[SkillCenterTag, ...]: ...

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_protocols.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_protocols.py
@@ -9,6 +9,9 @@ from agentclaw.community.api.runtime_layout_probe_service import RuntimeLayoutPr
 from agentclaw.community.api.skill_auth_service import SkillAuthServiceProtocol
 from agentclaw.community.api.skill_batch_sync_service import SkillBatchSyncServiceProtocol
 from agentclaw.community.api.skill_center_sync_service import SkillCenterSyncServiceProtocol
+from agentclaw.community.api.skill_center_gateway_service import (
+    SkillCenterGatewayServiceProtocol,
+)
 from agentclaw.community.api.skill_member_service import SkillMemberServiceProtocol
 from agentclaw.community.api.skill_parameter_service_factory import SkillParameterServiceFactoryProtocol
 from agentclaw.community.api.skill_propagation_service import SkillPropagationServiceProtocol
@@ -26,6 +29,9 @@ from agentclaw.community.core.skill_center.services.runtime_layout_probe import 
 from agentclaw.community.core.skill_center.services.skill_auth_service import SkillAuthService
 from agentclaw.community.core.skill_center.services.skill_batch_sync_service import SkillBatchSyncService
 from agentclaw.community.core.skill_center.services.skill_center_sync_service import SkillCenterSyncService
+from agentclaw.community.core.skill_center.services import (
+    skill_center_gateway_service,
+)
 from agentclaw.community.core.skill_center.services.skill_member_service import SkillMemberService
 from agentclaw.community.core.skill_center.services.skill_propagation_service import SkillPropagationService
 from agentclaw.community.core.skill_center.services.skill_publish_service import SkillPublishService
@@ -57,6 +63,14 @@ class SkillCenterProtocolBindings:
     @provider
     @inject
     def _skill_center_sync_service_protocol(self, svc: SkillCenterSyncService) -> SkillCenterSyncServiceProtocol:
+        return svc
+
+    @singleton
+    @provider
+    @inject
+    def _skill_center_gateway_service_protocol(
+        self, svc: skill_center_gateway_service.SkillCenterGatewayService
+    ) -> SkillCenterGatewayServiceProtocol:
         return svc
 
     @singleton
@@ -106,4 +120,3 @@ class SkillCenterProtocolBindings:
     @inject
     def _skill_set_service_factory_protocol(self, svc: SkillSetServiceFactory) -> SkillSetServiceFactoryProtocol:
         return svc
-

--- a/src/backend/tests/community/adapters/http/openapi_v1/market/test_market_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/market/test_market_contract.py
@@ -12,9 +12,23 @@ from agentclaw.community.api.skill_market_service import (
     SkillMarketSearchResult,
     SkillMarketServiceProtocol,
 )
-from agentclaw.community.plugin_api.skill_center_client import (
-    SkillCenterClient,
-    SkillCenterMarketSearchResult,
+from agentclaw.community.api.skill_center_gateway_service import (
+    SkillCenterGatewayServiceProtocol,
+)
+from agentclaw.community.core.skill_center.services import (
+    skill_center_gateway_service as gateway_service,
+)
+from agentclaw.community.plugin_api.skill_center_gateway import (
+    SkillCenterAccessLevel,
+    SkillCenterBelongTo,
+    SkillCenterGateway,
+    SkillCenterGatewayError,
+    SkillCenterGatewayErrorCode,
+    SkillCenterPublicSkillSearchRequest,
+    SkillCenterSkill,
+    SkillCenterSkillPage,
+    SkillCenterSortOrder,
+    SkillCenterTag,
 )
 
 
@@ -83,39 +97,44 @@ class _SkillCenter:
     def __init__(self) -> None:
         self.request = None
 
-    def search_market_skills(self, request):
+    def search_public_skills(
+        self, request: SkillCenterPublicSkillSearchRequest
+    ) -> SkillCenterSkillPage:
         self.request = request
-        return SkillCenterMarketSearchResult(
+        return SkillCenterSkillPage(
             total=1,
+            page_num=request.page_num,
+            page_size=request.page_size,
             items=(
-                {
-                    "skillCode": "sc-calendar",
-                    "skillName": "SC Calendar",
-                    "accessLevel": "PUBLIC",
-                },
+                SkillCenterSkill(
+                    skill_id="7",
+                    skill_code="sc-calendar",
+                    skill_name="SC Calendar",
+                    description="Manage Skill Center calendars",
+                    access_level=SkillCenterAccessLevel.PUBLIC,
+                    belong_to=SkillCenterBelongTo.TEAM,
+                    tags=("office",),
+                    latest_version_number="2.0.0",
+                    is_official=True,
+                ),
             ),
         )
 
-    def get_market_tags(self):
-        return [
-            {
-                "id": 1,
-                "name": "研发效能",
-                "description": None,
-                "iconUrl": None,
-                "parentId": None,
-                "tagLevel": 1,
-                "children": [
-                    {
-                        "id": 2,
-                        "name": "代码质量",
-                        "parentId": 1,
-                        "tagLevel": 2,
-                        "children": [],
-                    }
-                ],
-            }
-        ]
+    def list_public_tags(self) -> tuple[SkillCenterTag, ...]:
+        return (
+            SkillCenterTag(
+                tag_id="1",
+                name="研发效能",
+                children=(
+                    SkillCenterTag(
+                        tag_id="2",
+                        name="代码质量",
+                        parent_id="1",
+                        level=2,
+                    ),
+                ),
+            ),
+        )
 
 
 class _Bindings(Module):
@@ -127,7 +146,11 @@ class _Bindings(Module):
     def configure(self, binder) -> None:
         binder.bind(SkillMarketServiceProtocol, to=self.skill)
         binder.bind(MCPMarketServiceProtocol, to=self.mcp)
-        binder.bind(SkillCenterClient, to=self.sc)
+        binder.bind(SkillCenterGateway, to=self.sc)
+        binder.bind(
+            SkillCenterGatewayServiceProtocol,
+            to=gateway_service.SkillCenterGatewayService(self.sc),
+        )
 
 
 def _client():
@@ -280,17 +303,37 @@ def test_skill_center_market_forces_public_scope_and_hides_team_id():
             "pageSize": 10,
             "tagList": ["office"],
             "sortBy": "heat",
+            "isOfficial": True,
+            "isRecommended": False,
+            "creatorName": "Alice",
             "creatorWorkNo": "10001",
+            "belongTo": "TEAM",
         },
     )
 
     assert response.status_code == 200
     assert sc.request.page_num == 2
     assert sc.request.page_size == 10
-    assert sc.request.tag_list == ("office",)
-    assert sc.request.team_id is None
-    assert sc.request.access_level == "PUBLIC"
-    assert response.json()["data"]["items"][0]["skillCode"] == "sc-calendar"
+    assert sc.request.tags == ("office",)
+    assert sc.request.sort_by is SkillCenterSortOrder.HEAT
+    assert sc.request.official_only is True
+    assert sc.request.recommended_only is False
+    assert sc.request.creator_name == "Alice"
+    assert sc.request.creator_work_no == "10001"
+    assert sc.request.belong_to is SkillCenterBelongTo.TEAM
+    assert response.json()["data"]["items"][0] == {
+        "skillId": "7",
+        "skillCode": "sc-calendar",
+        "skillName": "SC Calendar",
+        "description": "Manage Skill Center calendars",
+        "creatorName": None,
+        "creatorWorkNo": None,
+        "accessLevel": "PUBLIC",
+        "belongTo": "TEAM",
+        "tagList": ["office"],
+        "latestVersionNumber": "2.0.0",
+        "isOfficial": True,
+    }
 
     request_schema = client.app.openapi()["components"]["schemas"][
         "SkillCenterMarketSearchRequest"
@@ -315,18 +358,10 @@ def test_skill_center_market_rejects_caller_supplied_team_id():
 
 
 def test_skill_center_tags_normalizes_null_children_to_empty_lists():
-    tag = {
-        "id": 1,
-        "name": "研发效能",
-        "description": None,
-        "iconUrl": None,
-        "parentId": None,
-        "tagLevel": 1,
-        "children": None,
-    }
+    tag = SkillCenterTag(tag_id="1", name="研发效能")
 
     client, _, _, sc = _client()
-    sc.get_market_tags = lambda: [tag]
+    sc.list_public_tags = lambda: (tag,)
 
     response = client.get(
         "/openapi/v1/bots/market/skill-center/tags",
@@ -367,3 +402,46 @@ def test_skill_center_tags_returns_nested_tag_tree_without_changing_search_contr
             ],
         }
     ]
+
+
+def test_skill_center_search_keeps_the_legacy_marketplace_502_envelope():
+    client, _, _, sc = _client()
+
+    def unavailable(_request):
+        raise SkillCenterGatewayError(
+            SkillCenterGatewayErrorCode.UNAVAILABLE,
+            "private upstream detail",
+        )
+
+    sc.search_public_skills = unavailable
+    response = client.post(
+        "/openapi/v1/bots/market/skill-center/skills",
+        params={"user_id": "user-1"},
+        json={},
+    )
+
+    assert response.status_code == 502
+    assert response.json()["code"] == 502000
+    assert response.json()["message"] == "Skill Center marketplace unavailable"
+    assert response.json()["data"] is None
+
+
+def test_skill_center_tags_keeps_the_legacy_marketplace_502_envelope():
+    client, _, _, sc = _client()
+
+    def unavailable():
+        raise SkillCenterGatewayError(
+            SkillCenterGatewayErrorCode.TIMEOUT,
+            "private upstream detail",
+        )
+
+    sc.list_public_tags = unavailable
+    response = client.get(
+        "/openapi/v1/bots/market/skill-center/tags",
+        params={"user_id": "user-1"},
+    )
+
+    assert response.status_code == 502
+    assert response.json()["code"] == 502000
+    assert response.json()["message"] == "Skill Center marketplace unavailable"
+    assert response.json()["data"] is None

--- a/src/backend/tests/community/architecture/test_service_api_conformance.py
+++ b/src/backend/tests/community/architecture/test_service_api_conformance.py
@@ -79,6 +79,9 @@ from agentclaw.community.api.skill_query_service import (
 from agentclaw.community.api.skill_metadata_parser import (
     SkillMetadataParserProtocol,
 )
+from agentclaw.community.api.skill_center_gateway_service import (
+    SkillCenterGatewayServiceProtocol,
+)
 from agentclaw.community.api.local_skill_upload_service import (
     LocalSkillUploadServiceProtocol,
 )
@@ -139,6 +142,9 @@ from agentclaw.community.core.skill_center.services.skill_query_service import (
     SkillQueryService,
 )
 from agentclaw.community.core.skill_center.services.skill_parser import SkillParser
+from agentclaw.community.core.skill_center.services.skill_center_gateway_service import (
+    SkillCenterGatewayService,
+)
 from agentclaw.community.core.skill_center.services.bot_runtime_projector import (
     BotRuntimeProjector,
 )
@@ -187,6 +193,7 @@ _PAIRS = [
     (BotRuntimeProjectorProtocol, BotRuntimeProjector),
     (SkillQueryServiceProtocol, SkillQueryService),
     (SkillMetadataParserProtocol, SkillParser),
+    (SkillCenterGatewayServiceProtocol, SkillCenterGatewayService),
     (LocalSkillUploadServiceProtocol, LocalSkillUploadService),
     (DirectActivationServiceProtocol, DirectActivationService),
     (LocalSkillDeleteServiceProtocol, LocalSkillDeleteService),


### PR DESCRIPTION
## Problem

The two public Skill Center marketplace routes still called the legacy, dict-based `SkillCenterClient` directly even after Avernet introduced the typed `SkillCenterGateway` and OCB implemented its Corp Adapter. This left the new product OpenAPI path outside the unified Gateway architecture and duplicated PUBLIC-scope and wire-shape assumptions in the Router.

## Solution

### Existing capability kept

- Keep both HTTP paths, methods, request fields, response fields, authorization, and admission policy unchanged.
- Keep `SkillCenterClient` and every non-market legacy caller unchanged.
- Keep the public marketplace failure contract unchanged: `HTTP 502`, `code=502000`, fixed `Skill Center marketplace unavailable` message, and no upstream detail leakage.

### Increment in this PR

- Route public Skill Center search and tags through a narrow `SkillCenterGatewayServiceProtocol` backed by the existing `SkillCenterGatewayService`.
- Translate the existing camelCase HTTP request into `SkillCenterPublicSkillSearchRequest`, including official/recommended/tags/sort/creator/`belongTo` filters.
- Translate typed Gateway Skills and nested tags back into the existing HTTP DTO, retaining all Gateway fields that the legacy forward-compatible response can expose.
- Keep PUBLIC catalogue validation in the consumer Service rather than the Router or OCB Adapter.
- Add Service API DI/signature conformance and Context Boundary metadata.
- Translate every Gateway failure back to the legacy marketplace 502 envelope.

### Explicit non-scope

- No migration of publish-status or Space-to-SC-Team binding.
- No deletion or narrowing of `SkillCenterClient`.
- No Publication, PublicReference, TrackLatest, or other speculative application services.
- No frontend implementation or frontend API document changes.
- No SkillCenter wire/auth/config implementation in Avernet; that remains in OCB #4403.

## Validation

- Backend CI gate: **15065/15065 passed**.
- Total line coverage: **87.62%**.
- Changed executable-line coverage: **34/35 = 97.14%**.
- Market, error mapping, architecture, Service API conformance, and DI focused suite: **102 passed**.
- Affected OpenAPI/market/Gateway suite: **74 passed** before the final hardening changes; final market contract: **10 passed**.
- Strict Ruff `E,W,F,C901`, compileall, and `git diff --check`: passed for changed implementation/test files.
- Generated OpenAPI comparison: both affected paths and `SkillCenterMarketSearchRequest`, `SkillCenterMarketItem`, and `SkillCenterTag` are identical to the published artifact. The repository-wide generated document has unrelated pre-existing `dev` drift, so this PR does not commit that broad artifact rewrite.
- Standards and Spec review: no remaining P0/P1/P2 findings.

## Compatibility and risk

The external HTTP contract is unchanged. Existing callers continue to use:

- `POST /openapi/v1/bots/market/skill-center/skills`
- `GET /openapi/v1/bots/market/skill-center/tags`

Community/Test profiles resolve the Local/Community Gateway implementations already present on `dev`. Corp runtime activation requires OCB #4403, followed by an OCB gitlink bump to the merge commit of this PR. Until that gitlink bump, deployed OCB continues using the legacy market route; no partial traffic switch occurs.

Rollback is the single commit in this PR; the legacy Client and its other callers remain intact.

## Spec

- `src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md`, SkillCenter Gateway boundary.
- Merged Gateway foundation #1518 and contract corrections #1654.

## Related issues

- Refs #1246.
- Runtime counterpart: [OCB #4403](https://code.alipay.com/teamclaw/ocb/pull_requests/4403).
