### PR TITLE
Arca renew enhance

### DIFF
--- a/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
@@ -21,6 +21,26 @@ from secbaas.community.core.service.scheduler import (
 from secbaas.community.core.utils.env_utils import get_current_env
 
 
+def _assert_threshold_consistent(thr, ttl) -> int:
+    """Coerce renew_threshold_hours and fail fast on EG-4 drift.
+
+    None-tolerant: when the YAML key is absent (None/empty), the 12-hour
+    default is returned without asserting — minimal test containers carry
+    only the engine key, and odd half-TTL deployments must omit the key and
+    rely on the derived value. When both values are explicitly present, a
+    threshold that is not half the TTL period raises ValueError at assembly
+    (startup failure instead of a silently drifted safety margin).
+    """
+    coerced = int(thr) if thr else 12
+    if thr and ttl and coerced * 60 != int(ttl) // 2:
+        raise ValueError(
+            f"renew_threshold_hours={thr!r} conflicts with "
+            f"arca.default_ttl_minutes={ttl!r} — threshold must equal half "
+            "the TTL period (EG-4)"
+        )
+    return coerced
+
+
 class CoreTaskContainer(containers.DeclarativeContainer):
     config = providers.Configuration()
 
@@ -114,7 +134,13 @@ class CoreTaskContainer(containers.DeclarativeContainer):
         cron_interval_seconds=config.renewal_scheduler.cron_interval_seconds,
         batch_size=config.renewal_scheduler.batch_size,
         max_concurrency=config.renewal_scheduler.max_concurrency,
-        renew_threshold_hours=config.renewal_scheduler.renew_threshold_hours,
+        # EG-4 fail-fast: the explicit threshold must equal half the TTL
+        # period (None-tolerant — a missing key returns 12, no assertion).
+        renew_threshold_hours=providers.Callable(
+            _assert_threshold_consistent,
+            config.renewal_scheduler.renew_threshold_hours,
+            config.arca.default_ttl_minutes,
+        ),
         # Rule 14 (configuration-driven wiring): the TTL period comes from
         # the arca config section, not hardcoded task constants. The
         # fallback keeps overlays without an arca section (minimal test

--- a/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
@@ -152,6 +152,16 @@ class CoreTaskContainer(containers.DeclarativeContainer):
             lambda v: int(v) if v else 1440,
             config.arca.default_ttl_minutes,
         ),
+        # D-01 tolerance knob wired symmetrically with default_ttl_minutes:
+        # the renewal_scheduler schema allows undeclared keys
+        # (SettingsConfigDict(extra="allow")), so a YAML-set
+        # post_extend_consistency_tol_minutes passes validation and must
+        # reach the watermark comparison — otherwise the operator believes
+        # the tolerance tightened while it silently stays 5 (WR-01).
+        post_extend_consistency_tol_minutes=providers.Callable(
+            lambda v: int(v) if v else 5,
+            config.renewal_scheduler.post_extend_consistency_tol_minutes,
+        ),
         retry_delay_minutes=config.renewal_scheduler.retry_delay_minutes,
         max_fail_count=config.renewal_scheduler.max_fail_count,
         ttl_safety_margin_minutes=config.renewal_scheduler.ttl_safety_margin_minutes,

--- a/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
@@ -164,7 +164,7 @@ class CoreTaskContainer(containers.DeclarativeContainer):
         # reach the watermark comparison — otherwise the operator believes
         # the tolerance tightened while it silently stays 5 (WR-01).
         post_extend_consistency_tol_minutes=providers.Callable(
-            lambda v: int(v) if v else 5,
+            lambda v: int(v) if v is not None else 5,
             config.renewal_scheduler.post_extend_consistency_tol_minutes,
         ),
         retry_delay_minutes=config.renewal_scheduler.retry_delay_minutes,

--- a/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
+++ b/src/baas/src/secbaas/community/bootstrap/_core_tasks.py
@@ -24,19 +24,24 @@ from secbaas.community.core.utils.env_utils import get_current_env
 def _assert_threshold_consistent(thr, ttl) -> int:
     """Coerce renew_threshold_hours and fail fast on EG-4 drift.
 
-    None-tolerant: when the YAML key is absent (None/empty), the 12-hour
-    default is returned without asserting — minimal test containers carry
-    only the engine key, and odd half-TTL deployments must omit the key and
-    rely on the derived value. When both values are explicitly present, a
-    threshold that is not half the TTL period raises ValueError at assembly
-    (startup failure instead of a silently drifted safety margin).
+    None-tolerant for the threshold itself: when the YAML key is absent
+    (None/empty), the 12-hour default is returned without asserting —
+    minimal test containers carry only the engine key, and odd half-TTL
+    deployments must omit the key and rely on the derived value. Whenever
+    the threshold IS explicitly present, it is asserted against the
+    effective TTL period — arca.default_ttl_minutes when set, otherwise the
+    1440-minute fallback — so a tuned threshold can never revert silently
+    (WR-02). A threshold that is not half the effective TTL period raises
+    ValueError at assembly (startup failure instead of a silently drifted
+    safety margin).
     """
     coerced = int(thr) if thr else 12
-    if thr and ttl and coerced * 60 != int(ttl) // 2:
+    effective_ttl = int(ttl) if ttl else 1440
+    if thr and coerced * 60 != effective_ttl // 2:
         raise ValueError(
             f"renew_threshold_hours={thr!r} conflicts with "
-            f"arca.default_ttl_minutes={ttl!r} — threshold must equal half "
-            "the TTL period (EG-4)"
+            f"arca.default_ttl_minutes={ttl!r} (effective {effective_ttl}) — "
+            "threshold must equal half the TTL period (EG-4)"
         )
     return coerced
 

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_config.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_config.py
@@ -29,6 +29,8 @@ class DeadlineRenewalSchedulerConfig:
         retry_delay_minutes: Delay between renewal retry attempts.
         max_fail_count: Consecutive failure count before marking STOPPED.
         ttl_safety_margin_minutes: Safety buffer subtracted from ttl_minutes.
+        post_extend_consistency_tol_minutes: Upper-bound tolerance for the
+            post-extend TTL consistency watermark (D1).
         anti_join_verify_interval_cycles: Periodic anti-join verification interval.
         engine: Config switch — "legacy" or "deadline".
         env: Deployment environment identifier ('pre', 'prod', or '' for test).
@@ -48,8 +50,21 @@ class DeadlineRenewalSchedulerConfig:
     max_fail_count: int = 10
     ttl_safety_margin_minutes: int = 1
     anti_join_verify_interval_cycles: int = 48
