### PR TITLE
fix(backend): route community runtime through BaaS

### DIFF
--- a/src/backend/src/agentclaw/community/core/aicoding/README.md
+++ b/src/backend/src/agentclaw/community/core/aicoding/README.md
@@ -13,6 +13,7 @@ provides:
 consumes:
   - "BotService"
   - "DeviceService"
+  - "BaasService"
   - "WorkspacePathFactory"
   - "CachePlugin"
   - "AntCodeConfig"
@@ -21,6 +22,7 @@ internal_dependencies:
   - agentclaw.community.core.repository.protocols.bot    # repository contracts consumed by this module
   - agentclaw.community.core.bot_management
   - agentclaw.community.core.devices
+  - agentclaw.community.core.service_bot
   - agentclaw.community.core.workspace
   - agentclaw.community.di.config
   - agentclaw.corp.di.config_corp

--- a/src/backend/src/agentclaw/community/core/aicoding/services/workspace_service.py
+++ b/src/backend/src/agentclaw/community/core/aicoding/services/workspace_service.py
@@ -16,7 +16,9 @@ import httpx
 from injector import inject
 
 from agentclaw.community.core.bot_management.services.bot_service import BotService
+from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
 from agentclaw.community.core.devices.services.device_service import DeviceService
+from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.workspace.path_factory import WorkspacePathFactory
 from agentclaw.community.plugin_api.sandbox_runtime import RELAY_PORT, SandboxRuntimeClient
 
@@ -50,11 +52,13 @@ class WorkspaceService:
         device_provider: DeviceService,
         path_factory: WorkspacePathFactory,
         sandbox_client: SandboxRuntimeClient,
+        baas_service: BaasService,
     ) -> None:
         self._bot_provider = bot_provider
         self._device_provider = device_provider
         self._path_factory = path_factory
         self._sandbox_client = sandbox_client
