### PR TITLE
fix(backend): delete failed unpublished skill drafts

### DIFF
--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
@@ -338,9 +338,11 @@ DELETE .../draft?expected_revision_id=rev-2&fencing_token=7
 ```
 
 - `deleted_scope=DRAFT`：仅放弃本次升级；Published Vn 仍在线；
-- `deleted_scope=SKILL`：首次从未发布且无外部事实，整个 Skill 被删除。
+- `deleted_scope=SKILL`：首次从未发布，且除终态 FAILED Attempt 外无外部事实，整个 Skill
+  及其失败 Attempt 被删除。
 
 FROZEN 时不显示删除按钮。Offline Skill 放弃 Vn+1 Draft 后仍保持 Offline，可再次点击升级。
+删除 Team Draft 会同时使当前 Lease/fencing token 失效，前端必须停止 Lease 轮询并退出编辑态。
 
 ### 7.3 查看历史版本
 

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -701,9 +701,10 @@ GET/PUT 分别服务编辑器目录、内容读取和保存。
 exact version 下载并修复 Store，再创建 Vn+1 Draft。禁止使用 current/latest、旧 Draft 或历史
 package URL。发布成功后不保留 Draft；只有再次点击升级才创建下一版 Draft。
 
-DELETE 要求 `expected_revision_id`，Team Lease 必须 FREE/HELD_BY_ME；无 Published Version 且
-无 Attempt/Version/Installation/Membership/Artifact 等外部事实时删除整个 Skill 聚合，否则只
-放弃升级 Draft。FROZEN 永不允许删除。DB 事实先提交，OSS 做 best-effort 清理。
+DELETE 要求 `expected_revision_id`，Team Lease 必须 FREE/HELD_BY_ME；无 Published Version，且
+除终态 FAILED Attempt 外不存在 Version/Installation/Membership/Artifact 等外部事实时，删除
+整个从未发布的 Skill 聚合及其 FAILED Attempt，否则只放弃升级 Draft。FROZEN 永不允许删除。
+DB 事实先提交，OSS 做 best-effort 清理；只放弃 Draft 时同步失效当前 Lease/fencing token。
 
 URL 中 `{version}` 是业务序号 `1/2/3`，不是 `ac_skill_version.id`。Published Version 不可修改、删除或单独下线。
 
@@ -744,9 +745,10 @@ TeamClaw Publication Attempt，因此该列必须允许 NULL，不能伪造 Atte
 - 本期只有 Owner/Manager 两种 Skill Grant，不新增 Editor 或普通 Skill Member。
 - Owner 直接 `PUT/DELETE managers` 不生成 Work Order。移除当前 Lease holder 的
   Manager Grant 时，必须在同一事务内使该 Lease/fencing token 失效。
-- 删除升级 Draft 只放弃本次升级；首次从未发布的 Draft 在没有 Attempt、Version、
-  Installation、SkillSet Membership、Artifact 或其他外部历史事实时，可以在同一事务中
-  删除 Draft 事实、Owner/Manager Grant、该 Skill 自己的 Space Binding 和 Skill Identity。
+- 删除升级 Draft 只放弃本次升级；首次从未发布的 Draft 在除终态 FAILED Attempt 外没有
+  Version、Installation、SkillSet Membership、Artifact 或其他外部历史事实时，可以在同一
+  事务中删除 FAILED Attempt、Draft 事实、Lease、Owner/Manager Grant、该 Skill 自己的 Space
+  Binding 和 Skill Identity。
 - FROZEN Draft 不能放弃，必须先由 Attempt 收敛到明确结果。
 
 编辑权申请 body：

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_draft.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/space_skill_draft.py
@@ -16,6 +16,7 @@ from agentclaw.community.core.models.space_skill import (
     SkillGrant,
     SkillSpaceBinding,
     SkillPublicationAttempt,
+    SkillPublicationAttemptStatus,
     SkillVersion,
 )
 from agentclaw.community.core.repository.protocols.skill_center import (
@@ -520,6 +521,7 @@ class SpaceSkillDraftRepository(SpaceSkillDraftRepositoryProtocol):
             )
             if grant is None:
                 raise SpaceSkillGrantForbiddenError("owner or manager required")
+            lease: SkillDraftEditLease | None = None
             if space_type == "TEAM":
                 lease = (
                     session.query(SkillDraftEditLease)
@@ -540,21 +542,25 @@ class SpaceSkillDraftRepository(SpaceSkillDraftRepositoryProtocol):
                     )
                 if lease.fencing_token != fencing_token:
                     raise DraftEditLeaseTokenRejectedError("stale fencing token")
+            publication_attempts = (
+                session.query(SkillPublicationAttempt)
+                .filter(
+                    SkillPublicationAttempt.skill_id == skill_id,
+                    SkillPublicationAttempt.env == env,
+                )
+                .all()
+            )
             external = (
                 any(
+                    attempt.status != SkillPublicationAttemptStatus.FAILED
+                    for attempt in publication_attempts
+                )
+                or any(
                     session.query(model)
-                    .filter(
-                        getattr(model, "skill_id", None) == skill_id,
-                        model.env == env,
-                    )
+                    .filter(model.skill_id == skill_id, model.env == env)
                     .first()
                     is not None
-                    for model in (
-                        SkillVersion,
-                        SkillPublicationAttempt,
-                        SkillSetSkill,
-                        BotSkillInstallation,
-                    )
+                    for model in (SkillVersion, SkillSetSkill, BotSkillInstallation)
                 )
                 or session.query(WorkOrderModel.id)
                 .filter(
@@ -579,8 +585,14 @@ class SpaceSkillDraftRepository(SpaceSkillDraftRepositoryProtocol):
                 skill.draft_status = None
                 skill.draft_description = None
                 skill.draft_source_kind = None
+                if space_type == "TEAM":
+                    assert lease is not None
+                    lease.holder_user_id = None
+                    lease.fencing_token += 1
                 scope = "DRAFT"
             else:
+                for attempt in publication_attempts:
+                    session.delete(attempt)
                 session.query(SkillDraftEditLease).filter_by(
                     skill_id=skill_id, env=env
                 ).delete(synchronize_session=False)

--- a/src/backend/tests/community/repository/skill_center/test_space_skill_draft_repository.py
+++ b/src/backend/tests/community/repository/skill_center/test_space_skill_draft_repository.py
@@ -15,6 +15,7 @@ from agentclaw.community.core.models.space_skill import (
     SkillDraftEditLease,
     SkillDraftUpgradeRequest,
     SkillGrant,
+    SkillPublicationAttempt,
     SkillSpaceBinding,
     SkillVersion,
 )
@@ -240,6 +241,51 @@ def test_delete_first_draft_removes_the_whole_unreferenced_skill_aggregate():
         )
 
 
+def test_delete_first_draft_after_failed_publication_removes_whole_skill():
+    db = _Database()
+    space_id, skill_id = _seed(db, space_type="TEAM")
+    with db.orm_session() as session:
+        session.add(
+            SkillPublicationAttempt(
+                skill_id=skill_id,
+                request_id="failed-first-publication",
+                frozen_draft_locator=f"draft://{_UUID}/v1/{_OLD_REV}",
+                target_version_ordinal=1,
+                status="FAILED",
+                error_code="SC_PUBLISH_REJECTED",
+                created_by="owner-1",
+                env="test",
+            )
+        )
+
+    result = SpaceSkillDraftRepository(db).delete_draft(
+        space_id=space_id,
+        skill_id=skill_id,
+        actor_id="owner-1",
+        expected_revision_id=_OLD_REV,
+        fencing_token=7,
+        env="test",
+    )
+
+    assert result["deleted_scope"] == "SKILL"
+    with db.orm_session() as session:
+        assert session.query(Skill).filter_by(id=skill_id).one_or_none() is None
+        assert (
+            session.query(SkillPublicationAttempt)
+            .filter_by(skill_id=skill_id)
+            .count()
+            == 0
+        )
+        assert (
+            session.query(SkillDraftEditLease).filter_by(skill_id=skill_id).count()
+            == 0
+        )
+        assert session.query(SkillGrant).filter_by(skill_id=skill_id).count() == 0
+        assert (
+            session.query(SkillSpaceBinding).filter_by(skill_id=skill_id).count() == 0
+        )
+
+
 def test_delete_upgrade_draft_preserves_published_skill_history():
     db = _Database()
     space_id, skill_id = _seed(db, space_type="PERSONAL")
@@ -252,6 +298,17 @@ def test_delete_upgrade_draft_preserves_published_skill_history():
                 sc_version_number="1.0.0",
                 name="draft-skill",
                 description="published",
+                created_by="owner-1",
+                env="test",
+            )
+        )
+        session.add(
+            SkillPublicationAttempt(
+                skill_id=skill_id,
+                request_id="failed-upgrade-publication",
+                frozen_draft_locator=f"draft://{_UUID}/v1/{_OLD_REV}",
+                target_version_ordinal=1,
+                status="FAILED",
                 created_by="owner-1",
                 env="test",
             )
@@ -272,6 +329,45 @@ def test_delete_upgrade_draft_preserves_published_skill_history():
         assert skill.draft_status is None
         assert skill.zip_url is None
         assert session.query(SkillVersion).filter_by(skill_id=skill_id).count() == 1
+        assert (
+            session.query(SkillPublicationAttempt)
+            .filter_by(skill_id=skill_id)
+            .count()
+            == 1
+        )
+
+
+def test_delete_team_upgrade_draft_invalidates_held_lease():
+    db = _Database()
+    space_id, skill_id = _seed(db, space_type="TEAM")
+    with db.orm_session() as session:
+        session.add(
+            SkillVersion(
+                skill_id=skill_id,
+                version_ordinal=1,
+                status="PUBLISHED",
+                sc_version_number="1.0.0",
+                name="draft-skill",
+                description="published",
+                created_by="owner-1",
+                env="test",
+            )
+        )
+
+    result = SpaceSkillDraftRepository(db).delete_draft(
+        space_id=space_id,
+        skill_id=skill_id,
+        actor_id="owner-1",
+        expected_revision_id=_OLD_REV,
+        fencing_token=7,
+        env="test",
+    )
+
+    assert result["deleted_scope"] == "DRAFT"
+    with db.orm_session() as session:
+        lease = session.query(SkillDraftEditLease).filter_by(skill_id=skill_id).one()
+        assert lease.holder_user_id is None
+        assert lease.fencing_token == 8
 
 
 def test_delete_upgrade_draft_preserves_spent_idempotency_request():


### PR DESCRIPTION
## Summary

- treat terminal `FAILED` publication attempts as disposable when deleting a never-published Skill with no other external facts
- delete the failed attempts together with the unpublished Skill aggregate instead of leaving a Draft-less shell
- invalidate held Team Draft leases when only the Draft is discarded, preserving monotonic fencing tokens
- align the Phase 2 spec and frontend integration guide with the corrected lifecycle

## Regression coverage

- first Team Draft + failed first publication deletes the full Skill aggregate and failed Attempt
- published Skill + failed Attempt still preserves history and only deletes the upgrade Draft
- deleting a Team upgrade Draft clears the lease holder and increments the fencing token

## Validation

- `uv run --project src/backend pytest -q src/backend/tests/community/core/skill_center/services/test_space_skill_application_service.py src/backend/tests/community/repository/skill_center/test_space_skill_draft_repository.py` (29 passed)
- `uv run --project src/backend ruff check ...`
- `git diff --check`