### PR TITLE
fix(aicoding): use MCP projection on restart

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/restart_authorization_listener.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/restart_authorization_listener.py
@@ -36,13 +36,11 @@ class AicodingRestartAuthorizationBaasPublishListener(LifecycleBase):
         *,
         bot_repo: "BotRepository",
         template_service: "TemplateService",
-        mcp_sync: Any = None,
         skill_set_factory: Any = None,
         runtime_reconciler: BotRuntimeProjectorProtocol | None = None,
     ) -> None:
         self._bot_repo = bot_repo
         self._template_service = template_service
-        self._mcp_sync = mcp_sync
         self._skill_set_factory = skill_set_factory
         self._runtime_reconciler = runtime_reconciler
 
@@ -115,7 +113,6 @@ class AicodingRestartAuthorizationBaasPublishListener(LifecycleBase):
                 ctx,
                 bot,
                 None,
-                mcp_sync=self._mcp_sync,
                 skill_set_factory=self._skill_set_factory,
                 runtime_reconciler=self._runtime_reconciler,
                 template_service=self._template_service,

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/restart_authorization_listener.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/restart_authorization_listener.py
@@ -15,6 +15,9 @@ if TYPE_CHECKING:
         TemplateService,
     )
     from agentclaw.community.core.repository.protocols.bot import BotRepository
+    from agentclaw.community.core.skill_center.runtime_projection_contract import (
+        BotRuntimeProjectorProtocol,
+    )
 
 logger = get_logger()
 
@@ -35,11 +38,13 @@ class AicodingRestartAuthorizationBaasPublishListener(LifecycleBase):
         template_service: "TemplateService",
         mcp_sync: Any = None,
         skill_set_factory: Any = None,
+        runtime_reconciler: BotRuntimeProjectorProtocol | None = None,
     ) -> None:
         self._bot_repo = bot_repo
         self._template_service = template_service
         self._mcp_sync = mcp_sync
         self._skill_set_factory = skill_set_factory
+        self._runtime_reconciler = runtime_reconciler
 
     async def startup(self) -> None:
         bus = get_event_bus()
@@ -112,6 +117,7 @@ class AicodingRestartAuthorizationBaasPublishListener(LifecycleBase):
                 None,
                 mcp_sync=self._mcp_sync,
                 skill_set_factory=self._skill_set_factory,
+                runtime_reconciler=self._runtime_reconciler,
                 template_service=self._template_service,
             )
             logger.info(

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/restart_authorization_listener.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/restart_authorization_listener.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from agentclaw.community.core.bot_management.engines import resolve_provisioning
 from agentclaw.community.core.events.bus import get_event_bus
@@ -38,11 +38,13 @@ class AicodingRestartAuthorizationBaasPublishListener(LifecycleBase):
         template_service: "TemplateService",
         skill_set_factory: Any = None,
         runtime_reconciler: BotRuntimeProjectorProtocol | None = None,
+        runtime_reconciler_provider: Callable[[], BotRuntimeProjectorProtocol] | None = None,
     ) -> None:
         self._bot_repo = bot_repo
         self._template_service = template_service
         self._skill_set_factory = skill_set_factory
         self._runtime_reconciler = runtime_reconciler
+        self._runtime_reconciler_provider = runtime_reconciler_provider
 
     async def startup(self) -> None:
         bus = get_event_bus()
@@ -109,12 +111,24 @@ class AicodingRestartAuthorizationBaasPublishListener(LifecycleBase):
                 template_type=bot.get("template_type"),
                 template_config=template_config if isinstance(template_config, dict) else None,
             )
+            runtime_reconciler = self._runtime_reconciler
+            if runtime_reconciler is None and self._runtime_reconciler_provider is not None:
+                try:
+                    runtime_reconciler = self._runtime_reconciler_provider()
+                except Exception as runtime_error:
+                    logger.warning(
+                        "[aicoding.restart_authorization_listener] runtime reconciler unavailable: bot_id=%s publish_id=%s error=%s",
+                        event.bot_id,
+                        event.publish_id,
+                        runtime_error,
+                        exc_info=True,
+                    )
             opted_in = strategy.refresh_restart_authorization(
                 ctx,
                 bot,
                 None,
                 skill_set_factory=self._skill_set_factory,
-                runtime_reconciler=self._runtime_reconciler,
+                runtime_reconciler=runtime_reconciler,
                 template_service=self._template_service,
             )
             logger.info(

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -719,61 +719,41 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                         exc_info=True,
                     )
 
-            if mcp_sync is not None:
+            if runtime_reconciler is not None:
                 try:
-                    async def _do_mcp_sync() -> dict:
-                        scope_result = await mcp_sync.refresh_mcp_scope(
-                            user_id=effective_entity_id,
-                            entity_id=effective_entity_id,
+                    from agentclaw.community.core.skill_center.runtime_projection_contract import (
+                        ProjectionScope,
+                    )
+
+                    async def _do_mcp_projection() -> None:
+                        await runtime_reconciler.project_mcp_and_cli(
                             bot_id=ctx.bot_id,
-                            entity_type=effective_entity_type,
-                            engine_type=effective_engine,
+                            owner_id=effective_entity_id,
+                            scope=ProjectionScope(mcp=True, claim_all_mcp=True),
                         )
-                        if not scope_result.get("success"):
-                            return scope_result
 
-                        if runtime_reconciler is not None:
-                            from agentclaw.community.core.skill_center.runtime_projection_contract import (
-                                ProjectionScope,
-                            )
-
-                            await runtime_reconciler.project_mcp_and_cli(
-                                bot_id=ctx.bot_id,
-                                owner_id=effective_entity_id,
-                                scope=ProjectionScope(mcp=True, claim_all_mcp=True),
-                            )
-                        return scope_result
-
-                    scope_result = asyncio.run(_do_mcp_sync())
-                    if not scope_result.get("success"):
-                        refresh_succeeded = False
-                        logger.error(
-                            "[aicoding.restart] MCP scope resync failed: "
-                            "bot_id=%s, engine_type=%s, error=%s; continue with skill sync",
-                            ctx.bot_id, effective_engine, scope_result.get("error"),
-                        )
-                    elif runtime_reconciler is not None:
-                        logger.info(
-                            "[aicoding.restart] MCP resync succeeded: "
-                            "bot_id=%s, engine_type=%s",
-                            ctx.bot_id, effective_engine,
-                        )
-                    else:
-                        refresh_succeeded = False
-                        logger.error(
-                            "[aicoding.restart] MCP projection resync skipped: "
-                            "bot_id=%s, engine_type=%s, error=%s; continue with skill sync",
-                            ctx.bot_id, effective_engine,
-                            "runtime reconciler unavailable",
-                        )
+                    asyncio.run(_do_mcp_projection())
+                    logger.info(
+                        "[aicoding.restart] MCP projection resync succeeded: "
+                        "bot_id=%s, engine_type=%s",
+                        ctx.bot_id, effective_engine,
+                    )
                 except Exception as mcp_error:
                     refresh_succeeded = False
                     logger.error(
-                        "[aicoding.restart] MCP resync error: "
+                        "[aicoding.restart] MCP projection resync failed: "
                         "bot_id=%s, engine_type=%s, error=%s; continue with skill sync",
                         ctx.bot_id, effective_engine, mcp_error,
                         exc_info=True,
                     )
+            else:
+                refresh_succeeded = False
+                logger.error(
+                    "[aicoding.restart] MCP projection resync skipped: "
+                    "bot_id=%s, engine_type=%s, error=%s; continue with skill sync",
+                    ctx.bot_id, effective_engine,
+                    "runtime reconciler unavailable",
+                )
 
             if skill_set_service is not None:
                 try:
@@ -784,7 +764,7 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                     # ``project_skills`` is async so that both halves of the
                     # capability boundary are awaited the same way; this is a
                     # worker thread with no running loop, so it bridges the
-                    # same way ``_do_mcp_sync`` above does.
+                    # same way ``_do_mcp_projection`` above does.
                     skill_synced = bool(asyncio.run(skill_set_service.project_skills()))
                     if skill_synced:
                         logger.info(

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -11,7 +11,7 @@ import json
 from copy import deepcopy
 import threading
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, TYPE_CHECKING
 
 from agentclaw.community.core.bot_management.capabilities import (
     is_template_factory_config,
@@ -58,6 +58,14 @@ _ENCRYPTED_VALUE_PREFIX = "enc:v1:"
 _AICODING_RESTART_MARKER_KEY = "_aicoding_restart"
 _AICODING_RESTART_RESYNC_KEY = "resync_authorization"
 logger = get_logger()
+
+
+
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.skill_center.runtime_projection_contract import (
+        BotRuntimeProjectorProtocol,
+    )
 
 
 def _validate_application_coding_config(
@@ -655,6 +663,7 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         *,
         mcp_sync: Any = None,
         skill_set_factory: Any = None,
+        runtime_reconciler: "BotRuntimeProjectorProtocol | None" = None,
         template_service: Any = None,
     ) -> bool:
         """Refresh AICoding restart authorization and runtime skill symlinks.
@@ -712,7 +721,7 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
 
             if mcp_sync is not None:
                 try:
-                    async def _do_mcp_sync() -> tuple[dict, bool | None]:
+                    async def _do_mcp_sync() -> dict:
                         scope_result = await mcp_sync.refresh_mcp_scope(
                             user_id=effective_entity_id,
                             entity_id=effective_entity_id,
@@ -721,28 +730,21 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                             engine_type=effective_engine,
                         )
                         if not scope_result.get("success"):
-                            return scope_result, None
+                            return scope_result
 
-                        detail_synced = None
-                        if skill_set_service is not None:
-                            declared_server_codes = set(
-                                await asyncio.to_thread(
-                                    skill_set_service.get_bot_mcp_codes,
-                                    effective_entity_id,
-                                    ctx.bot_id,
-                                    effective_entity_id,
-                                    effective_entity_type,
-                                    effective_engine,
-                                )
+                        if runtime_reconciler is not None:
+                            from agentclaw.community.core.skill_center.runtime_projection_contract import (
+                                ProjectionScope,
                             )
-                            detail_synced = await skill_set_service.project_mcps(
-                                claimed=frozenset(declared_server_codes),
-                                released=frozenset(),
-                                declared=declared_server_codes,
-                            )
-                        return scope_result, detail_synced
 
-                    scope_result, detail_synced = asyncio.run(_do_mcp_sync())
+                            await runtime_reconciler.project_mcp_and_cli(
+                                bot_id=ctx.bot_id,
+                                owner_id=effective_entity_id,
+                                scope=ProjectionScope(mcp=True, claim_all_mcp=True),
+                            )
+                        return scope_result
+
+                    scope_result = asyncio.run(_do_mcp_sync())
                     if not scope_result.get("success"):
                         refresh_succeeded = False
                         logger.error(
@@ -750,19 +752,19 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                             "bot_id=%s, engine_type=%s, error=%s; continue with skill sync",
                             ctx.bot_id, effective_engine, scope_result.get("error"),
                         )
-                    elif detail_synced is False:
-                        refresh_succeeded = False
-                        logger.error(
-                            "[aicoding.restart] MCP projection resync failed: "
-                            "bot_id=%s, engine_type=%s, error=%s; continue with skill sync",
-                            ctx.bot_id, effective_engine,
-                            "projection returned false",
-                        )
-                    else:
+                    elif runtime_reconciler is not None:
                         logger.info(
                             "[aicoding.restart] MCP resync succeeded: "
                             "bot_id=%s, engine_type=%s",
                             ctx.bot_id, effective_engine,
+                        )
+                    else:
+                        refresh_succeeded = False
+                        logger.error(
+                            "[aicoding.restart] MCP projection resync skipped: "
+                            "bot_id=%s, engine_type=%s, error=%s; continue with skill sync",
+                            ctx.bot_id, effective_engine,
+                            "runtime reconciler unavailable",
                         )
                 except Exception as mcp_error:
                     refresh_succeeded = False

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -683,9 +683,28 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             import asyncio
 
             refresh_succeeded = True
+            skill_set_service = None
+            if skill_set_factory is not None:
+                try:
+                    skill_set_service = skill_set_factory.create(
+                        user_id=effective_entity_id,
+                        entity_id=effective_entity_id,
+                        bot_id=ctx.bot_id,
+                        entity_type=effective_entity_type,
+                        engine_type=effective_engine,
+                    )
+                except Exception as skill_error:
+                    refresh_succeeded = False
+                    logger.error(
+                        "[aicoding.restart] skill set service create error: "
+                        "bot_id=%s, engine_type=%s, error=%s",
+                        ctx.bot_id, effective_engine, skill_error,
+                        exc_info=True,
+                    )
+
             if mcp_sync is not None:
                 try:
-                    async def _do_mcp_sync() -> tuple[dict, dict | None]:
+                    async def _do_mcp_sync() -> tuple[dict, bool | None]:
                         scope_result = await mcp_sync.refresh_mcp_scope(
                             user_id=effective_entity_id,
                             entity_id=effective_entity_id,
@@ -696,16 +715,24 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                         if not scope_result.get("success"):
                             return scope_result, None
 
-                        detail_result = await mcp_sync.sync_mcp_desired_state(
-                            user_id=effective_entity_id,
-                            entity_id=effective_entity_id,
-                            bot_id=ctx.bot_id,
-                            entity_type=effective_entity_type,
-                            engine_type=effective_engine,
-                        )
-                        return scope_result, detail_result
+                        detail_synced = None
+                        if skill_set_service is not None:
+                            declared_server_codes = set(
+                                await asyncio.to_thread(
+                                    skill_set_service.get_bot_mcp_codes,
+                                    effective_entity_id,
+                                    ctx.bot_id,
+                                    effective_entity_id,
+                                    effective_entity_type,
+                                    effective_engine,
+                                )
+                            )
+                            detail_synced = await skill_set_service.sync_mcp_desired_state(
+                                server_codes=declared_server_codes,
+                            )
+                        return scope_result, detail_synced
 
-                    scope_result, detail_result = asyncio.run(_do_mcp_sync())
+                    scope_result, detail_synced = asyncio.run(_do_mcp_sync())
                     if not scope_result.get("success"):
                         refresh_succeeded = False
                         logger.error(
@@ -713,12 +740,13 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                             "bot_id=%s, engine_type=%s, error=%s",
                             ctx.bot_id, effective_engine, scope_result.get("error"),
                         )
-                    elif detail_result and not detail_result.get("success"):
+                    elif detail_synced is False:
                         refresh_succeeded = False
                         logger.error(
-                            "[aicoding.restart] MCP detail resync failed: "
+                            "[aicoding.restart] MCP desired-state resync failed: "
                             "bot_id=%s, engine_type=%s, error=%s",
-                            ctx.bot_id, effective_engine, detail_result.get("error"),
+                            ctx.bot_id, effective_engine,
+                            "desired-state declaration returned false",
                         )
                     else:
                         logger.info(
@@ -735,15 +763,8 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                         exc_info=True,
                     )
 
-            if skill_set_factory is not None:
+            if skill_set_service is not None:
                 try:
-                    skill_set_service = skill_set_factory.create(
-                        user_id=effective_entity_id,
-                        entity_id=effective_entity_id,
-                        bot_id=ctx.bot_id,
-                        entity_type=effective_entity_type,
-                        engine_type=effective_engine,
-                    )
                     # ``project_skills`` is async so that both halves of the
                     # capability boundary are awaited the same way; this is a
                     # worker thread with no running loop, so it bridges the

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -684,6 +684,10 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
 
             refresh_succeeded = True
             skill_set_service = None
+            logger.info(
+                "[aicoding.restart] begin restart resync: bot_id=%s, engine_type=%s, entity_id=%s, entity_type=%s",
+                ctx.bot_id, effective_engine, effective_entity_id, effective_entity_type,
+            )
             if skill_set_factory is not None:
                 try:
                     skill_set_service = skill_set_factory.create(
@@ -693,11 +697,15 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                         entity_type=effective_entity_type,
                         engine_type=effective_engine,
                     )
+                    logger.info(
+                        "[aicoding.restart] skill set service created for restart resync: bot_id=%s, engine_type=%s",
+                        ctx.bot_id, effective_engine,
+                    )
                 except Exception as skill_error:
                     refresh_succeeded = False
                     logger.error(
                         "[aicoding.restart] skill set service create error: "
-                        "bot_id=%s, engine_type=%s, error=%s",
+                        "bot_id=%s, engine_type=%s, error=%s; continue with remaining restart resync steps",
                         ctx.bot_id, effective_engine, skill_error,
                         exc_info=True,
                     )
@@ -727,8 +735,10 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                                     effective_engine,
                                 )
                             )
-                            detail_synced = await skill_set_service.sync_mcp_desired_state(
-                                server_codes=declared_server_codes,
+                            detail_synced = await skill_set_service.project_mcps(
+                                claimed=frozenset(declared_server_codes),
+                                released=frozenset(),
+                                declared=declared_server_codes,
                             )
                         return scope_result, detail_synced
 
@@ -737,16 +747,16 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                         refresh_succeeded = False
                         logger.error(
                             "[aicoding.restart] MCP scope resync failed: "
-                            "bot_id=%s, engine_type=%s, error=%s",
+                            "bot_id=%s, engine_type=%s, error=%s; continue with skill sync",
                             ctx.bot_id, effective_engine, scope_result.get("error"),
                         )
                     elif detail_synced is False:
                         refresh_succeeded = False
                         logger.error(
-                            "[aicoding.restart] MCP desired-state resync failed: "
-                            "bot_id=%s, engine_type=%s, error=%s",
+                            "[aicoding.restart] MCP projection resync failed: "
+                            "bot_id=%s, engine_type=%s, error=%s; continue with skill sync",
                             ctx.bot_id, effective_engine,
-                            "desired-state declaration returned false",
+                            "projection returned false",
                         )
                     else:
                         logger.info(
@@ -758,13 +768,17 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                     refresh_succeeded = False
                     logger.error(
                         "[aicoding.restart] MCP resync error: "
-                        "bot_id=%s, engine_type=%s, error=%s",
+                        "bot_id=%s, engine_type=%s, error=%s; continue with skill sync",
                         ctx.bot_id, effective_engine, mcp_error,
                         exc_info=True,
                     )
 
             if skill_set_service is not None:
                 try:
+                    logger.info(
+                        "[aicoding.restart] start skill symlink resync after MCP stage: bot_id=%s, engine_type=%s",
+                        ctx.bot_id, effective_engine,
+                    )
                     # ``project_skills`` is async so that both halves of the
                     # capability boundary are awaited the same way; this is a
                     # worker thread with no running loop, so it bridges the
@@ -781,14 +795,14 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                         refresh_succeeded = False
                         logger.error(
                             "[aicoding.restart] skill symlink sync failed: "
-                            "bot_id=%s, engine_type=%s",
+                            "bot_id=%s, engine_type=%s; continue without clearing restart marker",
                             ctx.bot_id, effective_engine,
                         )
                 except Exception as skill_error:
                     refresh_succeeded = False
                     logger.error(
                         "[aicoding.restart] skill symlink sync error: "
-                        "bot_id=%s, engine_type=%s, error=%s",
+                        "bot_id=%s, engine_type=%s, error=%s; continue without clearing restart marker",
                         ctx.bot_id, effective_engine, skill_error,
                         exc_info=True,
                     )

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -696,7 +696,7 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                         if not scope_result.get("success"):
                             return scope_result, None
 
-                        detail_result = await mcp_sync.sync_mcp_details(
+                        detail_result = await mcp_sync.sync_mcp_desired_state(
                             user_id=effective_entity_id,
                             entity_id=effective_entity_id,
                             bot_id=ctx.bot_id,

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
@@ -118,6 +118,7 @@ class DefaultProvisioningStrategy(EngineProvisioningStrategy):
         *,
         mcp_sync: object = None,
         skill_set_factory: object = None,
+        runtime_reconciler: object = None,
         template_service: object = None,
     ) -> bool:
         return False

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
@@ -233,6 +233,7 @@ class EngineProvisioningStrategy(ABC):
         *,
         mcp_sync: Any = None,
         skill_set_factory: Any = None,
+        runtime_reconciler: Any = None,
         template_service: Any = None,
     ) -> bool:
         """Optionally refresh engine-owned restart authorization/runtime state.

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -339,7 +339,6 @@ class BotService:
         baas_service_provider: "Callable[[], BaasService] | None" = None,
         task_queue_service: "TaskQueueService | None" = None,
         common_config_service: "CommonConfigService | None" = None,
-        mcp_sync: "McpSyncProtocol | None" = None,
         runtime_reconciler: "CoreBotRuntimeProjectorProtocol | None" = None,
     ) -> None:
         self._repository = repository
@@ -403,7 +402,6 @@ class BotService:
         self._baas_template_resolver = baas_template_resolver
         self._task_queue_service = task_queue_service
         self._common_config_service = common_config_service
-        self._mcp_sync = mcp_sync
         self._runtime_reconciler = runtime_reconciler
 
     def _service_bot_image_policy_enabled(self) -> bool:
@@ -1945,7 +1943,6 @@ class BotService:
                             refresh_ctx,
                             bot_record or {},
                             extra_configs,
-                            mcp_sync=self._mcp_sync,
                             skill_set_factory=self._skill_set_factory,
                             runtime_reconciler=self._runtime_reconciler,
                             template_service=self._template_service,

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -51,6 +51,9 @@ if TYPE_CHECKING:
     from agentclaw.community.core.task_queue.services.task_queue_service import TaskQueueService
     from agentclaw.community.core.common_config.service import CommonConfigService
     from agentclaw.community.core.devices.protocols import McpSyncProtocol
+    from agentclaw.community.core.skill_center.runtime_projection_contract import (
+        BotRuntimeProjectorProtocol as CoreBotRuntimeProjectorProtocol,
+    )
     from agentclaw.community.core.bot_app_grant.protocols import (
         BotAppGrantSweepProtocol,
     )
@@ -337,6 +340,7 @@ class BotService:
         task_queue_service: "TaskQueueService | None" = None,
         common_config_service: "CommonConfigService | None" = None,
         mcp_sync: "McpSyncProtocol | None" = None,
+        runtime_reconciler: "CoreBotRuntimeProjectorProtocol | None" = None,
     ) -> None:
         self._repository = repository
         self._allocation_config = allocation_config
@@ -400,6 +404,7 @@ class BotService:
         self._task_queue_service = task_queue_service
         self._common_config_service = common_config_service
         self._mcp_sync = mcp_sync
+        self._runtime_reconciler = runtime_reconciler
 
     def _service_bot_image_policy_enabled(self) -> bool:
         """Whether draft create/restart should opt into image policy."""
@@ -1942,6 +1947,7 @@ class BotService:
                             extra_configs,
                             mcp_sync=self._mcp_sync,
                             skill_set_factory=self._skill_set_factory,
+                            runtime_reconciler=self._runtime_reconciler,
                             template_service=self._template_service,
                         )
                     except Exception as exc:

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -340,6 +340,7 @@ class BotService:
         task_queue_service: "TaskQueueService | None" = None,
         common_config_service: "CommonConfigService | None" = None,
         runtime_reconciler: "CoreBotRuntimeProjectorProtocol | None" = None,
