### PR TITLE
refactor(backend): drop the redundant bind_id lookup in teclaw delivery

### DIFF
--- a/src/backend/src/agentclaw/community/core/devices/services/teclaw_device_sync.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/teclaw_device_sync.py
@@ -6,12 +6,17 @@ and POSTs it to the running container, which re-pulls/applies it.
 
 Outbound HTTP uses an injected ``Annotated[HttpClient, QUALIFIER_GENERAL]``
 instance (full-absolute-URL client). ``info.http_url`` is resolved INSIDE the
-service at ``sync_*`` execution time via :meth:`BaasService.get_http_info`
-(``bind_id`` from :meth:`BaasService.get_bind_id`) — the dispatcher and DI
-service factory never call ``get_http_info`` and never pre-bind
-``info.http_url``, preserving the existing error dicts. The service imports no
-transport module directly; HTTP failure classification goes through the
-transport-neutral exception aliases re-exported from ``plugin_api.http_client``.
+service at ``sync_*`` execution time via :meth:`BaasService.get_http_info` —
+the dispatcher and DI service factory never call ``get_http_info`` and never
+pre-bind ``info.http_url``, preserving the existing error dicts. The service
+imports no transport module directly; HTTP failure classification goes through
+the transport-neutral exception aliases re-exported from
+``plugin_api.http_client``.
+
+The ``bind_id`` that call needs is **not** re-derived here: it arrives as
+``binding_id``, threaded in from the ``DeviceContext`` the factory was handed.
+See :meth:`_deliver` for why that is the same value the old
+:meth:`BaasService.get_bind_id` round trip returned.
 
 Identity fields (read this before wiring a new call site)
 --------------------------------------------------------
@@ -24,8 +29,9 @@ they differ for staff, project and team bots):
   (e.g. ``staff_{user_id}``). Scopes what the composer collects, so it must
   match what :class:`ExternalComposeProducer` uses for the same bot, or the
   runtime push and the publish snapshot would compose different content.
-* ``owner_id`` → :meth:`BaasService.get_bind_id` — the bot's
-  ``ac_bots.owner_id``, which is what the binding lookup filters on.
+* ``owner_id`` — the bot's ``ac_bots.owner_id``, the identity the binding was
+  resolved under and the fallback ``entity_id`` takes when omitted. It no
+  longer keys a binding lookup of its own (``binding_id`` comes in resolved).
 
 ``entity_id`` defaults to ``owner_id`` when omitted, so a call site that
 predates the split keeps its current behavior.
@@ -90,6 +96,7 @@ class TeclawDeviceSyncService(DeviceSync):
         conn_info: dict[str, Any] | None,
         bot_id: str,
         bot_name: str,
+        binding_id: int | None,
         user_id: str,
         owner_id: str | None,
         engine_type: str,
@@ -103,8 +110,13 @@ class TeclawDeviceSyncService(DeviceSync):
         self._conn_info = conn_info or {}
         self._bot_id = bot_id
         self._bot_name = bot_name
+        # ``DeviceContext.binding_id`` — the binding the caller's context was
+        # resolved against, threaded straight through to ``get_http_info``
+        # instead of being looked up again per delivery. See ``_deliver``.
+        self._binding_id = binding_id
         self._user_id = user_id
-        # ``ac_bots.owner_id`` — the binding lookup's filter (get_bind_id).
+        # ``ac_bots.owner_id`` — the identity the binding was resolved under;
+        # also ``entity_id``'s fallback below.
         self._owner_id = owner_id or user_id
         # ``ac_bots.entity_id`` — the composer's collection scope. Distinct from
         # owner_id for staff/project/team bots; falls back to owner_id so a call
@@ -113,7 +125,7 @@ class TeclawDeviceSyncService(DeviceSync):
         self._engine_type = engine_type
         self._composer_provider = composer_provider
         # Resolves the container URL + proxypass token per delivery via
-        # get_http_info (and bind_id via get_bind_id).
+        # get_http_info, keyed by the already-resolved ``binding_id``.
         self._baas_service = baas_service
         self._entity_type = entity_type
         # Injected ``Annotated[HttpClient, QUALIFIER_GENERAL]`` (full-absolute-
