### PR TITLE
fix(bcs): delegate persistent DB run retirement to platform, cover detached orphans

### DIFF
--- a/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
@@ -568,99 +568,31 @@ impl ChatRunRepoPort for SqlChatRunRepo {
 
     async fn drop_detached_expired(
         &self,
-        now_ms: u64,
-        retention_ms: u64,
+        _now_ms: u64,
+        _retention_ms: u64,
     ) -> Result<Vec<ChatRunRecord>, ChatRunRepoError> {
-        // MySQL delegates (terminal-row pruning is platform-managed; detached
-        // retirement is analogous — keep the auditable row). SQLite (dev/test)
-        // self-prunes here so the local table stays bounded and the path is
-        // covered by tests.
-        if self.flavor != DbSqlFlavor::Sqlite {
-            return Ok(Vec::new());
-        }
-        let cutoff = now_ms.saturating_sub(retention_ms);
-        let rows = self
-            .db
-            .query(DbStatement::with_params(
-                &format!(
-                    "SELECT {SELECT_COLS} FROM bcs_chat_runs \
-                     WHERE state = 'running' \
-                       AND completion_policy = 'detach_delivery_ack' \
-                       AND delivery_ack_at_ms IS NOT NULL \
-                       AND delivery_ack_at_ms < ? \
-                       AND env = ?"
-                ),
-                vec![DbValue::from(cutoff as i64), DbValue::from(self.env.as_str())],
-            ))
-            .await
-            .map_err(backend)?;
-        let mut dropped = Vec::new();
-        for row in rows {
-            let record = row_to_record(&row)?;
-            let _ = self
-                .db
-                .execute(DbStatement::with_params(
-                    &format!(
-                        "DELETE FROM bcs_chat_runs \
-                         WHERE run_id = ? AND state = 'running' \
-                           AND completion_policy = 'detach_delivery_ack' \
-                           AND delivery_ack_at_ms < ? \
-                           AND env = ?"
-                    ),
-                    vec![DbValue::from(record.run_id.clone()), DbValue::from(cutoff as i64), DbValue::from(self.env.as_str())],
-                ))
-                .await;
-            self.delete_overlay(&record.run_id).await;
-            dropped.push(record);
-        }
-        Ok(dropped)
+        // Persistent (SQL) DBs do not retire rows from the 10s cleanup loop.
+        // Acknowledged detached runs are pruned by the platform's scheduled task
+        // via the spec §11.2 SQL — terminal rows, plus acknowledged detached
+        // running rows past a *short* retention (not audit retention), so an
+        // orphaned-but-delivered run does not sit on the active-run gauge for
+        // 30/90 days. The memory impl performs the actual retirement and emits
+        // the `Dropped` lifecycle; this impl keeps the auditable row. Uniform
+        // across DB flavors — no per-flavor split.
+        Ok(Vec::new())
     }
 
     async fn delete_expired_terminal(
         &self,
-        now_ms: u64,
-        retention_ms: u64,
+        _now_ms: u64,
+        _retention_ms: u64,
     ) -> Result<Vec<ChatRunRecord>, ChatRunRepoError> {
-        // Production MySQL delegates terminal-row pruning to the platform's
-        // scheduled cleanup task (spec §11): keep the auditable rows, do not
-        // hard-delete from the 10s loop. SQLite (dev/test, no platform) still
-        // self-prunes here so the local table stays bounded and the delete path
-        // stays covered by tests.
-        if self.flavor != DbSqlFlavor::Sqlite {
-            return Ok(Vec::new());
-        }
-        let cutoff = now_ms.saturating_sub(retention_ms);
-        let rows = self
-            .db
-            .query(DbStatement::with_params(
-                &format!(
-                    "SELECT {SELECT_COLS} FROM bcs_chat_runs \
-                     WHERE state IN ({TERMINAL_STATES}) AND completed_at_ms < ? AND env = ?"
-                ),
-                vec![DbValue::from(cutoff as i64), DbValue::from(self.env.as_str())],
-            ))
-            .await
-            .map_err(backend)?;
-        let mut dropped = Vec::new();
-        for row in rows {
-            let record = row_to_record(&row)?;
-            // Delete one-by-one reusing the same cutoff guard to stay portable
-            // across SQLite/MySQL (no parameterized IN-list with variable arity).
-            let _ = self
-                .db
-                .execute(DbStatement::with_params(
-                    &format!(
-                        "DELETE FROM bcs_chat_runs \
-                         WHERE run_id = ? AND state IN ({TERMINAL_STATES}) AND completed_at_ms < ? \
-                         AND env = ?"
-                    ),
-                    vec![DbValue::from(record.run_id.clone()), DbValue::from(cutoff as i64), DbValue::from(self.env.as_str())],
-                ))
-                .await;
-            self.delete_overlay(&record.run_id).await;
-            dropped.push(record);
-        }
-        Ok(dropped)
+        // Persistent (SQL) DBs delegate terminal-row pruning to the platform's
+        // scheduled cleanup task (spec §11.2): keep the auditable rows, do not
+        // hard-delete from the 10s cleanup loop. The memory impl still prunes and
+        // emits the `Dropped`/`Expired` lifecycle. Uniform across DB flavors —
+        // no per-flavor split.
+        Ok(Vec::new())
     }
 
     async fn metric_counts(&self) -> Result<Vec<ChatRunMetricCount>, ChatRunRepoError> {

--- a/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
@@ -107,7 +107,7 @@ async fn streaming_append_advances_cache_ahead_of_db() {
 }
 
 #[tokio::test]
-async fn list_active_and_delete_expired_terminal() {
+async fn list_active_overdue_and_delete_expired_terminal_noop() {
     let repo = repo();
     let mut overdue = record("overdue", 1);
     overdue.expires_at_ms = 5;
@@ -119,7 +119,13 @@ async fn list_active_and_delete_expired_terminal() {
     assert_eq!(active.len(), 1);
     assert_eq!(active[0].run_id, "overdue");
 
-    // Mark overdue terminal then delete past retention.
+    // Mark overdue terminal. SQL repos do not prune — terminal-row deletion is
+    // delegated to the platform scheduled task (spec §11.2); the code path is a
+    // uniform no-op across DB flavors, so the auditable row stays in the DB.
+    //
+    // `delete_expired_terminal` returning the dropped records (so the engine can
+    // attribute the Dropped lifecycle) is exercised by the memory impl and the
+    // memory_repo.rs tests; the SQL impl returns empty and emits nothing here.
     let mut failed = active[0].clone();
     failed.state = ChatRunState::Failed;
     failed.completed_at_ms = Some(0);
@@ -127,12 +133,8 @@ async fn list_active_and_delete_expired_terminal() {
         .await
         .unwrap();
     let dropped = repo.delete_expired_terminal(100, 50).await.unwrap();
-    assert_eq!(dropped.len(), 1);
-    assert_eq!(dropped[0].run_id, "overdue");
-    // The deleted record carries `client` so the engine can attribute the
-    // Dropped lifecycle event without a separate full-table client scan.
-    assert_eq!(dropped[0].client.as_deref(), Some("http-chat-async"));
-    assert!(repo.get("overdue").await.unwrap().is_none());
+    assert!(dropped.is_empty());
+    assert!(repo.get("overdue").await.unwrap().is_some());
     assert!(repo.get("future").await.unwrap().is_some());
 }
 
@@ -164,16 +166,17 @@ async fn metric_counts_counts_active_runs_only() {
 }
 
 fn repo_mysql() -> SqlChatRunRepo {
-    // MySQL flavor over the local SQLite db. The MySQL code paths we test here
-    // return early (no-op) before issuing any DB statement, so the SQLite db is
-    // never actually queried — it just satisfies the constructor.
+    // Mysql flavor over the local in-memory SQLite db. The delete/retire code
+    // paths are uniform no-ops across DB flavors (spec §11.2, delegated to the
+    // platform), so this db is never actually queried — it just exercises the
+    // Mysql-flavor constructor.
     let db = Arc::new(LocalSqliteDbPlugin::new().expect("sqlite db"));
     let cache = Arc::new(InMemoryCachePlugin::new());
     SqlChatRunRepo::new(db, DbSqlFlavor::Mysql, cache, "bcs:".to_string(), 120_000, "test".to_string())
 }
 
 #[tokio::test]
-async fn list_active_excludes_acked_detached_and_drop_retires_them() {
+async fn list_active_excludes_acked_detached_and_drop_is_noop() {
     let repo = repo();
     // Acknowledged detached-delivery run: delivered successfully, overdue, but
     // must NOT be failed on timeout — list_active skips it.
@@ -192,22 +195,26 @@ async fn list_active_excludes_acked_detached_and_drop_retires_them() {
     assert_eq!(active.len(), 1);
     assert_eq!(active[0].run_id, "overdue");
 
-    // Retire the acked-detached run past its retention (now=100, retention=50).
+    // SQL repos do not retire detached rows here — acknowledged detached runs
+    // are pruned by the platform scheduled task (spec §11.2 detach branch). The
+    // code path is a uniform no-op; the auditable row stays, and list_active
+    // keeps excluding it so force_fail won't mark a delivered run as failed.
     let dropped = repo.drop_detached_expired(100, 50).await.unwrap();
-    assert_eq!(dropped.len(), 1);
-    assert_eq!(dropped[0].run_id, "detached");
-    assert!(repo.get("detached").await.unwrap().is_none());
+    assert!(dropped.is_empty());
+    assert!(repo.get("detached").await.unwrap().is_some());
     assert!(repo.get("overdue").await.unwrap().is_some());
 }
 
 #[tokio::test]
-async fn mysql_flavor_deletes_are_noops_delegated_to_platform() {
-    // In MySQL mode, terminal-row and detached-row pruning are delegated to the
-    // platform scheduled task (spec §11.2); the code paths must no-op (return
-    // empty) without touching the DB.
-    let repo = repo_mysql();
-    assert!(repo.delete_expired_terminal(100, 50).await.unwrap().is_empty());
-    assert!(repo.drop_detached_expired(100, 50).await.unwrap().is_empty());
+async fn deletes_are_noops_delegated_to_platform_across_flavors() {
+    // Terminal-row and detached-row pruning are delegated to the platform
+    // scheduled task (spec §11.2); the code paths no-op (return empty) without
+    // touching the DB, uniformly across DB flavors. list_active exclusion is
+    // covered above; here we confirm both delete ports no-op for both flavors.
+    for repo in [repo(), repo_mysql()] {
+        assert!(repo.delete_expired_terminal(100, 50).await.unwrap().is_empty());
+        assert!(repo.drop_detached_expired(100, 50).await.unwrap().is_empty());
+    }
 }
 
 #[tokio::test]

--- a/src/bcs/docs/superpowers/specs/2026-08-27-bcs-run-governance-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-27-bcs-run-governance-design.md
@@ -117,7 +117,7 @@ run_context_store = "redis" # | "memory";缺省 "memory"
 Codex 评审后修复(详见 PR 评论):
 - **C8**:ChatRun overlay TTL 由 `expires_at_ms` 改为 `expires_at_ms + retention`——超时清扫(`force_fail` 在 `expires_at < now` 后才跑)仍能合并流式正文,不再丢 `failed("timeout")` 的累积文本。
 - **C2**:`RedisBotRunContextStore` 的 context/transport/term 键 TTL 由固定 `retention`(120s)改为 `deadline_ms + retention`——长 provider run 不再在 120s 被驱逐成 `run_not_found`。两 store 统一"deadline + retention grace"模型。
-- **C11(回归)**:恢复 detached-delivery 清理语义——已 ack 的 `DetachDeliveryAck` run 不再被 `force_fail("timeout")`(已成功投递不应标失败);`list_active` 排除它们,新增 `drop_detached_expired` 端口按 `ack_at + retention` 静默退役(Dropped,非 Expired)。MySQL 侧 no-op 交平台。
+- **C11(回归)**:恢复 detached-delivery 清理语义——已 ack 的 `DetachDeliveryAck` run 不再被 `force_fail("timeout")`(已成功投递不应标失败);`list_active` 排除它们,新增 `drop_detached_expired` 端口按 `ack_at + retention` 静默退役(Dropped,非 Expired)。persistent DB 侧统一 no-op 交平台(见 §11.2 detach 分支)。
 - **C5**:启动校验 `bot_run_context_store="redis"` 要求 `[cache.redis]` 真为 Redis(capability 校验),否则 `InvalidConfig` 拒绝启动——不再静默退化为进程本地。
 - **C12**:启动校验 `async_chat_run_store`/`bot_run_context_store` 为枚举,拼写错误(如 `"persisent"`)直接报错而非静默落回 memory。
 - 拒绝/非-issue:C1(SQL CAS version 守卫——版本漂移容差是设计内,终态合并 overlay 已正确,真实子问题即 C8)、C3(bind 原子性——sticky-session 下单副本单次绑定)、C10(wait 跨副本唤醒——sticky-session),均在 PR 内回复并 resolve。
@@ -130,23 +130,29 @@ Codex 评审后修复(详见 PR 评论):
 - **Audit retention**(长,30/90 天):MySQL 终态行作为审计记录留存多久。persistent 模式专属。
 - 之前两者焊成同一个 `async_chat_run_retention_ms`(2min)→ persistent 模式终态正文 2min 即删,违背审计承诺;现已按模式区分。
 
-### 11.2 终态行删除:B1,外包给 MySQL 平台(persistent 代码不删)
-- 决定:persistent 模式终态行删除交由**内部 MySQL 平台的定时清理任务**,BCS 代码侧不实现删除定时器(除非将来有代码级定时任务基础设施,再以 `bcs-admin retention prune` / leader-gated housekeeping 作为 B2 备选)。
-- `SqlChatRunRepo::delete_expired_terminal`:`flavor == MySQL` 时 **no-op**(返回空,平台负责);`flavor == SQLite`(dev/test,无平台)仍照常删并返回被删记录。memory 实现照常删。引擎 `cleanup_expired` 对两模式统一调用,差异封在实现里。
-- 10s cleanup 循环只保留**活性职责**:`list_active`(索引范围扫,命中本窗口超时的非终态)+ `force_fail`(UPDATE 成 `failed("timeout")`——状态转移,不是删除)。
-- 交给平台的清理 SQL(用 `idx_chat_runs_completed` 索引,分块批量):
+### 11.2 行退役清理:B1,外包给平台(persistent 代码不删)
+- 决定:persistent 模式行删除交由**内部 MySQL 平台的定时清理任务**,BCS 代码侧不实现删除定时器(除非将来有代码级定时任务基础设施,再以 `bcs-admin retention prune` / leader-gated housekeeping 作为 B2 备选)。覆盖两类行:终态行(completed/failed/cancelled)与已 ack 的 detached running 行。
+- `SqlChatRunRepo::delete_expired_terminal` 与 `drop_detached_expired`:**对所有 DB flavor 统一 no-op**(返回空,退役交平台),不再按 `flavor` 分流。memory 实现照常退役并 emit `Dropped`/`Expired` 生命周期。SQLite(dev/test,无平台)同样 no-op——dev 无审计需求、本地表可跨用例 reset,统一实现优先于 SQLite 自清。引擎 `cleanup_expired` 对两模式统一调用,差异封在实现里。
+- 10s cleanup 循环只保留**活性职责**:`list_active`(索引范围扫,命中本窗口超时的非终态)+ `force_fail`(UPDATE 成 `failed("timeout")`——状态转移,不是删除)。`list_active` 排除已 ack 的 detached run(C11:已成功投递不应标 failed),其退役改由下方 SQL 的 detach 分支静默删除。
+- 交给平台的清理 SQL(分块批量,`LIMIT 1000` 循环到 affected_rows=0,框住单事务锁持有时间):
   ```sql
   DELETE FROM bcs_chat_runs
-   WHERE state IN ('completed','failed','cancelled')
-     AND completed_at_ms < <now - audit_retention_ms>
-   LIMIT 1000;   -- 循环到 affected_rows=0,框住单事务锁持有时间
+   WHERE (state IN ('completed','failed','cancelled')
+          AND completed_at_ms < <now - audit_retention_ms>)
+      OR (state = 'running'
+          AND completion_policy = 'detach_delivery_ack'
+          AND delivery_ack_at_ms IS NOT NULL
+          AND delivery_ack_at_ms < <now - detach_retention_ms>)
+   LIMIT 1000;
   ```
+  - 终态分支按 (env, state, completed_at_ms) 索引范围扫,审计 retention 30/90 天。
+  - detach 分支按 `state='running'` 前缀扫再过滤 `completion_policy`/`delivery_ack_at_ms`(无专用索引,但 detach running 行量小、仅平台 cron 周期跑,不在 10s 热路径);用**短** `<detach_retention_ms>`(对齐 memory/SQLite 旧 `drop_detached_expired` 的 `async_chat_run_retention_ms`≈2min,**不是** 30/90 天审计 retention)。如此 BCS 重启/流断产生的孤儿 detached run 不会在 active-run gauge 上挂一个月;平台 cron 哪怕每小时跑一次,gauge 窗口也 ≤ cron 间隔 + ~2min,有界。审计信号由生命周期 counter(`Dropped`)兜底。
 - 查询性反而更好:终态 run 在整个 audit retention 窗口都 `GET` 得到。
 
 ### 11.3 删除 `metric_client_kinds` 全表扫
-- 原 `metric_client_kinds`(`SELECT run_id, client FROM bcs_chat_runs`,无 WHERE 全表扫,每 10s × 副本,返回全表行建 HashMap)用于 cleanup 删前快照做 Expired/Dropped 的 client_kind 归属——属 memory 模式"遍历 slots 近乎零成本"的 port-到-SQL 成本陷阱,且 B1 下 persistent 的 `dropped` 恒空,快照失去意义。
+- 原 `metric_client_kinds`(`SELECT run_id, client FROM bcs_chat_runs`,无 WHERE 全表扫,每 10s × 副本,返回全表行建 HashMap)用于 cleanup 删前快照做 Expired/Dropped 的 client_kind 归属——属 memory 模式"遍历 slots 近乎零成本"的 port-到-SQL 成本陷阱,且 B1 下 persistent 两侧删除端口统一 no-op,`dropped` 恒空(仅 memory 实现返回被删记录),快照失去意义。
 - 已删掉该端口(`list_client_kinds`)+ 引擎方法(`metric_client_kinds`)。归属改用 cleanup **已 fetch 的记录**:
-  - `delete_expired_terminal` 返回 `Vec<ChatRunRecord>`(被删记录,带 `client`)→ Dropped 归属。
+  - `delete_expired_terminal` 返回 `Vec<ChatRunRecord>`(被删记录,带 `client`)→ Dropped 归属(SQL 实现返回空,退役已由 §11.2 平台 SQL 接管)。
   - `list_active` 返回的完整记录(带 `client`)→ Expired 归属。
   - 引擎 `cleanup_expired` 返回 `Vec<(String, DirectChatClientKind)>` 两个元组;mod.rs 直接用于 `emit_run_lifecycle`。
 - 改完 cleanup 的 DB 操作全是"本窗口有界 + 索引",与表大小无关;长 audit retention 才安全。


### PR DESCRIPTION
## Background

BCS direct-chat runs in persistent (MySQL) mode use a `DetachDeliveryAck` completion policy for async "detached" requests: the run is marked delivered (`delivery_ack_at_ms` set) on the provider's first progress event and stays in non-terminal `running` state (the caller does not wait for the final answer). The intended retirement for these runs is the `drop_detached_expired` port at `ack_at + retention` (a silent `Dropped` lifecycle), not terminalization — see spec C11.

## Problem

In persistent MySQL mode an acknowledged `DetachDeliveryAck` run could evade **every** retirement path and linger forever, counted by the active-run gauge indefinitely:

- `list_active` excludes acknowledged detached runs (C11 — a delivered run must not be `force_fail("timeout")`), so the 10s cleanup backstop never fails them.
- `SqlChatRunRepo::drop_detached_expired` / `delete_expired_terminal` were no-op **only for the MySQL flavor** (delegated to the platform, B1); the SQLite flavor self-pruned.
- The documented platform cleanup SQL (spec §11.2) pruned **only terminal rows** (`state IN ('completed','failed','cancelled')`).

So the "delegate detached retirement to platform" promise was never actually fulfilled: the platform SQL did not include a detached branch. The realistic trigger is a BCS restart (or provider-stream drop) mid-flight — the in-memory `drain_async_run` task dies, and for the default `SseFirst` transport the late `final` never arrives. The row is then orphaned `running` + `delivery_ack_at_ms` and stays forever, drifting the active-run gauge and growing the audit table without bound across restarts.

## Fix

- **Code (`crates/services/bcs-chat-run-store/src/sql.rs`)**: unify `delete_expired_terminal` and `drop_detached_expired` to a **uniform no-op across all DB flavors** — removed the per-flavor split and the SQLite `SELECT/DELETE` bodies. Persistent deletion is platform-owned; the memory implementation (default, safe-release path) is unchanged and still performs the actual retirement and emits the `Dropped`/`Expired` lifecycle.
- **Doc (spec §11.2 / C11 / §11.3)**: extend the platform cleanup SQL to also retire acknowledged detached running rows past a **short** retention:
  ```sql
  OR (state = 'running'
      AND completion_policy = 'detach_delivery_ack'
      AND delivery_ack_at_ms IS NOT NULL
      AND delivery_ack_at_ms < <now - detach_retention_ms>)
  ```
  where `<detach_retention_ms>` aligns with `async_chat_run_retention_ms` (~2 min, **not** the 30/90-day audit retention), so orphans leave the gauge promptly instead of sitting for a month (the audit signal is retained via the lifecycle counter). C11 is generalized ("persistent DB side no-op", not "MySQL side"), and §11.3's "persistent `dropped` is always empty" now holds uniformly across persistent flavors.
- **Tests (`crates/services/bcs-chat-run-store/tests/sql_repo.rs`)**: the three affected tests assert the uniform no-op (both SQLite and Mysql flavors) instead of deletion; the memory-repo tests keep covering the actual retirement path.

## Verification

- `cargo test -p bcs-chat-run-store` → **18 passed** (9 `sql_repo` + 9 `memory_repo`), no warnings.
- `cargo test -p bcs-message-flow --test run_store_engine` → **6 passed**, including `cleanup_expired_fails_overdue_drops_terminal_and_retires_detached` (memory path unchanged) and `detach_acknowledgement_guarded_by_policy`.
- `cargo build -p bcs-message-flow` → clean (depends on the updated trait; signature unchanged).

## Notes / follow-ups (not in this PR)

- The short-retention cutoff for the detached branch is a spec/ops decision; if the 30/90-day audit retention is preferred there instead, it is a one-line §11.2 change (the gauge would then overcount orphans for up to a month).
- `bcs-admin retention prune` (the B2 follow-up) is intentionally left as separate future work — it would give non-platform environments (SQLite dev, or clusters without the cron task) a manual prune path.
- An edge-case consistency gap where `drain_async_run`'s in-process timeout can `mark_failed` an already-acked detach run (vs the periodic `force_fail` excluding per C11) is left as a separate small fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
