### PR TITLE
fix(bcs): align visibility gating by viewer kind (search + friend-add)Dev friend notify

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -983,6 +983,7 @@ dependencies = [
  "bcs-user-directory-api",
  "serde_json",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/bots.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/bots.rs
@@ -527,9 +527,51 @@ pub async fn search_bots(
         ));
     }
 
-    let effective_visibility = visibility.or_else(|| {
-        Some(vec!["public".to_string(), "protected".to_string()])
-    });
+    // Viewer kind selects WHICH visibility field gates discovery:
+    //   human viewer → judged by `user_visibility`; the bot-facing `visibility`
+    //     is neutralized (all three values match every NOT NULL row) so a
+    //     `visibility=private` bot with `user_visibility=public` stays
+    //     human-discoverable.
+    //   bot viewer / anonymous → judged by `visibility` (legacy default).
+    // Explicit `?visibility=` / `?user_visibility=` always override the default.
+    let viewer_type = q.viewer_actor_type.as_deref().map(str::trim).unwrap_or("");
+    let viewer_kind = match viewer_type {
+        "human" => Some(ActorKind::Human),
+        "bot" => Some(ActorKind::Bot),
+        _ => match caller_id.as_deref() {
+            Some(id) if id.starts_with("human_") => Some(ActorKind::Human),
+            Some(_) => Some(ActorKind::Bot),
+            None => None,
+        },
+    };
+    let default_scope = vec!["public".to_string(), "protected".to_string()];
+    let all_visibility = vec![
+        "public".to_string(),
+        "protected".to_string(),
+        "private".to_string(),
+    ];
+    let (effective_visibility, effective_user_visibility, infer_human_viewer) = match viewer_kind {
+        Some(ActorKind::Human) => (
+            Some(visibility.unwrap_or_else(|| all_visibility)),
+            Some(user_visibility.unwrap_or_else(|| default_scope.clone())),
+            viewer_actor_id.is_none(),
+        ),
+        Some(ActorKind::Bot) | None => (
+            Some(visibility.unwrap_or_else(|| default_scope.clone())),
+            user_visibility,
+            false,
+        ),
+    };
+    // Inferred human viewer: with no explicit viewer params, use the
+    // authenticated human caller as the viewer so the returned `is_friend`
+    // marker is computed against the human's friend edges. The friendship
+    // FILTER still requires explicit viewer params (guarded above), so this
+    // feeds the `is_friend` return field only — it does not change filtering.
+    let effective_viewer_actor_id = if infer_human_viewer {
+        caller_id.clone()
+    } else {
+        viewer_actor_id
+    };
 
     let result = state
         .services
