### PR TITLE
feat(backend): openapi create surface template_config contract + factory snapshot passthrough

### DIFF
--- a/docs/bot-create-api-guide.zh-CN.md
+++ b/docs/bot-create-api-guide.zh-CN.md
@@ -210,7 +210,7 @@ POST /openapi/v1/bots/20260813_a7k2m9p1/auth-status
 - **混传**：完整工厂快照（双键身份）+ 手填专用键（`devflow_workflow` / `code_repos` / `yuque_kb_repos`）→ 422 `template factory snapshot must not mix application-coding fields: [...]`。工厂路径不解读手填键，两种形态**二选一**。只带零散工厂键（缺 `template_uid`）混有手填键 → 走手填路径，工厂键按未知键存活。
 - **组合约束（工厂与手填同受约束）**：`engine` 必须 `claude_code` + `bot_type=personal` + 个人空间 + 云端。违反 → 409（`BotCombinationUnsupportedError`，既语文案如 `application coding is cloud-only` / `application coding does not support engine: ...`）。
 
-**密钥落库口径**：顶层 `token` 出现即按既有策略加密落密文；`bot_template_config.ext_config.thetaKey` 后端无加密入口，密文由调用方产生、原样落库。两者在查询面**永不回显**（密文也不回，见 §1.4）。
+**密钥落库口径**：顶层 `token` 出现即按既有策略加密落密文；`bot_template_config.ext_config.thetaKey` 后端无加密入口，密文由调用方产生、原样落库。查询面按 #1785 verbatim 决策随存随显（见 §1.4）。
 
 ### 1.4 查询接口（创建后核对 / 列表展示）
 
@@ -220,9 +220,7 @@ POST /openapi/v1/bots/20260813_a7k2m9p1/auth-status
 | `GET /openapi/v1/bots/{bot_id}` | 单个 bot 详情 |
 | `GET /openapi/v1/bots/all`（Header `X-Space-Id` 可选） | 统一卡片列表（个人云/服务/本地） |
 
-响应中的模板相关字段（三个端点一致），按存档快照是否带工厂标记键（`template_key` / `template_uid` / `template_version` / `template_version_id` 任一）**双轨投影**：
-
-**工厂 bot —— 整段落库快照透传，只减两个敏感位置：**
+响应中的模板相关字段（三个端点一致）——**整段落库快照 verbatim 回显**（REL20260901 #1785 决策：查询面 owner-scoped，回显的是创建者自己的输入，不做投影过滤）：
 
 ```json
 "template_type": "normalCC",
@@ -237,23 +235,10 @@ POST /openapi/v1/bots/20260813_a7k2m9p1/auth-status
 }
 ```
 
-- 顶层 `token` 与 `bot_template_config.ext_config.thetaKey` **永不返回**（密文也不返回）；**其余全回**——`image` / `resource_spec` / `envs` / `capabilities` / `template_name` / `custom_field_values` 及 `bot_template_config` 的其余嵌套键。创建时存进去什么，查询就回什么。
-- `template_type` = 创建时的透传值。
-- 老 TC 链路落的存量工厂 bot，三个查询面同样切到透传投影（**有意变更，非回归**）。
+- **创建时存进去什么，查询就回什么**——包括调用方自己传入的 `token` / `bot_template_config.ext_config.thetaKey`（按 #1785 的 owner-scoped 决策随存随显）；`token` 落库时按既有策略存的是密文。
+- `template_type` = 创建时的值（透传值或手填形态的 `applicationCoding`）。
+- 工厂 bot 与手填 applicationCoding bot 查询行为一致，无分轨。
 
-**无工厂标记的 bot（含手填 applicationCoding）—— 仍走原白名单投影（原 6 键）：**
-
-```json
-"template_type": "applicationCoding",        // 无模板为 null
-"template_config": {
-  "template_key": "...", "template_uid": "...",
-  "code_repos": [...], "yuque_kb_repos": [...], "devflow_workflow": "...",
-  "engine_form": "aicoding"                   // 仅 aicoding 形态 bot 带 markers
-}
-```
-
-> `token`、`ext_config.thetaKey` 等密钥在两条投影轨**都**永不回显。
->
 > **前端判据**：**识别工厂 bot**——`template_config.template_uid` 非空（或 `template_key` / `template_version` / `template_version_id` 任一存在）。**判定 aicoding 形态**——`template_config.engine_form == "aicoding"`，或 `template_type` 非空且不等于 `"normalCC"`（任一命中即 aicoding 运行时；`normalCC` 是纯 claude_code 模板）。`engine` 字段只可能是真实引擎。
 
 ---

--- a/docs/bot-create-api-guide.zh-CN.md
+++ b/docs/bot-create-api-guide.zh-CN.md
@@ -1,8 +1,9 @@
 # Bot 创建接口对接指南（新 openapi / 老内部 API）
 
-> 面向前端。覆盖两条创建链路的请求/响应契约、错误码，以及"从第三方 openapi 拿 aicoding 配置来创建 Bot"的接入指引。
+> 面向前端。覆盖两条创建链路的请求/响应契约、错误码，以及"从模板工厂 / 第三方 openapi 拿 aicoding 配置来创建 Bot"的接入指引。
 >
-> 适用版本：backend `feat/engine-vocabulary-template-form`（engine/aicoding 词汇分离）之后。
+> 适用版本：backend `feat/engine-vocabulary-template-form`（engine/aicoding 词汇分离）之后，含 openapi 模板入参 v3 契约（`engine_properties.template_type` + `template_config`，工厂快照透传）。
+> v3 契约设计文档：[docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md](superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md)
 
 ---
 
@@ -14,7 +15,7 @@
 | 授权轮询 | `POST /openapi/v1/bots/{bot_id}/auth-status`（GET 拼写逐步退休中） | `POST /api/bots/auth-status` |
 | 鉴权 | 经 OCB 网关注入租户身份；owner 以 `user_id` 口径（详见网关接入文档） | 浏览器会话（buservice cookie） |
 | 引擎值 | **只收真实引擎**：`openclaw` / `claude_code` / `teclaw` / `hermes` / `moltis`；传 `aicoding` → 400 | 收上述引擎；传 `aicoding` 会被后端**自动折叠**为 `claude_code`（兼容存量调用） |
-| 模板入参 | `engine_properties.template`（一个自由 dict，严格校验见 §1.3） | `template_type` + `template_config` 两个字段直传（校验宽松，见 §2.1） |
+| 模板入参 | `engine_properties.template_type` + `template_config`（工厂快照透传——与 available-tc-list item 逐字段对应；或手填 applicationCoding。严格校验见 §1.3） | `template_type` + `template_config` 两个字段直传（校验宽松，见 §2.1） |
 | 响应封套 | `{code, message, data, request_id}`，`code = HTTP状态码×1000` | `{success, message, error_code, data}` |
 | 状态 | 测试中，未上线 | 已在线 |
 
@@ -36,7 +37,7 @@
 | `cluster_name` | string | ✅ | `ACRA`（teclaw 以外的一切引擎）/ `ANDC`（仅 teclaw），与 engine 一一对应，错配 400 |
 | `bot_type` | string | ✅ | `personal` 或 `service` |
 | `space_id` | string | — | 业务空间上下文，缺省用个人空间 |
-| `engine_properties` | object | — | 引擎私有入参；缺省=普通 bot；提供则**只允许一个键 `template`**（见 §1.3） |
+| `engine_properties` | object | — | 引擎私有入参；缺省=普通 bot。提供则**只允许两个键**：`template_type`（工厂快照必传、照抄模板值；手填省略或写死 `applicationCoding`）+ `template_config`（非空 dict，必填）。形态判定与校验见 §1.3 |
 
 **请求示例 A —— 普通 bot：**
 
@@ -51,7 +52,7 @@ POST /openapi/v1/bots
 }
 ```
 
-**请求示例 B —— applicationCoding（aicoding 形态）bot：**
+**请求示例 B —— 手填 applicationCoding（aicoding 形态，散字段拼装）：**
 
 ```json
 POST /openapi/v1/bots
@@ -62,7 +63,8 @@ POST /openapi/v1/bots
   "cluster_name": "ACRA",
   "bot_type": "personal",
   "engine_properties": {
-    "template": {
+    "template_type": "applicationCoding",
+    "template_config": {
       "devflow_workflow": "app-flow-id",
       "code_repos": ["https://code.example.com/team/svc"],
       "yuque_kb_repos": ["team/kb"],
@@ -70,6 +72,53 @@ POST /openapi/v1/bots
     }
   }
 }
+```
+
+（`template_type` 可省略——手填形态允许省略或写 `applicationCoding`，传其它值 422，见 §1.3 ②。）
+
+**请求示例 C —— 工厂模板快照照抄（从 available-tc-list 选模板创建，推荐）：**
+
+把 `/openapi/v1/bot-templates/available-tc-list` 返回的 item **逐字段照抄**即可——零键名映射、零二次 resolve 调用：
+
+```json
+POST /openapi/v1/bots
+{
+  "bot_name": "my-bot",
+  "bot_desc": "从模板工厂选模板创建",
+  "engine": "claude_code",
+  "cluster_name": "ACRA",
+  "bot_type": "personal",
+  "engine_properties": {
+    "template_type": "normalCC",
+    "template_config": {
+      "template_key": "applicationCoding",
+      "template_uid": "aicoding_bot_template",
+      "template_version": "V1",
+      "template_version_id": 2800006,
+      "template_name": "应用 Bot",
+      "image": "reg.antgroup-inc.cn/aicoding/bot-runtime:1.2.3",
+      "resource_spec": { "cpu": "4", "memory": "8g", "disk": "50" },
+      "envs": { "APP_LANG": "zh-CN" },
+      "capabilities": { "enable_network": true },
+      "bot_template_config": { "ext_config": { "thetaKey": "..." } }
+    }
+  }
+}
+```
+
+请求字段与 tc-list item 的逐字段对应：
+
+| 请求字段 | 来源（tc-list item） | 说明 |
+|---|---|---|
+| `engine` | `item.engine_type` | — |
+| `bot_type` | `item.bot_type` | — |
+| `engine_properties.template_type` | `item.template_type` | **照抄原值，任意值**（`normalCC` / `architect` / 用户自建字符串都合法，后端不校验值域）；工厂形态**必传**，缺失/空串 422 |
+| `engine_properties.template_config` | `item.template_config` | **整段原样回传**：`template_key` / `template_uid` / `template_version` / `template_version_id` / `template_name` / `image` / `resource_spec` / `envs` / `capabilities` / `bot_template_config` 等快照键全部保留，**一个键都不删**（含 `template_uid`，见 §1.3 ①） |
+
+用户在模板动态表单里填的值**追加**为 `template_config.custom_field_values`（dict，键名以该模板的表单 schema 为准；模板未开动态表单则不带该键）：
+
+```json
+"custom_field_values": { "repo_url": "https://code.example.com/team/svc" }
 ```
 
 **响应：**
@@ -87,7 +136,7 @@ POST /openapi/v1/bots
 
   前端引导用户完成 `iframe_url` 授权，然后轮询 §1.2。
 
-**错误码**：400 不支持的引擎/集群错配（`code: 400000`）、403 无权限、404 空间不存在、409 名称重复、422 请求体校验失败（含 server-managed 字段，见 §1.3）。
+**错误码**：400 不支持的引擎/集群错配（`code: 400000`）、403 无权限、404 空间不存在、409 名称重复或组合不支持（见 §1.3 ⑤）、422 请求体校验失败（server-managed 字段 / 混传 / 形态冒充，见 §1.3）。
 
 ### 1.2 授权轮询 `POST /openapi/v1/bots/{bot_id}/auth-status`
 
@@ -101,7 +150,7 @@ POST /openapi/v1/bots/20260813_a7k2m9p1/auth-status
   "bot_name": "coding-bot",
   "bot_desc": "应用研发 bot",
   "bot_type": "personal",
-  "engine_properties": { "template": { "...": "与创建时一致" } }
+  "engine_properties": { "template_type": "…", "template_config": { "…": "与创建时一致" } }
 }
 ```
 
@@ -117,29 +166,51 @@ POST /openapi/v1/bots/20260813_a7k2m9p1/auth-status
 
 `bot` 仅在 `ISSUED` 时返回。Passport 尚未就绪时返回 `PENDING` + 提示 message，继续轮询即可。
 
-### 1.3 `engine_properties.template` 校验规则（重点）
+### 1.3 `engine_properties` 校验规则（重点）
 
-这是一个**自由透传 dict**，但有以下硬规则：
+`engine_properties` 只收两个键（`extra=forbid`，多传 422 `unsupported engine_properties fields: [...]`，**旧键 `template` 已废**）：
 
-**① 顶层 server-managed 键，出现即 422（整单拒绝）：**
+- `template_type`（string，可省）
+- `template_config`（非空 dict；缺失/空 → 422 `applicationCoding template_config must not be empty`）
 
-`workspace_id`、`template_uid`、`bot_id`、`workspace_status`、`workspace_state`、`start_status`、`engine_form`
+提供 `engine_properties` 时走哪种**形态由 `template_config` 的内容自动判定**（判定与运行时消费完全对齐，前端不用声明）：
 
-这些是**平台管理的身份/形态字段**，不收外部输入。注意：`engine_form`（aicoding 形态标记）由后端在需要时写入，前端**永远不要传**。
+| 形态 | 判定 | 落库行为 |
+|---|---|---|
+| **工厂快照透传**（§1.1 示例 C） | `template_config.template_key` 与 `template_config.template_uid` **双非空** | 快照原样落库，`template_type` 用透传值（值域开放，照抄 item）；**不做键级类型校验** |
+| **手填 applicationCoding**（§1.1 示例 B） | 无上述双键身份（零散工厂键按未知键存活） | 固定 `template_type=applicationCoding`；键级类型校验照旧 |
 
-**② 已知键的类型检查（类型不符 422）：**
+**① server-managed 键，出现即 422（整单拒绝，`template_config contains server-managed fields: [...]`）：**
+
+两种形态**都拒**：`workspace_id`、`bot_id`、`workspace_status`、`workspace_state`、`start_status`、`engine_form`
+
+这些是**平台管理的身份/形态字段**，不收外部输入。`engine_form`（aicoding 形态标记）由后端在需要时写入，前端**永远不要传**。
+
+- 工厂快照形态：此外对**四个工厂身份键 `template_key` / `template_uid` / `template_version` / `template_version_id` 放行**——快照里的身份键照抄回传即可，**`template_uid` 不需要前端剔除**。
+- 手填形态：上表之外还拒 **`template_uid`**（模板 uid 由平台侧解析/分配；手填里出现即拒，想要工厂身份就走完整快照）。
+
+**② 手填形态的 `template_type` 冒充防护：**
+
+手填形态 `template_type` 省略或写死 `"applicationCoding"`；传**其它任何值 → 422**（`engine_properties.template_type must be applicationCoding for non factory snapshots`）。想要 `normalCC`/`architect`/自建的 `template_type`，必须带完整工厂快照（`template_key` + `template_uid` 双键）走工厂路径。
+
+**③ 已知键的类型检查（类型不符 422）——仅手填形态；工厂快照不做键级类型校验，透传：**
 
 | 键 | 类型 | 说明 |
 |---|---|---|
 | `devflow_workflow` | string \| object | 工作流标识/描述 |
 | `code_repos` | array | 代码仓库 |
 | `yuque_kb_repos` | array | 语雀知识库 |
-| `bot_template_config` | object | 引擎侧配置（密钥放 `ext_config` 下透传，如 `thetaKey`；`token` 会加密落库） |
+| `bot_template_config` | object | 引擎侧配置（密钥放 `ext_config` 下透传，如 `thetaKey`；顶层 `token` 会加密落库） |
 | `token` | string | 若出现必须非空 |
 
-**③ 其它未知键**：原样存活、随快照落库（引擎自有扩展），但**平台不解读**——见 §3 命名提醒。
+**④ 未知键**：原样存活、随快照落库（引擎自有扩展），但**平台不解读**——见 §3 命名提醒。工厂快照同理：未知键透传落库、平台不解读。
 
-**④ 组合约束**（带 `template` 创建时）：`engine` 必须 `claude_code` + `bot_type=personal` + 个人空间 + 云端。违反 → 409。
+**⑤ 混传拒绝 + 组合约束：**
+
+- **混传**：完整工厂快照（双键身份）+ 手填专用键（`devflow_workflow` / `code_repos` / `yuque_kb_repos`）→ 422 `template factory snapshot must not mix application-coding fields: [...]`。工厂路径不解读手填键，两种形态**二选一**。只带零散工厂键（缺 `template_uid`）混有手填键 → 走手填路径，工厂键按未知键存活。
+- **组合约束（工厂与手填同受约束）**：`engine` 必须 `claude_code` + `bot_type=personal` + 个人空间 + 云端。违反 → 409（`BotCombinationUnsupportedError`，既语文案如 `application coding is cloud-only` / `application coding does not support engine: ...`）。
+
+**密钥落库口径**：顶层 `token` 出现即按既有策略加密落密文；`bot_template_config.ext_config.thetaKey` 后端无加密入口，密文由调用方产生、原样落库。两者在查询面**永不回显**（密文也不回，见 §1.4）。
 
 ### 1.4 查询接口（创建后核对 / 列表展示）
 
@@ -149,18 +220,41 @@ POST /openapi/v1/bots/20260813_a7k2m9p1/auth-status
 | `GET /openapi/v1/bots/{bot_id}` | 单个 bot 详情 |
 | `GET /openapi/v1/bots/all`（Header `X-Space-Id` 可选） | 统一卡片列表（个人云/服务/本地） |
 
