### PR TITLE
feat(bcs): persist session opening messages and harden webhook delivery

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -1074,6 +1074,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
+ "tracing",
  "url",
  "uuid",
 ]
@@ -1669,6 +1670,7 @@ dependencies = [
  "bcs-domain",
  "bcs-group",
  "bcs-group-store",
+ "bcs-message-store",
  "bcs-service-api",
  "bcs-session-store",
  "bcs-test-support",

--- a/src/bcs/api-contracts/v1/domain-models.yaml
+++ b/src/bcs/api-contracts/v1/domain-models.yaml
@@ -777,9 +777,10 @@ AixUiOpeningMessage:
 
 OpeningMessage:
   description: >-
-    StateMachine Run opening-message template. Supported placeholders are
-    {{bcs.group_id}}, {{bcs.session_id}}, {{bcs.run_id}},
-    {{bcs.group_name}}, and {{bcs.session_name}}.
+    Group opening-message template. Chat and Manager-Worker render it once per
+    new Session and support {{bcs.group_id}}, {{bcs.session_id}},
+    {{bcs.group_name}}, and {{bcs.session_name}}. StateMachine renders it once
+    per Run and additionally supports {{bcs.run_id}}.
   oneOf:
     - type: string
       minLength: 1

--- a/src/bcs/api-contracts/v1/openapi/event-subscriptions.yaml
+++ b/src/bcs/api-contracts/v1/openapi/event-subscriptions.yaml
@@ -299,7 +299,7 @@ EventDeliveryDetailEnvelope:
           items:
             type: object
             additionalProperties: false
-            required: [attempt_no, started_at, completed_at, latency_ms, result]
+            required: [attempt_no, started_at]
             properties:
               attempt_no: {type: integer}
               started_at: {type: string, format: date-time}

--- a/src/bcs/api-contracts/v1/openapi/groups.yaml
+++ b/src/bcs/api-contracts/v1/openapi/groups.yaml
@@ -589,6 +589,9 @@ CreateCollaborationGroup:
     context:
       type: string
     opening_message:
+      description: >-
+        Optional opening-message template. Chat and Manager-Worker render it
+        once when a new Session is created; StateMachine renders it per Run.
       oneOf:
         - $ref: ../domain-models.yaml#/OpeningMessage
         - type: "null"
@@ -648,6 +651,9 @@ UpdateGroup:
     context:
       type: string
     opening_message:
+      description: >-
+        Replaces or clears the Group opening-message template. The selected
+        collaboration strategy determines the supported variables.
       oneOf:
         - $ref: ../domain-models.yaml#/OpeningMessage
         - type: "null"

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use bcs_domain::{
     CollaborationDefinition, CollaborationDefinitionRef, CollaborationRuntimeDefinition,
-    RuntimeParticipantBinding, StateMachineAssignee,
+    OpeningMessageScope, RuntimeParticipantBinding, StateMachineAssignee,
 };
 use bcs_protocol::{
     CreateGroupRequest, InlineEventPayloadMode, InlineEventSinkInfo,
@@ -515,16 +515,20 @@ fn validate_legacy_opening_message(req: &CreateGroupRequest) -> Result<(), HttpA
     let Some(opening_message) = req.opening_message.as_ref() else {
         return Ok(());
     };
-    let is_state_machine = req.group_kind.as_deref() != Some("dm")
-        && (req.collaboration_definition_yaml.is_some()
-            || req.group_strategy.as_deref() == Some("state_machine"));
-    if !is_state_machine {
+    if req.group_kind.as_deref() == Some("dm") {
         return Err(HttpAdapterError::InvalidOpeningMessage(
-            "opening_message is only supported for StateMachine Groups".to_string(),
+            "opening_message is not supported for DM Groups".to_string(),
         ));
     }
+    let scope = if req.collaboration_definition_yaml.is_some()
+        || req.group_strategy.as_deref() == Some("state_machine")
+    {
+        OpeningMessageScope::StateMachineRun
+    } else {
+        OpeningMessageScope::Session
+    };
     opening_message
-        .validate()
+        .validate_for(scope)
         .map_err(|error| HttpAdapterError::InvalidOpeningMessage(error.to_string()))
 }
 

--- a/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
@@ -961,7 +961,7 @@ async fn post_groups_delegates_to_group_management_create_and_preserves_response
 }
 
 #[tokio::test]
-async fn post_groups_rejects_opening_message_for_chat_with_declared_code() {
+async fn post_groups_accepts_session_scoped_opening_message_for_chat() {
     let (app, recorder, _temp_dir) = test_app().await;
 
     let response = app
@@ -974,7 +974,7 @@ async fn post_groups_rejects_opening_message_for_chat_with_declared_code() {
                 .body(Body::from(
                     serde_json::json!({
                         "driver_bot": "driver-bot",
-                        "opening_message": "hello",
+                        "opening_message": "hello {{bcs.session_id}}",
                         "participants": [
                             { "bot_uuid": "driver-bot", "role": "driver" }
                         ]
@@ -986,11 +986,15 @@ async fn post_groups_rejects_opening_message_for_chat_with_declared_code() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-    let json: Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["code"], "invalid_opening_message");
-    assert!(recorder.create_calls.lock().await.is_empty());
+    assert_eq!(response.status(), StatusCode::OK);
+    let calls = recorder.create_calls.lock().await;
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0].opening_message,
+        Some(OpeningMessage::Text(
+            "hello {{bcs.session_id}}".to_string()
+        ))
+    );
 }
 
 #[tokio::test]

--- a/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
@@ -21,7 +21,7 @@ use bcs_service_api::application::v1::{
     require_authenticated_user, require_human, select_principal,
 };
 use bcs_service_api::core::{GroupMutationCommand, GroupMutationKind};
-use bcs_service_api::types::{EventActor, EventActorType};
+use bcs_service_api::types::{EventActor, EventActorType, OpeningMessageScope};
 use bcs_service_api::{
     ActorKind, ActorStatus, AuthenticatedHumanCaller, BotRegistryCoreService,
     CollaborationDefinitionRef, CollaborationRuntimeError, CollaborationRuntimeService,
@@ -1109,13 +1109,7 @@ impl GroupServiceImpl {
         let (strategy, routing_policy, state_machine) =
             map_create_collaboration(request.collaboration.clone());
         if let Some(opening_message) = &request.opening_message {
-            if strategy != GroupStrategy::StateMachine {
-                return Err(ApplicationError::invalid(
-                    "invalid_opening_message",
-                    "opening_message is only supported for StateMachine Groups",
-                ));
-            }
-            opening_message.validate().map_err(|error| {
+            opening_message.validate_for(opening_message_scope(strategy)).map_err(|error| {
                 ApplicationError::invalid("invalid_opening_message", error.to_string())
             })?;
         }
@@ -2056,14 +2050,10 @@ impl GroupService for GroupServiceImpl {
             ));
         }
         if let Some(opening_message) = &command.patch.opening_message {
-            if group.group_strategy != GroupStrategy::StateMachine {
-                return Err(ApplicationError::invalid(
-                    "invalid_opening_message",
-                    "opening_message is only supported for StateMachine Groups",
-                ));
-            }
             if let Some(opening_message) = opening_message {
-                opening_message.validate().map_err(|error| {
+                opening_message
+                    .validate_for(opening_message_scope(group.group_strategy))
+                    .map_err(|error| {
                     ApplicationError::invalid("invalid_opening_message", error.to_string())
                 })?;
             }
@@ -2417,6 +2407,13 @@ impl GroupService for GroupServiceImpl {
             }
             Err(error) => Err(map_group_error(error)),
         }
+    }
+}
+
+fn opening_message_scope(strategy: GroupStrategy) -> OpeningMessageScope {
+    match strategy {
+        GroupStrategy::StateMachine => OpeningMessageScope::StateMachineRun,
+        GroupStrategy::Chat | GroupStrategy::ManagerWorker => OpeningMessageScope::Session,
     }
 }
 

--- a/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
@@ -3566,7 +3566,7 @@ async fn update_rejects_delivery_policy_for_non_chat_strategy() {
 }
 
 #[tokio::test]
-async fn update_opening_message_preserves_patch_states_and_strategy_guard() {
+async fn update_opening_message_preserves_patch_states_and_strategy_scopes() {
     let runtime = Arc::new(RecordingRuntime::default());
     let fixture = Fixture::new_with_runtime(runtime.clone()).await;
     for bot in ["driver", "helper"] {
@@ -3689,7 +3689,7 @@ async fn update_opening_message_preserves_patch_states_and_strategy_guard() {
     );
     chat.opening_message = None;
     fixture.groups.upsert(chat).await.expect("store Chat Group");
-    let error = fixture
+    fixture
         .service
         .update(UpdateGroup {
             caller: bot_principal("driver"),
@@ -3700,7 +3700,31 @@ async fn update_opening_message_preserves_patch_states_and_strategy_guard() {
             },
         })
         .await
-        .expect_err("Chat Group must reject opening message");
+        .expect("Chat Group accepts session-scoped opening message");
+    assert_eq!(
+        fixture
+            .groups
+            .get("chat")
+            .await
+            .expect("stored Chat Group")
+            .opening_message,
+        Some(OpeningMessage::Text("hello".into()))
+    );
+
+    let error = fixture
+        .service
+        .update(UpdateGroup {
+            caller: bot_principal("driver"),
+            group_id: "chat".into(),
+            patch: GroupPatch {
+                opening_message: Some(Some(OpeningMessage::Text(
+                    "Run {{bcs.run_id}}".into(),
+                ))),
+                ..Default::default()
+            },
+        })
+        .await
+        .expect_err("Chat Group must reject run-scoped variables");
     assert!(matches!(
         error,
         ApplicationError::InvalidInput { code, .. } if code == "invalid_opening_message"

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -1908,7 +1908,8 @@ impl Default for BcsServerState {
         let session_management: Arc<dyn SessionManagementService> = Arc::new(
             SessionManagementServiceImpl::new(session_repo.clone(), group_repo_for_session.clone())
                 .with_bot_runtime(bot_use_cases.clone())
-                .with_event_record_factory(group_event_factory.clone()),
+                .with_event_record_factory(group_event_factory.clone())
+                .with_opening_message_delivery(message_repo.clone(), frontend_delivery.clone()),
         );
         let bot_run_context: Arc<dyn BotRunContextPort> =
             Arc::new(bcs_message_flow::MemoryBotRunContextStore::new());
@@ -3472,7 +3473,8 @@ impl BcsServer {
         let session_management: Arc<dyn SessionManagementService> = Arc::new(
             SessionManagementServiceImpl::new(session_repo.clone(), group_repo_for_session.clone())
                 .with_bot_runtime(bot_use_cases.clone())
-                .with_event_record_factory(group_event_factory.clone()),
+                .with_event_record_factory(group_event_factory.clone())
+                .with_opening_message_delivery(message_repo.clone(), frontend_delivery.clone()),
         );
         let bot_run_context: Arc<dyn BotRunContextPort> =
             Arc::new(bcs_message_flow::MemoryBotRunContextStore::new());
@@ -4254,7 +4256,11 @@ let collaboration_templates = build_standalone_collaboration_template_service(&c
                     .with_event_record_factory(crate::eventing_wiring::event_record_factory(
                         &config,
                         event_repo.clone(),
-                    )),
+                    ))
+                    .with_opening_message_delivery(
+                        message_repo.clone(),
+                        frontend_delivery.clone(),
+                    ),
             );
             (
                 session_repo.clone() as Arc<dyn SessionRepoPort>,

--- a/src/bcs/crates/contracts/bcs-domain/src/group.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/group.rs
@@ -338,7 +338,8 @@ pub struct Group {
     /// User-provided group context (optional description of collaboration goal/background).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context: Option<String>,
-    /// Optional StateMachine Run opening-message template.
+    /// Optional Group opening-message template. Its render scope is selected
+    /// by `group_strategy`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub opening_message: Option<crate::opening_message::OpeningMessage>,
     /// All participants.

--- a/src/bcs/crates/contracts/bcs-domain/src/lib.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/lib.rs
@@ -70,16 +70,17 @@ pub use group_id::{
     channel_group_id, generated_group_id, is_valid_channel_type,
 };
 pub use message::{
-    AuditEntry, BCS_STATE_MACHINE_MESSAGE_SENDER, BCS_STATE_MACHINE_MESSAGE_SENDER_NAME,
-    DeliveryType, GroupMessage, GroupMessageType, MessageAttachment, MessageOwnerFilter,
-    MessagePage, MessageQuery, MessageRole, NewMessage, PersistedMessage, PersistedMessageStatus,
-    STATE_MACHINE_PANEL_MESSAGE_TYPE, SenderType, Task, TaskStatus,
+    AuditEntry, BCS_SESSION_OPENING_MESSAGE_SENDER, BCS_SESSION_OPENING_MESSAGE_SENDER_NAME,
+    BCS_STATE_MACHINE_MESSAGE_SENDER, BCS_STATE_MACHINE_MESSAGE_SENDER_NAME, DeliveryType,
+    GroupMessage, GroupMessageType, MessageAttachment, MessageOwnerFilter, MessagePage,
+    MessageQuery, MessageRole, NewMessage, PersistedMessage, PersistedMessageStatus,
+    SESSION_OPENING_MESSAGE_TYPE, STATE_MACHINE_PANEL_MESSAGE_TYPE, SenderType, Task, TaskStatus,
 };
 pub use organization::{Organization, OrganizationMember};
 pub use opening_message::{
     AixUiOpeningMessage, AixUiOpeningMessageType, AixUiOpeningTab, MAX_OPENING_MESSAGE_BYTES,
     MAX_OPENING_MESSAGE_COMPONENT_BYTES, OpeningMessage, OpeningMessageError,
-    OpeningMessageRenderContext, RenderedOpeningMessage,
+    OpeningMessageRenderContext, OpeningMessageScope, RenderedOpeningMessage,
 };
 pub use proposal::GroupChatProposal;
 pub use provider::{

--- a/src/bcs/crates/contracts/bcs-domain/src/message.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/message.rs
@@ -6,6 +6,9 @@ use serde::{Deserialize, Serialize};
 pub const BCS_STATE_MACHINE_MESSAGE_SENDER: &str = "bcs_state_machine";
 pub const BCS_STATE_MACHINE_MESSAGE_SENDER_NAME: &str = "BCS State Machine";
 pub const STATE_MACHINE_PANEL_MESSAGE_TYPE: &str = "state_machine_panel";
+pub const BCS_SESSION_OPENING_MESSAGE_SENDER: &str = "bcs_opening_message";
+pub const BCS_SESSION_OPENING_MESSAGE_SENDER_NAME: &str = "BCS";
+pub const SESSION_OPENING_MESSAGE_TYPE: &str = "opening_message";
 
 /// A task in the workspace.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/bcs/crates/contracts/bcs-domain/src/opening_message.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/opening_message.rs
@@ -73,13 +73,55 @@ where
     BTreeMap::<String, Value>::deserialize(deserializer).map(Some)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpeningMessageScope {
+    Session,
+    StateMachineRun,
+}
+
 #[derive(Debug, Clone, Copy)]
-pub struct OpeningMessageRenderContext<'a> {
-    pub group_id: &'a str,
-    pub session_id: &'a str,
-    pub run_id: &'a str,
-    pub group_name: Option<&'a str>,
-    pub session_name: Option<&'a str>,
+pub enum OpeningMessageRenderContext<'a> {
+    Session {
+        group_id: &'a str,
+        session_id: &'a str,
+        group_name: Option<&'a str>,
+        session_name: Option<&'a str>,
+    },
+    StateMachineRun {
+        group_id: &'a str,
+        session_id: &'a str,
+        run_id: &'a str,
+        group_name: Option<&'a str>,
+        session_name: Option<&'a str>,
+    },
+}
+
+impl<'a> OpeningMessageRenderContext<'a> {
+    fn scope(self) -> OpeningMessageScope {
+        match self {
+            Self::Session { .. } => OpeningMessageScope::Session,
+            Self::StateMachineRun { .. } => OpeningMessageScope::StateMachineRun,
+        }
+    }
+
+    fn value(self, token: &str) -> &'a str {
+        match (token, self) {
+            (GROUP_ID_TOKEN, Self::Session { group_id, .. })
+            | (GROUP_ID_TOKEN, Self::StateMachineRun { group_id, .. }) => group_id,
+            (SESSION_ID_TOKEN, Self::Session { session_id, .. })
+            | (SESSION_ID_TOKEN, Self::StateMachineRun { session_id, .. }) => session_id,
+            (RUN_ID_TOKEN, Self::StateMachineRun { run_id, .. }) => run_id,
+            (GROUP_NAME_TOKEN, Self::Session { group_name, .. })
+            | (GROUP_NAME_TOKEN, Self::StateMachineRun { group_name, .. }) => {
+                group_name.unwrap_or_default()
+            }
+            (SESSION_NAME_TOKEN, Self::Session { session_name, .. })
+            | (SESSION_NAME_TOKEN, Self::StateMachineRun { session_name, .. }) => {
+                session_name.unwrap_or_default()
+            }
+            _ => unreachable!("validated template variable for render scope"),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -108,13 +150,17 @@ pub enum OpeningMessageError {
 
 impl OpeningMessage {
     pub fn validate(&self) -> Result<(), OpeningMessageError> {
+        self.validate_for(OpeningMessageScope::StateMachineRun)
+    }
+
+    pub fn validate_for(&self, scope: OpeningMessageScope) -> Result<(), OpeningMessageError> {
         match self {
             Self::Text(template) => {
                 if template.trim().is_empty() {
                     return Err(OpeningMessageError::Empty);
                 }
                 ensure_size(template)?;
-                validate_template(template)
+                validate_template(template, scope)
             }
             Self::AixUi(message) => {
                 validate_component(&message.component)?;
@@ -123,12 +169,12 @@ impl OpeningMessage {
                 }
                 if let Some(params) = &message.params {
                     for value in params.values() {
-                        validate_value_templates(value)?;
+                        validate_value_templates(value, scope)?;
                     }
                 }
                 if let Some(tab) = &message.tab {
                     for template in [tab.id.as_deref(), tab.title.as_deref()].into_iter().flatten() {
-                        validate_template(template)?;
+                        validate_template(template, scope)?;
                     }
                 }
                 let canonical = serde_json::to_string(message)
@@ -142,7 +188,7 @@ impl OpeningMessage {
         &self,
         context: OpeningMessageRenderContext<'_>,
     ) -> Result<RenderedOpeningMessage, OpeningMessageError> {
-        self.validate()?;
+        self.validate_for(context.scope())?;
         let rendered = match self {
             Self::Text(template) => RenderedOpeningMessage {
                 content: render_template(template, context),
@@ -201,16 +247,26 @@ fn validate_component(component: &str) -> Result<(), OpeningMessageError> {
     Ok(())
 }
 
-fn validate_value_templates(value: &Value) -> Result<(), OpeningMessageError> {
+fn validate_value_templates(
+    value: &Value,
+    scope: OpeningMessageScope,
+) -> Result<(), OpeningMessageError> {
     match value {
-        Value::String(template) => validate_template(template),
-        Value::Array(values) => values.iter().try_for_each(validate_value_templates),
-        Value::Object(values) => values.values().try_for_each(validate_value_templates),
+        Value::String(template) => validate_template(template, scope),
+        Value::Array(values) => values
+            .iter()
+            .try_for_each(|value| validate_value_templates(value, scope)),
+        Value::Object(values) => values
+            .values()
+            .try_for_each(|value| validate_value_templates(value, scope)),
         Value::Null | Value::Bool(_) | Value::Number(_) => Ok(()),
     }
 }
 
-fn validate_template(template: &str) -> Result<(), OpeningMessageError> {
+fn validate_template(
+    template: &str,
+    scope: OpeningMessageScope,
+) -> Result<(), OpeningMessageError> {
     let mut remainder = template;
     while let Some(start) = remainder.find("{{") {
         remainder = &remainder[start..];
@@ -218,10 +274,11 @@ fn validate_template(template: &str) -> Result<(), OpeningMessageError> {
             return Err(OpeningMessageError::UnterminatedTemplateVariable);
         };
         let token = &remainder[..end + 2];
-        if !matches!(
+        let supported = matches!(
             token,
-            GROUP_ID_TOKEN | SESSION_ID_TOKEN | RUN_ID_TOKEN | GROUP_NAME_TOKEN | SESSION_NAME_TOKEN
-        ) {
+            GROUP_ID_TOKEN | SESSION_ID_TOKEN | GROUP_NAME_TOKEN | SESSION_NAME_TOKEN
+        ) || (scope == OpeningMessageScope::StateMachineRun && token == RUN_ID_TOKEN);
+        if !supported {
             return Err(OpeningMessageError::UnsupportedTemplateVariable(
                 token.to_string(),
             ));
@@ -241,14 +298,7 @@ fn render_template(template: &str, context: OpeningMessageRenderContext<'_>) -> 
             .find("}}")
             .expect("validated template must have a closing delimiter");
         let token = &token_start[..end + 2];
-        result.push_str(match token {
-            GROUP_ID_TOKEN => context.group_id,
-            SESSION_ID_TOKEN => context.session_id,
-            RUN_ID_TOKEN => context.run_id,
-            GROUP_NAME_TOKEN => context.group_name.unwrap_or_default(),
-            SESSION_NAME_TOKEN => context.session_name.unwrap_or_default(),
-            _ => unreachable!("validated template variable"),
-        });
+        result.push_str(context.value(token));
         remainder = &token_start[end + 2..];
     }
     result.push_str(remainder);
@@ -304,7 +354,7 @@ mod tests {
     use super::*;
 
     fn context<'a>() -> OpeningMessageRenderContext<'a> {
-        OpeningMessageRenderContext {
+        OpeningMessageRenderContext::StateMachineRun {
             group_id: "bcs_grp_1",
             session_id: "session_1",
             run_id: "run_1",
@@ -323,8 +373,13 @@ mod tests {
 
     #[test]
     fn template_substitution_is_single_pass() {
-        let mut context = context();
-        context.group_name = Some("{{bcs.run_id}}");
+        let context = OpeningMessageRenderContext::StateMachineRun {
+            group_id: "bcs_grp_1",
+            session_id: "session_1",
+            run_id: "run_1",
+            group_name: Some("{{bcs.run_id}}"),
+            session_name: Some("第一轮"),
+        };
         let message = OpeningMessage::Text("{{bcs.group_name}}/{{bcs.run_id}}".to_string());
         assert_eq!(
             message.render(context).expect("render").content,
@@ -338,9 +393,13 @@ mod tests {
             "{{bcs.group_id}}|{{bcs.session_id}}|{{bcs.run_id}}|{{bcs.group_name}}|{{bcs.session_name}}"
                 .to_string(),
         );
-        let mut context = context();
-        context.group_name = None;
-        context.session_name = None;
+        let context = OpeningMessageRenderContext::StateMachineRun {
+            group_id: "bcs_grp_1",
+            session_id: "session_1",
+            run_id: "run_1",
+            group_name: None,
+            session_name: None,
+        };
         assert_eq!(
             message.render(context).expect("render").content,
             "bcs_grp_1|session_1|run_1||"
@@ -441,8 +500,36 @@ mod tests {
         );
         let message = OpeningMessage::Text(GROUP_ID_TOKEN.to_string());
         let huge_group_id = "x".repeat(MAX_OPENING_MESSAGE_BYTES + 1);
-        let mut context = context();
-        context.group_id = &huge_group_id;
+        let context = OpeningMessageRenderContext::StateMachineRun {
+            group_id: &huge_group_id,
+            session_id: "session_1",
+            run_id: "run_1",
+            group_name: None,
+            session_name: None,
+        };
         assert_eq!(message.render(context), Err(OpeningMessageError::TooLarge));
+    }
+
+    #[test]
+    fn session_scope_renders_session_variables_and_rejects_run_id() {
+        let context = OpeningMessageRenderContext::Session {
+            group_id: "bcs_grp_1",
+            session_id: "session_1",
+            group_name: Some("自由聊天"),
+            session_name: Some("第一轮"),
+        };
+        let message = OpeningMessage::Text(
+            "{{bcs.group_name}}/{{bcs.session_name}}/{{bcs.group_id}}/{{bcs.session_id}}"
+                .to_string(),
+        );
+        assert_eq!(
+            message.render(context).expect("render").content,
+            "自由聊天/第一轮/bcs_grp_1/session_1"
+        );
+        assert!(matches!(
+            OpeningMessage::Text(RUN_ID_TOKEN.to_string())
+                .validate_for(OpeningMessageScope::Session),
+            Err(OpeningMessageError::UnsupportedTemplateVariable(token)) if token == RUN_ID_TOKEN
+        ));
     }
 }

--- a/src/bcs/crates/contracts/bcs-protocol/src/http/groups.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/http/groups.rs
@@ -137,7 +137,8 @@ pub struct CreateGroupRequest {
     /// User-provided group context (optional description of collaboration goal/background).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context: Option<String>,
-    /// Optional StateMachine Run opening-message template.
+    /// Optional Group opening-message template. Chat and Manager-Worker use a
+    /// Session scope; StateMachine uses a Run scope.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub opening_message: Option<OpeningMessage>,
     /// Group topic (sets the group label as "Group: {topic}").

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/event_subscription.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/event_subscription.rs
@@ -161,9 +161,12 @@ pub enum EventDeliveryAttemptResult {
 pub struct EventDeliveryAttemptSummary {
     pub attempt_no: u32,
     pub started_at: String,
-    pub completed_at: String,
-    pub latency_ms: u64,
-    pub result: EventDeliveryAttemptResult,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<EventDeliveryAttemptResult>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub http_status: Option<u16>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/group.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/group.rs
@@ -391,8 +391,10 @@ pub trait GroupEventSubscriptionProvisioner: Send + Sync {
     ) -> Result<(), ApplicationError>;
 
     /// Atomically make the Group available, activate all prepared
-    /// subscriptions, and persist the ordered creation Events. The optional
-    /// Session is the initial Session created by Group management.
+    /// subscriptions, snapshot matching Group Events persisted after prepare
+    /// while those subscriptions were pending, and persist the ordered
+    /// creation Events. The optional Session is the initial Session created by
+    /// Group management.
     async fn finalize(
         &self,
         prepared: &PreparedGroupEventSubscriptions,

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/repo/event.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/repo/event.rs
@@ -301,13 +301,16 @@ pub struct EventDeliveryAttemptRecord {
     pub delivery_id: String,
     pub attempt_no: u32,
     pub started_at_ms: u64,
-    pub completed_at_ms: u64,
-    pub latency_ms: u64,
-    pub result: EventDeliveryAttemptRecordResult,
+    /// Empty while the worker still owns the attempt lease.
+    pub completed_at_ms: Option<u64>,
+    /// Empty while in flight and when lease recovery cannot know the HTTP duration.
+    pub latency_ms: Option<u64>,
+    /// Empty while the attempt is in flight.
+    pub result: Option<EventDeliveryAttemptRecordResult>,
     pub http_status: Option<u16>,
     pub error_category: Option<String>,
     pub error_summary: Option<String>,
-    pub response_bytes_observed: u64,
+    pub response_bytes_observed: Option<u64>,
     pub worker_id: String,
 }
 

--- a/src/bcs/crates/service-api/bcs-service-api/tests/event_subscription_contract.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/event_subscription_contract.rs
@@ -6,9 +6,9 @@ use bcs_service_api::application::v1::{
     ERROR_EVENT_SUBSCRIPTION_FORBIDDEN, ERROR_EVENT_SUBSCRIPTION_LIMIT_REACHED,
     ERROR_EVENT_SUBSCRIPTION_NOT_FOUND, ERROR_EVENT_SUBSCRIPTION_REVISION_CONFLICT,
     ERROR_INVALID_EVENT_FILTER, ERROR_INVALID_EVENT_SCOPE, ERROR_INVALID_WEBHOOK_URL, EventActor,
-    EventActorType, EventEnvelope, EventPayload, EventPayloadMode, EventScope, EventStream,
-    EventSubject, EventSubscriptionScope, EventSubscriptionScopeType, EventSubscriptionService,
-    PatchEventSubscriptionRequest,
+    EventActorType, EventDeliveryAttemptSummary, EventEnvelope, EventPayload, EventPayloadMode,
+    EventScope, EventStream, EventSubject, EventSubscriptionScope, EventSubscriptionScopeType,
+    EventSubscriptionService, PatchEventSubscriptionRequest,
 };
 use serde_json::json;
 
@@ -62,6 +62,26 @@ fn event_envelope_has_stable_json_shape_and_accepts_additive_fields() {
         decoded.actor.expect("actor").actor_type,
         EventActorType::Bot
     );
+}
+
+#[test]
+fn in_flight_attempt_summary_omits_completion_fields() {
+    let value = serde_json::to_value(EventDeliveryAttemptSummary {
+        attempt_no: 4,
+        started_at: "2026-08-28T08:00:00.000Z".to_string(),
+        completed_at: None,
+        latency_ms: None,
+        result: None,
+        http_status: None,
+        error_category: None,
+    })
+    .expect("serialize in-flight Attempt");
+
+    assert_eq!(value["attempt_no"], 4);
+    assert_eq!(value["started_at"], "2026-08-28T08:00:00.000Z");
+    assert!(value.get("completed_at").is_none());
+    assert!(value.get("latency_ms").is_none());
+    assert!(value.get("result").is_none());
 }
 
 #[test]

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -5924,7 +5924,7 @@ fn render_state_machine_opening_message(
         ));
     };
     opening_message
-        .render(OpeningMessageRenderContext {
+        .render(OpeningMessageRenderContext::StateMachineRun {
             group_id: &group.id,
             session_id: &run.session_id,
             run_id: &run.run_id,

--- a/src/bcs/crates/services/bcs-event-store/src/db.rs
+++ b/src/bcs/crates/services/bcs-event-store/src/db.rs
@@ -763,7 +763,13 @@ impl EventRepoPort for DbEventStore {
             DbTransactionStep::Query(DbStatement::with_params(
                 sql_with_timestamp_params(self.flavor, &self.target_select_sql(
                     "WHERE env = ? AND status = 'pending' AND lease_owner = ? \
-                     AND lease_until = __bcs_timestamp_ms__ ORDER BY created_at, target_id",
+                     AND lease_until = __bcs_timestamp_ms__ ORDER BY created_at, \
+                     (SELECT event.stream_key FROM bcs_events event \
+                       WHERE event.env = bcs_event_fanout_targets.env \
+                         AND event.event_id = bcs_event_fanout_targets.event_id), \
+                     (SELECT event.sequence FROM bcs_events event \
+                       WHERE event.env = bcs_event_fanout_targets.env \
+                         AND event.event_id = bcs_event_fanout_targets.event_id), target_id",
                 )),
                 vec![
                     DbValue::from(command.env.as_str()),
@@ -1622,10 +1628,11 @@ fn claim_fanout_targets_sql(flavor: DbSqlFlavor) -> String {
      lease_until = __bcs_timestamp_ms__ \
      WHERE target_id IN (SELECT target_id FROM (\
        SELECT target.target_id FROM bcs_event_fanout_targets target \
+       JOIN bcs_events event ON event.env = target.env AND event.event_id = target.event_id \
        WHERE target.env = ? AND target.status = 'pending' \
          AND (target.lease_until IS NULL \
            OR target.lease_until <= __bcs_timestamp_ms__) \
-       ORDER BY created_at, target_id LIMIT ?\
+       ORDER BY target.created_at, event.stream_key, event.sequence, target.target_id LIMIT ?\
      ) claimable) AND env = ? AND status = 'pending' \
        AND (lease_until IS NULL OR lease_until <= __bcs_timestamp_ms__)"
     )

--- a/src/bcs/crates/services/bcs-event-store/src/db.rs
+++ b/src/bcs/crates/services/bcs-event-store/src/db.rs
@@ -28,6 +28,9 @@ use chrono::{SecondsFormat, TimeZone, Utc};
 use sha2::{Digest, Sha256};
 
 use crate::transaction_plan::EventAppendTransactionPlan;
+use crate::timestamp::{
+    optional_timestamp_value_from_ms, sql_with_timestamp_params, timestamp_value_from_ms,
+};
 use crate::{event_filter_matches, validate_scope};
 
 #[derive(Clone)]
@@ -241,9 +244,9 @@ impl EventRepoPort for DbEventStore {
         validate_new_subscription(&record)?;
         let scope_id = scope_storage_id(&record.subscription.scope);
         let scope_type = scope_type_name(record.subscription.scope.scope_type);
-        let created_at = db_timestamp_from_ms(record.subscription.created_at_ms)?;
-        let updated_at = db_timestamp_from_ms(record.subscription.updated_at_ms)?;
-        let activated_at = db_timestamp_from_ms(record.revision.activated_at_ms)?;
+        let created_at = timestamp_value_from_ms(self.flavor, record.subscription.created_at_ms)?;
+        let updated_at = timestamp_value_from_ms(self.flavor, record.subscription.updated_at_ms)?;
+        let activated_at = timestamp_value_from_ms(self.flavor, record.revision.activated_at_ms)?;
         let audit_id = uuid::Uuid::new_v4().to_string();
         let event_filters = serde_json::to_string(&record.revision.event_filters)
             .map_err(|error| EventRepoError::InvalidInput(format!("serialize filters: {error}")))?;
@@ -268,10 +271,12 @@ impl EventRepoPort for DbEventStore {
         let subscription_insert_step = steps.len();
         steps.push(DbTransactionStep::Execute(
             DbStatement::with_transaction_params(
-                "INSERT INTO bcs_event_subscriptions (subscription_id, name, scope_type, scope_id, \
+                sql_with_timestamp_params(self.flavor, "INSERT INTO bcs_event_subscriptions \
+                 (subscription_id, name, scope_type, scope_id, \
                  status, current_revision, created_by_type, created_by_id, \
                  created_at, updated_at, deleted_at, env) \
-                 SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? WHERE ? < ?",
+                 SELECT ?, ?, ?, ?, ?, ?, ?, ?, __bcs_timestamp_ms__, \
+                 __bcs_timestamp_ms__, __bcs_timestamp_ms__, ? WHERE ? < ?"),
                 vec![
                     DbValue::from(record.subscription.subscription_id.as_str()).into(),
                     DbValue::from(record.subscription.name.as_str()).into(),
@@ -282,9 +287,13 @@ impl EventRepoPort for DbEventStore {
                     DbValue::from(actor_type_name(record.subscription.created_by.actor_type))
                         .into(),
                     DbValue::from(record.subscription.created_by.id.as_str()).into(),
-                    DbValue::from(created_at.as_str()).into(),
-                    DbValue::from(updated_at.as_str()).into(),
-                    optional_db_timestamp(record.subscription.deleted_at_ms)?.into(),
+                    created_at.clone().into(),
+                    updated_at.clone().into(),
+                    optional_timestamp_value_from_ms(
+                        self.flavor,
+                        record.subscription.deleted_at_ms,
+                    )?
+                    .into(),
                     DbValue::from(record.subscription.env.as_str()).into(),
                     DbTransactionParam::query_result(reserved_count_step, 0, "reserved_count"),
                     DbValue::from(record.scope_limit).into(),
@@ -296,22 +305,24 @@ impl EventRepoPort for DbEventStore {
                 &record.revision,
                 &record.subscription.env,
                 &event_filters,
+                self.flavor,
                 &activated_at,
             )?,
         ));
         steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-            "INSERT INTO bcs_event_subscription_audits (audit_id, subscription_id, revision, \
+            sql_with_timestamp_params(self.flavor, "INSERT INTO bcs_event_subscription_audits \
+             (audit_id, subscription_id, revision, \
              action, actor_type, actor_id, reason, details_json, created_at, env) \
-             SELECT ?, ?, ?, 'created', ?, ?, NULL, NULL, ?, ? WHERE EXISTS (\
+             SELECT ?, ?, ?, 'created', ?, ?, NULL, NULL, __bcs_timestamp_ms__, ? WHERE EXISTS (\
                SELECT 1 FROM bcs_event_subscriptions WHERE env = ? AND subscription_id = ?\
-             )",
+             )"),
             vec![
                 DbValue::from(audit_id),
                 DbValue::from(record.subscription.subscription_id.as_str()),
                 DbValue::from(record.subscription.current_revision),
                 DbValue::from(actor_type_name(record.subscription.created_by.actor_type)),
                 DbValue::from(record.subscription.created_by.id.as_str()),
-                DbValue::from(created_at),
+                created_at,
                 DbValue::from(record.subscription.env.as_str()),
                 DbValue::from(record.subscription.env.as_str()),
                 DbValue::from(record.subscription.subscription_id.as_str()),
@@ -348,37 +359,40 @@ impl EventRepoPort for DbEventStore {
                 "pending Subscription cancellation reason must not be empty".to_string(),
             ));
         }
-        let cancelled_at = db_timestamp_from_ms(command.cancelled_at_ms)?;
+        let cancelled_at = timestamp_value_from_ms(self.flavor, command.cancelled_at_ms)?;
         let mut steps = Vec::with_capacity(command.subscription_ids.len() * 2);
         let mut update_steps = Vec::with_capacity(command.subscription_ids.len());
         for subscription_id in &command.subscription_ids {
             update_steps.push(steps.len());
             steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-                "UPDATE bcs_event_subscriptions SET status = 'deleted', updated_at = ?, \
-                 deleted_at = ? WHERE env = ? AND subscription_id = ? AND status = 'pending'",
+                sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_subscriptions SET \
+                 status = 'deleted', updated_at = __bcs_timestamp_ms__, \
+                 deleted_at = __bcs_timestamp_ms__ WHERE env = ? AND subscription_id = ? \
+                 AND status = 'pending'"),
                 vec![
-                    DbValue::from(cancelled_at.as_str()),
-                    DbValue::from(cancelled_at.as_str()),
+                    cancelled_at.clone(),
+                    cancelled_at.clone(),
                     DbValue::from(command.env.as_str()),
                     DbValue::from(subscription_id.as_str()),
                 ],
             )));
             steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-                "INSERT INTO bcs_event_subscription_audits \
+                sql_with_timestamp_params(self.flavor, "INSERT INTO bcs_event_subscription_audits \
                  (audit_id, subscription_id, revision, action, actor_type, actor_id, reason, \
                   details_json, created_at, env) \
                  SELECT ?, subscription_id, current_revision, 'provisioning_cancelled', ?, ?, ?, \
-                        NULL, ?, env FROM bcs_event_subscriptions \
-                 WHERE env = ? AND subscription_id = ? AND status = 'deleted' AND deleted_at = ?",
+                        NULL, __bcs_timestamp_ms__, env FROM bcs_event_subscriptions \
+                 WHERE env = ? AND subscription_id = ? AND status = 'deleted' \
+                   AND deleted_at = __bcs_timestamp_ms__"),
                 vec![
                     DbValue::from(uuid::Uuid::new_v4().to_string()),
                     DbValue::from(actor_type_name(command.actor.actor_type)),
                     DbValue::from(command.actor.id.as_str()),
                     DbValue::from(command.reason.as_str()),
-                    DbValue::from(cancelled_at.as_str()),
+                    cancelled_at.clone(),
                     DbValue::from(command.env.as_str()),
                     DbValue::from(subscription_id.as_str()),
-                    DbValue::from(cancelled_at.as_str()),
+                    cancelled_at.clone(),
                 ],
             )));
         }
@@ -519,10 +533,10 @@ impl EventRepoPort for DbEventStore {
 
         let scope_id = scope_storage_id(&current.scope);
         let scope_type = scope_type_name(current.scope.scope_type);
-        let updated_at = db_timestamp_from_ms(command.updated_at_ms)?;
+        let updated_at = timestamp_value_from_ms(self.flavor, command.updated_at_ms)?;
         let event_filters = serde_json::to_string(&command.revision.event_filters)
             .map_err(|error| EventRepoError::InvalidInput(format!("serialize filters: {error}")))?;
-        let activated_at = db_timestamp_from_ms(command.revision.activated_at_ms)?;
+        let activated_at = timestamp_value_from_ms(self.flavor, command.revision.activated_at_ms)?;
         let audit_id = uuid::Uuid::new_v4().to_string();
         let mut steps = scope_lock_steps(self.flavor, &command.env, scope_type, scope_id.as_str());
         steps.push(DbTransactionStep::Query(DbStatement::with_params(
@@ -533,10 +547,11 @@ impl EventRepoPort for DbEventStore {
             ],
         )));
         steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-            "UPDATE bcs_event_subscription_revisions SET retired_at = ? \
-             WHERE env = ? AND subscription_id = ? AND revision = ? AND retired_at IS NULL",
+            sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_subscription_revisions \
+             SET retired_at = __bcs_timestamp_ms__ \
+             WHERE env = ? AND subscription_id = ? AND revision = ? AND retired_at IS NULL"),
             vec![
-                DbValue::from(updated_at.as_str()),
+                updated_at.clone(),
                 DbValue::from(command.env.as_str()),
                 DbValue::from(command.subscription_id.as_str()),
                 DbValue::from(command.expected_revision),
@@ -546,20 +561,21 @@ impl EventRepoPort for DbEventStore {
             &command.revision,
             &command.env,
             &event_filters,
+            self.flavor,
             &activated_at,
         )?));
         steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-            "UPDATE bcs_event_subscriptions SET name = ?, status = ?, current_revision = ?, \
-             updated_at = ?, \
-             deleted_at = CASE WHEN ? = 'deleted' THEN ? ELSE deleted_at END \
-             WHERE env = ? AND subscription_id = ? AND current_revision = ?",
+            sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_subscriptions SET \
+             name = ?, status = ?, current_revision = ?, updated_at = __bcs_timestamp_ms__, \
+             deleted_at = CASE WHEN ? = 'deleted' THEN __bcs_timestamp_ms__ ELSE deleted_at END \
+             WHERE env = ? AND subscription_id = ? AND current_revision = ?"),
             vec![
                 DbValue::from(command.name.as_str()),
                 DbValue::from(subscription_status_name(command.status)),
                 DbValue::from(command.revision.revision),
-                DbValue::from(updated_at.as_str()),
+                updated_at.clone(),
                 DbValue::from(subscription_status_name(command.status)),
-                DbValue::from(updated_at.as_str()),
+                updated_at.clone(),
                 DbValue::from(command.env.as_str()),
                 DbValue::from(command.subscription_id.as_str()),
                 DbValue::from(command.expected_revision),
@@ -571,13 +587,14 @@ impl EventRepoPort for DbEventStore {
                 EventSubscriptionStatus::Disabled | EventSubscriptionStatus::Deleted
             );
             steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-                "UPDATE bcs_event_deliveries SET status = 'cancelled', cancelled_at = ?, \
+                sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_deliveries SET \
+                 status = 'cancelled', cancelled_at = __bcs_timestamp_ms__, \
                  lease_owner = NULL, lease_until = NULL \
                  WHERE env = ? AND subscription_id = ? \
                    AND (? = TRUE OR subscription_revision = ?) \
-                   AND status IN ('pending', 'retry_wait')",
+                   AND status IN ('pending', 'retry_wait')"),
                 vec![
-                    DbValue::from(updated_at.as_str()),
+                    updated_at.clone(),
                     DbValue::from(command.env.as_str()),
                     DbValue::from(command.subscription_id.as_str()),
                     DbValue::from(cancel_all_revisions),
@@ -585,12 +602,13 @@ impl EventRepoPort for DbEventStore {
                 ],
             )));
             steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-                "UPDATE bcs_event_fanout_targets SET status = 'cancelled', cancelled_at = ? \
+                sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_fanout_targets SET \
+                 status = 'cancelled', cancelled_at = __bcs_timestamp_ms__ \
                  WHERE env = ? AND subscription_id = ? \
                    AND (? = TRUE OR subscription_revision = ?) \
-                   AND status = 'pending'",
+                   AND status = 'pending'"),
                 vec![
-                    DbValue::from(updated_at.as_str()),
+                    updated_at.clone(),
                     DbValue::from(command.env.as_str()),
                     DbValue::from(command.subscription_id.as_str()),
                     DbValue::from(cancel_all_revisions),
@@ -608,9 +626,10 @@ impl EventRepoPort for DbEventStore {
             )));
         }
         steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-            "INSERT INTO bcs_event_subscription_audits (audit_id, subscription_id, revision, \
+            sql_with_timestamp_params(self.flavor, "INSERT INTO bcs_event_subscription_audits \
+             (audit_id, subscription_id, revision, \
              action, actor_type, actor_id, reason, details_json, created_at, env) \
-             VALUES (?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)",
+             VALUES (?, ?, ?, ?, ?, ?, ?, NULL, __bcs_timestamp_ms__, ?)"),
             vec![
                 DbValue::from(audit_id),
                 DbValue::from(command.subscription_id.as_str()),
@@ -619,7 +638,7 @@ impl EventRepoPort for DbEventStore {
                 DbValue::from(actor_type_name(command.actor.actor_type)),
                 DbValue::from(command.actor.id.as_str()),
                 DbValue::from(command.reason.clone()),
-                DbValue::from(updated_at),
+                updated_at,
                 DbValue::from(command.env.as_str()),
             ],
         )));
@@ -725,31 +744,31 @@ impl EventRepoPort for DbEventStore {
             command.limit,
             &command.env,
         )?;
-        let now = db_timestamp_from_ms(command.now_ms)?;
-        let lease_until = db_timestamp_from_ms(command.lease_until_ms)?;
+        let now = timestamp_value_from_ms(self.flavor, command.now_ms)?;
+        let lease_until = timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
         let lease_owner = claim_owner(&command.worker_id);
         let steps = vec![
             DbTransactionStep::Execute(DbStatement::with_params(
-                claim_fanout_targets_sql(),
+                claim_fanout_targets_sql(self.flavor),
                 vec![
                     DbValue::from(lease_owner.as_str()),
-                    DbValue::from(lease_until.as_str()),
+                    lease_until.clone(),
                     DbValue::from(command.env.as_str()),
-                    DbValue::from(now.as_str()),
+                    now.clone(),
                     DbValue::from(command.limit),
                     DbValue::from(command.env.as_str()),
-                    DbValue::from(now.as_str()),
+                    now,
                 ],
             )),
             DbTransactionStep::Query(DbStatement::with_params(
-                self.target_select_sql(
+                sql_with_timestamp_params(self.flavor, &self.target_select_sql(
                     "WHERE env = ? AND status = 'pending' AND lease_owner = ? \
-                     AND lease_until = ? ORDER BY created_at, target_id",
-                ),
+                     AND lease_until = __bcs_timestamp_ms__ ORDER BY created_at, target_id",
+                )),
                 vec![
                     DbValue::from(command.env.as_str()),
                     DbValue::from(lease_owner.as_str()),
-                    DbValue::from(lease_until),
+                    lease_until,
                 ],
             )),
         ];
@@ -792,13 +811,17 @@ impl EventRepoPort for DbEventStore {
                 "Delivery does not match its immutable fanout target and Event".into(),
             ));
         }
-        let materialized_at = db_timestamp_from_ms(command.materialized_at_ms)?;
-        let created_at = db_timestamp_from_ms(command.delivery.created_at_ms)?;
-        let dead_lettered_at = optional_db_timestamp(command.delivery.dead_lettered_at_ms)?;
+        let materialized_at = timestamp_value_from_ms(self.flavor, command.materialized_at_ms)?;
+        let created_at = timestamp_value_from_ms(self.flavor, command.delivery.created_at_ms)?;
+        let dead_lettered_at = optional_timestamp_value_from_ms(
+            self.flavor,
+            command.delivery.dead_lettered_at_ms,
+        )?;
         let insert_step = 0;
         let steps = vec![
             DbTransactionStep::Execute(DbStatement::with_params(
-                "INSERT INTO bcs_event_deliveries (delivery_id, fanout_target_id, event_id, \
+                sql_with_timestamp_params(self.flavor, "INSERT INTO bcs_event_deliveries \
+                 (delivery_id, fanout_target_id, event_id, \
                  subscription_id, subscription_revision, stream_key, sequence, payload_bytes, \
                  payload_sha256, status, attempt_count, first_attempt_at, last_attempt_at, \
                  next_attempt_at, lease_owner, lease_until, last_http_status, \
@@ -807,12 +830,14 @@ impl EventRepoPort for DbEventStore {
                  resolved_by_delivery_id, resolved_at, created_at, succeeded_at, env) \
                  SELECT ?, target.target_id, target.event_id, target.subscription_id, \
                  target.subscription_revision, event.stream_key, event.sequence, ?, ?, ?, \
-                 0, NULL, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, NULL, NULL, NULL, NULL, \
-                 target.replay_of_delivery_id, NULL, NULL, ?, NULL, target.env \
+                 0, NULL, NULL, NULL, NULL, NULL, NULL, ?, ?, __bcs_timestamp_ms__, NULL, NULL, \
+                 NULL, NULL, target.replay_of_delivery_id, NULL, NULL, \
+                 __bcs_timestamp_ms__, NULL, target.env \
                  FROM bcs_event_fanout_targets target JOIN bcs_events event \
                    ON event.env = target.env AND event.event_id = target.event_id \
                  WHERE target.env = ? AND target.target_id = ? AND target.status = 'pending' \
-                   AND target.lease_owner = ? AND target.lease_until > ?",
+                   AND target.lease_owner = ? \
+                   AND target.lease_until > __bcs_timestamp_ms__"),
                 vec![
                     DbValue::from(command.delivery.delivery_id.as_str()),
                     DbValue::from(command.delivery.payload_bytes.clone()),
@@ -821,24 +846,25 @@ impl EventRepoPort for DbEventStore {
                     DbValue::from(command.delivery.last_error_category.clone()),
                     DbValue::from(command.delivery.last_error_summary.clone()),
                     dead_lettered_at,
-                    DbValue::from(created_at),
+                    created_at,
                     DbValue::from(command.delivery.env.as_str()),
                     DbValue::from(command.target_id.as_str()),
                     DbValue::from(command.expected_lease_owner.as_str()),
-                    DbValue::from(materialized_at.as_str()),
+                    materialized_at.clone(),
                 ],
             )),
             DbTransactionStep::Execute(DbStatement::with_params(
-                "UPDATE bcs_event_fanout_targets SET status = 'materialized', \
-                 materialized_at = ?, lease_owner = NULL, lease_until = NULL \
+                sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_fanout_targets SET \
+                 status = 'materialized', materialized_at = __bcs_timestamp_ms__, \
+                 lease_owner = NULL, lease_until = NULL \
                  WHERE env = ? AND target_id = ? AND status = 'pending' \
-                   AND lease_owner = ? AND lease_until > ?",
+                   AND lease_owner = ? AND lease_until > __bcs_timestamp_ms__"),
                 vec![
-                    DbValue::from(materialized_at.as_str()),
+                    materialized_at.clone(),
                     DbValue::from(command.delivery.env.as_str()),
                     DbValue::from(command.target_id.as_str()),
                     DbValue::from(command.expected_lease_owner.as_str()),
-                    DbValue::from(materialized_at.as_str()),
+                    materialized_at,
                 ],
             )),
             DbTransactionStep::Execute(DbStatement::with_params(
@@ -881,40 +907,79 @@ impl EventRepoPort for DbEventStore {
             command.limit,
             &command.env,
         )?;
-        let now = db_timestamp_from_ms(command.now_ms)?;
-        let lease_until = db_timestamp_from_ms(command.lease_until_ms)?;
+        let now = timestamp_value_from_ms(self.flavor, command.now_ms)?;
+        let lease_until = timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
         let lease_owner = claim_owner(&command.worker_id);
         let steps = vec![
             DbTransactionStep::Execute(DbStatement::with_params(
-                claim_deliveries_sql(),
+                claim_deliveries_sql(self.flavor),
                 vec![
                     DbValue::from(lease_owner.as_str()),
-                    DbValue::from(lease_until.as_str()),
-                    DbValue::from(now.as_str()),
-                    DbValue::from(now.as_str()),
+                    lease_until.clone(),
+                    now.clone(),
+                    now.clone(),
                     DbValue::from(command.env.as_str()),
-                    DbValue::from(now.as_str()),
-                    DbValue::from(now.as_str()),
+                    now.clone(),
+                    now.clone(),
                     DbValue::from(command.limit),
                     DbValue::from(command.env.as_str()),
-                    DbValue::from(now.as_str()),
-                    DbValue::from(now.as_str()),
+                    now.clone(),
+                    now,
+                ],
+            )),
+            DbTransactionStep::Execute(DbStatement::with_params(
+                sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_delivery_attempts SET \
+                 completed_at = __bcs_timestamp_ms__, result = 'retryable', \
+                 error_category = 'lease_expired', \
+                 error_summary = 'Delivery lease expired before completion; remote outcome is unknown', \
+                 response_bytes_observed = 0 \
+                 WHERE completed_at IS NULL AND EXISTS (\
+                   SELECT 1 FROM bcs_event_deliveries delivery \
+                   WHERE delivery.delivery_id = bcs_event_delivery_attempts.delivery_id \
+                     AND delivery.env = ? AND delivery.status = 'in_flight' \
+                     AND delivery.lease_owner = ? \
+                     AND delivery.lease_until = __bcs_timestamp_ms__ \
+                     AND delivery.attempt_count = bcs_event_delivery_attempts.attempt_no + 1\
+                 )"),
+                vec![
+                    timestamp_value_from_ms(self.flavor, command.now_ms)?,
+                    DbValue::from(command.env.as_str()),
+                    DbValue::from(lease_owner.as_str()),
+                    timestamp_value_from_ms(self.flavor, command.lease_until_ms)?,
+                ],
+            )),
+            DbTransactionStep::Execute(DbStatement::with_params(
+                sql_with_timestamp_params(self.flavor, "INSERT INTO \
+                 bcs_event_delivery_attempts (delivery_id, attempt_no, started_at, \
+                 completed_at, latency_ms, result, http_status, error_category, error_summary, \
+                 response_bytes_observed, worker_id) \
+                 SELECT delivery_id, attempt_count, __bcs_timestamp_ms__, NULL, NULL, NULL, \
+                        NULL, NULL, NULL, NULL, ? \
+                 FROM bcs_event_deliveries WHERE env = ? AND status = 'in_flight' \
+                   AND lease_owner = ? AND lease_until = __bcs_timestamp_ms__"),
+                vec![
+                    timestamp_value_from_ms(self.flavor, command.now_ms)?,
+                    DbValue::from(command.worker_id.as_str()),
+                    DbValue::from(command.env.as_str()),
+                    DbValue::from(lease_owner.as_str()),
+                    timestamp_value_from_ms(self.flavor, command.lease_until_ms)?,
                 ],
             )),
             DbTransactionStep::Query(DbStatement::with_params(
-                self.delivery_select_sql(
+                sql_with_timestamp_params(self.flavor, &self.delivery_select_sql(
                     "WHERE d.env = ? AND d.status = 'in_flight' AND d.lease_owner = ? \
-                     AND d.lease_until = ? ORDER BY d.created_at, d.sequence, d.delivery_id",
-                ),
+                     AND d.lease_until = __bcs_timestamp_ms__ \
+                     ORDER BY d.created_at, d.sequence, d.delivery_id",
+                )),
                 vec![
                     DbValue::from(command.env.as_str()),
                     DbValue::from(lease_owner.as_str()),
-                    DbValue::from(lease_until),
+                    lease_until,
                 ],
             )),
         ];
         let results = self.db.transaction(steps).await.map_err(storage_error)?;
-        transaction_rows(&results, 1)?
+        transaction_rows(&results, 3)?
             .iter()
             .map(delivery_from_row)
             .collect()
@@ -925,21 +990,23 @@ impl EventRepoPort for DbEventStore {
         command: RenewEventDeliveryLease,
     ) -> Result<EventDeliveryRecord, EventRepoError> {
         validate_lease_renewal(&command)?;
-        let now = db_timestamp_from_ms(command.now_ms)?;
-        let lease_until = db_timestamp_from_ms(command.lease_until_ms)?;
+        let now = timestamp_value_from_ms(self.flavor, command.now_ms)?;
+        let lease_until = timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
         let result = self
             .db
             .execute(DbStatement::with_params(
-                "UPDATE bcs_event_deliveries SET lease_until = ? \
+                sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_deliveries SET \
+                 lease_until = __bcs_timestamp_ms__ \
                  WHERE env = ? AND delivery_id = ? AND status = 'in_flight' \
-                   AND lease_owner = ? AND attempt_count = ? AND lease_until > ?",
+                   AND lease_owner = ? AND attempt_count = ? \
+                   AND lease_until > __bcs_timestamp_ms__"),
                 vec![
-                    DbValue::from(lease_until),
+                    lease_until,
                     DbValue::from(command.env.as_str()),
                     DbValue::from(command.delivery_id.as_str()),
                     DbValue::from(command.expected_lease_owner.as_str()),
                     DbValue::from(command.attempt_no),
-                    DbValue::from(now),
+                    now,
                 ],
             ))
             .await
@@ -958,72 +1025,79 @@ impl EventRepoPort for DbEventStore {
         command: CompleteEventDeliveryAttempt,
     ) -> Result<EventDeliveryRecord, EventRepoError> {
         validate_completion(&command)?;
-        let started_at = db_timestamp_from_ms(command.started_at_ms)?;
-        let completed_at = db_timestamp_from_ms(command.completed_at_ms)?;
-        let next_attempt_at = optional_db_timestamp(command.next_attempt_at_ms)?;
+        let started_at = timestamp_value_from_ms(self.flavor, command.started_at_ms)?;
+        let completed_at = timestamp_value_from_ms(self.flavor, command.completed_at_ms)?;
+        let next_attempt_at =
+            optional_timestamp_value_from_ms(self.flavor, command.next_attempt_at_ms)?;
         let succeeded_at = (command.next_status == EventDeliveryStatus::Succeeded)
             .then_some(command.completed_at_ms);
         let dead_lettered_at = (command.next_status == EventDeliveryStatus::DeadLettered)
             .then_some(command.completed_at_ms);
-        let insert_step = 0;
+        let attempt_update_step = 0;
         let mut steps = vec![
             DbTransactionStep::Execute(DbStatement::with_params(
-                "INSERT INTO bcs_event_delivery_attempts (delivery_id, attempt_no, started_at, \
-                 completed_at, latency_ms, result, http_status, error_category, error_summary, \
-                 response_bytes_observed, worker_id) \
-                 SELECT delivery_id, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? \
-                 FROM bcs_event_deliveries WHERE delivery_id = ? AND status = 'in_flight' \
-                   AND lease_owner = ? AND lease_until > ? AND attempt_count = ?",
+                sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_delivery_attempts SET \
+                 started_at = __bcs_timestamp_ms__, completed_at = __bcs_timestamp_ms__, \
+                 latency_ms = ?, result = ?, http_status = ?, error_category = ?, \
+                 error_summary = ?, response_bytes_observed = ? \
+                 WHERE delivery_id = ? AND attempt_no = ? AND completed_at IS NULL \
+                   AND EXISTS (SELECT 1 FROM bcs_event_deliveries delivery \
+                     WHERE delivery.delivery_id = bcs_event_delivery_attempts.delivery_id \
+                       AND delivery.status = 'in_flight' AND delivery.lease_owner = ? \
+                       AND delivery.lease_until > __bcs_timestamp_ms__ \
+                       AND delivery.attempt_count = ?)"),
                 vec![
-                    DbValue::from(command.attempt_no),
-                    DbValue::from(started_at),
-                    DbValue::from(completed_at.as_str()),
+                    started_at,
+                    completed_at.clone(),
                     DbValue::from(command.completed_at_ms - command.started_at_ms),
                     DbValue::from(attempt_result_name(command.result)),
                     optional_u64_value(command.http_status.map(u64::from)),
                     DbValue::from(command.error_category.clone()),
                     DbValue::from(command.error_summary.clone()),
                     DbValue::from(command.response_bytes_observed),
-                    DbValue::from(lease_worker_id(&command.expected_lease_owner)),
                     DbValue::from(command.delivery_id.as_str()),
+                    DbValue::from(command.attempt_no),
                     DbValue::from(command.expected_lease_owner.as_str()),
-                    DbValue::from(completed_at.as_str()),
+                    completed_at.clone(),
                     DbValue::from(command.attempt_no),
                 ],
             )),
             DbTransactionStep::Execute(DbStatement::with_params(
-                "UPDATE bcs_event_deliveries SET status = ?, last_attempt_at = ?, \
-                 next_attempt_at = ?, lease_owner = NULL, lease_until = NULL, \
+                sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_deliveries SET \
+                 status = ?, last_attempt_at = __bcs_timestamp_ms__, \
+                 next_attempt_at = __bcs_timestamp_ms__, lease_owner = NULL, lease_until = NULL, \
                  last_http_status = ?, last_error_category = ?, last_error_summary = ?, \
-                 dead_lettered_at = ?, succeeded_at = ? \
+                 dead_lettered_at = __bcs_timestamp_ms__, \
+                 succeeded_at = __bcs_timestamp_ms__ \
                  WHERE delivery_id = ? AND status = 'in_flight' AND lease_owner = ? \
-                   AND lease_until > ? AND attempt_count = ?",
+                   AND lease_until > __bcs_timestamp_ms__ AND attempt_count = ?"),
                 vec![
                     DbValue::from(delivery_status_name(command.next_status)),
-                    DbValue::from(completed_at.as_str()),
+                    completed_at.clone(),
                     next_attempt_at,
                     optional_u64_value(command.http_status.map(u64::from)),
                     DbValue::from(command.error_category.clone()),
                     DbValue::from(command.error_summary.clone()),
-                    optional_db_timestamp(dead_lettered_at)?,
-                    optional_db_timestamp(succeeded_at)?,
+                    optional_timestamp_value_from_ms(self.flavor, dead_lettered_at)?,
+                    optional_timestamp_value_from_ms(self.flavor, succeeded_at)?,
                     DbValue::from(command.delivery_id.as_str()),
                     DbValue::from(command.expected_lease_owner.as_str()),
-                    DbValue::from(completed_at.as_str()),
+                    completed_at.clone(),
                     DbValue::from(command.attempt_no),
                 ],
             )),
         ];
         if command.next_status == EventDeliveryStatus::Succeeded {
             steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-                "UPDATE bcs_event_deliveries SET resolved_by_delivery_id = ?, resolved_at = ? \
+                sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_deliveries SET \
+                 resolved_by_delivery_id = ?, resolved_at = __bcs_timestamp_ms__ \
                  WHERE delivery_id = (SELECT replay_of_delivery_id FROM (\
                    SELECT replay_of_delivery_id FROM bcs_event_deliveries WHERE delivery_id = ?\
                  ) replacement) AND status = 'dead_lettered' \
-                   AND resolved_by_delivery_id IS NULL",
+                   AND resolved_by_delivery_id IS NULL"),
                 vec![
                     DbValue::from(command.delivery_id.as_str()),
-                    DbValue::from(completed_at),
+                    completed_at,
                     DbValue::from(command.delivery_id.as_str()),
                 ],
             )));
@@ -1034,7 +1108,7 @@ impl EventRepoPort for DbEventStore {
             vec![DbValue::from(command.delivery_id.as_str())],
         )));
         let results = self.db.transaction(steps).await.map_err(map_write_error)?;
-        if transaction_affected_rows(&results, insert_step)? != 1 {
+        if transaction_affected_rows(&results, attempt_update_step)? != 1 {
             return Err(EventRepoError::LeaseLost(command.delivery_id));
         }
         transaction_rows(&results, delivery_query_step)?
@@ -1205,7 +1279,7 @@ impl EventRepoPort for DbEventStore {
             }
         }
 
-        let created_at = db_timestamp_from_ms(command.created_at_ms)?;
+        let created_at = timestamp_value_from_ms(self.flavor, command.created_at_ms)?;
         let mut steps = vec![DbTransactionStep::Query(DbStatement::with_params(
             replay_delivery_lock_sql(self.flavor),
             vec![
@@ -1221,7 +1295,7 @@ impl EventRepoPort for DbEventStore {
                     DbValue::from(cause_event_id.as_str()),
                     DbValue::from(command.subscription_id.as_str()),
                     DbValue::from(command.subscription_revision),
-                    DbValue::from(created_at.as_str()),
+                    created_at.clone(),
                     DbValue::from(command.env.as_str()),
                     DbValue::from(command.env.as_str()),
                     DbValue::from(command.original_delivery_id.as_str()),
@@ -1230,19 +1304,19 @@ impl EventRepoPort for DbEventStore {
         }
         let replay_insert_step = steps.len();
         steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-            replay_target_insert_sql(),
+            replay_target_insert_sql(self.flavor),
             vec![
                 DbValue::from(command.target_id.as_str()),
                 DbValue::from(command.subscription_revision),
                 DbValue::from(command.replay_request_id.as_str()),
                 DbValue::from(command.original_delivery_id.as_str()),
                 DbValue::from(dependency),
-                DbValue::from(created_at.as_str()),
+                created_at.clone(),
                 DbValue::from(command.env.as_str()),
                 DbValue::from(command.original_delivery_id.as_str()),
                 DbValue::from(command.subscription_id.as_str()),
                 DbValue::from(command.subscription_revision),
-                DbValue::from(created_at.as_str()),
+                created_at.clone(),
             ],
         )));
         let replay_audit_id = uuid::Uuid::new_v4().to_string();
@@ -1252,24 +1326,25 @@ impl EventRepoPort for DbEventStore {
         })
         .to_string();
         steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-            "INSERT INTO bcs_event_subscription_audits (audit_id, subscription_id, revision, \
+            sql_with_timestamp_params(self.flavor, "INSERT INTO bcs_event_subscription_audits \
+             (audit_id, subscription_id, revision, \
              action, actor_type, actor_id, reason, details_json, created_at, env) \
              SELECT ?, target.subscription_id, target.subscription_revision, \
-             'delivery_replayed', ?, ?, ?, ?, ?, target.env \
+             'delivery_replayed', ?, ?, ?, ?, __bcs_timestamp_ms__, target.env \
              FROM bcs_event_fanout_targets target WHERE target.env = ? AND target.target_id = ? \
                AND target.purpose = 'manual_replay' AND NOT EXISTS (\
                  SELECT 1 FROM bcs_event_subscription_audits audit \
                  WHERE audit.env = target.env \
                    AND audit.subscription_id = target.subscription_id \
                    AND audit.action = 'delivery_replayed' AND audit.details_json = ?\
-               )",
+               )"),
             vec![
                 DbValue::from(replay_audit_id),
                 DbValue::from(actor_type_name(command.actor.actor_type)),
                 DbValue::from(command.actor.id.as_str()),
                 DbValue::from(command.reason.clone()),
                 DbValue::from(replay_details.as_str()),
-                DbValue::from(created_at.as_str()),
+                created_at,
                 DbValue::from(command.env.as_str()),
                 DbValue::from(command.target_id.as_str()),
                 DbValue::from(replay_details),
@@ -1336,19 +1411,20 @@ impl EventRepoPort for DbEventStore {
                 "skip reason must be between 1 and 128 bytes".into(),
             ));
         }
-        let skipped_at = db_timestamp_from_ms(command.skipped_at_ms)?;
+        let skipped_at = timestamp_value_from_ms(self.flavor, command.skipped_at_ms)?;
         let skip_actor = serde_json::to_string(&command.actor)
             .map_err(|error| EventRepoError::InvalidInput(format!("serialize actor: {error}")))?;
         let audit_id = uuid::Uuid::new_v4().to_string();
         let update_step = 0;
         let steps = vec![
             DbTransactionStep::Execute(DbStatement::with_params(
-                "UPDATE bcs_event_deliveries SET status = 'skipped', skipped_at = ?, \
+                sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_deliveries SET \
+                 status = 'skipped', skipped_at = __bcs_timestamp_ms__, \
                  skip_actor = ?, skip_reason = ?, lease_owner = NULL, lease_until = NULL \
                  WHERE env = ? AND delivery_id = ? AND status = 'dead_lettered' \
-                   AND resolved_by_delivery_id IS NULL",
+                   AND resolved_by_delivery_id IS NULL"),
                 vec![
-                    DbValue::from(skipped_at.as_str()),
+                    skipped_at.clone(),
                     DbValue::from(skip_actor),
                     DbValue::from(command.reason.as_str()),
                     DbValue::from(command.env.as_str()),
@@ -1356,40 +1432,44 @@ impl EventRepoPort for DbEventStore {
                 ],
             )),
             DbTransactionStep::Execute(DbStatement::with_params(
-                "UPDATE bcs_event_deliveries SET status = 'cancelled', cancelled_at = ?, \
+                sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_deliveries SET \
+                 status = 'cancelled', cancelled_at = __bcs_timestamp_ms__, \
                  lease_owner = NULL, lease_until = NULL WHERE env = ? \
-                 AND replay_of_delivery_id = ? AND status IN ('pending', 'retry_wait')",
+                 AND replay_of_delivery_id = ? AND status IN ('pending', 'retry_wait')"),
                 vec![
-                    DbValue::from(skipped_at.as_str()),
+                    skipped_at.clone(),
                     DbValue::from(command.env.as_str()),
                     DbValue::from(command.delivery_id.as_str()),
                 ],
             )),
             DbTransactionStep::Execute(DbStatement::with_params(
-                "UPDATE bcs_event_fanout_targets SET status = 'cancelled', cancelled_at = ?, \
+                sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_fanout_targets SET \
+                 status = 'cancelled', cancelled_at = __bcs_timestamp_ms__, \
                  lease_owner = NULL, lease_until = NULL WHERE env = ? \
-                 AND replay_of_delivery_id = ? AND status = 'pending'",
+                 AND replay_of_delivery_id = ? AND status = 'pending'"),
                 vec![
-                    DbValue::from(skipped_at.as_str()),
+                    skipped_at.clone(),
                     DbValue::from(command.env.as_str()),
                     DbValue::from(command.delivery_id.as_str()),
                 ],
             )),
             DbTransactionStep::Execute(DbStatement::with_params(
-                "INSERT INTO bcs_event_subscription_audits (audit_id, subscription_id, \
+                sql_with_timestamp_params(self.flavor, "INSERT INTO \
+                 bcs_event_subscription_audits (audit_id, subscription_id, \
                  revision, action, actor_type, actor_id, reason, details_json, created_at, env) \
                  SELECT ?, subscription_id, subscription_revision, 'delivery_skipped', ?, ?, ?, \
-                 NULL, ?, env FROM bcs_event_deliveries WHERE env = ? AND delivery_id = ? \
-                   AND status = 'skipped' AND skipped_at = ?",
+                 NULL, __bcs_timestamp_ms__, env FROM bcs_event_deliveries \
+                 WHERE env = ? AND delivery_id = ? AND status = 'skipped' \
+                   AND skipped_at = __bcs_timestamp_ms__"),
                 vec![
                     DbValue::from(audit_id),
                     DbValue::from(actor_type_name(command.actor.actor_type)),
                     DbValue::from(command.actor.id.as_str()),
                     DbValue::from(command.reason.as_str()),
-                    DbValue::from(skipped_at.as_str()),
+                    skipped_at.clone(),
                     DbValue::from(command.env.as_str()),
                     DbValue::from(command.delivery_id.as_str()),
-                    DbValue::from(skipped_at.as_str()),
+                    skipped_at.clone(),
                 ],
             )),
         ];
@@ -1414,7 +1494,7 @@ impl EventRepoPort for DbEventStore {
                 "retention limits and env must be non-empty".into(),
             ));
         }
-        let now = db_timestamp_from_ms(command.now_ms)?;
+        let now = timestamp_value_from_ms(self.flavor, command.now_ms)?;
         let attempt_delete_step = 0;
         let delivery_delete_step = 1;
         let event_delete_step = 3;
@@ -1422,12 +1502,13 @@ impl EventRepoPort for DbEventStore {
             .db
             .transaction(vec![
                 DbTransactionStep::Execute(DbStatement::with_params(
-                    "DELETE FROM bcs_event_delivery_attempts WHERE delivery_id IN (\
+                    sql_with_timestamp_params(self.flavor, "DELETE FROM \
+                       bcs_event_delivery_attempts WHERE delivery_id IN (\
                        SELECT delivery_id FROM (SELECT delivery.delivery_id \
                        FROM bcs_event_deliveries delivery WHERE delivery.env = ? \
                          AND delivery.event_id IN (SELECT event_id FROM (\
                            SELECT event.event_id FROM bcs_events event WHERE event.env = ? \
-                             AND event.retention_until <= ? AND NOT EXISTS (\
+                             AND event.retention_until <= __bcs_timestamp_ms__ AND NOT EXISTS (\
                                SELECT 1 FROM bcs_event_fanout_targets target \
                                WHERE target.env = event.env AND target.event_id = event.event_id \
                                  AND (target.status = 'pending' OR EXISTS (\
@@ -1444,21 +1525,22 @@ impl EventRepoPort for DbEventStore {
                                  ))\
                              ) ORDER BY event.retention_until, event.event_id LIMIT ?\
                          ) eligible_events)\
-                       ) eligible_deliveries)",
+                       ) eligible_deliveries)"),
                     vec![
                         DbValue::from(command.env.as_str()),
                         DbValue::from(command.env.as_str()),
-                        DbValue::from(now.as_str()),
+                        now.clone(),
                         DbValue::from(command.event_limit),
                     ],
                 )),
                 DbTransactionStep::Execute(DbStatement::with_params(
-                    "DELETE FROM bcs_event_deliveries WHERE delivery_id IN (\
+                    sql_with_timestamp_params(self.flavor, "DELETE FROM bcs_event_deliveries \
+                       WHERE delivery_id IN (\
                        SELECT delivery_id FROM (SELECT delivery.delivery_id \
                        FROM bcs_event_deliveries delivery WHERE delivery.env = ? \
                          AND delivery.event_id IN (SELECT event_id FROM (\
                            SELECT event.event_id FROM bcs_events event WHERE event.env = ? \
-                             AND event.retention_until <= ? AND NOT EXISTS (\
+                             AND event.retention_until <= __bcs_timestamp_ms__ AND NOT EXISTS (\
                                SELECT 1 FROM bcs_event_fanout_targets target \
                                WHERE target.env = event.env AND target.event_id = event.event_id \
                                  AND (target.status = 'pending' OR EXISTS (\
@@ -1475,21 +1557,23 @@ impl EventRepoPort for DbEventStore {
                                  ))\
                              ) ORDER BY event.retention_until, event.event_id LIMIT ?\
                          ) eligible_events)\
-                       ) eligible_deliveries)",
+                       ) eligible_deliveries)"),
                     vec![
                         DbValue::from(command.env.as_str()),
                         DbValue::from(command.env.as_str()),
-                        DbValue::from(now.as_str()),
+                        now.clone(),
                         DbValue::from(command.event_limit),
                     ],
                 )),
                 DbTransactionStep::Execute(DbStatement::with_params(
-                    "DELETE FROM bcs_event_fanout_targets WHERE target_id IN (\
+                    sql_with_timestamp_params(self.flavor, "DELETE FROM \
+                       bcs_event_fanout_targets WHERE target_id IN (\
                        SELECT target_id FROM (SELECT target.target_id \
                        FROM bcs_event_fanout_targets target \
                        JOIN bcs_events event ON event.env = target.env \
                          AND event.event_id = target.event_id \
-                       WHERE target.env = ? AND event.retention_until <= ? \
+                       WHERE target.env = ? \
+                         AND event.retention_until <= __bcs_timestamp_ms__ \
                          AND target.status <> 'pending' AND NOT EXISTS (\
                            SELECT 1 FROM bcs_event_fanout_targets dependent \
                            WHERE dependent.env = target.env \
@@ -1499,24 +1583,25 @@ impl EventRepoPort for DbEventStore {
                            WHERE delivery.env = target.env \
                              AND delivery.fanout_target_id = target.target_id\
                          ) ORDER BY event.retention_until, event.event_id LIMIT ?\
-                       ) eligible_targets)",
+                       ) eligible_targets)"),
                     vec![
                         DbValue::from(command.env.as_str()),
-                        DbValue::from(now.as_str()),
+                        now.clone(),
                         DbValue::from(command.event_limit),
                     ],
                 )),
                 DbTransactionStep::Execute(DbStatement::with_params(
-                    "DELETE FROM bcs_events WHERE event_id IN (SELECT event_id FROM (\
+                    sql_with_timestamp_params(self.flavor, "DELETE FROM bcs_events \
+                     WHERE event_id IN (SELECT event_id FROM (\
                    SELECT event.event_id FROM bcs_events event WHERE event.env = ? \
-                     AND event.retention_until <= ? AND NOT EXISTS (\
+                     AND event.retention_until <= __bcs_timestamp_ms__ AND NOT EXISTS (\
                        SELECT 1 FROM bcs_event_fanout_targets target \
                        WHERE target.env = event.env AND target.event_id = event.event_id\
                      ) ORDER BY event.retention_until, event.event_id LIMIT ?\
-                 ) eligible)",
+                 ) eligible)"),
                     vec![
                         DbValue::from(command.env.as_str()),
-                        DbValue::from(now),
+                        now,
                         DbValue::from(command.event_limit),
                     ],
                 )),
@@ -1532,21 +1617,26 @@ impl EventRepoPort for DbEventStore {
     }
 }
 
-fn claim_fanout_targets_sql() -> &'static str {
-    "UPDATE bcs_event_fanout_targets SET lease_owner = ?, lease_until = ? \
+fn claim_fanout_targets_sql(flavor: DbSqlFlavor) -> String {
+    sql_with_timestamp_params(flavor, "UPDATE bcs_event_fanout_targets SET lease_owner = ?, \
+     lease_until = __bcs_timestamp_ms__ \
      WHERE target_id IN (SELECT target_id FROM (\
        SELECT target.target_id FROM bcs_event_fanout_targets target \
        WHERE target.env = ? AND target.status = 'pending' \
-         AND (target.lease_until IS NULL OR target.lease_until <= ?) \
+         AND (target.lease_until IS NULL \
+           OR target.lease_until <= __bcs_timestamp_ms__) \
        ORDER BY created_at, target_id LIMIT ?\
      ) claimable) AND env = ? AND status = 'pending' \
-       AND (lease_until IS NULL OR lease_until <= ?)"
+       AND (lease_until IS NULL OR lease_until <= __bcs_timestamp_ms__)"
+    )
 }
 
-fn claim_deliveries_sql() -> &'static str {
-    "UPDATE bcs_event_deliveries SET status = 'in_flight', attempt_count = attempt_count + 1, \
-     lease_owner = ?, lease_until = ?, first_attempt_at = COALESCE(first_attempt_at, ?), \
-     last_attempt_at = ?, next_attempt_at = NULL \
+fn claim_deliveries_sql(flavor: DbSqlFlavor) -> String {
+    sql_with_timestamp_params(flavor, "UPDATE bcs_event_deliveries SET status = 'in_flight', \
+     attempt_count = attempt_count + 1, lease_owner = ?, \
+     lease_until = __bcs_timestamp_ms__, \
+     first_attempt_at = COALESCE(first_attempt_at, __bcs_timestamp_ms__), \
+     last_attempt_at = __bcs_timestamp_ms__, next_attempt_at = NULL \
      WHERE delivery_id IN (SELECT delivery_id FROM (\
        SELECT delivery.delivery_id FROM bcs_event_deliveries delivery \
        JOIN bcs_event_subscription_revisions revision \
@@ -1556,9 +1646,11 @@ fn claim_deliveries_sql() -> &'static str {
        JOIN bcs_event_fanout_targets target \
          ON target.env = delivery.env AND target.target_id = delivery.fanout_target_id \
        WHERE delivery.env = ? \
-         AND (delivery.lease_until IS NULL OR delivery.lease_until <= ?) \
+         AND (delivery.lease_until IS NULL \
+           OR delivery.lease_until <= __bcs_timestamp_ms__) \
          AND (delivery.status = 'pending' \
-           OR (delivery.status = 'retry_wait' AND delivery.next_attempt_at <= ?) \
+           OR (delivery.status = 'retry_wait' \
+             AND delivery.next_attempt_at <= __bcs_timestamp_ms__) \
            OR delivery.status = 'in_flight') \
          AND (target.depends_on_target_id IS NULL OR EXISTS (\
            SELECT 1 FROM bcs_event_deliveries dependency \
@@ -1580,19 +1672,20 @@ fn claim_deliveries_sql() -> &'static str {
          ) \
        ORDER BY delivery.created_at, delivery.sequence, delivery.delivery_id LIMIT ?\
      ) claimable) AND env = ? \
-       AND (lease_until IS NULL OR lease_until <= ?) \
-       AND (status = 'pending' OR (status = 'retry_wait' AND next_attempt_at <= ?) \
-         OR status = 'in_flight')"
+       AND (lease_until IS NULL OR lease_until <= __bcs_timestamp_ms__) \
+       AND (status = 'pending' OR (status = 'retry_wait' \
+         AND next_attempt_at <= __bcs_timestamp_ms__) OR status = 'in_flight')"
+    )
 }
 
-fn causal_replay_insert_sql(flavor: DbSqlFlavor) -> &'static str {
-    match flavor {
+fn causal_replay_insert_sql(flavor: DbSqlFlavor) -> String {
+    sql_with_timestamp_params(flavor, match flavor {
         DbSqlFlavor::Mysql => {
             "INSERT IGNORE INTO bcs_event_fanout_targets (target_id, event_id, subscription_id, \
              subscription_revision, purpose, replay_request_id, replay_of_delivery_id, \
              depends_on_target_id, status, lease_owner, lease_until, created_at, materialized_at, \
              cancelled_at, env) SELECT ?, ?, ?, ?, 'causal_prerequisite', '', NULL, NULL, \
-             'pending', NULL, NULL, ?, NULL, NULL, ? WHERE EXISTS (\
+             'pending', NULL, NULL, __bcs_timestamp_ms__, NULL, NULL, ? WHERE EXISTS (\
                SELECT 1 FROM bcs_event_deliveries original WHERE original.env = ? \
                  AND original.delivery_id = ? AND original.status = 'dead_lettered' \
                  AND original.resolved_by_delivery_id IS NULL\
@@ -1603,21 +1696,23 @@ fn causal_replay_insert_sql(flavor: DbSqlFlavor) -> &'static str {
              subscription_revision, purpose, replay_request_id, replay_of_delivery_id, \
              depends_on_target_id, status, lease_owner, lease_until, created_at, materialized_at, \
              cancelled_at, env) SELECT ?, ?, ?, ?, 'causal_prerequisite', '', NULL, NULL, \
-             'pending', NULL, NULL, ?, NULL, NULL, ? WHERE EXISTS (\
+             'pending', NULL, NULL, __bcs_timestamp_ms__, NULL, NULL, ? WHERE EXISTS (\
                SELECT 1 FROM bcs_event_deliveries original WHERE original.env = ? \
                  AND original.delivery_id = ? AND original.status = 'dead_lettered' \
                  AND original.resolved_by_delivery_id IS NULL\
              )"
         }
-    }
+    })
 }
 
-fn replay_target_insert_sql() -> &'static str {
-    "INSERT INTO bcs_event_fanout_targets (target_id, event_id, subscription_id, \
+fn replay_target_insert_sql(flavor: DbSqlFlavor) -> String {
+    sql_with_timestamp_params(flavor, "INSERT INTO bcs_event_fanout_targets \
+     (target_id, event_id, subscription_id, \
      subscription_revision, purpose, replay_request_id, replay_of_delivery_id, \
      depends_on_target_id, status, lease_owner, lease_until, created_at, materialized_at, \
      cancelled_at, env) SELECT ?, original.event_id, original.subscription_id, ?, \
-     'manual_replay', ?, ?, ?, 'pending', NULL, NULL, ?, NULL, NULL, original.env \
+     'manual_replay', ?, ?, ?, 'pending', NULL, NULL, __bcs_timestamp_ms__, \
+     NULL, NULL, original.env \
      FROM bcs_event_deliveries original JOIN bcs_events event \
        ON event.env = original.env AND event.event_id = original.event_id \
      JOIN bcs_event_subscriptions subscription \
@@ -1626,7 +1721,8 @@ fn replay_target_insert_sql() -> &'static str {
      WHERE original.env = ? AND original.delivery_id = ? AND original.subscription_id = ? \
        AND original.status = 'dead_lettered' AND original.resolved_by_delivery_id IS NULL \
        AND subscription.current_revision = ? \
-       AND subscription.status = 'active' AND event.retention_until > ? \
+       AND subscription.status = 'active' \
+       AND event.retention_until > __bcs_timestamp_ms__ \
        AND NOT EXISTS (\
          SELECT 1 FROM bcs_event_fanout_targets replay \
          LEFT JOIN bcs_event_deliveries replacement \
@@ -1635,7 +1731,7 @@ fn replay_target_insert_sql() -> &'static str {
            AND replay.replay_of_delivery_id = original.delivery_id \
            AND (replay.status = 'pending' \
              OR replacement.status IN ('pending', 'in_flight', 'retry_wait'))\
-       )"
+       )")
 }
 
 fn replay_delivery_lock_sql(flavor: DbSqlFlavor) -> &'static str {
@@ -1721,12 +1817,6 @@ fn validate_lease_renewal(command: &RenewEventDeliveryLease) -> Result<(), Event
 
 fn claim_owner(worker_id: &str) -> String {
     format!("{worker_id}#{}", uuid::Uuid::new_v4())
-}
-
-fn lease_worker_id(lease_owner: &str) -> &str {
-    lease_owner
-        .split_once('#')
-        .map_or(lease_owner, |(worker, _)| worker)
 }
 
 fn validate_materialization(command: &MaterializeFanoutTarget) -> Result<(), EventRepoError> {
@@ -1936,13 +2026,15 @@ fn revision_insert_statement(
     revision: &EventSubscriptionRevisionRecord,
     env: &str,
     event_filters: &str,
-    activated_at: &str,
+    flavor: DbSqlFlavor,
+    activated_at: &DbValue,
 ) -> Result<DbStatement, EventRepoError> {
     Ok(DbStatement::with_params(
-        "INSERT INTO bcs_event_subscription_revisions (subscription_id, revision, \
+        sql_with_timestamp_params(flavor, "INSERT INTO bcs_event_subscription_revisions \
+         (subscription_id, revision, \
          event_filters_json, payload_mode, \
          endpoint_url, request_timeout_ms, activated_at, retired_at, env) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+         VALUES (?, ?, ?, ?, ?, ?, __bcs_timestamp_ms__, __bcs_timestamp_ms__, ?)"),
         vec![
             DbValue::from(revision.subscription_id.as_str()),
             DbValue::from(revision.revision),
@@ -1950,8 +2042,8 @@ fn revision_insert_statement(
             DbValue::from(payload_mode_name(revision.payload_mode)),
             DbValue::from(revision.endpoint_url.as_str()),
             DbValue::from(revision.request_timeout_ms),
-            DbValue::from(activated_at),
-            optional_db_timestamp(revision.retired_at_ms)?,
+            activated_at.clone(),
+            optional_timestamp_value_from_ms(flavor, revision.retired_at_ms)?,
             DbValue::from(env),
         ],
     ))
@@ -1961,19 +2053,21 @@ fn revision_insert_if_subscription_exists_statement(
     revision: &EventSubscriptionRevisionRecord,
     env: &str,
     event_filters: &str,
-    activated_at: &str,
+    flavor: DbSqlFlavor,
+    activated_at: &DbValue,
 ) -> Result<DbStatement, EventRepoError> {
-    let mut params =
-        revision_insert_statement(revision, env, event_filters, activated_at)?.into_params();
+    let mut params = revision_insert_statement(revision, env, event_filters, flavor, activated_at)?
+        .into_params();
     params.push(DbValue::from(env));
     params.push(DbValue::from(revision.subscription_id.as_str()));
     Ok(DbStatement::with_params(
-        "INSERT INTO bcs_event_subscription_revisions (subscription_id, revision, \
+        sql_with_timestamp_params(flavor, "INSERT INTO bcs_event_subscription_revisions \
+         (subscription_id, revision, \
          event_filters_json, payload_mode, endpoint_url, request_timeout_ms, \
          activated_at, retired_at, env) \
-         SELECT ?, ?, ?, ?, ?, ?, ?, ?, ? WHERE EXISTS (\
+         SELECT ?, ?, ?, ?, ?, ?, __bcs_timestamp_ms__, __bcs_timestamp_ms__, ? WHERE EXISTS (\
            SELECT 1 FROM bcs_event_subscriptions WHERE env = ? AND subscription_id = ?\
-         )",
+         )"),
         params,
     ))
 }
@@ -2133,12 +2227,9 @@ fn delivery_from_row(row: &DbRow) -> Result<EventDeliveryRecord, EventRepoError>
 }
 
 fn attempt_from_row(row: &DbRow) -> Result<EventDeliveryAttemptRecord, EventRepoError> {
-    let completed_at_ms = optional_column(row, "completed_at_ms")?
-        .ok_or_else(|| EventRepoError::Storage("persisted Attempt is incomplete".into()))?;
-    let latency_ms = optional_column(row, "latency_ms")?
-        .ok_or_else(|| EventRepoError::Storage("persisted Attempt latency is missing".into()))?;
     let result = optional_column::<String>(row, "result")?
-        .ok_or_else(|| EventRepoError::Storage("persisted Attempt result is missing".into()))?;
+        .map(|result| parse_attempt_result(&result))
+        .transpose()?;
     let http_status = optional_column::<u64>(row, "http_status")?
         .map(u16::try_from)
         .transpose()
@@ -2147,14 +2238,13 @@ fn attempt_from_row(row: &DbRow) -> Result<EventDeliveryAttemptRecord, EventRepo
         delivery_id: column(row, "delivery_id")?,
         attempt_no: column(row, "attempt_no")?,
         started_at_ms: column(row, "started_at_ms")?,
-        completed_at_ms,
-        latency_ms,
-        result: parse_attempt_result(&result)?,
+        completed_at_ms: optional_column(row, "completed_at_ms")?,
+        latency_ms: optional_column(row, "latency_ms")?,
+        result,
         http_status,
         error_category: optional_column(row, "error_category")?,
         error_summary: optional_column(row, "error_summary")?,
-        response_bytes_observed: optional_column(row, "response_bytes_observed")?
-            .unwrap_or_default(),
+        response_bytes_observed: optional_column(row, "response_bytes_observed")?,
         worker_id: column(row, "worker_id")?,
     })
 }
@@ -2244,25 +2334,6 @@ fn timestamp_ms_expr(flavor: DbSqlFlavor, column: &str, alias: &str) -> String {
             )
         }
     }
-}
-
-fn db_timestamp_from_ms(timestamp_ms: u64) -> Result<String, EventRepoError> {
-    let timestamp_ms = i64::try_from(timestamp_ms).map_err(|_| {
-        EventRepoError::InvalidInput("timestamp is outside supported range".to_string())
-    })?;
-    Utc.timestamp_millis_opt(timestamp_ms)
-        .single()
-        .map(|timestamp| timestamp.format("%Y-%m-%d %H:%M:%S%.3f").to_string())
-        .ok_or_else(|| {
-            EventRepoError::InvalidInput("timestamp is outside supported range".to_string())
-        })
-}
-
-fn optional_db_timestamp(timestamp_ms: Option<u64>) -> Result<DbValue, EventRepoError> {
-    timestamp_ms
-        .map(db_timestamp_from_ms)
-        .transpose()
-        .map(DbValue::from)
 }
 
 fn rfc3339_from_ms(timestamp_ms: u64) -> Result<String, EventRepoError> {
@@ -2469,12 +2540,13 @@ mod tests {
 
     #[test]
     fn task_six_sql_has_expected_parameter_counts_for_both_dialects() {
-        assert_eq!(claim_fanout_targets_sql().matches('?').count(), 7);
-        assert_eq!(claim_deliveries_sql().matches('?').count(), 11);
-        assert_eq!(replay_target_insert_sql().matches('?').count(), 11);
         for flavor in [DbSqlFlavor::Mysql, DbSqlFlavor::Sqlite] {
+            assert_eq!(claim_fanout_targets_sql(flavor).matches('?').count(), 7);
+            assert_eq!(claim_deliveries_sql(flavor).matches('?').count(), 11);
+            assert_eq!(replay_target_insert_sql(flavor).matches('?').count(), 11);
             assert_eq!(causal_replay_insert_sql(flavor).matches('?').count(), 8);
             assert_eq!(replay_delivery_lock_sql(flavor).matches('?').count(), 2);
+            assert!(!claim_deliveries_sql(flavor).contains("__bcs_timestamp_ms__"));
         }
     }
 }

--- a/src/bcs/crates/services/bcs-event-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-event-store/src/lib.rs
@@ -5,6 +5,8 @@ pub mod memory;
 pub mod recorder;
 pub mod transaction_plan;
 
+mod timestamp;
+
 pub use db::DbEventStore;
 pub use memory::MemoryEventStore;
 pub use recorder::EventRecorder;

--- a/src/bcs/crates/services/bcs-event-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-event-store/src/memory.rs
@@ -116,8 +116,10 @@ impl MemoryEventStore {
     }
 
     /// Commit the in-memory half of Group provisioning while the caller holds
-    /// its Group write guard. The callback flips Group availability only after
-    /// a complete candidate Event state has been built; both locks remain held
+    /// its Group write guard. Matching Events produced while the inline
+    /// subscriptions were pending are snapshotted before the creation Events
+    /// are appended. The callback flips Group availability only after a
+    /// complete candidate Event state has been built; both locks remain held
     /// until the Event state is published.
     pub async fn finalize_group_provisioning<F>(
         &self,
@@ -235,6 +237,13 @@ impl MemoryEventStore {
                 ))
                 .or_default() += 1;
         }
+        backfill_group_provisioning_targets(
+            &mut candidate,
+            group_id,
+            subscription_ids,
+            finalized_at_ms,
+            env,
+        )?;
         let mut results = Vec::with_capacity(events.len());
         for event in events {
             results.push(append_event_to_state(&mut candidate, event)?);
@@ -991,13 +1000,30 @@ impl EventRepoPort for MemoryEventStore {
                         .lease_until_ms
                         .is_none_or(|lease_until| lease_until <= command.now_ms)
             })
-            .map(|target| (target.created_at_ms, target.target_id.clone()))
+            .map(|target| {
+                let (stream_key, sequence) = state
+                    .events
+                    .get(&target.event_id)
+                    .map(|event| {
+                        (
+                            event.envelope.stream.key.clone(),
+                            event.envelope.stream.sequence,
+                        )
+                    })
+                    .unwrap_or_default();
+                (
+                    target.created_at_ms,
+                    stream_key,
+                    sequence,
+                    target.target_id.clone(),
+                )
+            })
             .collect::<Vec<_>>();
         candidate_ids.sort();
         candidate_ids.truncate(command.limit as usize);
 
         let mut claimed = Vec::with_capacity(candidate_ids.len());
-        for (_, target_id) in candidate_ids {
+        for (_, _, _, target_id) in candidate_ids {
             let target = state.targets.get_mut(&target_id).ok_or_else(|| {
                 EventRepoError::Storage(
                     "candidate target disappeared while state was write locked".into(),
@@ -1869,6 +1895,141 @@ fn target_id(
         format!("{env}\0{event_id}\0{subscription_id}\0{revision}\0{purpose:?}").as_bytes(),
     );
     format!("evtgt_{digest:x}")
+}
+
+fn backfill_group_provisioning_targets(
+    state: &mut MemoryState,
+    group_id: &str,
+    subscription_ids: &[String],
+    finalized_at_ms: u64,
+    env: &str,
+) -> Result<(), EventRepoError> {
+    let subscriptions = subscription_ids
+        .iter()
+        .map(|subscription_id| {
+            let stored = state.subscriptions.get(subscription_id).ok_or_else(|| {
+                EventRepoError::NotFound(format!(
+                    "active subscription {subscription_id} was not found"
+                ))
+            })?;
+            let revision = stored
+                .revisions
+                .get(&stored.record.current_revision)
+                .ok_or_else(|| {
+                    EventRepoError::Storage(format!(
+                        "subscription {subscription_id} current revision is missing"
+                    ))
+                })?;
+            Ok((
+                subscription_id.clone(),
+                revision.revision,
+                stored.record.created_at_ms,
+                revision.event_filters.clone(),
+            ))
+        })
+        .collect::<Result<Vec<_>, EventRepoError>>()?;
+    let mut events = state
+        .events
+        .values()
+        .filter(|event| {
+            event.env == env
+                && event.envelope.scope.group_id.as_deref() == Some(group_id)
+                && event.retention_until_ms > finalized_at_ms
+        })
+        .map(|event| {
+            Ok((
+                parse_timestamp_ms(&event.envelope.recorded_at)?,
+                event.clone(),
+            ))
+        })
+        .collect::<Result<Vec<_>, EventRepoError>>()?;
+    events.sort_by(|left, right| {
+        left.0
+            .cmp(&right.0)
+            .then_with(|| left.1.envelope.stream.key.cmp(&right.1.envelope.stream.key))
+            .then_with(|| {
+                left.1
+                    .envelope
+                    .stream
+                    .sequence
+                    .cmp(&right.1.envelope.stream.sequence)
+            })
+            .then_with(|| left.1.envelope.event_id.cmp(&right.1.envelope.event_id))
+    });
+
+    for (subscription_id, revision, created_at_ms, filters) in subscriptions {
+        let matching_events = events
+            .iter()
+            .filter(|(recorded_at_ms, event)| {
+                *recorded_at_ms >= created_at_ms
+                    && *recorded_at_ms <= finalized_at_ms
+                    && filters
+                        .iter()
+                        .any(|filter| event_filter_matches(filter, &event.envelope.event_type))
+            })
+            .collect::<Vec<_>>();
+        for (recorded_at_ms, event) in &matching_events {
+            let normal_target_id = target_id(
+                env,
+                &event.envelope.event_id,
+                &subscription_id,
+                revision,
+                EventFanoutTargetPurpose::Normal,
+            );
+            if state.targets.contains_key(&normal_target_id) {
+                continue;
+            }
+            state.targets.insert(
+                normal_target_id.clone(),
+                EventFanoutTargetRecord {
+                    target_id: normal_target_id,
+                    event_id: event.envelope.event_id.clone(),
+                    subscription_id: subscription_id.clone(),
+                    subscription_revision: revision,
+                    purpose: EventFanoutTargetPurpose::Normal,
+                    replay_request_id: None,
+                    replay_of_delivery_id: None,
+                    depends_on_target_id: None,
+                    status: EventFanoutTargetStatus::Pending,
+                    created_at_ms: *recorded_at_ms,
+                    materialized_at_ms: None,
+                    cancelled_at_ms: None,
+                    lease_owner: None,
+                    lease_until_ms: None,
+                    env: env.to_string(),
+                },
+            );
+            if let Some(stored_event) = state.events.get_mut(&event.envelope.event_id) {
+                stored_event.fanout_status = EventFanoutStatus::Pending;
+            }
+        }
+        for (recorded_at_ms, event) in matching_events {
+            let depends_on_target_id = resolve_causal_target(
+                state,
+                env,
+                event.envelope.causation_event_id.as_deref(),
+                &subscription_id,
+                revision,
+                *recorded_at_ms,
+            )?;
+            let normal_target_id = target_id(
+                env,
+                &event.envelope.event_id,
+                &subscription_id,
+                revision,
+                EventFanoutTargetPurpose::Normal,
+            );
+            let normal_target = state.targets.get_mut(&normal_target_id).ok_or_else(|| {
+                EventRepoError::Storage(format!(
+                    "backfilled normal target {normal_target_id} is missing"
+                ))
+            })?;
+            if normal_target.depends_on_target_id.is_none() {
+                normal_target.depends_on_target_id = depends_on_target_id;
+            }
+        }
+    }
+    Ok(())
 }
 
 fn resolve_causal_target(

--- a/src/bcs/crates/services/bcs-event-store/src/memory.rs
+++ b/src/bcs/crates/services/bcs-event-store/src/memory.rs
@@ -8,11 +8,12 @@ use bcs_service_api::port::repo::{
     AppendEventRecord, AppendEventRecordResult, CancelPendingEventSubscriptions,
     ClaimEventDeliveries, ClaimFanoutTargets, CompleteEventDeliveryAttempt,
     CreateEventReplayTarget, CreateEventSubscriptionRecord, EventDeliveryAttemptRecord,
-    EventDeliveryRecord, EventFanoutStatus, EventFanoutTargetPurpose, EventFanoutTargetRecord,
-    EventFanoutTargetStatus, EventRecord, EventRepoError, EventRepoPort, EventRetentionRequest,
-    EventRetentionResult, EventSubscriptionRecord, EventSubscriptionRevisionRecord,
-    ListEventDeliveryRecords, ListEventSubscriptionRecords, MaterializeFanoutTarget,
-    RenewEventDeliveryLease, ReplaceEventSubscriptionRevision, SkipDeadLetteredEventDelivery,
+    EventDeliveryAttemptRecordResult, EventDeliveryRecord, EventFanoutStatus,
+    EventFanoutTargetPurpose, EventFanoutTargetRecord, EventFanoutTargetStatus, EventRecord,
+    EventRepoError, EventRepoPort, EventRetentionRequest, EventRetentionResult,
+    EventSubscriptionRecord, EventSubscriptionRevisionRecord, ListEventDeliveryRecords,
+    ListEventSubscriptionRecords, MaterializeFanoutTarget, RenewEventDeliveryLease,
+    ReplaceEventSubscriptionRevision, SkipDeadLetteredEventDelivery,
 };
 use bcs_service_api::types::{
     EVENT_SOURCE, EVENT_SPEC_VERSION, EventDeliveryStatus, EventEnvelope, EventStream,
@@ -1147,21 +1148,76 @@ impl EventRepoPort for MemoryEventStore {
             if !delivery_is_eligible(&state, &delivery_id, command.now_ms)? {
                 continue;
             }
-            let delivery = state.deliveries.get_mut(&delivery_id).ok_or_else(|| {
-                EventRepoError::Storage(
-                    "candidate Delivery disappeared while state was write locked".into(),
-                )
-            })?;
-            delivery.status = EventDeliveryStatus::InFlight;
-            delivery.attempt_count = delivery.attempt_count.checked_add(1).ok_or_else(|| {
-                EventRepoError::Conflict("Delivery attempt counter overflow".into())
-            })?;
-            delivery.first_attempt_at_ms.get_or_insert(command.now_ms);
-            delivery.last_attempt_at_ms = Some(command.now_ms);
-            delivery.next_attempt_at_ms = None;
-            delivery.lease_owner = Some(lease_owner.clone());
-            delivery.lease_until_ms = Some(command.lease_until_ms);
-            claimed.push(delivery.clone());
+            let next_attempt_no = state
+                .deliveries
+                .get(&delivery_id)
+                .ok_or_else(|| {
+                    EventRepoError::Storage(
+                        "candidate Delivery disappeared while state was write locked".into(),
+                    )
+                })?
+                .attempt_count
+                .checked_add(1)
+                .ok_or_else(|| {
+                    EventRepoError::Conflict("Delivery attempt counter overflow".into())
+                })?;
+            if state
+                .attempts
+                .get(&delivery_id)
+                .is_some_and(|attempts| attempts.contains_key(&next_attempt_no))
+            {
+                return Err(EventRepoError::Conflict(format!(
+                    "attempt {next_attempt_no} already exists for Delivery {delivery_id}"
+                )));
+            }
+            let (abandoned_attempt_no, claimed_delivery) = {
+                let delivery = state.deliveries.get_mut(&delivery_id).ok_or_else(|| {
+                    EventRepoError::Storage(
+                        "candidate Delivery disappeared while state was write locked".into(),
+                    )
+                })?;
+                let abandoned_attempt_no = (delivery.status == EventDeliveryStatus::InFlight)
+                    .then_some(delivery.attempt_count);
+                delivery.status = EventDeliveryStatus::InFlight;
+                delivery.attempt_count = next_attempt_no;
+                delivery.first_attempt_at_ms.get_or_insert(command.now_ms);
+                delivery.last_attempt_at_ms = Some(command.now_ms);
+                delivery.next_attempt_at_ms = None;
+                delivery.lease_owner = Some(lease_owner.clone());
+                delivery.lease_until_ms = Some(command.lease_until_ms);
+                (abandoned_attempt_no, delivery.clone())
+            };
+            let attempts = state.attempts.entry(delivery_id.clone()).or_default();
+            if let Some(attempt_no) = abandoned_attempt_no
+                && let Some(attempt) = attempts.get_mut(&attempt_no)
+                && attempt.completed_at_ms.is_none()
+            {
+                attempt.completed_at_ms = Some(command.now_ms);
+                attempt.result = Some(EventDeliveryAttemptRecordResult::Retryable);
+                attempt.error_category = Some("lease_expired".to_string());
+                attempt.error_summary = Some(
+                    "Delivery lease expired before completion; remote outcome is unknown"
+                        .to_string(),
+                );
+                attempt.response_bytes_observed = Some(0);
+            }
+            attempts.insert(
+                claimed_delivery.attempt_count,
+                EventDeliveryAttemptRecord {
+                    delivery_id: delivery_id.clone(),
+                    attempt_no: claimed_delivery.attempt_count,
+                    started_at_ms: command.now_ms,
+                    completed_at_ms: None,
+                    latency_ms: None,
+                    result: None,
+                    http_status: None,
+                    error_category: None,
+                    error_summary: None,
+                    response_bytes_observed: None,
+                    worker_id: command.worker_id.clone(),
+                },
+            );
+            claimed.push(claimed_delivery);
         }
         Ok(claimed)
     }
@@ -1191,30 +1247,33 @@ impl EventRepoPort for MemoryEventStore {
         }
         let attempts = state
             .attempts
-            .entry(command.delivery_id.clone())
-            .or_default();
-        if attempts.contains_key(&command.attempt_no) {
+            .get_mut(&command.delivery_id)
+            .ok_or_else(|| {
+                EventRepoError::Storage(format!(
+                    "active attempt {} is missing for Delivery {}",
+                    command.attempt_no, command.delivery_id
+                ))
+            })?;
+        let attempt = attempts.get_mut(&command.attempt_no).ok_or_else(|| {
+            EventRepoError::Storage(format!(
+                "active attempt {} is missing for Delivery {}",
+                command.attempt_no, command.delivery_id
+            ))
+        })?;
+        if attempt.completed_at_ms.is_some() {
             return Err(EventRepoError::Conflict(format!(
-                "attempt {} already exists for Delivery {}",
+                "attempt {} is already complete for Delivery {}",
                 command.attempt_no, command.delivery_id
             )));
         }
-        attempts.insert(
-            command.attempt_no,
-            EventDeliveryAttemptRecord {
-                delivery_id: command.delivery_id.clone(),
-                attempt_no: command.attempt_no,
-                started_at_ms: command.started_at_ms,
-                completed_at_ms: command.completed_at_ms,
-                latency_ms: command.completed_at_ms - command.started_at_ms,
-                result: command.result,
-                http_status: command.http_status,
-                error_category: command.error_category.clone(),
-                error_summary: command.error_summary.clone(),
-                response_bytes_observed: command.response_bytes_observed,
-                worker_id: lease_worker_id(&command.expected_lease_owner).to_string(),
-            },
-        );
+        attempt.started_at_ms = command.started_at_ms;
+        attempt.completed_at_ms = Some(command.completed_at_ms);
+        attempt.latency_ms = Some(command.completed_at_ms - command.started_at_ms);
+        attempt.result = Some(command.result);
+        attempt.http_status = command.http_status;
+        attempt.error_category = command.error_category.clone();
+        attempt.error_summary = command.error_summary.clone();
+        attempt.response_bytes_observed = Some(command.response_bytes_observed);
         let result = {
             let delivery = state
                 .deliveries
@@ -1934,12 +1993,6 @@ fn claim_owner(worker_id: &str) -> String {
     format!("{worker_id}#{}", uuid::Uuid::new_v4())
 }
 
-fn lease_worker_id(lease_owner: &str) -> &str {
-    lease_owner
-        .split_once('#')
-        .map_or(lease_owner, |(worker, _)| worker)
-}
-
 fn validate_materialization(command: &MaterializeFanoutTarget) -> Result<(), EventRepoError> {
     let delivery = &command.delivery;
     if command.target_id.is_empty()
@@ -2100,11 +2153,11 @@ fn validate_completion(command: &CompleteEventDeliveryAttempt) -> Result<(), Eve
         ));
     }
     let valid = match command.result {
-        bcs_service_api::port::repo::EventDeliveryAttemptRecordResult::Success => {
+        EventDeliveryAttemptRecordResult::Success => {
             command.next_status == EventDeliveryStatus::Succeeded
                 && command.next_attempt_at_ms.is_none()
         }
-        bcs_service_api::port::repo::EventDeliveryAttemptRecordResult::Retryable => {
+        EventDeliveryAttemptRecordResult::Retryable => {
             (command.next_status == EventDeliveryStatus::RetryWait
                 && command
                     .next_attempt_at_ms
@@ -2112,7 +2165,7 @@ fn validate_completion(command: &CompleteEventDeliveryAttempt) -> Result<(), Eve
                 || (command.next_status == EventDeliveryStatus::DeadLettered
                     && command.next_attempt_at_ms.is_none())
         }
-        bcs_service_api::port::repo::EventDeliveryAttemptRecordResult::Terminal => {
+        EventDeliveryAttemptRecordResult::Terminal => {
             command.next_status == EventDeliveryStatus::DeadLettered
                 && command.next_attempt_at_ms.is_none()
         }

--- a/src/bcs/crates/services/bcs-event-store/src/timestamp.rs
+++ b/src/bcs/crates/services/bcs-event-store/src/timestamp.rs
@@ -1,0 +1,108 @@
+use bcs_db_api::{DbSqlFlavor, DbValue};
+use bcs_service_api::port::repo::EventRepoError;
+use chrono::{DateTime, TimeZone, Utc};
+
+const TIMESTAMP_PARAM_MARKER: &str = "__bcs_timestamp_ms__";
+
+pub(crate) fn sql_with_timestamp_params(flavor: DbSqlFlavor, sql: &str) -> String {
+    let expression = match flavor {
+        DbSqlFlavor::Mysql => "FROM_UNIXTIME(? / 1000.0)",
+        DbSqlFlavor::Sqlite => "?",
+    };
+    sql.replace(TIMESTAMP_PARAM_MARKER, expression)
+}
+
+pub(crate) fn timestamp_value_from_ms(
+    flavor: DbSqlFlavor,
+    timestamp_ms: u64,
+) -> Result<DbValue, EventRepoError> {
+    let timestamp_ms = i64::try_from(timestamp_ms).map_err(|_| {
+        EventRepoError::InvalidInput("timestamp is outside supported range".to_string())
+    })?;
+    timestamp_value(flavor, timestamp_ms)
+}
+
+pub(crate) fn optional_timestamp_value_from_ms(
+    flavor: DbSqlFlavor,
+    timestamp_ms: Option<u64>,
+) -> Result<DbValue, EventRepoError> {
+    timestamp_ms
+        .map(|timestamp_ms| timestamp_value_from_ms(flavor, timestamp_ms))
+        .transpose()
+        .map(|value| value.unwrap_or(DbValue::Null))
+}
+
+pub(crate) fn timestamp_value_from_rfc3339(
+    flavor: DbSqlFlavor,
+    timestamp: &str,
+) -> Result<DbValue, EventRepoError> {
+    let parsed = DateTime::parse_from_rfc3339(timestamp).map_err(|error| {
+        EventRepoError::InvalidInput(format!("invalid RFC3339 timestamp {timestamp:?}: {error}"))
+    })?;
+    timestamp_value(flavor, parsed.timestamp_millis())
+}
+
+fn timestamp_value(flavor: DbSqlFlavor, timestamp_ms: i64) -> Result<DbValue, EventRepoError> {
+    let timestamp = Utc
+        .timestamp_millis_opt(timestamp_ms)
+        .single()
+        .ok_or_else(|| {
+            EventRepoError::InvalidInput("timestamp is outside supported range".to_string())
+        })?;
+    Ok(match flavor {
+        // Bind the epoch rather than a timezone-free UTC string. FROM_UNIXTIME
+        // renders it in the current MySQL session timezone before TIMESTAMP
+        // converts it back to the same instant for storage.
+        DbSqlFlavor::Mysql => DbValue::from(timestamp_ms),
+        DbSqlFlavor::Sqlite => {
+            DbValue::from(timestamp.format("%Y-%m-%d %H:%M:%S%.3f").to_string())
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TIMESTAMP_MS: u64 = 1_756_367_457_123;
+
+    #[test]
+    fn mysql_binds_epoch_inside_from_unixtime() {
+        assert_eq!(
+            sql_with_timestamp_params(
+                DbSqlFlavor::Mysql,
+                "VALUES (__bcs_timestamp_ms__)"
+            ),
+            "VALUES (FROM_UNIXTIME(? / 1000.0))"
+        );
+        assert_eq!(
+            timestamp_value_from_ms(DbSqlFlavor::Mysql, TIMESTAMP_MS).expect("timestamp"),
+            DbValue::from(i64::try_from(TIMESTAMP_MS).expect("signed timestamp"))
+        );
+    }
+
+    #[test]
+    fn sqlite_keeps_canonical_utc_text() {
+        assert_eq!(
+            sql_with_timestamp_params(
+                DbSqlFlavor::Sqlite,
+                "VALUES (__bcs_timestamp_ms__)"
+            ),
+            "VALUES (?)"
+        );
+        assert_eq!(
+            timestamp_value_from_ms(DbSqlFlavor::Sqlite, TIMESTAMP_MS).expect("timestamp"),
+            DbValue::from("2025-08-28 07:50:57.123")
+        );
+    }
+
+    #[test]
+    fn rfc3339_offsets_normalize_to_the_same_epoch() {
+        assert_eq!(
+            timestamp_value_from_rfc3339(DbSqlFlavor::Mysql, "2026-08-28T15:50:57+08:00")
+                .expect("offset timestamp"),
+            timestamp_value_from_rfc3339(DbSqlFlavor::Mysql, "2026-08-28T07:50:57Z")
+                .expect("UTC timestamp")
+        );
+    }
+}

--- a/src/bcs/crates/services/bcs-event-store/src/transaction_plan.rs
+++ b/src/bcs/crates/services/bcs-event-store/src/transaction_plan.rs
@@ -26,8 +26,9 @@ pub struct EventAppendTransactionPlan {
 /// Event-store-owned half of Group provisioning finalization.
 ///
 /// The Group repository prepends its locked availability transition, then
-/// appends these steps to activate the pending inline subscriptions and write
-/// the ordered creation Events in the same database transaction.
+/// appends these steps to activate the pending inline subscriptions, snapshot
+/// Events produced during the pending provisioning window, and write the
+/// ordered creation Events in the same database transaction.
 #[derive(Debug)]
 pub struct GroupProvisioningEventTransactionPlan {
     pub steps: Vec<DbTransactionStep>,
@@ -241,12 +242,51 @@ impl GroupProvisioningEventTransactionPlan {
                              'group_provisioning_finalized', NULL, __bcs_timestamp_ms__, ?)"),
                     vec![
                         value(uuid::Uuid::new_v4().to_string()),
-                        subscription_binding,
+                        subscription_binding.clone(),
                         value(event_actor_type_name(actor.actor_type)),
                         value(actor.id.as_str()),
                         value(finalized_at.clone()),
                         value(env),
                     ],
+                ),
+            ));
+            steps.push(DbTransactionStep::Execute(
+                DbStatement::with_transaction_params(
+                    provisioning_target_backfill_sql(flavor),
+                    vec![
+                        value(env),
+                        subscription_binding.clone(),
+                        value(group_id),
+                    ],
+                ),
+            ));
+            steps.push(DbTransactionStep::Execute(
+                DbStatement::with_transaction_params(
+                    provisioning_causal_target_backfill_sql(flavor),
+                    vec![
+                        value(env),
+                        subscription_binding.clone(),
+                        value(group_id),
+                    ],
+                ),
+            ));
+            steps.push(DbTransactionStep::Execute(
+                DbStatement::with_transaction_params(
+                    provisioning_causal_dependency_sql(flavor),
+                    vec![
+                        value(env),
+                        subscription_binding.clone(),
+                        value(group_id),
+                    ],
+                ),
+            ));
+            steps.push(DbTransactionStep::Execute(
+                DbStatement::with_transaction_params(
+                    "UPDATE bcs_events SET fanout_status = 'pending' WHERE env = ? \
+                     AND EXISTS (SELECT 1 FROM bcs_event_fanout_targets target \
+                       WHERE target.env = bcs_events.env AND target.event_id = bcs_events.event_id \
+                         AND target.subscription_id = ? AND target.status = 'pending')",
+                    vec![value(env), subscription_binding],
                 ),
             ));
         }
@@ -280,6 +320,188 @@ fn pending_subscription_lock_sql(flavor: DbSqlFlavor) -> &'static str {
             "SELECT subscription_id FROM bcs_event_subscriptions \
              WHERE env = ? AND subscription_id = ? AND scope_type = 'group' \
                AND scope_id = ? AND status = 'pending'"
+        }
+    }
+}
+
+fn provisioning_target_backfill_sql(flavor: DbSqlFlavor) -> &'static str {
+    match flavor {
+        DbSqlFlavor::Mysql => {
+            "INSERT IGNORE INTO bcs_event_fanout_targets (target_id, event_id, subscription_id, \
+             subscription_revision, purpose, replay_request_id, replay_of_delivery_id, \
+             depends_on_target_id, status, lease_owner, lease_until, created_at, materialized_at, \
+             cancelled_at, env) SELECT UUID(), event.event_id, subscription.subscription_id, \
+             subscription.current_revision, 'normal', '', NULL, NULL, 'pending', NULL, NULL, \
+             event.recorded_at, NULL, NULL, event.env FROM bcs_event_subscriptions subscription \
+             JOIN bcs_event_subscription_revisions revision \
+               ON revision.env = subscription.env \
+              AND revision.subscription_id = subscription.subscription_id \
+              AND revision.revision = subscription.current_revision \
+             JOIN bcs_events event ON event.env = subscription.env \
+              AND event.group_id = subscription.scope_id \
+             WHERE subscription.env = ? AND subscription.subscription_id = ? \
+               AND subscription.status = 'active' AND subscription.scope_type = 'group' \
+               AND event.group_id = ? AND event.recorded_at >= subscription.created_at \
+               AND event.recorded_at <= revision.activated_at \
+               AND event.retention_until > revision.activated_at \
+               AND (JSON_CONTAINS(revision.event_filters_json, JSON_QUOTE(event.event_type), '$') \
+                    OR EXISTS (SELECT 1 FROM JSON_TABLE(revision.event_filters_json, '$[*]' \
+                       COLUMNS(filter_value VARCHAR(128) PATH '$')) filters \
+                       WHERE RIGHT(filters.filter_value, 2) = '.*' \
+                         AND BINARY event.event_type LIKE CONCAT(LEFT(BINARY filters.filter_value, \
+                             CHAR_LENGTH(filters.filter_value) - 1), '%'))) \
+               AND NOT EXISTS (SELECT 1 FROM bcs_event_fanout_targets existing \
+                 WHERE existing.env = event.env AND existing.event_id = event.event_id \
+                   AND existing.subscription_id = subscription.subscription_id \
+                   AND existing.subscription_revision = subscription.current_revision \
+                   AND existing.purpose = 'normal') \
+             ORDER BY event.recorded_at, event.stream_key, event.sequence, event.event_id"
+        }
+        DbSqlFlavor::Sqlite => {
+            "INSERT OR IGNORE INTO bcs_event_fanout_targets (target_id, event_id, subscription_id, \
+             subscription_revision, purpose, replay_request_id, replay_of_delivery_id, \
+             depends_on_target_id, status, lease_owner, lease_until, created_at, materialized_at, \
+             cancelled_at, env) SELECT lower(hex(randomblob(16))), event.event_id, \
+             subscription.subscription_id, subscription.current_revision, 'normal', '', NULL, \
+             NULL, 'pending', NULL, NULL, event.recorded_at, NULL, NULL, event.env \
+             FROM bcs_event_subscriptions subscription JOIN bcs_event_subscription_revisions revision \
+               ON revision.env = subscription.env \
+              AND revision.subscription_id = subscription.subscription_id \
+              AND revision.revision = subscription.current_revision \
+             JOIN bcs_events event ON event.env = subscription.env \
+              AND event.group_id = subscription.scope_id \
+             WHERE subscription.env = ? AND subscription.subscription_id = ? \
+               AND subscription.status = 'active' AND subscription.scope_type = 'group' \
+               AND event.group_id = ? AND event.recorded_at >= subscription.created_at \
+               AND event.recorded_at <= revision.activated_at \
+               AND event.retention_until > revision.activated_at \
+               AND EXISTS (SELECT 1 FROM json_each(revision.event_filters_json) filters \
+                 WHERE filters.value = event.event_type OR (substr(filters.value, -2) = '.*' \
+                   AND event.event_type LIKE substr(filters.value, 1, length(filters.value) - 1) || '%')) \
+               AND NOT EXISTS (SELECT 1 FROM bcs_event_fanout_targets existing \
+                 WHERE existing.env = event.env AND existing.event_id = event.event_id \
+                   AND existing.subscription_id = subscription.subscription_id \
+                   AND existing.subscription_revision = subscription.current_revision \
+                   AND existing.purpose = 'normal') \
+             ORDER BY event.recorded_at, event.stream_key, event.sequence, event.event_id"
+        }
+    }
+}
+
+fn provisioning_causal_target_backfill_sql(flavor: DbSqlFlavor) -> &'static str {
+    match flavor {
+        DbSqlFlavor::Mysql => {
+            "INSERT IGNORE INTO bcs_event_fanout_targets (target_id, event_id, subscription_id, \
+             subscription_revision, purpose, replay_request_id, replay_of_delivery_id, \
+             depends_on_target_id, status, lease_owner, lease_until, created_at, materialized_at, \
+             cancelled_at, env) SELECT UUID(), cause.event_id, effect.subscription_id, \
+             effect.subscription_revision, 'causal_prerequisite', '', NULL, NULL, 'pending', \
+             NULL, NULL, effect.created_at, NULL, NULL, effect.env \
+             FROM bcs_event_fanout_targets effect \
+             JOIN bcs_events effect_event ON effect_event.env = effect.env \
+              AND effect_event.event_id = effect.event_id \
+             JOIN bcs_event_subscriptions subscription ON subscription.env = effect.env \
+              AND subscription.subscription_id = effect.subscription_id \
+             JOIN bcs_event_subscription_revisions revision ON revision.env = effect.env \
+              AND revision.subscription_id = effect.subscription_id \
+              AND revision.revision = effect.subscription_revision \
+             JOIN bcs_events cause ON cause.env = effect.env \
+              AND cause.event_id = effect_event.causation_event_id \
+             WHERE effect.env = ? AND effect.subscription_id = ? \
+               AND effect_event.group_id = ? AND effect.purpose = 'normal' \
+               AND effect.status <> 'cancelled' AND subscription.status = 'active' \
+               AND subscription.current_revision = effect.subscription_revision \
+               AND effect_event.recorded_at >= subscription.created_at \
+               AND effect_event.recorded_at <= revision.activated_at \
+               AND (JSON_CONTAINS(revision.event_filters_json, JSON_QUOTE(cause.event_type), '$') \
+                    OR EXISTS (SELECT 1 FROM JSON_TABLE(revision.event_filters_json, '$[*]' \
+                       COLUMNS(filter_value VARCHAR(128) PATH '$')) filters \
+                       WHERE RIGHT(filters.filter_value, 2) = '.*' \
+                         AND BINARY cause.event_type LIKE CONCAT(LEFT(BINARY filters.filter_value, \
+                             CHAR_LENGTH(filters.filter_value) - 1), '%'))) \
+               AND NOT EXISTS (SELECT 1 FROM bcs_event_fanout_targets existing \
+                 WHERE existing.env = effect.env AND existing.event_id = cause.event_id \
+                   AND existing.subscription_id = effect.subscription_id \
+                   AND existing.subscription_revision = effect.subscription_revision \
+                   AND existing.purpose IN ('normal', 'causal_prerequisite') \
+                   AND existing.status <> 'cancelled')"
+        }
+        DbSqlFlavor::Sqlite => {
+            "INSERT OR IGNORE INTO bcs_event_fanout_targets (target_id, event_id, subscription_id, \
+             subscription_revision, purpose, replay_request_id, replay_of_delivery_id, \
+             depends_on_target_id, status, lease_owner, lease_until, created_at, materialized_at, \
+             cancelled_at, env) SELECT lower(hex(randomblob(16))), cause.event_id, \
+             effect.subscription_id, effect.subscription_revision, 'causal_prerequisite', '', \
+             NULL, NULL, 'pending', NULL, NULL, effect.created_at, NULL, NULL, effect.env \
+             FROM bcs_event_fanout_targets effect \
+             JOIN bcs_events effect_event ON effect_event.env = effect.env \
+              AND effect_event.event_id = effect.event_id \
+             JOIN bcs_event_subscriptions subscription ON subscription.env = effect.env \
+              AND subscription.subscription_id = effect.subscription_id \
+             JOIN bcs_event_subscription_revisions revision ON revision.env = effect.env \
+              AND revision.subscription_id = effect.subscription_id \
+              AND revision.revision = effect.subscription_revision \
+             JOIN bcs_events cause ON cause.env = effect.env \
+              AND cause.event_id = effect_event.causation_event_id \
+             WHERE effect.env = ? AND effect.subscription_id = ? \
+               AND effect_event.group_id = ? AND effect.purpose = 'normal' \
+               AND effect.status <> 'cancelled' AND subscription.status = 'active' \
+               AND subscription.current_revision = effect.subscription_revision \
+               AND effect_event.recorded_at >= subscription.created_at \
+               AND effect_event.recorded_at <= revision.activated_at \
+               AND EXISTS (SELECT 1 FROM json_each(revision.event_filters_json) filters \
+                 WHERE filters.value = cause.event_type OR (substr(filters.value, -2) = '.*' \
+                   AND cause.event_type LIKE substr(filters.value, 1, length(filters.value) - 1) || '%')) \
+               AND NOT EXISTS (SELECT 1 FROM bcs_event_fanout_targets existing \
+                 WHERE existing.env = effect.env AND existing.event_id = cause.event_id \
+                   AND existing.subscription_id = effect.subscription_id \
+                   AND existing.subscription_revision = effect.subscription_revision \
+                   AND existing.purpose IN ('normal', 'causal_prerequisite') \
+                   AND existing.status <> 'cancelled')"
+        }
+    }
+}
+
+fn provisioning_causal_dependency_sql(flavor: DbSqlFlavor) -> &'static str {
+    match flavor {
+        DbSqlFlavor::Mysql => {
+            "UPDATE bcs_event_fanout_targets effect \
+             JOIN bcs_events effect_event ON effect_event.env = effect.env \
+              AND effect_event.event_id = effect.event_id \
+             JOIN bcs_event_fanout_targets cause ON cause.env = effect.env \
+              AND cause.event_id = effect_event.causation_event_id \
+              AND cause.subscription_id = effect.subscription_id \
+              AND cause.subscription_revision = effect.subscription_revision \
+              AND cause.purpose IN ('normal', 'causal_prerequisite') \
+              AND cause.status <> 'cancelled' \
+             SET effect.depends_on_target_id = cause.target_id \
+             WHERE effect.env = ? AND effect.subscription_id = ? \
+               AND effect_event.group_id = ? AND effect.purpose = 'normal' \
+               AND effect.depends_on_target_id IS NULL"
+        }
+        DbSqlFlavor::Sqlite => {
+            "UPDATE bcs_event_fanout_targets AS effect SET depends_on_target_id = (\
+               SELECT cause.target_id FROM bcs_events effect_event \
+               JOIN bcs_event_fanout_targets cause ON cause.env = effect.env \
+                AND cause.event_id = effect_event.causation_event_id \
+                AND cause.subscription_id = effect.subscription_id \
+                AND cause.subscription_revision = effect.subscription_revision \
+                AND cause.purpose IN ('normal', 'causal_prerequisite') \
+                AND cause.status <> 'cancelled' \
+               WHERE effect_event.env = effect.env AND effect_event.event_id = effect.event_id \
+               ORDER BY CASE cause.purpose WHEN 'normal' THEN 0 ELSE 1 END \
+               LIMIT 1) \
+             WHERE effect.env = ? AND effect.subscription_id = ? AND effect.purpose = 'normal' \
+               AND effect.depends_on_target_id IS NULL \
+               AND EXISTS (SELECT 1 FROM bcs_events effect_event \
+                 JOIN bcs_event_fanout_targets cause ON cause.env = effect.env \
+                  AND cause.event_id = effect_event.causation_event_id \
+                  AND cause.subscription_id = effect.subscription_id \
+                  AND cause.subscription_revision = effect.subscription_revision \
+                 AND cause.purpose IN ('normal', 'causal_prerequisite') \
+                 AND cause.status <> 'cancelled' \
+                 WHERE effect_event.env = effect.env AND effect_event.event_id = effect.event_id \
+                   AND effect_event.group_id = ?)"
         }
     }
 }
@@ -759,6 +981,42 @@ mod tests {
         let sqlite = causal_dependency_update_sql(DbSqlFlavor::Sqlite);
         assert!(sqlite.contains("SET depends_on_target_id = ("));
         assert!(!sqlite.contains("JOIN bcs_event_fanout_targets AS cause_target"));
+    }
+
+    #[test]
+    fn provisioning_backfill_uses_backend_compatible_idempotent_sql() {
+        let mysql = provisioning_target_backfill_sql(DbSqlFlavor::Mysql);
+        assert!(mysql.starts_with("INSERT IGNORE"));
+        assert!(mysql.contains("event.recorded_at >= subscription.created_at"));
+        assert_eq!(mysql.matches('?').count(), 3);
+
+        let sqlite = provisioning_target_backfill_sql(DbSqlFlavor::Sqlite);
+        assert!(sqlite.starts_with("INSERT OR IGNORE"));
+        assert!(sqlite.contains("event.recorded_at >= subscription.created_at"));
+        assert_eq!(sqlite.matches('?').count(), 3);
+
+        let mysql_causal = provisioning_causal_target_backfill_sql(DbSqlFlavor::Mysql);
+        assert!(mysql_causal.starts_with("INSERT IGNORE"));
+        assert!(mysql_causal.contains("'causal_prerequisite'"));
+        assert_eq!(mysql_causal.matches('?').count(), 3);
+
+        let sqlite_causal = provisioning_causal_target_backfill_sql(DbSqlFlavor::Sqlite);
+        assert!(sqlite_causal.starts_with("INSERT OR IGNORE"));
+        assert!(sqlite_causal.contains("'causal_prerequisite'"));
+        assert_eq!(sqlite_causal.matches('?').count(), 3);
+
+        assert_eq!(
+            provisioning_causal_dependency_sql(DbSqlFlavor::Mysql)
+                .matches('?')
+                .count(),
+            3
+        );
+        assert_eq!(
+            provisioning_causal_dependency_sql(DbSqlFlavor::Sqlite)
+                .matches('?')
+                .count(),
+            3
+        );
     }
 
     fn command() -> AppendEventRecord {

--- a/src/bcs/crates/services/bcs-event-store/src/transaction_plan.rs
+++ b/src/bcs/crates/services/bcs-event-store/src/transaction_plan.rs
@@ -8,7 +8,10 @@
 use bcs_db_api::{DbSqlFlavor, DbStatement, DbTransactionParam, DbTransactionStep, DbValue};
 use bcs_service_api::port::repo::{AppendEventRecord, EventRepoError};
 use bcs_service_api::types::{EventActor, EventActorType};
-use chrono::{DateTime, SecondsFormat, TimeZone, Utc};
+
+use crate::timestamp::{
+    sql_with_timestamp_params, timestamp_value_from_ms, timestamp_value_from_rfc3339,
+};
 
 /// A composable set of Event append steps plus the result positions needed to
 /// interpret the committed Event.
@@ -50,7 +53,7 @@ impl GroupDeletionEventTransactionPlan {
                 "Group deletion group id and env must be non-empty".to_string(),
             ));
         }
-        let deleted_at = db_timestamp_from_ms(deleted_at_ms)?;
+        let deleted_at = timestamp_value_from_ms(flavor, deleted_at_ms)?;
         let audit_id_expression = match flavor {
             DbSqlFlavor::Mysql => "UUID()",
             DbSqlFlavor::Sqlite => "lower(hex(randomblob(16)))",
@@ -74,44 +77,47 @@ impl GroupDeletionEventTransactionPlan {
             )),
         ];
         steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-            format!(
+            sql_with_timestamp_params(flavor, &format!(
                 "INSERT INTO bcs_event_subscription_audits \
                  (audit_id, subscription_id, revision, action, actor_type, actor_id, reason, \
                   details_json, created_at, env) \
                  SELECT {audit_id_expression}, subscription_id, current_revision, 'disabled', \
-                        'system', 'group-deletion', 'scope_deleted', NULL, ?, env \
+                        'system', 'group-deletion', 'scope_deleted', NULL, \
+                        __bcs_timestamp_ms__, env \
                  FROM bcs_event_subscriptions \
                  WHERE env = ? AND scope_type = 'group' AND scope_id = ? AND status = 'active'"
-            ),
+            )),
             vec![
-                DbValue::from(deleted_at.as_str()),
+                deleted_at.clone(),
                 DbValue::from(env),
                 DbValue::from(group_id),
             ],
         )));
         steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-            "UPDATE bcs_event_deliveries SET status = 'cancelled', cancelled_at = ?, \
+            sql_with_timestamp_params(flavor, "UPDATE bcs_event_deliveries SET status = \
+             'cancelled', cancelled_at = __bcs_timestamp_ms__, \
              next_attempt_at = NULL, lease_owner = NULL, lease_until = NULL \
              WHERE env = ? AND status IN ('pending', 'retry_wait') AND subscription_id IN (\
                SELECT subscription_id FROM bcs_event_subscriptions \
                WHERE env = ? AND scope_type = 'group' AND scope_id = ? AND status = 'active'\
-             )",
+             )"),
             vec![
-                DbValue::from(deleted_at.as_str()),
+                deleted_at.clone(),
                 DbValue::from(env),
                 DbValue::from(env),
                 DbValue::from(group_id),
             ],
         )));
         steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-            "UPDATE bcs_event_fanout_targets SET status = 'cancelled', cancelled_at = ?, \
+            sql_with_timestamp_params(flavor, "UPDATE bcs_event_fanout_targets SET status = \
+             'cancelled', cancelled_at = __bcs_timestamp_ms__, \
              lease_owner = NULL, lease_until = NULL \
              WHERE env = ? AND status = 'pending' AND subscription_id IN (\
                SELECT subscription_id FROM bcs_event_subscriptions \
                WHERE env = ? AND scope_type = 'group' AND scope_id = ? AND status = 'active'\
-             )",
+             )"),
             vec![
-                DbValue::from(deleted_at.as_str()),
+                deleted_at.clone(),
                 DbValue::from(env),
                 DbValue::from(env),
                 DbValue::from(group_id),
@@ -127,10 +133,11 @@ impl GroupDeletionEventTransactionPlan {
             vec![DbValue::from(env)],
         )));
         steps.push(DbTransactionStep::Execute(DbStatement::with_params(
-            "UPDATE bcs_event_subscriptions SET status = 'disabled', updated_at = ? \
-             WHERE env = ? AND scope_type = 'group' AND scope_id = ? AND status = 'active'",
+            sql_with_timestamp_params(flavor, "UPDATE bcs_event_subscriptions SET status = \
+             'disabled', updated_at = __bcs_timestamp_ms__ WHERE env = ? AND scope_type = 'group' \
+             AND scope_id = ? AND status = 'active'"),
             vec![
-                DbValue::from(deleted_at.as_str()),
+                deleted_at,
                 DbValue::from(env),
                 DbValue::from(group_id),
             ],
@@ -169,7 +176,7 @@ impl GroupProvisioningEventTransactionPlan {
                     .to_string(),
             ));
         }
-        let finalized_at = db_timestamp_from_ms(finalized_at_ms)?;
+        let finalized_at = timestamp_value_from_ms(flavor, finalized_at_ms)?;
         let mut steps = vec![
             DbTransactionStep::Execute(DbStatement::with_params(
                 scope_epoch_insert_sql(flavor),
@@ -203,10 +210,11 @@ impl GroupProvisioningEventTransactionPlan {
                 DbTransactionParam::query_result(query_step, 0, "subscription_id");
             steps.push(DbTransactionStep::Execute(
                 DbStatement::with_transaction_params(
-                    "UPDATE bcs_event_subscriptions SET status = 'active', updated_at = ? \
-                     WHERE env = ? AND subscription_id = ? AND status = 'pending'",
+                    sql_with_timestamp_params(flavor, "UPDATE bcs_event_subscriptions SET \
+                     status = 'active', updated_at = __bcs_timestamp_ms__ WHERE env = ? \
+                     AND subscription_id = ? AND status = 'pending'"),
                     vec![
-                        value(finalized_at.as_str()),
+                        value(finalized_at.clone()),
                         value(env),
                         subscription_binding.clone(),
                     ],
@@ -214,10 +222,11 @@ impl GroupProvisioningEventTransactionPlan {
             ));
             steps.push(DbTransactionStep::Execute(
                 DbStatement::with_transaction_params(
-                    "UPDATE bcs_event_subscription_revisions SET activated_at = ? \
-                     WHERE env = ? AND subscription_id = ? AND revision = 1",
+                    sql_with_timestamp_params(flavor, "UPDATE bcs_event_subscription_revisions \
+                     SET activated_at = __bcs_timestamp_ms__ WHERE env = ? \
+                     AND subscription_id = ? AND revision = 1"),
                     vec![
-                        value(finalized_at.as_str()),
+                        value(finalized_at.clone()),
                         value(env),
                         subscription_binding.clone(),
                     ],
@@ -225,17 +234,17 @@ impl GroupProvisioningEventTransactionPlan {
             ));
             steps.push(DbTransactionStep::Execute(
                 DbStatement::with_transaction_params(
-                    "INSERT INTO bcs_event_subscription_audits \
+                    sql_with_timestamp_params(flavor, "INSERT INTO bcs_event_subscription_audits \
                      (audit_id, subscription_id, revision, action, actor_type, actor_id, reason, \
                       details_json, created_at, env) \
                      VALUES (?, ?, 1, 'provisioning_activated', ?, ?, \
-                             'group_provisioning_finalized', NULL, ?, ?)",
+                             'group_provisioning_finalized', NULL, __bcs_timestamp_ms__, ?)"),
                     vec![
                         value(uuid::Uuid::new_v4().to_string()),
                         subscription_binding,
                         value(event_actor_type_name(actor.actor_type)),
                         value(actor.id.as_str()),
-                        value(finalized_at.as_str()),
+                        value(finalized_at.clone()),
                         value(env),
                     ],
                 ),
@@ -295,9 +304,9 @@ impl EventAppendTransactionPlan {
                 "event cannot cause itself".to_string(),
             ));
         }
-        let occurred_at = db_timestamp_from_rfc3339(&command.event.occurred_at)?;
-        let recorded_at = db_timestamp_from_rfc3339(&command.recorded_at)?;
-        let retention_until = db_timestamp_from_ms(command.retention_until_ms)?;
+        let occurred_at = timestamp_value_from_rfc3339(flavor, &command.event.occurred_at)?;
+        let recorded_at = timestamp_value_from_rfc3339(flavor, &command.recorded_at)?;
+        let retention_until = timestamp_value_from_ms(flavor, command.retention_until_ms)?;
         let actor_json = command
             .event
             .actor
@@ -350,12 +359,14 @@ impl EventAppendTransactionPlan {
         let event_insert_step = preceding_step_count + steps.len();
         steps.push(DbTransactionStep::Execute(
             DbStatement::with_transaction_params(
-                "INSERT INTO bcs_events (event_id, event_type, schema_version, producer, \
+                sql_with_timestamp_params(flavor, "INSERT INTO bcs_events \
+                 (event_id, event_type, schema_version, producer, \
                  producer_key, subject_type, subject_id, group_id, \
                  session_id, task_id, run_id, stream_key, sequence, actor_json, correlation_id, \
                  causation_event_id, trace_id, data_json, occurred_at, recorded_at, fanout_status, \
                  retention_until, env) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, \
-                 ?, ?, ?, ?, ?, ?, ?)",
+                 ?, ?, __bcs_timestamp_ms__, __bcs_timestamp_ms__, ?, \
+                 __bcs_timestamp_ms__, ?)"),
                 vec![
                     value(command.event.event_id.as_str()),
                     value(command.event.event_type.as_str()),
@@ -376,7 +387,7 @@ impl EventAppendTransactionPlan {
                     optional_value(command.event.trace_id.as_deref()),
                     value(data_json),
                     value(occurred_at),
-                    value(recorded_at.as_str()),
+                    value(recorded_at.clone()),
                     value("pending"),
                     value(retention_until),
                     value(command.env.as_str()),
@@ -392,7 +403,7 @@ impl EventAppendTransactionPlan {
             steps.push(DbTransactionStep::Execute(DbStatement::with_params(
                 causal_target_snapshot_sql(flavor),
                 vec![
-                    DbValue::from(recorded_at.as_str()),
+                    recorded_at.clone(),
                     DbValue::from(cause_event_id),
                     DbValue::from(command.env.as_str()),
                     DbValue::from(command.event.event_id.as_str()),
@@ -529,14 +540,14 @@ fn stream_sequence_sql(flavor: DbSqlFlavor) -> &'static str {
     }
 }
 
-fn target_snapshot_sql(flavor: DbSqlFlavor) -> &'static str {
-    match flavor {
+fn target_snapshot_sql(flavor: DbSqlFlavor) -> String {
+    sql_with_timestamp_params(flavor, match flavor {
         DbSqlFlavor::Mysql => {
             "INSERT INTO bcs_event_fanout_targets (target_id, event_id, subscription_id, \
              subscription_revision, purpose, replay_request_id, replay_of_delivery_id, \
              depends_on_target_id, status, lease_owner, lease_until, created_at, materialized_at, \
              cancelled_at, env) SELECT UUID(), ?, s.subscription_id, s.current_revision, 'normal', \
-             '', NULL, NULL, 'pending', NULL, NULL, ?, NULL, NULL, ? \
+             '', NULL, NULL, 'pending', NULL, NULL, __bcs_timestamp_ms__, NULL, NULL, ? \
              FROM bcs_event_subscriptions s JOIN bcs_event_subscription_revisions r \
                ON r.subscription_id = s.subscription_id AND r.revision = s.current_revision \
               AND r.env = s.env \
@@ -554,7 +565,8 @@ fn target_snapshot_sql(flavor: DbSqlFlavor) -> &'static str {
              subscription_revision, purpose, replay_request_id, replay_of_delivery_id, \
              depends_on_target_id, status, lease_owner, lease_until, created_at, materialized_at, \
              cancelled_at, env) SELECT lower(hex(randomblob(16))), ?, s.subscription_id, \
-             s.current_revision, 'normal', '', NULL, NULL, 'pending', NULL, NULL, ?, NULL, NULL, ? \
+             s.current_revision, 'normal', '', NULL, NULL, 'pending', NULL, NULL, \
+             __bcs_timestamp_ms__, NULL, NULL, ? \
              FROM bcs_event_subscriptions s JOIN bcs_event_subscription_revisions r \
                ON r.subscription_id = s.subscription_id AND r.revision = s.current_revision \
               AND r.env = s.env \
@@ -564,13 +576,13 @@ fn target_snapshot_sql(flavor: DbSqlFlavor) -> &'static str {
                      AND ? LIKE substr(filters.value, 1, length(filters.value) - 1) || '%')) \
                AND s.scope_type = 'group' AND s.scope_id = ?"
         }
-    }
+    })
 }
 
-fn target_snapshot_params(command: &AppendEventRecord, recorded_at: &str) -> Vec<DbValue> {
+fn target_snapshot_params(command: &AppendEventRecord, recorded_at: &DbValue) -> Vec<DbValue> {
     vec![
         DbValue::from(command.event.event_id.as_str()),
-        DbValue::from(recorded_at),
+        recorded_at.clone(),
         DbValue::from(command.env.as_str()),
         DbValue::from(command.env.as_str()),
         DbValue::from(command.event.event_type.as_str()),
@@ -579,15 +591,15 @@ fn target_snapshot_params(command: &AppendEventRecord, recorded_at: &str) -> Vec
     ]
 }
 
-fn causal_target_snapshot_sql(flavor: DbSqlFlavor) -> &'static str {
-    match flavor {
+fn causal_target_snapshot_sql(flavor: DbSqlFlavor) -> String {
+    sql_with_timestamp_params(flavor, match flavor {
         DbSqlFlavor::Mysql => {
             "INSERT IGNORE INTO bcs_event_fanout_targets (target_id, event_id, subscription_id, \
              subscription_revision, purpose, replay_request_id, replay_of_delivery_id, \
              depends_on_target_id, status, lease_owner, lease_until, created_at, materialized_at, \
              cancelled_at, env) SELECT UUID(), cause.event_id, effect.subscription_id, \
              effect.subscription_revision, 'causal_prerequisite', '', NULL, NULL, 'pending', \
-             NULL, NULL, ?, NULL, NULL, effect.env \
+             NULL, NULL, __bcs_timestamp_ms__, NULL, NULL, effect.env \
              FROM bcs_event_fanout_targets effect JOIN bcs_events cause \
                ON cause.env = effect.env AND cause.event_id = ? \
              JOIN bcs_event_subscription_revisions revision \
@@ -615,7 +627,7 @@ fn causal_target_snapshot_sql(flavor: DbSqlFlavor) -> &'static str {
              depends_on_target_id, status, lease_owner, lease_until, created_at, materialized_at, \
              cancelled_at, env) SELECT lower(hex(randomblob(16))), cause.event_id, \
              effect.subscription_id, effect.subscription_revision, 'causal_prerequisite', '', \
-             NULL, NULL, 'pending', NULL, NULL, ?, NULL, NULL, effect.env \
+             NULL, NULL, 'pending', NULL, NULL, __bcs_timestamp_ms__, NULL, NULL, effect.env \
              FROM bcs_event_fanout_targets effect JOIN bcs_events cause \
                ON cause.env = effect.env AND cause.event_id = ? \
              JOIN bcs_event_subscription_revisions revision \
@@ -636,7 +648,7 @@ fn causal_target_snapshot_sql(flavor: DbSqlFlavor) -> &'static str {
                    AND existing.purpose IN ('normal', 'causal_prerequisite') \
                    AND existing.status <> 'cancelled')"
         }
-    }
+    })
 }
 
 fn causal_dependency_update_sql(flavor: DbSqlFlavor) -> &'static str {
@@ -664,34 +676,6 @@ fn causal_dependency_update_sql(flavor: DbSqlFlavor) -> &'static str {
              ) WHERE effect.env = ? AND effect.event_id = ? AND effect.purpose = 'normal'"
         }
     }
-}
-
-fn db_timestamp_from_rfc3339(timestamp: &str) -> Result<String, EventRepoError> {
-    let parsed = DateTime::parse_from_rfc3339(timestamp).map_err(|error| {
-        EventRepoError::InvalidInput(format!("invalid RFC3339 timestamp {timestamp:?}: {error}"))
-    })?;
-    Ok(parsed
-        .with_timezone(&Utc)
-        .format("%Y-%m-%d %H:%M:%S%.3f")
-        .to_string())
-}
-
-fn db_timestamp_from_ms(timestamp_ms: u64) -> Result<String, EventRepoError> {
-    let timestamp_ms = i64::try_from(timestamp_ms).map_err(|_| {
-        EventRepoError::InvalidInput("timestamp is outside supported range".to_string())
-    })?;
-    Utc.timestamp_millis_opt(timestamp_ms)
-        .single()
-        .map(|timestamp| {
-            timestamp
-                .to_rfc3339_opts(SecondsFormat::Millis, true)
-                .replace('T', " ")
-                .trim_end_matches('Z')
-                .to_string()
-        })
-        .ok_or_else(|| {
-            EventRepoError::InvalidInput("timestamp is outside supported range".to_string())
-        })
 }
 
 fn value(value: impl Into<DbValue>) -> DbTransactionParam {

--- a/src/bcs/crates/services/bcs-event-store/tests/conformance_event_store_mysql.rs
+++ b/src/bcs/crates/services/bcs-event-store/tests/conformance_event_store_mysql.rs
@@ -10,6 +10,7 @@ use bcs_config_api::{MysqlDbConfig, StatementProtocol};
 use bcs_db_api::{DbPlugin, DbStatement};
 use bcs_db_mysql::{MysqlDbManager, MysqlDbPlugin};
 use bcs_event_store::DbEventStore;
+use bcs_service_api::port::repo::EventRepoPort;
 use bcs_test_support::contract::repo::{
     event_delivery_repo_port_contract_tests, event_repo_port_contract_tests,
 };
@@ -35,7 +36,9 @@ async fn mysql_event_store_passes_contract() {
             extra: BTreeMap::new(),
         })
         .with_statement_protocol(StatementProtocol::Text);
-    config.pool_size = 2;
+    // A single pooled connection keeps the non-UTC session timezone below
+    // stable for the entire regression test.
+    config.pool_size = 1;
     config.min_pool_size = 1;
 
     let manager = MysqlDbManager::new(config)
@@ -43,7 +46,45 @@ async fn mysql_event_store_passes_contract() {
         .expect("open MySQL contract datasource");
     let plugin = Arc::new(MysqlDbPlugin::new(manager.clone(), "bcs"));
     apply_eventing_migration(plugin.as_ref()).await;
+    plugin
+        .execute(DbStatement::new("SET SESSION time_zone = '+08:00'"))
+        .await
+        .expect("set non-UTC MySQL session timezone");
     let repo = DbEventStore::mysql(plugin);
+
+    let mut timezone_subscription = common::subscription("sub-mysql-timezone");
+    timezone_subscription.subscription.env = "contract-timezone-mysql".to_string();
+    let expected_activated_at_ms = timezone_subscription.revision.activated_at_ms;
+    repo.create_subscription(timezone_subscription)
+        .await
+        .expect("create subscription in non-UTC session");
+    let (_, timezone_revision) = repo
+        .get_subscription("sub-mysql-timezone", "contract-timezone-mysql")
+        .await
+        .expect("read timezone subscription")
+        .expect("timezone subscription exists");
+    assert_eq!(timezone_revision.activated_at_ms, expected_activated_at_ms);
+
+    let mut timezone_event = common::append(
+        "evt-mysql-timezone",
+        "mysql:timezone:group:created",
+        "group.created",
+    );
+    timezone_event.env = "contract-timezone-mysql".to_string();
+    let expected_occurred_at = timezone_event.event.occurred_at.clone();
+    let expected_recorded_at = timezone_event.recorded_at.clone();
+    let expected_retention_until_ms = timezone_event.retention_until_ms;
+    let stored_timezone_event = repo
+        .append_event(timezone_event)
+        .await
+        .expect("append Event in non-UTC session")
+        .event;
+    assert_eq!(stored_timezone_event.envelope.occurred_at, expected_occurred_at);
+    assert_eq!(stored_timezone_event.envelope.recorded_at, expected_recorded_at);
+    assert_eq!(
+        stored_timezone_event.retention_until_ms,
+        expected_retention_until_ms
+    );
 
     event_repo_port_contract_tests(
         &repo,

--- a/src/bcs/crates/services/bcs-eventing/Cargo.toml
+++ b/src/bcs/crates/services/bcs-eventing/Cargo.toml
@@ -24,6 +24,7 @@ sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
+tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
 

--- a/src/bcs/crates/services/bcs-eventing/src/dispatcher.rs
+++ b/src/bcs/crates/services/bcs-eventing/src/dispatcher.rs
@@ -189,7 +189,8 @@ impl EventDispatcher {
         &self,
         delivery_record: EventDeliveryRecord,
     ) -> Result<(), EventDispatcherError> {
-        let revision = self
+        let preflight_started_at_ms = (self.now_ms)();
+        let revision = match self
             .repo
             .get_subscription_revision(
                 &delivery_record.subscription_id,
@@ -197,17 +198,9 @@ impl EventDispatcher {
                 &self.env,
             )
             .await
-            .map_err(|error| {
-                warn!(
-                    delivery_id = %delivery_record.delivery_id,
-                    attempt_no = delivery_record.attempt_count,
-                    subscription_id = %delivery_record.subscription_id,
-                    error = %error,
-                    "failed to load webhook subscription revision"
-                );
-                EventDispatcherError::Repository
-            })?
-            .ok_or_else(|| {
+        {
+            Ok(Some(revision)) => revision,
+            Ok(None) => {
                 warn!(
                     delivery_id = %delivery_record.delivery_id,
                     attempt_no = delivery_record.attempt_count,
@@ -215,18 +208,56 @@ impl EventDispatcher {
                     revision = delivery_record.subscription_revision,
                     "webhook subscription revision is missing"
                 );
-                EventDispatcherError::MissingState
-            })?;
-        let host_key = endpoint_host_key(&revision.endpoint_url).map_err(|error| {
-            warn!(
-                delivery_id = %delivery_record.delivery_id,
-                attempt_no = delivery_record.attempt_count,
-                subscription_id = %delivery_record.subscription_id,
-                error = %error,
-                "webhook endpoint is invalid"
-            );
-            error
-        })?;
+                return self
+                    .complete_preflight_failure(
+                        &delivery_record,
+                        preflight_started_at_ms,
+                        EventDeliveryDisposition::Terminal,
+                        "subscription_revision_missing",
+                        "Webhook subscription revision is missing",
+                    )
+                    .await;
+            }
+            Err(error) => {
+                warn!(
+                    delivery_id = %delivery_record.delivery_id,
+                    attempt_no = delivery_record.attempt_count,
+                    subscription_id = %delivery_record.subscription_id,
+                    error = %error,
+                    "failed to load webhook subscription revision"
+                );
+                return self
+                    .complete_preflight_failure(
+                        &delivery_record,
+                        preflight_started_at_ms,
+                        EventDeliveryDisposition::Retryable,
+                        "subscription_revision_lookup",
+                        "Failed to load webhook subscription revision",
+                    )
+                    .await;
+            }
+        };
+        let host_key = match endpoint_host_key(&revision.endpoint_url) {
+            Ok(host_key) => host_key,
+            Err(error) => {
+                warn!(
+                    delivery_id = %delivery_record.delivery_id,
+                    attempt_no = delivery_record.attempt_count,
+                    subscription_id = %delivery_record.subscription_id,
+                    error = %error,
+                    "webhook endpoint is invalid"
+                );
+                return self
+                    .complete_preflight_failure(
+                        &delivery_record,
+                        preflight_started_at_ms,
+                        EventDeliveryDisposition::Terminal,
+                        "invalid_endpoint",
+                        "Webhook endpoint configuration is invalid",
+                    )
+                    .await;
+            }
+        };
         let semaphore = {
             let mut semaphores = self.host_semaphores.lock().await;
             semaphores
@@ -234,18 +265,26 @@ impl EventDispatcher {
                 .or_insert_with(|| Arc::new(Semaphore::new(self.per_host_concurrency)))
                 .clone()
         };
-        let _permit = semaphore
-            .acquire_owned()
-            .await
-            .map_err(|error| {
+        let _permit = match semaphore.acquire_owned().await {
+            Ok(permit) => permit,
+            Err(error) => {
                 warn!(
                     delivery_id = %delivery_record.delivery_id,
                     attempt_no = delivery_record.attempt_count,
                     error = %error,
                     "webhook host concurrency semaphore closed"
                 );
-                EventDispatcherError::InvalidEndpoint
-            })?;
+                return self
+                    .complete_preflight_failure(
+                        &delivery_record,
+                        preflight_started_at_ms,
+                        EventDeliveryDisposition::Retryable,
+                        "dispatcher_concurrency",
+                        "Webhook dispatcher concurrency control is unavailable",
+                    )
+                    .await;
+            }
+        };
         let started_at_ms = (self.now_ms)();
         let attempt_no = delivery_record.attempt_count;
         let mut response = match self
@@ -306,6 +345,36 @@ impl EventDispatcher {
             attempt_no,
             started_at_ms,
             completed_at_ms,
+            &response,
+        )
+        .await?;
+        self.metrics
+            .delivery_attempted(attempt_metric(&delivery_record.event_type, &response))
+            .await;
+        Ok(())
+    }
+
+    async fn complete_preflight_failure(
+        &self,
+        delivery_record: &EventDeliveryRecord,
+        started_at_ms: u64,
+        disposition: EventDeliveryDisposition,
+        error_category: &str,
+        error_summary: &str,
+    ) -> Result<(), EventDispatcherError> {
+        let response = EventDeliveryResponse {
+            disposition,
+            http_status: None,
+            retry_after_ms: None,
+            response_bytes_observed: 0,
+            error_category: Some(error_category.to_string()),
+            error_summary: Some(error_summary.to_string()),
+        };
+        self.complete_attempt(
+            delivery_record,
+            delivery_record.attempt_count,
+            started_at_ms,
+            (self.now_ms)(),
             &response,
         )
         .await?;

--- a/src/bcs/crates/services/bcs-eventing/src/dispatcher.rs
+++ b/src/bcs/crates/services/bcs-eventing/src/dispatcher.rs
@@ -21,6 +21,7 @@ use rand::RngCore;
 use sha2::Digest;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::time::{MissedTickBehavior, interval};
+use tracing::{debug, warn};
 use url::Url;
 
 use crate::retry::EventRetryPolicy;
@@ -106,11 +107,29 @@ impl EventDispatcher {
                 env: self.env.clone(),
             })
             .await
-            .map_err(|_| EventDispatcherError::Repository)?;
+            .map_err(|error| {
+                warn!(
+                    worker_id,
+                    env = %self.env,
+                    error = %error,
+                    "failed to claim webhook deliveries"
+                );
+                EventDispatcherError::Repository
+            })?;
         let count = deliveries.len();
+        debug!(worker_id, env = %self.env, count, "claimed webhook deliveries");
         stream::iter(deliveries)
             .for_each_concurrent(self.worker_concurrency, |delivery| async move {
-                let _ = self.dispatch(delivery).await;
+                let delivery_id = delivery.delivery_id.clone();
+                let attempt_no = delivery.attempt_count;
+                if let Err(error) = self.dispatch(delivery).await {
+                    warn!(
+                        delivery_id,
+                        attempt_no,
+                        error = %error,
+                        "webhook delivery dispatch did not complete"
+                    );
+                }
             })
             .await;
         self.host_semaphores
@@ -152,7 +171,15 @@ impl EventDispatcher {
                             env: env.clone(),
                         })
                         .await
-                        .map_err(|_| EventDispatcherError::Repository)?;
+                        .map_err(|error| {
+                            warn!(
+                                delivery_id,
+                                attempt_no,
+                                error = %error,
+                                "failed to renew webhook delivery lease"
+                            );
+                            EventDispatcherError::Repository
+                        })?;
                 }
             }
         }
@@ -170,9 +197,36 @@ impl EventDispatcher {
                 &self.env,
             )
             .await
-            .map_err(|_| EventDispatcherError::Repository)?
-            .ok_or(EventDispatcherError::MissingState)?;
-        let host_key = endpoint_host_key(&revision.endpoint_url)?;
+            .map_err(|error| {
+                warn!(
+                    delivery_id = %delivery_record.delivery_id,
+                    attempt_no = delivery_record.attempt_count,
+                    subscription_id = %delivery_record.subscription_id,
+                    error = %error,
+                    "failed to load webhook subscription revision"
+                );
+                EventDispatcherError::Repository
+            })?
+            .ok_or_else(|| {
+                warn!(
+                    delivery_id = %delivery_record.delivery_id,
+                    attempt_no = delivery_record.attempt_count,
+                    subscription_id = %delivery_record.subscription_id,
+                    revision = delivery_record.subscription_revision,
+                    "webhook subscription revision is missing"
+                );
+                EventDispatcherError::MissingState
+            })?;
+        let host_key = endpoint_host_key(&revision.endpoint_url).map_err(|error| {
+            warn!(
+                delivery_id = %delivery_record.delivery_id,
+                attempt_no = delivery_record.attempt_count,
+                subscription_id = %delivery_record.subscription_id,
+                error = %error,
+                "webhook endpoint is invalid"
+            );
+            error
+        })?;
         let semaphore = {
             let mut semaphores = self.host_semaphores.lock().await;
             semaphores
@@ -183,10 +237,18 @@ impl EventDispatcher {
         let _permit = semaphore
             .acquire_owned()
             .await
-            .map_err(|_| EventDispatcherError::InvalidEndpoint)?;
+            .map_err(|error| {
+                warn!(
+                    delivery_id = %delivery_record.delivery_id,
+                    attempt_no = delivery_record.attempt_count,
+                    error = %error,
+                    "webhook host concurrency semaphore closed"
+                );
+                EventDispatcherError::InvalidEndpoint
+            })?;
         let started_at_ms = (self.now_ms)();
         let attempt_no = delivery_record.attempt_count;
-        let mut response = self
+        let mut response = match self
             .delivery
             .deliver(EventDeliveryRequest {
                 endpoint_url: revision.endpoint_url,
@@ -194,30 +256,49 @@ impl EventDispatcher {
                 request_timeout_ms: revision.request_timeout_ms,
             })
             .await
-            .unwrap_or_else(|_| EventDeliveryResponse {
-                disposition: EventDeliveryDisposition::Retryable,
-                http_status: None,
-                retry_after_ms: None,
-                response_bytes_observed: 0,
-                error_category: Some("delivery_adapter".to_string()),
-                error_summary: Some("Webhook delivery adapter failed".to_string()),
-            });
-        if response.disposition == EventDeliveryDisposition::DisableSubscription
-            && self
+        {
+            Ok(response) => response,
+            Err(error) => {
+                warn!(
+                    delivery_id = %delivery_record.delivery_id,
+                    attempt_no,
+                    subscription_id = %delivery_record.subscription_id,
+                    error = %error,
+                    "webhook delivery adapter failed"
+                );
+                EventDeliveryResponse {
+                    disposition: EventDeliveryDisposition::Retryable,
+                    http_status: None,
+                    retry_after_ms: None,
+                    response_bytes_observed: 0,
+                    error_category: Some("delivery_adapter".to_string()),
+                    error_summary: Some("Webhook delivery adapter failed".to_string()),
+                }
+            }
+        };
+        if response.disposition == EventDeliveryDisposition::DisableSubscription {
+            if let Err(error) = self
                 .disable_subscription(&delivery_record.subscription_id)
                 .await
-                .is_err()
-        {
-            // Do not permanently consume the 410 until the required durable
-            // Subscription disable/cancellation transaction has committed.
-            response = EventDeliveryResponse {
-                disposition: EventDeliveryDisposition::Retryable,
-                http_status: response.http_status,
-                retry_after_ms: None,
-                response_bytes_observed: response.response_bytes_observed,
-                error_category: Some("subscription_disable".to_string()),
-                error_summary: Some("Subscription disable will be retried".to_string()),
-            };
+            {
+                warn!(
+                    delivery_id = %delivery_record.delivery_id,
+                    attempt_no,
+                    subscription_id = %delivery_record.subscription_id,
+                    error = %error,
+                    "failed to disable webhook subscription after terminal response"
+                );
+                // Do not permanently consume the 410 until the required durable
+                // Subscription disable/cancellation transaction has committed.
+                response = EventDeliveryResponse {
+                    disposition: EventDeliveryDisposition::Retryable,
+                    http_status: response.http_status,
+                    retry_after_ms: None,
+                    response_bytes_observed: response.response_bytes_observed,
+                    error_category: Some("subscription_disable".to_string()),
+                    error_summary: Some("Subscription disable will be retried".to_string()),
+                };
+            }
         }
         let completed_at_ms = (self.now_ms)();
         self.complete_attempt(
@@ -292,7 +373,37 @@ impl EventDispatcher {
                 response_bytes_observed: response.response_bytes_observed,
             })
             .await
-            .map_err(|_| EventDispatcherError::Repository)?;
+            .map_err(|error| {
+                warn!(
+                    delivery_id = %delivery.delivery_id,
+                    attempt_no,
+                    next_status = ?next_status,
+                    http_status = ?response.http_status,
+                    error_category = ?response.error_category,
+                    error_summary = ?response.error_summary,
+                    error = %error,
+                    "failed to persist webhook delivery attempt completion"
+                );
+                EventDispatcherError::Repository
+            })?;
+        if next_status == EventDeliveryStatus::Succeeded {
+            debug!(
+                delivery_id = %delivery.delivery_id,
+                attempt_no,
+                http_status = ?response.http_status,
+                "webhook delivery attempt succeeded"
+            );
+        } else {
+            warn!(
+                delivery_id = %delivery.delivery_id,
+                attempt_no,
+                next_status = ?next_status,
+                http_status = ?response.http_status,
+                error_category = ?response.error_category,
+                error_summary = ?response.error_summary,
+                "webhook delivery attempt failed"
+            );
+        }
         Ok(())
     }
 
@@ -304,7 +415,14 @@ impl EventDispatcher {
             .repo
             .get_subscription(subscription_id, &self.env)
             .await
-            .map_err(|_| EventDispatcherError::Repository)?
+            .map_err(|error| {
+                warn!(
+                    subscription_id,
+                    error = %error,
+                    "failed to load webhook subscription for disable"
+                );
+                EventDispatcherError::Repository
+            })?
         else {
             return Err(EventDispatcherError::MissingState);
         };
@@ -350,7 +468,14 @@ impl EventDispatcher {
                 env: self.env.clone(),
             })
             .await
-            .map_err(|_| EventDispatcherError::Repository)?;
+            .map_err(|error| {
+                warn!(
+                    subscription_id,
+                    error = %error,
+                    "failed to persist disabled webhook subscription"
+                );
+                EventDispatcherError::Repository
+            })?;
         Ok(())
     }
 }

--- a/src/bcs/crates/services/bcs-eventing/src/dispatcher.rs
+++ b/src/bcs/crates/services/bcs-eventing/src/dispatcher.rs
@@ -109,6 +109,8 @@ impl EventDispatcher {
             .await
             .map_err(|error| {
                 warn!(
+                    target: "bcs_event_webhook",
+                    component = "delivery",
                     worker_id,
                     env = %self.env,
                     error = %error,
@@ -117,13 +119,22 @@ impl EventDispatcher {
                 EventDispatcherError::Repository
             })?;
         let count = deliveries.len();
-        debug!(worker_id, env = %self.env, count, "claimed webhook deliveries");
+        debug!(
+            target: "bcs_event_webhook",
+            component = "delivery",
+            worker_id,
+            env = %self.env,
+            count,
+            "claimed webhook deliveries"
+        );
         stream::iter(deliveries)
             .for_each_concurrent(self.worker_concurrency, |delivery| async move {
                 let delivery_id = delivery.delivery_id.clone();
                 let attempt_no = delivery.attempt_count;
                 if let Err(error) = self.dispatch(delivery).await {
                     warn!(
+                        target: "bcs_event_webhook",
+                        component = "delivery",
                         delivery_id,
                         attempt_no,
                         error = %error,
@@ -173,6 +184,8 @@ impl EventDispatcher {
                         .await
                         .map_err(|error| {
                             warn!(
+                                target: "bcs_event_webhook",
+                                component = "delivery",
                                 delivery_id,
                                 attempt_no,
                                 error = %error,
@@ -202,6 +215,8 @@ impl EventDispatcher {
             Ok(Some(revision)) => revision,
             Ok(None) => {
                 warn!(
+                    target: "bcs_event_webhook",
+                    component = "delivery",
                     delivery_id = %delivery_record.delivery_id,
                     attempt_no = delivery_record.attempt_count,
                     subscription_id = %delivery_record.subscription_id,
@@ -220,6 +235,8 @@ impl EventDispatcher {
             }
             Err(error) => {
                 warn!(
+                    target: "bcs_event_webhook",
+                    component = "delivery",
                     delivery_id = %delivery_record.delivery_id,
                     attempt_no = delivery_record.attempt_count,
                     subscription_id = %delivery_record.subscription_id,
@@ -241,6 +258,8 @@ impl EventDispatcher {
             Ok(host_key) => host_key,
             Err(error) => {
                 warn!(
+                    target: "bcs_event_webhook",
+                    component = "delivery",
                     delivery_id = %delivery_record.delivery_id,
                     attempt_no = delivery_record.attempt_count,
                     subscription_id = %delivery_record.subscription_id,
@@ -269,6 +288,8 @@ impl EventDispatcher {
             Ok(permit) => permit,
             Err(error) => {
                 warn!(
+                    target: "bcs_event_webhook",
+                    component = "delivery",
                     delivery_id = %delivery_record.delivery_id,
                     attempt_no = delivery_record.attempt_count,
                     error = %error,
@@ -299,6 +320,8 @@ impl EventDispatcher {
             Ok(response) => response,
             Err(error) => {
                 warn!(
+                    target: "bcs_event_webhook",
+                    component = "delivery",
                     delivery_id = %delivery_record.delivery_id,
                     attempt_no,
                     subscription_id = %delivery_record.subscription_id,
@@ -321,6 +344,8 @@ impl EventDispatcher {
                 .await
             {
                 warn!(
+                    target: "bcs_event_webhook",
+                    component = "delivery",
                     delivery_id = %delivery_record.delivery_id,
                     attempt_no,
                     subscription_id = %delivery_record.subscription_id,
@@ -444,6 +469,8 @@ impl EventDispatcher {
             .await
             .map_err(|error| {
                 warn!(
+                    target: "bcs_event_webhook",
+                    component = "delivery",
                     delivery_id = %delivery.delivery_id,
                     attempt_no,
                     next_status = ?next_status,
@@ -457,6 +484,8 @@ impl EventDispatcher {
             })?;
         if next_status == EventDeliveryStatus::Succeeded {
             debug!(
+                target: "bcs_event_webhook",
+                component = "delivery",
                 delivery_id = %delivery.delivery_id,
                 attempt_no,
                 http_status = ?response.http_status,
@@ -464,6 +493,8 @@ impl EventDispatcher {
             );
         } else {
             warn!(
+                target: "bcs_event_webhook",
+                component = "delivery",
                 delivery_id = %delivery.delivery_id,
                 attempt_no,
                 next_status = ?next_status,
@@ -486,6 +517,8 @@ impl EventDispatcher {
             .await
             .map_err(|error| {
                 warn!(
+                    target: "bcs_event_webhook",
+                    component = "delivery",
                     subscription_id,
                     error = %error,
                     "failed to load webhook subscription for disable"
@@ -539,6 +572,8 @@ impl EventDispatcher {
             .await
             .map_err(|error| {
                 warn!(
+                    target: "bcs_event_webhook",
+                    component = "delivery",
                     subscription_id,
                     error = %error,
                     "failed to persist disabled webhook subscription"

--- a/src/bcs/crates/services/bcs-eventing/src/subscription.rs
+++ b/src/bcs/crates/services/bcs-eventing/src/subscription.rs
@@ -1347,15 +1347,15 @@ fn delivery_summary(
 fn attempt_summary(
     attempt: &EventDeliveryAttemptRecord,
 ) -> Result<EventDeliveryAttemptSummary, ApplicationError> {
-    let result = match attempt.result {
+    let result = attempt.result.map(|result| match result {
         EventDeliveryAttemptRecordResult::Success => EventDeliveryAttemptResult::Success,
         EventDeliveryAttemptRecordResult::Retryable => EventDeliveryAttemptResult::Retryable,
         EventDeliveryAttemptRecordResult::Terminal => EventDeliveryAttemptResult::Terminal,
-    };
+    });
     Ok(EventDeliveryAttemptSummary {
         attempt_no: attempt.attempt_no,
         started_at: timestamp(attempt.started_at_ms)?,
-        completed_at: timestamp(attempt.completed_at_ms)?,
+        completed_at: attempt.completed_at_ms.map(timestamp).transpose()?,
         latency_ms: attempt.latency_ms,
         result,
         http_status: attempt.http_status,

--- a/src/bcs/crates/services/bcs-eventing/tests/dispatcher.rs
+++ b/src/bcs/crates/services/bcs-eventing/tests/dispatcher.rs
@@ -12,7 +12,8 @@ use async_trait::async_trait;
 use bcs_eventing::{EventCatalog, EventDispatcher, EventFanoutWorker, EventRetryPolicy};
 use bcs_service_api::application::v1::EventSubscriptionService;
 use bcs_service_api::port::repo::{
-    AppendEventRecord, ClaimEventDeliveries, EventRepoPort, ListEventDeliveryRecords,
+    AppendEventRecord, ClaimEventDeliveries, EventDeliveryAttemptRecordResult, EventRepoPort,
+    ListEventDeliveryRecords, ReplaceEventSubscriptionRevision,
 };
 use bcs_service_api::port::{
     EventDeliveryDisposition, EventDeliveryError, EventDeliveryPort, EventDeliveryRequest,
@@ -66,6 +67,84 @@ async fn fanout_projects_the_fixed_revision_and_dispatcher_completes_delivery() 
             .body,
         delivery.payload_bytes
     );
+    assert_eq!(
+        metrics
+            .attempts
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn invalid_claimed_endpoint_completes_a_terminal_attempt() {
+    let harness = harness(true);
+    let created = harness
+        .service
+        .create(create_command(
+            vec!["group.*".to_string()],
+            EventPayloadMode::MetadataOnly,
+        ))
+        .await
+        .expect("Subscription");
+    let (subscription, mut invalid_revision) = harness
+        .repo
+        .get_subscription(&created.subscription_id, "test")
+        .await
+        .expect("read Subscription")
+        .expect("Subscription exists");
+    invalid_revision.revision = 2;
+    invalid_revision.endpoint_url = "not-a-webhook-url".to_string();
+    invalid_revision.activated_at_ms = NOW_MS + 1;
+    harness
+        .repo
+        .replace_subscription_revision(ReplaceEventSubscriptionRevision {
+            subscription_id: subscription.subscription_id.clone(),
+            expected_revision: 1,
+            name: subscription.name.clone(),
+            status: EventSubscriptionStatus::Active,
+            revision: invalid_revision,
+            cancel_retired_pending_deliveries: false,
+            actor: subscription.created_by.clone(),
+            reason: Some("inject invalid endpoint for dispatcher contract".to_string()),
+            updated_at_ms: NOW_MS + 1,
+            env: "test".to_string(),
+        })
+        .await
+        .expect("store invalid revision through repository boundary");
+    append_test_event(&harness, "evt-invalid-endpoint").await;
+
+    let metrics = Arc::new(CaptureMetrics::default());
+    fanout(&harness, metrics.clone(), "del-invalid-endpoint").await;
+    assert_eq!(
+        dispatcher(&harness, metrics.clone(), EventRetryPolicy::default())
+            .run_once("dispatcher-invalid-endpoint")
+            .await
+            .expect("dispatch invalid endpoint"),
+        1
+    );
+
+    let (delivery, attempts) = harness
+        .repo
+        .get_delivery("del-invalid-endpoint", "test")
+        .await
+        .expect("read Delivery")
+        .expect("Delivery exists");
+    assert_eq!(delivery.status, EventDeliveryStatus::DeadLettered);
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(
+        attempts[0].result,
+        Some(EventDeliveryAttemptRecordResult::Terminal)
+    );
+    assert!(attempts[0].completed_at_ms.is_some());
+    assert_eq!(attempts[0].error_category.as_deref(), Some("invalid_endpoint"));
+    assert!(harness
+        .delivery
+        .requests
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .is_empty());
     assert_eq!(
         metrics
             .attempts
@@ -525,6 +604,11 @@ async fn create_subscription_and_event(
         ))
         .await
         .expect("Subscription");
+    append_test_event(harness, event_id).await;
+    created
+}
+
+async fn append_test_event(harness: &support::Harness, event_id: &str) {
     harness
         .repo
         .append_event(AppendEventRecord {
@@ -556,7 +640,6 @@ async fn create_subscription_and_event(
         })
         .await
         .expect("append Event");
-    created
 }
 
 #[allow(dead_code)]

--- a/src/bcs/crates/services/bcs-eventing/tests/subscription_service.rs
+++ b/src/bcs/crates/services/bcs-eventing/tests/subscription_service.rs
@@ -203,7 +203,7 @@ async fn inline_group_finalization_activates_and_snapshots_ordered_creation_even
             "group-provisioning",
             vec![inline_subscription(
                 "creation-events",
-                vec!["group.created", "session.created"],
+                vec!["group.created", "session.created", "state_machine.*"],
             )],
         )
         .await
@@ -223,6 +223,46 @@ async fn inline_group_finalization_activates_and_snapshots_ordered_creation_even
         .upsert(group.clone())
         .await
         .expect("persist provisioning Group");
+    append_provisioning_state_machine_event(
+        &harness,
+        "evt-run-created",
+        "state_machine.run.created",
+        None,
+        "state-machine-run:run-1",
+    )
+    .await;
+    append_provisioning_state_machine_event(
+        &harness,
+        "evt-run-started",
+        "state_machine.run.started",
+        Some("evt-run-created"),
+        "state-machine-run:run-1",
+    )
+    .await;
+    append_provisioning_state_machine_event(
+        &harness,
+        "evt-node-started",
+        "state_machine.node.started",
+        Some("evt-run-started"),
+        "state-machine-run:run-1",
+    )
+    .await;
+    append_provisioning_state_machine_event(
+        &harness,
+        "evt-cross-stream-cause",
+        "state_machine.node.completed",
+        None,
+        "z-state-machine-cause",
+    )
+    .await;
+    append_provisioning_state_machine_event(
+        &harness,
+        "evt-cross-stream-effect",
+        "state_machine.node.started",
+        Some("evt-cross-stream-cause"),
+        "a-state-machine-effect",
+    )
+    .await;
     let session = Session {
         id: "group-provisioning:12345678".to_string(),
         group_id: group.id.clone(),
@@ -272,7 +312,7 @@ async fn inline_group_finalization_activates_and_snapshots_ordered_creation_even
     assert_eq!(revision.activated_at_ms, NOW_MS);
 
     let targets = claim_targets(&harness).await;
-    assert_eq!(targets.len(), 2);
+    assert_eq!(targets.len(), 7);
     let mut events = Vec::new();
     for target in &targets {
         events.push(
@@ -309,6 +349,44 @@ async fn inline_group_finalization_activates_and_snapshots_ordered_creation_even
     assert_eq!(
         session_target.depends_on_target_id.as_deref(),
         Some(group_target.target_id.as_str())
+    );
+    let run_targets = targets
+        .iter()
+        .filter_map(|target| {
+            events
+                .iter()
+                .find(|event| event.envelope.event_id == target.event_id)
+                .filter(|event| event.envelope.stream.key == "state-machine-run:run-1")
+                .map(|event| (event.envelope.stream.sequence, target))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        run_targets
+            .iter()
+            .map(|(sequence, _)| *sequence)
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    assert_eq!(
+        run_targets[1].1.depends_on_target_id.as_deref(),
+        Some(run_targets[0].1.target_id.as_str())
+    );
+    assert_eq!(
+        run_targets[2].1.depends_on_target_id.as_deref(),
+        Some(run_targets[1].1.target_id.as_str())
+    );
+    let cross_stream_causes = targets
+        .iter()
+        .filter(|target| target.event_id == "evt-cross-stream-cause")
+        .collect::<Vec<_>>();
+    assert_eq!(cross_stream_causes.len(), 1);
+    let cross_stream_effect = targets
+        .iter()
+        .find(|target| target.event_id == "evt-cross-stream-effect")
+        .expect("cross-stream effect target");
+    assert_eq!(
+        cross_stream_effect.depends_on_target_id.as_deref(),
+        Some(cross_stream_causes[0].target_id.as_str())
     );
 
     let redacted = harness
@@ -855,6 +933,48 @@ async fn append_group_event(harness: &support::Harness, event_id: &str) {
         })
         .await
         .expect("append group Event");
+}
+
+async fn append_provisioning_state_machine_event(
+    harness: &support::Harness,
+    event_id: &str,
+    event_type: &str,
+    causation_event_id: Option<&str>,
+    stream_key: &str,
+) {
+    harness
+        .repo
+        .append_event(AppendEventRecord {
+            event: NewEvent {
+                event_id: event_id.to_string(),
+                event_type: event_type.to_string(),
+                schema_version: EVENT_SCHEMA_VERSION_V1.to_string(),
+                producer: "state-machine-runtime".to_string(),
+                producer_key: event_id.to_string(),
+                occurred_at: "2026-08-18T04:40:00.000Z".to_string(),
+                subject: EventSubject {
+                    subject_type: "state_machine.run".to_string(),
+                    id: "run-1".to_string(),
+                },
+                scope: EventScope {
+                    group_id: Some("group-provisioning".to_string()),
+                    session_id: Some("group-provisioning:12345678".to_string()),
+                    run_id: Some("run-1".to_string()),
+                    ..EventScope::default()
+                },
+                stream_key: stream_key.to_string(),
+                actor: None,
+                correlation_id: None,
+                causation_event_id: causation_event_id.map(str::to_string),
+                trace_id: None,
+                data: BTreeMap::new(),
+            },
+            recorded_at: "2026-08-18T04:40:00.000Z".to_string(),
+            retention_until_ms: NOW_MS + 86_400_000,
+            env: "test".to_string(),
+        })
+        .await
+        .expect("append provisioning state-machine Event");
 }
 
 async fn claim_targets(

--- a/src/bcs/crates/services/bcs-group-store/tests/conformance_group_repo.rs
+++ b/src/bcs/crates/services/bcs-group-store/tests/conformance_group_repo.rs
@@ -10,8 +10,8 @@ use bcs_service_api::port::NewEvent;
 use bcs_service_api::port::repo::{
     AppendEventRecord, ClaimFanoutTargets, CommitGroupEventfulMutation,
     CreateEventSubscriptionRecord, EventRepoPort, EventSubscriptionRecord,
-    EventSubscriptionRevisionRecord, FinalizeGroupProvisioning, GroupEventfulMutation,
-    GroupRepoPort,
+    EventSubscriptionRevisionRecord, EventFanoutTargetPurpose, FinalizeGroupProvisioning,
+    GroupEventfulMutation, GroupRepoPort,
 };
 use bcs_service_api::types::{
     EVENT_SCHEMA_VERSION_V1, EventActor, EventActorType, EventPayloadMode, EventScope,
@@ -30,6 +30,10 @@ const PROVISIONING_ENV: &str = "contract";
 const PROVISIONING_GROUP: &str = "group-provisioning";
 const PROVISIONING_SUBSCRIPTION: &str = "sub-provisioning";
 const PROVISIONING_EVENT: &str = "evt-group-provisioning";
+const PROVISIONING_PREWINDOW_CAUSE_EVENT: &str = "evt-provisioning-prewindow-cause";
+const PROVISIONING_WINDOW_EFFECT_EVENT: &str = "evt-provisioning-window-effect";
+const PROVISIONING_RUN_CREATED_EVENT: &str = "evt-provisioning-run-created";
+const PROVISIONING_RUN_STARTED_EVENT: &str = "evt-provisioning-run-started";
 
 #[tokio::test]
 async fn memory_group_repo_passes_group_repo_contract() {
@@ -445,10 +449,53 @@ async fn sqlite_group_provisioning_finalization_commits_group_subscription_event
     let groups = MySqlGroupStore::sqlite(db.clone(), PROVISIONING_ENV.to_string());
     let events = DbEventStore::sqlite(db.clone());
     seed_provisioning_group(&groups).await;
+    let mut prewindow_cause = provisioning_runtime_event(
+        PROVISIONING_PREWINDOW_CAUSE_EVENT,
+        "state_machine.node.completed",
+        None,
+    );
+    prewindow_cause.event.occurred_at = "2026-08-18T04:39:58.500Z".to_string();
+    prewindow_cause.recorded_at = "2026-08-18T04:39:58.500Z".to_string();
+    events
+        .append_event(prewindow_cause)
+        .await
+        .expect("append cause before Subscription creation");
     events
         .create_subscription(pending_subscription())
         .await
         .expect("create pending Subscription");
+    events
+        .append_event(provisioning_runtime_event(
+            PROVISIONING_WINDOW_EFFECT_EVENT,
+            "state_machine.node.started",
+            Some(PROVISIONING_PREWINDOW_CAUSE_EVENT),
+        ))
+        .await
+        .expect("append effect while Subscription is pending");
+    events
+        .append_event(provisioning_runtime_event(
+            PROVISIONING_RUN_CREATED_EVENT,
+            "state_machine.run.created",
+            None,
+        ))
+        .await
+        .expect("append run.created while Subscription is pending");
+    events
+        .append_event(provisioning_runtime_event(
+            PROVISIONING_RUN_STARTED_EVENT,
+            "state_machine.run.started",
+            Some(PROVISIONING_RUN_CREATED_EVENT),
+        ))
+        .await
+        .expect("append run.started while Subscription is pending");
+    assert_eq!(
+        target_count(db.as_ref(), PROVISIONING_RUN_CREATED_EVENT).await,
+        0
+    );
+    assert_eq!(
+        target_count(db.as_ref(), PROVISIONING_RUN_STARTED_EVENT).await,
+        0
+    );
 
     groups
         .finalize_provisioning(finalization(event_record(None)))
@@ -487,6 +534,69 @@ async fn sqlite_group_provisioning_finalization_commits_group_subscription_event
         .await
         .expect("query target snapshot");
     assert_eq!(db_get_column::<i64>(&rows[0], "target_count").unwrap(), 1);
+    assert_eq!(
+        target_count(db.as_ref(), PROVISIONING_RUN_CREATED_EVENT).await,
+        1
+    );
+    assert_eq!(
+        target_count(db.as_ref(), PROVISIONING_RUN_STARTED_EVENT).await,
+        1
+    );
+    assert_eq!(
+        target_count(db.as_ref(), PROVISIONING_PREWINDOW_CAUSE_EVENT).await,
+        1
+    );
+    assert_eq!(
+        target_count(db.as_ref(), PROVISIONING_WINDOW_EFFECT_EVENT).await,
+        1
+    );
+    let claimed_targets = events
+        .claim_fanout_targets(ClaimFanoutTargets {
+            worker_id: "provisioning-order".to_string(),
+            now_ms: 1_787_028_000_001,
+            lease_until_ms: 1_787_028_010_001,
+            limit: 100,
+            env: PROVISIONING_ENV.to_string(),
+        })
+        .await
+        .expect("claim provisioning targets");
+    let run_targets = claimed_targets
+        .iter()
+        .filter(|target| {
+            target.event_id == PROVISIONING_RUN_CREATED_EVENT
+                || target.event_id == PROVISIONING_RUN_STARTED_EVENT
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        run_targets
+            .iter()
+            .map(|target| target.event_id.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            PROVISIONING_RUN_CREATED_EVENT,
+            PROVISIONING_RUN_STARTED_EVENT
+        ]
+    );
+    assert_eq!(
+        run_targets[1].depends_on_target_id.as_deref(),
+        Some(run_targets[0].target_id.as_str())
+    );
+    let prewindow_cause_target = claimed_targets
+        .iter()
+        .find(|target| target.event_id == PROVISIONING_PREWINDOW_CAUSE_EVENT)
+        .expect("pre-window causal prerequisite target");
+    assert_eq!(
+        prewindow_cause_target.purpose,
+        EventFanoutTargetPurpose::CausalPrerequisite
+    );
+    let window_effect_target = claimed_targets
+        .iter()
+        .find(|target| target.event_id == PROVISIONING_WINDOW_EFFECT_EVENT)
+        .expect("in-window effect target");
+    assert_eq!(
+        window_effect_target.depends_on_target_id.as_deref(),
+        Some(prewindow_cause_target.target_id.as_str())
+    );
 }
 
 #[tokio::test]
@@ -848,7 +958,7 @@ fn pending_subscription() -> CreateEventSubscriptionRecord {
         revision: EventSubscriptionRevisionRecord {
             subscription_id: PROVISIONING_SUBSCRIPTION.to_string(),
             revision: 1,
-            event_filters: vec!["group.created".to_string()],
+            event_filters: vec!["group.created".to_string(), "state_machine.*".to_string()],
             payload_mode: EventPayloadMode::MetadataOnly,
             endpoint_url: "https://events.example.com/group-provisioning".to_string(),
             request_timeout_ms: 5_000,
@@ -895,6 +1005,42 @@ fn event_record(causation_event_id: Option<&str>) -> AppendEventRecord {
             data: BTreeMap::new(),
         },
         recorded_at: "2026-08-19T00:00:00.001Z".to_string(),
+        retention_until_ms: 2_000_000_000_000,
+        env: PROVISIONING_ENV.to_string(),
+    }
+}
+
+fn provisioning_runtime_event(
+    event_id: &str,
+    event_type: &str,
+    causation_event_id: Option<&str>,
+) -> AppendEventRecord {
+    AppendEventRecord {
+        event: NewEvent {
+            event_id: event_id.to_string(),
+            event_type: event_type.to_string(),
+            schema_version: EVENT_SCHEMA_VERSION_V1.to_string(),
+            producer: "state-machine-runtime".to_string(),
+            producer_key: event_id.to_string(),
+            occurred_at: "2026-08-18T04:39:59.500Z".to_string(),
+            subject: EventSubject {
+                subject_type: "state_machine.run".to_string(),
+                id: "run-provisioning".to_string(),
+            },
+            scope: EventScope {
+                group_id: Some(PROVISIONING_GROUP.to_string()),
+                session_id: Some("session-provisioning".to_string()),
+                run_id: Some("run-provisioning".to_string()),
+                ..EventScope::default()
+            },
+            stream_key: "state-machine-run:run-provisioning".to_string(),
+            actor: Some(actor()),
+            correlation_id: None,
+            causation_event_id: causation_event_id.map(str::to_string),
+            trace_id: None,
+            data: BTreeMap::new(),
+        },
+        recorded_at: "2026-08-18T04:39:59.500Z".to_string(),
         retention_until_ms: 2_000_000_000_000,
         env: PROVISIONING_ENV.to_string(),
     }

--- a/src/bcs/crates/services/bcs-group/src/application/management.rs
+++ b/src/bcs/crates/services/bcs-group/src/application/management.rs
@@ -8,7 +8,7 @@ use crate::core::validate_service_spec_patch;
 use crate::noop::{
     EmptyRelationCoreService, EmptySessionManagementService, NoopSystemMessageService,
 };
-use bcs_service_api::types::{EventActor, EventActorType};
+use bcs_service_api::types::{EventActor, EventActorType, OpeningMessageScope};
 use bcs_service_api::{
     ActorKind, ActorStatus, BotRegistryCoreService, BotRuntimeConnectionService,
     CallbackChannelConfig, CanResolveInteraction, CanResolveInteractionCommand,
@@ -1006,13 +1006,11 @@ impl GroupManagementService for GroupManagement {
         }
         let requested_strategy = cmd.group_strategy.unwrap_or_default();
         if let Some(opening_message) = &cmd.opening_message {
-            if requested_strategy != GroupStrategy::StateMachine {
-                return Err(GroupUseCaseError::InvalidProposal(
-                    "invalid_opening_message: opening_message is only supported for state_machine groups"
-                        .to_string(),
-                ));
-            }
-            opening_message.validate().map_err(|error| {
+            let scope = match requested_strategy {
+                GroupStrategy::StateMachine => OpeningMessageScope::StateMachineRun,
+                GroupStrategy::Chat | GroupStrategy::ManagerWorker => OpeningMessageScope::Session,
+            };
+            opening_message.validate_for(scope).map_err(|error| {
                 GroupUseCaseError::InvalidProposal(format!("invalid_opening_message: {error}"))
             })?;
         }

--- a/src/bcs/crates/services/bcs-group/tests/management.rs
+++ b/src/bcs/crates/services/bcs-group/tests/management.rs
@@ -345,7 +345,7 @@ async fn create_state_machine_group_auto_creates_service_invocation_session() {
 }
 
 #[tokio::test]
-async fn create_chat_group_rejects_opening_message() {
+async fn create_chat_group_accepts_session_scoped_opening_message() {
     let fixture = Fixture::new().with_bot("driver", "Driver", "public", Some("alice"));
     let service = fixture.service_with_limits(5, 10, 10);
     let mut cmd = create_cmd(
@@ -353,13 +353,21 @@ async fn create_chat_group_rejects_opening_message() {
         "driver",
         vec![participant("driver", Some("driver"))],
     );
-    cmd.opening_message = Some(OpeningMessage::Text("hello".to_string()));
+    let opening_message = OpeningMessage::Text(
+        "hello {{bcs.session_id}}".to_string(),
+    );
+    cmd.opening_message = Some(opening_message.clone());
 
-    let error = service
-        .create_group(cmd)
-        .await
-        .expect_err("Chat Group must reject opening_message");
-    assert!(error.to_string().contains("invalid_opening_message"));
+    service.create_group(cmd).await.expect("create Chat Group");
+    assert_eq!(
+        fixture
+            .group
+            .get("group-under-test")
+            .await
+            .expect("created group")
+            .opening_message,
+        Some(opening_message)
+    );
 }
 
 #[tokio::test]

--- a/src/bcs/crates/services/bcs-message/src/lib.rs
+++ b/src/bcs/crates/services/bcs-message/src/lib.rs
@@ -546,6 +546,8 @@ impl GroupMessageHistoryService for MessageService {
                 cmd.view_bot_id.as_deref(),
                 self.new_participant_visible_limit,
             )?;
+            let merge_public_opening_message = !hide_opening_message
+                && matches!(&owner_filter, MessageOwnerFilter::Eq(_));
 
             info!(
                 session_id = %session_id,
@@ -556,7 +558,7 @@ impl GroupMessageHistoryService for MessageService {
             );
 
             let query = MessageQuery {
-                group_id: cmd.group_id,
+                group_id: cmd.group_id.clone(),
                 session_id: session_id.clone(),
                 cursor: cmd.before,
                 limit: self.effective_limit(cmd.limit),
@@ -567,12 +569,53 @@ impl GroupMessageHistoryService for MessageService {
                 time_range: None,
                 visible_from_seq,
             };
-            let page = self.message_repo.query_messages(query).await.map_err(|e| {
+            let mut page = self.message_repo.query_messages(query).await.map_err(|e| {
                 GroupUseCaseError::Service(ServiceError::InternalError(format!(
                     "message repo error: {}",
                     e
                 )))
             })?;
+            if merge_public_opening_message {
+                let opening_page = self
+                    .message_repo
+                    .query_messages(MessageQuery {
+                        group_id: cmd.group_id.clone(),
+                        session_id: session_id.clone(),
+                        cursor: cmd.before,
+                        limit,
+                        keyword: None,
+                        sender_id: None,
+                        message_type: Some(SESSION_OPENING_MESSAGE_TYPE.to_string()),
+                        owner_filter: MessageOwnerFilter::IsNull,
+                        time_range: None,
+                        visible_from_seq: None,
+                    })
+                    .await
+                    .map_err(|error| {
+                        GroupUseCaseError::Service(ServiceError::InternalError(format!(
+                            "message repo opening-message error: {error}"
+                        )))
+                    })?;
+                let source_has_more = page.has_more || opening_page.has_more;
+                page.messages.extend(opening_page.messages);
+                page.messages.sort_by(|left, right| {
+                    right
+                        .created_at
+                        .cmp(&left.created_at)
+                        .then_with(|| right.session_seq.cmp(&left.session_seq))
+                });
+                let combined_has_more = page.messages.len() > limit as usize;
+                page.messages.truncate(limit as usize);
+                page.has_more = source_has_more || combined_has_more;
+                page.next_cursor = page
+                    .has_more
+                    .then(|| {
+                        page.messages
+                            .last()
+                            .map(|message| (message.created_at, message.session_seq))
+                    })
+                    .flatten();
+            }
             let mut bot_names: std::collections::HashMap<String, Option<String>> =
                 std::collections::HashMap::new();
             let messages: Vec<GroupMessage> = {
@@ -681,7 +724,7 @@ impl GroupMessageHistoryService for MessageService {
                         keyword: None,
                         sender_id: None,
                         message_type: Some(SESSION_OPENING_MESSAGE_TYPE.to_string()),
-                        owner_filter,
+                        owner_filter: MessageOwnerFilter::IsNull,
                         time_range: None,
                         visible_from_seq: None,
                     })
@@ -1403,7 +1446,7 @@ mod tests {
         .await
         .expect("append opening message");
 
-        let mut human_command = session_cmd("group-1", &session_id, None);
+        let mut human_command = session_cmd("group-1", &session_id, Some("worker-a"));
         human_command.caller = CallerContext::Human(HumanActor {
             actor_id: "human-1".to_string(),
             staff_no: "human-1".to_string(),
@@ -1523,6 +1566,79 @@ mod tests {
         assert_eq!(fallback.session_calls().await, 0);
         assert_eq!(result.messages.len(), 1);
         assert_eq!(result.messages[0].content, "a-only");
+    }
+
+    #[tokio::test]
+    async fn manager_worker_human_worker_view_keeps_public_opening_message_after_cutoff() {
+        let (service, repo, _sessions, fallback, session_id) =
+            service_fixture(GroupStrategy::ManagerWorker, 0, 0, Vec::new()).await;
+        let stable_message_id = format!("{session_id}:000-opening");
+        repo.append_message(NewMessage {
+            group_id: "group-1".to_string(),
+            session_id: session_id.clone(),
+            sender_id: bcs_domain::BCS_SESSION_OPENING_MESSAGE_SENDER.to_string(),
+            sender_type: SenderType::Bot,
+            message_type: SESSION_OPENING_MESSAGE_TYPE.to_string(),
+            content: serde_json::json!({
+                "text": "任务协作群开场消息",
+                "bot_name": BCS_SESSION_OPENING_MESSAGE_SENDER_NAME,
+                "metadata": {
+                    "opening_message": {
+                        "scope": "session",
+                        "strategy": "manager_worker",
+                    }
+                }
+            }),
+            client_msg_id: Some(stable_message_id.clone()),
+            created_at: 1,
+            run_id: format!("{session_id}:opening"),
+            owner_bot_id: None,
+        })
+        .await
+        .expect("append opening message");
+        append_history(
+            &repo,
+            "group-1",
+            &session_id,
+            "worker-a",
+            "a-only",
+            Some("worker-a"),
+        )
+        .await;
+        append_history(
+            &repo,
+            "group-1",
+            &session_id,
+            "worker-b",
+            "b-only",
+            Some("worker-b"),
+        )
+        .await;
+
+        let mut command = session_cmd("group-1", &session_id, Some("worker-a"));
+        command.caller = CallerContext::Human(HumanActor {
+            actor_id: "human-1".to_string(),
+            staff_no: "human-1".to_string(),
+        });
+        let result = service
+            .get_session_history(command)
+            .await
+            .expect("manager worker human worker view history");
+
+        assert_eq!(fallback.session_calls().await, 0);
+        let message_ids = result
+            .messages
+            .iter()
+            .map(|message| message.id.as_str())
+            .collect::<Vec<_>>();
+        let contents = result
+            .messages
+            .iter()
+            .map(|message| message.content.as_str())
+            .collect::<Vec<_>>();
+        assert!(message_ids.contains(&stable_message_id.as_str()));
+        assert!(contents.contains(&"a-only"));
+        assert!(!contents.contains(&"b-only"));
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-message/src/lib.rs
+++ b/src/bcs/crates/services/bcs-message/src/lib.rs
@@ -651,14 +651,14 @@ impl GroupMessageHistoryService for MessageService {
             let panel_page = self
                 .message_repo
                 .query_messages(MessageQuery {
-                    group_id: cmd.group_id,
+                    group_id: cmd.group_id.clone(),
                     session_id: session_id.clone(),
                     cursor: cmd.before,
                     limit,
                     keyword: None,
                     sender_id: None,
                     message_type: Some(STATE_MACHINE_PANEL_MESSAGE_TYPE.to_string()),
-                    owner_filter,
+                    owner_filter: owner_filter.clone(),
                     time_range: None,
                     visible_from_seq: None,
                 })
@@ -668,20 +668,45 @@ impl GroupMessageHistoryService for MessageService {
                         "message repo panel-anchor error: {error}"
                     )))
                 })?;
-            if panel_page.messages.is_empty() {
+            let mut persisted_anchors = panel_page.messages;
+            let mut persisted_anchors_have_more = panel_page.has_more;
+            if !hide_opening_message {
+                let opening_page = self
+                    .message_repo
+                    .query_messages(MessageQuery {
+                        group_id: cmd.group_id,
+                        session_id: session_id.clone(),
+                        cursor: cmd.before,
+                        limit,
+                        keyword: None,
+                        sender_id: None,
+                        message_type: Some(SESSION_OPENING_MESSAGE_TYPE.to_string()),
+                        owner_filter,
+                        time_range: None,
+                        visible_from_seq: None,
+                    })
+                    .await
+                    .map_err(|error| {
+                        GroupUseCaseError::Service(ServiceError::InternalError(format!(
+                            "message repo opening-message error: {error}"
+                        )))
+                    })?;
+                persisted_anchors_have_more |= opening_page.has_more;
+                persisted_anchors.extend(opening_page.messages);
+            }
+            if persisted_anchors.is_empty() {
                 return Ok(fallback_result);
             }
 
             let source_has_more =
-                fallback_result.next_before.is_some() || panel_page.has_more;
+                fallback_result.next_before.is_some() || persisted_anchors_have_more;
             let mut seen_ids = fallback_result
                 .messages
                 .iter()
                 .map(|message| message.id.clone())
                 .collect::<std::collections::HashSet<_>>();
             fallback_result.messages.extend(
-                panel_page
-                    .messages
+                persisted_anchors
                     .into_iter()
                     .map(|message| persisted_to_group_message(message, None))
                     .filter(|message| seen_ids.insert(message.id.clone())),
@@ -1342,6 +1367,69 @@ mod tests {
         assert_eq!(fallback.session_calls().await, 1);
         assert_eq!(result.messages.len(), 1);
         assert_eq!(result.messages[0].content, "legacy");
+    }
+
+    #[tokio::test]
+    async fn pre_cutoff_manager_worker_merges_opening_message_only_for_humans() {
+        let (service, repo, _sessions, fallback, session_id) = service_fixture(
+            GroupStrategy::ManagerWorker,
+            0,
+            u64::MAX,
+            vec![fallback_message("legacy")],
+        )
+        .await;
+        let stable_message_id = format!("{session_id}:000-opening");
+        repo.append_message(NewMessage {
+            group_id: "group-1".to_string(),
+            session_id: session_id.clone(),
+            sender_id: bcs_domain::BCS_SESSION_OPENING_MESSAGE_SENDER.to_string(),
+            sender_type: SenderType::Bot,
+            message_type: SESSION_OPENING_MESSAGE_TYPE.to_string(),
+            content: serde_json::json!({
+                "text": "任务协作群开场消息",
+                "bot_name": BCS_SESSION_OPENING_MESSAGE_SENDER_NAME,
+                "metadata": {
+                    "opening_message": {
+                        "scope": "session",
+                        "strategy": "manager_worker",
+                    }
+                }
+            }),
+            client_msg_id: Some(stable_message_id.clone()),
+            created_at: 2,
+            run_id: format!("{session_id}:opening"),
+            owner_bot_id: None,
+        })
+        .await
+        .expect("append opening message");
+
+        let mut human_command = session_cmd("group-1", &session_id, None);
+        human_command.caller = CallerContext::Human(HumanActor {
+            actor_id: "human-1".to_string(),
+            staff_no: "human-1".to_string(),
+        });
+        let human_result = service
+            .get_session_history(human_command)
+            .await
+            .expect("human legacy history");
+        assert!(human_result
+            .messages
+            .iter()
+            .any(|message| message.id == stable_message_id));
+
+        let mut bot_command = session_cmd("group-1", &session_id, Some("worker-a"));
+        bot_command.caller = CallerContext::Bot(BotActor {
+            bot_uuid: "worker-a".to_string(),
+        });
+        let bot_result = service
+            .get_session_history(bot_command)
+            .await
+            .expect("bot legacy history");
+        assert!(bot_result
+            .messages
+            .iter()
+            .all(|message| message.id != stable_message_id));
+        assert_eq!(fallback.session_calls().await, 2);
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-message/src/lib.rs
+++ b/src/bcs/crates/services/bcs-message/src/lib.rs
@@ -9,15 +9,16 @@ use async_trait::async_trait;
 use tracing::info;
 
 use bcs_domain::{
-    BCS_STATE_MACHINE_MESSAGE_SENDER_NAME, MessageAttachment, MessageOwnerFilter, MessageQuery,
+    BCS_SESSION_OPENING_MESSAGE_SENDER_NAME, BCS_STATE_MACHINE_MESSAGE_SENDER_NAME,
+    MessageAttachment, MessageOwnerFilter, MessageQuery, SESSION_OPENING_MESSAGE_TYPE,
     STATE_MACHINE_PANEL_MESSAGE_TYPE, Session,
 };
 use bcs_service_api::{
-    application::session_files::SessionFileService, BotRegistryCoreService, GroupCoreService,
-    GroupHistoryCommand, GroupHistoryResult, GroupMessageHistoryService, GroupUseCaseError,
-    SessionHistoryCommand, SessionHistoryResult, Group, GroupMessage, GroupMessageType,
-    GroupStrategy, MessageRole, ParticipantRole, port::repo::{MessageRepoPort, SessionRepoPort},
-    ServiceError,
+    application::session_files::SessionFileService, BotRegistryCoreService, CallerContext,
+    Group, GroupCoreService, GroupHistoryCommand, GroupHistoryResult, GroupMessage,
+    GroupMessageHistoryService, GroupMessageType, GroupStrategy, GroupUseCaseError, MessageRole,
+    ParticipantRole, ServiceError, SessionHistoryCommand, SessionHistoryResult,
+    port::repo::{MessageRepoPort, SessionRepoPort},
 };
 
 /// Application service implementing [`GroupMessageHistoryService`].
@@ -307,19 +308,25 @@ fn persisted_to_group_message(
     pm: bcs_domain::PersistedMessage,
     bot_name: Option<String>,
 ) -> GroupMessage {
-    let is_state_machine_panel = pm.message_type == STATE_MACHINE_PANEL_MESSAGE_TYPE;
-    let message_id = if is_state_machine_panel {
+    let is_persisted_bcs_ui = matches!(
+        pm.message_type.as_str(),
+        STATE_MACHINE_PANEL_MESSAGE_TYPE | SESSION_OPENING_MESSAGE_TYPE
+    );
+    let message_id = if is_persisted_bcs_ui {
         pm.client_msg_id
             .clone()
             .unwrap_or_else(|| pm.message_id.clone())
     } else {
         pm.message_id.clone()
     };
-    let panel_bot_name = is_state_machine_panel.then(|| {
+    let bcs_bot_name = is_persisted_bcs_ui.then(|| {
         pm.content
             .get("bot_name")
             .and_then(serde_json::Value::as_str)
-            .unwrap_or(BCS_STATE_MACHINE_MESSAGE_SENDER_NAME)
+            .unwrap_or_else(|| match pm.message_type.as_str() {
+                SESSION_OPENING_MESSAGE_TYPE => BCS_SESSION_OPENING_MESSAGE_SENDER_NAME,
+                _ => BCS_STATE_MACHINE_MESSAGE_SENDER_NAME,
+            })
             .to_string()
     });
     let (role, metadata, content_str, attachments) = match pm.message_type.as_str() {
@@ -332,7 +339,7 @@ fn persisted_to_group_message(
             let (text, attachments) = extract_text_and_attachments(&pm.content);
             (role, None, text, attachments)
         }
-        STATE_MACHINE_PANEL_MESSAGE_TYPE => {
+        STATE_MACHINE_PANEL_MESSAGE_TYPE | SESSION_OPENING_MESSAGE_TYPE => {
             // TODO(sm-history-node-expansion): expand this persisted panel anchor
             // into node task/output messages after pagination and cursor semantics
             // for expanded state-machine history are defined.
@@ -370,7 +377,7 @@ fn persisted_to_group_message(
         sender: pm.sender_id,
         content: content_str,
         message_type: GroupMessageType::Bot,
-        bot_name: panel_bot_name.or(bot_name),
+        bot_name: bcs_bot_name.or(bot_name),
         role,
         run_id: pm.run_id,
         history_meta: None,
@@ -411,6 +418,7 @@ impl GroupMessageHistoryService for MessageService {
         &self,
         cmd: GroupHistoryCommand,
     ) -> Result<GroupHistoryResult, GroupUseCaseError> {
+        let hide_opening_message = matches!(&cmd.caller, CallerContext::Bot(_));
         let group = self
             .group
             .get(&cmd.group_id)
@@ -456,7 +464,14 @@ impl GroupMessageHistoryService for MessageService {
                 std::collections::HashMap::new();
             let messages: Vec<GroupMessage> = {
                 let mut result = Vec::with_capacity(page.messages.len());
-                for pm in page.messages {
+                for pm in page
+                    .messages
+                    .into_iter()
+                    .filter(|message| {
+                        !hide_opening_message
+                            || message.message_type != SESSION_OPENING_MESSAGE_TYPE
+                    })
+                {
                     let bot_name = match bot_names.entry(pm.sender_id.clone()) {
                         std::collections::hash_map::Entry::Occupied(e) => e.get().clone(),
                         std::collections::hash_map::Entry::Vacant(e) => {
@@ -511,6 +526,7 @@ impl GroupMessageHistoryService for MessageService {
         &self,
         cmd: SessionHistoryCommand,
     ) -> Result<SessionHistoryResult, GroupUseCaseError> {
+        let hide_opening_message = matches!(&cmd.caller, CallerContext::Bot(_));
         let session_id = cmd.session_id.clone();
         let session = self.session_repo.get(&session_id).await;
 
@@ -561,7 +577,14 @@ impl GroupMessageHistoryService for MessageService {
                 std::collections::HashMap::new();
             let messages: Vec<GroupMessage> = {
                 let mut result = Vec::with_capacity(page.messages.len());
-                for pm in page.messages {
+                for pm in page
+                    .messages
+                    .into_iter()
+                    .filter(|message| {
+                        !hide_opening_message
+                            || message.message_type != SESSION_OPENING_MESSAGE_TYPE
+                    })
+                {
                     let bot_name = match bot_names.entry(pm.sender_id.clone()) {
                         std::collections::hash_map::Entry::Occupied(e) => e.get().clone(),
                         std::collections::hash_map::Entry::Vacant(e) => {
@@ -698,7 +721,8 @@ mod tests {
             PrepareUploadResult, SessionFileService, SessionFileUseCaseError, ShareConsumeResult,
             ShareMintCommand, ShareMintResult,
         },
-        CallerContext, Group, MessageRole, Participant, ParticipantRole, SessionKind,
+        BotActor, CallerContext, Group, HumanActor, MessageRole, Participant, ParticipantRole,
+        SessionKind,
         port::repo::{
             MessageRepoError, NewSessionParams, SessionFileListPage, SessionFileListParams,
             SessionRepoPort,
@@ -1168,6 +1192,76 @@ mod tests {
                 .and_then(|metadata| metadata["state_machine"]["event"].as_str()),
             Some("panel")
         );
+    }
+
+    #[tokio::test]
+    async fn session_opening_message_is_visible_to_humans_and_hidden_from_bots() {
+        let (service, repo, _sessions, fallback, session_id) =
+            service_fixture(GroupStrategy::Chat, 0, u64::MAX, Vec::new()).await;
+        let stable_message_id = format!("{session_id}:000-opening");
+        repo.append_message(NewMessage {
+            group_id: "group-1".to_string(),
+            session_id: session_id.clone(),
+            sender_id: bcs_domain::BCS_SESSION_OPENING_MESSAGE_SENDER.to_string(),
+            sender_type: SenderType::Bot,
+            message_type: SESSION_OPENING_MESSAGE_TYPE.to_string(),
+            content: serde_json::json!({
+                "text": "欢迎来到研发群",
+                "bot_name": BCS_SESSION_OPENING_MESSAGE_SENDER_NAME,
+                "metadata": {
+                    "opening_message": {
+                        "scope": "session",
+                        "strategy": "chat",
+                    }
+                }
+            }),
+            client_msg_id: Some(stable_message_id.clone()),
+            created_at: 1,
+            run_id: format!("{session_id}:opening"),
+            owner_bot_id: None,
+        })
+        .await
+        .expect("append opening message");
+
+        let human_result = service
+            .get_session_history(SessionHistoryCommand {
+                caller: CallerContext::Human(HumanActor {
+                    actor_id: "human-1".to_string(),
+                    staff_no: "human-1".to_string(),
+                }),
+                group_id: "group-1".to_string(),
+                session_id: session_id.clone(),
+                session_participants: Vec::new(),
+                view_bot_id: None,
+                limit: 50,
+                before: None,
+            })
+            .await
+            .expect("human history");
+        assert_eq!(human_result.messages.len(), 1);
+        assert_eq!(human_result.messages[0].id, stable_message_id);
+        assert_eq!(human_result.messages[0].content, "欢迎来到研发群");
+        assert_eq!(
+            human_result.messages[0].bot_name.as_deref(),
+            Some(BCS_SESSION_OPENING_MESSAGE_SENDER_NAME)
+        );
+
+        let bot_result = service
+            .get_session_history(SessionHistoryCommand {
+                caller: CallerContext::Bot(BotActor {
+                    bot_uuid: "worker-a".to_string(),
+                }),
+                group_id: "group-1".to_string(),
+                session_id,
+                session_participants: Vec::new(),
+                view_bot_id: Some("worker-a".to_string()),
+                limit: 50,
+                before: None,
+            })
+            .await
+            .expect("bot history");
+        assert!(bot_result.messages.is_empty());
+        assert_eq!(fallback.session_calls().await, 0);
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-session/Cargo.toml
+++ b/src/bcs/crates/services/bcs-session/Cargo.toml
@@ -22,6 +22,7 @@ uuid = { workspace = true }
 bcs-bot = { workspace = true }
 bcs-group = { workspace = true }
 bcs-group-store = { workspace = true }
+bcs-message-store = { workspace = true }
 bcs-test-support = { workspace = true }
 tokio = { workspace = true }
 tokio-test = "0.4"

--- a/src/bcs/crates/services/bcs-session/src/application.rs
+++ b/src/bcs/crates/services/bcs-session/src/application.rs
@@ -2,8 +2,13 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
+use bcs_domain::{
+    BCS_SESSION_OPENING_MESSAGE_SENDER, BCS_SESSION_OPENING_MESSAGE_SENDER_NAME, NewMessage,
+    OpeningMessageRenderContext, SESSION_OPENING_MESSAGE_TYPE, SenderType,
+};
 
 use bcs_service_api::application::session::{
     ClaimSessionCallbackCommand, ClaimSessionCallbackOutcome,
@@ -14,9 +19,12 @@ use bcs_service_api::core::session::new_session_id;
 use bcs_service_api::port::repo::{
     AddSessionParticipantWithEvent, ClaimSessionCallback, CompleteSessionCallback,
     CompleteSessionWithEvent, CreateSessionWithEvent, GroupRepoPort,
-    RemoveSessionParticipantWithEvent, SessionRepoPort,
+    MessageRepoPort, RemoveSessionParticipantWithEvent, SessionRepoPort,
 };
-use bcs_service_api::port::{EventRecordFactoryPort, NewEvent};
+use bcs_service_api::port::{
+    EventRecordFactoryPort, FrontendDeliveryCommand, FrontendDeliveryKind, FrontendDeliveryPort,
+    FrontendDeliveryTarget, NewEvent,
+};
 use bcs_service_api::types::{EVENT_SCHEMA_VERSION_V1, EventScope, EventSubject};
 use bcs_service_api::{
     ActorKind, BotRuntimeConnectionService, CollaborationRuntimeService, GroupStrategy,
@@ -31,6 +39,8 @@ pub struct SessionManagementServiceImpl {
     group_repo: Arc<dyn GroupRepoPort>,
     bot_runtime: Option<Arc<dyn BotRuntimeConnectionService>>,
     event_record_factory: Option<Arc<dyn EventRecordFactoryPort>>,
+    message_repo: Option<Arc<dyn MessageRepoPort>>,
+    frontend_delivery: Option<Arc<dyn FrontendDeliveryPort>>,
 }
 
 pub struct SessionManagementWithRuntimeCleanup {
@@ -260,6 +270,8 @@ impl SessionManagementServiceImpl {
             group_repo,
             bot_runtime: None,
             event_record_factory: None,
+            message_repo: None,
+            frontend_delivery: None,
         }
     }
 
@@ -277,6 +289,154 @@ impl SessionManagementServiceImpl {
     ) -> Self {
         self.event_record_factory = Some(event_record_factory);
         self
+    }
+
+    pub fn with_opening_message_delivery(
+        mut self,
+        message_repo: Arc<dyn MessageRepoPort>,
+        frontend_delivery: Arc<dyn FrontendDeliveryPort>,
+    ) -> Self {
+        self.message_repo = Some(message_repo);
+        self.frontend_delivery = Some(frontend_delivery);
+        self
+    }
+
+    async fn persist_session_opening_message(
+        &self,
+        group: &bcs_service_api::Group,
+        session: &Session,
+    ) -> Result<(), SessionUseCaseError> {
+        if !matches!(
+            group.group_strategy,
+            GroupStrategy::Chat | GroupStrategy::ManagerWorker
+        ) {
+            return Ok(());
+        }
+        let Some(opening_message) = group.opening_message.as_ref() else {
+            return Ok(());
+        };
+        let Some(message_repo) = self.message_repo.as_ref() else {
+            return Err(SessionUseCaseError::Internal(ServiceError::InternalError(
+                "Session opening-message persistence is not configured".to_string(),
+            )));
+        };
+        let rendered = opening_message
+            .render(OpeningMessageRenderContext::Session {
+                group_id: &group.id,
+                session_id: &session.id,
+                group_name: group.label.as_deref(),
+                session_name: session.session_title.as_deref(),
+            })
+            .map_err(|error| {
+                SessionUseCaseError::Internal(ServiceError::InternalError(format!(
+                    "Failed to render opening_message for session '{}': {error}",
+                    session.id
+                )))
+            })?;
+        let strategy = match group.group_strategy {
+            GroupStrategy::Chat => "chat",
+            GroupStrategy::ManagerWorker => "manager_worker",
+            GroupStrategy::StateMachine => unreachable!("filtered above"),
+        };
+        let mut opening_metadata = serde_json::json!({
+            "scope": "session",
+            "strategy": strategy,
+        });
+        if let Some(component) = rendered.component.as_ref() {
+            opening_metadata["component"] = Value::String(component.clone());
+        }
+        let metadata = serde_json::json!({ "opening_message": opening_metadata });
+        let client_msg_id = format!("{}:000-opening", session.id);
+        let run_id = format!("{}:opening", session.id);
+        let persisted = message_repo
+            .append_message(NewMessage {
+                group_id: group.id.clone(),
+                session_id: session.id.clone(),
+                sender_id: BCS_SESSION_OPENING_MESSAGE_SENDER.to_string(),
+                sender_type: SenderType::Bot,
+                message_type: SESSION_OPENING_MESSAGE_TYPE.to_string(),
+                content: serde_json::json!({
+                    "text": rendered.content,
+                    "bot_name": BCS_SESSION_OPENING_MESSAGE_SENDER_NAME,
+                    "metadata": metadata,
+                }),
+                client_msg_id: Some(client_msg_id),
+                owner_bot_id: None,
+                created_at: session.created_at,
+                run_id: run_id.clone(),
+            })
+            .await
+            .map_err(|error| {
+                SessionUseCaseError::Internal(ServiceError::InternalError(format!(
+                    "Failed to persist opening_message for session '{}': {error}",
+                    session.id
+                )))
+            })?;
+
+        let Some(frontend_delivery) = self.frontend_delivery.as_ref() else {
+            return Ok(());
+        };
+        let content = persisted
+            .content
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let metadata = persisted
+            .content
+            .get("metadata")
+            .cloned()
+            .unwrap_or(Value::Null);
+        let payload = serde_json::json!({
+            "run_id": persisted.run_id,
+            "bcs_group_id": persisted.group_id,
+            "bcs_session_id": persisted.session_id,
+            "state": "final",
+            "role": "assistant",
+            "sender": BCS_SESSION_OPENING_MESSAGE_SENDER,
+            "content": content.clone(),
+            "message_type": "bot",
+            "bot_name": BCS_SESSION_OPENING_MESSAGE_SENDER_NAME,
+            "metadata": metadata,
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": content}],
+                "timestamp": persisted.created_at,
+            },
+        });
+        let frame = serde_json::json!({
+            "type": "event",
+            "event": "chat",
+            "payload": payload,
+            "group_id": group.id,
+            "bot_uuid": BCS_SESSION_OPENING_MESSAGE_SENDER,
+        });
+        match tokio::time::timeout(
+            Duration::from_millis(500),
+            frontend_delivery.publish(FrontendDeliveryCommand {
+                target: FrontendDeliveryTarget::Session {
+                    session_id: session.id.clone(),
+                },
+                event_json: frame.to_string(),
+                delivery_kind: FrontendDeliveryKind::WorkbenchEvent,
+                run_fallback: None,
+                exclude_conn_id: None,
+            }),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {}
+            Ok(Err(error)) => tracing::warn!(
+                session_id = %session.id,
+                error = %error,
+                "failed to publish persisted session opening message"
+            ),
+            Err(_) => tracing::warn!(
+                session_id = %session.id,
+                "timed out publishing persisted session opening message"
+            ),
+        }
+        Ok(())
     }
 
     fn prepare_event(
@@ -363,10 +523,9 @@ impl SessionManagementService for SessionManagementServiceImpl {
                 &cmd.params.participants,
             )
             .await?;
-            let group_is_provisioning = self
-                .group_repo
-                .try_get(&cmd.group_id)
-                .await?
+            let group = self.group_repo.try_get(&cmd.group_id).await?;
+            let group_is_provisioning = group
+                .as_ref()
                 .is_some_and(|group| group.record_status == "provisioning");
             let mut params = cmd.params;
             let session = if group_is_provisioning || self.event_record_factory.is_none() {
@@ -413,6 +572,39 @@ impl SessionManagementService for SessionManagementServiceImpl {
                     None => self.repo.create(&cmd.group_id, params).await?,
                 }
             };
+            if let Some(group) = group.as_ref() {
+                if let Err(opening_error) = self
+                    .persist_session_opening_message(group, &session)
+                    .await
+                {
+                    let opening_error_message = opening_error.to_string();
+                    let compensation_reason =
+                        Some("opening_message_persistence_failed".to_string());
+                    let compensation_result = if group_is_provisioning {
+                        self.repo
+                            .complete_if_running(&session.id, None, compensation_reason)
+                            .await
+                            .map_err(SessionUseCaseError::from)
+                    } else {
+                        SessionManagementService::complete_if_running(
+                            self,
+                            &session.id,
+                            None,
+                            compensation_reason,
+                        )
+                        .await
+                    };
+                    if let Err(compensation_error) = compensation_result {
+                        return Err(SessionUseCaseError::Internal(
+                            ServiceError::InternalError(format!(
+                                "{opening_error_message}; failed to compensate session '{}': {compensation_error}",
+                                session.id
+                            )),
+                        ));
+                    }
+                    return Err(opening_error);
+                }
+            }
             Ok(CreateOrReactivateOutcome {
                 session,
                 created: true,

--- a/src/bcs/crates/services/bcs-session/tests/conformance_session_services.rs
+++ b/src/bcs/crates/services/bcs-session/tests/conformance_session_services.rs
@@ -6,16 +6,48 @@ use bcs_service_api::application::session::{
 use std::collections::HashSet;
 
 use async_trait::async_trait;
-use bcs_service_api::port::repo::{GroupRepoPort, NewSessionParams, SessionRepoPort};
+use bcs_domain::{
+    MessageOwnerFilter, MessagePage, MessageQuery, NewMessage, OpeningMessage, PersistedMessage,
+    SESSION_OPENING_MESSAGE_TYPE,
+};
+use bcs_service_api::port::repo::{
+    GroupRepoPort, MessageRepoError, MessageRepoPort, NewSessionParams, SessionRepoPort,
+};
 use bcs_service_api::{
     BotDeliveryTarget, BotRuntimeConnectCommand, BotRuntimeConnectOutcome,
     BotRuntimeConnectionService, BotRuntimeDisconnectCommand, BotRuntimeStatusCommand,
-    BotRuntimeStatusOutcome, BotUseCaseError, Group, GroupStrategy, Participant, ParticipantRole,
-    ParticipantMode, ServiceError, ServiceResult, Session, SessionKind, SessionStatus,
+    BotRuntimeStatusOutcome, BotUseCaseError, FrontendDeliveryCommand, FrontendDeliveryPort,
+    FrontendDeliveryResult, Group, GroupStrategy, Participant, ParticipantMode, ParticipantRole,
+    ServiceError, ServiceResult, Session, SessionKind, SessionStatus,
 };
 use bcs_group_store::MemoryGroupRepo;
+use bcs_message_store::MemoryMessageRepo;
 use bcs_session::{NoopSessionManagementService, SessionManagementServiceImpl};
 use bcs_session_store::MemorySessionRepo;
+use tokio::sync::Mutex;
+
+#[derive(Default)]
+struct RecordingFrontendDelivery {
+    commands: Mutex<Vec<FrontendDeliveryCommand>>,
+}
+
+#[async_trait]
+impl FrontendDeliveryPort for RecordingFrontendDelivery {
+    async fn publish(
+        &self,
+        command: FrontendDeliveryCommand,
+    ) -> ServiceResult<FrontendDeliveryResult> {
+        self.commands.lock().await.push(command.clone());
+        Ok(FrontendDeliveryResult {
+            target: command.target,
+            delivered: 1,
+        })
+    }
+
+    async fn unregister_run(&self, _run_id: &str) -> ServiceResult<()> {
+        Ok(())
+    }
+}
 
 fn participants() -> Vec<Participant> {
     vec![Participant::bot("bot1", ParticipantRole::Driver)]
@@ -29,6 +61,39 @@ fn manager_worker_participants(worker_id: &str) -> Vec<Participant> {
 }
 
 struct FailingMembershipSessionRepo;
+
+struct FailingMessageRepo;
+
+#[async_trait]
+impl MessageRepoPort for FailingMessageRepo {
+    async fn append_message(
+        &self,
+        _message: NewMessage,
+    ) -> Result<PersistedMessage, MessageRepoError> {
+        Err(MessageRepoError::StorageError(
+            "opening message write failed".to_string(),
+        ))
+    }
+
+    async fn query_messages(
+        &self,
+        _query: MessageQuery,
+    ) -> Result<MessagePage, MessageRepoError> {
+        unimplemented!("not used by persistence failure test")
+    }
+
+    async fn get_message_by_id(
+        &self,
+        _session_id: &str,
+        _message_id: &str,
+    ) -> Result<Option<PersistedMessage>, MessageRepoError> {
+        unimplemented!("not used by persistence failure test")
+    }
+
+    async fn get_current_seq(&self, _session_id: &str) -> Result<i64, MessageRepoError> {
+        unimplemented!("not used by persistence failure test")
+    }
+}
 
 #[async_trait]
 impl SessionRepoPort for FailingMembershipSessionRepo {
@@ -180,6 +245,183 @@ async fn impl_creates_chat_session() {
         .expect("create chat ok");
     assert!(outcome.created);
     assert_eq!(outcome.session.status, SessionStatus::Running);
+}
+
+#[tokio::test]
+async fn impl_persists_and_publishes_chat_opening_message_once() {
+    let repo = Arc::new(MemorySessionRepo::new());
+    let group_repo = Arc::new(MemoryGroupRepo::new());
+    let message_repo = Arc::new(MemoryMessageRepo::new());
+    let frontend_delivery = Arc::new(RecordingFrontendDelivery::default());
+    let mut group = Group::new("g1", "bot1", participants());
+    group.label = Some("研发群".to_string());
+    group.opening_message = Some(OpeningMessage::Text(
+        "欢迎来到 {{bcs.group_name}} / {{bcs.session_name}} / {{bcs.session_id}}".to_string(),
+    ));
+    group_repo.upsert(group).await.expect("seed group");
+    let svc = SessionManagementServiceImpl::new(repo, group_repo)
+        .with_opening_message_delivery(message_repo.clone(), frontend_delivery.clone());
+
+    let outcome = svc
+        .create_or_reactivate(CreateOrReactivateCommand {
+            group_id: "g1".to_string(),
+            session_id: None,
+            params: NewSessionParams {
+                session_title: Some("第一轮".to_string()),
+                session_kind: SessionKind::ServiceInvocation,
+                participants: participants(),
+                ..Default::default()
+            },
+        })
+        .await
+        .expect("create chat with opening message");
+    let session_id = outcome.session.id.clone();
+    let page = message_repo
+        .query_messages(MessageQuery {
+            group_id: "g1".to_string(),
+            session_id: session_id.clone(),
+            cursor: None,
+            limit: 10,
+            keyword: None,
+            sender_id: None,
+            message_type: None,
+            owner_filter: MessageOwnerFilter::Any,
+            time_range: None,
+            visible_from_seq: None,
+        })
+        .await
+        .expect("query opening message");
+    assert_eq!(page.messages.len(), 1);
+    assert_eq!(
+        page.messages[0].message_type,
+        SESSION_OPENING_MESSAGE_TYPE
+    );
+    assert_eq!(
+        page.messages[0].content["text"],
+        format!("欢迎来到 研发群 / 第一轮 / {session_id}")
+    );
+    assert_eq!(frontend_delivery.commands.lock().await.len(), 1);
+
+    svc.complete_if_running(&session_id, None, None)
+        .await
+        .expect("complete session");
+    svc.update_callback_status(&session_id, "success")
+        .await
+        .expect("complete callback");
+    svc.create_or_reactivate(CreateOrReactivateCommand {
+        group_id: "g1".to_string(),
+        session_id: Some(session_id.clone()),
+        params: NewSessionParams::default(),
+    })
+    .await
+    .expect("reactivate session");
+    let page = message_repo
+        .query_messages(MessageQuery {
+            group_id: "g1".to_string(),
+            session_id,
+            cursor: None,
+            limit: 10,
+            keyword: None,
+            sender_id: None,
+            message_type: None,
+            owner_filter: MessageOwnerFilter::Any,
+            time_range: None,
+            visible_from_seq: None,
+        })
+        .await
+        .expect("query after reactivation");
+    assert_eq!(page.messages.len(), 1);
+    assert_eq!(frontend_delivery.commands.lock().await.len(), 1);
+}
+
+#[tokio::test]
+async fn impl_persists_manager_worker_opening_message() {
+    let repo = Arc::new(MemorySessionRepo::new());
+    let group_repo = Arc::new(MemoryGroupRepo::new());
+    let message_repo = Arc::new(MemoryMessageRepo::new());
+    let frontend_delivery = Arc::new(RecordingFrontendDelivery::default());
+    let participants = manager_worker_participants("worker");
+    let mut group = Group::new("mw", "manager", participants.clone());
+    group.group_strategy = GroupStrategy::ManagerWorker;
+    group.opening_message = Some(OpeningMessage::Text(
+        "任务会话 {{bcs.session_id}}".to_string(),
+    ));
+    group_repo.upsert(group).await.expect("seed group");
+    let svc = SessionManagementServiceImpl::new(repo, group_repo)
+        .with_opening_message_delivery(message_repo.clone(), frontend_delivery.clone());
+
+    let outcome = svc
+        .create_or_reactivate(CreateOrReactivateCommand {
+            group_id: "mw".to_string(),
+            session_id: None,
+            params: NewSessionParams {
+                session_kind: SessionKind::Chat,
+                participants,
+                ..Default::default()
+            },
+        })
+        .await
+        .expect("create Manager-Worker session");
+    let page = message_repo
+        .query_messages(MessageQuery {
+            group_id: "mw".to_string(),
+            session_id: outcome.session.id.clone(),
+            cursor: None,
+            limit: 10,
+            keyword: None,
+            sender_id: None,
+            message_type: None,
+            owner_filter: MessageOwnerFilter::Any,
+            time_range: None,
+            visible_from_seq: None,
+        })
+        .await
+        .expect("query opening message");
+    assert_eq!(page.messages.len(), 1);
+    assert_eq!(
+        page.messages[0].content["text"],
+        format!("任务会话 {}", outcome.session.id)
+    );
+    assert_eq!(
+        page.messages[0].content["metadata"]["opening_message"]["strategy"],
+        "manager_worker"
+    );
+    assert_eq!(frontend_delivery.commands.lock().await.len(), 1);
+}
+
+#[tokio::test]
+async fn impl_fails_and_completes_new_session_when_opening_message_persistence_fails() {
+    let repo = Arc::new(MemorySessionRepo::new());
+    let group_repo = Arc::new(MemoryGroupRepo::new());
+    let mut group = Group::new("g1", "bot1", participants());
+    group.opening_message = Some(OpeningMessage::Text("欢迎".to_string()));
+    group_repo.upsert(group).await.expect("seed group");
+    let svc = SessionManagementServiceImpl::new(repo.clone(), group_repo)
+        .with_opening_message_delivery(
+            Arc::new(FailingMessageRepo),
+            Arc::new(RecordingFrontendDelivery::default()),
+        );
+
+    let error = svc
+        .create_or_reactivate(CreateOrReactivateCommand {
+            group_id: "g1".to_string(),
+            session_id: None,
+            params: NewSessionParams {
+                session_kind: SessionKind::Chat,
+                participants: participants(),
+                ..Default::default()
+            },
+        })
+        .await
+        .expect_err("opening-message persistence must fail session creation");
+    assert!(error.to_string().contains("opening message write failed"));
+    let sessions = repo.list_by_group("g1", None, 0, 10, None, None).await;
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].status, SessionStatus::Completed);
+    assert_eq!(
+        sessions[0].error_message.as_deref(),
+        Some("opening_message_persistence_failed")
+    );
 }
 
 #[tokio::test]

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/repo/mod.rs
@@ -410,6 +410,17 @@ pub async fn event_delivery_repo_port_contract_tests<T: EventRepoPort + ?Sized>(
         .lease_owner
         .clone()
         .expect("claimed Delivery lease owner");
+    let (_, in_flight_attempts) = repo
+        .get_delivery(&first_delivery.delivery_id, &env)
+        .await
+        .expect("read claimed Delivery")
+        .expect("claimed Delivery exists");
+    assert_eq!(in_flight_attempts.len(), 1);
+    assert_eq!(in_flight_attempts[0].attempt_no, 1);
+    assert_eq!(in_flight_attempts[0].started_at_ms, BASE + 20);
+    assert_eq!(in_flight_attempts[0].completed_at_ms, None);
+    assert_eq!(in_flight_attempts[0].result, None);
+    assert_eq!(in_flight_attempts[0].worker_id, "delivery-a");
     let renewed = repo
         .renew_delivery_lease(RenewEventDeliveryLease {
             delivery_id: first_delivery.delivery_id.clone(),
@@ -504,6 +515,14 @@ pub async fn event_delivery_repo_port_contract_tests<T: EventRepoPort + ?Sized>(
     assert_eq!(first_attempts.len(), 2);
     assert_eq!(first_attempts[0].attempt_no, 1);
     assert_eq!(first_attempts[1].attempt_no, 2);
+    assert_eq!(
+        first_attempts[0].result,
+        Some(EventDeliveryAttemptRecordResult::Retryable)
+    );
+    assert_eq!(
+        first_attempts[1].result,
+        Some(EventDeliveryAttemptRecordResult::Success)
+    );
     assert!(
         repo.list_deliveries(ListEventDeliveryRecords {
             subscription_id: Some(subscription_id.clone()),
@@ -543,6 +562,23 @@ pub async fn event_delivery_repo_port_contract_tests<T: EventRepoPort + ?Sized>(
         .expect("recover expired Delivery lease");
     assert_eq!(recovered.len(), 1);
     assert_eq!(recovered[0].attempt_count, 2);
+    let (_, recovered_attempts) = repo
+        .get_delivery(&second_delivery.delivery_id, &env)
+        .await
+        .expect("read recovered Delivery")
+        .expect("recovered Delivery exists");
+    assert_eq!(recovered_attempts.len(), 2);
+    assert_eq!(recovered_attempts[0].completed_at_ms, Some(BASE + 81));
+    assert_eq!(
+        recovered_attempts[0].result,
+        Some(EventDeliveryAttemptRecordResult::Retryable)
+    );
+    assert_eq!(
+        recovered_attempts[0].error_category.as_deref(),
+        Some("lease_expired")
+    );
+    assert_eq!(recovered_attempts[1].completed_at_ms, None);
+    assert_eq!(recovered_attempts[1].result, None);
     assert!(matches!(
         repo.complete_delivery_attempt(completion(
             &crashed[0],

--- a/src/bcs/docs/custom-collaboration-opening-message-integration-guide.md
+++ b/src/bcs/docs/custom-collaboration-opening-message-integration-guide.md
@@ -1,22 +1,32 @@
 # BCS 自定义协作开场白控制副屏接入指南
 
-本文面向接入 BCS 自定义协作群的系统，说明如何在建群时指定开场消息，并在每次
-StateMachine Run 开始时打开自定义副屏。
+本文面向接入 BCS 自定义协作群的系统，说明如何在建群时指定开场消息。Chat 和
+ManagerWorker 在新 Session 创建时展示一次；StateMachine 在每次 Run 开始时展示一次。
 
 ## 1. 接入范围
 
-该能力当前仅适用于：
+该能力适用于：
 
 - `group_kind` 为 `normal`；
-- `collaboration.strategy` 为 `state_machine`；
+- `collaboration.strategy` 为 `chat`、`manager_worker` 或 `state_machine`；
 - 前端已经通过现有 AixUI 组件注册机制注册目标副屏组件。
 
-Chat、ManagerWorker 和 DM 群暂不支持 `opening_message`。不配置该字段时，BCS 继续打开默认的
-`bcsPanel.StateMachineRunView` 副屏。
+DM 群不支持 `opening_message`。Chat 和 ManagerWorker 不配置时不展示开场白；StateMachine
+不配置时继续打开默认的 `bcsPanel.StateMachineRunView` 副屏。
 
 ## 2. 工作方式
 
-每次 StateMachine Run 开始时，BCS 按以下顺序处理：
+Chat 和 ManagerWorker 在新 Session 创建时，BCS 按以下顺序处理：
+
+1. 生成 Session ID；
+2. 使用 Group 和 Session 信息渲染 `opening_message`；
+3. 将渲染后的最终消息持久化到 Session 消息历史；
+4. 将同一条消息发送给当前前端连接。
+
+开场白不会发送给 Bot，并且会从 Bot 的历史/上下文回放中排除。Session 重连、重新激活、成员加入和
+页面刷新不会创建第二条开场白。页面刷新直接读取已经持久化的最终消息，不使用 Group 当前配置重新渲染。
+
+StateMachine 每次 Run 开始时，BCS 按以下顺序处理：
 
 1. 生成本次执行的 Group ID、Session ID 和 Run ID；
 2. 使用这些运行信息渲染 Group 上配置的 `opening_message`；
@@ -161,13 +171,13 @@ BCS 不负责下载或注册业务组件。
 
 ## 5. 模板变量
 
-一期支持以下大小写敏感的完整占位符：
+支持以下大小写敏感的完整占位符：
 
 | 变量 | 渲染值 |
 | --- | --- |
 | `{{bcs.group_id}}` | 当前 Group ID |
 | `{{bcs.session_id}}` | 当前 Session ID |
-| `{{bcs.run_id}}` | 当前 StateMachine Run ID |
+| `{{bcs.run_id}}` | 当前 StateMachine Run ID；仅 `state_machine` 可用 |
 | `{{bcs.group_name}}` | 当前 Group 名称；未命名时为空字符串 |
 | `{{bcs.session_name}}` | 当前 Session 名称；未命名时为空字符串 |
 
@@ -182,7 +192,7 @@ BCS 不负责下载或注册业务组件。
 
 ## 6. 更新或恢复默认开场消息
 
-修改已经存在的 StateMachine Group：
+修改已经存在的 Normal Group：
 
 ```http
 PATCH /openapi/v1/collaboration/groups/{group_id}
@@ -216,8 +226,8 @@ Content-Type: application/json
 }
 ```
 
-PATCH 请求省略 `opening_message` 表示不修改。更新只影响随后开始的 Run；已经开始的 Run 以及已经
-持久化的历史开场消息不会变化。
+PATCH 请求省略 `opening_message` 表示不修改。更新只影响随后创建的 Session（Chat、ManagerWorker）
+或随后开始的 Run（StateMachine）；已经持久化的历史开场消息不会变化。
 
 ## 7. 前端接入要求
 
@@ -241,7 +251,7 @@ GET /openapi/v1/collaboration/sessions/{session_id}/messages
 ```
 
 Group detail 返回原始模板；Session messages 返回已经完成变量替换的最终消息。不要使用 Group 当前
-配置重新推导旧 Run 的副屏内容。
+配置重新推导旧 Session 或 Run 的副屏内容。
 
 ## 8. 校验规则和错误处理
 
@@ -253,7 +263,8 @@ Group detail 返回原始模板；Session messages 返回已经完成变量替�
 
 错误码为 `invalid_opening_message`。常见原因包括：
 
-- Group 不是 StateMachine Group；
+- Group 是 DM Group；
+- Chat 或 ManagerWorker 使用了 `{{bcs.run_id}}`；
 - 字符串为空或只包含空白；
 - 使用了未知模板变量；
 - 模板变量缺少结束的 `}}`；

--- a/src/bcs/docs/superpowers/plans/2026-08-20-bcs-event-subscription-webhook-manual-verification.md
+++ b/src/bcs/docs/superpowers/plans/2026-08-20-bcs-event-subscription-webhook-manual-verification.md
@@ -665,8 +665,9 @@ failpoint 后同一请求正常成功。不得在共享数据库执行。
 
 分别在 pending、retry_wait，以及 Receiver 已收请求但尚未响应时终止 BCS，再用同一数据库和 env 启动。
 
-预期：lease 到期后未完成 Delivery 恢复，不永久丢失或卡死；最后一种场景允许重复 Attempt，Receiver 通过 event_id
-去重。已 succeeded 的 Delivery 不应因普通重启重新投递。
+预期：领取后立即存在 `completed_at/result` 为空的 Attempt；lease 到期后未完成 Delivery 恢复，不永久丢失或卡死，
+上一条 Attempt 被补记为 `retryable`、`error_category=lease_expired`，错误摘要说明远端结果未知，并创建新的执行中
+Attempt。最后一种场景允许重复请求，Receiver 通过 event_id 去重。已 succeeded 的 Delivery 不应因普通重启重新投递。
 
 ### MV-32 多实例 claim、lease heartbeat 和并发限制（P1，MySQL）
 

--- a/src/bcs/docs/superpowers/specs/2026-08-18-bcs-event-subscription-webhook-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-18-bcs-event-subscription-webhook-design.md
@@ -870,7 +870,12 @@ pending
 ```
 
 - worker 通过有期限 lease 领取 Delivery；
+- 领取 Delivery、递增 `attempt_count` 和创建对应 Attempt 必须在同一事务内完成；新 Attempt 立即记录
+  `started_at`、`worker_id`，执行期间 `completed_at`、`latency_ms` 和 `result` 为空；
+- HTTP 结束后必须在同一事务内更新既有 Attempt 和 Delivery，不能到完成时才创建 Attempt；
 - 进程退出或崩溃后，lease 到期可由其他实例恢复；
+- 恢复过期 lease 时，上一条未完成 Attempt 记为 `retryable`，`error_category=lease_expired`，并明确远端
+  处理结果未知，然后创建下一条 Attempt；
 - 同一 Delivery 同时只能有一个有效 lease；
 - lease 不能提供 exactly-once，因此 receiver 仍必须去重；
 - strict lane 只允许领取 head Delivery。
@@ -1392,12 +1397,16 @@ revision 下重新投影 canonical Event，生成新的 Delivery 和 payload；�
 | 字段 | 说明 |
 | --- | --- |
 | `(delivery_id, attempt_no)` PK | Attempt |
-| `started_at`, `completed_at`, `latency_ms` | 时间 |
-| `result` | success/retryable/terminal |
+| `started_at`, `completed_at`, `latency_ms` | 时间；后两项在 Attempt 执行中可空 |
+| `result` | success/retryable/terminal；Attempt 执行中可空 |
 | `http_status` | 可空 HTTP status |
 | `error_category`, `error_summary` | 脱敏错误 |
 | `response_bytes_observed` | 诊断大小，不存原 body |
 | `worker_id` | 领取 worker |
+
+Delivery 详情允许返回执行中的 Attempt；此时只保证 `attempt_no`、`started_at` 和 `worker_id` 已持久化，完成时间、
+耗时和结果字段省略。这样即使 Worker 在 HTTP 返回或完成事务之前退出，也能审计该次尝试；后续租约恢复会补齐
+`lease_expired` 诊断，但不能推断远端是否已经处理请求。
 
 ### 18.9 Message schema 变更
 

--- a/src/bcs/docs/superpowers/specs/2026-08-21-bcs-custom-opening-message-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-21-bcs-custom-opening-message-design.md
@@ -4,6 +4,10 @@
 - 状态：已实现，待人工联调验收
 - 范围：Normal StateMachine Group 的创建、更新、Run 开场消息、历史查询和前端高级设置
 
+> 2026-08-27 补充：Chat 和 ManagerWorker 的 Session 级行为由
+> `2026-08-27-bcs-session-opening-message-design.md` 扩展并作为对应策略的权威定义；本文的
+> StateMachine Run 行为保持不变。
+
 ## 1. 背景
 
 自定义协作群目前在每次 StateMachine Run 开始时固定生成以下 AixUI 消息：
@@ -204,10 +208,9 @@ V1 和兼容路由必须在同一版本具备相同行为，不能只更新 Open
 
 约束：
 
-- `opening_message` 仅允许用于 `group_kind=normal` 且
-  `group_strategy/collaboration.strategy=state_machine`；
-- DM、Chat 和 ManagerWorker 请求携带该字段时返回 `400 invalid_opening_message`；
-- 省略或传 `null` 表示使用默认开场消息；
+- `opening_message` 仅允许用于 `group_kind=normal`；
+- DM 请求携带该字段时返回 `400 invalid_opening_message`；
+- 省略或传 `null` 时，StateMachine 使用默认开场消息，Chat 和 ManagerWorker 不展示开场白；
 - 空字符串或仅包含空白字符的字符串无明确展示意义，返回 `400 invalid_opening_message`。
 
 ### 6.3 更新 Group
@@ -229,9 +232,8 @@ V1 和兼容 `PATCH /groups/{group_id}` 增加三态字段：
 省略 `opening_message` 表示不修改。Service API 和 repo patch 必须保留这三个状态，不能使用单层
 `Option<OpeningMessage>` 混淆“未提供”和“清除”。
 
-只有现有 Group 管理者可以修改该字段，沿用当前 Group PATCH 授权逻辑。非 StateMachine、DM 或不存在
-的 Group 按现有资源隐藏和错误映射处理；对可见但策略不支持的 Group 返回
-`400 invalid_opening_message`。
+只有现有 Group 管理者可以修改该字段，沿用当前 Group PATCH 授权逻辑。DM 或不存在的 Group 按现有
+资源隐藏和错误映射处理。
 
 ### 6.4 查询 Group
 
@@ -249,7 +251,7 @@ Group detail 在存在自定义值时返回 `opening_message`；未配置时省�
 | --- | --- | --- |
 | `{{bcs.group_id}}` | `Group.id` | 无；运行时必须存在 |
 | `{{bcs.session_id}}` | `Session.id` | 无；运行时必须存在 |
-| `{{bcs.run_id}}` | `StateMachineRun.run_id` | 无；运行时必须存在 |
+| `{{bcs.run_id}}` | `StateMachineRun.run_id` | 仅 StateMachine 可用；运行时必须存在 |
 | `{{bcs.group_name}}` | `Group.label` | 空字符串 |
 | `{{bcs.session_name}}` | `Session.session_title` | 空字符串 |
 
@@ -265,9 +267,9 @@ Group detail 在存在自定义值时返回 `opening_message`；未配置时省�
    文本安全传给 `params` 或 `tab`。
 6. 一期不定义占位符转义语法。普通 JSON 的单花括号不受影响。
 
-因为 Group 策略在写入时已知，一期 StateMachine Group 的 `group_id`、`session_id` 和 `run_id` 在
-渲染时都必须存在。未来其他策略启用 `opening_message` 时，必须另外定义触发时机和可用变量，不能把
-不存在的 `run_id` 静默替换为空字符串。
+因为 Group 策略在写入时已知，StateMachine 的 `group_id`、`session_id` 和 `run_id` 在渲染时都必须
+存在。Chat 和 ManagerWorker 使用 Session 作用域，只支持除 `run_id` 外的四个变量；对这两种策略引用
+`run_id` 会在创建或更新时被拒绝，不会静默替换为空字符串。
 
 ## 8. 内容生成
 
@@ -466,12 +468,12 @@ pub opening_message: Option<Option<OpeningMessage>>,
 
 1. 创建群弹层增加一个“高级设置”折叠区，初始状态为折叠。
 2. 现有 Webhook URL 从成员 Bot 上方移入“高级设置”，默认留空；折叠和展开不得清除用户已输入的值。
-3. `opening_message` 与 Webhook URL 放在同一“高级设置”区域，默认留空；只有选择
-   StateMachine 自定义协作策略时显示开场白输入，其他策略不显示也不发送该字段。
+3. `opening_message` 与 Webhook URL 放在同一“高级设置”区域，默认留空；Chat、ManagerWorker 和
+   StateMachine 都显示开场白输入并发送非空字段。
 4. 开场白使用支持多行的 textarea。普通用户输入按字符串模板发送；留空时不传
-   `opening_message`，由服务端使用默认副屏。
-5. UI 提示可用变量，变量名统一为 `{{bcs.group_id}}`、`{{bcs.session_id}}`、
-   `{{bcs.run_id}}`、`{{bcs.group_name}}` 和 `{{bcs.session_name}}`。
+   `opening_message`。StateMachine 由服务端使用默认副屏，Chat 和 ManagerWorker 不展示开场白。
+5. UI 提示可用变量，三种策略均支持 `{{bcs.group_id}}`、`{{bcs.session_id}}`、
+   `{{bcs.group_name}}` 和 `{{bcs.session_name}}`；仅 StateMachine 显示并支持 `{{bcs.run_id}}`。
 6. “高级设置”的展开状态不属于建群请求；关闭或成功提交弹层并 reset form 后恢复为折叠状态，输入值也
    恢复为空。
 7. 折叠区中存在非空但校验失败的字段时，提交不得忽略错误；前端自动展开“高级设置”，展示字段级错误
@@ -520,7 +522,7 @@ pub opening_message: Option<Option<OpeningMessage>>,
 3. Legacy 创建请求接受相同字段并传入 Service API。
 4. V1 和 Legacy PATCH 区分省略、设置和 `null` 清除。
 5. detail 返回原始配置，summary 不返回。
-6. DM、Chat、ManagerWorker 携带字段时返回 `invalid_opening_message`。
+6. DM 携带字段时返回 `invalid_opening_message`；Chat、ManagerWorker 携带 `run_id` 时返回该错误。
 7. 未知对象字段、`position`、`card + tab`、未知变量和超限内容被拒绝。
 
 ### 16.2 模板渲染
@@ -581,15 +583,9 @@ pub opening_message: Option<Option<OpeningMessage>>,
 8. V1 与当前前端使用的 Legacy 建群接口行为一致。
 9. 前端 Webhook 和自定义开场白位于同一个默认折叠、默认留空的高级设置区域。
 
-## 18. 后续扩展条件
+## 18. Chat / ManagerWorker 扩展
 
-未来为 Chat 或 ManagerWorker Group 启用同一字段前，必须先定义：
-
-- 开场消息在 Group 创建、Session 创建还是任务开始时触发；
-- 是否每个 Session 只发送一次；
-- 哪些模板变量在该策略下存在；
-- 不存在 `run_id` 时是禁止引用还是提供新的策略变量；
-- 历史消息的确定性 ID 和幂等规则。
-
-届时沿用 `type=card|panel`，不再增加 `position`。只有出现两个以上明确需求时才扩展新的 AixUI 来源或
-展示方式，避免把一期实现演变成通用消息编排系统。
+Chat 和 ManagerWorker 的扩展条件已在
+`2026-08-27-bcs-session-opening-message-design.md` 中确认并批准。两种策略沿用
+`type=card|panel`，在新 Session 创建时持久化一次，禁止引用 `run_id`，并使用确定性的 Session
+开场消息 ID。该扩展不改变本设计定义的 StateMachine Run 行为。

--- a/src/bcs/docs/superpowers/specs/2026-08-27-bcs-session-opening-message-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-27-bcs-session-opening-message-design.md
@@ -1,0 +1,61 @@
+# BCS Session Opening Message Design
+
+**Status:** Approved
+**Date:** 2026-08-27
+**Scope:** BCS Chat and Manager-Worker collaboration sessions
+
+## Problem
+
+BCS already supports a group-level custom `opening_message` for StateMachine
+runs. Chat and Manager-Worker groups cannot configure the same experience, so
+their first screen cannot present instructions, a card, or a panel before the
+user sends a message.
+
+## Confirmed product semantics
+
+1. The rendered opening message is a real public session-history record in
+   `bcs_messages`.
+2. The opening message is a user-interface message. It is never delivered to a
+   Bot and is excluded from Bot history/context replay.
+3. Refresh restores the persisted rendered record. The frontend must not
+   re-render the current group configuration.
+
+## Behavior
+
+- `opening_message` is accepted for Normal groups using `chat`,
+  `manager_worker`, or `state_machine` strategies. Direct-message groups still
+  reject it.
+- Chat and Manager-Worker render the opening message once when a new session is
+  created. Reactivation, reconnect, participant join, and page refresh do not
+  create another record.
+- StateMachine keeps its existing run-scoped behavior and default opening panel.
+- Chat and Manager-Worker have no default opening message when the group omits
+  the configuration.
+- Session-scoped templates support `bcs.group_id`, `bcs.session_id`,
+  `bcs.group_name`, and `bcs.session_name`. `bcs.run_id` remains StateMachine
+  only and is rejected for Chat and Manager-Worker configuration.
+
+## Persistence and delivery
+
+- BCS renders from the group configuration at session creation and stores the
+  final rendered content as a public assistant message with a stable client
+  message ID.
+- Persistence succeeds before session creation is reported successful. On a
+  persistence failure, BCS completes the newly created session with an error
+  and reports the failure.
+- After persistence, BCS publishes the same persisted payload to the frontend.
+  Realtime delivery is best-effort because history is the recovery path.
+- Opening messages do not emit Bot delivery commands or `message.created`
+  domain events.
+
+## Acceptance criteria
+
+- Chat and Manager-Worker group create/update APIs accept valid custom opening
+  messages and reject `bcs.run_id`.
+- Creating a session persists and publishes exactly one rendered opening
+  message; reactivation does not duplicate it.
+- Human history returns the opening message after refresh while Bot history
+  omits it.
+- The creation UI offers opening-message configuration for all three Normal
+  strategies and applies the strategy-specific template-variable rules.
+- Existing StateMachine behavior remains compatible.

--- a/src/bcs/tests/openapi/test_event_subscription_v1_contract.py
+++ b/src/bcs/tests/openapi/test_event_subscription_v1_contract.py
@@ -112,6 +112,22 @@ def test_revision_cursor_and_status_contracts_are_explicit() -> None:
     assert set(skip["responses"]) >= {"200", "404", "409"}
 
 
+def test_in_flight_attempt_summary_requires_only_started_identity() -> None:
+    document = contract()
+    detail = document["paths"][
+        f"{BASE}/event-deliveries/{{delivery_id}}"
+    ]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+    attempt = detail["properties"]["data"]["properties"]["attempts"]["items"]
+    assert attempt["required"] == ["attempt_no", "started_at"]
+    assert {
+        "completed_at",
+        "latency_ms",
+        "result",
+        "http_status",
+        "error_category",
+    } <= set(attempt["properties"])
+
+
 def test_stable_event_error_vocabulary_is_declared() -> None:
     document = contract()
     declared = {

--- a/src/bcs/tests/openapi/test_group_v1_contract.py
+++ b/src/bcs/tests/openapi/test_group_v1_contract.py
@@ -167,7 +167,7 @@ def test_group_contract_keeps_the_approved_compatibility_surface() -> None:
     )
 
 
-def test_group_opening_message_contract_is_state_machine_scoped_and_nullable() -> None:
+def test_group_opening_message_contract_is_normal_group_scoped_and_nullable() -> None:
     contract = load_contract(CONTRACT_ROOT)
     request_variants = contract["paths"][GROUPS_PATH]["post"]["requestBody"][
         "content"

--- a/src/frontend/src/pages/GroupChat/components/CreateGroupModal.tsx
+++ b/src/frontend/src/pages/GroupChat/components/CreateGroupModal.tsx
@@ -1620,9 +1620,10 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
     const isManagerWorker = groupStrategy === 'manager_worker';
     const isStateMachine = groupStrategy === 'state_machine';
     const webhookUrlError = getGroupWebhookUrlError(webhookUrl);
-    const openingMessageError = isStateMachine
-      ? getGroupOpeningMessageError(openingMessage)
-      : undefined;
+    const openingMessageError = getGroupOpeningMessageError(
+      openingMessage,
+      groupStrategy,
+    );
 
     if (webhookUrlError || openingMessageError) {
       setAdvancedFieldErrors({
@@ -1854,6 +1855,7 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
         : undefined,
       group_strategy: groupStrategy,
       master_bot: isManagerWorker ? masterBot : undefined,
+      opening_message: buildGroupOpeningMessage(openingMessage),
       event_subscriptions: eventSubscriptions,
     };
 
@@ -2697,52 +2699,55 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
                       </p>
                     )}
                   </div>
-                  {groupStrategy === 'state_machine' && (
-                    <div>
-                      <label
-                        htmlFor="create-group-opening-message"
-                        className="mb-1 block text-sm font-medium text-slate-700"
-                      >
-                        自定义开场白
-                        <span className="ml-1 text-xs font-normal text-slate-400">
-                          （可选）
-                        </span>
-                      </label>
-                      <textarea
-                        ref={openingMessageInputRef}
-                        id="create-group-opening-message"
-                        rows={4}
-                        value={openingMessage}
-                        onChange={(event) => {
-                          setOpeningMessage(event.target.value);
-                          setAdvancedFieldErrors((current) => ({
-                            ...current,
-                            openingMessage: undefined,
-                          }));
-                        }}
-                        placeholder="协作群 {{bcs.group_name}} 已开始执行，Run ID：{{bcs.run_id}}"
-                        aria-invalid={Boolean(
-                          advancedFieldErrors.openingMessage
-                        )}
-                        className={cn(
-                          'w-full resize-y rounded-lg border bg-white px-3 py-2 text-sm text-slate-700 outline-none transition-colors placeholder:text-slate-400 focus:ring-2',
-                          advancedFieldErrors.openingMessage
-                            ? 'border-red-400 focus:border-red-400 focus:ring-red-100'
-                            : 'border-slate-200 focus:border-lavender-400 focus:ring-lavender-100',
-                        )}
-                      />
-                      <p className="mt-1 text-xs text-slate-400">
-                        支持 {'{{bcs.group_id}}'}、{'{{bcs.session_id}}'}、
-                        {'{{bcs.run_id}}'}、{'{{bcs.group_name}}'} 和
-                        {'{{bcs.session_name}}'}。
-                      </p>
-                      {advancedFieldErrors.openingMessage && (
-                        <p className="mt-1 text-xs text-red-500">
-                          {advancedFieldErrors.openingMessage}
-                        </p>
+                  <div>
+                    <label
+                      htmlFor="create-group-opening-message"
+                      className="mb-1 block text-sm font-medium text-slate-700"
+                    >
+                      自定义开场白
+                      <span className="ml-1 text-xs font-normal text-slate-400">
+                        （可选）
+                      </span>
+                    </label>
+                    <textarea
+                      ref={openingMessageInputRef}
+                      id="create-group-opening-message"
+                      rows={4}
+                      value={openingMessage}
+                      onChange={(event) => {
+                        setOpeningMessage(event.target.value);
+                        setAdvancedFieldErrors((current) => ({
+                          ...current,
+                          openingMessage: undefined,
+                        }));
+                      }}
+                      placeholder={
+                        groupStrategy === 'state_machine'
+                          ? '协作群 {{bcs.group_name}} 已开始执行，Run ID：{{bcs.run_id}}'
+                          : '欢迎来到 {{bcs.group_name}}，会话：{{bcs.session_name}}'
+                      }
+                      aria-invalid={Boolean(advancedFieldErrors.openingMessage)}
+                      className={cn(
+                        'w-full resize-y rounded-lg border bg-white px-3 py-2 text-sm text-slate-700 outline-none transition-colors placeholder:text-slate-400 focus:ring-2',
+                        advancedFieldErrors.openingMessage
+                          ? 'border-red-400 focus:border-red-400 focus:ring-red-100'
+                          : 'border-slate-200 focus:border-lavender-400 focus:ring-lavender-100',
                       )}
-                    </div>
-                  )}
+                    />
+                    <p className="mt-1 text-xs text-slate-400">
+                      支持 {'{{bcs.group_id}}'}、{'{{bcs.session_id}}'}、
+                      {'{{bcs.group_name}}'} 和 {'{{bcs.session_name}}'}
+                      {groupStrategy === 'state_machine' && (
+                        <>、{'{{bcs.run_id}}'}</>
+                      )}
+                      。
+                    </p>
+                    {advancedFieldErrors.openingMessage && (
+                      <p className="mt-1 text-xs text-red-500">
+                        {advancedFieldErrors.openingMessage}
+                      </p>
+                    )}
+                  </div>
                 </div>
               )}
             </div>

--- a/src/frontend/src/pages/GroupChat/types.ts
+++ b/src/frontend/src/pages/GroupChat/types.ts
@@ -224,7 +224,7 @@ export interface CreateGroupParams {
   auto_start_on_service_invocation?: boolean;
   /** 结构化协同定义 YAML（state_machine 群必填） */
   collaboration_definition_yaml?: string;
-  /** StateMachine Run 开场消息模板；留空时使用 BCS 默认副屏。 */
+  /** 自定义开场消息模板；StateMachine 留空时使用 BCS 默认副屏。 */
   opening_message?: string;
   /** 随建群创建的事件订阅；当前前端仅配置 Webhook URL */
   event_subscriptions?: Array<{

--- a/src/frontend/src/pages/GroupChat/utils/groupOpeningMessage.test.ts
+++ b/src/frontend/src/pages/GroupChat/utils/groupOpeningMessage.test.ts
@@ -14,20 +14,37 @@ describe('groupOpeningMessage', () => {
   it.each([
     '{{bcs.group_id}}',
     '{{bcs.session_id}}',
-    '{{bcs.run_id}}',
     '{{bcs.group_name}}',
     '{{bcs.session_name}}',
   ])('accepts supported token %s', (token) => {
-    expect(getGroupOpeningMessageError(`开始 ${token}`)).toBeUndefined();
+    expect(
+      getGroupOpeningMessageError(`开始 ${token}`, 'chat'),
+    ).toBeUndefined();
+  });
+
+  it('accepts run_id only for StateMachine', () => {
+    expect(
+      getGroupOpeningMessageError('{{bcs.run_id}}', 'state_machine'),
+    ).toBeUndefined();
+    expect(getGroupOpeningMessageError('{{bcs.run_id}}', 'chat')).toContain(
+      '不支持',
+    );
+    expect(
+      getGroupOpeningMessageError('{{bcs.run_id}}', 'manager_worker'),
+    ).toContain('不支持');
   });
 
   it('rejects unknown and unterminated template variables', () => {
-    expect(getGroupOpeningMessageError('{{group_id}}')).toContain('不支持');
-    expect(getGroupOpeningMessageError('{{bcs.run_id}')).toContain('未闭合');
+    expect(getGroupOpeningMessageError('{{group_id}}', 'chat')).toContain(
+      '不支持',
+    );
+    expect(getGroupOpeningMessageError('{{bcs.run_id}', 'chat')).toContain(
+      '未闭合',
+    );
   });
 
   it('enforces the UTF-8 byte limit', () => {
-    expect(getGroupOpeningMessageError('中'.repeat(22_000))).toBe(
+    expect(getGroupOpeningMessageError('中'.repeat(22_000), 'chat')).toBe(
       '自定义开场白不能超过 64 KiB',
     );
   });

--- a/src/frontend/src/pages/GroupChat/utils/groupOpeningMessage.ts
+++ b/src/frontend/src/pages/GroupChat/utils/groupOpeningMessage.ts
@@ -1,19 +1,29 @@
+import type { GroupStrategy } from '../types';
+
 const MAX_OPENING_MESSAGE_BYTES = 64 * 1024;
 
-const SUPPORTED_TOKENS = new Set([
+const SESSION_TOKENS = [
   '{{bcs.group_id}}',
   '{{bcs.session_id}}',
-  '{{bcs.run_id}}',
   '{{bcs.group_name}}',
   '{{bcs.session_name}}',
-]);
+] as const;
 
 export function getGroupOpeningMessageError(
   openingMessage: string,
+  groupStrategy: GroupStrategy,
 ): string | undefined {
   if (!openingMessage.trim()) return undefined;
-  if (new TextEncoder().encode(openingMessage).byteLength > MAX_OPENING_MESSAGE_BYTES) {
+  if (
+    new TextEncoder().encode(openingMessage).byteLength >
+    MAX_OPENING_MESSAGE_BYTES
+  ) {
     return '自定义开场白不能超过 64 KiB';
+  }
+
+  const supportedTokens = new Set<string>(SESSION_TOKENS);
+  if (groupStrategy === 'state_machine') {
+    supportedTokens.add('{{bcs.run_id}}');
   }
 
   let remainder = openingMessage;
@@ -23,7 +33,7 @@ export function getGroupOpeningMessageError(
     const end = remainder.indexOf('}}', start + 2);
     if (end < 0) return '自定义开场白包含未闭合的模板变量';
     const token = remainder.slice(start, end + 2);
-    if (!SUPPORTED_TOKENS.has(token)) {
+    if (!supportedTokens.has(token)) {
       return `不支持模板变量 ${token}`;
     }
     remainder = remainder.slice(end + 2);


### PR DESCRIPTION
## Problem

BCS 的自定义开场白和 Webhook 投递仍有以下完整性问题：

1. `opening_message` 主要按 StateMachine Run 渲染，自由聊天群和任务协作群缺少 Session 级开场白。前端也只允许 StateMachine 配置，导致二方系统无法通过统一配置控制不同协作群的开场内容或副屏资源。
2. Session 开场白没有作为普通消息持久化，重新加载历史消息时可能无法恢复；同时开场白不应该进入 Bot 上下文。
3. Webhook Attempt 原先在请求完成后才写入。进程中断、租约过期或请求前置检查失败时，可能缺少 Attempt 记录，难以判断下游是否实际收到请求。
4. MySQL 时间字段通过无时区字符串写入，可能受数据库 Session 时区影响，导致租约和重试时间比较不准确。
5. 创建群时内联 Subscription 会先处于 `Pending` 状态。初始化阶段产生的事件无法匹配有效 Subscription，导致 `run.created`、`run.started`、`node.started` 等事件缺失。

## Solution

### 自定义开场白

- 将 `opening_message` 扩展到全部群协作策略：
  - Chat 和 Manager-Worker：每个新 Session 渲染一次。
  - StateMachine：保持每个 Run 渲染一次。
- Session 模板支持：
  - `{{bcs.group_id}}`
  - `{{bcs.session_id}}`
  - `{{bcs.group_name}}`
  - `{{bcs.session_name}}`
- `{{bcs.run_id}}` 仅允许用于 StateMachine，前后端按协作策略进行一致校验。
- 创建 Session 时将渲染后的开场白持久化为具有稳定消息 ID 的 BCS 消息，并投递到前端。
- 人类用户查询历史消息时返回开场白，Bot 查询历史消息时过滤该消息，避免开场白进入 Bot 上下文。
- 消息持久化失败时返回错误并补偿完成已创建的 Session；前端实时推送失败仅记录告警，持久化历史仍可恢复。
- 前端在高级设置中为所有协作策略提供可选的自定义开场白输入，并保留原始字符串内容。
- 更新 OpenAPI、领域模型、前端类型和二方接入文档。

### Webhook 投递可靠性

- Delivery 被领取时立即创建未完成的 Attempt 记录，请求完成后再原子更新结果。
- Delivery 租约过期时，将未完成 Attempt 标记为 `lease_expired`，明确记录“下游结果未知”，再进入下一次重试。
- Subscription Revision 缺失、查询失败、Endpoint 非法和并发控制异常等请求前置失败也会持久化为 Attempt。
- 增加 Webhook 领取、前置失败、请求结果和持久化失败的结构化日志。
- Delivery 查询接口允许正在执行的 Attempt 只包含 `attempt_no` 和 `started_at`，完成字段在请求结束后返回。
- MySQL 使用 epoch 与 `FROM_UNIXTIME` 写入时间戳，避免 Session 时区造成租约和重试时间偏移；SQLite 保持规范 UTC 毫秒文本。
- Subscription 在群创建事务中激活时，回填创建至激活窗口内符合过滤条件的事件。
- 回填过程按事件流和序列号稳定排序，并补充跨事件流的因果依赖：
  - 避免重复创建原因事件目标。
  - 结果事件等待原因事件成功投递。
  - 原因事件早于 Subscription 创建时，创建 `causal_prerequisite` 目标保证因果顺序。
- 数据库仓储和内存仓储保持一致行为。

## Validation

已执行并通过：

- `cargo check -p bcs-event-store -p bcs-group-store -p bcs-eventing`
- `cargo test -q -p bcs-event-store -p bcs-group-store -p bcs-eventing`
  - 171 passed
  - 0 failed
  - 2 ignored
- `cargo test -q -p bcs-session -p bcs-message`
  - 52 passed
  - 0 failed
- `npm test -- --runInBand src/pages/GroupChat/utils/groupOpeningMessage.test.ts`
  - 1 suite passed
  - 8 tests passed
- `git diff --check`

本地未完成的验证：

- MySQL 合约测试未运行，因为未配置 `BCS_TEST_MYSQL_URL`。
- OpenAPI pytest 未运行，因为当前 Python 环境缺少 pytest/PyYAML 依赖。
- 当前 HEAD 未重新执行完整 Singlebox E2E 覆盖率；PR CI 将继续校验：
  - E2E 场景通过率
  - line coverage ≥ 40%
  - method coverage ≥ 36%
  - HTTP endpoint coverage = 100%
  - bcs-cli leaf-command coverage = 100%

## Compatibility and risk

- 不需要新增数据库表或执行 Schema Migration。
- 未配置 `opening_message` 的群保持现有行为。
- Chat 和 Manager-Worker 仅对新建 Session 生成开场白，不回填历史 Session。
- Session 开场白在创建时渲染并持久化；后续修改 Group 配置不会改变已有 Session 的开场白。
- Delivery Attempt 的完成字段在进行中的 Attempt 中可能暂时缺失；已完成 Attempt 的返回内容保持不变。
- Webhook Subscription 激活时可能投递此前遗漏的初始化事件，并可能额外投递用于保证顺序的因果前置事件。
- Webhook 仍采用 at-least-once 语义。租约过期代表远端结果未知，下游仍需根据 Event ID 实现幂等。
- 主要风险集中在 MySQL 时间表达式和事务化事件回填，建议上线后重点观察 Attempt、租约恢复、回填数量和下游重复事件指标。

## Spec

- [Event Subscription Webhook 设计](src/bcs/docs/superpowers/specs/2026-08-18-bcs-event-subscription-webhook-design.md)
- [自定义开场白设计](src/bcs/docs/superpowers/specs/2026-08-21-bcs-custom-opening-message-design.md)
- [Session 开场白设计](src/bcs/docs/superpowers/specs/2026-08-27-bcs-session-opening-message-design.md)