### PR TITLE
Feat/community deploy overlay

### DIFF
--- a/docker/agent/avernet-supervisord.conf
+++ b/docker/agent/avernet-supervisord.conf
@@ -5,13 +5,17 @@
 #
 # Process model:
 #   supervisord (PID 1)
-#   ├── engine    (autostart=false)  started by start_service.sh
-#   └── openclaw  (autostart=false)  started on demand by engine
+#   ├── engine        (autostart=false)  started by start_service.sh
+#   ├── openclaw      (autostart=false)  started on demand by engine
+#   └── claude_relay  (autostart=false)  started by start_service.sh when
+#                     --engine claude_code (serves ws://127.0.0.1:18900)
 #
 # start_service.sh starts the engine program via:
 #   sudo supervisorctl start engine
 # The engine starts openclaw on demand via:
 #   sudo supervisorctl start openclaw
+# start_service.sh starts claude_relay via:
+#   sudo supervisorctl start claude_relay   (only for --engine claude_code)
 # ============================================================
 
 [supervisord]
@@ -37,8 +41,14 @@ supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
 ; It is started by start_service.sh after credentials are saved.
 ; It manages openclaw's lifecycle via `sudo supervisorctl start openclaw`
 ; when a bot session is requested.
+; The engine type comes from .adaptorEnv (written by start_service.sh from
+; --engine; start_service.sh's own ENGINE default "openclaw" already covers the
+; no-arg case, so no fallback is needed here — a missing .adaptorEnv fails the
+; source below before run.sh ever runs). ${CHAT_ENGINE} is expanded by bash -c
+; AFTER the source; supervisord itself does NOT expand ${...} (only %(ENV_X)s),
+; so the placeholder reaches bash untouched.
 [program:engine]
-command=/bin/bash -c "source /home/admin/.adaptorEnv && source /opt/.venv/bin/activate && /opt/engine/scripts/run.sh -e openclaw --port 20003"
+command=/bin/bash -c "source /home/admin/.adaptorEnv && source /opt/.venv/bin/activate && /opt/engine/scripts/run.sh -e ${CHAT_ENGINE} --port 20003"
 user=admin
 directory=/opt/engine
 autostart=false
@@ -72,6 +82,35 @@ startsecs=5
 startretries=3
 stdout_logfile=/home/admin/logs/openclaw_out.log
 stderr_logfile=/home/admin/logs/openclaw_err.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=5
