### PR TITLE
fix(backend): clarify SkillSet add conflicts

### DIFF
--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -198,6 +198,9 @@ PUT/GET/DELETE /bots/{bot_id}/skills/{skill_id}/installation
 - 同一 Bot 下，同一 Skill/MCP 最多属于一个 SkillSet，System Default 包含在内；excluded
   仍然属于 Default。
 - Direct active 资源不能加入任何 SkillSet；必须先 Direct deactivate。
+- Installation 行存在本身不证明 Direct：若该行可由 active ordinary SkillSet 或未 exclusion
+  的 System Default Membership 解释，则资源是 Set-managed，加入第二个 Set 时返回
+  `RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET`，而不是 `RESOURCE_DIRECT_ACTIVE`。
 - 已属于任何 reaching SkillSet 的资源不能单独 activate/deactivate；Default exclusion 只能
   通过 Default Set-scoped add/remove 命令切换。
 - 激活/停用 SkillSet 原子批量增删成员对应的 Installation 行。

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/schemas.py
@@ -478,6 +478,8 @@ class AddSkillsResult(BaseModel):
 class AddSkillsFailedResult(BaseModel):
     skill_id: str
     error: str
+    error_code: Optional[str] = None
+    message: Optional[str] = None
 
 
 class AddSkillsResponse(BaseModel):

--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skillsets.py
@@ -99,6 +99,12 @@ _LEGACY_SKILL_SET_BATCH_PARTIAL_CONFLICTS = frozenset(
         "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET",
     }
 )
+_LEGACY_SKILL_SET_BATCH_ERROR_MESSAGES = {
+    "RESOURCE_DIRECT_ACTIVE": "该 Skill 已单独激活，请先停用后再加入能力集。",
+    "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET": (
+        "该 Skill 已由其他能力集管理，不能重复添加。"
+    ),
+}
 
 
 # ==================== Helper Functions ====================
@@ -112,6 +118,20 @@ def _is_legacy_skill_set_batch_partial_failure(error: Exception) -> bool:
         isinstance(error, SkillSetControlPlaneConflictError)
         and str(error) in _LEGACY_SKILL_SET_BATCH_PARTIAL_CONFLICTS
     )
+
+
+def _legacy_skill_set_batch_failure(skill_id: str, error: Exception) -> dict[str, str]:
+    """Preserve the legacy error code while providing display-safe text."""
+    error_code = str(error)
+    return {
+        "skill_id": skill_id,
+        "error": error_code,
+        "error_code": error_code,
+        "message": _LEGACY_SKILL_SET_BATCH_ERROR_MESSAGES.get(
+            error_code,
+            "暂时无法添加该 Skill，请刷新后重试。",
+        ),
+    }
 
 
 def _legacy_actor(ctx: RequestContext, requested_user_id: str | None) -> str:
@@ -812,7 +832,9 @@ async def add_skills_to_set(
         ) as exc:
             if not _is_legacy_skill_set_batch_partial_failure(exc):
                 raise
