### PR TITLE
fix(backend): avoid Lua renewal for SkillCenter sync

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_sync_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/skill_center_sync_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-import threading
+import time
 
 from agentclaw.community.core.repository.protocols.skill_center_reference import (
     SkillCenterReferenceRepositoryProtocol,
@@ -68,6 +68,7 @@ class SkillCenterSyncService(LifecycleBase, SkillCenterSyncServiceProtocol):
         cache: CachePlugin,
         env_provider: Callable[[], str] = get_current_env,
         interval_seconds: int = 30 * 60,
+        monotonic: Callable[[], float] = time.monotonic,
     ) -> None:
         if interval_seconds < 1:
             raise ValueError("interval_seconds must be positive")
@@ -78,6 +79,7 @@ class SkillCenterSyncService(LifecycleBase, SkillCenterSyncServiceProtocol):
         self._cache = cache
         self._env_provider = env_provider
         self._interval_seconds = interval_seconds
+        self._monotonic = monotonic
         self._periodic_task: asyncio.Task | None = None
 
     async def startup(self) -> None:
@@ -90,6 +92,10 @@ class SkillCenterSyncService(LifecycleBase, SkillCenterSyncServiceProtocol):
     def sync(self) -> SkillCenterSyncSummary:
         env = self._env_provider()
         lock_key = f"skill-center-public-sync:{env}"
