### PR TITLE
refactor(bcs): remove dead GET /groups/{id}/messages route

### DIFF
--- a/src/bcs/CLAUDE.md
+++ b/src/bcs/CLAUDE.md
@@ -391,7 +391,7 @@ export BOT_DATA_DIR=/path/to/bot/data
 | `/groups/{id}` | DELETE | Delete group |
 | `/groups/{id}/members` | POST | Add member to group |
 | `/groups/{id}/chat` | POST | Send group chat message |
-| `/groups/{id}/messages` | GET | Get message history |
+| `/groups/{id}/messages` | POST | Send a persistent group message |
 | `/groups/{id}/fuse` | POST | Fuse participant contexts |
 | `/groups/{id}/workspace` | GET/PUT | Get/update workspace |
 

--- a/src/bcs/crates/adapters/http/bcs-http/src/router.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/router.rs
@@ -313,7 +313,7 @@ fn build_api_routes() -> Router<HttpAppState> {
         )
         .route(
             "/groups/{id}/messages",
-            get(routes::group_messages::get_messages).post(routes::group_messages::send_message),
+            post(routes::group_messages::send_message),
         )
         .route("/groups/{id}/fuse", post(routes::messages::fuse_context))
         .route(

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/group_messages.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/group_messages.rs
@@ -1,12 +1,12 @@
 use axum::{
     Json,
-    extract::{Path, Query, State},
+    extract::{Path, State},
     http::{HeaderMap, StatusCode, Uri},
     response::{IntoResponse, Response},
 };
 use bcs_service_api::{
     BotActor, CallerContext, DeliveryType, GroupCallbackCommand, GroupChatCommand,
-    GroupDetailCommand, GroupHistoryCommand, GroupMessage, GroupMessageType, GroupUseCaseError,
+    GroupDetailCommand, GroupMessageType, GroupUseCaseError,
     HumanActor, MessageDeliveryResult, MessageRole, PersistentGroupSendCommand, ServiceError,
 };
 use bcs_service_api::application::v1::{
@@ -44,16 +44,6 @@ pub struct SendMessageRequest {
     pub message_type: Option<GroupMessageType>,
     #[serde(default)]
     pub role: Option<MessageRole>,
-}
-
-#[derive(Debug, Deserialize, Default)]
-pub struct GetMessagesQuery {
-    #[serde(default)]
-    pub view_bot_id: Option<String>,
-    #[serde(default)]
-    pub limit: Option<u64>,
-    #[serde(default)]
-    pub before: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -249,33 +239,6 @@ pub async fn send_message(
         "routed_to": outcome.routed_to,
         "mentions": outcome.mentions,
     })))