-响应中的模板相关字段（三个端点一致）：
+响应中的模板相关字段（三个端点一致），按存档快照是否带工厂标记键（`template_key` / `template_uid` / `template_version` / `template_version_id` 任一）**双轨投影**：
+
+**工厂 bot —— 整段落库快照透传，只减两个敏感位置：**
+
+```json
+"template_type": "normalCC",
+"template_config": {
+  "template_key": "applicationCoding", "template_uid": "aicoding_bot_template",
+  "template_version": "V1", "template_version_id": 2800006,
+  "template_name": "应用 Bot",
+  "image": "reg.antgroup-inc.cn/...", "resource_spec": { "cpu": "4", "memory": "8g", "disk": "50" },
+  "envs": { "...": "..." }, "capabilities": { "...": false },
+  "custom_field_values": { "repo_url": "..." },
+  "bot_template_config": { "...": "..." }
+}
+```
+
+- 顶层 `token` 与 `bot_template_config.ext_config.thetaKey` **永不返回**（密文也不返回）；**其余全回**——`image` / `resource_spec` / `envs` / `capabilities` / `template_name` / `custom_field_values` 及 `bot_template_config` 的其余嵌套键。创建时存进去什么，查询就回什么。
+- `template_type` = 创建时的透传值。
+- 老 TC 链路落的存量工厂 bot，三个查询面同样切到透传投影（**有意变更，非回归**）。
+
+**无工厂标记的 bot（含手填 applicationCoding）—— 仍走原白名单投影（原 6 键）：**
 
 ```json
 "template_type": "applicationCoding",        // 无模板为 null
-"template_config": {                          // 白名单投影，secret 永不返回
+"template_config": {
   "template_key": "...", "template_uid": "...",
   "code_repos": [...], "yuque_kb_repos": [...], "devflow_workflow": "...",
   "engine_form": "aicoding"                   // 仅 aicoding 形态 bot 带 markers
 }
 ```
 
-> `template_config` 是**服务的白名单投影**（`engine_form`/`code_repos` 等展示安全键），`token`、`ext_config.thetaKey` 等密钥永远不回。**前端判定"是否 aicoding 形态"：`template_config.engine_form == "aicoding"`，或 `template_type` 非空且不等于 `"normalCC"`**（任一命中即 aicoding 运行时；`normalCC` 是纯 claude_code 模板）。`engine` 字段只可能是真实引擎。
+> `token`、`ext_config.thetaKey` 等密钥在两条投影轨**都**永不回显。
+>
+> **前端判据**：**识别工厂 bot**——`template_config.template_uid` 非空（或 `template_key` / `template_version` / `template_version_id` 任一存在）。**判定 aicoding 形态**——`template_config.engine_form == "aicoding"`，或 `template_type` 非空且不等于 `"normalCC"`（任一命中即 aicoding 运行时；`normalCC` 是纯 claude_code 模板）。`engine` 字段只可能是真实引擎。
 
 ---
 
