### PR TITLE
chore(backend): log lazy materialization stage timings

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/_mutation_flow.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/_mutation_flow.py
@@ -10,6 +10,7 @@ the two services cannot drift.
 
 from __future__ import annotations
 
+import time
 from collections.abc import Callable, Sequence
 
 from agentclaw.community.core.bot_management.readiness import is_bot_ready
@@ -31,6 +32,10 @@ from agentclaw.community.core.skills_pool.mapping_intent import (
     retired_logical_skill_mappings,
 )
 from agentclaw.community.core.skills_pool.models import PoolSkillMapping
+from agentclaw.community.log import get_logger
+
+
+logger = get_logger()
 
 
 def skill_claim_scope(result: DesiredStateMutation) -> ProjectionScope:
@@ -141,23 +146,48 @@ class MutationProjectionFlow:
         if not is_bot_ready(bot):
             raise LocalSkillNotReadyError()
         owner_id = str(bot["owner_id"])
+        snapshot_started_at = time.perf_counter()
         previous_mappings = await self._runtime.snapshot_skill_mappings(
             bot_id=bot_id,
             owner_id=owner_id,
         )
+        self._log_timing(
+            stage="snapshot_before",
+            bot_id=bot_id,
+            engine_type=engine_type,
+            started_at=snapshot_started_at,
+            mapping_count=len(previous_mappings),
+        )
+        mutation_started_at = time.perf_counter()
         result = mutation()
+        self._log_timing(
+            stage="desired_state_mutation",
+            bot_id=bot_id,
+            engine_type=engine_type,
+            started_at=mutation_started_at,
+            changed=result.changed,
+            mcp_delta_count=len(result.mcp_codes),
+        )
         if skip_projection_when_unchanged and not result.changed:
             return {**result.item, "changed": False, **result.details}
         effective_scope = (
             scope_from_result(result) if scope_from_result is not None else scope
         )
         assert effective_scope is not None  # guaranteed by the check above
+        reconciliation_started_at = time.perf_counter()
         await self._project_or_compensate(
             bot_id=bot_id,
             owner_id=owner_id,
             engine_type=engine_type,
             mutation=result,
             previous_mappings=previous_mappings,
+            scope=effective_scope,
+        )
+        self._log_timing(
+            stage="runtime_reconcile",
+            bot_id=bot_id,
+            engine_type=engine_type,
+            started_at=reconciliation_started_at,
             scope=effective_scope,
         )
         return {**result.item, "changed": result.changed, **result.details}
@@ -174,10 +204,20 @@ class MutationProjectionFlow:
     ) -> None:
         current_mappings: Sequence[PoolSkillMapping] = ()
         try:
+            snapshot_started_at = time.perf_counter()
             current_mappings = await self._runtime.snapshot_skill_mappings(
                 bot_id=bot_id,
                 owner_id=owner_id,
             )
+            self._log_timing(
+                stage="snapshot_after",
+                bot_id=bot_id,
+                engine_type=engine_type,
+                started_at=snapshot_started_at,
+                mapping_count=len(current_mappings),
+                scope=scope,
+            )
+            projection_started_at = time.perf_counter()
             await self._runtime.project(
                 bot_id=bot_id,
                 owner_id=owner_id,
@@ -185,6 +225,13 @@ class MutationProjectionFlow:
                     list(previous_mappings),
                     list(current_mappings),
                 ),
+                scope=scope,
+            )
+            self._log_timing(
+                stage="runtime_projection",
+                bot_id=bot_id,
+                engine_type=engine_type,
+                started_at=projection_started_at,
                 scope=scope,
             )
         except Exception as exc:
@@ -209,3 +256,30 @@ class MutationProjectionFlow:
             except Exception as restore_error:
                 raise SkillSetRuntimeReconcileError() from restore_error
             raise SkillSetRuntimeReconcileError() from exc