+        runtime_reconciler_provider: "Callable[[], CoreBotRuntimeProjectorProtocol] | None" = None,
     ) -> None:
         self._repository = repository
         self._allocation_config = allocation_config
@@ -403,6 +404,7 @@ class BotService:
         self._task_queue_service = task_queue_service
         self._common_config_service = common_config_service
         self._runtime_reconciler = runtime_reconciler
+        self._runtime_reconciler_provider = runtime_reconciler_provider
 
     def _service_bot_image_policy_enabled(self) -> bool:
         """Whether draft create/restart should opt into image policy."""
@@ -1939,12 +1941,23 @@ class BotService:
                             template_type=(bot_record or {}).get("template_type") or bot_template_type,
                             template_config=None,
                         )
+                        runtime_reconciler = self._runtime_reconciler
+                        if runtime_reconciler is None and self._runtime_reconciler_provider is not None:
+                            try:
+                                runtime_reconciler = self._runtime_reconciler_provider()
+                            except Exception as runtime_error:
+                                logger.warning(
+                                    "[bot_service._allocate_device_async] restart runtime reconciler unavailable; continue allocation: bot_id=%s error=%s",
+                                    bot_id,
+                                    runtime_error,
+                                    exc_info=True,
+                                )
                         refresh_strategy.refresh_restart_authorization(
                             refresh_ctx,
                             bot_record or {},
                             extra_configs,
                             skill_set_factory=self._skill_set_factory,
-                            runtime_reconciler=self._runtime_reconciler,
+                            runtime_reconciler=runtime_reconciler,
                             template_service=self._template_service,
                         )
                     except Exception as exc:

--- a/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
@@ -286,13 +286,13 @@ class BotManagementModule(Module):
         repository: BotRepository,
         template_service: TemplateService,
         skill_set_factory: SkillSetServiceFactory,
-        runtime_reconciler: CoreBotRuntimeProjectorProtocol,
+        injector: Injector,
     ) -> AicodingRestartAuthorizationBaasPublishListener:
         return AicodingRestartAuthorizationBaasPublishListener(
             bot_repo=repository,
             template_service=template_service,
             skill_set_factory=skill_set_factory,
-            runtime_reconciler=runtime_reconciler,
+            runtime_reconciler_provider=lambda: injector.get(CoreBotRuntimeProjectorProtocol),
         )
 
     @singleton
@@ -352,7 +352,6 @@ class BotManagementModule(Module):
         workspace_hosting_config: cfg.WorkspaceHostingConfig,
         device_binding_repo: DeviceBindingRepository,
         skill_set_factory: SkillSetServiceFactory,
-        runtime_reconciler: CoreBotRuntimeProjectorProtocol,
         cleanup_service: BotCleanupService,
         bcn_service: BcnService,
         bot_publish_repo: BotPublishRepositoryProtocol,
@@ -417,7 +416,7 @@ class BotManagementModule(Module):
             task_queue_service=task_queue_service,
             common_config_service=common_config_service,
             caller_identity_repo=caller_identity_repo,