@@ -203,14 +297,19 @@ Body 必带 `bot_id`，其余与创建一致回传。响应 `data.status ∈ {PE
 
 ---
 
-## 3. aicoding 场景接入指引（第三方配置 → 创建）
+## 3. aicoding 场景接入指引（模板工厂 / 第三方配置 → 创建）
 
-前端从其他团队 openapi 取到 aicoding 配置后调我们的创建接口，按下面映射：
+前端拿到 aicoding 配置的来源分两类，拼装方式二选一：**模板快照**（available-tc-list 选模板）→ 工厂照抄；**散字段**（第三方 openapi）→ 手填拼装。
 
 **第一步：engine 固定填 `claude_code`（两个接口都一样）。**
 不要透传第三方配置里可能出现的 `aicoding` 引擎值——openapi 面会 400；老 API 虽会自动折叠，也请显式传 `claude_code` 以获得一致行为。
 
-**第二步：把第三方配置字段映射进 `engine_properties.template`（openapi）/ `template_config`（老 API）：**
+**第二步：按配置来源分流。**
+
+- **来源是 available-tc-list item（模板快照，推荐）→ 直接走工厂快照照抄（§1.1 请求示例 C）**：`engine ← item.engine_type`、`bot_type ← item.bot_type`、`engine_properties.template_type ← item.template_type`（照抄原值）、`engine_properties.template_config ← item.template_config` **整段原样回传**（含 `template_uid` 等身份键，后端放行，无需剔除），用户动态表单值**追加**为 `template_config.custom_field_values`。**这条路径零键名映射、不做键级类型校验、不剔除任何键。**
+- **来源是散字段（第三方给的不是模板快照）→ 按第三步映射表手填拼装。**
+
+**第三步（手填形态）：映射进 `engine_properties.template_config`（openapi，附 `template_type: "applicationCoding"` 或省略）/ `template_config`（老 API），并剔除 server-managed 键：**
 
 | 第三方可能的字段 | 我们契约的键位 | 说明 |
 |---|---|---|
@@ -220,15 +319,15 @@ Body 必带 `bot_id`，其余与创建一致回传。响应 `data.status ∈ {PE
 | 密钥类（thetaKey 等） | `bot_template_config.ext_config.*` | 嵌套透传，落库加密策略同现状 |
 | token | `token` | 出现就必须非空 |
 
-**第三步：剔除/不要携带这些键（openapi 面必 422）：**
-`template_uid`、`workspace_id`、`bot_id`、`workspace_status`、`workspace_state`、`start_status`、`engine_form`。如果第三方配置里带 `template_uid`，**由前端丢弃**（模板 uid 由平台侧解析/分配）。
+**手填必须剔除/不要携带这些键（openapi 面 422）：**
+`template_uid`、`workspace_id`、`bot_id`、`workspace_status`、`workspace_state`、`start_status`、`engine_form`。如果第三方配置里带 `template_uid`，**由前端丢弃**（模板 uid 由平台侧解析/分配；这条只约束手填形态——工厂快照来源整段回传放行）。**也不要把手填键拼进完整工厂快照**（422 混传拒绝，见 §1.3 ⑤）。
 
 **注意事项：**
 
-1. **命名即语义**：未知键虽然会原样存活落库，但平台只解读上表的键名——第三方字段名若与上表不一致，配置会"存了但没人读"，静默失效。拿到第三方 openapi 的字段表后，先与后端对一遍映射。
-2. **形态不需要前端表达**：`engine=claude_code` + applicationCoding 模板创建的 bot，运行时自动路由 aicoding 实现；`engine_form` 由后端在折叠老链路 `aicoding` 引擎值时写入，前端不传。查询面识别形态的判据见 §1.4。
-3. **约束**：applicationCoding 创建目前仅支持 `bot_type=personal` + 个人空间。
-4. **模板工厂模板（normalCC/architect/用户自建）**：老 API 可用（`template_type` 直传），openapi 面**暂无创建入口**，需要的话单独提需求。
+1. **命名即语义（手填形态）**：未知键虽然会原样存活落库，但平台只解读上表的键名——第三方字段名若与上表不一致，配置会"存了但没人读"，静默失效。拿到第三方 openapi 的字段表后，先与后端对一遍映射。
+2. **形态不需要前端表达**：`engine=claude_code` + applicationCoding 手填创建的 bot，运行时自动路由 aicoding 实现；`engine_form` 由后端在折叠老链路 `aicoding` 引擎值时写入，前端不传。查询面识别形态的判据见 §1.4。
+3. **约束**：applicationCoding 创建目前仅支持 `engine=claude_code` + `bot_type=personal` + 个人空间 + 云端（手填与工厂快照同受此组合约束，违反 409）。
+4. **模板工厂模板（normalCC/architect/用户自建）**：openapi 面单已支持——走工厂快照透传（§1.1 请求示例 C），`template_type` 照抄 item 值；老 API 照旧 `template_type` 直传。
 
 ---
 
@@ -237,8 +336,12 @@ Body 必带 `bot_id`，其余与创建一致回传。响应 `data.status ∈ {PE
 | 现象 | 原因 | 处理 |
 |---|---|---|
 | openapi 创建 400 `unsupported engine` | `engine` 传了 `aicoding` 或未部署的引擎 | 改传 `claude_code` 等真实引擎 |
-| openapi 创建 422 提到 `server-managed fields` | `template` 里带了 `template_uid`/`engine_form` 等 | 剔除这些键（§3 第三步） |
-| openapi 创建 422 `extra inputs not permitted` | 请求体多了未知字段（如 `engine_options`） 或 `engine_properties` 下不是 `template` | 对照 §1.1 字段表 |
-| openapi 创建 409 `application coding does not support...` | 带模板但 engine≠claude_code / bot_type≠personal / 非个人空间 | 对照 §1.3 ④ |
+| openapi 创建 422 `applicationCoding template_config must not be empty` | `template_config` 缺失或空 dict | 工厂=快照整段回传；手填=散字段拼装，非空必填 |
+| openapi 创建 422 提到 `server-managed fields` | 手填 `template_config` 带了 `template_uid`/`engine_form` 等；或工厂快照带了 `workspace_id`/`engine_form` 等 | 手填：剔除这些键（§3 第三步）；工厂快照：四个工厂身份键（`template_key`/`template_uid`/`template_version`/`template_version_id`）放行，其余 server-managed 键剔除 |
+| openapi 创建 422 `template factory snapshot must not mix application-coding fields` | 完整工厂快照（`template_key`+`template_uid`）里混了 `devflow_workflow`/`code_repos`/`yuque_kb_repos` 手填键 | 工厂与手填二选一：快照整段回传，别拼手填键（§1.3 ⑤） |
+| openapi 创建 422 `engine_properties.template_type is required for template factory snapshots` | 工厂快照未传 `engine_properties.template_type`（或空串） | 照抄 tc-list item 的 `template_type`（§1.1 示例 C 字段表） |
+| openapi 创建 422 `engine_properties.template_type must be applicationCoding for non factory snapshots` | 手填形态传了 `applicationCoding` 以外的 `template_type` | 手填省略该键或写死 `applicationCoding`；要其它值走工厂快照 |
+| openapi 创建 422 `extra inputs not permitted` | 请求体多了未知字段（如 `engine_options`），或 `engine_properties` 下不是 `template_type`/`template_config`（旧键 `template` 已废） | 对照 §1.1 字段表与 §1.3 键域 |
+| openapi 创建 409 `application coding does not support...` 等 | 带模板载荷（工厂**或**手填）但 engine≠claude_code / bot_type≠personal / 非个人空间 / 非云端 | 对照 §1.3 ⑤（工厂与手填同受约束） |
 | 老接口创建成功但 `active_engine` 变成 `claude_code` | `engine_type=aicoding` 被折叠（预期行为） | 无需处理；形态看查询面的 `engine_form`/`template_type` |
 | auth-status 一直 PENDING | 用户未完成 iframe 授权或 Passport 未就绪 | 继续轮询；终态值（REJECTED 等）会以 400 返回 |

--- a/docs/superpowers/plans/2026-09-01-openapi-template-config-passthrough.md
+++ b/docs/superpowers/plans/2026-09-01-openapi-template-config-passthrough.md
@@ -1,0 +1,979 @@
+# OpenAPI template_config 快照透传 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 `POST /openapi/v1/bots` 接收 template-factory 快照(`engine_properties.template_type + template_config`,与 available-tc-list item 逐字段对应),原样落库;三个查询面(bots/{id}/all)对工厂快照透传回显(减密钥);`template` 键改名 `template_config`。
+
+**Architecture:** strategy 工厂分支判定与运行时消费(`consumes_template_config`)对齐(`template_key`+`template_uid` 双非空);查询投影在 `project_template_config_for_public` 内 dispatch(四键任一 → 透传投影),`_to_bot` 与 `/all` attach 零改动;密钥(token)加密走既有 `_encrypt_token_field` 门控,thetaKey 无后端加密入口、原样落库、查询剔除。
+
+**Tech Stack:** Python 3.11+ / pydantic v2 / pytest / FastAPI(backend `src/backend`);网关 OpenAPI 契约 `src/gateway/configs/schemas/bots.openapi.json`(手工精准 patch,禁止全量 regen)+ ocb 仓库双写。
+
+**设计 spec(权威):** `docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md`
+
+**测试跑法(全部命令在仓库根 `/Users/rongzhi/PycharmProjects/Avernet` 下执行):**
+
+- 单文件单测:`cd src/backend && uv run pytest tests/community/<path> -v`
+- 变更行覆盖率 gate(推 PR 前必跑):`bash src/backend/scripts/ci_test.sh`(本地自动推导 base ref,与 CI 同阈值)
+- gateway 契约:`cd src/gateway && uv run pytest tests -k "bots" -v`
+
+**执行约定(用户已拍板):** 每 Task 实现+测试,全部完成后**一次批量终审**(不做每 Task 双重审查);分支从 `origin/dev` 新开 `feat/openapi-template-config-passthrough`。
+
+---
+
+### Task 1: strategy.prepare_create 键域迁移 + 工厂快照分支
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py:150-237`(`prepare_create`)
+- Test: `src/backend/tests/community/core/bot_management/test_application_coding_create.py`
+
+- [ ] **Step 1: 迁移既有测试键名(`"template"` → `"template_config"`)并写新工厂用例(RED)**
+
+在 `test_application_coding_create.py` 里,把所有调用 `_strategy_prepare` / `BotCreateSpec(engine_properties=...)` / 断言里的字面量 `{"template": ...}` 全局替换为 `{"template_config": ...}`(文件内约 20 处;`create_flow` 包装用例见 Task 2,本 Task 只改 strategy 直调的)。然后在文件尾部追加以下用例(完整代码):
+
+```python
+# ── template-factory snapshot passthrough (v3 contract) ─────────────────────
+
+_FACTORY_SNAPSHOT = {
+    "template_key": "applicationCoding",
+    "template_uid": "aicoding_bot_template",
+    "template_version": "V1",
+    "template_version_id": 2800006,
+    "template_name": "应用 Bot",
+    "image": "reg.antgroup-inc.cn/aixcoding/aixcoding-arca:20260901140138",
+    "resource_spec": {"cpu": "4", "memory": "8g", "disk": "50"},
+    "envs": {"AIX_SKIP_DAEMON": "false"},
+    "capabilities": {"channel_management": False},
+    "bot_template_config": {"id": 2800006, "custom_field_config": {}},
+    "custom_field_values": {"field_a": "value_a"},
+}
+
+
+def test_factory_snapshot_passthrough_keeps_type_and_config_verbatim() -> None:
+    prepared = _strategy_prepare(
+        "claude_code",
+        {
+            "template_type": "applicationCoding",
+            "template_config": dict(_FACTORY_SNAPSHOT),
+        },
+    )
+    assert prepared.template_type == "applicationCoding"
+    assert prepared.template_config == _FACTORY_SNAPSHOT
+    # requires_workspace_hosting 与老 TC 直传链路一致:工厂模板不加 hosting 门槛
+    assert prepared.requires_workspace_hosting is not True
+
+
+def test_factory_snapshot_accepts_any_template_type_value() -> None:
+    snapshot = dict(_FACTORY_SNAPSHOT, template_key="userCustomTemplate")
+    prepared = _strategy_prepare(
+        "claude_code",
+        {"template_type": "custom_xxx", "template_config": snapshot},
+    )
+    assert prepared.template_type == "custom_xxx"
+    assert prepared.template_config == snapshot
+
+
+def test_factory_snapshot_requires_declared_template_type() -> None:
+    with pytest.raises(BotTemplateInvalidError) as excinfo:
+        _strategy_prepare(
+            "claude_code", {"template_config": dict(_FACTORY_SNAPSHOT)}
+        )
+    assert "template_type" in str(excinfo.value)
+
+
+def test_factory_snapshot_rejects_plain_template_type() -> None:
+    with pytest.raises(BotTemplateInvalidError):
+        _strategy_prepare(
+            "claude_code",
+            {
+                "template_type": " ",
+                "template_config": dict(_FACTORY_SNAPSHOT),
+            },
+        )
+
+
+def test_factory_snapshot_rejects_handcrafted_field_mix() -> None:
+    mixed = dict(_FACTORY_SNAPSHOT, devflow_workflow="app-flow")
+    with pytest.raises(BotTemplateInvalidError) as excinfo:
+        _strategy_prepare(
+            "claude_code",
+            {"template_type": "applicationCoding", "template_config": mixed},
+        )
+    assert "devflow_workflow" in str(excinfo.value)
+
+
+def test_factory_snapshot_public_mode_rejects_server_managed_fields() -> None:
+    polluted = dict(_FACTORY_SNAPSHOT, engine_form="aicoding")
+    with pytest.raises(BotTemplateInvalidError):
+        _strategy_prepare(
+            "claude_code",
+            {"template_type": "applicationCoding", "template_config": polluted},
+            template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
+        )
+
+
+def test_factory_snapshot_keeps_factory_marker_keys_in_public_mode() -> None:
+    # template_key/template_uid/version 键不在 RESERVED 清单,PUBLIC 模式放行
+    prepared = _strategy_prepare(
+        "claude_code",
+        {"template_type": "applicationCoding", "template_config": dict(_FACTORY_SNAPSHOT)},
+        template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
+    )
+    assert prepared.template_config["template_uid"] == "aicoding_bot_template"
+
+
+def test_factory_snapshot_gates_match_application_coding() -> None:
+    props = {"template_type": "architect", "template_config": dict(_FACTORY_SNAPSHOT)}
+    with pytest.raises(BotCombinationUnsupportedError):
+        _strategy_prepare("claude_code", props, deployment_mode="local")
+    with pytest.raises(BotCombinationUnsupportedError):
+        _strategy_prepare("openclaw", props)
+    with pytest.raises(BotCombinationUnsupportedError):
+        _strategy_prepare("claude_code", props, bot_type="service")
+    with pytest.raises(BotCombinationUnsupportedError):
+        _strategy_prepare("claude_code", props, space_kind="team")
+
+
+def test_handcrafted_path_rejects_foreign_template_type() -> None:
+    with pytest.raises(BotTemplateInvalidError):
+        _strategy_prepare(
+            "claude_code",
+            {"template_type": "architect", "template_config": {"devflow_workflow": "x"}},
+        )
+
+
+def test_engine_properties_with_template_key_only_stays_handcrafted() -> None:
+    # 不完整快照(缺 template_uid)→ 走手填路径,工厂键按未知键存活(现状)
+    prepared = _strategy_prepare(
+        "claude_code",
+        {
+            "template_config": {
+                "template_key": "applicationCoding",
+                "devflow_workflow": "x",
+            }
+        },
+    )
+    assert prepared.template_type == "applicationCoding"
+    assert prepared.template_config["template_key"] == "applicationCoding"
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_management/test_application_coding_create.py -v`
+Expected: FAIL —— 迁移后的旧用例报 `unsupported engine_properties fields: ['template']` 或 `engine_properties.template_config is required`;新工厂用例报 template_type/template 未按工厂处理。
+
+- [ ] **Step 3: 重写 `prepare_create`(GREEN)**
+
+`strategy.py` — 先加模块级常量(放在 `CODING_TEMPLATE_TYPES` 定义附近):
+
+```python
+#: Public ``engine_properties`` envelope keys (v3 contract). The single
+#: implementation behind the hand-written application-coding shape and the
+#: template-factory snapshot passthrough shape.
+_ENGINE_PROPERTIES_KEYS = frozenset({"template_type", "template_config"})
+_HANDCRAFTED_MIX_REJECT_KEYS = (
+    "devflow_workflow",
+    "yuque_kb_repos",
+    "code_repos",
+)
+```
+
+然后用下面的完整新实现替换 `prepare_create` 的方法体(方法签名不变;原 150-237 整段替换):
+
+```python
+    def prepare_create(
+        self,
+        *,
+        engine_type: str,
+        engine_properties: Dict[str, Any],
+        bot_type: str,
+        deployment_mode: str,
+        space_kind: str,
+        template_validation_mode: BotCreateTemplateValidationMode = (
+            BotCreateTemplateValidationMode.LEGACY
+        ),
+    ) -> PreparedBotCreate:
+        """Parse and validate coding create input (single owner).
+
+        Two input shapes: the public ``engine_properties.template_config``
+        hand-written application-coding config, and the template-factory
+        snapshot passthrough (identified by full template identity:
+        ``template_key`` + ``template_uid``, aligned with
+        ``consumes_template_config``). Combination gates keep their
+        historical order, error types and messages so the HTTP mappings
+        answer identically; server-managed-field rejection follows the
+        caller's validation mode.
+        """
+        if not engine_properties:
+            return PreparedBotCreate()
+
+        # Envelope integrity for keys this engine owns. The public schema's
+        # ``extra="forbid"`` cannot guard direct Core-level spec construction,
+        # so unknown keys fail here instead of being silently ignored.
+        unknown_keys = set(engine_properties) - _ENGINE_PROPERTIES_KEYS
+        if unknown_keys:
+            raise BotTemplateInvalidError(
+                f"unsupported engine_properties fields: {sorted(unknown_keys)}"
+            )
+        if "template_config" not in engine_properties:
+            raise BotTemplateInvalidError(
+                "engine_properties.template_config is required"
+            )
+        declarative_type = engine_properties.get("template_type")
+
+        # Historical combination gates, in their historical order. The gate set
+        # and messages are mirrored (production-dead) in
+        # ``bot_inventory/policies/combo_policy.py``
+        # ``assert_application_coding_create`` — keep the two in sync, or
+        # single-source them once bot_management may depend on bot_inventory.
+        if deployment_mode != "cloud":
+            raise BotCombinationUnsupportedError("application coding is cloud-only")
+        if engine_type != CLAUDE_CODE_ENGINE_TYPE:
+            # The strategy class is registered for both engine types, but
+            # application-coding creation stays claude_code-only.
+            raise BotCombinationUnsupportedError(
+                f"application coding does not support engine: {engine_type}"
+            )
+        if bot_type != "personal":
+            raise BotCombinationUnsupportedError(
+                "application coding bot must be personal"
+            )
+        if space_kind != "personal":
+            raise BotCombinationUnsupportedError(
+                "application coding is personal-space only"
+            )
+
+        template = engine_properties["template_config"]
+        if self._is_factory_snapshot(template):
+            return self._prepare_factory_snapshot(
+                declarative_type=declarative_type,
+                template=template,
+                template_validation_mode=template_validation_mode,
+            )
+
+        if declarative_type is not None and declarative_type != "applicationCoding":
+            # Non-factory inputs may only declare the legacy type; anything
+            # else must come through a factory snapshot instead.
+            raise BotTemplateInvalidError(
+                "engine_properties.template_type must be applicationCoding "
+                "for non factory snapshots"
+            )
+        if template is None:
+            # Core-only legacy compatibility shape: the key's presence is the
+            # application-coding intent, ``None`` the intentionally-omitted
+            # config. The public schema requires a non-empty dict, so callers
+            # cannot express this through HTTP.
+            return PreparedBotCreate(
+                template_type="applicationCoding",
+                template_config=None,
+                requires_workspace_hosting=True,
+            )
+        sanitized = to_internal_template_config(
+            template,
+            reject_server_managed_fields=(
+                template_validation_mode is BotCreateTemplateValidationMode.PUBLIC
+            ),
+        )
+        return PreparedBotCreate(
+            template_type="applicationCoding",
+            template_config=_validate_application_coding_config(sanitized),
+            requires_workspace_hosting=True,
+        )
+
+    @staticmethod
+    def _is_factory_snapshot(template: Any) -> bool:
+        """Full template identity, matching ``consumes_template_config``.
+
+        ``template_key`` AND ``template_uid`` both non-empty: a snapshot with
+        only scattered factory keys stays on the hand-crafted path (factory
+        keys survive as unknown keys) so creation perception never diverges
+        from runtime consumption.
+        """
+        if not isinstance(template, Mapping):
+            return False
+        return bool(template.get("template_key") and template.get("template_uid"))
+
+    def _prepare_factory_snapshot(
+        self,
+        *,
+        declarative_type: Any,
+        template: Any,
+        template_validation_mode: BotCreateTemplateValidationMode,
+    ) -> PreparedBotCreate:
+        """Validate and pass through a template-factory snapshot verbatim.
+
+        Passthrough contract: the caller (available-tc-list consumer) owns
+        the snapshot semantics; we only enforce identity completeness, the
+        no-mix rule against hand-written keys, and (in PUBLIC mode) the
+        server-managed-field ownership rules. No ``template_type`` value
+        validation — the factory vocabulary is open.
+        """
+        if not isinstance(template, dict) or not template:
+            raise BotTemplateInvalidError(
+                "applicationCoding template_config must not be empty"
+            )
+        if not (isinstance(declarative_type, str) and declarative_type.strip()):
+            raise BotTemplateInvalidError(
+                "engine_properties.template_type is required for template "
+                "factory snapshots"
+            )
+        mixed = [key for key in _HANDCRAFTED_MIX_REJECT_KEYS if key in template]
+        if mixed:
+            raise BotTemplateInvalidError(
+                "template factory snapshot must not mix application-coding "
+                f"fields: {sorted(mixed)}"
+            )
+        return PreparedBotCreate(
+            template_type=declarative_type,
+            template_config=to_internal_template_config(
+                template,
+                reject_server_managed_fields=(
+                    template_validation_mode
+                    is BotCreateTemplateValidationMode.PUBLIC
+                ),
+            ),
+            # No workspace-hosting gate: aligned with the legacy TC direct
+            # path (create_flow generic branch), NOT the applicationCoding
+            # DIMA hosting requirement.
+        )
+```
+
+注意:原方法里 `if not template:`(空 dict 拒绝)分支在手填路径被吸收进 `_validate_application_coding_config`(空 dict 返回时它报"must not be empty")——保持:`sanitized` 为空 dict 时 `_validate_application_coding_config({})` 抛"applicationCoding template_config must not be empty"。上面的手填路径删除了独立的 `if not template:` 检查,确认空 dict 场景仍被 `_validate_application_coding_config` 覆盖(它的第一支就是 `if not value: raise`)。
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_management/test_application_coding_create.py -v`
+Expected: PASS(全部)。若有失败,先看失败信息是否来自 create_flow 包装用例(Task 2 处理),strategy 直调用例必须全绿再继续。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py \
+        src/backend/tests/community/core/bot_management/test_application_coding_create.py
+git commit -m "feat(backend): accept template-factory snapshots in engine_properties"
+```
+
+---
+
+### Task 2: create_flow legacy 包装键名迁移
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/core/bot_management/create_flow.py:322`
+- Test: `src/backend/tests/community/core/bot_management/test_application_coding_create.py`(routing 用例)
+
+- [ ] **Step 1: 确认/补 routing 用例(RED)**
+
+`test_application_coding_create.py` 已有 create_flow routing 用例(`_prepare_spec` + `_application_coding_spec`)。确认 Task 1 的迁移已把它们的 engine_properties 断言改为 `{"template_config": ...}`;若没有显式断言包装形态,追加:
+
+```python
+def test_legacy_application_coding_pair_is_wrapped_as_template_config() -> None:
+    prepared = _prepare_spec(_application_coding_spec())
+    # create_flow 把 legacy pair 归一成 strategy 的 v3 键域后消费
+    assert prepared.template_type == "applicationCoding"
+    assert prepared.template_config == {"devflow_workflow": "x"}
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_management/test_application_coding_create.py -v`
+Expected: routing 用例 FAIL(`unsupported engine_properties fields: ['template']` —— create_flow:322 还在包 `{"template": ...}`)。
+
+- [ ] **Step 3: 改 create_flow.py:322 一个词**
+
+```python
+        prepared = _prepare_with_engine_strategy(
+            replace(
+                spec, engine_properties={"template_config": spec.template_config}
+            ),
+            context,
+        )
+```
+
+(原来是 `engine_properties={"template": spec.template_config}`;`comment 318-320 里的 “‘template’ key's presence” 改为 “‘template_config’ key's presence”。)
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_management/test_application_coding_create.py -v`
+Expected: PASS 全绿。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/src/agentclaw/community/core/bot_management/create_flow.py \
+        src/backend/tests/community/core/bot_management/test_application_coding_create.py
+git commit -m "refactor(backend): wrap legacy application-coding pair as template_config"
+```
+
+---
+
+### Task 3: HTTP schema 键名迁移 + 端到端用例
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py:176-187`
+- Modify: `src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/router.py`(`_engine_properties_from_body` 无需改——`model_dump(exclude_none=True)` 自动跟随 pydantic 键名)
+- Test: `src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py`
+
+- [ ] **Step 1: 迁移 HTTP 测试键名 + 新用例(RED)**
+
+`test_bots_endpoints.py` 里所有 `"engine_properties": {"template": ...}`(约 680-1000 行区间,含 poll 面 945-974)改为 `"engine_properties": {"template_config": ...}`;`test_create_rejects_unknown_engine_properties_fields`(764)的 body 改成:
+
+```python
+            "engine_properties": {
+                "template_config": {},
+                "template_uid": "caller-controlled",
+            },
+```
+
+`test_create_schema_nests_template_under_engine_properties`(1388-1402)改名 `test_create_schema_nests_template_config_under_engine_properties`,断言改:
+
+```python
+    assert set(engine_properties) == {"template_type", "template_config"}
+    assert engine_properties["template_config"]["required"] == ["template_config"]
+```
+
+注:这条断言等 Task 5 的 gateway JSON patch 后才真正绿;本 Task 先改断言,Task 5 patch 后统一复验(Step 4 的运行命令先跑不含它的选择:`-k "not schema_nests"`)。
+
+在 create 用例区追加(完整代码):
+
+```python
+_FACTORY_SNAPSHOT_BODY = {
+    "template_type": "applicationCoding",
+    "template_config": {
+        "template_key": "applicationCoding",
+        "template_uid": "aicoding_bot_template",
+        "template_version": "V1",
+        "template_version_id": 2800006,
+        "template_name": "应用 Bot",
+        "image": "reg.antgroup-inc.cn/aixcoding/arca:20260901140138",
+        "resource_spec": {"cpu": "4", "memory": "8g", "disk": "50"},
+        "envs": {"AIX_SKIP_DAEMON": "false"},
+        "capabilities": {"channel_management": False},
+        "bot_template_config": {"id": 2800006},
+        "custom_field_values": {"field_a": "value_a"},
+    },
+}
+
+
+def test_create_factory_snapshot_passthrough_persists_verbatim(
+    client, svc, passport
+):
+    passport.apply_first_agent_passport.return_value = {
+        "token": "tok",
+        "agent_code": "ac",
+    }
+    with patch.object(bots_router, "generate_bot_id", return_value="default"):
+        response = client.post(
+            "/openapi/v1/bots",
+            json={
+                **_CREATE_BODY,
+                "engine": "claude_code",
+                "engine_properties": dict(_FACTORY_SNAPSHOT_BODY),
+            },
+        )
+    assert response.status_code == 201, response.json()
+    kwargs = svc.create_bot.call_args.kwargs
+    assert kwargs["template_type"] == "applicationCoding"
+    assert kwargs["template_config"] == _FACTORY_SNAPSHOT_BODY["template_config"]
+
+
+def test_create_factory_snapshot_missing_template_type_is_422(client, svc):
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine": "claude_code",
+            "engine_properties": {
+                "template_config": _FACTORY_SNAPSHOT_BODY["template_config"]
+            },
+        },
+    )
+    assert response.status_code == 422, response.json()
+    svc.create_bot.assert_not_called()
+
+
+def test_create_factory_snapshot_server_managed_field_is_422(client, svc):
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine": "claude_code",
+            "engine_properties": {
+                **_FACTORY_SNAPSHOT_BODY,
+                "template_config": {
+                    **_FACTORY_SNAPSHOT_BODY["template_config"],
+                    "engine_form": "aicoding",
+                },
+            },
+        },
+    )
+    assert response.status_code == 422, response.json()
+    svc.create_bot.assert_not_called()
+
+
+def test_create_factory_snapshot_mix_is_422(client, svc):
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine": "claude_code",
+            "engine_properties": {
+                **_FACTORY_SNAPSHOT_BODY,
+                "template_config": {
+                    **_FACTORY_SNAPSHOT_BODY["template_config"],
+                    "devflow_workflow": "x",
+                },
+            },
+        },
+    )
+    assert response.status_code == 422, response.json()
+    svc.create_bot.assert_not_called()
+
+
+def test_create_handcrafted_with_foreign_template_type_is_422(client, svc):
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine": "claude_code",
+            "engine_properties": {
+                "template_type": "architect",
+                "template_config": {"devflow_workflow": "x"},
+            },
+        },
+    )
+    assert response.status_code == 422, response.json()
+    svc.create_bot.assert_not_called()
+
+
+def test_create_rejects_legacy_template_key_name(client, svc):
+    # 改名反向回归:v1 契约的 "template" 键已不存在
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine": "claude_code",
+            "engine_properties": {"template": {"devflow_workflow": "x"}},
+        },
+    )
+    assert response.status_code == 422, response.json()
+    svc.create_bot.assert_not_called()
+
+
+def test_create_factory_snapshot_for_service_bot_is_409(client, svc):
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine": "claude_code",
+            "bot_type": "service",
+            "engine_properties": dict(_FACTORY_SNAPSHOT_BODY),
+        },
+    )
+    assert response.status_code == 409, response.json()
+    svc.create_bot.assert_not_called()
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && uv run pytest tests/community/adapters/http/openapi_v1/test_bots_endpoints.py -k "not schema_nests" -v`
+Expected: FAIL —— 迁移用例 422(`extra inputs not permitted`: pydantic 只有 `template` 键);工厂新用例 422/405 等未实现行为。
+
+- [ ] **Step 3: 改 pydantic schema(GREEN)**
+
+`schemas.py` 176-187 段整体替换为:
+
+```python
+class BotCreateEngineProperties(BaseModel):
+    """Engine-specific properties used while creating a bot."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    template_type: str | None = Field(
+        description=(
+            "Template type declared with the config. Required for template-"
+            "factory snapshots (any value, echoed from available-t-templates); "
+            "for hand-written application-coding configs omit it or pass "
+            "'applicationCoding'."
+        ),
+        default=None,
+    )
+    template_config: dict[str, Any] = Field(
+        description=(
+            "Template configuration. Either hand-written application-coding "
+            "properties, or a template-factory snapshot (identified by "
+            "template_key + template_uid) echoed verbatim from "
+            "bot-templates/available-tc-list; platform-managed identity and "
+            "lifecycle fields are not accepted."
+        ),
+    )
+```
+
+- [ ] **Step 4: 跑测试确认通过**
+
+Run: `cd src/backend && uv run pytest tests/community/adapters/http/openapi_v1/test_bots_endpoints.py -k "not schema_nests" -v`
+Expected: PASS 全绿(端点级契约由 pydantic + Task 1 的 strategy 组合达成)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py \
+        src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+git commit -m "feat(backend): rename openapi create template key and accept factory snapshots"
+```
+
+---
+
+### Task 4: 查询投影 dispatch + 工厂快照透传
+
+**Files:**
+- Modify: `src/backend/src/agentclaw/community/core/bot_management/template_public_view.py`
+- Test: `src/backend/tests/community/core/bot_management/test_template_public_view.py`
+- Test: `src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py`
+
+- [ ] **Step 1: 写投影用例(RED)**
+
+`test_template_public_view.py` 追加(完整代码,`project_template_config_for_public` 已有的 import 风格随文件头):
+
+```python
+_FACTORY_SNAPSHOT = {
+    "template_key": "applicationCoding",
+    "template_uid": "aicoding_bot_template",
+    "template_version_id": 2800006,
+    "template_name": "应用 Bot",
+    "image": "reg.antgroup-inc.cn/arca:20260901140138",
+    "resource_spec": {"cpu": "4", "memory": "8g"},
+    "envs": {"AIX_SKIP_DAEMON": "false"},
+    "capabilities": {"channel_management": False},
+    "bot_template_config": {
+        "id": 2800006,
+        "ext_config": {"thetaKey": "enc:v1:deadbeef", "other": "keep"},
+    },
+    "custom_field_values": {"field_a": "value_a"},
+    "token": "enc:v1:tokenblob",
+}
+
+
+def test_factory_snapshot_passthrough_returns_everything_but_secrets() -> None:
+    projected = project_template_config_for_public(_FACTORY_SNAPSHOT)
+    assert projected is not None
+    assert projected["template_key"] == "applicationCoding"
+    assert projected["image"] == "reg.antgroup-inc.cn/arca:20260901140138"
+    assert projected["resource_spec"] == {"cpu": "4", "memory": "8g"}
+    assert projected["envs"] == {"AIX_SKIP_DAEMON": "false"}
+    assert projected["custom_field_values"] == {"field_a": "value_a"}
+    assert "token" not in projected
+    assert "thetaKey" not in projected["bot_template_config"]["ext_config"]
+    assert projected["bot_template_config"]["ext_config"]["other"] == "keep"
+
+
+def test_factory_snapshot_projection_is_a_detached_copy() -> None:
+    config = {"template_key": "k", "template_uid": "u", "envs": {"a": "b"}}
+    projected = project_template_config_for_public(config)
+    projected["envs"]["a"] = "mutated"
+    assert config["envs"]["a"] == "b"
+
+
+def test_snapshot_with_scattered_factory_key_only_stays_allowlisted() -> None:
+    # 只带 template_key(无 uid)的非 applicationCoding config 不构成工厂快照:allowlist 判定照旧
+    config = {"template_key": "applicationCoding"}
+    # template_key 在 allowlist 里,回现有投影
+    projected = project_template_config_for_public(config)
+    assert projected == {"template_key": "applicationCoding"}
+
+
+def test_handwritten_config_stays_allowlisted_after_dispatch() -> None:
+    config = {"devflow_workflow": "w1", "code_repos": ["r1"]}
+    assert project_template_config_for_public(config) == config
+```
+
+- [ ] **Step 2: 跑测试确认失败**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_management/test_template_public_view.py -v`
+Expected: FAIL(工厂快照走 allowlist,`image` 等键丢失/None)。
+
+- [ ] **Step 3: 实现投影(GREEN)**
+
+`template_public_view.py` 在文件头 import 区追加:
+
+```python
+from copy import deepcopy
+
+from agentclaw.community.core.bot_management.capabilities import (
+    TEMPLATE_FACTORY_MARKER_KEYS,
+)
+```
+
+文件规则注释块(第 9-14 行)追加一条:
+
+```python
+# - Template-factory snapshots are the documented exception: they pass
+#   through verbatim minus their secret locations (token, thetaKey) — the
+#   caller stored them, the caller reads them back.
+```
+
+在 `project_template_config_for_public` 之前加两个新成员,并给该函数加 dispatch 首行:
+
+```python
+#: Secret locations stripped from passthrough factory snapshots. The outer
+#: ``token`` and ``bot_template_config.ext_config.thetaKey`` mirror the
+#: provisioning strategy's encryption paths.
+_FACTORY_SECRET_TOP_KEYS = ("token",)
+_THETA_SECRET_PATH = ("bot_template_config", "ext_config", "thetaKey")
+
+
+def _is_factory_snapshot(config: Mapping[str, Any]) -> bool:
+    return any(key in config for key in TEMPLATE_FACTORY_MARKER_KEYS)
+
+
+def project_factory_template_snapshot(
+    config: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Project a template-factory snapshot onto its passthrough subset.
+
+    Everything the caller stored comes back except the secret locations.
+    Factory snapshots always carry ``template_key``, so an empty result is
+    not expected; return ``None`` anyway to keep the None contract uniform.
+    """
+    projected = deepcopy(dict(config))
+    for key in _FACTORY_SECRET_TOP_KEYS:
+        projected.pop(key, None)
+    nested = projected.get(_THETA_SECRET_PATH[0])
+    if isinstance(nested, dict):
+        ext = nested.get(_THETA_SECRET_PATH[1])
+        if isinstance(ext, dict):
+            ext.pop(_THETA_SECRET_PATH[2], None)
+    return projected or None
+
+
+def project_template_config_for_public(
+    config: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Project a stored template snapshot onto its public display subset."""
+    if not isinstance(config, Mapping) or not config:
+        return None
+    if _is_factory_snapshot(config):
+        return project_factory_template_snapshot(config)
+    ...  # ← 现有 allowlist 主体(42-54 行)原样保留
+```
+
+现有主体保留不动(从 `if not any(key in config ...)` 到 return)。
+
+- [ ] **Step 4: 跑投影测试确认通过**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_management/test_template_public_view.py -v`
+Expected: PASS 全绿。
+
+- [ ] **Step 5: /all attach 面用例(存量工厂快照切换 + 全量回显)**
+
+`test_bot_inventory_service.py` 在 `test_page_slice_attaches_projected_template_config`(716)后追加(完整代码,复用该用例的 service/page 构造 helper 形态——以现有 716 用例的局部 setup 为模板,改 ext 内容):
+
+```python
+def test_page_slice_attaches_factory_snapshot_verbatim_minus_secrets(
+    service,
+) -> None:
+    # 存量工厂快照(老 TC 链路落的)在 /all 切到透传投影(spec §6 有意变更)
+    service_template = (
+        _service_with_template_bot(
+            "bot-factory-1",
+            template_type="applicationCoding",
+            ext={
+                "template_key": "applicationCoding",
+                "template_uid": "aicoding_bot_template",
+                "image": "reg.antgroup-inc.cn/arca:1",
+                "resource_spec": {"cpu": "4"},
+                "bot_template_config": {
+                    "ext_config": {"thetaKey": "enc:v1:x"}
+                },
+            },
+        )
+    )
+    items, _ = service.list_items(page=1, page_size=20)
+    item = next(i for i in items if i.bot_id == "bot-factory-1")
+    assert item.template_config == {
+        "template_key": "applicationCoding",
+        "template_uid": "aicoding_bot_template",
+        "image": "reg.antgroup-inc.cn/arca:1",
+        "resource_spec": {"cpu": "4"},
+        "bot_template_config": {"ext_config": {}},
+    }
+```
+
+注:`_service_with_template_bot` 是按现有 716 用例的 setup 内联改写的示意 helper 名——执行时直接以现有用例的 service/bot 行构造方式内联,不要新造 helper(以 716 用例真实代码为准搬移)。
+
+- [ ] **Step 6: 跑 attach 用例确认通过**
+
+Run: `cd src/backend && uv run pytest tests/community/core/bot_inventory/services/test_bot_inventory_service.py -v`
+Expected: PASS 全绿(716 老用例改键后也应保持:它的 ext 里 `{"template_key": "normalCC"}` 只带 key 无 uid → 到 allowlist 仍是 `{"template_key": "normalCC"}`,断言不变即验证了"散键不切投影")。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/backend/src/agentclaw/community/core/bot_management/template_public_view.py \
+        src/backend/tests/community/core/bot_management/test_template_public_view.py \
+        src/backend/tests/community/core/bot_inventory/services/test_bot_inventory_service.py
+git commit -m "feat(backend): passthrough-project factory template snapshots on queries"
+```
+
+---
+
+### Task 5: gateway 契约双写(avernet + ocb)
+
+**Files:**
+- Modify: `src/gateway/configs/schemas/bots.openapi.json`(BotCreateEngineProperties 段,约 877-895 行)
+- Modify: `src/gateway/tests/fixtures/bots.openapi.json`(同段)
+- Modify(ocb 仓库): `~/IdeaProjects/ocb/src/gateway/configs/schemas/bots.openapi.json` + `~/IdeaProjects/ocb/src/gateway/tests/fixtures/bots.openapi.json`(若存在对应段;ocb 双写是既有约定)
+
+**手工精准 patch,禁止全量 regen**(golden 快照流程,记忆既有约定)。
+
+- [ ] **Step 1: patch 两个 JSON 的 BotCreateEngineProperties 段**
+
+把 `configs/schemas/bots.openapi.json` 中:
+
+```json
+      "BotCreateEngineProperties": {
+        "additionalProperties": false,
+        "description": "Engine-specific properties used while creating a bot.",
+        "properties": {
+          "template": {
+            "additionalProperties": true,
+            "description": "Application-coding template properties. Passed through unchanged to the template validator; platform-managed identity and lifecycle fields are not accepted.",
+            "title": "Template",
+            "type": "object"
+          }
+        },
+        "required": ["template"],
+        "title": "BotCreateEngineProperties",
+        "type": "object"
+      },
+```
+
+替换为(注意保持 JSON 键序、缩进与文件风格一致 —— properties 按字母序 `template_config` < `template_type`):
+
+```json
+      "BotCreateEngineProperties": {
+        "additionalProperties": false,
+        "description": "Engine-specific properties used while creating a bot.",
+        "properties": {
+          "template_config": {
+            "additionalProperties": true,
+            "description": "Template configuration. Either hand-written application-coding properties, or a template-factory snapshot (identified by template_key + template_uid) echoed verbatim from bot-templates/available-tc-list; platform-managed identity and lifecycle fields are not accepted.",
+            "title": "Template Config",
+            "type": "object"
+          },
+          "template_type": {
+            "anyOf": [
+              { "type": "string" },
+              { "type": "null" }
+            ],
+            "default": null,
+            "description": "Template type declared with the config. Required for template-factory snapshots (any value, echoed from available-tc-list); for hand-written application-coding configs omit it or pass 'applicationCoding'.",
+            "title": "Template Type"
+          }
+        },
+        "required": ["template_config"],
+        "title": "BotCreateEngineProperties",
+        "type": "object"
+      },
+```
+
+`tests/fixtures/bots.openapi.json` 做完全相同的替换。顺手核对 `BotCreate`(843-853 行)里 `engine_properties` 字段的 description("Optional engine-specific properties. Omit for a plain bot; provide template for an application-coding bot.")改为:
+
+```json
+            "description": "Optional engine-specific properties. Omit for a plain bot; provide template_config (hand-written application-coding or a template-factory snapshot) for a template-backed bot.",
+```
+
+- [ ] **Step 2: 校验 JSON 合法 + backend schema 断言闭环**
+
+Run: `cd src/backend && uv run pytest tests/community/adapters/http/openapi_v1/test_bots_endpoints.py -k "schema_nests" -v`
+Expected: PASS(Task 3 预置的断言:`set(engine_properties) == {"template_type", "template_config"}`)。
+
+Run: `python -c "import json; json.load(open('src/gateway/configs/schemas/bots.openapi.json')); json.load(open('src/gateway/tests/fixtures/bots.openapi.json')); print('ok')" && cd src/gateway && uv run pytest tests -k "bots" -v`
+Expected: JSON ok;gateway 相关用例 PASS(注意 gateway 用例断言 spec 与 fixtures 一致的双份同步)。
+
+- [ ] **Step 3: ocb 仓库双写**
+
+把同样的两段 patch 应用到 `~/IdeaProjects/ocb/src/gateway/configs/schemas/bots.openapi.json` 与 `~/IdeaProjects/ocb/src/gateway/tests/fixtures/bots.openapi.json`(先 `grep -n "BotCreateEngineProperties" <file>` 确认段位置;ocb 侧文件头可能有差异,只替换等价段),随后在 ocb 仓库单独提交:
+
+```bash
+cd ~/IdeaProjects/ocb
+python -c "import json; json.load(open('src/gateway/configs/schemas/bots.openapi.json')); print('ok')"
+git add src/gateway/configs/schemas/bots.openapi.json src/gateway/tests/fixtures/bots.openapi.json
+git commit -m "chore(gateway): sync BotCreateEngineProperties template_config contract"
+```
+
+(ocb 侧的 commit/push 时机如与用户当期 PR 冲突,先本地 commit 不 push,告知用户。)
+
+- [ ] **Step 4: Commit(avernet 侧)**
+
+```bash
+git add src/gateway/configs/schemas/bots.openapi.json src/gateway/tests/fixtures/bots.openapi.json
+git commit -m "feat(gateway): rename BotCreateEngineProperties template key and add template_type"
+```
+
+---
+
+### Task 6: 接入指南改写
+
+**Files:**
+- Modify: `docs/bot-create-api-guide.zh-CN.md`
+
+- [ ] **Step 1: 改写 §0 表格、§1.1、§1.3、§1.4、§3、§4**
+
+按 spec §3 契约逐节改:
+
+1. §0 "模板入参"行:新 openapi 面改为 ``engine_properties.template_type + template_config``(工厂快照透传,与 available-tc-list item 逐字段对应;或手填 application-coding)。
+2. §1.1 请求表 `engine_properties` 行:改为"两键:template_type(工厂必传、手填省略/固定 applicationCoding)+ template_config";请求示例 B 改成 `{"template_type": null/省略..., "template_config": {...手填键...}}`;新增请求示例 C(tc-list 快照照抄体,含映射说明 `engine ← item.engine_type`、`custom_field_values` 追加)。
+3. §1.3 校验规则改写:键域(两个键)、工厂判定(template_key+template_uid 双非空)、密钥落库/查询剔除(token 加密;thetaKey 由调用方密文传入)、混传 422、手填 template_type 冒充 422、组合 gates 409(工厂同样适用);server-managed 拒收清单不变(强调 template_uid **工厂形态放行**,区别于手填形态)。
+4. §1.4 响应示例 `engine_properties` echo 改键名;`template_config` 说明改为"工厂快照:全量透传减 token/thetaKey;手填:白名单投影"。
+5. §3 第三步:available-tc-list 快照可整段回传(工厂形态),带 `template_uid` 没关系(该形态放行);删除"由前端丢弃 template_uid"的限制(仅手填形态仍要求删除)。
+6. §3.4/常见错误速查:删"模板工厂模板 openapi 面暂无创建入口"一条,改为已支持(工厂快照透传);错误表补 `422 template factory snapshot must not mix...`、`422 engine_properties.template_type is required...` 两行;`template`→`template_config` 全文替换。
+7. 文头"适用版本"行补本设计链接 `docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md`。
+
+- [ ] **Step 2: 自查一致性**
+
+全文 `grep -n "template" docs/bot-create-api-guide.zh-CN.md | grep -v template_config | grep -v template_type | grep -v template_key | grep -v template_uid | grep -v template_version`,Expected: 只剩"模板工厂/模板入参"类中文叙述,无 v1 契约的裸 `engine_properties.template` 引用。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/bot-create-api-guide.zh-CN.md
+git commit -m "docs: rewrite bot-create guide for template_config passthrough contract"
+```
+
+---
+
+### Task 7: 全量回归 + 覆盖率 gate + 批量终审
+
+- [ ] **Step 1: backend 全量回归**
+
+Run: `cd src/backend && uv run pytest tests/community -x -q`
+Expected: 全绿(重点注视:`test_bots_endpoints.py`、`test_application_coding_create.py`、`test_template_public_view.py`、`test_bot_inventory_service.py`、engine registry 路由测试、`bot_service` 消费链路测试)。
+
+- [ ] **Step 2: 变更行覆盖率 gate**
+
+Run: `bash src/backend/scripts/ci_test.sh`
+Expected: changed-line coverage ≥ 80%(阈值与 CI 一致);失败则按 report 补测试(工厂分支/投影分支必须全覆盖——注意 `_is_factory_snapshot`、`_prepare_factory_snapshot`、`project_factory_template_snapshot` 的每一 raise 分支都有用例)。
+
+- [ ] **Step 3: gateway 契约回归**
+
+Run: `cd src/gateway && uv run pytest tests -q`
+Expected: 全绿(记忆提示:本机 perl 被杀跑不了 singlebox,相关用例如被收集失败按既有 skip 规则处理,不算新增失败)。
+
+- [ ] **Step 4: 批量终审(用户约定:一次综合审查)**
+
+对 `git diff origin/dev...HEAD` 跑一次 code review(重点:错误码映射镜像、`Bot`/`BotAuthStatusPoll` 响应 schema、`engine_properties` echo、“老公/存量工厂 bot 投影不变/切换”两面回归锚点、ocb 双写一致性)。CRITICAL/HIGH 修复后重跑 Step 1-2。
+
+- [ ] **Step 5: 收尾**
+
+```bash
+git push -u origin feat/openapi-template-config-passthrough
+```
+
+(按用户当期指示决定是否提 PR;PR title/desc 遵循 `type(scope): outcome` + Problem/Solution/Validation 结构,Validation 里贴 ci_test.sh 的覆盖率输出。)
+
+---
+
+## Self-Review 记录
+
+- **Spec 覆盖:** §3 契约→Task 3/5;§4/§5 行为与校验→Task 1(gates 矩阵每个 raise 分支都有用例);§6 查询投影→Task 4;§7 密钥(token 加密自动覆盖于既有门控、thetaKey 透传+查询剔除→Task 4);§8 文件清单→Task 1-5 全覆盖(router.py 无需改动、provisioning.py 零改动——已由 Task 1 实现体证明);§10 测试计划 1-15→Task 1/3/4 用例 + Task 7 gate;§11 分支/双写→执行约定 + Task 5。
+- **类型一致性:** `_ENGINE_PROPERTIES_KEYS`/`_is_factory_snapshot`/`_prepare_factory_snapshot`/`project_factory_template_snapshot` 命名在 Task 1/4 间一致;pydantic 键序 `template_config`/`template_type` 与 JSON patch 一致。
+- **占位符:** 无 TBD/TODO;Task 4 Step 5 的 helper 说明了"以内联为准"的实现指令,属于明确指令非占位。

--- a/docs/superpowers/plans/2026-09-01-openapi-template-config-passthrough.md
+++ b/docs/superpowers/plans/2026-09-01-openapi-template-config-passthrough.md
@@ -1,5 +1,7 @@
 # OpenAPI template_config 快照透传 Implementation Plan
 
+> **状态(2026-09-01,实施期)**:Task 4 的查询分发设计已被 REL #1785(`template_config_for_public` verbatim 决策)取代,该 commit 在 REL 落位时被跳过;查询面以 REL 现状为准。其余 Task 全部按计划落地。
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** 让 `POST /openapi/v1/bots` 接收 template-factory 快照(`engine_properties.template_type + template_config`,与 available-tc-list item 逐字段对应),原样落库;三个查询面(bots/{id}/all)对工厂快照透传回显(减密钥);`template` 键改名 `template_config`。

--- a/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
+++ b/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
@@ -88,7 +88,9 @@ Front-end 映射:`engine ← item.engine_type`,`bot_type ← item.bot_type`,`eng
 
 `support_engines` 不做校验(透传信任;顶层 `engine` 的真实引擎/cluster 匹配校验既有逻辑不变)。
 
-## 6. 查询投影(bots/{id}/all 三面)
+## 6. 查询投影(bots/{id}/all 三面)——【已被 REL #1785 取代】
+
+> **状态更新(2026-09-01,实施期)**:REL20260901 上的 PR #1785(`template_config_for_public` verbatim 决策)已把三个查询面改为**全量 verbatim 回显**(含密钥,owner-scoped rationale)。本节的 dispatch/工厂透传投影设计随之作废,本 PR 只保留创建面/b 契约与文档;查询行为以 REL 现状为准。
 
 现状三面共用 `project_template_config_for_public`(`template_public_view.py`,allowlist 6 键)。设计:**dispatch,不改 allowlist 语义**——
 
@@ -105,7 +107,9 @@ def project_template_config_for_public(config):
 - 投影后空 dict → 返回 None,与现有行为一致。
 - **有意变更(非回归)**:老 TC 链路已落库的工厂 bot(快照带工厂标记,如 `template_key="applicationCoding"` 的 aicoding 模板)在三个查询面会从 6 键 allowlist 切到透传投影——这正是本设计要的效果;无工厂标记的老公行为不变。
 
-## 7. 密钥处理(不透传的底线)
+## 7. 密钥处理——【查询面条款已被 REL #1785 取代】
+
+> **状态更新(2026-09-01,实施期)**:创建侧的落库加密口径不变(token 密文);查询侧"永不回显"底线被 #1785 的 owner-scoped verbatim 决策取代——随存随显,包含调用方自传密钥。回退过滤是产品决策,须另行拍板(REL 文件头注明)。
 
 落库加密:
 

--- a/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
+++ b/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
@@ -79,7 +79,7 @@ Front-end 映射:`engine ← item.engine_type`,`bot_type ← item.bot_type`,`eng
 |---|---|---|
 | 1 | `engine_properties` 出现 `template_type/template_config` 以外的键 | 422 `unsupported engine_properties fields: [...]`(沿用既有文案,键名集合更新) |
 | 2 | 工厂形态:`template_type` 缺失或空串 | 422 `engine_properties.template_type is required for template-config creates` |
-| 3 | 任何形态:`template_config` 缺失或空 | 422(沿用 `applicationCoding template_config must not be empty` 语义,文案去掉 applicationCoding 字样) |
+| 3 | 任何形态:`template_config` 缺失或空 | 422(沿用现有 `applicationCoding template_config must not be empty` 文案,新增错误才用新文案,减少测试 churn) |
 | 4 | 完整工厂快照(双键)与手填专用键(`devflow_workflow/code_repos/yuque_kb_repos` 等外层契约键)混传 | 422 工厂路径不解读手填键,明确拒绝;不完整快照(缺 `template_uid`)混有手填键则走手填路径,工厂键按未知键存活(现状) |
 | 5 | 任何形态的 `template_config` 顶层出现拒收 server-managed 字段:`bot_id/workspace_id/workspace_status/workspace_state/start_status/engine_form` | 422 `template_config contains server-managed fields: [...]`(现有错误类型复用,放行清单新增工厂四键) |
 | 6 | 手填路径 `template_type` 传了且 ≠ `applicationCoding` | 422(防形态冒充;工厂值必须走工厂标记) |

--- a/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
+++ b/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
@@ -69,9 +69,9 @@ Front-end 映射:`engine ← item.engine_type`,`bot_type ← item.bot_type`,`eng
 |---|---|---|---|---|
 | 普通 bot | `engine_properties` 为空 | — | — | 既有组合约束 |
 | 手填 applicationCoding(legacy 路径) | 有 `template_config`,无工厂标记,无(或不冲突的)`template_type` | 写死 `applicationCoding` | 按现有 `_validate_application_coding_config` 校验类型 | 既有 5 条(cloud/claude_code/personal bot_type/personal space)|
-| 工厂快照透传(新) | `template_config` 有工厂标记键 | 调用方透传值(校验非空) | 原样 deepcopy + 密钥加密(§7) | 同 5 条组合 gates(见 §5 冲突规则) |
+| 工厂快照透传(新) | `template_config` 是 dict 且 `template_key`+`template_uid` 双非空 | 调用方透传值(校验非空) | 原样 deepcopy + 密钥加密(§7) | 同 5 条组合 gates(见 §5 冲突规则) |
 
-判定用现有 `is_template_factory_config`(`capabilities.py:18`,键 `template_key/template_uid/template_version_id/template_version` 任一命中)。
+**判定对齐运行时消费**:创建分支的工厂判定与 `consumes_template_config`(strategy.py:316)完全一致——`template_key` 与 `template_uid` 双非空才走工厂路径。这与 `is_template_factory_config` 的"四键任一"不同是有意的:只带零散工厂键(无完整身份)的 config 走手填路径(工厂键按未知键存活,现状行为),避免建出"创建时按工厂处理、运行时却不消费"的半吊子 bot。查询投影侧(§6)的 dispatch 仍用四键任一(只影响回显,不涉及消费)。
 
 ## 5. 校验规则(键级,错误码)
 
@@ -80,7 +80,7 @@ Front-end 映射:`engine ← item.engine_type`,`bot_type ← item.bot_type`,`eng
 | 1 | `engine_properties` 出现 `template_type/template_config` 以外的键 | 422 `unsupported engine_properties fields: [...]`(沿用既有文案,键名集合更新) |
 | 2 | 工厂形态:`template_type` 缺失或空串 | 422 `engine_properties.template_type is required for template-config creates` |
 | 3 | 任何形态:`template_config` 缺失或空 | 422(沿用 `applicationCoding template_config must not be empty` 语义,文案去掉 applicationCoding 字样) |
-| 4 | 工厂标记与手填专用键(`devflow_workflow/code_repos/yuque_kb_repos` 等外层契约键)混传 | 422 工厂路径不解读手填键,明确拒绝 |
+| 4 | 完整工厂快照(双键)与手填专用键(`devflow_workflow/code_repos/yuque_kb_repos` 等外层契约键)混传 | 422 工厂路径不解读手填键,明确拒绝;不完整快照(缺 `template_uid`)混有手填键则走手填路径,工厂键按未知键存活(现状) |
 | 5 | 任何形态的 `template_config` 顶层出现拒收 server-managed 字段:`bot_id/workspace_id/workspace_status/workspace_state/start_status/engine_form` | 422 `template_config contains server-managed fields: [...]`(现有错误类型复用,放行清单新增工厂四键) |
 | 6 | 手填路径 `template_type` 传了且 ≠ `applicationCoding` | 422(防形态冒充;工厂值必须走工厂标记) |
 | 7 | 组合 gates 违反(cloud-only、engine 非 claude_code、bot_type 非 personal、非个人空间) | 409(沿用 `BotCombinationUnsupportedError` 既有文案与顺序) |
@@ -107,10 +107,10 @@ def project_template_config_for_public(config):
 
 ## 7. 密钥处理(不透传的底线)
 
-落库加密(工厂路径与 legacy 同一套):
+落库加密:
 
-- 顶层 `token`(str 非空,出现即校验)→ 复用现有加密(`enc:v1:`)。
-- `bot_template_config.ext_config.thetaKey`(strategy.py `_THETA_KEY_PATH` 已有路径常量)→ 复用现有加密。
+- 顶层 `token`(str 非空,出现即校验)→ 复用现有 `template_service._encrypt_token_field`(`enc:v1:`);其门控 `should_encrypt_template_token` → `consumes_template_config` 已覆盖工厂双键身份,零改动自动生效。
+- `bot_template_config.ext_config.thetaKey` → **后端无加密入口**(核实:源码只有 `build_extra_properties` 的运行时解密,密文由调用方链路产生),工厂路径原样落库,不新增加密。
 
 查询剔除(工厂投影专用,新常量):
 

--- a/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
+++ b/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
@@ -81,7 +81,7 @@ Front-end 映射:`engine ← item.engine_type`,`bot_type ← item.bot_type`,`eng
 | 2 | 工厂形态:`template_type` 缺失或空串 | 422 `engine_properties.template_type is required for template-config creates` |
 | 3 | 任何形态:`template_config` 缺失或空 | 422(沿用现有 `applicationCoding template_config must not be empty` 文案,新增错误才用新文案,减少测试 churn) |
 | 4 | 完整工厂快照(双键)与手填专用键(`devflow_workflow/code_repos/yuque_kb_repos` 等外层契约键)混传 | 422 工厂路径不解读手填键,明确拒绝;不完整快照(缺 `template_uid`)混有手填键则走手填路径,工厂键按未知键存活(现状) |
-| 5 | 任何形态的 `template_config` 顶层出现拒收 server-managed 字段:`bot_id/workspace_id/workspace_status/workspace_state/start_status/engine_form` | 422 `template_config contains server-managed fields: [...]`(现有错误类型复用,放行清单新增工厂四键) |
+| 5 | 任何形态的 `template_config` 顶层出现拒收 server-managed 字段:`bot_id/workspace_id/workspace_status/workspace_state/start_status/engine_form` | 422 `template_config contains server-managed fields: [...]`(实现事实修正:`TEMPLATE_SERVER_RESERVED_FIELDS` 本含 `template_uid`,工厂分支在 strategy 层对四个工厂身份键做豁免后复用同一拒绝逻辑,手填路径拒绝集合不变) |
 | 6 | 手填路径 `template_type` 传了且 ≠ `applicationCoding` | 422(防形态冒充;工厂值必须走工厂标记) |
 | 7 | 组合 gates 违反(cloud-only、engine 非 claude_code、bot_type 非 personal、非个人空间) | 409(沿用 `BotCombinationUnsupportedError` 既有文案与顺序) |
 | 8 | 已知外层键类型不符 | 422(仅手填路径,沿用 `_validate_application_coding_config` 检查;工厂路径**不做**键级类型校验,透传) |
@@ -125,7 +125,8 @@ def project_template_config_for_public(config):
 |---|---|
 | `adapters/http/openapi_v1/bots/schemas.py` | `BotCreateEngineProperties`:`template` → `template_config` + 新增 `template_type: str \| None`;描述文案泛化 |
 | `core/bot_management/engines/aicoding/strategy.py` | `prepare_create`:键域更新、新增工厂分支(§4)、放行工厂四键进 `to_internal_template_config` 的 PUBLIC 模式(§5.5)、错误文案 |
-| `core/bot_management/engines/provisioning.py` | 预计零改动(工厂四键本就不在 `TEMPLATE_SERVER_RESERVED_FIELDS`),实现时核对确认 |
+| `core/bot_management/engines/provisioning.py` | 零改动(实现核对:`template_uid` 本在 `TEMPLATE_SERVER_RESERVED_FIELDS`,工厂身份四键的豁免落在 strategy 工厂分支内,`provisioning.py` 未动) |
+| `core/bot_management/engines/default.py` | template-intent 判定认 `template_config` 键,保持“非 coding 引擎 + 模板载荷 → 409”映射(Task 1 实现时发现计划漏列,补入) |
 | `core/bot_management/template_public_view.py` | 新增 `project_factory_snapshot` + dispatch(§6) |
 | `adapters/http/openapi_v1/bots/router.py` | 请求→strategy 的传参适配;`_to_bot` 无改动(dispatch 内完成) |
 | `src/gateway/configs/schemas/bots.openapi.json` | `BotCreateEngineProperties` schema 手工精准 patch(禁止全量 regen;含 description/example) |

--- a/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
+++ b/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
@@ -131,7 +131,7 @@ def project_template_config_for_public(config):
 | `adapters/http/openapi_v1/bots/router.py` | 请求→strategy 的传参适配;`_to_bot` 无改动(dispatch 内完成) |
 | `src/gateway/configs/schemas/bots.openapi.json` | `BotCreateEngineProperties` schema 手工精准 patch(禁止全量 regen;含 description/example) |
 | `src/gateway/tests/fixtures/bots.openapi.json` | 同步 patch(fixture 与 configs 一致) |
-| ocb 仓库 `src/gateway/configs/schemas/bots.openapi.json` + fixtures | 双写同步(既有约定) |
+| ocb 仓库 `src/gateway/configs/schemas/bots.openapi.json` | 双写约定落查:ocb 侧该文件为更老 vintage,连 `engine_properties` 面都不存在,本次无对应段可 patch;需整体 re-sync(推 PR 时与用户确认机构) |
 | `tests/community/adapters/http/openapi_v1/test_bots_endpoints.py` | 创建/查询用例(§10) |
 | `tests/community/core/bot_management/test_application_coding_create.py` | strategy 单测(§10);全部 `template` 键断言迁移 |
 | `tests/community/core/bot_inventory/services/test_bot_inventory_service.py` | /all attach 投影用例 |

--- a/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
+++ b/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
@@ -1,0 +1,178 @@
+# OpenAPI 创建/查询面的 template_config 快照透传设计
+
+- 日期:2026-09-01
+- 状态:已评审拍板(用户确认 v3 契约)
+- 关联:`docs/bot-create-api-guide.zh-CN.md`(接入指南,随本设计同步改写 §1.1/§1.3/§1.4)、`src/backend/specs/2026-08-24-engine-properties-polymorphic-create/design.md`(上一轮多态创建设计)
+
+## 1. 背景与问题
+
+AC 侧模板工厂的模板已通过 `/openapi/v1/bot-templates/available-tc-list` 暴露,返回项即 OCB create payload 形态(`engine_type/bot_type/template_type/template_config`),`template_config` 是 resolved 快照(含 `template_key/template_uid/template_version_id/image/resource_spec/envs/capabilities` 等)。模板工厂的 `template_type` 是开放值域:官方模板(`normalCC`/`architect`)+ 用户自建任意值,后端已删除按 `template_id` 枚举识别的常量(`TEMPLATE_CONFIG_CONSUMING_TYPES`),工厂 bot 统一靠 `template_config` 的工厂标记键识别。
+
+现状 `POST /openapi/v1/bots` 的 `engine_properties` 只收一个键 `template`,固定等价 `template_type="applicationCoding"`(strategy 在 `prepare_create` 里写死),`PUBLIC` 校验拒 `template_uid` 等标记字段——工厂模板在这条面**没有创建入口**;查询面上 `template_config` 是 6 键 allowlist 投影,工厂快照的 image/resource_spec/envs 等一律不回,前端也无法读回。
+
+## 2. 目标 / 非目标
+
+**目标**
+
+1. 前端把 available-tc-list 的 item 逐字段照抄即可创建 bot(零映射、零二次 resolve 调用)。
+2. 我们原样落库快照,查询时透传回读(存什么回什么),运行时消费走既有工厂快照链路,后端不新增 AC resolve 依赖。
+3. 键名与老 API、available-tc-list item、DB 列、内部 `PreparedBotCreate` 对齐:`engine_properties.template → template_config`,并新增并列键 `template_type`。
+4. 普通 bot 与 legacy applicationCoding 手填路径行为零变化。
+
+**非目标**
+
+- 不改老 `POST /api/bots`(TC 存量链路不动)。
+- 不做后端 resolve/校验 `image` 合法性(透传即信任调用方,风险见 §9)。
+- 不做 `template_type` 值域校验(开放值域,透传)。
+- 不迁移既有 bot 的存量快照(老公的 allowlist 投影行为不变)。
+
+## 3. 契约(v3,终稿)
+
+### 3.1 创建 `POST /openapi/v1/bots?user_id={uid}`
+
+```json
+{
+  "bot_name": "my-bot",
+  "bot_desc": "...",
+  "engine": "claude_code",
+  "cluster_name": "ACRA",
+  "bot_type": "personal",
+  "engine_properties": {
+    "template_type": "applicationCoding",
+    "template_config": {
+      "template_key": "applicationCoding",
+      "template_version": "V1",
+      "template_version_id": 2800006,
+      "template_uid": "aicoding_bot_template",
+      "template_name": "应用 Bot",
+      "image": "reg.antgroup-inc.cn/...",
+      "resource_spec": { "cpu": "4", "memory": "8g", "disk": "50" },
+      "envs": { "...": "..." },
+      "capabilities": { "...": false },
+      "bot_template_config": { "...": {} }
+    }
+  }
+}
+```
+
+Front-end 映射:`engine ← item.engine_type`,`bot_type ← item.bot_type`,`engine_properties.template_type ← item.template_type`,`engine_properties.template_config ← item.template_config` 整段 + 动态表单值追加为 `custom_field_values`。
+
+### 3.2 查询面
+
+`GET /openapi/v1/bots`、`GET /openapi/v1/bots/{bot_id}`、`GET /openapi/v1/bots/all` 一致:工厂模板 bot 的 `template_config` = 落库快照减敏感键(§6),`template_type` = 透传值。legacy applicationCoding bot 的回显字段保持现状(allowlist 投影)。
+
+## 4. 行为分支(创建)
+
+`engine_properties` 键域:`{template_type, template_config}`(都可选,`extra="forbid"`)。
+
+| 形态 | 判定 | template_type | template_config 落库 | gates |
+|---|---|---|---|---|
+| 普通 bot | `engine_properties` 为空 | — | — | 既有组合约束 |
+| 手填 applicationCoding(legacy 路径) | 有 `template_config`,无工厂标记,无(或不冲突的)`template_type` | 写死 `applicationCoding` | 按现有 `_validate_application_coding_config` 校验类型 | 既有 5 条(cloud/claude_code/personal bot_type/personal space)|
+| 工厂快照透传(新) | `template_config` 有工厂标记键 | 调用方透传值(校验非空) | 原样 deepcopy + 密钥加密(§7) | 同 5 条组合 gates(见 §5 冲突规则) |
+
+判定用现有 `is_template_factory_config`(`capabilities.py:18`,键 `template_key/template_uid/template_version_id/template_version` 任一命中)。
+
+## 5. 校验规则(键级,错误码)
+
+| # | 规则 | 错误 |
+|---|---|---|
+| 1 | `engine_properties` 出现 `template_type/template_config` 以外的键 | 422 `unsupported engine_properties fields: [...]`(沿用既有文案,键名集合更新) |
+| 2 | 工厂形态:`template_type` 缺失或空串 | 422 `engine_properties.template_type is required for template-config creates` |
+| 3 | 任何形态:`template_config` 缺失或空 | 422(沿用 `applicationCoding template_config must not be empty` 语义,文案去掉 applicationCoding 字样) |
+| 4 | 工厂标记与手填专用键(`devflow_workflow/code_repos/yuque_kb_repos` 等外层契约键)混传 | 422 工厂路径不解读手填键,明确拒绝 |
+| 5 | 任何形态的 `template_config` 顶层出现拒收 server-managed 字段:`bot_id/workspace_id/workspace_status/workspace_state/start_status/engine_form` | 422 `template_config contains server-managed fields: [...]`(现有错误类型复用,放行清单新增工厂四键) |
+| 6 | 手填路径 `template_type` 传了且 ≠ `applicationCoding` | 422(防形态冒充;工厂值必须走工厂标记) |
+| 7 | 组合 gates 违反(cloud-only、engine 非 claude_code、bot_type 非 personal、非个人空间) | 409(沿用 `BotCombinationUnsupportedError` 既有文案与顺序) |
+| 8 | 已知外层键类型不符 | 422(仅手填路径,沿用 `_validate_application_coding_config` 检查;工厂路径**不做**键级类型校验,透传) |
+
+`support_engines` 不做校验(透传信任;顶层 `engine` 的真实引擎/cluster 匹配校验既有逻辑不变)。
+
+## 6. 查询投影(bots/{id}/all 三面)
+
+现状三面共用 `project_template_config_for_public`(`template_public_view.py`,allowlist 6 键)。设计:**dispatch,不改 allowlist 语义**——
+
+```python
+def project_template_config_for_public(config):
+    if is_factory_snapshot(config):
+        return project_factory_snapshot(config)   # 新函数
+    return ... # 现有 allowlist 逻辑原样保留
+```
+
+- 判定函数与创建面同一套工厂标记键,保证"存取路径一致"。
+- `project_factory_snapshot`:deepcopy 后剔除敏感位置(§7),其余键原样回,包括嵌套 `bot_template_config`(减 thetaKey)、`envs/capabilities/image/resource_spec/template_name/custom_field_values`。
+- 分派在一个函数内完成,`_to_bot`(router.py:193)与 `_attach_page_templates`(bot_inventory_service.py:167)两处调用点零改动;`/all` 的 attach 条件(`template_type` 非空才拉快照,bot_inventory_service.py:178)对工厂 bot 天然成立(透传值非空)。
+- 投影后空 dict → 返回 None,与现有行为一致。
+- **有意变更(非回归)**:老 TC 链路已落库的工厂 bot(快照带工厂标记,如 `template_key="applicationCoding"` 的 aicoding 模板)在三个查询面会从 6 键 allowlist 切到透传投影——这正是本设计要的效果;无工厂标记的老公行为不变。
+
+## 7. 密钥处理(不透传的底线)
+
+落库加密(工厂路径与 legacy 同一套):
+
+- 顶层 `token`(str 非空,出现即校验)→ 复用现有加密(`enc:v1:`)。
+- `bot_template_config.ext_config.thetaKey`(strategy.py `_THETA_KEY_PATH` 已有路径常量)→ 复用现有加密。
+
+查询剔除(工厂投影专用,新常量):
+
+- 顶层 `token` → 剔除。
+- `bot_template_config.ext_config.thetaKey` → 原路径剔除(嵌套其余键保留)。
+
+不放宽现有"密文也不回显"的安全结论(template_public_view.py 文件头注释是 security 评审产物,新投影路径服从同一结论)。
+
+## 8. 改动文件清单
+
+| 位置 | 改动 |
+|---|---|
+| `adapters/http/openapi_v1/bots/schemas.py` | `BotCreateEngineProperties`:`template` → `template_config` + 新增 `template_type: str \| None`;描述文案泛化 |
+| `core/bot_management/engines/aicoding/strategy.py` | `prepare_create`:键域更新、新增工厂分支(§4)、放行工厂四键进 `to_internal_template_config` 的 PUBLIC 模式(§5.5)、错误文案 |
+| `core/bot_management/engines/provisioning.py` | 预计零改动(工厂四键本就不在 `TEMPLATE_SERVER_RESERVED_FIELDS`),实现时核对确认 |
+| `core/bot_management/template_public_view.py` | 新增 `project_factory_snapshot` + dispatch(§6) |
+| `adapters/http/openapi_v1/bots/router.py` | 请求→strategy 的传参适配;`_to_bot` 无改动(dispatch 内完成) |
+| `src/gateway/configs/schemas/bots.openapi.json` | `BotCreateEngineProperties` schema 手工精准 patch(禁止全量 regen;含 description/example) |
+| `src/gateway/tests/fixtures/bots.openapi.json` | 同步 patch(fixture 与 configs 一致) |
+| ocb 仓库 `src/gateway/configs/schemas/bots.openapi.json` + fixtures | 双写同步(既有约定) |
+| `tests/community/adapters/http/openapi_v1/test_bots_endpoints.py` | 创建/查询用例(§10) |
+| `tests/community/core/bot_management/test_application_coding_create.py` | strategy 单测(§10);全部 `template` 键断言迁移 |
+| `tests/community/core/bot_inventory/services/test_bot_inventory_service.py` | /all attach 投影用例 |
+| `docs/bot-create-api-guide.zh-CN.md` | §1.1/§1.3/§1.4/§3/§4 改写为 v3 契约 |
+
+## 9. 风险与 trade-off(拍板记录)
+
+- **信任调用方**:透传等于接受调用方指定的 `image/resource_spec/envs`(可指任意镜像/规格)。内部租户 + 受控调用方场景接受;若要收紧,只需在创建工厂分支加一条"`image` 必须等于该模板 key 已 resolve 版本的镜像"校验(留口,本期不做,记为后续收紧点)。
+- **`template_type` 冒充**:调用方传 `template_type=applicationCoding` + 无工厂标记 = legacy 路径,行为等同现状(gates 最严);传带工厂标记 + 自定义 `template_type=x` 时,五条 gates 照旧拦组合,单靠字符串不触发任何 legacy 副作用(memory init/BCN/容器消费都改为看快照标记,已在 TEMPLATE_CONFIG_CONSUMING_TYPES 删除时落地)。
+- **列表体积**:`/all` 每卡片回整段快照(image/envs/bot_template_config),分页 20 条可接受;如将来卡片列表嫌大,再压缩(本期 YAGNI)。
+- **改名窗口**:openapi 面未上线、无存量调用,`template` → `template_config` 零兼容成本;上线后键名冻结。
+
+## 10. 测试计划
+
+创建面(端点级,mock strategy 依赖按现有测试模式):
+
+1. 普通 bot:不传 `engine_properties` → 201,行为不变(回归)。
+2. 手填路径:传 `template_config` 无工厂标记 + `template_type` 省略 → 落 `applicationCoding`,既有断言全量迁移通过(回归)。
+3. 手填路径传 `template_type=personalCoding` → 422(§5.6)。
+4. 工厂路径:tc-list item 照抄体 → 201,落库快照断言(密钥位置为密文)、`template_type` 为透传值。
+5. 工厂路径缺 `template_type` → 422(§5.2)。
+6. 工厂路径带 `engine_form`/`workspace_id` → 422 server-managed(§5.5)。
+7. 工厂 + 手填专用键混传 → 422(§5.4)。
+8. 工厂 + `bot_type=service` / `engine=openclaw` / 团队空间 → 409(§5.7)。
+9. `engine_properties` 传旧键 `template` → 422 unsupported fields(改名反向回归)。
+
+strategy 单测(test_application_coding_create.py):
+
+10. 上述 2-9 的核心层映射,含错序 gates 不变断言(错误类型/消息镜像保持)。
+11. 工厂快照 token/thetaKey 加密后为 `enc:v1:` 前缀。
+
+查询面:
+
+12. 三面(bots/{id}/all)工厂 bot 的 `template_config` 回显 = 全量减 `token`/`ext_config.thetaKey`;`envs/image/resource_spec/template_name/custom_field_values` 原样在。
+13. legacy bot(无工厂标记)投影回归:仍只回 6 键 allowlist。
+14. `/all` 对 `template_type` 非空但快照投影为空的卡片行为不变(None,不挂)。
+15. 存量工厂快照(老 TC 链路落的,带工厂标记)在三个查询面切到透传投影(§6 有意变更的回归锚点)。
+
+覆盖率:新增/改动行按仓库 80% 门槛跑 `ci_test.sh` 验证(推 PR 前本地复现)。
+
+## 11. 上线与同步
+
+- 分支:从 `origin/dev` 新开功能分支(当前 `w3-source-credentials-cr-rework` 是 W3 凭据主题,不混入)。
+- gateway spec 双写:avernet + ocb 两侧同步提交(既有约定)。
+- 前端契约冻结:v3 键名(`template_type`/`template_config`)上线后不再改;联调方以本文件 §3 为准。

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -179,11 +179,22 @@ class BotCreateEngineProperties(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    template: dict[str, Any] = Field(
+    template_type: str | None = Field(
         description=(
-            "Application-coding template properties. Passed through unchanged to "
-            "the template validator; platform-managed identity and lifecycle "
-            "fields are not accepted."
+            "Template type declared with the config. Required for template-"
+            "factory snapshots (any value, echoed from available-t-templates); "
+            "for hand-written application-coding configs omit it or pass "
+            "'applicationCoding'."
+        ),
+        default=None,
+    )
+    template_config: dict[str, Any] = Field(
+        description=(
+            "Template configuration. Either hand-written application-coding "
+            "properties, or a template-factory snapshot (identified by "
+            "template_key + template_uid) echoed verbatim from "
+            "bot-templates/available-tc-list; platform-managed identity and "
+            "lifecycle fields are not accepted."
         ),
     )
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -182,7 +182,7 @@ class BotCreateEngineProperties(BaseModel):
     template_type: str | None = Field(
         description=(
             "Template type declared with the config. Required for template-"
-            "factory snapshots (any value, echoed from available-t-templates); "
+            "factory snapshots (any value, echoed from available-tc-list); "
             "for hand-written application-coding configs omit it or pass "
             "'applicationCoding'."
         ),

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/bots/schemas.py
@@ -232,7 +232,8 @@ class BotCreate(BaseModel):
         default=None,
         description=(
             "Optional engine-specific properties. Omit for a plain bot; provide "
-            "template for an application-coding bot."
+            "template_config (hand-written application-coding or a "
+            "template-factory snapshot) for a template-backed bot."
         ),
     )
     # ``engine_options`` is deliberately absent. The engine-owned bag the

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/auth_status.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/deprecated/auth_status.py
@@ -119,7 +119,7 @@ async def get_bot_auth_status(
 
     This retired GET spelling is plain-bot only: it carries no template
     parameters, so an application-coding creation must be completed through the
-    POST at the same path, which accepts the nested 'engine_properties.template' object.
+    POST at the same path, which accepts the nested 'engine_properties.template_config' object.
     Polling an application-coding creation here would complete it as a plain bot,
     which is not supported.
 

--- a/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/create_flow.py
@@ -315,11 +315,14 @@ def _prepare_create(
     if spec.engine_properties:
         prepared = _prepare_with_engine_strategy(spec, context)
     elif spec.template_type == "applicationCoding":
-        # Core-only compatibility representation: the "template" key's presence
-        # preserves the legacy intent even when the caller intentionally
-        # omitted the config, so both input shapes share the Strategy's gate.
+        # Core-only compatibility representation: the "template_config" key's
+        # presence preserves the legacy intent even when the caller
+        # intentionally omitted the config, so both input shapes share the
+        # Strategy's gate.
         prepared = _prepare_with_engine_strategy(
-            replace(spec, engine_properties={"template": spec.template_config}),
+            replace(
+                spec, engine_properties={"template_config": spec.template_config}
+            ),
             context,
         )
     else:

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -34,6 +34,7 @@ from ..provisioning import (
     BotProvisioningContext,
     EngineProvisioningStrategy,
     PreparedBotCreate,
+    TEMPLATE_SERVER_RESERVED_FIELDS,
     to_internal_template_config,
 )
 
@@ -48,6 +49,30 @@ AICODING_ENGINE_TYPE = "aicoding"
 CLAUDE_CODE_ENGINE_TYPE = "claude_code"
 TEMPLATE_CONFIG_CONSUMING_ENGINES = frozenset(
     {AICODING_ENGINE_TYPE, CLAUDE_CODE_ENGINE_TYPE}
+)
+#: Public ``engine_properties`` envelope keys (v3 contract). The single
+#: implementation behind the hand-written application-coding shape and the
+#: template-factory snapshot passthrough shape.
+_ENGINE_PROPERTIES_KEYS = frozenset({"template_type", "template_config"})
+_HANDCRAFTED_MIX_REJECT_KEYS = (
+    "devflow_workflow",
+    "yuque_kb_repos",
+    "code_repos",
+)
+#: Template-factory identity keys allowed through the factory branch's PUBLIC
+#: server-managed-field check (design §5.5: the reserved list's concession for
+#: factory snapshots). A resolved snapshot legitimately carries its own
+#: identity/version markers, whereas the same key from a hand-written config
+#: is caller smuggling — ``template_uid`` sits in the shared reserved set for
+#: exactly that hand-written case, so the exemption lives here instead of in
+#: the shared helpers.
+_FACTORY_SNAPSHOT_IDENTITY_KEYS = frozenset(
+    {
+        "template_key",
+        "template_uid",
+        "template_version",
+        "template_version_id",
+    }
 )
 LEGACY_BOT_TYPE_ENV_MAP = {
     "personalCoding": "personal",
@@ -153,14 +178,16 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             BotCreateTemplateValidationMode.LEGACY
         ),
     ) -> PreparedBotCreate:
-        """Parse and validate application-coding create input (single owner).
+        """Parse and validate coding create input (single owner).
 
-        The one implementation behind both input shapes: the public
-        ``engine_properties.template`` contract and the legacy
-        ``template_type="applicationCoding"`` normalized by the create flow.
-        Combination gates keep their historical order, error types and messages
-        so the HTTP mappings answer identically; server-managed-field rejection
-        follows the caller's validation mode.
+        Two input shapes: the public ``engine_properties.template_config``
+        hand-written application-coding config, and the template-factory
+        snapshot passthrough (identified by full template identity:
+        ``template_key`` + ``template_uid``, aligned with
+        ``consumes_template_config``). Combination gates keep their
+        historical order, error types and messages so the HTTP mappings
+        answer identically; server-managed-field rejection follows the
+        caller's validation mode.
         """
         if not engine_properties:
             return PreparedBotCreate()
@@ -168,13 +195,16 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
         # Envelope integrity for keys this engine owns. The public schema's
         # ``extra="forbid"`` cannot guard direct Core-level spec construction,
         # so unknown keys fail here instead of being silently ignored.
-        unknown_keys = set(engine_properties) - {"template"}
+        unknown_keys = set(engine_properties) - _ENGINE_PROPERTIES_KEYS
         if unknown_keys:
             raise BotTemplateInvalidError(
                 f"unsupported engine_properties fields: {sorted(unknown_keys)}"
             )
-        if "template" not in engine_properties:
-            raise BotTemplateInvalidError("engine_properties.template is required")
+        if "template_config" not in engine_properties:
+            raise BotTemplateInvalidError(
+                "engine_properties.template_config is required"
+            )
+        declarative_type = engine_properties.get("template_type")
 
         # Historical combination gates, in their historical order. The gate set
         # and messages are mirrored (production-dead) in
@@ -198,7 +228,21 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                 "application coding is personal-space only"
             )
 
