### PR TITLE
fix(backend): log Skill Center publication diagnostics

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_publication_task.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_publication_task.py
@@ -274,6 +274,29 @@ class SpaceSkillPublicationTaskHandler:
                 )
             )
         except SkillCenterGatewayError as exc:
+            diagnostics = {
+                "attempt_id": work.attempt.attempt_id,
+                "space_id": work.space_id,
+                "skill_id": work.attempt.skill_id,
+                "skill_uuid": work.skill_uuid,
+                "team_id": work.sc_team_id,
+                "sc_version_number": work.attempt.sc_version_number,
+                "gateway_error_code": exc.code.value,
+                "upstream_code": exc.upstream_code,
+                "upstream_trace_id": exc.trace_id,
+                "env": env,
+            }
+            logger.warning(
+                "[skill_center.publication.submit] failed "
+                "attempt_id=%(attempt_id)s space_id=%(space_id)s "
+                "skill_id=%(skill_id)s skill_uuid=%(skill_uuid)s "
+                "team_id=%(team_id)s sc_version_number=%(sc_version_number)s "
+                "gateway_error_code=%(gateway_error_code)s "
+                "upstream_code=%(upstream_code)s "
+                "upstream_trace_id=%(upstream_trace_id)s env=%(env)s",
+                diagnostics,
+                extra=diagnostics,
+            )
             if exc.code in (
                 SkillCenterGatewayErrorCode.BUSINESS,
                 SkillCenterGatewayErrorCode.TEAM_NOT_FOUND,

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from datetime import UTC, datetime
 import io
+import logging
 from pathlib import Path
 from threading import Barrier, Event, Thread, current_thread
 from uuid import uuid4
@@ -895,11 +896,13 @@ class _Gateway:
         *,
         timeout_once: bool = False,
         timeout_message: str = "outcome unknown",
+        submit_error: SkillCenterGatewayError | None = None,
         exact_missing_once: bool = False,
         status_state: SkillCenterPublishState = SkillCenterPublishState.PUBLISHED,
     ) -> None:
         self.timeout_once = timeout_once
         self.timeout_message = timeout_message
+        self.submit_error = submit_error
         self.exact_missing_once = exact_missing_once
         self.status_state = status_state
         self.submit_calls = 0
@@ -907,6 +910,8 @@ class _Gateway:
 
     def submit_publish(self, request):
         self.submit_calls += 1
+        if self.submit_error is not None:
+            raise self.submit_error
         if self.timeout_once:
             self.timeout_once = False
             raise SkillCenterGatewayError(
@@ -1137,6 +1142,69 @@ def test_submit_timeout_enters_result_unknown_and_never_reposts() -> None:
         handler.handle(publication_task_payload(attempt.attempt_id)), Complete
     )
     assert gateway.submit_calls == 1
+
+
+def test_submit_rejection_logs_safe_upstream_diagnostics(caplog) -> None:
+    db = _Database()
+    space_id, skill_id = _seed_draft(db, lease_holder="owner")
+    repository = SpaceSkillPublicationRepository(db)
+    attempt = repository.create_or_replay_attempt(
+        space_id=space_id,
+        skill_id=skill_id,
+        actor_id="owner",
+        request_id="worker-business-rejection",
+        env="test",
+    ).attempt
+    with db.orm_session() as session:
+        skill = session.get(Skill, skill_id)
+        space = session.get(SpaceModel, space_id)
+        assert skill is not None
+        assert space is not None
+        expected_skill_uuid = skill.skill_uuid
+        expected_team_id = space.sc_team_id
+    secret_url = "https://sc.invalid/download.zip?signature=do-not-leak"
+    gateway = _Gateway(
+        submit_error=SkillCenterGatewayError(
+            SkillCenterGatewayErrorCode.BUSINESS,
+            secret_url,
+            upstream_code="ILLEGAL_PERMISSION",
+            trace_id="sc-trace-rejected",
+        )
+    )
+    handler = _handler(db, repository, gateway, _Materializer(db))
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger=(
+            "agentclaw.community.core.skill_center.services."
+            "space_skill_publication_task"
+        ),
+    ):
+        result = handler.handle(publication_task_payload(attempt.attempt_id))
+
+    assert isinstance(result, Complete)
+    [record] = [
+        record
+        for record in caplog.records
+        if record.getMessage().startswith("[skill_center.publication.submit] failed")
+    ]
+    assert record.attempt_id == attempt.attempt_id
+    assert record.space_id == space_id
+    assert record.skill_id == skill_id
+    assert record.skill_uuid == expected_skill_uuid
+    assert record.team_id == expected_team_id
+    assert record.sc_version_number == "1.0.0"
+    assert record.gateway_error_code == "business_error"
+    assert record.upstream_code == "ILLEGAL_PERMISSION"
+    assert record.upstream_trace_id == "sc-trace-rejected"
+    assert record.env == "test"
+    assert f"attempt_id={attempt.attempt_id}" in caplog.text
+    assert f"skill_uuid={expected_skill_uuid}" in caplog.text
+    assert f"team_id={expected_team_id}" in caplog.text
+    assert "upstream_code=ILLEGAL_PERMISSION" in caplog.text
+    assert "upstream_trace_id=sc-trace-rejected" in caplog.text
+    assert "signature" not in caplog.text
+    assert secret_url not in caplog.text
 
 
 def test_sc_explicit_failure_restores_the_same_draft_to_editing() -> None:


### PR DESCRIPTION
## Problem

Space Skill publication submission failures are collapsed to `SC_PUBLISH_REJECTED`, which discards the Skill Center upstream error code and trace ID needed to diagnose pre-release failures.

## Solution

Log one warning when the publication worker catches a normalized Skill Center submission error. The log includes the publication attempt, Space, Skill, Team, SC version, normalized gateway error, upstream error code, upstream trace ID, and environment.

The log deliberately excludes the exception message, appKey, Cookie, and signed package URL. Publication state transitions, retry policy, and public contracts are unchanged.

## Validation

- `31 passed`: publication repository, publication gateway contract, publication DI wiring, and publication service tests.
- Focused regression verifies `upstream_code` and `upstream_trace_id` are searchable while a signed URL embedded in the exception message is not logged.
- Ruff check passed; changed production file is Ruff-formatted.
- Python SAST block scan passed for the changed production file.
- Standards/Spec dual-axis review passed after fixing the Skill UUID field name and removing duplicated diagnostic definitions.
- Backend full suite was stopped at the user request after `1224 passed, 2 skipped` with no failures; GitHub CI is the final full gate.

## Compatibility and risk

No API, database schema, task payload, or publication state-machine changes. Additional log volume occurs only when a Skill Center publication submission raises a normalized gateway error. Rollback is the single commit in this PR.