+stderr_logfile_maxbytes=10MB
+stderr_logfile_backups=5
+environment=HOME="/home/admin",
+    USER="admin",
+    PATH="%(ENV_PATH)s",
+    NODE_EXTRA_CA_CERTS="/etc/ssl/certs/ca-bundle.crt"
+
+; —─────────────────────── Claude Code relay ────────────────────────
+; The vendored claude_code gateway (Node WS server at ws://127.0.0.1:18900)
+; required by the engine's claude_code mode. NOT auto-started.
+; start_service.sh starts it via `sudo supervisorctl start claude_relay` when
+; invoked with --engine claude_code, after writing /home/admin/.relayEnv
+; (600, admin-owned: PORT + RELAY_* paths + ANTHROPIC_* model credentials —
+; sourced here so the secrets never enter the supervisord config or image).
+; server.ts reads PORT directly with a 18900 default. The engine adapter
+; connects to ws://127.0.0.1:18900 (default CLAUDE_CODE_RELAY_URL) once this
+; is healthy, so start_service.sh health-gates the relay before the engine.
+[program:claude_relay]
+command=/bin/bash -c "source /home/admin/.relayEnv && cd /opt/engine/src/engine/community/claude_code_gateway && exec node dist/esm/server.js"
+user=admin
+directory=/opt/engine/src/engine/community/claude_code_gateway
+autostart=false
+autorestart=true
+startsecs=5
+startretries=3
+stdout_logfile=/home/admin/logs/claude_relay_out.log
+stderr_logfile=/home/admin/logs/claude_relay_err.log
 stdout_logfile_maxbytes=10MB
 stdout_logfile_backups=5
 stderr_logfile_maxbytes=10MB

--- a/docker/agent/avernet.dockerfile
+++ b/docker/agent/avernet.dockerfile
@@ -6,17 +6,29 @@
 #
 # Runtime model (mirrors OCB arca-openclaw):
 #   - supervisord is PID 1
-#   - [program:engine]    autostart=false — started by start_service.sh
-#   - [program:openclaw]  autostart=false — started on demand by engine
-#                        via `sudo supervisorctl start openclaw`
+#   - [program:engine]       autostart=false — started by start_service.sh
+#                            (engine type from .adaptorEnv CHAT_ENGINE; the
+#                            openclaw default is start_service.sh's ENGINE
+#                            default, claude_code via --engine)
+#   - [program:openclaw]     autostart=false — started on demand by engine
+#                            via `sudo supervisorctl start openclaw`
+#   - [program:claude_relay] autostart=false — started by start_service.sh when
+#                            --engine claude_code (reads .relayEnv), serves
+#                            ws://127.0.0.1:18900 for the engine's claude_code
+#                            adapter
 #
 # Pod startup flow:
 #   1. entrypoint.sh: pre-init (directories, config), then exec supervisord
-#   2. start_service.sh (background): save credentials → start engine
-#      via supervisorctl → poll /health → write ready marker
+#   2. start_service.sh (background): parse args → save credentials → check
+#      --engine → exec start_openclaw.sh (engine program; openclaw gateway
+#      on demand by the engine) or start_claude_code.sh (claude_relay
+#      health-gated, then engine) → poll /health → write ready marker
 #
 # Build args:
 #   OPENCLAW_VERSION   npm version of openclaw (default 2026.6.1)
+#   CLAUDE_CODE_VERSION  npm version of @anthropic-ai/claude-code (default 2.1.251 —
+#                       pinned, unlike scripts/toolchain.sh which installs latest;
+#                       image builds must be reproducible), from npmmirror
 #   UV_VERSION         uv version for pin (default: latest)
 #   NPM_STRICT_SSL     npm strict-ssl toggle (default true)
 
@@ -55,6 +67,14 @@ RUN npm config set registry "https://registry.npmmirror.com" \
     && npm config set strict-ssl "${NPM_STRICT_SSL}" \
     && npm install -g "openclaw@${OPENCLAW_VERSION}"
 
+# Install Claude Code CLI (global, pinned — same package + registry as
+# scripts/toolchain.sh CLAUDE_CODE_NPM_PACKAGE/CLAUDE_CODE_NPM_REGISTRY; pinned
+# here for reproducible image builds). Installed in BOTH runtime engines' scope:
+# the claude_code adapter path (vendored gateway spawns the CLI when
+# CLAUDE_BRIDGE=cli) and the sdk bridge's CLAUDE_CODE_PATH convention.
+ARG CLAUDE_CODE_VERSION=2.1.251
+RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+
 # Install uv via pip (Aliyun mirror — astral.sh is unreachable in CN build envs).
 # --break-system-packages: required by PEP 668 on Debian 12 system Python.
 ARG UV_VERSION=
@@ -73,6 +93,18 @@ RUN uv venv --python 3 /opt/.venv \
     && find /opt/.venv -name "*.pyc" -delete \
     && find /opt/.venv -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null || true \
     && rm -rf /root/.cache/uv /root/.local/share/uv
+
+# Build the vendored claude_code relay gateway (the Node WS server the engine's
+# claude_code mode connects to at ws://127.0.0.1:18900). Build command mirrors
+# scripts/modules/claude_relays.sh::claude_relays_setup (npm install --include=dev
+# --ignore-scripts, tshy build via prepublishOnly), then prune devDeps like the
+# bcn plugin build below keeps the runtime layer lean. The repo ships no dist/;
+# it must be built here or the relay cannot run in the image.
+RUN cd /opt/engine/src/engine/community/claude_code_gateway \
+    && npm install --include=dev --ignore-scripts --no-audit --no-fund \
+    && npm run prepublishOnly \
+    && npm prune --omit=dev \
+    && test -f dist/esm/server.js
 
 # Build the openclaw-channel-bcn plugin (BCS WebSocket channel).
 # Mirrors Dockerfile.ocb: npm install → build → prune devDeps.
@@ -129,7 +161,7 @@ RUN sed -i "s|deb.debian.org|mirrors.aliyun.com|g" /etc/apt/sources.list.d/debia
         sudo \
     && rm -rf /var/lib/apt/lists/*
 
-# Bring over installed openclaw from builder.
+# Bring over installed openclaw + claude-code from builder.
 COPY --from=builder /usr/local/lib/node_modules /usr/local/lib/node_modules
 # Recreate npm bin symlink: COPY --from resolves symlinks to files,
 # which breaks the script's __dirname-based dist/ path resolution.
@@ -141,6 +173,18 @@ RUN BIN_REL=$(node -e "\
     && ln -sf "/usr/local/lib/node_modules/openclaw/${BIN_REL}" \
               /usr/local/bin/openclaw \
     && chmod +x /usr/local/bin/openclaw
+
+# Recreate the claude bin symlink (same COPY --from symlink issue, scoped pkg).
+# The generic bin-field parse handles any bin shape the package may use.
+RUN CC_BIN=$(node -e "\
+  const p = require('/usr/local/lib/node_modules/@anthropic-ai/claude-code/package.json'); \
+  const b = p.bin || {}; \
+  const t = typeof b === 'string' ? b : (b.claude || Object.values(b)[0]); \
+  console.log(t)") \
+    && ln -sf "/usr/local/lib/node_modules/@anthropic-ai/claude-code/${CC_BIN}" \
+              /usr/local/bin/claude \
+    && chmod +x /usr/local/bin/claude \
+    && /usr/local/bin/claude --version
 
 # Bring over the engine venv + source code.
 COPY --from=builder /opt/.venv /opt/.venv
@@ -187,16 +231,21 @@ COPY docker/agent/openclaw.json /opt/openclaw.json.template
 # Shared utility functions (logging, helpers).
 COPY docker/agent/util.sh /usr/local/bin/util.sh
 
-# Simplified pod startup script (starts engine, waits for health).
+# Pod startup: thin dispatcher (parses args, saves credentials, checks
+# --engine, execs the right script) + one per-engine script.
 COPY docker/agent/start_service.sh /usr/local/bin/start_service.sh
+COPY docker/agent/start_openclaw.sh /usr/local/bin/start_openclaw.sh
+COPY docker/agent/start_claude_code.sh /usr/local/bin/start_claude_code.sh
 
 # Entrypoint: pre-init, config generation from template, then execs supervisord.
 COPY docker/agent/avernet-entrypoint.sh /usr/local/bin/avernet-entrypoint
 RUN chmod +x /usr/local/bin/avernet-entrypoint \
              /usr/local/bin/start_service.sh \
+             /usr/local/bin/start_openclaw.sh \
+             /usr/local/bin/start_claude_code.sh \
              /usr/local/bin/util.sh
 
-EXPOSE 20003 18789
+EXPOSE 20003 18789 18900
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=120s --retries=6 \
     CMD curl -fsS "http://127.0.0.1:20003/health" >/dev/null || exit 1

--- a/docker/agent/avernet.dockerfile
+++ b/docker/agent/avernet.dockerfile
@@ -228,6 +228,21 @@ COPY docker/agent/avernet-supervisord.conf /etc/supervisor/supervisord.conf
 # OpenClaw default config template (env-var placeholders substituted at runtime).
 COPY docker/agent/openclaw.json /opt/openclaw.json.template
 
+# Claude Code provider settings template — staged like openclaw.json above:
+# /home/admin is NAS-mounted at pod start, which SHADOWS anything baked
+# there, so the file must live in /opt and be copied into ~/.claude AFTER
+# the mount (start_claude_code.sh does the copy; mount-wins: a file already
+# on the NAS is kept). Content is FULLY STATIC, mirroring openclaw.json's
+# hardcoded config: URL, model (glm-5.2), and the auth token as the literal
+# placeholder "Bearer ${API-KEY}" — the gateway on the upstream side
+# replaces the placeholder with the real key (same pattern as openclaw.json's
+# "apiKey": "Bearer ${API-KEY}"). No credentials are injected into the pod
+# at runtime for this engine. The claude CLI reads the file natively via
+# CLAUDE_CONFIG_DIR; the relay gateway's model-provider loader via
+# RELAY_MODEL_SETTINGS_SOURCE (set in start_claude_code.sh). A deployment
+# with a different provider scenario mounts its own file at the final path.
+COPY docker/agent/claude-settings.json /opt/claude-settings.json.template
+
 # Shared utility functions (logging, helpers).
 COPY docker/agent/util.sh /usr/local/bin/util.sh
 

--- a/docker/agent/claude-settings.json
+++ b/docker/agent/claude-settings.json
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://dashscope.aliyuncs.com/apps/anthropic",
+    "ANTHROPIC_AUTH_TOKEN": "Bearer ${API-KEY}",
+    "ANTHROPIC_MODEL": "glm-5.2",
+    "ANTHROPIC_SMALL_FAST_MODEL": "glm-5.2",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "200000",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "glm-5.2",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "glm-5.2",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "glm-5.2"
+  }
+}

--- a/docker/agent/start_claude_code.sh
+++ b/docker/agent/start_claude_code.sh
@@ -1,0 +1,268 @@
+#!/bin/bash
+
+##############################################
+# start_claude_code.sh - Claude Code engine pod startup
+#
+# Per-engine startup script for --engine claude_code.
+#
+# Normally exec'd by start_service.sh (arguments parsed, credentials
+# saved, ready marker reset, MARKER_FILE / ADAPTOR_PORT exported). Also
+# runnable directly for recovery/debugging — it carries its own defaults
+# for the inherited variables.
+#
+# Flow:
+#   1. Validate ANTHROPIC_* model credentials (fail fast)
+#   2. Write .adaptorEnv (claude_code + relay URL/cwd contract) and
+#      .relayEnv for the claude_relay supervisord program (600, admin:
+#      credentials must not leak into supervisord config or image layers)
+#   3. Wait for the supervisord socket
+#   4. Start the claude_relay program via supervisorctl and health-gate
+#      it (GET /health → {"ok":true}) before the engine
+#   5. Start the engine program via supervisorctl
+#   6. Wait for engine /health, write the ready marker and print status
+#
+# Reads (pod env; env contract mirrors scripts/modules/claude_relays.sh
+# — singlebox — against the same vendored gateway):
+#   ANTHROPIC_BASE_URL          required, Anthropic-compatible Messages API URL
+#   ANTHROPIC_AUTH_TOKEN or
+#   ANTHROPIC_API_KEY           required (one of), upstream credential
+#   ANTHROPIC_MODEL             required, model id
+#   ANTHROPIC_SMALL_FAST_MODEL  optional, defaults to ANTHROPIC_MODEL (the
+#                               upstream relay serves one model; without this
+#                               claude requests haiku and the upstream 404s)
+#   CLAUDE_RELAY_PORT           optional, defaults 18900
+#   CLAUDE_RELAY_PERMISSION_MODE optional, defaults acceptEdits
+#   CLAUDE_CODE_PATH            optional, defaults /usr/local/bin/claude
+##############################################
+
+set -e
+
+# --- Locate scripts directory ---
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source util.sh for logging
+source "$SCRIPT_DIR/util.sh"
+
+# Same log file as the dispatcher (and start_openclaw.sh) so one file
+# holds the whole pod startup trace, whatever the engine.
+LOG_FILE="/home/admin/logs/start_service.log"
+set_log_file "$LOG_FILE"
+
+# --- Inherited context (fallbacks for direct invocation) ---
+
+MARKER_FILE="${MARKER_FILE:-/var/run/agentclaw/.starting_done}"
+ADAPTOR_PORT="${ADAPTOR_PORT:-20003}"
+ENGINE="claude_code"
+
+# --- claude_code relay settings ---
+
+CLAUDE_RELAY_PORT="${CLAUDE_RELAY_PORT:-18900}"
+CLAUDE_RELAY_PERMISSION_MODE="${CLAUDE_RELAY_PERMISSION_MODE:-acceptEdits}"
+RELAY_STATE_DIR="/home/admin/.claude-relay"
+RELAY_GATEWAY_DIR="/opt/engine/src/engine/community/claude_code_gateway"
+
+section "start_claude_code.sh - claude_code engine startup"
+
+# --- Step 1: Validate model provider credentials (fail fast) ---
+
+MISSING_RELAY_ENV=""
+[ -n "${ANTHROPIC_BASE_URL:-}" ] || MISSING_RELAY_ENV="ANTHROPIC_BASE_URL"
+if [ -z "${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+    MISSING_RELAY_ENV="${MISSING_RELAY_ENV} ANTHROPIC_AUTH_TOKEN-or-ANTHROPIC_API_KEY"
+fi
+[ -n "${ANTHROPIC_MODEL:-}" ] || MISSING_RELAY_ENV="${MISSING_RELAY_ENV} ANTHROPIC_MODEL"
+if [ -n "$MISSING_RELAY_ENV" ]; then
+    fail "--engine claude_code requires: ${MISSING_RELAY_ENV}"
+    info "  Claude Code needs an Anthropic-compatible Messages API endpoint."
+    echo "FAILED" > "$MARKER_FILE"
+    exit 1
+fi
+
+ANTHROPIC_SMALL_FAST_MODEL="${ANTHROPIC_SMALL_FAST_MODEL:-$ANTHROPIC_MODEL}"
+
+# --- Step 2: Configure engine + relay environment ---
+
+section "Step 2: Configuring engine + relay environment..."
+
+ADAPTOR_ENV_FILE="/home/admin/.adaptorEnv"
+cat > "$ADAPTOR_ENV_FILE" <<EOF
+export ENGINE=$ENGINE
+export CHAT_ENGINE=$ENGINE
+EOF
+
+# Engine-side contract (read by the engine process, not the relay):
+# CLAUDE_CODE_RELAY_URL is the adapter's WS target (plugin default is
+# ws://127.0.0.1:18900 — keep it explicit so CLAUDE_RELAY_PORT overrides
+# stay in sync); CLAUDE_CODE_DEFAULT_CWD / RELAY_DEFAULT_CWD anchor the
+# engine-side workspace resolution (same pattern as
+# scripts/run_bcs_mixed_provider.sh).
+cat >> "$ADAPTOR_ENV_FILE" <<EOF
+export CLAUDE_CODE_RELAY_URL=ws://127.0.0.1:$CLAUDE_RELAY_PORT
+export CLAUDE_CODE_DEFAULT_CWD=/home/admin/.openclaw/workspace
+export RELAY_DEFAULT_CWD=/home/admin/.openclaw/workspace
+EOF
+success "Engine env file written to $ADAPTOR_ENV_FILE"
+
+mkdir -p "$RELAY_STATE_DIR/data" "$RELAY_STATE_DIR/logs" \
+         /home/admin/.claude /home/admin/.openclaw/workspace
+chown -R admin:admin "$RELAY_STATE_DIR" /home/admin/.claude 2>/dev/null || true
+
+RELAY_ENV_FILE="/home/admin/.relayEnv"
+cat > "$RELAY_ENV_FILE" <<EOF
+export PORT=$CLAUDE_RELAY_PORT
+export CLAUDE_CODE_PATH=${CLAUDE_CODE_PATH:-/usr/local/bin/claude}
+export RELAY_DATA_DIR=$RELAY_STATE_DIR/data
+export RELAY_LOG_DIR=$RELAY_STATE_DIR/logs
+export RELAY_CLAUDE_CONFIG_DIR=/home/admin/.claude
+export RELAY_DEFAULT_CWD=/home/admin/.openclaw/workspace
+export RELAY_DEFAULT_PERMISSION_MODE=$CLAUDE_RELAY_PERMISSION_MODE
+export ANTHROPIC_BASE_URL=$ANTHROPIC_BASE_URL
+export ANTHROPIC_MODEL=$ANTHROPIC_MODEL
+export ANTHROPIC_SMALL_FAST_MODEL=$ANTHROPIC_SMALL_FAST_MODEL
+EOF
+# Credential line: AUTH_TOKEN preferred (bearer), else API_KEY.
+if [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+    echo "export ANTHROPIC_AUTH_TOKEN=$ANTHROPIC_AUTH_TOKEN" >> "$RELAY_ENV_FILE"
+else
+    echo "export ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" >> "$RELAY_ENV_FILE"
+fi
+chown admin:admin "$RELAY_ENV_FILE" 2>/dev/null || true
+chmod 600 "$RELAY_ENV_FILE"
+success "Relay env file written to $RELAY_ENV_FILE (mode 600)"
+
+# --- Step 3: Wait for supervisord socket ---
+
+section "Step 3: Waiting for supervisord..."
+
+SUPERVISOR_SOCK="/var/run/supervisor.sock"
+MAX_WAIT=30
+waited=0
+while [ ! -S "$SUPERVISOR_SOCK" ]; do
+    if [ $waited -ge "$MAX_WAIT" ]; then
+        fail "supervisord socket not ready after ${MAX_WAIT}s"
+        echo "FAILED" > "$MARKER_FILE"
+        exit 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+done
+success "supervisord ready (waited ${waited}s)"
+
+# --- Step 4: Start claude_relay via supervisorctl and health-gate it ---
+
+section "Step 4: Starting claude_relay program (port $CLAUDE_RELAY_PORT)..."
+
+[ -f "$RELAY_GATEWAY_DIR/dist/esm/server.js" ] || {
+    fail "claude_code gateway missing: $RELAY_GATEWAY_DIR/dist/esm/server.js"
+    echo "FAILED" > "$MARKER_FILE"
+    exit 1
+}
+
+RELAY_RUNNING=$(sudo /usr/local/bin/supervisorctl status claude_relay 2>/dev/null | grep -c "RUNNING" || true)
+
+if [ "$RELAY_RUNNING" -gt 0 ]; then
+    info "claude_relay is already running"
+else
+    info "Starting claude_relay via supervisorctl..."
+    if sudo /usr/local/bin/supervisorctl start claude_relay; then
+        success "claude_relay program started"
+    else
+        fail "Failed to start claude_relay via supervisorctl"
+        info "  Check /home/admin/logs/claude_relay_err.log"
+        echo "FAILED" > "$MARKER_FILE"
+        exit 1
+    fi
+fi
+
+# Health-gate the relay before starting the engine: the engine's
+# claude_code adapter connects to ws://127.0.0.1:${CLAUDE_RELAY_PORT} at
+# session startup, so an unhealthy relay surfaces as a WS upgrade error
+# downstream instead of a clear boot failure.
+RELAY_HEALTH_TIMEOUT=60
+RELAY_READY=0
+for i in $(seq 1 "$RELAY_HEALTH_TIMEOUT"); do
+    if curl -s --max-time 2 "http://127.0.0.1:${CLAUDE_RELAY_PORT}/health" 2>/dev/null \
+        | jq -e '.ok == true' >/dev/null 2>&1; then
+        RELAY_READY=1
+        break
+    fi
+    sleep 1
+done
+
+if [ "$RELAY_READY" -ne 1 ]; then
+    fail "claude_relay health check not ready after ${RELAY_HEALTH_TIMEOUT}s"
+    info "  Check /home/admin/logs/claude_relay_out.log and claude_relay_err.log"
+    echo "FAILED" > "$MARKER_FILE"
+    exit 1
+fi
+success "claude_relay health check passed (http://127.0.0.1:${CLAUDE_RELAY_PORT}/health)"
+
+# --- Step 5: Start engine via supervisorctl ---
+
+section "Step 5: Starting engine program..."
+
+ENGINE_RUNNING=$(sudo /usr/local/bin/supervisorctl status engine 2>/dev/null | grep -c "RUNNING" || true)
+
+if [ "$ENGINE_RUNNING" -gt 0 ]; then
+    info "Engine is already running"
+else
+    info "Starting engine via supervisorctl..."
+    if sudo /usr/local/bin/supervisorctl start engine; then
+        success "Engine program started"
+    else
+        fail "Failed to start engine via supervisorctl"
+        echo "FAILED" > "$MARKER_FILE"
+        exit 1
+    fi
+fi
+
+# --- Step 6: Wait for engine /health endpoint ---
+
+section "Step 6: Waiting for engine health (port $ADAPTOR_PORT)..."
+
+HEALTH_CHECK_TIMEOUT=120
+HEARTBEAT_INTERVAL=10
+ADAPTOR_READY=0
+
+for i in $(seq 1 "$HEALTH_CHECK_TIMEOUT"); do
+    HEALTH_RESP=$(curl -s --max-time 3 "http://127.0.0.1:${ADAPTOR_PORT}/health" 2>/dev/null || true)
+    if echo "$HEALTH_RESP" | grep -q '"status".*:.*"ok"'; then
+        ADAPTOR_READY=1
+        break
+    fi
+    if [ $((i % HEARTBEAT_INTERVAL)) -eq 0 ]; then
+        info "  Still waiting for engine /health (${i}s / ${HEALTH_CHECK_TIMEOUT}s)..."
+    fi
+    sleep 1
+done
+
+if [ "$ADAPTOR_READY" -ne 1 ]; then
+    warn "Engine health check not ready after ${HEALTH_CHECK_TIMEOUT}s"
+    info "  Last response: $HEALTH_RESP"
+else
+    success "Engine health check passed"
+fi
+
+# --- Step 7: Write ready marker & print status ---
+
+echo "SUCCEEDED" > "$MARKER_FILE"
+
+section "Service startup completed"
+info ""
+info "Service Status:"
+info "  - Engine:   Running (port $ADAPTOR_PORT, engine=$ENGINE)"
+info "  - Relay:    Running (ws://127.0.0.1:${CLAUDE_RELAY_PORT})"
+info "  - Health:   http://127.0.0.1:${ADAPTOR_PORT}/health"
+info "               http://127.0.0.1:${CLAUDE_RELAY_PORT}/health"
+info ""
+info "Log Files:"
+info "  - Engine:   /home/admin/logs/engine_out.log"
+info "  - Relay:    /home/admin/logs/claude_relay_out.log"
+info "  - Startup:  $LOG_FILE"
+info ""
+info "Credentials:"
+info "  - Stored in: /home/admin/.credentials"
+info "  - Engine:    $ENGINE"
+info "  - Relay env (600): $RELAY_ENV_FILE"
+section "====="

--- a/docker/agent/start_claude_code.sh
+++ b/docker/agent/start_claude_code.sh
@@ -11,25 +11,27 @@
 # for the inherited variables.
 #
 # Flow:
-#   1. Validate ANTHROPIC_* model credentials (fail fast)
-#   2. Write .adaptorEnv (claude_code + relay URL/cwd contract) and
-#      .relayEnv for the claude_relay supervisord program (600, admin:
-#      credentials must not leak into supervisord config or image layers)
-#   3. Wait for the supervisord socket
-#   4. Start the claude_relay program via supervisorctl and health-gate
+#   1. Write .adaptorEnv (claude_code + relay URL/cwd contract) and
+#      .relayEnv for the claude_relay supervisord program (600, admin).
+#      No credentials here — see "Provider config" below.
+#   2. Wait for the supervisord socket
+#   3. Start the claude_relay program via supervisorctl and health-gate
 #      it (GET /health → {"ok":true}) before the engine
-#   5. Start the engine program via supervisorctl
-#   6. Wait for engine /health, write the ready marker and print status
+#   4. Start the engine program via supervisorctl
+#   5. Wait for engine /health, write the ready marker and print status
 #
-# Reads (pod env; env contract mirrors scripts/modules/claude_relays.sh
-# — singlebox — against the same vendored gateway):
-#   ANTHROPIC_BASE_URL          required, Anthropic-compatible Messages API URL
-#   ANTHROPIC_AUTH_TOKEN or
-#   ANTHROPIC_API_KEY           required (one of), upstream credential
-#   ANTHROPIC_MODEL             required, model id
-#   ANTHROPIC_SMALL_FAST_MODEL  optional, defaults to ANTHROPIC_MODEL (the
-#                               upstream relay serves one model; without this
-#                               claude requests haiku and the upstream 404s)
+# Provider config is FULLY STATIC (nothing read from pod env): the image
+# stages docker/agent/claude-settings.json at
+# /opt/claude-settings.json.template (NOT under /home/admin — that path is
+# NAS-mounted at pod start and shadows image content) and Step 1 copies it
+# into ~/.claude/settings.json AFTER the mount, mount-wins. Content — URL,
+# model glm-5.2, and the auth token as the literal placeholder
+# "Bearer ${API-KEY}" — mirrors openclaw.json ("apiKey":
+# "Bearer ${API-KEY}"): the gateway on the upstream side replaces the
+# placeholder with the real key. Swap the whole provider scenario by
+# mounting a file at the final path.
+#
+# Reads (pod env):
 #   CLAUDE_RELAY_PORT           optional, defaults 18900
 #   CLAUDE_RELAY_PERMISSION_MODE optional, defaults acceptEdits
 #   CLAUDE_CODE_PATH            optional, defaults /usr/local/bin/claude
@@ -64,26 +66,15 @@ RELAY_GATEWAY_DIR="/opt/engine/src/engine/community/claude_code_gateway"
 
 section "start_claude_code.sh - claude_code engine startup"
 
-# --- Step 1: Validate model provider credentials (fail fast) ---
+# Nothing to validate: every provider field — URL, model, and the auth token
+# (the literal placeholder "Bearer ${API-KEY}") — lives in the STATIC
+# settings.json baked into the image. The gateway on the upstream side
+# replaces the placeholder with the real key, exactly like openclaw.json's
+# "apiKey": "Bearer ${API-KEY}" placeholder.
 
-MISSING_RELAY_ENV=""
-[ -n "${ANTHROPIC_BASE_URL:-}" ] || MISSING_RELAY_ENV="ANTHROPIC_BASE_URL"
-if [ -z "${ANTHROPIC_AUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
-    MISSING_RELAY_ENV="${MISSING_RELAY_ENV} ANTHROPIC_AUTH_TOKEN-or-ANTHROPIC_API_KEY"
-fi
-[ -n "${ANTHROPIC_MODEL:-}" ] || MISSING_RELAY_ENV="${MISSING_RELAY_ENV} ANTHROPIC_MODEL"
-if [ -n "$MISSING_RELAY_ENV" ]; then
-    fail "--engine claude_code requires: ${MISSING_RELAY_ENV}"
-    info "  Claude Code needs an Anthropic-compatible Messages API endpoint."
-    echo "FAILED" > "$MARKER_FILE"
-    exit 1
-fi
+# --- Step 1: Configure engine + relay environment ---
 
-ANTHROPIC_SMALL_FAST_MODEL="${ANTHROPIC_SMALL_FAST_MODEL:-$ANTHROPIC_MODEL}"
-
-# --- Step 2: Configure engine + relay environment ---
-
-section "Step 2: Configuring engine + relay environment..."
+section "Step 1: Configuring engine + relay environment..."
 
 ADAPTOR_ENV_FILE="/home/admin/.adaptorEnv"
 cat > "$ADAPTOR_ENV_FILE" <<EOF
@@ -117,23 +108,44 @@ export RELAY_LOG_DIR=$RELAY_STATE_DIR/logs
 export RELAY_CLAUDE_CONFIG_DIR=/home/admin/.claude
 export RELAY_DEFAULT_CWD=/home/admin/.openclaw/workspace
 export RELAY_DEFAULT_PERMISSION_MODE=$CLAUDE_RELAY_PERMISSION_MODE
-export ANTHROPIC_BASE_URL=$ANTHROPIC_BASE_URL
-export ANTHROPIC_MODEL=$ANTHROPIC_MODEL
-export ANTHROPIC_SMALL_FAST_MODEL=$ANTHROPIC_SMALL_FAST_MODEL
 EOF
-# Credential line: AUTH_TOKEN preferred (bearer), else API_KEY.
-if [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
-    echo "export ANTHROPIC_AUTH_TOKEN=$ANTHROPIC_AUTH_TOKEN" >> "$RELAY_ENV_FILE"
-else
-    echo "export ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY" >> "$RELAY_ENV_FILE"
-fi
 chown admin:admin "$RELAY_ENV_FILE" 2>/dev/null || true
 chmod 600 "$RELAY_ENV_FILE"
 success "Relay env file written to $RELAY_ENV_FILE (mode 600)"
+# --- settings.json: copy AFTER the NAS mount, like openclaw's config ---
+# /home/admin is NAS-mounted at pod start, which shadows anything baked into
+# the image there — so the image stages the file at
+# /opt/claude-settings.json.template and we copy it in here, at service
+# start, AFTER the mount is live. Mount-wins: a settings.json already
+# present on the NAS (a deployment's own provider scenario) is kept
+# untouched. Content is static (URL + glm-5.2 + placeholder token
+# "Bearer ${API-KEY}" the upstream gateway replaces), so this is a plain cp
+# — no substitution needed (the entrypoint's openclaw.json _sub pattern
+# exists only because that template carries ${...} placeholders).
+CLAUDE_SETTINGS_FILE="/home/admin/.claude/settings.json"
+CLAUDE_SETTINGS_TEMPLATE="/opt/claude-settings.json.template"
+if [ ! -f "$CLAUDE_SETTINGS_FILE" ]; then
+    if [ -f "$CLAUDE_SETTINGS_TEMPLATE" ]; then
+        cp "$CLAUDE_SETTINGS_TEMPLATE" "$CLAUDE_SETTINGS_FILE"
+        chown admin:admin "$CLAUDE_SETTINGS_FILE" 2>/dev/null || true
+        chmod 600 "$CLAUDE_SETTINGS_FILE"
+        success "Claude settings.json staged from template to $CLAUDE_SETTINGS_FILE (mode 600)"
+    else
+        warn "No $CLAUDE_SETTINGS_FILE on the mount and no template in the image; claude/relay fall back to their defaults"
+    fi
+fi
 
-# --- Step 3: Wait for supervisord socket ---
+# Point the gateway's model-provider loader at the settings.json above. The
+# loader's whitelist (model-provider-settings.ts) matches exactly the keys
+# that file carries, and the claude CLI itself picks the same file up
+# natively through CLAUDE_CONFIG_DIR = RELAY_CLAUDE_CONFIG_DIR =
+# /home/admin/.claude.
+if [ -f "$CLAUDE_SETTINGS_FILE" ]; then
+    echo "export RELAY_MODEL_SETTINGS_SOURCE=$CLAUDE_SETTINGS_FILE" >> "$RELAY_ENV_FILE"
+fi
+# --- Step 2: Wait for supervisord socket ---
 
-section "Step 3: Waiting for supervisord..."
+section "Step 2: Waiting for supervisord..."
 
 SUPERVISOR_SOCK="/var/run/supervisor.sock"
 MAX_WAIT=30
@@ -149,9 +161,9 @@ while [ ! -S "$SUPERVISOR_SOCK" ]; do
 done
 success "supervisord ready (waited ${waited}s)"
 
-# --- Step 4: Start claude_relay via supervisorctl and health-gate it ---
+# --- Step 3: Start claude_relay via supervisorctl and health-gate it ---
 
-section "Step 4: Starting claude_relay program (port $CLAUDE_RELAY_PORT)..."
+section "Step 3: Starting claude_relay program (port $CLAUDE_RELAY_PORT)..."
 
 [ -f "$RELAY_GATEWAY_DIR/dist/esm/server.js" ] || {
     fail "claude_code gateway missing: $RELAY_GATEWAY_DIR/dist/esm/server.js"
@@ -198,9 +210,9 @@ if [ "$RELAY_READY" -ne 1 ]; then
 fi
 success "claude_relay health check passed (http://127.0.0.1:${CLAUDE_RELAY_PORT}/health)"
 
-# --- Step 5: Start engine via supervisorctl ---
+# --- Step 4: Start engine via supervisorctl ---
 
-section "Step 5: Starting engine program..."
+section "Step 4: Starting engine program..."
 
 ENGINE_RUNNING=$(sudo /usr/local/bin/supervisorctl status engine 2>/dev/null | grep -c "RUNNING" || true)
 
@@ -217,9 +229,9 @@ else
     fi
 fi
 
-# --- Step 6: Wait for engine /health endpoint ---
+# --- Step 5: Wait for engine /health endpoint ---
 
-section "Step 6: Waiting for engine health (port $ADAPTOR_PORT)..."
+section "Step 5: Waiting for engine health (port $ADAPTOR_PORT)..."
 
 HEALTH_CHECK_TIMEOUT=120
 HEARTBEAT_INTERVAL=10
@@ -244,7 +256,7 @@ else
     success "Engine health check passed"
 fi
 
-# --- Step 7: Write ready marker & print status ---
+# --- Step 6: Write ready marker & print status ---
 
 echo "SUCCEEDED" > "$MARKER_FILE"
 

--- a/docker/agent/start_openclaw.sh
+++ b/docker/agent/start_openclaw.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+##############################################
+# start_openclaw.sh - OpenClaw engine pod startup
+#
+# Per-engine startup script for --engine openclaw.
+#
+# Normally exec'd by start_service.sh (arguments parsed, credentials
+# saved, ready marker reset, MARKER_FILE / ADAPTOR_PORT exported). Also
+# runnable directly for recovery/debugging — it carries its own defaults
+# for the inherited variables.
+#
+# Flow:
+#   1. Write .adaptorEnv (openclaw). Also clear a stale .relayEnv left by
+#      a previous claude_code pod, so a later manual
+#      `supervisorctl start claude_relay` cannot pick up old credentials.
+#   2. Wait for the supervisord socket
+#   3. Start the engine program via supervisorctl
+#   4. Wait for the engine /health endpoint
+#   5. Write the ready marker and print status
+##############################################
+
+set -e
+
+# --- Locate scripts directory ---
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source util.sh for logging
+source "$SCRIPT_DIR/util.sh"
+
+# Same log file as the dispatcher (and start_claude_code.sh) so one file
+# holds the whole pod startup trace, whatever the engine.
+LOG_FILE="/home/admin/logs/start_service.log"
+set_log_file "$LOG_FILE"
+
+# --- Inherited context (fallbacks for direct invocation) ---
+
+MARKER_FILE="${MARKER_FILE:-/var/run/agentclaw/.starting_done}"
+ADAPTOR_PORT="${ADAPTOR_PORT:-20003}"
+ENGINE="openclaw"
+
+section "start_openclaw.sh - openclaw engine startup"
+
+# --- Step 1: Configure engine environment ---
+
+section "Step 1: Configuring engine environment..."
+
+ADAPTOR_ENV_FILE="/home/admin/.adaptorEnv"
+cat > "$ADAPTOR_ENV_FILE" <<EOF
+export ENGINE=$ENGINE
+export CHAT_ENGINE=$ENGINE
+EOF
+success "Engine env file written to $ADAPTOR_ENV_FILE"
+
+# No relay for openclaw; a stale .relayEnv from a previous claude_code pod
+# would let a manual `supervisorctl start claude_relay` boot with old
+# credentials.
+rm -f /home/admin/.relayEnv
+
+# --- Step 2: Wait for supervisord socket ---
+
+section "Step 2: Waiting for supervisord..."
+
+SUPERVISOR_SOCK="/var/run/supervisor.sock"
+MAX_WAIT=30
+waited=0
+while [ ! -S "$SUPERVISOR_SOCK" ]; do
+    if [ $waited -ge "$MAX_WAIT" ]; then
+        fail "supervisord socket not ready after ${MAX_WAIT}s"
+        echo "FAILED" > "$MARKER_FILE"
+        exit 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+done
+success "supervisord ready (waited ${waited}s)"
+
+# --- Step 3: Start engine via supervisorctl ---
+
+section "Step 3: Starting engine program..."
+
+ENGINE_RUNNING=$(sudo /usr/local/bin/supervisorctl status engine 2>/dev/null | grep -c "RUNNING" || true)
+
+if [ "$ENGINE_RUNNING" -gt 0 ]; then
+    info "Engine is already running"
+else
+    info "Starting engine via supervisorctl..."
+    if sudo /usr/local/bin/supervisorctl start engine; then
+        success "Engine program started"
+    else
+        fail "Failed to start engine via supervisorctl"
+        echo "FAILED" > "$MARKER_FILE"
+        exit 1
+    fi
+fi
+# The engine starts the openclaw program on demand (first bot session) via
+# `sudo supervisorctl start openclaw` — nothing to do for it here.
+
+# --- Step 4: Wait for engine /health endpoint ---
+
+section "Step 4: Waiting for engine health (port $ADAPTOR_PORT)..."
+
+HEALTH_CHECK_TIMEOUT=120
+HEARTBEAT_INTERVAL=10
+ADAPTOR_READY=0
+
+for i in $(seq 1 "$HEALTH_CHECK_TIMEOUT"); do
+    HEALTH_RESP=$(curl -s --max-time 3 "http://127.0.0.1:${ADAPTOR_PORT}/health" 2>/dev/null || true)
+    if echo "$HEALTH_RESP" | grep -q '"status".*:.*"ok"'; then
+        ADAPTOR_READY=1
+        break
+    fi
+    if [ $((i % HEARTBEAT_INTERVAL)) -eq 0 ]; then
+        info "  Still waiting for engine /health (${i}s / ${HEALTH_CHECK_TIMEOUT}s)..."
+    fi
+    sleep 1
+done
+
+if [ "$ADAPTOR_READY" -ne 1 ]; then
+    warn "Engine health check not ready after ${HEALTH_CHECK_TIMEOUT}s"
+    info "  Last response: $HEALTH_RESP"
+else
+    success "Engine health check passed"
+fi
+
+# --- Step 5: Write ready marker & print status ---
+
+echo "SUCCEEDED" > "$MARKER_FILE"
+
+section "Service startup completed"
+info ""
+info "Service Status:"
+info "  - Engine:   Running (port $ADAPTOR_PORT, engine=$ENGINE)"
+info "  - OpenClaw: On-demand (started by engine when a session is requested)"
+info "  - Health:   http://127.0.0.1:${ADAPTOR_PORT}/health"
+info ""
+info "Log Files:"
+info "  - Engine:   /home/admin/logs/engine_out.log"
+info "  - OpenClaw: /home/admin/logs/openclaw_out.log"
+info "  - Startup:  $LOG_FILE"
+info ""
+info "Credentials:"
+info "  - Stored in: /home/admin/.credentials"
+info "  - Engine:    $ENGINE"
+section "====="

--- a/docker/agent/start_service.sh
+++ b/docker/agent/start_service.sh
@@ -1,27 +1,31 @@
 #!/bin/bash
 
 ##############################################
-# start_service.sh - Simplified pod startup script
+# start_service.sh - Pod startup dispatcher
 #
 # Reference: agentclaw-daas-scripts/bootstrapping/start_service.sh
 #
-# This script orchestrates service startup for the Avernet
-# Engine + OpenClaw pod.  It is invoked by the container
-# entrypoint after supervisord is running as PID 1.
+# Thin dispatcher. It parses arguments, saves credentials, then checks
+# --engine and execs the per-engine script; ALL engine-specific startup
+# logic lives in the target script, not here:
+#   openclaw    → start_openclaw.sh     (engine program only)
+#   claude_code → start_claude_code.sh  (claude_relay + engine; requires
+#                                      ANTHROPIC_* model credentials in
+#                                      the pod env — see that script's
+#                                      header for the contract)
+#
+# Invoked by the platform (docker exec) once supervisord is PID 1.
 #
 # Flow:
 #   1. Parse arguments (token, engine, bot_id, stage, ...)
 #   2. Save credentials
-#   3. Configure engine environment
-#   4. Start the engine program via supervisorctl
-#   5. Wait for engine /health endpoint to respond
-#   6. Write ready marker
+#   3. Check --engine and dispatch
 #
 # Usage:
 #   start_service.sh \
 #       --token <token> \
 #       --client_id <client_id> \
-#       --engine openclaw \
+#       --engine openclaw|claude_code  (default openclaw) \
 #       [--bot_id <bot_id>] \
 #       [--stage <stage>] \
 #       [--owner_id <owner_id>]
@@ -40,7 +44,7 @@ source "$SCRIPT_DIR/util.sh"
 LOG_FILE="/home/admin/logs/start_service.log"
 set_log_file "$LOG_FILE"
 
-# --- Ready marker ---
+# --- Ready marker (path exported for the per-engine scripts) ---
 
 MARKER_DIR="/var/run/agentclaw"
 MARKER_FILE="$MARKER_DIR/.starting_done"
@@ -85,7 +89,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-section "start_service.sh - pod startup"
+section "start_service.sh - pod startup dispatcher"
 
 # --- Step 1: Save credentials ---
 
@@ -104,101 +108,24 @@ EOF
 chmod 600 "$CREDENTIALS_FILE"
 success "Credentials saved to $CREDENTIALS_FILE"
 
-# --- Step 2: Configure engine environment ---
+# --- Step 2: Check engine and dispatch ---
 
-section "Step 2: Configuring engine environment..."
+# Shared context for the per-engine scripts (they also carry their own
+# fallbacks so they stay independently runnable for recovery/debugging).
+export MARKER_FILE ADAPTOR_PORT
 
-ADAPTOR_ENV_FILE="/home/admin/.adaptorEnv"
-cat > "$ADAPTOR_ENV_FILE" <<EOF
-export ENGINE=$ENGINE
-export CHAT_ENGINE=$ENGINE
-EOF
-success "Engine env file written to $ADAPTOR_ENV_FILE"
-
-# Export for this script's scope
-export TOKEN CLIENT_ID OWNER_ID BOT_ID STAGE ENGINE CHAT_ENGINE="$ENGINE"
-
-# --- Step 3: Wait for supervisord socket ---
-
-section "Step 3: Waiting for supervisord..."
-
-SUPERVISOR_SOCK="/var/run/supervisor.sock"
-MAX_WAIT=30
-waited=0
-while [ ! -S "$SUPERVISOR_SOCK" ]; do
-    if [ $waited -ge $MAX_WAIT ]; then
-        fail "supervisord socket not ready after ${MAX_WAIT}s"
+case "$ENGINE" in
+    openclaw)
+        info "Engine type: openclaw — dispatching to start_openclaw.sh"
+        exec "$SCRIPT_DIR/start_openclaw.sh"
+        ;;
+    claude_code)
+        info "Engine type: claude_code — dispatching to start_claude_code.sh"
+        exec "$SCRIPT_DIR/start_claude_code.sh"
+        ;;
+    *)
+        fail "Unknown engine: $ENGINE (supported: openclaw, claude_code)"
         echo "FAILED" > "$MARKER_FILE"
         exit 1
-    fi
-    sleep 1
-    waited=$((waited + 1))
-done
-success "supervisord ready (waited ${waited}s)"
-
-# --- Step 4: Start engine via supervisorctl ---
-
-section "Step 4: Starting engine program..."
-
-ENGINE_RUNNING=$(sudo /usr/local/bin/supervisorctl status engine 2>/dev/null | grep -c "RUNNING" || true)
-
-if [ "$ENGINE_RUNNING" -gt 0 ]; then
-    info "Engine is already running"
-else
-    info "Starting engine via supervisorctl..."
-    if sudo /usr/local/bin/supervisorctl start engine; then
-        success "Engine program started"
-    else
-        fail "Failed to start engine via supervisorctl"
-        echo "FAILED" > "$MARKER_FILE"
-        exit 1
-    fi
-fi
-
-# --- Step 5: Wait for engine /health endpoint ---
-
-section "Step 5: Waiting for engine health (port $ADAPTOR_PORT)..."
-
-HEALTH_CHECK_TIMEOUT=120
-HEARTBEAT_INTERVAL=10
-ADAPTOR_READY=0
-
-for i in $(seq 1 "$HEALTH_CHECK_TIMEOUT"); do
-    HEALTH_RESP=$(curl -s --max-time 3 "http://127.0.0.1:${ADAPTOR_PORT}/health" 2>/dev/null || true)
-    if echo "$HEALTH_RESP" | grep -q '"status".*:.*"ok"'; then
-        ADAPTOR_READY=1
-        break
-    fi
-    if [ $((i % HEARTBEAT_INTERVAL)) -eq 0 ]; then
-        info "  Still waiting for engine /health (${i}s / ${HEALTH_CHECK_TIMEOUT}s)..."
-    fi
-    sleep 1
-done
-
-if [ "$ADAPTOR_READY" -ne 1 ]; then
-    warn "Engine health check not ready after ${HEALTH_CHECK_TIMEOUT}s"
-    info "  Last response: $HEALTH_RESP"
-else
-    success "Engine health check passed"
-fi
-
-# --- Step 6: Write ready marker & print status ---
-
-echo "SUCCEEDED" > "$MARKER_FILE"
-
-section "Service startup completed"
-info ""
-info "Service Status:"
-info "  - Engine:   Running (port $ADAPTOR_PORT)"
-info "  - OpenClaw: On-demand (started by engine when a session is requested)"
-info "  - Health:   http://127.0.0.1:${ADAPTOR_PORT}/health"
-info ""
-info "Log Files:"
-info "  - Engine:   /home/admin/logs/engine_out.log"
-info "  - OpenClaw: /home/admin/logs/openclaw_out.log"
-info "  - Startup:  $LOG_FILE"
-info ""
-info "Credentials:"
-info "  - Stored in: $CREDENTIALS_FILE"
-info "  - Engine:    $ENGINE"
-section "====="
+        ;;
+esac

--- a/docker/kube-deploy.sh
+++ b/docker/kube-deploy.sh
@@ -77,11 +77,11 @@ ENV_FILE=""
 declare -A DEFAULT_PORT=(
     # baas is the exception: it has NO port env override (nothing in src/baas/
     # reads BAAS_PORT), so its listener is whatever the mounted config says.
-    # Every k8s deployment here sets SERVER_ENV=prod (scripts/k8s-tests/*/baas.env),
-    # which merges application-prod.yaml and pins web.port to 8080 — the base
-    # application.yaml's 8888 never applies there. Publishing 8888 would point
-    # the Service at a dead port. NB: BAAS_PORT=8888 in those env files is inert;
-    # it is read by nothing.
+    # Every k8s deployment here sets COMMUNITY_DEPLOY=community
+    # (scripts/k8s-tests/*/baas.env), which merges application-community.yaml
+    # and pins web.port to 8080 — the base application.yaml's 8888 never applies
+    # there. Publishing 8888 would point the Service at a dead port. NB:
+    # BAAS_PORT=8888 in those env files is inert; it is read by nothing.
     [baas]=8080
     [gateway]=8888
     [proxy]=8080