-        template = engine_properties["template"]
+        template = engine_properties["template_config"]
+        if self._is_factory_snapshot(template):
+            return self._prepare_factory_snapshot(
+                declarative_type=declarative_type,
+                template=template,
+                template_validation_mode=template_validation_mode,
+            )
+
+        if declarative_type is not None and declarative_type != "applicationCoding":
+            # Non-factory inputs may only declare the legacy type; anything
+            # else must come through a factory snapshot instead.
+            raise BotTemplateInvalidError(
+                "engine_properties.template_type must be applicationCoding "
+                "for non factory snapshots"
+            )
         if template is None:
             # Core-only legacy compatibility shape: the key's presence is the
             # application-coding intent, ``None`` the intentionally-omitted
@@ -208,15 +252,6 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                 template_type="applicationCoding",
                 template_config=None,
                 requires_workspace_hosting=True,
-            )
-        if not template:
-            # Byte-identical to the historical ladder: only genuinely empty
-            # payloads are rejected. Truthy non-dict values (legacy internal
-            # callers forwarding raw JSON ``template_config``) keep the
-            # historical pass-through — the expected-type checks and
-            # reserved-field scan below treat them exactly as before.
-            raise BotTemplateInvalidError(
-                "applicationCoding template_config must not be empty"
             )
         sanitized = to_internal_template_config(
             template,
@@ -228,6 +263,73 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
             template_type="applicationCoding",
             template_config=_validate_application_coding_config(sanitized),
             requires_workspace_hosting=True,
+        )
+
+    @staticmethod
+    def _is_factory_snapshot(template: Any) -> bool:
+        """Full template identity, matching ``consumes_template_config``.
+
+        ``template_key`` AND ``template_uid`` both non-empty: a snapshot with
+        only scattered factory keys stays on the hand-crafted path (factory
+        keys survive as unknown keys) so creation perception never diverges
+        from runtime consumption.
+        """
+        if not isinstance(template, Mapping):
+            return False
+        return bool(template.get("template_key") and template.get("template_uid"))
+
+    def _prepare_factory_snapshot(
+        self,
+        *,
+        declarative_type: Any,
+        template: Any,
+        template_validation_mode: BotCreateTemplateValidationMode,
+    ) -> PreparedBotCreate:
+        """Validate and pass through a template-factory snapshot verbatim.
+
+        Passthrough contract: the caller (available-tc-list consumer) owns
+        the snapshot semantics; we only enforce identity completeness, the
+        no-mix rule against hand-written keys, and (in PUBLIC mode) the
+        server-managed-field ownership rules. No ``template_type`` value
+        validation — the factory vocabulary is open.
+        """
+        if not isinstance(template, dict) or not template:
+            raise BotTemplateInvalidError(
+                "applicationCoding template_config must not be empty"
+            )
+        if not (isinstance(declarative_type, str) and declarative_type.strip()):
+            raise BotTemplateInvalidError(
+                "engine_properties.template_type is required for template "
+                "factory snapshots"
+            )
+        mixed = [key for key in _HANDCRAFTED_MIX_REJECT_KEYS if key in template]
+        if mixed:
+            raise BotTemplateInvalidError(
+                "template factory snapshot must not mix application-coding "
+                f"fields: {sorted(mixed)}"
+            )
+        if template_validation_mode is BotCreateTemplateValidationMode.PUBLIC:
+            # Design §5.5: the factory branch reuses the shared
+            # server-managed-field contract minus the factory identity keys.
+            # The shared helper cannot express that split — its reserved set
+            # governs the hand-written surface, where ``template_uid`` is
+            # caller smuggling — so the check lives here instead.
+            reserved = sorted(
+                (TEMPLATE_SERVER_RESERVED_FIELDS - _FACTORY_SNAPSHOT_IDENTITY_KEYS)
+                & set(template)
+            )
+            if reserved:
+                raise BotTemplateInvalidError(
+                    f"template_config contains server-managed fields: {reserved}"
+                )
+        return PreparedBotCreate(
+            template_type=declarative_type,
+            template_config=to_internal_template_config(
+                template, reject_server_managed_fields=False
+            ),
+            # No workspace-hosting gate: aligned with the legacy TC direct
+            # path (create_flow generic branch), NOT the applicationCoding
+            # DIMA hosting requirement.
         )
 
     def resolve_bot_engine(self, bot: dict[str, Any]) -> str | None:

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/default.py
@@ -41,9 +41,10 @@ class DefaultProvisioningStrategy(EngineProvisioningStrategy):
     ) -> PreparedBotCreate:
         """Reject create-time engine properties this engine does not own.
 
-        A ``template`` key means application-coding intent (new public contract
-        or legacy normalization); the combination error keeps the historical
-        409 mapping for the legacy shape instead of turning it into a 422.
+        A ``template_config`` key (v3 public contract) or ``template`` key
+        (legacy normalization) means application-coding intent; the
+        combination error keeps the historical 409 mapping for both shapes
+        instead of turning it into a 422.
         Gates replicate the deleted ``prepare_bot_create`` ladder exactly:
         error messages name the *requested* engine (the shared fallback
         instance's own ``engine_type`` would say "default"), and the cloud-only
@@ -51,7 +52,7 @@ class DefaultProvisioningStrategy(EngineProvisioningStrategy):
         """
         if not engine_properties:
             return PreparedBotCreate()
