### PR TITLE
feat(backend): forward principal and log BCN callbacks

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
@@ -67,7 +67,10 @@ from agentclaw.community.core.work_orders.models import (
 )
 from agentclaw.community.di import Injected
 from agentclaw.community.adapters.http.openapi_v1.authorization import PublicAPIRoute
+from agentclaw.community.log import get_logger
 
+
+logger = get_logger()
 
 router = APIRouter(tags=["work-orders"], route_class=PublicAPIRoute)
 PositiveIdPath = Annotated[int, Path(ge=1, description="Positive numeric identifier.")]
@@ -83,6 +86,7 @@ _REFUSES_APP_ONLY = [Depends(refuse_app_only_caller)]
 
 _CALLBACK_HEADER_NAMES = {
     "authorization",
+    "x-avernet-principal",
     "x-request-id",
     "x-trace-id",
 }
@@ -274,6 +278,10 @@ async def create_work_order_event(
     service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
 ) -> Envelope[WorkOrderEventCreated]:
     actor_id = _require_user_delegation(caller)
+    logger.info(
+        "work-order event received",
+        extra={"work_order_event": body.model_dump(mode="json")},
+    )
     data = create_work_order_event_data(
         body=body,
         actor_id=actor_id,

--- a/src/backend/src/agentclaw/community/core/work_orders/callbacks.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/callbacks.py
@@ -29,6 +29,7 @@ from agentclaw.community.plugin_api.http_client import (
 
 
 logger = get_logger()
+_RESPONSE_BODY_LOG_LIMIT = 16 * 1024
 
 
 @dataclass(frozen=True)
@@ -117,16 +118,67 @@ class FriendDecisionCallbackHandler:
             if decision is WorkOrderDecision.APPROVED
             else {"reason": review_remark}
         )
+        callback_headers = dict(credential.headers)
+        lowered_headers = {key.lower(): value for key, value in callback_headers.items()}
+        logger.info(
+            "friend work-order BCN callback request",
+            extra={
+                "work_order_id": context.work_order.id,
+                "event_type": context.source_event_type,
+                "request_id": request_id,
+                "action": action,
+                "callback_path": path,
+                "request_body": body,
+                "has_authorization": "authorization" in lowered_headers,
+                "has_x_avernet_principal": "x-avernet-principal" in lowered_headers,
+                "x_request_id": lowered_headers.get("x-request-id"),
+                "x_trace_id": lowered_headers.get("x-trace-id"),
+            },
+        )
+        response = None
+        response_body_raw = ""
+        response_payload: dict[str, object] | None = None
         try:
             response = self._http.post(
                 path,
                 json=body,
-                headers=dict(credential.headers),
+                headers=callback_headers,
                 timeout=self._timeout,
             )
+            response_body_raw = response.text
+            logged_response_body = response_body_raw
+            if len(logged_response_body) > _RESPONSE_BODY_LOG_LIMIT:
+                logged_response_body = (
+                    logged_response_body[:_RESPONSE_BODY_LOG_LIMIT] + "...<truncated>"
+                )
+            try:
+                parsed = json.loads(response_body_raw)
+            except (json.JSONDecodeError, TypeError):
+                parsed = None
+            if isinstance(parsed, dict):
+                response_payload = parsed
+            logger.info(
+                "friend work-order BCN callback response",
+                extra={
+                    "work_order_id": context.work_order.id,
+                    "event_type": context.source_event_type,
+                    "request_id": request_id,
+                    "action": action,
+                    "http_status": response.status_code,
+                    "response_code": response_payload.get("code")
+                    if response_payload
+                    else None,
+                    "response_message": response_payload.get("message")
+                    if response_payload
+                    else None,
+                    "response_request_id": response_payload.get("request_id")
+                    if response_payload
+                    else None,
+                    "response_body_raw": logged_response_body,
+                },
+            )
             response.raise_for_status()
-            payload = response.json()
-            if not isinstance(payload, dict) or payload.get("success") is not True:
+            if response_payload is None or response_payload.get("success") is not True:
                 raise ValueError("BCN callback did not report success")
         except Exception as exc:
             logger.warning(
@@ -134,6 +186,23 @@ class FriendDecisionCallbackHandler:
                 extra={
                     "work_order_id": context.work_order.id,
                     "event_type": context.source_event_type,
+                    "request_id": request_id,
+                    "action": action,
+                    "http_status": response.status_code if response is not None else None,
+                    "response_code": response_payload.get("code")
+                    if response_payload
+                    else None,
+                    "response_message": response_payload.get("message")
+                    if response_payload
+                    else None,
+                    "response_request_id": response_payload.get("request_id")
+                    if response_payload
+                    else None,
+                    "response_body_raw": (
+                        response_body_raw[:_RESPONSE_BODY_LOG_LIMIT] + "...<truncated>"
+                        if len(response_body_raw) > _RESPONSE_BODY_LOG_LIMIT
+                        else response_body_raw
+                    ),
                 },
                 exc_info=True,
             )

--- a/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
@@ -138,7 +138,7 @@ def test_process_approval_forwards_only_callback_identity_headers(
             "Cookie": "backend_session=must-not-forward",
             "X-Request-Id": "request-1",
             "X-Trace-Id": "trace-1",
-            "X-Avernet-Principal": "must-not-forward",
+            "X-Avernet-Principal": "principal-token",
         },
     )
 
