### PR TITLE
feat(bcs): support one-shot opening messages

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/collaboration_runs.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/collaboration_runs.rs
@@ -21,6 +21,7 @@ use bcs_service_api::{
     StartSessionStateMachineRunCommand, StartStateMachineRunCommand,
     StateMachineRunAccessCommand, StateMachineRunView,
 };
+use bcs_service_api::types::OpeningMessage;
 
 #[derive(Debug, Deserialize)]
 pub struct StartStateMachineRunRequest {
@@ -46,6 +47,8 @@ pub struct CancelStateMachineRunRequest {
 pub struct StartSessionStateMachineRunRequest {
     pub definition_yaml: String,
     pub participant_bindings: BTreeMap<String, RuntimeParticipantBinding>,
+    #[serde(default)]
+    pub opening_message: Option<Value>,
     #[serde(default)]
     pub input: Value,
 }
@@ -95,6 +98,7 @@ pub async fn start_state_machine_run(
             definition: body.definition,
             definition_ref: body.definition_ref,
             participant_bindings: None,
+            opening_message_override: None,
             input: body.input,
             caller_id: authenticated_human
                 .as_ref()
@@ -146,6 +150,13 @@ pub async fn start_session_state_machine_run(
     {
         return error.into_response();
     }
+    let opening_message = match body.opening_message {
+        Some(opening_message) => match serde_json::from_value::<OpeningMessage>(opening_message) {
+            Ok(opening_message) => Some(opening_message),
+            Err(error) => return invalid_opening_message_response(error.to_string()),
+        },
+        None => None,
+    };
     match state
         .services
         .collaboration_runtime
@@ -154,6 +165,7 @@ pub async fn start_session_state_machine_run(
             caller_bot_id,
             definition_yaml: body.definition_yaml,
             participant_bindings: body.participant_bindings,
+            opening_message,
             input: body.input,
             judge_available: state.judge_enabled,
         })
@@ -415,6 +427,11 @@ pub(crate) fn collaboration_error_to_response(error: CollaborationRuntimeError) 
         CollaborationRuntimeError::InvalidParticipantBinding(_) => {
             (StatusCode::BAD_REQUEST, "invalid_participant_binding")
         }
+        CollaborationRuntimeError::InvalidRequest(message)
+            if message.starts_with("invalid_opening_message:") =>
+        {
+            (StatusCode::BAD_REQUEST, "invalid_opening_message")
+        }
         CollaborationRuntimeError::InvalidRequest(_) => {
             (StatusCode::BAD_REQUEST, "invalid_request")
         }
@@ -433,6 +450,17 @@ pub(crate) fn collaboration_error_to_response(error: CollaborationRuntimeError) 
         Json(serde_json::json!({
             "error": code,
             "message": error.to_string()
+        })),
+    )
+        .into_response()
+}
+
+fn invalid_opening_message_response(message: String) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({
+            "error": "invalid_opening_message",
+            "message": message,
         })),
     )
         .into_response()

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/groups.rs
@@ -870,6 +870,7 @@ async fn start_initial_state_machine_run_for_group(
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: session.input.clone().unwrap_or(Value::Null),
             caller_id,
             authenticated_human,

--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/services.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/services.rs
@@ -151,6 +151,7 @@ pub async fn post_invocation(
                         definition: None,
                         definition_ref: None,
                         participant_bindings: None,
+                        opening_message_override: None,
                         input: outcome.session.input.clone().unwrap_or(Value::Null),
                         caller_id: outcome.session.caller_id.clone(),
                         authenticated_human: None,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/groups_contract.rs
@@ -50,6 +50,27 @@ use tempfile::TempDir;
 use tokio::sync::Mutex;
 use tower::ServiceExt;
 
+const ONE_SHOT_DEFINITION_YAML: &str = r#"
+name: One Shot
+participants:
+  writer:
+    required: true
+runtime:
+  kind: state_machine
+  state_machine:
+    version: 1
+    graph_mode: acyclic
+    nodes:
+      write:
+        kind: bot_task
+        display_name: Write
+        assignee:
+          type: bot_binding
+          binding: writer
+        instruction: Write the final answer.
+        final_output: true
+"#;
+
 fn static_auth_chain(staff_no: &str, nick_name: &str) -> Arc<AuthPluginChain> {
     let principal = AuthPrincipal {
         user_id: Some(staff_no.to_string()),
@@ -197,6 +218,7 @@ impl CollaborationRuntimeService for RecordingCollaborationRuntime {
                     created_by: Some(cmd.caller_bot_id),
                     status: StateMachineRunStatus::Running,
                     input: cmd.input,
+                    opening_message_override: cmd.opening_message,
                     output: None,
                     error: None,
                     created_at: 1,
@@ -236,6 +258,7 @@ impl CollaborationRuntimeService for RecordingCollaborationRuntime {
                     created_by: Some("human_alice".to_string()),
                     status: StateMachineRunStatus::Running,
                     input: Value::Null,
+                    opening_message_override: None,
                     output: None,
                     error: None,
                     created_at: 2,
@@ -302,6 +325,7 @@ impl CollaborationRuntimeService for RecordingCollaborationRuntime {
                 created_by: Some("human_alice".to_string()),
                 status: StateMachineRunStatus::Completed,
                 input: Value::Null,
+                opening_message_override: None,
                 output: None,
                 error: None,
                 created_at: 1,
@@ -790,26 +814,7 @@ async fn session_state_machine_permission_uses_authenticated_bot_identity() {
 async fn session_state_machine_start_forwards_yaml_and_transient_role_bindings() {
     let (app, _, collaboration_runtime, _temp_dir) =
         test_app_with_collaboration_runtime().await;
-    let definition_yaml = r#"
-name: One Shot
-participants:
-  writer:
-    required: true
-runtime:
-  kind: state_machine
-  state_machine:
-    version: 1
-    graph_mode: acyclic
-    nodes:
-      write:
-        kind: bot_task
-        display_name: Write
-        assignee:
-          type: bot_binding
-          binding: writer
-        instruction: Write the final answer.
-        final_output: true
-"#;
+    let definition_yaml = ONE_SHOT_DEFINITION_YAML;
 
     let response = app
         .oneshot(
@@ -827,6 +832,18 @@ runtime:
                                 "bot_ids": ["target-bot"]
                             }
                         },
+                        "opening_message": {
+                            "type": "panel",
+                            "component": "partnerPanel.OneShotRunView",
+                            "params": {
+                                "runId": "{{bcs.run_id}}",
+                                "scene": "release"
+                            },
+                            "tab": {
+                                "title": "One Shot",
+                                "closable": true
+                            }
+                        },
                         "input": {"question": "draft it"}
                     })
                     .to_string(),
@@ -842,6 +859,7 @@ runtime:
     assert_eq!(json["run"]["run_id"], "run-one-shot");
     assert_eq!(json["run"]["session_id"], "session-chat");
     assert_eq!(json["run"]["created_by"], "driver-bot");
+    assert!(json["run"].get("opening_message_override").is_none());
 
     let commands = collaboration_runtime.session_start_commands.lock().await;
     assert_eq!(commands.len(), 1);
@@ -850,6 +868,21 @@ runtime:
     assert_eq!(commands[0].definition_yaml, definition_yaml);
     assert_eq!(commands[0].input, serde_json::json!({"question": "draft it"}));
     assert_eq!(
+        serde_json::to_value(commands[0].opening_message.as_ref().unwrap()).unwrap(),
+        serde_json::json!({
+            "type": "panel",
+            "component": "partnerPanel.OneShotRunView",
+            "params": {
+                "runId": "{{bcs.run_id}}",
+                "scene": "release"
+            },
+            "tab": {
+                "title": "One Shot",
+                "closable": true
+            }
+        })
+    );
+    assert_eq!(
         commands[0]
             .participant_bindings
             .get("writer")
@@ -857,6 +890,105 @@ runtime:
         Some(("manual", &["target-bot".to_string()][..]))
     );
     assert!(!commands[0].judge_available);
+}
+
+#[tokio::test]
+async fn session_state_machine_start_accepts_compatible_opening_message_shapes() {
+    let (app, _, collaboration_runtime, _temp_dir) =
+        test_app_with_collaboration_runtime().await;
+    let opening_messages = [
+        None,
+        Some(Value::Null),
+        Some(serde_json::json!("Run {{bcs.run_id}}")),
+        Some(serde_json::json!({
+            "type": "card",
+            "component": "partnerCard.OneShotSummary",
+            "params": {"runId": "{{bcs.run_id}}"}
+        })),
+    ];
+
+    for opening_message in opening_messages {
+        let mut payload = serde_json::json!({
+            "definition_yaml": ONE_SHOT_DEFINITION_YAML,
+            "participant_bindings": {},
+            "input": null
+        });
+        if let Some(opening_message) = opening_message {
+            payload["opening_message"] = opening_message;
+        }
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/sessions/session-chat/state-machine-runs")
+                    .header("authorization", "Bearer driver-token")
+                    .header("content-type", "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+    }
+
+    let commands = collaboration_runtime.session_start_commands.lock().await;
+    assert_eq!(commands.len(), 4);
+    assert!(commands[0].opening_message.is_none());
+    assert!(commands[1].opening_message.is_none());
+    assert_eq!(
+        serde_json::to_value(commands[2].opening_message.as_ref().unwrap()).unwrap(),
+        serde_json::json!("Run {{bcs.run_id}}")
+    );
+    assert_eq!(
+        serde_json::to_value(commands[3].opening_message.as_ref().unwrap()).unwrap(),
+        serde_json::json!({
+            "type": "card",
+            "component": "partnerCard.OneShotSummary",
+            "params": {"runId": "{{bcs.run_id}}"}
+        })
+    );
+}
+
+#[tokio::test]
+async fn session_state_machine_start_rejects_malformed_opening_message_as_bad_request() {
+    let (app, _, collaboration_runtime, _temp_dir) =
+        test_app_with_collaboration_runtime().await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/sessions/session-chat/state-machine-runs")
+                .header("authorization", "Bearer driver-token")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "definition_yaml": ONE_SHOT_DEFINITION_YAML,
+                        "participant_bindings": {},
+                        "opening_message": {
+                            "type": "panel",
+                            "component": "partnerPanel.OneShotRunView",
+                            "unknown": true
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"], "invalid_opening_message");
+    assert!(
+        collaboration_runtime
+            .session_start_commands
+            .lock()
+            .await
+            .is_empty()
+    );
 }
 
 #[tokio::test]

--- a/src/bcs/crates/adapters/http/bcs-http/tests/service_routes_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/service_routes_contract.rs
@@ -429,6 +429,7 @@ impl CollaborationRuntimeService for RecordingCollaborationRuntime {
                     created_by: cmd.caller_id.clone(),
                     status: StateMachineRunStatus::Running,
                     input: cmd.input,
+                    opening_message_override: None,
                     output: None,
                     error: None,
                     created_at: 1,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/session_create_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/session_create_contract.rs
@@ -740,6 +740,7 @@ impl CollaborationRuntimeService for RecordingCollaborationRuntime {
                     created_by: cmd.caller_id.clone(),
                     status: StateMachineRunStatus::Running,
                     input: cmd.input,
+                    opening_message_override: None,
                     output: None,
                     error: None,
                     created_at: 1,

--- a/src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs
+++ b/src/bcs/crates/adapters/ws/bcs-ws/tests/web_frame_compat.rs
@@ -115,6 +115,7 @@ impl CollaborationRuntimeService for RecordingCollaborationRuntime {
                         created_by: None,
                         status: StateMachineRunStatus::Running,
                         input: serde_json::Value::Null,
+                        opening_message_override: None,
                         output: None,
                         error: None,
                         created_at: 1,

--- a/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/src/lib.rs
@@ -1342,6 +1342,7 @@ impl GroupServiceImpl {
                     definition: None,
                     definition_ref: None,
                     participant_bindings: None,
+                    opening_message_override: None,
                     input: session.input.unwrap_or(Value::Null),
                     caller_id: Some(principal_actor_id),
                     authenticated_human,

--- a/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-group/tests/v1_group_service.rs
@@ -569,6 +569,7 @@ impl CollaborationRuntimeService for RecordingRuntime {
                     created_by: cmd.caller_id,
                     status: StateMachineRunStatus::Running,
                     input: cmd.input,
+                    opening_message_override: None,
                     output: None,
                     error: None,
                     created_at: 1,

--- a/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
+++ b/src/bcs/crates/application/v1/bcs-app-session/tests/v1_session_service.rs
@@ -163,6 +163,7 @@ impl CollaborationRuntimeService for RecordingRuntime {
                     created_by: cmd.caller_id,
                     status: StateMachineRunStatus::Running,
                     input: cmd.input,
+                    opening_message_override: None,
                     output: None,
                     error: None,
                     created_at: 1,

--- a/src/bcs/crates/bootstrap/bcs/src/migrations.rs
+++ b/src/bcs/crates/bootstrap/bcs/src/migrations.rs
@@ -537,6 +537,7 @@ const SQLITE_DDL_STATEMENTS: &[&str] = &[
         created_by TEXT DEFAULT NULL,
         status TEXT NOT NULL,
         input_json TEXT DEFAULT NULL,
+        opening_message_override_json TEXT DEFAULT NULL,
         output_text TEXT DEFAULT NULL,
         error_message TEXT DEFAULT NULL,
         created_at_ms INTEGER NOT NULL,
@@ -995,6 +996,10 @@ const SQLITE_VERSIONED_MIGRATIONS: &[SqliteMigration] = &[
         version: 18,
         name: "state_machine_rerun_lineage",
     },
+    SqliteMigration {
+        version: 19,
+        name: "one_shot_opening_message_override",
+    },
 ];
 
 pub fn sqlite_target_version() -> i64 {
@@ -1368,8 +1373,29 @@ async fn apply_sqlite_migration_body(
         16 => Ok(()),
         17 => add_sqlite_session_callback_lease_schema(db).await,
         18 => add_sqlite_state_machine_rerun_lineage_schema(db).await,
+        19 => add_sqlite_one_shot_opening_message_override_schema(db).await,
         _ => Ok(()),
     }
+}
+
+async fn add_sqlite_one_shot_opening_message_override_schema(
+    db: &dyn DbPlugin,
+) -> DbResult<()> {
+    if !table_exists(db, "bcs_state_machine_runs").await? {
+        return Ok(());
+    }
+    let columns = sqlite_table_columns(db, "bcs_state_machine_runs").await?;
+    if !columns
+        .iter()
+        .any(|column| column == "opening_message_override_json")
+    {
+        db.execute(DbStatement::new(
+            "ALTER TABLE bcs_state_machine_runs \
+             ADD COLUMN opening_message_override_json TEXT DEFAULT NULL",
+        ))
+        .await?;
+    }
+    Ok(())
 }
 
 async fn add_sqlite_state_machine_rerun_lineage_schema(db: &dyn DbPlugin) -> DbResult<()> {
@@ -1894,6 +1920,11 @@ mod tests {
                     18,
                     "state_machine_rerun_lineage".to_string(),
                     "sqlite".to_string()
+                ),
+                (
+                    19,
+                    "one_shot_opening_message_override".to_string(),
+                    "sqlite".to_string()
                 )
             ]
         );
@@ -1906,7 +1937,7 @@ mod tests {
 
         let report = check_sqlite_migrations(&db).await?;
 
-        assert_eq!(report.pending_versions.len(), 18);
+        assert_eq!(report.pending_versions.len(), 19);
         assert_eq!(report.pending_versions[0].version, 1);
         assert_eq!(report.pending_versions[0].name, "init_schema");
         assert!(report.pending_versions[0].statements.is_empty());
@@ -1965,6 +1996,11 @@ assert_eq!(report.pending_versions[10].version, 11);
         assert_eq!(
             report.pending_versions[17].name,
             "state_machine_rerun_lineage"
+        );
+        assert_eq!(report.pending_versions[18].version, 19);
+        assert_eq!(
+            report.pending_versions[18].name,
+            "one_shot_opening_message_override"
         );
         Ok(())
     }
@@ -2069,6 +2105,40 @@ assert_eq!(report.pending_versions[10].version, 11);
     }
 
     #[tokio::test]
+    async fn sqlite_one_shot_opening_message_override_migration_repairs_legacy_run_table()
+    -> DbResult<()> {
+        let db = LocalSqliteDbPlugin::new()?;
+        db.execute(DbStatement::new(
+            "CREATE TABLE bcs_state_machine_runs (
+                env TEXT NOT NULL,
+                run_id TEXT NOT NULL
+            )",
+        ))
+        .await?;
+
+        add_sqlite_one_shot_opening_message_override_schema(&db).await?;
+        add_sqlite_one_shot_opening_message_override_schema(&db).await?;
+
+        let columns = column_names(&db, "bcs_state_machine_runs").await?;
+        assert!(
+            columns
+                .iter()
+                .any(|column| column == "opening_message_override_json")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn mysql_one_shot_opening_message_override_migration_adds_nullable_column() {
+        let migration = include_str!(
+            "../../../../migrations/mysql/018_one_shot_opening_message_override.sql"
+        );
+        assert!(migration.contains(
+            "ADD COLUMN IF NOT EXISTS `opening_message_override_json` text DEFAULT NULL"
+        ));
+    }
+
+    #[tokio::test]
     async fn sqlite_migrations_are_idempotent() -> DbResult<()> {
         let db = LocalSqliteDbPlugin::new()?;
 
@@ -2150,6 +2220,11 @@ assert_eq!(report.pending_versions[10].version, 11);
                 (
                     18,
                     "state_machine_rerun_lineage".to_string(),
+                    "sqlite".to_string()
+                ),
+                (
+                    19,
+                    "one_shot_opening_message_override".to_string(),
                     "sqlite".to_string()
                 )
             ]

--- a/src/bcs/crates/contracts/bcs-domain/src/collaboration.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/collaboration.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::{Map, Value};
 
 use crate::group::ParticipantRole;
+use crate::opening_message::OpeningMessage;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CollaborationDefinitionRef {
@@ -438,6 +439,11 @@ pub struct StateMachineRun {
     pub created_by: Option<String>,
     pub status: StateMachineRunStatus,
     pub input: Value,
+    /// Immutable request-level opening-message override for one-shot Runs.
+    ///
+    /// This is runtime persistence state, not part of the public Run view.
+    #[serde(default, skip_serializing)]
+    pub opening_message_override: Option<OpeningMessage>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/bcs/crates/contracts/bcs-domain/src/opening_message.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/opening_message.rs
@@ -7,6 +7,8 @@ use serde_json::Value;
 
 pub const MAX_OPENING_MESSAGE_BYTES: usize = 64 * 1024;
 pub const MAX_OPENING_MESSAGE_COMPONENT_BYTES: usize = 256;
+/// Maximum encoded JSON size that fits in the MySQL `TEXT` persistence column.
+pub const MAX_OPENING_MESSAGE_PERSISTED_JSON_BYTES: usize = 65_535;
 
 const GROUP_ID_TOKEN: &str = "{{bcs.group_id}}";
 const SESSION_ID_TOKEN: &str = "{{bcs.session_id}}";
@@ -146,6 +148,8 @@ pub enum OpeningMessageError {
     CardWithTab,
     #[error("opening_message could not be serialized: {0}")]
     Serialization(String),
+    #[error("opening_message JSON encoding exceeds the {MAX_OPENING_MESSAGE_PERSISTED_JSON_BYTES}-byte persistence limit")]
+    PersistedEncodingTooLarge,
 }
 
 impl OpeningMessage {
@@ -181,7 +185,13 @@ impl OpeningMessage {
                     .map_err(|error| OpeningMessageError::Serialization(error.to_string()))?;
                 ensure_size(&canonical)
             }
+        }?;
+        let persisted = serde_json::to_string(self)
+            .map_err(|error| OpeningMessageError::Serialization(error.to_string()))?;
+        if persisted.len() > MAX_OPENING_MESSAGE_PERSISTED_JSON_BYTES {
+            return Err(OpeningMessageError::PersistedEncodingTooLarge);
         }
+        Ok(())
     }
 
     pub fn render(
@@ -508,6 +518,34 @@ mod tests {
             session_name: None,
         };
         assert_eq!(message.render(context), Err(OpeningMessageError::TooLarge));
+    }
+
+    #[test]
+    fn encoded_opening_message_must_fit_the_mysql_text_column() {
+        let largest_plain_text = OpeningMessage::Text(
+            "x".repeat(MAX_OPENING_MESSAGE_PERSISTED_JSON_BYTES - 2),
+        );
+        assert_eq!(largest_plain_text.validate(), Ok(()));
+        assert_eq!(
+            serde_json::to_string(&largest_plain_text).unwrap().len(),
+            MAX_OPENING_MESSAGE_PERSISTED_JSON_BYTES
+        );
+
+        let oversized_plain_text = OpeningMessage::Text(
+            "x".repeat(MAX_OPENING_MESSAGE_PERSISTED_JSON_BYTES - 1),
+        );
+        assert_eq!(
+            oversized_plain_text.validate(),
+            Err(OpeningMessageError::PersistedEncodingTooLarge)
+        );
+
+        let escaped_raw = "\"".repeat(MAX_OPENING_MESSAGE_PERSISTED_JSON_BYTES / 2);
+        assert!(escaped_raw.len() < MAX_OPENING_MESSAGE_BYTES);
+        let escaped_text = OpeningMessage::Text(escaped_raw);
+        assert_eq!(
+            escaped_text.validate(),
+            Err(OpeningMessageError::PersistedEncodingTooLarge)
+        );
     }
 
     #[test]

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/collaboration_runtime.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/collaboration_runtime.rs
@@ -9,9 +9,10 @@ use crate::application::message_flow::ChatEventState;
 use crate::core::ServiceError;
 use crate::port::{JudgeArtifact, JudgeDecision};
 use crate::types::{
-    CollaborationDefinition, CollaborationDefinitionRef, RuntimeParticipantBinding,
-    StateMachineAssignee, StateMachineDeliveryCorrelation, StateMachineGraphMode,
-    StateMachineNodeKind, StateMachineNodeRun, StateMachineNodeStatus, StateMachineRun,
+    CollaborationDefinition, CollaborationDefinitionRef, OpeningMessage,
+    RuntimeParticipantBinding, StateMachineAssignee, StateMachineDeliveryCorrelation,
+    StateMachineGraphMode, StateMachineNodeKind, StateMachineNodeRun, StateMachineNodeStatus,
+    StateMachineRun,
 };
 
 pub const MAX_COLLABORATION_DEFINITION_YAML_BYTES: usize = 256 * 1024;
@@ -143,6 +144,9 @@ pub struct StartStateMachineRunCommand {
     /// Optional one-run participant bindings. When present, these override the
     /// group's persisted bindings without mutating the group configuration.
     pub participant_bindings: Option<BTreeMap<String, RuntimeParticipantBinding>>,
+    /// Request-level opening-message override. Only session one-shot starts
+    /// may populate this field.
+    pub opening_message_override: Option<OpeningMessage>,
     pub input: Value,
     pub caller_id: Option<String>,
     pub authenticated_human: Option<AuthenticatedHumanCaller>,
@@ -175,6 +179,7 @@ pub struct StartSessionStateMachineRunCommand {
     pub caller_bot_id: String,
     pub definition_yaml: String,
     pub participant_bindings: BTreeMap<String, RuntimeParticipantBinding>,
+    pub opening_message: Option<OpeningMessage>,
     pub input: Value,
     pub judge_available: bool,
 }

--- a/src/bcs/crates/service-api/bcs-service-api/tests/collaboration_runtime_contract.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/tests/collaboration_runtime_contract.rs
@@ -55,6 +55,7 @@ async fn session_state_machine_contract_defaults_to_fail_closed() {
             caller_bot_id: "bot-owner".to_string(),
             definition_yaml: "name: one-shot".to_string(),
             participant_bindings: BTreeMap::new(),
+            opening_message: None,
             input: Value::Null,
             judge_available: false,
         })

--- a/src/bcs/crates/services/bcs-channel/src/lib.rs
+++ b/src/bcs/crates/services/bcs-channel/src/lib.rs
@@ -509,6 +509,7 @@ impl BcsChannelService {
                 definition: None,
                 definition_ref: None,
                 participant_bindings: None,
+                opening_message_override: None,
                 input,
                 caller_id: Some(actor_id.to_string()),
                 authenticated_human: Some(AuthenticatedHumanCaller {
@@ -6726,6 +6727,7 @@ mod tests {
                     created_by: cmd.caller_id,
                     status: StateMachineRunStatus::Running,
                     input: cmd.input,
+                    opening_message_override: None,
                     output: None,
                     error: None,
                     created_at: 1,
@@ -6808,6 +6810,7 @@ mod tests {
                     created_by: None,
                     status: StateMachineRunStatus::Running,
                     input: serde_json::Value::Null,
+                    opening_message_override: None,
                     output: None,
                     error: None,
                     created_at: 1,

--- a/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/src/runtime.rs
@@ -9,12 +9,12 @@ use bcs_domain::{
     BCS_STATE_MACHINE_MESSAGE_SENDER, BCS_STATE_MACHINE_MESSAGE_SENDER_NAME,
     CollaborationDefinition, CollaborationDefinitionRef, CollaborationRuntimeDefinition, Group,
     GroupKind, GroupMessage, GroupMessageType, GroupRuntimeBinding, GroupStatus, GroupStrategy,
-    MessageOwnerFilter, MessageQuery, MessageRole, NewMessage, OpeningMessageRenderContext,
-    Participant, ParticipantMode, ParticipantRole, RenderedOpeningMessage, ResolvedParticipant,
-    ResolvedParticipantBinding, RuntimeParticipantBinding, STATE_MACHINE_PANEL_MESSAGE_TYPE,
-    SenderType, Session, StateMachineAssignee, StateMachineDeliveryCorrelation,
-    StateMachineNodeKind, StateMachineNodeRun, StateMachineNodeStatus, StateMachineRun,
-    StateMachineRunStatus,
+    MessageOwnerFilter, MessageQuery, MessageRole, NewMessage, OpeningMessage,
+    OpeningMessageRenderContext, OpeningMessageScope, Participant, ParticipantMode,
+    ParticipantRole, RenderedOpeningMessage, ResolvedParticipant, ResolvedParticipantBinding,
+    RuntimeParticipantBinding, STATE_MACHINE_PANEL_MESSAGE_TYPE, SenderType, Session,
+    StateMachineAssignee, StateMachineDeliveryCorrelation, StateMachineNodeKind,
+    StateMachineNodeRun, StateMachineNodeStatus, StateMachineRun, StateMachineRunStatus,
 };
 use bcs_protocol::{
     BCS_PROTOCOL_VERSION, BcsFrame, EventFrame, GroupContextInput, GroupContextParticipant,
@@ -1179,10 +1179,10 @@ impl CollaborationRuntime {
             return Ok(message);
         }
         let session_title = self.session_title(&run.session_id).await;
-        Ok(default_state_machine_opening_message(
-            &run.run_id,
-            session_title.as_deref(),
-        ))
+        let group = self.groups.get(&run.group_id).await.ok_or_else(|| {
+            CollaborationRuntimeError::InvalidRequest(format!("group not found: {}", run.group_id))
+        })?;
+        render_state_machine_opening_message(&group, run, session_title.as_deref())
     }
 
     async fn resume_materialized_rerun(
@@ -2680,6 +2680,7 @@ impl CollaborationRuntimeService for CollaborationRuntime {
             definition: None,
             definition_ref: None,
             participant_bindings: Some(cmd.participant_bindings),
+            opening_message_override: cmd.opening_message,
             input: cmd.input,
             caller_id: Some(cmd.caller_bot_id),
             authenticated_human: None,
@@ -2699,6 +2700,26 @@ impl CollaborationRuntimeService for CollaborationRuntime {
         let mut group = self.groups.get(&cmd.group_id).await.ok_or_else(|| {
             CollaborationRuntimeError::InvalidRequest(format!("group not found: {}", cmd.group_id))
         })?;
+        if cmd.opening_message_override.is_some()
+            && (!is_one_shot_session_run
+                || !matches!(
+                    group.group_strategy,
+                    GroupStrategy::Chat | GroupStrategy::ManagerWorker
+                ))
+        {
+            return Err(CollaborationRuntimeError::InvalidRequest(
+                "opening_message override is supported only for one-shot session Runs".to_string(),
+            ));
+        }
+        if let Some(opening_message) = cmd.opening_message_override.as_ref() {
+            opening_message
+                .validate_for(OpeningMessageScope::StateMachineRun)
+                .map_err(|error| {
+                    CollaborationRuntimeError::InvalidRequest(format!(
+                        "invalid_opening_message: {error}"
+                    ))
+                })?;
+        }
         if cmd.participant_bindings.is_some() {
             if let Some(session_id) = cmd.session_id.as_deref() {
                 let participant_scope = self
@@ -2892,6 +2913,7 @@ impl CollaborationRuntimeService for CollaborationRuntime {
             created_by: cmd.caller_id.clone(),
             status: StateMachineRunStatus::Pending,
             input: cmd.input,
+            opening_message_override: cmd.opening_message_override,
             output: None,
             error: None,
             created_at: now,
@@ -3131,11 +3153,7 @@ impl CollaborationRuntimeService for CollaborationRuntime {
             })?;
         let compiled = validate_definition(definition)?;
         if let Some(existing) = self.runs.get_direct_rerun(&source.run_id).await? {
-            let opening_message = render_state_machine_opening_message(
-                &group,
-                &existing,
-                session.session_title.as_deref(),
-            )?;
+            let opening_message = self.opening_message_for_existing_run(&existing).await?;
             return self
                 .resume_materialized_rerun(
                     &compiled,
@@ -3173,6 +3191,7 @@ impl CollaborationRuntimeService for CollaborationRuntime {
                 .or_else(|| source.created_by.clone()),
             status: StateMachineRunStatus::Pending,
             input: source.input.clone(),
+            opening_message_override: source.opening_message_override.clone(),
             output: None,
             error: None,
             created_at: now,
@@ -3196,11 +3215,7 @@ impl CollaborationRuntimeService for CollaborationRuntime {
             .await?
         {
             CreateStateMachineRerunOutcome::Existing(existing) => {
-                let opening_message = render_state_machine_opening_message(
-                    &group,
-                    &existing,
-                    session.session_title.as_deref(),
-                )?;
+                let opening_message = self.opening_message_for_existing_run(&existing).await?;
                 (existing, opening_message, false)
             }
             CreateStateMachineRerunOutcome::Conflict => {
@@ -5922,6 +5937,9 @@ fn render_state_machine_opening_message(
     // default panel instead of interpreting that Session template as a Run
     // opening message.
     if group.group_strategy != GroupStrategy::StateMachine {
+        if let Some(opening_message) = run.opening_message_override.as_ref() {
+            return render_run_opening_message(opening_message, group, run, session_title);
+        }
         return Ok(default_state_machine_opening_message(
             &run.run_id,
             session_title,
@@ -5933,6 +5951,15 @@ fn render_state_machine_opening_message(
             session_title,
         ));
     };
+    render_run_opening_message(opening_message, group, run, session_title)
+}
+
+fn render_run_opening_message(
+    opening_message: &OpeningMessage,
+    group: &Group,
+    run: &StateMachineRun,
+    session_title: Option<&str>,
+) -> Result<RenderedOpeningMessage, CollaborationRuntimeError> {
     opening_message
         .render(OpeningMessageRenderContext::StateMachineRun {
             group_id: &group.id,
@@ -6049,7 +6076,7 @@ mod tests {
     }
 
     #[test]
-    fn session_opening_message_does_not_override_one_shot_state_machine_panel() {
+    fn one_shot_opening_message_is_run_scoped_for_chat_and_manager_worker_groups() {
         let run = StateMachineRun {
             run_id: "run-1".to_string(),
             root_run_id: Some("run-1".to_string()),
@@ -6063,6 +6090,7 @@ mod tests {
             created_by: None,
             status: StateMachineRunStatus::Running,
             input: Value::Null,
+            opening_message_override: None,
             output: None,
             error: None,
             created_at: 1,
@@ -6072,7 +6100,7 @@ mod tests {
         for strategy in [GroupStrategy::Chat, GroupStrategy::ManagerWorker] {
             let mut group = Group::new("group-1", "driver", Vec::new());
             group.group_strategy = strategy;
-            group.opening_message = Some(bcs_domain::OpeningMessage::Text(
+            group.opening_message = Some(OpeningMessage::Text(
                 "Session opening {{bcs.session_id}}".to_string(),
             ));
 
@@ -6081,6 +6109,26 @@ mod tests {
                     .expect("render one-shot panel"),
                 default_state_machine_opening_message("run-1", Some("一次性任务"))
             );
+
+            let mut overridden_run = run.clone();
+            overridden_run.opening_message_override = Some(
+                serde_json::from_value(serde_json::json!({
+                    "type": "panel",
+                    "component": "custom.OneShotRunView",
+                    "params": {
+                        "groupId": "{{bcs.group_id}}",
+                        "runId": "{{bcs.run_id}}"
+                    }
+                }))
+                .expect("valid one-shot panel"),
+            );
+            let rendered =
+                render_state_machine_opening_message(&group, &overridden_run, Some("一次性任务"))
+                    .expect("render explicit one-shot panel");
+            assert_eq!(rendered.component.as_deref(), Some("custom.OneShotRunView"));
+            assert!(rendered.content.contains("\"groupId\":\"group-1\""));
+            assert!(rendered.content.contains("\"runId\":\"run-1\""));
+            assert!(!rendered.content.contains("Session opening"));
         }
     }
 
@@ -6141,6 +6189,7 @@ runtime:
             created_by: None,
             status: StateMachineRunStatus::Running,
             input: Value::Null,
+            opening_message_override: None,
             output: None,
             error: None,
             created_at: 1,
@@ -6228,6 +6277,7 @@ runtime:
             created_by: None,
             status: StateMachineRunStatus::Running,
             input: Value::Null,
+            opening_message_override: None,
             output: None,
             error: None,
             created_at: 1,

--- a/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
+++ b/src/bcs/crates/services/bcs-collaboration-runtime/tests/runtime_progression.rs
@@ -299,6 +299,7 @@ async fn current_session_permission_is_owned_by_chat_and_manager_group_driver() 
                     extensions: Default::default(),
                 },
             )]),
+            opening_message: None,
             input: Value::Null,
             judge_available: false,
         })
@@ -395,6 +396,40 @@ async fn one_shot_session_run_uses_transient_bindings_keeps_chat_open_and_publis
     .with_message_repo(message_repo.clone())
     .with_result_publisher(result_publisher.clone());
 
+    let invalid_opening_message = runtime
+        .start_session_state_machine_run(StartSessionStateMachineRunCommand {
+            session_id: session.id.clone(),
+            caller_bot_id: "driver-bot".to_string(),
+            definition_yaml: one_shot_authoring_yaml(),
+            participant_bindings: BTreeMap::from([(
+                "writer".to_string(),
+                RuntimeParticipantBinding {
+                    source: "manual".to_string(),
+                    bot_ids: vec!["worker-bot".to_string()],
+                    extensions: Default::default(),
+                },
+            )]),
+            opening_message: Some(OpeningMessage::Text(
+                "Invalid {{bcs.unknown}}".to_string(),
+            )),
+            input: Value::Null,
+            judge_available: false,
+        })
+        .await
+        .expect_err("invalid one-shot opening message must be rejected");
+    assert!(matches!(
+        invalid_opening_message,
+        CollaborationRuntimeError::InvalidRequest(message)
+            if message.contains("invalid_opening_message")
+    ));
+    assert!(
+        StateMachineRunRepoPort::get_run_by_session_id(&*store, &session.id)
+            .await
+            .expect("query run after invalid opening message")
+            .is_none()
+    );
+    assert!(delivery.commands.lock().await.is_empty());
+
     let started = runtime
         .start_session_state_machine_run(StartSessionStateMachineRunCommand {
             session_id: session.id.clone(),
@@ -408,6 +443,7 @@ async fn one_shot_session_run_uses_transient_bindings_keeps_chat_open_and_publis
                     extensions: Default::default(),
                 },
             )]),
+            opening_message: None,
             input: json!({"question": "resolve this"}),
             judge_available: false,
         })
@@ -563,7 +599,8 @@ async fn one_shot_session_run_uses_transient_bindings_keeps_chat_open_and_publis
 #[tokio::test]
 async fn one_shot_result_publication_failure_marks_run_failed_and_allows_rerun() {
     let group_store = Arc::new(GroupStore::new());
-    let group = test_group();
+    let mut group = test_group();
+    group.label = Some("Original Group".to_string());
     group_store
         .upsert(group.clone())
         .await
@@ -594,18 +631,36 @@ async fn one_shot_result_publication_failure_marks_run_failed_and_allows_rerun()
         .session;
     let store = Arc::new(MemoryCollaborationStore::new());
     let delivery = Arc::new(RecordingDelivery::default());
+    let message_repo = Arc::new(MemoryMessageRepo::new());
+    let frontend_delivery = Arc::new(RecordingFrontendDelivery::default());
     let runtime = test_runtime!(
         store.clone(),
         store.clone(),
         store.clone(),
         store.clone(),
-        group_store,
+        group_store.clone(),
         sessions.clone(),
         delivery.clone(),
         noop_judge(),
     )
-    .with_message_repo(Arc::new(MemoryMessageRepo::new()))
+    .with_message_repo(message_repo.clone())
+    .with_frontend_delivery(frontend_delivery.clone())
     .with_result_publisher(Arc::new(FailingResultPublisher));
+    let opening_message: OpeningMessage = serde_json::from_value(json!({
+        "type": "panel",
+        "component": "custom.OneShotRunView",
+        "params": {
+            "groupName": "{{bcs.group_name}}",
+            "runId": "{{bcs.run_id}}",
+            "sessionId": "{{bcs.session_id}}"
+        },
+        "tab": {
+            "id": "one-shot-{{bcs.run_id}}",
+            "title": "One Shot",
+            "closable": true
+        }
+    }))
+    .expect("valid one-shot opening panel");
 
     let started = runtime
         .start_session_state_machine_run(StartSessionStateMachineRunCommand {
@@ -620,11 +675,27 @@ async fn one_shot_result_publication_failure_marks_run_failed_and_allows_rerun()
                     extensions: Default::default(),
                 },
             )]),
+            opening_message: Some(opening_message.clone()),
             input: json!({"question": "resolve this"}),
             judge_available: false,
         })
         .await
         .expect("start one-shot run");
+    let persisted_source = StateMachineRunRepoPort::get_run(&*store, &started.view.run.run_id)
+        .await
+        .expect("load persisted source run")
+        .expect("persisted source run");
+    assert_eq!(
+        persisted_source.opening_message_override.as_ref(),
+        Some(&opening_message)
+    );
+    assert!(
+        serde_json::to_value(&started.view)
+            .expect("serialize public run view")
+            .pointer("/run/opening_message_override")
+            .is_none(),
+        "the raw one-shot override must not be exposed in the public Run view"
+    );
     let delivery_run_id = delivery.commands.lock().await[0].run_id.clone();
     let completed = runtime
         .handle_bot_terminal_event(bcs_service_api::HandleBotTerminalEventCommand {
@@ -692,6 +763,10 @@ async fn one_shot_result_publication_failure_marks_run_failed_and_allows_rerun()
         Some(started.view.run.run_id.as_str())
     );
     assert_eq!(rerun.view.run.input, started.view.run.input);
+    assert_eq!(
+        rerun.view.run.opening_message_override,
+        started.view.run.opening_message_override
+    );
     assert_eq!(rerun.view.nodes.len(), 1);
     assert_eq!(rerun.view.nodes[0].attempt, 0);
     assert_eq!(rerun.view.nodes[0].status, StateMachineNodeStatus::Running);
@@ -731,6 +806,42 @@ async fn one_shot_result_publication_failure_marks_run_failed_and_allows_rerun()
     assert_eq!(panel_run_ids.len(), 2);
     assert!(panel_run_ids.contains(&started.view.run.run_id.as_str()));
     assert!(panel_run_ids.contains(&rerun.view.run.run_id.as_str()));
+    let panel_history = message_repo
+        .query_messages(MessageQuery {
+            group_id: group.id.clone(),
+            session_id: session.id.clone(),
+            cursor: None,
+            limit: 20,
+            keyword: None,
+            sender_id: None,
+            message_type: Some(STATE_MACHINE_PANEL_MESSAGE_TYPE.to_string()),
+            owner_filter: MessageOwnerFilter::Any,
+            time_range: None,
+            visible_from_seq: None,
+        })
+        .await
+        .expect("query custom panel history");
+    let panel_text_for = |run_id: &str| {
+        panel_history
+            .messages
+            .iter()
+            .find(|message| message.run_id == run_id)
+            .and_then(|message| message.content["text"].as_str())
+            .expect("persisted panel text")
+    };
+    let source_panel = panel_text_for(&started.view.run.run_id);
+    assert!(source_panel.contains("custom.OneShotRunView"));
+    assert!(source_panel.contains(&started.view.run.run_id));
+    let rerun_panel = panel_text_for(&rerun.view.run.run_id);
+    assert!(rerun_panel.contains("custom.OneShotRunView"));
+    assert!(rerun_panel.contains("Original Group"));
+    assert!(rerun_panel.contains(&rerun.view.run.run_id));
+    assert!(!rerun_panel.contains(&started.view.run.run_id));
+
+    group_store
+        .update_label(&group.id, Some("Renamed Group".to_string()))
+        .await
+        .expect("rename group after rerun panel persistence");
 
     let repeated = runtime
         .rerun_state_machine_run(RerunStateMachineCommand {
@@ -742,6 +853,24 @@ async fn one_shot_result_publication_failure_marks_run_failed_and_allows_rerun()
     assert!(!repeated.created);
     assert_eq!(repeated.view.run.run_id, rerun.view.run.run_id);
     assert_eq!(delivery.commands.lock().await.len(), 2);
+    let frontend_commands = frontend_delivery.commands.lock().await;
+    let repeated_event: Value = serde_json::from_str(
+        &frontend_commands
+            .last()
+            .expect("repeated rerun frontend event")
+            .event_json,
+    )
+    .expect("decode repeated rerun frontend event");
+    assert_eq!(
+        repeated_event["payload"]["content"].as_str(),
+        Some(rerun_panel),
+        "an idempotent rerun must publish the already persisted opening message"
+    );
+    assert!(!repeated_event["payload"]["content"]
+        .as_str()
+        .unwrap()
+        .contains("Renamed Group"));
+    drop(frontend_commands);
 
     let rerun_delivery_run_id = delivery.commands.lock().await[1].run_id.clone();
     let failed_rerun = runtime
@@ -861,6 +990,7 @@ async fn human_input_without_authenticated_or_present_human_is_invalid_request()
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"proposal": "ship it"}),
             caller_id: Some("human_untrusted".to_string()),
             authenticated_human: None,
@@ -920,6 +1050,7 @@ async fn human_input_can_start_without_authenticated_human_when_session_has_pres
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"proposal": "ship it"}),
             caller_id: Some("bot_driver".to_string()),
             authenticated_human: None,
@@ -975,6 +1106,7 @@ async fn authenticated_human_is_added_or_restored_before_human_input_starts() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"proposal": "ship it"}),
             caller_id: Some("bot_driver".to_string()),
             authenticated_human: Some(AuthenticatedHumanCaller {
@@ -1028,6 +1160,7 @@ async fn authenticated_human_is_added_or_restored_before_human_input_starts() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"proposal": "ship it"}),
             caller_id: Some("bot_driver".to_string()),
             authenticated_human: Some(AuthenticatedHumanCaller {
@@ -1082,6 +1215,7 @@ async fn human_input_waits_without_bot_delivery_and_completes_from_natural_langu
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"proposal": "ship it"}),
             caller_id: Some("human_1001".to_string()),
             authenticated_human: Some(AuthenticatedHumanCaller {
@@ -1284,6 +1418,7 @@ async fn frontend_human_input_skips_im_delivery_and_accepts_present_human() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"proposal": "review in frontend"}),
             caller_id: Some("human_1001".to_string()),
             authenticated_human: Some(AuthenticatedHumanCaller {
@@ -1370,6 +1505,7 @@ async fn im_human_input_rejects_a_different_present_human() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"proposal": "assigned review"}),
             caller_id: Some("bot_driver".to_string()),
             authenticated_human: None,
@@ -1427,6 +1563,7 @@ async fn state_machine_session_rejects_message_without_pending_human_input() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "wait for the bot"}),
             caller_id: Some("human_1001".to_string()),
             authenticated_human: Some(AuthenticatedHumanCaller {
@@ -1493,6 +1630,7 @@ async fn human_run_owner_can_cancel_through_human_access_api() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"proposal": "cancel it"}),
             caller_id: Some("human_1001".to_string()),
             authenticated_human: Some(AuthenticatedHumanCaller {
@@ -1558,6 +1696,7 @@ async fn human_runtime_rejects_missing_context_and_invalid_response_targets() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"proposal": "validate errors"}),
             caller_id: Some("human_1001".to_string()),
             authenticated_human: Some(AuthenticatedHumanCaller {
@@ -1584,6 +1723,7 @@ async fn human_runtime_rejects_missing_context_and_invalid_response_targets() {
                 definition: None,
                 definition_ref: None,
                 participant_bindings: None,
+                opening_message_override: None,
                 input: json!({"proposal": "invalid start"}),
                 caller_id: Some("human_1001".to_string()),
                 authenticated_human: Some(AuthenticatedHumanCaller {
@@ -1751,6 +1891,7 @@ async fn human_input_uses_the_same_judge_contract_as_bot_output() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"proposal": "ship it"}),
             caller_id: Some("human_1001".to_string()),
             authenticated_human: Some(AuthenticatedHumanCaller {
@@ -1803,6 +1944,7 @@ async fn human_input_is_persisted_and_no_longer_pending_while_judging() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"proposal": "ship it"}),
             caller_id: Some("human_1001".to_string()),
             authenticated_human: Some(AuthenticatedHumanCaller {
@@ -1895,6 +2037,7 @@ async fn human_input_remains_persisted_when_judge_fails() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"proposal": "ship it"}),
             caller_id: Some("human_1001".to_string()),
             authenticated_human: Some(AuthenticatedHumanCaller {
@@ -1961,6 +2104,7 @@ async fn human_input_timeout_ignores_global_retries_and_rejects_late_response() 
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"proposal": "ship it"}),
             caller_id: Some("human_1001".to_string()),
             authenticated_human: Some(AuthenticatedHumanCaller {
@@ -2029,6 +2173,7 @@ async fn timeout_scanner_aborts_run_when_group_is_missing() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "group will be deleted"}),
             caller_id: None,
             authenticated_human: None,
@@ -2081,6 +2226,7 @@ async fn timeout_scanner_aborts_run_when_session_is_missing() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "session will be deleted"}),
             caller_id: None,
             authenticated_human: None,
@@ -2136,6 +2282,7 @@ async fn timeout_scanner_skips_invalid_candidate_and_processes_later_run() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "valid timeout"}),
             caller_id: None,
             authenticated_human: None,
@@ -2234,6 +2381,7 @@ async fn single_node_run_completes_session_with_bot_final_text() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "review this"}),
             caller_id: None,
             authenticated_human: None,
@@ -2508,6 +2656,7 @@ async fn state_machine_bot_delivery_registers_message_flow_run_context() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "stream this"}),
             caller_id: None,
             authenticated_human: None,
@@ -2563,6 +2712,7 @@ async fn state_machine_explicit_node_timeout_overrides_provider_chat_default() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "stream this"}),
             caller_id: None,
             authenticated_human: None,
@@ -2611,6 +2761,7 @@ async fn start_run_fails_and_marks_node_failed_when_delivery_returns_not_deliver
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "review this"}),
             caller_id: None,
             authenticated_human: None,
@@ -2674,6 +2825,7 @@ async fn message_less_final_fails_attempt_and_schedules_retry() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "empty final should retry"}),
             caller_id: None,
             authenticated_human: None,
@@ -2790,6 +2942,7 @@ async fn state_machine_completion_dispatches_service_callback() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "callback after completion"}),
             caller_id: None,
             authenticated_human: None,
@@ -2842,6 +2995,7 @@ async fn state_machine_runtime_logs_run_node_and_terminal_lifecycle() {
                 definition: None,
                 definition_ref: None,
                 participant_bindings: None,
+                opening_message_override: None,
                 input: json!({"question": "logging"}),
                 caller_id: Some("caller-1".to_string()),
                 authenticated_human: None,
@@ -2942,6 +3096,7 @@ async fn start_run_uses_group_default_definition_binding() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "use binding"}),
             caller_id: None,
             authenticated_human: None,
@@ -2977,6 +3132,7 @@ async fn deleting_session_aborts_all_active_state_machine_runs() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "delete the session"}),
             caller_id: None,
             authenticated_human: None,
@@ -3039,6 +3195,7 @@ async fn deleting_group_aborts_active_state_machine_runs() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "delete the group"}),
             caller_id: None,
             authenticated_human: None,
@@ -3093,6 +3250,7 @@ async fn retrying_deleted_group_cleanup_aborts_orphaned_active_runs() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "recover orphaned run"}),
             caller_id: None,
             authenticated_human: None,
@@ -3159,6 +3317,7 @@ async fn group_runtime_cleanup_aborts_runs_and_removes_sessions_and_binding() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "review this"}),
             caller_id: Some("driver-bot".to_string()),
             authenticated_human: None,
