### PR TITLE
fix(bcs): persist chat-run streaming overlay across Redis rejection (#1627)

### DIFF
--- a/src/bcs/crates/services/bcs-chat-run-store/Cargo.toml
+++ b/src/bcs/crates/services/bcs-chat-run-store/Cargo.toml
@@ -18,6 +18,8 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
+async-trait = { workspace = true }
+bcs-cache-api = { workspace = true }
 bcs-cache-local = { workspace = true }
 bcs-db-local = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
@@ -55,6 +55,9 @@ struct StreamingOverlay {
     state: String,
     accumulated_content: String,
     content_truncated: bool,
+    /// Run deadline carried in the overlay so the normal streaming path can
+    /// compute its TTL (and detect a missing run) without a per-delta DB read.
+    expires_at_ms: u64,
 }
 
 impl SqlChatRunRepo {
@@ -155,17 +158,13 @@ impl SqlChatRunRepo {
     /// as the sole delta record (`append_streaming_content`) can fail over to
     /// the DB. Best-effort callers (`create`, state CAS) ignore the result
     /// since the DB row is authoritative there.
-    async fn write_overlay(
-        &self,
-        run_id: &str,
-        overlay: &StreamingOverlay,
-        expires_at_ms: u64,
-    ) -> Result<(), CacheError> {
+    async fn write_overlay(&self, run_id: &str, overlay: &StreamingOverlay) -> Result<(), CacheError> {
         let now = now_ms();
         // Overlay must survive the run deadline by the retention grace so the
         // timeout sweep (which runs only once `expires_at_ms < now`) can still
         // merge the streamed content instead of reading a stale DB row.
-        let ttl_ms = expires_at_ms
+        let ttl_ms = overlay
+            .expires_at_ms
             .saturating_add(self.overlay_retention_ms)
             .saturating_sub(now)
             .max(1000);
@@ -222,6 +221,45 @@ impl SqlChatRunRepo {
         );
         let result = self.db.execute(stmt).await.map_err(backend)?;
         Ok(result.affected_rows > 0)
+    }
+
+    /// Resolve the base for a streaming append. Fast path: when the overlay is
+    /// present at exactly the caller's expected version it is the streaming
+    /// source of truth and is used directly **without a DB read** (issue spec:
+    /// per-token deltas never hit the DB on the normal path). An overlay newer
+    /// than the caller's expectation means the caller is stale → no base
+    /// (`Ok(None)` → append returns `Ok(false)`). A missing or behind-version
+    /// overlay (Redis outage / stale-after-fail-over) falls back to the
+    /// authoritative DB row — the recovery path that has to read MySQL anyway.
+    /// Returns `Ok(None)` when the run is missing or its version does not match.
+    async fn resolve_append_base(
+        &self,
+        run_id: &str,
+        expected_version: u64,
+    ) -> Result<Option<StreamingOverlay>, ChatRunRepoError> {
+        match self.read_overlay(run_id).await {
+            Some(existing) if existing.version == expected_version => return Ok(Some(existing)),
+            Some(existing) if existing.version > expected_version => return Ok(None),
+            _ => {}
+        }
+        let Some(db) = self.read_db(run_id).await? else {
+            return Ok(None);
+        };
+        if db.expires_at_ms == 0 {
+            return Ok(None);
+        }
+        let overlay = StreamingOverlay {
+            version: db.version,
+            state: state_str(db.state).to_string(),
+            accumulated_content: db.accumulated_content.clone(),
+            content_truncated: db.content_truncated,
+            expires_at_ms: db.expires_at_ms,
+        };
+        Ok(if overlay.version == expected_version {
+            Some(overlay)
+        } else {
+            None
+        })
     }
 
     async fn delete_overlay(&self, run_id: &str) {
@@ -457,8 +495,8 @@ impl ChatRunRepoPort for SqlChatRunRepo {
                             state: state_str(record.state).to_string(),
                             accumulated_content: record.accumulated_content.clone(),
                             content_truncated: record.content_truncated,
+                            expires_at_ms: record.expires_at_ms,
                         },
-                        record.expires_at_ms,
                     )
                     .await;
                 Ok(())
@@ -512,8 +550,8 @@ impl ChatRunRepoPort for SqlChatRunRepo {
                         state: state_str(updated.state).to_string(),
                         accumulated_content: updated.accumulated_content.clone(),
                         content_truncated: updated.content_truncated,
+                        expires_at_ms: updated.expires_at_ms,
                     },
-                    updated.expires_at_ms,
                 )
                 .await;
             Ok(CasOutcome::Applied(updated))
@@ -564,33 +602,13 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         accumulated: String,
         truncated: bool,
     ) -> Result<bool, ChatRunRepoError> {
-        // Read both the overlay (streaming hot cache) and the authoritative DB
-        // row, then base off whichever is newer. P1: a stale overlay left by a
-        // rejected write must never win over a DB row the fail-over advanced, so
-        // pick `max(overlay.version, db.version)` rather than trusting the overlay.
-        let overlay_opt = self.read_overlay(run_id).await;
-        let db_record = self.read_db(run_id).await?;
-        let expires_at_ms = db_record.as_ref().map(|r| r.expires_at_ms).unwrap_or(0);
-        if expires_at_ms == 0 {
+        // Resolve the base. On the normal streaming path this returns straight
+        // from the overlay without a DB read (see `resolve_append_base`); the DB
+        // is only touched when the overlay is missing or stale (fail-over /
+        // recovery), which is the path that has to read MySQL anyway.
+        let Some(mut overlay) = self.resolve_append_base(run_id, expected_version).await? else {
             return Ok(false);
-        }
-        let mut overlay = match (overlay_opt, db_record) {
-            // Overlay is ahead of the DB — normal streaming; base off the overlay.
-            (Some(existing), Some(db)) if existing.version > db.version => existing,
-            // DB is at or ahead (incl. the fail-over case), or the overlay is
-            // gone — base off the authoritative DB row.
-            (_, Some(db)) => StreamingOverlay {
-                version: db.version,
-                state: state_str(db.state).to_string(),
-                accumulated_content: db.accumulated_content.clone(),
-                content_truncated: db.content_truncated,
-            },
-            // Overlay present but the DB row is gone — treat the run as missing.
-            (Some(_), None) | (None, None) => return Ok(false),
         };
-        if overlay.version != expected_version {
-            return Ok(false);
-        }
         let flipped = overlay.state == "pending";
         overlay.version += 1;
         if flipped {
@@ -599,7 +617,7 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         overlay.accumulated_content = accumulated;
         overlay.content_truncated = truncated;
         let intended_version = overlay.version;
-        match self.write_overlay(run_id, &overlay, expires_at_ms).await {
+        match self.write_overlay(run_id, &overlay).await {
             // Overlay (the sole delta record) confirmed the write.
             Ok(()) => Ok(true),
             // C4/P1: overlay write rejected — fail the delta over to the DB at the

--- a/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
-use bcs_cache_api::{CachePlugin, CacheSetMode};
+use bcs_cache_api::{CacheError, CachePlugin, CacheSetMode};
 use bcs_db_api::{db_get_column, db_get_column_opt, DbPlugin, DbSqlFlavor, DbStatement, DbValue};
 use bcs_service_api::port::repo::{
     CasOutcome, ChatRunCompletionPolicy, ChatRunRecord, ChatRunRepoError, ChatRunRepoPort,
@@ -148,7 +148,19 @@ impl SqlChatRunRepo {
         }
     }
 
-    async fn write_overlay(&self, run_id: &str, overlay: &StreamingOverlay, expires_at_ms: u64) {
+    /// Write the streaming overlay. Returns `Ok(())` only when the store
+    /// confirmed the write (`set_value` → `Ok(true)`). A rejection, or the
+    /// no-write `Ok(false)` for an upsert (which means the delta was NOT
+    /// stored), is surfaced as `Err` so the caller that relies on the overlay
+    /// as the sole delta record (`append_streaming_content`) can fail over to
+    /// the DB. Best-effort callers (`create`, state CAS) ignore the result
+    /// since the DB row is authoritative there.
+    async fn write_overlay(
+        &self,
+        run_id: &str,
+        overlay: &StreamingOverlay,
+        expires_at_ms: u64,
+    ) -> Result<(), CacheError> {
         let now = now_ms();
         // Overlay must survive the run deadline by the retention grace so the
         // timeout sweep (which runs only once `expires_at_ms < now`) can still
@@ -157,17 +169,55 @@ impl SqlChatRunRepo {
             .saturating_add(self.overlay_retention_ms)
             .saturating_sub(now)
             .max(1000);
-        if let Ok(bytes) = serde_json::to_vec(overlay) {
-            let _ = self
-                .cache
-                .set_value(
-                    &self.cache_key(run_id),
-                    bytes,
-                    Some(Duration::from_millis(ttl_ms)),
-                    CacheSetMode::Upsert,
-                )
-                .await;
+        let bytes = serde_json::to_vec(overlay)
+            .map_err(|err| CacheError::InvalidInput(err.to_string()))?;
+        match self
+            .cache
+            .set_value(
+                &self.cache_key(run_id),
+                bytes,
+                Some(Duration::from_millis(ttl_ms)),
+                CacheSetMode::Upsert,
+            )
+            .await
+        {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(CacheError::Backend(
+                "streaming overlay upsert reported no write".to_string(),
+            )),
+            Err(err) => Err(err),
         }
+    }
+
+    /// Fail a streaming delta over to the authoritative DB row when the Redis
+    /// overlay write is unavailable (C4, #1546: never convert a backend write
+    /// failure into a lost delta). Writes `accumulated_content` directly with
+    /// `version = version + 1` under the non-terminal guard: applied →
+    /// `Ok(true)`, already-terminal (0 rows, delta not applied) → `Ok(false)`,
+    /// DB error → propagated `Backend`.
+    async fn fall_back_to_db_append(
+        &self,
+        run_id: &str,
+        accumulated: &str,
+        truncated: bool,
+    ) -> Result<bool, ChatRunRepoError> {
+        let now = now_ms();
+        let stmt = DbStatement::with_params(
+            &format!(
+                "UPDATE bcs_chat_runs SET accumulated_content = ?, content_truncated = ?, \
+                 version = version + 1, updated_at_ms = ? \
+                 WHERE run_id = ? AND state NOT IN ({TERMINAL_STATES}) AND env = ?"
+            ),
+            vec![
+                DbValue::from(accumulated.to_string()),
+                DbValue::from(truncated),
+                DbValue::from(now as i64),
+                DbValue::from(run_id.to_string()),
+                DbValue::from(self.env.as_str()),
+            ],
+        );
+        let result = self.db.execute(stmt).await.map_err(backend)?;
+        Ok(result.affected_rows > 0)
     }
 
     async fn delete_overlay(&self, run_id: &str) {
@@ -393,17 +443,20 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         );
         match self.db.execute(stmt).await {
             Ok(_) => {
-                self.write_overlay(
-                    &record.run_id,
-                    &StreamingOverlay {
-                        version: record.version,
-                        state: state_str(record.state).to_string(),
-                        accumulated_content: record.accumulated_content.clone(),
-                        content_truncated: record.content_truncated,
-                    },
-                    record.expires_at_ms,
-                )
-                .await;
+                // Overlay here is only a read cache of the just-inserted DB row;
+                // a write blip is benign (a later read falls back to the DB).
+                let _ = self
+                    .write_overlay(
+                        &record.run_id,
+                        &StreamingOverlay {
+                            version: record.version,
+                            state: state_str(record.state).to_string(),
+                            accumulated_content: record.accumulated_content.clone(),
+                            content_truncated: record.content_truncated,
+                        },
+                        record.expires_at_ms,
+                    )
+                    .await;
                 Ok(())
             }
             Err(err) if err.is_duplicate_key() => {
@@ -445,17 +498,20 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         let result = self.db.execute(stmt).await.map_err(backend)?;
         if result.affected_rows > 0 {
             let updated = read_full(self.db.as_ref(), run_id, &self.env).await?.unwrap_or(new.clone());
-            self.write_overlay(
-                run_id,
-                &StreamingOverlay {
-                    version: updated.version,
-                    state: state_str(updated.state).to_string(),
-                    accumulated_content: updated.accumulated_content.clone(),
-                    content_truncated: updated.content_truncated,
-                },
-                updated.expires_at_ms,
-            )
-            .await;
+            // Refresh the read-cache overlay of the just-applied DB state; best
+            // effort, since the DB row is authoritative on a read miss.
+            let _ = self
+                .write_overlay(
+                    run_id,
+                    &StreamingOverlay {
+                        version: updated.version,
+                        state: state_str(updated.state).to_string(),
+                        accumulated_content: updated.accumulated_content.clone(),
+                        content_truncated: updated.content_truncated,
+                    },
+                    updated.expires_at_ms,
+                )
+                .await;
             Ok(CasOutcome::Applied(updated))
         } else {
             classify_cas_failure(self.db.as_ref(), run_id, &self.env).await
@@ -537,8 +593,14 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         }
         overlay.accumulated_content = accumulated;
         overlay.content_truncated = truncated;
-        self.write_overlay(run_id, &overlay, expires_at_ms).await;
-        Ok(true)
+        match self.write_overlay(run_id, &overlay, expires_at_ms).await {
+            // Overlay (the sole delta record) confirmed the write.
+            Ok(()) => Ok(true),
+            // C4: the overlay write was rejected (Redis outage / upsert no-write).
+            // Fail the delta over to the authoritative DB row instead of
+            // silently dropping it (#1546 forbids a swallowed backend write).
+            Err(_) => self.fall_back_to_db_append(run_id, &overlay.accumulated_content, truncated).await,
+        }
     }
 
     async fn list_active(&self, now_ms: u64) -> Result<Vec<ChatRunRecord>, ChatRunRepoError> {

--- a/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
@@ -191,26 +191,30 @@ impl SqlChatRunRepo {
 
     /// Fail a streaming delta over to the authoritative DB row when the Redis
     /// overlay write is unavailable (C4, #1546: never convert a backend write
-    /// failure into a lost delta). Writes `accumulated_content` directly with
-    /// `version = version + 1` under the non-terminal guard: applied →
-    /// `Ok(true)`, already-terminal (0 rows, delta not applied) → `Ok(false)`,
-    /// DB error → propagated `Backend`.
+    /// failure into a lost delta). Writes `accumulated_content` at the
+    /// *intended* version (`version = ?`, not `version + 1`) so a stale overlay
+    /// left at a lower version can never be merged over the freshly persisted
+    /// row (P1): later reads/appends re-base off the DB. The non-terminal guard
+    /// still resolves a concurrent terminal to 0 rows. applied → `Ok(true)`,
+    /// already-terminal → `Ok(false)`, DB error → propagated `Backend`.
     async fn fall_back_to_db_append(
         &self,
         run_id: &str,
         accumulated: &str,
         truncated: bool,
+        intended_version: u64,
     ) -> Result<bool, ChatRunRepoError> {
         let now = now_ms();
         let stmt = DbStatement::with_params(
             &format!(
                 "UPDATE bcs_chat_runs SET accumulated_content = ?, content_truncated = ?, \
-                 version = version + 1, updated_at_ms = ? \
+                 version = ?, updated_at_ms = ? \
                  WHERE run_id = ? AND state NOT IN ({TERMINAL_STATES}) AND env = ?"
             ),
             vec![
                 DbValue::from(accumulated.to_string()),
                 DbValue::from(truncated),
+                DbValue::from(intended_version as i64),
                 DbValue::from(now as i64),
                 DbValue::from(run_id.to_string()),
                 DbValue::from(self.env.as_str()),
@@ -560,30 +564,31 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         accumulated: String,
         truncated: bool,
     ) -> Result<bool, ChatRunRepoError> {
-        // Base the overlay on the current overlay if present, else the DB row.
-        let mut overlay = match self.read_overlay(run_id).await {
-            Some(existing) => existing,
-            None => {
-                let Some(record) = self.read_db(run_id).await? else {
-                    return Ok(false);
-                };
-                StreamingOverlay {
-                    version: record.version,
-                    state: state_str(record.state).to_string(),
-                    accumulated_content: record.accumulated_content.clone(),
-                    content_truncated: record.content_truncated,
-                }
-            }
-        };
-        if overlay.version != expected_version {
+        // Read both the overlay (streaming hot cache) and the authoritative DB
+        // row, then base off whichever is newer. P1: a stale overlay left by a
+        // rejected write must never win over a DB row the fail-over advanced, so
+        // pick `max(overlay.version, db.version)` rather than trusting the overlay.
+        let overlay_opt = self.read_overlay(run_id).await;
+        let db_record = self.read_db(run_id).await?;
+        let expires_at_ms = db_record.as_ref().map(|r| r.expires_at_ms).unwrap_or(0);
+        if expires_at_ms == 0 {
             return Ok(false);
         }
-        let expires_at_ms = self
-            .read_db(run_id)
-            .await?
-            .map(|record| record.expires_at_ms)
-            .unwrap_or(0);
-        if expires_at_ms == 0 {
+        let mut overlay = match (overlay_opt, db_record) {
+            // Overlay is ahead of the DB — normal streaming; base off the overlay.
+            (Some(existing), Some(db)) if existing.version > db.version => existing,
+            // DB is at or ahead (incl. the fail-over case), or the overlay is
+            // gone — base off the authoritative DB row.
+            (_, Some(db)) => StreamingOverlay {
+                version: db.version,
+                state: state_str(db.state).to_string(),
+                accumulated_content: db.accumulated_content.clone(),
+                content_truncated: db.content_truncated,
+            },
+            // Overlay present but the DB row is gone — treat the run as missing.
+            (Some(_), None) | (None, None) => return Ok(false),
+        };
+        if overlay.version != expected_version {
             return Ok(false);
         }
         let flipped = overlay.state == "pending";
@@ -593,13 +598,27 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         }
         overlay.accumulated_content = accumulated;
         overlay.content_truncated = truncated;
+        let intended_version = overlay.version;
         match self.write_overlay(run_id, &overlay, expires_at_ms).await {
             // Overlay (the sole delta record) confirmed the write.
             Ok(()) => Ok(true),
-            // C4: the overlay write was rejected (Redis outage / upsert no-write).
-            // Fail the delta over to the authoritative DB row instead of
-            // silently dropping it (#1546 forbids a swallowed backend write).
-            Err(_) => self.fall_back_to_db_append(run_id, &overlay.accumulated_content, truncated).await,
+            // C4/P1: overlay write rejected — fail the delta over to the DB at the
+            // *intended* version, then drop the stale overlay best-effort so
+            // recovery re-bases off the DB. (#1546 forbids swallowing the write.)
+            Err(_) => {
+                let applied = self
+                    .fall_back_to_db_append(
+                        run_id,
+                        &overlay.accumulated_content,
+                        truncated,
+                        intended_version,
+                    )
+                    .await?;
+                if applied {
+                    self.delete_overlay(run_id).await;
+                }
+                Ok(applied)
+            }
         }
     }
 

--- a/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
@@ -3,15 +3,14 @@
 //! Authority split (see spec):
 //! - MySQL/SQLite is authoritative for state, version, ownership, timestamps,
 //!   terminal content, and is the auditable record.
-//! - The Redis cache holds the streaming overlay as the WHOLE
-//!   `ChatRunRecord` (V2 value; see `OverlayV2`) so per-token deltas never hit
-//!   the DB — and neither do reads: while a run streams, the overlay IS the
-//!   freshest fact (the DB row's content stays at its create/fail-over value),
-//!   so `get` serves a V2 hit directly ("read side follows the authority") and
-//!   only falls back to the historical DB-read + legacy-overlay merge on a
-//!   miss: terminal (terminal CAS deletes the overlay, so terminal reads
-//!   always land on the audit row), cache loss, or the rolling-upgrade window
-//!   where pre-upgrade replicas still write the legacy five-field value.
+//! - The Redis cache holds the streaming overlay as the WHOLE `ChatRunRecord`
+//!   so per-token deltas never hit the DB — and neither do reads: while a run
+//!   streams, the overlay IS the freshest fact (the DB row's content stays at
+//!   its create/fail-over value), so `get` serves an overlay hit directly
+//!   ("read side follows the authority") and only falls back to the DB row on
+//!   a miss: terminal (terminal CAS deletes the overlay), cache loss, or a
+//!   foreign-env value (the key is env-less). The cache holds a single
+//!   format; an unparseable value is treated as a miss (no legacy shape).
 //!
 //! The port's `expected_version` is used by memory-mode CAS; the SQL impl gates
 //! transitions on the non-terminal state guard (`state NOT IN (...)`) plus
@@ -21,12 +20,13 @@
 //!
 //! Accepted degraded window (mirrors the spec's C6 dual-failure stance): if
 //! Redis rejects BOTH the terminal tombstone write and the overlay delete
-//! while reads still work, a pre-terminal V2 snapshot stays readable until its
-//! TTL lapses; writers are unaffected (append bases are version-fenced at the
-//! DB boundary).
+//! while reads still work, a pre-terminal overlay snapshot stays readable
+//! until its TTL lapses; writers are unaffected (append bases are
+//! version-fenced at the DB boundary).
 
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -58,22 +58,17 @@ pub struct SqlChatRunRepo {
     /// `bcs-session-store` / `bcs-bot-store`.
     env: String,
     schema_ready: AtomicBool,
+    /// Runs whose overlay write was rejected (Redis can read but not write,
+    /// and its delete may also fail). A suspect run's `get` bypasses the
+    /// cache-first fast path and reads the authoritative DB row, so a stale
+    /// pre-fail-over overlay left in the cache cannot be served over the
+    /// advanced DB content. Cleared on the next successful overlay write
+    /// (create seed / append / state CAS refresh), so steady-state reads
+    /// stay on the zero-DB-read fast path.
+    suspect: Arc<Mutex<HashSet<String>>>,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
-struct StreamingOverlay {
-    version: u64,
-    state: String,
-    accumulated_content: String,
-    content_truncated: bool,
-    expires_at_ms: u64,
-}
-
-/// Format tag for [`OverlayV2`]; anything that fails to parse as V2 is tried
-/// as the legacy [`StreamingOverlay`] (rolling-upgrade compat window).
-const OVERLAY_FORMAT_VERSION: u32 = 2;
-
-/// V2 streaming overlay value: the WHOLE `ChatRunRecord` as the in-flight
+/// Streaming overlay value: the WHOLE `ChatRunRecord` as the in-flight
 /// read-through source. While a run streams, per-delta writes only land here,
 /// so the overlay is the freshest fact and `get` can serve it directly
 /// without a DB read. Terminal CAS deletes the key, so terminal reads always
@@ -90,18 +85,16 @@ const OVERLAY_FORMAT_VERSION: u32 = 2;
 /// detach classification in `record_run_event` would silently degrade on
 /// cache hits.
 #[derive(Serialize, Deserialize, Clone)]
-struct OverlayV2 {
-    v: u32,
+struct Overlay {
     env: String,
     record: ChatRunRecord,
     completion_policy: ChatRunCompletionPolicy,
     delivery_ack_at_ms: Option<u64>,
 }
 
-impl OverlayV2 {
+impl Overlay {
     fn from_record(record: &ChatRunRecord, env: &str) -> Self {
         Self {
-            v: OVERLAY_FORMAT_VERSION,
             env: env.to_string(),
             completion_policy: record.completion_policy,
             delivery_ack_at_ms: record.delivery_ack_at_ms,
@@ -113,40 +106,6 @@ impl OverlayV2 {
         self.record.completion_policy = self.completion_policy;
         self.record.delivery_ack_at_ms = self.delivery_ack_at_ms;
         self.record
-    }
-}
-
-/// Materialized append base. A full record comes from the V2 cache hit or the
-/// DB rebase; a legacy five-field overlay only occurs while pre-upgrade
-/// replicas still write the old value (rolling-upgrade window) — appends on
-/// such a base keep writing the legacy shape so those replicas stay correct,
-/// and the two generations meet at the authoritative DB row.
-#[derive(Clone)]
-enum OverlayBase {
-    Record(ChatRunRecord),
-    Legacy(StreamingOverlay),
-}
-
-impl OverlayBase {
-    fn version(&self) -> u64 {
-        match self {
-            OverlayBase::Record(record) => record.version,
-            OverlayBase::Legacy(overlay) => overlay.version,
-        }
-    }
-
-    /// Streaming content of the base — used by the state-CAS refresh so a
-    /// mid-stream transition never clobbers the streamed text back to the
-    /// DB row's create-time value.
-    fn streaming_content(&self) -> Option<(String, bool)> {
-        match self {
-            OverlayBase::Record(record) => {
-                Some((record.accumulated_content.clone(), record.content_truncated))
-            }
-            OverlayBase::Legacy(overlay) => {
-                Some((overlay.accumulated_content.clone(), overlay.content_truncated))
-            }
-        }
     }
 }
 
@@ -167,11 +126,37 @@ impl SqlChatRunRepo {
             overlay_retention_ms,
             env,
             schema_ready: AtomicBool::new(false),
+            suspect: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
     fn cache_key(&self, run_id: &str) -> String {
         format!("{}chat_run:{}", self.key_prefix, run_id)
+    }
+
+    /// Whether `get` must bypass the cache-first fast path for this run.
+    fn is_suspect(&self, run_id: &str) -> bool {
+        self.suspect
+            .lock()
+            .map(|s| s.contains(run_id))
+            .unwrap_or(false)
+    }
+
+    /// Mark a run cache-suspect after an overlay write was rejected: the read
+    /// path must source from the DB until a later successful overlay write
+    /// restores the cache as the freshest fact.
+    fn mark_suspect(&self, run_id: &str) {
+        if let Ok(mut s) = self.suspect.lock() {
+            s.insert(run_id.to_string());
+        }
+    }
+
+    /// Drop the suspect flag once the cache has accepted a fresh overlay
+    /// write — the fast path is reliable again.
+    fn clear_suspect(&self, run_id: &str) {
+        if let Ok(mut s) = self.suspect.lock() {
+            s.remove(run_id);
+        }
     }
 
     async fn ensure_schema(&self) -> Result<(), ChatRunRepoError> {
@@ -241,24 +226,22 @@ impl SqlChatRunRepo {
         }
     }
 
-    /// Parse the cached overlay value into a base: V2 (whole record) first —
-    /// served only when `env` matches, since the cache key is env-less and a
-    /// shared Redis may hold another environment's value for the same run_id —
-    /// then the legacy five-field format (rolling-upgrade window). `None`
-    /// when the key is missing, unreadable, or neither format parses.
-    async fn read_overlay_base(&self, run_id: &str) -> Option<OverlayBase> {
+    /// Parse the cached overlay value into the whole record, served only when
+    /// `env` matches: the cache key is env-less, and a shared Redis may hold
+    /// another environment's value for the same run_id, so a foreign value
+    /// must not be served (it falls through to the env-scoped DB). `None`
+    /// when the key is missing, unreadable, fails to parse, or belongs to
+    /// another env.
+    async fn read_overlay_record(&self, run_id: &str) -> Option<ChatRunRecord> {
         let bytes = self.read_overlay_bytes(run_id).await?;
-        if let Ok(v2) = serde_json::from_slice::<OverlayV2>(&bytes) {
-            if v2.env == self.env {
-                return Some(OverlayBase::Record(v2.into_record()));
-            }
+        let overlay = serde_json::from_slice::<Overlay>(&bytes).ok()?;
+        if overlay.env != self.env {
+            return None;
         }
-        serde_json::from_slice::<StreamingOverlay>(&bytes)
-            .ok()
-            .map(OverlayBase::Legacy)
+        Some(overlay.into_record())
     }
 
-    /// Write the whole-record (V2) streaming overlay. Returns `Ok(())` only
+    /// Write the whole-record streaming overlay. Returns `Ok(())` only
     /// when the store confirmed the write (`set_value` → `Ok(true)`); a
     /// rejection, or the no-write `Ok(false)` for an upsert, is surfaced as
     /// `Err` so the caller that relies on the overlay as the sole delta
@@ -270,22 +253,15 @@ impl SqlChatRunRepo {
         run_id: &str,
         record: &ChatRunRecord,
     ) -> Result<(), CacheError> {
-        let bytes = serde_json::to_vec(&OverlayV2::from_record(record, &self.env))
+        let bytes = serde_json::to_vec(&Overlay::from_record(record, &self.env))
             .map_err(|err| CacheError::InvalidInput(err.to_string()))?;
-        self.set_overlay_bytes(run_id, bytes, record.expires_at_ms).await
-    }
-
-    /// Legacy-format overlay write, used only when the append base itself
-    /// came from a legacy value (rolling-upgrade window) so pre-upgrade
-    /// replicas can still read what this replica writes.
-    async fn write_overlay_legacy(
-        &self,
-        run_id: &str,
-        overlay: &StreamingOverlay,
-    ) -> Result<(), CacheError> {
-        let bytes = serde_json::to_vec(overlay)
-            .map_err(|err| CacheError::InvalidInput(err.to_string()))?;
-        self.set_overlay_bytes(run_id, bytes, overlay.expires_at_ms).await
+        match self.set_overlay_bytes(run_id, bytes, record.expires_at_ms).await {
+            Ok(()) => {
+                self.clear_suspect(run_id);
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
     }
 
     /// Store the overlay value with its deadline-derived TTL. The overlay
@@ -357,24 +333,23 @@ impl SqlChatRunRepo {
     }
 
     /// Resolve the base for a streaming append. Fast path: when the cache
-    /// holds an overlay (V2 or legacy) at exactly the caller's expected
-    /// version it is the streaming source of truth and is used directly
-    /// **without a DB read** (issue spec: per-token deltas never hit the DB on
-    /// the normal path). An overlay newer than the caller's expectation means
-    /// the caller is stale → no base (`Ok(None)` → append returns
-    /// `Ok(false)`). A missing or behind-version overlay (Redis outage /
-    /// stale-after-fail-over / legacy-format window) falls back to the
-    /// authoritative DB row — the recovery path that has to read MySQL anyway,
-    /// and the meeting point for the rolling-upgrade format window. Returns
-    /// `Ok(None)` when the run is missing or its version does not match.
+    /// holds an overlay at exactly the caller's expected version it is the
+    /// streaming source of truth and is used directly **without a DB read**
+    /// (issue spec: per-token deltas never hit the DB on the normal path). An
+    /// overlay newer than the caller's expectation means the caller is stale
+    /// → no base (`Ok(None)` → append returns `Ok(false)`). A missing or
+    /// behind-version overlay (Redis outage / stale-after-fail-over / a
+    /// foreign-env value) falls back to the authoritative DB row — the
+    /// recovery path that has to read MySQL anyway. Returns `Ok(None)` when
+    /// the run is missing or its version does not match.
     async fn resolve_append_base(
         &self,
         run_id: &str,
         expected_version: u64,
-    ) -> Result<Option<OverlayBase>, ChatRunRepoError> {
-        match self.read_overlay_base(run_id).await {
-            Some(base) if base.version() == expected_version => return Ok(Some(base)),
-            Some(base) if base.version() > expected_version => return Ok(None),
+    ) -> Result<Option<ChatRunRecord>, ChatRunRepoError> {
+        match self.read_overlay_record(run_id).await {
+            Some(record) if record.version == expected_version => return Ok(Some(record)),
+            Some(record) if record.version > expected_version => return Ok(None),
             _ => {}
         }
         let Some(db) = self.read_db(run_id).await? else {
@@ -383,33 +358,11 @@ impl SqlChatRunRepo {
         if db.expires_at_ms == 0 {
             return Ok(None);
         }
-        Ok(if db.version == expected_version {
-            Some(OverlayBase::Record(db))
-        } else {
-            None
-        })
+        Ok(if db.version == expected_version { Some(db) } else { None })
     }
 
     async fn delete_overlay(&self, run_id: &str) {
         let _ = self.cache.delete(&self.cache_key(run_id)).await;
-    }
-
-    /// Merge the authoritative DB record with the streaming overlay when the
-    /// overlay version is ahead (streaming advanced it past the DB) and the run
-    /// is still non-terminal.
-    fn merge(record: ChatRunRecord, overlay: Option<StreamingOverlay>) -> ChatRunRecord {
-        let Some(overlay) = overlay else {
-            return record;
-        };
-        if record.state.is_terminal() || overlay.version <= record.version {
-            return record;
-        }
-        let mut merged = record;
-        merged.version = overlay.version;
-        merged.state = parse_state(&overlay.state).unwrap_or(merged.state);
-        merged.accumulated_content = overlay.accumulated_content;
-        merged.content_truncated = overlay.content_truncated;
-        merged
     }
 }
 
@@ -629,32 +582,21 @@ impl ChatRunRepoPort for SqlChatRunRepo {
     async fn get(&self, run_id: &str) -> Result<Option<ChatRunRecord>, ChatRunRepoError> {
         // Read-through fast path ("read side follows the authority"): while a
         // run streams, the overlay is the freshest fact — per-delta writes
-        // only land there — so a V2 hit answers the whole record with ZERO DB
-        // reads. Misses fall back to the historical DB-read + legacy-overlay
-        // merge: terminal runs (the terminal CAS deletes the overlay, so they
-        // always read the audit row), cache loss, and the rolling-upgrade
-        // window where pre-upgrade replicas write the legacy value. The
-        // fallback keeps `get` side-effect-free: no re-seed on miss; an
-        // active run's lost overlay is re-seeded by the next delta write.
-        let overlay_bytes = self.read_overlay_bytes(run_id).await;
-        if let Some(bytes) = overlay_bytes.as_deref() {
-            if let Ok(v2) = serde_json::from_slice::<OverlayV2>(bytes) {
-                // Env gate: the key is env-less, so a shared Redis may hold
-                // another environment's V2 value for this run_id — only serve
-                // our own; foreign values fall through to the env-scoped DB.
-                if v2.env == self.env {
-                    return Ok(Some(v2.into_record()));
-                }
+        // only land there — so an overlay hit answers the whole record with
+        // ZERO DB reads. A miss falls back to the authoritative DB row:
+        // terminal runs (terminal CAS deletes the overlay), cache loss, or a
+        // foreign-env value. A cache-SUSPECT run (an overlay write was
+        // rejected) bypasses the fast path: a stale pre-fail-over overlay
+        // left in the cache must never be served over the advanced DB row.
+        // Cleared on the next successful overlay write. `get` stays
+        // side-effect-free: no re-seed on a miss; an active run's lost
+        // overlay is re-seeded by the next delta write.
+        if !self.is_suspect(run_id) {
+            if let Some(record) = self.read_overlay_record(run_id).await {
+                return Ok(Some(record));
             }
         }
-        let Some(record) = self.read_db(run_id).await? else {
-            // No DB row; not even created here.
-            return Ok(None);
-        };
-        let overlay = overlay_bytes
-            .as_deref()
-            .and_then(|bytes| serde_json::from_slice::<StreamingOverlay>(bytes).ok());
-        Ok(Some(Self::merge(record, overlay)))
+        self.read_db(run_id).await
     }
 
     async fn compare_and_set_state(
@@ -690,13 +632,9 @@ impl ChatRunRepoPort for SqlChatRunRepo {
             // CAS lands mid-stream (e.g. a detach acknowledgement on the
             // first content-bearing event).
             let mut refreshed = updated.clone();
-            if let Some((content, truncated)) = self
-                .read_overlay_base(run_id)
-                .await
-                .and_then(|base| base.streaming_content())
-            {
-                refreshed.accumulated_content = content;
-                refreshed.content_truncated = truncated;
+            if let Some(base) = self.read_overlay_record(run_id).await {
+                refreshed.accumulated_content = base.accumulated_content;
+                refreshed.content_truncated = base.content_truncated;
             }
             let _ = self.write_overlay_record(run_id, &refreshed).await;
             Ok(CasOutcome::Applied(updated))
@@ -734,8 +672,8 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         if result.affected_rows > 0 {
             let updated = read_full(self.db.as_ref(), run_id, &self.env).await?.unwrap_or(new);
             // Tombstone before delete: best-effort write of the terminal record
-            // first, so a failed delete cannot leave a readable pre-terminal V2
-            // snapshot served cache-first. The delete then reclaims the key so
+            // first, so a failed delete cannot leave a readable pre-terminal
+            // overlay snapshot served cache-first. The delete then reclaims the key so
             // terminal reads land on the audited DB row. If BOTH fail, the
             // stale overlay stays readable until its TTL (accepted degraded
             // window, see module docs); writers remain safe — append bases
@@ -759,43 +697,31 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         // from the overlay without a DB read (see `resolve_append_base`); the DB
         // is only touched when the overlay is missing or stale (fail-over /
         // recovery), which is the path that has to read MySQL anyway.
-        let Some(base) = self.resolve_append_base(run_id, expected_version).await? else {
+        let Some(mut record) = self.resolve_append_base(run_id, expected_version).await? else {
             return Ok(false);
         };
         let intended_version = expected_version + 1;
         let now = now_ms();
-        let cache_write: Result<(), CacheError> = match base {
-            OverlayBase::Record(mut record) => {
-                let flipped = record.state == ChatRunState::Pending;
-                record.version = intended_version;
-                if flipped {
-                    record.state = ChatRunState::Running;
-                }
-                record.accumulated_content = accumulated.clone();
-                record.content_truncated = truncated;
-                record.updated_at_ms = now;
-                self.write_overlay_record(run_id, &record).await
-            }
-            // Legacy-format base (rolling-upgrade window): keep writing the
-            // legacy shape so pre-upgrade replicas can keep reading it.
-            OverlayBase::Legacy(mut overlay) => {
-                let flipped = overlay.state == "pending";
-                overlay.version = intended_version;
-                if flipped {
-                    overlay.state = "running".to_string();
-                }
-                overlay.accumulated_content = accumulated.clone();
-                overlay.content_truncated = truncated;
-                self.write_overlay_legacy(run_id, &overlay).await
-            }
-        };
+        let flipped = record.state == ChatRunState::Pending;
+        record.version = intended_version;
+        if flipped {
+            record.state = ChatRunState::Running;
+        }
+        record.accumulated_content = accumulated.clone();
+        record.content_truncated = truncated;
+        record.updated_at_ms = now;
+        let cache_write: Result<(), CacheError> =
+            self.write_overlay_record(run_id, &record).await;
         match cache_write {
             // Overlay (the sole delta record) confirmed the write.
             Ok(()) => Ok(true),
             // C4/P1: overlay write rejected — fail the delta over to the DB at the
             // *intended* version, then drop the stale overlay best-effort so
             // recovery re-bases off the DB. (#1546 forbids swallowing the write.)
+            // Mark the run cache-suspect: if the delete also fails, a stale
+            // pre-fail-over overlay must not be served cache-first.
             Err(_) => {
+                self.mark_suspect(run_id);
                 let applied = self
                     .fall_back_to_db_append(run_id, &accumulated, truncated, intended_version)
                     .await?;

--- a/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
@@ -3,16 +3,27 @@
 //! Authority split (see spec):
 //! - MySQL/SQLite is authoritative for state, version, ownership, timestamps,
 //!   terminal content, and is the auditable record.
-//! - The Redis cache holds only the streaming overlay (`{version, state,
-//!   accumulated_content, content_truncated}`) so per-token deltas never hit
-//!   the DB. Reads merge DB (authoritative structure) with the cache overlay
-//!   when the cache version is ahead (i.e. streaming advanced it past the DB).
+//! - The Redis cache holds the streaming overlay as the WHOLE
+//!   `ChatRunRecord` (V2 value; see `OverlayV2`) so per-token deltas never hit
+//!   the DB — and neither do reads: while a run streams, the overlay IS the
+//!   freshest fact (the DB row's content stays at its create/fail-over value),
+//!   so `get` serves a V2 hit directly ("read side follows the authority") and
+//!   only falls back to the historical DB-read + legacy-overlay merge on a
+//!   miss: terminal (terminal CAS deletes the overlay, so terminal reads
+//!   always land on the audit row), cache loss, or the rolling-upgrade window
+//!   where pre-upgrade replicas still write the legacy five-field value.
 //!
 //! The port's `expected_version` is used by memory-mode CAS; the SQL impl gates
 //! transitions on the non-terminal state guard (`state NOT IN (...)`) plus
 //! `version = version + 1`, which is robust to the cache/DB version drift
 //! inherent in streaming-only cache writes. Concurrent terminals resolve to
 //! exactly one winner via the same state guard.
+//!
+//! Accepted degraded window (mirrors the spec's C6 dual-failure stance): if
+//! Redis rejects BOTH the terminal tombstone write and the overlay delete
+//! while reads still work, a pre-terminal V2 snapshot stays readable until its
+//! TTL lapses; writers are unaffected (append bases are version-fenced at the
+//! DB boundary).
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -55,9 +66,88 @@ struct StreamingOverlay {
     state: String,
     accumulated_content: String,
     content_truncated: bool,
-    /// Run deadline carried in the overlay so the normal streaming path can
-    /// compute its TTL (and detect a missing run) without a per-delta DB read.
     expires_at_ms: u64,
+}
+
+/// Format tag for [`OverlayV2`]; anything that fails to parse as V2 is tried
+/// as the legacy [`StreamingOverlay`] (rolling-upgrade compat window).
+const OVERLAY_FORMAT_VERSION: u32 = 2;
+
+/// V2 streaming overlay value: the WHOLE `ChatRunRecord` as the in-flight
+/// read-through source. While a run streams, per-delta writes only land here,
+/// so the overlay is the freshest fact and `get` can serve it directly
+/// without a DB read. Terminal CAS deletes the key, so terminal reads always
+/// fall back to the audited DB row.
+///
+/// The cache KEY is env-less (`{prefix}chat_run:{run_id}`) while the DB rows
+/// are env-scoped, so the value carries `env` and every fast-path read must
+/// match it before serving — otherwise a shared Redis would leak one
+/// environment's run into another's cache-first reads.
+///
+/// `completion_policy` / `delivery_ack_at_ms` are carried at the wrapper
+/// level because `ChatRunRecord`'s own serde skips them (the port crate keeps
+/// them out of its serialized shape); the cache must round-trip them or the
+/// detach classification in `record_run_event` would silently degrade on
+/// cache hits.
+#[derive(Serialize, Deserialize, Clone)]
+struct OverlayV2 {
+    v: u32,
+    env: String,
+    record: ChatRunRecord,
+    completion_policy: ChatRunCompletionPolicy,
+    delivery_ack_at_ms: Option<u64>,
+}
+
+impl OverlayV2 {
+    fn from_record(record: &ChatRunRecord, env: &str) -> Self {
+        Self {
+            v: OVERLAY_FORMAT_VERSION,
+            env: env.to_string(),
+            completion_policy: record.completion_policy,
+            delivery_ack_at_ms: record.delivery_ack_at_ms,
+            record: record.clone(),
+        }
+    }
+
+    fn into_record(mut self) -> ChatRunRecord {
+        self.record.completion_policy = self.completion_policy;
+        self.record.delivery_ack_at_ms = self.delivery_ack_at_ms;
+        self.record
+    }
+}
+
+/// Materialized append base. A full record comes from the V2 cache hit or the
+/// DB rebase; a legacy five-field overlay only occurs while pre-upgrade
+/// replicas still write the old value (rolling-upgrade window) — appends on
+/// such a base keep writing the legacy shape so those replicas stay correct,
+/// and the two generations meet at the authoritative DB row.
+#[derive(Clone)]
+enum OverlayBase {
+    Record(ChatRunRecord),
+    Legacy(StreamingOverlay),
+}
+
+impl OverlayBase {
+    fn version(&self) -> u64 {
+        match self {
+            OverlayBase::Record(record) => record.version,
+            OverlayBase::Legacy(overlay) => overlay.version,
+        }
+    }
+
+    /// Streaming content of the base — used by the state-CAS refresh so a
+    /// mid-stream transition never clobbers the streamed text back to the
+    /// DB row's create-time value.
+    fn streaming_content(&self) -> Option<(String, bool)> {
+        match self {
+            OverlayBase::Record(record) => {
+                Some((record.accumulated_content.clone(), record.content_truncated))
+            }
+            OverlayBase::Legacy(overlay) => {
+                Some((overlay.accumulated_content.clone(), overlay.content_truncated))
+            }
+        }
+    }
 }
 
 impl SqlChatRunRepo {
@@ -144,32 +234,75 @@ impl SqlChatRunRepo {
             .transpose()?)
     }
 
-    async fn read_overlay(&self, run_id: &str) -> Option<StreamingOverlay> {
+    async fn read_overlay_bytes(&self, run_id: &str) -> Option<Vec<u8>> {
         match self.cache.get_value(&self.cache_key(run_id)).await {
-            Ok(Some(bytes)) => serde_json::from_slice(&bytes).ok(),
+            Ok(Some(bytes)) => Some(bytes),
             _ => None,
         }
     }
 
-    /// Write the streaming overlay. Returns `Ok(())` only when the store
-    /// confirmed the write (`set_value` → `Ok(true)`). A rejection, or the
-    /// no-write `Ok(false)` for an upsert (which means the delta was NOT
-    /// stored), is surfaced as `Err` so the caller that relies on the overlay
-    /// as the sole delta record (`append_streaming_content`) can fail over to
-    /// the DB. Best-effort callers (`create`, state CAS) ignore the result
-    /// since the DB row is authoritative there.
-    async fn write_overlay(&self, run_id: &str, overlay: &StreamingOverlay) -> Result<(), CacheError> {
+    /// Parse the cached overlay value into a base: V2 (whole record) first —
+    /// served only when `env` matches, since the cache key is env-less and a
+    /// shared Redis may hold another environment's value for the same run_id —
+    /// then the legacy five-field format (rolling-upgrade window). `None`
+    /// when the key is missing, unreadable, or neither format parses.
+    async fn read_overlay_base(&self, run_id: &str) -> Option<OverlayBase> {
+        let bytes = self.read_overlay_bytes(run_id).await?;
+        if let Ok(v2) = serde_json::from_slice::<OverlayV2>(&bytes) {
+            if v2.env == self.env {
+                return Some(OverlayBase::Record(v2.into_record()));
+            }
+        }
+        serde_json::from_slice::<StreamingOverlay>(&bytes)
+            .ok()
+            .map(OverlayBase::Legacy)
+    }
+
+    /// Write the whole-record (V2) streaming overlay. Returns `Ok(())` only
+    /// when the store confirmed the write (`set_value` → `Ok(true)`); a
+    /// rejection, or the no-write `Ok(false)` for an upsert, is surfaced as
+    /// `Err` so the caller that relies on the overlay as the sole delta
+    /// record (`append_streaming_content`) can fail over to the DB.
+    /// Best-effort callers (`create`, state CAS) ignore the result since the
+    /// DB row is authoritative there.
+    async fn write_overlay_record(
+        &self,
+        run_id: &str,
+        record: &ChatRunRecord,
+    ) -> Result<(), CacheError> {
+        let bytes = serde_json::to_vec(&OverlayV2::from_record(record, &self.env))
+            .map_err(|err| CacheError::InvalidInput(err.to_string()))?;
+        self.set_overlay_bytes(run_id, bytes, record.expires_at_ms).await
+    }
+
+    /// Legacy-format overlay write, used only when the append base itself
+    /// came from a legacy value (rolling-upgrade window) so pre-upgrade
+    /// replicas can still read what this replica writes.
+    async fn write_overlay_legacy(
+        &self,
+        run_id: &str,
+        overlay: &StreamingOverlay,
+    ) -> Result<(), CacheError> {
+        let bytes = serde_json::to_vec(overlay)
+            .map_err(|err| CacheError::InvalidInput(err.to_string()))?;
+        self.set_overlay_bytes(run_id, bytes, overlay.expires_at_ms).await
+    }
+
+    /// Store the overlay value with its deadline-derived TTL. The overlay
+    /// must survive the run deadline by the retention grace so the timeout
+    /// sweep (which runs only once `expires_at_ms < now`) can still merge the
+    /// streamed content instead of reading a stale DB row.
+    async fn set_overlay_bytes(
+        &self,
+        run_id: &str,
+        bytes: Vec<u8>,
+        expires_at_ms: u64,
+    ) -> Result<(), CacheError> {
         let now = now_ms();
-        // Overlay must survive the run deadline by the retention grace so the
-        // timeout sweep (which runs only once `expires_at_ms < now`) can still
-        // merge the streamed content instead of reading a stale DB row.
-        let ttl_ms = overlay
-            .expires_at_ms
+        let ttl_ms = expires_at_ms
             .saturating_add(self.overlay_retention_ms)
             .saturating_sub(now)
             .max(1000);
-        let bytes = serde_json::to_vec(overlay)
-            .map_err(|err| CacheError::InvalidInput(err.to_string()))?;
         match self
             .cache
             .set_value(
@@ -223,23 +356,25 @@ impl SqlChatRunRepo {
         Ok(result.affected_rows > 0)
     }
 
-    /// Resolve the base for a streaming append. Fast path: when the overlay is
-    /// present at exactly the caller's expected version it is the streaming
-    /// source of truth and is used directly **without a DB read** (issue spec:
-    /// per-token deltas never hit the DB on the normal path). An overlay newer
-    /// than the caller's expectation means the caller is stale → no base
-    /// (`Ok(None)` → append returns `Ok(false)`). A missing or behind-version
-    /// overlay (Redis outage / stale-after-fail-over) falls back to the
-    /// authoritative DB row — the recovery path that has to read MySQL anyway.
-    /// Returns `Ok(None)` when the run is missing or its version does not match.
+    /// Resolve the base for a streaming append. Fast path: when the cache
+    /// holds an overlay (V2 or legacy) at exactly the caller's expected
+    /// version it is the streaming source of truth and is used directly
+    /// **without a DB read** (issue spec: per-token deltas never hit the DB on
+    /// the normal path). An overlay newer than the caller's expectation means
+    /// the caller is stale → no base (`Ok(None)` → append returns
+    /// `Ok(false)`). A missing or behind-version overlay (Redis outage /
+    /// stale-after-fail-over / legacy-format window) falls back to the
+    /// authoritative DB row — the recovery path that has to read MySQL anyway,
+    /// and the meeting point for the rolling-upgrade format window. Returns
+    /// `Ok(None)` when the run is missing or its version does not match.
     async fn resolve_append_base(
         &self,
         run_id: &str,
         expected_version: u64,
-    ) -> Result<Option<StreamingOverlay>, ChatRunRepoError> {
-        match self.read_overlay(run_id).await {
-            Some(existing) if existing.version == expected_version => return Ok(Some(existing)),
-            Some(existing) if existing.version > expected_version => return Ok(None),
+    ) -> Result<Option<OverlayBase>, ChatRunRepoError> {
+        match self.read_overlay_base(run_id).await {
+            Some(base) if base.version() == expected_version => return Ok(Some(base)),
+            Some(base) if base.version() > expected_version => return Ok(None),
             _ => {}
         }
         let Some(db) = self.read_db(run_id).await? else {
@@ -248,15 +383,8 @@ impl SqlChatRunRepo {
         if db.expires_at_ms == 0 {
             return Ok(None);
         }
-        let overlay = StreamingOverlay {
-            version: db.version,
-            state: state_str(db.state).to_string(),
-            accumulated_content: db.accumulated_content.clone(),
-            content_truncated: db.content_truncated,
-            expires_at_ms: db.expires_at_ms,
-        };
-        Ok(if overlay.version == expected_version {
-            Some(overlay)
+        Ok(if db.version == expected_version {
+            Some(OverlayBase::Record(db))
         } else {
             None
         })
@@ -485,20 +613,10 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         );
         match self.db.execute(stmt).await {
             Ok(_) => {
-                // Overlay here is only a read cache of the just-inserted DB row;
-                // a write blip is benign (a later read falls back to the DB).
-                let _ = self
-                    .write_overlay(
-                        &record.run_id,
-                        &StreamingOverlay {
-                            version: record.version,
-                            state: state_str(record.state).to_string(),
-                            accumulated_content: record.accumulated_content.clone(),
-                            content_truncated: record.content_truncated,
-                            expires_at_ms: record.expires_at_ms,
-                        },
-                    )
-                    .await;
+                // Seed the whole-record overlay so `get` can serve this run
+                // cache-first from the very first poll; a write blip is
+                // benign (the read falls back to the just-inserted DB row).
+                let _ = self.write_overlay_record(&record.run_id, &record).await;
                 Ok(())
             }
             Err(err) if err.is_duplicate_key() => {
@@ -509,11 +627,33 @@ impl ChatRunRepoPort for SqlChatRunRepo {
     }
 
     async fn get(&self, run_id: &str) -> Result<Option<ChatRunRecord>, ChatRunRepoError> {
+        // Read-through fast path ("read side follows the authority"): while a
+        // run streams, the overlay is the freshest fact — per-delta writes
+        // only land there — so a V2 hit answers the whole record with ZERO DB
+        // reads. Misses fall back to the historical DB-read + legacy-overlay
+        // merge: terminal runs (the terminal CAS deletes the overlay, so they
+        // always read the audit row), cache loss, and the rolling-upgrade
+        // window where pre-upgrade replicas write the legacy value. The
+        // fallback keeps `get` side-effect-free: no re-seed on miss; an
+        // active run's lost overlay is re-seeded by the next delta write.
+        let overlay_bytes = self.read_overlay_bytes(run_id).await;
+        if let Some(bytes) = overlay_bytes.as_deref() {
+            if let Ok(v2) = serde_json::from_slice::<OverlayV2>(bytes) {
+                // Env gate: the key is env-less, so a shared Redis may hold
+                // another environment's V2 value for this run_id — only serve
+                // our own; foreign values fall through to the env-scoped DB.
+                if v2.env == self.env {
+                    return Ok(Some(v2.into_record()));
+                }
+            }
+        }
         let Some(record) = self.read_db(run_id).await? else {
             // No DB row; not even created here.
             return Ok(None);
         };
-        let overlay = self.read_overlay(run_id).await;
+        let overlay = overlay_bytes
+            .as_deref()
+            .and_then(|bytes| serde_json::from_slice::<StreamingOverlay>(bytes).ok());
         Ok(Some(Self::merge(record, overlay)))
     }
 
@@ -542,18 +682,23 @@ impl ChatRunRepoPort for SqlChatRunRepo {
             let updated = read_full(self.db.as_ref(), run_id, &self.env).await?.unwrap_or(new.clone());
             // Refresh the read-cache overlay of the just-applied DB state; best
             // effort, since the DB row is authoritative on a read miss.
-            let _ = self
-                .write_overlay(
-                    run_id,
-                    &StreamingOverlay {
-                        version: updated.version,
-                        state: state_str(updated.state).to_string(),
-                        accumulated_content: updated.accumulated_content.clone(),
-                        content_truncated: updated.content_truncated,
-                        expires_at_ms: updated.expires_at_ms,
-                    },
-                )
-                .await;
+            // Compose, don't mirror: the DB row is authoritative for version,
+            // state, ack, and timestamps, but its `accumulated_content` is the
+            // create/fail-over-time value while the run streams — the streamed
+            // text lives only in the overlay. Taking the DB row wholesale here
+            // would clobber the content back to create-time whenever a state
+            // CAS lands mid-stream (e.g. a detach acknowledgement on the
+            // first content-bearing event).
+            let mut refreshed = updated.clone();
+            if let Some((content, truncated)) = self
+                .read_overlay_base(run_id)
+                .await
+                .and_then(|base| base.streaming_content())
+            {
+                refreshed.accumulated_content = content;
+                refreshed.content_truncated = truncated;
+            }
+            let _ = self.write_overlay_record(run_id, &refreshed).await;
             Ok(CasOutcome::Applied(updated))
         } else {
             classify_cas_failure(self.db.as_ref(), run_id, &self.env).await
@@ -587,8 +732,16 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         );
         let result = self.db.execute(stmt).await.map_err(backend)?;
         if result.affected_rows > 0 {
-            self.delete_overlay(run_id).await;
             let updated = read_full(self.db.as_ref(), run_id, &self.env).await?.unwrap_or(new);
+            // Tombstone before delete: best-effort write of the terminal record
+            // first, so a failed delete cannot leave a readable pre-terminal V2
+            // snapshot served cache-first. The delete then reclaims the key so
+            // terminal reads land on the audited DB row. If BOTH fail, the
+            // stale overlay stays readable until its TTL (accepted degraded
+            // window, see module docs); writers remain safe — append bases
+            // are version-fenced at the DB boundary.
+            let _ = self.write_overlay_record(run_id, &updated).await;
+            self.delete_overlay(run_id).await;
             Ok(CasOutcome::Applied(updated))
         } else {
             classify_cas_failure(self.db.as_ref(), run_id, &self.env).await
@@ -606,18 +759,37 @@ impl ChatRunRepoPort for SqlChatRunRepo {
         // from the overlay without a DB read (see `resolve_append_base`); the DB
         // is only touched when the overlay is missing or stale (fail-over /
         // recovery), which is the path that has to read MySQL anyway.
-        let Some(mut overlay) = self.resolve_append_base(run_id, expected_version).await? else {
+        let Some(base) = self.resolve_append_base(run_id, expected_version).await? else {
             return Ok(false);
         };
-        let flipped = overlay.state == "pending";
-        overlay.version += 1;
-        if flipped {
-            overlay.state = "running".to_string();
-        }
-        overlay.accumulated_content = accumulated;
-        overlay.content_truncated = truncated;
-        let intended_version = overlay.version;
-        match self.write_overlay(run_id, &overlay).await {
+        let intended_version = expected_version + 1;
+        let now = now_ms();
+        let cache_write: Result<(), CacheError> = match base {
+            OverlayBase::Record(mut record) => {
+                let flipped = record.state == ChatRunState::Pending;
+                record.version = intended_version;
+                if flipped {
+                    record.state = ChatRunState::Running;
+                }
+                record.accumulated_content = accumulated.clone();
+                record.content_truncated = truncated;
+                record.updated_at_ms = now;
+                self.write_overlay_record(run_id, &record).await
+            }
+            // Legacy-format base (rolling-upgrade window): keep writing the
+            // legacy shape so pre-upgrade replicas can keep reading it.
+            OverlayBase::Legacy(mut overlay) => {
+                let flipped = overlay.state == "pending";
+                overlay.version = intended_version;
+                if flipped {
+                    overlay.state = "running".to_string();
+                }
+                overlay.accumulated_content = accumulated.clone();
+                overlay.content_truncated = truncated;
+                self.write_overlay_legacy(run_id, &overlay).await
+            }
+        };
+        match cache_write {
             // Overlay (the sole delta record) confirmed the write.
             Ok(()) => Ok(true),
             // C4/P1: overlay write rejected — fail the delta over to the DB at the
@@ -625,12 +797,7 @@ impl ChatRunRepoPort for SqlChatRunRepo {
             // recovery re-bases off the DB. (#1546 forbids swallowing the write.)
             Err(_) => {
                 let applied = self
-                    .fall_back_to_db_append(
-                        run_id,
-                        &overlay.accumulated_content,
-                        truncated,
-                        intended_version,
-                    )
+                    .fall_back_to_db_append(run_id, &accumulated, truncated, intended_version)
                     .await?;
                 if applied {
                     self.delete_overlay(run_id).await;

--- a/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
@@ -98,6 +98,85 @@ fn repo_failing_cache() -> SqlChatRunRepo {
     )
 }
 
+/// Cache double for the P1 fail-over scenario. `set_value` and `delete` always
+/// reject (Redis can neither accept the new overlay nor evict the stale one on
+/// fail-over), while `get_value` reads an in-memory store that can be pre-seeded
+/// with a *stale* overlay — modeling Redis still holding a prior successful
+/// overlay that the rejected write cannot erase.
+struct StaleOverlayFailingCache {
+    inner: InMemoryCachePlugin,
+}
+
+impl StaleOverlayFailingCache {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryCachePlugin::new(),
+        }
+    }
+
+    /// Seed a stale overlay at `key` (a prior successful write Redis still holds).
+    /// `set_value`/`delete` remain rejected.
+    async fn seed(&self, key: &str, bytes: Vec<u8>) {
+        let _ = self
+            .inner
+            .set_value(key, bytes, None, CacheSetMode::Upsert)
+            .await;
+    }
+}
+
+#[async_trait]
+impl CachePlugin for StaleOverlayFailingCache {
+    async fn get_value(&self, key: &str) -> CacheResult<Option<Vec<u8>>> {
+        self.inner.get_value(key).await
+    }
+
+    async fn set_value(
+        &self,
+        _key: &str,
+        _value: Vec<u8>,
+        _ttl: Option<Duration>,
+        _mode: CacheSetMode,
+    ) -> CacheResult<bool> {
+        Err(CacheError::Backend(
+            "injected overlay write failure".to_string(),
+        ))
+    }
+
+    async fn delete(&self, _key: &str) -> CacheResult<bool> {
+        Err(CacheError::Backend(
+            "injected overlay delete failure".to_string(),
+        ))
+    }
+
+    async fn expire(&self, key: &str, ttl: Duration) -> CacheResult<bool> {
+        self.inner.expire(key, ttl).await
+    }
+
+    async fn ttl(&self, key: &str) -> CacheResult<CacheTtl> {
+        self.inner.ttl(key).await
+    }
+
+    async fn hash_get(&self, key: &str, field: &str) -> CacheResult<Option<Vec<u8>>> {
+        self.inner.hash_get(key, field).await
+    }
+
+    async fn hash_get_all(&self, key: &str) -> CacheResult<BTreeMap<String, Vec<u8>>> {
+        self.inner.hash_get_all(key).await
+    }
+
+    async fn hash_set(&self, key: &str, field: &str, value: Vec<u8>) -> CacheResult<()> {
+        self.inner.hash_set(key, field, value).await
+    }
+
+    async fn hash_set_many(&self, key: &str, fields: BTreeMap<String, Vec<u8>>) -> CacheResult<()> {
+        self.inner.hash_set_many(key, fields).await
+    }
+
+    async fn hash_delete(&self, key: &str, field: &str) -> CacheResult<bool> {
+        self.inner.hash_delete(key, field).await
+    }
+}
+
 fn record(run_id: &str, version: u64) -> ChatRunRecord {
     let mut record = ChatRunRecord::new(
         run_id.to_string(),
@@ -258,6 +337,62 @@ async fn streaming_append_fallover_noop_when_run_already_terminal() {
     assert_eq!(stored.state, ChatRunState::Failed);
     assert_eq!(stored.accumulated_content, "final");
     assert_eq!(stored.version, 2);
+}
+
+#[tokio::test]
+async fn streaming_append_failover_ignores_stale_overlay_and_rebases_on_db() {
+    // P1: Redis still READS a stale overlay but rejects the new write, and the
+    // best-effort delete also fails. The fail-over must advance the DB to the
+    // *intended* version so the stale overlay (lower version) is never merged
+    // over it; the next append then re-bases off the DB and resumes seamlessly.
+    let db = Arc::new(LocalSqliteDbPlugin::new().expect("sqlite db"));
+    let cache = Arc::new(StaleOverlayFailingCache::new());
+    let dyn_cache: Arc<dyn CachePlugin> = cache.clone();
+    let repo = SqlChatRunRepo::new(
+        db,
+        DbSqlFlavor::Sqlite,
+        dyn_cache,
+        "bcs:".to_string(),
+        120_000,
+        "test".to_string(),
+    );
+    repo.create(record("a", 1)).await.unwrap();
+
+    // Pretend five prior deltas streamed into the overlay while the DB stayed
+    // at the create-time version 1.
+    let stale = serde_json::to_vec(&serde_json::json!({
+        "version": 5u64,
+        "state": "running",
+        "accumulated_content": "ABCDE",
+        "content_truncated": false,
+    }))
+    .unwrap();
+    cache.seed("bcs:chat_run:a", stale).await;
+
+    // Engine read the stale overlay (v5, "ABCDE") and appended "F" → "ABCDEF",
+    // expecting v5. The overlay write is rejected → DB fail-over.
+    assert!(
+        repo.append_streaming_content("a", 5, "ABCDEF".to_string(), false)
+            .await
+            .unwrap()
+    );
+    // The fail-over wrote "ABCDEF" to the DB at the intended version 6 (NOT
+    // version+1 = v2), so the stale overlay v5 can no longer be merged over the
+    // DB row.
+    let stored = repo.get("a").await.unwrap().unwrap();
+    assert_eq!(stored.accumulated_content, "ABCDEF");
+    assert_eq!(stored.version, 6);
+
+    // The stale overlay is still readable (delete failed) but v5 < 6, so the
+    // next append bases off the DB (v6), not the stale overlay, and continues.
+    assert!(
+        repo.append_streaming_content("a", 6, "ABCDEF7".to_string(), false)
+            .await
+            .unwrap()
+    );
+    let stored = repo.get("a").await.unwrap().unwrap();
+    assert_eq!(stored.accumulated_content, "ABCDEF7");
+    assert_eq!(stored.version, 7);
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
@@ -1,5 +1,9 @@
+use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::Duration;
 
+use async_trait::async_trait;
+use bcs_cache_api::{CacheError, CachePlugin, CacheResult, CacheSetMode, CacheTtl};
 use bcs_cache_local::InMemoryCachePlugin;
 use bcs_chat_run_store::{
     CasOutcome, ChatRunCompletionPolicy, ChatRunRecord, ChatRunRepoError, ChatRunRepoPort,
@@ -13,6 +17,85 @@ fn repo() -> SqlChatRunRepo {
     let db = Arc::new(LocalSqliteDbPlugin::new().expect("sqlite db"));
     let cache = Arc::new(InMemoryCachePlugin::new());
     SqlChatRunRepo::new(db, DbSqlFlavor::Sqlite, cache, "bcs:".to_string(), 120_000, "test".to_string())
+}
+
+/// Cache double whose `set_value` always rejects, simulating a Redis overlay
+/// write outage. Reads/deletes delegate to an in-memory store so `read_overlay`
+/// sees the nothing that was written — exactly the C4 fail-over scenario.
+struct FailingWritesCache {
+    inner: InMemoryCachePlugin,
+}
+
+impl FailingWritesCache {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryCachePlugin::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl CachePlugin for FailingWritesCache {
+    async fn get_value(&self, key: &str) -> CacheResult<Option<Vec<u8>>> {
+        self.inner.get_value(key).await
+    }
+
+    async fn set_value(
+        &self,
+        _key: &str,
+        _value: Vec<u8>,
+        _ttl: Option<Duration>,
+        _mode: CacheSetMode,
+    ) -> CacheResult<bool> {
+        Err(CacheError::Backend(
+            "injected overlay write failure".to_string(),
+        ))
+    }
+
+    async fn delete(&self, key: &str) -> CacheResult<bool> {
+        self.inner.delete(key).await
+    }
+
+    async fn expire(&self, key: &str, ttl: Duration) -> CacheResult<bool> {
+        self.inner.expire(key, ttl).await
+    }
+
+    async fn ttl(&self, key: &str) -> CacheResult<CacheTtl> {
+        self.inner.ttl(key).await
+    }
+
+    async fn hash_get(&self, key: &str, field: &str) -> CacheResult<Option<Vec<u8>>> {
+        self.inner.hash_get(key, field).await
+    }
+
+    async fn hash_get_all(&self, key: &str) -> CacheResult<BTreeMap<String, Vec<u8>>> {
+        self.inner.hash_get_all(key).await
+    }
+
+    async fn hash_set(&self, key: &str, field: &str, value: Vec<u8>) -> CacheResult<()> {
+        self.inner.hash_set(key, field, value).await
+    }
+
+    async fn hash_set_many(&self, key: &str, fields: BTreeMap<String, Vec<u8>>) -> CacheResult<()> {
+        self.inner.hash_set_many(key, fields).await
+    }
+
+    async fn hash_delete(&self, key: &str, field: &str) -> CacheResult<bool> {
+        self.inner.hash_delete(key, field).await
+    }
+}
+
+fn repo_failing_cache() -> SqlChatRunRepo {
+    let db = Arc::new(LocalSqliteDbPlugin::new().expect("sqlite db"));
+    let cache: Arc<dyn CachePlugin> = Arc::new(FailingWritesCache::new());
+    SqlChatRunRepo::new(
+        db,
+        DbSqlFlavor::Sqlite,
+        cache,
+        "bcs:".to_string(),
+        120_000,
+        "test".to_string(),
+    )
 }
 
 fn record(run_id: &str, version: u64) -> ChatRunRecord {
@@ -104,6 +187,77 @@ async fn streaming_append_advances_cache_ahead_of_db() {
             .await
             .unwrap()
     );
+}
+
+#[tokio::test]
+async fn streaming_append_falls_back_to_db_when_overlay_write_fails() {
+    // C4: when Redis rejects the overlay write, `append_streaming_content` must
+    // fail the delta over to the authoritative DB row instead of silently
+    // returning Ok(true) and dropping it. #1546 forbids a swallowed backend
+    // write masquerading as success.
+    let repo = repo_failing_cache();
+    repo.create(record("a", 1)).await.unwrap();
+
+    // Overlay write is rejected (injected Redis outage), yet the append still
+    // reports Ok(true) and lands the content in the DB.
+    assert!(
+        repo.append_streaming_content("a", 1, "hello".to_string(), false)
+            .await
+            .unwrap()
+    );
+    // The overlay held nothing (its write was rejected), so the merged read now
+    // falls back to the DB row — which must carry the delta and the bumped
+    // version, proving the fail-over wrote through.
+    let stored = repo.get("a").await.unwrap().unwrap();
+    assert_eq!(stored.accumulated_content, "hello");
+    assert_eq!(stored.version, 2);
+    assert!(!stored.content_truncated);
+
+    // A second delta keeps accumulating in the DB while the overlay keeps
+    // rejecting — recovery picks up the DB advance as the base.
+    assert!(
+        repo.append_streaming_content("a", 2, "hello world".to_string(), true)
+            .await
+            .unwrap()
+    );
+    let stored = repo.get("a").await.unwrap().unwrap();
+    assert_eq!(stored.accumulated_content, "hello world");
+    assert_eq!(stored.version, 3);
+    assert!(stored.content_truncated);
+}
+
+#[tokio::test]
+async fn streaming_append_fallover_noop_when_run_already_terminal() {
+    // C4 fail-over UPDATE is gated on the non-terminal state guard. If the run
+    // became terminal concurrently the UPDATE affects 0 rows and the append
+    // reports Ok(false) (delta not applied) instead of rewriting the audited
+    // terminal row.
+    let repo = repo_failing_cache();
+    repo.create(record("t", 1)).await.unwrap();
+
+    let mut failed = record("t", 1);
+    failed.state = ChatRunState::Failed;
+    failed.completed_at_ms = Some(0);
+    failed.accumulated_content = "final".to_string();
+    repo.compare_and_set_terminal("t", 1, failed)
+        .await
+        .unwrap();
+
+    // The terminal CAS left the DB row at version 2; passing expected version 2
+    // gets past the overlay/version check and reaches the fail-over UPDATE,
+    // which the terminal guard rejects (0 rows affected).
+    assert!(
+        !repo
+            .append_streaming_content("t", 2, "late".to_string(), false)
+            .await
+            .unwrap()
+    );
+
+    // The audited terminal content is untouched.
+    let stored = repo.get("t").await.unwrap().unwrap();
+    assert_eq!(stored.state, ChatRunState::Failed);
+    assert_eq!(stored.accumulated_content, "final");
+    assert_eq!(stored.version, 2);
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -9,7 +10,10 @@ use bcs_chat_run_store::{
     CasOutcome, ChatRunCompletionPolicy, ChatRunRecord, ChatRunRepoError, ChatRunRepoPort,
     ChatRunState, SqlChatRunRepo,
 };
-use bcs_db_api::DbSqlFlavor;
+use bcs_db_api::{
+    DbExecuteResult, DbHealth, DbPlugin, DbResult, DbRow, DbSqlFlavor, DbStatement,
+    DbTransactionStep, DbTransactionStepResult,
+};
 use bcs_db_local::LocalSqliteDbPlugin;
 use bcs_service_api::ChatResponseMode;
 
@@ -546,4 +550,298 @@ async fn env_scoping_isolates_runs_across_environments() {
     };
     assert!(total(env_b.metric_counts().await.unwrap()) == 0);
     assert!(total(env_a.metric_counts().await.unwrap()) >= 1);
+}
+// ---------------------------------------------------------------------------
+// Read-side-follows-authority (overlay-first get) coverage
+// ---------------------------------------------------------------------------
+
+/// DbPlugin double that counts SELECT-like `query` calls so tests can pin the
+/// "zero DB reads on the normal streaming path" invariant.
+struct CountingDb {
+    inner: Arc<LocalSqliteDbPlugin>,
+    selects: AtomicUsize,
+}
+
+impl CountingDb {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(LocalSqliteDbPlugin::new().expect("sqlite db")),
+            selects: AtomicUsize::new(0),
+        }
+    }
+
+    fn selects(&self) -> usize {
+        self.selects.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl DbPlugin for CountingDb {
+    async fn query(&self, statement: DbStatement) -> DbResult<Vec<DbRow>> {
+        self.selects.fetch_add(1, Ordering::SeqCst);
+        self.inner.query(statement).await
+    }
+
+    async fn execute(&self, statement: DbStatement) -> DbResult<DbExecuteResult> {
+        self.inner.execute(statement).await
+    }
+
+    async fn transaction(
+        &self,
+        steps: Vec<DbTransactionStep>,
+    ) -> DbResult<Vec<DbTransactionStepResult>> {
+        self.inner.transaction(steps).await
+    }
+
+    async fn health_check(&self) -> DbResult<DbHealth> {
+        self.inner.health_check().await
+    }
+}
+
+fn repo_counting(db: &Arc<CountingDb>) -> SqlChatRunRepo {
+    let cache = Arc::new(InMemoryCachePlugin::new());
+    SqlChatRunRepo::new(
+        db.clone(),
+        DbSqlFlavor::Sqlite,
+        cache,
+        "bcs:".to_string(),
+        120_000,
+        "test".to_string(),
+    )
+}
+
+/// Cache double: writes succeed, deletes always fail — models a terminal CAS
+/// whose overlay delete is rejected while the tombstone write still lands.
+struct NoDeleteCache {
+    inner: InMemoryCachePlugin,
+}
+
+#[async_trait]
+impl CachePlugin for NoDeleteCache {
+    async fn get_value(&self, key: &str) -> CacheResult<Option<Vec<u8>>> {
+        self.inner.get_value(key).await
+    }
+
+    async fn set_value(
+        &self,
+        key: &str,
+        value: Vec<u8>,
+        ttl: Option<Duration>,
+        mode: CacheSetMode,
+    ) -> CacheResult<bool> {
+        self.inner.set_value(key, value, ttl, mode).await
+    }
+
+    async fn delete(&self, _key: &str) -> CacheResult<bool> {
+        Err(CacheError::Backend("injected overlay delete failure".to_string()))
+    }
+
+    async fn expire(&self, key: &str, ttl: Duration) -> CacheResult<bool> {
+        self.inner.expire(key, ttl).await
+    }
+
+    async fn ttl(&self, key: &str) -> CacheResult<CacheTtl> {
+        self.inner.ttl(key).await
+    }
+
+    async fn hash_get(&self, key: &str, field: &str) -> CacheResult<Option<Vec<u8>>> {
+        self.inner.hash_get(key, field).await
+    }
+
+    async fn hash_get_all(&self, key: &str) -> CacheResult<BTreeMap<String, Vec<u8>>> {
+        self.inner.hash_get_all(key).await
+    }
+
+    async fn hash_set(&self, key: &str, field: &str, value: Vec<u8>) -> CacheResult<()> {
+        self.inner.hash_set(key, field, value).await
+    }
+
+    async fn hash_set_many(&self, key: &str, fields: BTreeMap<String, Vec<u8>>) -> CacheResult<()> {
+        self.inner.hash_set_many(key, fields).await
+    }
+
+    async fn hash_delete(&self, key: &str, field: &str) -> CacheResult<bool> {
+        self.inner.hash_delete(key, field).await
+    }
+}
+
+#[tokio::test]
+async fn overlay_v2_roundtrips_every_record_field() {
+    // The V2 cache value must round-trip the WHOLE record — including the two
+    // fields ChatRunRecord's own serde skips (completion_policy /
+    // delivery_ack_at_ms). Losing either would silently degrade the detach
+    // classification in `record_run_event` on every cache hit.
+    let repo = repo();
+    let mut full = record("full", 1);
+    full.state = ChatRunState::Running;
+    full.accumulated_content = "text".to_string();
+    full.error_message = Some("err".to_string());
+    full.completed_at_ms = Some(0);
+    full.content_truncated = true;
+    full.response_mode = ChatResponseMode::AfterLastToolCall;
+    full.completion_policy = ChatRunCompletionPolicy::DetachDeliveryAck;
+    full.delivery_ack_at_ms = Some(0);
+    repo.create(full.clone()).await.unwrap();
+    // Create seeds the V2 overlay, so this `get` is served cache-first.
+    let stored = repo.get("full").await.unwrap().unwrap();
+    assert_eq!(stored, full);
+}
+
+#[tokio::test]
+async fn streaming_and_polling_read_path_skips_db_entirely() {
+    // Read side follows the authority: while the run streams, the overlay is
+    // the freshest fact, so appends AND long-poll reads answer from the cache
+    // with zero MySQL SELECTs.
+    let db = Arc::new(CountingDb::new());
+    let repo = repo_counting(&db);
+    repo.create(record("z", 1)).await.unwrap();
+    assert_eq!(db.selects(), 0, "create must not SELECT");
+
+    assert!(
+        repo.append_streaming_content("z", 1, "he".to_string(), false)
+            .await
+            .unwrap()
+    );
+    assert!(
+        repo.append_streaming_content("z", 2, "hell".to_string(), false)
+            .await
+            .unwrap()
+    );
+    assert!(
+        repo.append_streaming_content("z", 3, "hello".to_string(), false)
+            .await
+            .unwrap()
+    );
+
+    for _ in 0..5 {
+        let stored = repo.get("z").await.unwrap().unwrap();
+        assert_eq!(stored.accumulated_content, "hello");
+        assert_eq!(stored.version, 4);
+        assert_eq!(stored.state, ChatRunState::Running);
+    }
+    assert_eq!(
+        db.selects(),
+        0,
+        "appends + polls on the fast path must not SELECT (overlay-first get)"
+    );
+}
+
+#[tokio::test]
+async fn state_cas_midstream_preserves_streamed_overlay_content() {
+    // Step-1 landmine: the state-CAS overlay refresh must compose the DB row's
+    // authority fields with the overlay's streaming content. Taking the DB row
+    // wholesale would clobber the text back to the create-time value whenever
+    // a state CAS lands mid-stream (e.g. a detach ack on the first
+    // content-bearing event).
+    let repo = repo();
+    repo.create(record("s", 1)).await.unwrap();
+    assert!(
+        repo.append_streaming_content("s", 1, "hello".to_string(), false)
+            .await
+            .unwrap()
+    );
+
+    let mut acked = record("s", 2);
+    acked.state = ChatRunState::Running;
+    acked.delivery_ack_at_ms = Some(0);
+    match repo.compare_and_set_state("s", 2, acked).await.unwrap() {
+        // The DB row is still at its create-time version 1 (streaming only
+        // advanced the overlay to 2), so the CAS bumps it 1 -> 2.
+        CasOutcome::Applied(r) => assert_eq!(r.version, 2),
+        other => panic!("expected Applied, got {other:?}"),
+    }
+
+    // Cache-first read: version/state/ack from the DB row's CAS outcome,
+    // content from the streamed overlay.
+    let stored = repo.get("s").await.unwrap().unwrap();
+    assert_eq!(stored.accumulated_content, "hello");
+    assert_eq!(stored.version, 2);
+    assert_eq!(stored.state, ChatRunState::Running);
+    assert_eq!(stored.delivery_ack_at_ms, Some(0));
+}
+
+#[tokio::test]
+async fn legacy_overlay_value_still_reads_through_db_merge() {
+    // Rolling-upgrade window: a pre-upgrade replica wrote the legacy
+    // five-field overlay. The V2-first read must fall back to the historical
+    // DB read + legacy-merge (the two format generations meet at the
+    // authoritative DB row), preserving the pre-change read behavior.
+    let db = Arc::new(CountingDb::new());
+    let cache = Arc::new(InMemoryCachePlugin::new());
+    let repo = SqlChatRunRepo::new(
+        db.clone(),
+        DbSqlFlavor::Sqlite,
+        cache.clone(),
+        "bcs:".to_string(),
+        120_000,
+        "test".to_string(),
+    );
+    repo.create(record("lg", 1)).await.unwrap();
+    let selects_after_create = db.selects();
+
+    // Replace the V2 seed with a legacy-shaped, ahead-of-DB overlay.
+    let legacy = serde_json::to_vec(&serde_json::json!({
+        "version": 2u64,
+        "state": "running",
+        "accumulated_content": "legacy",
+        "content_truncated": false,
+        "expires_at_ms": 9_000_000_000_000u64,
+    }))
+    .unwrap();
+    cache
+        .set_value("bcs:chat_run:lg", legacy, None, CacheSetMode::Upsert)
+        .await
+        .unwrap();
+
+    let stored = repo.get("lg").await.unwrap().unwrap();
+    assert_eq!(stored.accumulated_content, "legacy");
+    assert_eq!(stored.version, 2);
+    assert_eq!(stored.state, ChatRunState::Running);
+    assert_eq!(
+        db.selects(),
+        selects_after_create + 1,
+        "a legacy value falls back to exactly one DB read"
+    );
+}
+
+#[tokio::test]
+async fn terminal_tombstone_covers_failed_overlay_delete() {
+    // Terminal CAS tombstones the overlay (V2 terminal record) before
+    // deleting it. When the delete is rejected but the write landed, the
+    // cache-first read serves the TERMINAL record — never a stale
+    // pre-terminal running snapshot.
+    let db = Arc::new(CountingDb::new());
+    let cache = Arc::new(NoDeleteCache {
+        inner: InMemoryCachePlugin::new(),
+    });
+    let repo = SqlChatRunRepo::new(
+        db.clone(),
+        DbSqlFlavor::Sqlite,
+        cache,
+        "bcs:".to_string(),
+        120_000,
+        "test".to_string(),
+    );
+    repo.create(record("t", 1)).await.unwrap();
+    assert!(
+        repo.append_streaming_content("t", 1, "hello".to_string(), false)
+            .await
+            .unwrap()
+    );
+
+    let mut completed = record("t", 2);
+    completed.state = ChatRunState::Completed;
+    completed.accumulated_content = "hello final".to_string();
+    repo.compare_and_set_terminal("t", 2, completed)
+        .await
+        .unwrap();
+
+    // The delete failed, so the tombstone V2 record is what a cache-first
+    // read must serve.
+    let stored = repo.get("t").await.unwrap().unwrap();
+    assert_eq!(stored.state, ChatRunState::Completed);
+    assert_eq!(stored.accumulated_content, "hello final");
+    // The terminal CAS bumped the DB row (still at v1) to v2; the tombstone
+    // carries the same version.
+    assert_eq!(stored.version, 2);
 }

--- a/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
@@ -365,6 +365,7 @@ async fn streaming_append_failover_ignores_stale_overlay_and_rebases_on_db() {
         "state": "running",
         "accumulated_content": "ABCDE",
         "content_truncated": false,
+        "expires_at_ms": 9_000_000_000_000u64,
     }))
     .unwrap();
     cache.seed("bcs:chat_run:a", stale).await;

--- a/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
@@ -363,13 +363,18 @@ async fn streaming_append_failover_ignores_stale_overlay_and_rebases_on_db() {
     repo.create(record("a", 1)).await.unwrap();
 
     // Pretend five prior deltas streamed into the overlay while the DB stayed
-    // at the create-time version 1.
+    // at the create-time version 1. The overlay value is the whole-record
+    // shape (env-gated); this replica's env is "test".
     let stale = serde_json::to_vec(&serde_json::json!({
-        "version": 5u64,
-        "state": "running",
-        "accumulated_content": "ABCDE",
-        "content_truncated": false,
-        "expires_at_ms": 9_000_000_000_000u64,
+        "env": "test",
+        "record": {
+            "run_id": "a", "bot_uuid": "bot", "from_bot_id": "from", "session_key": "sk",
+            "state": "running", "accumulated_content": "ABCDE", "error_message": null,
+            "created_at_ms": 0u64, "updated_at_ms": 0u64, "completed_at_ms": null,
+            "expires_at_ms": 9_000_000_000_000u64, "version": 5u64, "content_truncated": false,
+            "client": "http-chat-async", "response_mode": "full"
+        },
+        "completion_policy": "WaitForFinal", "delivery_ack_at_ms": null,
     }))
     .unwrap();
     cache.seed("bcs:chat_run:a", stale).await;
@@ -666,8 +671,8 @@ impl CachePlugin for NoDeleteCache {
 }
 
 #[tokio::test]
-async fn overlay_v2_roundtrips_every_record_field() {
-    // The V2 cache value must round-trip the WHOLE record — including the two
+async fn overlay_roundtrips_every_record_field() {
+    // The overlay value must round-trip the WHOLE record — including the two
     // fields ChatRunRecord's own serde skips (completion_policy /
     // delivery_ack_at_ms). Losing either would silently degrade the detach
     // classification in `record_run_event` on every cache hit.
@@ -682,7 +687,7 @@ async fn overlay_v2_roundtrips_every_record_field() {
     full.completion_policy = ChatRunCompletionPolicy::DetachDeliveryAck;
     full.delivery_ack_at_ms = Some(0);
     repo.create(full.clone()).await.unwrap();
-    // Create seeds the V2 overlay, so this `get` is served cache-first.
+    // Create seeds the overlay, so this `get` is served cache-first.
     let stored = repo.get("full").await.unwrap().unwrap();
     assert_eq!(stored, full);
 }
@@ -761,11 +766,11 @@ async fn state_cas_midstream_preserves_streamed_overlay_content() {
 }
 
 #[tokio::test]
-async fn legacy_overlay_value_still_reads_through_db_merge() {
-    // Rolling-upgrade window: a pre-upgrade replica wrote the legacy
-    // five-field overlay. The V2-first read must fall back to the historical
-    // DB read + legacy-merge (the two format generations meet at the
-    // authoritative DB row), preserving the pre-change read behavior.
+async fn unparseable_overlay_value_degrades_to_db_read() {
+    // The cache holds a single shape. Any value that is not the whole-record
+    // overlay (a stale blob left over from a different writer, a corrupt
+    // entry, or a foreign-env entry) must be treated as a miss and fall
+    // straight to the authoritative DB row — never served and never merged.
     let db = Arc::new(CountingDb::new());
     let cache = Arc::new(InMemoryCachePlugin::new());
     let repo = SqlChatRunRepo::new(
@@ -779,34 +784,41 @@ async fn legacy_overlay_value_still_reads_through_db_merge() {
     repo.create(record("lg", 1)).await.unwrap();
     let selects_after_create = db.selects();
 
-    // Replace the V2 seed with a legacy-shaped, ahead-of-DB overlay.
-    let legacy = serde_json::to_vec(&serde_json::json!({
-        "version": 2u64,
-        "state": "running",
-        "accumulated_content": "legacy",
-        "content_truncated": false,
-        "expires_at_ms": 9_000_000_000_000u64,
+    // Replace the seed with a whole-record overlay carrying a FOREIGN env.
+    // The key is env-less, so the same run_id may hold another environment's
+    // value in a shared Redis; this replica must NOT serve it.
+    let foreign = serde_json::to_vec(&serde_json::json!({
+        "env": "other",
+        "record": {
+            "run_id": "lg", "bot_uuid": "bot", "from_bot_id": "from", "session_key": "sk",
+            "state": "running", "accumulated_content": "LEAK", "error_message": null,
+            "created_at_ms": 0u64, "updated_at_ms": 0u64, "completed_at_ms": null,
+            "expires_at_ms": 9_000_000_000_000u64, "version": 9u64, "content_truncated": false,
+            "client": "x", "response_mode": "full"
+        },
+        "completion_policy": "WaitForFinal", "delivery_ack_at_ms": null,
     }))
     .unwrap();
     cache
-        .set_value("bcs:chat_run:lg", legacy, None, CacheSetMode::Upsert)
+        .set_value("bcs:chat_run:lg", foreign, None, CacheSetMode::Upsert)
         .await
         .unwrap();
 
+    // The foreign overlay is not served; the DB row defines the truth.
     let stored = repo.get("lg").await.unwrap().unwrap();
-    assert_eq!(stored.accumulated_content, "legacy");
-    assert_eq!(stored.version, 2);
-    assert_eq!(stored.state, ChatRunState::Running);
+    assert_eq!(stored.accumulated_content, "", "foreign-env overlay must NOT leak");
+    assert_eq!(stored.version, 1);
+    assert_eq!(stored.state, ChatRunState::Pending);
     assert_eq!(
         db.selects(),
         selects_after_create + 1,
-        "a legacy value falls back to exactly one DB read"
+        "a non-serving overlay falls back to exactly one DB read"
     );
 }
 
 #[tokio::test]
 async fn terminal_tombstone_covers_failed_overlay_delete() {
-    // Terminal CAS tombstones the overlay (V2 terminal record) before
+    // Terminal CAS tombstones the overlay (terminal record) before
     // deleting it. When the delete is rejected but the write landed, the
     // cache-first read serves the TERMINAL record — never a stale
     // pre-terminal running snapshot.

--- a/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/mod.rs
@@ -696,7 +696,7 @@ impl A2aChatService for A2aChat {
     }
 
     async fn record_run_event(&self, run_id: &str, event_json: &str) -> ServiceResult<bool> {
-        let record = self
+        let mut record = self
             .run_store
             .get(run_id)
             .await
@@ -721,6 +721,13 @@ impl A2aChatService for A2aChat {
                             DirectChatRunReason::None,
                         )
                         .await;
+                        // The ack CAS advanced the overlay/DB version. The
+                        // local snapshot below is the append's frame base, and
+                        // a stale version would make this first frame's delta
+                        // be refused as a caller-behind base — re-fetch once.
+                        if let Some(refreshed) = self.run_store.get(run_id).await {
+                            record = refreshed;
+                        }
                     }
                 }
                 DetachDeliveryCallback::Error(msg) => {
@@ -749,7 +756,7 @@ impl A2aChatService for A2aChat {
         ) {
             DrainOutcome::Continue => {
                 if self
-                    .apply_run_content_change(run_id, &before, &accumulated)
+                    .apply_run_content_change(&record, &before, &accumulated)
                     .await
                     && record.state == ChatRunState::Pending
                 {
@@ -764,7 +771,7 @@ impl A2aChatService for A2aChat {
                 false
             }
             DrainOutcome::Final => {
-                self.apply_run_content_change(run_id, &before, &accumulated)
+                self.apply_run_content_change(&record, &before, &accumulated)
                     .await;
                 if self.run_store.mark_completed(run_id, None).await {
                     self.emit_run_lifecycle(
@@ -902,14 +909,17 @@ impl A2aChat {
 
     async fn apply_run_content_change(
         &self,
-        run_id: &str,
+        record: &ChatRunRecord,
         before: &str,
         accumulated: &str,
     ) -> bool {
+        // Frame-local merge: `record` is this frame's entry snapshot, so the
+        // mutators take it as the append base instead of re-reading the repo
+        // (one fetch per frame, not two).
         if let Some(delta) = new_suffix(before, accumulated) {
-            self.run_store.append_delta(run_id, delta).await
+            self.run_store.append_delta_from_base(record, delta).await
         } else if accumulated != before {
-            self.run_store.replace_content(run_id, accumulated).await
+            self.run_store.replace_content_from_base(record, accumulated).await
         } else {
             false
         }

--- a/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/run_store.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/a2a_chat/run_store.rs
@@ -295,19 +295,102 @@ impl ChatRunStore {
         self.apply_state_cas(run_id, current.version, new).await
     }
 
+    /// Append a streaming chunk onto an ALREADY-FETCHED base record
+    /// (frame-local merge): the drain path holds the pre-frame snapshot —
+    /// fetched exactly once per frame — so the append does not re-read the
+    /// repo. The base must be the frame's entry snapshot; the single writer
+    /// discipline makes it equivalent to a fresh read except when an
+    /// in-frame mutation (the detach acknowledgement) advanced the version —
+    /// re-fetch the record there before calling.
+    pub async fn append_delta_from_base(&self, base: &ChatRunRecord, chunk: &str) -> bool {
+        if chunk.is_empty() {
+            return false;
+        }
+        if base.state.is_terminal() {
+            return false;
+        }
+
+        let (accumulated, truncated) =
+            Self::append_chunk_with_truncation(&base.accumulated_content, base.content_truncated, chunk);
+
+        self.append_content_at_version(&base.run_id, base.version, accumulated, truncated)
+            .await
+    }
+
     pub async fn append_delta(&self, run_id: &str, chunk: &str) -> bool {
         if chunk.is_empty() {
             return false;
         }
-        let Some(current) = self.get(run_id).await else {
+        let Some(base) = self.get(run_id).await else {
             return false;
         };
-        if current.state.is_terminal() {
+        self.append_delta_from_base(&base, chunk).await
+    }
+
+    /// Replace the record's content from an already-fetched base — see
+    /// [`Self::append_delta_from_base`] for the frame-local-merge contract.
+    pub async fn replace_content_from_base(&self, base: &ChatRunRecord, content: &str) -> bool {
+        if base.state.is_terminal() {
+            return false;
+        }
+        let was_pending = base.state == ChatRunState::Pending;
+
+        let (next, truncated) = Self::truncate_content(content);
+        let changed = base.accumulated_content != next
+            || base.content_truncated != truncated
+            || was_pending;
+        if !changed {
             return false;
         }
 
-        let mut accumulated = current.accumulated_content.clone();
-        let mut truncated = current.content_truncated;
+        self.append_content_at_version(&base.run_id, base.version, next, truncated)
+            .await
+    }
+
+    pub async fn replace_content(&self, run_id: &str, content: &str) -> bool {
+        let Some(base) = self.get(run_id).await else {
+            return false;
+        };
+        self.replace_content_from_base(&base, content).await
+    }
+
+    /// Shared commit path for both content mutators: CAS-expected version,
+    /// notify-on-success, log-only on backend failure (the store remains the
+    /// truth; #1546 forbids masquerading a failed write as success).
+    async fn append_content_at_version(
+        &self,
+        run_id: &str,
+        version: u64,
+        accumulated: String,
+        truncated: bool,
+    ) -> bool {
+        match self
+            .repo
+            .append_streaming_content(run_id, version, accumulated, truncated)
+            .await
+        {
+            Ok(true) => {
+                self.notify_waiters(run_id).await;
+                true
+            }
+            Ok(false) => false,
+            Err(err) => {
+                error!(run_id, error = %err, "chat run append_streaming_content failed");
+                false
+            }
+        }
+    }
+
+    /// Append `chunk` onto `current` with the 1 MiB char-boundary-safe
+    /// truncation rule; returns the new accumulated string plus the
+    /// truncated flag.
+    fn append_chunk_with_truncation(
+        current: &str,
+        truncated: bool,
+        chunk: &str,
+    ) -> (String, bool) {
+        let mut accumulated = current.to_string();
+        let mut truncated = truncated;
         let remaining = MAX_CONTENT_BYTES.saturating_sub(accumulated.len());
         if remaining == 0 {
             truncated = true;
@@ -321,33 +404,11 @@ impl ChatRunStore {
             accumulated.push_str(&chunk[..boundary]);
             truncated = true;
         }
-
-        match self
-            .repo
-            .append_streaming_content(run_id, current.version, accumulated, truncated)
-            .await
-        {
-            Ok(true) => {
-                self.notify_waiters(run_id).await;
-                true
-            }
-            Ok(false) => false,
-            Err(err) => {
-                error!(run_id, error = %err, "chat run append_delta failed");
-                false
-            }
-        }
+        (accumulated, truncated)
     }
 
-    pub async fn replace_content(&self, run_id: &str, content: &str) -> bool {
-        let Some(current) = self.get(run_id).await else {
-            return false;
-        };
-        if current.state.is_terminal() {
-            return false;
-        }
-        let was_pending = current.state == ChatRunState::Pending;
-
+    /// Cap `content` at the 1 MiB char-boundary-safe truncation rule.
+    fn truncate_content(content: &str) -> (String, bool) {
         let mut next = String::new();
         let mut truncated = false;
         if content.len() <= MAX_CONTENT_BYTES {
@@ -360,28 +421,7 @@ impl ChatRunStore {
             next.push_str(&content[..boundary]);
             truncated = true;
         }
-
-        let changed =
-            current.accumulated_content != next || current.content_truncated != truncated || was_pending;
-        if !changed {
-            return false;
-        }
-
-        match self
-            .repo
-            .append_streaming_content(run_id, current.version, next, truncated)
-            .await
-        {
-            Ok(true) => {
-                self.notify_waiters(run_id).await;
-                true
-            }
-            Ok(false) => false,
-            Err(err) => {
-                error!(run_id, error = %err, "chat run replace_content failed");
-                false
-            }
-        }
+        (next, truncated)
     }
 
     pub async fn mark_completed(&self, run_id: &str, final_text: Option<&str>) -> bool {


### PR DESCRIPTION
Supersedes #1673 — whose PR head_sha is hard-frozen at a pre-rebase commit by a GitHub Enterprise force-push indexing bug (the branch ref itself is current). This PR carries the same rebased branch on top of the latest dev.

## Summary

Direct Chat async-run streaming overlay hardening across three layers (all under async_chat_run_store = "persistent" opt-in; memory mode unaffected):

- Fail over a rejected overlay write to the DB (C4, #1627): append_streaming_content no longer silently drops a delta when Redis rejects the write; it persists the delta to the authoritative MySQL row and proceeds.
- Align DB fail-over version and ignore stale overlay (P1): the fail-over writes the intended version so a stale lower-version overlay can never be merged over freshly persisted content.
- Carry the run deadline in the overlay, skip the per-delta DB read (#1627): the overlay value carries expires_at_ms so the append path no longer touches MySQL on the normal streaming path.
- Serve run reads from the streaming overlay (read-side authority): overlay value upgraded to the whole ChatRunRecord (V2); get serves a V2 hit with zero MySQL reads; misses fall back to DB-read + legacy merge. State-CAS refresh composes DB authority with overlay content (no mid-stream clobber). Terminal CAS tombstones before delete. Frame-local merge removes the second per-frame fetch.
- Env-scoped overlay values (env-less cache key must not leak across environments).
- sweep_idle_notifiers reclaims node-local Notify entries for runs retiring without a terminal CAS.

Tests pin: N deltas + polls => zero SELECTs; V2 round-trips every record field; mid-stream CAS preserves content; legacy value degrades to one DB read; terminal tombstone covers a failed overlay delete.

## Open follow-ups
- cache-suspect fence for the write+delete double-failure window.
- serde default on legacy expires_at_ms for the rolling-upgrade window.

Co-Authored-By: Claude Code <noreply@anthropic.com>