-            runtime_reconciler=runtime_reconciler,
+            runtime_reconciler_provider=lambda: injector.get(CoreBotRuntimeProjectorProtocol),
         )
 
     @singleton

--- a/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
@@ -17,7 +17,7 @@ they pick up the swapped repositories transparently.
 
 from __future__ import annotations
 
-from typing import Annotated, Callable, cast
+from typing import Annotated, Callable
 
 from injector import (
     Binder,
@@ -79,7 +79,6 @@ from agentclaw.community.core.repository.protocols.identity import (
     CallerIdentityRepositoryProtocol,
 )
 from agentclaw.community.core.devices.protocols import McpSyncProtocol
-from agentclaw.community.core.mcp.services.sync_service import MCPSyncService
 from agentclaw.community.core.bot_management.services.bot_space_service import (
     BotSpaceService,
 )
@@ -286,14 +285,12 @@ class BotManagementModule(Module):
         self,
         repository: BotRepository,
         template_service: TemplateService,
-        mcp_sync_service: MCPSyncService,
         skill_set_factory: SkillSetServiceFactory,
         runtime_reconciler: CoreBotRuntimeProjectorProtocol,
     ) -> AicodingRestartAuthorizationBaasPublishListener:
         return AicodingRestartAuthorizationBaasPublishListener(
             bot_repo=repository,
             template_service=template_service,
-            mcp_sync=mcp_sync_service,
             skill_set_factory=skill_set_factory,
             runtime_reconciler=runtime_reconciler,
         )
@@ -375,7 +372,6 @@ class BotManagementModule(Module):
         task_queue_service: TaskQueueService,
         common_config_service: CommonConfigService,
         caller_identity_repo: CallerIdentityRepositoryProtocol,
-        mcp_sync_service: MCPSyncService,
         injector: Injector,
     ) -> BotService:
         # Explicit provider: ``BotService.__init__`` types several
@@ -421,7 +417,6 @@ class BotManagementModule(Module):
             task_queue_service=task_queue_service,
             common_config_service=common_config_service,
             caller_identity_repo=caller_identity_repo,
-            mcp_sync=cast(McpSyncProtocol, mcp_sync_service),
             runtime_reconciler=runtime_reconciler,
         )
 

--- a/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/bot_management_module.py
@@ -147,6 +147,9 @@ from agentclaw.community.core.task_queue.services.task_queue_service import (
 )
 from agentclaw.community.core.system_config import SystemConfigService
 from agentclaw.community.core.skill_center.factories import SkillSetServiceFactory
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    BotRuntimeProjectorProtocol as CoreBotRuntimeProjectorProtocol,
+)
 from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 from agentclaw.community.di import config as cfg
 from agentclaw.community.log import get_logger
@@ -285,12 +288,14 @@ class BotManagementModule(Module):
         template_service: TemplateService,
         mcp_sync_service: MCPSyncService,
         skill_set_factory: SkillSetServiceFactory,
+        runtime_reconciler: CoreBotRuntimeProjectorProtocol,
     ) -> AicodingRestartAuthorizationBaasPublishListener:
         return AicodingRestartAuthorizationBaasPublishListener(
             bot_repo=repository,
             template_service=template_service,
             mcp_sync=mcp_sync_service,
             skill_set_factory=skill_set_factory,
+            runtime_reconciler=runtime_reconciler,
         )
 
     @singleton
@@ -350,6 +355,7 @@ class BotManagementModule(Module):
         workspace_hosting_config: cfg.WorkspaceHostingConfig,
         device_binding_repo: DeviceBindingRepository,
         skill_set_factory: SkillSetServiceFactory,
+        runtime_reconciler: CoreBotRuntimeProjectorProtocol,
         cleanup_service: BotCleanupService,
         bcn_service: BcnService,
         bot_publish_repo: BotPublishRepositoryProtocol,
@@ -416,6 +422,7 @@ class BotManagementModule(Module):
             common_config_service=common_config_service,
             caller_identity_repo=caller_identity_repo,
             mcp_sync=cast(McpSyncProtocol, mcp_sync_service),
+            runtime_reconciler=runtime_reconciler,
         )
 
     @singleton

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_restart_idempotency.py
@@ -146,6 +146,7 @@ def _make_service(
     task_queue_service: MagicMock | None = None,
     common_config_service: MagicMock | None = None,
     mcp_sync: object | None = None,
+    runtime_reconciler: object | None = None,
 ) -> BotService:
     if lock_repo is None:
         lock_repo = FakeRestartLockRepo()
@@ -164,7 +165,7 @@ def _make_service(
     svc._baas_template_resolver = baas_template_resolver
     svc._task_queue_service = task_queue_service or MagicMock()
     svc._common_config_service = common_config_service
-    svc._mcp_sync = mcp_sync if mcp_sync is not None else MagicMock()
+    svc._runtime_reconciler = runtime_reconciler if runtime_reconciler is not None else MagicMock()
     svc._teclaw_provision_provider = lambda: SimpleNamespace(
         is_teclaw=lambda active_engine: active_engine == "teclaw"
     )
@@ -2190,14 +2191,13 @@ class TestRestartAuthorizationResyncWiring:
     def test_async_replacement_refreshes_after_device_apply(self):
         repo = FakeRestartLockRepo()
         device_service = MagicMock()
-        mcp_sync = object()
         device_service.apply_device.return_value = SimpleNamespace(
             id=42,
             device_id="dev-42",
             device_provider="arca",
             status=DeviceBindingStatus.ACTIVE.value,
         )
-        svc = _make_service(repo, device_provider=device_service, mcp_sync=mcp_sync)
+        svc = _make_service(repo, device_provider=device_service)
         bot = _make_bot(
             owner_id="owner001",
             status="PENDING",
@@ -2237,8 +2237,8 @@ class TestRestartAuthorizationResyncWiring:
             ANY,
             bot,
             {"confirmed_template_update": True},
-            mcp_sync=mcp_sync,
             skill_set_factory=svc._skill_set_factory,
+            runtime_reconciler=svc._runtime_reconciler,
             template_service=svc._template_service,
         )
         assert repo.release_calls == 1
@@ -2246,7 +2246,6 @@ class TestRestartAuthorizationResyncWiring:
     def test_baas_in_place_restart_defers_refresh_to_publish_event(self):
         repo = FakeRestartLockRepo()
         device_service = MagicMock()
-        mcp_sync = object()
         device_service.get_device.return_value = SimpleNamespace(
             id=42,
             device_provider="baas",
@@ -2257,7 +2256,6 @@ class TestRestartAuthorizationResyncWiring:
             repo,
             device_provider=device_service,
             baas_service_provider=lambda: MagicMock(),
-            mcp_sync=mcp_sync,
         )
         bot = _make_bot(
             status="ACTIVE",

--- a/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
+++ b/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
@@ -19,6 +19,9 @@ import pytest
 from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
     AicodingProvisioningStrategy,
 )
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    ProjectionScope,
+)
 from agentclaw.community.core.bot_management.engines.default import (
     DefaultProvisioningStrategy,
 )
@@ -99,9 +102,9 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
+    runtime_reconciler = MagicMock()
+    runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
     skill_set_service = MagicMock()
-    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a", "mcp-b"]
-    skill_set_service.project_mcps = AsyncMock(return_value=True)
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -112,6 +115,7 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
             {"confirmed_template_update": flag},
             mcp_sync=mcp_sync,
             skill_set_factory=factory,
+            runtime_reconciler=runtime_reconciler,
         ) is True
 
     mcp_sync.refresh_mcp_scope.assert_awaited_once()
@@ -122,17 +126,10 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     assert scope_kwargs["entity_type"] == "staff"
     assert scope_kwargs["engine_type"] == "aicoding"
     assert "extra_cli_items" not in scope_kwargs
-    skill_set_service.get_bot_mcp_codes.assert_called_once_with(
-        "ent-9",
-        "bot-1",
-        "ent-9",
-        "staff",
-        "aicoding",
-    )
-    skill_set_service.project_mcps.assert_awaited_once_with(
-        claimed=frozenset({"mcp-a", "mcp-b"}),
-        released=frozenset(),
-        declared={"mcp-a", "mcp-b"},
+    runtime_reconciler.project_mcp_and_cli.assert_awaited_once_with(
+        bot_id="bot-1",
+        owner_id="ent-9",
+        scope=ProjectionScope(mcp=True, claim_all_mcp=True),
     )
     factory.create.assert_called_once_with(
         user_id="ent-9",
@@ -149,6 +146,8 @@ def test_aicoding_refresh_is_best_effort_and_keeps_skill_sync_on_mcp_error() -> 
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(side_effect=RuntimeError("scope down"))
     factory = MagicMock()
+    runtime_reconciler = MagicMock()
+    runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
     skill_set_service = MagicMock()
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
@@ -160,6 +159,7 @@ def test_aicoding_refresh_is_best_effort_and_keeps_skill_sync_on_mcp_error() -> 
             {"confirmed_template_update": True},
             mcp_sync=mcp_sync,
             skill_set_factory=factory,
+            runtime_reconciler=runtime_reconciler,
         ) is True
     factory.create.assert_called_once()
     skill_set_service.project_skills.assert_awaited_once_with()
@@ -173,8 +173,9 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
         return_value={"success": False, "error": "scope denied"}
     )
     factory = MagicMock()