@@ -3257,6 +3416,7 @@ async fn configure_im_definition_defers_channel_validation_until_run_start() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: Value::Null,
             caller_id: None,
             authenticated_human: None,
@@ -3523,6 +3683,7 @@ async fn start_run_from_group_binding_does_not_upsert_persisted_definition() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "use binding without rewriting definition"}),
             caller_id: None,
             authenticated_human: None,
@@ -3598,12 +3759,17 @@ async fn custom_opening_message_is_rendered_once_and_reused_from_history() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: Value::Null,
             caller_id: None,
             authenticated_human: None,
         })
         .await
         .expect("start run");
+    assert!(
+        started.view.run.opening_message_override.is_none(),
+        "configured StateMachine Runs must keep the request override unset"
+    );
     let expected = format!(
         "群=发布检查 session=Single Node group=group-1 session_id={} run={}",
         started.view.run.session_id, started.view.run.run_id
@@ -3642,6 +3808,7 @@ async fn custom_opening_message_is_rendered_once_and_reused_from_history() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: Value::Null,
             caller_id: None,
             authenticated_human: None,
@@ -3696,6 +3863,7 @@ async fn opening_message_persistence_failure_fails_run_before_node_dispatch() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: Value::Null,
             caller_id: None,
             authenticated_human: None,
@@ -3764,6 +3932,7 @@ async fn start_run_uses_group_participant_bindings_for_template_definition() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "use participant binding"}),
             caller_id: None,
             authenticated_human: None,
