### PR TITLE
docs(backend): finalize Phase 2 skill upgrade spec

### DIFF
--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/product-prd-conformance.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/product-prd-conformance.md
@@ -84,7 +84,7 @@ presentation metadata，不能映射到 `ac_skill.name` 或绕过 Version。
 | 产品动作 | Mock 证据 | 正式 Spec | 结论 |
 | --- | --- | --- | --- |
 | 能力集列表、折叠、Skill/MCP 数量 | `BotEdit.tsx:39-57,213-294` | SkillSet list/resources/skills/mcps | 满足 |
-| 新建能力集 | `BotEdit.tsx:76-83,296-298` | POST 创建 inactive ordinary Set | **前端需对齐**：Mock 新建时 `enabled=true` |
+| 新建能力集 | `BotEdit.tsx:76-83,296-298` | POST 创建 active ordinary Set；空集合不触发 Runtime | 满足，与最新 dev 语义一致 |
 | 整体开关 | `BotEdit.tsx:224-245` | activate/deactivate 原子维护 Skill/MCP Installation | 满足 |
 | 删除能力集 | `BotEdit.tsx:85-94,240-245` | 只允许删除 inactive ordinary Set，Default 禁止 | Backend 满足；前端需先关闭或处理 409 |
 | 市场/工坊多选 Skill | `BotEdit.tsx:63-103,300-341` | TeamClaw/工坊普通 Membership；SC Public 批量 Reference 最多 20 | 满足 |
@@ -130,4 +130,4 @@ SkillSet 原子开关、MCP、Track Latest、Service 历史重放和退役。
 3. 未物化 SC 详情继续使用现有 `homepageUrl` iframe，不触发物化。
 4. 把升级影响弹窗移到发布确认，把“下线回草稿”替换为 Retirement，并支持完整 blocker。
 5. 实现 SC Reference Operation 的处理中、部分成功、刷新恢复；Mock 当前只有同步 toast。
-6. 新建 SkillSet 默认 inactive，与 Backend 原子控制语义一致。
+6. 新建 SkillSet 默认 active；空集合不触发 Runtime，后续新增成员立即生效。

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/product-prd-conformance.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/product-prd-conformance.md
@@ -37,8 +37,8 @@
 | 发布失败/RESULT_UNKNOWN/物化失败恢复 | 原型未画 | Attempt Retry + recovery summary | 原型未定义，Spec 有完备合同 |
 | 查看发布影响 | Mock 在“确认升级”时展示 Bot，`CapabilityWorkshop.tsx:1046-1076` | 最终接口为 `publication-impact`，在真正发布前提示；upgrade 仅创建 Draft | **已由产品确认**：PD 后续把影响弹窗从 upgrade 移到 publish confirm |
 | 升级 Vn→Vn+1 | `CapabilityWorkshop.tsx:1046-1076` | 从 exact Published Vn 创建 Vn+1 EDITING Draft | 满足，除影响弹窗时机 |
-| 下线 | Mock 无引用时把 running 改回 draft，`CapabilityWorkshop.tsx:1078-1125` | 不可逆 TeamClaw-local Retirement；Versions/Draft 历史保留，不回 Draft | **前端需对齐**：旧“下线后回草稿”已被最终决策替换 |
-| 下线前引用阻断 | 同上，只展示 Bot refs | Retirement impact 覆盖 Membership、Installation、Attempt、Artifact、UNKNOWN_ARTIFACT | Backend 更严格且满足安全需求；前端需支持非 Bot blocker 分类/counts |
+| 下线 | Mock 无引用时把 running 改回 draft，`CapabilityWorkshop.tsx:1078-1125` | TeamClaw-local Offline；保留 Published Vn 并创建 Vn+1 Draft，重新发布后上线 | 满足产品意图；前端需避免把历史 Vn 真正改成 Draft |
+| 下线前引用阻断 | 同上，只展示 Bot refs | Offline impact 覆盖 Membership、Installation、Attempt、Artifact、UNKNOWN_ARTIFACT | Backend 更严格且满足安全需求；前端需支持非 Bot blocker 分类/counts |
 | 删除未发布 Skill/放弃升级 Draft | Draft 卡片“删除”，`CapabilityWorkshop.tsx:762-770` | `DELETE .../draft` 返回 `deleted_scope=SKILL|DRAFT`，FROZEN 拒绝 | 满足 |
 | Team 编辑锁、抢占、关闭释放 | `CapabilityWorkshop.tsx:572-662,742-751,928-947` | 永久 Lease、fencing、acquire/release/takeover，无 TTL | 满足 |
 | 普通成员申请编辑权限 | `CapabilityWorkshop.tsx:554-569,746-760` | `editor-requests` + `SKILL_COLLABORATOR` Work Order | 满足 |
@@ -106,14 +106,14 @@ presentation metadata，不能映射到 `ac_skill.name` 或绕过 Version。
 | Bot restart/re-ACTIVE | Reader + Resolver + full Projector；首次失败有有界 Retry | Bot 恢复后使用 latest exact Version |
 | Service 新 Release | build 前完整 Projector，Artifact 冻结 exact Center/MCP | 新 Release 使用最新 PUBLISHED |
 | Service restart/scale/rollback | 只读历史 Artifact | 历史版本不漂移 |
-| Retirement | replayable Artifact 是硬 blocker | 产品显示受影响 Service Bot/Version，禁止继续 |
+| Offline | replayable Artifact 是硬 blocker | 产品显示受影响 Service Bot/Version，禁止继续；无 blocker 时进入 Vn+1 Draft |
 
 ## 6. 明确不属于缺口的原型差异
 
 - 原型没有超时、并发、幂等、补偿、Task deadline、RESULT_UNKNOWN 和 UNKNOWN_ARTIFACT；这些是
   Backend 必须补齐的可靠性合同，不需要 Mock 先画出来。
 - 原型把状态压成 `draft/running/offline`；正式 Spec 使用 Asset、Draft、Attempt、Version、
-  Retirement 分离状态，前端必须映射，不能要求 Backend 回到单 status。
+  Offline 分离状态，前端必须映射，不能要求 Backend 把旧 Published Vn 变成 Draft。
 - 原型只模拟文件内容；Canonical OSS、Mapping v3、Pool、Teclaw v4 和 Artifact 冻结不属于页面
   ViewModel，但仍是发布门禁。
 - 产品入口没开放某个 Bot Type × Engine 组合不等于 Center 技术不支持；Backend 不编码静态拒绝。
@@ -121,13 +121,13 @@ presentation metadata，不能映射到 `ac_skill.name` 或绕过 Version。
 ## 7. Review 结论
 
 正式 Spec 已覆盖产品主链路：创建、保存、协作编辑、发布、版本、市场发现/收藏、加入能力集、
-SkillSet 原子开关、MCP、Track Latest、Service 历史重放和退役。
+SkillSet 原子开关、MCP、Track Latest、Service 历史重放和可恢复下线。
 
 产品合同未再保留开放问题。Frontend Guide/Ticket 阶段需要执行的已定稿调整：
 
 1. 删除“展示名称/描述/图标即时生效”的 Backend 依赖；Published 内容只读，修改走 Draft/Version。
 2. 能力工坊搜索调用 Backend `keyword/page/page_size`。
 3. 未物化 SC 详情继续使用现有 `homepageUrl` iframe，不触发物化。
