### PR TITLE
fix(aicoding): sync MCP desired state on restart

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -683,9 +683,28 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             import asyncio
 
             refresh_succeeded = True
+            skill_set_service = None
+            if skill_set_factory is not None:
+                try:
+                    skill_set_service = skill_set_factory.create(
+                        user_id=effective_entity_id,
+                        entity_id=effective_entity_id,
+                        bot_id=ctx.bot_id,
+                        entity_type=effective_entity_type,
+                        engine_type=effective_engine,
+                    )
+                except Exception as skill_error:
+                    refresh_succeeded = False
+                    logger.error(
+                        "[aicoding.restart] skill set service create error: "
+                        "bot_id=%s, engine_type=%s, error=%s",
+                        ctx.bot_id, effective_engine, skill_error,
+                        exc_info=True,
+                    )
+
             if mcp_sync is not None:
                 try:
-                    async def _do_mcp_sync() -> tuple[dict, dict | None]:
+                    async def _do_mcp_sync() -> tuple[dict, bool | None]:
                         scope_result = await mcp_sync.refresh_mcp_scope(
                             user_id=effective_entity_id,
                             entity_id=effective_entity_id,
@@ -696,16 +715,24 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                         if not scope_result.get("success"):
                             return scope_result, None
 
-                        detail_result = await mcp_sync.sync_mcp_desired_state(
-                            user_id=effective_entity_id,
-                            entity_id=effective_entity_id,
-                            bot_id=ctx.bot_id,
-                            entity_type=effective_entity_type,
-                            engine_type=effective_engine,
-                        )
-                        return scope_result, detail_result
+                        detail_synced = None
+                        if skill_set_service is not None:
+                            declared_server_codes = set(
+                                await asyncio.to_thread(
+                                    skill_set_service.get_bot_mcp_codes,
+                                    effective_entity_id,
+                                    ctx.bot_id,
+                                    effective_entity_id,
+                                    effective_entity_type,
+                                    effective_engine,
+                                )
+                            )
+                            detail_synced = await skill_set_service.sync_mcp_desired_state(
+                                server_codes=declared_server_codes,
+                            )
+                        return scope_result, detail_synced
 
-                    scope_result, detail_result = asyncio.run(_do_mcp_sync())
+                    scope_result, detail_synced = asyncio.run(_do_mcp_sync())
                     if not scope_result.get("success"):
                         refresh_succeeded = False
                         logger.error(
@@ -713,12 +740,13 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                             "bot_id=%s, engine_type=%s, error=%s",
                             ctx.bot_id, effective_engine, scope_result.get("error"),
                         )
-                    elif detail_result and not detail_result.get("success"):
+                    elif detail_synced is False:
                         refresh_succeeded = False
                         logger.error(
-                            "[aicoding.restart] MCP detail resync failed: "
+                            "[aicoding.restart] MCP desired-state resync failed: "
                             "bot_id=%s, engine_type=%s, error=%s",
-                            ctx.bot_id, effective_engine, detail_result.get("error"),
+                            ctx.bot_id, effective_engine,
+                            "desired-state declaration returned false",
                         )
                     else:
                         logger.info(
@@ -735,15 +763,8 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                         exc_info=True,
                     )
 
-            if skill_set_factory is not None:
+            if skill_set_service is not None:
                 try:
-                    skill_set_service = skill_set_factory.create(
-                        user_id=effective_entity_id,
-                        entity_id=effective_entity_id,
-                        bot_id=ctx.bot_id,
-                        entity_type=effective_entity_type,
-                        engine_type=effective_engine,
-                    )
                     # ``project_skills`` is async so that both halves of the
                     # capability boundary are awaited the same way; this is a
                     # worker thread with no running loop, so it bridges the

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -684,6 +684,10 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
 
             refresh_succeeded = True
             skill_set_service = None
+            logger.info(
+                "[aicoding.restart] begin restart resync: bot_id=%s, engine_type=%s, entity_id=%s, entity_type=%s",
+                ctx.bot_id, effective_engine, effective_entity_id, effective_entity_type,
+            )
             if skill_set_factory is not None:
                 try:
                     skill_set_service = skill_set_factory.create(
@@ -693,11 +697,15 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                         entity_type=effective_entity_type,
                         engine_type=effective_engine,
                     )
+                    logger.info(
+                        "[aicoding.restart] skill set service created for restart resync: bot_id=%s, engine_type=%s",
+                        ctx.bot_id, effective_engine,
+                    )
                 except Exception as skill_error:
                     refresh_succeeded = False
                     logger.error(
                         "[aicoding.restart] skill set service create error: "
-                        "bot_id=%s, engine_type=%s, error=%s",
+                        "bot_id=%s, engine_type=%s, error=%s; continue with remaining restart resync steps",
                         ctx.bot_id, effective_engine, skill_error,
                         exc_info=True,
                     )
@@ -727,8 +735,10 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                                     effective_engine,
                                 )
                             )
