### PR TITLE
fix(backend): re-address the principal token before the BCN friend callback

### DIFF
--- a/src/backend/src/agentclaw/community/core/gateway_principal/README.md
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/README.md
@@ -10,6 +10,14 @@ earns the right to believe that header: signature, `aud` (this component), `iss`
 agrees on one non-empty tenant. Any failure is total — there is no partial trust
 and no fallback.
 
+`signer.py` is the same contract read backwards: when this component has to call
+a second one *as the caller* — the friend-approval decision applying to BCN — the
+inbound token cannot be relayed, because the gateway addresses each token to one
+upstream and BCN refuses ours. So a verified token is **re-addressed**: same
+identities, same lifetime, new `iss`/`aud`/`kid`. Verification comes first and is
+not optional there — a function that signed an unverified payload would be a
+token-minting oracle for every component that trusts the shared key.
+
 Nothing here reads a framework, a header, the environment, or a secret store
 (Rule 7). The HTTP seam lives in `adapters/http/openapi_v1/dependencies.py`; the
 config — including resolving the shared signing key through `SecretResolver` —
@@ -18,7 +26,7 @@ in `utils/gateway_principal_config.py`.
 ## Context Boundary
 
 ```yaml
-purpose: Verify the gateway-signed forwarded principal and project it onto backend caller DTOs.
+purpose: Verify the gateway-signed forwarded principal, project it onto backend caller DTOs, and re-address a verified token to a second upstream.
 provides:
   - GatewayPrincipal
   - UserPrincipal
@@ -31,14 +39,19 @@ provides:
   - GatewayAccessKey
   - PrincipalType
   - PrincipalVerifierConfig
+  - PrincipalSignerConfig
   - VerifiedCaller
   - verify_principal_token
+  - decode_principal_token
+  - caller_from_claims
+  - resign_principal_token
   - key_fingerprint
   - is_weak_signing_key
   - MIN_SIGNING_KEY_BYTES
   - PrincipalVerificationError
 consumes:
   - "Gateway PrincipalSigner (the signing half of the contract, in src/gateway)"
+  - "BCS/BCN GatewayPrincipalTokenVerifier (the target of a re-addressed token, in src/bcs)"
 internal_dependencies:
   - agentclaw.community.utils
 ```
@@ -64,6 +77,19 @@ an unknown field; and a set naming two tenants is still refused. The load-bearin
 assumption is therefore narrower than before — that the gateway registers
 `teamclaw` only to first-party apps. If that stops being true, this guard is what
 has to come back.
+
+**Added 2026-09-01 — this module now signs, not only verifies.** `signer.py`
+re-addresses a verified token so the backend can call BCN as the caller
+(`core/work_orders/callbacks.py`). Three properties hold the boundary and must
+survive any change to it: the original is fully verified — signature, `aud`,
+`exp`, *and* the identity-set admission — before anything is signed; the copy
+carries the original's `principals` and `exp` unchanged, so it names the same
+caller and dies at the same moment; and the target's `iss`/`aud`/`kid` come from
+config rather than from the inbound token. Relaxing the first turns this
+component into a token-minting oracle for everything that trusts the shared key.
+BCN's requirements are pinned in `utils/gateway_principal_config.py` and
+published in `src/bcs/api-contracts/v1/gateway-principal/contract.md`; the two
+must move together.
 
 The DTOs mirror the gateway's `spi/authn/_models.py` wire shape. Unknown fields
 are ignored, so the gateway can add one freely; a **rename or removal** on its

--- a/src/backend/src/agentclaw/community/core/gateway_principal/README.md
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/README.md
@@ -84,12 +84,16 @@ re-addresses a verified token so the backend can call BCN as the caller
 survive any change to it: the original is fully verified — signature, `aud`,
 `exp`, *and* the identity-set admission — before anything is signed; the copy
 carries the original's `principals` and `exp` unchanged, so it names the same
-caller and dies at the same moment; and the target's `iss`/`aud`/`kid` come from
-config rather than from the inbound token. Relaxing the first turns this
-component into a token-minting oracle for everything that trusts the shared key.
-BCN's requirements are pinned in `utils/gateway_principal_config.py` and
-published in `src/bcs/api-contracts/v1/gateway-principal/contract.md`; the two
-must move together.
+caller and dies at the same moment; and the new envelope comes from config
+rather than from the inbound token. Relaxing the first turns this component into
+a token-minting oracle for everything that trusts the shared key.
+
+`aud` and `kid` are the target's requirements; `iss` is **ours** — a token this
+component signs is issued by this component, whatever the claims inside assert —
+so the target has to trust that issuer. Both ends are pinned in
+`utils/gateway_principal_config.py`, against BCN's contract in
+`src/bcs/api-contracts/v1/gateway-principal/contract.md`; the two must move
+together.
 
 The DTOs mirror the gateway's `spi/authn/_models.py` wire shape. Unknown fields
 are ignored, so the gateway can add one freely; a **rename or removal** on its

--- a/src/backend/src/agentclaw/community/core/gateway_principal/__init__.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/__init__.py
@@ -1,9 +1,10 @@
 """Gateway principal verification — the backend half of auth design §7.1.
 
 Verifies the gateway-signed ``X-Avernet-Principal`` token and projects it onto
-backend DTOs. The HTTP seam that uses this lives in
-``adapters/http/openapi_v1/dependencies.py``; the environment-driven config in
-``utils/gateway_principal_config.py``.
+backend DTOs, and re-addresses a verified token to a second upstream when this
+component has to call one on the caller's behalf (:mod:`.signer`). The HTTP seam
+that uses this lives in ``adapters/http/openapi_v1/dependencies.py``; the
+environment-driven config in ``utils/gateway_principal_config.py``.
 """
 
 from __future__ import annotations
@@ -23,10 +24,16 @@ from agentclaw.community.core.gateway_principal.models import (
     PrincipalType,
     UserPrincipal,
 )