-4. 把升级影响弹窗移到发布确认，把“下线回草稿”替换为 Retirement，并支持完整 blocker。
+4. 把升级影响弹窗移到发布确认；下线时保留 Published Vn、创建 Vn+1 Draft，并支持完整 blocker。
 5. 实现 SC Reference Operation 的处理中、部分成功、刷新恢复；Mock 当前只有同步 toast。
 6. 新建 SkillSet 默认 active；空集合不触发 Runtime，后续新增成员立即生效。

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/product-prd-conformance.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/product-prd-conformance.md
@@ -1,0 +1,133 @@
+# Skill 能力升级 Spec × 产品 PRD Mock 对照
+
+> 状态：产品一致性 Review 证据，不是第二份领域 Spec
+>
+> Backend 基线：`github/dev@b68ec64f1698a931585612801f2db6529c8ec4aa`
+>
+> 产品基线：`Teamclaw_PRD_new origin/master@72de5d1c12ea1b7e51a00f36a56f6ab718ee26a3`
+>
+> 正式领域权威：同目录 `spec.md`
+
+## 1. 证据边界
+
+产品仓库是 React/TypeScript Mock，没有 Backend 请求、失败恢复或持久状态实现。本文只把可见
+页面、按钮、字段和 Mock state transition 当作产品证据；原型没有画出的超时、并发、幂等、
+回滚、Runtime、Artifact 行为不能反推为产品结论。
+
+结论分为：
+
+- **满足**：正式 Spec 已提供完成该产品动作所需的领域与 OpenAPI。
+- **前端需对齐**：最终领域决策已明确，Mock 仍保留被替换的旧交互。
+- **已由产品确认**：Mock 与最终决定存在差异，PD/前端将按正式 Spec 修订。
+- **原型未定义**：Spec 为可靠性补齐的行为，不能说与 PRD 冲突。
+
+## 2. 能力工坊
+
+| 产品动作 | Mock 证据 | 正式 Spec | 结论 |
+| --- | --- | --- | --- |
+| 在 Personal/Team Space 查看 Skill 卡片 | `CapabilityWorkshop.tsx:385-456,680-923` | `SpaceSkillSummary` 返回生命周期、Version、Draft、Attempt、Owner、Actor permissions、Lease summary | 满足 |
+| 在能力工坊同时展示当前 Space 的市场收藏 | `CapabilityWorkshop.tsx:900-909` | Space Skill list 与 market-favorites search 分别读取，由前端组合分区 | 满足；收藏不是 Space-owned Skill，不能混入 SpaceSkillSummary |
+| 搜索能力工坊 Skill | `CapabilityWorkshop.tsx:821` | Backend `keyword + page/page_size`，过滤后分页，稳定倒序 | 满足；前端不全量拉取后本地过滤 |
+| 文件夹创建 V1 | `CapabilityWorkshop.tsx:201-240,928-979` | multipart `files + file_paths`，持久 Identity/Owner/V1 Draft | 满足；Mock 只模拟选择，Spec 补齐持久化 |
+| Git snapshot 创建 | `CapabilityWorkshop.tsx:241-270` | Git URL/branch/subdir、确定性第一 `SKILL.md`、commit/source_subdir 固化 | 满足；多 Skill/失败行为属于原型未定义 |
+| 保存 Draft | `CapabilityWorkshop.tsx:928-979` 的“保存/草稿已保存” | immutable ZIP Revision + expected revision CAS；V1 保存后即有 Draft | 满足 |
+| 文件树、读取、编辑、保存单文件 | `CapabilityWorkshop.tsx:273-383` | Draft files tree、file GET/PUT | 满足 |
+| Git 手动更新 | `CapabilityWorkshop.tsx:343-357` | `POST .../draft/refresh-from-git`，只读冻结 source_subdir | 满足 |
+| 发布前规范校验和安全扫描 | `CapabilityWorkshop.tsx:1128-1248` | Publication Attempt + SC checks + Materializer；PUBLISHED 才成功 | 满足；原型没有画 materialization/失败/恢复 |
+| 发布失败/RESULT_UNKNOWN/物化失败恢复 | 原型未画 | Attempt Retry + recovery summary | 原型未定义，Spec 有完备合同 |
+| 查看发布影响 | Mock 在“确认升级”时展示 Bot，`CapabilityWorkshop.tsx:1046-1076` | 最终接口为 `publication-impact`，在真正发布前提示；upgrade 仅创建 Draft | **已由产品确认**：PD 后续把影响弹窗从 upgrade 移到 publish confirm |
+| 升级 Vn→Vn+1 | `CapabilityWorkshop.tsx:1046-1076` | 从 exact Published Vn 创建 Vn+1 EDITING Draft | 满足，除影响弹窗时机 |
+| 下线 | Mock 无引用时把 running 改回 draft，`CapabilityWorkshop.tsx:1078-1125` | 不可逆 TeamClaw-local Retirement；Versions/Draft 历史保留，不回 Draft | **前端需对齐**：旧“下线后回草稿”已被最终决策替换 |
+| 下线前引用阻断 | 同上，只展示 Bot refs | Retirement impact 覆盖 Membership、Installation、Attempt、Artifact、UNKNOWN_ARTIFACT | Backend 更严格且满足安全需求；前端需支持非 Bot blocker 分类/counts |
+| 删除未发布 Skill/放弃升级 Draft | Draft 卡片“删除”，`CapabilityWorkshop.tsx:762-770` | `DELETE .../draft` 返回 `deleted_scope=SKILL|DRAFT`，FROZEN 拒绝 | 满足 |
+| Team 编辑锁、抢占、关闭释放 | `CapabilityWorkshop.tsx:572-662,742-751,928-947` | 永久 Lease、fencing、acquire/release/takeover，无 TTL | 满足 |
+| 普通成员申请编辑权限 | `CapabilityWorkshop.tsx:554-569,746-760` | `editor-requests` + `SKILL_COLLABORATOR` Work Order | 满足 |
+| Owner/Manager 授权 | `SkillAuthDrawer`, `CapabilityWorkshop.tsx:55-189` | 唯一 Owner + 多 Manager；Owner PUT/DELETE managers | 领域能力满足；前端 `admin/member` 术语需映射为 Owner/Manager |
+| Owner 转移与原因 | `CapabilityWorkshop.tsx:465-502,1251-1321` | 原子 Owner transfer、reason、旧 Lease 失效、原 Owner 不自动保留 Manager | 满足 |
+| 历史版本下拉与文件查看 | `SkillDetail.tsx:18-179` | Versions list/detail/tree/file GET | 满足 |
+| 编辑“展示名称/描述/图标”并即时生效 | `CapabilityWorkshop.tsx:984-1036` | Published SKILL.md 不可修改；Draft 可编辑但 name 永久不变、description 随 Version；本期无独立 presentation mutation | **已确认移除即时编辑语义**；图标使用默认展示 |
+
+### 2.1 元信息冲突必须显式关闭
+
+Mock 的“编辑 Skill 信息”同时表达：
+
+```text
+Skill 名称只读
+Skill ID 只读
+展示名称可改
+功能描述可改
+图标可改
+修改后即时生效、无需重新发布
+```
+
+最终决定为：Published `SKILL.md` 不可原地修改；Draft 中可以编辑文件并发布新 Version，但
+`name` 永久不可变，`description` 只随 Version 生效。本期不实现该即时编辑弹窗的 Backend
+写接口，图标使用默认展示。未来若需要独立展示名称/图标，只能 additive 增加 Asset
+presentation metadata，不能映射到 `ac_skill.name` 或绕过 Version。
+
+## 3. 能力市场
+
+| 产品动作 | Mock 证据 | 正式 Spec | 结论 |
+| --- | --- | --- | --- |
+| SkillCenter/TeamClaw 两个来源 Tab | `PublicMarket.tsx:15-18,151-243` | 两个独立查询：SC Public search、TeamClaw Repository Catalog | 满足 |
+| SkillCenter 分类筛选 | `PublicMarket.tsx:182-198` | SC search tags/official/recommended/belongTo | 满足 |
+| TeamClaw 业务目录 | `PublicMarket.tsx:229-241` | Repository tree/path | 满足 |
+| 手动同步最新 Skill | `PublicMarket.tsx:177-179` | TeamClaw Repo sync 与 SC materialized-assets sync 两个接口 | 满足；前端必须按当前来源分流 |
+| 收藏到当前 Space | `PublicMarket.tsx:32-53,207-218` | 冻结的 Space market-favorites add/cancel/search/status | 满足 |
+| 从市场选择 Bot 和 SkillSet | `PublicMarket.tsx:55-90,328-423` | Bot/SkillSet ACL + Membership/SC Reference | 满足 |
+| TeamClaw 市场添加 | 同上 | 已有 `skill_id`，普通 Membership PUT | 满足 |
+| SkillCenter Public 添加 | 同上 | 持久异步 Reference Operation、202/轮询、懒物化后 Membership | Backend 满足；Mock 只 toast 成功，**前端需增加处理中/部分失败/恢复** |
+| 查看市场 Skill 详情 | BotEdit 卡片跳 `#/skill/{marketId}`，`BotEdit.tsx:331-334` | 已物化共享资产可用 Botless `readme`；未物化 SC 使用 search `homepageUrl` | 满足；前端已通过 iframe 嵌入 SC 页面，查看不触发物化 |
+
+## 4. Bot 工坊能力集
+
+| 产品动作 | Mock 证据 | 正式 Spec | 结论 |
+| --- | --- | --- | --- |
+| 能力集列表、折叠、Skill/MCP 数量 | `BotEdit.tsx:39-57,213-294` | SkillSet list/resources/skills/mcps | 满足 |
+| 新建能力集 | `BotEdit.tsx:76-83,296-298` | POST 创建 inactive ordinary Set | **前端需对齐**：Mock 新建时 `enabled=true` |
+| 整体开关 | `BotEdit.tsx:224-245` | activate/deactivate 原子维护 Skill/MCP Installation | 满足 |
+| 删除能力集 | `BotEdit.tsx:85-94,240-245` | 只允许删除 inactive ordinary Set，Default 禁止 | Backend 满足；前端需先关闭或处理 409 |
+| 市场/工坊多选 Skill | `BotEdit.tsx:63-103,300-341` | TeamClaw/工坊普通 Membership；SC Public 批量 Reference 最多 20 | 满足 |
+| 本地文件夹 | 当前 master 的选项仅 market/workshop；用户后续 PRD 截图已出现“添加本地文件夹” | multipart Bot-local Local upload + Membership | Backend 已覆盖；master Mock 落后最新产品图 |
+| 添加/移除 Skill | `BotEdit.tsx:250-269` | SkillSet Membership PUT/DELETE；active Set 同事务维护 Installation | 满足 |
+| 添加/移除 MCP | `BotEdit.tsx:271-289,343-374` | MCP Membership + permission flow | 满足 |
+| MCP Owner/Caller 身份 | `BotEdit.tsx:114-209` | 已发布 caller-context 与 per-MCP call-type PATCH | 满足，不应重复进 SkillSet 表 |
+| Default Set/CLI/exclusion | Mock 未完整画出 | 既有 resources、Default exclusion、CLI 接口保持 | 原型未定义，Backend 向前兼容 |
+
+## 5. Runtime、Track Latest 与 Service Artifact
+
+产品 Mock 没有真实 Runtime/Artifact Consumer，因此只能验证用户可见结果，不能证明下列合同。
+正式 Spec 已补齐并必须以真实 Consumer 验收：
+
+| 场景 | Spec 结果 | 产品可见结果 |
+| --- | --- | --- |
+| active Set 添加 Center Skill | Reference 完成后 Installation + exact Runtime Projection | 最终显示已添加；处理中由 Operation 状态驱动 |
+| Space/SC Public 发布新版本 | PUBLISHED 后 Track Latest 异步扇出 | 发布先成功；Bot 更新不阻断成功弹窗 |
+| Bot restart/re-ACTIVE | Reader + Resolver + full Projector；首次失败有有界 Retry | Bot 恢复后使用 latest exact Version |
+| Service 新 Release | build 前完整 Projector，Artifact 冻结 exact Center/MCP | 新 Release 使用最新 PUBLISHED |
+| Service restart/scale/rollback | 只读历史 Artifact | 历史版本不漂移 |
+| Retirement | replayable Artifact 是硬 blocker | 产品显示受影响 Service Bot/Version，禁止继续 |
+
+## 6. 明确不属于缺口的原型差异
+
+- 原型没有超时、并发、幂等、补偿、Task deadline、RESULT_UNKNOWN 和 UNKNOWN_ARTIFACT；这些是
+  Backend 必须补齐的可靠性合同，不需要 Mock 先画出来。
+- 原型把状态压成 `draft/running/offline`；正式 Spec 使用 Asset、Draft、Attempt、Version、
+  Retirement 分离状态，前端必须映射，不能要求 Backend 回到单 status。
+- 原型只模拟文件内容；Canonical OSS、Mapping v3、Pool、Teclaw v4 和 Artifact 冻结不属于页面
+  ViewModel，但仍是发布门禁。
+- 产品入口没开放某个 Bot Type × Engine 组合不等于 Center 技术不支持；Backend 不编码静态拒绝。
+
+## 7. Review 结论
+
+正式 Spec 已覆盖产品主链路：创建、保存、协作编辑、发布、版本、市场发现/收藏、加入能力集、
+SkillSet 原子开关、MCP、Track Latest、Service 历史重放和退役。
+
+产品合同未再保留开放问题。Frontend Guide/Ticket 阶段需要执行的已定稿调整：
+
+1. 删除“展示名称/描述/图标即时生效”的 Backend 依赖；Published 内容只读，修改走 Draft/Version。
+2. 能力工坊搜索调用 Backend `keyword/page/page_size`。
+3. 未物化 SC 详情继续使用现有 `homepageUrl` iframe，不触发物化。
+4. 把升级影响弹窗移到发布确认，把“下线回草稿”替换为 Retirement，并支持完整 blocker。
+5. 实现 SC Reference Operation 的处理中、部分成功、刷新恢复；Mock 当前只有同步 toast。
+6. 新建 SkillSet 默认 inactive，与 Backend 原子控制语义一致。

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -1,9 +1,13 @@
 # Skill 能力全量 OpenAPI Gateway 化与 Space Skill 升级 Spec
 
 > 状态：**正式 Spec / 开发与团队 Review 共同基线**
-> 日期：2026-08-20
+> 初版日期：2026-08-20
+> 最后修订：2026-08-30
 > 目标分支：`dev`
 > 本文是 Phase 1、Phase 2 开发、测试、Ticket 拆分和团队 Review 的唯一方案基线。
+> 本次修订基于 `github/dev@b68ec64f1` 与产品 PRD Mock
+> `Teamclaw_PRD_new origin/master@72de5d1c`；原型只作为产品 User Story 证据，未定义行为
+> 以本文最终领域决策为准。
 
 ## Problem Statement
 
@@ -28,10 +32,10 @@ Legacy BFF；Local 的 active 又通过 Default SkillSet exclusion 间接表达�
 
 建设一个深的 Skill/MCP 控制面，以稳定 Skill Asset、Bot Installation、SkillSet
 Membership 和 Runtime Full Projection 为核心。Local、Repo、Space 是三种长期并存
-的资产类型；Bot 当前期望生效的 Skill/MCP 由 Installation 物化，普通 SkillSet
-通过原子批量命令维护 Membership 与 Installation，Direct activate/deactivate
-直接维护 Installation。所有 Runtime 更新和 Bot 重启都经过同一个 Resolver 生成
-完整投影。
+的资产类型；Bot 当前有效的 Skill/MCP 只从 Installation 读取。所有会改变有效能力的
+命令实时维护 Installation；迁移期所有 Effective Read 先经统一 Reader 幂等 flush
+SkillSet、System Default 与 exclusion 语义，再只读 Installation。所有 Runtime 更新和
+Bot 重启都经过同一个 Resolver/Projector 生成完整投影。
 
 Phase 1 保留已发布 Local/MCP/Space wire，新增 canonical Repo、SkillSet、Bot MCP
 接口，并让 Legacy BFF 退化为兼容 Adapter。Phase 2 在稳定 ac_skill Identity 上增加
@@ -58,9 +62,9 @@ artifact。本文先冻结待实现合同；实现完成后生成的 OpenAPI JSO
 12. 作为 SkillSet 用户，我希望停用一个 SkillSet 时其中全部 Skill/MCP 原子失效。
 13. 作为 SkillSet 用户，我希望向 active SkillSet 添加成员后新成员立即生效。
 14. 作为 SkillSet 用户，我希望从 active SkillSet 移除成员后该成员立即失效。
-15. 作为用户，我希望同一资源最多属于一个普通 SkillSet，避免来源冲突。
-16. 作为用户，我希望 Direct active 资源加入 SkillSet 前被要求先停用 Direct 来源。
-17. 作为用户，我希望 SkillSet 管理的资源不能被单独 activate/deactivate，避免破坏原子状态。
+15. 作为用户，我希望同一资源最多属于一个 SkillSet（System Default 包含在内），避免来源冲突。
+16. 作为用户，我希望 Direct active 资源加入任何 SkillSet 前被要求先停用 Direct 来源。
+17. 作为用户，我希望任何 SkillSet 管理的资源不能被单独 activate/deactivate；Default 成员通过 exclusion 控制。
 18. 作为平台管理员，我希望 System Default 始终生效且不可删除或停用。
 19. 作为 Repo 市场用户，我希望搜索、列表、目录树和同步都从 aiworkbench master 得到一致结果。
 20. 作为 Repo 市场用户，我希望同步接口同步完成后才返回，并在并发同步时收到稳定冲突。
@@ -92,6 +96,11 @@ artifact。本文先冻结待实现合同；实现完成后生成的 OpenAPI JSO
 46. 作为 Team Space 普通成员，我希望可以向当前 Skill Owner 申请编辑权限，并在工单中查询结果。
 47. 作为 Skill Owner，我希望批准编辑申请后申请人原子获得 Manager Grant，拒绝时不改变 Skill Grant。
 48. 作为前端开发者，我希望列表返回稳定的 Skill/Draft/Attempt/Lease 领域摘要与当前调用者权限，而不把页面按钮 ViewModel 写入公共合同。
+49. 作为 Bot 工坊用户，我希望“引用市场 Skill”同时展示 TeamClaw Repo 与 SkillCenter Public 结果，并由前端按来源调用不同的添加命令。
+50. 作为 SkillCenter Public 用户，我希望一次选择多个 Skill 后获得可跨刷新恢复的异步引用进度，且只有物化完成后才加入 SkillSet。
+51. 作为发布者，我希望发布前看到可能受 Track Latest 影响的 Bot，但该预览不阻断发布，发布成功后由后端重新计算真实候选。
+52. 作为发布者，我希望自动重试耗尽后可以针对同一个 Attempt 恢复准备、查询 SC 结果或重试物化，而不会重复发布。
+53. 作为 Skill Owner/Manager，我希望退役前看到完整血缘；任何 Membership、Installation、进行中操作或仍可重放 Service Artifact 都必须阻断退役。
 
 ## Implementation Decisions
 
@@ -133,13 +142,18 @@ Backend 真实提供，同时避免在 Review 阶段暴露返回 `501` 的占位
 | --- | --- | --- | --- |
 | `LOCAL` | Bot-owned | Bot 上传 ZIP | 删除 Local 资产 |
 | `REPO` | 环境共享 | `security_release/aiworkbench` master 扫描 | 不能删除共享资产 |
-| `SPACE` | Space-owned | Draft 发布到 Skill Center | 不能通过 Bot API 删除 |
+| `SPACE` | Space-owned 或 SC Public 懒物化的环境共享只读资产 | Draft 发布到 Skill Center，或 SC Public exact download | 不能通过 Bot API 删除 |
 
 公开 `skill_id` 统一使用十进制字符串形式的 `ac_skill.id`。Item API 根据 `skill_id` 在服务端解析类型，调用方不传 `type`。
 
