### PR TITLE
refactor(backend): add transactional task pending writer

### DIFF
--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -648,6 +648,14 @@ PREPARING → SC_SUBMITTING → WAITING_SC → MATERIALIZING
 - RESULT_UNKNOWN：Draft 保持 FROZEN，普通用户不能处理。
 - 不建设长期 Snapshot URI/Hash，不提供 Attempt cancel。
 - Runtime reconcile 不使用 `ac_task_queue`；SC 发布与物化继续使用持久任务。
+- Task Queue Implementation 提供内部 `TaskQueuePendingRowWriter`：接收 Unit of Work
+  已拥有的 `transactional_orm_session`，隐藏 `TaskQueueModel`、payload JSON、DB clock、
+  env/app 字段和 active-only idempotency SQL，并且绝不 commit/rollback 外层事务。keyed
+  冲突只回滚自己的 nested SAVEPOINT，不能回滚已写入的 Draft/Attempt/Version 事实。
+  普通 `TaskQueueRepository.enqueue()` 同样复用该 writer 并自行打开真实事务；公共
+  `TaskQueueService.enqueue()` 不增加 `session` 参数，仍只在 Repository 已提交、任务新建且
+  due-now/type opt-in 后 best-effort wake Worker。本条只冻结事务 seam，不提前注册
+  Publication task type 或 Handler。
 - Bot Binding、Service Artifact 或进行中操作存在时阻断整体退役。
 
 前端阶段投影固定为：`PREPARING/SC_SUBMITTING/WAITING_SC` 显示“发布中”；SC 已形成