+    runtime_reconciler = MagicMock()
+    runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
     skill_set_service = MagicMock()
-    skill_set_service.project_mcps = AsyncMock()
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -185,9 +186,10 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
             {"confirmed_template_update": True},
             mcp_sync=mcp_sync,
             skill_set_factory=factory,
+            runtime_reconciler=runtime_reconciler,
         ) is True
 
-    skill_set_service.project_mcps.assert_not_called()
+    runtime_reconciler.project_mcp_and_cli.assert_not_called()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -197,8 +199,8 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     skill_set_service = MagicMock()
-    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
-    skill_set_service.project_mcps = AsyncMock(return_value=False)
+    runtime_reconciler = MagicMock()
+    runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
     skill_set_service.project_skills = AsyncMock(return_value=False)
     factory.create.return_value = skill_set_service
 
@@ -209,12 +211,13 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
             {"confirmed_template_update": True},
             mcp_sync=mcp_sync,
             skill_set_factory=factory,
+            runtime_reconciler=runtime_reconciler,
         ) is True
 
-    skill_set_service.project_mcps.assert_awaited_once_with(
-        claimed=frozenset({"mcp-a"}),
-        released=frozenset(),
-        declared={"mcp-a"},
+    runtime_reconciler.project_mcp_and_cli.assert_awaited_once_with(
+        bot_id="bot-1",
+        owner_id="ent-1",
+        scope=ProjectionScope(mcp=True, claim_all_mcp=True),
     )
     skill_set_service.project_skills.assert_awaited_once_with()
 
@@ -225,10 +228,8 @@ def test_aicoding_refresh_does_not_retry_mcp_projection_when_runtime_not_ready()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     skill_set_service = MagicMock()
-    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
-    skill_set_service.project_mcps = AsyncMock(
-        side_effect=[False, True]
-    )
+    runtime_reconciler = MagicMock()
+    runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -241,11 +242,7 @@ def test_aicoding_refresh_does_not_retry_mcp_projection_when_runtime_not_ready()
             skill_set_factory=factory,
         ) is True
 
-    skill_set_service.project_mcps.assert_awaited_once_with(
-        claimed=frozenset({"mcp-a"}),
-        released=frozenset(),
-        declared={"mcp-a"},
-    )
+    runtime_reconciler.project_mcp_and_cli.assert_not_called()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -254,11 +251,9 @@ def test_aicoding_refresh_does_not_retry_mcp_projection_exception() -> None:
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
+    runtime_reconciler = MagicMock()
+    runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
     skill_set_service = MagicMock()
-    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
-    skill_set_service.project_mcps = AsyncMock(
-        side_effect=RuntimeError("BaaS API error: NO_ACTIVE_DEVICES")
-    )
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -269,12 +264,13 @@ def test_aicoding_refresh_does_not_retry_mcp_projection_exception() -> None:
             {"confirmed_template_update": True},
             mcp_sync=mcp_sync,
             skill_set_factory=factory,
+            runtime_reconciler=runtime_reconciler,
         ) is True
 
-    skill_set_service.project_mcps.assert_awaited_once_with(
-        claimed=frozenset({"mcp-a"}),
-        released=frozenset(),
-        declared={"mcp-a"},
+    runtime_reconciler.project_mcp_and_cli.assert_awaited_once_with(
+        bot_id="bot-1",
+        owner_id="ent-1",
+        scope=ProjectionScope(mcp=True, claim_all_mcp=True),
     )
     skill_set_service.project_skills.assert_awaited_once_with()
 
@@ -324,9 +320,9 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
+    runtime_reconciler = MagicMock()
+    runtime_reconciler.project_mcp_and_cli = AsyncMock(side_effect=RuntimeError("detail down"))
     skill_set_service = MagicMock()
-    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
-    skill_set_service.project_mcps = AsyncMock(side_effect=RuntimeError("detail down"))
     skill_set_service.project_skills = AsyncMock(side_effect=RuntimeError("skill down"))
     factory.create.return_value = skill_set_service
 
@@ -337,12 +333,13 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
             {"confirmed_template_update": True},
             mcp_sync=mcp_sync,
             skill_set_factory=factory,
+            runtime_reconciler=runtime_reconciler,
         ) is True
 
-    skill_set_service.project_mcps.assert_awaited_once_with(
-        claimed=frozenset({"mcp-a"}),
-        released=frozenset(),
-        declared={"mcp-a"},
+    runtime_reconciler.project_mcp_and_cli.assert_awaited_once_with(
+        bot_id="bot-1",
+        owner_id="ent-1",
+        scope=ProjectionScope(mcp=True, claim_all_mcp=True),
     )
     skill_set_service.project_skills.assert_awaited_once_with()
 
@@ -371,6 +368,7 @@ def test_default_strategy_always_returns_false() -> None:
             _ctx(), _bot(), {"confirmed_template_update": True},
             mcp_sync=MagicMock(),
             skill_set_factory=MagicMock(),
+            runtime_reconciler=MagicMock(),
         )
         is False
     )
@@ -388,6 +386,8 @@ def test_aicoding_refresh_clears_persisted_marker_after_confirmed_extra_success(
     }
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
+    runtime_reconciler = MagicMock()
+    runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
     template_service = MagicMock()
     template_service.get_template_config.return_value = stored_template_config
 
@@ -398,10 +398,16 @@ def test_aicoding_refresh_clears_persisted_marker_after_confirmed_extra_success(
             {"confirmed_template_update": True},
             mcp_sync=mcp_sync,
             skill_set_factory=None,
+            runtime_reconciler=runtime_reconciler,
             template_service=template_service,
         ) is True
 
     template_service.update_template.assert_called_once()
+    runtime_reconciler.project_mcp_and_cli.assert_awaited_once_with(
+        bot_id="bot-1",
+        owner_id="ent-1",
+        scope=ProjectionScope(mcp=True, claim_all_mcp=True),
+    )
     cleared = template_service.update_template.call_args.kwargs["template_config"]
     assert "_aicoding_restart" not in cleared
     assert cleared["template_version_id"] == 101
@@ -426,6 +432,8 @@ def test_aicoding_refresh_uses_persisted_template_marker_and_clears_after_succes
     )
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
+    runtime_reconciler = MagicMock()
+    runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
     template_service = MagicMock()
     template_service.get_template_config.return_value = template_config
 
@@ -436,6 +444,7 @@ def test_aicoding_refresh_uses_persisted_template_marker_and_clears_after_succes
             None,
             mcp_sync=mcp_sync,
             skill_set_factory=None,
+            runtime_reconciler=runtime_reconciler,
             template_service=template_service,
         ) is True
 
@@ -462,6 +471,7 @@ def test_baas_restart_publish_listener_dispatches_strategy_after_restart_event()
     template_service = MagicMock()
     template_service.get_template_config.return_value = template_config
     mcp_sync = object()
+    runtime_reconciler = object()
     factory = object()
     strategy = MagicMock()
     strategy.engine_type = "claude_code"
@@ -472,6 +482,7 @@ def test_baas_restart_publish_listener_dispatches_strategy_after_restart_event()
         template_service=template_service,
         mcp_sync=mcp_sync,
         skill_set_factory=factory,
+        runtime_reconciler=runtime_reconciler,
     )
 
     with patch(
@@ -502,6 +513,7 @@ def test_baas_restart_publish_listener_dispatches_strategy_after_restart_event()
         None,
         mcp_sync=mcp_sync,
         skill_set_factory=factory,
+        runtime_reconciler=runtime_reconciler,
         template_service=template_service,
     )
 

--- a/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
+++ b/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
@@ -2,8 +2,7 @@
 
 ``refresh_restart_authorization`` now owns both the opt-in decision and the
 AICoding-specific side effects:
-  * refresh MCP scope;
-  * declare MCP desired state to runtime;
+  * project MCP/CLI through the runtime projector;
   * resync ~/.claude/skills symlinks via SkillSetService.project_skills().
 All side effects are best-effort/fire-and-forget.
 """
@@ -81,26 +80,21 @@ def _bot(entity_id: str = "ent-1", entity_type: str = "staff") -> dict:
 )
 def test_aicoding_refresh_is_noop_without_opt_in(extra_configs) -> None:
     strategy = AicodingProvisioningStrategy("claude_code")
-    mcp_sync = MagicMock()
     factory = MagicMock()
 
     assert (
         strategy.refresh_restart_authorization(
             _ctx(), _bot(), extra_configs,
-            mcp_sync=mcp_sync,
             skill_set_factory=factory,
         )
         is False
     )
-    mcp_sync.refresh_mcp_scope.assert_not_called()
     factory.create.assert_not_called()
 
 
 @pytest.mark.parametrize("flag", [True, 1, "yes"], ids=["true", "one", "truthy-str"])
 def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
-    mcp_sync = MagicMock()
-    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     runtime_reconciler = MagicMock()
     runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
@@ -113,19 +107,10 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
             _ctx(active_engine="aicoding"),
             _bot(entity_id="ent-9", entity_type="staff"),
             {"confirmed_template_update": flag},
-            mcp_sync=mcp_sync,
             skill_set_factory=factory,
             runtime_reconciler=runtime_reconciler,
         ) is True
 
-    mcp_sync.refresh_mcp_scope.assert_awaited_once()
-    scope_kwargs = mcp_sync.refresh_mcp_scope.await_args.kwargs
-    assert scope_kwargs["user_id"] == "ent-9"
-    assert scope_kwargs["entity_id"] == "ent-9"
-    assert scope_kwargs["bot_id"] == "bot-1"
-    assert scope_kwargs["entity_type"] == "staff"
-    assert scope_kwargs["engine_type"] == "aicoding"
-    assert "extra_cli_items" not in scope_kwargs
     runtime_reconciler.project_mcp_and_cli.assert_awaited_once_with(
         bot_id="bot-1",
         owner_id="ent-9",
@@ -141,13 +126,11 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
-def test_aicoding_refresh_is_best_effort_and_keeps_skill_sync_on_mcp_error() -> None:
+def test_aicoding_refresh_is_best_effort_and_keeps_skill_sync_on_projection_error() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
-    mcp_sync = MagicMock()
-    mcp_sync.refresh_mcp_scope = AsyncMock(side_effect=RuntimeError("scope down"))
     factory = MagicMock()
     runtime_reconciler = MagicMock()
-    runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
+    runtime_reconciler.project_mcp_and_cli = AsyncMock(side_effect=RuntimeError("projection down"))
     skill_set_service = MagicMock()
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
@@ -157,24 +140,22 @@ def test_aicoding_refresh_is_best_effort_and_keeps_skill_sync_on_mcp_error() -> 
             _ctx(active_engine="aicoding"),
             _bot(),
             {"confirmed_template_update": True},
-            mcp_sync=mcp_sync,
             skill_set_factory=factory,
             runtime_reconciler=runtime_reconciler,
         ) is True
+    runtime_reconciler.project_mcp_and_cli.assert_awaited_once_with(
+        bot_id="bot-1",
+        owner_id="ent-1",
+        scope=ProjectionScope(mcp=True, claim_all_mcp=True),
+    )
     factory.create.assert_called_once()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
 
-def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
+def test_aicoding_refresh_skips_projection_when_runtime_not_ready_and_still_syncs_skills() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
-    mcp_sync = MagicMock()
-    mcp_sync.refresh_mcp_scope = AsyncMock(
-        return_value={"success": False, "error": "scope denied"}
-    )
     factory = MagicMock()
-    runtime_reconciler = MagicMock()
-    runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
     skill_set_service = MagicMock()
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
@@ -184,19 +165,14 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
             _ctx(active_engine="aicoding"),
             _bot(),
             {"confirmed_template_update": True},
-            mcp_sync=mcp_sync,
             skill_set_factory=factory,
-            runtime_reconciler=runtime_reconciler,
         ) is True
 
-    runtime_reconciler.project_mcp_and_cli.assert_not_called()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
 def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
-    mcp_sync = MagicMock()
-    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     skill_set_service = MagicMock()
     runtime_reconciler = MagicMock()
@@ -209,7 +185,6 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
             _ctx(active_engine="aicoding"),
             _bot(),
             {"confirmed_template_update": True},
-            mcp_sync=mcp_sync,
             skill_set_factory=factory,
             runtime_reconciler=runtime_reconciler,
         ) is True
@@ -224,12 +199,8 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
 
 def test_aicoding_refresh_does_not_retry_mcp_projection_when_runtime_not_ready() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
-    mcp_sync = MagicMock()
-    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     skill_set_service = MagicMock()
-    runtime_reconciler = MagicMock()
-    runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -238,21 +209,17 @@ def test_aicoding_refresh_does_not_retry_mcp_projection_when_runtime_not_ready()
             _ctx(active_engine="aicoding"),
             _bot(),
             {"confirmed_template_update": True},
-            mcp_sync=mcp_sync,
             skill_set_factory=factory,
         ) is True
 
-    runtime_reconciler.project_mcp_and_cli.assert_not_called()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
 def test_aicoding_refresh_does_not_retry_mcp_projection_exception() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
-    mcp_sync = MagicMock()
-    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     runtime_reconciler = MagicMock()
-    runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
+    runtime_reconciler.project_mcp_and_cli = AsyncMock(side_effect=RuntimeError("projection down"))
     skill_set_service = MagicMock()
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
@@ -262,7 +229,6 @@ def test_aicoding_refresh_does_not_retry_mcp_projection_exception() -> None:
             _ctx(active_engine="aicoding"),
             _bot(),
             {"confirmed_template_update": True},
-            mcp_sync=mcp_sync,
             skill_set_factory=factory,
             runtime_reconciler=runtime_reconciler,
         ) is True
@@ -287,7 +253,6 @@ def test_aicoding_refresh_does_not_retry_skill_symlink_when_false() -> None:
             _ctx(active_engine="aicoding"),
             _bot(),
             {"confirmed_template_update": True},
-            mcp_sync=None,
             skill_set_factory=factory,
         ) is True
 
@@ -308,7 +273,6 @@ def test_aicoding_refresh_does_not_retry_skill_symlink_exception() -> None:
             _ctx(active_engine="aicoding"),
             _bot(),
             {"confirmed_template_update": True},
-            mcp_sync=None,
             skill_set_factory=factory,
         ) is True
 
@@ -317,8 +281,6 @@ def test_aicoding_refresh_does_not_retry_skill_symlink_exception() -> None:
 
 def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
-    mcp_sync = MagicMock()
-    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     runtime_reconciler = MagicMock()
     runtime_reconciler.project_mcp_and_cli = AsyncMock(side_effect=RuntimeError("detail down"))
@@ -331,7 +293,6 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
             _ctx(active_engine="aicoding"),
             _bot(),
             {"confirmed_template_update": True},
-            mcp_sync=mcp_sync,
             skill_set_factory=factory,
             runtime_reconciler=runtime_reconciler,
         ) is True
@@ -354,7 +315,6 @@ def test_aicoding_refresh_swallows_skill_sync_exception() -> None:
             _ctx(active_engine="aicoding"),
             _bot(),
             {"confirmed_template_update": True},
-            mcp_sync=None,
             skill_set_factory=factory,
         ) is True
 
@@ -366,7 +326,6 @@ def test_default_strategy_always_returns_false() -> None:
     assert (
         strategy.refresh_restart_authorization(
             _ctx(), _bot(), {"confirmed_template_update": True},
-            mcp_sync=MagicMock(),
             skill_set_factory=MagicMock(),
             runtime_reconciler=MagicMock(),
         )
@@ -384,8 +343,6 @@ def test_aicoding_refresh_clears_persisted_marker_after_confirmed_extra_success(
             "template_version_id": 101,
         },
     }
-    mcp_sync = MagicMock()
-    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     runtime_reconciler = MagicMock()
     runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
     template_service = MagicMock()
@@ -396,7 +353,6 @@ def test_aicoding_refresh_clears_persisted_marker_after_confirmed_extra_success(
             _ctx(active_engine="aicoding"),
             _bot(),
             {"confirmed_template_update": True},
-            mcp_sync=mcp_sync,
             skill_set_factory=None,
             runtime_reconciler=runtime_reconciler,
             template_service=template_service,
@@ -430,8 +386,6 @@ def test_aicoding_refresh_uses_persisted_template_marker_and_clears_after_succes
         template_type="architect",
         template_config=template_config,
     )
-    mcp_sync = MagicMock()
-    mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     runtime_reconciler = MagicMock()
     runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
     template_service = MagicMock()
@@ -442,7 +396,6 @@ def test_aicoding_refresh_uses_persisted_template_marker_and_clears_after_succes
             ctx,
             _bot(),
             None,
-            mcp_sync=mcp_sync,
             skill_set_factory=None,
             runtime_reconciler=runtime_reconciler,
             template_service=template_service,
@@ -452,6 +405,55 @@ def test_aicoding_refresh_uses_persisted_template_marker_and_clears_after_succes
     cleared = template_service.update_template.call_args.kwargs["template_config"]
     assert "_aicoding_restart" not in cleared
     assert cleared["template_version_id"] == 101
+
+
+def test_aicoding_refresh_keeps_succeeded_refresh_when_marker_clear_fails() -> None:
+    strategy = AicodingProvisioningStrategy("aicoding")
+    template_config = {
+        "template_version_id": 101,
+        "_aicoding_restart": {
+            "resync_authorization": True,
+            "template_version_id": 101,
+        },
+    }
+    ctx = BotProvisioningContext(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        bot_type="personal",
+        active_engine="aicoding",
+        template_type="architect",
+        template_config=template_config,
+    )
+    runtime_reconciler = MagicMock()
+    runtime_reconciler.project_mcp_and_cli = AsyncMock(return_value=None)
+    skill_set_service = MagicMock()
+    skill_set_service.project_skills = AsyncMock(return_value=True)
+    factory = MagicMock()
+    factory.create.return_value = skill_set_service
+    template_service = MagicMock()
+    template_service.get_template_config.return_value = template_config
+
+    with patch.object(
+        strategy,
+        "_clear_restart_resync_marker",
+        side_effect=RuntimeError("marker down"),
+    ), patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
+        assert strategy.refresh_restart_authorization(
+            ctx,
+            _bot(),
+            None,
+            skill_set_factory=factory,
+            runtime_reconciler=runtime_reconciler,
+            template_service=template_service,
+        ) is True
+
+    runtime_reconciler.project_mcp_and_cli.assert_awaited_once_with(
+        bot_id="bot-1",
+        owner_id="ent-1",
+        scope=ProjectionScope(mcp=True, claim_all_mcp=True),
+    )
+    skill_set_service.project_skills.assert_awaited_once_with()
+    template_service.update_template.assert_not_called()
 
 
 def test_baas_restart_publish_listener_dispatches_strategy_after_restart_event() -> None:
@@ -470,7 +472,6 @@ def test_baas_restart_publish_listener_dispatches_strategy_after_restart_event()
     }
     template_service = MagicMock()
     template_service.get_template_config.return_value = template_config
-    mcp_sync = object()
     runtime_reconciler = object()
     factory = object()
     strategy = MagicMock()
@@ -480,7 +481,6 @@ def test_baas_restart_publish_listener_dispatches_strategy_after_restart_event()
     listener = AicodingRestartAuthorizationBaasPublishListener(
         bot_repo=bot_repo,
         template_service=template_service,
-        mcp_sync=mcp_sync,
         skill_set_factory=factory,
         runtime_reconciler=runtime_reconciler,
     )
@@ -511,7 +511,6 @@ def test_baas_restart_publish_listener_dispatches_strategy_after_restart_event()
         "ctx",
         bot_repo.get_by_id_and_owner.return_value,
         None,
-        mcp_sync=mcp_sync,
         skill_set_factory=factory,
         runtime_reconciler=runtime_reconciler,
         template_service=template_service,

--- a/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
+++ b/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
@@ -3,7 +3,7 @@
 ``refresh_restart_authorization`` now owns both the opt-in decision and the
 AICoding-specific side effects:
   * refresh MCP scope;
-  * push MCP details to runtime;
+  * declare MCP desired state to runtime;
   * resync ~/.claude/skills symlinks via SkillSetService.project_skills().
 All side effects are best-effort/fire-and-forget.
 """
