### PR TITLE
fix(backend): log safe skill materialization stages

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/materialization_contract.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/materialization_contract.py
@@ -19,6 +19,10 @@ from agentclaw.community.plugin_api.skill_center_gateway import (
 class SkillVersionMaterializationError(RuntimeError):
     """An exact Version failed a Ready Gate and remains non-consumable."""
 
+    def __init__(self, message: str, *, stage: str | None = None) -> None:
+        super().__init__(message)
+        self.stage = stage
+
 
 @dataclass(frozen=True, slots=True)
 class SkillVersionMaterializationRequest:

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_reference_processor.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_reference_processor.py
@@ -246,10 +246,20 @@ class SkillCenterReferenceProcessor:
             return self._retry_or_fail(
                 batch.env, current, "SC_MARKET_UNAVAILABLE"
             )
-        except SkillVersionMaterializationError:
-            logger.exception(
-                "[SkillCenterReference] materialization failure: reference_id=%s",
+        except SkillVersionMaterializationError as exc:
+            # Do not log the exception text or traceback here: download errors
+            # can embed an exact-package presigned URL.  The materializer's
+            # finite stage plus the exception type remain sufficient to locate
+            # the failed Ready Gate without exposing credentials.
+            cause = exc.__cause__
+            logger.warning(
+                "[SkillCenterReference] materialization failure: reference_id=%s "
+                "skill_code=%s skill_version_id=%s failure_stage=%s cause_type=%s",
                 item.reference_id,
+                item.skill_code,
+                current.skill_version_id,
+                exc.stage or "unknown",
+                type(cause).__name__ if cause is not None else type(exc).__name__,
             )
             return self._retry_or_fail(
                 batch.env, current, "MATERIALIZATION_FAILED"

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_materializer.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_materializer.py
@@ -181,6 +181,7 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
     def materialize(
         self, request: SkillVersionMaterializationRequest
     ) -> PublishedMaterializedSkillVersion:
+        stage = "target_read"
         try:
             target = self._versions.get_materialization_target(
                 env=request.env,
@@ -197,12 +198,14 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
             if target.sc_skill_id < 1 or target.sc_version_id < 1:
                 raise ValueError("exact SC identity is incomplete")
             if target.status == "PUBLISHED":
+                stage = "canonical_verify"
                 if not self._store.verify_version(ref):
                     raise ValueError(
                         "PUBLISHED Version has no verified canonical content"
                     )
                 return self._published_target(target)
 
+            stage = "exact_download"
             exact = self._gateway.get_exact_download(
                 SkillCenterExactDownloadRequest(
                     skill_code=target.skill_code,
@@ -218,23 +221,29 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
             ):
                 raise ValueError("Skill Center returned a different exact Version")
             expected_digest = exact.sha256.lower()
+            stage = "package_download"
             response = self._http.get(exact.download_url, timeout=30.0)
             response.raise_for_status()
             package_bytes = bytes(response.content)
+            stage = "digest_verify"
             if hashlib.sha256(package_bytes).hexdigest() != expected_digest:
                 raise ValueError("downloaded package digest does not match SC")
 
+            stage = "package_validate"
             package = (
                 self._validator.validate_public_center_zip(package_bytes)
                 if request.scope is SkillCenterReadScope.PUBLIC
                 else self._validator.validate_zip(package_bytes)
             )
+            stage = "name_match"
             if (
                 request.scope is not SkillCenterReadScope.PUBLIC
                 and package.name != target.name
             ):
                 raise ValueError("materialized SKILL.md name changed")
+            stage = "scanner"
             scan = self._scanner.scan(package)
+            stage = "metadata_build"
             dependencies = _dependencies(
                 tuple(scan.mcp_dependencies),
                 tuple(
@@ -264,9 +273,12 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
                 sort_keys=True,
             )
             version = CanonicalCenterVersion.from_files(identity, dict(package.files))
+            stage = "canonical_write"
             written = self._store.write_version(version)
+            stage = "canonical_verify"
             if written != ref or not self._store.verify_version(ref):
                 raise ValueError("canonical exact Version did not verify")
+            stage = "publish"
             return self._versions.publish_materialized(
                 env=request.env,
                 skill_id=request.skill_id,
@@ -276,10 +288,12 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
                 description=package.description,
                 published_at=self._clock(),
             )
-        except SkillVersionMaterializationError:
-            raise
+        except SkillVersionMaterializationError as exc:
+            if exc.stage is not None:
+                raise
+            raise SkillVersionMaterializationError(str(exc), stage=stage) from exc
         except Exception as exc:
-            raise SkillVersionMaterializationError(str(exc)) from exc
+            raise SkillVersionMaterializationError(str(exc), stage=stage) from exc
 
     @staticmethod
     def _published_target(

--- a/src/backend/tests/community/core/skill_center/test_skill_center_reference_processor.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_center_reference_processor.py
@@ -385,7 +385,7 @@ def test_gateway_failure_persists_only_public_error_message() -> None:
     assert "signature" not in repr(references.batch.items)
 
 
-def test_materialization_failure_persists_only_public_error_message() -> None:
+def test_materialization_failure_logs_safe_stage_without_leaking_url(caplog) -> None:
     class _LeakyMaterializer(_Materializer):
         def materialize(self, request):
             from agentclaw.community.core.skill_center.materialization_contract import (
@@ -410,6 +410,9 @@ def test_materialization_failure_persists_only_public_error_message() -> None:
         "Exact Version materialization failed"
     }
     assert "signature" not in repr(references.batch.items)
+    assert "failure_stage=unknown" in caplog.text
+    assert "cause_type=SkillVersionMaterializationError" in caplog.text
+    assert "private-token" not in caplog.text
 
 
 def test_final_membership_infrastructure_failure_propagates_for_task_retry() -> None:

--- a/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
@@ -254,7 +254,7 @@ def test_validation_or_scanner_failure_never_publishes(
     versions = _Versions(_target())
     materializer = _materializer(package=package, scanner=scanner, versions=versions)
 
-    with pytest.raises(SkillVersionMaterializationError):
+    with pytest.raises(SkillVersionMaterializationError) as failure:
         materializer.materialize(
             SkillVersionMaterializationRequest(
                 env="pre",
@@ -264,6 +264,7 @@ def test_validation_or_scanner_failure_never_publishes(
             )
         )
 
+    assert failure.value.stage == "scanner"
     assert versions.published is None
 
 
@@ -275,7 +276,7 @@ def test_team_exact_package_still_rejects_manifest_name_mismatch() -> None:
         versions=versions,
     )
 
-    with pytest.raises(SkillVersionMaterializationError, match="name changed"):
+    with pytest.raises(SkillVersionMaterializationError, match="name changed") as failure:
         materializer.materialize(
             SkillVersionMaterializationRequest(
                 env="pre",
@@ -286,6 +287,7 @@ def test_team_exact_package_still_rejects_manifest_name_mismatch() -> None:
             )
         )
 
+    assert failure.value.stage == "name_match"
     assert versions.published is None
 
 


### PR DESCRIPTION
## Problem

SC Public Reference materialization collapses all Ready-Gate failures into `MATERIALIZATION_FAILED`. Existing exception logging can expose a presigned package URL and does not provide a safe, queryable failure stage.

## Solution

- Carry a finite materialization stage on `SkillVersionMaterializationError`.
- Emit only `reference_id`, `skill_code`, `skill_version_id`, `failure_stage`, and exception type.
- Do not log exception text or traceback, so presigned URLs and their signatures cannot enter application logs.

## Validation

- Focused materializer/reference processor tests: 16 passed locally.

## Compatibility and risk

No API, database, or lifecycle-state change. Reference items still expose the existing stable public error. Logging becomes safe structured diagnostics for operator investigation.