@@ -246,20 +258,37 @@ class TeclawDeviceSyncService(DeviceSync):
         """POST the composed full artifact to the running teclaw container.
 
         Resolves the container URL + proxypass token per-request via
-        :meth:`BaasService.get_http_info` (``bind_id`` from
-        :meth:`BaasService.get_bind_id`), derives the teclaw bot id from the
+        :meth:`BaasService.get_http_info`, derives the teclaw bot id from the
         resolved ``target``, and POSTs the ``/api/v1/bot/apply`` contract with
         the proxy token in the ``x-proxypass-token`` header (the auth the
         agentclawproxy ``/proxypass`` gateway expects — same gateway/header
         ARCA uses). The full ``info.http_url`` is posted through the injected
         ``HttpClient`` (resolved INSIDE the service at ``sync_*`` time).
+
+        ``bind_id`` is ``self._binding_id`` — the id the ``DeviceContext``
+        already carried — not a fresh :meth:`BaasService.get_bind_id` round
+        trip. The two are the same value on this path, and the substitution is
+        safe because ``get_bind_id`` only performs publish-stage selection when
+        it is *given* a ``publish_status``:
+
+        * This call site never passed one, so ``get_bind_id`` always took its
+          ``publish_status is None`` branch — ``get_by_id_and_owner`` then the
+          row's ``binding_id`` column. ``select_stage_bind_id`` was unreachable
+          from here (the stage-aware callers pass ``PublishStatus.SUCCESS``
+          explicitly). Its ``bot_type`` argument is not read at all.
+        * Every ``DeviceSync`` ctx in the tree is built by
+          ``DeviceContextResolver.resolve_for_bot``, whose binding comes from
+          ``get_active_by_bot_and_owner`` — an ``ac_bots``⋈``binding`` JOIN on
+          ``ac_bots.binding_id == binding.id``. So ``ctx.binding_id`` *is* that
+          same column of that same row, draft/published split included.
+
+        Threading it also makes the delivery internally consistent: the
+        container is now addressed by the binding the rest of this service's
+        state (conn_info, tenant, port) was built from, rather than by a second
+        lookup that could, in principle, answer for a different row.
         """
         conn = self._conn_info
