### PR TITLE
fix(bcs): V1 create-group anchors participant reachability on the ori…

### DIFF
--- a/src/bcs/api-contracts/v1/openapi/groups.yaml
+++ b/src/bcs/api-contracts/v1/openapi/groups.yaml
@@ -611,10 +611,12 @@ CreateCollaborationGroup:
         Optional caller-designated originator. When omitted, the selected
         HumanOrOwnedBot Principal becomes the originator. A Human Principal
         may instead select a registered Bot it owns (`created_by` matches the
-        caller). A Bot Principal may select only itself. When a Human selects
-        an owned Bot distinct from the driver, the driver must be reachable
-        from that originator (public visibility, or a friend of it). The `dm`
-        group kind does not carry an originator.
+        caller). A Bot Principal may select only itself. Every Bot participant
+        — including the driver when it differs from the originator — is
+        anchored on the originator: a public bot is always reachable; a
+        protected bot is reachable only if the originator is a Human that owns
+        it (`created_by` matches the caller) or a Bot that is friends with it.
+        The `dm` group kind does not carry an originator.
     event_subscriptions:
       type: array
       maxItems: 32

--- a/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
@@ -583,37 +583,6 @@ impl GroupServiceImpl {
         Ok(())
     }
 
-    /// When the originator is a caller-owned Bot distinct from the caller,
-    /// the driver must be reachable from that originator bot (public or a
-    /// friend of it). Skipped when the originator is the human caller itself
-    /// — the driver is ungated against the caller by design.
-    async fn ensure_originator_can_reach_driver(
-        &self,
-        originator_bot_id: &str,
-        driver_bot_id: &str,
-    ) -> Result<(), ApplicationError> {
-        let driver = self.load_bot(driver_bot_id).await?;
-        if driver.status == ActorStatus::Hidden {
-            return Err(ApplicationError::forbidden(format!(
-                "Bot '{driver_bot_id}' is hidden and cannot be invited into a group"
-            )));
-        }
-        if driver.capabilities.visibility == "public" {
-            return Ok(());
-        }
-        if self
-            .friends
-            .try_are_friends(originator_bot_id, driver_bot_id)
-            .await
-            .map_err(map_service_error)?
-        {
-            return Ok(());
-        }
-        Err(ApplicationError::forbidden(format!(
-            "Driver '{driver_bot_id}' is not reachable from originator '{originator_bot_id}'"
-        )))
-    }
-
     async fn can_read_group(
         &self,
         principal: &Principal,
@@ -1054,22 +1023,13 @@ impl GroupServiceImpl {
         self.authorize_originator(&principal, &originator)
             .await?;
         // Structural validity only: the driver must be a registered Bot Actor.
-        // This is NOT a caller↔driver relationship check (that was deliberately
-        // dropped); callers may drive bots they do not own, as long as the bot
-        // exists and is a Bot.
+        // The driver↔originator reachability gate runs in the core loop
+        // (GroupManagement::create_group), where every Bot participant —
+        // including the driver when it differs from the originator — is
+        // anchored on the originator (public, owned-by-human, or a friend of a
+        // bot originator).
         self.ensure_driver_is_registered_bot(&request.driver_bot_uuid)
             .await?;
-        // The driver is ungated against the caller (caller↔driver is not
-        // checked). Only when the originator is a caller-owned Bot distinct
-        // from both the caller and the driver must the driver be reachable
-        // from that originator (an originator that is itself the driver is
-        // self-reachable; a protected bot cannot friend itself).
-        if originator != principal.actor_id()
-            && originator != request.driver_bot_uuid
-        {
-            self.ensure_originator_can_reach_driver(&originator, &request.driver_bot_uuid)
-                .await?;
-        }
         if request
             .participants
             .iter()

--- a/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
@@ -2063,15 +2063,13 @@ async fn provisioning_reconciler_cancels_only_stale_orphaned_pending_sets() {
 }
 
 #[tokio::test]
-async fn human_participant_can_create_with_driver_reachable_protected_participants() {
+async fn human_originator_can_create_with_owned_protected_participant() {
+    // Originator-anchored: a Human originator reaches a protected participant
+    // via ownership (`created_by` matches the caller). The driver is public, so
+    // the participant ownership gate is the binding check.
     let fixture = Fixture::new().await;
     fixture.add_public_bot("driver").await;
-    fixture.add_protected_bot("helper").await;
-    fixture
-        .friends
-        .add_friendship("driver", "helper")
-        .await
-        .expect("driver/helper friendship");
+    fixture.add_bot_owned_by("helper", "staff-1", "protected").await;
 
     let detail = fixture
         .service
@@ -2104,7 +2102,7 @@ async fn human_participant_can_create_with_driver_reachable_protected_participan
             }),
         })
         .await