+    post_extend_consistency_tol_minutes: int = 5
     engine: str = "legacy"
     env: str = ""
+
+    @property
+    def renew_threshold_minutes(self) -> int:
+        """Renewal threshold in minutes — half the configured TTL period.
+
+        EG-4 single-source: the (g)/(h) decision derives from
+        default_ttl_minutes instead of the YAML renew_threshold_hours, so a
+        reconfigured TTL period keeps the threshold coherent. Minutes
+        granularity preserves odd half-periods (e.g. 1500//2 = 750) that
+        the hours field cannot express.
+        """
+        return self.default_ttl_minutes // 2
 
     def resolved_lock_name(self) -> str:
         """Return the env-scoped distributed lock name.

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
@@ -638,8 +638,8 @@ class DeadlineRenewalScheduler:
             )
             return "skipped"
 
-        # ---- Step 3(g): 12h < remaining <= 24h — not yet due ----
-        if remaining_hours > self._config.renew_threshold_hours:
+        # ---- Step 3(g): derived threshold < remaining <= 24h — not yet due ----
+        if remaining_hours * 60.0 > self._config.renew_threshold_minutes:
             expiration_dt = naive_cst_fromtimestamp(ttl_ms / 1000.0)
             next_renew = expiration_dt - self._renewal_window
             self._schedule_repo.postpone_renewal(
@@ -650,10 +650,11 @@ class DeadlineRenewalScheduler:
             )
             log.info(
                 "[DeadlineRenewalScheduler] sandbox_id=%s remaining=%.1fh "
-                "in (%.1f, 24] — postponed to %s",
+                "in (%.0f, %d]min — postponed to %s",
                 sandbox_id,
                 remaining_hours,
-                self._config.renew_threshold_hours,
+                self._config.renew_threshold_minutes,
+                24 * 60,
                 next_renew.isoformat(),
             )
             self._emit_renew_digest(
@@ -661,12 +662,12 @@ class DeadlineRenewalScheduler:
             )
             return "skipped"
 
-        # ---- Step 3(h): 0 <= remaining <= 12h — renewal window ----
+        # ---- Step 3(h): 0 <= remaining <= derived threshold — renewal window ----
         # TTL period comes from the configured default_ttl_minutes (1440:
         # identical to the former 86400-second constant); the safety margin
         # is subtracted so an extension never lands exactly on the expiry.
         # WR-03: clamp to a 1-minute floor — when the operator configures a
-        # default_ttl_minutes below renew_threshold_hours the raw formula
+        # default_ttl_minutes below the derived threshold the raw formula
         # can go 0/negative, which extend_ttl must never receive.
         ttl_minutes = max(
             1,
@@ -733,15 +734,67 @@ class DeadlineRenewalScheduler:
         except Exception:
             new_expiration_ms = None
 
-        if new_expiration_ms is not None:
-            new_expiration_dt = naive_cst_fromtimestamp(new_expiration_ms / 1000)
-            next_renew = new_expiration_dt - self._renewal_window
-            log.info(
-                "[DeadlineRenewalScheduler] sandbox_id=%s post-extend ttl=%d — "
-                "next_renew derived from clamped expiry",
+        # D1 upper-bound consistency watermark: the platform must not report
+        # more remaining life than the pre-extend expiry plus the requested
+        # extension minutes (plus tol). An optimistic echo — the platform
+        # clamped the TTL but reported the request — exceeds this bound;
+        # reject it into the conservative rescan fallback below instead of
+        # scheduling past the real expiry. Both values share the platform
+        # epoch domain, so the comparison is clock-offset free.
+        expected_expiration_ms = ttl_ms + ttl_minutes * 60_000
+        if (
+            new_expiration_ms is not None
+            and new_expiration_ms
+            > expected_expiration_ms
+            + self._config.post_extend_consistency_tol_minutes * 60_000
+        ):
+            log.warning(
+                "[DeadlineRenewalScheduler] sandbox_id=%s post-extend ttl=%d "
+                "exceeds expected=%d + %dmin tol — untrusted, conservative rescan",
                 sandbox_id,
                 new_expiration_ms,
+                expected_expiration_ms,
+                self._config.post_extend_consistency_tol_minutes,
             )
+            log.info(
+                "[arca_ttl_metrics] post_extend_ttl_inconsistent=1 sandbox_id=%s "
+                "source_table=%s source_id=%s",
+                record.get("sandbox_id"),
+                record["source_table"],
+                record["source_id"],
+            )
+            new_expiration_ms = None
+
+        if new_expiration_ms is not None:
+            new_expiration_dt = naive_cst_fromtimestamp(new_expiration_ms / 1000)
+            # D2: R' stays in the platform epoch domain (same arithmetic as
+            # remaining_hours at step 3(c-d)); the persisted next_renew stays
+            # a naive Asia/Shanghai wall clock (CR-01).
+            # D2 notation R' (plan-level spec) kept as the variable name.
+            R_minutes = (new_expiration_ms / 1000.0 - time.time()) / 60.0  # noqa: N806
+            window_minutes = self._renewal_window.total_seconds() / 60.0
+            cron_minutes = self._config.cron_interval_seconds / 60.0
+            if R_minutes > window_minutes:
+                next_renew = new_expiration_dt - self._renewal_window
+                log.info(
+                    "[DeadlineRenewalScheduler] sandbox_id=%s post-extend ttl=%d — "
+                    "next_renew derived from clamped expiry",
+                    sandbox_id,
+                    new_expiration_ms,
+                )
+            else:
+                half_life_minutes = max(R_minutes / 2.0, cron_minutes)
+                next_renew = naive_cst_now() + timedelta(minutes=half_life_minutes)
+                log.info(
+                    "[DeadlineRenewalScheduler] sandbox_id=%s post-extend ttl=%d "
+                    "R_minutes=%.1f window_minutes=%.0f — half-life next_renew "
+                    "at now + %.1fmin",
+                    sandbox_id,
+                    new_expiration_ms,
+                    R_minutes,
+                    window_minutes,
+                    half_life_minutes,
+                )
         else:
             log.warning(
                 "[DeadlineRenewalScheduler] sandbox_id=%s renewed %d min but "
@@ -753,6 +806,14 @@ class DeadlineRenewalScheduler:
             next_renew = naive_cst_now() + timedelta(
                 seconds=self._config.cron_interval_seconds
             )
+        # EG-1 floor: EVERY success outcome schedules at least one full cron
+        # interval out — including the status-quo branch, whose E' - window
+        # target can land at/behind now when the platform clamps hard (the
+        # fallback branch is already at the floor, so max is an identity).
+        cron_floor = naive_cst_now() + timedelta(
+            seconds=self._config.cron_interval_seconds
+        )
+        next_renew = max(next_renew, cron_floor)
         self._schedule_repo.update_after_success(
             self._config.env, record["source_table"], record["source_id"], next_renew
         )

--- a/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
+++ b/src/baas/src/secbaas/community/core/service/scheduler/_tasks/_deadline_renewal_task.py
@@ -57,6 +57,26 @@ def _digest_ttl(ms: int | None) -> str | None:
         return None
 
 
+def _requested_ttl_minutes(
+    default_ttl_minutes: int,
+    remaining_hours: float,
+    ttl_safety_margin_minutes: int,
+) -> int:
+    """Requested extension minutes for one renewal (WR-03 clamp).
+
+    Full-TTL target minus the currently-remaining lead, with the safety
+    margin subtracted and a 1-minute floor. The clamp lives in this
+    module-level helper so it keeps honest unit coverage even though the
+    derived threshold (EG-4) makes the negative input unreachable via
+    _renew_one.
+    """
+    return max(
+        1,
+        int((default_ttl_minutes * 60 - remaining_hours * 3600) / 60)
+        - ttl_safety_margin_minutes,
+    )
+
+
 class DeadlineRenewalScheduler:
     """Deadline-driven ARCA container TTL renewal scheduler.
 