-        bind_id = self._baas_service.get_bind_id(
-            bot_id=self._bot_id,
-            owner_id=self._owner_id,
-            bot_type=conn.get("bot_type", ""),
-        )
+        bind_id = self._binding_id
         if not bind_id:
             raise ValueError(
                 f"TeclawDeviceSyncService: no bind_id for bot={self._bot_id}"

--- a/src/backend/src/agentclaw/community/core/devices/services/teclaw_device_sync.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/teclaw_device_sync.py
@@ -96,7 +96,7 @@ class TeclawDeviceSyncService(DeviceSync):
         conn_info: dict[str, Any] | None,
         bot_id: str,
         bot_name: str,
-        binding_id: int | None,
+        binding_id: int,
         user_id: str,
         owner_id: str | None,
         engine_type: str,
@@ -112,7 +112,10 @@ class TeclawDeviceSyncService(DeviceSync):
         self._bot_name = bot_name
         # ``DeviceContext.binding_id`` — the binding the caller's context was
         # resolved against, threaded straight through to ``get_http_info``
-        # instead of being looked up again per delivery. See ``_deliver``.
+        # instead of being looked up again per delivery. Required, like the
+        # field it comes from: a bot with no binding raises
+        # ``DeviceNotBoundError`` in the resolver and never reaches this
+        # constructor. See ``_deliver``.
         self._binding_id = binding_id
         self._user_id = user_id
         # ``ac_bots.owner_id`` — the identity the binding was resolved under;
@@ -288,14 +291,8 @@ class TeclawDeviceSyncService(DeviceSync):
         lookup that could, in principle, answer for a different row.
         """
         conn = self._conn_info
-        bind_id = self._binding_id
-        if not bind_id:
-            raise ValueError(
-                f"TeclawDeviceSyncService: no bind_id for bot={self._bot_id}"
-            )
-
         info = self._baas_service.get_http_info(
-            bind_id=bind_id,
+            bind_id=self._binding_id,
             port=conn.get("engine_port", 20003),
             path=TECLAW_BOT_APPLY_PATH,
             tenant=conn.get("tenant"),

--- a/src/backend/src/agentclaw/community/di/modules/infrastructure/community/teclaw_device_sync.py
+++ b/src/backend/src/agentclaw/community/di/modules/infrastructure/community/teclaw_device_sync.py
@@ -61,15 +61,19 @@ class TeclawDeviceSyncFactory:
         self._draft_recorder = draft_recorder
 
     def __call__(self, ctx: DeviceContext) -> DeviceSync:
-        # The bot row carries the identity fields the composer and the binding
-        # lookup need. ``entity_id`` (compose scope) and ``owner_id`` (binding
-        # lookup) are deliberately kept apart — see the TeclawDeviceSyncService
-        # module docstring.
+        # The bot row carries the identity fields the composer needs.
+        # ``entity_id`` (compose scope) and ``owner_id`` (the identity the
+        # binding was resolved under) are deliberately kept apart — see the
+        # TeclawDeviceSyncService module docstring.
         bot = self._lookup_bot(ctx.bot_id)
         return TeclawDeviceSyncService(
             conn_info=ctx.conn_info,
             bot_id=ctx.bot_id,
             bot_name=bot.get("bot_name", ""),
+            # The resolver already read this binding to build ``ctx``; passing
+            # it through is what keeps ``_deliver`` off a second lookup for a
+            # value it was handed. Declared non-optional on ``DeviceContext``.
+            binding_id=ctx.binding_id,
             user_id=ctx.user_id,
             owner_id=bot.get("owner_id") or ctx.user_id,
             entity_id=bot.get("entity_id") or None,

--- a/src/backend/tests/community/core/devices/test_teclaw_device_sync.py
+++ b/src/backend/tests/community/core/devices/test_teclaw_device_sync.py
@@ -55,7 +55,10 @@ def _ok_response() -> httpx.Response:
 
 def _baas_service() -> MagicMock:
     baas = MagicMock()
-    baas.get_bind_id.return_value = 42
+    # Deliberately a *different* id from the ``binding_id`` the service is
+    # constructed with: every delivery must address the container by the
+    # threaded-through context id, never by a fresh lookup.
+    baas.get_bind_id.return_value = 999
     baas.get_http_info.return_value = SimpleNamespace(
         http_url=HTTP_URL, token="tok-xyz", target=TARGET
     )
@@ -75,6 +78,7 @@ def _make_service(**overrides) -> tuple[TeclawDeviceSyncService, dict[str, Any]]
         "conn_info": _conn_info(),
         "bot_id": "bot7",
         "bot_name": "GY服务助手",
+        "binding_id": 42,
         "user_id": "u1",
         "owner_id": "u1",
         "entity_id": "staff_u1",
@@ -133,10 +137,10 @@ def test_sync_symlinks_composes_and_posts_the_whole_artifact():
     assert kwargs["json"]["operation"] == "UPDATE"
 
 
-def test_compose_scopes_by_entity_id_while_binding_lookup_uses_owner_id():
+def test_compose_scopes_by_entity_id_and_stays_distinct_from_owner_id():
     """The two identity fields are distinct and must not be conflated: the
-    composer collects by ``ac_bots.entity_id``, the binding lookup filters by
-    ``ac_bots.owner_id``."""
+    composer collects by ``ac_bots.entity_id``, while ``ac_bots.owner_id`` is
+    the identity the binding was resolved under."""
     service, m = _make_service(owner_id="u1", entity_id="staff_u1")
 
     service.sync_symlinks([])
@@ -147,9 +151,6 @@ def test_compose_scopes_by_entity_id_while_binding_lookup_uses_owner_id():
     assert req.bot_id == "bot7"
     assert req.engine_type == "teclaw"
     assert req.entity_type == "staff"
-    m["baas"].get_bind_id.assert_called_once_with(
-        bot_id="bot7", owner_id="u1", bot_type="service"
-    )
 
 
 def test_entity_id_defaults_to_owner_id_when_omitted():
@@ -186,6 +187,49 @@ def test_http_info_is_resolved_per_delivery_with_the_apply_path():
         tenant="team_claw",
         device_affinity="u1",
     )
