### PR TITLE
fix(backend): default BCN registration when DRM is unavailable

### DIFF
--- a/src/backend/specs/2026-09-01-claude-code-bcn-drm-default-enabled/009-pr-report.md
+++ b/src/backend/specs/2026-09-01-claude-code-bcn-drm-default-enabled/009-pr-report.md
@@ -1,0 +1,38 @@
+# PR Convergence Report: claude-code-bcn-drm-default-enabled
+
+## Scope
+
+- Worktree / repo: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/claude-code-bcn-drm-default-register-dev-20260901` / GitHub `inclusionAI/Avernet`
+- Head / base: `fix/claude-code-bcn-drm-default-register-dev-20260901` / GitHub `dev@a7caaf39a`
+- PR: created in this run
+- PR title: pending commit and PR creation
+- PR description sections: Problem / Solution / Validation / Compatibility and risk / Spec
+- Human comment mode: auto
+
+## PR Decision
+
+| Result | Evidence | Notes |
+|---|---|---|
+| GitHub source remote verified | `git ls-remote` and `gh repo view` | Push and PR use `inclusionAI/Avernet`, not the internal mirror. |
+| Existing PR | none | No open PR matches this head branch and base `dev`. |
+| Local validation | focused backend tests | `85 passed`; test-file ruff, service compilation, and diff check passed. |
+
+## Automated Comments
+
+Pending PR creation.
+
+## ACI/CI
+
+Pending PR creation.
+
+## Human Comments
+
+Pending PR creation.
+
+## Current Conclusion
+
+- PR: NOT_CREATED
+- Automated comments: PENDING
+- ACI/CI: PENDING
+- Human comments: PENDING
+- Next: commit task files, rebase the unpublished topic commit on current GitHub `dev`, push, and create the PR.

--- a/src/backend/specs/2026-09-01-claude-code-bcn-drm-default-enabled/009-pr-report.md
+++ b/src/backend/specs/2026-09-01-claude-code-bcn-drm-default-enabled/009-pr-report.md
@@ -15,7 +15,7 @@
 |---|---|---|
 | GitHub source remote verified | `git ls-remote` and `gh repo view` | Push and PR use `inclusionAI/Avernet`, not the internal mirror. |
 | Existing PR | none | No open PR matches this head branch and base `dev`. |
-| Local validation | focused backend tests | `85 passed`; test-file ruff, service compilation, and diff check passed. |
+| Local validation | focused backend tests | BCN-focused suite: `85 passed`; task queue worker/wakeup suite: `30 passed`; both touched test files pass Ruff; service compilation and diff check passed. |
 | PR created | GitHub #1777 | Open PR targets `dev`; title and Problem / Solution / Validation sections match the verified diff. |
 | Rebase pass | `git rebase origin/dev` | Unpublished task commit was replayed without conflict onto GitHub `dev@a7caaf39a`. |
 
@@ -25,16 +25,20 @@ Round 1: no review, inline comment, or ordinary comment was returned by GitHub.
 
 ## ACI/CI
 
-All eight observed checks are `PENDING`: BCS e2e, Singlebox coverage, BCS unit tests, Backend unit tests, Engine unit tests, BaaS unit tests, Gateway unit tests, and Sandbox-proxy unit tests.
+Round 1 completed with seven passing checks: BCS e2e, Singlebox coverage, BCS unit tests, Engine unit tests, BaaS unit tests, Gateway unit tests, and Sandbox-proxy unit tests.
+
+The Backend unit-test job failed with `1 failed, 16222 passed, 59 skipped`. Its only failure was `test_idle_worker_loop_wakes_on_an_opted_in_enqueue`, outside the BCN DRM change. The test raced a fixed sleep and used one StaticPool SQLite connection concurrently from the event-loop and enqueue threads. The failure was reproduced locally (including a SQLite cross-thread `InterfaceError`). The test now waits for the worker's real idle latch, keeps its SQLite interaction on one thread, and uses a handler completion event to assert the actual wake-to-claim path. Cross-thread `WorkerWakeup` delivery remains covered by its dedicated unit test. The revised test passed ten consecutive runs and the full related suite (`30 passed`).
+
+Round 2 will begin after the stabilization commit is pushed.
 
 ## Human Comments
 
-Round 1: no human review, inline comment, or ordinary comment was returned by GitHub.
+Round 1: reviewer `totalfrank` approved the PR with `LGTM`; no inline comments were returned.
 
 ## Current Conclusion
 
 - PR: OPEN
 - Automated comments: CLEAR (round 1)
-- ACI/CI: PENDING
-- Human comments: CLEAR (round 1)
-- Next: monitor the current head's checks and each new review/comment; investigate and minimally fix any reproducible task-related failure.
+- ACI/CI: ROUND 2 PENDING AFTER A MINIMAL TEST-STABILITY FIX
+- Human comments: APPROVED (round 1)
+- Next: push the stabilization commit and monitor its checks and each new review/comment.

--- a/src/backend/specs/2026-09-01-claude-code-bcn-drm-default-enabled/009-pr-report.md
+++ b/src/backend/specs/2026-09-01-claude-code-bcn-drm-default-enabled/009-pr-report.md
@@ -3,9 +3,9 @@
 ## Scope
 
 - Worktree / repo: `/Users/helloworld/Desktop/codes/teamclaw_worktrees/Avernet_worktrees/claude-code-bcn-drm-default-register-dev-20260901` / GitHub `inclusionAI/Avernet`
-- Head / base: `fix/claude-code-bcn-drm-default-register-dev-20260901` / GitHub `dev@a7caaf39a`
-- PR: created in this run
-- PR title: pending commit and PR creation
+- Head / base: `fix/claude-code-bcn-drm-default-register-dev-20260901@fb289d9e7` / GitHub `dev@a7caaf39a`
+- PR: [GitHub #1777](https://github.com/inclusionAI/Avernet/pull/1777)
+- PR title: `fix(backend): default BCN registration when DRM is unavailable`
 - PR description sections: Problem / Solution / Validation / Compatibility and risk / Spec
 - Human comment mode: auto
 
@@ -16,23 +16,25 @@
 | GitHub source remote verified | `git ls-remote` and `gh repo view` | Push and PR use `inclusionAI/Avernet`, not the internal mirror. |
 | Existing PR | none | No open PR matches this head branch and base `dev`. |
 | Local validation | focused backend tests | `85 passed`; test-file ruff, service compilation, and diff check passed. |
+| PR created | GitHub #1777 | Open PR targets `dev`; title and Problem / Solution / Validation sections match the verified diff. |
+| Rebase pass | `git rebase origin/dev` | Unpublished task commit was replayed without conflict onto GitHub `dev@a7caaf39a`. |
 
 ## Automated Comments
 
-Pending PR creation.
+Round 1: no review, inline comment, or ordinary comment was returned by GitHub.
 
 ## ACI/CI
 
-Pending PR creation.
+All eight observed checks are `PENDING`: BCS e2e, Singlebox coverage, BCS unit tests, Backend unit tests, Engine unit tests, BaaS unit tests, Gateway unit tests, and Sandbox-proxy unit tests.
 
 ## Human Comments
 
-Pending PR creation.
+Round 1: no human review, inline comment, or ordinary comment was returned by GitHub.
 
 ## Current Conclusion
 
-- PR: NOT_CREATED
-- Automated comments: PENDING
+- PR: OPEN
+- Automated comments: CLEAR (round 1)
 - ACI/CI: PENDING
-- Human comments: PENDING
-- Next: commit task files, rebase the unpublished topic commit on current GitHub `dev`, push, and create the PR.
+- Human comments: CLEAR (round 1)
+- Next: monitor the current head's checks and each new review/comment; investigate and minimally fix any reproducible task-related failure.

--- a/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/bot_service.py
@@ -3339,7 +3339,7 @@ class BotService(BotServiceProtocol):
             )
 
     # DRM 控制开关: claude_code 启动时是否往 BCN 注册 Provider bot.
-    # value 取 "true"/"on"/"1" 视为开启, 其它 (含空 / 异常 / 未配置) 视为关闭.
+    # value 取 "true"/"on"/"1" 视为开启; 空 / 异常 / 未配置默认开启.
     # 排查日志关键字: [DRM] ClaudeCodeBcnRegister
     _CLAUDE_CODE_BCN_REGISTER_DRM_ID = (
         "Alipay.agentclaw:name=com.alipay.agentclaw.service.drm."
@@ -3353,17 +3353,31 @@ class BotService(BotServiceProtocol):
     )
 
     def _is_claude_code_bcn_register_enabled(self) -> bool:
-        """读 DRM 判断 claude_code BCN 注册是否启用. 默认关 (失败也关).
+        """读 DRM 判断 claude_code BCN 注册是否启用. 默认开 (失败也开).
 
         Returns:
-            True: DRM 显式开启 (value in {"true", "on", "1"} 不区分大小写)
-            False: DRM 关闭 / 取不到 / 异常
+            True: DRM 显式开启，或 DRM 未配置 / 不可用
+            False: DRM 显式配置为关闭值
         """
-        raw_value = self._drm_reader.read(self._CLAUDE_CODE_BCN_REGISTER_DRM_ID)
-        value = str(raw_value).strip().lower() if raw_value else ""
+        try:
+            raw_value = self._drm_reader.read(self._CLAUDE_CODE_BCN_REGISTER_DRM_ID)
+        except Exception as error:
+            logger.warning(
+                "[DRM] ClaudeCodeBcnRegister unavailable; default enabled "
+                "error_type=%s",
+                type(error).__name__,
+            )
+            return True
+
+        value = str(raw_value).strip().lower() if raw_value is not None else ""
+        if not value:
+            logger.info("[DRM] ClaudeCodeBcnRegister unset; default enabled")
+            return True
+
         enabled = value in ("true", "on", "1")
         logger.info(
-            f"[DRM] ClaudeCodeBcnRegister value={raw_value!r} enabled={enabled}"
+            "[DRM] ClaudeCodeBcnRegister explicit_value_present=true enabled=%s",
+            enabled,
         )
         return enabled
 

--- a/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
+++ b/src/backend/tests/community/core/bot_management/services/test_bot_service_stop_start.py
@@ -64,7 +64,7 @@ def _make_service() -> BotService:
     # Restart idempotency lock repo. Default: acquire() returns a truthy mock
     # so restart_bot treats the lock as acquired and proceeds to stop+start.
     svc._restart_lock_repo = MagicMock()
-    # DRM reader: default "unset" (None) so BCN-register reads as disabled;
+    # DRM reader: default "unset" (None) so BCN-register falls back to enabled;
     # tests that exercise the flag override ``_drm_reader.read.return_value``.
     svc._drm_reader = MagicMock()
     svc._drm_reader.read.return_value = None
@@ -578,27 +578,46 @@ class TestStartBotBcnRegister:
         svc._bcn_service.register_provider_bot.assert_not_called()
         mock_ext.assert_not_called()
 
-    def test_drm_default_off_skips_register_when_drm_unreachable(self):
-        # DRM 读取异常 → 默认关闭, 不注册
+    def test_drm_unset_registers_provider_bot_by_default(self):
+        """DRM 未配置时，Claude Code Bot 仍自动注册 BCN Provider。"""
         svc = _make_service()
         svc._bcn_service = MagicMock()
+        svc._bcn_service.register_provider_bot.return_value = {"skipped": True}
         bot = _make_bot()
         bot["active_engine"] = "claude_code"
         bot["template_type"] = "normalCC"
         svc._repository.get_by_id_and_owner.side_effect = [bot, bot]
 
         # 不打 patch _is_claude_code_bcn_register_enabled, 让真实方法跑.
-        # 单测 DRM seam 默认 reader 返回 None → enabled False → 不注册.
+        # 单测 DRM seam 默认 reader 返回 None → enabled True → 注册.
         with patch.object(svc, "_allocate_device_async"):
             svc.start_bot(bot_id="bot001", user_id="user001")
 
-        svc._bcn_service.register_provider_bot.assert_not_called()
+        svc._bcn_service.register_provider_bot.assert_called_once_with(
+            teamclaw_bot_uuid="bot001",
+            owner_workno="user001",
+            name="TestBot",
+            summary="",
+        )
 
-    def test_drm_helper_unset_returns_false(self):
-        # DRM 未配置 / 不可用 (reader 返回 None) → False.
+    @pytest.mark.parametrize("raw_value", [None, "", "   "])
+    def test_drm_helper_empty_config_returns_true(self, raw_value):
+        # DRM 未配置 (None 或空白值) → 自动注册.
         svc = _make_service()
-        svc._drm_reader.read.return_value = None
-        assert svc._is_claude_code_bcn_register_enabled() is False
+        svc._drm_reader.read.return_value = raw_value
+        assert svc._is_claude_code_bcn_register_enabled() is True
+
+    def test_drm_helper_returns_true_when_reader_is_missing(self):
+        # 组合根未注入 DRM reader 时，不阻塞自动注册。
+        svc = _make_service()
+        del svc._drm_reader
+        assert svc._is_claude_code_bcn_register_enabled() is True
+
+    def test_drm_helper_returns_true_when_reader_raises(self):
+        # DRM 读取异常时，不阻塞自动注册。
+        svc = _make_service()
+        svc._drm_reader.read.side_effect = RuntimeError("DRM unavailable")
+        assert svc._is_claude_code_bcn_register_enabled() is True
 
     def test_drm_helper_returns_true_when_value_explicitly_on(self):
         # 覆盖正常 enabled 路径 (raw_value 非空且匹配 truthy 集合).

--- a/src/backend/tests/community/core/task_queue/test_task_worker.py
+++ b/src/backend/tests/community/core/task_queue/test_task_worker.py
@@ -490,28 +490,46 @@ def test_enqueue_survives_a_wakeup_that_has_no_loop_bound():
     assert w.status_of(record.id) == TaskStatus.SUCCEEDED
 
 
-def test_idle_worker_loop_wakes_on_an_opted_in_enqueue():
+def test_idle_worker_loop_wakes_on_an_opted_in_enqueue(monkeypatch):
     """The whole feature, end to end through the real loop: with a poll interval
     far longer than the test could tolerate, an enqueue still gets claimed
     promptly because it cuts the idle wait short."""
     w = _world(poll_interval_seconds=30.0, poll_jitter_seconds=0.0)
-    w.registry.register(NoopTaskHandler("urgent"), wake_on_enqueue=True)
 
     async def drive():
+        idle_wait_entered = asyncio.Event()
+        task_claimed = asyncio.Event()
+        loop = asyncio.get_running_loop()
+        original_wait = w.wakeup.wait
+
+        async def wait(timeout):
+            idle_wait_entered.set()
+            return await original_wait(timeout)
+
+        class SignallingHandler:
+            task_type = "urgent"
+
+            def handle(self, payload):
+                loop.call_soon_threadsafe(task_claimed.set)
+                return Complete()
+
+        monkeypatch.setattr(w.wakeup, "wait", wait)
+        w.registry.register(SignallingHandler(), wake_on_enqueue=True)
         await w.worker.startup()
         try:
-            # First tick finds nothing and settles into the 30s idle wait.
-            await asyncio.sleep(0.1)
-            record = await asyncio.to_thread(w.enqueue, "urgent")
+            # Wait until the initial empty tick is interruptibly idle rather
+            # than racing it with a fixed sleep.
+            await asyncio.wait_for(idle_wait_entered.wait(), timeout=1.0)
+            # The cross-thread notify behavior is covered in
+            # test_worker_wakeup.py. Keeping this SQLite-backed integration
+            # test on one thread avoids concurrent use of its StaticPool
+            # connection while still exercising the real worker loop.
+            w.enqueue("urgent")
             started = time.monotonic()
-            while time.monotonic() - started < 5.0:
-                if w.status_of(record.id) == TaskStatus.SUCCEEDED:
-                    return time.monotonic() - started
-                await asyncio.sleep(0.02)
-            return None
+            await asyncio.wait_for(task_claimed.wait(), timeout=1.0)
+            return time.monotonic() - started
         finally:
             await w.worker.shutdown()
 
     elapsed = asyncio.run(drive())
-    assert elapsed is not None, "task was not claimed — the wake never landed"
-    assert elapsed < 5.0
+    assert elapsed < 1.0


### PR DESCRIPTION
## Problem

Eligible Bots skipped BCN Provider registration whenever the DRM reader was unavailable or the `ClaudeCodeBcnRegister.enabled` value was not configured. This made automatic enrollment depend on optional DRM infrastructure.

## Solution

- Default registration to enabled when the DRM reader attribute is missing, reading it raises, or its value is empty.
- Preserve explicit control: only `true`, `on`, and `1` enable a non-empty DRM value; other non-empty values disable registration.
- Add low-sensitivity diagnostics that record the fallback reason and exception type without logging DRM values or exception messages.
- Cover the helper defaults and the real Claude Code `start_bot` registration path.

## Validation

- `uv run pytest -q tests/community/core/bot_management/services/test_bot_service_stop_start.py tests/community/core/bot_management/services/test_bot_service_create_bcn_register.py tests/community/core/bot_management/services/test_bot_service_restart_baas_envs.py` — 85 passed.
- `uv run ruff check tests/community/core/bot_management/services/test_bot_service_stop_start.py` — passed.
- `uv run python -m py_compile src/agentclaw/community/core/bot_management/services/bot_service.py` — passed.
- `git diff --check origin/dev...HEAD` — passed.

## Compatibility and risk

This changes the default for unavailable or empty DRM configuration from disabled to enabled. Deployments that need to disable BCN registration must set a non-empty explicit disabling value.

## Spec

`src/backend/specs/2026-09-01-claude-code-bcn-drm-default-enabled/009-pr-report.md`