-        .expect("V1 uses driver collaboration reachability");
+        .expect("human originator reaches owned protected participant");
 
     let GroupDetail::Collaboration(detail) = detail else {
         panic!("expected collaboration detail");
@@ -2116,6 +2114,43 @@ async fn human_participant_can_create_with_driver_reachable_protected_participan
         .await
         .expect("V1 normal Group creation must materialize the Human participant");
     assert_eq!(human.capabilities.name.as_deref(), Some("Alice"));
+}
+
+#[tokio::test]
+async fn human_originator_rejects_non_owned_protected_participant() {
+    // A protected participant the human originator does not own is not
+    // reachable (human↔bot friendship is not consulted), so creation is
+    // rejected. The driver is public, isolating the participant gate.
+    let fixture = Fixture::new().await;
+    fixture.add_public_bot("driver").await;
+    fixture.add_bot_owned_by("helper", "someone-else", "protected").await;
+
+    let err = fixture
+        .service
+        .create(CreateGroup {
+            caller: human_principal_with_profile("staff-1", "alice-login", Some("Alice"), None),
+            group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
+                originator: None,
+                name: None,
+                context: None,
+                opening_message: None,
+                visibility: GroupVisibility::Private,
+                driver_bot_uuid: "driver".into(),
+                participants: vec![CreateParticipant {
+                    actor_id: "helper".into(),
+                    role: ParticipantRole::Consultant,
+                    tags: Vec::new(),
+                }],
+                collaboration: CollaborationConfiguration::Chat(ChatConfiguration {
+                    delivery_policy: GroupDeliveryPolicy {
+                        bot_final_delivery: BotFinalDelivery::SendToDriver,
+                    },
+                }),
+            }),
+        })
+        .await
+        .expect_err("protected participant not owned by human originator");
+    assert!(matches!(err, ApplicationError::Forbidden { .. }), "got {err:?}");
 }
 
 #[tokio::test]
@@ -3448,20 +3483,19 @@ async fn state_machine_patch_failure_does_not_commit_requested_changes() {
 }
 
 #[tokio::test]
-async fn create_does_not_friendship_check_driver_against_caller() {
-    // caller↔driver was dropped: a protected driver the caller neither owns nor
-    // is friends with is no longer friendship-checked (there are no protected
-    // participants that would consult the friend store either), so even a
-    // failing friend store must not block creation of the group.
-    let friends = Arc::new(FriendCore::with_repo(Arc::new(FailingFriendRepo)));
-    let fixture = Fixture::new_with_friends(friends).await;
+async fn create_gates_driver_against_bot_originator_by_friendship() {
+    // Originator-anchored: a Bot originator may drive only a public bot or a
+    // bot it is friends with. Here the protected driver is neither, so the
+    // driver↔originator gate rejects creation (the driver is no longer exempt
+    // from the originator reachability check).
+    let fixture = Fixture::new().await;
     fixture.add_public_bot("requester").await;
     fixture.add_protected_bot("driver").await;
 
-    let result = fixture
+    let err = fixture
         .service
         .create(CreateGroup {
-            caller: bot_principal("requester"),
+            caller: authenticated_bot_principal("requester", "requester"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 originator: None,
                 name: None,
@@ -3477,12 +3511,46 @@ async fn create_does_not_friendship_check_driver_against_caller() {
                 }),
             }),
         })
