### PR TITLE
fix(backend): scan validated Skill directories

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_materializer.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_materializer.py
@@ -154,10 +154,9 @@ class SdkSkillVersionScanner:
                     target = base.joinpath(*relative.split("/"))
                     target.parent.mkdir(parents=True, exist_ok=True)
                     target.write_bytes(content)
-                skill_path = base / "SKILL.md"
-                scan_result = sdk.scan(str(skill_path))
+                scan_result = sdk.scan(str(base))
                 dependencies = sdk.get_mcp_dependencies(
-                    skill_path=str(skill_path),
+                    skill_path=str(base),
                     base_dir=str(base),
                     min_confidence=0.8,
                 )

--- a/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_version_materializer.py
@@ -9,6 +9,7 @@ import zipfile
 from contextlib import contextmanager
 from dataclasses import replace
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine
@@ -339,7 +340,7 @@ def test_team_exact_package_still_rejects_manifest_name_mismatch() -> None:
     assert versions.published is None
 
 
-def test_sdk_scanner_reads_only_the_validated_exact_package(tmp_path) -> None:
+def test_sdk_scanner_reads_only_the_validated_exact_package() -> None:
     package = SkillPackageValidator(SkillParser()).validate_zip(_package())
 
     class _Scan:
@@ -347,13 +348,20 @@ def test_sdk_scanner_reads_only_the_validated_exact_package(tmp_path) -> None:
 
     class _Sdk:
         def scan(self, skill_path: str):
-            assert skill_path.endswith("/SKILL.md")
-            assert open(skill_path, "rb").read().startswith(b"---\n")
+            package_dir = Path(skill_path)
+            assert package_dir.is_dir()
+            assert (package_dir / "SKILL.md").read_bytes().startswith(b"---\n")
+            assert sorted(
+                path.relative_to(package_dir).as_posix()
+                for path in package_dir.rglob("*")
+                if path.is_file()
+            ) == ["SKILL.md", "scripts/fetch.py"]
             return _Scan()
 
         def get_mcp_dependencies(self, *, skill_path, base_dir, min_confidence):
-            assert skill_path.endswith("/SKILL.md")
-            assert base_dir == skill_path.removesuffix("/SKILL.md")
+            assert skill_path == base_dir
+            assert Path(skill_path).is_dir()
+            assert (Path(skill_path) / "SKILL.md").is_file()
             assert min_confidence == 0.8
             return [{"code": "mcp.fs", "name": "FS"}]
 


### PR DESCRIPTION
## Problem

SkillCenter materialization passed the plain `SKILL.md` file to the Scanner SDK. The SDK classifies existing non-directory paths as tarballs, so valid exact Skill packages fail during scanning with `ScanError`.

## Solution

Pass the reconstructed, validated package directory to both Scanner SDK calls. The directory contains only files emitted by `ValidatedSkillPackage`, including the required `SKILL.md`.

## Validation

- `PYTHONPATH=src /Users/freddie/Documents/codebase/worktree/ocb-sc-pre-url-routing-rel20260901/src/backend/.venv/bin/python -m pytest tests/community/core/skill_center/test_skill_version_materializer.py -q` (8 passed)
- `PYTHONPATH=src /Users/freddie/Documents/codebase/worktree/ocb-sc-pre-url-routing-rel20260901/src/backend/.venv/bin/python -m ruff check src/agentclaw/community/core/skill_center/services/skill_version_materializer.py tests/community/core/skill_center/test_skill_version_materializer.py`
- `git diff --check`
- Standards and Spec reviews: no blocking findings.

## Compatibility and risk

No API, persistence, lifecycle, or retry semantics change. Scanner failures remain fail-closed; only the existing SDK path argument is corrected from a file to the validated package directory.