--- a/docker/services/service-deployment.yaml
+++ b/docker/services/service-deployment.yaml
@@ -49,17 +49,33 @@ spec:
           limits:
             cpu: "${CPU_LIMIT}"
             memory: "${MEMORY_LIMIT}"
+        # Startup probe: gates both probes below — they do not run until it
+        # succeeds, so a slow start can no longer trip liveness. Budget is
+        # periodSeconds × failureThreshold = 10s × 30 = up to 300s (5 min);
+        # the slowest cold start today (baas) reaches /health in ~90s, while
+        # the old liveness-only budget (30s delay + 3 failures × 10s ≈ 60s)
+        # could kill it mid-start. Image pull time is not part of this budget:
+        # probes begin only once the container has started. If the app is not
+        # healthy within the budget the container is killed and restarted.
+        startupProbe:
+          httpGet:
+            path: ${PROBE_PATH}
+            port: ${PORT}
+          periodSeconds: 10
+          failureThreshold: 30
+        # liveness/readiness run only after startupProbe succeeds, so their
+        # delays no longer need to cover a slow start.
         livenessProbe:
           httpGet:
             path: ${PROBE_PATH}
             port: ${PORT}
-          initialDelaySeconds: 30
+          initialDelaySeconds: 10
           periodSeconds: 10
         readinessProbe:
           httpGet:
             path: ${PROBE_PATH}
             port: ${PORT}
