### PR TITLE
feat(bcs): expose caller_principal and created_by in v1 session list

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs
@@ -600,6 +600,8 @@ fn session_summary() -> SessionSummary {
         status: SessionStatus::Running,
         title: Some("Planning".into()),
         participant_count: Some(1),
+        caller_principal: None,
+        created_by: None,
         created_at: 1,
         updated_at: 2,
         collected: None,

--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -1268,6 +1268,8 @@ fn project_summary(session: &Session) -> SessionSummary {
         status: project_status(session.status),
         title: session.session_title.clone(),
         participant_count: Some(session.participants.len()),
+        caller_principal: session.caller_principal.clone(),
+        created_by: session.created_by.clone(),
         created_at: session.created_at,
         updated_at: session.updated_at,
         collected: None,

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session.rs
@@ -40,6 +40,12 @@ pub struct SessionSummary {
     pub title: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub participant_count: Option<usize>,
+    /// Stable identity of the session creator (e.g. `svc-key:{sha256_hex[:16]}`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caller_principal: Option<String>,
+    /// Actor id of the session creator, when recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_by: Option<String>,
     pub created_at: u64,
     pub updated_at: u64,
     /// Whether the view actor (`view_bot_id`) has collected this session.


### PR DESCRIPTION
## Problem
The V1 OpenAPI `list_sessions` response (`bcs_api_http::v1::openapi::routes::session::list_sessions`) did not surface the session's `caller_principal` and `created_by`, unlike the legacy `bcs_http::routes::sessions::list_sessions_for_group` handler, which serializes the full domain `Session` where both fields already exist. Consumers of the V1 OpenAPI surface therefore could not read the creator's stable principal or actor id from the list endpoint.

## Solution
Add `caller_principal: Option<String>` and `created_by: Option<String>` to the V1 list DTO `SessionSummary` in `bcs-service-api`, mirroring the domain `Session` field shape and its `skip_serializing_if = "Option::is_none"` semantics. Populate them in `project_summary` (`bcs-app-session`) from the underlying domain `Session`. The `list_sessions` route already returns `Page<SessionSummary>` directly through the envelope, so no handler change is required — the new fields serialize automatically, matching the legacy `list_sessions_for_group` behavior.

## Validation
- `cargo check --all-targets --package bcs-service-api --package bcs-app-session --package bcs-api-http` — clean.
- `cargo test --package bcs-api-http --package bcs-app-session session` — `bcs-app-session` session suite 35/35 pass; `bcs-api-http` filtered session tests pass.
- Could not run the full singlebox coverage / pre-push CI gate locally.

## Compatibility and risk
Additive, backward-compatible response change: both fields are optional and omitted from JSON when `None`. No schema, config, or migration impact — the underlying `bcs_group_sessions` columns (`caller_principal`, `created_by`) already exist. Existing clients that ignore unknown fields are unaffected; rollback is simply reverting the commit.