+`SPACE` 是现有 OpenAPI 中 Center-backed Runtime asset 的统一类型，不新增 `CENTER` wire enum。
+TeamClaw 工坊 Skill 通过 `ac_skill_space_binding + Grant` 表达 Space ownership；SC Public 懒物化
+资产没有 Space Binding/Grant，是环境共享只读 Asset。两者运行时都使用内部 UUID + exact
+Version 的 Center corpus，但创作/授权能力不同。
+
 #### 3.2 Bot 当前有效 Skill
 
-`ac_bot_skill_installation` 是 **Bot 当前期望生效 Skill 的物化清单**：
+`ac_bot_skill_installation` 是 **Bot 当前有效 Skill 的唯一读取事实**：
 
 ```text
 UNIQUE(tenant, env, owner_id, bot_id, skill_id)
@@ -147,26 +161,30 @@ UNIQUE(tenant, env, owner_id, bot_id, skill_id)
 
 - 行存在即 active，不保存 inactive 行。
 - 不保存 `source_type`、`skill_set_id`、`direct_active` 或 Runtime observed status。
-- `Installation + 普通 SkillSet Membership` 表示由 SkillSet 管理。
-- `Installation + 无普通 Membership` 表示 Direct 管理。
-- Active 普通 SkillSet 与 Direct Activate 最终物化到同一张表；System Default 是
-  Resolver 的独立平台输入。
+- `Installation + 任意 reaching SkillSet Membership` 表示由 SkillSet 管理。
+- `Installation + 无任何 reaching Membership` 表示 Direct 管理。
+- Active 普通 SkillSet、未 exclusion 的 System Default 成员与 Direct Activate 最终都
+  物化到同一张表；Resolver 禁止再从 SkillSet/Default/exclusion 内存合并一套 Effective Skill。
 
 | 场景 | Asset | Membership | Installation |
 | --- | --- | --- | --- |
 | Local 已上传未激活 | 有 | 无 | 无 |
 | Repo/Space 在 inactive SkillSet | 有 | 有 | 无 |
 | Direct active | 有 | 无 | 有 |
-| Active SkillSet 成员 | 有 | 有 | 有 |
+| Active 普通 SkillSet 成员 | 有 | 有 | 有 |
+| System Default 未 exclusion 成员 | 有 | Default | 有 |
+| System Default excluded 成员 | 有 | Default | 无 |
 
-切流不执行全库 Installation backfill。普通 active SkillSet 的历史成员由按 Bot 懒物化
-补齐：在完整 Runtime reconcile 前、以及 Service Bot 构建新 Artifact 前，查询当前
-`is_default=false AND is_active=true` 的 Membership，对缺失 Installation 执行插入。
-同一串行重试会因已存在关系成为 no-op；本期不额外建设并发竞争协调，竞争失败由下一次
-完整 reconcile 或 Artifact 构建重试收敛。
-该过程不删除行、不读取历史 Default exclusion、也不在 GET/list/detail、Pool 运维循环或
-文件快照中写入。inactive SkillSet、未激活 Local 与 System Default 都不参与物化；极少
-历史 Local Direct 残留通过 DB 订正。
+切流不要求先完成全库 backfill。`BotCapabilityStateReader` 是回答“Bot 当前有效能力”的唯一
+DB Read seam：每次 Effective Read 先调用统一 `flush_installations()`，把普通 SkillSet、
+System Default 与 Default exclusion 的当前规则幂等物化到 Installation，再只读 Installation。
+冷 Bot/Legacy drift 因此会在首次读取时修复；稳态读取走 read-only fast path。
+
+Flush 是纯 DB→DB 收敛：active ordinary Set 与未 exclusion Default 成员补行；inactive
+ordinary Set 与 excluded Default 成员删行；无任何 Set 能解释的 Direct Installation 永不触碰。
+它不访问设备、不触发 Runtime Projection。所有写命令仍在同一 UoW 中 eager 维护
+Installation，flush 只承担迁移期兼容和漂移修复。未来完成一次全量 DB flush 后可以移除
+读前保护，但在此之前所有 Effective Read 必须通过 Reader。
 
 不存在公开的 Installation Resource API：
 
@@ -177,13 +195,16 @@ PUT/GET/DELETE /bots/{bot_id}/skills/{skill_id}/installation
 #### 3.3 SkillSet 原子语义
 
 - 一个普通 SkillSet 只有 active 或 inactive，不存在半选。
-- 同一 Bot 下，同一 Skill/MCP 最多属于一个普通 SkillSet。
-- Direct active 资源不能加入普通 SkillSet；必须先 Direct deactivate。
-- 已属于普通 SkillSet 的资源不能单独 activate/deactivate。
+- 同一 Bot 下，同一 Skill/MCP 最多属于一个 SkillSet，System Default 包含在内；excluded
+  仍然属于 Default。
+- Direct active 资源不能加入任何 SkillSet；必须先 Direct deactivate。
+- 已属于任何 reaching SkillSet 的资源不能单独 activate/deactivate；Default exclusion 只能
+  通过 Default Set-scoped add/remove 命令切换。
 - 激活/停用 SkillSet 原子批量增删成员对应的 Installation 行。
 - 向 active SkillSet 添加成员时，同事务创建 Installation。
 - 从 active SkillSet 移除成员时，同事务删除 Installation。
-- System Default 始终 active，不承接历史 Local exclusion hack。
+- System Default 始终 active、不能删除/停用/编辑共享 Membership；其 per-Bot exclusion 与
+  Installation delta 必须同事务写入。
 
 稳定错误码：
 
@@ -195,17 +216,24 @@ RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET
 
 #### 3.4 MCP 对齐
 
-`ac_bot_mcp_installation` 与 Skill 使用相同定义：它是 Bot 当前期望生效 MCP 的物化清单，不保存 inactive 行。
+`ac_bot_mcp_installation` 与 Skill 使用相同定义：它是 Bot 显式有效 MCP 的唯一读取事实，不保存 inactive 行。
 
 - Direct activate/deactivate 增删 Installation。
-- Active SkillSet 原子增删显式 MCP 成员。
-- Effective Skill 声明的 MCP 依赖和 System Default 由全量 Resolver 物化。
+- Active ordinary SkillSet 与未 exclusion Default MCP 成员原子增删 Installation。
+- Skill 声明的 MCP dependency 是版本化 Runtime 派生，不写 MCP Installation。
 - 安装、加入 SkillSet、激活前执行服务端权限校验。
 - MCP Catalog、用户配置、调用身份仍是独立事实。
 
-Engine/Template Default MCP Policy 与 Active Skill MCP dependency 的统一深模块边界仍为
-**TBD**。本次 Phase 2 合同收口不修改现有 MCP Effective/Runtime 语义，也不得在
-Asset、Draft、Grant、Lease、Publication 或 Version 实现中复制另一套 MCP Union。
+Engine/Template Default MCP Policy 是唯一明确例外：它来自代码配置而非 Set Membership，
+不进入 Installation flush。Runtime Effective MCP 只能在统一 Collector 中计算：
+
+```text
+Engine/Template Default MCP Policy（应用其 exclusion）
+∪ BotCapabilityStateReader.active_mcp_server_codes
+∪ Active exact Skill Version 的 mcp_dependencies
+```
+
+Asset、Draft、Grant、Lease、Publication、Version 和 Artifact 实现不得复制另一套 MCP Union。
 
 #### 3.5 持久化合同
 
@@ -213,13 +241,14 @@ Phase 1 新增两张 Desired State 表：
 
 | 表 | 唯一键 | 行语义 |
 | --- | --- | --- |
-| `ac_bot_skill_installation` | `tenant + env + owner_id + bot_id + skill_id` | Skill 当前应在 Bot 生效 |
-| `ac_bot_mcp_installation` | `tenant + env + bot_id + server_code` | MCP 当前应在 Bot 生效 |
+| `ac_bot_skill_installation` | `tenant + env + owner_id + bot_id + skill_id` | Bot 当前有效 Skill |
+| `ac_bot_mcp_installation` | `tenant + env + owner_id + bot_id + server_code` | Bot 当前显式有效 MCP |
 
 两表都不保存 inactive 行、来源类型、SkillSet ID 或 Runtime observed status。
-普通 SkillSet Membership 继续复用既有关系表；同一 Bot 的同一资源最多属于一个
-普通 SkillSet，由数据库可表达的唯一约束与事务内校验共同保证。System Default
-保留平台默认 Skill/MCP/CLI 配置，但不再作为 Local active 的 exclusion 存储技巧。
+普通 SkillSet Membership 继续复用既有关系表；同一 Bot 的同一资源最多属于一个 Set，
+Default Set 包含在内，excluded 仍算 Membership。System Default 保留平台默认
+Skill/MCP/CLI 配置；exclusion 是 Default Set 自身的 per-Bot deactivate，不把资源交回 Direct
+控制。Local Direct 不再借用 Default exclusion 表达。
 
 Phase 2 复用一条 `ac_skill` 作为跨版本稳定 Identity：
 
@@ -254,6 +283,16 @@ Phase 2 复用一条 `ac_skill` 作为跨版本稳定 Identity：
   不得伪造 Publication Attempt。
 - `ac_skill_publication_attempt` 保存幂等键、目标版本、外部提交阶段、失败原因和
   RESULT_UNKNOWN；一个 Skill 同时最多一个进行中 Attempt。
+- `ac_skill_center_reference_operation` 保存一次把 SC Public 外部 `skill_code` 懒物化并加入
+  目标 Bot SkillSet 的持久业务过程；每个 code 一行、同一批共享 `request_id`。它保存冻结
+  `sc_version_number`、最终 `resolved_skill_id`、状态和错误，不替代 Asset、Version、Membership
+  或 Installation。终态永久保留，本期不提供 cancel/delete/retry 或 TTL 清理。
+- SC Public 外部身份不复用同名 Local/Repo/Space：`ac_skill.git_path=center://<external_skill_code>`
+  保存外部定位，TeamClaw 为该资产生成自己的 UUIDv4 `skill_uuid`；Canonical OSS、Runtime、
+  Artifact 始终使用内部 `skill_uuid + exact sc_version_number`。不新增 `origin_kind/corpus` 持久列；
+  `LOCAL/REPO/CENTER` corpus 由 locator 派生，并在使用点复用一个全局枚举。
+- 已有 `zip_url` 保存持久 Draft locator，`package_url` 仅保存当前 Publication 调 SC 的临时
+  signed URL；线上字段可复用，不新增同义列。
 - 所有新增表的 `env` 非空，所有查询和唯一键同时包含 tenant/env。
 
 当前目标分支已存在部分 Additive Schema。实现必须以本节覆盖其中仍残留的 TTL、
@@ -262,27 +301,35 @@ Space 删除或旧状态定义；已合入代码不因“已经存在”而自�
 ### 4. Runtime 一致性
 
 ```text
-ac_bot_skill_installation
-+ ac_bot_mcp_installation
-+ System Default / CLI
+SkillSet/Default/exclusion rules
+        ↓ flush（DB→DB，无设备 side effect）
+ac_bot_skill_installation + ac_bot_mcp_installation
+        ↓ BotCapabilityStateReader
+RuntimeProjectionResolver（纯计算）
         ↓
-统一 Resolver
+BotRuntimeProjector（DB→Engine）
         ↓
-skills-local / skills-repo / skill-center / MCP projection
+skills-local / skills-repo / skill-center / MCP/CLI projection
 ```
 
-1. Mutation 前校验 ACL、Bot ready、Membership、MCP 权限和 runtime name 冲突。
-2. Runtime name 统一使用 `ac_skill.name`，由单一 `RuntimeNamePolicy` 规范化。
-3. 每次 mutation 后执行一次完整 reconcile，不逐资源增量推送。
-4. Runtime 明确失败时按方案 A 恢复旧 Installation 集合，再恢复旧 Projection。
-5. activate/deactivate 即使 `changed=false`，仍完整 reconcile，作为自愈入口。
-6. 不建设 Runtime 持久重试任务，不为此使用 `ac_task_queue`。
-7. 进程崩溃窗口接受暂时不一致；下次 mutation 或 Bot 重启时全量自愈。
-8. Installation 是 Desired State，不是 Runtime observed state。
-9. Bot offline/not-ready 返回 `409 BOT_NOT_READY`，不写新的 Desired State。
-10. Runtime reconcile 前、Service Bot 新 Artifact build 前执行普通 active SkillSet
-    Installation 的按 Bot 懒物化；普通读取、历史 Default exclusion 与已发布 Artifact
-    重启/扩容/回滚都不触发该写入。
+1. 所有回答或驱动“Bot 当前真正能用什么”的 use case 必须从
+   `BotCapabilityStateReader` 读取；Asset、Draft、Version 和历史 Artifact 读取不触发 flush。
+2. Mutation 前校验 ACL、Bot ready、Ownership Policy、MCP 权限和 runtime name 冲突。
+3. Runtime name 统一使用 `ac_skill.name`，由单一 `RuntimeNamePolicy` 规范化。
+4. Command Service 使用共享 `mutate → project → compensate` 流程；Runtime 明确失败时以第二个
+   补偿事务恢复旧 Desired State，再重新投影旧状态。Projector 不拥有业务事务。
+5. Projection 默认按受影响 Domain 选择 Scope；启动/重新 ACTIVE、Service Draft build 和需要
+   全量自愈时使用 `ProjectionScope.everything()`。Teclaw 仍一次 compose/deliver whole Artifact。
+6. activate/deactivate 即使 `changed=false` 仍允许投影，作为显式自愈入口。
+7. 不建设无限期 Runtime observed-state 对账和逐 Bot actual-version 表。Track Latest 与首次
+   Device ACTIVE 失败允许 deadline 有界的 `ac_task_queue` 持久重试；普通命令仍同步投影并补偿。
+8. Device ACTIVE 首次完整投影失败时入队唯一
+   `BOT_RUNTIME_BOOTSTRAP_RETRY(binding_id)`；执行前必须确认 binding 仍是当前 Draft binding，
+   替换/释放或 Published Service binding 均 no-op。
+9. Installation 是 Effective Desired State，不是 Runtime observed state。Bot offline/not-ready 的
+   变更沿现有 Command 合同失败关闭，不留下新的半套 Desired State。
+10. Center 总是使用 `pool_center` exact-version corpus，不参与 Local/Repo `legacy|pool` 选择；
+    禁止 `legacy_center`、按名称寻址和 Backend 硬编码 Engine home 路径。
 
 ### 5. Phase 1：Bot Skill OpenAPI
 