+
+    @staticmethod
+    def _log_timing(
+        *,
+        stage: str,
+        bot_id: str,
+        engine_type: str | None,
+        started_at: float,
+        mapping_count: int | None = None,
+        changed: bool | None = None,
+        mcp_delta_count: int | None = None,
+        scope: ProjectionScope | None = None,
+    ) -> None:
+        logger.info(
+            "[MutationProjectionFlow] timing stage=%s bot_id=%s engine_type=%s "
+            "duration_ms=%s mapping_count=%s changed=%s mcp_delta_count=%s "
+            "scope_skills=%s scope_mcp=%s",
+            stage,
+            bot_id,
+            engine_type,
+            round((time.perf_counter() - started_at) * 1000),
+            mapping_count,
+            changed,
+            mcp_delta_count,
+            scope.skills if scope is not None else None,
+            scope.mcp if scope is not None else None,
+        )

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_reference_processor.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_reference_processor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
+import time
 
 from agentclaw.community.core.repository.protocols.skill_center_reference import (
     SkillCenterReferenceRepositoryProtocol,
@@ -68,6 +69,10 @@ _PUBLIC_REFERENCE_ERRORS = {
 }
 
 
+def _duration_ms(started_at: float) -> int:
+    return round((time.perf_counter() - started_at) * 1000)
+
+
 class SkillCenterReferenceProcessor:
     """Materialize independently, then commit successful members in one batch."""
 
@@ -93,6 +98,7 @@ class SkillCenterReferenceProcessor:
         self._max_concurrency = max_concurrency
 
     async def process(self, request_id: str) -> TaskOutcome:
+        batch_started_at = time.perf_counter()
         batch = self._references.get_work_batch(
             env=self._env_provider(), request_id=request_id
         )
@@ -109,14 +115,40 @@ class SkillCenterReferenceProcessor:
                 SkillCenterReferenceStatus.PROJECTING_RUNTIME,
             }
         ]
+        logger.info(
+            "[SkillCenterReference] batch materialization started: request_id=%s "
+            "env=%s item_count=%s pending_count=%s max_concurrency=%s",
+            batch.request_id,
+            batch.env,
+            len(batch.items),
+            len(pending),
+            self._max_concurrency,
+        )
         semaphore = asyncio.Semaphore(self._max_concurrency)
 
         async def run(item: SkillCenterReferenceWorkItem) -> bool:
             async with semaphore:
                 return await asyncio.to_thread(self._materialize_one, batch, item)
 
+        materialization_started_at = time.perf_counter()
         retry_required = any(await asyncio.gather(*(run(item) for item in pending)))
+        logger.info(
+            "[SkillCenterReference] batch materialization barrier completed: "
+            "request_id=%s env=%s pending_count=%s retry_required=%s duration_ms=%s",
+            batch.request_id,
+            batch.env,
+            len(pending),
+            retry_required,
+            _duration_ms(materialization_started_at),
+        )
         if retry_required:
+            logger.info(
+                "[SkillCenterReference] batch processing deferred for retry: "
+                "request_id=%s env=%s duration_ms=%s",
+                batch.request_id,
+                batch.env,
+                _duration_ms(batch_started_at),
+            )
             return Retry("one or more Reference items need another attempt")
 
         latest = self._references.get_work_batch(
@@ -133,8 +165,23 @@ class SkillCenterReferenceProcessor:
             }
         ]
         if not ready:
+            logger.info(
+                "[SkillCenterReference] batch processing completed without final add: "
+                "request_id=%s env=%s duration_ms=%s",
+                batch.request_id,
+                batch.env,
+                _duration_ms(batch_started_at),
+            )
             return Complete()
         await self._add_ready(latest, ready)
+        logger.info(
+            "[SkillCenterReference] batch processing completed: request_id=%s env=%s "
+            "ready_count=%s duration_ms=%s",
+            batch.request_id,
+            batch.env,
+            len(ready),
+            _duration_ms(batch_started_at),
+        )
         return Complete()
 
     def _materialize_one(
@@ -142,6 +189,7 @@ class SkillCenterReferenceProcessor:
         batch: SkillCenterReferenceWorkBatch,
         item: SkillCenterReferenceWorkItem,
     ) -> bool:
+        started_at = time.perf_counter()
         current = self._references.update_item(
             env=batch.env,
             reference_id=item.reference_id,
@@ -203,6 +251,8 @@ class SkillCenterReferenceProcessor:
                 error_code=None,
                 error_message=None,
             )
+            resolution_ms = _duration_ms(started_at)
+            materialization_started_at = time.perf_counter()
             published = self._materializer.materialize(
                 SkillVersionMaterializationRequest(
                     env=batch.env,
@@ -211,10 +261,13 @@ class SkillCenterReferenceProcessor:
                     scope=SkillCenterReadScope.PUBLIC,
                 )
             )
+            materialization_ms = _duration_ms(materialization_started_at)
             # Re-ensure the level-triggered task even when another Reference
             # already published this exact Version.  This closes the accepted
             # post-commit enqueue window without creating a second event model.
+            track_latest_started_at = time.perf_counter()
             self._track_latest.version_published(published)
+            track_latest_ms = _duration_ms(track_latest_started_at)
             self._references.update_item(
                 env=batch.env,
                 reference_id=item.reference_id,
@@ -224,6 +277,21 @@ class SkillCenterReferenceProcessor:
                 resolved_skill_id=target.skill_id,
                 error_code=None,
                 error_message=None,
+            )
+            logger.info(
+                "[SkillCenterReference] item materialized: request_id=%s env=%s "
+                "reference_id=%s skill_code=%s skill_id=%s skill_version_id=%s "
+                "resolution_ms=%s materialization_ms=%s track_latest_ms=%s duration_ms=%s",
+                batch.request_id,
+                batch.env,
+                item.reference_id,
+                item.skill_code,
+                target.skill_id,
+                target.skill_version_id,
+                resolution_ms,
+                materialization_ms,
+                track_latest_ms,
+                _duration_ms(started_at),
             )
             return False
         except _PermanentReferenceError as exc:
@@ -262,13 +330,14 @@ class SkillCenterReferenceProcessor:
             logger.warning(
                 "[SkillCenterReference] materialization failure: operation=reference_materialization "
                 "env=%s scope=public reference_id=%s skill_code=%s skill_version_id=%s "
-                "failure_stage=%s cause_type=%s",
+                "failure_stage=%s cause_type=%s duration_ms=%s",
                 batch.env,
                 item.reference_id,
                 item.skill_code,
                 current.skill_version_id,
                 exc.stage or "unknown",
                 type(cause).__name__ if cause is not None else type(exc).__name__,
+                _duration_ms(started_at),
             )
             return self._retry_or_fail(
                 batch.env, current, "MATERIALIZATION_FAILED"
@@ -277,12 +346,13 @@ class SkillCenterReferenceProcessor:
             logger.warning(
                 "[SkillCenterReference] invalid materialization facts: "
                 "operation=reference_materialization env=%s scope=public "
-                "reference_id=%s skill_code=%s skill_version_id=%s failure_type=%s",
+                "reference_id=%s skill_code=%s skill_version_id=%s failure_type=%s duration_ms=%s",
                 batch.env,
                 item.reference_id,
                 item.skill_code,
                 current.skill_version_id,
                 type(exc).__name__,
+                _duration_ms(started_at),
             )
             self._fail(batch.env, item.reference_id, "MATERIALIZATION_FAILED")
             return False
@@ -292,6 +362,10 @@ class SkillCenterReferenceProcessor:
         batch: SkillCenterReferenceWorkBatch,
         ready: list[SkillCenterReferenceWorkItem],
     ) -> None:
+        started_at = time.perf_counter()
+        skill_ids = tuple(
+            sorted((str(item.resolved_skill_id) for item in ready), key=int)
+        )
         try:
             target = self._skill_sets.get_set(
                 bot_id=batch.bot_id,
@@ -306,6 +380,15 @@ class SkillCenterReferenceProcessor:
                         reference_id=item.reference_id,
                         status=SkillCenterReferenceStatus.PROJECTING_RUNTIME,
                     )