-}
-
-pub async fn get_messages(
-    State(state): State<HttpAppState>,
-    Path(id): Path<String>,
-    headers: HeaderMap,
-    uri: Uri,
-    Query(query): Query<GetMessagesQuery>,
-) -> Result<Json<Vec<GroupMessage>>, LegacyGroupError> {
-    let caller = human_caller_from_identity(&state, &headers, &uri).await?;
-    let result = state
-        .services
-        .group_message_history
-        .get_history(GroupHistoryCommand {
-            caller: CallerContext::Human(HumanActor {
-                actor_id: caller.actor_id,
-                staff_no: caller.staff_no,
-            }),
-            group_id: id,
-            view_bot_id: query.view_bot_id,
-            limit: query.limit.unwrap_or(u64::MAX),
-            before: query.before,
-        })
-        .await
-        .map_err(group_use_case_error_to_legacy)?;
-
-    Ok(Json(result.messages))
 }
 
 async fn ensure_group_message_group_exists(

--- a/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/group_messages_contract.rs
@@ -1540,9 +1540,9 @@ async fn group_message_routes_preserve_delivery_and_history_shapes() {
         routing,
         bot_delivery,
         frontend_delivery,
-        bot_request,
+        _bot_request,
         message_flow,
-        group_message_history,
+        _group_message_history,
     ) = build_group_app().await;
 
     let response = app
@@ -1583,40 +1583,6 @@ async fn group_message_routes_preserve_delivery_and_history_shapes() {
     assert!(routing.sent_to_bot.lock().await.is_empty());
     let group = group_store.get("group-1").await.unwrap();
     assert_eq!(group.messages.len(), 1);
-
-    let response = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("GET")
-                .uri("/groups/group-1/messages?view_bot_id=owner-bot")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-    let json: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json[0]["id"], "hist-use-case");
-    assert_eq!(json[0]["sender"], "owner-bot");
-    assert_eq!(json[0]["content"], "history answer");
-    assert_eq!(json[0]["role"], "assistant");
-    let history_calls = group_message_history.calls.lock().await;
-    assert_eq!(history_calls.len(), 1);
-    assert_eq!(history_calls[0].group_id, "group-1");
-    assert_eq!(history_calls[0].view_bot_id.as_deref(), Some("owner-bot"));
-    assert_eq!(history_calls[0].limit, u64::MAX);
-    assert_eq!(history_calls[0].before, None);
-    assert!(matches!(
-        &history_calls[0].caller,
-        CallerContext::Human(human)
-            if human.actor_id == "human_123" && human.staff_no == "123"
-    ));
-    drop(history_calls);
-    let history_requests = bot_request.requests.lock().await;
-    assert!(history_requests.is_empty());
 
     let response = app
         .clone()

--- a/src/bcs/crates/bootstrap/bcs/tests/provider_downlink_integration.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/provider_downlink_integration.rs
@@ -77,52 +77,6 @@ async fn provider_bot_registers_and_is_routable_without_ws_connection() {
 }
 
 #[tokio::test]
-async fn provider_history_converts_to_group_messages_shape() {
-    let provider = start_provider_webhook().await;
-    let bots_dir = create_temp_bots_dir();
-    let (bcs_addr, _bcs_server) = start_test_server(&bots_dir.path().to_path_buf()).await;
-    let client = reqwest::Client::new();
-    let registered = register_provider_bot(
-        &client,
-        bcs_addr,
-        provider.url(),
-        "provider-history",
-        "history-v1",
-    )
-    .await;
-    let group_id = create_single_provider_group(
-        &client,
-        bcs_addr,
-        &registered.bot_runtime_token,
-        &registered.bot_uuid,
-    )
-    .await;
-
-    let response = client
-        .get(format!(
-            "http://{}/groups/{}/messages?view_bot_id={}",
-            bcs_addr, group_id, registered.bot_uuid
-        ))
-        .header("X-Mock-User-Id", "11111111")
-        .send()
-        .await
-        .expect("history request");
-    let status = response.status();
-    let body_text = response.text().await.expect("history response body");
-    assert!(status.is_success(), "history request failed: {status} {body_text}");
-    let messages: Value = serde_json::from_str(&body_text).expect("history response");
-    assert_eq!(messages[0]["sender"], registered.bot_uuid);
-    assert_eq!(messages[0]["role"], "assistant");
-    assert_eq!(messages[0]["content"], "done");
-
-    let history = provider.capture.wait_for_method("chat.history").await;
-    assert_eq!(history.body["bcn_group_id"], group_id);
-    assert!(history.body.get("bcs_group_id").is_none());
-    assert_eq!(history.body["session_id"], group_id);
-    assert!(history.body.get("session_key").is_none());
-}
-
-#[tokio::test]
 async fn provider_final_callback_uses_run_context_not_request_group() {
     let provider = start_provider_webhook().await;
     let bots_dir = create_temp_bots_dir();
@@ -1063,34 +1017,6 @@ async fn create_group(
     assert!(status.is_success(), "create group failed: {status} {body_text}");
     let group: Value = serde_json::from_str(&body_text).expect("group response");
     group["id"].as_str().expect("group id").to_string()
-}
-
-async fn create_single_provider_group(
-    client: &reqwest::Client,
-    bcs_addr: SocketAddr,
-    provider_token: &str,
-    provider_bot: &str,
-) -> String {
-    let response = client
-        .post(format!("http://{}/groups", bcs_addr))
-        .header("Authorization", format!("Bearer {provider_token}"))
-        .json(&json!({
-            "driver_bot": provider_bot,
-            "participants": [
-                { "bot_uuid": provider_bot, "role": "driver" }
-            ]
-        }))
-        .send()
-        .await
-        .expect("create provider group");
-    let status = response.status();
-    let body_text = response.text().await.expect("provider group response body");
-    assert!(
-        status.is_success(),
-        "create provider group failed: {status} {body_text}"
-    );
-    let group: Value = serde_json::from_str(&body_text).expect("provider group response");
-    group["id"].as_str().expect("provider group id").to_string()
 }
 
 async fn create_state_machine_group(

--- a/src/bcs/scripts/e2e-test/stories.sh
+++ b/src/bcs/scripts/e2e-test/stories.sh
@@ -407,12 +407,6 @@ _story_group_workspace_round_trip() {
     assert_json_not_empty "persistent message receives an id" "$RESPONSE" "message_id"
     assert_json_not_empty "persistent message records routing targets" "$RESPONSE" "routed_to"
 
-    api_get "/groups/${group_id}/messages?limit=20"
-    require_status "human reads group message history" "200" || return
-    local history_is_array
-    history_is_array=$(printf '%s' "$RESPONSE" | python3 -c 'import json,sys; print("1" if isinstance(json.load(sys.stdin), list) else "0")' 2>/dev/null || echo 0)
-    assert_eq "group history response is a JSON array" "$history_is_array" "1"
-
     bot_post "/groups/${group_id}/chat" CEO \
         "{\"message\":\"@产品经理 please coordinate the release\",\"from\":\"${BOT_CEO_UUID}\"}"
     require_status "driver sends a live group chat message" "200" || return


### PR DESCRIPTION
## Summary

The BCS HTTP adapter exposed `GET /groups/{id}/messages` for pulling group message history. That business capability has been retired with no replacement and no in-repo callers, so the GET branch is dead code. This change removes the GET route branch and its handler, leaving only `POST /groups/{id}/messages` (`send_message`).

## Changes

- `router.rs`: `/groups/{id}/messages` now registers only `post(send_message)` (previously `get(get_messages).post(send_message)`). The shared `axum::routing::get` import is retained (used by many other routes).
- `routes/group_messages.rs`: deleted the `get_messages` handler, its exclusive `GetMessagesQuery` struct, and the now-unused `Query`, `GroupHistoryCommand`, and `GroupMessage` imports.
- `tests/group_messages_contract.rs`: removed the `GET /groups/{id}/messages` assertion block from `group_message_routes_preserve_delivery_and_history_shapes`; kept the POST `send_message` / `/chat` / `/callback` assertions. Marked now-unused test bindings with `_`.
- `tests/provider_downlink_integration.rs`: removed the GET-only `provider_history_converts_to_group_messages_shape` test and the now-dead `create_single_provider_group` helper it was the sole caller of.

## What is intentionally retained

- `POST /groups/{id}/messages` (`send_message`) behavior is unchanged.
- `GroupMessageHistoryService` trait and `get_history` implementation are untouched; they remain in use by `sessions.rs` `get_session_history` and the message-service fallback path.
- No changes to frontend, gateway, bcsfuse, or other subdomains.

## Runtime behavior

`GET /groups/{id}/messages` is no longer route-matched and returns axum's default `405 Method Not Allowed` (POST is still registered). `POST /groups/{id}/messages` is unaffected.

## Verification

- `cargo build` and `cargo test` for the affected BCS crates pass; no new warnings introduced by the change (only pre-existing unused-method warnings in unrelated `bcs-edge-permission*` crates remain).
- `cargo test --package bcs-http`: all unit and contract tests pass, including the updated `group_message_routes_preserve_delivery_and_history_shapes`.
- `cargo test --package bcs --test provider_downlink_integration`: 7 passed.

## Compatibility / risk

Low. The removed GET endpoint has no callers (frontend export-only, bcsfuse confirmed independent). POST send_message and the retained history trait/impl cover all still-needed behavior. Not a breaking change for active consumers since the capability was already retired.

## Rollback

Revert the commit; the removed route/handler can be restored from git history if ever needed.