--- a/src/backend/src/agentclaw/community/core/repository/implementations/platform/task_queue.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/platform/task_queue.py
@@ -64,17 +64,22 @@ default + ``ON UPDATE CURRENT_TIMESTAMP``); this body never sets them.
 """
 from __future__ import annotations
 
-import json
 from typing import List, Optional
 
 from injector import inject
 from sqlalchemy import and_, func, or_, text
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.elements import ColumnElement
 
 from agentclaw.community.core.task_queue.repository.models import TaskQueueModel
+from agentclaw.community.core.task_queue.repository.pending_row_writer import (
+    _ACTIVE_IDEM_INDEXES,
+    _KEYED_INSERT_ATTEMPTS,
+    _MAX_IDEMPOTENCY_KEY_LEN,
+    _MAX_TASK_TYPE_LEN,
+    TaskQueuePendingRowWriter,
+    _is_active_idem_conflict,
+)
 from agentclaw.community.core.task_queue.types import (
-    TERMINAL_STATUSES,
     EnqueueResult,
     TaskRecord,
     TaskStatus,
@@ -85,192 +90,14 @@ from agentclaw.community.core.repository.protocols.platform import TaskQueueRepo
 
 logger = get_logger()
 
-#: The unique indexes backing active-only enqueue dedup. Named here because the
-#: two engines report a violation differently and both spellings must be
-#: recognised — see :func:`_is_active_idem_conflict`.
-#:
-#: There are two because the deployed table still carries the pre-``app`` index
-#: alongside the one that scopes dedup by ``app``. Either can reject an INSERT,
-#: so both have to be recognised; the names are not substrings of one another,
-#: so matching them is unambiguous. Dropping the legacy index is the last step of
-#: the app migration (see ``models.py`` and README "Provisioning"), and its
-#: spelling comes out of this tuple then.
-_ACTIVE_IDEM_INDEXES = (
-    "uk_env_app_task_type_active_idempotency_key",
-    "uk_env_task_type_active_idempotency_key",
-)
-
-#: How many times :meth:`TaskQueueRepository.enqueue` will try to insert a keyed
-#: task. A further attempt is only ever reached when the conflicting row went
-#: terminal — releasing the key — between the failed INSERT and the re-SELECT,
-#: i.e. when the key really is free again and the insert deserves another go.
-#:
-#: This was 2, which conflated two failures: a *permanently* held key burned the
-#: same budget as a genuine race, and a caller unlucky enough to lose twice in a
-#: row got an error even though nothing was wrong. The permanent case now raises
-#: on its own (see ``_find_stranded_key_holder``), leaving this bound to cover
-#: only repeated benign races — each needing another caller to claim *and*
-#: release the key inside one microsecond-wide window. A handful of attempts
-#: makes that vanishingly unlikely; a bound is still kept so pathological churn
-#: cannot spin forever.
-_KEYED_INSERT_ATTEMPTS = 5
-
-#: Read off the columns themselves so the limits and the schema cannot drift
-#: apart. Both are scope columns of the dedup index, so both can collide two
-#: distinct values if a non-strict server truncates them.
-_MAX_IDEMPOTENCY_KEY_LEN = TaskQueueModel.__table__.c.idempotency_key.type.length
-_MAX_TASK_TYPE_LEN = TaskQueueModel.__table__.c.task_type.type.length
-
-
-def _validate_idempotency_key(key: str) -> None:
-    """Reject keys the storage layer cannot represent faithfully.
-
-    Enforced in Python because the engines disagree, and the disagreement is
-    invisible to the SQLite suite:
-
-    - SQLite (all tests, local dev) ignores ``VARCHAR`` length entirely.
-    - MySQL/OceanBase under ``STRICT_*_TABLES`` raise ``DataError`` — which is
-      *not* an ``IntegrityError``, so it would escape the conflict handling.
-    - MySQL/OceanBase non-strict **silently truncate**, which is the dangerous
-      one: two distinct keys sharing a 190-char prefix collapse to the same
-      stored value, so the second enqueue takes the conflict path,
-      :meth:`_find_active_by_key` matches the *other* task, and the caller is
-      handed somebody else's record with ``created=False`` while its own work
-      is silently dropped. ``idempotency_key`` truncates too, so the audit
-      column could not tell them apart afterwards either.
-
-    An empty or whitespace-only key is rejected for the mirror-image reason:
-    ``None`` is the opt-out, so ``""`` would otherwise be a *valid* key and
-    become a single global dedup slot per ``(env, task_type)``, collapsing
-    unrelated work onto one row.
-
-    Leading/trailing whitespace is rejected as a correctness rule, not
-    tidiness. ``utf8mb4_bin`` fixes case folding but is a **PAD SPACE**
-    collation on MySQL/OceanBase, so ``"k1"`` and ``"k1 "`` still compare
-    *equal* in the unique index while SQLite keeps them apart — the same
-    join-the-wrong-task failure as truncation, one layer down. Rather than
-    depend on a NO PAD collation (``utf8mb4_0900_bin`` is not available on
-    every OceanBase version) or switch to ``VARBINARY`` (which would make the
-    audit column opaque, defeating the reason it survives terminal), refuse
-    keys whose ends could be padded away: if no accepted key carries trailing
-    whitespace, PAD SPACE can never merge two accepted keys. That holds
-    whatever the engine's pad attribute turns out to be.
-
-    Raising beats truncating or hashing: a hash would keep the key opaque in
-    the audit column, whereas a ``ValueError`` surfaces the first time someone
-    writes the key rather than in production months later. Note it rejects
-    rather than trims — silently rewriting the key is the very thing the
-    "stored verbatim" contract forbids.
-    """
-    if not key.strip():
-        raise ValueError(
-            "idempotency_key must be a non-empty string; omit it entirely to opt out of dedup"
-        )
-    if key != key.strip():
-        raise ValueError(
-            f"idempotency_key must not have leading or trailing whitespace ({key!r}); "
-            "MySQL/OceanBase PAD SPACE collations compare 'k1' and 'k1 ' as equal, so "
-            "such keys would collide in production while staying distinct on SQLite — "
-            "strip it at the call site"
-        )
-    if len(key) > _MAX_IDEMPOTENCY_KEY_LEN:
-        raise ValueError(
-            f"idempotency_key exceeds {_MAX_IDEMPOTENCY_KEY_LEN} chars ({len(key)}); "
-            "shorten it or hash the variable part — it is stored in a "
-            f"VARCHAR({_MAX_IDEMPOTENCY_KEY_LEN}) and would be truncated"
-        )
-
-
-def _validate_keyed_task_type(task_type: str) -> None:
-    """Reject a ``task_type`` that would blur the dedup scope of a keyed row.
-
-    ``task_type`` is a scope column of the dedup unique index, so it decides
-    *which* key space a row lands in. ``utf8mb4_bin`` settles case but is PAD
-    SPACE, so ``"job "`` and ``"job"`` are one entry on MySQL/OceanBase — and a
-    padded row can therefore occupy the dedup slot belonging to the bare type.
-    The direction that matters is the one that costs real work: a live
-    ``"job "`` row holding ``k1`` makes a legitimate ``"job"`` enqueue for
-    ``k1`` take the conflict path, match that row, and return it with
-    ``created=False``. Work that *would* have run is suppressed by a row that
-    cannot run at all — the worker fails an unregistered type outright.
-
-    :class:`HandlerRegistry` already refuses to *register* such a type, but that
-    cannot cover this: ``enqueue`` never consults the registry, and the worker
-    explicitly tolerates persisted types with no handler, so a row can carry a
-    ``task_type`` no registry ever saw. The registry guard protects startup; this
-    one protects every stored row. Two boundaries, so deliberately two checks —
-    core cannot import the plugin, so they cannot share an implementation.
-
-    The width bound is the same rule ``_validate_idempotency_key`` applies to
-    the key, for the same reason and on the same column family. A non-strict
-    MySQL/OceanBase silently truncates an over-long value, so the row is filed
-    under the *truncated* scope while :meth:`_find_active_by_key` searches for
-    the full string. A duplicate enqueue then conflicts with a row it cannot
-    find, exhausts its retries, and raises — where the contract promises the
-    live holder with ``created=False``. (A strict server raises ``DataError`` on
-    the first insert instead: louder, but still not the documented behaviour.)
-    Both limits are read off their columns so neither can drift from the schema.
-
-    Only keyed enqueues are validated. An un-keyed row has a ``NULL``
-    ``active_idempotency_key`` and so never participates in the unique index at
-    all; neither padding nor truncation of its ``task_type`` can collide with
-    anything. Validating it would change behaviour for un-keyed callers, which
-    this change is otherwise careful to leave exactly as they were.
-    """
-    if task_type != task_type.strip():
-        raise ValueError(
-            f"task_type {task_type!r} must not have leading or trailing "
-            "whitespace when an idempotency_key is supplied; MySQL/OceanBase "
-            "compare with a PAD SPACE collation, so 'job ' and 'job' share one "
-            "dedup slot and this row could suppress a legitimate enqueue for the "
-            "unpadded type — strip it at the call site"
-        )
-    if len(task_type) > _MAX_TASK_TYPE_LEN:
-        raise ValueError(
-            f"task_type exceeds {_MAX_TASK_TYPE_LEN} chars ({len(task_type)}) "
-            "and an idempotency_key was supplied; it is stored in a "
-            f"VARCHAR({_MAX_TASK_TYPE_LEN}), and a non-strict MySQL/OceanBase "
-            "would truncate it — the row would then be filed under the truncated "
-            "scope while the lookup searches for the full string, so a duplicate "
-            "enqueue could neither insert nor find its holder"
-        )
-
-
-def _is_active_idem_conflict(exc: IntegrityError) -> bool:
-    """Is this ``IntegrityError`` a violation of the active-idempotency index?
-
-    Scoped deliberately: a blanket ``except IntegrityError`` would turn an
-    unrelated constraint violation into a bogus "duplicate" and hand the caller
-    somebody else's row.
-
-    The two engines name the violation differently, so both spellings are
-    matched:
-
-    - MySQL / OceanBase report the **index** — either of the two the table
-      carries::
-
-          Duplicate entry 'dev-agentclaw-demo-k1' for key 'uk_env_app_task_type_active_idempotency_key'
-          Duplicate entry 'dev-demo-k1' for key 'uk_env_task_type_active_idempotency_key'
-
-    - SQLite reports the **columns**::
-
-          UNIQUE constraint failed: ac_task_queue.env, ac_task_queue.task_type,
-          ac_task_queue.active_idempotency_key
-
-      ``active_idempotency_key`` appears in both indexes and in no other
-      constraint, so the column form identifies the violation without having to
-      tell the two apart — which is all :meth:`enqueue` needs, since it resolves
-      the holder by querying for it rather than by parsing the message.
-
-    A pure function over the exception so it is unit-testable against both
-    message forms without a MySQL instance.
-    """
-    message = str(getattr(exc, "orig", None) or exc)
-    if any(index in message for index in _ACTIVE_IDEM_INDEXES):
-        return True
-    # SQLite names the columns instead of the index. active_idempotency_key
-    # appears in no other constraint on this table, so it alone identifies it.
-    return "UNIQUE constraint failed" in message and "active_idempotency_key" in message
+__all__ = [
+    "TaskQueueRepository",
+    "_ACTIVE_IDEM_INDEXES",
+    "_KEYED_INSERT_ATTEMPTS",
+    "_MAX_IDEMPOTENCY_KEY_LEN",
+    "_MAX_TASK_TYPE_LEN",
+    "_is_active_idem_conflict",
+]
 
 
 class TaskQueueRepository(
@@ -282,6 +109,7 @@ class TaskQueueRepository(
     def __init__(self, db: DatabasePlugin) -> None:
         self._db = db
         self.Model = TaskQueueModel
+        self._pending_writer = TaskQueuePendingRowWriter()
 
     # ── DB-clock helpers ────────────────────────────────────────────────
 
@@ -336,88 +164,6 @@ class TaskQueueRepository(
 
     # ── enqueue (INSERT; deduped against live rows when keyed) ──────────
 
-    def _insert(
-        self,
-        *,
-        task_type: str,
-        payload_json: str,
-        delay_seconds: int,
-        deadline_seconds: int,
-        env: str,
-        app: str,
-        idempotency_key: Optional[str],
-    ) -> TaskRecord:
-        """INSERT one PENDING row and return it. Raises ``IntegrityError`` when
-        a keyed insert loses to a live holder of the same key.
-
-        ``app`` is written explicitly rather than left to the column default:
-        the default names one particular deployment, and any other one would
-        insert rows it could never claim."""
-        with self._db.orm_session() as db:
-            row = self.Model(
-                task_type=task_type,
-                payload=payload_json,
-                status=TaskStatus.PENDING.value,
-                run_at=self._now_plus(db, delay_seconds),
-                deadline_at=self._now_plus(db, deadline_seconds),
-                attempts=0,
-                env=env,
-                app=app,
-                idempotency_key=idempotency_key,
-                # Mirrors the key while the task is live; nulled on terminal.
-                active_idempotency_key=idempotency_key,
-            )
-            db.add(row)
-            db.flush()
-            new_id = row.id
-        record = self.get_by_id(new_id)
-        assert record is not None  # just inserted
-        return record
-
-    def _find_active_by_key(
-        self, *, env: str, app: str, task_type: str, idempotency_key: str
-    ) -> Optional[TaskRecord]:
-        """The **live** holder of ``idempotency_key`` in this app, or ``None``.
-
-        Scoped to ``app`` because that is the scope the caller is promised, and
-        because handing back another app's task would be worse than raising:
-        the caller would get ``created=False`` for work that this fleet can
-        never claim, so the work would simply never run.
-
-        Filtering on ``active_idempotency_key`` alone *should* be enough:
-        terminal transitions null it, so terminal rows drop out by
-        construction. The status predicate is therefore redundant in a
-        consistent database — and is here precisely for when that assumption
-        does not hold.
-
-        A row can be terminal while still holding its active key if something
-        wrote the terminal status without the release: a pre-idempotency worker
-        in a mixed-version fleet, a manual DB edit, or a future transition that
-        forgets to null the column. Without this predicate that row is returned
-        as the "live holder", so the caller gets a *finished* task with
-        ``created=False`` and its work is silently dropped — permanently, since
-        nothing will ever release that key. With it, the lookup finds nothing,
-        the insert is retried, the unique index (which does not care about
-        status) rejects it again, and :meth:`enqueue` raises. A loud failure on
-        an inconsistent row beats a silent wrong answer.
-
-        This does not *fix* such a row — releasing the key is the writer's job.
-        It converts an undetectable failure into an obvious one.
-        """
-        with self._db.orm_session() as db:
-            row = (
-                db.query(self.Model)
-                .filter(
-                    self.Model.env == env,
-                    self.Model.app == app,
-                    self.Model.task_type == task_type,
-                    self.Model.active_idempotency_key == idempotency_key,
-                    self.Model.status.notin_([s.value for s in TERMINAL_STATUSES]),
-                )
-                .first()
-            )
-            return row.to_record() if row else None
-
     def _find_stranded_key_holder(
         self, *, env: str, app: str, task_type: str, idempotency_key: str
     ) -> Optional[int]:
@@ -444,19 +190,14 @@ class TaskQueueRepository(
         it were bad luck. Told apart, the stranded case fails immediately and
         names the row to clear.
         """