@@ -309,6 +356,7 @@ skills-local / skills-repo / skill-center / MCP projection
 | GET | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/content` | path | 返回可消费 `SKILL.md` |
 | GET | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/parameters` | path | Bot 级参数 |
 | PUT | `/openapi/v1/bots/{bot_id}/skills/{skill_id}/parameters` | 全量参数对象 | 按 `SKILL.md config` 校验；保存失败必须传播 |
+| GET | `/openapi/v1/bots/skills/{skill_id}/readme` | path | Botless 共享资产详情：Repo 或已发布 Space/Center 的可展示 `SKILL.md` |
 
 统一列表集合：
 
@@ -336,11 +384,16 @@ deactivate
 
 对 Repo/Space，Direct activate 即 runtime install，deactivate 即 runtime uninstall。Local deactivate 只删除 Installation，Local 资产保留。
 
+Botless `readme` 只凭全局 `skill_id` 定位共享 Repo 或已发布 Space/Center Asset；`user_id` 仅表达
+调用者。它不接受 bot/entity/engine 参数，不读取 Bot-owned Local、Space Draft 或未发布 Skill。
+查看某个 Bot 已安装 Skill 的内容继续使用 Bot-scoped `/content`。
+
 旧 `/api/skills/upload` 的实现本期原样冻结，等待产品链路下线；不将其纳入新上传模块改造。新 OpenAPI 的 raw ZIP 与 multipart 文件夹入口必须在 HTTP 解码后汇入同一个 `LocalSkillUploadService.upload_local_skill()` 生命周期；两种输入先由共享 `SkillPackageValidator` 规范化为同一 package contract，再共用同名替换、存储、DB 更新和失败补偿。
 
 #### 5.3 Skill 添加来源与 Skill Center 懒物化
 
-添加弹窗读取三个独立目录：
+添加弹窗读取三个独立目录。Bot 工坊“引用市场 Skill”由前端分别查询 TeamClaw 与
+SkillCenter Public 后聚合展示；Backend 不建设混合分页接口。用户确认后前端按来源拆分命令：
 
 | 入口 | 接口 | 权威来源 |
 | --- | --- | --- |
@@ -350,25 +403,53 @@ deactivate
 
 旧 `POST /openapi/v1/bots/market/skills` 保留为 TeamClaw 市场兼容入口。Skill Center 的团队搜索不得作为工坊目录；TC 才是 Space、Grant、Draft 和消费状态的权威。
 
+未物化 SC Public Skill 的“查看详情”复用现有 search response 的 `homepageUrl`，由前端 iframe
+嵌入 SkillCenter 页面；查看行为不创建 `ac_skill`、不下载 Package、不触发物化。Botless
+`readme` 只服务已经成为 TeamClaw 共享资产的 Repo/Published Space/已懒物化 Center Skill。
+
+- TeamClaw/工坊结果已经存在 `ac_skill.id`，调用普通
+  `PUT /openapi/v1/bots/{bot_id}/skill-sets/{set_id}/skills/{skill_id}`。
+- SkillCenter Public 结果只有外部 `skill_code`，调用以下专用异步 Reference；不使用
+  `market_source + identifier` 通用 Router。
+
 Skill Center 市场有万级且持续增长的外部记录，禁止全量扫描/写入 `ac_skill`。用户确认引用时才按需物化。公开 Interface 使用 Bot/SkillSet-scoped 的专用异步 Reference，不复用通用 Membership 的 `skill_id`，也不传 `market_source`：
 
 ```text
 POST /openapi/v1/bots/{bot_id}/skill-sets/{set_id}/skill-center-references
+GET  /openapi/v1/bots/{bot_id}/skill-sets/{set_id}/skill-center-references
 GET  /openapi/v1/bots/{bot_id}/skill-sets/{set_id}/skill-center-references/{reference_id}
 
 Idempotency-Key: required
 {
-  "skill_code": "<SkillCenter stable code>"
+  "skill_codes": ["public-skill-a", "public-skill-b"]
 }
 ```
 
-POST 返回 `202 Accepted` 与持久 `reference_id`；前端通过 GET 查询
-`PENDING/RUNNING/SUCCEEDED/FAILED`。Reference 首次受理时解析并冻结精确
-`sc_version_number`，内部完成 SC PUBLIC 授权、`ac_skill/ac_skill_version` 幂等创建、
-Canonical Store 完整性校验和最终 ACL/SkillSet 状态复验；只有 Version=`PUBLISHED` 后才调用
-`SkillSetManagementService` 写 Membership，active Set 再维护 Installation 与 Runtime
-Projection。已物化但最终 Membership 失败时保留共享只读 Asset/Version，不写悬空
-Membership。当前阶段只冻结合同；没有真实 Backend 实现前不得加入 Gateway 正式 OpenAPI artifact。
+POST 单次最多 20 个 code，返回 `202 + request_id + reference_id[]`；相同 Key 返回原
+Operations 并幂等确保 live Task。每个 code 独立持久状态：
+
+```text
+QUEUED → RESOLVING_VERSION → MATERIALIZING
+       → ADDING_TO_SKILL_SET → PROJECTING_RUNTIME
+       → COMPLETED | FAILED
+```
+
+collection 使用标准 `page/page_size<=100`，默认倒序并支持 `request_id/status` 过滤；终态永久
+保留，本期无 cancel/delete/retry。前端关闭弹窗后仍可恢复进度；失败项由用户重新提交。
+POST 受理时要求目标 SkillSet live；若执行期间 Set 被删除，item 以 `SKILL_SET_NOT_FOUND`
+失败。为保证失败结果仍可恢复，collection/detail GET 以 Bot ACL + Operation 中冻结的 exact
+`skill_set_id` 授权和过滤，不要求该 Set 当前仍存在。
+
+Worker 以受控并发（初始 4）解析/物化，冻结外部 `skill_code → exact version`，收集本批成功
+`skill_id` 后只调用一次 `SkillSetManagementService.add_skills()`，active Set 只投影一次。
+物化成功前禁止写 Membership；物化成功但 Membership/Projection 失败时保留共享 Asset/Version，
+补偿目标 Bot 的 Membership/Installation。最终写入前必须重验最新 Bot、Owner、Actor 权限和
+SkillSet 状态；inactive Set 只写 Membership，active Set 同时维护 Installation/Runtime。
+
+`ac_task_queue` key 为 `skill-center-reference:<request_id>`，只承担执行。Operation 事务提交后
+再 enqueue；失败时 POST 返回 503，相同 Idempotency-Key 重放原 Operations 并重新确保 Task。
+瞬时 SC/OSS 错误有限自动 Retry，永久错误或 Retry 耗尽使对应 item `FAILED`。当前阶段只冻结
+合同；没有真实 Backend 实现前不得加入 Gateway 正式 OpenAPI artifact。
 
 ### 6. Phase 1：Repo Catalog
 
@@ -441,6 +522,18 @@ GET/PUT /openapi/v1/bots/mcp/servers/{server_code}/config
 
 不存在 MCP Installation Resource API。产品通过 SkillSet 管理 MCP；外部调用方可 Direct activate/deactivate。
 
+Bot 工坊中每个 active MCP 的 Owner/Caller 身份配置复用已经发布的 Caller Identity 合同，不在
+SkillSet Membership 中重复保存：
+
+```text
+GET   /openapi/v1/bots/{bot_id}/caller-context
+PATCH /openapi/v1/bots/{bot_id}/mcps/{server_code}/call-type
+       {"call_type":"owner|caller"}
+```
+
+inactive Membership 尚未进入 Runtime，不创建独立 call-type；成为 active 后通过 Caller Identity
+模块配置。Skill/MCP Control Plane 只负责 Effective MCP，Caller Identity 模块负责执行身份。
+
 ### 9. 七桃负责且冻结的 OpenAPI
 
 以下接口以七桃当前方案和已发布合同为准，本文不重构：
@@ -457,6 +550,7 @@ POST   /openapi/v1/bots/spaces/{space_id}/join-requests
 POST   /openapi/v1/bots/spaces/{space_id}/market-favorites
 POST   /openapi/v1/bots/spaces/{space_id}/market-favorites/cancel
 POST   /openapi/v1/bots/spaces/{space_id}/market-favorites/search
+POST   /openapi/v1/bots/spaces/{space_id}/market-favorites/status
 ```
 
 本期不支持 Space 删除，不调用 Skill Center close/disable/delete Team。
@@ -467,13 +561,28 @@ POST   /openapi/v1/bots/spaces/{space_id}/market-favorites/search
 
 | Method | Path | 语义 |
 | --- | --- | --- |
-| GET | `/openapi/v1/bots/spaces/{space_id}/skills` | 能力工坊 Skill 列表 |
+| GET | `/openapi/v1/bots/spaces/{space_id}/skills` | 能力工坊 Skill 列表；`keyword?,page,page_size`，返回 `Page[SpaceSkillSummary]` |
 | POST | `/openapi/v1/bots/spaces/{space_id}/skills` | multipart 本地文件夹 + 幂等键创建 Identity、V1 Draft、Binding、Owner |
 | POST | `/openapi/v1/bots/spaces/{space_id}/skills/import-from-git` | JSON Git source + 幂等键，映射同一创建命令 |
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}` | 创作详情：Draft、Version、Attempt、权限 |
 | GET | `/openapi/v1/bots/skills/repository/{skill_id}` | 消费详情：只返回 latest Published |
 
-创建事务包含 `ac_skill Identity + V1 Draft facts + ac_skill_space_binding + 唯一 Skill Owner`；SC RPC 不进入事务。本地文件夹上传使用重复 `files` 与可选 JSON `file_paths` 字段保存相对目录结构，不要求前端生成 ZIP。Git 导入后与本地文件夹创建同模型，不转换 Legacy Repo Skill。
+两个入口均要求 `Idempotency-Key` 并汇入同一个 Draft Application Service。创建顺序为：
+鉴权和共享 `SkillPackageValidator` 完整校验 → 生成 `skill_uuid/revision_id` → 写 immutable Draft
+ZIP → DB 事务创建 `ac_skill Identity + V1 EDITING Draft + Space Binding + 唯一 Owner`。SC、
+Installation、SkillSet、Runtime 和 Skills Pool 不进入创建事务。DB 失败时 best-effort 清理新 ZIP。
+
+本地文件夹上传使用重复 `files` 与 JSON `file_paths` 保留相对目录，不要求浏览器生成 ZIP；
+Backend 解码后与现有 Local folder upload 复用同一 package 校验模块，但不复用包含 Bot/Pool/
+Runtime side effect 的整个 Local upload 生命周期。
+
+Git 导入是 snapshot，不转换 Legacy Repo。仓库包含多个 `SKILL.md` 时，根目录优先；否则按
+规范化 POSIX 父目录 bytewise lexicographical ascending 选择第一项，禁止依赖 walk 顺序或
+非法后跳到下一项。持久化实际 `source_subdir + resolved branch + commit_sha`；后续 refresh
+只读取同一 subdir。用户需要其他 Skill 必须显式提供更精确的 `subdir`。
+
+`creation_request_id` 唯一范围 `(tenant,env,request_id)`；同 Key 同 Space 返回原 Skill，跨
+Space 返回 `409 IDEMPOTENCY_KEY_REUSED`。V1 保存完成后立即存在持久 Draft，不依赖页面内存。
 
 详情分别返回：
 
@@ -484,13 +593,21 @@ draft_status
 publication_status
 ```
 
-SKILL.md 是名称和描述的唯一事实来源。
+SKILL.md 是名称和描述的唯一事实来源。`name` 创建后不可变；所有后续保存/refresh/publish
+必须保持同名。`description` 随 Version 可变：Draft detail 返回 Draft description，
+`ac_skill.description` 在新 Version PUBLISHED 后才更新为 latest Published description。
+Published `SKILL.md` 不可原地修改；只允许在 EDITING Draft 中通过文件接口编辑并发布新
+Version。产品本期不提供“展示名称/描述/图标即时生效”的独立 mutation：展示名称不得脱离
+`SKILL.md.name`，描述不得绕过 Version，图标使用既有默认展示，未来有明确需求再 additive
+增加独立 presentation metadata。
 
 ##### 10.1.1 工坊列表领域摘要
 
 `GET /openapi/v1/bots/spaces/{space_id}/skills` 是能力工坊的集合读取接口。
 它返回稳定领域摘要，而不是数据库表行或页面按钮 ViewModel。工坊列表包含已退役
 Skill 供历史查看；消费型 Repository/Consumable 列表仍排除已退役 Skill。
+`keyword` 由 Backend 对名称和描述做不区分大小写过滤，过滤后再分页；默认按
+`gmt_modified DESC, skill_id DESC` 稳定排序。`page` 从 1 开始，`page_size` 默认 20、最大 100。
 
 当前代码中的旧 `SpaceSkillItem` 从未被产品或外部调用方使用，不承担向前兼容；实现时
 直接删除旧 `status/draft_status/current_user_skill_role/can_edit/can_grant/
