### PR TITLE
perf(skillset): skip non-skill plan for skill-only projection

### DIFF
--- a/src/backend/src/agentclaw/community/core/config_compose/models.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/models.py
@@ -61,8 +61,8 @@ class ComposeRequest:
     )
     """The bot's effective MCP set, when the caller already resolved it.
 
-    A whole-artifact delivery resolves this set during plan resolution
-    (``BotRuntimeProjector._build_plan``) and the composer would otherwise
+    A whole-artifact delivery resolves this set during capability-plan resolution
+    (``BotRuntimeProjector._build_capability_plan``) and the composer would otherwise
     re-read the identical set from the same database microseconds later — both
     reads go through ``collect_bot_active_mcps`` with
     ``strict_policy_context=True``, so they are contractually the same answer.

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -179,8 +179,9 @@ that way:
   transaction; nothing else re-derives those decisions.
 
 Writes go through two command services, one per scope, with identical shape —
-authorize, mutate desired state in one UoW transaction, project the complete
-runtime, compensate on failure: `SkillSetManagementService` for Set-scoped
+authorize, mutate desired state in one UoW transaction, project the runtime
+halves declared by `ProjectionScope`, compensate on failure:
+`SkillSetManagementService` for Set-scoped
 mutations (Default-Set edits become per-Bot exclusion rows) and
 `DirectActivationService` for Set-free single-capability activation, Skills
 and MCPs alike.
@@ -212,14 +213,17 @@ resolves template Default MCP context strictly; a provider failure aborts the
 projection and enters command compensation rather than becoming an empty
 Default policy.
 
-`RuntimeProjectionResolver` is the only source of a mutation/restart runtime
-snapshot. It receives Installation, active ordinary SkillSet membership,
-System Default assets and required configuration, then produces a complete
-Local/Repo/Center/MCP/CLI projection. Engine adapters receive that snapshot;
-they do not reconstruct it from Default exclusions or BFF state.
+`RuntimeProjectionResolver` is the only source of Projector snapshots.
+`resolve_skills` produces the complete Local/Repo/Center Skill half for a
+Skill-only command; `resolve` additionally receives Installation, System
+Default MCP and CLI facts and produces the complete Skill/MCP/CLI projection.
+The two results have distinct types, so an Engine Adapter cannot interpret an
+unresolved Non-Skill half as an empty final state. A whole-artifact runtime's
+existing ConfigComposer still rebuilds its persisted MCP artifact at delivery;
+CLI authorization remains an overwrite-style Passport projection.
 
 Direct activation and canonical SkillSet mutations commit desired state in the
-repository transaction and then reconcile the complete runtime projection.
+repository transaction and then reconcile the declared runtime projection.
 They do not acquire `SkillsPoolEditGuard`: Pool editing is a file-corpus and
 layout-migration concern, retained only by Local package upload/replacement/
 deletion and Pool cutover/rollback paths. Phase 1 intentionally has no

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
@@ -10,6 +10,7 @@ from typing import Optional, Protocol, runtime_checkable
 from agentclaw.community.core.skill_center.runtime_resolver import (
     RegisteredSkillAsset,
     RuntimeProjection,
+    RuntimeSkillProjection,
 )
 from agentclaw.community.core.skills_pool.models import PoolSkillMapping
 
@@ -62,13 +63,12 @@ class CapabilityRuntimeBoundary(Protocol):
 
 
 @dataclass(frozen=True, slots=True)
-class ResolvedCapabilityPlan:
-    """One Bot's desired capability state, resolved and ready to apply.
+class ResolvedSkillPlan:
+    """One Bot's complete Skill state, resolved and ready to apply.
 
-    Everything read-only about a projection, gathered before anything is
-    written: the flush has run, the pre-flight checks have passed, and the
-    values below cannot change under the write that follows. A projection that
-    aborts does so while building this, with nothing half-applied behind it.
+    The Installation flush, Skill validation, and mapping resolution have all
+    completed before this value crosses the engine seam. It deliberately says
+    nothing about MCP, CLI, or Passport state.
 
     It exists as a value rather than a tuple because it crosses a seam — an
     ``EngineRuntimeProjection`` acts from the plan alone — and a positional
@@ -88,9 +88,22 @@ class ResolvedCapabilityPlan:
     #: ``ac_bots.active_engine`` — the registry key. Whose runtime contract
     #: applies is decided from this and nothing else.
     engine: str
-    #: The deduplicated Skill/MCP/CLI snapshot to converge the runtime on.
+    #: The complete Skill half. It is a distinct type from RuntimeProjection,
+    #: so an engine cannot mistake omitted Non-Skill state for an empty final
+    #: MCP/CLI snapshot.
+    projection: RuntimeSkillProjection
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedCapabilityPlan(ResolvedSkillPlan):
+    """One Bot's complete Skill/MCP/CLI state, resolved before any write."""
+
+    #: The complete engine-neutral projection. This field deliberately narrows
+    #: the base type: a ResolvedCapabilityPlan can always satisfy a Skill-only
+    #: consumer, while its MCP consumers receive a genuine full snapshot.
     projection: RuntimeProjection
