### PR TITLE
feat(backend): add recoverable skill offline lineage

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/admission.py
@@ -605,6 +605,8 @@ ADMISSION: dict[tuple[str, str], AdmissionMode] = {
     ("POST", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft/upgrade"): AdmissionMode.REFUSED,
     ("POST", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft/refresh-from-git"): AdmissionMode.REFUSED,
     ("DELETE", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft"): AdmissionMode.REFUSED,
+    ("GET", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline-impact"): AdmissionMode.REFUSED,
+    ("POST", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline"): AdmissionMode.REFUSED,
     ("GET", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/grants"): AdmissionMode.USER_GATED,
     ("PUT", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/managers/{manager_user_id}"): AdmissionMode.REFUSED,
     ("DELETE", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/managers/{manager_user_id}"): AdmissionMode.REFUSED,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/authorization.py
@@ -495,6 +495,10 @@ AUTHORIZATION: dict[tuple[str, str], Authorization] = {
         NoCheck("Skill Grant, frozen Git source and revision CAS, adjudicated by the Skill service"),
     ("DELETE", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft"):
         NoCheck("Skill Grant, revision CAS, Lease fencing and aggregate history, adjudicated by the Skill service"),
+    ("GET", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline-impact"):
+        NoCheck("Skill Owner or Manager Grant and fail-closed lineage, adjudicated by the Offline service"),
+    ("POST", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline"):
+        NoCheck("Skill Owner or Manager Grant and transactional blocker recheck, adjudicated by the Offline service"),
     ("GET", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/grants"):
         NoCheck("Space membership and Skill Grants, adjudicated by the Grant service"),
     ("PUT", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/managers/{manager_user_id}"):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space.py
@@ -34,6 +34,8 @@ class SpaceErrorCode(IntEnum):
     PUBLICATION_RECOVERY_NOT_AVAILABLE = 409311
     PUBLICATION_REQUIRES_NEW_ATTEMPT = 409315
     PUBLICATION_TASK_UNAVAILABLE = 503203
+    SKILL_OFFLINE = 409312
+    SKILL_OFFLINE_BLOCKED = 409313
 
 
 class SpacePublicErrorMessage(StrEnum):
@@ -67,3 +69,5 @@ class SpacePublicErrorMessage(StrEnum):
     PUBLICATION_RECOVERY_NOT_AVAILABLE = "Publication recovery is not available"
     PUBLICATION_REQUIRES_NEW_ATTEMPT = "Edit the Draft and create a new Publication"
     PUBLICATION_TASK_UNAVAILABLE = "Publication task is unavailable"
+    SKILL_OFFLINE = "Skill is offline"
+    SKILL_OFFLINE_BLOCKED = "Skill Offline is blocked"

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space_skill.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/errors_space_skill.py
@@ -13,6 +13,8 @@ from agentclaw.community.core.skill_center.errors import (
     DraftRevisionConflictError,
     DraftSourceNotRefreshableError,
     SkillNameChangedError,
+    SkillOfflineBlockedError,
+    SkillOfflineError,
     SpaceSkillIdempotencyConflictError,
     DraftEditLeaseConflictError,
     DraftEditLeaseForbiddenError,
@@ -125,6 +127,11 @@ SPACE_SKILL_HTTP_ERRORS = {
         503,
         SpacePublicErrorMessage.PUBLICATION_TASK_UNAVAILABLE,
     ),
+    SkillOfflineError: (409, SpacePublicErrorMessage.SKILL_OFFLINE),
+    SkillOfflineBlockedError: (
+        409,
+        SpacePublicErrorMessage.SKILL_OFFLINE_BLOCKED,
+    ),
 }
 
 SPACE_SKILL_ERROR_CODES = {
@@ -162,4 +169,6 @@ SPACE_SKILL_ERROR_CODES = {
     PublicationRecoveryNotAvailableError: SpaceErrorCode.PUBLICATION_RECOVERY_NOT_AVAILABLE,
     PublicationRequiresNewAttemptError: SpaceErrorCode.PUBLICATION_REQUIRES_NEW_ATTEMPT,
     PublicationTaskUnavailableError: SpaceErrorCode.PUBLICATION_TASK_UNAVAILABLE,
+    SkillOfflineError: SpaceErrorCode.SKILL_OFFLINE,
+    SkillOfflineBlockedError: SpaceErrorCode.SKILL_OFFLINE_BLOCKED,
 }

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -23,6 +23,7 @@ from json import JSONDecodeError
 from typing import Awaitable, Callable, Mapping, TypeVar
 
 from fastapi import Request
+from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 
 from agentclaw.community.adapters.http.error_logging import (
@@ -220,6 +221,7 @@ from agentclaw.community.core.skill_center.errors import (
     SkillEngineNotSupportedError,
     SkillParameterValidationError,
     SkillRuntimeNameConflictError,
+    SkillOfflineBlockedError,
     SkillSetControlPlaneConflictError,
     SkillSetControlPlaneLockUnavailableError,
     SkillSetControlPlaneNotFoundError,
@@ -892,6 +894,7 @@ def _error_response(
     *,
     headers: Mapping[str, str] | None = None,
     code: int | None = None,
+    data: object | None = None,
 ) -> JSONResponse:
     # ``ErrorEnvelope``, not ``Envelope``: it is the model every route documents
     # for failures (``ERROR_RESPONSES``), and since ``Envelope`` gained the
@@ -899,15 +902,17 @@ def _error_response(
     # the documented model keeps the wire and the published schema in step — an
     # error body has no partial payload to caveat, so ``warning`` has no meaning
     # here.
-    body = ErrorEnvelope(
+    content = ErrorEnvelope(
         code=code if code is not None else http_status * 1000,
         message=message,
         data=None,
         request_id=_trace_id(request),
-    )
+    ).model_dump()
+    if data is not None:
+        content["data"] = jsonable_encoder(data)
     return JSONResponse(
         status_code=http_status,
-        content=body.model_dump(),
+        content=content,
         headers=_error_headers(request, headers),
     )
 
@@ -989,5 +994,6 @@ def mapped_error_response(exc: Exception, request: Request) -> JSONResponse | No
                 message,
                 request,
                 code=ENVELOPE_ERROR_CODES.get(error_type),
+                data=(exc.impact if isinstance(exc, SkillOfflineBlockedError) else None),
             )
     return None

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/responses.py
@@ -897,19 +897,18 @@ def _error_response(
     data: object | None = None,
 ) -> JSONResponse:
     # ``ErrorEnvelope``, not ``Envelope``: it is the model every route documents
-    # for failures (``ERROR_RESPONSES``), and since ``Envelope`` gained the
-    # optional ``warning`` field the two shapes are no longer identical. Building
-    # the documented model keeps the wire and the published schema in step — an
-    # error body has no partial payload to caveat, so ``warning`` has no meaning
-    # here.
-    content = ErrorEnvelope(
-        code=code if code is not None else http_status * 1000,
-        message=message,
-        data=None,
-        request_id=_trace_id(request),
-    ).model_dump()
-    if data is not None:
-        content["data"] = jsonable_encoder(data)
+    resolved_code = code if code is not None else http_status * 1000
+    request_id = _trace_id(request)
+    if data is None:
+        content = ErrorEnvelope(
+            code=resolved_code, message=message, data=None, request_id=request_id
+        ).model_dump()
+    else:
+        # P2-OFF-002 documents Envelope[SkillOfflineImpact], not ErrorEnvelope.
+        content = dict(
+            code=resolved_code, message=message,
+            data=jsonable_encoder(data), request_id=request_id,
+        )
     return JSONResponse(
         status_code=http_status,
         content=content,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
@@ -551,6 +551,43 @@ class SpaceSkillDetail(SpaceSkillSummary):
     )
 
 
+class SkillOfflineBlockerKind(_DocumentedEnum):
+    DRAFT = "DRAFT"
+    PUBLICATION = "PUBLICATION"
+    MEMBERSHIP = "MEMBERSHIP"
+    INSTALLATION = "INSTALLATION"
+    SERVICE_ARTIFACT = "SERVICE_ARTIFACT"
+    UNKNOWN_ARTIFACT = "UNKNOWN_ARTIFACT"
+
+    __descriptions__ = {
+        "DRAFT": "A mutable or frozen Draft already exists.",
+        "PUBLICATION": "A publication Attempt is still in progress or unknown.",
+        "MEMBERSHIP": "An ordinary or Default SkillSet still contains the Skill.",
+        "INSTALLATION": "A Bot still has an effective Skill Installation.",
+        "SERVICE_ARTIFACT": "A live Service Bot can replay this exact Skill Version.",
+        "UNKNOWN_ARTIFACT": "Artifact lineage could not be proved complete and valid.",
+    }
+
+
+class SkillOfflineImpactItem(BaseModel):
+    kind: SkillOfflineBlockerKind
+    resource_id: str = Field(description="Stable blocker resource identifier.")
+    display_name: str = Field(description="Human-readable blocker label.")
+
+
+class SkillOfflineImpact(BaseModel):
+    blocked: bool
+    total: int = Field(ge=0)
+    counts: dict[str, int]
+    items: list[SkillOfflineImpactItem]
+
+
+class SkillOfflineResult(BaseModel):
+    changed: bool
+    lifecycle_status: Literal["OFFLINE"]
+    draft: SkillDraftSummary
+
+
 class ImportSpaceSkillFromGitRequest(BaseModel):
     """Credential-free Git snapshot coordinates for Space Skill creation."""
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
@@ -552,6 +552,8 @@ class SpaceSkillDetail(SpaceSkillSummary):
 
 
 class SkillOfflineBlockerKind(_DocumentedEnum):
+    """Reason a Space Skill cannot safely enter recoverable Offline."""
+
     DRAFT = "DRAFT"
     PUBLICATION = "PUBLICATION"
     MEMBERSHIP = "MEMBERSHIP"
@@ -570,22 +572,40 @@ class SkillOfflineBlockerKind(_DocumentedEnum):
 
 
 class SkillOfflineImpactItem(BaseModel):
-    kind: SkillOfflineBlockerKind
+    """One live fact that prevents recoverable Offline."""
+
+    kind: SkillOfflineBlockerKind = Field(
+        description="Category of the blocking reference or lifecycle fact."
+    )
     resource_id: str = Field(description="Stable blocker resource identifier.")
     display_name: str = Field(description="Human-readable blocker label.")
 
 
 class SkillOfflineImpact(BaseModel):
-    blocked: bool
-    total: int = Field(ge=0)
-    counts: dict[str, int]
-    items: list[SkillOfflineImpactItem]
+    """Complete blocker counts plus one requested page of blocker details."""
+
+    blocked: bool = Field(description="Whether at least one blocker exists.")
+    total: int = Field(ge=0, description="Total blockers across all categories.")
+    counts: dict[str, int] = Field(
+        description="Non-zero blocker totals keyed by blocker category."
+    )
+    items: list[SkillOfflineImpactItem] = Field(
+        description="Requested page of blockers in deterministic order."
+    )
 
 
 class SkillOfflineResult(BaseModel):
-    changed: bool
-    lifecycle_status: Literal["OFFLINE"]
-    draft: SkillDraftSummary
+    """Recoverable Offline state and the editable next-version Draft."""
+
+    changed: bool = Field(
+        description="Whether this request newly moved the Skill Offline."
+    )
+    lifecycle_status: Literal["OFFLINE"] = Field(
+        description="Current recoverable lifecycle state."
+    )
+    draft: SkillDraftSummary = Field(
+        description="Editable Vn+1 Draft retained for recovery publication."
+    )
 
 
 class ImportSpaceSkillFromGitRequest(BaseModel):

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/skill_routes.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/skill_routes.py
@@ -42,6 +42,8 @@ from agentclaw.community.adapters.http.openapi_v1.spaces.schemas import (
     SpaceSkillFolderUpload,
     SpaceSkillDetail,
     SpaceSkillSummary,
+    SkillOfflineImpact,
+    SkillOfflineResult,
 )
 from agentclaw.community.api.space_skill_application_service import (
     SpaceSkillApplicationServiceProtocol,
@@ -52,6 +54,9 @@ from agentclaw.community.api.space_skill_query_service import (
 )
 from agentclaw.community.api.space_skill_version_query_service import (
     SpaceSkillVersionQueryServiceProtocol,
+)
+from agentclaw.community.api.space_skill_offline_service import (
+    SpaceSkillOfflineServiceProtocol,
 )
 from agentclaw.community.core.skill_center.skill_package import (
     MAX_EXPANDED_BYTES,
@@ -409,4 +414,67 @@ async def read_space_skill_version_file(
     return envelope(
         PublishedVersionFileContent.model_validate(result),
         request,
+    )
+
+
+@router.get(
+    "/{space_id}/skills/{skill_id}/offline-impact",
+    response_model=Envelope[SkillOfflineImpact],
+    dependencies=_REFUSES_APP_ONLY,
+)
+@envelope_errors
+async def get_space_skill_offline_impact(
+    space_id: SpaceIdPath,
+    skill_id: SkillIdPath,
+    request: Request,
+    caller: ActingCallerDep,
+    page_number: Annotated[int, Query(alias="page", ge=1)] = 1,
+    page_size: PageSizeQuery = 20,
+    service: SpaceSkillOfflineServiceProtocol = Injected(
+        SpaceSkillOfflineServiceProtocol
+    ),
+) -> Envelope[SkillOfflineImpact]:
+    actor_id = _require_user_delegation(caller)
+    result = await run_in_threadpool(
+        service.impact,
+        space_id=space_id,
+        skill_id=skill_id,
+        actor_id=actor_id,
+        page=page_number,
+        page_size=page_size,
+    )
+    return envelope(
+        SkillOfflineImpact.model_validate(result, from_attributes=True), request
+    )
+
+
+@router.post(
+    "/{space_id}/skills/{skill_id}/offline",
+    response_model=Envelope[SkillOfflineResult],
+    dependencies=_REFUSES_APP_ONLY,
+    responses={
+        409: {
+            "model": Envelope[SkillOfflineImpact],
+            "description": "Latest Offline blockers from the command transaction.",
+        }
+    },
+)
+@envelope_errors
+async def offline_space_skill(
+    space_id: SpaceIdPath,
+    skill_id: SkillIdPath,
+    request: Request,
+    user_id: UserIdDep,
+    service: SpaceSkillOfflineServiceProtocol = Injected(
+        SpaceSkillOfflineServiceProtocol
+    ),
+) -> Envelope[SkillOfflineResult]:
+    result = await run_in_threadpool(
+        service.offline,
+        space_id=space_id,
+        skill_id=skill_id,
+        actor_id=user_id,
+    )
+    return envelope(
+        SkillOfflineResult.model_validate(result, from_attributes=True), request
     )

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/skill_routes.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/skill_routes.py
@@ -428,7 +428,10 @@ async def get_space_skill_offline_impact(
     skill_id: SkillIdPath,
     request: Request,
     caller: ActingCallerDep,
-    page_number: Annotated[int, Query(alias="page", ge=1)] = 1,
+    page_number: Annotated[
+        int,
+        Query(alias="page", ge=1, description="One-based blocker page number."),
+    ] = 1,
     page_size: PageSizeQuery = 20,
     service: SpaceSkillOfflineServiceProtocol = Injected(
         SpaceSkillOfflineServiceProtocol

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/skill_routes.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/skill_routes.py
@@ -473,10 +473,11 @@ async def offline_space_skill(
     ),
 ) -> Envelope[SkillOfflineResult]:
     result = await run_in_threadpool(
-        service.offline,
-        space_id=space_id,
-        skill_id=skill_id,
-        actor_id=user_id,
+        lambda: service.offline(
+            space_id=space_id,
+            skill_id=skill_id,
+            actor_id=user_id,
+        )
     )
     return envelope(
         SkillOfflineResult.model_validate(result, from_attributes=True), request

--- a/src/backend/src/agentclaw/community/api/README.md
+++ b/src/backend/src/agentclaw/community/api/README.md
@@ -108,6 +108,8 @@ provides:
   - SpaceSkillPublicationServiceProtocol
   - SkillCenterPublicationGatewayProtocol
   - SkillMetadataParserProtocol
+  - ServiceArtifactLineageReaderProtocol
+  - SpaceSkillOfflineServiceProtocol
 consumes:
   - "No service impls at import time — Protocols only declare shape, they don't depend on concrete services"
   - "A small number of core dataclass / schema types used to type Protocol method signatures (see internal_dependencies)"
@@ -131,6 +133,7 @@ internal_dependencies:
   - agentclaw.community.core.engine_runtime.models    # EngineResult / BotFacts / ConnectionResult — typed in engine_runtime_service.py (real signatures, so the conformance gate can compare them)
   - agentclaw.community.core.quality.models          # QualityTaskRecord — typed in quality_service.py and task_processor_service.py
   - agentclaw.community.core.service_bot.repository.models  # BotPublishRecord — typed in engine_config_service.py
+  - agentclaw.community.core.service_bot.service_artifact_lineage_reader_protocol
   - agentclaw.community.core.resources.models        # Resource / ResourceType — typed in resource_service.py (Protocol signatures mirror slim ResourceService verbatim; round-2 review #4)
   - agentclaw.community.core.spaces.models           # Space/member records and enums — typed in space_service.py
   - agentclaw.community.core.repository.protocols.skill_center_types # Space Skill query projection

--- a/src/backend/src/agentclaw/community/api/service_artifact_lineage.py
+++ b/src/backend/src/agentclaw/community/api/service_artifact_lineage.py
@@ -1,0 +1,16 @@
+"""Public re-export of the Service Artifact lineage read contract."""
+
+from agentclaw.community.core.service_bot.service_artifact_lineage_reader_protocol import (
+    ServiceArtifactLineage,
+    ServiceArtifactLineageReaderProtocol,
+    ServiceArtifactReference,
+    UnknownServiceArtifact,
+)
+
+
+__all__ = [
+    "ServiceArtifactLineage",
+    "ServiceArtifactLineageReaderProtocol",
+    "ServiceArtifactReference",
+    "UnknownServiceArtifact",
+]

--- a/src/backend/src/agentclaw/community/api/space_skill_offline_service.py
+++ b/src/backend/src/agentclaw/community/api/space_skill_offline_service.py
@@ -1,0 +1,20 @@
+"""Public re-export of the recoverable Space Skill Offline contract."""
+
+from agentclaw.community.core.skill_center.space_skill_offline_service_protocol import (
+    OfflineBlockerKind,
+    OfflineDraft,
+    OfflineImpact,
+    OfflineImpactItem,
+    SpaceSkillOfflineResult,
+    SpaceSkillOfflineServiceProtocol,
+)
+
+
+__all__ = [
+    "OfflineBlockerKind",
+    "OfflineDraft",
+    "OfflineImpact",
+    "OfflineImpactItem",
+    "SpaceSkillOfflineResult",
+    "SpaceSkillOfflineServiceProtocol",
+]

--- a/src/backend/src/agentclaw/community/core/models/space_skill.py
+++ b/src/backend/src/agentclaw/community/core/models/space_skill.py
@@ -73,18 +73,6 @@ class SkillPublicationAttemptStatus(StrEnum):
     RESULT_UNKNOWN = "RESULT_UNKNOWN"
 
 
-ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES = tuple(
-    status.value
-    for status in (
-        SkillPublicationAttemptStatus.PREPARING,
-        SkillPublicationAttemptStatus.SC_SUBMITTING,
-        SkillPublicationAttemptStatus.WAITING_SC,
-        SkillPublicationAttemptStatus.MATERIALIZING,
-        SkillPublicationAttemptStatus.RESULT_UNKNOWN,
-    )
-)
-
-
 class SkillDraftUpgradeRequestStatus(StrEnum):
     ACTIVE = "ACTIVE"
     SPENT = "SPENT"
@@ -338,7 +326,6 @@ __all__ = [
     "SkillGrant",
     "SkillPublicationAttempt",
     "SkillPublicationAttemptStatus",
-    "ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES",
     "SkillSpaceBinding",
     "SkillVersion",
     "SkillVersionStatus",

--- a/src/backend/src/agentclaw/community/core/models/space_skill.py
+++ b/src/backend/src/agentclaw/community/core/models/space_skill.py
@@ -73,6 +73,18 @@ class SkillPublicationAttemptStatus(StrEnum):
     RESULT_UNKNOWN = "RESULT_UNKNOWN"
 
 
+ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES = tuple(
+    status.value
+    for status in (
+        SkillPublicationAttemptStatus.PREPARING,
+        SkillPublicationAttemptStatus.SC_SUBMITTING,
+        SkillPublicationAttemptStatus.WAITING_SC,
+        SkillPublicationAttemptStatus.MATERIALIZING,
+        SkillPublicationAttemptStatus.RESULT_UNKNOWN,
+    )
+)
+
+
 class SkillDraftUpgradeRequestStatus(StrEnum):
     ACTIVE = "ACTIVE"
     SPENT = "SPENT"
@@ -326,6 +338,7 @@ __all__ = [
     "SkillGrant",
     "SkillPublicationAttempt",
     "SkillPublicationAttemptStatus",
+    "ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES",
     "SkillSpaceBinding",
     "SkillVersion",
     "SkillVersionStatus",

--- a/src/backend/src/agentclaw/community/core/repository/README.md
+++ b/src/backend/src/agentclaw/community/core/repository/README.md
@@ -155,6 +155,8 @@ provides:
   - SpaceSkillDraftRepository
   - SpaceSkillReadRepository
   - SpaceSkillVersionReadRepository
+  - SpaceSkillOfflineRepositoryProtocol
+  - SpaceSkillOfflineRepository
   - SkillEditorRequestRepository
   - DraftEditLeaseRepository
   - SkillVersionRepositoryProtocol

--- a/src/backend/src/agentclaw/community/core/repository/implementations/publishing/bot_publish.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/publishing/bot_publish.py
@@ -39,16 +39,20 @@ from typing import Any, Dict, List, Optional, Sequence
 from injector import inject
 from sqlalchemy import func
 
+from agentclaw.community.core.models.skill import Skill
 from agentclaw.community.core.service_bot.repository.config_artifact_offload import (
     ConfigArtifactOffloader,
 )
 from agentclaw.community.core.service_bot.repository.models import (
+    BotPublishLineagePage,
     BotPublishModel,
     BotPublishRecord,
     PublishStatus,
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.database import DatabasePlugin
+from agentclaw.community.plugin_api.models import BotModel
+from agentclaw.community.core.skill_center.offline_policy import require_skill_online
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.core.repository.protocols.publishing import BotPublishRepositoryProtocol
 
@@ -271,6 +275,46 @@ class BotPublishRepository(
             records = [r.to_record() for r in rows]
         return [self._resolve_record(r) for r in records]
 
+    def list_lineage_candidates_page(
+        self,
+        *,
+        env: str,
+        after_id: int | None,
+        limit: int,
+    ) -> BotPublishLineagePage:
+        """Scan only records whose source Service Bot still exists.
+
+        ``id`` is immutable and monotonically increasing, so this cursor cannot
+        skip records when unrelated rows change status while a scan runs.
+        """
+        if limit < 1 or limit > 1000:
+            raise ValueError("lineage page limit is out of range")
+        with self._db.orm_session() as db:
+            query = (
+                db.query(self.Model)
+                .join(BotModel, BotModel.id == self.Model.source_bot_pk)
+                .filter(
+                    self.Model.env == env,
+                    BotModel.env == env,
+                    BotModel.is_delete == 0,
+                    BotModel.bot_type == "service",
+                )
+            )
+            if after_id is not None:
+                query = query.filter(self.Model.id > after_id)
+            rows = query.order_by(self.Model.id.asc()).limit(limit + 1).all()
+            has_more = len(rows) > limit
+            visible = rows[:limit]
+            records = tuple(row.to_record() for row in visible)
+        resolved = tuple(self._resolve_record(record) for record in records)
+        if any(record is None for record in resolved):  # pragma: no cover - invariant
+            raise RuntimeError("lineage page lost a publish record")
+        return BotPublishLineagePage(
+            records=resolved,
+            next_cursor=(int(visible[-1].id) if has_more and visible else None),
+            complete=not has_more,
+        )
+
     def get_latest_by_source_bot_id_and_owner_and_status(
         self,
         source_bot_id: str,
@@ -438,6 +482,65 @@ class BotPublishRepository(
             query = db.query(self.Model).filter(
                 self.Model.id == publish_id,
                 self.Model.status == source_status,
+            )
+            if expected_json is None:
+                query = query.filter(self.Model.ext.is_(None))
+            else:
+                query = query.filter(self.Model.ext == expected_json)
+            affected = query.update(
+                {
+                    self.Model.status: target_status,
+                    self.Model.ext: ext_json,
+                    self.Model.gmt_modified: func.now(),
+                },
+                synchronize_session=False,
+            )
+            if affected > 0:
+                self._offload.upload(pending)
+        if affected == 0:
+            return None
+        return self.get_by_id(publish_id)
+
+    def compare_and_set_built_with_ext(
+        self,
+        *,
+        publish_id: int,
+        source_status: str,
+        target_status: str,
+        expected_ext: Optional[Dict[str, Any]],
+        ext: Dict[str, Any],
+        center_skill_uuids: Sequence[str],
+        env: str,
+    ) -> Optional[BotPublishRecord]:
+        """Fence Offline against the moment an Artifact becomes replayable."""
+        expected_json, _ = self._offload.prepare(expected_ext, publish_id, env)
+        ext_json, pending = self._offload.prepare(ext, publish_id, env)
+        uuids = tuple(sorted(set(center_skill_uuids)))
+        with self._db.orm_session() as db:
+            skill_ids = [
+                int(value[0])
+                for value in db.query(Skill.id)
+                .filter(Skill.env == env, Skill.skill_uuid.in_(uuids))
+                .order_by(Skill.id.asc())
+                .all()
+            ] if uuids else []
+            if len(skill_ids) != len(uuids):
+                raise RuntimeError("Artifact references an unknown Center Skill")
+            # Acquire one row lock at a time in immutable id order. Offline and
+            # every new consumption write take the same row lock.
+            for skill_id in skill_ids:
+                skill = (
+                    db.query(Skill)
+                    .filter(Skill.id == skill_id, Skill.env == env)
+                    .with_for_update()
+                    .one()
+                )
+                require_skill_online(skill)
+
+            query = db.query(self.Model).filter(
+                self.Model.id == publish_id,
+                self.Model.status == source_status,
+                self.Model.env == env,
             )
             if expected_json is None:
                 query = query.filter(self.Model.ext.is_(None))

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/capability_desired_state.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/capability_desired_state.py
@@ -61,6 +61,7 @@ from agentclaw.community.core.skill_center.errors import (
     SkillSetControlPlaneConflictError,
     SkillSetControlPlaneNotFoundError,
 )
+from agentclaw.community.core.skill_center.offline_policy import require_skill_online
 from agentclaw.community.core.skill_center.policies.capability_ownership import (
     require_can_join_set,
 )
@@ -327,6 +328,7 @@ class CapabilityDesiredStateRepository(
                 and skill.bolt_id != bot_id
             ):
                 raise SkillSetControlPlaneNotFoundError()
+            require_skill_online(skill)
             old = self._snapshot(
                 session, bot_id, owner_id, engine_type=engine_type
             )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/capability_desired_state.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/capability_desired_state.py
@@ -589,6 +589,26 @@ class CapabilityDesiredStateRepository(
             if engine_type is not None:
                 query = query.filter(SkillSet.engine_type == engine_type)
             current_sets = query.with_for_update().all()
+            restored_skill_ids = set(state.installations)
+            restored_skill_ids.update(
+                skill_id
+                for members in state.memberships.values()
+                for skill_id, _user_id, _skill_uuid in members
+            )
+            # Compensation is another consumption writer: projection failure
+            # must not resurrect a Membership/Installation after Offline won.
+            # Match every forward writer's lock and take multiple Skills in
+            # immutable id order before the first desired-state mutation.
+            for skill_id in sorted(restored_skill_ids):
+                skill = (
+                    self._scope(session.query(Skill), Skill)
+                    .filter(Skill.id == skill_id)
+                    .with_for_update()
+                    .one_or_none()
+                )
+                if skill is None:
+                    raise SkillSetControlPlaneNotFoundError()
+                require_skill_online(skill)
             current_ids = {int(row.id) for row in current_sets}
             if current_ids:
                 self._scope(session.query(SkillSetSkill), SkillSetSkill).filter(

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/default_exclusion_commands.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/default_exclusion_commands.py
@@ -27,6 +27,7 @@ from agentclaw.community.core.repository.capability_desired_state_types import (
 from agentclaw.community.core.skill_center.errors import (
     SkillSetControlPlaneNotFoundError,
 )
+from agentclaw.community.core.skill_center.offline_policy import require_skill_online
 from agentclaw.community.utils.env_utils import get_current_env
 
 
@@ -119,6 +120,15 @@ class DefaultExclusionCommands:
             old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
             if not str(skill_id).isdecimal():
                 return DesiredStateMutation(_item(row), False, old)
+            skill = (
+                self._scope(session.query(Skill), Skill)
+                .filter(Skill.id == int(skill_id))
+                .with_for_update()
+                .one_or_none()
+            )
+            if skill is None:
+                raise SkillSetControlPlaneNotFoundError()
+            require_skill_online(skill)
             removed = default_exclusions.unexclude_skill(
                 session, bot_id=bot_id, owner_id=owner_id,
                 set_id=int(row.id), skill_id=int(skill_id),

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/direct_installation_commands.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/direct_installation_commands.py
@@ -32,6 +32,7 @@ from agentclaw.community.core.skill_center.errors import (
 from agentclaw.community.core.skill_center.policies.capability_ownership import (
     is_set_managed,
 )
+from agentclaw.community.core.skill_center.offline_policy import require_skill_online
 from agentclaw.community.utils.env_utils import get_current_env
 
 
@@ -61,6 +62,7 @@ class DirectInstallationCommands:
                 and skill.bolt_id != bot_id
             ):
                 raise SkillSetControlPlaneNotFoundError()
+            require_skill_online(skill)
             old = self._snapshot(session, bot_id, owner_id, engine_type=engine_type)
             self._require_not_set_managed(
                 session,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
@@ -53,6 +53,7 @@ from sqlalchemy import and_, func, or_
 
 from agentclaw.community.log import get_logger
 from agentclaw.community.core.skill_center.errors import ActiveSkillSetReferenceError
+from agentclaw.community.core.skill_center.offline_policy import require_skill_online
 from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
@@ -1480,10 +1481,12 @@ class SkillSetRepository(
                     self.Skill.id == int(skill_id),
                     self.Skill.env == get_current_env(),
                 )
+                .with_for_update()
                 .one_or_none()
             )
             if skill_set is None or skill is None:
                 return False
+            require_skill_online(skill)
             # Existing membership remains the successful idempotent result.
             # Canonical cross-Set uniqueness is enforced by the new control
             # plane under its Bot mutation lease, not by this legacy writer.

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
@@ -8,7 +8,7 @@ from injector import inject
 from sqlalchemy import and_, func
 
 from agentclaw.community.core.models.skill import Skill
-from agentclaw.community.core.models.space_skill import SkillVersion
+from agentclaw.community.core.models.space_skill import SkillSpaceBinding, SkillVersion
 from agentclaw.community.core.repository.protocols.skill_center import (
     SkillVersionMaterializationRepositoryProtocol,
     SkillVersionRepositoryProtocol,
@@ -169,6 +169,21 @@ class SkillVersionRepository(
                 version.status = "PUBLISHED"
                 skill.description = description
                 skill.status = "PUBLISHED"
+                # Only a real new publication of a Space-owned Skill restores
+                # TeamClaw visibility. An idempotent replay of an already
+                # PUBLISHED Version must never clear a later Offline fact, and
+                # SC Public Reference/Sync has no Space ownership to restore.
+                owns_space = (
+                    session.query(SkillSpaceBinding.id)
+                    .filter(
+                        SkillSpaceBinding.skill_id == skill_id,
+                        SkillSpaceBinding.env == env,
+                    )
+                    .one_or_none()
+                )
+                if owns_space is not None:
+                    skill.offline_at = None
+                    skill.offline_by = None
                 session.flush()
             else:
                 raise RuntimeError("Skill Version is not MATERIALIZING")

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
@@ -16,6 +16,9 @@ from agentclaw.community.core.repository.protocols.skill_center import (
 from agentclaw.community.core.repository.protocols.skill_center_types import (
     SkillVersionRecord,
 )
+from agentclaw.community.core.repository.implementations.skill_center.skill_version_lock import (
+    lock_skill_then_exact_version,
+)
 from agentclaw.community.core.skill_center.materialization_contract import (
     MaterializingSkillVersion,
     PublishedMaterializedSkillVersion,
@@ -138,21 +141,15 @@ class SkillVersionRepository(
         published_at: datetime,
     ) -> PublishedMaterializedSkillVersion:
         with self._db.orm_session() as session:
-            result = (
-                session.query(SkillVersion, Skill)
-                .join(Skill, Skill.id == SkillVersion.skill_id)
-                .filter(
-                    SkillVersion.id == skill_version_id,
-                    SkillVersion.skill_id == skill_id,
-                    SkillVersion.env == env,
-                    Skill.env == env,
-                )
-                .with_for_update()
-                .one_or_none()
+            locked = lock_skill_then_exact_version(
+                session,
+                env=env,
+                skill_id=skill_id,
+                skill_version_id=skill_version_id,
             )
-            if result is None:
+            if locked is None:
                 raise RuntimeError("materializing Skill Version not found")
-            version, skill = result
+            skill, version = locked
             if version.status == "PUBLISHED":
                 if (
                     version.metadata_json != metadata_json
@@ -181,7 +178,10 @@ class SkillVersionRepository(
                     )
                     .one_or_none()
                 )
-                if owns_space is not None:
+                if (
+                    owns_space is not None
+                    and version.publication_attempt_id is not None
+                ):
                     skill.offline_at = None
                     skill.offline_by = None
                 session.flush()

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version_lock.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version_lock.py
@@ -8,6 +8,16 @@ from agentclaw.community.core.models.skill import Skill
 from agentclaw.community.core.models.space_skill import SkillVersion
 
 
+def lock_skill_row(session: Any, *, env: str, skill_id: int) -> Skill | None:
+    """Lock one Skill row, the first lock in every Skill lifecycle write."""
+    return (
+        session.query(Skill)
+        .filter(Skill.id == skill_id, Skill.env == env)
+        .with_for_update()
+        .one_or_none()
+    )
+
+
 def lock_skill_then_exact_version(
     session: Any,
     *,
@@ -16,12 +26,7 @@ def lock_skill_then_exact_version(
     skill_version_id: int,
 ) -> tuple[Skill, SkillVersion] | None:
     """Lock the parent Skill before one exact Version in every database."""
-    skill = (
-        session.query(Skill)
-        .filter(Skill.id == skill_id, Skill.env == env)
-        .with_for_update()
-        .one_or_none()
-    )
+    skill = lock_skill_row(session, env=env, skill_id=skill_id)
     if skill is None:
         return None
     version = (
@@ -46,12 +51,7 @@ def lock_skill_then_latest_published_version(
     skill_id: int,
 ) -> tuple[Skill, SkillVersion | None] | None:
     """Lock the parent Skill before its latest PUBLISHED Version."""
-    skill = (
-        session.query(Skill)
-        .filter(Skill.id == skill_id, Skill.env == env)
-        .with_for_update()
-        .one_or_none()
-    )
+    skill = lock_skill_row(session, env=env, skill_id=skill_id)
     if skill is None:
         return None
     latest = (
@@ -69,6 +69,7 @@ def lock_skill_then_latest_published_version(
 
 
 __all__ = [
+    "lock_skill_row",
     "lock_skill_then_exact_version",
     "lock_skill_then_latest_published_version",
 ]

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version_lock.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version_lock.py
@@ -1,0 +1,74 @@
+"""Canonical Skill -> SkillVersion row-lock order for lifecycle writes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentclaw.community.core.models.skill import Skill
+from agentclaw.community.core.models.space_skill import SkillVersion
+
+
+def lock_skill_then_exact_version(
+    session: Any,
+    *,
+    env: str,
+    skill_id: int,
+    skill_version_id: int,
+) -> tuple[Skill, SkillVersion] | None:
+    """Lock the parent Skill before one exact Version in every database."""
+    skill = (
+        session.query(Skill)
+        .filter(Skill.id == skill_id, Skill.env == env)
+        .with_for_update()
+        .one_or_none()
+    )
+    if skill is None:
+        return None
+    version = (
+        session.query(SkillVersion)
+        .filter(
+            SkillVersion.id == skill_version_id,
+            SkillVersion.skill_id == skill_id,
+            SkillVersion.env == env,
+        )
+        .with_for_update()
+        .one_or_none()
+    )
+    if version is None:
+        return None
+    return skill, version
+
+
+def lock_skill_then_latest_published_version(
+    session: Any,
+    *,
+    env: str,
+    skill_id: int,
+) -> tuple[Skill, SkillVersion | None] | None:
+    """Lock the parent Skill before its latest PUBLISHED Version."""
+    skill = (
+        session.query(Skill)
+        .filter(Skill.id == skill_id, Skill.env == env)
+        .with_for_update()
+        .one_or_none()
+    )
+    if skill is None:
+        return None
+    latest = (
+        session.query(SkillVersion)
+        .filter(
+            SkillVersion.skill_id == skill_id,
+            SkillVersion.env == env,
+            SkillVersion.status == "PUBLISHED",
+        )
+        .order_by(SkillVersion.version_ordinal.desc())
+        .with_for_update()
+        .first()
+    )
+    return skill, latest
+
+
+__all__ = [
+    "lock_skill_then_exact_version",
+    "lock_skill_then_latest_published_version",
+]

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_offline.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_offline.py
@@ -8,10 +8,6 @@ from datetime import datetime, timezone
 from injector import inject
 from sqlalchemy import or_
 
-from agentclaw.community.core.skill_center.space_skill_offline_service_protocol import (
-    OfflineBlockerKind,
-    OfflineImpactItem,
-)
 from agentclaw.community.core.models.skill import (
     BotSkillInstallation,
     Skill,
@@ -19,6 +15,7 @@ from agentclaw.community.core.models.skill import (
     SkillSetSkill,
 )
 from agentclaw.community.core.models.space_skill import (
+    ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES,
     SkillGrant,
     SkillPublicationAttempt,
     SkillSpaceBinding,
@@ -27,28 +24,23 @@ from agentclaw.community.core.models.space_skill import (
 from agentclaw.community.core.repository.space_skill_offline_types import (
     OfflineCommit,
     OfflineInspection,
+    OfflineInstallationFact,
+    OfflineMembershipFact,
+    OfflinePublicationAttemptFact,
     OfflineSkillIdentity,
 )
 from agentclaw.community.core.repository.protocols.space_skill_offline import (
     SpaceSkillOfflineRepositoryProtocol,
 )
+from agentclaw.community.core.repository.implementations.skill_center.skill_version_lock import (
+    lock_skill_then_latest_published_version,
+)
 from agentclaw.community.core.skill_center.errors import (
     DraftNotFoundError,
     DraftRevisionConflictError,
-    SpaceSkillGrantForbiddenError,
 )
 from agentclaw.community.core.spaces.repository.models import SpaceModel
 from agentclaw.community.plugin_api.database import DatabasePlugin
-
-
-_ACTIVE_ATTEMPTS = (
-    "PREPARING",
-    "SC_SUBMITTING",
-    "WAITING_SC",
-    "MATERIALIZING",
-    "RESULT_UNKNOWN",
-)
-_BLOCKER_ORDER = {kind: index for index, kind in enumerate(OfflineBlockerKind)}
 
 
 class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
@@ -63,7 +55,7 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
         self, *, space_id: int, skill_id: int, actor_id: str, env: str
     ) -> OfflineInspection:
         with self._db.orm_session() as session:
-            identity = self._identity(
+            inspection = self._inspection(
                 session,
                 space_id=space_id,
                 skill_id=skill_id,
@@ -71,8 +63,7 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
                 env=env,
                 lock=False,
             )
-            blockers = self._db_blockers(session, identity=identity, env=env)
-        return OfflineInspection(identity=identity, blockers=self._ordered(blockers))
+        return inspection
 
     def commit(
         self,
@@ -88,7 +79,7 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
         guard: Callable[[OfflineInspection], None],
     ) -> OfflineCommit:
         with self._db.transactional_orm_session() as session:
-            identity = self._identity(
+            inspection = self._inspection(
                 session,
                 space_id=space_id,
                 skill_id=skill_id,
@@ -96,6 +87,7 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
                 env=env,
                 lock=True,
             )
+            identity = inspection.identity
             skill = session.query(Skill).filter(Skill.id == skill_id).one()
             if (
                 skill.offline_at is not None
@@ -110,14 +102,7 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
                     locator=str(skill.zip_url),
                 )
 
-            guard(
-                OfflineInspection(
-                    identity=identity,
-                    blockers=self._ordered(
-                        self._db_blockers(session, identity=identity, env=env)
-                    ),
-                )
-            )
+            guard(inspection)
             if identity.latest_version_id != expected_version_id:
                 raise DraftRevisionConflictError("latest Published Version changed")
             if target_version != identity.latest_version_ordinal + 1:
@@ -138,7 +123,7 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
                 locator=new_locator,
             )
 
-    def _identity(
+    def _inspection(
         self,
         session,
         *,
@@ -147,11 +132,23 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
         actor_id: str,
         env: str,
         lock: bool,
-    ) -> OfflineSkillIdentity:
+    ) -> OfflineInspection:
         # Lock the Skill row before reading or mutating any related fact.  The
         # membership/direct/default and Artifact-commit paths take this same lock.
-        query = session.query(Skill).filter(Skill.id == skill_id, Skill.env == env)
-        skill = (query.with_for_update() if lock else query).one_or_none()
+        locked_latest = None
+        if lock:
+            locked_latest = lock_skill_then_latest_published_version(
+                session,
+                env=env,
+                skill_id=skill_id,
+            )
+            skill = locked_latest[0] if locked_latest is not None else None
+        else:
+            skill = (
+                session.query(Skill)
+                .filter(Skill.id == skill_id, Skill.env == env)
+                .one_or_none()
+            )
         if skill is None or not skill.skill_uuid:
             raise DraftNotFoundError("space skill not found")
         ownership = (
@@ -169,36 +166,38 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
             )
             .one_or_none()
         )
-        grant = (
-            session.query(SkillGrant.id)
+        actor_roles = tuple(
+            str(row[0])
+            for row in session.query(SkillGrant.role)
             .filter(
                 SkillGrant.skill_id == skill_id,
                 SkillGrant.user_id == actor_id,
                 SkillGrant.env == env,
                 SkillGrant.status == "ACTIVE",
-                SkillGrant.role.in_(("OWNER", "MANAGER")),
             )
-            .one_or_none()
+            .all()
         )
-        if ownership is None or grant is None:
-            raise SpaceSkillGrantForbiddenError("owner or manager required")
-        latest_query = (
-            session.query(SkillVersion)
-            .filter(
-                SkillVersion.skill_id == skill_id,
-                SkillVersion.env == env,
-                SkillVersion.status == "PUBLISHED",
+        if lock:
+            assert locked_latest is not None
+            latest = locked_latest[1]
+        else:
+            latest = (
+                session.query(SkillVersion)
+                .filter(
+                    SkillVersion.skill_id == skill_id,
+                    SkillVersion.env == env,
+                    SkillVersion.status == "PUBLISHED",
+                )
+                .order_by(SkillVersion.version_ordinal.desc())
+                .first()
             )
-            .order_by(SkillVersion.version_ordinal.desc())
-        )
-        latest = (latest_query.with_for_update() if lock else latest_query).first()
         if latest is None:
             raise DraftNotFoundError("latest Published Version not found")
-        return OfflineSkillIdentity(
+        identity = OfflineSkillIdentity(
             skill_id=int(skill.id),
             skill_uuid=str(skill.skill_uuid),
             name=str(skill.name),
-            sc_team_id=ownership[1].sc_team_id,
+            sc_team_id=ownership[1].sc_team_id if ownership is not None else None,
             latest_version_id=int(latest.id),
             latest_version_ordinal=int(latest.version_ordinal),
             sc_version_number=str(latest.sc_version_number),
@@ -207,32 +206,22 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
             draft_status=skill.draft_status,
             draft_locator=skill.zip_url,
         )
-
-    def _db_blockers(self, session, *, identity: OfflineSkillIdentity, env: str):
-        blockers: list[OfflineImpactItem] = []
-        if identity.draft_status is not None:
-            blockers.append(
-                OfflineImpactItem(
-                    kind=OfflineBlockerKind.DRAFT,
-                    resource_id=str(identity.skill_id),
-                    display_name=f"Draft V{identity.draft_target_version}",
-                )
-            )
         attempts = (
             session.query(SkillPublicationAttempt)
             .filter(
                 SkillPublicationAttempt.skill_id == identity.skill_id,
                 SkillPublicationAttempt.env == env,
-                SkillPublicationAttempt.status.in_(_ACTIVE_ATTEMPTS),
+                SkillPublicationAttempt.status.in_(
+                    ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES
+                ),
             )
-            .order_by(SkillPublicationAttempt.id.asc())
             .all()
         )
-        blockers.extend(
-            OfflineImpactItem(
-                kind=OfflineBlockerKind.PUBLICATION,
-                resource_id=str(attempt.id),
-                display_name=f"Publication V{attempt.target_version_ordinal}",
+        publication_attempts = tuple(
+            OfflinePublicationAttemptFact(
+                id=int(attempt.id),
+                target_version_ordinal=int(attempt.target_version_ordinal),
+                status=str(attempt.status),
             )
             for attempt in attempts
         )
@@ -247,14 +236,12 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
                 SkillSet.env == env,
                 or_(*identity_predicates),
             )
-            .order_by(SkillSetSkill.id.asc())
             .all()
         )
-        blockers.extend(
-            OfflineImpactItem(
-                kind=OfflineBlockerKind.MEMBERSHIP,
-                resource_id=str(membership.id),
-                display_name=str(skill_set.name),
+        membership_facts = tuple(
+            OfflineMembershipFact(
+                id=int(membership.id),
+                skill_set_name=str(skill_set.name),
             )
             for membership, skill_set in memberships
         )
@@ -264,30 +251,22 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
                 BotSkillInstallation.skill_id == identity.skill_id,
                 BotSkillInstallation.env == env,
             )
-            .order_by(BotSkillInstallation.id.asc())
             .all()
         )
-        blockers.extend(
-            OfflineImpactItem(
-                kind=OfflineBlockerKind.INSTALLATION,
-                resource_id=str(installation.id),
-                display_name=str(installation.bot_id),
+        installation_facts = tuple(
+            OfflineInstallationFact(
+                id=int(installation.id),
+                bot_id=str(installation.bot_id),
             )
             for installation in installations
         )
-        return blockers
-
-    @staticmethod
-    def _ordered(blockers):
-        return tuple(
-            sorted(
-                blockers,
-                key=lambda item: (
-                    _BLOCKER_ORDER[item.kind],
-                    item.resource_id,
-                    item.display_name,
-                ),
-            )
+        return OfflineInspection(
+            identity=identity,
+            space_bound=ownership is not None,
+            actor_roles=actor_roles,
+            publication_attempts=publication_attempts,
+            memberships=membership_facts,
+            installations=installation_facts,
         )
 
 __all__ = ["SpaceSkillOfflineRepository"]

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_offline.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_offline.py
@@ -1,0 +1,333 @@
+"""Transactional blocker recheck and commit for recoverable Skill Offline."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from injector import inject
+from sqlalchemy import or_
+
+from agentclaw.community.core.service_bot.service_artifact_lineage_reader_protocol import (
+    ServiceArtifactLineageReaderProtocol,
+)
+from agentclaw.community.core.skill_center.space_skill_offline_service_protocol import (
+    OfflineBlockerKind,
+    OfflineImpact,
+    OfflineImpactItem,
+)
+from agentclaw.community.core.models.skill import (
+    BotSkillInstallation,
+    Skill,
+    SkillSet,
+    SkillSetSkill,
+)
+from agentclaw.community.core.models.space_skill import (
+    SkillGrant,
+    SkillPublicationAttempt,
+    SkillSpaceBinding,
+    SkillVersion,
+)
+from agentclaw.community.core.repository.space_skill_offline_types import (
+    OfflineCommit,
+    OfflineInspection,
+    OfflineSkillIdentity,
+)
+from agentclaw.community.core.repository.protocols.space_skill_offline import (
+    SpaceSkillOfflineRepositoryProtocol,
+)
+from agentclaw.community.core.skill_center.errors import (
+    DraftNotFoundError,
+    DraftRevisionConflictError,
+    SkillOfflineBlockedError,
+    SpaceSkillGrantForbiddenError,
+)
+from agentclaw.community.core.spaces.repository.models import SpaceModel
+from agentclaw.community.plugin_api.database import DatabasePlugin
+
+
+_ACTIVE_ATTEMPTS = (
+    "PREPARING",
+    "SC_SUBMITTING",
+    "WAITING_SC",
+    "MATERIALIZING",
+    "RESULT_UNKNOWN",
+)
+_BLOCKER_ORDER = {kind: index for index, kind in enumerate(OfflineBlockerKind)}
+
+
+class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
+    @inject
+    def __init__(
+        self,
+        db: DatabasePlugin,
+        lineage: ServiceArtifactLineageReaderProtocol,
+    ) -> None:
+        self._db = db
+        self._lineage = lineage
+
+    def inspect(
+        self, *, space_id: int, skill_id: int, actor_id: str, env: str
+    ) -> OfflineInspection:
+        with self._db.orm_session() as session:
+            identity = self._identity(
+                session,
+                space_id=space_id,
+                skill_id=skill_id,
+                actor_id=actor_id,
+                env=env,
+                lock=False,
+            )
+            blockers = self._db_blockers(session, identity=identity, env=env)
+        blockers.extend(self._artifact_blockers(identity=identity, env=env))
+        return OfflineInspection(identity=identity, blockers=self._ordered(blockers))
+
+    def commit(
+        self,
+        *,
+        space_id: int,
+        skill_id: int,
+        actor_id: str,
+        expected_version_id: int,
+        target_version: int,
+        new_locator: str,
+        new_description: str | None,
+        env: str,
+    ) -> OfflineCommit:
+        with self._db.transactional_orm_session() as session:
+            identity = self._identity(
+                session,
+                space_id=space_id,
+                skill_id=skill_id,
+                actor_id=actor_id,
+                env=env,
+                lock=True,
+            )
+            skill = session.query(Skill).filter(Skill.id == skill_id).one()
+            if (
+                skill.offline_at is not None
+                and skill.draft_status is not None
+                and skill.zip_url
+                and skill.draft_target_version is not None
+            ):
+                return OfflineCommit(
+                    changed=False,
+                    target_version=int(skill.draft_target_version),
+                    status=str(skill.draft_status),
+                    locator=str(skill.zip_url),
+                )
+
+            blockers = self._db_blockers(session, identity=identity, env=env)
+            blockers.extend(self._artifact_blockers(identity=identity, env=env))
+            blockers = list(self._ordered(blockers))
+            if blockers:
+                raise SkillOfflineBlockedError(self._impact(blockers, page_size=20))
+            if identity.latest_version_id != expected_version_id:
+                raise DraftRevisionConflictError("latest Published Version changed")
+            if target_version != identity.latest_version_ordinal + 1:
+                raise DraftRevisionConflictError("Offline Draft target changed")
+
+            skill.offline_at = datetime.now(timezone.utc).replace(tzinfo=None)
+            skill.offline_by = actor_id
+            skill.zip_url = new_locator
+            skill.draft_target_version = target_version
+            skill.draft_status = "EDITING"
+            skill.draft_description = new_description
+            skill.draft_source_kind = "PUBLISHED_VERSION"
+            session.flush()
+            return OfflineCommit(
+                changed=True,
+                target_version=target_version,
+                status="EDITING",
+                locator=new_locator,
+            )
+
+    def _identity(
+        self,
+        session,
+        *,
+        space_id: int,
+        skill_id: int,
+        actor_id: str,
+        env: str,
+        lock: bool,
+    ) -> OfflineSkillIdentity:
+        # Lock the Skill row before reading or mutating any related fact.  The
+        # membership/direct/default and Artifact-commit paths take this same lock.
+        query = session.query(Skill).filter(Skill.id == skill_id, Skill.env == env)
+        skill = (query.with_for_update() if lock else query).one_or_none()
+        if skill is None or not skill.skill_uuid:
+            raise DraftNotFoundError("space skill not found")
+        ownership = (
+            session.query(SkillSpaceBinding, SpaceModel)
+            .join(
+                SpaceModel,
+                (SpaceModel.id == SkillSpaceBinding.space_id)
+                & (SpaceModel.env == SkillSpaceBinding.env),
+            )
+            .filter(
+                SkillSpaceBinding.skill_id == skill_id,
+                SkillSpaceBinding.space_id == space_id,
+                SkillSpaceBinding.env == env,
+                SpaceModel.deleted_at.is_(None),
+            )
+            .one_or_none()
+        )
+        grant = (
+            session.query(SkillGrant.id)
+            .filter(
+                SkillGrant.skill_id == skill_id,
+                SkillGrant.user_id == actor_id,
+                SkillGrant.env == env,
+                SkillGrant.status == "ACTIVE",
+                SkillGrant.role.in_(("OWNER", "MANAGER")),
+            )
+            .one_or_none()
+        )
+        if ownership is None or grant is None:
+            raise SpaceSkillGrantForbiddenError("owner or manager required")
+        latest_query = (
+            session.query(SkillVersion)
+            .filter(
+                SkillVersion.skill_id == skill_id,
+                SkillVersion.env == env,
+                SkillVersion.status == "PUBLISHED",
+            )
+            .order_by(SkillVersion.version_ordinal.desc())
+        )
+        latest = (latest_query.with_for_update() if lock else latest_query).first()
+        if latest is None:
+            raise DraftNotFoundError("latest Published Version not found")
+        return OfflineSkillIdentity(
+            skill_id=int(skill.id),
+            skill_uuid=str(skill.skill_uuid),
+            name=str(skill.name),
+            sc_team_id=ownership[1].sc_team_id,
+            latest_version_id=int(latest.id),
+            latest_version_ordinal=int(latest.version_ordinal),
+            sc_version_number=str(latest.sc_version_number),
+            offline_at=skill.offline_at,
+            draft_target_version=skill.draft_target_version,
+            draft_status=skill.draft_status,
+            draft_locator=skill.zip_url,
+        )
+
+    def _db_blockers(self, session, *, identity: OfflineSkillIdentity, env: str):
+        blockers: list[OfflineImpactItem] = []
+        if identity.draft_status is not None:
+            blockers.append(
+                OfflineImpactItem(
+                    kind=OfflineBlockerKind.DRAFT,
+                    resource_id=str(identity.skill_id),
+                    display_name=f"Draft V{identity.draft_target_version}",
+                )
+            )
+        attempts = (
+            session.query(SkillPublicationAttempt)
+            .filter(
+                SkillPublicationAttempt.skill_id == identity.skill_id,
+                SkillPublicationAttempt.env == env,
+                SkillPublicationAttempt.status.in_(_ACTIVE_ATTEMPTS),
+            )
+            .order_by(SkillPublicationAttempt.id.asc())
+            .all()
+        )
+        blockers.extend(
+            OfflineImpactItem(
+                kind=OfflineBlockerKind.PUBLICATION,
+                resource_id=str(attempt.id),
+                display_name=f"Publication V{attempt.target_version_ordinal}",
+            )
+            for attempt in attempts
+        )
+        identity_predicates = [SkillSetSkill.skill_id == identity.skill_id]
+        if identity.skill_uuid:
+            identity_predicates.append(SkillSetSkill.skill_uuid == identity.skill_uuid)
+        memberships = (
+            session.query(SkillSetSkill, SkillSet)
+            .join(SkillSet, SkillSet.id == SkillSetSkill.skill_set_id)
+            .filter(
+                SkillSetSkill.env == env,
+                SkillSet.env == env,
+                or_(*identity_predicates),
+            )
+            .order_by(SkillSetSkill.id.asc())
+            .all()
+        )
+        blockers.extend(
+            OfflineImpactItem(
+                kind=OfflineBlockerKind.MEMBERSHIP,
+                resource_id=str(membership.id),
+                display_name=str(skill_set.name),
+            )
+            for membership, skill_set in memberships
+        )
+        installations = (
+            session.query(BotSkillInstallation)
+            .filter(
+                BotSkillInstallation.skill_id == identity.skill_id,
+                BotSkillInstallation.env == env,
+            )
+            .order_by(BotSkillInstallation.id.asc())
+            .all()
+        )
+        blockers.extend(
+            OfflineImpactItem(
+                kind=OfflineBlockerKind.INSTALLATION,
+                resource_id=str(installation.id),
+                display_name=str(installation.bot_id),
+            )
+            for installation in installations
+        )
+        return blockers
+
+    def _artifact_blockers(self, *, identity: OfflineSkillIdentity, env: str):
+        lineage = self._lineage.scan(skill_uuid=identity.skill_uuid, env=env)
+        blockers = [
+            OfflineImpactItem(
+                kind=OfflineBlockerKind.SERVICE_ARTIFACT,
+                resource_id=str(reference.publish_id),
+                display_name=(
+                    f"{reference.source_bot_name} V{reference.service_version} "
+                    f"(Skill {reference.sc_version_number})"
+                ),
+            )
+            for reference in lineage.references
+        ]
+        blockers.extend(
+            OfflineImpactItem(
+                kind=OfflineBlockerKind.UNKNOWN_ARTIFACT,
+                resource_id=item.resource_id,
+                display_name=item.display_name,
+            )
+            for item in lineage.unknown
+        )
+        return blockers
+
+    @staticmethod
+    def _ordered(blockers):
+        return tuple(
+            sorted(
+                blockers,
+                key=lambda item: (
+                    _BLOCKER_ORDER[item.kind],
+                    item.resource_id,
+                    item.display_name,
+                ),
+            )
+        )
+
+    @staticmethod
+    def _impact(blockers, *, page_size: int) -> OfflineImpact:
+        counts = {kind.value: 0 for kind in OfflineBlockerKind}
+        for item in blockers:
+            counts[item.kind.value] += 1
+        counts = {kind: count for kind, count in counts.items() if count}
+        return OfflineImpact(
+            blocked=bool(blockers),
+            total=len(blockers),
+            counts=counts,
+            items=tuple(blockers[:page_size]),
+        )
+
+
+__all__ = ["SpaceSkillOfflineRepository"]

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_offline.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_offline.py
@@ -15,11 +15,13 @@ from agentclaw.community.core.models.skill import (
     SkillSetSkill,
 )
 from agentclaw.community.core.models.space_skill import (
-    ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES,
     SkillGrant,
     SkillPublicationAttempt,
     SkillSpaceBinding,
     SkillVersion,
+)
+from agentclaw.community.core.skill_center.publication_contract import (
+    ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES,
 )
 from agentclaw.community.core.repository.space_skill_offline_types import (
     OfflineCommit,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_offline.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_offline.py
@@ -2,17 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime, timezone
 
 from injector import inject
 from sqlalchemy import or_
 
-from agentclaw.community.core.service_bot.service_artifact_lineage_reader_protocol import (
-    ServiceArtifactLineageReaderProtocol,
-)
 from agentclaw.community.core.skill_center.space_skill_offline_service_protocol import (
     OfflineBlockerKind,
-    OfflineImpact,
     OfflineImpactItem,
 )
 from agentclaw.community.core.models.skill import (
@@ -38,7 +35,6 @@ from agentclaw.community.core.repository.protocols.space_skill_offline import (
 from agentclaw.community.core.skill_center.errors import (
     DraftNotFoundError,
     DraftRevisionConflictError,
-    SkillOfflineBlockedError,
     SpaceSkillGrantForbiddenError,
 )
 from agentclaw.community.core.spaces.repository.models import SpaceModel
@@ -60,10 +56,8 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
     def __init__(
         self,
         db: DatabasePlugin,
-        lineage: ServiceArtifactLineageReaderProtocol,
     ) -> None:
         self._db = db
-        self._lineage = lineage
 
     def inspect(
         self, *, space_id: int, skill_id: int, actor_id: str, env: str
@@ -78,7 +72,6 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
                 lock=False,
             )
             blockers = self._db_blockers(session, identity=identity, env=env)
-        blockers.extend(self._artifact_blockers(identity=identity, env=env))
         return OfflineInspection(identity=identity, blockers=self._ordered(blockers))
 
     def commit(
@@ -92,6 +85,7 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
         new_locator: str,
         new_description: str | None,
         env: str,
+        guard: Callable[[OfflineInspection], None],
     ) -> OfflineCommit:
         with self._db.transactional_orm_session() as session:
             identity = self._identity(
@@ -116,11 +110,14 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
                     locator=str(skill.zip_url),
                 )
 
-            blockers = self._db_blockers(session, identity=identity, env=env)
-            blockers.extend(self._artifact_blockers(identity=identity, env=env))
-            blockers = list(self._ordered(blockers))
-            if blockers:
-                raise SkillOfflineBlockedError(self._impact(blockers, page_size=20))
+            guard(
+                OfflineInspection(
+                    identity=identity,
+                    blockers=self._ordered(
+                        self._db_blockers(session, identity=identity, env=env)
+                    ),
+                )
+            )
             if identity.latest_version_id != expected_version_id:
                 raise DraftRevisionConflictError("latest Published Version changed")
             if target_version != identity.latest_version_ordinal + 1:
@@ -280,29 +277,6 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
         )
         return blockers
 
-    def _artifact_blockers(self, *, identity: OfflineSkillIdentity, env: str):
-        lineage = self._lineage.scan(skill_uuid=identity.skill_uuid, env=env)
-        blockers = [
-            OfflineImpactItem(
-                kind=OfflineBlockerKind.SERVICE_ARTIFACT,
-                resource_id=str(reference.publish_id),
-                display_name=(
-                    f"{reference.source_bot_name} V{reference.service_version} "
-                    f"(Skill {reference.sc_version_number})"
-                ),
-            )
-            for reference in lineage.references
-        ]
-        blockers.extend(
-            OfflineImpactItem(
-                kind=OfflineBlockerKind.UNKNOWN_ARTIFACT,
-                resource_id=item.resource_id,
-                display_name=item.display_name,
-            )
-            for item in lineage.unknown
-        )
-        return blockers
-
     @staticmethod
     def _ordered(blockers):
         return tuple(
@@ -315,19 +289,5 @@ class SpaceSkillOfflineRepository(SpaceSkillOfflineRepositoryProtocol):
                 ),
             )
         )
-
-    @staticmethod
-    def _impact(blockers, *, page_size: int) -> OfflineImpact:
-        counts = {kind.value: 0 for kind in OfflineBlockerKind}
-        for item in blockers:
-            counts[item.kind.value] += 1
-        counts = {kind: count for kind, count in counts.items() if count}
-        return OfflineImpact(
-            blocked=bool(blockers),
-            total=len(blockers),
-            counts=counts,
-            items=tuple(blockers[:page_size]),
-        )
-
 
 __all__ = ["SpaceSkillOfflineRepository"]

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_publication.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_publication.py
@@ -82,6 +82,59 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
                     session,
                     request_id=request_id,
                     env=env,
+                    lock=False,
+                )
+                if replay is not None:
+                    replay = self._attempt_by_request(
+                        session,
+                        request_id=request_id,
+                        env=env,
+                        lock=True,
+                    )
+                    if replay is None:
+                        raise RuntimeError("Publication Attempt disappeared")
+                    self._require_attempt_scope(
+                        session,
+                        attempt=replay,
+                        space_id=space_id,
+                        skill_id=skill_id,
+                        actor_id=actor_id,
+                        env=env,
+                    )
+                    return PublicationAttemptCreation(
+                        attempt=self._record(replay), created=False
+                    )
+                skill = lock_skill_row(session, env=env, skill_id=skill_id)
+                if skill is None:
+                    raise DraftNotFoundError("draft not found")
+                ownership = (
+                    session.query(SkillSpaceBinding, SpaceModel)
+                    .join(
+                        SpaceModel,
+                        (SpaceModel.id == SkillSpaceBinding.space_id)
+                        & (SpaceModel.env == SkillSpaceBinding.env),
+                    )
+                    .filter(
+                        SkillSpaceBinding.skill_id == skill_id,
+                        SkillSpaceBinding.env == env,
+                        SkillSpaceBinding.space_id == space_id,
+                        SpaceModel.deleted_at.is_(None),
+                    )
+                    .one_or_none()
+                )
+                if ownership is None:
+                    raise DraftNotFoundError("draft not found")
+                _binding, space = ownership
+                self._require_publisher(
+                    session,
+                    skill_id=skill_id,
+                    actor_id=actor_id,
+                    env=env,
+                )
+                replay = self._attempt_by_request(
+                    session,
+                    request_id=request_id,
+                    env=env,
                     lock=True,
                 )
                 if replay is not None:
@@ -96,36 +149,6 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
                     return PublicationAttemptCreation(
                         attempt=self._record(replay), created=False
                     )
-                row = (
-                    session.query(Skill, SpaceModel)
-                    .join(
-                        SkillSpaceBinding,
-                        (SkillSpaceBinding.skill_id == Skill.id)
-                        & (SkillSpaceBinding.env == Skill.env),
-                    )
-                    .join(
-                        SpaceModel,
-                        (SpaceModel.id == SkillSpaceBinding.space_id)
-                        & (SpaceModel.env == SkillSpaceBinding.env),
-                    )
-                    .filter(
-                        Skill.id == skill_id,
-                        Skill.env == env,
-                        SkillSpaceBinding.space_id == space_id,
-                        SpaceModel.deleted_at.is_(None),
-                    )
-                    .with_for_update()
-                    .one_or_none()
-                )
-                if row is None:
-                    raise DraftNotFoundError("draft not found")
-                skill, space = row
-                self._require_publisher(
-                    session,
-                    skill_id=skill_id,
-                    actor_id=actor_id,
-                    env=env,
-                )
                 if skill.draft_status != "EDITING" or not skill.zip_url:
                     if skill.draft_status == "FROZEN":
                         active = (
@@ -494,7 +517,10 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
     ) -> PublicationAttemptRecord:
         with self._db.transactional_orm_session() as session:
             attempt, skill, version = self._lock_attempt_aggregate(
-                session, attempt_id=attempt_id, env=env
+                session,
+                attempt_id=attempt_id,
+                env=env,
+                allow_version_appearance=True,
             )
             if attempt.status == "SUCCEEDED":
                 return self._record(attempt)
@@ -782,7 +808,12 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
         return int(row[0]), int(row[1]) if row[1] is not None else None
 
     def _lock_attempt_aggregate(
-        self, session, *, attempt_id: int, env: str
+        self,
+        session,
+        *,
+        attempt_id: int,
+        env: str,
+        allow_version_appearance: bool = False,
     ) -> tuple[SkillPublicationAttempt, Skill, SkillVersion | None]:
         """Lock one Publication aggregate as Skill [-> Version] -> Attempt."""
         skill_id, located_version_id = self._attempt_version_identity(
@@ -811,6 +842,7 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
             attempt,
             skill_id=skill_id,
             skill_version_id=located_version_id,
+            allow_version_appearance=allow_version_appearance,
         )
         return attempt, skill, version
 
@@ -820,13 +852,21 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
         *,
         skill_id: int,
         skill_version_id: int | None,
+        allow_version_appearance: bool = False,
     ) -> None:
         current_version_id = (
             int(attempt.skill_version_id)
             if attempt.skill_version_id is not None
             else None
         )
-        if int(attempt.skill_id) != skill_id or current_version_id != skill_version_id:
+        version_matches = current_version_id == skill_version_id
+        if (
+            allow_version_appearance
+            and skill_version_id is None
+            and current_version_id is not None
+        ):
+            version_matches = True
+        if int(attempt.skill_id) != skill_id or not version_matches:
             raise RuntimeError("Attempt identity changed while acquiring locks")
 
     @staticmethod

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_publication.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_publication.py
@@ -37,6 +37,7 @@ from agentclaw.community.core.skill_center.errors import (
     SpaceSkillIdempotencyConflictError,
 )
 from agentclaw.community.core.skill_center.publication_contract import (
+    ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES,
     PublicationAttemptCreation,
     PublicationAttemptRecord,
     PublicationAttemptStatus,
@@ -52,15 +53,6 @@ from agentclaw.community.core.spaces.repository.models import SpaceModel
 from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.plugin_api.models import BotModel
 from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
-
-
-_ACTIVE_STATUSES = (
-    "PREPARING",
-    "SC_SUBMITTING",
-    "WAITING_SC",
-    "MATERIALIZING",
-    "RESULT_UNKNOWN",
-)
 
 
 class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
@@ -137,7 +129,9 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
                             .filter(
                                 SkillPublicationAttempt.skill_id == skill_id,
                                 SkillPublicationAttempt.env == env,
-                                SkillPublicationAttempt.status.in_(_ACTIVE_STATUSES),
+                                SkillPublicationAttempt.status.in_(
+                                    ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES
+                                ),
                             )
                             .order_by(SkillPublicationAttempt.id.desc())
                             .first()
@@ -156,7 +150,9 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
                     .filter(
                         SkillPublicationAttempt.skill_id == skill_id,
                         SkillPublicationAttempt.env == env,
-                        SkillPublicationAttempt.status.in_(_ACTIVE_STATUSES),
+                        SkillPublicationAttempt.status.in_(
+                            ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES
+                        ),
                     )
                     .with_for_update()
                     .one_or_none()
@@ -239,7 +235,9 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
                         .filter(
                             SkillPublicationAttempt.skill_id == skill_id,
                             SkillPublicationAttempt.env == env,
-                            SkillPublicationAttempt.status.in_(_ACTIVE_STATUSES),
+                            SkillPublicationAttempt.status.in_(
+                                ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES
+                            ),
                         )
                         .first()
                     )
@@ -743,7 +741,10 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
         if row is None:
             raise PublicationAttemptNotFoundError("publication attempt not found")
         attempt, skill, binding, space = row
-        if attempt.status in _ACTIVE_STATUSES and not attempt.frozen_draft_locator:
+        if (
+            attempt.status in ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES
+            and not attempt.frozen_draft_locator
+        ):
             raise RuntimeError(
                 "active Publication Attempt has no frozen Draft Revision"
             )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_publication.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_publication.py
@@ -135,7 +135,7 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
                     session,
                     request_id=request_id,
                     env=env,
-                    lock=True,
+                    lock=False,
                 )
                 if replay is not None:
                     self._require_attempt_scope(

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_publication.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_publication.py
@@ -25,6 +25,10 @@ from agentclaw.community.core.models.space_skill import (
 from agentclaw.community.core.repository.protocols.space_skill_publication import (
     SpaceSkillPublicationRepositoryProtocol,
 )
+from agentclaw.community.core.repository.implementations.skill_center.skill_version_lock import (
+    lock_skill_row,
+    lock_skill_then_exact_version,
+)
 from agentclaw.community.core.skill_center.errors import (
     DraftEditLeaseConflictError,
     DraftNotFoundError,
@@ -403,7 +407,7 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
 
     def get_work(self, *, attempt_id: int, env: str) -> PublicationWork:
         with self._db.orm_session() as session:
-            return self._work(session, attempt_id=attempt_id, env=env, lock=False)
+            return self._work(session, attempt_id=attempt_id, env=env)
 
     def mark_prepared(
         self, *, attempt_id: int, package_url: str, env: str
@@ -411,20 +415,24 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
         if not package_url:
             raise ValueError("package_url is required")
         with self._db.transactional_orm_session() as session:
-            work = self._work(session, attempt_id=attempt_id, env=env, lock=True)
-            if work.attempt.status is not PublicationAttemptStatus.PREPARING:
+            attempt, skill, _version = self._lock_attempt_aggregate(
+                session, attempt_id=attempt_id, env=env
+            )
+            work = self._work(session, attempt_id=attempt_id, env=env)
+            if attempt.status != "PREPARING":
                 return work
-            skill = session.query(Skill).filter(Skill.id == work.attempt.skill_id).one()
             skill.package_url = package_url
             session.flush()
-            return self._work(session, attempt_id=attempt_id, env=env, lock=False)
+            return self._work(session, attempt_id=attempt_id, env=env)
 
     def claim_sc_submission(
         self, *, attempt_id: int, started_at: datetime, env: str
     ) -> PublicationSubmissionClaim:
         with self._db.transactional_orm_session() as session:
-            work = self._work(session, attempt_id=attempt_id, env=env, lock=True)
-            attempt = self._attempt(session, attempt_id=attempt_id, env=env)
+            attempt, _skill, _version = self._lock_attempt_aggregate(
+                session, attempt_id=attempt_id, env=env
+            )
+            work = self._work(session, attempt_id=attempt_id, env=env)
             may_submit = False
             if attempt.status == "PREPARING" and attempt.sc_post_started_at is None:
                 if not work.package_url:
@@ -435,7 +443,7 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
                 attempt.recovery_kind = "SC_STATUS_CHECK"
                 may_submit = True
                 session.flush()
-                work = self._work(session, attempt_id=attempt_id, env=env, lock=False)
+                work = self._work(session, attempt_id=attempt_id, env=env)
             return PublicationSubmissionClaim(work=work, may_submit=may_submit)
 
     def mark_waiting_sc(
@@ -485,17 +493,13 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
         env: str,
     ) -> PublicationAttemptRecord:
         with self._db.transactional_orm_session() as session:
-            attempt = self._attempt(session, attempt_id=attempt_id, env=env, lock=True)
+            attempt, skill, version = self._lock_attempt_aggregate(
+                session, attempt_id=attempt_id, env=env
+            )
             if attempt.status == "SUCCEEDED":
                 return self._record(attempt)
-            if attempt.skill_version_id is not None:
+            if version is not None or attempt.skill_version_id is not None:
                 raise RuntimeError("a materializing Version cannot become FAILED")
-            skill = (
-                session.query(Skill)
-                .filter(Skill.id == attempt.skill_id, Skill.env == env)
-                .with_for_update()
-                .one()
-            )
             if skill.draft_status == "FROZEN":
                 skill.draft_status = "EDITING"
             skill.package_url = None
@@ -521,12 +525,15 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
         if sc_skill_id < 1 or sc_version_id < 1:
             raise ValueError("exact SC ids must be positive integers")
         with self._db.transactional_orm_session() as session:
-            work = self._work(session, attempt_id=attempt_id, env=env, lock=True)
-            attempt = self._attempt(session, attempt_id=attempt_id, env=env)
+            attempt, skill, locked_version = self._lock_attempt_aggregate(
+                session, attempt_id=attempt_id, env=env
+            )
+            work = self._work(session, attempt_id=attempt_id, env=env)
             if attempt.status == "MATERIALIZING":
-                version = self._version_for_attempt(session, attempt, env=env)
+                if locked_version is None:
+                    raise RuntimeError("MATERIALIZING Attempt has no locked Version")
                 self._require_exact_version(
-                    version,
+                    locked_version,
                     sc_skill_id=sc_skill_id,
                     sc_version_id=sc_version_id,
                     sc_sha256=sc_sha256,
@@ -538,12 +545,6 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
                 "RESULT_UNKNOWN",
             ):
                 raise RuntimeError("Attempt cannot begin materialization")
-            skill = (
-                session.query(Skill)
-                .filter(Skill.id == attempt.skill_id, Skill.env == env)
-                .with_for_update()
-                .one()
-            )
             expected_locator = f"center://{skill.skill_uuid}"
             if skill.git_path not in (None, "", expected_locator):
                 raise RuntimeError("Space Skill has a conflicting Center locator")
@@ -574,7 +575,7 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
             attempt.error_code = None
             attempt.error_message = None
             session.flush()
-            return self._work(session, attempt_id=attempt_id, env=env, lock=False)
+            return self._work(session, attempt_id=attempt_id, env=env)
 
     def complete_success(
         self,
@@ -585,34 +586,27 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
         env: str,
     ) -> PublicationAttemptRecord:
         with self._db.transactional_orm_session() as session:
-            attempt = self._attempt(session, attempt_id=attempt_id, env=env, lock=True)
+            attempt, skill, version = self._lock_attempt_aggregate(
+                session, attempt_id=attempt_id, env=env
+            )
+            located_version_id = (
+                int(attempt.skill_version_id)
+                if attempt.skill_version_id is not None
+                else None
+            )
+            if located_version_id is None or version is None:
+                raise RuntimeError("Attempt is not materializing a Version")
             if attempt.status == "SUCCEEDED":
-                if int(attempt.skill_version_id or 0) != skill_version_id:
+                if located_version_id != skill_version_id:
                     raise RuntimeError("SUCCEEDED Attempt points at another Version")
                 return self._record(attempt)
             if (
                 attempt.status != "MATERIALIZING"
-                or int(attempt.skill_version_id or 0) != skill_version_id
+                or located_version_id != skill_version_id
             ):
                 raise RuntimeError("Attempt is not materializing this Version")
-            version = (
-                session.query(SkillVersion)
-                .filter(
-                    SkillVersion.id == skill_version_id,
-                    SkillVersion.skill_id == attempt.skill_id,
-                    SkillVersion.env == env,
-                )
-                .with_for_update()
-                .one()
-            )
             if version.status != "PUBLISHED":
                 raise RuntimeError("Version is not PUBLISHED")
-            skill = (
-                session.query(Skill)
-                .filter(Skill.id == attempt.skill_id, Skill.env == env)
-                .with_for_update()
-                .one()
-            )
             if skill.draft_status == "FROZEN":
                 if int(skill.draft_target_version or 0) != int(
                     attempt.target_version_ordinal
@@ -710,9 +704,7 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
                 attempt=self._record(attempt), task_required=True
             )
 
-    def _work(
-        self, session, *, attempt_id: int, env: str, lock: bool
-    ) -> PublicationWork:
+    def _work(self, session, *, attempt_id: int, env: str) -> PublicationWork:
         query = (
             session.query(SkillPublicationAttempt, Skill, SkillSpaceBinding, SpaceModel)
             .join(
@@ -735,8 +727,6 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
                 SkillPublicationAttempt.env == env,
             )
         )
-        if lock:
-            query = query.with_for_update()
         row = query.one_or_none()
         if row is None:
             raise PublicationAttemptNotFoundError("publication attempt not found")
@@ -773,18 +763,71 @@ class SpaceSkillPublicationRepository(SpaceSkillPublicationRepositoryProtocol):
         return attempt
 
     @staticmethod
-    def _version_for_attempt(session, attempt, *, env: str):
-        if attempt.skill_version_id is None:
-            raise RuntimeError("MATERIALIZING Attempt has no Version")
-        return (
-            session.query(SkillVersion)
-            .filter(
-                SkillVersion.id == attempt.skill_version_id,
-                SkillVersion.skill_id == attempt.skill_id,
-                SkillVersion.env == env,
+    def _attempt_version_identity(
+        session, *, attempt_id: int, env: str
+    ) -> tuple[int, int | None]:
+        row = (
+            session.query(
+                SkillPublicationAttempt.skill_id,
+                SkillPublicationAttempt.skill_version_id,
             )
-            .one()
+            .filter(
+                SkillPublicationAttempt.id == attempt_id,
+                SkillPublicationAttempt.env == env,
+            )
+            .one_or_none()
         )
+        if row is None:
+            raise PublicationAttemptNotFoundError("publication attempt not found")
+        return int(row[0]), int(row[1]) if row[1] is not None else None
+
+    def _lock_attempt_aggregate(
+        self, session, *, attempt_id: int, env: str
+    ) -> tuple[SkillPublicationAttempt, Skill, SkillVersion | None]:
+        """Lock one Publication aggregate as Skill [-> Version] -> Attempt."""
+        skill_id, located_version_id = self._attempt_version_identity(
+            session,
+            attempt_id=attempt_id,
+            env=env,
+        )
+        version = None
+        if located_version_id is None:
+            skill = lock_skill_row(session, env=env, skill_id=skill_id)
+        else:
+            locked = lock_skill_then_exact_version(
+                session,
+                env=env,
+                skill_id=skill_id,
+                skill_version_id=located_version_id,
+            )
+            if locked is None:
+                skill = lock_skill_row(session, env=env, skill_id=skill_id)
+            else:
+                skill, version = locked
+        if skill is None:
+            raise RuntimeError("Publication Skill not found")
+        attempt = self._attempt(session, attempt_id=attempt_id, env=env, lock=True)
+        self._require_attempt_version_identity(
+            attempt,
+            skill_id=skill_id,
+            skill_version_id=located_version_id,
+        )
+        return attempt, skill, version
+
+    @staticmethod
+    def _require_attempt_version_identity(
+        attempt: SkillPublicationAttempt,
+        *,
+        skill_id: int,
+        skill_version_id: int | None,
+    ) -> None:
+        current_version_id = (
+            int(attempt.skill_version_id)
+            if attempt.skill_version_id is not None
+            else None
+        )
+        if int(attempt.skill_id) != skill_id or current_version_id != skill_version_id:
+            raise RuntimeError("Attempt identity changed while acquiring locks")
 
     @staticmethod
     def _require_exact_version(

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_read.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_read.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import aliased
 
 from agentclaw.community.core.models.skill import Skill
 from agentclaw.community.core.models.space_skill import (
+    ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES,
     SkillDraftEditLease,
     SkillGrant,
     SkillPublicationAttempt,
@@ -31,15 +32,6 @@ from agentclaw.community.core.work_orders.models import (
 )
 from agentclaw.community.core.work_orders.repository.models import WorkOrderModel
 from agentclaw.community.plugin_api.database import DatabasePlugin
-
-
-_ACTIVE_ATTEMPT_STATES = (
-    "PREPARING",
-    "SC_SUBMITTING",
-    "WAITING_SC",
-    "MATERIALIZING",
-    "RESULT_UNKNOWN",
-)
 
 
 class SpaceSkillReadRepository(SpaceSkillReadRepositoryProtocol):
@@ -202,7 +194,9 @@ class SpaceSkillReadRepository(SpaceSkillReadRepositoryProtocol):
                 and_(
                     SkillPublicationAttempt.skill_id == Skill.id,
                     SkillPublicationAttempt.env == env,
-                    SkillPublicationAttempt.status.in_(_ACTIVE_ATTEMPT_STATES),
+                    SkillPublicationAttempt.status.in_(
+                        ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES
+                    ),
                 ),
             )
             .outerjoin(

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_read.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_read.py
@@ -8,12 +8,14 @@ from sqlalchemy.orm import aliased
 
 from agentclaw.community.core.models.skill import Skill
 from agentclaw.community.core.models.space_skill import (
-    ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES,
     SkillDraftEditLease,
     SkillGrant,
     SkillPublicationAttempt,
     SkillSpaceBinding,
     SkillVersion,
+)
+from agentclaw.community.core.skill_center.publication_contract import (
+    ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES,
 )
 from agentclaw.community.core.repository.protocols.skill_center import (
     SpaceSkillReadRepository as SpaceSkillReadRepositoryProtocol,

--- a/src/backend/src/agentclaw/community/core/repository/protocols/publishing.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/publishing.py
@@ -12,7 +12,11 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Protocol, Sequence, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from agentclaw.community.core.service_bot.repository.models import BotPublishRecord, PublishOperationRecord
+    from agentclaw.community.core.service_bot.repository.models import (
+        BotPublishLineagePage,
+        BotPublishRecord,
+        PublishOperationRecord,
+    )
 
 
 class BotPublishRepositoryProtocol(Protocol):
@@ -193,6 +197,22 @@ class BotPublishRepositoryProtocol(Protocol):
         ...
 
     @abstractmethod
+    def list_lineage_candidates_page(
+        self,
+        *,
+        env: str,
+        after_id: int | None,
+        limit: int,
+    ) -> BotPublishLineagePage:
+        """Page live Service Bot records by immutable ascending publish id.
+
+        The implementation transparently re-inlines offloaded artifacts.  A
+        non-final page must carry ``next_cursor``; the final page must set
+        ``complete=True`` and omit it.
+        """
+        ...
+
+    @abstractmethod
     def get_latest_by_source_bot_id_and_owner_and_status(
         self,
         source_bot_id: str,
@@ -316,6 +336,21 @@ class BotPublishRepositoryProtocol(Protocol):
         ext: Dict[str, Any],
     ) -> Optional[BotPublishRecord]:
         """Atomically replace status and ext when both snapshots still match."""
+        ...
+
+    @abstractmethod
+    def compare_and_set_built_with_ext(
+        self,
+        *,
+        publish_id: int,
+        source_status: str,
+        target_status: str,
+        expected_ext: Optional[Dict[str, Any]],
+        ext: Dict[str, Any],
+        center_skill_uuids: Sequence[str],
+        env: str,
+    ) -> Optional[BotPublishRecord]:
+        """Commit a replayable Artifact while exact Center Skills stay online."""
         ...
 
     @abstractmethod

--- a/src/backend/src/agentclaw/community/core/repository/protocols/space_skill_offline.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/space_skill_offline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -31,6 +32,7 @@ class SpaceSkillOfflineRepositoryProtocol(Protocol):
         new_locator: str,
         new_description: str | None,
         env: str,
+        guard: Callable[[OfflineInspection], None],
     ) -> OfflineCommit: ...
 
 

--- a/src/backend/src/agentclaw/community/core/repository/protocols/space_skill_offline.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/space_skill_offline.py
@@ -1,0 +1,39 @@
+"""Persistence contract for the recoverable Offline unit of work."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from agentclaw.community.core.repository.space_skill_offline_types import (
+        OfflineCommit,
+        OfflineInspection,
+    )
+
+
+@runtime_checkable
+class SpaceSkillOfflineRepositoryProtocol(Protocol):
+    @abstractmethod
+    def inspect(
+        self, *, space_id: int, skill_id: int, actor_id: str, env: str
+    ) -> OfflineInspection: ...
+
+    @abstractmethod
+    def commit(
+        self,
+        *,
+        space_id: int,
+        skill_id: int,
+        actor_id: str,
+        expected_version_id: int,
+        target_version: int,
+        new_locator: str,
+        new_description: str | None,
+        env: str,
+    ) -> OfflineCommit: ...
+
+
+__all__ = [
+    "SpaceSkillOfflineRepositoryProtocol",
+]

--- a/src/backend/src/agentclaw/community/core/repository/space_skill_offline_types.py
+++ b/src/backend/src/agentclaw/community/core/repository/space_skill_offline_types.py
@@ -5,11 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
-from agentclaw.community.core.skill_center.space_skill_offline_service_protocol import (
-    OfflineImpactItem,
-)
-
-
 @dataclass(frozen=True, slots=True)
 class OfflineSkillIdentity:
     skill_id: int
@@ -26,9 +21,34 @@ class OfflineSkillIdentity:
 
 
 @dataclass(frozen=True, slots=True)
+class OfflinePublicationAttemptFact:
+    id: int
+    target_version_ordinal: int
+    status: str
+
+
+@dataclass(frozen=True, slots=True)
+class OfflineMembershipFact:
+    id: int
+    skill_set_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class OfflineInstallationFact:
+    id: int
+    bot_id: str
+
+
+@dataclass(frozen=True, slots=True)
 class OfflineInspection:
+    """Raw persistence facts observed in one repository session."""
+
     identity: OfflineSkillIdentity
-    blockers: tuple[OfflineImpactItem, ...]
+    space_bound: bool
+    actor_roles: tuple[str, ...]
+    publication_attempts: tuple[OfflinePublicationAttemptFact, ...]
+    memberships: tuple[OfflineMembershipFact, ...]
+    installations: tuple[OfflineInstallationFact, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,4 +59,11 @@ class OfflineCommit:
     locator: str
 
 
-__all__ = ["OfflineCommit", "OfflineInspection", "OfflineSkillIdentity"]
+__all__ = [
+    "OfflineCommit",
+    "OfflineInspection",
+    "OfflineInstallationFact",
+    "OfflineMembershipFact",
+    "OfflinePublicationAttemptFact",
+    "OfflineSkillIdentity",
+]

--- a/src/backend/src/agentclaw/community/core/repository/space_skill_offline_types.py
+++ b/src/backend/src/agentclaw/community/core/repository/space_skill_offline_types.py
@@ -1,0 +1,42 @@
+"""Value records exchanged across the Space Skill Offline repository seam."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from agentclaw.community.core.skill_center.space_skill_offline_service_protocol import (
+    OfflineImpactItem,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OfflineSkillIdentity:
+    skill_id: int
+    skill_uuid: str
+    name: str
+    sc_team_id: int | None
+    latest_version_id: int
+    latest_version_ordinal: int
+    sc_version_number: str
+    offline_at: datetime | None
+    draft_target_version: int | None
+    draft_status: str | None
+    draft_locator: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class OfflineInspection:
+    identity: OfflineSkillIdentity
+    blockers: tuple[OfflineImpactItem, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class OfflineCommit:
+    changed: bool
+    target_version: int
+    status: str
+    locator: str
+
+
+__all__ = ["OfflineCommit", "OfflineInspection", "OfflineSkillIdentity"]

--- a/src/backend/src/agentclaw/community/core/service_bot/README.md
+++ b/src/backend/src/agentclaw/community/core/service_bot/README.md
@@ -16,6 +16,7 @@ provides:
   - "BaasService"
   - "ServiceSkillsManifestBuilder"
   - "ResolvedSharedCorpusDelivery"
+  - "ServiceArtifactLineageReader"
   - "ServiceBot SQLAlchemy models"
 consumes:
   - "BotManagement"

--- a/src/backend/src/agentclaw/community/core/service_bot/repository/models.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/repository/models.py
@@ -7,6 +7,7 @@ Contains:
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
 from typing import Any, Dict, Optional
@@ -116,6 +117,15 @@ class BotPublishRecord(BaseModel):
             "gmt_create": self.gmt_create.isoformat() if self.gmt_create else None,
             "gmt_modified": self.gmt_modified.isoformat() if self.gmt_modified else None,
         }
+
+
+@dataclass(frozen=True, slots=True)
+class BotPublishLineagePage:
+    """One immutable-id page for complete Artifact lineage scans."""
+
+    records: tuple[BotPublishRecord, ...]
+    next_cursor: int | None
+    complete: bool
 
 
 class BotPublishCreate(BaseModel):

--- a/src/backend/src/agentclaw/community/core/service_bot/service_artifact_lineage_reader_protocol.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/service_artifact_lineage_reader_protocol.py
@@ -1,0 +1,42 @@
+"""Service API contract for exact Skill lineage in replayable artifacts."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceArtifactReference:
+    publish_id: int
+    source_bot_id: str
+    source_bot_name: str
+    service_version: int | None
+    sc_version_number: str
+
+
+@dataclass(frozen=True, slots=True)
+class UnknownServiceArtifact:
+    resource_id: str
+    display_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceArtifactLineage:
+    references: tuple[ServiceArtifactReference, ...]
+    unknown: tuple[UnknownServiceArtifact, ...]
+
+
+@runtime_checkable
+class ServiceArtifactLineageReaderProtocol(Protocol):
+    @abstractmethod
+    def scan(self, *, skill_uuid: str, env: str) -> ServiceArtifactLineage: ...
+
+
+__all__ = [
+    "ServiceArtifactLineage",
+    "ServiceArtifactLineageReaderProtocol",
+    "ServiceArtifactReference",
+    "UnknownServiceArtifact",
+]

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -363,6 +363,31 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         logger.info(f"[update_publish_status_with_ext] id={publish_id}, target_status={target_status}, source_status={source_status}")
         return record
 
+    def commit_built_artifact(
+        self,
+        *,
+        publish_id: int,
+        ext: Dict[str, Any],
+        expected_ext: Optional[Dict[str, Any]],
+        center_skill_uuids: tuple[str, ...],
+        env: str,
+    ) -> BotPublishRecord:
+        record = self._repo.compare_and_set_built_with_ext(
+            publish_id=publish_id,
+            source_status=PublishStatus.BUILDING.value,
+            target_status=PublishStatus.BUILT.value,
+            expected_ext=expected_ext,
+            ext=ext,
+            center_skill_uuids=center_skill_uuids,
+            env=env,
+        )
+        if record is None:
+            raise PublishNotFoundError(
+                "Publish record changed before Artifact commit: "
+                f"publish_id={publish_id}"
+            )
+        return record
+
     def update_publish_ext(
         self,
         publish_id: int,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/build_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/build_stage.py
@@ -30,6 +30,9 @@ from agentclaw.community.core.service_bot.services.publish_flow.ext_state import
 from agentclaw.community.core.service_bot.services.publish_flow.provider_behavior import (
     ProviderBehaviorRouter,
 )
+from agentclaw.community.core.service_bot.services.service_artifact_refs import (
+    exact_center_refs_from_artifact_ext,
+)
 from agentclaw.community.core.skill_center.bot_runtime_projector_protocol import (
     BotRuntimeProjectorProtocol,
 )
@@ -126,12 +129,22 @@ class BuildStageRunner:
             # content_hash/engine_ext).
             ext, expected_ext = self._ext_state.get_latest_ext_snapshot(publish_id)
             ext.update(artifact.ext)
-            self._ext_state.update_status(
+            center_skill_uuids = tuple(
+                sorted(
+                    {
+                        ref.skill_uuid
+                        for ref in exact_center_refs_from_artifact_ext(
+                            ext, validate_full_artifact=False
+                        )
+                    }
+                )
+            )
+            self._ext_state.commit_built_artifact(
                 publish_id=publish_id,
-                target_status=PublishStatus.BUILT,
-                source_status=PublishStatus.BUILDING,
                 ext=ext,
                 expected_ext=expected_ext,
+                center_skill_uuids=center_skill_uuids,
+                env=publish_record.env,
             )
 
             logger.info(

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/ext_state.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/ext_state.py
@@ -130,6 +130,24 @@ class PublishExtState:
             expected_ext=expected_ext,
         )
 
+    def commit_built_artifact(
+        self,
+        *,
+        publish_id: int,
+        ext: dict,
+        expected_ext: dict | None,
+        center_skill_uuids: tuple[str, ...],
+        env: str,
+    ) -> None:
+        """Atomically fence Offline and make the built Artifact replayable."""
+        self._publish_service.commit_built_artifact(
+            publish_id=publish_id,
+            ext=ext,
+            expected_ext=expected_ext,
+            center_skill_uuids=center_skill_uuids,
+            env=env,
+        )
+
     # ── per-stage engine_overrides / artifact stamping ───────────────────
     def stage_overrides(
         self, publish_record: BotPublishRecord, stage: PublishStage

--- a/src/backend/src/agentclaw/community/core/service_bot/services/service_artifact_lineage_reader.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/service_artifact_lineage_reader.py
@@ -20,7 +20,7 @@ from agentclaw.community.core.service_bot.services.service_artifact_refs import 
 
 
 _PAGE_SIZE = 100
-_AUDIT_ONLY_STATUSES = {PublishStatus.DRAFT.value, PublishStatus.FAILED.value}
+_AUDIT_ONLY_STATUSES = {PublishStatus.DRAFT.value}
 
 
 class ServiceArtifactLineageReader(ServiceArtifactLineageReaderProtocol):
@@ -81,7 +81,14 @@ class ServiceArtifactLineageReader(ServiceArtifactLineageReaderProtocol):
                     )
                     if not has_artifact:
                         # BUILDING has not crossed the replayable commit seam yet.
-                        if status is PublishStatus.BUILDING:
+                        # A FAILED build is equally non-replayable only when its
+                        # retry source is BUILDING; every later FAILED state can
+                        # retry from the already-frozen Artifact and must block.
+                        failed_before_artifact = (
+                            status is PublishStatus.FAILED
+                            and ext.get("source_status") == PublishStatus.BUILDING.value
+                        )
+                        if status is PublishStatus.BUILDING or failed_before_artifact:
                             continue
                         raise ValueError("replayable record has no artifact")
                     refs = exact_center_refs_from_artifact_ext(ext)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/service_artifact_lineage_reader.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/service_artifact_lineage_reader.py
@@ -1,0 +1,140 @@
+"""Complete, fail-closed lineage scan over replayable Service artifacts."""
+
+from __future__ import annotations
+
+from injector import inject
+
+from agentclaw.community.core.service_bot.service_artifact_lineage_reader_protocol import (
+    ServiceArtifactLineage,
+    ServiceArtifactLineageReaderProtocol,
+    ServiceArtifactReference,
+    UnknownServiceArtifact,
+)
+from agentclaw.community.core.repository.protocols.publishing import (
+    BotPublishRepositoryProtocol,
+)
+from agentclaw.community.core.service_bot.repository.models import PublishStatus
+from agentclaw.community.core.service_bot.services.service_artifact_refs import (
+    exact_center_refs_from_artifact_ext,
+)
+
+
+_PAGE_SIZE = 100
+_AUDIT_ONLY_STATUSES = {PublishStatus.DRAFT.value, PublishStatus.FAILED.value}
+
+
+class ServiceArtifactLineageReader(ServiceArtifactLineageReaderProtocol):
+    """Hide pagination, offload resolution and both Artifact wire shapes."""
+
+    @inject
+    def __init__(self, repository: BotPublishRepositoryProtocol) -> None:
+        self._repository = repository
+
+    def scan(self, *, skill_uuid: str, env: str) -> ServiceArtifactLineage:
+        references: list[ServiceArtifactReference] = []
+        unknown: list[UnknownServiceArtifact] = []
+        cursor: int | None = None
+        seen_cursors: set[int] = set()
+
+        while True:
+            try:
+                page = self._repository.list_lineage_candidates_page(
+                    env=env,
+                    after_id=cursor,
+                    limit=_PAGE_SIZE,
+                )
+            except Exception:
+                unknown.append(
+                    UnknownServiceArtifact(
+                        resource_id="artifact-scan",
+                        display_name="Service Artifact lineage is unreadable",
+                    )
+                )
+                break
+
+            ids = [record.id for record in page.records]
+            if (
+                any(value is None for value in ids)
+                or ids != sorted(ids)
+                or len(ids) != len(set(ids))
+                or (cursor is not None and ids and int(ids[0]) <= cursor)
+            ):
+                unknown.append(self._pagination_unknown())
+                break
+
+            for record in page.records:
+                if record.status in _AUDIT_ONLY_STATUSES:
+                    continue
+                try:
+                    status = PublishStatus(record.status)
+                    ext = record.ext
+                    if not isinstance(ext, dict):
+                        raise ValueError("artifact ext is missing")
+                    has_artifact = any(
+                        key in ext
+                        for key in (
+                            "migration_path",
+                            "build_target_path",
+                            "skills_manifest",
+                            "config_artifact",
+                        )
+                    )
+                    if not has_artifact:
+                        # BUILDING has not crossed the replayable commit seam yet.
+                        if status is PublishStatus.BUILDING:
+                            continue
+                        raise ValueError("replayable record has no artifact")
+                    refs = exact_center_refs_from_artifact_ext(ext)
+                except Exception:
+                    unknown.append(
+                        UnknownServiceArtifact(
+                            resource_id=str(record.id),
+                            display_name=f"{record.name} artifact is unreadable",
+                        )
+                    )
+                    continue
+
+                for ref in refs:
+                    if ref.skill_uuid != skill_uuid:
+                        continue
+                    references.append(
+                        ServiceArtifactReference(
+                            publish_id=int(record.id),
+                            source_bot_id=record.source_bot_id,
+                            source_bot_name=record.name,
+                            service_version=record.version,
+                            sc_version_number=ref.sc_version_number,
+                        )
+                    )
+
+            if page.complete:
+                if page.next_cursor is not None:
+                    unknown.append(self._pagination_unknown())
+                break
+            next_cursor = page.next_cursor
+            if (
+                next_cursor is None
+                or not page.records
+                or next_cursor != page.records[-1].id
+                or next_cursor in seen_cursors
+                or (cursor is not None and next_cursor <= cursor)
+            ):
+                unknown.append(self._pagination_unknown())
+                break
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
+
+        return ServiceArtifactLineage(
+            references=tuple(references),
+            unknown=tuple(unknown),
+        )
+
+    @staticmethod
+    def _pagination_unknown() -> UnknownServiceArtifact:
+        return UnknownServiceArtifact(
+            resource_id="artifact-scan",
+            display_name="Service Artifact lineage scan is incomplete",
+        )
+
+
+__all__ = ["ServiceArtifactLineageReader"]

--- a/src/backend/src/agentclaw/community/core/service_bot/services/service_artifact_refs.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/service_artifact_refs.py
@@ -1,0 +1,93 @@
+"""Pure exact-Center reference parser shared by build admission and lineage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agentclaw.community.core.service_bot.services.deploy.service_skills_manifest import (
+    validate_service_skills_manifest_for_release,
+)
+from agentclaw.community.core.skill_center.canonical_center_store import (
+    CanonicalCenterVersionIdentity,
+)
+from agentclaw.community.kernel.bot_config import BotConfigArtifact, SCHEMA_VERSION
+
+
+@dataclass(frozen=True, order=True, slots=True)
+class ExactCenterArtifactRef:
+    skill_uuid: str
+    sc_version_number: str
+
+
+def exact_center_refs_from_artifact_ext(
+    ext: dict,
+    *,
+    validate_full_artifact: bool = True,
+) -> tuple[ExactCenterArtifactRef, ...]:
+    """Parse both file-manifest v1 and Teclaw artifact v1-v4 shapes.
+
+    Old file artifacts without ``skills_manifest`` are valid and return no
+    Center refs.  Any present-but-invalid metadata raises so the lineage reader
+    can report UNKNOWN and the build commit can fail closed.
+    """
+
+    if not isinstance(ext, dict):
+        raise ValueError("artifact ext must be an object")
+    refs: set[ExactCenterArtifactRef] = set()
+
+    manifest = ext.get("skills_manifest")
+    if manifest is not None:
+        if not isinstance(manifest, dict):
+            raise ValueError("skills_manifest must be an object")
+        validate_service_skills_manifest_for_release(
+            manifest,
+            {"active_engine": manifest.get("engine")},
+        )
+        for item in manifest.get("center_skills") or ():
+            identity = CanonicalCenterVersionIdentity(
+                skill_uuid=item["skill_uuid"],
+                sc_version_number=item["sc_version_number"],
+            )
+            refs.add(
+                ExactCenterArtifactRef(
+                    skill_uuid=identity.skill_uuid,
+                    sc_version_number=identity.sc_version_number,
+                )
+            )
+
+    raw_artifact = ext.get("config_artifact")
+    if raw_artifact is not None:
+        if not isinstance(raw_artifact, dict):
+            raise ValueError("config_artifact must be an object")
+        if not validate_full_artifact and "skills" not in raw_artifact:
+            return tuple(sorted(refs))
+        artifact = BotConfigArtifact.from_dict(raw_artifact)
+        if (
+            not isinstance(artifact.schema_version, int)
+            or artifact.schema_version < 1
+            or artifact.schema_version > SCHEMA_VERSION
+        ):
+            raise ValueError("unsupported config artifact schema")
+        for skill in artifact.skills:
+            if skill.store != "skill-center":
+                continue
+            if skill.store not in artifact.stores:
+                raise ValueError("skill-center ref has no Store")
+            parts = skill.path.split("/")
+            if len(parts) != 2:
+                raise ValueError("skill-center path must be uuid/version")
+            identity = CanonicalCenterVersionIdentity(
+                skill_uuid=parts[0],
+                sc_version_number=parts[1],
+            )
+            refs.add(
+                ExactCenterArtifactRef(
+                    skill_uuid=identity.skill_uuid,
+                    sc_version_number=identity.sc_version_number,
+                )
+            )
+
+    return tuple(sorted(refs))
+
+
+__all__ = ["ExactCenterArtifactRef", "exact_center_refs_from_artifact_ext"]

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -52,6 +52,7 @@ provides:
   - "SpaceSkillPublicationServiceProtocol"
   - "SkillCenterPublicationGatewayProtocol"
   - "SpaceSkillPublicationTaskHandler"
+  - "ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES"
   - "PublicationAttemptRecord"
   - "BotRuntimeProjector"
   - "BotRuntimeProjectorProtocol"

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -30,6 +30,8 @@ provides:
   - "SkillSetManagementService"
   - "SpaceSkillGrantService"
   - "SpaceSkillApplicationService"
+  - "SpaceSkillOfflineService"
+  - "PublishedVersionDraftBuilder"
   - "SpaceSkillApplicationServiceProtocol"
   - "SpaceSkillDraftRepository"
   - "SpaceSkillReadRepository"
@@ -104,6 +106,7 @@ consumes:
   - "SpaceSkillPublicationRepositoryProtocol"
   - "SkillVersionScannerProtocol"
   - "HttpClient"
+  - "ServiceArtifactLineageReaderProtocol"
 internal_dependencies:
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.skill_center    # repository contracts consumed by this module
@@ -111,6 +114,9 @@ internal_dependencies:
   - agentclaw.community.core.repository.protocols.skill_center_types # query projection types consumed by this module
   - agentclaw.community.core.repository.protocols.space_skill_publication # Publication aggregate persistence contract
   - agentclaw.community.core.repository.protocols.work_orders
+  - agentclaw.community.core.repository.protocols.space_skill_offline
+  - agentclaw.community.core.repository.space_skill_offline_types
+  - agentclaw.community.core.service_bot.service_artifact_lineage_reader_protocol
   - agentclaw.community.core.work_orders
   - agentclaw.community.core.repository.protocols.skill_installation
   - agentclaw.community.core.repository.protocols.skills_pool    # Skills Pool repository contracts consumed by this module

--- a/src/backend/src/agentclaw/community/core/skill_center/errors.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/errors.py
@@ -3,6 +3,18 @@
 from agentclaw.community.core.errors import DomainError
 
 
+class SkillOfflineError(Exception):
+    """A new consumption write addressed a recoverably Offline Skill."""
+
+
+class SkillOfflineBlockedError(Exception):
+    """Offline could not prove that every destructive blocker is absent."""
+
+    def __init__(self, impact) -> None:
+        super().__init__("skill offline is blocked")
+        self.impact = impact
+
+
 class SkillDeleteConsistencyError(RuntimeError):
     """A Skill delete could not safely converge filesystem and database state."""
 

--- a/src/backend/src/agentclaw/community/core/skill_center/offline_policy.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/offline_policy.py
@@ -1,0 +1,11 @@
+"""Single invariant for commands that create a new Skill consumption fact."""
+
+from agentclaw.community.core.skill_center.errors import SkillOfflineError
+
+
+def require_skill_online(skill) -> None:
+    if skill.offline_at is not None:
+        raise SkillOfflineError("SKILL_OFFLINE")
+
+
+__all__ = ["require_skill_online"]

--- a/src/backend/src/agentclaw/community/core/skill_center/publication_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/publication_contract.py
@@ -20,6 +20,18 @@ class PublicationAttemptStatus(StrEnum):
     RESULT_UNKNOWN = "RESULT_UNKNOWN"
 
 
+ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES = tuple(
+    status.value
+    for status in (
+        PublicationAttemptStatus.PREPARING,
+        PublicationAttemptStatus.SC_SUBMITTING,
+        PublicationAttemptStatus.WAITING_SC,
+        PublicationAttemptStatus.MATERIALIZING,
+        PublicationAttemptStatus.RESULT_UNKNOWN,
+    )
+)
+
+
 class PublicationRecoveryState(StrEnum):
     AUTO_RETRYING = "AUTO_RETRYING"
     AVAILABLE = "AVAILABLE"
@@ -121,6 +133,7 @@ class PublicationPackageStagerProtocol(Protocol):
 
 
 __all__ = [
+    "ACTIVE_SKILL_PUBLICATION_ATTEMPT_STATUSES",
     "PublicationAttemptCreation",
     "PublicationAttemptRecord",
     "PublicationAttemptStatus",

--- a/src/backend/src/agentclaw/community/core/skill_center/services/published_version_draft.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/published_version_draft.py
@@ -1,0 +1,132 @@
+"""Prepare one immutable Draft revision from an exact Published Version."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from uuid import uuid4
+
+from agentclaw.community.core.skill_center.canonical_center_store import (
+    CanonicalCenterStoreError,
+    CanonicalCenterStoreErrorCode,
+    CanonicalCenterVersion,
+    CanonicalCenterVersionIdentity,
+    CanonicalCenterVersionRef,
+    CanonicalCenterVersionStore,
+)
+from agentclaw.community.core.skill_center.draft_content import (
+    DraftContentStore,
+    DraftRevisionIdentity,
+    DraftRevisionRef,
+)
+from agentclaw.community.core.skill_center.errors import SkillNameChangedError
+from agentclaw.community.core.skill_center.skill_package import SkillPackageValidator
+from agentclaw.community.plugin_api.skill_center_gateway import (
+    SkillCenterExactDownloadRequest,
+    SkillCenterGateway,
+    SkillCenterReadScope,
+)
+from agentclaw.community.plugin_api.space_skill_source import SpaceSkillSourcePlugin
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedPublishedVersionDraft:
+    expected_version_id: int
+    target_version: int
+    description: str | None
+    ref: DraftRevisionRef
+
+
+class PublishedVersionDraftBuilder:
+    """Hide exact Store repair, validation and immutable Revision creation."""
+
+    def __init__(
+        self,
+        *,
+        canonical_store: CanonicalCenterVersionStore,
+        skill_center: SkillCenterGateway,
+        sources: SpaceSkillSourcePlugin,
+        validator: SkillPackageValidator,
+        draft_store: DraftContentStore,
+        env_provider: Callable[[], str],
+        tenant_provider: Callable[[], str],
+    ) -> None:
+        self._canonical = canonical_store
+        self._skill_center = skill_center
+        self._sources = sources
+        self._validator = validator
+        self._draft_store = draft_store
+        self._env_provider = env_provider
+        self._tenant_provider = tenant_provider
+
+    def prepare(self, *, identity, latest) -> PreparedPublishedVersionDraft:
+        exact_identity = CanonicalCenterVersionIdentity(
+            skill_uuid=identity["skill_uuid"],
+            sc_version_number=latest["sc_version_number"],
+        )
+        exact_ref = CanonicalCenterVersionRef(exact_identity)
+        try:
+            exact = self._canonical.read_version(exact_ref)
+        except CanonicalCenterStoreError as exc:
+            if exc.code not in {
+                CanonicalCenterStoreErrorCode.NOT_READY,
+                CanonicalCenterStoreErrorCode.CORRUPT_CONTENT,
+            }:
+                raise
+            exact = self._repair(identity, exact_identity)
+        package = self._validator.validate_directory(
+            tuple((item.path, item.content) for item in exact.files)
+        )
+        if package.name != identity["name"]:
+            raise SkillNameChangedError("SKILL.md name is immutable")
+        target_version = int(latest["version_ordinal"]) + 1
+        revision = DraftRevisionIdentity(
+            tenant=self._tenant_provider(),
+            env=self._env_provider(),
+            skill_uuid=identity["skill_uuid"],
+            target_version=target_version,
+            revision_id=str(uuid4()),
+        )
+        ref = self._draft_store.write_revision(revision, package)
+        return PreparedPublishedVersionDraft(
+            expected_version_id=int(latest["id"]),
+            target_version=target_version,
+            description=package.description,
+            ref=ref,
+        )
+
+    def discard(self, prepared: PreparedPublishedVersionDraft) -> None:
+        try:
+            self._draft_store.delete_revision(prepared.ref)
+        except Exception:
+            logger.warning(
+                "failed to clean prepared Published-Version Draft revision",
+                exc_info=True,
+            )
+
+    def _repair(self, identity, exact_identity):
+        if identity["sc_team_id"] is None:
+            raise RuntimeError("Space Skill has no SkillCenter team identity")
+        download = self._skill_center.get_exact_download(
+            SkillCenterExactDownloadRequest(
+                skill_code=identity["skill_uuid"],
+                version_number=exact_identity.sc_version_number,
+                scope=SkillCenterReadScope.TEAM,
+                team_id=str(identity["sc_team_id"]),
+            )
+        )
+        package = self._validator.validate_zip(
+            self._sources.fetch_exact_package(
+                url=download.download_url, expected_sha256=download.sha256
+            )
+        )
+        version = CanonicalCenterVersion.from_files(exact_identity, dict(package.files))
+        self._canonical.write_version(version)
+        return self._canonical.read_version(CanonicalCenterVersionRef(exact_identity))
+
+
+__all__ = ["PreparedPublishedVersionDraft", "PublishedVersionDraftBuilder"]

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_application_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_application_service.py
@@ -12,14 +12,7 @@ from agentclaw.community.core.repository.protocols.skill_center import (
     SpaceSkillDraftRepository,
     SpaceSkillRepository,
 )
-from agentclaw.community.core.skill_center.canonical_center_store import (
-    CanonicalCenterStoreError,
-    CanonicalCenterStoreErrorCode,
-    CanonicalCenterVersion,
-    CanonicalCenterVersionIdentity,
-    CanonicalCenterVersionRef,
-    CanonicalCenterVersionStore,
-)
+from agentclaw.community.core.skill_center.canonical_center_store import CanonicalCenterVersionStore
 from agentclaw.community.core.repository.protocols.skill_center_types import (
     SpaceSkillDraftRecord,
 )
@@ -51,12 +44,11 @@ from agentclaw.community.core.skill_center.space_skill_application_service_proto
     SpaceSkillApplicationServiceProtocol,
     SpaceSkillCreationOutcome,
 )
-from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
-from agentclaw.community.plugin_api.skill_center_gateway import (
-    SkillCenterExactDownloadRequest,
-    SkillCenterGateway,
-    SkillCenterReadScope,
+from agentclaw.community.core.skill_center.services.published_version_draft import (
+    PublishedVersionDraftBuilder,
 )
+from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
+from agentclaw.community.plugin_api.skill_center_gateway import SkillCenterGateway
 from agentclaw.community.plugin_api.space_skill_source import (
     SpaceSkillSourcePlugin,
 )
@@ -88,10 +80,17 @@ class SpaceSkillApplicationService(SpaceSkillApplicationServiceProtocol):
         self._draft_store = draft_store
         self._sources = sources
         self._versions = versions
-        self._canonical = canonical_store
-        self._skill_center = skill_center
         self._env_provider = env_provider
         self._tenant_provider = tenant_provider
+        self._published_drafts = PublishedVersionDraftBuilder(
+            canonical_store=canonical_store,
+            skill_center=skill_center,
+            sources=sources,
+            validator=package_validator,
+            draft_store=draft_store,
+            env_provider=env_provider,
+            tenant_provider=tenant_provider,
+        )
 
     def create_from_folder(
         self,
@@ -338,76 +337,25 @@ class SpaceSkillApplicationService(SpaceSkillApplicationServiceProtocol):
         if not rows:
             raise DraftNotFoundError("latest Published Version not found")
         latest = rows[0]
-        exact_identity = CanonicalCenterVersionIdentity(
-            skill_uuid=identity["skill_uuid"],
-            sc_version_number=latest["sc_version_number"],
-        )
-        exact_ref = CanonicalCenterVersionRef(exact_identity)
-        try:
-            exact = self._canonical.read_version(exact_ref)
-        except CanonicalCenterStoreError as exc:
-            if exc.code not in {
-                CanonicalCenterStoreErrorCode.NOT_READY,
-                CanonicalCenterStoreErrorCode.CORRUPT_CONTENT,
-            }:
-                raise
-            exact = self._repair_exact_version(identity, exact_identity)
-        package = self._validator.validate_directory(
-            tuple((item.path, item.content) for item in exact.files)
-        )
-        self._require_stable_name(
-            {
-                "name": identity["name"],
-            },
-            package,
-        )
-        target_version = latest["version_ordinal"] + 1
-        revision = DraftRevisionIdentity(
-            tenant=self._tenant_provider(),
-            env=self._env_provider(),
-            skill_uuid=identity["skill_uuid"],
-            target_version=target_version,
-            revision_id=str(uuid4()),
-        )
-        ref = self._draft_store.write_revision(revision, package)
+        prepared = self._published_drafts.prepare(identity=identity, latest=latest)
         try:
             result = self._draft_repository.create_upgrade_draft(
                 space_id=space_id,
                 skill_id=skill_id,
                 actor_id=actor_id,
                 request_id=request_id,
-                expected_version_id=latest["id"],
-                target_version=target_version,
-                new_locator=ref.locator,
-                new_description=package.description,
+                expected_version_id=prepared.expected_version_id,
+                target_version=prepared.target_version,
+                new_locator=prepared.ref.locator,
+                new_description=prepared.description,
                 env=self._env_provider(),
             )
         except Exception:
-            self._best_effort_delete(ref)
+            self._published_drafts.discard(prepared)
             raise
         if not result["created"]:
-            self._best_effort_delete(ref)
+            self._published_drafts.discard(prepared)
         return self._draft_result(result["draft"])
-
-    def _repair_exact_version(self, identity, exact_identity):
-        if identity["sc_team_id"] is None:
-            raise RuntimeError("Space Skill has no SkillCenter team identity")
-        download = self._skill_center.get_exact_download(
-            SkillCenterExactDownloadRequest(
-                skill_code=identity["skill_uuid"],
-                version_number=exact_identity.sc_version_number,
-                scope=SkillCenterReadScope.TEAM,
-                team_id=str(identity["sc_team_id"]),
-            )
-        )
-        package = self._validator.validate_zip(
-            self._sources.fetch_exact_package(
-                url=download.download_url, expected_sha256=download.sha256
-            )
-        )
-        version = CanonicalCenterVersion.from_files(exact_identity, dict(package.files))
-        self._canonical.write_version(version)
-        return self._canonical.read_version(CanonicalCenterVersionRef(exact_identity))
 
     @staticmethod
     def _draft_result(record) -> DraftMutationResult:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_offline_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_offline_service.py
@@ -1,0 +1,163 @@
+"""Recoverable Offline orchestration at the Space Skill seam."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from agentclaw.community.core.skill_center.space_skill_offline_service_protocol import (
+    OfflineBlockerKind,
+    OfflineDraft,
+    OfflineImpact,
+    SpaceSkillOfflineResult,
+    SpaceSkillOfflineServiceProtocol,
+)
+from agentclaw.community.core.repository.space_skill_offline_types import (
+    OfflineInspection,
+)
+from agentclaw.community.core.repository.protocols.space_skill_offline import (
+    SpaceSkillOfflineRepositoryProtocol,
+)
+from agentclaw.community.core.skill_center.draft_content import DraftRevisionRef
+from agentclaw.community.core.skill_center.errors import SkillOfflineBlockedError
+from agentclaw.community.core.skill_center.services.published_version_draft import (
+    PublishedVersionDraftBuilder,
+)
+from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
+
+
+class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
+    def __init__(
+        self,
+        *,
+        access: SpaceAccessServiceProtocol,
+        repository: SpaceSkillOfflineRepositoryProtocol,
+        drafts: PublishedVersionDraftBuilder,
+        env_provider: Callable[[], str],
+        tenant_provider: Callable[[], str],
+    ) -> None:
+        self._access = access
+        self._repository = repository
+        self._drafts = drafts
+        self._env_provider = env_provider
+        self._tenant_provider = tenant_provider
+
+    def impact(
+        self,
+        *,
+        space_id: int,
+        skill_id: int,
+        actor_id: str,
+        page: int,
+        page_size: int,
+    ) -> OfflineImpact:
+        inspection = self._inspect(
+            space_id=space_id, skill_id=skill_id, actor_id=actor_id
+        )
+        return self._impact(inspection, page=page, page_size=page_size)
+
+    def offline(
+        self, *, space_id: int, skill_id: int, actor_id: str
+    ) -> SpaceSkillOfflineResult:
+        inspection = self._inspect(
+            space_id=space_id, skill_id=skill_id, actor_id=actor_id
+        )
+        identity = inspection.identity
+        if (
+            identity.offline_at is not None
+            and identity.draft_status is not None
+            and identity.draft_locator
+            and identity.draft_target_version is not None
+        ):
+            return self._result(
+                changed=False,
+                target_version=identity.draft_target_version,
+                status=identity.draft_status,
+                locator=identity.draft_locator,
+            )
+        if inspection.blockers:
+            raise SkillOfflineBlockedError(
+                self._impact(inspection, page=1, page_size=20)
+            )
+
+        prepared = self._drafts.prepare(
+            identity={
+                "skill_uuid": identity.skill_uuid,
+                "name": identity.name,
+                "sc_team_id": identity.sc_team_id,
+            },
+            latest={
+                "id": identity.latest_version_id,
+                "version_ordinal": identity.latest_version_ordinal,
+                "sc_version_number": identity.sc_version_number,
+            },
+        )
+        try:
+            committed = self._repository.commit(
+                space_id=space_id,
+                skill_id=skill_id,
+                actor_id=actor_id,
+                expected_version_id=prepared.expected_version_id,
+                target_version=prepared.target_version,
+                new_locator=prepared.ref.locator,
+                new_description=prepared.description,
+                env=self._env_provider(),
+            )
+        except Exception:
+            self._drafts.discard(prepared)
+            raise
+        if not committed.changed:
+            self._drafts.discard(prepared)
+        return self._result(
+            changed=committed.changed,
+            target_version=committed.target_version,
+            status=committed.status,
+            locator=committed.locator,
+        )
+
+    def _inspect(
+        self, *, space_id: int, skill_id: int, actor_id: str
+    ) -> OfflineInspection:
+        self._access.require_space_member(space_id=space_id, user_id=actor_id)
+        return self._repository.inspect(
+            space_id=space_id,
+            skill_id=skill_id,
+            actor_id=actor_id,
+            env=self._env_provider(),
+        )
+
+    @staticmethod
+    def _impact(
+        inspection: OfflineInspection, *, page: int, page_size: int
+    ) -> OfflineImpact:
+        blockers = inspection.blockers
+        counts = {kind.value: 0 for kind in OfflineBlockerKind}
+        for item in blockers:
+            counts[item.kind.value] += 1
+        start = (page - 1) * page_size
+        return OfflineImpact(
+            blocked=bool(blockers),
+            total=len(blockers),
+            counts={kind: count for kind, count in counts.items() if count},
+            items=blockers[start : start + page_size],
+        )
+
+    def _result(
+        self, *, changed: bool, target_version: int, status: str, locator: str
+    ) -> SpaceSkillOfflineResult:
+        ref = DraftRevisionRef.from_locator(
+            tenant=self._tenant_provider(),
+            env=self._env_provider(),
+            locator=locator,
+        )
+        return SpaceSkillOfflineResult(
+            changed=changed,
+            lifecycle_status="OFFLINE",
+            draft=OfflineDraft(
+                target_version=target_version,
+                status=status,
+                revision_id=ref.revision_id,
+            ),
+        )
+
+
+__all__ = ["SpaceSkillOfflineService"]

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_offline_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_offline_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 
 from agentclaw.community.core.service_bot.service_artifact_lineage_reader_protocol import (
     ServiceArtifactLineageReaderProtocol,
@@ -17,12 +18,16 @@ from agentclaw.community.core.skill_center.space_skill_offline_service_protocol 
 )
 from agentclaw.community.core.repository.space_skill_offline_types import (
     OfflineInspection,
+    OfflineSkillIdentity,
 )
 from agentclaw.community.core.repository.protocols.space_skill_offline import (
     SpaceSkillOfflineRepositoryProtocol,
 )
 from agentclaw.community.core.skill_center.draft_content import DraftRevisionRef
-from agentclaw.community.core.skill_center.errors import SkillOfflineBlockedError
+from agentclaw.community.core.skill_center.errors import (
+    SkillOfflineBlockedError,
+    SpaceSkillGrantForbiddenError,
+)
 from agentclaw.community.core.skill_center.services.published_version_draft import (
     PublishedVersionDraftBuilder,
 )
@@ -30,6 +35,12 @@ from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
 
 
 _BLOCKER_ORDER = {kind: index for index, kind in enumerate(OfflineBlockerKind)}
+
+
+@dataclass(frozen=True, slots=True)
+class _OfflineEvaluation:
+    identity: OfflineSkillIdentity
+    blockers: tuple[OfflineImpactItem, ...]
 
 
 class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
@@ -126,7 +137,7 @@ class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
 
     def _inspect(
         self, *, space_id: int, skill_id: int, actor_id: str
-    ) -> OfflineInspection:
+    ) -> _OfflineEvaluation:
         self._access.require_space_member(space_id=space_id, user_id=actor_id)
         inspection = self._repository.inspect(
             space_id=space_id,
@@ -134,23 +145,67 @@ class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
             actor_id=actor_id,
             env=self._env_provider(),
         )
-        return self._with_artifact_blockers(inspection)
+        return self._evaluate(inspection)
 
     def _guard_locked_offline(self, inspection: OfflineInspection) -> None:
-        latest = self._with_artifact_blockers(inspection)
+        latest = self._evaluate(inspection)
         if latest.blockers:
             raise SkillOfflineBlockedError(
                 self._impact(latest, page=1, page_size=20)
             )
 
+    def _evaluate(self, inspection: OfflineInspection) -> _OfflineEvaluation:
+        if not inspection.space_bound or not {
+            "OWNER",
+            "MANAGER",
+        }.intersection(inspection.actor_roles):
+            raise SpaceSkillGrantForbiddenError("owner or manager required")
+        identity = inspection.identity
+        blockers: list[OfflineImpactItem] = []
+        if identity.draft_status is not None:
+            blockers.append(
+                OfflineImpactItem(
+                    kind=OfflineBlockerKind.DRAFT,
+                    resource_id=str(identity.skill_id),
+                    display_name=f"Draft V{identity.draft_target_version}",
+                )
+            )
+        blockers.extend(
+            OfflineImpactItem(
+                kind=OfflineBlockerKind.PUBLICATION,
+                resource_id=str(attempt.id),
+                display_name=f"Publication V{attempt.target_version_ordinal}",
+            )
+            for attempt in inspection.publication_attempts
+        )
+        blockers.extend(
+            OfflineImpactItem(
+                kind=OfflineBlockerKind.MEMBERSHIP,
+                resource_id=str(membership.id),
+                display_name=membership.skill_set_name,
+            )
+            for membership in inspection.memberships
+        )
+        blockers.extend(
+            OfflineImpactItem(
+                kind=OfflineBlockerKind.INSTALLATION,
+                resource_id=str(installation.id),
+                display_name=installation.bot_id,
+            )
+            for installation in inspection.installations
+        )
+        return self._with_artifact_blockers(
+            _OfflineEvaluation(identity=identity, blockers=tuple(blockers))
+        )
+
     def _with_artifact_blockers(
-        self, inspection: OfflineInspection
-    ) -> OfflineInspection:
+        self, evaluation: _OfflineEvaluation
+    ) -> _OfflineEvaluation:
         lineage = self._lineage.scan(
-            skill_uuid=inspection.identity.skill_uuid,
+            skill_uuid=evaluation.identity.skill_uuid,
             env=self._env_provider(),
         )
-        blockers = list(inspection.blockers)
+        blockers = list(evaluation.blockers)
         blockers.extend(
             OfflineImpactItem(
                 kind=OfflineBlockerKind.SERVICE_ARTIFACT,
@@ -180,11 +235,11 @@ class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
                 ),
             )
         )
-        return OfflineInspection(identity=inspection.identity, blockers=ordered)
+        return _OfflineEvaluation(identity=evaluation.identity, blockers=ordered)
 
     @staticmethod
     def _impact(
-        inspection: OfflineInspection, *, page: int, page_size: int
+        inspection: _OfflineEvaluation, *, page: int, page_size: int
     ) -> OfflineImpact:
         blockers = inspection.blockers
         counts = {kind.value: 0 for kind in OfflineBlockerKind}

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_offline_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_offline_service.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
+from agentclaw.community.core.service_bot.service_artifact_lineage_reader_protocol import (
+    ServiceArtifactLineageReaderProtocol,
+)
 from agentclaw.community.core.skill_center.space_skill_offline_service_protocol import (
     OfflineBlockerKind,
     OfflineDraft,
     OfflineImpact,
+    OfflineImpactItem,
     SpaceSkillOfflineResult,
     SpaceSkillOfflineServiceProtocol,
 )
@@ -25,18 +29,23 @@ from agentclaw.community.core.skill_center.services.published_version_draft impo
 from agentclaw.community.core.spaces.protocols import SpaceAccessServiceProtocol
 
 
+_BLOCKER_ORDER = {kind: index for index, kind in enumerate(OfflineBlockerKind)}
+
+
 class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
     def __init__(
         self,
         *,
         access: SpaceAccessServiceProtocol,
         repository: SpaceSkillOfflineRepositoryProtocol,
+        lineage: ServiceArtifactLineageReaderProtocol,
         drafts: PublishedVersionDraftBuilder,
         env_provider: Callable[[], str],
         tenant_provider: Callable[[], str],
     ) -> None:
         self._access = access
         self._repository = repository
+        self._lineage = lineage
         self._drafts = drafts
         self._env_provider = env_provider
         self._tenant_provider = tenant_provider
@@ -101,6 +110,7 @@ class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
                 new_locator=prepared.ref.locator,
                 new_description=prepared.description,
                 env=self._env_provider(),
+                guard=self._guard_locked_offline,
             )
         except Exception:
             self._drafts.discard(prepared)
@@ -118,12 +128,59 @@ class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
         self, *, space_id: int, skill_id: int, actor_id: str
     ) -> OfflineInspection:
         self._access.require_space_member(space_id=space_id, user_id=actor_id)
-        return self._repository.inspect(
+        inspection = self._repository.inspect(
             space_id=space_id,
             skill_id=skill_id,
             actor_id=actor_id,
             env=self._env_provider(),
         )
+        return self._with_artifact_blockers(inspection)
+
+    def _guard_locked_offline(self, inspection: OfflineInspection) -> None:
+        latest = self._with_artifact_blockers(inspection)
+        if latest.blockers:
+            raise SkillOfflineBlockedError(
+                self._impact(latest, page=1, page_size=20)
+            )
+
+    def _with_artifact_blockers(
+        self, inspection: OfflineInspection
+    ) -> OfflineInspection:
+        lineage = self._lineage.scan(
+            skill_uuid=inspection.identity.skill_uuid,
+            env=self._env_provider(),
+        )
+        blockers = list(inspection.blockers)
+        blockers.extend(
+            OfflineImpactItem(
+                kind=OfflineBlockerKind.SERVICE_ARTIFACT,
+                resource_id=str(reference.publish_id),
+                display_name=(
+                    f"{reference.source_bot_name} V{reference.service_version} "
+                    f"(Skill {reference.sc_version_number})"
+                ),
+            )
+            for reference in lineage.references
+        )
+        blockers.extend(
+            OfflineImpactItem(
+                kind=OfflineBlockerKind.UNKNOWN_ARTIFACT,
+                resource_id=item.resource_id,
+                display_name=item.display_name,
+            )
+            for item in lineage.unknown
+        )
+        ordered = tuple(
+            sorted(
+                blockers,
+                key=lambda item: (
+                    _BLOCKER_ORDER[item.kind],
+                    item.resource_id,
+                    item.display_name,
+                ),
+            )
+        )
+        return OfflineInspection(identity=inspection.identity, blockers=ordered)
 
     @staticmethod
     def _impact(

--- a/src/backend/src/agentclaw/community/core/skill_center/space_skill_offline_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/space_skill_offline_service_protocol.py
@@ -1,0 +1,75 @@
+"""Service API contract for recoverable Space Skill Offline."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol, runtime_checkable
+
+
+class OfflineBlockerKind(StrEnum):
+    DRAFT = "DRAFT"
+    PUBLICATION = "PUBLICATION"
+    MEMBERSHIP = "MEMBERSHIP"
+    INSTALLATION = "INSTALLATION"
+    SERVICE_ARTIFACT = "SERVICE_ARTIFACT"
+    UNKNOWN_ARTIFACT = "UNKNOWN_ARTIFACT"
+
+
+@dataclass(frozen=True, slots=True)
+class OfflineImpactItem:
+    kind: OfflineBlockerKind
+    resource_id: str
+    display_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class OfflineImpact:
+    blocked: bool
+    total: int
+    counts: dict[str, int]
+    items: tuple[OfflineImpactItem, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class OfflineDraft:
+    target_version: int
+    status: str
+    revision_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class SpaceSkillOfflineResult:
+    changed: bool
+    lifecycle_status: str
+    draft: OfflineDraft
+
+
+@runtime_checkable
+class SpaceSkillOfflineServiceProtocol(Protocol):
+    @abstractmethod
+    def impact(
+        self,
+        *,
+        space_id: int,
+        skill_id: int,
+        actor_id: str,
+        page: int,
+        page_size: int,
+    ) -> OfflineImpact: ...
+
+    @abstractmethod
+    def offline(
+        self, *, space_id: int, skill_id: int, actor_id: str
+    ) -> SpaceSkillOfflineResult: ...
+
+
+__all__ = [
+    "OfflineBlockerKind",
+    "OfflineDraft",
+    "OfflineImpact",
+    "OfflineImpactItem",
+    "SpaceSkillOfflineResult",
+    "SpaceSkillOfflineServiceProtocol",
+]

--- a/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
@@ -43,6 +43,9 @@ from agentclaw.community.api.publish_approval import PublishApprovalServiceProto
 from agentclaw.community.api.service_publication_facade import (
     ServicePublicationFacadeProtocol,
 )
+from agentclaw.community.api.service_artifact_lineage import (
+    ServiceArtifactLineageReaderProtocol,
+)
 from agentclaw.community.api.collaborator_lock_service import (
     CollaboratorLockServiceProtocol,
 )
@@ -91,6 +94,9 @@ from agentclaw.community.core.service_bot.services.bot_process import (
     ServiceBotProcess,
 )
 from agentclaw.community.core.service_bot.services.bot_publish_service import BotPublishService
+from agentclaw.community.core.service_bot.services.service_artifact_lineage_reader import (
+    ServiceArtifactLineageReader,
+)
 from agentclaw.community.core.service_bot.services.deploy.arca_snapshot_producer import (
     ArcaSnapshotProducer,
 )
@@ -175,6 +181,11 @@ class ServiceBotModule(Module):
         binder.bind(
             BotPublishRepositoryProtocol,
             to=UnifiedBotPublishRepository,
+            scope=singleton,
+        )
+        binder.bind(
+            ServiceArtifactLineageReaderProtocol,
+            to=ServiceArtifactLineageReader,
             scope=singleton,
         )
         # Publish operation ledger repository — same unified-ORM pattern; the

--- a/src/backend/src/agentclaw/community/di/modules/space_skill_repository_bindings.py
+++ b/src/backend/src/agentclaw/community/di/modules/space_skill_repository_bindings.py
@@ -14,6 +14,9 @@ from agentclaw.community.core.repository.implementations.skill_center.space_skil
 from agentclaw.community.core.repository.implementations.skill_center.space_skill_version_read import (
     SpaceSkillVersionReadRepository as UnifiedSpaceSkillVersionReadRepository,
 )
+from agentclaw.community.core.repository.implementations.skill_center.space_skill_offline import (
+    SpaceSkillOfflineRepository as UnifiedSpaceSkillOfflineRepository,
+)
 from agentclaw.community.core.repository.implementations.skill_center.space_skill_publication import (
     SpaceSkillPublicationRepository as UnifiedSpaceSkillPublicationRepository,
 )
@@ -25,6 +28,9 @@ from agentclaw.community.core.repository.protocols.skill_center import (
 )
 from agentclaw.community.core.repository.protocols.space_skill_version import (
     SpaceSkillVersionReadRepository,
+)
+from agentclaw.community.core.repository.protocols.space_skill_offline import (
+    SpaceSkillOfflineRepositoryProtocol,
 )
 from agentclaw.community.core.repository.protocols.space_skill_publication import (
     SpaceSkillPublicationRepositoryProtocol,
@@ -61,5 +67,10 @@ def bind_space_skill_repositories(binder: Binder) -> None:
     binder.bind(
         DraftEditLeaseRepository,
         to=UnifiedSpaceSkillRepository,
+        scope=singleton,
+    )
+    binder.bind(
+        SpaceSkillOfflineRepositoryProtocol,
+        to=UnifiedSpaceSkillOfflineRepository,
         scope=singleton,
     )

--- a/src/backend/src/agentclaw/community/di/modules/spaces_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/spaces_module.py
@@ -66,6 +66,9 @@ from agentclaw.community.core.repository.protocols.work_orders import (
 from agentclaw.community.core.repository.protocols.space_skill_offline import (
     SpaceSkillOfflineRepositoryProtocol,
 )
+from agentclaw.community.core.service_bot.service_artifact_lineage_reader_protocol import (
+    ServiceArtifactLineageReaderProtocol,
+)
 from agentclaw.community.core.spaces.services import (
     SpaceAccessService,
     SpaceMemberService,
@@ -233,6 +236,7 @@ class SpacesModule(Module):
         sources: SpaceSkillSourcePlugin,
         canonical_store: CanonicalCenterVersionStore,
         skill_center: SkillCenterGateway,
+        lineage: ServiceArtifactLineageReaderProtocol,
     ) -> SpaceSkillOfflineServiceProtocol:
         validator = SkillPackageValidator(SkillParser())
         drafts = PublishedVersionDraftBuilder(
@@ -247,6 +251,7 @@ class SpacesModule(Module):
         return SpaceSkillOfflineService(
             access=access,
             repository=repository,
+            lineage=lineage,
             drafts=drafts,
             env_provider=get_current_env,
             tenant_provider=get_current_avernet_tenant,

--- a/src/backend/src/agentclaw/community/di/modules/spaces_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/spaces_module.py
@@ -33,6 +33,9 @@ from agentclaw.community.api.space_skill_grant_service import (
 from agentclaw.community.api.space_skill_editor_request_service import (
     SpaceSkillEditorRequestServiceProtocol,
 )
+from agentclaw.community.api.space_skill_offline_service import (
+    SpaceSkillOfflineServiceProtocol,
+)
 from agentclaw.community.api.draft_edit_lease_service import (
     DraftEditLeaseServiceProtocol,
 )
@@ -59,6 +62,9 @@ from agentclaw.community.core.repository.protocols.space_skill_publication impor
 )
 from agentclaw.community.core.repository.protocols.work_orders import (
     WorkOrderRepositoryProtocol,
+)
+from agentclaw.community.core.repository.protocols.space_skill_offline import (
+    SpaceSkillOfflineRepositoryProtocol,
 )
 from agentclaw.community.core.spaces.services import (
     SpaceAccessService,
@@ -112,6 +118,12 @@ from agentclaw.community.core.skill_center.services.space_skill_editor_request_s
 )
 from agentclaw.community.core.skill_center.services.draft_edit_lease_service import (
     DraftEditLeaseService,
+)
+from agentclaw.community.core.skill_center.services.published_version_draft import (
+    PublishedVersionDraftBuilder,
+)
+from agentclaw.community.core.skill_center.services.space_skill_offline_service import (
+    SpaceSkillOfflineService,
 )
 from agentclaw.community.core.spaces.protocols import (
     SpaceAccessServiceProtocol as CoreSpaceAccessServiceProtocol,
@@ -209,6 +221,36 @@ class SpacesModule(Module):
     ) -> SpaceSkillEditorRequestServiceProtocol:
         """Assemble editor-request policy with environment at the boundary."""
         return SpaceSkillEditorRequestService(repository, get_current_env)
+
+    @singleton
+    @provider
+    @inject
+    def space_skill_offline_service(
+        self,
+        access: CoreSpaceAccessServiceProtocol,
+        repository: SpaceSkillOfflineRepositoryProtocol,
+        draft_store: DraftContentStore,
+        sources: SpaceSkillSourcePlugin,
+        canonical_store: CanonicalCenterVersionStore,
+        skill_center: SkillCenterGateway,
+    ) -> SpaceSkillOfflineServiceProtocol:
+        validator = SkillPackageValidator(SkillParser())
+        drafts = PublishedVersionDraftBuilder(
+            canonical_store=canonical_store,
+            skill_center=skill_center,
+            sources=sources,
+            validator=validator,
+            draft_store=draft_store,
+            env_provider=get_current_env,
+            tenant_provider=get_current_avernet_tenant,
+        )
+        return SpaceSkillOfflineService(
+            access=access,
+            repository=repository,
+            drafts=drafts,
+            env_provider=get_current_env,
+            tenant_provider=get_current_avernet_tenant,
+        )
 
     @singleton
     @provider

--- a/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
@@ -49,6 +49,14 @@ from agentclaw.community.plugin_api.space_skill_source import (
 from agentclaw.community.api.space_skill_version_query_service import (
     SpaceSkillVersionQueryServiceProtocol,
 )
+from agentclaw.community.api.space_skill_offline_service import (
+    OfflineBlockerKind,
+    OfflineDraft,
+    OfflineImpact,
+    OfflineImpactItem,
+    SpaceSkillOfflineResult,
+    SpaceSkillOfflineServiceProtocol,
+)
 from agentclaw.community.api.space_skill_editor_request_service import (
     SpaceSkillEditorRequestServiceProtocol,
 )
@@ -93,6 +101,7 @@ from agentclaw.community.core.skill_center.errors import (
     DraftEditLeaseNotFoundError,
     DraftEditLeaseTokenRejectedError,
     DraftSourceNotRefreshableError,
+    SkillOfflineBlockedError,
 )
 from tests.community.adapters.http.openapi_v1.conftest import (
     mount_public_error_handlers,
@@ -158,6 +167,11 @@ def draft_edit_lease_service():
 
 
 @pytest.fixture
+def skill_offline_service():
+    return MagicMock()
+
+
+@pytest.fixture
 def client(
     member_service,
     space_service,
@@ -168,6 +182,7 @@ def client(
     skill_version_query_service,
     skill_editor_request_service,
     draft_edit_lease_service,
+    skill_offline_service,
 ):
     class _Bindings(Module):
         def configure(self, binder):
@@ -188,6 +203,7 @@ def client(
                 to=skill_editor_request_service,
             )
             binder.bind(DraftEditLeaseServiceProtocol, to=draft_edit_lease_service)
+            binder.bind(SpaceSkillOfflineServiceProtocol, to=skill_offline_service)
 
     app = FastAPI()
     app.include_router(router)
@@ -1232,6 +1248,90 @@ def test_upgrade_refresh_and_delete_routes_publish_command_contracts(
         skill_application_service.refresh_draft_from_git,
         skill_application_service.delete_draft,
     ]
+
+
+def test_offline_impact_and_command_publish_stable_contracts(
+    client, skill_offline_service
+):
+    impact = OfflineImpact(
+        blocked=True,
+        total=1,
+        counts={"MEMBERSHIP": 1},
+        items=(
+            OfflineImpactItem(
+                kind=OfflineBlockerKind.MEMBERSHIP,
+                resource_id="1115804",
+                display_name="基础能力集",
+            ),
+        ),
+    )
+    skill_offline_service.impact.return_value = impact
+    skill_offline_service.offline.return_value = SpaceSkillOfflineResult(
+        changed=True,
+        lifecycle_status="OFFLINE",
+        draft=OfflineDraft(
+            target_version=3,
+            status="EDITING",
+            revision_id="33333333-3333-4333-8333-333333333333",
+        ),
+    )
+
+    preview = client.get(
+        "/openapi/v1/bots/spaces/7/skills/51/offline-impact",
+        params={"page": 1, "page_size": 20},
+    )
+    executed = client.post("/openapi/v1/bots/spaces/7/skills/51/offline")
+
+    assert preview.status_code == 200
+    assert preview.json()["data"] == {
+        "blocked": True,
+        "total": 1,
+        "counts": {"MEMBERSHIP": 1},
+        "items": [
+            {
+                "kind": "MEMBERSHIP",
+                "resource_id": "1115804",
+                "display_name": "基础能力集",
+            }
+        ],
+    }
+    assert executed.status_code == 200
+    assert executed.json()["data"]["changed"] is True
+    assert executed.json()["data"]["draft"]["target_version"] == 3
+    skill_offline_service.impact.assert_called_once_with(
+        space_id=7,
+        skill_id=51,
+        actor_id="owner-1",
+        page=1,
+        page_size=20,
+    )
+    skill_offline_service.offline.assert_called_once_with(
+        space_id=7, skill_id=51, actor_id="owner-1"
+    )
+
+
+def test_offline_blocked_returns_latest_impact_in_409_data(
+    client, skill_offline_service
+):
+    impact = OfflineImpact(
+        blocked=True,
+        total=1,
+        counts={"UNKNOWN_ARTIFACT": 1},
+        items=(
+            OfflineImpactItem(
+                kind=OfflineBlockerKind.UNKNOWN_ARTIFACT,
+                resource_id="artifact-scan",
+                display_name="scan incomplete",
+            ),
+        ),
+    )
+    skill_offline_service.offline.side_effect = SkillOfflineBlockedError(impact)
+
+    response = client.post("/openapi/v1/bots/spaces/7/skills/51/offline")
+
+    assert response.status_code == 409
+    assert response.json()["code"] == 409313
+    assert response.json()["data"]["counts"] == {"UNKNOWN_ARTIFACT": 1}
 
 
 def test_upgrade_maps_exact_source_failure_to_sc_unavailable(

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_explicit_user_id.py
@@ -413,7 +413,7 @@ _LOGS_PREFIX = f"{PUBLIC_API_PREFIX}/bots/logs"
 #: The task grant/revoke operations also carry the target in ``bcs_bot_id``
 #: request-body fields rather than a ``bot_id`` parameter, adding two more
 #: operations without changing the path/query counts.
-_BOT_ID_PLACEMENT = {"path": 143, "query": 1, "none": 94}
+_BOT_ID_PLACEMENT = {"path": 143, "query": 1, "none": 96}
 
 
 def _schema() -> dict:
@@ -543,8 +543,9 @@ def test_the_pinned_number_of_operations_take_it():
     # creation/detail/Draft/Published-Version operations; none addresses a Bot,
     # and each carries the explicit user dimension. The merged surface contains
     # 207 operations. Phase 2 Group 3 Publication adds five Space-addressed
-    # operations with an explicit user dimension, bringing the surface to 212.
-    assert len(taking) == 212
+    # operations and Group 5 adds Offline impact + command, bringing the
+    # surface to 214; all seven carry the explicit user dimension.
+    assert len(taking) == 214
 
 
 def test_the_exempt_operations_take_none():

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_openapi_error_schema.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_openapi_error_schema.py
@@ -26,6 +26,7 @@ _ERROR_REF = "#/components/schemas/ErrorEnvelope"
 # ``data`` and the route declares that shape. Every other error stays uniform.
 _DOCUMENTED_DATA_BEARING_ERRORS = {
     ("/openapi/v1/bots/{bot_id}/auth-status", 400),
+    ("/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline", 409),
 }
 
 

--- a/src/backend/tests/community/architecture/test_service_api_conformance.py
+++ b/src/backend/tests/community/architecture/test_service_api_conformance.py
@@ -106,6 +106,12 @@ from agentclaw.community.api.repository_catalog_service import (
 from agentclaw.community.api.service_publication_facade import (
     ServicePublicationFacadeProtocol,
 )
+from agentclaw.community.api.service_artifact_lineage import (
+    ServiceArtifactLineageReaderProtocol,
+)
+from agentclaw.community.api.space_skill_offline_service import (
+    SpaceSkillOfflineServiceProtocol,
+)
 from agentclaw.community.api.space_service import (
     SpaceAccessServiceProtocol,
     SpaceMemberServiceProtocol,
@@ -204,6 +210,12 @@ from agentclaw.community.core.market_favorites.services import MarketFavoriteSer
 from agentclaw.community.core.service_bot.services.service_publication_facade import (
     ServicePublicationFacade,
 )
+from agentclaw.community.core.service_bot.services.service_artifact_lineage_reader import (
+    ServiceArtifactLineageReader,
+)
+from agentclaw.community.core.skill_center.services.space_skill_offline_service import (
+    SpaceSkillOfflineService,
+)
 from agentclaw.community.core.spaces.services import (
     SpaceAccessService,
     SpaceMemberService,
@@ -246,6 +258,8 @@ _PAIRS = [
     (SpaceMemberServiceProtocol, SpaceMemberService),
     (MarketFavoriteServiceProtocol, MarketFavoriteService),
     (ServicePublicationFacadeProtocol, ServicePublicationFacade),
+    (ServiceArtifactLineageReaderProtocol, ServiceArtifactLineageReader),
+    (SpaceSkillOfflineServiceProtocol, SpaceSkillOfflineService),
 ]
 
 _IDS = [f"{p.__name__}->{c.__name__}" for p, c in _PAIRS]

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -1057,7 +1057,11 @@ def _build_svc_with_router(router, bot, provider="baas", **publish_flow_kwargs):
     )
     # Avoid touching real status/ext plumbing — isolate the build phase.
     svc._ext_state.get_latest_ext = Mock(return_value={})
-    svc._ext_state.update_status = Mock()
+    artifact_commit = Mock()
+    svc._ext_state.commit_built_artifact = artifact_commit
+    # Existing assertions read this historical attribute; both names point at
+    # the same call recorder while build now commits through the Offline fence.
+    svc._ext_state.update_status = artifact_commit
     svc._ext_state.owner_id = Mock(return_value="u1")
     publish_service.update_publish_status = Mock()
     return svc, publish_service
@@ -1180,6 +1184,53 @@ async def test_build_phase_routes_external_and_merges_artifact_ext():
     }
     assert ext_written["content_hash"] == "sha256:y"
     assert ext_written["engine_ext"] == {"k": 1}
+
+
+@pytest.mark.asyncio
+async def test_build_commit_fences_exact_center_skills_before_built_status():
+    skill_uuid = "11111111-1111-4111-8111-111111111111"
+    teclaw = _StubProducer(
+        {
+            "config_artifact": {
+                "schema_version": 4,
+                "engine_type": "teclaw",
+                "skills": [
+                    {
+                        "name": "center",
+                        "scope": "shared",
+                        "store": "skill-center",
+                        "path": f"{skill_uuid}/2.0.0",
+                    }
+                ],
+                "stores": {
+                    "skill-center": {
+                        "type": "oss",
+                        "bucket": "bucket",
+                        "base": "skills-center",
+                    }
+                },
+            }
+        }
+    )
+    router = DeployArtifactProducerRouter(
+        providers={"teclaw": teclaw}, default_provider_key="teclaw"
+    )
+    bot = {
+        "bot_id": "b2",
+        "owner_id": "owner-1",
+        "active_engine": "teclaw",
+        "env": "prod",
+    }
+    svc, _ = _build_svc_with_router(router, bot, provider="teclaw")
+
+    result = await svc.execute_build_phase(
+        _make_publish_record(status=PublishStatus.DRAFT.value, version=2), "op"
+    )
+
+    assert result.status == PublishStatus.BUILT
+    assert svc._ext_state.commit_built_artifact.call_args.kwargs[
+        "center_skill_uuids"
+    ] == (skill_uuid,)
 
 
 @pytest.mark.asyncio
@@ -3413,10 +3464,6 @@ async def test_eval_publish_with_default_tag():
 
 def test_eval_teardown_with_default_tag():
     """场景三：eval_teardown 传入 default_tag 时记录到 result。"""
-    from agentclaw.community.core.service_bot.services.publish_flow.tasks import (
-        EVAL_TEARDOWN_TASK,
-    )
-
     build_service = Mock()
     baas_service = Mock()
     task_queue_service = Mock()

--- a/src/backend/tests/community/core/service_bot/services/test_service_artifact_lineage_reader.py
+++ b/src/backend/tests/community/core/service_bot/services/test_service_artifact_lineage_reader.py
@@ -1,0 +1,201 @@
+"""Behavior tests for the unique Service Artifact lineage read seam."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from agentclaw.community.api.service_artifact_lineage import (
+    ServiceArtifactLineageReaderProtocol,
+)
+from agentclaw.community.core.service_bot.repository.models import (
+    BotPublishLineagePage,
+    BotPublishRecord,
+)
+from agentclaw.community.core.service_bot.services.service_artifact_lineage_reader import (
+    ServiceArtifactLineageReader,
+)
+
+
+_UUID = "11111111-1111-4111-8111-111111111111"
+
+
+def _record(
+    publish_id: int,
+    *,
+    status: str = "success",
+    ext: dict | None = None,
+) -> BotPublishRecord:
+    now = datetime(2026, 8, 30, 8, 0, 0)
+    return BotPublishRecord(
+        id=publish_id,
+        source_bot_pk=publish_id,
+        source_bot_id=f"service-{publish_id}",
+        publish_bot_id=f"service-{publish_id}-pub",
+        name=f"Service {publish_id}",
+        owner_id="owner-1",
+        status=status,
+        version=publish_id,
+        env="test",
+        ext=ext,
+        permission_owner="owner-1",
+        gmt_create=now,
+        gmt_modified=now,
+    )
+
+
+class _Pages:
+    def __init__(self, pages: list[BotPublishLineagePage]) -> None:
+        self.pages = pages
+        self.calls: list[int | None] = []
+
+    def list_lineage_candidates_page(self, *, env, after_id, limit):
+        assert env == "test"
+        assert limit == 100
+        self.calls.append(after_id)
+        return self.pages[len(self.calls) - 1]
+
+
+def test_reader_finds_file_and_teclaw_exact_refs_across_complete_pages():
+    file_record = _record(
+        1,
+        ext={
+            "migration_path": "/artifact/v1",
+            "skills_manifest": {
+                "schema_version": 1,
+                "engine": "openclaw",
+                "active_layout": "pool",
+                "layout_contract_version": "skills-pool-p3-v1",
+                "center_skills": [
+                    {
+                        "runtime_name": "pdf",
+                        "skill_uuid": _UUID,
+                        "sc_version_number": "1.0.0",
+                        "mcp_dependencies": ["mcp.a"],
+                    }
+                ],
+                "shared_corpora": [
+                    {
+                        "corpus": "repo",
+                        "runtime_path": "/runtime/skills-pool/skills-repo",
+                        "store_prefix": "skills-repo",
+                        "layout_contract_version": "skills-pool-p3-v1",
+                        "permission": "read_only",
+                        "snapshot_policy": "exclude",
+                    },
+                    {
+                        "corpus": "center",
+                        "runtime_path": "/runtime/skills-pool/skill-center",
+                        "store_prefix": "skills-center",
+                        "layout_contract_version": "skills-pool-p3-v1",
+                        "permission": "read_only",
+                        "snapshot_policy": "exclude",
+                    },
+                ],
+            },
+        },
+    )
+    teclaw_record = _record(
+        2,
+        status="upgraded",
+        ext={
+            "config_artifact": {
+                "schema_version": 4,
+                "engine_type": "teclaw",
+                "skills": [
+                    {
+                        "name": "pdf",
+                        "scope": "shared",
+                        "store": "skill-center",
+                        "path": f"{_UUID}/2.0.0",
+                    }
+                ],
+                "stores": {
+                    "skill-center": {
+                        "type": "oss",
+                        "bucket": "bucket",
+                        "base": "skills-center",
+                    }
+                },
+            }
+        },
+    )
+    pages = _Pages(
+        [
+            BotPublishLineagePage(
+                records=(file_record,), next_cursor=1, complete=False
+            ),
+            BotPublishLineagePage(
+                records=(teclaw_record,), next_cursor=None, complete=True
+            ),
+        ]
+    )
+
+    reader: ServiceArtifactLineageReaderProtocol = ServiceArtifactLineageReader(pages)
+    result = reader.scan(skill_uuid=_UUID, env="test")
+
+    assert [(item.publish_id, item.sc_version_number) for item in result.references] == [
+        (1, "1.0.0"),
+        (2, "2.0.0"),
+    ]
+    assert result.unknown == ()
+    assert pages.calls == [None, 1]
+
+
+def test_reader_keeps_old_artifacts_compatible_and_ignores_draft_failed_audit_rows():
+    pages = _Pages(
+        [
+            BotPublishLineagePage(
+                records=(
+                    _record(1, ext={"migration_path": "/legacy/v1"}),
+                    _record(2, status="draft", ext={"skills_manifest": "broken"}),
+                    _record(3, status="failed", ext={"config_artifact": "broken"}),
+                ),
+                next_cursor=None,
+                complete=True,
+            )
+        ]
+    )
+
+    result = ServiceArtifactLineageReader(pages).scan(skill_uuid=_UUID, env="test")
+
+    assert result.references == ()
+    assert result.unknown == ()
+
+
+def test_reader_fails_closed_for_corrupt_artifact_and_incomplete_pagination():
+    pages = _Pages(
+        [
+            BotPublishLineagePage(
+                records=(
+                    _record(
+                        7,
+                        ext={
+                            "config_artifact": {
+                                "schema_version": 4,
+                                "engine_type": "teclaw",
+                                "skills": [
+                                    {
+                                        "name": "bad",
+                                        "scope": "shared",
+                                        "store": "skill-center",
+                                        "path": "../latest",
+                                    }
+                                ],
+                                "stores": {},
+                            }
+                        },
+                    ),
+                ),
+                next_cursor=None,
+                complete=False,
+            )
+        ]
+    )
+
+    result = ServiceArtifactLineageReader(pages).scan(skill_uuid=_UUID, env="test")
+
+    assert result.references == ()
+    assert {item.resource_id for item in result.unknown} == {
+        "7",
+        "artifact-scan",
+    }

--- a/src/backend/tests/community/core/service_bot/services/test_service_artifact_lineage_reader.py
+++ b/src/backend/tests/community/core/service_bot/services/test_service_artifact_lineage_reader.py
@@ -141,14 +141,18 @@ def test_reader_finds_file_and_teclaw_exact_refs_across_complete_pages():
     assert pages.calls == [None, 1]
 
 
-def test_reader_keeps_old_artifacts_compatible_and_ignores_draft_failed_audit_rows():
+def test_reader_keeps_old_artifacts_compatible_and_skips_non_replayable_rows():
     pages = _Pages(
         [
             BotPublishLineagePage(
                 records=(
                     _record(1, ext={"migration_path": "/legacy/v1"}),
                     _record(2, status="draft", ext={"skills_manifest": "broken"}),
-                    _record(3, status="failed", ext={"config_artifact": "broken"}),
+                    _record(
+                        3,
+                        status="failed",
+                        ext={"source_status": "building"},
+                    ),
                 ),
                 next_cursor=None,
                 complete=True,
@@ -160,6 +164,55 @@ def test_reader_keeps_old_artifacts_compatible_and_ignores_draft_failed_audit_ro
 
     assert result.references == ()
     assert result.unknown == ()
+
+
+def test_reader_blocks_failed_record_that_can_retry_frozen_artifact():
+    pages = _Pages(
+        [
+            BotPublishLineagePage(
+                records=(
+                    _record(
+                        4,
+                        status="failed",
+                        ext={
+                            "source_status": "success",
+                            "config_artifact": {
+                                "schema_version": 4,
+                                "engine_type": "teclaw",
+                                "skills": [
+                                    {
+                                        "name": "pdf",
+                                        "scope": "shared",
+                                        "store": "skill-center",
+                                        "path": f"{_UUID}/4.0.0",
+                                    }
+                                ],
+                                "stores": {
+                                    "skill-center": {
+                                        "type": "oss",
+                                        "bucket": "bucket",
+                                        "base": "skills-center",
+                                    }
+                                },
+                            },
+                        },
+                    ),
+                ),
+                next_cursor=None,
+                complete=True,
+            )
+        ]
+    )
+
+    result = ServiceArtifactLineageReader(pages).scan(
+        skill_uuid=_UUID,
+        env="test",
+    )
+
+    assert result.unknown == ()
+    assert [(item.publish_id, item.sc_version_number) for item in result.references] == [
+        (4, "4.0.0")
+    ]
 
 
 def test_reader_fails_closed_for_corrupt_artifact_and_incomplete_pagination():

--- a/src/backend/tests/community/core/skill_center/services/test_space_skill_offline_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_space_skill_offline_service.py
@@ -15,13 +15,22 @@ from agentclaw.community.api.service_artifact_lineage import (
     ServiceArtifactLineage,
     ServiceArtifactReference,
 )
+from agentclaw.community.core.service_bot.service_artifact_lineage_reader_protocol import (
+    UnknownServiceArtifact,
+)
 from agentclaw.community.core.repository.space_skill_offline_types import (
     OfflineCommit,
     OfflineInspection,
+    OfflineInstallationFact,
+    OfflineMembershipFact,
+    OfflinePublicationAttemptFact,
     OfflineSkillIdentity,
 )
 from agentclaw.community.core.skill_center.draft_content import DraftRevisionRef
-from agentclaw.community.core.skill_center.errors import SkillOfflineBlockedError
+from agentclaw.community.core.skill_center.errors import (
+    SkillOfflineBlockedError,
+    SpaceSkillGrantForbiddenError,
+)
 from agentclaw.community.core.skill_center.services.published_version_draft import (
     PreparedPublishedVersionDraft,
 )
@@ -51,12 +60,31 @@ def _identity(*, offline=False, draft=False):
     )
 
 
-def _service(*, inspection):
+def _inspection(
+    *,
+    identity=None,
+    space_bound=True,
+    actor_roles=("OWNER",),
+    publication_attempts=(),
+    memberships=(),
+    installations=(),
+):
+    return OfflineInspection(
+        identity=identity or _identity(),
+        space_bound=space_bound,
+        actor_roles=actor_roles,
+        publication_attempts=publication_attempts,
+        memberships=memberships,
+        installations=installations,
+    )
+
+
+def _service(*, inspection, lineage_result=None):
     access = MagicMock()
     repository = MagicMock()
     repository.inspect.return_value = inspection
     lineage = MagicMock()
-    lineage.scan.return_value = ServiceArtifactLineage((), ())
+    lineage.scan.return_value = lineage_result or ServiceArtifactLineage((), ())
     drafts = MagicMock()
     prepared = PreparedPublishedVersionDraft(
         expected_version_id=61,
@@ -89,22 +117,37 @@ def _service(*, inspection):
 
 
 def test_impact_counts_all_blocker_kinds_then_paginates_items():
-    blockers = tuple(
-        OfflineImpactItem(kind=kind, resource_id=str(index), display_name=kind.value)
-        for index, kind in enumerate(
-            (
-                OfflineBlockerKind.DRAFT,
-                OfflineBlockerKind.PUBLICATION,
-                OfflineBlockerKind.MEMBERSHIP,
-                OfflineBlockerKind.INSTALLATION,
-                OfflineBlockerKind.SERVICE_ARTIFACT,
-                OfflineBlockerKind.UNKNOWN_ARTIFACT,
+    inspection = _inspection(
+        identity=_identity(draft=True),
+        publication_attempts=(
+            OfflinePublicationAttemptFact(
+                id=2,
+                target_version_ordinal=3,
+                status="MATERIALIZING",
             ),
-            start=1,
-        )
+        ),
+        memberships=(OfflineMembershipFact(id=3, skill_set_name="Set"),),
+        installations=(OfflineInstallationFact(id=4, bot_id="Bot"),),
     )
     service, access, *_ = _service(
-        inspection=OfflineInspection(identity=_identity(), blockers=blockers)
+        inspection=inspection,
+        lineage_result=ServiceArtifactLineage(
+            references=(
+                ServiceArtifactReference(
+                    publish_id=5,
+                    source_bot_id="service-5",
+                    source_bot_name="Service",
+                    service_version=1,
+                    sc_version_number="2.0.0",
+                ),
+            ),
+            unknown=(
+                UnknownServiceArtifact(
+                    resource_id="6",
+                    display_name="Unknown artifact",
+                ),
+            ),
+        ),
     )
 
     impact = service.impact(
@@ -125,7 +168,7 @@ def test_impact_counts_all_blocker_kinds_then_paginates_items():
 
 def test_offline_prepares_exact_revision_then_commits_and_returns_vn_plus_one():
     service, _access, repository, _lineage, drafts, prepared = _service(
-        inspection=OfflineInspection(identity=_identity(), blockers=())
+        inspection=_inspection()
     )
 
     result = service.offline(space_id=7, skill_id=51, actor_id="owner-1")
@@ -150,7 +193,7 @@ def test_offline_prepares_exact_revision_then_commits_and_returns_vn_plus_one():
 
 def test_offline_idempotent_replay_does_not_prepare_another_revision():
     service, _access, repository, _lineage, drafts, _prepared = _service(
-        inspection=OfflineInspection(identity=_identity(offline=True, draft=True), blockers=())
+        inspection=_inspection(identity=_identity(offline=True, draft=True))
     )
 
     result = service.offline(space_id=7, skill_id=51, actor_id="owner-1")
@@ -163,7 +206,7 @@ def test_offline_idempotent_replay_does_not_prepare_another_revision():
 
 def test_concurrent_blocker_from_transaction_recheck_discards_prepared_revision():
     service, _access, repository, lineage, drafts, prepared = _service(
-        inspection=OfflineInspection(identity=_identity(), blockers=())
+        inspection=_inspection()
     )
     latest = OfflineImpactItem(
         kind=OfflineBlockerKind.SERVICE_ARTIFACT,
@@ -187,7 +230,7 @@ def test_concurrent_blocker_from_transaction_recheck_discards_prepared_revision(
     ]
 
     def _commit(**kwargs):
-        kwargs["guard"](OfflineInspection(identity=_identity(), blockers=()))
+        kwargs["guard"](_inspection())
 
     repository.commit.side_effect = _commit
 
@@ -196,3 +239,25 @@ def test_concurrent_blocker_from_transaction_recheck_discards_prepared_revision(
 
     assert blocked.value.impact.items == (latest,)
     drafts.discard.assert_called_once_with(prepared)
+
+
+@pytest.mark.parametrize(
+    ("space_bound", "actor_roles"),
+    [(False, ("OWNER",)), (True, ()), (True, ("MEMBER",))],
+)
+def test_owner_manager_policy_is_enforced_by_service(
+    space_bound: bool, actor_roles: tuple[str, ...]
+) -> None:
+    service, _access, repository, lineage, drafts, _prepared = _service(
+        inspection=_inspection(
+            space_bound=space_bound,
+            actor_roles=actor_roles,
+        )
+    )
+
+    with pytest.raises(SpaceSkillGrantForbiddenError, match="owner or manager"):
+        service.offline(space_id=7, skill_id=51, actor_id="member")
+
+    repository.commit.assert_not_called()
+    lineage.scan.assert_not_called()
+    drafts.prepare.assert_not_called()

--- a/src/backend/tests/community/core/skill_center/services/test_space_skill_offline_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_space_skill_offline_service.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 from datetime import datetime
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 
 from agentclaw.community.api.space_skill_offline_service import (
     OfflineBlockerKind,
     OfflineImpactItem,
+)
+from agentclaw.community.api.service_artifact_lineage import (
+    ServiceArtifactLineage,
+    ServiceArtifactReference,
 )
 from agentclaw.community.core.repository.space_skill_offline_types import (
     OfflineCommit,
@@ -51,6 +55,8 @@ def _service(*, inspection):
     access = MagicMock()
     repository = MagicMock()
     repository.inspect.return_value = inspection
+    lineage = MagicMock()
+    lineage.scan.return_value = ServiceArtifactLineage((), ())
     drafts = MagicMock()
     prepared = PreparedPublishedVersionDraft(
         expected_version_id=61,
@@ -74,11 +80,12 @@ def _service(*, inspection):
     service = SpaceSkillOfflineService(
         access=access,
         repository=repository,
+        lineage=lineage,
         drafts=drafts,
         env_provider=lambda: "test",
         tenant_provider=lambda: "tenant-a",
     )
-    return service, access, repository, drafts, prepared
+    return service, access, repository, lineage, drafts, prepared
 
 
 def test_impact_counts_all_blocker_kinds_then_paginates_items():
@@ -117,7 +124,7 @@ def test_impact_counts_all_blocker_kinds_then_paginates_items():
 
 
 def test_offline_prepares_exact_revision_then_commits_and_returns_vn_plus_one():
-    service, _access, repository, drafts, prepared = _service(
+    service, _access, repository, _lineage, drafts, prepared = _service(
         inspection=OfflineInspection(identity=_identity(), blockers=())
     )
 
@@ -137,11 +144,12 @@ def test_offline_prepares_exact_revision_then_commits_and_returns_vn_plus_one():
         new_locator=prepared.ref.locator,
         new_description="published",
         env="test",
+        guard=ANY,
     )
 
 
 def test_offline_idempotent_replay_does_not_prepare_another_revision():
-    service, _access, repository, drafts, _prepared = _service(
+    service, _access, repository, _lineage, drafts, _prepared = _service(
         inspection=OfflineInspection(identity=_identity(offline=True, draft=True), blockers=())
     )
 
@@ -154,21 +162,34 @@ def test_offline_idempotent_replay_does_not_prepare_another_revision():
 
 
 def test_concurrent_blocker_from_transaction_recheck_discards_prepared_revision():
-    service, _access, repository, drafts, prepared = _service(
+    service, _access, repository, lineage, drafts, prepared = _service(
         inspection=OfflineInspection(identity=_identity(), blockers=())
     )
     latest = OfflineImpactItem(
         kind=OfflineBlockerKind.SERVICE_ARTIFACT,
         resource_id="88",
-        display_name="Service 88 V4",
+        display_name="Service 88 V4 (Skill 2.0.0)",
     )
-    repository.commit.side_effect = SkillOfflineBlockedError(
-        service._impact(
-            OfflineInspection(identity=_identity(), blockers=(latest,)),
-            page=1,
-            page_size=20,
+    lineage.scan.side_effect = [
+        ServiceArtifactLineage((), ()),
+        ServiceArtifactLineage(
+            (
+                ServiceArtifactReference(
+                    publish_id=88,
+                    source_bot_id="service-88",
+                    source_bot_name="Service 88",
+                    service_version=4,
+                    sc_version_number="2.0.0",
+                ),
+            ),
+            (),
         )
-    )
+    ]
+
+    def _commit(**kwargs):
+        kwargs["guard"](OfflineInspection(identity=_identity(), blockers=()))
+
+    repository.commit.side_effect = _commit
 
     with pytest.raises(SkillOfflineBlockedError) as blocked:
         service.offline(space_id=7, skill_id=51, actor_id="owner-1")

--- a/src/backend/tests/community/core/skill_center/services/test_space_skill_offline_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_space_skill_offline_service.py
@@ -1,0 +1,177 @@
+"""Behavior tests for impact, Offline and transaction-race compensation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentclaw.community.api.space_skill_offline_service import (
+    OfflineBlockerKind,
+    OfflineImpactItem,
+)
+from agentclaw.community.core.repository.space_skill_offline_types import (
+    OfflineCommit,
+    OfflineInspection,
+    OfflineSkillIdentity,
+)
+from agentclaw.community.core.skill_center.draft_content import DraftRevisionRef
+from agentclaw.community.core.skill_center.errors import SkillOfflineBlockedError
+from agentclaw.community.core.skill_center.services.published_version_draft import (
+    PreparedPublishedVersionDraft,
+)
+from agentclaw.community.core.skill_center.services.space_skill_offline_service import (
+    SpaceSkillOfflineService,
+)
+
+
+_UUID = "11111111-1111-4111-8111-111111111111"
+_EXISTING_REV = "22222222-2222-4222-8222-222222222222"
+_NEW_REV = "33333333-3333-4333-8333-333333333333"
+
+
+def _identity(*, offline=False, draft=False):
+    return OfflineSkillIdentity(
+        skill_id=51,
+        skill_uuid=_UUID,
+        name="draft-skill",
+        sc_team_id=91,
+        latest_version_id=61,
+        latest_version_ordinal=2,
+        sc_version_number="2.0.0",
+        offline_at=datetime(2026, 8, 30) if offline else None,
+        draft_target_version=3 if draft else None,
+        draft_status="EDITING" if draft else None,
+        draft_locator=(f"draft://{_UUID}/v3/{_EXISTING_REV}" if draft else None),
+    )
+
+
+def _service(*, inspection):
+    access = MagicMock()
+    repository = MagicMock()
+    repository.inspect.return_value = inspection
+    drafts = MagicMock()
+    prepared = PreparedPublishedVersionDraft(
+        expected_version_id=61,
+        target_version=3,
+        description="published",
+        ref=DraftRevisionRef(
+            tenant="tenant-a",
+            env="test",
+            skill_uuid=_UUID,
+            target_version=3,
+            revision_id=_NEW_REV,
+        ),
+    )
+    drafts.prepare.return_value = prepared
+    repository.commit.return_value = OfflineCommit(
+        changed=True,
+        target_version=3,
+        status="EDITING",
+        locator=prepared.ref.locator,
+    )
+    service = SpaceSkillOfflineService(
+        access=access,
+        repository=repository,
+        drafts=drafts,
+        env_provider=lambda: "test",
+        tenant_provider=lambda: "tenant-a",
+    )
+    return service, access, repository, drafts, prepared
+
+
+def test_impact_counts_all_blocker_kinds_then_paginates_items():
+    blockers = tuple(
+        OfflineImpactItem(kind=kind, resource_id=str(index), display_name=kind.value)
+        for index, kind in enumerate(
+            (
+                OfflineBlockerKind.DRAFT,
+                OfflineBlockerKind.PUBLICATION,
+                OfflineBlockerKind.MEMBERSHIP,
+                OfflineBlockerKind.INSTALLATION,
+                OfflineBlockerKind.SERVICE_ARTIFACT,
+                OfflineBlockerKind.UNKNOWN_ARTIFACT,
+            ),
+            start=1,
+        )
+    )
+    service, access, *_ = _service(
+        inspection=OfflineInspection(identity=_identity(), blockers=blockers)
+    )
+
+    impact = service.impact(
+        space_id=7, skill_id=51, actor_id="owner-1", page=2, page_size=2
+    )
+
+    assert impact.blocked is True
+    assert impact.total == 6
+    assert impact.counts == {kind.value: 1 for kind in OfflineBlockerKind}
+    assert [item.kind for item in impact.items] == [
+        OfflineBlockerKind.MEMBERSHIP,
+        OfflineBlockerKind.INSTALLATION,
+    ]
+    access.require_space_member.assert_called_once_with(
+        space_id=7, user_id="owner-1"
+    )
+
+
+def test_offline_prepares_exact_revision_then_commits_and_returns_vn_plus_one():
+    service, _access, repository, drafts, prepared = _service(
+        inspection=OfflineInspection(identity=_identity(), blockers=())
+    )
+
+    result = service.offline(space_id=7, skill_id=51, actor_id="owner-1")
+
+    assert result.changed is True
+    assert result.lifecycle_status == "OFFLINE"
+    assert result.draft.target_version == 3
+    assert result.draft.revision_id == _NEW_REV
+    drafts.prepare.assert_called_once()
+    repository.commit.assert_called_once_with(
+        space_id=7,
+        skill_id=51,
+        actor_id="owner-1",
+        expected_version_id=61,
+        target_version=3,
+        new_locator=prepared.ref.locator,
+        new_description="published",
+        env="test",
+    )
+
+
+def test_offline_idempotent_replay_does_not_prepare_another_revision():
+    service, _access, repository, drafts, _prepared = _service(
+        inspection=OfflineInspection(identity=_identity(offline=True, draft=True), blockers=())
+    )
+
+    result = service.offline(space_id=7, skill_id=51, actor_id="owner-1")
+
+    assert result.changed is False
+    assert result.draft.revision_id == _EXISTING_REV
+    drafts.prepare.assert_not_called()
+    repository.commit.assert_not_called()
+
+
+def test_concurrent_blocker_from_transaction_recheck_discards_prepared_revision():
+    service, _access, repository, drafts, prepared = _service(
+        inspection=OfflineInspection(identity=_identity(), blockers=())
+    )
+    latest = OfflineImpactItem(
+        kind=OfflineBlockerKind.SERVICE_ARTIFACT,
+        resource_id="88",
+        display_name="Service 88 V4",
+    )
+    repository.commit.side_effect = SkillOfflineBlockedError(
+        service._impact(
+            OfflineInspection(identity=_identity(), blockers=(latest,)),
+            page=1,
+            page_size=20,
+        )
+    )
+
+    with pytest.raises(SkillOfflineBlockedError) as blocked:
+        service.offline(space_id=7, skill_id=51, actor_id="owner-1")
+
+    assert blocked.value.impact.items == (latest,)
+    drafts.discard.assert_called_once_with(prepared)

--- a/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
@@ -419,6 +419,7 @@ def test_offline_vn_plus_one_recovers_through_unified_materializer() -> None:
             SkillVersion(
                 id=102,
                 skill_id=skill_id,
+                publication_attempt_id=701,
                 version_ordinal=3,
                 status="MATERIALIZING",
                 sc_version_number="3.0.0",

--- a/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
@@ -223,6 +223,7 @@ def test_exact_package_becomes_published_only_after_all_ready_inputs_exist() -> 
         (_package(name="different-name"), _Scanner()),
         (_package(), _Scanner(fail=True)),
     ],
+    ids=("name-mismatch", "scanner-failure"),
 )
 def test_validation_or_scanner_failure_never_publishes(
     package: bytes, scanner: _Scanner

--- a/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
@@ -6,10 +6,30 @@ import hashlib
 import io
 import json
 import zipfile
+from contextlib import contextmanager
 from datetime import UTC, datetime
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
+from agentclaw.community.core.base import Base
+from agentclaw.community.core.models.skill import Skill
+from agentclaw.community.core.models.space_skill import (
+    SkillGrant,
+    SkillSpaceBinding,
+    SkillVersion,
+)
+from agentclaw.community.core.repository.implementations.skill_center.skill_version import (
+    SkillVersionRepository,
+)
+from agentclaw.community.core.repository.implementations.skill_center.space_skill_offline import (
+    SpaceSkillOfflineRepository,
+)
+from agentclaw.community.core.service_bot.service_artifact_lineage_reader_protocol import (
+    ServiceArtifactLineage,
+)
+from agentclaw.community.core.skill_center.draft_content import DraftRevisionRef
 from agentclaw.community.core.skill_center.materialization_contract import (
     MaterializingSkillVersion,
     PublishedMaterializedSkillVersion,
@@ -22,11 +42,18 @@ from agentclaw.community.core.skill_center.services.skill_version_materializer i
     SdkSkillVersionScanner,
     SkillVersionMaterializer,
 )
+from agentclaw.community.core.skill_center.services.published_version_draft import (
+    PreparedPublishedVersionDraft,
+)
+from agentclaw.community.core.skill_center.services.space_skill_offline_service import (
+    SpaceSkillOfflineService,
+)
 from agentclaw.community.core.skill_center.skill_package import SkillPackageValidator
 from agentclaw.community.plugin_api.skill_center_gateway import (
     SkillCenterExactDownload,
     SkillCenterReadScope,
 )
+from agentclaw.community.core.spaces.repository.models import SpaceModel
 from agentclaw.community.testing.canonical_center_store import (
     LocalCanonicalCenterVersionStore,
 )
@@ -257,3 +284,178 @@ def test_sdk_scanner_unavailable_fails_closed() -> None:
 
     with pytest.raises(SkillVersionMaterializationError, match="unavailable"):
         SdkSkillVersionScanner(_Plugin()).scan(package)
+
+
+class _RecoveryDatabase:
+    def __init__(self) -> None:
+        self.engine = create_engine("sqlite://")
+        Base.metadata.create_all(self.engine)
+        self._factory = sessionmaker(bind=self.engine)
+
+    @contextmanager
+    def orm_session(self):
+        session = self._factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    transactional_orm_session = orm_session
+
+
+class _RecoveryAccess:
+    def require_space_member(self, **_kwargs) -> None:
+        return None
+
+
+class _RecoveryLineage:
+    def scan(self, **_kwargs) -> ServiceArtifactLineage:
+        return ServiceArtifactLineage((), ())
+
+
+class _RecoveryDrafts:
+    def __init__(self, *, skill_uuid: str) -> None:
+        self.skill_uuid = skill_uuid
+
+    def prepare(self, *, identity, latest) -> PreparedPublishedVersionDraft:
+        assert identity["skill_uuid"] == self.skill_uuid
+        return PreparedPublishedVersionDraft(
+            expected_version_id=int(latest["id"]),
+            target_version=int(latest["version_ordinal"]) + 1,
+            description="old",
+            ref=DraftRevisionRef(
+                tenant="teamclaw",
+                env="pre",
+                skill_uuid=self.skill_uuid,
+                target_version=3,
+                revision_id="33333333-3333-4333-8333-333333333333",
+            ),
+        )
+
+    def discard(self, _prepared) -> None:
+        raise AssertionError("successful Offline must retain the Draft revision")
+
+
+def test_offline_vn_plus_one_recovers_through_unified_materializer() -> None:
+    db = _RecoveryDatabase()
+    skill_uuid = "00000000-0000-4000-8000-000000000010"
+    with db.orm_session() as session:
+        space = SpaceModel(
+            space_code="materializer-recovery",
+            space_type="TEAM",
+            name="Recovery",
+            created_by="owner",
+            updated_by="owner",
+            env="pre",
+        )
+        skill = Skill(
+            name="weather",
+            git_path=f"center://{skill_uuid}",
+            skill_uuid=skill_uuid,
+            status="PUBLISHED",
+            env="pre",
+        )
+        session.add_all((space, skill))
+        session.flush()
+        skill_id = int(skill.id)
+        session.add_all(
+            (
+                SkillSpaceBinding(
+                    skill_id=skill_id,
+                    space_id=int(space.id),
+                    created_by="owner",
+                    env="pre",
+                ),
+                SkillGrant(
+                    skill_id=skill_id,
+                    user_id="owner",
+                    role="OWNER",
+                    status="ACTIVE",
+                    owner_slot=1,
+                    granted_by="owner",
+                    env="pre",
+                ),
+                SkillVersion(
+                    id=101,
+                    skill_id=skill_id,
+                    version_ordinal=2,
+                    status="PUBLISHED",
+                    sc_version_number="2.0.0",
+                    sc_skill_id=1010,
+                    sc_version_id=2101,
+                    name="weather",
+                    description="old",
+                    metadata_json='{"mcp_dependencies": []}',
+                    published_at=datetime(2026, 8, 29, tzinfo=UTC),
+                    created_by="owner",
+                    env="pre",
+                ),
+            )
+        )
+        space_id = int(space.id)
+
+    offline = SpaceSkillOfflineService(
+        access=_RecoveryAccess(),
+        repository=SpaceSkillOfflineRepository(db),
+        lineage=_RecoveryLineage(),
+        drafts=_RecoveryDrafts(skill_uuid=skill_uuid),
+        env_provider=lambda: "pre",
+        tenant_provider=lambda: "teamclaw",
+    )
+    committed = offline.offline(
+        space_id=space_id,
+        skill_id=skill_id,
+        actor_id="owner",
+    )
+    assert committed.draft.target_version == 3
+    with db.orm_session() as session:
+        persisted = session.query(Skill).filter_by(id=skill_id).one()
+        assert persisted.offline_at is not None
+        session.add(
+            SkillVersion(
+                id=102,
+                skill_id=skill_id,
+                version_ordinal=3,
+                status="MATERIALIZING",
+                sc_version_number="3.0.0",
+                sc_skill_id=1010,
+                sc_version_id=2102,
+                name="weather",
+                created_by="owner",
+                env="pre",
+            )
+        )
+
+    package = _package()
+    published = SkillVersionMaterializer(
+        versions=SkillVersionRepository(db),
+        gateway=_Gateway(package),
+        http=_Http(package),
+        validator=SkillPackageValidator(SkillParser()),
+        scanner=_Scanner(),
+        store=LocalCanonicalCenterVersionStore(),
+        clock=lambda: datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
+    ).materialize(
+        SkillVersionMaterializationRequest(
+            env="pre",
+            skill_id=skill_id,
+            skill_version_id=102,
+            scope=SkillCenterReadScope.TEAM,
+            team_id="91",
+        )
+    )
+
+    assert published.status == "PUBLISHED"
+    assert published.version_ordinal == 3
+    with db.orm_session() as session:
+        recovered = session.query(Skill).filter_by(id=skill_id).one()
+        assert recovered.offline_at is None
+        assert recovered.offline_by is None
+        assert (
+            session.query(SkillVersion).filter_by(id=101).one().status
+            == "PUBLISHED"
+        )

--- a/src/backend/tests/community/endpoints/test_spaces_router.py
+++ b/src/backend/tests/community/endpoints/test_spaces_router.py
@@ -39,6 +39,12 @@ from agentclaw.community.api.space_skill_grant_service import (
 from agentclaw.community.api.space_skill_editor_request_service import (
     SpaceSkillEditorRequestServiceProtocol,
 )
+from agentclaw.community.api.space_skill_offline_service import (
+    OfflineDraft,
+    OfflineImpact,
+    SpaceSkillOfflineResult,
+    SpaceSkillOfflineServiceProtocol,
+)
 from agentclaw.community.api.draft_edit_lease_service import (
     DraftEditLeaseServiceProtocol,
 )
@@ -364,6 +370,31 @@ def _seed_space_skill_version_reads(world) -> None:
     )
 
 
+def _seed_space_skill_offline(world) -> None:
+    _enable_public_auth(world)
+    bind_overrides(
+        world,
+        SpaceSkillOfflineServiceProtocol,
+        {
+            "impact": lambda _self, **_kwargs: OfflineImpact(
+                blocked=False,
+                total=0,
+                counts={},
+                items=(),
+            ),
+            "offline": lambda _self, **_kwargs: SpaceSkillOfflineResult(
+                changed=True,
+                lifecycle_status="OFFLINE",
+                draft=OfflineDraft(
+                    target_version=3,
+                    status="EDITING",
+                    revision_id="33333333-3333-4333-8333-333333333333",
+                ),
+            ),
+        },
+    )
+
+
 def _without_principal(case: CaseInput) -> CaseInput:
     return CaseInput(
         path_params=case.path_params,
@@ -381,6 +412,28 @@ def _without_principal(case: CaseInput) -> CaseInput:
 
 
 _SPACE_SKILL_LOOP_CASES = (
+    (
+        "GET",
+        "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline-impact",
+        _seed_space_skill_offline,
+        CaseInput(
+            path_params={"space_id": 1, "skill_id": 51},
+            query_params={"user_id": _USER_ID},
+            headers=_principal_headers(),
+        ),
+        200,
+    ),
+    (
+        "POST",
+        "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline",
+        _seed_space_skill_offline,
+        CaseInput(
+            path_params={"space_id": 1, "skill_id": 51},
+            query_params={"user_id": _USER_ID},
+            headers=_principal_headers(),
+        ),
+        200,
+    ),
     (
         "DELETE",
         "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/draft",

--- a/src/backend/tests/community/repository/publishing/test_bot_publish_unified.py
+++ b/src/backend/tests/community/repository/publishing/test_bot_publish_unified.py
@@ -7,11 +7,15 @@ optimistic-lock UPDATEs (wrong source-status → None, no row touched),
 and single hard DELETE.
 """
 from contextlib import contextmanager
+from datetime import datetime
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from agentclaw.community.core.base import Base
+from agentclaw.community.core.models.skill import Skill
+from agentclaw.community.core.skill_center.errors import SkillOfflineError
 from agentclaw.community.core.service_bot.repository.models import (
     BotPublishModel,
     PublishStatus,
@@ -22,7 +26,11 @@ from agentclaw.community.core.service_bot.repository.config_artifact_offload imp
     ARTIFACT_OSS_THRESHOLD_BYTES,
     ConfigArtifactOffloader,
 )
+from agentclaw.community.core.service_bot.services.service_artifact_lineage_reader import (
+    ServiceArtifactLineageReader,
+)
 from agentclaw.community.core.repository.implementations.publishing.bot_publish import BotPublishRepository
+from agentclaw.community.plugin_api.models import BotModel
 
 pytestmark = pytest.mark.integration
 
@@ -79,6 +87,45 @@ def _data(**overrides):
     )
     base.update(overrides)
     return base
+
+
+def _full_repo(tmp_path, oss=None):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'bp-full.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    return BotPublishRepository(
+        _FileSqliteDB(engine),
+        offload=ConfigArtifactOffloader(oss or _FakeOSS()),
+    )
+
+
+def _seed_service_bot_and_skill(repo, *, deleted=False, offline=False):
+    with repo._db.orm_session() as session:
+        bot = BotModel(
+            bot_id="src-bot",
+            bot_name="Service",
+            entity_id="emp001",
+            entity_type="staff",
+            creator_id="emp001",
+            owner_id="emp001",
+            active_engine="teclaw",
+            status="ACTIVE",
+            is_delete=1 if deleted else 0,
+            env="dev",
+            bot_type="service",
+        )
+        skill = Skill(
+            name="center",
+            git_path="center://center",
+            skill_uuid="11111111-1111-4111-8111-111111111111",
+            offline_at=(datetime(2026, 8, 30) if offline else None),
+            env="dev",
+        )
+        session.add_all((bot, skill))
+        session.flush()
+        return int(bot.id), str(skill.skill_uuid)
 
 
 # ── insert (plain INSERT — no upsert) ───────────────────────────────
@@ -598,6 +645,129 @@ def test_delete_tolerates_sweep_failure(tmp_path):
     # Sweep raises inside delete → swallowed → DB delete still reports success.
     assert repo.delete(rec.id) is True
     assert repo.get_by_id(rec.id) is None
+
+
+def test_built_artifact_commit_refuses_skill_that_offline_won_first(tmp_path):
+    repo = _full_repo(tmp_path)
+    bot_pk, skill_uuid = _seed_service_bot_and_skill(repo, offline=True)
+    record = repo.insert(
+        _data(
+            source_bot_pk=bot_pk,
+            status=PublishStatus.BUILDING.value,
+            ext={"building": True},
+        )
+    )
+
+    with pytest.raises(SkillOfflineError, match="SKILL_OFFLINE"):
+        repo.compare_and_set_built_with_ext(
+            publish_id=record.id,
+            source_status=PublishStatus.BUILDING.value,
+            target_status=PublishStatus.BUILT.value,
+            expected_ext={"building": True},
+            ext={"skills_manifest": {"schema_version": 1}},
+            center_skill_uuids=(skill_uuid,),
+            env="dev",
+        )
+
+    persisted = repo.get_by_id(record.id)
+    assert persisted.status == PublishStatus.BUILDING.value
+    assert persisted.ext == {"building": True}
+
+
+def test_lineage_page_is_stable_complete_reinlined_and_excludes_deleted_bot(tmp_path):
+    oss = _FakeOSS()
+    repo = _full_repo(tmp_path, oss)
+    live_pk, _ = _seed_service_bot_and_skill(repo)
+    with repo._db.orm_session() as session:
+        deleted = BotModel(
+            bot_id="deleted-bot",
+            bot_name="Deleted",
+            entity_id="emp002",
+            entity_type="staff",
+            creator_id="emp002",
+            owner_id="emp002",
+            active_engine="teclaw",
+            status="ACTIVE",
+            is_delete=1,
+            env="dev",
+            bot_type="service",
+        )
+        session.add(deleted)
+        session.flush()
+        deleted_pk = int(deleted.id)
+    live = repo.insert(
+        _data(
+            source_bot_pk=live_pk,
+            status=PublishStatus.SUCCESS.value,
+            ext={"config_artifact": _big_artifact()},
+        )
+    )
+    repo.insert(
+        _data(
+            source_bot_pk=deleted_pk,
+            source_bot_id="deleted-bot",
+            publish_bot_id="deleted-bot.pub.1",
+            status=PublishStatus.SUCCESS.value,
+            ext={"config_artifact": _big_artifact()},
+        )
+    )
+
+    page = repo.list_lineage_candidates_page(env="dev", after_id=None, limit=1)
+
+    assert page.complete is True
+    assert page.next_cursor is None
+    assert [record.id for record in page.records] == [live.id]
+    assert page.records[0].ext["config_artifact"] == _big_artifact()
+
+
+def test_lineage_reader_resolves_exact_ref_from_offloaded_artifact(tmp_path):
+    oss = _FakeOSS()
+    repo = _full_repo(tmp_path, oss)
+    bot_pk, skill_uuid = _seed_service_bot_and_skill(repo)
+    artifact = {
+        "schema_version": 4,
+        "engine_type": "teclaw",
+        "skills": [
+            {
+                "name": "center",
+                "scope": "shared",
+                "store": "skill-center",
+                "path": f"{skill_uuid}/3.2.1",
+            }
+        ],
+        "stores": {
+            "skill-center": {
+                "type": "oss",
+                "bucket": "skills",
+                "base": "skill-center",
+            }
+        },
+        "engine_ext": {
+            "padding": "x" * (ARTIFACT_OSS_THRESHOLD_BYTES + 2048)
+        },
+    }
+    record = repo.insert(
+        _data(
+            source_bot_pk=bot_pk,
+            status=PublishStatus.SUCCESS.value,
+            ext={"config_artifact": artifact},
+        )
+    )
+
+    raw = _raw_ext(repo, record.id)
+    assert ARTIFACT_KEY not in raw
+    assert ARTIFACT_OSS_MARKER in raw
+
+    lineage = ServiceArtifactLineageReader(repo).scan(
+        skill_uuid=skill_uuid,
+        env="dev",
+    )
+
+    assert lineage.unknown == ()
+    assert [
+        (item.publish_id, item.sc_version_number)
+        for item in lineage.references
+    ] == [(record.id, "3.2.1")]
 
 
 def _artifact_of_json_size(nbytes):

--- a/src/backend/tests/community/repository/publishing/test_bot_publish_unified.py
+++ b/src/backend/tests/community/repository/publishing/test_bot_publish_unified.py
@@ -8,9 +8,10 @@ and single hard DELETE.
 """
 from contextlib import contextmanager
 from datetime import datetime
+from threading import Event, Thread, current_thread
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event as sqlalchemy_event
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.base import Base
@@ -672,6 +673,82 @@ def test_built_artifact_commit_refuses_skill_that_offline_won_first(tmp_path):
     persisted = repo.get_by_id(record.id)
     assert persisted.status == PublishStatus.BUILDING.value
     assert persisted.ext == {"building": True}
+
+
+def test_artifact_commit_waits_for_concurrent_offline_and_then_fails(tmp_path):
+    offline_holds_transaction = Event()
+    artifact_entered_transaction = Event()
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'artifact-offline-race.db'}",
+        connect_args={"check_same_thread": False, "timeout": 5},
+    )
+
+    @sqlalchemy_event.listens_for(engine, "connect")
+    def _manual_transactions(dbapi_connection, _connection_record):
+        dbapi_connection.isolation_level = None
+
+    @sqlalchemy_event.listens_for(engine, "begin")
+    def _begin_immediate(connection):
+        if current_thread().name == "artifact-commit":
+            artifact_entered_transaction.set()
+        connection.exec_driver_sql("BEGIN IMMEDIATE")
+
+    Base.metadata.create_all(engine)
+    db = _FileSqliteDB(engine)
+    repo = BotPublishRepository(
+        db,
+        offload=ConfigArtifactOffloader(_FakeOSS()),
+    )
+    bot_pk, skill_uuid = _seed_service_bot_and_skill(repo)
+    record = repo.insert(
+        _data(
+            source_bot_pk=bot_pk,
+            status=PublishStatus.BUILDING.value,
+            ext={"building": True},
+        )
+    )
+    errors: list[Exception] = []
+
+    def _offline_winner():
+        with db.orm_session() as session:
+            skill = (
+                session.query(Skill)
+                .filter(Skill.skill_uuid == skill_uuid)
+                .with_for_update()
+                .one()
+            )
+            skill.offline_at = datetime(2026, 8, 30, 12, 0)
+            skill.offline_by = "owner"
+            offline_holds_transaction.set()
+            assert artifact_entered_transaction.wait(timeout=2)
+
+    def _artifact_loser():
+        assert offline_holds_transaction.wait(timeout=2)
+        try:
+            repo.compare_and_set_built_with_ext(
+                publish_id=record.id,
+                source_status=PublishStatus.BUILDING.value,
+                target_status=PublishStatus.BUILT.value,
+                expected_ext={"building": True},
+                ext={"skills_manifest": {"schema_version": 1}},
+                center_skill_uuids=(skill_uuid,),
+                env="dev",
+            )
+        except Exception as exc:  # captured for the parent test thread
+            errors.append(exc)
+
+    offline_thread = Thread(target=_offline_winner, name="offline-command")
+    artifact_thread = Thread(target=_artifact_loser, name="artifact-commit")
+    offline_thread.start()
+    artifact_thread.start()
+    offline_thread.join(timeout=5)
+    artifact_thread.join(timeout=5)
+
+    assert not offline_thread.is_alive()
+    assert not artifact_thread.is_alive()
+    assert len(errors) == 1
+    assert isinstance(errors[0], SkillOfflineError)
+    assert repo.get_by_id(record.id).status == PublishStatus.BUILDING.value
 
 
 def test_lineage_page_is_stable_complete_reinlined_and_excludes_deleted_bot(tmp_path):

--- a/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -29,6 +30,7 @@ from agentclaw.community.core.repository.implementations.skill_center.capability
     CapabilityDesiredStateRepository,
 )
 from agentclaw.community.core.skill_center.errors import (
+    SkillOfflineError,
     SkillRuntimeNameConflictError,
     SkillSetControlPlaneConflictError,
     SkillSetControlPlaneNotFoundError,
@@ -2343,6 +2345,49 @@ def test_unexclusion_restores_the_installation_row_in_one_command():
     assert not repository.unexclude_default_skill(
         set_id=str(default.id), skill_id=str(skill.id), **_DEFAULT_SCOPE
     ).changed
+
+
+def test_offline_skill_rejects_membership_direct_and_default_restore_before_writes():
+    db = _Database()
+    repository = CapabilityDesiredStateRepository(db)
+    default, skill = _seed_default_with_member(db)
+    repository.exclude_default_skill(
+        set_id=str(default.id), skill_id=str(skill.id), **_DEFAULT_SCOPE
+    )
+    with db.transactional_orm_session() as session:
+        row = session.query(Skill).filter_by(id=skill.id).one()
+        row.offline_at = datetime(2026, 8, 30)
+        ordinary = SkillSet(
+            name="ordinary",
+            user_id="owner",
+            bolt_id="bot",
+            is_active=True,
+            env="dev",
+        )
+        session.add(ordinary)
+        session.flush()
+        ordinary_id = ordinary.id
+
+    with pytest.raises(SkillOfflineError, match="SKILL_OFFLINE"):
+        repository.add_skill(
+            bot_id="bot",
+            owner_id="owner",
+            set_id=str(ordinary_id),
+            skill_id=str(skill.id),
+        )
+    with pytest.raises(SkillOfflineError, match="SKILL_OFFLINE"):
+        repository.install_skill(
+            bot_id="bot", owner_id="owner", skill_id=str(skill.id)
+        )
+    with pytest.raises(SkillOfflineError, match="SKILL_OFFLINE"):
+        repository.unexclude_default_skill(
+            set_id=str(default.id), skill_id=str(skill.id), **_DEFAULT_SCOPE
+        )
+
+    with db.orm_session() as session:
+        assert session.query(SkillSetSkill).filter_by(skill_set_id=ordinary_id).count() == 0
+        assert session.query(BotSkillInstallation).count() == 0
+        assert session.query(DefaultSkillsetSkillExclusion).count() == 1
 
 
 def test_unexclusion_fails_closed_on_a_runtime_name_conflict():

--- a/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
@@ -2600,6 +2600,31 @@ def test_restore_desired_state_compensates_exclusion_commands():
     ).changed
 
 
+def test_compensation_cannot_restore_reference_after_offline_wins():
+    db = _Database()
+    repository = CapabilityDesiredStateRepository(db)
+    default, skill = _seed_default_with_member(db)
+    previous = repository.snapshot_desired_state(
+        bot_id="bot", owner_id="owner", engine_type="openclaw"
+    )
+    with db.transactional_orm_session() as session:
+        session.query(BotSkillInstallation).filter_by(skill_id=skill.id).delete()
+        persisted = session.query(Skill).filter_by(id=skill.id).one()
+        persisted.offline_at = datetime(2026, 8, 30, 12, 0)
+        persisted.offline_by = "owner"
+
+    with pytest.raises(SkillOfflineError, match="SKILL_OFFLINE"):
+        repository.restore_desired_state(
+            bot_id="bot",
+            owner_id="owner",
+            state=previous,
+            engine_type="openclaw",
+        )
+
+    with db.orm_session() as session:
+        assert session.query(BotSkillInstallation).count() == 0
+
+
 def test_excluding_a_stray_mcp_code_owns_neither_half():
     """The MCP twin of the skill never-member gate: no dangling row.
 

--- a/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
@@ -11,6 +11,7 @@ upsert (add_default_mcp_exclusion idempotent on
 uk_user_bot_skillset_mcp).
 """
 from contextlib import contextmanager
+from datetime import datetime
 
 import pytest
 from sqlalchemy import create_engine, event
@@ -18,7 +19,10 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.models import BotSkillInstallation, Skill, SkillSet, SkillSetSkill
-from agentclaw.community.core.skill_center.errors import ActiveSkillSetReferenceError
+from agentclaw.community.core.skill_center.errors import (
+    ActiveSkillSetReferenceError,
+    SkillOfflineError,
+)
 from agentclaw.community.core.models.mcp import SkillSetMCPServer
 from agentclaw.community.core.models.skill import AcSkillMember
 from agentclaw.community.plugin_api.models import BotModel
@@ -105,6 +109,22 @@ def test_skill_create_get_update_delete(skills):
     assert skills.delete(sid) is True
     assert skills.get_by_id(sid) is None  # hard delete
     assert skills.delete(sid) is False
+
+
+def test_legacy_add_refuses_offline_skill_before_membership_write(skills, sets, db):
+    skill = skills.create({"name": "offline", "git_path": "center://offline"})
+    skill_set = sets.create({"name": "set", "is_active": False})
+    with db.orm_session() as session:
+        session.query(Skill).filter_by(id=int(skill["id"])).update(
+            {Skill.offline_at: datetime(2026, 8, 30)},
+            synchronize_session=False,
+        )
+
+    with pytest.raises(SkillOfflineError, match="SKILL_OFFLINE"):
+        sets.add_skill_to_set(skill_set["id"], skill["id"])
+
+    with db.orm_session() as session:
+        assert session.query(SkillSetSkill).count() == 0
 
 
 def test_delete_removes_all_associations_for_active_and_inactive_local_skills(

--- a/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
@@ -11,7 +11,8 @@ from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.base import Base
 from agentclaw.community.core.models.skill import BotSkillInstallation, Skill
-from agentclaw.community.core.models.space_skill import SkillVersion
+from agentclaw.community.core.models.space_skill import SkillSpaceBinding, SkillVersion
+from agentclaw.community.core.spaces.repository.models import SpaceModel
 from agentclaw.community.core.repository.capability_desired_state_types import (
     InstallationFlushPlan,
 )
@@ -371,3 +372,117 @@ def test_materialization_publish_replay_requires_the_same_frozen_facts() -> None
             )
 
     assert replay.status == "PUBLISHED"
+
+
+def test_new_space_publication_clears_offline_but_published_replay_never_does() -> None:
+    db = _Database()
+    offline_at = datetime(2026, 8, 30, 10, 0)
+    with db.orm_session() as session:
+        space = SpaceModel(
+            space_code="space-publish",
+            space_type="TEAM",
+            name="Space",
+            created_by="owner",
+            updated_by="owner",
+            env="pre",
+        )
+        skill = Skill(
+            id=10,
+            name="weather",
+            git_path="center://space-weather",
+            skill_uuid="00000000-0000-4000-8000-000000000010",
+            offline_at=offline_at,
+            offline_by="owner",
+            env="pre",
+        )
+        session.add_all((space, skill))
+        session.flush()
+        session.add(
+            SkillSpaceBinding(
+                skill_id=10,
+                space_id=space.id,
+                created_by="owner",
+                env="pre",
+            )
+        )
+    _add_version(
+        db,
+        skill_id=10,
+        version_id=101,
+        ordinal=2,
+        status="MATERIALIZING",
+        number="2.0.0",
+    )
+    repo = SkillVersionRepository(db)
+
+    with avernet_tenant_scope("teamclaw"):
+        repo.publish_materialized(
+            env="pre",
+            skill_id=10,
+            skill_version_id=101,
+            metadata_json='{"mcp_dependencies":[]}',
+            description="online again",
+            published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
+        )
+    with db.orm_session() as session:
+        skill = session.get(Skill, 10)
+        assert skill is not None
+        assert skill.offline_at is None and skill.offline_by is None
+        skill.offline_at = offline_at
+        skill.offline_by = "owner"
+
+    with avernet_tenant_scope("teamclaw"):
+        repo.publish_materialized(
+            env="pre",
+            skill_id=10,
+            skill_version_id=101,
+            metadata_json='{"mcp_dependencies":[]}',
+            description="online again",
+            published_at=datetime(2026, 8, 30, 13, 0, tzinfo=UTC),
+        )
+    with db.orm_session() as session:
+        skill = session.get(Skill, 10)
+        assert skill is not None
+        assert skill.offline_at == offline_at
+        assert skill.offline_by == "owner"
+
+
+def test_sc_public_materialization_never_clears_offline_without_space_binding() -> None:
+    db = _Database()
+    offline_at = datetime(2026, 8, 30, 10, 0)
+    with db.orm_session() as session:
+        session.add(
+            Skill(
+                id=10,
+                name="weather",
+                git_path="center://public-weather",
+                skill_uuid="00000000-0000-4000-8000-000000000010",
+                offline_at=offline_at,
+                offline_by="owner",
+                env="pre",
+            )
+        )
+    _add_version(
+        db,
+        skill_id=10,
+        version_id=101,
+        ordinal=2,
+        status="MATERIALIZING",
+        number="2.0.0",
+    )
+
+    with avernet_tenant_scope("teamclaw"):
+        SkillVersionRepository(db).publish_materialized(
+            env="pre",
+            skill_id=10,
+            skill_version_id=101,
+            metadata_json='{"mcp_dependencies":[]}',
+            description="updated",
+            published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
+        )
+
+    with db.orm_session() as session:
+        skill = session.get(Skill, 10)
+        assert skill is not None
+        assert skill.offline_at == offline_at
+        assert skill.offline_by == "owner"

--- a/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from datetime import UTC, datetime
+from threading import Event, Lock, Thread
 
 import pytest
 from sqlalchemy import create_engine
@@ -21,6 +22,10 @@ from agentclaw.community.core.repository.implementations.skill_center.skill impo
 )
 from agentclaw.community.core.repository.implementations.skill_center.skill_version import (
     SkillVersionRepository,
+)
+from agentclaw.community.core.repository.implementations.skill_center.skill_version_lock import (
+    lock_skill_then_exact_version,
+    lock_skill_then_latest_published_version,
 )
 from agentclaw.community.core.skill_center.services.bot_capability_state_reader import (
     BotCapabilityStateReader,
@@ -82,13 +87,14 @@ def _add_version(
     ordinal: int,
     status: str,
     number: str,
+    publication_attempt_id: int | None = None,
 ) -> None:
     with avernet_tenant_scope(tenant), db.orm_session() as session:
         session.add(
             SkillVersion(
                 id=version_id,
                 skill_id=skill_id,
-                publication_attempt_id=None,
+                publication_attempt_id=publication_attempt_id,
                 version_ordinal=ordinal,
                 status=status,
                 sc_version_number=number,
@@ -412,6 +418,7 @@ def test_new_space_publication_clears_offline_but_published_replay_never_does() 
         ordinal=2,
         status="MATERIALIZING",
         number="2.0.0",
+        publication_attempt_id=501,
     )
     repo = SkillVersionRepository(db)
 
@@ -486,3 +493,167 @@ def test_sc_public_materialization_never_clears_offline_without_space_binding() 
         assert skill is not None
         assert skill.offline_at == offline_at
         assert skill.offline_by == "owner"
+
+
+def test_space_binding_without_publication_attempt_never_clears_offline() -> None:
+    db = _Database()
+    offline_at = datetime(2026, 8, 30, 10, 0)
+    with db.orm_session() as session:
+        space = SpaceModel(
+            space_code="space-null-attempt",
+            space_type="TEAM",
+            name="Space",
+            created_by="owner",
+            updated_by="owner",
+            env="pre",
+        )
+        skill = Skill(
+            id=10,
+            name="weather",
+            git_path="center://space-weather",
+            skill_uuid="00000000-0000-4000-8000-000000000010",
+            offline_at=offline_at,
+            offline_by="owner",
+            env="pre",
+        )
+        session.add_all((space, skill))
+        session.flush()
+        session.add(
+            SkillSpaceBinding(
+                skill_id=10,
+                space_id=space.id,
+                created_by="owner",
+                env="pre",
+            )
+        )
+    _add_version(
+        db,
+        skill_id=10,
+        version_id=101,
+        ordinal=2,
+        status="MATERIALIZING",
+        number="2.0.0",
+        publication_attempt_id=None,
+    )
+
+    with avernet_tenant_scope("teamclaw"):
+        SkillVersionRepository(db).publish_materialized(
+            env="pre",
+            skill_id=10,
+            skill_version_id=101,
+            metadata_json='{"mcp_dependencies":[]}',
+            description="updated",
+            published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
+        )
+
+    with db.orm_session() as session:
+        skill = session.get(Skill, 10)
+        assert skill is not None
+        assert skill.offline_at == offline_at
+        assert skill.offline_by == "owner"
+
+
+class _LockCoordinator:
+    """Model row locks used to expose overlapping lock acquisition intent."""
+
+    def __init__(self) -> None:
+        self.locks = {Skill: Lock(), SkillVersion: Lock()}
+        self.publisher_has_skill = Event()
+        self.offline_waits_for_skill = Event()
+        self.orders: dict[str, list[type]] = {"publish": [], "offline": []}
+
+
+class _LockQuery:
+    def __init__(self, session: "_LockSession", model: type) -> None:
+        self._session = session
+        self._model = model
+
+    def filter(self, *_criteria):
+        return self
+
+    def order_by(self, *_criteria):
+        return self
+
+    def with_for_update(self):
+        return self
+
+    def one_or_none(self):
+        return self._lock()
+
+    def first(self):
+        return self._lock()
+
+    def _lock(self):
+        coordinator = self._session.coordinator
+        if self._session.name == "offline" and self._model is Skill:
+            coordinator.offline_waits_for_skill.set()
+        lock = coordinator.locks[self._model]
+        lock.acquire()
+        self._session.held.append(lock)
+        coordinator.orders[self._session.name].append(self._model)
+        if self._session.name == "publish" and self._model is Skill:
+            coordinator.publisher_has_skill.set()
+            assert coordinator.offline_waits_for_skill.wait(timeout=2)
+        return Skill(id=10, env="pre") if self._model is Skill else SkillVersion(id=101)
+
+
+class _LockSession:
+    def __init__(self, coordinator: _LockCoordinator, name: str) -> None:
+        self.coordinator = coordinator
+        self.name = name
+        self.held: list[Lock] = []
+
+    def query(self, model: type) -> _LockQuery:
+        return _LockQuery(self, model)
+
+    def release(self) -> None:
+        for lock in reversed(self.held):
+            lock.release()
+        self.held.clear()
+
+
+def test_materialization_and_offline_overlap_use_skill_then_version_lock_order() -> None:
+    coordinator = _LockCoordinator()
+    failures: list[BaseException] = []
+
+    def _publish() -> None:
+        session = _LockSession(coordinator, "publish")
+        try:
+            lock_skill_then_exact_version(
+                session,
+                env="pre",
+                skill_id=10,
+                skill_version_id=101,
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+        finally:
+            session.release()
+
+    def _offline() -> None:
+        session = _LockSession(coordinator, "offline")
+        try:
+            lock_skill_then_latest_published_version(
+                session,
+                env="pre",
+                skill_id=10,
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+        finally:
+            session.release()
+
+    publisher = Thread(target=_publish)
+    publisher.start()
+    assert coordinator.publisher_has_skill.wait(timeout=2)
+    offliner = Thread(target=_offline)
+    offliner.start()
+    publisher.join(timeout=2)
+    offliner.join(timeout=2)
+
+    assert failures == []
+    assert not publisher.is_alive() and not offliner.is_alive()
+    assert coordinator.orders == {
+        "publish": [Skill, SkillVersion],
+        "offline": [Skill, SkillVersion],
+    }

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_offline_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_offline_repository.py
@@ -1,0 +1,260 @@
+"""Persistence tests for Offline blocker inventory and atomic commit."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from agentclaw.community.api.service_artifact_lineage import (
+    ServiceArtifactLineage,
+    ServiceArtifactReference,
+    UnknownServiceArtifact,
+)
+from agentclaw.community.api.space_skill_offline_service import OfflineBlockerKind
+from agentclaw.community.core.base import Base
+from agentclaw.community.core.models.skill import (
+    BotSkillInstallation,
+    Skill,
+    SkillSet,
+    SkillSetSkill,
+)
+from agentclaw.community.core.models.space_skill import (
+    SkillGrant,
+    SkillPublicationAttempt,
+    SkillSpaceBinding,
+    SkillVersion,
+)
+from agentclaw.community.core.repository.implementations.skill_center.space_skill_offline import (
+    SpaceSkillOfflineRepository,
+)
+from agentclaw.community.core.skill_center.errors import SkillOfflineBlockedError
+from agentclaw.community.core.spaces.repository.models import SpaceModel
+
+
+_UUID = "11111111-1111-4111-8111-111111111111"
+_REV = "22222222-2222-4222-8222-222222222222"
+
+
+class _Database:
+    def __init__(self) -> None:
+        self.engine = create_engine("sqlite://")
+        Base.metadata.create_all(self.engine)
+        self._factory = sessionmaker(bind=self.engine)
+
+    @contextmanager
+    def orm_session(self):
+        session = self._factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    transactional_orm_session = orm_session
+
+
+class _Lineage:
+    def __init__(self, *answers: ServiceArtifactLineage) -> None:
+        self.answers = list(answers) or [ServiceArtifactLineage((), ())]
+
+    def scan(self, *, skill_uuid, env):
+        assert skill_uuid == _UUID
+        assert env == "test"
+        if len(self.answers) > 1:
+            return self.answers.pop(0)
+        return self.answers[0]
+
+
+def _seed(db: _Database):
+    with db.orm_session() as session:
+        space = SpaceModel(
+            space_code="team-offline",
+            space_type="TEAM",
+            name="Offline Space",
+            created_by="owner-1",
+            updated_by="owner-1",
+            env="test",
+        )
+        session.add(space)
+        session.flush()
+        skill = Skill(
+            name="offline-skill",
+            description="published",
+            git_path=f"center://{_UUID}",
+            status="PUBLISHED",
+            env="test",
+            skill_uuid=_UUID,
+        )
+        session.add(skill)
+        session.flush()
+        session.add_all(
+            [
+                SkillSpaceBinding(
+                    skill_id=skill.id,
+                    space_id=space.id,
+                    created_by="owner-1",
+                    env="test",
+                ),
+                SkillGrant(
+                    skill_id=skill.id,
+                    user_id="owner-1",
+                    role="OWNER",
+                    status="ACTIVE",
+                    owner_slot=1,
+                    granted_by="owner-1",
+                    env="test",
+                ),
+                SkillVersion(
+                    skill_id=skill.id,
+                    version_ordinal=2,
+                    status="PUBLISHED",
+                    sc_version_number="2.0.0",
+                    name="offline-skill",
+                    description="published",
+                    created_by="owner-1",
+                    env="test",
+                ),
+            ]
+        )
+        return int(space.id), int(skill.id)
+
+
+def test_inspection_includes_inactive_membership_installation_attempt_and_unknown_artifact():
+    db = _Database()
+    space_id, skill_id = _seed(db)
+    with db.orm_session() as session:
+        skill_set = SkillSet(
+            name="Inactive Set",
+            user_id="owner-1",
+            bolt_id="service-a",
+            is_active=False,
+            is_default=False,
+            env="test",
+        )
+        session.add(skill_set)
+        session.flush()
+        session.add_all(
+            [
+                SkillSetSkill(
+                    skill_set_id=skill_set.id,
+                    skill_id=skill_id,
+                    env="test",
+                ),
+                BotSkillInstallation(
+                    bot_id="service-a",
+                    owner_id="owner-1",
+                    skill_id=skill_id,
+                    env="test",
+                ),
+                SkillPublicationAttempt(
+                    skill_id=skill_id,
+                    request_id="attempt-1",
+                    active_skill_key=f"test:{skill_id}",
+                    target_version_ordinal=3,
+                    status="RESULT_UNKNOWN",
+                    created_by="owner-1",
+                    env="test",
+                ),
+            ]
+        )
+    lineage = _Lineage(
+        ServiceArtifactLineage(
+            (),
+            (
+                UnknownServiceArtifact(
+                    resource_id="artifact-scan",
+                    display_name="scan incomplete",
+                ),
+            ),
+        )
+    )
+
+    inspection = SpaceSkillOfflineRepository(db, lineage).inspect(
+        space_id=space_id,
+        skill_id=skill_id,
+        actor_id="owner-1",
+        env="test",
+    )
+
+    assert [item.kind for item in inspection.blockers] == [
+        OfflineBlockerKind.PUBLICATION,
+        OfflineBlockerKind.MEMBERSHIP,
+        OfflineBlockerKind.INSTALLATION,
+        OfflineBlockerKind.UNKNOWN_ARTIFACT,
+    ]
+
+
+def test_offline_commit_preserves_published_version_and_creates_editing_vn_plus_one():
+    db = _Database()
+    space_id, skill_id = _seed(db)
+    repo = SpaceSkillOfflineRepository(db, _Lineage())
+    identity = repo.inspect(
+        space_id=space_id, skill_id=skill_id, actor_id="owner-1", env="test"
+    ).identity
+
+    result = repo.commit(
+        space_id=space_id,
+        skill_id=skill_id,
+        actor_id="owner-1",
+        expected_version_id=identity.latest_version_id,
+        target_version=3,
+        new_locator=f"draft://{_UUID}/v3/{_REV}",
+        new_description="published",
+        env="test",
+    )
+
+    assert result.changed is True
+    with db.orm_session() as session:
+        skill = session.query(Skill).filter_by(id=skill_id).one()
+        assert skill.status == "PUBLISHED"
+        assert skill.offline_at is not None
+        assert skill.offline_by == "owner-1"
+        assert skill.draft_target_version == 3
+        assert skill.draft_status == "EDITING"
+        assert session.query(SkillVersion).filter_by(skill_id=skill_id).count() == 1
+
+
+def test_artifact_inserted_after_preview_blocks_transactional_recheck():
+    db = _Database()
+    space_id, skill_id = _seed(db)
+    empty = ServiceArtifactLineage((), ())
+    new_artifact = ServiceArtifactLineage(
+        (
+            ServiceArtifactReference(
+                publish_id=88,
+                source_bot_id="service-a",
+                source_bot_name="Service A",
+                service_version=4,
+                sc_version_number="2.0.0",
+            ),
+        ),
+        (),
+    )
+    repo = SpaceSkillOfflineRepository(db, _Lineage(empty, new_artifact))
+    identity = repo.inspect(
+        space_id=space_id, skill_id=skill_id, actor_id="owner-1", env="test"
+    ).identity
+
+    with pytest.raises(SkillOfflineBlockedError) as blocked:
+        repo.commit(
+            space_id=space_id,
+            skill_id=skill_id,
+            actor_id="owner-1",
+            expected_version_id=identity.latest_version_id,
+            target_version=3,
+            new_locator=f"draft://{_UUID}/v3/{_REV}",
+            new_description="published",
+            env="test",
+        )
+
+    assert blocked.value.impact.counts == {"SERVICE_ARTIFACT": 1}
+    with db.orm_session() as session:
+        skill = session.query(Skill).filter_by(id=skill_id).one()
+        assert skill.offline_at is None
+        assert skill.draft_status is None

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_offline_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_offline_repository.py
@@ -8,12 +8,11 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from agentclaw.community.api.service_artifact_lineage import (
-    ServiceArtifactLineage,
-    ServiceArtifactReference,
-    UnknownServiceArtifact,
+from agentclaw.community.api.space_skill_offline_service import (
+    OfflineBlockerKind,
+    OfflineImpact,
+    OfflineImpactItem,
 )
-from agentclaw.community.api.space_skill_offline_service import OfflineBlockerKind
 from agentclaw.community.core.base import Base
 from agentclaw.community.core.models.skill import (
     BotSkillInstallation,
@@ -57,18 +56,6 @@ class _Database:
             session.close()
 
     transactional_orm_session = orm_session
-
-
-class _Lineage:
-    def __init__(self, *answers: ServiceArtifactLineage) -> None:
-        self.answers = list(answers) or [ServiceArtifactLineage((), ())]
-
-    def scan(self, *, skill_uuid, env):
-        assert skill_uuid == _UUID
-        assert env == "test"
-        if len(self.answers) > 1:
-            return self.answers.pop(0)
-        return self.answers[0]
 
 
 def _seed(db: _Database):
@@ -125,7 +112,7 @@ def _seed(db: _Database):
         return int(space.id), int(skill.id)
 
 
-def test_inspection_includes_inactive_membership_installation_attempt_and_unknown_artifact():
+def test_inspection_includes_inactive_membership_installation_and_attempt():
     db = _Database()
     space_id, skill_id = _seed(db)
     with db.orm_session() as session:
@@ -137,12 +124,25 @@ def test_inspection_includes_inactive_membership_installation_attempt_and_unknow
             is_default=False,
             env="test",
         )
-        session.add(skill_set)
+        default_set = SkillSet(
+            name="Default Set",
+            user_id="",
+            bolt_id="",
+            is_active=True,
+            is_default=True,
+            env="test",
+        )
+        session.add_all((skill_set, default_set))
         session.flush()
         session.add_all(
             [
                 SkillSetSkill(
                     skill_set_id=skill_set.id,
+                    skill_id=skill_id,
+                    env="test",
+                ),
+                SkillSetSkill(
+                    skill_set_id=default_set.id,
                     skill_id=skill_id,
                     env="test",
                 ),
@@ -163,19 +163,7 @@ def test_inspection_includes_inactive_membership_installation_attempt_and_unknow
                 ),
             ]
         )
-    lineage = _Lineage(
-        ServiceArtifactLineage(
-            (),
-            (
-                UnknownServiceArtifact(
-                    resource_id="artifact-scan",
-                    display_name="scan incomplete",
-                ),
-            ),
-        )
-    )
-
-    inspection = SpaceSkillOfflineRepository(db, lineage).inspect(
+    inspection = SpaceSkillOfflineRepository(db).inspect(
         space_id=space_id,
         skill_id=skill_id,
         actor_id="owner-1",
@@ -185,15 +173,15 @@ def test_inspection_includes_inactive_membership_installation_attempt_and_unknow
     assert [item.kind for item in inspection.blockers] == [
         OfflineBlockerKind.PUBLICATION,
         OfflineBlockerKind.MEMBERSHIP,
+        OfflineBlockerKind.MEMBERSHIP,
         OfflineBlockerKind.INSTALLATION,
-        OfflineBlockerKind.UNKNOWN_ARTIFACT,
     ]
 
 
 def test_offline_commit_preserves_published_version_and_creates_editing_vn_plus_one():
     db = _Database()
     space_id, skill_id = _seed(db)
-    repo = SpaceSkillOfflineRepository(db, _Lineage())
+    repo = SpaceSkillOfflineRepository(db)
     identity = repo.inspect(
         space_id=space_id, skill_id=skill_id, actor_id="owner-1", env="test"
     ).identity
@@ -207,6 +195,7 @@ def test_offline_commit_preserves_published_version_and_creates_editing_vn_plus_
         new_locator=f"draft://{_UUID}/v3/{_REV}",
         new_description="published",
         env="test",
+        guard=lambda _inspection: None,
     )
 
     assert result.changed is True
@@ -220,26 +209,30 @@ def test_offline_commit_preserves_published_version_and_creates_editing_vn_plus_
         assert session.query(SkillVersion).filter_by(skill_id=skill_id).count() == 1
 
 
-def test_artifact_inserted_after_preview_blocks_transactional_recheck():
+def test_transaction_guard_runs_after_locked_db_recheck_and_can_abort():
     db = _Database()
     space_id, skill_id = _seed(db)
-    empty = ServiceArtifactLineage((), ())
-    new_artifact = ServiceArtifactLineage(
-        (
-            ServiceArtifactReference(
-                publish_id=88,
-                source_bot_id="service-a",
-                source_bot_name="Service A",
-                service_version=4,
-                sc_version_number="2.0.0",
-            ),
-        ),
-        (),
-    )
-    repo = SpaceSkillOfflineRepository(db, _Lineage(empty, new_artifact))
+    repo = SpaceSkillOfflineRepository(db)
     identity = repo.inspect(
         space_id=space_id, skill_id=skill_id, actor_id="owner-1", env="test"
     ).identity
+
+    latest = OfflineImpactItem(
+        kind=OfflineBlockerKind.SERVICE_ARTIFACT,
+        resource_id="88",
+        display_name="Service A V4 (Skill 2.0.0)",
+    )
+
+    def _guard(locked):
+        assert locked.identity.skill_id == skill_id
+        raise SkillOfflineBlockedError(
+            OfflineImpact(
+                blocked=True,
+                total=1,
+                counts={"SERVICE_ARTIFACT": 1},
+                items=(latest,),
+            )
+        )
 
     with pytest.raises(SkillOfflineBlockedError) as blocked:
         repo.commit(
@@ -251,6 +244,7 @@ def test_artifact_inserted_after_preview_blocks_transactional_recheck():
             new_locator=f"draft://{_UUID}/v3/{_REV}",
             new_description="published",
             env="test",
+            guard=_guard,
         )
 
     assert blocked.value.impact.counts == {"SERVICE_ARTIFACT": 1}

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_offline_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_offline_repository.py
@@ -8,11 +8,6 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from agentclaw.community.api.space_skill_offline_service import (
-    OfflineBlockerKind,
-    OfflineImpact,
-    OfflineImpactItem,
-)
 from agentclaw.community.core.base import Base
 from agentclaw.community.core.models.skill import (
     BotSkillInstallation,
@@ -29,7 +24,6 @@ from agentclaw.community.core.models.space_skill import (
 from agentclaw.community.core.repository.implementations.skill_center.space_skill_offline import (
     SpaceSkillOfflineRepository,
 )
-from agentclaw.community.core.skill_center.errors import SkillOfflineBlockedError
 from agentclaw.community.core.spaces.repository.models import SpaceModel
 
 
@@ -170,12 +164,16 @@ def test_inspection_includes_inactive_membership_installation_and_attempt():
         env="test",
     )
 
-    assert [item.kind for item in inspection.blockers] == [
-        OfflineBlockerKind.PUBLICATION,
-        OfflineBlockerKind.MEMBERSHIP,
-        OfflineBlockerKind.MEMBERSHIP,
-        OfflineBlockerKind.INSTALLATION,
+    assert [(item.target_version_ordinal, item.status) for item in inspection.publication_attempts] == [
+        (3, "RESULT_UNKNOWN")
     ]
+    assert {item.skill_set_name for item in inspection.memberships} == {
+        "Inactive Set",
+        "Default Set",
+    }
+    assert [(item.bot_id) for item in inspection.installations] == ["service-a"]
+    assert inspection.space_bound is True
+    assert inspection.actor_roles == ("OWNER",)
 
 
 def test_offline_commit_preserves_published_version_and_creates_editing_vn_plus_one():
@@ -217,24 +215,13 @@ def test_transaction_guard_runs_after_locked_db_recheck_and_can_abort():
         space_id=space_id, skill_id=skill_id, actor_id="owner-1", env="test"
     ).identity
 
-    latest = OfflineImpactItem(
-        kind=OfflineBlockerKind.SERVICE_ARTIFACT,
-        resource_id="88",
-        display_name="Service A V4 (Skill 2.0.0)",
-    )
-
     def _guard(locked):
         assert locked.identity.skill_id == skill_id
-        raise SkillOfflineBlockedError(
-            OfflineImpact(
-                blocked=True,
-                total=1,
-                counts={"SERVICE_ARTIFACT": 1},
-                items=(latest,),
-            )
-        )
+        assert locked.space_bound is True
+        assert locked.actor_roles == ("OWNER",)
+        raise RuntimeError("artifact guard blocked")
 
-    with pytest.raises(SkillOfflineBlockedError) as blocked:
+    with pytest.raises(RuntimeError, match="artifact guard blocked"):
         repo.commit(
             space_id=space_id,
             skill_id=skill_id,
@@ -247,7 +234,6 @@ def test_transaction_guard_runs_after_locked_db_recheck_and_can_abort():
             guard=_guard,
         )
 
-    assert blocked.value.impact.counts == {"SERVICE_ARTIFACT": 1}
     with db.orm_session() as session:
         skill = session.query(Skill).filter_by(id=skill_id).one()
         assert skill.offline_at is None

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
@@ -6,11 +6,12 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 import io
 from pathlib import Path
+from threading import Event, Thread, current_thread
 from uuid import uuid4
 import zipfile
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.base import Base
@@ -29,6 +30,12 @@ from agentclaw.community.core.models.space_skill import (
 )
 from agentclaw.community.core.repository.implementations.skill_center.space_skill_publication import (
     SpaceSkillPublicationRepository,
+)
+from agentclaw.community.core.repository.implementations.skill_center.space_skill_offline import (
+    SpaceSkillOfflineRepository,
+)
+from agentclaw.community.core.repository.implementations.skill_center import (
+    space_skill_publication as publication_repository_module,
 )
 from agentclaw.community.core.skill_center.errors import (
     DraftEditLeaseConflictError,
@@ -92,6 +99,35 @@ class _Database:
             session.close()
 
     transactional_orm_session = orm_session
+
+
+class _ConcurrentDatabase(_Database):
+    def __init__(self, path: Path) -> None:
+        self.engine = create_engine(
+            f"sqlite:///{path}",
+            connect_args={"check_same_thread": False, "timeout": 5},
+        )
+        Base.metadata.create_all(self.engine)
+        self._factory = sessionmaker(bind=self.engine)
+        self.offline_begin_attempted = Event()
+        self.materialization_begin_attempted = Event()
+
+    @contextmanager
+    def transactional_orm_session(self):
+        session = self._factory()
+        try:
+            if current_thread().name == "offline":
+                self.offline_begin_attempted.set()
+            elif current_thread().name == "begin":
+                self.materialization_begin_attempted.set()
+            session.execute(text("BEGIN IMMEDIATE"))
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
 
 
 def _seed_draft(
@@ -172,6 +208,270 @@ def _seed_draft(
             )
         session.flush()
         return int(space.id), int(skill.id)
+
+
+def _seed_waiting_publication(
+    db: _Database,
+) -> tuple[int, int, int]:
+    space_id, skill_id = _seed_draft(db, lease_holder="owner")
+    repository = SpaceSkillPublicationRepository(db)
+    attempt = repository.create_or_replay_attempt(
+        space_id=space_id,
+        skill_id=skill_id,
+        actor_id="owner",
+        request_id=f"complete-{uuid4()}",
+        env="test",
+    ).attempt
+    repository.mark_prepared(
+        attempt_id=attempt.attempt_id,
+        package_url="https://example.invalid/frozen.zip",
+        env="test",
+    )
+    repository.claim_sc_submission(
+        attempt_id=attempt.attempt_id,
+        started_at=datetime(2026, 8, 30, 11, 0, tzinfo=UTC),
+        env="test",
+    )
+    repository.mark_waiting_sc(
+        attempt_id=attempt.attempt_id,
+        accepted_at=datetime(2026, 8, 30, 11, 1, tzinfo=UTC),
+        env="test",
+    )
+    return space_id, skill_id, attempt.attempt_id
+
+
+def _seed_published_materialization(
+    db: _Database,
+) -> tuple[int, int, int, int]:
+    space_id, skill_id, attempt_id = _seed_waiting_publication(db)
+    repository = SpaceSkillPublicationRepository(db)
+    materializing = repository.begin_materialization(
+        attempt_id=attempt_id,
+        sc_skill_id=701,
+        sc_version_id=801,
+        sc_sha256="a" * 64,
+        env="test",
+    ).attempt
+    assert materializing.skill_version_id is not None
+    with db.orm_session() as session:
+        version = session.get(SkillVersion, materializing.skill_version_id)
+        assert version is not None
+        version.status = "PUBLISHED"
+        version.metadata_json = '{"mcp_dependencies":[]}'
+        version.description = "Review risk"
+        version.published_at = datetime(2026, 8, 30, 12, 0, tzinfo=UTC)
+    return (
+        space_id,
+        skill_id,
+        attempt_id,
+        materializing.skill_version_id,
+    )
+
+
+def test_begin_materialization_rechecks_status_after_skill_lock(
+    monkeypatch,
+) -> None:
+    db = _Database()
+    _space_id, _skill_id, attempt_id = _seed_waiting_publication(db)
+    repository = SpaceSkillPublicationRepository(db)
+    original = publication_repository_module.lock_skill_row
+
+    def _fail_after_skill_lock(session, **kwargs):
+        skill = original(session, **kwargs)
+        session.query(SkillPublicationAttempt).filter(
+            SkillPublicationAttempt.id == attempt_id
+        ).update({"status": "FAILED"}, synchronize_session=False)
+        return skill
+
+    monkeypatch.setattr(
+        publication_repository_module,
+        "lock_skill_row",
+        _fail_after_skill_lock,
+    )
+
+    with pytest.raises(RuntimeError, match="cannot begin materialization"):
+        repository.begin_materialization(
+            attempt_id=attempt_id,
+            sc_skill_id=701,
+            sc_version_id=801,
+            sc_sha256="a" * 64,
+            env="test",
+        )
+
+
+@pytest.mark.parametrize(
+    ("drift", "message"),
+    [
+        ({"status": "FAILED"}, "Attempt is not materializing"),
+        ({"skill_version_id": 999999}, "Attempt identity changed"),
+    ],
+)
+def test_complete_success_rechecks_attempt_after_canonical_locks(
+    monkeypatch, drift: dict[str, object], message: str
+) -> None:
+    db = _Database()
+    _space_id, _skill_id, attempt_id, version_id = (
+        _seed_published_materialization(db)
+    )
+    original = publication_repository_module.lock_skill_then_exact_version
+
+    def _drift_after_skill_version_lock(session, **kwargs):
+        locked = original(session, **kwargs)
+        session.query(SkillPublicationAttempt).filter(
+            SkillPublicationAttempt.id == attempt_id
+        ).update(drift, synchronize_session=False)
+        return locked
+
+    monkeypatch.setattr(
+        publication_repository_module,
+        "lock_skill_then_exact_version",
+        _drift_after_skill_version_lock,
+    )
+
+    with pytest.raises(RuntimeError, match=message):
+        SpaceSkillPublicationRepository(db).complete_success(
+            attempt_id=attempt_id,
+            skill_version_id=version_id,
+            completed_at=datetime(2026, 8, 30, 12, 1, tzinfo=UTC),
+            env="test",
+        )
+
+
+def test_complete_success_and_offline_overlap_without_lock_inversion(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db = _ConcurrentDatabase(tmp_path / "publication-offline.db")
+    space_id, skill_id, attempt_id, version_id = _seed_published_materialization(db)
+    complete_holds_skill_version = Event()
+    failures: list[BaseException] = []
+    original = publication_repository_module.lock_skill_then_exact_version
+
+    def _pause_after_skill_version_lock(session, **kwargs):
+        locked = original(session, **kwargs)
+        complete_holds_skill_version.set()
+        assert db.offline_begin_attempted.wait(timeout=2)
+        return locked
+
+    monkeypatch.setattr(
+        publication_repository_module,
+        "lock_skill_then_exact_version",
+        _pause_after_skill_version_lock,
+    )
+
+    def _complete() -> None:
+        try:
+            SpaceSkillPublicationRepository(db).complete_success(
+                attempt_id=attempt_id,
+                skill_version_id=version_id,
+                completed_at=datetime(2026, 8, 30, 12, 1, tzinfo=UTC),
+                env="test",
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+
+    def _offline() -> None:
+        try:
+            SpaceSkillOfflineRepository(db).commit(
+                space_id=space_id,
+                skill_id=skill_id,
+                actor_id="owner",
+                expected_version_id=version_id,
+                target_version=2,
+                new_locator=f"draft://offline-skill/v2/{uuid4()}",
+                new_description="Review risk",
+                env="test",
+                guard=lambda inspection: None,
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+
+    completer = Thread(target=_complete, name="complete")
+    completer.start()
+    assert complete_holds_skill_version.wait(timeout=2)
+    offliner = Thread(target=_offline, name="offline")
+    offliner.start()
+    completer.join(timeout=5)
+    offliner.join(timeout=5)
+
+    assert failures == []
+    assert not completer.is_alive() and not offliner.is_alive()
+    with db.orm_session() as session:
+        attempt = session.get(SkillPublicationAttempt, attempt_id)
+        skill = session.get(Skill, skill_id)
+        assert attempt is not None and attempt.status == "SUCCEEDED"
+        assert skill is not None and skill.offline_at is not None
+
+
+def test_mark_failed_and_begin_materialization_overlap_without_lock_inversion(
+    tmp_path: Path, monkeypatch
+) -> None:
+    db = _ConcurrentDatabase(tmp_path / "publication-failure-begin.db")
+    _space_id, skill_id, attempt_id = _seed_waiting_publication(db)
+    fail_holds_skill = Event()
+    failures: list[BaseException] = []
+    expected_begin_errors: list[RuntimeError] = []
+    lock_threads: list[str] = []
+    original = publication_repository_module.lock_skill_row
+
+    def _observe_skill_lock(session, **kwargs):
+        skill = original(session, **kwargs)
+        lock_threads.append(current_thread().name)
+        if current_thread().name == "fail":
+            fail_holds_skill.set()
+            assert db.materialization_begin_attempted.wait(timeout=2)
+        return skill
+
+    monkeypatch.setattr(
+        publication_repository_module,
+        "lock_skill_row",
+        _observe_skill_lock,
+    )
+
+    def _fail() -> None:
+        try:
+            SpaceSkillPublicationRepository(db).mark_failed(
+                attempt_id=attempt_id,
+                error_code="SC_PUBLISH_REJECTED",
+                error_message="rejected",
+                completed_at=datetime(2026, 8, 30, 12, 1, tzinfo=UTC),
+                env="test",
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+
+    def _begin() -> None:
+        try:
+            SpaceSkillPublicationRepository(db).begin_materialization(
+                attempt_id=attempt_id,
+                sc_skill_id=701,
+                sc_version_id=801,
+                sc_sha256="a" * 64,
+                env="test",
+            )
+        except RuntimeError as exc:
+            expected_begin_errors.append(exc)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+
+    failure = Thread(target=_fail, name="fail")
+    failure.start()
+    assert fail_holds_skill.wait(timeout=2)
+    materialization = Thread(target=_begin, name="begin")
+    materialization.start()
+    failure.join(timeout=5)
+    materialization.join(timeout=5)
+
+    assert failures == []
+    assert not failure.is_alive() and not materialization.is_alive()
+    assert [str(error) for error in expected_begin_errors] == [
+        "Attempt cannot begin materialization"
+    ]
+    assert lock_threads == ["fail", "begin"]
+    with db.orm_session() as session:
+        attempt = session.get(SkillPublicationAttempt, attempt_id)
+        skill = session.get(Skill, skill_id)
+        assert attempt is not None and attempt.status == "FAILED"
+        assert skill is not None and skill.draft_status == "EDITING"
 
 
 def test_create_attempt_freezes_latest_draft_and_replays_same_request() -> None:

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
@@ -299,6 +299,38 @@ def test_begin_materialization_rechecks_status_after_skill_lock(
         )
 
 
+def test_mark_failed_rejects_version_that_appears_during_locking(
+    monkeypatch,
+) -> None:
+    db = _Database()
+    _space_id, _skill_id, attempt_id = _seed_waiting_publication(db)
+    original = publication_repository_module.lock_skill_row
+
+    def _attach_version_after_skill_lock(session, **kwargs):
+        skill = original(session, **kwargs)
+        session.query(SkillPublicationAttempt).filter(
+            SkillPublicationAttempt.id == attempt_id
+        ).update({"skill_version_id": 999999}, synchronize_session=False)
+        return skill
+
+    monkeypatch.setattr(
+        publication_repository_module,
+        "lock_skill_row",
+        _attach_version_after_skill_lock,
+    )
+
+    with pytest.raises(
+        RuntimeError, match="a materializing Version cannot become FAILED"
+    ):
+        SpaceSkillPublicationRepository(db).mark_failed(
+            attempt_id=attempt_id,
+            error_code="SC_PUBLISH_REJECTED",
+            error_message="rejected",
+            completed_at=datetime(2026, 8, 30, 12, 1, tzinfo=UTC),
+            env="test",
+        )
+
+
 @pytest.mark.parametrize(
     ("drift", "message"),
     [
@@ -559,6 +591,52 @@ def test_same_publication_request_key_conflicts_across_skills() -> None:
         )
 
     assert first.created is True
+
+
+def test_create_attempt_rechecks_request_after_skill_lock(monkeypatch) -> None:
+    db = _Database()
+    space_id, skill_id = _seed_draft(db, lease_holder="owner")
+    inserted_attempt_ids: list[int] = []
+    original = publication_repository_module.lock_skill_row
+
+    def _concurrent_replay_after_skill_lock(session, **kwargs):
+        skill = original(session, **kwargs)
+        assert skill is not None
+        replay = SkillPublicationAttempt(
+            skill_id=skill_id,
+            request_id="request-after-skill-lock",
+            frozen_draft_locator=skill.zip_url,
+            active_skill_key=f"teamclaw:test:{skill_id}",
+            target_version_ordinal=int(skill.draft_target_version),
+            sc_version_number="1.0.0",
+            status="PREPARING",
+            recovery_state="AUTO_RETRYING",
+            recovery_kind="PREPARATION",
+            created_by="owner",
+            env="test",
+        )
+        skill.draft_status = "FROZEN"
+        session.add(replay)
+        session.flush()
+        inserted_attempt_ids.append(int(replay.id))
+        return skill
+
+    monkeypatch.setattr(
+        publication_repository_module,
+        "lock_skill_row",
+        _concurrent_replay_after_skill_lock,
+    )
+
+    result = SpaceSkillPublicationRepository(db).create_or_replay_attempt(
+        space_id=space_id,
+        skill_id=skill_id,
+        actor_id="owner",
+        request_id="request-after-skill-lock",
+        env="test",
+    )
+
+    assert result.created is False
+    assert result.attempt.attempt_id == inserted_attempt_ids[0]
 
 
 def test_group3_migration_adds_frozen_draft_locator_compatibly() -> None:

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from datetime import UTC, datetime
 import io
 from pathlib import Path
-from threading import Event, Thread, current_thread
+from threading import Barrier, Event, Thread, current_thread
 from uuid import uuid4
 import zipfile
 
@@ -369,7 +369,7 @@ def test_complete_success_rechecks_attempt_after_canonical_locks(
         )
 
 
-def test_complete_success_and_offline_overlap_without_lock_inversion(
+def test_complete_success_and_offline_overlap_converges(
     tmp_path: Path, monkeypatch
 ) -> None:
     db = _ConcurrentDatabase(tmp_path / "publication-offline.db")
@@ -434,7 +434,7 @@ def test_complete_success_and_offline_overlap_without_lock_inversion(
         assert skill is not None and skill.offline_at is not None
 
 
-def test_mark_failed_and_begin_materialization_overlap_without_lock_inversion(
+def test_mark_failed_and_begin_materialization_overlap_serializes_to_failed(
     tmp_path: Path, monkeypatch
 ) -> None:
     db = _ConcurrentDatabase(tmp_path / "publication-failure-begin.db")
@@ -591,6 +591,132 @@ def test_same_publication_request_key_conflicts_across_skills() -> None:
         )
 
     assert first.created is True
+
+
+def test_create_miss_never_locks_the_global_request_gap(monkeypatch) -> None:
+    db = _Database()
+    space_id, skill_id = _seed_draft(db, lease_holder="owner")
+    lock_flags: list[bool] = []
+    original = SpaceSkillPublicationRepository._attempt_by_request
+
+    def _observe_request_lookup(session, *, request_id, env, lock):
+        lock_flags.append(lock)
+        return original(session, request_id=request_id, env=env, lock=lock)
+
+    monkeypatch.setattr(
+        SpaceSkillPublicationRepository,
+        "_attempt_by_request",
+        staticmethod(_observe_request_lookup),
+    )
+
+    created = SpaceSkillPublicationRepository(db).create_or_replay_attempt(
+        space_id=space_id,
+        skill_id=skill_id,
+        actor_id="owner",
+        request_id="no-global-request-gap-lock",
+        env="test",
+    )
+
+    assert created.created is True
+    assert lock_flags == [False, False]
+
+
+def test_cross_skill_same_request_converges_to_one_global_identity(
+    tmp_path: Path,
+) -> None:
+    """SQLite serializes state convergence; it does not prove row-lock order."""
+    db = _ConcurrentDatabase(tmp_path / "publication-global-request.db")
+    first_space, first_skill = _seed_draft(db, lease_holder="owner")
+    second_space, second_skill = _seed_draft(
+        db,
+        lease_holder="owner",
+        sc_team_id="sc-team-8",
+    )
+    start = Barrier(2)
+    created_attempt_ids: list[int] = []
+    conflicts: list[SpaceSkillIdempotencyConflictError] = []
+    failures: list[BaseException] = []
+
+    def _create(space_id: int, skill_id: int) -> None:
+        try:
+            start.wait(timeout=2)
+            result = SpaceSkillPublicationRepository(db).create_or_replay_attempt(
+                space_id=space_id,
+                skill_id=skill_id,
+                actor_id="owner",
+                request_id="cross-skill-global-request",
+                env="test",
+            )
+            created_attempt_ids.append(result.attempt.attempt_id)
+        except SpaceSkillIdempotencyConflictError as exc:
+            conflicts.append(exc)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+
+    first = Thread(target=_create, args=(first_space, first_skill))
+    second = Thread(target=_create, args=(second_space, second_skill))
+    first.start()
+    second.start()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert failures == []
+    assert not first.is_alive() and not second.is_alive()
+    assert len(created_attempt_ids) == 1
+    assert len(conflicts) == 1
+    with db.orm_session() as session:
+        assert session.query(SkillPublicationAttempt).count() == 1
+
+
+def test_cross_skill_unique_insert_loser_reads_winner_after_rollback(
+    monkeypatch,
+) -> None:
+    db = _Database()
+    first_space, first_skill = _seed_draft(db, lease_holder="owner")
+    second_space, second_skill = _seed_draft(
+        db,
+        lease_holder="owner",
+        sc_team_id="sc-team-8",
+    )
+    repository = SpaceSkillPublicationRepository(db)
+    winner = repository.create_or_replay_attempt(
+        space_id=first_space,
+        skill_id=first_skill,
+        actor_id="owner",
+        request_id="integrity-race-global-request",
+        env="test",
+    )
+    original = SpaceSkillPublicationRepository._attempt_by_request
+    lookups = 0
+
+    def _hide_winner_until_integrity_rollback(session, *, request_id, env, lock):
+        nonlocal lookups
+        lookups += 1
+        if lookups <= 2:
+            return None
+        return original(session, request_id=request_id, env=env, lock=lock)
+
+    monkeypatch.setattr(
+        SpaceSkillPublicationRepository,
+        "_attempt_by_request",
+        staticmethod(_hide_winner_until_integrity_rollback),
+    )
+
+    with pytest.raises(SpaceSkillIdempotencyConflictError):
+        repository.create_or_replay_attempt(
+            space_id=second_space,
+            skill_id=second_skill,
+            actor_id="owner",
+            request_id="integrity-race-global-request",
+            env="test",
+        )
+
+    assert lookups == 3
+    with db.orm_session() as session:
+        attempts = session.query(SkillPublicationAttempt).all()
+        assert [int(attempt.id) for attempt in attempts] == [
+            winner.attempt.attempt_id
+        ]
 
 
 def test_create_attempt_rechecks_request_after_skill_lock(monkeypatch) -> None:

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -19336,6 +19336,7 @@
         "type": "object"
       },
       "SkillOfflineBlockerKind": {
+        "description": "Reason a Space Skill cannot safely enter recoverable Offline.",
         "enum": [
           "DRAFT",
           "PUBLICATION",
@@ -19372,8 +19373,10 @@
         ]
       },
       "SkillOfflineImpact": {
+        "description": "Complete blocker counts plus one requested page of blocker details.",
         "properties": {
           "blocked": {
+            "description": "Whether at least one blocker exists.",
             "title": "Blocked",
             "type": "boolean"
           },
@@ -19381,10 +19384,12 @@
             "additionalProperties": {
               "type": "integer"
             },
+            "description": "Non-zero blocker totals keyed by blocker category.",
             "title": "Counts",
             "type": "object"
           },
           "items": {
+            "description": "Requested page of blockers in deterministic order.",
             "items": {
               "$ref": "#/components/schemas/SkillOfflineImpactItem"
             },
@@ -19392,6 +19397,7 @@
             "type": "array"
           },
           "total": {
+            "description": "Total blockers across all categories.",
             "minimum": 0.0,
             "title": "Total",
             "type": "integer"
@@ -19407,6 +19413,7 @@
         "type": "object"
       },
       "SkillOfflineImpactItem": {
+        "description": "One live fact that prevents recoverable Offline.",
         "properties": {
           "display_name": {
             "description": "Human-readable blocker label.",
@@ -19414,7 +19421,8 @@
             "type": "string"
           },
           "kind": {
-            "$ref": "#/components/schemas/SkillOfflineBlockerKind"
+            "$ref": "#/components/schemas/SkillOfflineBlockerKind",
+            "description": "Category of the blocking reference or lifecycle fact."
           },
           "resource_id": {
             "description": "Stable blocker resource identifier.",
@@ -19431,16 +19439,20 @@
         "type": "object"
       },
       "SkillOfflineResult": {
+        "description": "Recoverable Offline state and the editable next-version Draft.",
         "properties": {
           "changed": {
+            "description": "Whether this request newly moved the Skill Offline.",
             "title": "Changed",
             "type": "boolean"
           },
           "draft": {
-            "$ref": "#/components/schemas/SkillDraftSummary"
+            "$ref": "#/components/schemas/SkillDraftSummary",
+            "description": "Editable Vn+1 Draft retained for recovery publication."
           },
           "lifecycle_status": {
             "const": "OFFLINE",
+            "description": "Current recoverable lifecycle state.",
             "title": "Lifecycle Status",
             "type": "string"
           }
@@ -42910,11 +42922,13 @@
             }
           },
           {
+            "description": "One-based blocker page number.",
             "in": "query",
             "name": "page",
             "required": false,
             "schema": {
               "default": 1,
+              "description": "One-based blocker page number.",
               "minimum": 1,
               "title": "Page",
               "type": "integer"

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -9534,6 +9534,90 @@
         "title": "Envelope[SkillGrantItem]",
         "type": "object"
       },
+      "Envelope_SkillOfflineImpact_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SkillOfflineImpact"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[SkillOfflineImpact]",
+        "type": "object"
+      },
+      "Envelope_SkillOfflineResult_": {
+        "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
+        "properties": {
+          "code": {
+            "description": "6-digit code: HTTP status (3) + business subcode (3).",
+            "example": 200000,
+            "title": "Code",
+            "type": "integer"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SkillOfflineResult"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Response payload; present but null on errors or empty results."
+          },
+          "message": {
+            "description": "Human-readable status; always English (e.g. \"OK\").",
+            "example": "OK",
+            "title": "Message",
+            "type": "string"
+          },
+          "request_id": {
+            "description": "Trace id; mirrors the X-Trace-Id response header.",
+            "example": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d",
+            "title": "Request Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "message",
+          "data",
+          "request_id"
+        ],
+        "title": "Envelope[SkillOfflineResult]",
+        "type": "object"
+      },
       "Envelope_SkillParameters_": {
         "description": "Uniform response wrapper for every endpoint: `code`/`message` say how the call went, `data` carries the payload named in the wrapper's title, and `request_id` identifies the request for support.",
         "properties": {
@@ -19249,6 +19333,124 @@
           }
         },
         "title": "SkillMarketSearchRequest",
+        "type": "object"
+      },
+      "SkillOfflineBlockerKind": {
+        "enum": [
+          "DRAFT",
+          "PUBLICATION",
+          "MEMBERSHIP",
+          "INSTALLATION",
+          "SERVICE_ARTIFACT",
+          "UNKNOWN_ARTIFACT"
+        ],
+        "title": "SkillOfflineBlockerKind",
+        "type": "string",
+        "x-enum-descriptions": [
+          "A mutable or frozen Draft already exists.",
+          "A publication Attempt is still in progress or unknown.",
+          "An ordinary or Default SkillSet still contains the Skill.",
+          "A Bot still has an effective Skill Installation.",
+          "A live Service Bot can replay this exact Skill Version.",
+          "Artifact lineage could not be proved complete and valid."
+        ],
+        "x-enum-varnames": [
+          "DRAFT",
+          "PUBLICATION",
+          "MEMBERSHIP",
+          "INSTALLATION",
+          "SERVICE_ARTIFACT",
+          "UNKNOWN_ARTIFACT"
+        ],
+        "x-enumNames": [
+          "DRAFT",
+          "PUBLICATION",
+          "MEMBERSHIP",
+          "INSTALLATION",
+          "SERVICE_ARTIFACT",
+          "UNKNOWN_ARTIFACT"
+        ]
+      },
+      "SkillOfflineImpact": {
+        "properties": {
+          "blocked": {
+            "title": "Blocked",
+            "type": "boolean"
+          },
+          "counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Counts",
+            "type": "object"
+          },
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/SkillOfflineImpactItem"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "total": {
+            "minimum": 0.0,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "blocked",
+          "total",
+          "counts",
+          "items"
+        ],
+        "title": "SkillOfflineImpact",
+        "type": "object"
+      },
+      "SkillOfflineImpactItem": {
+        "properties": {
+          "display_name": {
+            "description": "Human-readable blocker label.",
+            "title": "Display Name",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/SkillOfflineBlockerKind"
+          },
+          "resource_id": {
+            "description": "Stable blocker resource identifier.",
+            "title": "Resource Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "resource_id",
+          "display_name"
+        ],
+        "title": "SkillOfflineImpactItem",
+        "type": "object"
+      },
+      "SkillOfflineResult": {
+        "properties": {
+          "changed": {
+            "title": "Changed",
+            "type": "boolean"
+          },
+          "draft": {
+            "$ref": "#/components/schemas/SkillDraftSummary"
+          },
+          "lifecycle_status": {
+            "const": "OFFLINE",
+            "title": "Lifecycle Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "changed",
+          "lifecycle_status",
+          "draft"
+        ],
+        "title": "SkillOfflineResult",
         "type": "object"
       },
       "SkillOwnerSummary": {
@@ -42502,6 +42704,384 @@
         "summary": "Add Space Skill Manager",
         "tags": [
           "spaces"
+        ]
+      }
+    },
+    "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline": {
+      "post": {
+        "operationId": "offline_space_skill_openapi_v1_bots_spaces__space_id__skills__skill_id__offline_post",
+        "parameters": [
+          {
+            "description": "Space primary identifier.",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "description": "Space primary identifier.",
+              "minimum": 1,
+              "title": "Space Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Space Skill primary identifier.",
+            "in": "path",
+            "name": "skill_id",
+            "required": true,
+            "schema": {
+              "description": "Space Skill primary identifier.",
+              "minimum": 1,
+              "title": "Skill Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SkillOfflineResult_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SkillOfflineImpact_"
+                }
+              }
+            },
+            "description": "Latest Offline blockers from the command transaction."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Offline Space Skill",
+        "tags": [
+          "space-skills"
+        ]
+      }
+    },
+    "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline-impact": {
+      "get": {
+        "operationId": "get_space_skill_offline_impact_openapi_v1_bots_spaces__space_id__skills__skill_id__offline_impact_get",
+        "parameters": [
+          {
+            "description": "Space primary identifier.",
+            "in": "path",
+            "name": "space_id",
+            "required": true,
+            "schema": {
+              "description": "Space primary identifier.",
+              "minimum": 1,
+              "title": "Space Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Space Skill primary identifier.",
+            "in": "path",
+            "name": "skill_id",
+            "required": true,
+            "schema": {
+              "description": "Space Skill primary identifier.",
+              "minimum": 1,
+              "title": "Skill Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Number of records per page.",
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Number of records per page.",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+            "in": "query",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "description": "The end user this request acts for. Every read and write is scoped to it. A caller authenticated as a person must name themselves; naming another user is refused (403). An application calling with its own credential and no end user names the user who authorized it, and reaches only what that user has authorized it for — anything else is answered exactly as if it did not exist (404).",
+              "minLength": 1,
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Envelope_SkillOfflineImpact_"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 400000,
+                  "message": "Bad Request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 401000,
+                  "message": "Unauthorized",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Missing or invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 403000,
+                  "message": "Forbidden",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "The authenticated user lacks the required space membership or role"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 404000,
+                  "message": "Not found",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Not found — also returned when the resource exists but does not belong to the caller"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 409000,
+                  "message": "Conflict",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Conflicts with current state"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 422000,
+                  "message": "Invalid request",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Request failed validation"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 500000,
+                  "message": "Internal Server Error",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Internal error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": 502000,
+                  "message": "Bad Gateway",
+                  "request_id": "b0a6d2f4e8c94b1a9f3d5e7c60218a4d"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Upstream service error"
+          }
+        },
+        "summary": "Get Space Skill Offline Impact",
+        "tags": [
+          "space-skills"
         ]
       }
     },

--- a/src/gateway/tests/contracts/test_space_skill_published_contract.py
+++ b/src/gateway/tests/contracts/test_space_skill_published_contract.py
@@ -66,6 +66,11 @@ _EXPECTED_OPERATIONS = {
         "post",
         "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/publications/{attempt_id}/retry",
     ),
+    (
+        "get",
+        "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline-impact",
+    ),
+    ("post", "/openapi/v1/bots/spaces/{space_id}/skills/{skill_id}/offline"),
 }
 
 
@@ -84,4 +89,6 @@ def test_published_artifact_contains_complete_space_skill_loop() -> None:
     assert "SpaceSkillSummary" in schemas
     assert "PublicationAttempt" in schemas
     assert "PublicationImpactItem" in schemas
+    assert "SkillOfflineImpact" in schemas
+    assert "SkillOfflineResult" in schemas
     assert "SpaceSkillItem" not in schemas


### PR DESCRIPTION
## Problem

Service Artifact history could not prove exact Skill Center lineage for recoverable Offline, and new capability/reference writers were not uniformly fenced against an Offline race. Restart, rollback, scale, failed-publish retry, and offloaded Artifact history must remain reproducible from the frozen target Artifact without resolving current Installation or latest Center state.

## Solution

- Freeze exact Center Skill refs into the existing file manifest v1 and Teclaw v4 Artifact shapes, preserving legacy Artifact compatibility and excluding shared corpora from file snapshots.
- Add the single fail-closed ArtifactLineageReader over stable id cursor pagination and transparent inline/offloaded metadata reads; corrupt, unreadable, or incomplete lineage becomes UNKNOWN_ARTIFACT.
- Fence BUILDING to BUILT Artifact commit and every Membership, Installation, Default restore, legacy add, and compensation writer with the same Skill row lock and SKILL_OFFLINE invariant.
- Add Public offline-impact and recoverable Offline commands with stable envelopes/codes, transactional Draft, Attempt, Membership, Installation, Artifact, and UNKNOWN rechecks, preserving Vn and creating Vn+1 EDITING Draft.
- Restore visibility only for a real Space-bound MATERIALIZING to PUBLISHED materialization; idempotent PUBLISHED replay and SC Public materialization cannot clear a later Offline.
- Generate and compatibility-gate the published Gateway OpenAPI Artifact.

## Validation

- Focused build/replay/restart/scale/rollback suite: 304 passed.
- Offline, lineage, row-lock, Materializer, repository and concurrency suites: 136 passed.
- Architecture: 234 passed; DI: 289 passed; Public API contracts: 84 passed; Gateway schema contracts: 14 passed.
- Standards/Spec dual-axis review rerun: no remaining P1/P2 findings.
- Backend complete community run reached 15675 passed and 57 skipped; its final two framework-only failures were fixed and rechecked by the async contract, endpoint coverage gate, and 13 Offline endpoint cases.
- Gateway non-e2e suite with SERVER_ENV=local and host proxy variables cleared: 1060 passed, 5 skipped, 40 deselected.
- OCB origin/dev 8b2fc53e0521c2e74631a44e73f9dcd796865fe9 / ocb-public b68ec64f1698a931585612801f2db6529c8ec4aa: 50 focused Artifact, Teclaw delivery, restart, scale, and rollback tests passed; no OCB change required.

## Compatibility and risk

The change is additive: file manifest stays v1, Teclaw Artifact stays v4, old Artifacts without Center refs remain readable, and no lineage index table or force/admin bypass is introduced. Offline does not call Skill Center to remove external content. The principal residual risk is production database lock behavior under high contention; deterministic lock ordering and real overlapping transaction tests cover the intended invariant.

## Spec

Implements Phase 2 Group 5 Service Artifact, historical replay, and recoverable Offline, including the Manager A-D concurrency constraints and the Group 3 Materializer recovery seam.

## Related issues

Closes #1184