### PR TITLE
feat(bcs): expose caller_principal and created_by in v1 session detail

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/session_routes.rs
@@ -605,6 +605,8 @@ fn session_detail() -> SessionDetail {
         input: None,
         meta: None,
         participants: vec![session_participant()],
+        caller_principal: None,
+        created_by: None,
         created_at: 1,
         updated_at: 2,
         state_machine_run_id: None,

--- a/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/src/lib.rs
@@ -556,6 +556,8 @@ impl SessionServiceImpl {
             input: session.input.clone(),
             meta: session.meta.clone(),
             participants,
+            caller_principal: session.caller_principal.clone(),
+            created_by: session.created_by.clone(),
             created_at: session.created_at,
             updated_at: session.updated_at,
             state_machine_run_id: state_machine_run

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/group_session_connection.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/group_session_connection.rs
@@ -270,6 +270,8 @@ fn session_detail(session_id: &str, group_id: &str) -> SessionDetail {
             mode: ParticipantMode::Present,
             joined_at: None,
         }],
+        caller_principal: None,
+        created_by: None,
         created_at: 1,
         updated_at: 1,
         state_machine_run_id: None,

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/session.rs
@@ -70,6 +70,12 @@ pub struct SessionDetail {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
     pub participants: Vec<SessionParticipant>,
+    /// Stable identity of the session creator (e.g. `svc-key:{sha256_hex[:16]}`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caller_principal: Option<String>,
+    /// Actor id of the session creator, when recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_by: Option<String>,
     pub created_at: u64,
     pub updated_at: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Problem

The V1 OpenAPI session detail response
(`bcs_api_http::v1::openapi::routes::session::get_session`) does not surface
the session's `caller_principal` and `created_by`, unlike the V1 list endpoint
(fixed in #1715) and the legacy handler, which serializes the full domain
`Session` where both fields already exist. Consumers of the detail endpoint
therefore cannot read the creator's stable principal or actor id.

## Solution

Add `caller_principal: Option<String>` and `created_by: Option<String>` to the
V1 detail DTO `SessionDetail` in `bcs-service-api`, mirroring the domain
`Session` field shape and its `skip_serializing_if = "Option::is_none"`
semantics (same as `SessionSummary` from #1715). Populate them in
`project_detail` (`bcs-app-session`) from the underlying domain `Session`. The
`get_session` route already returns `SessionDetail` directly through the
envelope, so no handler change is required — the new fields serialize
automatically.

- Add the two fields to `SessionDetail`.
- Populate both from the domain `Session` in `project_detail`.
- Update the `SessionDetail` test helpers in `session_routes.rs` and
  `group_session_connection.rs`.

## Validation

- `cargo check --all-targets --package bcs-service-api --package bcs-app-session --package bcs-api-http` — clean.
- `cargo test --package bcs-app-session` — 99 passed.
- `cargo test --package bcs-api-http --test session_routes` — 34 passed.
- Could not run the full singlebox coverage / pre-push CI gate locally.

## Compatibility and risk

Additive, backward-compatible response change: both fields are optional and
omitted from JSON when `None`. No schema, config, or migration impact — the
underlying `bcs_group_sessions` columns (`caller_principal`, `created_by`)
already exist. Existing clients that ignore unknown fields are unaffected;
rollback is simply reverting the commit. Like #1715, this does not update the
OpenAPI contract schema or the `bcn.openapi.json` snapshot.