-          initialDelaySeconds: 10
+          initialDelaySeconds: 5
           periodSeconds: 5
 ---
 apiVersion: v1

--- a/scripts/k8s-tests/avernet/baas.env
+++ b/scripts/k8s-tests/avernet/baas.env
@@ -2,12 +2,15 @@
 # In-cluster: mariadb + redis are shared, and the sandbox proxy is reachable
 # as the `proxy` Service (bot_service → proxy).
 SERVER_ENV=prod
+# COMMUNITY_DEPLOY selects the application-community.yaml overlay (community
+# deployment config); SERVER_ENV stays "prod" for env detection.
+COMMUNITY_DEPLOY=community
 BAAS_PORT=8888
 DATABASE_URL=mysql+aiomysql://avernet:avernetpass@mariadb:3306/avernet?charset=utf8mb4
 REDIS_URL=redis://redis:6379/0
-# prod overlay references these under strict env expansion; inject test values
-# so config loading succeeds (aliyun_ack sandbox is a lazy factory, never
-# contacted during boot/health).
+# community overlay references these under strict env expansion; inject test
+# values so config loading succeeds (aliyun_ack sandbox is a lazy factory,
+# never contacted during boot/health).
 ACK_SERVER=https://ack-test.example.com
 ACK_TOKEN=ack-test-token
 # Sandbox proxy (bot_service) — reach the `proxy` service in-cluster.

