### PR TITLE
feat(bcs): add human mention notification plugin family

### DIFF
--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -309,6 +309,8 @@ dependencies = [
  "bcs-group",
  "bcs-group-store",
  "bcs-http",
+ "bcs-human-notify-api",
+ "bcs-human-notify-dummy",
  "bcs-interaction",
  "bcs-judge",
  "bcs-jwt",
@@ -1254,6 +1256,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bcs-human-notify-api"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bcs-config-api",
+ "bcs-service-api",
+ "futures",
+ "inventory",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "bcs-human-notify-dummy"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bcs-config-api",
+ "bcs-human-notify-api",
+ "bcs-service-api",
+ "bcs-test-support",
+ "futures",
+ "inventory",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "bcs-interaction"
 version = "0.1.0"
 dependencies = [
@@ -1826,6 +1855,7 @@ dependencies = [
  "bcs-cache-api",
  "bcs-db-api",
  "bcs-domain",
+ "bcs-human-notify-api",
  "bcs-llm-api",
  "bcs-service-api",
  "bcs-session",

--- a/src/bcs/Cargo.lock
+++ b/src/bcs/Cargo.lock
@@ -1261,7 +1261,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bcs-config-api",
- "bcs-service-api",
  "futures",
  "inventory",
  "thiserror 2.0.20",
@@ -1274,7 +1273,6 @@ dependencies = [
  "async-trait",
  "bcs-config-api",
  "bcs-human-notify-api",
- "bcs-service-api",
  "bcs-test-support",
  "futures",
  "inventory",

--- a/src/bcs/Cargo.toml
+++ b/src/bcs/Cargo.toml
@@ -68,6 +68,7 @@ members = [
     "crates/plugin-api/bcs-cache-api",
     "crates/plugin-api/bcs-channel-api",
     "crates/plugin-api/bcs-db-api",
+    "crates/plugin-api/bcs-human-notify-api",
     "crates/plugin-api/bcs-llm-api",
     "crates/plugin-api/bcs-security-gateway-api",
     "crates/plugin-api/bcs-secret-api",
@@ -80,6 +81,7 @@ members = [
     "crates/plugins/bcs-storage-local",
     "crates/plugins/bcs-db-local",
     "crates/plugins/bcs-db-mysql",
+    "crates/plugins/bcs-human-notify-dummy",
     "crates/plugins/bcs-llm-anthropic",
     "crates/plugins/bcs-llm-openai-compatible",
     "crates/plugins/bcs-secret-local",
@@ -304,6 +306,7 @@ bcs-system-message         = { path = "crates/services/bcs-system-message" }
 bcs-cache-api              = { path = "crates/plugin-api/bcs-cache-api" }
 bcs-channel-api            = { path = "crates/plugin-api/bcs-channel-api" }
 bcs-db-api                 = { path = "crates/plugin-api/bcs-db-api" }
+bcs-human-notify-api       = { path = "crates/plugin-api/bcs-human-notify-api" }
 bcs-llm-api                = { path = "crates/plugin-api/bcs-llm-api" }
 bcs-storage-api            = { path = "crates/plugin-api/bcs-storage-api" }
 bcs-storage-local          = { path = "crates/plugins/bcs-storage-local" }
@@ -314,6 +317,7 @@ bcs-cache-local            = { path = "crates/plugins/bcs-cache-local" }
 bcs-cache-redis            = { path = "crates/plugins/bcs-cache-redis" }
 bcs-db-local               = { path = "crates/plugins/bcs-db-local" }
 bcs-db-mysql               = { path = "crates/plugins/bcs-db-mysql" }
+bcs-human-notify-dummy     = { path = "crates/plugins/bcs-human-notify-dummy" }
 bcs-llm-anthropic          = { path = "crates/plugins/bcs-llm-anthropic" }
 bcs-llm-openai-compatible = { path = "crates/plugins/bcs-llm-openai-compatible" }
 bcs-secret-local           = { path = "crates/plugins/bcs-secret-local" }

--- a/src/bcs/configs/bcs-config-example.toml
+++ b/src/bcs/configs/bcs-config-example.toml
@@ -238,6 +238,20 @@ tower_http = "warn"
 # [user_directory.providers.<provider>].
 enabled = false
 
+# Human mention notification: notify human participants when a message
+# @-mentions them. Select a linked backend; omit `provider` to disable.
+[human_notify]
+provider = "dummy"
+
+[human_notify.providers.dummy]
+enabled = true
+# DingTalk backend options (internal builds), for illustration:
+# [human_notify.providers.dingtalk]
+# enabled = true
+# robot_code = "ding..."
+# client_id = "ding..."
+# client_secret = "${DINGTALK_NOTIFY_CLIENT_SECRET}"
+
 [auth]
 chain = ["oauth_session"]
 require_authentication = true

--- a/src/bcs/configs/bcs-config-local.toml
+++ b/src/bcs/configs/bcs-config-local.toml
@@ -182,6 +182,14 @@ use_remote_login_check = false
 # [user_directory.providers.<provider>].
 enabled = false
 
+# Human mention notification: notify human participants when a message
+# @-mentions them. Select a linked backend; omit `provider` to disable.
+[human_notify]
+provider = "dummy"
+
+[human_notify.providers.dummy]
+enabled = true
+
 [auth]
 chain = ["local", "session"]
 require_authentication = false

--- a/src/bcs/crates/bootstrap/bcs/Cargo.toml
+++ b/src/bcs/crates/bootstrap/bcs/Cargo.toml
@@ -131,6 +131,8 @@ bcs-system-message = { workspace = true }
 bcs-secret   = { workspace = true }
 bcs-secret-api = { workspace = true }
 bcs-secret-local = { workspace = true }
+bcs-human-notify-api = { workspace = true }
+bcs-human-notify-dummy = { workspace = true }
 ding-logger  = { workspace = true }
 bcs-http      = { workspace = true }
 bcs-api-http  = { workspace = true }

--- a/src/bcs/crates/bootstrap/bcs/src/config.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/config.rs
@@ -18,9 +18,9 @@ pub use bcs_config_api::{
 pub use bcs_config_api::{
     AuthChainConfig, AuthSdkConfig,
     ChannelConfigSection, DingTalkAccountConfig, EventingConfig, FusionProviderConfig,
-    LeaderElectionConfig, LlmConfig, LlmProviderType, LogOutputConfig, LogOutputFormat,
-    LoggingConfig, ManifestConfig, SecretConfig, SecurityConfig, StructuredOutputMode,
-    UserDirectoryConfig, UserDirectoryProviderConfig,
+    HumanNotifyConfig, LeaderElectionConfig, LlmConfig, LlmProviderType, LogOutputConfig,
+    LogOutputFormat, LoggingConfig, ManifestConfig, SecretConfig, SecurityConfig,
+    StructuredOutputMode, UserDirectoryConfig, UserDirectoryProviderConfig,
     deserialize_optional_secret, serialize_optional_secret,
 };
 #[allow(unused_imports)]
@@ -621,6 +621,10 @@ pub struct BcsConfig {
     #[serde(default)]
     pub channels: ChannelConfigSection,
 
+    /// Human mention notification configuration.
+    #[serde(default)]
+    pub human_notify: HumanNotifyConfig,
+
     /// HTTP provider webhook adapter configuration.
     #[serde(default)]
     pub provider_http: ProviderHttpConfig,
@@ -1115,6 +1119,7 @@ impl Default for BcsConfig {
             database: DatabaseConfig::default(),
             secret: SecretConfig::default(),
             channels: ChannelConfigSection::default(),
+            human_notify: HumanNotifyConfig::default(),
             provider_http: ProviderHttpConfig::default(),
             collaboration: CollaborationConfig::default(),
             openapi_v1: OpenApiV1Config::default(),
@@ -3140,5 +3145,23 @@ base_url = "https://directory.example.com"
                 "{label} config {path} still carries the legacy scalar `issuer` key",
             );
         }
+    }
+
+    #[test]
+    fn human_notify_section_parses() {
+        let config: BcsConfig = toml::from_str(
+            r#"
+bots_base_dir = "/tmp/bots"
+
+[human_notify]
+provider = "dummy"
+
+[human_notify.providers.dummy]
+enabled = true
+"#,
+        )
+        .expect("config parses");
+        assert_eq!(config.human_notify.provider.as_deref(), Some("dummy"));
+        assert!(config.human_notify.enabled_provider("dummy"));
     }
 }

--- a/src/bcs/crates/bootstrap/bcs/src/plugins.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/plugins.rs
@@ -21,6 +21,12 @@ use bcs_service_api::port::repo::ChannelBindingRepoPort;
 use bcs_user_directory_api::UserDirectoryPlugin;
 use futures::future::BoxFuture;
 
+// Force-link the built-in dummy notifier so its inventory registration is
+// retained in the final binary: this constant references the dummy build
+// function directly instead of relying on an elided unused import.
+const _: bcs_human_notify_api::HumanMentionNotifierBuild =
+    bcs_human_notify_dummy::build_dummy_notifier;
+
 use crate::config::{
     BcsConfig, DatabaseType, SecurityGatewayProviderConfig, UserDirectoryProviderConfig,
 };
@@ -282,6 +288,100 @@ pub fn build_registered_channel_provider(
         }
     }
     Ok(None)
+}
+
+/// Build the selected human mention notification port.
+///
+/// Returns a no-op port when the feature is not configured or the selected
+/// provider entry is disabled. Returns a startup error when the selected
+/// provider is not linked into this binary or its config is invalid.
+pub async fn build_human_mention_notify_port(
+    config: &BcsConfig,
+) -> crate::Result<Arc<dyn bcs_service_api::port::HumanMentionNotifyPort>> {
+    let Some(provider) = config.human_notify.provider.as_deref() else {
+        tracing::info!("human_notify disabled: no provider configured");
+        return Ok(Arc::new(bcs_service_api::port::NoopHumanMentionNotifyPort));
+    };
+    let Some(provider_config) = config.human_notify.providers.get(provider) else {
+        return Err(crate::BcsError::InvalidConfig(format!(
+            "human_notify.provider '{provider}' has no [human_notify.providers.{provider}] entry"
+        )));
+    };
+    if !provider_config.enabled {
+        tracing::info!(provider, "human_notify disabled: provider entry not enabled");
+        return Ok(Arc::new(bcs_service_api::port::NoopHumanMentionNotifyPort));
+    }
+    for factory in inventory::iter::<bcs_human_notify_api::HumanMentionNotifierFactory> {
+        if factory.name == provider {
+            let notifier = (factory.build)(provider_config.clone())
+                .await
+                .map_err(human_notify_build_error)?;
+            tracing::info!(provider, "human_notify backend selected");
+            return Ok(Arc::new(HumanMentionNotifyAdapter { notifier }));
+        }
+    }
+    Err(crate::BcsError::InvalidConfig(format!(
+        "human_notify.provider '{provider}' is not available in this binary"
+    )))
+}
+
+fn human_notify_build_error(error: bcs_human_notify_api::HumanNotifyError) -> crate::BcsError {
+    match error {
+        bcs_human_notify_api::HumanNotifyError::Config(message) => {
+            crate::BcsError::InvalidConfig(message)
+        }
+        bcs_human_notify_api::HumanNotifyError::Delivery(message) => {
+            crate::BcsError::StorageInitError(message)
+        }
+    }
+}
+
+const HUMAN_NOTIFY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Adapts a selected [`bcs_human_notify_api::HumanMentionNotifier`] to the
+/// service port. Swallows errors into logs and bounds runtime with a timeout.
+pub struct HumanMentionNotifyAdapter {
+    pub notifier: Arc<dyn bcs_human_notify_api::HumanMentionNotifier>,
+}
+
+#[async_trait::async_trait]
+impl bcs_service_api::port::HumanMentionNotifyPort for HumanMentionNotifyAdapter {
+    fn is_available(&self) -> bool {
+        true
+    }
+
+    async fn notify_mentioned_humans(
+        &self,
+        notification: bcs_service_api::port::human_notify::MentionNotification,
+    ) -> bcs_service_api::ServiceResult<()> {
+        let backend = self.notifier.backend_name();
+        let group_id = notification.group_id.clone();
+        let session_id = notification.session_id.clone();
+        match tokio::time::timeout(HUMAN_NOTIFY_TIMEOUT, self.notifier.notify(&notification)).await
+        {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(error)) => {
+                tracing::error!(
+                    backend,
+                    group_id = %group_id,
+                    session_id = %session_id,
+                    "human mention notification failed: {error}"
+                );
+                Err(bcs_service_api::ServiceError::InternalError(error.to_string()))
+            }
+            Err(_elapsed) => {
+                tracing::error!(
+                    backend,
+                    group_id = %group_id,
+                    session_id = %session_id,
+                    "human mention notification timed out"
+                );
+                Err(bcs_service_api::ServiceError::InternalError(
+                    "human mention notification timed out".to_string(),
+                ))
+            }
+        }
+    }
 }
 
 fn resolve_sqlite_path(config: &BcsConfig) -> String {
@@ -913,4 +1013,104 @@ mod tests {
         assert!(Arc::ptr_eq(&plugins.db().expect("db handle"), &db));
     }
 
+}
+
+#[cfg(test)]
+mod human_notify_selection_tests {
+    use super::*;
+
+    fn failing_notifier_factory(
+        _config: bcs_config_api::HumanNotifyProviderConfig,
+    ) -> futures::future::BoxFuture<
+        'static,
+        bcs_human_notify_api::HumanNotifyResult<Arc<dyn bcs_human_notify_api::HumanMentionNotifier>>,
+    > {
+        Box::pin(async move {
+            Err(bcs_human_notify_api::HumanNotifyError::Config(
+                "boom".to_string(),
+            ))
+        })
+    }
+
+    inventory::submit! {
+        bcs_human_notify_api::HumanMentionNotifierFactory {
+            name: "test-failing-notifier",
+            build: failing_notifier_factory,
+        }
+    }
+
+    fn config_with(provider: Option<&str>, entry: Option<(bool, &str)>) -> BcsConfig {
+        let mut config = BcsConfig::default();
+        config.human_notify.provider = provider.map(str::to_string);
+        if let Some((enabled, name)) = entry {
+            let mut provider_config = bcs_config_api::HumanNotifyProviderConfig::default();
+            provider_config.enabled = enabled;
+            config.human_notify.providers.insert(name.to_string(), provider_config);
+        }
+        config
+    }
+
+    #[tokio::test]
+    async fn unset_provider_selects_noop() {
+        let port = build_human_mention_notify_port(&config_with(None, None)).await.unwrap();
+        assert!(!port.is_available());
+    }
+
+    #[tokio::test]
+    async fn disabled_entry_selects_noop() {
+        let port = build_human_mention_notify_port(&config_with(Some("dummy"), Some((false, "dummy"))))
+            .await
+            .unwrap();
+        assert!(!port.is_available());
+    }
+
+    #[tokio::test]
+    async fn missing_provider_entry_is_startup_error() {
+        let error = match build_human_mention_notify_port(&config_with(Some("dummy"), None)).await
+        {
+            Ok(_) => panic!("missing entry must fail startup"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("human_notify.providers.dummy"));
+    }
+
+    #[tokio::test]
+    async fn unregistered_provider_is_startup_error() {
+        let error = match build_human_mention_notify_port(&config_with(
+            Some("missing-backend"),
+            Some((true, "missing-backend")),
+        ))
+        .await
+        {
+            Ok(_) => panic!("unregistered backend must fail startup"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("not available in this binary"));
+    }
+
+    #[tokio::test]
+    async fn failing_factory_is_startup_error() {
+        let error = match build_human_mention_notify_port(&config_with(
+            Some("test-failing-notifier"),
+            Some((true, "test-failing-notifier")),
+        ))
+        .await
+        {
+            Ok(_) => panic!("factory config error must fail startup"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, crate::BcsError::InvalidConfig(_)));
+        assert!(
+            error.to_string().contains("boom"),
+            "error must come from the registered failing factory: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dummy_backend_builds_available_port() {
+        let port = build_human_mention_notify_port(&config_with(Some("dummy"), Some((true, "dummy"))))
+            .await
+            .unwrap();
+        assert!(port.is_available());
+    }
 }

--- a/src/bcs/crates/bootstrap/bcs/src/plugins.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/plugins.rs
@@ -317,7 +317,7 @@ pub async fn build_human_mention_notify_port(
                 .await
                 .map_err(human_notify_build_error)?;
             tracing::info!(provider, "human_notify backend selected");
-            return Ok(Arc::new(HumanMentionNotifyAdapter { notifier }));
+            return Ok(Arc::new(HumanMentionNotifyAdapter::new(notifier)));
         }
     }
     Err(crate::BcsError::InvalidConfig(format!(
@@ -330,6 +330,9 @@ fn human_notify_build_error(error: bcs_human_notify_api::HumanNotifyError) -> cr
         bcs_human_notify_api::HumanNotifyError::Config(message) => {
             crate::BcsError::InvalidConfig(message)
         }
+        // A factory is expected to fail with `Config`; a `Delivery` here means
+        // the backend could not be initialized (e.g. reachability self-check),
+        // which is the same failure class as other plugin init failures.
         bcs_human_notify_api::HumanNotifyError::Delivery(message) => {
             crate::BcsError::StorageInitError(message)
         }
@@ -339,9 +342,20 @@ fn human_notify_build_error(error: bcs_human_notify_api::HumanNotifyError) -> cr
 const HUMAN_NOTIFY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Adapts a selected [`bcs_human_notify_api::HumanMentionNotifier`] to the
-/// service port. Swallows errors into logs and bounds runtime with a timeout.
+/// service port: translates the port DTO into the plugin-owned schema, logs
+/// errors, and bounds runtime with a timeout.
 pub struct HumanMentionNotifyAdapter {
     pub notifier: Arc<dyn bcs_human_notify_api::HumanMentionNotifier>,
+    pub timeout: std::time::Duration,
+}
+
+impl HumanMentionNotifyAdapter {
+    pub fn new(notifier: Arc<dyn bcs_human_notify_api::HumanMentionNotifier>) -> Self {
+        Self {
+            notifier,
+            timeout: HUMAN_NOTIFY_TIMEOUT,
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -357,7 +371,28 @@ impl bcs_service_api::port::HumanMentionNotifyPort for HumanMentionNotifyAdapter
         let backend = self.notifier.backend_name();
         let group_id = notification.group_id.clone();
         let session_id = notification.session_id.clone();
-        match tokio::time::timeout(HUMAN_NOTIFY_TIMEOUT, self.notifier.notify(&notification)).await
+        let mentioned_actors: Vec<String> = notification
+            .mentioned
+            .iter()
+            .map(|human| human.actor_id.clone())
+            .collect();
+        let plugin_notification = bcs_human_notify_api::MentionNotification {
+            session_id: notification.session_id,
+            group_id: notification.group_id,
+            sender_actor_id: notification.sender_actor_id,
+            sender_label: notification.sender_label,
+            mentioned: notification
+                .mentioned
+                .into_iter()
+                .map(|human| bcs_human_notify_api::MentionedHuman {
+                    actor_id: human.actor_id,
+                    display_name: human.display_name,
+                })
+                .collect(),
+            message_text: notification.message_text,
+            timestamp_ms: notification.timestamp_ms,
+        };
+        match tokio::time::timeout(self.timeout, self.notifier.notify(&plugin_notification)).await
         {
             Ok(Ok(())) => Ok(()),
             Ok(Err(error)) => {
@@ -365,6 +400,7 @@ impl bcs_service_api::port::HumanMentionNotifyPort for HumanMentionNotifyAdapter
                     backend,
                     group_id = %group_id,
                     session_id = %session_id,
+                    mentioned = ?mentioned_actors,
                     "human mention notification failed: {error}"
                 );
                 Err(bcs_service_api::ServiceError::InternalError(error.to_string()))
@@ -374,6 +410,7 @@ impl bcs_service_api::port::HumanMentionNotifyPort for HumanMentionNotifyAdapter
                     backend,
                     group_id = %group_id,
                     session_id = %session_id,
+                    mentioned = ?mentioned_actors,
                     "human mention notification timed out"
                 );
                 Err(bcs_service_api::ServiceError::InternalError(
@@ -1018,6 +1055,7 @@ mod tests {
 #[cfg(test)]
 mod human_notify_selection_tests {
     use super::*;
+    use bcs_service_api::port::HumanMentionNotifyPort;
 
     fn failing_notifier_factory(
         _config: bcs_config_api::HumanNotifyProviderConfig,
@@ -1112,5 +1150,98 @@ mod human_notify_selection_tests {
             .await
             .unwrap();
         assert!(port.is_available());
+    }
+
+    struct SlowNotifier;
+
+    #[async_trait::async_trait]
+    impl bcs_human_notify_api::HumanMentionNotifier for SlowNotifier {
+        fn backend_name(&self) -> &'static str {
+            "slow"
+        }
+
+        async fn notify(
+            &self,
+            _notification: &bcs_human_notify_api::MentionNotification,
+        ) -> bcs_human_notify_api::HumanNotifyResult<()> {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            Ok(())
+        }
+    }
+
+    fn port_notification() -> bcs_service_api::port::human_notify::MentionNotification {
+        bcs_service_api::port::human_notify::MentionNotification {
+            session_id: "group-1:s1".to_string(),
+            group_id: "group-1".to_string(),
+            sender_actor_id: "human_1".to_string(),
+            sender_label: "Human One".to_string(),
+            mentioned: vec![bcs_service_api::port::human_notify::MentionedHuman {
+                actor_id: "human_2".to_string(),
+                display_name: "Human Two".to_string(),
+            }],
+            message_text: "hello".to_string(),
+            timestamp_ms: 1_700_000_000_000,
+        }
+    }
+
+    #[tokio::test]
+    async fn adapter_bounds_runtime_with_timeout() {
+        let adapter = HumanMentionNotifyAdapter {
+            notifier: Arc::new(SlowNotifier),
+            timeout: std::time::Duration::from_millis(50),
+        };
+        let error = adapter
+            .notify_mentioned_humans(port_notification())
+            .await
+            .expect_err("slow backend must hit the timeout");
+        assert!(
+            error.to_string().contains("timed out"),
+            "timeout must surface as the error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn adapter_translates_port_dto_into_plugin_schema() {
+        use std::sync::Mutex;
+
+        #[derive(Default)]
+        struct RecordingNotifier {
+            received: Mutex<Vec<bcs_human_notify_api::MentionNotification>>,
+        }
+
+        #[async_trait::async_trait]
+        impl bcs_human_notify_api::HumanMentionNotifier for RecordingNotifier {
+            fn backend_name(&self) -> &'static str {
+                "recording"
+            }
+
+            async fn notify(
+                &self,
+                notification: &bcs_human_notify_api::MentionNotification,
+            ) -> bcs_human_notify_api::HumanNotifyResult<()> {
+                self.received.lock().unwrap().push(notification.clone());
+                Ok(())
+            }
+        }
+
+        let recorder = Arc::new(RecordingNotifier::default());
+        let adapter = HumanMentionNotifyAdapter::new(recorder.clone());
+        adapter
+            .notify_mentioned_humans(port_notification())
+            .await
+            .expect("recording backend succeeds");
+
+        let received = recorder.received.lock().unwrap();
+        assert_eq!(received.len(), 1);
+        let notification = &received[0];
+        assert_eq!(notification.session_id, "group-1:s1");
+        assert_eq!(notification.group_id, "group-1");
+        assert_eq!(notification.sender_actor_id, "human_1");
+        assert_eq!(notification.sender_label, "Human One");
+        assert_eq!(notification.mentioned.len(), 1);
+        assert_eq!(notification.mentioned[0].actor_id, "human_2");
+        assert_eq!(notification.mentioned[0].display_name, "Human Two");
+        assert_eq!(notification.message_text, "hello");
+        assert_eq!(notification.timestamp_ms, 1_700_000_000_000);
     }
 }

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -34,9 +34,9 @@ use crate::lifecycle::LifecycleOrchestrator;
 use crate::friend_connect_notification::HttpFriendConnectNotificationPort;
 use crate::plugins::{
     CachePluginKind, DbPluginKind, InfrastructurePlugins, LeaderElectionRegistration,
-    build_registered_channel_provider, build_registered_leader_election,
-    build_registered_llm_provider, build_registered_security_gateway,
-    build_registered_user_directory,
+    build_human_mention_notify_port, build_registered_channel_provider,
+    build_registered_leader_election, build_registered_llm_provider,
+    build_registered_security_gateway, build_registered_user_directory,
 };
 use bcs_api_http::v1::gateway_principal::{GatewayPrincipalTokenVerifier, GatewayPrincipalTrust};
 use bcs_api_http::v1::openapi::SessionFileUrlProjector;
@@ -1991,6 +1991,7 @@ impl Default for BcsServerState {
             config.provider_chat_run_timeout_ms,
             config.eventing.enabled.then(|| group_event_factory.clone()),
             crate::eventing_wiring::event_recorder(&config, event_repo.clone()),
+            Arc::new(bcs_service_api::port::NoopHumanMentionNotifyPort),
         );
         let pending_messages = message_flow_builder
             .pending_message_port()
@@ -2818,6 +2819,7 @@ fn create_message_flow_builder(
     provider_chat_run_timeout_ms: u64,
     event_record_factory: Option<Arc<dyn EventRecordFactoryPort>>,
     event_recorder: Arc<dyn EventRecorderPort>,
+    human_mention_notify: Arc<dyn bcs_service_api::port::HumanMentionNotifyPort>,
 ) -> BcsMessageFlow {
     let mut message_flow = BcsMessageFlow::new(
         group,
@@ -2833,7 +2835,8 @@ fn create_message_flow_builder(
     .with_provider_chat_run_timeout_ms(provider_chat_run_timeout_ms)
     .with_provider_stream_gray_list(provider_stream_gray_list)
     .with_bot_terminal_observer(bot_terminal_observer)
-    .with_event_recorder(event_recorder);
+    .with_event_recorder(event_recorder)
+    .with_human_mention_notify(human_mention_notify);
     if let Some(factory) = event_record_factory {
         message_flow = message_flow.with_event_record_factory(factory);
     }
@@ -3536,6 +3539,7 @@ impl BcsServer {
             config.provider_chat_run_timeout_ms,
             config.eventing.enabled.then(|| group_event_factory.clone()),
             crate::eventing_wiring::event_recorder(&config, event_repo.clone()),
+            Arc::new(bcs_service_api::port::NoopHumanMentionNotifyPort),
         );
         let pending_messages = message_flow_builder
             .pending_message_port()
@@ -4356,6 +4360,7 @@ let collaboration_templates = build_standalone_collaboration_template_service(&c
                 .enabled
                 .then(|| crate::eventing_wiring::event_record_factory(&config, event_repo.clone())),
             crate::eventing_wiring::event_recorder(&config, event_repo.clone()),
+            build_human_mention_notify_port(&config).await?,
         );
         let pending_messages = message_flow_builder
             .pending_message_port()

--- a/src/bcs/crates/bootstrap/bcs/src/server.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/server.rs
@@ -3523,6 +3523,15 @@ impl BcsServer {
             ]));
         let state_machine_terminal_observer =
             Arc::new(DeferredStateMachineTerminalObserver::new(terminal_observer));
+        if config.human_notify.provider.is_some() {
+            // This synchronous construction path cannot await the notifier
+            // factory build; keep the configured backend from being silently
+            // ignored.
+            tracing::warn!(
+                "human_notify.provider is configured but ignored in this construction path; \
+                 use BcsServer::new_with_storage to enable human mention notifications"
+            );
+        }
         let message_flow_builder = create_message_flow_builder(
             bot_registry.clone(),
             sessions.clone(),

--- a/src/bcs/crates/plugin-api/README.md
+++ b/src/bcs/crates/plugin-api/README.md
@@ -22,6 +22,9 @@ capabilities such as cache or database access.
 - `bcs-db-api` is a driver-level SQL execution contract. It abstracts driver,
   connection, transaction, health, and row conversion concerns, but does not
   promise SQL dialect portability.
+- `bcs-human-notify-api` owns the human mention notification contract:
+  `HumanMentionNotifier` backends deliver per-message notifications to
+  @-mentioned human participants; selection via `human_notify.provider`.
 - `bcs-user-directory-api` owns user-directory lookup primitives such as
   `staff_no -> nick_name`; business fallbacks and actor writes belong to the
   consuming service.

--- a/src/bcs/crates/plugin-api/bcs-human-notify-api/CONTEXT.md
+++ b/src/bcs/crates/plugin-api/bcs-human-notify-api/CONTEXT.md
@@ -2,14 +2,15 @@
 
 ## Provides
 - `HumanMentionNotifier` trait、`HumanMentionNotifierFactory` inventory 注册单元、
-  `HumanNotifyError`、`MentionNotification`/`MentionedHuman` re-export。
+  `HumanNotifyError`、插件自有 schema `MentionNotification`/`MentionedHuman`。
 
 ## Consumes
-- `bcs-service-api`（`MentionNotification` 等类型归属）
 - `bcs-config-api`（`HumanNotifyProviderConfig`）
 
 ## Allowed dependencies
-- contracts/service-api/config-api 叶子 crate；`futures`、`inventory`、`thiserror`。
+- config-api 叶子 crate；`async-trait`、`futures`、`inventory`、`thiserror`。
 
 ## Forbidden dependencies
-- 具体 plugins/* 实现 crate、services/*、bootstrap、transport/runtime crate、env/文件系统访问。
+- 具体 plugins/* 实现 crate、services/*、service-api、bootstrap、transport/runtime crate、env/文件系统访问。
+- 通知 schema 由本 crate 自有（Plugin API 与 Service API 分别演化），不 re-export
+  service-api 端口类型；端口 DTO 与插件 DTO 的翻译由 bootstrap 适配层完成。

--- a/src/bcs/crates/plugin-api/bcs-human-notify-api/CONTEXT.md
+++ b/src/bcs/crates/plugin-api/bcs-human-notify-api/CONTEXT.md
@@ -1,0 +1,15 @@
+# bcs-human-notify-api
+
+## Provides
+- `HumanMentionNotifier` trait、`HumanMentionNotifierFactory` inventory 注册单元、
+  `HumanNotifyError`、`MentionNotification`/`MentionedHuman` re-export。
+
+## Consumes
+- `bcs-service-api`（`MentionNotification` 等类型归属）
+- `bcs-config-api`（`HumanNotifyProviderConfig`）
+
+## Allowed dependencies
+- contracts/service-api/config-api 叶子 crate；`futures`、`inventory`、`thiserror`。
+
+## Forbidden dependencies
+- 具体 plugins/* 实现 crate、services/*、bootstrap、transport/runtime crate、env/文件系统访问。

--- a/src/bcs/crates/plugin-api/bcs-human-notify-api/Cargo.toml
+++ b/src/bcs/crates/plugin-api/bcs-human-notify-api/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bcs-human-notify-api"
+description = "Human mention notification plugin API for BCS"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+bcs-config-api = { workspace = true }
+bcs-service-api = { workspace = true }
+futures = { workspace = true }
+inventory = { workspace = true }
+thiserror = { workspace = true }

--- a/src/bcs/crates/plugin-api/bcs-human-notify-api/Cargo.toml
+++ b/src/bcs/crates/plugin-api/bcs-human-notify-api/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 [dependencies]
 async-trait = { workspace = true }
 bcs-config-api = { workspace = true }
-bcs-service-api = { workspace = true }
 futures = { workspace = true }
 inventory = { workspace = true }
 thiserror = { workspace = true }

--- a/src/bcs/crates/plugin-api/bcs-human-notify-api/src/lib.rs
+++ b/src/bcs/crates/plugin-api/bcs-human-notify-api/src/lib.rs
@@ -8,6 +8,11 @@
 //!
 //! Provider crates receive only their own config table from
 //! `human_notify.providers.<provider>`.
+//!
+//! The Plugin API owns its notification schema ([`MentionNotification`] /
+//! [`MentionedHuman`]) so the plugin contract evolves independently from the
+//! Service API port that produces it; the bootstrap adapter translates
+//! between the two.
 
 use std::sync::Arc;
 
@@ -15,7 +20,32 @@ use bcs_config_api::HumanNotifyProviderConfig;
 use futures::future::BoxFuture;
 use thiserror::Error;
 
-pub use bcs_service_api::port::human_notify::{MentionNotification, MentionedHuman};
+/// A single @-mentioned human participant (plugin contract schema).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MentionedHuman {
+    /// Human participant actor id, shaped as `human_{staff_no}`.
+    pub actor_id: String,
+    /// Display name used at mention time (participant `bot_name`).
+    pub display_name: String,
+}
+
+/// One @-human mention event (plugin contract schema). One message maps to
+/// one event carrying every human mentioned by that message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MentionNotification {
+    /// Session id; empty string for group-level messages without a session.
+    pub session_id: String,
+    pub group_id: String,
+    /// Sender actor id (`bot_x` or `human_y`).
+    pub sender_actor_id: String,
+    /// Sender display name.
+    pub sender_label: String,
+    /// Every human @-mentioned by this message (sender excluded).
+    pub mentioned: Vec<MentionedHuman>,
+    /// Message text shown to the mentioned human.
+    pub message_text: String,
+    pub timestamp_ms: u64,
+}
 
 /// Error returned by human-mention notification backends.
 #[derive(Debug, Error)]
@@ -40,9 +70,11 @@ pub trait HumanMentionNotifier: Send + Sync {
     fn backend_name(&self) -> &'static str;
 
     /// Deliver one notification. Implementations decide per-recipient
-    /// delivery; aggregation semantics are defined by the design spec:
-    /// at least one recipient delivered (or no recipients) -> `Ok`,
-    /// all recipients failed -> `Err(HumanNotifyError::Delivery)`.
+    /// delivery; the aggregation contract is:
+    /// a recipient whose `actor_id` the backend cannot parse is skipped and
+    /// does not count as a failure; at least one recipient delivered (or no
+    /// recipients at all, or all skipped) -> `Ok`; every recipient failed ->
+    /// `Err(HumanNotifyError::Delivery)`.
     async fn notify(&self, notification: &MentionNotification) -> HumanNotifyResult<()>;
 }
 

--- a/src/bcs/crates/plugin-api/bcs-human-notify-api/src/lib.rs
+++ b/src/bcs/crates/plugin-api/bcs-human-notify-api/src/lib.rs
@@ -1,0 +1,63 @@
+//! Human mention notification plugin API for BCS.
+//!
+//! This crate is the provider-neutral contract for notifying human
+//! participants when a message @-mentions them. Public binaries include the
+//! built-in `dummy` backend; product-specific binaries can link crates that
+//! submit [`HumanMentionNotifierFactory`] entries through `inventory`
+//! (e.g. the internal DingTalk notifier).
+//!
+//! Provider crates receive only their own config table from
+//! `human_notify.providers.<provider>`.
+
+use std::sync::Arc;
+
+use bcs_config_api::HumanNotifyProviderConfig;
+use futures::future::BoxFuture;
+use thiserror::Error;
+
+pub use bcs_service_api::port::human_notify::{MentionNotification, MentionedHuman};
+
+/// Error returned by human-mention notification backends.
+#[derive(Debug, Error)]
+pub enum HumanNotifyError {
+    /// The provider config table is syntactically valid but invalid for this
+    /// provider. Build-time failures surface as startup errors.
+    #[error("invalid human notify provider config: {0}")]
+    Config(String),
+
+    /// Runtime delivery failed for every recipient.
+    #[error("human mention notification delivery failed: {0}")]
+    Delivery(String),
+}
+
+/// Result alias for human-mention notification operations.
+pub type HumanNotifyResult<T> = Result<T, HumanNotifyError>;
+
+/// Notification backend for @-mentioned human participants.
+#[async_trait::async_trait]
+pub trait HumanMentionNotifier: Send + Sync {
+    /// Backend name, matching the registered factory name.
+    fn backend_name(&self) -> &'static str;
+
+    /// Deliver one notification. Implementations decide per-recipient
+    /// delivery; aggregation semantics are defined by the design spec:
+    /// at least one recipient delivered (or no recipients) -> `Ok`,
+    /// all recipients failed -> `Err(HumanNotifyError::Delivery)`.
+    async fn notify(&self, notification: &MentionNotification) -> HumanNotifyResult<()>;
+}
+
+/// Factory function implemented by linked notifier provider crates.
+pub type HumanMentionNotifierBuild = fn(
+    HumanNotifyProviderConfig,
+) -> BoxFuture<'static, HumanNotifyResult<Arc<dyn HumanMentionNotifier>>>;
+
+/// Inventory entry for a human-mention notification backend.
+pub struct HumanMentionNotifierFactory {
+    /// Backend name selected by `human_notify.provider`.
+    pub name: &'static str,
+
+    /// Build the backend from `human_notify.providers.<name>`.
+    pub build: HumanMentionNotifierBuild,
+}
+
+inventory::collect!(HumanMentionNotifierFactory);

--- a/src/bcs/crates/plugins/bcs-human-notify-dummy/CONTEXT.md
+++ b/src/bcs/crates/plugins/bcs-human-notify-dummy/CONTEXT.md
@@ -1,0 +1,14 @@
+# bcs-human-notify-dummy
+
+## Provides
+- `DummyHumanMentionNotifier`：日志型通知后端（`backend_name = "dummy"`）。
+- `inventory::submit!` 注册的 `HumanMentionNotifierFactory`（name = "dummy"）。
+
+## Consumes
+- `bcs-human-notify-api`、`bcs-config-api`。
+
+## Allowed dependencies
+- plugin-api/config-api 叶子 crate；`async-trait`、`futures`、`inventory`、`tracing`。
+
+## Forbidden dependencies
+- services/*、bootstrap、transport/runtime crate、网络或文件系统访问。

--- a/src/bcs/crates/plugins/bcs-human-notify-dummy/Cargo.toml
+++ b/src/bcs/crates/plugins/bcs-human-notify-dummy/Cargo.toml
@@ -19,6 +19,5 @@ inventory = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-bcs-service-api = { workspace = true }
 bcs-test-support = { workspace = true }
 tokio = { workspace = true }

--- a/src/bcs/crates/plugins/bcs-human-notify-dummy/Cargo.toml
+++ b/src/bcs/crates/plugins/bcs-human-notify-dummy/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "bcs-human-notify-dummy"
+description = "Dummy human mention notification backend for BCS (logs only)"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+bcs-config-api = { workspace = true }
+bcs-human-notify-api = { workspace = true }
+futures = { workspace = true }
+inventory = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+bcs-service-api = { workspace = true }
+bcs-test-support = { workspace = true }
+tokio = { workspace = true }

--- a/src/bcs/crates/plugins/bcs-human-notify-dummy/src/lib.rs
+++ b/src/bcs/crates/plugins/bcs-human-notify-dummy/src/lib.rs
@@ -1,0 +1,90 @@
+//! Dummy human mention notification backend: logs each notification and
+//! performs no delivery. Default backend for public/local deployments.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bcs_config_api::HumanNotifyProviderConfig;
+use bcs_human_notify_api::{
+    HumanMentionNotifier, HumanMentionNotifierFactory, HumanNotifyResult, MentionNotification,
+};
+use futures::future::BoxFuture;
+
+pub const DUMMY_BACKEND_NAME: &str = "dummy";
+
+/// Notification backend that only emits log lines.
+pub struct DummyHumanMentionNotifier;
+
+impl DummyHumanMentionNotifier {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for DummyHumanMentionNotifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl HumanMentionNotifier for DummyHumanMentionNotifier {
+    fn backend_name(&self) -> &'static str {
+        DUMMY_BACKEND_NAME
+    }
+
+    async fn notify(&self, notification: &MentionNotification) -> HumanNotifyResult<()> {
+        for human in &notification.mentioned {
+            tracing::info!(
+                backend = DUMMY_BACKEND_NAME,
+                session_id = %notification.session_id,
+                group_id = %notification.group_id,
+                sender_actor_id = %notification.sender_actor_id,
+                actor_id = %human.actor_id,
+                display_name = %human.display_name,
+                message_chars = notification.message_text.chars().count(),
+                "dummy human mention notification (no delivery)"
+            );
+        }
+        Ok(())
+    }
+}
+
+pub fn build_dummy_notifier(
+    _config: HumanNotifyProviderConfig,
+) -> BoxFuture<'static, HumanNotifyResult<Arc<dyn HumanMentionNotifier>>> {
+    Box::pin(async move {
+        Ok(Arc::new(DummyHumanMentionNotifier::new()) as Arc<dyn HumanMentionNotifier>)
+    })
+}
+
+inventory::submit! {
+    HumanMentionNotifierFactory {
+        name: DUMMY_BACKEND_NAME,
+        build: build_dummy_notifier,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn dummy_backend_reports_name_and_succeeds() {
+        let notifier = DummyHumanMentionNotifier::new();
+        assert_eq!(notifier.backend_name(), "dummy");
+        let notification = MentionNotification {
+            session_id: String::new(),
+            group_id: "group-1".to_string(),
+            sender_actor_id: "bot-driver".to_string(),
+            sender_label: "Driver".to_string(),
+            mentioned: vec![bcs_human_notify_api::MentionedHuman {
+                actor_id: "human_1".to_string(),
+                display_name: "Human One".to_string(),
+            }],
+            message_text: "hello".to_string(),
+            timestamp_ms: 0,
+        };
+        notifier.notify(&notification).await.expect("dummy succeeds");
+    }
+}

--- a/src/bcs/crates/plugins/bcs-human-notify-dummy/tests/conformance.rs
+++ b/src/bcs/crates/plugins/bcs-human-notify-dummy/tests/conformance.rs
@@ -2,8 +2,8 @@
 
 use std::sync::Arc;
 
+use bcs_human_notify_api::{MentionNotification, MentionedHuman};
 use bcs_human_notify_dummy::DummyHumanMentionNotifier;
-use bcs_service_api::port::human_notify::{MentionNotification, MentionedHuman};
 use bcs_test_support::contract::port::{
     human_mention_notifier_contract_tests, HumanNotifyContractHarness,
 };

--- a/src/bcs/crates/plugins/bcs-human-notify-dummy/tests/conformance.rs
+++ b/src/bcs/crates/plugins/bcs-human-notify-dummy/tests/conformance.rs
@@ -1,0 +1,40 @@
+//! Conformance tests for the dummy human mention notifier.
+
+use std::sync::Arc;
+
+use bcs_human_notify_dummy::DummyHumanMentionNotifier;
+use bcs_service_api::port::human_notify::{MentionNotification, MentionedHuman};
+use bcs_test_support::contract::port::{
+    human_mention_notifier_contract_tests, HumanNotifyContractHarness,
+};
+
+fn sample_notification() -> MentionNotification {
+    MentionNotification {
+        session_id: "group-1:abcdef12".to_string(),
+        group_id: "group-1".to_string(),
+        sender_actor_id: "bot-driver".to_string(),
+        sender_label: "Driver".to_string(),
+        mentioned: vec![MentionedHuman {
+            actor_id: "human_1".to_string(),
+            display_name: "Human One".to_string(),
+        }],
+        message_text: "hello @Human One".to_string(),
+        timestamp_ms: 1_700_000_000_000,
+    }
+}
+
+#[tokio::test]
+async fn dummy_conforms() {
+    let notifier: Arc<dyn bcs_human_notify_api::HumanMentionNotifier> =
+        Arc::new(DummyHumanMentionNotifier::new());
+    human_mention_notifier_contract_tests(
+        notifier.as_ref(),
+        HumanNotifyContractHarness {
+            backend_name: "dummy",
+            success_case: sample_notification(),
+            failure_case: None,
+            partial_case: None,
+        },
+    )
+    .await;
+}

--- a/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
+++ b/src/bcs/crates/service-api/bcs-config-api/src/lib.rs
@@ -832,6 +832,45 @@ pub struct ChannelDingTalkConfig {
 }
 
 // ---------------------------------------------------------------------------
+// Human mention notification
+// ---------------------------------------------------------------------------
+
+/// Human mention notification configuration (`[human_notify]`).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HumanNotifyConfig {
+    /// Selected backend name; the feature is off when absent.
+    #[serde(default)]
+    pub provider: Option<String>,
+
+    /// Backend-specific configuration keyed by backend name.
+    #[serde(default)]
+    pub providers: BTreeMap<String, HumanNotifyProviderConfig>,
+}
+
+impl HumanNotifyConfig {
+    /// Returns true when `provider` selects `name` and that entry is enabled.
+    pub fn enabled_provider(&self, name: &str) -> bool {
+        self.provider.as_deref() == Some(name)
+            && self
+                .providers
+                .get(name)
+                .is_some_and(|provider| provider.enabled)
+    }
+}
+
+/// Generic human-mention notification backend configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HumanNotifyProviderConfig {
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Backend-owned options. The public host only carries these through to
+    /// the backend factory.
+    #[serde(default, flatten)]
+    pub options: BTreeMap<String, serde_json::Value>,
+}
+
+// ---------------------------------------------------------------------------
 // Auth SDK
 // ---------------------------------------------------------------------------
 
@@ -1899,5 +1938,40 @@ mod tests {
             ];
             assert!(config.validate().is_err(), "rule should be rejected: {host}");
         }
+    }
+
+    #[test]
+    fn human_notify_config_parses_provider_and_options() {
+        let value: toml::Value = toml::from_str(
+            r#"
+provider = "dingtalk"
+
+[providers.dingtalk]
+enabled = true
+robot_code = "ding-robot"
+client_secret = "s3cret"
+"#,
+        )
+        .expect("toml must parse");
+        let config: HumanNotifyConfig = value.try_into().expect("config must deserialize");
+        assert_eq!(config.provider.as_deref(), Some("dingtalk"));
+        let provider = config
+            .providers
+            .get("dingtalk")
+            .expect("dingtalk provider entry");
+        assert!(provider.enabled);
+        assert!(config.enabled_provider("dingtalk"));
+        assert_eq!(
+            provider.options.get("robot_code").and_then(|v| v.as_str()),
+            Some("ding-robot")
+        );
+    }
+
+    #[test]
+    fn human_notify_config_defaults_to_disabled() {
+        let config = HumanNotifyConfig::default();
+        assert!(config.provider.is_none());
+        assert!(config.providers.is_empty());
+        assert!(!config.enabled_provider("dummy"));
     }
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/human_notify.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/human_notify.rs
@@ -24,13 +24,15 @@ pub struct MentionNotification {
     /// 本条消息中被 @ 的全部人类（已排除发送者自身与 Hidden 状态人类）。
     pub mentioned: Vec<MentionedHuman>,
     /// 消息文本：文本路由为 `RoutingDecision.cleaned_message`，
-    /// 显式 mention 路径为原始消息文本（契约 6.1）。
+    /// 显式 mention 路径为原始消息文本。
     pub message_text: String,
     pub timestamp_ms: u64,
 }
 
 /// @ 人类提醒通知端口。核心消息流只依赖本 trait；bootstrap 组合根把选中的
 /// 通知后端（`bcs-human-notify-api` 的 `HumanMentionNotifier`）适配为端口。
+/// 插件契约拥有独立的 `MentionNotification` schema（Plugin API 与 Service API
+/// 分别演化），端口 DTO 到插件 DTO 的翻译由 bootstrap 适配层完成。
 #[async_trait]
 pub trait HumanMentionNotifyPort: Send + Sync {
     /// 后端是否可用。未配置后端时为 `false`，消息流零开销跳过。

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/human_notify.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/human_notify.rs
@@ -1,0 +1,95 @@
+use async_trait::async_trait;
+
+use crate::ServiceResult;
+
+/// 单个被 @ 的人类参与者。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MentionedHuman {
+    /// 人类参与者 actor id，形如 `human_{staff_no}`。
+    pub actor_id: String,
+    /// @ 时使用的显示名（参与者 `bot_name`）。
+    pub display_name: String,
+}
+
+/// 一次 @ 人类提醒事件。一条消息对应一个事件，包含该消息中全部被 @ 的人类。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MentionNotification {
+    /// 会话 id；群级消息（无 session）时为空字符串。
+    pub session_id: String,
+    pub group_id: String,
+    /// 发送者 actor id（`bot_x` 或 `human_y`，群回调为 `system`）。
+    pub sender_actor_id: String,
+    /// 发送者展示名。
+    pub sender_label: String,
+    /// 本条消息中被 @ 的全部人类（已排除发送者自身与 Hidden 状态人类）。
+    pub mentioned: Vec<MentionedHuman>,
+    /// 消息文本：文本路由为 `RoutingDecision.cleaned_message`，
+    /// 显式 mention 路径为原始消息文本（契约 6.1）。
+    pub message_text: String,
+    pub timestamp_ms: u64,
+}
+
+/// @ 人类提醒通知端口。核心消息流只依赖本 trait；bootstrap 组合根把选中的
+/// 通知后端（`bcs-human-notify-api` 的 `HumanMentionNotifier`）适配为端口。
+#[async_trait]
+pub trait HumanMentionNotifyPort: Send + Sync {
+    /// 后端是否可用。未配置后端时为 `false`，消息流零开销跳过。
+    fn is_available(&self) -> bool;
+
+    /// 投递一次提醒。错误由调用方（消息流）吞掉，不影响主路径。
+    async fn notify_mentioned_humans(
+        &self,
+        notification: MentionNotification,
+    ) -> ServiceResult<()>;
+}
+
+/// 未配置通知后端时的 no-op 端口。
+pub struct NoopHumanMentionNotifyPort;
+
+#[async_trait]
+impl HumanMentionNotifyPort for NoopHumanMentionNotifyPort {
+    fn is_available(&self) -> bool {
+        false
+    }
+
+    async fn notify_mentioned_humans(
+        &self,
+        _notification: MentionNotification,
+    ) -> ServiceResult<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_notification() -> MentionNotification {
+        MentionNotification {
+            session_id: "group-1:abcdef12".to_string(),
+            group_id: "group-1".to_string(),
+            sender_actor_id: "bot-driver".to_string(),
+            sender_label: "Driver".to_string(),
+            mentioned: vec![MentionedHuman {
+                actor_id: "human_1".to_string(),
+                display_name: "Human One".to_string(),
+            }],
+            message_text: "hello".to_string(),
+            timestamp_ms: 1_700_000_000_000,
+        }
+    }
+
+    #[test]
+    fn noop_port_is_unavailable_and_returns_ok() {
+        let port = NoopHumanMentionNotifyPort;
+        assert!(!port.is_available());
+    }
+
+    #[tokio::test]
+    async fn noop_port_accepts_notification() {
+        let port = NoopHumanMentionNotifyPort;
+        port.notify_mentioned_humans(sample_notification())
+            .await
+            .expect("noop port must accept notifications");
+    }
+}

--- a/src/bcs/crates/service-api/bcs-service-api/src/port/mod.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/port/mod.rs
@@ -10,6 +10,7 @@ pub mod event_recording;
 pub mod friend_connect_notification;
 pub mod group_context;
 pub mod group_session_token;
+pub mod human_notify;
 pub mod interaction;
 pub mod judge;
 pub mod leader_election;
@@ -43,6 +44,9 @@ pub use delivery::{
 pub use friend_connect_notification::{
     FriendConnectNotificationCommand, FriendConnectNotificationKind,
     FriendConnectNotificationPort, NoopFriendConnectNotificationPort,
+};
+pub use human_notify::{
+    HumanMentionNotifyPort, MentionNotification, MentionedHuman, NoopHumanMentionNotifyPort,
 };
 pub use event_delivery::*;
 pub use event_metrics::*;

--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -574,21 +574,6 @@ async fn relay_final_chat_event(
         message_text
     };
     let sender_display_name = sender_display_name(flow, &cmd.bot_id).await;
-    if routing_source == RequestSource::LegacyMention && group.group_kind != GroupKind::Dm {
-        crate::human_notify_hook::spawn_human_mention_notify(
-            &flow.human_mention_notify,
-            Some(decision.mentions.as_slice()),
-            &overlay,
-            crate::human_notify_hook::MentionNotifyContext {
-                session_id: cmd.bcs_session_id.clone().unwrap_or_default(),
-                group_id: cmd.group_id.clone(),
-                sender_actor_id: cmd.bot_id.clone(),
-                sender_label: sender_display_name.clone(),
-                message_text: decision.cleaned_message.clone(),
-                timestamp_ms: now_ms(),
-            },
-        );
-    }
     let from_bot_owner = from_bot_owner(flow, &cmd.bot_id).await;
     let routing_mode = routing_meta
         .as_ref()
@@ -609,6 +594,35 @@ async fn relay_final_chat_event(
     // as ONE row, using the final frame's complete text. (Final-only runs with
     // no buffered deltas just insert the final text.)
     persist_final_chat(flow, &cmd, cleaned.clone()).await?;
+
+    // Notify @-mentioned humans only after the message is persisted, and only
+    // if the content passes the outbound policy that governs bot deliveries
+    // of the same message.
+    if routing_source == RequestSource::LegacyMention && group.group_kind != GroupKind::Dm {
+        if let Some(notify_text) = crate::group_flow::apply_notify_outbound_policy(
+            flow,
+            &cmd.group_id,
+            &cmd.bot_id,
+            &decision.cleaned_message,
+            &decision.targets,
+        )
+        .await
+        {
+            crate::human_notify_hook::spawn_human_mention_notify(
+                &flow.human_mention_notify,
+                Some(decision.mentions.as_slice()),
+                &overlay,
+                crate::human_notify_hook::MentionNotifyContext {
+                    session_id: cmd.bcs_session_id.clone().unwrap_or_default(),
+                    group_id: cmd.group_id.clone(),
+                    sender_actor_id: cmd.bot_id.clone(),
+                    sender_label: sender_display_name.clone(),
+                    message_text: notify_text,
+                    timestamp_ms: now_ms(),
+                },
+            );
+        }
+    }
 
     for target in &decision.targets {
         let directive = build_response_directive(

--- a/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/bot_event.rs
@@ -574,6 +574,21 @@ async fn relay_final_chat_event(
         message_text
     };
     let sender_display_name = sender_display_name(flow, &cmd.bot_id).await;
+    if routing_source == RequestSource::LegacyMention && group.group_kind != GroupKind::Dm {
+        crate::human_notify_hook::spawn_human_mention_notify(
+            &flow.human_mention_notify,
+            Some(decision.mentions.as_slice()),
+            &overlay,
+            crate::human_notify_hook::MentionNotifyContext {
+                session_id: cmd.bcs_session_id.clone().unwrap_or_default(),
+                group_id: cmd.group_id.clone(),
+                sender_actor_id: cmd.bot_id.clone(),
+                sender_label: sender_display_name.clone(),
+                message_text: decision.cleaned_message.clone(),
+                timestamp_ms: now_ms(),
+            },
+        );
+    }
     let from_bot_owner = from_bot_owner(flow, &cmd.bot_id).await;
     let routing_mode = routing_meta
         .as_ref()

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -752,24 +752,11 @@ pub async fn handle_web_send(
         if group.group_kind == GroupKind::Dm {
             (None, String::new())
         } else if !cmd.mentions.is_empty() {
-            // 显式 mention 路径：使用原始消息文本（契约 6.1）。
+            // 显式 mention 路径：使用人类发送者看到的原始消息文本。
             (Some(cmd.mentions.as_slice()), cmd.message.clone())
         } else {
             (Some(decision.mentions.as_slice()), decision.cleaned_message.clone())
         };
-    crate::human_notify_hook::spawn_human_mention_notify(
-        &flow.human_mention_notify,
-        mention_source,
-        &overlay,
-        crate::human_notify_hook::MentionNotifyContext {
-            session_id: cmd.session_id.clone().unwrap_or_default(),
-            group_id: cmd.group_id.clone(),
-            sender_actor_id: cmd.from_actor_id.clone(),
-            sender_label: sender_display_name.clone(),
-            message_text: mention_message_text,
-            timestamp_ms: now_ms(),
-        },
-    );
     let sender_type = if cmd.from_actor_id.starts_with("human_") {
         SenderType::Human
     } else {
@@ -788,6 +775,34 @@ pub async fn handle_web_send(
         "", // run_id: user messages don't associate with bot runs
     )
     .await?;
+    // Notify @-mentioned humans only after the message is accepted and
+    // persisted, and only if the content passes the outbound policy that
+    // governs bot deliveries of the same message.
+    if let Some(mention_actor_ids) = mention_source {
+        if let Some(notify_text) = apply_notify_outbound_policy(
+            flow,
+            &cmd.group_id,
+            &cmd.from_actor_id,
+            &mention_message_text,
+            &decision.targets,
+        )
+        .await
+        {
+            crate::human_notify_hook::spawn_human_mention_notify(
+                &flow.human_mention_notify,
+                Some(mention_actor_ids),
+                &overlay,
+                crate::human_notify_hook::MentionNotifyContext {
+                    session_id: cmd.session_id.clone().unwrap_or_default(),
+                    group_id: cmd.group_id.clone(),
+                    sender_actor_id: cmd.from_actor_id.clone(),
+                    sender_label: sender_display_name.clone(),
+                    message_text: notify_text,
+                    timestamp_ms: now_ms(),
+                },
+            );
+        }
+    }
     let mut active_run_ids = Vec::new();
     let mut bot_deliveries = Vec::new();
     let mut delivery_results = Vec::new();
@@ -1283,8 +1298,8 @@ pub async fn handle_persistent_group_send(
     )
     .await?;
 
+    let overlay = build_route_overlay(flow, &group).await;
     let decision = if group.group_kind == GroupKind::Dm {
-        let overlay = build_route_overlay(flow, &group).await;
         flow.routing
             .route_dm_with_overlay(&group, &message.content, message.sender.as_str(), &overlay)
             .await
@@ -1294,9 +1309,37 @@ pub async fn handle_persistent_group_send(
             .await
     };
 
-    let mut routed_to = Vec::new();
     let sender_display_name = sender_display_name(flow, &cmd.sender).await;
     let from_bot_owner = from_bot_owner(flow, &cmd.sender).await;
+    // Notify @-mentioned humans (non-DM only) once the message is persisted
+    // and the content passes the same outbound policy as bot deliveries.
+    if group.group_kind != GroupKind::Dm {
+        if let Some(notify_text) = apply_notify_outbound_policy(
+            flow,
+            &cmd.group_id,
+            &cmd.sender,
+            &decision.cleaned_message,
+            &decision.targets,
+        )
+        .await
+        {
+            crate::human_notify_hook::spawn_human_mention_notify(
+                &flow.human_mention_notify,
+                Some(decision.mentions.as_slice()),
+                &overlay,
+                crate::human_notify_hook::MentionNotifyContext {
+                    session_id: String::new(),
+                    group_id: cmd.group_id.clone(),
+                    sender_actor_id: cmd.sender.clone(),
+                    sender_label: sender_display_name.clone(),
+                    message_text: notify_text,
+                    timestamp_ms: now_ms(),
+                },
+            );
+        }
+    }
+
+    let mut routed_to = Vec::new();
     let synthetic_send = WebSendCommand {
         caller: cmd.caller.clone(),
         group_id: cmd.group_id.clone(),
@@ -1478,6 +1521,57 @@ pub(crate) async fn apply_outbound_interceptors(
     }
 }
 
+/// Run the outbound interceptor chain once for a human-mention notification
+/// before it leaves the process, using the first non-sender delivery target
+/// as the policy receiver. Returns the (possibly rewritten) text to notify
+/// with, or `None` when the chain blocks the content: what policy forbids for
+/// bot deliveries must not reach humans through the notification channel.
+///
+/// The chain is credential-gated (see [`apply_outbound_interceptors`]):
+/// senders without AgentPass credentials skip evaluation, matching what bot
+/// deliveries receive under the same posture. With no bot receiver at all
+/// there is nothing to evaluate, and the notification proceeds unmodified.
+pub(crate) async fn apply_notify_outbound_policy(
+    flow: &BcsMessageFlow,
+    group_id: &str,
+    sender_actor_id: &str,
+    message_text: &str,
+    targets: &[RoutingTarget],
+) -> Option<String> {
+    let Some(receiver) = targets
+        .iter()
+        .find(|target| target.bot_uuid != sender_actor_id)
+    else {
+        return Some(message_text.to_string());
+    };
+    let candidate = GroupMessage {
+        id: uuid::Uuid::new_v4().to_string(),
+        timestamp: now_ms(),
+        sender: sender_actor_id.to_string(),
+        content: message_text.to_string(),
+        message_type: GroupMessageType::Bot,
+        bot_name: None,
+        role: MessageRole::User,
+        run_id: String::new(),
+        history_meta: None,
+        metadata: None,
+        attachments: None,
+    };
+    match apply_outbound_interceptors(flow, group_id, &candidate, receiver).await {
+        Ok(message) => Some(message.content),
+        Err(reason) => {
+            warn!(
+                group_id,
+                sender = %sender_actor_id,
+                interceptor = %reason.interceptor_id,
+                code = %reason.code,
+                "human mention notification suppressed by outbound policy"
+            );
+            None
+        }
+    }
+}
+
 /// Run the outbound interceptor chain for an A2A (1:1 bot-to-bot) chat.
 ///
 /// A2A chats have no group context — `context_tag` is purely a log/trace label
@@ -1635,26 +1729,11 @@ pub async fn handle_group_callback(
         build_explicit_mention_decision(&group, &cmd.mentions, &routable_message, &overlay)
     };
 
-    let (mention_source, mention_message_text): (Option<&[String]>, String) =
-        if cmd.mentions.is_empty() || mentions_all(&cmd.mentions) {
-            (Some(decision.mentions.as_slice()), decision.cleaned_message.clone())
-        } else {
-            // 显式 mention 路径：使用进入路由的原始文本（契约 6.1）。
-            (Some(cmd.mentions.as_slice()), routable_message.clone())
-        };
-    crate::human_notify_hook::spawn_human_mention_notify(
-        &flow.human_mention_notify,
-        mention_source,
-        &overlay,
-        crate::human_notify_hook::MentionNotifyContext {
-            session_id: String::new(),
-            group_id: cmd.group_id.clone(),
-            sender_actor_id: "system".to_string(),
-            sender_label: "system".to_string(),
-            message_text: mention_message_text,
-            timestamp_ms: now_ms(),
-        },
-    );
+    // NOTE: group callbacks deliberately do NOT trigger human mention
+    // notifications. `POST /groups/{id}/callback` carries no caller identity,
+    // so request-controlled `mentions` would let anyone able to reach the
+    // route push external notifications (e.g. IM DMs) to arbitrary human
+    // participants. Re-enable only behind an authenticated callback caller.
 
     if cmd.store_message {
         let group_message = GroupMessage {

--- a/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/group_flow.rs
@@ -32,7 +32,7 @@ use bcs_service_api::{
     },
     message_log_json,
     port::repo::{AppendMessageWithEvent, MessageRepoPort},
-    port::{EventRecordFactoryPort, EventRecorderPort, NewEvent},
+    port::{EventRecordFactoryPort, EventRecorderPort, HumanMentionNotifyPort, NewEvent},
     types::{EVENT_SCHEMA_VERSION_V1, EventActor, EventActorType, EventScope, EventSubject},
 };
 use chrono::{SecondsFormat, TimeZone, Utc};
@@ -66,6 +66,7 @@ pub struct BcsMessageFlow {
     pub provider_stream_gray_list: Option<Arc<ProviderStreamGrayList>>,
     pub channel: Arc<OnceLock<Arc<dyn ChannelService>>>,
     pub bot_terminal_observer: Arc<dyn BotTerminalObserverPort>,
+    pub human_mention_notify: Option<Arc<dyn HumanMentionNotifyPort>>,
 }
 
 impl BcsMessageFlow {
@@ -96,6 +97,7 @@ impl BcsMessageFlow {
             provider_stream_gray_list: None,
             channel: Arc::new(OnceLock::new()),
             bot_terminal_observer: Arc::new(NoopBotTerminalObserver),
+            human_mention_notify: None,
         }
     }
 
@@ -127,6 +129,14 @@ impl BcsMessageFlow {
 
     pub fn with_system_message(mut self, system_message: Arc<dyn SystemMessageService>) -> Self {
         self.system_message = Some(system_message);
+        self
+    }
+
+    pub fn with_human_mention_notify(
+        mut self,
+        human_mention_notify: Arc<dyn HumanMentionNotifyPort>,
+    ) -> Self {
+        self.human_mention_notify = Some(human_mention_notify);
         self
     }
 
@@ -738,6 +748,28 @@ pub async fn handle_web_send(
 
     let sender_display_name = preferred_sender_display_name(flow, &cmd).await;
     let from_bot_owner = from_bot_owner(flow, &cmd.from_actor_id).await;
+    let (mention_source, mention_message_text): (Option<&[String]>, String) =
+        if group.group_kind == GroupKind::Dm {
+            (None, String::new())
+        } else if !cmd.mentions.is_empty() {
+            // 显式 mention 路径：使用原始消息文本（契约 6.1）。
+            (Some(cmd.mentions.as_slice()), cmd.message.clone())
+        } else {
+            (Some(decision.mentions.as_slice()), decision.cleaned_message.clone())
+        };
+    crate::human_notify_hook::spawn_human_mention_notify(
+        &flow.human_mention_notify,
+        mention_source,
+        &overlay,
+        crate::human_notify_hook::MentionNotifyContext {
+            session_id: cmd.session_id.clone().unwrap_or_default(),
+            group_id: cmd.group_id.clone(),
+            sender_actor_id: cmd.from_actor_id.clone(),
+            sender_label: sender_display_name.clone(),
+            message_text: mention_message_text,
+            timestamp_ms: now_ms(),
+        },
+    );
     let sender_type = if cmd.from_actor_id.starts_with("human_") {
         SenderType::Human
     } else {
@@ -1602,6 +1634,27 @@ pub async fn handle_group_callback(
     } else {
         build_explicit_mention_decision(&group, &cmd.mentions, &routable_message, &overlay)
     };
+
+    let (mention_source, mention_message_text): (Option<&[String]>, String) =
+        if cmd.mentions.is_empty() || mentions_all(&cmd.mentions) {
+            (Some(decision.mentions.as_slice()), decision.cleaned_message.clone())
+        } else {
+            // 显式 mention 路径：使用进入路由的原始文本（契约 6.1）。
+            (Some(cmd.mentions.as_slice()), routable_message.clone())
+        };
+    crate::human_notify_hook::spawn_human_mention_notify(
+        &flow.human_mention_notify,
+        mention_source,
+        &overlay,
+        crate::human_notify_hook::MentionNotifyContext {
+            session_id: String::new(),
+            group_id: cmd.group_id.clone(),
+            sender_actor_id: "system".to_string(),
+            sender_label: "system".to_string(),
+            message_text: mention_message_text,
+            timestamp_ms: now_ms(),
+        },
+    );
 
     if cmd.store_message {
         let group_message = GroupMessage {

--- a/src/bcs/crates/services/bcs-message-flow/src/human_notify_hook.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/human_notify_hook.rs
@@ -1,0 +1,157 @@
+//! Human mention notification hook: resolves @-mention sources to human
+//! participants and spawns fire-and-forget notifications.
+
+use std::sync::Arc;
+
+use bcs_domain::routing::RouteParticipantOverlay;
+use bcs_domain::{ActorKind, ActorStatus};
+use bcs_service_api::port::{HumanMentionNotifyPort, MentionNotification, MentionedHuman};
+
+/// Context needed to assemble a [`MentionNotification`].
+pub(crate) struct MentionNotifyContext {
+    pub session_id: String,
+    pub group_id: String,
+    pub sender_actor_id: String,
+    pub sender_label: String,
+    pub message_text: String,
+    pub timestamp_ms: u64,
+}
+
+/// Resolve a mention source (text-parsed or explicit actor ids) to the human
+/// participants it refers to. Excludes the sender and Hidden humans, and
+/// drops ids that are not participants.
+pub(crate) fn build_mention_trigger(
+    mention_actor_ids: &[String],
+    overlay: &[RouteParticipantOverlay],
+    sender_actor_id: &str,
+) -> Option<Vec<MentionedHuman>> {
+    let mut humans: Vec<MentionedHuman> = Vec::new();
+    for actor_id in mention_actor_ids {
+        if actor_id == sender_actor_id {
+            continue;
+        }
+        let Some(entry) = overlay.iter().find(|entry| entry.bot_uuid == *actor_id) else {
+            continue;
+        };
+        if entry.actor_kind != ActorKind::Human {
+            continue;
+        }
+        if entry.status == ActorStatus::Hidden {
+            continue;
+        }
+        if humans.iter().any(|human| human.actor_id == *actor_id) {
+            continue;
+        }
+        let display_name = entry
+            .bot_name
+            .clone()
+            .unwrap_or_else(|| actor_id.clone());
+        humans.push(MentionedHuman {
+            actor_id: actor_id.clone(),
+            display_name,
+        });
+    }
+    if humans.is_empty() {
+        None
+    } else {
+        Some(humans)
+    }
+}
+
+/// Spawn a fire-and-forget notification when the trigger resolves to at least
+/// one human and the port is available. Errors are logged by the port adapter.
+pub(crate) fn spawn_human_mention_notify(
+    port: &Option<Arc<dyn HumanMentionNotifyPort>>,
+    mention_actor_ids: Option<&[String]>,
+    overlay: &[RouteParticipantOverlay],
+    context: MentionNotifyContext,
+) {
+    let Some(port) = port.as_ref().filter(|port| port.is_available()) else {
+        return;
+    };
+    let Some(mention_actor_ids) = mention_actor_ids else {
+        return;
+    };
+    let Some(humans) = build_mention_trigger(mention_actor_ids, overlay, &context.sender_actor_id)
+    else {
+        return;
+    };
+    let notification = MentionNotification {
+        session_id: context.session_id,
+        group_id: context.group_id,
+        sender_actor_id: context.sender_actor_id,
+        sender_label: context.sender_label,
+        mentioned: humans,
+        message_text: context.message_text,
+        timestamp_ms: context.timestamp_ms,
+    };
+    let port = port.clone();
+    tokio::spawn(async move {
+        let _ = port.notify_mentioned_humans(notification).await;
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn overlay_entry(
+        bot_uuid: &str,
+        bot_name: Option<&str>,
+        actor_kind: ActorKind,
+        status: ActorStatus,
+    ) -> RouteParticipantOverlay {
+        RouteParticipantOverlay {
+            bot_uuid: bot_uuid.to_string(),
+            bot_name: bot_name.map(str::to_string),
+            actor_kind,
+            mode: None,
+            status,
+            is_driver: false,
+        }
+    }
+
+    fn overlay() -> Vec<RouteParticipantOverlay> {
+        vec![
+            overlay_entry("bot-driver", Some("Driver"), ActorKind::Bot, ActorStatus::Online),
+            overlay_entry("human_1", Some("Human One"), ActorKind::Human, ActorStatus::Online),
+            overlay_entry("human_2", Some("Hidden Human"), ActorKind::Human, ActorStatus::Hidden),
+        ]
+    }
+
+    #[test]
+    fn trigger_resolves_human_mentions() {
+        let ids = vec!["human_1".to_string(), "bot-driver".to_string()];
+        let trigger = build_mention_trigger(&ids, &overlay(), "bot-driver").expect("trigger");
+        assert_eq!(trigger.len(), 1);
+        assert_eq!(trigger[0].actor_id, "human_1");
+        assert_eq!(trigger[0].display_name, "Human One");
+    }
+
+    #[test]
+    fn trigger_excludes_self_mention() {
+        let ids = vec!["human_1".to_string()];
+        assert!(build_mention_trigger(&ids, &overlay(), "human_1").is_none());
+    }
+
+    #[test]
+    fn trigger_skips_hidden_humans() {
+        let ids = vec!["human_2".to_string()];
+        assert!(build_mention_trigger(&ids, &overlay(), "bot-driver").is_none());
+    }
+
+    #[test]
+    fn trigger_none_for_bot_only_or_unknown_mentions() {
+        let overlay = overlay();
+        assert!(build_mention_trigger(&["bot-driver".to_string()], &overlay, "human_1").is_none());
+        assert!(build_mention_trigger(&["unknown".to_string()], &overlay, "bot-driver").is_none());
+        assert!(build_mention_trigger(&[], &overlay, "bot-driver").is_none());
+    }
+
+    #[test]
+    fn trigger_deduplicates_repeated_mentions() {
+        let ids = vec!["human_1".to_string(), "human_1".to_string()];
+        let trigger = build_mention_trigger(&ids, &overlay(), "bot-driver").expect("trigger");
+        assert_eq!(trigger.len(), 1);
+    }
+}

--- a/src/bcs/crates/services/bcs-message-flow/src/lib.rs
+++ b/src/bcs/crates/services/bcs-message-flow/src/lib.rs
@@ -3,6 +3,7 @@ pub mod bot_event;
 pub mod group_flow;
 pub mod group_fusion;
 pub mod group_history;
+pub(crate) mod human_notify_hook;
 mod pending_message;
 pub(crate) mod protocol_context;
 pub(crate) mod message_tracker;

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -6390,3 +6390,101 @@ async fn bot_event_structured_routing_does_not_notify() {
         "non-mention routing paths must not notify"
     );
 }
+
+#[tokio::test]
+async fn bot_event_sender_routes_do_not_notify() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    group_with_present_human(&support).await;
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    let mut group = support.group.get("group-1").await.unwrap();
+    group.routing_policy = Some(RoutingPolicy {
+        sender_routes: std::collections::HashMap::from([(
+            "bot-driver".to_string(),
+            vec!["bot-observer".to_string()],
+        )]),
+        ..Default::default()
+    });
+    support.group.upsert(group).await.unwrap();
+
+    flow.handle_bot_event(bot_event_with_text("@Human One 请确认")).await.unwrap();
+
+    let notifications = recorder.wait_for_none().await;
+    assert!(
+        notifications.is_empty(),
+        "sender-routes path does not parse text mentions and must not notify"
+    );
+}
+
+#[tokio::test]
+async fn bot_event_structured_compat_mentions_do_not_notify() {
+    // Structured routing copies the resolved *responder selection* into
+    // `decision.mentions` for backward compatibility; that field may name
+    // humans without any text @-mention and must not trigger notifications.
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    group_with_present_human(&support).await;
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    let mut group = support.group.get("group-1").await.unwrap();
+    group.routing_policy = Some(RoutingPolicy {
+        mode: RoutingMode::Structured,
+        ..Default::default()
+    });
+    support.group.upsert(group).await.unwrap();
+
+    let mut cmd = bot_event_with_text("请确认");
+    cmd.event_payload["routing"] = json!({
+        "responders": [{"type": "bot", "value": "human_1"}],
+        "reason": "contract test: compat mention names a human",
+    });
+    flow.handle_bot_event(cmd).await.unwrap();
+
+    let notifications = recorder.wait_for_none().await;
+    assert!(
+        notifications.is_empty(),
+        "structured routing compat mentions must not notify"
+    );
+}
+
+#[tokio::test]
+async fn bot_event_policy_blocked_message_does_not_notify() {
+    // The notification must go through the same outbound policy as bot
+    // deliveries: when the chain blocks the content, humans must not receive
+    // it out-of-band either.
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    group_with_present_human(&support).await;
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_interceptor(BlockingInterceptor)
+    .with_human_mention_notify(recorder.clone());
+
+    flow.handle_bot_event(bot_event_with_text("@Human One 请确认")).await.unwrap();
+
+    let notifications = recorder.wait_for_none().await;
+    assert!(
+        notifications.is_empty(),
+        "policy-blocked content must not reach humans via notifications"
+    );
+}

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -6308,3 +6308,85 @@ async fn task_final_from_non_target_bot_does_not_append_history() {
         "a task terminal from a non-target bot must not append history"
     );
 }
+
+async fn group_with_present_human(support: &support::FlowTestSupport) {
+    let mut group = support.group.get("group-1").await.unwrap();
+    for participant in &mut group.participants {
+        if participant.bot_uuid == "human_1" {
+            participant.mode = Some(ParticipantMode::Present);
+        }
+    }
+    support.group.upsert(group).await.unwrap();
+}
+
+fn bot_event_with_text(message_text: &str) -> BotEventCommand {
+    BotEventCommand {
+        bot_id: "bot-driver".to_string(),
+        run_id: "run-1".to_string(),
+        group_id: "group-1".to_string(),
+        event_type: "chat.event".to_string(),
+        event_payload: json!({
+            "run_id": "run-1",
+            "bcs_group_id": "group-1",
+            "state": "final",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": message_text}],
+            },
+        }),
+        state: ChatEventState::Final,
+        bcs_session_id: None,
+    }
+}
+
+#[tokio::test]
+async fn bot_event_legacy_mention_notifies_mentioned_human() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    group_with_present_human(&support).await;
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    flow.handle_bot_event(bot_event_with_text("@Human One 请确认")).await.unwrap();
+
+    let notifications = recorder.wait_for(1).await;
+    assert_eq!(notifications.len(), 1, "bot text @human must notify");
+    assert_eq!(notifications[0].mentioned[0].actor_id, "human_1");
+    assert_eq!(notifications[0].sender_actor_id, "bot-driver");
+}
+
+#[tokio::test]
+async fn bot_event_structured_routing_does_not_notify() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    group_with_present_human(&support).await;
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    let mut group = support.group.get("group-1").await.unwrap();
+    group.routing_policy = Some(RoutingPolicy {
+        mode: RoutingMode::Structured,
+        ..Default::default()
+    });
+    support.group.upsert(group).await.unwrap();
+
+    flow.handle_bot_event(bot_event_with_text("@Human One 请确认")).await.unwrap();
+
+    let notifications = recorder.wait_for_none().await;
+    assert!(
+        notifications.is_empty(),
+        "non-mention routing paths must not notify"
+    );
+}

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -4138,3 +4138,283 @@ async fn web_send_persists_raw_mention_text_while_bots_receive_cleaned_text() {
     );
     assert_eq!(event["payload"]["message"]["mentions"][0], "bot-driver");
 }
+
+fn web_send_human_mentions(mention_actor_ids: Vec<String>) -> WebSendCommand {
+    WebSendCommand {
+        caller: CallerContext::Human(HumanActor {
+            actor_id: "human_1".to_string(),
+            staff_no: "1".to_string(),
+        }),
+        group_id: "group-1".to_string(),
+        session_id: Some("group-1:s1".to_string()),
+        from_actor_id: "human_1".to_string(),
+        from_name: Some("Human One".to_string()),
+        message: "hello".to_string(),
+        mentions: mention_actor_ids,
+        attachments: None,
+        thinking: None,
+        idempotency_key: None,
+        source_im_message_id: None,
+        channel_sender_identity: None,
+        sender_conn_id: None,
+        provider_bypass_headers: Vec::new(),
+    }
+}
+
+async fn set_human_1_present(support: &support::FlowTestSupport) {
+    let mut group = support.group.get("group-1").await.unwrap();
+    let human = group
+        .participants
+        .iter_mut()
+        .find(|participant| participant.bot_uuid == "human_1")
+        .unwrap();
+    human.mode = Some(ParticipantMode::Present);
+    support.group.upsert(group).await.unwrap();
+}
+
+async fn add_present_human_2(support: &support::FlowTestSupport) {
+    let mut group = support.group.get("group-1").await.unwrap();
+    group.participants.push(Participant {
+        bot_uuid: "human_2".to_string(),
+        bot_name: Some("Human Two".to_string()),
+        kind: None,
+        role: ParticipantRole::Observer,
+        actor_kind: ActorKind::Human,
+        mode: Some(ParticipantMode::Present),
+        tags: Vec::new(),
+    });
+    support.group.upsert(group).await.unwrap();
+}
+
+#[tokio::test]
+async fn web_send_notifies_explicitly_mentioned_human() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let mut group = support.group.get("group-1").await.unwrap();
+    group.participants.push(Participant {
+        bot_uuid: "human_2".to_string(),
+        bot_name: Some("Human Two".to_string()),
+        kind: None,
+        role: ParticipantRole::Observer,
+        actor_kind: ActorKind::Human,
+        mode: None,
+        tags: Vec::new(),
+    });
+    support.group.upsert(group).await.unwrap();
+
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    flow.handle_web_send(web_send_human_mentions(vec!["human_2".to_string()]))
+        .await
+        .unwrap();
+
+    let notifications = recorder.wait_for(1).await;
+    assert_eq!(notifications.len(), 1, "mentioned human must be notified");
+    assert_eq!(notifications[0].mentioned.len(), 1);
+    assert_eq!(notifications[0].mentioned[0].actor_id, "human_2");
+    assert_eq!(notifications[0].mentioned[0].display_name, "Human Two");
+    assert_eq!(notifications[0].sender_actor_id, "human_1");
+    assert_eq!(notifications[0].group_id, "group-1");
+    assert_eq!(notifications[0].session_id, "group-1:s1");
+}
+
+#[tokio::test]
+async fn web_send_skips_notification_for_self_mention() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    flow.handle_web_send(web_send_human_mentions(vec!["human_1".to_string()]))
+        .await
+        .unwrap();
+
+    let notifications = recorder.wait_for_none().await;
+    assert!(notifications.is_empty(), "self mention must not notify");
+}
+
+#[tokio::test]
+async fn web_send_skips_notification_for_bot_only_mentions() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    flow.handle_web_send(web_send_human_mentions(vec!["bot-driver".to_string()]))
+        .await
+        .unwrap();
+
+    let notifications = recorder.wait_for_none().await;
+    assert!(notifications.is_empty(), "bot-only mentions must not notify");
+}
+
+#[tokio::test]
+async fn web_send_skips_notification_when_port_unavailable() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let mut group = support.group.get("group-1").await.unwrap();
+    group.participants.push(Participant {
+        bot_uuid: "human_2".to_string(),
+        bot_name: Some("Human Two".to_string()),
+        kind: None,
+        role: ParticipantRole::Observer,
+        actor_kind: ActorKind::Human,
+        mode: None,
+        tags: Vec::new(),
+    });
+    support.group.upsert(group).await.unwrap();
+
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(false));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    flow.handle_web_send(web_send_human_mentions(vec!["human_2".to_string()]))
+        .await
+        .unwrap();
+
+    let notifications = recorder.wait_for_none().await;
+    assert!(
+        notifications.is_empty(),
+        "unavailable port must block a would-be notification"
+    );
+}
+
+#[tokio::test]
+async fn web_send_text_mention_notifies_resolved_human() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    add_present_human_2(&support).await;
+
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    let mut cmd = web_send_human_mentions(Vec::new());
+    cmd.message = "@Human Two 你怎么看".to_string();
+    flow.handle_web_send(cmd).await.unwrap();
+
+    let notifications = recorder.wait_for(1).await;
+    assert_eq!(notifications.len(), 1, "text-mentioned human must be notified");
+    assert_eq!(notifications[0].mentioned.len(), 1);
+    assert_eq!(notifications[0].mentioned[0].actor_id, "human_2");
+    assert_eq!(notifications[0].mentioned[0].display_name, "Human Two");
+}
+
+#[tokio::test]
+async fn web_send_at_all_alone_does_not_notify() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    set_human_1_present(&support).await;
+
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    let mut cmd = web_send_human_mentions(Vec::new());
+    cmd.message = "@所有人 通知一下".to_string();
+    flow.handle_web_send(cmd).await.unwrap();
+
+    let notifications = recorder.wait_for_none().await;
+    assert!(notifications.is_empty(), "@all alone must not notify humans");
+}
+
+#[tokio::test]
+async fn web_send_at_all_with_explicit_human_notifies_that_human() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    add_present_human_2(&support).await;
+
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    let mut cmd = web_send_human_mentions(Vec::new());
+    cmd.message = "@所有人 @Human Two 请回复".to_string();
+    flow.handle_web_send(cmd).await.unwrap();
+
+    let notifications = recorder.wait_for(1).await;
+    assert_eq!(notifications.len(), 1, "explicit human next to @all must be notified");
+    assert_eq!(notifications[0].mentioned.len(), 1);
+    assert_eq!(notifications[0].mentioned[0].actor_id, "human_2");
+}
+
+#[tokio::test]
+async fn group_callback_notifies_explicitly_mentioned_human() {
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    let mut group = support.group.get("group-1").await.unwrap();
+    group.participants.push(Participant {
+        bot_uuid: "human_2".to_string(),
+        bot_name: Some("Human Two".to_string()),
+        kind: None,
+        role: ParticipantRole::Observer,
+        actor_kind: ActorKind::Human,
+        mode: None,
+        tags: Vec::new(),
+    });
+    support.group.upsert(group).await.unwrap();
+
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    flow.handle_group_callback(GroupCallbackCommand {
+        group_id: "group-1".to_string(),
+        message: "system callback".to_string(),
+        mentions: vec!["human_2".to_string()],
+        metadata: Some(json!({"source": "contract"})),
+        store_message: false,
+    })
+    .await
+    .unwrap();
+
+    let notifications = recorder.wait_for(1).await;
+    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications[0].mentioned[0].actor_id, "human_2");
+    assert_eq!(notifications[0].sender_actor_id, "system");
+    assert_eq!(notifications[0].session_id, "");
+}

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_message_flow.rs
@@ -3055,7 +3055,9 @@ async fn persistent_group_send_routes_stores_and_returns_legacy_fields() {
         outcome.routed_to,
         vec!["bot-driver".to_string(), "bot-observer".to_string()]
     );
-    assert_eq!(outcome.mentions, Vec::<String>::new());
+    // The fake router resolves text mentions like the production legacy
+    // `route()` does: "@Driver" resolves to the driver bot.
+    assert_eq!(outcome.mentions, vec!["bot-driver".to_string()]);
     assert_eq!(
         support.routing.route_calls().await,
         vec![(
@@ -4378,7 +4380,10 @@ async fn web_send_at_all_with_explicit_human_notifies_that_human() {
 }
 
 #[tokio::test]
-async fn group_callback_notifies_explicitly_mentioned_human() {
+async fn group_callback_never_triggers_human_notification() {
+    // Security boundary: the callback route carries no caller identity, so its
+    // request-controlled `mentions` must never reach the notification backend
+    // (an unauthenticated caller could otherwise DM arbitrary participants).
     let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
     let mut group = support.group.get("group-1").await.unwrap();
     group.participants.push(Participant {
@@ -4412,9 +4417,120 @@ async fn group_callback_notifies_explicitly_mentioned_human() {
     .await
     .unwrap();
 
+    let notifications = recorder.wait_for_none().await;
+    assert!(
+        notifications.is_empty(),
+        "unauthenticated callbacks must not trigger human notifications"
+    );
+}
+
+#[tokio::test]
+async fn web_send_dm_group_does_not_notify_mentioned_human() {
+    // DM groups carry no @-mention semantics, so even an explicit mention
+    // must not notify.
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    make_human_bot_dm(&support).await;
+    let mut group = support.group.get("group-1").await.unwrap();
+    group.participants.push(Participant {
+        bot_uuid: "human_2".to_string(),
+        bot_name: Some("Human Two".to_string()),
+        kind: None,
+        role: ParticipantRole::Observer,
+        actor_kind: ActorKind::Human,
+        mode: Some(ParticipantMode::Present),
+        tags: Vec::new(),
+    });
+    support.group.upsert(group).await.unwrap();
+
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    flow.handle_web_send(web_send_human_mentions(vec!["human_2".to_string()]))
+        .await
+        .unwrap();
+
+    let notifications = recorder.wait_for_none().await;
+    assert!(
+        notifications.is_empty(),
+        "DM groups must not trigger human notifications"
+    );
+}
+
+#[tokio::test]
+async fn web_send_policy_blocked_message_does_not_notify_humans() {
+    // The notification must go through the same outbound policy as bot
+    // deliveries: when the chain blocks the content, humans must not receive
+    // it out-of-band either.
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    add_present_human_2(&support).await;
+
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_interceptor(BlockingInterceptor)
+    .with_human_mention_notify(recorder.clone());
+
+    flow.handle_web_send(web_send_human_mentions(vec!["human_2".to_string()]))
+        .await
+        .unwrap();
+
+    let notifications = recorder.wait_for_none().await;
+    assert!(
+        notifications.is_empty(),
+        "policy-blocked content must not reach humans via notifications"
+    );
+}
+
+#[tokio::test]
+async fn persistent_group_send_text_mention_notifies_human() {
+    // `POST /groups/{id}/messages` resolves text @-mentions through the same
+    // router and must notify mentioned humans like the workbench send path.
+    let support = support::FlowTestSupport::new_group_with_driver_and_observer().await;
+    add_present_human_2(&support).await;
+
+    let recorder = Arc::new(support::RecordingHumanMentionNotify::available(true));
+    let flow = BcsMessageFlow::new(
+        support.group.clone(),
+        support.routing.clone(),
+        support.registry.clone(),
+        support.bot_delivery.clone(),
+        support.frontend_delivery.clone(),
+    )
+    .with_human_mention_notify(recorder.clone());
+
+    flow.handle_persistent_group_send(PersistentGroupSendCommand {
+        caller: CallerContext::Human(HumanActor {
+            actor_id: "human_1".to_string(),
+            staff_no: "1".to_string(),
+        }),
+        group_id: "group-1".to_string(),
+        sender: "human_1".to_string(),
+        content: "@Human Two 请查收".to_string(),
+        message_type: GroupMessageType::Bot,
+        role: MessageRole::User,
+        max_group_messages: 10,
+        store_messages: true,
+    })
+    .await
+    .unwrap();
+
     let notifications = recorder.wait_for(1).await;
-    assert_eq!(notifications.len(), 1);
+    assert_eq!(notifications.len(), 1, "persistent send must notify");
+    assert_eq!(notifications[0].mentioned.len(), 1);
     assert_eq!(notifications[0].mentioned[0].actor_id, "human_2");
-    assert_eq!(notifications[0].sender_actor_id, "system");
-    assert_eq!(notifications[0].session_id, "");
+    assert_eq!(notifications[0].mentioned[0].display_name, "Human Two");
+    assert_eq!(notifications[0].sender_actor_id, "human_1");
+    assert_eq!(notifications[0].message_text, "Human Two 请查收");
 }

--- a/src/bcs/crates/test-support/bcs-test-support/Cargo.toml
+++ b/src/bcs/crates/test-support/bcs-test-support/Cargo.toml
@@ -17,6 +17,7 @@ bcs-auth-api    = { workspace = true }
 bcs-cache-api   = { workspace = true }
 bcs-db-api      = { workspace = true }
 bcs-llm-api     = { workspace = true }
+bcs-human-notify-api = { workspace = true }
 bcs-session     = { workspace = true }
 bcs-session-file = { workspace = true }
 axum            = { workspace = true }

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/port/human_notify.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/port/human_notify.rs
@@ -1,0 +1,72 @@
+//! Conformance harness for `HumanMentionNotifier` implementations.
+
+use bcs_human_notify_api::{
+    HumanMentionNotifier, HumanNotifyError, MentionNotification, MentionedHuman,
+};
+
+/// Harness inputs describing how the host environment behaves for a specific
+/// implementation. Implementations without failure injection leave the
+/// failure cases as `None` and those assertions are skipped.
+#[derive(Debug, Clone)]
+pub struct HumanNotifyContractHarness {
+    /// Backend name the implementation must report.
+    pub backend_name: &'static str,
+    /// A notification whose recipients all deliver successfully.
+    pub success_case: MentionNotification,
+    /// A notification whose recipients all fail (optional).
+    pub failure_case: Option<MentionNotification>,
+    /// A notification mixing one successful and one failing recipient
+    /// (optional).
+    pub partial_case: Option<MentionNotification>,
+}
+
+/// Runs the shared conformance assertions against a notifier implementation.
+pub async fn human_mention_notifier_contract_tests<T>(
+    notifier: &T,
+    harness: HumanNotifyContractHarness,
+) where
+    T: HumanMentionNotifier + ?Sized,
+{
+    assert_eq!(
+        notifier.backend_name(),
+        harness.backend_name,
+        "backend_name must match the registered factory name"
+    );
+
+    let mut empty = harness.success_case.clone();
+    empty.mentioned.clear();
+    notifier
+        .notify(&empty)
+        .await
+        .expect("empty recipient list must succeed without delivery");
+
+    notifier
+        .notify(&harness.success_case)
+        .await
+        .expect("all-success notification must return Ok");
+
+    if let Some(failure_case) = &harness.failure_case {
+        let error = notifier
+            .notify(failure_case)
+            .await
+            .expect_err("all-failure notification must return Err");
+        assert!(
+            matches!(error, HumanNotifyError::Delivery(_)),
+            "all-failure notification must classify as Delivery, got: {error}"
+        );
+    }
+
+    if let Some(partial_case) = &harness.partial_case {
+        notifier
+            .notify(partial_case)
+            .await
+            .expect("partial-failure notification must return Ok");
+    }
+
+    let mut invalid = harness.success_case.clone();
+    invalid.mentioned = vec![MentionedHuman {
+        actor_id: "not-a-human-prefix".to_string(),
+        display_name: "Invalid".to_string(),
+    }];
+    let _ = notifier.notify(&invalid).await;
+}

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/port/human_notify.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/port/human_notify.rs
@@ -68,5 +68,10 @@ pub async fn human_mention_notifier_contract_tests<T>(
         actor_id: "not-a-human-prefix".to_string(),
         display_name: "Invalid".to_string(),
     }];
-    let _ = notifier.notify(&invalid).await;
+    // Aggregation contract: recipient ids the backend cannot parse are
+    // skipped and logged, and must not count as delivery failures.
+    notifier
+        .notify(&invalid)
+        .await
+        .expect("invalid recipient ids must be skipped, not failed");
 }

--- a/src/bcs/crates/test-support/bcs-test-support/src/contract/port/mod.rs
+++ b/src/bcs/crates/test-support/bcs-test-support/src/contract/port/mod.rs
@@ -1,6 +1,7 @@
 //! Port contract harnesses.
 
 pub mod bot_terminal_observer;
+pub mod human_notify;
 pub mod metrics;
 
 use bcs_domain::HumanInputNotificationMode;
@@ -17,6 +18,7 @@ use bcs_service_api::{
 };
 
 pub use bot_terminal_observer::bot_terminal_observer_port_contract_tests;
+pub use human_notify::{human_mention_notifier_contract_tests, HumanNotifyContractHarness};
 pub use metrics::{
     bot_metrics_snapshot_port_contract_tests,
     delivery_policy_block_instrumentation_hook_contract_tests,

--- a/src/bcs/crates/test-support/message_flow_contract_support.rs
+++ b/src/bcs/crates/test-support/message_flow_contract_support.rs
@@ -372,6 +372,151 @@ impl RoutingCoreService for FakeRoutingCoreService {
         }
     }
 
+    /// Mirrors the production router contract for text @-mentions so message
+    /// flow contract tests can exercise the human mention notify hook:
+    /// display-name/uuid resolution, Absent-Human drop (Human default mode is
+    /// Absent), Hidden drop, `@all`/`@所有人` all-Bot Send, and mention
+    /// stripping. Actor kind/mode/status are read from the overlay first
+    /// (authoritative, like production `route_with_overlay`), falling back to
+    /// the participant row when the overlay has no entry. Simplifications vs
+    /// the production router: no display-name mention boundary check, no
+    /// ManagerWorker worker exclusion, and no muted/hidden forced-Inject
+    /// downgrade (Hidden actors are dropped from mentions entirely instead of
+    /// being carried as hidden mentions).
+    async fn route_with_overlay(
+        &self,
+        group: &Group,
+        message: &str,
+        sender_bot_id: Option<&str>,
+        overlay: &[bcs_service_api::RouteParticipantOverlay],
+    ) -> RoutingDecision {
+        self.route_calls.write().await.push((
+            group.id.clone(),
+            message.to_string(),
+            sender_bot_id.map(str::to_string),
+        ));
+        let lower = message.to_lowercase();
+        let has_all = lower.contains("@all") || message.contains("@所有人");
+
+        let mut resolved: Vec<String> = Vec::new();
+        let mut strip_at: Vec<usize> = Vec::new();
+        for (at_index, _) in message.match_indices('@') {
+            let after_at = &message[at_index + '@'.len_utf8()..];
+            let by_name = group
+                .participants
+                .iter()
+                .filter(|participant| {
+                    participant
+                        .bot_name
+                        .as_deref()
+                        .map_or(false, |name| !name.is_empty() && after_at.starts_with(name))
+                })
+                .max_by_key(|participant| participant.bot_name.as_deref().map(str::len));
+            let uuid = if let Some(participant) = by_name {
+                Some(participant.bot_uuid.clone())
+            } else {
+                let token: String = after_at
+                    .chars()
+                    .take_while(|ch| ch.is_alphanumeric() || *ch == '-' || *ch == '_' || *ch == ':')
+                    .collect();
+                if token.is_empty() {
+                    None
+                } else {
+                    group
+                        .participants
+                        .iter()
+                        .find(|participant| participant.bot_uuid == token)
+                        .map(|participant| participant.bot_uuid.clone())
+                }
+            };
+            if let Some(uuid) = uuid {
+                strip_at.push(at_index);
+                if !resolved.contains(&uuid) {
+                    resolved.push(uuid);
+                }
+            }
+        }
+
+        let mut mentions: Vec<String> = Vec::new();
+        let mut bot_mentions: Vec<String> = Vec::new();
+        for uuid in &resolved {
+            let Some(participant) = group.get_participant(uuid) else {
+                continue;
+            };
+            let (actor_kind, mode, status) = match overlay
+                .iter()
+                .find(|entry| entry.bot_uuid == *uuid)
+            {
+                Some(entry) => (
+                    entry.actor_kind,
+                    entry
+                        .mode
+                        .unwrap_or_else(|| ParticipantMode::default_for(entry.actor_kind)),
+                    entry.status,
+                ),
+                None => (
+                    participant.actor_kind,
+                    participant
+                        .mode
+                        .unwrap_or_else(|| ParticipantMode::default_for(participant.actor_kind)),
+                    ActorStatus::Online,
+                ),
+            };
+            if status == ActorStatus::Hidden {
+                continue;
+            }
+            if actor_kind == ActorKind::Human && mode == ParticipantMode::Absent {
+                continue;
+            }
+            if actor_kind == ActorKind::Bot {
+                bot_mentions.push(uuid.clone());
+            }
+            if !mentions.contains(uuid) {
+                mentions.push(uuid.clone());
+            }
+        }
+
+        let targets = group
+            .participants
+            .iter()
+            .filter(|participant| participant.is_bot())
+            .map(|participant| {
+                let delivery_type = if has_all {
+                    bcs_service_api::DeliveryType::Send
+                } else if !bot_mentions.is_empty() {
+                    if bot_mentions.contains(&participant.bot_uuid) {
+                        bcs_service_api::DeliveryType::Send
+                    } else {
+                        bcs_service_api::DeliveryType::Inject
+                    }
+                } else if participant.bot_uuid == group.driver_bot {
+                    bcs_service_api::DeliveryType::Send
+                } else {
+                    bcs_service_api::DeliveryType::Inject
+                };
+                RoutingTarget {
+                    bot_uuid: participant.bot_uuid.clone(),
+                    url: String::new(),
+                    is_driver: participant.bot_uuid == group.driver_bot,
+                    delivery_type,
+                }
+            })
+            .collect();
+
+        let cleaned_message = message
+            .char_indices()
+            .filter(|(index, _)| !strip_at.contains(index))
+            .map(|(_, ch)| ch)
+            .collect();
+
+        RoutingDecision {
+            targets,
+            mentions,
+            cleaned_message,
+            hidden_mentions: vec![],
+        }
+    }
+
     async fn route_dm_with_overlay(
         &self,
         group: &Group,
@@ -833,6 +978,69 @@ impl FrontendDeliveryPort for RecordingFrontendDelivery {
     }
 
     async fn unregister_run(&self, _run_id: &str) -> ServiceResult<()> {
+        Ok(())
+    }
+}
+
+/// Recording fake for the human mention notify port (contract tests).
+#[derive(Default)]
+pub struct RecordingHumanMentionNotify {
+    available: std::sync::atomic::AtomicBool,
+    notifications: tokio::sync::Mutex<Vec<bcs_service_api::port::human_notify::MentionNotification>>,
+}
+
+impl RecordingHumanMentionNotify {
+    pub fn available(available: bool) -> Self {
+        Self {
+            available: std::sync::atomic::AtomicBool::new(available),
+            notifications: tokio::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    pub async fn notifications(
+        &self,
+    ) -> Vec<bcs_service_api::port::human_notify::MentionNotification> {
+        self.notifications.lock().await.clone()
+    }
+
+    /// Poll until `expected` notifications arrive or a 2s deadline passes.
+    pub async fn wait_for(
+        &self,
+        expected: usize,
+    ) -> Vec<bcs_service_api::port::human_notify::MentionNotification> {
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(2);
+        loop {
+            let count = self.notifications.lock().await.len();
+            if count >= expected || tokio::time::Instant::now() >= deadline {
+                return self.notifications.lock().await.clone();
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        }
+    }
+
+    /// Negative assertion helper: waits a fixed window during which a spawned
+    /// notification would have arrived, then returns what was recorded
+    /// (callers assert emptiness). `wait_for(0)` must NOT be used for
+    /// negative assertions — it returns immediately.
+    pub async fn wait_for_none(
+        &self,
+    ) -> Vec<bcs_service_api::port::human_notify::MentionNotification> {
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        self.notifications.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl bcs_service_api::port::human_notify::HumanMentionNotifyPort for RecordingHumanMentionNotify {
+    fn is_available(&self) -> bool {
+        self.available.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    async fn notify_mentioned_humans(
+        &self,
+        notification: bcs_service_api::port::human_notify::MentionNotification,
+    ) -> ServiceResult<()> {
+        self.notifications.lock().await.push(notification);
         Ok(())
     }
 }

--- a/src/bcs/crates/test-support/message_flow_contract_support.rs
+++ b/src/bcs/crates/test-support/message_flow_contract_support.rs
@@ -338,38 +338,18 @@ impl FakeRoutingCoreService {
 
 #[async_trait]
 impl RoutingCoreService for FakeRoutingCoreService {
+    /// Mirrors the production legacy `route()`: text @-mentions are resolved
+    /// against participants (including Humans, which `route()` does not
+    /// classify), so this delegates to the overlay variant with an empty
+    /// overlay — actor kind/mode/status then fall back to the participant
+    /// rows, matching the production router's defensive default.
     async fn route(
         &self,
         group: &Group,
         message: &str,
         sender_bot_id: Option<&str>,
     ) -> RoutingDecision {
-        self.route_calls.write().await.push((
-            group.id.clone(),
-            message.to_string(),
-            sender_bot_id.map(str::to_string),
-        ));
-        let targets = group
-            .participants
-            .iter()
-            .filter(|participant| participant.is_bot())
-            .map(|participant| RoutingTarget {
-                bot_uuid: participant.bot_uuid.clone(),
-                url: String::new(),
-                is_driver: participant.bot_uuid == group.driver_bot,
-                delivery_type: if participant.bot_uuid == group.driver_bot {
-                    bcs_service_api::DeliveryType::Send
-                } else {
-                    bcs_service_api::DeliveryType::Inject
-                },
-            })
-            .collect();
-        RoutingDecision {
-            targets,
-            mentions: Vec::new(),
-            cleaned_message: message.to_string(),
-            hidden_mentions: vec![],
-        }
+        self.route_with_overlay(group, message, sender_bot_id, &[]).await
     }
 
     /// Mirrors the production router contract for text @-mentions so message
@@ -582,14 +562,62 @@ impl RoutingCoreService for FakeRoutingCoreService {
         }
     }
 
+    /// Minimal faithful stand-in for the production structured router:
+    /// resolves `bot`/`name` selectors by participant uuid or display name and
+    /// mirrors the production compatibility behavior of copying the resolved
+    /// responder ids into `decision.mentions` (which may name Humans — the
+    /// field is a routing transcript, not a text-mention signal).
     async fn route_structured(
         &self,
-        _group: &Group,
-        _routing: &bcs_service_api::ChatEventRouting,
-        _sender_bot_id: &str,
+        group: &Group,
+        routing: &bcs_service_api::ChatEventRouting,
+        sender_bot_id: &str,
         _registry: &dyn BotRegistryCoreService,
     ) -> Result<RoutingDecision, StructuredRoutingError> {
-        Err(StructuredRoutingError::NoTargetMatched)
+        let mut resolved: Vec<String> = Vec::new();
+        for selector in &routing.responders {
+            let Some(value) = selector.value.as_deref() else {
+                continue;
+            };
+            if selector.selector_type != "bot" && selector.selector_type != "name" {
+                continue;
+            }
+            if let Some(participant) = group
+                .participants
+                .iter()
+                .find(|p| p.bot_uuid == value || p.bot_name.as_deref() == Some(value))
+            {
+                if !resolved.contains(&participant.bot_uuid) {
+                    resolved.push(participant.bot_uuid.clone());
+                }
+            }
+        }
+        if resolved.is_empty() {
+            return Err(StructuredRoutingError::NoTargetMatched);
+        }
+        let include_self = routing.include_self.unwrap_or(false);
+        let targets = group
+            .participants
+            .iter()
+            .filter(|p| p.is_bot())
+            .filter(|p| p.bot_uuid != sender_bot_id || (include_self && resolved.contains(&p.bot_uuid)))
+            .map(|p| RoutingTarget {
+                bot_uuid: p.bot_uuid.clone(),
+                url: String::new(),
+                is_driver: p.bot_uuid == group.driver_bot,
+                delivery_type: if resolved.contains(&p.bot_uuid) {
+                    bcs_service_api::DeliveryType::Send
+                } else {
+                    bcs_service_api::DeliveryType::Inject
+                },
+            })
+            .collect();
+        Ok(RoutingDecision {
+            targets,
+            mentions: resolved,
+            cleaned_message: String::new(),
+            hidden_mentions: vec![],
+        })
     }
 }
 


### PR DESCRIPTION
## Problem

BCS Human Actor V1 models humans as first-class participants (`human_{staff_no}`), and the router resolves text `@`-mentions against them. But when a message @-mentions a human participant, nothing actively notifies that human — `RoutingDecision.mentions` surfaces the mention for transcripts only, and humans never enter the delivery table. Mentions are only seen if the human happens to be watching the bound IM conversation or the workbench.

## Solution

Add a pluggable "human mention notification" plugin family that notifies @-mentioned humans through configurable backends:

- **Contract**: new leaf crate `bcs-human-notify-api` — `HumanMentionNotifier` trait + `inventory`-registered `HumanMentionNotifierFactory` (modeled on `bcs-secret-api`), with `HumanNotifyError::{Config, Delivery}` distinguishing build-time from runtime failures. The Plugin API owns its notification schema (`MentionNotification` / `MentionedHuman`); the Service API port keeps its own DTOs and the bootstrap adapter translates between them, so the two contracts evolve independently.
- **Port**: `HumanMentionNotifyPort` (+ noop default) in `bcs-service-api`; message flow depends only on the port.
- **Trigger boundary**: shared `human_notify_hook` helpers in `bcs-message-flow`, wired at the identified entry points (`handle_web_send`, `handle_persistent_group_send`, bot-event legacy-mention path). Triggers fire only on real text/explicit human mentions — not on structured routing's compatibility `mentions` field, not on sender-routes/default-policy decisions, not on DM groups, excluding self-mentions and Hidden humans.
- **Outbound policy**: before a notification leaves the process, the message content passes the same outbound interceptor chain that governs bot deliveries of the same message (first non-sender delivery target as policy receiver; credential-gated exactly like bot deliveries). Policy-blocked content is never pushed to humans out-of-band, and the hook fires only after the message is persisted.
- **Callback exclusion**: `handle_group_callback` deliberately does not trigger notifications — the callback route carries no caller identity, so request-controlled `mentions` would let unauthenticated callers push external notifications to arbitrary human participants. Can be re-enabled behind an authenticated callback caller.
- **Backend**: built-in `dummy` backend (log-only) registered via `inventory`; backends selected by new `[human_notify]` config section.
- **Bootstrap**: selection with startup-error semantics (unset/disabled → noop; missing entry / unregistered backend / invalid config → startup failure) and a port adapter that logs errors (with mentioned actor context) and bounds runtime with a 10s timeout.
- **Conformance**: reusable harness in `bcs-test-support`, mounted by the dummy backend.

Configuration (feature off by default when absent):

```toml
[human_notify]
provider = "dummy"

[human_notify.providers.dummy]
enabled = true
```

Internal DingTalk backend (DM per mentioned human) is delivered separately in the internal repo against this contract.

## Validation

- `cargo test -p bcs-service-api human_notify`, `cargo test -p bcs-config-api human_notify`: pass
- `cargo test -p bcs-human-notify-dummy`: unit + conformance pass
- `cargo test -p bcs-message-flow`: 277 passed, incl. trigger-boundary integration tests (explicit/text mentions, self-mention, bot-only, port unavailable, `@all` alone vs `@all` + explicit human, DM-group negative, sender-routes/structured/default-policy negatives, callback-exclusion negative, policy-blocked suppression for both web_send and bot_event paths, persistent-send positive)
- `cargo test -p bcs human_notify`: 9 passed (config parse + 6 selection-branch tests + adapter timeout-bounds-runtime + adapter DTO translation)
- `cargo check --workspace --all-targets`: clean (no new warnings)
- Example/local configs parse through the checked-in config loader tests

## Compatibility and risk

- New `[human_notify]` config section is additive; absent/disabled → noop port, zero behavior change.
- New Plugin API crate and new Service API port are both additive contracts; no existing contract changed.
- `handle_group_callback` no longer triggers notifications (relative to the initial revision of this PR): intentional security boundary for an unauthenticated route.
- Rollback: remove the `[human_notify]` section (or set `enabled = false`) → noop port.

## 架构合规自检（修改 BCS service-api 或 plugin-api 时必填）

- [x] 契约方向分类：[x] Service API   [x] Plugin API   [ ] Protocol Definition
- [x] 改动类型：[x] additive   [ ] breaking

### 新增 Outbound Port（仅引入新 Port 时必填）

通过了 `src/bcs/docs/arch/refactor-arch-proposal.md` "Outbound Port Design Criteria" 三条检验：

- **De-domain test**：签名仅依赖 std / 3rd-party / types，论证：`HumanMentionNotifyPort::notify_mentioned_humans` 只消费端口自有 DTO（`MentionNotification`，纯 String/Vec<u64> 字段），不依赖 application/core 类型；通知投递是典型的基础设施关注点，与 BCS 群组域规则无关。
- **Infrastructure swap test**：给出至少两种基础设施实现方案：公开仓库内置 log-only `dummy` 实现（本地/CI 形态）；内部仓库落地钉钉 DM 实现（真实生产形态）；端口另有 noop 默认实现。三者经同一 `HumanMentionNotifierFactory` inventory 注册按配置互换。
- **Business reuse test**：业务动词单一性论证：端口只有一个业务动词"提醒被 @ 的人类参与者"（`notify_mentioned_humans` + `is_available` 可用性探测），触发判定（哪些提及算数）留在消息流，投递策略留给后端，端口不混入路由或成员管理语义。

### 新增偏离（仅在确实必要时）

- [x] 否