@@ -553,17 +670,33 @@ Grants、Versions、Publication 历史、文件树或升级/退役影响列表�
 | Method | Path | 语义 |
 | --- | --- | --- |
 | POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft/upgrade` | 创建下一版本 Draft；要求幂等键 |
-| GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft` | Draft 状态和 Git metadata |
 | GET/PUT | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft/files/{path}` | 读取/保存单文件 |
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft/files` | Draft 文件树 |
-| POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft/replace` | multipart 本地文件夹原子替换 |
 | POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft/refresh-from-git` | 从原 Git 来源手动刷新 |
+| DELETE | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft` | 放弃 EDITING Draft；未发布且无外部事实时删除整个 Skill |
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions` | Published Version 列表 |
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}` | 精确业务版本详情 |
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/files` | 精确版本文件树 |
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/files/{path}` | 精确版本文件内容 |
 
-URL 中 `{version}` 是业务序号 `1/2/3`，不是 `ac_skill_version.id`。Published Version 不可修改、删除或单独下线。Git 刷新失败时 Draft 完全不变。
+创作详情已经返回完整 Draft summary（target/status/revision/metadata/source），不再提供独立
+`GET .../draft`。产品没有“重新上传整个文件夹覆盖 Draft”入口，因此不公开
+`POST .../draft/replace`；package replacement 保持 Draft 模块内部能力。文件树与单文件
+GET/PUT 分别服务编辑器目录、内容读取和保存。
+
+每次内容 mutation 使用：完整校验 → 写新 immutable ZIP → DB CAS
+`EDITING + expected revision + Team fencing_token` → commit → best-effort 删除旧 ZIP。Personal
+同样使用 expected revision CAS；FROZEN 拒绝全部内容写入。Git refresh 失败时 Draft 完全不变。
+
+升级 Draft 从 TC Canonical Store 精确复制 latest Published Vn；Store 缺失或校验失败时从 SC
+exact version 下载并修复 Store，再创建 Vn+1 Draft。禁止使用 current/latest、旧 Draft 或历史
+package URL。发布成功后不保留 Draft；只有再次点击升级才创建下一版 Draft。
+
+DELETE 要求 `expected_revision_id`，Team Lease 必须 FREE/HELD_BY_ME；无 Published Version 且
+无 Attempt/Version/Installation/Membership/Artifact 等外部事实时删除整个 Skill 聚合，否则只
+放弃升级 Draft。FROZEN 永不允许删除。DB 事实先提交，OSS 做 best-effort 清理。
+
+URL 中 `{version}` 是业务序号 `1/2/3`，不是 `ac_skill_version.id`。Published Version 不可修改、删除或单独下线。
 
 #### 10.3 Owner、Manager、编辑权申请与放弃 Draft
 
@@ -630,11 +763,11 @@ Owner 审批，旧 Owner 不得继续审批。
 
 | Method | Path | 语义 |
 | --- | --- | --- |
-| GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/upgrade-impact` | 发布前查看受影响 Bot |
+| GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/publication-impact` | 发布前查看可能受 Track Latest 影响的 Bot；信息提示，不是门禁 |
 | POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/publications` | 冻结 Draft、创建 Attempt 和 task；幂等；202 |
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/publications` | Attempt 历史 |
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/publications/{attempt_id}` | Attempt 详情 |
-| POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/versions/{version}/materialization-retry` | 只重试同一 Version 物化 |
+| POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/publications/{attempt_id}/retry` | 恢复同一 Attempt；按最新阶段分流，不要求新幂等键 |
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/retirement-impact` | 退役影响检查 |
 | POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/retirement` | 整体退役 Skill |
 
@@ -644,8 +777,13 @@ Owner 审批，旧 Owner 不得继续审批。
 Draft=EDITING
 → Draft=FROZEN
 → 创建 Publication Attempt
-→ 写入 ac_task_queue
+→ commit
+→ 调用现有 TaskQueueService.enqueue()
 ```
+
+本期明确接受业务事务与 Task enqueue 的有限非事务窗口，不采用 Transactional Pending Writer。
+enqueue 失败时同一 Publication POST Idempotency-Key 或 Attempt Retry 必须返回原 Attempt 并重建
+Task，不能创建新 Attempt/Version，也不能重复调用 SC publish。
 
 Attempt 状态：
 
@@ -660,8 +798,16 @@ PREPARING → SC_SUBMITTING → WAITING_SC → MATERIALIZING
 - 物化失败：不再次 POST SC，只重试同一 Version。
 - RESULT_UNKNOWN：Draft 保持 FROZEN，普通用户不能处理。
 - 不建设长期 Snapshot URI/Hash，不提供 Attempt cancel。
-- Runtime reconcile 不使用 `ac_task_queue`；SC 发布与物化继续使用持久任务。
-- Bot Binding、Service Artifact 或进行中操作存在时阻断整体退役。
+- Publication POST 不要求 `fencing_token`：Personal 直接发布；Team 重新校验权限和 Lease，
+  `HELD_BY_OTHER` 拒绝，FREE/HELD_BY_ME 冻结服务端最新已提交 Revision。并发保存通过
+  `EDITING + fencing_token` CAS 与发布冻结互斥。
+- `PREPARING + sc_post_started_at=NULL` 的 Retry 可继续首次 submit；`SC_SUBMITTING/
+  WAITING_SC/RESULT_UNKNOWN` 只能查询状态，禁止再次 publish；`MATERIALIZING` 只重试同一
+  `skill_version_id`；FAILED 必须修改 Draft 后新建 Attempt；SUCCEEDED 幂等成功。
+- 自动 Task Retry 有 deadline；耗尽后 Attempt detail/summary 返回：
+  `recovery.state=AUTO_RETRYING|AVAILABLE|NOT_AVAILABLE` 与
+  `recovery.kind=PREPARATION|SC_STATUS_CHECK|MATERIALIZATION|null`。前端三个恢复按钮统一调用
+  Attempt Retry；普通 FAILED/SUCCEEDED 无恢复按钮。
 
 前端阶段投影固定为：`PREPARING/SC_SUBMITTING/WAITING_SC` 显示“发布中”；SC 已形成
 精确 Version 且处于 `MATERIALIZING` 时显示“物化中”；只有
@@ -669,12 +815,52 @@ PREPARING → SC_SUBMITTING → WAITING_SC → MATERIALIZING
 `RESULT_UNKNOWN` 单独显示“发布结果确认中”，不得提供普通重新发布按钮。Bot Track
 Latest 是发布成功后的 Best-Effort 异步刷新，不参与发布成功门禁。
 
+`upgrade` 只创建 Vn+1 EDITING Draft，不查询影响面。产品在发布确认时先 GET
+`publication-impact` 展示 Bot 列表，用户点击“已知悉并发布”后调用 Publication POST；不签发
+acknowledgement token。预览到 PUBLISHED 之间事实可能变化，Track Latest 必须在发布成功后按
+最新 Installation/迁移期候选重新发现并由 Reader 复核，禁止信任前端预览列表。
+
+#### 12.1 Retirement 与血缘
+
+本期采用 TeamClaw 本地不可逆整体退役：写 `ac_skill.retired_at/retired_by`，隐藏于 TeamClaw
+市场和 consumable 列表，禁止新 Draft、Publication、Direct activation、Membership 和 SC
+Public Reference 复用；不调用 Skill Center 删除/关闭/下线。Published Versions、Canonical
+Store、历史 Attempt/Grant/Binding/Artifact 全部保留；不支持 unretire 或单 Version offline。
+
+GET impact 供产品预览，POST 必须在事务内锁定 Skill 并重新检查全部 blocker；没有 force、
+管理员绕过或“已知悉后继续”。Owner 与 Manager 均可查看和执行，普通 Member 无权限。
+
+| blocker | 退役是否拒绝 |
+| --- | --- |
+| Active/Frozen Draft | 是 |
+| 进行中或 RESULT_UNKNOWN Attempt | 是 |
+| 任意普通/Default Membership，含 inactive/excluded | 是 |
+| Bot Skill Installation | 是 |
+| 存活 Service Bot 仍可 restart/scale/rollback 的 exact Artifact ref | 是 |
+| 无法读取/解析/完整扫描的 Artifact | 是，返回 UNKNOWN_ARTIFACT |
+| Published Version、Canonical Store、Favorite、Grant、Space Binding | 否 |
+| Source Service Bot 已彻底删除，只剩审计 Artifact | 否 |
+
+Service Artifact 血缘不建新索引表、不 backfill。唯一 `ServiceArtifactLineageReader` 通过现有
+`BotPublishRepository` 读取 inline 或透明 re-inline 的 offloaded `ext`：文件型解析
+`skills_manifest.center_skills[]`，Teclaw 解析 `config_artifact.skills[]` 中
+`store=skill-center,path=<skill_uuid>/<version>`。任何 OSS/JSON/分页未知都 fail closed。
+仅把存活 Service Bot 的 SUCCESS/UPGRADED/RELEASED/VALIDATING 等仍可重放记录作为 blocker；
+只下线不释放血缘，必须彻底删除/退役对应 Service Bot。
+
+POST 已退役幂等 `changed=false`；存在 blocker 返回 `409 SKILL_RETIREMENT_BLOCKED` 与最新
+counts。退役与新增引用写入共享 Skill row lock 和 `retired_at IS NULL` 不变量；同一
+`center://external_skill_code` 退役后返回 `SKILL_RETIRED`，不得生成第二个 TeamClaw 资产绕过。
+
 ### 13. Skill Center 映射与精确版本物化
 
 - Space 持久化 SC Team ID；每次 SC 调用沿 Skill Ownership 显式解析 Team，禁止使用
   全局默认 Team。本期不提供 Team close/disable/delete。
 - 新 Space Skill 的 `skill_uuid` 直接作为全局唯一 SC `skillCode`；可变名称只写
   `skillName`，名称允许重复且不参与查找。
+- SC Public 已有 `skillCode/userProvidedSkillId` 不要求 UUID。懒物化时按
+  `git_path=center://<external_skill_code>` 幂等定位 TeamClaw 资产，并为它生成内部 UUIDv4；
+  不能因为外部 code 与已有 Local/Repo/Space 同名就复用后者。
 - Version 保存精确 `sc_version_number` 和可用的 SC version ID；不新增重复的
   `sc_skill_code` 字段。
 - Skill Center Gateway 只负责 transport、鉴权、配置、请求/响应归一化和错误分类；
@@ -731,37 +917,142 @@ Latest 是发布成功后的 Best-Effort 异步刷新，不参与发布成功门
 - 禁止 `current/latest`、版本覆盖和数量型 GC；历史 Service Artifact 可能继续引用
   任意旧版本。
 
+`SkillVersionResolver` 是唯一 exact-version Read seam：
+
+```text
+BotCapabilityStateReader.active_skill_assets()
+→ flush Installation
+→ SkillVersionResolver.resolve_latest_runtime_assets(env, assets)
+   ├─ Local/Repo：保持 ac_skill 当前内容
+   └─ Center：一次批量查询各 skill_id 最高 ordinal 的 PUBLISHED Version
+→ Runtime-ready RegisteredSkillAsset tuple
+```
+
+Resolver 只读 DB，不下载 SC、不物化、不写 Installation、不推 Runtime；禁止 N+1、字符串版本
+排序、MATERIALIZING、SC 现场 latest 或 current symlink。Runtime、Teclaw Composer 与新 Service
+Artifact build 都消费同一已解析值对象；Published Service 历史实例不调用 Resolver。
+
+所有 Skill 都有 `mcp_dependencies`；Local/Repo 从当前兼容投影读取，Center 的权威是 exact
+`ac_skill_version.metadata_json.mcp_dependencies`（或等价版本级列/子表）。Materializer 只有在
+依赖解析、metadata 和所有 Canonical Store 完整后才能 PUBLISHED；扫描失败不能降级为空依赖。
+
+SC Public 不接 Webhook。周期巡检与手动同步复用一个新的 exact-version
+`SkillCenterSyncService.sync()` 深模块：
+
+```http
+POST /openapi/v1/bots/market/skill-center/sync
+```
+
+只扫描已经懒物化的 `center://` Public assets，不扫描 SC 全量市场，也不巡检 TeamClaw 自己
+发布的 Space Skills。同步查询 SC latest，对比 latest PUBLISHED Version，新版本交给同一
+Materializer；接口等待发现和物化完成后返回摘要，Track Latest 异步触发。旧 Sync 仅复用调度/
+DI 壳子，废弃 name 映射、latest/current、NAS 中转、保留 N 版本、旧完成日志和数量型 GC。
+单项失败保留旧 PUBLISHED 并继续其他资产。
+
 ### 14. Track Latest 与 Service Artifact
 
-- Personal/Desktop 和 Service Bot 草稿态使用 Track Latest。
-- Space Skill 发布并物化后，对 Personal/Desktop Bot执行 Best-Effort 全量 reconcile。
-- 不维护逐 Bot target/actual resolution 表。
-- Service Bot 发布时把 `skill_uuid + 精确 SC version` 固化到 Artifact。
-- 已发布 Service Bot 重启、扩容、回滚只读历史 Artifact，不动态解析 latest。
-- Skill 新版本只更新 Service Bot 草稿；下次发布 Service Bot 时才进入新 Artifact。
-- Local/Repo/Space 路径解析集中在统一 Resolver/Engine Adapter。
-- 文件型 OpenClaw/Claude Code Service Artifact 的 contract version、精确 Center dependency
-  字段和兼容读取规则标记为 **TBD**；“Artifact v5”目前只是未冻结的候选名称/版本，
-  不得作为已确认合同实现。上述内容必须在 P2-11 实现前冻结；Teclaw 继续使用已确认的
-  Artifact v4 `store=skill-center,path=<skill_uuid>/<sc_version_number>`。
+#### 14.1 Track Latest
 