@@ -3833,6 +4002,7 @@ async fn start_run_rejects_multi_bot_slot_with_current_single_assignee_runtime()
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "multi"}),
             caller_id: None,
             authenticated_human: None,
@@ -3869,6 +4039,7 @@ async fn graph_view_returns_snapshot_edges_and_node_status() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "graph"}),
             caller_id: None,
             authenticated_human: None,
@@ -3943,6 +4114,7 @@ async fn complete_transitions_support_fan_out_and_implicit_all_join() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "join"}),
             caller_id: None,
             authenticated_human: None,
@@ -4042,6 +4214,7 @@ async fn judged_node_routes_selected_outcome_and_skips_unselected_branch() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "judge branch"}),
             caller_id: None,
             authenticated_human: None,
@@ -4132,6 +4305,7 @@ async fn judged_node_publishes_bot_output_but_not_judge_message_to_workbench() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "judge branch"}),
             caller_id: None,
             authenticated_human: None,
@@ -4197,6 +4371,7 @@ async fn judged_node_failure_records_runtime_event_and_fails_run() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "judge branch"}),
             caller_id: None,
             authenticated_human: None,
@@ -4277,6 +4452,7 @@ async fn judged_node_timeout_records_runtime_event_and_fails_run() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "judge branch"}),
             caller_id: None,
             authenticated_human: None,