@@ -537,10 +579,10 @@ pub async fn search_bots(
         .search_bots(SearchBotsCommand {
             q: q.q.clone(),
             visibility: effective_visibility,
-            user_visibility,
+            user_visibility: effective_user_visibility,
             status,
             requester_actor_id: caller_id.clone(),
-            viewer_actor_id,
+            viewer_actor_id: effective_viewer_actor_id,
             friendship: Some(match friendship {
                 FriendshipFilter::All => bcs_service_api::BotSearchFriendshipFilter::All,
                 FriendshipFilter::Friends => bcs_service_api::BotSearchFriendshipFilter::Friends,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bots_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bots_contract.rs
@@ -1314,7 +1314,7 @@ async fn search_bots_route_defaults_to_public_and_protected_without_bearer() {
 }
 
 #[tokio::test]
-async fn search_bots_route_omits_is_friend_without_explicit_viewer() {
+async fn search_bots_route_infers_human_viewer_from_caller() {
     let query = Arc::new(RecordingBotQueryService {
         search_result: Ok(BotSearchResult {
             items: vec![query_entry("bot-alpha")],
@@ -1328,8 +1328,12 @@ async fn search_bots_route_omits_is_friend_without_explicit_viewer() {
         ChainUserIdentityPort::new(chain),
     )));
 
-    // No visibility param means the route uses the default public + protected scope,
-    // while friendship is only calculated when explicit viewer params are present.
+    // A human caller without explicit viewer params: the viewer is inferred from
+    // the caller (`human_alice`) so the returned `is_friend` marker is computed
+    // against the human's friend edges; discoverability is judged by
+    // `user_visibility` (default public + protected) and `visibility` is
+    // neutralized (all three values ⇒ unfiltered). The friendship FILTER still
+    // requires explicit viewer params (see ..._rejects_friendship_filter_without_explicit_viewer).
     let response = app
         .oneshot(
             Request::builder()
@@ -1345,15 +1349,28 @@ async fn search_bots_route_omits_is_friend_without_explicit_viewer() {
     let json: Value = serde_json::from_slice(&body).unwrap();
     let items = json["items"].as_array().unwrap();
     assert_eq!(items.len(), 1);
+    // The recording stub does not compute is_friend; real computation against
+    // the inferred viewer's friend edges is exercised by integration tests.
     assert!(items[0].get("is_friend").is_none());
 
     let commands = query.search_commands.lock().await;
     assert_eq!(commands.len(), 1);
+    // `visibility` is neutralized for a human viewer (all three ⇒ unfiltered).
     assert_eq!(
         commands[0].visibility.as_ref().unwrap(),
+        &vec![
+            "public".to_string(),
+            "protected".to_string(),
+            "private".to_string()
+        ]
+    );
+    // ...and discoverability is gated by `user_visibility` (default public + protected).
+    assert_eq!(
+        commands[0].user_visibility.as_ref().unwrap(),
         &vec!["public".to_string(), "protected".to_string()]
     );
-    assert!(commands[0].viewer_actor_id.is_none());
+    // The human caller is inferred as the viewer so `is_friend` is computed.
+    assert_eq!(commands[0].viewer_actor_id.as_deref(), Some("human_alice"));
     assert_eq!(commands[0].requester_actor_id.as_deref(), Some("human_alice"));
 }
 
@@ -1397,6 +1414,13 @@ async fn search_bots_route_uses_explicit_viewer_for_is_friend_filter() {
     assert_eq!(commands.len(), 1);
     assert_eq!(commands[0].viewer_actor_id.as_deref(), Some("viewer-bot"));
     assert_eq!(commands[0].friendship, Some(bcs_service_api::BotSearchFriendshipFilter::Friends));
+    // bot viewer → discoverability judged by `visibility` (public + protected default);
+    // `user_visibility` stays None unless explicitly requested.
+    assert_eq!(
+        commands[0].visibility.as_ref().unwrap(),
+        &vec!["public".to_string(), "protected".to_string()]
+    );
+    assert!(commands[0].user_visibility.is_none());
 }
 
 #[tokio::test]

--- a/src/bcs/crates/bootstrap/bcs/src/friend_connect_notification.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/friend_connect_notification.rs
@@ -54,12 +54,21 @@ impl HttpFriendConnectNotificationPort {
         })
     }
 
-    fn build_request(
+    fn request_parts(
         &self,
         command: &FriendConnectNotificationCommand,
-        payload: &FriendWorkOrderEventRequest,
-    ) -> Result<reqwest::RequestBuilder, ServiceError> {
+    ) -> Result<(reqwest::Url, FriendWorkOrderEventRequest), ServiceError> {
         let url = self.work_order_url()?;
+        let payload = FriendWorkOrderEventRequest::from_command(command);
+        Ok((url, payload))
+    }
+
+    fn build_request_with_payload(
+        &self,
+        command: &FriendConnectNotificationCommand,
+        url: reqwest::Url,
+        payload: &FriendWorkOrderEventRequest,
+    ) -> reqwest::RequestBuilder {
         let mut request = self.client.post(url);
         // The backend internal endpoint authenticates BCS via the forwarded
         // gateway principal (`x-avernet-principal`) and derives the acting
@@ -75,7 +84,17 @@ impl HttpFriendConnectNotificationPort {
                 }
             }
         }
-        Ok(request.json(payload))
+        request.json(payload)
+    }
+
+    #[cfg(test)]
+    fn build_request(
+        &self,
+        command: &FriendConnectNotificationCommand,
+        payload: &FriendWorkOrderEventRequest,
+    ) -> Result<reqwest::RequestBuilder, ServiceError> {
+        let url = self.work_order_url()?;
+        Ok(self.build_request_with_payload(command, url, payload))
     }
 }
 
@@ -93,7 +112,7 @@ struct FriendWorkOrderEventRequest {
     recipient_user_ids: Vec<String>,
     title: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    content: Option<String>,
+    content: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     apply_reason: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -177,6 +196,34 @@ fn content_for(command: &FriendConnectNotificationCommand) -> String {
     }
 }
 
+fn friend_work_order_payload_for_log(payload: &FriendWorkOrderEventRequest) -> String {
+    serde_json::to_string(payload).unwrap_or_else(|error| {
+        format!("<failed to serialize friend work-order request payload: {error}>")
+    })
+}
+
+fn friend_work_order_non_success_error(
+    status: reqwest::StatusCode,
+    body: &str,
+    url: &reqwest::Url,
+    payload: &FriendWorkOrderEventRequest,
+    command: &FriendConnectNotificationCommand,
+) -> ServiceError {
+    warn!(
+        kind = %notification_kind_label(command.kind),
+        request_ids = ?command.request_ids,
+        target_bot_id = %command.target_bot_id,
+        status = %status,
+        url = %url,
+        response_body = %body,
+        request_payload = %friend_work_order_payload_for_log(payload),
+        "friend-connect notification failed"
+    );
+    ServiceError::InternalError(format!(
+        "friend work-order create request returned {status}: {body}"
+    ))
+}
+
 impl FriendWorkOrderEventRequest {
     fn from_command(command: &FriendConnectNotificationCommand) -> Self {
         let event_type = event_type_for(command.kind, &command.applicant_actor_id);
@@ -215,7 +262,7 @@ impl FriendWorkOrderEventRequest {
             approver_user_ids,
             recipient_user_ids,
             title: title_for(command.kind).to_string(),
-            content: Some(content_for(command)),
+            content: Some(serde_json::json!({ "text": content_for(command) })),
             apply_reason: command.message.clone(),
             biz_data: Some(biz_data),
         }
@@ -241,12 +288,10 @@ impl FriendConnectNotificationPort for HttpFriendConnectNotificationPort {
             recipient_count = command.recipient_user_ids.len(),
             "sending friend-connect notification"
         );
-        let payload = FriendWorkOrderEventRequest::from_command(&command);
-        let request_body = serde_json::to_string(&payload).unwrap_or_else(|error| {
-            format!(r#"{{"serialization_error":"{error}"}}"#)
-        });
+        let (url, payload) = self.request_parts(&command)?;
+        let request_payload = friend_work_order_payload_for_log(&payload);
         let response = self
-            .build_request(&command, &payload)?
+            .build_request_with_payload(&command, url.clone(), &payload)
             .send()
             .await
             .map_err(|error| {
@@ -254,7 +299,8 @@ impl FriendConnectNotificationPort for HttpFriendConnectNotificationPort {
                     kind = %notification_kind_label(command.kind),
                     request_ids = ?command.request_ids,
                     target_bot_id = %command.target_bot_id,
-                    request_body = %request_body,
+                    url = %url,
+                    request_payload = %request_payload,
                     error = %error,
                     "friend-connect notification request failed"
                 );
@@ -274,18 +320,13 @@ impl FriendConnectNotificationPort for HttpFriendConnectNotificationPort {
         }
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        warn!(
-            kind = %notification_kind_label(command.kind),
-            request_ids = ?command.request_ids,
-            target_bot_id = %command.target_bot_id,
-            request_body = %request_body,
-            status = %status,
-            response_body = %body,
-            "friend-connect notification failed"
-        );
-        Err(ServiceError::InternalError(format!(
-            "friend work-order create request returned {status}: {body}"
-        )))
+        Err(friend_work_order_non_success_error(
+            status,
+            &body,
+            &url,
+            &payload,
+            &command,
+        ))
     }
 }
 
@@ -379,6 +420,55 @@ mod tests {
     }
 
     #[test]
+    fn non_success_error_logs_request_payload_with_json_content_and_approvers() {
+        let payload = FriendWorkOrderEventRequest::from_command(&FriendConnectNotificationCommand {
+            kind: FriendConnectNotificationKind::ApprovalRequested,
+            env: "dev".to_string(),
+            request_ids: vec!["1".to_string()],
+            applicant_actor_id: "human_1001".to_string(),
+            target_bot_id: "bot_2001".to_string(),
+            recipient_user_ids: vec!["user_2001".to_string()],
+            message: Some("please add me".to_string()),
+            request_auth: None,
+        });
+        let url = reqwest::Url::parse(
+            "https://backend.example.com/api/v1/work-orders/events",
+        )
+        .expect("url");
+
+        let command = FriendConnectNotificationCommand {
+            kind: FriendConnectNotificationKind::ApprovalRequested,
+            env: "dev".to_string(),
+            request_ids: vec!["1".to_string()],
+            applicant_actor_id: "human_1001".to_string(),
+            target_bot_id: "bot_2001".to_string(),
+            recipient_user_ids: vec!["user_2001".to_string()],
+            message: Some("please add me".to_string()),
+            request_auth: None,
+        };
+        let error = friend_work_order_non_success_error(
+            reqwest::StatusCode::UNPROCESSABLE_ENTITY,
+            "Invalid request",
+            &url,
+            &payload,
+            &command,
+        );
+        assert!(matches!(error, ServiceError::InternalError(message) if message.contains("422 Unprocessable Entity")));
+
+        let logged_payload: serde_json::Value = serde_json::from_str(
+            &friend_work_order_payload_for_log(&payload),
+        )
+        .expect("request payload log is json");
+        assert_eq!(
+            logged_payload["content"],
+            serde_json::json!({
+                "text": "human_1001 申请添加 Bot bot_2001 为好友，请在好友申请列表中处理。"
+            })
+        );
+        assert_eq!(logged_payload["approver_user_ids"], serde_json::json!(["user_2001"]));
+    }
+
+    #[test]
     fn builds_pending_friend_request_payload() {
         let payload = FriendWorkOrderEventRequest::from_command(&FriendConnectNotificationCommand {
             kind: FriendConnectNotificationKind::ApprovalRequested,
@@ -401,8 +491,10 @@ mod tests {
         assert!(payload.recipient_user_ids.is_empty());
         assert_eq!(payload.title, "好友添加申请待审批");
         assert_eq!(
-            payload.content.as_deref(),
-            Some("human_1001 申请添加 Bot bot_2001 为好友，请在好友申请列表中处理。")
+            payload.content,
+            Some(serde_json::json!({
+                "text": "human_1001 申请添加 Bot bot_2001 为好友，请在好友申请列表中处理。"
+            }))
         );
         assert_eq!(
             payload.biz_data,
@@ -413,6 +505,34 @@ mod tests {
                 "notification_kind": "approval_requested",
                 "message": "please add me"
             }))
+        );
+    }
+
+    #[test]
+    fn serializes_content_as_json_object_and_keeps_approvers() {
+        let payload = FriendWorkOrderEventRequest::from_command(&FriendConnectNotificationCommand {
+            kind: FriendConnectNotificationKind::ApprovalRequested,
+            env: "dev".to_string(),
+            request_ids: vec!["1".to_string()],
+            applicant_actor_id: "human_1001".to_string(),
+            target_bot_id: "bot_2001".to_string(),
+            recipient_user_ids: vec!["user_2001".to_string()],
+            message: Some("please add me".to_string()),
+            request_auth: None,
+        });
+
+        let serialized = serde_json::to_value(&payload).expect("serialize payload");
+        assert!(serialized["content"].is_object(), "content must be a JSON object for backend schema");
+        assert_eq!(
+            serialized["content"],
+            serde_json::json!({
+                "text": "human_1001 申请添加 Bot bot_2001 为好友，请在好友申请列表中处理。"
+            })
+        );
+        assert_eq!(
+            serialized["approver_user_ids"],
+            serde_json::json!(["user_2001"]),
+            "approval notifications must pass target owner ids as approvers"
         );
     }
 
@@ -458,8 +578,10 @@ mod tests {
         assert_eq!(payload.title, "好友添加申请待审批");
         assert_eq!(payload.apply_reason.as_deref(), Some("bot-to-bot"));
         assert_eq!(
-            payload.content.as_deref(),
-            Some("bot_1001 申请添加 Bot bot_2001 为好友，请在好友申请列表中处理。")
+            payload.content,
+            Some(serde_json::json!({
+                "text": "bot_1001 申请添加 Bot bot_2001 为好友，请在好友申请列表中处理。"
+            }))
         );
     }
 
@@ -484,8 +606,10 @@ mod tests {
         assert_eq!(payload.title, "好友添加申请已处理");
         assert_eq!(payload.apply_reason.as_deref(), Some("handled"));
         assert_eq!(
-            payload.content.as_deref(),
-            Some("human_1001 与 Bot bot_2001 的好友申请已处理。")
+            payload.content,
+            Some(serde_json::json!({
+                "text": "human_1001 与 Bot bot_2001 的好友申请已处理。"
+            }))
         );
     }
 

--- a/src/bcs/crates/services/bcs-edge-permission-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-edge-permission-store/src/lib.rs
@@ -995,7 +995,7 @@ impl DbBotActorConfigStore {
     /// SELECT the decision columns for `(bot_uuid, env)`. Excludes soft-deleted
     /// rows, mirroring the bot store read (`COALESCE(is_deleted, 0) = 0`).
     const SELECT_BOT_CONFIG_SQL: &'static str =
-        "SELECT bot_uuid, env, visibility, bot_info, status, created_by \
+        "SELECT bot_uuid, env, visibility, user_visibility, bot_info, status, created_by \
          FROM bcs_bots \
          WHERE bot_uuid = ? AND env = ? AND COALESCE(is_deleted, 0) = 0 LIMIT 1";
 }
@@ -1150,17 +1150,17 @@ fn row_to_edge_grant(row: &DbRow) -> ServiceResult<EdgeGrant> {
 
 /// Map a `bcs_bots` row to a [`BotActorConfig`].
 ///
-/// `created_by` is `NULL` for legacy bots. `bot_info` carries the existing
-/// internal attributes payload and is reused for friend gating defaults.
+/// `created_by` is `NULL` for legacy bots. `user_visibility` is read from its
+/// own `bcs_bots.user_visibility` column — the same column the internal-
+/// attributes PATCH writes — so friend-gating sees the value the operator
+/// actually set (rather than a `bot_info` default that no write path populates).
+/// `bot_info` still carries `friend_check_in_strategy` / `friend_ext`.
 fn row_to_bot_actor_config(row: &DbRow) -> ServiceResult<BotActorConfig> {
     let bot_info = optional_string(row, "bot_info")?
         .and_then(|value| serde_json::from_str::<serde_json::Value>(&value).ok())
         .unwrap_or_default();
-    let user_visibility = bot_info
-        .get("user_visibility")
-        .and_then(|value| value.as_str())
-        .unwrap_or("protected")
-        .to_string();
+    let user_visibility = optional_string(row, "user_visibility")?
+        .unwrap_or_else(|| "protected".to_string());
     let friend_check_in_strategy = bot_info
         .get("friend_check_in_strategy")
         .and_then(|value| value.as_str())
@@ -1797,6 +1797,7 @@ mod tests {
                 bot_uuid TEXT NOT NULL, \
                 env TEXT NOT NULL, \
                 visibility TEXT NOT NULL DEFAULT 'public', \
+                user_visibility TEXT NOT NULL DEFAULT 'protected', \
                 bot_info TEXT DEFAULT NULL, \
                 status TEXT NOT NULL DEFAULT 'online', \
                 created_by TEXT, \
@@ -1845,7 +1846,6 @@ mod tests {
         friend_ext: serde_json::Map<String, serde_json::Value>,
     ) {
         let bot_info = serde_json::json!({
-            "user_visibility": user_visibility,
             "friend_check_in_strategy": friend_check_in_strategy,
             "friend_ext": friend_ext,
         });
@@ -1854,12 +1854,13 @@ mod tests {
                 "seed_bot",
                 DbStatement::with_params(
                     "INSERT INTO bcs_bots \
-                     (bot_uuid, env, visibility, bot_info, status, created_by) \
-                     VALUES (?, ?, ?, ?, ?, ?)",
+                     (bot_uuid, env, visibility, user_visibility, bot_info, status, created_by) \
+                     VALUES (?, ?, ?, ?, ?, ?, ?)",
                     vec![
                         DbValue::from(bot_uuid),
                         DbValue::from(env),
                         DbValue::from(visibility),
+                        DbValue::from(user_visibility),
                         DbValue::from(serde_json::to_string(&bot_info).expect("bot_info json")),
                         DbValue::from(status),
                         match created_by {
@@ -1910,7 +1911,8 @@ mod tests {
         // Different env -> None (PK is bot_uuid + env).
         seed_bot(&store, "bot_b", "prod", "protected", "private", "DEPT_FREE", "hidden", None).await;
         assert!(store.get("bot_b", "dev").await.is_none());
-        // Same env row reads back; internal attributes come from bot_info.
+        // Same env row reads back; user_visibility comes from its column,
+        // friend_* still come from bot_info.
         let cfg = store.get("bot_b", "prod").await.expect("bot exists in prod");
         assert_eq!(cfg.user_visibility, "private");
         assert_eq!(cfg.friend_check_in_strategy, "DEPT_FREE");

--- a/src/bcs/crates/services/bcs-edge-permission/Cargo.toml
+++ b/src/bcs/crates/services/bcs-edge-permission/Cargo.toml
@@ -14,6 +14,7 @@ bcs-service-api = { workspace = true }
 bcs-user-directory-api = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
+++ b/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
@@ -227,10 +227,15 @@ impl ConnectService for DbConnectService {
         }
 
         // 5. Existing visibility/status gates.
+        // Bots collaborate under `visibility`; humans add under `user_visibility`
+        // (mirrors /bots/search viewer-kind selection). `visibility=private`
+        // blocks bot→bot collaboration; `user_visibility=private` blocks human→bot
+        // add. The bot-facing `visibility` no longer gates human callers, so a
+        // `visibility=private` + `user_visibility=public` bot stays human-addable.
         if cfg.status == "hidden" {
             return Err(ServiceError::BotHidden(to_bot.to_string()));
         }
-        if is_private_visibility(&cfg.visibility) {
+        if caller_kind == ActorKind::Bot && is_private_visibility(&cfg.visibility) {
             return Err(ServiceError::PrivateBotCannotCollaborate);
         }
         if caller_kind == ActorKind::Human && is_private_visibility(&cfg.user_visibility) {
@@ -245,7 +250,15 @@ impl ConnectService for DbConnectService {
                 .caller_department_matches_friend_allowlist(caller, &cfg, request_auth.as_ref())
                 .await;
         let needs_approval = !(friend_strategy == "open" || dept_free_auto_approved);
-        match normalize_policy_value(&cfg.visibility).as_str() {
+        // Dispatch on the caller-appropriate visibility: bots on `visibility`,
+        // humans on `user_visibility`. The matching `private` case is rejected
+        // above for that kind, so only public/protected reach here in practice.
+        let collab_visibility = if caller_kind == ActorKind::Human {
+            normalize_policy_value(&cfg.user_visibility)
+        } else {
+            normalize_policy_value(&cfg.visibility)
+        };
+        match collab_visibility.as_str() {
             "public" | "protected" => {
                 if needs_approval {
                     let request_ids = self
@@ -1384,6 +1397,7 @@ mod tests {
                 bot_uuid TEXT NOT NULL, \
                 env TEXT NOT NULL, \
                 visibility TEXT NOT NULL DEFAULT 'public', \
+                user_visibility TEXT NOT NULL DEFAULT 'protected', \
                 bot_info TEXT DEFAULT NULL, \
                 status TEXT NOT NULL DEFAULT 'online', \
                 created_by TEXT, \
@@ -1595,17 +1609,17 @@ mod tests {
         friend_ext: serde_json::Map<String, serde_json::Value>,
     ) {
         let bot_info = serde_json::json!({
-            "user_visibility": user_visibility,
             "friend_check_in_strategy": friend_check_in_strategy,
             "friend_ext": friend_ext,
         });
         db.execute(DbStatement::with_params(
             "INSERT INTO bcs_bots \
-             (bot_uuid, env, visibility, bot_info, status, created_by) \
-             VALUES (?, 'dev', ?, ?, ?, ?)",
+             (bot_uuid, env, visibility, user_visibility, bot_info, status, created_by) \
+             VALUES (?, 'dev', ?, ?, ?, ?, ?)",
             vec![
                 DbValue::from(bot_uuid),
                 DbValue::from(visibility),
+                DbValue::from(user_visibility),
                 DbValue::from(serde_json::to_string(&bot_info).expect("bot_info json")),
                 DbValue::from(status),
                 match created_by {
@@ -1696,12 +1710,16 @@ mod tests {
     #[tokio::test]
     async fn private_bot_rejected() {
         let (eg, pp, rq, bc, db) = assemble().await;
+        // visibility=private blocks bot→bot collaboration (a bot adding a
+        // private-visibility bot). Human callers are gated by `user_visibility`,
+        // not `visibility` — see user_visibility_private_for_human_caller and
+        // human_adds_visibility_private_user_visibility_public_bot_succeeds.
         seed_bot(&db, "x:priv", "private", "protected", "OPEN", "online", Some("85020")).await;
         let svc = service(&eg, &pp, &rq, &bc);
         let err = svc
-            .create_connect("human_1", "x:priv", None, None)
+            .create_connect("caller_bot:1", "x:priv", None, None)
             .await
-            .expect_err("private → PrivateBotCannotCollaborate");
+            .expect_err("bot→private visibility → PrivateBotCannotCollaborate");
         assert!(
             matches!(err, ServiceError::PrivateBotCannotCollaborate),
             "got {err:?}"
@@ -1718,6 +1736,24 @@ mod tests {
             .await
             .expect_err("user_visibility=private → Forbidden for human caller");
         assert!(matches!(err, ServiceError::Forbidden(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn human_adds_visibility_private_user_visibility_public_bot_succeeds() {
+        let (eg, pp, rq, bc, db) = assemble().await;
+        // visibility=private no longer blocks a human caller — humans are gated by
+        // `user_visibility=public`, so this bot is human-addable (mirrors the
+        // /bots/search viewer-kind selection).
+        seed_bot(&db, "x:privuvis", "private", "public", "OPEN", "online", Some("85020")).await;
+        let svc = service(&eg, &pp, &rq, &bc);
+        let res = svc
+            .create_connect("human_1", "x:privuvis", None, None)
+            .await
+            .expect("human→(visibility=private, user_visibility=public) is human-addable");
+        assert_eq!(res.status, ConnectStatus::Approved);
+        assert!(res.auto_accepted);
+        assert_eq!(res.edge_ids.len(), 1);
+        assert!(eg.has_friend_edge("human_1", "x:privuvis", "dev").await);
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
+++ b/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
@@ -26,6 +26,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use tracing::{info, warn};
 use uuid::Uuid;
 use bcs_domain::actor::ActorKind;
 use bcs_domain::edge_permission::{
@@ -665,20 +666,73 @@ impl DbConnectService {
         actor_id: &str,
         request_auth: Option<&RequestAuthHeaders>,
     ) -> Option<String> {
-        let user_directory = self.user_directory.as_ref()?;
+        let Some(user_directory) = self.user_directory.as_ref() else {
+            info!(
+                actor_id = %actor_id,
+                env = %self.env,
+                "skip user department lookup because user directory is not configured"
+            );
+            return None;
+        };
         let staff_no = match actor_kind_of(actor_id) {
-            ActorKind::Human => actor_id.strip_prefix("human_")?.to_string(),
+            ActorKind::Human => match actor_id.strip_prefix("human_").filter(|staff_no| !staff_no.is_empty()) {
+                Some(staff_no) => staff_no.to_string(),
+                None => {
+                    warn!(
+                        actor_id = %actor_id,
+                        env = %self.env,
+                        "skip user department lookup because human actor id has no staff_no"
+                    );
+                    return None;
+                }
+            },
             ActorKind::Bot => {
-                let cfg = self.bot_config.get(actor_id, &self.env).await?;
-                cfg.created_by?
+                let Some(cfg) = self.bot_config.get(actor_id, &self.env).await else {
+                    info!(
+                        actor_id = %actor_id,
+                        env = %self.env,
+                        "skip user department lookup because bot config was not found"
+                    );
+                    return None;
+                };
+                let Some(created_by) = cfg.created_by else {
+                    info!(
+                        actor_id = %actor_id,
+                        env = %self.env,
+                        "skip user department lookup because bot owner staff_no is missing"
+                    );
+                    return None;
+                };
+                created_by
             }
         };
         let lookup_context = user_directory_lookup_context(request_auth);
-        user_directory
+        match user_directory
             .lookup_department_by_staff_no_with_context(&staff_no, &lookup_context)
             .await
-            .ok()
-            .flatten()
+        {
+            Ok(department) => {
+                info!(
+                    actor_id = %actor_id,
+                    staff_no = %staff_no,
+                    department_code = department.as_deref().unwrap_or(""),
+                    found = department.is_some(),
+                    env = %self.env,
+                    "resolved user department for friend connect allowlist check"
+                );
+                department
+            }
+            Err(error) => {
+                warn!(
+                    actor_id = %actor_id,
+                    staff_no = %staff_no,
+                    error = %error,
+                    env = %self.env,
+                    "failed to resolve user department for friend connect allowlist check"
+                );
+                None
+            }
+        }
     }
 
     async fn caller_department_matches_friend_allowlist(
@@ -1447,6 +1501,37 @@ mod tests {
     }
 
     #[derive(Clone, Default)]
+    struct FailingUserDirectoryPlugin;
+
+    #[async_trait]
+    impl UserDirectoryPlugin for FailingUserDirectoryPlugin {
+        async fn lookup_by_staff_no(
+            &self,
+            staff_no: &str,
+        ) -> Result<Option<bcs_user_directory_api::UserDirectoryProfile>, bcs_user_directory_api::UserDirectoryError> {
+            Ok(Some(bcs_user_directory_api::UserDirectoryProfile {
+                staff_no: staff_no.to_string(),
+                nick_name: None,
+            }))
+        }
+
+        async fn lookup_department_by_staff_no(
+            &self,
+            _staff_no: &str,
+        ) -> Result<Option<String>, bcs_user_directory_api::UserDirectoryError> {
+            Err(bcs_user_directory_api::UserDirectoryError::Request("boom".to_string()))
+        }
+
+        async fn lookup_department_by_staff_no_with_context(
+            &self,
+            _staff_no: &str,
+            _context: &UserDirectoryLookupContext,
+        ) -> Result<Option<String>, bcs_user_directory_api::UserDirectoryError> {
+            Err(bcs_user_directory_api::UserDirectoryError::Request("boom".to_string()))
+        }
+    }
+
+    #[derive(Clone, Default)]
     struct RecordingFriendConnectNotificationPort {
         events: Arc<tokio::sync::Mutex<Vec<FriendConnectNotificationCommand>>>,
     }
@@ -1656,6 +1741,83 @@ mod tests {
         assert_eq!(r.edge_id, Some(res.edge_ids[0]));
     }
 
+
+    #[tokio::test]
+    async fn department_lookup_logs_success_result_path() {
+        let (eg, pp, rq, bc, db) = assemble().await;
+        seed_bot(
+            &db,
+            "human_1",
+            "protected",
+            "protected",
+            "APPROVAL",
+            "online",
+            Some("85020"),
+        )
+        .await;
+        let departments = Arc::new(StaticUserDirectoryPlugin {
+            departments: Arc::new(std::collections::HashMap::from([(
+                "1".to_string(),
+                "F4858".to_string(),
+            )])),
+        });
+        let svc = service_with_departments(&eg, &pp, &rq, &bc, departments);
+
+        assert_eq!(
+            svc.resolve_user_department_code("human_1", None).await.as_deref(),
+            Some("F4858")
+        );
+    }
+
+    #[tokio::test]
+    async fn department_lookup_logs_failure_result_path() {
+        let (eg, pp, rq, bc, db) = assemble().await;
+        seed_bot(
+            &db,
+            "human_1",
+            "protected",
+            "protected",
+            "APPROVAL",
+            "online",
+            Some("85020"),
+        )
+        .await;
+        let svc = service_with_departments(&eg, &pp, &rq, &bc, Arc::new(FailingUserDirectoryPlugin));
+
+        assert_eq!(svc.resolve_user_department_code("human_1", None).await, None);
+    }
+
+    #[tokio::test]
+    async fn department_lookup_logs_missing_directory_path() {
+        let (eg, pp, rq, bc, _db) = assemble().await;
+        let svc = service(&eg, &pp, &rq, &bc);
+
+        assert_eq!(svc.resolve_user_department_code("human_1", None).await, None);
+    }
+
+    #[tokio::test]
+    async fn department_lookup_logs_skip_paths() {
+        let (eg, pp, rq, bc, db) = assemble().await;
+        let departments = Arc::new(StaticUserDirectoryPlugin {
+            departments: Arc::new(std::collections::HashMap::new()),
+        });
+        let svc = service_with_departments(&eg, &pp, &rq, &bc, departments);
+
+        assert_eq!(svc.resolve_user_department_code("human_", None).await, None);
+        assert_eq!(svc.resolve_user_department_code("x:missing", None).await, None);
+
+        seed_bot(
+            &db,
+            "x:no_owner",
+            "protected",
+            "protected",
+            "APPROVAL",
+            "online",
+            None,
+        )
+        .await;
+        assert_eq!(svc.resolve_user_department_code("x:no_owner", None).await, None);
+    }
 
     #[tokio::test]
     async fn dept_free_allowlist_stays_pending_with_noop_department_port() {


### PR DESCRIPTION
 user_visibility was read from the bot_info JSON, which no write path
    populates (it defaults to "protected"), so the user_visibility friend gate
    was effectively dead. Realign so the bot-facing `visibility` gates bots and
    the human-facing `user_visibility` gates humans, consistently across search
    and friend-add.
    
    - bcs-edge-permission-store: row_to_bot_actor_config now reads
      user_visibility from the bcs_bots.user_visibility column (the column the
      internal-attributes PATCH writes); SELECT + test schemas/seeds updated.
    - bcs-http /bots/search: select the visibility field by viewer kind — human
      viewers are gated by user_visibility, bot viewers by visibility; the
      non-active field is unfiltered unless its own query param is given. When
      the viewer is inferred as human from the authenticated caller, pass it as
      viewer_actor_id so the returned is_friend marker is computed against the
      human's friend edges (the friendship FILTER still requires explicit viewer).
    - bcs-edge-permission create_connect: mirror search — visibility=private
      blocks bot->bot only (no longer human callers); the dispatch match keys on
      user_visibility for human callers and visibility for bot callers. So a
      visibility=private + user_visibility=public bot stays human-discoverable
      and human-addable; bots still cannot collaborate with it.
    
    Tests: bcs-edge-permission-store 14, bcs-edge-permission 51, bcs-http
    bots_contract 31, bootstrap integration_friendship 15 — all green.