### PR TITLE
feat(backend): resolve exact published skill versions

### DIFF
--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -552,6 +552,25 @@ Grants、Versions、Publication 历史、文件树或升级/退役影响列表�
 
 URL 中 `{version}` 是业务序号 `1/2/3`，不是 `ac_skill_version.id`。Published Version 不可修改、删除或单独下线。Git 刷新失败时 Draft 完全不变。
 
+所有回答“Bot 当前真正能使用哪些 Skill”的消费者必须经
+`BotCapabilityStateReader.active_skill_assets()` 读取。Reader 在 Installation flush 和
+`Installation JOIN ac_skill` 后，通过唯一 `SkillVersionResolver` 补齐 Center 资产的精确版本：
+
+```text
+Local / Repo → 保持 ac_skill 内容，不查询 Version
+Center       → 单次批量查询各 skill_id 的最高 version_ordinal PUBLISHED Version
+             → 返回 exact sc_version_number 与版本级 mcp_dependencies
+```
+
+禁止使用 `ac_skill.version/status`、SC latest/current、字符串版本排序或 MATERIALIZING Version。
+Center 缺 `skill_uuid`、PUBLISHED Version、`sc_version_number` 或合法 dependency metadata 时，
+整批 Runtime 解析 fail closed；不能跳过后投影半套运行时。一次 Runtime projection 只能消费
+Reader/Resolver 返回的同一份不可变 assets tuple，避免 Skill mapping 与 MCP dependency 跨版本。
+
+Space 发布产生的 `ac_skill_version.publication_attempt_id` 非空；SC Public 懒物化没有
+TeamClaw Publication Attempt，因此该列必须允许 NULL，不能伪造 Attempt。Published Service
+历史实例不解析 latest，只读取冻结 Artifact 中的 exact Version。
+
 #### 10.3 Owner、Manager、编辑权申请与放弃 Draft
 
 | Method | Path | 语义 |

--- a/src/backend/src/agentclaw/community/core/models/space_skill.py
+++ b/src/backend/src/agentclaw/community/core/models/space_skill.py
@@ -166,7 +166,10 @@ class SkillVersion(_ScopedDomainFact, Base):
 
     id = Column(AutoIncrementBigInteger, primary_key=True, autoincrement=True)
     skill_id = Column(UnsignedBigInteger, nullable=False)
-    publication_attempt_id = Column(UnsignedBigInteger, nullable=False)
+    # Space publication Versions reference an Attempt. SC Public lazy
+    # materialization has no TeamClaw publication command, so it must remain
+    # NULL rather than fabricating an Attempt.
+    publication_attempt_id = Column(UnsignedBigInteger, nullable=True)
     version_ordinal = Column(UnsignedInteger, nullable=False)
     status = Column(String(24), nullable=False)
     sc_version_number = Column(String(128), nullable=False)

--- a/src/backend/src/agentclaw/community/core/repository/README.md
+++ b/src/backend/src/agentclaw/community/core/repository/README.md
@@ -154,6 +154,7 @@ provides:
   - SpaceSkillRepository
   - SkillEditorRequestRepository
   - DraftEditLeaseRepository
+  - SkillVersionRepositoryProtocol
   - SkillSetRepository
   # skills_pool
   - QuarantineRepositoryProtocol
@@ -199,6 +200,7 @@ provides:
   - OrmPublishOperationRepository
   # skill_center
   - SpaceSkillRepository