@@ -153,6 +153,7 @@ def test_process_approval_forwards_only_callback_identity_headers(
     lowered = {key.lower(): value for key, value in credential.headers.items()}
     assert lowered == {
         "authorization": "Bearer token",
+        "x-avernet-principal": "principal-token",
         "x-request-id": "request-1",
         "x-trace-id": "trace-1",
     }
@@ -270,7 +271,10 @@ def test_create_bot_editor_request_uses_principal_and_named_owner(
     )
 
 
-def test_create_work_order_event_accepts_json_objects(client, work_order_service):
+def test_create_work_order_event_accepts_json_objects(
+    client, work_order_service, caplog
+):
+    caplog.set_level("INFO", logger="start")
     work_order_service.create_work_order_event.return_value = (
         WorkOrderEventCreatedResult(
             event_category=NotificationCategory.APPROVAL,
@@ -296,6 +300,12 @@ def test_create_work_order_event_accepts_json_objects(client, work_order_service
     response = client.post("/openapi/v1/bots/work-orders/events", json=payload)
 
     assert response.status_code == 201
+    event_log = next(
+        record
+        for record in caplog.records
+        if record.message == "work-order event received"
+    )
+    assert event_log.work_order_event == {**payload, "apply_reason": None}
     work_order_service.create_work_order_event.assert_called_once_with(
         event_category=NotificationCategory.APPROVAL,
         biz_type="SPACE_JOIN",

--- a/src/backend/tests/community/core/work_orders/test_work_order_callbacks.py
+++ b/src/backend/tests/community/core/work_orders/test_work_order_callbacks.py
@@ -104,6 +104,86 @@ def test_friend_handler_accepts_and_forwards_only_supplied_credential() -> None:
     )
 
 
+def test_friend_handler_logs_bcn_response_details_without_credentials(caplog) -> None:
+    caplog.set_level("INFO", logger="start")
+    http = MagicMock(spec=HttpClient)
+    http.post.return_value = _response(
+        {
+            "code": 403201,
+            "message": "Forbidden",
+            "data": None,
+            "request_id": "bcn-request-1",
+        },
+        status_code=403,
+    )
+    handler = FriendDecisionCallbackHandler(http)
+
+    with pytest.raises(WorkOrderCallbackError):
+        handler.handle(
+            context=_context(),
+            decision=WorkOrderDecision.APPROVED,
+            review_remark=None,
+            credential=WorkOrderCallbackCredential(
+                headers={
+                    "Authorization": "Bearer secret-auth",
+                    "X-Avernet-Principal": "secret-principal",
+                }
+            ),
+        )
+
+    request_log = next(
+        record
+        for record in caplog.records
+        if record.message == "friend work-order BCN callback request"
+    )
+    response_log = next(
+        record
+        for record in caplog.records
+        if record.message == "friend work-order BCN callback response"
+    )
+    assert request_log.request_body is None
+    assert request_log.has_authorization is True
+    assert request_log.has_x_avernet_principal is True
+    assert response_log.http_status == 403
+    assert response_log.response_code == 403201
+    assert response_log.response_message == "Forbidden"
+    assert response_log.response_request_id == "bcn-request-1"
+    assert response_log.response_body_raw == (
+        '{"code":403201,"message":"Forbidden","data":null,'
+        '"request_id":"bcn-request-1"}'
+    )
+    assert "secret-auth" not in caplog.text
+    assert "secret-principal" not in caplog.text
+
+
+def test_friend_handler_logs_non_json_bcn_response(caplog) -> None:
+    caplog.set_level("INFO", logger="start")
+    http = MagicMock(spec=HttpClient)
+    http.post.return_value = httpx.Response(
+        502,
+        text="Bad Gateway",
+        request=httpx.Request("POST", "https://bcn.test/callback"),
+    )
+    handler = FriendDecisionCallbackHandler(http)
+
+    with pytest.raises(WorkOrderCallbackError):
+        handler.handle(
+            context=_context(),
+            decision=WorkOrderDecision.APPROVED,
+            review_remark=None,
+            credential=WorkOrderCallbackCredential(headers={}),
+        )
+
+    response_log = next(
+        record
+        for record in caplog.records
+        if record.message == "friend work-order BCN callback response"
+    )
+    assert response_log.http_status == 502
+    assert response_log.response_code is None
+    assert response_log.response_body_raw == "Bad Gateway"
+
+
 def test_friend_handler_rejects_with_review_reason() -> None:
     http = MagicMock(spec=HttpClient)
     http.post.return_value = _response({"success": True})


### PR DESCRIPTION
1. 转发 X-Avernet-Principal
2. 增加工单事件入站 Body 日志