### PR TITLE
fix(backend): add safe SkillCenter diagnostics

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_reference_processor.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_reference_processor.py
@@ -253,8 +253,10 @@ class SkillCenterReferenceProcessor:
             # the failed Ready Gate without exposing credentials.
             cause = exc.__cause__
             logger.warning(
-                "[SkillCenterReference] materialization failure: reference_id=%s "
-                "skill_code=%s skill_version_id=%s failure_stage=%s cause_type=%s",
+                "[SkillCenterReference] materialization failure: operation=reference_materialization "
+                "env=%s scope=public reference_id=%s skill_code=%s skill_version_id=%s "
+                "failure_stage=%s cause_type=%s",
+                batch.env,
                 item.reference_id,
                 item.skill_code,
                 current.skill_version_id,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_reference_processor.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_reference_processor.py
@@ -235,10 +235,17 @@ class SkillCenterReferenceProcessor:
             self._fail(batch.env, item.reference_id, exc.code)
             return False
         except SkillCenterGatewayError as exc:
-            logger.exception(
-                "[SkillCenterReference] gateway failure: reference_id=%s code=%s",
+            logger.warning(
+                "[SkillCenterReference] gateway failure: operation=reference_resolution "
+                "env=%s scope=public reference_id=%s skill_code=%s skill_version_id=%s "
+                "gateway_error_code=%s upstream_code=%s upstream_trace_id=%s",
+                batch.env,
                 item.reference_id,
+                item.skill_code,
+                current.skill_version_id,
                 exc.code,
+                exc.upstream_code,
+                exc.trace_id,
             )
             if exc.code is SkillCenterGatewayErrorCode.BUSINESS:
                 self._fail(batch.env, item.reference_id, "SC_SKILL_NOT_FOUND")
@@ -266,10 +273,16 @@ class SkillCenterReferenceProcessor:
             return self._retry_or_fail(
                 batch.env, current, "MATERIALIZATION_FAILED"
             )
-        except (TypeError, ValueError, RuntimeError):
-            logger.exception(
-                "[SkillCenterReference] invalid materialization facts: reference_id=%s",
+        except (TypeError, ValueError, RuntimeError) as exc:
+            logger.warning(
+                "[SkillCenterReference] invalid materialization facts: "
+                "operation=reference_materialization env=%s scope=public "
+                "reference_id=%s skill_code=%s skill_version_id=%s failure_type=%s",
+                batch.env,
                 item.reference_id,
+                item.skill_code,
+                current.skill_version_id,
+                type(exc).__name__,
             )
             self._fail(batch.env, item.reference_id, "MATERIALIZATION_FAILED")
             return False

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_materializer.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_materializer.py
@@ -6,9 +6,11 @@ from collections.abc import Mapping
 from datetime import UTC, datetime
 import hashlib
 import json
+import logging
 from pathlib import Path
 import tempfile
 from typing import Callable
+from urllib.parse import urlsplit
 
 from injector import inject
 
@@ -46,6 +48,25 @@ from agentclaw.community.plugin_api.skill_center_gateway import (
     SkillCenterReadScope,
 )
 from agentclaw.community.plugin_api.skill_scanner import SkillScannerPlugin
+
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_url_parts(url: object) -> tuple[str | None, str | None]:
+    """Return only host and path; signatures, query values, and userinfo stay secret."""
+    if not isinstance(url, str):
+        return None, None
+    parsed = urlsplit(url)
+    return parsed.hostname or None, parsed.path or None
+
+
+def _response_metadata(response: object) -> tuple[int | None, str | None]:
+    status = getattr(response, "status_code", None)
+    status_code = status if isinstance(status, int) else None
+    headers = getattr(response, "headers", None)
+    content_type = headers.get("content-type") if hasattr(headers, "get") else None
+    return status_code, content_type if isinstance(content_type, str) else None
 
 
 def _json_value(value: object) -> object:
@@ -182,6 +203,10 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
         self, request: SkillVersionMaterializationRequest
     ) -> PublishedMaterializedSkillVersion:
         stage = "target_read"
+        target: MaterializingSkillVersion | None = None
+        download_host: str | None = None
+        download_path: str | None = None
+        response: object | None = None
         try:
             target = self._versions.get_materialization_target(
                 env=request.env,
@@ -220,6 +245,7 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
                 or not exact.download_url
             ):
                 raise ValueError("Skill Center returned a different exact Version")
+            download_host, download_path = _safe_url_parts(exact.download_url)
             expected_digest = exact.sha256.lower()
             stage = "package_download"
             response = self._http.get(exact.download_url, timeout=30.0)
@@ -289,11 +315,77 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
                 published_at=self._clock(),
             )
         except SkillVersionMaterializationError as exc:
+            self._log_failure(
+                request=request,
+                target=target,
+                stage=exc.stage or stage,
+                failure_type=type(exc.__cause__ or exc).__name__,
+                download_host=download_host,
+                download_path=download_path,
+                response=response,
+            )
             if exc.stage is not None:
                 raise
             raise SkillVersionMaterializationError(str(exc), stage=stage) from exc
         except Exception as exc:
+            self._log_failure(
+                request=request,
+                target=target,
+                stage=stage,
+                failure_type=type(exc).__name__,
+                download_host=download_host,
+                download_path=download_path,
+                response=response,
+            )
             raise SkillVersionMaterializationError(str(exc), stage=stage) from exc
+
+    @staticmethod
+    def _log_failure(
+        *,
+        request: SkillVersionMaterializationRequest,
+        target: MaterializingSkillVersion | None,
+        stage: str,
+        failure_type: str,
+        download_host: str | None,
+        download_path: str | None,
+        response: object | None,
+    ) -> None:
+        """Emit correlation facts without serializing exception text or download URLs."""
+        http_status, http_content_type = _response_metadata(response)
+        diagnostics = {
+            "operation": "skill_version_materialization",
+            "stage": stage,
+            "env": request.env,
+            "scope": request.scope.value,
+            "team_id": request.team_id,
+            "skill_id": request.skill_id,
+            "skill_version_id": request.skill_version_id,
+            "skill_uuid": target.skill_uuid if target is not None else None,
+            "skill_code": target.skill_code if target is not None else None,
+            "sc_version_number": (
+                target.sc_version_number if target is not None else None
+            ),
+            "sc_skill_id": target.sc_skill_id if target is not None else None,
+            "sc_version_id": target.sc_version_id if target is not None else None,
+            "download_host": download_host,
+            "download_path": download_path,
+            "http_status": http_status,
+            "http_content_type": http_content_type,
+            "failure_type": failure_type,
+        }
+        logger.warning(
+            "skill_center_materialization_failed "
+            "operation=%(operation)s stage=%(stage)s env=%(env)s scope=%(scope)s "
+            "team_id=%(team_id)s skill_id=%(skill_id)s "
+            "skill_version_id=%(skill_version_id)s skill_uuid=%(skill_uuid)s "
+            "skill_code=%(skill_code)s sc_version_number=%(sc_version_number)s "
+            "sc_skill_id=%(sc_skill_id)s sc_version_id=%(sc_version_id)s "
+            "download_host=%(download_host)s download_path=%(download_path)s "
+            "http_status=%(http_status)s http_content_type=%(http_content_type)s "
+            "failure_type=%(failure_type)s",
+            diagnostics,
+            extra=diagnostics,
+        )
 
     @staticmethod
     def _published_target(

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_publication_task.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_publication_task.py
@@ -283,28 +283,13 @@ class SpaceSkillPublicationTaskHandler:
                 )
             )
         except SkillCenterGatewayError as exc:
-            diagnostics = {
-                "attempt_id": work.attempt.attempt_id,
-                "space_id": work.space_id,
-                "skill_id": work.attempt.skill_id,
-                "skill_uuid": work.skill_uuid,
-                "team_id": work.sc_team_id,
-                "sc_version_number": work.attempt.sc_version_number,
-                "gateway_error_code": exc.code.value,
-                "upstream_code": exc.upstream_code,
-                "upstream_trace_id": exc.trace_id,
-                "env": env,
-            }
-            logger.warning(
-                "[skill_center.publication.submit] failed "
-                "attempt_id=%(attempt_id)s space_id=%(space_id)s "
-                "skill_id=%(skill_id)s skill_uuid=%(skill_uuid)s "
-                "team_id=%(team_id)s sc_version_number=%(sc_version_number)s "
-                "gateway_error_code=%(gateway_error_code)s "
-                "upstream_code=%(upstream_code)s "
-                "upstream_trace_id=%(upstream_trace_id)s env=%(env)s",
-                diagnostics,
-                extra=diagnostics,
+            self._log_failure(
+                operation="publication_submit",
+                stage="publish_submit",
+                work=work,
+                env=env,
+                failure_type=type(exc).__name__,
+                gateway_error=exc,
             )
             if exc.code in (
                 SkillCenterGatewayErrorCode.BUSINESS,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_publication_task.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_publication_task.py
@@ -223,6 +223,7 @@ class SpaceSkillPublicationTaskHandler:
                 error_message="Publication prerequisites are incomplete",
                 env=env,
             )
+        stage = "draft_read"
         try:
             ref = DraftRevisionRef.from_locator(
                 tenant=self._tenant_provider(), env=env, locator=frozen_locator
@@ -237,7 +238,8 @@ class SpaceSkillPublicationTaskHandler:
                     env=env,
                 )
                 return Complete()
-            stage = self._stager.stage(
+            stage = "package_stage"
+            package_stage = self._stager.stage(
                 attempt_id=work.attempt.attempt_id,
                 tenant=self._tenant_provider(),
                 env=env,
@@ -245,10 +247,17 @@ class SpaceSkillPublicationTaskHandler:
             )
             return self._repository.mark_prepared(
                 attempt_id=work.attempt.attempt_id,
-                package_url=stage.package_url,
+                package_url=package_stage.package_url,
                 env=env,
             )
-        except Exception:
+        except Exception as exc:
+            self._log_failure(
+                operation="publication_prepare",
+                stage=stage,
+                work=work,
+                env=env,
+                failure_type=type(exc).__name__,
+            )
             return self._retry_or_available(
                 work,
                 kind=PublicationRecoveryKind.PREPARATION,
@@ -327,7 +336,15 @@ class SpaceSkillPublicationTaskHandler:
                     SkillCenterGatewayErrorCode.UNKNOWN_RESPONSE,
                     "SC status refers to another version",
                 )
-        except SkillCenterGatewayError:
+        except SkillCenterGatewayError as exc:
+            self._log_failure(
+                operation="publication_status",
+                stage="publish_status",
+                work=work,
+                env=env,
+                failure_type=type(exc).__name__,
+                gateway_error=exc,
+            )
             return self._unknown_or_available(work, env=env)
         if status.status is SkillCenterPublishState.PENDING:
             if self._expired(work):
@@ -408,7 +425,15 @@ class SpaceSkillPublicationTaskHandler:
                 env=env,
             )
             return self._materialize(work, env=env)
-        except SkillCenterGatewayError:
+        except SkillCenterGatewayError as exc:
+            self._log_failure(
+                operation="publication_status_or_version_discovery",
+                stage="status_or_version_discovery",
+                work=work,
+                env=env,
+                failure_type=type(exc).__name__,
+                gateway_error=exc,
+            )
             return self._retry_or_available(
                 work,
                 kind=PublicationRecoveryKind.SC_STATUS_CHECK,
@@ -446,7 +471,14 @@ class SpaceSkillPublicationTaskHandler:
                 self._delete_frozen_draft_best_effort(work, env=env)
             get_event_bus().publish(published)
             return Complete()
-        except SkillVersionMaterializationError:
+        except SkillVersionMaterializationError as exc:
+            self._log_failure(
+                operation="publication_materialization",
+                stage=exc.stage or "unknown",
+                work=work,
+                env=env,
+                failure_type=type(exc.__cause__ or exc).__name__,
+            )
             return self._retry_or_available(
                 work,
                 kind=PublicationRecoveryKind.MATERIALIZATION,
@@ -474,6 +506,51 @@ class SpaceSkillPublicationTaskHandler:
                 "failed to clean published Space Skill Draft revision",
                 extra={"attempt_id": work.attempt.attempt_id},
             )
+
+    @staticmethod
+    def _log_failure(
+        *,
+        operation: str,
+        stage: str,
+        work: PublicationWork,
+        env: str,
+        failure_type: str,
+        gateway_error: SkillCenterGatewayError | None = None,
+    ) -> None:
+        """Keep retry semantics unchanged while retaining safe upstream correlation facts."""
+        diagnostics = {
+            "operation": operation,
+            "stage": stage,
+            "env": env,
+            "attempt_id": work.attempt.attempt_id,
+            "space_id": work.space_id,
+            "skill_id": work.attempt.skill_id,
+            "skill_uuid": work.skill_uuid,
+            "team_id": work.sc_team_id,
+            "sc_version_number": work.attempt.sc_version_number,
+            "skill_version_id": work.attempt.skill_version_id,
+            "gateway_error_code": (
+                gateway_error.code.value if gateway_error is not None else None
+            ),
+            "upstream_code": (
+                gateway_error.upstream_code if gateway_error is not None else None
+            ),
+            "upstream_trace_id": (
+                gateway_error.trace_id if gateway_error is not None else None
+            ),
+            "failure_type": failure_type,
+        }
+        logger.warning(
+            "skill_center_publication_failed "
+            "operation=%(operation)s stage=%(stage)s env=%(env)s "
+            "attempt_id=%(attempt_id)s space_id=%(space_id)s "
+            "skill_id=%(skill_id)s skill_uuid=%(skill_uuid)s team_id=%(team_id)s "
+            "sc_version_number=%(sc_version_number)s skill_version_id=%(skill_version_id)s "
+            "gateway_error_code=%(gateway_error_code)s upstream_code=%(upstream_code)s "
+            "upstream_trace_id=%(upstream_trace_id)s failure_type=%(failure_type)s",
+            diagnostics,
+            extra=diagnostics,
+        )
 
     def _unknown_or_available(self, work: PublicationWork, *, env: str) -> TaskOutcome:
         available = self._expired(work)

--- a/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
@@ -268,6 +268,54 @@ def test_validation_or_scanner_failure_never_publishes(
     assert versions.published is None
 
 
+def test_download_failure_logs_safe_structured_diagnostics(caplog) -> None:
+    class _FailedResponse:
+        status_code = 502
+        headers = {"content-type": "text/html"}
+        content = b"<html>gateway failure</html>"
+
+        def raise_for_status(self) -> None:
+            raise RuntimeError(
+                "download https://signed.example/package.zip?signature=private-token failed"
+            )
+
+    class _FailedHttp:
+        def get(self, _path: str, **_kwargs) -> _FailedResponse:
+            return _FailedResponse()
+
+    package = _package()
+    versions = _Versions(_target())
+    materializer = SkillVersionMaterializer(
+        versions=versions,
+        gateway=_Gateway(package),
+        http=_FailedHttp(),
+        validator=SkillPackageValidator(SkillParser()),
+        scanner=_Scanner(),
+        store=LocalCanonicalCenterVersionStore(),
+    )
+
+    with pytest.raises(SkillVersionMaterializationError) as failure:
+        materializer.materialize(
+            SkillVersionMaterializationRequest(
+                env="pre",
+                skill_id=10,
+                skill_version_id=101,
+                scope=SkillCenterReadScope.PUBLIC,
+            )
+        )
+
+    assert failure.value.stage == "package_download"
+    assert versions.published is None
+    assert "skill_center_materialization_failed" in caplog.text
+    assert "stage=package_download" in caplog.text
+    assert "download_host=download.example" in caplog.text
+    assert "download_path=/exact.zip" in caplog.text
+    assert "http_status=502" in caplog.text
+    assert "http_content_type=text/html" in caplog.text
+    assert "private-token" not in caplog.text
+    assert "signature=" not in caplog.text
+
+
 def test_team_exact_package_still_rejects_manifest_name_mismatch() -> None:
     versions = _Versions(_target())
     materializer = _materializer(

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_publication_repository.py
@@ -1186,7 +1186,7 @@ def test_submit_rejection_logs_safe_upstream_diagnostics(caplog) -> None:
     [record] = [
         record
         for record in caplog.records
-        if record.getMessage().startswith("[skill_center.publication.submit] failed")
+        if record.getMessage().startswith("skill_center_publication_failed")
     ]
     assert record.attempt_id == attempt.attempt_id
     assert record.space_id == space_id
@@ -1198,6 +1198,8 @@ def test_submit_rejection_logs_safe_upstream_diagnostics(caplog) -> None:
     assert record.upstream_code == "ILLEGAL_PERMISSION"
     assert record.upstream_trace_id == "sc-trace-rejected"
     assert record.env == "test"
+    assert record.operation == "publication_submit"
+    assert record.stage == "publish_submit"
     assert f"attempt_id={attempt.attempt_id}" in caplog.text
     assert f"skill_uuid={expected_skill_uuid}" in caplog.text
     assert f"team_id={expected_team_id}" in caplog.text


### PR DESCRIPTION
## Problem
SkillCenter pre-release investigation only surfaced a fixed materialization error, while several SC hops either lacked stable correlation fields or could log credential-bearing URLs and response fragments.

## Solution
- Add structured, sanitized diagnostics across the gateway/client, publication worker, exact-version materializer, and Reference processor.
- Record operation/stage, stable identifiers, HTTP metadata, and upstream errorCode/traceId where available; omit appKey, credentials, cookies, response bodies, and signed URL queries.
- Preserve existing public APIs, error classes, state transitions, and retry behavior.

## Validation
- `DEPLOY_PROFILE=corp_test uv run pytest tests/corp/plugins/prod/test_skill_center_gateway.py tests/corp/core/skill_center/services/test_skill_center_client.py -q` (113 passed)
- `DEPLOY_PROFILE=test uv run pytest tests/community/core/skill_center/test_skill_version_materializer.py tests/community/core/skill_center/test_skill_center_reference_processor.py tests/community/repository/skill_center/test_space_skill_publication_repository.py -q` (44 passed)
- Targeted E/W/F lint passed for all changed Python files.
- Standards/Spec review completed; high-priority findings fixed.

## Compatibility and risk
No contract, database, state-machine, or retry-semantics changes. Log-only observability change; downstream log parsers should use additive fields.

## Related issues
Dima: 2026090100118702355