### PR TITLE
fix(bcs): fail over streaming-overlay write to DB on Redis rejection (#1627)

### DIFF
--- a/src/bcs/crates/services/bcs-chat-run-store/Cargo.toml
+++ b/src/bcs/crates/services/bcs-chat-run-store/Cargo.toml
@@ -18,6 +18,8 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
+bcs-cache-api = { workspace = true }
 bcs-cache-local = { workspace = true }
 bcs-db-local = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
@@ -55,6 +55,9 @@ struct StreamingOverlay {
     state: String,
     accumulated_content: String,
     content_truncated: bool,
+    /// Run deadline carried in the overlay so the normal streaming path can
+    /// compute its TTL (and detect a missing run) without a per-delta DB read.
+    expires_at_ms: u64,
 }
 
 impl SqlChatRunRepo {
@@ -155,17 +158,13 @@ impl SqlChatRunRepo {
     /// as the sole delta record (`append_streaming_content`) can fail over to
     /// the DB. Best-effort callers (`create`, state CAS) ignore the result
     /// since the DB row is authoritative there.
-    async fn write_overlay(
-        &self,
-        run_id: &str,
-        overlay: &StreamingOverlay,
-        expires_at_ms: u64,
-    ) -> Result<(), CacheError> {
+    async fn write_overlay(&self, run_id: &str, overlay: &StreamingOverlay) -> Result<(), CacheError> {
         let now = now_ms();
         // Overlay must survive the run deadline by the retention grace so the
         // timeout sweep (which runs only once `expires_at_ms < now`) can still
         // merge the streamed content instead of reading a stale DB row.
-        let ttl_ms = expires_at_ms
+        let ttl_ms = overlay
+            .expires_at_ms
             .saturating_add(self.overlay_retention_ms)
             .saturating_sub(now)
             .max(1000);
@@ -222,6 +221,45 @@ impl SqlChatRunRepo {
         );
         let result = self.db.execute(stmt).await.map_err(backend)?;
         Ok(result.affected_rows > 0)
+    }
+
+    /// Resolve the base for a streaming append. Fast path: when the overlay is
+    /// present at exactly the caller's expected version it is the streaming
+    /// source of truth and is used directly **without a DB read** (issue spec:
+    /// per-token deltas never hit the DB on the normal path). An overlay newer
+    /// than the caller's expectation means the caller is stale → no base
+    /// (`Ok(None)` → append returns `Ok(false)`). A missing or behind-version
+    /// overlay (Redis outage / stale-after-fail-over) falls back to the
+    /// authoritative DB row — the recovery path that has to read MySQL anyway.
+    /// Returns `Ok(None)` when the run is missing or its version does not match.
+    async fn resolve_append_base(
+        &self,
+        run_id: &str,
+        expected_version: u64,
+    ) -> Result<Option<StreamingOverlay>, ChatRunRepoError> {
+        match self.read_overlay(run_id).await {
+            Some(existing) if existing.version == expected_version => return Ok(Some(existing)),
+            Some(existing) if existing.version > expected_version => return Ok(None),
+            _ => {}
+        }
+        let Some(db) = self.read_db(run_id).await? else {
+            return Ok(None);
+        };
+        if db.expires_at_ms == 0 {
+            return Ok(None);
+        }
+        let overlay = StreamingOverlay {
+            version: db.version,
+            state: state_str(db.state).to_string(),
+            accumulated_content: db.accumulated_content.clone(),
+            content_truncated: db.content_truncated,
+            expires_at_ms: db.expires_at_ms,
+        };
+        Ok(if overlay.version == expected_version {
+            Some(overlay)
+        } else {
+            None
+        })
     }
 
     async fn delete_overlay(&self, run_id: &str) {
@@ -457,8 +495,8 @@ impl ChatRunRepoPort for SqlChatRunRepo {
                             state: state_str(record.state).to_string(),
                             accumulated_content: record.accumulated_content.clone(),
                             content_truncated: record.content_truncated,
+                            expires_at_ms: record.expires_at_ms,
                         },
-                        record.expires_at_ms,
                     )
                     .await;
                 Ok(())
@@ -512,8 +550,8 @@ impl ChatRunRepoPort for SqlChatRunRepo {
                         state: state_str(updated.state).to_string(),
                         accumulated_content: updated.accumulated_content.clone(),
                         content_truncated: updated.content_truncated,
+                        expires_at_ms: updated.expires_at_ms,
                     },
-                    updated.expires_at_ms,
                 )
                 .await;
             Ok(CasOutcome::Applied(updated))
@@ -564,33 +602,13 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         accumulated: String,
         truncated: bool,
     ) -> Result<bool, ChatRunRepoError> {
-        // Read both the overlay (streaming hot cache) and the authoritative DB
-        // row, then base off whichever is newer. P1: a stale overlay left by a
-        // rejected write must never win over a DB row the fail-over advanced, so
-        // pick `max(overlay.version, db.version)` rather than trusting the overlay.
-        let overlay_opt = self.read_overlay(run_id).await;
-        let db_record = self.read_db(run_id).await?;
-        let expires_at_ms = db_record.as_ref().map(|r| r.expires_at_ms).unwrap_or(0);
-        if expires_at_ms == 0 {
+        // Resolve the base. On the normal streaming path this returns straight
+        // from the overlay without a DB read (see `resolve_append_base`); the DB
+        // is only touched when the overlay is missing or stale (fail-over /
+        // recovery), which is the path that has to read MySQL anyway.
+        let Some(mut overlay) = self.resolve_append_base(run_id, expected_version).await? else {
             return Ok(false);
-        }
-        let mut overlay = match (overlay_opt, db_record) {
-            // Overlay is ahead of the DB — normal streaming; base off the overlay.
-            (Some(existing), Some(db)) if existing.version > db.version => existing,
-            // DB is at or ahead (incl. the fail-over case), or the overlay is
-            // gone — base off the authoritative DB row.
-            (_, Some(db)) => StreamingOverlay {
-                version: db.version,
-                state: state_str(db.state).to_string(),
-                accumulated_content: db.accumulated_content.clone(),
-                content_truncated: db.content_truncated,
-            },
-            // Overlay present but the DB row is gone — treat the run as missing.
-            (Some(_), None) | (None, None) => return Ok(false),
         };
-        if overlay.version != expected_version {
-            return Ok(false);
-        }
         let flipped = overlay.state == "pending";
         overlay.version += 1;
         if flipped {
@@ -599,7 +617,7 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         overlay.accumulated_content = accumulated;
         overlay.content_truncated = truncated;
         let intended_version = overlay.version;
-        match self.write_overlay(run_id, &overlay, expires_at_ms).await {
+        match self.write_overlay(run_id, &overlay).await {
             // Overlay (the sole delta record) confirmed the write.
             Ok(()) => Ok(true),
             // C4/P1: overlay write rejected — fail the delta over to the DB at the

--- a/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use bcs_cache_api::{CachePlugin, CacheSetMode};
+use bcs_cache_api::{CacheError, CachePlugin, CacheSetMode};
 use bcs_db_api::{db_get_column, db_get_column_opt, DbPlugin, DbSqlFlavor, DbStatement, DbValue};
 use bcs_service_api::port::repo::{
     CasOutcome, ChatRunCompletionPolicy, ChatRunRecord, ChatRunRepoError, ChatRunRepoPort,
@@ -148,7 +148,19 @@ impl SqlChatRunRepo {
         }
     }
 
-    async fn write_overlay(&self, run_id: &str, overlay: &StreamingOverlay, expires_at_ms: u64) {
+    /// Write the streaming overlay. Returns `Ok(())` only when the store
+    /// confirmed the write (`set_value` → `Ok(true)`). A rejection, or the
+    /// no-write `Ok(false)` for an upsert (which means the delta was NOT
+    /// stored), is surfaced as `Err` so the caller that relies on the overlay
+    /// as the sole delta record (`append_streaming_content`) can fail over to
+    /// the DB. Best-effort callers (`create`, state CAS) ignore the result
+    /// since the DB row is authoritative there.
+    async fn write_overlay(
+        &self,
+        run_id: &str,
+        overlay: &StreamingOverlay,
+        expires_at_ms: u64,
+    ) -> Result<(), CacheError> {
         let now = now_ms();
         // Overlay must survive the run deadline by the retention grace so the
         // timeout sweep (which runs only once `expires_at_ms < now`) can still
@@ -157,17 +169,55 @@ impl SqlChatRunRepo {
             .saturating_add(self.overlay_retention_ms)
             .saturating_sub(now)
             .max(1000);
-        if let Ok(bytes) = serde_json::to_vec(overlay) {
-            let _ = self
-                .cache
-                .set_value(
-                    &self.cache_key(run_id),
-                    bytes,
-                    Some(Duration::from_millis(ttl_ms)),
-                    CacheSetMode::Upsert,
-                )
-                .await;
+        let bytes = serde_json::to_vec(overlay)
+            .map_err(|err| CacheError::InvalidInput(err.to_string()))?;
+        match self
+            .cache
+            .set_value(
+                &self.cache_key(run_id),
+                bytes,
+                Some(Duration::from_millis(ttl_ms)),
+                CacheSetMode::Upsert,
+            )
+            .await
+        {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(CacheError::Backend(
+                "streaming overlay upsert reported no write".to_string(),
+            )),
+            Err(err) => Err(err),
         }
+    }
+
+    /// Fail a streaming delta over to the authoritative DB row when the Redis
+    /// overlay write is unavailable (C4, #1546: never convert a backend write
+    /// failure into a lost delta). Writes `accumulated_content` directly with
+    /// `version = version + 1` under the non-terminal guard: applied →
+    /// `Ok(true)`, already-terminal (0 rows, delta not applied) → `Ok(false)`,
+    /// DB error → propagated `Backend`.
+    async fn fall_back_to_db_append(
+        &self,
+        run_id: &str,
+        accumulated: &str,
+        truncated: bool,
+    ) -> Result<bool, ChatRunRepoError> {
+        let now = now_ms();
+        let stmt = DbStatement::with_params(
+            &format!(
+                "UPDATE bcs_chat_runs SET accumulated_content = ?, content_truncated = ?, \
+                 version = version + 1, updated_at_ms = ? \
+                 WHERE run_id = ? AND state NOT IN ({TERMINAL_STATES}) AND env = ?"
+            ),
+            vec![
+                DbValue::from(accumulated.to_string()),
+                DbValue::from(truncated),
+                DbValue::from(now as i64),
+                DbValue::from(run_id.to_string()),
+                DbValue::from(self.env.as_str()),
+            ],
+        );
+        let result = self.db.execute(stmt).await.map_err(backend)?;
+        Ok(result.affected_rows > 0)
     }
 
     async fn delete_overlay(&self, run_id: &str) {
@@ -393,17 +443,20 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         );
         match self.db.execute(stmt).await {
             Ok(_) => {
-                self.write_overlay(
-                    &record.run_id,
-                    &StreamingOverlay {
-                        version: record.version,
-                        state: state_str(record.state).to_string(),
-                        accumulated_content: record.accumulated_content.clone(),
-                        content_truncated: record.content_truncated,
-                    },
-                    record.expires_at_ms,
-                )
-                .await;
+                // Overlay here is only a read cache of the just-inserted DB row;
+                // a write blip is benign (a later read falls back to the DB).
+                let _ = self
+                    .write_overlay(
+                        &record.run_id,
+                        &StreamingOverlay {
+                            version: record.version,
+                            state: state_str(record.state).to_string(),
+                            accumulated_content: record.accumulated_content.clone(),
+                            content_truncated: record.content_truncated,
+                        },
+                        record.expires_at_ms,
+                    )
+                    .await;
                 Ok(())
             }
             Err(err) if err.is_duplicate_key() => {
@@ -445,17 +498,20 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         let result = self.db.execute(stmt).await.map_err(backend)?;
         if result.affected_rows > 0 {
             let updated = read_full(self.db.as_ref(), run_id, &self.env).await?.unwrap_or(new.clone());
-            self.write_overlay(
-                run_id,
-                &StreamingOverlay {
-                    version: updated.version,
-                    state: state_str(updated.state).to_string(),
-                    accumulated_content: updated.accumulated_content.clone(),
-                    content_truncated: updated.content_truncated,
-                },
-                updated.expires_at_ms,
-            )
-            .await;
+            // Refresh the read-cache overlay of the just-applied DB state; best
+            // effort, since the DB row is authoritative on a read miss.
+            let _ = self
+                .write_overlay(
+                    run_id,
+                    &StreamingOverlay {
+                        version: updated.version,
+                        state: state_str(updated.state).to_string(),
+                        accumulated_content: updated.accumulated_content.clone(),
+                        content_truncated: updated.content_truncated,
+                    },
+                    updated.expires_at_ms,
+                )
+                .await;
             Ok(CasOutcome::Applied(updated))
         } else {
             classify_cas_failure(self.db.as_ref(), run_id, &self.env).await
@@ -537,8 +593,14 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         }
         overlay.accumulated_content = accumulated;
         overlay.content_truncated = truncated;
-        self.write_overlay(run_id, &overlay, expires_at_ms).await;
-        Ok(true)
+        match self.write_overlay(run_id, &overlay, expires_at_ms).await {
+            // Overlay (the sole delta record) confirmed the write.
+            Ok(()) => Ok(true),
+            // C4: the overlay write was rejected (Redis outage / upsert no-write).
+            // Fail the delta over to the authoritative DB row instead of
+            // silently dropping it (#1546 forbids a swallowed backend write).
+            Err(_) => self.fall_back_to_db_append(run_id, &overlay.accumulated_content, truncated).await,
+        }
     }
 
     async fn list_active(&self, now_ms: u64) -> Result<Vec<ChatRunRecord>, ChatRunRepoError> {

--- a/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
@@ -191,26 +191,30 @@ impl SqlChatRunRepo {
 
     /// Fail a streaming delta over to the authoritative DB row when the Redis
     /// overlay write is unavailable (C4, #1546: never convert a backend write
-    /// failure into a lost delta). Writes `accumulated_content` directly with
-    /// `version = version + 1` under the non-terminal guard: applied →
-    /// `Ok(true)`, already-terminal (0 rows, delta not applied) → `Ok(false)`,
-    /// DB error → propagated `Backend`.
+    /// failure into a lost delta). Writes `accumulated_content` at the
+    /// *intended* version (`version = ?`, not `version + 1`) so a stale overlay
+    /// left at a lower version can never be merged over the freshly persisted
+    /// row (P1): later reads/appends re-base off the DB. The non-terminal guard
+    /// still resolves a concurrent terminal to 0 rows. applied → `Ok(true)`,
+    /// already-terminal → `Ok(false)`, DB error → propagated `Backend`.
     async fn fall_back_to_db_append(
         &self,
         run_id: &str,
         accumulated: &str,
         truncated: bool,
+        intended_version: u64,
     ) -> Result<bool, ChatRunRepoError> {
         let now = now_ms();
         let stmt = DbStatement::with_params(
             &format!(
                 "UPDATE bcs_chat_runs SET accumulated_content = ?, content_truncated = ?, \
-                 version = version + 1, updated_at_ms = ? \
+                 version = ?, updated_at_ms = ? \
                  WHERE run_id = ? AND state NOT IN ({TERMINAL_STATES}) AND env = ?"
             ),
             vec![
                 DbValue::from(accumulated.to_string()),
                 DbValue::from(truncated),
+                DbValue::from(intended_version as i64),
                 DbValue::from(now as i64),
                 DbValue::from(run_id.to_string()),
                 DbValue::from(self.env.as_str()),
@@ -560,30 +564,31 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         accumulated: String,
         truncated: bool,
     ) -> Result<bool, ChatRunRepoError> {
-        // Base the overlay on the current overlay if present, else the DB row.
-        let mut overlay = match self.read_overlay(run_id).await {
-            Some(existing) => existing,
-            None => {
-                let Some(record) = self.read_db(run_id).await? else {
-                    return Ok(false);
-                };
-                StreamingOverlay {
-                    version: record.version,
-                    state: state_str(record.state).to_string(),
-                    accumulated_content: record.accumulated_content.clone(),
-                    content_truncated: record.content_truncated,
-                }
-            }
-        };
-        if overlay.version != expected_version {
+        // Read both the overlay (streaming hot cache) and the authoritative DB
+        // row, then base off whichever is newer. P1: a stale overlay left by a
+        // rejected write must never win over a DB row the fail-over advanced, so
+        // pick `max(overlay.version, db.version)` rather than trusting the overlay.
+        let overlay_opt = self.read_overlay(run_id).await;
+        let db_record = self.read_db(run_id).await?;
+        let expires_at_ms = db_record.as_ref().map(|r| r.expires_at_ms).unwrap_or(0);
+        if expires_at_ms == 0 {
             return Ok(false);
         }
-        let expires_at_ms = self
-            .read_db(run_id)
-            .await?
-            .map(|record| record.expires_at_ms)
-            .unwrap_or(0);
-        if expires_at_ms == 0 {
+        let mut overlay = match (overlay_opt, db_record) {
+            // Overlay is ahead of the DB — normal streaming; base off the overlay.
+            (Some(existing), Some(db)) if existing.version > db.version => existing,
+            // DB is at or ahead (incl. the fail-over case), or the overlay is
+            // gone — base off the authoritative DB row.
+            (_, Some(db)) => StreamingOverlay {
+                version: db.version,
+                state: state_str(db.state).to_string(),
+                accumulated_content: db.accumulated_content.clone(),
+                content_truncated: db.content_truncated,
+            },
+            // Overlay present but the DB row is gone — treat the run as missing.
+            (Some(_), None) | (None, None) => return Ok(false),
+        };
+        if overlay.version != expected_version {
             return Ok(false);
         }
         let flipped = overlay.state == "pending";
@@ -593,13 +598,27 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         }
         overlay.accumulated_content = accumulated;
         overlay.content_truncated = truncated;
+        let intended_version = overlay.version;
         match self.write_overlay(run_id, &overlay, expires_at_ms).await {
             // Overlay (the sole delta record) confirmed the write.
             Ok(()) => Ok(true),
-            // C4: the overlay write was rejected (Redis outage / upsert no-write).
-            // Fail the delta over to the authoritative DB row instead of
-            // silently dropping it (#1546 forbids a swallowed backend write).
-            Err(_) => self.fall_back_to_db_append(run_id, &overlay.accumulated_content, truncated).await,
+            // C4/P1: overlay write rejected — fail the delta over to the DB at the
+            // *intended* version, then drop the stale overlay best-effort so
+            // recovery re-bases off the DB. (#1546 forbids swallowing the write.)
+            Err(_) => {
+                let applied = self
+                    .fall_back_to_db_append(
+                        run_id,
+                        &overlay.accumulated_content,
+                        truncated,
+                        intended_version,
+                    )
+                    .await?;
+                if applied {
+                    self.delete_overlay(run_id).await;
+                }
+                Ok(applied)
+            }
         }
     }
 

--- a/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
@@ -98,6 +98,85 @@ fn repo_failing_cache() -> SqlChatRunRepo {
     )
 }
 
+/// Cache double for the P1 fail-over scenario. `set_value` and `delete` always
+/// reject (Redis can neither accept the new overlay nor evict the stale one on
+/// fail-over), while `get_value` reads an in-memory store that can be pre-seeded
+/// with a *stale* overlay — modeling Redis still holding a prior successful
+/// overlay that the rejected write cannot erase.
+struct StaleOverlayFailingCache {
+    inner: InMemoryCachePlugin,
+}
+
+impl StaleOverlayFailingCache {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryCachePlugin::new(),
+        }
+    }
+
+    /// Seed a stale overlay at `key` (a prior successful write Redis still holds).
+    /// `set_value`/`delete` remain rejected.
+    async fn seed(&self, key: &str, bytes: Vec<u8>) {
+        let _ = self
+            .inner
+            .set_value(key, bytes, None, CacheSetMode::Upsert)
+            .await;
+    }
+}
+
+#[async_trait]
+impl CachePlugin for StaleOverlayFailingCache {
+    async fn get_value(&self, key: &str) -> CacheResult<Option<Vec<u8>>> {
+        self.inner.get_value(key).await
+    }
+
+    async fn set_value(
+        &self,
+        _key: &str,
+        _value: Vec<u8>,
+        _ttl: Option<Duration>,
+        _mode: CacheSetMode,
+    ) -> CacheResult<bool> {
+        Err(CacheError::Backend(
+            "injected overlay write failure".to_string(),
+        ))
+    }
+
+    async fn delete(&self, _key: &str) -> CacheResult<bool> {
+        Err(CacheError::Backend(
+            "injected overlay delete failure".to_string(),
+        ))
+    }
+
+    async fn expire(&self, key: &str, ttl: Duration) -> CacheResult<bool> {
+        self.inner.expire(key, ttl).await
+    }
+
+    async fn ttl(&self, key: &str) -> CacheResult<CacheTtl> {
+        self.inner.ttl(key).await
+    }
+
+    async fn hash_get(&self, key: &str, field: &str) -> CacheResult<Option<Vec<u8>>> {
+        self.inner.hash_get(key, field).await
+    }
+
+    async fn hash_get_all(&self, key: &str) -> CacheResult<BTreeMap<String, Vec<u8>>> {
+        self.inner.hash_get_all(key).await
+    }
+
+    async fn hash_set(&self, key: &str, field: &str, value: Vec<u8>) -> CacheResult<()> {
+        self.inner.hash_set(key, field, value).await
+    }
+
+    async fn hash_set_many(&self, key: &str, fields: BTreeMap<String, Vec<u8>>) -> CacheResult<()> {
+        self.inner.hash_set_many(key, fields).await
+    }
+
+    async fn hash_delete(&self, key: &str, field: &str) -> CacheResult<bool> {
+        self.inner.hash_delete(key, field).await
+    }
+}
+
 fn record(run_id: &str, version: u64) -> ChatRunRecord {
     let mut record = ChatRunRecord::new(
         run_id.to_string(),
@@ -258,6 +337,62 @@ async fn streaming_append_fallover_noop_when_run_already_terminal() {
     assert_eq!(stored.state, ChatRunState::Failed);
     assert_eq!(stored.accumulated_content, "final");
     assert_eq!(stored.version, 2);
+}
+
+#[tokio::test]
+async fn streaming_append_failover_ignores_stale_overlay_and_rebases_on_db() {
+    // P1: Redis still READS a stale overlay but rejects the new write, and the
+    // best-effort delete also fails. The fail-over must advance the DB to the
+    // *intended* version so the stale overlay (lower version) is never merged
+    // over it; the next append then re-bases off the DB and resumes seamlessly.
+    let db = Arc::new(LocalSqliteDbPlugin::new().expect("sqlite db"));
+    let cache = Arc::new(StaleOverlayFailingCache::new());
+    let dyn_cache: Arc<dyn CachePlugin> = cache.clone();
+    let repo = SqlChatRunRepo::new(
+        db,
+        DbSqlFlavor::Sqlite,
+        dyn_cache,
+        "bcs:".to_string(),
+        120_000,
+        "test".to_string(),
+    );
+    repo.create(record("a", 1)).await.unwrap();
+
+    // Pretend five prior deltas streamed into the overlay while the DB stayed
+    // at the create-time version 1.
+    let stale = serde_json::to_vec(&serde_json::json!({
+        "version": 5u64,
+        "state": "running",
+        "accumulated_content": "ABCDE",
+        "content_truncated": false,
+    }))
+    .unwrap();
+    cache.seed("bcs:chat_run:a", stale).await;
+
+    // Engine read the stale overlay (v5, "ABCDE") and appended "F" → "ABCDEF",
+    // expecting v5. The overlay write is rejected → DB fail-over.
+    assert!(
+        repo.append_streaming_content("a", 5, "ABCDEF".to_string(), false)
+            .await
+            .unwrap()
+    );
+    // The fail-over wrote "ABCDEF" to the DB at the intended version 6 (NOT
+    // version+1 = v2), so the stale overlay v5 can no longer be merged over the
+    // DB row.
+    let stored = repo.get("a").await.unwrap().unwrap();
+    assert_eq!(stored.accumulated_content, "ABCDEF");
+    assert_eq!(stored.version, 6);
+
+    // The stale overlay is still readable (delete failed) but v5 < 6, so the
+    // next append bases off the DB (v6), not the stale overlay, and continues.
+    assert!(
+        repo.append_streaming_content("a", 6, "ABCDEF7".to_string(), false)
+            .await
+            .unwrap()
+    );
+    let stored = repo.get("a").await.unwrap().unwrap();
+    assert_eq!(stored.accumulated_content, "ABCDEF7");
+    assert_eq!(stored.version, 7);
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
@@ -1,5 +1,9 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::Duration;
 
+use async_trait::async_trait;
+use bcs_cache_api::{CacheError, CachePlugin, CacheResult, CacheSetMode, CacheTtl};
 use bcs_cache_local::InMemoryCachePlugin;
 use bcs_chat_run_store::{
     CasOutcome, ChatRunCompletionPolicy, ChatRunRecord, ChatRunRepoError, ChatRunRepoPort,
@@ -13,6 +17,85 @@ fn repo() -> SqlChatRunRepo {
     let db = Arc::new(LocalSqliteDbPlugin::new().expect("sqlite db"));
     let cache = Arc::new(InMemoryCachePlugin::new());
     SqlChatRunRepo::new(db, DbSqlFlavor::Sqlite, cache, "bcs:".to_string(), 120_000, "test".to_string())
+}
+
+/// Cache double whose `set_value` always rejects, simulating a Redis overlay
+/// write outage. Reads/deletes delegate to an in-memory store so `read_overlay`
+/// sees the nothing that was written — exactly the C4 fail-over scenario.
+struct FailingWritesCache {
+    inner: InMemoryCachePlugin,
+}
+
+impl FailingWritesCache {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryCachePlugin::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl CachePlugin for FailingWritesCache {
+    async fn get_value(&self, key: &str) -> CacheResult<Option<Vec<u8>>> {
+        self.inner.get_value(key).await
+    }
+
+    async fn set_value(
+        &self,
+        _key: &str,
+        _value: Vec<u8>,
+        _ttl: Option<Duration>,
+        _mode: CacheSetMode,
+    ) -> CacheResult<bool> {
+        Err(CacheError::Backend(
+            "injected overlay write failure".to_string(),
+        ))
+    }
+
+    async fn delete(&self, key: &str) -> CacheResult<bool> {
+        self.inner.delete(key).await
+    }
+
+    async fn expire(&self, key: &str, ttl: Duration) -> CacheResult<bool> {
+        self.inner.expire(key, ttl).await
+    }
+
+    async fn ttl(&self, key: &str) -> CacheResult<CacheTtl> {
+        self.inner.ttl(key).await
+    }
+
+    async fn hash_get(&self, key: &str, field: &str) -> CacheResult<Option<Vec<u8>>> {
+        self.inner.hash_get(key, field).await
+    }
+
+    async fn hash_get_all(&self, key: &str) -> CacheResult<BTreeMap<String, Vec<u8>>> {
+        self.inner.hash_get_all(key).await
+    }
+
+    async fn hash_set(&self, key: &str, field: &str, value: Vec<u8>) -> CacheResult<()> {
+        self.inner.hash_set(key, field, value).await
+    }
+
+    async fn hash_set_many(&self, key: &str, fields: BTreeMap<String, Vec<u8>>) -> CacheResult<()> {
+        self.inner.hash_set_many(key, fields).await
+    }
+
+    async fn hash_delete(&self, key: &str, field: &str) -> CacheResult<bool> {
+        self.inner.hash_delete(key, field).await
+    }
+}
+
+fn repo_failing_cache() -> SqlChatRunRepo {
+    let db = Arc::new(LocalSqliteDbPlugin::new().expect("sqlite db"));
+    let cache: Arc<dyn CachePlugin> = Arc::new(FailingWritesCache::new());
+    SqlChatRunRepo::new(
+        db,
+        DbSqlFlavor::Sqlite,
+        cache,
+        "bcs:".to_string(),
+        120_000,
+        "test".to_string(),
+    )
 }
 
 fn record(run_id: &str, version: u64) -> ChatRunRecord {
@@ -104,6 +187,77 @@ async fn streaming_append_advances_cache_ahead_of_db() {
             .await
             .unwrap()
     );
+}
+
+#[tokio::test]
+async fn streaming_append_falls_back_to_db_when_overlay_write_fails() {
+    // C4: when Redis rejects the overlay write, `append_streaming_content` must
+    // fail the delta over to the authoritative DB row instead of silently
+    // returning Ok(true) and dropping it. #1546 forbids a swallowed backend
+    // write masquerading as success.
+    let repo = repo_failing_cache();
+    repo.create(record("a", 1)).await.unwrap();
+
+    // Overlay write is rejected (injected Redis outage), yet the append still
+    // reports Ok(true) and lands the content in the DB.
+    assert!(
+        repo.append_streaming_content("a", 1, "hello".to_string(), false)
+            .await
+            .unwrap()
+    );
+    // The overlay held nothing (its write was rejected), so the merged read now
+    // falls back to the DB row — which must carry the delta and the bumped
+    // version, proving the fail-over wrote through.
+    let stored = repo.get("a").await.unwrap().unwrap();
+    assert_eq!(stored.accumulated_content, "hello");
+    assert_eq!(stored.version, 2);
+    assert!(!stored.content_truncated);
+
+    // A second delta keeps accumulating in the DB while the overlay keeps
+    // rejecting — recovery picks up the DB advance as the base.
+    assert!(
+        repo.append_streaming_content("a", 2, "hello world".to_string(), true)
+            .await
+            .unwrap()
+    );
+    let stored = repo.get("a").await.unwrap().unwrap();
+    assert_eq!(stored.accumulated_content, "hello world");
+    assert_eq!(stored.version, 3);
+    assert!(stored.content_truncated);
+}
+
+#[tokio::test]
+async fn streaming_append_fallover_noop_when_run_already_terminal() {
+    // C4 fail-over UPDATE is gated on the non-terminal state guard. If the run
+    // became terminal concurrently the UPDATE affects 0 rows and the append
+    // reports Ok(false) (delta not applied) instead of rewriting the audited
+    // terminal row.
+    let repo = repo_failing_cache();
+    repo.create(record("t", 1)).await.unwrap();
+
+    let mut failed = record("t", 1);
+    failed.state = ChatRunState::Failed;
+    failed.completed_at_ms = Some(0);
+    failed.accumulated_content = "final".to_string();
+    repo.compare_and_set_terminal("t", 1, failed)
+        .await
+        .unwrap();
+
+    // The terminal CAS left the DB row at version 2; passing expected version 2
+    // gets past the overlay/version check and reaches the fail-over UPDATE,
+    // which the terminal guard rejects (0 rows affected).
+    assert!(
+        !repo
+            .append_streaming_content("t", 2, "late".to_string(), false)
+            .await
+            .unwrap()
+    );
+
+    // The audited terminal content is untouched.
+    let stored = repo.get("t").await.unwrap().unwrap();
+    assert_eq!(stored.state, ChatRunState::Failed);
+    assert_eq!(stored.accumulated_content, "final");
+    assert_eq!(stored.version, 2);
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
@@ -365,6 +365,7 @@ async fn streaming_append_failover_ignores_stale_overlay_and_rebases_on_db() {
         "state": "running",
         "accumulated_content": "ABCDE",
         "content_truncated": false,
+        "expires_at_ms": 9_000_000_000_000u64,
     }))
     .unwrap();
     cache.seed("bcs:chat_run:a", stale).await;


### PR DESCRIPTION
## Summary

Closes the **C4** item of #1627 — the `#1576` review follow-up to #1546 (Direct Chat run governance). When the Redis streaming-overlay write is rejected, `append_streaming_content` now falls back to writing the delta directly to the authoritative MySQL row instead of silently returning `Ok(true)` and dropping it.

**No engine or trait change.** C9 and C6 from the same follow-up are intentionally **not** in this PR (still tracked under #1627).

## Problem

`append_streaming_content` stored each streaming delta *only* in the Redis overlay (`{version, accumulated_content, content_truncated}`) — there is no per-delta DB write. `write_overlay` discarded the `set_value` result with `let _ =`, so when Redis rejected the overlay write the method still returned `Ok(true)`. The engine acked the delta, but the later terminal record built from the merged `get()` (DB + overlay) was missing the dropped delta — permanently missing from the audited terminal content. That is exactly the "persistence failure → successful-but-wrong API response" #1546 forbids.

## Changes

**`crates/services/bcs-chat-run-store/src/sql.rs`**
- `write_overlay` now returns `Result<(), CacheError>`: `Ok(true)` → `Ok(())`; `Ok(false)` (an upsert that did not store) and `Err` → `Err`, so callers that rely on the overlay as the sole delta record can detect the failure.
- New `fall_back_to_db_append`: on overlay-write failure, `append_streaming_content` writes the accumulated content straight to MySQL with `version = version + 1` under the non-terminal guard:
  ```sql
  UPDATE bcs_chat_runs
     SET accumulated_content = ?, content_truncated = ?, version = version + 1, updated_at_ms = ?
   WHERE run_id = ? AND state NOT IN ('completed','failed','cancelled') AND env = ?
  ```
  - affected_rows > 0 → `Ok(true)` (delta preserved in the auditable row)
  - 0 rows (run went terminal concurrently) → `Ok(false)` (delta not applied)
  - DB error → `Err(ChatRunRepoError::Backend(...))` (propagated — the opposite of swallowing)
- `create` and `compare_and_set_state` overlay writes switch to best-effort `let _ =` (behavior unchanged): the DB row is authoritative there, so an overlay blip just means the next read falls back to the DB. The DB-write cost of fail-over only materializes during a Redis outage.

**`crates/services/bcs-chat-run-store/Cargo.toml`** — dev-deps `async-trait` and `bcs-cache-api` (needed by the fault-injecting cache test double).

**`crates/services/bcs-chat-run-store/tests/sql_repo.rs`** — `FailingWritesCache` double (reads pass through; `set_value` always `Err`) + `repo_failing_cache()`, and two tests:
- `streaming_append_falls_back_to_db_when_overlay_write_fails` — overlay rejection still lands the delta in the DB and returns `Ok(true)`; a second delta keeps accumulating in the DB.
- `streaming_append_fallover_noop_when_run_already_terminal` — a concurrently terminal run makes the fail-over UPDATE affect 0 rows → `Ok(false)`, leaving the audited terminal content untouched.

## Verification

```
cargo test -p bcs-chat-run-store   # memory 9 + sql 11 (incl. 2 new) — all pass
cargo test -p bcs-message-flow     # all green (run_store_engine append paths intact)
cargo check -p bcs                  # passes
```

## Out of scope

- **C9** (`ChatRunStore.get` mapping `Backend` → 500/retryable instead of 404) and **C6** (`RedisBotRunContextStore` as memory-primary + Redis-mirror) remain pending in #1627.
- Residual by design: deltas already acked into a healthy overlay that later becomes *unreadable* (Redis fully down for reads) can be lost when the engine recomputes from a stale DB base. That is the inherent limitation of "streaming lives only in the Redis overlay" (spec §4.2); C4 fixes write-rejection-while-the-engine-sees-correct-content, not overlay durability.

Refs #1627 (#1546 follow-up; #1576 review item C4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)