-### 15. Bot Type × Engine 兼容矩阵
+Space Skill 或已懒物化 SC Public Skill 的新 Version 只有在 `PUBLISHED` 后才触发 Track Latest；
+失败不回滚 Version。候选发现使用 Installation 与迁移期 active ordinary Membership，随后每个
+Bot 必须通过 Reader flush-then-read 再确认当前是否 active。只由 Default Set 解释的引用不主动
+扇出，在重启/重新 ACTIVE/下一次 Skill mutation 时自愈。
 
-| Bot Type | 本期完整支持的 Logical Engine | Space/Center 交付 |
-| --- | --- | --- |
-| Personal | OpenClaw、Claude Code、Hermes、Teclaw | Draft Track Latest；重启/下一次 mutation 全量自愈 |
-| Desktop | OpenClaw、Hermes | Track Latest；重启/重新 ACTIVE 时全量自愈 |
-| Service | OpenClaw、Claude Code、Teclaw | Draft Track Latest；Published Release 固化精确版本 |
+```text
+PUBLISHED
+→ TRACK_LATEST_FANOUT(skill_id)
+→ BOT_TRACK_LATEST_RECONCILE(owner_id,bot_id,skill_id)
+→ Reader + SkillVersionResolver 重新解析执行时 latest
+→ BotRuntimeProjector
+```
 
-- Claude Code 的产品能力与 OpenClaw 一致；新增 Bot 实际使用 AICoding image 的
-  personalCoding/applicationCoding 变体。物理目录由 Runtime probe/Adapter 判定，
-  不能只凭 active_engine 分流。
-- 历史纯 Claude Code、历史 active_engine=aicoding、Desktop Claude Code 等未在矩阵
-  中的对象只保留现有安全读取/删除能力，不新增 Center 支持。
-- 不支持组合在创建、变更 Engine、Direct activate、SkillSet activate 和 Service
-  publish 等所有写入口统一失败关闭。
-- 文件型 Engine 的路径编码集中在 Engine Adapter；Backend 只传结构化 Local/Repo/
-  Center dependency。Teclaw 只接收 Artifact Store/Path。
+Task 使用 `ac_task_queue` 有限 Retry，不持久化逐 Bot target/actual version。V2 Task 执行时 V3
+已经 PUBLISHED，则直接收敛到 V3。投影前后比较完整 mapping snapshot；发生漂移时 Reschedule，
+不把 snapshot 作为新领域状态。
+
+文件型 Runtime 的 Track Latest Scope 包含 Skill 与 MCP dependency delta：当前 Version 新增的
+MCP 为 claimed，旧 Version 不再需要且无其他来源的 MCP 为 released，同时全量刷新 allow-list；
+无关 MCP 不重推配置。Teclaw 每次本来就 compose whole Artifact，因此一次 Track Latest 只做
+一次 whole delivery。
+
+Personal/Desktop 与 Service Draft binding 参与 Track Latest。Published Service online binding
+永远不参与；Skill 新 Version 只更新其 Draft，下一次 Service 发布才冻结新版本。
+
+#### 14.2 文件型 Service Artifact
+
+本期采用简单方案 A，不新增 `ServiceCapabilitySnapshot`：Service build pre-stage 先经 Reader
+执行一次 `BotRuntimeProjector.project(ProjectionScope.everything())`，随后现有 Artifact Producer
+从已收敛的同一 Runtime 目录打包。接受 build 期间能力并发变化的有限窗口；未来可增加不可变
+Snapshot/fingerprint，但不阻塞本期。
+
+Artifact 只复制 Bot 实际 active Slice：Local 内容随 Artifact 复制；完整 `skills-repo` 和
+`skill-center` corpus 必须排除，只保留实际 active Skill 的精确 symlink。Deploy 时把共享
+Repo/Center OSS 只读挂载到 physical runtime 的 `skills-pool/skills-repo` 与
+`skills-pool/skill-center`；logical Claude Code + coding template 必须由统一 layout resolver
+落到 physical AICoding 路径。
+
+现有 `skills_manifest schema_version=1` 采用 additive optional `center_skills`，不升 v2：
+
+```json
+{
+  "schema_version": 1,
+  "center_skills": [
+    {
+      "runtime_name": "pdf",
+      "skill_uuid": "uuid",
+      "sc_version_number": "1.0.0",
+      "mcp_dependencies": ["mcp.a"]
+    }
+  ]
+}
+```
+
+按 `runtime_name + skill_uuid + sc_version_number` 稳定排序。Manifest 只承担 exact-version 审计、
+物理 Artifact 校验、退役血缘和问题定位，不在 restart 时重新解析 latest 或重建软链。旧 Artifact
+没有 `center_skills` 时按无 Center 的原合同读取。Validator 必须保证：不携带完整共享 Corpus；
+Center link 与 manifest 一一对应并指向 exact version；共享 Store 中 `SKILL.md` 可读；不存在
+未声明/版本漂移/越界 link。
+
+#### 14.3 Teclaw v4
+
+Teclaw 继续使用 Artifact v4，不新增 v5。Composition Root 增加通用 Store：
+
+```text
+store_id = skill-center
+type     = oss
+bucket   = bot_oss.bucket_name
+base     = aidesktop/aidesktop_<env>/bolt_shared/skills-center
+```
+
+Center SkillRef 为 `name=ac_skill.name, scope=shared, store=skill-center,
+path=<skill_uuid>/<sc_version_number>`；只有被 Ref 实际使用时才写 Store。V1→V2 只替换 Ref path，
+停用移除 Ref，最后一个 Center Ref 移除后可省略 Store。缺 Store、缺 exact Version、权限或下载失败
+时整次 apply fail closed。v4 JSON Schema 只做 additive 扩展，旧 Artifact、offload/re-inline 与历史
+restart/rollback 必须继续可读。
+
+#### 14.4 历史重放
+
+Service Bot 发布成功时 Artifact 冻结 exact Center Version 和最终 Effective MCP；restart、scale、
+rollback 只读对应历史 Artifact，禁止调用 Reader/Resolver、SC latest 或 Track Latest。文件型
+Scale 必须复用原发布 Artifact，而不是从当前 Draft Runtime 重打包。不存在历史 Center ref 的
+Artifact 不需要迁移。
+
+### 15. Bot Type × Engine 产品入口与技术合同
+
+Center Skill 的技术链路对所有实际存在的 Bot Type × Engine 组合使用同一 exact-version
+Resolver/Projector/Artifact 合同。Backend 不得因为产品当前未开放某个创建入口而编码
+`SKILL_RUNTIME_NOT_SUPPORTED` 或静态矩阵拒绝；若目标 Bot 已存在，就不能仅凭
+`bot_type/engine_type` 拒绝 Membership、activation 或 Artifact build。
+
+产品当前可达组合仍按 PRD 决定 E2E 范围；未开放组合通过共享 contract/unit fixtures 保证无
+Center 专属分支。Claude Code 的 logical identity 与 physical runtime layout 分离：
+personalCoding/applicationCoding 使用 AICoding physical paths，纯 Claude Code 使用自身 paths，
+统一 resolver 必须基于 Bot facts 判定，不能只读 `active_engine`。
+
+文件型 Engine 的 home/path 编码集中在 Engine Adapter；Backend 只传结构化
+Local/Repo/Center dependency。Teclaw 只接收 Artifact Store/Path。Mapping v3 未广告、真实
+Consumer 未识别 Center Store、OSS/Mount/Device 不可用属于发布门禁或真实 Projection 失败，
+沿用统一 fail-closed/补偿，不转化为产品“不支持”错误。
 
 ### 16. Principal、幂等、错误
 
@@ -769,7 +1060,8 @@ Latest 是发布成功后的 Best-Effort 异步刷新，不参与发布成功门
 - Space Skill创作、编辑、发布：必须有明确 User 身份并校验 Owner/Manager。
 - `tenant/env/user_id` 从认证上下文取得，业务 body 不得任意指定。
 - Bot Principal 不能修改 Skill、SkillSet 或 Space。
-- Create Space Skill、Create Draft、Publish、Materialization Retry 要求 `Idempotency-Key`。
+- Create Space Skill、Create Upgrade Draft、Publication、SC Public Reference 要求
+  `Idempotency-Key`；Attempt Retry 以 `attempt_id` 作为稳定恢复身份，不要求新 Key。
 - Membership PUT/DELETE 天然幂等。
 - Local 同名上传继续原地替换。
 
@@ -777,8 +1069,8 @@ Latest 是发布成功后的 Best-Effort 异步刷新，不参与发布成功门
 | --- | --- |
 | 400 | wire/request 格式错误 |
 | 403 | ACL、Owner/Manager、MCP 权限失败 |
-| 404 | Skill/Space/Version/Attempt 不存在 |
-| 409 | 状态机、Membership、Bot ready、runtime name 冲突 |
+| 404 | Skill/Space/Version/Attempt/Reference 不存在 |
+| 409 | 状态机、Membership、Bot ready、runtime name、Retirement blocker 冲突 |
 | 422 | SKILL.md、本地文件夹、Git 内容或参数校验失败 |
 | 502/503 | Skill Center 或 Runtime 不可用 |
 
@@ -795,8 +1087,14 @@ Latest 是发布成功后的 Best-Effort 异步刷新，不参与发布成功门
    `SpaceSkillSummary` 替换，不保留旧按钮 ViewModel 字段。
 7. Local、Repo、Space 不自动转换；Bot-local 长期保持 Bot-local。
 8. Legacy Local/Repo 不要求补 UUID 才能读取；公开身份仍是 `ac_skill.id`。
-9. Resolver 覆盖 Local/Repo/Space、OpenClaw、Claude Code(AICoding image)、Hermes、Teclaw 及产品支持的 Bot Type。
-10. Service Bot v4 旧 Artifact 继续可读；Center 精确依赖采用 additive contract/capability gate。
+9. 所有 Effective Read 通过 Reader flush-then-read Installation；Legacy Set/Default/exclusion
+   语义仍能惰性物化，不能保留第二套 in-memory merge。
+10. Resolver 覆盖 Local/Repo/Center、OpenClaw、Claude Code(AICoding image)、Hermes、Teclaw；
+    不因产品未开放入口而静态拒绝已经存在的 Bot/Engine 组合。
+11. 文件型 `skills_manifest schema_version=1` additive optional `center_skills`，Teclaw 继续 v4
+    additive `skill-center` Store；旧 Artifact 不升版、不切流并继续可读。
+12. SC Public 外部 code 与 Local/Repo/Space 同名不复用资产；`center://` locator 与内部 UUID
+    映射必须稳定，退役后不得生成第二个资产绕过。
 
 ### 18. 交付、切流与回滚
 
@@ -807,9 +1105,13 @@ Phase 1 是 Phase 2 的控制面基础，但允许 Phase 2 的纯内部模块在
    按 Bot 懒物化、Runtime Resolver、兼容 Adapter 和 OpenAPI 兼容测试，不改变产品流量。
 2. **Phase 1 Enable**：切换 Local active 的内部事实源，开放 Repo/SkillSet/MCP
    canonical OpenAPI，产品显式使用统一 Gateway；通过 Phase 1 全量门禁。
-3. **Phase 2 Consumer first**：先部署 Mapping v3、pool_center、Teclaw skill-center
-   Store 和 Service Artifact 精确版本读取能力。
-4. **Phase 2 Enable**：再开放 Space Skill 创建、编辑、发布、Track Latest 和退役。
+3. **Phase 2 Consumer first**：先部署并以 CI/Singlebox/预发真实 Consumer 验证 Canonical
+   Materializer、Mapping v3、pool_center、文件型 exact Center mapping、Teclaw v4
+   `skill-center` Store 和 Service Artifact 精确版本读取/重放能力。
+4. **Phase 2 Producer**：再部署 Backend Publication、SC Public Reference、Track Latest、
+   Artifact Producer；协议不建设长期 feature flag、双版本或 Bot Type 静态支持矩阵。
+5. **Phase 2 Enable**：最后发布新增 Gateway OpenAPI 和产品入口。软件协议兼容由发布门禁证明；
+   每次真实 OSS/Device/Projection 仍按执行结果 fail closed/补偿。
 
 Phase 1 回滚可以恢复旧 Adapter/Resolver，但不得丢失已经写入的 Installation；
 回滚版本必须继续理解新表或先停止新写并验证等价投影。Phase 2 一旦生成 Space Skill、
@@ -844,8 +1146,9 @@ Phase 1 必测：
 - MCP Catalog/permission/config 兼容与新 Bot MCP Direct 语义。
 - Runtime 明确失败的方案 A 补偿、进程崩溃窗口、下一次 mutation 和 Bot restart
   全量自愈。
+- Reader 对普通/Default Skill/MCP membership 与 exclusion 做一次幂等 flush，随后全部消费者只读
+  Installation；Engine/Template Policy MCP 仍由统一 Effective MCP Collector 合并。
 - Legacy Local/Repo/Bot-local 不转换，System Default Skill/MCP/CLI 仍然生效。
-- 所有支持 Bot Type × Engine 组合及未支持组合 fail-closed。
 
 Phase 1 Backend 完成定义：Gateway OpenAPI gate 通过，存量 BFF 与 canonical
 OpenAPI 的等价测试通过，全部产品能力均存在可供前端切流的 Gateway Backend 合同，
@@ -861,15 +1164,25 @@ Lease、发布、版本升级、Skill Center 物化、Track Latest、Service Art
 
 Phase 2 必测：
 
