### PR TITLE
feat(backend): fold legacy aicoding engine into claude_code with template form marker

### DIFF
--- a/docs/bot-create-api-guide.zh-CN.md
+++ b/docs/bot-create-api-guide.zh-CN.md
@@ -1,0 +1,244 @@
+# Bot 创建接口对接指南（新 openapi / 老内部 API）
+
+> 面向前端。覆盖两条创建链路的请求/响应契约、错误码，以及"从第三方 openapi 拿 aicoding 配置来创建 Bot"的接入指引。
+>
+> 适用版本：backend `feat/engine-vocabulary-template-form`（engine/aicoding 词汇分离）之后。
+
+---
+
+## 0. 两面接口总览
+
+| | 新 openapi 面（推荐新接入） | 老 内部 API（存量页面） |
+|---|---|---|
+| 创建 | `POST /openapi/v1/bots` | `POST /api/bots` |
+| 授权轮询 | `POST /openapi/v1/bots/{bot_id}/auth-status`（GET 拼写逐步退休中） | `POST /api/bots/auth-status` |
+| 鉴权 | 经 OCB 网关注入租户身份；owner 以 `user_id` 口径（详见网关接入文档） | 浏览器会话（buservice cookie） |
+| 引擎值 | **只收真实引擎**：`openclaw` / `claude_code` / `teclaw` / `hermes` / `moltis`；传 `aicoding` → 400 | 收上述引擎；传 `aicoding` 会被后端**自动折叠**为 `claude_code`（兼容存量调用） |
+| 模板入参 | `engine_properties.template`（一个自由 dict，严格校验见 §1.3） | `template_type` + `template_config` 两个字段直传（校验宽松，见 §2.1） |
+| 响应封套 | `{code, message, data, request_id}`，`code = HTTP状态码×1000` | `{success, message, error_code, data}` |
+| 状态 | 测试中，未上线 | 已在线 |
+
+**创建流程（两面相同）**：创建 → 首次可能需要用户授权（返回授权 URL）→ 前端引导用户完成 → 轮询 auth-status → `ISSUED` 时 Bot 才真正落库创建。
+
+---
+
+## 1. 新 openapi 面
+
+### 1.1 创建 `POST /openapi/v1/bots`
+
+**请求体**（`extra=forbid`，多传字段直接 422）：
+
+| 字段 | 类型 | 必填 | 说明 |
+|---|---|---|---|
+| `bot_name` | string | ✅ | 非空、不含 `@`、首尾空白会被 trim、租户内唯一（重复 409） |
+| `bot_desc` | string | ✅ | 描述，可为空串 |
+| `engine` | string | ✅ | 真实引擎：`openclaw` / `claude_code` / `teclaw` / `hermes` / `moltis`；以部署配置为准（可从 available-engines 端点读取）。**`aicoding` 不是合法值，400** |
+| `cluster_name` | string | ✅ | `ACRA`（teclaw 以外的一切引擎）/ `ANDC`（仅 teclaw），与 engine 一一对应，错配 400 |
+| `bot_type` | string | ✅ | `personal` 或 `service` |
+| `space_id` | string | — | 业务空间上下文，缺省用个人空间 |
+| `engine_properties` | object | — | 引擎私有入参；缺省=普通 bot；提供则**只允许一个键 `template`**（见 §1.3） |
+
+**请求示例 A —— 普通 bot：**
+
+```json
+POST /openapi/v1/bots
+{
+  "bot_name": "research-assistant",
+  "bot_desc": "Summarizes weekly industry news.",
+  "engine": "openclaw",
+  "cluster_name": "ACRA",
+  "bot_type": "personal"
+}
+```
+
+**请求示例 B —— applicationCoding（aicoding 形态）bot：**
+
+```json
+POST /openapi/v1/bots
+{
+  "bot_name": "coding-bot",
+  "bot_desc": "应用研发 bot",
+  "engine": "claude_code",
+  "cluster_name": "ACRA",
+  "bot_type": "personal",
+  "engine_properties": {
+    "template": {
+      "devflow_workflow": "app-flow-id",
+      "code_repos": ["https://code.example.com/team/svc"],
+      "yuque_kb_repos": ["team/kb"],
+      "bot_template_config": { "ext_config": { "thetaKey": "..." } }
+    }
+  }
+}
+```
+
+**响应：**
+
+- **201**（`code: 201000`）— 不需授权，直接创建成功，`data` 为 Bot 对象（见 §1.4 字段）。
+- **202**（`code: 202000`）— 需要用户授权，`data`：
+
+```json
+{
+  "bot_id": "20260813_a7k2m9p1",
+  "iframe_url": "https://auth.example.com/passport/consent?flow=f-123",
+  "redirect_url": ""
+}
+```
+
+  前端引导用户完成 `iframe_url` 授权，然后轮询 §1.2。
+
+**错误码**：400 不支持的引擎/集群错配（`code: 400000`）、403 无权限、404 空间不存在、409 名称重复、422 请求体校验失败（含 server-managed 字段，见 §1.3）。
+
+### 1.2 授权轮询 `POST /openapi/v1/bots/{bot_id}/auth-status`
+
+**不是只读操作**——授权通过后 Bot 在这里才真正创建。轮询时必须把创建时的属性**原样回传**（不回传会按默认值创建，与用户请求矛盾），且创建接口的所有校验会全部重跑：
+
+```json
+POST /openapi/v1/bots/20260813_a7k2m9p1/auth-status
+{
+  "engine": "claude_code",
+  "cluster_name": "ACRA",
+  "bot_name": "coding-bot",
+  "bot_desc": "应用研发 bot",
+  "bot_type": "personal",
+  "engine_properties": { "template": { "...": "与创建时一致" } }
+}
+```
+
+**响应 `data`（`code: 200000`）：**
+
+```json
+{
+  "status": "ISSUED",          // PENDING=继续轮询; ISSUED=已创建; 其它值(如 REJECTED)=终态,以400返回
+  "message": null,
+  "bot": { "bot_id": "...", "engine": "claude_code", "template_type": "applicationCoding", "..." : "..." }
+}
+```
+
+`bot` 仅在 `ISSUED` 时返回。Passport 尚未就绪时返回 `PENDING` + 提示 message，继续轮询即可。
+
+### 1.3 `engine_properties.template` 校验规则（重点）
+
+这是一个**自由透传 dict**，但有以下硬规则：
+
+**① 顶层 server-managed 键，出现即 422（整单拒绝）：**
+
+`workspace_id`、`template_uid`、`bot_id`、`workspace_status`、`workspace_state`、`start_status`、`engine_form`
+
+这些是**平台管理的身份/形态字段**，不收外部输入。注意：`engine_form`（aicoding 形态标记）由后端在需要时写入，前端**永远不要传**。
+
+**② 已知键的类型检查（类型不符 422）：**
+
+| 键 | 类型 | 说明 |
+|---|---|---|
+| `devflow_workflow` | string \| object | 工作流标识/描述 |
+| `code_repos` | array | 代码仓库 |
+| `yuque_kb_repos` | array | 语雀知识库 |
+| `bot_template_config` | object | 引擎侧配置（密钥放 `ext_config` 下透传，如 `thetaKey`；`token` 会加密落库） |
+| `token` | string | 若出现必须非空 |
+
+**③ 其它未知键**：原样存活、随快照落库（引擎自有扩展），但**平台不解读**——见 §3 命名提醒。
+
+**④ 组合约束**（带 `template` 创建时）：`engine` 必须 `claude_code` + `bot_type=personal` + 个人空间 + 云端。违反 → 409。
+
+### 1.4 查询接口（创建后核对 / 列表展示）
+
+| 端点 | 说明 |
+|---|---|
+| `GET /openapi/v1/bots?keyword=&engine=&status=&page=&page_size=` | 本人 bot 分页列表 |
+| `GET /openapi/v1/bots/{bot_id}` | 单个 bot 详情 |
+| `GET /openapi/v1/bots/all`（Header `X-Space-Id` 可选） | 统一卡片列表（个人云/服务/本地） |
+
+响应中的模板相关字段（三个端点一致）：
+
+```json
+"template_type": "applicationCoding",        // 无模板为 null
+"template_config": {                          // 白名单投影，secret 永不返回
+  "template_key": "...", "template_uid": "...",
+  "code_repos": [...], "yuque_kb_repos": [...], "devflow_workflow": "...",
+  "engine_form": "aicoding"                   // 仅 aicoding 形态 bot 带 markers
+}
+```
+
+> `template_config` 是**服务的白名单投影**（`engine_form`/`code_repos` 等展示安全键），`token`、`ext_config.thetaKey` 等密钥永远不回。**前端判定"是否 aicoding 形态"：`template_config.engine_form == "aicoding"`，或 `template_type` 非空且不等于 `"normalCC"`**（任一命中即 aicoding 运行时；`normalCC` 是纯 claude_code 模板）。`engine` 字段只可能是真实引擎。
+
+---
+
+## 2. 老 内部 API
+
+### 2.1 创建 `POST /api/bots`
+
+**请求体**（宽松直传，浏览器会话取 user_id）：
+
+| 字段 | 必填 | 说明 |
+|---|---|---|
+| `bot_name` | — | 不传按规则默认命名 |
+| `bot_desc` | — | |
+| `engine_type` | — | 缺省 `openclaw`。传 `aicoding` 会被后端**自动折叠为 `claude_code`**（响应与落库都是 claude_code，存量调用零破坏） |
+| `bot_type` | — | 缺省 `personal` |
+| `entity_id` / `entity_type` | — | 缺省 `staff_{user_id}` / `staff` |
+| `template_type` | — | 如 `applicationCoding`；模板工厂类型（`normalCC` 等）也可 |
+| `template_config` | — | 配置 dict；**LEGACY 模式，不拒 server-managed 字段**（`template_uid` 等平台字段可带） |
+| `avatar_url` / `share_policy` | — | |
+
+**响应**（`{success, message, error_code, data}`）：
+
+```json
+// 授权已具备，直接创建成功（error_code=200）
+{ "success": true, "data": {
+    "bot": { "bot_id": "...", "active_engine": "claude_code", "...": "..." },
+    "passport": { "token": "...", "status": "ISSUED", "is_first_bot": false } } }
+
+// 需要授权（error_code=401，前端引导 iframe_url 后轮询 2.2）
+{ "success": false, "error_code": 401, "data": {
+    "need_authorization": true, "bot_id": "...",
+    "iframe_url": "...", "redirect_url": "" } }
+```
+
+**错误码**：400 参数非法、401 需授权（见上）、409 重名或组合不支持（`BotCombinationUnsupportedError`）、429 数量上限、500/501 服务异常、5400 授权服务异常。
+
+### 2.2 授权轮询 `POST /api/bots/auth-status`
+
+Body 必带 `bot_id`，其余与创建一致回传。响应 `data.status ∈ {PENDING, ISSUED}`，`ISSUED` 时带 `data.bot`。
+
+---
+
+## 3. aicoding 场景接入指引（第三方配置 → 创建）
+
+前端从其他团队 openapi 取到 aicoding 配置后调我们的创建接口，按下面映射：
+
+**第一步：engine 固定填 `claude_code`（两个接口都一样）。**
+不要透传第三方配置里可能出现的 `aicoding` 引擎值——openapi 面会 400；老 API 虽会自动折叠，也请显式传 `claude_code` 以获得一致行为。
+
+**第二步：把第三方配置字段映射进 `engine_properties.template`（openapi）/ `template_config`（老 API）：**
+
+| 第三方可能的字段 | 我们契约的键位 | 说明 |
+|---|---|---|
+| 工作流 | `devflow_workflow` | str 或 object |
+| 代码仓库 | `code_repos` | list；模板工厂命名是 `repos`/`init_repos`/`application_repo_urls` |
+| 语雀/知识库 | `yuque_kb_repos` | list |
+| 密钥类（thetaKey 等） | `bot_template_config.ext_config.*` | 嵌套透传，落库加密策略同现状 |
+| token | `token` | 出现就必须非空 |
+
+**第三步：剔除/不要携带这些键（openapi 面必 422）：**
+`template_uid`、`workspace_id`、`bot_id`、`workspace_status`、`workspace_state`、`start_status`、`engine_form`。如果第三方配置里带 `template_uid`，**由前端丢弃**（模板 uid 由平台侧解析/分配）。
+
+**注意事项：**
+
+1. **命名即语义**：未知键虽然会原样存活落库，但平台只解读上表的键名——第三方字段名若与上表不一致，配置会"存了但没人读"，静默失效。拿到第三方 openapi 的字段表后，先与后端对一遍映射。
+2. **形态不需要前端表达**：`engine=claude_code` + applicationCoding 模板创建的 bot，运行时自动路由 aicoding 实现；`engine_form` 由后端在折叠老链路 `aicoding` 引擎值时写入，前端不传。查询面识别形态的判据见 §1.4。
+3. **约束**：applicationCoding 创建目前仅支持 `bot_type=personal` + 个人空间。
+4. **模板工厂模板（normalCC/architect/用户自建）**：老 API 可用（`template_type` 直传），openapi 面**暂无创建入口**，需要的话单独提需求。
+
+---
+
+## 4. 常见错误速查
+
+| 现象 | 原因 | 处理 |
+|---|---|---|
+| openapi 创建 400 `unsupported engine` | `engine` 传了 `aicoding` 或未部署的引擎 | 改传 `claude_code` 等真实引擎 |
+| openapi 创建 422 提到 `server-managed fields` | `template` 里带了 `template_uid`/`engine_form` 等 | 剔除这些键（§3 第三步） |
+| openapi 创建 422 `extra inputs not permitted` | 请求体多了未知字段（如 `engine_options`） 或 `engine_properties` 下不是 `template` | 对照 §1.1 字段表 |
+| openapi 创建 409 `application coding does not support...` | 带模板但 engine≠claude_code / bot_type≠personal / 非个人空间 | 对照 §1.3 ④ |
+| 老接口创建成功但 `active_engine` 变成 `claude_code` | `engine_type=aicoding` 被折叠（预期行为） | 无需处理；形态看查询面的 `engine_form`/`template_type` |
+| auth-status 一直 PENDING | 用户未完成 iframe 授权或 Passport 未就绪 | 继续轮询；终态值（REJECTED 等）会以 400 返回 |

