### PR TITLE
fix(backend): materialize SC public manifest identity

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_center_reference.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_center_reference.py
@@ -280,6 +280,12 @@ class SkillCenterReferenceRepository(SkillCenterReferenceRepositoryProtocol):
             elif skill.skill_uuid != skill_uuid:
                 raise RuntimeError("SC Public locator has a conflicting identity")
 
+            # The first exact package may converge the provisional market
+            # display name to ``SKILL.md.name`` before PUBLISHED.  Every later
+            # Version inherits that frozen runtime identity; SC presentation
+            # metadata must never overwrite it.
+            version_name = str(skill.name)
+
             existing = (
                 session.query(SkillVersion)
                 .filter(
@@ -309,7 +315,7 @@ class SkillCenterReferenceRepository(SkillCenterReferenceRepositoryProtocol):
                     sc_version_number=sc_version_number,
                     sc_skill_id=sc_skill_id,
                     sc_version_id=sc_version_id,
-                    name=skill_name,
+                    name=version_name,
                     description=description,
                     metadata_json=None,
                     published_at=None,
@@ -482,8 +488,7 @@ class SkillCenterReferenceRepository(SkillCenterReferenceRepositoryProtocol):
         items = (
             session.query(SkillCenterReferenceItemModel)
             .filter(
-                SkillCenterReferenceItemModel.avernet_tenant
-                == row.avernet_tenant,
+                SkillCenterReferenceItemModel.avernet_tenant == row.avernet_tenant,
                 SkillCenterReferenceItemModel.env == row.env,
                 SkillCenterReferenceItemModel.request_id == row.request_id,
             )

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill_version.py
@@ -7,7 +7,11 @@ from datetime import datetime
 from injector import inject
 from sqlalchemy import and_, func
 
-from agentclaw.community.core.models.skill import Skill
+from agentclaw.community.core.models.skill import (
+    BotSkillInstallation,
+    Skill,
+    SkillSetSkill,
+)
 from agentclaw.community.core.models.space_skill import SkillSpaceBinding, SkillVersion
 from agentclaw.community.core.repository.protocols.skill_center import (
     SkillVersionMaterializationRepositoryProtocol,
@@ -121,9 +125,7 @@ class SkillVersionRepository(
                 or not git_path.startswith("center://")
                 or not git_path[len("center://") :]
             ):
-                raise RuntimeError(
-                    "Center Version has no stable Asset identity"
-                )
+                raise RuntimeError("Center Version has no stable Asset identity")
             return self._materializing(
                 version,
                 skill_uuid=skill_uuid,
@@ -136,6 +138,7 @@ class SkillVersionRepository(
         env: str,
         skill_id: int,
         skill_version_id: int,
+        name: str,
         metadata_json: str,
         description: str,
         published_at: datetime,
@@ -152,7 +155,8 @@ class SkillVersionRepository(
             skill, version = locked
             if version.status == "PUBLISHED":
                 if (
-                    version.metadata_json != metadata_json
+                    version.name != name
+                    or version.metadata_json != metadata_json
                     or version.description != description
                     or version.published_at is None
                 ):
@@ -160,6 +164,13 @@ class SkillVersionRepository(
                         "PUBLISHED Skill Version conflicts with materialized facts"
                     )
             elif version.status == "MATERIALIZING":
+                self._converge_public_manifest_name(
+                    session,
+                    skill=skill,
+                    version=version,
+                    env=env,
+                    manifest_name=name,
+                )
                 version.metadata_json = metadata_json
                 version.description = description
                 version.published_at = published_at
@@ -207,6 +218,72 @@ class SkillVersionRepository(
                 metadata_json=version.metadata_json,
                 published_at=version.published_at,
             )
+
+    @staticmethod
+    def _converge_public_manifest_name(
+        session,
+        *,
+        skill: Skill,
+        version: SkillVersion,
+        env: str,
+        manifest_name: str,
+    ) -> None:
+        """Freeze the exact package name for an unconsumed SC Public Asset.
+
+        Public catalogue metadata is available before the exact package and
+        may use a presentation name unrelated to ``SKILL.md.name``.  The row
+        is still provisional while its first Version is MATERIALIZING.  A
+        one-time convergence is safe only before any PUBLISHED Version or Bot
+        relationship exists; every later mismatch fails closed.
+        """
+        if skill.name == manifest_name and version.name == manifest_name:
+            return
+        git_path = skill.git_path or ""
+        if (
+            not manifest_name
+            or not git_path.startswith("center://")
+            or not git_path[len("center://") :]
+            or version.publication_attempt_id is not None
+        ):
+            raise RuntimeError("materialized SKILL.md name changed")
+        has_space = (
+            session.query(SkillSpaceBinding.id)
+            .filter(
+                SkillSpaceBinding.skill_id == int(skill.id),
+                SkillSpaceBinding.env == env,
+            )
+            .first()
+            is not None
+        )
+        has_published = (
+            session.query(SkillVersion.id)
+            .filter(
+                SkillVersion.skill_id == int(skill.id),
+                SkillVersion.env == env,
+                SkillVersion.status == "PUBLISHED",
+            )
+            .first()
+            is not None
+        )
+        has_membership = (
+            session.query(SkillSetSkill.id)
+            .filter(SkillSetSkill.skill_id == int(skill.id), SkillSetSkill.env == env)
+            .first()
+            is not None
+        )
+        has_installation = (
+            session.query(BotSkillInstallation.id)
+            .filter(
+                BotSkillInstallation.skill_id == int(skill.id),
+                BotSkillInstallation.env == env,
+            )
+            .first()
+            is not None
+        )
+        if has_space or has_published or has_membership or has_installation:
+            raise RuntimeError("materialized SKILL.md name changed")
+        skill.name = manifest_name
+        version.name = manifest_name
 
     @staticmethod
     def _materializing(

--- a/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
+++ b/src/backend/src/agentclaw/community/core/repository/protocols/skill_center.py
@@ -347,6 +347,7 @@ class SkillVersionMaterializationRepositoryProtocol(Protocol):
         env: str,
         skill_id: int,
         skill_version_id: int,
+        name: str,
         metadata_json: str,
         description: str,
         published_at: datetime,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_materializer.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_materializer.py
@@ -43,6 +43,7 @@ from agentclaw.community.core.skill_center.skill_center_gateway_service_protocol
 from agentclaw.community.plugin_api.http_client import HttpClient
 from agentclaw.community.plugin_api.skill_center_gateway import (
     SkillCenterExactDownloadRequest,
+    SkillCenterReadScope,
 )
 from agentclaw.community.plugin_api.skill_scanner import SkillScannerPlugin
 
@@ -75,7 +76,9 @@ def _dependency(entry: object) -> dict[str, object]:
         "icon_url": ("icon_url", "iconUrl"),
         "description": ("description",),
     }.items():
-        selected = next((value.get(key) for key in alternatives if value.get(key)), None)
+        selected = next(
+            (value.get(key) for key in alternatives if value.get(key)), None
+        )
         if selected is not None:
             normalized[target] = selected
     return normalized
@@ -195,7 +198,9 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
                 raise ValueError("exact SC identity is incomplete")
             if target.status == "PUBLISHED":
                 if not self._store.verify_version(ref):
-                    raise ValueError("PUBLISHED Version has no verified canonical content")
+                    raise ValueError(
+                        "PUBLISHED Version has no verified canonical content"
+                    )
                 return self._published_target(target)
 
             exact = self._gateway.get_exact_download(
@@ -219,8 +224,15 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
             if hashlib.sha256(package_bytes).hexdigest() != expected_digest:
                 raise ValueError("downloaded package digest does not match SC")
 
-            package = self._validator.validate_zip(package_bytes)
-            if package.name != target.name:
+            package = (
+                self._validator.validate_public_center_zip(package_bytes)
+                if request.scope is SkillCenterReadScope.PUBLIC
+                else self._validator.validate_zip(package_bytes)
+            )
+            if (
+                request.scope is not SkillCenterReadScope.PUBLIC
+                and package.name != target.name
+            ):
                 raise ValueError("materialized SKILL.md name changed")
             scan = self._scanner.scan(package)
             dependencies = _dependencies(
@@ -251,9 +263,7 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
                 separators=(",", ":"),
                 sort_keys=True,
             )
-            version = CanonicalCenterVersion.from_files(
-                identity, dict(package.files)
-            )
+            version = CanonicalCenterVersion.from_files(identity, dict(package.files))
             written = self._store.write_version(version)
             if written != ref or not self._store.verify_version(ref):
                 raise ValueError("canonical exact Version did not verify")
@@ -261,6 +271,7 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
                 env=request.env,
                 skill_id=request.skill_id,
                 skill_version_id=request.skill_version_id,
+                name=package.name,
                 metadata_json=metadata_json,
                 description=package.description,
                 published_at=self._clock(),

--- a/src/backend/src/agentclaw/community/core/skill_center/skill_package.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/skill_package.py
@@ -89,14 +89,41 @@ class SkillPackageValidator:
 
     def validate_zip(self, package: bytes) -> ValidatedSkillPackage:
         """Validate a governed package with mandatory YAML frontmatter."""
-        return self._validate_zip(package, allow_legacy_local_manifest=False)
+        return self._validate_zip(
+            package,
+            allow_legacy_local_manifest=False,
+            require_wrapper_name_match=True,
+        )
+
+    def validate_public_center_zip(self, package: bytes) -> ValidatedSkillPackage:
+        """Validate one SC Public package with an opaque transport wrapper.
+
+        Skill Center's exact download may wrap a valid Skill in its external
+        ``skillCode`` directory.  That transport name is not the manifest or
+        runtime identity.  Every other package invariant remains identical to
+        :meth:`validate_zip`, and the normalized result still has a root-level
+        ``SKILL.md``.
+        """
+        return self._validate_zip(
+            package,
+            allow_legacy_local_manifest=False,
+            require_wrapper_name_match=False,
+        )
 
     def validate_legacy_local_zip(self, package: bytes) -> ValidatedSkillPackage:
         """Validate the historical Local upload wire with explicit fallback."""
-        return self._validate_zip(package, allow_legacy_local_manifest=True)
+        return self._validate_zip(
+            package,
+            allow_legacy_local_manifest=True,
+            require_wrapper_name_match=True,
+        )
 
     def _validate_zip(
-        self, package: bytes, *, allow_legacy_local_manifest: bool
+        self,
+        package: bytes,
+        *,
+        allow_legacy_local_manifest: bool,
+        require_wrapper_name_match: bool,
     ) -> ValidatedSkillPackage:
         if len(package) > MAX_COMPRESSED_BYTES:
             raise SkillPackageTooLargeError()
@@ -138,6 +165,7 @@ class SkillPackageValidator:
         return self._validate_entries(
             entries,
             allow_legacy_local_manifest=allow_legacy_local_manifest,
+            require_wrapper_name_match=require_wrapper_name_match,
         )
 
     def validate_directory(
@@ -197,6 +225,7 @@ class SkillPackageValidator:
         entries: Sequence[tuple[str, bytes]],
         *,
         allow_legacy_local_manifest: bool,
+        require_wrapper_name_match: bool,
     ) -> ValidatedSkillPackage:
         skill_files = [
             entry for entry in entries if entry[0].split("/")[-1] == "SKILL.md"
@@ -248,7 +277,7 @@ class SkillPackageValidator:
             or name.lower() in _RESERVED_SKILL_NAMES
         ):
             raise SkillPackageInvalidError("invalid_metadata")
-        if wrapper and wrapper != name:
+        if require_wrapper_name_match and wrapper and wrapper != name:
             raise SkillPackageInvalidError("wrapper_name_mismatch")
         if wrapper is not None and any(
             not path.startswith(f"{wrapper}/") for path, _content in entries

--- a/src/backend/tests/community/core/skill_center/test_skill_package_validator.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_package_validator.py
@@ -279,6 +279,37 @@ def test_wrapper_must_match_the_manifest_name_and_contain_every_file() -> None:
     assert conflict.value.reason == "invalid_wrapper"
 
 
+def test_public_center_accepts_one_opaque_wrapper_without_relaxing_layout() -> None:
+    validator = SkillPackageValidator(SkillParser())
+    manifest = _skill_md(name="dima")
+
+    package = validator.validate_public_center_zip(
+        _zip(
+            [
+                ("dima-official-skill/SKILL.md", manifest),
+                ("dima-official-skill/scripts/run.py", b"pass\n"),
+            ]
+        )
+    )
+
+    assert package.name == "dima"
+    assert package.files == (
+        ("SKILL.md", manifest),
+        ("scripts/run.py", b"pass\n"),
+    )
+    with pytest.raises(SkillPackageInvalidError) as invalid:
+        validator.validate_public_center_zip(
+            _zip(
+                [
+                    ("dima-official-skill/SKILL.md", manifest),
+                    ("outside.txt", b"outside"),
+                ]
+            )
+        )
+
+    assert invalid.value.reason == "invalid_wrapper"
+
+
 @pytest.mark.parametrize("name", ["skills-center", "skills-local", "skills-repo"])
 def test_reserved_content_store_names_are_rejected(name: str) -> None:
     with pytest.raises(SkillPackageInvalidError) as error:
@@ -305,9 +336,7 @@ def test_strict_validator_rejects_a_manifest_without_frontmatter() -> None:
     assert error.value.reason == "invalid_metadata"
 
 
-def test_strict_directory_validation_rejects_a_manifest_without_frontmatter() -> (
-    None
-):
+def test_strict_directory_validation_rejects_a_manifest_without_frontmatter() -> None:
     with pytest.raises(SkillPackageInvalidError) as error:
         SkillPackageValidator(SkillParser()).validate_directory(
             [

--- a/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
@@ -7,6 +7,7 @@ import io
 import json
 import zipfile
 from contextlib import contextmanager
+from dataclasses import replace
 from datetime import UTC, datetime
 
 import pytest
@@ -59,11 +60,12 @@ from agentclaw.community.testing.canonical_center_store import (
 )
 
 
-def _package(*, name: str = "weather") -> bytes:
+def _package(*, name: str = "weather", wrapper: str | None = None) -> bytes:
     stream = io.BytesIO()
+    prefix = f"{wrapper}/" if wrapper else ""
     with zipfile.ZipFile(stream, "w") as archive:
         archive.writestr(
-            "SKILL.md",
+            f"{prefix}SKILL.md",
             (
                 "---\n"
                 f"name: {name}\n"
@@ -72,7 +74,7 @@ def _package(*, name: str = "weather") -> bytes:
                 "---\n# Weather\n"
             ),
         )
-        archive.writestr("scripts/fetch.py", "print('weather')\n")
+        archive.writestr(f"{prefix}scripts/fetch.py", "print('weather')\n")
     return stream.getvalue()
 
 
@@ -111,20 +113,19 @@ class _Gateway:
 
 
 class _Scanner:
-    def __init__(self, *, fail: bool = False) -> None:
+    def __init__(self, *, fail: bool = False, expected_name: str = "weather") -> None:
         self.fail = fail
+        self.expected_name = expected_name
         self.calls = 0
 
     def scan(self, package):
         self.calls += 1
         if self.fail:
             raise RuntimeError("scanner unavailable")
-        assert package.name == "weather"
+        assert package.name == self.expected_name
         return SkillVersionScanResult(
             risk_tags=({"name": "network", "level": "LOW"},),
-            mcp_dependencies=(
-                {"code": "mcp.weather", "name": "Weather MCP"},
-            ),
+            mcp_dependencies=({"code": "mcp.weather", "name": "Weather MCP"},),
         )
 
 
@@ -147,7 +148,7 @@ class _Versions:
             sc_version_number=self.target.sc_version_number,
             sc_skill_id=self.target.sc_skill_id,
             sc_version_id=self.target.sc_version_id,
-            name=self.target.name,
+            name=kwargs["name"],
             description=kwargs["description"],
             metadata_json=kwargs["metadata_json"],
             published_at=kwargs["published_at"],
@@ -188,9 +189,7 @@ def test_exact_package_becomes_published_only_after_all_ready_inputs_exist() -> 
     package = _package()
     versions = _Versions(_target())
     scanner = _Scanner()
-    materializer = _materializer(
-        package=package, scanner=scanner, versions=versions
-    )
+    materializer = _materializer(package=package, scanner=scanner, versions=versions)
 
     published = materializer.materialize(
         SkillVersionMaterializationRequest(
@@ -209,29 +208,51 @@ def test_exact_package_becomes_published_only_after_all_ready_inputs_exist() -> 
     metadata = json.loads(versions.published["metadata_json"])
     assert metadata == {
         "config": [{"name": "city", "required": True}],
-        "mcp_dependencies": [
-            {"code": "mcp.weather", "name": "Weather MCP"}
-        ],
+        "mcp_dependencies": [{"code": "mcp.weather", "name": "Weather MCP"}],
         "risk_tags": [{"level": "LOW", "name": "network"}],
     }
     assert "sc_sha256" not in versions.published
 
 
+def test_public_exact_package_uses_manifest_name_and_ignores_opaque_wrapper() -> None:
+    package = _package(name="dima", wrapper="dima-official-skill")
+    versions = _Versions(
+        replace(
+            _target(),
+            skill_code="dima-official-skill",
+            name="Dima-cli-skill",
+        )
+    )
+    materializer = _materializer(
+        package=package,
+        scanner=_Scanner(expected_name="dima"),
+        versions=versions,
+    )
+
+    published = materializer.materialize(
+        SkillVersionMaterializationRequest(
+            env="pre",
+            skill_id=10,
+            skill_version_id=101,
+            scope=SkillCenterReadScope.PUBLIC,
+        )
+    )
+
+    assert published.name == "dima"
+    assert versions.published is not None
+    assert versions.published["name"] == "dima"
+
+
 @pytest.mark.parametrize(
     ("package", "scanner"),
-    [
-        (_package(name="different-name"), _Scanner()),
-        (_package(), _Scanner(fail=True)),
-    ],
-    ids=("name-mismatch", "scanner-failure"),
+    [(_package(), _Scanner(fail=True))],
+    ids=("scanner-failure",),
 )
 def test_validation_or_scanner_failure_never_publishes(
     package: bytes, scanner: _Scanner
 ) -> None:
     versions = _Versions(_target())
-    materializer = _materializer(
-        package=package, scanner=scanner, versions=versions
-    )
+    materializer = _materializer(package=package, scanner=scanner, versions=versions)
 
     with pytest.raises(SkillVersionMaterializationError):
         materializer.materialize(
@@ -240,6 +261,28 @@ def test_validation_or_scanner_failure_never_publishes(
                 skill_id=10,
                 skill_version_id=101,
                 scope=SkillCenterReadScope.PUBLIC,
+            )
+        )
+
+    assert versions.published is None
+
+
+def test_team_exact_package_still_rejects_manifest_name_mismatch() -> None:
+    versions = _Versions(_target())
+    materializer = _materializer(
+        package=_package(name="different-name"),
+        scanner=_Scanner(expected_name="different-name"),
+        versions=versions,
+    )
+
+    with pytest.raises(SkillVersionMaterializationError, match="name changed"):
+        materializer.materialize(
+            SkillVersionMaterializationRequest(
+                env="pre",
+                skill_id=10,
+                skill_version_id=101,
+                scope=SkillCenterReadScope.TEAM,
+                team_id="team-a",
             )
         )
 
@@ -457,7 +500,4 @@ def test_offline_vn_plus_one_recovers_through_unified_materializer() -> None:
         recovered = session.query(Skill).filter_by(id=skill_id).one()
         assert recovered.offline_at is None
         assert recovered.offline_by is None
-        assert (
-            session.query(SkillVersion).filter_by(id=101).one().status
-            == "PUBLISHED"
-        )
+        assert session.query(SkillVersion).filter_by(id=101).one().status == "PUBLISHED"

--- a/src/backend/tests/community/integration/skill_center/test_public_reference_materialization_identity.py
+++ b/src/backend/tests/community/integration/skill_center/test_public_reference_materialization_identity.py
@@ -206,6 +206,7 @@ def test_public_wrapper_and_market_display_name_converge_to_manifest_name() -> N
     )
     package = _wrapped_public_package()
 
+    store = LocalCanonicalCenterVersionStore()
     with avernet_tenant_scope("teamclaw"):
         target = references.ensure_public_version(
             env="pre",
@@ -224,7 +225,7 @@ def test_public_wrapper_and_market_display_name_converge_to_manifest_name() -> N
             http=_Http(package),
             validator=SkillPackageValidator(SkillParser()),
             scanner=_Scanner(),
-            store=LocalCanonicalCenterVersionStore(),
+            store=store,
             clock=lambda: datetime(2026, 8, 30, tzinfo=UTC),
         ).materialize(
             SkillVersionMaterializationRequest(
@@ -234,8 +235,37 @@ def test_public_wrapper_and_market_display_name_converge_to_manifest_name() -> N
                 scope=SkillCenterReadScope.PUBLIC,
             )
         )
+        next_target = references.ensure_public_version(
+            env="pre",
+            actor_id="actor",
+            locator=identity.locator,
+            skill_uuid=identity.skill_uuid,
+            skill_name="A newer SC display name",
+            description="SC market V2 description",
+            sc_skill_id=9001,
+            sc_version_number="2.0.0",
+            sc_version_id=10002,
+        )
+        next_published = SkillVersionMaterializer(
+            versions=versions,
+            gateway=_Gateway(package),
+            http=_Http(package),
+            validator=SkillPackageValidator(SkillParser()),
+            scanner=_Scanner(),
+            store=store,
+            clock=lambda: datetime(2026, 8, 31, tzinfo=UTC),
+        ).materialize(
+            SkillVersionMaterializationRequest(
+                env="pre",
+                skill_id=next_target.skill_id,
+                skill_version_id=next_target.skill_version_id,
+                scope=SkillCenterReadScope.PUBLIC,
+            )
+        )
 
     assert published.name == "dima"
+    assert next_published.name == "dima"
+    assert next_published.version_ordinal == 2
     with db.orm_session() as session:
         skill = session.get(Skill, target.skill_id)
         version = session.get(SkillVersion, target.skill_version_id)
@@ -244,3 +274,5 @@ def test_public_wrapper_and_market_display_name_converge_to_manifest_name() -> N
         assert skill.skill_uuid == identity.skill_uuid
         assert skill.name == "dima"
         assert version is not None and version.name == "dima"
+        next_version = session.get(SkillVersion, next_target.skill_version_id)
+        assert next_version is not None and next_version.name == "dima"

--- a/src/backend/tests/community/integration/skill_center/test_public_reference_materialization_identity.py
+++ b/src/backend/tests/community/integration/skill_center/test_public_reference_materialization_identity.py
@@ -13,6 +13,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from agentclaw.community.core.base import Base
+from agentclaw.community.core.models.skill import Skill
+from agentclaw.community.core.models.space_skill import SkillVersion
 from agentclaw.community.core.repository.implementations.skill_center.skill_center_reference import (
     SkillCenterReferenceRepository,
 )
@@ -70,6 +72,16 @@ def _package() -> bytes:
         archive.writestr(
             "SKILL.md",
             "---\nname: weather\ndescription: Exact weather.\n---\n# Weather\n",
+        )
+    return stream.getvalue()
+
+
+def _wrapped_public_package() -> bytes:
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w") as archive:
+        archive.writestr(
+            "dima-official-skill/SKILL.md",
+            "---\nname: dima\ndescription: Dima CLI.\n---\n# Dima\n",
         )
     return stream.getvalue()
 
@@ -171,9 +183,64 @@ def test_public_identity_converges_and_remains_scope_isolated() -> None:
     assert replay == first
     assert UUID(first.skill_uuid).version == 4
     assert first.locator == "center://opaque-Code"
-    assert PublicCenterSkillIdentity.derive(
-        tenant="teamclaw", env="prod", skill_code="opaque-Code"
-    ).skill_uuid != first.skill_uuid
-    assert PublicCenterSkillIdentity.derive(
-        tenant="another-tenant", env="pre", skill_code="opaque-Code"
-    ).skill_uuid != first.skill_uuid
+    assert (
+        PublicCenterSkillIdentity.derive(
+            tenant="teamclaw", env="prod", skill_code="opaque-Code"
+        ).skill_uuid
+        != first.skill_uuid
+    )
+    assert (
+        PublicCenterSkillIdentity.derive(
+            tenant="another-tenant", env="pre", skill_code="opaque-Code"
+        ).skill_uuid
+        != first.skill_uuid
+    )
+
+
+def test_public_wrapper_and_market_display_name_converge_to_manifest_name() -> None:
+    db = _Database()
+    references = SkillCenterReferenceRepository(db)
+    versions = SkillVersionRepository(db)
+    identity = PublicCenterSkillIdentity.derive(
+        tenant="teamclaw", env="pre", skill_code="dima-official-skill"
+    )
+    package = _wrapped_public_package()
+
+    with avernet_tenant_scope("teamclaw"):
+        target = references.ensure_public_version(
+            env="pre",
+            actor_id="actor",
+            locator=identity.locator,
+            skill_uuid=identity.skill_uuid,
+            skill_name="Dima-cli-skill",
+            description="SC market description",
+            sc_skill_id=9001,
+            sc_version_number="1.0.0",
+            sc_version_id=10001,
+        )
+        published = SkillVersionMaterializer(
+            versions=versions,
+            gateway=_Gateway(package),
+            http=_Http(package),
+            validator=SkillPackageValidator(SkillParser()),
+            scanner=_Scanner(),
+            store=LocalCanonicalCenterVersionStore(),
+            clock=lambda: datetime(2026, 8, 30, tzinfo=UTC),
+        ).materialize(
+            SkillVersionMaterializationRequest(
+                env="pre",
+                skill_id=target.skill_id,
+                skill_version_id=target.skill_version_id,
+                scope=SkillCenterReadScope.PUBLIC,
+            )
+        )
+
+    assert published.name == "dima"
+    with db.orm_session() as session:
+        skill = session.get(Skill, target.skill_id)
+        version = session.get(SkillVersion, target.skill_version_id)
+        assert skill is not None
+        assert skill.git_path == "center://dima-official-skill"
+        assert skill.skill_uuid == identity.skill_uuid
+        assert skill.name == "dima"
+        assert version is not None and version.name == "dima"

--- a/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_version_repository.py
@@ -88,6 +88,7 @@ def _add_version(
     status: str,
     number: str,
     publication_attempt_id: int | None = None,
+    name: str | None = None,
 ) -> None:
     with avernet_tenant_scope(tenant), db.orm_session() as session:
         session.add(
@@ -100,7 +101,7 @@ def _add_version(
                 sc_version_number=number,
                 sc_skill_id=1000 + skill_id,
                 sc_version_id=2000 + version_id,
-                name=f"skill-{skill_id}",
+                name=name or f"skill-{skill_id}",
                 description=None,
                 metadata_json='{"mcp_dependencies": []}',
                 published_at=(
@@ -295,6 +296,7 @@ def test_materialization_publish_is_one_tenant_scoped_compare_and_set() -> None:
             env="pre",
             skill_id=10,
             skill_version_id=101,
+            name="skill-10",
             metadata_json='{"mcp_dependencies":[]}',
             description="new description",
             published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
@@ -326,6 +328,99 @@ def test_materialization_publish_is_one_tenant_scoped_compare_and_set() -> None:
         assert version.sc_sha256 is None
         assert skill is not None and skill.description == "new description"
         assert skill.status == "PUBLISHED"
+
+
+def test_public_first_publish_freezes_manifest_name_before_consumption() -> None:
+    db = _Database()
+    with db.orm_session() as session:
+        session.add(
+            Skill(
+                id=10,
+                name="Dima-cli-skill",
+                git_path="center://dima-official-skill",
+                skill_uuid="00000000-0000-4000-8000-000000000010",
+                user_id=None,
+                bolt_id="default",
+                env="pre",
+            )
+        )
+    _add_version(
+        db,
+        skill_id=10,
+        version_id=101,
+        ordinal=1,
+        status="MATERIALIZING",
+        number="1.0.0",
+    )
+
+    with avernet_tenant_scope("teamclaw"):
+        published = SkillVersionRepository(db).publish_materialized(
+            env="pre",
+            skill_id=10,
+            skill_version_id=101,
+            name="dima",
+            metadata_json='{"mcp_dependencies":[]}',
+            description="Dima CLI",
+            published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
+        )
+
+    assert published.name == "dima"
+    with db.orm_session() as session:
+        skill = session.get(Skill, 10)
+        version = session.get(SkillVersion, 101)
+        assert skill is not None and skill.name == "dima"
+        assert version is not None and version.name == "dima"
+        assert version.status == "PUBLISHED"
+
+
+def test_public_name_convergence_fails_closed_after_installation_exists() -> None:
+    db = _Database()
+    with db.orm_session() as session:
+        session.add(
+            Skill(
+                id=10,
+                name="Dima-cli-skill",
+                git_path="center://dima-official-skill",
+                skill_uuid="00000000-0000-4000-8000-000000000010",
+                user_id=None,
+                bolt_id="default",
+                env="pre",
+            )
+        )
+        session.add(
+            BotSkillInstallation(
+                bot_id="bot-a", owner_id="owner", skill_id=10, env="pre"
+            )
+        )
+    _add_version(
+        db,
+        skill_id=10,
+        version_id=101,
+        ordinal=1,
+        status="MATERIALIZING",
+        number="1.0.0",
+    )
+
+    with (
+        avernet_tenant_scope("teamclaw"),
+        pytest.raises(RuntimeError, match="name changed"),
+    ):
+        SkillVersionRepository(db).publish_materialized(
+            env="pre",
+            skill_id=10,
+            skill_version_id=101,
+            name="dima",
+            metadata_json='{"mcp_dependencies":[]}',
+            description="Dima CLI",
+            published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
+        )
+
+    with db.orm_session() as session:
+        skill = session.get(Skill, 10)
+        version = session.get(SkillVersion, 101)
+        assert skill is not None and skill.name == "Dima-cli-skill"
+        assert version is not None and version.name == "skill-10"
+        assert version.status == "MATERIALIZING"
 
 
 def test_materialization_publish_replay_requires_the_same_frozen_facts() -> None:
@@ -363,6 +458,7 @@ def test_materialization_publish_replay_requires_the_same_frozen_facts() -> None
             env="pre",
             skill_id=10,
             skill_version_id=101,
+            name="skill-10",
             metadata_json='{"mcp_dependencies":[]}',
             description="same",
             published_at=datetime(2026, 8, 30, 13, 0, tzinfo=UTC),
@@ -372,6 +468,7 @@ def test_materialization_publish_replay_requires_the_same_frozen_facts() -> None
                 env="pre",
                 skill_id=10,
                 skill_version_id=101,
+                name="skill-10",
                 metadata_json='{"mcp_dependencies":[{"code":"other"}]}',
                 description="same",
                 published_at=datetime(2026, 8, 30, 13, 0, tzinfo=UTC),
@@ -419,6 +516,7 @@ def test_new_space_publication_clears_offline_but_published_replay_never_does() 
         status="MATERIALIZING",
         number="2.0.0",
         publication_attempt_id=501,
+        name="weather",
     )
     repo = SkillVersionRepository(db)
 
@@ -427,6 +525,7 @@ def test_new_space_publication_clears_offline_but_published_replay_never_does() 
             env="pre",
             skill_id=10,
             skill_version_id=101,
+            name="weather",
             metadata_json='{"mcp_dependencies":[]}',
             description="online again",
             published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
@@ -443,6 +542,7 @@ def test_new_space_publication_clears_offline_but_published_replay_never_does() 
             env="pre",
             skill_id=10,
             skill_version_id=101,
+            name="weather",
             metadata_json='{"mcp_dependencies":[]}',
             description="online again",
             published_at=datetime(2026, 8, 30, 13, 0, tzinfo=UTC),
@@ -476,6 +576,7 @@ def test_sc_public_materialization_never_clears_offline_without_space_binding() 
         ordinal=2,
         status="MATERIALIZING",
         number="2.0.0",
+        name="weather",
     )
 
     with avernet_tenant_scope("teamclaw"):
@@ -483,6 +584,7 @@ def test_sc_public_materialization_never_clears_offline_without_space_binding() 
             env="pre",
             skill_id=10,
             skill_version_id=101,
+            name="weather",
             metadata_json='{"mcp_dependencies":[]}',
             description="updated",
             published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
@@ -534,6 +636,7 @@ def test_space_binding_without_publication_attempt_never_clears_offline() -> Non
         status="MATERIALIZING",
         number="2.0.0",
         publication_attempt_id=None,
+        name="weather",
     )
 
     with avernet_tenant_scope("teamclaw"):
@@ -541,6 +644,7 @@ def test_space_binding_without_publication_attempt_never_clears_offline() -> Non
             env="pre",
             skill_id=10,
             skill_version_id=101,
+            name="weather",
             metadata_json='{"mcp_dependencies":[]}',
             description="updated",
             published_at=datetime(2026, 8, 30, 12, 0, tzinfo=UTC),
@@ -612,7 +716,9 @@ class _LockSession:
         self.held.clear()
 
 
-def test_materialization_and_offline_overlap_use_skill_then_version_lock_order() -> None:
+def test_materialization_and_offline_overlap_use_skill_then_version_lock_order() -> (
+    None
+):
     coordinator = _LockCoordinator()
     failures: list[BaseException] = []
 


### PR DESCRIPTION
## Summary
- accept an opaque single-directory wrapper only for SC Public exact ZIP downloads while preserving all shared package safety and metadata validation
- freeze `ac_skill.name` and runtime identity from exact `SKILL.md.name`, never from SC market display metadata
- safely converge only unconsumed, first-time MATERIALIZING public assets; PUBLISHED, Space-owned, Membership, and Installation states fail closed
- preserve the frozen manifest name across later exact SC Public versions

## Validation
- 69 focused package/materializer/reference/repository/integration tests passed
- 21 contract/architecture/DI tests passed
- Ruff and `git diff --check` passed
- Standards/Spec dual-axis review completed; initial V2-name P1 fixed and re-review has no remaining P0-P2
- Backend full local CI was stopped at user request; GitHub CI is the authoritative full gate

## Scope
- target branch: `REL20260901`
- no OpenAPI/router change; generated Gateway schema is unaffected
- `git_path` length-limit mismatch is explicitly deferred
- no DDL change