+
+
+# ── bind_id threading ────────────────────────────────────────────────────
+
+
+def test_delivery_addresses_the_threaded_binding_id_without_a_lookup():
+    """The resolved ``DeviceContext`` already carried this binding; re-deriving
+    it cost a BaaS round trip per delivery for a value the caller was handed."""
+    service, m = _make_service(binding_id=1382508)
+
+    service.sync_symlinks([])
+
+    m["baas"].get_bind_id.assert_not_called()
+    assert m["baas"].get_http_info.call_args.kwargs["bind_id"] == 1382508
+
+
+def test_no_get_bind_id_round_trip_on_any_sync_entry_point():
+    """Every ``sync_*`` funnels through ``_compose_and_deliver``; none of them
+    may reintroduce the lookup."""
+    for method, args in (
+        ("sync_symlinks", ([],)),
+        ("sync_bot_config", ("bot7", 42, "1", "OWNER", "u1", "nick")),
+        ("sync_all_mcp_servers", ([],)),
+        ("sync_single_mcp", ({"server_code": "s1"},)),
+        ("sync_remove_mcp", ("s1",)),
+    ):
+        service, m = _make_service()
+
+        getattr(service, method)(*args)
+
+        m["baas"].get_bind_id.assert_not_called()
+
+
+def test_a_stale_get_bind_id_answer_cannot_redirect_the_delivery():
+    """Guards the container the artifact lands in: even when ``get_bind_id``
+    would answer with a different binding, delivery stays on the one the
+    context was resolved against."""
+    service, m = _make_service(binding_id=42)
+    m["baas"].get_bind_id.return_value = 777
+
+    service.sync_symlinks([])
+
+    assert m["baas"].get_http_info.call_args.kwargs["bind_id"] == 42
 
 
 def test_sync_bot_config_redelivers_the_whole_artifact():
@@ -272,14 +316,17 @@ def test_request_error_maps_to_a_failure_dict():
     assert result["message"].startswith("请求失败")
 
 
-def test_missing_bind_id_fails_without_posting():
-    service, m = _make_service()
-    m["baas"].get_bind_id.return_value = None
+@pytest.mark.parametrize("binding_id", [None, 0])
+def test_missing_bind_id_fails_without_posting(binding_id):
+    """An absent binding still fails as the same ``{"success": False}`` dict —
+    it must not reach ``get_http_info`` or the container."""
+    service, m = _make_service(binding_id=binding_id)
 
     result = service.sync_symlinks([])
 
     assert result["success"] is False
     assert "no bind_id" in result["message"]
+    m["baas"].get_http_info.assert_not_called()
     m["http_client"].post.assert_not_called()
 
 

--- a/src/backend/tests/community/core/devices/test_teclaw_device_sync.py
+++ b/src/backend/tests/community/core/devices/test_teclaw_device_sync.py
@@ -190,6 +190,11 @@ def test_http_info_is_resolved_per_delivery_with_the_apply_path():
 
 
 # ── bind_id threading ────────────────────────────────────────────────────
+# ``binding_id`` is required, mirroring the non-optional ``DeviceContext``
+# field it comes from, so there is no absent-binding case to pin here: a bot
+# with no active binding raises ``DeviceNotBoundError`` in the resolver and
+# never reaches this constructor (``test_device_context_resolver.py::
+# test_bot_no_active_binding_raises_device_not_bound``).
 
 
 def test_delivery_addresses_the_threaded_binding_id_without_a_lookup():
@@ -314,20 +319,6 @@ def test_request_error_maps_to_a_failure_dict():
 
     assert result["success"] is False
     assert result["message"].startswith("请求失败")
-
-
-@pytest.mark.parametrize("binding_id", [None, 0])
-def test_missing_bind_id_fails_without_posting(binding_id):
-    """An absent binding still fails as the same ``{"success": False}`` dict —
-    it must not reach ``get_http_info`` or the container."""
-    service, m = _make_service(binding_id=binding_id)
-
-    result = service.sync_symlinks([])
-
-    assert result["success"] is False
-    assert "no bind_id" in result["message"]
-    m["baas"].get_http_info.assert_not_called()
-    m["http_client"].post.assert_not_called()
 
 
 def test_compose_failure_is_contained_in_the_result_dict():