@@ -98,9 +98,10 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a", "mcp-b"]
+    skill_set_service.sync_mcp_desired_state = AsyncMock(return_value=True)
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -121,12 +122,15 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     assert scope_kwargs["entity_type"] == "staff"
     assert scope_kwargs["engine_type"] == "aicoding"
     assert "extra_cli_items" not in scope_kwargs
-    mcp_sync.sync_mcp_desired_state.assert_awaited_once_with(
-        user_id="ent-9",
-        entity_id="ent-9",
-        bot_id="bot-1",
-        entity_type="staff",
-        engine_type="aicoding",
+    skill_set_service.get_bot_mcp_codes.assert_called_once_with(
+        "ent-9",
+        "bot-1",
+        "ent-9",
+        "staff",
+        "aicoding",
+    )
+    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
+        server_codes={"mcp-a", "mcp-b"},
     )
     factory.create.assert_called_once_with(
         user_id="ent-9",
@@ -166,9 +170,9 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
     mcp_sync.refresh_mcp_scope = AsyncMock(
         return_value={"success": False, "error": "scope denied"}
     )
-    mcp_sync.sync_mcp_desired_state = AsyncMock()
     factory = MagicMock()
     skill_set_service = MagicMock()
+    skill_set_service.sync_mcp_desired_state = AsyncMock()
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -181,7 +185,7 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_desired_state.assert_not_called()
+    skill_set_service.sync_mcp_desired_state.assert_not_called()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -189,11 +193,10 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(
-        return_value={"success": False, "error": "detail down"}
-    )
     factory = MagicMock()
     skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
+    skill_set_service.sync_mcp_desired_state = AsyncMock(return_value=False)
     skill_set_service.project_skills = AsyncMock(return_value=False)
     factory.create.return_value = skill_set_service
 
@@ -206,22 +209,22 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
+    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
+        server_codes={"mcp-a"},
+    )
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
-def test_aicoding_refresh_does_not_retry_mcp_detail_when_runtime_not_ready() -> None:
+def test_aicoding_refresh_does_not_retry_mcp_desired_state_when_runtime_not_ready() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(
-        side_effect=[
-            {"success": False, "error": "NO_ACTIVE_DEVICES"},
-            {"success": True},
-        ]
-    )
     factory = MagicMock()
     skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
+    skill_set_service.sync_mcp_desired_state = AsyncMock(
+        side_effect=[False, True]
+    )
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -234,20 +237,24 @@ def test_aicoding_refresh_does_not_retry_mcp_detail_when_runtime_not_ready() -> 
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
+    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
+        server_codes={"mcp-a"},
+    )
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
-def test_aicoding_refresh_does_not_retry_mcp_detail_exception() -> None:
+def test_aicoding_refresh_does_not_retry_mcp_desired_state_exception() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(
-        side_effect=[
-            RuntimeError("BaaS API error: NO_ACTIVE_DEVICES"),
-            {"success": True},
-        ]
+    factory = MagicMock()
+    skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
+    skill_set_service.sync_mcp_desired_state = AsyncMock(
+        side_effect=RuntimeError("BaaS API error: NO_ACTIVE_DEVICES")
     )
+    skill_set_service.project_skills = AsyncMock(return_value=True)
+    factory.create.return_value = skill_set_service
 
     with patch(_AICODING_THREADING, SimpleNamespace(Thread=_InlineThread)):
         assert strategy.refresh_restart_authorization(
@@ -255,10 +262,13 @@ def test_aicoding_refresh_does_not_retry_mcp_detail_exception() -> None:
             _bot(),
             {"confirmed_template_update": True},
             mcp_sync=mcp_sync,
-            skill_set_factory=None,
+            skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
+    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
+        server_codes={"mcp-a"},
+    )
+    skill_set_service.project_skills.assert_awaited_once_with()
 
 
 def test_aicoding_refresh_does_not_retry_skill_symlink_when_false() -> None:
@@ -305,9 +315,10 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(side_effect=RuntimeError("detail down"))
     factory = MagicMock()
     skill_set_service = MagicMock()
+    skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
+    skill_set_service.sync_mcp_desired_state = AsyncMock(side_effect=RuntimeError("detail down"))
     skill_set_service.project_skills = AsyncMock(side_effect=RuntimeError("skill down"))
     factory.create.return_value = skill_set_service
 
@@ -320,7 +331,9 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
+    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
+        server_codes={"mcp-a"},
+    )
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -339,6 +352,7 @@ def test_aicoding_refresh_swallows_skill_sync_exception() -> None:
         ) is True
 
     factory.create.assert_called_once()
+
 
 def test_default_strategy_always_returns_false() -> None:
     strategy = DefaultProvisioningStrategy("openclaw")

--- a/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
+++ b/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
@@ -98,7 +98,7 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(return_value={"success": True})
+    mcp_sync.sync_mcp_desired_state = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.project_skills = AsyncMock(return_value=True)
@@ -121,7 +121,7 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     assert scope_kwargs["entity_type"] == "staff"
     assert scope_kwargs["engine_type"] == "aicoding"
     assert "extra_cli_items" not in scope_kwargs
