### PR TITLE
feat(bcs): friend-connect notification names + bot-owner applicant id

### DIFF
--- a/src/bcs/crates/bootstrap/bcs/src/friend_connect_notification.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/friend_connect_notification.rs
@@ -173,25 +173,35 @@ fn notification_kind_label(kind: FriendConnectNotificationKind) -> &'static str 
 
 fn title_for(kind: FriendConnectNotificationKind) -> &'static str {
     match kind {
-        FriendConnectNotificationKind::ApprovalRequested => "好友添加申请待审批",
-        FriendConnectNotificationKind::AutoApproved => "好友添加申请已自动通过",
-        FriendConnectNotificationKind::Reviewed => "好友添加申请已处理",
+        FriendConnectNotificationKind::ApprovalRequested => "好友申请待审批",
+        FriendConnectNotificationKind::AutoApproved => "好友申请已自动通过",
+        FriendConnectNotificationKind::Reviewed => "好友申请已处理",
     }
 }
 
 fn content_for(command: &FriendConnectNotificationCommand) -> String {
+    // Prefer the resolved display names (a human nick name / a bot name); fall
+    // back to the raw actor ids when a name could not be resolved.
+    let applicant = command
+        .applicant_name
+        .as_deref()
+        .unwrap_or(&command.applicant_actor_id);
+    let target = command
+        .target_bot_name
+        .as_deref()
+        .unwrap_or(&command.target_bot_id);
     match command.kind {
         FriendConnectNotificationKind::ApprovalRequested => format!(
-            "{} 申请添加 Bot {} 为好友，请在好友申请列表中处理。",
-            command.applicant_actor_id, command.target_bot_id
+            "{}申请添加你的 Bot「{}」为好友，请及时处理。",
+            applicant, target
         ),
         FriendConnectNotificationKind::AutoApproved => format!(
-            "{} 与 Bot {} 的好友申请已自动通过。",
-            command.applicant_actor_id, command.target_bot_id
+            "{}与 Bot「{}」的好友申请已自动通过。",
+            applicant, target
         ),
         FriendConnectNotificationKind::Reviewed => format!(
-            "{} 与 Bot {} 的好友申请已处理。",
-            command.applicant_actor_id, command.target_bot_id
+            "{}与 Bot「{}」的好友申请已处理。",
+            applicant, target
         ),
     }
 }
