### PR TITLE
perf(backend): fetch MCP Center detail concurrently in artifact compose

### DIFF
--- a/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
@@ -60,12 +60,34 @@ if TYPE_CHECKING:
 
 logger = get_logger()
 
-# Ceiling on simultaneous MCP Center detail lookups for one compose. The point of
-# the fan-out is to stop paying ``n`` round trips in sequence, not to hand MCP
-# Center ``n`` simultaneous requests: a bot may hold dozens of MCPs, and several
-# bots can compose at once. Eight covers the observed shape (~13 servers, ~90 ms
-# each) in two waves while leaving Center's connection pool room to breathe.
+# Ceiling on simultaneous MCP Center detail lookups. The point of the fan-out is
+# to stop paying ``n`` round trips in sequence, not to hand MCP Center ``n``
+# simultaneous requests: a bot may hold dozens of MCPs, and several bots can
+# compose at once. Eight covers the observed shape (~13 servers, ~90 ms each) in
+# two waves while leaving Center's connection pool room to breathe.
 _MCP_DETAIL_WORKERS = 8
+
+# ONE pool for the process, deliberately not one per compose. A per-call executor
+# would cap each compose at ``_MCP_DETAIL_WORKERS`` and cap nothing across them:
+# ``project_skills`` dispatches every projection through ``asyncio.to_thread``, so
+# concurrent bot projections would multiply into ``8 x in-flight composes`` threads
+# and that many simultaneous Center lookups — the ceiling would describe one
+# compose while the service as a whole had none. Sharing the pool makes the number
+# mean what it says process-wide, and puts it *below* the sequential behaviour it
+# replaced, which already allowed one concurrent Center call per in-flight compose
+# with no ceiling at all.
+#
+# No deadlock risk from sharing: tasks only call ``get_mcp_detail`` and never
+# re-enter this pool, and ``mcps()`` itself runs on the default executor's threads,
+# not on these.
+#
+# Worker threads are spawned lazily on first submit, so importing this module costs
+# nothing. This deployment serves from a single ``uvicorn.run(app)`` process; a
+# pre-fork server would need to build the pool per worker instead, since threads do
+# not survive a fork.
+_MCP_DETAIL_POOL = ThreadPoolExecutor(
+    max_workers=_MCP_DETAIL_WORKERS, thread_name_prefix="mcp-detail"
+)
 
 
 class McpDetailUnavailableError(LookupError):
@@ -375,6 +397,10 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         worker thread, so a pool drops into the existing shape where converting
         the call chain to async would not.
 
+        The pool is the process-wide :data:`_MCP_DETAIL_POOL`, not one built per
+        call, so the ceiling holds across concurrent composes rather than only
+        within one — see the constant for why that distinction matters.
+
         Each task runs under its own *copy* of the calling context. Pool workers
         do not inherit context vars — the reason ``bind_current_avernet_tenant``
         exists — and a Center lookup reads the request's tenant and mints its log
@@ -389,15 +415,13 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         entries = list(raw)
         if len(entries) < 2:
             return [self._enrich_mcp_detail(svc, md) for md in entries]