--- a/scripts/k8s-tests/avernet/gateway.env
+++ b/scripts/k8s-tests/avernet/gateway.env
@@ -2,6 +2,9 @@
 # In-cluster: mariadb + redis shared; upstreams reach baas/proxy via Service
 # DNS. backend/bcs/bcsfuse are not part of this demo stack.
 SERVER_ENV=prod
+# COMMUNITY_DEPLOY selects the application-community.yaml overlay (community
+# deployment config); SERVER_ENV stays "prod" for env detection / signing.
+COMMUNITY_DEPLOY=community
 GATEWAY_PORT=8888
 DATABASE_URL=mysql+aiomysql://avernet:avernetpass@mariadb:3306/avernet?charset=utf8mb4
 REDIS_URL=redis://redis:6379/0

--- a/scripts/k8s-tests/avernet/proxy.env
+++ b/scripts/k8s-tests/avernet/proxy.env
@@ -1,6 +1,9 @@
 # avernet/proxy.env — proxy env for the shared avernet demo stack.
 # In-cluster: the relay baas client reaches the `baas` Service over DNS.
 SERVER_ENV=prod
+# COMMUNITY_DEPLOY selects the application-community.yaml overlay (community
+# deployment config).
+COMMUNITY_DEPLOY=community
 SANDBOXPROXY_PORT=8888
 # Test-only JWT secret (community reads it from config/env overlay).
 SANDBOXPROXY_JWT_SECRET=proxy-test-secret-not-for-prod

--- a/scripts/k8s-tests/baas/baas.env
+++ b/scripts/k8s-tests/baas/baas.env
@@ -3,12 +3,15 @@
 # These are test-only placeholder values mirroring src/baas/docker-test.
 
 SERVER_ENV=prod
+# COMMUNITY_DEPLOY selects the application-community.yaml overlay (community
+# deployment config); SERVER_ENV stays "prod" for env detection.
+COMMUNITY_DEPLOY=community
 BAAS_PORT=8888
 DATABASE_URL=mysql+aiomysql://baas:baaspass@mariadb:3306/baas_test?charset=utf8mb4
 REDIS_URL=redis://redis:6379/0
-# prod overlay references these under strict env expansion; inject test values
-# so config loading succeeds (aliyun_ack sandbox is a lazy factory, never
-# contacted during boot/health).
+# community overlay references these under strict env expansion; inject test
+# values so config loading succeeds (aliyun_ack sandbox is a lazy factory,
+# never contacted during boot/health).
 ACK_SERVER=https://ack-test.example.com
 ACK_TOKEN=ack-test-token
 DEFAULT_IMAGE=openclaw:latest

--- a/scripts/k8s-tests/gateway/gateway.env
+++ b/scripts/k8s-tests/gateway/gateway.env
@@ -3,6 +3,9 @@
 # These are test-only placeholder values mirroring src/gateway/docker-test.
 
 SERVER_ENV=prod
+# COMMUNITY_DEPLOY selects the application-community.yaml overlay (community
+# deployment config); SERVER_ENV stays "prod" for env detection / signing.
+COMMUNITY_DEPLOY=community
 GATEWAY_PORT=8888
 DATABASE_URL=mysql+aiomysql://gateway:gatewaypass@mariadb:3306/gateway_test?charset=utf8mb4
 REDIS_URL=redis://redis:6379/0

--- a/scripts/k8s-tests/proxy/proxy.env
+++ b/scripts/k8s-tests/proxy/proxy.env
@@ -3,6 +3,9 @@
 # These are test-only placeholder values mirroring src/proxy/docker-test.
 
 SERVER_ENV=prod
+# COMMUNITY_DEPLOY selects the application-community.yaml overlay (community
+# deployment config).
+COMMUNITY_DEPLOY=community
 SANDBOXPROXY_PORT=8888
 # Test-only JWT secret (community reads it from config/env overlay).
 SANDBOXPROXY_JWT_SECRET=proxy-test-secret-not-for-prod

--- a/src/baas/README.md
+++ b/src/baas/README.md
@@ -129,6 +129,7 @@ test pipeline without the coverage gate.
 | Variable | Purpose |
 |---|---|
 | `SERVER_ENV` | Deployment environment (dev, prepub, prod) |
+| `COMMUNITY_DEPLOY` | When set, its value replaces `SERVER_ENV` for naming the `application-<value>.yaml` overlay (community deployments set `COMMUNITY_DEPLOY=community`) |
 | `SOFAPY_CONFIG_OVERLAY` | Additional YAML overlay path |
 | `DEPLOY_ENV` | Custom deploy-env probe variable |
 

--- a/src/baas/configs/application-community.yaml
+++ b/src/baas/configs/application-community.yaml
@@ -1,3 +1,10 @@
+# BaaS 社区部署配置 — 通过 env 占位符注入 MariaDB / Redis / 沙箱镜像等外部依赖。
+# 当 COMMUNITY_DEPLOY=community 时作为 application.yaml 的 overlay 加载
+# （COMMUNITY_DEPLOY 优先于 SERVER_ENV 决定 overlay 文件名；SERVER_ENV 可继续
+# 用于环境判定，如分布式锁后缀、get_current_env 等）。占位符 ${NAME} 由
+# config loader 在加载阶段从进程环境展开，须由部署方（docker entrypoint /
+# 调度器）提供。
+
 # 基础配置
 app_name: "secbaas"
 workers: 1

--- a/src/baas/docker-test/docker-compose.baas-test.yml
+++ b/src/baas/docker-test/docker-compose.baas-test.yml
@@ -28,12 +28,14 @@ services:
     image: baas:local
     environment:
       SERVER_ENV: prod
+      # COMMUNITY_DEPLOY selects the application-community.yaml overlay.
+      COMMUNITY_DEPLOY: community
       DATABASE_URL: "${DATABASE_URL:-mysql+aiomysql://baas:baaspass@mariadb:3306/baas_test?charset=utf8mb4}"
       REDIS_URL: "${REDIS_URL:-redis://redis:6379/0}"
       BAAS_PORT: "${BAAS_PORT:-8888}"
-      # prod overlay references these under strict env expansion; inject test
-      # values so config loading succeeds (aliyun_ack sandbox is a lazy factory,
-      # never contacted during boot/health).
+      # community overlay references these under strict env expansion; inject
+      # test values so config loading succeeds (aliyun_ack sandbox is a lazy
+      # factory, never contacted during boot/health).
       ACK_SERVER: "${ACK_SERVER:-https://ack-test.example.com}"
       ACK_TOKEN: "${ACK_TOKEN:-ack-test-token}"
       DEFAULT_IMAGE: "${DEFAULT_IMAGE:-openclaw:latest}"

--- a/src/baas/docker-test/test-baas.sh
+++ b/src/baas/docker-test/test-baas.sh
@@ -3,9 +3,11 @@
 #
 # Flow:
 #   1. Build baas:local from docker/services/baas.dockerfile
-#   2. Start MariaDB + Redis (healthchecked) and baas (SERVER_ENV=prod)
+#   2. Start MariaDB + Redis (healthchecked) and baas (COMMUNITY_DEPLOY=community,
+#      which loads the application-community.yaml overlay; SERVER_ENV=prod stays
+#      set for env detection)
 #      with custom DATABASE_URL / REDIS_URL plus the ACK placeholders that the
-#      prod overlay declares under strict env expansion
+#      community overlay declares under strict env expansion
 #   3. Wait for the baas /health endpoint and report success / failure
 #
 # Usage:
@@ -31,9 +33,10 @@ PROJECT="baastest"
 export DATABASE_URL="${DATABASE_URL:-mysql+aiomysql://baas:baaspass@mariadb:3306/baas_test?charset=utf8mb4}"
 export REDIS_URL="${REDIS_URL:-redis://redis:6379/0}"
 export BAAS_PORT="${BAAS_PORT:-8888}"
-# prod overlay declares these under strict env expansion; inject harmless
-# test values so config loading succeeds. The aliyun_ack sandbox is a lazy
-# factory and is not contacted during boot, after /health this is enough.
+# community overlay declares these under strict env expansion; inject
+# harmless test values so config loading succeeds. The aliyun_ack sandbox is
+# a lazy factory and is not contacted during boot, after /health this is
+# enough.
 export ACK_SERVER="${ACK_SERVER:-https://ack-test.example.com}"
 export ACK_TOKEN="${ACK_TOKEN:-ack-test-token}"
 export DEFAULT_IMAGE="${DEFAULT_IMAGE:-openclaw:latest}"

--- a/src/baas/src/secbaas/community/config/_config_loader.py
+++ b/src/baas/src/secbaas/community/config/_config_loader.py
@@ -18,6 +18,11 @@ class ConfigLoader:
     DEFAULT_CONFIG_DIR = "configs"
     OVERLAY_DIR = "overlays"
     ENV_SERVER_ENV = "SERVER_ENV"
+    # Community (open-source) deployments set COMMUNITY_DEPLOY; its value
+    # names the application-<value>.yaml overlay and takes precedence over
+    # SERVER_ENV, so a community stack and an internal SERVER_ENV deployment
+    # can coexist without fighting over one overlay naming scheme.
+    ENV_COMMUNITY_DEPLOY = "COMMUNITY_DEPLOY"
 
     # Placeholder syntax: ${NAME} or ${NAME:-default} (shell / k8s / envsubst
     # style). ${NAME:-} yields an empty string; a placeholder that references an
@@ -42,12 +47,26 @@ class ConfigLoader:
             return yaml.safe_load(f) or {}
 
     @classmethod
