### PR TITLE
fix(aicoding): use MCP projection on restart

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -8,6 +8,8 @@ services.
 from __future__ import annotations
 
 import json
+from copy import deepcopy
+import threading
 import uuid
 from typing import Any, Dict
 
@@ -24,6 +26,7 @@ from agentclaw.community.core.workspace.runtime_identity import (
 
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.utils import secret_utils
+from agentclaw.community.utils.avernet_tenant import bind_current_avernet_tenant
 from agentclaw.community.log import get_logger
 
 from ..provisioning import (
@@ -52,7 +55,8 @@ LEGACY_BOT_TYPE_ENV_MAP = {
 }
 _THETA_KEY_PATH = ("bot_template_config", "ext_config", "thetaKey")
 _ENCRYPTED_VALUE_PREFIX = "enc:v1:"
-
+_AICODING_RESTART_MARKER_KEY = "_aicoding_restart"
+_AICODING_RESTART_RESYNC_KEY = "resync_authorization"
 logger = get_logger()
 
 
@@ -548,6 +552,55 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         except (TypeError, ValueError):
             return None
 
+    @staticmethod
+    def _has_restart_resync_marker(template_config: Any) -> bool:
+        if not isinstance(template_config, dict):
+            return False
+        marker = template_config.get(_AICODING_RESTART_MARKER_KEY)
+        return isinstance(marker, dict) and bool(
+            marker.get(_AICODING_RESTART_RESYNC_KEY)
+        )
+
+    @staticmethod
+    def _with_restart_resync_marker(
+        template_config: dict[str, Any], *, template_version_id: int | None
+    ) -> dict[str, Any]:
+        updated = deepcopy(template_config)
+        marker = updated.get(_AICODING_RESTART_MARKER_KEY)
+        if not isinstance(marker, dict):
+            marker = {}
+        marker[_AICODING_RESTART_RESYNC_KEY] = True
+        if template_version_id is not None:
+            marker["template_version_id"] = template_version_id
+        marker.setdefault("source", "restart_template_update")
+        updated[_AICODING_RESTART_MARKER_KEY] = marker
+        return updated
+
+    @staticmethod
+    def _clear_restart_resync_marker(
+        ctx: BotProvisioningContext, *, template_service: Any
+    ) -> None:
+        if template_service is None:
+            return
+        current = template_service.get_template_config(ctx.bot_id)
+        if (
+            not isinstance(current, dict)
+            or not AicodingProvisioningStrategy._has_restart_resync_marker(current)
+        ):
+            return
+        updated = deepcopy(current)
+        updated.pop(_AICODING_RESTART_MARKER_KEY, None)
+        template_service.update_template(
+            bot_id=ctx.bot_id,
+            template_config=updated,
+            template_type=ctx.template_type,
+            active_engine=ctx.active_engine,
+        )
+        logger.info(
+            "[aicoding.restart] cleared persisted restart resync marker: bot_id=%s",
+            ctx.bot_id,
+        )
+
     def apply_restart_extra_configs(
         self,
         ctx: BotProvisioningContext,
@@ -573,18 +626,25 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         if stored_version is not None and incoming_version <= stored_version:
             return
 
+        persisted_config = candidate
+        if extra_configs.get("confirmed_template_update"):
+            persisted_config = self._with_restart_resync_marker(
+                candidate, template_version_id=incoming_version
+            )
+
         template_service.update_template(
             bot_id=ctx.bot_id,
-            template_config=candidate,
+            template_config=persisted_config,
             template_type=ctx.template_type,
             active_engine=ctx.active_engine,
         )
         logger.info(
             "[aicoding.restart] persisted newer template snapshot: "
-            "bot_id=%s old_version=%s new_version=%s",
+            "bot_id=%s old_version=%s new_version=%s resync_marker=%s",
             ctx.bot_id,
             stored_version,
             incoming_version,
+            persisted_config is not candidate,
         )
 
     def refresh_restart_authorization(
@@ -593,128 +653,158 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         bot: Dict[str, Any],
         extra_configs: Dict[str, Any] | None,
         *,
-        passport_plugin: Any,
-        skill_set_factory: Any,
-        template_service: Any,
-        caller_identity_repo: Any,
-    ) -> None:
-        """Refresh this bot's Passport authorization scope on restart.
+        mcp_sync: Any = None,
+        skill_set_factory: Any = None,
+        template_service: Any = None,
+    ) -> bool:
+        """Refresh AICoding restart authorization and runtime skill symlinks.
 
-        Mirrors the create-time passport scope (``create_flow._apply_passport``)
-        so an ``aicoding`` / ``claude_code`` bot keeps the same MCP + CLI grants
-        after a restart: recompute the passport MCP codes and the engine default
-        CLI items, then push them to Passport via ``update_passport`` as a full
-        ``resource_scope`` snapshot (Passport treats each resource list as a
-        full replacement). Best-effort: failures are logged by the caller and
-        must not block the restart.
-
-        Opt-in: only runs when ``extra_configs['confirmed_template_update']`` is
-        truthy — a plain restart must never silently rewrite the Passport
-        authorization scope. Anything falsy (missing key, None, false) no-ops.
-
-        The pushed scope carries each MCP's execution identity, not just its
-        code: ``resource_scope`` replaces the MCP resource list wholesale, so a
-        code-only snapshot would assert Owner for every MCP and drop the Bot's
-        Caller grants on every confirmed template update. An *unreadable*
-        identity therefore skips the refresh, leaving the existing scope
-        standing rather than replacing it with an owner-only snapshot. An
-        absent repository is not a case this handles: it is required.
+        This is intentionally AICoding-owned: only a confirmed template update
+        opts in. The refresh is fire-and-forget and best-effort so restart is
+        never blocked.
         """
-        if not (
+        should_resync = (
             isinstance(extra_configs, dict)
-            and extra_configs.get("confirmed_template_update")
-        ):
+            and bool(extra_configs.get("confirmed_template_update"))
+        ) or self._has_restart_resync_marker(ctx.template_config)
+        if not should_resync:
             logger.info(
-                "[aicoding.restart] skip passport refresh: "
+                "[aicoding.restart] skip authorization/runtime resync: "
                 "confirmed_template_update is not set for bot_id=%s",
                 ctx.bot_id,
             )
-            return
-        # Imported lazily: create_flow imports this module's registry, so a
-        # module-level import would cycle.
-        from agentclaw.community.core.bot_management.create_flow import (
-            _get_bot_mcp_codes,
-        )
-        from agentclaw.community.core.mcp.errors import McpIdentityUnresolvedError
-        from agentclaw.community.core.mcp.services._defaults import (
-            get_default_cli_items,
-        )
-        from agentclaw.community.core.mcp.services.passport_scope import (
-            passport_mcp_items_from_codes,
-            resolve_mcp_identity_modes,
-        )
+            return False
 
-        stored_config: Dict[str, Any] = (
-            template_service.get_template_config(ctx.bot_id) or {}
-        )
-        engine_type = ctx.active_engine or self.engine_type
-        entity_id = str(bot.get("entity_id") or "")
-        entity_type = str(bot.get("entity_type") or "staff")
-        owner_id = ctx.owner_id
+        effective_entity_id = str(bot.get("entity_id") or ctx.owner_id or "")
+        effective_entity_type = str(bot.get("entity_type") or "staff")
+        effective_engine = ctx.active_engine or self.engine_type
 
-        mcp_codes = _get_bot_mcp_codes(
-            skill_set_factory,
-            owner_id,
-            ctx.bot_id,
-            entity_id,
-            entity_type,
-            engine_type,
-        )
-        cli_items = get_default_cli_items(
-            engine_type,
-            ctx.template_type,
-            ext_info={"template_config": stored_config}
-            if stored_config
-            else None,
-        )
+        skill_set_service = None
+        if skill_set_factory is not None:
+            try:
+                skill_set_service = skill_set_factory.create(
+                    user_id=effective_entity_id,
+                    entity_id=effective_entity_id,
+                    bot_id=ctx.bot_id,
+                    entity_type=effective_entity_type,
+                    engine_type=effective_engine,
+                )
+            except Exception as skill_error:
+                logger.error(
+                    "[aicoding.restart] skill set service init error: "
+                    "bot_id=%s, engine_type=%s, error=%s",
+                    ctx.bot_id, effective_engine, skill_error,
+                    exc_info=True,
+                )
+                skill_set_service = None
 
-        try:
-            identity_modes = resolve_mcp_identity_modes(
-                caller_identity_repo,
-                bot_pk=bot.get("id"),
-                engine_type=engine_type,
-                bot_id=ctx.bot_id,
-            )
-            mcp_items = passport_mcp_items_from_codes(
-                mcp_codes, identity_modes=identity_modes
-            )
-        except (McpIdentityUnresolvedError, ValueError):
-            logger.warning(
-                "[aicoding.restart] skip passport refresh: MCP execution "
-                "identity unresolved for bot_id=%s; leaving the existing "
-                "scope in place",
-                ctx.bot_id,
-                exc_info=True,
-            )
-            return
+        def _run() -> None:
+            import asyncio
 
-        passport_plugin.update_passport(
-            bot_id=ctx.bot_id,
-            user_id=owner_id,
-            bot_name=bot.get("bot_name"),
-            bot_desc=bot.get("bot_desc"),
-            engine_type=engine_type,
-            resource_scope={
-                # Derived from the items: ``unpack_resource_scope`` ignores
-                # ``mcp_codes`` once ``mcp_items`` is present, so two
-                # independent lists could only ever drift apart.
-                "mcp_codes": [item["mcp_code"] for item in mcp_items],
-                "mcp_items": mcp_items,
-                "cli_items": cli_items,
-            },
-        )
-        caller_count = sum(
-            1 for item in mcp_items if item.get("identity_mode") == "caller"
-        )
-        logger.info(
-            "[aicoding.restart] refreshed passport authorization scope: "
-            "bot_id=%s mcp_codes=%s caller=%s owner=%s cli_items=%s",
-            ctx.bot_id,
-            mcp_codes,
-            caller_count,
-            len(mcp_items) - caller_count,
-            cli_items,
-        )
+            refresh_succeeded = True
+            if mcp_sync is not None:
+                try:
+                    async def _do_mcp_sync() -> dict | None:
+                        scope_result = await mcp_sync.refresh_mcp_scope(
+                            user_id=effective_entity_id,
+                            entity_id=effective_entity_id,
+                            bot_id=ctx.bot_id,
+                            entity_type=effective_entity_type,
+                            engine_type=effective_engine,
+                        )
+                        if not scope_result.get("success"):
+                            return scope_result
+
+                        if skill_set_service is None:
+                            logger.info(
+                                "[aicoding.restart] skip MCP projection: "
+                                "skill set service unavailable, bot_id=%s, engine_type=%s",
+                                ctx.bot_id, effective_engine,
+                            )
+                            return scope_result
+
+                        mcp_codes = skill_set_service.get_bot_mcp_codes(
+                            entity_id=effective_entity_id,
+                            bot_id=ctx.bot_id,
+                            user_id=effective_entity_id,
+                            entity_type=effective_entity_type,
+                            engine_type=effective_engine,
+                        )
+                        projection_ok = await skill_set_service.sync_mcp_projection(
+                            claimed=frozenset(mcp_codes),
+                            released=frozenset(),
+                            declared=set(mcp_codes),
+                        )
+                        if not projection_ok:
+                            return {"success": False, "error": "mcp projection failed"}
+                        return scope_result
+
+                    scope_result = asyncio.run(_do_mcp_sync())
+                    if not scope_result.get("success"):
+                        refresh_succeeded = False
+                        logger.error(
+                            "[aicoding.restart] MCP projection resync failed: "
+                            "bot_id=%s, engine_type=%s, error=%s",
+                            ctx.bot_id, effective_engine, scope_result.get("error"),
+                        )
+                    else:
+                        logger.info(
+                            "[aicoding.restart] MCP projection resync succeeded: "
+                            "bot_id=%s, engine_type=%s",
+                            ctx.bot_id, effective_engine,
+                        )
+                except Exception as mcp_error:
+                    refresh_succeeded = False
+                    logger.error(
+                        "[aicoding.restart] MCP projection resync error: "
+                        "bot_id=%s, engine_type=%s, error=%s",
+                        ctx.bot_id, effective_engine, mcp_error,
+                        exc_info=True,
+                    )
+
+            if skill_set_service is not None:
+                try:
+                    skill_synced = bool(skill_set_service.sync_runtime())
+                    if skill_synced:
+                        logger.info(
+                            "[aicoding.restart] skill symlink sync succeeded: "
+                            "bot_id=%s, engine_type=%s",
+                            ctx.bot_id, effective_engine,
+                        )
+
+                    if not skill_synced:
+                        refresh_succeeded = False
+                        logger.error(
+                            "[aicoding.restart] skill symlink sync failed: "
+                            "bot_id=%s, engine_type=%s",
+                            ctx.bot_id, effective_engine,
+                        )
+                except Exception as skill_error:
+                    refresh_succeeded = False
+                    logger.error(
+                        "[aicoding.restart] skill symlink sync error: "
+                        "bot_id=%s, engine_type=%s, error=%s",
+                        ctx.bot_id, effective_engine, skill_error,
+                        exc_info=True,
+                    )
+
+            if refresh_succeeded and should_resync and template_service is not None:
+                try:
+                    self._clear_restart_resync_marker(
+                        ctx, template_service=template_service
+                    )
+                except Exception as clear_error:
+                    logger.warning(
+                        "[aicoding.restart] clear persisted restart resync marker failed; "
+                        "bot_id=%s, engine_type=%s, error=%s",
+                        ctx.bot_id, effective_engine, clear_error,
+                        exc_info=True,
+                    )
+
+        threading.Thread(
+            target=bind_current_avernet_tenant(_run), daemon=True
+        ).start()
+        return True
 
     def on_bot_created(self, ctx: BotProvisioningContext) -> None:
         # Application-only hooks (DIMA workspace/memory/cron) intentionally stay

--- a/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
+++ b/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
@@ -1,21 +1,20 @@
-"""Unit tests for ``AicodingProvisioningStrategy.refresh_restart_authorization``.
+"""Unit tests for AICoding restart authorization refresh.
 
-These mirror the create-time passport scope (``create_flow._apply_passport``)
-so an ``aicoding`` / ``claude_code`` bot keeps the same MCP + CLI grants after a
-restart. The strategy is opt-in: only when the caller passes
-``extra_configs['confirmed_template_update']`` truthy does it recompute the
-passport MCP codes + engine default CLI items and push them to Passport as a
-full ``resource_scope`` snapshot (full replacement).
-
-Because that snapshot replaces the MCP resource list wholesale, it must carry
-each MCP's execution identity: a code-only scope asserts ``owner`` for every
-MCP and silently drops the bot's caller grants. Identity therefore gates the
-refresh: an unreadable identity declines the refresh and leaves the existing
-scope alone. The repository itself is a required argument, so "absent" is a
-type error rather than a runtime branch.
+``refresh_restart_authorization`` now owns both the opt-in decision and the
+AICoding-specific side effects:
+  * refresh MCP scope;
+  * project MCP config / mcporter state to runtime;
+  * resync ~/.claude/skills symlinks via SkillSetService.sync_runtime().
+All side effects are best-effort/fire-and-forget.
 """
 
-from unittest.mock import MagicMock, patch
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
     AicodingProvisioningStrategy,
@@ -26,15 +25,26 @@ from agentclaw.community.core.bot_management.engines.default import (
 from agentclaw.community.core.bot_management.engines.provisioning import (
     BotProvisioningContext,
 )
+from agentclaw.community.core.bot_management.engines.aicoding.restart_authorization_listener import (
+    AicodingRestartAuthorizationBaasPublishListener,
+)
+from agentclaw.community.core.events.bus import get_event_bus, reset_event_bus
+from agentclaw.community.core.events.types import BaasPublishCompletedEvent
 
-# Patch targets for the function-local imports inside
-# ``refresh_restart_authorization`` (kept local to avoid the create_flow ->
-# bot_service import cycle).
-_MCP_CODES_PATH = "agentclaw.community.core.bot_management.create_flow._get_bot_mcp_codes"
-_CLI_ITEMS_PATH = "agentclaw.community.core.mcp.services._defaults.get_default_cli_items"
+_AICODING_THREADING = "agentclaw.community.core.bot_management.engines.aicoding.strategy.threading"
 
 
-def _ctx(active_engine="claude_code"):
+class _InlineThread:
+    def __init__(self, target=None, **kwargs) -> None:
+        self.target = target
+        self.daemon = kwargs.get("daemon")
+
+    def start(self) -> None:
+        assert self.target is not None
+        self.target()
+
+
+def _ctx(active_engine: str = "claude_code") -> BotProvisioningContext:
     return BotProvisioningContext(
         bot_id="bot-1",
         owner_id="owner-1",
@@ -44,364 +54,505 @@ def _ctx(active_engine="claude_code"):
     )
 
 
-def _bot(entity_id="ent-1", entity_type="staff", bot_name="my-bot", bot_desc="d"):
+def _bot(entity_id: str = "ent-1", entity_type: str = "staff") -> dict:
     return {
-        # The primary key the identity lookup is keyed by. Every persisted bot
-        # carries one; the strategy declines rather than guessing when it does not.
-        "id": 42,
         "entity_id": entity_id,
         "entity_type": entity_type,
-        "bot_name": bot_name,
-        "bot_desc": bot_desc,
+        "bot_name": "my-bot",
+        "bot_desc": "d",
     }
 
 
-def _identity_repo(modes=None):
-    """A caller-identity repository answering with ``modes`` (default: none)."""
-    repo = MagicMock(name="caller_identity_repo")
-    repo.list_draft_call_types.return_value = modes or {}
-    return repo
-
-
-def _owner_items(*codes):
-    return [{"mcp_code": code, "identity_mode": "owner"} for code in codes]
-
-
-def _template_service(stored_config):
-    service = MagicMock()
-    service.get_template_config.return_value = stored_config
-    return service
-
-
-def _assert_skip(extra_configs):
-    """Run refresh with ``extra_configs`` and assert a complete no-op.
-
-    A no-op must not touch the template service, the MCP/CLI collectors, nor the
-    passport plugin — the gate returns before any of them are touched.
-    """
-    template_service = _template_service({"template_key": "architect"})
-    passport_plugin = MagicMock()
-    skill_set_factory = MagicMock(name="skill_set_factory")
-    strategy = AicodingProvisioningStrategy("claude_code")
-
-    with patch(_MCP_CODES_PATH) as mcp_mock, patch(_CLI_ITEMS_PATH) as cli_mock:
-        strategy.refresh_restart_authorization(
-            _ctx(),
-            _bot(),
-            extra_configs,
-            passport_plugin=passport_plugin,
-            skill_set_factory=skill_set_factory,
-            template_service=template_service,
-            caller_identity_repo=_identity_repo(),
-        )
-        template_service.get_template_config.assert_not_called()
-        mcp_mock.assert_not_called()
-        cli_mock.assert_not_called()
-        passport_plugin.update_passport.assert_not_called()
-
-
-# --------------------------------------------------------------------------- #
-# Gate / no-op branch                                                         #
-# --------------------------------------------------------------------------- #
-def test_skip_when_extra_configs_is_none():
-    _assert_skip(None)
-
-
-def test_skip_when_extra_configs_is_empty_dict():
-    _assert_skip({})
-
-
-def test_skip_when_confirmed_template_update_key_missing():
-    _assert_skip({"unrelated_key": True})
-
-
-def test_skip_when_confirmed_template_update_is_false():
-    _assert_skip({"confirmed_template_update": False})
-
-
-def test_skip_when_confirmed_template_update_is_none():
-    _assert_skip({"confirmed_template_update": None})
-
-
-def test_skip_when_extra_configs_is_not_a_dict():
-    # A non-dict envelope (str / list / bool) must also no-op without raising.
-    for extra_configs in ("confirmed_template_update=true", ["confirmed"], True):
-        _assert_skip(extra_configs)
-
-
-# --------------------------------------------------------------------------- #
-# Active branch: opt-in confirmed                                             #
-# --------------------------------------------------------------------------- #
-def _do_refresh(
-    stored_config,
-    active_engine="claude_code",
-    strategy_engine="claude_code",
-    identity_repo=None,
-):
-    """Run refresh with the opt-in flag set; return all collaborators + mocks."""
-    ctx = _ctx(active_engine=active_engine)
-    bot = _bot()
-    template_service = _template_service(stored_config)
-    passport_plugin = MagicMock()
-    skill_set_factory = MagicMock(name="skill_set_factory")
-    caller_identity_repo = identity_repo or _identity_repo()
-    strategy = AicodingProvisioningStrategy(strategy_engine)
-
-    with patch(_MCP_CODES_PATH, return_value=["mcp-a", "mcp-b"]) as mcp_mock, \
-            patch(_CLI_ITEMS_PATH, return_value=["cli-1"]) as cli_mock:
-        strategy.refresh_restart_authorization(
-            ctx,
-            bot,
-            {"confirmed_template_update": True},
-            passport_plugin=passport_plugin,
-            skill_set_factory=skill_set_factory,
-            template_service=template_service,
-            caller_identity_repo=caller_identity_repo,
-        )
-    return {
-        "ctx": ctx,
-        "bot": bot,
-        "template_service": template_service,
-        "passport_plugin": passport_plugin,
-        "skill_set_factory": skill_set_factory,
-        "caller_identity_repo": caller_identity_repo,
-        "mcp_mock": mcp_mock,
-        "cli_mock": cli_mock,
-    }
-
-
-def test_active_updates_passport_with_full_resource_scope():
-    r = _do_refresh({"template_key": "architect"})
-
-    r["template_service"].get_template_config.assert_called_once_with("bot-1")
-    r["mcp_mock"].assert_called_once_with(
-        r["skill_set_factory"], "owner-1", "bot-1", "ent-1", "staff", "claude_code"
-    )
-    r["cli_mock"].assert_called_once_with(
-        "claude_code", "architect",
-        ext_info={"template_config": {"template_key": "architect"}},
-    )
-    r["passport_plugin"].update_passport.assert_called_once_with(
-        bot_id="bot-1",
-        user_id="owner-1",
-        bot_name="my-bot",
-        bot_desc="d",
-        engine_type="claude_code",
-        resource_scope={
-            "mcp_codes": ["mcp-a", "mcp-b"],
-            "mcp_items": _owner_items("mcp-a", "mcp-b"),
-            "cli_items": ["cli-1"],
-        },
-    )
-
-
-def test_active_passes_ext_info_none_when_stored_config_is_none():
-    # template_service.get_template_config -> None  =>  stored_config = {}
-    r = _do_refresh(None)
-    r["cli_mock"].assert_called_once_with(
-        "claude_code", "architect", ext_info=None,
-    )
-    r["passport_plugin"].update_passport.assert_called_once()
-
-
-def test_active_passes_ext_info_none_when_stored_config_is_empty_dict():
-    r = _do_refresh({})
-    r["cli_mock"].assert_called_once_with(
-        "claude_code", "architect", ext_info=None,
-    )
-    r["passport_plugin"].update_passport.assert_called_once()
-
-
-def test_active_uses_strategy_engine_type_when_ctx_active_engine_is_none():
-    r = _do_refresh(
-        {"template_key": "architect"},
-        active_engine=None,
-        strategy_engine="aicoding",
-    )
-    r["mcp_mock"].assert_called_once_with(
-        r["skill_set_factory"], "owner-1", "bot-1", "ent-1", "staff", "aicoding"
-    )
-    r["cli_mock"].assert_called_once_with(
-        "aicoding", "architect", ext_info={"template_config": {"template_key": "architect"}},
-    )
-    r["passport_plugin"].update_passport.assert_called_once_with(
-        bot_id="bot-1",
-        user_id="owner-1",
-        bot_name="my-bot",
-        bot_desc="d",
-        engine_type="aicoding",
-        resource_scope={
-            "mcp_codes": ["mcp-a", "mcp-b"],
-            "mcp_items": _owner_items("mcp-a", "mcp-b"),
-            "cli_items": ["cli-1"],
-        },
-    )
-
-
-def test_active_defaults_entity_type_when_bot_missing_entity_type():
-    bot = {"id": 42, "entity_id": "ent-9", "bot_name": "b", "bot_desc": "x"}  # no entity_type
-    ctx = _ctx()
-    template_service = _template_service({})
-    passport_plugin = MagicMock()
-    skill_set_factory = MagicMock(name="skill_set_factory")
-    strategy = AicodingProvisioningStrategy("claude_code")
-
-    with patch(_MCP_CODES_PATH, return_value=[]) as mcp_mock, \
-            patch(_CLI_ITEMS_PATH, return_value=[]) as cli_mock:
-        strategy.refresh_restart_authorization(
-            ctx, bot, {"confirmed_template_update": True},
-            passport_plugin=passport_plugin,
-            skill_set_factory=skill_set_factory,
-            template_service=template_service,
-            caller_identity_repo=_identity_repo(),
-        )
-    mcp_mock.assert_called_once_with(
-        skill_set_factory, "owner-1", "bot-1", "ent-9", "staff", "claude_code"
-    )
-    passport_plugin.update_passport.assert_called_once_with(
-        bot_id="bot-1",
-        user_id="owner-1",
-        bot_name="b",
-        bot_desc="x",
-        engine_type="claude_code",
-        resource_scope={"mcp_codes": [], "mcp_items": [], "cli_items": []},
-    )
-
-
-# --------------------------------------------------------------------------- #
-# MCP execution identity                                                      #
-# --------------------------------------------------------------------------- #
-def test_active_carries_caller_identity_into_the_passport_scope():
-    """A caller-mode MCP survives the refresh instead of being demoted.
-
-    This is the regression the whole identity path exists for: the scope is a
-    full replacement, so pushing ``mcp-b`` without ``identity_mode`` would
-    rewrite it to owner and revoke the caller grant.
-    """
-    r = _do_refresh(
-        {"template_key": "architect"},
-        identity_repo=_identity_repo({"mcp-b": "caller"}),
-    )
-
-    r["caller_identity_repo"].list_draft_call_types.assert_called_once_with(
-        42, "claude_code"
-    )
-    scope = r["passport_plugin"].update_passport.call_args.kwargs["resource_scope"]
-    assert scope["mcp_items"] == [
-        {"mcp_code": "mcp-a", "identity_mode": "owner"},
-        {"mcp_code": "mcp-b", "identity_mode": "caller"},
-    ]
-    # Derived from the items, never assembled independently.
-    assert scope["mcp_codes"] == ["mcp-a", "mcp-b"]
-
-
-def test_skip_when_identity_lookup_fails():
-    """An unreadable identity row declines the refresh rather than defaulting."""
-    repo = _identity_repo()
-    repo.list_draft_call_types.side_effect = RuntimeError("identity store down")
-    passport_plugin = MagicMock()
-    strategy = AicodingProvisioningStrategy("claude_code")
-
-    with patch(_MCP_CODES_PATH, return_value=["mcp-a"]), \
-            patch(_CLI_ITEMS_PATH, return_value=[]):
-        strategy.refresh_restart_authorization(
-            _ctx(),
-            _bot(),
-            {"confirmed_template_update": True},
-            passport_plugin=passport_plugin,
-            skill_set_factory=MagicMock(name="skill_set_factory"),
-            template_service=_template_service({}),
-            caller_identity_repo=repo,
-        )
-    passport_plugin.update_passport.assert_not_called()
-
-
-def test_skip_when_bot_record_has_no_primary_key():
-    """A bot without a primary key cannot be keyed for identity — decline."""
-    bot = _bot()
-    del bot["id"]
-    repo = _identity_repo()
-    passport_plugin = MagicMock()
-    strategy = AicodingProvisioningStrategy("claude_code")
-
-    with patch(_MCP_CODES_PATH, return_value=["mcp-a"]), \
-            patch(_CLI_ITEMS_PATH, return_value=[]):
-        strategy.refresh_restart_authorization(
-            _ctx(),
-            bot,
-            {"confirmed_template_update": True},
-            passport_plugin=passport_plugin,
-            skill_set_factory=MagicMock(name="skill_set_factory"),
-            template_service=_template_service({}),
-            caller_identity_repo=repo,
-        )
-    repo.list_draft_call_types.assert_not_called()
-    passport_plugin.update_passport.assert_not_called()
-
-
-# --------------------------------------------------------------------------- #
-# Failure propagation                                                         #
-# --------------------------------------------------------------------------- #
-def test_passport_failure_propagates_and_is_not_swallowed():
-    """The strategy must let update_passport raise so the caller's try/except
-    can log-and-continue; it must not swallow authorization errors itself."""
-
-    ctx = _ctx()
-    bot = _bot()
-    template_service = _template_service({})
-    passport_plugin = MagicMock()
-    passport_plugin.update_passport.side_effect = RuntimeError("passport down")
-    skill_set_factory = MagicMock(name="skill_set_factory")
-    strategy = AicodingProvisioningStrategy("claude_code")
-
-    with patch(_MCP_CODES_PATH, return_value=["mcp-a"]), \
-            patch(_CLI_ITEMS_PATH, return_value=[]):
-        raised = False
-        try:
-            strategy.refresh_restart_authorization(
-                ctx, bot, {"confirmed_template_update": True},
-                passport_plugin=passport_plugin,
-                skill_set_factory=skill_set_factory,
-                template_service=template_service,
-                caller_identity_repo=_identity_repo(),
-            )
-        except RuntimeError:
-            raised = True
-        assert raised, "update_passport failure must propagate to the caller"
-
-
-# --------------------------------------------------------------------------- #
-# Default engine strategy: no-op                                              #
-# --------------------------------------------------------------------------- #
-def test_default_strategy_no_op_does_not_touch_passport():
-    template_service = MagicMock()
-    passport_plugin = MagicMock()
-    skill_set_factory = MagicMock(name="skill_set_factory")
-    strategy = DefaultProvisioningStrategy("openclaw")
-
-    # Even an opt-in request on a default engine must not authorize anything.
-    strategy.refresh_restart_authorization(
-        _ctx(),
-        _bot(),
-        {"confirmed_template_update": True},
-        passport_plugin=passport_plugin,
-        skill_set_factory=skill_set_factory,
-        template_service=template_service,
-        caller_identity_repo=_identity_repo(),
-    )
-    passport_plugin.update_passport.assert_not_called()
-    template_service.get_template_config.assert_not_called()
-
-
-def test_default_strategy_no_op_returns_none():
-    strategy = DefaultProvisioningStrategy("openclaw")
-    result = strategy.refresh_restart_authorization(
-        _ctx(),
-        _bot(),
+@pytest.mark.parametrize(
+    "extra_configs",
+    [
         None,
-        passport_plugin=MagicMock(),
-        skill_set_factory=MagicMock(),
-        template_service=MagicMock(),
-        caller_identity_repo=_identity_repo(),
+        {},
+        {"unrelated_key": True},
+        {"confirmed_template_update": False},
+        {"confirmed_template_update": None},
+        "confirmed_template_update=true",
+        ["confirmed"],
+        True,
+    ],
+)
+def test_aicoding_refresh_is_noop_without_opt_in(extra_configs) -> None:
+    strategy = AicodingProvisioningStrategy("claude_code")
+    mcp_sync = MagicMock()
+    factory = MagicMock()
+
+    assert (
+        strategy.refresh_restart_authorization(
+            _ctx(), _bot(), extra_configs,
+            mcp_sync=mcp_sync,
+            skill_set_factory=factory,
+        )
+        is False
     )
-    assert result is None
+    mcp_sync.refresh_mcp_scope.assert_not_called()
+    factory.create.assert_not_called()
+
+
+@pytest.mark.parametrize("flag", [True, 1, "yes"], ids=["true", "one", "truthy-str"])
+def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    mcp_sync = MagicMock()
+    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a", "mcp-b"]
+    skill_set_service.sync_mcp_projection = AsyncMock(return_value=True)
+    skill_set_service.sync_runtime.return_value = True
+    factory.create.return_value = skill_set_service
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(entity_id="ent-9", entity_type="staff"),
+            {"confirmed_template_update": flag},
+            mcp_sync=mcp_sync,
+            skill_set_factory=factory,
+        ) is True
+
+    mcp_sync.refresh_mcp_scope.assert_awaited_once()
+    scope_kwargs = mcp_sync.refresh_mcp_scope.await_args.kwargs
+    assert scope_kwargs["user_id"] == "ent-9"
+    assert scope_kwargs["entity_id"] == "ent-9"
+    assert scope_kwargs["bot_id"] == "bot-1"
+    assert scope_kwargs["entity_type"] == "staff"
+    assert scope_kwargs["engine_type"] == "aicoding"
+    assert "extra_cli_items" not in scope_kwargs
+    skill_set_service.get_bot_mcp_codes.assert_called_once_with(
+        entity_id="ent-9",
+        bot_id="bot-1",
+        user_id="ent-9",
+        entity_type="staff",
+        engine_type="aicoding",
+    )
+    skill_set_service.sync_mcp_projection.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a", "mcp-b"}),
+        released=frozenset(),
+        declared={"mcp-a", "mcp-b"},
+    )
+    factory.create.assert_called_once_with(
+        user_id="ent-9",
+        entity_id="ent-9",
+        bot_id="bot-1",
+        entity_type="staff",
+        engine_type="aicoding",
+    )
+    skill_set_service.sync_runtime.assert_called_once_with()
+
+
+def test_aicoding_refresh_is_best_effort_and_keeps_skill_sync_on_mcp_error() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    mcp_sync = MagicMock()
+    mcp_sync.refresh_mcp_scope = AsyncMock(side_effect=RuntimeError("scope down"))
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.sync_runtime.return_value = True
+    factory.create.return_value = skill_set_service
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=mcp_sync,
+            skill_set_factory=factory,
+        ) is True
+    factory.create.assert_called_once()
+    skill_set_service.sync_runtime.assert_called_once_with()
+
+
+
+def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    mcp_sync = MagicMock()
+    mcp_sync.refresh_mcp_scope = AsyncMock(
+        return_value={"success": False, "error": "scope denied"}
+    )
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.sync_runtime.return_value = True
+    factory.create.return_value = skill_set_service
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=mcp_sync,
+            skill_set_factory=factory,
+        ) is True
+
+    skill_set_service.sync_mcp_projection.assert_not_called()
+    skill_set_service.sync_runtime.assert_called_once_with()
+
+
+def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    mcp_sync = MagicMock()
+    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
+    skill_set_service.sync_mcp_projection = AsyncMock(return_value=False)
+    skill_set_service.sync_runtime.return_value = False
+    factory.create.return_value = skill_set_service
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=mcp_sync,
+            skill_set_factory=factory,
+        ) is True
+
+    skill_set_service.sync_mcp_projection.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a"}),
+        released=frozenset(),
+        declared={"mcp-a"},
+    )
+    skill_set_service.sync_runtime.assert_called_once_with()
+
+
+def test_aicoding_refresh_does_not_retry_mcp_detail_when_runtime_not_ready() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    mcp_sync = MagicMock()
+    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
+    skill_set_service.sync_mcp_projection = AsyncMock(side_effect=[False, True])
+    skill_set_service.sync_runtime.return_value = True
+    factory.create.return_value = skill_set_service
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=mcp_sync,
+            skill_set_factory=factory,
+        ) is True
+
+    skill_set_service.sync_mcp_projection.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a"}),
+        released=frozenset(),
+        declared={"mcp-a"},
+    )
+    skill_set_service.sync_runtime.assert_called_once_with()
+
+
+def test_aicoding_refresh_does_not_retry_mcp_detail_exception() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    mcp_sync = MagicMock()
+    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
+    skill_set_service.sync_mcp_projection = AsyncMock(side_effect=RuntimeError("projection down"))
+    skill_set_service.sync_runtime.return_value = True
+    factory.create.return_value = skill_set_service
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=mcp_sync,
+            skill_set_factory=factory,
+        ) is True
+
+    skill_set_service.sync_mcp_projection.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a"}),
+        released=frozenset(),
+        declared={"mcp-a"},
+    )
+
+
+def test_aicoding_refresh_does_not_retry_skill_symlink_when_false() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.sync_runtime.side_effect = [False, True]
+    factory.create.return_value = skill_set_service
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=None,
+            skill_set_factory=factory,
+        ) is True
+
+    skill_set_service.sync_runtime.assert_called_once_with()
+
+
+def test_aicoding_refresh_does_not_retry_skill_symlink_exception() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.sync_runtime.side_effect = [
+        RuntimeError("BaaS API error: NO_ACTIVE_DEVICES"),
+        True,
+    ]
+    factory.create.return_value = skill_set_service
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=None,
+            skill_set_factory=factory,
+        ) is True
+
+    skill_set_service.sync_runtime.assert_called_once_with()
+
+
+def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    mcp_sync = MagicMock()
+    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
+    skill_set_service.sync_mcp_projection = AsyncMock(side_effect=RuntimeError("projection down"))
+    skill_set_service.sync_runtime.side_effect = RuntimeError("skill down")
+    factory.create.return_value = skill_set_service
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=mcp_sync,
+            skill_set_factory=factory,
+        ) is True
+
+    skill_set_service.sync_mcp_projection.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a"}),
+        released=frozenset(),
+        declared={"mcp-a"},
+    )
+    skill_set_service.sync_runtime.assert_called_once_with()
+
+
+def test_aicoding_refresh_swallows_skill_sync_exception() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    factory = MagicMock()
+    factory.create.side_effect = RuntimeError("skill unavailable")
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=None,
+            skill_set_factory=factory,
+        ) is True
+
+    factory.create.assert_called_once()
+
+def test_default_strategy_always_returns_false() -> None:
+    strategy = DefaultProvisioningStrategy("openclaw")
+    assert (
+        strategy.refresh_restart_authorization(
+            _ctx(), _bot(), {"confirmed_template_update": True},
+            mcp_sync=MagicMock(),
+            skill_set_factory=MagicMock(),
+        )
+        is False
+    )
+    assert strategy.refresh_restart_authorization(_ctx(), _bot(), None) is False
+
+
+def test_aicoding_refresh_clears_persisted_marker_after_confirmed_extra_success() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    stored_template_config = {
+        "template_version_id": 101,
+        "_aicoding_restart": {
+            "resync_authorization": True,
+            "template_version_id": 101,
+        },
+    }
+    mcp_sync = MagicMock()
+    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
+    template_service = MagicMock()
+    template_service.get_template_config.return_value = stored_template_config
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            _ctx(active_engine="aicoding"),
+            _bot(),
+            {"confirmed_template_update": True},
+            mcp_sync=mcp_sync,
+            skill_set_factory=None,
+            template_service=template_service,
+        ) is True
+
+    template_service.update_template.assert_called_once()
+    cleared = template_service.update_template.call_args.kwargs["template_config"]
+    assert "_aicoding_restart" not in cleared
+    assert cleared["template_version_id"] == 101
+
+
+def test_aicoding_refresh_uses_persisted_template_marker_and_clears_after_success() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    template_config = {
+        "template_version_id": 101,
+        "_aicoding_restart": {
+            "resync_authorization": True,
+            "template_version_id": 101,
+        },
+    }
+    ctx = BotProvisioningContext(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        bot_type="personal",
+        active_engine="aicoding",
+        template_type="architect",
+        template_config=template_config,
+    )
+    mcp_sync = MagicMock()
+    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
+    template_service = MagicMock()
+    template_service.get_template_config.return_value = template_config
+
+    with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            ctx,
+            _bot(),
+            None,
+            mcp_sync=mcp_sync,
+            skill_set_factory=None,
+            template_service=template_service,
+        ) is True
+
+    template_service.update_template.assert_called_once()
+    cleared = template_service.update_template.call_args.kwargs["template_config"]
+    assert "_aicoding_restart" not in cleared
+    assert cleared["template_version_id"] == 101
+
+
+def test_baas_restart_publish_listener_dispatches_strategy_after_restart_event() -> None:
+    bot_repo = MagicMock()
+    bot_repo.get_by_id_and_owner.return_value = {
+        "bot_id": "bot-1",
+        "owner_id": "owner-1",
+        "binding_id": 42,
+        "bot_type": "personal",
+        "active_engine": "claude_code",
+        "template_type": "architect",
+    }
+    template_config = {
+        "template_version_id": 101,
+        "_aicoding_restart": {"resync_authorization": True},
+    }
+    template_service = MagicMock()
+    template_service.get_template_config.return_value = template_config
+    mcp_sync = object()
+    factory = object()
+    strategy = MagicMock()
+    strategy.engine_type = "claude_code"
+    strategy.refresh_restart_authorization.return_value = True
+
+    listener = AicodingRestartAuthorizationBaasPublishListener(
+        bot_repo=bot_repo,
+        template_service=template_service,
+        mcp_sync=mcp_sync,
+        skill_set_factory=factory,
+    )
+
+    with patch(
+        "agentclaw.community.core.bot_management.engines.aicoding.restart_authorization_listener.resolve_provisioning",
+        return_value=("ctx", strategy),
+    ) as resolve:
+        listener.handle(
+            BaasPublishCompletedEvent(
+                binding_id=42,
+                bot_id="bot-1",
+                owner_id="owner-1",
+                publish_id=1001,
+                publish_kind="restart",
+            )
+        )
+
+    resolve.assert_called_once_with(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        bot_type="personal",
+        active_engine="claude_code",
+        template_type="architect",
+        template_config=template_config,
+    )
+    strategy.refresh_restart_authorization.assert_called_once_with(
+        "ctx",
+        bot_repo.get_by_id_and_owner.return_value,
+        None,
+        mcp_sync=mcp_sync,
+        skill_set_factory=factory,
+        template_service=template_service,
+    )
+
+
+def test_baas_restart_publish_listener_ignores_non_restart_or_stale_binding() -> None:
+    bot_repo = MagicMock()
+    bot_repo.get_by_id_and_owner.return_value = {"binding_id": 99}
+    listener = AicodingRestartAuthorizationBaasPublishListener(
+        bot_repo=bot_repo, template_service=MagicMock()
+    )
+
+    listener.handle(
+        BaasPublishCompletedEvent(
+            binding_id=42,
+            bot_id="bot-1",
+            owner_id="owner-1",
+            publish_id=1001,
+            publish_kind="create",
+        )
+    )
+    bot_repo.get_by_id_and_owner.assert_not_called()
+
+    listener.handle(
+        BaasPublishCompletedEvent(
+            binding_id=42,
+            bot_id="bot-1",
+            owner_id="owner-1",
+            publish_id=1002,
+            publish_kind="restart",
+        )
+    )
+    bot_repo.get_by_id_and_owner.assert_called_once_with("bot-1", "owner-1")
+
+
+def test_baas_restart_publish_listener_startup_is_idempotent() -> None:
+    reset_event_bus()
+    try:
+        listener = AicodingRestartAuthorizationBaasPublishListener(
+            bot_repo=MagicMock(), template_service=MagicMock()
+        )
+        handler = MagicMock()
+        listener.handle = handler
+
+        asyncio.run(listener.startup())
+        asyncio.run(listener.startup())
+
+        bus = get_event_bus()
+        assert bus.is_subscribed(BaasPublishCompletedEvent, handler)
+        bus.publish(
+            BaasPublishCompletedEvent(
+                binding_id=42,
+                bot_id="bot-1",
+                owner_id="owner-1",
+                publish_id=1001,
+                publish_kind="restart",
+            )
+        )
+        handler.assert_called_once()
+    finally:
+        reset_event_bus()


### PR DESCRIPTION
## 背景
重启链路里原先的 MCP 同步链路不够完整，新增 MCP 后希望在 restart 场景也能把 MCP 授权与 runtime 投递一起补齐。

## 这次改了什么
- 重启时继续刷新 MCP scope
- 增加 MCP projection 同步：通过 `get_bot_mcp_codes` 取出当前 bot 的 MCP，再调用 `sync_mcp_projection` 投递到设备侧
- 保留 `sync_runtime()`，继续处理 skills 软链同步
- 补充/调整对应单测，覆盖成功、失败和 best-effort 场景

## 影响
- 让 restart 场景也能补齐 MCP 授权与设备侧 MCP 配置
- 不影响 skills 同步链路

## 验证
- `git diff --check`
- `python3 -m py_compile src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py`