+  - SkillVersionRepository
   # skills_pool
   - SkillsPoolLayoutRepository
   - SkillsPoolRolloutRepository

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
@@ -1,0 +1,102 @@
+"""ORM reads for immutable, consumable Skill Versions."""
+
+from __future__ import annotations
+
+from injector import inject
+from sqlalchemy import and_, func
+
+from agentclaw.community.core.models.space_skill import SkillVersion
+from agentclaw.community.core.repository.protocols.skill_center import (
+    SkillVersionRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.skill_center_types import (
+    SkillVersionRecord,
+)
+from agentclaw.community.plugin_api.database import DatabasePlugin
+
+
+class SkillVersionRepository(SkillVersionRepositoryProtocol):
+    """Tenant-guarded, env-scoped reads from ``ac_skill_version``."""
+
+    @inject
+    def __init__(self, db: DatabasePlugin) -> None:
+        self._db = db
+
+    def list_latest_published(
+        self, *, env: str, skill_ids: tuple[int, ...]
+    ) -> tuple[SkillVersionRecord, ...]:
+        if not skill_ids:
+            return ()
+        ordered_ids = tuple(dict.fromkeys(skill_ids))
+        with self._db.orm_session() as session:
+            latest = (
+                session.query(
+                    SkillVersion.skill_id.label("skill_id"),
+                    func.max(SkillVersion.version_ordinal).label("version_ordinal"),
+                )
+                .filter(
+                    SkillVersion.env == env,
+                    SkillVersion.status == "PUBLISHED",
+                    SkillVersion.skill_id.in_(ordered_ids),
+                )
+                .group_by(SkillVersion.skill_id)
+                .subquery()
+            )
+            rows = (
+                session.query(SkillVersion)
+                .join(
+                    latest,
+                    and_(
+                        latest.c.skill_id == SkillVersion.skill_id,
+                        latest.c.version_ordinal == SkillVersion.version_ordinal,
+                    ),
+                )
+                .filter(
+                    SkillVersion.env == env,
+                    SkillVersion.status == "PUBLISHED",
+                )
+                .all()
+            )
+            by_skill_id = {int(row.skill_id): self._record(row) for row in rows}
+            return tuple(
+                by_skill_id[skill_id]
+                for skill_id in ordered_ids
+                if skill_id in by_skill_id
+            )
+
+    def get_exact_published(
+        self, *, env: str, skill_id: int, skill_version_id: int
+    ) -> SkillVersionRecord | None:
+        with self._db.orm_session() as session:
+            row = (
+                session.query(SkillVersion)
+                .filter(
+                    SkillVersion.id == skill_version_id,
+                    SkillVersion.skill_id == skill_id,
+                    SkillVersion.env == env,
+                    SkillVersion.status == "PUBLISHED",
+                )
+                .one_or_none()
+            )
+            return self._record(row) if row is not None else None
+
+    @staticmethod
+    def _record(row: SkillVersion) -> SkillVersionRecord:
+        return SkillVersionRecord(
+            id=int(row.id),
+            skill_id=int(row.skill_id),
+            version_ordinal=int(row.version_ordinal),
+            status=row.status,
+            sc_version_number=row.sc_version_number,
+            sc_skill_id=int(row.sc_skill_id) if row.sc_skill_id is not None else None,
+            sc_version_id=(
+                int(row.sc_version_id) if row.sc_version_id is not None else None
+            ),
+            name=row.name,
+            description=row.description,
+            metadata_json=row.metadata_json,
+            published_at=row.published_at,
+        )
+
+
+__all__ = ["SkillVersionRepository"]

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
@@ -30,6 +30,7 @@ from .skill_center_types import (
     SpaceSkillGrantItem,
     SpaceSkillGrantSetRecord,
     DraftEditLeaseRecord,
+    SkillVersionRecord,
 )
 
 
@@ -191,6 +192,25 @@ class DraftEditLeaseRepository(Protocol):
     def takeover(
         self, *, space_id: int, skill_id: int, actor_id: str, env: str
     ) -> DraftEditLeaseRecord: ...
+
+
+@runtime_checkable
+class SkillVersionRepositoryProtocol(Protocol):
+    """Read-only persistence seam for immutable published Skill Versions."""
+
+    @abstractmethod
+    def list_latest_published(
+        self, *, env: str, skill_ids: tuple[int, ...]
+    ) -> tuple[SkillVersionRecord, ...]:
+        """Return at most one highest-ordinal PUBLISHED row per Skill."""
+        ...
+
+    @abstractmethod
+    def get_exact_published(
+        self, *, env: str, skill_id: int, skill_version_id: int
+    ) -> SkillVersionRecord | None:
+        """Return the addressed PUBLISHED row, never MATERIALIZING."""
+        ...
 
 @runtime_checkable
 class SkillRepository(Protocol):

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center_types.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center_types.py
@@ -180,3 +180,19 @@ class DraftEditLeaseSummaryRecord(TypedDict):
     state: Literal["NOT_REQUIRED", "FREE", "HELD_BY_ME", "HELD_BY_OTHER"]
     holder_user_id: str | None
     holder_display_name: str | None
+
+
+class SkillVersionRecord(TypedDict):
+    """Persistence projection for one immutable Skill Version."""
+
+    id: int
+    skill_id: int
+    version_ordinal: int
+    status: Literal["MATERIALIZING", "PUBLISHED"]
+    sc_version_number: str
+    sc_skill_id: int | None
+    sc_version_id: int | None
+    name: str
+    description: str | None
+    metadata_json: str | None
+    published_at: datetime | None

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -27,6 +27,8 @@ provides:
   - "RuntimeProjectionResolver"
   - "resolve_effective_mcp_server_codes"
   - "BotCapabilityStateReader"
+  - "SkillVersionResolver"
+  - "SkillVersionResolverProtocol"
   - "BotRuntimeProjector"
   - "BotRuntimeProjectorProtocol"
   - "LocalSkillCleanupWorkModel"
@@ -68,6 +70,7 @@ consumes:
   - "SpaceSkillRepository"
   - "WorkOrderRepositoryProtocol"
   - "DraftEditLeaseRepository"
+  - "SkillVersionRepositoryProtocol"
 internal_dependencies:
   - agentclaw.community.api.skill_parameter_service_factory
   - agentclaw.community.api.skill_market_service

--- a/src/backend/src/agentclaw/community/core/skill_center/capability_state_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/capability_state_contract.py
@@ -16,10 +16,11 @@ if TYPE_CHECKING:
 class BotCapabilityStateReaderProtocol(Protocol):
     """The one read model for a Bot's active capabilities.
 
-    Installation is the single source of truth; the tables are not
+    Installation is the active-identity source of truth; the tables are not
     backfilled, so every read first flushes SkillSet configuration into
-    Installation, then answers from Installation alone. The flush is
-    DB-side only — the reader never triggers a runtime projection.
+    Installation, then answers from Installation alone. Center identities are
+    resolved to an exact PUBLISHED Version before they leave this seam. The
+    reader never triggers a runtime projection.
     """
 
     def member_skill_ids(self, *, bot: Mapping[str, Any]) -> frozenset[int]:
@@ -37,7 +38,7 @@ class BotCapabilityStateReaderProtocol(Protocol):
         owner_id: str,
         bot: Mapping[str, Any] | None = None,
     ) -> tuple[RegisteredSkillAsset, ...]:
-        """Flush, then read the Installation→``ac_skill`` join."""
+        """Flush, then return Runtime-ready assets with exact Center Versions."""
         ...
 
     def active_mcp_server_codes(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_capability_state_reader.py
@@ -22,16 +22,21 @@ from agentclaw.community.core.skill_center.bot_engine_scope import (
     bot_engine_type,
 )
 from agentclaw.community.core.skill_center.errors import LocalSkillNotFoundError
+from agentclaw.community.core.skill_center.version_resolution_contract import (
+    SkillVersionResolverProtocol,
+)
 from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
 
 
 class BotCapabilityStateReader:
     """The one read model for a Bot's active capabilities.
 
-    Installation is the single source of truth; the tables are not
+    Installation is the active-identity source of truth; the tables are not
     backfilled, so every read first flushes SkillSet configuration into
-    Installation, then answers from Installation alone. The flush is
-    DB-side only — this reader never triggers a runtime projection.
+    Installation, then answers from Installation alone. Center identities are
+    resolved to an exact PUBLISHED Version before they leave this seam. The
+    flush and Version resolution are DB-side only — this reader never triggers
+    a runtime projection.
     """
 
     @inject
@@ -40,10 +45,12 @@ class BotCapabilityStateReader:
         repository: CapabilityDesiredStateRepositoryProtocol,
         bot_repo: BotRepository,
         pool_skills: SkillsPoolSkillRepositoryProtocol,
+        version_resolver: SkillVersionResolverProtocol,
     ) -> None:
         self._repository = repository
         self._bot_repo = bot_repo
         self._pool_skills = pool_skills
+        self._version_resolver = version_resolver
 
     def member_skill_ids(self, *, bot: Mapping[str, Any]) -> frozenset[int]:
         plan = self._flush(
@@ -62,12 +69,15 @@ class BotCapabilityStateReader:
     ) -> tuple[RegisteredSkillAsset, ...]:
         bot = self._bot(bot_id=bot_id, owner_id=owner_id, bot=bot)
         self._flush(bot=bot, bot_id=bot_id, owner_id=owner_id)
