### PR TITLE
feat(bcs): gate session invite tokens on session membership only

### DIFF
--- a/src/bcs/crates/application/v1/bcs-app-invitation/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-invitation/src/lib.rs
@@ -298,8 +298,6 @@ impl InvitationService for InvitationFriendshipServiceImpl {
                     format!("Session '{}' was not found", command.session_id),
                 )
             })?;
-        // Manager of the parent group may mint a session invitation, mirroring
-        // the legacy `create_session_invite_token` authorization.
         let group = self
             .groups
             .try_get(&session.group_id)
@@ -311,11 +309,6 @@ impl InvitationService for InvitationFriendshipServiceImpl {
                     format!("Group '{}' was not found", session.group_id),
                 )
             })?;
-        if !self.can_manage_group(&principal, &group).await? {
-            return Err(ApplicationError::forbidden(
-                "Only the Group originator, driver, or manager may manage Sessions",
-            ));
-        }
         // Vcj6M: legacy `create_session_invite_token` L186-189 rejects DM parent
         // groups. Mirror it so session invitations on pairwise DM targets are
         // not minted. The legacy session path skips `session.status` (it never
@@ -332,6 +325,19 @@ impl InvitationService for InvitationFriendshipServiceImpl {
             return Err(ApplicationError::conflict(
                 "conflict",
                 "group is not active",
+            ));
+        }
+        // Minting is gated on session membership only: any participant of the
+        // session (any role) may create an invitation for it. Group-level
+        // roles (driver, originator, manager) are intentionally NOT required,
+        // mirroring the relaxed legacy `create_session_invite_token`.
+        if !session
+            .participants
+            .iter()
+            .any(|p| p.bot_uuid == principal.actor_id())
+        {
+            return Err(ApplicationError::forbidden(
+                "Only Session participants may create invitations for this Session",
             ));
         }
         Ok(self.mint_invitation(

--- a/src/bcs/crates/application/v1/bcs-app-invitation/tests/v1_invitation_friendship_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-invitation/tests/v1_invitation_friendship_service.rs
@@ -237,6 +237,22 @@ impl Fixture {
     }
 
     async fn create_session(&self, group_id: &str, driver: &str) -> String {
+        self.create_session_with_participants(
+            group_id,
+            driver,
+            vec![Participant::bot(driver, ParticipantRole::Driver)],
+        )
+        .await
+    }
+
+    /// Like `create_session`, but seeds the session with the given
+    /// participants (the driver is always included first).
+    async fn create_session_with_participants(
+        &self,
+        group_id: &str,
+        driver: &str,
+        participants: Vec<Participant>,
+    ) -> String {
         let group = self
             .groups
             .get(group_id)
@@ -244,7 +260,7 @@ impl Fixture {
             .expect("group exists for session");
         let params = NewSessionParams {
             session_kind: SessionKind::Chat,
-            participants: vec![Participant::bot(driver, ParticipantRole::Driver)],
+            participants,
             group_version: Some(group.version),
             caller_id: Some(driver.to_string()),
             caller_principal: Some(driver.to_string()),
@@ -508,21 +524,36 @@ async fn create_group_invitation_dm_group_rejected() {
 }
 
 #[tokio::test]
-async fn create_session_invitation_manager_ok() {
+async fn create_session_invitation_session_participant_ok() {
+    // Session invitations are gated on session membership only: a Human
+    // Consultant participant — not the group driver, originator, or a bot
+    // owner — may mint. staff-9 holds no group-level privilege on grp-1.
     let fx = Fixture::new().await;
     fx.add_bot("bot-a").await;
     fx.store_group("grp-1", "bot-a").await;
-    let session_id = fx.create_session("grp-1", "bot-a").await;
+    let session_id = fx
+        .create_session_with_participants(
+            "grp-1",
+            "bot-a",
+            vec![
+                Participant::bot("bot-a", ParticipantRole::Driver),
+                Participant::human(
+                    Fixture::human_actor_id("staff-9"),
+                    ParticipantRole::Consultant,
+                ),
+            ],
+        )
+        .await;
 
     let invitation = fx
         .service
         .create_session_invitation(CreateSessionInvitation {
-            caller: Fixture::bot_principal("bot-a"),
+            caller: Fixture::human_principal("staff-9"),
             session_id: session_id.clone(),
             expires_in_seconds: None,
         })
         .await
-        .expect("group manager may create session invitation");
+        .expect("session participant may create session invitation");
 
     assert_eq!(invitation.target_type, InvitationTargetType::Session);
     assert_eq!(invitation.target_id, session_id);
@@ -534,14 +565,17 @@ async fn create_session_invitation_manager_ok() {
 }
 
 #[tokio::test]
-async fn human_owner_of_legacy_group_driver_bot_can_create_session_invitation() {
+async fn create_session_invitation_non_participant_forbidden() {
+    // The owner of the group's driver Bot (and of the group via
+    // originator-ownership) is still NOT a session participant, and
+    // group-level privilege no longer substitutes for session membership.
     let fx = Fixture::new().await;
     fx.add_bot("bot-a").await;
     fx.store_legacy_group("grp-1", "bot-a", "human_other")
         .await;
     let session_id = fx.create_session("grp-1", "bot-a").await;
 
-    let invitation = fx
+    let error = fx
         .service
         .create_session_invitation(CreateSessionInvitation {
             caller: Fixture::human_principal("staff-1"),
@@ -549,10 +583,13 @@ async fn human_owner_of_legacy_group_driver_bot_can_create_session_invitation() 
             expires_in_seconds: None,
         })
         .await
-        .expect("Human owner may act for the session's group driver Bot");
+        .expect_err("non-participant is forbidden even when owning the driver Bot");
 
-    assert_eq!(invitation.target_type, InvitationTargetType::Session);
-    assert_eq!(invitation.target_id, session_id);
+    assert!(
+        matches!(error, ApplicationError::Forbidden(_)),
+        "expected Forbidden, got {error:?}",
+    );
+    assert_eq!(error.code(), "forbidden");
 }
 
 #[tokio::test]
@@ -870,12 +907,25 @@ async fn accept_invitation_session_target_joins() {
     let fx = Fixture::new().await;
     fx.add_bot("bot-a").await;
     fx.store_group("grp-1", "bot-a").await;
-    let session_id = fx.create_session("grp-1", "bot-a").await;
+    // staff-9 is the session participant who mints; staff-1 is the invitee.
+    let session_id = fx
+        .create_session_with_participants(
+            "grp-1",
+            "bot-a",
+            vec![
+                Participant::bot("bot-a", ParticipantRole::Driver),
+                Participant::human(
+                    Fixture::human_actor_id("staff-9"),
+                    ParticipantRole::Consultant,
+                ),
+            ],
+        )
+        .await;
 
     let invitation = fx
         .service
         .create_session_invitation(CreateSessionInvitation {
-            caller: Fixture::bot_principal("bot-a"),
+            caller: Fixture::human_principal("staff-9"),
             session_id: session_id.clone(),
             expires_in_seconds: None,
         })

--- a/src/bcs/crates/services/bcs-group/src/application/invite.rs
+++ b/src/bcs/crates/services/bcs-group/src/application/invite.rs
@@ -72,6 +72,30 @@ impl InviteServiceImpl {
         ))
     }
 
+    /// Session invite tokens are gated on session membership only: any
+    /// participant of the session (any role, bot or human) may mint one.
+    /// Group-level roles (driver, originator, manager) are intentionally NOT
+    /// required here.
+    fn ensure_session_member(
+        &self,
+        cmd: &CreateInviteTokenCommand,
+        session: &bcs_service_api::Session,
+    ) -> Result<(), InviteUseCaseError> {
+        let is_member =
+            |actor_id: &str| session.participants.iter().any(|p| p.bot_uuid == actor_id);
+        if cmd.caller_actor_id.as_deref().is_some_and(is_member) {
+            return Ok(());
+        }
+        if let Some(staff_no) = cmd.caller_staff_no.as_deref() {
+            if is_member(&format!("human_{}", staff_no)) {
+                return Ok(());
+            }
+        }
+        Err(InviteUseCaseError::Forbidden(
+            "only session participants can generate session invite links".to_string(),
+        ))
+    }
+
     fn make_token(&self, target_id: &str, ttl_seconds: Option<u64>) -> (String, u64) {
         let ttl = ttl_seconds.unwrap_or(self.default_ttl_seconds);
         let now = std::time::SystemTime::now()
@@ -189,7 +213,7 @@ impl InviteService for InviteServiceImpl {
             ));
         }
 
-        self.authorize_group_invite(&cmd, &group).await?;
+        self.ensure_session_member(&cmd, &session)?;
         let (token, exp) = self.make_token(&cmd.target_id, cmd.ttl_seconds);
         let join_url = match &self.session_link_url {
             Some(url) => format!("{}/{}", url.trim_end_matches('/'), token),

--- a/src/bcs/crates/services/bcs-group/tests/invite.rs
+++ b/src/bcs/crates/services/bcs-group/tests/invite.rs
@@ -1,0 +1,224 @@
+//! Session invite-token authorization tests for `InviteServiceImpl`.
+//!
+//! `create_session_invite_token` is gated on session membership only: any
+//! participant of the session (any role, Bot or Human) may mint a token.
+//! Group-level roles (driver, originator, manager) are intentionally NOT
+//! required. Group invite tokens keep the stricter
+//! `authorize_group_invite` contract (see `invite_integration` in the
+//! bootstrap crate for the HTTP-level group path).
+
+use std::sync::Arc;
+
+use bcs_bot::BotCore;
+use bcs_group::application::invite::InviteServiceImpl;
+use bcs_group::{GroupCore, MemoryGroupRepo};
+use bcs_service_api::application::invite::{
+    CreateInviteTokenCommand, InviteService, InviteUseCaseError,
+};
+use bcs_service_api::application::session::{CreateOrReactivateCommand, SessionManagementService};
+use bcs_service_api::port::repo::{GroupRepoPort, NewSessionParams, SessionRepoPort};
+use bcs_service_api::{
+    Group, GroupCoreService, GroupStrategy, Participant, ParticipantRole, SessionKind,
+};
+use bcs_session::SessionManagementServiceImpl;
+use bcs_session_store::MemorySessionRepo;
+use bcs_test_support::NoopSystemMessageService;
+
+const SECRET: &[u8] = b"test-invite-secret-32-bytes-long!!";
+
+struct Fixture {
+    service: InviteServiceImpl,
+    groups: Arc<GroupCore>,
+    sessions: Arc<SessionManagementServiceImpl>,
+}
+
+impl Fixture {
+    async fn new() -> Self {
+        let group_repo: Arc<dyn GroupRepoPort> = Arc::new(MemoryGroupRepo::new());
+        let groups = Arc::new(GroupCore::with_repo(group_repo.clone()));
+        // The session invite path never consults the bot registry; BotCore is
+        // wired in only because the impl struct requires it.
+        let bots = Arc::new(BotCore::memory());
+        let session_repo: Arc<dyn SessionRepoPort> = Arc::new(MemorySessionRepo::new());
+        let sessions = Arc::new(SessionManagementServiceImpl::new(
+            session_repo.clone(),
+            group_repo.clone(),
+        ));
+        let service = InviteServiceImpl {
+            registry: bots,
+            group: groups.clone(),
+            session: sessions.clone(),
+            system_message: Arc::new(NoopSystemMessageService),
+            token_secret: SECRET.to_vec(),
+            default_ttl_seconds: 3600,
+            base_url: None,
+            group_link_url: None,
+            session_link_url: None,
+        };
+        Self {
+            service,
+            groups,
+            sessions,
+        }
+    }
+
+    async fn store_group(&self, group_id: &str, driver: &str) {
+        let mut group = Group::new(
+            group_id,
+            driver,
+            vec![Participant::bot(driver, ParticipantRole::Driver)],
+        );
+        group.originator = Some("human_staff-owner".to_string());
+        group.label = Some(group_id.to_string());
+        group.group_strategy = GroupStrategy::Chat;
+        self.groups.upsert(group).await.expect("store group");
+    }
+
+    async fn create_session_with_participants(
+        &self,
+        group_id: &str,
+        driver: &str,
+        participants: Vec<Participant>,
+    ) -> String {
+        let group = self
+            .groups
+            .get(group_id)
+            .await
+            .expect("group exists for session");
+        let params = NewSessionParams {
+            session_kind: SessionKind::Chat,
+            participants,
+            group_version: Some(group.version),
+            caller_id: Some(driver.to_string()),
+            caller_principal: Some(driver.to_string()),
+            input: None,
+            created_by: Some(driver.to_string()),
+            session_title: Some(format!("{group_id}-session")),
+            id: None,
+            meta: None,
+        };
+        let outcome = self
+            .sessions
+            .create_or_reactivate(CreateOrReactivateCommand {
+                group_id: group_id.to_string(),
+                session_id: None,
+                params,
+            })
+            .await
+            .expect("create session");
+        outcome.session.id
+    }
+
+    fn cmd(&self, session_id: &str, caller_actor_id: Option<&str>) -> CreateInviteTokenCommand {
+        CreateInviteTokenCommand {
+            caller_actor_id: caller_actor_id.map(str::to_string),
+            caller_staff_no: None,
+            target_id: session_id.to_string(),
+            ttl_seconds: None,
+        }
+    }
+}
+
+#[tokio::test]
+async fn session_invite_token_allows_human_participant() {
+    // A Human Consultant participant — not the group driver, originator, or a
+    // bot owner — may mint a session invite token. Both caller identification
+    // forms (direct actor id and staff_no) resolve to the same membership.
+    let fx = Fixture::new().await;
+    fx.store_group("grp-1", "bot-a").await;
+    let session_id = fx
+        .create_session_with_participants(
+            "grp-1",
+            "bot-a",
+            vec![
+                Participant::bot("bot-a", ParticipantRole::Driver),
+                Participant::human("human_staff-9", ParticipantRole::Consultant),
+            ],
+        )
+        .await;
+
+    let result = fx
+        .service
+        .create_session_invite_token(fx.cmd(&session_id, Some("human_staff-9")))
+        .await
+        .expect("human participant may mint");
+    assert!(result.invite_token.len() > 0);
+    assert!(result.join_url.contains("/sessions/join/"));
+
+    // Same human identified via staff_no instead of the actor id.
+    let via_staff = CreateInviteTokenCommand {
+        caller_actor_id: None,
+        caller_staff_no: Some("staff-9".to_string()),
+        target_id: session_id.clone(),
+        ttl_seconds: None,
+    };
+    let result = fx
+        .service
+        .create_session_invite_token(via_staff)
+        .await
+        .expect("human participant identified by staff_no may mint");
+    assert!(result.invite_token.len() > 0);
+}
+
+#[tokio::test]
+async fn session_invite_token_allows_bot_consultant_participant() {
+    // A Bot Consultant session participant — not the group driver nor
+    // originator — may mint; previously only driver/originator/owner could.
+    let fx = Fixture::new().await;
+    fx.store_group("grp-1", "bot-a").await;
+    let session_id = fx
+        .create_session_with_participants(
+            "grp-1",
+            "bot-a",
+            vec![
+                Participant::bot("bot-a", ParticipantRole::Driver),
+                Participant::bot("bot-b", ParticipantRole::Consultant),
+            ],
+        )
+        .await;
+
+    let result = fx
+        .service
+        .create_session_invite_token(fx.cmd(&session_id, Some("bot-b")))
+        .await
+        .expect("bot consultant participant may mint");
+    assert!(result.invite_token.len() > 0);
+}
+
+#[tokio::test]
+async fn session_invite_token_rejects_non_participant() {
+    // bot-b participates in the parent GROUP but not in the session — session
+    // membership is the only grant, and group membership does not substitute.
+    let fx = Fixture::new().await;
+    let mut group = Group::new(
+        "grp-1",
+        "bot-a",
+        vec![
+            Participant::bot("bot-a", ParticipantRole::Driver),
+            Participant::bot("bot-b", ParticipantRole::Consultant),
+        ],
+    );
+    group.originator = Some("human_staff-owner".to_string());
+    group.label = Some("grp-1".to_string());
+    group.group_strategy = GroupStrategy::Chat;
+    fx.groups.upsert(group).await.expect("store group");
+
+    let session_id = fx
+        .create_session_with_participants(
+            "grp-1",
+            "bot-a",
+            vec![Participant::bot("bot-a", ParticipantRole::Driver)],
+        )
+        .await;
+
+    let error = fx
+        .service
+        .create_session_invite_token(fx.cmd(&session_id, Some("bot-b")))
+        .await
+        .expect_err("non-participant is forbidden");
+
+    assert!(
+        matches!(error, InviteUseCaseError::Forbidden(_)),
+        "expected Forbidden, got {error:?}",
+    );
+}


### PR DESCRIPTION
## Problem

Minting a session invite token required the caller to hold a group-level role (driver, originator, manager, or owner of the driver/originator bot) — on both the legacy `POST /sessions/{id}/invite-link` path (`InviteServiceImpl::create_session_invite_token`) and the V1 `POST /openapi/v1/collaboration/sessions/{session_id}/invitations` path (`InvitationFriendshipServiceImpl::create_session_invitation`). A session participant with no group role could not invite others into their own session.

## Solution

Gate both mint paths on session membership only: any participant of the session (human or bot, any role) may mint a token.

- Legacy `InviteServiceImpl`: `authorize_group_invite` on the session path replaced by a new `ensure_session_member` check against `session.participants` (matches `caller_actor_id` directly or `human_{caller_staff_no}`); the group invite-link path keeps the stricter authorization untouched.
- V1 facade: `can_manage_group` replaced by a `session.participants` membership check on `principal.actor_id()`, placed after the existing DM-parent and inactive-parent guards, which are preserved (target-state checks, not role checks).
- No contract change: the 403 description ("Principal cannot invite into the session") is already role-agnostic, so gateway pins and the bcn artifact are unaffected.

## Validation

- New `bcs-group` suite `tests/invite.rs` (session path previously had zero coverage): human Consultant participant mints OK via both caller identification forms, bot Consultant participant mints OK (both 403 under the old rule), group-member-but-not-session-participant 403.
- V1 suite updated: consultant participant OK (`create_session_invitation_session_participant_ok`), driver-bot owner who is not a session participant 403 (`create_session_invitation_non_participant_forbidden`, pins the behavior change), accept-session tests re-seeded with a participant minter.
- `cargo test --package bcs-group --package bcs-app-invitation` green (91 + 33); `bcs-api-http --test invitation_routes` 10/10; bootstrap `invite_integration` 5/5 (group path not regressed); clippy clean on the touched files.