### PR TITLE
fix(backend): STAGE_VALUE 增加 PublishStage.EVAL 映射

### DIFF
--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/engine_ext_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/engine_ext_stage.py
@@ -26,12 +26,13 @@ KEY_BOT_NAME = "bot_name"
 KEY_STAGE = "stage"
 
 #: ``PublishStage`` → the engine-facing ``engine_ext.stage`` string. The engine
-#: expects ``draft`` / ``canary`` / ``release`` — NOT the raw enum values
+#: expects ``draft`` / ``canary`` / ``release`` / ``eval`` — NOT the raw enum values
 #: (``verify`` / ``online``). This mapping is the deliberate translation.
 STAGE_VALUE: dict[PublishStage, str] = {
     PublishStage.DRAFT: "draft",
     PublishStage.VERIFY: "canary",
     PublishStage.ONLINE: "release",
+    PublishStage.EVAL: "eval",
 }
 
 

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_engine_ext_stage.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_engine_ext_stage.py
@@ -62,12 +62,22 @@ def test_enrich_stringifies_bot_id_and_does_not_mutate_input() -> None:
 
 
 @pytest.mark.unit
+def test_enrich_eval_stage_maps_to_eval() -> None:
+    out = enrich_engine_ext(
+        {}, bot_id="b1", owner_id="u1", bot_name="Eval Bot", stage=PublishStage.EVAL
+    )
+    assert out["stage"] == "eval"
+
+
+@pytest.mark.unit
 def test_stage_value_mapping() -> None:
-    # The deliberate translation: enum verify/online → engine canary/release.
+    # The deliberate translation: enum verify/online → engine canary/release,
+    # enum eval → engine eval (评测沙箱场景).
     assert STAGE_VALUE == {
         PublishStage.DRAFT: "draft",
         PublishStage.VERIFY: "canary",
         PublishStage.ONLINE: "release",
+        PublishStage.EVAL: "eval",
     }
 
 
@@ -78,6 +88,7 @@ def test_stage_value_mapping() -> None:
         (PublishStage.DRAFT, "draft"),
         (PublishStage.VERIFY, "canary"),
         (PublishStage.ONLINE, "release"),
+        (PublishStage.EVAL, "eval"),
     ],
 )
 def test_restamp_sets_stage(stage: PublishStage, expected: str) -> None:
@@ -252,3 +263,14 @@ def test_compose_does_not_mutate_input() -> None:
     base = {"engine_ext": engine_ext, "engine_overrides": {}}
     DeliveryArtifact.compose(base, PublishStage.VERIFY, _VERIFY_CHANNELS)
     assert engine_ext == {"bot_id": "b", "stage": "draft"}  # input untouched
+
+
+@pytest.mark.unit
+def test_compose_eval_stage_restamps_to_eval() -> None:
+    # 评测沙箱场景：stage=EVAL 时 engine_ext.stage 应重标记为 "eval"
+    base = {
+        "engine_ext": {"bot_id": "b", "stage": "draft"},
+        "engine_overrides": {},
+    }
+    out = DeliveryArtifact.compose(base, PublishStage.EVAL, None)
+    assert out.config_artifact["engine_ext"]["stage"] == "eval"


### PR DESCRIPTION
## Problem

teclaw 引擎类型的服务 bot 调用 `api/service-bot/default-env/create` 创建评测沙箱时，接口返回 500：

```
创建评测沙箱容器时发生未预期异常: <PublishStage.EVAL: 'eval'>
```

根因：`engine_ext_stage.py` 的 `STAGE_VALUE` 字典只有 `DRAFT`/`VERIFY`/`ONLINE` 三个键，缺少 `EVAL`。`eval_publish` 传 `stage=PublishStage.EVAL` 时，`restamp_stage` 执行 `STAGE_VALUE[PublishStage.EVAL]` 抛出 `KeyError`，被上层 `except Exception` 捕获后拼成未预期异常消息。

影响范围：所有带 `engine_ext.stage` 的 `config_artifact`（teclaw 引擎必有）走 eval 发布时 100% 失败。ARCA 通常 `config_artifact=None` 走 mount 路径，不触发。

## Solution

在 `STAGE_VALUE` 字典中增加 `PublishStage.EVAL: "eval"` 映射。

```python
# 修复前
STAGE_VALUE: dict[PublishStage, str] = {
    PublishStage.DRAFT: "draft",
    PublishStage.VERIFY: "canary",
    PublishStage.ONLINE: "release",
}

# 修复后
STAGE_VALUE: dict[PublishStage, str] = {
    PublishStage.DRAFT: "draft",
    PublishStage.VERIFY: "canary",
    PublishStage.ONLINE: "release",
    PublishStage.EVAL: "eval",
}
```

## Validation

- Avernet `tests/community/core/service_bot/services/deploy/test_engine_ext_stage.py`：27 个测试全部通过
  - `test_stage_value_mapping`：断言 `STAGE_VALUE` 包含 `EVAL: "eval"` ✅
  - `test_restamp_sets_stage[eval-eval]`：`restamp_stage(artifact, EVAL)` 输出 `"eval"` ✅
  - `test_enrich_eval_stage_maps_to_eval`：`enrich_engine_ext(stage=EVAL)` 输出 `"eval"` ✅
  - `test_compose_eval_stage_restamps_to_eval`：`DeliveryArtifact.compose(base, EVAL, None)` 输出 `"eval"` ✅
- 全量 27 个测试无回归 ✅

## Compatibility and risk
- **向后兼容**：`DRAFT`/`VERIFY`/`ONLINE` 映射不变，生产发布路径不受影响
- **新增映射**：`EVAL` 是纯增量，之前 eval 路径必报 `KeyError`，修复后正常工作
- **无 schema / config / migration 影响**

## Related issues
- 关联 fixing 文档：`fixing/fixing_teclaw_eval_create_failed.md`