+from agentclaw.community.core.gateway_principal.signer import (
+    PrincipalSignerConfig,
+    resign_principal_token,
+)
 from agentclaw.community.core.gateway_principal.verifier import (
     MIN_SIGNING_KEY_BYTES,
     PrincipalVerifierConfig,
     VerifiedCaller,
+    caller_from_claims,
+    decode_principal_token,
     is_weak_signing_key,
     key_fingerprint,
     verify_principal_token,
@@ -43,11 +50,15 @@ __all__ = [
     "GatewayPrincipal",
     "GatewayUser",
     "PrincipalType",
+    "PrincipalSignerConfig",
     "PrincipalVerificationError",
     "PrincipalVerifierConfig",
     "UserPrincipal",
     "VerifiedCaller",
+    "caller_from_claims",
+    "decode_principal_token",
     "is_weak_signing_key",
     "key_fingerprint",
+    "resign_principal_token",
     "verify_principal_token",
 ]

--- a/src/backend/src/agentclaw/community/core/gateway_principal/signer.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/signer.py
@@ -9,10 +9,10 @@ for another component.
 Which leaves a gap the moment a component has to call a second one *on the
 caller's behalf*. The friend-approval flow is exactly that: the decision arrives
 at ``/openapi/v1`` with a token addressed to ``backend``, and applying it means
-calling BCN, which verifies the same shared key but requires ``aud=bcs`` (and
-its own ``iss``/``kid`` — see ``src/bcs/api-contracts/v1/gateway-principal/
-contract.md``). Forwarding the inbound header verbatim therefore fails at BCN's
-audience check, every time, and no amount of retrying changes that.
+calling BCN, which verifies the same shared key but requires ``aud=bcs`` (see
+``src/bcs/api-contracts/v1/gateway-principal/contract.md``). Forwarding the
+inbound header verbatim therefore fails at BCN's audience check, every time, and
+no amount of retrying changes that.
 
 This module re-addresses the token: same identities, same lifetime, new
 envelope. What it deliberately does not do is *mint* one. The original must
@@ -31,8 +31,13 @@ What survives the re-addressing, and why:
   fresh one on every hop, which is a lifetime extension nobody asked for.
 - every other claim — untouched, because a claim we do not understand is one
   BCN might, and dropping it is a decision this module has no basis to make.
-- ``iss``/``aud`` — replaced with what the target requires. These two *are* the
-  re-addressing.
+- ``aud`` — replaced with the target's name. Together with ``iss`` below, this
+  *is* the re-addressing.
+- ``iss`` — replaced with **the signing component's own name**, because that is
+  what an issuer claim means: the claims inside are still the gateway's
+  assertions, but the signature over this copy is ours, and a token that named
+  the gateway as its issuer would be claiming a provenance it does not have.
+  The target has to trust that issuer for the call to be accepted.
 - ``kid`` — set from the target's config rather than copied, because it names
   the key the target should verify with, and the key is ours, not the inbound
   token's to assert.
@@ -75,10 +80,12 @@ class PrincipalSignerConfig:
     deployment resolved none, and :func:`resign_principal_token` then refuses to
     sign rather than emitting a token signed with nothing.
 
-    ``audience``, ``issuer`` and ``key_id`` are the target's half of the
-    contract: what *it* requires to accept a token, not what we require to
-    accept one. They are fixed in code beside the verifier's own constants —
-    see ``utils/gateway_principal_config.py`` for why that is a deliberate call
+    ``audience`` and ``key_id`` are the target's half of the contract: what *it*
+    requires to accept a token, not what we require to accept one. ``issuer`` is
+    the other way round — it names the component doing the signing, so it is our
+    identity, and the target has to be configured to trust it. All three are
+    fixed in code beside the verifier's own constants — see
+    ``utils/gateway_principal_config.py`` for why that is a deliberate call
     rather than a missing knob.
     """
 

--- a/src/backend/src/agentclaw/community/core/gateway_principal/signer.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/signer.py
@@ -1,0 +1,141 @@
+"""Re-address a verified principal token to a second upstream.
+
+The gateway mints one ``X-Avernet-Principal`` per hop: it signs the identity set
+it resolved into a JWT whose ``aud`` names the upstream it is forwarding to, so
+a token minted for ``backend`` verifies at the backend and **nowhere else** —
+that is the property :mod:`.verifier` leans on when it refuses a token minted
+for another component.
+
+Which leaves a gap the moment a component has to call a second one *on the
+caller's behalf*. The friend-approval flow is exactly that: the decision arrives
+at ``/openapi/v1`` with a token addressed to ``backend``, and applying it means
+calling BCN, which verifies the same shared key but requires ``aud=bcs`` (and
+its own ``iss``/``kid`` — see ``src/bcs/api-contracts/v1/gateway-principal/
+contract.md``). Forwarding the inbound header verbatim therefore fails at BCN's
+audience check, every time, and no amount of retrying changes that.
+
+This module re-addresses the token: same identities, same lifetime, new
+envelope. What it deliberately does not do is *mint* one. The original must
+verify first — signature, issuer, audience, expiry, and the full identity-set
+admission — so the only thing this can produce is a re-addressed copy of a
+credential the gateway already vouched for. A function that signed whatever
+string it was handed would be a token-minting oracle for every upstream that
+trusts the shared key, reachable by anyone who can reach the caller side of it.
+
+What survives the re-addressing, and why:
+
+- ``principals`` — untouched. It is the identity BCN authorizes against; the
+  point of the exercise is that BCN sees the same caller we did.
+- ``exp``/``iat`` — untouched, so the copy dies exactly when the original does.
+  Re-stamping them would quietly turn a 60-second gateway credential into a
+  fresh one on every hop, which is a lifetime extension nobody asked for.
+- every other claim — untouched, because a claim we do not understand is one
+  BCN might, and dropping it is a decision this module has no basis to make.
+- ``iss``/``aud`` — replaced with what the target requires. These two *are* the
+  re-addressing.
+- ``kid`` — set from the target's config rather than copied, because it names
+  the key the target should verify with, and the key is ours, not the inbound
+  token's to assert.
+
+Transport-agnostic like the rest of this package (Rule 7): no header parsing, no
+environment reads, no secret store. ``utils/gateway_principal_config.py`` binds
+the configs; ``core/work_orders/callbacks.py`` is the caller.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import jwt
+
+from agentclaw.community.core.gateway_principal.errors import (
+    PrincipalVerificationError,
+)
+from agentclaw.community.core.gateway_principal.verifier import (
+    PrincipalVerifierConfig,
+    caller_from_claims,
+    decode_principal_token,
+    key_fingerprint,
+)
+
+# Pinned for the same reason :mod:`.verifier` pins its accept list: every peer on
+# this contract verifies HS256 with the shared key, and signing anything else
+# would either be rejected or — worse, on a laxer verifier — accepted as an
+# algorithm nobody agreed to.
+_ALGORITHM = "HS256"
+
+
+@dataclass(frozen=True)
+class PrincipalSignerConfig:
+    """Where a re-addressed principal token is going, and what signs it.
+
+    ``signing_key`` is the same HMAC secret :class:`PrincipalVerifierConfig`
+    holds — one shared key across the gateway and every component on this
+    contract, so re-signing needs no second credential. An empty key means the
+    deployment resolved none, and :func:`resign_principal_token` then refuses to
+    sign rather than emitting a token signed with nothing.
+
+    ``audience``, ``issuer`` and ``key_id`` are the target's half of the
+    contract: what *it* requires to accept a token, not what we require to
+    accept one. They are fixed in code beside the verifier's own constants —
+    see ``utils/gateway_principal_config.py`` for why that is a deliberate call
+    rather than a missing knob.
+    """
+
+    signing_key: str
+    audience: str
+    issuer: str
+    key_id: str
+
+    @property
+    def key_fingerprint(self) -> str:
+        """This config's key as :func:`key_fingerprint` renders it for a log."""
+        return key_fingerprint(self.signing_key)
+
+
+def resign_principal_token(
+    token: str,
+    *,
+    verifier: PrincipalVerifierConfig,
+    signer: PrincipalSignerConfig,
+) -> str:
+    """Return ``token``'s claims re-addressed to ``signer``'s upstream.
+
+    ``verifier`` is *this* component's config — the contract the inbound token
+    must satisfy — and ``signer`` is the target's. Both are needed: the first
+    decides whether there is anything worth re-addressing, the second decides
+    what the re-addressed copy says.
+
+    Raises:
+        PrincipalVerificationError: when the inbound token does not verify (bad
+            signature, expired, wrong audience, an identity set this surface
+            would refuse) or when no signing key is configured on either side.
+            One error type, as in :mod:`.errors`: a caller cannot act on the
+            distinction, and the message carries it for the log.
+    """
+    if not signer.signing_key:
+        # Same reading as an unconfigured verifier key, from the other side: we
+        # cannot produce a credential the target will believe, and a token
+        # signed with an empty key is not a lesser credential but a forgeable
+        # one.
+        raise PrincipalVerificationError(
+            "no principal signing key is configured, so no token can be "
+            f"re-addressed to aud={signer.audience!r}"
+        )
+
+    claims = decode_principal_token(token, verifier)
+    # The result is deliberately dropped: this is the admission gate, not a
+    # projection. Re-addressing an identity set this surface would answer 401
+    # to would hand the target a caller we ourselves refuse — so the same check
+    # every public route makes runs before anything is signed.
+    caller_from_claims(claims)
+
+    payload = dict(claims)
+    payload["iss"] = signer.issuer
+    payload["aud"] = signer.audience
+    return jwt.encode(
+        payload,
+        signer.signing_key,
+        algorithm=_ALGORITHM,
+        headers={"kid": signer.key_id},
+    )

--- a/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
+++ b/src/backend/src/agentclaw/community/core/gateway_principal/verifier.py
@@ -29,7 +29,9 @@ resolves the signing key through ``SecretResolver``.
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Any
 
 import jwt
 from pydantic import TypeAdapter, ValidationError
@@ -264,6 +266,37 @@ def verify_principal_token(
     expired, unparseable payload, contradictory tenants, an
     identity set naming neither an end user nor an application, or no signing
     key configured at all.
+
+    The two halves are also callable on their own — see
+    :func:`decode_principal_token` and :func:`caller_from_claims`. This is the
+    composition of them, and the only form any HTTP seam should reach for: a
+    caller that decodes without admitting has verified a signature and nothing
+    else.
+    """
+    return caller_from_claims(decode_principal_token(token, config))
+
+
+def decode_principal_token(
+    token: str, config: PrincipalVerifierConfig
+) -> dict[str, Any]:
+    """Return ``token``'s claims once its signature and time window check out.
+
+    The cryptographic half of :func:`verify_principal_token`: signature against
+    the shared key, ``alg`` pinned to :data:`_ALGORITHMS`, ``iss`` and (when
+    configured) ``aud`` value-checked, ``exp``/``iat``/``iss`` required to be
+    present, ``exp`` judged with :data:`_LEEWAY_SECONDS` of skew.
+
+    What comes back is **authenticated but not yet admitted**: the gateway
+    signed these claims, so they are not a caller's assertion — but nothing here
+    has looked at *who* they name, whether the identity set parses, or whether
+    the tenants agree. :func:`caller_from_claims` is that half, and any decision
+    about the caller belongs to it.
+
+    Separate from it because one consumer needs the claims themselves rather
+    than the caller they project onto: :mod:`.signer` re-addresses a verified
+    token to a second upstream, and re-addressing means preserving every claim
+    the gateway wrote (see that module). Every other consumer wants
+    :func:`verify_principal_token`.
     """
     if not config.signing_key:
         # No key means we cannot tell a gateway token from a forged one. The
@@ -312,6 +345,22 @@ def verify_principal_token(
             f"{_unverified_token_header(token)}]"
         ) from exc
 
+    return claims
+
+
+def caller_from_claims(claims: Mapping[str, Any]) -> VerifiedCaller:
+    """Project already-authenticated ``claims`` onto the caller they name.
+
+    The identity half of :func:`verify_principal_token`: the ``principals``
+    payload must parse onto :mod:`.models`, every principal that asserts a
+    tenant must agree on one, and the set must name an end user or an
+    application.
+
+    **Takes claims a signature has already vouched for**, which is the whole of
+    its precondition — it has no way to check that itself, so its only callers
+    are :func:`verify_principal_token` and :mod:`.signer`, each of which decodes
+    through :func:`decode_principal_token` first.
+    """
     principals = _parse_principals(claims.get("principals"))
     _reject_contradictory_tenant(principals)
     _require_admissible_principal(principals)

--- a/src/backend/src/agentclaw/community/core/work_orders/callbacks.py
+++ b/src/backend/src/agentclaw/community/core/work_orders/callbacks.py
@@ -5,12 +5,9 @@ from __future__ import annotations
 import hashlib
 import json
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import Annotated
 from urllib.parse import quote
-
-from injector import inject
 
 from agentclaw.community.core.work_orders.errors import (
     WorkOrderCallbackError,
@@ -24,14 +21,16 @@ from agentclaw.community.core.work_orders.models import (
     WorkOrderEventType,
 )
 from agentclaw.community.log import get_logger
-from agentclaw.community.plugin_api.http_client import (
-    QUALIFIER_BCN,
-    HttpClient,
-)
+from agentclaw.community.plugin_api.http_client import HttpClient
 
 
 logger = get_logger()
 _RESPONSE_BODY_LOG_LIMIT = 16 * 1024
+
+# The forwarded identity header, lowercased for the case-insensitive comparisons
+# below — HTTP header names are case-insensitive and the inbound spelling is
+# whatever the gateway and the ASGI server happened to use.
+_PRINCIPAL_HEADER = "x-avernet-principal"
 
 
 def _principal_fingerprint(headers: Mapping[str, str]) -> str | None:
@@ -39,11 +38,16 @@ def _principal_fingerprint(headers: Mapping[str, str]) -> str | None:
 
     The JWT itself is never logged; the short digest lets operators compare the
     approval request credential with the BCN callback credential.
+
+    Since the callback credential is **re-addressed** before it is sent (see
+    :meth:`FriendDecisionCallbackHandler.handle`), the two no longer share a
+    digest — a re-signed token is a different token. Both are logged, under
+    ``principal_fingerprint`` for what went to BCN and
+    ``source_principal_fingerprint`` for what arrived here, so the hop is still
+    correlatable from one log line to the next.
     """
     values = [
-        value
-        for key, value in headers.items()
-        if key.lower() == "x-avernet-principal"
+        value for key, value in headers.items() if key.lower() == _PRINCIPAL_HEADER
     ]
     if not values:
         return None
@@ -51,7 +55,7 @@ def _principal_fingerprint(headers: Mapping[str, str]) -> str | None:
 
 
 def _principal_header_count(headers: Mapping[str, str]) -> int:
-    return sum(key.lower() == "x-avernet-principal" for key in headers)
+    return sum(key.lower() == _PRINCIPAL_HEADER for key in headers)
 
 
 def _is_successful_bcn_response(payload: dict[str, object] | None) -> bool:
@@ -115,11 +119,85 @@ def validate_friend_approval_event(
 
 
 class FriendDecisionCallbackHandler:
-    """Apply a friend-request decision to BCN before local persistence."""
+    """Apply a friend-request decision to BCN before local persistence.
 
-    def __init__(self, http_client: HttpClient, timeout: float = 10.0) -> None:
+    The decision arrives on ``/openapi/v1`` carrying the gateway-signed
+    ``X-Avernet-Principal`` the backend just verified, and applying it means
+    calling BCN as that same caller. The header cannot simply be relayed: the
+    gateway addresses each token to one upstream, so the one we hold says
+    ``aud=backend`` and BCN's verifier refuses it — the callback failed its
+    audience check on every friend approval, and no retry could have fixed it.
+
+    So the credential is **re-addressed** before it is forwarded:
+    ``resign_principal`` re-signs the verified claims with the shared key under
+    the ``iss``/``aud``/``kid`` BCN requires, leaving the identities and the
+    token's lifetime untouched (``core/gateway_principal/signer.py``). BCN then
+    authorizes the same caller the backend did, which is the whole point — the
+    approval is applied *as the approver*, not as the backend.
+    """
+
+    def __init__(
+        self,
+        http_client: HttpClient,
+        resign_principal: Callable[[str], str],
+        timeout: float = 10.0,
+    ) -> None:
         self._http = http_client
+        self._resign_principal = resign_principal
         self._timeout = timeout
+
+    def _readdressed_headers(
+        self, headers: Mapping[str, str], *, work_order_id: int
+    ) -> dict[str, str]:
+        """Return ``headers`` with the forwarded Principal re-addressed to BCN.
+
+        Every other header is passed through untouched — this seam forwards a
+        credential, it does not compose a request.
+
+        A **missing or blank** Principal is left alone rather than raised on:
+        there is nothing to re-address, and the call then fails at BCN exactly
+        as it did before, with ``has_principal=False`` already on the log line
+        below naming why. A Principal that is present but cannot be
+        re-addressed is a different matter — the token did not verify, or this
+        deployment has no signing key — and there is no point sending a
+        credential we know BCN will refuse, so the callback fails closed and
+        the decision is not stored.
+        """
+        readdressed = dict(headers)
+        for key in [k for k in readdressed if k.lower() == _PRINCIPAL_HEADER]:
+            token = readdressed[key].strip()
+            if not token:
+                continue
+            try:
+                readdressed[key] = self._resign_principal(token)
+            except Exception as exc:
+                # The reason, never the token. A verification failure names the
+                # contract and the key fingerprint this side judged the token
+                # against, which is what an operator needs; the digest
+                # correlates this line with the request that carried the
+                # credential, since no re-addressed one exists to log.
+                logger.warning(
+                    "friend work-order BCN callback credential could not be "
+                    "re-addressed: work_order_id=%s "
+                    "source_principal_fingerprint=%s "
+                    "exception_type=%s reason=%s",
+                    work_order_id,
+                    _principal_fingerprint(headers),
+                    type(exc).__name__,
+                    exc,
+                    extra={
+                        "work_order_id": work_order_id,
+                        "source_principal_fingerprint": _principal_fingerprint(
+                            headers
+                        ),
+                        "exception_type": type(exc).__name__,
+                    },
+                    exc_info=True,
+                )
+                raise WorkOrderCallbackError(
+                    "BCN callback credential could not be re-addressed"
+                ) from exc
+        return readdressed
 
     def handle(
         self,
@@ -154,7 +232,10 @@ class FriendDecisionCallbackHandler:
             if decision is WorkOrderDecision.APPROVED
             else {"reason": review_remark}
         )
-        callback_headers = dict(credential.headers)
+        source_principal_fingerprint = _principal_fingerprint(credential.headers)
+        callback_headers = self._readdressed_headers(
+            credential.headers, work_order_id=context.work_order.id
+        )
         lowered_headers = {key.lower(): value for key, value in callback_headers.items()}
         has_principal = "x-avernet-principal" in lowered_headers
         has_authorization = "authorization" in lowered_headers
@@ -168,10 +249,12 @@ class FriendDecisionCallbackHandler:
         logger.info(
             "BCN callback auth headers: has_principal=%s "
             "principal_header_count=%s principal_fingerprint=%s "
+            "source_principal_fingerprint=%s "
             "principal_length=%s has_authorization=%s",
             has_principal,
             principal_header_count,
             principal_fingerprint,
+            source_principal_fingerprint,
             principal_length,
             has_authorization,
         )
@@ -179,7 +262,8 @@ class FriendDecisionCallbackHandler:
             "friend work-order BCN callback request: "
             "work_order_id=%s callback_path=%s action=%s "
             "has_principal=%s principal_header_count=%s "
-            "principal_fingerprint=%s principal_length=%s "
+            "principal_fingerprint=%s source_principal_fingerprint=%s "
+            "principal_length=%s "
             "has_authorization=%s x_request_id=%s x_trace_id=%s",
             context.work_order.id,
             path,
@@ -187,6 +271,7 @@ class FriendDecisionCallbackHandler:
             has_principal,
             principal_header_count,
             principal_fingerprint,
+            source_principal_fingerprint,
             principal_length,
             has_authorization,
             lowered_headers.get("x-request-id"),
@@ -202,6 +287,7 @@ class FriendDecisionCallbackHandler:
                 "has_x_avernet_principal": has_principal,
                 "principal_header_count": principal_header_count,
                 "principal_fingerprint": principal_fingerprint,
+                "source_principal_fingerprint": source_principal_fingerprint,
                 "principal_length": principal_length,
                 "x_request_id": lowered_headers.get("x-request-id"),
                 "x_trace_id": lowered_headers.get("x-trace-id"),
@@ -287,7 +373,8 @@ class FriendDecisionCallbackHandler:
                 "http_status=%s response_code=%s response_message=%s "
                 "response_request_id=%s response_body_raw=%s duration_ms=%.1f "
                 "exception_type=%s principal_header_count=%s "
-                "principal_fingerprint=%s principal_length=%s",
+                "principal_fingerprint=%s source_principal_fingerprint=%s "
+                "principal_length=%s",
                 context.work_order.id,
                 path,
                 action,
@@ -300,6 +387,7 @@ class FriendDecisionCallbackHandler:
                 type(exc).__name__,
                 principal_header_count,
                 principal_fingerprint,
+                source_principal_fingerprint,
                 principal_length,
                 extra={
                     "work_order_id": context.work_order.id,
@@ -312,6 +400,7 @@ class FriendDecisionCallbackHandler:
                     "response_request_id": response_request_id,
                     "principal_header_count": principal_header_count,
                     "principal_fingerprint": principal_fingerprint,
+                    "source_principal_fingerprint": source_principal_fingerprint,
                     "principal_length": principal_length,
                     "duration_ms": failure_duration_ms,
                     "exception_type": type(exc).__name__,
@@ -323,14 +412,23 @@ class FriendDecisionCallbackHandler:
 
 
 class WorkOrderDecisionCallbackDispatcher:
-    """Dispatch only explicitly registered approval events; all others are no-op."""
+    """Dispatch only explicitly registered approval events; all others are no-op.
 
-    @inject
+    ``resign_principal`` is handed in by the composition root
+    (``di/modules/work_orders_module.py``) rather than resolved here: it closes
+    over the process-wide signing key, which is deployment configuration this
+    layer must stay transport- and config-agnostic about (Rule 7). See
+    :class:`FriendDecisionCallbackHandler` for what it is for.
+    """
+
     def __init__(
         self,
-        http_client: Annotated[HttpClient, QUALIFIER_BCN],
+        http_client: HttpClient,
+        resign_principal: Callable[[str], str],
     ) -> None:
-        friend_handler = FriendDecisionCallbackHandler(http_client)
+        friend_handler = FriendDecisionCallbackHandler(
+            http_client, resign_principal=resign_principal
+        )
         self._handlers = {
             WorkOrderEventType.HUMAN2BOT_FRIEND_APPLIED.value: friend_handler,
             WorkOrderEventType.BOT2BOT_FRIEND_APPLIED.value: friend_handler,

--- a/src/backend/src/agentclaw/community/di/modules/work_orders_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/work_orders_module.py
@@ -1,5 +1,7 @@
 """DI bindings for work orders and recipient notifications."""
 
+from typing import Annotated
+
 from injector import Binder, Module, inject, provider, singleton
 
 from agentclaw.community.api.work_order_service import (
@@ -26,7 +28,11 @@ from agentclaw.community.core.work_orders.services import (
     WorkOrderNotificationService,
     WorkOrderService,
 )
+from agentclaw.community.plugin_api.http_client import QUALIFIER_BCN, HttpClient
 from agentclaw.community.utils.env_utils import get_current_env
+from agentclaw.community.utils.gateway_principal_config import (
+    resign_principal_for_bcn,
+)
 
 
 class WorkOrdersModule(Module):
@@ -34,13 +40,30 @@ class WorkOrdersModule(Module):
         binder.bind(
             WorkOrderRepositoryProtocol, to=WorkOrderRepository, scope=singleton
         )
-        binder.bind(WorkOrderDecisionCallbackDispatcher, scope=singleton)
         binder.bind(WorkOrderServiceProtocol, to=WorkOrderService, scope=singleton)
         binder.bind(WorkOrderEventServiceProtocol, to=WorkOrderService, scope=singleton)
         binder.bind(
             WorkOrderNotificationServiceProtocol,
             to=WorkOrderNotificationService,
             scope=singleton,
+        )
+
+    @singleton
+    @provider
+    @inject
+    def work_order_decision_callbacks(
+        self, http_client: Annotated[HttpClient, QUALIFIER_BCN]
+    ) -> WorkOrderDecisionCallbackDispatcher:
+        """Assemble the BCN decision callbacks with the principal re-signer.
+
+        The callback calls BCN as the approving caller, which means re-addressing
+        the gateway-signed principal the backend verified to the audience BCN
+        requires. Which key and which audience that takes is deployment
+        configuration, so it is bound here rather than read from the core seam
+        that uses it.
+        """
+        return WorkOrderDecisionCallbackDispatcher(
+            http_client, resign_principal=resign_principal_for_bcn
         )
 
     @singleton

--- a/src/backend/src/agentclaw/community/utils/gateway_principal_config.py
+++ b/src/backend/src/agentclaw/community/utils/gateway_principal_config.py
@@ -52,6 +52,13 @@ What comes from where:
   ``/openapi/v1`` request answers 401. If that ever needs to vary per
   deployment, this is the line to revisit.
 
+- **BCN's ``aud``/``iss``/``kid``** are fixed in code too, next to ours, and for
+  the same reason. They are not a second contract but the other end of this one:
+  the backend re-addresses a verified principal token when it calls BCN on the
+  caller's behalf (:func:`resign_principal_for_bcn`), and BCN's trust config
+  decides what that copy has to say. See the constants below for the coupling
+  that creates.
+
 Resolved once, at boot: the key is deployment configuration, and a per-request
 secret-store round trip on the hot path buys nothing. There is deliberately no
 re-read, so rotating the shared secret requires a restart on both sides.
@@ -61,9 +68,11 @@ from __future__ import annotations
 
 from agentclaw.community.core.gateway_principal import (
     MIN_SIGNING_KEY_BYTES,
+    PrincipalSignerConfig,
     PrincipalVerifierConfig,
     is_weak_signing_key,
     key_fingerprint,
+    resign_principal_token,
 )
 from agentclaw.community.log import get_logger
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
@@ -80,6 +89,29 @@ _AUDIENCE = "backend"
 # ``user_config.principal_signer.issuer``, which is configurable on that side —
 # so this constant and that setting must move together or every request 401s.
 _ISSUER = "gateway"
+
+# BCN's half of the same contract, for the one flow that has to call it on the
+# caller's behalf (``core/work_orders/callbacks.py`` → the friend accept/reject
+# routes). These are BCN's requirements, not ours: it verifies the same shared
+# key but refuses a token addressed to ``backend``, so the credential has to be
+# re-addressed before it is forwarded — see ``core/gateway_principal/signer.py``.
+#
+# Fixed in code for the same reason ``aud``/``iss`` above are, and pinned to the
+# defaults BCN ships (``gateway_principal.{issuer,audience,key_id}`` in
+# ``src/bcs/crates/bootstrap/bcs/src/config.rs``, spelled out in
+# ``src/bcs/api-contracts/v1/gateway-principal/contract.md``). BCN can override
+# all three per deployment, so the same coupling the ``iss`` note above
+# describes applies here in both directions: **changing BCN's trust config
+# requires changing these constants in the same release**, or every friend
+# approval fails its callback with a 401 from BCN.
+_BCN_AUDIENCE = "bcs"
+_BCN_ISSUER = "gateway"
+
+# The ``kid`` BCN requires on the JOSE header. It names the key the token is
+# signed with — the gateway's ``bare`` signer and the shared secret resolved
+# below are the same key — so a re-addressed token carries it too, or BCN
+# rejects the header before it ever checks the signature.
+_BCN_KEY_ID = "bare"
 
 # What every unresolved deployment gets: an empty key, which the verifier treats
 # as "trust nothing" and answers 401 to everything. Also the pre-boot value, so
@@ -180,6 +212,46 @@ def get_principal_verifier_config() -> PrincipalVerifierConfig:
     without finding a key — this is the deny config.
     """
     return _config
+
+
+def get_bcn_principal_signer_config() -> PrincipalSignerConfig:
+    """Return the config for re-addressing a principal token to BCN.
+
+    Reads the same installed key the verifier uses — one shared secret, not a
+    second credential — so a deployment that cannot verify a principal cannot
+    re-address one either, and both fail closed on the same missing value.
+
+    Derived per call rather than assembled at boot beside ``_config``, so that
+    the two can never disagree about which key is installed: there is one
+    source, and this is a view onto it.
+    """
+    return PrincipalSignerConfig(
+        signing_key=_config.signing_key,
+        audience=_BCN_AUDIENCE,
+        issuer=_BCN_ISSUER,
+        key_id=_BCN_KEY_ID,
+    )
+
+
+def resign_principal_for_bcn(token: str) -> str:
+    """Re-address a verified inbound principal token to BCN.
+
+    This is what the composition root hands ``core/work_orders/callbacks.py``:
+    that seam needs "turn this header value into one BCN will accept" and has no
+    business knowing which key or which audience that takes. Resolving both
+    configs here — at call time, from the process-wide install — also keeps it
+    correct regardless of whether the caller was constructed before or after
+    :func:`init_principal_verifier_config` ran.
+
+    Raises:
+        PrincipalVerificationError: when the inbound token does not verify, or
+            when this deployment has no signing key.
+    """
+    return resign_principal_token(
+        token,
+        verifier=get_principal_verifier_config(),
+        signer=get_bcn_principal_signer_config(),
+    )
 
 
 def _resolve_signing_key(resolver: SecretResolver, secret_name: str) -> str:

--- a/src/backend/src/agentclaw/community/utils/gateway_principal_config.py
+++ b/src/backend/src/agentclaw/community/utils/gateway_principal_config.py
@@ -52,12 +52,13 @@ What comes from where:
   ``/openapi/v1`` request answers 401. If that ever needs to vary per
   deployment, this is the line to revisit.
 
-- **BCN's ``aud``/``iss``/``kid``** are fixed in code too, next to ours, and for
-  the same reason. They are not a second contract but the other end of this one:
-  the backend re-addresses a verified principal token when it calls BCN on the
-  caller's behalf (:func:`resign_principal_for_bcn`), and BCN's trust config
-  decides what that copy has to say. See the constants below for the coupling
-  that creates.
+- **The envelope we put on a token addressed to BCN** — ``aud``/``iss``/``kid``
+  — is fixed in code too, next to ours, and for the same reason. It is not a
+  second contract but the other end of this one: the backend re-addresses a
+  verified principal token when it calls BCN on the caller's behalf
+  (:func:`resign_principal_for_bcn`). ``aud`` is BCN's name; ``iss`` is **ours**,
+  because we are the component that signed that copy. See the constants below
+  for the coupling that creates on BCN's side.
 
 Resolved once, at boot: the key is deployment configuration, and a per-request
 secret-store round trip on the hot path buys nothing. There is deliberately no
@@ -79,33 +80,43 @@ from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 
 logger = get_logger()
 
-# The ``aud`` we accept: this component's name under ``servers:`` in the
-# gateway's ``configs/application.yaml``, which is what its forwarder signs the
-# token's audience as (``adapters/web/_forward.py``). A token minted for another
-# upstream must not verify here, so these two spellings have to match.
-_AUDIENCE = "backend"
+# What the gateway calls this component: our key under ``servers:`` in its
+# ``configs/application.yaml``. Its forwarder signs a token's audience as
+# exactly that name (``adapters/web/_forward.py`` → ``audience=server.name``),
+# so this one spelling is both the ``aud`` we accept from the gateway and the
+# name we issue under when we mint a token ourselves — see :data:`_BCN_ISSUER`.
+_COMPONENT_NAME = "backend"
+
+# The ``aud`` we accept. A token minted for another upstream must not verify
+# here, so this and the gateway's server name have to match.
+_AUDIENCE = _COMPONENT_NAME
 
 # The ``iss`` we accept. Matches the default of the gateway's
 # ``user_config.principal_signer.issuer``, which is configurable on that side —
 # so this constant and that setting must move together or every request 401s.
 _ISSUER = "gateway"
 
-# BCN's half of the same contract, for the one flow that has to call it on the
-# caller's behalf (``core/work_orders/callbacks.py`` → the friend accept/reject
-# routes). These are BCN's requirements, not ours: it verifies the same shared
-# key but refuses a token addressed to ``backend``, so the credential has to be
-# re-addressed before it is forwarded — see ``core/gateway_principal/signer.py``.
+# The envelope we put on a token addressed to BCN, for the one flow that has to
+# call it on the caller's behalf (``core/work_orders/callbacks.py`` → the friend
+# accept/reject routes). The gateway addresses each token to a single upstream,
+# so the one that arrives here says ``aud=backend`` and BCN refuses it; the
+# credential is re-addressed before it is forwarded (see
+# ``core/gateway_principal/signer.py``).
 #
-# Fixed in code for the same reason ``aud``/``iss`` above are, and pinned to the
-# defaults BCN ships (``gateway_principal.{issuer,audience,key_id}`` in
-# ``src/bcs/crates/bootstrap/bcs/src/config.rs``, spelled out in
-# ``src/bcs/api-contracts/v1/gateway-principal/contract.md``). BCN can override
-# all three per deployment, so the same coupling the ``iss`` note above
-# describes applies here in both directions: **changing BCN's trust config
-# requires changing these constants in the same release**, or every friend
-# approval fails its callback with a 401 from BCN.
+# ``aud`` is BCN's name under the gateway's ``servers:`` map, the same way
+# :data:`_AUDIENCE` is ours — it names who the token is *for*.
 _BCN_AUDIENCE = "bcs"
-_BCN_ISSUER = "gateway"
+
+# ``iss`` names who *issued* it, and for a token we mint that is this component,
+# not the gateway: the claims are the gateway's assertions, but the signature
+# over this copy is ours. So it is :data:`_COMPONENT_NAME` — the name the
+# gateway knows us by, which is the name BCN's operators configure to trust.
+#
+# **BCN must trust that issuer.** Its verifier compares ``iss`` against a single
+# configured value (``gateway_principal.issuer`` in
+# ``src/bcs/crates/bootstrap/bcs/src/config.rs``), so the two must move
+# together: a BCN that trusts only the gateway answers 401 to this callback.
+_BCN_ISSUER = _COMPONENT_NAME
 
 # The ``kid`` BCN requires on the JOSE header. It names the key the token is
 # signed with — the gateway's ``bare`` signer and the shared secret resolved

--- a/src/backend/tests/community/core/gateway_principal/test_signer.py
+++ b/src/backend/tests/community/core/gateway_principal/test_signer.py
@@ -4,12 +4,19 @@ The tests mint tokens the way the gateway's ``BarePrincipalSigner`` does (via
 :func:`mint` from the verifier suite, so both files exercise one spelling of the
 contract) and then judge the re-addressed copy against **BCN's** published
 requirements — ``src/bcs/api-contracts/v1/gateway-principal/contract.md``:
-``alg=HS256``, ``typ=JWT``, ``kid=bare``, ``iss=gateway``, ``aud=bcs``, integer
-``iat``/``exp``, a non-empty ``principals`` array.
+``alg=HS256``, ``typ=JWT``, ``kid=bare``, ``aud=bcs``, integer ``iat``/``exp``,
+a non-empty ``principals`` array.
 
-That contract is the whole reason this module exists, so the assertions here are
-deliberately literal about it: a re-addressed token that satisfies these checks
-is one BCN accepts, and one that does not is the bug this fixes coming back.
+``iss`` is the one field that is ours rather than BCN's. BCN checks it against
+the issuer it is configured to trust, and for a token this component signs that
+is this component's own name — the gateway's ``servers:`` key for us,
+``backend`` — not the gateway's. The assertions here pin that value, so a change
+of who we claim to be cannot pass unnoticed on the side that has to trust it.
+
+The rest of the contract is the whole reason this module exists, so the
+assertions are deliberately literal about it: a re-addressed token that
+satisfies these checks is one BCN accepts, and one that does not is the bug this
+fixes coming back.
 """
 
 from __future__ import annotations
@@ -37,10 +44,11 @@ from tests.community.core.gateway_principal.test_verifier import (
     user_principal,
 )
 
-# What BCN requires of a token addressed to it. Mirrors the shipped defaults of
-# ``gateway_principal.{issuer,audience,key_id}`` on the BCN side.
+# The envelope a token addressed to BCN carries. ``aud``/``kid`` mirror BCN's
+# shipped ``gateway_principal.{audience,key_id}``; ``iss`` is this component's
+# own name, which BCN has to be configured to trust.
 BCN_AUDIENCE = "bcs"
-BCN_ISSUER = "gateway"
+BCN_ISSUER = "backend"
 BCN_KEY_ID = "bare"
 
 VERIFIER = PrincipalVerifierConfig(signing_key=KEY, audience=AUDIENCE, issuer=ISSUER)
@@ -73,7 +81,11 @@ def bcn_verify(token: str, *, key: str = KEY) -> dict:
 
 
 def test_readdressed_token_satisfies_the_bcn_contract():
-    """The point of the module: BCN accepts what the backend could not forward."""
+    """The point of the module: BCN accepts what the backend could not forward.
+
+    ``iss`` names this component, not the gateway — the claims are still the
+    gateway's assertions, but the signature over this copy is the backend's.
+    """
     original = mint([user_principal()])
 
     readdressed = resign_principal_token(original, verifier=VERIFIER, signer=SIGNER)
@@ -95,8 +107,13 @@ def test_the_inbound_token_is_the_one_bcn_refuses():
     Without it the suite could pass while the header the backend actually
     forwards is still addressed to ``backend`` — which is exactly the state the
     friend-approval callback was in.
+
+    Both halves of the envelope are wrong on the inbound token: it is addressed
+    to us rather than to BCN, and it was issued by the gateway rather than by
+    the component making this call. PyJWT reports whichever it checks first, so
+    the assertion names the pair.
     """
-    with pytest.raises(jwt.InvalidAudienceError):
+    with pytest.raises((jwt.InvalidAudienceError, jwt.InvalidIssuerError)):
         bcn_verify(mint([user_principal()]))
 
 

--- a/src/backend/tests/community/core/gateway_principal/test_signer.py
+++ b/src/backend/tests/community/core/gateway_principal/test_signer.py
@@ -1,0 +1,251 @@
+"""Unit tests for re-addressing a verified principal token to a second upstream.
+
+The tests mint tokens the way the gateway's ``BarePrincipalSigner`` does (via
+:func:`mint` from the verifier suite, so both files exercise one spelling of the
+contract) and then judge the re-addressed copy against **BCN's** published
+requirements — ``src/bcs/api-contracts/v1/gateway-principal/contract.md``:
+``alg=HS256``, ``typ=JWT``, ``kid=bare``, ``iss=gateway``, ``aud=bcs``, integer
+``iat``/``exp``, a non-empty ``principals`` array.
+
+That contract is the whole reason this module exists, so the assertions here are
+deliberately literal about it: a re-addressed token that satisfies these checks
+is one BCN accepts, and one that does not is the bug this fixes coming back.
+"""
+
+from __future__ import annotations
+
+import time
+
+import jwt
+import pytest
+
+from agentclaw.community.core.gateway_principal import (
+    PrincipalSignerConfig,
+    PrincipalVerificationError,
+    PrincipalVerifierConfig,
+    resign_principal_token,
+)
+from tests.community.core.gateway_principal.test_verifier import (
+    AUDIENCE,
+    ISSUER,
+    KEY,
+    TENANT,
+    access_key_principal,
+    app_principal,
+    bot_principal,
+    mint,
+    user_principal,
+)
+
+# What BCN requires of a token addressed to it. Mirrors the shipped defaults of
+# ``gateway_principal.{issuer,audience,key_id}`` on the BCN side.
+BCN_AUDIENCE = "bcs"
+BCN_ISSUER = "gateway"
+BCN_KEY_ID = "bare"
+
+VERIFIER = PrincipalVerifierConfig(signing_key=KEY, audience=AUDIENCE, issuer=ISSUER)
+SIGNER = PrincipalSignerConfig(
+    signing_key=KEY,
+    audience=BCN_AUDIENCE,
+    issuer=BCN_ISSUER,
+    key_id=BCN_KEY_ID,
+)
+
+
+def bcn_verify(token: str, *, key: str = KEY) -> dict:
+    """Decode ``token`` the way BCN does, and fail the test if BCN would not.
+
+    Not a paraphrase of BCN's verifier — the claim checks it can express in
+    PyJWT are asserted here, and the JOSE header checks BCN makes before it ever
+    looks at the signature are asserted by the caller.
+    """
+    return jwt.decode(
+        token,
+        key,
+        algorithms=["HS256"],
+        audience=BCN_AUDIENCE,
+        issuer=BCN_ISSUER,
+        options={"require": ["exp", "iat", "iss", "aud"]},
+    )
+
+
+# ── the re-addressing itself ─────────────────────────────────────────────────
+
+
+def test_readdressed_token_satisfies_the_bcn_contract():
+    """The point of the module: BCN accepts what the backend could not forward."""
+    original = mint([user_principal()])
+
+    readdressed = resign_principal_token(original, verifier=VERIFIER, signer=SIGNER)
+
+    header = jwt.get_unverified_header(readdressed)
+    assert header["alg"] == "HS256"
+    assert header["typ"] == "JWT"
+    assert header["kid"] == BCN_KEY_ID
+    claims = bcn_verify(readdressed)
+    assert claims["iss"] == BCN_ISSUER
+    assert claims["aud"] == BCN_AUDIENCE
+    assert isinstance(claims["iat"], int)
+    assert isinstance(claims["exp"], int)
+
+
+def test_the_inbound_token_is_the_one_bcn_refuses():
+    """The failure this fixes, asserted rather than assumed.
+
+    Without it the suite could pass while the header the backend actually
+    forwards is still addressed to ``backend`` — which is exactly the state the
+    friend-approval callback was in.
+    """
+    with pytest.raises(jwt.InvalidAudienceError):
+        bcn_verify(mint([user_principal()]))
+
+
+def test_identities_and_lifetime_survive_the_re_addressing():
+    """Same caller, same window — only the envelope changes.
+
+    BCN authorizes the approval against the identity set, so a re-addressing
+    that altered it would apply the decision as somebody else. And ``exp`` is
+    the gateway's 60-second budget: re-stamping it here would silently mint a
+    longer-lived credential on every hop.
+    """
+    issued_at = int(time.time()) - 5
+    original = mint(
+        [app_principal(), user_principal()], ttl=60, issued_at=issued_at
+    )
+
+    claims = bcn_verify(
+        resign_principal_token(original, verifier=VERIFIER, signer=SIGNER)
+    )
+
+    assert claims["principals"] == [app_principal(), user_principal()]
+    assert claims["iat"] == issued_at
+    assert claims["exp"] == issued_at + 60
+
+
+def test_unknown_claims_are_carried_across():
+    """A claim we do not read may still be one BCN does; dropping it is not ours."""
+    now = int(time.time())
+    original = jwt.encode(
+        {
+            "iss": ISSUER,
+            "aud": AUDIENCE,
+            "iat": now,
+            "exp": now + 60,
+            "principals": [user_principal()],
+            "trace_id": "gateway-trace-1",
+        },
+        KEY,
+        algorithm="HS256",
+        headers={"kid": "bare"},
+    )
+
+    claims = bcn_verify(
+        resign_principal_token(original, verifier=VERIFIER, signer=SIGNER)
+    )
+
+    assert claims["trace_id"] == "gateway-trace-1"
+
+
+def test_the_copy_is_signed_with_the_shared_key_only():
+    """A different key produces a token BCN rejects — the key is the contract."""
+    readdressed = resign_principal_token(
+        mint([user_principal()]), verifier=VERIFIER, signer=SIGNER
+    )
+
+    with pytest.raises(jwt.InvalidSignatureError):
+        bcn_verify(readdressed, key="a-different-secret-of-at-least-32-bytes!!")
+
+
+# ── nothing is signed that was not verified first ────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("label", "token"),
+    [
+        ("forged signature", mint([user_principal()], key="attacker-supplied-key")),
+        ("expired", mint([user_principal()], ttl=-3600)),
+        ("minted for another upstream", mint([user_principal()], audience="bcs")),
+        ("wrong issuer", mint([user_principal()], issuer="not-the-gateway")),
+        ("no principals claim", mint([user_principal()], omit=("principals",))),
+        ("empty", ""),
+    ],
+)
+def test_a_token_that_does_not_verify_is_never_re_addressed(label: str, token: str):
+    """Re-addressing must not be a way to launder a token into a valid one.
+
+    Every case here is a credential this component would answer ``401`` to. If
+    any of them came back signed with the shared key, the backend would be a
+    token-minting oracle for every upstream that trusts it.
+    """
+    with pytest.raises(PrincipalVerificationError):
+        resign_principal_token(token, verifier=VERIFIER, signer=SIGNER)
+
+
+def test_an_identity_set_this_surface_refuses_is_never_re_addressed():
+    """The admission check runs before signing, not only at the HTTP seam.
+
+    An access-key-only set names no end user and no application, so no public
+    route would serve it. Handing BCN a caller we ourselves refuse would move
+    that decision to a component that cannot see our route table.
+    """
+    with pytest.raises(PrincipalVerificationError, match="neither a user nor an app"):
+        resign_principal_token(
+            mint([access_key_principal()]), verifier=VERIFIER, signer=SIGNER
+        )
+
+
+def test_a_contradictory_tenant_is_refused_before_signing():
+    """Two tenants in one set is unresolvable here and would be there too."""
+    with pytest.raises(PrincipalVerificationError, match="mixes 2 tenants"):
+        resign_principal_token(
+            mint([user_principal(), bot_principal(tenant="other-tenant"),
+                  app_principal(tenant=TENANT)]),
+            verifier=VERIFIER,
+            signer=SIGNER,
+        )
+
+
+def test_no_signing_key_refuses_rather_than_signing_with_nothing():
+    """An unconfigured deployment produces no credential at all.
+
+    Same reading as the verifier's empty key, from the signing side: a token
+    signed with ``""`` is not a weaker credential, it is a forgeable one.
+    """
+    with pytest.raises(PrincipalVerificationError, match="no principal signing key"):
+        resign_principal_token(
+            mint([user_principal()]),
+            verifier=VERIFIER,
+            signer=PrincipalSignerConfig(
+                signing_key="",
+                audience=BCN_AUDIENCE,
+                issuer=BCN_ISSUER,
+                key_id=BCN_KEY_ID,
+            ),
+        )
+
+
+def test_no_verifier_key_refuses_even_when_the_signer_has_one():
+    """Both halves are needed: nothing verifies, so nothing is worth signing."""
+    with pytest.raises(PrincipalVerificationError, match="no principal signing key"):
+        resign_principal_token(
+            mint([user_principal()]),
+            verifier=PrincipalVerifierConfig(
+                signing_key="", audience=AUDIENCE, issuer=ISSUER
+            ),
+            signer=SIGNER,
+        )
+
+
+def test_the_signer_config_fingerprints_its_key_for_a_log():
+    """Boot lines compare fingerprints across components, never the key itself."""
+    assert SIGNER.key_fingerprint != "unset"
+    assert KEY not in SIGNER.key_fingerprint
+    assert (
+        PrincipalSignerConfig(
+            signing_key="",
+            audience=BCN_AUDIENCE,
+            issuer=BCN_ISSUER,
+            key_id=BCN_KEY_ID,
+        ).key_fingerprint
+        == "unset"
+    )

--- a/src/backend/tests/community/core/work_orders/test_work_order_callbacks.py
+++ b/src/backend/tests/community/core/work_orders/test_work_order_callbacks.py
@@ -1,6 +1,7 @@
 """Unit tests for opt-in work-order decision callbacks."""
 
 import json
+from collections.abc import Callable
 from datetime import datetime
 from unittest.mock import MagicMock
 
@@ -32,6 +33,47 @@ from agentclaw.community.plugin_api.http_client import HttpClient
 
 
 NOW = datetime(2026, 8, 27, 10, 0, 0)
+
+# What the re-signer hands back. A sentinel rather than a real JWT: this suite
+# asserts that the *re-addressed* credential is what reaches BCN and that the
+# inbound one is what reaches the re-signer — whether the copy satisfies BCN's
+# contract is ``core/gateway_principal``'s question, and ``test_signer.py``
+# answers it against that contract directly.
+READDRESSED_PRINCIPAL = "readdressed-principal-token"
+
+
+class StubResigner:
+    """Stands in for ``resign_principal_for_bcn``, recording what it was given."""
+
+    def __init__(self, readdressed: str = READDRESSED_PRINCIPAL) -> None:
+        self._readdressed = readdressed
+        self.calls: list[str] = []
+
+    def __call__(self, token: str) -> str:
+        self.calls.append(token)
+        return self._readdressed
+
+
+class FailingResigner:
+    """A re-signer that refuses, as it does for a token that does not verify."""
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self._error = error or ValueError("principal token rejected")
+
+    def __call__(self, token: str) -> str:
+        raise self._error
+
+
+def _handler(
+    http: HttpClient,
+    *,
+    resign: Callable[[str], str] | None = None,
+    timeout: float = 10.0,
+) -> FriendDecisionCallbackHandler:
+    """Build the handler under test with a re-signer that is never a no-op."""
+    return FriendDecisionCallbackHandler(
+        http, resign_principal=resign or StubResigner(), timeout=timeout
+    )
 
 
 def _context(
@@ -81,10 +123,19 @@ def _response(payload: object, status_code: int = 200) -> httpx.Response:
     )
 
 
-def test_friend_handler_accepts_and_forwards_only_supplied_credential() -> None:
+def test_friend_handler_readdresses_the_principal_and_forwards_the_rest() -> None:
+    """BCN is called with the re-addressed credential, and nothing else changes.
+
+    The inbound ``X-Avernet-Principal`` is addressed to ``backend`` and BCN
+    refuses it, so relaying it verbatim — as this handler used to — failed every
+    friend approval on BCN's audience check. Every other supplied header is
+    still forwarded untouched: this seam forwards a credential, it does not
+    compose a request.
+    """
     http = MagicMock(spec=HttpClient)
     http.post.return_value = _response({"success": True, "data": {}})
-    handler = FriendDecisionCallbackHandler(http, timeout=3.0)
+    resigner = StubResigner()
+    handler = _handler(http, resign=resigner, timeout=3.0)
     credential = WorkOrderCallbackCredential(
         headers={
             "Authorization": "Bearer token",
@@ -100,16 +151,102 @@ def test_friend_handler_accepts_and_forwards_only_supplied_credential() -> None:
         credential=credential,
     )
 
+    assert resigner.calls == ["principal-token"]
     http.post.assert_called_once_with(
         "/openapi/v1/collaboration/friend-connections/requests/request%2F77/accept",
         json=None,
         headers={
             "Authorization": "Bearer token",
-            "X-Avernet-Principal": "principal-token",
+            "X-Avernet-Principal": READDRESSED_PRINCIPAL,
             "X-Trace-Id": "trace",
         },
         timeout=3.0,
     )
+    assert credential.headers["X-Avernet-Principal"] == "principal-token"
+
+
+def test_friend_handler_readdresses_a_lowercased_principal_header() -> None:
+    """Header names are case-insensitive; the inbound spelling is not ours to pick."""
+    http = MagicMock(spec=HttpClient)
+    http.post.return_value = _response({"success": True})
+    resigner = StubResigner()
+    handler = _handler(http, resign=resigner)
+
+    handler.handle(
+        context=_context(),
+        decision=WorkOrderDecision.APPROVED,
+        review_remark=None,
+        credential=WorkOrderCallbackCredential(
+            headers={"x-avernet-principal": "principal-token"}
+        ),
+    )
+
+    assert resigner.calls == ["principal-token"]
+    assert http.post.call_args.kwargs["headers"] == {
+        "x-avernet-principal": READDRESSED_PRINCIPAL
+    }
+
+
+def test_friend_handler_leaves_a_credential_without_a_principal_alone() -> None:
+    """Nothing to re-address, so nothing is invented — the call fails at BCN.
+
+    Which is the same outcome as before this change, with the existing
+    ``has_principal=False`` diagnostic already naming why.
+    """
+    http = MagicMock(spec=HttpClient)
+    http.post.return_value = _response({"success": True})
+    resigner = StubResigner()
+    handler = _handler(http, resign=resigner)
+
+    handler.handle(
+        context=_context(),
+        decision=WorkOrderDecision.APPROVED,
+        review_remark=None,
+        credential=WorkOrderCallbackCredential(
+            headers={"Authorization": "Bearer token", "X-Avernet-Principal": "  "}
+        ),
+    )
+
+    assert resigner.calls == []
+    assert http.post.call_args.kwargs["headers"] == {
+        "Authorization": "Bearer token",
+        "X-Avernet-Principal": "  ",
+    }
+
+
+def test_friend_handler_fails_closed_when_the_principal_cannot_be_readdressed(
+    caplog,
+) -> None:
+    """No credential BCN would accept means no call and no stored decision.
+
+    A token that does not verify, or a deployment with no signing key, both land
+    here. Sending the original anyway would only trade this failure for a 403
+    from BCN, and the approval must not be persisted either way.
+    """
+    caplog.set_level("INFO", logger="start")
+    http = MagicMock(spec=HttpClient)
+    handler = _handler(http, resign=FailingResigner())
+
+    with pytest.raises(WorkOrderCallbackError):
+        handler.handle(
+            context=_context(),
+            decision=WorkOrderDecision.APPROVED,
+            review_remark=None,
+            credential=WorkOrderCallbackCredential(
+                headers={"X-Avernet-Principal": "secret-principal"}
+            ),
+        )
+
+    http.post.assert_not_called()
+    failure_log = next(
+        record
+        for record in caplog.records
+        if record.message.startswith(
+            "friend work-order BCN callback credential could not be re-addressed:"
+        )
+    )
+    assert "exception_type=ValueError" in failure_log.message
+    assert "secret-principal" not in caplog.text
 
 
 def test_friend_handler_logs_bcn_response_details_without_credentials(caplog) -> None:
@@ -124,7 +261,7 @@ def test_friend_handler_logs_bcn_response_details_without_credentials(caplog) ->
         },
         status_code=403,
     )
-    handler = FriendDecisionCallbackHandler(http)
+    handler = _handler(http)
 
     with pytest.raises(WorkOrderCallbackError):
         handler.handle(
@@ -159,11 +296,18 @@ def test_friend_handler_logs_bcn_response_details_without_credentials(caplog) ->
     )
     assert "has_principal=True" in auth_log.message
     assert "principal_header_count=1" in auth_log.message
-    assert "principal_length=16" in auth_log.message
+    assert f"principal_length={len(READDRESSED_PRINCIPAL)}" in auth_log.message
     assert auth_log.message.endswith("has_authorization=True")
     assert request_log.principal_header_count == 1
-    assert request_log.principal_length == len("secret-principal")
+    # The credential BCN was actually handed, not the one that arrived: after
+    # re-addressing they are different tokens, so both digests are logged and
+    # the hop stays correlatable across the two components' log lines.
+    assert request_log.principal_length == len(READDRESSED_PRINCIPAL)
     assert len(request_log.principal_fingerprint) == 16
+    assert len(request_log.source_principal_fingerprint) == 16
+    assert (
+        request_log.source_principal_fingerprint != request_log.principal_fingerprint
+    )
     assert "secret-principal" not in request_log.message
     assert "http_status=403" in response_log.message
     assert "response_code=403201" in response_log.message
@@ -193,7 +337,7 @@ def test_friend_handler_accepts_openapi_success_envelope() -> None:
             "request_id": "bcn-request-1",
         }
     )
-    handler = FriendDecisionCallbackHandler(http)
+    handler = _handler(http)
 
     handler.handle(
         context=_context(),
@@ -215,7 +359,7 @@ def test_friend_handler_logs_non_json_bcn_response(caplog) -> None:
         text="Bad Gateway",
         request=httpx.Request("POST", "https://bcn.test/callback"),
     )
-    handler = FriendDecisionCallbackHandler(http)
+    handler = _handler(http)
 
     with pytest.raises(WorkOrderCallbackError):
         handler.handle(
@@ -242,6 +386,7 @@ def test_friend_handler_logs_non_json_bcn_response(caplog) -> None:
     assert "response_body_raw=Bad Gateway" in failure_log.message
     assert failure_log.principal_header_count == 0
     assert failure_log.principal_fingerprint is None
+    assert failure_log.source_principal_fingerprint is None
     assert failure_log.principal_length is None
 
 
@@ -255,7 +400,7 @@ def test_friend_handler_truncates_large_response_body_in_logs(caplog) -> None:
         text=large_body,
         request=httpx.Request("POST", "https://bcn.test/callback"),
     )
-    handler = FriendDecisionCallbackHandler(http)
+    handler = _handler(http)
 
     with pytest.raises(WorkOrderCallbackError):
         handler.handle(
@@ -277,7 +422,7 @@ def test_friend_handler_truncates_large_response_body_in_logs(caplog) -> None:
 def test_friend_handler_rejects_with_review_reason() -> None:
     http = MagicMock(spec=HttpClient)
     http.post.return_value = _response({"success": True})
-    handler = FriendDecisionCallbackHandler(http)
+    handler = _handler(http)
 
     handler.handle(
         context=_context(event_type=WorkOrderEventType.BOT2BOT_FRIEND_APPLIED),
@@ -303,7 +448,7 @@ def test_friend_handler_turns_every_upstream_failure_into_callback_error(
 ) -> None:
     http = MagicMock(spec=HttpClient)
     http.post.return_value = response
-    handler = FriendDecisionCallbackHandler(http)
+    handler = _handler(http)
 
     with pytest.raises(WorkOrderCallbackError):
         handler.handle(
@@ -316,7 +461,7 @@ def test_friend_handler_turns_every_upstream_failure_into_callback_error(
 
 def test_friend_handler_rejects_wrong_biz_type_before_http() -> None:
     http = MagicMock(spec=HttpClient)
-    handler = FriendDecisionCallbackHandler(http)
+    handler = _handler(http)
 
     with pytest.raises(WorkOrderInvalidEventError, match="BOT_FRIEND"):
         handler.handle(
@@ -332,7 +477,7 @@ def test_friend_handler_rejects_wrong_biz_type_before_http() -> None:
 @pytest.mark.parametrize("biz_data", [None, "not-json", "[]"])
 def test_friend_handler_rejects_invalid_persisted_json(biz_data: str | None) -> None:
     http = MagicMock(spec=HttpClient)
-    handler = FriendDecisionCallbackHandler(http)
+    handler = _handler(http)
 
     with pytest.raises(WorkOrderInvalidEventError):
         handler.handle(
@@ -347,7 +492,9 @@ def test_friend_handler_rejects_invalid_persisted_json(biz_data: str | None) -> 
 
 def test_dispatcher_is_noop_for_unregistered_event() -> None:
     http = MagicMock(spec=HttpClient)
-    dispatcher = WorkOrderDecisionCallbackDispatcher(http)
+    dispatcher = WorkOrderDecisionCallbackDispatcher(
+        http, resign_principal=StubResigner()
+    )
     context = _context().model_copy(update={"source_event_type": "OTHER_APPLIED"})
 
     assert dispatcher.requires_callback(context.source_event_type) is False
@@ -362,7 +509,9 @@ def test_dispatcher_is_noop_for_unregistered_event() -> None:
 
 
 def test_dispatcher_registers_both_friend_events() -> None:
-    dispatcher = WorkOrderDecisionCallbackDispatcher(MagicMock(spec=HttpClient))
+    dispatcher = WorkOrderDecisionCallbackDispatcher(
+        MagicMock(spec=HttpClient), resign_principal=StubResigner()
+    )
 
     assert dispatcher.requires_callback(
         WorkOrderEventType.HUMAN2BOT_FRIEND_APPLIED.value
@@ -373,7 +522,9 @@ def test_dispatcher_registers_both_friend_events() -> None:
 def test_dispatcher_invokes_registered_friend_handler() -> None:
     http = MagicMock(spec=HttpClient)
     http.post.return_value = _response({"success": True})
-    dispatcher = WorkOrderDecisionCallbackDispatcher(http)
+    dispatcher = WorkOrderDecisionCallbackDispatcher(
+        http, resign_principal=StubResigner()
+    )
 
     dispatcher.dispatch(
         context=_context(),

--- a/src/backend/tests/community/utils/test_gateway_principal_config.py
+++ b/src/backend/tests/community/utils/test_gateway_principal_config.py
@@ -9,24 +9,33 @@ These tests are the record of that wiring, of ``aud``/``iss`` being fixed in cod
 rather than configurable, and of the deliberate choice to deny rather than invent
 a fallback key: every way the key can fail to resolve ends in an empty key, and
 the verifier answers 401 to everything on an empty key.
+
+The same install also feeds the other direction — re-addressing a verified
+principal to BCN when the backend calls it on the caller's behalf — so BCN's
+trust values are pinned here too, and an unresolved key denies that as well.
 """
 
 from __future__ import annotations
 
 import logging
+import time
 
+import jwt
 import pytest
 
 from agentclaw.community.core.gateway_principal import (
     MIN_SIGNING_KEY_BYTES,
+    PrincipalVerificationError,
     is_weak_signing_key,
     key_fingerprint,
 )
 from agentclaw.community.plugin_api.secret_resolver import SecretResolver
 from agentclaw.community.utils.gateway_principal_config import (
+    get_bcn_principal_signer_config,
     get_principal_verifier_config,
     init_principal_verifier_config,
     reset_principal_verifier_config_cache,
+    resign_principal_for_bcn,
 )
 
 SECRET_NAME = "the-registered-secret-name"
@@ -85,6 +94,86 @@ def test_audience_and_issuer_are_fixed_in_code():
 
     assert config.audience == "backend"
     assert config.issuer == "gateway"
+
+
+def test_bcn_signer_reads_the_same_installed_key():
+    """One shared secret, two views of it — never a second credential."""
+    init_principal_verifier_config(_FakeResolver(_Secret(KEY)), SECRET_NAME, strict=False)
+
+    signer = get_bcn_principal_signer_config()
+
+    assert signer.signing_key == get_principal_verifier_config().signing_key
+    assert signer.key_fingerprint == key_fingerprint(KEY)
+
+
+def test_bcn_trust_values_are_fixed_in_code():
+    """BCN's half of the contract, pinned to the defaults BCN ships.
+
+    ``aud=bcs`` is what makes the friend-approval callback verifiable there at
+    all; ``kid=bare`` is checked before the signature is; ``iss`` names the
+    gateway both components trust. All three are BCN's requirements, and this
+    test is the record that changing them there means changing them here.
+    """
+    signer = get_bcn_principal_signer_config()
+
+    assert signer.audience == "bcs"
+    assert signer.issuer == "gateway"
+    assert signer.key_id == "bare"
+
+
+def test_re_addressing_produces_a_token_bcn_accepts():
+    """The whole fix, through the installed configuration rather than around it.
+
+    The inbound token is addressed to ``backend``, which is what BCN refuses and
+    what made every friend-approval callback fail. The re-addressed copy is
+    judged here exactly as BCN judges it — ``alg``/``typ``/``kid`` on the header,
+    ``iss``/``aud`` and the time claims under the shared key — with the caller
+    unchanged.
+    """
+    init_principal_verifier_config(_FakeResolver(_Secret(KEY)), SECRET_NAME, strict=False)
+    principals = [
+        {
+            "type": "user",
+            "subject": {"id": "u-1", "username": "alice@example.com"},
+        }
+    ]
+    now = int(time.time())
+    inbound = jwt.encode(
+        {
+            "iss": "gateway",
+            "aud": "backend",
+            "iat": now,
+            "exp": now + 60,
+            "principals": principals,
+        },
+        KEY,
+        algorithm="HS256",
+        headers={"kid": "bare"},
+    )
+
+    readdressed = resign_principal_for_bcn(inbound)
+
+    assert jwt.get_unverified_header(readdressed) == {
+        "alg": "HS256",
+        "typ": "JWT",
+        "kid": "bare",
+    }
+    claims = jwt.decode(
+        readdressed,
+        KEY,
+        algorithms=["HS256"],
+        audience="bcs",
+        issuer="gateway",
+        options={"require": ["exp", "iat", "iss", "aud"]},
+    )
+    assert claims["principals"] == principals
+    assert (claims["iat"], claims["exp"]) == (now, now + 60)
+
+
+def test_re_addressing_to_bcn_denies_before_boot():
+    """No key, no re-addressed credential — the same fail-closed as verifying."""
+    with pytest.raises(PrincipalVerificationError, match="no principal signing key"):
+        resign_principal_for_bcn("any.token.value")
 
 
 def test_before_boot_the_config_denies():

--- a/src/backend/tests/community/utils/test_gateway_principal_config.py
+++ b/src/backend/tests/community/utils/test_gateway_principal_config.py
@@ -107,18 +107,37 @@ def test_bcn_signer_reads_the_same_installed_key():
 
 
 def test_bcn_trust_values_are_fixed_in_code():
-    """BCN's half of the contract, pinned to the defaults BCN ships.
+    """The envelope a token addressed to BCN carries.
 
     ``aud=bcs`` is what makes the friend-approval callback verifiable there at
-    all; ``kid=bare`` is checked before the signature is; ``iss`` names the
-    gateway both components trust. All three are BCN's requirements, and this
-    test is the record that changing them there means changing them here.
+    all and ``kid=bare`` is checked before the signature is — both are BCN's
+    requirements, so changing them there means changing them here.
+
+    ``iss`` runs the other way: it names the component that signed this copy,
+    which is us, so it is the name the gateway knows us by rather than the
+    gateway's own. BCN has to be configured to trust it.
     """
     signer = get_bcn_principal_signer_config()
 
     assert signer.audience == "bcs"
-    assert signer.issuer == "gateway"
+    assert signer.issuer == "backend"
     assert signer.key_id == "bare"
+
+
+def test_the_issuer_we_assert_is_the_name_the_gateway_knows_us_by():
+    """One spelling for "this component", used in both directions.
+
+    The gateway addresses us as ``backend`` (its ``servers:`` key, which its
+    forwarder signs into ``aud``), so that is the audience we accept — and the
+    identity we issue under when we sign a token of our own. Deriving both from
+    one constant keeps a rename from changing only half of it.
+    """
+    init_principal_verifier_config(_FakeResolver(_Secret(KEY)), SECRET_NAME, strict=False)
+
+    assert (
+        get_bcn_principal_signer_config().issuer
+        == get_principal_verifier_config().audience
+    )
 
 
 def test_re_addressing_produces_a_token_bcn_accepts():
@@ -128,7 +147,7 @@ def test_re_addressing_produces_a_token_bcn_accepts():
     what made every friend-approval callback fail. The re-addressed copy is
     judged here exactly as BCN judges it — ``alg``/``typ``/``kid`` on the header,
     ``iss``/``aud`` and the time claims under the shared key — with the caller
-    unchanged.
+    unchanged. ``iss`` is this component, since this component signed it.
     """
     init_principal_verifier_config(_FakeResolver(_Secret(KEY)), SECRET_NAME, strict=False)
     principals = [
@@ -163,7 +182,7 @@ def test_re_addressing_produces_a_token_bcn_accepts():
         KEY,
         algorithms=["HS256"],
         audience="bcs",
-        issuer="gateway",
+        issuer="backend",
         options={"require": ["exp", "iat", "iss", "aud"]},
     )
     assert claims["principals"] == principals


### PR DESCRIPTION
> [!IMPORTANT]
> **This PR depends on a BCS-side change that is not in it.** The re-addressed token is issued as `iss=backend`, and BCS compares `iss` against a single configured value that every shipped config pins to `gateway` (`[gateway_principal] issuer` in `src/bcs/configs/bcs-config-{prod,local,example}.toml`, default in `config.rs:481`, enforced at `verifier.rs:122` via `validation.set_issuer(&[&self.trust.issuer])`). Until BCS trusts `backend` as an issuer, the friend callback fails there on the issuer check. That change is being handled separately.

## Problem

A friend-approval decision arrives on `/openapi/v1` carrying the gateway-signed `X-Avernet-Principal` that the backend has just verified, and applying it means calling BCN's `friend-connections/requests/{id}/accept|reject` routes as that same caller. `FriendDecisionCallbackHandler.handle()` relayed the inbound header verbatim.

That header cannot be relayed. The gateway addresses each principal token to exactly one upstream — its forwarder signs `aud` as the upstream's own key under `servers:` in `src/gateway/configs/application.yaml` — so the token the backend holds says `aud=backend`, while BCN requires `aud=bcs`. Every friend approval therefore failed BCN's audience check, the callback raised `WorkOrderCallbackError`, and the decision was never stored. No retry could have fixed it.

## Solution

Re-address the credential before forwarding it, in the one place that calls BCN on the caller's behalf.

- **`core/gateway_principal/signer.py` (new)** — `resign_principal_token()` verifies the inbound token in full (signature, `iss`, `aud`, `exp`, *and* the identity-set admission that every public route applies), then re-signs the same claims under a new envelope. `principals` and `exp`/`iat` are carried over untouched, so BCN authorizes the same caller the backend did and the copy dies exactly when the original does; unknown claims are preserved rather than dropped.
  Verifying first is load-bearing, not defensive: a function that signed whatever string it was handed would be a token-minting oracle for every component that trusts the shared key.
- **The envelope**, and which side each field belongs to:
  - `aud` → `bcs` and `kid` → `bare` are **BCN's** requirements (`src/bcs/api-contracts/v1/gateway-principal/contract.md`).
  - `iss` → `backend` is **ours**. The claims inside remain the gateway's assertions, but the signature over this copy is this component's, so the issuer names this component — `backend`, the gateway's `servers:` key for us, which is also the audience the gateway signs when it forwards to us. One constant (`_COMPONENT_NAME`) now feeds both, so a rename cannot change only half of it.
- **`core/gateway_principal/verifier.py`** — split into `decode_principal_token()` (signature/time) and `caller_from_claims()` (identity admission), with `verify_principal_token()` as their composition. The signer needs the claims themselves, not just the projected caller, and this keeps one place where the algorithm, leeway and required claims are pinned.
- **`utils/gateway_principal_config.py`** — pins the BCN envelope beside the verifier's own constants, reusing the same installed signing key, and exposes `resign_principal_for_bcn()`.
- **`core/work_orders/callbacks.py`** — the handler re-addresses the `X-Avernet-Principal` header (case-insensitively) and forwards every other header untouched. A principal that is present but cannot be re-addressed fails the callback closed, so no decision is persisted on a credential BCN would refuse; an absent one is left alone, which is the pre-existing behaviour the `has_principal=False` diagnostic already explains. Both the inbound and the forwarded token are now fingerprinted in the logs (`source_principal_fingerprint` / `principal_fingerprint`), since re-signing means they are different tokens.
- **`di/modules/work_orders_module.py`** — the composition root hands the dispatcher the re-signer, so the core seam keeps no knowledge of the signing key or the audience.

Rejected alternative: making the callback call BCN under a service credential of its own. That would apply the approval as the backend rather than as the approver, and BCN's authorization is written against the caller identity.

## Validation

Run locally with `.venv/bin/python -m pytest` (dependencies installed from PyPI; the pinned `mirrors.aliyun.com` index is unreachable from this environment, and `uv.lock` is left untouched):

- `tests/community/core/gateway_principal` — 31 passed (17 new in `test_signer.py`, judging the re-addressed token field by field against BCN's published header and claim requirements, plus the fail-closed cases: forged signature, expired, wrong issuer/audience, inadmissible identity set, no signing key).
- `tests/community/core/work_orders` — 76 passed (4 new: re-addressing, case-insensitive header, absent principal, fail-closed).
- `tests/community/utils` — 31 passed, including an end-to-end check that a token minted as the gateway mints it comes back out satisfying BCN's contract through the installed configuration, and that the issuer we assert is the audience we accept.
- `tests/community/di tests/community/adapters/http/openapi_v1 tests/community/utils` — 1977 passed, 2 skipped.
- `tests/community/architecture` — 249 passed (module boundaries, service-locator, layering guards).
- `python_sast_local.sh` block rules via flake8 — clean on every touched file.

CI on the first commit was green on all 8 checks, including Backend unit tests and Singlebox coverage (which this environment cannot run locally).

## Compatibility and risk

No schema, API or config-file changes on this side. The re-addressing is confined to the friend accept/reject callback; every other consumer of the principal is untouched.

**Ordering matters**: BCS must trust `backend` as an issuer before this reaches an environment where friend approvals are exercised, or the callback fails there on the issuer check rather than the audience check. BCS's `gateway_principal.{issuer,audience,key_id}` are per-deployment values, so they and the constants in `utils/gateway_principal_config.py` must stay in step in both directions.

A deployment with no signing key now fails the callback closed instead of sending a credential BCN would refuse; those deployments already answer 401 to the whole `/openapi/v1` surface, so the approval could not reach this code path there anyway.

Rollback is the revert of these commits: the handler returns to forwarding the header verbatim.

## Spec

`src/bcs/api-contracts/v1/gateway-principal/contract.md` — BCN's verifier contract, which the re-addressed token is built to satisfy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rnd3TjJreEEeqrMRp8VBp5