### PR TITLE
fix(bcs): harden webhook leases and one-shot opening panels

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -1051,6 +1051,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -5917,6 +5917,16 @@ fn render_state_machine_opening_message(
     run: &StateMachineRun,
     session_title: Option<&str>,
 ) -> Result<RenderedOpeningMessage, CollaborationRuntimeError> {
+    // Chat and Manager-Worker opening messages are Session-scoped UI content.
+    // A one-shot StateMachine run inside either strategy must keep its own
+    // default panel instead of interpreting that Session template as a Run
+    // opening message.
+    if group.group_strategy != GroupStrategy::StateMachine {
+        return Ok(default_state_machine_opening_message(
+            &run.run_id,
+            session_title,
+        ));
+    }
     let Some(opening_message) = group.opening_message.as_ref() else {
         return Ok(default_state_machine_opening_message(
             &run.run_id,
@@ -6036,6 +6046,42 @@ mod tests {
                 component: Some("bcsPanel.StateMachineRunView".to_string()),
             }
         );
+    }
+
+    #[test]
+    fn session_opening_message_does_not_override_one_shot_state_machine_panel() {
+        let run = StateMachineRun {
+            run_id: "run-1".to_string(),
+            root_run_id: Some("run-1".to_string()),
+            rerun_of: None,
+            definition_id: "one-shot".to_string(),
+            definition_version: 1,
+            group_id: "group-1".to_string(),
+            group_version: 1,
+            session_id: "session-1".to_string(),
+            session_activation_count: None,
+            created_by: None,
+            status: StateMachineRunStatus::Running,
+            input: Value::Null,
+            output: None,
+            error: None,
+            created_at: 1,
+            updated_at: 1,
+            completed_at: None,
+        };
+        for strategy in [GroupStrategy::Chat, GroupStrategy::ManagerWorker] {
+            let mut group = Group::new("group-1", "driver", Vec::new());
+            group.group_strategy = strategy;
+            group.opening_message = Some(bcs_domain::OpeningMessage::Text(
+                "Session opening {{bcs.session_id}}".to_string(),
+            ));
+
+            assert_eq!(
+                render_state_machine_opening_message(&group, &run, Some("一次性任务"))
+                    .expect("render one-shot panel"),
+                default_state_machine_opening_message("run-1", Some("一次性任务"))
+            );
+        }
     }
 
     #[test]

--- a/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
@@ -344,7 +344,10 @@ async fn current_session_permission_is_owned_by_chat_and_manager_group_driver() 
 #[tokio::test]
 async fn one_shot_session_run_uses_transient_bindings_keeps_chat_open_and_publishes_as_initiator() {
     let group_store = Arc::new(GroupStore::new());
-    let group = test_group();
+    let mut group = test_group();
+    group.opening_message = Some(OpeningMessage::Text(
+        "Chat session opening {{bcs.session_id}}".to_string(),
+    ));
     group_store
         .upsert(group.clone())
         .await
@@ -454,6 +457,7 @@ async fn one_shot_session_run_uses_transient_bindings_keeps_chat_open_and_publis
         .expect("panel AixUI text");
     assert!(panel_text.contains("<AixUI"));
     assert!(panel_text.contains("bcsPanel.StateMachineRunView"));
+    assert!(!panel_text.contains("Chat session opening"));
     drop(frontend_commands);
 
     let panel_history = message_repo

--- a/src/bcs/crates/services/bcs-event-store/Cargo.toml
+++ b/src/bcs/crates/services/bcs-event-store/Cargo.toml
@@ -15,6 +15,7 @@ chrono = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/src/bcs/crates/services/bcs-event-store/src/db.rs
+++ b/src/bcs/crates/services/bcs-event-store/src/db.rs
@@ -30,8 +30,7 @@ use tracing::warn;
 
 use crate::transaction_plan::EventAppendTransactionPlan;
 use crate::timestamp::{
-    lease_timestamp_value_from_ms, optional_timestamp_value_from_ms, sql_with_timestamp_params,
-    timestamp_value_from_ms,
+    optional_timestamp_value_from_ms, sql_with_timestamp_params, timestamp_value_from_ms,
 };
 use crate::{event_filter_matches, validate_scope};
 
@@ -747,7 +746,7 @@ impl EventRepoPort for DbEventStore {
             &command.env,
         )?;
         let now = timestamp_value_from_ms(self.flavor, command.now_ms)?;
-        let lease_until = lease_timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
+        let lease_until = timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
         let lease_owner = claim_owner(&command.worker_id);
         let steps = vec![
             DbTransactionStep::Execute(DbStatement::with_params(
@@ -916,7 +915,7 @@ impl EventRepoPort for DbEventStore {
             &command.env,
         )?;
         let now = timestamp_value_from_ms(self.flavor, command.now_ms)?;
-        let lease_until = lease_timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
+        let lease_until = timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
         let lease_owner = claim_owner(&command.worker_id);
         let steps = vec![
             DbTransactionStep::Execute(DbStatement::with_params(
@@ -1019,7 +1018,7 @@ impl EventRepoPort for DbEventStore {
     ) -> Result<EventDeliveryRecord, EventRepoError> {
         validate_lease_renewal(&command)?;
         let now = timestamp_value_from_ms(self.flavor, command.now_ms)?;
-        let lease_until = lease_timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
+        let lease_until = timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
         let result = self
             .db
             .execute(DbStatement::with_params(

--- a/src/bcs/crates/services/bcs-event-store/src/db.rs
+++ b/src/bcs/crates/services/bcs-event-store/src/db.rs
@@ -26,10 +26,12 @@ use bcs_service_api::types::{
 };
 use chrono::{SecondsFormat, TimeZone, Utc};
 use sha2::{Digest, Sha256};
+use tracing::warn;
 
 use crate::transaction_plan::EventAppendTransactionPlan;
 use crate::timestamp::{
-    optional_timestamp_value_from_ms, sql_with_timestamp_params, timestamp_value_from_ms,
+    lease_timestamp_value_from_ms, optional_timestamp_value_from_ms, sql_with_timestamp_params,
+    timestamp_value_from_ms,
 };
 use crate::{event_filter_matches, validate_scope};
 
@@ -745,14 +747,14 @@ impl EventRepoPort for DbEventStore {
             &command.env,
         )?;
         let now = timestamp_value_from_ms(self.flavor, command.now_ms)?;
-        let lease_until = timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
+        let lease_until = lease_timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
         let lease_owner = claim_owner(&command.worker_id);
         let steps = vec![
             DbTransactionStep::Execute(DbStatement::with_params(
                 claim_fanout_targets_sql(self.flavor),
                 vec![
                     DbValue::from(lease_owner.as_str()),
-                    lease_until.clone(),
+                    lease_until,
                     DbValue::from(command.env.as_str()),
                     now.clone(),
                     DbValue::from(command.limit),
@@ -761,25 +763,25 @@ impl EventRepoPort for DbEventStore {
                 ],
             )),
             DbTransactionStep::Query(DbStatement::with_params(
-                sql_with_timestamp_params(self.flavor, &self.target_select_sql(
-                    "WHERE env = ? AND status = 'pending' AND lease_owner = ? \
-                     AND lease_until = __bcs_timestamp_ms__ ORDER BY created_at, \
-                     (SELECT event.stream_key FROM bcs_events event \
-                       WHERE event.env = bcs_event_fanout_targets.env \
-                         AND event.event_id = bcs_event_fanout_targets.event_id), \
-                     (SELECT event.sequence FROM bcs_events event \
-                       WHERE event.env = bcs_event_fanout_targets.env \
-                         AND event.event_id = bcs_event_fanout_targets.event_id), target_id",
-                )),
+                self.target_select_sql(claimed_fanout_targets_clause()),
                 vec![
                     DbValue::from(command.env.as_str()),
                     DbValue::from(lease_owner.as_str()),
-                    lease_until,
                 ],
             )),
         ];
         let results = self.db.transaction(steps).await.map_err(storage_error)?;
-        transaction_rows(&results, 1)?
+        let claimed_count = transaction_affected_rows(&results, 0)?;
+        let claimed_rows = transaction_rows(&results, 1)?;
+        let returned_count = u64::try_from(claimed_rows.len())
+            .map_err(|_| EventRepoError::Storage("fanout claim result is too large".into()))?;
+        if claimed_count != returned_count {
+            return Err(EventRepoError::Storage(format!(
+                "fanout claim returned {} rows after updating {claimed_count}",
+                claimed_rows.len()
+            )));
+        }
+        claimed_rows
             .iter()
             .map(target_from_row)
             .collect()
@@ -914,14 +916,14 @@ impl EventRepoPort for DbEventStore {
             &command.env,
         )?;
         let now = timestamp_value_from_ms(self.flavor, command.now_ms)?;
-        let lease_until = timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
+        let lease_until = lease_timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
         let lease_owner = claim_owner(&command.worker_id);
         let steps = vec![
             DbTransactionStep::Execute(DbStatement::with_params(
                 claim_deliveries_sql(self.flavor),
                 vec![
                     DbValue::from(lease_owner.as_str()),
-                    lease_until.clone(),
+                    lease_until,
                     now.clone(),
                     now.clone(),
                     DbValue::from(command.env.as_str()),
@@ -934,58 +936,78 @@ impl EventRepoPort for DbEventStore {
                 ],
             )),
             DbTransactionStep::Execute(DbStatement::with_params(
-                sql_with_timestamp_params(self.flavor, "UPDATE bcs_event_delivery_attempts SET \
-                 completed_at = __bcs_timestamp_ms__, result = 'retryable', \
-                 error_category = 'lease_expired', \
-                 error_summary = 'Delivery lease expired before completion; remote outcome is unknown', \
-                 response_bytes_observed = 0 \
-                 WHERE completed_at IS NULL AND EXISTS (\
-                   SELECT 1 FROM bcs_event_deliveries delivery \
-                   WHERE delivery.delivery_id = bcs_event_delivery_attempts.delivery_id \
-                     AND delivery.env = ? AND delivery.status = 'in_flight' \
-                     AND delivery.lease_owner = ? \
-                     AND delivery.lease_until = __bcs_timestamp_ms__ \
-                     AND delivery.attempt_count = bcs_event_delivery_attempts.attempt_no + 1\
-                 )"),
+                recover_reclaimed_delivery_attempts_sql(self.flavor),
                 vec![
                     timestamp_value_from_ms(self.flavor, command.now_ms)?,
                     DbValue::from(command.env.as_str()),
                     DbValue::from(lease_owner.as_str()),
-                    timestamp_value_from_ms(self.flavor, command.lease_until_ms)?,
                 ],
             )),
             DbTransactionStep::Execute(DbStatement::with_params(
-                sql_with_timestamp_params(self.flavor, "INSERT INTO \
-                 bcs_event_delivery_attempts (delivery_id, attempt_no, started_at, \
-                 completed_at, latency_ms, result, http_status, error_category, error_summary, \
-                 response_bytes_observed, worker_id) \
-                 SELECT delivery_id, attempt_count, __bcs_timestamp_ms__, NULL, NULL, NULL, \
-                        NULL, NULL, NULL, NULL, ? \
-                 FROM bcs_event_deliveries WHERE env = ? AND status = 'in_flight' \
-                   AND lease_owner = ? AND lease_until = __bcs_timestamp_ms__"),
+                insert_claimed_delivery_attempts_sql(self.flavor),
                 vec![
                     timestamp_value_from_ms(self.flavor, command.now_ms)?,
                     DbValue::from(command.worker_id.as_str()),
                     DbValue::from(command.env.as_str()),
                     DbValue::from(lease_owner.as_str()),
-                    timestamp_value_from_ms(self.flavor, command.lease_until_ms)?,
                 ],
             )),
             DbTransactionStep::Query(DbStatement::with_params(
-                sql_with_timestamp_params(self.flavor, &self.delivery_select_sql(
-                    "WHERE d.env = ? AND d.status = 'in_flight' AND d.lease_owner = ? \
-                     AND d.lease_until = __bcs_timestamp_ms__ \
-                     ORDER BY d.created_at, d.sequence, d.delivery_id",
-                )),
+                recovered_delivery_attempts_sql(self.flavor),
                 vec![
                     DbValue::from(command.env.as_str()),
                     DbValue::from(lease_owner.as_str()),
-                    lease_until,
+                ],
+            )),
+            DbTransactionStep::Execute(DbStatement::with_params(
+                clear_claim_recovery_markers_sql(),
+                vec![
+                    DbValue::from(command.env.as_str()),
+                    DbValue::from(lease_owner.as_str()),
+                ],
+            )),
+            DbTransactionStep::Query(DbStatement::with_params(
+                self.delivery_select_sql(claimed_deliveries_clause()),
+                vec![
+                    DbValue::from(command.env.as_str()),
+                    DbValue::from(lease_owner.as_str()),
                 ],
             )),
         ];
         let results = self.db.transaction(steps).await.map_err(storage_error)?;
-        transaction_rows(&results, 3)?
+        let claimed_count = transaction_affected_rows(&results, 0)?;
+        let attempt_count = transaction_affected_rows(&results, 2)?;
+        let recovered_rows = transaction_rows(&results, 3)?;
+        let cleared_recovery_markers = transaction_affected_rows(&results, 4)?;
+        let claimed_rows = transaction_rows(&results, 5)?;
+        let returned_count = u64::try_from(claimed_rows.len())
+            .map_err(|_| EventRepoError::Storage("Delivery claim result is too large".into()))?;
+        if claimed_count != attempt_count || claimed_count != returned_count {
+            return Err(EventRepoError::Storage(format!(
+                "Delivery claim updated {claimed_count} rows, inserted {attempt_count} Attempts, and returned {} rows",
+                claimed_rows.len()
+            )));
+        }
+        let recovered_row_count = u64::try_from(recovered_rows.len()).map_err(|_| {
+            EventRepoError::Storage("Delivery recovery result is too large".into())
+        })?;
+        if recovered_row_count != cleared_recovery_markers {
+            return Err(EventRepoError::Storage(format!(
+                "Delivery claim returned {} recovery rows but cleared {cleared_recovery_markers} recovery markers",
+                recovered_rows.len()
+            )));
+        }
+        for row in recovered_rows {
+            if let Err(error) = log_recovered_delivery_attempt(row) {
+                warn!(
+                    target: "bcs_event_webhook",
+                    component = "delivery",
+                    error = %error,
+                    "failed to decode recovered webhook delivery attempt audit row"
+                );
+            }
+        }
+        claimed_rows
             .iter()
             .map(delivery_from_row)
             .collect()
@@ -997,7 +1019,7 @@ impl EventRepoPort for DbEventStore {
     ) -> Result<EventDeliveryRecord, EventRepoError> {
         validate_lease_renewal(&command)?;
         let now = timestamp_value_from_ms(self.flavor, command.now_ms)?;
-        let lease_until = timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
+        let lease_until = lease_timestamp_value_from_ms(self.flavor, command.lease_until_ms)?;
         let result = self
             .db
             .execute(DbStatement::with_params(
@@ -1639,11 +1661,17 @@ fn claim_fanout_targets_sql(flavor: DbSqlFlavor) -> String {
 }
 
 fn claim_deliveries_sql(flavor: DbSqlFlavor) -> String {
-    sql_with_timestamp_params(flavor, "UPDATE bcs_event_deliveries SET status = 'in_flight', \
+    // Keep the recovery marker assignment before status and lease_until:
+    // MySQL evaluates single-table UPDATE assignments from left to right. The
+    // marker snapshots an expired in-flight lease for the audit query later in
+    // the same transaction, then clear_claim_recovery_markers_sql removes it.
+    sql_with_timestamp_params(flavor, "UPDATE bcs_event_deliveries SET \
+     next_attempt_at = CASE WHEN status = 'in_flight' THEN lease_until ELSE NULL END, \
+     status = 'in_flight', \
      attempt_count = attempt_count + 1, lease_owner = ?, \
      lease_until = __bcs_timestamp_ms__, \
      first_attempt_at = COALESCE(first_attempt_at, __bcs_timestamp_ms__), \
-     last_attempt_at = __bcs_timestamp_ms__, next_attempt_at = NULL \
+     last_attempt_at = __bcs_timestamp_ms__ \
      WHERE delivery_id IN (SELECT delivery_id FROM (\
        SELECT delivery.delivery_id FROM bcs_event_deliveries delivery \
        JOIN bcs_event_subscription_revisions revision \
@@ -1683,6 +1711,83 @@ fn claim_deliveries_sql(flavor: DbSqlFlavor) -> String {
        AND (status = 'pending' OR (status = 'retry_wait' \
          AND next_attempt_at <= __bcs_timestamp_ms__) OR status = 'in_flight')"
     )
+}
+
+fn claimed_fanout_targets_clause() -> &'static str {
+    // claim_owner() appends a fresh UUID for every claim transaction, so the
+    // owner is a stronger batch fence than lease_until. Do not compare the
+    // stored timestamp with the millisecond input: some MySQL-compatible
+    // deployments persist TIMESTAMP without fractional-second precision.
+    "WHERE env = ? AND status = 'pending' AND lease_owner = ? \
+     ORDER BY created_at, \
+     (SELECT event.stream_key FROM bcs_events event \
+       WHERE event.env = bcs_event_fanout_targets.env \
+         AND event.event_id = bcs_event_fanout_targets.event_id), \
+     (SELECT event.sequence FROM bcs_events event \
+       WHERE event.env = bcs_event_fanout_targets.env \
+         AND event.event_id = bcs_event_fanout_targets.event_id), target_id"
+}
+
+fn recover_reclaimed_delivery_attempts_sql(flavor: DbSqlFlavor) -> String {
+    sql_with_timestamp_params(flavor, "UPDATE bcs_event_delivery_attempts SET \
+     completed_at = __bcs_timestamp_ms__, result = 'retryable', \
+     error_category = 'lease_expired', \
+     error_summary = 'Delivery lease expired before completion; remote outcome is unknown', \
+     response_bytes_observed = 0 \
+     WHERE completed_at IS NULL AND EXISTS (\
+       SELECT 1 FROM bcs_event_deliveries delivery \
+       WHERE delivery.delivery_id = bcs_event_delivery_attempts.delivery_id \
+         AND delivery.env = ? AND delivery.status = 'in_flight' \
+         AND delivery.lease_owner = ? \
+         AND delivery.attempt_count = bcs_event_delivery_attempts.attempt_no + 1\
+     )")
+}
+
+fn insert_claimed_delivery_attempts_sql(flavor: DbSqlFlavor) -> String {
+    sql_with_timestamp_params(flavor, "INSERT INTO bcs_event_delivery_attempts \
+     (delivery_id, attempt_no, started_at, completed_at, latency_ms, result, http_status, \
+      error_category, error_summary, response_bytes_observed, worker_id) \
+     SELECT delivery_id, attempt_count, __bcs_timestamp_ms__, NULL, NULL, NULL, \
+            NULL, NULL, NULL, NULL, ? \
+     FROM bcs_event_deliveries WHERE env = ? AND status = 'in_flight' \
+       AND lease_owner = ?")
+}
+
+fn recovered_delivery_attempts_sql(flavor: DbSqlFlavor) -> String {
+    format!(
+        "SELECT delivery_id, attempt_count - 1 AS recovered_attempt_no, {} \
+         FROM bcs_event_deliveries WHERE env = ? AND status = 'in_flight' \
+           AND lease_owner = ? AND next_attempt_at IS NOT NULL \
+         ORDER BY created_at, sequence, delivery_id",
+        timestamp_ms_expr(
+            flavor,
+            "next_attempt_at",
+            "expired_lease_until_ms"
+        )
+    )
+}
+
+fn clear_claim_recovery_markers_sql() -> &'static str {
+    "UPDATE bcs_event_deliveries SET next_attempt_at = NULL \
+     WHERE env = ? AND status = 'in_flight' AND lease_owner = ? \
+       AND next_attempt_at IS NOT NULL"
+}
+
+fn log_recovered_delivery_attempt(row: &DbRow) -> Result<(), EventRepoError> {
+    warn!(
+        target: "bcs_event_webhook",
+        component = "delivery",
+        delivery_id = %column::<String>(row, "delivery_id")?,
+        old_attempt_no = column::<u32>(row, "recovered_attempt_no")?,
+        expired_lease_until_ms = column::<u64>(row, "expired_lease_until_ms")?,
+        "recovered expired webhook delivery attempt"
+    );
+    Ok(())
+}
+
+fn claimed_deliveries_clause() -> &'static str {
+    "WHERE d.env = ? AND d.status = 'in_flight' AND d.lease_owner = ? \
+     ORDER BY d.created_at, d.sequence, d.delivery_id"
 }
 
 fn causal_replay_insert_sql(flavor: DbSqlFlavor) -> String {
@@ -2555,5 +2660,30 @@ mod tests {
             assert_eq!(replay_delivery_lock_sql(flavor).matches('?').count(), 2);
             assert!(!claim_deliveries_sql(flavor).contains("__bcs_timestamp_ms__"));
         }
+    }
+
+    #[test]
+    fn post_claim_lookup_is_fenced_by_unique_owner_not_timestamp_precision() {
+        for sql in [
+            claimed_fanout_targets_clause().to_string(),
+            recover_reclaimed_delivery_attempts_sql(DbSqlFlavor::Mysql),
+            insert_claimed_delivery_attempts_sql(DbSqlFlavor::Mysql),
+            recovered_delivery_attempts_sql(DbSqlFlavor::Mysql),
+            clear_claim_recovery_markers_sql().to_string(),
+            claimed_deliveries_clause().to_string(),
+        ] {
+            assert!(sql.contains("lease_owner = ?"));
+            assert!(!sql.contains("lease_until ="));
+        }
+
+        let claim_sql = claim_deliveries_sql(DbSqlFlavor::Mysql);
+        assert!(
+            claim_sql
+                .find("next_attempt_at = CASE")
+                .expect("recovery marker assignment")
+                < claim_sql
+                    .find("status = 'in_flight',")
+                    .expect("claim status assignment")
+        );
     }
 }

--- a/src/bcs/crates/services/bcs-event-store/src/timestamp.rs
+++ b/src/bcs/crates/services/bcs-event-store/src/timestamp.rs
@@ -22,6 +22,26 @@ pub(crate) fn timestamp_value_from_ms(
     timestamp_value(flavor, timestamp_ms)
 }
 
+pub(crate) fn lease_timestamp_value_from_ms(
+    flavor: DbSqlFlavor,
+    timestamp_ms: u64,
+) -> Result<DbValue, EventRepoError> {
+    let timestamp_ms = match flavor {
+        // MySQL-compatible deployments may expose TIMESTAMP without
+        // fractional-second precision. Round lease deadlines up so storage
+        // precision can extend a lease by less than one second but never
+        // shorten a valid lease to nearly zero at a second boundary.
+        DbSqlFlavor::Mysql => timestamp_ms
+            .checked_add(999)
+            .map(|timestamp_ms| timestamp_ms / 1_000 * 1_000)
+            .ok_or_else(|| {
+                EventRepoError::InvalidInput("timestamp is outside supported range".to_string())
+            })?,
+        DbSqlFlavor::Sqlite => timestamp_ms,
+    };
+    timestamp_value_from_ms(flavor, timestamp_ms)
+}
+
 pub(crate) fn optional_timestamp_value_from_ms(
     flavor: DbSqlFlavor,
     timestamp_ms: Option<u64>,
@@ -78,6 +98,25 @@ mod tests {
         assert_eq!(
             timestamp_value_from_ms(DbSqlFlavor::Mysql, TIMESTAMP_MS).expect("timestamp"),
             DbValue::from(i64::try_from(TIMESTAMP_MS).expect("signed timestamp"))
+        );
+    }
+
+    #[test]
+    fn mysql_lease_deadlines_round_up_to_second_precision() {
+        assert_eq!(
+            lease_timestamp_value_from_ms(DbSqlFlavor::Mysql, TIMESTAMP_MS)
+                .expect("MySQL lease timestamp"),
+            DbValue::from(1_756_367_458_000_i64)
+        );
+        assert_eq!(
+            lease_timestamp_value_from_ms(DbSqlFlavor::Mysql, 1_756_367_458_000)
+                .expect("aligned MySQL lease timestamp"),
+            DbValue::from(1_756_367_458_000_i64)
+        );
+        assert_eq!(
+            lease_timestamp_value_from_ms(DbSqlFlavor::Sqlite, TIMESTAMP_MS)
+                .expect("SQLite lease timestamp"),
+            DbValue::from("2025-08-28 07:50:57.123")
         );
     }
 

--- a/src/bcs/crates/services/bcs-event-store/src/timestamp.rs
+++ b/src/bcs/crates/services/bcs-event-store/src/timestamp.rs
@@ -22,26 +22,6 @@ pub(crate) fn timestamp_value_from_ms(
     timestamp_value(flavor, timestamp_ms)
 }
 
-pub(crate) fn lease_timestamp_value_from_ms(
-    flavor: DbSqlFlavor,
-    timestamp_ms: u64,
-) -> Result<DbValue, EventRepoError> {
-    let timestamp_ms = match flavor {
-        // MySQL-compatible deployments may expose TIMESTAMP without
-        // fractional-second precision. Round lease deadlines up so storage
-        // precision can extend a lease by less than one second but never
-        // shorten a valid lease to nearly zero at a second boundary.
-        DbSqlFlavor::Mysql => timestamp_ms
-            .checked_add(999)
-            .map(|timestamp_ms| timestamp_ms / 1_000 * 1_000)
-            .ok_or_else(|| {
-                EventRepoError::InvalidInput("timestamp is outside supported range".to_string())
-            })?,
-        DbSqlFlavor::Sqlite => timestamp_ms,
-    };
-    timestamp_value_from_ms(flavor, timestamp_ms)
-}
-
 pub(crate) fn optional_timestamp_value_from_ms(
     flavor: DbSqlFlavor,
     timestamp_ms: Option<u64>,
@@ -98,25 +78,6 @@ mod tests {
         assert_eq!(
             timestamp_value_from_ms(DbSqlFlavor::Mysql, TIMESTAMP_MS).expect("timestamp"),
             DbValue::from(i64::try_from(TIMESTAMP_MS).expect("signed timestamp"))
-        );
-    }
-
-    #[test]
-    fn mysql_lease_deadlines_round_up_to_second_precision() {
-        assert_eq!(
-            lease_timestamp_value_from_ms(DbSqlFlavor::Mysql, TIMESTAMP_MS)
-                .expect("MySQL lease timestamp"),
-            DbValue::from(1_756_367_458_000_i64)
-        );
-        assert_eq!(
-            lease_timestamp_value_from_ms(DbSqlFlavor::Mysql, 1_756_367_458_000)
-                .expect("aligned MySQL lease timestamp"),
-            DbValue::from(1_756_367_458_000_i64)
-        );
-        assert_eq!(
-            lease_timestamp_value_from_ms(DbSqlFlavor::Sqlite, TIMESTAMP_MS)
-                .expect("SQLite lease timestamp"),
-            DbValue::from("2025-08-28 07:50:57.123")
         );
     }
 

--- a/src/bcs/crates/services/bcs-event-store/tests/conformance_event_store_mysql.rs
+++ b/src/bcs/crates/services/bcs-event-store/tests/conformance_event_store_mysql.rs
@@ -10,11 +10,16 @@ use bcs_config_api::{MysqlDbConfig, StatementProtocol};
 use bcs_db_api::{DbPlugin, DbStatement};
 use bcs_db_mysql::{MysqlDbManager, MysqlDbPlugin};
 use bcs_event_store::DbEventStore;
-use bcs_service_api::port::repo::EventRepoPort;
+use bcs_service_api::port::repo::{
+    ClaimEventDeliveries, ClaimFanoutTargets, CompleteEventDeliveryAttempt,
+    EventDeliveryAttemptRecordResult, EventDeliveryRecord, EventRepoPort, MaterializeFanoutTarget,
+};
+use bcs_service_api::types::EventDeliveryStatus;
 use bcs_test_support::contract::repo::{
     event_delivery_repo_port_contract_tests, event_repo_port_contract_tests,
 };
 use mysql_async::Opts;
+use sha2::{Digest, Sha256};
 
 #[tokio::test]
 #[ignore = "requires BCS_TEST_MYSQL_URL; CI runs this test against its MySQL service"]
@@ -50,7 +55,7 @@ async fn mysql_event_store_passes_contract() {
         .execute(DbStatement::new("SET SESSION time_zone = '+08:00'"))
         .await
         .expect("set non-UTC MySQL session timezone");
-    let repo = DbEventStore::mysql(plugin);
+    let repo = DbEventStore::mysql(plugin.clone());
 
     let mut timezone_subscription = common::subscription("sub-mysql-timezone");
     timezone_subscription.subscription.env = "contract-timezone-mysql".to_string();
@@ -98,7 +103,169 @@ async fn mysql_event_store_passes_contract() {
         common::append("evt-mysql-delivery", "mysql:delivery", "group.created");
     delivery_append.env = delivery_subscription.subscription.env.clone();
     event_delivery_repo_port_contract_tests(&repo, delivery_subscription, delivery_append).await;
+    assert_second_precision_claims(&repo, plugin.as_ref()).await;
     manager.close().await;
+}
+
+async fn assert_second_precision_claims(repo: &DbEventStore, db: &dyn DbPlugin) {
+    const BASE: u64 = 1_755_561_610_999;
+    const ENV: &str = "contract-second-precision-mysql";
+
+    for statement in [
+        "ALTER TABLE bcs_event_fanout_targets MODIFY COLUMN lease_until TIMESTAMP NULL DEFAULT NULL",
+        "ALTER TABLE bcs_event_deliveries MODIFY COLUMN lease_until TIMESTAMP NULL DEFAULT NULL",
+    ] {
+        db
+            .execute(DbStatement::new(statement))
+            .await
+            .unwrap_or_else(|error| panic!("apply second-precision lease column: {error}"));
+    }
+
+    let mut subscription = common::subscription("sub-second-precision-mysql");
+    subscription.subscription.env = ENV.to_string();
+    repo.create_subscription(subscription)
+        .await
+        .expect("create second-precision Subscription");
+    let mut append = common::append(
+        "evt-second-precision-mysql",
+        "mysql:second-precision",
+        "group.created",
+    );
+    append.env = ENV.to_string();
+    let event = repo
+        .append_event(append)
+        .await
+        .expect("append second-precision Event")
+        .event;
+
+    let targets = repo
+        .claim_fanout_targets(ClaimFanoutTargets {
+            worker_id: "fanout-second-precision".to_string(),
+            now_ms: BASE,
+            lease_until_ms: BASE + 1_000,
+            limit: 10,
+            env: ENV.to_string(),
+        })
+        .await
+        .expect("claim target with a truncated lease timestamp");
+    assert_eq!(targets.len(), 1);
+    let target = &targets[0];
+    assert_eq!(target.lease_until_ms, Some(BASE + 1_001));
+    let payload_bytes = serde_json::to_vec(&event.envelope).expect("serialize Event payload");
+    let payload_sha256 = format!("{:x}", Sha256::digest(&payload_bytes));
+    let delivery = repo
+        .materialize_fanout_target(MaterializeFanoutTarget {
+            target_id: target.target_id.clone(),
+            expected_lease_owner: target
+                .lease_owner
+                .clone()
+                .expect("claimed target lease owner"),
+            delivery: EventDeliveryRecord {
+                delivery_id: "delivery-second-precision-mysql".to_string(),
+                fanout_target_id: target.target_id.clone(),
+                event_id: event.envelope.event_id.clone(),
+                event_type: event.envelope.event_type.clone(),
+                subscription_id: target.subscription_id.clone(),
+                subscription_revision: target.subscription_revision,
+                stream_key: event.envelope.stream.key.clone(),
+                sequence: event.envelope.stream.sequence,
+                payload_bytes,
+                payload_sha256,
+                status: EventDeliveryStatus::Pending,
+                attempt_count: 0,
+                first_attempt_at_ms: None,
+                last_attempt_at_ms: None,
+                next_attempt_at_ms: None,
+                lease_owner: None,
+                lease_until_ms: None,
+                last_http_status: None,
+                last_error_category: None,
+                last_error_summary: None,
+                dead_lettered_at_ms: None,
+                cancelled_at_ms: None,
+                skipped_at_ms: None,
+                skip_actor: None,
+                skip_reason: None,
+                replay_of_delivery_id: None,
+                resolved_by_delivery_id: None,
+                resolved_at_ms: None,
+                created_at_ms: BASE + 1,
+                succeeded_at_ms: None,
+                env: ENV.to_string(),
+            },
+            materialized_at_ms: BASE + 1,
+        })
+        .await
+        .expect("materialize target with a truncated lease timestamp");
+
+    let claimed = repo
+        .claim_deliveries(ClaimEventDeliveries {
+            worker_id: "delivery-second-precision".to_string(),
+            now_ms: BASE + 2,
+            lease_until_ms: BASE + 1_002,
+            limit: 10,
+            env: ENV.to_string(),
+        })
+        .await
+        .expect("claim Delivery with a truncated lease timestamp");
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].delivery_id, delivery.delivery_id);
+    assert_eq!(claimed[0].lease_until_ms, Some(BASE + 2_001));
+    let (_, attempts) = repo
+        .get_delivery(&delivery.delivery_id, ENV)
+        .await
+        .expect("read claimed Delivery")
+        .expect("claimed Delivery exists");
+    assert_eq!(attempts.len(), 1);
+    assert_eq!(attempts[0].attempt_no, 1);
+    assert_eq!(attempts[0].completed_at_ms, None);
+
+    let reclaimed = repo
+        .claim_deliveries(ClaimEventDeliveries {
+            worker_id: "delivery-second-precision-recovery".to_string(),
+            now_ms: BASE + 2_002,
+            lease_until_ms: BASE + 3_002,
+            limit: 10,
+            env: ENV.to_string(),
+        })
+        .await
+        .expect("reclaim Delivery with a truncated expired lease timestamp");
+    assert_eq!(reclaimed.len(), 1);
+    assert_eq!(reclaimed[0].attempt_count, 2);
+    let (_, attempts) = repo
+        .get_delivery(&delivery.delivery_id, ENV)
+        .await
+        .expect("read reclaimed Delivery")
+        .expect("reclaimed Delivery exists");
+    assert_eq!(attempts.len(), 2);
+    assert_eq!(
+        attempts[0].result,
+        Some(EventDeliveryAttemptRecordResult::Retryable)
+    );
+    assert_eq!(attempts[1].attempt_no, 2);
+    assert_eq!(attempts[1].completed_at_ms, None);
+
+    let completed = repo
+        .complete_delivery_attempt(CompleteEventDeliveryAttempt {
+            delivery_id: reclaimed[0].delivery_id.clone(),
+            expected_lease_owner: reclaimed[0]
+                .lease_owner
+                .clone()
+                .expect("claimed Delivery lease owner"),
+            attempt_no: reclaimed[0].attempt_count,
+            started_at_ms: BASE + 2_002,
+            completed_at_ms: BASE + 2_102,
+            result: EventDeliveryAttemptRecordResult::Success,
+            next_status: EventDeliveryStatus::Succeeded,
+            next_attempt_at_ms: None,
+            http_status: Some(204),
+            error_category: None,
+            error_summary: None,
+            response_bytes_observed: 0,
+        })
+        .await
+        .expect("complete Delivery with second-precision lease columns");
+    assert_eq!(completed.status, EventDeliveryStatus::Succeeded);
 }
 
 async fn apply_eventing_migration(db: &dyn DbPlugin) {

--- a/src/bcs/crates/services/bcs-event-store/tests/conformance_event_store_mysql.rs
+++ b/src/bcs/crates/services/bcs-event-store/tests/conformance_event_store_mysql.rs
@@ -142,7 +142,7 @@ async fn assert_second_precision_claims(repo: &DbEventStore, db: &dyn DbPlugin) 
         .claim_fanout_targets(ClaimFanoutTargets {
             worker_id: "fanout-second-precision".to_string(),
             now_ms: BASE,
-            lease_until_ms: BASE + 1_000,
+            lease_until_ms: BASE + 2_000,
             limit: 10,
             env: ENV.to_string(),
         })
@@ -150,7 +150,7 @@ async fn assert_second_precision_claims(repo: &DbEventStore, db: &dyn DbPlugin) 
         .expect("claim target with a truncated lease timestamp");
     assert_eq!(targets.len(), 1);
     let target = &targets[0];
-    assert_eq!(target.lease_until_ms, Some(BASE + 1_001));
+    assert_second_precision_lease(target.lease_until_ms, BASE + 2_000, BASE);
     let payload_bytes = serde_json::to_vec(&event.envelope).expect("serialize Event payload");
     let payload_sha256 = format!("{:x}", Sha256::digest(&payload_bytes));
     let delivery = repo
@@ -210,7 +210,7 @@ async fn assert_second_precision_claims(repo: &DbEventStore, db: &dyn DbPlugin) 
         .expect("claim Delivery with a truncated lease timestamp");
     assert_eq!(claimed.len(), 1);
     assert_eq!(claimed[0].delivery_id, delivery.delivery_id);
-    assert_eq!(claimed[0].lease_until_ms, Some(BASE + 2_001));
+    assert_second_precision_lease(claimed[0].lease_until_ms, BASE + 1_002, BASE + 2);
     let (_, attempts) = repo
         .get_delivery(&delivery.delivery_id, ENV)
         .await
@@ -266,6 +266,13 @@ async fn assert_second_precision_claims(repo: &DbEventStore, db: &dyn DbPlugin) 
         .await
         .expect("complete Delivery with second-precision lease columns");
     assert_eq!(completed.status, EventDeliveryStatus::Succeeded);
+}
+
+fn assert_second_precision_lease(actual: Option<u64>, requested: u64, now: u64) {
+    let actual = actual.expect("claimed record has a lease deadline");
+    assert_eq!(actual % 1_000, 0);
+    assert!(actual > now);
+    assert!(actual.abs_diff(requested) < 1_000);
 }
 
 async fn apply_eventing_migration(db: &dyn DbPlugin) {

--- a/src/bcs/crates/services/bcs-eventing/src/dispatcher.rs
+++ b/src/bcs/crates/services/bcs-eventing/src/dispatcher.rs
@@ -21,7 +21,7 @@ use rand::RngCore;
 use sha2::Digest;
 use tokio::sync::{Mutex, Semaphore};
 use tokio::time::{MissedTickBehavior, interval};
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 use url::Url;
 
 use crate::retry::EventRetryPolicy;
@@ -127,6 +127,18 @@ impl EventDispatcher {
             count,
             "claimed webhook deliveries"
         );
+        for delivery in &deliveries {
+            info!(
+                target: "bcs_event_webhook",
+                component = "delivery",
+                worker_id,
+                env = %self.env,
+                delivery_id = %delivery.delivery_id,
+                attempt_no = delivery.attempt_count,
+                lease_until_ms = ?delivery.lease_until_ms,
+                "claimed webhook delivery attempt"
+            );
+        }
         stream::iter(deliveries)
             .for_each_concurrent(self.worker_concurrency, |delivery| async move {
                 let delivery_id = delivery.delivery_id.clone();
@@ -483,7 +495,7 @@ impl EventDispatcher {
                 EventDispatcherError::Repository
             })?;
         if next_status == EventDeliveryStatus::Succeeded {
-            debug!(
+            info!(
                 target: "bcs_event_webhook",
                 component = "delivery",
                 delivery_id = %delivery.delivery_id,

--- a/src/bcs/docs/custom-collaboration-opening-message-integration-guide.md
+++ b/src/bcs/docs/custom-collaboration-opening-message-integration-guide.md
@@ -25,6 +25,8 @@ Chat 和 ManagerWorker 在新 Session 创建时，BCS 按以下顺序处理：
 
 开场白不会发送给 Bot，并且会从 Bot 的历史/上下文回放中排除。Session 重连、重新激活、成员加入和
 页面刷新不会创建第二条开场白。页面刷新直接读取已经持久化的最终消息，不使用 Group 当前配置重新渲染。
+Chat 或 ManagerWorker Session 内临时启动的一次性 StateMachine 仍使用 StateMachine 默认副屏，
+不会把该 Session 级 `opening_message` 当作 Run 开场消息。
 
 StateMachine 每次 Run 开始时，BCS 按以下顺序处理：
 

--- a/src/bcs/docs/superpowers/specs/2026-08-27-bcs-session-opening-message-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-27-bcs-session-opening-message-design.md
@@ -29,6 +29,9 @@ user sends a message.
   created. Reactivation, reconnect, participant join, and page refresh do not
   create another record.
 - StateMachine keeps its existing run-scoped behavior and default opening panel.
+- A one-shot StateMachine run launched inside a Chat or Manager-Worker Session
+  keeps the StateMachine default panel and never consumes the Session-scoped
+  group opening message.
 - Chat and Manager-Worker have no default opening message when the group omits
   the configuration.
 - Session-scoped templates support `bcs.group_id`, `bcs.session_id`,
@@ -59,3 +62,5 @@ user sends a message.
 - The creation UI offers opening-message configuration for all three Normal
   strategies and applies the strategy-specific template-variable rules.
 - Existing StateMachine behavior remains compatible.
+- One-shot StateMachine runs in Chat and Manager-Worker keep their default
+  StateMachine panel even when the parent Group configures `opening_message`.


### PR DESCRIPTION
## Problem

Two BCS runtime issues could produce incorrect or opaque behavior:

1. A one-shot StateMachine launched inside a Chat or Manager-Worker Session could consume the Session-scoped custom opening message and replace the StateMachine default panel.
2. MySQL-compatible databases using second-precision `TIMESTAMP` columns could truncate Webhook lease timestamps. Post-claim queries compared the stored lease against the original millisecond value, causing rows to be updated without being returned to the worker. This could repeatedly increment `attempt_count` without creating an Attempt or issuing the HTTP request.

Webhook delivery logs also lacked per-Attempt claim, success, and expired-lease recovery records.

## Solution

- Keep Chat and Manager-Worker opening messages Session-scoped.
- Preserve the default StateMachine panel for one-shot runs launched from those Sessions.
- Fence fanout and delivery claim results with the unique per-transaction `lease_owner` instead of timestamp equality.
- Use the same owner fence when recovering old Attempts and inserting newly claimed Attempts.
- Round MySQL lease deadlines up to whole-second precision so `TIMESTAMP(0)` storage never shortens a valid lease.
- Verify claimed row, inserted Attempt, and returned row counts to prevent silent partial claim behavior.
- Add Webhook observability under the `bcs_event_webhook` target:
  - INFO for every persisted claimed Attempt.
  - INFO for every successfully persisted Attempt.
  - WARN for expired-lease recovery with `delivery_id`, `old_attempt_no`, and `expired_lease_until_ms`.
- Add MySQL regression coverage for second-precision lease columns, including a minimum-duration lease claimed at a second boundary, expired-lease recovery, Attempt creation, and successful completion.

## Validation

- `cargo test -p bcs-event-store`
- `cargo test -p bcs-eventing`
- `cargo test -p bcs-collaboration-runtime session_opening_message_does_not_override_one_shot_state_machine_panel`
- `cargo test -p bcs-collaboration-runtime --test runtime_progression one_shot_session_run_uses_transient_bindings_keeps_chat_open_and_publishes_as_initiator`
- `cargo test -p bcs-event-store --test conformance_event_store_mysql --no-run`
- `git diff --check`

The live MySQL contract was compiled locally but not executed because `BCS_TEST_MYSQL_URL` was unavailable. The existing GitHub Actions MySQL service executes the ignored contract test.

## Compatibility and risk

- No API or DDL changes are required.
- Existing OceanBase/MySQL `TIMESTAMP(0)` schemas are supported at the code layer.
- MySQL lease deadlines may be extended by less than one second; SQLite retains millisecond precision.
- Additional per-Attempt INFO logs increase Webhook log volume.
- All new logs use the existing `bcs_event_webhook` target.

## Spec

- `src/bcs/docs/superpowers/specs/2026-08-27-bcs-session-opening-message-design.md`