-            results["failed"].append({"skill_id": skill_id, "error": str(exc)})
+            results["failed"].append(
+                _legacy_skill_set_batch_failure(str(skill_id), exc)
+            )
     if resolved:
         outcomes = await control_plane.add_skills(
             bot_id=effective_bot_id,
@@ -830,7 +852,7 @@ async def add_skills_to_set(
             assert outcome.error is not None
             if _is_legacy_skill_set_batch_partial_failure(outcome.error):
                 results["failed"].append(
-                    {"skill_id": legacy_skill_id, "error": str(outcome.error)}
+                    _legacy_skill_set_batch_failure(legacy_skill_id, outcome.error)
                 )
                 continue
             raise outcome.error

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/bot_skillset_installations.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/bot_skillset_installations.py
@@ -245,6 +245,60 @@ class BotSkillSetInstallations:
             mcps_to_uninstall=frozenset(inactive_mcps - active_mcps),
         )
 
+    def _has_active_skill_set_claim(
+        self,
+        session,
+        *,
+        bot_sets: list[SkillSet],
+        membership_set_ids: set[int],
+        skill_id: int,
+        bot_id: str,
+        owner_id: str,
+    ) -> bool:
+        """Whether an existing membership, rather than Direct, explains a Skill Installation."""
+        for row in bot_sets:
+            if int(row.id) not in membership_set_ids:
+                continue
+            if row.is_default:
+                excluded = default_exclusions.excluded_skill_ids(
+                    session,
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                    set_id=int(row.id),
+                )
+                if skill_id not in excluded:
+                    return True
+            elif row.is_active:
+                return True
+        return False
+
+    def _has_active_mcp_set_claim(
+        self,
+        session,
+        *,
+        bot_sets: list[SkillSet],
+        membership_set_ids: set[int],
+        server_code: str,
+        bot_id: str,
+        owner_id: str,
+    ) -> bool:
+        """Whether an existing membership, rather than Direct, explains an MCP Installation."""
+        for row in bot_sets:
+            if int(row.id) not in membership_set_ids:
+                continue
+            if row.is_default:
+                excluded = default_exclusions.excluded_mcp_codes(
+                    session,
+                    bot_id=bot_id,
+                    owner_id=owner_id,
+                    set_id=int(row.id),
+                )
+                if server_code not in excluded:
+                    return True
+            elif row.is_active:
+                return True
+        return False
+
     def _bot_sets(
         self,
         session,

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/capability_desired_state.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/capability_desired_state.py
@@ -344,32 +344,47 @@ class CapabilityDesiredStateRepository(
                 return DesiredStateMutation(_item(row), False, old)
             # R3 covers ANY of the Bot's Sets — the Default included, its
             # members excluded or not.
-            reachable_ids = {
-                int(candidate.id)
-                for candidate in self._bot_sets(
-                    session,
-                    bot_id=bot_id,
-                    owner_id=owner_id,
-                    engine_type=engine_type,
-                    default_engine_types=default_engine_types,
-                )
-            } - {int(row.id)}
+            bot_sets = self._bot_sets(
+                session,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                engine_type=engine_type,
+                default_engine_types=default_engine_types,
+            )
+            reachable_ids = {int(candidate.id) for candidate in bot_sets} - {
+                int(row.id)
+            }
             identity = [SkillSetSkill.skill_id == skill.id]
             if skill.skill_uuid:
                 identity.append(SkillSetSkill.skill_uuid == skill.skill_uuid)
-            membership = (
+            memberships = (
                 self._scope(session.query(SkillSetSkill), SkillSetSkill)
                 .filter(
                     SkillSetSkill.skill_set_id.in_(reachable_ids),
                     or_(*identity),
                 )
-                .first()
+                .all()
                 if reachable_ids
-                else None
+                else []
+            )
+            # Installation is the effective-capability SSOT, not its
+            # provenance.  An active Default/ordinary Set legitimately
+            # materializes an Installation row, so row existence alone must
+            # not turn a Set-managed Skill into a Direct-active Skill.
+            active_set_claim = self._has_active_skill_set_claim(
+                session,
+                bot_sets=bot_sets,
+                membership_set_ids={int(item.skill_set_id) for item in memberships},
+                skill_id=int(skill.id),
+                bot_id=bot_id,
+                owner_id=owner_id,
             )
             require_can_join_set(
-                is_directly_active=skill.id in old.installations,
-                is_in_another_set=membership is not None,
+                is_directly_active=(
+                    skill.id in old.installations
+                    and not active_set_claim
+                ),
+                is_in_another_set=bool(memberships),
             )
             if row.is_active:
                 self._require_unique_runtime_names(

--- a/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
+++ b/src/backend/src/agentclaw/community/core/repository/implementations/skill_center/mcp_skill_set_control_plane.py
@@ -83,29 +83,43 @@ class McpSkillSetControlPlaneCommands:
                 return DesiredStateMutation(self._as_item(row), False, old)
             # R3 covers ANY of the Bot's Sets — the Default included, its
             # members excluded or not.
-            reachable_ids = {
-                int(candidate.id)
-                for candidate in self._bot_sets(
-                    session,
-                    bot_id=bot_id,
-                    owner_id=owner_id,
-                    engine_type=engine_type,
-                    default_engine_types=default_engine_types,
-                )
-            } - {int(row.id)}
-            membership = (
+            bot_sets = self._bot_sets(
+                session,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                engine_type=engine_type,
+                default_engine_types=default_engine_types,
+            )
+            reachable_ids = {int(candidate.id) for candidate in bot_sets} - {
+                int(row.id)
+            }
+            memberships = (
                 self._scope(session.query(SkillSetMCPServer), SkillSetMCPServer)
                 .filter(
                     SkillSetMCPServer.skill_set_id.in_(reachable_ids),
                     SkillSetMCPServer.server_code == server_code,
                 )
-                .first()
+                .all()
                 if reachable_ids
-                else None
+                else []
+            )
+            # Keep MCP ownership aligned with Skill ownership: an active Set
+            # may have materialized this Installation, which is not Direct
+            # control merely because the Installation row exists.
+            active_set_claim = self._has_active_mcp_set_claim(
+                session,
+                bot_sets=bot_sets,
+                membership_set_ids={int(item.skill_set_id) for item in memberships},
+                server_code=server_code,
+                bot_id=bot_id,
+                owner_id=owner_id,
             )
             require_can_join_set(
-                is_directly_active=server_code in old.mcp_installations,
-                is_in_another_set=membership is not None,
+                is_directly_active=(
+                    server_code in old.mcp_installations
+                    and not active_set_claim
+                ),
+                is_in_another_set=bool(memberships),
             )
             session.add(SkillSetMCPServer(
                 skill_set_id=row.id, server_code=server_code, name=name,

--- a/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
+++ b/src/backend/tests/community/adapters/http/skill_center/test_legacy_skill_control_plane.py
@@ -334,7 +334,55 @@ async def test_legacy_skill_set_batch_keeps_domain_partial_success() -> None:
 
     assert response.success is True
     assert response.data["success"] == []
-    assert response.data["failed"][0]["skill_id"] == "7"
+    assert response.data["failed"] == [
+        {
+            "skill_id": "7",
+            "error": "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET",
+            "error_code": "RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET",
+            "message": "该 Skill 已由其他能力集管理，不能重复添加。",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_legacy_skill_set_batch_keeps_direct_error_code_and_adds_message() -> None:
+    class _ControlPlane:
+        def get_set(self, **_kwargs):
+            return {"id": "set-1", "is_default": False}
+
+        def resolve_legacy_skill_id(self, **kwargs):
+            return kwargs["identifier"]
+
+        async def add_skills(self, **_kwargs):
+            return [
+                SkillSetSkillOutcome(
+                    skill_id="7",
+                    error=SkillSetControlPlaneConflictError(
+                        "RESOURCE_DIRECT_ACTIVE"
+                    ),
+                )
+            ]
+
+    response = await add_skills_to_set(
+        "set-1",
+        AddSkillsRequest(skill_ids=["7"], user_id="owner", bot_id="bot"),
+        entity_id=None,
+        entity_type=None,
+        bot_id=None,
+        engine_type=None,
+        ctx=SimpleNamespace(user_id="owner", bot_id="bot"),
+        bot_repo=_Bots(),
+        control_plane=_ControlPlane(),
+    )
+
+    assert response.data["failed"] == [
+        {
+            "skill_id": "7",
+            "error": "RESOURCE_DIRECT_ACTIVE",
+            "error_code": "RESOURCE_DIRECT_ACTIVE",
+            "message": "该 Skill 已单独激活，请先停用后再加入能力集。",
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
+++ b/src/backend/tests/community/repository/skill_center/test_capability_desired_state_uow.py
@@ -2015,6 +2015,9 @@ def test_a_default_set_member_cannot_join_an_ordinary_set():
                 SkillSetSkill(
                     skill_set_id=default_set.id, skill_id=excluded.id, env="dev"
                 ),
+                BotSkillInstallation(
+                    bot_id="bot", owner_id="owner", skill_id=member.id, env="dev"
+                ),
                 DefaultSkillsetSkillExclusion(
                     user_id="owner",
                     bot_id="bot",
@@ -2111,6 +2114,11 @@ def test_a_default_set_mcp_member_cannot_join_an_ordinary_set():
                 server_code="mcp.default-member",
                 name="mcp.default-member",
                 env="dev",
+            )
+        )
+        session.add(
+            BotMCPInstallation(
+                bot_id="bot", owner_id="owner", server_code="mcp.default-member", env="dev"
             )
         )
 


### PR DESCRIPTION
## Summary
- Distinguish a true Direct Installation from an Installation materialized by an active ordinary SkillSet or unexcluded System Default membership.
- Return `RESOURCE_ALREADY_IN_ANOTHER_SKILL_SET` for Default/active Set members added to another Set; retain `RESOURCE_DIRECT_ACTIVE` only for a true Direct-effective capability.
- Apply the same ownership classification to Skills and MCPs without re-running a full Bot flush plan for every batch member.
- Keep legacy BFF `failed[].error` unchanged and add `error_code` plus user-facing Chinese `message`.

## Compatibility
- No DDL or OpenAPI change.
- Legacy batch callers that consume `failed[].error` continue receiving the stable raw code.
- Frontends can render additive `failed[].message` and fall back to `error` during rollout.

## Validation
- Focused UoW/BFF/ownership/service/architecture suite: 233 passed.
- Backend full suite: 16388 passed, 59 skipped.
- Ruff, local Python SAST, diff check passed.
- Standards/Spec dual review: one batch-performance P2 found and fixed; no remaining P0-P2.
