### PR TITLE
bcn-downlink: narrow chat.abort to (bot_id, session_id) dimension for group chats

### DIFF
--- a/src/baas/docs/2026-09-01-bcn-downlink-chat-abort-bot-dimension-semantics.md
+++ b/src/baas/docs/2026-09-01-bcn-downlink-chat-abort-bot-dimension-semantics.md
@@ -1,0 +1,38 @@
+# BCN 下行 chat.abort 语义变更（bot 维度过滤 & 仅终止 RUNNING）
+
+- 日期：2026-09-01
+- 范围：baas 模块，仅 `chat.abort` 下行单链路
+
+## 行为契约变更（Breaking / P1）
+
+`chat.abort` 下行处理由"按 `session_id` 取消该 session 下所有 PENDING/RUNNING run",
+收窄为"按 `(bot_id=to_bot.provider_bot_ref, session_id)` 维度仅取消该 bot 在该
+session 下 RUNNING 的 run"。BCN 调用方需知悉该行为变更。
+
+### 变更前后对照
+
+| 场景 | 变更前 | 变更后 |
+|---|---|---|
+| 群聊：abort 指定 bot，该 bot 有 RUNNING run | 取消该 session 下所有 bot 的 PENDING+RUNNING | 仅取消该 bot 的 RUNNING run（FAILED+force_done+本机 cancel+engine 通知） |
+| 群聊：abort 指定 bot，该 bot 无 RUNNING 但其他 bot 有 | 误杀其他 bot 的 run | 不影响任何 run；按该 bot 维度判 410/200 |
+| 目标 bot 仅有 PENDING run | 标 FAILED+force_done | 不动；aborted=false；PENDING 由 `chat.abort` 超时扫描兜底 |
+| 重复 abort 同一终态 run（该 bot 维度） | 410 run_terminated | 410 run_terminated（幂等不变，判定维度收窄到该 bot） |
+| session 无任何 run 记录 | 200 aborted=false | 200 aborted=false（不变） |
+
+## 请求体契约
+
+不变。复用现有 `to_bot.provider_bot_ref` 作为 bot 维度过滤键，无新增字段。
+`bot_id`/`session_id` 字段早已存在于 `baas_bot_run_queue`（`BotRunQueueRecord.bot_id` / `.session_id`），
+无 DDL / 数据迁移。
+
+## 响应码
+
+- 200 `{ok: true, aborted: true, aborted_run_ids: [...]}`：目标 bot 在该 session 下存在被取消的 RUNNING run。
+- 200 `{ok: true, aborted: false, aborted_run_ids: []}`：该 bot 在该 session 无任何 run 记录，或仅有 PENDING（不命中 cancel）。
+- 410 `run_terminated`（不重试）：该 bot 在该 session 下无 RUNNING run 但存在已终结（DONE）记录。
+
+## 回滚
+
+单次提交即可回滚：移除新增的 `find_running_by_bot_session` / `find_terminal_by_bot_session`
+与 worker/service 的 `bot_id` 传参，恢复 `abort_runs_by_session(session_id)` 旧签名与旧 repo 调用。
+请求体契约不变 + 无 DDL，回滚无需数据修复或配置回退，直接 revert 该 PR 即可恢复原 session 维度全量取消行为。

--- a/src/baas/src/secbaas/community/core/repository/bot_run_queue/_orm_repository.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_queue/_orm_repository.py
@@ -387,3 +387,56 @@ class OrmBotRunQueueRepository(OrmConnectionMixin, BotRunQueueRepository):
             .all()
         )
         return [row.to_record() for row in rows]
+
+    @with_orm_session
+    def find_running_by_bot_session(
+        self, session_id: str, bot_id: str
+    ) -> list[BotRunQueueRecord]:
+        """按 (bot_id, session_id) 维度查询所有 RUNNING 的队列工作项。
+
+        供 ``chat.abort`` 在群聊多 bot 共享同一 ``session_id`` 时精确定位目标 bot 的
+        RUNNING run，避免误杀同 session 下其它 bot 的 run。``session_id`` 与
+        ``bot_id`` 任一为空（首条消息入队前 session_id 可能为 NULL）时返回空，
+        调用方按 best-effort 处理。PENDING 工作项不在此处命中，由
+        ``_timeout_scan_once`` 超时路径兜底。
+        """
+        if not session_id or not bot_id:
+            return []
+        rows = (
+            self._session.query(BotRunQueueModel)
+            .filter(
+                BotRunQueueModel.bot_id == bot_id,
+                BotRunQueueModel.session_id == session_id,
+                BotRunQueueModel.status == "RUNNING",
+                BotRunQueueModel.env == get_current_env(),
+            )
+            .order_by(BotRunQueueModel.gmt_create.asc())
+            .all()
+        )
+        return [row.to_record() for row in rows]
+
+    @with_orm_session
+    def find_terminal_by_bot_session(
+        self, session_id: str, bot_id: str
+    ) -> list[BotRunQueueRecord]:
+        """按 (bot_id, session_id) 维度查询所有已终结（DONE）的队列工作项。
+
+        用于 ``chat.abort`` 在群聊场景区分"该 bot 在该 session 下存在已终结记录"
+        与"该 session 无该 bot 的任何 run 记录"：前者返回 410 ``run_terminated``，
+        后者返回 200 ``{aborted: false}``。维度收窄到目标 bot，避免其它 bot 的
+        终态记录影响判定。
+        """
+        if not session_id or not bot_id:
+            return []
+        rows = (
+            self._session.query(BotRunQueueModel)
+            .filter(
+                BotRunQueueModel.bot_id == bot_id,
+                BotRunQueueModel.session_id == session_id,
+                BotRunQueueModel.status == "DONE",
+                BotRunQueueModel.env == get_current_env(),
+            )
+            .order_by(BotRunQueueModel.gmt_create.asc())
+            .all()
+        )
+        return [row.to_record() for row in rows]