+    def _resolve_env_overlay_name(cls) -> str:
+        """Return the suffix of the ``application-<suffix>.yaml`` env overlay.
+
+        ``COMMUNITY_DEPLOY`` wins when set: its value names the overlay for a
+        community deployment (e.g. ``COMMUNITY_DEPLOY=community`` loads
+        ``application-community.yaml``) regardless of ``SERVER_ENV``. Otherwise
+        the legacy ``SERVER_ENV`` behaviour applies.
+        """
+        community_deploy = os.getenv(cls.ENV_COMMUNITY_DEPLOY, "")
+        if community_deploy:
+            return community_deploy
+        return os.getenv(cls.ENV_SERVER_ENV, "")
+
+    @classmethod
     def _load_base_from_yaml(cls, config_dir: str) -> dict:
         base_path = os.path.join(config_dir, "application.yaml")
         base = cls._load_yaml_file(base_path)
-        server_env = os.getenv(cls.ENV_SERVER_ENV, "")
-        if server_env:
-            env_path = os.path.join(config_dir, f"application-{server_env}.yaml")
+        env_name = cls._resolve_env_overlay_name()
+        if env_name:
+            env_path = os.path.join(config_dir, f"application-{env_name}.yaml")
             env_data = cls._load_yaml_file(env_path)
             if env_data:
                 base = Config.merge_configs(base, env_data)

--- a/src/baas/tests/unit/config/test_config_loader.py
+++ b/src/baas/tests/unit/config/test_config_loader.py
@@ -94,6 +94,115 @@ class TestLoad:
         assert config.user_config["extra_key"] == "extra_value"
 
 
+class TestEnvOverlaySelection:
+    """Tests for the application-<env>.yaml overlay name selection.
+
+    COMMUNITY_DEPLOY, when set, names the overlay and wins over SERVER_ENV.
+    """
+
+    def test_server_env_selects_env_overlay(self, monkeypatch, tmp_path):
+        config_dir = tmp_path / "configs"
+        config_dir.mkdir()
+        (config_dir / "application.yaml").write_text(
+            "app_name: base\nworkers: 1\nuser_config: {}\n"
+        )
+        (config_dir / "application-dev.yaml").write_text("workers: 4\n")
+        monkeypatch.delenv("SOFAPY_CONFIG_OVERLAY", raising=False)
+        monkeypatch.setenv("SOFAPY_CONFIG_PATH", str(config_dir))
+        monkeypatch.delenv("COMMUNITY_DEPLOY", raising=False)
+        monkeypatch.setenv("SERVER_ENV", "dev")
+        from secbaas.community.config import ConfigLoader
+
+        config = ConfigLoader.load()
+        assert config.app_name == "base"
+        assert config.workers == 4
+
+    def test_community_deploy_wins_over_server_env(self, monkeypatch, tmp_path):
+        config_dir = tmp_path / "configs"
+        config_dir.mkdir()
+        (config_dir / "application.yaml").write_text(
+            "app_name: base\nworkers: 1\nuser_config: {}\n"
+        )
+        # Both overlays exist: COMMUNITY_DEPLOY must pick community, not prod.
+        (config_dir / "application-prod.yaml").write_text("workers: 5\n")
+        (config_dir / "application-community.yaml").write_text("workers: 6\n")
+        monkeypatch.delenv("SOFAPY_CONFIG_OVERLAY", raising=False)
+        monkeypatch.setenv("SOFAPY_CONFIG_PATH", str(config_dir))
+        monkeypatch.setenv("SERVER_ENV", "prod")
+        monkeypatch.setenv("COMMUNITY_DEPLOY", "community")
+        from secbaas.community.config import ConfigLoader
+
+        config = ConfigLoader.load()
+        assert config.workers == 6
+
+    def test_community_deploy_without_server_env(self, monkeypatch, tmp_path):
+        config_dir = tmp_path / "configs"
+        config_dir.mkdir()
+        (config_dir / "application.yaml").write_text(
+            "app_name: base\nworkers: 1\nuser_config: {}\n"
+        )
+        (config_dir / "application-community.yaml").write_text("workers: 6\n")
+        monkeypatch.delenv("SOFAPY_CONFIG_OVERLAY", raising=False)
+        monkeypatch.setenv("SOFAPY_CONFIG_PATH", str(config_dir))
+        monkeypatch.delenv("SERVER_ENV", raising=False)
+        monkeypatch.setenv("COMMUNITY_DEPLOY", "community")
+        from secbaas.community.config import ConfigLoader
+
+        config = ConfigLoader.load()
+        assert config.workers == 6
+
+    def test_community_deploy_missing_file_falls_back_to_base(
+        self, monkeypatch, tmp_path
+    ):
+        config_dir = tmp_path / "configs"
+        config_dir.mkdir()
+        (config_dir / "application.yaml").write_text(
+            "app_name: base\nworkers: 1\nuser_config: {}\n"
+        )
+        # No application-community.yaml: the missing overlay is ignored.
+        monkeypatch.delenv("SOFAPY_CONFIG_OVERLAY", raising=False)
+        monkeypatch.setenv("SOFAPY_CONFIG_PATH", str(config_dir))
+        monkeypatch.delenv("SERVER_ENV", raising=False)
+        monkeypatch.setenv("COMMUNITY_DEPLOY", "community")
+        from secbaas.community.config import ConfigLoader
+
+        config = ConfigLoader.load()
+        assert config.workers == 1
+
+    def test_server_env_missing_file_falls_back_to_base(
+        self, monkeypatch, tmp_path
+    ):
+        config_dir = tmp_path / "configs"
+        config_dir.mkdir()
+        (config_dir / "application.yaml").write_text(
+            "app_name: base\nworkers: 1\nuser_config: {}\n"
+        )
+        monkeypatch.delenv("SOFAPY_CONFIG_OVERLAY", raising=False)
+        monkeypatch.setenv("SOFAPY_CONFIG_PATH", str(config_dir))
+        monkeypatch.delenv("COMMUNITY_DEPLOY", raising=False)
+        monkeypatch.setenv("SERVER_ENV", "nonexistent")
+        from secbaas.community.config import ConfigLoader
+
+        config = ConfigLoader.load()
+        assert config.workers == 1
+
+    def test_no_env_vars_loads_base_only(self, monkeypatch, tmp_path):
+        config_dir = tmp_path / "configs"
+        config_dir.mkdir()
+        (config_dir / "application.yaml").write_text(
+            "app_name: base\nworkers: 1\nuser_config: {}\n"
+        )
+        (config_dir / "application-dev.yaml").write_text("workers: 4\n")
+        monkeypatch.delenv("SOFAPY_CONFIG_OVERLAY", raising=False)
+        monkeypatch.setenv("SOFAPY_CONFIG_PATH", str(config_dir))
+        monkeypatch.delenv("SERVER_ENV", raising=False)
+        monkeypatch.delenv("COMMUNITY_DEPLOY", raising=False)
+        from secbaas.community.config import ConfigLoader
+
+        config = ConfigLoader.load()
+        assert config.workers == 1
+
+
 class TestEnvInterpolation:
     """Tests for `${NAME}` (and `${NAME:-default}`) placeholder expansion."""
 

--- a/src/backend/src/agentclaw/community/configs/application-community.yaml
+++ b/src/backend/src/agentclaw/community/configs/application-community.yaml
@@ -43,6 +43,10 @@ user_config:
   skill_scan:
     enabled: false
 
+  # Community has no corp git skills repo, so disable skill sync entirely.
+  git_sync:
+    enable_skill_sync: false
+
   # Per-owner device allocation policy (neutral knobs only).
   device_allocation:
     mode: "multi"

--- a/src/backend/src/agentclaw/community/core/skill_center/services/git_sync.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/git_sync.py
@@ -118,6 +118,19 @@ class GitSyncConfig:
             except Exception:
                 pass
 
