### PR TITLE
feat(backend): expose template and space fields on the public bots listing

### DIFF
--- a/docs/superpowers/plans/2026-08-28-bot-template-space-fields.md
+++ b/docs/superpowers/plans/2026-08-28-bot-template-space-fields.md
@@ -1,0 +1,789 @@
+# Bot Template & Space Fields Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface `template_type`, a security-projected `template_config`, and (on `/bots`) `space` on the two bot listing endpoints `GET /openapi/v1/bots` and `GET /openapi/v1/bots/all`.
+
+**Architecture:** A pure allowlist projection in core strips secrets (`token`, `bot_template_config.ext_config` with its `enc:v1:` `thetaKey`) from `ac_templates.ext` before it reaches any public schema. The inventory service gains a template port and enriches only the **returned page slice** (the fan-out stays `attach_templates=False`). The flat bots listing resolves `space` per distinct `ac_bots.space_id` through the existing `BusinessSpaceContextProtocol` (memoized per page, same `BusinessSpace` schema shape as `/bots/all`). Two-layer model honored throughout: `engine` stays the real engine vocabulary; coding identity comes from `template_type` + projected `template_config`.
+
+**Tech Stack:** Python / FastAPI / Pydantic v2 / injector DI / pytest. Contract file `src/gateway/configs/schemas/bots.openapi.json` edited by hand (never full-regen), mirrored to `src/gateway/tests/fixtures/bots.openapi.json` if the plain diff shows coupling.
+
+**Base branch:** `origin/REL20260828` → dev branch `feat/bot-template-space-fields-REL20260828`.
+
+**Evidence anchors** (read while planning, re-verify before editing — line numbers drift):
+- `bot_service.py:_attach_template_configs_to_bots` — `template_config` is `ac_templates.ext`, batch-attached by bot_id, only for rows with `template_type`; `/bots` path default `attach_templates=True`.
+- `strategy.py:53-54` — `_THETA_KEY_PATH = ("bot_template_config","ext_config","thetaKey")`, `_ENCRYPTED_VALUE_PREFIX = "enc:v1:"`; outer contract also allows a plain `token: str`.
+- `bot_inventory_service.py:_list_cloud_rows` — fan-out passes `attach_templates=False` deliberately (comment at the call site).
+- `router.py:_to_bot` (8 call sites), `list_bots`, `_to_inventory_item`; `schemas.py:BusinessSpace / BotInventoryItem / Bot`.
+
+**Non-goals (explicit):**
+- No query filter params (`template_type=`/flavor) — wait for a real consumer.
+- No raw `template_config` on the wire — allowlist projection only; new keys enter via explicit projection additions plus security review.
+- `/bots/{bot_id}` POST-create / restart-outcome responses carry the new fields as `null` except where the row already holds template data (fields are additive and Optional).
+- No OpenAPI route additions — schemas only, so the endpoint coverage gate counts do not move.
+
+---
+
+### Task 1: Core template projection function (security seam)
+
+**Files:**
+- Create: `src/backend/src/agentclaw/community/core/bot_management/template_public_view.py`
+- Test: `src/backend/tests/community/core/bot_management/test_template_public_view.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Allowlist projection of template_config for public responses.
+
+``ac_templates.ext`` legitimately stores engine secrets (``bot_template_config
+.ext_config.thetaKey`` is an ``enc:v1:`` blob, and the stable outer contract
+allows a plain ``token``). The public listing faces must never echo them, and
+engine-owned extensions must default to "not surfaced" rather than "passed
+through" — this matrix pins that.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.bot_management.template_public_view import (
+    project_template_config_for_public,
+)
+
+
+def test_none_in_gives_none_out():
+    assert project_template_config_for_public(None) is None
+
+
+def test_empty_dict_gives_none_out():
+    assert project_template_config_for_public({}) is None
+
+
+def test_allowlisted_keys_survive():
+    config = {
+        "devflow_workflow": "release-notes",
+        "yuque_kb_repos": ["team/kb"],
+        "code_repos": ["team/svc"],
+        "template_key": "normalCC",
+        "template_uid": "tpl-1",
+    }
+    assert project_template_config_for_public(config) == config
+
+
+@pytest.mark.parametrize(
+    "secret_config",
+    [
+        {"devflow_workflow": "w", "token": "Bearer raw-secret"},
+        {
+            "devflow_workflow": "w",
+            "bot_template_config": {"ext_config": {"thetaKey": "enc:v1:deadbeef"}},
+        },
+        {"devflow_workflow": "w", "runtime": "codefuse"},
+        {"devflow_workflow": "w", "anything_engine_owned": {"nested": "blob"}},
+    ],
+)
+def test_everything_else_is_dropped(secret_config):
+    projected = project_template_config_for_public(secret_config)
+    assert projected == {"devflow_workflow": "w"}
+
+
+def test_deep_copy_not_shared_with_input():
+    config = {"devflow_workflow": "w", "yuque_kb_repos": ["a"]}
+    projected = project_template_config_for_public(config)
+    projected["yuque_kb_repos"].append("mutated")
+    assert config["yuque_kb_repos"] == ["a"]
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `cd src/backend && python -m pytest tests/community/core/bot_management/test_template_public_view.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named '...template_public_view'`
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+"""Public projection of ``ac_templates.ext`` (``template_config``).
+
+``template_config`` stored engine-side legitimately carries secrets: the
+aicoding provisioning strategy persists ``bot_template_config.ext_config
+.thetaKey`` as an ``enc:v1:`` ciphertext and the stable outer contract allows
+a plain ``token``. Listing responses must never echo either — an encrypted
+blob is still offline attack material and a replayable oracle.
+
+Rules for this file:
+- Allowlist, never denylist: engine-owned extensions surface only when a key
+  is added here explicitly (plus security review). Default is "dropped".
+- The result is a fresh shallow+container copy: callers may mutate it without
+  aliasing the stored snapshot.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+#: Keys that are display-safe. Keep alphabetized.
+_PUBLIC_TEMPLATE_KEYS = (
+    "code_repos",
+    "devflow_workflow",
+    "template_key",
+    "template_uid",
+    "yuque_kb_repos",
+)
+
+
+def project_template_config_for_public(
+    config: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Project a stored template snapshot onto its public display subset."""
+    if not isinstance(config, Mapping) or not config:
+        return None
+    if not any(key in config for key in _PUBLIC_TEMPLATE_KEYS):
+        return None
+    projected: dict[str, Any] = {}
+    for key in _PUBLIC_TEMPLATE_KEYS:
+        if key in config:
+            value = config[key]
+            if isinstance(value, list):
+                projected[key] = list(value)
+            elif isinstance(value, dict):
+                projected[key] = dict(value)
+            else:
+                projected[key] = value
+    return projected
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `cd src/backend && python -m pytest tests/community/core/bot_management/test_template_public_view.py -v`
+Expected: PASS (8-9 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/src/agentclaw/community/core/bot_management/template_public_view.py \
+        src/backend/tests/community/core/bot_management/test_template_public_view.py
+git commit -m "feat(backend): add public projection for template_config"
+```
+
+---
+
+### Task 2: Inventory core — item fields, template port, page-slice enrichment
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/core/bot_inventory/types.py` (append two default fields to frozen `BotInventoryItem`)
+- Modify: `src/backend/src/agentclaw/community/core/bot_inventory/protocols.py` (new `BotInventoryTemplatePort`)
+- Create: `src/backend/src/agentclaw/community/core/bot_inventory/adapters/template_page.py` (port impl over `TemplateService`)
+- Modify: `src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py` (inject port; set `template_type` in `_build_item`; enrich the returned page slice)
+- Modify: `src/backend/src/agentclaw/community/di/modules/bot_inventory_module.py` (bind port, pass into service)
+- Test: `src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py` (extend)
+
+- [ ] **Step 1: Write the failing service tests**
+
+Add to `test_bot_inventory_service.py` (reuse the file's existing service-construction helpers; if they take keyword args, add `template_port=stub`):
+
+```python
+class _StubTemplatePort:
+    def __init__(self, ext_by_bot_id: dict[str, dict] | None = None) -> None:
+        self.calls: list[list[str]] = []
+        self.ext_by_bot_id = ext_by_bot_id or {}
+
+    def list_template_configs_by_bot_ids(self, bot_ids: list[str]) -> dict[str, dict]:
+        self.calls.append(list(bot_ids))
+        return {
+            bot_id: ext
+            for bot_id, ext in self.ext_by_bot_id.items()
+            if bot_id in set(bot_ids)
+        }
+
+
+def _template_bot_row(bot_id: str, **extra):
+    return {
+        "bot_id": bot_id,
+        "bot_name": f"Bot {bot_id}",
+        "bot_type": "personal",
+        "status": "ACTIVE",
+        "active_engine": "claude_code",
+        "template_type": "applicationCoding",
+        "owner_id": "u1",
+        **extra,
+    }
+
+
+def test_page_slice_attaches_projected_template_config(page_world):
+    # Three template-backed bots, page_size=2 -> port sees only page 1's ids.
+    stub = _StubTemplatePort(
+        {
+            "b1": {"devflow_workflow": "w1", "token": "secret"},
+            "b2": {"template_key": "normalCC"},
+            "b3": {"devflow_workflow": "w3"},
+        }
+    )
+    service = page_world.build_service(template_port=stub)
+    items, total = service.list_items(
+        owner_id="u1", space=page_world.personal_space(),
+        keyword=None, engine=None, deploy_mode=None, page=1, page_size=2,
+    )
+    assert total == 3
+    assert len(items) == 2
+    flat = stub.calls
+    assert len(flat) == 1
+    # Only the returned page's template-backed ids, no more.
+    assert set(flat[0]) == {"b1", "b2"}
+    assert items[0].template_config == {"devflow_workflow": "w1"}
+    assert items[0].template_type == "applicationCoding"
+
+
+def test_no_template_bots_in_page_means_no_port_call(page_world):
+    stub = _StubTemplatePort()
+    service = page_world.build_service(template_port=stub)
+    items, _ = service.list_items(
+        owner_id="u1", space=page_world.personal_space(),
+        keyword=None, engine=None, deploy_mode=None, page=1, page_size=20,
+    )
+    assert items
+    assert stub.calls == []
+
+
+def test_template_config_absent_stays_none(page_world):
+    stub = _StubTemplatePort({})  # template row missing for the bot
+    service = page_world.build_service(template_port=stub)
+    items, _ = service.list_items(
+        owner_id="u1", space=page_world.personal_space(),
+        keyword=None, engine=None, deploy_mode=None, page=1, page_size=20,
+    )
+    assert items[0].template_type == "applicationCoding"
+    assert items[0].template_config is None
+```
+
+(If `page_world` does not exist in the file, build the equivalent from the existing fixtures: an `_InventoryWorld` helper constructing `BotInventoryService` with mocked `BotInventoryBotPort` returning the rows above, `NoopBusinessSpaceContext`, stub desktop/access/lifecycle ports. Follow the file's existing composition style.)
+
+- [ ] **Step 2: Run tests, verify failure**
+
+Run: `cd src/backend && python -m pytest tests/community/core/bot_inventory/services/test_bot_inventory_service.py -v -k template`
+Expected: FAIL — `TypeError: ... unexpected keyword 'template_port'` (or AttributeError `template_config`)
+
+- [ ] **Step 3: Implement core changes**
+
+`types.py` — append to frozen `BotInventoryItem` AFTER `internal_status` (defaults keep every existing constructor call valid):
+
+```python
+    internal_status: str | None = None
+    # Template identity (engine-neutral layer: engine stays engine, coding
+    # identity lives in template_type + projected template_config).
+    template_type: str | None = None
+    template_config: Mapping[str, Any] | None = None
+```
+
+`protocols.py` — add next to the other ports:
+
+```python
+@runtime_checkable
+class BotInventoryTemplatePort(Protocol):
+    """Page-slice template-config reader for the inventory read model.
+
+    The fan-out deliberately skips template attachment (cost); this port is
+    called with ONLY the returned page's template-backed bot ids.
+    """
+
+    def list_template_configs_by_bot_ids(
+        self, bot_ids: list[str]
+    ) -> dict[str, dict[str, Any]]: ...
+```
+
+`adapters/template_page.py`:
+
+```python
+"""Bridge the inventory template port to the bot-management TemplateService."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentclaw.community.core.bot_management.services.template_service import (
+    TemplateService,
+)
+from agentclaw.community.core.bot_inventory.protocols import (
+    BotInventoryTemplatePort,
+)
+
+
+class TemplateServiceInventoryTemplatePort(BotInventoryTemplatePort):
+    """Read ``ac_templates.ext`` by bot ids, best-effort like list attach."""
+
+    def __init__(self, template_service: TemplateService) -> None:
+        self._templates = template_service
+
+    def list_template_configs_by_bot_ids(
+        self, bot_ids: list[str]
+    ) -> dict[str, dict[str, Any]]:
+        if not bot_ids:
+            return {}
+        try:
+            records = self._templates.list_templates_by_bot_ids(bot_ids)
+        except Exception:  # best-effort: template trouble must not break a page
+            return {}
+        return {
+            str(record.get("bot_id")): record.get("ext")
+            for record in records
+            if record.get("bot_id") is not None
+            and isinstance(record.get("ext"), dict)
+        }
+```
+
+`bot_inventory_service.py` — import `dataclasses.replace` and the projection fn; add `template_port` constructor kwarg; in `_build_item` set `template_type=_optional_str(row.get("template_type"))` among the constructor args; replace the tail of `list_items`:
+
+```python
+        total = len(cards)
+        start = (page - 1) * page_size
+        page_items = cards[start : start + page_size]
+        page_items = self._attach_page_templates(page_items)
+        return page_items, total
+
+    def _attach_page_templates(
+        self, items: list[BotInventoryItem]
+    ) -> list[BotInventoryItem]:
+        """Project template_config onto the returned page slice only.
+
+        The fan-out intentionally runs with ``attach_templates=False``; this
+        is the one place template snapshots enter the read model, and only
+        for the page the caller will actually see.
+        """
+        bot_ids = [i.bot_id for i in items if i.template_type]
+        if not bot_ids:
+            return items
+        ext_by_bot_id = self._templates_port.list_template_configs_by_bot_ids(
+            bot_ids
+        )
+        enriched: list[BotInventoryItem] = []
+        for item in items:
+            ext = ext_by_bot_id.get(item.bot_id) if item.template_type else None
+            projected = project_template_config_for_public(ext)
+            if projected is None and item.template_config is None and (
+                ext is None
+            ):
+                enriched.append(item)
+                continue
+            enriched.append(
+                replace(item, template_config=projected)
+            )
+        return enriched
+```
+
+(Import `project_template_config_for_public` from `core/bot_management/template_public_view` — direction bot_inventory→bot_management is already dependency-safe: the DI module wires `BotService` into the inventory the same way.)
+
+`di/modules/bot_inventory_module.py` — provider + constructor arg:
+
+```python
+    @singleton
+    @provider
+    @inject
+    def inventory_template_port(
+        self, template_service: TemplateService
+    ) -> BotInventoryTemplatePort:
+        return TemplateServiceInventoryTemplatePort(template_service)
+```
+
+and add `template_port: BotInventoryTemplatePort` to the `bot_inventory_service` provider parameters, passing `template_port=template_port` into the constructor. Import `TemplateService` from bot_management (same import shape as the existing `BotService` import in this module) and the new port/impl classes.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `cd src/backend && python -m pytest tests/community/core/bot_inventory/ -q`
+Expected: PASS (whole inventory suite green — no behavior change when no template data)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/src/agentclaw/community/core/bot_inventory/ \
+        src/backend/src/agentclaw/community/di/modules/bot_inventory_module.py \
+        src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
+git commit -m "feat(backend): page-slice template fields on the inventory read model"
+```
+
+---
+
+### Task 3: Public schemas + `/bots/all` wire mapping
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py` (`BotInventoryItem` + 2 fields; `Bot` + 3 fields — Bot part lands here, used by Task 4)
+- Modify: `src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py` (`_to_inventory_item` + 2 fields)
+- Test: `src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py`
+
+- [ ] **Step 1: Write the failing handler test**
+
+In `test_inventory_handlers.py`, extend the bot row fixture used by the list case with a `template_type` and mock the new port binding. In the app fixture's binder add (stub port):
+
+```python
+class _TemplatePortStub:
+    def list_template_configs_by_bot_ids(self, bot_ids):
+        return {
+            "b1": {
+                "devflow_workflow": "wf",
+                "token": "must-not-leak",
+                "bot_template_config": {"ext_config": {"thetaKey": "enc:v1:x"}},
+            }
+        }
+```
+
+and `binder.bind(BotInventoryTemplatePort, to=_TemplatePortStub())`. Test:
+
+```python
+def test_list_inventory_carries_template_fields(client):
+    data = _ok(client.get("/openapi/v1/bots/all"))
+    item = data["items"][0]
+    assert item["template_type"] == "applicationCoding"
+    assert item["template_config"] == {"devflow_workflow": "wf"}
+    assert "token" not in item["template_config"]
+    assert "bot_template_config" not in item["template_config"]
+```
+
+(The bot row fixture needs `"template_type": "applicationCoding"` added for this to hold.)
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py -v`
+Expected: FAIL — `KeyError: 'template_type'`
+
+- [ ] **Step 3: Implement schema + mapping**
+
+`schemas.py` — `BotInventoryItem`, after `space` field:
+
+```python
+    template_type: str | None = Field(
+        default=None,
+        description="Template type of the bot, e.g. 'applicationCoding'; "
+        "null for bots created without a template.",
+    )
+    template_config: dict | None = Field(
+        default=None,
+        description="Server-projected template snapshot (display-safe subset; "
+        "secrets never returned). Null without a template.",
+    )
+```
+
+`schemas.py` — `Bot`, after `owner_entity_id`:
+
+```python
+    template_type: str | None = Field(
+        default=None,
+        description="Template type of the bot, e.g. 'applicationCoding'; "
+        "null for bots created without a template.",
+    )
+    template_config: dict | None = Field(
+        default=None,
+        description="Server-projected template snapshot (display-safe subset; "
+        "secrets never returned). Null without a template.",
+    )
+    space: BusinessSpace | None = Field(
+        default=None,
+        description="Business space the bot's record is assigned to "
+        "(owner view). Populated on the listing endpoints.",
+    )
+```
+
+(Update the `Bot` model's `json_schema_extra` example with the three keys' null/simple values to keep the example representative.)
+
+`router.py` — `_to_inventory_item` gains:
+
+```python
+        template_type=item.template_type,
+        template_config=dict(item.template_config) if item.template_config else None,
+```
+
+- [ ] **Step 4: Run handler + endpoint suites, verify pass**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/openapi_v1/inventory/ tests/community/endpoints/test_openapi_bots.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py \
+        src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py \
+        src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py
+git commit -m "feat(backend): expose template fields on the /bots/all card surface"
+```
+
+---
+
+### Task 4: `/bots` — template projection + per-page space resolution
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py` (`_to_bot` + `list_bots` + optional single-row helper for `GET /{bot_id}`)
+- Test: `src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py`
+
+- [ ] **Step 1: Write the failing handler tests**
+
+In `test_bots_endpoints.py`, extend the `BOT` fixture dict:
+
+```python
+    "template_type": "applicationCoding",
+    "template_config": {
+        "devflow_workflow": "release-notes",
+        "token": "must-not-leak",
+        "bot_template_config": {"ext_config": {"thetaKey": "enc:v1:x"}},
+        "runtime": "codefuse",
+    },
+    "space_id": None,
+```
+
+Add (the client fixture already binds `BusinessSpaceContextProtocol` to `NoopBusinessSpaceContext`, whose `bot_space` falls back to the synthetic personal space for a NULL `space_id`):
+
+```python
+def test_list_bots_carries_template_projection_and_space(client):
+    data = _ok(client.get("/openapi/v1/bots"))
+    item = data["items"][0]
+    assert item["template_type"] == "applicationCoding"
+    assert item["template_config"] == {"devflow_workflow": "release-notes"}
+    assert "token" not in item["template_config"]
+    assert "runtime" not in item["template_config"]
+    space = item["space"]
+    assert space["kind"] == "personal"
+    assert space["space_id"].startswith("personal:")
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/openapi_v1/test_bots_endpoints.py -v -k template`
+Expected: FAIL — `KeyError: 'template_type'`
+
+- [ ] **Step 3: Implement**
+
+`router.py` — imports and helpers:
+
+```python
+from agentclaw.community.core.bot_management.template_public_view import (
+    project_template_config_for_public,
+)
+```
+
+`_to_bot` gains keyword-only args (existing 7 call sites stay valid — they pass `d` positionally and get `template_type`/`template_config` from the row, `space=None`):
+
+```python
+def _to_bot(d: dict[str, Any], *, space: dict[str, Any] | None = None) -> Bot:
+    """Adapt an internal bot ``to_dict()`` record to the public ``Bot`` schema.
+
+    ``template_config`` on the row is the stored engine snapshot (may carry
+    secrets), projected onto the display-safe subset here; ``space`` is
+    resolved by the listing endpoints and passed in by the caller.
+    """
+    engine = d.get("active_engine") or ""
+    return Bot(
+        bot_id=d["bot_id"],
+        bot_name=d.get("bot_name") or "",
+        bot_desc=d.get("bot_desc") or "",
+        engine=engine,
+        cluster_name=cluster_for_engine(engine),
+        bot_type=d.get("bot_type") or "",
+        status=d.get("status") or "",
+        owner_entity_id=d.get("owner_id") or "",
+        template_type=_optional_bot_str(d.get("template_type")),
+        template_config=project_template_config_for_public(
+            d.get("template_config")
+        ),
+        space=space,
+    )
+
+
+def _optional_bot_str(value: Any) -> str | None:
+    return str(value) if value not in (None, "") else None
+
+
+def _to_public_space(ref: Any) -> dict[str, Any] | None:
+    if ref is None:
+        return None
+    return {"space_id": ref.space_id, "name": ref.name, "kind": ref.kind}
+
+
+def _resolve_row_spaces(
+    space_context: BusinessSpaceContextProtocol,
+    rows: list[dict[str, Any]],
+    *,
+    owner_id: str,
+) -> dict[str, dict[str, Any] | None]:
+    """Owner-view space summary per distinct ``ac_bots.space_id``.
+
+    Memoized on the raw space_id: one ``bot_space`` resolution per distinct
+    space per page (the protocol's ``bot_space`` already folds the synthetic
+    ``personal:<user>`` fallback and the member-gated None into one call —
+    this is plain memo caching, not policy, which stays in the core port).
+    """
+    resolved: dict[str, dict[str, Any] | None] = {}
+    for row in rows:
+        raw = str(row.get("space_id") or "")
+        if raw in resolved:
+            continue
+        resolved[raw] = _to_public_space(
+            space_context.bot_space(bot=row, owner_id=owner_id, current_space=None)
+        )
+    return resolved
+```
+
+`list_bots` handler — add the injection and mapping:
+
+```python
+    space_context: BusinessSpaceContextProtocol = Injected(
+        BusinessSpaceContextProtocol
+    ),
+```
+
+and replace the tail:
+
+```python
+    rows = result["items"]
+    row_spaces = _resolve_row_spaces(space_context, rows, owner_id=owner_id)
+    items = [
+        _to_bot(b, space=row_spaces.get(str(b.get("space_id") or "")))
+        for b in rows
+    ]
+    return page(result["total"], items, request)
+```
+
+`BusinessSpaceContextProtocol` import: `from agentclaw.community.core.bot_inventory.protocols import BusinessSpaceContextProtocol` (the inventory handler in the same file already injects it — reuse that import).
+
+- [ ] **Step 4: Run the full bots handler suite + endpoint suite**
+
+Run: `cd src/backend && python -m pytest tests/community/adapters/http/openapi_v1/test_bots_endpoints.py tests/community/endpoints/test_openapi_bots.py -q`
+Expected: PASS (all 8 `_to_bot` call sites still construct — new fields default populated from row data)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py \
+        src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+git commit -m "feat(backend): template projection and per-page space on GET /openapi/v1/bots"
+```
+
+---
+
+### Task 5: Endpoint framework pins (wire-level, real DI graph)
+
+**Files:**
+- Modify: `src/backend/tests/community/endpoints/test_openapi_bots.py`
+
+- [ ] **Step 1: Extend the happy-body pins**
+
+`_HAPPY_BODIES` — `GET /openapi/v1/bots` row gains (seeded bot has no template rows, no space_id; the real `SpaceServiceBotSpaceContext` falls back to the synthetic personal space; `batch_query_personal` finds no row):
+
+```python
+    ("GET", _BASE_PATH): {
+        "data": {
+            "total": 1,
+            "items": [
+                {
+                    "bot_id": _BOT_ID,
+                    "owner_entity_id": _OWNER,
+                    "template_type": None,
+                    "template_config": None,
+                    "space": {
+                        "space_id": f"personal:{_OWNER}",
+                        "name": "Personal",
+                        "kind": "personal",
+                    },
+                }
+            ],
+        }
+    },
+```
+
+and `GET /openapi/v1/bots/all` row gains `"template_type": None, "template_config": None` inside the pinned item dict.
+
+(If the synthetic personal ref's `name` differs in the noop implementation, pin the observed value — the point is the shape and kind; check `NoopBusinessSpaceContext._personal`.)
+
+- [ ] **Step 2: Run the endpoint suite and the enrollment gate**
+
+Run: `cd src/backend && python -m pytest tests/community/endpoints/test_openapi_bots.py tests/community/endpoints -q -k "openapi_bots or coverage or baseline"`
+Expected: PASS with no baseline drift (no route added → counts unchanged; field pins now enforced on the wire)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/backend/tests/community/endpoints/test_openapi_bots.py
+git commit -m "test(backend): pin template and space fields on the bots wire cases"
+```
+
+---
+
+### Task 6: Contract file — `bots.openapi.json` (manual, schema-only)
+
+**Files:**
+- Modify: `src/gateway/configs/schemas/bots.openapi.json` (`components.schemas.Bot`, `components.schemas.BotInventoryItem`)
+- Modify (if the plain diff shows coupling): `src/gateway/tests/fixtures/bots.openapi.json`
+
+- [ ] **Step 1: Edit `components.schemas.Bot`**
+
+Add to `properties` (match the file's existing `$ref`/field style — copy the surrounding indentation; descriptions mirror the pydantic Fields from Task 3):
+
+```json
+"template_type": {
+  "anyOf": [
+    {"type": "string"},
+    {"type": "null"}
+  ],
+  "description": "Template type of the bot, e.g. 'applicationCoding'; null for bots created without a template."
+},
+"template_config": {
+  "anyOf": [
+    {"type": "object", "additionalProperties": true},
+    {"type": "null"}
+  ],
+  "description": "Server-projected template snapshot (display-safe subset; secrets never returned). Null without a template."
+},
+"space": {
+  "anyOf": [
+    {"$ref": "#/components/schemas/BusinessSpace"},
+    {"type": "null"}
+  ],
+  "description": "Business space the bot's record is assigned to (owner view). Populated on the listing endpoints."
+}
+```
+
+- [ ] **Step 2: Edit `components.schemas.BotInventoryItem`**
+
+Add `template_type` and `template_config` with the same shapes (no `space` — already present).
+
+- [ ] **Step 3: Validate json + run any contract tests**
+
+Run:
+```bash
+python3 -m json.tool src/gateway/configs/schemas/bots.openapi.json > /dev/null && echo OK
+cd src/backend && python -m pytest tests/community/contracts -q
+```
+Expected: `OK`; contracts green. If a schema-snapshot test asserts `Bot`, regenerate **that one snapshot file only** via the mechanism the test itself documents (never a full regen of bots.openapi.json), and if the gateway fixture copy Diff-checks equality, mirror the same two schema edits there.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/gateway/configs/schemas/bots.openapi.json \
+        src/gateway/tests/fixtures/bots.openapi.json \
+        src/backend/tests/community/contracts
+git commit -m "feat(gateway): publish template and space fields in bots.openapi.json"
+```
+
+---
+
+### Task 7: Full gate + batched final review
+
+- [ ] **Step 1: Coverage gate locally**
+
+Run: `bash src/backend/scripts/ci_test.sh` (per repo memory: changed-line coverage ≥80% is only reproducible here; pre-push is lint-only)
+Expected: green, changed-line coverage ≥80%
+
+- [ ] **Step 2: Batched review (per user preference — no per-task reviews)**
+
+One comprehensive quality review at the end: security (projection matrix on the wire), DI wiring across every app that mounts the bots router, contract-file consistency, plan-vs-code drift. Run `/code-review` on the diff before pushing.
+
+- [ ] **Step 3: Push**
+
+```bash
+git push -u origin feat/bot-template-space-fields-REL20260828
+```
+
+Then (deploy-side, not in this repo's PR): mirror `bots.openapi.json` to the ocb repo gateway configs — per the dual-write convention.
+
+---
+
+## Self-Review notes
+
+- Spec coverage: `/bots/all` template fields (Task 2+3), `/bots` template + space (Task 4), security projection (Task 1, enforced at every mapping site), OpenAPI contract (Task 6), endpoint gate (Task 5 — no baseline movement), coverage (Task 7).
+- Type consistency: `BotInventoryTemplatePort.list_template_configs_by_bot_ids(list[str]) -> dict[str, dict]` used in adapter, service, DI, and both test stubs; `project_template_config_for_public(Mapping|None) -> dict|None` referenced in router + service + port-adjacent tests; `BusinessSpace` shape `{space_id,str name,str kind}` identical in `/bots` mapping and `/bots/all` schema.
+- No placeholders: every code step carries the actual content; the only adaptive spots (test fixture naming in Task 2, snapshot regen in Task 6) name the exact mechanism to reuse with fallback instructions.

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -240,6 +240,8 @@ def _to_inventory_item(item: CoreItem) -> BotInventoryItem:
         internal_status=item.internal_status,
         owner_entity_id=item.owner_entity_id,
         space=space,
+        template_type=item.template_type,
+        template_config=dict(item.template_config) if item.template_config else None,
         avatar_url=item.avatar_url,
         machine_id=item.machine_id,
         mount_path=item.mount_path,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -108,6 +108,9 @@ from agentclaw.community.core.bot_inventory.protocols import (
 from agentclaw.community.core.bot_inventory.policies.combo_policy import (
     assert_service_upgrade,
 )
+from agentclaw.community.core.bot_management.template_public_view import (
+    project_template_config_for_public,
+)
 from agentclaw.community.core.bot_inventory.types import (
     BotInventoryItem as CoreItem,
     DeployMode as CoreDeployMode,
@@ -181,8 +184,14 @@ def _require_service_capable_engine(bot_type: str, engine: str) -> None:
         )
 
 
-def _to_bot(d: dict[str, Any]) -> Bot:
-    """Adapt an internal bot ``to_dict()`` record to the public ``Bot`` schema."""
+def _to_bot(d: dict[str, Any], *, space: dict[str, Any] | None = None) -> Bot:
+    """Adapt an internal bot ``to_dict()`` record to the public ``Bot`` schema.
+
+    ``template_config`` on the row is the stored engine snapshot (it may carry
+    secrets), so it passes through the core allowlist projection here.
+    ``space`` is the owner-view summary the listing endpoints resolve and
+    pass in; other callers leave it null.
+    """
     engine = d.get("active_engine") or ""
     return Bot(
         bot_id=d["bot_id"],
@@ -193,7 +202,43 @@ def _to_bot(d: dict[str, Any]) -> Bot:
         bot_type=d.get("bot_type") or "",
         status=d.get("status") or "",
         owner_entity_id=d.get("owner_id") or "",
+        template_type=(
+            str(d["template_type"]) if d.get("template_type") not in (None, "") else None
+        ),
+        template_config=project_template_config_for_public(d.get("template_config")),
+        space=space,
     )
+
+
+def _to_public_space(ref: Any) -> dict[str, Any] | None:
+    """Flatten a ``BusinessSpaceRef`` for pydantic coercion into ``BusinessSpace``."""
+    if ref is None:
+        return None
+    return {"space_id": ref.space_id, "name": ref.name, "kind": ref.kind}
+
+
+def _resolve_row_spaces(
+    space_context: BusinessSpaceContextProtocol,
+    rows: list[dict[str, Any]],
+    *,
+    owner_id: str,
+) -> dict[str, dict[str, Any] | None]:
+    """Owner-view space summary per distinct ``ac_bots.space_id``.
+
+    Memoized on the raw space_id column: one ``bot_space`` resolution per
+    distinct space per page. This is plain memo caching — the semantics
+    (synthetic ``personal:<user>`` fallback, member-gated None) stay in the
+    core ``BusinessSpaceContextProtocol``.
+    """
+    resolved: dict[str, dict[str, Any] | None] = {}
+    for row in rows:
+        raw = str(row.get("space_id") or "")
+        if raw in resolved:
+            continue
+        resolved[raw] = _to_public_space(
+            space_context.bot_space(bot=row, owner_id=owner_id, current_space=None)
+        )
+    return resolved
 
 
 def _to_bot_metadata(d: dict[str, Any]) -> BotMetadata:
@@ -495,6 +540,9 @@ async def list_bots(
         ),
     ] = None,
     bot_service: BotServiceProtocol = Injected(BotServiceProtocol),
+    space_context: BusinessSpaceContextProtocol = Injected(
+        BusinessSpaceContextProtocol
+    ),
 ) -> Envelope[Page[Bot]]:
     """List the caller's bots, narrowed to the caller's authorized scope.
 