+            logger.info(
+                "[SkillCenterReference] final SkillSet add started: request_id=%s env=%s "
+                "skill_set_id=%s ready_count=%s runtime_projection_required=%s",
+                batch.request_id,
+                batch.env,
+                batch.skill_set_id,
+                len(ready),
+                bool(target.get("is_active") or target.get("is_default")),
+            )
             outcomes = await self._skill_sets.add_skills(
                 bot_id=batch.bot_id,
                 owner_id=batch.owner_id,
@@ -315,11 +398,7 @@ class SkillCenterReferenceProcessor:
                 # ready in a different order on each replay. The batch has set
                 # semantics, but sorting its numeric IDs keeps the wire and
                 # idempotent observability stable.
-                skill_ids=tuple(
-                    sorted(
-                        (str(item.resolved_skill_id) for item in ready), key=int
-                    )
-                ),
+                skill_ids=skill_ids,
             )
         except (
             SkillOfflineError,
@@ -329,8 +408,9 @@ class SkillCenterReferenceProcessor:
             SkillSetRuntimeReconcileError,
         ) as exc:
             logger.exception(
-                "[SkillCenterReference] final SkillSet add failed: request_id=%s",
+                "[SkillCenterReference] final SkillSet add failed: request_id=%s duration_ms=%s",
                 batch.request_id,
+                _duration_ms(started_at),
             )
             code = _final_add_error_code(exc)
             for item in ready:
@@ -338,6 +418,7 @@ class SkillCenterReferenceProcessor:
             return
 
         by_skill_id = {outcome.skill_id: outcome for outcome in outcomes}
+        succeeded_count = 0
         for item in ready:
             skill_id = str(item.resolved_skill_id)
             outcome = by_skill_id.get(skill_id)
@@ -361,6 +442,18 @@ class SkillCenterReferenceProcessor:
                 error_code=None,
                 error_message=None,
             )
+            succeeded_count += 1
+        logger.info(
+            "[SkillCenterReference] final SkillSet add completed: request_id=%s env=%s "
+            "skill_set_id=%s ready_count=%s succeeded_count=%s skill_ids=%s duration_ms=%s",
+            batch.request_id,
+            batch.env,
+            batch.skill_set_id,
+            len(ready),
+            succeeded_count,
+            skill_ids,
+            _duration_ms(started_at),
+        )
 
     def _retry_or_fail(
         self,

--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_materializer.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_version_materializer.py
@@ -9,6 +9,7 @@ import json
 import logging
 from pathlib import Path
 import tempfile
+import time
 from typing import Callable
 from urllib.parse import urlsplit
 
@@ -67,6 +68,10 @@ def _response_metadata(response: object) -> tuple[int | None, str | None]:
     headers = getattr(response, "headers", None)
     content_type = headers.get("content-type") if hasattr(headers, "get") else None
     return status_code, content_type if isinstance(content_type, str) else None
+
+
+def _duration_ms(started_at: float) -> int:
+    return round((time.perf_counter() - started_at) * 1000)
 
 
 def _json_value(value: object) -> object:
@@ -202,10 +207,25 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
         self, request: SkillVersionMaterializationRequest
     ) -> PublishedMaterializedSkillVersion:
         stage = "target_read"
+        started_at = time.perf_counter()
+        stage_started_at = started_at
+        stage_durations_ms: dict[str, int] = {}
+
+        def advance_stage(next_stage: str) -> None:
+            nonlocal stage, stage_started_at
+            stage_durations_ms[stage] = _duration_ms(stage_started_at)
+            stage = next_stage
+            stage_started_at = time.perf_counter()
+
+        def finish_stage() -> None:
+            stage_durations_ms[stage] = _duration_ms(stage_started_at)
+
         target: MaterializingSkillVersion | None = None
         download_host: str | None = None
         download_path: str | None = None
         response: object | None = None
