### PR TITLE
chore(skills): add runtime projection latency logs

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/_mutation_flow.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/_mutation_flow.py
@@ -10,6 +10,7 @@ the two services cannot drift.
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable, Sequence
 
 from agentclaw.community.core.bot_management.readiness import is_bot_ready
@@ -31,6 +32,10 @@ from agentclaw.community.core.skills_pool.mapping_intent import (
     retired_logical_skill_mappings,
 )
 from agentclaw.community.core.skills_pool.models import PoolSkillMapping
+from agentclaw.community.log import get_logger
+
+
+logger = get_logger()
 
 
 def skill_claim_scope(result: DesiredStateMutation) -> ProjectionScope:
@@ -141,11 +146,51 @@ class MutationProjectionFlow:
         if not is_bot_ready(bot):
             raise LocalSkillNotReadyError()
         owner_id = str(bot["owner_id"])
-        previous_mappings = await self._runtime.snapshot_skill_mappings(
+        snapshot_started_at = time.perf_counter()
+        try:
+            previous_mappings = await self._runtime.snapshot_skill_mappings(
+                bot_id=bot_id,
+                owner_id=owner_id,
+            )
+        except Exception:
+            self._log_timing(
+                stage="snapshot_before",
+                bot_id=bot_id,
+                engine_type=engine_type,
+                started_at=snapshot_started_at,
+                outcome="error",
+            )
+            raise
+        self._log_timing(
+            stage="snapshot_before",
             bot_id=bot_id,
-            owner_id=owner_id,
+            engine_type=engine_type,
+            started_at=snapshot_started_at,
+            outcome="success",
+            mapping_count=len(previous_mappings),
         )
-        result = mutation()
+
+        mutation_started_at = time.perf_counter()
+        try:
+            result = mutation()
+        except Exception:
+            self._log_timing(
+                stage="mutation_tx",
+                bot_id=bot_id,
+                engine_type=engine_type,
+                started_at=mutation_started_at,
+                outcome="error",
+            )
+            raise
+        self._log_timing(
+            stage="mutation_tx",
+            bot_id=bot_id,
+            engine_type=engine_type,
+            started_at=mutation_started_at,
+            outcome="success",
+            changed=result.changed,
+            mcp_delta_count=len(result.mcp_codes),
+        )
         if skip_projection_when_unchanged and not result.changed:
             return {**result.item, "changed": False, **result.details}
         effective_scope = (
@@ -174,9 +219,30 @@ class MutationProjectionFlow:
     ) -> None:
         current_mappings: Sequence[PoolSkillMapping] = ()
         try:
-            current_mappings = await self._runtime.snapshot_skill_mappings(
+            snapshot_started_at = time.perf_counter()
+            try:
+                current_mappings = await self._runtime.snapshot_skill_mappings(
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                )
+            except Exception:
+                self._log_timing(
+                    stage="snapshot_after",
+                    bot_id=bot_id,
+                    engine_type=engine_type,
+                    started_at=snapshot_started_at,
+                    outcome="error",
+                    scope=scope,
+                )
+                raise
+            self._log_timing(
+                stage="snapshot_after",
                 bot_id=bot_id,
-                owner_id=owner_id,
+                engine_type=engine_type,
+                started_at=snapshot_started_at,
+                outcome="success",
+                mapping_count=len(current_mappings),
+                scope=scope,
             )
             await self._runtime.project(
                 bot_id=bot_id,
@@ -209,3 +275,32 @@ class MutationProjectionFlow:
             except Exception as restore_error:
                 raise SkillSetRuntimeReconcileError() from restore_error
             raise SkillSetRuntimeReconcileError() from exc
+
+    @staticmethod
+    def _log_timing(
+        *,
+        stage: str,
+        bot_id: str,
+        engine_type: str | None,
+        started_at: float,
+        outcome: str,
+        mapping_count: int | None = None,
+        changed: bool | None = None,
+        mcp_delta_count: int | None = None,
+        scope: ProjectionScope | None = None,
+    ) -> None:
+        logger.info(
+            "[MutationProjectionFlow] timing stage=%s bot_id=%s "
+            "engine_type=%s duration_ms=%.3f outcome=%s mapping_count=%s "
+            "changed=%s mcp_delta_count=%s scope_skills=%s scope_mcp=%s",
+            stage,
+            bot_id,
+            engine_type,
+            (time.perf_counter() - started_at) * 1000,
+            outcome,
+            mapping_count,
+            changed,
+            mcp_delta_count,
+            scope.skills if scope is not None else None,
+            scope.mcp if scope is not None else None,
+        )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/bot_runtime_projector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Mapping, Sequence
 
 from injector import inject
@@ -42,7 +43,9 @@ from agentclaw.community.core.skill_center.runtime_resolver import (
 from agentclaw.community.core.skills_pool.models import PoolSkillMapping
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.passport import McpScopeItem, PassportPlugin
-from agentclaw.community.core.skill_center.bot_runtime_projector_protocol import BotRuntimeProjectorProtocol
+from agentclaw.community.core.skill_center.bot_runtime_projector_protocol import (
+    BotRuntimeProjectorProtocol,
+)
 
 
 logger = get_logger()
@@ -102,19 +105,17 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
             raise LocalSkillNotFoundError()
         engine = str(bot.get("active_engine") or "openclaw")
         skill_assets = list(
-            self._reader.active_skill_assets(
-                bot_id=bot_id, owner_id=owner_id, bot=bot
-            )
+            self._reader.active_skill_assets(bot_id=bot_id, owner_id=owner_id, bot=bot)
         )
         # The engine refuses what its runtime has no contract for. Asked here
         # rather than tested here, so a caller of this module never has to
         # know which engines those are.
-        self._registry.for_engine(engine).validate_plan(
-            skill_assets=skill_assets
+        self._registry.for_engine(engine).validate_plan(skill_assets=skill_assets)
+        return (
+            RuntimeProjectionResolver()
+            .resolve_skills(tuple(skill_assets))
+            .skill_mappings
         )
-        return RuntimeProjectionResolver().resolve_skills(
-            tuple(skill_assets)
-        ).skill_mappings
 
     async def project(
         self,
@@ -153,7 +154,8 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
             logger.info(
                 "[BotRuntimeProjector] Passport update skipped, scope declares "
                 "no MCP change: bot_id=%s, engine=%s",
-                plan.bot_id, plan.engine,
+                plan.bot_id,
+                plan.engine,
             )
 
     async def project_mcp_and_cli(
@@ -195,11 +197,30 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         bot = self._bot_repo.get_by_id_and_owner(bot_id, owner_id)
         if bot is None:
             raise LocalSkillNotFoundError()
-        skill_plan = self._build_skill_plan(
-            bot=bot,
+        skill_plan_started_at = time.perf_counter()
+        try:
+            skill_plan = self._build_skill_plan(
+                bot=bot,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                retired_mappings=retired_mappings,
+            )
+        except Exception:
+            self._log_plan_timing(
+                stage="build_skill_plan",
+                bot_id=bot_id,
+                engine=str(bot.get("active_engine") or "openclaw"),
+                started_at=skill_plan_started_at,
+                outcome="error",
+            )
+            raise
+        self._log_plan_timing(
+            stage="build_skill_plan",
             bot_id=bot_id,
-            owner_id=owner_id,
-            retired_mappings=retired_mappings,
+            engine=skill_plan.engine,
+            started_at=skill_plan_started_at,
+            outcome="success",
+            skill_count=len(skill_plan.projection.skill_assets),
         )
         if not scope.mcp:
             logger.info(
@@ -209,7 +230,54 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
                 skill_plan.engine,
             )
             return skill_plan
-        return self._build_capability_plan(skill_plan)
+        capability_plan_started_at = time.perf_counter()
+        try:
+            capability_plan = self._build_capability_plan(skill_plan)
+        except Exception:
+            self._log_plan_timing(
+                stage="build_mcp_plan",
+                bot_id=bot_id,
+                engine=skill_plan.engine,
+                started_at=capability_plan_started_at,
+                outcome="error",
+            )
+            raise
+        self._log_plan_timing(
+            stage="build_mcp_plan",
+            bot_id=bot_id,
+            engine=skill_plan.engine,
+            started_at=capability_plan_started_at,
+            outcome="success",
+            mcp_count=len(capability_plan.projection.mcp_server_codes),
+            cli_count=len(capability_plan.effective_cli_items),
+        )
+        return capability_plan
+
+    @staticmethod
+    def _log_plan_timing(
+        *,
+        stage: str,
+        bot_id: str,
+        engine: str,
+        started_at: float,
+        outcome: str,
+        skill_count: int | None = None,
+        mcp_count: int | None = None,
+        cli_count: int | None = None,
+    ) -> None:
+        logger.info(
+            "[BotRuntimeProjector] timing stage=%s bot_id=%s engine=%s "
+            "duration_ms=%.3f outcome=%s skill_count=%s mcp_count=%s "
+            "cli_count=%s",
+            stage,
+            bot_id,
+            engine,
+            (time.perf_counter() - started_at) * 1000,
+            outcome,
+            skill_count,
+            mcp_count,
+            cli_count,
+        )
 
     def _resolve_mcp_identity_modes(
         self, *, bot: dict, bot_id: str, engine: str
@@ -255,9 +323,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         # over Installation that agrees with Set configuration — the lazy
         # flush every read runs, not a projector-only repair.
         skill_assets = tuple(
-            self._reader.active_skill_assets(
-                bot_id=bot_id, owner_id=owner_id, bot=bot
-            )
+            self._reader.active_skill_assets(bot_id=bot_id, owner_id=owner_id, bot=bot)
         )
         # Reject before querying or writing any external MCP, Passport, or
         # runtime boundary. What an engine's runtime cannot carry is the
@@ -310,9 +376,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         )
         try:
             # Passport is the authority for the effective Default CLI scope.
-            effective_cli_items = self._passport.query_passport_clis(
-                bot_id, owner_id
-            )
+            effective_cli_items = self._passport.query_passport_clis(bot_id, owner_id)
         except Exception as exc:
             raise SkillSetRuntimeReconcileError() from exc
         projection = RuntimeProjectionResolver().resolve(
@@ -367,9 +431,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         so a stale row for an MCP this Bot no longer holds cannot re-grant it.
         """
         items = passport_mcp_items_from_codes(codes, identity_modes=identity_modes)
-        caller_count = sum(
-            1 for item in items if item.get("identity_mode") == "caller"
-        )
+        caller_count = sum(1 for item in items if item.get("identity_mode") == "caller")
         logger.info(
             "[BotRuntimeProjector] Passport MCP scope resolved: bot_id=%s, "
             "engine=%s, mcps=%s, caller=%s, owner=%s",
@@ -404,9 +466,7 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
         ``identity_mode: "owner"`` for every MCP.
         """
         try:
-            passport_codes = filter_passport_mcp_codes(
-                plan.projection.mcp_server_codes
-            )
+            passport_codes = filter_passport_mcp_codes(plan.projection.mcp_server_codes)
             # Mandatory, not an optimisation — see ``_passport_mcp_items``.
             mcp_items = self._passport_mcp_items(
                 identity_modes=plan.identity_modes,
@@ -430,8 +490,6 @@ class BotRuntimeProjector(BotRuntimeProjectorProtocol):
             )
         except Exception as exc:
             raise SkillSetRuntimeReconcileError() from exc
-
-
 
 
 __all__ = [

--- a/src/backend/src/agentclaw/community/core/skills_pool/runtime.py
+++ b/src/backend/src/agentclaw/community/core/skills_pool/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Sequence
 from typing import Any
 
@@ -22,7 +23,10 @@ from agentclaw.community.core.skills_pool.models import (
     PoolSkillMapping,
     SkillMappingSourceLayout,
 )
-from agentclaw.community.core.skills_pool.quarantine import RuntimeQuarantineCleanupResult, RuntimeQuarantineCleanupStatus
+from agentclaw.community.core.skills_pool.quarantine import (
+    RuntimeQuarantineCleanupResult,
+    RuntimeQuarantineCleanupStatus,
+)
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.device_adapter_transport import (
     DeviceAdapterTransport,
@@ -395,7 +399,9 @@ class SkillsPoolRuntime:
                 body={"items": items},
             )
         except Exception:
-            logger.exception("[skills_pool.runtime] center ensure failed bot_id=%s", bot_id)
+            logger.exception(
+                "[skills_pool.runtime] center ensure failed bot_id=%s", bot_id
+            )
             return False
         data = response.get("data")
         return (
@@ -414,7 +420,25 @@ class SkillsPoolRuntime:
         path: str,
         body: dict[str, Any],
     ) -> dict[str, Any]:
-        context = self._resolver.resolve_for_bot(bot_id, user_id)
+        context_started_at = time.perf_counter()
+        try:
+            context = self._resolver.resolve_for_bot(bot_id, user_id)
+        except Exception:
+            logger.info(
+                "[skills_pool.runtime] timing stage=resolve_device_context "
+                "bot_id=%s path=%s duration_ms=%.3f outcome=error",
+                bot_id,
+                path,
+                (time.perf_counter() - context_started_at) * 1000,
+            )
+            raise
+        logger.info(
+            "[skills_pool.runtime] timing stage=resolve_device_context "
+            "bot_id=%s path=%s duration_ms=%.3f outcome=success",
+            bot_id,
+            path,
+            (time.perf_counter() - context_started_at) * 1000,
+        )
         return await self._transport.invoke(
             context.conn_info,
             "POST",

--- a/src/backend/tests/community/core/skill_center/test_bot_runtime_projector_timing.py
+++ b/src/backend/tests/community/core/skill_center/test_bot_runtime_projector_timing.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import logging
+
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    ProjectionScope,
+    ResolvedCapabilityPlan,
+)
+from agentclaw.community.core.skill_center.services.bot_runtime_projector import (
+    BotRuntimeProjector,
+)
+
+
+class _Bots:
+    def get_by_id_and_owner(self, bot_id: str, owner_id: str) -> dict:
+        assert (bot_id, owner_id) == ("bot-1", "owner-1")
+        return {
+            "id": 1,
+            "active_engine": "openclaw",
+            "entity_id": owner_id,
+            "entity_type": "staff",
+        }
+
+
+class _Factory:
+    def create(self, **_kwargs) -> "_SkillSetService":
+        return _SkillSetService()
+
+
+class _SkillSetService:
+    def collect_bot_active_mcps(self, **_kwargs) -> list[dict]:
+        return []
+
+
+class _Reader:
+    def active_skill_assets(self, **_kwargs) -> list:
+        return []
+
+
+class _Projection:
+    def validate_plan(self, **_kwargs) -> None:
+        return None
+
+
+class _Registry:
+    def for_engine(self, engine: str) -> _Projection:
+        assert engine == "openclaw"
+        return _Projection()
+
+
+class _Repository:
+    def list_installed_mcps(self, **_kwargs) -> set[str]:
+        return set()
+
+
+class _Passport:
+    def query_passport_clis(self, *_args) -> list[dict]:
+        return []
+
+
+class _IdentityRepository:
+    def list_draft_call_types(self, *_args) -> dict:
+        return {}
+
+
+def test_runtime_projector_logs_skill_and_mcp_plan_timing(caplog) -> None:
+    projector = BotRuntimeProjector(
+        factory=_Factory(),
+        bot_repo=_Bots(),
+        repository=_Repository(),
+        reader=_Reader(),
+        registry=_Registry(),
+        passport=_Passport(),
+        caller_identity_repo=_IdentityRepository(),
+    )
+    caplog.set_level(logging.INFO)
+
+    plan = projector._resolve_plan(
+        bot_id="bot-1",
+        owner_id="owner-1",
+        scope=ProjectionScope(skills=True, mcp=True),
+    )
+
+    assert isinstance(plan, ResolvedCapabilityPlan)
+    messages = [record.getMessage() for record in caplog.records]
+    for stage in ("build_skill_plan", "build_mcp_plan"):
+        assert any(
+            "[BotRuntimeProjector] timing" in message
+            and f"stage={stage}" in message
+            and "bot_id=bot-1" in message
+            and "duration_ms=" in message
+            for message in messages
+        )

--- a/src/backend/tests/community/core/skill_center/test_mutation_flow_timing.py
+++ b/src/backend/tests/community/core/skill_center/test_mutation_flow_timing.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from agentclaw.community.core.repository.capability_desired_state_types import (
+    CapabilityDesiredState,
+    DesiredStateMutation,
+)
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    ProjectionScope,
+)
+from agentclaw.community.core.skill_center.services._mutation_flow import (
+    MutationProjectionFlow,
+)
+
+
+class _Repository:
+    def restore_desired_state(self, **_kwargs) -> None:
+        raise AssertionError("restore is not expected on the success path")
+
+
+class _Runtime:
+    async def snapshot_skill_mappings(self, **_kwargs):
+        return ()
+
+    async def project(self, **_kwargs) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_mutation_flow_logs_control_plane_timing_stages(caplog) -> None:
+    flow = MutationProjectionFlow(repository=_Repository(), runtime=_Runtime())
+    caplog.set_level(logging.INFO)
+
+    result = await flow.apply(
+        bot={"owner_id": "owner-1", "status": "ACTIVE"},
+        bot_id="bot-1",
+        engine_type="openclaw",
+        scope=ProjectionScope(skills=True),
+        mutation=lambda: DesiredStateMutation(
+            item={"id": "set-1"},
+            changed=True,
+            previous_state=CapabilityDesiredState(
+                installations=set(),
+                set_active={},
+                memberships={},
+            ),
+        ),
+    )
+
+    assert result == {"id": "set-1", "changed": True}
+    messages = [record.getMessage() for record in caplog.records]
+    for stage in ("snapshot_before", "mutation_tx", "snapshot_after"):
+        assert any(
+            "[MutationProjectionFlow] timing" in message
+            and f"stage={stage}" in message
+            and "bot_id=bot-1" in message
+            and "duration_ms=" in message
+            for message in messages
+        )

--- a/src/backend/tests/community/core/skills_pool/test_runtime.py
+++ b/src/backend/tests/community/core/skills_pool/test_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -10,7 +11,9 @@ from agentclaw.community.core.skills_pool.models import (
     PoolCutoverStatus,
     PoolSkillMapping,
 )
-from agentclaw.community.core.skills_pool.quarantine import RuntimeQuarantineCleanupStatus
+from agentclaw.community.core.skills_pool.quarantine import (
+    RuntimeQuarantineCleanupStatus,
+)
 from agentclaw.community.core.skills_pool.runtime import OpenClawSkillsPoolRuntime
 from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
     MAPPING_V3_CONTRACT_VERSION,
@@ -74,7 +77,13 @@ class CenterEnsureTransport(FakeTransport):
     async def invoke(self, conn_info, method, path, *, body, timeout):
         if path.endswith("/center/ensure"):
             self.calls.append(
-                {"conn_info": conn_info, "method": method, "path": path, "body": body, "timeout": timeout}
+                {
+                    "conn_info": conn_info,
+                    "method": method,
+                    "path": path,
+                    "body": body,
+                    "timeout": timeout,
+                }
             )
             return {"success": True, "data": {"ok": body["items"], "failed": []}}
         return await super().invoke(conn_info, method, path, body=body, timeout=timeout)
@@ -198,8 +207,35 @@ async def test_pool_runtime_resolves_current_binding_for_each_mutation() -> None
 
 
 @pytest.mark.asyncio
+async def test_pool_runtime_logs_device_context_resolution_timing(caplog) -> None:
+    runtime = OpenClawSkillsPoolRuntime(
+        resolver=FakeResolver(),
+        adapter_transport=FakeTransport(),
+        probe_service=FakeProbe(),
+    )
+    caplog.set_level(logging.INFO)
+
+    assert await runtime.verify_mappings(
+        bot_id="bot-1",
+        user_id="owner-1",
+        mappings=[],
+    )
+
+    assert any(
+        "[skills_pool.runtime] timing stage=resolve_device_context"
+        in record.getMessage()
+        and "bot_id=bot-1" in record.getMessage()
+        and "path=/api/skills/layout/mappings/verify" in record.getMessage()
+        and "duration_ms=" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("provider", ["local", "baas"])
-async def test_repo_retirement_projection_reaches_each_device_provider(provider: str) -> None:
+async def test_repo_retirement_projection_reaches_each_device_provider(
+    provider: str,
+) -> None:
     """Repo Direct deactivate clears the old entry for Local and BaaS engines."""
     transport = FakeTransport()
     runtime = OpenClawSkillsPoolRuntime(


### PR DESCRIPTION
## 背景

预发成功的 SkillSet 激活已观察到 OpenClaw 14.75s 与 Teclaw 22.29s / 22.46s 长尾。现有日志无法可靠区分 SQL、控制面编排、设备上下文解析和 MCP 计划构建。

## 变更

仅新增结构化阶段耗时日志 duration_ms，不改变激活与运行时投影行为：

- MutationProjectionFlow：snapshot_before、mutation_tx、snapshot_after
- BotRuntimeProjector：build_skill_plan、build_mcp_plan
- SkillsPoolRuntime：resolve_device_context

日志记录 bot、engine、结果状态及必要计数；异常路径也记录耗时。

## 不包含

- 不改 Center ensure / mappings publish / verify 语义
- 不跳过 MCP allow-list 或 Passport 声明
- 不做 Teclaw / OpenClaw 性能行为优化

## 验证

- 相关 pytest：10 passed
- 相关 Ruff：passed
- Standards / Spec 双轴审查：无阻塞项

部署到预发并收集新的 stage 日志后，再单独提交实际性能优化。