--- a/src/baas/src/secbaas/community/core/repository/bot_run_queue/_protocol.py
+++ b/src/baas/src/secbaas/community/core/repository/bot_run_queue/_protocol.py
@@ -89,3 +89,24 @@ class BotRunQueueRepository(Protocol):
         清理前可见。
         """
         ...
+
+    def find_running_by_bot_session(
+        self, session_id: str, bot_id: str
+    ) -> list[BotRunQueueRecord]:
+        """按 (bot_id, session_id) 维度查询所有 RUNNING 的队列工作项。
+
+        供群聊 ``chat.abort`` 精确定位目标 bot 的 RUNNING run，避免误杀同 session
+        下其它 bot 的 run。``session_id`` 或 ``bot_id`` 为空时返回空列表。PENDING
+        工作项不命中，由超时扫描路径兜底。
+        """
+        ...
+
+    def find_terminal_by_bot_session(
+        self, session_id: str, bot_id: str
+    ) -> list[BotRunQueueRecord]:
+        """按 (bot_id, session_id) 维度查询所有已终结（DONE）的队列工作项。
+
+        用于群聊 ``chat.abort`` 维度收窄后的"已终结"判定（410 vs 200），仅参考
+        目标 bot 的终态记录，不被同 session 其它 bot 的终态记录影响。
+        """
+        ...

--- a/src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py
+++ b/src/baas/src/secbaas/community/core/service/bcn/_bcn_service.py
@@ -174,25 +174,30 @@ class DefaultBcnDownlinkService(BcnDownlinkService):
     ) -> ChatAbortResult:
         """处理 chat.abort 请求
 
-        按 ``session_id`` 委派 ``BotRunAbortSurface.abort_runs_by_session`` 取消
-        当前 session 下所有未终结（PENDING/RUNNING）的 run，并据结果返回：
+        按 ``(bot_id=to_bot.provider_bot_ref, session_id)`` 维度委派
+        ``BotRunAbortSurface.abort_runs_by_session`` 取消该 bot 在该 session 下所有
+        RUNNING 的 run，并据结果返回：
 
         - 有可取消 run → 200 ``{aborted: true, aborted_run_ids: [...]}``；
-        - 无可取消 run 但存在已终结记录 → 抛 ``BcnRunTerminatedError`` (410)
-          （重复 abort 同一终态 run 稳定 410，幂等）；
-        - session 无任何 run 记录 → 200 ``{aborted: false, aborted_run_ids: []}``
+        - 无可取消 run 但该 bot 维度存在已终结记录 → 抛 ``BcnRunTerminatedError`` (410)
+          （重复 abort 同一终态 run 稳定 410，幂等；维度收窄到目标 bot）；
+        - 该 bot 在该 session 无任何 run 记录 → 200 ``{aborted: false, aborted_run_ids: []}``
           （best-effort，决策 D2）。
+
+        群聊多 bot 共享同一 ``session_id`` 时仅取消目标 bot 的 RUNNING run，PENDING
+        不动（由超时扫描兜底），不影响同 session 下其它 bot 的 run。
 
         ``body.id`` 为本次 abort 请求 ID（幂等键），用于日志追踪；abort 操作本身
         幂等（``update_error`` / ``force_done`` 均幂等），重复请求自然落入 410 分支。
         """
+        bot_id = chat_abort_input.to_bot.provider_bot_ref
         logger.info(
             "[chat.abort] id=%s session_id=%s provider_id=%s "
             "provider_bot_ref=%s bcn_group_id=%s",
             chat_abort_input.id,
             chat_abort_input.session_id,
             chat_abort_input.to_bot.provider_id,
-            chat_abort_input.to_bot.provider_bot_ref,
+            bot_id,
             chat_abort_input.bcn_group_id,
         )
 
@@ -201,21 +206,23 @@ class DefaultBcnDownlinkService(BcnDownlinkService):
             # 不抛异常，保持下行链路稳定。
             logger.warning(
                 "[chat.abort] no abort surface wired, returning aborted=false "
-                "id=%s session_id=%s",
+                "id=%s session_id=%s bot_id=%s",
                 chat_abort_input.id,
                 chat_abort_input.session_id,
+                bot_id,
             )
             return ChatAbortResult(aborted=False, aborted_run_ids=[])
 
         outcome = await self._abort_surface.abort_runs_by_session(
-            chat_abort_input.session_id
+            chat_abort_input.session_id, bot_id
         )
 
         if outcome.aborted_run_ids:
             logger.info(
-                "[chat.abort] aborted id=%s session_id=%s run_ids=%s",
+                "[chat.abort] aborted id=%s session_id=%s bot_id=%s run_ids=%s",
                 chat_abort_input.id,
                 chat_abort_input.session_id,
+                bot_id,
                 outcome.aborted_run_ids,
             )
             return ChatAbortResult(
@@ -224,16 +231,18 @@ class DefaultBcnDownlinkService(BcnDownlinkService):
 
         if outcome.had_terminal:
             logger.info(
-                "[chat.abort] run already terminated id=%s session_id=%s",
+                "[chat.abort] run already terminated id=%s session_id=%s bot_id=%s",
                 chat_abort_input.id,
                 chat_abort_input.session_id,
+                bot_id,
             )
             raise BcnRunTerminatedError(chat_abort_input.session_id)
 
         logger.info(
-            "[chat.abort] no run record id=%s session_id=%s",
+            "[chat.abort] no run record id=%s session_id=%s bot_id=%s",
             chat_abort_input.id,
             chat_abort_input.session_id,
+            bot_id,
         )
         return ChatAbortResult(aborted=False, aborted_run_ids=[])
 

--- a/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_internal_protocols.py
@@ -367,14 +367,14 @@ class SessionLockService(Protocol):
 
 @dataclass(slots=True)
 class AbortOutcome:
-    """``chat.abort`` 按 session 取消 run 的结果。
+    """``chat.abort`` 按 (bot_id, session_id) 维度取消 run 的结果。
 
     Attributes:
         aborted_run_ids: 本次实际取消（标 FAILED + force_done + 本机 task cancel）
-            的 run_id 列表。空表示 session 下无可取消的未终结 run。
-        had_terminal: session 下是否存在已终结（DONE）的队列工作项。
+            的 run_id 列表。空表示目标 bot 在该 session 下无可取消的 RUNNING run。
+        had_terminal: 目标 bot 在该 session 下是否存在已终结（DONE）的队列工作项。
             用于区分 410 ``run_terminated``（已终结）与 200 ``{aborted: false}``
-            （session 无任何 run 记录）。
+            （该 bot 在该 session 无任何 run 记录）。
     """
 
     aborted_run_ids: list[str] = field(default_factory=list)
