### PR TITLE
fix(backend): persist Center SkillSet membership identity

### DIFF
--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/bot_skillset_installations.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/bot_skillset_installations.py
@@ -6,7 +6,7 @@ range over every Set a Bot has and answer what its Installation table should say
 
 from __future__ import annotations
 
-from sqlalchemy import and_, func
+from sqlalchemy import and_, func, or_
 
 from agentclaw.community.core.models.mcp import SkillSetMCPServer
 from agentclaw.community.core.models.skill import (
@@ -25,7 +25,25 @@ from agentclaw.community.core.repository.implementations.skill_center.tables imp
 from agentclaw.community.core.repository.capability_desired_state_types import (
     InstallationFlushPlan,
 )
+from agentclaw.community.core.skill_center.errors import (
+    SkillSetControlPlaneConflictError,
+)
 from agentclaw.community.utils.env_utils import get_current_env
+
+
+CENTER_MEMBERSHIP_IDENTITY_MISSING = "CENTER_MEMBERSHIP_IDENTITY_MISSING"
+
+
+def center_membership_skill_uuid(skill: Skill) -> str | None:
+    """Return the stable Membership identity required by a Center Skill."""
+    if not str(skill.git_path or "").startswith("center://"):
+        return None
+    skill_uuid = str(skill.skill_uuid or "").strip()
+    if not skill_uuid:
+        raise SkillSetControlPlaneConflictError(
+            CENTER_MEMBERSHIP_IDENTITY_MISSING
+        )
+    return skill_uuid
 
 
 def set_member_skill_ids(scope, session, *, skill_set_id: int) -> set[int]:
@@ -36,6 +54,25 @@ def set_member_skill_ids(scope, session, *, skill_set_id: int) -> set[int]:
     the highest PUBLISHED version, everything else joins by ``skill_id``.
     """
     env = get_current_env()
+
+    malformed_center = (
+        scope(session.query(SkillSetSkill.id), SkillSetSkill)
+        .join(Skill, SkillSetSkill.skill_id == Skill.id)
+        .filter(
+            SkillSetSkill.skill_set_id == skill_set_id,
+            SkillSetSkill.env == env,
+            Skill.git_path.like("center://%"),
+            or_(
+                SkillSetSkill.skill_uuid.is_(None),
+                func.trim(SkillSetSkill.skill_uuid) == "",
+            ),
+        )
+        .first()
+    )
+    if malformed_center is not None:
+        raise SkillSetControlPlaneConflictError(
+            CENTER_MEMBERSHIP_IDENTITY_MISSING
+        )
 
     def ids(query) -> set[int]:
         return {int(row[0]) for row in query.all()}

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/capability_desired_state.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/capability_desired_state.py
@@ -33,6 +33,8 @@ from agentclaw.community.core.repository.protocols.capability_desired_state impo
 )
 from agentclaw.community.core.repository.implementations.skill_center.bot_skillset_installations import (
     BotSkillSetInstallations,
+    CENTER_MEMBERSHIP_IDENTITY_MISSING,
+    center_membership_skill_uuid,
     set_member_skill_ids,
 )
 from agentclaw.community.core.repository.implementations.skill_center.default_exclusion_commands import (
@@ -329,6 +331,7 @@ class CapabilityDesiredStateRepository(
             ):
                 raise SkillSetControlPlaneNotFoundError()
             require_skill_online(skill)
+            membership_skill_uuid = center_membership_skill_uuid(skill)
             old = self._snapshot(
                 session, bot_id, owner_id, engine_type=engine_type
             )
@@ -341,6 +344,13 @@ class CapabilityDesiredStateRepository(
                 .first()
             )
             if current is not None:
+                if (
+                    membership_skill_uuid is not None
+                    and current.skill_uuid != membership_skill_uuid
+                ):
+                    raise SkillSetControlPlaneConflictError(
+                        CENTER_MEMBERSHIP_IDENTITY_MISSING
+                    )
                 return DesiredStateMutation(_item(row), False, old)
             # R3 covers ANY of the Bot's Sets — the Default included, its
             # members excluded or not.
@@ -382,6 +392,7 @@ class CapabilityDesiredStateRepository(
                 SkillSetSkill(
                     skill_set_id=row.id,
                     skill_id=skill.id,
+                    skill_uuid=membership_skill_uuid,
                     user_id=row.user_id,
                     env=get_current_env(),
                     avernet_tenant=get_current_avernet_tenant(),

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/skill.py
@@ -52,8 +52,15 @@ from injector import inject
 from sqlalchemy import and_, func, or_
 
 from agentclaw.community.log import get_logger
-from agentclaw.community.core.skill_center.errors import ActiveSkillSetReferenceError
+from agentclaw.community.core.skill_center.errors import (
+    ActiveSkillSetReferenceError,
+    SkillSetControlPlaneConflictError,
+)
 from agentclaw.community.core.skill_center.offline_policy import require_skill_online
+from agentclaw.community.core.repository.implementations.skill_center.bot_skillset_installations import (
+    CENTER_MEMBERSHIP_IDENTITY_MISSING,
+    center_membership_skill_uuid,
+)
 from agentclaw.community.plugin_api.database import DatabasePlugin
 from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
 from agentclaw.community.utils.env_utils import get_current_env
@@ -1487,10 +1494,11 @@ class SkillSetRepository(
             if skill_set is None or skill is None:
                 return False
             require_skill_online(skill)
+            membership_skill_uuid = center_membership_skill_uuid(skill)
             # Existing membership remains the successful idempotent result.
             # Canonical cross-Set uniqueness is enforced by the new control
             # plane under its Bot mutation lease, not by this legacy writer.
-            if (
+            existing_membership = (
                 db.query(self.SkillSetSkill)
                 .filter(
                     self.SkillSetSkill.skill_set_id == int(skill_set_id),
@@ -1498,13 +1506,21 @@ class SkillSetRepository(
                     self.SkillSetSkill.env == get_current_env(),
                 )
                 .first()
-                is not None
-            ):
+            )
+            if existing_membership is not None:
+                if (
+                    membership_skill_uuid is not None
+                    and existing_membership.skill_uuid != membership_skill_uuid
+                ):
+                    raise SkillSetControlPlaneConflictError(
+                        CENTER_MEMBERSHIP_IDENTITY_MISSING
+                    )
                 return True
             db.add(
                 self.SkillSetSkill(
                     skill_set_id=int(skill_set_id),
                     skill_id=int(skill_id),
+                    skill_uuid=membership_skill_uuid,
                     user_id=_normalize_user_id(user_id),
                     env=get_current_env(),
                 )

--- a/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
@@ -1570,6 +1570,59 @@ def test_repair_resolves_a_center_member_by_uuid_not_by_stored_skill_id():
         } == {1}
 
 
+def test_repair_rejects_a_center_membership_without_its_stable_uuid():
+    """A malformed Center membership must not disappear from desired state.
+
+    Runtime projection selects mapping-v3 only after Installation exposes a
+    Center asset. Silently resolving this row to no Skill would let an active
+    SkillSet report success while publishing only its Local/Repo mappings.
+    """
+    db = _Database()
+    with db.transactional_orm_session() as session:
+        skill_set = SkillSet(
+            name="active",
+            bolt_id="bot",
+            user_id="owner",
+            engine_type="openclaw",
+            is_active=True,
+            env="dev",
+        )
+        skill = Skill(
+            name="center",
+            git_path="center://public-center",
+            skill_uuid="stable-center-uuid",
+            version=1,
+            status="PUBLISHED",
+            env="dev",
+        )
+        session.add_all([skill_set, skill])
+        session.flush()
+        session.add(
+            SkillSetSkill(
+                skill_set_id=skill_set.id,
+                skill_id=skill.id,
+                skill_uuid=None,
+                env="dev",
+            )
+        )
+
+    repository = CapabilityDesiredStateRepository(db)
+
+    with pytest.raises(
+        SkillSetControlPlaneConflictError,
+        match="CENTER_MEMBERSHIP_IDENTITY_MISSING",
+    ):
+        repository.flush_installations(
+            bot_id="bot",
+            owner_id="owner",
+            env="dev",
+            engine_type="openclaw",
+        )
+
+    with db.orm_session() as session:
+        assert session.query(BotSkillInstallation).count() == 0
+
+
 class _FailingInsertSession:
     """A session whose BotSkillInstallation insert fails without persisting.
 
@@ -2811,6 +2864,58 @@ def test_add_skill_reports_the_skill_s_mcp_dependencies():
 
     # Both stored shapes decode, through the same decoder the projection uses.
     assert result.mcp_codes == frozenset({"mcp.weather", "mcp.maps"})
+
+
+def test_add_center_skill_persists_uuid_and_later_activation_installs_it():
+    db = _Database()
+    repository = CapabilityDesiredStateRepository(db)
+    with db.transactional_orm_session() as session:
+        skill = Skill(
+            name="center",
+            git_path="center://public-center",
+            skill_uuid="stable-center-uuid",
+            version=1,
+            status="PUBLISHED",
+            env="dev",
+        )
+        skill_set = SkillSet(
+            name="set",
+            user_id="owner",
+            bolt_id="bot",
+            engine_type="openclaw",
+            is_active=False,
+            env="dev",
+        )
+        session.add_all([skill, skill_set])
+        session.flush()
+        skill_id = str(skill.id)
+        set_id = str(skill_set.id)
+
+    repository.add_skill(
+        bot_id="bot",
+        owner_id="owner",
+        set_id=set_id,
+        skill_id=skill_id,
+        engine_type="openclaw",
+    )
+
+    with db.orm_session() as session:
+        membership = session.query(SkillSetSkill).one()
+        assert membership.skill_uuid == "stable-center-uuid"
+
+    repository.set_skill_set_active(
+        bot_id="bot",
+        owner_id="owner",
+        set_id=set_id,
+        active=True,
+        engine_type="openclaw",
+    )
+
+    with db.orm_session() as session:
+        assert {
+            installation.skill_id
+            for installation in session.query(BotSkillInstallation).all()
+        } == {int(skill_id)}
 
 
 def test_add_skill_reports_no_dependencies_when_the_skill_declares_none():

--- a/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
+++ b/src/backend/tests/community/repository/skill_center/test_skill_repository_unified.py
@@ -735,6 +735,27 @@ def test_add_remove_skill_to_set(skills, sets):
     assert sets.get_skills_in_set(ss["id"]) == []
 
 
+def test_legacy_add_center_skill_to_set_persists_membership_uuid(
+    skills, sets, db
+):
+    skill = skills.create(
+        {
+            "name": "center",
+            "git_path": "center://public-center",
+            "skill_uuid": "stable-center-uuid",
+            "status": "PUBLISHED",
+            "version": 1,
+        }
+    )
+    skill_set = sets.create({"name": "set"})
+
+    assert sets.add_skill_to_set(skill_set["id"], skill["id"]) is True
+
+    with db.orm_session() as session:
+        membership = session.query(SkillSetSkill).one()
+        assert membership.skill_uuid == "stable-center-uuid"
+
+
 def test_legacy_center_version_rows_are_rejected_by_stable_uuid_constraint(skills, sets):
     sets.create({"name": "cset"})
     skills.create(


### PR DESCRIPTION
## Problem

Center SkillSet membership writes persisted only the numeric `skill_id`, while runtime installation resolution identifies Center memberships by `skill_uuid`. A missing UUID could therefore make a Center Skill disappear from the resolved installation set and publish an incomplete runtime mapping while the activation flow appeared successful.

## Solution

- Persist `skill_uuid` when canonical and legacy repository paths add a Center Skill to a SkillSet.
- Reject malformed existing Center memberships with `CENTER_MEMBERSHIP_IDENTITY_MISSING` instead of silently omitting them during installation resolution.
- Add regression coverage for canonical writes, legacy writes, later activation, and fail-closed handling of malformed data.

## Validation

- Rebased onto `github/REL20260901` at `2888fc380` without conflicts.
- Focused repository tests: `116 passed, 5 skipped`.
- Equivalent patch before the unrelated target-branch advance passed the full Backend suite: `16015 passed, 58 skipped`; Backend CI gate and changed-line coverage gate passed.
- `git diff --check github/REL20260901...HEAD` passed.

## Compatibility and risk

No API or schema change. Existing Center membership rows with a missing `skill_uuid` will now fail closed instead of being silently dropped, so those rows must be backfilled before this code is deployed. The data correction is intentionally kept outside this PR.