### PR TITLE
fix(engine): resolve favorites beyond session list cap

### DIFF
--- a/src/engine/src/engine/community/api/session_favorites/router.py
+++ b/src/engine/src/engine/community/api/session_favorites/router.py
@@ -10,7 +10,7 @@ from engine.community.api.caps import check_capability
 from engine.community.api.response import ApiResponse
 from engine.community.api.session.router import _get_session_api, _session_to_dict
 from engine.community.core.engine.capability import Capability
-from engine.community.core.session.models import SessionListRequest
+from engine.community.core.session.models import Session, SessionListRequest
 from engine.community.core.session_favorite import get_session_favorite_repository
 from engine.community.shared.utils import decode_session_key
 
@@ -18,9 +18,8 @@ log = logging.getLogger("session-favorites")
 
 router = APIRouter(prefix="/api/session-favorites", tags=["session-favorites"])
 
-# Engine SessionService implementations paginate in memory. Fetching this bounded
-# set lets the adapter apply pagination after it filters by the SQLite metadata.
-_FAVORITE_SESSION_SCAN_LIMIT = 10_000
+# Bound exact lookups so a large favorite set cannot flood the engine gateway.
+_FAVORITE_SESSION_LOOKUP_CONCURRENCY = 8
 
 
 def _require_user_id(user_id: str | None) -> str:
@@ -49,23 +48,32 @@ async def list_session_favorites(
             return ApiResponse(success=True, data=[], warning=warning)
 
         api = _get_session_api(engine)
-        sessions = await api.list(
-            SessionListRequest(
-                user_id=resolved_user_id,
-                agent_id=agent_id,
-                limit=_FAVORITE_SESSION_SCAN_LIMIT,
-                offset=0,
+        semaphore = asyncio.Semaphore(_FAVORITE_SESSION_LOOKUP_CONCURRENCY)
+
+        async def resolve_favorite(session_id: str) -> Session | None:
+            async with semaphore:
+                sessions = await api.list(
+                    SessionListRequest(
+                        user_id=resolved_user_id,
+                        agent_id=agent_id,
+                        session_key=session_id,
+                        limit=1,
+                        offset=0,
+                    )
+                )
+            return next(
+                (session for session in sessions if session.id == session_id),
+                None,
             )
+
+        # gather preserves the repository's newest-favorite-first order. Resolve
+        # before slicing so stale favorite rows do not leave pages under-filled.
+        resolved_sessions = await asyncio.gather(
+            *(resolve_favorite(session_id) for session_id in favorite_session_ids)
         )
-        # Engines own their session ordering, so restore the SQLite favorite
-        # order before applying favorite-list pagination.
-        favorite_rank = {
-            session_id: index for index, session_id in enumerate(favorite_session_ids)
-        }
         favorite_sessions = [
-            session for session in sessions if session.id in favorite_rank
+            session for session in resolved_sessions if session is not None
         ]
-        favorite_sessions.sort(key=lambda session: favorite_rank[session.id])
         paged_sessions = favorite_sessions[offset:offset + limit]
         return ApiResponse(
             success=True,

--- a/src/engine/src/engine/community/api/session_favorites/tests/test_router.py
+++ b/src/engine/src/engine/community/api/session_favorites/tests/test_router.py
@@ -56,11 +56,11 @@ def test_list_returns_full_session_data_for_current_users_favorites(
     session_api,
 ):
     repository.list_session_ids.return_value = ["session-3", "session-1"]
-    session_api.list = AsyncMock(return_value=[
-        _make_session("session-1"),
-        _make_session("session-2"),
-        _make_session("session-3"),
-    ])
+
+    async def list_session(request):
+        return [_make_session(request.session_key)]
+
+    session_api.list = AsyncMock(side_effect=list_session)
 
     response = client.get(
         "/api/session-favorites",
@@ -83,11 +83,36 @@ def test_list_returns_full_session_data_for_current_users_favorites(
         "message_count": 0,
     }]
     repository.list_session_ids.assert_called_once_with("user-a")
-    request = session_api.list.call_args.args[0]
-    assert request.user_id == "user-a"
-    assert request.agent_id == "main"
-    assert request.limit == 10_000
-    assert request.offset == 0
+    assert session_api.list.call_count == 2
+    requests = [call.args[0] for call in session_api.list.call_args_list]
+    assert {request.session_key for request in requests} == {"session-3", "session-1"}
+    assert all(request.user_id == "user-a" for request in requests)
+    assert all(request.agent_id == "main" for request in requests)
+    assert all(request.limit == 1 for request in requests)
+    assert all(request.offset == 0 for request in requests)
+
+
+def test_list_filters_stale_favorites_before_applying_pagination(
+    client,
+    repository,
+    session_api,
+):
+    repository.list_session_ids.return_value = ["stale", "session-2", "session-1"]
+
+    async def list_session(request):
+        if request.session_key == "stale":
+            return []
+        return [_make_session(request.session_key)]
+
+    session_api.list = AsyncMock(side_effect=list_session)
+
+    response = client.get(
+        "/api/session-favorites",
+        params={"user_id": "user-a", "limit": 1, "offset": 1},
+    )
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.json()["data"]] == ["session-1"]
 
 
 def test_list_skips_engine_query_when_user_has_no_favorites(client, repository, session_api):


### PR DESCRIPTION
## Summary
- resolve favorite sessions by exact session key instead of scanning the capped gateway session list
- bound concurrent lookups while preserving favorite order and post-filter pagination
- add regression coverage for exact lookups and stale favorite records

## Verification
- session favorites router tests: 14 passed
- OpenClaw session port tests: 47 passed
- pre-push SAST gate passed
- validated against an OpenClaw 2026.5.12 runtime: favorite list restored all 3 records, including 2 sessions outside the default 100-session window