--- a/src/backend/tests/community/di/test_device_sync_wiring.py
+++ b/src/backend/tests/community/di/test_device_sync_wiring.py
@@ -28,9 +28,10 @@ from agentclaw.community.plugin_api.device_sync_dispatcher import DeviceSyncDisp
 from agentclaw.community.plugins.community.device_sync_dispatcher import CommunityDeviceSyncDispatcher
 
 
-def _ctx(provider="baas"):
+def _ctx(provider="baas", binding_id=1382508):
     return SimpleNamespace(
         provider=provider, bot_id="b", user_id="u1", bot_type="personal",
+        binding_id=binding_id,
         conn_info={"bind_id": 1, "engine_port": 20003, "tenant": "", "paas_device_id": "u"},
     )
 
@@ -104,6 +105,24 @@ def test_teclaw_factory_takes_identity_from_the_bot_row():
     assert service._bot_name == "助手"
     assert service._entity_type == "staff"
     assert service._engine_type == "teclaw"
+
+
+def test_teclaw_factory_threads_the_resolved_binding_id_onto_the_service():
+    """``ctx.binding_id`` is what the delivery addresses; the service must not
+    have to ask BaaS for it again."""
+    service = _teclaw_factory()(_ctx(provider="teclaw", binding_id=1382508))
+
+    assert service._binding_id == 1382508
+
+
+def test_threaded_binding_id_is_independent_of_the_bot_row():
+    """It comes off the context the resolver built, not off the ``ac_bots``
+    row the factory reads for the composer's identity fields."""
+    service = _teclaw_factory(bot_row=_bot_row(binding_id=1))(
+        _ctx(provider="teclaw", binding_id=2)
+    )
+
+    assert service._binding_id == 2
 
 
 def test_teclaw_factory_falls_back_to_ctx_identity_when_the_bot_row_is_missing():


### PR DESCRIPTION
## Problem

`DeviceContextResolver.resolve_for_bot` reads the active binding and puts its id on the `DeviceContext` it returns (`device_context_resolver.py:78`, `:100`); `binding_id: int` is a declared, non-optional field on `DeviceContext` (`device_context.py:38`).

`TeclawDeviceSyncFactory.__call__` receives that context and builds the service from it, but did not pass `binding_id` through. So at delivery time `TeclawDeviceSyncService._deliver` asked the database for it again via `BaasService.get_bind_id`.

From the `POST /skillset/deactivate` trace in #1668 — the same binding resolved twice, ~3.3 s apart in one request:

```
16:33:09.845  [get_by_id] id=1382508 ...      ← DeviceContextResolver; now on the DeviceContext
16:33:13.116  [BaasService.get_bind_id] bot_id=…, publish_status=None
16:33:13.218  [BaasService.get_bind_id] Got bind_id from bot: 1382508   ← same value, ~100 ms
```

Roughly 100 ms per delivery spent re-deriving a value already sitting in a field on an object the caller was handed.

## Solution

Thread `ctx.binding_id` from the factory into `TeclawDeviceSyncService.__init__`, and use it in `_deliver` in place of the `get_bind_id` call.

### The divergence question, answered

The issue asked this be settled before any code lands: `get_bind_id` is **not** a plain "read the active binding" call — it takes a `publish_status` and delegates to `select_stage_bind_id` (`baas_service.py:2135`), while `DeviceContextResolver` picks the *active* binding via `get_active_by_bot_and_owner`. Can they diverge for any bot type reaching `TeclawDeviceSyncService`?

**They cannot, on this path.** `get_bind_id` performs stage selection only when it is *given* a `publish_status`, and two facts close the question:

