### PR TITLE
feat(backend): return template_config verbatim through openapi bot query faces

### DIFF
--- a/docs/superpowers/specs/2026-08-31-engine-vocabulary-template-form-design.md
+++ b/docs/superpowers/specs/2026-08-31-engine-vocabulary-template-form-design.md
@@ -160,6 +160,12 @@ def uses_aicoding_runtime(
 
 ## 4. 查询接口补齐（all / bots / bot_id 展示 template_type + template_config）
 
+> **修订（2026-09-01）**：本节及 §6 第 7 条中「白名单投影」「`token`/`thetaKey`
+> 绝不出现」的验收要求已被
+> [2026-09-01-template-config-passthrough-decision.md](2026-09-01-template-config-passthrough-decision.md)
+> 撤销——查询面改为全字段原样透传。`engine_form` 露出问题随透传自然消解（存储快照里有什么就返回什么）。
+> 下文保留为历史设计记录。
+
 三个端点已具备返回能力（§1.4），本设计只补三件事：
 
 1. **`_PUBLIC_TEMPLATE_KEYS` 白名单追加 `"engine_form"`**（template_public_view.py:21）——
@@ -205,6 +211,7 @@ def uses_aicoding_runtime(
    runtime/bucket/identity 布局逐项不变。
 7. 查询三接口：template_type/template_config 返回、`engine_form` 露出、
    `token`/`bot_template_config`（thetaKey）绝不出现（扫描断言）。
+   **（2026-09-01 修订：末项已撤销，改为原样透传，见 §4 顶部修订说明。）**
 8. PUBLIC 校验模式：`engine_properties.template` 用户传 `engine_form` → 422。
 
 ## 7. 分期与开放问题

--- a/docs/superpowers/specs/2026-09-01-template-config-passthrough-decision.md
+++ b/docs/superpowers/specs/2026-09-01-template-config-passthrough-decision.md
@@ -1,0 +1,48 @@
+# OpenAPI template_config 查询面全字段透传决策
+
+- **日期**：2026-09-01
+- **决策**：产品拍板（平台负责人）：公开查询面（`/openapi/v1/bots`、`/openapi/v1/bots/all`、`/openapi/v1/bots/{bot_id}`）对 `template_config` 由白名单投影改为**原样透传**——存储快照（`ac_templates.ext`）深拷贝直接返回，不做任何字段过滤。
+- **范围**：所有模板 bot（aicoding/applicationCoding、normalCC 模板工厂、personalCoding 等），三类一致透传。
+- **背景**：集成方反馈「老 API 创建的 aicoding，经 openapi all/bots 返回时 template_config 字段缺失」。根因即白名单投影：老面（`/api/bots`）原样回传 `ac_templates.ext`，新面只保留 6 个 key（`code_repos`/`devflow_workflow`/`engine_form`/`template_key`/`template_uid`/`yuque_kb_repos`），其余（`devflow_workflows` 复数、`model`/`runtime`、`token`、`bot_template_config` 等）全部被丢弃。
+
+## 1. 安全取舍（已确认接受）
+
+原白名单的存在理由：`template_config.token`（可为明文业务 token）与
+`bot_template_config.ext_config.thetaKey`（`enc:v1:` 密文）属于密钥材料，列表响应不应回显。
+
+本决策的反驳理由（已由平台负责人确认接受）：
+
+1. 三个查询面均为 **owner-scoped**（`user_id` 必须是被验证的 owner 本人，或经 owner 显式授权的应用调用方）——回显的是调用方自己创建时传入的输入，而非泄露他人秘密。
+2. 密文回显的离线攻击前提（响应落日志/缓存）由网关与客户端侧承担；平台侧不再替调用方做此判断。
+3. 消除两面（老 `/api` vs 新 `/openapi`）行为分叉，`devflow_workflows`（复数，引擎读路径的权威键）等字段不再静默丢失。
+
+**若未来要恢复过滤，属产品决策 revert，不是 bug fix**；恢复时须先阅本文件与
+`template_public_view.py` 模块 docstring。
+
+## 2. 实现锚点
+
+| # | 文件 | 改动 |
+| --- | --- | --- |
+| 1 | `core/bot_management/template_public_view.py` | 删除 `_PUBLIC_TEMPLATE_KEYS`；`project_template_config_for_public` 改名 `template_config_for_public`，实现为「非 Mapping → None；否则 deepcopy 原样返回」 |
+| 2 | `adapters/http/openapi_v1/bots/router.py`（`_to_bot`） | 调用改为 `template_config_for_public`；`template_type` 空时仍返回 null（"null without a template" 契约不变） |
+| 3 | `core/bot_inventory/services/bot_inventory_service.py`（`_attach_page_templates`） | 同上改调用；attach 语义 verbatim |
+| 4 | `adapters/http/openapi_v1/bots/schemas.py` | `Bot`/`BotInventoryItem` 的 template_config description 改为 verbatim + 敏感提示 |
+
+不变的部分：
+
+- 「无 template → null」的 `template_type` 门控不变。
+- 深拷贝契约不变（调用方可安全变更返回值，不别名到存储快照）。
+- 创建路径的 PUBLIC 校验（server-managed 字段拒绝清单，包括用户传 `engine_form` → 422）不变——透传只放开**读**面。
+
+## 3. 对既有文档的修订
+
+- `2026-08-31-engine-vocabulary-template-form-design.md` §6 第 7 条验收
+  「`token`/`bot_template_config`（thetaKey）绝不出现（扫描断言）」——**被本决策撤销**，断言已改为「原样回显」。
+- `plans/2026-08-28-bot-template-space-fields.md` 记录的是当期实现（白名单），保留为历史，不回改。
+
+## 4. 钉死测试（已落地）
+
+- `tests/community/core/bot_management/test_template_public_view.py`：非 Mapping → None；`{}` 原样；全字段（含 `token`/`thetaKey`/`devflow_workflows`/`model`/`runtime`）等值透传；深拷贝不别名。
+- `test_bots_endpoints.py::test_list_bots_carries_template_snapshot_and_space`：/bots 列表全量等值。
+- `inventory/test_inventory_handlers.py::test_list_inventory_carries_template_snapshot_verbatim`：/all 全量等值。
+- `test_bot_inventory_service.py::test_page_slice_attaches_template_config_verbatim`：分页 attach 全量等值。

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py
@@ -113,7 +113,7 @@ from agentclaw.community.core.bot_inventory.policies.combo_policy import (
     assert_service_upgrade,
 )
 from agentclaw.community.core.bot_management.template_public_view import (
-    project_template_config_for_public,
+    template_config_for_public,
 )
 from agentclaw.community.core.bot_inventory.types import (
     BotInventoryItem as CoreItem,
@@ -191,12 +191,14 @@ def _require_service_capable_engine(bot_type: str, engine: str) -> None:
 def _to_bot(d: dict[str, Any], *, space: dict[str, Any] | None = None) -> Bot:
     """Adapt an internal bot ``to_dict()`` record to the public ``Bot`` schema.
 
-    ``template_config`` on the row is the stored engine snapshot (it may carry
-    secrets), so it passes through the core allowlist projection here — gated
-    on a truthy ``template_type`` so the detail path (whose attach is not
-    template-gated) honors the same "null without a template" contract the
-    listings publish. ``space`` is the owner-view summary the listing
-    endpoints resolve and pass in; other callers leave it null.
+    ``template_config`` on the row is the stored engine snapshot, returned
+    verbatim (2026-09-01 passthrough decision — an owner-scoped face echoes
+    the caller's own creation input, secrets included), detached via the core
+    deep-copy helper — gated on a truthy ``template_type`` so the detail path
+    (whose attach is not template-gated) honors the same "null without a
+    template" contract the listings publish. ``space`` is the owner-view
+    summary the listing endpoints resolve and pass in; other callers leave it
+    null.
     """
     engine = d.get("active_engine") or ""
     has_template = d.get("template_type") not in (None, "")
@@ -211,7 +213,7 @@ def _to_bot(d: dict[str, Any], *, space: dict[str, Any] | None = None) -> Bot:
         owner_entity_id=d.get("owner_id") or "",
         template_type=str(d["template_type"]) if has_template else None,
         template_config=(
-            project_template_config_for_public(d.get("template_config"))
+            template_config_for_public(d.get("template_config"))
             if has_template
             else None
         ),

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -117,10 +117,11 @@ class Bot(BaseModel):
     )
     template_config: dict | None = Field(
         default=None,
-        description="Server-projected template snapshot (display-safe subset; "
-        "secrets never returned). Null without a template. Includes the "
-        "server-managed 'engine_form' marker for bots whose runtime form "
-        "differs from the engine (e.g. engine_form='aicoding').",
+        description="Stored template snapshot, copied verbatim from the bot's "
+        "creation input (no field filtering). Null without a template. May "
+        "carry sensitive values the creator supplied (e.g. 'token', "
+        "'bot_template_config.ext_config.thetaKey') and the server-managed "
+        "'engine_form' marker — treat as sensitive.",
     )
     space: BusinessSpace | None = Field(
         default=None,
@@ -724,10 +725,11 @@ class BotInventoryItem(BaseModel):
     )
     template_config: dict | None = Field(
         default=None,
-        description="Server-projected template snapshot (display-safe subset; "
-        "secrets never returned). Null without a template. Includes the "
-        "server-managed 'engine_form' marker for bots whose runtime form "
-        "differs from the engine (e.g. engine_form='aicoding').",
+        description="Stored template snapshot, copied verbatim from the bot's "
+        "creation input (no field filtering). Null without a template. May "
+        "carry sensitive values the creator supplied (e.g. 'token', "
+        "'bot_template_config.ext_config.thetaKey') and the server-managed "
+        "'engine_form' marker — treat as sensitive.",
     )
     avatar_url: str | None = Field(
         default=None, description="Avatar URL for the bot, when configured."

--- a/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_inventory/services/bot_inventory_service.py
@@ -19,7 +19,7 @@ from agentclaw.community.core.bot_inventory.protocols import (
     ServiceEditLockPort,
 )
 from agentclaw.community.core.bot_management.template_public_view import (
-    project_template_config_for_public,
+    template_config_for_public,
 )
 from agentclaw.community.core.bot_inventory.services.lifecycle_view import (
     BotLifecycleView,
@@ -167,13 +167,17 @@ class BotInventoryService(BotInventoryServiceProtocol):
     def _attach_page_templates(
         self, items: list[BotInventoryItem]
     ) -> list[BotInventoryItem]:
-        """Project template_config onto the returned page slice only.
+        """Attach template_config onto the returned page slice only.
 
         The fan-out intentionally pulls rows with ``attach_templates=False``
         (one batched template read per 200-row page would tax every listing);
         this is the single place template snapshots enter the read model, and
         it sees only the page the caller will actually see — so the per-request
         template cost is one bounded read over ≤page_size ids.
+
+        Attach is verbatim (2026-09-01 passthrough decision): the stored
+        snapshot is deep-copied onto the read model, secrets included — the
+        listing is owner-scoped, so that echoes the caller's own input.
         """
         bot_ids = [item.bot_id for item in items if item.template_type]
         if not bot_ids:
@@ -186,13 +190,11 @@ class BotInventoryService(BotInventoryServiceProtocol):
             if not item.template_type:
                 enriched.append(item)
                 continue
-            projected = project_template_config_for_public(
-                ext_by_bot_id.get(item.bot_id)
-            )
-            if projected is None:
+            attached = template_config_for_public(ext_by_bot_id.get(item.bot_id))
+            if attached is None:
                 enriched.append(item)
                 continue
-            enriched.append(replace(item, template_config=projected))
+            enriched.append(replace(item, template_config=attached))
         return enriched
 
     def _attach_edit_locks(

--- a/src/backend/src/agentclaw/community/core/bot_management/template_public_view.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/template_public_view.py
@@ -1,54 +1,34 @@
-"""Public projection of ``ac_templates.ext`` (``template_config``).
+"""Public view of ``ac_templates.ext`` (``template_config``).
 
-``template_config`` stored engine-side legitimately carries secrets: the
-aicoding provisioning strategy persists ``bot_template_config.ext_config
-.thetaKey`` as an ``enc:v1:`` ciphertext, and the stable outer contract allows
-a plain ``token``. Listing responses must never echo either — an encrypted
-blob is still offline attack material and a replayable oracle.
+Decision (2026-09-01): the public query faces return the stored template
+snapshot **verbatim** — no allowlist filtering. The snapshot is exactly what
+the bot's creation input supplied, the query faces are owner-scoped (the
+caller is the owner or a delegate the owner authorized), and echoing
+``token`` / ``bot_template_config.ext_config.thetaKey`` therefore echoes the
+caller's own input rather than disclosing a secret. The previous allowlist
+projection was removed by that same decision; reverting to filtering is a
+product call, not a bug fix, and must go through it.
 
-Rules for this file:
-- Allowlist, never denylist: engine-owned extensions surface only when a key
-  is added here explicitly (plus security review). Default is "dropped".
-- The result is a fresh shallow+container copy: callers may mutate it without
-  aliasing the stored snapshot.
+The one rule that survives: the result is a fresh deep copy — callers may
+mutate it without ever aliasing the stored snapshot.
 """
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any, Mapping
 
-from agentclaw.community.core.workspace.runtime_identity import ENGINE_FORM_KEY
 
-#: Keys that are display-safe. Keep alphabetized.
-_PUBLIC_TEMPLATE_KEYS = (
-    "code_repos",
-    "devflow_workflow",
-    # Server-managed form marker (e.g. "aicoding" on bots created by folding
-    # the legacy aicoding engine into claude_code): the display-side way to
-    # tell an aicoding-form bot from a plain claude_code bot.
-    ENGINE_FORM_KEY,
-    "template_key",
-    "template_uid",
-    "yuque_kb_repos",
-)
-
-
-def project_template_config_for_public(
+def template_config_for_public(
     config: Mapping[str, Any] | None,
 ) -> dict[str, Any] | None:
-    """Project a stored template snapshot onto its public display subset."""
-    if not isinstance(config, Mapping) or not config:
+    """Return the stored template snapshot, detached, for public responses.
+
+    ``None`` for anything that is not a mapping (a missing template row); a
+    verbatim deep copy otherwise — including secrets such as ``token`` and
+    ``bot_template_config.ext_config.thetaKey``, per the 2026-09-01
+    passthrough decision.
+    """
+    if not isinstance(config, Mapping):
         return None
-    if not any(key in config for key in _PUBLIC_TEMPLATE_KEYS):
-        return None
-    projected: dict[str, Any] = {}
-    for key in _PUBLIC_TEMPLATE_KEYS:
-        if key in config:
-            value = config[key]
-            if isinstance(value, list):
-                projected[key] = list(value)
-            elif isinstance(value, dict):
-                projected[key] = dict(value)
-            else:
-                projected[key] = value
-    return projected
+    return deepcopy(config)

--- a/src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/inventory/test_inventory_handlers.py
@@ -45,14 +45,14 @@ CLOUD = {
 
 
 class _TemplatePortStub:
-    """Hands one stored snapshot back — including the secrets that must not
-    survive the wire — so the handler test pins the projection end to end."""
+    """Hands one stored snapshot back — secrets included — so the handler test
+    pins the verbatim passthrough end to end."""
 
     def list_template_configs_by_bot_ids(self, bot_ids):
         return {
             "c1": {
                 "devflow_workflow": "release-notes",
-                "token": "must-not-leak",
+                "token": "echoed-to-owner",
                 "bot_template_config": {"ext_config": {"thetaKey": "enc:v1:x"}},
                 "runtime": "codefuse",
             }
@@ -131,16 +131,21 @@ def test_list_inventory_combines_personal_cloud_and_local(client):
     assert ids == {"c1", "l1"}
 
 
-def test_list_inventory_carries_projected_template_fields(client):
+def test_list_inventory_carries_template_snapshot_verbatim(client):
     data = _ok(client.get("/openapi/v1/bots/all"))
 
     by_id = {item["bot_id"]: item for item in data["items"]}
     cloud = by_id["c1"]
+    # The stored snapshot reaches the wire verbatim — the passthrough decision
+    # (2026-09-01): an owner-scoped face echoes the caller's own creation
+    # input, secrets included, with no allowlist filtering.
     assert cloud["template_type"] == "applicationCoding"
-    assert cloud["template_config"] == {"devflow_workflow": "release-notes"}
-    assert "token" not in cloud["template_config"]
-    assert "bot_template_config" not in cloud["template_config"]
-    assert "runtime" not in cloud["template_config"]
+    assert cloud["template_config"] == {
+        "devflow_workflow": "release-notes",
+        "token": "echoed-to-owner",
+        "bot_template_config": {"ext_config": {"thetaKey": "enc:v1:x"}},
+        "runtime": "codefuse",
+    }
     # Desktop rows carry no template identity.
     assert by_id["l1"]["template_type"] is None
     assert by_id["l1"]["template_config"] is None

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -83,11 +83,12 @@ BOT = {
     "entity_id": "u1",
     "entity_type": "staff",
     "device_binding": {"device_id": "dev-9"},
-    # Stored template snapshot: the wire must keep only the allowlisted keys.
+    # Stored template snapshot: returned on the wire verbatim (2026-09-01
+    # passthrough decision — owner-scoped faces echo the caller's own input).
     "template_type": "applicationCoding",
     "template_config": {
         "devflow_workflow": "release-notes",
-        "token": "must-not-leak",
+        "token": "echoed-to-owner",
         "bot_template_config": {"ext_config": {"thetaKey": "enc:v1:x"}},
         "runtime": "codefuse",
     },
@@ -251,16 +252,19 @@ def test_list_bots(client):
     assert data["items"][0]["bot_id"] == "b1"
 
 
-def test_list_bots_carries_template_projection_and_space(client):
+def test_list_bots_carries_template_snapshot_and_space(client):
     data = _ok(client.get("/openapi/v1/bots"))
     item = data["items"][0]
-    # The stored snapshot's secrets never reach the wire; only the
-    # allowlisted display keys survive.
+    # The stored snapshot reaches the wire verbatim — the passthrough decision
+    # (2026-09-01): an owner-scoped face echoes the caller's own creation
+    # input, secrets included, with no allowlist filtering.
     assert item["template_type"] == "applicationCoding"
-    assert item["template_config"] == {"devflow_workflow": "release-notes"}
-    assert "token" not in item["template_config"]
-    assert "bot_template_config" not in item["template_config"]
-    assert "runtime" not in item["template_config"]
+    assert item["template_config"] == {
+        "devflow_workflow": "release-notes",
+        "token": "echoed-to-owner",
+        "bot_template_config": {"ext_config": {"thetaKey": "enc:v1:x"}},
+        "runtime": "codefuse",
+    }
     # A NULL ac_bots.space_id resolves to the owner's synthetic personal space.
     space = item["space"]
     assert space["kind"] == "personal"

--- a/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
+++ b/src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
@@ -713,10 +713,10 @@ def _template_bot(bot_id: str, row_id: int) -> dict:
 
 
 @pytest.mark.unit
-def test_page_slice_attaches_projected_template_config() -> None:
+def test_page_slice_attaches_template_config_verbatim() -> None:
     # Three template-backed bots, page_size=2 -> the port sees only the
-    # returned page's template-backed ids, and the stored ext is projected
-    # (token stripped) before it reaches the read model.
+    # returned page's template-backed ids, and the stored ext is attached
+    # verbatim (2026-09-01 passthrough decision — secrets echo to the owner).
     stub = _StubTemplatePort(
         {
             "b1": {"devflow_workflow": "w1", "token": "raw-secret"},
@@ -746,8 +746,8 @@ def test_page_slice_attaches_projected_template_config() -> None:
     assert len(stub.calls) == 1
     assert set(stub.calls[0]) == {"b1", "b2"}
     assert items[0].template_type == "applicationCoding"
-    assert items[0].template_config == {"devflow_workflow": "w1"}
-    assert items[1].template_config == {"template_key": "normalCC"}
+    assert items[0].template_config == {"devflow_workflow": "w1", "token": "raw-secret"}
+    assert items[1].template_config == {"template_key": "normalCC", "runtime": "codefuse"}
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/bot_management/test_template_public_view.py
+++ b/src/backend/tests/community/core/bot_management/test_template_public_view.py
@@ -1,11 +1,13 @@
-"""Allowlist projection of ``template_config`` for public responses.
+"""Verbatim passthrough of ``template_config`` for public responses.
 
-``ac_templates.ext`` legitimately stores engine secrets: the aicoding
-provisioning strategy persists ``bot_template_config.ext_config.thetaKey`` as
-an ``enc:v1:`` ciphertext, and the stable outer contract allows a plain
-``token``. The public listing faces must never echo either, and engine-owned
-extensions must default to "not surfaced" rather than "passed through" — this
-matrix pins that.
+``ac_templates.ext`` stores the template snapshot exactly as the creation
+input supplied it. Decision (2026-09-01): the public query faces return that
+snapshot **verbatim** — the caller is the owner (or a delegate the owner
+authorized), so echoing ``token`` / ``bot_template_config.ext_config.thetaKey``
+is echoing the caller's own input rather than disclosing a secret. The allowlist
+projection this module used to enforce was removed deliberately; this matrix
+pins the passthrough contract plus the one remaining rule: the result is a
+fresh deep copy, never an alias of the stored snapshot.
 """
 
 from __future__ import annotations
@@ -13,27 +15,40 @@ from __future__ import annotations
 import pytest
 
 from agentclaw.community.core.bot_management.template_public_view import (
-    project_template_config_for_public,
+    template_config_for_public,
 )
 
 
 def test_none_in_gives_none_out():
-    assert project_template_config_for_public(None) is None
+    assert template_config_for_public(None) is None
 
 
-def test_empty_dict_gives_none_out():
-    assert project_template_config_for_public({}) is None
+def test_non_mapping_in_gives_none_out():
+    assert template_config_for_public("not-a-mapping") is None
+    assert template_config_for_public([("k", "v")]) is None
 
 
-def test_allowlisted_keys_survive():
+def test_empty_dict_is_returned_verbatim():
+    # No truthiness collapsing: an empty stored object is an empty object,
+    # not a missing one.
+    assert template_config_for_public({}) == {}
+
+
+def test_snapshot_passes_through_unchanged():
     config = {
         "devflow_workflow": "release-notes",
+        "devflow_workflows": [{"path": "release-notes"}, {"path": "trivial"}],
         "yuque_kb_repos": ["team/kb"],
         "code_repos": ["team/svc"],
         "template_key": "normalCC",
         "template_uid": "tpl-1",
+        "model": "qwen",
+        "runtime": "codefuse",
+        "engine_form": "aicoding",
+        "bot_template_config": {"ext_config": {"thetaKey": "enc:v1:deadbeef"}},
+        "token": "Bearer raw-secret",
     }
-    assert project_template_config_for_public(config) == config
+    assert template_config_for_public(config) == config
 
 
 @pytest.mark.parametrize(
@@ -44,24 +59,25 @@ def test_allowlisted_keys_survive():
             "devflow_workflow": "w",
             "bot_template_config": {"ext_config": {"thetaKey": "enc:v1:deadbeef"}},
         },
-        {"devflow_workflow": "w", "runtime": "codefuse"},
-        {"devflow_workflow": "w", "anything_engine_owned": {"nested": "blob"}},
     ],
 )
-def test_everything_else_is_dropped(secret_config):
-    projected = project_template_config_for_public(secret_config)
-    assert projected == {"devflow_workflow": "w"}
-
-
-def test_projection_of_only_secrets_gives_none():
-    config = {"token": "Bearer raw-secret"}
-    assert project_template_config_for_public(config) is None
+def test_secret_fields_are_echoed_to_the_owner(secret_config):
+    # The 2026-09-01 decision: owner-scoped query faces echo the caller's own
+    # creation input, secrets included. Pinned so a future revert is a
+    # conscious, logged decision rather than silent drift.
+    assert template_config_for_public(secret_config) == secret_config
 
 
 def test_result_is_not_aliased_with_input():
-    config = {"devflow_workflow": "w", "yuque_kb_repos": ["a"]}
-    projected = project_template_config_for_public(config)
-    projected["yuque_kb_repos"].append("mutated")
-    projected["devflow_workflow"] = "mutated"
+    config = {
+        "devflow_workflow": "w",
+        "yuque_kb_repos": ["a"],
+        "bot_template_config": {"ext_config": {"thetaKey": "v"}},
+    }
+    result = template_config_for_public(config)
+    result["yuque_kb_repos"].append("mutated")
+    result["devflow_workflow"] = "mutated"
+    result["bot_template_config"]["ext_config"]["thetaKey"] = "mutated"
     assert config["yuque_kb_repos"] == ["a"]
     assert config["devflow_workflow"] == "w"
+    assert config["bot_template_config"]["ext_config"]["thetaKey"] == "v"

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -541,7 +541,7 @@
                 "type": "null"
               }
             ],
-            "description": "Server-projected template snapshot (display-safe subset; secrets never returned). Null without a template. Includes the server-managed 'engine_form' marker for bots whose runtime form differs from the engine (e.g. engine_form='aicoding').",
+            "description": "Stored template snapshot, copied verbatim from the bot's creation input (no field filtering). Null without a template. May carry sensitive values the creator supplied (e.g. 'token', 'bot_template_config.ext_config.thetaKey') and the server-managed 'engine_form' marker — treat as sensitive.",
             "title": "Template Config"
           },
           "template_type": {
@@ -1302,7 +1302,7 @@
                 "type": "null"
               }
             ],
-            "description": "Server-projected template snapshot (display-safe subset; secrets never returned). Null without a template. Includes the server-managed 'engine_form' marker for bots whose runtime form differs from the engine (e.g. engine_form='aicoding').",
+            "description": "Stored template snapshot, copied verbatim from the bot's creation input (no field filtering). Null without a template. May carry sensitive values the creator supplied (e.g. 'token', 'bot_template_config.ext_config.thetaKey') and the server-managed 'engine_form' marker — treat as sensitive.",
             "title": "Template Config"
           },
           "template_type": {


### PR DESCRIPTION
## Problem

老平台 API 创建的 aicoding bot，经新平台 openapi 查询接口（`GET /openapi/v1/bots`、`GET /openapi/v1/bots/all`、`GET /openapi/v1/bots/{bot_id}`）返回时，template_config 的字段缺失：`devflow_workflows`（复数，引擎读路径的权威键）、`model`/`runtime`、`bot_template_config`、`token` 等被白名单投影静默丢弃，与老平台查询面（原样回传 `ac_templates.ext`）行为不一致。

## Solution

产品拍板（2026-09-01）：查询面改为**全字段原样透传**，不做任何白名单过滤。三个查询面均为 owner-scoped，回显的是调用方自己传入的创建输入；`token`/`thetaKey` 回显风险已由平台负责人确认接受（决策记录见 `docs/superpowers/specs/2026-09-01-template-config-passthrough-decision.md`）。

- `core/bot_management/template_public_view.py`：删除 `_PUBLIC_TEMPLATE_KEYS` 白名单；`project_template_config_for_public` 改名 `template_config_for_public`（非 Mapping → None，否则 deepcopy 原样返回）
- `/bots`（`_to_bot`）与 `/all`（`_attach_page_templates`）两个 attach 点改调透传；"null without a template" 门控不变；创建路径 PUBLIC 校验（server-managed 字段拒绝，含 `engine_form`→422）不变，**只放开读面**
- `Bot`/`BotInventoryItem` 的 template_config 字段描述改为 verbatim + 敏感提示；本仓 gateway `bots.openapi.json` 两处描述手工同步（ocb 仓同文件已同步至其工作区，随 ocb 发布流程提交）
- 测试改钉透传契约：非 Mapping→None、`{}` 原样、全字段等值（含 `token`/`thetaKey` 回显断言）、深拷贝不别名
- 规格：2026-08-31 引擎词汇规格的「token/thetaKey 绝不出现」验收条款加修订注记（被本决策撤销）

## Validation

- `src/backend/scripts/ci_test.sh --base origin/REL20260901`：16007 passed / 58 skipped；case pass rate 100%；line coverage 88.06%（≥75%）；**changed-line coverage 100%（7/7，≥80%）**
- gateway `scripts/ci_test.sh`：gate passed（描述性 JSON 改动无可执行行）
- `python_sast_local.sh`：通过
- 期间一次 E3 架构测试失败为本地 worktree 的 `__pycache__` 孤儿目录残留（w11 分支切换残留）导致，清理后通过，与本 PR 改动无关

## Test Plan

- [ ] CI 承接 singlebox coverage gate（本机环境限制无法运行）
- [ ] ocb 仓 `bots.openapi.json` 描述同步随其发布流程提交
- [ ] 预发回归：老 API 创建的 aicoding bot 经 /openapi/v1/bots 与 /all 返回完整 template_config