-    #: Effective Default CLI facts, as the authorization service holds them.
+    #: Effective Default CLI facts, as the authorization service holds them,
+    #: ready for the overwrite-style Passport update.
     effective_cli_items: list[dict]
     #: The Bot's effective MCP set — default policy ∪ installed ∪ Skill
     #: dependencies — as ``collect_bot_active_mcps`` resolved it for the
@@ -147,7 +160,7 @@ class EngineRuntimeProjection(Protocol):
     async def apply(
         self,
         *,
-        plan: ResolvedCapabilityPlan,
+        plan: ResolvedSkillPlan,
         scope: ProjectionScope,
         retired_mappings: Sequence[PoolSkillMapping] = (),
     ) -> None:
@@ -155,7 +168,9 @@ class EngineRuntimeProjection(Protocol):
 
         Raises ``SkillSetRuntimeReconcileError`` if it did not converge, so
         the caller can compensate. How many runtime calls that took, and in
-        what order, is decided here and is not observable to the caller.
+        what order, is decided here and is not observable to the caller. MCP
+        writers require ``ResolvedCapabilityPlan``; Skill-only writers accept
+        the narrower ``ResolvedSkillPlan``.
         """
         ...
 
@@ -288,7 +303,11 @@ class BotRuntimeProjectorProtocol(Protocol):
         owner_id: str,
         scope: ProjectionScope,
     ) -> None:
-        """Project MCP/CLI while an external authority owns Skill mappings."""
+        """Project MCP/CLI while an external authority owns Skill mappings.
+
+        ``scope.mcp`` must be true; callers cannot use this entry point to
+        smuggle a Skill-only projection around the normal ``project`` seam.
+        """
         ...
 
 
@@ -298,4 +317,5 @@ __all__ = [
     "EngineRuntimeProjection",
     "ProjectionScope",
     "ResolvedCapabilityPlan",
+    "ResolvedSkillPlan",
 ]

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_resolver.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_resolver.py
@@ -1,10 +1,11 @@
-"""Resolve one complete, transport-independent Skill/MCP runtime projection.
+"""Resolve typed, transport-independent Skill and Skill/MCP projections.
 
 The resolver is deliberately a pure domain service.  Its only input is the
 already-authorized desired state: active Installation assets, active normal
 SkillSet members, System Defaults, and the MCP/CLI facts those inputs select.
 It neither reads legacy Default exclusions nor treats a runtime result as
-desired state.
+desired state. ``resolve_skills`` returns the complete Skill half;
+``resolve`` returns the complete Skill/MCP/CLI snapshot.
 """
 
 from __future__ import annotations
@@ -39,11 +40,17 @@ class RuntimeDesiredState:
 
 
 @dataclass(frozen=True, slots=True)
