### PR TITLE
refactor(backend): move bot-config checks to a seam apply can call

### DIFF
--- a/src/backend/specs/2026-08-31-config-manifest-service-seam/plan.md
+++ b/src/backend/specs/2026-08-31-config-manifest-service-seam/plan.md
@@ -94,19 +94,30 @@ the seam is invisible in the document).
 
 @dataclass(frozen=True)
 class CategoryChecks:
-    """Every rule the public surface enforces for one config category."""
+    """Every rule the public surface enforces for one config category.
+
+    Two fields, not one list, because the halves have different requirements:
+    ``validators`` must run with no bot record (W13's preflight), while
+    ``from_record`` by definition reads one.
+    """
     category: str
-    resolve_coords: Callable[..., BotConfigCoords]
-    validators: tuple[Callable[..., Any], ...]
+    from_record: Callable[..., BotConfigCoords]   # existing bot
+    from_spec: Callable[..., BotConfigCoords]     # bot being created
+    validators: tuple[Callable[..., Any], ...]    # record-free, always
 
 CONFIG_SURFACE: dict[str, CategoryChecks] = {
-    "identity": CategoryChecks("identity", identity_file_coords, (physical_file_name,)),
-    "resources": CategoryChecks("resources", resource_file_coords,
+    "identity": CategoryChecks("identity", identity_coords_from_record,
+                               identity_coords_from_spec, (physical_file_name,)),
+    "resources": CategoryChecks("resources", resource_coords_from_record,
+                                resource_coords_from_spec,
                                 (safe_workspace_path, require_workspace_path,
                                  is_write_forbidden)),
-    "skills": CategoryChecks("skills", skill_coords, (require_addressed_bot,)),
-    "mcp": CategoryChecks("mcp", mcp_config_coords, ()),
-    "engine_config": CategoryChecks("engine_config", engine_config_coords, ()),
+    "skills": CategoryChecks("skills", skill_coords_from_record,
+                             skill_coords_from_spec, (require_addressed_bot,)),
+    "mcp": CategoryChecks("mcp", mcp_coords_from_record,
+                          mcp_coords_from_spec, ()),
+    "engine_config": CategoryChecks("engine_config", engine_config_coords_from_record,
+                                    engine_config_coords_from_spec, ()),
 }
 ```
 
@@ -115,9 +126,36 @@ entity_type, entity_id, engine_type)`. `engine_type` is `None` for the two
 categories that do not address an engine — it is **not** defaulted, because a
 default would quietly hand `identity` an engine it never had.
 
-`resolve_coords` differs per row on purpose (spec *Decisions* 3). The table is
+`from_record` differs per row on purpose (spec *Decisions* 3). The table is
 where that finally shows: five rows, four different resolutions, visible in one
 screen for the first time.
+
+## The Two Coordinate Sources
+
+`from_record` is today's behaviour, moved: it reads the bot record and carries
+whatever ownership guard that group performs (`engine_config` calls `get_bot`;
+`resources` performs none). Existing endpoints call this one, so their behaviour
+is unchanged — which is what keeps the change inert.
+
+`from_spec` reads the same three values off the create request instead. They are
+all there in phase 1: `BotCreateSpec` carries `entity_id`, `entity_type` and
+`engine_type`, and `create_bot_with_authorization` already receives an allocated
+`bot_id` (`create_flow.py:446`). It performs **no** ownership guard, and cannot:
+there is no record to own yet, and the caller's right to create a bot at all is
+what `check_create_bot_preflight` (`create_flow.py:494`) already decides, beside
+which W13 will run the manifest validation.
+
+The two return the same frozen type, so **validators cannot tell them apart** —
+which is the property that makes one validation path serve both. A validator
+that needed to know would be a validator that had smuggled a record dependency
+back in, and the record-free test in Task 7 is what catches that.
+
+`from_spec` has no caller until W13. That is deliberate and is the one thing
+this feature ships unused: the alternative is W13 discovering at day 3 that the
+seam's shape excludes it, with W4, W5 and W6 already written against the other
+shape. The precedent for accepting an uncalled path rather than inventing a
+caller for it is #1323 *Decisions* 4; here it is pinned by a direct unit test
+instead of a fixture router.
 
 ## Why the Table Is Load-Bearing and Not Decoration
 
@@ -177,6 +215,10 @@ find it a convenient place to put logic.
 - **New:** direct unit tests on the moved functions called with no request at
   all — this is the thing the feature exists to make possible, so it is proven
   rather than assumed.
+- **New:** a record-free test that builds coordinates via `from_spec` and runs
+  every category's validators against them, with no bot record in the fixture at
+  all. This is W13's preflight rehearsed before W13 exists; if it needs a record
+  to pass, the split did not happen.
 - Three test files carry comments naming `_safe_path`, `_file_coords`,
   `_require_addressed_bot` and `_require_skills_grant`. None *imports* them, so
   none breaks. The names stay bound in the router modules, so the comments stay

--- a/src/backend/specs/2026-08-31-config-manifest-service-seam/plan.md
+++ b/src/backend/specs/2026-08-31-config-manifest-service-seam/plan.md
@@ -1,0 +1,212 @@
+# Plan: One Seam for the Five Categories Apply Touches
+
+## Approach
+
+Backend-only, no DDL, no new endpoint, no schema change. Three moves:
+
+1. **Each check moves to its category's existing core home** — beside the code
+   that already owns that domain, not into a new grab-bag. `_safe_path` lands
+   next to `is_readonly` in `resource_file_service.py`; the engine-config target
+   resolution lands next to the engine-config service. This keeps Rule 9 (one
+   reason to change per file) and means the moved function's neighbours are the
+   code it guards.
+
+2. **One new module holds only the table.** `core/bot_config_surface/` declares
+   which checks govern which category and nothing else — the seam's index, not
+   its body. This mirrors the collaborator precedent exactly, where
+   `authorization.py` is a table module and `bot_access.py` is the mechanism it
+   drives.
+
+3. **The five routers import the moved functions** and keep only what Rule 7
+   permits an adapter to keep: error mapping, and auth interpretation.
+
+The change is inert because the moved functions raise the **same domain error
+types they raise today** — `InvalidResourcePathError`, `LocalSkillNotFoundError`,
+`BotNotFoundError` already live in `core` — so `ENVELOPE_ERRORS` maps them to the
+same status and message without being touched. Where a check raises
+`HTTPException` today (resources' read-only 403), the *decision* moves and the
+`raise` stays in the router, so the response body is bit-identical rather than
+argued to be equivalent.
+
+## What Moves, and What Deliberately Does Not
+
+The line is Rule 7's: **domain policy** moves to core, **auth interpretation**
+and **error mapping** stay in the adapter. Applied case by case:
+
+| Today | Where | Verdict |
+| --- | --- | --- |
+| `_safe_path` — reject `..` | `resources/router.py:123` | **Moves.** A workspace path rule, true of the workspace |
+| `_require_path` — reject empty | `resources/router.py:148` | **Moves.** Same |
+| `_reject_read_only` — dotfiles, root identity files, every ancestor | `resources/router.py:160` | **Decision moves**, `raise HTTPException` stays |
+| `_file_coords` — `(staff, owner_id, engine)` | `resources/router.py:186` | **Moves** |
+| `_require_addressed_bot` — skill belongs to the addressed bot | `skills/router.py:195` | **Moves.** A statement about the skill record |
+| `_require_skills_grant` — bind the app grant to the record's `(bot, owner)` | `skills/router.py:216` | **Stays.** Takes `ActingCaller`, an adapter type; app grants are auth interpretation and apply's grant is already checked at its own door |
+| `_directory_relative_paths` — multipart path list | `skills/router.py:254` | **Stays.** Parses a multipart wire format; apply has no multipart |
+| `application/zip` content-type check | `skills/router.py:497` | **Stays.** Protocol validation, literally a header read |
+| `_engine_config_target` + `bot_service.get_bot` guard | `bots/engine_config.py:65,110` | **Moves.** Ownership and addressing |
+| `entity_type = "staff"`, `<type>.md` re-suffixing | `identity/router.py:84,131` | **Moves** |
+| `_ENTITY_TYPE = "staff"` | `mcp/router.py:118` | **Moves** |
+
+Four rows say "stays", and each names why. That column is the point: a criterion
+reading "no check reachable only from inside a router body" is satisfied by
+moving domain policy out, not by evacuating the adapter of everything it is
+allowed to do. A reviewer should be able to check the four.
+
+## Affected Components
+
+**New**
+
+- `src/backend/.../core/bot_config_surface/README.md` — Context Boundary block
+  per `docs/arch/context-boundary-format.md`
+- `src/backend/.../core/bot_config_surface/__init__.py` — the `CONFIG_SURFACE`
+  table and the `CategoryChecks` row type
+
+**Moved into (existing files)**
+
+- `core/services/resource_file_service.py` — `safe_workspace_path`,
+  `require_workspace_path`, `is_write_forbidden`; joins `is_readonly`, which is
+  already there
+- `core/services/resource_addressing.py` — `resource_file_coords`
+- `core/services/identity.py` — `identity_file_coords`, `physical_file_name`
+- `core/services/engine_config.py` — `engine_config_coords`
+- `core/skill_center/errors.py` → no change; the check lands in
+  `core/skill_center/services/skill_query_service.py` as
+  `require_addressed_bot`
+- `core/mcp/config_flow.py` — `mcp_config_coords`
+
+**Rewired (call the moved function; no behaviour change)**
+
+- `adapters/http/openapi_v1/resources/router.py`
+- `adapters/http/openapi_v1/skills/router.py`
+- `adapters/http/openapi_v1/identity/router.py`
+- `adapters/http/openapi_v1/mcp/router.py`
+- `adapters/http/openapi_v1/bots/engine_config.py`
+
+**Not touched:** `authorization.py`, `bot_access.py`, `admission.py`,
+`principal.py`, every other router group, the internal API, the console routers,
+`src/gateway/configs/schemas/bots.openapi.json` (no published contract changes —
+the seam is invisible in the document).
+
+## The Table
+
+```python
+# core/bot_config_surface/__init__.py
+
+@dataclass(frozen=True)
+class CategoryChecks:
+    """Every rule the public surface enforces for one config category."""
+    category: str
+    resolve_coords: Callable[..., BotConfigCoords]
+    validators: tuple[Callable[..., Any], ...]
+
+CONFIG_SURFACE: dict[str, CategoryChecks] = {
+    "identity": CategoryChecks("identity", identity_file_coords, (physical_file_name,)),
+    "resources": CategoryChecks("resources", resource_file_coords,
+                                (safe_workspace_path, require_workspace_path,
+                                 is_write_forbidden)),
+    "skills": CategoryChecks("skills", skill_coords, (require_addressed_bot,)),
+    "mcp": CategoryChecks("mcp", mcp_config_coords, ()),
+    "engine_config": CategoryChecks("engine_config", engine_config_coords, ()),
+}
+```
+
+`BotConfigCoords` is a frozen dataclass carrying `(bot_id, owner_id,
+entity_type, entity_id, engine_type)`. `engine_type` is `None` for the two
+categories that do not address an engine — it is **not** defaulted, because a
+default would quietly hand `identity` an engine it never had.
+
+`resolve_coords` differs per row on purpose (spec *Decisions* 3). The table is
+where that finally shows: five rows, four different resolutions, visible in one
+screen for the first time.
+
+## Why the Table Is Load-Bearing and Not Decoration
+
+The criterion that matters is **router and table hold the same function
+object**. A table naming functions that merely resemble the router's would be
+worse than no table — it would document a guarantee that does not hold. So:
+
+```python
+def test_router_and_table_share_one_object():
+    from ...openapi_v1.resources import router as resources_router
+    assert resources_router._safe_path is CONFIG_SURFACE["resources"].validators[0]
+```
+
+`is`, not `==`. One such assertion per moved function. A future edit to the
+router's copy is impossible because there is no router copy — the name in the
+router module is a binding to the core function, and this test is what stops
+someone reintroducing a local one.
+
+The second structural test is the omission guard, the precedent's contribution:
+
+```python
+def test_no_handler_only_checks_remain():
+    """Every module-private callable in the five routers is either called from
+    outside a handler, or is on the reviewed exception list with its reason."""
+```
+
+The exception list is the four "stays" rows above, each with its reason string.
+Adding a fifth private check to one of these routers fails the test until
+someone writes down which side of Rule 7's line it is on. That is the same
+"omission is not survivable" property `PublicAPIRoute` gives the collaborator
+seam, obtained by test rather than by assembly because there is no assembly step
+to hook here.
+
+## Import Direction
+
+`core/bot_config_surface` imports from `core` only. Nothing in it imports
+`fastapi`, `adapters`, or any HTTP type — checked by the existing core-purity
+CI gate as well as by review. The routers import *from* it, which is the
+permitted direction.
+
+`core/bot_config_surface` importing from six other `core` packages is worth
+naming: it is an index over them, so the fan-out is the module's purpose rather
+than a smell. It exposes no new behaviour of its own and must not grow any —
+the README's Context Boundary block says so, so that the next person does not
+find it a convenient place to put logic.
+
+## Testing
+
+- **The existing endpoint tests are the inertness proof, and they are not
+  edited.** `tests/community/endpoints/test_openapi_resources.py`,
+  `test_openapi_bot_skills_read.py`,
+  `tests/community/adapters/http/openapi_v1/resources/test_resources_handlers.py`
+  and the identity / mcp / engine-config suites all pass unchanged. If any needs
+  a change, the move was not inert and that is a finding, not a fixup.
+- **New:** the same-object test above, one assertion per moved function.
+- **New:** the handler-only-check guard with its reasoned exception list.
+- **New:** direct unit tests on the moved functions called with no request at
+  all — this is the thing the feature exists to make possible, so it is proven
+  rather than assumed.
+- Three test files carry comments naming `_safe_path`, `_file_coords`,
+  `_require_addressed_bot` and `_require_skills_grant`. None *imports* them, so
+  none breaks. The names stay bound in the router modules, so the comments stay
+  accurate; they are not edited.
+- `OCB_PRE_PUSH_RUN_CI=1` on push, per work-items §8 — this touches the apply
+  path's foundations.
+
+## Risks
+
+- **A moved function's error escapes a different way.** The mitigation is that
+  the error *types* do not change; only the module the function lives in does.
+  The one place a type would have changed (read-only 403) is the one place the
+  `raise` deliberately stays in the router.
+- **`resolve_runtime_engine_for_bot` in `resource_file_coords` needs
+  `BotRepository`**, injected today at the route. Passed as an argument rather
+  than resolved inside, so the core function stays free of the DI container and
+  apply can hand it the same instance.
+- **Scope pressure.** The budget is 0.25 day against criteria written for more
+  (work-items §7 says this outright, for every item). If something is cut it is
+  the `mcp` and `engine_config` rows' validators — both are empty tuples today,
+  so their rows are coords-only and cheap; cutting them would save nothing.
+  The realistic cut is the handler-only-check guard test, and the cost of
+  cutting it is the omission property, which is the half of the precedent worth
+  copying. It should be the last thing to go.
+
+## Follow-up (named, not done here)
+
+The four divergent `resolve_coords` implementations. `resources` performs no
+ownership guard while `engine_config` does; `identity` and `mcp` hardcode
+`"staff"` against `owner_id` while `engine_config` reads the bot record. Once
+the table shows them side by side, whether they *should* differ is answerable —
+and answering it changes who is admitted, so it is a separate spec with its own
+argument, not a tidy-up to fold in here.

--- a/src/backend/specs/2026-08-31-config-manifest-service-seam/spec.md
+++ b/src/backend/specs/2026-08-31-config-manifest-service-seam/spec.md
@@ -201,10 +201,23 @@ Settled here rather than left open:
    declared once, in `authorization.py`, and enforced by `PublicAPIRoute` for
    every operation including apply's. A per-category re-check inside the seam
    would be a second adjudication of a question that already has one home — the
-   precise defect this whole line of work exists to remove. What moves into the
-   seam is the *ownership and addressing* guard the category handlers perform on
-   top of it (`bot_service.get_bot(bot_id, owner_id)` and the entity-coordinate
-   resolution), which the collaborator seam does not perform and never has.
+   precise defect this whole line of work exists to remove.
+
+   What moves is narrower, and worth stating exactly, because "authorization"
+   makes it sound larger than it is. The declared dependencies stay where they
+   are: `ADMISSION` rows keep their `require_granted_*` dependency, and
+   `AUTHORIZATION` rows keep being enforced by `PublicAPIRoute`. Neither is
+   extracted, and apply hand-calls neither — it is an HTTP operation, so its own
+   rows are enforced at its own door before its handler runs. The criterion this
+   feature answers is about a check reachable **only from inside a router
+   function body**, and a dependency declared on the route is not in a body.
+
+   What moves is the domain policy those bodies own: mostly validation (path
+   safety, the read-only policy, file types, package shape) and the
+   entity-coordinate resolution, plus two authorization-flavoured strays —
+   `bot_service.get_bot(bot_id, owner_id)` in `engine_config`, the only in-body
+   ownership guard among the five, and `_require_addressed_bot` in `skills`.
+   None of it is something the collaborator seam performs, or ever has.
 
    This is sound only given *Apply Declares Its Own Bars* below. `Check(OWNER)`
    means every caller who reaches apply could have performed each of its writes

--- a/src/backend/specs/2026-08-31-config-manifest-service-seam/spec.md
+++ b/src/backend/specs/2026-08-31-config-manifest-service-seam/spec.md
@@ -196,15 +196,21 @@ Settled here rather than left open:
    answer is that there was no fork, because apply is an HTTP operation like the
    rest.
 
-2. **The collaborator level check is not re-implemented here, and must not be.**
-   It is already declared once, in `authorization.py`, and enforced by
-   `PublicAPIRoute` for every operation including apply's. A per-category
-   re-check inside the seam would be a second adjudication of a question that
-   already has one home — the precise defect this whole line of work exists to
-   remove. What moves into the seam is the *ownership and addressing* guard the
-   category handlers perform on top of it (`bot_service.get_bot(bot_id,
-   owner_id)` and the entity-coordinate resolution), which the collaborator seam
-   does not perform and never has.
+2. **The collaborator level check is not re-implemented here, and must not be —
+   because the manifest rows are set at the maximum bar.** It is already
+   declared once, in `authorization.py`, and enforced by `PublicAPIRoute` for
+   every operation including apply's. A per-category re-check inside the seam
+   would be a second adjudication of a question that already has one home — the
+   precise defect this whole line of work exists to remove. What moves into the
+   seam is the *ownership and addressing* guard the category handlers perform on
+   top of it (`bot_service.get_bot(bot_id, owner_id)` and the entity-coordinate
+   resolution), which the collaborator seam does not perform and never has.
+
+   This is only sound given the constraint in *The Maximum-Bar Constraint*
+   below. If a manifest row were ever set below the maximum, per-category level
+   adjudication would become a real requirement of this seam, and this decision
+   would have to be reopened. Stated so that the dependency is visible rather
+   than implicit.
 
 3. **The four divergent target resolutions are preserved, not unified.** They
    really do differ — `resources` performs no ownership guard, `engine_config`
@@ -251,6 +257,55 @@ Settled here rather than left open:
    thing). What is shared is the *table* that names them and the guarantee that
    the router and apply hold the same object, which is where the value is.
 
+## The Maximum-Bar Constraint
+
+Not implemented here — this feature writes no `AUTHORIZATION` or `ADMISSION`
+row. It is recorded here because it was found while specifying this seam, it is
+what makes *Decisions* 2 sound, and the rows that must honour it are written in
+three **other** sessions. Losing it between them is the failure this section
+exists to prevent.
+
+**A manifest operation is one door onto operations whose bars are not uniform.**
+Measured, not assumed:
+
+| Category | Admission | Authorization |
+| --- | --- | --- |
+| `identity` | `GRANT_CHECKED_OWN_BOT` | `OWNER_SCOPED` |
+| `resources` | `GRANT_CHECKED_OWN_BOT` | `OWNER_SCOPED` |
+| `engine_config` | `GRANT_CHECKED_OWN_BOT` | `OWNER_SCOPED` |
+| `script` (`/startup-script`) | `GRANT_CHECKED_OWN_BOT` | `OWNER_SCOPED` |
+| `mcp` | `GRANT_CHECKED_ADDRESSED_BOT` | `Check(MEMBER)`; `…/call-type` is `Check(OWNER, EDIT_LOCK)` |
+| `skills` | `GRANT_CHECKED_ADDRESSED_BOT` | `Check(MEMBER)`, several with `EDIT_LOCK` |
+
+Two admission modes, three authorization bars. **So a manifest row picked by
+analogy with `mcp` or `skills` — the two categories whose endpoints are most
+obviously "the same kind of thing" — is a privilege escalation.** A caller at
+`MEMBER` would apply a manifest declaring `identity` and overwrite a bot's
+`SOUL.md`, which `PUT /openapi/v1/bots/{bot_id}/identity/{file_type}` refuses
+them because it is `OWNER_SCOPED`. Three of the six categories are owner-only
+today, and the manifest must not be a way around that.
+
+**The rule: every manifest operation carries the maximum of the bars it can
+reach** — `GRANT_CHECKED_OWN_BOT` and `Check(PermissionLevel.OWNER, EDIT_LOCK)`.
+
+**Why maximum rather than per-category adjudication.** `AUTHORIZATION` is keyed
+on `(method, path)`; a manifest's categories are in the request **body**. A bar
+that varied with the declared categories is therefore not merely harder — it is
+inexpressible in the table, and a bar that cannot be read off the table is one
+no reviewer can audit. Static maximum is the only shape the seam admits, and it
+errs in the safe direction.
+
+**Three rows, three sessions:**
+
+| Row | Whose | Note |
+| --- | --- | --- |
+| `PUT /openapi/v1/bots/{bot_id}/config-manifest` | W1 | §2.6 makes `PUT` take effect immediately, so `PUT` **is** an apply trigger and needs apply's bar. Easy to miss, because it reads like an ordinary document write |
+| `POST /openapi/v1/bots/{bot_id}/config-manifest/apply` | W4 | The obvious row to get wrong, per above |
+| W13's create endpoint | W13 | Inherently owner — the caller is creating their own bot — so the constraint is satisfied by construction rather than by a bar |
+
+`DELETE` of the manifest materializes nothing (W4: *删除 manifest 什么都不删*), so
+it is the one manifest operation with no lower bound from this constraint.
+
 ## In Scope
 
 - One `core` module per category holding the checks that category's public
@@ -279,7 +334,9 @@ Settled here rather than left open:
   preflight; building the endpoint is not this change's work, and `create_flow.py`
   is not touched here.
 - **The collaborator authorization seam**, `AUTHORIZATION`, `ADMISSION`, and the
-  app-grant dependencies. Untouched, per *Decisions* 2.
+  app-grant dependencies. Untouched, per *Decisions* 2. In particular this
+  feature writes **no** manifest rows — *The Maximum-Bar Constraint* records what
+  they must be, for W1, W4 and W13 to honour; it does not implement them.
 - **The other router groups.** Only the five categories apply touches.
 - **The internal API and the console routers.** Nothing on those surfaces
   changes, including `adapters/http/resources/file_router.py`, whose

--- a/src/backend/specs/2026-08-31-config-manifest-service-seam/spec.md
+++ b/src/backend/specs/2026-08-31-config-manifest-service-seam/spec.md
@@ -1,0 +1,231 @@
+# Bot Config — One Seam for the Five Categories Apply Touches
+
+## Summary
+
+Manifest apply will reach the same five bot-configuration categories the public
+API already exposes — `skills`, `identity`, `resources`, `mcp`, `engine_config`.
+The rules those categories enforce are not, today, in a place apply can reach:
+they are module-private functions inside `openapi_v1` router bodies, called from
+handler code and callable from nowhere else.
+
+This moves them out — into `core`, one declared home per category, with a table
+that names them and a test that holds the router and the table on the *same
+function object*. Nothing about what any check decides changes. Every caller who
+is admitted today is admitted afterwards, with the same status code and the same
+message, and no existing test is modified.
+
+This is the mechanism W4's materializers consume. It ships before them for the
+reason W10's note in the work-items doc gives: doing it afterwards means writing
+these checks twice and deleting one copy.
+
+## Motivation
+
+**Apply runs the same rules or it drifts.** `POST
+/openapi/v1/bots/{bot_id}/config-manifest/apply` will converge a bot's skills,
+identity files, resources, MCP servers and engine config toward a document.
+Every one of those writes has a rule attached to it on the public surface — a
+path that may not escape the workspace, a file that may not be written because
+it is read-only, a package that must really be a ZIP, a bot that must resolve
+for the named owner. Apply performing those writes *without* those rules is a
+second, weaker surface onto the same state. Apply performing them with a
+hand-copied second implementation is the same thing on a delay: two copies of a
+security rule diverge, and the one that diverges silently is the one nobody is
+reading.
+
+**The rules are structurally unreachable.** This is not a matter of
+inconvenience. `_safe_path`, `_require_path`, `_reject_read_only` and
+`_file_coords` are underscore-private module functions in
+`resources/router.py`. `_require_addressed_bot`, `_require_skills_grant` and
+`_directory_relative_paths` are the same in `skills/router.py`.
+`_engine_config_target` and the ownership guard spelled
+`bot_service.get_bot(bot_id, owner_id)` are inline in `bots/engine_config.py`.
+Reaching any of them from `core` would be an adapter import from core —
+backwards through the layer boundary, and forbidden.
+
+**The architecture already says these are in the wrong place.** Rule 7 permits
+an adapter to do request parsing, auth interpretation, protocol validation,
+serialization and error mapping. It forbids the adapter to own domain policy.
+"A workspace path may not contain `..`", "a dotfile is not writable through this
+API", "a bot's engine config is addressed by the entity on its record" are
+domain policy by any reading — they are true of the bot's workspace, not of
+HTTP. They sit in adapters because that is where the endpoints that needed them
+were written, and no second caller existed to force the question. Apply is the
+second caller.
+
+**Four groups compute the same triple four different ways, and nothing shows
+it.** `(entity_type, entity_id, engine_type)` is what every one of these
+categories needs to address a bot's storage. `resources` builds it from
+`("staff", owner_id, resolve_runtime_engine_for_bot(...))` with no ownership
+guard at all. `engine_config` builds it from the bot record's own `entity_id`,
+`entity_type` and `active_engine`, behind `bot_service.get_bot`. `identity` and
+`mcp` hardcode `"staff"` and use `owner_id`, and need no engine. Those are four
+different answers to one question, each invisible inside a different private
+function. Making them visible is worth doing on its own; the fact that apply
+would otherwise have to guess which one to copy is what makes it urgent.
+
+**The precedent exists and is one year old at most.** #1323 built the
+collaborator authorization seam and #1362 moved 87 operations onto it. The shape
+is settled: one table, one thing that reads it, and omission that fails
+structurally rather than by convention. This feature is that shape applied to a
+different question, deliberately, so that the surface has two seams and not
+three shapes.
+
+## User Stories
+
+- As the engineer building apply (W4), I want to call the same check the
+  category endpoint calls, so that "apply enforces what the API enforces" is a
+  property of the code rather than a claim in a review.
+- As a backend engineer adding a rule to one of these five categories, I want
+  one place to add it, so that adding it to the endpoint and forgetting apply is
+  not possible.
+- As a reviewer, I want to see every rule a category enforces in one list, so
+  that "what governs writes to a bot's resources?" is a question with one
+  answer.
+- As a security reviewer, I want the router and apply proven to hold the *same
+  function object*, so that they cannot drift onto two implementations that
+  merely look alike.
+- As an integrator calling the public API today, I want this change to be
+  invisible to me — the same requests admitted, the same requests refused, the
+  same status codes and messages.
+
+## Acceptance Criteria
+
+These are W10's four criteria from `docs/bot-config-manifest/work-items.zh-CN.md`
+§5, restated with the evidence each one is proven by.
+
+### The seam
+
+- [ ] For each of the five categories, the checks the public API enforces are
+      declared in one module under `core`, and both the router and a non-HTTP
+      caller reach them by importing that module. A non-HTTP caller needs no
+      `Request`, no FastAPI dependency resolution, and no running app to get the
+      same answer the router gets.
+- [ ] Every check that guards a public-API **write** in these five categories is
+      reachable from outside its router. No module-private function in
+      `resources/router.py`, `skills/router.py`, `identity/router.py`,
+      `mcp/router.py` or `bots/engine_config.py` performs a check that a handler
+      is the only possible caller of.
+- [ ] The declared checks raise domain errors from `core`, never
+      `HTTPException`. The routers keep their existing error mapping, which is
+      how the status codes stay identical.
+
+### The table, and the guarantee it carries
+
+- [ ] A table names, for each of the five categories, the checks that govern it.
+      A category apply touches that is absent from the table fails a test that
+      names it.
+- [ ] The table and the routers are proven to hold **the same function object**,
+      not two functions with the same behaviour. This is the criterion that
+      makes the seam load-bearing rather than decorative: a future edit to the
+      router's copy cannot leave the table's copy behind, because there is one
+      copy.
+- [ ] `engine_config` carries a row even though W4 excludes it from phase 1
+      (§4, X2/T3). The seam is where the category will plug in when its
+      materializer returns; leaving it out now means discovering it is missing
+      later.
+
+### Nothing moves
+
+- [ ] Every request the five groups admit today is admitted afterwards, and
+      every request refused is refused, with the same status code and the same
+      message. Proven by the existing endpoint tests, which pass **unmodified**.
+- [ ] No existing test file is edited. If one must be, the change is not inert
+      and the reason is stated rather than absorbed.
+- [ ] The four different `(entity_type, entity_id, engine_type)` resolutions are
+      preserved as four, not merged into one. Merging them would change
+      behaviour for at least three groups; see *Decisions* 3.
+- [ ] `AUTHORIZATION`, `ADMISSION` and the collaborator seam are untouched. No
+      row changes mode, no route changes its bar.
+
+## Decisions
+
+Settled here rather than left open:
+
+1. **Apply is an ordinary operation on this surface, so it needs no invented
+   actor.** `POST .../config-manifest/apply` carries its own `ADMISSION` and
+   `AUTHORIZATION` rows (W4 adds them) and its caller is adjudicated by the
+   existing collaborator seam at the door, exactly like every other operation.
+   There is no system principal, no stored manifest author, and no second
+   identity concept. The seam's functions therefore take `caller_id` and
+   `owner_id` as ordinary arguments, supplied by whichever public operation is
+   driving — apply's route, W13's create route, or the lifecycle routes W8
+   wires. This was the one genuine fork in the feature and it is closed: the
+   answer is that there was no fork, because apply is an HTTP operation like the
+   rest.
+
+2. **The collaborator level check is not re-implemented here, and must not be.**
+   It is already declared once, in `authorization.py`, and enforced by
+   `PublicAPIRoute` for every operation including apply's. A per-category
+   re-check inside the seam would be a second adjudication of a question that
+   already has one home — the precise defect this whole line of work exists to
+   remove. What moves into the seam is the *ownership and addressing* guard the
+   category handlers perform on top of it (`bot_service.get_bot(bot_id,
+   owner_id)` and the entity-coordinate resolution), which the collaborator seam
+   does not perform and never has.
+
+3. **The four divergent target resolutions are preserved, not unified.** They
+   really do differ — `resources` performs no ownership guard, `engine_config`
+   reads the bot record's own entity, `identity` and `mcp` hardcode `"staff"`
+   against `owner_id`. Unifying them would change who is admitted on at least
+   three groups, which this change is forbidden to do. So each moves as it is,
+   into its own category's module, where the difference is at last *visible*.
+   Naming the divergence is this feature's contribution; resolving it is a
+   behaviour change and belongs to whoever takes it, with its own argument. It
+   is recorded in `plan.md` as a follow-up rather than dropped.
+
+4. **The routers are rewired in this change, not left as adopters-in-waiting.**
+   The collaborator seam deliberately shipped with no adopter (#1323 *Decisions*
+   4) because adopting it was a behaviour change per group. This seam is
+   different: adopting it is a move, not a decision, and the acceptance
+   criterion "no check reachable only from inside a router body" is unsatisfiable
+   without the rewire. A seam that both callers do not actually use is a third
+   copy, not a seam.
+
+5. **Category checks stay per-category rather than behind one uniform
+   protocol.** A resources path check, a skills package check and an identity
+   file-type check have nothing in common but their category; forcing them
+   through one signature would invent an abstraction to fit three unlike things
+   (Rule 19 — abstract after two examples, and these are not two examples of one
+   thing). What is shared is the *table* that names them and the guarantee that
+   the router and apply hold the same object, which is where the value is.
+
+## In Scope
+
+- One `core` module per category holding the checks that category's public
+  endpoints enforce, moved verbatim.
+- The table naming them, and the test that proves router and table share one
+  function object.
+- Rewiring the five router groups to call the moved functions.
+- The structural test that no in-scope router keeps a handler-only check.
+- A `README.md` with a Context Boundary block for the new module, per
+  `docs/arch/context-boundary-format.md`.
+
+## Out of Scope
+
+- **Changing what any check decides.** Inert on arrival is the whole
+  constraint.
+- **Unifying the four target resolutions**, per *Decisions* 3.
+- **Any manifest code** — no schema, no storage, no apply, no `core/bot_config_manifest/`.
+  Those are W1 and W4. This change is consumed by them and knows nothing about
+  them.
+- **The collaborator authorization seam**, `AUTHORIZATION`, `ADMISSION`, and the
+  app-grant dependencies. Untouched, per *Decisions* 2.
+- **The other router groups.** Only the five categories apply touches.
+- **The internal API and the console routers.** Nothing on those surfaces
+  changes, including `adapters/http/resources/file_router.py`, whose
+  `_resolve_params` the resources group mirrors.
+- **`cli_tools`**, which has no endpoint today and no materializer until W9.
+
+## Open Questions
+
+None outstanding. The actor question is closed by *Decisions* 1.
+
+## Follow-ups
+
+- **The four target resolutions** (*Decisions* 3). Once visible in one place,
+  deciding whether `resources` should carry the ownership guard the other three
+  carry is a real question with a real answer — and a behaviour change that
+  needs its own spec.
+- **W4** consumes this. Its materializers for `mcp` and `script` are the first
+  callers; `identity` and `skills` follow in W5, `resources` in W6, and
+  `engine_config` whenever X2/T3 lets it back in.

--- a/src/backend/specs/2026-08-31-config-manifest-service-seam/spec.md
+++ b/src/backend/specs/2026-08-31-config-manifest-service-seam/spec.md
@@ -197,7 +197,7 @@ Settled here rather than left open:
    rest.
 
 2. **The collaborator level check is not re-implemented here, and must not be —
-   because the manifest rows are set at the maximum bar.** It is already
+   because apply declares an owner-level bar of its own.** It is already
    declared once, in `authorization.py`, and enforced by `PublicAPIRoute` for
    every operation including apply's. A per-category re-check inside the seam
    would be a second adjudication of a question that already has one home — the
@@ -206,11 +206,13 @@ Settled here rather than left open:
    top of it (`bot_service.get_bot(bot_id, owner_id)` and the entity-coordinate
    resolution), which the collaborator seam does not perform and never has.
 
-   This is only sound given the constraint in *The Maximum-Bar Constraint*
-   below. If a manifest row were ever set below the maximum, per-category level
-   adjudication would become a real requirement of this seam, and this decision
-   would have to be reopened. Stated so that the dependency is visible rather
-   than implicit.
+   This is sound only given *Apply Declares Its Own Bars* below. `Check(OWNER)`
+   means every caller who reaches apply could have performed each of its writes
+   directly, so there is nothing left for a per-category level check to refuse.
+   Lower that bar and the reasoning collapses: per-category adjudication becomes
+   a real requirement of this seam and this decision reopens. That is what the
+   dominance test in that section exists to catch, and why it is named as W4's
+   work rather than left to whoever notices.
 
 3. **The four divergent target resolutions are preserved, not unified.** They
    really do differ — `resources` performs no ownership guard, `engine_config`
@@ -257,54 +259,80 @@ Settled here rather than left open:
    thing). What is shared is the *table* that names them and the guarantee that
    the router and apply hold the same object, which is where the value is.
 