@@ -4353,6 +4529,7 @@ async fn judged_node_keeps_shared_merge_reachable_from_selected_branch() {
             definition: None,
             definition_ref: None,
             participant_bindings: None,
+            opening_message_override: None,
             input: json!({"question": "judge shared merge"}),
             caller_id: None,
             authenticated_human: None,

--- a/src/bcs/crates/services/bcs-collaboration-store/src/lib.rs
+++ b/src/bcs/crates/services/bcs-collaboration-store/src/lib.rs
@@ -10,8 +10,9 @@ use bcs_db_api::{
 };
 use bcs_domain::{
     CollaborationDefinition, CollaborationDefinitionRef, GroupRuntimeBinding,
-    ResolvedParticipantBinding, RuntimeParticipantBinding, StateMachineDeliveryCorrelation,
-    StateMachineNodeRun, StateMachineNodeStatus, StateMachineRun, StateMachineRunStatus,
+    OpeningMessage, ResolvedParticipantBinding, RuntimeParticipantBinding,
+    StateMachineDeliveryCorrelation, StateMachineNodeRun, StateMachineNodeStatus, StateMachineRun,
+    StateMachineRunStatus,
 };
 use bcs_event_store::{EventAppendTransactionPlan, MemoryEventStore};
 use bcs_service_api::port::repo::StateMachineEventfulTransition;
@@ -26,10 +27,11 @@ use sha2::{Digest, Sha256};
 use tokio::sync::RwLock;
 
 const CURRENT_GROUP_VERSION_SENTINEL: i32 = 2_147_483_647;
+const RUN_OPENING_MESSAGE_OVERRIDE_PARAM_INDEX: usize = 13;
 const SM_RUN_SELECT_COLS: &str = "run_id, root_run_id, rerun_of, definition_id, \
     definition_version, group_id, group_version, session_id, session_activation_count, \
-    created_by, status, input_json, output_text, error_message, created_at_ms, updated_at_ms, \
-    completed_at_ms";
+    created_by, status, input_json, opening_message_override_json, output_text, error_message, \
+    created_at_ms, updated_at_ms, completed_at_ms";
 const SM_NODE_SELECT_COLS: &str = "run_id, node_id, status, attempt, node_timeout_ms, \
     timeout_deadline_ms, max_attempts, assignee_bot_id, outcome, responded_by, \
     delivery_request_id, bot_delivery_run_id, artifact_text, error_message, \
@@ -394,6 +396,7 @@ impl StateMachineRunRepoPort for MemoryCollaborationStore {
         let Some(source) = inner.runs.get(&command.source_run_id) else {
             return Ok(CreateStateMachineRerunOutcome::Conflict);
         };
+        let opening_message_override = source.opening_message_override.clone();
         if source.status != StateMachineRunStatus::Failed
             || source.session_id != command.run.session_id
             || inner.runs.values().any(|run| {
@@ -450,13 +453,15 @@ impl StateMachineRunRepoPort for MemoryCollaborationStore {
             );
         }
         let run_id = command.run.run_id.clone();
+        let mut run = command.run;
+        run.opening_message_override = opening_message_override;
         inner.run_snapshots.insert(run_id.clone(), snapshot);
         if let Some(resolved_bindings) = resolved_bindings {
             inner
                 .run_resolved_participant_bindings
                 .insert(run_id.clone(), resolved_bindings);
         }
-        inner.runs.insert(run_id.clone(), command.run);
+        inner.runs.insert(run_id.clone(), run);
         for node in command.nodes {
             inner
                 .nodes
@@ -2073,12 +2078,12 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
         let run_sql = "INSERT INTO bcs_state_machine_runs \
                        (env, run_id, root_run_id, rerun_of, definition_id, definition_version, group_id, \
                         group_version, session_id, session_activation_count, created_by, status, input_json, \
-                        output_text, error_message, created_at_ms, updated_at_ms, \
+                        opening_message_override_json, output_text, error_message, created_at_ms, updated_at_ms, \
                         completed_at_ms, record_status) \
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')";
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active')";
         let mut steps = vec![DbTransactionStep::Execute(DbStatement::with_params(
             run_sql,
-            run_insert_params(&self.env, &run),
+            run_insert_params(&self.env, &run)?,
         ))];
         if let Some((node_sql, node_params)) =
             build_node_runs_insert(&self.env, &run.run_id, &nodes)
@@ -2110,9 +2115,9 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
         let run_sql = "INSERT INTO bcs_state_machine_runs \
                        (env, run_id, root_run_id, rerun_of, definition_id, definition_version, group_id, \
                         group_version, session_id, session_activation_count, created_by, status, input_json, \
-                        output_text, error_message, created_at_ms, updated_at_ms, \
+                        opening_message_override_json, output_text, error_message, created_at_ms, updated_at_ms, \
                         completed_at_ms, record_status) \
-                       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active' \
+                       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active' \
                        FROM bcs_group_sessions session_lock \
                        WHERE session_lock.env = ? AND session_lock.session_id = ? \
                          AND NOT EXISTS ( \
@@ -2123,7 +2128,7 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
                              AND active_run.record_status = 'active' \
                          ) \
                        LIMIT 1";
-        let mut run_params = run_insert_params(&self.env, &run);
+        let mut run_params = run_insert_params(&self.env, &run)?;
         run_params.extend([
             DbValue::from(self.env.as_str()),
             DbValue::from(run.session_id.as_str()),
@@ -2183,9 +2188,10 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
         let run_sql = "INSERT INTO bcs_state_machine_runs \
                        (env, run_id, root_run_id, rerun_of, definition_id, definition_version, \
                         group_id, group_version, session_id, session_activation_count, created_by, \
-                        status, input_json, output_text, error_message, created_at_ms, updated_at_ms, \
+                        status, input_json, opening_message_override_json, output_text, error_message, created_at_ms, updated_at_ms, \
                         completed_at_ms, record_status) \
-                       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active' \
+                       SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, \
+                              source_run.opening_message_override_json, ?, ?, ?, ?, ?, 'active' \
                        FROM bcs_state_machine_runs source_run \
                        INNER JOIN bcs_group_sessions session_state \
                          ON session_state.env = source_run.env \
@@ -2221,7 +2227,9 @@ impl StateMachineRunRepoPort for MySqlCollaborationStore {
                            WHERE source_snapshot.env = source_run.env \
                              AND source_snapshot.run_id = source_run.run_id) \
                        LIMIT 1";
-        let mut run_params = run_insert_params(&self.env, &command.run);
+        let mut run_params = run_insert_params(&self.env, &command.run)?;
+        // The rerun INSERT copies this value directly from the source row.
+        run_params.remove(RUN_OPENING_MESSAGE_OVERRIDE_PARAM_INDEX);
         run_params.extend([
             DbValue::from(self.env.as_str()),
             DbValue::from(command.source_run_id.as_str()),
@@ -3265,8 +3273,18 @@ fn optional_u64_value(value: Option<u64>) -> DbValue {
     value.map(DbValue::from).unwrap_or(DbValue::Null)
 }
 
-fn run_insert_params(env: &str, run: &StateMachineRun) -> Vec<DbValue> {
-    vec![
+fn run_insert_params(env: &str, run: &StateMachineRun) -> ServiceResult<Vec<DbValue>> {
+    let opening_message_override_json = run
+        .opening_message_override
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()
+        .map_err(|error| {
+            ServiceError::InternalError(format!(
+                "serialize state-machine opening_message_override: {error}"
+            ))
+        })?;
+    Ok(vec![
         DbValue::from(env),
         DbValue::from(run.run_id.as_str()),
         DbValue::from(run.root_run_id.as_deref()),
@@ -3282,12 +3300,13 @@ fn run_insert_params(env: &str, run: &StateMachineRun) -> Vec<DbValue> {
         DbValue::from(run.created_by.as_deref()),
         DbValue::from(run_status_to_str(run.status)),
         DbValue::from(run.input.to_string()),
+        DbValue::from(opening_message_override_json.as_deref()),
         DbValue::from(run.output.as_deref()),
         DbValue::from(run.error.as_deref()),
         DbValue::from(run.created_at),
         DbValue::from(run.updated_at),
         optional_u64_value(run.completed_at),
-    ]
+    ])
 }
 
 fn build_guarded_node_runs_inserts(
@@ -3385,6 +3404,7 @@ fn row_to_state_machine_run(row: DbRow) -> ServiceResult<StateMachineRun> {
         created_by: db_optional_string(&row, "created_by")?,
         status: parse_run_status(&status_raw)?,
         input: db_json(&row, "input_json")?.unwrap_or(serde_json::Value::Null),
+        opening_message_override: db_opening_message_override(&row)?,
         output: db_optional_string(&row, "output_text")?,
         error: db_optional_string(&row, "error_message")?,
         created_at: db_u64(&row, "created_at_ms")?,
@@ -3719,6 +3739,20 @@ fn db_json(row: &DbRow, column: &str) -> ServiceResult<Option<serde_json::Value>
     }
 }
 
+fn db_opening_message_override(row: &DbRow) -> ServiceResult<Option<OpeningMessage>> {
+    match db_optional_string(row, "opening_message_override_json")? {
+        None => Ok(None),
+        Some(value) if value.is_empty() => Err(ServiceError::InternalError(
+            "opening_message_override_json: persisted value must not be empty".to_string(),
+        )),
+        Some(value) => serde_json::from_str(&value).map(Some).map_err(|error| {
+            ServiceError::InternalError(format!(
+                "opening_message_override_json: json parse: {error}"
+            ))
+        }),
+    }
+}
+
 fn run_status_to_str(status: StateMachineRunStatus) -> &'static str {
     match status {
         StateMachineRunStatus::Pending => "pending",
@@ -3887,6 +3921,7 @@ mod tests {
                 created_by TEXT DEFAULT NULL,
                 status TEXT NOT NULL,
                 input_json TEXT DEFAULT NULL,
+                opening_message_override_json TEXT DEFAULT NULL,
                 output_text TEXT DEFAULT NULL,
                 error_message TEXT DEFAULT NULL,
                 created_at_ms INTEGER NOT NULL,
@@ -3972,6 +4007,7 @@ mod tests {
             created_by: None,
             status: StateMachineRunStatus::Running,
             input: serde_json::Value::Null,
+            opening_message_override: None,
             output: None,
             error: None,
             created_at: 1_000,
@@ -4017,6 +4053,7 @@ mod tests {
                         created_by: None,
                         status: StateMachineRunStatus::Running,
                         input: serde_json::Value::Null,
+                        opening_message_override: None,
                         output: None,
                         error: None,
                         created_at: 1_001,
@@ -4063,6 +4100,163 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sqlite_store_round_trips_and_rejects_invalid_run_opening_message_overrides()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (db, store) = sqlite_state_machine_store().await?;
+        let opening_messages = vec![
+            None,
+            Some(OpeningMessage::Text("Run {{bcs.run_id}}".to_string())),
+            Some(serde_json::from_value(serde_json::json!({
+                "type": "card",
+                "component": "partnerCard.OneShotSummary",
+                "params": {"runId": "{{bcs.run_id}}"}
+            }))?),
+            Some(serde_json::from_value(serde_json::json!({
+                "type": "panel",
+                "component": "partnerPanel.OneShotRunView",
+                "params": {"runId": "{{bcs.run_id}}"},
+                "tab": {"title": "One Shot", "closable": true}
+            }))?),
+        ];
+
+        for (index, opening_message_override) in opening_messages.into_iter().enumerate() {
+            let run_id = format!("run-opening-{index}");
+            let run = StateMachineRun {
+                run_id: run_id.clone(),
+                root_run_id: Some(run_id.clone()),
+                rerun_of: None,
+                definition_id: "definition".to_string(),
+                definition_version: 1,
+                group_id: "group".to_string(),
+                group_version: 1,
+                session_id: format!("session-opening-{index}"),
+                session_activation_count: None,
+                created_by: None,
+                status: StateMachineRunStatus::Running,
+                input: serde_json::Value::Null,
+                opening_message_override: opening_message_override.clone(),
+                output: None,
+                error: None,
+                created_at: index as u64 + 1,
+                updated_at: index as u64 + 1,
+                completed_at: None,
+            };
+            store.create_run(run, Vec::new()).await?;
+            assert_eq!(
+                store
+                    .get_run(&run_id)
+                    .await?
+                    .expect("round-tripped run")
+                    .opening_message_override,
+                opening_message_override
+            );
+        }
+
+        db.execute(DbStatement::with_params(
+            "UPDATE bcs_state_machine_runs \
+             SET opening_message_override_json = ? WHERE env = ? AND run_id = ?",
+            vec![
+                DbValue::from("{invalid"),
+                DbValue::from("dev"),
+                DbValue::from("run-opening-0"),
+            ],
+        ))
+        .await?;
+        let error = store
+            .get_run("run-opening-0")
+            .await
+            .expect_err("invalid persisted override must fail the read");
+        assert!(error.to_string().contains("opening_message_override_json"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sqlite_one_shot_rerun_atomically_inherits_source_opening_message_override()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (db, store) = sqlite_state_machine_store().await?;
+        db.execute(DbStatement::with_params(
+            "INSERT INTO bcs_group_sessions \
+             (env, session_id, group_id, session_kind, status, activation_count) \
+             VALUES (?, ?, ?, 'chat', 'running', 1)",
+            vec![
+                DbValue::from("dev"),
+                DbValue::from("session-one-shot-rerun"),
+                DbValue::from("group"),
+            ],
+        ))
+        .await?;
+        let definition: CollaborationDefinition = serde_yaml::from_str(
+            r#"
+api_version: bcs.collaboration/v1
+id: definition
+version: 1
+name: One-Shot Rerun Definition
+runtime:
+  kind: chat
+"#,
+        )?;
+        let opening_message: OpeningMessage = serde_json::from_value(serde_json::json!({
+            "type": "panel",
+            "component": "partnerPanel.OneShotRunView",
+            "params": {"runId": "{{bcs.run_id}}"}
+        }))?;
+        let source = StateMachineRun {
+            run_id: "run-one-shot-source".to_string(),
+            root_run_id: Some("run-one-shot-source".to_string()),
+            rerun_of: None,
+            definition_id: "definition".to_string(),
+            definition_version: 1,
+            group_id: "group".to_string(),
+            group_version: 1,
+            session_id: "session-one-shot-rerun".to_string(),
+            session_activation_count: None,
+            created_by: None,
+            status: StateMachineRunStatus::Failed,
+            input: serde_json::Value::Null,
+            opening_message_override: Some(opening_message.clone()),
+            output: None,
+            error: Some("failed".to_string()),
+            created_at: 1,
+            updated_at: 2,
+            completed_at: Some(2),
+        };
+        store.create_run(source.clone(), Vec::new()).await?;
+        store
+            .save_run_snapshot(&source, 1, &definition, None)
+            .await?;
+        let mut child = source.clone();
+        child.run_id = "run-one-shot-child".to_string();
+        child.rerun_of = Some(source.run_id.clone());
+        child.status = StateMachineRunStatus::Pending;
+        child.opening_message_override = None;
+        child.error = None;
+        child.created_at = 3;
+        child.updated_at = 3;
+        child.completed_at = None;
+
+        assert!(matches!(
+            store
+                .create_rerun_if_session_idle(CreateStateMachineRerun {
+                    source_run_id: source.run_id,
+                    run: child.clone(),
+                    nodes: Vec::new(),
+                    reactivate_service_session: false,
+                })
+                .await?,
+            CreateStateMachineRerunOutcome::Created
+        ));
+        assert_eq!(
+            store
+                .get_run(&child.run_id)
+                .await?
+                .expect("rerun child")
+                .opening_message_override,
+            Some(opening_message)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn sqlite_store_reactivates_session_creates_one_rerun_and_copies_snapshot_atomically()
     -> Result<(), Box<dyn std::error::Error>> {
         let (db, store) = sqlite_state_machine_store().await?;
@@ -4100,6 +4294,7 @@ runtime:
             created_by: None,
             status: StateMachineRunStatus::Failed,
             input: serde_json::json!({"question": "retry"}),
+            opening_message_override: None,
             output: None,
             error: Some("failed".to_string()),
             created_at: 1,
@@ -4392,6 +4587,7 @@ runtime:
             created_by: None,
             status: StateMachineRunStatus::Running,
             input: serde_json::Value::Null,
+            opening_message_override: None,
             output: None,
             error: None,
             created_at: 1,

--- a/src/bcs/crates/services/bcs-collaboration-store/tests/memory_store.rs
+++ b/src/bcs/crates/services/bcs-collaboration-store/tests/memory_store.rs
@@ -1,6 +1,6 @@
 use bcs_collaboration_store::MemoryCollaborationStore;
 use bcs_domain::{
-    CollaborationDefinition, StateMachineDeliveryCorrelation, StateMachineNodeRun,
+    CollaborationDefinition, OpeningMessage, StateMachineDeliveryCorrelation, StateMachineNodeRun,
     StateMachineNodeStatus, StateMachineRun, StateMachineRunStatus,
 };
 use bcs_event_store::MemoryEventStore;
@@ -171,6 +171,9 @@ async fn rerun_create_is_source_idempotent_and_rejects_another_active_session_ru
     let definition = test_definition("Say hello.");
     let mut source = test_run("sm-run-source", "group-1:abcdef12", 1);
     source.status = StateMachineRunStatus::Failed;
+    source.opening_message_override = Some(OpeningMessage::Text(
+        "Retry {{bcs.run_id}}".to_string(),
+    ));
     source.error = Some("source failed".to_string());
     source.completed_at = Some(2);
     store
@@ -208,6 +211,10 @@ async fn rerun_create_is_source_idempotent_and_rejects_another_active_session_ru
         CreateStateMachineRerunOutcome::Existing(existing) => {
             assert_eq!(existing.run_id, child.run_id);
             assert_eq!(existing.rerun_of.as_deref(), Some(source.run_id.as_str()));
+            assert_eq!(
+                existing.opening_message_override,
+                source.opening_message_override
+            );
         }
         other => panic!("expected existing direct child, got {other:?}"),
     }
@@ -572,6 +579,7 @@ fn test_run(run_id: &str, session_id: &str, created_at: u64) -> StateMachineRun 
         created_by: Some("tester".to_string()),
         status: StateMachineRunStatus::Running,
         input: json!({"question": "hello"}),
+        opening_message_override: None,
         output: None,
         error: None,
         created_at,

--- a/src/bcs/crates/services/bcs-collaboration-store/tests/mysql_store.rs
+++ b/src/bcs/crates/services/bcs-collaboration-store/tests/mysql_store.rs
@@ -11,7 +11,7 @@ use bcs_db_api::{
 };
 use bcs_db_local::LocalSqliteDbPlugin;
 use bcs_domain::{
-    CollaborationDefinition, CollaborationDefinitionRef, ParticipantRole, ResolvedParticipant,
+    CollaborationDefinition, CollaborationDefinitionRef, OpeningMessage, ParticipantRole, ResolvedParticipant,
     ResolvedParticipantBinding, RuntimeParticipantBinding, StateMachineDeliveryCorrelation,
     StateMachineNodeRun, StateMachineNodeStatus, StateMachineRun, StateMachineRunStatus,
 };
@@ -302,6 +302,7 @@ async fn mysql_definition_snapshot_writes_run_definition_snapshot_table() {
         created_by: Some("tester".to_string()),
         status: StateMachineRunStatus::Running,
         input: json!({"question": "hello"}),
+        opening_message_override: None,
         output: None,
         error: None,
         created_at: 1,
@@ -376,7 +377,10 @@ async fn mysql_definition_snapshot_reads_run_definition_snapshot_table() {
 async fn mysql_runtime_create_run_writes_run_and_node_rows() {
     let db = Arc::new(RecordingDb::default());
     let store = MySqlCollaborationStore::new(db.clone(), "dev".to_string());
-    let run = test_run();
+    let mut run = test_run();
+    run.opening_message_override = Some(OpeningMessage::Text(
+        "Run {{bcs.run_id}}".to_string(),
+    ));
     let node = test_node();
 
     store
@@ -397,6 +401,15 @@ async fn mysql_runtime_create_run_writes_run_and_node_rows() {
             assert_eq!(stmt.params()[7], DbValue::from(7));
             assert_eq!(stmt.params()[10], DbValue::from("tester"));
             assert_eq!(stmt.params()[11], DbValue::from("running"));
+            assert!(stmt.sql().contains("opening_message_override_json"));
+            assert_eq!(
+                stmt.params()[13],
+                DbValue::from(
+                    serde_json::to_string(run.opening_message_override.as_ref().unwrap())
+                        .unwrap()
+                        .as_str()
+                )
+            );
         }
         _ => panic!("expected run execute step"),
     }
@@ -447,7 +460,15 @@ async fn mysql_session_idle_create_locks_session_and_guards_run_and_nodes() {
 
 #[tokio::test]
 async fn mysql_runtime_reads_run_and_node_rows() {
-    let run = test_run();
+    let mut run = test_run();
+    run.opening_message_override = Some(
+        serde_json::from_value(json!({
+            "type": "panel",
+            "component": "partnerPanel.OneShotRunView",
+            "params": {"runId": "{{bcs.run_id}}"}
+        }))
+        .expect("valid opening panel"),
+    );
     let node = test_node();
     let db = Arc::new(RecordingDb {
         runtime_run_row: Mutex::new(Some(run_row(&run))),
@@ -464,6 +485,10 @@ async fn mysql_runtime_reads_run_and_node_rows() {
     assert_eq!(loaded_run.group_version, 7);
     assert_eq!(loaded_run.created_by.as_deref(), Some("tester"));
     assert_eq!(loaded_run.input["question"], "hello");
+    assert_eq!(
+        loaded_run.opening_message_override,
+        run.opening_message_override
+    );
 
     let loaded_by_session = store
         .get_run_by_session_id("group-1:abcdef12")
@@ -488,6 +513,25 @@ async fn mysql_runtime_reads_run_and_node_rows() {
     assert_eq!(queries[1].params()[1], DbValue::from("group-1:abcdef12"));
     assert!(queries[2].sql().contains("session_id = ?"));
     assert!(!queries[2].sql().contains("LIMIT 1"));
+}
+
+#[tokio::test]
+async fn mysql_runtime_rejects_invalid_persisted_opening_message_override_json() {
+    let run = test_run();
+    let db = Arc::new(RecordingDb {
+        runtime_run_row: Mutex::new(Some(run_row_with_opening_json(
+            &run,
+            DbValue::from("{invalid"),
+        ))),
+        ..RecordingDb::default()
+    });
+    let store = MySqlCollaborationStore::new(db, "dev".to_string());
+
+    let error = store
+        .get_run(&run.run_id)
+        .await
+        .expect_err("invalid persisted override must fail the read");
+    assert!(error.to_string().contains("opening_message_override_json"));
 }
 
 #[tokio::test]
@@ -1292,6 +1336,7 @@ fn test_run() -> StateMachineRun {
         created_by: Some("tester".to_string()),
         status: StateMachineRunStatus::Running,
         input: json!({"question": "hello"}),
+        opening_message_override: None,
         output: None,
         error: None,
         created_at: 1,
@@ -1369,6 +1414,18 @@ fn test_correlation() -> StateMachineDeliveryCorrelation {
 }
 
 fn run_row(run: &StateMachineRun) -> DbRow {
+    let opening_message_override_json = run
+        .opening_message_override
+        .as_ref()
+        .map(|opening_message| DbValue::from(serde_json::to_string(opening_message).unwrap()))
+        .unwrap_or(DbValue::Null);
+    run_row_with_opening_json(run, opening_message_override_json)
+}
+
+fn run_row_with_opening_json(
+    run: &StateMachineRun,
+    opening_message_override_json: DbValue,
+) -> DbRow {
     DbRow::new(BTreeMap::from([
         ("run_id".to_string(), DbValue::from(run.run_id.as_str())),
         (
@@ -1396,6 +1453,10 @@ fn run_row(run: &StateMachineRun) -> DbRow {
         (
             "input_json".to_string(),
             DbValue::from(run.input.to_string()),
+        ),
+        (
+            "opening_message_override_json".to_string(),
+            opening_message_override_json,
         ),
         ("output_text".to_string(), DbValue::Null),
         ("error_message".to_string(), DbValue::Null),

--- a/src/bcs/crates/services/bcs-session/src/launch.rs
+++ b/src/bcs/crates/services/bcs-session/src/launch.rs
@@ -392,6 +392,7 @@ impl SessionLaunchApplication {
                     definition: None,
                     definition_ref: None,
                     participant_bindings: None,
+                    opening_message_override: None,
                     input: session.input.clone().unwrap_or(serde_json::Value::Null),
                     caller_id: Some(prepared.caller.actor_id().to_string()),
                     authenticated_human,

--- a/src/bcs/crates/services/bcs-session/tests/session_launch.rs
+++ b/src/bcs/crates/services/bcs-session/tests/session_launch.rs
@@ -50,6 +50,7 @@ impl CollaborationRuntimeService for RecordingRuntime {
                     created_by: command.caller_id,
                     status: StateMachineRunStatus::Running,
                     input: command.input,
+                    opening_message_override: None,
                     output: None,
                     error: None,
                     created_at: 1,

--- a/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/custom-collaboration.md
+++ b/src/bcs/crates/tools/bcs-cli/bcs-coordination/references/custom-collaboration.md
@@ -48,7 +48,7 @@ candidate_file="$(mktemp "${TMPDIR:-/tmp}/avernet-session-collaboration.XXXXXX")
 # 将候选 YAML 写入 "$candidate_file"
 ```
 
-5. 一次性提交 YAML、全部必需角色绑定和本次运行输入：
+5. 一次性提交 YAML、全部必需角色绑定和本次运行输入。无需自定义副屏时使用基础命令：
 
 ```bash
 bcs collaborate run "$candidate_file" \
@@ -61,8 +61,35 @@ bcs collaborate run "$candidate_file" \
 
 `--binding` 格式是 `逻辑角色=Bot UUID`，可重复；真实 Bot UUID 不得写进 YAML。`--input` 接受 JSON 字面量或 `@path/to/input.json`。该命令只发送一次运行请求；BCS 在服务端重新检查权限、严格校验 YAML 和角色绑定，然后以临时绑定启动 run，不修改 Group 的持久定义或绑定。
 
-6. 提交成功后保留返回的 run ID 用于诊断。BCS 会向原 session 发送 `bcsPanel.StateMachineRunView` AixUI 副屏消息；完成后，BCS 以发起 Bot 的身份将唯一最终产物发回原群，并保持 Chat session 为 Running。发起 Bot 不要再次手工转发结果。
-7. 无论成功或失败，最后执行 `rm -f -- "$candidate_file"`。
+仅当调用方已经提供可用的 AixUI panel 组件名，或当前产品流程明确指定已注册组件时，才为本次 run 增加自定义副屏。不得猜测组件名或假定前端已经注册组件。常用调用只增加组件和 params；复杂 JSON 使用独立临时文件，避免 shell 转义：
+
+```bash
+panel_params_file="$(mktemp "${TMPDIR:-/tmp}/avernet-session-panel-params.XXXXXX")"
+# 向 "$panel_params_file" 写入 JSON object，例如：
+# {"runId":"{{bcs.run_id}}","scene":"release_review"}
+
+bcs collaborate run "$candidate_file" \
+  --session "$session_id" \
+  --binding "planner=$initiator_bot_uuid" \
+  --binding "researcher=$researcher_bot_uuid" \
+  --binding "writer=$writer_bot_uuid" \
+  --input '{"question":"本次需要解决的问题"}' \
+  --panel-component "$panel_component" \
+  --panel-params "@$panel_params_file"
+```
+
+BCS 不会向自定义组件自动注入 `runId`、`groupId` 或 `sessionId`；组件需要这些值时，必须在 params 中显式使用 `{{bcs.run_id}}`、`{{bcs.group_id}}` 和 `{{bcs.session_id}}`。只有明确需要自定义 Tab 时，才在上述命令末尾继续追加：
+
+```bash
+  --panel-tab-id 'one-shot-{{bcs.run_id}}' \
+  --panel-tab-title '一次性协作' \
+  --panel-tab-closable true
+```
+
+这些 Tab 选项和 `--panel-params` 都依赖 `--panel-component`。未提供 `--panel-component` 时继续使用 BCS 默认副屏。
+
+6. 提交成功后保留返回的 run ID 用于诊断。BCS 会向原 session 发送本次请求指定的自定义副屏；未指定时发送默认 `bcsPanel.StateMachineRunView` AixUI 副屏。完成后，BCS 以发起 Bot 的身份将唯一最终产物发回原群，并保持 Chat session 为 Running。发起 Bot 不要再次手工转发结果。
+7. 无论成功或失败，最后执行 `rm -f -- "$candidate_file"`；如果创建了 `panel_params_file`，同时删除该临时文件。
 
 ## 新建持久自定义协作群
 

--- a/src/bcs/crates/tools/bcs-cli/src/client.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/client.rs
@@ -78,6 +78,7 @@ pub struct RunSessionCollaborationOptions {
     pub participant_bindings: BTreeMap<String, ParticipantBindingInfo>,
     pub definition_yaml: String,
     pub input: serde_json::Value,
+    pub opening_message: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1496,12 +1497,16 @@ impl BcsClient {
             "{}/sessions/{}/state-machine-runs",
             self.base_url, options.session_id
         );
+        let mut payload = serde_json::json!({
+            "definition_yaml": options.definition_yaml,
+            "participant_bindings": options.participant_bindings,
+            "input": options.input,
+        });
+        if let Some(opening_message) = options.opening_message {
+            payload["opening_message"] = opening_message;
+        }
         let response = self
-            .add_auth(self.http_client.post(&url).json(&serde_json::json!({
-                "definition_yaml": options.definition_yaml,
-                "participant_bindings": options.participant_bindings,
-                "input": options.input,
-            })))
+            .add_auth(self.http_client.post(&url).json(&payload))
             .send()
             .await
             .context("Failed to start session state-machine run")?;

--- a/src/bcs/crates/tools/bcs-cli/src/main.rs
+++ b/src/bcs/crates/tools/bcs-cli/src/main.rs
@@ -453,6 +453,51 @@ fn parse_json_arg(raw: &str) -> Result<serde_json::Value> {
     }
 }
 
+fn build_panel_opening_message(
+    component: Option<String>,
+    params: Option<String>,
+    tab_id: Option<String>,
+    tab_title: Option<String>,
+    tab_closable: Option<bool>,
+) -> Result<Option<serde_json::Value>> {
+    let Some(component) = component else {
+        if params.is_some() || tab_id.is_some() || tab_title.is_some() || tab_closable.is_some() {
+            return Err(anyhow!(
+                "--panel-params and --panel-tab-* require --panel-component"
+            ));
+        }
+        return Ok(None);
+    };
+
+    let mut opening_message = serde_json::Map::from_iter([
+        ("type".to_string(), json!("panel")),
+        ("component".to_string(), json!(component)),
+    ]);
+    if let Some(params) = params {
+        let params = parse_json_arg(&params)?;
+        if !params.is_object() {
+            return Err(anyhow!("--panel-params must be a JSON object"));
+        }
+        opening_message.insert("params".to_string(), params);
+    }
+
+    let mut tab = serde_json::Map::new();
+    if let Some(id) = tab_id {
+        tab.insert("id".to_string(), json!(id));
+    }
+    if let Some(title) = tab_title {
+        tab.insert("title".to_string(), json!(title));
+    }
+    if let Some(closable) = tab_closable {
+        tab.insert("closable".to_string(), json!(closable));
+    }
+    if !tab.is_empty() {
+        opening_message.insert("tab".to_string(), serde_json::Value::Object(tab));
+    }
+
+    Ok(Some(serde_json::Value::Object(opening_message)))
+}
+
 fn merge_baas_session_id_into_meta(
     meta: Option<serde_json::Value>,
     baas_session_id: Option<&str>,
@@ -1426,6 +1471,26 @@ enum CollaborationCommands {
         /// Runtime input JSON, or @path/to/input.json
         #[arg(long, default_value = "{}")]
         input: String,
+
+        /// AixUI panel component to show when this Run starts
+        #[arg(long)]
+        panel_component: Option<String>,
+
+        /// Panel params JSON object, or @path/to/params.json
+        #[arg(long, requires = "panel_component")]
+        panel_params: Option<String>,
+
+        /// Optional panel tab ID template
+        #[arg(long, requires = "panel_component")]
+        panel_tab_id: Option<String>,
+
+        /// Optional panel tab title template
+        #[arg(long, requires = "panel_component")]
+        panel_tab_title: Option<String>,
+
+        /// Whether the optional panel tab is closable
+        #[arg(long, requires = "panel_component")]
+        panel_tab_closable: Option<bool>,
     },
 
     /// Validate a custom collaboration definition against the current BCS server
@@ -3052,12 +3117,24 @@ pub async fn run() -> Result<()> {
                 session,
                 bindings,
                 input,
+                panel_component,
+                panel_params,
+                panel_tab_id,
+                panel_tab_title,
+                panel_tab_closable,
             } => {
                 let definition_yaml = std::fs::read_to_string(&file).map_err(|error| {
                     anyhow!("Failed to read YAML file {}: {error}", file.display())
                 })?;
                 let participant_bindings = parse_custom_group_bindings(&bindings)?;
                 let input = parse_json_arg(&input)?;
+                let opening_message = build_panel_opening_message(
+                    panel_component,
+                    panel_params,
+                    panel_tab_id,
+                    panel_tab_title,
+                    panel_tab_closable,
+                )?;
                 let token = get_token(token.as_deref())?;
                 let client = create_client(
                     &bcs_url,
@@ -3065,15 +3142,19 @@ pub async fn run() -> Result<()> {
                     bcs_cookie.as_deref(),
                     oauth_headers.as_ref(),
                 );
+                let mut debug_payload = json!({
+                    "definition_yaml": &definition_yaml,
+                    "participant_bindings": &participant_bindings,
+                    "input": &input,
+                });
+                if let Some(opening_message) = opening_message.as_ref() {
+                    debug_payload["opening_message"] = opening_message.clone();
+                }
                 debug_request!(
                     debug,
                     "POST",
                     &format!("/sessions/{session}/state-machine-runs"),
-                    json!({
-                        "definition_yaml": &definition_yaml,
-                        "participant_bindings": &participant_bindings,
-                        "input": &input,
-                    })
+                    debug_payload
                 );
                 let result = client
                     .run_session_collaboration(RunSessionCollaborationOptions {
@@ -3081,6 +3162,7 @@ pub async fn run() -> Result<()> {
                         participant_bindings,
                         definition_yaml,
                         input,
+                        opening_message,
                     })
                     .await?;
                 debug_response!(debug, "202", &result);
@@ -5125,6 +5207,11 @@ mod tests {
                         session,
                         bindings,
                         input,
+                        panel_component: None,
+                        panel_params: None,
+                        panel_tab_id: None,
+                        panel_tab_title: None,
+                        panel_tab_closable: None,
                     },
             } => {
                 assert_eq!(token, "test-token");
@@ -5138,6 +5225,91 @@ mod tests {
             }
             _ => panic!("expected collaborate run command"),
         }
+    }
+
+    #[test]
+    fn collaborate_run_parses_panel_arguments() {
+        let cli = Cli::try_parse_from([
+            "bcs-cli",
+            "collaborate",
+            "run",
+            "/tmp/workflow.yaml",
+            "--session",
+            "group-1:abc12345",
+            "--binding",
+            "writer=bot-writer",
+            "--panel-component",
+            "partnerPanel.OneShotRunView",
+            "--panel-params",
+            r#"{"scene":"release","runId":"{{bcs.run_id}}"}"#,
+            "--panel-tab-id",
+            "one-shot-{{bcs.run_id}}",
+            "--panel-tab-title",
+            "一次性协作",
+            "--panel-tab-closable",
+            "true",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Commands::Collaboration {
+                command:
+                    CollaborationCommands::Run {
+                        panel_component,
+                        panel_params,
+                        panel_tab_id,
+                        panel_tab_title,
+                        panel_tab_closable,
+                        ..
+                    },
+                ..
+            } => {
+                assert_eq!(
+                    panel_component.as_deref(),
+                    Some("partnerPanel.OneShotRunView")
+                );
+                assert_eq!(
+                    panel_params.as_deref(),
+                    Some(r#"{"scene":"release","runId":"{{bcs.run_id}}"}"#)
+                );
+                assert_eq!(panel_tab_id.as_deref(), Some("one-shot-{{bcs.run_id}}"));
+                assert_eq!(panel_tab_title.as_deref(), Some("一次性协作"));
+                assert_eq!(panel_tab_closable, Some(true));
+            }
+            _ => panic!("expected collaborate run command"),
+        }
+    }
+
+    #[test]
+    fn collaborate_run_requires_panel_component_for_dependent_arguments() {
+        let error = Cli::try_parse_from([
+            "bcs-cli",
+            "collaborate",
+            "run",
+            "/tmp/workflow.yaml",
+            "--session",
+            "group-1:abc12345",
+            "--binding",
+            "writer=bot-writer",
+            "--panel-params",
+            "{}",
+        ])
+        .err()
+        .expect("panel params without a component must be rejected");
+        assert!(error.to_string().contains("--panel-component"));
+    }
+
+    #[test]
+    fn panel_opening_message_requires_object_params() {
+        let error = build_panel_opening_message(
+            Some("partnerPanel.OneShotRunView".to_string()),
+            Some("[]".to_string()),
+            None,
+            None,
+            None,
+        )
+        .expect_err("array params must be rejected");
+        assert!(error.to_string().contains("must be a JSON object"));
     }
 
     #[test]

--- a/src/bcs/crates/tools/bcs-cli/tests/e2e/custom_collaboration_test.rs
+++ b/src/bcs/crates/tools/bcs-cli/tests/e2e/custom_collaboration_test.rs
@@ -157,6 +157,91 @@ async fn collaborate_run_posts_yaml_bindings_and_input_once() {
 }
 
 #[tokio::test]
+async fn collaborate_run_posts_structured_panel_opening_message() {
+    let ctx = TestContext::new()
+        .await
+        .expect("Failed to create test context");
+    let yaml_file = ctx.temp_dir.path().join("one-shot-panel.yaml");
+    let params_file = ctx.temp_dir.path().join("panel-params.json");
+    std::fs::write(&yaml_file, WORKFLOW_YAML).unwrap();
+    std::fs::write(
+        &params_file,
+        r#"{"scene":"release","runId":"{{bcs.run_id}}"}"#,
+    )
+    .unwrap();
+
+    Mock::given(method("POST"))
+        .and(path("/sessions/group-1:abc12345/state-machine-runs"))
+        .and(bearer_token(&ctx.session.token))
+        .and(body_json(serde_json::json!({
+            "definition_yaml": WORKFLOW_YAML,
+            "participant_bindings": {
+                "writer": {"source": "manual", "bot_ids": ["bot-writer"]}
+            },
+            "input": {},
+            "opening_message": {
+                "type": "panel",
+                "component": "partnerPanel.OneShotRunView",
+                "params": {
+                    "scene": "release",
+                    "runId": "{{bcs.run_id}}"
+                },
+                "tab": {
+                    "id": "one-shot-{{bcs.run_id}}",
+                    "title": "一次性协作",
+                    "closable": true
+                }
+            }
+        })))
+        .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+            "run": {
+                "run_id": "run-one-shot-panel",
+                "definition_id": "definition-one-shot",
+                "definition_version": 1,
+                "group_id": "group-1",
+                "group_version": 1,
+                "session_id": "group-1:abc12345",
+                "created_by": ctx.session.bot_uuid,
+                "status": "running",
+                "input": {},
+                "created_at": 1,
+                "updated_at": 1
+            },
+            "nodes": [],
+            "judge_outputs": []
+        })))
+        .expect(1)
+        .mount(&ctx.mock_server)
+        .await;
+
+    let output = ctx
+        .cmd()
+        .arg("collaborate")
+        .arg("run")
+        .arg(&yaml_file)
+        .arg("--session")
+        .arg("group-1:abc12345")
+        .arg("--binding")
+        .arg("writer=bot-writer")
+        .arg("--panel-component")
+        .arg("partnerPanel.OneShotRunView")
+        .arg("--panel-params")
+        .arg(format!("@{}", params_file.display()))
+        .arg("--panel-tab-id")
+        .arg("one-shot-{{bcs.run_id}}")
+        .arg("--panel-tab-title")
+        .arg("一次性协作")
+        .arg("--panel-tab-closable")
+        .arg("true")
+        .output()
+        .expect("Failed to execute panel one-shot run command");
+
+    assert_success(&output);
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["run"]["run_id"], "run-one-shot-panel");
+}
+
+#[tokio::test]
 async fn collaboration_validate_calls_server_validation_api() {
     let ctx = TestContext::new()
         .await

--- a/src/bcs/docs/superpowers/specs/2026-08-21-bcs-custom-opening-message-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-21-bcs-custom-opening-message-design.md
@@ -351,6 +351,7 @@ Group detail 在存在自定义值时返回 `opening_message`；未配置时省�
 - 原始字符串模板最多 `64 KiB` UTF-8 字节；
 - 结构化对象的 canonical JSON 最多 `64 KiB` UTF-8 字节；
 - 模板渲染后的最终消息最多 `64 KiB` UTF-8 字节；
+- 完整 `OpeningMessage` 的持久化 JSON 编码最多 65,535 字节，以适配 MySQL `TEXT`；
 - 字符串不得为空或全空白；
 - `component` 去除首尾空白后必须非空、不得包含控制字符、引号、`<`、`>` 或空白；
 - 对象未知字段、未知模板变量、`card + tab` 和不支持的 Group 策略统一返回
@@ -444,6 +445,7 @@ ALTER TABLE bcs_groups
 - 不修改或重命名已经存在的 `009_eventing.sql`，避免改变已登记迁移的 checksum；
 - `NULL` 表示使用默认消息；
 - 字符串和对象统一以 JSON 编码保存，避免将字符串与对象分别建列；
+- 写入前校验完整 JSON 编码不超过 MySQL `TEXT` 的 65,535 字节上限；
 - 旧记录自然读取为 `None`；
 - DB adapter 负责序列化和反序列化，解析失败必须返回存储错误，不得静默退回默认值。
 

--- a/src/bcs/docs/superpowers/specs/2026-08-27-bcs-session-opening-message-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-08-27-bcs-session-opening-message-design.md
@@ -4,6 +4,10 @@
 **Date:** 2026-08-27
 **Scope:** BCS Chat and Manager-Worker collaboration sessions
 
+> 2026-09-01 extension: an explicit one-shot Run `opening_message` is defined by
+> `2026-09-01-bcs-one-shot-opening-message-design.md`. The default-panel rule in
+> this document continues to apply when the one-shot request omits that field.
+
 ## Problem
 
 BCS already supports a group-level custom `opening_message` for StateMachine

--- a/src/bcs/docs/superpowers/specs/2026-09-01-bcs-one-shot-opening-message-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-09-01-bcs-one-shot-opening-message-design.md
@@ -1,0 +1,489 @@
+# BCS one-shot StateMachine 自定义开场消息设计
+
+- 日期：2026-09-01
+- 状态：已实现
+- 范围：Chat 和 ManagerWorker Session 中提交的 one-shot StateMachine Run
+- 相关设计：
+  - `2026-08-21-bcs-custom-opening-message-design.md`
+  - `2026-08-27-bcs-session-opening-message-design.md`
+  - `2026-08-19-bcs-collaboration-state-persistence-fo-rerun-design.md`
+
+## 1. 摘要
+
+BCS 已支持 Normal Group 的自定义 `opening_message`：Chat 和 ManagerWorker 在 Session 创建时
+展示一次，StateMachine 在每个 Run 开始时展示一次。Chat 或 ManagerWorker Session 内临时提交的
+one-shot StateMachine 当前固定使用默认 `bcsPanel.StateMachineRunView` 副屏，并且不会读取 Group
+的 Session 级开场消息。
+
+本设计允许 one-shot 调用方在提交 Run 时携带可选的 `opening_message`。HTTP API 与 Group
+`opening_message` 使用同一个联合类型，支持字符串、AixUI `card` 和 AixUI `panel`；BCS CLI
+第一期只提供用于构造 `panel` 的参数。
+
+提交级配置只覆盖本次 one-shot Run，不修改 Group 或 Session。原始配置持久化到
+`bcs_state_machine_runs.opening_message_override_json`，渲染后的最终消息继续写入 `bcs_messages`。
+自定义 StateMachine Group 创建的配置型 Run 不写该覆盖字段，继续从
+`bcs_groups.opening_message_json` 读取 Group 配置。
+
+## 2. 背景与问题
+
+当前 one-shot 提交接口为：
+
+```http
+POST /sessions/{session_id}/state-machine-runs
+```
+
+请求可以指定 StateMachine definition、临时参与者绑定和运行输入，但不能指定本次 Run 的展示内容。
+运行时会生成固定的默认消息：
+
+```xml
+<AixUI
+  type="panel"
+  component="bcsPanel.StateMachineRunView"
+  tab='{"id":"state-machine-run-<run_id>","title":"State Machine - <session_name>","closable":true}'
+  params='{"runId":"<run_id>"}'
+/>
+```
+
+调用方可能已经注册了面向具体业务的卡片或副屏组件，希望 one-shot Run 启动时直接展示该组件，并把
+Run、Group、Session 和业务参数传给组件。把该配置写到 Chat 或 ManagerWorker Group 上不可行：
+Group `opening_message` 属于 Session，不能影响 Session 内临时启动的 StateMachine Run。
+
+## 3. 术语
+
+- **Group opening message**：持久化在 Group 上，由 Group 策略决定在 Session 或 Run 创建时触发。
+- **Run opening-message override**：one-shot 请求显式提交、只属于一个 Run lineage 的开场消息配置。
+- **Rendered opening message**：使用确定的 Group、Session 和 Run 上下文完成模板替换后的最终消息。
+- **one-shot Run**：Chat 或 ManagerWorker Session 中通过
+  `POST /sessions/{session_id}/state-machine-runs` 临时提交的 StateMachine Run。
+- **configured Run**：StateMachine Group 根据持久化 definition 和 binding 创建的 Run。
+
+## 4. 目标
+
+1. one-shot 提交可以携带与 Group 相同结构的 `opening_message`。
+2. API 支持字符串、AixUI `card` 和 AixUI `panel`。
+3. CLI 第一期只暴露结构化 `panel` 的组件、参数和 Tab 参数。
+4. 未提交 `opening_message` 时保持现有默认 StateMachine 副屏。
+5. one-shot 配置不修改、不读取也不覆盖 Chat 或 ManagerWorker 的 Group 开场消息。
+6. 原始提交配置可在故障恢复和用户 rerun 时使用，并使用新 Run ID 重新渲染。
+7. 渲染结果进入 Session 历史，页面刷新恢复同一结果，Bot 不可见。
+8. configured StateMachine Group 的现有开场消息语义保持不变。
+
+## 5. 非目标
+
+本期不包含：
+
+- 在一个 Run 中提交多条开场消息；
+- 修改 StateMachine definition YAML 以承载展示配置；
+- 允许 one-shot 请求修改 Group 或 Session 的开场消息；
+- 由 BCS 下载、发布或注册前端组件；
+- 校验组件是否存在于某个具体前端版本的注册表；
+- 为 CLI 提供字符串或 `card` 的专用参数；
+- 在 rerun 时替换源 Run 的开场消息、definition、binding 或 input；
+- 修改已经持久化的历史开场消息；
+- 把开场消息内容发送给 Bot 或注入 Bot 上下文。
+
+## 6. 核心语义
+
+### 6.1 配置来源和优先级
+
+| Run 场景 | 请求配置 | Group 配置 | 最终行为 |
+| --- | --- | --- | --- |
+| one-shot | 已提供 | 无论是否存在 | 使用请求级 `opening_message` |
+| one-shot | 省略或 `null` | 无论是否存在 | 使用 BCS 默认 StateMachine 副屏 |
+| configured StateMachine | 接口不提供 | 已提供 | 使用 Group `opening_message` |
+| configured StateMachine | 接口不提供 | 未提供 | 使用 BCS 默认 StateMachine 副屏 |
+
+Chat 和 ManagerWorker Group 的 `opening_message` 始终属于 Session。one-shot 未提供覆盖时不得回退到
+Group `opening_message`，否则会重新引入 Session 开场白污染 StateMachine 副屏的问题。
+
+### 6.2 配置作用域
+
+请求级 `opening_message` 属于创建出的 one-shot Run：
+
+- 不写入 `bcs_groups`；
+- 不写入 `bcs_group_sessions`；
+- 不改变 Session 已经持久化的开场白；
+- 不影响同一 Session 中随后独立提交的其他 one-shot Run；
+- 用户 rerun 创建新 Run 时继承源 Run 的原始覆盖配置。
+
+### 6.3 一次 Run 一条逻辑开场消息
+
+每个 Run 只产生一条逻辑开场消息，使用稳定的：
+
+```text
+client_msg_id = <run_id>:000-panel
+message_type = state_machine_panel
+```
+
+`state_machine_panel` 是现有的 StateMachine 开场消息类型名称。即使实际内容是文本或 `card`，本期也
+不新增消息类型，避免改变历史查询、Bot 过滤和前端恢复协议。
+
+## 7. HTTP API 契约
+
+### 7.1 请求字段
+
+`POST /sessions/{session_id}/state-machine-runs` 增加可选字段：
+
+```text
+opening_message?: OpeningMessage | null
+```
+
+`OpeningMessage` 与 Group API 使用同一个联合类型：
+
+```text
+OpeningMessage = StringTemplate | AixUiOpeningMessage
+```
+
+该接口是创建接口，不是 PATCH：省略和显式 `null` 都表示没有请求级覆盖并使用默认副屏，不需要三态
+patch 语义。
+
+### 7.2 `panel` 示例
+
+```json
+{
+  "definition_yaml": "<state-machine yaml>",
+  "participant_bindings": {
+    "writer": {
+      "source": "manual",
+      "bot_ids": ["bot_writer"]
+    }
+  },
+  "input": {
+    "question": "生成发布方案"
+  },
+  "opening_message": {
+    "type": "panel",
+    "component": "partnerPanel.OneShotRunView",
+    "params": {
+      "runId": "{{bcs.run_id}}",
+      "groupId": "{{bcs.group_id}}",
+      "sessionId": "{{bcs.session_id}}",
+      "businessScene": "release_review"
+    },
+    "tab": {
+      "id": "one-shot-{{bcs.run_id}}",
+      "title": "{{bcs.session_name}}",
+      "closable": true
+    }
+  }
+}
+```
+
+BCS 不向自定义组件隐式合并 `runId`、`groupId` 或其他参数。需要运行标识的组件必须在 `params` 中
+显式使用模板变量，避免服务端默认参数与业务参数发生覆盖冲突。
+
+### 7.3 `card` 示例
+
+```json
+{
+  "opening_message": {
+    "type": "card",
+    "component": "partnerCard.OneShotSummary",
+    "params": {
+      "runId": "{{bcs.run_id}}"
+    }
+  }
+}
+```
+
+`card` 展示在消息区，不打开副屏，并且不得携带 `tab`。
+
+### 7.4 字符串示例
+
+```json
+{
+  "opening_message": "一次性协作已启动，Run ID：{{bcs.run_id}}"
+}
+```
+
+字符串作为普通 Run 开场消息展示，不保证打开副屏。为了与 Group 协议一致，字符串仍允许包含调用方
+自行构造的完整 AixUI 文本；BCS 只执行模板替换，不解析其中的 AixUI 属性。需要动态 JSON 参数时
+应使用结构化对象。
+
+### 7.5 响应
+
+成功响应继续返回现有 `StateMachineRunView`，本期不在公开 Run view 中增加原始
+`opening_message`。页面展示以 Session 历史中的渲染结果为准。
+
+## 8. 校验和渲染
+
+### 8.1 校验时机
+
+BCS 在完成调用方权限校验后、创建 Run 之前对请求级 `opening_message` 执行
+`OpeningMessageScope::StateMachineRun` 校验。非法配置返回：
+
+```http
+400 Bad Request
+```
+
+```text
+invalid_opening_message
+```
+
+非法配置不得创建 Run、Node、definition snapshot、消息或 delivery correlation，也不得调度 Bot。
+
+### 8.2 校验规则
+
+校验规则与 configured StateMachine Group 一致：
+
+- 字符串不得为空或只包含空白；
+- 原始配置和渲染结果不得超过 64 KiB UTF-8 字节；
+- 持久化前的 JSON 编码结果不得超过 65,535 字节，以保证完整写入 MySQL `TEXT`；字符串中的引号、
+  反斜杠等转义字符计入编码结果；
+- 只接受已声明的模板变量；
+- 模板变量必须具有完整的 `{{...}}` 结束标记；
+- `component` 长度为 1–256 字节，不得包含空白、控制字符、引号、`<` 或 `>`；
+- `params` 必须是 JSON object；
+- `type=card` 时不得提供 `tab`；
+- 结构化对象不得包含未声明字段。
+
+BCS 只校验组件标识格式，不查询前端组件注册表。组件未注册不阻止 StateMachine 执行；前端应显示
+组件不可用状态并记录可观测错误。
+
+### 8.3 模板变量
+
+请求级消息使用 StateMachine Run 作用域，支持：
+
+| 占位符 | 渲染来源 |
+| --- | --- |
+| `{{bcs.group_id}}` | 当前 Group ID |
+| `{{bcs.session_id}}` | 当前 Session ID |
+| `{{bcs.run_id}}` | 当前 Run ID |
+| `{{bcs.group_name}}` | 当前 Group 名称；未设置时为空字符串 |
+| `{{bcs.session_name}}` | 当前 Session 标题；未设置时为空字符串 |
+
+结构化对象只在 `params` 的字符串值、`tab.id` 和 `tab.title` 中替换模板。`type`、`component` 和
+JSON key 不参与模板替换。
+
+## 9. 数据模型和持久化
+
+### 9.1 Run 覆盖字段
+
+在 `bcs_state_machine_runs` 增加可空字段：
+
+```text
+opening_message_override_json TEXT NULL
+```
+
+该字段保存 one-shot 请求提交的原始 `OpeningMessage` JSON，而不是渲染后的 AixUI 文本。字符串类型
+同样使用 JSON 字符串编码，保证读取时可以按统一联合类型反序列化。
+
+字段保持 `TEXT`，不为极端边界输入扩大存储类型。BCS 在创建 Run 前校验完整 JSON 编码结果不超过
+MySQL `TEXT` 的 65,535 字节上限；超过上限按 `400 invalid_opening_message` 拒绝，不进入持久化流程。
+
+字段命名必须包含 `override`，避免与 Group 配置或最终消息混淆。不使用含义模糊的
+`opening_message_json`。
+
+### 9.2 写入规则
+
+| 场景 | `opening_message_override_json` |
+| --- | --- |
+| one-shot，显式提供非空配置 | 写入原始配置 |
+| one-shot，省略或传 `null` | `NULL` |
+| configured StateMachine Group 创建 Run | `NULL` |
+| one-shot rerun | 复制 source Run 的字段 |
+| configured StateMachine rerun | `NULL`，继续使用 Group 当前配置 |
+
+configured Run 不复制 `bcs_groups.opening_message_json`。Group 仍是该模式的配置事实来源，Group
+修改只影响随后开始的 Run；每个 Run 已经渲染并持久化的历史消息保持不变。
+
+### 9.3 Repository 契约
+
+内部 `StateMachineRun` 增加 `opening_message_override` 字段，Run 创建 port 必须把它与 Run 行在同一
+数据库事务中写入。该字段使用 `serde(skip_serializing)`，因此可供 repository 和 runtime 使用，但不
+进入公开 Run JSON：
+
+```text
+StateMachineRun {
+  ...,
+  opening_message_override: Option<OpeningMessage>
+}
+```
+
+数据库和内存实现都必须支持：
+
+- 创建 Run 时写入 override；
+- 按 Run ID 读取 override；
+- 创建直接 rerun child 时原子复制 source override；
+- 遇到无法反序列化的非空数据时返回持久化错误，不静默当作 `NULL`。
+
+原始 override 属于运行时内部快照，不要求加入公开 `StateMachineRunView`。
+
+### 9.4 渲染结果消息
+
+渲染后的最终内容继续写入 `bcs_messages`，不增加消息表字段。消息包含：
+
+- `group_id` 和 `session_id`；
+- `run_id`；
+- 稳定的 `client_msg_id`；
+- 最终 `text`；
+- `metadata.state_machine.event = "panel"`；
+- 结构化 AixUI 消息的 `metadata.state_machine.component`。
+
+原始模板不写入消息 content 或 metadata。Session history 只返回最终渲染结果，避免刷新时重新渲染，
+也避免通过历史接口同时暴露两种事实来源。
+
+## 10. Run 启动流程
+
+one-shot 启动顺序为：
+
+1. 验证调用方对当前 Session 的 one-shot 权限；
+2. 校验 definition、临时 participant bindings、input 和 `opening_message`；
+3. 生成 Run ID；
+4. 创建 Run、Node，并在 Run 行中原子保存原始 override；
+5. 保存现有 definition 和 resolved binding snapshot；
+6. 根据请求级 override 或默认副屏渲染最终消息；
+7. 持久化 `state_machine_panel` 消息；
+8. 向前端发布相同消息；
+9. 调度 StateMachine 初始节点。
+
+节点调度必须发生在开场消息持久化成功之后。override 或消息持久化失败时，Run 按现有规则标记失败，
+不得向 Bot 派发节点。
+
+实时前端发布保持 best-effort。发布失败不回滚已经持久化的 Run 或消息，页面刷新和重连通过历史消息
+恢复。
+
+## 11. 恢复和 rerun
+
+### 11.1 已存在 Run 的恢复
+
+恢复或重新发布已有 Run 的开场消息时按以下顺序解析：
+
+1. 已存在匹配 `client_msg_id` 或 `run_id` 的持久化消息：复用该最终内容；
+2. 消息缺失且 Run 存在请求级 override：使用该 Run 上下文重新渲染 override；
+3. one-shot 无 override：生成默认 StateMachine 副屏；
+4. configured Run：沿用既有 Group 开场消息恢复规则，本设计不改变其语义。
+
+持久化消息一旦存在，不得根据原始 override 或 Group 当前配置重新生成另一个版本。
+
+### 11.2 用户 rerun
+
+Failed one-shot Run 的用户 rerun 创建新的 Run，并继承 source Run 的原始 override。新 Run 必须：
+
+- 获得新的 `run_id`；
+- 复制 source override，而不是复制 source 的最终 AixUI 文本；
+- 使用新 Run 上下文重新替换 `{{bcs.run_id}}`；
+- 生成新的 `<new_run_id>:000-panel` 消息；
+- 不允许 rerun 请求临时替换 override。
+
+复制最终文本会使业务组件继续查询旧 Run，因此禁止把已渲染消息作为 rerun 模板。
+
+## 12. Bot、前端和消息历史
+
+- 开场消息是 UI 消息，不通过 `BotDeliveryPort` 发送给 Bot。
+- Bot 消息历史和上下文回放继续排除 `state_machine_panel`。
+- Human Session history 返回渲染后的开场消息。
+- 页面刷新、重新连接或晚加入只读取历史消息，不读取 Run override 或 Group 配置重新渲染。
+- 前端继续通过现有 AixUI 解析和组件注册机制展示 `card` 或 `panel`。
+- 未注册组件只影响展示，不影响 StateMachine 节点执行和最终结果发布。
+
+## 13. CLI 设计
+
+`bcs-cli collaborate run` 第一期增加：
+
+```text
+--panel-component <COMPONENT>
+--panel-params <JSON|@FILE>
+--panel-tab-id <TEMPLATE>
+--panel-tab-title <TEMPLATE>
+--panel-tab-closable <true|false>
+```
+
+CLI 行为：
+
+- 未提供 `--panel-component` 时不发送 `opening_message`；
+- 提供 `--panel-component` 时构造 `type=panel` 的结构化 `opening_message`；
+- `--panel-params` 省略时不发送 `params`；
+- 任意 `--panel-params` 或 `--panel-tab-*` 参数都必须依赖 `--panel-component`；
+- `--panel-params` 必须解析为 JSON object；
+- 仅当至少提供一个 Tab 参数时才发送 `tab`；
+- CLI debug 输出沿用现有请求调试机制，但服务端结构化日志不得记录完整 params。
+
+示例：
+
+```bash
+bcs-cli collaborate run workflow.yaml \
+  --session session-1 \
+  --binding writer=bot-writer \
+  --input @input.json \
+  --panel-component partnerPanel.OneShotRunView \
+  --panel-params @panel-params.json \
+  --panel-tab-id 'one-shot-{{bcs.run_id}}' \
+  --panel-tab-title '一次性协作' \
+  --panel-tab-closable true
+```
+
+HTTP API 的字符串和 `card` 能力可以由 SDK 或直接 HTTP 调用使用。CLI 暂不增加通用
+`--opening-message`，后续出现明确需求时再扩展。
+
+## 14. 错误和可观测性
+
+- 请求格式、模板或组件格式非法：`400 invalid_opening_message`；
+- Run override 持久化失败：返回内部错误并确保节点未调度；
+- 渲染失败：Run 标记失败并返回错误；
+- 历史消息持久化失败：Run 标记失败并且不调度节点；
+- 前端实时发布失败：记录包含 Run ID、Group ID 和 Session ID 的 warning，Run 继续；
+- 前端组件未注册：由前端记录组件名和 Run ID，BCS 不把它解释为运行失败。
+
+日志、metrics 和 collaboration events 不记录完整 `opening_message` 或 params。可记录以下低基数字段：
+
+- `opening_message_source = request_override | group | default`；
+- `opening_message_kind = text | card | panel`；
+- `component` 只允许出现在受控 debug 诊断中，不作为 metrics label。
+
+## 15. 兼容性和发布
+
+- 新 HTTP 字段可选，旧调用方请求和响应保持不变；
+- 新数据库字段可空，历史 Run 按 `NULL` 处理；
+- Group API、Group 数据和 configured StateMachine Run 行为不变；
+- Chat 和 ManagerWorker 的 Session 开场消息行为不变；
+- 前端消息 schema 和查询接口不变；
+- CLI 未使用新参数时请求体保持现状。
+
+数据库迁移必须同时覆盖 SQLite 和 MySQL，并加入 schema migration 验证。部署顺序为先升级支持可空字段
+和读取逻辑的 BCS，再允许调用方发送 `opening_message`。回滚时旧版本会忽略不了未知请求字段的风险由
+流量切换保证：回滚 BCS 前必须先停止新调用方发送该字段。
+
+## 16. 测试要求
+
+### 16.1 Contract tests
+
+- HTTP 路由接受字符串、`card`、`panel`、省略和 `null`；
+- HTTP 路由拒绝结构化 `opening_message` 中的未知字段、非法模板、非法组件和带 `tab` 的 `card`；
+- Service API 把原始配置完整传给 runtime；
+- CLI panel 参数生成预期请求 JSON，并校验参数依赖关系。
+
+### 16.2 Store conformance
+
+- SQLite、MySQL 和内存 store round-trip 字符串、`card` 和 `panel` override；
+- one-shot 未配置时保持 `NULL`；
+- configured Run 即使 Group 配置了开场消息也保持 `NULL`；
+- rerun child 原子复制 source override；
+- 无法反序列化的非空数据返回错误；
+- 历史数据库升级后旧 Run 可以正常读取。
+
+### 16.3 Runtime integration
+
+- Chat 和 ManagerWorker one-shot 的请求 override 优先于 Group Session 开场白；
+- one-shot 未提供 override 时继续使用默认 `StateMachineRunView`；
+- 字符串、`card`、`panel` 都按 Run 作用域完成模板替换；
+- 渲染结果只持久化一次并使用稳定 client message ID；
+- persistence failure 发生在节点调度前并使 Run 失败；
+- 前端实时事件与历史消息内容一致；
+- Human 刷新可以恢复消息，Bot 历史看不到消息；
+- Failed one-shot rerun 继承原始 override，并使用新的 Run ID 重新渲染；
+- configured StateMachine Group 继续使用 Group 配置且 Run override 字段为 `NULL`。
+
+## 17. 验收标准
+
+1. 旧 one-shot 请求无需修改，仍打开默认 BCS StateMachine 副屏。
+2. one-shot 请求可以提交字符串、`card` 或 `panel` 开场消息。
+3. CLI 可以通过 `panel-*` 参数提交副屏组件、params 和 Tab 配置。
+4. 请求配置不会修改或消费 Chat、ManagerWorker Group 的 Session 开场白。
+5. 自定义 StateMachine Group 创建 Run 时
+   `bcs_state_machine_runs.opening_message_override_json IS NULL`。
+6. one-shot 显式配置时保存原始 override，最终消息保存到 `bcs_messages`。
+7. 页面刷新得到与实时事件相同的内容，且不会重新渲染当前配置。
+8. Bot 不会接收开场消息，也不会在历史或上下文中看到它。
+9. one-shot rerun 使用新 Run ID 重新渲染原始配置，不引用 source Run。
+10. Group、Session、configured StateMachine 和现有 rerun 行为没有兼容性回归。

--- a/src/bcs/migrations/README.md
+++ b/src/bcs/migrations/README.md
@@ -23,6 +23,7 @@ The open-source v1 baseline starts from a single MySQL/OceanBase init schema:
 | 015 | `mysql/015_add_bot_internal_attributes.sql` | Add persistent Provider Bot attributes (visibility, friend extension, check-in strategy) |
 | 016 | `mysql/016_session_callback_lease.sql` | Add activation-aware callback delivery lease columns and recovery index |
 | 017 | `mysql/017_state_machine_rerun_lineage.sql` | Add State Machine Run lineage, activation identity, and natural rerun idempotency |
+| 018 | `mysql/018_one_shot_opening_message_override.sql` | Persist request-level opening-message overrides for one-shot State Machine Runs |
 
 The previous internal incremental SQL files were removed from the public
 migration path and replaced by the v1 baseline. New public migrations should be
@@ -90,7 +91,7 @@ The startup runner executes SQLite schema work in this order:
 Each migration is recorded only after all of its steps succeed. Re-running
 startup must be idempotent, and checksum mismatches fail startup.
 
-The current SQLite migration chain records versions `001` through `018`.
+The current SQLite migration chain records versions `001` through `019`.
 Versions whose schema is already created by the startup bootstrap record
 progress as no-ops; version `007` repairs the HumanInput output metadata on
 existing databases, versions `008` and `009` add their tables through the
@@ -100,9 +101,10 @@ plaintext, version `011` adds Group opening-message configuration, versions
 columns added through the additive bootstrap DDL, version `013` adds the
 edge-permission tables, version `015` adds per-participant provider routing
 tags, version `016` records parity for SQLite's already unbounded `TEXT`
-session identifiers, and version `017` adds activation-aware callback lease columns plus the
-periodic recovery index, and version `018` adds State Machine Run lineage,
-activation identity, and the unique direct-rerun constraint.
+session identifiers, version `017` adds activation-aware callback lease columns
+plus the periodic recovery index, version `018` adds State Machine Run lineage,
+activation identity, and the unique direct-rerun constraint, and version `019`
+adds the request-level one-shot opening-message override column.
 Future schema changes should use later numeric versions.
 Do not add pre-open-source local schema repairs to the baseline migration.
 Pre-baseline local SQLite files are not a compatibility target; recreate them

--- a/src/bcs/migrations/mysql/018_one_shot_opening_message_override.sql
+++ b/src/bcs/migrations/mysql/018_one_shot_opening_message_override.sql
@@ -1,0 +1,6 @@
+-- Persist only request-level opening-message overrides for one-shot
+-- StateMachine Runs. Configured StateMachine Runs keep this column NULL and
+-- continue to resolve their opening message from the Group.
+ALTER TABLE `bcs_state_machine_runs`
+  ADD COLUMN IF NOT EXISTS `opening_message_override_json` text DEFAULT NULL
+  AFTER `input_json`;


### PR DESCRIPTION
## Problem

Chat 和 ManagerWorker Session 中提交的 one-shot StateMachine Run 只能展示默认副屏，调用方无法为本次 Run 指定业务组件和参数。

同时需要保证：

- Group 的 Session 级开场白不会影响 one-shot StateMachine 副屏；
- configured StateMachine Group 继续使用 Group 级开场白；
- 页面刷新后展示结果保持一致；
- 开场消息不会进入 Bot 历史或上下文；
- rerun 使用新 Run ID 重新渲染原始配置。

## Solution

- 为 `POST /sessions/{session_id}/state-machine-runs` 增加可选 `opening_message`：
  - 支持字符串、AixUI `card` 和 `panel`；
  - 省略或传 `null` 时继续使用默认 StateMachine 副屏；
  - 使用 StateMachine Run 作用域校验和渲染模板变量。
- 为 `bcs-cli collaborate run` 增加：
  - `--panel-component`
  - `--panel-params`
  - `--panel-tab-id`
  - `--panel-tab-title`
  - `--panel-tab-closable`
- 新增 `bcs_state_machine_runs.opening_message_override_json`：
  - 仅保存 one-shot 请求的原始配置；
  - configured StateMachine Run 保持 `NULL`；
  - 渲染后的最终消息继续写入 `bcs_messages`。
- one-shot rerun 原子继承 source Run 的原始 override，并使用新 Run ID 重新渲染。
- 幂等 rerun 优先复用已经持久化的开场消息，避免实时事件与刷新后的历史内容不一致。
- 保持 MySQL 字段为 `TEXT`，在创建 Run 前限制完整 JSON 编码结果不超过 65,535 字节，超限返回 `400 invalid_opening_message`。
- 补充 SQLite version 19 和 MySQL version 018 migration。

## Validation

已通过：

- `cargo check --workspace`
- `cargo test --workspace --no-run`
- `cargo test -p bcs-domain`
- `cargo test -p bcs-collaboration-runtime`
- `cargo test -p bcs-collaboration-store`
- `cargo test -p bcs-http --test groups_contract`
- Service API collaboration runtime contract tests
- BCS CLI `collaborate run` 参数及请求兼容性测试
- SQLite/MySQL migration 检查及持久化 round-trip 测试
- `git diff --check`

覆盖场景包括：

- 字符串、card、panel、省略和 `null`；
- 非法结构、模板变量和持久化编码大小；
- Chat/ManagerWorker Group 开场白隔离；
- configured StateMachine Run override 保持为空；
- 页面历史恢复与 Bot 历史过滤；
- rerun 继承、重新渲染和幂等恢复。

## Compatibility and risk

- HTTP 新字段为可选字段，旧调用方请求保持兼容。
- CLI 未使用 `panel-*` 参数时，请求体保持不变。
- 数据库新增 nullable 字段，历史 Run 按 `NULL` 读取。
- 公开 `StateMachineRunView` 不返回原始 override。
- Chat、ManagerWorker Session 开场白和 configured StateMachine Group 行为保持不变。
- 部署时应先执行数据库 migration，再允许调用方发送 `opening_message`。
- 回滚旧版本前应先停止新调用方发送该字段。

## Spec

- [BCS one-shot StateMachine 自定义开场消息设计](src/bcs/docs/superpowers/specs/2026-09-01-bcs-one-shot-opening-message-design.md)