### PR TITLE
fix(backend): read Git Skill README from shared repository

### DIFF
--- a/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
+++ b/src/backend/src/agentclaw/community/adapters/http/skill_center/skills.py
@@ -1310,14 +1310,15 @@ async def get_skill_readme(
     skill_service_factory: SkillServiceFactoryProtocol = Injected(
         SkillServiceFactoryProtocol
     ),
+    query_service: SkillQueryServiceProtocol = Injected(SkillQueryServiceProtocol),
     skill_center_client: SkillCenterClient = Injected(SkillCenterClient),
     resolver: DeviceContextResolver = Injected(DeviceContextResolver),
 ) -> SkillReadmeResponse:
     """Get skill README content.
 
-    Looks up the skill in DB by id/link_name first. If git_path is center://,
-    fetch from SkillCenter file-content API; otherwise delegate to
-    SkillService.get_skill_readme (handles local://, git://, etc.).
+    Looks up the skill in DB by id/link_name first. Center content comes from
+    SkillCenter, Git market content from SkillQueryService, and local content
+    from the owning Bot's workspace.
     """
     logger.info(
         "[skills.get_skill_readme] Request: user_id=%s, ctx_bot_id=%s, "
@@ -1400,6 +1401,23 @@ async def get_skill_readme(
                 f"[skills.get_skill_readme] SkillCenter file-content failed: {e}"
             )
         raise HTTPException(status_code=404, detail="Skill or README not found")
+
+    # Git market content is shared. Its query seam resolves it from the global
+    # skills-repo, without treating a historical ``bolt_id`` as content owner.
+    if skill and (skill.get("git_path") or "").startswith("git://"):
+        try:
+            readme = await query_service.get_readme_by_skill(
+                skill_id=str(skill.get("id") or skill_id),
+                actor_id=ctx.user_id,
+            )
+        except LocalSkillNotFoundError as exc:
+            raise HTTPException(
+                status_code=404, detail="Skill or README not found"
+            ) from exc
+        if not readme:
+            raise HTTPException(status_code=404, detail="Skill or README not found")
+        logger.info(f"[skills.get_skill_readme] Found in Git market: skill_id={skill_id}")
+        return SkillReadmeResponse(success=True, data={"content": readme})
 
     # A Skill may be read while the caller is operating another Bot.  Its DB
     # ``bolt_id`` is the authoritative target; derive owner, entity type and

--- a/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
+++ b/src/backend/tests/community/api/skill_center/test_skills_routes_teclaw.py
@@ -18,6 +18,7 @@ from agentclaw.community.adapters.http.dependencies import (
 from agentclaw.community.adapters.http.skill_center.skills import (
     router as skills_router,
 )
+from agentclaw.community.core.skill_center.errors import LocalSkillNotFoundError
 
 pytestmark = pytest.mark.unit
 
@@ -80,6 +81,8 @@ def _app(skill_service):
         "has_permission": True,
         "level": "ADMIN",
     }
+    query_service = MagicMock()
+    query_service.get_readme_by_skill = AsyncMock()
 
     app = FastAPI()
     app.include_router(skills_router)
@@ -92,6 +95,9 @@ def _app(skill_service):
             )
             from agentclaw.community.api.skill_parameter_service_factory import (
                 SkillParameterServiceFactoryProtocol,
+            )
+            from agentclaw.community.api.skill_query_service import (
+                SkillQueryServiceProtocol,
             )
             from agentclaw.community.core.repository.protocols.bot import BotRepository
             from agentclaw.community.core.bot_collaborator.services.collaborator_lock_service import (
@@ -116,6 +122,7 @@ def _app(skill_service):
 
             binder.bind(SkillServiceFactory, to=factory)
             binder.bind(SkillServiceFactoryProtocol, to=factory)
+            binder.bind(SkillQueryServiceProtocol, to=query_service)
             binder.bind(WorkspacePathFactory, to=path_factory)
             binder.bind(BotRepository, to=bot_repo)
             binder.bind(DeviceContextResolver, to=resolver)
@@ -372,6 +379,92 @@ def test_readme_route_rejects_local_skill_when_owning_bot_is_missing():
     assert resp.status_code == 404
     assert resp.json()["detail"] == "Skill's owning bot was not found"
     assert factory.create.call_count == 1
+
+
+def test_readme_route_reads_git_skill_without_owning_bot():
+    lookup_svc = MagicMock()
+    lookup_svc.get_skill.return_value = {
+        "id": "1",
+        "name": "shared-skill",
+        "git_path": "git://infra/shared-skill",
+        "bolt_id": "deleted-bot",
+    }
+
+    client, factory, _ = _app(lookup_svc)
+    bot_repo = client.app.state.injector.get(
+        __import__(
+            "agentclaw.community.core.repository.protocols.bot",
+            fromlist=["BotRepository"],
+        ).BotRepository
+    )
+    bot_repo.get_unique_by_id.return_value = None
+    bot_repo.get_live_by_id_owner_and_env.return_value = []
+    query_service = client.app.state.injector.get(
+        __import__(
+            "agentclaw.community.api.skill_query_service",
+            fromlist=["SkillQueryServiceProtocol"],
+        ).SkillQueryServiceProtocol
+    )
+    query_service.get_readme_by_skill = AsyncMock(return_value="# Shared Skill")
+
+    resp = client.get("/api/skills/1/readme", params=_Q)
+
+    assert resp.status_code == 200
+    assert resp.json()["data"]["content"] == "# Shared Skill"
+    assert factory.create.call_count == 1
+    bot_repo.get_live_by_id_owner_and_env.assert_not_called()
+    bot_repo.get_unique_by_id.assert_not_called()
+    query_service.get_readme_by_skill.assert_awaited_once_with(
+        skill_id="1", actor_id="u1"
+    )
+
+
+def test_readme_route_returns_not_found_when_git_content_is_missing():
+    lookup_svc = MagicMock()
+    lookup_svc.get_skill.return_value = {
+        "id": "1",
+        "name": "shared-skill",
+        "git_path": "git://infra/shared-skill",
+        "bolt_id": "deleted-bot",
+    }
+    client, _, _ = _app(lookup_svc)
+    query_service = client.app.state.injector.get(
+        __import__(
+            "agentclaw.community.api.skill_query_service",
+            fromlist=["SkillQueryServiceProtocol"],
+        ).SkillQueryServiceProtocol
+    )
+    query_service.get_readme_by_skill = AsyncMock(
+        side_effect=LocalSkillNotFoundError()
+    )
+
+    resp = client.get("/api/skills/1/readme", params=_Q)
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Skill or README not found"
+
+
+def test_readme_route_rejects_empty_git_content():
+    lookup_svc = MagicMock()
+    lookup_svc.get_skill.return_value = {
+        "id": "1",
+        "name": "shared-skill",
+        "git_path": "git://infra/shared-skill",
+        "bolt_id": "deleted-bot",
+    }
+    client, _, _ = _app(lookup_svc)
+    query_service = client.app.state.injector.get(
+        __import__(
+            "agentclaw.community.api.skill_query_service",
+            fromlist=["SkillQueryServiceProtocol"],
+        ).SkillQueryServiceProtocol
+    )
+    query_service.get_readme_by_skill = AsyncMock(return_value="")
+
+    resp = client.get("/api/skills/1/readme", params=_Q)
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Skill or README not found"
 
 
 def test_readme_route_resolves_default_bot_by_env_owner_and_bot_id():


### PR DESCRIPTION
## Problem
Legacy README routing treated every non-SkillCenter record with a stored `bolt_id` as Bot-owned. Historical `git://` market rows can carry stale values, causing a 404 before the shared market content was read.

## Solution
Route `git://` README reads through `SkillQueryService.get_readme_by_skill`, which resolves the governed global `skills-repo` by stable Skill ID. Preserve the existing Bot-owned fail-closed path for `local://` and the SkillCenter path for `center://`.

## Validation
- `tests/community/api/skill_center/test_skills_routes_teclaw.py`
- `tests/community/core/skill_center/test_skill_query_service.py`
- Ruff on changed files
- Standards/Spec dual review
- Backend full suite intentionally not run locally per request; GitHub CI is the full-validation gate.

## Compatibility and risk
No schema or public response-shape change. Git market README requests no longer depend on stale `ac_skill.bolt_id`; Local and SkillCenter behavior is unchanged.