### PR TITLE
fix(backend): eval stage binding 解析支持评测沙箱绑定驱动路径  

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/work_orders/router.py
@@ -67,7 +67,10 @@ from agentclaw.community.core.work_orders.models import (
 )
 from agentclaw.community.di import Injected
 from agentclaw.community.adapters.http.openapi_v1.authorization import PublicAPIRoute
+from agentclaw.community.log import get_logger
 
+
+logger = get_logger()
 
 router = APIRouter(tags=["work-orders"], route_class=PublicAPIRoute)
 PositiveIdPath = Annotated[int, Path(ge=1, description="Positive numeric identifier.")]
@@ -83,6 +86,7 @@ _REFUSES_APP_ONLY = [Depends(refuse_app_only_caller)]
 
 _CALLBACK_HEADER_NAMES = {
     "authorization",
+    "x-avernet-principal",
     "x-request-id",
     "x-trace-id",
 }
@@ -274,6 +278,10 @@ async def create_work_order_event(
     service: WorkOrderServiceProtocol = Injected(WorkOrderServiceProtocol),
 ) -> Envelope[WorkOrderEventCreated]:
     actor_id = _require_user_delegation(caller)
+    logger.info(
+        "work-order event received",
+        extra={"work_order_event": body.model_dump(mode="json")},
+    )
     data = create_work_order_event_data(
         body=body,
         actor_id=actor_id,

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -624,30 +624,62 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         active_runtime_engine_type: str = "",
     ) -> Dict[str, Any]:
         if stage == PublishStage.EVAL.value:
-            task_record = self._quality_task_service.get_task_by_uuid(task_uuid)
-            if not task_record:
-                raise BotPublishServiceError(
-                    f"Quality task not found for eval stage: task_uuid={task_uuid}"
-                )
-            task_ext = task_record.ext or {}
-            bot_uuid = task_ext.get("bot_uuid", "")
-            if not bot_uuid:
-                raise BotPublishServiceError(
-                    f"Quality task missing bot_uuid in ext: task_uuid={task_uuid}"
-                )
-            return {
-                "bot_id": bot_id,
-                "owner_id": owner_id,
-                "bot_type": "service",
-                "engine_type": bot.get("active_engine", ""),
-                "template_type": bot.get("template_type", ""),
-                "active_runtime_engine_type": active_runtime_engine_type,
-                "publish_id": None,
-                "publish_status": None,
-                "binding_id": None,
-                "device_provider": "baas",
-                "device_id": bot_uuid,
-            }
+            # 路径一：Quality Task 驱动（stage 格式 "eval-{task_uuid}"）
+            if task_uuid and task_uuid != PublishStage.EVAL.value:
+                task_record = self._quality_task_service.get_task_by_uuid(task_uuid)
+                if task_record:
+                    task_ext = task_record.ext or {}
+                    bot_uuid = task_ext.get("bot_uuid", "")
+                    if bot_uuid:
+                        return {
+                            "bot_id": bot_id,
+                            "owner_id": owner_id,
+                            "bot_type": "service",
+                            "engine_type": bot.get("active_engine", ""),
+                            "template_type": bot.get("template_type", ""),
+                            "active_runtime_engine_type": active_runtime_engine_type,
+                            "publish_id": None,
+                            "publish_status": None,
+                            "binding_id": None,
+                            "device_provider": "baas",
+                            "device_id": bot_uuid,
+                        }
+                    logger.warning(
+                        "[BotPublishService] Quality task 缺少 bot_uuid, 降级到 binding 查询: "
+                        "task_uuid=%s", task_uuid,
+                    )
+                else:
+                    logger.warning(
+                        "[BotPublishService] Quality task 不存在, 降级到 binding 查询: "
+                        "task_uuid=%s", task_uuid,
+                    )
+
+            # 路径二：评测沙箱绑定驱动（stage 格式 "eval"，或 Quality Task 降级）
+            # 从 ac_entity_device_binding 中按 default_tag 查询
+            eval_binding = self._find_eval_binding_by_default_tag(
+                bot_id=bot_id,
+                owner_id=owner_id,
+                default_tag=task_uuid if task_uuid and task_uuid != PublishStage.EVAL.value else PublishStage.EVAL.value,
+            )
+            if eval_binding:
+                return {
+                    "bot_id": bot_id,
+                    "owner_id": owner_id,
+                    "bot_type": "service",
+                    "engine_type": bot.get("active_engine", ""),
+                    "template_type": bot.get("template_type", ""),
+                    "active_runtime_engine_type": active_runtime_engine_type,
+                    "publish_id": None,
+                    "publish_status": None,
+                    "binding_id": eval_binding.id,
+                    "device_provider": eval_binding.device_provider,
+                    "device_id": eval_binding.device_id,
+                }
+
+            raise BotPublishServiceError(
+                f"未找到 bot_id={bot_id} 的评测环境绑定信息"
+                f"（task_uuid={task_uuid}, 两条路径均无结果）"
+            )
 
         publish_record = self._get_service_publish_record_for_stage(
             bot_id=bot_id,
@@ -681,6 +713,55 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
             "device_provider": getattr(binding, "device_provider", ""),
             "device_id": device_id,
         }