-        return tuple(
+        assets = tuple(
             self._pool_skills.list_bot_installed_assets(
                 env=str(bot["env"]),
                 bot_id=bot_id,
                 owner_id=owner_id,
             )
+        )
+        return self._version_resolver.resolve_latest_runtime_assets(
+            env=str(bot["env"]), assets=assets
         )
 
     def active_mcp_server_codes(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_resolver.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_resolver.py
@@ -1,0 +1,154 @@
+"""Resolve Center assets to exact immutable PUBLISHED Versions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
+import json
+
+from injector import inject
+
+from agentclaw.community.core.repository.protocols.skill_center import (
+    SkillVersionRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.skill_center_types import (
+    SkillVersionRecord,
+)
+from agentclaw.community.core.skill_center.mcp_dependency_scope import (
+    mcp_dependency_codes,
+)
+from agentclaw.community.core.skill_center.version_resolution_contract import (
+    PublishedSkillVersion,
+    SkillVersionResolutionError,
+)
+from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+
+
+class SkillVersionResolver:
+    """Pure DB-read module: no SC, Store, Installation, or Runtime side effects."""
+
+    @inject
+    def __init__(self, versions: SkillVersionRepositoryProtocol) -> None:
+        self._versions = versions
+
+    def resolve_latest_runtime_assets(
+        self,
+        *,
+        env: str,
+        assets: Sequence[RegisteredSkillAsset],
+    ) -> tuple[RegisteredSkillAsset, ...]:
+        stable_assets = tuple(assets)
+        center_ids = tuple(
+            dict.fromkeys(
+                asset.skill_id
+                for asset in stable_assets
+                if asset.git_path.startswith("center://")
+            )
+        )
+        if not center_ids:
+            return stable_assets
+        rows = self._versions.list_latest_published(env=env, skill_ids=center_ids)
+        versions_by_skill_id = {int(row["skill_id"]): row for row in rows}
+        if len(versions_by_skill_id) != len(center_ids):
+            raise SkillVersionResolutionError("Center Skill has no PUBLISHED Version")
+
+        resolved: list[RegisteredSkillAsset] = []
+        for asset in stable_assets:
+            if not asset.git_path.startswith("center://"):
+                resolved.append(asset)
+                continue
+            if not isinstance(asset.skill_uuid, str) or not asset.skill_uuid:
+                raise SkillVersionResolutionError(
+                    "Center Skill has no stable skill_uuid"
+                )
+            version = self._published(versions_by_skill_id[asset.skill_id])
+            resolved.append(
+                replace(
+                    asset,
+                    sc_version_number=version.sc_version_number,
+                    mcp_dependencies=version.mcp_dependencies,
+                )
+            )
+        return tuple(resolved)
+
+    def resolve_exact_published(
+        self,
+        *,
+        env: str,
+        skill_id: int,
+        skill_version_id: int,
+    ) -> PublishedSkillVersion:
+        row = self._versions.get_exact_published(
+            env=env,
+            skill_id=skill_id,
+            skill_version_id=skill_version_id,
+        )
+        if row is None:
+            raise SkillVersionResolutionError(
+                "Addressed Skill Version is not PUBLISHED"
+            )
+        return self._published(row)
+
+    @staticmethod
+    def _published(row: SkillVersionRecord) -> PublishedSkillVersion:
+        number = row["sc_version_number"]
+        if not isinstance(number, str) or not number:
+            raise SkillVersionResolutionError(
+                "PUBLISHED Skill Version has no SC version number"
+            )
+        metadata = SkillVersionResolver._metadata(row["metadata_json"])
+        if "mcp_dependencies" not in metadata:
+            raise SkillVersionResolutionError(
+                "Skill Version has no materialized MCP dependency metadata"
+            )
+        dependencies = metadata["mcp_dependencies"]
+        if not isinstance(dependencies, list):
+            raise SkillVersionResolutionError(
+                "Skill Version MCP dependencies must be a list"
+            )
+        try:
+            dependency_codes = mcp_dependency_codes(dependencies)
+        except ValueError as exc:
+            raise SkillVersionResolutionError(
+                "Skill Version has invalid MCP dependencies"
+            ) from exc
+        if any(not code for code in dependency_codes):
+            raise SkillVersionResolutionError(
+                "Skill Version has an empty MCP dependency code"
+            )
+        name = row["name"]
+        if not isinstance(name, str) or not name:
+            raise SkillVersionResolutionError("Skill Version has no name")
+        return PublishedSkillVersion(
+            skill_version_id=int(row["id"]),
+            skill_id=int(row["skill_id"]),
+            version_ordinal=int(row["version_ordinal"]),
+            sc_version_number=number,
+            sc_skill_id=row["sc_skill_id"],
+            sc_version_id=row["sc_version_id"],
+            name=name,
+            description=row["description"],
+            mcp_dependencies=tuple(dependencies),
+            published_at=row["published_at"],
+        )
+
+    @staticmethod
+    def _metadata(raw: str | None) -> Mapping[str, object]:
+        if raw is None:
+            raise SkillVersionResolutionError(
+                "PUBLISHED Skill Version has no materialized metadata"
+            )
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise SkillVersionResolutionError(
+                "Skill Version metadata is not valid JSON"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise SkillVersionResolutionError(
+                "Skill Version metadata must be an object"
+            )
+        return parsed
+
+
+__all__ = ["SkillVersionResolver"]

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_19_additive_space_skill_schema.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_19_additive_space_skill_schema.sql
@@ -88,7 +88,7 @@ CREATE TABLE IF NOT EXISTS ac_skill_draft_edit_lease (
 CREATE TABLE IF NOT EXISTS ac_skill_version (
   id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
   skill_id BIGINT UNSIGNED NOT NULL,
-  publication_attempt_id BIGINT UNSIGNED NOT NULL,
+  publication_attempt_id BIGINT UNSIGNED NULL,
   version_ordinal INT UNSIGNED NOT NULL,
   status VARCHAR(24) NOT NULL COMMENT 'MATERIALIZING/PUBLISHED',
   sc_version_number VARCHAR(128) NOT NULL,

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_19_additive_space_skill_schema_verify.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_19_additive_space_skill_schema_verify.sql
@@ -42,3 +42,8 @@ SELECT table_name, column_name, is_nullable
    AND table_name IN ('ac_space', 'ac_space_member', 'ac_skill_space_binding',
                       'ac_skill_grant', 'ac_skill_draft_edit_lease',
                       'ac_skill_version', 'ac_skill_publication_attempt');
+SELECT table_name, column_name, is_nullable
+  FROM information_schema.columns
+ WHERE table_schema = DATABASE()
+   AND table_name = 'ac_skill_version'
+   AND column_name = 'publication_attempt_id';

--- a/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_30_nullable_skill_version_attempt.sql
+++ b/src/backend/src/agentclaw/community/core/skill_center/sql/2026_08_30_nullable_skill_version_attempt.sql
@@ -1,0 +1,6 @@
+-- SC Public lazy materialization creates a TeamClaw Skill Version without a
+-- TeamClaw Publication Attempt.  MySQL/OceanBase unique indexes allow multiple
+-- NULL values, so uk_version_attempt continues to enforce one Version per
+-- non-null Space Publication Attempt while public-market Versions remain valid.
+ALTER TABLE ac_skill_version
+  MODIFY COLUMN publication_attempt_id BIGINT UNSIGNED NULL;

--- a/src/backend/src/agentclaw/community/core/skill_center/version_resolution_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/version_resolution_contract.py
@@ -1,0 +1,57 @@
+"""Contract and immutable values for exact Skill Version resolution."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+
+
+class SkillVersionResolutionError(ValueError):
+    """A Center asset has no complete, consumable PUBLISHED Version."""
+
+
+@dataclass(frozen=True, slots=True)
+class PublishedSkillVersion:
+    """Exact immutable version metadata used outside latest resolution."""
+
+    skill_version_id: int
+    skill_id: int
+    version_ordinal: int
+    sc_version_number: str
+    sc_skill_id: int | None
+    sc_version_id: int | None
+    name: str
+    description: str | None
+    mcp_dependencies: tuple[object, ...]
+    published_at: datetime | None
+
+
+@runtime_checkable
+class SkillVersionResolverProtocol(Protocol):
+    """Resolve latest or exact PUBLISHED Versions without side effects."""
+
+    def resolve_latest_runtime_assets(
+        self,
+        *,
+        env: str,
+        assets: Sequence[RegisteredSkillAsset],
+    ) -> tuple[RegisteredSkillAsset, ...]: ...
+
+    def resolve_exact_published(
+        self,
+        *,
+        env: str,
+        skill_id: int,
+        skill_version_id: int,
+    ) -> PublishedSkillVersion: ...
+
+
+__all__ = [
+    "PublishedSkillVersion",
+    "SkillVersionResolutionError",
+    "SkillVersionResolverProtocol",
+]

--- a/src/backend/src/agentclaw/community/di/container.py
+++ b/src/backend/src/agentclaw/community/di/container.py
@@ -49,16 +49,15 @@ from agentclaw.community.di.modules.resources_module import ResourcesModule
 from agentclaw.community.di.modules.service_bot_module import ServiceBotModule
 from agentclaw.community.di.modules.session_resources_module import SessionResourcesModule
 from agentclaw.community.di.modules.skill_center_module import SkillCenterModule
+from agentclaw.community.di.modules.skill_version_module import SkillVersionModule
 from agentclaw.community.di.modules.skills_pool_module import SkillsPoolModule
 from agentclaw.community.di.modules.spaces_module import SpacesModule
 from agentclaw.community.di.modules.system_config_module import SystemConfigModule
 from agentclaw.community.di.modules.task_discovery_module import TaskDiscoveryModule
-from agentclaw.community.di.modules.task_module import TaskModule
 from agentclaw.community.di.modules.task_persistence_module import TaskPersistenceModule
 from agentclaw.community.di.modules.task_queue_module import TaskQueueModule
 from agentclaw.community.di.modules.user_list_module import UserListModule
 from agentclaw.community.di.modules.work_orders_module import WorkOrdersModule
-from agentclaw.community.di.modules.task_discovery_module import TaskDiscoveryModule
 from agentclaw.community.di.profile import DeployProfile
 from agentclaw.community.di.profile_modules import modules_for
 from agentclaw.community.log import get_logger
@@ -105,6 +104,7 @@ def build_injector(
     modules: list[Module] = [
         ConfigModule(),
         SkillCenterModule(),
+        SkillVersionModule(),
         ServiceBotModule(),
         DesktopBotModule(),
         SystemConfigModule(),

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -67,9 +67,6 @@ from agentclaw.community.core.repository.implementations.skill_center.capability
 from agentclaw.community.core.repository.implementations.skill_center.space_skill import (
     SpaceSkillRepository as UnifiedSpaceSkillRepository,
 )
-from agentclaw.community.core.repository.implementations.skill_center.skill_version import (
-    SkillVersionRepository,
-)
 from agentclaw.community.core.repository.implementations.skill_center.skill_editor_request import (
     SkillEditorRequestRepository,
 )
@@ -83,7 +80,6 @@ from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.repository.protocols.skill_center import (
     SkillEditorRequestRepositoryProtocol,
     SkillCategoryRepository,
-    SkillVersionRepositoryProtocol,
 )
 from agentclaw.community.core.repository.protocols.skill_center import (
     SkillCenterSyncLogRepository,
@@ -136,12 +132,6 @@ from agentclaw.community.core.skill_center.policies.platform_default_mcp import 
 )
 from agentclaw.community.core.skill_center.services.bot_capability_state_reader import (
     BotCapabilityStateReader,
-)
-from agentclaw.community.core.skill_center.services.skill_version_resolver import (
-    SkillVersionResolver,
-)
-from agentclaw.community.core.skill_center.version_resolution_contract import (
-    SkillVersionResolverProtocol,
 )
 from agentclaw.community.core.skill_center.services.bot_runtime_projector import (
     BotRuntimeProjector,
@@ -339,16 +329,6 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
         binder.bind(
             CapabilityDesiredStateRepositoryProtocol,
             to=CapabilityDesiredStateRepository,
-            scope=singleton,
-        )
-        binder.bind(
-            SkillVersionRepositoryProtocol,
-            to=SkillVersionRepository,
-            scope=singleton,
-        )
-        binder.bind(
-            SkillVersionResolverProtocol,
-            to=SkillVersionResolver,
             scope=singleton,
         )
         binder.bind(

--- a/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_center_module.py
@@ -67,6 +67,9 @@ from agentclaw.community.core.repository.implementations.skill_center.capability
 from agentclaw.community.core.repository.implementations.skill_center.space_skill import (
     SpaceSkillRepository as UnifiedSpaceSkillRepository,
 )
+from agentclaw.community.core.repository.implementations.skill_center.skill_version import (
+    SkillVersionRepository,
+)
 from agentclaw.community.core.repository.implementations.skill_center.skill_editor_request import (
     SkillEditorRequestRepository,
 )
@@ -80,6 +83,7 @@ from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.repository.protocols.skill_center import (
     SkillEditorRequestRepositoryProtocol,
     SkillCategoryRepository,
+    SkillVersionRepositoryProtocol,
 )
 from agentclaw.community.core.repository.protocols.skill_center import (
     SkillCenterSyncLogRepository,
@@ -132,6 +136,12 @@ from agentclaw.community.core.skill_center.policies.platform_default_mcp import 
 )
 from agentclaw.community.core.skill_center.services.bot_capability_state_reader import (
     BotCapabilityStateReader,
+)
+from agentclaw.community.core.skill_center.services.skill_version_resolver import (
+    SkillVersionResolver,
+)
+from agentclaw.community.core.skill_center.version_resolution_contract import (
+    SkillVersionResolverProtocol,
 )
 from agentclaw.community.core.skill_center.services.bot_runtime_projector import (
     BotRuntimeProjector,
@@ -329,6 +339,16 @@ class SkillCenterModule(SkillCenterProtocolBindings, Module):
         binder.bind(
             CapabilityDesiredStateRepositoryProtocol,
             to=CapabilityDesiredStateRepository,
+            scope=singleton,
+        )
+        binder.bind(
+            SkillVersionRepositoryProtocol,
+            to=SkillVersionRepository,
+            scope=singleton,
+        )
+        binder.bind(
+            SkillVersionResolverProtocol,
+            to=SkillVersionResolver,
             scope=singleton,
         )
         binder.bind(

--- a/src/backend/src/agentclaw/community/di/modules/skill_version_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/skill_version_module.py
@@ -1,0 +1,32 @@
+"""Composition-root bindings for exact published Skill version resolution."""
+
+from injector import Binder, Module, singleton
+
+from agentclaw.community.core.repository.implementations.skill_center.skill_version import (
+    SkillVersionRepository,
+)
+from agentclaw.community.core.repository.protocols.skill_center import (
+    SkillVersionRepositoryProtocol,
+)
+from agentclaw.community.core.skill_center.services.skill_version_resolver import (
+    SkillVersionResolver,
+)
+from agentclaw.community.core.skill_center.version_resolution_contract import (
+    SkillVersionResolverProtocol,
+)
+
+
+class SkillVersionModule(Module):
+    """Wire the Version Resolution repository and Service API implementation."""
+
+    def configure(self, binder: Binder) -> None:
+        binder.bind(
+            SkillVersionRepositoryProtocol,
+            to=SkillVersionRepository,
+            scope=singleton,
+        )
+        binder.bind(
+            SkillVersionResolverProtocol,
+            to=SkillVersionResolver,
+            scope=singleton,
+        )

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_skills_endpoints.py
@@ -14,6 +14,7 @@ from fastapi_injector import attach_injector
 from injector import Injector, Module
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from tests.community.skill_version_fakes import PassthroughSkillVersionResolver
 
 from agentclaw.community.adapters.http.middleware import AvernetTenantMiddleware
 from agentclaw.community.adapters.http.openapi_v1.contracts import EXAMPLE_TRACE_ID
@@ -626,7 +627,10 @@ def _real_query_service(db, bots, skills) -> SkillQueryService:
     parameters is read, so nothing ever calls them.
     """
     reader = BotCapabilityStateReader(
-        CapabilityDesiredStateRepository(db), bots, skills
+        CapabilityDesiredStateRepository(db),
+        bots,
+        skills,
+        PassthroughSkillVersionResolver(),
     )
     return SkillQueryService(
         skills, bots, object(), reader, object(), object(), lambda: object()

--- a/src/backend/tests/community/core/skill_center/services/test_collect_bot_active_mcps_union.py
+++ b/src/backend/tests/community/core/skill_center/services/test_collect_bot_active_mcps_union.py
@@ -26,6 +26,7 @@ from agentclaw.community.core.skill_center.services.bot_capability_state_reader 
 from agentclaw.community.core.skill_center.services.skill_set_service import (
     SkillSetService,
 )
+from tests.community.skill_version_fakes import PassthroughSkillVersionResolver
 
 pytestmark = pytest.mark.unit
 
@@ -89,6 +90,7 @@ def _service(db: _Database, tmp_path, *, ext_info_provider=None) -> SkillSetServ
             repository=CapabilityDesiredStateRepository(db),
             bot_repo=_Bots(),
             pool_skills=skills,
+            version_resolver=PassthroughSkillVersionResolver(),
         ),
     )
 

--- a/src/backend/tests/community/core/skill_center/test_bot_capability_state_reader.py
+++ b/src/backend/tests/community/core/skill_center/test_bot_capability_state_reader.py
@@ -74,19 +74,36 @@ class _PoolSkills:
         ]
 
 
+class _Versions:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def resolve_latest_runtime_assets(self, **kwargs):
+        self.calls.append(kwargs)
+        return tuple(kwargs["assets"])
+
+    def resolve_exact_published(self, **kwargs):  # pragma: no cover - not used here
+        raise AssertionError(kwargs)
+
+
 def _reader(
     *, bots: _Bots | None = None
-) -> tuple[BotCapabilityStateReader, _Repository, _PoolSkills, _Bots]:
+) -> tuple[BotCapabilityStateReader, _Repository, _PoolSkills, _Bots, _Versions]:
     repository = _Repository()
     pool_skills = _PoolSkills().bind(repository)
+    versions = _Versions()
     bots = bots if bots is not None else _Bots()
     return (
         BotCapabilityStateReader(
-            repository=repository, bot_repo=bots, pool_skills=pool_skills
+            repository=repository,
+            bot_repo=bots,
+            pool_skills=pool_skills,
+            version_resolver=versions,
         ),
         repository,
         pool_skills,
         bots,
+        versions,
     )
 
 
@@ -100,12 +117,12 @@ _EXPECTED_FLUSH = {
 
 
 def test_the_implementation_satisfies_the_public_protocol():
-    reader, _repository, _pool, _bots = _reader()
+    reader, _repository, _pool, _bots, _versions = _reader()
     assert isinstance(reader, BotCapabilityStateReaderProtocol)
 
 
 def test_skill_read_flushes_then_answers_from_the_installation_join():
-    reader, repository, pool_skills, bots = _reader()
+    reader, repository, pool_skills, bots, versions = _reader()
 
     assets = reader.active_skill_assets(bot_id="bot-1", owner_id="owner")
 
@@ -117,10 +134,18 @@ def test_skill_read_flushes_then_answers_from_the_installation_join():
         RegisteredSkillAsset(skill_id=1, name="qa", git_path="local://qa"),
     )
     assert bots.lookups == [("bot-1", "owner")]
+    assert versions.calls == [
+        {
+            "env": "pre",
+            "assets": (
+                RegisteredSkillAsset(skill_id=1, name="qa", git_path="local://qa"),
+            ),
+        }
+    ]
 
 
 def test_mcp_read_flushes_then_answers_from_installed_codes():
-    reader, repository, _pool, _bots = _reader()
+    reader, repository, _pool, _bots, _versions = _reader()
 
     codes = reader.active_mcp_server_codes(bot_id="bot-1", owner_id="owner")
 
@@ -130,7 +155,7 @@ def test_mcp_read_flushes_then_answers_from_installed_codes():
 
 
 def test_a_caller_supplied_bot_row_skips_the_lookup():
-    reader, repository, _pool, bots = _reader()
+    reader, repository, _pool, bots, _versions = _reader()
 
     reader.active_skill_assets(bot_id="bot-1", owner_id="owner", bot=_BOT)
 
@@ -139,7 +164,7 @@ def test_a_caller_supplied_bot_row_skips_the_lookup():
 
 
 def test_a_missing_bot_raises_before_any_flush():
-    reader, repository, _pool, _bots = _reader(bots=_Bots(bot=None))
+    reader, repository, _pool, _bots, _versions = _reader(bots=_Bots(bot=None))
 
     with pytest.raises(LocalSkillNotFoundError):
         reader.active_skill_assets(bot_id="bot-1", owner_id="owner")
@@ -149,7 +174,7 @@ def test_a_missing_bot_raises_before_any_flush():
 
 
 def test_member_skill_ids_flushes_and_answers_the_set_membership_half():
-    reader, repository, _pool, bots = _reader()
+    reader, repository, _pool, bots, _versions = _reader()
 
     ids = reader.member_skill_ids(bot=_BOT)
 

--- a/src/backend/tests/community/core/skill_center/test_skill_query_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_query_service.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from tests.community.skill_version_fakes import PassthroughSkillVersionResolver
 
 from agentclaw.community.core.models.mcp import (
     BotMCPInstallation,
@@ -113,7 +114,9 @@ def _listing_service(
     allowed: bool = True,
 ):
     skills, sets, bots = _Skills(), _SkillSets(bridge), _Bots(bot)
-    reader = BotCapabilityStateReader(sets, bots, object())
+    reader = BotCapabilityStateReader(
+        sets, bots, object(), PassthroughSkillVersionResolver()
+    )
     service = SkillQueryService(
         skills,
         bots,
@@ -528,7 +531,10 @@ def test_a_bridged_skill_is_active_in_detail_before_any_listing_ran(tmp_path):
         )
 
     reader = BotCapabilityStateReader(
-        CapabilityDesiredStateRepository(db), bots, skills
+        CapabilityDesiredStateRepository(db),
+        bots,
+        skills,
+        PassthroughSkillVersionResolver(),
     )
     service = SkillQueryService(
         skills, bots, object(), reader, object(), object(), lambda: object()

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -39,6 +39,7 @@ from agentclaw.community.core.skill_center.skill_set_batch import (
 from agentclaw.community.core.skill_center.services.bot_capability_state_reader import (
     BotCapabilityStateReader,
 )
+from tests.community.skill_version_fakes import PassthroughSkillVersionResolver
 from agentclaw.community.core.skill_center.services.bot_runtime_projector import (
     BotRuntimeProjector,
 )
@@ -742,6 +743,7 @@ def _reader(skills, repository=None, bots=None):
         repository=repository if repository is not None else _McpInstallations(),
         bot_repo=bots if bots is not None else _RuntimeBots(),
         pool_skills=skills,
+        version_resolver=PassthroughSkillVersionResolver(),
     )
 
 

--- a/src/backend/tests/community/core/skill_center/test_skill_version_resolver.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_version_resolver.py
@@ -1,0 +1,262 @@
+"""Exact published-version resolution for Runtime consumers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from agentclaw.community.core.skill_center.version_resolution_contract import (
+    PublishedSkillVersion,
+    SkillVersionResolutionError,
+)
+from agentclaw.community.core.skill_center.services.skill_version_resolver import (
+    SkillVersionResolver,
+)
+from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+
+
+def _version(
+    *,
+    skill_id: int,
+    version_id: int,
+    ordinal: int,
+    number: str,
+    metadata_json: str | None = '{"mcp_dependencies": []}',
+) -> dict[str, object]:
+    return {
+        "id": version_id,
+        "skill_id": skill_id,
+        "version_ordinal": ordinal,
+        "status": "PUBLISHED",
+        "sc_version_number": number,
+        "sc_skill_id": 1000 + skill_id,
+        "sc_version_id": 2000 + version_id,
+        "name": f"version-name-{skill_id}",
+        "description": f"version-description-{skill_id}",
+        "metadata_json": metadata_json,
+        "published_at": datetime(2026, 8, 30, tzinfo=UTC),
+    }
+
+
+class _Versions:
+    def __init__(self, rows: tuple[dict[str, object], ...] = ()) -> None:
+        self.rows = rows
+        self.latest_calls: list[dict[str, object]] = []
+        self.exact_calls: list[dict[str, object]] = []
+
+    def list_latest_published(
+        self, *, env: str, skill_ids: tuple[int, ...]
+    ) -> tuple[dict[str, object], ...]:
+        self.latest_calls.append({"env": env, "skill_ids": skill_ids})
+        selected = set(skill_ids)
+        return tuple(row for row in self.rows if int(row["skill_id"]) in selected)
+
+    def get_exact_published(
+        self, *, env: str, skill_id: int, skill_version_id: int
+    ) -> dict[str, object] | None:
+        self.exact_calls.append(
+            {
+                "env": env,
+                "skill_id": skill_id,
+                "skill_version_id": skill_version_id,
+            }
+        )
+        return next(
+            (
+                row
+                for row in self.rows
+                if int(row["skill_id"]) == skill_id
+                and int(row["id"]) == skill_version_id
+            ),
+            None,
+        )
+
+
+def test_local_and_repo_assets_do_not_query_versions() -> None:
+    versions = _Versions()
+    resolver = SkillVersionResolver(versions)
+    assets = (
+        RegisteredSkillAsset(skill_id=1, name="local", git_path="local://local"),
+        RegisteredSkillAsset(skill_id=2, name="repo", git_path="git://repo/path"),
+    )
+
+    assert resolver.resolve_latest_runtime_assets(env="pre", assets=assets) == assets
+    assert versions.latest_calls == []
+
+
+def test_center_assets_use_one_batch_and_preserve_input_order() -> None:
+    versions = _Versions(
+        (
+            _version(
+                skill_id=20,
+                version_id=202,
+                ordinal=2,
+                number="2.0.0",
+                metadata_json=(
+                    '{"mcp_dependencies": '
+                    '[{"code": "mcp.search", "name": "Search", "url": "x"}]}'
+                ),
+            ),
+            _version(skill_id=10, version_id=101, ordinal=1, number="1.0.0"),
+        )
+    )
+    resolver = SkillVersionResolver(versions)
+    local = RegisteredSkillAsset(skill_id=1, name="local", git_path="local://local")
+    center_v1 = RegisteredSkillAsset(
+        skill_id=10,
+        name="stable-runtime-name-1",
+        git_path="center://public-one",
+        skill_uuid="00000000-0000-4000-8000-000000000010",
+        sc_version_number="stale-value-must-be-replaced",
+    )
+    center_v2 = RegisteredSkillAsset(
+        skill_id=20,
+        name="stable-runtime-name-2",
+        git_path="center://public-two",
+        skill_uuid="00000000-0000-4000-8000-000000000020",
+    )
+
+    resolved = resolver.resolve_latest_runtime_assets(
+        env="pre", assets=(center_v1, local, center_v2)
+    )
+
+    assert versions.latest_calls == [{"env": "pre", "skill_ids": (10, 20)}]
+    assert [asset.skill_id for asset in resolved] == [10, 1, 20]
+    assert resolved[0].name == "stable-runtime-name-1"
+    assert resolved[0].sc_version_number == "1.0.0"
+    assert resolved[0].mcp_dependencies == ()
+    assert resolved[1] is local
+    assert resolved[2].sc_version_number == "2.0.0"
+    assert resolved[2].mcp_dependencies == (
+        {"code": "mcp.search", "name": "Search", "url": "x"},
+    )
+
+
+@pytest.mark.parametrize(
+    ("asset", "rows"),
+    [
+        (
+            RegisteredSkillAsset(
+                skill_id=10,
+                name="center",
+                git_path="center://public",
+                skill_uuid="00000000-0000-4000-8000-000000000010",
+            ),
+            (),
+        ),
+        (
+            RegisteredSkillAsset(
+                skill_id=10,
+                name="center",
+                git_path="center://public",
+                skill_uuid=None,
+            ),
+            (_version(skill_id=10, version_id=101, ordinal=1, number="1.0.0"),),
+        ),
+    ],
+)
+def test_center_asset_without_complete_published_identity_fails_closed(
+    asset: RegisteredSkillAsset, rows: tuple[dict[str, object], ...]
+) -> None:
+    resolver = SkillVersionResolver(_Versions(rows))
+
+    with pytest.raises(SkillVersionResolutionError):
+        resolver.resolve_latest_runtime_assets(env="pre", assets=(asset,))
+
+
+def test_invalid_version_dependency_metadata_fails_closed() -> None:
+    versions = _Versions(
+        (
+            _version(
+                skill_id=10,
+                version_id=101,
+                ordinal=1,
+                number="1.0.0",
+                metadata_json='{"mcp_dependencies": [{"unexpected": "shape"}]}',
+            ),
+        )
+    )
+    resolver = SkillVersionResolver(versions)
+
+    with pytest.raises(SkillVersionResolutionError):
+        resolver.resolve_latest_runtime_assets(
+            env="pre",
+            assets=(
+                RegisteredSkillAsset(
+                    skill_id=10,
+                    name="center",
+                    git_path="center://public",
+                    skill_uuid="00000000-0000-4000-8000-000000000010",
+                ),
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    "metadata_json",
+    [
+        None,
+        "{}",
+        '{"mcp_dependencies": [{"code": ""}]}',
+    ],
+)
+def test_published_version_requires_explicit_complete_dependency_metadata(
+    metadata_json: str | None,
+) -> None:
+    resolver = SkillVersionResolver(
+        _Versions(
+            (
+                _version(
+                    skill_id=10,
+                    version_id=101,
+                    ordinal=1,
+                    number="1.0.0",
+                    metadata_json=metadata_json,
+                ),
+            )
+        )
+    )
+
+    with pytest.raises(SkillVersionResolutionError):
+        resolver.resolve_latest_runtime_assets(
+            env="pre",
+            assets=(
+                RegisteredSkillAsset(
+                    skill_id=10,
+                    name="center",
+                    git_path="center://public",
+                    skill_uuid="00000000-0000-4000-8000-000000000010",
+                ),
+            ),
+        )
+
+
+def test_exact_resolution_requires_the_addressed_published_version() -> None:
+    versions = _Versions(
+        (_version(skill_id=10, version_id=101, ordinal=1, number="1.0.0"),)
+    )
+    resolver = SkillVersionResolver(versions)
+
+    resolved = resolver.resolve_exact_published(
+        env="pre", skill_id=10, skill_version_id=101
+    )
+
+    assert resolved == PublishedSkillVersion(
+        skill_version_id=101,
+        skill_id=10,
+        version_ordinal=1,
+        sc_version_number="1.0.0",
+        sc_skill_id=1010,
+        sc_version_id=2101,
+        name="version-name-10",
+        description="version-description-10",
+        mcp_dependencies=(),
+        published_at=datetime(2026, 8, 30, tzinfo=UTC),
+    )
+    assert versions.exact_calls == [
+        {"env": "pre", "skill_id": 10, "skill_version_id": 101}
+    ]
+
+    with pytest.raises(SkillVersionResolutionError):
+        resolver.resolve_exact_published(env="pre", skill_id=10, skill_version_id=999)

--- a/src/backend/tests/community/endpoints/test_openapi_skill_state.py
+++ b/src/backend/tests/community/endpoints/test_openapi_skill_state.py
@@ -38,6 +38,7 @@ from agentclaw.community.core.repository.protocols.skill_center import (
 )
 from agentclaw.community.core.repository.protocols.skill_center import SkillRepository
 from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
+from tests.community.skill_version_fakes import PassthroughSkillVersionResolver
 from agentclaw.community.utils.gateway_principal_config import (
     init_principal_verifier_config,
 )
@@ -187,6 +188,7 @@ def _seed_state(world, *, runtime_success: bool) -> None:
                 repository=world.get(CapabilityDesiredStateRepositoryProtocol),
                 bot_repo=world.get(BotRepository),
                 pool_skills=world.get(SkillRepository),
+                version_resolver=PassthroughSkillVersionResolver(),
             ),
             PlatformDefaultMcpPolicy(lambda _bot_id: None),
         ),

--- a/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
@@ -1,0 +1,250 @@
+"""Persistence contract for exact published Skill versions."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import UTC, datetime
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.core.base import Base
+from agentclaw.community.core.models.skill import BotSkillInstallation, Skill
+from agentclaw.community.core.models.space_skill import SkillVersion
+from agentclaw.community.core.repository.capability_desired_state_types import (
+    InstallationFlushPlan,
+)
+from agentclaw.community.core.repository.implementations.skill_center.skill import (
+    SkillRepository,
+)
+from agentclaw.community.core.repository.implementations.skill_center.skill_version import (
+    SkillVersionRepository,
+)
+from agentclaw.community.core.skill_center.services.bot_capability_state_reader import (
+    BotCapabilityStateReader,
+)
+from agentclaw.community.core.skill_center.services.skill_version_resolver import (
+    SkillVersionResolver,
+)
+from agentclaw.community.utils.avernet_tenant import avernet_tenant_scope
+
+
+class _Database:
+    def __init__(self) -> None:
+        self.engine = create_engine("sqlite://")
+        Base.metadata.create_all(self.engine)
+        self._factory = sessionmaker(bind=self.engine)
+
+    @contextmanager
+    def orm_session(self):
+        session = self._factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+
+class _Flush:
+    def flush_installations(self, **_kwargs) -> InstallationFlushPlan:
+        return InstallationFlushPlan(
+            member_skill_ids=frozenset(),
+            skills_to_install=frozenset(),
+            skills_to_uninstall=frozenset(),
+        )
+
+
+class _Bots:
+    def get_by_id_and_owner(self, bot_id: str, owner_id: str) -> dict:
+        return {
+            "bot_id": bot_id,
+            "owner_id": owner_id,
+            "entity_id": owner_id,
+            "env": "pre",
+            "active_engine": "openclaw",
+        }
+
+
+def _add_version(
+    db: _Database,
+    *,
+    tenant: str = "teamclaw",
+    skill_id: int,
+    version_id: int,
+    ordinal: int,
+    status: str,
+    number: str,
+) -> None:
+    with avernet_tenant_scope(tenant), db.orm_session() as session:
+        session.add(
+            SkillVersion(
+                id=version_id,
+                skill_id=skill_id,
+                publication_attempt_id=None,
+                version_ordinal=ordinal,
+                status=status,
+                sc_version_number=number,
+                sc_skill_id=1000 + skill_id,
+                sc_version_id=2000 + version_id,
+                name=f"skill-{skill_id}",
+                description=None,
+                metadata_json='{"mcp_dependencies": []}',
+                published_at=(
+                    datetime(2026, 8, 30, tzinfo=UTC) if status == "PUBLISHED" else None
+                ),
+                created_by="owner",
+                env="pre",
+            )
+        )
+
+
+def test_latest_query_ignores_materializing_and_is_tenant_scoped() -> None:
+    db = _Database()
+    repo = SkillVersionRepository(db)
+    _add_version(
+        db,
+        skill_id=10,
+        version_id=101,
+        ordinal=1,
+        status="PUBLISHED",
+        number="1.0.0",
+    )
+    _add_version(
+        db,
+        skill_id=10,
+        version_id=102,
+        ordinal=2,
+        status="MATERIALIZING",
+        number="2.0.0",
+    )
+    _add_version(
+        db,
+        skill_id=20,
+        version_id=201,
+        ordinal=1,
+        status="PUBLISHED",
+        number="1.0.0",
+    )
+    _add_version(
+        db,
+        tenant="external",
+        skill_id=10,
+        version_id=103,
+        ordinal=3,
+        status="PUBLISHED",
+        number="3.0.0",
+    )
+
+    with avernet_tenant_scope("teamclaw"):
+        rows = repo.list_latest_published(env="pre", skill_ids=(10, 20))
+
+    assert [(row["skill_id"], row["id"]) for row in rows] == [
+        (10, 101),
+        (20, 201),
+    ]
+
+
+def test_exact_query_requires_skill_env_status_and_tenant() -> None:
+    db = _Database()
+    repo = SkillVersionRepository(db)
+    _add_version(
+        db,
+        skill_id=10,
+        version_id=101,
+        ordinal=1,
+        status="PUBLISHED",
+        number="1.0.0",
+    )
+    _add_version(
+        db,
+        skill_id=10,
+        version_id=102,
+        ordinal=2,
+        status="MATERIALIZING",
+        number="2.0.0",
+    )
+
+    with avernet_tenant_scope("teamclaw"):
+        assert (
+            repo.get_exact_published(env="pre", skill_id=10, skill_version_id=101)["id"]
+            == 101
+        )
+        assert (
+            repo.get_exact_published(env="pre", skill_id=10, skill_version_id=102)
+            is None
+        )
+        assert (
+            repo.get_exact_published(env="prod", skill_id=10, skill_version_id=101)
+            is None
+        )
+        assert (
+            repo.get_exact_published(env="pre", skill_id=20, skill_version_id=101)
+            is None
+        )
+
+
+def test_public_market_version_can_exist_without_publication_attempt() -> None:
+    db = _Database()
+    _add_version(
+        db,
+        skill_id=10,
+        version_id=101,
+        ordinal=1,
+        status="PUBLISHED",
+        number="1.0.0",
+    )
+
+    with db.orm_session() as session:
+        stored = session.get(SkillVersion, 101)
+        assert stored is not None
+        assert stored.publication_attempt_id is None
+
+
+def test_reader_returns_runtime_ready_center_asset_from_installation_and_version() -> (
+    None
+):
+    db = _Database()
+    with db.orm_session() as session:
+        session.add(
+            Skill(
+                id=10,
+                name="stable-runtime-name",
+                description="asset description",
+                git_path="center://public-skill-code",
+                skill_uuid="00000000-0000-4000-8000-000000000010",
+                user_id="owner",
+                bolt_id="default",
+                env="pre",
+            )
+        )
+        session.add(
+            BotSkillInstallation(
+                bot_id="default", owner_id="owner", skill_id=10, env="pre"
+            )
+        )
+    _add_version(
+        db,
+        skill_id=10,
+        version_id=101,
+        ordinal=1,
+        status="PUBLISHED",
+        number="1.0.0",
+    )
+    reader = BotCapabilityStateReader(
+        repository=_Flush(),
+        bot_repo=_Bots(),
+        pool_skills=SkillRepository(db),
+        version_resolver=SkillVersionResolver(SkillVersionRepository(db)),
+    )
+
+    assets = reader.active_skill_assets(bot_id="default", owner_id="owner")
+
+    assert len(assets) == 1
+    assert assets[0].skill_id == 10
+    assert assets[0].name == "stable-runtime-name"
+    assert assets[0].skill_uuid == "00000000-0000-4000-8000-000000000010"
+    assert assets[0].sc_version_number == "1.0.0"
+    assert assets[0].mcp_dependencies == ()

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_schema_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_schema_repository.py
@@ -116,6 +116,7 @@ def test_additive_schema_registers_space_and_skill_fact_scope(db):
     assert {"status", "removed_at", "removed_by"} <= {
         column.name for column in SpaceMemberModel.__table__.columns
     }
+    assert SkillVersion.__table__.columns["publication_attempt_id"].nullable is True
 
 
 def test_additive_orm_contract_extends_only_the_documented_legacy_tables(db):

--- a/src/backend/tests/community/services/test_skill_set_service_symlink_mappings.py
+++ b/src/backend/tests/community/services/test_skill_set_service_symlink_mappings.py
@@ -24,6 +24,7 @@ from agentclaw.community.core.skill_center.services.skill_set_service import (
     SkillSetService,
     SynlinkMappingInfo,
 )
+from tests.community.skill_version_fakes import PassthroughSkillVersionResolver
 
 pytestmark = pytest.mark.unit
 
@@ -105,6 +106,7 @@ def test_an_excluded_default_member_is_no_longer_symlinked(tmp_path):
         repository=CapabilityDesiredStateRepository(db),
         bot_repo=_Bots(),
         pool_skills=skills,
+        version_resolver=PassthroughSkillVersionResolver(),
     )
     service = SkillSetService(
         skill_repo=skills,

--- a/src/backend/tests/community/skill_version_fakes.py
+++ b/src/backend/tests/community/skill_version_fakes.py
@@ -1,0 +1,16 @@
+"""Test doubles for callers whose fixtures are already Runtime-ready."""
+
+from __future__ import annotations
+
+
+class PassthroughSkillVersionResolver:
+    """Preserve explicitly prepared assets in tests outside version resolution."""
+
+    def resolve_latest_runtime_assets(self, *, env, assets):
+        return tuple(assets)
+
+    def resolve_exact_published(self, **kwargs):  # pragma: no cover - misuse guard
+        raise AssertionError(kwargs)
+
+
+__all__ = ["PassthroughSkillVersionResolver"]


### PR DESCRIPTION
## Summary
- add the SkillVersionResolver deep module and immutable published-version contract
- batch-resolve active Center assets from ac_skill_version while leaving Local/Repo unchanged
- make publication_attempt_id nullable for SC Public lazy materialization
- wire BotCapabilityStateReader to return Runtime-ready exact Center assets
- persist version-level MCP dependency metadata as a PUBLISHED consumption gate

## Compatibility
- Local and Repo assets bypass version queries and keep their existing projection
- Center assets fail closed before Runtime projection when UUID, PUBLISHED Version, SC version number, or dependency metadata is incomplete
- Space publication Versions still retain their non-null Attempt; only SC Public materialization uses NULL

## Validation
- 200 focused Reader/Resolver/Repository/OpenAPI/SkillSet compatibility tests passed
- 115 architecture, repository-contract, module-boundary, DI and Skills Pool wiring tests passed
- Ruff checks passed on changed Python files
- Standards/Spec dual review completed; fixed missing metadata being mistaken for an explicit empty dependency set
- Full community suite was stopped per owner direction after 1153 passed / 2 skipped; two failures were in unrelated existing bot-access test doubles recording duplicate audit/edit-lock calls. GitHub CI is the final full gate.

Refs #1246