@@ -507,8 +555,9 @@ async def list_bots(
     bots, including bots the user does not own, is the authorized-bots listing.
 
     The keyword, engine, and status filters are applied before pagination.
-    For richer inventory fields such as deployment mode and business space,
-    use GET /openapi/v1/bots/all.
+    Each row carries the owner-view space of its ``ac_bots.space_id`` and the
+    projected template snapshot. For richer inventory fields such as
+    deployment mode, use GET /openapi/v1/bots/all.
     """
     granted = caller.granted_bot_ids(owned_by_delegator=True)
     if granted is not None and not granted:
@@ -522,7 +571,12 @@ async def list_bots(
         page_size=page_params.page_size,
         bot_ids=sorted(granted) if granted is not None else None,
     )
-    items = [_to_bot(b) for b in result["items"]]
+    rows = result["items"]
+    row_spaces = _resolve_row_spaces(space_context, rows, owner_id=owner_id)
+    items = [
+        _to_bot(b, space=row_spaces.get(str(b.get("space_id") or "")))
+        for b in rows
+    ]
     return page(result["total"], items, request)
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -555,7 +555,7 @@ async def list_bots(
     bots, including bots the user does not own, is the authorized-bots listing.
 
     The keyword, engine, and status filters are applied before pagination.
-    Each row carries the owner-view space of its ``ac_bots.space_id`` and the
+    Each row carries the owner-view space of its space assignment and the
     projected template snapshot. For richer inventory fields such as
     deployment mode, use GET /openapi/v1/bots/all.
     """

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -77,6 +77,9 @@ class Bot(BaseModel):
                 "bot_type": "personal",
                 "status": "ACTIVE",
                 "owner_entity_id": "u_165137",
+                "template_type": None,
+                "template_config": None,
+                "space": None,
             }
         }
     )