-class RuntimeProjection:
-    """Engine-neutral full snapshot; adapters must apply it as a whole."""
+class RuntimeSkillProjection:
+    """Engine-neutral Skill snapshot used by a Skill-only projection."""
 
     skill_mappings: tuple[PoolSkillMapping, ...]
     skill_assets: tuple[RegisteredSkillAsset, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeProjection(RuntimeSkillProjection):
+    """Engine-neutral full snapshot; adapters must apply it as a whole."""
+
     mcp_server_codes: tuple[str, ...]
     cli_commands: tuple[str, ...]
 
@@ -92,10 +99,13 @@ def resolve_effective_mcp_server_codes(
 class RuntimeProjectionResolver:
     """Build the deduplicated Local/Repo/Center/MCP/CLI snapshot."""
 
-    def resolve(self, state: RuntimeDesiredState) -> RuntimeProjection:
+    def resolve_skills(
+        self, skills: tuple[RegisteredSkillAsset, ...]
+    ) -> RuntimeSkillProjection:
+        """Build the complete Skill half without inventing Non-Skill state."""
         # Validate all names before mapping so unsupported/ambiguous desired
         # state cannot be partially delivered by an Engine Adapter.
-        assets = tuple(state.skills)
+        assets = tuple(skills)
         for asset in assets:
             RuntimeNamePolicy.name_for(asset)
             if not asset.git_path.startswith(("local://", "git://", "center://")):
@@ -104,9 +114,16 @@ class RuntimeProjectionResolver:
             mappings = build_logical_skill_mappings(list(assets))
         except RuntimeMappingNameConflictError as exc:
             raise RuntimeNameConflictError() from exc
-        return RuntimeProjection(
+        return RuntimeSkillProjection(
             skill_mappings=tuple(mappings),
             skill_assets=assets,
+        )
+
+    def resolve(self, state: RuntimeDesiredState) -> RuntimeProjection:
+        skills = self.resolve_skills(state.skills)
+        return RuntimeProjection(
+            skill_mappings=skills.skill_mappings,
+            skill_assets=skills.skill_assets,
             mcp_server_codes=resolve_effective_mcp_server_codes(state),
             cli_commands=tuple(dict.fromkeys(state.system_default_cli_commands)),
         )
@@ -118,5 +135,6 @@ __all__ = [
     "RuntimeNamePolicy",
     "RuntimeProjection",
     "RuntimeProjectionResolver",
+    "RuntimeSkillProjection",
     "resolve_effective_mcp_server_codes",
 ]

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
@@ -30,6 +30,7 @@ from agentclaw.community.core.skill_center.factories import SkillSetServiceFacto
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     ProjectionScope,
     ResolvedCapabilityPlan,
+    ResolvedSkillPlan,
 )
 from agentclaw.community.core.skill_center.services.runtime_projections.registry import (
     EngineRuntimeProjectionRegistry,
@@ -37,9 +38,6 @@ from agentclaw.community.core.skill_center.services.runtime_projections.registry
 from agentclaw.community.core.skill_center.runtime_resolver import (
     RuntimeDesiredState,
     RuntimeProjectionResolver,
-)
-from agentclaw.community.core.skills_pool.mapping_intent import (
-    build_logical_skill_mappings,
 )
 from agentclaw.community.core.skills_pool.models import PoolSkillMapping
 from agentclaw.community.log import get_logger
@@ -57,12 +55,13 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
     runtime contract selection, full mapping publication, MCP delivery, and the
     overwrite-style Passport MCP/CLI manifest.
 
-    Resolving and applying are separated by the ``ProjectionScope``: the plan
-    is always built whole — it is read-only, and every pre-flight failure in it
-    must happen before anything is written — while the scope decides which
-    halves are *written*. Keeping the reads unconditional is what lets a
-    projection abort cleanly, with nothing half-applied for a compensation to
-    unpick.
+    Resolving and applying are separated by the ``ProjectionScope``. The
+    Skill state is always resolved into ``ResolvedSkillPlan``, including its
+    Installation flush and engine validation. MCP/CLI/Passport pre-flight is
+    added only when the scope can write that half, producing the stricter
+    ``ResolvedCapabilityPlan``. A whole-artifact runtime independently
+    composes its retained MCP state from DB during its one delivery; CLI
+    authorization remains in Passport.
     """
 
     @inject
@@ -113,7 +112,9 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         self._registry.for_engine(engine).validate_plan(
             skill_assets=skill_assets
         )
-        return tuple(build_logical_skill_mappings(skill_assets))
+        return RuntimeProjectionResolver().resolve_skills(
+            tuple(skill_assets)
+        ).skill_mappings
 
     async def project(
         self,
@@ -127,7 +128,12 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
             bot_id=bot_id,
             owner_id=owner_id,
             retired_mappings=retired_mappings,
+            scope=scope,
         )
+        if scope.mcp and not isinstance(plan, ResolvedCapabilityPlan):
+            # Contract guard before any engine write: an MCP scope must never
+            # cross the seam with a Skill-only plan.
+            raise SkillSetRuntimeReconcileError()
         # How a runtime consumes a projection — how many calls converging takes,
         # and whether the scope's halves mean anything to it at all — is the
         # engine's fact, so the engine's own implementation answers it. Nothing
@@ -141,6 +147,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         # platform's authorization record, the same for every engine. Its
         # trigger is unchanged.
         if scope.mcp:
+            assert isinstance(plan, ResolvedCapabilityPlan)
             self._apply_passport_projection(plan=plan)
         else:
             logger.info(
@@ -163,33 +170,46 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         ``skills`` flag is false already says exactly that — so no separate
         entry point into the engine's projection is needed.
         """
+        if not scope.mcp:
+            raise ValueError("project_mcp_and_cli requires scope.mcp=True")
         plan = self._resolve_plan(
             bot_id=bot_id,
             owner_id=owner_id,
+            scope=scope,
         )
+        assert isinstance(plan, ResolvedCapabilityPlan)
         await self._registry.for_engine(plan.engine).apply(
             plan=plan,
             scope=scope,
         )
-        if scope.mcp:
-            self._apply_passport_projection(plan=plan)
+        self._apply_passport_projection(plan=plan)
 
     def _resolve_plan(
         self,
         *,
         bot_id: str,
         owner_id: str,
+        scope: ProjectionScope,
         retired_mappings: Sequence[PoolSkillMapping] = (),
-    ) -> ResolvedCapabilityPlan:
+    ) -> ResolvedSkillPlan:
         bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
         if bot is None:
             raise LocalSkillNotFoundError()
-        return self._build_plan(
+        skill_plan = self._build_skill_plan(
             bot=bot,
             bot_id=bot_id,
             owner_id=owner_id,
             retired_mappings=retired_mappings,
         )
+        if not scope.mcp:
+            logger.info(
+                "[BotRuntimeProjector] Non-Skill plan skipped for Skill-only "
+                "scope: bot_id=%s, engine=%s",
+                bot_id,
+                skill_plan.engine,
+            )
+            return skill_plan
+        return self._build_capability_plan(skill_plan)
 
     def _resolve_mcp_identity_modes(
         self, *, bot: dict, bot_id: str, engine: str
@@ -215,14 +235,14 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         except McpIdentityUnresolvedError as exc:
             raise SkillSetRuntimeReconcileError() from exc
 
-    def _build_plan(
+    def _build_skill_plan(
         self,
         *,
         bot: dict,
         bot_id: str,
         owner_id: str,
         retired_mappings: Sequence[PoolSkillMapping] = (),
-    ) -> ResolvedCapabilityPlan:
+    ) -> ResolvedSkillPlan:
         engine = str(bot.get("active_engine") or "openclaw")
         service = self._factory.create(
             user_id=owner_id,
@@ -246,17 +266,32 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
             skill_assets=skill_assets,
             retired_mappings=retired_mappings,
         )
+        return ResolvedSkillPlan(
+            bot_id=bot_id,
+            owner_id=owner_id,
+            service=service,
+            bot=bot,
+            engine=engine,
+            projection=RuntimeProjectionResolver().resolve_skills(skill_assets),
+        )
+
+    def _build_capability_plan(
+        self, skill_plan: ResolvedSkillPlan
+    ) -> ResolvedCapabilityPlan:
+        bot = skill_plan.bot
+        bot_id = skill_plan.bot_id
+        owner_id = skill_plan.owner_id
+        engine = skill_plan.engine
+        service = skill_plan.service
         # Resolved here, with the other pre-flight checks, because it can fail:
         # doing it at the Passport call would abort after the device allow-list
-        # was already written, and the compensating projection would then hit
-        # the same failure and be unable to counter-project.
+        # was already written, and compensation would hit the same failure.
         identity_modes = self._resolve_mcp_identity_modes(
             bot=bot, bot_id=bot_id, engine=engine
         )
         # The legacy SkillSet service remains the authority for effective
-        # System Defaults during Phase 1.  It resolves template presets and
-        # applies ac_default_skillset_mcp_exclusion; rebuilding defaults from
-        # static constants here would silently resurrect user exclusions.
+        # System Defaults during Phase 1. It resolves template presets and
+        # applies ac_default_skillset_mcp_exclusion.
         try:
             effective_mcp_entries = service.collect_bot_active_mcps(
                 entity_id=str(bot.get("entity_id") or owner_id),
@@ -267,9 +302,6 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
                 strict_policy_context=True,
             )
         except Exception as exc:
-            # A failed policy-context lookup is not an empty Default policy.
-            # Fail before any overwrite-style MCP or Passport projection so a
-            # transient dependency outage cannot remove template-only MCPs.
             raise SkillSetRuntimeReconcileError() from exc
         effective_default_mcp_codes = frozenset(
             str(item.get("server_code") or item.get("serverCode") or "").strip()
@@ -277,9 +309,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
             if item.get("server_code") or item.get("serverCode")
         )
         try:
-            # CLI removal is currently persisted by the authorization service. Its
-            # current scope is therefore the only effective Default CLI fact;
-            # merging static engine defaults here would undo that removal.
+            # Passport is the authority for the effective Default CLI scope.
             effective_cli_items = self._passport.query_passport_clis(
                 bot_id, owner_id
             )
@@ -287,7 +317,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
             raise SkillSetRuntimeReconcileError() from exc
         projection = RuntimeProjectionResolver().resolve(
             RuntimeDesiredState(
-                skills=skill_assets,
+                skills=skill_plan.projection.skill_assets,
                 installed_mcp_server_codes=frozenset(
                     self._repository.list_installed_mcps(
                         bot_id=bot_id, owner_id=owner_id

--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/per_domain.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/per_domain.py
@@ -11,8 +11,9 @@ from agentclaw.community.core.skill_center.runtime_projection_contract import (
     EngineRuntimeProjection,
     ProjectionScope,
     ResolvedCapabilityPlan,
+    ResolvedSkillPlan,
 )
-from agentclaw.community.core.skill_center.runtime_resolver import RuntimeProjection
+from agentclaw.community.core.skill_center.runtime_resolver import RuntimeSkillProjection
 from agentclaw.community.core.repository.protocols.skills_pool import (
     SkillsPoolLayoutRepositoryProtocol,
 )
@@ -72,7 +73,7 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
     async def apply(
         self,
         *,
-        plan: ResolvedCapabilityPlan,
+        plan: ResolvedSkillPlan,
         scope: ProjectionScope,
         retired_mappings: Sequence[PoolSkillMapping] = (),
     ) -> None:
@@ -100,6 +101,8 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
                 plan.bot_id, plan.engine,
             )
         if scope.mcp:
+            if not isinstance(plan, ResolvedCapabilityPlan):
+                raise SkillSetRuntimeReconcileError()
             await self._apply_mcp_projection(plan=plan, scope=scope)
         else:
             logger.info(
@@ -111,7 +114,7 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
     async def _apply_skill_projection(
         self,
         *,
-        plan: ResolvedCapabilityPlan,
+        plan: ResolvedSkillPlan,
         retired_mappings: Sequence[PoolSkillMapping],
     ) -> None:
         mappings = list(plan.projection.skill_mappings)
@@ -241,7 +244,7 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
 
     @staticmethod
     def _desired_skills(
-        projection: RuntimeProjection,
+        projection: RuntimeSkillProjection,
     ) -> list[dict[str, str | None]]:
         return [
             {

--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/whole_artifact.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/whole_artifact.py
@@ -11,8 +11,9 @@ from agentclaw.community.core.skill_center.runtime_projection_contract import (
     EngineRuntimeProjection,
     ProjectionScope,
     ResolvedCapabilityPlan,
+    ResolvedSkillPlan,
 )
-from agentclaw.community.core.skill_center.runtime_resolver import RuntimeProjection
+from agentclaw.community.core.skill_center.runtime_resolver import RuntimeSkillProjection
 from agentclaw.community.core.skills_pool.models import (
     PoolSkillMapping,
     RegisteredSkillAsset,
@@ -66,7 +67,7 @@ class WholeArtifactRuntimeProjection(EngineRuntimeProjection):
     async def apply(
         self,
         *,
-        plan: ResolvedCapabilityPlan,
+        plan: ResolvedSkillPlan,
         scope: ProjectionScope,
         retired_mappings: Sequence[PoolSkillMapping] = (),
     ) -> None:
@@ -95,19 +96,18 @@ class WholeArtifactRuntimeProjection(EngineRuntimeProjection):
 
         logger.info(
             "[WholeArtifactRuntimeProjection] Delivering whole artifact: "
-            "bot_id=%s, engine=%s, skills=%s, mcps=%s",
+            "bot_id=%s, engine=%s, skills=%s, mcp_scope=%s",
             plan.bot_id,
             plan.engine,
             len(plan.projection.skill_assets),
-            len(plan.projection.mcp_server_codes),
+            scope.mcp,
         )
         # This one call is the whole delivery. Despite the name, on a
-        # whole-artifact engine ``project_skills`` does not write Skills: it
-        # resolves the device, recomposes the Bot's entire
-        # ``BotConfigArtifact`` from the database — Skills, MCP servers, CLI,
-        # credentials — and POSTs it to ``/api/v1/bot/apply``. The MCP half of
-        # this projection rides in that same document, which is why there is
-        # no second call here.
+        # whole-artifact engine ``project_skills`` does not write only Skills:
+        # it resolves the device, recomposes the BotConfigArtifact from the
+        # database — Skills, MCP servers, and credentials — and POSTs it to
+        # ``/api/v1/bot/apply``. CLI authorization remains in Passport. The
+        # MCP half rides in the same artifact, so there is no second call.
         #
         # All of that is blocking, but staying off the event loop is
         # ``project_skills``'s own responsibility — it dispatches to a thread
@@ -127,16 +127,23 @@ class WholeArtifactRuntimeProjection(EngineRuntimeProjection):
         # are derived from it — and the compose inside this call would
         # otherwise ask the same database the same question again, with
         # ``strict_policy_context=True`` on both sides making the two answers
-        # the same by contract.
+        # the same by contract. A Skill-only plan intentionally has no such
+        # value: passing ``None`` preserves ConfigComposer's database fallback
+        # without rebuilding the projector's Non-Skill plan.
+        effective_mcps = (
+            plan.effective_mcp_entries
+            if isinstance(plan, ResolvedCapabilityPlan)
+            else None
+        )
         if not await plan.service.project_skills(
             desired_skills=self._desired_skills(plan.projection),
-            effective_mcps=plan.effective_mcp_entries,
+            effective_mcps=effective_mcps,
         ):
             raise SkillSetRuntimeReconcileError()
 
     @staticmethod
     def _desired_skills(
-        projection: RuntimeProjection,
+        projection: RuntimeSkillProjection,
     ) -> list[dict[str, str | None]]:
         return [
             {

--- a/src/backend/tests/community/core/skill_center/test_runtime_resolver.py
+++ b/src/backend/tests/community/core/skill_center/test_runtime_resolver.py
@@ -7,7 +7,9 @@ import pytest
 from agentclaw.community.core.skill_center.runtime_resolver import (
     RuntimeDesiredState,
     RuntimeNameConflictError,
+    RuntimeProjection,
     RuntimeProjectionResolver,
+    RuntimeSkillProjection,
 )
 from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
 from agentclaw.community.core.workspace.skill_layout import (
@@ -50,6 +52,22 @@ def test_resolver_projects_every_supported_skill_corpus_and_deduplicates_inputs(
     ]
     assert projection.mcp_server_codes == ("mcp-a", "mcp-b", "mcp-default")
     assert projection.cli_commands == ("builtin",)
+
+
+def test_skill_projection_is_explicitly_distinct_from_the_complete_snapshot() -> None:
+    """A Skill-only plan must not masquerade as a complete RuntimeProjection."""
+    resolver = RuntimeProjectionResolver()
+    skills = (
+        RegisteredSkillAsset(skill_id=1, name="repo", git_path="git://team/repo"),
+    )
+
+    skill_projection = resolver.resolve_skills(skills)
+    complete_projection = resolver.resolve(RuntimeDesiredState(skills=skills))
+
+    assert type(skill_projection) is RuntimeSkillProjection
+    assert type(complete_projection) is RuntimeProjection
+    assert skill_projection.skill_assets == complete_projection.skill_assets
+    assert skill_projection.skill_mappings == complete_projection.skill_mappings
 
 
 def test_resolver_uses_ac_skill_name_for_local_runtime_entry_not_locator_tail() -> None:

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -659,12 +659,16 @@ class _TeclawRuntimeBots(_RuntimeBots):
 class _McpInstallations:
     def __init__(self) -> None:
         self.flush_calls: list[dict] = []
+        self.list_installed_calls: list[dict] = []
 
     def flush_installations(self, **kwargs) -> InstallationFlushPlan:
         self.flush_calls.append(kwargs)
         return InstallationFlushPlan(frozenset(), frozenset(), frozenset())
 
     def list_installed_mcps(self, *, bot_id: str, owner_id: str) -> set[str]:
+        self.list_installed_calls.append(
+            {"bot_id": bot_id, "owner_id": owner_id}
+        )
         assert bot_id == "bot-1"
         assert owner_id == "true-owner"
         return {"mcp.weather"}
@@ -763,11 +767,13 @@ class _RuntimeLayouts:
 class _RuntimePassport:
     def __init__(self) -> None:
         self.calls: list[dict] = []
+        self.query_calls: list[tuple[str, str]] = []
 
     def update_passport(self, **kwargs) -> None:
         self.calls.append(kwargs)
 
     def query_passport_clis(self, bot_id: str, owner_id: str) -> list[dict]:
+        self.query_calls.append((bot_id, owner_id))
         assert (bot_id, owner_id) == ("bot-1", "true-owner")
         # This is the effective Default CLI scope after a user removed a
         # static default. A reconcile must preserve it exactly, not revive the
@@ -2623,20 +2629,34 @@ async def test_non_skill_projection_never_writes_skill_mappings():
     assert pool.verify_calls == []
 
 
+@pytest.mark.asyncio
+async def test_non_skill_entry_rejects_a_scope_without_mcp():
+    runtime = _scoped_projector()
 
-def _teclaw_runtime(factory, *, pool=None, passport=None):
+    with pytest.raises(ValueError, match="requires scope.mcp=True"):
+        await runtime.project_mcp_and_cli(
+            bot_id="bot-1",
+            owner_id="true-owner",
+            scope=ProjectionScope(skills=True),
+        )
+
+
+
+def _teclaw_runtime(
+    factory, *, pool=None, passport=None, repository=None, identity=None
+):
     """A projector over a teclaw Bot, wired the way production wires one."""
     return BotRuntimeProjector(
         factory=factory,
         bot_repo=_TeclawRuntimeBots(),
-        repository=_McpInstallations(),
+        repository=repository or _McpInstallations(),
         reader=_reader(_TeclawRuntimeSkills()),
         registry=_registry(
             pool_runtime=pool or _RuntimePool(),
             pool_layouts=_RuntimeLayouts(),
         ),
         passport=passport or _RuntimePassport(),
-        caller_identity_repo=_RuntimeCallerIdentity(),
+        caller_identity_repo=identity or _RuntimeCallerIdentity(),
     )
 
 
@@ -2788,7 +2808,14 @@ async def test_teclaw_still_updates_the_passport_with_identity_coloured_items():
 async def test_teclaw_skill_only_scope_makes_no_passport_call():
     """No MCP change declared, no manifest write — unchanged from today."""
     passport = _RuntimePassport()
-    runtime = _teclaw_runtime(_RuntimeFactory(), passport=passport)
+    factory = _RuntimeFactory()
+    repository, identity = _McpInstallations(), _RuntimeCallerIdentity()
+    runtime = _teclaw_runtime(
+        factory,
+        passport=passport,
+        repository=repository,
+        identity=identity,
+    )
 
     await runtime.project(
         bot_id="bot-1", owner_id="true-owner",
@@ -2796,6 +2823,15 @@ async def test_teclaw_skill_only_scope_makes_no_passport_call():
     )
 
     assert passport.calls == []
+    # Teclaw still delivers exactly one full artifact, whose ConfigComposer
+    # independently reads persisted MCP/CLI state. The projector must not
+    # duplicate those reads for a Skill-only mutation.
+    assert len(factory.service.runtime_syncs) == 1
+    assert factory.service.delivered_effective_mcps == [None]
+    assert factory.service.collect_calls == []
+    assert repository.list_installed_calls == []
+    assert passport.query_calls == []
+    assert identity.calls == []
 
 
 @pytest.mark.asyncio
@@ -3414,15 +3450,17 @@ async def test_an_inactive_set_still_skips_projection_entirely():
 # already there. The scope the command declares is what decides.
 
 
-def _scoped_projector(pool=None, passport=None, factory=None):
+def _scoped_projector(
+    pool=None, passport=None, factory=None, repository=None, identity=None
+):
     return BotRuntimeProjector(
         factory=factory or _RuntimeFactory(),
         bot_repo=_RuntimeBots(),
-        repository=_McpInstallations(),
+        repository=repository or _McpInstallations(),
         reader=_reader(_RuntimeSkills()),
         registry=_registry(pool_runtime=pool or _RuntimePool(), pool_layouts=_RuntimeLayouts()),
         passport=passport or _RuntimePassport(),
-        caller_identity_repo=_RuntimeCallerIdentity(),
+        caller_identity_repo=identity or _RuntimeCallerIdentity(),
     )
 
 
@@ -3459,7 +3497,13 @@ async def test_a_skill_only_scope_touches_neither_the_device_mcps_nor_passport()
     mutation.
     """
     passport, factory = _RuntimePassport(), _RuntimeFactory()
-    runtime = _scoped_projector(passport=passport, factory=factory)
+    repository, identity = _McpInstallations(), _RuntimeCallerIdentity()
+    runtime = _scoped_projector(
+        passport=passport,
+        factory=factory,
+        repository=repository,
+        identity=identity,
+    )
 
     await runtime.project(
         bot_id="bot-1", owner_id="true-owner", scope=ProjectionScope(skills=True)
@@ -3469,6 +3513,60 @@ async def test_a_skill_only_scope_touches_neither_the_device_mcps_nor_passport()
     assert factory.service.mcp_codes is None
     assert factory.service.deliveries == []
     assert passport.calls == []
+    # No MCP mutation means no MCP/CLI read-side pre-flight either.  Those
+    # facts would only be consumed by a device-MCP write or Passport update,
+    # both of which this scope explicitly omits.
+    assert factory.service.collect_calls == []
+    assert repository.list_installed_calls == []
+    assert passport.query_calls == []
+    assert identity.calls == []
+
+
+@pytest.mark.asyncio
+async def test_projector_exposes_skill_and_complete_plan_shapes_at_the_engine_seam():
+    """The engine seam receives an honest type, never an incomplete full plan."""
+    from agentclaw.community.core.skill_center.runtime_projection_contract import (
+        EngineRuntimeProjection,
+        ResolvedCapabilityPlan,
+        ResolvedSkillPlan,
+    )
+    from agentclaw.community.core.skill_center.services.runtime_projections.registry import (
+        EngineRuntimeProjectionRegistry,
+    )
+
+    plans = []
+
+    class _RecordingProjection(EngineRuntimeProjection):
+        def validate_plan(self, *, skill_assets, retired_mappings=()) -> None:
+            return None
+
+        async def apply(self, *, plan, scope, retired_mappings=()) -> None:
+            plans.append(plan)
+
+    projection = _RecordingProjection()
+    runtime = BotRuntimeProjector(
+        factory=_RuntimeFactory(),
+        bot_repo=_RuntimeBots(),
+        repository=_McpInstallations(),
+        reader=_reader(_RuntimeSkills()),
+        registry=EngineRuntimeProjectionRegistry(default=projection),
+        passport=_RuntimePassport(),
+        caller_identity_repo=_RuntimeCallerIdentity(),
+    )
+
+    await runtime.project(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        scope=ProjectionScope(skills=True),
+    )
+    await runtime.project(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        scope=ProjectionScope(mcp=True),
+    )
+
+    assert type(plans[0]) is ResolvedSkillPlan
+    assert type(plans[1]) is ResolvedCapabilityPlan
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem
Skill-only SkillSet operations built the entire MCP, Passport, and CLI plan even though their ProjectionScope could not write that half. This added unrelated policy and authorization reads to the synchronous runtime path.

After #1670 merged into `dev`, its whole-artifact MCP handoff also assumed every plan had `effective_mcp_entries`. A Skill-only projection now deliberately carries `ResolvedSkillPlan`, so the clean Git merge would fail at runtime with `AttributeError` unless the two optimizations were composed explicitly.

## Solution
Keep ProjectionScope as the single intent source. Resolve every Skill operation into an explicit ResolvedSkillPlan backed by RuntimeSkillProjection. Only `scope.mcp=True` upgrades it to ResolvedCapabilityPlan backed by the existing complete RuntimeProjection.

Per-domain and whole-artifact engine implementations consume the common Skill plan. MCP delivery and Passport require the complete subtype. Teclaw still performs one whole-artifact delivery and independently composes persisted MCP state:

- a complete capability plan passes #1670's already-resolved `effective_mcp_entries` to avoid a duplicate read;
- a Skill-only plan passes `effective_mcps=None`, preserving ConfigComposer's database fallback without rebuilding the Projector's Non-Skill plan.

## Validation
- Red on latest `dev`: `test_teclaw_skill_only_scope_makes_no_passport_call` reproduced `AttributeError: 'ResolvedSkillPlan' object has no attribute 'effective_mcp_entries'`.
- Green integration slice: Skill-only Teclaw fallback, MCP-scope Teclaw handoff, and per-domain no-handoff tests — 3 passed.
- SkillCenter/ConfigComposer/device/contract/architecture narrow gate — 307 passed.
- Post-review affected tests — 160 passed.
- Changed-file Ruff, changed-file Python SAST, and `git diff --check` passed.
- Standards/Spec dual-axis review passed after correcting the stale `_build_plan` documentation reference.
- The local full community suite was stopped at the user's request after 1,255 passed and 2 skipped with no failures; GitHub Actions is the final full-suite authority.

## Compatibility and risk
No HTTP, database, configuration, or external Plugin API changes. RuntimeProjection remains the complete Skill/MCP/CLI snapshot contract. Skill-only commands no longer fail on unrelated MCP/Passport/identity read failures. MCP-scoped commands retain the existing fail-closed complete preflight, overwrite-style Passport update, dependency claim/release, compensation semantics, and #1670's effective-MCP reuse.

The main integration risk was the whole-artifact distinction between `ResolvedSkillPlan` and `ResolvedCapabilityPlan`; it is now covered at the public projector seam for both paths.