+        # Start the local budget before SET NX EX. The cache TTL starts while
+        # acquiring the lock, so this may shorten a batch but cannot extend it
+        # beyond the actual cross-worker lease.
+        lease_started = self._monotonic()
         try:
             lock_value = self._cache.acquire_lock_strict(
                 lock_key, ttl=_SYNC_LOCK_TTL_SECONDS
@@ -98,108 +104,54 @@ class SkillCenterSyncService(LifecycleBase, SkillCenterSyncServiceProtocol):
             raise SkillCenterSyncUnavailableError("SYNC_COORDINATOR_UNAVAILABLE") from exc
         if lock_value is None:
             raise SkillCenterSyncInProgressError("SYNC_IN_PROGRESS")
-        stop_renewal = threading.Event()
-        lease_error: list[Exception] = []
-
-        def renew_lease() -> None:
-            while not stop_renewal.wait(_SYNC_LOCK_TTL_SECONDS / 3):
-                try:
-                    if not self._cache.renew_lock_strict(
-                        lock_key,
-                        lock_value,
-                        ttl=_SYNC_LOCK_TTL_SECONDS,
-                    ):
-                        lease_error.append(
-                            SkillCenterSyncInProgressError("SYNC_LOCK_LOST")
-                        )
-                        return
-                except Exception as exc:
-                    lease_error.append(exc)
-                    return
-
-        renewal = threading.Thread(
-            target=renew_lease,
-            name="skill-center-public-sync-lock-renewal",
-            daemon=True,
-        )
-        renewal.start()
-        try:
-            assets = self._assets.list_materialized_public_assets(env=env)
-            updated = 0
-            unchanged = 0
-            failures: list[SkillCenterSyncFailure] = []
-            for asset in assets:
-                # This is a best-effort batch boundary, not transactional
-                # fencing. If renewal fails while _sync_asset is running, that
-                # exact/idempotent item may finish; the next boundary stops
-                # subsequent items and reports the coordinator failure.
-                self._renew_or_raise(
-                    lock_key=lock_key,
-                    lock_value=lock_value,
-                    lease_error=lease_error,
+        lease_deadline = lease_started + _SYNC_LOCK_TTL_SECONDS
+        # This cache adapter has no atomic compare-and-delete, so this fixed
+        # lease is not released early. Its TTL is the only safe cross-worker
+        # handoff point.
+        assets = self._assets.list_materialized_public_assets(env=env)
+        scanned = 0
+        updated = 0
+        unchanged = 0
+        failures: list[SkillCenterSyncFailure] = []
+        for asset in assets:
+            # The cache adapter supports fixed-TTL acquisition but not
+            # token-checked renewal, so this coordinator deliberately follows
+            # GitSync's fixed-TTL lease pattern. Exact materialization is
+            # idempotent at an asset boundary; stop before beginning a new
+            # asset once the lease has expired.
+            if self._monotonic() >= lease_deadline:
+                logger.warning(
+                    "[SkillCenterSync] lease budget exhausted; deferring "
+                    "remaining public assets to the next reconciliation"
                 )
-                try:
-                    changed = self._sync_asset(env=env, asset=asset)
-                    if changed:
-                        updated += 1
-                    else:
-                        unchanged += 1
-                except (
-                    SkillCenterGatewayError,
-                    SkillVersionMaterializationError,
-                    _SkillCenterSyncAssetError,
-                    ValueError,
-                ) as exc:
-                    failures.append(
-                        SkillCenterSyncFailure(
-                            skill_id=str(asset.skill_id),
-                            skill_code=asset.skill_code,
-                            error_code=_sync_error_code(exc),
-                        )
+                break
+            scanned += 1
+            try:
+                changed = self._sync_asset(env=env, asset=asset)
+                if changed:
+                    updated += 1
+                else:
+                    unchanged += 1
+            except (
+                SkillCenterGatewayError,
+                SkillVersionMaterializationError,
+                _SkillCenterSyncAssetError,
+                ValueError,
+            ) as exc:
+                failures.append(
+                    SkillCenterSyncFailure(
+                        skill_id=str(asset.skill_id),
+                        skill_code=asset.skill_code,
+                        error_code=_sync_error_code(exc),
                     )
-            if lease_error:
-                self._raise_lease_error(lease_error[0])
-            return SkillCenterSyncSummary(
-                scanned=len(assets),
-                updated=updated,
-                unchanged=unchanged,
-                failed=len(failures),
-                failures=tuple(failures),
-            )
-        finally:
-            stop_renewal.set()
-            renewal.join(timeout=1)
-            self._cache.release_lock(lock_key, lock_value)
-
-    def _renew_or_raise(
-        self,
-        *,
-        lock_key: str,
-        lock_value: str,
-        lease_error: list[Exception],
-    ) -> None:
-        if lease_error:
-            self._raise_lease_error(lease_error[0])
-        try:
-            renewed = self._cache.renew_lock_strict(
-                lock_key,
-                lock_value,
-                ttl=_SYNC_LOCK_TTL_SECONDS,
-            )
-        except CacheLockInfrastructureError as exc:
-            raise SkillCenterSyncUnavailableError(
-                "SYNC_COORDINATOR_UNAVAILABLE"
-            ) from exc
-        if not renewed:
-            raise SkillCenterSyncInProgressError("SYNC_LOCK_LOST")
-
-    @staticmethod
-    def _raise_lease_error(error: Exception) -> None:
-        if isinstance(error, SkillCenterSyncInProgressError):
-            raise error
-        raise SkillCenterSyncUnavailableError(
-            "SYNC_COORDINATOR_UNAVAILABLE"
-        ) from error
+                )
+        return SkillCenterSyncSummary(
+            scanned=scanned,
+            updated=updated,
+            unchanged=unchanged,
+            failed=len(failures),
+            failures=tuple(failures),
+        )
 
     async def sync_bootstrap(self) -> SkillCenterSyncSummary:
         try:

--- a/src/backend/tests/community/core/skill_center/test_materialized_center_sync.py
+++ b/src/backend/tests/community/core/skill_center/test_materialized_center_sync.py
@@ -111,9 +111,8 @@ class _TrackLatest:
 
 
 class _Cache:
-    def __init__(self, *, lock_value="lock-token", renew_ok=True) -> None:
+    def __init__(self, *, lock_value="lock-token") -> None:
         self.lock_value = lock_value
-        self.renew_ok = renew_ok
         self.released = []
         self.renewed = []
 
@@ -126,7 +125,7 @@ class _Cache:
 
     def renew_lock_strict(self, key, value, ttl):
         self.renewed.append((key, value, ttl))
-        return self.renew_ok
+        return True
 
 
 class _UnavailableCache(_Cache):
@@ -135,18 +134,13 @@ class _UnavailableCache(_Cache):
 
 
 class _RenewUnavailableCache(_Cache):
-    def renew_lock_strict(self, key, value, ttl):
-        raise CacheLockInfrastructureError("redis renew endpoint details")
-
-
-class _SequencedRenewCache(_Cache):
-    def __init__(self, renewals: list[bool]) -> None:
+    def __init__(self) -> None:
         super().__init__()
-        self._renewals = iter(renewals)
+        self.renew_attempts = 0
 
     def renew_lock_strict(self, key, value, ttl):
-        self.renewed.append((key, value, ttl))
-        return next(self._renewals)
+        self.renew_attempts += 1
+        raise CacheLockInfrastructureError("redis renew endpoint details")
 
 
 def test_sync_continues_after_one_failure_and_tracks_only_new_published_version() -> None:
@@ -172,7 +166,7 @@ def test_sync_continues_after_one_failure_and_tracks_only_new_published_version(
     assert summary.failures[0].skill_id == "20"
     assert len(materializer.calls) == 1
     assert len(track_latest.calls) == 1
-    assert len(service._cache.renewed) == 2
+    assert service._cache.renewed == []
 
 
 def test_manual_sync_returns_stable_conflict_when_distributed_lock_is_held() -> None:
@@ -221,52 +215,43 @@ def test_startup_cache_outage_is_deferred_to_periodic_retry() -> None:
     assert summary.scanned == summary.failed == 0
 
 
-def test_manual_sync_maps_cache_renewal_outage_to_stable_unavailable_error() -> None:
+def test_sync_does_not_require_unsupported_lock_renewal() -> None:
+    materializer = _Materializer()
     service = SkillCenterSyncService(
         assets=_Assets(),
         gateway=_Gateway(),
-        materializer=_Materializer(),
+        materializer=materializer,
         track_latest=_TrackLatest(),
         cache=_RenewUnavailableCache(),
         env_provider=lambda: "pre",
     )
 
-    with pytest.raises(SkillCenterSyncUnavailableError):
-        service.sync()
+    summary = service.sync()
 
-
-def test_sync_stops_before_the_first_item_when_lease_loss_is_observed() -> None:
-    materializer = _Materializer()
-    service = SkillCenterSyncService(
-        assets=_Assets(),
-        gateway=_Gateway(),
-        materializer=materializer,
-        track_latest=_TrackLatest(),
-        cache=_Cache(renew_ok=False),
-        env_provider=lambda: "pre",
-    )
-
-    with pytest.raises(SkillCenterSyncInProgressError, match="SYNC_LOCK_LOST"):
-        service.sync()
-
-    assert materializer.calls == []
-
-
-def test_sync_allows_current_idempotent_item_then_stops_after_lease_loss() -> None:
-    materializer = _Materializer()
-    service = SkillCenterSyncService(
-        assets=_Assets(),
-        gateway=_Gateway(),
-        materializer=materializer,
-        track_latest=_TrackLatest(),
-        cache=_SequencedRenewCache([True, False]),
-        env_provider=lambda: "pre",
-    )
-
-    with pytest.raises(SkillCenterSyncInProgressError, match="SYNC_LOCK_LOST"):
-        service.sync()
-
+    assert summary.scanned == 2
     assert len(materializer.calls) == 1
+    assert service._cache.renew_attempts == 0
+    assert service._cache.renewed == []
+
+
+def test_sync_defers_remaining_assets_after_fixed_lease_expires() -> None:
+    materializer = _Materializer()
+    ticks = iter((0.0, 0.0, float(30 * 60)))
+    service = SkillCenterSyncService(
+        assets=_Assets(),
+        gateway=_Gateway(),
+        materializer=materializer,
+        track_latest=_TrackLatest(),
+        cache=_Cache(),
+        env_provider=lambda: "pre",
+        monotonic=lambda: next(ticks),
+    )
+
+    summary = service.sync()
+
+    assert summary.scanned == 1
+    assert len(materializer.calls) == 1
+    assert service._cache.released == []
 
 
 def test_published_exact_version_reensures_track_latest_before_unchanged() -> None:
@@ -321,9 +306,7 @@ def test_lifecycle_bootstrap_reconciles_once_then_starts_and_stops_periodic_task
         assert service._periodic_task is None
 
     asyncio.run(run_lifecycle())
-    assert cache.released == [
-        ("skill-center-public-sync:pre", "lock-token")
-    ]
+    assert cache.released == []
 
 
 @pytest.mark.parametrize(
@@ -350,6 +333,4 @@ def test_sync_propagates_persistence_failure_instead_of_returning_success(
     with pytest.raises(type(error), match="database unavailable"):
         service.sync()
 
-    assert cache.released == [
-        ("skill-center-public-sync:pre", "lock-token")
-    ]
+    assert cache.released == []


### PR DESCRIPTION
## Problem

Pre-release ZCache supports `SET NX EX` but rejects Redis Lua `EVAL`. `SkillCenterSyncService` renewed its coordination lease before processing every public asset, so periodic reconciliation failed with `SYNC_COORDINATOR_UNAVAILABLE` before any SC work began.

## Solution

Use the existing fixed-TTL lock pattern used by GitSync: retain strict `SET NX EX` acquisition, remove renewal calls and the renewal thread, and stop before starting another asset once the fixed lease expires. Use `time.monotonic()` from before lock acquisition to keep the local budget conservative. Do not release early: ZCache lacks atomic compare-and-delete, so TTL is the safe cross-worker handoff point.

## Validation

- Focused SkillCenter sync, DI, and module-boundary tests: 16 passed.
- Ruff and `git diff --check`: passed.
- Standards and Spec reviews: no remaining high-priority findings after fixes.
- Community full suite was started as final validation; stopped after 489 passing tests at 2% because it is materially long-running locally. GitHub CI is required for the full result.

## Compatibility and risk

No public API, schema, or Plugin API change. A short completed reconciliation now leaves the 30-minute lock until TTL expiry, so a manually requested immediate second reconciliation can return `SYNC_IN_PROGRESS`; periodic work remains level-triggered and resumes after lease expiry.