### PR TITLE
fix(bcs): stop remote chat-run runtime DDL

### DIFF
--- a/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/src/sql.rs
@@ -163,6 +163,9 @@ impl SqlChatRunRepo {
         if self.schema_ready.load(Ordering::Relaxed) {
             return Ok(());
         }
+        if self.flavor != DbSqlFlavor::Sqlite {
+            return Ok(());
+        }
         let create = "CREATE TABLE IF NOT EXISTS bcs_chat_runs (\
             id INTEGER PRIMARY KEY AUTOINCREMENT,\
             gmt_create TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,\

--- a/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
+++ b/src/bcs/crates/services/bcs-chat-run-store/tests/sql_repo.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -195,6 +195,77 @@ fn record(run_id: &str, version: u64) -> ChatRunRecord {
     );
     record.version = version;
     record
+}
+
+struct RecordingDb {
+    executed_sql: Mutex<Vec<String>>,
+}
+
+impl RecordingDb {
+    fn new() -> Self {
+        Self {
+            executed_sql: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn executed_sql(&self) -> Vec<String> {
+        self.executed_sql
+            .lock()
+            .expect("recording db lock")
+            .clone()
+    }
+}
+
+#[async_trait]
+impl DbPlugin for RecordingDb {
+    async fn query(&self, _statement: DbStatement) -> DbResult<Vec<DbRow>> {
+        Ok(Vec::new())
+    }
+
+    async fn execute(&self, statement: DbStatement) -> DbResult<DbExecuteResult> {
+        self.executed_sql
+            .lock()
+            .expect("recording db lock")
+            .push(statement.sql().to_string());
+        Ok(DbExecuteResult {
+            affected_rows: 1,
+            last_insert_id: None,
+        })
+    }
+
+    async fn transaction(
+        &self,
+        _steps: Vec<DbTransactionStep>,
+    ) -> DbResult<Vec<DbTransactionStepResult>> {
+        Ok(Vec::new())
+    }
+
+    async fn health_check(&self) -> DbResult<DbHealth> {
+        Ok(DbHealth::healthy())
+    }
+}
+
+#[tokio::test]
+async fn mysql_create_does_not_issue_runtime_ddl() {
+    let db = Arc::new(RecordingDb::new());
+    let repo = SqlChatRunRepo::new(
+        db.clone(),
+        DbSqlFlavor::Mysql,
+        Arc::new(InMemoryCachePlugin::new()),
+        "bcs:".to_string(),
+        120_000,
+        "test".to_string(),
+    );
+
+    repo.create(record("remote", 1)).await.unwrap();
+
+    let sql = db.executed_sql();
+    assert_eq!(sql.len(), 1, "remote create must issue only the INSERT");
+    assert!(sql[0].starts_with("INSERT INTO bcs_chat_runs"));
+    assert!(
+        sql.iter()
+            .all(|statement| !statement.starts_with("CREATE "))
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem
Persistent Direct Chat run creation called the embedded SQLite schema bootstrap before the first insert in each process. In MySQL/OceanBase production this sent INTEGER PRIMARY KEY AUTOINCREMENT through Layotto and caused chat_async to return HTTP 500.

## Solution
- Skip repository schema initialization for non-SQLite SQL flavors.
- Preserve the existing local SQLite schema bootstrap.
- Add a regression test proving MySQL create issues only the INSERT and never runtime DDL.

## Validation
- cargo test -p bcs-chat-run-store: 30 tests passed.
- cargo check -p bcs: passed with pre-existing warnings in unrelated crates.
- Push used --no-verify as requested; no post-rebase verification was run.

## Compatibility and risk
No Service API, Plugin API, configuration, or schema changes. MySQL/OceanBase deployments must provision bcs_chat_runs through the existing platform migration path. SQLite behavior is unchanged.