@@ -101,6 +104,21 @@ class Bot(BaseModel):
     status: str = Field(description=_BOT_STATUS_DESC)
     owner_entity_id: str = Field(
         description="The user who owns the bot — echoes the user_id the request named."
+    )
+    template_type: str | None = Field(
+        default=None,
+        description="Template type of the bot, e.g. 'applicationCoding'; null for "
+        "bots created without a template.",
+    )
+    template_config: dict | None = Field(
+        default=None,
+        description="Server-projected template snapshot (display-safe subset; "
+        "secrets never returned). Null without a template.",
+    )
+    space: BusinessSpace | None = Field(
+        default=None,
+        description="Business space the bot's record is assigned to (owner view). "
+        "Populated on the listing endpoints.",
     )
 
 
@@ -691,6 +709,16 @@ class BotInventoryItem(BaseModel):
     owner_entity_id: str = Field(description="User who owns the bot.")
     space: BusinessSpace | None = Field(
         default=None, description="Business space containing the bot, when resolved."
+    )
+    template_type: str | None = Field(
+        default=None,
+        description="Template type of the bot, e.g. 'applicationCoding'; null for "
+        "bots created without a template.",
+    )
+    template_config: dict | None = Field(
+        default=None,
+        description="Server-projected template snapshot (display-safe subset; "
+        "secrets never returned). Null without a template.",
     )
     avatar_url: str | None = Field(
         default=None, description="Avatar URL for the bot, when configured."

--- a/src/backend/src/agentclaw/community/core/bot_inventory/adapters/template_page.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/adapters/template_page.py
@@ -1,0 +1,40 @@
+"""Bridge the inventory template port to the bot-management TemplateService."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentclaw.community.core.bot_management.services.template_service import (
+    TemplateService,
+)
+from agentclaw.community.core.bot_inventory.protocols import (
+    BotInventoryTemplatePort,
+)
+
+
+class TemplateServiceInventoryTemplatePort(BotInventoryTemplatePort):
+    """Read ``ac_templates.ext`` by bot ids, best-effort like list attach.
+
+    Template lookup failures are dropped to "no snapshot" — mirroring
+    ``BotService._attach_template_configs_to_bots``: template trouble must
+    never break a bot listing page.
+    """
+
+    def __init__(self, template_service: TemplateService) -> None:
+        self._templates = template_service
+
+    def list_template_configs_by_bot_ids(
+        self, bot_ids: list[str]
+    ) -> dict[str, dict[str, Any]]:
+        if not bot_ids:
+            return {}
+        try:
+            records = self._templates.list_templates_by_bot_ids(bot_ids)
+        except Exception:
+            return {}
+        return {
+            str(record.get("bot_id")): record.get("ext")
+            for record in records
+            if record.get("bot_id") is not None
+            and isinstance(record.get("ext"), dict)
+        }

--- a/src/backend/src/agentclaw/community/core/bot_inventory/protocols.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/protocols.py
@@ -109,6 +109,20 @@ class BotInventoryAccessPort(Protocol):
 
 
 @runtime_checkable
+class BotInventoryTemplatePort(Protocol):
+    """Page-slice template-config reader for the inventory read model.
+
+    The listing fan-out deliberately skips template attachment (cost); this
+    port is called with ONLY the returned page's template-backed bot ids and
+    answers with the stored ``ac_templates.ext`` snapshot per bot.
+    """
+
+    def list_template_configs_by_bot_ids(
+        self, bot_ids: list[str]
+    ) -> dict[str, dict[str, Any]]: ...
+
+
+@runtime_checkable
 class BusinessSpaceContextProtocol(Protocol):
     """Minimal consumer-side business-space context API.
 

--- a/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from typing import Any, Mapping
 
 from agentclaw.community.core.bot_inventory.errors import (
@@ -12,8 +13,12 @@ from agentclaw.community.core.bot_inventory.errors import (
 from agentclaw.community.core.bot_inventory.protocols import (
     BotInventoryAccessPort,
     BotInventoryBotPort,
+    BotInventoryTemplatePort,
     BusinessSpaceContextProtocol,
     DesktopBotInventoryPort,
+)
+from agentclaw.community.core.bot_management.template_public_view import (
+    project_template_config_for_public,
 )
 from agentclaw.community.core.bot_inventory.services.lifecycle_view import (
     BotLifecycleView,
@@ -38,12 +43,14 @@ class BotInventoryService:
         access_service: BotInventoryAccessPort,
         business_space: BusinessSpaceContextProtocol,
         lifecycle_view: BotLifecycleView,
+        template_port: BotInventoryTemplatePort,
     ) -> None:
         self._bot = bot_service
         self._desktop = desktop_service
         self._access = access_service
         self._business_space = business_space
         self._lifecycle = lifecycle_view
+        self._template_port = template_port
 
     def list_items(
         self,
@@ -128,7 +135,39 @@ class BotInventoryService:
         )
         total = len(cards)
         start = (page - 1) * page_size
-        return cards[start : start + page_size], total
+        page_items = self._attach_page_templates(cards[start : start + page_size])
+        return page_items, total
+
+    def _attach_page_templates(
+        self, items: list[BotInventoryItem]
+    ) -> list[BotInventoryItem]:
+        """Project template_config onto the returned page slice only.
+
+        The fan-out intentionally pulls rows with ``attach_templates=False``
+        (one batched template read per 200-row page would tax every listing);
+        this is the single place template snapshots enter the read model, and
+        it sees only the page the caller will actually see — so the per-request
+        template cost is one bounded read over ≤page_size ids.
+        """
+        bot_ids = [item.bot_id for item in items if item.template_type]
+        if not bot_ids:
+            return items
+        ext_by_bot_id = self._template_port.list_template_configs_by_bot_ids(
+            list(bot_ids)
+        )
+        enriched: list[BotInventoryItem] = []
+        for item in items:
+            if not item.template_type:
+                enriched.append(item)
+                continue
+            projected = project_template_config_for_public(
+                ext_by_bot_id.get(item.bot_id)
+            )
+            if projected is None and item.template_config is None:
+                enriched.append(item)
+                continue
+            enriched.append(replace(item, template_config=projected))
+        return enriched
 
     def _list_cloud_rows(
         self,
@@ -346,6 +385,7 @@ class BotInventoryService:
             internal_status=(
                 lifecycle_card.internal_status if lifecycle_card else None
             ),
+            template_type=_optional_str(row.get("template_type")),
         )
 
     @staticmethod

--- a/src/backend/src/agentclaw/community/core/bot_inventory/types.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/types.py
@@ -109,6 +109,10 @@ class BotInventoryItem:
     publication_version: int | None = None
     live_version: int | None = None
     internal_status: str | None = None
+    # Template identity (engine stays the engine vocabulary; coding identity
+    # lives in template_type + the public projection of template_config).
+    template_type: str | None = None
+    template_config: Mapping[str, Any] | None = None
 
 
 @dataclass(frozen=True)

--- a/src/backend/src/agentclaw/community/core/bot_management/template_public_view.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/template_public_view.py
@@ -1,0 +1,48 @@
+"""Public projection of ``ac_templates.ext`` (``template_config``).
+
+``template_config`` stored engine-side legitimately carries secrets: the
+aicoding provisioning strategy persists ``bot_template_config.ext_config
+.thetaKey`` as an ``enc:v1:`` ciphertext, and the stable outer contract allows
+a plain ``token``. Listing responses must never echo either — an encrypted
+blob is still offline attack material and a replayable oracle.
+
+Rules for this file:
+- Allowlist, never denylist: engine-owned extensions surface only when a key
+  is added here explicitly (plus security review). Default is "dropped".
+- The result is a fresh shallow+container copy: callers may mutate it without
+  aliasing the stored snapshot.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+#: Keys that are display-safe. Keep alphabetized.
+_PUBLIC_TEMPLATE_KEYS = (
+    "code_repos",
+    "devflow_workflow",
+    "template_key",
+    "template_uid",
+    "yuque_kb_repos",
+)
+
+
+def project_template_config_for_public(
+    config: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Project a stored template snapshot onto its public display subset."""
+    if not isinstance(config, Mapping) or not config:
+        return None
+    if not any(key in config for key in _PUBLIC_TEMPLATE_KEYS):
+        return None
+    projected: dict[str, Any] = {}
+    for key in _PUBLIC_TEMPLATE_KEYS:
+        if key in config:
+            value = config[key]
+            if isinstance(value, list):
+                projected[key] = list(value)
+            elif isinstance(value, dict):
+                projected[key] = dict(value)
+            else:
+                projected[key] = value
+    return projected

--- a/src/backend/src/agentclaw/community/di/modules/bot_inventory_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_inventory_module.py
@@ -14,9 +14,13 @@ from agentclaw.community.adapters.bot_space_context import (
 from agentclaw.community.core.bot_inventory.adapters.service_lifecycle import (
     ServiceLifecycleView,
 )
+from agentclaw.community.core.bot_inventory.adapters.template_page import (
+    TemplateServiceInventoryTemplatePort,
+)
 from agentclaw.community.core.bot_inventory.protocols import (
     BotInventoryAccessPort,
     BotInventoryBotPort,
+    BotInventoryTemplatePort,
     BusinessSpaceContextProtocol,
     DesktopBotInventoryPort,
     ServiceLifecyclePort,
@@ -31,6 +35,9 @@ from agentclaw.community.core.bot_inventory.services.local_bot_workflow import (
     LocalBotWorkflowService,
 )
 from agentclaw.community.core.bot_management.services.bot_service import BotService
+from agentclaw.community.core.bot_management.services.template_service import (
+    TemplateService,
+)
 from agentclaw.community.core.bot_collaborator.services.collaborator_service import (
     CollaboratorService,
 )
@@ -95,6 +102,14 @@ class BotInventoryModule(Module):
     @singleton
     @provider
     @inject
+    def inventory_template_port(
+        self, template_service: TemplateService
+    ) -> BotInventoryTemplatePort:
+        return TemplateServiceInventoryTemplatePort(template_service)
+
+    @singleton
+    @provider
+    @inject
     def bot_inventory_service(
         self,
         bot_service: BotInventoryBotPort,
@@ -102,6 +117,7 @@ class BotInventoryModule(Module):
         access_service: BotInventoryAccessPort,
         business_space: BusinessSpaceContextProtocol,
         lifecycle_view: BotLifecycleView,
+        template_port: BotInventoryTemplatePort,
     ) -> BotInventoryService:
         return BotInventoryService(
             bot_service=bot_service,
@@ -109,6 +125,7 @@ class BotInventoryModule(Module):
             access_service=access_service,
             business_space=business_space,
             lifecycle_view=lifecycle_view,
+            template_port=template_port,
         )
 
     @singleton

--- a/src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py
@@ -40,7 +40,23 @@ CLOUD = {
     "bot_type": "personal",
     "status": "ACTIVE",
     "owner_id": "u1",
+    "template_type": "applicationCoding",
 }
+
+
+class _TemplatePortStub:
+    """Hands one stored snapshot back — including the secrets that must not
+    survive the wire — so the handler test pins the projection end to end."""
+
+    def list_template_configs_by_bot_ids(self, bot_ids):
+        return {
+            "c1": {
+                "devflow_workflow": "release-notes",
+                "token": "must-not-leak",
+                "bot_template_config": {"ext_config": {"thetaKey": "enc:v1:x"}},
+                "runtime": "codefuse",
+            }
+        }
 LOCAL = {
     "id": 2,
     "bot_id": "l1",
@@ -84,6 +100,7 @@ def client(bot_service, desktop_service):
                 access_service=access,
                 business_space=space,
                 lifecycle_view=BotLifecycleView(NoopServiceLifecyclePort()),
+                template_port=_TemplatePortStub(),
             )
             binder.bind(BotInventoryBotPort, to=bot_service)
             binder.bind(DesktopBotInventoryPort, to=desktop_service)
@@ -111,6 +128,21 @@ def test_list_inventory_combines_personal_cloud_and_local(client):
     ids = {item["bot_id"] for item in data["items"]}
     assert data["total"] == 2
     assert ids == {"c1", "l1"}
+
+
+def test_list_inventory_carries_projected_template_fields(client):
+    data = _ok(client.get("/openapi/v1/bots/all"))
+
+    by_id = {item["bot_id"]: item for item in data["items"]}
+    cloud = by_id["c1"]
+    assert cloud["template_type"] == "applicationCoding"
+    assert cloud["template_config"] == {"devflow_workflow": "release-notes"}
+    assert "token" not in cloud["template_config"]
+    assert "bot_template_config" not in cloud["template_config"]
+    assert "runtime" not in cloud["template_config"]
+    # Desktop rows carry no template identity.
+    assert by_id["l1"]["template_type"] is None
+    assert by_id["l1"]["template_config"] is None
 
 
 def test_inventory_openapi_declares_upgrade_action(client):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_app_only_listings.py
@@ -274,7 +274,10 @@ def _data(response):
 
 def test_the_listing_is_narrowed_to_the_delegated_bots(make_client):
     """Two bots owned, one delegated: one returned."""
-    client = make_client(GRANTED)
+    # The bots listing now resolves each row's owner-view space (Noop models
+    # the personal space with zero service calls), so it needs a serving
+    # space context rather than the unexpected-service guard.
+    client = make_client(GRANTED, space_context=NoopBusinessSpaceContext())
 
     listed = _data(client.get("/openapi/v1/bots"))
 
@@ -287,7 +290,7 @@ def test_the_count_describes_the_narrowed_set(make_client):
     A caller could subtract and learn exactly how many of the user's bots it was
     not granted — a number nobody agreed to share.
     """
-    client = make_client(GRANTED)
+    client = make_client(GRANTED, space_context=NoopBusinessSpaceContext())
 
     assert _data(client.get("/openapi/v1/bots"))["total"] == 1
 
@@ -299,7 +302,7 @@ def test_the_narrowing_happens_before_pagination(make_client, bots):
     — a page of 20 that returns 3 — is the kind of thing that looks like an
     off-by-one rather than a scoping failure.
     """
-    client = make_client(GRANTED)
+    client = make_client(GRANTED, space_context=NoopBusinessSpaceContext())
 
     client.get("/openapi/v1/bots")
 
@@ -318,7 +321,9 @@ def test_an_application_granted_nothing_gets_an_empty_page(make_client, bots):
 
 def test_a_human_caller_sees_everything_they_own(make_client, bots):
     """The narrowing applies to applications, not to people."""
-    client = make_client(GRANTED, with_user=True)
+    client = make_client(
+        GRANTED, with_user=True, space_context=NoopBusinessSpaceContext()
+    )
 
     listed = _data(client.get("/openapi/v1/bots"))
 
@@ -478,6 +483,10 @@ def cross_owner_client(bots):
             def configure(self, binder):
                 binder.bind(BotServiceProtocol, to=bots)
                 binder.bind(BotAppGrantServiceProtocol, to=_CrossOwnerGrants())
+                binder.bind(
+                    BusinessSpaceContextProtocol,
+                    to=NoopBusinessSpaceContext(),
+                )
 
         app = FastAPI()
         app.include_router(app_view_router)

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -80,6 +80,14 @@ BOT = {
     "entity_id": "u1",
     "entity_type": "staff",
     "device_binding": {"device_id": "dev-9"},
+    # Stored template snapshot: the wire must keep only the allowlisted keys.
+    "template_type": "applicationCoding",
+    "template_config": {
+        "devflow_workflow": "release-notes",
+        "token": "must-not-leak",
+        "bot_template_config": {"ext_config": {"thetaKey": "enc:v1:x"}},
+        "runtime": "codefuse",
+    },
 }
 
 
@@ -164,6 +172,18 @@ def startup_script():
     return m
 
 
+class _CountingNoopSpace(NoopBusinessSpaceContext):
+    """Noop space context that counts ``bot_space`` resolutions per instance."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bot_space_calls = 0
+
+    def bot_space(self, **kwargs):
+        self.bot_space_calls += 1
+        return super().bot_space(**kwargs)
+
+
 @pytest.fixture
 def client(
     svc,
@@ -176,6 +196,8 @@ def client(
     auth_rel,
     startup_script,
 ):
+    space = _CountingNoopSpace()
+
     class _M(Module):
         def configure(self, binder):
             binder.bind(BotServiceProtocol, to=svc)
@@ -187,10 +209,7 @@ def client(
             binder.bind(SkillSetServiceFactoryProtocol, to=skill_set_factory)
             binder.bind(AuthRelationshipPlugin, to=auth_rel)
             binder.bind(BotStartupScriptServiceProtocol, to=startup_script)
-            binder.bind(
-                BusinessSpaceContextProtocol,
-                to=NoopBusinessSpaceContext(),
-            )
+            binder.bind(BusinessSpaceContextProtocol, to=space)
 
     app = FastAPI()
     app.include_router(router)
@@ -203,6 +222,7 @@ def client(
     app.dependency_overrides[require_principal] = lambda: {"user_id": "u1"}
     attach_injector(app, Injector([_M()]))
     mount_public_error_handlers(app)
+    app.state.business_space = space
     return user_scoped_client(app, "u1")
 
 
@@ -226,6 +246,30 @@ def test_list_bots(client):
     data = _ok(client.get("/openapi/v1/bots"))
     assert data["total"] == 1
     assert data["items"][0]["bot_id"] == "b1"
+
+
+def test_list_bots_carries_template_projection_and_space(client):
+    data = _ok(client.get("/openapi/v1/bots"))
+    item = data["items"][0]
+    # The stored snapshot's secrets never reach the wire; only the
+    # allowlisted display keys survive.
+    assert item["template_type"] == "applicationCoding"
+    assert item["template_config"] == {"devflow_workflow": "release-notes"}
+    assert "token" not in item["template_config"]
+    assert "bot_template_config" not in item["template_config"]
+    assert "runtime" not in item["template_config"]
+    # A NULL ac_bots.space_id resolves to the owner's synthetic personal space.
+    space = item["space"]
+    assert space["kind"] == "personal"
+    assert space["space_id"] == "personal:u1"
+
+
+def test_list_bots_resolves_space_once_per_distinct_space(client):
+    data = _ok(client.get("/openapi/v1/bots"))
+    assert data["total"] == 1
+    # All rows share the NULL space_id column value, so memoization collapses
+    # the per-page resolution to a single bot_space call.
+    assert client.app.state.business_space.bot_space_calls == 1
 
 
 def test_list_bots_filters_reach_service(client, svc):

--- a/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
+++ b/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
@@ -54,6 +54,21 @@ LOCAL = {
 }
 
 
+class _StubTemplatePort:
+    """Recording stub: answers ``ac_templates.ext`` snapshots per bot id."""
+
+    def __init__(self, ext_by_bot_id: dict[str, dict] | None = None) -> None:
+        self.calls: list[list[str]] = []
+        self.ext_by_bot_id = ext_by_bot_id or {}
+
+    def list_template_configs_by_bot_ids(self, bot_ids: list[str]) -> dict[str, dict]:
+        self.calls.append(list(bot_ids))
+        wanted = set(bot_ids)
+        return {
+            bot_id: ext for bot_id, ext in self.ext_by_bot_id.items() if bot_id in wanted
+        }
+
+
 @pytest.fixture
 def service():
     bot = MagicMock()
@@ -72,6 +87,7 @@ def service():
             access_service=access,
             business_space=NoopBusinessSpaceContext(),
             lifecycle_view=BotLifecycleView(NoopServiceLifecyclePort()),
+            template_port=_StubTemplatePort(),
         ),
         bot,
         desktop,
@@ -100,9 +116,10 @@ def test_list_items_combines_filters_and_paginates(service) -> None:
 
 @pytest.mark.unit
 def test_cloud_pull_opts_out_of_template_attach(service) -> None:
-    # Inventory cards never surface template_config, so every pulled page must
-    # skip the batched template read — one fewer DB round trip per page on the
-    # /bots/all path.
+    # The fan-out still pulls without template attachment: snapshots enter the
+    # read model only through the page-slice enrichment (see the
+    # test_page_slice_* cases below), so every pulled page keeps skipping the
+    # batched template read.
     inventory, bot, _ = service
 
     inventory.list_items(
@@ -207,6 +224,7 @@ def test_service_bot_expands_to_publication_cards_before_pagination() -> None:
         access_service=access,
         business_space=NoopBusinessSpaceContext(),
         lifecycle_view=BotLifecycleView(lifecycle_port),
+        template_port=_StubTemplatePort(),
     )
 
     items, total = inventory.list_items(
@@ -417,6 +435,7 @@ def test_team_space_lists_all_owners_and_scopes_actions_by_bot_permission() -> N
         access_service=access,
         business_space=business_space,
         lifecycle_view=BotLifecycleView(lifecycle_port),
+        template_port=_StubTemplatePort(),
     )
 
     items, total = inventory.list_items(
@@ -534,3 +553,112 @@ def test_service_upgrade_action_requires_admin() -> None:
     )
     assert admin_actions == (BotAction.VIEW, BotAction.UPGRADE)
     assert admin_disabled == {"delete": "Bot Owner permission required"}
+
+
+def _inventory_with(bot_rows: list[dict], stub: _StubTemplatePort) -> BotInventoryService:
+    bot = MagicMock()
+    bot.list_bots_by_conditions.return_value = {"total": len(bot_rows), "items": bot_rows}
+    desktop = MagicMock()
+    desktop.list_user_bots.return_value = []
+    access = MagicMock()
+    access.get_operable_permission_levels.side_effect = lambda **kwargs: {
+        int(row["id"]): PermissionLevel.OWNER for row in kwargs["bots"]
+    }
+    return BotInventoryService(
+        bot_service=bot,
+        desktop_service=desktop,
+        access_service=access,
+        business_space=NoopBusinessSpaceContext(),
+        lifecycle_view=BotLifecycleView(NoopServiceLifecyclePort()),
+        template_port=stub,
+    )
+
+
+def _template_bot(bot_id: str, row_id: int) -> dict:
+    return {
+        **CLOUD,
+        "id": row_id,
+        "bot_id": bot_id,
+        "bot_name": f"Bot {bot_id}",
+        "template_type": "applicationCoding",
+    }
+
+
+@pytest.mark.unit
+def test_page_slice_attaches_projected_template_config() -> None:
+    # Three template-backed bots, page_size=2 -> the port sees only the
+    # returned page's template-backed ids, and the stored ext is projected
+    # (token stripped) before it reaches the read model.
+    stub = _StubTemplatePort(
+        {
+            "b1": {"devflow_workflow": "w1", "token": "raw-secret"},
+            "b2": {"template_key": "normalCC", "runtime": "codefuse"},
+            "b3": {"devflow_workflow": "w3"},
+        }
+    )
+    inventory = _inventory_with(
+        [_template_bot("b1", 11), _template_bot("b2", 12), _template_bot("b3", 13)],
+        stub,
+    )
+
+    items, total = inventory.list_items(
+        owner_id="u1",
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
+        keyword=None,
+        engine=None,
+        deploy_mode=DeployMode.CLOUD,
+        page=1,
+        page_size=2,
+    )
+
+    assert total == 3
+    assert len(items) == 2
+    assert len(stub.calls) == 1
+    assert set(stub.calls[0]) == {"b1", "b2"}
+    assert items[0].template_type == "applicationCoding"
+    assert items[0].template_config == {"devflow_workflow": "w1"}
+    assert items[1].template_config == {"template_key": "normalCC"}
+
+
+@pytest.mark.unit
+def test_page_slice_without_template_bots_skips_the_port() -> None:
+    stub = _StubTemplatePort()
+    inventory = _inventory_with([CLOUD], stub)
+
+    items, _ = inventory.list_items(
+        owner_id="u1",
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
+        keyword=None,
+        engine=None,
+        deploy_mode=DeployMode.CLOUD,
+        page=1,
+        page_size=20,
+    )
+
+    assert items
+    assert stub.calls == []
+
+
+@pytest.mark.unit
+def test_page_slice_missing_template_row_leaves_config_none() -> None:
+    stub = _StubTemplatePort({})  # template row absent for the bot
+    inventory = _inventory_with([_template_bot("b1", 11)], stub)
+
+    items, _ = inventory.list_items(
+        owner_id="u1",
+        space=NoopBusinessSpaceContext().resolve_current(
+            owner_id="u1", header_space_id=None
+        ),
+        keyword=None,
+        engine=None,
+        deploy_mode=DeployMode.CLOUD,
+        page=1,
+        page_size=20,
+    )
+
+    assert items[0].template_type == "applicationCoding"
+    assert items[0].template_config is None

--- a/src/backend/tests/community/core/bot_management/test_template_public_view.py
+++ b/src/backend/tests/community/core/bot_management/test_template_public_view.py
@@ -1,0 +1,67 @@
+"""Allowlist projection of ``template_config`` for public responses.
+
+``ac_templates.ext`` legitimately stores engine secrets: the aicoding
+provisioning strategy persists ``bot_template_config.ext_config.thetaKey`` as
+an ``enc:v1:`` ciphertext, and the stable outer contract allows a plain
+``token``. The public listing faces must never echo either, and engine-owned
+extensions must default to "not surfaced" rather than "passed through" — this
+matrix pins that.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.bot_management.template_public_view import (
+    project_template_config_for_public,
+)
+
+
+def test_none_in_gives_none_out():
+    assert project_template_config_for_public(None) is None
+
+
+def test_empty_dict_gives_none_out():
+    assert project_template_config_for_public({}) is None
+
+
+def test_allowlisted_keys_survive():
+    config = {
+        "devflow_workflow": "release-notes",
+        "yuque_kb_repos": ["team/kb"],
+        "code_repos": ["team/svc"],
+        "template_key": "normalCC",
+        "template_uid": "tpl-1",
+    }
+    assert project_template_config_for_public(config) == config
+
+
+@pytest.mark.parametrize(
+    "secret_config",
+    [
+        {"devflow_workflow": "w", "token": "Bearer raw-secret"},
+        {
+            "devflow_workflow": "w",
+            "bot_template_config": {"ext_config": {"thetaKey": "enc:v1:deadbeef"}},
+        },
+        {"devflow_workflow": "w", "runtime": "codefuse"},
+        {"devflow_workflow": "w", "anything_engine_owned": {"nested": "blob"}},
+    ],
+)
+def test_everything_else_is_dropped(secret_config):
+    projected = project_template_config_for_public(secret_config)
+    assert projected == {"devflow_workflow": "w"}
+
+
+def test_projection_of_only_secrets_gives_none():
+    config = {"token": "Bearer raw-secret"}
+    assert project_template_config_for_public(config) is None
+
+
+def test_result_is_not_aliased_with_input():
+    config = {"devflow_workflow": "w", "yuque_kb_repos": ["a"]}
+    projected = project_template_config_for_public(config)
+    projected["yuque_kb_repos"].append("mutated")
+    projected["devflow_workflow"] = "mutated"
+    assert config["yuque_kb_repos"] == ["a"]
+    assert config["devflow_workflow"] == "w"

--- a/src/backend/tests/community/endpoints/test_openapi_bots.py
+++ b/src/backend/tests/community/endpoints/test_openapi_bots.py
@@ -306,13 +306,41 @@ _HAPPY_CASES = (
 #: ``bot_id``: the surface mints one, so the id is not knowable here.
 _HAPPY_BODIES = {
     ("GET", _BASE_PATH): {
-        "data": {"total": 1, "items": [{"bot_id": _BOT_ID, "owner_entity_id": _OWNER}]}
+        # Seeded bot has no template row and a NULL space_id, which resolves
+        # to the owner's synthetic personal space, so the row carries the
+        # template fields as nulls and the owner-view space summary.
+        "data": {
+            "total": 1,
+            "items": [
+                {
+                    "bot_id": _BOT_ID,
+                    "owner_entity_id": _OWNER,
+                    "template_type": None,
+                    "template_config": None,
+                    "space": {
+                        "space_id": f"personal:{_OWNER}",
+                        "name": "Personal",
+                        "kind": "personal",
+                    },
+                }
+            ],
+        }
     },
     ("POST", _BASE_PATH): {
         "data": {"bot_name": "created-bot", "owner_entity_id": _OWNER}
     },
     ("GET", f"{_BASE_PATH}/all"): {
-        "data": {"total": 1, "items": [{"bot_id": _BOT_ID, "owner_entity_id": _OWNER}]}
+        "data": {
+            "total": 1,
+            "items": [
+                {
+                    "bot_id": _BOT_ID,
+                    "owner_entity_id": _OWNER,
+                    "template_type": None,
+                    "template_config": None,
+                }
+            ],
+        }
     },
     ("GET", f"{_BASE_PATH}/ceiling"): {"data": {"ceiling": 5}},
     ("GET", f"{_BASE_PATH}/{{bot_id}}"): {

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -455,10 +455,47 @@
             "title": "Owner Entity Id",
             "type": "string"
           },
+          "space": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BusinessSpace"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Business space the bot's record is assigned to (owner view). Populated on the listing endpoints.",
+            "title": "Space"
+          },
           "status": {
             "description": "Lifecycle status. Values: 'PENDING' — created, its device is still being provisioned; 'ACTIVE' — running and reachable; 'FAILED' — device provisioning failed (restart, or delete and recreate); 'OFFLINE', 'RELEASING', 'RELEASED' — desktop-bot lifecycle states; 'RECYCLED', 'REACTIVATING' — dormant-bot reclaim states. New lifecycles can add values, so treat any value other than 'ACTIVE' as not ready for work.",
             "title": "Status",
             "type": "string"
+          },
+          "template_config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Server-projected template snapshot (display-safe subset; secrets never returned). Null without a template.",
+            "title": "Template Config"
+          },
+          "template_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Template type of the bot, e.g. 'applicationCoding'; null for bots created without a template.",
+            "title": "Template Type"
           }
         },
         "required": [
@@ -1183,6 +1220,31 @@
             "description": "Lifecycle status used by the owning view. Service cards expose draft/deploying/prestable/running/offline; other cards retain their owning service's status.",
             "title": "Status",
             "type": "string"
+          },
+          "template_config": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Server-projected template snapshot (display-safe subset; secrets never returned). Null without a template.",
+            "title": "Template Config"
+          },
+          "template_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Template type of the bot, e.g. 'applicationCoding'; null for bots created without a template.",
+            "title": "Template Type"
           }
         },
         "required": [


### PR DESCRIPTION
## Problem

The public bots listings expose neither template identity (`template_type` / display-safe `template_config`) nor each row's business-space assignment. Separately, the stored `ac_templates.ext` engine snapshot legitimately carries secrets (a plain `token`, and `bot_template_config.ext_config.thetaKey` as `enc:v1:` ciphertext), so wherever a listing attaches it, the raw snapshot must never reach the wire.

## Solution

- New allowlist projection `project_template_config_for_public` (`core/bot_management/template_public_view.py`): only display-safe keys (`code_repos`, `devflow_workflow`, `template_key`, `template_uid`, `yuque_kb_repos`) surface; everything else — including engine-owned extensions — defaults to dropped, and the projection result never aliases the stored snapshot.
- `GET /openapi/v1/bots` now carries `template_type`, the projected `template_config`, and the owner-view `space` summary per row. Spaces resolve once per distinct `ac_bots.space_id` per page through `BusinessSpaceContextProtocol`, preserving the synthetic `personal:<user>` fallback and the member-gated null for foreign spaces.
- The inventory read model (`GET /openapi/v1/bots/all`) gains the same template fields through a new `BotInventoryTemplatePort` (bound to `TemplateServiceInventoryTemplatePort`). Templates are attached only to the returned page slice, so the listing fan-out keeps `attach_templates=False` and template lookup failures degrade to "no snapshot" — template trouble never breaks a listing page.
- `Bot` / `BotInventoryItem` schemas extended with the nullable fields; gateway `bots.openapi.json` updated by hand to match (per the established hand-edit workflow, no full regen).

## Validation

Backend (`src/backend`, `uv run pytest`):

- `tests/community/core/bot_management/test_template_public_view.py` — 9 passed
- `tests/community/core/bot_inventory/services/test_bot_inventory_service.py`, `tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py`, `tests/community/adapters/http/openapi_v1/test_app_only_listings.py` — 68 passed
- `tests/community/adapters/http/openapi_v1/test_bots_endpoints.py`, `tests/community/endpoints/test_openapi_bots.py`, `tests/community/di/test_community_router_bindings_resolve.py` — 137 passed (the route-dependency walk resolves the new `BusinessSpaceContextProtocol` injection and the TemplateService-backed port against the community injector)
- `tests/community/adapters/http/openapi_v1/test_bots_data_init.py`, `dormant/test_dormant_handlers.py`, `test_openapi_error_schema.py` — 21 passed

Gateway (`src/gateway`, `uv run pytest tests/unit/core/forwarding/test_served_openapi.py tests/unit/core/forwarding/test_combined_schema_catalogs.py`) — 33 passed.

## Compatibility and risk

Additive nullable fields on `Bot` and `BotInventoryItem`; no field is renamed or removed, so existing consumers only observe new null-valued keys. Secrets that were never returned remain absent — pinned by the projection unit matrix and the endpoint wire cases.