-        with ThreadPoolExecutor(
-            max_workers=min(len(entries), _MCP_DETAIL_WORKERS),
-            thread_name_prefix="mcp-detail",
-        ) as pool:
-            futures = [
-                pool.submit(copy_context().run, self._enrich_mcp_detail, svc, md)
-                for md in entries
-            ]
-            return [f.result() for f in futures]
+        futures = [
+            _MCP_DETAIL_POOL.submit(
+                copy_context().run, self._enrich_mcp_detail, svc, md
+            )
+            for md in entries
+        ]
+        return [f.result() for f in futures]
 
     def _enrich_mcp_detail(
         self, svc: Any, md: dict[str, Any]

--- a/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
@@ -409,12 +409,18 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         calling thread, one per task: a single ``Context`` cannot be entered by
         two threads at once.
 
-        Below two entries there is nothing to overlap, so the pool is skipped
-        entirely and the lookups run inline, exactly as before.
+        *Every* lookup goes through the pool, a lone one included. Running a
+        single entry inline would cost less — no hand-off, no future — but a
+        ceiling with a side door is not a ceiling: concurrent one-MCP composes
+        would each add a Center call on top of the pool's
+        ``_MCP_DETAIL_WORKERS``, so the process-wide total would be
+        ``_MCP_DETAIL_WORKERS + <one-MCP composes in flight>``. The hand-off is
+        microseconds against an ~90 ms call, and it buys a bound that actually
+        holds. Only the empty case short-circuits, having nothing to submit.
         """
         entries = list(raw)
-        if len(entries) < 2:
-            return [self._enrich_mcp_detail(svc, md) for md in entries]
+        if not entries:
+            return []
         futures = [
             _MCP_DETAIL_POOL.submit(
                 copy_context().run, self._enrich_mcp_detail, svc, md

--- a/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
+++ b/src/backend/src/agentclaw/community/core/config_compose/services/collector.py
@@ -21,7 +21,9 @@ secrets inlined) is the composer's job, not this collector's.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
+from typing import TYPE_CHECKING, Any, Sequence
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.channel.services.engine_overrides_reader import (
@@ -57,6 +59,13 @@ if TYPE_CHECKING:
     from agentclaw.community.core.services.identity import IdentityService
 
 logger = get_logger()
+
+# Ceiling on simultaneous MCP Center detail lookups for one compose. The point of
+# the fan-out is to stop paying ``n`` round trips in sequence, not to hand MCP
+# Center ``n`` simultaneous requests: a bot may hold dozens of MCPs, and several
+# bots can compose at once. Eight covers the observed shape (~13 servers, ~90 ms
+# each) in two waves while leaving Center's connection pool room to breathe.
+_MCP_DETAIL_WORKERS = 8
 
 
 class McpDetailUnavailableError(LookupError):
@@ -207,13 +216,14 @@ class ConfigComposerInputCollector(ComposeInputCollector):
         # ``get_mcp_detail`` dict straight through); the whole-artifact compose
         # path re-collects from DB, so it must fetch the detail itself or the
         # composer would see ``endpoints=[]`` and raise "no usable endpoint".
+        # The lookups are issued together rather than one at a time — see
+        # :meth:`_enrich_mcp_details`; the list it returns still follows ``raw``.
         # Endpoint-selection policy is per-engine: teclaw selects deterministically
         # by network priority (OFFICE > INTERNET > INTRANET), other engines keep
         # the legacy filter + transport-preference selection (network_priority None).
         network_priority = mcp_network_priority_for(req.engine_type)
         inputs: list[McpComposeInput] = []
-        for md in raw:
-            md, detail_failure = self._enrich_mcp_detail(svc, md)
+        for md, detail_failure in self._enrich_mcp_details(svc, raw):
             server_code = md.get("server_code") or md.get("serverCode") or ""
             stdio = self._stdio_launch_for(server_code, md, req.engine_type)
             if stdio is None and detail_failure is not None:
@@ -336,6 +346,58 @@ class ConfigComposerInputCollector(ComposeInputCollector):
             elif str(declared).strip().lower() == engine_type.strip().lower():
                 return cfg
         return default
+
+    def _enrich_mcp_details(
+        self, svc: Any, raw: Sequence[dict[str, Any]]
+    ) -> list[tuple[dict[str, Any], Exception | None]]:
+        """:meth:`_enrich_mcp_detail` over every entry — concurrently, **in order**.
+
+        ``get_mcp_detail`` is one blocking round trip per server with no batch
+        form and no cache, so enriching in sequence cost this compose ``n`` round
+        trips for a bot holding ``n`` MCPs — ~90 ms each, over *every* MCP the bot
+        holds rather than only the ones a mutation touched. Issuing them together
+        collapses that to roughly one round trip of wall clock.
+
+        Two properties the sequential loop had for free, and which the caller
+        reads as a contract:
+
+        * **Order.** Futures are read back in *submit* order, never completion
+          order, so the result still follows ``raw`` — which is the order the
+          ``McpComposeInput`` list carries into ``McporterComposer``.
+        * **Per-entry failure.** ``_enrich_mcp_detail`` returns its cause instead
+          of raising, so an unresolvable lookup stays attached to its own entry
+          and the caller keeps deciding per entry whether it is fatal (for a
+          local server it is not). Fanning out must not collapse ``n`` separate
+          causes into whichever one happened to surface first.
+
+        Threads rather than async: ``get_mcp_detail`` is a synchronous plugin
+        call and ``mcps`` is a sync method already reached from ``project_skills``'
+        worker thread, so a pool drops into the existing shape where converting
+        the call chain to async would not.
+
+        Each task runs under its own *copy* of the calling context. Pool workers
+        do not inherit context vars — the reason ``bind_current_avernet_tenant``
+        exists — and a Center lookup reads the request's tenant and mints its log
+        lines under the request's trace id; copying the whole context carries both
+        without this having to enumerate them. The copy is taken here, on the
+        calling thread, one per task: a single ``Context`` cannot be entered by
+        two threads at once.
+
+        Below two entries there is nothing to overlap, so the pool is skipped
+        entirely and the lookups run inline, exactly as before.
+        """
+        entries = list(raw)
+        if len(entries) < 2:
+            return [self._enrich_mcp_detail(svc, md) for md in entries]
+        with ThreadPoolExecutor(
+            max_workers=min(len(entries), _MCP_DETAIL_WORKERS),
+            thread_name_prefix="mcp-detail",
+        ) as pool:
+            futures = [
+                pool.submit(copy_context().run, self._enrich_mcp_detail, svc, md)
+                for md in entries
+            ]
+            return [f.result() for f in futures]
 
     def _enrich_mcp_detail(
         self, svc: Any, md: dict[str, Any]

--- a/src/backend/tests/community/core/config_compose/test_collector.py
+++ b/src/backend/tests/community/core/config_compose/test_collector.py
@@ -5,6 +5,8 @@ container-view inputs: skill scope/name derivation, the MCP collect+merge loop,
 resource/identity mapping, and the engine_overrides default.
 """
 import tempfile
+import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -16,6 +18,7 @@ from agentclaw.community.core.channel.services.engine_overrides_reader import (
 )
 from agentclaw.community.core.config_compose.models import ComposeRequest, StdioLaunch
 from agentclaw.community.core.config_compose.services.collector import (
+    _MCP_DETAIL_WORKERS,
     ConfigComposerInputCollector,
     McpDetailUnavailableError,
 )
@@ -23,6 +26,10 @@ from agentclaw.community.core.config_compose.services.mcporter_composer import (
     McporterComposeError,
 )
 from agentclaw.community.core.mcp.services.local_mcp_registry import LocalMCPRegistry
+from agentclaw.community.utils.avernet_tenant import (
+    avernet_tenant_scope,
+    get_current_avernet_tenant,
+)
 
 
 def _req(engine_type: str = "openclaw") -> ComposeRequest:
@@ -542,6 +549,168 @@ def test_mcps_preserve_local_fields_when_center_lacks_them():
     inputs = _collector(skill_set_service=svc, mcp_config_service=mcp_cfg).mcps(_req())
     assert inputs[0].mcp_data["headers"] == {"x-ling-auth": "tok"}
     assert inputs[0].mcp_data["runMode"] == "REMOTE"
+
+
+# ── concurrent Center enrichment ────────────────────────────────────────────
+#
+# ``get_mcp_detail`` is one blocking round trip per server (~90 ms in the traced
+# request), so enriching in sequence made the whole compose scale linearly with
+# the bot's MCP count. These pin the fan-out and, more importantly, the four
+# properties the sequential loop gave the caller for free.
+
+
+def _remote(server_code: str) -> dict:
+    """A Center reply for a remote server — enough for compose to accept it."""
+    return {"serverCode": server_code, "runMode": "REMOTE", "endpoints": []}
+
+
+def _mcps_over(codes, lookup, *, registry_catalog=None):
+    """Run ``mcps()`` over ``codes``, answering Center with ``lookup(code)``."""
+    svc = MagicMock()
+    svc.collect_bot_active_mcps.return_value = [{"server_code": c} for c in codes]
+    svc.mcp_center.get_mcp_detail.side_effect = lookup
+    mcp_cfg = MagicMock()
+    mcp_cfg.build_mcp_sync_payload.return_value = (None, {}, "PROD", None)
+    return _collector(
+        skill_set_service=svc,
+        mcp_config_service=mcp_cfg,
+        local_mcp_registry=_registry_over(registry_catalog or {}),
+    ).mcps(_req())
+
+
+@pytest.mark.unit
+def test_mcps_fetch_center_detail_concurrently():
+    """The lookups overlap — a serial loop cannot get past this barrier.
+
+    Every lookup blocks until all five have arrived, so the call only completes
+    if the five are genuinely in flight at once. One-at-a-time enrichment leaves
+    the first waiter to time out, which surfaces as a failed compose rather than
+    as a quietly slower one.
+    """
+    codes = ["a", "b", "c", "d", "e"]
+    gate = threading.Barrier(len(codes), timeout=10)
+
+    def lookup(server_code):
+        gate.wait()
+        return _remote(server_code)
+
+    inputs = _mcps_over(codes, lookup)
+
+    assert [i.mcp_data["server_code"] for i in inputs] == codes
+
+
+@pytest.mark.unit
+def test_mcps_keep_raw_order_when_lookups_finish_out_of_order():
+    """Output follows ``raw``, not completion.
+
+    The composer writes ``McpComposeInput`` entries in list order, so reading
+    futures as they complete would reorder the artifact for no reason other than
+    which Center reply landed first. Here the replies land in exactly reverse
+    order.
+    """
+    codes = ["first", "second", "third", "fourth"]
+    delay = {code: 0.05 * (len(codes) - i) for i, code in enumerate(codes)}
+    finished: list[str] = []
+    lock = threading.Lock()
+
+    def lookup(server_code):
+        time.sleep(delay[server_code])
+        with lock:
+            finished.append(server_code)
+        return _remote(server_code)
+
+    inputs = _mcps_over(codes, lookup)
+
+    assert finished == list(reversed(codes))  # completion order really did invert
+    assert [i.mcp_data["server_code"] for i in inputs] == codes
+
+
+@pytest.mark.unit
+def test_mcps_bound_the_fan_out_at_mcp_center():
+    """A bot with many MCPs must not open one request per server at once.
+
+    Removing the sequential cost is the point; replacing it with an unbounded
+    burst at MCP Center is not. More servers than workers, so the ceiling has to
+    actually hold some of them back.
+    """
+    codes = [f"s{i}" for i in range(_MCP_DETAIL_WORKERS * 2 + 3)]
+    lock = threading.Lock()
+    in_flight = 0
+    peak = 0
+
+    def lookup(server_code):
+        nonlocal in_flight, peak
+        with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        time.sleep(0.05)
+        with lock:
+            in_flight -= 1
+        return _remote(server_code)
+
+    inputs = _mcps_over(codes, lookup)
+
+    assert [i.mcp_data["server_code"] for i in inputs] == codes
+    assert peak <= _MCP_DETAIL_WORKERS
+    assert peak > 1  # …and the bound is a ceiling, not a serial loop in disguise
+
+
+@pytest.mark.unit
+def test_mcps_carry_each_entrys_own_failure_through_the_fan_out():
+    """One server's failure stays that server's, with its own cause chained.
+
+    ``_enrich_mcp_detail`` returns the cause instead of raising precisely so the
+    caller can judge each entry separately. Fanning out must not collapse the
+    per-entry causes into whichever one happened to surface first — the raise
+    still has to name the server that failed and chain *its* exception.
+    """
+    boom = RuntimeError("center down for c")
+
+    def lookup(server_code):
+        if server_code == "c":
+            raise boom
+        return _remote(server_code)
+
+    with pytest.raises(McporterComposeError, match="MCP c:") as excinfo:
+        _mcps_over(["a", "b", "c", "d"], lookup)
+
+    assert excinfo.value.__cause__ is boom
+
+
+@pytest.mark.unit
+def test_mcps_local_server_still_survives_an_empty_lookup_beside_remote_peers():
+    """The converse under concurrency: a local server with no Center record
+    composes, while its remote siblings resolve normally in the same fan-out."""
+    def lookup(server_code):
+        return None if server_code == "hitl" else _remote(server_code)
+
+    inputs = _mcps_over(
+        ["a", "hitl", "b"], lookup, registry_catalog=_HITL_CATALOG
+    )
+
+    assert [i.mcp_data["server_code"] for i in inputs] == ["a", "hitl", "b"]
+    assert inputs[1].stdio is not None
+    assert inputs[1].stdio.command == "python3"
+    assert inputs[0].stdio is None and inputs[2].stdio is None
+
+
+@pytest.mark.unit
+def test_mcps_lookups_run_under_the_requests_tenant():
+    """Pool workers inherit no context vars, so the tenant is copied onto each
+    task. Without that, a Center lookup for a registered external tenant would
+    run under the default one — reading another tenant's catalog."""
+    seen: list[str] = []
+    lock = threading.Lock()
+
+    def lookup(server_code):
+        with lock:
+            seen.append(get_current_avernet_tenant())
+        return _remote(server_code)
+
+    with avernet_tenant_scope("acme"):
+        _mcps_over(["a", "b", "c"], lookup)
+
+    assert seen == ["acme"] * 3
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/config_compose/test_collector.py
+++ b/src/backend/tests/community/core/config_compose/test_collector.py
@@ -677,6 +677,74 @@ def test_mcps_bound_the_fan_out_at_mcp_center():
 
 
 @pytest.mark.unit
+def test_mcps_bound_the_fan_out_across_concurrent_composes():
+    """The ceiling is process-wide, not per compose.
+
+    A pool built per call would cap each compose at ``_MCP_DETAIL_WORKERS`` and
+    cap nothing between them — and composes *do* run concurrently, since
+    ``project_skills`` dispatches each projection through ``asyncio.to_thread``.
+    Two at once would then reach ``2 x _MCP_DETAIL_WORKERS`` simultaneous Center
+    lookups while the constant still claimed eight.
+
+    The breach is detected directly rather than inferred from a peak count: the
+    lookups rendezvous on a barrier needing ``_MCP_DETAIL_WORKERS + 1`` parties,
+    one more than the ceiling allows. Under a shared pool that barrier can never
+    fill — at most ``_MCP_DETAIL_WORKERS`` lookups are ever resident — so it
+    times out and every waiter leaves by the broken-barrier path. Under a
+    per-call pool the two composes bring twice that many workers, the barrier
+    fills, and ``breached`` is set.
+
+    (Counting a peak instead would prove nothing here: whatever releases the
+    workers has to fire at the very threshold the test is trying to exceed, so
+    the count stops at the ceiling under both implementations.)
+    """
+    start = threading.Barrier(2, timeout=10)
+    over_ceiling = threading.Barrier(_MCP_DETAIL_WORKERS + 1, timeout=2)
+    breached = threading.Event()
+    lock = threading.Lock()
+    resident = 0
+    peak = 0
+
+    def lookup(server_code):
+        nonlocal resident, peak
+        with lock:
+            resident += 1
+            peak = max(peak, resident)
+        try:
+            over_ceiling.wait()
+        except threading.BrokenBarrierError:
+            pass  # never enough in flight to fill it — the ceiling held
+        else:
+            breached.set()  # one more than the ceiling was resident at once
+        with lock:
+            resident -= 1
+        return _remote(server_code)
+
+    per_compose = _MCP_DETAIL_WORKERS
+    results: list[list] = []
+
+    def compose(tag):
+        codes = [f"{tag}{i}" for i in range(per_compose)]
+        start.wait()  # both composes submit together, so they really do overlap
+        results.append(_mcps_over(codes, lookup))
+
+    threads = [threading.Thread(target=compose, args=(tag,)) for tag in ("a", "b")]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert not any(t.is_alive() for t in threads), "a compose never finished"
+    assert len(results) == 2
+    assert all(len(r) == per_compose for r in results)
+    assert not breached.is_set(), (
+        f"{_MCP_DETAIL_WORKERS + 1} lookups were in flight at once — the fan-out "
+        "ceiling is per-compose, not process-wide"
+    )
+    assert peak <= _MCP_DETAIL_WORKERS
+
+
+@pytest.mark.unit
 def test_mcps_carry_each_entrys_own_failure_through_the_fan_out():
     """One server's failure stays that server's, with its own cause chained.
 

--- a/src/backend/tests/community/core/config_compose/test_collector.py
+++ b/src/backend/tests/community/core/config_compose/test_collector.py
@@ -694,11 +694,19 @@ def test_mcps_bound_the_fan_out_across_concurrent_composes():
     per-call pool the two composes bring twice that many workers, the barrier
     fills, and ``breached`` is set.
 
+    The mix deliberately includes **single-entry composes**. Running a lone
+    lookup inline would be cheaper but would open a side door around the pool:
+    one saturating compose plus N one-MCP composes would put
+    ``_MCP_DETAIL_WORKERS + N`` lookups in flight while the constant still
+    claimed ``_MCP_DETAIL_WORKERS``. A test built only from fat composes cannot
+    see that, since every one of their entries goes through the pool.
+
     (Counting a peak instead would prove nothing here: whatever releases the
     workers has to fire at the very threshold the test is trying to exceed, so
     the count stops at the ceiling under both implementations.)
     """
-    start = threading.Barrier(2, timeout=10)
+    sizes = [_MCP_DETAIL_WORKERS, 1, 1, 1]
+    start = threading.Barrier(len(sizes), timeout=10)
     over_ceiling = threading.Barrier(_MCP_DETAIL_WORKERS + 1, timeout=2)
     breached = threading.Event()
     lock = threading.Lock()
@@ -720,26 +728,27 @@ def test_mcps_bound_the_fan_out_across_concurrent_composes():
             resident -= 1
         return _remote(server_code)
 
-    per_compose = _MCP_DETAIL_WORKERS
     results: list[list] = []
 
-    def compose(tag):
-        codes = [f"{tag}{i}" for i in range(per_compose)]
-        start.wait()  # both composes submit together, so they really do overlap
+    def compose(tag, size):
+        codes = [f"{tag}{i}" for i in range(size)]
+        start.wait()  # every compose submits together, so they really do overlap
         results.append(_mcps_over(codes, lookup))
 
-    threads = [threading.Thread(target=compose, args=(tag,)) for tag in ("a", "b")]
+    threads = [
+        threading.Thread(target=compose, args=(tag, size))
+        for tag, size in zip("abcd", sizes)
+    ]
     for t in threads:
         t.start()
     for t in threads:
         t.join(timeout=30)
 
     assert not any(t.is_alive() for t in threads), "a compose never finished"
-    assert len(results) == 2
-    assert all(len(r) == per_compose for r in results)
+    assert sorted(len(r) for r in results) == sorted(sizes)
     assert not breached.is_set(), (
         f"{_MCP_DETAIL_WORKERS + 1} lookups were in flight at once — the fan-out "
-        "ceiling is per-compose, not process-wide"
+        "ceiling is not process-wide (per-compose pool, or a path around it)"
     )
     assert peak <= _MCP_DETAIL_WORKERS
 

--- a/src/backend/tests/community/core/config_compose/test_collector.py
+++ b/src/backend/tests/community/core/config_compose/test_collector.py
@@ -6,7 +6,6 @@ resource/identity mapping, and the engine_overrides default.
 """
 import tempfile
 import threading
-import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -607,21 +606,34 @@ def test_mcps_keep_raw_order_when_lookups_finish_out_of_order():
     futures as they complete would reorder the artifact for no reason other than
     which Center reply landed first. Here the replies land in exactly reverse
     order.
+
+    Completion order is *forced* with a chain of events rather than staggered
+    sleeps: a thread descheduled longer than a sleep gap would otherwise invert
+    the inversion and fail the test for scheduler timing that has nothing to do
+    with the behaviour under test. Each lookup waits for its turn, so the
+    replies land in reverse order deterministically or the test times out
+    saying so. (The chain needs all entries in flight at once, which holds:
+    the pool is ``min(len(codes), _MCP_DETAIL_WORKERS)`` wide.)
     """
     codes = ["first", "second", "third", "fourth"]
-    delay = {code: 0.05 * (len(codes) - i) for i, code in enumerate(codes)}
+    completion_order = list(reversed(codes))
+    turns = {code: threading.Event() for code in codes}
+    turns[completion_order[0]].set()
     finished: list[str] = []
     lock = threading.Lock()
 
     def lookup(server_code):
-        time.sleep(delay[server_code])
+        assert turns[server_code].wait(timeout=10), f"never got a turn: {server_code}"
         with lock:
             finished.append(server_code)
+            done = len(finished)
+        if done < len(completion_order):
+            turns[completion_order[done]].set()
         return _remote(server_code)
 
     inputs = _mcps_over(codes, lookup)
 
-    assert finished == list(reversed(codes))  # completion order really did invert
+    assert finished == completion_order  # completion order really did invert
     assert [i.mcp_data["server_code"] for i in inputs] == codes
 
 
@@ -632,18 +644,28 @@ def test_mcps_bound_the_fan_out_at_mcp_center():
     Removing the sequential cost is the point; replacing it with an unbounded
     burst at MCP Center is not. More servers than workers, so the ceiling has to
     actually hold some of them back.
+
+    Every worker is held until the pool is provably saturated, so the ceiling is
+    *observed* rather than raced for: peak lands on exactly
+    ``_MCP_DETAIL_WORKERS`` — never above it (that is the bound) and never
+    below (nothing may exit until that many are in flight at once). A
+    sleep-based version would only show "some overlap happened", and would say
+    it on the strength of CI scheduling.
     """
     codes = [f"s{i}" for i in range(_MCP_DETAIL_WORKERS * 2 + 3)]
     lock = threading.Lock()
     in_flight = 0
     peak = 0
+    saturated = threading.Event()
 
     def lookup(server_code):
         nonlocal in_flight, peak
         with lock:
             in_flight += 1
             peak = max(peak, in_flight)
-        time.sleep(0.05)
+            if in_flight >= _MCP_DETAIL_WORKERS:
+                saturated.set()
+        assert saturated.wait(timeout=10), "pool never reached its worker ceiling"
         with lock:
             in_flight -= 1
         return _remote(server_code)
@@ -651,8 +673,7 @@ def test_mcps_bound_the_fan_out_at_mcp_center():
     inputs = _mcps_over(codes, lookup)
 
     assert [i.mcp_data["server_code"] for i in inputs] == codes
-    assert peak <= _MCP_DETAIL_WORKERS
-    assert peak > 1  # …and the bound is a ceiling, not a serial loop in disguise
+    assert peak == _MCP_DETAIL_WORKERS
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

`collect_bot_active_mcps` deliberately does not call MCP Center — it returns only the skill-set association fields. The composer needs `endpoints` / `runMode` / `transportProtocol` to select a URL, so `ConfigComposerInputCollector.mcps` enriched each entry with a Center lookup, one at a time:

```python
for md in raw:
    md, detail_failure = self._enrich_mcp_detail(svc, md)   # → svc.mcp_center.get_mcp_detail(code)
```

`get_mcp_detail` is a blocking per-server call with no batch form and no cache, so the loop cost `O(n)` round trips in sequence — over *every* MCP the bot holds, not just the ones a mutation touched. In the traced `POST /skillset/deactivate` (8.62 s total) the 13 consecutive `[get_mcp_detail]` lines spanned `16:33:11.836 → 16:33:12.989`: **1.15 s, ~88 ms per server**. A bot with 30 MCPs pays ~2.6 s here.

## Solution

Issue the lookups together through a bounded thread pool (`_enrich_mcp_details`) instead of one at a time. `_enrich_mcp_detail` is pure with respect to the rest of the loop — one entry in, merged dict plus optional failure out — so the results zip straight back into the existing loop, which is otherwise untouched.

The three properties the sequential loop gave the caller for free are kept explicitly, and each is pinned by a test:

- **Order.** Futures are read back in *submit* order, never completion order, so the `McpComposeInput` list still follows `raw` — the order `McporterComposer` writes entries in.
- **Per-entry failure.** `_enrich_mcp_detail` still returns its cause rather than raising, so a remote server's unresolvable lookup reaches the `McporterComposeError` branch with *that entry's* exception chained, while a local (stdio) server with no Center record still composes. Fanning out does not collapse `n` causes into whichever surfaced first.
- **Bounded fan-out.** Capped at `_MCP_DETAIL_WORKERS = 8` via a **single process-wide** `_MCP_DETAIL_POOL`, so the ceiling holds across concurrent composes rather than only within one. Every lookup goes through it — a lone entry included — so there is no path around the bound; only an empty entry list short-circuits.

Two choices worth calling out:

- **Threads, not async.** `get_mcp_detail` is a synchronous plugin call and `mcps` is a sync method already reached from `project_skills`' worker thread. A pool drops into the existing shape; converting the call chain to async would be a far larger change. That design question was raised in review and argued out in the thread below; the agreed target architecture is tracked as #1683.
- **Context propagation.** Pool workers inherit no context vars — the reason `bind_current_avernet_tenant` exists — and a Center lookup reads the request's tenant and mints log lines under the request's trace id. Each task runs under its own `copy_context()`, taken on the calling thread, which carries both without enumerating them; a fresh copy per task because one `Context` cannot be entered by two threads at once.

**On the shared pool:** tasks only call `get_mcp_detail` and never re-enter the pool, and `mcps()` runs on the default executor's threads rather than these, so there is no re-entrancy deadlock. Workers spawn lazily on first submit, so import costs nothing. This deployment serves from a single `uvicorn.run(app)` process; the code records that a pre-fork server would need a per-worker pool, since threads do not survive a fork.

Not done here: the short-lived per-request memo the issue floats as a companion. The same `server_code` can be looked up by both this loop and `sync_mcp_delivery` in one request, but sharing a cache across the two services is separate plumbing, and concurrency is what removes the linear cost.

## Review history

Three defects were found in this change during review and fixed; recording them since the commit series is the honest record:

| Commit | What |
|---|---|
| `2a720ca` | The original fan-out. |
| `811300c` | Two new tests asserted facts derived from `time.sleep` gaps, which a loaded CI worker can invalidate. Completion order is now **forced** by `threading.Event` chains, and the bound assertion tightened from `peak > 1` to `peak == _MCP_DETAIL_WORKERS`. (Codex P2.) |
| `ac0803d` | The pool was built **per call**, so the ceiling bounded one compose and nothing across composes — up to an 8× amplification of peak Center concurrency versus the sequential code. Hoisted to module scope. (Codex P1.) |
| `2f1d6ea` | The `len(entries) < 2` inline branch ran a lone lookup **outside** the pool, so N concurrent one-MCP composes added N calls on top of the eight. A ceiling with a side door is not a ceiling. (Codex P1, second round.) |

## Validation

- `pytest tests/community/core/config_compose/test_collector.py` — 45 passed. The 38 pre-existing tests pass **unmodified**; seven new ones cover the fan-out:
  - `test_mcps_fetch_center_detail_concurrently` — five lookups block on a shared `threading.Barrier`, so the call only completes if they are genuinely in flight at once; a serial loop times out and fails the compose.
  - `test_mcps_keep_raw_order_when_lookups_finish_out_of_order` — completion order is forced to the exact reverse of input via an event chain; output still follows `raw`.
  - `test_mcps_bound_the_fan_out_at_mcp_center` — workers are held until the pool is provably saturated, so `peak == _MCP_DETAIL_WORKERS` exactly.
  - `test_mcps_bound_the_fan_out_across_concurrent_composes` — composes of mixed size (`[8, 1, 1, 1]`) submit together and rendezvous on a barrier needing one more party than the ceiling permits. A shared pool can never fill it; a per-call pool or an inline singleton path can.
  - `test_mcps_carry_each_entrys_own_failure_through_the_fan_out` — one failure among four raises naming that server, with its own exception chained.
  - `test_mcps_local_server_still_survives_an_empty_lookup_beside_remote_peers` — the converse, under concurrency.
  - `test_mcps_lookups_run_under_the_requests_tenant` — workers observe the caller's tenant, not the default.
- Both bound tests were verified **in both directions** — green on the fix, red on the defect — rather than merely observed to pass.
- `pytest tests/community/core/config_compose tests/community/core/mcp tests/community/core/skill_center` — 1211 passed, 25 skipped.
- Full `tests/community` (`-n auto --dist loadfile`, as `scripts/ci_test.sh` runs it) on `2a720ca` — 15257 passed, 60 skipped, 2 failed. Both failures were `test_bot_build_service_skill_artifact.py::test_pool_build_uses_the_versioned_filesystem_snapshot_when_runtime_cannot_write_nfs[openclaw|claude_code]`, `rsync: not found`, reproducing identically with this branch's files reverted to `dev` — that sandbox lacks `rsync`. CI covers this properly and is green.
- `ruff check` on both changed files — clean.
- **CI: 8/8 green on `2f1d6ea`.**
- No manual/staging run: reproducing the 8.62 s trace needs a live MCP Center, which this environment cannot reach. The latency claim rests on the trace in the issue plus the concurrency test above, not on a re-measurement.

## Compatibility and risk

No contract, schema, config, or migration impact — the collector's inputs and outputs are byte-identical, only their fetch timing changes.

Two behavioural notes:
- When a compose is going to fail, all `n` lookups are now issued rather than stopping at the first failing entry. The raise happens at the same entry with the same cause; it is a little wasted work on an already-failing path.
- Peak MCP Center concurrency is now capped at 8 for the whole process. That is *lower* than the code this replaces, which allowed one concurrent call per in-flight compose with no ceiling at all. Under heavy concurrent load a compose can now queue behind others — which is what bounding a downstream resource means.

Thread-safety of `get_mcp_detail` across plugin implementations: `LocalMCPRegistry` is stateless (re-reads its file per call, no lazy cache) and `CommunityMCPCenter` delegates to it, so both are safe under fan-out. Rollback is reverting the four commits.

## Related issues

Closes #1667. Follow-up architecture work: #1683.

Touches `collector.py`, which #1666 also touches — that one changes `_skill_set_service` and the `collect_bot_active_mcps` call site; this one changes the enrichment loop and adds `_enrich_mcp_details` beside `_enrich_mcp_detail`. Adjacent but not overlapping. #1668 has no file overlap with either.