-    mcp_sync.sync_mcp_details.assert_awaited_once_with(
+    mcp_sync.sync_mcp_desired_state.assert_awaited_once_with(
         user_id="ent-9",
         entity_id="ent-9",
         bot_id="bot-1",
@@ -166,7 +166,7 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
     mcp_sync.refresh_mcp_scope = AsyncMock(
         return_value={"success": False, "error": "scope denied"}
     )
-    mcp_sync.sync_mcp_details = AsyncMock()
+    mcp_sync.sync_mcp_desired_state = AsyncMock()
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.project_skills = AsyncMock(return_value=True)
@@ -181,7 +181,7 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_details.assert_not_called()
+    mcp_sync.sync_mcp_desired_state.assert_not_called()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -189,7 +189,7 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(
+    mcp_sync.sync_mcp_desired_state = AsyncMock(
         return_value={"success": False, "error": "detail down"}
     )
     factory = MagicMock()
@@ -206,7 +206,7 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_details.assert_awaited_once()
+    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -214,7 +214,7 @@ def test_aicoding_refresh_does_not_retry_mcp_detail_when_runtime_not_ready() -> 
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(
+    mcp_sync.sync_mcp_desired_state = AsyncMock(
         side_effect=[
             {"success": False, "error": "NO_ACTIVE_DEVICES"},
             {"success": True},
@@ -234,7 +234,7 @@ def test_aicoding_refresh_does_not_retry_mcp_detail_when_runtime_not_ready() -> 
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_details.assert_awaited_once()
+    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -242,7 +242,7 @@ def test_aicoding_refresh_does_not_retry_mcp_detail_exception() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(
+    mcp_sync.sync_mcp_desired_state = AsyncMock(
         side_effect=[
             RuntimeError("BaaS API error: NO_ACTIVE_DEVICES"),
             {"success": True},
@@ -258,7 +258,7 @@ def test_aicoding_refresh_does_not_retry_mcp_detail_exception() -> None:
             skill_set_factory=None,
         ) is True
 
-    mcp_sync.sync_mcp_details.assert_awaited_once()
+    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
 
 
 def test_aicoding_refresh_does_not_retry_skill_symlink_when_false() -> None:
@@ -305,7 +305,7 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(side_effect=RuntimeError("detail down"))
+    mcp_sync.sync_mcp_desired_state = AsyncMock(side_effect=RuntimeError("detail down"))
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.project_skills = AsyncMock(side_effect=RuntimeError("skill down"))
@@ -320,7 +320,7 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
             skill_set_factory=factory,
         ) is True
 
-    mcp_sync.sync_mcp_details.assert_awaited_once()
+    mcp_sync.sync_mcp_desired_state.assert_awaited_once()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -364,7 +364,7 @@ def test_aicoding_refresh_clears_persisted_marker_after_confirmed_extra_success(
     }
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(return_value={"success": True})
+    mcp_sync.sync_mcp_desired_state = AsyncMock(return_value={"success": True})
     template_service = MagicMock()
     template_service.get_template_config.return_value = stored_template_config
 
@@ -403,7 +403,7 @@ def test_aicoding_refresh_uses_persisted_template_marker_and_clears_after_succes
     )
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_details = AsyncMock(return_value={"success": True})
+    mcp_sync.sync_mcp_desired_state = AsyncMock(return_value={"success": True})
     template_service = MagicMock()
     template_service.get_template_config.return_value = template_config
 

--- a/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
+++ b/src/backend/tests/community/core/bot_management/services/test_restart_authorization_refresh.py
@@ -101,7 +101,7 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a", "mcp-b"]
-    skill_set_service.sync_mcp_desired_state = AsyncMock(return_value=True)
+    skill_set_service.project_mcps = AsyncMock(return_value=True)
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -129,8 +129,10 @@ def test_aicoding_refresh_updates_mcp_and_skill_symlinks(flag) -> None:
         "staff",
         "aicoding",
     )
-    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
-        server_codes={"mcp-a", "mcp-b"},
+    skill_set_service.project_mcps.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a", "mcp-b"}),
+        released=frozenset(),
+        declared={"mcp-a", "mcp-b"},
     )
     factory.create.assert_called_once_with(
         user_id="ent-9",
@@ -172,7 +174,7 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
     )
     factory = MagicMock()
     skill_set_service = MagicMock()
-    skill_set_service.sync_mcp_desired_state = AsyncMock()
+    skill_set_service.project_mcps = AsyncMock()
     skill_set_service.project_skills = AsyncMock(return_value=True)
     factory.create.return_value = skill_set_service
 
@@ -185,7 +187,7 @@ def test_aicoding_refresh_logs_scope_failure_and_still_syncs_skills() -> None:
             skill_set_factory=factory,
         ) is True
 
-    skill_set_service.sync_mcp_desired_state.assert_not_called()
+    skill_set_service.project_mcps.assert_not_called()
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
@@ -196,7 +198,7 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
-    skill_set_service.sync_mcp_desired_state = AsyncMock(return_value=False)
+    skill_set_service.project_mcps = AsyncMock(return_value=False)
     skill_set_service.project_skills = AsyncMock(return_value=False)
     factory.create.return_value = skill_set_service
 
@@ -209,20 +211,22 @@ def test_aicoding_refresh_logs_detail_and_skill_runtime_failures() -> None:
             skill_set_factory=factory,
         ) is True
 
-    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
-        server_codes={"mcp-a"},
+    skill_set_service.project_mcps.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a"}),
+        released=frozenset(),
+        declared={"mcp-a"},
     )
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
-def test_aicoding_refresh_does_not_retry_mcp_desired_state_when_runtime_not_ready() -> None:
+def test_aicoding_refresh_does_not_retry_mcp_projection_when_runtime_not_ready() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
-    skill_set_service.sync_mcp_desired_state = AsyncMock(
+    skill_set_service.project_mcps = AsyncMock(
         side_effect=[False, True]
     )
     skill_set_service.project_skills = AsyncMock(return_value=True)
@@ -237,20 +241,22 @@ def test_aicoding_refresh_does_not_retry_mcp_desired_state_when_runtime_not_read
             skill_set_factory=factory,
         ) is True
 
-    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
-        server_codes={"mcp-a"},
+    skill_set_service.project_mcps.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a"}),
+        released=frozenset(),
+        declared={"mcp-a"},
     )
     skill_set_service.project_skills.assert_awaited_once_with()
 
 
-def test_aicoding_refresh_does_not_retry_mcp_desired_state_exception() -> None:
+def test_aicoding_refresh_does_not_retry_mcp_projection_exception() -> None:
     strategy = AicodingProvisioningStrategy("aicoding")
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
-    skill_set_service.sync_mcp_desired_state = AsyncMock(
+    skill_set_service.project_mcps = AsyncMock(
         side_effect=RuntimeError("BaaS API error: NO_ACTIVE_DEVICES")
     )
     skill_set_service.project_skills = AsyncMock(return_value=True)
@@ -265,8 +271,10 @@ def test_aicoding_refresh_does_not_retry_mcp_desired_state_exception() -> None:
             skill_set_factory=factory,
         ) is True
 
-    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
-        server_codes={"mcp-a"},
+    skill_set_service.project_mcps.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a"}),
+        released=frozenset(),
+        declared={"mcp-a"},
     )
     skill_set_service.project_skills.assert_awaited_once_with()
 
@@ -318,7 +326,7 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
     factory = MagicMock()
     skill_set_service = MagicMock()
     skill_set_service.get_bot_mcp_codes.return_value = ["mcp-a"]
-    skill_set_service.sync_mcp_desired_state = AsyncMock(side_effect=RuntimeError("detail down"))
+    skill_set_service.project_mcps = AsyncMock(side_effect=RuntimeError("detail down"))
     skill_set_service.project_skills = AsyncMock(side_effect=RuntimeError("skill down"))
     factory.create.return_value = skill_set_service
 
@@ -331,8 +339,10 @@ def test_aicoding_refresh_swallows_non_transient_runtime_exceptions() -> None:
             skill_set_factory=factory,
         ) is True
 
-    skill_set_service.sync_mcp_desired_state.assert_awaited_once_with(
-        server_codes={"mcp-a"},
+    skill_set_service.project_mcps.assert_awaited_once_with(
+        claimed=frozenset({"mcp-a"}),
+        released=frozenset(),
+        declared={"mcp-a"},
     )
     skill_set_service.project_skills.assert_awaited_once_with()
 
@@ -378,7 +388,6 @@ def test_aicoding_refresh_clears_persisted_marker_after_confirmed_extra_success(
     }
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(return_value={"success": True})
     template_service = MagicMock()
     template_service.get_template_config.return_value = stored_template_config
 
@@ -417,7 +426,6 @@ def test_aicoding_refresh_uses_persisted_template_marker_and_clears_after_succes
     )
     mcp_sync = MagicMock()
     mcp_sync.refresh_mcp_scope = AsyncMock(return_value={"success": True})
-    mcp_sync.sync_mcp_desired_state = AsyncMock(return_value={"success": True})
     template_service = MagicMock()
     template_service.get_template_config.return_value = template_config
 


### PR DESCRIPTION
This PR updates the AICoding restart resync path to use `project_mcps(...)` instead of only syncing desired state.

It also adds non-blocking diagnostic logs so MCP/skill sync failures are visible without stopping the restart flow.

Targeted unit tests were updated accordingly and pass locally.