+        package_bytes: bytes | None = None
+        package: ValidatedSkillPackage | None = None
         try:
             target = self._versions.get_materialization_target(
                 env=request.env,
@@ -222,14 +242,25 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
             if target.sc_skill_id < 1 or target.sc_version_id < 1:
                 raise ValueError("exact SC identity is incomplete")
             if target.status == "PUBLISHED":
-                stage = "canonical_verify"
+                advance_stage("canonical_verify")
                 if not self._store.verify_version(ref):
                     raise ValueError(
                         "PUBLISHED Version has no verified canonical content"
                     )
-                return self._published_target(target)
+                published = self._published_target(target)
+                finish_stage()
+                self._log_success(
+                    request=request,
+                    target=target,
+                    duration_ms=_duration_ms(started_at),
+                    stage_durations_ms=stage_durations_ms,
+                    package_bytes=None,
+                    package_file_count=None,
+                    already_published=True,
+                )
+                return published
 
-            stage = "exact_download"
+            advance_stage("exact_download")
             exact = self._gateway.get_exact_download(
                 SkillCenterExactDownloadRequest(
                     skill_code=target.skill_code,
@@ -246,29 +277,29 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
                 raise ValueError("Skill Center returned a different exact Version")
             download_host, download_path = _safe_url_parts(exact.download_url)
             expected_digest = exact.sha256.lower()
-            stage = "package_download"
+            advance_stage("package_download")
             response = self._http.get(exact.download_url, timeout=30.0)
             response.raise_for_status()
             package_bytes = bytes(response.content)
-            stage = "digest_verify"
+            advance_stage("digest_verify")
             if hashlib.sha256(package_bytes).hexdigest() != expected_digest:
                 raise ValueError("downloaded package digest does not match SC")
 
-            stage = "package_validate"
+            advance_stage("package_validate")
             package = (
                 self._validator.validate_public_center_zip(package_bytes)
                 if request.scope is SkillCenterReadScope.PUBLIC
                 else self._validator.validate_zip(package_bytes)
             )
-            stage = "name_match"
+            advance_stage("name_match")
             if (
                 request.scope is not SkillCenterReadScope.PUBLIC
                 and package.name != target.name
             ):
                 raise ValueError("materialized SKILL.md name changed")
-            stage = "scanner"
+            advance_stage("scanner")
             scan = self._scanner.scan(package)
-            stage = "metadata_build"
+            advance_stage("metadata_build")
             dependencies = _dependencies(
                 tuple(scan.mcp_dependencies),
                 tuple(
@@ -298,13 +329,13 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
                 sort_keys=True,
             )
             version = CanonicalCenterVersion.from_files(identity, dict(package.files))
-            stage = "canonical_write"
+            advance_stage("canonical_write")
             written = self._store.write_version(version)
-            stage = "canonical_verify"
+            advance_stage("canonical_verify")
             if written != ref or not self._store.verify_version(ref):
                 raise ValueError("canonical exact Version did not verify")
-            stage = "publish"
-            return self._versions.publish_materialized(
+            advance_stage("publish")
+            published = self._versions.publish_materialized(
                 env=request.env,
                 skill_id=request.skill_id,
                 skill_version_id=request.skill_version_id,
@@ -313,7 +344,19 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
                 description=package.description,
                 published_at=self._clock(),
             )
+            finish_stage()
+            self._log_success(
+                request=request,
+                target=target,
+                duration_ms=_duration_ms(started_at),
+                stage_durations_ms=stage_durations_ms,
+                package_bytes=len(package_bytes),
+                package_file_count=len(package.files),
+                already_published=False,
+            )
+            return published
         except SkillVersionMaterializationError as exc:
+            finish_stage()
             self._log_failure(
                 request=request,
                 target=target,
@@ -322,11 +365,14 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
                 download_host=download_host,
                 download_path=download_path,
                 response=response,
+                duration_ms=_duration_ms(started_at),
+                stage_durations_ms=stage_durations_ms,
             )
             if exc.stage is not None:
                 raise
             raise SkillVersionMaterializationError(str(exc), stage=stage) from exc
         except Exception as exc:
+            finish_stage()
             self._log_failure(
                 request=request,
                 target=target,
@@ -335,6 +381,8 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
                 download_host=download_host,
                 download_path=download_path,
                 response=response,
+                duration_ms=_duration_ms(started_at),
+                stage_durations_ms=stage_durations_ms,
             )
             raise SkillVersionMaterializationError(str(exc), stage=stage) from exc
 
@@ -348,6 +396,8 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
         download_host: str | None,
         download_path: str | None,
         response: object | None,
+        duration_ms: int,
+        stage_durations_ms: Mapping[str, int],
     ) -> None:
         """Emit correlation facts without serializing exception text or download URLs."""
         http_status, http_content_type = _response_metadata(response)
@@ -371,6 +421,8 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
             "http_status": http_status,
             "http_content_type": http_content_type,
             "failure_type": failure_type,
+            "duration_ms": duration_ms,
+            "stage_durations_ms": json.dumps(stage_durations_ms, sort_keys=True),
         }
         logger.warning(
             "skill_center_materialization_failed "
@@ -381,7 +433,47 @@ class SkillVersionMaterializer(SkillVersionMaterializerProtocol):
             "sc_skill_id=%(sc_skill_id)s sc_version_id=%(sc_version_id)s "
             "download_host=%(download_host)s download_path=%(download_path)s "
             "http_status=%(http_status)s http_content_type=%(http_content_type)s "
-            "failure_type=%(failure_type)s",
+            "failure_type=%(failure_type)s duration_ms=%(duration_ms)s "
+            "stage_durations_ms=%(stage_durations_ms)s",
+            diagnostics,
+            extra=diagnostics,
+        )
+
+    @staticmethod
+    def _log_success(
+        *,
+        request: SkillVersionMaterializationRequest,
+        target: MaterializingSkillVersion,
+        duration_ms: int,
+        stage_durations_ms: Mapping[str, int],
+        package_bytes: int | None,
+        package_file_count: int | None,
+        already_published: bool,
+    ) -> None:
+        diagnostics = {
+            "operation": "skill_version_materialization",
+            "env": request.env,
+            "scope": request.scope.value,
+            "team_id": request.team_id,
+            "skill_id": request.skill_id,
+            "skill_version_id": request.skill_version_id,
+            "skill_uuid": target.skill_uuid,
+            "skill_code": target.skill_code,
+            "sc_version_number": target.sc_version_number,
+            "duration_ms": duration_ms,
+            "stage_durations_ms": json.dumps(stage_durations_ms, sort_keys=True),
+            "package_bytes": package_bytes,
+            "package_file_count": package_file_count,
+            "already_published": already_published,
+        }
+        logger.info(
+            "skill_center_materialization_succeeded "
+            "operation=%(operation)s env=%(env)s scope=%(scope)s team_id=%(team_id)s "
+            "skill_id=%(skill_id)s skill_version_id=%(skill_version_id)s "
+            "skill_uuid=%(skill_uuid)s skill_code=%(skill_code)s "
+            "sc_version_number=%(sc_version_number)s duration_ms=%(duration_ms)s "
+            "stage_durations_ms=%(stage_durations_ms)s package_bytes=%(package_bytes)s "
+            "package_file_count=%(package_file_count)s already_published=%(already_published)s",
             diagnostics,
             extra=diagnostics,
         )


### PR DESCRIPTION
## Problem
Lazy SkillCenter materialization previously exposed only one scanner duration and the terminal batch status, so the post-download tail could not be attributed to individual materialization, final SkillSet add, or runtime projection.

## Solution
Add safe duration-only logs for exact Version stages, per-Reference resolution/materialization/Track Latest, batch barriers, final SkillSet add, and mutation/projection sub-stages. The logs retain correlation IDs and counts but never emit presigned download URLs or package content.

## Validation
- `uv run ruff check` for the three changed Backend modules: passed.
- `uv run pytest -q tests/community/core/skill_center/test_skill_version_materializer.py tests/community/core/skill_center/test_skill_center_reference_processor.py`: 17 passed.
- `git diff --check`: passed.

## Compatibility and risk
No API, schema, status-machine, queue, or projection behavior changes. This adds INFO/WARN observability only; the added log volume is proportional to materialization stages and control-plane projection calls.