-        with self._db.orm_session() as db:
-            row = (
-                db.query(self.Model.id)
-                .filter(
-                    self.Model.env == env,
-                    self.Model.app == app,
-                    self.Model.task_type == task_type,
-                    self.Model.active_idempotency_key == idempotency_key,
-                    self.Model.status.in_([s.value for s in TERMINAL_STATUSES]),
-                )
-                .first()
+        with self._db.orm_session() as session:
+            return self._pending_writer._find_stranded_key_holder(
+                session,
+                env=env,
+                app=app,
+                task_type=task_type,
+                idempotency_key=idempotency_key,
             )
-            return row[0] if row else None
 
     def enqueue(
         self,
@@ -469,98 +210,25 @@ class TaskQueueRepository(
         app: str,
         idempotency_key: Optional[str] = None,
     ) -> EnqueueResult:
-        # Validate before any work: neither a key the column cannot hold
-        # faithfully, nor a task_type that would blur the dedup scope, may reach
-        # the INSERT. Both checks are keyed-only — an un-keyed row has a NULL
-        # active key and never enters the unique index, so neither can bite it.
-        if idempotency_key is not None:
-            _validate_idempotency_key(idempotency_key)
-            _validate_keyed_task_type(task_type)
-
-        payload_json = json.dumps(payload, ensure_ascii=False)
-        insert_kwargs = dict(
-            task_type=task_type,
-            payload_json=payload_json,
-            delay_seconds=delay_seconds,
-            deadline_seconds=deadline_seconds,
-            env=env,
-            app=app,
-            idempotency_key=idempotency_key,
-        )
-
-        # Un-keyed: the caller opted out of dedup, so this stays a plain INSERT
-        # with none of the conflict machinery on the path.
-        if idempotency_key is None:
-            record = self._insert(**insert_kwargs)
-            self._log_enqueued(record, delay_seconds, deadline_seconds, created=True)
-            return EnqueueResult(record, True)
-
-        # Keyed: try-insert, and on a conflict with *this* index hand back the
-        # live holder. ``orm_session()`` rolls back and closes on exception
-        # (and the corp engine runs at AUTOCOMMIT), so the failed INSERT leaves
-        # nothing to clean up and the lookup below runs in a fresh session.
-        for _ in range(_KEYED_INSERT_ATTEMPTS):
-            try:
-                record = self._insert(**insert_kwargs)
-            except IntegrityError as exc:
-                if not _is_active_idem_conflict(exc):
-                    raise  # unrelated constraint — never read as a duplicate
-                existing = self._find_active_by_key(
-                    env=env,
-                    app=app,
-                    task_type=task_type,
-                    idempotency_key=idempotency_key,
-                )
-                if existing is not None:
-                    logger.info(
-                        "[task_queue.enqueue] type=%s joined existing id=%s key=%s",
-                        task_type,
-                        existing.id,
-                        idempotency_key,
-                    )
-                    return EnqueueResult(existing, False)
-                # No live holder of ours, yet an index rejected us. Two very
-                # different situations, and retrying is right for only one of
-                # them.
-                stranded_id = self._find_stranded_key_holder(
-                    env=env,
-                    app=app,
-                    task_type=task_type,
-                    idempotency_key=idempotency_key,
-                )
-                if stranded_id is not None:
-                    raise RuntimeError(
-                        f"[task_queue.enqueue] key={idempotency_key!r} "
-                        f"type={task_type} env={env} app={app} is held by task "
-                        f"id={stranded_id}, which is terminal but never released "
-                        "it. Retrying cannot help — the key is occupied "
-                        "forever. Most likely a worker running code from "
-                        "before enqueue idempotency wrote the terminal status "
-                        "without clearing active_idempotency_key; clear that "
-                        "column on the row to free the key"
-                    )
-                # Otherwise the holder reached a terminal state between our
-                # INSERT and this lookup, releasing the key — it is free again,
-                # so retry.
-                continue
-            self._log_enqueued(record, delay_seconds, deadline_seconds, created=True)
-            return EnqueueResult(record, True)
-
-        # Every attempt lost the insert and found no holder of ours. Usually
-        # contention rather than corruption (the permanent case raises above):
-        # a fresh holder claimed and released the key inside each window, so it
-        # is being churned faster than this loop can win. The other way to reach
-        # here is the legacy unique index, which ignores app and so rejects a key
-        # a *different* deployment holds — named in the message because retrying
-        # can never clear that one.
-        raise RuntimeError(
-            "[task_queue.enqueue] could not insert or resolve a holder for "
-            f"key={idempotency_key!r} type={task_type} env={env} app={app} after "
-            f"{_KEYED_INSERT_ATTEMPTS} attempts; either the key was taken and "
-            "released by other callers on every attempt, or another app holds it "
-            "and the pre-app index uk_env_task_type_active_idempotency_key (which "
-            "ignores app) is still on the table"
-        )
+        with self._db.transactional_orm_session() as session:
+            result = self._pending_writer.write_pending(
+                session,
+                task_type=task_type,
+                payload=payload,
+                delay_seconds=delay_seconds,
+                deadline_seconds=deadline_seconds,
+                env=env,
+                app=app,
+                idempotency_key=idempotency_key,
+            )
+        if result.created:
+            self._log_enqueued(
+                result.record,
+                delay_seconds,
+                deadline_seconds,
+                created=True,
+            )
+        return result
 
     @staticmethod
     def _log_enqueued(

--- a/src/backend/src/agentclaw/community/core/repository/implementations/platform/task_queue.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/platform/task_queue.py
@@ -80,6 +80,7 @@ from agentclaw.community.core.task_queue.repository.pending_row_writer import (
     _is_active_idem_conflict,
 )
 from agentclaw.community.core.task_queue.types import (
+    TERMINAL_STATUSES,
     EnqueueResult,
     TaskRecord,
     TaskStatus,
@@ -191,13 +192,16 @@ class TaskQueueRepository(
         names the row to clear.
         """
         with self._db.orm_session() as session:
-            return self._pending_writer._find_stranded_key_holder(
+            holder = self._pending_writer._find_key_holder_current(
                 session,
                 env=env,
                 app=app,
                 task_type=task_type,
                 idempotency_key=idempotency_key,
             )
+            if holder is None or holder.status not in TERMINAL_STATUSES:
+                return None
+            return holder.id
 
     def enqueue(
         self,

--- a/src/backend/src/agentclaw/community/core/task_queue/README.md
+++ b/src/backend/src/agentclaw/community/core/task_queue/README.md
@@ -15,12 +15,33 @@ a handler that reschedules itself until done, bounded by a wall-clock deadline.
 ## Pieces
 
 - `repository/models.py` — `ac_task_queue` ORM table.
+- `repository/pending_row_writer.py` — session-bound PENDING-row writer. It
+  owns model construction, JSON serialization, DB-clock timestamps, and
+  active-only idempotency, but never commits or rolls back the caller's outer
+  transaction.
 - `repository/protocol.py` — `TaskQueueRepositoryProtocol` (claim CAS + holder-guarded transitions). Impl: `plugins/task_queue_repository.py` (unified, runs on SQLite + OceanBase). **The DB owns all timing** — callers pass durations; the repo computes `run_at`/`lease`/`deadline` and every comparison with the DB clock (`now()`), so pod clock skew can't affect coordination.
 - `types.py` — `TaskRecord`, the `TaskStatus` enum (`PENDING`/`RUNNING`/`SUCCEEDED`/`FAILED`/`TIMED_OUT`), and the handler outcomes `Complete` / `Reschedule` / `Retry` / `Fail`.
 - `services/registry.py` — `TaskHandler` Protocol + `HandlerRegistry`.
 - `services/task_queue_service.py` — `TaskQueueService.enqueue(...)`, the entry point adopters call.
 - `services/worker.py` — `TaskWorker`, the Lifecycle that polls, claims, runs handlers, and applies outcomes.
 - `examples.py` — `NoopTaskHandler` + `PollUntilTerminalExampleHandler` (not wired in prod).
+
+## Transaction-bound enqueue seam
+
+`TaskQueuePendingRowWriter.write_pending(session, ...)` is the internal seam
+for a domain Unit of Work that must commit its business facts and
+`ac_task_queue` together. The caller supplies the ORM session it already owns;
+the writer hides `TaskQueueModel`, payload encoding, DB-clock expressions, and
+the active-key queries. A keyed duplicate is isolated with a nested SAVEPOINT,
+so resolving the live holder never rolls back unrelated business changes in
+the outer transaction.
+
+The ordinary `TaskQueueRepository.enqueue(...)` now opens a real
+`transactional_orm_session`, delegates to this same writer, and returns only
+after that context commits. `TaskQueueService.enqueue(...)` keeps its public
+signature and existing post-repository wake policy: a due, newly-created,
+opted-in task wakes the worker only after the row is committed. The low-level
+writer itself never commits, rolls back, or signals the worker.
 
 ## App scoping
 

--- a/src/backend/src/agentclaw/community/core/task_queue/repository/pending_row_writer.py
+++ b/src/backend/src/agentclaw/community/core/task_queue/repository/pending_row_writer.py
@@ -1,0 +1,251 @@
+"""Session-bound writer for one durable PENDING task row.
+
+The caller owns the surrounding transaction. This module owns every TaskQueue
+storage detail: model construction, JSON serialization, DB-clock timestamps,
+and active-only idempotency. It never commits or rolls back the outer session.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from sqlalchemy import func, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.sql.elements import ColumnElement
+
+from agentclaw.community.core.task_queue.repository.models import TaskQueueModel
+from agentclaw.community.core.task_queue.types import (
+    TERMINAL_STATUSES,
+    EnqueueResult,
+    TaskRecord,
+    TaskStatus,
+)
+from agentclaw.community.log import get_logger
+
+
+logger = get_logger()
+
+_ACTIVE_IDEM_INDEXES = (
+    "uk_env_app_task_type_active_idempotency_key",
+    "uk_env_task_type_active_idempotency_key",
+)
+_KEYED_INSERT_ATTEMPTS = 5
+_MAX_IDEMPOTENCY_KEY_LEN = TaskQueueModel.__table__.c.idempotency_key.type.length
+_MAX_TASK_TYPE_LEN = TaskQueueModel.__table__.c.task_type.type.length
+
+
+def _validate_idempotency_key(key: str) -> None:
+    """Reject values MySQL/OceanBase could pad or truncate into collisions."""
+    if not isinstance(key, str) or not key.strip():
+        raise ValueError(
+            "idempotency_key must be a non-empty string; omit it entirely to opt out of dedup"
+        )
+    if key != key.strip():
+        raise ValueError(
+            f"idempotency_key must not have leading or trailing whitespace ({key!r}); "
+            "MySQL/OceanBase PAD SPACE collations would merge distinct keys"
+        )
+    if len(key) > _MAX_IDEMPOTENCY_KEY_LEN:
+        raise ValueError(
+            f"idempotency_key exceeds {_MAX_IDEMPOTENCY_KEY_LEN} chars ({len(key)}); "
+            "shorten it or hash the variable part"
+        )
+
+
+def _validate_keyed_task_type(task_type: str) -> None:
+    """Protect the task-type scope columns of the active-key indexes."""
+    if not isinstance(task_type, str) or task_type != task_type.strip():
+        raise ValueError(
+            f"task_type {task_type!r} must not have leading or trailing "
+            "whitespace when an idempotency_key is supplied"
+        )
+    if len(task_type) > _MAX_TASK_TYPE_LEN:
+        raise ValueError(
+            f"task_type exceeds {_MAX_TASK_TYPE_LEN} chars ({len(task_type)}) "
+            "and an idempotency_key was supplied"
+        )
+
+
+def _is_active_idem_conflict(exc: IntegrityError) -> bool:
+    """Whether an engine-specific IntegrityError names the active-key index."""
+    message = str(getattr(exc, "orig", None) or exc)
+    if any(index in message for index in _ACTIVE_IDEM_INDEXES):
+        return True
+    return (
+        "UNIQUE constraint failed" in message
+        and "active_idempotency_key" in message
+    )
+
+
+class TaskQueuePendingRowWriter:
+    """Insert or join one PENDING task inside an existing ORM transaction."""
+
+    Model = TaskQueueModel
+
+    @staticmethod
+    def _now_plus(session: Any, seconds: float) -> ColumnElement:
+        n = int(round(seconds))
+        if n == 0:
+            return func.now()
+        if session.bind.dialect.name == "sqlite":
+            return func.datetime(func.now(), text(f"'+{n} seconds'"))
+        return func.date_add(func.now(), text(f"INTERVAL {n} SECOND"))
+
+    def write_pending(
+        self,
+        session: Any,
+        *,
+        task_type: str,
+        payload: dict,
+        delay_seconds: int,
+        deadline_seconds: int,
+        env: str,
+        app: str,
+        idempotency_key: str | None = None,
+    ) -> EnqueueResult:
+        """Write without committing the caller-owned outer transaction."""
+        if idempotency_key is not None:
+            _validate_idempotency_key(idempotency_key)
+            _validate_keyed_task_type(task_type)
+
+        payload_json = json.dumps(payload, ensure_ascii=False)
+        values = dict(
+            task_type=task_type,
+            payload_json=payload_json,
+            delay_seconds=delay_seconds,
+            deadline_seconds=deadline_seconds,
+            env=env,
+            app=app,
+            idempotency_key=idempotency_key,
+        )
+        if idempotency_key is None:
+            return EnqueueResult(self._insert(session, **values), True)
+
+        for _ in range(_KEYED_INSERT_ATTEMPTS):
+            try:
+                # A duplicate must roll back only its INSERT. Rolling back the
+                # outer session would discard the Publication/Materialization
+                # facts this writer is specifically meant to share a UoW with.
+                with session.begin_nested():
+                    record = self._insert(session, **values)
+            except IntegrityError as error:
+                if not _is_active_idem_conflict(error):
+                    raise
+                existing = self._find_active_by_key(
+                    session,
+                    env=env,
+                    app=app,
+                    task_type=task_type,
+                    idempotency_key=idempotency_key,
+                )
+                if existing is not None:
+                    logger.info(
+                        "[task_queue.enqueue] type=%s joined existing id=%s key=%s",
+                        task_type,
+                        existing.id,
+                        idempotency_key,
+                    )
+                    return EnqueueResult(existing, False)
+                stranded_id = self._find_stranded_key_holder(
+                    session,
+                    env=env,
+                    app=app,
+                    task_type=task_type,
+                    idempotency_key=idempotency_key,
+                )
+                if stranded_id is not None:
+                    raise RuntimeError(
+                        f"[task_queue.enqueue] key={idempotency_key!r} "
+                        f"type={task_type} env={env} app={app} is held by task "
+                        f"id={stranded_id}, which is terminal but never released "
+                        "it. Retrying cannot help — the key is occupied "
+                        "forever. Most likely a worker running code from "
+                        "before enqueue idempotency wrote the terminal status "
+                        "without clearing active_idempotency_key; clear that "
+                        "column on the row to free the key"
+                    )
+                continue
+            return EnqueueResult(record, True)
+
+        raise RuntimeError(
+            "[task_queue.enqueue] could not insert or resolve a holder for "
+            f"key={idempotency_key!r} type={task_type} env={env} app={app} "
+            f"after {_KEYED_INSERT_ATTEMPTS} attempts; either the key was taken "
+            "and released by other callers on every attempt, or another app "
+            "holds it and the pre-app index "
+            "uk_env_task_type_active_idempotency_key (which ignores app) is "
+            "still on the table"
+        )
+
+    def _insert(
+        self,
+        session: Any,
+        *,
+        task_type: str,
+        payload_json: str,
+        delay_seconds: int,
+        deadline_seconds: int,
+        env: str,
+        app: str,
+        idempotency_key: str | None,
+    ) -> TaskRecord:
+        row = self.Model(
+            task_type=task_type,
+            payload=payload_json,
+            status=TaskStatus.PENDING.value,
+            run_at=self._now_plus(session, delay_seconds),
+            deadline_at=self._now_plus(session, deadline_seconds),
+            attempts=0,
+            env=env,
+            app=app,
+            idempotency_key=idempotency_key,
+            active_idempotency_key=idempotency_key,
+        )
+        session.add(row)
+        session.flush()
+        return row.to_record()
+
+    def _find_active_by_key(
+        self,
+        session: Any,
+        *,
+        env: str,
+        app: str,
+        task_type: str,
+        idempotency_key: str,
+    ) -> TaskRecord | None:
+        row = (
+            session.query(self.Model)
+            .filter(
+                self.Model.env == env,
+                self.Model.app == app,
+                self.Model.task_type == task_type,
+                self.Model.active_idempotency_key == idempotency_key,
+                self.Model.status.notin_([item.value for item in TERMINAL_STATUSES]),
+            )
+            .first()
+        )
+        return row.to_record() if row else None
+
+    def _find_stranded_key_holder(
+        self,
+        session: Any,
+        *,
+        env: str,
+        app: str,
+        task_type: str,
+        idempotency_key: str,
+    ) -> int | None:
+        row = (
+            session.query(self.Model.id)
+            .filter(
+                self.Model.env == env,
+                self.Model.app == app,
+                self.Model.task_type == task_type,
+                self.Model.active_idempotency_key == idempotency_key,
+                self.Model.status.in_([item.value for item in TERMINAL_STATUSES]),
+            )
+            .first()
+        )
+        return row[0] if row else None

--- a/src/backend/src/agentclaw/community/core/task_queue/repository/pending_row_writer.py
+++ b/src/backend/src/agentclaw/community/core/task_queue/repository/pending_row_writer.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from sqlalchemy import func, text
+from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -132,39 +132,32 @@ class TaskQueuePendingRowWriter:
             except IntegrityError as error:
                 if not _is_active_idem_conflict(error):
                     raise
-                existing = self._find_active_by_key(
+                holder = self._find_key_holder_current(
                     session,
                     env=env,
                     app=app,
                     task_type=task_type,
                     idempotency_key=idempotency_key,
                 )
-                if existing is not None:
-                    logger.info(
-                        "[task_queue.enqueue] type=%s joined existing id=%s key=%s",
-                        task_type,
-                        existing.id,
-                        idempotency_key,
-                    )
-                    return EnqueueResult(existing, False)
-                stranded_id = self._find_stranded_key_holder(
-                    session,
-                    env=env,
-                    app=app,
-                    task_type=task_type,
-                    idempotency_key=idempotency_key,
-                )
-                if stranded_id is not None:
+                if holder is not None and holder.status in TERMINAL_STATUSES:
                     raise RuntimeError(
                         f"[task_queue.enqueue] key={idempotency_key!r} "
                         f"type={task_type} env={env} app={app} is held by task "
-                        f"id={stranded_id}, which is terminal but never released "
+                        f"id={holder.id}, which is terminal but never released "
                         "it. Retrying cannot help — the key is occupied "
                         "forever. Most likely a worker running code from "
                         "before enqueue idempotency wrote the terminal status "
                         "without clearing active_idempotency_key; clear that "
                         "column on the row to free the key"
                     )
+                if holder is not None:
+                    logger.info(
+                        "[task_queue.enqueue] type=%s joined existing id=%s key=%s",
+                        task_type,
+                        holder.id,
+                        idempotency_key,
+                    )
+                    return EnqueueResult(holder, False)
                 continue
             return EnqueueResult(record, True)
 
@@ -206,7 +199,35 @@ class TaskQueuePendingRowWriter:
         session.flush()
         return row.to_record()
 
-    def _find_active_by_key(
+    def _key_holder_statement(
+        self,
+        *,
+        env: str,
+        app: str,
+        task_type: str,
+        idempotency_key: str,
+    ):
+        """Current/locking read for the unique-key holder.
+
+        A Publication UoW may already have a REPEATABLE READ snapshot from
+        locking Draft/Attempt rows. The unique index sees a concurrent holder
+        even when that snapshot does not; FOR UPDATE is therefore required to
+        resolve the conflict against current committed state. populate_existing
+        prevents an older identity-map instance from winning over that read.
+        """
+        return (
+            select(self.Model)
+            .where(
+                self.Model.env == env,
+                self.Model.app == app,
+                self.Model.task_type == task_type,
+                self.Model.active_idempotency_key == idempotency_key,
+            )
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+
+    def _find_key_holder_current(
         self,
         session: Any,
         *,
@@ -215,37 +236,12 @@ class TaskQueuePendingRowWriter:
         task_type: str,
         idempotency_key: str,
     ) -> TaskRecord | None:
-        row = (
-            session.query(self.Model)
-            .filter(
-                self.Model.env == env,
-                self.Model.app == app,
-                self.Model.task_type == task_type,
-                self.Model.active_idempotency_key == idempotency_key,
-                self.Model.status.notin_([item.value for item in TERMINAL_STATUSES]),
+        row = session.execute(
+            self._key_holder_statement(
+                env=env,
+                app=app,
+                task_type=task_type,
+                idempotency_key=idempotency_key,
             )
-            .first()
-        )
-        return row.to_record() if row else None
-
-    def _find_stranded_key_holder(
-        self,
-        session: Any,
-        *,
-        env: str,
-        app: str,
-        task_type: str,
-        idempotency_key: str,
-    ) -> int | None:
-        row = (
-            session.query(self.Model.id)
-            .filter(
-                self.Model.env == env,
-                self.Model.app == app,
-                self.Model.task_type == task_type,
-                self.Model.active_idempotency_key == idempotency_key,
-                self.Model.status.in_([item.value for item in TERMINAL_STATUSES]),
-            )
-            .first()
-        )
-        return row[0] if row else None
+        ).scalar_one_or_none()
+        return row.to_record() if row is not None else None

--- a/src/backend/tests/community/core/skill_center/test_skill_activation_sync_task.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_activation_sync_task.py
@@ -318,6 +318,9 @@ class _InMemorySqliteDB:
         finally:
             db.close()
 
+    def transactional_orm_session(self):
+        return self.orm_session()
+
 
 @pytest.fixture
 def queue(monkeypatch):

--- a/src/backend/tests/community/core/task_queue/test_task_worker.py
+++ b/src/backend/tests/community/core/task_queue/test_task_worker.py
@@ -5,6 +5,7 @@ Timing is DB-owned, so deadline behavior is exercised via ``deadline_seconds``
 and backoff config rather than injected clocks.
 """
 import asyncio
+import threading
 import time
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -42,18 +43,26 @@ APP = DEFAULT_APP
 class InMemorySqliteDB:
     def __init__(self, engine):
         self._session_factory = sessionmaker(bind=engine, autoflush=False)
+        # StaticPool exposes one sqlite3 connection to both the worker thread
+        # and the test thread. Mirror LocalDatabasePlugin's serialization so
+        # the harness never drives that single connection concurrently.
+        self._session_lock = threading.RLock()
 
     @contextmanager
     def orm_session(self):
-        db = self._session_factory()
-        try:
-            yield db
-            db.commit()
-        except Exception:
-            db.rollback()
-            raise
-        finally:
-            db.close()
+        with self._session_lock:
+            db = self._session_factory()
+            try:
+                yield db
+                db.commit()
+            except Exception:
+                db.rollback()
+                raise
+            finally:
+                db.close()
+
+    def transactional_orm_session(self):
+        return self.orm_session()
 
 
 class _World:

--- a/src/backend/tests/community/repository/platform/test_task_queue_pending_row_writer.py
+++ b/src/backend/tests/community/repository/platform/test_task_queue_pending_row_writer.py
@@ -1,0 +1,215 @@
+"""Session-bound pending-row writer integration contracts."""
+
+from contextlib import contextmanager
+import inspect
+
+import pytest
+from sqlalchemy import (
+    Column,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    create_engine,
+    func,
+    select,
+)
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from agentclaw.community.core.base import Base
+from agentclaw.community.core.repository.implementations.platform.task_queue import (
+    TaskQueueRepository,
+)
+from agentclaw.community.core.task_queue.repository.models import TaskQueueModel
+from agentclaw.community.core.task_queue.repository.pending_row_writer import (
+    TaskQueuePendingRowWriter,
+)
+from agentclaw.community.core.task_queue.services.task_queue_service import (
+    TaskQueueService,
+)
+from agentclaw.community.core.task_queue.types import DEFAULT_APP, TaskStatus
+
+
+pytestmark = pytest.mark.integration
+
+
+class _Database:
+    def __init__(self, engine) -> None:
+        self._session_factory = sessionmaker(bind=engine, autoflush=False)
+
+    @contextmanager
+    def orm_session(self):
+        with self.transactional_orm_session() as session:
+            yield session
+
+    @contextmanager
+    def transactional_orm_session(self):
+        session = self._session_factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+
+@pytest.fixture
+def database():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    metadata = MetaData()
+    business_facts = Table(
+        "phase2_test_business_fact",
+        metadata,
+        Column("id", Integer, primary_key=True),
+        Column("value", String(50), nullable=False),
+    )
+    metadata.create_all(engine)
+    return _Database(engine), engine, business_facts
+
+
+def _write(writer, session, **overrides):
+    values = {
+        "task_type": "phase2-test",
+        "payload": {"attempt_id": 42},
+        "delay_seconds": 0,
+        "deadline_seconds": 3600,
+        "env": "dev",
+        "app": DEFAULT_APP,
+        "idempotency_key": None,
+    }
+    values.update(overrides)
+    return writer.write_pending(session, **values)
+
+
+def test_public_service_enqueue_does_not_expose_a_session_parameter() -> None:
+    assert "session" not in inspect.signature(TaskQueueService.enqueue).parameters
+
+
+def test_business_fact_and_pending_task_commit_atomically(database) -> None:
+    db, engine, business_facts = database
+    writer = TaskQueuePendingRowWriter()
+
+    with db.transactional_orm_session() as session:
+        session.execute(business_facts.insert().values(id=1, value="frozen"))
+        result = _write(writer, session)
+        assert result.created is True
+        assert result.record.status is TaskStatus.PENDING
+
+    with engine.connect() as connection:
+        assert connection.scalar(select(func.count()).select_from(business_facts)) == 1
+        assert connection.scalar(
+            select(func.count()).select_from(TaskQueueModel.__table__)
+        ) == 1
+
+
+def test_outer_transaction_rollback_removes_business_fact_and_pending_task(
+    database,
+) -> None:
+    db, engine, business_facts = database
+    writer = TaskQueuePendingRowWriter()
+
+    with pytest.raises(RuntimeError, match="abort publication"):
+        with db.transactional_orm_session() as session:
+            session.execute(business_facts.insert().values(id=1, value="frozen"))
+            _write(writer, session)
+            raise RuntimeError("abort publication")
+
+    with engine.connect() as connection:
+        assert connection.scalar(select(func.count()).select_from(business_facts)) == 0
+        assert connection.scalar(
+            select(func.count()).select_from(TaskQueueModel.__table__)
+        ) == 0
+
+
+def test_active_idempotency_joins_existing_row_inside_same_transaction(
+    database,
+) -> None:
+    db, _, _ = database
+    writer = TaskQueuePendingRowWriter()
+
+    with db.transactional_orm_session() as session:
+        first = _write(writer, session, idempotency_key="publication:42")
+        second = _write(writer, session, idempotency_key="publication:42")
+
+    assert first.created is True
+    assert second.created is False
+    assert second.record.id == first.record.id
+
+
+def test_duplicate_savepoint_does_not_rollback_outer_business_fact(
+    database,
+) -> None:
+    db, engine, business_facts = database
+    writer = TaskQueuePendingRowWriter()
+    with db.transactional_orm_session() as session:
+        first = _write(writer, session, idempotency_key="publication:42")
+
+    with db.transactional_orm_session() as session:
+        session.execute(business_facts.insert().values(id=1, value="joined"))
+        duplicate = _write(
+            writer,
+            session,
+            idempotency_key="publication:42",
+        )
+        assert duplicate.created is False
+        assert duplicate.record.id == first.record.id
+
+    with engine.connect() as connection:
+        assert connection.scalar(select(func.count()).select_from(business_facts)) == 1
+        assert connection.scalar(
+            select(func.count()).select_from(TaskQueueModel.__table__)
+        ) == 1
+
+
+def test_writer_preserves_payload_owner_and_db_clock_fields(database) -> None:
+    db, _, _ = database
+    writer = TaskQueuePendingRowWriter()
+
+    with db.transactional_orm_session() as session:
+        result = _write(
+            writer,
+            session,
+            payload={"nested": [1, 2], "message": "你好"},
+            delay_seconds=5,
+            deadline_seconds=30,
+            env="pre",
+            app="teclaw",
+        )
+
+    stored = TaskQueueRepository(db).get_by_id(result.record.id)
+    assert stored is not None
+    assert stored.payload == {"nested": [1, 2], "message": "你好"}
+    assert stored.env == "pre"
+    assert stored.app == "teclaw"
+    assert stored.run_at is not None
+    assert stored.deadline_at is not None
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("idempotency_key", ""),
+        ("idempotency_key", " key"),
+        ("idempotency_key", "k" * 191),
+        ("task_type", " task"),
+        ("task_type", "t" * 101),
+    ],
+)
+def test_writer_keeps_key_and_scope_validation(database, field, value) -> None:
+    db, _, _ = database
+    writer = TaskQueuePendingRowWriter()
+    overrides = {field: value, "idempotency_key": "key"}
+    if field == "idempotency_key":
+        overrides = {field: value}
+
+    with pytest.raises(ValueError):
+        with db.transactional_orm_session() as session:
+            _write(writer, session, **overrides)

--- a/src/backend/tests/community/repository/platform/test_task_queue_pending_row_writer.py
+++ b/src/backend/tests/community/repository/platform/test_task_queue_pending_row_writer.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
+from sqlalchemy.dialects import mysql
 
 from agentclaw.community.core.base import Base
 from agentclaw.community.core.repository.implementations.platform.task_queue import (
@@ -91,6 +92,19 @@ def _write(writer, session, **overrides):
 
 def test_public_service_enqueue_does_not_expose_a_session_parameter() -> None:
     assert "session" not in inspect.signature(TaskQueueService.enqueue).parameters
+
+
+def test_key_conflict_resolution_is_a_mysql_current_locking_read() -> None:
+    statement = TaskQueuePendingRowWriter()._key_holder_statement(
+        env="prod",
+        app=DEFAULT_APP,
+        task_type="publication",
+        idempotency_key="publication:42",
+    )
+
+    sql = str(statement.compile(dialect=mysql.dialect()))
+    assert "FOR UPDATE" in sql
+    assert statement.get_execution_options()["populate_existing"] is True
 
 
 def test_business_fact_and_pending_task_commit_atomically(database) -> None:

--- a/src/backend/tests/community/repository/platform/test_task_queue_repository.py
+++ b/src/backend/tests/community/repository/platform/test_task_queue_repository.py
@@ -54,6 +54,9 @@ class InMemorySqliteDB:
         finally:
             db.close()
 
+    def transactional_orm_session(self):
+        return self.orm_session()
+
 
 @pytest.fixture
 def repo():
@@ -595,12 +598,12 @@ def test_is_active_idem_conflict_recognises_both_engine_message_forms():
 def test_unrelated_integrity_error_propagates(repo, monkeypatch):
     """A blanket except would turn someone else's constraint violation into a
     bogus duplicate and hand back the wrong row."""
-    def boom(**_kwargs):
+    def boom(_session, **_kwargs):
         raise IntegrityError(
             "INSERT ...", {}, Exception("UNIQUE constraint failed: ac_task_queue.other")
         )
 
-    monkeypatch.setattr(repo, "_insert", boom)
+    monkeypatch.setattr(repo._pending_writer, "_insert", boom)
     with pytest.raises(IntegrityError):
         _enqueue_result(repo, idempotency_key="k1")
 
@@ -621,16 +624,24 @@ def test_holder_going_terminal_between_insert_and_lookup_is_retried(repo):
     """The insert/re-SELECT race: the conflicting row can reach a terminal state
     in that window, releasing the key. The retry then inserts cleanly."""
     first = _enqueue_result(repo, idempotency_key="k1")
-    real_find = repo._find_active_by_key
+    writer = repo._pending_writer
+    real_find = writer._find_active_by_key
 
-    def free_the_key_then_look(**kwargs):
+    def free_the_key_then_look(session, **kwargs):
         # Simulate the holder finishing the instant after our INSERT lost.
-        _claim(repo, "W")
-        repo.complete(task_id=first.record.id, worker_id="W")
-        repo._find_active_by_key = real_find
-        return real_find(**kwargs)
+        session.query(TaskQueueModel).filter(
+            TaskQueueModel.id == first.record.id
+        ).update(
+            {
+                TaskQueueModel.status: TaskStatus.SUCCEEDED.value,
+                TaskQueueModel.active_idempotency_key: None,
+            },
+            synchronize_session=False,
+        )
+        writer._find_active_by_key = real_find
+        return real_find(session, **kwargs)
 
-    repo._find_active_by_key = free_the_key_then_look
+    writer._find_active_by_key = free_the_key_then_look
 
     second = _enqueue_result(repo, idempotency_key="k1")
     assert second.created is True  # second attempt inserted
@@ -644,7 +655,7 @@ def test_enqueue_raises_when_it_can_neither_insert_nor_resolve_a_holder(repo):
     one — the key looks free on every retry and another caller keeps winning."""
     _enqueue_result(repo, idempotency_key="k1")
     # A holder that is never found: every attempt conflicts, every lookup misses.
-    repo._find_active_by_key = lambda **_kwargs: None
+    repo._pending_writer._find_active_by_key = lambda _session, **_kwargs: None
 
     with pytest.raises(RuntimeError, match="taken and released by other callers"):
         _enqueue_result(repo, idempotency_key="k1")
@@ -663,10 +674,11 @@ def test_three_consecutive_benign_races_still_enqueue(repo):
     _claim(repo, "W")
     repo.complete(task_id=first.record.id, worker_id="W")  # key genuinely free
 
-    real_insert = repo._insert
+    writer = repo._pending_writer
+    real_insert = writer._insert
     losses = {"n": 0}
 
-    def lose_three_times_then_succeed(**kwargs):
+    def lose_three_times_then_succeed(session, **kwargs):
         if losses["n"] < 3:
             losses["n"] += 1
             raise IntegrityError(
@@ -674,9 +686,9 @@ def test_three_consecutive_benign_races_still_enqueue(repo):
                 {},
                 Exception(f"Duplicate entry 'x' for key '{_ACTIVE_IDEM_INDEXES[0]}'"),
             )
-        return real_insert(**kwargs)
+        return real_insert(session, **kwargs)
 
-    repo._insert = lose_three_times_then_succeed
+    writer._insert = lose_three_times_then_succeed
     result = _enqueue_result(repo, idempotency_key="k1")
 
     assert losses["n"] == 3  # it really did lose three times

--- a/src/backend/tests/community/repository/platform/test_task_queue_repository.py
+++ b/src/backend/tests/community/repository/platform/test_task_queue_repository.py
@@ -625,7 +625,7 @@ def test_holder_going_terminal_between_insert_and_lookup_is_retried(repo):
     in that window, releasing the key. The retry then inserts cleanly."""
     first = _enqueue_result(repo, idempotency_key="k1")
     writer = repo._pending_writer
-    real_find = writer._find_active_by_key
+    real_find = writer._find_key_holder_current
 
     def free_the_key_then_look(session, **kwargs):
         # Simulate the holder finishing the instant after our INSERT lost.
@@ -638,10 +638,10 @@ def test_holder_going_terminal_between_insert_and_lookup_is_retried(repo):
             },
             synchronize_session=False,
         )
-        writer._find_active_by_key = real_find
+        writer._find_key_holder_current = real_find
         return real_find(session, **kwargs)
 
-    writer._find_active_by_key = free_the_key_then_look
+    writer._find_key_holder_current = free_the_key_then_look
 
     second = _enqueue_result(repo, idempotency_key="k1")
     assert second.created is True  # second attempt inserted
@@ -655,7 +655,9 @@ def test_enqueue_raises_when_it_can_neither_insert_nor_resolve_a_holder(repo):
     one — the key looks free on every retry and another caller keeps winning."""
     _enqueue_result(repo, idempotency_key="k1")
     # A holder that is never found: every attempt conflicts, every lookup misses.
-    repo._pending_writer._find_active_by_key = lambda _session, **_kwargs: None
+    repo._pending_writer._find_key_holder_current = (
+        lambda _session, **_kwargs: None
+    )
 
     with pytest.raises(RuntimeError, match="taken and released by other callers"):
         _enqueue_result(repo, idempotency_key="k1")


### PR DESCRIPTION
## Problem

A future Publication or Materialization Unit of Work must persist its domain facts and the corresponding ac_task_queue row in one database transaction. The existing TaskQueueRepository.enqueue owns a separate session, so calling it after freezing a Draft or creating an Attempt would leave a commit gap. Adding a session parameter to the public TaskQueueService would leak persistence concerns into every adopter.

## Solution

- extract TaskQueuePendingRowWriter as the TaskQueue-owned session-bound insert seam
- keep TaskQueueModel construction, payload JSON serialization, DB-clock run_at/deadline_at, env/app, and active-only idempotency inside that writer
- never commit or roll back the caller-owned outer transaction
- isolate a keyed INSERT conflict with a nested SAVEPOINT so unrelated Draft/Attempt/Version facts are not rolled back
- resolve the conflicting holder with one SELECT FOR UPDATE current read and populate_existing, preserving correctness under MySQL/OceanBase REPEATABLE READ even when the outer UoW already has an older snapshot
- keep live-holder join, terminal stranded-key failure, released-key retry budget, length/whitespace rules, and binary-collation scope behavior
- make ordinary TaskQueueRepository.enqueue reuse the writer inside transactional_orm_session
- leave TaskQueueService.enqueue unchanged; it still wakes only after Repository commit and only for newly-created, due-now, opted-in task types

No Publication task type, handler, Publication Application Service, or Materialization flow is implemented.

## Validation

- TDD integration tests prove business fact plus queue row commit and roll back atomically
- tests prove a duplicate SAVEPOINT preserves outer business facts and active-only idempotency inside one session
- MySQL dialect contract test asserts the conflict lookup renders FOR UPDATE and refreshes existing ORM state
- 196 focused TaskQueue, Repository, DI, and existing adopter tests passed
- 372 architecture plus focused tests passed
- targeted Ruff, Python SAST, compileall, and git diff checks passed
- Standards review: passed after closing the REPEATABLE READ stale-snapshot finding
- Spec review: passed after current-read and legacy cross-app behavior verification

The expensive Backend full suite remains deferred to the one final four-PR integration gate.

## Compatibility and risk

TaskQueueService.enqueue has no session argument and no caller changes. TaskQueueRepositoryProtocol is unchanged. Existing queue rows, schema, task types, payloads, worker claim behavior, active-key indexes, and wake policy are unchanged.

Ordinary enqueue now uses the real transactional ORM context instead of the prod AUTOCOMMIT context so nested SAVEPOINT behavior is portable. The returned EnqueueResult remains identical. The locking read occurs only after a real active-key conflict and is released with the caller-owned transaction.

Rollback is local: restore the Repository-owned insert body and remove the additive pending-row writer; there is no schema or wire migration.

## Spec

Implements the finalized Publication and Task Queue atomic transaction seam from section 7.5 of the Phase 2 runtime product research ledger and records only that internal seam in src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md.