-        if "template" in engine_properties:
+        if "template" in engine_properties or "template_config" in engine_properties:
             # Historical gate order: a local deployment reports "cloud-only"
             # before the engine gate gets to answer.
             if deployment_mode != "cloud":

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/provisioning.py
@@ -155,7 +155,7 @@ class EngineProvisioningStrategy(ABC):
         strategy may interpret its keys. Called before Passport apply and any
         persistence, so every violation must raise, never silently drop input.
 
-        ``{"template": None}`` is a Core-only legacy compatibility shape (the
+        ``{"template_config": None}`` is a Core-only legacy compatibility shape (the
         public schema requires a non-empty object): the key's *presence* carries
         the application-coding intent when a legacy caller omitted the config.
 

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -1541,7 +1541,7 @@ def test_create_schema_nests_template_config_under_engine_properties(client):
     assert "template_type" not in poll_properties
     assert "template_config" not in poll_properties
     assert set(engine_properties) == {"template_type", "template_config"}
-    assert engine_properties["template_config"]["required"] == ["template_config"]
+    assert schemas["BotCreateEngineProperties"]["required"] == ["template_config"]
 
 
 def test_auth_status_validates_cluster_against_default_engine(client, svc, passport):

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -728,7 +728,7 @@ def test_create_application_coding_maps_template_to_internal_spec(
             json={
                 **_CREATE_BODY,
                 "engine": "claude_code",
-                "engine_properties": {"template": properties},
+                "engine_properties": {"template_config": properties},
             },
         )
 
@@ -771,7 +771,7 @@ def test_create_rejects_unknown_engine_properties_fields(client, svc):
         json={
             **_CREATE_BODY,
             "engine_properties": {
-                "template": {},
+                "template_config": {},
                 "template_uid": "caller-controlled",
             },
         },
@@ -791,11 +791,148 @@ def test_create_engine_properties_for_non_coding_engine_is_combination_error(
         "/openapi/v1/bots",
         json={
             **_CREATE_BODY,
-            "engine_properties": {"template": {"devflow_workflow": "x"}},
+            "engine_properties": {"template_config": {"devflow_workflow": "x"}},
         },
     )
     assert response.status_code == 409, response.json()
     assert response.json()["code"] == 409000
+    svc.create_bot.assert_not_called()
+
+
+_FACTORY_SNAPSHOT_BODY = {
+    "template_type": "applicationCoding",
+    "template_config": {
+        "template_key": "applicationCoding",
+        "template_uid": "aicoding_bot_template",
+        "template_version": "V1",
+        "template_version_id": 2800006,
+        "template_name": "应用 Bot",
+        "image": "reg.antgroup-inc.cn/aixcoding/arca:20260901140138",
+        "resource_spec": {"cpu": "4", "memory": "8g", "disk": "50"},
+        "envs": {"AIX_SKIP_DAEMON": "false"},
+        "capabilities": {"channel_management": False},
+        "bot_template_config": {"id": 2800006},
+        "custom_field_values": {"field_a": "value_a"},
+    },
+}
+
+
+def test_create_factory_snapshot_passthrough_persists_verbatim(
+    client, svc, passport
+):
+    passport.apply_first_agent_passport.return_value = {
+        "token": "tok",
+        "agent_code": "ac",
+    }
+    with patch.object(bots_router, "generate_bot_id", return_value="default"):
+        response = client.post(
+            "/openapi/v1/bots",
+            json={
+                **_CREATE_BODY,
+                "engine": "claude_code",
+                "engine_properties": dict(_FACTORY_SNAPSHOT_BODY),
+            },
+        )
+    assert response.status_code == 201, response.json()
+    kwargs = svc.create_bot.call_args.kwargs
+    assert kwargs["template_type"] == "applicationCoding"
+    assert kwargs["template_config"] == _FACTORY_SNAPSHOT_BODY["template_config"]
+
+
+def test_create_factory_snapshot_missing_template_type_is_422(client, svc):
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine": "claude_code",
+            "engine_properties": {
+                "template_config": _FACTORY_SNAPSHOT_BODY["template_config"]
+            },
+        },
+    )
+    assert response.status_code == 422, response.json()
+    svc.create_bot.assert_not_called()
+
+
+def test_create_factory_snapshot_server_managed_field_is_422(client, svc):
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine": "claude_code",
+            "engine_properties": {
+                **_FACTORY_SNAPSHOT_BODY,
+                "template_config": {
+                    **_FACTORY_SNAPSHOT_BODY["template_config"],
+                    "engine_form": "aicoding",
+                },
+            },
+        },
+    )
+    assert response.status_code == 422, response.json()
+    svc.create_bot.assert_not_called()
+
+
+def test_create_factory_snapshot_mix_is_422(client, svc):
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine": "claude_code",
+            "engine_properties": {
+                **_FACTORY_SNAPSHOT_BODY,
+                "template_config": {
+                    **_FACTORY_SNAPSHOT_BODY["template_config"],
+                    "devflow_workflow": "x",
+                },
+            },
+        },
+    )
+    assert response.status_code == 422, response.json()
+    svc.create_bot.assert_not_called()
+
+
+def test_create_handcrafted_with_foreign_template_type_is_422(client, svc):
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine": "claude_code",
+            "engine_properties": {
+                "template_type": "architect",
+                "template_config": {"devflow_workflow": "x"},
+            },
+        },
+    )
+    assert response.status_code == 422, response.json()
+    svc.create_bot.assert_not_called()
+
+
+def test_create_rejects_legacy_template_key_name(client, svc):
+    # 改名反向回归:v1 契约的 "template" 键已不存在
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine": "claude_code",
+            "engine_properties": {"template": {"devflow_workflow": "x"}},
+        },
+    )
+    assert response.status_code == 422, response.json()
+    svc.create_bot.assert_not_called()
+
+
+def test_create_factory_snapshot_for_service_bot_is_409(client, svc):
+    response = client.post(
+        "/openapi/v1/bots",
+        json={
+            **_CREATE_BODY,
+            "engine": "claude_code",
+            "bot_type": "service",
+            "engine_properties": dict(_FACTORY_SNAPSHOT_BODY),
+        },
+    )
+    assert response.status_code == 409, response.json()
     svc.create_bot.assert_not_called()
 
 