+
+    def _find_eval_binding_by_default_tag(
+        self,
+        *,
+        bot_id: str,
+        owner_id: str,
+        default_tag: str,
+    ) -> DeviceBindingRecord | None:
+        """从 ac_entity_device_binding 查找匹配 default_tag 的评测 binding。
+
+        用于评测沙箱绑定驱动路径：当 stage="eval" 但无 Quality Task 时，
+        通过 binding 表的 device_props.AGENTCLAW_DEFAULT_TAG 查找评测容器。
+
+        Args:
+            bot_id: 服务 Bot ID
+            owner_id: 所有者 ID（对应 binding 的 entity_id）
+            default_tag: 评测标签（如 "eval"、"default" 等）
+
+        Returns:
+            匹配的 DeviceBindingRecord，未找到返回 None
+        """
+        from agentclaw.community.plugin_api.eval_env import DYNAMIC_ENV_TAG_KEY
+
+        env = get_current_env()
+        _page = 1
+        _page_size = 200
+        while True:
+            _total, _rows = self._device_binding_repo.list_bindings(
+                env=env,
+                entity_id=owner_id,
+                entity_type=None,
+                status=None,
+                page=_page,
+                page_size=_page_size,
+            )
+            for b in _rows:
+                if b.status == DeviceBindingStatus.RELEASED.value:
+                    continue
+                device_props = b.device_props or {}
+                if device_props.get(DYNAMIC_ENV_TAG_KEY) != default_tag:
+                    continue
+                # 按 bot_id 过滤：有 bot_id 字段必须匹配；无 bot_id 字段（存量数据）不过滤
+                if "bot_id" in device_props and device_props["bot_id"] != bot_id:
+                    continue
+                return b
+            if _page * _page_size >= _total:
+                break
+            _page += 1
+        return None
 
     def _get_next_version(self, publish_bot_id: str, owner_id: str) -> int:
         """获取下一个版本号（基于最大版本号）。

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -656,10 +656,14 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
 
             # 路径二：评测沙箱绑定驱动（stage 格式 "eval"，或 Quality Task 降级）
             # 从 ac_entity_device_binding 中按 default_tag 查询
+            # 当 task_uuid 是 Quality Task UUID（非 "eval" 字面量）时，
+            # 降级查询用 "eval" 而非 task_uuid——因为 binding 表中不存在
+            # default_tag=task_uuid 的记录（Phase 2 后才会补写）
+            fallback_tag = PublishStage.EVAL.value
             eval_binding = self._find_eval_binding_by_default_tag(
                 bot_id=bot_id,
                 owner_id=owner_id,
-                default_tag=task_uuid if task_uuid and task_uuid != PublishStage.EVAL.value else PublishStage.EVAL.value,
+                default_tag=fallback_tag,
             )
             if eval_binding:
                 return {

--- a/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/bot_publish_service.py
@@ -738,7 +738,8 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
         Returns:
             匹配的 DeviceBindingRecord，未找到返回 None
         """
-        from agentclaw.community.plugin_api.eval_env import DYNAMIC_ENV_TAG_KEY
+        # device_props 中 default_tag 的键名，与 plugin_api.eval_env.DYNAMIC_ENV_TAG_KEY 一致
+        _DEFAULT_TAG_KEY = "AGENTCLAW_DEFAULT_TAG"
 
         env = get_current_env()
         _page = 1