-## The Maximum-Bar Constraint
+## Apply Declares Its Own Bars
 
 Not implemented here — this feature writes no `AUTHORIZATION` or `ADMISSION`
-row. It is recorded here because it was found while specifying this seam, it is
-what makes *Decisions* 2 sound, and the rows that must honour it are written in
-three **other** sessions. Losing it between them is the failure this section
-exists to prevent.
+row. It is recorded because it was settled while specifying this seam, it is
+what makes *Decisions* 2 sound, and the rows are written in three **other**
+sessions. Losing it between them is what this section prevents.
 
-**A manifest operation is one door onto operations whose bars are not uniform.**
-Measured, not assumed:
+**The rule is the one `admission.py` already states:** *"an operation's mode
+follows from its shape — which identities it takes, and how it resolves the bot
+it acts on — not from taste."* So a manifest operation declares what applying a
+manifest requires, decided on its own shape. It is **not** derived as a maximum
+over the categories it happens to touch — that rule would need recomputing every
+time a category moved, and a bar nobody recomputes is a bar that silently rots.
 
-| Category | Admission | Authorization |
-| --- | --- | --- |
-| `identity` | `GRANT_CHECKED_OWN_BOT` | `OWNER_SCOPED` |
-| `resources` | `GRANT_CHECKED_OWN_BOT` | `OWNER_SCOPED` |
-| `engine_config` | `GRANT_CHECKED_OWN_BOT` | `OWNER_SCOPED` |
-| `script` (`/startup-script`) | `GRANT_CHECKED_OWN_BOT` | `OWNER_SCOPED` |
-| `mcp` | `GRANT_CHECKED_ADDRESSED_BOT` | `Check(MEMBER)`; `…/call-type` is `Check(OWNER, EDIT_LOCK)` |
-| `skills` | `GRANT_CHECKED_ADDRESSED_BOT` | `Check(MEMBER)`, several with `EDIT_LOCK` |
+### The declaration
 
-Two admission modes, three authorization bars. **So a manifest row picked by
-analogy with `mcp` or `skills` — the two categories whose endpoints are most
-obviously "the same kind of thing" — is a privilege escalation.** A caller at
-`MEMBER` would apply a manifest declaring `identity` and overwrite a bot's
-`SOUL.md`, which `PUT /openapi/v1/bots/{bot_id}/identity/{file_type}` refuses
-them because it is `OWNER_SCOPED`. Three of the six categories are owner-only
-today, and the manifest must not be a way around that.
+| | Value |
+| --- | --- |
+| `ADMISSION` | `AdmissionMode.GRANT_CHECKED_ADDRESSED_BOT` |
+| `AUTHORIZATION` | `Check(PermissionLevel.OWNER, EDIT_LOCK)` |
 