-                            detail_synced = await skill_set_service.sync_mcp_desired_state(
-                                server_codes=declared_server_codes,
+                            detail_synced = await skill_set_service.project_mcps(
+                                claimed=frozenset(declared_server_codes),
+                                released=frozenset(),
+                                declared=declared_server_codes,
                             )
                         return scope_result, detail_synced
 
@@ -737,16 +747,16 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                         refresh_succeeded = False
                         logger.error(
                             "[aicoding.restart] MCP scope resync failed: "
-                            "bot_id=%s, engine_type=%s, error=%s",
+                            "bot_id=%s, engine_type=%s, error=%s; continue with skill sync",
                             ctx.bot_id, effective_engine, scope_result.get("error"),
                         )
                     elif detail_synced is False:
                         refresh_succeeded = False
                         logger.error(
-                            "[aicoding.restart] MCP desired-state resync failed: "
-                            "bot_id=%s, engine_type=%s, error=%s",
+                            "[aicoding.restart] MCP projection resync failed: "
+                            "bot_id=%s, engine_type=%s, error=%s; continue with skill sync",
                             ctx.bot_id, effective_engine,
-                            "desired-state declaration returned false",
+                            "projection returned false",
                         )
                     else:
                         logger.info(
@@ -758,13 +768,17 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                     refresh_succeeded = False
                     logger.error(
                         "[aicoding.restart] MCP resync error: "
-                        "bot_id=%s, engine_type=%s, error=%s",
+                        "bot_id=%s, engine_type=%s, error=%s; continue with skill sync",
                         ctx.bot_id, effective_engine, mcp_error,
                         exc_info=True,
                     )
 
             if skill_set_service is not None:
                 try:
+                    logger.info(
+                        "[aicoding.restart] start skill symlink resync after MCP stage: bot_id=%s, engine_type=%s",
+                        ctx.bot_id, effective_engine,
+                    )
                     # ``project_skills`` is async so that both halves of the
                     # capability boundary are awaited the same way; this is a
                     # worker thread with no running loop, so it bridges the
@@ -781,14 +795,14 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                         refresh_succeeded = False
                         logger.error(
                             "[aicoding.restart] skill symlink sync failed: "
-                            "bot_id=%s, engine_type=%s",
+                            "bot_id=%s, engine_type=%s; continue without clearing restart marker",
                             ctx.bot_id, effective_engine,
                         )
                 except Exception as skill_error:
                     refresh_succeeded = False
                     logger.error(
                         "[aicoding.restart] skill symlink sync error: "
-                        "bot_id=%s, engine_type=%s, error=%s",
+                        "bot_id=%s, engine_type=%s, error=%s; continue without clearing restart marker",
                         ctx.bot_id, effective_engine, skill_error,
                         exc_info=True,
                     )

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -696,7 +696,7 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                         if not scope_result.get("success"):
                             return scope_result, None
 
-                        detail_result = await mcp_sync.sync_mcp_details(
+                        detail_result = await mcp_sync.sync_mcp_desired_state(
                             user_id=effective_entity_id,
                             entity_id=effective_entity_id,
                             bot_id=ctx.bot_id,

--- a/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
+++ b/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
@@ -3,7 +3,7 @@
 ``refresh_restart_authorization`` now owns both the opt-in decision and the
 AICoding-specific side effects:
   * refresh MCP scope;
-  * push MCP details to runtime;
+  * declare MCP desired state to runtime;
   * resync ~/.claude/skills symlinks via SkillSetService.project_skills().
 All side effects are best-effort/fire-and-forget.
 """
@@ -98,9 +98,10 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a", "mcp-b"]
+    skill_set_service.sync_mcp_desired_state = AsyncMock(return_value=True)
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -121,12 +122,15 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     assert scope_kwargs["entity_type"] == "staff"
     assert scope_kwargs["engine_type"] == "aicoding"
     assert "extra_cli_items" not in scope_kwargs
-    mcp_sync.sync_mcp_desired_state.assert_awaited_once_with(
-        user_id="ent-9",
-        entity_id="ent-9",
-        bot_id="bot-1",
-        entity_type="staff",
-        engine_type="aicoding",
+    skill_set_service.get_bot_mcp_codes.assert_called_once_with(
+        "ent-9",
+        "bot-1",
+        "ent-9",
+        "staff",
+        "aicoding",
+    )
+    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
+        server_codes={"mcp-a", "mcp-b"},
     )
     factory.create.assert_called_once_with(
         user_id="ent-9",
@@ -166,9 +170,9 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
     mcp_sync.refresh_mcp_scope = AsyncMock(
         return_value={"success": False, "error": "scope denied"}
     )
-    mcp_sync.sync_mcp_desired_state = AsyncMock()
     factory = MagicMock()
     skill_set_service = MagicMock()
+    skill_set_service.sync_mcp_desired_state = AsyncMock()
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -181,7 +185,7 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_desired_state.assert_not_called()
+    skill_set_service.sync_mcp_desired_state.assert_not_called()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -189,11 +193,10 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(
-        return_value={"success": False, "error": "detail down"}
-    )
     factory = MagicMock()
     skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
+    skill_set_service.sync_mcp_desired_state = AsyncMock(return_value=False)
     skill_set_service.project_skills = AsyncMock(return_value=False)
     factory.create.return_value = skill_set_service
 
@@ -206,22 +209,22 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
+    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
+        server_codes={"mcp-a"},
+    )
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
-def test_aicoding_refresh_does_not_retry_mcp_detail_when_runtime_not_ready() -> None:
+def test_aicoding_refresh_does_not_retry_mcp_desired_state_when_runtime_not_ready() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(
-        side_effect=[
-            {"success": False, "error": "NO_ACTIVE_DEVICES"},
-            {"success": True},
-        ]
-    )
     factory = MagicMock()
     skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
+    skill_set_service.sync_mcp_desired_state = AsyncMock(
+        side_effect=[False, True]
+    )
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -234,20 +237,24 @@ def test_aicoding_refresh_does_not_retry_mcp_detail_when_runtime_not_ready() -> 
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
+    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
+        server_codes={"mcp-a"},
+    )
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
-def test_aicoding_refresh_does_not_retry_mcp_detail_exception() -> None:
+def test_aicoding_refresh_does_not_retry_mcp_desired_state_exception() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(
-        side_effect=[
-            RuntimeError("BaaS API error: NO_ACTIVE_DEVICES"),
-            {"success": True},
-        ]
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
+    skill_set_service.sync_mcp_desired_state = AsyncMock(
+        side_effect=RuntimeError("BaaS API error: NO_ACTIVE_DEVICES")
     )
+    skill_set_service.project_skills = AsyncMock(return_value=True)
+    factory.create.return_value = skill_set_service
 
     with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
         assert strategy.refresh_restart_authorization(
@@ -255,10 +262,13 @@ def test_aicoding_refresh_does_not_retry_mcp_detail_exception() -> None:
             _bot(),
             {"confirmed_template_update": True},
             mcp_sync=mcp_sync,
-            skill_set_factory=None,
+            skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
+    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
+        server_codes={"mcp-a"},
+    )
+    skill_set_service.project_skills.assert_awaited_once_with()
 
 
 def test_aicoding_refresh_does_not_retry_skill_symlink_when_false() -> None:
@@ -305,9 +315,10 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(side_effect=RuntimeError("detail down"))
     factory = MagicMock()
     skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
+    skill_set_service.sync_mcp_desired_state = AsyncMock(side_effect=RuntimeError("detail down"))
     skill_set_service.project_skills = AsyncMock(side_effect=RuntimeError("skill down"))
     factory.create.return_value = skill_set_service
 
@@ -320,7 +331,9 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
+    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
+        server_codes={"mcp-a"},
+    )
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -339,6 +352,7 @@ def test_aicoding_refresh_swallows_skill_sync_exception() -> None:
         ) is True
 
     factory.create.assert_called_once()
+
 
 def test_default_strategy_always_returns_false() -> None:
     strategy = DefaultProvisioningStrategy("openclaw")

--- a/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
+++ b/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
@@ -98,7 +98,7 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(return_value={"success": True})
+    mcp_sync.sync_mcp_desired_state = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.project_skills = AsyncMock(return_value=True)
@@ -121,7 +121,7 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     assert scope_kwargs["entity_type"] == "staff"
     assert scope_kwargs["engine_type"] == "aicoding"
     assert "extra_cli_items" not in scope_kwargs
-    mcp_sync.sync_mcp_details.assert_awaited_once_with(
+    mcp_sync.sync_mcp_desired_state.assert_awaited_once_with(
         user_id="ent-9",
         entity_id="ent-9",
         bot_id="bot-1",
@@ -166,7 +166,7 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
     mcp_sync.refresh_mcp_scope = AsyncMock(
         return_value={"success": False, "error": "scope denied"}
     )
-    mcp_sync.sync_mcp_details = AsyncMock()
+    mcp_sync.sync_mcp_desired_state = AsyncMock()
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.project_skills = AsyncMock(return_value=True)
@@ -181,7 +181,7 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_details.assert_not_called()
+    mcp_sync.sync_mcp_desired_state.assert_not_called()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -189,7 +189,7 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(
+    mcp_sync.sync_mcp_desired_state = AsyncMock(
         return_value={"success": False, "error": "detail down"}
     )
     factory = MagicMock()
@@ -206,7 +206,7 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_details.assert_awaited_once()
+    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -214,7 +214,7 @@ def test_aicoding_refresh_does_not_retry_mcp_detail_when_runtime_not_ready() -> 
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(
+    mcp_sync.sync_mcp_desired_state = AsyncMock(
         side_effect=[
             {"success": False, "error": "NO_ACTIVE_DEVICES"},
             {"success": True},
@@ -234,7 +234,7 @@ def test_aicoding_refresh_does_not_retry_mcp_detail_when_runtime_not_ready() -> 
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_details.assert_awaited_once()
+    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -242,7 +242,7 @@ def test_aicoding_refresh_does_not_retry_mcp_detail_exception() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(
+    mcp_sync.sync_mcp_desired_state = AsyncMock(
         side_effect=[
             RuntimeError("BaaS API error: NO_ACTIVE_DEVICES"),
             {"success": True},
@@ -258,7 +258,7 @@ def test_aicoding_refresh_does_not_retry_mcp_detail_exception() -> None:
             skill_set_factory=None,
         ) is True
 
-    mcp_sync.sync_mcp_details.assert_awaited_once()
+    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
 
 
 def test_aicoding_refresh_does_not_retry_skill_symlink_when_false() -> None:
@@ -305,7 +305,7 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(side_effect=RuntimeError("detail down"))
+    mcp_sync.sync_mcp_desired_state = AsyncMock(side_effect=RuntimeError("detail down"))
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.project_skills = AsyncMock(side_effect=RuntimeError("skill down"))
@@ -320,7 +320,7 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_details.assert_awaited_once()
+    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -364,7 +364,7 @@ def test_aicoding_refresh_clears_persisted_marker_after_confirmed_extra_success(
     }
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(return_value={"success": True})
+    mcp_sync.sync_mcp_desired_state = AsyncMock(return_value={"success": True})
     template_service = MagicMock()
     template_service.get_template_config.return_value = stored_template_config
 
@@ -403,7 +403,7 @@ def test_aicoding_refresh_uses_persisted_template_marker_and_clears_after_succes
     )
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(return_value={"success": True})
+    mcp_sync.sync_mcp_desired_state = AsyncMock(return_value={"success": True})
     template_service = MagicMock()
     template_service.get_template_config.return_value = template_config
 

--- a/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
+++ b/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
@@ -101,7 +101,7 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a", "mcp-b"]
-    skill_set_service.sync_mcp_desired_state = AsyncMock(return_value=True)
+    skill_set_service.project_mcps = AsyncMock(return_value=True)
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -129,8 +129,10 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
         "staff",
         "aicoding",
     )
-    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
-        server_codes={"mcp-a", "mcp-b"},
+    skill_set_service.project_mcps.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a", "mcp-b"}),
+        released=frozenset(),
+        declared={"mcp-a", "mcp-b"},
     )
     factory.create.assert_called_once_with(
         user_id="ent-9",
@@ -172,7 +174,7 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
     )
     factory = MagicMock()
     skill_set_service = MagicMock()
-    skill_set_service.sync_mcp_desired_state = AsyncMock()
+    skill_set_service.project_mcps = AsyncMock()
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -185,7 +187,7 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
             skill_set_factory=factory,
         ) is True
 
-    skill_set_service.sync_mcp_desired_state.assert_not_called()
+    skill_set_service.project_mcps.assert_not_called()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -196,7 +198,7 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
-    skill_set_service.sync_mcp_desired_state = AsyncMock(return_value=False)
+    skill_set_service.project_mcps = AsyncMock(return_value=False)
     skill_set_service.project_skills = AsyncMock(return_value=False)
     factory.create.return_value = skill_set_service
 
@@ -209,20 +211,22 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
             skill_set_factory=factory,
         ) is True
 
-    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
-        server_codes={"mcp-a"},
+    skill_set_service.project_mcps.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a"}),
+        released=frozenset(),
+        declared={"mcp-a"},
     )
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
-def test_aicoding_refresh_does_not_retry_mcp_desired_state_when_runtime_not_ready() -> None:
+def test_aicoding_refresh_does_not_retry_mcp_projection_when_runtime_not_ready() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
-    skill_set_service.sync_mcp_desired_state = AsyncMock(
+    skill_set_service.project_mcps = AsyncMock(
         side_effect=[False, True]
     )
     skill_set_service.project_skills = AsyncMock(return_value=True)
@@ -237,20 +241,22 @@ def test_aicoding_refresh_does_not_retry_mcp_desired_state_when_runtime_not_read
             skill_set_factory=factory,
         ) is True
 
-    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
-        server_codes={"mcp-a"},
+    skill_set_service.project_mcps.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a"}),
+        released=frozenset(),
+        declared={"mcp-a"},
     )
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
-def test_aicoding_refresh_does_not_retry_mcp_desired_state_exception() -> None:
+def test_aicoding_refresh_does_not_retry_mcp_projection_exception() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
-    skill_set_service.sync_mcp_desired_state = AsyncMock(
+    skill_set_service.project_mcps = AsyncMock(
         side_effect=RuntimeError("BaaS API error: NO_ACTIVE_DEVICES")
     )
     skill_set_service.project_skills = AsyncMock(return_value=True)
@@ -265,8 +271,10 @@ def test_aicoding_refresh_does_not_retry_mcp_desired_state_exception() -> None:
             skill_set_factory=factory,
         ) is True
 
-    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
-        server_codes={"mcp-a"},
+    skill_set_service.project_mcps.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a"}),
+        released=frozenset(),
+        declared={"mcp-a"},
     )
     skill_set_service.project_skills.assert_awaited_once_with()
 
@@ -318,7 +326,7 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
-    skill_set_service.sync_mcp_desired_state = AsyncMock(side_effect=RuntimeError("detail down"))
+    skill_set_service.project_mcps = AsyncMock(side_effect=RuntimeError("detail down"))
     skill_set_service.project_skills = AsyncMock(side_effect=RuntimeError("skill down"))
     factory.create.return_value = skill_set_service
 
@@ -331,8 +339,10 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
             skill_set_factory=factory,
         ) is True
 
-    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
-        server_codes={"mcp-a"},
+    skill_set_service.project_mcps.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a"}),
+        released=frozenset(),
+        declared={"mcp-a"},
     )
     skill_set_service.project_skills.assert_awaited_once_with()
 
@@ -378,7 +388,6 @@ def test_aicoding_refresh_clears_persisted_marker_after_confirmed_extra_success(
     }
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(return_value={"success": True})
     template_service = MagicMock()
     template_service.get_template_config.return_value = stored_template_config
 
@@ -417,7 +426,6 @@ def test_aicoding_refresh_uses_persisted_template_marker_and_clears_after_succes
     )
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(return_value={"success": True})
     template_service = MagicMock()
     template_service.get_template_config.return_value = template_config
 


### PR DESCRIPTION
This PR updates the AICoding restart resync path to use SkillSetService.sync_mcp_desired_state(server_codes=...).\n\nIt also updates the targeted unit tests to match the new contract.