@@ -975,7 +1112,7 @@ def test_post_auth_status_maps_template_to_internal_spec(client, svc, passport):
         json={
             "engine": "claude_code",
             "cluster_name": "ACRA",
-            "engine_properties": {"template": properties},
+            "engine_properties": {"template_config": properties},
         },
     )
 
@@ -1389,7 +1526,7 @@ def test_create_schema_does_not_advertise_engine_options(client):
     assert "engine_options" not in schema["properties"]
 
 
-def test_create_schema_nests_template_under_engine_properties(client):
+def test_create_schema_nests_template_config_under_engine_properties(client):
     schemas = client.app.openapi()["components"]["schemas"]
     create_properties = schemas["BotCreate"]["properties"]
     poll_properties = schemas["BotAuthStatusPoll"]["properties"]
@@ -1403,7 +1540,8 @@ def test_create_schema_nests_template_under_engine_properties(client):
     assert "template_config" not in create_properties
     assert "template_type" not in poll_properties
     assert "template_config" not in poll_properties
-    assert set(engine_properties) == {"template"}
+    assert set(engine_properties) == {"template_type", "template_config"}
+    assert engine_properties["template_config"]["required"] == ["template_config"]
 
 
 def test_auth_status_validates_cluster_against_default_engine(client, svc, passport):