@@ -383,20 +383,24 @@ class AbortOutcome:
 
 @runtime_checkable
 class BotRunAbortSurface(Protocol):
-    """按 session_id 取消运行中 run 的接入面。
+    """按 (bot_id, session_id) 维度取消运行中 run 的接入面。
 
     由 ``BotRequestWorker`` 实现（owns ``_running_tasks`` / ``_queue`` /
     ``_executor``），复用 ``_timeout_scan_once`` 的 cancel+force_done 模板。
-    ``BcnDownlinkService.handle_chat_abort`` 经组装根既有 seam 委派该面。
+    ``BcnDownlinkService.handle_chat_abort`` 经组装根既有 seam 委派该面。群聊多
+    bot 共享同一 ``session_id`` 时，仅取消目标 bot 的 RUNNING run，不影响其它 bot。
     """
 
-    async def abort_runs_by_session(self, session_id: str) -> AbortOutcome:
-        """取消 session 下所有未终结（PENDING/RUNNING）的 run。
+    async def abort_runs_by_session(
+        self, session_id: str, bot_id: str
+    ) -> AbortOutcome:
+        """取消目标 bot 在该 session 下所有 RUNNING 的 run。
 
-        顺序（与 ``_timeout_scan_once`` 一致）：先 ``update_error`` 标 FAILED，
-        再 ``queue.force_done(run_id)``，最后对本机 task ``running_task.cancel()``。
-        非本机 RUNNING run 无法本机 cancel，由 force_done + engine 通知 + 对端
-        超时/心跳兜底（与 timeout 同构）。engine 通知（``BotWebsocketClient.chat_abort``）
-        为 best-effort，失败仅记录日志。
+        维度收窄到 ``(bot_id, session_id)``，PENDING 不动（由 ``_timeout_scan_once``
+        超时路径兜底）。顺序（与 ``_timeout_scan_once`` 一致）：先 ``update_error``
+        标 FAILED，再 ``queue.force_done(run_id)``，最后对本机 task
+        ``running_task.cancel()``。非本机 RUNNING run 无法本机 cancel，由 force_done
+        + engine 通知 + 对端超时/心跳兜底（与 timeout 同构）。engine 通知
+        （``BotWebsocketClient.chat_abort``）为 best-effort，失败仅记录日志。
         """
         ...

--- a/src/baas/src/secbaas/community/core/service/bot_run/_worker.py
+++ b/src/baas/src/secbaas/community/core/service/bot_run/_worker.py
@@ -287,8 +287,10 @@ class BotRequestWorker:
 
     # ----------------------------- chat.abort 接入面 -----------------------------
 
-    async def abort_runs_by_session(self, session_id: str) -> AbortOutcome:
-        """按 session_id 取消所有未终结（PENDING/RUNNING）的 run。
+    async def abort_runs_by_session(
+        self, session_id: str, bot_id: str
+    ) -> AbortOutcome:
+        """按 (bot_id, session_id) 维度取消目标 bot 的 RUNNING run。
 
         复用 ``_timeout_scan_once`` 的 cancel+force_done 模板，顺序：
         1. ``run_repository.update_error(run_id, ...)`` 标 FAILED（幂等：已终态时 no-op）；
@@ -296,19 +298,22 @@ class BotRequestWorker:
         3. 若 ``assigned_worker == 本 worker``，cancel 本机 ``_running_tasks[run_id]``；
         4. best-effort 通知 engine（``engine_abort_notifier``），失败仅记录日志。
 
-        非本机 RUNNING run 无法本机 cancel，由 force_done + engine 通知 + 对端
-        超时/心跳兜底（与 timeout 同构）。``update_error`` 与 ``force_done`` 均幂等，
-        abort 与 timeout 并发争抢同一 run 时靠幂等收敛到同一终态（R1）。
+        群聊多 bot 共享同一 ``session_id`` 时仅取消目标 bot 的 RUNNING run；PENDING
+        不命中（由 ``_timeout_scan_once`` 超时路径兜底）。非本机 RUNNING run 无法本机
+        cancel，由 force_done + engine 通知 + 对端超时/心跳兜底（与 timeout 同构）。
+        ``update_error`` 与 ``force_done`` 均幂等，abort 与 timeout 并发争抢同一 run
+        时靠幂等收敛到同一终态（R1）。
 
         Returns:
-            AbortOutcome: 被取消的 run_id 列表，以及 session 下是否存在已终结记录。
+            AbortOutcome: 被取消的 run_id 列表，以及目标 bot 在该 session 下是否存在
+            已终结记录（用于 410 vs 200 判定，维度收窄到该 bot）。
         """
-        if not session_id:
+        if not session_id or not bot_id:
             return AbortOutcome(aborted_run_ids=[], had_terminal=False)
 
-        records = self._queue.find_running_by_session(session_id)
+        records = self._queue.find_running_by_bot_session(session_id, bot_id)
         if not records:
-            terminals = self._queue.find_terminal_by_session(session_id)
+            terminals = self._queue.find_terminal_by_bot_session(session_id, bot_id)
             return AbortOutcome(aborted_run_ids=[], had_terminal=bool(terminals))
 
         aborted_run_ids: list[str] = []
@@ -339,22 +344,25 @@ class BotRequestWorker:
                     )
             aborted_run_ids.append(run_id)
             logger.info(
-                "[BotRequestWorker] abort run_id=%s session_id=%s status=%s "
-                "worker=%s marked failed+force_done",
+                "[BotRequestWorker] abort run_id=%s session_id=%s bot_id=%s "
+                "status=%s worker=%s marked failed+force_done",
                 run_id,
                 session_id,
+                bot_id,
                 record.status,
                 record.assigned_worker,
             )
 
-        # 4. best-effort 通知 engine（一次session 级通知，run_id 取首个）
+        # 4. best-effort 通知 engine（一次 维度通知，run_id 取首个）
         if self._engine_abort_notifier is not None and aborted_run_ids:
             try:
                 await self._engine_abort_notifier(session_id, aborted_run_ids[0])
             except Exception as e:
                 logger.warning(
-                    "[BotRequestWorker] abort engine notify failed session_id=%s: %s",
+                    "[BotRequestWorker] abort engine notify failed session_id=%s "
+                    "bot_id=%s: %s",
                     session_id,
+                    bot_id,
                     e,
                     exc_info=True,
                 )

--- a/src/baas/tests/e2e/asgi/baseline/test_bcn_downlink_extended.py
+++ b/src/baas/tests/e2e/asgi/baseline/test_bcn_downlink_extended.py
@@ -619,3 +619,45 @@ class TestChatAbort:
         assert body["ok"] is True
         assert body["aborted"] is False
         assert body["aborted_run_ids"] == []
+
+    @pytest.mark.asyncio
+    async def test_chat_abort_group_chat_passes_provider_bot_ref(
+        self, api: APITestHelper, _testclient_app
+    ) -> None:
+        """群聊 abort：router 透传 to_bot.provider_bot_ref，service 收到的 ChatAbortInput.to_bot.provider_bot_ref 与 body 一致。"""
+        from secbaas.community.api.bcn import ChatAbortResult
+
+        class _CapturingService:
+            async def handle_chat_abort(self, input_):
+                captured["input"] = input_
+                return ChatAbortResult(aborted=True, aborted_run_ids=["run-a"])
+
+        captured: dict = {}
+        downlink_route = next(
+            route
+            for route in iter_api_routes(_testclient_app)
+            if route.path == _BCN_DOWNLINK_URL
+        )
+        dep_key = next(
+            dependency.call
+            for dependency in downlink_route.dependant.dependencies
+            if dependency.name == "service"
+        )
+        _testclient_app.dependency_overrides[dep_key] = lambda: _CapturingService()
+        body = dict(self._CHAT_ABORT_BODY)
+        body["to_bot"] = {
+            "provider_id": "baas",
+            "provider_bot_ref": "bot-A",
+        }
+        try:
+            response = await api.client.post(
+                _BCN_DOWNLINK_URL,
+                json=body,
+                headers=_VALID_HEADERS,
+            )
+        finally:
+            _testclient_app.dependency_overrides.pop(dep_key, None)
+
+        assert response.status_code == 200, response.text[:200]
+        assert captured["input"].to_bot.provider_bot_ref == "bot-A"
+        assert captured["input"].session_id == body["session_id"]

--- a/src/baas/tests/unit/core/repository/bot_run_queue/test_bot_run_queue.py
+++ b/src/baas/tests/unit/core/repository/bot_run_queue/test_bot_run_queue.py
@@ -337,3 +337,91 @@ def test_find_terminal_by_session_returns_done_only(
     # no-terminal session -> empty
     assert repo.find_terminal_by_session("no-such-session") == []
     assert repo.find_terminal_by_session("") == []
+
+
+# ---------------------------------------------------------------------------
+# find_running_by_bot_session / find_terminal_by_bot_session —— 群聊 bot 维度
+# ---------------------------------------------------------------------------
+
+
+def test_find_running_by_bot_session_only_returns_target_bot_running(
+    repo: OrmBotRunQueueRepository,
+):
+    """群聊多 bot 共 session：仅返回目标 bot 的 RUNNING，其它 bot 的 PENDING/RUNNING 不命中。"""
+    ra = _insert(repo, "bot-A", session_id="sess-group")
+    rb = _insert(repo, "bot-B", session_id="sess-group")
+    rc = _insert(repo, "bot-A", session_id="sess-group")  # 第二个 bot-A PENDING
+    # claim 各 bot 的第一条 -> RUNNING
+    claimed_a = repo.claim_pending_by_bot("bot-A", "wA")
+    claimed_b = repo.claim_pending_by_bot("bot-B", "wB")
+    assert claimed_a is not None and claimed_a.run_id == ra
+    assert claimed_b is not None and claimed_b.run_id == rb
+
+    running_a = repo.find_running_by_bot_session("sess-group", "bot-A")
+    assert [r.run_id for r in running_a] == [ra]
+    assert all(r.status == "RUNNING" for r in running_a)
+
+    running_b = repo.find_running_by_bot_session("sess-group", "bot-B")
+    assert [r.run_id for r in running_b] == [rb]
+
+    # 不存在的 bot
+    assert repo.find_running_by_bot_session("sess-group", "bot-none") == []
+    # 空入参
+    assert repo.find_running_by_bot_session("", "bot-A") == []
+    assert repo.find_running_by_bot_session("sess-group", "") == []
+
+
+def test_find_running_by_bot_session_excludes_pending_and_done(
+    repo: OrmBotRunQueueRepository,
+):
+    """find_running_by_bot_session 仅命中 RUNNING；PENDING 不动，DONE 不命中。"""
+    r_pending = _insert(repo, "bot-1", session_id="sess-abort")
+    r_running = _insert(repo, "bot-1", session_id="sess-abort")
+    r_done = _insert(repo, "bot-1", session_id="sess-abort")
+    # claim 顺序 FIFO：r_pending 先入队，先被 claim → RUNNING
+    claimed1 = repo.claim_pending_by_bot("bot-1", "w")
+    assert claimed1 is not None and claimed1.run_id == r_pending
+    claimed2 = repo.claim_pending_by_bot("bot-1", "w")
+    assert claimed2 is not None and claimed2.run_id == r_running
+    claimed3 = repo.claim_pending_by_bot("bot-1", "w")
+    assert claimed3 is not None and claimed3.run_id == r_done
+    # 把 r_done 置 DONE
+    assert repo.mark_done(r_done, "w") == 1
+
+    running = repo.find_running_by_bot_session("sess-abort", "bot-1")
+    run_ids = {r.run_id for r in running}
+    # 仅 RUNNING（r_pending, r_running），DONE 排除；PENDING 在此例被 claim 走了
+    assert run_ids == {r_pending, r_running}
+    assert all(r.status == "RUNNING" for r in running)
+
+
+def test_find_running_by_bot_session_pending_only_returns_empty(
+    repo: OrmBotRunQueueRepository,
+):
+    """PENDING-only record (not claimed) 命中空：超时扫描兜底，abort 不处理 PENDING。"""
+    _insert(repo, "bot-1", session_id="sess-abort")  # PENDING
+
+    assert repo.find_running_by_bot_session("sess-abort", "bot-1") == []
+
+
+def test_find_terminal_by_bot_session_returns_target_bot_done_only(
+    repo: OrmBotRunQueueRepository,
+):
+    """find_terminal_by_bot_session 维度收窄到目标 bot；其它 bot 的 DONE 不命中。"""
+    r_a = _insert(repo, "bot-A", session_id="sess-group")
+    r_b = _insert(repo, "bot-B", session_id="sess-group")
+    claimed_a = repo.claim_pending_by_bot("bot-A", "wA")
+    claimed_b = repo.claim_pending_by_bot("bot-B", "wB")
+    assert claimed_a is not None and claimed_a.run_id == r_a
+    assert claimed_b is not None and claimed_b.run_id == r_b
+    assert repo.mark_done(r_a, "wA") == 1
+    assert repo.mark_done(r_b, "wB") == 1
+
+    terminals_a = repo.find_terminal_by_bot_session("sess-group", "bot-A")
+    assert [r.run_id for r in terminals_a] == [r_a]
+    terminals_b = repo.find_terminal_by_bot_session("sess-group", "bot-B")
+    assert [r.run_id for r in terminals_b] == [r_b]
+    # 不存在 / 空入参
+    assert repo.find_terminal_by_bot_session("sess-group", "bot-none") == []
+    assert repo.find_terminal_by_bot_session("", "bot-A") == []
+    assert repo.find_terminal_by_bot_session("sess-group", "") == []

--- a/src/baas/tests/unit/core/service/bcn/test_bcn_service.py
+++ b/src/baas/tests/unit/core/service/bcn/test_bcn_service.py
@@ -850,7 +850,9 @@ async def test_handle_chat_abort_success(service_with_abort, mock_abort_surface)
 
     assert result.aborted is True
     assert result.aborted_run_ids == ["run-a", "run-b"]
-    mock_abort_surface.abort_runs_by_session.assert_awaited_once_with("session-abort-1")
+    mock_abort_surface.abort_runs_by_session.assert_awaited_once_with(
+        "session-abort-1", "bot-1"
+    )
 
 
 @pytest.mark.asyncio
@@ -905,6 +907,42 @@ async def test_handle_chat_abort_no_run_record_returns_aborted_false(
 async def test_handle_chat_abort_no_surface_returns_aborted_false(service):
     """When no abort_surface wired, best-effort returns aborted=false (no raise)."""
     result = await service.handle_chat_abort(_make_chat_abort_input())
+
+    assert result.aborted is False
+    assert result.aborted_run_ids == []
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_abort_passes_provider_bot_ref_as_bot_id(
+    service_with_abort, mock_abort_surface
+):
+    """abort_runs_by_session 的 bot_id 入参取自 to_bot.provider_bot_ref。"""
+    mock_abort_surface.abort_runs_by_session.return_value = AbortOutcome(
+        aborted_run_ids=["run-x"], had_terminal=False
+    )
+    alt_input = _make_chat_abort_input(
+        to_bot=BotRef(provider_id="baas", provider_bot_ref="bot-other")
+    )
+
+    result = await service_with_abort.handle_chat_abort(alt_input)
+
+    assert result.aborted is True
+    mock_abort_surface.abort_runs_by_session.assert_awaited_once_with(
+        "session-abort-1", "bot-other"
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_chat_abort_group_chat_410_narrowed_to_target_bot(
+    service_with_abort, mock_abort_surface
+):
+    """群聊：目标 bot 在该 session 无终态记录时返回 200，不被其它 bot 的终态记录影响。"""
+    # 模拟 worker 只在 bot-A 维度判 had_terminal=False
+    mock_abort_surface.abort_runs_by_session.return_value = AbortOutcome(
+        aborted_run_ids=[], had_terminal=False
+    )
+
+    result = await service_with_abort.handle_chat_abort(_make_chat_abort_input())
 
     assert result.aborted is False
     assert result.aborted_run_ids == []

--- a/src/baas/tests/unit/core/service/bot_run/test_worker.py
+++ b/src/baas/tests/unit/core/service/bot_run/test_worker.py
@@ -1059,7 +1059,7 @@ async def test_abort_runs_by_session_marks_failed_force_done_and_cancels_local_t
     worker = _worker(queue, repo, ex, run_repository=repo)
     worker._running_tasks[run_id] = task
 
-    outcome = await worker.abort_runs_by_session("sess-abort")
+    outcome = await worker.abort_runs_by_session("sess-abort", "bot-1")
 
     await asyncio.sleep(0)  # let CancelledError propagate
     assert outcome.aborted_run_ids == [run_id]
@@ -1067,22 +1067,24 @@ async def test_abort_runs_by_session_marks_failed_force_done_and_cancels_local_t
     assert cancelled.is_set(), "local task must be cancelled"
     assert repo.get_by_run_id(run_id).status == "FAILED"
     assert queue.get_by_run_id(run_id).status == "DONE"
-    # idempotent: aborted run no longer in find_running_by_session
-    assert worker._queue.find_running_by_session("sess-abort") == []
+    # idempotent: aborted run no longer in find_running_by_bot_session
+    assert worker._queue.find_running_by_bot_session("sess-abort", "bot-1") == []
 
 
-async def test_abort_runs_by_session_pending_record_marked_failed(repo, queue):
-    """PENDING record (not yet claimed) is also aborted (mark FAILED + force_done)."""
+async def test_abort_runs_by_session_pending_record_left_untouched(repo, queue):
+    """PENDING record (not yet claimed) is NOT aborted; only RUNNING is cancelled."""
     run_id = _insert_with_session(repo, queue, "bot-1", "sess-abort")
 
     ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
     worker = _worker(queue, repo, ex, run_repository=repo)
 
-    outcome = await worker.abort_runs_by_session("sess-abort")
+    outcome = await worker.abort_runs_by_session("sess-abort", "bot-1")
 
-    assert outcome.aborted_run_ids == [run_id]
-    assert repo.get_by_run_id(run_id).status == "FAILED"
-    assert queue.get_by_run_id(run_id).status == "DONE"
+    assert outcome.aborted_run_ids == []
+    assert outcome.had_terminal is False
+    # PENDING 不动，由超时扫描兜底
+    assert queue.get_by_run_id(run_id).status == "PENDING"
+    assert repo.get_by_run_id(run_id).status != "FAILED"
 
 
 async def test_abort_runs_by_session_no_run_record_returns_aborted_false(repo, queue):
@@ -1090,7 +1092,7 @@ async def test_abort_runs_by_session_no_run_record_returns_aborted_false(repo, q
     ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
     worker = _worker(queue, repo, ex, run_repository=repo)
 
-    outcome = await worker.abort_runs_by_session("no-such-session")
+    outcome = await worker.abort_runs_by_session("no-such-session", "bot-1")
 
     assert outcome.aborted_run_ids == []
     assert outcome.had_terminal is False
@@ -1106,26 +1108,28 @@ async def test_abort_runs_by_session_terminal_record_had_terminal_true(repo, que
     ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
     worker = _worker(queue, repo, ex, run_repository=repo)
 
-    outcome = await worker.abort_runs_by_session("sess-abort")
+    outcome = await worker.abort_runs_by_session("sess-abort", "bot-1")
 
     assert outcome.aborted_run_ids == []
     assert outcome.had_terminal is True
 
 
-async def test_abort_runs_by_session_empty_session_returns_empty(repo, queue):
-    """Empty session_id short-circuits to empty outcome."""
+async def test_abort_runs_by_session_empty_session_or_bot_returns_empty(repo, queue):
+    """Empty session_id or bot_id short-circuits to empty outcome."""
     ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
     worker = _worker(queue, repo, ex, run_repository=repo)
 
-    outcome = await worker.abort_runs_by_session("")
-
-    assert outcome.aborted_run_ids == []
-    assert outcome.had_terminal is False
+    assert (await worker.abort_runs_by_session("", "bot-1")).aborted_run_ids == []
+    assert (await worker.abort_runs_by_session("sess", "")).aborted_run_ids == []
+    out = await worker.abort_runs_by_session("", "")
+    assert out.aborted_run_ids == [] and out.had_terminal is False
 
 
 async def test_abort_runs_by_session_engine_notifier_best_effort(repo, queue):
-    """engine_abort_notifier is awaited once per session; failure is logged, not raised."""
+    """engine_abort_notifier is awaited once per (bot,session); failure logged, not raised."""
     run_id = _insert_with_session(repo, queue, "bot-1", "sess-abort")
+    claimed = queue.claim_pending_by_bot("bot-1", "worker-1", candidates=5)
+    assert claimed is not None and claimed.run_id == run_id
 
     notified = asyncio.Event()
 
@@ -1139,7 +1143,7 @@ async def test_abort_runs_by_session_engine_notifier_best_effort(repo, queue):
         queue, repo, ex, run_repository=repo, engine_abort_notifier=notifier
     )
 
-    outcome = await worker.abort_runs_by_session("sess-abort")
+    outcome = await worker.abort_runs_by_session("sess-abort", "bot-1")
 
     assert outcome.aborted_run_ids == [run_id]
     assert notified.is_set()
@@ -1148,6 +1152,8 @@ async def test_abort_runs_by_session_engine_notifier_best_effort(repo, queue):
 async def test_abort_runs_by_session_engine_notifier_error_swallowed(repo, queue):
     """engine_abort_notifier raising must not fail the abort."""
     run_id = _insert_with_session(repo, queue, "bot-1", "sess-abort")
+    claimed = queue.claim_pending_by_bot("bot-1", "worker-1", candidates=5)
+    assert claimed is not None and claimed.run_id == run_id
 
     async def notifier(session_id: str, rid: str | None) -> None:
         raise RuntimeError("engine notify boom")
@@ -1157,7 +1163,7 @@ async def test_abort_runs_by_session_engine_notifier_error_swallowed(repo, queue
         queue, repo, ex, run_repository=repo, engine_abort_notifier=notifier
     )
 
-    outcome = await worker.abort_runs_by_session("sess-abort")
+    outcome = await worker.abort_runs_by_session("sess-abort", "bot-1")
 
     assert outcome.aborted_run_ids == [run_id]
     assert repo.get_by_run_id(run_id).status == "FAILED"
@@ -1189,9 +1195,115 @@ async def test_abort_runs_by_session_without_run_repo_skips_update_error(repo, q
     worker = _worker(queue, repo, ex)
     worker._running_tasks[run_id] = task
 
-    outcome = await worker.abort_runs_by_session("sess-abort")
+    outcome = await worker.abort_runs_by_session("sess-abort", "bot-1")
 
     await asyncio.sleep(0)
     assert outcome.aborted_run_ids == [run_id]
     assert cancelled.is_set()
     assert queue.get_by_run_id(run_id).status == "DONE"
+
+
+# ── bot 维度收窄：群聊多 bot 共 session 不误杀 ──────────────────────
+
+
+async def test_abort_runs_by_session_group_chat_other_bot_running_not_killed(
+    repo, queue
+):
+    """群聊：abort bot-A，同 session 下 bot-B 的 RUNNING run 不被取消。"""
+    run_a = _insert_with_session(repo, queue, "bot-A", "sess-group")
+    run_b = _insert_with_session(repo, queue, "bot-B", "sess-group")
+    # 各自 claim -> RUNNING
+    claimed_a = queue.claim_pending_by_bot("bot-A", "wA", candidates=5)
+    claimed_b = queue.claim_pending_by_bot("bot-B", "wB", candidates=5)
+    assert claimed_a is not None and claimed_a.run_id == run_a
+    assert claimed_b is not None and claimed_b.run_id == run_b
+
+    ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
+    worker = _worker(queue, repo, ex, run_repository=repo)
+
+    outcome = await worker.abort_runs_by_session("sess-group", "bot-A")
+
+    assert outcome.aborted_run_ids == [run_a]
+    # bot-B 的 RUNNING run 不受影响
+    assert queue.get_by_run_id(run_b).status == "RUNNING"
+    assert repo.get_by_run_id(run_b).status != "FAILED"
+
+
+async def test_abort_runs_by_session_group_chat_target_bot_no_running_410_dimension(
+    repo, queue
+):
+    """群聊：abort bot-A，bot-A 无 RUNNING 但 bot-B 有 -> 不影响任何 run，按 bot-A 维度判 410/200。"""
+    _run_a = _insert_with_session(repo, queue, "bot-A", "sess-group")
+    run_b = _insert_with_session(repo, queue, "bot-B", "sess-group")
+    # bot-B claim 成 RUNNING；bot-A 仍是 PENDING（不会命中 find_running_by_bot_session）
+    claimed_b = queue.claim_pending_by_bot("bot-B", "wB", candidates=5)
+    assert claimed_b is not None and claimed_b.run_id == run_b
+
+    ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
+    worker = _worker(queue, repo, ex, run_repository=repo)
+
+    outcome = await worker.abort_runs_by_session("sess-group", "bot-A")
+
+    assert outcome.aborted_run_ids == []
+    assert outcome.had_terminal is False  # bot-A 自己在该 session 无终态记录
+    # bot-B RUNNING run 不受影响
+    assert queue.get_by_run_id(run_b).status == "RUNNING"
+    # bot-A PENDING 也不动
+    assert queue.get_by_run_id(_run_a).status == "PENDING"
+
+
+async def test_abort_runs_by_session_had_terminal_narrowed_to_target_bot(
+    repo, queue
+):
+    """410 维度收窄到目标 bot：其它 bot 的终态记录不影响该 bot 的 410 判定。"""
+    # bot-B 在该 session 有一条 DONE 记录
+    run_b = _insert_with_session(repo, queue, "bot-B", "sess-group")
+    claimed_b = queue.claim_pending_by_bot("bot-B", "wB", candidates=5)
+    assert claimed_b is not None and claimed_b.run_id == run_b
+    assert queue.mark_done(run_b, "wB") == 1
+
+    ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
+    worker = _worker(queue, repo, ex, run_repository=repo)
+
+    # abort bot-A：bot-A 无任何记录 -> aborted=false, had_terminal=False（不被 bot-B 的 DONE 影响）
+    outcome = await worker.abort_runs_by_session("sess-group", "bot-A")
+    assert outcome.aborted_run_ids == []
+    assert outcome.had_terminal is False
+
+    # abort bot-B：bot-B 有 DONE 记录 -> had_terminal=True（410）
+    outcome_b = await worker.abort_runs_by_session("sess-group", "bot-B")
+    assert outcome_b.aborted_run_ids == []
+    assert outcome_b.had_terminal is True
+
+
+async def test_abort_runs_by_session_calls_repo_with_bot_session_args(repo, queue):
+    """repository 调用收窄到 (session_id, bot_id) 维度（spy 模式断言调用参数）。"""
+    run_id = _insert_with_session(repo, queue, "bot-1", "sess-abort")
+    claimed = queue.claim_pending_by_bot("bot-1", "worker-1", candidates=5)
+    assert claimed is not None and claimed.run_id == run_id
+
+    ex = ResultGuardExecutor(_CompletingExecutor(repo), repo)
+    worker = _worker(queue, repo, ex, run_repository=repo)
+
+    find_running_calls: list[tuple[str, str]] = []
+    find_terminal_calls: list[tuple[str, str]] = []
+    orig_running = worker._queue.find_running_by_bot_session
+    orig_terminal = worker._queue.find_terminal_by_bot_session
+
+    def spy_running(session_id: str, bot_id: str):
+        find_running_calls.append((session_id, bot_id))
+        return orig_running(session_id, bot_id)
+
+    def spy_terminal(session_id: str, bot_id: str):
+        find_terminal_calls.append((session_id, bot_id))
+        return orig_terminal(session_id, bot_id)
+
+    worker._queue.find_running_by_bot_session = spy_running  # type: ignore[assignment]
+    worker._queue.find_terminal_by_bot_session = spy_terminal  # type: ignore[assignment]
+
+    outcome = await worker.abort_runs_by_session("sess-abort", "bot-1")
+
+    assert outcome.aborted_run_ids == [run_id]
+    assert find_running_calls == [("sess-abort", "bot-1")]
+    # 有可取消 run 时不调用 find_terminal_by_bot_session
+    assert find_terminal_calls == []


### PR DESCRIPTION
## Summary

Narrow `chat.abort` for the BCN downlink from a session-level fan-out to a
`(bot_id, session_id)` dimension. In group chats where multiple bots share
the same `session_id`, abort previously cancelled every non-terminal run in
that session, including runs belonging to other bots. After this change only
the target bot's `RUNNING` runs are cancelled.

## Behavior change (P1 / Breaking)

`chat.abort` is now bot-scoped: it cancels only `RUNNING` runs of the target
bot (`to_bot.provider_bot_ref`) within the session.

- BCN downlink callers that relied on session-level fan-out cancellation must
  issue abort per bot.
- `PENDING` runs are no longer touched by abort; they fall back to the
  existing `_timeout_scan_once` timeout path, consistent with the timeout
  pipeline.
- The 410 `run_terminated` vs 200 `{aborted: false}` distinction now keys off
  the target bot's terminal records, so a terminal record from another bot in
  the same session can no longer force a 410 for an abort that has no
  target-bot runs.

## Changes

- `repository/bot_run_queue/_orm_repository.py`,
  `repository/bot_run_queue/_protocol.py`: add
  `find_running_by_bot_session` / `find_terminal_by_bot_session`, mirroring
  the existing session-only queries but scoped to `(bot_id, session_id)`.
- `service/bot_run/_internal_protocols.py`: document the new dimension on
  `AbortOutcome` and update `BotRunAbortSurface.abort_runs_by_session` to
  accept `bot_id`.
- `service/bot_run/_worker.py`: `BotRequestWorker.abort_runs_by_session` now
  requires `bot_id`, routes to the new repository queries, and logs the
  bot dimension. The legacy session-only repository methods are intentionally
  retained so existing e2e/unit tests are not broken.
- `service/bcn/_bcn_service.py`: `handle_chat_abort` resolves
  `bot_id = to_bot.provider_bot_ref`, forwards it to the abort surface, and
  updates logging and docstrings.
- `docs/2026-09-01-bcn-downlink-chat-abort-bot-dimension-semantics.md`: design
  note describing the new semantics for BCN downlink callers.

## Concurrency / safety

`update_error` and `force_done` remain idempotent. Concurrent abort and
timeout racing the same run converge on the same terminal state via
idempotency (R1). Non-local `RUNNING` runs that cannot be cancelled on this
worker are still handled by `force_done` + best-effort engine notification +
peer timeout/heartbeat fallback, identical to the timeout pipeline.

## Tests

Unit and e2e baseline coverage for:

- New `(bot_id, session_id)` repository queries.
- Worker abort path passing `bot_id`, including empty-`bot_id` short-circuit.
- BCN service 410 / 200 / abort branches under group-chat multi-bot
  conditions.

No new test failures. The pre-existing mypy baseline errors are unchanged in
kind; this change adds only two same-kind `untyped-decorator` warnings on the
new repository methods.

## Review notes

Three P3 (non-blocking) review findings are acknowledged:

- The in-repo design doc is the mitigation surface for the behavior change;
  no module CHANGELOG convention exists in this repository.
- The legacy session-only repository methods are retained intentionally; a
  future refactor may consolidate or explicitly deprecate them once e2e tests
  are migrated.
- The step-4 engine notification remains `session_id` + `run_id` scoped
  (`run_id` uniquely identifies the bot via the queue row); the updated
  wording in the worker docstring is a comment-only nuance.