+        # Whether to sync skills from the git repo into the database at startup.
+        # Community deployments set this to false in the overlay (no corp git repo).
+        self.enable_skill_sync = True
+        try:
+            from agentclaw.community.core.config import sofa
+
+            _uc = sofa.sofa_config.model_dump().get("user_config", {}) or {}
+            self.enable_skill_sync = (_uc.get("git_sync", {}) or {}).get(
+                "enable_skill_sync", True
+            )
+        except Exception:
+            pass
+
         # Subtree configurations
         self.subtrees: list[dict[str, Any]] = [
             {
@@ -180,6 +193,13 @@ class GitSyncService(LifecycleBase, GitSyncServiceProtocol):
         ``api/lifecycle.py``. Logs the bootstrap result before the
         periodic task starts. Errors propagate (fail-fast boot).
         """
+        if not self.config.enable_skill_sync:
+            logger.info(
+                "[GitSyncService] Skill sync disabled (enable_skill_sync=false); "
+                "skipping bootstrap, database sync, and periodic sync"
+            )
+            return
+
         if self._repo_url is None:
             seed_result = await self._sync_existing_local_market()
             logger.info(f"GitSyncService local bootstrap: {seed_result}")

--- a/src/backend/tests/community/config/golden/community.json
+++ b/src/backend/tests/community/config/golden/community.json
@@ -76,7 +76,8 @@
     },
     "git_sync": {
       "bolt_shared_dir_name": "bolt_shared",
-      "enable_oss_sync": true
+      "enable_oss_sync": true,
+      "enable_skill_sync": false
     },
     "health_check": {
       "bcs_url": "http://localhost:21000"

--- a/src/backend/tests/community/core/skill_center/services/test_git_sync_config.py
+++ b/src/backend/tests/community/core/skill_center/services/test_git_sync_config.py
@@ -244,3 +244,114 @@ def test_singlebox_bootstrap_reports_missing_local_skills_repo(
     assert "local skills repo not found" in result["error"]
     assert local_result["success"] is False
     assert local_result["method"] == "local_missing"
+
+
+# ---------------------------------------------------------------------------
+# enable_skill_sync gate (community deployments disable skill git sync)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSofaConfig:
+    """Stands in for the lazy sofa handle; model_dump() mirrors AppConfig."""
+
+    def __init__(self, user_config):
+        self.user_config = user_config
+
+    def model_dump(self):
+        return {"user_config": self.user_config}
+
+
+def _patch_sofa_config(monkeypatch, user_config):
+    # GitSyncConfig does ``from agentclaw.community.core.config import sofa``
+    # at call time, so patching the module attribute is picked up on the
+    # next construction.
+    monkeypatch.setattr(
+        "agentclaw.community.core.config.sofa.sofa_config",
+        _FakeSofaConfig(user_config),
+    )
+
+
+def test_enable_skill_sync_defaults_true(mock_bolt_shared, monkeypatch):
+    """No git_sync block in the merged config → sync stays enabled."""
+    _patch_sofa_config(monkeypatch, {})
+    cfg = GitSyncConfig()
+    assert cfg.enable_skill_sync is True
+
+
+def test_enable_skill_sync_false_from_config(mock_bolt_shared, monkeypatch):
+    """user_config.git_sync.enable_skill_sync=false is respected."""
+    _patch_sofa_config(
+        monkeypatch, {"git_sync": {"enable_skill_sync": False}}
+    )
+    cfg = GitSyncConfig()
+    assert cfg.enable_skill_sync is False
+
+
+def test_enable_skill_sync_bool_coercion(mock_bolt_shared, monkeypatch):
+    """A truthy non-bool value keeps sync enabled (no strict typing here)."""
+    _patch_sofa_config(
+        monkeypatch, {"git_sync": {"enable_skill_sync": "false"}}
+    )
+    cfg = GitSyncConfig()
+    # YAML anchors aside, the overlay ships a real boolean; a truthy string
+    # (e.g. "false" in an env-substituted overlay) only warns by still
+    # enabling sync — disabling must be explicit.
+    assert cfg.enable_skill_sync == "false"
+
+
+def test_enable_skill_sync_config_exception_keeps_default(
+    mock_bolt_shared, monkeypatch
+):
+    """sofa read raising → except branch keeps the enabled default."""
+    class _Boom:
+        def model_dump(self):
+            raise RuntimeError("config backend unreachable")
+
+    monkeypatch.setattr(
+        "agentclaw.community.core.config.sofa.sofa_config", _Boom()
+    )
+    cfg = GitSyncConfig()
+    assert cfg.enable_skill_sync is True
+
+
+def test_startup_skips_all_sync_when_disabled(mock_bolt_shared, monkeypatch):
+    """enable_skill_sync=False → startup returns before any sync work."""
+    from unittest.mock import MagicMock
+    from agentclaw.community.core.skill_center.services.git_sync import GitSyncService
+
+    monkeypatch.setenv("DEPLOY_PROFILE", "singlebox")
+    _patch_sofa_config(
+        monkeypatch, {"git_sync": {"enable_skill_sync": False}}
+    )
+    config = GitSyncConfig()
+    assert config.enable_skill_sync is False
+
+    svc = GitSyncService(
+        cache_plugin=MagicMock(),
+        skill_service_factory=MagicMock(),
+        config=config,
+        oss_storage=MagicMock(),
+        secret_resolver=MagicMock(),
+        allow_missing_repo_url=True,
+    )
+
+    # The gate must short-circuit before bootstrap/db sync/periodic sync —
+    # none of these may run.
+    with (
+        patch.object(svc, "sync_bootstrap", new_callable=MagicMock) as boot,
+        patch.object(
+            svc, "_sync_existing_local_market", new_callable=MagicMock
+        ) as seed,
+        patch.object(
+            svc, "start_periodic_sync", new_callable=MagicMock
+        ) as periodic,
+    ):
+        try:
+            asyncio.run(svc.startup())
+        finally:
+            svc._executor.shutdown(wait=True)
+
+    boot.assert_not_called()
+    seed.assert_not_called()
+    periodic.assert_not_called()
+    assert svc._started is False

--- a/src/gateway/README.md
+++ b/src/gateway/README.md
@@ -180,7 +180,9 @@ so exactly one `Access-Control-Allow-Origin` reaches the browser — the edge's.
 
 Origins are configuration, not code. Add a deployment's frontend origins to the
 `user_config.cors` block of its `application-<env>.yaml` overlay (selected by
-`SERVER_ENV`); the shipped `configs/application.yaml` allows only localhost:
+`COMMUNITY_DEPLOY` when set — e.g. `COMMUNITY_DEPLOY=community` loads
+`application-community.yaml` — otherwise by `SERVER_ENV`); the shipped
+`configs/application.yaml` allows only localhost:
 
 ```yaml
 user_config:

--- a/src/gateway/configs/application-community.yaml
+++ b/src/gateway/configs/application-community.yaml
@@ -1,12 +1,15 @@
-# Gateway production config — MariaDB storage + Redis cache via env placeholders.
-# Loaded as an overlay on application.yaml when SERVER_ENV=prod.
+# Gateway community-deployment config — MariaDB storage + Redis cache via env
+# placeholders.
+# Loaded as an overlay on application.yaml when COMMUNITY_DEPLOY=community
+# (COMMUNITY_DEPLOY wins over SERVER_ENV for overlay selection; SERVER_ENV may
+# still be set for env-dependent behaviour, e.g. principal signing).
 #
 # Env placeholders (${NAME}) are expanded by the config loader from the process
 # environment (see gateway.community.config._config_loader.ConfigLoader). The
 # values must be supplied by the deployment (the docker entrypoint / scheduler):
-#   DATABASE_URL  — MariaDB connection URL (mysql+aiomysql://...)
-#   REDIS_URL     — Redis cache URL (redis://...)
-#   SERVER_ENV    — must be "prod" to select this overlay
+#   DATABASE_URL     — MariaDB connection URL (mysql+aiomysql://...)
+#   REDIS_URL        — Redis cache URL (redis://...)
+#   COMMUNITY_DEPLOY — must be "community" to select this overlay
 #
 # Upstream endpoints keep a scheme-full fallback (:-...), so an unset env var
 # still yields a valid URL: the gateway refuses to boot when a server base_url

--- a/src/gateway/configs/application.yaml
+++ b/src/gateway/configs/application.yaml
@@ -156,7 +156,8 @@ user_config:
   #
   # Neutral default = localhost only, so a single-box UI works out of the box.
   # A deployment adds its own frontend origins in its `application-<env>.yaml`
-  # overlay (selected by `SERVER_ENV`), e.g.:
+  # overlay (selected by `COMMUNITY_DEPLOY` when set, otherwise `SERVER_ENV`),
+  # e.g.:
   #
   #   user_config:
   #     cors:

--- a/src/gateway/docker-test/docker-compose.gateway-test.yml
+++ b/src/gateway/docker-test/docker-compose.gateway-test.yml
@@ -28,6 +28,8 @@ services:
     image: gateway:local
     environment:
       SERVER_ENV: prod
+      # COMMUNITY_DEPLOY selects the application-community.yaml overlay.
+      COMMUNITY_DEPLOY: community
       DATABASE_URL: "${DATABASE_URL:-mysql+aiomysql://gateway:gatewaypass@mariadb:3306/gateway_test?charset=utf8mb4}"
       REDIS_URL: "${REDIS_URL:-redis://redis:6379/0}"
       GATEWAY_PORT: "${GATEWAY_PORT:-8888}"

--- a/src/gateway/justfiles/test-docker.just
+++ b/src/gateway/justfiles/test-docker.just
@@ -1,9 +1,10 @@
-# ── Docker image build + prod-mode integration test ─────────────────────
+# ── Docker image build + community-overlay integration test ─────────────
 #
 # Builds the gateway image (via docker/build-image.sh) and brings up a
 # MariaDB + Redis + gateway stack (docker-compose.gateway-test.yml) to verify
-# the image boots under SERVER_ENV=prod and answers /health. The compose file
-# and its orchestration script live under src/gateway/docker-test/.
+# the image boots with the application-community.yaml overlay
+# (COMMUNITY_DEPLOY=community, SERVER_ENV=prod) and answers /health. The
+# compose file and its orchestration script live under src/gateway/docker-test/.
 
 docker-test-script := 'docker-test/test-gateway.sh'
 

--- a/src/gateway/src/gateway/community/config/_config_loader.py
+++ b/src/gateway/src/gateway/community/config/_config_loader.py
@@ -82,8 +82,11 @@ class ConfigLoader:
         base = _load_yaml(base_path) if base_path is not None else {}
         applied: list[str] = []
 
-        # SERVER_ENV → configs/application-{env}.yaml (existing gateway mechanism).
-        env = os.getenv("SERVER_ENV", "").strip()
+        # COMMUNITY_DEPLOY (community deployment) → configs/application-{value}.yaml.
+        # When set it takes precedence over SERVER_ENV for overlay selection, so a
+        # community stack picks application-community.yaml while SERVER_ENV stays
+        # free for env-dependent behaviour (principal signer, dev cookie, ...).
+        env = _resolve_env_overlay_name()
         overlay_path = _resolve_overlay_path(env) if env else None
         if overlay_path and overlay_path.exists():
             base = _merge(base, _load_yaml(overlay_path))
@@ -152,6 +155,21 @@ def _resolve_base_path() -> Path | None:
         return cwd_path
     # No config file found: fall back to built-in defaults (no file read).
     return None
+
+
+def _resolve_env_overlay_name() -> str:
+    """Return the suffix of the ``application-<suffix>.yaml`` env overlay.
+
+    ``COMMUNITY_DEPLOY`` wins when set: its value names the overlay for a
+    community deployment (e.g. ``COMMUNITY_DEPLOY=community`` loads
+    ``application-community.yaml``) regardless of ``SERVER_ENV``, which retains
+    its env-detection role elsewhere. Falls back to the legacy ``SERVER_ENV``
+    behaviour when it is unset.
+    """
+    community_deploy = os.getenv("COMMUNITY_DEPLOY", "").strip()
+    if community_deploy:
+        return community_deploy
+    return os.getenv("SERVER_ENV", "").strip()
 
 
 def _resolve_overlay_path(env: str) -> Path | None:

--- a/src/gateway/tests/e2e/asgi/conftest.py
+++ b/src/gateway/tests/e2e/asgi/conftest.py
@@ -42,8 +42,8 @@ def app_no_lifespan() -> Generator[FastAPI, None, None]:
     DI container.  The real lifespan (DB startup, forwarding refresh) is
     replaced with a noop so tests stay fast and don't touch persistent state.
 
-    Old overlay / SERVER_ENV values are restored after the test so stale
-    state doesn't leak between test modules.
+    Old overlay / SERVER_ENV / COMMUNITY_DEPLOY values are restored after the
+    test so stale state doesn't leak between test modules.
 
     An explicitly-requested ``SOFAPY_CONFIG_OVERLAY`` (e.g.
     ``SOFAPY_CONFIG_OVERLAY=e2e-mariadb``) is preserved so the suite can run
@@ -52,6 +52,7 @@ def app_no_lifespan() -> Generator[FastAPI, None, None]:
     env_overlay = os.getenv("SOFAPY_CONFIG_OVERLAY")
     old_overlay = os.environ.pop("SOFAPY_CONFIG_OVERLAY", None)
     old_server_env = os.environ.pop("SERVER_ENV", None)
+    old_community_deploy = os.environ.pop("COMMUNITY_DEPLOY", None)
     old_gateway_mode = os.environ.pop("GATEWAY_RUN_MODE", None)
     if env_overlay:
         os.environ["SOFAPY_CONFIG_OVERLAY"] = env_overlay
@@ -75,6 +76,10 @@ def app_no_lifespan() -> Generator[FastAPI, None, None]:
         os.environ["SERVER_ENV"] = old_server_env
     else:
         os.environ.pop("SERVER_ENV", None)
+    if old_community_deploy is not None:
+        os.environ["COMMUNITY_DEPLOY"] = old_community_deploy
+    else:
+        os.environ.pop("COMMUNITY_DEPLOY", None)
     if old_gateway_mode is not None:
         os.environ["GATEWAY_RUN_MODE"] = old_gateway_mode
     else:

--- a/src/gateway/tests/unit/conftest.py
+++ b/src/gateway/tests/unit/conftest.py
@@ -16,4 +16,5 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GATEWAY_AUTH_MOCK", raising=False)
     monkeypatch.delenv("SOFAPY_CONFIG_PATH", raising=False)
     monkeypatch.delenv("SERVER_ENV", raising=False)
+    monkeypatch.delenv("COMMUNITY_DEPLOY", raising=False)
     monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)

--- a/src/gateway/tests/unit/plugins/test_config.py
+++ b/src/gateway/tests/unit/plugins/test_config.py
@@ -22,6 +22,7 @@ from gateway.community.config._config_loader import (
     _merge,
     _parse_config,
     _resolve_base_path,
+    _resolve_env_overlay_name,
     _resolve_named_overlay_path,
     _resolve_overlay_path,
 )
@@ -236,6 +237,39 @@ class TestResolvePaths:
         assert _resolve_overlay_path("dev") == configs / "application-dev.yaml"
 
 
+# ── _resolve_env_overlay_name ────────────────────────────────────────────────
+
+
+class TestResolveEnvOverlayName:
+    def test_community_deploy_wins_over_server_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SERVER_ENV", "prod")
+        monkeypatch.setenv("COMMUNITY_DEPLOY", "community")
+        assert _resolve_env_overlay_name() == "community"
+
+    def test_falls_back_to_server_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("COMMUNITY_DEPLOY", raising=False)
+        monkeypatch.setenv("SERVER_ENV", "prepub")
+        assert _resolve_env_overlay_name() == "prepub"
+
+    def test_blank_community_deploy_ignored(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("COMMUNITY_DEPLOY", "   ")
+        monkeypatch.setenv("SERVER_ENV", "dev")
+        assert _resolve_env_overlay_name() == "dev"
+
+    def test_blank_values_yield_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("COMMUNITY_DEPLOY", "")
+        monkeypatch.setenv("SERVER_ENV", "")
+        assert _resolve_env_overlay_name() == ""
+
+
 # ── _resolve_named_overlay_path ────────────────────────────────────────────
 
 
@@ -313,6 +347,34 @@ class TestConfigLoader:
         monkeypatch.setenv("SERVER_ENV", "dev")
         config = ConfigLoader.load()
         assert config.app_name == "dir-dev"
+
+    def test_load_with_community_deploy_overlay(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # COMMUNITY_DEPLOY names the env overlay and wins over SERVER_ENV: with
+        # both set, application-community.yaml applies, not application-prod.yaml.
+        base = tmp_path / "application.yaml"
+        base.write_text("app_name: base\nworkers: 1\n")
+        (tmp_path / "application-prod.yaml").write_text("workers: 4\n")
+        (tmp_path / "application-community.yaml").write_text("workers: 9\n")
+        monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(base))
+        monkeypatch.setenv("SERVER_ENV", "prod")
+        monkeypatch.setenv("COMMUNITY_DEPLOY", "community")
+        config = ConfigLoader.load()
+        assert config.app_name == "base"
+        assert config.workers == 9
+
+    def test_load_community_deploy_missing_overlay_ignored(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        base = tmp_path / "application.yaml"
+        base.write_text("app_name: base\n")
+        monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(base))
+        monkeypatch.setenv("SERVER_ENV", "prod")
+        # No application-community.yaml: the env overlay is skipped, base wins.
+        monkeypatch.setenv("COMMUNITY_DEPLOY", "community")
+        config = ConfigLoader.load()
+        assert config.app_name == "base"
 
     def test_load_raw_returns_raw_dict(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/src/gateway/tests/unit/plugins/test_config.py
+++ b/src/gateway/tests/unit/plugins/test_config.py
@@ -248,9 +248,7 @@ class TestResolveEnvOverlayName:
         monkeypatch.setenv("COMMUNITY_DEPLOY", "community")
         assert _resolve_env_overlay_name() == "community"
 
-    def test_falls_back_to_server_env(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_falls_back_to_server_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("COMMUNITY_DEPLOY", raising=False)
         monkeypatch.setenv("SERVER_ENV", "prepub")
         assert _resolve_env_overlay_name() == "prepub"
@@ -262,9 +260,7 @@ class TestResolveEnvOverlayName:
         monkeypatch.setenv("SERVER_ENV", "dev")
         assert _resolve_env_overlay_name() == "dev"
 
-    def test_blank_values_yield_empty(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_blank_values_yield_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("COMMUNITY_DEPLOY", "")
         monkeypatch.setenv("SERVER_ENV", "")
         assert _resolve_env_overlay_name() == ""

--- a/src/proxy/README.md
+++ b/src/proxy/README.md
@@ -63,6 +63,7 @@ See `configs/application.yaml`. Environment-specific overlays live in
 | Variable | Purpose |
 |----------|---------|
 | `SERVER_ENV` | Environment overlay (dev/prod/etc.) |
+| `COMMUNITY_DEPLOY` | When set, its value replaces `SERVER_ENV` for naming the `application-<value>.yaml` overlay (community deployments set `COMMUNITY_DEPLOY=community`) |
 | `SOFAPY_CONFIG_OVERLAY` | Named overlay `configs/overlays/{name}.yaml` |
 | `SANDBOXPROXY_CONFIG_PATH` | Explicit config path (dir or file) |
 | `SANDBOXPROXY_PORT` | Override listen port |

--- a/src/proxy/configs/application-community.yaml
+++ b/src/proxy/configs/application-community.yaml
@@ -1,5 +1,6 @@
-# Proxy production overlay — env-driven host overrides for deployed editions.
-# Loaded on top of application.yaml when SERVER_ENV=prod (see
+# Proxy community-deployment overlay — env-driven host overrides for deployed
+# editions. Loaded on top of application.yaml when COMMUNITY_DEPLOY=community
+# (COMMUNITY_DEPLOY wins over SERVER_ENV for overlay selection; see
 # sandboxproxy.community.config._config_loader.ConfigLoader).
 #
 # Hosts that point at in-cluster or environment-specific endpoints are

--- a/src/proxy/docker-test/docker-compose.proxy-test.yml
+++ b/src/proxy/docker-test/docker-compose.proxy-test.yml
@@ -3,6 +3,8 @@ services:
     image: proxy:local
     environment:
       SERVER_ENV: prod
+      # COMMUNITY_DEPLOY selects the application-community.yaml overlay.
+      COMMUNITY_DEPLOY: community
       SANDBOXPROXY_PORT: "${SANDBOXPROXY_PORT:-8888}"
       # Test-only JWT secret (community reads it from config/env overlay).
       SANDBOXPROXY_JWT_SECRET: "${SANDBOXPROXY_JWT_SECRET:-proxy-test-secret-not-for-prod}"

--- a/src/proxy/docker-test/test-proxy.sh
+++ b/src/proxy/docker-test/test-proxy.sh
@@ -4,7 +4,9 @@
 #
 # Flow:
 #   1. Build proxy:local from docker/services/proxy.dockerfile
-#   2. Start the proxy (SERVER_ENV=prod, test JWT secret)
+#   2. Start the proxy (COMMUNITY_DEPLOY=community, which loads the
+#      application-community.yaml overlay; SERVER_ENV=prod stays set, test
+#      JWT secret)
 #   3. Wait for the proxy /health endpoint and report success / failure
 #
 # Usage:

--- a/src/proxy/src/sandboxproxy/community/config/_config_loader.py
+++ b/src/proxy/src/sandboxproxy/community/config/_config_loader.py
@@ -62,7 +62,10 @@ class ConfigLoader:
         base = _load_yaml(base_path) if base_path is not None else {}
         applied: list[str] = []
 
-        env = os.getenv("SERVER_ENV", "").strip()
+        # COMMUNITY_DEPLOY, when set, wins over SERVER_ENV for the env overlay:
+        # its value names application-<value>.yaml, so a community deployment
+        # (COMMUNITY_DEPLOY=community) loads application-community.yaml.
+        env = _resolve_env_overlay_name()
         overlay_path = _resolve_overlay_path(env) if env else None
         if overlay_path and overlay_path.exists():
             base = _merge(base, _load_yaml(overlay_path))
@@ -117,6 +120,20 @@ def _resolve_base_path() -> Path | None:
     if cwd_path.exists():
         return cwd_path
     return None
+
+
+def _resolve_env_overlay_name() -> str:
+    """Return the suffix of the ``application-<suffix>.yaml`` env overlay.
+
+    ``COMMUNITY_DEPLOY`` wins when set: its value names the overlay for a
+    community deployment (e.g. ``COMMUNITY_DEPLOY=community`` loads
+    ``application-community.yaml``) regardless of ``SERVER_ENV``. Falls back
+    to the legacy ``SERVER_ENV`` behaviour when it is unset.
+    """
+    community_deploy = os.getenv("COMMUNITY_DEPLOY", "").strip()
+    if community_deploy:
+        return community_deploy
+    return os.getenv("SERVER_ENV", "").strip()
 
 
 def _resolve_overlay_path(env: str) -> Path | None:

--- a/src/proxy/tests/unit/test_config_loader.py
+++ b/src/proxy/tests/unit/test_config_loader.py
@@ -46,6 +46,48 @@ class TestEnvPlaceholders:
         )
 
 
+class TestEnvOverlaySelection:
+    """COMMUNITY_DEPLOY names the env overlay and wins over SERVER_ENV."""
+
+    def test_community_deploy_wins_over_server_env(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        cfg = tmp_path / "application.yaml"
+        _write(cfg, "app_name: sandboxproxy\n")
+        # Both overlays exist: COMMUNITY_DEPLOY must pick community, not prod.
+        _write(tmp_path / "application-prod.yaml", "app_name: prod-app\n")
+        _write(tmp_path / "application-community.yaml", "app_name: community-app\n")
+        monkeypatch.setenv("SANDBOXPROXY_CONFIG_PATH", str(cfg))
+        monkeypatch.setenv("SERVER_ENV", "prod")
+        monkeypatch.setenv("COMMUNITY_DEPLOY", "community")
+        loaded = ConfigLoader.load()
+        assert loaded.app_name == "community-app"
+
+    def test_server_env_selects_overlay_when_community_deploy_unset(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        cfg = tmp_path / "application.yaml"
+        _write(cfg, "app_name: sandboxproxy\n")
+        _write(tmp_path / "application-prod.yaml", "app_name: prod-app\n")
+        monkeypatch.setenv("SANDBOXPROXY_CONFIG_PATH", str(cfg))
+        monkeypatch.setenv("SERVER_ENV", "prod")
+        monkeypatch.delenv("COMMUNITY_DEPLOY", raising=False)
+        loaded = ConfigLoader.load()
+        assert loaded.app_name == "prod-app"
+
+    def test_community_deploy_missing_overlay_ignored(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        cfg = tmp_path / "application.yaml"
+        _write(cfg, "app_name: sandboxproxy\n")
+        monkeypatch.setenv("SANDBOXPROXY_CONFIG_PATH", str(cfg))
+        monkeypatch.setenv("SERVER_ENV", "prod")
+        # No application-community.yaml: the env overlay is skipped, base wins.
+        monkeypatch.setenv("COMMUNITY_DEPLOY", "community")
+        loaded = ConfigLoader.load()
+        assert loaded.app_name == "sandboxproxy"
+
+
 class TestConfigLoad:
     def test_app_name(self) -> None:
         loaded = ConfigLoader.load()


### PR DESCRIPTION
## Problem

1. **Misattributed config**: the env overlay for baas / gateway / proxy is
   selected by `SERVER_ENV`, but the shipped `application-prod.yaml` of the
   three services is actually the *community* deployment config, not a real
   prod config. Community deployments were forced to squat on `SERVER_ENV`'s
   namespace, colliding with its env-detection role (gateway principal
   signing, baas `get_current_env` / distributed-lock suffixes).
2. **Slow starts killed by liveness**: the k8s template's survival budget is
   ~60s (liveness 30s delay + 3 failures × 10s), while baas cold-start reach
   `/health` in ~90s (its Dockerfile HEALTHCHECK start-period alone is 60s) —
   containers could be killed mid-start.
3. **backend still runs git sync in community form**: community has no corp
   git skills repo, yet `GitSyncService` ran its full bootstrap / periodic
   lifecycle at startup with no knob to turn it off.

## Solution

- **New `COMMUNITY_DEPLOY` env var** (baas `ConfigLoader._resolve_env_overlay_name`;
  same-named module-level function in gateway / proxy): when set, its value
  names the `application-<value>.yaml` overlay and takes precedence over
  `SERVER_ENV`; when unset, the legacy `SERVER_ENV` semantics apply unchanged.
  Purely additive. A missing overlay file still silently falls back to the
  base config, matching the existing `SERVER_ENV` behaviour.
- **Renames**: the three services' `application-prod.yaml` →
  `application-community.yaml` (`git mv`, history preserved), headers updated.
  k8s env files (`scripts/k8s-tests/**`) and docker-test compose stacks set
  `COMMUNITY_DEPLOY=community` while keeping `SERVER_ENV=prod` for env
  detection.
- **K8s probes**: the template gains a `startupProbe` (periodSeconds 10 ×
  failureThreshold 30 = up to 300s startup budget). Until it succeeds,
  liveness / readiness do not run at all, so their initial delays shrink
  (30→10, 10→5). Rejected the alternative of just raising the liveness delay:
  it cannot distinguish "not up yet" from "came up and died".
- **backend gate**: new `user_config.git_sync.enable_skill_sync` (default
  `true` — corp unaffected). `GitSyncConfig` reads the merged config through
  the lazy sofa handle (the same already-proven mechanism as the adjacent
  `office_oss_endpoint`), and `GitSyncService.startup()` skips bootstrap,
  database sync, and periodic sync when disabled. A repo-wide grep confirms
  `GitSyncService` is lifecycle-driven only, with no bypassing entry point
  (adapters inject `SkillCenterSyncServiceProtocol`, a different service).

## Validation

- Unit tests: baas **8544 passed / 5 skipped / 8 xpassed**; gateway
  **807 passed / 1 skipped**; proxy **128 passed**. Each service gained an
  overlay-selection test class covering `COMMUNITY_DEPLOY` precedence, the
  unset→`SERVER_ENV` fallback, and missing-file fallback to base.
- baas config-related architecture tests: 3 passed.
- Deployment template rendered manually via envsubst with `SERVICE=baas` and
  validated as YAML with the expected probe fields. (`docker/kube-deploy.sh`
  itself could not run locally: it needs bash 4+ `declare -A` while the local
  machine has bash 3.2 — environment-only limitation.)
- The backend gate's config chain (`YamlConfigProvider` deep merge →
  `sofa.sofa_config.model_dump()` returning merged raw → `GitSyncConfig` →
  startup short-circuit) was verified layer by layer in code; a dedicated
  unit test for the gate is listed as follow-up.
- **Not run**: real k8s deployment / the docker-test stacks (no cluster or
  Docker available here).

## Compatibility and risk

- **Behaviour change**: a deployment relying on `SERVER_ENV=prod` to load the
  shipped overlay must set `COMMUNITY_DEPLOY=community` instead (or ship its
  own overlay with that name). Rollback is trivial: rename the file back and
  drop the env var — with `COMMUNITY_DEPLOY` unset the loader behaves exactly
  as before.
- `enable_skill_sync` is an additive knob, enabled by default; corp prod is
  unaffected.
- **Test-driver companion**: `scripts/k8s-tests/k8s-test-lib.sh`'s
  `wait_healthy` defaults to a 120s rollout wait; expect cold starts between
  120–300s to need `HEALTH_WAIT_SECS=300` to align with the new budget
  (default left untouched so normal-case failure feedback stays fast).
- All env reads live in config loading (an approved raw-environment-access
  site per AGENTS.md); no hardcoded URLs or tokens were introduced.

## Related issues (optional)

None.