--- a/src/backend/tests/community/core/bot_management/test_application_coding_create.py
+++ b/src/backend/tests/community/core/bot_management/test_application_coding_create.py
@@ -740,3 +740,10 @@ def test_engine_properties_with_template_key_only_stays_handcrafted() -> None:
     )
     assert prepared.template_type == "applicationCoding"
     assert prepared.template_config["template_key"] == "applicationCoding"
+
+
+def test_legacy_application_coding_pair_is_wrapped_as_template_config() -> None:
+    prepared = _prepare_spec(_application_coding_spec())
+    # create_flow 把 legacy pair 归一成 strategy 的 v3 键域后消费
+    assert prepared.template_type == "applicationCoding"
+    assert prepared.template_config == {"devflow_workflow": "x"}

--- a/src/backend/tests/community/core/bot_management/test_application_coding_create.py
+++ b/src/backend/tests/community/core/bot_management/test_application_coding_create.py
@@ -2,10 +2,10 @@
 
 The policy's single implementation is
 ``AicodingProvisioningStrategy.prepare_create``. ``create_flow._prepare_create``
-routes both input shapes into it — the public ``engine_properties`` bag and the
-legacy ``template_type="applicationCoding"`` pair normalized to
-``{"template": config}`` — so the tests below cover the strategy directly plus
-the flow's routing on top.
+routes both input shapes into it — the public ``engine_properties`` bag (v3 key
+domain: ``template_type`` / ``template_config``) and the legacy
+``template_type="applicationCoding"`` pair normalized into it — so the tests
+below cover the strategy directly plus the flow's routing on top.
 """
 
 from __future__ import annotations
@@ -100,11 +100,11 @@ def test_application_coding_engine_gate_reads_the_strategy_instance() -> None:
     # The aicoding strategy class is registered for both engine types, but
     # application-coding creation stays claude_code-only.
     prepared = _strategy_prepare(
-        "claude_code", {"template": {"devflow_workflow": "x"}}
+        "claude_code", {"template_config": {"devflow_workflow": "x"}}
     )
     assert prepared.template_type == "applicationCoding"
     with pytest.raises(BotCombinationUnsupportedError):
-        _strategy_prepare("aicoding", {"template": {"devflow_workflow": "x"}})
+        _strategy_prepare("aicoding", {"template_config": {"devflow_workflow": "x"}})
 
 
 def test_default_engine_rejects_application_coding_as_combination_error() -> None:
@@ -114,7 +114,7 @@ def test_default_engine_rejects_application_coding_as_combination_error() -> Non
     with pytest.raises(BotCombinationUnsupportedError):
         DefaultProvisioningStrategy("openclaw").prepare_create(
             engine_type="openclaw",
-            engine_properties={"template": {"devflow_workflow": "x"}},
+            engine_properties={"template_config": {"devflow_workflow": "x"}},
             bot_type="personal",
             deployment_mode="cloud",
             space_kind="personal",
@@ -128,7 +128,7 @@ def test_default_engine_answers_cloud_only_before_the_engine_gate() -> None:
     with pytest.raises(BotCombinationUnsupportedError, match="cloud-only"):
         DefaultProvisioningStrategy("openclaw").prepare_create(
             engine_type="openclaw",
-            engine_properties={"template": {"devflow_workflow": "x"}},
+            engine_properties={"template_config": {"devflow_workflow": "x"}},
             bot_type="personal",
             deployment_mode="local",
             space_kind="personal",
@@ -169,7 +169,7 @@ def test_unknown_engine_properties_keys_are_rejected_by_the_strategy() -> None:
     # Core-level invariant: the HTTP schema's extra="forbid" cannot guard
     # direct spec construction by internal callers.
     with pytest.raises(BotTemplateInvalidError, match="unsupported"):
-        _strategy_prepare("claude_code", {"template": {"a": 1}, "other": 2})
+        _strategy_prepare("claude_code", {"template_config": {"a": 1}, "other": 2})
 
 
 # ── strategy policy ────────────────────────────────────────────────────────
@@ -185,7 +185,7 @@ def test_prepare_plain_bot_has_no_hosting_requirement() -> None:
 @pytest.mark.parametrize(
     ("overrides", "error"),
     [
-        ({"engine_properties": {"template": {}}}, BotTemplateInvalidError),
+        ({"engine_properties": {"template_config": {}}}, BotTemplateInvalidError),
         ({"engine_type": "aicoding"}, BotCombinationUnsupportedError),
         ({"bot_type": "service"}, BotCombinationUnsupportedError),
         ({"space_kind": "team"}, BotCombinationUnsupportedError),
@@ -197,7 +197,7 @@ def test_prepare_rejects_invalid_application_coding_combinations(
 ) -> None:
     params = dict(
         engine_type="claude_code",
-        engine_properties={"template": {"devflow_workflow": "x"}},
+        engine_properties={"template_config": {"devflow_workflow": "x"}},
         bot_type="personal",
         deployment_mode="cloud",
         space_kind="personal",
@@ -208,9 +208,9 @@ def test_prepare_rejects_invalid_application_coding_combinations(
 
 
 def test_prepare_application_coding_without_config_preserves_legacy_default() -> None:
-    # ``{"template": None}`` is the Core-only legacy compatibility shape: key
-    # presence is the intent, None the intentionally-omitted config.
-    prepared = _strategy_prepare("claude_code", {"template": None})
+    # ``{"template_config": None}`` is the Core-only legacy compatibility shape:
+    # key presence is the intent, None the intentionally-omitted config.
+    prepared = _strategy_prepare("claude_code", {"template_config": None})
     assert prepared.template_type == "applicationCoding"
     assert prepared.template_config is None
     assert prepared.requires_workspace_hosting is True
@@ -218,17 +218,19 @@ def test_prepare_application_coding_without_config_preserves_legacy_default() ->
 
 def test_prepare_application_coding_rejects_supplied_empty_config() -> None:
     with pytest.raises(BotTemplateInvalidError, match="must not be empty"):
-        _strategy_prepare("claude_code", {"template": {}})
+        _strategy_prepare("claude_code", {"template_config": {}})
 
 
 def test_prepare_application_coding_rejects_known_field_with_wrong_type() -> None:
     with pytest.raises(BotTemplateInvalidError, match="code_repos"):
-        _strategy_prepare("claude_code", {"template": {"code_repos": "not-a-list"}})
+        _strategy_prepare(
+            "claude_code", {"template_config": {"code_repos": "not-a-list"}}
+        )
 
 
 def test_prepare_valid_application_coding_returns_detached_config() -> None:
     payload = {"devflow_workflow": "x"}
-    prepared = _strategy_prepare("claude_code", {"template": payload})
+    prepared = _strategy_prepare("claude_code", {"template_config": payload})
     assert prepared.template_config == payload
     assert prepared.template_config is not payload
     assert prepared.requires_workspace_hosting is True
@@ -238,7 +240,7 @@ def test_legacy_application_coding_preserves_template_uid() -> None:
     # Internal snapshots may carry platform-managed fields; the LEGACY mode
     # (the internal callers' default) must keep accepting them (#1442).
     payload = {"template_uid": "legacy-template", "devflow_workflow": "x"}
-    prepared = _strategy_prepare("claude_code", {"template": payload})
+    prepared = _strategy_prepare("claude_code", {"template_config": payload})
     assert prepared.template_config == payload
     assert prepared.template_config is not payload
     assert prepared.requires_workspace_hosting is True
@@ -249,7 +251,7 @@ def test_legacy_non_dict_template_config_keeps_historical_passthrough() -> None:
     # pre-strategy ladder let truthy non-dict values through (only genuinely
     # empty payloads were rejected). The strategy keeps that contract instead
     # of tightening it into a rejection.
-    prepared = _strategy_prepare("claude_code", {"template": "legacy-ref"})
+    prepared = _strategy_prepare("claude_code", {"template_config": "legacy-ref"})
     assert prepared.template_type == "applicationCoding"
     assert prepared.template_config == "legacy-ref"
     assert prepared.requires_workspace_hosting is True
@@ -262,7 +264,7 @@ def test_public_application_coding_rejects_template_uid() -> None:
     ):
         _strategy_prepare(
             "claude_code",
-            {"template": {"template_uid": "caller-value"}},
+            {"template_config": {"template_uid": "caller-value"}},
             template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
         )
 
@@ -286,7 +288,7 @@ def test_flow_routes_both_input_shapes_through_the_same_strategy() -> None:
             engine_type="claude_code",
             bot_type="personal",
             bot_name="Coding Bot",
-            engine_properties={"template": {"devflow_workflow": "x"}},
+            engine_properties={"template_config": {"devflow_workflow": "x"}},
         )
     )
     assert legacy.template_type == modern.template_type == "applicationCoding"
@@ -307,7 +309,7 @@ def test_flow_output_satisfies_its_own_mixed_source_invariant() -> None:
             engine_type="claude_code",
             bot_type="personal",
             bot_name="Coding Bot",
-            engine_properties={"template": {"devflow_workflow": "x"}},
+            engine_properties={"template_config": {"devflow_workflow": "x"}},
         )
     )
     assert prepared.template_type == "applicationCoding"
@@ -353,7 +355,7 @@ def test_flow_rejects_mixed_template_sources() -> None:
                 bot_name="Coding Bot",
                 template_type="applicationCoding",
                 template_config={"devflow_workflow": "x"},
-                engine_properties={"template": {"devflow_workflow": "x"}},
+                engine_properties={"template_config": {"devflow_workflow": "x"}},
             )
         )
 
@@ -600,7 +602,7 @@ def test_public_input_cannot_smuggle_the_form_marker() -> None:
     with pytest.raises(BotTemplateInvalidError) as excinfo:
         _strategy_prepare(
             engine_properties={
-                "template": {"devflow_workflow": "x", "engine_form": "aicoding"}
+                "template_config": {"devflow_workflow": "x", "engine_form": "aicoding"}
             },
             template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
         )
@@ -608,8 +610,133 @@ def test_public_input_cannot_smuggle_the_form_marker() -> None:
     # The legacy internal shape may carry it (platform-written snapshot).
     prepared = _strategy_prepare(
         engine_properties={
-            "template": {"devflow_workflow": "x", "engine_form": "aicoding"}
+            "template_config": {"devflow_workflow": "x", "engine_form": "aicoding"}
         },
         template_validation_mode=BotCreateTemplateValidationMode.LEGACY,
     )
     assert prepared.template_config["engine_form"] == "aicoding"
+
+
+# ── template-factory snapshot passthrough (v3 contract) ─────────────────────
+
+_FACTORY_SNAPSHOT = {
+    "template_key": "applicationCoding",
+    "template_uid": "aicoding_bot_template",
+    "template_version": "V1",
+    "template_version_id": 2800006,
+    "template_name": "应用 Bot",
+    "image": "reg.antgroup-inc.cn/aixcoding/aixcoding-arca:20260901140138",
+    "resource_spec": {"cpu": "4", "memory": "8g", "disk": "50"},
+    "envs": {"AIX_SKIP_DAEMON": "false"},
+    "capabilities": {"channel_management": False},
+    "bot_template_config": {"id": 2800006, "custom_field_config": {}},
+    "custom_field_values": {"field_a": "value_a"},
+}
+
+
+def test_factory_snapshot_passthrough_keeps_type_and_config_verbatim() -> None:
+    prepared = _strategy_prepare(
+        "claude_code",
+        {
+            "template_type": "applicationCoding",
+            "template_config": dict(_FACTORY_SNAPSHOT),
+        },
+    )
+    assert prepared.template_type == "applicationCoding"
+    assert prepared.template_config == _FACTORY_SNAPSHOT
+    # requires_workspace_hosting 与老 TC 直传链路一致:工厂模板不加 hosting 门槛
+    assert prepared.requires_workspace_hosting is not True
+
+
+def test_factory_snapshot_accepts_any_template_type_value() -> None:
+    snapshot = dict(_FACTORY_SNAPSHOT, template_key="userCustomTemplate")
+    prepared = _strategy_prepare(
+        "claude_code",
+        {"template_type": "custom_xxx", "template_config": snapshot},
+    )
+    assert prepared.template_type == "custom_xxx"
+    assert prepared.template_config == snapshot
+
+
+def test_factory_snapshot_requires_declared_template_type() -> None:
+    with pytest.raises(BotTemplateInvalidError) as excinfo:
+        _strategy_prepare(
+            "claude_code", {"template_config": dict(_FACTORY_SNAPSHOT)}
+        )
+    assert "template_type" in str(excinfo.value)
+
+
+def test_factory_snapshot_rejects_blank_template_type() -> None:
+    with pytest.raises(BotTemplateInvalidError):
+        _strategy_prepare(
+            "claude_code",
+            {
+                "template_type": " ",
+                "template_config": dict(_FACTORY_SNAPSHOT),
+            },
+        )
+
+
+def test_factory_snapshot_rejects_handcrafted_field_mix() -> None:
+    mixed = dict(_FACTORY_SNAPSHOT, devflow_workflow="app-flow")
+    with pytest.raises(BotTemplateInvalidError) as excinfo:
+        _strategy_prepare(
+            "claude_code",
+            {"template_type": "applicationCoding", "template_config": mixed},
+        )
+    assert "devflow_workflow" in str(excinfo.value)
+
+
+def test_factory_snapshot_public_mode_rejects_server_managed_fields() -> None:
+    polluted = dict(_FACTORY_SNAPSHOT, engine_form="aicoding")
+    with pytest.raises(BotTemplateInvalidError):
+        _strategy_prepare(
+            "claude_code",
+            {"template_type": "applicationCoding", "template_config": polluted},
+            template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
+        )
+
+
+def test_factory_snapshot_keeps_factory_marker_keys_in_public_mode() -> None:
+    # template_key/template_uid/version 键不在 RESERVED 清单,PUBLIC 模式放行
+    prepared = _strategy_prepare(
+        "claude_code",
+        {"template_type": "applicationCoding", "template_config": dict(_FACTORY_SNAPSHOT)},
+        template_validation_mode=BotCreateTemplateValidationMode.PUBLIC,
+    )
+    assert prepared.template_config["template_uid"] == "aicoding_bot_template"
+
+
+def test_factory_snapshot_gates_match_application_coding() -> None:
+    props = {"template_type": "architect", "template_config": dict(_FACTORY_SNAPSHOT)}
+    with pytest.raises(BotCombinationUnsupportedError):
+        _strategy_prepare("claude_code", props, deployment_mode="local")
+    with pytest.raises(BotCombinationUnsupportedError):
+        _strategy_prepare("openclaw", props)
+    with pytest.raises(BotCombinationUnsupportedError):
+        _strategy_prepare("claude_code", props, bot_type="service")
+    with pytest.raises(BotCombinationUnsupportedError):
+        _strategy_prepare("claude_code", props, space_kind="team")
+
+
+def test_handcrafted_path_rejects_foreign_template_type() -> None:
+    with pytest.raises(BotTemplateInvalidError):
+        _strategy_prepare(
+            "claude_code",
+            {"template_type": "architect", "template_config": {"devflow_workflow": "x"}},
+        )
+
+
+def test_engine_properties_with_template_key_only_stays_handcrafted() -> None:
+    # 不完整快照(缺 template_uid)→ 走手填路径,工厂键按未知键存活(现状)
+    prepared = _strategy_prepare(
+        "claude_code",
+        {
+            "template_config": {
+                "template_key": "applicationCoding",
+                "devflow_workflow": "x",
+            }
+        },
+    )
+    assert prepared.template_type == "applicationCoding"
+    assert prepared.template_config["template_key"] == "applicationCoding"

--- a/src/backend/tests/community/core/gateway_principal/test_signer.py
+++ b/src/backend/tests/community/core/gateway_principal/test_signer.py
@@ -176,6 +176,10 @@ def test_the_copy_is_signed_with_the_shared_key_only():
 # ── nothing is signed that was not verified first ────────────────────────────
 
 
+# ``ids`` is pinned to the label on purpose: the token values are minted at
+# *collection* time (JWT iat/exp differ by the second), so the default
+# id-by-repr makes pytest-xdist's cross-worker collection check see different
+# test sets whenever workers finish collecting more than a second apart.
 @pytest.mark.parametrize(
     ("label", "token"),
     [
@@ -185,6 +189,14 @@ def test_the_copy_is_signed_with_the_shared_key_only():
         ("wrong issuer", mint([user_principal()], issuer="not-the-gateway")),
         ("no principals claim", mint([user_principal()], omit=("principals",))),
         ("empty", ""),
+    ],
+    ids=[
+        "forged-signature",
+        "expired",
+        "another-upstream",
+        "wrong-issuer",
+        "no-principals-claim",
+        "empty",
     ],
 )
 def test_a_token_that_does_not_verify_is_never_re_addressed(label: str, token: str):

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -845,7 +845,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional engine-specific properties. Omit for a plain bot; provide template for an application-coding bot."
+            "description": "Optional engine-specific properties. Omit for a plain bot; provide template_config (hand-written application-coding or a template-factory snapshot) for a template-backed bot."
           },
           "space_id": {
             "anyOf": [
@@ -874,15 +874,28 @@
         "additionalProperties": false,
         "description": "Engine-specific properties used while creating a bot.",
         "properties": {
-          "template": {
+          "template_config": {
             "additionalProperties": true,
-            "description": "Application-coding template properties. Passed through unchanged to the template validator; platform-managed identity and lifecycle fields are not accepted.",
-            "title": "Template",
+            "description": "Template configuration. Either hand-written application-coding properties, or a template-factory snapshot (identified by template_key + template_uid) echoed verbatim from bot-templates/available-tc-list; platform-managed identity and lifecycle fields are not accepted.",
+            "title": "Template Config",
             "type": "object"
+          },
+          "template_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Template type declared with the config. Required for template-factory snapshots (any value, echoed from available-tc-list); for hand-written application-coding configs omit it or pass applicationCoding.",
+            "title": "Template Type"
           }
         },
         "required": [
-          "template"
+          "template_config"
         ],
         "title": "BotCreateEngineProperties",
         "type": "object"
@@ -51277,7 +51290,7 @@
     "/openapi/v1/bots/{bot_id}/auth-status": {
       "get": {
         "deprecated": true,
-        "description": "Poll authorization for a pending creation; the bot is created on ISSUED.\n\nOn the 202 create flow the bot is only actually created here, so the\ncaller must re-supply the attributes it created with — the optional query\nparameters mirror the create body and are forwarded to completion. Omit\nthem and the bot is created with defaults that contradict what was\nrequested, so always echo back engine, cluster_name, bot_name, bot_desc\nand bot_type when polling.\n\nEvery restriction create enforces is re-applied to the echoed values:\nthe same engine registry check, the same engine/cluster pairing, and the\nsame personal/service restriction on bot_type.\n\nThis retired GET spelling is plain-bot only: it carries no template\nparameters, so an application-coding creation must be completed through the\nPOST at the same path, which accepts the nested 'engine_properties.template' object.\nPolling an application-coding creation here would complete it as a plain bot,\nwhich is not supported.\n\nWhile the authorization service has no status for the bot yet — the\nPassport is not ready — the poll answers PENDING with a message saying\nso, rather than an error: keep polling.\n\nDeprecated: use POST /openapi/v1/bots/{bot_id}/auth-status instead.",
+        "description": "Poll authorization for a pending creation; the bot is created on ISSUED.\n\nOn the 202 create flow the bot is only actually created here, so the\ncaller must re-supply the attributes it created with — the optional query\nparameters mirror the create body and are forwarded to completion. Omit\nthem and the bot is created with defaults that contradict what was\nrequested, so always echo back engine, cluster_name, bot_name, bot_desc\nand bot_type when polling.\n\nEvery restriction create enforces is re-applied to the echoed values:\nthe same engine registry check, the same engine/cluster pairing, and the\nsame personal/service restriction on bot_type.\n\nThis retired GET spelling is plain-bot only: it carries no template\nparameters, so an application-coding creation must be completed through the\nPOST at the same path, which accepts the nested 'engine_properties.template_config' object.\nPolling an application-coding creation here would complete it as a plain bot,\nwhich is not supported.\n\nWhile the authorization service has no status for the bot yet — the\nPassport is not ready — the poll answers PENDING with a message saying\nso, rather than an error: keep polling.\n\nDeprecated: use POST /openapi/v1/bots/{bot_id}/auth-status instead.",
         "operationId": "get_bot_auth_status_openapi_v1_bots__bot_id__auth_status_get",
         "parameters": [
           {


### PR DESCRIPTION
## Problem

- `POST /openapi/v1/bots` 的 `engine_properties` 只收一个 `template` 键,固定等价 `template_type="applicationCoding"`,且 PUBLIC 校验拒收 `template_uid` 等工厂身份字段——模板工厂(available-tc-list 返回项即 OCB create payload 形态)在 OpenAPI 面没有创建入口。
- 模板工厂的 `template_type` 值域开放(`normalCC`/`architect`/用户自建任意值,`TEMPLATE_CONFIG_CONSUMING_TYPES` 枚举已删除),公开创建面表达不了这种输入。

## Solution

- **契约 v3**:`engine_properties: {template_type?, template_config}`——键名与老 API/available-tc-list item/DB 列/内部 `PreparedBotCreate` 对齐,前端逐字段照抄 item(engine / bot_type / template_type / template_config),动态表单值追加为 `template_config.custom_field_values`。
- **strategy 工厂分支**(`engines/aicoding/strategy.py`):`template_key`+`template_uid` 双非空 → 工厂快照透传(判定与运行时消费 `consumes_template_config` 对齐;`template_type` 必传任意值、组合 gates 沿用 409 家族、无键级校验);工厂+手填键混传 422;手填 `template_type` 冒充 422;PUBLIC server-managed 拒绝对四个工厂身份键豁免(`template_uid` 在共享保留清单内的豁免落在 strategy 层)。
- `default.py` template-intent 判定认 `template_config`,非 claude_code 引擎保持 409(组合错误)映射。
- `create_flow` 把 legacy applicationCoding pair 包装为 `{"template_config": ...}`。
- **gateway golden 契约**手工精准 patch(`BotCreateEngineProperties`: `template_config` 必填 + `template_type` 可空)。
- **文档**:`docs/bot-create-api-guide.zh-CN.md` 重写为 v3;设计与实施记录在 `docs/superpowers/specs|plans/2026-09-01-openapi-template-config-passthrough*`。
- **查询面说明**:已被 REL 上 #1785(`template_config_for_public` verbatim 决策)取代,本 PR 原查询分发设计对应 commit 已跳过,guide/spec 已按 #1785 行为对齐。

## Validation

- backend 全量(REL20260901 基线):16041 passed / 58 skipped(本地有一处架构覆盖测试失败来自工作区无关 untracked 模块 `bot_config_*`,移开即绿,CI 干净 checkout 不存在)。
- `ci_test.sh --base origin/REL20260901`:case pass rate 100%,line coverage 88.06%,**changed-line coverage 93.94%(门槛 80%)**。
- 新增 strategy 单测 + HTTP 端到端用例覆盖:工厂透传/gates/混传/冒充/server-managed/409 映射/旧键 `template` 反向 422 回归。
- 实现完成后批量代码审查:APPROVE_WITH_NOTES,两处 docstring 与 golden 源文案偏差已在 `34a6eecc3` 修复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)