-        .await;
+        .await
+        .expect_err("protected driver not reachable from bot originator");
+    assert!(matches!(err, ApplicationError::Forbidden { .. }), "got {err:?}");
+}
 
-    assert!(
-        result.is_ok(),
-        "driver must be ungated vs caller; got {result:?}"
-    );
+#[tokio::test]
+async fn bot_originator_rejects_non_friend_protected_participant() {
+    // A Bot originator reaches a protected participant only via friendship.
+    // The public driver is reachable, isolating the participant gate.
+    let fixture = Fixture::new().await;
+    fixture.add_public_bot("requester").await;
+    fixture.add_public_bot("driver").await;
+    fixture.add_protected_bot("helper").await;
+
+    let err = fixture
+        .service
+        .create(CreateGroup {
+            caller: authenticated_bot_principal("requester", "requester"),
+            group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
+                originator: None,
+                name: None,
+                context: None,
+                opening_message: None,
+                visibility: GroupVisibility::Private,
+                driver_bot_uuid: "driver".into(),
+                participants: vec![CreateParticipant {
+                    actor_id: "helper".into(),
+                    role: ParticipantRole::Consultant,
+                    tags: Vec::new(),
+                }],
+                collaboration: CollaborationConfiguration::Chat(ChatConfiguration {
+                    delivery_policy: GroupDeliveryPolicy {
+                        bot_final_delivery: BotFinalDelivery::SendToDriver,
+                    },
+                }),
+            }),
+        })
+        .await
+        .expect_err("protected participant not reachable from bot originator");
+    assert!(matches!(err, ApplicationError::Forbidden { .. }), "got {err:?}");
 }
 
 #[tokio::test]