@@ -237,7 +247,10 @@ impl FriendWorkOrderEventRequest {
         let biz_data = serde_json::to_value(biz_data).expect("friend work-order biz_data json");
         let (applicant_user_id, approver_user_ids, recipient_user_ids) = match command.kind {
             FriendConnectNotificationKind::ApprovalRequested => (
-                applicant_user_id(&command.applicant_actor_id)
+                command
+                    .applicant_user_id
+                    .clone()
+                    .or_else(|| applicant_user_id(&command.applicant_actor_id))
                     .or_else(|| Some(command.applicant_actor_id.clone())),
                 command.recipient_user_ids.clone(),
                 Vec::new(),
@@ -353,6 +366,9 @@ mod tests {
                 recipient_user_ids: Vec::new(),
                 message: Some("ignored".to_string()),
                 request_auth: None,
+                applicant_name: None,
+                target_bot_name: None,
+                applicant_user_id: None,
             })
             .await
             .expect("empty recipients should short-circuit");
@@ -381,6 +397,9 @@ mod tests {
             recipient_user_ids: vec!["user_2001".to_string()],
             message: Some("please add me".to_string()),
             request_auth: Some(request_auth.clone()),
+            applicant_name: None,
+            target_bot_name: None,
+            applicant_user_id: None,
         };
         let payload = FriendWorkOrderEventRequest::from_command(&command);
         let request = adapter
@@ -414,6 +433,9 @@ mod tests {
                 recipient_user_ids: vec!["user_2001".to_string()],
                 message: Some("please add me".to_string()),
                 request_auth: None,
+                applicant_name: None,
+                target_bot_name: None,
+                applicant_user_id: None,
             })
             .await;
         assert!(matches!(result, Err(ServiceError::InternalError(message)) if message.contains("friend work-order create request failed")));
@@ -430,6 +452,9 @@ mod tests {
             recipient_user_ids: vec!["user_2001".to_string()],
             message: Some("please add me".to_string()),
             request_auth: None,
+            applicant_name: None,
+            target_bot_name: None,
+            applicant_user_id: None,
         });
         let url = reqwest::Url::parse(
             "https://backend.example.com/api/v1/work-orders/events",
@@ -445,6 +470,9 @@ mod tests {
             recipient_user_ids: vec!["user_2001".to_string()],
             message: Some("please add me".to_string()),
             request_auth: None,
+            applicant_name: None,
+            target_bot_name: None,
+            applicant_user_id: None,
         };
         let error = friend_work_order_non_success_error(
             reqwest::StatusCode::UNPROCESSABLE_ENTITY,
@@ -462,7 +490,7 @@ mod tests {
         assert_eq!(
             logged_payload["content"],
             serde_json::json!({
-                "text": "human_1001 申请添加 Bot bot_2001 为好友，请在好友申请列表中处理。"
+                "text": "human_1001申请添加你的 Bot「bot_2001」为好友，请及时处理。"
             })
         );
         assert_eq!(logged_payload["approver_user_ids"], serde_json::json!(["user_2001"]));
@@ -479,6 +507,9 @@ mod tests {
             recipient_user_ids: vec!["user_2001".to_string()],
             message: Some("please add me".to_string()),
             request_auth: None,
+            applicant_name: None,
+            target_bot_name: None,
+            applicant_user_id: None,
         });
 
         assert_eq!(payload.event_category, "APPROVAL");
@@ -489,11 +520,11 @@ mod tests {
         assert_eq!(payload.apply_reason.as_deref(), Some("please add me"));
         assert_eq!(payload.approver_user_ids, vec!["user_2001".to_string()]);
         assert!(payload.recipient_user_ids.is_empty());
-        assert_eq!(payload.title, "好友添加申请待审批");
+        assert_eq!(payload.title, "好友申请待审批");
         assert_eq!(
             payload.content,
             Some(serde_json::json!({
-                "text": "human_1001 申请添加 Bot bot_2001 为好友，请在好友申请列表中处理。"
+                "text": "human_1001申请添加你的 Bot「bot_2001」为好友，请及时处理。"
             }))
         );
         assert_eq!(
@@ -519,6 +550,9 @@ mod tests {
             recipient_user_ids: vec!["user_2001".to_string()],
             message: Some("please add me".to_string()),
             request_auth: None,
+            applicant_name: None,
+            target_bot_name: None,
+            applicant_user_id: None,
         });
 
         let serialized = serde_json::to_value(&payload).expect("serialize payload");
@@ -526,7 +560,7 @@ mod tests {
         assert_eq!(
             serialized["content"],
             serde_json::json!({
-                "text": "human_1001 申请添加 Bot bot_2001 为好友，请在好友申请列表中处理。"
+                "text": "human_1001申请添加你的 Bot「bot_2001」为好友，请及时处理。"
             })
         );
         assert_eq!(
@@ -547,6 +581,9 @@ mod tests {
             recipient_user_ids: vec!["user_2001".to_string()],
             message: None,
             request_auth: None,
+            applicant_name: None,
+            target_bot_name: None,
+            applicant_user_id: None,
         });
 
         assert_eq!(payload.event_category, "NOTICE");
@@ -554,7 +591,7 @@ mod tests {
         assert_eq!(payload.applicant_user_id, None);
         assert!(payload.approver_user_ids.is_empty());
         assert_eq!(payload.recipient_user_ids, vec!["user_2001".to_string()]);
-        assert_eq!(payload.title, "好友添加申请已自动通过");
+        assert_eq!(payload.title, "好友申请已自动通过");
     }
 
     #[test]
@@ -568,19 +605,24 @@ mod tests {
             recipient_user_ids: vec!["user_2001".to_string()],
             message: Some("bot-to-bot".to_string()),
             request_auth: None,
+            applicant_name: None,
+            target_bot_name: None,
+            applicant_user_id: Some("152819".to_string()),
         });
 
         assert_eq!(payload.event_category, "APPROVAL");
         assert_eq!(payload.event_type, "BOT2BOT_FRIEND_APPLIED");
-        assert_eq!(payload.applicant_user_id.as_deref(), Some("bot_1001"));
+        // bot→bot: applicant_user_id is the initiating bot's OWNER (user id),
+        // not the bot id (the backend rejects a bot id as not matching the user).
+        assert_eq!(payload.applicant_user_id.as_deref(), Some("152819"));
         assert_eq!(payload.approver_user_ids, vec!["user_2001".to_string()]);
         assert!(payload.recipient_user_ids.is_empty());
-        assert_eq!(payload.title, "好友添加申请待审批");
+        assert_eq!(payload.title, "好友申请待审批");
         assert_eq!(payload.apply_reason.as_deref(), Some("bot-to-bot"));
         assert_eq!(
             payload.content,
             Some(serde_json::json!({
-                "text": "bot_1001 申请添加 Bot bot_2001 为好友，请在好友申请列表中处理。"
+                "text": "bot_1001申请添加你的 Bot「bot_2001」为好友，请及时处理。"
             }))
         );
     }
@@ -596,6 +638,9 @@ mod tests {
             recipient_user_ids: vec!["user_2001".to_string()],
             message: Some("handled".to_string()),
             request_auth: None,
+            applicant_name: None,
+            target_bot_name: None,
+            applicant_user_id: None,
         });
 
         assert_eq!(payload.event_category, "NOTICE");
@@ -603,12 +648,12 @@ mod tests {
         assert_eq!(payload.applicant_user_id, None);
         assert!(payload.approver_user_ids.is_empty());
         assert_eq!(payload.recipient_user_ids, vec!["user_2001".to_string()]);
-        assert_eq!(payload.title, "好友添加申请已处理");
+        assert_eq!(payload.title, "好友申请已处理");
         assert_eq!(payload.apply_reason.as_deref(), Some("handled"));
         assert_eq!(
             payload.content,
             Some(serde_json::json!({
-                "text": "human_1001 与 Bot bot_2001 的好友申请已处理。"
+                "text": "human_1001与 Bot「bot_2001」的好友申请已处理。"
             }))
         );
     }
@@ -628,5 +673,76 @@ mod tests {
     fn applicant_user_id_handles_non_human_actor() {
         assert_eq!(applicant_user_id("bot_1001"), None);
         assert_eq!(applicant_user_id("human_"), None);
+    }
+
+    #[test]
+    fn approval_requested_content_uses_resolved_names() {
+        let payload = FriendWorkOrderEventRequest::from_command(&FriendConnectNotificationCommand {
+            kind: FriendConnectNotificationKind::ApprovalRequested,
+            env: "dev".to_string(),
+            request_ids: vec!["1".to_string()],
+            applicant_actor_id: "human_447147".to_string(),
+            target_bot_id: "20260828_eeua0r54:330429".to_string(),
+            recipient_user_ids: vec!["447147".to_string()],
+            message: None,
+            request_auth: None,
+            applicant_name: Some("李四".to_string()),
+            target_bot_name: Some("本地代码专家".to_string()),
+            applicant_user_id: None,
+        });
+        assert_eq!(payload.title, "好友申请待审批");
+        assert_eq!(
+            payload.content,
+            Some(serde_json::json!({
+                "text": "李四申请添加你的 Bot「本地代码专家」为好友，请及时处理。"
+            }))
+        );
+    }
+
+    #[test]
+    fn approval_requested_content_falls_back_per_field_when_partially_resolved() {
+        let payload = FriendWorkOrderEventRequest::from_command(&FriendConnectNotificationCommand {
+            kind: FriendConnectNotificationKind::ApprovalRequested,
+            env: "dev".to_string(),
+            request_ids: vec!["1".to_string()],
+            applicant_actor_id: "human_447147".to_string(),
+            target_bot_id: "bot_2001".to_string(),
+            recipient_user_ids: vec!["447147".to_string()],
+            message: None,
+            request_auth: None,
+            applicant_name: Some("李四".to_string()),
+            target_bot_name: None,
+            applicant_user_id: None,
+        });
+        assert_eq!(
+            payload.content,
+            Some(serde_json::json!({
+                "text": "李四申请添加你的 Bot「bot_2001」为好友，请及时处理。"
+            }))
+        );
+    }
+
+    #[test]
+    fn auto_approved_content_uses_resolved_names() {
+        let payload = FriendWorkOrderEventRequest::from_command(&FriendConnectNotificationCommand {
+            kind: FriendConnectNotificationKind::AutoApproved,
+            env: "dev".to_string(),
+            request_ids: vec!["2".to_string()],
+            applicant_actor_id: "human_447147".to_string(),
+            target_bot_id: "bot_2001".to_string(),
+            recipient_user_ids: vec!["447147".to_string()],
+            message: None,
+            request_auth: None,
+            applicant_name: Some("李四".to_string()),
+            target_bot_name: Some("本地代码专家".to_string()),
+            applicant_user_id: None,
+        });
+        assert_eq!(payload.title, "好友申请已自动通过");
+        assert_eq!(
+            payload.content,
+            Some(serde_json::json!({
+                "text": "李四与 Bot「本地代码专家」的好友申请已自动通过。"
+            }))
+        );
     }
 }

--- a/src/bcs/crates/contracts/bcs-domain/src/edge_permission.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/edge_permission.rs
@@ -273,6 +273,8 @@ pub struct AuthzContext {
 pub struct BotActorConfig {
     pub bot_id: String,
     pub env: String,
+    /// Bot display name (`bcs_bots.name`); used in friend-connect notifications.
+    pub name: String,
     /// `public` | `protected` | `private`.
     pub visibility: String,
     /// `online` | `hidden` — `hidden` ⇒ admission rejects (spec §4.3).

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/friend_connect_notification.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/friend_connect_notification.rs
@@ -25,6 +25,16 @@ pub struct FriendConnectNotificationCommand {
     pub recipient_user_ids: Vec<String>,
     pub message: Option<String>,
     pub request_auth: Option<RequestAuthHeaders>,
+    /// Resolved display name of the applicant (a human nick name or a bot
+    /// name). When `None`, the adapter falls back to `applicant_actor_id`.
+    pub applicant_name: Option<String>,
+    /// Resolved display name of the target bot. When `None`, the adapter
+    /// falls back to `target_bot_id`.
+    pub target_bot_name: Option<String>,
+    /// Resolved `applicant_user_id` to send to the backend work-order API.
+    /// For a bot applicant this is the bot's owner (`created_by`); for a human
+    /// applicant it is left `None` and the adapter strips `human_` to a staff_no.
+    pub applicant_user_id: Option<String>,
 }
 
 #[async_trait]

--- a/src/bcs/crates/services/bcs-edge-permission-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-edge-permission-store/src/lib.rs
@@ -995,7 +995,7 @@ impl DbBotActorConfigStore {
     /// SELECT the decision columns for `(bot_uuid, env)`. Excludes soft-deleted
     /// rows, mirroring the bot store read (`COALESCE(is_deleted, 0) = 0`).
     const SELECT_BOT_CONFIG_SQL: &'static str =
-        "SELECT bot_uuid, env, visibility, user_visibility, bot_info, status, created_by \
+        "SELECT bot_uuid, env, name, visibility, user_visibility, bot_info, status, created_by \
          FROM bcs_bots \
          WHERE bot_uuid = ? AND env = ? AND COALESCE(is_deleted, 0) = 0 LIMIT 1";
 }
@@ -1174,6 +1174,7 @@ fn row_to_bot_actor_config(row: &DbRow) -> ServiceResult<BotActorConfig> {
     Ok(BotActorConfig {
         bot_id: required_string(row, "bot_uuid")?,
         env: required_string(row, "env")?,
+        name: required_string(row, "name")?,
         visibility: required_string(row, "visibility")?,
         status: required_string(row, "status")?,
         created_by: optional_string(row, "created_by")?,
@@ -1796,6 +1797,7 @@ mod tests {
             "CREATE TABLE bcs_bots (\
                 bot_uuid TEXT NOT NULL, \
                 env TEXT NOT NULL, \
+                name TEXT NOT NULL DEFAULT '', \
                 visibility TEXT NOT NULL DEFAULT 'public', \
                 user_visibility TEXT NOT NULL DEFAULT 'protected', \
                 bot_info TEXT DEFAULT NULL, \
@@ -1854,11 +1856,12 @@ mod tests {
                 "seed_bot",
                 DbStatement::with_params(
                     "INSERT INTO bcs_bots \
-                     (bot_uuid, env, visibility, user_visibility, bot_info, status, created_by) \
-                     VALUES (?, ?, ?, ?, ?, ?, ?)",
+                     (bot_uuid, env, name, visibility, user_visibility, bot_info, status, created_by) \
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                     vec![
                         DbValue::from(bot_uuid),
                         DbValue::from(env),
+                        DbValue::from(bot_uuid),
                         DbValue::from(visibility),
                         DbValue::from(user_visibility),
                         DbValue::from(serde_json::to_string(&bot_info).expect("bot_info json")),
@@ -1895,6 +1898,7 @@ mod tests {
             .expect("bot exists");
         assert_eq!(cfg.bot_id, "20260421_x:85020");
         assert_eq!(cfg.env, "dev");
+        assert_eq!(cfg.name, "20260421_x:85020");
         assert_eq!(cfg.visibility, "public");
         assert_eq!(cfg.user_visibility, "protected");
         assert_eq!(cfg.friend_check_in_strategy, "APPROVAL");

--- a/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
+++ b/src/bcs/crates/services/bcs-edge-permission/src/lib.rs
@@ -786,6 +786,24 @@ impl DbConnectService {
         if recipient_user_ids.is_empty() {
             return Ok(());
         }
+        // Resolve human-readable display names so the notification body says
+        // "李四 申请添加你的 Bot「本地代码专家」…" instead of raw actor ids. Falls
+        // back to None (the adapter then renders the actor id) on any miss.
+        let applicant_name = self.resolve_actor_display_name(applicant_actor_id).await;
+        let target_bot_name = self.resolve_actor_display_name(target_bot_id).await;
+        // For a bot applicant the backend work-order API expects the applicant's
+        // HUMAN owner (the bot's `created_by`) as `applicant_user_id`, not the
+        // bot id (which the backend rejects as not matching the acting user).
+        // Human applicants leave this `None` — the adapter strips `human_` to a
+        // staff_no.
+        let applicant_user_id = if actor_kind_of(applicant_actor_id) == ActorKind::Bot {
+            self.bot_config
+                .get(applicant_actor_id, &self.env)
+                .await
+                .and_then(|cfg| cfg.created_by)
+        } else {
+            None
+        };
         self.friend_connect_notification
             .notify(FriendConnectNotificationCommand {
                 kind,
@@ -796,8 +814,40 @@ impl DbConnectService {
                 recipient_user_ids,
                 message: message.map(ToOwned::to_owned),
                 request_auth,
+                applicant_name,
+                target_bot_name,
+                applicant_user_id,
             })
             .await
+    }
+
+    /// Resolve a display name for an actor id: a human's nick name (via the user
+    /// directory) or a bot's `name` (from its control-plane config). Returns
+    /// `None` when no directory is wired, the staff_no is absent, the lookup
+    /// misses, or the bot/config is unknown — callers fall back to the raw id.
+    async fn resolve_actor_display_name(&self, actor_id: &str) -> Option<String> {
+        match actor_kind_of(actor_id) {
+            ActorKind::Human => {
+                let user_directory = self.user_directory.as_ref()?;
+                let staff_no = actor_id
+                    .strip_prefix("human_")
+                    .filter(|staff_no| !staff_no.is_empty())?;
+                let profile = user_directory
+                    .lookup_by_staff_no(staff_no)
+                    .await
+                    .ok()
+                    .flatten()?;
+                profile.nick_name.filter(|name| !name.is_empty())
+            }
+            ActorKind::Bot => {
+                let name = self.bot_config.get(actor_id, &self.env).await?.name;
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(name)
+                }
+            }
+        }
     }
 
     /// Find pending `Connect` requests from `from` → `to` in this env.
@@ -1396,6 +1446,7 @@ mod tests {
             "CREATE TABLE bcs_bots (\
                 bot_uuid TEXT NOT NULL, \
                 env TEXT NOT NULL, \
+                name TEXT NOT NULL DEFAULT '', \
                 visibility TEXT NOT NULL DEFAULT 'public', \
                 user_visibility TEXT NOT NULL DEFAULT 'protected', \
                 bot_info TEXT DEFAULT NULL, \
@@ -1458,6 +1509,32 @@ mod tests {
             staff_no: &str,
         ) -> Result<Option<String>, bcs_user_directory_api::UserDirectoryError> {
             Ok(self.departments.get(staff_no).cloned())
+        }
+    }
+
+    /// User-directory stub that returns a fixed nick name for any staff_no —
+    /// used to verify friend-connect notifications resolve the applicant's name.
+    struct FixedNickUserDirectoryPlugin {
+        nick: String,
+    }
+
+    #[async_trait]
+    impl UserDirectoryPlugin for FixedNickUserDirectoryPlugin {
+        async fn lookup_by_staff_no(
+            &self,
+            staff_no: &str,
+        ) -> Result<Option<bcs_user_directory_api::UserDirectoryProfile>, bcs_user_directory_api::UserDirectoryError> {
+            Ok(Some(bcs_user_directory_api::UserDirectoryProfile {
+                staff_no: staff_no.to_string(),
+                nick_name: Some(self.nick.clone()),
+            }))
+        }
+
+        async fn lookup_department_by_staff_no(
+            &self,
+            _staff_no: &str,
+        ) -> Result<Option<String>, bcs_user_directory_api::UserDirectoryError> {
+            Ok(None)
         }
     }
 
@@ -1614,9 +1691,10 @@ mod tests {
         });
         db.execute(DbStatement::with_params(
             "INSERT INTO bcs_bots \
-             (bot_uuid, env, visibility, user_visibility, bot_info, status, created_by) \
-             VALUES (?, 'dev', ?, ?, ?, ?, ?)",
+             (bot_uuid, env, name, visibility, user_visibility, bot_info, status, created_by) \
+             VALUES (?, 'dev', ?, ?, ?, ?, ?, ?)",
             vec![
+                DbValue::from(bot_uuid),
                 DbValue::from(bot_uuid),
                 DbValue::from(visibility),
                 DbValue::from(user_visibility),
@@ -2178,6 +2256,90 @@ mod tests {
         assert_eq!(event.recipient_user_ids, vec!["85020".to_string()]);
         assert_eq!(event.message.as_deref(), Some("hi"));
         assert_eq!(event.request_auth, Some(request_auth));
+    }
+
+    #[tokio::test]
+    async fn friend_connect_notification_resolves_applicant_and_target_names() {
+        let (eg, pp, rq, bc, db) = assemble().await;
+        // Target bot: seed (default name = bot_uuid) then set a human-friendly name.
+        seed_bot(&db, "x:expert", "protected", "public", "APPROVAL", "online", Some("85020")).await;
+        db.execute(DbStatement::with_params(
+            "UPDATE bcs_bots SET name = ? WHERE bot_uuid = ?",
+            vec![DbValue::from("本地代码专家"), DbValue::from("x:expert")],
+        ))
+        .await
+        .expect("set target bot name");
+        let recorder = RecordingFriendConnectNotificationPort::default();
+        let events = recorder.events.clone();
+        let user_directory: Arc<dyn UserDirectoryPlugin> =
+            Arc::new(FixedNickUserDirectoryPlugin { nick: "李四".to_string() });
+        let svc = DbConnectService::new(
+            eg.clone(),
+            pp.clone(),
+            rq.clone(),
+            bc.clone(),
+            Some(user_directory),
+            Arc::new(recorder),
+            "dev".to_string(),
+        );
+        // Human applicant (nick 李四) → bot "本地代码专家" (owner 85020); APPROVAL → pending.
+        svc.create_connect("human_12345", "x:expert", None, None)
+            .await
+            .expect("manual pending connect");
+        let events = events.lock().await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, FriendConnectNotificationKind::ApprovalRequested);
+        // applicant nick resolved via the user directory; target name via bot config.
+        assert_eq!(events[0].applicant_name.as_deref(), Some("李四"));
+        assert_eq!(events[0].target_bot_name.as_deref(), Some("本地代码专家"));
+        assert_eq!(events[0].recipient_user_ids, vec!["85020".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn friend_connect_notification_falls_back_when_user_directory_absent() {
+        let (eg, pp, rq, bc, db) = assemble().await;
+        // No UPDATE → name stays the seed default (= bot_uuid).
+        seed_bot(&db, "x:noexp", "protected", "public", "APPROVAL", "online", Some("85020")).await;
+        let recorder = RecordingFriendConnectNotificationPort::default();
+        let events = recorder.events.clone();
+        // service_with_notification wires user_directory = None.
+        let svc = service_with_notification(&eg, &pp, &rq, &bc, Arc::new(recorder));
+        svc.create_connect("human_12345", "x:noexp", None, None)
+            .await
+            .expect("manual pending connect");
+        let events = events.lock().await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].applicant_name,
+            None,
+            "no user directory → applicant name unresolved (falls back to id)"
+        );
+        // Target name still resolves from the bot's config (seed default = bot_uuid).
+        assert_eq!(events[0].target_bot_name.as_deref(), Some("x:noexp"));
+    }
+
+    #[tokio::test]
+    async fn friend_connect_notification_uses_bot_applicant_owner_as_applicant_user_id() {
+        let (eg, pp, rq, bc, db) = assemble().await;
+        // Applicant bot owned by 152819; target bot owned by 85020.
+        seed_bot(&db, "x:applicant", "protected", "public", "APPROVAL", "online", Some("152819")).await;
+        seed_bot(&db, "x:target", "protected", "public", "APPROVAL", "online", Some("85020")).await;
+        let recorder = RecordingFriendConnectNotificationPort::default();
+        let events = recorder.events.clone();
+        let svc = service_with_notification(&eg, &pp, &rq, &bc, Arc::new(recorder));
+        // Bot→Bot pending connect (APPROVAL strategy → needs approval → ApprovalRequested).
+        svc.create_connect("x:applicant", "x:target", None, None)
+            .await
+            .expect("bot→bot manual pending connect");
+        let events = events.lock().await;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, FriendConnectNotificationKind::ApprovalRequested);
+        // applicant_user_id = the applicant bot's OWNER (user id), not the bot id.
+        assert_eq!(events[0].applicant_user_id.as_deref(), Some("152819"));
+        assert_eq!(events[0].applicant_actor_id, "x:applicant");
+        assert_eq!(events[0].target_bot_id, "x:target");
+        // Approver/recipient = the target bot's owner.
+        assert_eq!(events[0].recipient_user_ids, vec!["85020".to_string()]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
The friend-request work-order notification now resolves human-readable names and the correct applicant user id.

- BotActorConfig carries the bot `name` (read from bcs_bots.name) so the body can render "李四 申请添加你的 Bot「本地代码专家」…" instead of raw actor ids. Names are resolved at the emission site (human nick via the user directory, bot name via the control-plane config) and fall back to the actor id when unavailable; command gains applicant_name/target_bot_name.
- Title/content wording updated: ApprovalRequested title "好友申请待审批"; body "{applicant}申请添加你的 Bot「{target}」为好友，请及时处理。" with matched wording for AutoApproved/Reviewed.
- For Bot->Bot requests the backend needs the applicant's HUMAN owner, not the bot id (it rejects a bot id as not matching the identity). Resolve the initiating bot's `created_by` and send it as `applicant_user_id`; humans still strip `human_` to a staff_no; legacy bots without an owner fall back to the bot id (unchanged). approver_user_ids (= target owner) and biz_data.actor ids are untouched.

Tests: bcs-edge-permission 54, bcs friend_connect_notification 15, integration_friendship 15 — all green.

<!--
Title format: <type>(<scope>): <concise outcome>
  e.g. feat(backend): add whitelist observed state
Types: feat | fix | refactor | docs | test | ci | build | chore
The title becomes the commit message on squash merge, so make it self-contained.
See "Pull Request Conventions" in AGENTS.md.
Delete the optional sections that do not apply.
-->

## Problem

<!-- The defect, gap, or requirement, and why it matters. -->

## Solution

<!-- The approach taken, and rejected alternatives when the choice is not obvious. -->

## Validation

<!-- Tests, gates, and manual checks you ran, with results. State what you could not run and why. -->

## Compatibility and risk (optional)

<!-- Contract, schema, config, or migration impact, and the rollback path. -->

## Spec (optional)

<!-- The contract or design document this change implements. -->

## Related issues (optional)

<!-- Issues this closes or relates to. -->