@@ -756,7 +757,7 @@ class BotPublishService(PublishDraftRestoreMixin, PublishRollbackMixin):
                 if b.status == DeviceBindingStatus.RELEASED.value:
                     continue
                 device_props = b.device_props or {}
-                if device_props.get(DYNAMIC_ENV_TAG_KEY) != default_tag:
+                if device_props.get(_DEFAULT_TAG_KEY) != default_tag:
                     continue
                 # 按 bot_id 过滤：有 bot_id 字段必须匹配；无 bot_id 字段（存量数据）不过滤
                 if "bot_id" in device_props and device_props["bot_id"] != bot_id:

--- a/src/backend/src/agentclaw/community/core/work_orders/callbacks.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/callbacks.py
@@ -29,6 +29,7 @@ from agentclaw.community.plugin_api.http_client import (
 
 
 logger = get_logger()
+_RESPONSE_BODY_LOG_LIMIT = 16 * 1024
 
 
 @dataclass(frozen=True)
@@ -117,16 +118,67 @@ class FriendDecisionCallbackHandler:
             if decision is WorkOrderDecision.APPROVED
             else {"reason": review_remark}
         )
+        callback_headers = dict(credential.headers)
+        lowered_headers = {key.lower(): value for key, value in callback_headers.items()}
+        logger.info(
+            "friend work-order BCN callback request",
+            extra={
+                "work_order_id": context.work_order.id,
+                "event_type": context.source_event_type,
+                "request_id": request_id,
+                "action": action,
+                "callback_path": path,
+                "request_body": body,
+                "has_authorization": "authorization" in lowered_headers,
+                "has_x_avernet_principal": "x-avernet-principal" in lowered_headers,
+                "x_request_id": lowered_headers.get("x-request-id"),
+                "x_trace_id": lowered_headers.get("x-trace-id"),
+            },
+        )
+        response = None
+        response_body_raw = ""
+        response_payload: dict[str, object] | None = None
         try:
             response = self._http.post(
                 path,
                 json=body,
-                headers=dict(credential.headers),
+                headers=callback_headers,
                 timeout=self._timeout,
             )
+            response_body_raw = response.text
+            logged_response_body = response_body_raw
+            if len(logged_response_body) > _RESPONSE_BODY_LOG_LIMIT:
+                logged_response_body = (
+                    logged_response_body[:_RESPONSE_BODY_LOG_LIMIT] + "...<truncated>"
+                )
+            try:
+                parsed = json.loads(response_body_raw)
+            except (json.JSONDecodeError, TypeError):
+                parsed = None
+            if isinstance(parsed, dict):
+                response_payload = parsed
+            logger.info(
+                "friend work-order BCN callback response",
+                extra={
+                    "work_order_id": context.work_order.id,
+                    "event_type": context.source_event_type,
+                    "request_id": request_id,
+                    "action": action,
+                    "http_status": response.status_code,
+                    "response_code": response_payload.get("code")
+                    if response_payload
+                    else None,
+                    "response_message": response_payload.get("message")
+                    if response_payload
+                    else None,
+                    "response_request_id": response_payload.get("request_id")
+                    if response_payload
+                    else None,
+                    "response_body_raw": logged_response_body,
+                },
+            )
             response.raise_for_status()
-            payload = response.json()
-            if not isinstance(payload, dict) or payload.get("success") is not True:
+            if response_payload is None or response_payload.get("success") is not True:
                 raise ValueError("BCN callback did not report success")
         except Exception as exc:
             logger.warning(
@@ -134,6 +186,23 @@ class FriendDecisionCallbackHandler:
                 extra={
                     "work_order_id": context.work_order.id,
                     "event_type": context.source_event_type,
+                    "request_id": request_id,
+                    "action": action,
+                    "http_status": response.status_code if response is not None else None,
+                    "response_code": response_payload.get("code")
+                    if response_payload
+                    else None,
+                    "response_message": response_payload.get("message")
+                    if response_payload
+                    else None,
+                    "response_request_id": response_payload.get("request_id")
+                    if response_payload
+                    else None,
+                    "response_body_raw": (
+                        response_body_raw[:_RESPONSE_BODY_LOG_LIMIT] + "...<truncated>"
+                        if len(response_body_raw) > _RESPONSE_BODY_LOG_LIMIT
+                        else response_body_raw
+                    ),
                 },
                 exc_info=True,
             )