+        self._baas_service = baas_service
 
     def get_workspace_path(
         self,
@@ -180,36 +184,48 @@ class WorkspaceService:
         if not self._bot_provider or not self._device_provider:
             raise RuntimeError("WorkspaceService requires bot_provider and device_provider for git clone")
 
-        sandbox_id = self._resolve_sandbox_id(bot_id, user_id)
-        req = self._sandbox_client.build_proxy_request(
-            sandbox_id=sandbox_id, api_path="/api/git/clone", port=RELAY_PORT
-        )
+        device = self._resolve_device(bot_id, user_id)
+        payload = {"url": git_url, "target_dir": target_dir, "branch": branch}
 
-        async with httpx.AsyncClient(timeout=CLONE_TIMEOUT) as client:
-            resp = await client.post(
-                req.url,
-                json={"url": git_url, "target_dir": target_dir, "branch": branch},
-                headers=req.headers,
+        if device.device_provider == "baas":
+            # BaaS owns runtime addressing, including its backing platform.
+            resp = await asyncio.to_thread(
+                self._baas_service.invoke_http,
+                bind_id=device.id,
+                port=RELAY_PORT,
+                path="/api/git/clone",
+                method="POST",
+                json=payload,
+                device_affinity=user_id,
+                auth_header="x-proxypass-token",
+                timeout=CLONE_TIMEOUT,
             )
-            resp.raise_for_status()
-            result = resp.json()
+        else:
+            sandbox_id = (device.device_props or {}).get("sandbox_id")
+            if not sandbox_id:
+                raise ValueError(f"Bot {bot_id} device has no sandbox_id")
+            req = self._sandbox_client.build_proxy_request(
+                sandbox_id=sandbox_id, api_path="/api/git/clone", port=RELAY_PORT
+            )
+            async with httpx.AsyncClient(timeout=CLONE_TIMEOUT) as client:
+                resp = await client.post(req.url, json=payload, headers=req.headers)
+
+        resp.raise_for_status()
+        result = resp.json()
 
         if not result.get("success"):
             raise Exception(result.get("error", "克隆失败"))
 
-    def _resolve_sandbox_id(self, bot_id: Optional[str], user_id: Optional[str]) -> str:
-        """bot_id → binding_id → sandbox_id"""
+    def _resolve_device(
+        self, bot_id: Optional[str], user_id: Optional[str]
+    ) -> DeviceBindingRecord:
+        """Resolve the binding while preserving its provider identity."""
         bot = self._bot_provider.get_bot(bot_id, user_id)
         binding_id = bot.get("binding_id")
         if not binding_id:
             raise ValueError(f"Bot {bot_id} has no device binding")
 
-        device = self._device_provider.get_device(binding_id=binding_id)
-        device_props = getattr(device, "device_props", {}) or {}
-        sandbox_id = device_props.get("sandbox_id")
-        if not sandbox_id:
-            raise ValueError(f"Bot {bot_id} device has no sandbox_id")
-        return sandbox_id
+        return self._device_provider.get_device(binding_id=binding_id)
 
     async def _check_workspace(self, path: str, user_id: str) -> Dict[str, Any]:
         """检查工作区环境"""

--- a/src/backend/src/agentclaw/community/core/devices/services/baas_conn_info.py
+++ b/src/backend/src/agentclaw/community/core/devices/services/baas_conn_info.py
@@ -16,6 +16,9 @@ from typing import TYPE_CHECKING, Any
 
 from agentclaw.community.core.service_bot.services.baas_service import BotWsConnectionInfoResponse
 from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.sandbox_runtime import (
+    SandboxRuntimeUnavailableError,
+)
 
 if TYPE_CHECKING:
     from agentclaw.community.plugin_api.sandbox_runtime import SandboxRuntimeClient
@@ -158,18 +161,20 @@ def build_baas_conn_info_for_http(
     # 跟进：docs/superpowers/baas-refactor-dirty-work.md §1
     target = ws_info.target or ""
     if target.startswith("ARCA_"):
-        # The sandbox-runtime client owns the proxy base URL (prod=arca proxy).
-        # An ``ARCA_`` target is only ever produced by a prod/corp deployment, so
-        # ``sandbox_client`` is always wired for the callers that can reach this
-        # branch (baas builder/plugin). The community client never yields an
-        # ``ARCA_`` target, so its ``proxy_base_url()`` (which raises) is never hit.
-        if sandbox_client is None:
-            raise RuntimeError(
-                "build_baas_conn_info_for_http: ARCA target requires a "
-                f"sandbox_client to resolve the proxy base URL (target={target!r})"
-            )
-        proxy_base = sandbox_client.proxy_base_url()
-        info["url"] = f"{proxy_base}/proxypass/{target}"
+        # A BaaS binding may itself be backed by ARCA. Corp keeps its historical
+        # direct-proxy base; community has no ARCA client and trusts the proxypass
+        # URL BaaS returned (already normalised by build_baas_conn_info above).
+        if sandbox_client is not None:
+            try:
+                proxy_base = sandbox_client.proxy_base_url()
+            except SandboxRuntimeUnavailableError:
+                logger.info(
+                    "BaaS returned an ARCA-backed target without a local ARCA "
+                    "runtime; using the BaaS-issued proxy URL (target=%s)",
+                    target,
+                )
+            else:
+                info["url"] = f"{proxy_base}/proxypass/{target}"
         info["sandbox_id"] = target
     else:
         # 真 BaaS 后端（desktop bot / 未来 personal+baas）走 invoke-http 网关。

--- a/src/backend/src/agentclaw/community/plugin_api/device_adapter_transport.py
+++ b/src/backend/src/agentclaw/community/plugin_api/device_adapter_transport.py
@@ -12,6 +12,8 @@ runs for real. Implementations:
 
 - ``plugins.prod.device_adapter_transport.HttpDeviceAdapterTransport``
   — builds the adapter URL from ``conn_info`` and forwards over httpx.
+- ``plugins.community.device_adapter_transport.CommunityDeviceAdapterTransport``
+  — resolves BaaS ``/http-info`` and forwards without any platform-specific SDK.
 - ``plugins.local.device_adapter_transport.InMemoryDeviceAdapterTransport``
   — a stateful in-memory cron adapter used by injection tests and local
   boots, so the real relay exercises end-to-end without a live adapter.

--- a/src/backend/src/agentclaw/community/plugins/community/device_adapter_transport.py
+++ b/src/backend/src/agentclaw/community/plugins/community/device_adapter_transport.py
@@ -1,28 +1,90 @@
-"""Community no-op ``DeviceAdapterTransport``.
+"""Community ``DeviceAdapterTransport`` backed by BaaS connection discovery.
 
-Community ships no container runtime, so there is no engine adapter to relay to
-(BaaS-team-owned, out of B6 scope). This impl exists so ``CronRelayService`` (a
-base-list cron service that injects ``DeviceAdapterTransport``) stays
-constructable in the community profile; ``invoke`` makes no network call and
-returns a uniform failure envelope. Real impl (not a ``MockSeam``); imports only
-``plugin_api``, so it satisfies the community column isolation guard.
+The community profile owns no container runtime. BaaS does, and its ``/http-info``
+contract hides whether a device is backed by ARCA, ACK, Docker, or another
+platform. This transport routes by BaaS binding id and never reads
+runtime-specific target prefixes or ARCA configuration.
 """
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from typing import Any, Optional
 
+import httpx
+from injector import inject
+
+from agentclaw.community.core.service_bot.services.baas_service import (
+    BaasService,
+    BaasServiceError,
+)
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.device_adapter_transport import (
+    DeviceAdapterEndpointNotFoundError,
+    DeviceAdapterHTTPStatusError,
     DeviceAdapterStreamResponse,
+    DeviceAdapterTimeoutError,
     DeviceAdapterTransport,
 )
 
 logger = get_logger()
 
+_DEFAULT_TIMEOUT = 120.0
+
+
+def _binding_id(conn_info: dict[str, Any]) -> int:
+    raw = conn_info.get("binding_id", conn_info.get("bind_id"))
+    if isinstance(raw, bool):
+        raise ValueError("BaaS adapter connection requires a valid binding_id")
+    try:
+        binding_id = int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("BaaS adapter connection requires a valid binding_id") from exc
+    if binding_id <= 0:
+        raise ValueError("BaaS adapter connection requires a valid binding_id")
+    return binding_id
+
 
 class CommunityDeviceAdapterTransport(DeviceAdapterTransport):
-    """No-op adapter transport for the community profile (no device runtime)."""
+    """Forward engine-adapter requests through BaaS ``/http-info``."""
+
+    @inject
+    def __init__(self, baas_service: BaasService) -> None:
+        self._baas_service = baas_service
+
+    @staticmethod
+    def _invoke_kwargs(
+        conn_info: dict[str, Any],
+        method: str,
+        path: str,
+        body: Optional[dict[str, Any]],
+        params: Optional[dict[str, Any]],
+        timeout: float | None,
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "bind_id": _binding_id(conn_info),
+            "port": int(conn_info.get("engine_port", 20003)),
+            "path": path,
+            "method": method,
+            "json": body,
+            "params": params,
+            "tenant": conn_info.get("tenant") or None,
+            "device_affinity": conn_info.get("device_affinity") or None,
+            "device_uuid": conn_info.get("device_uuid") or None,
+            "auth_header": "x-proxypass-token",
+        }
+        if timeout is not None:
+            kwargs["timeout"] = timeout
+        return kwargs
+
+    @staticmethod
+    def _map_status_error(exc: httpx.HTTPStatusError) -> Exception:
+        status_code = exc.response.status_code
+        if status_code == 404:
+            return DeviceAdapterEndpointNotFoundError(
+                f"Adapter returned HTTP 404: {exc.response.text}"
+            )
+        return DeviceAdapterHTTPStatusError(status_code, exc.response.text)
 
     async def invoke(
         self,
@@ -34,16 +96,26 @@ class CommunityDeviceAdapterTransport(DeviceAdapterTransport):
         *,
         timeout: float | None = None,
     ) -> dict[str, Any]:
-        logger.warning(
-            "[CommunityDeviceAdapterTransport] no-op (community has no device "
-            "runtime): %s %s",
-            method,
-            path,
-        )
-        return {
-            "success": False,
-            "message": "community mode — no device adapter (no container runtime)",
-        }
+        try:
+            response = await asyncio.to_thread(
+                self._baas_service.invoke_http,
+                **self._invoke_kwargs(conn_info, method, path, body, params, timeout),
+            )
+            response.raise_for_status()
+            result = response.json()
+            if not isinstance(result, dict):
+                raise ValueError("Adapter returned a non-object JSON response")
+            return result
+        except httpx.HTTPStatusError as exc:
+            raise self._map_status_error(exc) from exc
+        except httpx.RequestError as exc:
+            if timeout is not None and isinstance(exc, httpx.TimeoutException):
+                raise DeviceAdapterTimeoutError(
+                    f"Adapter request timed out: {method} {path}"
+                ) from exc
+            raise ValueError(f"Failed to connect to adapter: {exc}") from exc
+        except BaasServiceError as exc:
+            raise ValueError(f"Failed to resolve adapter connection: {exc}") from exc
 
     async def stream(
         self,
@@ -55,21 +127,67 @@ class CommunityDeviceAdapterTransport(DeviceAdapterTransport):
         *,
         timeout: float | None = None,
     ) -> DeviceAdapterStreamResponse:
-        logger.warning(
-            "[CommunityDeviceAdapterTransport] stream unavailable: %s %s",
-            method,
-            path,
-        )
+        request_timeout = timeout if timeout is not None else _DEFAULT_TIMEOUT
+        try:
+            info = await asyncio.to_thread(
+                self._baas_service.get_http_info,
+                bind_id=_binding_id(conn_info),
+                port=int(conn_info.get("engine_port", 20003)),
+                path=path,
+                tenant=conn_info.get("tenant") or None,
+                device_affinity=conn_info.get("device_affinity") or None,
+                device_uuid=conn_info.get("device_uuid") or None,
+            )
+            client = httpx.AsyncClient(timeout=request_timeout)
+            try:
+                request = client.build_request(
+                    method=method,
+                    url=info.http_url,
+                    json=body,
+                    params=params,
+                    headers={"x-proxypass-token": info.token},
+                )
+                response = await client.send(request, stream=True)
+            except Exception:
+                await client.aclose()
+                raise
+        except httpx.RequestError as exc:
+            if timeout is not None and isinstance(exc, httpx.TimeoutException):
+                raise DeviceAdapterTimeoutError(
+                    f"Adapter stream timed out: {method} {path}"
+                ) from exc
+            raise ValueError(f"Failed to open adapter stream: {exc}") from exc
+        except BaasServiceError as exc:
+            raise ValueError(f"Failed to resolve adapter connection: {exc}") from exc
 
-        async def error_body() -> AsyncIterator[bytes]:
-            yield b'{"detail":"device adapter stream unavailable"}'
+        closed = False
 
         async def close() -> None:
-            return None
+            nonlocal closed
+            if closed:
+                return
+            closed = True
+            try:
+                await response.aclose()
+            finally:
+                await client.aclose()
 
+        async def stream_body() -> AsyncIterator[bytes]:
+            try:
+                async for chunk in response.aiter_bytes():
+                    yield chunk
+            finally:
+                await close()
+
+        logger.info(
+            "[CommunityDeviceAdapterTransport] stream opened: %s %s status=%s",
+            method,
+            path,
+            response.status_code,
+        )
         return DeviceAdapterStreamResponse(
-            status_code=503,
-            headers={"content-type": "application/json"},
-            body=error_body(),
+            status_code=response.status_code,
+            headers=dict(response.headers),
+            body=stream_body(),
             close=close,
         )

--- a/src/backend/tests/community/api/aicoding/test_workspace_router.py
+++ b/src/backend/tests/community/api/aicoding/test_workspace_router.py
@@ -1,5 +1,5 @@
 """Tests for aicoding workspace initialization endpoint path validation."""
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import FastAPI
@@ -118,6 +118,7 @@ class TestWorkspaceServiceDefaults:
             device_provider=MagicMock(),
             path_factory=mock_pf,
             sandbox_client=MagicMock(),
+            baas_service=MagicMock(),
         )
         result = svc.get_workspace_path("u", "bot")
         assert result == "/base/staff_u/bot/aicoding/workspace"

--- a/src/backend/tests/community/core/aicoding/services/test_workspace_service.py
+++ b/src/backend/tests/community/core/aicoding/services/test_workspace_service.py
@@ -1,0 +1,110 @@
+"""Provider routing tests for the AICoding workspace Relay calls."""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from agentclaw.community.core.aicoding.services.workspace_service import WorkspaceService
+from agentclaw.community.kernel.device_dto import ProxyRequest
+
+
+def _service(provider: str, *, device_props: dict | None = None):
+    bot_service = MagicMock()
+    bot_service.get_bot.return_value = {"binding_id": 41}
+    device_service = MagicMock()
+    device_service.get_device.return_value = SimpleNamespace(
+        id=41,
+        device_provider=provider,
+        device_props=device_props or {},
+    )
+    sandbox_client = MagicMock()
+    baas_service = MagicMock()
+    service = WorkspaceService(
+        bot_provider=bot_service,
+        device_provider=device_service,
+        path_factory=MagicMock(),
+        sandbox_client=sandbox_client,
+        baas_service=baas_service,
+    )
+    return service, sandbox_client, baas_service
+
+
+def _response(payload: object) -> httpx.Response:
+    return httpx.Response(
+        200,
+        json=payload,
+        request=httpx.Request("POST", "https://proxy.example/api/git/clone"),
+    )
+
+
+def test_baas_clone_uses_binding_without_requiring_sandbox_id():
+    service, sandbox_client, baas_service = _service("baas")
+    baas_service.invoke_http.return_value = _response({"success": True})
+
+    asyncio.run(
+        service._clone_repository(
+            "https://git.example/repo.git",
+            "/workspace/repo",
+            "main",
+            "bot-1",
+            "user-1",
+        )
+    )
+
+    baas_service.invoke_http.assert_called_once_with(
+        bind_id=41,
+        port=18900,
+        path="/api/git/clone",
+        method="POST",
+        json={
+            "url": "https://git.example/repo.git",
+            "target_dir": "/workspace/repo",
+            "branch": "main",
+        },
+        device_affinity="user-1",
+        auth_header="x-proxypass-token",
+        timeout=300.0,
+    )
+    sandbox_client.build_proxy_request.assert_not_called()
+
+
+def test_arca_clone_keeps_existing_sandbox_proxy_request():
+    service, sandbox_client, baas_service = _service(
+        "arca", device_props={"sandbox_id": "sandbox-1"}
+    )
+    sandbox_client.build_proxy_request.return_value = ProxyRequest(
+        url="https://arca.example/proxypass/target/api/git/clone",
+        headers={"x-proxypass-token": "token-1"},
+    )
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.post = AsyncMock(return_value=_response({"success": True}))
+
+    with patch("httpx.AsyncClient", return_value=client):
+        asyncio.run(
+            service._clone_repository(
+                "https://git.example/repo.git",
+                "/workspace/repo",
+                None,
+                "bot-1",
+                "user-1",
+            )
+        )
+
+    sandbox_client.build_proxy_request.assert_called_once_with(
+        sandbox_id="sandbox-1", api_path="/api/git/clone", port=18900
+    )
+    client.post.assert_awaited_once_with(
+        "https://arca.example/proxypass/target/api/git/clone",
+        json={
+            "url": "https://git.example/repo.git",
+            "target_dir": "/workspace/repo",
+            "branch": None,
+        },
+        headers={"x-proxypass-token": "token-1"},
+    )
+    baas_service.invoke_http.assert_not_called()

--- a/src/backend/tests/community/core/devices/services/test_baas_conn_info.py
+++ b/src/backend/tests/community/core/devices/services/test_baas_conn_info.py
@@ -347,7 +347,7 @@ def _ws_info(target: str):
     """Build a BotWsConnectionInfoResponse with the given target field."""
     from agentclaw.community.core.service_bot.services.baas_service import BotWsConnectionInfoResponse
     return BotWsConnectionInfoResponse(
-        ws_url="wss://secbaas-pre.teamclaw.com/proxypass/foo/api/openclaw/ws",
+        ws_url=f"wss://secbaas-pre.teamclaw.com/proxypass/{target}/api/openclaw/ws",
         token="tok-xyz",
         target=target,
         expires_at="2026-01-01T00:00:00Z",
@@ -396,23 +396,38 @@ def test_build_for_http_arca_target_falls_back_to_proxypass():
     assert info["device_affinity"] == "100014"
 
 
-def test_build_for_http_arca_target_without_sandbox_client_raises():
-    """ARCA target 但没注入 sandbox_client → 立即 RuntimeError(不静默产坏 URL)。
-
-    生产链路(baas builder/plugin)总会注入 sandbox_client;此守卫保证误用
-    (能产出 ARCA target 的 caller 漏传 client)早炸而非一路炸到 transport。
-    """
-    import pytest as _pytest
+def test_build_for_http_arca_target_without_sandbox_client_uses_baas_url():
+    """BaaS owns its returned proxy URL even when the backing target is ARCA."""
     from agentclaw.community.core.devices.services.baas_conn_info import build_baas_conn_info_for_http
 
-    ws_info = _ws_info(target="ARCA_ARCA-SANDBOX-xxx@0:20003")
-    with _pytest.raises(RuntimeError, match="sandbox_client"):
-        build_baas_conn_info_for_http(
-            bind_id=1,
-            ws_info=ws_info,
-            engine_type="openclaw",
-            bot_type="service",
-        )
+    target = "ARCA_ARCA-SANDBOX-xxx@0:20003"
+    info = build_baas_conn_info_for_http(
+        bind_id=1,
+        ws_info=_ws_info(target=target),
+        engine_type="openclaw",
+        bot_type="service",
+    )
+
+    assert info["url"] == f"https://secbaas-pre.teamclaw.com/proxypass/{target}"
+    assert info["sandbox_id"] == target
+
+
+def test_build_for_http_arca_target_with_community_client_uses_baas_url():
+    """Regression: community client must not make a BaaS-backed session fail."""
+    from agentclaw.community.core.devices.services.baas_conn_info import build_baas_conn_info_for_http
+    from agentclaw.community.plugins.community.sandbox_client import CommunitySandboxClient
+
+    target = "ARCA_ARCA-SANDBOX-cloud@0:20003"
+    info = build_baas_conn_info_for_http(
+        bind_id=2,
+        ws_info=_ws_info(target=target),
+        engine_type="openclaw",
+        bot_type="service",
+        sandbox_client=CommunitySandboxClient(),
+    )
+
+    assert info["url"] == f"https://secbaas-pre.teamclaw.com/proxypass/{target}"
+    assert info["sandbox_id"] == target
 
 
 def test_build_for_http_non_arca_target_uses_invoke_http():

--- a/src/backend/tests/community/plugins/community/test_device_adapter_transport.py
+++ b/src/backend/tests/community/plugins/community/test_device_adapter_transport.py
@@ -1,0 +1,192 @@
+"""BaaS-backed community engine adapter transport tests."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from agentclaw.community.core.service_bot.services.baas_service import (
+    BaasServiceError,
+    HttpConnectionInfo,
+)
+from agentclaw.community.plugin_api.device_adapter_transport import (
+    DeviceAdapterEndpointNotFoundError,
+    DeviceAdapterHTTPStatusError,
+    DeviceAdapterTimeoutError,
+)
+from agentclaw.community.plugins.community.device_adapter_transport import (
+    CommunityDeviceAdapterTransport,
+)
+
+
+def _response(status: int, payload: object) -> httpx.Response:
+    return httpx.Response(
+        status,
+        json=payload,
+        request=httpx.Request("POST", "https://proxy.example/api/sessions"),
+    )
+
+
+def _transport(response: httpx.Response | None = None):
+    baas = MagicMock()
+    if response is not None:
+        baas.invoke_http.return_value = response
+    return CommunityDeviceAdapterTransport(baas), baas
+
+
+def test_invoke_routes_through_baas_with_binding_context():
+    transport, baas = _transport(
+        _response(200, {"success": True, "data": {"id": "s-1"}})
+    )
+
+    result = asyncio.run(
+        transport.invoke(
+            conn_info={
+                "binding_id": 17,
+                "engine_port": 20003,
+                "tenant": "tenant-a",
+                "device_affinity": "user-1",
+                "device_uuid": "device-1",
+            },
+            method="POST",
+            path="/api/sessions",
+            body={"title": "test"},
+            params={"stage": "draft"},
+            timeout=10.0,
+        )
+    )
+
+    assert result == {"success": True, "data": {"id": "s-1"}}
+    baas.invoke_http.assert_called_once_with(
+        bind_id=17,
+        port=20003,
+        path="/api/sessions",
+        method="POST",
+        json={"title": "test"},
+        params={"stage": "draft"},
+        tenant="tenant-a",
+        device_affinity="user-1",
+        device_uuid="device-1",
+        auth_header="x-proxypass-token",
+        timeout=10.0,
+    )
+
+
+def test_invoke_accepts_legacy_bind_id_alias():
+    transport, baas = _transport(_response(200, {"success": True}))
+
+    asyncio.run(
+        transport.invoke(
+            conn_info={"bind_id": 23}, method="GET", path="/api/engine/status"
+        )
+    )
+
+    assert baas.invoke_http.call_args.kwargs["bind_id"] == 23
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (404, DeviceAdapterEndpointNotFoundError),
+        (503, DeviceAdapterHTTPStatusError),
+    ],
+)
+def test_invoke_maps_http_statuses(status, expected):
+    transport, _ = _transport(_response(status, {"detail": "failed"}))
+
+    with pytest.raises(expected):
+        asyncio.run(
+            transport.invoke(
+                conn_info={"binding_id": 1}, method="GET", path="/api/test"
+            )
+        )
+
+
+def test_invoke_maps_explicit_timeout():
+    transport, baas = _transport()
+    baas.invoke_http.side_effect = httpx.ReadTimeout(
+        "slow", request=httpx.Request("GET", "https://proxy.example/api/test")
+    )
+
+    with pytest.raises(DeviceAdapterTimeoutError):
+        asyncio.run(
+            transport.invoke(
+                conn_info={"binding_id": 1},
+                method="GET",
+                path="/api/test",
+                timeout=1.0,
+            )
+        )
+
+
+def test_invoke_maps_baas_resolution_error():
+    transport, baas = _transport()
+    baas.invoke_http.side_effect = BaasServiceError("no active device")
+
+    with pytest.raises(ValueError, match="resolve adapter connection"):
+        asyncio.run(
+            transport.invoke(
+                conn_info={"binding_id": 1}, method="GET", path="/api/test"
+            )
+        )
+
+
+def test_stream_uses_baas_http_info_and_closes():
+    transport, baas = _transport()
+    baas.get_http_info.return_value = HttpConnectionInfo(
+        http_url="https://proxy.example/api/chat/stream",
+        token="token-1",
+        target="ARCA_device@0:20003",
+    )
+    response = MagicMock()
+    response.status_code = 200
+    response.headers = {"content-type": "text/event-stream"}
+    response.aclose = AsyncMock()
+
+    async def chunks():
+        yield b"one"
+        yield b"two"
+
+    response.aiter_bytes.side_effect = chunks
+    client = MagicMock()
+    client.build_request.return_value = httpx.Request(
+        "POST", "https://proxy.example/api/chat/stream"
+    )
+    client.send = AsyncMock(return_value=response)
+    client.aclose = AsyncMock()
+
+    async def exercise_stream():
+        with patch("httpx.AsyncClient", return_value=client):
+            stream = await transport.stream(
+                conn_info={"binding_id": 9, "engine_port": 20003},
+                method="POST",
+                path="/api/chat/stream",
+                body={"message": "hello"},
+            )
+            body = [chunk async for chunk in stream.body]
+            await stream.close()
+            return stream, body
+
+    stream, body = asyncio.run(exercise_stream())
+
+    assert stream.status_code == 200
+    assert body == [b"one", b"two"]
+    baas.get_http_info.assert_called_once_with(
+        bind_id=9,
+        port=20003,
+        path="/api/chat/stream",
+        tenant=None,
+        device_affinity=None,
+        device_uuid=None,
+    )
+    client.build_request.assert_called_once_with(
+        method="POST",
+        url="https://proxy.example/api/chat/stream",
+        json={"message": "hello"},
+        params=None,
+        headers={"x-proxypass-token": "token-1"},
+    )
+    response.aclose.assert_awaited_once()
+    client.aclose.assert_awaited_once()