--- a/docs/superpowers/specs/2026-08-31-engine-vocabulary-template-form-design.md
+++ b/docs/superpowers/specs/2026-08-31-engine-vocabulary-template-form-design.md
@@ -1,0 +1,218 @@
+# Engine 词汇表收口与 Template 拓展字段设计（2026-08-31）
+
+> **状态：DRAFT，待评审。**
+>
+> **原则（用户拍板）：** `engine` 只有真实引擎（openclaw、claude_code、teclaw、hermes、moltis…）；
+> `aicoding` 这类"形态/产品"概念进入 template 等拓展字段，不再作为引擎值创建新 bot。
+> 存量业务零影响。
+>
+> **前提：** openapi 对外面**尚未上线**（测试中）——对外面可以直接拒绝 `aicoding`，
+> 不存在外部调用方兼容包袱；兼容包袱只存在于内部老链路。
+
+---
+
+## 1. 现状事实（调研锚点，2026-08-31 dev HEAD 9147fe741）
+
+### 1.1 两条创建链路早已汇合
+
+```text
+openapi:  POST /openapi/v1/bots        router.py:435-530
+            └─ body.engine ∈ _get_engine_types()   ← 校验含 aicoding（SUPPORTED_ENGINE_TYPES）
+老链路:   POST /api/bots               bot_management/router.py:922 + _bot_create_spec:119
+            └─ engine_type 从 body 直取，template_type/template_config 直传，无校验
+两条链路 ↓
+core:     create_bot_with_authorization  create_flow.py:446
+            └─ _prepare_create           create_flow.py:248   ← 兼容收口的天然单点
+            └─ bot_service.create_bot    bot_service.py:1244
+                 ├─ ac_bots.active_engine = engine_type 原样落库（:1312,:1397）
+                 ├─ ac_bots.template_type 列（:1406）
+                 └─ template_type and template_config → ac_templates.ext 行（:1433, TemplateService.create_template）
+```
+
+### 1.2 runtime 已实现"claude_code 为壳、aicoding 为内部实现"
+
+- `workspace/runtime_identity.py:6` `claude_code_uses_aicoding_runtime`：
+  `claude_code + template_type 非空且非 normalCC → aicoding 运行时`
+- `engines/registry.py:236-237`：`AicodingProvisioningStrategy` 同时注册给 `aicoding` 与 `claude_code`；
+  `resolve_bot_engine` / `resolve_baas_engine_bucket` 动态路由
+- `bot_inventory/policies/combo_policy.py:57` 方向已写死：
+  *"claude_code is the only external engine value: the runtime routing to the aicoding
+  adapter is an internal concern, not an alternative engine"*
+- openapi application-coding 创建已只认 claude_code（`strategy.py:177-182` engine≠claude_code 直接
+  `BotCombinationUnsupportedError`）
+
+### 1.3 词汇表与存量耦合点（`SUPPORTED_ENGINE_TYPES` 不能直接删 aicoding 的原因）
+
+| 消费点 | 锚点 | 影响 |
+| --- | --- | --- |
+| bot 行 `engine_types` 列存量已存 aicoding | `implementations/bot/bot.py:110`、`plugin_api/models.py:69` | switch_engine 靠它校验 |
+| `{engine}_conf` 资源目录名展开 | `services/resource_file_service.py:82` | 读路径出现 `aicoding_conf` |
+| 引擎列表下发（desktop/内部路由/available-engines） | `desktop_bot_service.py:691`、`bot_management/router.py:1385` | 部署配置 |
+| 引擎过滤查询 | `protocols/bot/bot.py:351` | active_engine='aicoding' 过滤 |
+| notify / mcp / cli defaults bucket | `notify/constants.py:5` 等 | 读词汇 |
+| singlebox 模板别名 | `di/.../singlebox/template_config.py:18-19` | local 测试形态 |
+| manifest 能力表（未落地的设计文档） | `docs/.../engine-requirements` ARC_ENGINES | 待同步修订 |
+
+**结论：读全动，写收口。**
+
+### 1.4 查询接口现状（用户要求的展示能力，大部分已具备）
+
+| 端点 | schema | 填充 | 现状 |
+| --- | --- | --- | --- |
+| `GET /openapi/v1/bots` | `Bot`（schemas.py:69，含 template_type:111 / template_config:116） | `_to_bot`（router.py:190-218） | ✅ 已返回（白名单投影） |
+| `GET /openapi/v1/bots/all` | `BotInventoryItem`（schemas.py:670，含 :716/:721） | `_to_inventory_item`（router.py:273-318）+ 分页批量 attach（`bot_inventory_service.py:178-195`） | ✅ 已返回（template_type 非空的卡片才 attach） |
+| `GET /openapi/v1/bots/{bot_id}` | `Bot` | `_to_bot` | ✅ 已返回 |
+
+公共投影：`template_public_view.py` `_PUBLIC_TEMPLATE_KEYS = (code_repos, devflow_workflow,
+template_key, template_uid, yuque_kb_repos)` —— 密钥（`token`、`bot_template_config.ext_config.thetaKey`）
+永不露出。**缺口：form 标记不在白名单，查询面看不见 aicoding 形态。**
+
+---
+
+## 2. 词汇表设计：engine 与 form 分离
+
+```text
+engine（真实引擎，可创建/可切换）: openclaw | claude_code | teclaw | hermes | moltis
+                                   （= SUPPORTED_ENGINE_TYPES − aicoding）
+form（形态，进拓展字段，只读展示）: aicoding（后续可扩展）
+```
+
+- 常量落点：`core/workspace/constants.py` 追加
+  `PUBLIC_CREATABLE_ENGINES = frozenset(SUPPORTED_ENGINE_TYPES) - {"aicoding"}`；
+  **`SUPPORTED_ENGINE_TYPES` 本体不动**（存量读词汇，见 §1.3）。
+- form 标记键：**`engine_form`**（顶层键，值如 `"aicoding"`）。
+  - 显示层语义归平台（不是引擎私有），放 template_config 顶层而非 `bot_template_config.ext_config`
+    （后者是引擎私有扩展先例 thetaKey，且不进公共投影）。
+  - **server-managed**：只能由归一化/平台写入；PUBLIC 校验模式下用户在
+    `engine_properties.template` 传 `engine_form` → 422（加入 server-managed 拒绝清单）。
+
+## 3. 链路兼容设计
+
+### 3.1 openapi 创建/切换（未上线 → 直接拒，不归一化）
+
+- `create_bot`（router.py:498）与切换端点（router.py:1113）的校验由
+  `engine in _get_engine_types()` 收紧为 **`engine in PUBLIC_CREATABLE_ENGINES`**
+  （以部署 registry 为上限再交公共白名单）。
+- `engine="aicoding"` → 400 `UnsupportedEngineError`。文档/`_ENGINE_DESC` 明确词汇表。
+- openapi 一期**不提供**创建 aicoding form bot 的入口；aicoding 形态 bot 仍走内部链路。
+
+### 3.2 老链路归一化（汇合点，单点收口）
+
+位置：`create_flow._prepare_create`（create_flow.py:248）——openapi 已在 router 层
+被 400 拦截，到这里的 `aicoding` 只来自内部面，归一化只服务老链路。
+
+规则（`engine=="aicoding"` 时）：
+
+```text
+1. engine               → "claude_code"
+2. form 标记写位置（保运行时等价的唯一依据）：
+   a. template_type 非空且 template_config 非空：template_config 合并 {"engine_form": "aicoding"}
+      （随 ac_templates.ext 落库）
+   b. template_type 为空（plain bot）：不写任何标记——归一后就是干净的
+      claude_code plain bot（见下方修订记录）
+3. 其余字段（bot_type/space/template_type 本体）不动。
+```
+
+> **实现期修订（2026-08-31）**：原 §3.2-b 设计为 plain bot 写 `ac_bots.ext` 标记。
+> 修订为 **plain bot 不写标记**：form 是模板属性（"aicoding 的类型只在 template 的
+> 拓展字段"），无模板即无形态；且 ext 标记若只被部分消费点读取，会造成
+> "运行时=aicoding、开通 bucket=claude_code"的半吊子不一致。plain 老 aicoding
+> bot 归一后统一按 claude_code plain bot 运行（runtime/bucket/layout 一致），
+> 读路径存量 `active_engine='aicoding'` 的 bot 完全不受影响。
+
+归一化幂等：engine 已是 claude_code 则零改动——正例回归。
+
+### 3.3 运行时判定升级（判定函数唯一化）
+
+`workspace/runtime_identity.py` 升级为单一判定入口：
+
+```python
+def uses_aicoding_runtime(
+    *, active_engine: str | None,
+    template_type: str | None,
+    template_config: Mapping | None = None,
+    bot_ext: Mapping | None = None,
+) -> bool:
+    # 1) 存量短路：active_engine == "aicoding" → True（读路径不动）
+    # 2) form 标记：active_engine == "claude_code" 且
+    #    template_config.engine_form == "aicoding" 或 bot_ext.engine_form == "aicoding" → True
+    # 3) 既有语义保留：claude_code + template_type 非空且非 normalCC → True
+```
+
+存量 `claude_code_uses_aicoding_runtime` 保留为薄包装（或有调用方逐步迁移）；消费锚点
+（改造成传全量输入，一期不强制全量替换）：
+
+- `engines/registry.py` `resolve_bot_engine` / `AicodingProvisioningStrategy.resolve_bot_engine`
+- `resolve_baas_engine_bucket`（BaaS bucket 与 default MCP/CLI bucket 的 resolver 签名需能吃到
+  form 标记——调用方传入，registry 不新增查库能力）
+- `engine_resolver.resolve_runtime_engine_for_bot`
+- `AicodingProvisioningStrategy.resolve_bot_engine`（strategy.py:224）
+
+### 3.4 存量兼容红线（一条都不能踩）
+
+1. `SUPPORTED_ENGINE_TYPES` 不删 aicoding；`AicodingProvisioningStrategy(AICODING_ENGINE_TYPE)`
+   注册保留——存量 `active_engine='aicoding'` bot 的策略解析/bucket/identity/skill 布局全部照旧。
+2. 读路径（查询响应的 `engine` 字段、bucket 解析、`{engine}_conf` 目录、notify/身份文件白名单）
+   对存量 aicoding bot **返回原值 `aicoding`**——读不归一，schema 本就是开放 `str`。
+3. 不做存量数据迁移（active_engine 批量改写是二期可选项，须只读窗口+全量回归，本期不做）。
+
+---
+
+## 4. 查询接口补齐（all / bots / bot_id 展示 template_type + template_config）
+
+三个端点已具备返回能力（§1.4），本设计只补三件事：
+
+1. **`_PUBLIC_TEMPLATE_KEYS` 白名单追加 `"engine_form"`**（template_public_view.py:21）——
+   `project_template_config_for_public` 是三个端点共用的唯一投影，加一处三个接口同时露出，
+   前端由此判定"这是 aicoding 形态卡片"。
+2. **`/all` 的 attach 语义确认**：现状只对 `template_type` 非空的卡片 attach template_config
+   （bot_inventory_service.py:178-195）。plain aicoding 归一 bot（form 标记在 bot.ext）
+   的 template_config 为 null、template_type 为 null——**这是预期行为**，前端对这类卡片读
+   `bot.ext` 侧标记（见 §5 响应面）或在 bot 详情补 `engine_form`。
+3. **响应描述更新**：`Bot`/`BotInventoryItem` 的 template_config 字段 description 补一句
+   form 标记的说明（docstring 进 OpenAPI 文档，走既有发布链）。
+
+> 说明：查询接口**不按 form 过滤**（engine 查询参数语义保持"真实引擎"）；
+> form 是展示维度，过滤需求出现时再加独立查询参数。
+
+---
+
+## 5. 改动锚点清单
+
+| # | 文件 | 改动 |
+| --- | --- | --- |
+| 1 | `core/workspace/constants.py` | `PUBLIC_CREATABLE_ENGINES` 常量 |
+| 2 | `adapters/http/openapi_v1/bots/router.py:498,1113` | 创建/切换校验收紧（400 拒 aicoding） |
+| 3 | `core/bot_management/create_flow.py:248` | `_prepare_create` 归一化（aicoding→claude_code + form 标记） |
+| 4 | `core/workspace/runtime_identity.py` | `uses_aicoding_runtime`（三元输入 + 存量短路） |
+| 5 | `core/bot_management/engines/aicoding/strategy.py` | `to_internal_template_config` server-managed 清单 + `engine_form`；`resolve_bot_engine` 吃 form |
+| 6 | `core/bot_management/template_public_view.py:21` | 白名单 + `engine_form` |
+| 7 | `adapters/http/openapi_v1/bots/schemas.py` | 两个 response schema 的 template_config description |
+| 8 | `bots.openapi.json` + ocb 仓 `application.yaml` | 手工增量（若 router 行为变化影响文档措辞；§0.3 硬规矩） |
+
+无新表、无 DDL、无数据迁移。
+
+## 6. 钉死测试清单
+
+1. openapi `POST /bots` engine=aicoding → 400；engine=claude_code/openclaw → 不受影响。
+2. openapi 切换引擎至 aicoding → 400；存量 aicoding bot 切出到其它引擎 → 照旧允许。
+3. 老链路 aicoding + applicationCoding → 落库 active_engine=claude_code、
+   ac_templates.ext 含 `engine_form: aicoding`；BaaS bucket 与改造前同 bucket（等价性断言）。
+4. 老链路 plain aicoding → active_engine=claude_code + `ac_bots.ext.engine_form=aicoding`；
+   不插 ac_templates 行、不触发 workspace hosting。
+5. 归一化幂等：engine=claude_code 输入零改动。
+6. 存量回归：`active_engine='aicoding'` 的 bot —— 查询返回 `engine:'aicoding'`、
+   runtime/bucket/identity 布局逐项不变。
+7. 查询三接口：template_type/template_config 返回、`engine_form` 露出、
+   `token`/`bot_template_config`（thetaKey）绝不出现（扫描断言）。
+8. PUBLIC 校验模式：`engine_properties.template` 用户传 `engine_form` → 422。
+
+## 7. 分期与开放问题
+
+- **一期**（本设计）：写入收口 + 判定函数 + 白名单露出。老链路归一化让新行不再出现 engine='aicoding'。
+- **二期**（另立决策）：存量数据迁移（a­ctive_engine 批量改写 + 标记回填）、读路径收紧、
+  manifest `ARC_ENGINES` 改为引擎×形态二维、openapi 面是否开放 aicoding form 创建。
+- **待拍板**：
+  1. form 标记键名 `engine_form` 是否与前端/模板工厂契约对齐（当前拍板权在后端，越早定越好）。
+  2. 老链路是否仍有"engine=aicoding 无模板"的真实流量——决定 §3.2-b 分支是否只是防御性代码
+     （不影响设计形状，但影响测试投入）。

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -89,6 +89,7 @@ from agentclaw.community.api.bot_startup_script_service import (
 from agentclaw.community.api.data_init_service import DataInitServiceProtocol
 from agentclaw.community.core.workspace.constants import (
     DEFAULT_ENGINE_TYPE,
+    INTERNAL_ENGINE_TYPES,
     _get_engine_types,
 )
 from agentclaw.community.di import Injected
@@ -418,6 +419,19 @@ def _sync_passport_identity(
         raise PassportError(f"Passport metadata update failed: {exc}") from exc
 
 
+def _require_publicly_creatable_engine(engine: str) -> None:
+    """Refuse engines this surface cannot create on or switch to (→ 400).
+
+    Two gates in one: the value must be in the deployment-configured registry
+    (``_get_engine_types`` — the same check switch/engine completion uses), and
+    it must not be an internal implementation engine (``aicoding`` is the
+    internal runtime behind ``claude_code``, not a product engine; its form
+    travels on the template snapshot's ``engine_form`` marker instead).
+    """
+    if engine not in _get_engine_types() or engine in INTERNAL_ENGINE_TYPES:
+        raise UnsupportedEngineError(engine)
+
+
 def _engine_properties_from_body(
     body: BotCreate | BotAuthStatusPoll,
 ) -> dict[str, Any]:
@@ -495,8 +509,7 @@ async def create_bot(
     # below treats every non-teclaw value as ACRA, so an unknown engine would
     # otherwise sail through, allocate an id, apply for a Passport, and only fail
     # later at device provisioning — with those side effects already committed.
-    if body.engine not in _get_engine_types():
-        raise UnsupportedEngineError(body.engine)
+    _require_publicly_creatable_engine(body.engine)
     # The engine/cluster pair must obey the bijection (ANDC⟺teclaw, ACRA⟺else).
     validate_engine_cluster(body.engine, body.cluster_name)
     _require_service_capable_engine(body.bot_type, body.engine)
@@ -1110,8 +1123,7 @@ def _complete_auth_status(
     # configured registry, that bot's active_engine would be absent from its own
     # enabled-engine list. Runs before Passport is queried, so nothing external
     # happens for a request that cannot succeed.
-    if effective_engine not in _get_engine_types():
-        raise UnsupportedEngineError(effective_engine)
+    _require_publicly_creatable_engine(effective_engine)
     if cluster_name is not None:
         validate_engine_cluster(effective_engine, cluster_name)
     _require_service_capable_engine(bot_type or "personal", effective_engine)

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -47,7 +47,9 @@ _CLUSTER_DESC = (
 _ENGINE_DESC = (
     "Engine that powers the bot, fixed at creation. The valid set is "
     "deployment-configured — read it from the engine group's available-engines "
-    "endpoint; an unlisted engine is refused (400)."
+    "endpoint; an unlisted engine is refused (400). Internal implementation "
+    "engines (e.g. 'aicoding', the internal runtime behind 'claude_code') are "
+    "not accepted; runtime forms travel on the template, not the engine."
 )
 
 # The status vocabulary is a pass-through of the stored lifecycle state, and the
@@ -116,7 +118,9 @@ class Bot(BaseModel):
     template_config: dict | None = Field(
         default=None,
         description="Server-projected template snapshot (display-safe subset; "
-        "secrets never returned). Null without a template.",
+        "secrets never returned). Null without a template. Includes the "
+        "server-managed 'engine_form' marker for bots whose runtime form "
+        "differs from the engine (e.g. engine_form='aicoding').",
     )
     space: BusinessSpace | None = Field(
         default=None,
@@ -721,7 +725,9 @@ class BotInventoryItem(BaseModel):
     template_config: dict | None = Field(
         default=None,
         description="Server-projected template snapshot (display-safe subset; "
-        "secrets never returned). Null without a template.",
+        "secrets never returned). Null without a template. Includes the "
+        "server-managed 'engine_form' marker for bots whose runtime form "
+        "differs from the engine (e.g. engine_form='aicoding').",
     )
     avatar_url: str | None = Field(
         default=None, description="Avatar URL for the bot, when configured."

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -30,6 +30,11 @@ from agentclaw.community.core.bot_management.engines.provisioning import (
 )
 from agentclaw.community.core.bot_management.engines.registry import (
     get_engine_provisioning_registry,
+    normalize_engine_type,
+)
+from agentclaw.community.core.bot_management.engines.aicoding.strategy import (
+    AICODING_ENGINE_TYPE,
+    CLAUDE_CODE_ENGINE_TYPE,
 )
 from agentclaw.community.core.bot_management.errors import (
     ApplicationCodingUnavailableError,
@@ -42,6 +47,10 @@ from agentclaw.community.core.bot_management.services.bot_service import (
 from agentclaw.community.core.mcp.services._defaults import get_default_cli_items
 from agentclaw.community.core.mcp.services.passport_scope import (
     filter_passport_mcp_codes,
+)
+from agentclaw.community.core.workspace.runtime_identity import (
+    AICODING_ENGINE_FORM,
+    ENGINE_FORM_KEY,
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.auth_relationship import AuthRelationshipError
@@ -88,6 +97,49 @@ def _reject_mixed_create_sources(spec: BotCreateSpec) -> None:
         raise BotTemplateInvalidError(
             "engine_properties cannot be combined with legacy template fields"
         )
+
+
+# Legacy internal-engine values folded at the shared create seam. ``aicoding``
+# is the internal implementation engine of ``claude_code``, not a product
+# engine: new bots store the real engine and carry the form marker
+# (``engine_form``) in their template snapshot instead (engine/form vocabulary
+# split — docs/superpowers/specs/2026-08-31-engine-vocabulary-template-form-design.md).
+_LEGACY_ENGINE_ALIASES = {AICODING_ENGINE_TYPE: CLAUDE_CODE_ENGINE_TYPE}
+
+
+def _normalize_legacy_engine_alias(spec: BotCreateSpec) -> BotCreateSpec:
+    """Fold legacy internal-engine values into the real engine (old-link compat).
+
+    Internal callers (``/api/bots``) may still send ``engine_type="aicoding"``.
+    The bot is created on the real engine (``claude_code``); a template-backed
+    create records the server-managed ``engine_form`` marker in the template
+    snapshot so runtime/bucket routing stays equivalent. A plain no-template
+    bot has no form — it is simply a plain ``claude_code`` bot. The public
+    surface never reaches this: it rejects internal engines with 400.
+
+    Idempotent: a spec already on the real engine passes through unchanged.
+    """
+    real_engine = _LEGACY_ENGINE_ALIASES.get(
+        normalize_engine_type(spec.engine_type, default="")
+    )
+    if real_engine is None:
+        return spec
+    template_config = spec.template_config
+    if spec.template_type and template_config is not None:
+        template_config = {**template_config, ENGINE_FORM_KEY: AICODING_ENGINE_FORM}
+    logger.info(
+        "[create_flow] folded legacy engine alias: requested_engine=%s "
+        "engine=%s template_type=%s form_marker_written=%s",
+        spec.engine_type,
+        real_engine,
+        spec.template_type,
+        spec.template_type and template_config is not None,
+    )
+    return replace(
+        spec,
+        engine_type=real_engine,
+        template_config=template_config,
+    )
 
 
 def _prepare_with_engine_strategy(
@@ -253,6 +305,12 @@ def _prepare_create(
 ) -> BotCreateSpec:
     """Apply shared creation policy before any external or persistence effects."""
     _reject_mixed_create_sources(spec)
+
+    # Fold legacy internal-engine values before the strategy gates: the
+    # aicoding strategy rejects application-coding creates on any engine other
+    # than claude_code, so normalizing afterwards would keep rejecting the
+    # old link's engine_type="aicoding" + applicationCoding combination.
+    spec = _normalize_legacy_engine_alias(spec)
 
     if spec.engine_properties:
         prepared = _prepare_with_engine_strategy(spec, context)

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -11,7 +11,7 @@ import json
 from copy import deepcopy
 import threading
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, Mapping
 
 from agentclaw.community.core.bot_management.capabilities import (
     is_template_factory_config,
@@ -21,7 +21,7 @@ from agentclaw.community.core.bot_management.errors import (
     BotTemplateInvalidError,
 )
 from agentclaw.community.core.workspace.runtime_identity import (
-    claude_code_uses_aicoding_runtime,
+    uses_aicoding_runtime,
 )
 
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
@@ -58,6 +58,11 @@ _ENCRYPTED_VALUE_PREFIX = "enc:v1:"
 _AICODING_RESTART_MARKER_KEY = "_aicoding_restart"
 _AICODING_RESTART_RESYNC_KEY = "resync_authorization"
 logger = get_logger()
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any] | None:
+    """Coerce a raw bot-record field to a read-only mapping, or None."""
+    return value if isinstance(value, Mapping) else None
 
 
 def _validate_application_coding_config(
@@ -104,10 +109,12 @@ class AicodingBaasEngineBucketResolver:
         *,
         normalized_engine_type: str,
         template_type: str | None,
+        template_config: Mapping[str, Any] | None = None,
     ) -> str | None:
         return AicodingProvisioningStrategy.resolve_baas_engine_bucket(
             active_engine=normalized_engine_type,
             template_type=template_type,
+            template_config=template_config,
         )
 
     def resolve_default_capabilities_engine_bucket(
@@ -115,10 +122,12 @@ class AicodingBaasEngineBucketResolver:
         *,
         normalized_engine_type: str,
         template_type: str | None,
+        template_config: Mapping[str, Any] | None = None,
     ) -> str | None:
         return self.resolve_baas_engine_bucket(
             normalized_engine_type=normalized_engine_type,
             template_type=template_type,
+            template_config=template_config,
         )
 
 
@@ -227,6 +236,7 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         if self.should_use_aicoding_runtime_engine(
             active_engine=active_engine,
             template_type=bot.get("template_type"),
+            template_config=_as_mapping(bot.get("template_config")),
         ):
             return AICODING_ENGINE_TYPE
         return active_engine
@@ -247,11 +257,19 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         *,
         active_engine: str | None,
         template_type: str | None,
+        template_config: Mapping[str, Any] | None = None,
     ) -> bool:
-        """Whether this bot should use the aicoding runtime engine."""
-        return claude_code_uses_aicoding_runtime(
+        """Whether this bot should use the aicoding runtime engine.
+
+        ``template_config`` carries the server-managed ``engine_form`` marker
+        written by creation normalization (legacy ``aicoding`` engine folded
+        into ``claude_code``); a stored ``aicoding`` engine short-circuits to
+        True (read paths never rewrite stored engines).
+        """
+        return uses_aicoding_runtime(
             active_engine=active_engine,
             template_type=template_type,
+            template_config=template_config,
         )
 
     @classmethod
@@ -260,11 +278,13 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         *,
         active_engine: str | None,
         template_type: str | None,
+        template_config: Mapping[str, Any] | None = None,
     ) -> bool:
         """Whether this context should select the aicoding BaaS bucket."""
         return cls.should_use_aicoding_runtime_engine(
             active_engine=active_engine,
             template_type=template_type,
+            template_config=template_config,
         )
 
     @classmethod
@@ -273,11 +293,13 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         *,
         active_engine: str | None,
         template_type: str | None,
+        template_config: Mapping[str, Any] | None = None,
     ) -> str | None:
         """Return the aicoding BaaS bucket override, if this engine owns it."""
         if cls.should_use_aicoding_baas_bucket(
             active_engine=active_engine,
             template_type=template_type,
+            template_config=template_config,
         ):
             return AICODING_ENGINE_TYPE
         return None

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
@@ -18,9 +18,12 @@ from enum import StrEnum
 from typing import Any, Dict, Optional
 
 from agentclaw.community.core.bot_management.errors import BotTemplateInvalidError
+from agentclaw.community.core.workspace.runtime_identity import ENGINE_FORM_KEY
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 
 # Public template input must not set platform-owned identity or lifecycle data.
+# ``engine_form`` is the server-managed form marker written only by creation
+# normalization (legacy ``aicoding`` engine folded into ``claude_code``).
 TEMPLATE_SERVER_RESERVED_FIELDS = frozenset(
     {
         "workspace_id",
@@ -29,6 +32,7 @@ TEMPLATE_SERVER_RESERVED_FIELDS = frozenset(
         "workspace_status",
         "workspace_state",
         "start_status",
+        ENGINE_FORM_KEY,
     }
 )
 

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/registry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol, TYPE_CHECKING
+from typing import Any, Mapping, Protocol, TYPE_CHECKING
 
 from .aicoding.strategy import (
     AICODING_ENGINE_TYPE,
@@ -37,7 +37,9 @@ class BaasEngineBucketResolver(Protocol):
 
     Return ``None`` when the resolver does not own the input.  The routing
     registry continues with the next resolver and eventually falls back to the
-    normalized engine type.
+    normalized engine type.  ``template_config`` is optional: call sites that
+    hold the bot's template snapshot pass it so the resolver can read the
+    server-managed ``engine_form`` marker.
     """
 
     def resolve_baas_engine_bucket(
@@ -45,6 +47,7 @@ class BaasEngineBucketResolver(Protocol):
         *,
         normalized_engine_type: str,
         template_type: str | None,
+        template_config: Mapping[str, Any] | None = None,
     ) -> str | None:
         """Return a bucket override, or ``None`` when not applicable."""
 
@@ -63,12 +66,14 @@ class BaasEngineBucketResolverRegistry:
         *,
         engine_type: str | None,
         template_type: str | None,
+        template_config: Mapping[str, Any] | None = None,
     ) -> str:
         normalized_engine = normalize_engine_type(engine_type)
         for resolver in self._resolvers:
             engine_bucket = resolver.resolve_baas_engine_bucket(
                 normalized_engine_type=normalized_engine,
                 template_type=template_type,
+                template_config=template_config,
             )
             if engine_bucket is not None:
                 return engine_bucket
@@ -83,6 +88,7 @@ class DefaultCapabilitiesEngineBucketResolver(Protocol):
         *,
         normalized_engine_type: str,
         template_type: str | None,
+        template_config: Mapping[str, Any] | None = None,
     ) -> str | None:
         """Return a bucket override, or ``None`` when not applicable."""
 
@@ -101,12 +107,14 @@ class DefaultCapabilitiesEngineBucketResolverRegistry:
         *,
         engine_type: str | None,
         template_type: str | None,
+        template_config: Mapping[str, Any] | None = None,
     ) -> str:
         normalized_engine = normalize_engine_type(engine_type)
         for resolver in self._resolvers:
             engine_bucket = resolver.resolve_default_capabilities_engine_bucket(
                 normalized_engine_type=normalized_engine,
                 template_type=template_type,
+                template_config=template_config,
             )
             if engine_bucket is not None:
                 return engine_bucket
@@ -283,16 +291,21 @@ def resolve_baas_engine_bucket(
     *,
     engine_type: str | None,
     template_type: str | None,
+    template_config: Mapping[str, Any] | None = None,
 ) -> str:
     """Resolve the engine bucket used by BaaS template/rollout routing.
 
     This public entrypoint delegates to the bucket resolver registry. Concrete
     engine-specific overrides are contributed by registered resolvers; unclaimed
-    inputs fall back to the normalized engine type.
+    inputs fall back to the normalized engine type. ``template_config``, when
+    the caller holds it, carries the server-managed ``engine_form`` marker so
+    resolvers can route form-marked ``claude_code`` bots to their runtime
+    bucket.
     """
     return get_baas_engine_bucket_resolver_registry().resolve(
         engine_type=engine_type,
         template_type=template_type,
+        template_config=template_config,
     )
 
 
@@ -321,11 +334,13 @@ def resolve_default_capabilities_engine_bucket(
     *,
     engine_type: str | None,
     template_type: str | None,
+    template_config: Mapping[str, Any] | None = None,
 ) -> str:
     """Resolve the engine bucket used by default MCP/CLI capability routing."""
     return get_default_capabilities_engine_bucket_resolver_registry().resolve(
         engine_type=engine_type,
         template_type=template_type,
+        template_config=template_config,
     )
 
 

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -718,9 +718,13 @@ class BotService(BotServiceProtocol):
 
         active_engine = normalize_engine_type(bot.get("active_engine"), default="")
         template_type = bot.get("template_type")
+        template_config = bot.get("template_config")
         engine_bucket = resolve_baas_engine_bucket(
             engine_type=active_engine,
             template_type=template_type,
+            template_config=template_config
+            if isinstance(template_config, dict)
+            else None,
         )
         if active_engine not in {"openclaw", "hermes", "claude_code"}:
             return source_provider

--- a/src/backend/src/agentclaw/community/core/bot_management/template_public_view.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/template_public_view.py
@@ -17,10 +17,16 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from agentclaw.community.core.workspace.runtime_identity import ENGINE_FORM_KEY
+
 #: Keys that are display-safe. Keep alphabetized.
 _PUBLIC_TEMPLATE_KEYS = (
     "code_repos",
     "devflow_workflow",
+    # Server-managed form marker (e.g. "aicoding" on bots created by folding
+    # the legacy aicoding engine into claude_code): the display-side way to
+    # tell an aicoding-form bot from a plain claude_code bot.
+    ENGINE_FORM_KEY,
     "template_key",
     "template_uid",
     "yuque_kb_repos",

--- a/src/backend/src/agentclaw/community/core/default_capabilities.py
+++ b/src/backend/src/agentclaw/community/core/default_capabilities.py
@@ -7,7 +7,7 @@ than branching here on engine-name literals.
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Mapping
 
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 from agentclaw.community.core.bot_management.engines.registry import (
@@ -40,21 +40,32 @@ def normalize_template_type(template_type: Any) -> str:
 def normalize_engine_type(
     engine_type: Any,
     template_type: Any = None,
+    template_config: Any = None,
     *,
     default: str = DEFAULT_ENGINE_TYPE,
 ) -> str:
-    """Normalize to the engine bucket used by default MCP/CLI capabilities."""
+    """Normalize to the engine bucket used by default MCP/CLI capabilities.
+
+    ``template_config``, when the caller holds it, carries the server-managed
+    ``engine_form`` marker so form-marked ``claude_code`` bots resolve to their
+    runtime bucket (legacy ``aicoding`` engine folded into ``claude_code``).
+    """
     normalized_engine = normalize_raw_engine_type(engine_type, default=default)
     normalized_template_type = normalize_template_type(template_type) or None
+    normalized_template_config = (
+        template_config if isinstance(template_config, Mapping) else None
+    )
     return resolve_default_capabilities_engine_bucket(
         engine_type=normalized_engine,
         template_type=normalized_template_type,
+        template_config=normalized_template_config,
     )
 
 
 def resolve_default_capabilities_engine_type(
     engine_type: Any,
     template_type: Any = None,
+    template_config: Any = None,
 ) -> str:
     """Resolve the engine bucket used by default MCP/CLI capability lists."""
-    return normalize_engine_type(engine_type, template_type)
+    return normalize_engine_type(engine_type, template_type, template_config)

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_template_resolver.py
@@ -153,6 +153,7 @@ class SystemConfigBaasTemplateResolver:
                 self.normalize_engine_for_template(
                     engine_type=engine_type,
                     template_type=template_type,
+                    template_config=template_config,
                 ),
                 template_type,
                 template_uid,
@@ -168,6 +169,7 @@ class SystemConfigBaasTemplateResolver:
         engine = self.normalize_engine_for_template(
             engine_type=engine_type,
             template_type=template_type,
+            template_config=template_config,
         )
         template_uid = self.select_template_uid(
             mapping=mapping,
@@ -176,6 +178,7 @@ class SystemConfigBaasTemplateResolver:
             bot_type=bot_type,
             engine_type=engine_type,
             template_type=template_type,
+            template_config=template_config,
         )
         version = self._config_version(mapping)
         logger.info(
@@ -302,16 +305,20 @@ class SystemConfigBaasTemplateResolver:
         bot_type: str,
         engine_type: str | None,
         template_type: str | None,
+        template_config: dict | None = None,
     ) -> str:
         """根据 selectors 选择最匹配的 template_uid。
 
         bot_type 只作为可选 selector 维度参与匹配；provider=baas 是否支持
         该 bot_type，由 BaasDeviceService 在真正创建前校验。
+        ``template_config`` 携带 server-managed ``engine_form`` 标记时参与
+        engine bucket 判定（老链路归一化后的 aicoding 形态 bot）。
         """
         normalized_bot_type = (bot_type or "").strip().lower()
         engine = self.normalize_engine_for_template(
             engine_type=engine_type,
             template_type=template_type,
+            template_config=template_config,
         )
         selectors = mapping.get("selectors")
         if not isinstance(selectors, list):
@@ -384,11 +391,17 @@ class SystemConfigBaasTemplateResolver:
         *,
         engine_type: str | None,
         template_type: str | None,
+        template_config: dict | None = None,
     ) -> str:
-        """把历史 engine 表达归一成 template 配置里的 engine。"""
+        """把历史 engine 表达归一成 template 配置里的 engine。
+
+        ``template_config`` 携带 server-managed ``engine_form`` 标记时参与
+        bucket 判定（老链路归一化后的 aicoding 形态 bot）。
+        """
         return resolve_baas_engine_bucket(
             engine_type=engine_type,
             template_type=template_type,
+            template_config=template_config,
         )
 
     def _legacy_template_whitelist_hit(

--- a/src/backend/src/agentclaw/community/core/devices/services/conn_info_builders/baas_builder.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/conn_info_builders/baas_builder.py
@@ -83,9 +83,13 @@ class BaasConnInfoBuilder:
         raw_engine_type = (bot or {}).get("active_engine") or _DEFAULT_ENGINE_TYPE
         bot_type = (bot or {}).get("bot_type") or ""
         template_type = (bot or {}).get("template_type") or ""
+        raw_template_config = (bot or {}).get("template_config")
         engine_type = SystemConfigBaasTemplateResolver.normalize_engine_for_template(
             engine_type=raw_engine_type,
             template_type=template_type,
+            template_config=raw_template_config
+            if isinstance(raw_template_config, dict)
+            else None,
         )
 
         if not bot:

--- a/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_session_runtime.py
+++ b/src/backend/src/agentclaw/community/core/expert_chat/services/expert_chat_session_runtime.py
@@ -200,6 +200,7 @@ class ExpertChatSessionRuntimeMixin:
         return resolve_baas_engine_bucket(
             engine_type=raw_engine_type,
             template_type=bot.get("template_type") or "",
+            template_config=template_config,
         )
 
     def _resolve_chat_engine_strategy(

--- a/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
+++ b/src/backend/src/agentclaw/community/core/mcp/services/_defaults.py
@@ -185,11 +185,28 @@ _DEFAULT_CLI_RESOLVER = _EngineCliDefaultsResolver()
 def _resolve_default_mcp_engine_bucket(
     engine_type: Optional[str],
     template_type: Any = None,
+    *,
+    ext_info: Optional[Mapping[str, Any]] = None,
 ) -> str:
     return resolve_default_capabilities_engine_type(
         engine_type,
         template_type,
+        _ext_template_config(ext_info),
     )
+
+
+def _ext_template_config(ext_info: Optional[Mapping[str, Any]]) -> Any:
+    """Pull the template snapshot out of an ``ext_info`` bag, if present.
+
+    ``ext_info`` callers (e.g. the create flow) pack ``{"template_config": ...}``;
+    its server-managed ``engine_form`` marker routes form-marked ``claude_code``
+    bots to the aicoding defaults bucket.
+    """
+    if isinstance(ext_info, Mapping):
+        template_config = ext_info.get("template_config")
+        if isinstance(template_config, Mapping):
+            return template_config
+    return None
 
 
 def _mcp_defaults_resolver(engine_bucket: str):
@@ -214,7 +231,8 @@ def get_default_mcp_servers(
     engine_bucket = _resolve_default_mcp_engine_bucket(
         engine_type,
         template_type,
-    ) 
+        ext_info=ext_info,
+    )
     resolver = _mcp_defaults_resolver(engine_bucket)
     servers = resolver.resolve(
         _DEFAULT_MCP_SERVERS_BY_ENGINE.get(engine_bucket, []),
@@ -310,6 +328,7 @@ def get_default_cli_items(
     key = resolve_default_capabilities_engine_type(
         engine_type,
         template_type,
+        _ext_template_config(ext_info),
     )
     resolver = _cli_defaults_resolver(key)
     return resolver.resolve(

--- a/src/backend/src/agentclaw/community/core/workspace/constants.py
+++ b/src/backend/src/agentclaw/community/core/workspace/constants.py
@@ -20,6 +20,13 @@ SUPPORTED_ENGINE_TYPES = [
 # 每个 bot 的实际引擎类型由 bot 自身属性决定，此值仅作 fallback。
 DEFAULT_ENGINE_TYPE = "openclaw"
 
+# 内部实现类引擎：不是可对外创建的产品引擎，只是某个产品引擎的运行时实现
+# （如 aicoding 是 claude_code 的内部实现）。形态信息记录在 template 的
+# 拓展字段（runtime_identity.ENGINE_FORM_KEY），不再作为 engine 值创建新 bot。
+# 存量 bot 的读路径（engine_types 列、{engine}_conf 目录、引擎过滤、
+# bucket 解析）仍需识别它们，故 SUPPORTED_ENGINE_TYPES 保持全集不动。
+INTERNAL_ENGINE_TYPES = frozenset({"aicoding"})
+
 
 def _get_engine_types() -> list[str]:
     """从环境变量或默认列表获取引擎类型。

--- a/src/backend/src/agentclaw/community/core/workspace/runtime_identity.py
+++ b/src/backend/src/agentclaw/community/core/workspace/runtime_identity.py
@@ -2,6 +2,68 @@
 
 from __future__ import annotations
 
+from typing import Any, Mapping
+
+#: Server-managed form marker. Creation normalization writes it into the
+#: template snapshot (``ac_templates.ext``) for template-backed bots, or the
+#: bot record's ``ext`` column for plain bots, when a legacy ``aicoding``
+#: engine value is folded into ``claude_code``. It marks the product form the
+#: bot runs; it is never accepted from public create input (server-managed).
+ENGINE_FORM_KEY = "engine_form"
+AICODING_ENGINE_FORM = "aicoding"
+
+
+def normalize_runtime_engine(active_engine: str | None) -> str:
+    """Normalize an engine spelling to the registry key form."""
+    return (active_engine or "").strip().lower().replace("-", "_")
+
+
+def engine_form_of(*sources: Mapping[str, Any] | None) -> str | None:
+    """First server-managed ``engine_form`` found across template/bot sources.
+
+    Sources are probed in order (template snapshot first, bot ``ext`` second);
+    a non-mapping or blank value is skipped, matching how ``bot`` records
+    degrade when the template attach is missing.
+    """
+    for source in sources:
+        if not isinstance(source, Mapping):
+            continue
+        value = source.get(ENGINE_FORM_KEY)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def uses_aicoding_runtime(
+    *,
+    active_engine: str | None,
+    template_type: str | None,
+    template_config: Mapping[str, Any] | None = None,
+) -> bool:
+    """Whether a Bot runs the AICoding runtime implementation.
+
+    Judgment order (engine/form vocabulary split, see
+    ``docs/superpowers/specs/2026-08-31-engine-vocabulary-template-form-design.md``):
+
+    1. Legacy short-circuit — a stored ``aicoding`` ``active_engine`` (rows
+       created before the vocabulary split) always runs the AICoding
+       implementation; read paths never rewrite stored engines.
+    2. Form marker — a ``claude_code`` bot whose template snapshot carries
+       the server-managed ``engine_form: aicoding`` marker (where creation
+       normalization records the form; a plain no-template bot has no form).
+    3. Historical semantics — ``claude_code`` plus a non-empty,
+       non-``normalCC`` template type.
+    """
+    normalized_engine = normalize_runtime_engine(active_engine)
+    if normalized_engine == "aicoding":
+        return True
+    if normalized_engine != "claude_code":
+        return False
+    if engine_form_of(template_config) == AICODING_ENGINE_FORM:
+        return True
+    normalized_template = (template_type or "").strip().lower()
+    return bool(normalized_template) and normalized_template != "normalcc"
+
 
 def claude_code_uses_aicoding_runtime(
     *,
@@ -10,7 +72,7 @@ def claude_code_uses_aicoding_runtime(
 ) -> bool:
     """Whether a logical Claude Code Bot runs the AICoding implementation."""
 
-    normalized_engine = (active_engine or "").strip().lower().replace("-", "_")
+    normalized_engine = normalize_runtime_engine(active_engine)
     normalized_template = (template_type or "").strip().lower()
     return (
         normalized_engine == "claude_code"
@@ -19,4 +81,11 @@ def claude_code_uses_aicoding_runtime(
     )
 
 
-__all__ = ["claude_code_uses_aicoding_runtime"]
+__all__ = [
+    "AICODING_ENGINE_FORM",
+    "ENGINE_FORM_KEY",
+    "claude_code_uses_aicoding_runtime",
+    "engine_form_of",
+    "normalize_runtime_engine",
+    "uses_aicoding_runtime",
+]

--- a/src/backend/src/agentclaw/community/core/workspace/skill_layout.py
+++ b/src/backend/src/agentclaw/community/core/workspace/skill_layout.py
@@ -14,7 +14,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 
 from agentclaw.community.core.workspace.runtime_identity import (
-    claude_code_uses_aicoding_runtime,
+    uses_aicoding_runtime,
 )
 
 
@@ -67,6 +67,9 @@ def runtime_layout_engine_for_bot(bot: Mapping[str, object]) -> str:
     catalogue selection, Passport, and persisted control-plane state therefore
     continue to use it.  Those templates run in an AICoding image, however,
     so every filesystem Pool operation must address AICoding's physical roots.
+    Bots created by folding a legacy ``aicoding`` engine into ``claude_code``
+    carry the server-managed ``engine_form`` marker in their template snapshot
+    and address the same roots; stored ``aicoding`` engines keep theirs.
 
     This dependency-free workspace contract is deliberately shared by Skill
     Center and Skills Pool.  It prevents either domain from inferring a
@@ -75,9 +78,13 @@ def runtime_layout_engine_for_bot(bot: Mapping[str, object]) -> str:
 
     engine = str(bot.get("active_engine") or "")
     template_type = str(bot.get("template_type") or "")
-    if claude_code_uses_aicoding_runtime(
+    template_config = bot.get("template_config")
+    if uses_aicoding_runtime(
         active_engine=engine,
         template_type=template_type,
+        template_config=(
+            template_config if isinstance(template_config, Mapping) else None
+        ),
     ):
         return "aicoding"
     return engine

--- a/src/backend/tests/community/api/bot_management/test_router.py
+++ b/src/backend/tests/community/api/bot_management/test_router.py
@@ -1441,15 +1441,16 @@ class TestCreateBot:
         # openclaw (default engine) carries no CLI items — fail-closed for non-aicoding
         assert passport_kwargs["cli_items"] == []
 
-    def test_create_passport_carries_default_cli_items_for_aicoding(
+    def test_create_passport_folds_plain_aicoding_engine_into_claude_code(
         self, mock_bot_service, mock_passport
     ):
-        """aicoding engine create path carries the 9 default CLI items.
+        """Plain engine_type=aicoding folds into claude_code with no CLI items.
 
-        Mirrors test_create_filters_local_mcp_codes_before_passport but posts
-        engine_type=aicoding, then asserts the passport call receives the full
-        default CLI list (verifies router.py wiring end-to-end, not just the
-        _defaults getter in isolation).
+        The old link's engine_type=aicoding is a legacy internal-engine value:
+        the bot is created on the real engine (claude_code), and the aicoding
+        default CLI grants follow the aicoding *form* — a plain no-template
+        bot has no form, so it is authorized nothing (fail-closed), like the
+        openclaw default in the sibling test above.
         """
         from agentclaw.community.adapters.http.bot_management.router import router
         import agentclaw.community.adapters.http.bot_management.router as router_module
@@ -1479,9 +1480,56 @@ class TestCreateBot:
 
         assert resp.json()["success"] is True
         passport_kwargs = mock_passport.apply_first_agent_passport.call_args.kwargs
-        assert passport_kwargs["engine_type"] == "aicoding"
-        # MCP codes still passed through independently of CLI items
+        assert passport_kwargs["engine_type"] == "claude_code"  # folded alias
         assert passport_kwargs["mcp_codes"] == ["mcp.remote.1"]
+        assert passport_kwargs["cli_items"] == []
+
+    def test_create_passport_carries_aicoding_cli_items_for_form_marked_template(
+        self, mock_bot_service, mock_passport
+    ):
+        """Template-backed engine_type=aicoding keeps the 9 default CLI items.
+
+        The fold records the server-managed engine_form marker in the template
+        snapshot and the default-capability bucket resolution reads it, so the
+        passport still authorizes the full aicoding CLI set — end-to-end
+        through the router, not just the _defaults getter in isolation.
+        """
+        from agentclaw.community.adapters.http.bot_management.router import router
+        import agentclaw.community.adapters.http.bot_management.router as router_module
+
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[get_request_context] = lambda: _make_ctx()
+        mock_auth = MagicMock()
+        mock_auth.authorize_entity_access = AsyncMock(
+            side_effect=lambda ctx, requested_entity_id, requested_entity_type: (
+                requested_entity_id, requested_entity_type,
+            )
+        )
+        attach_injector(app, Injector([_bind_bot_service(
+            mock_bot_service,
+            bot_repo=MagicMock(),
+            passport=mock_passport,
+            auth=mock_auth,
+            auth_rel=MagicMock(),
+            skill_set_factory=_stub_skill_set_factory(["mcp.remote.1"]),
+        )]))
+
+        with patch.object(router_module, "generate_bot_id", return_value="default"):
+            resp = TestClient(app).post(
+                "/api/bots",
+                json={
+                    "bot_name": "NewBot",
+                    "engine_type": "aicoding",
+                    "template_type": "applicationCoding",
+                    "template_config": {"devflow_workflow": "x"},
+                },
+            )
+
+        assert resp.json()["success"] is True
+        passport_kwargs = mock_passport.apply_first_agent_passport.call_args.kwargs
+        assert passport_kwargs["engine_type"] == "claude_code"  # folded alias
+        # The aicoding form (marker in the template snapshot) keeps the CLI set.
         cli_codes = [c["cli_code"] for c in passport_kwargs["cli_items"]]
         assert len(cli_codes) == 9
         assert "antcode-cli" in cli_codes

--- a/src/backend/tests/community/core/bot_management/test_application_coding_create.py
+++ b/src/backend/tests/community/core/bot_management/test_application_coding_create.py
@@ -524,3 +524,92 @@ def test_is_workspace_hosting_available() -> None:
     assert svc.is_workspace_hosting_available() is False
     svc._workspace_hosting_service = MagicMock()
     assert svc.is_workspace_hosting_available() is True
+
+
+# ── legacy engine alias folding (engine/form vocabulary split) ─────────────
+
+
+def test_legacy_aicoding_engine_folds_into_claude_code_with_form_marker() -> None:
+    """Old-link compat: engine_type="aicoding" + applicationCoding creates.
+
+    Before the vocabulary split this combination was rejected by the strategy's
+    claude_code-only gate; folding the alias first both restores the old link's
+    behavior and records the server-managed form marker the runtime bucket
+    routing reads.
+    """
+    prepared = _prepare_spec(
+        _application_coding_spec(
+            engine_type="aicoding", template_config={"devflow_workflow": "x"}
+        )
+    )
+    assert prepared.engine_type == "claude_code"
+    assert prepared.template_type == "applicationCoding"
+    assert prepared.template_config == {
+        "devflow_workflow": "x",
+        "engine_form": "aicoding",
+    }
+
+
+def test_legacy_aicoding_plain_bot_folds_without_any_marker() -> None:
+    """A plain no-template bot has no form: it is simply a claude_code bot."""
+    prepared = _prepare_spec(
+        BotCreateSpec(
+            entity_id="u1",
+            engine_type="aicoding",
+            bot_type="personal",
+            bot_name="Bot",
+        )
+    )
+    assert prepared.engine_type == "claude_code"
+    assert prepared.template_type is None
+    assert prepared.template_config is None
+
+
+def test_legacy_aicoding_without_template_config_writes_no_marker() -> None:
+    """Legacy Core-only shape (template present, config intentionally None):
+    nothing to merge the marker into; the existing template-type semantics
+    (claude_code + applicationCoding → aicoding runtime) already route it."""
+    prepared = _prepare_spec(
+        _application_coding_spec(engine_type="aicoding", template_config=None)
+    )
+    assert prepared.engine_type == "claude_code"
+    assert prepared.template_type == "applicationCoding"
+    assert prepared.template_config is None
+
+
+def test_engine_folding_is_idempotent_for_real_engines() -> None:
+    spec = _application_coding_spec()  # engine_type="claude_code"
+    prepared = _prepare_spec(spec)
+    assert prepared.engine_type == "claude_code"
+    assert prepared.template_config == {"devflow_workflow": "x"}
+    # Re-prepare of the translated output keeps a stable single marker.
+    second = _prepare_spec(
+        _application_coding_spec(
+            engine_type="aicoding",
+            template_config={"devflow_workflow": "x", "engine_form": "aicoding"},
+        )
+    )
+    assert second.template_config == {
+        "devflow_workflow": "x",
+        "engine_form": "aicoding",
+    }
+
+
+def test_public_input_cannot_smuggle_the_form_marker() -> None:
+    """The marker is server-managed: PUBLIC validation rejects caller input."""
+    with pytest.raises(BotTemplateInvalidError) as excinfo:
+        _strategy_prepare(
+            engine_properties={
+                "template": {"devflow_workflow": "x", "engine_form": "aicoding"}
+            },
+            template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
+        )
+    assert "engine_form" in str(excinfo.value)
+    # The legacy internal shape may carry it (platform-written snapshot).
+    prepared = _strategy_prepare(
+        engine_properties={
+            "template": {"devflow_workflow": "x", "engine_form": "aicoding"}
+        },
+        template_validation_mode=BotCreateTemplateValidationMode.LEGACY,
+    )
+    assert prepared.template_config["engine_form"] == "aicoding"

--- a/src/backend/tests/community/core/workspace/test_runtime_identity.py
+++ b/src/backend/tests/community/core/workspace/test_runtime_identity.py
@@ -1,0 +1,121 @@
+"""Judgment matrix for the engine/form vocabulary split.
+
+``uses_aicoding_runtime`` is the single judgment entry for "does this bot run
+the AICoding runtime implementation" (see
+docs/superpowers/specs/2026-08-31-engine-vocabulary-template-form-design.md):
+a stored ``aicoding`` engine short-circuits (read paths never rewrite stored
+engines), the server-managed ``engine_form`` marker routes folded
+``claude_code`` bots, and the historical template-type semantics stay intact.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.workspace.runtime_identity import (
+    AICODING_ENGINE_FORM,
+    ENGINE_FORM_KEY,
+    claude_code_uses_aicoding_runtime,
+    engine_form_of,
+    uses_aicoding_runtime,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_stored_aicoding_engine_short_circuits_to_true():
+    # Legacy rows read True regardless of template shape — the read path never
+    # rewrites stored engines.
+    assert uses_aicoding_runtime(
+        active_engine="aicoding", template_type=None, template_config=None
+    )
+    assert uses_aicoding_runtime(
+        active_engine="aicoding", template_type="normalCC", template_config={}
+    )
+
+
+def test_engine_form_marker_routes_folded_claude_code_bot():
+    assert uses_aicoding_runtime(
+        active_engine="claude_code",
+        template_type="normalCC",
+        template_config={ENGINE_FORM_KEY: AICODING_ENGINE_FORM},
+    )
+    # A plain (no-template-config) claude_code bot has no form.
+    assert not uses_aicoding_runtime(
+        active_engine="claude_code", template_type=None, template_config=None
+    )
+
+
+def test_marker_beats_template_type_semantics():
+    # normalCC alone stays on the claude_code runtime; the marker says the bot
+    # was folded from the legacy aicoding engine and must keep the aicoding
+    # runtime — the marker is authoritative where both signals exist.
+    assert not uses_aicoding_runtime(
+        active_engine="claude_code", template_type="normalCC"
+    )
+    assert uses_aicoding_runtime(
+        active_engine="claude_code",
+        template_type="normalCC",
+        template_config={ENGINE_FORM_KEY: AICODING_ENGINE_FORM},
+    )
+
+
+@pytest.mark.parametrize(
+    "engine", ["openclaw", "teclaw", "hermes", "moltis", "", None]
+)
+def test_non_coding_engines_never_use_aicoding_runtime(engine):
+    assert not uses_aicoding_runtime(
+        active_engine=engine, template_type="applicationCoding"
+    )
+    assert not uses_aicoding_runtime(
+        active_engine=engine,
+        template_type="normalCC",
+        template_config={ENGINE_FORM_KEY: AICODING_ENGINE_FORM},
+    )
+
+
+def test_historical_template_type_semantics_preserved():
+    assert uses_aicoding_runtime(
+        active_engine="claude_code", template_type="applicationCoding"
+    )
+    assert uses_aicoding_runtime(
+        active_engine="claude_code", template_type="architect"
+    )
+    assert not uses_aicoding_runtime(
+        active_engine="claude_code", template_type="normalCC"
+    )
+    # Engine spelling normalizes (registry key form).
+    assert uses_aicoding_runtime(
+        active_engine="claude-code", template_type="applicationCoding"
+    )
+
+
+def test_legacy_helper_keeps_its_historical_contract():
+    # claude_code_uses_aicoding_runtime is the pre-split judgment: it must not
+    # short-circuit on a stored aicoding engine (that input belongs to callers
+    # that route by stored engine already).
+    assert not claude_code_uses_aicoding_runtime(
+        active_engine="aicoding", template_type="applicationCoding"
+    )
+    assert claude_code_uses_aicoding_runtime(
+        active_engine="claude_code", template_type="applicationCoding"
+    )
+    assert not claude_code_uses_aicoding_runtime(
+        active_engine="claude_code", template_type="normalCC"
+    )
+
+
+def test_engine_form_of_probes_sources_in_order():
+    marker = {ENGINE_FORM_KEY: AICODING_ENGINE_FORM}
+    assert (
+        engine_form_of(marker, {ENGINE_FORM_KEY: "other"}) == AICODING_ENGINE_FORM
+    )
+    assert engine_form_of(None, marker) == AICODING_ENGINE_FORM
+    assert engine_form_of(None, {"unrelated": 1}) is None
+    assert engine_form_of({"template_config": marker}) is None  # nested ≠ marker
+
+
+def test_engine_form_of_skips_non_string_and_blank_values():
+    assert engine_form_of({ENGINE_FORM_KEY: 42}) is None
+    assert engine_form_of({ENGINE_FORM_KEY: "   "}) is None
+    assert engine_form_of({ENGINE_FORM_KEY: " aicoding "}) == AICODING_ENGINE_FORM

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -510,7 +510,7 @@
             "type": "string"
           },
           "engine": {
-            "description": "Engine that powers the bot, fixed at creation. The valid set is deployment-configured — read it from the engine group's available-engines endpoint; an unlisted engine is refused (400).",
+            "description": "Engine that powers the bot, fixed at creation. The valid set is deployment-configured — read it from the engine group's available-engines endpoint; an unlisted engine is refused (400). Internal implementation engines (e.g. 'aicoding', the internal runtime behind 'claude_code') are not accepted; runtime forms travel on the template, not the engine.",
             "title": "Engine",
             "type": "string"
           },
@@ -545,7 +545,7 @@
                 "type": "null"
               }
             ],
-            "description": "Server-projected template snapshot (display-safe subset; secrets never returned). Null without a template.",
+            "description": "Server-projected template snapshot (display-safe subset; secrets never returned). Null without a template. Includes the server-managed 'engine_form' marker for bots whose runtime form differs from the engine (e.g. engine_form='aicoding').",
             "title": "Template Config"
           },
           "template_type": {
@@ -836,7 +836,7 @@
             "type": "string"
           },
           "engine": {
-            "description": "Engine that powers the bot, fixed at creation. The valid set is deployment-configured — read it from the engine group's available-engines endpoint; an unlisted engine is refused (400).",
+            "description": "Engine that powers the bot, fixed at creation. The valid set is deployment-configured — read it from the engine group's available-engines endpoint; an unlisted engine is refused (400). Internal implementation engines (e.g. 'aicoding', the internal runtime behind 'claude_code') are not accepted; runtime forms travel on the template, not the engine.",
             "title": "Engine",
             "type": "string"
           },
@@ -1306,7 +1306,7 @@
                 "type": "null"
               }
             ],
-            "description": "Server-projected template snapshot (display-safe subset; secrets never returned). Null without a template.",
+            "description": "Server-projected template snapshot (display-safe subset; secrets never returned). Null without a template. Includes the server-managed 'engine_form' marker for bots whose runtime form differs from the engine (e.g. engine_form='aicoding').",
             "title": "Template Config"
           },
           "template_type": {


### PR DESCRIPTION
## Problem

engine 词汇里 `aicoding` 同时扮演了两种角色：真实引擎值（可经 `/api/bots` 创建落库 `active_engine`）与 claude_code 的内部运行时实现。新 openapi 面（未上线）的引擎校验 `_get_engine_types()` 也会放行 `aicoding`，一旦上线会继续产生 engine='aicoding' 的新 bot，词汇表无法收敛。

## Solution

engine/form 词汇分离（设计：`docs/superpowers/specs/2026-08-31-engine-vocabulary-template-form-design.md`）：

- **openapi 面（未上线，直接拒）**：创建与授权完成路径共用 `_require_publicly_creatable_engine`——`aicoding` 属 `INTERNAL_ENGINE_TYPES`，400 拒绝；真实引擎（openclaw/claude_code/teclaw/hermes/moltis）不受影响。
- **老链路（汇合点归一化）**：`create_flow._prepare_create` 在策略门之前把 legacy `engine_type=aicoding` 折叠为 `claude_code`；带模板的创建在 template 快照写入 server-managed `engine_form: aicoding` 标记（随 ac_templates.ext 落库），plain 无模板 bot 折叠为干净 claude_code bot 不写标记。存量 `active_engine='aicoding'` 的 bot 读路径零改动（`SUPPORTED_ENGINE_TYPES` 保持全集、strategy 注册保留）。
- **运行时判定统一**：`runtime_identity.uses_aicoding_runtime`（存量 aicoding 短路 → form 标记 → 既有 template_type 语义），BaaS bucket、默认 MCP/CLI 能力桶、skill 布局、restart provider、expert_chat 全部接入 form 读取。
- **防伪造**：`engine_form` 进 `TEMPLATE_SERVER_RESERVED_FIELDS`，PUBLIC 校验模式下用户传入即 422。
- **查询面露出**：`/openapi/v1/bots`、`/bots/all`、`/bots/{bot_id}` 的 template_config 公共投影白名单追加 `engine_form`，前端可据此识别 aicoding 形态卡片（secret 永不露出）；gateway `bots.openapi.json` 手工增量同步描述。

## Validation

本地 `ci_test.sh`（worktree 干净检出提交）：

- 15816 passed, 57 skipped；用例通过率 100%
- 行覆盖 88.04%（≥75）
- **变行覆盖 100%（64/64，≥80）**
- 新增/改造用例：判定矩阵（aicoding 短路/form 标记优先/normalCC/无模板）、老链路折叠（带模板写标记保 9 个默认 CLI 授权、plain 折叠后 fail-closed 零 CLI）、openapi 三入口 400、存量回归（bucket/layout/strategy 不变）、投影露出与防伪造

## Spec

`docs/superpowers/specs/2026-08-31-engine-vocabulary-template-form-design.md`（含实现期修订记录：plain bot 不写 ext 标记，form 只存在于 template 拓展字段）