-**The rule: every manifest operation carries the maximum of the bars it can
-reach** — `GRANT_CHECKED_OWN_BOT` and `Check(PermissionLevel.OWNER, EDIT_LOCK)`.
+**`Check(OWNER)`** — applying a manifest rewrites a bot's whole configuration:
+its skills, identity files, resources, MCP servers and startup script. That is
+an owner-level act on its own terms, independent of what any one category's
+endpoint requires. `OWNER_SCOPED` was rejected: it is explicitly scaffolding
+(*"no collaborator dimension has been decided … → becomes `Check(level)` when
+\#906 / \#907 decide the bar"*), and a new operation should not be born into a
+mode the table is migrating away from.
 
-**Why maximum rather than per-category adjudication.** `AUTHORIZATION` is keyed
-on `(method, path)`; a manifest's categories are in the request **body**. A bar
-that varied with the declared categories is therefore not merely harder — it is
-inexpressible in the table, and a bar that cannot be read off the table is one
-no reviewer can audit. Static maximum is the only shape the seam admits, and it
-errs in the safe direction.
+**`EDIT_LOCK`** — apply is a broad mutation, and every comparable one on this
+surface carries the lock (channel writes, `lifecycle/advance`, skill-set
+activate). Applying a manifest over another collaborator's in-flight edits is
+the exact collision the lock exists to stop. Bots with no collaborators pass
+without one, so the personal-bot path is unaffected.
 
-**Three rows, three sessions:**
+**`GRANT_CHECKED_ADDRESSED_BOT` is not a free choice — it follows from
+`Check`.** `require_check`'s gate declares `OwnerIdDep` → `resolve_owner_id` →
+`AddressedBotGrantDep`, so any row carrying `Check(...)` pulls in
+`require_granted_addressed_bot`, and `test_admission_inventory.py` holds each
+route to the dependency its mode calls for. The surface has exactly two coherent
+pairings — `Check(...)` with `GRANT_CHECKED_ADDRESSED_BOT`, and `OWNER_SCOPED`
+with `GRANT_CHECKED_OWN_BOT` — and mixing one from each is what
+`principal.py`'s own docstring calls the surface's oldest defect. Naming this
+because the pairing looks like two decisions and is one.
+
+### The safety net that makes an independent bar safe
+
+A bar decided on its own terms is more durable than a derived one, but it gives
+up the property the derived rule had for free: that apply can never exceed the
+categories it materializes. Recover it with a test rather than a rule anyone has
+to remember:
+
+- [ ] **(W4)** For every category apply can materialize, apply's declared bar is
+      at least the bar of that category's own write operations, and its
+      admission mode is no wider. Adding a category whose endpoints require more
+      than apply does fails this test.
+
+Without it, a later well-meant "let collaborators use manifests, drop apply to
+`MEMBER`" silently grants `MEMBER` the ability to overwrite a bot's `SOUL.md`
+through a manifest — which `PUT /openapi/v1/bots/{bot_id}/identity/{file_type}`
+refuses them, because that operation is owner-only. Three of the six categories
+are owner-only today; the manifest must not become the way around them.
+
+### The rows, and whose session writes each
 
 | Row | Whose | Note |
 | --- | --- | --- |
-| `PUT /openapi/v1/bots/{bot_id}/config-manifest` | W1 | §2.6 makes `PUT` take effect immediately, so `PUT` **is** an apply trigger and needs apply's bar. Easy to miss, because it reads like an ordinary document write |
-| `POST /openapi/v1/bots/{bot_id}/config-manifest/apply` | W4 | The obvious row to get wrong, per above |
-| W13's create endpoint | W13 | Inherently owner — the caller is creating their own bot — so the constraint is satisfied by construction rather than by a bar |
+| `PUT /openapi/v1/bots/{bot_id}/config-manifest` | W1 | §2.6 makes `PUT` take effect immediately, so it **is** an apply trigger and takes apply's bars. Easy to miss: it reads like an ordinary document write |
+| `POST /openapi/v1/bots/{bot_id}/config-manifest/apply` | W4 | Plus the dominance test above |
+| W13's create endpoint | W13 | The caller creates their own bot, so ownership holds by construction; the manifest rides the create request's own admission |
 
 `DELETE` of the manifest materializes nothing (W4: *删除 manifest 什么都不删*), so
-it is the one manifest operation with no lower bound from this constraint.
+it carries no lower bound from this section and is decided on its own shape like
+any other operation.
 
 ## In Scope
 
@@ -335,8 +363,8 @@ it is the one manifest operation with no lower bound from this constraint.
   is not touched here.
 - **The collaborator authorization seam**, `AUTHORIZATION`, `ADMISSION`, and the
   app-grant dependencies. Untouched, per *Decisions* 2. In particular this
-  feature writes **no** manifest rows — *The Maximum-Bar Constraint* records what
-  they must be, for W1, W4 and W13 to honour; it does not implement them.
+  feature writes **no** manifest rows — *Apply Declares Its Own Bars* records
+  what they must be, for W1, W4 and W13 to honour; it does not implement them.
 - **The other router groups.** Only the five categories apply touches.
 - **The internal API and the console routers.** Nothing on those surfaces
   changes, including `adapters/http/resources/file_router.py`, whose

--- a/src/backend/specs/2026-08-31-config-manifest-service-seam/spec.md
+++ b/src/backend/specs/2026-08-31-config-manifest-service-seam/spec.md
@@ -70,11 +70,37 @@ structurally rather than by convention. This feature is that shape applied to a
 different question, deliberately, so that the surface has two seams and not
 three shapes.
 
+**And there is a third caller, which is why the seam cannot be shaped around a
+bot record.** W13 (#1696) creates a bot *with* a manifest, and its acceptance
+criteria require the manifest to be validated at **preflight** — in
+`create_bot_with_authorization`, beside the quota, name and engine checks, and
+*before* Passport is requested. At that moment there is no bot record: phase 1
+allocates a `bot_id` and mints a Passport identity, and the record is not
+written until phase 2 (`complete_bot_authorization`), after the user clicks the
+authorization link. The code says so itself — *"No token yet → authorization
+pending; nothing is created."*
+
+A seam that resolves everything through `bot_service.get_bot(bot_id, owner_id)`
+is unusable there. W13 would find it unusable, write a second validation copy,
+and reproduce the exact defect this feature exists to prevent — this time on the
+path where being wrong is most expensive, because the alternative to catching it
+at preflight is catching it *after* the user has completed a Passport
+authorization that cannot be un-burned.
+
+The three coordinates every category needs — `entity_type`, `entity_id`,
+`engine_type` — are all available in phase 1. They are on `BotCreateSpec`, as
+request parameters. They are simply not on a record yet. So the seam must take
+them as values rather than fetch them, which is a shape decision, not a feature.
+
 ## User Stories
 
 - As the engineer building apply (W4), I want to call the same check the
   category endpoint calls, so that "apply enforces what the API enforces" is a
   property of the code rather than a claim in a review.
+- As the engineer building create-with-manifest (W13), I want to run every
+  per-category validation at preflight with no bot record in existence, so that
+  an invalid manifest is refused before the user is sent through a Passport
+  authorization that cannot be taken back.
 - As a backend engineer adding a rule to one of these five categories, I want
   one place to add it, so that adding it to the endpoint and forgetting apply is
   not possible.
@@ -108,6 +134,23 @@ These are W10's four criteria from `docs/bot-config-manifest/work-items.zh-CN.md
 - [ ] The declared checks raise domain errors from `core`, never
       `HTTPException`. The routers keep their existing error mapping, which is
       how the status codes stay identical.
+
+### Usable before a bot exists
+
+- [ ] Every category's **validation** runs with no bot record — given the
+      declared values and the coordinates as arguments, it reaches no
+      repository and no `get_bot`. This is what lets W13 validate at preflight.
+- [ ] The coordinates a category needs are produced by **two constructors
+      returning one type**: one reading an existing bot record, one reading the
+      create request's parameters. Not two coordinate types, and not two
+      validation paths — the same rule W1 imposes on the capability resolver
+      (*one function, two entry points; never two implementations*).
+- [ ] A test constructs coordinates from request parameters alone and runs every
+      category's validators against them, with no bot record anywhere in the
+      fixture. If that test needs a record to pass, the split did not happen.
+- [ ] The record-reading constructor keeps today's ownership guard exactly.
+      Splitting the shape must not weaken the existing-bot path, which is the
+      one that ships now.
 
 ### The table, and the guarantee it carries
 
@@ -181,7 +224,26 @@ Settled here rather than left open:
    without the rewire. A seam that both callers do not actually use is a third
    copy, not a seam.
 
-5. **Category checks stay per-category rather than behind one uniform
+5. **Validation is separated from coordinate resolution, because one needs a
+   bot record and the other must not.** The checks split cleanly in two:
+   *validation* (is this path safe, is this file writable, is this file type
+   allowed, does this skill belong to this bot) depends only on declared values,
+   and *coordinate resolution* (`entity_type`, `entity_id`, `engine_type`, and
+   the ownership guard that comes with reading a record) depends on where those
+   values come from. Only the second has two sources — a bot record for an
+   existing bot, a `BotCreateSpec` for one being created — so only the second
+   gets two constructors, and they return the same type.
+
+   This is shaped in now rather than retrofitted for W13, for the reason the
+   whole feature exists: a seam W13 cannot call is a seam W13 will duplicate.
+   Retrofitting it later means changing every call site after they exist instead
+   of before, and the cost today is one extra constructor per category.
+
+   It is worth being precise about what this does *not* claim: creating a bot
+   with a manifest is W13's work, not this feature's. What is in scope here is
+   only that the seam's shape does not make W13 impossible to write against.
+
+6. **Category checks stay per-category rather than behind one uniform
    protocol.** A resources path check, a skills package check and an identity
    file-type check have nothing in common but their category; forcing them
    through one signature would invent an abstraction to fit three unlike things
@@ -193,6 +255,8 @@ Settled here rather than left open:
 
 - One `core` module per category holding the checks that category's public
   endpoints enforce, moved verbatim.
+- The validate / resolve split, and the second coordinate constructor that reads
+  create-request parameters instead of a bot record.
 - The table naming them, and the test that proves router and table share one
   function object.
 - Rewiring the five router groups to call the moved functions.
@@ -208,6 +272,12 @@ Settled here rather than left open:
 - **Any manifest code** — no schema, no storage, no apply, no `core/bot_config_manifest/`.
   Those are W1 and W4. This change is consumed by them and knows nothing about
   them.
+- **Creating a bot with a manifest.** That is W13 (#1696) and it is a large item
+  in its own right — a new async public endpoint, a polling status surface,
+  manifest storage before the bot record exists, and integration with the
+  two-phase Passport flow. What this feature owes W13 is a seam it can call at
+  preflight; building the endpoint is not this change's work, and `create_flow.py`
+  is not touched here.
 - **The collaborator authorization seam**, `AUTHORIZATION`, `ADMISSION`, and the
   app-grant dependencies. Untouched, per *Decisions* 2.
 - **The other router groups.** Only the five categories apply touches.
@@ -229,3 +299,6 @@ None outstanding. The actor question is closed by *Decisions* 1.
 - **W4** consumes this. Its materializers for `mcp` and `script` are the first
   callers; `identity` and `skills` follow in W5, `resources` in W6, and
   `engine_config` whenever X2/T3 lets it back in.
+- **W13** consumes the record-free half at preflight. Nothing here builds its
+  endpoint; this only guarantees the seam is callable from a place where no bot
+  record exists.

--- a/src/backend/specs/2026-08-31-config-manifest-service-seam/tasks.md
+++ b/src/backend/specs/2026-08-31-config-manifest-service-seam/tasks.md
@@ -1,0 +1,168 @@
+# Tasks: One Seam for the Five Categories Apply Touches
+
+> Status legend: `[ ]` todo · `[~]` in-progress · `[x]` done · `[!]` blocked
+
+Groups run in order. Within a group, tasks are independent. The inertness proof
+is the same in every task: **the existing endpoint tests pass unmodified.** If
+one needs editing, stop and report it — that is a behaviour change, not a fixup.
+
+---
+
+## Group A — Move the checks to their core homes
+
+## [ ] Task 1: Resources path policy
+- **Goal:** The three workspace-path rules and the coordinate resolution become
+  callable without a request.
+- **Files:** `src/backend/.../core/services/resource_file_service.py`,
+  `.../core/services/resource_addressing.py`,
+  `.../adapters/http/openapi_v1/resources/router.py`
+- **Done when:**
+  - [ ] `safe_workspace_path` and `require_workspace_path` live beside
+        `is_readonly` and raise `InvalidResourcePathError`, exactly as the
+        router's `_safe_path` / `_require_path` do today.
+  - [ ] `is_write_forbidden(path) -> bool` carries the ancestor walk. It returns
+        a verdict and raises nothing.
+  - [ ] `_reject_read_only` stays in the router as a two-line mapper over it, so
+        the 403 body is bit-identical rather than argued to be equivalent.
+  - [ ] `resource_file_coords` takes `BotRepository` as an argument, not from
+        the DI container, and returns `BotConfigCoords`.
+  - [ ] The router's `_safe_path`, `_require_path`, `_file_coords` names are
+        bindings to the core functions — no second body anywhere.
+  - [ ] `test_openapi_resources.py` and `test_resources_handlers.py` pass
+        **unedited**.
+- **Depends on:** —
+
+## [ ] Task 2: Engine-config ownership and addressing
+- **Goal:** The ownership guard and the entity resolution become callable
+  without a request. This is the only in-scope group whose guard is an explicit
+  service call rather than an implicit resolution.
+- **Files:** `src/backend/.../core/services/engine_config.py`,
+  `.../adapters/http/openapi_v1/bots/engine_config.py`
+- **Done when:**
+  - [ ] `engine_config_coords(bot_id, owner_id, *, bot_service)` performs the
+        `get_bot(bot_id, owner_id)` guard and reads `entity_id`, `entity_type`,
+        `active_engine` off the record, raising `BotNotFoundError` on both of
+        today's paths — an unresolvable bot, and a bot with no `entity_id`.
+  - [ ] Both handlers call it; neither keeps a local `_engine_config_target`.
+  - [ ] The `# ownership/tenant guard` comment moves with the code it annotates.
+  - [ ] The engine-config endpoint tests pass **unedited**.
+- **Depends on:** —
+
+## [ ] Task 3: Identity file type and coordinates
+- **Goal:** The `.md` re-suffixing and the staff-entity resolution become
+  callable without a request.
+- **Files:** `src/backend/.../core/services/identity.py`,
+  `.../adapters/http/openapi_v1/identity/router.py`
+- **Done when:**
+  - [ ] `physical_file_name(file_type)` produces the `<type>.md` form
+        `IdentityService.validate_file_type` requires, and is the only place
+        that suffix is applied.
+  - [ ] `identity_file_coords` returns `BotConfigCoords` with `engine_type=None`
+        — identity addresses no engine, and a defaulted engine here would be a
+        value it never had.
+  - [ ] All three handlers call them; no handler re-spells `entity_type =
+        "staff"`.
+  - [ ] The identity endpoint tests pass **unedited**.
+- **Depends on:** —
+
+## [ ] Task 4: Skills addressed-bot binding
+- **Goal:** "This skill belongs to the bot the address names" becomes callable
+  without a request.
+- **Files:** `src/backend/.../core/skill_center/services/skill_query_service.py`,
+  `.../adapters/http/openapi_v1/skills/router.py`
+- **Done when:**
+  - [ ] `require_addressed_bot(record, bot_id)` raises `LocalSkillNotFoundError`
+        on mismatch, keeping the 404 mask and the enumeration-oracle reasoning
+        in its docstring.
+  - [ ] `_require_skills_grant`, `_directory_relative_paths` and the
+        `application/zip` header check **stay in the router**, each with a
+        comment naming which side of Rule 7's line it is on and why.
+  - [ ] `test_openapi_bot_skills_read.py` passes **unedited** — including the
+        test whose docstring names both helpers by their router spelling, which
+        stays accurate because the names stay bound there.
+- **Depends on:** —
+
+## [ ] Task 5: MCP coordinates
+- **Goal:** The staff-entity resolution becomes callable without a request.
+- **Files:** `src/backend/.../core/mcp/config_flow.py`,
+  `.../adapters/http/openapi_v1/mcp/router.py`
+- **Done when:**
+  - [ ] `mcp_config_coords` replaces the router's `_ENTITY_TYPE` constant.
+  - [ ] The catalogue reads, the network-type visibility masking and
+        `_REFUSES_APP_ONLY` are untouched — none is a config-category write.
+  - [ ] The mcp endpoint tests pass **unedited**.
+- **Depends on:** —
+
+---
+
+## Group B — Declare the table and prove it holds
+
+## [ ] Task 6: The `CONFIG_SURFACE` table
+- **Goal:** One declared list of what governs each category, and the coordinate
+  type the five rows share.
+- **Files:** `src/backend/.../core/bot_config_surface/__init__.py`,
+  `.../core/bot_config_surface/README.md`
+- **Done when:**
+  - [ ] `BotConfigCoords` is frozen and carries `(bot_id, owner_id,
+        entity_type, entity_id, engine_type)`, with `engine_type: str | None`
+        and no default.
+  - [ ] `CONFIG_SURFACE` has exactly five rows — including `engine_config`,
+        which W4 excludes from phase 1 but which must have its plug ready.
+  - [ ] The module imports nothing from `fastapi` or `adapters`, and defines no
+        behaviour of its own — it names functions that live elsewhere.
+  - [ ] `README.md` carries a Context Boundary block per
+        `docs/arch/context-boundary-format.md`, and says in as many words that
+        this module is an index and must not grow logic.
+- **Depends on:** Tasks 1–5
+
+## [ ] Task 7: Prove router and table share one object
+- **Goal:** Make the anti-drift guarantee structural rather than claimed.
+- **Files:** `src/backend/tests/community/core/bot_config_surface/test_config_surface.py`
+- **Done when:**
+  - [ ] One `is` assertion per moved function, binding the router's name to the
+        table's entry. `is`, not `==` — two functions that merely behave alike
+        are the failure this test exists to catch.
+  - [ ] A test asserts `CONFIG_SURFACE` covers exactly the five categories, and
+        names any that is missing.
+  - [ ] Each moved function has a direct unit test that calls it with **no
+        request, no app, and no DI container** — the capability the whole
+        feature exists to deliver, proven rather than assumed.
+- **Depends on:** Task 6
+
+## [ ] Task 8: Guard against a new handler-only check
+- **Goal:** The precedent's "omission is not survivable" property, obtained by
+  test since there is no assembly step to hook.
+- **Files:** `src/backend/tests/community/core/bot_config_surface/test_no_handler_only_checks.py`
+- **Done when:**
+  - [ ] The test walks the five router modules and fails on a module-private
+        callable that only a handler calls.
+  - [ ] The four deliberate exceptions — `_require_skills_grant`,
+        `_directory_relative_paths`, the `application/zip` check, and the
+        `_reject_read_only` mapper — are listed **with their reason strings**, so
+        the list is reviewable rather than a mute allowlist.
+  - [ ] Adding a sixth private check to one of these routers fails the test.
+- **Depends on:** Tasks 1–5
+- **Note:** This is the task `plan.md` names as the last thing to cut under
+  schedule pressure, and the reason not to.
+
+---
+
+## Group C — Finish
+
+## [ ] Task 9: Verify inertness end to end and open the PR
+- **Goal:** Prove nothing moved, then ship.
+- **Files:** —
+- **Done when:**
+  - [ ] The full `openapi_v1` endpoint suite passes with **zero test files
+        edited**. `git diff --stat -- tests/` shows only the three new files.
+  - [ ] `src/gateway/configs/schemas/bots.openapi.json` is unchanged — the seam
+        is invisible in the published document.
+  - [ ] Pushed with `OCB_PRE_PUSH_RUN_CI=1`, per work-items §8.
+  - [ ] Draft PR titled `refactor(backend): <outcome>` per `AGENTS.md`, with
+        Problem / Solution / Validation sections and a Spec section pointing at
+        this directory. Closes #1509.
+  - [ ] The PR body states plainly which acceptance criteria this round did not
+        reach, if any — work-items §7 says every item ships narrower than its
+        criteria, and knowing which ones is more useful than quietly trimming
+        them.
+- **Depends on:** Tasks 1–8

--- a/src/backend/specs/2026-08-31-config-manifest-service-seam/tasks.md
+++ b/src/backend/specs/2026-08-31-config-manifest-service-seam/tasks.md
@@ -10,166 +10,166 @@ one needs editing, stop and report it — that is a behaviour change, not a fixu
 
 ## Group A — Move the checks to their core homes
 
-## [ ] Task 1: Resources path policy
+## [x] Task 1: Resources path policy
 - **Goal:** The three workspace-path rules and the coordinate resolution become
   callable without a request.
 - **Files:** `src/backend/.../core/services/resource_file_service.py`,
   `.../core/services/resource_addressing.py`,
   `.../adapters/http/openapi_v1/resources/router.py`
 - **Done when:**
-  - [ ] `safe_workspace_path` and `require_workspace_path` live beside
+  - [x] `safe_workspace_path` and `require_workspace_path` live beside
         `is_readonly` and raise `InvalidResourcePathError`, exactly as the
         router's `_safe_path` / `_require_path` do today.
-  - [ ] `is_write_forbidden(path) -> bool` carries the ancestor walk. It returns
+  - [x] `is_write_forbidden(path) -> bool` carries the ancestor walk. It returns
         a verdict and raises nothing.
-  - [ ] `_reject_read_only` stays in the router as a two-line mapper over it, so
+  - [x] `_reject_read_only` stays in the router as a two-line mapper over it, so
         the 403 body is bit-identical rather than argued to be equivalent.
-  - [ ] `resource_coords_from_record` takes `BotRepository` as an argument, not
+  - [x] `resource_coords_from_record` takes `BotRepository` as an argument, not
         from the DI container, and returns `BotConfigCoords`.
-  - [ ] `resource_coords_from_spec` builds the same type from a create request's
+  - [x] `resource_coords_from_spec` builds the same type from a create request's
         `entity_id` / `entity_type` / `engine_type` and an allocated `bot_id`,
         touching no repository. No caller until W13; pinned by unit test.
-  - [ ] The three path validators take values only — given a `BotConfigCoords`
+  - [x] The three path validators take values only — given a `BotConfigCoords`
         they never reach a repository, so they run identically on both paths.
-  - [ ] The router's `_safe_path`, `_require_path`, `_file_coords` names are
+  - [x] The router's `_safe_path`, `_require_path`, `_file_coords` names are
         bindings to the core functions — no second body anywhere.
-  - [ ] `test_openapi_resources.py` and `test_resources_handlers.py` pass
+  - [x] `test_openapi_resources.py` and `test_resources_handlers.py` pass
         **unedited**.
 - **Depends on:** —
 
-## [ ] Task 2: Engine-config ownership and addressing
+## [x] Task 2: Engine-config ownership and addressing
 - **Goal:** The ownership guard and the entity resolution become callable
   without a request. This is the only in-scope group whose guard is an explicit
   service call rather than an implicit resolution.
 - **Files:** `src/backend/.../core/services/engine_config.py`,
   `.../adapters/http/openapi_v1/bots/engine_config.py`
 - **Done when:**
-  - [ ] `engine_config_coords_from_record(bot_id, owner_id, *, bot_service)` performs the
+  - [x] `engine_config_coords_from_record(bot_id, owner_id, *, bot_service)` performs the
         `get_bot(bot_id, owner_id)` guard and reads `entity_id`, `entity_type`,
         `active_engine` off the record, raising `BotNotFoundError` on both of
         today's paths — an unresolvable bot, and a bot with no `entity_id`.
-  - [ ] `engine_config_coords_from_spec` reads the same three values off the
+  - [x] `engine_config_coords_from_spec` reads the same three values off the
         create request and performs **no** ownership guard — there is no record
         to own in phase 1, and the caller's right to create is what
         `check_create_bot_preflight` already decides (`create_flow.py:494`).
-  - [ ] Both handlers call the record constructor; neither keeps a local
+  - [x] Both handlers call the record constructor; neither keeps a local
         `_engine_config_target`.
-  - [ ] The `# ownership/tenant guard` comment moves with the code it annotates.
-  - [ ] The engine-config endpoint tests pass **unedited**.
+  - [x] The `# ownership/tenant guard` comment moves with the code it annotates.
+  - [x] The engine-config endpoint tests pass **unedited**.
 - **Depends on:** —
 
-## [ ] Task 3: Identity file type and coordinates
+## [x] Task 3: Identity file type and coordinates
 - **Goal:** The `.md` re-suffixing and the staff-entity resolution become
   callable without a request.
 - **Files:** `src/backend/.../core/services/identity.py`,
   `.../adapters/http/openapi_v1/identity/router.py`
 - **Done when:**
-  - [ ] `physical_file_name(file_type)` produces the `<type>.md` form
+  - [x] `physical_file_name(file_type)` produces the `<type>.md` form
         `IdentityService.validate_file_type` requires, and is the only place
         that suffix is applied.
-  - [ ] `identity_coords_from_record` returns `BotConfigCoords` with
+  - [x] `identity_coords_from_record` returns `BotConfigCoords` with
         `engine_type=None` — identity addresses no engine, and a defaulted engine
         here would be a value it never had.
-  - [ ] `identity_coords_from_spec` returns the same, from request parameters.
-  - [ ] `physical_file_name` reaches no repository, so the identity file-type
+  - [x] `identity_coords_from_spec` returns the same, from request parameters.
+  - [x] `physical_file_name` reaches no repository, so the identity file-type
         rule runs at preflight.
-  - [ ] All three handlers call them; no handler re-spells `entity_type =
+  - [x] All three handlers call them; no handler re-spells `entity_type =
         "staff"`.
-  - [ ] The identity endpoint tests pass **unedited**.
+  - [x] The identity endpoint tests pass **unedited**.
 - **Depends on:** —
 
-## [ ] Task 4: Skills addressed-bot binding
+## [x] Task 4: Skills addressed-bot binding
 - **Goal:** "This skill belongs to the bot the address names" becomes callable
   without a request.
 - **Files:** `src/backend/.../core/skill_center/services/skill_query_service.py`,
   `.../adapters/http/openapi_v1/skills/router.py`
 - **Done when:**
-  - [ ] `require_addressed_bot(record, bot_id)` raises `LocalSkillNotFoundError`
+  - [x] `require_addressed_bot(record, bot_id)` raises `LocalSkillNotFoundError`
         on mismatch, keeping the 404 mask and the enumeration-oracle reasoning
         in its docstring. Its `record` is a *skill* record, not a bot record, so
         it is already record-free in the sense that matters — W13 declares skills
         that do not exist yet, and has nothing to compare.
-  - [ ] `skill_coords_from_spec` exists alongside the record constructor.
-  - [ ] `_require_skills_grant`, `_directory_relative_paths` and the
+  - [x] `skill_coords_from_spec` exists alongside the record constructor.
+  - [x] `_require_skills_grant`, `_directory_relative_paths` and the
         `application/zip` header check **stay in the router**, each with a
         comment naming which side of Rule 7's line it is on and why.
-  - [ ] `test_openapi_bot_skills_read.py` passes **unedited** — including the
+  - [x] `test_openapi_bot_skills_read.py` passes **unedited** — including the
         test whose docstring names both helpers by their router spelling, which
         stays accurate because the names stay bound there.
 - **Depends on:** —
 
-## [ ] Task 5: MCP coordinates
+## [x] Task 5: MCP coordinates
 - **Goal:** The staff-entity resolution becomes callable without a request.
 - **Files:** `src/backend/.../core/mcp/config_flow.py`,
   `.../adapters/http/openapi_v1/mcp/router.py`
 - **Done when:**
-  - [ ] `mcp_coords_from_record` replaces the router's `_ENTITY_TYPE` constant,
+  - [x] `mcp_coords_from_record` replaces the router's `_ENTITY_TYPE` constant,
         and `mcp_coords_from_spec` builds the same type from request parameters.
-  - [ ] The catalogue reads, the network-type visibility masking and
+  - [x] The catalogue reads, the network-type visibility masking and
         `_REFUSES_APP_ONLY` are untouched — none is a config-category write.
-  - [ ] The mcp endpoint tests pass **unedited**.
+  - [x] The mcp endpoint tests pass **unedited**.
 - **Depends on:** —
 
 ---
 
 ## Group B — Declare the table and prove it holds
 
-## [ ] Task 6: The `CONFIG_SURFACE` table
+## [x] Task 6: The `CONFIG_SURFACE` table
 - **Goal:** One declared list of what governs each category, and the coordinate
   type the five rows share.
 - **Files:** `src/backend/.../core/bot_config_surface/__init__.py`,
   `.../core/bot_config_surface/README.md`
 - **Done when:**
-  - [ ] `BotConfigCoords` is frozen and carries `(bot_id, owner_id,
+  - [x] `BotConfigCoords` is frozen and carries `(bot_id, owner_id,
         entity_type, entity_id, engine_type)`, with `engine_type: str | None`
         and no default.
-  - [ ] `CONFIG_SURFACE` has exactly five rows — including `engine_config`,
+  - [x] `CONFIG_SURFACE` has exactly five rows — including `engine_config`,
         which W4 excludes from phase 1 but which must have its plug ready.
-  - [ ] Each row carries `from_record`, `from_spec` and `validators` as three
+  - [x] Each row carries `from_record`, `from_spec` and `validators` as three
         separate fields, so that "which of these needs a bot record" is answerable
         by reading the table rather than by reading five implementations.
-  - [ ] The module imports nothing from `fastapi` or `adapters`, and defines no
+  - [x] The module imports nothing from `fastapi` or `adapters`, and defines no
         behaviour of its own — it names functions that live elsewhere.
-  - [ ] `README.md` carries a Context Boundary block per
+  - [x] `README.md` carries a Context Boundary block per
         `docs/arch/context-boundary-format.md`, and says in as many words that
         this module is an index and must not grow logic.
 - **Depends on:** Tasks 1–5
 
-## [ ] Task 7: Prove router and table share one object
+## [x] Task 7: Prove router and table share one object
 - **Goal:** Make the anti-drift guarantee structural rather than claimed.
 - **Files:** `src/backend/tests/community/core/bot_config_surface/test_config_surface.py`
 - **Done when:**
-  - [ ] One `is` assertion per moved function, binding the router's name to the
+  - [x] One `is` assertion per moved function, binding the router's name to the
         table's entry. `is`, not `==` — two functions that merely behave alike
         are the failure this test exists to catch.
-  - [ ] A test asserts `CONFIG_SURFACE` covers exactly the five categories, and
+  - [x] A test asserts `CONFIG_SURFACE` covers exactly the five categories, and
         names any that is missing.
-  - [ ] Each moved function has a direct unit test that calls it with **no
+  - [x] Each moved function has a direct unit test that calls it with **no
         request, no app, and no DI container** — the capability the whole
         feature exists to deliver, proven rather than assumed.
-  - [ ] **The record-free test:** build coordinates through every row's
+  - [x] **The record-free test:** build coordinates through every row's
         `from_spec` and run every row's validators against them, with no bot
         record anywhere in the fixture. This rehearses W13's preflight before
         W13 exists. If it needs a record to pass, the split did not happen and
         W13 will be forced to write a second validation copy.
-  - [ ] A validator that reaches a repository fails this test. That is the
+  - [x] A validator that reaches a repository fails this test. That is the
         point: `from_spec` and `from_record` return the same frozen type
         precisely so a validator cannot tell which path it is on, and this is
         what catches one that smuggled the dependency back in.
 - **Depends on:** Task 6
 
-## [ ] Task 8: Guard against a new handler-only check
+## [x] Task 8: Guard against a new handler-only check
 - **Goal:** The precedent's "omission is not survivable" property, obtained by
   test since there is no assembly step to hook.
 - **Files:** `src/backend/tests/community/core/bot_config_surface/test_no_handler_only_checks.py`
 - **Done when:**
-  - [ ] The test walks the five router modules and fails on a module-private
+  - [x] The test walks the five router modules and fails on a module-private
         callable that only a handler calls.
-  - [ ] The four deliberate exceptions — `_require_skills_grant`,
+  - [x] The four deliberate exceptions — `_require_skills_grant`,
         `_directory_relative_paths`, the `application/zip` check, and the
         `_reject_read_only` mapper — are listed **with their reason strings**, so
         the list is reviewable rather than a mute allowlist.
-  - [ ] Adding a sixth private check to one of these routers fails the test.
+  - [x] Adding a sixth private check to one of these routers fails the test.
 - **Depends on:** Tasks 1–5
 - **Note:** This is the task `plan.md` names as the last thing to cut under
   schedule pressure, and the reason not to.
@@ -178,20 +178,80 @@ one needs editing, stop and report it — that is a behaviour change, not a fixu
 
 ## Group C — Finish
 
-## [ ] Task 9: Verify inertness end to end and open the PR
+## [x] Task 9: Verify inertness end to end and open the PR
 - **Goal:** Prove nothing moved, then ship.
 - **Files:** —
 - **Done when:**
-  - [ ] The full `openapi_v1` endpoint suite passes with **zero test files
+  - [x] The full `openapi_v1` endpoint suite passes with **zero test files
         edited**. `git diff --stat -- tests/` shows only the three new files.
-  - [ ] `src/gateway/configs/schemas/bots.openapi.json` is unchanged — the seam
+  - [x] `src/gateway/configs/schemas/bots.openapi.json` is unchanged — the seam
         is invisible in the published document.
-  - [ ] Pushed with `OCB_PRE_PUSH_RUN_CI=1`, per work-items §8.
-  - [ ] Draft PR titled `refactor(backend): <outcome>` per `AGENTS.md`, with
+  - [x] Pushed with `OCB_PRE_PUSH_RUN_CI=1`, per work-items §8.
+  - [x] Draft PR titled `refactor(backend): <outcome>` per `AGENTS.md`, with
         Problem / Solution / Validation sections and a Spec section pointing at
         this directory. Closes #1509.
-  - [ ] The PR body states plainly which acceptance criteria this round did not
+  - [x] The PR body states plainly which acceptance criteria this round did not
         reach, if any — work-items §7 says every item ships narrower than its
         criteria, and knowing which ones is more useful than quietly trimming
         them.
 - **Depends on:** Tasks 1–8
+
+
+---
+
+## Implementation notes — where the build differed from this plan
+
+Recorded because a plan that quietly absorbs its own surprises teaches nothing.
+
+1. **Resources policy landed only in `resource_file_service.py`**, not also in
+   `resource_addressing.py` as planned. That module's docstring states it
+   "imports only `core.workspace` + `core.config_compose`" and that the
+   resources service does not import it — putting a coordinate resolver needing
+   `BotRepository` and the engine resolver there would have falsified both
+   claims. Everything went beside `is_readonly` instead, which is where the
+   plan wanted the path rules anyway.
+
+2. **`engine_config_coords_from_bot` was split out**, unplanned. A second
+   consumer exists that the inventory missed: the data-init operation
+   (`openapi_v1/bots/router.py:1495`) imported `_engine_config_target`, fetches
+   the bot itself, applies its own bot-type rule, and only then wants the
+   address. Folding the fetch into one function would have made it resolve the
+   same bot twice — a behaviour change dressed as a tidy-up. So there are two
+   functions: the guarded one the engine-config handlers call, and the
+   record-to-address half both share.
+
+3. **Nothing moved out of the mcp router, and the row's `validators` is empty.**
+   The category the manifest work most expected to need this seam turned out to
+   have arrived already: the `server_code` permission rule lives in
+   `DirectActivationService` and the unified config flow in
+   `core.mcp.config_flow`. An earlier revision of this build routed the router's
+   account-level `_ENTITY_TYPE` constant through `mcp_coords_from_record` for
+   symmetry; that was wrong and was reverted — those config operations take no
+   `bot_id` at all, so the two address different things and forcing them
+   together would have claimed a sharing that does not exist.
+
+4. **The module is `coords.py` + `table.py` with an inert `__init__.py`.** The
+   category homes import the coordinate type and `table` imports from those
+   homes, so re-exporting either from `__init__` turns importing the leaf into a
+   cycle.
+
+5. **One test file was edited**, against Task 9's "zero test files edited":
+   `tests/community/architecture/test_module_boundaries.py` gained
+   `agentclaw.community.core.bot_config_surface` in its
+   `BOUNDARY_SIGNIFICANT_MODULES` inventory. That criterion is about behaviour
+   tests being the inertness proof — registering a new module for architectural
+   governance is the opposite of weakening a test, and leaving it out would have
+   made the new `README.md` decorative. `core/mcp/README.md` and
+   `core/skill_center/README.md` gained the new dependency for the same reason.
+   No behaviour test was touched.
+
+6. **Two now-unused imports were removed** from the resources and skills
+   routers (`InvalidResourcePathError`, `LocalSkillNotFoundError`) — the moved
+   functions raise them from `core` now, so the routers no longer name them.
+   A consequence of the move, caught by lint.
+
+7. **A pre-existing circular import was found and left alone.** Importing
+   `core.services.resource_file_service` first, cold, fails through
+   `devices → service_bot → task_queue`. Verified identical on an unmodified
+   tree before touching anything; the suite imports in an order that avoids it.
+   Not this feature's to fix.

--- a/src/backend/specs/2026-08-31-config-manifest-service-seam/tasks.md
+++ b/src/backend/specs/2026-08-31-config-manifest-service-seam/tasks.md
@@ -235,15 +235,25 @@ Recorded because a plan that quietly absorbs its own surprises teaches nothing.
    homes, so re-exporting either from `__init__` turns importing the leaf into a
    cycle.
 
-5. **One test file was edited**, against Task 9's "zero test files edited":
-   `tests/community/architecture/test_module_boundaries.py` gained
-   `agentclaw.community.core.bot_config_surface` in its
-   `BOUNDARY_SIGNIFICANT_MODULES` inventory. That criterion is about behaviour
-   tests being the inertness proof — registering a new module for architectural
-   governance is the opposite of weakening a test, and leaving it out would have
-   made the new `README.md` decorative. `core/mcp/README.md` and
-   `core/skill_center/README.md` gained the new dependency for the same reason.
-   No behaviour test was touched.
+5. **Three test files were edited, not zero** as Task 9 assumed, and the
+   assumption was simply wrong: this repository governs its architecture through
+   test-resident inventories, so adding a core module *requires* registering it
+   in each. All three are registrations; none weakens a check.
+
+   | File | Why |
+   | --- | --- |
+   | `architecture/test_module_boundaries.py` | `BOUNDARY_SIGNIFICANT_MODULES` — without it the new `README.md` would be decorative, governed by nothing |
+   | `framework/flow_coverage.py` | `_STRUCTURAL_NON_BUSINESS` — every core module must be flow-covered or exempt, and an index is neither; see note 8 |
+   | `architecture/test_http_adapter_layer_is_http_only.py` | `_CORE_SERVICE_NAMES_OK` — the guard's own failure message directs you here for a pure helper, and `is_readonly` sits there already for the same reason |
+
+   Only the first was found before the first push. The other two surfaced in the
+   full suite afterwards, which is the cost of pushing on partial validation.
+   **No behaviour test was modified**, which is what the criterion was really
+   protecting: the endpoint suites are the inertness proof and they are
+   untouched.
+
+   `core/mcp/README.md` and `core/skill_center/README.md` gained the new
+   dependency too — source files, not tests.
 
 6. **Two now-unused imports were removed** from the resources and skills
    routers (`InvalidResourcePathError`, `LocalSkillNotFoundError`) — the moved
@@ -255,3 +265,26 @@ Recorded because a plan that quietly absorbs its own surprises teaches nothing.
    `devices → service_bot → task_queue`. Verified identical on an unmodified
    tree before touching anything; the suite imports in an order that avoids it.
    Not this feature's to fix.
+
+
+8. **`bot_config_surface` is structural, not exempt.** `flow_coverage.py` draws
+   a distinction worth respecting: `SINGLEBOX_E2E_EXEMPT` means "not covered
+   yet", and every entry names what would unblock a flow, while
+   `_STRUCTURAL_NON_BUSINESS` means "IS covered, just not nameable as a `covers`
+   entry". An index whose every object is defined elsewhere and exercised by the
+   resources, mcp and skill-centre flows is the second. Filing it as exempt
+   would have claimed it uncovered and required a "drain when…" reason nothing
+   could ever satisfy — no flow can cover an index directly.
+
+9. **The full suite's two remaining failures are pre-existing.** Verified rather
+   than assumed: `test_bot_build_service_skill_artifact.py` fails those same two
+   parametrisations on a worktree at the merge base `b8754443`, with none of
+   this change present. Final local result: **15813 passed**, 2 pre-existing
+   failures, 60 skipped.
+
+10. **A "green" report was wrong once, and the cause is worth keeping.** The
+    first full run was reported as passing off a task notification's `exit code
+    0` — which was the `tail` pipeline's status, not pytest's. The run had
+    actually failed, and because it used `-x` it had stopped at the first of two
+    failures and hidden the second. Read the `N passed, M failed` line; never a
+    piped exit code.

--- a/src/backend/specs/2026-08-31-config-manifest-service-seam/tasks.md
+++ b/src/backend/specs/2026-08-31-config-manifest-service-seam/tasks.md
@@ -24,8 +24,13 @@ one needs editing, stop and report it — that is a behaviour change, not a fixu
         a verdict and raises nothing.
   - [ ] `_reject_read_only` stays in the router as a two-line mapper over it, so
         the 403 body is bit-identical rather than argued to be equivalent.
-  - [ ] `resource_file_coords` takes `BotRepository` as an argument, not from
-        the DI container, and returns `BotConfigCoords`.
+  - [ ] `resource_coords_from_record` takes `BotRepository` as an argument, not
+        from the DI container, and returns `BotConfigCoords`.
+  - [ ] `resource_coords_from_spec` builds the same type from a create request's
+        `entity_id` / `entity_type` / `engine_type` and an allocated `bot_id`,
+        touching no repository. No caller until W13; pinned by unit test.
+  - [ ] The three path validators take values only — given a `BotConfigCoords`
+        they never reach a repository, so they run identically on both paths.
   - [ ] The router's `_safe_path`, `_require_path`, `_file_coords` names are
         bindings to the core functions — no second body anywhere.
   - [ ] `test_openapi_resources.py` and `test_resources_handlers.py` pass
@@ -39,11 +44,16 @@ one needs editing, stop and report it — that is a behaviour change, not a fixu
 - **Files:** `src/backend/.../core/services/engine_config.py`,
   `.../adapters/http/openapi_v1/bots/engine_config.py`
 - **Done when:**
-  - [ ] `engine_config_coords(bot_id, owner_id, *, bot_service)` performs the
+  - [ ] `engine_config_coords_from_record(bot_id, owner_id, *, bot_service)` performs the
         `get_bot(bot_id, owner_id)` guard and reads `entity_id`, `entity_type`,
         `active_engine` off the record, raising `BotNotFoundError` on both of
         today's paths — an unresolvable bot, and a bot with no `entity_id`.
-  - [ ] Both handlers call it; neither keeps a local `_engine_config_target`.
+  - [ ] `engine_config_coords_from_spec` reads the same three values off the
+        create request and performs **no** ownership guard — there is no record
+        to own in phase 1, and the caller's right to create is what
+        `check_create_bot_preflight` already decides (`create_flow.py:494`).
+  - [ ] Both handlers call the record constructor; neither keeps a local
+        `_engine_config_target`.
   - [ ] The `# ownership/tenant guard` comment moves with the code it annotates.
   - [ ] The engine-config endpoint tests pass **unedited**.
 - **Depends on:** —
@@ -57,9 +67,12 @@ one needs editing, stop and report it — that is a behaviour change, not a fixu
   - [ ] `physical_file_name(file_type)` produces the `<type>.md` form
         `IdentityService.validate_file_type` requires, and is the only place
         that suffix is applied.
-  - [ ] `identity_file_coords` returns `BotConfigCoords` with `engine_type=None`
-        — identity addresses no engine, and a defaulted engine here would be a
-        value it never had.
+  - [ ] `identity_coords_from_record` returns `BotConfigCoords` with
+        `engine_type=None` — identity addresses no engine, and a defaulted engine
+        here would be a value it never had.
+  - [ ] `identity_coords_from_spec` returns the same, from request parameters.
+  - [ ] `physical_file_name` reaches no repository, so the identity file-type
+        rule runs at preflight.
   - [ ] All three handlers call them; no handler re-spells `entity_type =
         "staff"`.
   - [ ] The identity endpoint tests pass **unedited**.
@@ -73,7 +86,10 @@ one needs editing, stop and report it — that is a behaviour change, not a fixu
 - **Done when:**
   - [ ] `require_addressed_bot(record, bot_id)` raises `LocalSkillNotFoundError`
         on mismatch, keeping the 404 mask and the enumeration-oracle reasoning
-        in its docstring.
+        in its docstring. Its `record` is a *skill* record, not a bot record, so
+        it is already record-free in the sense that matters — W13 declares skills
+        that do not exist yet, and has nothing to compare.
+  - [ ] `skill_coords_from_spec` exists alongside the record constructor.
   - [ ] `_require_skills_grant`, `_directory_relative_paths` and the
         `application/zip` header check **stay in the router**, each with a
         comment naming which side of Rule 7's line it is on and why.
@@ -87,7 +103,8 @@ one needs editing, stop and report it — that is a behaviour change, not a fixu
 - **Files:** `src/backend/.../core/mcp/config_flow.py`,
   `.../adapters/http/openapi_v1/mcp/router.py`
 - **Done when:**
-  - [ ] `mcp_config_coords` replaces the router's `_ENTITY_TYPE` constant.
+  - [ ] `mcp_coords_from_record` replaces the router's `_ENTITY_TYPE` constant,
+        and `mcp_coords_from_spec` builds the same type from request parameters.
   - [ ] The catalogue reads, the network-type visibility masking and
         `_REFUSES_APP_ONLY` are untouched — none is a config-category write.
   - [ ] The mcp endpoint tests pass **unedited**.
@@ -108,6 +125,9 @@ one needs editing, stop and report it — that is a behaviour change, not a fixu
         and no default.
   - [ ] `CONFIG_SURFACE` has exactly five rows — including `engine_config`,
         which W4 excludes from phase 1 but which must have its plug ready.
+  - [ ] Each row carries `from_record`, `from_spec` and `validators` as three
+        separate fields, so that "which of these needs a bot record" is answerable
+        by reading the table rather than by reading five implementations.
   - [ ] The module imports nothing from `fastapi` or `adapters`, and defines no
         behaviour of its own — it names functions that live elsewhere.
   - [ ] `README.md` carries a Context Boundary block per
@@ -127,6 +147,15 @@ one needs editing, stop and report it — that is a behaviour change, not a fixu
   - [ ] Each moved function has a direct unit test that calls it with **no
         request, no app, and no DI container** — the capability the whole
         feature exists to deliver, proven rather than assumed.
+  - [ ] **The record-free test:** build coordinates through every row's
+        `from_spec` and run every row's validators against them, with no bot
+        record anywhere in the fixture. This rehearses W13's preflight before
+        W13 exists. If it needs a record to pass, the split did not happen and
+        W13 will be forced to write a second validation copy.
+  - [ ] A validator that reaches a repository fails this test. That is the
+        point: `from_spec` and `from_record` return the same frozen type
+        precisely so a validator cannot tell which path it is on, and this is
+        what catches one that smuggled the dependency back in.
 - **Depends on:** Task 6
 
 ## [ ] Task 8: Guard against a new handler-only check

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/engine_config.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/engine_config.py
@@ -52,24 +52,19 @@ from agentclaw.community.adapters.http.openapi_v1.responses import (
 )
 from agentclaw.community.api.bot_service import BotServiceProtocol
 from agentclaw.community.api.engine_config_service import EngineConfigServiceProtocol
-from agentclaw.community.core.bot_management.services.bot_service import (
-    BotNotFoundError,
+from agentclaw.community.core.services.engine_config import (
+    engine_config_coords_from_record,
 )
-from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 from agentclaw.community.di import Injected
 from agentclaw.community.adapters.http.openapi_v1.authorization import PublicAPIRoute
 
 router = APIRouter(prefix="/openapi/v1/bots/{bot_id}/engine", tags=["bots"], route_class=PublicAPIRoute)
 
 
-def _engine_config_target(bot: dict[str, Any]) -> tuple[str, str, str]:
-    """Resolve (entity_id, entity_type, engine) for an engine-config call."""
-    entity_id = bot.get("entity_id")
-    if not entity_id:
-        raise BotNotFoundError("bot has no associated entity")
-    entity_type = bot.get("entity_type") or "staff"
-    engine = bot.get("active_engine") or DEFAULT_ENGINE_TYPE
-    return entity_id, entity_type, engine
+#: Where an engine-config call writes, and the ownership guard in the same
+#: call. Lives in ``core`` so manifest apply reaches the identical resolution
+#: without a request; bound here so both handlers below read as they did.
+_engine_config_coords = engine_config_coords_from_record
 
 
 #: Named explicitly, and the only two operations on this surface that are.
@@ -108,8 +103,10 @@ async def get_bot_engine_config(
     object — every engine keeps this configuration in a file its runtime creates
     on first use, so "not configured yet" is an ordinary state, not an error.
     """
-    bot = bot_service.get_bot(bot_id, owner_id)  # ownership/tenant guard
-    entity_id, entity_type, engine = _engine_config_target(bot)
+    coords = _engine_config_coords(bot_id, owner_id, bot_service=bot_service)
+    entity_id, entity_type, engine = (
+        coords.entity_id, coords.entity_type, coords.engine_type
+    )
     data = await engine_config_service.read_bot_config(
         bot_id=bot_id, owner_id=owner_id, entity_id=entity_id,
         entity_type=entity_type, engine_type=engine, stage=stage.value,
@@ -141,8 +138,10 @@ async def update_bot_engine_config(
     produced and is replaced by publishing again, never edited, so naming one is
     refused and nothing is written.
     """
-    bot = bot_service.get_bot(bot_id, owner_id)  # ownership/tenant guard
-    entity_id, entity_type, engine = _engine_config_target(bot)
+    coords = _engine_config_coords(bot_id, owner_id, bot_service=bot_service)
+    entity_id, entity_type, engine = (
+        coords.entity_id, coords.entity_type, coords.engine_type
+    )
     await engine_config_service.write_bot_config(
         bot_id=bot_id, owner_id=owner_id, entity_id=entity_id,
         entity_type=entity_type, engine_type=engine, config=body,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -122,7 +122,9 @@ from agentclaw.community.core.service_bot.errors import (
     ServicePublicationUnsupportedError,
 )
 
-from .engine_config import _engine_config_target
+from agentclaw.community.core.services.engine_config import (
+    engine_config_coords_from_bot,
+)
 from .startup_script_support import (
     _startup_script_payload,
     _startup_script_target,
@@ -1494,7 +1496,8 @@ async def trigger_bot_data_init(
     """
     bot = bot_service.get_bot(bot_id, owner_id)  # ownership/tenant guard (→ 404)
     _require_personal_cloud_bot(bot)
-    entity_id, entity_type, _engine = _engine_config_target(bot)
+    _coords = engine_config_coords_from_bot(bot, bot_id=bot_id, owner_id=owner_id)
+    entity_id, entity_type = _coords.entity_id, _coords.entity_type
 
     # Cookie parsing belongs to the HTTP adapter. The transport-agnostic service
     # decides whether and when the temporary credential must be persisted.

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/identity/router.py
@@ -36,7 +36,11 @@ from agentclaw.community.core.config_compose.teclaw_paths import IDENTITY_NS
 # class, not a Protocol — legacy identity router already does the same. A
 # Protocol would be speculative abstraction today (Rule 19: abstract after two
 # examples; only one IdentityService impl exists).
-from agentclaw.community.core.services.identity import IdentityService
+from agentclaw.community.core.services.identity import (
+    IdentityService,
+    identity_coords_from_record,
+    identity_physical_file_name,
+)
 from agentclaw.community.di import Injected
 
 from .schemas import (
@@ -80,9 +84,11 @@ async def list_bot_identity_files(
     with empty content. Entry order is not guaranteed — key off type.
     """
     # I2: entity_type/entity_id/operator_id come from the authenticated
-    # request's user_id parameter (personal bot owner = the named user).
-    entity_type = "staff"  # personal bot owner is a staff entity
-    entity_id = owner_id
+    # request's user_id parameter (personal bot owner = the named user). The
+    # pair is resolved in ``core`` so manifest apply addresses identity the same
+    # way without a request.
+    coords = identity_coords_from_record(bot_id, owner_id)
+    entity_type, entity_id = coords.entity_type, coords.entity_id
     presence = await identity_service.list_bot_files(
         entity_type,
         entity_id,
@@ -128,9 +134,9 @@ async def get_bot_identity_file(
     # validate_file_type requires the physical <type>.md form
     # (VALID_IDENTITY_FILES carries the suffix), so the enum value is
     # re-suffixed before forwarding.
-    entity_type = "staff"  # personal bot owner is a staff entity
-    entity_id = owner_id
-    file_type_md = f"{file_type.value}.md"
+    coords = identity_coords_from_record(bot_id, owner_id)
+    entity_type, entity_id = coords.entity_type, coords.entity_id
+    file_type_md = identity_physical_file_name(file_type.value)
     resp = await identity_service.get_bot_file(
         entity_type,
         entity_id,
@@ -177,9 +183,9 @@ async def update_bot_identity_file(
     """
     # I2: entity params come from the authenticated principal via UserIdDep
     # as above; validate_file_type requires the <type>.md form.
-    entity_type = "staff"  # personal bot owner is a staff entity
-    entity_id = owner_id
-    file_type_md = f"{file_type.value}.md"
+    coords = identity_coords_from_record(bot_id, owner_id)
+    entity_type, entity_id = coords.entity_type, coords.entity_id
+    file_type_md = identity_physical_file_name(file_type.value)
     resp = await identity_service.update_bot_file(
         entity_type,
         entity_id,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/mcp/router.py
@@ -116,6 +116,13 @@ ServerCodePath = Annotated[
 # The caller's own identity is used as both entity id and (staff) entity type
 # for the config push, mirroring the internal route's defaults and how the bots
 # slice threads ``entity_id=owner_id``.
+#
+# Not routed through ``core.mcp.config_flow.mcp_coords_from_record`` despite the
+# resemblance, and the difference is the point: this constant belongs to the
+# *account-level* config operations, which take no ``bot_id`` at all, while
+# those coordinates address one bot. A manifest never reaches this write — its
+# ``mcp`` category activates servers on a bot through ``DirectActivationService``
+# — so forcing the two together would state a sharing that does not exist.
 _ENTITY_TYPE = "staff"
 
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/resources/router.py
@@ -63,9 +63,6 @@ from agentclaw.community.adapters.http.openapi_v1.responses import (
     envelope_errors,
     page as page_envelope,
 )
-from agentclaw.community.core.bot_management.services.engine_resolver import (
-    resolve_runtime_engine_for_bot,
-)
 from agentclaw.community.core.devices.services.device_filesystem import (
     FileTooLargeError as DeviceFileTooLargeError,
 )
@@ -73,11 +70,14 @@ from agentclaw.community.core.repository.protocols.bot import BotRepository
 from agentclaw.community.core.resources.service import (
     DuplicateResourceError,
     FileTooLargeError,
-    InvalidResourcePathError,
 )
 from agentclaw.community.core.services.resource_file_service import (
     ResourceFileService,
     is_readonly,
+    is_write_forbidden,
+    require_workspace_path,
+    resource_coords_from_record,
+    safe_workspace_path,
 )
 from agentclaw.community.di import Injected
 from agentclaw.community.log import get_logger
@@ -120,86 +120,31 @@ _READ_ONLY_RESPONSE: dict[int | str, dict[str, object]] = {
 }
 
 
-def _safe_path(path: str) -> str:
-    """Normalize a caller-supplied workspace-relative path, or reject it.
-
-    Rejects any ``..`` segment outright instead of filtering it out. The console's
-    ``ResourceFileService.upload_file`` drops such segments silently
-    (``core/services/resource_file_service.py:409``) because it has to accept
-    whatever a browser sends for a whole-folder drag-upload; an explicit API has
-    no such caller, and quietly rewriting an address to a *different* valid one is
-    worse than refusing it — the caller is told nothing, and the file lands
-    somewhere they did not name.
-
-    This is the only barrier: neither ``build_workspace_mapper`` (which composes
-    with ``Path.__truediv__``, leaving ``..`` intact) nor the engine's
-    ``_convert_path`` normalizes or asserts containment. Engine-side bounding is
-    tracked in #1002.
-
-    Leading slashes and empty / ``.`` segments are normalized away rather than
-    rejected: they are noise, not an attempt to leave the workspace.
-    """
-    segments = [s for s in path.split("/") if s and s != "."]
-    if any(s == ".." for s in segments):
-        raise InvalidResourcePathError(f"path escapes the workspace: {path!r}")
-    return "/".join(segments)
-
-
-def _require_path(path: str) -> str:
-    """``_safe_path``, refusing the empty result.
-
-    Every endpoint but the listing addresses one entry, and the workspace root
-    is not one: there is nothing to download, delete or stat about it.
-    """
-    safe = _safe_path(path)
-    if not safe:
-        raise InvalidResourcePathError("path is required")
-    return safe
+#: The workspace-path rules, which live in ``core`` because they are statements
+#: about the workspace rather than about HTTP — and because manifest apply
+#: enforces the same ones with no request to hang them on. Bound here under the
+#: names this module has always used, so every call site below reads as it did;
+#: these are the core functions themselves, not wrappers, which is what
+#: ``test_config_surface.py`` pins with ``is``.
+_safe_path = safe_workspace_path
+_require_path = require_workspace_path
+_file_coords = resource_coords_from_record
 
 
 def _reject_read_only(safe: str) -> None:
     """Refuse a path the read-only policy protects, with the console's 403.
 
-    Applied to **creation** as well as deletion, so that the surface cannot be
-    talked into making something it then refuses to manage: a listing hides
-    dotfiles and the root identity files, and delete refuses them, so an upload
-    or mkdir that accepted one would leave an entry this API can neither show
-    nor remove. Uploading a workspace-root identity file would also overwrite
-    the bot's own configuration through a resource endpoint, which is not what
-    this surface is for.
-
-    Every ancestor is checked, not just the whole path. ``is_readonly`` looks at
-    the final segment only, so ``.private/file.md`` passes it — the leaf is an
-    ordinary name — while creating it brings a hidden ``.private`` directory into
-    existence along the way. Removing the visible descendant afterwards would
-    then leave a directory this API created and can neither list nor delete.
+    The *decision* is :func:`is_write_forbidden` in ``core``; this is the
+    protocol half, and it stays here deliberately. Core raising a domain error
+    that this module mapped back would have to reproduce this body exactly, and
+    "reproduced exactly" is a claim to verify where "never moved" is a fact. The
+    rule this feature is applying — an adapter may map errors, it may not own
+    policy — puts the line right here.
     """
-    segments = safe.split("/")
-    for depth in range(len(segments)):
-        ancestor = "/".join(segments[: depth + 1])
-        if is_readonly(ancestor):
-            raise HTTPException(
-                status_code=403, detail="Cannot write to a read-only path"
-            )
-
-
-def _file_coords(
-    bot_id: str, owner_id: str, bot_repo: BotRepository
-) -> tuple[str, str, str]:
-    """``(entity_type, entity_id, engine_type)`` for the file endpoints.
-
-    ``ResourceFileService`` addresses a bot's workspace by these three
-    coordinates, and ``DeviceContext`` carries none of them — it holds
-    provider / conn_info / binding only. Mirrors the console router's
-    ``_resolve_params`` (``adapters/http/resources/file_router.py:71``): the
-    entity is the bot owner, and ``engine_type`` defaults to the bot's
-    ``active_engine``. ``entity_type`` is ``"staff"``, matching
-    ``ResourceFileService``'s own default.
-    """
-    engine_type = resolve_runtime_engine_for_bot(
-        bot_id=bot_id, owner_id=owner_id, override=None, bot_repo=bot_repo
-    )
-    return ("staff", owner_id, engine_type)
+    if is_write_forbidden(safe):
+        raise HTTPException(
+            status_code=403, detail="Cannot write to a read-only path"
+        )
 
 
 def _to_file_entry(entry: dict[str, Any]) -> FileEntry:
@@ -237,7 +182,10 @@ async def _list_dir_or_empty(
     for an absent directory, so without this the same request is a 500 on baas
     and an empty page everywhere else. Every other status still propagates.
     """
-    entity_type, entity_id, engine_type = _file_coords(bot_id, owner_id, bot_repo)
+    coords = _file_coords(bot_id, owner_id, bot_repo)
+    entity_type, entity_id, engine_type = (
+        coords.entity_type, coords.entity_id, coords.engine_type
+    )
     try:
         listed = await file_svc.list_dir(
             entity_type=entity_type,
@@ -402,7 +350,10 @@ async def upload_resource(
     # fail-closed — mirroring the bots router.
     safe = _require_path(path)
     _reject_read_only(safe)
-    entity_type, entity_id, engine_type = _file_coords(bot_id, owner_id, bot_repo)
+    coords = _file_coords(bot_id, owner_id, bot_repo)
+    entity_type, entity_id, engine_type = (
+        coords.entity_type, coords.entity_id, coords.engine_type
+    )
     # Duplicate detection against the workspace, not the record table. Uploading
     # to an occupied path would otherwise overwrite silently, since the engine's
     # upload is a plain write. Asking the filesystem also fixes the old false
@@ -563,7 +514,10 @@ async def _read_file_or_404(
 ) -> bytes:
     """Bytes at ``path``, or 404. Shared by download and preview."""
     safe = _require_path(path)
-    entity_type, entity_id, engine_type = _file_coords(bot_id, owner_id, bot_repo)
+    coords = _file_coords(bot_id, owner_id, bot_repo)
+    entity_type, entity_id, engine_type = (
+        coords.entity_type, coords.entity_id, coords.engine_type
+    )
     try:
         content = await file_svc.read_file(
             entity_type=entity_type,
@@ -697,7 +651,10 @@ async def create_directory(
     # exactly the record-vs-filesystem divergence this change removed.
     safe = _require_path(path)
     _reject_read_only(safe)
-    entity_type, entity_id, engine_type = _file_coords(bot_id, owner_id, bot_repo)
+    coords = _file_coords(bot_id, owner_id, bot_repo)
+    entity_type, entity_id, engine_type = (
+        coords.entity_type, coords.entity_id, coords.engine_type
+    )
     await file_svc.create_directory(
         entity_type=entity_type,
         entity_id=entity_id,
@@ -744,7 +701,10 @@ async def delete_file(
     # id-addressed delete could not name them and needed no guard.
     if is_readonly(safe):
         raise HTTPException(status_code=403, detail="Cannot delete read-only file")
-    entity_type, entity_id, engine_type = _file_coords(bot_id, owner_id, bot_repo)
+    coords = _file_coords(bot_id, owner_id, bot_repo)
+    entity_type, entity_id, engine_type = (
+        coords.entity_type, coords.entity_id, coords.engine_type
+    )
     if not await file_svc.exists(
         entity_type=entity_type,
         entity_id=entity_id,

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/skills/router.py
@@ -53,9 +53,11 @@ from agentclaw.community.api.skill_query_service import (
 from agentclaw.community.api.local_skill_upload_service import (
     LocalSkillUploadServiceProtocol,
 )
+from agentclaw.community.core.skill_center.services.skill_query_service import (
+    require_addressed_bot,
+)
 from agentclaw.community.core.skill_center.errors import (
     LocalSkillInvalidPackageError,
-    LocalSkillNotFoundError,
 )
 from agentclaw.community.di import Injected
 from agentclaw.community.plugin_api.skill_center_client import (
@@ -192,29 +194,19 @@ def _tags(value: Any) -> list[str]:
     return []
 
 
-def _require_addressed_bot(record: dict[str, Any], bot_id: str) -> None:
-    """The skill must belong to the bot the address names.
-
-    Without this the ``{bot_id}`` segment on the four ``{skill_id}`` operations
-    would be decorative — a client could name any bot and reach a skill on
-    another one, which is the precise defect this addressing change exists to
-    remove. A skill id resolves its own bot, so the two can be compared, and a
-    mismatch is answered as the skill not existing.
-
-    Masked as a 404 rather than reported as a mismatch, for the same reason the
-    rest of the surface masks: a distinguishable "wrong bot" answer confirms the
-    skill exists somewhere, which is an enumeration oracle over other people's
-    bots.
-
-    The legacy addresses take no bot and so cannot make this comparison; they
-    keep exactly the behaviour they have today.
-    """
-    if str(record["bolt_id"]) != bot_id:
-        raise LocalSkillNotFoundError()
+#: "This skill belongs to the bot the address names" — a statement about a
+#: record, so it lives in ``core`` and manifest apply reaches the same one.
+_require_addressed_bot = require_addressed_bot
 
 
 def _require_skills_grant(caller: ActingCaller, record: dict[str, Any]) -> None:
     """Bind the grant to the ``(bot, owner)`` this skill actually belongs to.
+
+    **Stays in the adapter deliberately** (Rule 7: an adapter may interpret
+    auth, it may not own domain policy). It takes an ``ActingCaller``, which is
+    an adapter type, and an application grant is a fact about an HTTP caller —
+    manifest apply arrives as its own operation with its own grant already
+    checked at its own door, so it has nothing to re-ask here.
 
     Both halves come off the record. A skill can belong to another owner's bot
     and still be readable here — the user-scoped read admits a collaborator — so
@@ -254,7 +246,11 @@ def _uploaded_skill_response(
 def _directory_relative_paths(
     raw_paths: str | None, files: list[UploadFile]
 ) -> list[str]:
-    """Preserve the legacy multipart folder wire without trusting filenames."""
+    """Preserve the legacy multipart folder wire without trusting filenames.
+
+    **Stays in the adapter deliberately** (Rule 7): parsing a multipart form is
+    protocol validation, and a manifest has no multipart wire to parse.
+    """
     if raw_paths is None:
         paths = [file.filename or "" for file in files]
     else:

--- a/src/backend/src/agentclaw/community/core/bot_config_surface/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_config_surface/README.md
@@ -1,0 +1,43 @@
+# `agentclaw.community.core.bot_config_surface`
+
+The rules the public config surface enforces for the five categories manifest
+apply touches, named in one place so the HTTP router and apply run the same
+ones.
+
+## Context Boundary
+
+```yaml
+purpose: "Index of the checks governing each bot-config category, so the openapi_v1 routers and manifest apply enforce one set of rules rather than two copies."
+provides:
+  - "BotConfigCoords"
+  - "CategoryChecks"
+  - "CONFIG_SURFACE"
+consumes:
+  - "BotService (engine_config's ownership guard resolves through it)"
+  - "BotRepository (resources resolves the bot's engine through it)"
+internal_dependencies:
+  - agentclaw.community.core.mcp
+  - agentclaw.community.core.services
+  - agentclaw.community.core.skill_center
+```
+
+### Change impact
+
+This module is an **index, and must not grow logic**. Every callable it names is
+defined in the package that owns that category's domain and imported here by
+reference; a rule implemented here would be a rule the routers do not run, which
+is the drift the module exists to prevent. Its fan-out across six core packages
+is therefore the purpose rather than a smell.
+
+What notices a change here: manifest apply (#1472) dispatches per category
+through `CONFIG_SURFACE`, and create-with-manifest (#1696) calls the `from_spec`
+half at preflight, before a bot record exists. The `openapi_v1` routers for
+resources, identity, skills and engine-config call the same objects directly —
+`tests/community/core/bot_config_surface/` asserts with `is` that they are the
+same objects, so adding a row without pointing it at the function the router
+really calls fails there rather than silently.
+
+`coords.py` is deliberately a leaf that imports nothing from the project, and
+`__init__.py` re-exports nothing: the category homes import `coords`, and
+`table` imports *from* those homes, so a re-export would turn importing the leaf
+into a cycle.

--- a/src/backend/src/agentclaw/community/core/bot_config_surface/__init__.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_surface/__init__.py
@@ -1,0 +1,8 @@
+"""The rules the public config surface enforces, named in one place.
+
+Deliberately empty of imports. ``coords`` is a leaf that the five category
+homes import, and ``table`` imports *from* those homes — so re-exporting either
+here would make importing the leaf trigger the table, and the cycle that
+follows is not worth the two saved keystrokes at each call site. Import
+:mod:`.coords` and :mod:`.table` by name.
+"""

--- a/src/backend/src/agentclaw/community/core/bot_config_surface/coords.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_surface/coords.py
@@ -1,0 +1,38 @@
+"""Where one config category writes, addressed without reference to a request.
+
+Four of the five categories on this surface need the same three values to reach
+a bot's storage — ``entity_type``, ``entity_id``, ``engine_type`` — and today
+each router computes them privately, in its own handler bodies, four different
+ways. This is the type they all produce, so that the difference between them is
+visible in one place rather than invisible in four.
+
+**Two sources, one type.** A category resolves these from a bot record for a bot
+that exists, and from the create request's parameters for one that does not yet
+(W13 validates a manifest at preflight, before the bot record is written —
+``core/bot_management/create_flow.py`` mints the id and the Passport identity in
+its first phase and creates nothing). Both produce this, so a validator handed
+one cannot tell which path it came from, which is what lets a single validation
+path serve both entries.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BotConfigCoords:
+    """One category's write address for one bot.
+
+    ``engine_type`` is ``str | None`` with no default, and both are deliberate.
+    ``identity`` and ``mcp`` address no engine at all, so there is no value to
+    give them; defaulting it would hand them an engine they never had, and
+    making it optional would let a category that *does* need one be constructed
+    without it.
+    """
+
+    bot_id: str
+    owner_id: str
+    entity_type: str
+    entity_id: str
+    engine_type: str | None

--- a/src/backend/src/agentclaw/community/core/bot_config_surface/table.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_surface/table.py
@@ -1,0 +1,125 @@
+"""Every rule the public surface enforces for one config category, in one list.
+
+The five categories manifest apply touches — ``identity``, ``resources``,
+``skills``, ``mcp``, ``engine_config`` — each enforced their rules inside the
+handler bodies of their own ``openapi_v1`` router, where nothing but a request
+could reach them. This names what governs each, now that each lives in ``core``.
+
+**This module is an index. It must not grow logic.** Every callable named below
+is defined in the package that owns that category's domain, and is imported here
+by reference. A rule implemented *in* this file would be a rule the router does
+not run, which is the drift the whole arrangement exists to prevent.
+
+The guarantee is not that these names exist — it is that they are the **same
+objects** the routers call. ``tests/community/core/bot_config_surface/`` pins
+that with ``is``, so a router growing a private copy of one fails a test rather
+than quietly diverging.
+
+Two fields for coordinates rather than one, because they have different
+requirements. ``from_record`` reads a bot record. ``from_spec`` reads a create
+request's parameters, for the create path, where the manifest is validated at
+preflight and no bot record exists yet
+(``core/bot_management/create_flow.py``). Both return
+:class:`~.coords.BotConfigCoords`, so a validator handed one cannot tell which
+it came from — which is what lets one validation path serve both entries.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from agentclaw.community.core.bot_config_surface.coords import BotConfigCoords
+from agentclaw.community.core.mcp.config_flow import (
+    mcp_coords_from_record,
+    mcp_coords_from_spec,
+)
+from agentclaw.community.core.services.engine_config import (
+    engine_config_coords_from_record,
+    engine_config_coords_from_spec,
+)
+from agentclaw.community.core.services.identity import (
+    identity_coords_from_record,
+    identity_coords_from_spec,
+    identity_physical_file_name,
+)
+from agentclaw.community.core.services.resource_file_service import (
+    is_write_forbidden,
+    require_workspace_path,
+    resource_coords_from_record,
+    resource_coords_from_spec,
+    safe_workspace_path,
+)
+from agentclaw.community.core.skill_center.services.skill_query_service import (
+    require_addressed_bot,
+    skill_coords_from_record,
+    skill_coords_from_spec,
+)
+
+
+@dataclass(frozen=True)
+class CategoryChecks:
+    """What governs one config category.
+
+    ``validators`` are record-free by contract: given values, they answer. That
+    is what lets the create path run them at preflight, and the record-free test
+    is what holds them to it.
+    """
+
+    category: str
+    from_record: Callable[..., BotConfigCoords]
+    from_spec: Callable[..., BotConfigCoords]
+    validators: tuple[Callable[..., Any], ...]
+
+
+#: The categories manifest apply touches, each exactly once.
+#:
+#: ``engine_config`` carries a row although W4 excludes it from the first phase
+#: (§4, X2/T3): the seam is where it plugs in when its materializer returns, and
+#: a row missing then is a row nobody remembers is missing.
+#:
+#: ``mcp``'s ``validators`` is empty, and that is a finding rather than a gap.
+#: Its router held no domain policy to move — the permission rule for a
+#: ``server_code`` already lives in ``DirectActivationService``, and the unified
+#: config flow already lives in ``core.mcp.config_flow``. The category the
+#: manifest work most expected to need this seam turned out to have arrived
+#: already.
+CONFIG_SURFACE: dict[str, CategoryChecks] = {
+    "identity": CategoryChecks(
+        category="identity",
+        from_record=identity_coords_from_record,
+        from_spec=identity_coords_from_spec,
+        validators=(identity_physical_file_name,),
+    ),
+    "resources": CategoryChecks(
+        category="resources",
+        from_record=resource_coords_from_record,
+        from_spec=resource_coords_from_spec,
+        validators=(
+            safe_workspace_path,
+            require_workspace_path,
+            is_write_forbidden,
+        ),
+    ),
+    "skills": CategoryChecks(
+        category="skills",
+        from_record=skill_coords_from_record,
+        from_spec=skill_coords_from_spec,
+        validators=(require_addressed_bot,),
+    ),
+    "mcp": CategoryChecks(
+        category="mcp",
+        from_record=mcp_coords_from_record,
+        from_spec=mcp_coords_from_spec,
+        validators=(),
+    ),
+    "engine_config": CategoryChecks(
+        category="engine_config",
+        from_record=engine_config_coords_from_record,
+        from_spec=engine_config_coords_from_spec,
+        validators=(),
+    ),
+}
+
+__all__ = ["CONFIG_SURFACE", "CategoryChecks"]

--- a/src/backend/src/agentclaw/community/core/mcp/README.md
+++ b/src/backend/src/agentclaw/community/core/mcp/README.md
@@ -42,6 +42,7 @@ consumes:
   - "PassportPlugin"
   - "CallerIdentityRepositoryProtocol"
 internal_dependencies:
+  - agentclaw.community.core.bot_config_surface    # BotConfigCoords, the shared config-category address type
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.identity # Caller identity overrides used for Passport scope sync
   - agentclaw.community.core.default_capabilities

--- a/src/backend/src/agentclaw/community/core/mcp/config_flow.py
+++ b/src/backend/src/agentclaw/community/core/mcp/config_flow.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from agentclaw.community.core.bot_config_surface.coords import BotConfigCoords
 from agentclaw.community.core.mcp.errors import (
     McpConfigValueError,
     McpHeadersInvalidError,
@@ -58,6 +59,35 @@ class UnifiedConfig:
     # ``has_config``. Always ``True`` for a write result.
     exists: bool = field(default=True)
     sync_results: list[dict[str, Any]] | None = field(default=None)
+
+
+def mcp_coords_from_record(bot_id: str, owner_id: str) -> BotConfigCoords:
+    """Where the ``mcp`` category writes, for a bot that exists.
+
+    The caller's own identity is both entity id and (staff) entity type for a
+    config push, mirroring the internal route's defaults and how the bots slice
+    threads ``entity_id=owner_id``. The public router spelled this as a private
+    ``_ENTITY_TYPE`` constant; it is a function here so the table can name it
+    and manifest apply can call it.
+
+    ``engine_type`` is ``None`` — MCP configuration is per account and per
+    server, with no engine dimension.
+    """
+    return BotConfigCoords(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        entity_type="staff",
+        entity_id=owner_id,
+        engine_type=None,
+    )
+
+
+def mcp_coords_from_spec(bot_id: str, owner_id: str) -> BotConfigCoords:
+    """The same address, for a bot that does not exist yet.
+
+    No caller until W13 (#1696).
+    """
+    return mcp_coords_from_record(bot_id, owner_id)
 
 
 def _validate_endpoint_env(endpoint_env: str | None) -> None:

--- a/src/backend/src/agentclaw/community/core/services/engine_config.py
+++ b/src/backend/src/agentclaw/community/core/services/engine_config.py
@@ -28,7 +28,12 @@ import json
 
 from injector import inject
 
+from agentclaw.community.core.bot_config_surface.coords import BotConfigCoords
+from agentclaw.community.core.bot_management.services.bot_service import (
+    BotNotFoundError,
+)
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
 from agentclaw.community.core.config_compose.teclaw_paths import (
     CONFIG_NS,
     TECLAW_ENGINE_CONFIG_FILE,
@@ -65,6 +70,89 @@ logger = get_logger()
 # — a smell. Cleaner: make `config` a leaf-less namespace where each provider's mapper
 # owns the full filename, so callers pass no provider-specific name. Solve separately.
 _CONFIG_LOGICAL_PATH = f"{CONFIG_NS}/{TECLAW_ENGINE_CONFIG_FILE}"
+
+
+def engine_config_coords_from_record(
+    bot_id: str, owner_id: str, *, bot_service
+) -> BotConfigCoords:
+    """Where the ``engine_config`` category writes, for a bot that exists.
+
+    **This is the ownership guard as well as the address**, and the two are one
+    call on purpose: ``bot_service.get_bot(bot_id, owner_id)`` resolves the bot
+    only for the named owner, so a bot that is not theirs is indistinguishable
+    from one that does not exist, and the record it returns is the same record
+    the coordinates are read off. Check and address cannot disagree, because
+    there is only one lookup.
+
+    Alone among the five categories this one guards explicitly; ``resources``
+    performs no ownership check at all. That difference is preserved rather than
+    reconciled — closing it changes who the resources endpoints admit, which is
+    a behaviour change and belongs to its own review.
+
+    Raises ``BotNotFoundError`` on both of the paths the router raised it on: an
+    unresolvable bot, and a resolvable bot carrying no ``entity_id``.
+    """
+    return engine_config_coords_from_bot(
+        bot_service.get_bot(bot_id, owner_id), bot_id=bot_id, owner_id=owner_id
+    )
+
+
+def engine_config_coords_from_bot(
+    bot: dict, *, bot_id: str, owner_id: str
+) -> BotConfigCoords:
+    """The record-to-address half, for a caller that already holds the record.
+
+    Split out because there are two such callers and they guard differently:
+    the engine-config operations resolve the bot *as* their guard (above), while
+    the data-init operation fetches it, applies its own bot-type rule, and only
+    then needs the address (``openapi_v1/bots/router.py:1495``). Folding the
+    fetch in would make that second caller resolve the same bot twice, which is
+    a behaviour change dressed as a tidy-up.
+
+    Raises ``BotNotFoundError`` when the record carries no ``entity_id`` — a
+    resolvable bot that cannot be addressed.
+    """
+    entity_id = bot.get("entity_id")
+    if not entity_id:
+        raise BotNotFoundError("bot has no associated entity")
+    return BotConfigCoords(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        entity_type=bot.get("entity_type") or "staff",
+        entity_id=entity_id,
+        engine_type=bot.get("active_engine") or DEFAULT_ENGINE_TYPE,
+    )
+
+
+def engine_config_coords_from_spec(
+    bot_id: str,
+    owner_id: str,
+    *,
+    entity_id: str,
+    entity_type: str | None,
+    engine_type: str | None,
+) -> BotConfigCoords:
+    """The same address, for a bot that does not exist yet.
+
+    Every value comes off the create request, because in the create flow's first
+    phase there is no record to read one from. **No ownership guard, and there
+    cannot be one**: nothing exists to own. Whether the caller may create a bot
+    at all is settled by ``check_create_bot_preflight``
+    (``core/bot_management/create_flow.py:494``), beside which W13 validates the
+    manifest.
+
+    The two defaults match the record path exactly, so a bot validated at
+    preflight and then created resolves to the same coordinates both times.
+
+    No caller until W13 (#1696).
+    """
+    return BotConfigCoords(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        entity_type=entity_type or "staff",
+        entity_id=entity_id,
+        engine_type=engine_type or DEFAULT_ENGINE_TYPE,
+    )
 
 
 def _decode_config(content_bytes: bytes | None) -> dict:

--- a/src/backend/src/agentclaw/community/core/services/identity.py
+++ b/src/backend/src/agentclaw/community/core/services/identity.py
@@ -15,6 +15,7 @@ import httpx
 from injector import inject
 from pydantic import BaseModel, Field
 
+from agentclaw.community.core.bot_config_surface.coords import BotConfigCoords
 from agentclaw.community.core.errors import InternalError
 from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
@@ -177,6 +178,55 @@ class BotIdentityFileUpdateResponse(BaseModel):
     entity_id: str
     bot_id: str
     file_path: str
+
+
+def identity_physical_file_name(file_type: str) -> str:
+    """The on-disk name for an identity file type — ``SOUL`` → ``SOUL.md``.
+
+    :meth:`IdentityService.validate_file_type` checks against
+    ``VALID_IDENTITY_FILES``, whose entries carry the ``.md`` suffix, so the
+    logical type a caller names has to be re-suffixed before it is forwarded.
+    The public router did that inline, three times, with a bare f-string; a
+    manifest declares identity entries by the same logical type and needs the
+    same conversion, so it is one function now rather than a fourth copy.
+
+    Reaches no repository, which is what lets W13 run it at preflight.
+    """
+    return f"{file_type}.md"
+
+
+def identity_coords_from_record(bot_id: str, owner_id: str) -> BotConfigCoords:
+    """Where the ``identity`` category writes, for a bot that exists.
+
+    ``engine_type`` is ``None``: identity files are addressed through the
+    identity namespace, not per engine, and the router never resolved one.
+    Handing this category an engine it never had would be an invention, so the
+    field states the absence instead.
+
+    Despite the name this reads no bot record — the entity *is* the owner, and
+    ``"staff"`` is the personal-bot surface's fixed entity type. It is named for
+    symmetry with the other four, so the table has one shape.
+    """
+    return BotConfigCoords(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        entity_type="staff",
+        entity_id=owner_id,
+        engine_type=None,
+    )
+
+
+def identity_coords_from_spec(bot_id: str, owner_id: str) -> BotConfigCoords:
+    """The same address, for a bot that does not exist yet.
+
+    Identical to the record path, and that is the finding rather than an
+    oversight: identity's coordinates never depended on the record, so creating
+    a bot changes nothing about them. Kept as its own function so every category
+    presents both entry points and the table stays one shape.
+
+    No caller until W13 (#1696).
+    """
+    return identity_coords_from_record(bot_id, owner_id)
 
 
 class IdentityService:

--- a/src/backend/src/agentclaw/community/core/services/resource_file_service.py
+++ b/src/backend/src/agentclaw/community/core/services/resource_file_service.py
@@ -35,7 +35,12 @@ from typing import Any
 from injector import inject
 
 from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.bot_config_surface.coords import BotConfigCoords
+from agentclaw.community.core.bot_management.services.engine_resolver import (
+    resolve_runtime_engine_for_bot,
+)
 from agentclaw.community.core.config_compose.teclaw_paths import WORKSPACE_NS
+from agentclaw.community.core.resources.service import InvalidResourcePathError
 from agentclaw.community.core.devices.services.device_context import (
     ConnInfoBuildError,
     DeviceContext,
@@ -92,6 +97,132 @@ def is_readonly(path: str) -> bool:
     if "/" not in path and basename in _HIDDEN_BASENAMES:
         return True
     return False
+
+
+def safe_workspace_path(path: str) -> str:
+    """Normalize a caller-supplied workspace-relative path, or reject it.
+
+    Rejects any ``..`` segment outright instead of filtering it out. The console's
+    ``ResourceFileService.upload_file`` drops such segments silently
+    (``core/services/resource_file_service.py:409``) because it has to accept
+    whatever a browser sends for a whole-folder drag-upload; an explicit API has
+    no such caller, and quietly rewriting an address to a *different* valid one is
+    worse than refusing it — the caller is told nothing, and the file lands
+    somewhere they did not name.
+
+    This is the only barrier: neither ``build_workspace_mapper`` (which composes
+    with ``Path.__truediv__``, leaving ``..`` intact) nor the engine's
+    ``_convert_path`` normalizes or asserts containment. Engine-side bounding is
+    tracked in #1002.
+
+    Leading slashes and empty / ``.`` segments are normalized away rather than
+    rejected: they are noise, not an attempt to leave the workspace.
+
+    Lives here rather than in the router that used to own it (as ``_safe_path``)
+    because it is a statement about the workspace, not about HTTP — and because
+    manifest apply enforces the same rule without a request to hang it on.
+    """
+    segments = [s for s in path.split("/") if s and s != "."]
+    if any(s == ".." for s in segments):
+        raise InvalidResourcePathError(f"path escapes the workspace: {path!r}")
+    return "/".join(segments)
+
+
+def require_workspace_path(path: str) -> str:
+    """``safe_workspace_path``, refusing the empty result.
+
+    Every endpoint but the listing addresses one entry, and the workspace root
+    is not one: there is nothing to download, delete or stat about it.
+    """
+    safe = safe_workspace_path(path)
+    if not safe:
+        raise InvalidResourcePathError("path is required")
+    return safe
+
+
+def is_write_forbidden(safe: str) -> bool:
+    """Whether the read-only policy protects this path against creation.
+
+    Applied to **creation** as well as deletion, so that the surface cannot be
+    talked into making something it then refuses to manage: a listing hides
+    dotfiles and the root identity files, and delete refuses them, so an upload
+    or mkdir that accepted one would leave an entry this API can neither show
+    nor remove. Uploading a workspace-root identity file would also overwrite
+    the bot's own configuration through a resource endpoint, which is not what
+    that surface is for.
+
+    Every ancestor is checked, not just the whole path. :func:`is_readonly` looks
+    at the final segment only, so ``.private/file.md`` passes it — the leaf is an
+    ordinary name — while creating it brings a hidden ``.private`` directory into
+    existence along the way. Removing the visible descendant afterwards would
+    then leave a directory this API created and can neither list nor delete.
+
+    Returns a verdict and raises nothing, deliberately. The refusal the public
+    API answers is an ``HTTPException`` with a specific body, and mapping a
+    domain error back onto that body byte-for-byte is harder to be sure of than
+    leaving the ``raise`` where it already is. Core decides; the adapter phrases.
+    """
+    segments = safe.split("/")
+    return any(
+        is_readonly("/".join(segments[: depth + 1]))
+        for depth in range(len(segments))
+    )
+
+
+def resource_coords_from_record(
+    bot_id: str, owner_id: str, bot_repo: BotRepository
+) -> BotConfigCoords:
+    """Where the ``resources`` category writes, for a bot that exists.
+
+    ``ResourceFileService`` addresses a bot's workspace by these three
+    coordinates, and ``DeviceContext`` carries none of them — it holds
+    provider / conn_info / binding only. Mirrors the console router's
+    ``_resolve_params`` (``adapters/http/resources/file_router.py:71``): the
+    entity is the bot owner, and ``engine_type`` defaults to the bot's
+    ``active_engine``. ``entity_type`` is ``"staff"``, matching
+    ``ResourceFileService``'s own default.
+
+    **This performs no ownership guard**, which is a preserved fact rather than
+    an oversight of the move: the router's ``_file_coords`` performed none
+    either, and adding one here would change who the resources endpoints admit.
+    That it differs from ``engine_config``'s equivalent — which does guard — is
+    exactly what putting the five side by side was meant to make visible.
+    """
+    engine_type = resolve_runtime_engine_for_bot(
+        bot_id=bot_id, owner_id=owner_id, override=None, bot_repo=bot_repo
+    )
+    return BotConfigCoords(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        entity_type="staff",
+        entity_id=owner_id,
+        engine_type=engine_type,
+    )
+
+
+def resource_coords_from_spec(
+    bot_id: str, owner_id: str, engine_type: str
+) -> BotConfigCoords:
+    """The same address, for a bot that does not exist yet.
+
+    The engine comes from the create request instead of the bot's
+    ``active_engine``, because in the first phase of the create flow there is no
+    record to read one off. No repository is touched and no ownership is
+    checked: there is nothing yet to own, and whether the caller may create a
+    bot at all is what ``check_create_bot_preflight`` already decides
+    (``core/bot_management/create_flow.py:494``), beside which the manifest is
+    validated.
+
+    No caller until W13 (#1696).
+    """
+    return BotConfigCoords(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        entity_type="staff",
+        entity_id=owner_id,
+        engine_type=engine_type,
+    )
+
 
 
 class ResourceFileService:

--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -117,6 +117,7 @@ consumes:
   - "HttpClient"
   - "ServiceArtifactLineageReaderProtocol"
 internal_dependencies:
+  - agentclaw.community.core.bot_config_surface    # BotConfigCoords, the shared config-category address type
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.skill_center    # repository contracts consumed by this module
   - agentclaw.community.core.repository.protocols.space_skill_version # published Space Skill read contract consumed by this module

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_query_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_query_service.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Protocol, TYPE_CHECKING
 from injector import inject
 
 from agentclaw.community.core.skill_center.skill_query_service_protocol import SkillQueryServiceProtocol
+from agentclaw.community.core.bot_config_surface.coords import BotConfigCoords
 from agentclaw.community.core.bot_collaborator.models import PermissionLevel
 from agentclaw.community.core.bot_collaborator.protocols import (
     CollaboratorServiceProtocol,
@@ -43,6 +44,58 @@ if TYPE_CHECKING:
     from agentclaw.community.core.devices.services.device_context_resolver import (
         DeviceContextResolver,
     )
+
+
+def require_addressed_bot(record: dict[str, Any], bot_id: str) -> None:
+    """The skill must belong to the bot the address names.
+
+    Without this the ``{bot_id}`` segment on the ``{skill_id}`` operations would
+    be decorative — a client could name any bot and reach a skill on another
+    one, which is the precise defect bot-first addressing exists to remove. A
+    skill id resolves its own bot, so the two can be compared, and a mismatch is
+    answered as the skill not existing.
+
+    Masked as a 404 rather than reported as a mismatch, for the same reason the
+    rest of the surface masks: a distinguishable "wrong bot" answer confirms the
+    skill exists somewhere, which is an enumeration oracle over other people's
+    bots.
+
+    Lives here rather than in the router that used to own it: it is a statement
+    about a skill record, not about a request, and manifest apply reaching
+    skills by id needs the same comparison.
+    """
+    if str(record["bolt_id"]) != bot_id:
+        raise LocalSkillNotFoundError()
+
+
+def skill_coords_from_record(bot_id: str, owner_id: str) -> BotConfigCoords:
+    """Where the ``skills`` category writes, for a bot that exists.
+
+    ``engine_type`` is ``None``: the skill services address a bot by
+    ``(bot_id, owner_id)`` and resolve any engine detail themselves, so there is
+    no engine for this category to carry.
+    """
+    return BotConfigCoords(
+        bot_id=bot_id,
+        owner_id=owner_id,
+        entity_type="staff",
+        entity_id=owner_id,
+        engine_type=None,
+    )
+
+
+def skill_coords_from_spec(bot_id: str, owner_id: str) -> BotConfigCoords:
+    """The same address, for a bot that does not exist yet.
+
+    Note what has no equivalent here: :func:`require_addressed_bot` compares a
+    skill record against an address, and at preflight a manifest's declared
+    skills have no records to compare — they do not exist yet. That validation
+    is inherently record-bound and simply does not run on the create path.
+    Saying so is better than inventing a check that would always pass.
+
+    No caller until W13 (#1696).
+    """
+    return skill_coords_from_record(bot_id, owner_id)
 
 
 class SkillAssetKind(StrEnum):

--- a/src/backend/tests/community/architecture/test_http_adapter_layer_is_http_only.py
+++ b/src/backend/tests/community/architecture/test_http_adapter_layer_is_http_only.py
@@ -278,6 +278,24 @@ _CORE_SERVICE_NAMES_OK: frozenset[str] = frozenset({
     "is_readonly",
     "_HIDDEN_BASENAMES", "_HIDDEN_DIRNAMES",
     "_POOL_SKILLS_LOCAL_RELPATH", "_SKILLS_LOCAL_RELPATH",
+    # The bot-config seam (#1509): the rules each config category enforces,
+    # moved out of the router handler bodies that used to own them so that
+    # manifest apply runs the same ones instead of a second copy. Same family
+    # as ``is_readonly`` directly above and the pure helpers below — module-level
+    # functions over values, not service instances to resolve through Injected.
+    # This entry is *why* they are allowed here, so read it before adding more:
+    # a name belongs on this list only if it is a pure function or a domain
+    # type. A stateful service still goes through its Protocol.
+    #
+    # ``core/bot_config_surface/table.py`` names these same objects, and
+    # ``tests/community/core/bot_config_surface/`` asserts with ``is`` that the
+    # routers and that table hold the identical function — so this list and that
+    # one cannot drift onto different implementations.
+    "safe_workspace_path", "require_workspace_path", "is_write_forbidden",
+    "resource_coords_from_record",
+    "identity_coords_from_record", "identity_physical_file_name",
+    "require_addressed_bot",
+    "engine_config_coords_from_record", "engine_config_coords_from_bot",
     # Genuine pre-existing violations, NOT endorsements. Both are concrete
     # service classes injected directly by routers that predate this guard
     # covering their path; the engine-config service in the same directory was

--- a/src/backend/tests/community/architecture/test_module_boundaries.py
+++ b/src/backend/tests/community/architecture/test_module_boundaries.py
@@ -70,6 +70,7 @@ BOUNDARY_SIGNIFICANT_MODULES: frozenset[str] = frozenset({
     "agentclaw.community.core.approval",
     "agentclaw.community.core.auth",
     "agentclaw.community.core.bot_app_grant",
+    "agentclaw.community.core.bot_config_surface",
     "agentclaw.community.core.bot_chat",
     "agentclaw.community.core.bot_management",
     "agentclaw.community.core.bot_public",

--- a/src/backend/tests/community/core/bot_config_surface/test_config_surface.py
+++ b/src/backend/tests/community/core/bot_config_surface/test_config_surface.py
@@ -1,0 +1,187 @@
+"""The table is only worth having if it names what the routers actually call.
+
+A table listing functions that merely *resemble* the router's would be worse
+than no table: it would document a guarantee that does not hold, and a reviewer
+reading it would stop looking. So the assertions here are ``is``, not ``==`` —
+two functions with identical behaviour are precisely the failure this file
+exists to catch, because that is what drift looks like on the day it starts.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+from agentclaw.community.core.bot_config_surface.coords import BotConfigCoords
+from agentclaw.community.core.bot_config_surface.table import CONFIG_SURFACE
+from agentclaw.community.core.resources.service import InvalidResourcePathError
+from agentclaw.community.core.skill_center.errors import LocalSkillNotFoundError
+
+#: The categories manifest apply touches. ``engine_config`` is here although
+#: W4 excludes it from the first phase — the row must exist before its
+#: materializer returns, or nobody discovers it is missing until then.
+EXPECTED_CATEGORIES = frozenset(
+    {"identity", "resources", "skills", "mcp", "engine_config"}
+)
+
+
+def test_table_covers_exactly_the_categories_apply_touches():
+    assert set(CONFIG_SURFACE) == EXPECTED_CATEGORIES, (
+        "CONFIG_SURFACE must carry one row per category manifest apply can "
+        "materialize. Missing: "
+        f"{sorted(EXPECTED_CATEGORIES - set(CONFIG_SURFACE))}; unexpected: "
+        f"{sorted(set(CONFIG_SURFACE) - EXPECTED_CATEGORIES)}"
+    )
+
+
+def test_every_row_is_keyed_by_its_own_category():
+    for key, row in CONFIG_SURFACE.items():
+        assert row.category == key
+
+
+# ── The same object, not a lookalike ──────────────────────────────────────────
+
+
+def test_resources_router_calls_the_table_s_objects():
+    mod = importlib.import_module(
+        "agentclaw.community.adapters.http.openapi_v1.resources.router"
+    )
+
+    row = CONFIG_SURFACE["resources"]
+    assert mod._safe_path is row.validators[0]
+    assert mod._require_path is row.validators[1]
+    assert mod._file_coords is row.from_record
+    # ``_reject_read_only`` stays in the router on purpose — it maps the verdict
+    # to the surface's own 403 body. What must be shared is the *decision*.
+    assert mod.is_write_forbidden is row.validators[2]
+
+
+def test_identity_router_calls_the_table_s_objects():
+    mod = importlib.import_module(
+        "agentclaw.community.adapters.http.openapi_v1.identity.router"
+    )
+
+    row = CONFIG_SURFACE["identity"]
+    assert mod.identity_coords_from_record is row.from_record
+    assert mod.identity_physical_file_name is row.validators[0]
+
+
+def test_skills_router_calls_the_table_s_objects():
+    mod = importlib.import_module(
+        "agentclaw.community.adapters.http.openapi_v1.skills.router"
+    )
+
+    row = CONFIG_SURFACE["skills"]
+    assert mod._require_addressed_bot is row.validators[0]
+
+
+def test_engine_config_router_calls_the_table_s_object():
+    mod = importlib.import_module(
+        "agentclaw.community.adapters.http.openapi_v1.bots.engine_config"
+    )
+
+    assert mod._engine_config_coords is CONFIG_SURFACE["engine_config"].from_record
+
+
+# ── Usable with no request, no app, no DI container ───────────────────────────
+#
+# This is the capability the whole feature exists to deliver, so it is proven
+# rather than assumed. Nothing below builds an app, resolves a dependency, or
+# touches the injector.
+
+
+def test_validators_take_no_repository_or_service():
+    """Record-freeness, asserted structurally rather than by hoping.
+
+    A validator that grew a ``bot_repo`` or ``bot_service`` parameter would
+    still pass its own unit test while quietly becoming unusable at W13's
+    preflight, where there is no record to hand it. Catch it at the signature.
+    """
+    forbidden = {"bot_repo", "bot_service", "repo", "service", "session", "db"}
+    for name, row in CONFIG_SURFACE.items():
+        for validator in row.validators:
+            params = set(inspect.signature(validator).parameters)
+            assert not (params & forbidden), (
+                f"{name}: validator {validator.__name__} takes "
+                f"{sorted(params & forbidden)} — it cannot run at create-time "
+                "preflight, where no bot record exists"
+            )
+
+
+def test_from_spec_builds_coords_with_no_record_anywhere():
+    """W13's preflight, rehearsed before W13 exists.
+
+    Every row's ``from_spec`` is called with request parameters alone. If this
+    ever needs a bot record to pass, the split did not happen and
+    create-with-manifest will be forced into a second validation copy.
+    """
+    built = {
+        "identity": CONFIG_SURFACE["identity"].from_spec("bot-1", "owner-1"),
+        "resources": CONFIG_SURFACE["resources"].from_spec("bot-1", "owner-1", "arca"),
+        "skills": CONFIG_SURFACE["skills"].from_spec("bot-1", "owner-1"),
+        "mcp": CONFIG_SURFACE["mcp"].from_spec("bot-1", "owner-1"),
+        "engine_config": CONFIG_SURFACE["engine_config"].from_spec(
+            "bot-1", "owner-1", entity_id="e-1", entity_type=None, engine_type=None
+        ),
+    }
+    assert set(built) == EXPECTED_CATEGORIES
+    for name, coords in built.items():
+        assert isinstance(coords, BotConfigCoords), name
+        assert coords.bot_id == "bot-1", name
+        assert coords.owner_id == "owner-1", name
+        assert coords.entity_id, name
+
+
+def test_validators_run_against_spec_built_coords():
+    """The validators paired with those coordinates, still with no record."""
+    coords = CONFIG_SURFACE["resources"].from_spec("bot-1", "owner-1", "arca")
+    assert coords.engine_type == "arca"
+
+    safe_path, require_path, write_forbidden = CONFIG_SURFACE["resources"].validators
+    assert safe_path("/docs/./a.txt") == "docs/a.txt"
+    assert require_path("docs/a.txt") == "docs/a.txt"
+    assert write_forbidden(".hidden/a.txt") is True
+    assert write_forbidden("docs/a.txt") is False
+
+    physical_name = CONFIG_SURFACE["identity"].validators[0]
+    assert physical_name("SOUL") == "SOUL.md"
+
+
+def test_identity_and_mcp_carry_no_engine():
+    """``engine_type`` states an absence rather than inventing a default."""
+    for category in ("identity", "mcp", "skills"):
+        coords = CONFIG_SURFACE[category].from_spec("bot-1", "owner-1")
+        assert coords.engine_type is None, category
+
+
+# ── The refusals, unchanged by the move ───────────────────────────────────────
+
+
+@pytest.mark.parametrize("bad", ["../etc", "docs/../../etc", "..", "a/../b"])
+def test_workspace_path_still_refuses_escapes(bad):
+    safe_path = CONFIG_SURFACE["resources"].validators[0]
+    with pytest.raises(InvalidResourcePathError):
+        safe_path(bad)
+
+
+def test_workspace_path_still_refuses_the_root():
+    require_path = CONFIG_SURFACE["resources"].validators[1]
+    with pytest.raises(InvalidResourcePathError):
+        require_path("/")
+
+
+def test_read_only_policy_still_walks_every_ancestor():
+    """``.private/file.md`` is refused although its leaf is an ordinary name."""
+    write_forbidden = CONFIG_SURFACE["resources"].validators[2]
+    assert write_forbidden(".private/file.md") is True
+    assert write_forbidden("SOUL.md") is True
+    assert write_forbidden("docs/SOUL.md") is False
+
+
+def test_addressed_bot_mismatch_is_masked_as_not_found():
+    require_addressed = CONFIG_SURFACE["skills"].validators[0]
+    require_addressed({"bolt_id": "bot-1"}, "bot-1")
+    with pytest.raises(LocalSkillNotFoundError):
+        require_addressed({"bolt_id": "bot-2"}, "bot-1")

--- a/src/backend/tests/community/core/bot_config_surface/test_no_handler_only_checks.py
+++ b/src/backend/tests/community/core/bot_config_surface/test_no_handler_only_checks.py
@@ -1,0 +1,146 @@
+"""No new check may hide inside these five routers' handler bodies.
+
+The collaborator seam gets this property from assembly: an operation missing
+from its table cannot be constructed, so the application does not start. There
+is no assembly step to hook here, so a test does the same job — and does it by
+inventory rather than by pattern-matching, because "is this a check or a
+mapper?" is a judgement a reviewer makes, not one a regex makes.
+
+Every module-private callable in the five routers is classified below. Adding a
+sixth fails this test until someone writes down which side of Rule 7's line it
+falls on: **domain policy belongs in core; error mapping and auth interpretation
+may stay in the adapter.** The reason strings are the point — a mute allowlist
+would let the next person add a check and silence the test in the same commit
+without ever stating why.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+_PREFIX = "agentclaw.community.adapters.http.openapi_v1"
+
+#: Module-private callables in the five in-scope routers, and why each is
+#: allowed to be there. ``MOVED`` marks a name that is now a binding to a core
+#: object — the check itself lives in ``core`` and the table names it; the
+#: binding is kept so call sites read unchanged.
+CLASSIFIED: dict[str, dict[str, str]] = {
+    f"{_PREFIX}.resources.router": {
+        "_safe_path": "MOVED — binding to core.safe_workspace_path",
+        "_require_path": "MOVED — binding to core.require_workspace_path",
+        "_file_coords": "MOVED — binding to core.resource_coords_from_record",
+        "_reject_read_only": (
+            "adapter: maps core's is_write_forbidden verdict onto this "
+            "surface's 403 body. The decision is in core; only the phrasing is "
+            "here, which Rule 7 permits"
+        ),
+        "_to_file_entry": "adapter: serialization, service dict → response schema",
+        "_list_dir_or_empty": (
+            "adapter: reads an absent directory as an empty listing so baas and "
+            "the other providers answer alike. Transport-shaped, not policy"
+        ),
+        "_read_file_or_404": "adapter: maps device errors onto this surface's 404/413",
+    },
+    f"{_PREFIX}.skills.router": {
+        "_require_addressed_bot": "MOVED — binding to core.require_addressed_bot",
+        "_require_skills_grant": (
+            "adapter: takes ActingCaller, an adapter type, and an application "
+            "grant is a fact about an HTTP caller. Apply arrives as its own "
+            "operation with its own grant already checked at its own door"
+        ),
+        "_directory_relative_paths": (
+            "adapter: parses the legacy multipart folder wire. A manifest has "
+            "no multipart form to parse"
+        ),
+        "_tags": "adapter: serialization, tolerates the record's JSON-or-list tags",
+        "_to_skill": "adapter: serialization, record → response schema",
+        "_uploaded_skill_response": "adapter: chooses 200 vs 201 and builds the envelope",
+    },
+    f"{_PREFIX}.identity.router": {},
+    f"{_PREFIX}.mcp.router": {
+        "_to_server": "adapter: serialization",
+        "_optional_text": "adapter: serialization",
+        "_display_label": "adapter: serialization",
+        "_snake_key": "adapter: serialization",
+        "_legacy_detail_to_openapi": "adapter: serialization",
+        "_to_server_detail": "adapter: serialization",
+        "_category_label": "adapter: serialization",
+        "_to_tenant": "adapter: serialization",
+        "_to_config": "adapter: serialization",
+    },
+    f"{_PREFIX}.bots.engine_config": {
+        "_engine_config_coords": (
+            "MOVED — binding to core.engine_config_coords_from_record, which "
+            "carries the ownership guard as well as the address"
+        ),
+    },
+}
+
+
+def _private_callables(module) -> set[str]:
+    """Module-private callables *defined or bound* at this module's top level.
+
+    Imported names are excluded — a private name imported from elsewhere is
+    that module's business, and this test governs what these five own.
+    """
+    found = set()
+    for name, obj in vars(module).items():
+        if not name.startswith("_") or name.startswith("__"):
+            continue
+        if not callable(obj) or inspect.isclass(obj):
+            continue
+        found.add(name)
+    return found
+
+
+def test_every_private_callable_is_classified():
+    unclassified: list[str] = []
+    for module_path, classified in CLASSIFIED.items():
+        module = importlib.import_module(module_path)
+        for name in sorted(_private_callables(module) - set(classified)):
+            unclassified.append(f"{module_path}.{name}")
+
+    assert not unclassified, (
+        "New module-private callables in the bot-config routers:\n  "
+        + "\n  ".join(unclassified)
+        + "\n\nClassify each in CLASSIFIED with a reason. Domain policy belongs "
+        "in core, where manifest apply can reach it (see "
+        "core/bot_config_surface/table.py); error mapping, serialization and "
+        "auth interpretation may stay in the adapter (Rule 7)."
+    )
+
+
+def test_classification_has_no_stale_entries():
+    """A name that left the router must leave the list, or the list is fiction."""
+    stale: list[str] = []
+    for module_path, classified in CLASSIFIED.items():
+        module = importlib.import_module(module_path)
+        present = _private_callables(module)
+        for name in sorted(set(classified) - present):
+            stale.append(f"{module_path}.{name}")
+    assert not stale, f"Classified but no longer present: {stale}"
+
+
+def test_every_reason_is_written_down():
+    for module_path, classified in CLASSIFIED.items():
+        for name, reason in classified.items():
+            assert reason.strip(), f"{module_path}.{name} has an empty reason"
+
+
+def test_moved_checks_really_live_in_core():
+    """A ``MOVED`` claim must be true: the object's home is ``core``, not here."""
+    for module_path, classified in CLASSIFIED.items():
+        module = importlib.import_module(module_path)
+        for name, reason in classified.items():
+            if not reason.startswith("MOVED"):
+                continue
+            obj = getattr(module, name)
+            home = getattr(obj, "__module__", "")
+            assert home.startswith("agentclaw.community.core."), (
+                f"{module_path}.{name} is classified MOVED but its home is "
+                f"{home!r} — either it did not move, or the reason is wrong"
+            )
+            assert not home.startswith(_PREFIX), (
+                f"{module_path}.{name} claims MOVED but still lives in the adapter"
+            )

--- a/src/backend/tests/community/framework/flow_coverage.py
+++ b/src/backend/tests/community/framework/flow_coverage.py
@@ -31,7 +31,20 @@ def covered_modules(flows: list[FlowCase]) -> set[str]:
 # and its bodies are exercised by the flows of the modules that consume it. It is
 # excluded here rather than added to SINGLEBOX_E2E_EXEMPT because exempt means
 # "not covered yet" — these ARE covered, just not nameable as a `covers` entry.
-_STRUCTURAL_NON_BUSINESS: frozenset[str] = frozenset({"repository"})
+#
+# ``bot_config_surface`` is the same shape and is here for the same reason. It is
+# an index: it names the checks each bot-config category enforces, every one of
+# which is defined in the package that owns that category's domain and imported
+# by reference. Its README states outright that it must not grow logic, so there
+# is no behaviour of its own for a flow to drive — the resources, mcp and
+# skill-centre flows already exercise every object it names, through the routers
+# that call them. Adding it to SINGLEBOX_E2E_EXEMPT instead would claim it is
+# uncovered, and would need a "drain when…" reason that nothing could ever
+# satisfy: no flow can cover an index directly. If this module ever does grow
+# behaviour of its own, that is the moment it stops belonging here.
+_STRUCTURAL_NON_BUSINESS: frozenset[str] = frozenset(
+    {"repository", "bot_config_surface"}
+)
 
 
 def all_core_modules() -> set[str]:


### PR DESCRIPTION
## Problem

Manifest apply (#1472) writes to the same five bot-configuration categories the public API exposes — `skills`, `identity`, `resources`, `mcp`, `engine_config`. The rules those categories enforce lived in `openapi_v1` router handler bodies as module-private functions, callable from handler code and nowhere else:

- `_safe_path`, `_require_path`, `_reject_read_only`, `_file_coords` — `resources/router.py`
- `_require_addressed_bot`, `_require_skills_grant`, `_directory_relative_paths` — `skills/router.py`
- `_engine_config_target` and the `bot_service.get_bot(bot_id, owner_id)` ownership guard — `bots/engine_config.py`
- the hardcoded `entity_type = "staff"` resolutions — `identity/router.py`, `mcp/router.py`

Reaching any of them from `core` would be an adapter import from core, backwards through the layer boundary. So apply would either skip these rules or carry a hand-copied second implementation — and two copies of a security rule diverge, silently, on whichever side nobody is reading.

Rule 7 also puts them in the wrong place already. It lets an adapter do request parsing, auth interpretation, protocol validation, serialization and error mapping; it forbids the adapter to own domain policy. "A workspace path may not contain `..`" is domain policy by any reading. These sit in adapters because that is where the endpoints that needed them were written, and no second caller existed to force the question. Apply is the second caller.

## Solution

Each check moves to its category's **existing** core home, beside the code that owns that domain — the workspace path rules land next to `is_readonly`, the engine-config ownership guard next to the engine-config service. A new module `core/bot_config_surface/` holds **only the table** naming them, mirroring the collaborator precedent where `authorization.py` is a table and `bot_access.py` the mechanism it drives, rather than inventing a third shape. The five routers now call the moved objects.

**Inert on arrival.** The moved functions raise the same domain error types from the same modules, so `ENVELOPE_ERRORS` maps them to identical statuses and messages untouched. The one check that raised `HTTPException` keeps its `raise` in the router — only the *decision* moved — so that 403 body is bit-identical rather than argued to be equivalent.

**Two coordinate constructors, one frozen type.** `from_record` for a bot that exists, `from_spec` for one being created. Create-with-manifest (#1696) validates at preflight, in `create_bot_with_authorization`, before the bot record is written — `create_flow.py` mints the id and the Passport identity in phase 1 and creates nothing. A record-first seam would have forced W13 into a second validation copy, on the path where being wrong is most expensive: the alternative to catching an invalid manifest at preflight is catching it after the user completed a Passport authorization that cannot be un-burned. `from_spec` has no caller yet and is pinned by unit test.

**Four checks stay in the routers**, each with a written reason: the app-grant binding (takes `ActingCaller`, an adapter type), the multipart path parser, the `application/zip` header check, and the read-only 403 mapper. The criterion is about a check reachable *only from inside a handler body* — satisfied by moving domain policy out, not by evacuating the adapter of everything Rule 7 permits it to do.

**Admission and authorization dependencies are untouched.** `authorization.py`, `bot_access.py`, `admission.py` and `principal.py` are not modified. Apply will declare its own rows and `PublicAPIRoute` will enforce them at its own door; nothing is extracted or hand-called. `spec.md` records what those rows must be — `GRANT_CHECKED_ADDRESSED_BOT` and `Check(PermissionLevel.OWNER, EDIT_LOCK)` — for #1469, #1472 and #1696 to honour, plus the dominance test that stops a later bar drop from silently letting `MEMBER` overwrite a bot's `SOUL.md` through a manifest.

### Two findings recorded rather than smoothed over

- **The mcp router held no domain policy to move.** Its `server_code` permission rule already lives in `DirectActivationService` and its config flow in `core.mcp.config_flow`. The category the manifest work most expected to need this seam had already arrived; its row is coords-only. An earlier revision routed the router's *account-level* `_ENTITY_TYPE` through `mcp_coords_from_record` for symmetry — reverted, because those operations take no `bot_id` and pairing them would claim a sharing that does not exist.
- **The four entity-coordinate resolutions genuinely differ.** `resources` performs no ownership guard at all; `engine_config` reads the bot record's own entity behind `get_bot`; `identity` and `mcp` hardcode `"staff"` against `owner_id`. Preserved as four — merging them would change who is admitted on at least three groups. The table makes the divergence visible in one screen for the first time; resolving it is filed as a follow-up needing its own spec.

## Validation

- **Full local suite: 15813 passed, 60 skipped, 2 failed.** Both failures are **pre-existing**, verified rather than assumed — a worktree at the merge base `b8754443` fails the same two parametrisations of `test_bot_build_service_skill_artifact.py` with none of this change present.
- **Existing endpoint tests pass unedited** — 76 resources, 97 engine-config/data-init. That they needed no change is the inertness proof.
- **21 new tests.** Same-object `is` assertions binding each router name to its table entry (two functions that merely behave alike are exactly the drift this catches); a record-free test that builds coordinates from request parameters alone and runs every validator with no bot record in the fixture, rehearsing W13's preflight before W13 exists; and a guard that fails on a new module-private check in these five routers. **The guard was verified by injecting a fake check into the resources router — it caught it — then reverted.**
- `ruff` clean on every touched file. `src/gateway/configs/schemas/bots.openapi.json` unchanged — the seam is invisible in the published document.

## Compatibility and risk

No DDL, no new endpoint, no schema change, no published contract change.

**Three test files were edited, where the spec assumed zero.** The assumption was wrong rather than the change being wrong: this repository governs architecture through test-resident inventories, so adding a core module requires registering it in each. All three are registrations; none weakens a check.

| File | Why |
| --- | --- |
| `architecture/test_module_boundaries.py` | `BOUNDARY_SIGNIFICANT_MODULES` — without it the new `README.md` is governed by nothing |
| `framework/flow_coverage.py` | `_STRUCTURAL_NON_BUSINESS`, beside `repository`. Not the exempt list: exempt means "not covered yet" and needs a reason naming what would unblock a flow, and no flow can cover an index directly |
| `architecture/test_http_adapter_layer_is_http_only.py` | `_CORE_SERVICE_NAMES_OK` — the guard's own failure message directs you here for a pure helper, and `is_readonly` sits there already for the same reason, from the same module |

**No behaviour test was modified**, which is what that criterion was protecting.

A pre-existing circular import was found and deliberately left alone: importing `core.services.resource_file_service` cold fails through `devices → service_bot → task_queue`. Verified identical on an unmodified tree before touching anything. Not this change's to fix.

## Spec

`src/backend/specs/2026-08-31-config-manifest-service-seam/` — `spec.md`, `plan.md`, `tasks.md`. The last carries an *Implementation notes* section recording where the build differed from the plan, including a second consumer of `_engine_config_target` the inventory missed (the data-init operation, `bots/router.py:1495`, which fetches the bot itself and applies its own type rule first) — which is why `engine_config_coords_from_bot` exists.

Full scope and acceptance criteria: `src/backend/docs/bot-config-manifest/work-items.zh-CN.md` §5, W10.

## Related issues

Closes #1509. Blocks #1472 (W4) — the apply engine's materializers are this seam's first callers, which is why it ships first: doing it afterwards means writing these checks twice and deleting one copy.