@@ -3495,7 +3563,7 @@ async fn create_propagates_protected_participant_friendship_lookup_failure() {
     let result = fixture
         .service
         .create(CreateGroup {
-            caller: bot_principal("driver"),
+            caller: authenticated_bot_principal("driver", "driver"),
             group: CreateGroupSpec::Collaboration(CreateCollaborationGroup {
                 originator: None,
                 name: None,
@@ -3976,12 +4044,7 @@ async fn dm_create_outcome_reports_when_the_existing_pair_is_reused() {
 async fn client_caused_group_errors_map_to_documented_4xx_classes() {
     let fixture = Fixture::new().await;
     fixture.add_public_bot("driver").await;
-    fixture.add_protected_bot("protected").await;
-    fixture
-        .friends
-        .add_friendship("driver", "protected")
-        .await
-        .expect("driver/protected friendship");
+    fixture.add_bot_owned_by("protected", "driver", "protected").await;
 
     let public_with_protected = fixture
         .service
@@ -4265,18 +4328,19 @@ mod originator_v1_policy {
     }
 
     #[tokio::test]
-    async fn driver_not_gated_against_caller_when_originator_is_human() {
-        // caller staff-1 does NOT own the driver and is not its friend; with
-        // caller↔driver dropped and originator=caller (default), the group
-        // must still be created (driver ungated vs caller).
+    async fn driver_gated_against_human_originator_unless_owned_or_public() {
+        // Originator-anchored: a Human originator may drive only a public bot
+        // or a bot it owns. Here the protected driver is owned by someone else,
+        // so the driver↔originator gate rejects creation (the driver is no
+        // longer exempt from the originator reachability check).
         let fixture = Fixture::new().await;
         fixture.add_bot_owned_by("driver", "someone-else", "protected").await;
-        let detail = fixture
+        let err = fixture
             .service
             .create(chat_group_with_driver("driver", None, vec![]))
             .await
-            .expect("driver ungated vs caller");
-        assert_eq!(collaboration_originator(detail), "human_staff-1");
+            .expect_err("protected driver not owned by human originator");
+        assert!(matches!(err, ApplicationError::Forbidden { .. }), "got {err:?}");
     }
 
     #[tokio::test]

--- a/src/bcs/crates/services/bcs-group/src/application/management.rs
+++ b/src/bcs/crates/services/bcs-group/src/application/management.rs
@@ -964,11 +964,30 @@ impl GroupManagementService for GroupManagement {
             .ok_or_else(|| ServiceError::BotNotFound(bot_id.clone()))?;
             if bot.actor_kind == ActorKind::Bot {
                 if self.v1_openapi_create_policy {
-                    if bot_id != cmd.driver_bot_id {
-                        self.ensure_v1_reachable(&cmd.driver_bot_id, &bot).await?;
-                    }
-                    if bot_id != cmd.driver_bot_id && bot.capabilities.visibility == "public" {
-                        subscription_targets.push(bot.clone());
+                    // Originator-anchored (aligned with legacy): every Bot
+                    // participant except the originator itself — including the
+                    // driver when it differs from the originator — must be
+                    // reachable from the originator. A Human originator reaches
+                    // a bot via public visibility or ownership (`created_by`);
+                    // a Bot originator reaches it via public visibility or
+                    // friendship.
+                    if bot_id != originator {
+                        if is_human_originator {
+                            let staff_no = originator.trim_start_matches("human_");
+                            if bot.capabilities.visibility != "public"
+                                && bot.created_by.as_deref() != Some(staff_no)
+                            {
+                                return Err(GroupUseCaseError::Forbidden(format!(
+                                    "Bot '{}' is neither public nor owned by human '{}'",
+                                    bot_id, staff_no
+                                )));
+                            }
+                        } else {
+                            self.ensure_v1_reachable(&originator, &bot).await?;
+                        }
+                        if bot.capabilities.visibility == "public" {
+                            subscription_targets.push(bot.clone());
+                        }
                     }
                 } else if bot_id != originator {
                     if is_human_originator {


### PR DESCRIPTION
## Problem

The V1 OpenAPI create-group endpoint (`POST /openapi/v1/collaboration/groups`) anchored participant reachability on the **driver**: every non-driver participant had to be `public` or a friend of the driver, and the driver itself was exempt (ungated vs the caller). This diverged from legacy `POST /groups`, which is originator-centered, and blocked a Human caller from pulling their own protected bots into a group (a protected owned bot that isn't a friend of the driver was rejected).

## Change

Anchor the V1 participant gate on the **originator**, aligning with legacy:

- **Human originator** (the default for a Human caller): a participant is reachable if `public` or owned by that human (`created_by` matches the caller). Friendship is not consulted.
- **Bot originator** (a Bot caller, or a Human designating an owned Bot as originator): a participant is reachable if `public` or a friend of the originator bot.
- The **driver is no longer exempt**: when the driver differs from the originator it is gated like any other participant (when it equals the originator it is self-reachable and exempt).

### Files
- `crates/services/bcs-group/src/application/management.rs` — the `v1_openapi_create_policy` participant branch now mirrors the legacy originator-anchored branch (Human branch: public/ownership; Bot branch: `ensure_v1_reachable(originator, …)`). Reuses the already-computed `originator` / `is_human_originator`.
- `crates/application/v1/bcs-app-group/src/lib.rs` — removed the now-redundant facade-level `ensure_originator_can_reach_driver` (the core loop gates the driver against the originator uniformly).
- `api-contracts/v1/openapi/groups.yaml` — refreshed the `originator` field description.
- Tests — flipped the two `driver-ungated` assertions, rewrote the driver-reachability case to participant ownership, and added Human/Bot originator participant-gate coverage.

## Result

A Human caller can now pull **owned** and **public** bots into a V1 collaboration group; protected bots they do not own are rejected — matching legacy semantics. `authorize_originator` is unchanged and stays stricter than legacy (self or a caller-owned Bot only).

## Verification

`cargo test -p bcs-app-group -p bcs-group` → all green (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)