### PR TITLE
fix(backend): isolate service edit-lock dependencies

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/service_publications/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/service_publications/router.py
@@ -26,6 +26,9 @@ from agentclaw.community.adapters.http.openapi_v1.responses import (
 from agentclaw.community.api.service_publication_facade import (
     ServicePublicationFacadeProtocol,
 )
+from agentclaw.community.api.service_edit_lock_service import (
+    ServiceEditLockServiceProtocol,
+)
 from agentclaw.community.di import Injected
 
 from .schemas import (
@@ -290,11 +293,11 @@ async def get_edit_lock(
     request: Request,
     actor_id: UserIdDep,
     owner_id: OwnerIdDep,
-    facade: ServicePublicationFacadeProtocol = Injected(
-        ServicePublicationFacadeProtocol
+    locks: ServiceEditLockServiceProtocol = Injected(
+        ServiceEditLockServiceProtocol
     ),
 ) -> Envelope[EditLock]:
-    info = facade.get_lock(bot_id, actor_id=actor_id, owner_id=owner_id)
+    info = locks.get_lock(bot_id, actor_id=actor_id, owner_id=owner_id)
     return envelope(_lock_payload(info), request)
 
 
@@ -305,12 +308,12 @@ async def acquire_edit_lock(
     request: Request,
     actor_id: UserIdDep,
     owner_id: OwnerIdDep,
-    facade: ServicePublicationFacadeProtocol = Injected(
-        ServicePublicationFacadeProtocol
+    locks: ServiceEditLockServiceProtocol = Injected(
+        ServiceEditLockServiceProtocol
     ),
 ) -> Envelope[EditLock]:
-    lock = facade.acquire_lock(bot_id, actor_id=actor_id, owner_id=owner_id)
-    info = facade.get_lock(bot_id, actor_id=actor_id, owner_id=owner_id)
+    lock = locks.acquire_lock(bot_id, actor_id=actor_id, owner_id=owner_id)
+    info = locks.get_lock(bot_id, actor_id=actor_id, owner_id=owner_id)
     return envelope(_lock_payload(info, acquired=lock is not None), request)
 
 
@@ -321,11 +324,11 @@ async def release_edit_lock(
     request: Request,
     actor_id: UserIdDep,
     owner_id: OwnerIdDep,
-    facade: ServicePublicationFacadeProtocol = Injected(
-        ServicePublicationFacadeProtocol
+    locks: ServiceEditLockServiceProtocol = Injected(
+        ServiceEditLockServiceProtocol
     ),
 ) -> Envelope[EditLockRelease]:
-    released = facade.release_lock(bot_id, actor_id=actor_id, owner_id=owner_id)
+    released = locks.release_lock(bot_id, actor_id=actor_id, owner_id=owner_id)
     return envelope(EditLockRelease(released=released), request)
 
 
@@ -336,10 +339,10 @@ async def steal_edit_lock(
     request: Request,
     actor_id: UserIdDep,
     owner_id: OwnerIdDep,
-    facade: ServicePublicationFacadeProtocol = Injected(
-        ServicePublicationFacadeProtocol
+    locks: ServiceEditLockServiceProtocol = Injected(
+        ServiceEditLockServiceProtocol
     ),
 ) -> Envelope[EditLock]:
-    lock = facade.steal_lock(bot_id, actor_id=actor_id, owner_id=owner_id)
-    info = facade.get_lock(bot_id, actor_id=actor_id, owner_id=owner_id)
+    lock = locks.steal_lock(bot_id, actor_id=actor_id, owner_id=owner_id)
+    info = locks.get_lock(bot_id, actor_id=actor_id, owner_id=owner_id)
     return envelope(_lock_payload(info, acquired=lock is not None), request)

--- a/src/backend/src/agentclaw/community/api/README.md
+++ b/src/backend/src/agentclaw/community/api/README.md
@@ -112,6 +112,7 @@ provides:
   - TrackLatestServiceProtocol
   - SkillMetadataParserProtocol
   - ServiceArtifactLineageReaderProtocol
+  - ServiceEditLockServiceProtocol
   - SpaceSkillOfflineServiceProtocol
 consumes:
   - "No service impls at import time — Protocols only declare shape, they don't depend on concrete services"
@@ -137,6 +138,7 @@ internal_dependencies:
   - agentclaw.community.core.quality.models          # QualityTaskRecord — typed in quality_service.py and task_processor_service.py
   - agentclaw.community.core.service_bot.repository.models  # BotPublishRecord — typed in engine_config_service.py
   - agentclaw.community.core.service_bot.service_artifact_lineage_reader_protocol
+  - agentclaw.community.core.service_bot.service_edit_lock_service_protocol
   - agentclaw.community.core.resources.models        # Resource / ResourceType — typed in resource_service.py (Protocol signatures mirror slim ResourceService verbatim; round-2 review #4)
   - agentclaw.community.core.spaces.models           # Space/member records and enums — typed in space_service.py
   - agentclaw.community.core.repository.protocols.skill_center_types # Space Skill query projection

--- a/src/backend/src/agentclaw/community/api/service_edit_lock_service.py
+++ b/src/backend/src/agentclaw/community/api/service_edit_lock_service.py
@@ -1,0 +1,9 @@
+"""Public re-export of the service-Bot edit-lock contract."""
+
+from agentclaw.community.core.service_bot.service_edit_lock_service_protocol import (
+    ServiceEditLockInfo,
+    ServiceEditLockServiceProtocol,
+)
+
+
+__all__ = ["ServiceEditLockInfo", "ServiceEditLockServiceProtocol"]

--- a/src/backend/src/agentclaw/community/core/service_bot/README.md
+++ b/src/backend/src/agentclaw/community/core/service_bot/README.md
@@ -17,6 +17,7 @@ provides:
   - "ServiceSkillsManifestBuilder"
   - "ResolvedSharedCorpusDelivery"
   - "ServiceArtifactLineageReader"
+  - "ServiceEditLockService"
   - "ServiceBot SQLAlchemy models"
 consumes:
   - "BotManagement"

--- a/src/backend/src/agentclaw/community/core/service_bot/service_edit_lock_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/service_edit_lock_service_protocol.py
@@ -1,0 +1,41 @@
+"""Service API contract for service-Bot collaborative edit locks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceEditLockInfo:
+    """Public lock projection enriched with service-draft applicability."""
+
+    lock: Any
+    holder_name: str | None
+    has_collaborators: bool
+    is_owner: bool
+    need_lock: bool
+
+
+@runtime_checkable
+class ServiceEditLockServiceProtocol(Protocol):
+    """Authorize and manage one service Bot's collaborative edit lock."""
+
+    def get_lock(
+        self, bot_id: str, *, actor_id: str, owner_id: str
+    ) -> ServiceEditLockInfo: ...
+
+    def acquire_lock(
+        self, bot_id: str, *, actor_id: str, owner_id: str
+    ) -> Any: ...
+
+    def release_lock(
+        self, bot_id: str, *, actor_id: str, owner_id: str
+    ) -> bool: ...
+
+    def steal_lock(
+        self, bot_id: str, *, actor_id: str, owner_id: str
+    ) -> Any: ...
+
+
+__all__ = ["ServiceEditLockInfo", "ServiceEditLockServiceProtocol"]

--- a/src/backend/src/agentclaw/community/core/service_bot/services/service_edit_lock_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/service_edit_lock_service.py
@@ -1,0 +1,142 @@
+"""Narrow service-Bot collaborative edit-lock application service."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agentclaw.community.core.bot_collaborator.models import PermissionLevel
+from agentclaw.community.core.bot_collaborator.collaborator_lock_service_protocol import (
+    CollaboratorLockServiceProtocol,
+)
+from agentclaw.community.core.bot_collaborator.collaborator_service_protocol import (
+    CollaboratorServiceProtocol,
+)
+from agentclaw.community.core.bot_collaborator.protocols import (
+    resolve_operable_permission_level,
+)
+from agentclaw.community.core.repository.protocols.bot import BotRepository
+from agentclaw.community.core.service_bot.errors import (
+    ServicePublicationNotFoundError,
+    ServicePublicationUnsupportedError,
+)
+from agentclaw.community.core.service_bot.service_edit_lock_service_protocol import (
+    ServiceEditLockInfo,
+    ServiceEditLockServiceProtocol,
+)
+from agentclaw.community.utils.env_utils import get_current_env
+
+
+class ServiceEditLockService(ServiceEditLockServiceProtocol):
+    """Resolve and authorize edit locks without constructing publication flow."""
+
+    def __init__(
+        self,
+        *,
+        bot_repo: BotRepository,
+        collaborator_service: CollaboratorServiceProtocol,
+        lock_service: CollaboratorLockServiceProtocol,
+    ) -> None:
+        self._bot_repo = bot_repo
+        self._collaborator_service = collaborator_service
+        self._lock_service = lock_service
+
+    def _resolve_bot(
+        self,
+        bot_id: str,
+        *,
+        actor_id: str,
+        owner_id: str,
+    ) -> dict[str, Any]:
+        bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
+        if not bot:
+            raise ServicePublicationNotFoundError("bot not found")
+
+        level = resolve_operable_permission_level(
+            self._collaborator_service,
+            bot=bot,
+            user_id=actor_id,
+            owner_id=owner_id,
+            env=get_current_env(),
+        )
+        if level < PermissionLevel.MEMBER:
+            # COSEC: mask authorization failures to prevent Bot-ID probing.
+            raise ServicePublicationNotFoundError("bot not found")
+        if bot.get("bot_type") != "service":
+            raise ServicePublicationUnsupportedError("bot is not a service bot")
+        return bot
+
+    def _lock_info(
+        self,
+        bot: dict[str, Any],
+        *,
+        actor_id: str,
+    ) -> ServiceEditLockInfo:
+        info = self._lock_service.get_lock_info(
+            bot["bot_id"], bot["owner_id"], actor_id
+        )
+        return ServiceEditLockInfo(
+            lock=info.lock,
+            holder_name=info.holder_name,
+            has_collaborators=info.has_collaborators,
+            is_owner=info.is_owner,
+            need_lock=info.has_collaborators,
+        )
+
+    def get_lock(
+        self,
+        bot_id: str,
+        *,
+        actor_id: str,
+        owner_id: str,
+    ) -> ServiceEditLockInfo:
+        bot = self._resolve_bot(bot_id, actor_id=actor_id, owner_id=owner_id)
+        return self._lock_info(bot, actor_id=actor_id)
+
+    def _has_collaborators(
+        self,
+        bot: dict[str, Any],
+        *,
+        actor_id: str,
+    ) -> bool:
+        return self._lock_info(bot, actor_id=actor_id).has_collaborators
+
+    def acquire_lock(
+        self,
+        bot_id: str,
+        *,
+        actor_id: str,
+        owner_id: str,
+    ) -> Any:
+        bot = self._resolve_bot(bot_id, actor_id=actor_id, owner_id=owner_id)
+        if not self._has_collaborators(bot, actor_id=actor_id):
+            return None
+        return self._lock_service.acquire_lock(bot_id, bot["owner_id"], actor_id)
+
+    def release_lock(
+        self,
+        bot_id: str,
+        *,
+        actor_id: str,
+        owner_id: str,
+    ) -> bool:
+        bot = self._resolve_bot(bot_id, actor_id=actor_id, owner_id=owner_id)
+        return bool(
+            self._lock_service.release_lock(
+                bot_id,
+                bot["owner_id"],
+                actor_id,
+                False,
+            )
+        )
+
+    def steal_lock(
+        self,
+        bot_id: str,
+        *,
+        actor_id: str,
+        owner_id: str,
+    ) -> Any:
+        bot = self._resolve_bot(bot_id, actor_id=actor_id, owner_id=owner_id)
+        if not self._has_collaborators(bot, actor_id=actor_id):
+            return None
+        return self._lock_service.steal_lock(bot_id, bot["owner_id"], actor_id)

--- a/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
@@ -43,6 +43,9 @@ from agentclaw.community.api.publish_approval import PublishApprovalServiceProto
 from agentclaw.community.api.service_publication_facade import (
     ServicePublicationFacadeProtocol,
 )
+from agentclaw.community.api.service_edit_lock_service import (
+    ServiceEditLockServiceProtocol,
+)
 from agentclaw.community.api.service_artifact_lineage import (
     ServiceArtifactLineageReaderProtocol,
 )
@@ -131,6 +134,9 @@ from agentclaw.community.core.task_queue.services.task_queue_service import (
 from agentclaw.community.core.service_bot.services.publish_approval_service import PublishApprovalService
 from agentclaw.community.core.service_bot.services.service_publication_facade import (
     ServicePublicationFacade,
+)
+from agentclaw.community.core.service_bot.services.service_edit_lock_service import (
+    ServiceEditLockService,
 )
 from agentclaw.community.core.system_config import SystemConfigService
 from agentclaw.community.core.workspace.engine_sandbox import EngineSandboxRegistry
@@ -719,3 +725,28 @@ class ServiceBotModule(Module):
         self, facade: ServicePublicationFacade
     ) -> ServicePublicationFacadeProtocol:
         return facade
+
+    @singleton
+    @provider
+    @inject
+    def service_edit_lock_service(
+        self,
+        bot_repo: BotRepository,
+        collaborator_service: CollaboratorServiceProtocol,
+        lock_service: CollaboratorLockServiceProtocol,
+    ) -> ServiceEditLockService:
+        """Construct edit locks without resolving the publication pipeline."""
+        return ServiceEditLockService(
+            bot_repo=bot_repo,
+            collaborator_service=collaborator_service,
+            lock_service=lock_service,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def _service_edit_lock_service_protocol(
+        self,
+        service: ServiceEditLockService,
+    ) -> ServiceEditLockServiceProtocol:
+        return service

--- a/src/backend/tests/community/architecture/test_service_api_conformance.py
+++ b/src/backend/tests/community/architecture/test_service_api_conformance.py
@@ -116,6 +116,9 @@ from agentclaw.community.api.repository_catalog_service import (
 from agentclaw.community.api.service_publication_facade import (
     ServicePublicationFacadeProtocol,
 )
+from agentclaw.community.api.service_edit_lock_service import (
+    ServiceEditLockServiceProtocol,
+)
 from agentclaw.community.api.service_artifact_lineage import (
     ServiceArtifactLineageReaderProtocol,
 )
@@ -230,6 +233,9 @@ from agentclaw.community.core.market_favorites.services import MarketFavoriteSer
 from agentclaw.community.core.service_bot.services.service_publication_facade import (
     ServicePublicationFacade,
 )
+from agentclaw.community.core.service_bot.services.service_edit_lock_service import (
+    ServiceEditLockService,
+)
 from agentclaw.community.core.service_bot.services.service_artifact_lineage_reader import (
     ServiceArtifactLineageReader,
 )
@@ -282,6 +288,7 @@ _PAIRS = [
     (SpaceMemberServiceProtocol, SpaceMemberService),
     (MarketFavoriteServiceProtocol, MarketFavoriteService),
     (ServicePublicationFacadeProtocol, ServicePublicationFacade),
+    (ServiceEditLockServiceProtocol, ServiceEditLockService),
     (ServiceArtifactLineageReaderProtocol, ServiceArtifactLineageReader),
     (SpaceSkillOfflineServiceProtocol, SpaceSkillOfflineService),
 ]

--- a/src/backend/tests/community/core/service_bot/services/test_service_edit_lock_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_service_edit_lock_service.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from agentclaw.community.core.bot_collaborator.models import PermissionLevel
+from agentclaw.community.core.service_bot.errors import (
+    ServicePublicationNotFoundError,
+    ServicePublicationUnsupportedError,
+)
+from agentclaw.community.core.service_bot.services.service_edit_lock_service import (
+    ServiceEditLockService,
+)
+
+
+@pytest.fixture
+def deps():
+    values = SimpleNamespace(
+        bot_repo=Mock(),
+        collaborator_service=Mock(),
+        lock_service=Mock(),
+    )
+    values.bot_repo.get_by_id_and_owner.return_value = {
+        "id": 10,
+        "bot_id": "bot-1",
+        "owner_id": "owner",
+        "bot_type": "service",
+    }
+    values.lock_service.get_lock_info.return_value = SimpleNamespace(
+        lock=None,
+        holder_name=None,
+        has_collaborators=False,
+        is_owner=False,
+    )
+    values.service = ServiceEditLockService(
+        bot_repo=values.bot_repo,
+        collaborator_service=values.collaborator_service,
+        lock_service=values.lock_service,
+    )
+    return values
+
+
+def test_get_lock_returns_service_projection_without_publication_dependencies(
+    deps, monkeypatch
+):
+    monkeypatch.setattr(
+        "agentclaw.community.core.service_bot.services."
+        "service_edit_lock_service.get_current_env",
+        lambda: "pre",
+    )
+    deps.lock_service.get_lock_info.return_value = SimpleNamespace(
+        lock=SimpleNamespace(holder_user_id="owner"),
+        holder_name="Owner",
+        has_collaborators=True,
+        is_owner=True,
+    )
+
+    info = deps.service.get_lock("bot-1", actor_id="owner", owner_id="owner")
+
+    assert info.need_lock is True
+    assert info.holder_name == "Owner"
+    deps.bot_repo.get_by_id_and_owner.assert_called_once_with("bot-1", "owner")
+    deps.lock_service.get_lock_info.assert_called_once_with(
+        "bot-1", "owner", "owner"
+    )
+
+
+def test_missing_bot_is_masked(deps):
+    deps.bot_repo.get_by_id_and_owner.return_value = None
+
+    with pytest.raises(ServicePublicationNotFoundError, match="bot not found"):
+        deps.service.get_lock("missing", actor_id="owner", owner_id="owner")
+
+
+def test_non_service_bot_is_rejected(deps):
+    deps.bot_repo.get_by_id_and_owner.return_value["bot_type"] = "personal"
+
+    with pytest.raises(ServicePublicationUnsupportedError):
+        deps.service.get_lock("bot-1", actor_id="owner", owner_id="owner")
+
+
+def test_non_member_is_masked(deps, monkeypatch):
+    monkeypatch.setattr(
+        "agentclaw.community.core.service_bot.services."
+        "service_edit_lock_service.get_current_env",
+        lambda: "pre",
+    )
+    deps.collaborator_service.get_permission_level.return_value = PermissionLevel.NONE
+
+    with pytest.raises(ServicePublicationNotFoundError, match="bot not found"):
+        deps.service.get_lock("bot-1", actor_id="stranger", owner_id="owner")
+
+
+def test_acquire_is_a_noop_when_bot_has_no_collaborators(deps):
+    assert (
+        deps.service.acquire_lock("bot-1", actor_id="owner", owner_id="owner")
+        is None
+    )
+    deps.lock_service.acquire_lock.assert_not_called()
+
+
+def test_acquire_uses_the_resolved_bot_owner(deps):
+    deps.lock_service.get_lock_info.return_value.has_collaborators = True
+    deps.lock_service.acquire_lock.return_value = SimpleNamespace(
+        holder_user_id="owner"
+    )
+
+    result = deps.service.acquire_lock(
+        "bot-1", actor_id="owner", owner_id="owner"
+    )
+
+    assert result.holder_user_id == "owner"
+    deps.lock_service.acquire_lock.assert_called_once_with(
+        "bot-1", "owner", "owner"
+    )
+
+
+def test_release_does_not_force_another_users_lock(deps):
+    deps.lock_service.release_lock.return_value = True
+
+    assert deps.service.release_lock(
+        "bot-1", actor_id="owner", owner_id="owner"
+    )
+    deps.lock_service.release_lock.assert_called_once_with(
+        "bot-1", "owner", "owner", False
+    )
+
+
+def test_steal_uses_the_resolved_bot_owner(deps):
+    deps.lock_service.get_lock_info.return_value.has_collaborators = True
+    deps.lock_service.steal_lock.return_value = SimpleNamespace(
+        holder_user_id="owner"
+    )
+
+    result = deps.service.steal_lock(
+        "bot-1", actor_id="owner", owner_id="owner"
+    )
+
+    assert result.holder_user_id == "owner"
+    deps.lock_service.steal_lock.assert_called_once_with(
+        "bot-1", "owner", "owner"
+    )

--- a/src/backend/tests/community/endpoints/test_openapi_service_publications.py
+++ b/src/backend/tests/community/endpoints/test_openapi_service_publications.py
@@ -40,6 +40,9 @@ from agentclaw.community.adapters.http.openapi_v1.dependencies import PRINCIPAL_
 from agentclaw.community.api.service_publication_facade import (
     ServicePublicationFacadeProtocol,
 )
+from agentclaw.community.api.service_edit_lock_service import (
+    ServiceEditLockServiceProtocol,
+)
 from agentclaw.community.utils.gateway_principal_config import (
     init_principal_verifier_config,
 )
@@ -200,18 +203,6 @@ def _seed_happy_services(world) -> None:
     def delete_initial_draft(_self, _bot_id, **_kwargs) -> bool:
         return True
 
-    def get_lock(_self, _bot_id, *, actor_id, **_kwargs):
-        return _lock_info(actor_id)
-
-    def acquire_lock(_self, _bot_id, *, actor_id, **_kwargs):
-        return _lock_info(actor_id).lock
-
-    def release_lock(_self, _bot_id, **_kwargs) -> bool:
-        return True
-
-    def steal_lock(_self, _bot_id, *, actor_id, **_kwargs):
-        return _lock_info(actor_id).lock
-
     bind_overrides(
         world,
         ServicePublicationFacadeProtocol,
@@ -227,6 +218,31 @@ def _seed_happy_services(world) -> None:
             "offline": offline,
             "retry": retry,
             "delete_initial_draft": delete_initial_draft,
+        },
+    )
+
+
+def _seed_happy_edit_locks(world) -> None:
+    """Wire edit-locks alone; resolving the publication facade is a failure."""
+    _seed_verifier(world)
+    make_bot(world, bot_id=_BOT_ID, owner_id=_OWNER)
+
+    def get_lock(_self, _bot_id, *, actor_id, **_kwargs):
+        return _lock_info(actor_id)
+
+    def acquire_lock(_self, _bot_id, *, actor_id, **_kwargs):
+        return _lock_info(actor_id).lock
+
+    def release_lock(_self, _bot_id, **_kwargs) -> bool:
+        return True
+
+    def steal_lock(_self, _bot_id, *, actor_id, **_kwargs):
+        return _lock_info(actor_id).lock
+
+    bind_overrides(
+        world,
+        ServiceEditLockServiceProtocol,
+        {
             "get_lock": get_lock,
             "acquire_lock": acquire_lock,
             "release_lock": release_lock,
@@ -366,12 +382,17 @@ _HAPPY_CASES = (
 
 
 for _method, _path, _input, _status, _contains in _HAPPY_CASES:
+    _seed = (
+        _seed_happy_edit_locks
+        if _path.startswith(_EDIT_LOCK)
+        else _seed_happy_services
+    )
     endpoint_test(
         method=_method,
         path=_path,
         scenario="happy",
         input=_input,
-        seed=_seed_happy_services,
+        seed=_seed,
         expect=ExpectSuccess(status=_status, json_contains=_contains),
     )(lambda: None)
 


### PR DESCRIPTION
## Summary
- split service-Bot edit-lock operations behind a narrow Service API
- prevent edit-lock requests from constructing publication artifact dependencies
- retain existing authorization and lock semantics

## Why
Pre-release `GET /openapi/v1/bots/{bot_id}/edit-lock` was resolving the full publication facade. That transitively constructed Canonical Center Store and turned an unrelated artifact configuration failure into a 500 on edit-lock.

## Test Plan
- `uv run pytest -q tests/community/core/service_bot/services/test_service_edit_lock_service.py`
- `uv run pytest -q tests/community/endpoints/test_openapi_service_publications.py tests/community/architecture/test_service_api_conformance.py`
- `uv run pytest -q tests/community/di/test_all_bindings_resolve.py tests/community/di/test_community_router_bindings_resolve.py tests/community/di/test_canonical_center_store_config_provider.py`
- `uv run pytest -q tests/community/adapters/http/openapi_v1/test_service_publication_endpoints.py tests/community/adapters/http/openapi_v1/test_authorization_inventory.py`
- `uv run pytest -q tests/community/architecture`
