### PR TITLE
fix(cron): drop owner_id/bot_id from cron.add wire params

### DIFF
--- a/src/engine/src/engine/community/api/cron/router.py
+++ b/src/engine/src/engine/community/api/cron/router.py
@@ -163,10 +163,6 @@ async def create_task(request: CreateTaskRequest):
             "message": request.command,
             "timeout_secs": request.timeout_secs if request.timeout_secs is not None else 86400
         }
-        if request.owner_id:
-            payload["owner_id"] = request.owner_id
-        if request.bot_id:
-            payload["bot_id"] = request.bot_id
         if request.model:
             payload["model"] = request.model  # 指定AI模型
         if request.runtime:

--- a/src/engine/src/engine/community/api/tests/test_cron_router.py
+++ b/src/engine/src/engine/community/api/tests/test_cron_router.py
@@ -187,8 +187,8 @@ class TestCreateTask:
         assert call_args.owner_id == "owner-1"
         assert call_args.bot_id == "bot-1"
         assert call_args.payload["model"] == "gpt-4o"
-        assert call_args.payload["owner_id"] == "owner-1"
-        assert call_args.payload["bot_id"] == "bot-1"
+        assert "owner_id" not in call_args.payload
+        assert "bot_id" not in call_args.payload
         assert call_args.payload["timeout_secs"] == 120
         assert call_args.notify is not None
         assert call_args.notify.user_ids == ["u1", "u2"]
@@ -221,8 +221,8 @@ class TestCreateTask:
         call_args = mock_cron_api.add_job.call_args[0][0]
         assert call_args.owner_id == "owner-2"
         assert call_args.bot_id == "bot-2"
-        assert call_args.payload["owner_id"] == "owner-2"
-        assert call_args.payload["bot_id"] == "bot-2"
+        assert "owner_id" not in call_args.payload
+        assert "bot_id" not in call_args.payload
 
     def test_service_error_returns_500(self, client, mock_cron_api):
         mock_cron_api.add_job.side_effect = RuntimeError("storage error")

--- a/src/engine/src/engine/community/core/adapters/claude_code/cron.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/cron.py
@@ -206,8 +206,6 @@ def _build_add_params(request: CreateJobRequest) -> dict[str, Any]:
         "name": request.name,
         "schedule": _schedule_for_wire(request.schedule),
         "payload": _convert_payload_for_wire(request.payload),
-        "owner_id": request.owner_id,
-        "bot_id": request.bot_id,
         "sessionTarget": request.session_target,
         "enabled": request.enabled,
         "delivery": _notify_to_delivery(request.notify),

--- a/src/engine/src/engine/community/core/adapters/claude_code/tests/test_adapters.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/tests/test_adapters.py
@@ -837,8 +837,8 @@ class TestCronAdapter:
         assert call["job"]["payload"]["timeoutSeconds"] == 30
         # schedule every → everyMs
         assert call["job"]["schedule"]["everyMs"] == 60000
-        assert call["job"]["owner_id"] == "owner-2"
-        assert call["job"]["bot_id"] == "bot-2"
+        assert "owner_id" not in call["job"]
+        assert "bot_id" not in call["job"]
 
     async def test_get_job_preserves_owner_and_bot_ids(self):
         adapter = ClaudeCodeCronAdapter(_FakeCronPort())

--- a/src/engine/src/engine/community/core/adapters/openclaw/cron.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/cron.py
@@ -254,8 +254,6 @@ def _build_add_params(request: CreateJobRequest) -> dict[str, Any]:
         "name": request.name,
         "schedule": openclaw_schedule,
         "payload": openclaw_payload,
-        "owner_id": request.owner_id,
-        "bot_id": request.bot_id,
         "sessionTarget": request.session_target,
         "enabled": request.enabled,
     }

--- a/src/engine/src/engine/community/core/adapters/openclaw/tests/test_cron.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/tests/test_cron.py
@@ -293,8 +293,8 @@ async def test_add_job_serialises_request_and_returns_cron_job():
     params = call["params"]
     assert params["name"] == "hourly"
     assert params["schedule"] == {"kind": "cron", "expr": "0 * * * *"}
-    assert params["owner_id"] == "owner-1"
-    assert params["bot_id"] == "bot-1"
+    assert "owner_id" not in params
+    assert "bot_id" not in params
     # delivery should be present (no notify → mode none, no accountId)
     assert params["delivery"]["mode"] == "none"
     assert "accountId" not in params["delivery"]


### PR DESCRIPTION
## 问题
PR #1586「fix(cron): propagate owner and bot context」把 `owner_id`/`bot_id` 放到了 cron.add 写路径上：
- `claude_code/cron.py`、`openclaw/cron.py` 的 `_build_add_params` 放到根级；
- `api/cron/router.py create_task` 注入到 `payload`。

但 relay 的 cron.add schema 是 `additionalProperties:false`（根级只接受 `{name,schedule,payload,sessionTarget,enabled,delivery}`，payload 只接受各 kind 分支的私有字段），会拒绝未知的 `owner_id`/`bot_id`，导致 CreateTask 返回 HTTP 500：

```
invalid cron.add params: at root: unexpected 'owner_id'; at root: unexpected 'bot_id';
at /payload: must have required property 'text'; at /payload: unexpected property 'message';
at /payload: unexpected property 'timeoutSeconds'; at /payload: unexpected property 'owner_id';
at /payload/kind: must be equal to constant; at /payload: must match a schema in anyOf
```

其中 `text`/`message`/`kind`/`timeoutSeconds` 是 payload 因多出 `owner_id` 失配后 anyOf 兜底报出的噪音，根因是 `owner_id`/`bot_id`。

owner/bot 上下文本就编码在命令串里（落到 `payload.message`：`user:<owner_id>` / `agent:<bot_id>`），relay 跑任务时从命令串解析——显式字段在写路径上冗余。

## 改动（6 个文件，仅 engine 写路径）
- `claude_code/cron.py` / `openclaw/cron.py`：`_build_add_params` 不再把 `owner_id`/`bot_id` 放到 cron.add 根级。
- `api/cron/router.py`：`create_task` 不再把 `owner_id`/`bot_id` 注入 `payload`。
- 三个测试文件：由「wire/payload 含 owner_id/bot_id」改为「不含」；DTO 层、读侧 round-trip 断言保留。
- DTO 层 `CreateTaskRequest`/`CreateJobRequest`/`CronJob` 的 `owner_id`/`bot_id`（additive/optional、不影响 relay）保留为未来 relay 支持时的接缝。

## 验证
engine cron 相关测试 161 passed。

## 复现路径
`default_engine` 归一到 `claude_code`（社区树 `engines/claude_code`）时：`POST /api/cron` -> `router.create_task` -> `get_cron_api()` -> `ClaudeCodeCronAdapter.add_job` -> `_build_add_params` -> `port.cron_add_job` -> relay `cron.add`。backend `cron_auto_setup` 走 `CronRelayService.forward_request` 打到同一 `/api/cron`。