-- Identity/Ownership/Owner/Manager/Draft 原子创建；并发升级和并发发布唯一。
+- folder/Git Identity/Ownership/Owner/V1 Draft 原子创建；Git 多 SKILL.md 确定性第一项与
+  source_subdir 固化；请求重放不重复 Identity。
 - Team Edit Lease acquire/release/takeover/fencing；Personal 不需要 Lease；无 TTL。
-- Git 导入/刷新失败不改变 Draft；FROZEN 后所有写入口拒绝。
-- SC 单次 POST、明确失败、超时 RESULT_UNKNOWN、迟到结果和人工恢复。
+- immutable Draft Revision、单文件保存 CAS、Git 刷新失败不改变 Draft；FROZEN 后全部写入口拒绝。
+- SC Publication 单次 POST、明确失败、RESULT_UNKNOWN、迟到结果，以及同 Attempt 的
+  PREPARATION/SC_STATUS_CHECK/MATERIALIZATION 恢复。
+- publication-impact 只提示；发布成功后按最新候选重算，不信任预览。
 - MATERIALIZING 对消费者不可见；文件型/Teclaw 物化全部成功后才 PUBLISHED。
-- Track Latest 不维护逐 Bot actual；下一次 mutation/restart 自愈。
+- SC Public 一次 20 code 的持久 Reference：Idempotency replay、跨刷新轮询、部分成功、终态
+  永久保留、最终最新权限/Set 状态复验、单次批量 Membership/Runtime Projection。
+- SC Public 周期/手动 Sync 只巡检已物化 center:// 资产，单项失败保留旧 PUBLISHED。
+- Track Latest 不维护逐 Bot actual；Direct/ordinary 候选、Default-only 延迟自愈、Version/MCP
+  delta、Task 合并和 Device ACTIVE bootstrap retry 全部覆盖。
 - Service Release 固化 V1 后，V2 发布不影响 V1 的扩容、重启和回滚。
-- Skill retirement 的 Binding、Artifact、Attempt、Materialization 前置阻断。
-- Local/Repo/Center 并存、Mapping v2/v3、Teclaw v4 兼容和 Store 访问隔离。
+- 文件型 manifest v1 additive center_skills、共享 Center mount、排除完整 Corpus、exact symlink
+  校验；Teclaw v4 additive Store 与真实 Consumer/offload/re-inline。
+- Retirement 覆盖 Draft/Attempt、inactive/default Membership、Installation、inline/offloaded
+  replayable Artifact 与 UNKNOWN_ARTIFACT；无 force、无 SC 下线。
+- Local/Repo/Center 并存、Mapping v2/v3、所有实际 Bot/Engine 走共享合同而无静态拒绝分支。
 
 Phase 2 完成定义：产品主流程 E2E、SC pre 联调、多引擎矩阵、Service Artifact
 回滚和 Phase 1 全量回归全部通过。
@@ -883,8 +1196,12 @@ Phase 2 完成定义：产品主流程 E2E、SC pre 联调、多引擎矩阵、S
 - Skill 复制/Clone；最终 PRD 已移除该功能，本期不定义对应接口。
 - Publication Attempt cancel。
 - Runtime effective/reconcile 运维接口。
-- Runtime 持久重试或逐 Bot observed resolution 查询。
-- 普通用户处理 `RESULT_UNKNOWN`。
+- 无限期 Runtime 对账、逐 Bot observed actual-version 查询或 `ServiceCapabilitySnapshot`。
+- Transactional TaskQueue Pending Writer；本期接受业务事务后 enqueue 的有限窗口。
+- SC Webhook、全量 SC Public 扫描或 SC 全局下线。
+- Reference Operation cancel/delete/原地 retry 与终态 TTL 清理。
+- Retirement force/admin bypass、unretire 和新的 Artifact lineage 索引表/backfill。
+- 长期 feature flag、Center 双协议版本和按 Bot Type × Engine 的静态支持表。
 
 ## Further Notes
 
@@ -904,34 +1221,12 @@ Phase 2 完成定义：产品主流程 E2E、SC pre 联调、多引擎矩阵、S
 
 ### Ticket 治理
 
-- 本 Spec 发布后重新执行 to-tickets，按 Phase 1/Phase 2 建立 blocking edges。
-- Phase 1 采用五个纵向实现 Ticket 加一个 Backend Gate，顺序如下：
-  1. `P1-01 Installation 深模块与 Local 兼容` 无业务实现 blocker，先建立 Skill/MCP
-     Installation 事实源、统一 Service 边界和已发布 Local wire 兼容。
-  2. `P1-02 Repo Catalog 与 Direct API`、`P1-03 SkillSet Skill 原子语义` 均被
-     P1-01 阻塞，P1-01 完成后可以并行。
-  3. `P1-04 MCP Direct 与 SkillSet 语义` 被 P1-03 阻塞，复用同一套 SkillSet
-     原子命令和 Installation 语义。
-  4. `P1-05 统一 Resolver 与 Runtime 全量投影` 被 P1-02、P1-03、P1-04 阻塞。
-  5. `P1-GATE Backend 全量兼容与矩阵验收` 被 P1-05 阻塞，并复用已经落地的
-     Legacy 回归基线；同时从真实 Backend Router 生成并提交正式
-     `src/gateway/configs/schemas/bots.openapi.json`，供涔涔通过 Swagger/Redoc Review。
-- 不创建 Phase 1 前端实现 Ticket；前端切流只作为独立产品发布验收项，由前端团队
-  依据生成 OpenAPI/Swagger 执行。
-- Phase 2 治理基础拆为可独立 Review 的深模块：#1166 Canonical Parser、#1169
-  Team-scoped SkillCenterGateway、#1174 P2-02A Grant 可与 P2-01 并行；#1515 P2-02B
-  Editor Request 与 #1516 P2-02C Draft Edit Lease 只依赖 #1174，二者可并行。
-- P2-01 Identity/Initial Draft 与 P2-03 Draft 文件编辑必须等待
-  `DraftContentStore` 及失败补偿合同冻结；P2-03 还依赖 #1516 的 Lease/fencing seam。
-  随后 P2-04 Git 导入和 P2-05 Publication Attempt 可并行。P2-06 文件型 Store、P2-07 Teclaw Store、P2-08
-  真实 SC 映射在 P2-05 后按真实依赖并行，汇合到 P2-09 PUBLISHED/升级/版本读取；
-  再执行 P2-10 Track Latest、P2-11 Service Artifact、P2-12 退役和最终 Gate/Rollback。
-- 旧 #1165～#1187 必须逐条归类为“已完成并关闭”“修订复用”或“被新 Ticket
-  取代并关闭”；禁止保留两套同时可领取的 ready-for-agent 工作。
-- 每个实现 Ticket 使用独立上下文和 `implement` 流程，以小 PR 合入
-  `dev`；一个 PR 只关闭一个可独立验收的纵向行为。
-- Phase 2 Ticket 可以在其真实 blockers 完成后并行，但 Phase 2 功能启用必须等待
-  Phase 1 Gate。
+- 旧 Phase 2 Ticket 正文基于早期 Draft/Artifact/Reference 语义，不能继续作为实现权威。
+- 本次先完成正式 Spec 与产品 PRD 对照；Frontend Guide/OpenAPI 清单对齐后再统一重新拆 Ticket。
+- 旧 Ticket 必须逐条归类为“已完成关闭”“按最终 Spec 修订复用”或“被新 Ticket 取代关闭”，
+  禁止保留两套同时可领取的 ready-for-agent 工作。
+- 新 Ticket 按可独立验收的纵向闭环拆分，每个实现 PR 合入 `dev`；Consumer-first 门禁、
+  Backend Producer 和 Gateway/Product Enable 必须有明确 blocking edges。
 
 ### 前端接口文档
 

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -481,7 +481,7 @@ Canonical 前缀：`/openapi/v1/bots/{bot_id}/skill-sets`。
 | Method | 相对路径 | 语义 |
 | --- | --- | --- |
 | GET | `/skill-sets` | 列出全部 SkillSet，含 Default |
-| POST | `/skill-sets` | 创建 inactive SkillSet；要求 `Idempotency-Key` |
+| POST | `/skill-sets` | 创建 active SkillSet；要求 `Idempotency-Key`；空集合不触发 Runtime |
 | GET | `/skill-sets/{set_id}` | 详情和父子范围校验 |
 | PUT | `/skill-sets/{set_id}` | 修改元信息；名称唯一范围 `tenant+env+bot_id` |
 | DELETE | `/skill-sets/{set_id}` | 删除 inactive 普通 Set；Default 禁止 |

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -90,7 +90,7 @@ artifact。本文先冻结待实现合同；实现完成后生成的 OpenAPI JSO
 40. 作为文件型 Runtime 用户，我希望 Local、Repo、Center 在统一投影中共存但不互相转换。
 41. 作为历史用户，我希望旧 Local、Repo、Bot-local 和不含 Center 的 Artifact 行为保持不变。
 42. 作为安全负责人，我希望跨 tenant/env、路径穿越、非法压缩包和越权访问失败关闭。
-43. 作为产品负责人，我希望仍被 SkillSet、Artifact 或进行中操作引用的 Skill 不能退役。
+43. 作为产品负责人，我希望仍被 SkillSet、Artifact 或进行中操作引用的 Skill 不能下线。
 44. 作为前端开发者，我希望实现后直接使用 Gateway OpenAPI/Swagger 获取准确请求、响应和错误合同。
 45. 作为发布负责人，我希望 Phase 1 和 Phase 2 各有独立验收门禁，并能定位安全回滚下限。
 46. 作为 Team Space 普通成员，我希望可以向当前 Skill Owner 申请编辑权限，并在工单中查询结果。
@@ -100,7 +100,7 @@ artifact。本文先冻结待实现合同；实现完成后生成的 OpenAPI JSO
 50. 作为 SkillCenter Public 用户，我希望一次选择多个 Skill 后获得可跨刷新恢复的异步引用进度，且只有物化完成后才加入 SkillSet。
 51. 作为发布者，我希望发布前看到可能受 Track Latest 影响的 Bot，但该预览不阻断发布，发布成功后由后端重新计算真实候选。
 52. 作为发布者，我希望自动重试耗尽后可以针对同一个 Attempt 恢复准备、查询 SC 结果或重试物化，而不会重复发布。
-53. 作为 Skill Owner/Manager，我希望退役前看到完整血缘；任何 Membership、Installation、进行中操作或仍可重放 Service Artifact 都必须阻断退役。
+53. 作为 Skill Owner/Manager，我希望下线前看到完整血缘；无引用时保留历史 Published Vn、创建 Vn+1 Draft，并允许修改后重新发布。
 
 ## Implementation Decisions
 
@@ -127,7 +127,7 @@ Backend 真实提供，同时避免在 Review 阶段暴露返回 `501` 的占位
 #### Phase 2：Space Skill 能力升级
 
 - Space Skill Identity、Draft、Version、Edit Lease、Publication Attempt。
-- Skill Center 发布、精确版本物化、升级传播和整体退役。
+- Skill Center 发布、精确版本物化、升级传播和可恢复下线。
 - 七桃负责的 Space、Member、Join Request、Favorite 接口保持现有合同，不在本文重构。
 - 当前 `GET /openapi/v1/bots/spaces/{space_id}/skills` 的旧 `SpaceSkillItem` 尚无真实
   调用方，且已与前端确认不作为兼容合同；Phase 2 直接以本节的
@@ -254,8 +254,11 @@ Phase 2 复用一条 `ac_skill` 作为跨版本稳定 Identity：
 
 - Legacy Local/Repo 可以没有 `skill_uuid`；公开 API 身份仍是 `ac_skill.id`。
 - 新 Space Skill 必须由服务端生成唯一 UUID，并直接作为 SC `skillCode`。
-- `ac_skill` 只增加活动 Draft 目标版本、Draft 状态、Git 来源和整体退役事实；
+- `ac_skill` 只增加活动 Draft 目标版本、Draft 状态、Git 来源和 TeamClaw-local Offline 事实；
   不新增 `ac_skill_draft`，也不把 Version 再写成一条 `ac_skill`。
+- Offline 使用 `offline_at/offline_by`（或实现 Review 时按仓库命名确认的等价字段）；当前尚未
+  被业务使用的 `retired_at/retired_by` 旧骨架不作为最终合同，必须在实现前替换/废弃，禁止用
+  永久退役字段承载可恢复语义。
 - `ac_skill_space_binding` 是一个 Skill 在一个环境下唯一的 Space Ownership。
 - `ac_skill_grant` 表达恰好一个 Owner 和多个 Manager，不读取 Legacy 权限表。
 - `ac_skill_draft_edit_lease` 是永久协作锁事实，保存 holder 与单调递增 fencing
@@ -604,8 +607,8 @@ Version。产品本期不提供“展示名称/描述/图标即时生效”的�
 ##### 10.1.1 工坊列表领域摘要
 
 `GET /openapi/v1/bots/spaces/{space_id}/skills` 是能力工坊的集合读取接口。
-它返回稳定领域摘要，而不是数据库表行或页面按钮 ViewModel。工坊列表包含已退役
-Skill 供历史查看；消费型 Repository/Consumable 列表仍排除已退役 Skill。
+它返回稳定领域摘要，而不是数据库表行或页面按钮 ViewModel。工坊列表包含 Offline Skill
+供继续编辑和重新发布；消费型 Repository/Consumable 列表排除 Offline Skill。
 `keyword` 由 Backend 对名称和描述做不区分大小写过滤，过滤后再分页；默认按
 `gmt_modified DESC, skill_id DESC` 稳定排序。`page` 从 1 开始，`page_size` 默认 20、最大 100。
 