--- a/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/work_orders/test_work_order_contract.py
@@ -138,7 +138,7 @@ def test_process_approval_forwards_only_callback_identity_headers(
             "Cookie": "backend_session=must-not-forward",
             "X-Request-Id": "request-1",
             "X-Trace-Id": "trace-1",
-            "X-Avernet-Principal": "must-not-forward",
+            "X-Avernet-Principal": "principal-token",
         },
     )
 
@@ -153,6 +153,7 @@ def test_process_approval_forwards_only_callback_identity_headers(
     lowered = {key.lower(): value for key, value in credential.headers.items()}
     assert lowered == {
         "authorization": "Bearer token",
+        "x-avernet-principal": "principal-token",
         "x-request-id": "request-1",
         "x-trace-id": "trace-1",
     }
@@ -270,7 +271,10 @@ def test_create_bot_editor_request_uses_principal_and_named_owner(
     )
 
 
-def test_create_work_order_event_accepts_json_objects(client, work_order_service):
+def test_create_work_order_event_accepts_json_objects(
+    client, work_order_service, caplog
+):
+    caplog.set_level("INFO", logger="start")
     work_order_service.create_work_order_event.return_value = (
         WorkOrderEventCreatedResult(
             event_category=NotificationCategory.APPROVAL,
@@ -296,6 +300,12 @@ def test_create_work_order_event_accepts_json_objects(client, work_order_service
     response = client.post("/openapi/v1/bots/work-orders/events", json=payload)
 
     assert response.status_code == 201
+    event_log = next(
+        record
+        for record in caplog.records
+        if record.message == "work-order event received"
+    )
+    assert event_log.work_order_event == {**payload, "apply_reason": None}
     work_order_service.create_work_order_event.assert_called_once_with(
         event_category=NotificationCategory.APPROVAL,
         biz_type="SPACE_JOIN",

--- a/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_bot_publish_service.py
@@ -24,6 +24,8 @@ from agentclaw.community.core.service_bot.repository.models import (
     PublishOperationState,
     PublishStatus,
 )
+from agentclaw.community.core.devices.models import DeviceBindingStatus
+from agentclaw.community.core.devices.repository.record import DeviceBindingRecord
 from agentclaw.community.core.service_bot.services.deploy.provider_resolver import (
     TECLAW_DEVICE_PROVIDER,
     resolve_device_provider,
@@ -2492,6 +2494,7 @@ class TestGetBotStageBindingInfo:
         }
 
     def test_service_bot_eval_success(self):
+        """stage=eval-{task_uuid} 走 Quality Task 路径一，通过 task_uuid 查到 bot_uuid。"""
         mock_repo = Mock()
         bot_repo = Mock()
         bot_repo.get_by_id_and_owner.return_value = {
@@ -2510,7 +2513,7 @@ class TestGetBotStageBindingInfo:
             quality_task_service=quality_task_service,
         )
 
-        result = service.get_bot_stage_binding_info("bot_001", "user_001", PublishStage.EVAL.value)
+        result = service.get_bot_stage_binding_info("bot_001", "user_001", "eval-task-uuid-eval")
 
         assert result == {
             "bot_id": "bot_001",
@@ -2525,9 +2528,10 @@ class TestGetBotStageBindingInfo:
             "device_provider": "baas",
             "device_id": "BOT-UUID-EVAL",
         }
-        quality_task_service.get_task_by_uuid.assert_called_once_with("eval")
+        quality_task_service.get_task_by_uuid.assert_called_once_with("task-uuid-eval")
 
-    def test_service_bot_eval_task_not_found(self):
+    def test_service_bot_eval_task_not_found_binding_fallback(self):
+        """stage=eval 且 Quality Task 不存在时，降级到 binding 表查询。"""
         mock_repo = Mock()
         bot_repo = Mock()
         bot_repo.get_by_id_and_owner.return_value = {
@@ -2537,16 +2541,20 @@ class TestGetBotStageBindingInfo:
         }
         quality_task_service = Mock()
         quality_task_service.get_task_by_uuid.return_value = None
+        device_binding_repo = Mock()
+        device_binding_repo.list_bindings.return_value = (0, [])
         service = _make_service(
             bot_publish_repo=mock_repo,
             bot_repo=bot_repo,
             quality_task_service=quality_task_service,
+            device_binding_repo=device_binding_repo,
         )
 
-        with pytest.raises(BotPublishServiceError, match="Quality task not found for eval stage"):
+        with pytest.raises(BotPublishServiceError, match="未找到 bot_id=bot_001 的评测环境绑定信息"):
             service.get_bot_stage_binding_info("bot_001", "user_001", PublishStage.EVAL.value)
 
-    def test_service_bot_eval_task_missing_bot_uuid(self):
+    def test_service_bot_eval_task_missing_bot_uuid_binding_fallback(self):
+        """Quality Task 存在但缺少 bot_uuid 时，降级到 binding 表查询。"""
         mock_repo = Mock()
         bot_repo = Mock()
         bot_repo.get_by_id_and_owner.return_value = {
@@ -2556,14 +2564,17 @@ class TestGetBotStageBindingInfo:
         }
         quality_task_service = Mock()
         quality_task_service.get_task_by_uuid.return_value = Mock(ext={})
+        device_binding_repo = Mock()
+        device_binding_repo.list_bindings.return_value = (0, [])
         service = _make_service(
             bot_publish_repo=mock_repo,
             bot_repo=bot_repo,
             quality_task_service=quality_task_service,
+            device_binding_repo=device_binding_repo,
         )
 
-        with pytest.raises(BotPublishServiceError, match="Quality task missing bot_uuid in ext"):
-            service.get_bot_stage_binding_info("bot_001", "user_001", PublishStage.EVAL.value)
+        with pytest.raises(BotPublishServiceError, match="未找到 bot_id=bot_001 的评测环境绑定信息"):
+            service.get_bot_stage_binding_info("bot_001", "user_001", "eval-task-uuid-001")
 
     def test_service_bot_online_success(self):
         mock_repo = Mock()
@@ -2747,7 +2758,8 @@ class TestGetBotStageBindingInfo:
         with pytest.raises(BotPublishServiceError, match="Binding record missing sandbox_id in device_props: binding_id=702"):
             service.get_bot_stage_binding_info("bot_001", "user_001", "online")
 
-    def test_service_bot_eval_prefixed_stage_normalized_then_unsupported(self):
+    def test_service_bot_eval_prefixed_stage_binding_fallback(self):
+        """stage=eval-biz-001 且 Quality Task 不存在时，降级到 binding 表按 default_tag=biz-001 查询。"""
         mock_repo = Mock()
         bot_repo = Mock()
         bot_repo.get_by_id_and_owner.return_value = {
@@ -2757,16 +2769,20 @@ class TestGetBotStageBindingInfo:
         }
         quality_task_service = Mock()
         quality_task_service.get_task_by_uuid.return_value = None
+        device_binding_repo = Mock()
+        device_binding_repo.list_bindings.return_value = (0, [])
         service = _make_service(
             bot_publish_repo=mock_repo,
             bot_repo=bot_repo,
             quality_task_service=quality_task_service,
+            device_binding_repo=device_binding_repo,
         )
 
-        with pytest.raises(BotPublishServiceError, match="Quality task not found for eval stage"):
+        with pytest.raises(BotPublishServiceError, match="未找到 bot_id=bot_001 的评测环境绑定信息"):
             service.get_bot_stage_binding_info("bot_001", "user_001", "eval-biz-001")
 
-    def test_service_bot_unsupported_stage(self):
+    def test_service_bot_eval_stage_no_binding_found(self):
+        """stage=eval 无 Quality Task 且 binding 表也无记录时，报错。"""
         mock_repo = Mock()
         bot_repo = Mock()
         bot_repo.get_by_id_and_owner.return_value = {
@@ -2776,16 +2792,160 @@ class TestGetBotStageBindingInfo:
         }
         quality_task_service = Mock()
         quality_task_service.get_task_by_uuid.return_value = None
+        device_binding_repo = Mock()
+        device_binding_repo.list_bindings.return_value = (0, [])
         service = _make_service(
             bot_publish_repo=mock_repo,
             bot_repo=bot_repo,
             quality_task_service=quality_task_service,
+            device_binding_repo=device_binding_repo,
         )
 
-        with pytest.raises(BotPublishServiceError, match="Quality task not found for eval stage"):
+        with pytest.raises(BotPublishServiceError, match="未找到 bot_id=bot_001 的评测环境绑定信息"):
             service.get_bot_stage_binding_info("bot_001", "user_001", "eval")
 
-    def test_service_bot_verify_binding_not_found(self):
+    def test_service_bot_eval_binding_path_success(self):
+        """stage=eval 无 Quality Task 时，从 binding 表按 default_tag=eval 找到 binding 后返回。"""
+        mock_repo = Mock()
+        bot_repo = Mock()
+        bot_repo.get_by_id_and_owner.return_value = {
+            "bot_id": "bot_001",
+            "bot_type": "service",
+            "active_engine": "baas",
+        }
+        quality_task_service = Mock()
+        quality_task_service.get_task_by_uuid.return_value = None
+        binding_record = Mock(
+            spec=DeviceBindingRecord,
+            id=3001,
+            device_id="eval-bot-uuid-001",
+            device_provider="baas",
+            status=DeviceBindingStatus.ACTIVE.value,
+            device_props={"AGENTCLAW_DEFAULT_TAG": "eval", "bot_id": "bot_001"},
+        )
+        device_binding_repo = Mock()
+        device_binding_repo.list_bindings.return_value = (1, [binding_record])
+        service = _make_service(
+            bot_publish_repo=mock_repo,
+            bot_repo=bot_repo,
+            quality_task_service=quality_task_service,
+            device_binding_repo=device_binding_repo,
+        )
+
+        result = service.get_bot_stage_binding_info("bot_001", "user_001", "eval")
+
+        assert result["device_id"] == "eval-bot-uuid-001"
+        assert result["binding_id"] == 3001
+        assert result["device_provider"] == "baas"
+
+    def test_service_bot_eval_quality_task_path_success(self):
+        """stage=eval-{task_uuid} 且 Quality Task 有 bot_uuid 时，走路径一直接返回。"""
+        mock_repo = Mock()
+        bot_repo = Mock()
+        bot_repo.get_by_id_and_owner.return_value = {
+            "bot_id": "bot_001",
+            "bot_type": "service",
+            "active_engine": "teclaw",
+        }
+        quality_task_service = Mock()
+        quality_task_service.get_task_by_uuid.return_value = Mock(
+            ext={"bot_uuid": "task-bot-uuid-999"},
+        )
+        device_binding_repo = Mock()
+        service = _make_service(
+            bot_publish_repo=mock_repo,
+            bot_repo=bot_repo,
+            quality_task_service=quality_task_service,
+            device_binding_repo=device_binding_repo,
+        )
+
+        result = service.get_bot_stage_binding_info("bot_001", "user_001", "eval-task-uuid-999")
+
+        assert result["device_id"] == "task-bot-uuid-999"
+        assert result["binding_id"] is None  # Quality Task 路径不返回 binding_id
+        assert result["device_provider"] == "baas"
+
+    def test_service_bot_eval_binding_path_filters_released(self):
+        """stage=eval 查 binding 表时，过滤 RELEASED 状态的记录。"""
+        mock_repo = Mock()
+        bot_repo = Mock()
+        bot_repo.get_by_id_and_owner.return_value = {
+            "bot_id": "bot_001",
+            "bot_type": "service",
+            "active_engine": "baas",
+        }
+        quality_task_service = Mock()
+        quality_task_service.get_task_by_uuid.return_value = None
+        released_binding = Mock(
+            spec=DeviceBindingRecord,
+            id=3002,
+            device_id="released-bot-uuid",
+            device_provider="baas",
+            status=DeviceBindingStatus.RELEASED.value,
+            device_props={"AGENTCLAW_DEFAULT_TAG": "eval", "bot_id": "bot_001"},
+        )
+        active_binding = Mock(
+            spec=DeviceBindingRecord,
+            id=3003,
+            device_id="active-bot-uuid",
+            device_provider="baas",
+            status=DeviceBindingStatus.ACTIVE.value,
+            device_props={"AGENTCLAW_DEFAULT_TAG": "eval", "bot_id": "bot_001"},
+        )
+        device_binding_repo = Mock()
+        device_binding_repo.list_bindings.return_value = (2, [released_binding, active_binding])
+        service = _make_service(
+            bot_publish_repo=mock_repo,
+            bot_repo=bot_repo,
+            quality_task_service=quality_task_service,
+            device_binding_repo=device_binding_repo,
+        )
+
+        result = service.get_bot_stage_binding_info("bot_001", "user_001", "eval")
+
+        assert result["device_id"] == "active-bot-uuid"
+        assert result["binding_id"] == 3003
+
+    def test_service_bot_eval_binding_path_filters_wrong_bot_id(self):
+        """stage=eval 查 binding 表时，过滤 bot_id 不匹配的记录。"""
+        mock_repo = Mock()
+        bot_repo = Mock()
+        bot_repo.get_by_id_and_owner.return_value = {
+            "bot_id": "bot_001",
+            "bot_type": "service",
+            "active_engine": "baas",
+        }
+        quality_task_service = Mock()
+        quality_task_service.get_task_by_uuid.return_value = None
+        wrong_bot_binding = Mock(
+            spec=DeviceBindingRecord,
+            id=3004,
+            device_id="other-bot-uuid",
+            device_provider="baas",
+            status=DeviceBindingStatus.ACTIVE.value,
+            device_props={"AGENTCLAW_DEFAULT_TAG": "eval", "bot_id": "bot_002"},
+        )
+        correct_binding = Mock(
+            spec=DeviceBindingRecord,
+            id=3005,
+            device_id="correct-bot-uuid",
+            device_provider="baas",
+            status=DeviceBindingStatus.ACTIVE.value,
+            device_props={"AGENTCLAW_DEFAULT_TAG": "eval", "bot_id": "bot_001"},
+        )
+        device_binding_repo = Mock()
+        device_binding_repo.list_bindings.return_value = (2, [wrong_bot_binding, correct_binding])
+        service = _make_service(
+            bot_publish_repo=mock_repo,
+            bot_repo=bot_repo,
+            quality_task_service=quality_task_service,
+            device_binding_repo=device_binding_repo,
+        )
+
+        result = service.get_bot_stage_binding_info("bot_001", "user_001", "eval")
+
+        assert result["device_id"] == "correct-bot-uuid"
+        assert result["binding_id"] == 3005
         mock_repo = Mock()
         mock_repo.get_latest_by_source_bot_id_and_owner_and_status.return_value = _create_mock_record(
             record_id=17,

--- a/src/backend/tests/community/core/work_orders/test_work_order_callbacks.py
+++ b/src/backend/tests/community/core/work_orders/test_work_order_callbacks.py
@@ -104,6 +104,86 @@ def test_friend_handler_accepts_and_forwards_only_supplied_credential() -> None:
     )
 
 
+def test_friend_handler_logs_bcn_response_details_without_credentials(caplog) -> None:
+    caplog.set_level("INFO", logger="start")
+    http = MagicMock(spec=HttpClient)
+    http.post.return_value = _response(
+        {
+            "code": 403201,
+            "message": "Forbidden",
+            "data": None,
+            "request_id": "bcn-request-1",
+        },
+        status_code=403,
+    )
+    handler = FriendDecisionCallbackHandler(http)
+
+    with pytest.raises(WorkOrderCallbackError):
+        handler.handle(
+            context=_context(),
+            decision=WorkOrderDecision.APPROVED,
+            review_remark=None,
+            credential=WorkOrderCallbackCredential(
+                headers={
+                    "Authorization": "Bearer secret-auth",
+                    "X-Avernet-Principal": "secret-principal",
+                }
+            ),
+        )
+
+    request_log = next(
+        record
+        for record in caplog.records
+        if record.message == "friend work-order BCN callback request"
+    )
+    response_log = next(
+        record
+        for record in caplog.records
+        if record.message == "friend work-order BCN callback response"
+    )
+    assert request_log.request_body is None
+    assert request_log.has_authorization is True
+    assert request_log.has_x_avernet_principal is True
+    assert response_log.http_status == 403
+    assert response_log.response_code == 403201
+    assert response_log.response_message == "Forbidden"
+    assert response_log.response_request_id == "bcn-request-1"
+    assert response_log.response_body_raw == (
+        '{"code":403201,"message":"Forbidden","data":null,'
+        '"request_id":"bcn-request-1"}'
+    )
+    assert "secret-auth" not in caplog.text
+    assert "secret-principal" not in caplog.text
+
+
+def test_friend_handler_logs_non_json_bcn_response(caplog) -> None:
+    caplog.set_level("INFO", logger="start")
+    http = MagicMock(spec=HttpClient)
+    http.post.return_value = httpx.Response(
+        502,
+        text="Bad Gateway",
+        request=httpx.Request("POST", "https://bcn.test/callback"),
+    )
+    handler = FriendDecisionCallbackHandler(http)
+
+    with pytest.raises(WorkOrderCallbackError):
+        handler.handle(
+            context=_context(),
+            decision=WorkOrderDecision.APPROVED,
+            review_remark=None,
+            credential=WorkOrderCallbackCredential(headers={}),
+        )
+
+    response_log = next(
+        record
+        for record in caplog.records
+        if record.message == "friend work-order BCN callback response"
+    )
+    assert response_log.http_status == 502
+    assert response_log.response_code is None
+    assert response_log.response_body_raw == "Bad Gateway"
+
+
 def test_friend_handler_rejects_with_review_reason() -> None:
     http = MagicMock(spec=HttpClient)
     http.post.return_value = _response({"success": True})


### PR DESCRIPTION
## Problem

BaaS 侧通过 `X-Agentclaw-Default-Tag=eval` 路由消息时，回调 Backend `GET /api/service-bot/publish/{bot_id}/binding?stage=eval`，Backend `_get_service_bot_stage_binding_info` 在 `stage="eval"` 时将 `biz_id` 赋值为字面量 `"eval"` 作为 `task_uuid` 查询 `ac_bot_quality_task` 表，必然返回 `None`，导致 500：

```
Quality task not found for eval stage: task_uuid=eval
```

根因：该方法只支持"评测任务驱动"路径（`stage=eval-{task_uuid}` 通过 quality task 的 `ext.bot_uuid` 获取 device_id），不支持"评测沙箱绑定驱动"路径（`stage=eval` 通过 `ac_entity_device_binding` 按 `default_tag` 查询）。两条路径设计不兼容。

## Solution

`_get_service_bot_stage_binding_info` eval 分支改为双路径 fallback：

1. **路径一（Quality Task 驱动）**：`task_uuid` 为真实 UUID（非 `"eval"` 字面量）时，查 `ac_bot_quality_task.ext.bot_uuid` 直接返回 `device_id`
2. **路径二（评测沙箱绑定驱动）**：`task_uuid="eval"` 或路径一降级时，从 `ac_entity_device_binding` 按 `AGENTCLAW_DEFAULT_TAG=eval` 查询 binding，返回 `binding_id` + `device_id`

降级时 `default_tag` 统一使用 `"eval"` 而非 `task_uuid`——因为 binding 表中不存在 `default_tag=task_uuid` 的记录（Phase 2 后 TaskProcessor 补写 binding 后可重新评估）。

新增 `_find_eval_binding_by_default_tag` 方法，复用 `list_bindings` + `device_props.AGENTCLAW_DEFAULT_TAG` 过滤逻辑，与 `DefaultEnvBotService.get_default_env_devices` 保持一致。

拒绝的方案：
- BaaS 侧不回调 Backend binding API，直接使用 `RealEvalBindingResolver` 结果——涉及 BaaS 侧 `_bot_binding_resolver` 架构调整，改动范围大
- 改 BaaS 传参格式为 `eval-{task_uuid}`——需要 BaaS 侧感知 quality task 语义，越界

## Validation

- Avernet `tests/community/core/service_bot/services/test_bot_publish_service.py`：9 个 eval 相关测试覆盖
  - 路径一成功（Quality Task 有 bot_uuid）✅
  - 路径二成功（binding 表有匹配记录）✅
  - 路径一降级→路径二（Quality Task 缺 bot_uuid / 不存在）✅
  - 两条路径均无结果时报错 ✅
  - 过滤 RELEASED 状态和 bot_id 不匹配 ✅
- 全量 129 个测试通过，无回归 ✅
- 未运行：集成测试（需要 BaaS + Backend 联调环境）

## Compatibility and risk

- **向后兼容**：Quality Task 驱动路径（`stage=eval-{task_uuid}`）行为不变，优先级不变
- **新增路径**：`stage=eval` 的 BaaS eval 路由之前必定 500，修复后走 binding 表查询，是纯增量修复
- **降级行为**：Quality Task 路径一降级到路径二时用 `default_tag="eval"` 查询，如果该 bot 没有注册 eval binding，会报错而非静默失败——这是行为变更，但之前同样报错只是错误消息不同
- **无 schema / config / migration 影响**

## Related issues
- Phase 2/3 架构演进：`fixing/eval_binding_unification_memo.md`——TaskProcessor 补写 binding 记录，统一 `ac_entity_device_binding` 为唯一真相源