--- a/src/backend/tests/community/plugins/community/test_device_community_impls.py
+++ b/src/backend/tests/community/plugins/community/test_device_community_impls.py
@@ -1,11 +1,11 @@
-"""Unit tests for the B6 community device impls (real, vendor-free, no-op-by-design).
+"""Unit tests for the B6 community device implementations.
 
 Covers:
 - ``CommunityHealthProbe`` — direct-HTTP /readiness probe (all branches: no
   bindings, no-url binding, healthy/unhealthy/exception probes, payload parsing,
   list_bindings failure, sandbox unsupported).
 - ``CommunityDeviceSyncDispatcher`` — selects the DI-provided BaaS DeviceSync service.
-- ``CommunityDeviceAdapterTransport`` — no-op relay transport.
+- ``CommunityDeviceAdapterTransport`` — BaaS-backed relay transport.
 
 These ship in the community distribution, so they must be exercised directly
 (the contract/wiring suites only prove they're *bound*).
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import pytest
 
 from agentclaw.community.plugins.community.device_adapter_transport import (
     CommunityDeviceAdapterTransport,
@@ -173,11 +174,11 @@ def test_sandbox_health_unsupported():
 
 # ── CommunityDeviceAdapterTransport ──────────────────────────────────────────
 
-def test_adapter_transport_invoke_is_noop_envelope():
-    out = asyncio.run(
-        CommunityDeviceAdapterTransport().invoke(
-            conn_info={"url": "http://x"}, method="POST", path="/api/cron", body={"a": 1},
+def test_adapter_transport_requires_binding_id():
+    baas_service = MagicMock()
+    with pytest.raises(ValueError, match="binding_id"):
+        asyncio.run(
+            CommunityDeviceAdapterTransport(baas_service).invoke(
+                conn_info={"url": "http://x"}, method="POST", path="/api/cron", body={"a": 1},
+            )
         )
-    )
-    assert out["success"] is False
-    assert "no device adapter" in out["message"]


### PR DESCRIPTION
## Summary
- keep BaaS-managed ARCA-backed targets on the BaaS connection path when the community profile has no local ARCA runtime
- implement the community engine-adapter transport through BaaS `/http-info` for normal and streaming requests
- route AICoding workspace clone by `device_provider`, preserving the existing sandbox proxy path for non-BaaS devices

## Compatibility
- corp deployments with a real ARCA sandbox client keep the existing direct proxy behavior
- non-BaaS workspace cloning remains unchanged

## Verification
- `ruff check` on changed Python files
- focused runtime, workspace, session and wiring tests: 318 passed
- community architecture tests: 252 passed
- community DI tests: 310 passed
- repository pre-push SAST gate passed