### PR TITLE
Log level mod

### DIFF
--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
@@ -552,6 +552,12 @@ class DeadlineRenewalScheduler:
                 sandbox_id,
                 e,
             )
+            log.debug(
+                "[DeadlineRenewalScheduler] get_device_info failed sandbox_id=%s: %s",
+                sandbox_id,
+                e,
+                exc_info=True,
+            )
             outcome = await self._handle_failure(record)
             self._emit_renew_digest(record, outcome, run_uuid=run_uuid)
             return outcome
@@ -677,6 +683,14 @@ class DeadlineRenewalScheduler:
                 sandbox_id,
                 ttl_minutes,
                 e,
+            )
+            log.debug(
+                "[DeadlineRenewalScheduler] extend_ttl failed sandbox_id=%s "
+                "ttl_minutes=%d: %s",
+                sandbox_id,
+                ttl_minutes,
+                e,
+                exc_info=True,
             )
             outcome = await self._handle_failure(record)
             self._emit_renew_digest(

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
@@ -546,10 +546,11 @@ class DeadlineRenewalScheduler:
         # ---- Step 3(a): Get authoritative TTL from Arca ----
         try:
             device_info = await self._paas_facade.get_device_info(sandbox_id)
-        except Exception:
-            log.exception(
-                "[DeadlineRenewalScheduler] get_device_info failed sandbox_id=%s",
+        except Exception as e:
+            log.warning(
+                "[DeadlineRenewalScheduler] get_device_info failed sandbox_id=%s: %s",
                 sandbox_id,
+                e,
             )
             outcome = await self._handle_failure(record)
             self._emit_renew_digest(record, outcome, run_uuid=run_uuid)
@@ -669,12 +670,13 @@ class DeadlineRenewalScheduler:
 
         try:
             renewed = await self._paas_facade.extend_ttl(sandbox_id, ttl_minutes)
-        except Exception:
-            log.exception(
+        except Exception as e:
+            log.warning(
                 "[DeadlineRenewalScheduler] extend_ttl failed sandbox_id=%s "
-                "ttl_minutes=%d",
+                "ttl_minutes=%d: %s",
                 sandbox_id,
                 ttl_minutes,
+                e,
             )
             outcome = await self._handle_failure(record)
             self._emit_renew_digest(
@@ -778,7 +780,7 @@ class DeadlineRenewalScheduler:
             self._schedule_repo.set_status(
                 self._config.env, record["source_table"], record["source_id"], "STOPPED"
             )
-            log.error(
+            log.warning(
                 "[DeadlineRenewalScheduler] sandbox_id=%s "
                 "source=%s:%s reached max_fail_count=%d, marked STOPPED",
                 record.get("sandbox_id"),

--- a/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_bot_run_executor.py
@@ -780,7 +780,10 @@ async def test_executor_stream_agent_byte_threshold_splits_chunks():
     # 每个 metadata 约 100B，N=800 -> ~80KB > 64KB，应触发至少一次字节阈值 flush。
     per_frame = {"engine_frame": {"stream": "tool", "phase": "x"}, "data": "x" * 80}
     n_frames = 800
-    chunks = [StreamChunk(type="agent", content="", metadata=per_frame) for _ in range(n_frames)]
+    chunks = [
+        StreamChunk(type="agent", content="", metadata=per_frame)
+        for _ in range(n_frames)
+    ]
     chunks.append(StreamChunk(type="final", content="done"))
 
     async def _stream_gen(*a, **kw):
@@ -793,7 +796,12 @@ async def test_executor_stream_agent_byte_threshold_splits_chunks():
 
     chunk_repo = MagicMock()
     executor = BotRunRequestExecutor(
-        repo, plugin, selector, chunk_repo, MagicMock(), _api_key_repo(),
+        repo,
+        plugin,
+        selector,
+        chunk_repo,
+        MagicMock(),
+        _api_key_repo(),
         stream_flush_max_content_bytes=4096,
     )
     await executor.execute(
@@ -854,7 +862,12 @@ async def test_executor_stream_delta_byte_threshold_splits_chunks():
 
     chunk_repo = MagicMock()
     executor = BotRunRequestExecutor(
-        repo, plugin, selector, chunk_repo, MagicMock(), _api_key_repo(),
+        repo,
+        plugin,
+        selector,
+        chunk_repo,
+        MagicMock(),
+        _api_key_repo(),
         stream_flush_max_content_bytes=4096,
     )
     await executor.execute(
@@ -914,7 +927,12 @@ async def test_executor_stream_byte_threshold_not_triggered_preserves_merge():
     chunk_repo = MagicMock()
     # 阈值足够大，这批小 payload 不会触发字节 flush
     executor = BotRunRequestExecutor(
-        repo, plugin, selector, chunk_repo, MagicMock(), _api_key_repo(),
+        repo,
+        plugin,
+        selector,
+        chunk_repo,
+        MagicMock(),
+        _api_key_repo(),
         stream_flush_max_content_bytes=1 << 20,
     )
     await executor.execute(

--- a/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
@@ -768,6 +768,36 @@ class TestStep3RenewalDecision:
         assert "timeout" in failure_lines[0].message
 
     @pytest.mark.asyncio
+    async def test_get_device_info_failure_logs_debug_traceback(self, caplog):
+        """WR-01: get_device_info failure keeps a DEBUG exc_info traceback."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+
+        mock_facade.get_device_info = AsyncMock(side_effect=Exception("timeout"))
+        mock_facade.extend_ttl = AsyncMock()
+        mock_repo.update_after_failure = MagicMock()
+
+        caplog.set_level(logging.DEBUG, logger="core-scheduler")
+        record = _renewal_record()
+        result = await scheduler._renew_one(record)
+
+        assert result == "failed"
+
+        matching = [r for r in caplog.records if "get_device_info failed" in r.message]
+        warning_records = [r for r in matching if r.levelno == logging.WARNING]
+        debug_records = [r for r in matching if r.levelno == logging.DEBUG]
+        assert len(warning_records) == 1
+        assert len(debug_records) == 1
+
+        warning = warning_records[0]
+        assert "timeout" in warning.message
+        assert warning.exc_info is None
+
+        debug = debug_records[0]
+        assert "timeout" in debug.message
+        assert debug.exc_info is not None
+        assert debug.exc_info[0] is Exception
+
+    @pytest.mark.asyncio
     async def test_ttl_timestamp_none_enters_failure(self):
         """Test 21: ttl_timestamp is None → failure handling."""
         scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
@@ -826,6 +856,40 @@ class TestStep3RenewalDecision:
         assert failure_lines[0].levelno == logging.WARNING
         assert "Arca API error" in failure_lines[0].message
         assert "ttl_minutes=" in failure_lines[0].message
+
+    @pytest.mark.asyncio
+    async def test_extend_ttl_failure_logs_debug_traceback(self, caplog):
+        """WR-01: extend_ttl failure keeps a DEBUG exc_info traceback."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+
+        mock_facade.get_device_info = AsyncMock(
+            return_value=MagicMock(ttl_timestamp=_ttl_ms(10))
+        )
+        mock_facade.extend_ttl = AsyncMock(side_effect=Exception("Arca API error"))
+        mock_repo.update_after_failure = MagicMock()
+
+        caplog.set_level(logging.DEBUG, logger="core-scheduler")
+        record = _renewal_record()
+        result = await scheduler._renew_one(record)
+
+        assert result == "failed"
+
+        matching = [r for r in caplog.records if "extend_ttl failed" in r.message]
+        warning_records = [r for r in matching if r.levelno == logging.WARNING]
+        debug_records = [r for r in matching if r.levelno == logging.DEBUG]
+        assert len(warning_records) == 1
+        assert len(debug_records) == 1
+
+        warning = warning_records[0]
+        assert "Arca API error" in warning.message
+        assert "ttl_minutes=" in warning.message
+        assert warning.exc_info is None
+
+        debug = debug_records[0]
+        assert "extend_ttl failed" in debug.message
+        assert "ttl_minutes=" in debug.message
+        assert debug.exc_info is not None
+        assert debug.exc_info[0] is Exception
 
     @pytest.mark.asyncio
     async def test_extend_ttl_returns_false_enters_failure(self):

--- a/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
@@ -744,7 +744,7 @@ class TestStep3RenewalDecision:
         assert result == "failed"
 
     @pytest.mark.asyncio
-    async def test_get_device_info_raises_enters_failure(self):
+    async def test_get_device_info_raises_enters_failure(self, caplog):
         """Test 20: get_device_info raises Exception → failure handling."""
         scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
 
@@ -753,11 +753,19 @@ class TestStep3RenewalDecision:
         mock_repo.update_after_failure = MagicMock()
 
         record = _renewal_record()
-        result = await scheduler._renew_one(record)
+        with caplog.at_level(logging.WARNING, logger="core-scheduler"):
+            result = await scheduler._renew_one(record)
 
         mock_facade.extend_ttl.assert_not_called()
         mock_repo.update_after_failure.assert_called_once()
         assert result == "failed"
+
+        failure_lines = [
+            r for r in caplog.records if "get_device_info failed" in r.message
+        ]
+        assert len(failure_lines) == 1
+        assert failure_lines[0].levelno == logging.WARNING
+        assert "timeout" in failure_lines[0].message
 
     @pytest.mark.asyncio
     async def test_ttl_timestamp_none_enters_failure(self):
@@ -794,7 +802,7 @@ class TestStep3RenewalDecision:
         assert result == "failed"
 
     @pytest.mark.asyncio
-    async def test_extend_ttl_raises_enters_failure(self):
+    async def test_extend_ttl_raises_enters_failure(self, caplog):
         """Test 22: get_device_info succeeds, but extend_ttl raises → failure."""
         scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
 
@@ -805,10 +813,19 @@ class TestStep3RenewalDecision:
         mock_repo.update_after_failure = MagicMock()
 
         record = _renewal_record()
-        result = await scheduler._renew_one(record)
+        with caplog.at_level(logging.WARNING, logger="core-scheduler"):
+            result = await scheduler._renew_one(record)
 
         mock_repo.update_after_failure.assert_called_once()
         assert result == "failed"
+
+        failure_lines = [
+            r for r in caplog.records if "extend_ttl failed" in r.message
+        ]
+        assert len(failure_lines) == 1
+        assert failure_lines[0].levelno == logging.WARNING
+        assert "Arca API error" in failure_lines[0].message
+        assert "ttl_minutes=" in failure_lines[0].message
 
     @pytest.mark.asyncio
     async def test_extend_ttl_returns_false_enters_failure(self):
@@ -1601,6 +1618,18 @@ class TestStoppedTransitionMetric:
         assert "stopped_transition=1" in msg
         assert "sandbox_id=sb-1" in msg
         assert "fail_count=10" in msg
+
+        transition_records = [
+            r for r in caplog.records if "stopped_transition" in r.message
+        ]
+        assert len(transition_records) == 1
+        assert transition_records[0].levelno == logging.INFO
+
+        stopped_lines = [
+            r for r in caplog.records if "marked STOPPED" in r.message
+        ]
+        assert len(stopped_lines) == 1
+        assert stopped_lines[0].levelno == logging.WARNING
 
 
 class TestRenewalDigestLogging:

--- a/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
@@ -849,9 +849,7 @@ class TestStep3RenewalDecision:
         mock_repo.update_after_failure.assert_called_once()
         assert result == "failed"
 
-        failure_lines = [
-            r for r in caplog.records if "extend_ttl failed" in r.message
-        ]
+        failure_lines = [r for r in caplog.records if "extend_ttl failed" in r.message]
         assert len(failure_lines) == 1
         assert failure_lines[0].levelno == logging.WARNING
         assert "Arca API error" in failure_lines[0].message
@@ -1689,9 +1687,7 @@ class TestStoppedTransitionMetric:
         assert len(transition_records) == 1
         assert transition_records[0].levelno == logging.INFO
 
-        stopped_lines = [
-            r for r in caplog.records if "marked STOPPED" in r.message
-        ]
+        stopped_lines = [r for r in caplog.records if "marked STOPPED" in r.message]
         assert len(stopped_lines) == 1
         assert stopped_lines[0].levelno == logging.WARNING
 
@@ -1794,7 +1790,9 @@ class TestRenewalDigestLogging:
         assert fields[8] == "-"
 
     @pytest.mark.asyncio
-    async def test_pathological_ttl_digest_format_failure_uses_placeholder(self, caplog):
+    async def test_pathological_ttl_digest_format_failure_uses_placeholder(
+        self, caplog
+    ):
         """ME-01: a numeric-but-pathological ttl_timestamp (huge negative
         epoch overflowing the datetime range) flows through failure
         accounting exactly once; the digest TTL formatter's failure


### PR DESCRIPTION
## Problem

  `DeadlineRenewalScheduler` logged per-item renewal failures inconsistently
  with the legacy engine. `get_device_info` / `extend_ttl` failures went through
  `log.exception` (ERROR plus traceback) or `log.error`, although these failures
  are routine and recoverable per item. Operators therefore got either noisy
  error logs or — after downgrading — no traceback at all, which left on-call
  diagnosis of renewal failures without the stack.

  ## Solution

  - Failure-path log levels aligned with the legacy engine:
    `get_device_info` / `extend_ttl` failures now log at `log.warning` with the
    error message inline (`"...: %s"`), and the remaining `log.error` failure
    path moved to `log.warning`.
  - Tracebacks are preserved without raising the level: both failure sites now
    additionally emit `log.debug(..., exc_info=True)`.
  - Renewal scheduling logic itself is unchanged.

  The branch also carried commits predating the REL20260828 alignment. After
  rebasing onto `github/dev`, most were already merged upstream and whitened
  out. The PR therefore leaves three small deltas beyond the baas change:
  a regenerated `bots.openapi.json` section for the owner-level routines
  aggregate (orig. #1595), corp-overlay config lookup dirs in `yaml_provider.py`,
  and a line-level adjustment in `notify.py`'s DingTalk sender wiring carried by
  the task-claim commit (#1606). A cleanup commit dropped the remaining conflict
  resolution residue.

  ## Validation

  - Unit tests updated in `test_deadline_renewal_task.py`:
    - caplog assertions pin the WARNING level on the `core-scheduler` logger for
      both failure paths;
    - a new test pins the DEBUG `exc_info` traceback (`WR-01`).
  - The two baas commits replayed byte-identical across the rebase (patch-id
    equality verified).
  - Ran locally: `py_compile` on affected files, duplicate-definition scan, and
    conflict-marker scan — all clean.
  - Not run locally: full pytest suite and coverage (no local venv available) —
    deferred to the PR CI gates.

  ## Compatibility and risk

  - Log-level semantics only; no API, config, or schema contract change.
  - `bots.openapi.json` is a generated doc dump; the gateway config test
    validates it in CI.
  - Rollback: revert the two baas commits; the remaining small deltas revert
    independently.

  ## Related issues

  - #1595 — owner-level routines aggregate (source of the schema regen delta)