1. **This call site never passed one.** With `publish_status=None`, `get_bind_id` takes its first branch unconditionally: `get_by_id_and_owner(bot_id, owner_id)`, then `bot["bind_id"] or bot["binding_id"]` — the `ac_bots.binding_id` column. `select_stage_bind_id` is structurally unreachable from `TeclawDeviceSyncService`; the stage-aware callers (`expert_chat_service.py:235`, `:735`) pass `PublishStatus.SUCCESS.value` explicitly. Its `bot_type` argument is not read by the function at all, so the service-vs-personal distinction never entered into it either.

2. **`ctx.binding_id` is that same column.** All seven `device_sync_dispatcher.dispatch(ctx)` call sites in the tree (`channel_service`, `skill_set_service` ×2, `skill_symlink_listener`, `skill_propagation_service`, `bot_public_service`, `adapters/http/skill_center/skillsets`) build their ctx via `resolve_for_bot` — none via `resolve_for_binding` / `resolve_for_binding_invoke`. `resolve_for_bot`'s binding comes from `get_active_by_bot_and_owner`, which is an `ac_bots` ⋈ `ac_entity_device_binding` JOIN on `ac_bots.binding_id == binding.id`. Its `.id` therefore *is* `ac_bots.binding_id`.

Same row, same column, read two different ways. This holds for a service bot with a draft/published split too: the old call read the draft-side `ac_bots.binding_id` exactly as the resolver does, because it never asked for a stage. So this is `ctx.binding_id` used directly and the call deleted — not a partial swap or a short-circuit hint.

Threading it also makes each delivery internally consistent: the container is addressed by the binding the rest of the service's state (`conn_info`, tenant, port, composer scope) was built from, rather than by a second lookup keyed on `owner_id` that could in principle answer for a different row than the one the context was resolved against.

Not touched, per the issue: the ws-info / http-info double container resolution stays as it is — different BaaS endpoints serving different transports.

### `binding_id` is required, and the old falsy guard is gone

Per review feedback (a5c6194): the parameter is `int`, not `int | None`, and `_deliver`'s `if not bind_id: raise ValueError(...)` is removed.

The guard was load-bearing before this PR, because `get_bind_id` could return `None`. It no longer can be reached: `DeviceContext.binding_id` is non-optional, the DI factory is the only production construction site, and a bot with no active binding raises `DeviceNotBoundError` inside `resolve_for_bot` — so no context is produced and the service is never constructed. The absent case is validated at that boundary and covered there by `test_device_context_resolver.py::test_bot_no_active_binding_raises_device_not_bound`. This follows AGENTS.md § "Python Type Contracts": keep constructor arguments non-optional end to end and validate at the boundary, rather than widening a required type defensively.

The service-level test for the absent case went with the guard, since it pinned an unreachable state; a comment in its place points at the resolver test that covers the real boundary.

## Validation

- `tests/community/core/devices/test_teclaw_device_sync.py` and `tests/community/di/test_device_sync_wiring.py` — new coverage for the threaded-through id: delivery addresses `ctx.binding_id` with no lookup; no `sync_*` entry point reintroduces the round trip; a `get_bind_id` answering with a *different* binding cannot redirect the delivery. The shared `_baas_service()` mock now returns a deliberately different id from the constructed `binding_id`, so any reintroduced lookup fails loudly rather than silently agreeing.
- `tests/community/core/devices`, `tests/community/di`, `tests/community/contract` — 1017 passed.
- Full backend suite — **15255 passed, 60 skipped**.
- `ruff check` on all four changed files — clean.

Not run: `tests/community/core/service_bot/services/test_bot_build_service_skill_artifact.py` fails in this sandbox with `rsync: not found` (`rsync` is absent from the image). It is unrelated to this diff — the file exercises `bot_build_service` rsync migration, which this change does not touch — and it is the only file deselected from the full-suite runs above. CI's Backend unit tests job runs it and passes.

## Compatibility and risk

No contract, schema, config, or migration impact. `binding_id` is a new required keyword-only parameter on `TeclawDeviceSyncService.__init__`; the DI factory is its only production construction site (verified by grep across `src/` and `tests/`), so no other caller needs updating. Delivery targets the same container it does today for personal, desktop and service bots, including a service bot with a draft/published split — per the reasoning above.

Rollback is the revert of these commits; nothing persists state that would need unwinding.

## Related issues

Closes #1668. No file overlap with #1666 or #1667.