### PR TITLE
fix(skills): gate Center mappings on mount readiness

### DIFF
--- a/docs/arch/skills-management-publishing-current-state-and-upgrade-plan.md
+++ b/docs/arch/skills-management-publishing-current-state-and-upgrade-plan.md
@@ -278,6 +278,13 @@ SC 接入后，`skills-center` 作为 `skills-pool` 下与 `skills-repo`、`skil
 
 `skills-repo` 与 `skills-center` 只读是架构约束，而不是实现细节。已发布 Skill 的运行时内容不可被 Agent 对话直接修改；写操作必须经过相应的治理和发布路径。
 
+Center 映射能力还必须以运行时事实为准。Pool probe 可以在 Local/Repo
+布局就绪时保持 `READY`，但只有在版本化 `pool_center` 目录确实是可读挂载时
+才能声明支持 `skills-pool-mapping-v3`；挂载缺失时只声明 v2，并返回
+`restart_required` 证据供产品提示用户重启 Bot。`/api/skills/center/ensure`
+只核对挂载和精确 `<skill_uuid>/<sc_version_number>/SKILL.md`，不得创建目录、
+复制内容、更新 `current` 软链或承担任何分发职责。
+
 ### 4.3 引擎目录所有权与统一激活 API
 
 目标架构中，Backend 不再拼接或解释任何引擎物理目录，例如 `~/.openclaw/...`、`~/.claude_code/...`。路径、挂载和兼容桥的所有权统一收敛到 Engine Runtime。

--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_layout_probe.py
@@ -56,10 +56,19 @@ class _ResolvedFilesystemLayoutEvidence(BaseModel):
     pool_center: str
 
 
+class _CenterMountEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["READY", "NOT_READY", "UNAVAILABLE"]
+    reason: str | None
+    restart_required: bool
+
+
 class _RuntimeLayoutProbeEvidence(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     resolved_layout: _ResolvedFilesystemLayoutEvidence | None = None
+    center_mount: _CenterMountEvidence | None = None
 
 
 class _RuntimeLayoutProbeData(BaseModel):

--- a/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/per_domain.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/runtime_projections/per_domain.py
@@ -20,7 +20,10 @@ from agentclaw.community.core.skill_center.runtime_resolver import RuntimeSkillP
 from agentclaw.community.core.repository.protocols.skills_pool import (
     SkillsPoolLayoutRepositoryProtocol,
 )
-from agentclaw.community.core.skills_pool.mapping_intent import mapping_contract_for
+from agentclaw.community.core.skills_pool.mapping_intent import (
+    MAPPING_CONTRACT_V3,
+    mapping_contract_for,
+)
 from agentclaw.community.core.skills_pool.models import (
     MappingApplyMode,
     MappingProjectionStatus,
@@ -279,6 +282,19 @@ class PerDomainRuntimeProjection(EngineRuntimeProjection):
                 supported_versions = probe.evidence.get(
                     "supported_mapping_contract_versions"
                 )
+                center_mount = probe.evidence.get("center_mount")
+                if (
+                    isinstance(center_mount, dict)
+                    and center_mount.get("restart_required") is True
+                    and (
+                        not isinstance(supported_versions, list)
+                        or MAPPING_CONTRACT_V3 not in supported_versions
+                    )
+                ):
+                    return RuntimeProjectionResult.pending(
+                        code="CENTER_RUNTIME_RESTART_REQUIRED",
+                        reason="Bot 尚未加载 Skill Center 目录，请重启 Bot 后重试",
+                    )
             contract = mapping_contract_for(contract_mappings, supported_versions)
             raw_published = await self._pool_runtime.publish_mappings(
                 bot_id=bot_id,

--- a/src/backend/tests/community/core/skill_center/test_runtime_layout_probe.py
+++ b/src/backend/tests/community/core/skill_center/test_runtime_layout_probe.py
@@ -47,6 +47,11 @@ def _service(
                     "preparation_id": "2a958f59-8cf4-4413-a267-7d56d3382f23",
                     "evidence": {
                         "mapping_contract_version": "skills-pool-mapping-v2",
+                        "center_mount": {
+                            "status": "NOT_READY",
+                            "reason": "center_mount_missing",
+                            "restart_required": True,
+                        },
                         "checks": {
                             "pool_repo_mounted": True,
                             "legacy_repo_bridge_valid": True,
@@ -74,6 +79,7 @@ async def test_ready_is_taken_from_current_runtime_inspection():
 
     assert result.status is RuntimeLayoutProbeStatus.READY
     assert result.preparation_id == "2a958f59-8cf4-4413-a267-7d56d3382f23"
+    assert result.evidence["center_mount"]["restart_required"] is True
     resolver.resolve_for_bot.assert_called_once_with("bot-1", "user-1")
     transport.invoke.assert_awaited_once_with(
         context.conn_info,

--- a/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
+++ b/src/backend/tests/community/core/skill_center/test_skill_set_management_service.py
@@ -739,6 +739,23 @@ class _CenterRuntimePool(_RuntimePool):
         )
 
 
+class _CenterMountMissingRuntimePool(_CenterRuntimePool):
+    async def probe(self, **_kwargs):
+        self.probe_calls.append(_kwargs)
+        return SimpleNamespace(
+            evidence={
+                "supported_mapping_contract_versions": [
+                    "skills-pool-mapping-v2"
+                ],
+                "center_mount": {
+                    "status": "NOT_READY",
+                    "reason": "center_mount_missing",
+                    "restart_required": True,
+                },
+            }
+        )
+
+
 class _CenterRuntimeSkills:
     def list_bot_installed_assets(self, **_kwargs):
         return [
@@ -2477,6 +2494,34 @@ async def test_runtime_reconcile_requires_and_uses_mapping_v3_for_center():
             "skill_uuid": "00000000-0000-4000-8000-000000000007",
         "sc_version_number": "3.0.0",
     }
+
+
+@pytest.mark.asyncio
+async def test_center_projection_requests_bot_restart_when_mount_is_missing():
+    pool = _CenterMountMissingRuntimePool()
+    runtime = BotRuntimeProjector(
+        factory=_RuntimeFactory(),
+        bot_repo=_RuntimeBots(),
+        repository=_McpInstallations(),
+        reader=_reader(_CenterRuntimeSkills()),
+        registry=_registry(pool_runtime=pool, pool_layouts=_RuntimeLayouts()),
+        passport=_RuntimePassport(),
+        caller_identity_repo=_RuntimeCallerIdentity(),
+    )
+
+    result = await runtime.project(
+        bot_id="bot-1",
+        owner_id="true-owner",
+        scope=ProjectionScope.everything(),
+    )
+
+    assert result.status.value == "PENDING"
+    assert result.issues[0].code == "CENTER_RUNTIME_RESTART_REQUIRED"
+    assert result.issues[0].reason == (
+        "Bot 尚未加载 Skill Center 目录，请重启 Bot 后重试"
+    )
+    assert pool.publish_calls == []
+    assert pool.verify_calls == []
 
 
 @pytest.mark.asyncio

--- a/src/engine/src/engine/community/api/skills/router.py
+++ b/src/engine/src/engine/community/api/skills/router.py
@@ -435,7 +435,12 @@ async def ensure_center_skills(body: CenterEnsureRequestSchema) -> ApiResponse:
                 {"skill_uuid": x.skill_uuid, "version": x.version} for x in result.ok
             ],
             "failed": [
-                {"skill_uuid": x.skill_uuid, "version": x.version, "reason": x.reason}
+                {
+                    "skill_uuid": x.skill_uuid,
+                    "version": x.version,
+                    "reason": x.reason,
+                    **({"code": x.code} if x.code is not None else {}),
+                }
                 for x in result.failed
             ],
         },

--- a/src/engine/src/engine/community/api/skills/schemas.py
+++ b/src/engine/src/engine/community/api/skills/schemas.py
@@ -75,6 +75,7 @@ class CenterEnsureFailureSchema(BaseModel):
     skill_uuid: str
     version: str
     reason: str
+    code: str | None = None
 
 
 class CenterEnsureResponseSchema(BaseModel):
@@ -100,12 +101,24 @@ class ResolvedFilesystemLayoutEvidence(BaseModel):
     pool_center: str
 
 
+class CenterMountEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["READY", "NOT_READY", "UNAVAILABLE"]
+    reason: str | None
+    restart_required: bool
+
+
 class RuntimeLayoutProbeEvidence(BaseModel):
     """Extensible probe evidence with a typed resolved-layout member."""
 
     model_config = ConfigDict(extra="allow")
 
     resolved_layout: ResolvedFilesystemLayoutEvidence | None = Field(
+        default=None,
+        exclude_if=lambda value: value is None,
+    )
+    center_mount: CenterMountEvidence | None = Field(
         default=None,
         exclude_if=lambda value: value is None,
     )

--- a/src/engine/src/engine/community/api/tests/test_skills_router.py
+++ b/src/engine/src/engine/community/api/tests/test_skills_router.py
@@ -227,7 +227,10 @@ def test_ensure_center_skills_route_success(rich_manager, client):
                 ok=[CenterEnsureItem(skill_uuid="u1", version="1.0.0")],
                 failed=[
                     CenterEnsureFailure(
-                        skill_uuid="u2", version="2.0.0", reason="missing"
+                        skill_uuid="u2",
+                        version="2.0.0",
+                        reason="missing",
+                        code="CENTER_VERSION_NOT_FOUND",
                     )
                 ],
             )
@@ -249,7 +252,12 @@ def test_ensure_center_skills_route_success(rich_manager, client):
     assert body["success"] is True
     assert body["data"]["ok"] == [{"skill_uuid": "u1", "version": "1.0.0"}]
     assert body["data"]["failed"] == [
-        {"skill_uuid": "u2", "version": "2.0.0", "reason": "missing"}
+        {
+            "skill_uuid": "u2",
+            "version": "2.0.0",
+            "reason": "missing",
+            "code": "CENTER_VERSION_NOT_FOUND",
+        }
     ]
     assert len(captured["items"]) == 2
 

--- a/src/engine/src/engine/community/core/adapters/claude_code/skills.py
+++ b/src/engine/src/engine/community/core/adapters/claude_code/skills.py
@@ -357,6 +357,7 @@ class ClaudeCodeSkillsAdapter(SkillsService):
                 skill_uuid=d.get("skill_uuid", ""),
                 version=str(d.get("version", "")),
                 reason=d.get("reason", ""),
+                code=d.get("code"),
             )
             for d in raw.get("failed", [])
             if isinstance(d, dict)

--- a/src/engine/src/engine/community/core/adapters/openclaw/skills.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/skills.py
@@ -115,6 +115,7 @@ class OpenClawSkillsAdapter(SkillsService):
                 skill_uuid=d["skill_uuid"],
                 version=d["version"],
                 reason=d["reason"],
+                code=d.get("code"),
             )
             for d in raw.get("failed", [])
         ]

--- a/src/engine/src/engine/community/core/adapters/openclaw/tests/test_skills.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/tests/test_skills.py
@@ -48,7 +48,12 @@ class _FakeSkillsPort:
 async def test_ensure_center_skills_serializes_and_builds_result():
     port = _FakeSkillsPort(ensure_center_skills={
         "ok": [{"skill_uuid": "u1", "version": "1"}],
-        "failed": [{"skill_uuid": "u2", "version": "2", "reason": "NAS missing"}],
+        "failed": [{
+            "skill_uuid": "u2",
+            "version": "2",
+            "reason": "Center missing",
+            "code": "CENTER_VERSION_NOT_FOUND",
+        }],
     })
     adapter = OpenClawSkillsAdapter(port)
     req = CenterEnsureRequest(items=[
@@ -63,7 +68,8 @@ async def test_ensure_center_skills_serializes_and_builds_result():
     ]
     # built DTOs
     assert [(i.skill_uuid, i.version) for i in result.ok] == [("u1", "1")]
-    assert result.failed[0].reason == "NAS missing"
+    assert result.failed[0].reason == "Center missing"
+    assert result.failed[0].code == "CENTER_VERSION_NOT_FOUND"
 
 
 async def test_sync_symlinks_serializes_and_builds_result():

--- a/src/engine/src/engine/community/core/skills/models.py
+++ b/src/engine/src/engine/community/core/skills/models.py
@@ -170,6 +170,7 @@ class CenterEnsureFailure:
     skill_uuid: str
     version: str
     reason: str
+    code: str | None = None
 
 
 @dataclass

--- a/src/engine/src/engine/community/plugin_api/openclaw/skills.py
+++ b/src/engine/src/engine/community/plugin_api/openclaw/skills.py
@@ -1,8 +1,8 @@
 """OpenClawSkillsPort — native port for bulk symlink-based skills management.
 
 Skills operations are local-infra: they reconcile symlinks on the pod
-filesystem (``$SKILLS_LINK_BASE_DIR``) and rsync from a NAS source — no
-gateway, no pool, no token.  The port impl owns all FS/subprocess logic;
+filesystem (``$SKILLS_LINK_BASE_DIR``) and validate the provisioned Center
+mount — no gateway, no pool, no token.  The port impl owns filesystem logic;
 the adapter builds core DTOs from the primitive dicts returned here.
 
 Decision 5 (leaf-safety): ``CapabilityNotSupportedError`` and ``Capability``
@@ -49,8 +49,9 @@ class OpenClawSkillsPort(Protocol):
           ``failed`` (list[dict] each with ``skill_uuid``, ``version``,
           ``reason``).
 
-        Individual item failures do not abort the batch.  Items already
-        present locally are returned in ``ok`` without IO.
+        Individual item failures do not abort the batch. The operation is
+        read-only; runtime provisioning owns Center corpus delivery. Failed
+        items may include a stable ``code`` for callers to map to guidance.
         """
         ...
 

--- a/src/engine/src/engine/community/plugins/openclaw/_skills.py
+++ b/src/engine/src/engine/community/plugins/openclaw/_skills.py
@@ -1,6 +1,7 @@
 """_SkillsPortMixin — skills management port methods.
 
-Also contains _SkillsEnsureError (relocated from engines/openclaw/skills.py).
+Center ensure is deliberately read-only: corpus delivery belongs to runtime
+provisioning, not this request path.
 """
 
 from __future__ import annotations
@@ -12,12 +13,15 @@ from pathlib import Path
 from typing import Any
 
 from engine.community.core.skills.layout_planner import (
+    LAYOUT_CONTRACT_VERSION,
     MAPPING_CONTRACT_VERSION,
+    LayoutIdentity,
+    RuntimeLayoutContext,
+    resolve_filesystem_skill_layout,
 )
 from engine.community.plugin_api.openclaw.skills import (
     PoolLayoutActivationPortResult,
 )
-from engine.community.plugin_api.workspace_root import workspace_root
 from engine.community.plugins.openclaw._file import _convert_path
 from engine.community.plugins.openclaw.layout_activation import (
     MappingApplyMode,
@@ -31,6 +35,11 @@ from engine.community.plugins.openclaw.layout_probe import inspect_runtime_layou
 from engine.community.plugins.skills_pool.layout_quarantine import (
     cleanup_quarantine,
 )
+from engine.community.plugins.skills_pool.center_mount import (
+    CenterMountStatus,
+    inspect_center_mount,
+    inspect_center_version,
+)
 from engine.community.plugins.skills_pool.mapping_contract import (
     ResolvedMappingPayload,
     resolve_mapping_payload,
@@ -39,26 +48,12 @@ from engine.community.plugins.skills_pool.mapping_contract import (
 log = logging.getLogger("openclaw-port")
 
 
-class _SkillsEnsureError(RuntimeError):
-    """A single center-skill ensure failed (NAS source missing / rsync error).
-
-    Mirrors the legacy `engines/openclaw/skills.py:_EnsureError` so
-    `ensure_center_skills` soft-fails only THESE (→ a `failed` entry), while
-    unexpected OSErrors still propagate (→ HTTP 500), matching legacy.
-    """
-
-
 class _SkillsPortMixin:
     """Domain mixin: skills sync/ensure (local-infra, no gateway/pool/token)."""
 
     _SKILLS_LINK_BASE_DIR_ENV = "SKILLS_LINK_BASE_DIR"
     _DEFAULT_SKILLS_LINK_BASE_DIR = "/home/admin/.extra-skills"
-    _SKILLS_CENTER_NAS_ROOT_ENV = "SKILLS_CENTER_NAS_ROOT"
-    _SKILLS_CENTER_LOCAL_ROOT_ENV = "SKILLS_CENTER_LOCAL_ROOT"
-    _DEFAULT_SKILLS_CENTER_NAS_ROOT = "/home/admin/nfs/skills-center"
-    _DEFAULT_SKILLS_CENTER_LOCAL_ROOT = str(
-        workspace_root() / "skills-pool" / "skill-center"
-    )
+    _skills_center_is_mounted = staticmethod(os.path.ismount)
 
     @staticmethod
     def _pool_mappings(
@@ -205,16 +200,6 @@ class _SkillsPortMixin:
             base = self._DEFAULT_SKILLS_LINK_BASE_DIR
         return Path(base).expanduser().resolve()
 
-    # Per-key asyncio locks (in-process; single-process deployment, isolated per bot).
-    @classmethod
-    def _get_ensure_lock(cls, key: str) -> Any:
-        import asyncio as _asyncio
-        from collections import defaultdict
-
-        if not hasattr(cls, "_skills_ensure_locks_store"):
-            cls._skills_ensure_locks_store: dict[str, Any] = defaultdict(_asyncio.Lock)
-        return cls._skills_ensure_locks_store[key]
-
     @staticmethod
     def _skills_normalize_relative_path(raw: str, field: str) -> str:
         """Validate and normalise a path relative to a base dir.
@@ -267,127 +252,65 @@ class _SkillsPortMixin:
         return (link_path.parent / raw).resolve(strict=False)
 
     @staticmethod
-    def _skills_rsync_dir(src: Path, dst: Path) -> None:
-        """rsync src/ into dst/ (blocking).
-
-        Relocated intact from
-        ``engines/openclaw/skills.py:OpenClawSkillsService._rsync_dir``.
-        """
-        import subprocess as _sp
-
-        result = _sp.run(
-            ["rsync", "-rltD", "--delete", f"{src}/", f"{dst}/"],
-            capture_output=True,
-            text=True,
-            timeout=120,
-            check=False,
-        )
-        if result.returncode != 0:
-            raise _SkillsEnsureError(
-                f"rsync exit {result.returncode}: {result.stderr.strip()[:200]}"
-            )
-
-    @staticmethod
-    def _skills_ensure_current_symlink(uuid_dir: Path, version_dir_name: str) -> None:
-        """Atomically update the ``current`` symlink under ``uuid_dir``.
-
-        Relocated intact from
-        ``engines/openclaw/skills.py:OpenClawSkillsService._ensure_current_symlink``.
-        """
-        current = uuid_dir / "current"
-        if current.is_symlink() and os.readlink(current) == version_dir_name:
-            return
-        tmp = uuid_dir / f".current.tmp.{os.getpid()}"
-        if tmp.is_symlink() or tmp.exists():
-            tmp.unlink()
-        tmp.symlink_to(version_dir_name)
-        os.replace(tmp, current)
-
-    async def _skills_ensure_one(
-        self,
-        item: dict[str, Any],
-        nas_root: Path,
-        local_root: Path,
-    ) -> None:
-        """Ensure a single (skill_uuid, version) exists locally; rsync if absent.
-
-        Relocated intact from
-        ``engines/openclaw/skills.py:OpenClawSkillsService._ensure_one``
-        operating on plain dicts.  Raises ``RuntimeError`` on NAS-source-
-        missing or rsync failure.
-        """
-        import asyncio as _asyncio
-
-        skill_uuid = item["skill_uuid"]
-        version_dir_name = str(item["version"])
-        local_uuid_dir = local_root / skill_uuid
-        local_version_dir = local_uuid_dir / version_dir_name
-
-        if local_version_dir.exists() and any(local_version_dir.iterdir()):
-            return
-
-        lock_key = f"{skill_uuid}/{version_dir_name}"
-        lock = self._get_ensure_lock(lock_key)
-        async with lock:
-            if local_version_dir.exists() and any(local_version_dir.iterdir()):
-                return
-
-            nas_version_dir = nas_root / skill_uuid / version_dir_name
-            if not nas_version_dir.exists():
-                raise _SkillsEnsureError(f"NAS source missing: {nas_version_dir}")
-
-            local_version_dir.parent.mkdir(parents=True, exist_ok=True)
-            await _asyncio.to_thread(
-                self._skills_rsync_dir, nas_version_dir, local_version_dir
-            )
+    def _skills_center_root() -> Path:
+        return resolve_filesystem_skill_layout(
+            LayoutIdentity("openclaw", LAYOUT_CONTRACT_VERSION),
+            RuntimeLayoutContext(home=Path("/home/admin")),
+        ).pool_center
 
     async def ensure_center_skills(self, params: dict[str, Any]) -> dict[str, Any]:
-        """Ensure each (skill_uuid, version) from ``params["items"]`` is present locally.
+        """Read-only check that each requested exact Center version is mounted.
 
         ``params`` keys: ``items`` (list[dict] each with ``skill_uuid``,
         ``version``).
         Returns dict with keys ``ok`` (list[dict]) and ``failed``
         (list[dict] each with ``skill_uuid``, ``version``, ``reason``).
-        Relocated intact from
-        ``engines/openclaw/skills.py:OpenClawSkillsService.ensure_center_skills``.
+        Runtime provisioning owns the mount. This endpoint never creates,
+        copies, replaces, or deletes filesystem content.
         """
         log.info("[skills.ensure] start")
-        nas_root = Path(
-            os.environ.get(
-                self._SKILLS_CENTER_NAS_ROOT_ENV, self._DEFAULT_SKILLS_CENTER_NAS_ROOT
-            )
-        )
-        local_root = Path(
-            os.environ.get(
-                self._SKILLS_CENTER_LOCAL_ROOT_ENV,
-                self._DEFAULT_SKILLS_CENTER_LOCAL_ROOT,
-            )
+        center_root = self._skills_center_root()
+        mount = inspect_center_mount(
+            center_root,
+            is_mounted=self._skills_center_is_mounted,
         )
 
         ok: list[dict[str, Any]] = []
         failed: list[dict[str, Any]] = []
 
         for item in params.get("items", []):
-            try:
-                await self._skills_ensure_one(item, nas_root, local_root)
-                ok.append(item)
-            except _SkillsEnsureError as e:
-                # Soft-fail ONLY explicit ensure errors (NAS-missing / rsync),
-                # matching legacy `_EnsureError`. Unexpected OSErrors propagate
-                # (→ HTTP 500) rather than being silently logged as failures.
-                log.warning(
-                    "[skills.ensure] failed uuid=%s ver=%s: %s",
-                    item.get("skill_uuid"),
-                    item.get("version"),
-                    e,
+            if mount.status is CenterMountStatus.READY:
+                inspection = inspect_center_version(
+                    center_root,
+                    skill_uuid=str(item.get("skill_uuid", "")),
+                    version=str(item.get("version", "")),
                 )
-                failed.append(
-                    {
-                        "skill_uuid": item.get("skill_uuid", ""),
-                        "version": item.get("version", ""),
-                        "reason": str(e),
-                    }
-                )
+                if inspection.ready:
+                    ok.append(item)
+                    continue
+                code = inspection.code or "CENTER_MOUNT_UNAVAILABLE"
+                reason = inspection.reason or "Skill Center 目录当前不可用，请稍后重试"
+            elif mount.status is CenterMountStatus.NOT_READY:
+                code = "CENTER_MOUNT_NOT_READY"
+                reason = "Skill Center 目录尚未挂载，请重启 Bot 后重试"
+            else:
+                code = "CENTER_MOUNT_UNAVAILABLE"
+                reason = "Skill Center 目录当前不可用，请稍后重试"
+            log.warning(
+                "[skills.ensure] failed uuid=%s ver=%s code=%s mount_reason=%s",
+                item.get("skill_uuid"),
+                item.get("version"),
+                code,
+                mount.reason,
+            )
+            failed.append(
+                {
+                    "skill_uuid": item.get("skill_uuid", ""),
+                    "version": item.get("version", ""),
+                    "code": code,
+                    "reason": reason,
+                }
+            )
 
         log.info(
             "[skills.ensure] done total=%d ok=%d failed=%d",

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_center_ensure.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_center_ensure.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from engine.community.plugins.openclaw.plugin_impl import OpenClawPluginImpl
+
+
+def _plugin_for_root(
+    monkeypatch: pytest.MonkeyPatch,
+    root: Path,
+    *,
+    mounted: bool,
+) -> OpenClawPluginImpl:
+    plugin = OpenClawPluginImpl()
+    monkeypatch.setattr(plugin, "_skills_center_root", lambda: root)
+    monkeypatch.setattr(
+        plugin,
+        "_skills_center_is_mounted",
+        lambda path: mounted and path == root,
+    )
+    return plugin
+
+
+@pytest.mark.asyncio
+async def test_ensure_is_read_only_when_center_mount_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "skill-center"
+    plugin = _plugin_for_root(monkeypatch, root, mounted=False)
+
+    result = await plugin.ensure_center_skills(
+        {"items": [{"skill_uuid": "u1", "version": "1"}]}
+    )
+
+    assert result == {
+        "ok": [],
+        "failed": [
+            {
+                "skill_uuid": "u1",
+                "version": "1",
+                "code": "CENTER_MOUNT_NOT_READY",
+                "reason": "Skill Center 目录尚未挂载，请重启 Bot 后重试",
+            }
+        ],
+    }
+    assert not root.exists()
+
+
+@pytest.mark.asyncio
+async def test_ensure_accepts_an_exact_readable_center_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "skill-center"
+    version = root / "u1" / "1"
+    version.mkdir(parents=True)
+    (version / "SKILL.md").write_text("---\nname: demo\n---\n")
+    plugin = _plugin_for_root(monkeypatch, root, mounted=True)
+
+    item = {"skill_uuid": "u1", "version": "1"}
+    result = await plugin.ensure_center_skills({"items": [item]})
+
+    assert result == {"ok": [item], "failed": []}
+
+
+@pytest.mark.asyncio
+async def test_ensure_reports_missing_exact_center_version_without_writing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "skill-center"
+    root.mkdir()
+    plugin = _plugin_for_root(monkeypatch, root, mounted=True)
+
+    result = await plugin.ensure_center_skills(
+        {"items": [{"skill_uuid": "u1", "version": "2"}]}
+    )
+
+    assert result["ok"] == []
+    assert result["failed"][0]["code"] == "CENTER_VERSION_NOT_FOUND"
+    assert not (root / "u1").exists()

--- a/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
+++ b/src/engine/src/engine/community/plugins/openclaw/tests/test_layout_probe.py
@@ -86,6 +86,41 @@ def test_ready_requires_real_bridge_mount_and_readable_repo(tmp_path):
     }
     assert result.evidence["checks"]["pool_repo_mounted"] is True
     assert result.evidence["checks"]["legacy_repo_bridge_valid"] is True
+    assert result.evidence["supported_mapping_contract_versions"] == [
+        "skills-pool-mapping-v2"
+    ]
+    assert result.evidence["center_mount"] == {
+        "status": "NOT_READY",
+        "reason": "center_mount_missing",
+        "restart_required": True,
+    }
+
+
+def test_ready_advertises_v3_only_when_center_mount_is_ready(tmp_path):
+    home, _, _, pool_repo = _ready_home(tmp_path)
+    pool_center = home / ".openclaw/workspace/skills-pool/skill-center"
+    pool_center.mkdir()
+
+    result = inspect_runtime_layout(
+        engine="openclaw",
+        expected_contract_version=LAYOUT_CONTRACT_VERSION,
+        home=home,
+        repo_is_mounted=lambda path: path == pool_repo,
+        center_is_mounted=lambda path: path == pool_center,
+    )
+
+    assert result.status is RuntimeLayoutInspectionStatus.READY
+    assert result.evidence["supported_mapping_contract_versions"] == [
+        "skills-pool-mapping-v2",
+        "skills-pool-mapping-v3",
+    ]
+    assert result.evidence["checks"]["pool_center_mounted"] is True
+    assert result.evidence["checks"]["pool_center_readable"] is True
+    assert result.evidence["center_mount"] == {
+        "status": "READY",
+        "reason": None,
+        "restart_required": False,
+    }
 
 
 def test_active_marker_requires_direct_pool_mappings_and_absent_storage_entries(

--- a/src/engine/src/engine/community/plugins/skills_pool/center_mount.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/center_mount.py
@@ -1,0 +1,189 @@
+"""Read-only inspection of the shared Skill Center corpus mount."""
+
+from __future__ import annotations
+
+import os
+import stat
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+
+class CenterMountStatus(StrEnum):
+    READY = "READY"
+    NOT_READY = "NOT_READY"
+    UNAVAILABLE = "UNAVAILABLE"
+
+
+@dataclass(frozen=True, slots=True)
+class CenterMountInspection:
+    status: CenterMountStatus
+    reason: str | None
+    restart_required: bool
+
+    def to_evidence(self) -> dict[str, object]:
+        return {
+            "status": self.status.value,
+            "reason": self.reason,
+            "restart_required": self.restart_required,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CenterVersionInspection:
+    ready: bool
+    code: str | None = None
+    reason: str | None = None
+
+
+def inspect_center_mount(
+    root: Path,
+    *,
+    is_mounted: Callable[[Path], bool] = os.path.ismount,
+) -> CenterMountInspection:
+    """Inspect the provisioned corpus without creating or repairing anything."""
+
+    try:
+        root_stat = root.lstat()
+    except (FileNotFoundError, NotADirectoryError):
+        return CenterMountInspection(
+            CenterMountStatus.NOT_READY,
+            "center_mount_missing",
+            True,
+        )
+    except PermissionError:
+        return CenterMountInspection(
+            CenterMountStatus.UNAVAILABLE,
+            "center_mount_unreadable",
+            False,
+        )
+    except OSError:
+        return CenterMountInspection(
+            CenterMountStatus.UNAVAILABLE,
+            "center_mount_temporarily_unavailable",
+            False,
+        )
+
+    if stat.S_ISLNK(root_stat.st_mode) or not stat.S_ISDIR(root_stat.st_mode):
+        return CenterMountInspection(
+            CenterMountStatus.NOT_READY,
+            "center_mount_not_directory",
+            True,
+        )
+    try:
+        mounted = is_mounted(root)
+    except OSError:
+        return CenterMountInspection(
+            CenterMountStatus.UNAVAILABLE,
+            "center_mount_temporarily_unavailable",
+            False,
+        )
+    if not mounted:
+        return CenterMountInspection(
+            CenterMountStatus.NOT_READY,
+            "center_mount_not_mounted",
+            True,
+        )
+    try:
+        with os.scandir(root):
+            pass
+    except PermissionError:
+        return CenterMountInspection(
+            CenterMountStatus.UNAVAILABLE,
+            "center_mount_unreadable",
+            False,
+        )
+    except OSError:
+        return CenterMountInspection(
+            CenterMountStatus.UNAVAILABLE,
+            "center_mount_temporarily_unavailable",
+            False,
+        )
+    return CenterMountInspection(CenterMountStatus.READY, None, False)
+
+
+def _safe_component(value: str) -> bool:
+    path = Path(value)
+    return (
+        bool(value)
+        and not path.is_absolute()
+        and path.name == value
+        and value not in {".", ".."}
+    )
+
+
+def inspect_center_version(
+    root: Path,
+    *,
+    skill_uuid: str,
+    version: str,
+) -> CenterVersionInspection:
+    """Verify that one exact mounted version contains a readable ``SKILL.md``."""
+
+    if not _safe_component(skill_uuid) or not _safe_component(version):
+        return CenterVersionInspection(
+            False,
+            "CENTER_VERSION_INVALID",
+            "Skill Center 版本标识无效",
+        )
+
+    version_root = root / skill_uuid / version
+    manifest = version_root / "SKILL.md"
+    try:
+        version_stat = version_root.lstat()
+        manifest_stat = manifest.lstat()
+    except (FileNotFoundError, NotADirectoryError):
+        return CenterVersionInspection(
+            False,
+            "CENTER_VERSION_NOT_FOUND",
+            "Skill Center 中未找到指定版本",
+        )
+    except PermissionError:
+        return CenterVersionInspection(
+            False,
+            "CENTER_MOUNT_UNAVAILABLE",
+            "Skill Center 目录当前不可读取，请稍后重试",
+        )
+    except OSError:
+        return CenterVersionInspection(
+            False,
+            "CENTER_MOUNT_UNAVAILABLE",
+            "Skill Center 目录当前不可用，请稍后重试",
+        )
+    if (
+        stat.S_ISLNK(version_stat.st_mode)
+        or not stat.S_ISDIR(version_stat.st_mode)
+        or stat.S_ISLNK(manifest_stat.st_mode)
+        or not stat.S_ISREG(manifest_stat.st_mode)
+    ):
+        return CenterVersionInspection(
+            False,
+            "CENTER_VERSION_INVALID",
+            "Skill Center 版本目录无效",
+        )
+    try:
+        with manifest.open("rb") as stream:
+            stream.read(1)
+    except PermissionError:
+        return CenterVersionInspection(
+            False,
+            "CENTER_MOUNT_UNAVAILABLE",
+            "Skill Center 目录当前不可读取，请稍后重试",
+        )
+    except OSError:
+        return CenterVersionInspection(
+            False,
+            "CENTER_MOUNT_UNAVAILABLE",
+            "Skill Center 目录当前不可用，请稍后重试",
+        )
+    return CenterVersionInspection(True)
+
+
+__all__ = [
+    "CenterMountInspection",
+    "CenterMountStatus",
+    "CenterVersionInspection",
+    "inspect_center_mount",
+    "inspect_center_version",
+]

--- a/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/layout_probe.py
@@ -20,11 +20,14 @@ from engine.community.core.skills.layout_planner import (
     MAPPING_V3_CONTRACT_VERSION,
     LayoutIdentity,
     RuntimeLayoutContext,
+    ResolvedFilesystemLayoutPlan as _FilesystemPoolLayout,
     resolve_filesystem_skill_layout,
     resolved_filesystem_layout_evidence,
 )
-from engine.community.core.skills.layout_planner import (
-    ResolvedFilesystemLayoutPlan as _FilesystemPoolLayout,
+from engine.community.plugins.skills_pool.center_mount import (
+    CenterMountInspection,
+    CenterMountStatus,
+    inspect_center_mount,
 )
 
 
@@ -58,6 +61,7 @@ def _ready_evidence(
     layout: _FilesystemPoolLayout,
     marker: dict[str, Any],
     checks: dict[str, bool],
+    center_mount: CenterMountInspection,
     mapping_contract_version: str | None,
     activation_state: str | None = None,
 ) -> dict[str, Any]:
@@ -75,13 +79,14 @@ def _ready_evidence(
             }
         )
     if mapping_contract_version is not None:
+        supported_mapping_contract_versions = [MAPPING_CONTRACT_VERSION]
+        if center_mount.status is CenterMountStatus.READY:
+            supported_mapping_contract_versions.append(MAPPING_V3_CONTRACT_VERSION)
         evidence.update(
             {
                 "mapping_contract_version": mapping_contract_version,
-                "supported_mapping_contract_versions": [
-                    MAPPING_CONTRACT_VERSION,
-                    MAPPING_V3_CONTRACT_VERSION,
-                ],
+                "supported_mapping_contract_versions": supported_mapping_contract_versions,
+                "center_mount": center_mount.to_evidence(),
                 "resolved_layout": resolved_filesystem_layout_evidence(
                     layout,
                     local_root=layout.pool_local,
@@ -467,6 +472,7 @@ def inspect_runtime_layout(
     mapping_contract_version: str | None = MAPPING_CONTRACT_VERSION,
     home: Path = Path("/home/admin"),
     repo_is_mounted: Callable[[Path], bool] = os.path.ismount,
+    center_is_mounted: Callable[[Path], bool] | None = None,
     repo_delivery: RepoDelivery | None = None,
 ) -> RuntimeLayoutInspection:
     """Inspect local runtime facts; this function never mutates the filesystem."""
@@ -675,6 +681,10 @@ def inspect_runtime_layout(
             error=error,
             preparation_id=preparation_id,
         )
+    center_mount = inspect_center_mount(
+        layout.pool_center,
+        is_mounted=center_is_mounted or repo_is_mounted,
+    )
     active_marker: dict[str, Any] | None = None
     try:
         active_marker_stat = layout.active_marker.lstat()
@@ -826,6 +836,9 @@ def inspect_runtime_layout(
                 active_marker["activation_state"] == "active"
             ),
         }
+        if center_mount.status is CenterMountStatus.READY:
+            active_checks["pool_center_mounted"] = True
+            active_checks["pool_center_readable"] = True
         if (
             engine in {"aicoding", "hermes"}
             and active_marker["activation_state"] == "active"
@@ -842,6 +855,7 @@ def inspect_runtime_layout(
                 activation_state=active_marker["activation_state"],
                 mapping_contract_version=mapping_contract_version,
                 checks=active_checks,
+                center_mount=center_mount,
             ),
         )
     if engine == "claude_code" and effective_repo_delivery is RepoDelivery.MOUNT:
@@ -986,6 +1000,9 @@ def inspect_runtime_layout(
         "pool_repo_readable": True,
         "managed_active_entries_valid": True,
     }
+    if center_mount.status is CenterMountStatus.READY:
+        checks["pool_center_mounted"] = True
+        checks["pool_center_readable"] = True
     if engine == "openclaw" and effective_repo_delivery is RepoDelivery.MOUNT:
         checks["legacy_repo_bridge_valid"] = True
     else:
@@ -1007,6 +1024,7 @@ def inspect_runtime_layout(
             marker=marker,
             mapping_contract_version=mapping_contract_version,
             checks=checks,
+            center_mount=center_mount,
         ),
     )
 

--- a/src/engine/src/engine/community/plugins/skills_pool/tests/test_center_mount.py
+++ b/src/engine/src/engine/community/plugins/skills_pool/tests/test_center_mount.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from engine.community.plugins.skills_pool import center_mount as subject
+from engine.community.plugins.skills_pool.center_mount import (
+    CenterMountStatus,
+    inspect_center_mount,
+    inspect_center_version,
+)
+
+
+def test_missing_mount_requires_restart(tmp_path: Path) -> None:
+    result = inspect_center_mount(tmp_path / "missing")
+
+    assert result.status is CenterMountStatus.NOT_READY
+    assert result.reason == "center_mount_missing"
+    assert result.restart_required is True
+
+
+@pytest.mark.parametrize("kind", ["file", "symlink"])
+def test_non_directory_mountpoint_requires_restart(tmp_path: Path, kind: str) -> None:
+    root = tmp_path / "skill-center"
+    if kind == "file":
+        root.write_text("not a directory")
+    else:
+        target = tmp_path / "target"
+        target.mkdir()
+        root.symlink_to(target, target_is_directory=True)
+
+    result = inspect_center_mount(root, is_mounted=lambda _path: True)
+
+    assert result.status is CenterMountStatus.NOT_READY
+    assert result.reason == "center_mount_not_directory"
+
+
+def test_plain_directory_is_not_treated_as_a_mount(tmp_path: Path) -> None:
+    root = tmp_path / "skill-center"
+    root.mkdir()
+
+    result = inspect_center_mount(root, is_mounted=lambda _path: False)
+
+    assert result.status is CenterMountStatus.NOT_READY
+    assert result.reason == "center_mount_not_mounted"
+    assert result.restart_required is True
+
+
+def test_mount_checker_failure_is_transient(tmp_path: Path) -> None:
+    root = tmp_path / "skill-center"
+    root.mkdir()
+
+    def fail(_path: Path) -> bool:
+        raise OSError("mount table unavailable")
+
+    result = inspect_center_mount(root, is_mounted=fail)
+
+    assert result.status is CenterMountStatus.UNAVAILABLE
+    assert result.reason == "center_mount_temporarily_unavailable"
+    assert result.restart_required is False
+
+
+@pytest.mark.parametrize(
+    ("error", "reason"),
+    [
+        (PermissionError("denied"), "center_mount_unreadable"),
+        (OSError("io"), "center_mount_temporarily_unavailable"),
+    ],
+)
+def test_mountpoint_stat_failure_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error: OSError,
+    reason: str,
+) -> None:
+    root = tmp_path / "skill-center"
+    original_lstat = Path.lstat
+
+    def fail_lstat(path: Path):
+        if path == root:
+            raise error
+        return original_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", fail_lstat)
+    result = inspect_center_mount(root)
+
+    assert result.status is CenterMountStatus.UNAVAILABLE
+    assert result.reason == reason
+
+
+@pytest.mark.parametrize(
+    ("error", "reason"),
+    [
+        (PermissionError("denied"), "center_mount_unreadable"),
+        (OSError("io"), "center_mount_temporarily_unavailable"),
+    ],
+)
+def test_mounted_directory_must_be_readable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error: OSError,
+    reason: str,
+) -> None:
+    root = tmp_path / "skill-center"
+    root.mkdir()
+
+    def fail_scandir(path: Path):
+        assert path == root
+        raise error
+
+    monkeypatch.setattr(subject.os, "scandir", fail_scandir)
+    result = inspect_center_mount(root, is_mounted=lambda _path: True)
+
+    assert result.status is CenterMountStatus.UNAVAILABLE
+    assert result.reason == reason
+
+
+def test_readable_mounted_directory_is_ready(tmp_path: Path) -> None:
+    root = tmp_path / "skill-center"
+    root.mkdir()
+
+    result = inspect_center_mount(root, is_mounted=lambda _path: True)
+
+    assert result.status is CenterMountStatus.READY
+    assert result.to_evidence() == {
+        "status": "READY",
+        "reason": None,
+        "restart_required": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("skill_uuid", "version"),
+    [("../escape", "1"), ("u1", "../escape"), ("", "1")],
+)
+def test_exact_version_rejects_unsafe_components(
+    tmp_path: Path,
+    skill_uuid: str,
+    version: str,
+) -> None:
+    result = inspect_center_version(
+        tmp_path,
+        skill_uuid=skill_uuid,
+        version=version,
+    )
+
+    assert result.code == "CENTER_VERSION_INVALID"
+
+
+def test_exact_version_requires_directory_and_regular_manifest(tmp_path: Path) -> None:
+    root = tmp_path / "skill-center"
+    version = root / "u1" / "1"
+    version.mkdir(parents=True)
+    target = root / "manifest-target"
+    target.write_text("---\nname: demo\n---\n")
+    (version / "SKILL.md").symlink_to(target)
+
+    result = inspect_center_version(root, skill_uuid="u1", version="1")
+
+    assert result.code == "CENTER_VERSION_INVALID"
+    assert result.reason == "Skill Center 版本目录无效"
+
+
+@pytest.mark.parametrize(
+    ("error", "reason"),
+    [
+        (PermissionError("denied"), "Skill Center 目录当前不可读取，请稍后重试"),
+        (OSError("io"), "Skill Center 目录当前不可用，请稍后重试"),
+    ],
+)
+def test_exact_version_reports_stat_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error: OSError,
+    reason: str,
+) -> None:
+    root = tmp_path / "skill-center"
+    version = root / "u1" / "1"
+    version.mkdir(parents=True)
+    (version / "SKILL.md").write_text("---\nname: demo\n---\n")
+    original_lstat = Path.lstat
+
+    def fail_lstat(path: Path):
+        if path == version:
+            raise error
+        return original_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", fail_lstat)
+    result = inspect_center_version(root, skill_uuid="u1", version="1")
+
+    assert result.code == "CENTER_MOUNT_UNAVAILABLE"
+    assert result.reason == reason
+
+
+@pytest.mark.parametrize(
+    ("error", "reason"),
+    [
+        (PermissionError("denied"), "Skill Center 目录当前不可读取，请稍后重试"),
+        (OSError("io"), "Skill Center 目录当前不可用，请稍后重试"),
+    ],
+)
+def test_exact_version_reports_manifest_read_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error: OSError,
+    reason: str,
+) -> None:
+    root = tmp_path / "skill-center"
+    version = root / "u1" / "1"
+    version.mkdir(parents=True)
+    manifest = version / "SKILL.md"
+    manifest.write_text("---\nname: demo\n---\n")
+    original_open = Path.open
+
+    def fail_open(path: Path, *args, **kwargs):
+        if path == manifest:
+            raise error
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "open", fail_open)
+    result = inspect_center_version(root, skill_uuid="u1", version="1")
+
+    assert result.code == "CENTER_MOUNT_UNAVAILABLE"
+    assert result.reason == reason
+
+
+def test_exact_version_accepts_readable_manifest(tmp_path: Path) -> None:
+    root = tmp_path / "skill-center"
+    version = root / "u1" / "1"
+    version.mkdir(parents=True)
+    (version / "SKILL.md").write_text("---\nname: demo\n---\n")
+
+    result = inspect_center_version(root, skill_uuid="u1", version="1")
+
+    assert result.ready is True
+    assert result.code is None


### PR DESCRIPTION
## Problem

Filesystem runtimes advertised the v3 Center mapping contract whenever the base Skills Pool layout was ready, even when the read-only Center corpus was not mounted. The Center ensure path also copied files with rsync and created local directories, which mixed corpus delivery into a request-time validation endpoint and could hide a missing runtime mount.

## Solution

- inspect the versioned Center corpus as a read-only runtime fact
- advertise mapping v3 only when the Center mount is present and readable; keep v2 READY for Local and Repo when it is absent
- make Center ensure validate only the exact skill UUID/version/SKILL.md path and return stable failure codes
- return CENTER_RUNTIME_RESTART_REQUIRED so products can ask the user to restart the Bot when the new mount has not been loaded
- document that Center delivery is owned by runtime provisioning, not ensure

## Validation

- Engine full gate: 2431 passed, 5 deselected; 93.14% line coverage; 97.17% changed-line coverage
- Backend full gate: 16007 passed, 58 skipped; 88.06% line coverage; 100% changed-line coverage
- Python SAST block scan passed for changed Backend and Engine files
- Standards review: architecture boundaries, filesystem ownership, compatibility, and failure safety checked
- Spec review: v2 fallback, conditional v3, read-only ensure, exact-version validation, and restart guidance checked

## Compatibility and risk

The probe evidence and ensure failure code are additive. Older runtimes may omit them. Local and Repo mapping behavior remains on v2. Existing Center mappings require a runtime image that provisions the new read-only mount; otherwise the mutation remains pending with restart guidance.

## Spec

Implements the runtime readiness and read-only ensure semantics documented in docs/arch/skills-management-publishing-current-state-and-upgrade-plan.md.