@@ -617,7 +620,7 @@ can_apply_edit` 投影，以本节 `SpaceSkillSummary` 作为唯一响应模型�
 
 ```text
 skill_id / skill_uuid / name / description / space_type / owner
-lifecycle_status = DRAFT_ONLY | PUBLISHED | RETIRED
+lifecycle_status = DRAFT_ONLY | PUBLISHED | OFFLINE
 latest_published_version
 draft = { target_version, status = EDITING | FROZEN } | null
 active_publication = { attempt_id, target_version, status } | null
@@ -641,7 +644,7 @@ edit_draft
 publish_draft
 delete_draft
 create_upgrade_draft
-retire_skill
+offline_skill
 manage_grants
 transfer_owner
 request_edit_access
@@ -663,7 +666,7 @@ holder_display_name
 
 无 Draft 时 `lease_summary=null`；Personal Draft 返回 `required=false,state=NOT_REQUIRED`。列表不返回
 fencing token；点击编辑后通过 Lease 资源重新查询/变更实时状态。列表也不内联全量
-Grants、Versions、Publication 历史、文件树或升级/退役影响列表，这些由对应资源接口提供。
+Grants、Versions、Publication 历史、文件树或发布/下线影响列表，这些由对应资源接口提供。
 
 #### 10.2 Draft 与 Version
 
@@ -759,7 +762,7 @@ Owner 审批，旧 Owner 不得继续审批。
 
 本期不建设 TTL 或续租。关闭编辑抽屉主动释放；遗留锁由 Takeover。旧 fencing token 永久不能写入。
 
-### 12. Phase 2：Publication Attempt 与退役
+### 12. Phase 2：Publication Attempt 与可恢复下线
 
 | Method | Path | 语义 |
 | --- | --- | --- |
@@ -768,8 +771,8 @@ Owner 审批，旧 Owner 不得继续审批。
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/publications` | Attempt 历史 |
 | GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/publications/{attempt_id}` | Attempt 详情 |
 | POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/publications/{attempt_id}/retry` | 恢复同一 Attempt；按最新阶段分流，不要求新幂等键 |
-| GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/retirement-impact` | 退役影响检查 |
-| POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/retirement` | 整体退役 Skill |
+| GET | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline-impact` | 下线影响检查 |
+| POST | `/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline` | 本地隐藏 Published Skill，并创建下一版 Draft |
 
 发布事务：
 
@@ -820,19 +823,24 @@ Latest 是发布成功后的 Best-Effort 异步刷新，不参与发布成功门
 acknowledgement token。预览到 PUBLISHED 之间事实可能变化，Track Latest 必须在发布成功后按
 最新 Installation/迁移期候选重新发现并由 Reader 复核，禁止信任前端预览列表。
 
-#### 12.1 Retirement 与血缘
+#### 12.1 Offline、重新发布与血缘
 
-本期采用 TeamClaw 本地不可逆整体退役：写 `ac_skill.retired_at/retired_by`，隐藏于 TeamClaw
-市场和 consumable 列表，禁止新 Draft、Publication、Direct activation、Membership 和 SC
-Public Reference 复用；不调用 Skill Center 删除/关闭/下线。Published Versions、Canonical
-Store、历史 Attempt/Grant/Binding/Artifact 全部保留；不支持 unretire 或单 Version offline。
+产品“下线”是 TeamClaw-local、可恢复的 Offline，不是永久 Retirement，也不把历史 Published
+Version 改回 Draft。无 blocker 时，Offline 保留不可变 Published Vn，并基于 Vn 创建 Vn+1
+EDITING Draft；用户修改后发布 Vn+1，成功事务清空 `offline_at/offline_by`，恢复 PUBLISHED
+可见性。重新上线必须产生新 Version，禁止覆盖或重新发布旧 Vn。
+
+Offline 期间从 TeamClaw 市场和 consumable 列表隐藏，禁止新的 Direct activation、Membership
+和其他 Bot 消费；Owner/Manager 仍可查看历史、编辑 Draft 和发布。它不调用 Skill Center
+删除/关闭/下线，因此 SC 外部页面可能持续可见。永久 Retirement、SC 全局下线和单 Version
+offline 均不在本期范围。
 
 GET impact 供产品预览，POST 必须在事务内锁定 Skill 并重新检查全部 blocker；没有 force、
 管理员绕过或“已知悉后继续”。Owner 与 Manager 均可查看和执行，普通 Member 无权限。
 
-| blocker | 退役是否拒绝 |
+| blocker | 下线是否拒绝 |
 | --- | --- |
-| Active/Frozen Draft | 是 |
+| Active/Frozen Draft | 是；先放弃或完成当前 Draft/Attempt |
 | 进行中或 RESULT_UNKNOWN Attempt | 是 |
 | 任意普通/Default Membership，含 inactive/excluded | 是 |
 | Bot Skill Installation | 是 |
@@ -846,11 +854,18 @@ Service Artifact 血缘不建新索引表、不 backfill。唯一 `ServiceArtifa
 `skills_manifest.center_skills[]`，Teclaw 解析 `config_artifact.skills[]` 中
 `store=skill-center,path=<skill_uuid>/<version>`。任何 OSS/JSON/分页未知都 fail closed。
 仅把存活 Service Bot 的 SUCCESS/UPGRADED/RELEASED/VALIDATING 等仍可重放记录作为 blocker；
-只下线不释放血缘，必须彻底删除/退役对应 Service Bot。
+Service Bot 仅下线仍可能重新上线，因此仍阻断，必须彻底删除/退役该 Service Bot 才释放血缘。
 
-POST 已退役幂等 `changed=false`；存在 blocker 返回 `409 SKILL_RETIREMENT_BLOCKED` 与最新
-counts。退役与新增引用写入共享 Skill row lock 和 `retired_at IS NULL` 不变量；同一
-`center://external_skill_code` 退役后返回 `SKILL_RETIRED`，不得生成第二个 TeamClaw 资产绕过。
+Offline Application Service 复用 Upgrade Draft 的 exact source 规则：先做只读 impact 预检，
+从 TC Canonical Store 读取 Published Vn（失败时从 SC exact version 修复）并写新 immutable Draft
+Revision，再在一个 DB 事务中锁 Skill、重查 blocker、写 `offline_at/offline_by` 与 Vn+1 Draft
+facts。DB 失败或并发 blocker 出现时清理新 Revision；不存在“已下线但没有 Draft”的半状态。
+
+POST 已 Offline 且 Vn+1 Draft 存在时幂等 `changed=false`。存在 blocker 返回
+`409 SKILL_OFFLINE_BLOCKED` 与最新 counts。Offline 与新增引用共享 Skill row lock 和
+`offline_at IS NULL` 不变量；Offline 期间新引用返回 `SKILL_OFFLINE`。若用户主动放弃 Offline
+Draft，Skill 仍保持 Offline，可再次调用 `draft/upgrade` 重新创建下一版 Draft；只有新 Version
+PUBLISHED 才恢复上线。
 
 ### 13. Skill Center 映射与精确版本物化
 
@@ -1008,7 +1023,7 @@ Repo/Center OSS 只读挂载到 physical runtime 的 `skills-pool/skills-repo` �
 ```
 
 按 `runtime_name + skill_uuid + sc_version_number` 稳定排序。Manifest 只承担 exact-version 审计、
-物理 Artifact 校验、退役血缘和问题定位，不在 restart 时重新解析 latest 或重建软链。旧 Artifact
+物理 Artifact 校验、Offline 血缘和问题定位，不在 restart 时重新解析 latest 或重建软链。旧 Artifact
 没有 `center_skills` 时按无 Center 的原合同读取。Validator 必须保证：不携带完整共享 Corpus；
 Center link 与 manifest 一一对应并指向 exact version；共享 Store 中 `SKILL.md` 可读；不存在
 未声明/版本漂移/越界 link。
@@ -1070,7 +1085,7 @@ Consumer 未识别 Center Store、OSS/Mount/Device 不可用属于发布门禁�
 | 400 | wire/request 格式错误 |
 | 403 | ACL、Owner/Manager、MCP 权限失败 |
 | 404 | Skill/Space/Version/Attempt/Reference 不存在 |
-| 409 | 状态机、Membership、Bot ready、runtime name、Retirement blocker 冲突 |
+| 409 | 状态机、Membership、Bot ready、runtime name、Offline blocker 冲突 |
 | 422 | SKILL.md、本地文件夹、Git 内容或参数校验失败 |
 | 502/503 | Skill Center 或 Runtime 不可用 |
 
@@ -1094,7 +1109,7 @@ Consumer 未识别 Center Store、OSS/Mount/Device 不可用属于发布门禁�
 11. 文件型 `skills_manifest schema_version=1` additive optional `center_skills`，Teclaw 继续 v4
     additive `skill-center` Store；旧 Artifact 不升版、不切流并继续可读。
 12. SC Public 外部 code 与 Local/Repo/Space 同名不复用资产；`center://` locator 与内部 UUID
-    映射必须稳定，退役后不得生成第二个资产绕过。
+    映射必须稳定。
 
 ### 18. 交付、切流与回滚
 
@@ -1159,7 +1174,7 @@ Phase 1 对新产品 PRD 的可测边界：Local 上传、Repo Catalog、MCP Cat
 添加到 SkillSet、SkillSet 整体激活/停用、System Default 和 Runtime 恢复可做完整
 Backend 验收。真实 Space Skill 的本地文件夹/Git 创建、Draft 编辑、Owner/Manager/Edit
 Lease、发布、版本升级、Skill Center 物化、Track Latest、Service Artifact 精确版本
-和退役属于 Phase 2；Phase 1 只能通过兼容 Fixture 验证已有 Space wire 和消费边界，
+和可恢复下线属于 Phase 2；Phase 1 只能通过兼容 Fixture 验证已有 Space wire 和消费边界，
 不能把它计为新产品主流程 E2E。
 
 Phase 2 必测：
@@ -1180,8 +1195,8 @@ Phase 2 必测：
 - Service Release 固化 V1 后，V2 发布不影响 V1 的扩容、重启和回滚。
 - 文件型 manifest v1 additive center_skills、共享 Center mount、排除完整 Corpus、exact symlink
   校验；Teclaw v4 additive Store 与真实 Consumer/offload/re-inline。
-- Retirement 覆盖 Draft/Attempt、inactive/default Membership、Installation、inline/offloaded
-  replayable Artifact 与 UNKNOWN_ARTIFACT；无 force、无 SC 下线。
+- Offline 覆盖 Draft/Attempt、inactive/default Membership、Installation、inline/offloaded
+  replayable Artifact 与 UNKNOWN_ARTIFACT；无 force、无 SC 下线；成功创建 Vn+1 Draft并可重新发布。
 - Local/Repo/Center 并存、Mapping v2/v3、所有实际 Bot/Engine 走共享合同而无静态拒绝分支。
 
 Phase 2 完成定义：产品主流程 E2E、SC pre 联调、多引擎矩阵、Service Artifact
@@ -1200,7 +1215,7 @@ Phase 2 完成定义：产品主流程 E2E、SC pre 联调、多引擎矩阵、S
 - Transactional TaskQueue Pending Writer；本期接受业务事务后 enqueue 的有限窗口。
 - SC Webhook、全量 SC Public 扫描或 SC 全局下线。
 - Reference Operation cancel/delete/原地 retry 与终态 TTL 清理。
-- Retirement force/admin bypass、unretire 和新的 Artifact lineage 索引表/backfill。
+- Offline force/admin bypass、永久 Retirement 和新的 Artifact lineage 索引表/backfill。
 - 长期 feature flag、Center 双协议版本和按 Bot Type × Engine 的静态支持表。
 
 ## Further Notes


### PR DESCRIPTION
## Problem

The Phase 2 Skill capability-upgrade spec still contained superseded contracts for Installation reads, Draft APIs, publication impact/recovery, SkillCenter Public references, exact-version Runtime delivery, Service Artifacts, offline/republication, and Bot/Engine support. The frontend PRD Mock also had not been systematically compared against the final domain decisions.

## Solution

- make Installation plus `BotCapabilityStateReader` the only Effective Capability read seam
- finalize Draft/Publication/Materialization, Track Latest, file Artifact, Teclaw v4, and recoverable Offline contracts
- define persistent asynchronous multi-Skill SkillCenter Public Reference Operations
- define the two-market frontend/backend split and existing iframe detail behavior
- align SkillSet creation with current `dev` (`is_active=true` for a new empty Set)
- define Offline as: hard lineage gate, retain Published Vn, create Vn+1 Draft, and clear Offline after the new Version is published
- remove superseded Draft, impact, retry, Artifact-version, permanent-retirement, and unsupported-matrix semantics
- add a product-PRD conformance report against `Teamclaw_PRD_new origin/master@72de5d1c`
- freeze confirmed frontend alignment points and record that remaining Ticket text must be rebuilt from this spec

## Validation

- `git diff --check` — passed
- searched the final spec for superseded `upgrade-impact`, version-scoped materialization retry, public Draft replace, Artifact v5/TBD, legacy market-source router, permanent Retirement endpoints, and static unsupported-matrix terms — no conflicting contracts remain
- refreshed `github/dev@b68ec64f1` immediately before push; branch is rebased and conflict-free
- Backend tests were not run because this PR changes Markdown specifications only

## Compatibility and risk

No runtime code, generated OpenAPI artifact, schema, or released route changes are included. Candidate Phase 2 interfaces must still be implemented before they may appear in the generated Gateway OpenAPI.

## Spec

- `src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md`
- `src/backend/specs/2026-08-20-skill-capability-upgrade/product-prd-conformance.md`

## Related issues

Relates to #1246.