@@ -666,13 +686,15 @@ class DeadlineRenewalScheduler:
         # TTL period comes from the configured default_ttl_minutes (1440:
         # identical to the former 86400-second constant); the safety margin
         # is subtracted so an extension never lands exactly on the expiry.
-        # WR-03: clamp to a 1-minute floor — when the operator configures a
-        # default_ttl_minutes below the derived threshold the raw formula
-        # can go 0/negative, which extend_ttl must never receive.
-        ttl_minutes = max(
-            1,
-            int((self._config.default_ttl_minutes * 60 - remaining_hours * 3600) / 60)
-            - self._config.ttl_safety_margin_minutes,
+        # WR-03: clamps the requested minutes to a 1-minute floor so
+        # extend_ttl never receives a non-positive value — the clamp lives
+        # in the module-level _requested_ttl_minutes helper so it keeps
+        # honest unit coverage even though the derived threshold (EG-4)
+        # makes the negative input unreachable via _renew_one.
+        ttl_minutes = _requested_ttl_minutes(
+            self._config.default_ttl_minutes,
+            remaining_hours,
+            self._config.ttl_safety_margin_minutes,
         )
 
         try:

--- a/src/baas/tests/unit/bootstrap/test_renewal_assembly_smoke.py
+++ b/src/baas/tests/unit/bootstrap/test_renewal_assembly_smoke.py
@@ -137,6 +137,19 @@ class TestDeadlineEngineAssembly:
         task = container.tasks().deadline_renewal_task()
         assert task._config.post_extend_consistency_tol_minutes == 5
 
+    def test_post_extend_tol_zero_preserved(self):
+        """An explicit zero tolerance is a legal operator choice (strict
+        watermark) and must not be coerced back to the 5-minute default by
+        a falsy check (silent-knob guard)."""
+        container = _container_with("deadline")
+        container.config.from_dict(
+            {"renewal_scheduler": {"post_extend_consistency_tol_minutes": 0}}
+        )
+        set_container(container)
+
+        task = container.tasks().deadline_renewal_task()
+        assert task._config.post_extend_consistency_tol_minutes == 0
+
     def test_device_service_overridden_with_schedule_aware_wrapper(self):
         """services.device_service resolves to the schedule-aware wrapper."""
         container = _container_with("deadline")

--- a/src/baas/tests/unit/bootstrap/test_renewal_assembly_smoke.py
+++ b/src/baas/tests/unit/bootstrap/test_renewal_assembly_smoke.py
@@ -191,3 +191,60 @@ class TestLegacyEngineAssembly:
         assert not isinstance(svc, ArcaScheduleAwareDeviceService)
         # Community de-hook: no schedule repository residue on the default
         assert "_schedule_repo" not in type(svc).__dict__
+
+
+class TestEg4ThresholdConsistency:
+    """EG-4 bootstrap fail-fast: renew_threshold_hours vs arca.default_ttl_minutes.
+
+    Three assembly states at DeadlineRenewalSchedulerConfig materialisation:
+    mismatch raises ValueError (startup tripwire), an absent threshold key is
+    tolerated (12-hour default, no assertion), and consistent values resolve.
+    """
+
+    def test_mismatched_renew_threshold_raises_at_resolution(self):
+        """An explicit threshold inconsistent with the TTL period fails at
+        resolution — 12h vs "2880" (24h) must raise ValueError, never a
+        half-wired config (threshold != half the TTL period, EG-4)."""
+        container = _container_with("deadline")
+        container.config.from_dict(
+            {
+                "renewal_scheduler": {
+                    "engine": "deadline",
+                    "renew_threshold_hours": 12,
+                },
+                "arca": {"default_ttl_minutes": "2880"},
+            }
+        )
+        set_container(container)
+
+        with pytest.raises(ValueError):
+            container.tasks().deadline_renewal_task()
+
+    def test_absent_renew_threshold_tolerated_with_default(self):
+        """A missing threshold key resolves with the 12-hour default and the
+        1440-minute TTL fallback — the None-tolerant path keeps minimal
+        containers (only the engine key) assembling."""
+        container = _container_with("deadline")
+        set_container(container)
+
+        task = container.tasks().deadline_renewal_task()
+        assert task._config.renew_threshold_hours == 12
+        assert task._config.default_ttl_minutes == 1440
+
+    def test_consistent_renew_threshold_resolves(self):
+        """12h vs "1440" (string-coerced) resolves — threshold*60 ==
+        default_ttl_minutes//2 holds (WR-03 coercion chain reused)."""
+        container = _container_with("deadline")
+        container.config.from_dict(
+            {
+                "renewal_scheduler": {
+                    "engine": "deadline",
+                    "renew_threshold_hours": 12,
+                },
+                "arca": {"default_ttl_minutes": "1440"},
+            }
+        )
+        set_container(container)
+
+        task = container.tasks().deadline_renewal_task()
+        assert task._config.renew_threshold_hours == 12

--- a/src/baas/tests/unit/bootstrap/test_renewal_assembly_smoke.py
+++ b/src/baas/tests/unit/bootstrap/test_renewal_assembly_smoke.py
@@ -115,6 +115,28 @@ class TestDeadlineEngineAssembly:
         task = container.tasks().deadline_renewal_task()
         assert task._config.default_ttl_minutes == 1440
 
+    def test_post_extend_tol_wired_from_renewal_scheduler_config(self):
+        """WR-01: a YAML-set post_extend_consistency_tol_minutes reaches the
+        scheduler config — a non-default value (2) must land on the
+        dataclass (silent-config-drift guard on the D-01 tolerance knob)."""
+        container = _container_with("deadline")
+        container.config.from_dict(
+            {"renewal_scheduler": {"post_extend_consistency_tol_minutes": 2}}
+        )
+        set_container(container)
+
+        task = container.tasks().deadline_renewal_task()
+        assert task._config.post_extend_consistency_tol_minutes == 2
+
+    def test_post_extend_tol_defaults_to_5_without_key(self):
+        """WR-01: without the YAML key the tolerance keeps the locked
+        5-minute default (D-01 code-only default remains intact)."""
+        container = _container_with("deadline")
+        set_container(container)
+
+        task = container.tasks().deadline_renewal_task()
+        assert task._config.post_extend_consistency_tol_minutes == 5
+
     def test_device_service_overridden_with_schedule_aware_wrapper(self):
         """services.device_service resolves to the schedule-aware wrapper."""
         container = _container_with("deadline")

--- a/src/baas/tests/unit/bootstrap/test_renewal_assembly_smoke.py
+++ b/src/baas/tests/unit/bootstrap/test_renewal_assembly_smoke.py
@@ -253,6 +253,45 @@ class TestEg4ThresholdConsistency:
         assert task._config.renew_threshold_hours == 12
         assert task._config.default_ttl_minutes == 1440
 
+    def test_explicit_threshold_without_arca_section_raises(self):
+        """WR-02: an explicit threshold is checked against the effective TTL
+        even when the arca section is absent — 8h vs the 1440-minute
+        fallback (12h half-period) raises instead of silently reverting the
+        tuned threshold to 12h with a dead knob."""
+        container = _container_with("deadline")
+        container.config.from_dict(
+            {
+                "renewal_scheduler": {
+                    "engine": "deadline",
+                    "renew_threshold_hours": 8,
+                },
+            }
+        )
+        set_container(container)
+
+        with pytest.raises(ValueError):
+            container.tasks().deadline_renewal_task()
+
+    def test_explicit_12h_threshold_without_arca_section_resolves(self):
+        """WR-02 boundary: an explicit 12h threshold stays consistent with
+        the 1440-minute fallback when no arca section exists — every
+        in-repo overlay carries renew_threshold_hours: 12 without an arca
+        section, so this quadrant must assemble."""
+        container = _container_with("deadline")
+        container.config.from_dict(
+            {
+                "renewal_scheduler": {
+                    "engine": "deadline",
+                    "renew_threshold_hours": 12,
+                },
+            }
+        )
+        set_container(container)
+
+        task = container.tasks().deadline_renewal_task()
+        assert task._config.renew_threshold_hours == 12
+        assert task._config.default_ttl_minutes == 1440
+
     def test_consistent_renew_threshold_resolves(self):
         """12h vs "1440" (string-coerced) resolves — threshold*60 ==
         default_ttl_minutes//2 holds (WR-03 coercion chain reused)."""

--- a/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_config.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_config.py
@@ -85,6 +85,39 @@ class TestSchedulerConfig:
         assert config.engine == "deadline"
         assert config.env == ""
 
+    def test_post_extend_consistency_tol_defaults_to_five(self):
+        """D1/D-01 locked value: the post-extend consistency watermark
+        tolerance defaults to 5 minutes."""
+        config = DeadlineRenewalSchedulerConfig()
+        assert config.post_extend_consistency_tol_minutes == 5
+
+    def test_renew_threshold_minutes_defaults_to_half_default_ttl(self):
+        """EG-4 derivation: the default config's threshold is half the
+        default TTL period — 1440 // 2 == 720 minutes (12h)."""
+        config = DeadlineRenewalSchedulerConfig()
+        assert config.renew_threshold_minutes == 720
+
+    def test_renew_threshold_minutes_derives_for_custom_and_odd_ttl(self):
+        """EG-4 minute granularity: threshold follows default_ttl_minutes // 2
+        for custom periods, preserving odd half-periods (1500 -> 750)."""
+        cases = [
+            (2880, 1440),
+            (600, 300),
+            (1500, 750),
+        ]
+        for default_ttl_minutes, expected in cases:
+            config = DeadlineRenewalSchedulerConfig(
+                default_ttl_minutes=default_ttl_minutes,
+            )
+            assert config.renew_threshold_minutes == expected
+
+    def test_renew_threshold_hours_knob_retained_with_default_12(self):
+        """Keep-and-assert (EG-4/D-03): the renew_threshold_hours field stays
+        as the bootstrap assertion subject and the dual-track YAML test
+        input — default unchanged at 12."""
+        config = DeadlineRenewalSchedulerConfig()
+        assert config.renew_threshold_hours == 12
+
 
 class TestResolvedLockName:
     """F4/D-11': resolved_lock_name() appends the runtime env suffix.

--- a/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
@@ -917,11 +917,12 @@ class TestTtlWindowDerivation:
     behavior is byte-identical to the former hardcoded 12h/86400 values."""
 
     @pytest.mark.asyncio
-    async def test_success_window_derives_from_clamped_post_extend_ttl(self):
-        """WR-03: default_ttl_minutes=2880 -> window is 24h, but Arca clamps
-        the extension at its 24h remaining cap — the derived success target
-        is clamped_expiry - window (≈ now), NOT the assumed now+24h (which
-        would land at/after the real expiry and risk device expiry)."""
+    async def test_success_half_life_when_post_extend_remaining_within_window(self):
+        """D2/D-02: default_ttl_minutes=2880 -> window is 24h; a post-extend
+        re-read of 18h lands inside the window, so next_renew_at is the
+        half-life target now + max(R'/2, cron) = now + 9h (the 30min cron
+        floor is dominated by 9h), instead of the old E' - window target
+        which would land ~6h behind now."""
         scheduler, mock_repo, _, mock_facade = _make_scheduler(
             enabled=True,
             config_overrides={"default_ttl_minutes": 2880},
@@ -930,7 +931,7 @@ class TestTtlWindowDerivation:
         mock_facade.get_device_info = AsyncMock(
             side_effect=[
                 MagicMock(ttl_timestamp=_ttl_ms(6)),
-                MagicMock(ttl_timestamp=_ttl_ms(24)),  # platform clamp
+                MagicMock(ttl_timestamp=_ttl_ms(18)),  # honest post-extend value
             ]
         )
         mock_facade.extend_ttl = AsyncMock(return_value=True)
@@ -944,16 +945,17 @@ class TestTtlWindowDerivation:
         from zoneinfo import ZoneInfo
 
         now_cst = datetime.now(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
-        expected_min = now_cst - timedelta(seconds=5)
-        expected_max = now_cst + timedelta(seconds=5)
+        expected_min = now_cst + timedelta(hours=9) - timedelta(seconds=5)
+        expected_max = now_cst + timedelta(hours=9) + timedelta(seconds=5)
         assert expected_min <= next_renew <= expected_max
-        # Explicit asymmetry lock: nowhere near the assumed now+24h target.
-        assert next_renew < now_cst + timedelta(hours=12)
 
     @pytest.mark.asyncio
-    async def test_postpone_target_derives_from_default_ttl_minutes(self):
-        """default_ttl_minutes=2880, remaining=18h -> postpone to expiry-24h
-        instead of the hardcoded expiry-12h."""
+    async def test_renew_target_derives_from_default_ttl_minutes(self):
+        """EG-4/D-03: with default_ttl_minutes=2880 the derived threshold is
+        2880//2 = 1440min = 24h, so remaining=18h falls INTO the renewal
+        window (h) — extend_ttl is called with m = 1799 and next_renew
+        derives from the post-extend re-read (R'=42h > window 24h →
+        D2 status quo: next = E' - window ≈ now + 18h)."""
         scheduler, mock_repo, _, mock_facade = _make_scheduler(
             enabled=True,
             config_overrides={"default_ttl_minutes": 2880},
@@ -961,22 +963,26 @@ class TestTtlWindowDerivation:
 
         ttl_ms = _ttl_ms(18)
         mock_facade.get_device_info = AsyncMock(
-            return_value=MagicMock(ttl_timestamp=ttl_ms)
+            side_effect=[
+                MagicMock(ttl_timestamp=ttl_ms),
+                MagicMock(ttl_timestamp=_ttl_ms(42)),
+            ]
         )
-        mock_facade.extend_ttl = AsyncMock()
+        mock_facade.extend_ttl = AsyncMock(return_value=True)
+        mock_repo.update_after_success = MagicMock()
 
         result = await scheduler._renew_one(_renewal_record())
 
-        assert result == "skipped"
-        next_renew = mock_repo.postpone_renewal.call_args[0][3]
+        assert result == "success"
+        mock_facade.extend_ttl.assert_awaited_once_with("sb-1", 1799)
+        mock_repo.postpone_renewal.assert_not_called()
+        next_renew = mock_repo.update_after_success.call_args[0][3]
         from datetime import datetime, timedelta
         from zoneinfo import ZoneInfo
 
-        expiration_utc = datetime.fromtimestamp(
-            ttl_ms / 1000.0, tz=ZoneInfo("Asia/Shanghai")
-        ).replace(tzinfo=None)
-        expected_min = expiration_utc - timedelta(hours=24) - timedelta(seconds=5)
-        expected_max = expiration_utc - timedelta(hours=24) + timedelta(seconds=5)
+        now_cst = datetime.now(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
+        expected_min = now_cst + timedelta(hours=18) - timedelta(seconds=5)
+        expected_max = now_cst + timedelta(hours=18) + timedelta(seconds=5)
         assert expected_min <= next_renew <= expected_max
 
     @pytest.mark.asyncio
@@ -1000,26 +1006,36 @@ class TestTtlWindowDerivation:
         mock_facade.extend_ttl.assert_awaited_once_with("sb-1", 2159)
 
     @pytest.mark.asyncio
-    async def test_negative_ttl_minutes_clamped_to_one(self):
-        """WR-03: default_ttl_minutes=600 (10h period) with ~10h remaining
-        computes int((600*60 - 10*3600)/60) - 1 = -1 — the Step 3(h)
-        formula clamps to a 1-minute floor instead of passing a
-        non-positive value to extend_ttl."""
+    async def test_default_ttl_below_derived_threshold_postpones_to_expiry_minus_window(self):
+        """EG-4/D-03: default_ttl_minutes=600 -> derived threshold is
+        600//2 = 300min = 5h, so remaining=10h falls into the (g) postpone
+        branch — postpone_renewal gets expiry - window (≈ now + 5h) and
+        extend_ttl is never called. The WR-03 1-minute clamp keeps honest
+        coverage via the module-level _requested_ttl_minutes helper tests
+        (84-01 Task 2, Open Question 3 option b)."""
         scheduler, mock_repo, _, mock_facade = _make_scheduler(
             enabled=True,
             config_overrides={"default_ttl_minutes": 600},
         )
 
+        ttl_ms = _ttl_ms(10)
         mock_facade.get_device_info = AsyncMock(
-            return_value=MagicMock(ttl_timestamp=_ttl_ms(10))
+            return_value=MagicMock(ttl_timestamp=ttl_ms)
         )
-        mock_facade.extend_ttl = AsyncMock(return_value=True)
-        mock_repo.update_after_success = MagicMock()
+        mock_facade.extend_ttl = AsyncMock()
 
         result = await scheduler._renew_one(_renewal_record())
 
-        assert result == "success"
-        mock_facade.extend_ttl.assert_awaited_once_with("sb-1", 1)
+        assert result == "skipped"
+        mock_facade.extend_ttl.assert_not_awaited()
+        next_renew = mock_repo.postpone_renewal.call_args[0][3]
+        from datetime import datetime, timedelta
+        from zoneinfo import ZoneInfo
+
+        now_cst = datetime.now(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
+        expected_min = now_cst + timedelta(hours=5) - timedelta(seconds=5)
+        expected_max = now_cst + timedelta(hours=5) + timedelta(seconds=5)
+        assert expected_min <= next_renew <= expected_max
 
     @pytest.mark.asyncio
     async def test_discovery_register_target_derives_from_default_ttl_minutes(self):
@@ -1335,21 +1351,22 @@ class TestPostExtendNextRenewDerivation:
     extension at its 24h remaining cap)."""
 
     @pytest.mark.asyncio
-    async def test_success_with_clamped_extension_derives_from_platform(self):
-        """WR-03: Arca clamps the extension at its 24h remaining cap — the
-        post-extend re-read yields the clamped expiry and next_renew_at =
-        clamped_expiry - window, so the next due scan precedes the real
-        expiry."""
+    async def test_success_status_quo_when_post_extend_remaining_exceeds_window(self):
+        """D2/D-02: default_ttl_minutes=2880 -> window 24h; a post-extend
+        re-read of 36h exceeds the window, so the D2 status-quo target
+        holds: next_renew_at = E' - window ≈ now + 12h. The fixture sits
+        far from the R' == window boundary (Pitfall 1) so the branch choice
+        is deterministic."""
         scheduler, mock_repo, _, mock_facade = _make_scheduler(
             enabled=True,
             config_overrides={"default_ttl_minutes": 2880},
         )
         # remaining=2h -> extend request = int((2880*60 - 2*3600)/60) - 1
-        # = 2759 min; Arca clamps the result to 24h remaining.
+        # = 2759 min; the re-read returns 36h (clearly above the 24h window).
         mock_facade.get_device_info = AsyncMock(
             side_effect=[
                 MagicMock(ttl_timestamp=_ttl_ms(2)),
-                MagicMock(ttl_timestamp=_ttl_ms(24)),
+                MagicMock(ttl_timestamp=_ttl_ms(36)),
             ]
         )
         mock_facade.extend_ttl = AsyncMock(return_value=True)
@@ -1364,13 +1381,9 @@ class TestPostExtendNextRenewDerivation:
         from zoneinfo import ZoneInfo
 
         now_cst = datetime.now(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
-        assert (
-            now_cst - timedelta(seconds=5)
-            <= next_renew
-            <= now_cst + timedelta(seconds=5)
-        )
-        # Not the assumed now+window (now+24h) target.
-        assert next_renew < now_cst + timedelta(hours=12)
+        expected_min = now_cst + timedelta(hours=12) - timedelta(seconds=5)
+        expected_max = now_cst + timedelta(hours=12) + timedelta(seconds=5)
+        assert expected_min <= next_renew <= expected_max
 
     @pytest.mark.asyncio
     async def test_success_post_extend_reread_failure_short_rescans(self):
@@ -1399,6 +1412,84 @@ class TestPostExtendNextRenewDerivation:
 
         now_cst = datetime.now(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
         expected = now_cst + timedelta(seconds=scheduler._config.cron_interval_seconds)
+        assert (
+            expected - timedelta(seconds=5)
+            <= next_renew
+            <= expected + timedelta(seconds=5)
+        )
+
+
+class TestPostExtendConsistencyWatermark:
+    """D1/D-01: the post-extend TTL re-read must never exceed the pre-extend
+    expiry plus the requested extension minutes plus the locked 5-minute
+    tolerance — an optimistic echo (platform clamped the TTL but reported
+    the request) violates the bound and is rejected into the conservative
+    short rescan, with a post_extend_ttl_inconsistent=1 metrics line and a
+    dash digest ttl_after."""
+
+    @staticmethod
+    def _digest_lines(caplog):
+        return [
+            r.getMessage()
+            for r in caplog.records
+            if r.name == "arca-renew-digest"
+            and r.getMessage().startswith("ttl_renew_digest,")
+        ]
+
+    @pytest.mark.asyncio
+    async def test_reject_reread_above_expected_plus_tol_short_rescans_with_metric_and_dash(
+        self, caplog
+    ):
+        """D1 end-to-end: re-read = expected + 30min > tol 5min → rejected
+        into the short rescan (next_renew = now + cron_interval), the
+        post_extend_ttl_inconsistent=1 metric fires, and the digest keeps
+        result="success" with ttl_after="-". The 30-minute overflow is
+        deterministic and independent of wall-clock drift, and the fallback
+        target doubles as the EG-1 floor."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+
+        pre_read = _ttl_ms(10)
+        expected_minutes = _expected_ttl_minutes(10)  # 839 under TTL 1440
+        re_read = pre_read + expected_minutes * 60_000 + 30 * 60_000
+        mock_facade.get_device_info = AsyncMock(
+            side_effect=[
+                MagicMock(ttl_timestamp=pre_read),
+                MagicMock(ttl_timestamp=re_read),
+            ]
+        )
+        mock_facade.extend_ttl = AsyncMock(return_value=True)
+        mock_repo.update_after_success = MagicMock()
+
+        caplog.set_level(logging.INFO, logger="core-scheduler")
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        result = await scheduler._renew_one(_renewal_record())
+
+        assert result == "success"
+        # (a) The scrapeable inconsistency metric line.
+        metric_lines = [
+            r.message
+            for r in caplog.records
+            if "post_extend_ttl_inconsistent" in r.message
+        ]
+        assert len(metric_lines) == 1
+        assert "[arca_ttl_metrics]" in metric_lines[0]
+        assert "post_extend_ttl_inconsistent=1" in metric_lines[0]
+        assert "sandbox_id=sb-1" in metric_lines[0]
+        # (b) Digest contract: success result, dash ttl_after.
+        lines = self._digest_lines(caplog)
+        assert len(lines) == 1
+        fields = lines[0].split(",")
+        assert fields[6] == "success"
+        assert fields[8] == "-"
+        # (c) Conservative short rescan: now + cron_interval.
+        next_renew = mock_repo.update_after_success.call_args[0][3]
+        from datetime import datetime, timedelta
+        from zoneinfo import ZoneInfo
+
+        now_cst = datetime.now(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
+        expected = now_cst + timedelta(
+            seconds=scheduler._config.cron_interval_seconds
+        )
         assert (
             expected - timedelta(seconds=5)
             <= next_renew

--- a/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
+++ b/src/baas/tests/unit/core/service/scheduler/test_deadline_renewal_task.py
@@ -27,6 +27,9 @@ from secbaas.community.core.service.scheduler import (
     GapDetectionResult,
     RenewalRunReport,
 )
+from secbaas.community.core.service.scheduler._tasks._deadline_renewal_task import (
+    _requested_ttl_minutes,
+)
 from secbaas.community.core.utils.env_utils import get_current_env
 from secbaas.community.core.utils.time_utils import format_ttl_expiration_time
 
@@ -1006,7 +1009,9 @@ class TestTtlWindowDerivation:
         mock_facade.extend_ttl.assert_awaited_once_with("sb-1", 2159)
 
     @pytest.mark.asyncio
-    async def test_default_ttl_below_derived_threshold_postpones_to_expiry_minus_window(self):
+    async def test_default_ttl_below_derived_threshold_postpones_to_expiry_minus_window(
+        self,
+    ):
         """EG-4/D-03: default_ttl_minutes=600 -> derived threshold is
         600//2 = 300min = 5h, so remaining=10h falls into the (g) postpone
         branch — postpone_renewal gets expiry - window (≈ now + 5h) and
@@ -1487,9 +1492,208 @@ class TestPostExtendConsistencyWatermark:
         from zoneinfo import ZoneInfo
 
         now_cst = datetime.now(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
-        expected = now_cst + timedelta(
-            seconds=scheduler._config.cron_interval_seconds
+        expected = now_cst + timedelta(seconds=scheduler._config.cron_interval_seconds)
+        assert (
+            expected - timedelta(seconds=5)
+            <= next_renew
+            <= expected + timedelta(seconds=5)
         )
+
+    @pytest.mark.asyncio
+    async def test_reread_four_minutes_over_expected_accepted(self, caplog):
+        """D1 tol boundary (accept side): re-read = expected + 4min < tol
+        5min → trusted; R' ≈ 24h3m > window 12h → D2 status quo gives
+        next ≈ now + 12h3m (E' = now + 24h3m minus the 12h window), an
+        accepted digest without the inconsistency metric. Fixture math is
+        drift-immune: both sides compute m=1079 from the same 6h pre-read."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+
+        pre_read = _ttl_ms(6)
+        expected_minutes = _expected_ttl_minutes(6)  # 1079 under TTL 1440
+        re_read = pre_read + expected_minutes * 60_000 + 4 * 60_000
+        mock_facade.get_device_info = AsyncMock(
+            side_effect=[
+                MagicMock(ttl_timestamp=pre_read),
+                MagicMock(ttl_timestamp=re_read),
+            ]
+        )
+        mock_facade.extend_ttl = AsyncMock(return_value=True)
+        mock_repo.update_after_success = MagicMock()
+
+        caplog.set_level(logging.INFO, logger="core-scheduler")
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        result = await scheduler._renew_one(_renewal_record())
+
+        assert result == "success"
+        messages = [r.message for r in caplog.records]
+        assert not any("post_extend_ttl_inconsistent" in m for m in messages)
+        lines = self._digest_lines(caplog)
+        assert len(lines) == 1
+        fields = lines[0].split(",")
+        assert fields[6] == "success"
+        assert fields[8] != "-"
+        next_renew = mock_repo.update_after_success.call_args[0][3]
+        from datetime import datetime, timedelta
+        from zoneinfo import ZoneInfo
+
+        now_cst = datetime.now(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
+        expected = now_cst + timedelta(hours=12, minutes=3)
+        assert (
+            expected - timedelta(seconds=5)
+            <= next_renew
+            <= expected + timedelta(seconds=5)
+        )
+
+    @pytest.mark.asyncio
+    async def test_reread_six_minutes_over_expected_rejected(self, caplog):
+        """D1 tol boundary (reject side): re-read = expected + 6min > tol
+        5min → rejected: metric line fires, digest ttl_after dash, short
+        rescan next ≈ now + cron_interval."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+
+        pre_read = _ttl_ms(6)
+        expected_minutes = _expected_ttl_minutes(6)  # 1079 under TTL 1440
+        re_read = pre_read + expected_minutes * 60_000 + 6 * 60_000
+        mock_facade.get_device_info = AsyncMock(
+            side_effect=[
+                MagicMock(ttl_timestamp=pre_read),
+                MagicMock(ttl_timestamp=re_read),
+            ]
+        )
+        mock_facade.extend_ttl = AsyncMock(return_value=True)
+        mock_repo.update_after_success = MagicMock()
+
+        caplog.set_level(logging.INFO, logger="core-scheduler")
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        result = await scheduler._renew_one(_renewal_record())
+
+        assert result == "success"
+        metric_lines = [
+            r.message
+            for r in caplog.records
+            if "post_extend_ttl_inconsistent" in r.message
+        ]
+        assert len(metric_lines) == 1
+        lines = self._digest_lines(caplog)
+        assert len(lines) == 1
+        fields = lines[0].split(",")
+        assert fields[6] == "success"
+        assert fields[8] == "-"
+        next_renew = mock_repo.update_after_success.call_args[0][3]
+        from datetime import datetime, timedelta
+        from zoneinfo import ZoneInfo
+
+        now_cst = datetime.now(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
+        expected = now_cst + timedelta(seconds=scheduler._config.cron_interval_seconds)
+        assert (
+            expected - timedelta(seconds=5)
+            <= next_renew
+            <= expected + timedelta(seconds=5)
+        )
+
+
+class TestD2SchedulingBranches:
+    """D2/D-02 half-life and EG-1 floor: within the window the success
+    target is now + max(R'/2, cron); any branch result below now + cron is
+    lifted to the floor. All fixtures keep the post-extend re-read clearly
+    inside one branch (Pitfall 1)."""
+
+    @pytest.mark.asyncio
+    async def test_half_life_uses_now_plus_half_of_remaining(self, caplog):
+        """R' = 8h ≤ window 12h → half-life: next ≈ now + 8h/2 = now + 4h;
+        no inconsistency metric, digest ttl_after formatted."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+
+        mock_facade.get_device_info = AsyncMock(
+            side_effect=[
+                MagicMock(ttl_timestamp=_ttl_ms(6)),
+                MagicMock(ttl_timestamp=_ttl_ms(8)),
+            ]
+        )
+        mock_facade.extend_ttl = AsyncMock(return_value=True)
+        mock_repo.update_after_success = MagicMock()
+
+        caplog.set_level(logging.INFO, logger="core-scheduler")
+        caplog.set_level(logging.INFO, logger="arca-renew-digest")
+        result = await scheduler._renew_one(_renewal_record())
+
+        assert result == "success"
+        messages = [r.message for r in caplog.records]
+        assert not any("post_extend_ttl_inconsistent" in m for m in messages)
+        digest_lines = [
+            r.getMessage()
+            for r in caplog.records
+            if r.name == "arca-renew-digest"
+            and r.getMessage().startswith("ttl_renew_digest,")
+        ]
+        assert digest_lines[0].split(",")[8] != "-"
+        next_renew = mock_repo.update_after_success.call_args[0][3]
+        from datetime import datetime, timedelta
+        from zoneinfo import ZoneInfo
+
+        now_cst = datetime.now(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
+        expected = now_cst + timedelta(hours=4)
+        assert (
+            expected - timedelta(seconds=5)
+            <= next_renew
+            <= expected + timedelta(seconds=5)
+        )
+
+    @pytest.mark.asyncio
+    async def test_half_life_lifted_to_cron_floor(self):
+        """R' = 18min ≤ window 12h → half-life max(R'/2=9min, cron=30min)
+        = 30min → next ≈ now + 30min (the half-life branch's own floor)."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+
+        mock_facade.get_device_info = AsyncMock(
+            side_effect=[
+                MagicMock(ttl_timestamp=_ttl_ms(6)),
+                MagicMock(ttl_timestamp=_ttl_ms(0.3)),
+            ]
+        )
+        mock_facade.extend_ttl = AsyncMock(return_value=True)
+        mock_repo.update_after_success = MagicMock()
+
+        result = await scheduler._renew_one(_renewal_record())
+
+        assert result == "success"
+        next_renew = mock_repo.update_after_success.call_args[0][3]
+        from datetime import datetime, timedelta
+        from zoneinfo import ZoneInfo
+
+        now_cst = datetime.now(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
+        expected = now_cst + timedelta(minutes=30)
+        assert (
+            expected - timedelta(seconds=5)
+            <= next_renew
+            <= expected + timedelta(seconds=5)
+        )
+
+    @pytest.mark.asyncio
+    async def test_status_quo_lifted_to_cron_floor(self):
+        """R' = 12.2h > window 12h → status quo next = E' - window ≈ now +
+        12min < now + cron(30min) → EG-1 floor lifts to now + 30min — the
+        original churn defect scenario EG-1 was raised for."""
+        scheduler, mock_repo, _, mock_facade = _make_scheduler(enabled=True)
+
+        mock_facade.get_device_info = AsyncMock(
+            side_effect=[
+                MagicMock(ttl_timestamp=_ttl_ms(6)),
+                MagicMock(ttl_timestamp=_ttl_ms(12.2)),
+            ]
+        )
+        mock_facade.extend_ttl = AsyncMock(return_value=True)
+        mock_repo.update_after_success = MagicMock()
+
+        result = await scheduler._renew_one(_renewal_record())
+
+        assert result == "success"
+        next_renew = mock_repo.update_after_success.call_args[0][3]
+        from datetime import datetime, timedelta
+        from zoneinfo import ZoneInfo
+
+        now_cst = datetime.now(ZoneInfo("Asia/Shanghai")).replace(tzinfo=None)
+        expected = now_cst + timedelta(minutes=30)
         assert (
             expected - timedelta(seconds=5)
             <= next_renew
@@ -2065,3 +2269,27 @@ class TestRenewalDigestLogging:
         assert fields[6] == "failure"
         assert fields[7] == "-"
         assert fields[8] == "-"
+
+
+class TestRequestedTtlMinutes:
+    """WR-03: the requested-minutes clamp lives in the module-level
+    _requested_ttl_minutes helper so the 1-minute floor keeps honest unit
+    coverage even though the derived threshold (EG-4) makes the negative
+    input unreachable via _renew_one."""
+
+    def test_normal_derivation(self):
+        assert _requested_ttl_minutes(1440, 6.0, 1) == 1079
+
+    def test_large_ttl_derivation(self):
+        assert _requested_ttl_minutes(2880, 18.0, 1) == 1799
+
+    def test_negative_clamped_to_one(self):
+        assert _requested_ttl_minutes(600, 10.0, 1) == 1
+
+    def test_zero_clamped_to_one(self):
+        assert _requested_ttl_minutes(600, 10.0, 0) == 1
+
+    def test_safety_margin_subtracted(self):
+        assert _requested_ttl_minutes(1440, 6.0, 30) == (
+            int((1440 * 60 - 6 * 3600) / 60) - 30
+        )


### PR DESCRIPTION
  ## Problem

  The deadline renewal scheduler (currently live in production) has three boundary defects on
  its success path:

  1. **Silent expiry (A3)** — after a successful extend, the platform may report an optimistic
  post-extend TTL, further out than the true expiry point. The scheduler trusts the echo, and
  the container expires before the next due scan with zero alerts.
  2. **Renewal churn (EG-1)** — the success path sets `next_renew` without a minimum-interval
  floor, so platform clamping / absolute-vs-relative semantics drift can force a renew attempt
  every cron round.
  3. **Dual-source threshold (EG-4)** — `renew_threshold_hours` and `arca.default_ttl_minutes`
  are independent YAML knobs whose defaults only coincidentally agree; drift silently decouples
  the renew threshold from the real TTL.

  ## Solution

  - **Post-extend consistency watermark (D1):** compare the post-extend re-read expiry against
  `expected_expiration_ms = ttl_ms + ttl_minutes * 60_000`. If the platform echo exceeds it by
  more than a tolerance (default 5 min, injectable via `post_extend_consistency_tol_minutes`),
  the echo is rejected — the existing re-read-failure fallback runs a short-interval rescan, a
  `post_extend_ttl_inconsistent` metric is emitted, and the digest `ttl_after` is dashed.
  - **Scheduling rework (D2):** remaining `>` window keeps `next = expiry − window`; remaining
  `≤` window schedules a half-life rescan at `now + max(R'/2, cron_interval)`; every successful
  outcome is floored at `now + cron_interval`, which eliminates the per-round churn.
  - **Threshold single-source (EG-4):** `renew_threshold_minutes` is now derived as
  `default_ttl_minutes // 2`. The legacy `renew_threshold_hours` knob is retained for explicit
  override and guarded by a bootstrap fail-fast assertion — an explicit value inconsistent with
  `effective_ttl // 2` aborts startup (None-tolerant; absent or matching config passes).

  ## Validation

  - **Community unit suite:** 8,587 passed after the review-fix commits (8,583 before),
  including the new watermark accept/reject boundary matrix, half-life and floor scheduling
  branches, bootstrap three-state assembly smoke tests, and config pinning for derived
  threshold / tolerance default / retained knob.
  - **Static gates:** ruff clean; CI architecture gate passes.
  - **Code review:** deep review produced 2 warnings (tolerance knob unwired in DI; tripwire
  uncovered the explicit-threshold quadrant) — both verified as real and fixed atomically (the
  last two commits); 4 info-level findings consciously left unfixed. Phase verification: 10/10
  acceptance criteria passed.
  - **Not run locally** (delegated to remote CI per repo convention): e2e suite and singlebox
  full-stack validation.

  ## Compatibility and risk

  - **Config:** new optional key `post_extend_consistency_tol_minutes` (default 5). No YAML
  edit required for existing deployments.
  - **Config:** `renew_threshold_hours` is kept-and-asserted. Fail-fast semantics: a deployment
  whose explicit threshold does not match `effective_ttl // 2` (effective_ttl = 1440 when
  section `arca` is absent) will now fail at boot — intentional, so stale YAML surfaces at
  deploy time instead of producing silently mismatched renews. Odd half-period TTL deployments
  must **omit** the key (derivation then applies automatically).
  - **Data/contract:** no DB schema change; `renewal_scheduler.engine` switching semantics
  untouched.
  - **Rollback:** standard commit revert; no migration involved.