### PR TITLE
feat(bcs): expose bcs session login through openapi and gatewayDev friend notify

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/common/state.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/common/state.rs
@@ -2,8 +2,7 @@ use std::sync::Arc;
 
 use bcs_config_api::ManifestConfig;
 use bcs_service_api::application::v1::{
-    BotService, CollaborationDefinitionService, CollaborationTemplateService, EventSubscriptionService, FriendConnectionService, FriendshipService, GroupService, InvitationService,
-    RegisterService,
+    AuthService as ApplicationAuthService, BotService, CollaborationDefinitionService, CollaborationTemplateService, EventSubscriptionService, FriendConnectionService, FriendshipService, GroupService, InvitationService, RegisterService,
     SessionFileApplicationService, SessionMessageService, SessionService,
 };
 use bcs_service_api::application::channel::ChannelService;
@@ -19,6 +18,8 @@ pub trait PrincipalVerificationState: Clone + Send + Sync + 'static {
 
 #[derive(Clone)]
 pub struct ApiState {
+    pub auth_service: Option<Arc<dyn ApplicationAuthService>>,
+    pub auth_public_base_url: String,
     pub bot_service: Option<Arc<dyn BotService>>,
     pub event_subscription_service: Option<Arc<dyn EventSubscriptionService>>,
     pub group_service: Arc<dyn GroupService>,
@@ -50,6 +51,8 @@ impl ApiState {
         principal_verifier: Arc<dyn PrincipalVerifier>,
     ) -> Self {
         Self {
+            auth_service: None,
+            auth_public_base_url: "http://127.0.0.1/openapi/v1/auth".to_string(),
             bot_service: None,
             event_subscription_service: None,
             group_service,
@@ -69,6 +72,16 @@ impl ApiState {
             manifest_env: "local".to_string(),
             principal_verifier,
         }
+    }
+
+    pub fn with_auth_service(
+        mut self,
+        service: Arc<dyn ApplicationAuthService>,
+        public_base_url: String,
+    ) -> Self {
+        self.auth_service = Some(service);
+        self.auth_public_base_url = public_base_url;
+        self
     }
 
     /// Add the Bot control-plane V1 slice.

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/mod.rs
@@ -28,8 +28,7 @@ pub fn protected_router() -> Router<ApiState> {
 }
 
 pub fn public_router() -> Router<ApiState> {
-    Router::new().nest(
-        "/openapi/v1/auth",
-        routes::auth::router(),
-    )
+    Router::new()
+        .nest("/openapi/v1/auth", routes::auth::router())
+        .merge(routes::register::public_router())
 }

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/mod.rs
@@ -28,12 +28,8 @@ pub fn protected_router() -> Router<ApiState> {
 }
 
 pub fn public_router() -> Router<ApiState> {
-    // v1::router merges this WITHOUT the "/openapi/v1/collaboration" nest the
-    // protected router uses (nesting happens here, not at the merge site —
-    // compare internal::public_router, whose routes carry full paths).
-    Router::new()
-        .nest(
-            "/openapi/v1/collaboration",
-            routes::register::public_router(),
-        )
+    Router::new().nest(
+        "/openapi/v1/auth",
+        routes::auth::router(),
+    )
 }

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/auth.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/auth.rs
@@ -1,0 +1,183 @@
+use axum::{
+    extract::{Path, Query, State},
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use bcs_service_api::application::{RequestAuthHeaders};
+use bcs_service_api::application::v1::{
+    ApplicationError, BuildLoginUrls, CompleteOAuthLogin, LogoutSession, ReadCurrentUser,
+    RefreshSession,
+};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::v1::common::{
+    application_error_response, ApiState, Envelope, ErrorResponse, RequestId,
+};
+
+pub fn router() -> Router<ApiState> {
+    Router::new()
+        .route("/url", get(login_urls))
+        .route("/callback/{provider}", get(callback))
+        .route("/user", get(current_user))
+        .route("/refresh", post(refresh))
+        .route("/logout", post(logout))
+}
+
+#[derive(Deserialize)]
+struct CallbackParams {
+    code: Option<String>,
+    auth_code: Option<String>,
+    state: String,
+}
+
+async fn login_urls(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, ErrorResponse> {
+    let request_id = RequestId::from_headers(&headers);
+    let auth_service = auth_service(&state, &request_id)?;
+
+    let callback_base_url = callback_base_url(&state);
+    let result = auth_service
+        .login_urls(BuildLoginUrls { callback_base_url })
+        .await
+        .map_err(|error| application_error_response(&request_id, error))?;
+
+    Ok(Json(Envelope::success(20_000, "OK", result, request_id.0)).into_response())
+}
+
+async fn callback(
+    State(state): State<ApiState>,
+    Path(provider): Path<String>,
+    Query(params): Query<CallbackParams>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, ErrorResponse> {
+    let request_id = RequestId::from_headers(&headers);
+    let auth_service = auth_service(&state, &request_id)?;
+    let redirect = auth_service
+        .complete_login(CompleteOAuthLogin {
+            provider,
+            code: params.code,
+            auth_code: params.auth_code,
+            state: params.state,
+            callback_base_url: callback_base_url(&state),
+        })
+        .await
+        .map_err(|error| application_error_response(&request_id, error))?;
+
+    Ok((
+        StatusCode::FOUND,
+        [
+            ("location", redirect.location),
+            ("set-cookie", redirect.set_cookie),
+        ],
+    )
+        .into_response())
+}
+
+async fn current_user(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, ErrorResponse> {
+    let request_id = RequestId::from_headers(&headers);
+    let auth_service = auth_service(&state, &request_id)?;
+    let result = auth_service
+        .current_user(ReadCurrentUser {
+            headers: request_auth_headers(&headers),
+        })
+        .await
+        .map_err(|error| application_error_response(&request_id, error))?;
+
+    Ok(Json(Envelope::success(20_000, "OK", result, request_id.0)).into_response())
+}
+
+async fn refresh(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, ErrorResponse> {
+    let request_id = RequestId::from_headers(&headers);
+    let auth_service = auth_service(&state, &request_id)?;
+    let result = auth_service
+        .refresh_session(RefreshSession {
+            headers: request_auth_headers(&headers),
+        })
+        .await
+        .map_err(|error| application_error_response(&request_id, error))?;
+
+    Ok((
+        StatusCode::OK,
+        [("set-cookie", result.set_cookie)],
+        Json(Envelope::success(20_000, "OK", json!({}), request_id.0)),
+    )
+        .into_response())
+}
+
+async fn logout(
+    State(state): State<ApiState>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, ErrorResponse> {
+    let request_id = RequestId::from_headers(&headers);
+    let auth_service = auth_service(&state, &request_id)?;
+    let result = auth_service
+        .logout(LogoutSession {
+            headers: request_auth_headers(&headers),
+        })
+        .await
+        .map_err(|error| application_error_response(&request_id, error))?;
+
+    Ok((
+        StatusCode::OK,
+        [("set-cookie", result.set_cookie)],
+        Json(Envelope::success(20_000, "OK", json!({}), request_id.0)),
+    )
+        .into_response())
+}
+
+fn auth_service<'a>(
+    state: &'a ApiState,
+    request_id: &RequestId,
+) -> Result<&'a std::sync::Arc<dyn bcs_service_api::application::v1::AuthService>, ErrorResponse> {
+    state.auth_service.as_ref().ok_or_else(|| {
+        application_error_response(
+            request_id,
+            ApplicationError::not_found("auth_not_configured", "OAuth is not configured"),
+        )
+    })
+}
+
+fn callback_base_url(state: &ApiState) -> String {
+    format!(
+        "{}/callback",
+        state.auth_public_base_url.trim_end_matches('/')
+    )
+}
+
+fn request_auth_headers(headers: &HeaderMap) -> RequestAuthHeaders {
+    let header = |name: axum::http::header::HeaderName| {
+        headers
+            .get(name)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string)
+    };
+    RequestAuthHeaders {
+        authorization: header(axum::http::header::AUTHORIZATION),
+        cookie: header(axum::http::header::COOKIE),
+        forwarded_headers: headers
+            .iter()
+            .filter_map(|(name, value)| {
+                let name = name.as_str();
+                if name.starts_with("x-") || name.starts_with("forwarded") {
+                    value
+                        .to_str()
+                        .ok()
+                        .map(|value| (name.to_string(), value.to_string()))
+                } else {
+                    None
+                }
+            })
+            .collect(),
+    }
+}

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod bot;
 pub mod channel;
 pub mod event_subscription;

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/register.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/register.rs
@@ -18,7 +18,7 @@ pub fn router() -> Router<ApiState> {
 /// Mounted OUTSIDE the `verify_principal` boundary: POST /register is
 /// anonymous and the register token is its only credential.
 pub fn public_router() -> Router<ApiState> {
-    Router::new().route("/openapi/v1/collaboration/register", post(register_bot))
+    Router::new().route("/register", post(register_bot))
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/register.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/register.rs
@@ -18,7 +18,7 @@ pub fn router() -> Router<ApiState> {
 /// Mounted OUTSIDE the `verify_principal` boundary: POST /register is
 /// anonymous and the register token is its only credential.
 pub fn public_router() -> Router<ApiState> {
-    Router::new().route("/register", post(register_bot))
+    Router::new().route("/openapi/v1/collaboration/register", post(register_bot))
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/register.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/src/v1/openapi/routes/register.rs
@@ -15,10 +15,10 @@ pub fn router() -> Router<ApiState> {
     Router::new().route("/register/token", get(get_register_token))
 }
 
-/// Mounted OUTSIDE the `verify_principal` boundary: POST /register is
+/// Mounted OUTSIDE the `verify_principal` boundary: POST /openapi/v1/collaboration/register is
 /// anonymous and the register token is its only credential.
 pub fn public_router() -> Router<ApiState> {
-    Router::new().route("/register", post(register_bot))
+    Router::new().route("/openapi/v1/collaboration/register", post(register_bot))
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/friendship_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/friendship_routes.rs
@@ -7,23 +7,25 @@ use bcs_api_http::{ApiState, PrincipalVerificationError, PrincipalVerifier, rout
 use bcs_service_api::RequestAuthHeaders;
 use bcs_service_api::application::v1::{
     AcceptFriendRequest, AcceptFriendConnectionRequest, AcceptInvitation, AddGroupParticipant,
-    AddSessionParticipant, ApplicationError, AuthenticatedCaller, AuthenticatedUserIdentity,
-    BotRegistration, CancelFriendConnectionRequest, CompleteSession, CreateBotFriendRequest,
-    CreateFriendConnectionRequest, CreateGroup, CreateGroupInvitation, CreateSession,
-    CreateSessionInvitation, CreateSessionOutcome, DeleteFriendConnection,
-    DeleteGroup, DeleteGroupParticipant, DeleteResult, DeleteSession, DeleteSessionParticipant,
-    Friendship, FriendshipService, FriendConnectionActor, FriendConnectionActorType,
+    AddSessionParticipant, ApplicationError, AuthProviderUrlList, AuthRedirect,
+    AuthService as ApplicationAuthService, AuthUserInfo, AuthenticatedCaller,
+    AuthenticatedUserIdentity, BotRegistration, BuildLoginUrls, CancelFriendConnectionRequest,
+    CompleteOAuthLogin, CompleteSession, CreateBotFriendRequest, CreateFriendConnectionRequest,
+    CreateGroup, CreateGroupInvitation, CreateSession, CreateSessionInvitation,
+    CreateSessionOutcome, DeleteBotFriendship, DeleteFriendConnection, DeleteGroup,
+    DeleteGroupParticipant, DeleteResult, DeleteSession, DeleteSessionParticipant, Friendship,
+    FriendshipService, FriendConnectionActor, FriendConnectionActorType,
     FriendConnectionCreateResult, FriendConnectionCreateStatus, FriendConnectionPage,
     FriendConnectionRequestDirection, FriendConnectionRequestPage,
     FriendConnectionRequestStatus, FriendConnectionRequestView, FriendConnectionService,
-    FriendConnectionView,
-    FriendRequest, FriendRequestDirection, FriendRequestStatus, GetGroup, GetSession, GroupDetail,
-    GroupService, GroupSummary, Invitation, InvitationAcceptResult, InvitationService,
-    IssueRegisterToken, ListGroups, ListBotFriendRequests, ListBotFriendships,
-    ListFriendConnectionRequests, ListFriendConnections, ListSessionMessages, ListSessions, Page,
+    FriendConnectionView, FriendRequest, FriendRequestDirection, FriendRequestStatus, GetGroup,
+    GetSession, GroupDetail, GroupService, GroupSummary, Invitation, InvitationAcceptResult,
+    InvitationService, IssueRegisterToken, ListBotFriendRequests, ListBotFriendships,
+    ListFriendConnectionRequests, ListFriendConnections, ListGroups, ListSessionMessages,
+    ListSessions, LogoutResult, LogoutSession, Page, ReadCurrentUser, RefreshSession,
     RegisterBot, RegisterService, RegisterTokenView, RejectFriendConnectionRequest,
-    RejectFriendRequest, DeleteBotFriendship, SessionCompletionResult, SessionDetail,
-    SessionMessageService, SessionParticipant, SessionService, SessionSummary, UpdateGroup,
+    RejectFriendRequest, SessionCompletionResult, SessionDetail, SessionMessageService,
+    SessionParticipant, SessionRenewal, SessionService, SessionSummary, UpdateGroup,
     UpdateGroupParticipant, UpdateSession, UpdateSessionParticipant,
 };
 use serde_json::{Value, json};
@@ -868,6 +870,105 @@ fn openapi_test_router(service: Arc<FakeFriendConnectionService>) -> axum::Route
         }),
     )
     .with_friend_connection_service(service))
+}
+
+#[derive(Default)]
+struct CapturingAuthService {
+    current_user_request: Mutex<Option<ReadCurrentUser>>,
+}
+
+#[async_trait]
+impl ApplicationAuthService for CapturingAuthService {
+    async fn login_urls(
+        &self,
+        _request: BuildLoginUrls,
+    ) -> Result<AuthProviderUrlList, ApplicationError> {
+        Err(ApplicationError::internal("unused"))
+    }
+
+    async fn complete_login(
+        &self,
+        _request: CompleteOAuthLogin,
+    ) -> Result<AuthRedirect, ApplicationError> {
+        Err(ApplicationError::internal("unused"))
+    }
+
+    async fn current_user(&self, request: ReadCurrentUser) -> Result<AuthUserInfo, ApplicationError> {
+        *self
+            .current_user_request
+            .lock()
+            .expect("current user request lock") = Some(request);
+        Ok(AuthUserInfo {
+            user_id: "staff-1".to_string(),
+            name: Some("alice".to_string()),
+            provider: "chain".to_string(),
+            avatar: None,
+        })
+    }
+
+    async fn refresh_session(
+        &self,
+        _request: RefreshSession,
+    ) -> Result<SessionRenewal, ApplicationError> {
+        Err(ApplicationError::internal("unused"))
+    }
+
+    async fn logout(&self, _request: LogoutSession) -> Result<LogoutResult, ApplicationError> {
+        Err(ApplicationError::internal("unused"))
+    }
+}
+
+#[tokio::test]
+async fn openapi_auth_user_forwards_request_auth_headers_to_auth_service() {
+    let auth_service = Arc::new(CapturingAuthService::default());
+    let app = router(
+        ApiState::new(
+            Arc::new(NoopGroupService),
+            Arc::new(NoopSessionService),
+            Arc::new(NoopSessionMessageService),
+            Arc::new(NoopInvitationService),
+            Arc::new(NoopRegisterService),
+            Arc::new(FakeFriendshipService::default()),
+            Arc::new(HeaderVerifier { caller: caller() }),
+        )
+        .with_auth_service(auth_service.clone(), "http://127.0.0.1/openapi/v1/auth".to_string()),
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/openapi/v1/auth/user")
+                .header("x-test-auth", "yes")
+                .header("authorization", "Bearer forwarded-user-token")
+                .header("cookie", "bcs_session=session-token")
+                .header("x-forwarded-for", "1.2.3.4")
+                .header("forwarded", "for=1.2.3.4")
+                .body(Body::empty())
+                .expect("auth user request"),
+        )
+        .await
+        .expect("auth user response");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let request = auth_service
+        .current_user_request
+        .lock()
+        .expect("current user request lock")
+        .clone()
+        .expect("captured auth request");
+    assert_eq!(request.headers.authorization.as_deref(), Some("Bearer forwarded-user-token"));
+    assert_eq!(request.headers.cookie.as_deref(), Some("bcs_session=session-token"));
+    let mut forwarded = request.headers.forwarded_headers.clone();
+    forwarded.sort();
+    assert_eq!(
+        forwarded,
+        vec![
+            ("forwarded".to_string(), "for=1.2.3.4".to_string()),
+            ("x-forwarded-for".to_string(), "1.2.3.4".to_string()),
+            ("x-test-auth".to_string(), "yes".to_string()),
+        ]
+    );
 }
 
 #[tokio::test]

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/register_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/register_routes.rs
@@ -411,7 +411,7 @@ async fn post_register_is_anonymous_and_returns_created_envelope() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/register?token=abc123&bot-name=%E6%B5%8B%E8%AF%95%E6%9C%BA%E5%99%A8%E4%BA%BA")
+                .uri("/openapi/v1/collaboration/register?token=abc123&bot-name=%E6%B5%8B%E8%AF%95%E6%9C%BA%E5%99%A8%E4%BA%BA")
                 .header("x-request-id", "request-123")
                 .body(Body::empty())
                 .expect("request"),
@@ -435,7 +435,7 @@ async fn post_register_rejects_missing_token_and_name() {
     let app = test_router(service);
     let response = app
         .clone()
-        .oneshot(bare_request("POST", "/register"))
+        .oneshot(bare_request("POST", "/openapi/v1/collaboration/register"))
         .await
         .expect("missing params response");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -443,7 +443,7 @@ async fn post_register_rejects_missing_token_and_name() {
     assert_eq!(body["code"], 40_000);
 
     let response = app
-        .oneshot(bare_request("POST", "/register?token=abc123"))
+        .oneshot(bare_request("POST", "/openapi/v1/collaboration/register?token=abc123"))
         .await
         .expect("missing name response");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -454,7 +454,7 @@ async fn post_register_maps_unauthenticated_token_failures() {
     let service = fake_service(true);
     let app = test_router(service);
     let response = app
-        .oneshot(bare_request("POST", "/register?token=abc123&bot_name=tester"))
+        .oneshot(bare_request("POST", "/openapi/v1/collaboration/register?token=abc123&bot_name=tester"))
         .await
         .expect("401 response");
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);

--- a/src/bcs/crates/adapters/http/bcs-api-http/tests/register_routes.rs
+++ b/src/bcs/crates/adapters/http/bcs-api-http/tests/register_routes.rs
@@ -411,7 +411,7 @@ async fn post_register_is_anonymous_and_returns_created_envelope() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/openapi/v1/collaboration/register?token=abc123&bot-name=%E6%B5%8B%E8%AF%95%E6%9C%BA%E5%99%A8%E4%BA%BA")
+                .uri("/register?token=abc123&bot-name=%E6%B5%8B%E8%AF%95%E6%9C%BA%E5%99%A8%E4%BA%BA")
                 .header("x-request-id", "request-123")
                 .body(Body::empty())
                 .expect("request"),
@@ -435,7 +435,7 @@ async fn post_register_rejects_missing_token_and_name() {
     let app = test_router(service);
     let response = app
         .clone()
-        .oneshot(bare_request("POST", "/openapi/v1/collaboration/register"))
+        .oneshot(bare_request("POST", "/register"))
         .await
         .expect("missing params response");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -443,7 +443,7 @@ async fn post_register_rejects_missing_token_and_name() {
     assert_eq!(body["code"], 40_000);
 
     let response = app
-        .oneshot(bare_request("POST", "/openapi/v1/collaboration/register?token=abc123"))
+        .oneshot(bare_request("POST", "/register?token=abc123"))
         .await
         .expect("missing name response");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -454,7 +454,7 @@ async fn post_register_maps_unauthenticated_token_failures() {
     let service = fake_service(true);
     let app = test_router(service);
     let response = app
-        .oneshot(bare_request("POST", "/openapi/v1/collaboration/register?token=abc123&bot_name=tester"))
+        .oneshot(bare_request("POST", "/register?token=abc123&bot_name=tester"))
         .await
         .expect("401 response");
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);

--- a/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
@@ -116,7 +116,7 @@ impl AuthService for OAuthRouteState {
         &self,
         request: BuildLoginUrls,
     ) -> Result<AuthProviderUrlList, ApplicationError> {
-        let callback_base_url = request.callback_base_url.trim_end_matches('/');
+        let callback_base_url = request.callback_base_url.trim().trim_end_matches('/');
         if callback_base_url.is_empty() {
             return Err(ApplicationError::invalid(
                 "invalid_callback_base_url",
@@ -144,7 +144,7 @@ impl AuthService for OAuthRouteState {
         &self,
         request: CompleteOAuthLogin,
     ) -> Result<AuthRedirect, ApplicationError> {
-        let callback_base_url = request.callback_base_url.trim_end_matches('/');
+        let callback_base_url = request.callback_base_url.trim().trim_end_matches('/');
         if callback_base_url.is_empty() {
             return Err(ApplicationError::invalid(
                 "invalid_callback_base_url",

--- a/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use axum::{
     extract::{Path, State},
-    http::{HeaderMap, StatusCode},
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
@@ -22,6 +22,12 @@ use tracing::{info, warn};
 
 use bcs_auth_api::{extract_session_cookie, OAuthConfig, OAuthProvider, UserIdentityPort, BCS_SESSION_COOKIE};
 use bcs_jwt::{Claims, JwtService};
+use bcs_service_api::application::v1::{
+    ApplicationError, AuthProviderUrl as V1AuthProviderUrl, AuthProviderUrlList, AuthRedirect,
+    AuthService, AuthUserInfo, BuildLoginUrls, CompleteOAuthLogin, LogoutResult, LogoutSession,
+    ReadCurrentUser, RefreshSession, SessionRenewal,
+};
+use bcs_service_api::application::RequestAuthHeaders;
 
 use crate::oauth::state::OAuthStateStore;
 
@@ -38,6 +44,33 @@ pub struct OAuthRouteState {
     /// local mock plugin. `None` only in contract-test state that never serves
     /// real traffic.
     pub auth_chain: Option<Arc<bcs_auth_api::AuthPluginChain>>,
+}
+
+
+fn headers_from_request_auth(input: &RequestAuthHeaders) -> Result<HeaderMap, ApplicationError> {
+    let mut headers = HeaderMap::new();
+    if let Some(value) = input.authorization.as_ref() {
+        let header_value = HeaderValue::from_str(value).map_err(|_| {
+            ApplicationError::invalid("invalid_authorization_header", "authorization header is invalid")
+        })?;
+        headers.insert(axum::http::header::AUTHORIZATION, header_value);
+    }
+    if let Some(value) = input.cookie.as_ref() {
+        let header_value = HeaderValue::from_str(value).map_err(|_| {
+            ApplicationError::invalid("invalid_cookie_header", "cookie header is invalid")
+        })?;
+        headers.insert(axum::http::header::COOKIE, header_value);
+    }
+    for (name, value) in &input.forwarded_headers {
+        let header_name = HeaderName::from_bytes(name.as_bytes()).map_err(|_| {
+            ApplicationError::invalid("invalid_forwarded_header", "forwarded header name is invalid")
+        })?;
+        let header_value = HeaderValue::from_str(value).map_err(|_| {
+            ApplicationError::invalid("invalid_forwarded_header", "forwarded header value is invalid")
+        })?;
+        headers.insert(header_name, header_value);
+    }
+    Ok(headers)
 }
 
 impl OAuthRouteState {
@@ -74,6 +107,209 @@ impl OAuthRouteState {
             config: OAuthConfig::default(),
             auth_chain: Some(auth_chain),
         }
+    }
+}
+
+#[async_trait::async_trait]
+impl AuthService for OAuthRouteState {
+    async fn login_urls(
+        &self,
+        request: BuildLoginUrls,
+    ) -> Result<AuthProviderUrlList, ApplicationError> {
+        let callback_base_url = request.callback_base_url.trim_end_matches('/');
+        if callback_base_url.is_empty() {
+            return Err(ApplicationError::invalid(
+                "invalid_callback_base_url",
+                "callback_base_url must not be empty",
+            ));
+        }
+        let mut providers = Vec::new();
+        let mut names: Vec<&str> = self.providers.keys().map(|s| s.as_str()).collect();
+        names.sort();
+        for name in names {
+            if let Some(provider) = self.providers.get(name) {
+                let csrf_state = self.state_store.generate(name).await;
+                let redirect_uri = format!("{callback_base_url}/{name}");
+                let url = provider.auth_url(&csrf_state, &redirect_uri);
+                providers.push(V1AuthProviderUrl {
+                    name: name.to_string(),
+                    url,
+                });
+            }
+        }
+        Ok(AuthProviderUrlList { providers })
+    }
+
+    async fn complete_login(
+        &self,
+        request: CompleteOAuthLogin,
+    ) -> Result<AuthRedirect, ApplicationError> {
+        let callback_base_url = request.callback_base_url.trim_end_matches('/');
+        if callback_base_url.is_empty() {
+            return Err(ApplicationError::invalid(
+                "invalid_callback_base_url",
+                "callback_base_url must not be empty",
+            ));
+        }
+
+        let provider_key = self
+            .state_store
+            .consume(&request.state)
+            .await
+            .map_err(|_| ApplicationError::invalid("invalid_state", "invalid state"))?;
+
+        if provider_key != request.provider {
+            return Err(ApplicationError::invalid("provider_mismatch", "provider mismatch"));
+        }
+
+        let provider = self.providers.get(&request.provider).cloned().ok_or_else(|| {
+            ApplicationError::not_found("provider_not_found", "provider not found")
+        })?;
+
+        let code = request.code.or(request.auth_code).ok_or_else(|| {
+            ApplicationError::invalid("missing_code", "missing code or auth_code")
+        })?;
+        let redirect_uri = format!("{callback_base_url}/{}", request.provider);
+        let token = provider.exchange_code(&code, &redirect_uri).await.map_err(|e| {
+            warn!(error = %e, provider = %request.provider, "OAuth token exchange failed");
+            ApplicationError::bad_gateway("token_exchange_failed", "token exchange failed")
+        })?;
+
+        let user_info = provider.get_user_info(&token).await.map_err(|e| {
+            warn!(error = %e, provider = %request.provider, "OAuth userinfo failed");
+            ApplicationError::bad_gateway("userinfo_request_failed", "userinfo request failed")
+        })?;
+
+        let user_id = self
+            .user_port
+            .ensure_identity(
+                &request.provider,
+                &user_info.id,
+                user_info.name.as_deref(),
+                user_info.avatar.as_deref(),
+                &self.config.env,
+            )
+            .await
+            .map_err(|e| {
+                warn!(error = %e, "ensure_identity failed");
+                ApplicationError::internal("identity creation failed")
+            })?;
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let claims = Claims {
+            sub: user_id,
+            src: request.provider.clone(),
+            iat: now,
+            exp: now + self.config.idle_timeout_secs(),
+        };
+        let jwt = self.jwt_service.sign(&claims).map_err(|e| {
+            warn!(error = %e, "JWT signing failed");
+            ApplicationError::internal("session creation failed")
+        })?;
+
+        self.user_port
+            .update_token(&claims.sub, &bcs_jwt::token_hash(&jwt), claims.exp)
+            .await
+            .map_err(|e| {
+                warn!(error = %e, "update_token failed; aborting login");
+                ApplicationError::internal("session creation failed")
+            })?;
+
+        info!(provider = %request.provider, user_id = %claims.sub, "OAuth login successful");
+        Ok(AuthRedirect {
+            location: "/?login=success".to_string(),
+            set_cookie: session_cookie(&jwt, self.config.cookie_secure),
+        })
+    }
+
+    async fn current_user(&self, request: ReadCurrentUser) -> Result<AuthUserInfo, ApplicationError> {
+        let Some(chain) = self.auth_chain.as_ref() else {
+            return Err(ApplicationError::Unauthenticated);
+        };
+        let headers = headers_from_request_auth(&request.headers)?;
+        match chain.authenticate(&headers).await {
+            Ok(result) => match result.principal {
+                Some(principal)
+                    if principal
+                        .user_id
+                        .as_deref()
+                        .is_some_and(|id| !id.is_empty()) =>
+                {
+                    Ok(AuthUserInfo {
+                        user_id: principal.user_id.unwrap(),
+                        name: principal.user_name,
+                        provider: principal.source_name.unwrap_or_else(|| "chain".to_string()),
+                        avatar: principal.avatar,
+                    })
+                }
+                _ => Err(ApplicationError::Unauthenticated),
+            },
+            Err(e) => {
+                warn!(error = %e, "auth chain failed in OpenAPI auth user");
+                Err(ApplicationError::internal("auth chain failed"))
+            }
+        }
+    }
+
+    async fn refresh_session(&self, request: RefreshSession) -> Result<SessionRenewal, ApplicationError> {
+        let headers = headers_from_request_auth(&request.headers)?;
+        let jwt = extract_session_cookie(&headers).ok_or(ApplicationError::Unauthenticated)?;
+        let claims = self
+            .jwt_service
+            .verify_no_exp(&jwt)
+            .map_err(|_| ApplicationError::Unauthenticated)?;
+
+        match self.user_port.get_identity_by_token(&bcs_jwt::token_hash(&jwt)).await {
+            Ok(Some(info)) if info.user_id == claims.sub => {}
+            Ok(_) => return Err(ApplicationError::Unauthenticated),
+            Err(e) => {
+                warn!(error = %e, "refresh: identity lookup failed");
+                return Err(ApplicationError::internal("identity lookup failed"));
+            }
+        };
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let new_claims = Claims {
+            sub: claims.sub.clone(),
+            src: claims.src.clone(),
+            iat: now,
+            exp: now + self.config.idle_timeout_secs(),
+        };
+        let new_jwt = self.jwt_service.sign(&new_claims).map_err(|e| {
+            warn!(error = %e, "refresh: JWT signing failed");
+            ApplicationError::internal("session renewal failed")
+        })?;
+        self.user_port
+            .update_token(&new_claims.sub, &bcs_jwt::token_hash(&new_jwt), new_claims.exp)
+            .await
+            .map_err(|e| {
+                warn!(error = %e, "refresh: update_token failed");
+                ApplicationError::internal("session renewal failed")
+            })?;
+
+        Ok(SessionRenewal {
+            set_cookie: session_cookie(&new_jwt, self.config.cookie_secure),
+        })
+    }
+
+    async fn logout(&self, request: LogoutSession) -> Result<LogoutResult, ApplicationError> {
+        let headers = headers_from_request_auth(&request.headers)?;
+        if let Some(jwt) = extract_session_cookie(&headers) {
+            if let Ok(claims) = self.jwt_service.verify(&jwt) {
+                if let Err(e) = self.user_port.update_token(&claims.sub, "", 0).await {
+                    warn!(error = %e, user_id = %claims.sub, "logout: token revocation failed");
+                }
+            }
+        }
+        Ok(LogoutResult {
+            set_cookie: clear_session_cookie(self.config.cookie_secure),
+        })
     }
 }
 
@@ -482,7 +718,7 @@ mod tests {
     use async_trait::async_trait;
     use axum::body::to_bytes;
     use bcs_auth_api::{AuthError, AuthPlugin, AuthPluginChain, AuthPrincipal, AuthSource};
-    use bcs_test_support::{NoopAuthPlugin, NoopUserIdentityPort};
+    use bcs_test_support::{MockOAuthProvider, NoopAuthPlugin, NoopUserIdentityPort};
 
     /// A chain plugin that always yields a principal with the given `user_id`
     /// (which may be `None`), so the empty/missing-user_id branch of
@@ -532,6 +768,57 @@ mod tests {
         let bytes = to_bytes(resp.into_body(), usize::MAX).await.expect("body");
         let body = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
         (status, body)
+    }
+
+    #[tokio::test]
+    async fn auth_service_complete_login_issues_redirect_cookie_without_network() {
+        let mut providers: HashMap<String, Arc<dyn OAuthProvider>> = HashMap::new();
+        providers.insert(
+            "google".to_string(),
+            Arc::new(MockOAuthProvider::new("google", "external-123")),
+        );
+        let state = OAuthRouteState::new(
+            "test-secret-key-at-least-32-bytes!!",
+            Arc::new(NoopUserIdentityPort),
+            providers,
+            OAuthConfig {
+                jwt_secret: "test-secret-key-at-least-32-bytes!!".to_string(),
+                idle_timeout_minutes: 30,
+                base_url: "https://bcs.example.com".to_string(),
+                cookie_secure: false,
+                env: "test".to_string(),
+            },
+            None,
+        );
+
+        let urls = state
+            .login_urls(BuildLoginUrls {
+                callback_base_url: "https://bcs.example.com/openapi/v1/auth/callback".to_string(),
+            })
+            .await
+            .expect("login urls");
+        let provider_url = &urls.providers[0].url;
+        let state_param = provider_url
+            .split('&')
+            .find_map(|part| part.strip_prefix("state="))
+            .expect("state query param")
+            .to_string();
+
+        let result = state
+            .complete_login(CompleteOAuthLogin {
+                provider: "google".to_string(),
+                code: Some("auth-code".to_string()),
+                auth_code: None,
+                state: state_param,
+                callback_base_url: "https://bcs.example.com/openapi/v1/auth/callback".to_string(),
+            })
+            .await
+            .expect("complete login");
+
+        assert_eq!(result.location, "/?login=success");
+        assert!(result.set_cookie.starts_with("bcs_session="));
+        assert!(result.set_cookie.contains("HttpOnly"));
+        assert!(result.set_cookie.contains("SameSite=Lax"));
     }
 
     /// A principal whose `user_id` is `None` is not a human login — `/auth/user`

--- a/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
@@ -822,6 +822,86 @@ mod tests {
         assert!(result.set_cookie.contains("SameSite=Lax"));
     }
 
+
+    #[tokio::test]
+    async fn login_urls_rejects_empty_callback_base_url() {
+        let mut providers: HashMap<String, Arc<dyn OAuthProvider>> = HashMap::new();
+        providers.insert(
+            "google".to_string(),
+            Arc::new(MockOAuthProvider::new("google", "external-123")),
+        );
+        let state = OAuthRouteState::new(
+            "test-secret-key-at-least-32-bytes!!",
+            Arc::new(NoopUserIdentityPort),
+            providers,
+            OAuthConfig {
+                jwt_secret: "test-secret-key-at-least-32-bytes!!".to_string(),
+                idle_timeout_minutes: 30,
+                base_url: "https://bcs.example.com".to_string(),
+                cookie_secure: false,
+                env: "test".to_string(),
+            },
+            None,
+        );
+
+        let err = state
+            .login_urls(BuildLoginUrls {
+                callback_base_url: "   ".to_string(),
+            })
+            .await
+            .expect_err("empty callback base url should fail");
+
+        assert_eq!(err.code(), "invalid_callback_base_url");
+    }
+
+    #[tokio::test]
+    async fn complete_login_rejects_missing_code() {
+        let mut providers: HashMap<String, Arc<dyn OAuthProvider>> = HashMap::new();
+        providers.insert(
+            "google".to_string(),
+            Arc::new(MockOAuthProvider::new("google", "external-123")),
+        );
+        let state = OAuthRouteState::new(
+            "test-secret-key-at-least-32-bytes!!",
+            Arc::new(NoopUserIdentityPort),
+            providers,
+            OAuthConfig {
+                jwt_secret: "test-secret-key-at-least-32-bytes!!".to_string(),
+                idle_timeout_minutes: 30,
+                base_url: "https://bcs.example.com".to_string(),
+                cookie_secure: false,
+                env: "test".to_string(),
+            },
+            None,
+        );
+
+        let urls = state
+            .login_urls(BuildLoginUrls {
+                callback_base_url: "https://bcs.example.com/openapi/v1/auth/callback".to_string(),
+            })
+            .await
+            .expect("login urls");
+        let provider_url = &urls.providers[0].url;
+        let state_param = provider_url
+            .split('&')
+            .find_map(|part| part.strip_prefix("state="))
+            .expect("state query param")
+            .to_string();
+
+        let err = state
+            .complete_login(CompleteOAuthLogin {
+                provider: "google".to_string(),
+                code: None,
+                auth_code: None,
+                state: state_param,
+                callback_base_url: "https://bcs.example.com/openapi/v1/auth/callback".to_string(),
+            })
+            .await
+            .expect_err("missing code should fail");
+
+        assert_eq!(err.code(), "missing_code");
+    }
+
     /// A principal whose `user_id` is `None` is not a human login — `/auth/user`
     /// must NOT return 200 with an empty user_id.
     #[tokio::test]

--- a/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/oauth/mod.rs
@@ -275,11 +275,12 @@ impl AuthService for OAuthRouteState {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
+        let iat = now.max(claims.iat.saturating_add(1));
         let new_claims = Claims {
             sub: claims.sub.clone(),
             src: claims.src.clone(),
-            iat: now,
-            exp: now + self.config.idle_timeout_secs(),
+            iat,
+            exp: iat + self.config.idle_timeout_secs(),
         };
         let new_jwt = self.jwt_service.sign(&new_claims).map_err(|e| {
             warn!(error = %e, "refresh: JWT signing failed");

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -4724,24 +4724,8 @@ let collaboration_templates = build_collaboration_template_service_with_storage(
         Ok(Self { config, state })
     }
 
-    /// Build the `/auth/*` router.
-    ///
-    /// Two mounting paths:
-    /// 1. **Full OAuth** — when `[auth.oauth]` is configured with a non-empty
-    ///    `jwt_secret`, an `http(s)` `base_url`, and at least one provider:
-    ///    mounts the complete OAuth protocol routes with the auth chain
-    ///    injected as the `/auth/user` fallback.
-    /// 2. **Identity-only** — when no usable OAuth config exists but an auth
-    ///    chain (e.g. the `local` mock plugin) is present: mounts just
-    ///    `GET /auth/user`, resolved solely via the chain. This lets deployments
-    ///    use `/auth/user` without configuring any OAuth provider.
-    ///
-    /// `jwt_secret` comes from the resolved `auth_config` (see
-    /// `auth_wiring::resolve_auth_config`). Currently only `google` is wired.
-    fn build_auth_router(&self) -> Option<Router> {
+    fn build_full_oauth_route_state(&self) -> Option<Arc<bcs_http::oauth::OAuthRouteState>> {
         let auth_chain = Arc::clone(&self.state.auth_chain);
-
-        // --- Case 1: full OAuth configuration ------------------------------
         // `auth_config.oauth` is the resolved form: present only when a
         // non-empty jwt_secret was configured (I6 gate lives in resolve).
         if let (Some(resolved), Some(raw)) = (
@@ -4786,9 +4770,9 @@ let collaboration_templates = build_collaboration_template_service_with_storage(
                                 providers = ?route_state.providers.keys().collect::<Vec<_>>(),
                                 cookie_secure = resolved.cookie_secure,
                                 env = %resolved.env,
-                                "Mounting OAuth /auth/* routes"
+                                "Mounting OAuth routes"
                             );
-                            return Some(bcs_http::oauth::routes(route_state));
+                            return Some(route_state);
                         }
                     } else {
                         warn!(
@@ -4807,10 +4791,43 @@ let collaboration_templates = build_collaboration_template_service_with_storage(
             }
         }
 
-        // --- Case 2: identity-only (chain-backed, no OAuth) -----------------
+        None
+    }
+
+    fn openapi_auth_public_base_url(&self) -> Option<String> {
+        self.state.auth_config.oauth.as_ref().map(|oauth| {
+            format!("{}/openapi/v1/auth", oauth.base_url.trim_end_matches('/'))
+        })
+    }
+
+    /// Build the `/auth/*` router.
+    ///
+    /// Two mounting paths:
+    /// 1. **Full OAuth** — when `[auth.oauth]` is configured with a non-empty
+    ///    `jwt_secret`, an `http(s)` `base_url`, and at least one provider:
+    ///    mounts the complete OAuth protocol routes with the auth chain
+    ///    injected as the `/auth/user` fallback.
+    /// 2. **Identity-only** — when no usable OAuth config exists but an auth
+    ///    chain (e.g. the `local` mock plugin) is present: mounts just
+    ///    `GET /auth/user`, resolved solely via the chain. This lets deployments
+    ///    use `/auth/user` without configuring any OAuth provider.
+    ///
+    /// `jwt_secret` comes from the resolved `auth_config` (see
+    /// `auth_wiring::resolve_auth_config`).
+    fn build_auth_router(
+        &self,
+        oauth_state: Option<Arc<bcs_http::oauth::OAuthRouteState>>,
+    ) -> Option<Router> {
+        if let Some(route_state) = oauth_state {
+            info!("Mounting OAuth /auth/* routes");
+            return Some(bcs_http::oauth::routes(route_state));
+        }
+
+        // Identity-only (chain-backed, no OAuth).
         if let Some(user_port) = self.state.user_identity_port.clone() {
             let route_state = Arc::new(bcs_http::oauth::OAuthRouteState::new_chain_only(
-                user_port, auth_chain,
+                user_port,
+                Arc::clone(&self.state.auth_chain),
             ));
             info!("Mounting identity-only /auth/user (no OAuth providers configured)");
             return Some(bcs_http::oauth::identity_routes(route_state));
@@ -4835,6 +4852,14 @@ let collaboration_templates = build_collaboration_template_service_with_storage(
             web_ws_dispatch_state(&self.state, Some(group_session_connections.clone())),
             ws_lifecycle_hook(&self.state),
         );
+        let oauth_state = self.build_full_oauth_route_state();
+        let mut openapi_v1 = self.state.openapi_v1.clone();
+        if let (Some(auth_service), Some(public_base_url)) = (
+            oauth_state.clone(),
+            self.openapi_auth_public_base_url(),
+        ) {
+            openapi_v1 = openapi_v1.with_auth_service(auth_service, public_base_url);
+        }
 
         let mut router = Router::new()
             // WebSocket endpoint for frontend clients (via gateway)
@@ -4849,14 +4874,14 @@ let collaboration_templates = build_collaboration_template_service_with_storage(
         let mut router = router
             .with_state(Arc::clone(&self.state))
             .merge(api_router)
-            .merge(bcs_api_http::router(self.state.openapi_v1.clone()))
+            .merge(bcs_api_http::router(openapi_v1))
             .merge(bcs_api_http::group_session_connection_router(
                 group_session_connections,
                 self.state.gateway_principal_verifier.clone(),
             ))
             .merge(group_session_websocket_router);
 
-        if let Some(oauth_router) = self.build_auth_router() {
+        if let Some(oauth_router) = self.build_auth_router(oauth_state) {
             router = router.merge(oauth_router);
         }
 

--- a/src/bcs/crates/bootstrap/bcs/tests/integration_oauth_routes.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/integration_oauth_routes.rs
@@ -12,6 +12,8 @@ use serde_json::{json, Value};
 
 use bcs::{BcsConfig, BcsError, BcsServer};
 
+const TEST_JWT_SECRET: &str = "test-secret-key-at-least-32-bytes!!";
+
 /// Build a minimal in-memory BCS config; `oauth` (a JSON object or `null`) is
 /// spliced into the `auth` block.
 fn config_with_oauth(bots_dir: &PathBuf, oauth: Value) -> BcsConfig {
@@ -46,6 +48,64 @@ fn config_with_oauth(bots_dir: &PathBuf, oauth: Value) -> BcsConfig {
     serde_json::from_value(config_json).expect("Failed to parse BcsConfig")
 }
 
+fn config_with_auth(bots_dir: &PathBuf, auth: Value) -> BcsConfig {
+    let config_json = json!({
+        "bind": "127.0.0.1",
+        "port": 0,
+        "bots_base_dir": bots_dir,
+        "max_history_per_session": 100,
+        "store_messages": true,
+        "max_groups_as_driver": 3,
+        "group_chat_delay_min_ms": 0,
+        "group_chat_delay_max_ms": 0,
+        "max_group_members": 5,
+        "max_groups_as_member": 10,
+        "max_group_messages": 100,
+        "onboard_binding_enabled": false,
+        "strict_container_validation": false,
+        "bcs_endpoint": null,
+        "default_visibility": null,
+        "auth": auth,
+        "logging": {
+            "default_level": "info",
+            "console": true,
+            "modules": {},
+            "tags": {},
+            "outputs": []
+        }
+    });
+    serde_json::from_value(config_json).expect("Failed to parse BcsConfig")
+}
+
+async fn seed_bound_oauth_cookie(
+    user_port: std::sync::Arc<dyn bcs_auth_api::UserIdentityPort>,
+    env: &str,
+    name: &str,
+    avatar: &str,
+) -> (String, String) {
+    let user_id = user_port
+        .ensure_identity("google", "ext-123", Some(name), Some(avatar), env)
+        .await
+        .expect("ensure_identity");
+    let jwt_svc = bcs_jwt::JwtService::new(TEST_JWT_SECRET);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let claims = bcs_jwt::Claims {
+        sub: user_id.clone(),
+        src: "google".to_string(),
+        iat: now,
+        exp: now + 1800,
+    };
+    let jwt = jwt_svc.sign(&claims).expect("sign jwt");
+    user_port
+        .update_token(&user_id, &bcs_jwt::token_hash(&jwt), claims.exp)
+        .await
+        .expect("bind token");
+    (user_id, jwt)
+}
+
 async fn start(config: BcsConfig) -> (SocketAddr, tokio::task::JoinHandle<Result<(), BcsError>>) {
     BcsServer::new_allowing_private_outbound_for_tests(config)
         .run_on_random_port()
@@ -54,6 +114,424 @@ async fn start(config: BcsConfig) -> (SocketAddr, tokio::task::JoinHandle<Result
 }
 
 // __CONTINUE_HERE__
+
+// Seam under test: public HTTP OpenAPI v1 auth facade. These tests assert
+// versioned status/envelope/cookie behavior without reaching into provider
+// implementation internals.
+
+#[tokio::test]
+async fn openapi_bots_mine_rejects_bound_oauth_cookie_without_gateway_principal() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let config = config_with_auth(
+        &tmp.path().to_path_buf(),
+        json!({
+            "chain": ["oauth_session"],
+            "oauth": {
+                "jwt_secret": TEST_JWT_SECRET,
+                "base_url": "https://bcs.example.com",
+                "cookie_secure": false,
+                "providers": {
+                    "google": {
+                        "client_id": "test-client-id.apps.googleusercontent.com",
+                        "client_secret": "test-client-secret",
+                    }
+                }
+            }
+        }),
+    );
+    let (addr, handle, state) = BcsServer::new_allowing_private_outbound_for_tests(config)
+        .run_on_random_port_with_state()
+        .await
+        .expect("start server with state");
+    let user_port = state.user_identity_port.clone().expect("user port");
+    let env = state.auth_config.oauth.as_ref().expect("oauth config").env.clone();
+    let (_user_id, jwt) = seed_bound_oauth_cookie(
+        user_port,
+        &env,
+        "Alice OAuth",
+        "https://example.com/a.png",
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("http://{addr}/openapi/v1/collaboration/bots/mine"))
+        .header("cookie", format!("bcs_session={jwt}"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("request /openapi/v1/collaboration/bots/mine");
+
+    assert_eq!(resp.status(), 401, "protected openapi routes require gateway principal");
+    let body: Value = resp.json().await.expect("json body");
+    assert_eq!(body["code"], 40_100);
+    assert_eq!(body["data"]["error_code"], "unauthenticated");
+
+    handle.abort();
+}
+
+
+#[tokio::test]
+async fn openapi_auth_user_returns_unauthenticated_without_session() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let config = config_with_oauth(
+        &tmp.path().to_path_buf(),
+        json!({
+            "jwt_secret": "test-secret",
+            "base_url": "https://bcs.example.com",
+            "providers": {
+                "google": {
+                    "client_id": "test-client-id.apps.googleusercontent.com",
+                    "client_secret": "test-client-secret",
+                }
+            }
+        }),
+    );
+    let (addr, handle) = start(config).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("http://{addr}/openapi/v1/auth/user"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("request /openapi/v1/auth/user");
+    assert_eq!(resp.status(), 401);
+    let body: Value = resp.json().await.expect("json body");
+    assert_eq!(body["code"], 40_100);
+    assert_eq!(body["data"]["error_code"], "unauthenticated");
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn openapi_auth_refresh_returns_unauthenticated_without_session() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let config = config_with_oauth(
+        &tmp.path().to_path_buf(),
+        json!({
+            "jwt_secret": "test-secret",
+            "base_url": "https://bcs.example.com",
+            "providers": {
+                "google": {
+                    "client_id": "test-client-id.apps.googleusercontent.com",
+                    "client_secret": "test-client-secret",
+                }
+            }
+        }),
+    );
+    let (addr, handle) = start(config).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/openapi/v1/auth/refresh"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("request /openapi/v1/auth/refresh");
+    assert_eq!(resp.status(), 401);
+    let body: Value = resp.json().await.expect("json body");
+    assert_eq!(body["code"], 40_100);
+    assert_eq!(body["data"]["error_code"], "unauthenticated");
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn openapi_auth_logout_returns_envelope_and_clears_cookie() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let config = config_with_oauth(
+        &tmp.path().to_path_buf(),
+        json!({
+            "jwt_secret": "test-secret",
+            "base_url": "https://bcs.example.com",
+            "providers": {
+                "google": {
+                    "client_id": "test-client-id.apps.googleusercontent.com",
+                    "client_secret": "test-client-secret",
+                }
+            }
+        }),
+    );
+    let (addr, handle) = start(config).await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/openapi/v1/auth/logout"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("request /openapi/v1/auth/logout");
+    assert_eq!(resp.status(), 200);
+    let set_cookie = resp
+        .headers()
+        .get(reqwest::header::SET_COOKIE)
+        .and_then(|value| value.to_str().ok())
+        .expect("set-cookie header");
+    assert!(set_cookie.contains("bcs_session="));
+    assert!(set_cookie.contains("Max-Age=0"));
+    let body: Value = resp.json().await.expect("json body");
+    assert_eq!(body["code"], 20_000);
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn openapi_auth_callback_returns_v1_error_for_invalid_state() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let config = config_with_oauth(
+        &tmp.path().to_path_buf(),
+        json!({
+            "jwt_secret": "test-secret",
+            "base_url": "https://bcs.example.com",
+            "providers": {
+                "google": {
+                    "client_id": "test-client-id.apps.googleusercontent.com",
+                    "client_secret": "test-client-secret",
+                }
+            }
+        }),
+    );
+    let (addr, handle) = start(config).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("http://{addr}/openapi/v1/auth/callback/google?code=abc&state=bad-state"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("request /openapi/v1/auth/callback/google");
+    assert_eq!(resp.status(), 400);
+    let body: Value = resp.json().await.expect("json body");
+    assert_eq!(body["code"], 40_000);
+    assert_eq!(body["data"]["error_code"], "invalid_state");
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn openapi_auth_callback_uses_provider_state_binding() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let config = config_with_oauth(
+        &tmp.path().to_path_buf(),
+        json!({
+            "jwt_secret": "test-secret",
+            "base_url": "https://bcs.example.com",
+            "providers": {
+                "google": {
+                    "client_id": "test-client-id.apps.googleusercontent.com",
+                    "client_secret": "test-client-secret",
+                }
+            }
+        }),
+    );
+    let (addr, handle) = start(config).await;
+
+    let body: Value = reqwest::Client::new()
+        .get(format!("http://{addr}/openapi/v1/auth/url"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("request /openapi/v1/auth/url")
+        .json()
+        .await
+        .expect("json body");
+    let provider_url = body["data"]["providers"][0]["url"].as_str().expect("provider url");
+    let parsed = reqwest::Url::parse(provider_url).expect("provider url parses");
+    let state = parsed
+        .query_pairs()
+        .find(|(name, _)| name == "state")
+        .map(|(_, value)| value.into_owned())
+        .expect("state query param");
+
+    let resp = reqwest::Client::new()
+        .get(format!("http://{addr}/openapi/v1/auth/callback/alipay?code=abc&state={state}"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("request /openapi/v1/auth/callback/alipay");
+    assert_eq!(resp.status(), 400);
+    let body: Value = resp.json().await.expect("json body");
+    assert_eq!(body["data"]["error_code"], "provider_mismatch");
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn openapi_auth_user_returns_oauth_identity_from_bound_cookie() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let config = config_with_auth(
+        &tmp.path().to_path_buf(),
+        json!({
+            "chain": ["oauth_session"],
+            "oauth": {
+                "jwt_secret": TEST_JWT_SECRET,
+                "base_url": "https://bcs.example.com",
+                "cookie_secure": false,
+                "providers": {
+                    "google": {
+                        "client_id": "test-client-id.apps.googleusercontent.com",
+                        "client_secret": "test-client-secret",
+                    }
+                }
+            }
+        }),
+    );
+    let (addr, handle, state) = BcsServer::new_allowing_private_outbound_for_tests(config)
+        .run_on_random_port_with_state()
+        .await
+        .expect("start server with state");
+    let user_port = state.user_identity_port.clone().expect("user port");
+    let env = state.auth_config.oauth.as_ref().expect("oauth config").env.clone();
+    let (user_id, jwt) = seed_bound_oauth_cookie(
+        user_port,
+        &env,
+        "Alice OAuth",
+        "https://example.com/a.png",
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("http://{addr}/openapi/v1/auth/user"))
+        .header("cookie", format!("bcs_session={jwt}"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("request /openapi/v1/auth/user");
+
+    assert_eq!(resp.status(), 200, "bound cookie should authenticate");
+    let body: Value = resp.json().await.expect("json body");
+    assert_eq!(body["code"], 20_000);
+    assert_eq!(body["data"]["user_id"], user_id);
+    assert_eq!(body["data"]["name"], "Alice OAuth");
+    assert_eq!(body["data"]["provider"], "google");
+    assert_eq!(body["data"]["avatar"], "https://example.com/a.png");
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn openapi_auth_refresh_renews_bound_cookie() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let config = config_with_auth(
+        &tmp.path().to_path_buf(),
+        json!({
+            "chain": ["oauth_session"],
+            "oauth": {
+                "jwt_secret": TEST_JWT_SECRET,
+                "base_url": "https://bcs.example.com",
+                "cookie_secure": false,
+                "providers": {
+                    "google": {
+                        "client_id": "test-client-id.apps.googleusercontent.com",
+                        "client_secret": "test-client-secret",
+                    }
+                }
+            }
+        }),
+    );
+    let (addr, handle, state) = BcsServer::new_allowing_private_outbound_for_tests(config)
+        .run_on_random_port_with_state()
+        .await
+        .expect("start server with state");
+    let user_port = state.user_identity_port.clone().expect("user port");
+    let env = state.auth_config.oauth.as_ref().expect("oauth config").env.clone();
+    let (_user_id, jwt) = seed_bound_oauth_cookie(
+        user_port,
+        &env,
+        "Alice OAuth",
+        "https://example.com/a.png",
+    )
+    .await;
+
+    let resp = reqwest::Client::new()
+        .post(format!("http://{addr}/openapi/v1/auth/refresh"))
+        .header("cookie", format!("bcs_session={jwt}"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("request /openapi/v1/auth/refresh");
+
+    assert_eq!(resp.status(), 200, "bound cookie should refresh");
+    let set_cookie = resp
+        .headers()
+        .get(reqwest::header::SET_COOKIE)
+        .and_then(|value| value.to_str().ok())
+        .expect("set-cookie header");
+    assert!(set_cookie.starts_with("bcs_session="));
+    assert!(!set_cookie.contains(&jwt), "refresh should issue a new JWT");
+    let body: Value = resp.json().await.expect("json body");
+    assert_eq!(body["code"], 20_000);
+
+    handle.abort();
+}
+
+/// OpenAPI Auth facade exposes the same configured providers under a versioned
+/// public contract and uses the OpenAPI callback path in redirect_uri.
+#[tokio::test]
+async fn openapi_auth_url_returns_google_login_url_with_openapi_callback() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let config = config_with_oauth(
+        &tmp.path().to_path_buf(),
+        json!({
+            "jwt_secret": "test-secret",
+            "base_url": "https://bcs.example.com",
+            "providers": {
+                "google": {
+                    "client_id": "test-client-id.apps.googleusercontent.com",
+                    "client_secret": "test-client-secret",
+                }
+            }
+        }),
+    );
+    let (addr, handle) = start(config).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("http://{addr}/openapi/v1/auth/url"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("request /openapi/v1/auth/url");
+    assert_eq!(resp.status(), 200, "/openapi/v1/auth/url should be mounted");
+
+    let body: Value = resp.json().await.expect("json body");
+    assert_eq!(body["code"], 20_000, "OpenAPI auth returns v1 envelope");
+    let providers = body["data"]["providers"].as_array().expect("providers array");
+    assert_eq!(providers.len(), 1, "exactly one provider configured");
+    assert_eq!(providers[0]["name"], "google");
+    let url = providers[0]["url"].as_str().expect("provider url");
+    assert!(
+        url.starts_with("https://accounts.google.com/o/oauth2/v2/auth"),
+        "google auth endpoint, got: {url}"
+    );
+    assert!(
+        url.contains("client_id=test-client-id.apps.googleusercontent.com"),
+        "carries configured client_id, got: {url}"
+    );
+    assert!(
+        url.contains("redirect_uri=https%3A%2F%2Fbcs.example.com%2Fopenapi%2Fv1%2Fauth%2Fcallback%2Fgoogle"),
+        "redirect_uri uses OpenAPI callback path, got: {url}"
+    );
+
+    handle.abort();
+}
+
+/// When OAuth is not configured, the OpenAPI Auth facade fails closed with a
+/// versioned error instead of returning a misleading empty provider list.
+#[tokio::test]
+async fn openapi_auth_url_returns_not_found_when_oauth_absent() {
+    let tmp = tempfile::TempDir::new().expect("temp dir");
+    let config = config_with_oauth(&tmp.path().to_path_buf(), Value::Null);
+    let (addr, handle) = start(config).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("http://{addr}/openapi/v1/auth/url"))
+        .timeout(Duration::from_secs(5))
+        .send()
+        .await
+        .expect("request /openapi/v1/auth/url");
+    assert_eq!(resp.status(), 404, "OpenAPI auth should fail closed");
+    let body: Value = resp.json().await.expect("json body");
+    assert_eq!(body["code"], 40_400);
+    assert_eq!(body["data"]["error_code"], "auth_not_configured");
+
+    handle.abort();
+}
 
 /// When `[auth.oauth.google]` is configured, `GET /auth/url` returns the
 /// google provider's login URL built from the configured client_id/base_url.

--- a/src/bcs/crates/bootstrap/bcs/tests/openapi_v1_mount.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/openapi_v1_mount.rs
@@ -357,7 +357,7 @@ async fn register_routes_have_the_expected_security_boundary() {
     // principal boundary — an anonymous POST reaches the handler and gets a
     // 400 (missing params) instead of the boundary's 401.
     let anonymous = client
-        .post(format!("http://{addr}/openapi/v1/collaboration/register"))
+        .post(format!("http://{addr}/register"))
         .send()
         .await
         .expect("anonymous register request");

--- a/src/bcs/crates/bootstrap/bcs/tests/openapi_v1_mount.rs
+++ b/src/bcs/crates/bootstrap/bcs/tests/openapi_v1_mount.rs
@@ -330,7 +330,7 @@ async fn register_routes_have_the_expected_security_boundary() {
     let (addr, handle) = server.run_on_random_port().await.expect("start server");
     let client = reqwest::Client::new();
 
-    // GET /register/token sits on the protected router: missing or invalid
+    // GET /openapi/v1/collaboration/register/token sits on the protected router: missing or invalid
     // principal is rejected by the boundary before the handler runs.
     let missing = client
         .get(format!("http://{addr}/openapi/v1/collaboration/register/token"))
@@ -353,11 +353,11 @@ async fn register_routes_have_the_expected_security_boundary() {
     assert_eq!(body["code"], 20_000);
     assert!(body["data"]["token"].as_str().expect("token data").len() > 16);
 
-    // POST /register sits on the public router: it must NOT be gated by the
+    // POST /openapi/v1/collaboration/register sits on the public router: it must NOT be gated by the
     // principal boundary — an anonymous POST reaches the handler and gets a
     // 400 (missing params) instead of the boundary's 401.
     let anonymous = client
-        .post(format!("http://{addr}/register"))
+        .post(format!("http://{addr}/openapi/v1/collaboration/register"))
         .send()
         .await
         .expect("anonymous register request");

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/auth.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/auth.rs
@@ -1,0 +1,97 @@
+use async_trait::async_trait;
+use serde::Serialize;
+
+use crate::application::RequestAuthHeaders;
+
+use super::ApplicationError;
+
+/// Command for building OAuth login URLs for a versioned public auth surface.
+///
+/// `callback_base_url` is the public base callback path without the provider
+/// segment, e.g. `https://host/openapi/v1/auth/callback`.
+#[derive(Debug, Clone)]
+pub struct BuildLoginUrls {
+    pub callback_base_url: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AuthProviderUrl {
+    pub name: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AuthProviderUrlList {
+    pub providers: Vec<AuthProviderUrl>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompleteOAuthLogin {
+    pub provider: String,
+    pub code: Option<String>,
+    pub auth_code: Option<String>,
+    pub state: String,
+    pub callback_base_url: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ReadCurrentUser {
+    pub headers: RequestAuthHeaders,
+}
+
+#[derive(Debug, Clone)]
+pub struct RefreshSession {
+    pub headers: RequestAuthHeaders,
+}
+
+#[derive(Debug, Clone)]
+pub struct LogoutSession {
+    pub headers: RequestAuthHeaders,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AuthUserInfo {
+    pub user_id: String,
+    pub name: Option<String>,
+    pub provider: String,
+    pub avatar: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AuthRedirect {
+    pub location: String,
+    pub set_cookie: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionRenewal {
+    #[serde(skip_serializing)]
+    pub set_cookie: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LogoutResult {
+    #[serde(skip_serializing)]
+    pub set_cookie: String,
+}
+
+#[async_trait]
+pub trait AuthService: Send + Sync {
+    async fn login_urls(
+        &self,
+        request: BuildLoginUrls,
+    ) -> Result<AuthProviderUrlList, ApplicationError>;
+
+    async fn complete_login(
+        &self,
+        request: CompleteOAuthLogin,
+    ) -> Result<AuthRedirect, ApplicationError>;
+
+    async fn current_user(&self, request: ReadCurrentUser)
+        -> Result<AuthUserInfo, ApplicationError>;
+
+    async fn refresh_session(&self, request: RefreshSession)
+        -> Result<SessionRenewal, ApplicationError>;
+
+    async fn logout(&self, request: LogoutSession) -> Result<LogoutResult, ApplicationError>;
+}

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/v1/mod.rs
@@ -4,6 +4,7 @@
 //! HTTP requests into these commands and never pass credentials or
 //! request-supplied caller identities into domain services.
 
+pub mod auth;
 pub mod authorization;
 pub mod bot;
 pub mod collaboration_definition;
@@ -23,6 +24,7 @@ pub mod register;
 pub mod session;
 pub mod session_file;
 
+pub use auth::*;
 pub use authorization::{
     Action, AuthorizationService, IdentityPolicy, ResourceRef, require_authenticated_user,
     require_human, select_principal,

--- a/src/bcs/docs/superpowers/specs/2026-08-28-openapi-auth-facade.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-28-openapi-auth-facade.md
@@ -1,0 +1,84 @@
+# OpenAPI V1 Auth Facade
+
+## Problem
+
+BCS already has server-side OAuth login plugins (Google, Alipay, GitHub, and compatible providers) exposed through legacy `/auth/*` routes. Other modules need a versioned OpenAPI surface so they can discover login URLs, complete callbacks, read the current human identity, refresh sessions, and logout without depending on legacy route response shapes or concrete OAuth provider plugins.
+
+## Decision
+
+Expose a transport-independent `AuthService` contract in `bcs_service_api::application::v1` and mount a public OpenAPI HTTP facade at `/openapi/v1/auth/*`.
+
+The HTTP adapter depends only on the `AuthService` trait. Concrete provider construction remains in the bootstrap composition root. The current implementation reuses the existing OAuth route state as the service implementation so token exchange, CSRF state, identity persistence, JWT signing, token hash binding, refresh, and logout semantics stay consistent with the legacy routes.
+
+For OpenAPI protected business routes, the request boundary is: `x-avernet-principal` if the gateway has already signed the caller; otherwise, when the request carries a valid `bcs_session` cookie and OpenAPI auth is configured, the HTTP layer resolves the cookie through `AuthService::current_user`, projects that identity into `AuthenticatedCaller`, and lets the route proceed.
+
+## OpenAPI HTTP contract
+
+All JSON responses use the OpenAPI V1 envelope:
+
+```json
+{
+  "code": 20000,
+  "message": "OK",
+  "data": {},
+  "request_id": "..."
+}
+```
+
+Errors use the standard V1 error envelope and application error mapping.
+
+### `GET /openapi/v1/auth/url`
+
+Returns configured OAuth provider login URLs.
+
+- Success: `200`, `data.providers[]` with `name` and `url`.
+- The generated provider URL uses `/openapi/v1/auth/callback/{provider}` as its `redirect_uri`.
+- If OAuth providers are not configured: `404`, `data.error_code = "auth_not_configured"`.
+
+### `GET /openapi/v1/auth/callback/{provider}`
+
+Completes OAuth login using `code` or `auth_code` plus `state`.
+
+- Success: `302`, `Location: /?login=success`, `Set-Cookie: bcs_session=...`.
+- Invalid or expired CSRF state: `400`, `data.error_code = "invalid_state"`.
+- Provider in path does not match provider bound to state: `400`, `data.error_code = "provider_mismatch"`.
+- Missing authorization code: `400`, `data.error_code = "missing_code"`.
+- Unknown provider: `404`, `data.error_code = "provider_not_found"`.
+
+### `GET /openapi/v1/auth/user`
+
+Returns the current authenticated human user resolved by the configured auth chain.
+
+- Success: `200`, `data = { user_id, name, provider, avatar }`.
+- Anonymous or non-human principal: `401`, `data.error_code = "unauthenticated"`.
+
+### `POST /openapi/v1/auth/refresh`
+
+Renews a bound `bcs_session` cookie.
+
+- Success: `200`, success envelope, and a fresh `Set-Cookie` header.
+- Missing, malformed, expired beyond server-side binding, or unbound cookie: `401`, `data.error_code = "unauthenticated"`.
+
+
+### Protected OpenAPI business routes
+
+Protected `/openapi/v1/collaboration/*` routes are gateway-compatible first: they accept the signed internal principal header when present. If that header is absent, the adapter may fall back to the configured OpenAPI auth service and resolve the caller from `bcs_session`. This keeps browser-driven OpenAPI calls usable while still allowing backend callers to use the gateway trust boundary.
+
+### `POST /openapi/v1/auth/logout`
+
+Clears the session cookie and best-effort revokes the bound server-side token hash.
+
+- Always returns `200` when auth service is configured.
+- Response includes `Set-Cookie` clearing `bcs_session` with `Max-Age=0`.
+
+## Tests
+
+The contract is covered by bootstrap integration tests in `crates/bootstrap/bcs/tests/integration_oauth_routes.rs`:
+
+- OpenAPI URL discovery returns a V1 envelope and OpenAPI callback redirect URI.
+- OpenAPI URL discovery fails closed when OAuth is absent.
+- `/user` returns V1 unauthenticated errors without a session and returns user info for a bound OAuth cookie.
+- `/refresh` returns V1 unauthenticated errors without a session and issues a new cookie for a bound OAuth cookie.
+- `/logout` returns a success envelope and clears the cookie.
+- `/callback/{provider}` returns V1 errors for invalid state and provider/state mismatch.
+- Protected business routes use `x-avernet-principal` when present and fall back to the configured OpenAPI auth service + `bcs_session` when the gateway header is absent.

--- a/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
+++ b/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
@@ -8,6 +8,7 @@ from gateway.community.plugins.authn.access_key_token import AccessKeyTokenStrat
 from gateway.community.plugins.authn.app_token import AppTokenStrategy
 from gateway.community.plugins.authn.bot_token import BotTokenStrategy
 from gateway.community.plugins.authn.dev_cookie import DevCookieUserStrategy
+from gateway.community.plugins.authn.oauth_session import OauthSessionStrategy
 from gateway.community.plugins.authn.google_token import GoogleUserStrategy
 from gateway.community.plugins.cache.in_memory import InMemoryCachePlugin
 from gateway.community.plugins.cache.redis import RedisCachePlugin
@@ -94,6 +95,13 @@ class PluginContainer(containers.DeclarativeContainer):
         ),
     )
     dev_cookie_strategy = providers.Singleton(DevCookieUserStrategy)
+    oauth_session_strategy = providers.Singleton(
+        OauthSessionStrategy,
+        secret_resolver=secret_resolver,
+        secret_name=providers.Callable(
+            _default, config.authn.oauth_session_secret_name, "bcs_session_jwt_secret"
+        ),
+    )
 
     bot_token_strategy = providers.Singleton(
         BotTokenStrategy,
@@ -129,6 +137,7 @@ class PluginContainer(containers.DeclarativeContainer):
     authn_strategies = providers.Dict(
         google=google_strategy,
         dev_cookie=dev_cookie_strategy,
+        oauth_session=oauth_session_strategy,
         bot_token=bot_token_strategy,
         app_token=app_token_strategy,
         access_key_token=access_key_token_strategy,

--- a/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
+++ b/src/gateway/src/gateway/community/bootstrap/plugins/_plugin_core.py
@@ -8,8 +8,8 @@ from gateway.community.plugins.authn.access_key_token import AccessKeyTokenStrat
 from gateway.community.plugins.authn.app_token import AppTokenStrategy
 from gateway.community.plugins.authn.bot_token import BotTokenStrategy
 from gateway.community.plugins.authn.dev_cookie import DevCookieUserStrategy
-from gateway.community.plugins.authn.oauth_session import OauthSessionStrategy
 from gateway.community.plugins.authn.google_token import GoogleUserStrategy
+from gateway.community.plugins.authn.oauth_session import OauthSessionStrategy
 from gateway.community.plugins.cache.in_memory import InMemoryCachePlugin
 from gateway.community.plugins.cache.redis import RedisCachePlugin
 from gateway.community.plugins.database.mariadb import MariaDbOrmPlugin

--- a/src/gateway/src/gateway/community/config/_models.py
+++ b/src/gateway/src/gateway/community/config/_models.py
@@ -34,7 +34,9 @@ class AuthnPluginConfig(BaseSettings):
     model_config = SettingsConfigDict(extra="allow")
     app_token: str = Field(default="stub")
     tenant: str = Field(default="stub")
-    oauth_session_secret_name: str = Field(default="bcs_session_jwt_secret", min_length=1)
+    oauth_session_secret_name: str = Field(
+        default="bcs_session_jwt_secret", min_length=1
+    )
 
 
 class SecretConfig(BaseModel):

--- a/src/gateway/src/gateway/community/config/_models.py
+++ b/src/gateway/src/gateway/community/config/_models.py
@@ -34,6 +34,7 @@ class AuthnPluginConfig(BaseSettings):
     model_config = SettingsConfigDict(extra="allow")
     app_token: str = Field(default="stub")
     tenant: str = Field(default="stub")
+    oauth_session_secret_name: str = Field(default="bcs_session_jwt_secret", min_length=1)
 
 
 class SecretConfig(BaseModel):

--- a/src/gateway/src/gateway/community/plugins/authn/oauth_session/__init__.py
+++ b/src/gateway/src/gateway/community/plugins/authn/oauth_session/__init__.py
@@ -1,0 +1,5 @@
+"""``oauth_session`` strategy — verify a BCS session cookie into ``UserPrincipal``."""
+
+from ._strategy import OauthSessionStrategy
+
+__all__ = ["OauthSessionStrategy"]

--- a/src/gateway/src/gateway/community/plugins/authn/oauth_session/_strategy.py
+++ b/src/gateway/src/gateway/community/plugins/authn/oauth_session/_strategy.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import jwt
 
 from gateway.community.logger import get_logger
-from gateway.community.spi.auth import AuthError, AuthenticatedUser
+from gateway.community.spi.auth import AuthenticatedUser, AuthError
 from gateway.community.spi.authn import (
     CredentialBundle,
     Principal,

--- a/src/gateway/src/gateway/community/plugins/authn/oauth_session/_strategy.py
+++ b/src/gateway/src/gateway/community/plugins/authn/oauth_session/_strategy.py
@@ -1,0 +1,91 @@
+"""``oauth_session`` strategy — verify the ``bcs_session`` JWT cookie in place.
+
+The gateway's browser/session path uses the same signed JWT that BCS issues at
+login time. This strategy reads the ``bcs_session`` cookie, verifies its HS256
+signature locally, and maps the ``sub`` claim onto a ``UserPrincipal``.
+
+Absent cookie → ``None`` (not applicable).
+Present but invalid cookie → ``AuthError`` (hard failure, no fallback).
+"""
+
+from __future__ import annotations
+
+import jwt
+
+from gateway.community.logger import get_logger
+from gateway.community.spi.auth import AuthError, AuthenticatedUser
+from gateway.community.spi.authn import (
+    CredentialBundle,
+    Principal,
+    PrincipalType,
+    UserPrincipal,
+)
+from gateway.community.spi.secret_resolver import SecretResolver
+
+logger = get_logger("authn-oauth-session")
+
+_BCS_SESSION_COOKIE = "bcs_session"
+_BCS_SESSION_ALGORITHM = "HS256"
+
+
+class OauthSessionStrategy:
+    """Resolve a verified BCS session JWT into a ``UserPrincipal``."""
+
+    name = "oauth_session"
+    principal_type = PrincipalType.USER
+
+    def __init__(
+        self,
+        *,
+        jwt_secret: str | None = None,
+        secret_resolver: SecretResolver | None = None,
+        secret_name: str = "bcs_session_jwt_secret",
+    ) -> None:
+        self._jwt_secret = jwt_secret
+        self._secret_resolver = secret_resolver
+        self._secret_name = secret_name
+
+    def _resolve_secret(self) -> str:
+        if self._jwt_secret is not None:
+            return self._jwt_secret
+        if self._secret_resolver is None:
+            raise AuthError("bcs session secret is unavailable")
+        secret = self._secret_resolver.get_secret(self._secret_name)
+        if secret is None:
+            raise AuthError("bcs session secret is unavailable")
+        value = getattr(secret, "secret_value", secret)
+        if not isinstance(value, str) or not value.strip():
+            raise AuthError("bcs session secret is unavailable")
+        return value
+
+    async def build(self, creds: CredentialBundle) -> Principal | None:
+        token = creds.cookies.get(_BCS_SESSION_COOKIE, "").strip()
+        if not token:
+            return None
+
+        try:
+            claims = jwt.decode(
+                token,
+                self._resolve_secret(),
+                algorithms=[_BCS_SESSION_ALGORITHM],
+                options={"require": ["sub", "src", "iat", "exp"]},
+            )
+        except jwt.PyJWTError as exc:
+            logger.warning("bcs_session cookie verification failed")
+            raise AuthError("invalid bcs session cookie") from exc
+
+        try:
+            subject_id = str(claims["sub"])
+        except KeyError as exc:
+            logger.warning("bcs_session cookie missing sub claim")
+            raise AuthError("invalid bcs session cookie") from exc
+
+        logger.debug(
+            "bcs_session resolved: sub=%s src=%s", subject_id, claims.get("src")
+        )
+        return UserPrincipal(
+            subject=AuthenticatedUser(
+                id=subject_id,
+                username=subject_id,
+            )
+        )

--- a/src/gateway/tests/contracts/spi/test_auth_strategy.py
+++ b/src/gateway/tests/contracts/spi/test_auth_strategy.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 
 import httpx
+import jwt
 
 from gateway.community.plugins.authn.access_key_token import AccessKeyTokenStrategy
 from gateway.community.plugins.authn.app_token import AppTokenStrategy
 from gateway.community.plugins.authn.bot_token import BotTokenStrategy
 from gateway.community.plugins.authn.google_token import GoogleUserStrategy
+from gateway.community.plugins.authn.oauth_session import OauthSessionStrategy
 from gateway.community.spi.access_key import RegisteredAccessKey
 from gateway.community.spi.app import RegisteredApp
 from gateway.community.spi.authn import CredentialBundle, PrincipalType
@@ -96,6 +98,32 @@ class TestGoogleUserStrategy(AuthStrategyContract):
         )
         self.applicable_creds = CredentialBundle(
             headers={"x-avernet-google-token": "tok"}, cookies={}, query={}
+        )
+        self.inapplicable_creds = CredentialBundle(headers={}, cookies={}, query={})
+
+    async def test_builds_user_principal(self) -> None:
+        from gateway.community.spi.authn import UserPrincipal
+
+        result = await self.strategy.build(self.applicable_creds)  # type: ignore[attr-defined]
+        assert isinstance(result, UserPrincipal)
+
+
+class TestOauthSessionStrategy(AuthStrategyContract):
+    def setup_method(self) -> None:
+        self.strategy = OauthSessionStrategy(jwt_secret="test-bcs-session-secret-32-bytes!!")
+        now = datetime.now(tz=UTC)
+        token = jwt.encode(
+            {
+                "sub": "user-123",
+                "src": "google",
+                "iat": int(now.timestamp()),
+                "exp": int((now + timedelta(minutes=5)).timestamp()),
+            },
+            "test-bcs-session-secret-32-bytes!!",
+            algorithm="HS256",
+        )
+        self.applicable_creds = CredentialBundle(
+            headers={}, cookies={"bcs_session": token}, query={}
         )
         self.inapplicable_creds = CredentialBundle(headers={}, cookies={}, query={})
 

--- a/src/gateway/tests/contracts/spi/test_auth_strategy.py
+++ b/src/gateway/tests/contracts/spi/test_auth_strategy.py
@@ -110,7 +110,9 @@ class TestGoogleUserStrategy(AuthStrategyContract):
 
 class TestOauthSessionStrategy(AuthStrategyContract):
     def setup_method(self) -> None:
-        self.strategy = OauthSessionStrategy(jwt_secret="test-bcs-session-secret-32-bytes!!")
+        self.strategy = OauthSessionStrategy(
+            jwt_secret="test-bcs-session-secret-32-bytes!!"
+        )
         now = datetime.now(tz=UTC)
         token = jwt.encode(
             {

--- a/src/gateway/tests/integration/test_forward_route.py
+++ b/src/gateway/tests/integration/test_forward_route.py
@@ -17,6 +17,7 @@ from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 from gateway.community.adapters.web._cors import install_cors
+from gateway.community.adapters.web.app import create_app
 from gateway.community.adapters.web._forward import (
     _ALL_METHODS,
     _request_body,
@@ -176,6 +177,32 @@ class _RequestWithStream:
 
     def stream(self) -> _FailingRequestStream:
         return self._stream
+
+
+class _CapturingForwarder:
+    class _Upstream:
+        def __init__(self) -> None:
+            self.status_code = 200
+            self.headers = []
+            self.body = self
+            self._sent = False
+
+        def __aiter__(self) -> _CapturingForwarder._Upstream:
+            return self
+
+        async def __anext__(self) -> bytes:
+            if self._sent:
+                raise StopAsyncIteration
+            self._sent = True
+            return b"{}"
+
+    def __init__(self) -> None:
+        self.captured: ForwardRequest | None = None
+
+    @asynccontextmanager
+    async def forward(self, request: ForwardRequest) -> AsyncIterator[object]:
+        self.captured = request
+        yield self._Upstream()
 
 
 class _EntryFailureForwarder:
@@ -578,3 +605,80 @@ def test_real_authenticator_rejects_missing_required_identity() -> None:
         resp = c.get("/openapi/v1/bots")
     assert resp.status_code == 401
     assert resp.json()["code"] == 401001
+
+
+_TEST_BCS_SECRET = "integration-bcs-session-secret-32b!!"
+
+
+def _real_auth_app() -> FastAPI:
+    from gateway.community.bootstrap._authn import build_authenticator
+    from gateway.community.plugins.authn.access_key_token import AccessKeyTokenStrategy
+    from gateway.community.plugins.authn.app_token import AppTokenStrategy
+    from gateway.community.plugins.authn.bot_token import BotTokenStrategy
+    from gateway.community.plugins.authn.google_token import GoogleUserStrategy
+    from gateway.community.plugins.authn.oauth_session import OauthSessionStrategy
+
+    app = create_app()
+    app.state.domain_map = DomainMap.from_config(
+        {
+            "domains": {"bots": {"server": "up"}},
+            "servers": {"up": {"base_url": "http://upstream"}},
+        },
+        variables={},
+    )
+    app.state.forwarder = _CapturingForwarder()
+    app.state.principal_signer = _build_signer()
+    app.state.authenticator = build_authenticator(
+        strategies={
+            "google": GoogleUserStrategy(token_header="x-google-token"),
+            "oauth_session": OauthSessionStrategy(jwt_secret=_TEST_BCS_SECRET),
+            "bot_token": BotTokenStrategy(registry=None),
+            "app_token": AppTokenStrategy(registry=None),
+            "access_key_token": AccessKeyTokenStrategy(registry=None),
+        },
+        user_config=UserConfig(
+            identity_strategies={"user": ["oauth_session"]},
+            route_security={"/**": {"user": "required"}},
+        ),
+    )
+    return app
+
+
+async def test_forward_uses_bcs_session_cookie_to_resolve_user_principal() -> None:
+    import time
+
+    import jwt
+
+    now = int(time.time())
+    token = jwt.encode(
+        {
+            "sub": "bcs-user-1",
+            "src": "google",
+            "iat": now,
+            "exp": now + 300,
+        },
+        _TEST_BCS_SECRET,
+        algorithm="HS256",
+    )
+
+    app = _real_auth_app()
+    transport = httpx.ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get(
+            "/openapi/v1/bots/x",
+            headers={"cookie": f"bcs_session={token}"},
+        )
+
+    assert resp.status_code == 200
+    forwarder = app.state.forwarder
+    assert forwarder.captured is not None
+    signed = forwarder.captured.headers[_PRINCIPAL_HEADER]
+    decoded = jwt.decode(
+        signed,
+        _TEST_KEY,
+        algorithms=["HS256"],
+        audience="up",
+        issuer="gateway",
+    )
+    assert decoded["principals"][0]["type"] == "user"
+    assert decoded["principals"][0]["subject"]["id"] == "bcs-user-1"

--- a/src/gateway/tests/integration/test_forward_route.py
+++ b/src/gateway/tests/integration/test_forward_route.py
@@ -15,14 +15,16 @@ import httpx
 import pytest
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
+from httpx import AsyncClient
 
 from gateway.community.adapters.web._cors import install_cors
-from gateway.community.adapters.web.app import create_app
 from gateway.community.adapters.web._forward import (
     _ALL_METHODS,
+    _PRINCIPAL_HEADER,
     _request_body,
     forward_request,
 )
+from gateway.community.adapters.web.app import create_app
 from gateway.community.bootstrap._principal_signer import build_principal_signer
 from gateway.community.config import ConfigLoader, CorsConfig, UserConfig
 from gateway.community.core.forwarding import DomainMap

--- a/src/gateway/tests/unit/plugins/test_oauth_session_strategy.py
+++ b/src/gateway/tests/unit/plugins/test_oauth_session_strategy.py
@@ -47,6 +47,50 @@ async def test_valid_cookie_builds_user_principal() -> None:
     assert result.subject.display_name is None
 
 
+class _MissingSecretResolver:
+    def get_secret(self, name: str):
+        return None
+
+
+class _EmptySecretResolver:
+    class _Secret:
+        secret_value = "   "
+
+    def get_secret(self, name: str):
+        return self._Secret()
+
+
+@pytest.mark.asyncio
+async def test_missing_secret_resolver_raises_auth_error() -> None:
+    strategy = OauthSessionStrategy(secret_resolver=_MissingSecretResolver())
+
+    with pytest.raises(AuthError):
+        await strategy.build(_creds(_token()))
+
+
+@pytest.mark.asyncio
+async def test_empty_secret_value_raises_auth_error() -> None:
+    strategy = OauthSessionStrategy(secret_resolver=_EmptySecretResolver())
+
+    with pytest.raises(AuthError):
+        await strategy.build(_creds(_token()))
+
+
+@pytest.mark.asyncio
+async def test_missing_sub_claim_raises_auth_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    strategy = OauthSessionStrategy(jwt_secret=_TEST_SECRET)
+    token = _token()
+
+    monkeypatch.setattr(
+        jwt, "decode", lambda *args, **kwargs: {"src": "google", "iat": 1, "exp": 2}
+    )
+
+    with pytest.raises(AuthError):
+        await strategy.build(_creds(token))
+
+
 @pytest.mark.asyncio
 async def test_invalid_cookie_raises_auth_error() -> None:
     strategy = OauthSessionStrategy(jwt_secret=_TEST_SECRET)

--- a/src/gateway/tests/unit/plugins/test_oauth_session_strategy.py
+++ b/src/gateway/tests/unit/plugins/test_oauth_session_strategy.py
@@ -1,0 +1,60 @@
+"""Unit tests for the ``oauth_session`` user strategy (bcs_session JWT → UserPrincipal)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+
+from gateway.community.plugins.authn.oauth_session import OauthSessionStrategy
+from gateway.community.spi.auth import AuthError
+from gateway.community.spi.authn import CredentialBundle, UserPrincipal
+
+_TEST_SECRET = "test-bcs-session-secret-32-bytes!!"
+
+
+def _creds(token: str | None) -> CredentialBundle:
+    cookies = {"bcs_session": token} if token else {}
+    return CredentialBundle(headers={}, cookies=cookies, query={})
+
+
+def _token(*, sub: str = "user-123", src: str = "google") -> str:
+    now = datetime.now(tz=UTC)
+    claims = {
+        "sub": sub,
+        "src": src,
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(minutes=5)).timestamp()),
+    }
+    return jwt.encode(claims, _TEST_SECRET, algorithm="HS256")
+
+
+@pytest.mark.asyncio
+async def test_absent_cookie_returns_none() -> None:
+    strategy = OauthSessionStrategy(jwt_secret=_TEST_SECRET)
+    assert await strategy.build(_creds(None)) is None
+
+
+@pytest.mark.asyncio
+async def test_valid_cookie_builds_user_principal() -> None:
+    strategy = OauthSessionStrategy(jwt_secret=_TEST_SECRET)
+    result = await strategy.build(_creds(_token()))
+
+    assert isinstance(result, UserPrincipal)
+    assert result.subject.id == "user-123"
+    assert result.subject.username == "user-123"
+    assert result.subject.display_name is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_cookie_raises_auth_error() -> None:
+    strategy = OauthSessionStrategy(jwt_secret=_TEST_SECRET)
+    bad_token = jwt.encode(
+        {"sub": "user-123", "src": "google", "iat": 1, "exp": 9999999999},
+        "wrong-secret",
+        algorithm="HS256",
+    )
+
+    with pytest.raises(AuthError):
+        await strategy.build(_creds(bad_token))

--- a/src/gateway/tests/unit/plugins/test_strategy_chains.py
+++ b/src/gateway/tests/unit/plugins/test_strategy_chains.py
@@ -19,7 +19,6 @@ from gateway.community.plugins.authn.google_token import GoogleUserStrategy
 from gateway.community.plugins.authn.oauth_session import OauthSessionStrategy
 from gateway.community.spi.authn import PrincipalType
 
-
 _TEST_BCS_SECRET = "test-bcs-session-secret-32-bytes!!"
 
 

--- a/src/gateway/tests/unit/plugins/test_strategy_chains.py
+++ b/src/gateway/tests/unit/plugins/test_strategy_chains.py
@@ -16,12 +16,17 @@ from gateway.community.plugins.authn.access_key_token import AccessKeyTokenStrat
 from gateway.community.plugins.authn.app_token import AppTokenStrategy
 from gateway.community.plugins.authn.bot_token import BotTokenStrategy
 from gateway.community.plugins.authn.google_token import GoogleUserStrategy
+from gateway.community.plugins.authn.oauth_session import OauthSessionStrategy
 from gateway.community.spi.authn import PrincipalType
+
+
+_TEST_BCS_SECRET = "test-bcs-session-secret-32-bytes!!"
 
 
 def _pool():
     return {
         "google": GoogleUserStrategy(token_header="x-google-token"),
+        "oauth_session": OauthSessionStrategy(jwt_secret=_TEST_BCS_SECRET),
         "bot_token": BotTokenStrategy(registry=None),
         "app_token": AppTokenStrategy(registry=None),
         "access_key_token": AccessKeyTokenStrategy(registry=None),
@@ -177,3 +182,12 @@ def test_dev_mock_cannot_be_declared_in_config(tmp_path, monkeypatch):
     monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(tmp_path))
     with pytest.raises(KeyError, match="unknown strategy 'dev_header'"):
         _strategy_chains(_pool(), user_config=_user_config())
+
+
+def test_oauth_session_strategy_can_be_declared_in_user_chain(tmp_path, monkeypatch):
+    (tmp_path / "application.yaml").write_text(
+        "user_config:\n  identity_strategies:\n    user: [oauth_session]\n"
+    )
+    monkeypatch.setenv("GATEWAY_CONFIG_PATH", str(tmp_path))
+    chains = _strategy_chains(_pool(), user_config=_user_config())
+    assert _user_chain_names(chains) == ["oauth_session"]


### PR DESCRIPTION
### Problem

  BCS 已经实现了开源的支付宝/Google 等登录插件，但登录态能力没有以统一 OpenAPI 的方式暴露出来，导致其他模块以及 Gateway 侧无法直接复用这套身份链路。

  ### Solution

  本次改造打通了 BCS 登录态能力向 OpenAPI 的输出，并在 Gateway 侧新增 oauth_session auth strategy，支持：

  - 从 bcs_session cookie 中提取登录态
  - 本地校验 JWT 签名
  - 将登录身份映射为 Gateway principal
  - 让浏览器通过 Gateway 调用 OpenAPI 时，后续后端接口也能识别到身份信息

  同时补充了：

  - BCS 侧 OpenAPI 登录态门面接口
  - Gateway 侧策略接入与配置项
  - 对应单测、契约测试、集成测试

  ### Validation

  - 新增/更新测试覆盖登录态提取、策略链路和转发链路
  - 已补充 OpenAPI 登录态相关实现与路由接入

  ### Impact

  - 浏览器 -> Gateway -> BCS/OpenAPI 的认证链路打通
  - 后续业务接口可以统一依赖 Gateway principal 获取身份
  - 不需要业务模块直接理解 bcs_session 的内部实现