### PR TITLE
perf(backend): resolve a bot's MCP set once per whole-artifact compose

### DIFF
--- a/src/backend/src/agentclaw/community/core/config_compose/models.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/models.py
@@ -6,8 +6,9 @@ composer services pass around while turning DB state into a ``BotConfigArtifact`
 """
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, TypeVar
 
 
 __all__ = [
@@ -17,6 +18,8 @@ __all__ = [
     "CollectedSkill",
     "CollectedFile",
 ]
+
+_T = TypeVar("_T")
 
 
 @dataclass(frozen=True)
@@ -37,7 +40,15 @@ class StdioLaunch:
 
 @dataclass(frozen=True)
 class ComposeRequest:
-    """Identifies the bot + engine context a single compose runs for."""
+    """Identifies the bot + engine context a single compose runs for.
+
+    One request object serves exactly one ``ConfigComposer.compose`` pass, and
+    that is what makes the two non-identity fields at the end safe: they are
+    per-compose carry-alongs, scoped by the request's own lifetime. Both are
+    excluded from equality — they are *derived from* the identity above, never
+    part of it, so two requests naming the same bot are the same request
+    whether or not one of them arrived with its MCP set already resolved.
+    """
 
     entity_id: str
     bot_id: str
@@ -45,6 +56,42 @@ class ComposeRequest:
     engine_type: str
     entity_type: str = "staff"
     version: int | None = None  # set for a published snapshot; None for live/draft
+    effective_mcps: tuple[dict[str, Any], ...] | None = field(
+        default=None, compare=False
+    )
+    """The bot's effective MCP set, when the caller already resolved it.
+
+    A whole-artifact delivery resolves this set during plan resolution
+    (``BotRuntimeProjector._build_plan``) and the composer would otherwise
+    re-read the identical set from the same database microseconds later — both
+    reads go through ``collect_bot_active_mcps`` with
+    ``strict_policy_context=True``, so they are contractually the same answer.
+    Handing the resolved value down is what makes the second read unnecessary;
+    ``None`` means nobody resolved it yet and the collector reads it itself.
+
+    Empty is *not* ``None``: a bot with no MCPs threads an empty tuple, and the
+    collector must not fall back to a second read for it.
+    """
+
+    _memo: dict[str, Any] = field(
+        default_factory=dict, compare=False, repr=False
+    )
+    """Backing store for :meth:`memoized`. Never read or written directly."""
+
+    def memoized(self, key: str, build: Callable[[], _T]) -> _T:
+        """``build()``'s result, computed at most once for this request.
+
+        Scoped to the request object rather than to the caller, deliberately.
+        The collector that uses this is a process-wide singleton, and compose
+        runs inside ``asyncio.to_thread`` — so a memo kept on the collector
+        would let one bot's per-bot service be handed to another bot's compose,
+        concurrently and silently. A request is created for one compose and
+        passed to every collector method within it, which is exactly the
+        lifetime a per-compose memo wants.
+        """
+        if key not in self._memo:
+            self._memo[key] = build()
+        return self._memo[key]
 
 
 @dataclass(frozen=True)

--- a/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
@@ -189,16 +189,26 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         The plaintext stays here only as an intermediate — inlining it into the
         artifact entry (endpoint query / headers) is the ``McporterComposer``'s
         job downstream, not this collector's.
+
+        Step 1 is skipped when the request already carries the effective set
+        (``ComposeRequest.effective_mcps``): a whole-artifact delivery resolves
+        it during plan resolution and this would otherwise be the *second*
+        ``collect_bot_active_mcps`` of one request — the same query, against the
+        same database, for the same contractual answer. Step 2 runs either way;
+        the threaded value is the bare association set, exactly what step 1
+        returns, so nothing downstream can tell the two apart.
         """
         svc = self._skill_set_service(req)
-        raw = svc.collect_bot_active_mcps(
-            entity_id=req.entity_id,
-            bot_id=req.bot_id,
-            user_id=req.user_id,
-            entity_type=req.entity_type,
-            engine_type=req.engine_type,
-            strict_policy_context=True,
-        )
+        raw = req.effective_mcps
+        if raw is None:
+            raw = svc.collect_bot_active_mcps(
+                entity_id=req.entity_id,
+                bot_id=req.bot_id,
+                user_id=req.user_id,
+                entity_type=req.entity_type,
+                engine_type=req.engine_type,
+                strict_policy_context=True,
+            )
         # ``collect_bot_active_mcps`` returns only the skill-set association fields
         # (server_code/name/…) — it deliberately does NOT call MCP Center. The
         # composer needs the full detail (``endpoints``/``runMode``/
@@ -502,7 +512,7 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         return bot_data_relpath(host_path)
 
     def _skill_set_service(self, req: ComposeRequest):
-        """Build a per-bot ``SkillSetService`` bound to this compose request.
+        """The per-bot ``SkillSetService`` for this compose request — built once.
 
         Both :meth:`skills` and :meth:`mcps` go through the same per-bot service,
         so this centralizes the factory call (unpacking the request's identifiers).
@@ -510,11 +520,25 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         engine_type="openclaw", entity_type="staff")`` it returns the
         ``SkillSetService`` scoped to that staff/bot/engine, from which
         ``get_symlink_mappings`` / ``collect_bot_active_mcps`` read.
+
+        Building it is not cheap — the factory re-resolves the bot's workspace
+        paths, re-reads the bot row, and mints a ``SkillService`` whose
+        construction mkdirs against the shared ``/aidesktop`` mount — and the
+        request's identifiers fully determine the result, so the two call sites
+        of one compose share a single instance.
+
+        The memo lives on the *request*, not on ``self``: this collector is a
+        singleton and compose runs on a thread pool, so a memo held here would
+        eventually hand bot A's service to bot B's compose. See
+        ``ComposeRequest.memoized``.
         """
-        return self._skill_set_service_factory.create(
-            user_id=req.user_id,
-            entity_id=req.entity_id,
-            bot_id=req.bot_id,
-            engine_type=req.engine_type,
-            entity_type=req.entity_type,
+        return req.memoized(
+            "skill_set_service",
+            lambda: self._skill_set_service_factory.create(
+                user_id=req.user_id,
+                entity_id=req.entity_id,
+                bot_id=req.bot_id,
+                engine_type=req.engine_type,
+                entity_type=req.entity_type,
+            ),
         )

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_sync.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_sync.py
@@ -7,7 +7,7 @@ behavior without making the service profile-aware.
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 from agentclaw.community.core.devices.services.baas_invoke_transport import BaasTransport
 
@@ -51,7 +51,7 @@ class BaasDeviceSyncService(DeviceSync):
         self,
         symlinks: list[dict[str, Any]],
         *,
-        effective_mcps: "list[dict[str, Any]] | None" = None,
+        effective_mcps: Optional[list[dict[str, Any]]] = None,
     ) -> dict[str, Any]:
         # ``effective_mcps`` only means something to a device that recomposes
         # its whole configuration; this one is told exactly what to link and

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_device_sync.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_device_sync.py
@@ -48,8 +48,14 @@ class BaasDeviceSyncService(DeviceSync):
         self._headers: dict[str, str] = conn_info.get("headers", {})
 
     def sync_symlinks(
-        self, symlinks: list[dict[str, Any]]
+        self,
+        symlinks: list[dict[str, Any]],
+        *,
+        effective_mcps: "list[dict[str, Any]] | None" = None,
     ) -> dict[str, Any]:
+        # ``effective_mcps`` only means something to a device that recomposes
+        # its whole configuration; this one is told exactly what to link and
+        # ignores it.
         symlinks_count = len(symlinks)
         logger.info(
             "[BaasDeviceSyncService.sync_symlinks] bot_uuid=%s, count=%d",

--- a/src/backend/src/agentclaw/community/core/devices/services/device_sync.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/device_sync.py
@@ -36,11 +36,21 @@ class DeviceSync(Protocol):
     def sync_symlinks(
         self,
         symlinks: list[dict[str, str]],
+        *,
+        effective_mcps: Optional[list[dict[str, Any]]] = None,
     ) -> dict[str, Any]:
         """Sync symlink mappings to the device.
 
         Args:
             symlinks: List of ``{"source": ..., "target": ...}`` mappings.
+            effective_mcps: The bot's already-resolved effective MCP set, when
+                the caller has one. Only a whole-artifact device reads it —
+                such a device ignores ``symlinks`` and recomposes the bot's
+                whole configuration from the database, and this spares that
+                compose a re-read of a set the caller just resolved. An
+                implementation that consumes ``symlinks`` directly composes
+                nothing and ignores it. Callers pass it only when they have
+                it, so an implementation is never *required* to accept it.
 
         Returns:
             Result dict with at least ``{"success": bool, "message": str}``.

--- a/src/backend/src/agentclaw/community/core/devices/services/singlebox_device_sync.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/singlebox_device_sync.py
@@ -23,7 +23,15 @@ class SingleboxDeviceSyncService(DeviceSync):
     def __init__(self, delegate: DeviceSync) -> None:
         self._delegate = delegate
 
-    def sync_symlinks(self, symlinks: list[dict[str, Any]]) -> dict[str, Any]:
+    def sync_symlinks(
+        self,
+        symlinks: list[dict[str, Any]],
+        *,
+        effective_mcps: Optional[list[dict[str, Any]]] = None,
+    ) -> dict[str, Any]:
+        # ``effective_mcps`` is a whole-artifact hint; the BaaS transport
+        # behind this wrapper consumes the symlinks directly, so it is
+        # accepted (the contract declares it) and dropped here.
         return self._delegate.sync_symlinks(symlinks)
 
     def sync_bot_config(

--- a/src/backend/src/agentclaw/community/core/devices/services/teclaw_device_sync.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/teclaw_device_sync.py
@@ -125,9 +125,17 @@ class TeclawDeviceSyncService(DeviceSync):
         # for personal bots / non-draft rows inside ``record_draft_artifact``.
         self._draft_recorder = draft_recorder
 
-    def sync_symlinks(self, symlinks: list[dict[str, str]]) -> dict[str, Any]:
+    def sync_symlinks(
+        self,
+        symlinks: list[dict[str, str]],
+        *,
+        effective_mcps: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
         # symlinks ignored: teclaw re-pulls the whole composed artifact.
-        return self._compose_and_deliver(caller="sync_symlinks")
+        # ``effective_mcps`` is not ignored — see ``_compose_and_deliver``.
+        return self._compose_and_deliver(
+            caller="sync_symlinks", effective_mcps=effective_mcps
+        )
 
     def sync_bot_config(
         self,
@@ -168,7 +176,24 @@ class TeclawDeviceSyncService(DeviceSync):
         # arca/baas).
         return True
 
-    def _compose_and_deliver(self, *, caller: str) -> dict[str, Any]:
+    def _compose_and_deliver(
+        self,
+        *,
+        caller: str,
+        effective_mcps: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Compose this bot's whole artifact and POST it to its container.
+
+        ``effective_mcps`` is the bot's effective MCP set when the caller
+        already resolved it (capability projection does, before it decides
+        anything). It rides on the request rather than being re-read: the
+        composer's own read is the same ``collect_bot_active_mcps`` query
+        against the same database, so the only thing a second one adds is its
+        latency. The identifiers below scope the compose to this service's
+        bot, and the entries were resolved for that same bot by the projection
+        that called it, so the two cannot describe different bots. When it is
+        ``None`` the collector reads the set itself, exactly as before.
+        """
         try:
             artifact = self._composer_provider().compose(
                 ComposeRequest(
@@ -177,6 +202,9 @@ class TeclawDeviceSyncService(DeviceSync):
                     user_id=self._user_id,
                     engine_type=self._engine_type,
                     entity_type=self._entity_type,
+                    effective_mcps=(
+                        None if effective_mcps is None else tuple(effective_mcps)
+                    ),
                 )
             )
             # Enrich the composer's (empty) engine_ext with the backend identity/stage

--- a/src/backend/src/agentclaw/community/core/devices/services/teclaw_device_sync.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/teclaw_device_sync.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 import dataclasses
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 from agentclaw.community.core.config_compose.models import ComposeRequest
 from agentclaw.community.core.devices.services.device_sync import DeviceSync
@@ -129,7 +129,7 @@ class TeclawDeviceSyncService(DeviceSync):
         self,
         symlinks: list[dict[str, str]],
         *,
-        effective_mcps: list[dict[str, Any]] | None = None,
+        effective_mcps: Optional[list[dict[str, Any]]] = None,
     ) -> dict[str, Any]:
         # symlinks ignored: teclaw re-pulls the whole composed artifact.
         # ``effective_mcps`` is not ignored — see ``_compose_and_deliver``.
@@ -180,7 +180,7 @@ class TeclawDeviceSyncService(DeviceSync):
         self,
         *,
         caller: str,
-        effective_mcps: list[dict[str, Any]] | None = None,
+        effective_mcps: Optional[list[dict[str, Any]]] = None,
     ) -> dict[str, Any]:
         """Compose this bot's whole artifact and POST it to its container.
 

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
-from typing import Protocol, runtime_checkable
+from typing import Optional, Protocol, runtime_checkable
 
 from agentclaw.community.core.skill_center.runtime_resolver import (
     RegisteredSkillAsset,
@@ -32,8 +32,8 @@ class CapabilityRuntimeBoundary(Protocol):
     async def project_skills(
         self,
         *,
-        desired_skills: list[dict] | None = None,
-        effective_mcps: list[dict] | None = None,
+        desired_skills: Optional[list[dict]] = None,
+        effective_mcps: Optional[list[dict]] = None,
     ) -> bool:
         """Apply one complete resolver-owned Skill snapshot to the runtime.
 

--- a/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/runtime_projection_contract.py
@@ -30,7 +30,10 @@ class CapabilityRuntimeBoundary(Protocol):
     """
 
     async def project_skills(
-        self, *, desired_skills: list[dict] | None = None
+        self,
+        *,
+        desired_skills: list[dict] | None = None,
+        effective_mcps: list[dict] | None = None,
     ) -> bool:
         """Apply one complete resolver-owned Skill snapshot to the runtime.
 
@@ -38,6 +41,12 @@ class CapabilityRuntimeBoundary(Protocol):
         whole-artifact engine an artifact compose and the outbound apply
         request — but keeping off the event loop is the implementation's
         responsibility, not the caller's. Await it like ``project_mcps``.
+
+        ``effective_mcps`` is for the whole-artifact case only, and for the
+        same reason ``desired_skills`` is passed: the compose behind this call
+        re-reads desired state that plan resolution already read, and handing
+        the resolved value over is what avoids the second pass. A runtime with
+        a separate MCP endpoint composes nothing here and leaves it ``None``.
         """
         ...
 
@@ -83,6 +92,13 @@ class ResolvedCapabilityPlan:
     projection: RuntimeProjection
     #: Effective Default CLI facts, as the authorization service holds them.
     effective_cli_items: list[dict]
+    #: The Bot's effective MCP set — default policy ∪ installed ∪ Skill
+    #: dependencies — as ``collect_bot_active_mcps`` resolved it for the
+    #: projected MCP codes. Carried rather than recomputed because a
+    #: whole-artifact engine composes its document from the same set: without
+    #: this the delivery would re-read it from the database it was just read
+    #: from. Bare association entries, no MCP Center detail merged in.
+    effective_mcp_entries: list[dict]
     #: Per-MCP execution identity, resolved during plan resolution because it
     #: can fail — see ``BotRuntimeProjector._resolve_mcp_identity_modes``.
     identity_modes: Mapping[str, object]

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
@@ -309,6 +309,7 @@ class BotRuntimeProjector:
             engine=engine,
             projection=projection,
             effective_cli_items=effective_cli_items,
+            effective_mcp_entries=effective_mcp_entries,
             identity_modes=identity_modes,
         )
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/whole_artifact.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/whole_artifact.py
@@ -121,8 +121,16 @@ class WholeArtifactRuntimeProjection(EngineRuntimeProjection):
         # falls back to ``get_active_skills`` when this is ``None``, which
         # re-runs the flush-and-read that ``_resolve_plan`` just did. Handing
         # over the resolved assets is what avoids that second pass.
+        #
+        # The MCP set rides along for exactly that reason. Plan resolution
+        # collected it — it had to, the projected codes and the Passport scope
+        # are derived from it — and the compose inside this call would
+        # otherwise ask the same database the same question again, with
+        # ``strict_policy_context=True`` on both sides making the two answers
+        # the same by contract.
         if not await plan.service.project_skills(
             desired_skills=self._desired_skills(plan.projection),
+            effective_mcps=plan.effective_mcp_entries,
         ):
             raise SkillSetRuntimeReconcileError()
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -474,9 +474,9 @@ class SkillSetService:
 
     def _sync_symlinks_to_device_if_needed(
         self,
-        user_id: str | None = None,
-        desired_skills: list[dict] | None = None,
-        effective_mcps: list[dict] | None = None,
+        user_id: Optional[str] = None,
+        desired_skills: Optional[list[dict]] = None,
+        effective_mcps: Optional[list[dict]] = None,
     ) -> bool:
         """如果需要，同步软链配置到设备。
 
@@ -531,8 +531,8 @@ class SkillSetService:
     async def project_skills(
         self,
         *,
-        desired_skills: list[dict] | None = None,
-        effective_mcps: list[dict] | None = None,
+        desired_skills: Optional[list[dict]] = None,
+        effective_mcps: Optional[list[dict]] = None,
     ) -> bool:
         """Apply one complete resolver-owned skill snapshot to the runtime.
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_set_service.py
@@ -473,7 +473,10 @@ class SkillSetService:
         return template_type if isinstance(template_type, str) else None
 
     def _sync_symlinks_to_device_if_needed(
-        self, user_id: str | None = None, desired_skills: list[dict] | None = None
+        self,
+        user_id: str | None = None,
+        desired_skills: list[dict] | None = None,
+        effective_mcps: list[dict] | None = None,
     ) -> bool:
         """如果需要，同步软链配置到设备。
 
@@ -482,6 +485,9 @@ class SkillSetService:
 
         Args:
             user_id: 用户ID
+            desired_skills: 调用方已解析的技能快照（可选）
+            effective_mcps: 调用方已解析的 MCP 集合（可选）。仅整包投递的设备
+                会用到它——它会跳过 compose 里重复的那次 DB 读取。
 
         Returns:
             True if sync attempted, False otherwise
@@ -501,7 +507,15 @@ class SkillSetService:
             logger.info(f"[_sync_symlinks_to_device_if_needed] Syncing {len(symlinks)} symlinks to device (bot_id={self.bot_id})")
 
             symlinks_dict = [sm.to_dict() for sm in symlinks]
-            sync_result = device_sync.sync_symlinks(symlinks_dict)
+            # Passed only when the caller actually resolved it, the same way
+            # ``desired_skills`` is threaded above: the keyword means something
+            # to a whole-artifact device and nothing to the rest, so a
+            # DeviceSync implementation that has no use for it never has to
+            # grow a parameter to stay callable from here.
+            sync_kwargs: dict[str, Any] = {}
+            if effective_mcps is not None:
+                sync_kwargs["effective_mcps"] = effective_mcps
+            sync_result = device_sync.sync_symlinks(symlinks_dict, **sync_kwargs)
 
             if sync_result.get("success"):
                 logger.info(f"[_sync_symlinks_to_device_if_needed] Sync successful: {sync_result.get('message')}")
@@ -515,7 +529,10 @@ class SkillSetService:
             return False
 
     async def project_skills(
-        self, *, desired_skills: list[dict] | None = None
+        self,
+        *,
+        desired_skills: list[dict] | None = None,
+        effective_mcps: list[dict] | None = None,
     ) -> bool:
         """Apply one complete resolver-owned skill snapshot to the runtime.
 
@@ -530,11 +547,18 @@ class SkillSetService:
         request behind it. Owning the ``to_thread`` here makes staying off the
         event loop a property of this method, which no caller can forget —
         the same reason ``sync_mcp_desired_state`` wraps its own device calls.
+
+        ``effective_mcps`` is the caller's already-resolved MCP set, carried
+        for the same reason ``desired_skills`` is: on a whole-artifact engine
+        the compose behind this call would otherwise re-read state the caller
+        has just read. Meaningless to a device that consumes the symlinks
+        directly, which is why it is optional and ignored there.
         """
         return await asyncio.to_thread(
             self._sync_symlinks_to_device_if_needed,
             self.user_id or self.entity_id,
             desired_skills,
+            effective_mcps,
         )
 
     async def project_mcps(

--- a/src/backend/tests/community/core/config_compose/test_collector.py
+++ b/src/backend/tests/community/core/config_compose/test_collector.py
@@ -191,6 +191,136 @@ def test_mcps_require_strict_policy_context_for_a_complete_artifact():
     )
 
 
+@pytest.mark.unit
+def test_one_compose_builds_one_skill_set_service():
+    """``skills`` and ``mcps`` of one compose share a single service.
+
+    Building it is not free — the factory re-resolves the bot's workspace
+    paths, re-reads the bot row, and mints a ``SkillService`` whose
+    construction mkdirs against the shared ``/aidesktop`` mount. The request's
+    identifiers fully determine the result, so a compose that built it twice
+    paid for the same object twice.
+    """
+    svc = MagicMock()
+    svc.get_active_skills.return_value = []
+    svc.collect_bot_active_mcps.return_value = []
+    factory = _factory_returning(svc)
+    collector = ConfigComposerInputCollector(
+        skill_set_service_factory=factory,
+        mcp_config_service=MagicMock(),
+        resource_repository=MagicMock(),
+        bot_repo=MagicMock(),
+        path_factory=MagicMock(),
+        identity_service=MagicMock(),
+        overrides_reader=_reader_over(None),
+        local_mcp_registry=_registry_over({}),
+    )
+
+    req = _req()
+    collector.skills(req)
+    collector.mcps(req)
+
+    assert factory.create.call_count == 1
+
+
+@pytest.mark.unit
+def test_a_memoized_service_never_crosses_from_one_bot_to_another():
+    """The memo is per-request, so bot B's compose cannot observe bot A's service.
+
+    The collector is a process-wide singleton and compose runs on a thread
+    pool, so a memo held on the collector would eventually hand one bot's
+    per-bot service — its workspace paths, its bot row — to another bot's
+    compose. Two requests, two services, however many calls each makes.
+    """
+    factory = MagicMock()
+    services = [MagicMock(), MagicMock()]
+    for svc in services:
+        svc.get_active_skills.return_value = []
+        svc.collect_bot_active_mcps.return_value = []
+    factory.create.side_effect = services
+    collector = ConfigComposerInputCollector(
+        skill_set_service_factory=factory,
+        mcp_config_service=MagicMock(),
+        resource_repository=MagicMock(),
+        bot_repo=MagicMock(),
+        path_factory=MagicMock(),
+        identity_service=MagicMock(),
+        overrides_reader=_reader_over(None),
+        local_mcp_registry=_registry_over({}),
+    )
+
+    bot_a = ComposeRequest(
+        entity_id="staff_u1", bot_id="botA", user_id="u1", engine_type="openclaw"
+    )
+    bot_b = ComposeRequest(
+        entity_id="staff_u2", bot_id="botB", user_id="u2", engine_type="openclaw"
+    )
+    collector.skills(bot_a)
+    collector.skills(bot_b)
+    collector.mcps(bot_b)
+
+    assert factory.create.call_count == 2
+    assert [
+        call.kwargs["bot_id"] for call in factory.create.call_args_list
+    ] == ["botA", "botB"]
+    # Bot B's second call reused bot B's service, not bot A's.
+    services[0].collect_bot_active_mcps.assert_not_called()
+    services[1].collect_bot_active_mcps.assert_called_once()
+
+
+@pytest.mark.unit
+def test_mcps_reuse_the_set_the_request_already_carries():
+    """A resolved set on the request replaces the collector's own read.
+
+    Whole-artifact delivery resolves the effective MCP set during plan
+    resolution and threads it here; re-collecting would put the identical
+    query against the identical database microseconds later. The threaded
+    entries are the bare associations ``collect_bot_active_mcps`` returns, so
+    everything downstream — Center enrichment, the per-server merge — still
+    runs over them.
+    """
+    svc = MagicMock()
+    svc.mcp_center.get_mcp_detail.return_value = {
+        "runMode": "REMOTE", "endpoints": []
+    }
+    mcp_cfg = MagicMock()
+    mcp_cfg.build_mcp_sync_payload.return_value = ("kee", {}, "PROD", "http")
+
+    inputs = _collector(skill_set_service=svc, mcp_config_service=mcp_cfg).mcps(
+        ComposeRequest(
+            entity_id="staff_u1", bot_id="bot1", user_id="u1",
+            engine_type="teclaw",
+            effective_mcps=({"server_code": "a"}, {"server_code": "b"}),
+        )
+    )
+
+    svc.collect_bot_active_mcps.assert_not_called()
+    assert [i.mcp_data["server_code"] for i in inputs] == ["a", "b"]
+    assert mcp_cfg.build_mcp_sync_payload.call_count == 2
+
+
+@pytest.mark.unit
+def test_an_empty_carried_set_is_not_a_missing_one():
+    """``()`` means "this bot has no MCPs", not "nobody resolved them".
+
+    A falsy check here would re-read the database for exactly the bots the
+    reuse is cheapest for, and — worse — could compose a set the projection
+    that called it never declared.
+    """
+    svc = MagicMock()
+    svc.collect_bot_active_mcps.return_value = [{"server_code": "ghost"}]
+
+    inputs = _collector(skill_set_service=svc).mcps(
+        ComposeRequest(
+            entity_id="staff_u1", bot_id="bot1", user_id="u1",
+            engine_type="teclaw", effective_mcps=(),
+        )
+    )
+
+    assert inputs == []
+    svc.collect_bot_active_mcps.assert_not_called()
+
+
 _HITL_CATALOG = {
     "hitl": {
         "command": "python3",

--- a/src/backend/tests/community/core/devices/test_teclaw_device_sync.py
+++ b/src/backend/tests/community/core/devices/test_teclaw_device_sync.py
@@ -152,6 +152,39 @@ def test_compose_scopes_by_entity_id_while_binding_lookup_uses_owner_id():
     )
 
 
+def test_an_already_resolved_mcp_set_rides_on_the_compose_request():
+    """The caller's effective MCP set reaches the composer instead of a re-read.
+
+    Capability projection resolves this set before it decides anything — the
+    projected codes and the Passport scope come out of it — and the compose
+    here would otherwise put the same ``collect_bot_active_mcps`` query to the
+    same database again. Threading it is what removes the second read; the
+    collector still enriches and merges each entry.
+    """
+    service, m = _make_service()
+
+    service.sync_symlinks([], effective_mcps=[{"server_code": "a"}])
+
+    req = m["composer"].compose.call_args.args[0]
+    assert req.effective_mcps == ({"server_code": "a"},)
+    assert req.bot_id == "bot7"
+
+
+def test_a_caller_with_no_resolved_mcp_set_leaves_the_collector_to_read_it():
+    """``None``, not ``()``: the collector must still do its own read.
+
+    Every non-projection entry point (a channel edit, an MCP edit, the
+    device-activated listener) composes without having collected anything.
+    Handing those an empty set would compose an artifact with no MCP servers
+    at all.
+    """
+    service, m = _make_service()
+
+    service.sync_symlinks([])
+
+    assert m["composer"].compose.call_args.args[0].effective_mcps is None
+
+
 def test_entity_id_defaults_to_owner_id_when_omitted():
     """Back-compat for a call site that predates the entity_id/owner_id split."""
     service, m = _make_service(owner_id="org_7", entity_id=None)

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -511,10 +511,20 @@ class _RuntimeFactoryService:
         self.mcp_projections: list[
             tuple[frozenset[str], frozenset[str], set[str]]
         ] = []
+        # What each delivery was handed as the already-resolved MCP set. A
+        # whole-artifact delivery composes from the database, so this is what
+        # decides whether that compose re-reads what plan resolution read.
+        self.delivered_effective_mcps: list[list[dict] | None] = []
 
-    async def project_skills(self, *, desired_skills: list[dict]) -> bool:
+    async def project_skills(
+        self,
+        *,
+        desired_skills: list[dict],
+        effective_mcps: list[dict] | None = None,
+    ) -> bool:
         self.desired_skills = desired_skills
         self.runtime_syncs.append(desired_skills)
+        self.delivered_effective_mcps.append(effective_mcps)
         return True
 
     async def sync_mcp_delivery(
@@ -2692,6 +2702,65 @@ async def test_teclaw_mcp_only_scope_still_delivers_the_skill_bearing_artifact()
 
 
 @pytest.mark.asyncio
+async def test_teclaw_delivery_carries_the_mcp_set_plan_resolution_read():
+    """One projection reads the effective MCP set once, then hands it over.
+
+    Plan resolution has to collect it — the projected codes and the Passport
+    scope are derived from it — and the whole-artifact delivery recomposes the
+    bot's document from the same database moments later. Without the handover
+    that compose repeats the identical ``collect_bot_active_mcps`` query for an
+    answer the projection is already holding; both sides ask with
+    ``strict_policy_context=True``, so it is the same answer by contract.
+
+    Asserted on the collect count and the delivered value rather than on
+    timing: what makes the second read unnecessary is that the first one's
+    result reaches the composer, and that is what would silently regress.
+    """
+    factory = _RuntimeFactory()
+    runtime = _teclaw_runtime(factory)
+
+    await runtime.project(
+        bot_id="bot-1", owner_id="true-owner", scope=ProjectionScope.everything(),
+    )
+
+    assert len(factory.service.collect_calls) == 1
+    assert factory.service.delivered_effective_mcps == [
+        [
+            {"server_code": "mcp.template-preset"},
+            {"server_code": "hitl", "source": "local"},
+        ]
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_per_domain_delivery_carries_no_mcp_set():
+    """The handover is for engines that compose; a per-domain one does not.
+
+    Its Skill call writes symlinks and its MCP half goes to a separate
+    endpoint, so there is no compose behind ``project_skills`` to spare a read
+    — passing the set would only imply a re-use that never happens.
+    """
+    factory = _RuntimeFactory()
+    runtime = BotRuntimeProjector(
+        factory=factory,
+        bot_repo=_RuntimeBots(),
+        repository=_McpInstallations(),
+        reader=_reader(_RuntimeSkills()),
+        registry=_registry(
+            pool_runtime=_RuntimePool(), pool_layouts=_RuntimeLayouts()
+        ),
+        passport=_RuntimePassport(),
+        caller_identity_repo=_RuntimeCallerIdentity(),
+    )
+
+    await runtime.project(
+        bot_id="bot-1", owner_id="true-owner", scope=ProjectionScope.everything(),
+    )
+
+    assert factory.service.delivered_effective_mcps == [None]
+
+
+@pytest.mark.asyncio
 async def test_teclaw_still_updates_the_passport_with_identity_coloured_items():
     """The Passport is the platform's record, not the runtime's — it still runs.
 
@@ -2809,7 +2878,9 @@ async def test_runtime_delivery_never_runs_on_the_event_loop():
         user_id = "owner-1"
         entity_id = "owner-1"
 
-        def _sync_symlinks_to_device_if_needed(self, user_id, desired_skills):
+        def _sync_symlinks_to_device_if_needed(
+            self, user_id, desired_skills, effective_mcps
+        ):
             seen.append(threading.get_ident())
             return True
 

--- a/src/backend/tests/community/framework/device_seams.py
+++ b/src/backend/tests/community/framework/device_seams.py
@@ -33,8 +33,10 @@ class RecordingDeviceSync:
     def __init__(self) -> None:
         self.calls: list[_CallRecord] = []
 
-    def sync_symlinks(self, symlinks):  # type: ignore[no-untyped-def]
-        self.calls.append(_CallRecord("sync_symlinks", (symlinks,), {}))
+    def sync_symlinks(self, symlinks, **kwargs):  # type: ignore[no-untyped-def]
+        # ``**kwargs`` so the double records the optional whole-artifact
+        # ``effective_mcps`` hint rather than rejecting it.
+        self.calls.append(_CallRecord("sync_symlinks", (symlinks,), kwargs))
         return {"success": True}
 
     def sync_bot_config(self, *args, **kwargs):  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Problem

On a whole-artifact engine (teclaw), one `POST /skillset/deactivate` resolved the same capability state twice and minted three `SkillSetService` instances — roughly **1.5 s of an 8.62 s** request, all of it a repeat of work the same request had already done.

Two independent causes:

* **`ConfigComposerInputCollector._skill_set_service` (`collector.py:504`) had no memoization.** `ConfigComposer.compose` asks the collector for skills and MCPs independently, and each half built its own service. Every build re-resolves the bot's workspace paths, re-reads the bot row, and mints a `SkillService` whose construction mkdirs against the shared `/aidesktop` mount.
* **The effective MCP set was read twice.** `BotRuntimeProjector._build_plan` (`bot_runtime_projector.py:260`) collects it — it must, the projected MCP codes and the Passport scope are derived from it — and the compose that follows re-read the identical set from the same database microseconds later (`collector.py:194`). Both sides ask with `strict_policy_context=True`, so the two answers are the same by contract.

Trace evidence, ordering, and the per-call costs are in inclusionAI/Avernet#1666.

## Solution

Both pieces from the issue, taken as written.

**1. Memoize the service per `ComposeRequest`.** The memo lives on the request, not on the collector: the collector is a process-wide singleton and compose runs inside `asyncio.to_thread`, so a memo held there would eventually hand one bot's per-bot service to another bot's compose, concurrently and silently. A request is created for one compose and passed to every collector method within it, which is exactly the lifetime a per-compose memo wants — `ComposeRequest.memoized(key, build)` makes that explicit, and a test pins that bot B's compose cannot observe bot A's service.

**2. Thread the resolved MCP set as a value** rather than adding a cache with a lifetime, as the issue asked. `ResolvedCapabilityPlan` carries what plan resolution collected (beside the `effective_cli_items` it already carried); `WholeArtifactRuntimeProjection` hands it to `project_skills`; `TeclawDeviceSyncService` puts it on the `ComposeRequest` it builds for its own bot. This is the same handover, for the same reason, that `desired_skills` already rides down this path.

Notes on the choices that were not obvious:

* **Empty is not missing.** An empty set threads as `()`; `None`, and only `None`, means nobody resolved it and the collector reads it itself. A falsy check would have re-read the database for exactly the bots the reuse is cheapest for, and could compose a set the projection never declared.
* **`DeviceSync.sync_symlinks` gained the keyword, but callers pass it only when they have one.** It means something to a whole-artifact device and nothing to a device that consumes the symlinks directly, so no implementation — including one out of tree — has to grow a parameter to stay callable. The in-tree BaaS and Singlebox services accept and drop it so the declared contract stays total.
* **`resources()` is untouched** — it builds a `ResourceService`, not a `SkillSetService`, and was never part of this.

Per deactivate this is two `SkillSetService` builds (plan resolution's and the compose's) instead of three, one `collect_bot_active_mcps` instead of two, and two `_ensure_directories` instead of three.

Second commit (`fd55409`) is review follow-up only: the new optional parameters now use `Optional[X]` rather than `X | None`, matching the surrounding device-sync code. Pure annotation change — `Optional[list[dict]]` and `list[dict] | None` are the same annotation object at runtime.

## Validation

All 8 CI checks green on `fd55409` (current head) — including Backend unit tests and Singlebox coverage.

Locally, against `dev` @ `0a6f013`:

* `pytest tests/community/core -n 4` — **8547 passed**, 53 skipped, 2 failed.
* `pytest tests/community --ignore=tests/community/core -n 4` — **6712 passed**, 7 skipped.
* The 2 local failures are `test_bot_build_service_skill_artifact.py::test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_write_nfs[openclaw|claude_code]`, failing with `exec: rsync: not found` — the container running them has no `rsync`. They reproduce identically on the parent commit with this change reverted, and both pass on CI, which has the binary.
* The `config_compose` collector and composer tests pass **unmodified** (88 passed before the new cases were added), as the issue required.
* Block-rule lint (`scripts/ci/python_sast_local.sh`'s flake8 select set) over every changed file: clean.
* The acceptance suite is excluded by `pytest.ini` locally (it needs a spawned baas/mosn/sofa-registry stack); CI's Singlebox coverage job runs it against a real stack and passed.

New tests, each asserting on construction/call counts rather than timing:

* `test_collector.py` — one service per compose; the memo never crosses from one bot to another; a carried set replaces the collector's read; `()` is not treated as missing.
* `test_teclaw_device_sync.py` — a resolved set rides on the `ComposeRequest`; a caller without one leaves it `None`.
* `test_skill_set_management_service.py` — a teclaw projection collects once and hands the result to the delivery; a per-domain projection carries nothing.

## Compatibility and risk

No schema, config, or wire-format change; the artifact a compose produces is byte-identical for the same database state.

Contract surfaces that moved, all backwards-compatible (new keyword-only parameters and one new plan field):

* `CapabilityRuntimeBoundary.project_skills` / `SkillSetService.project_skills` — kept in lockstep, which the existing signature-mirroring conformance test enforces.
* `ResolvedCapabilityPlan.effective_mcp_entries` — one construction site.
* `DeviceSync.sync_symlinks` — see the note above on why an implementation is never required to accept it.

The correctness risk is threading the wrong bot's MCP set into a compose. It is bounded by construction: `TeclawDeviceSyncService` scopes the request to its own `bot_id`, and the entries reach it from the projection for that same bot, over a chain whose every hop is keyed on one bot. Rollback is a plain revert — nothing persisted changes.

## Related issues

Closes inclusionAI/Avernet#1666.

Touches `collector.py`, which inclusionAI/Avernet#1667 also touches. That one changes `_enrich_mcp_detail` and the `for md in raw:` loop; this one changes `_skill_set_service` and the `collect_bot_active_mcps` call site immediately above that loop. Adjacent, not overlapping — whichever lands second rebases. inclusionAI/Avernet#1668 has no file overlap with either.