### PR TITLE
fix(backend): align service artifacts with runtime mounts

### DIFF
--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -1041,27 +1041,72 @@ Personal/Desktop 与 Service Draft binding 参与 Track Latest。Published Servi
 #### 14.2 文件型 Service Artifact
 
 本期采用简单方案 A，不新增 `ServiceCapabilitySnapshot`：Service build pre-stage 先经 Reader
-执行一次 `BotRuntimeProjector.project(ProjectionScope.everything())`，随后现有 Artifact Producer
-从已收敛的同一 Runtime 目录打包。接受 build 期间能力并发变化的有限窗口；未来可增加不可变
-Snapshot/fingerprint，但不阻塞本期。
+执行一次 `BotRuntimeProjector.project(ProjectionScope.everything())`，随后按 Artifact Producer
+能力决定是否读取当前 Runtime layout。ARCA/BaaS 文件型 Producer 在每次 build 执行一次 fresh
+`RuntimeLayoutProbeServiceProtocol.probe_bot()`，将 transport evidence 归一化为 typed
+`ServiceArtifactLayoutObservation`，并通过不可变 `ArtifactBuildRequest` 传给 Producer；Teclaw
+Config Artifact 不做文件系统 Probe。Artifact build 禁止读取
+`ac_bot_skill_layout_state.last_probe_evidence` 作为当前物理路径证据，该字段仅属于 Pool
+Reconcile/Recovery。Local/Repo 仍接受既有 build 并发窗口；Center exact capability 在 finalize
+前重新通过 Reader 读取并与 capture 完全比较，发生漂移时本次 build 失败、由既有发布 Retry 重做。
 
 Artifact 只复制 Bot 实际 active Slice：Local 内容随 Artifact 复制；完整 `skills-repo` 和
-`skill-center` corpus 必须排除，只保留实际 active Skill 的精确 symlink。Deploy 时把共享
-Repo/Center OSS 只读挂载到 physical runtime 的 `skills-pool/skills-repo` 与
-`skills-pool/skill-center`；logical Claude Code + coding template 必须由统一 layout resolver
-落到 physical AICoding 路径。
+`skill-center` corpus 必须排除，只保留实际 active Skill 的精确 symlink。Repo/Center 物理
+OSS mount 的唯一 Owner 是 OCB image entrypoint；Avernet 的 Managed BaaS deploy composer
+不得把 `shared_corpora` 或默认 Repo 再转换为 `mount_points`。`shared_corpora` 只承担 Snapshot
+exclusion、exact-link validation 与历史 Artifact 声明，不是运行时 mount 指令。logical
+Claude Code + coding template 必须由统一 layout resolver 落到 physical AICoding 路径。
 
-现有 `skills_manifest schema_version=1` 采用 additive optional `center_skills`，不升 v2：
+文件型 build 的顺序固定为：
+
+```text
+Runtime Project (best effort)
+→ resolve Artifact Producer
+→ ARCA/BaaS fresh Probe once
+→ ArtifactBuildRequest(bot, version, typed observation)
+→ capture exact Center refs + layout generation
+→ rsync Snapshot
+→ validate corpus exclusion + exact Center links
+→ re-read exact Center refs + layout generation
+→ finalize skills_manifest
+```
+
+Probe 总状态与 Center mount 瞬时状态分离：Pool 或包含 Center 的 Legacy build 需要总体
+`READY` 路径证据；无 Center 的 Legacy build 在 `NOT_CAPABLE/TRANSIENT_ERROR/INVALID` 时继续
+使用历史静态 BuildPlan。Center 需要 Engine 声明支持 mapping v3，无 Center 的 Pool 至少支持
+mapping v2。`center_mount=NOT_READY/UNAVAILABLE` 不单独阻止 Artifact，因为 OCB 会在每次启动
+重新 mount；但 Canonical Store exact Version、Snapshot exact links 和 exclusion 仍然 fail closed。
+
+现有 `skills_manifest schema_version=1` 采用 additive optional `center_skills` 与
+`shared_corpora`，不升 v2。兼容矩阵为：Legacy 无 Center 不写 shared；Legacy 有 Center 只写
+`[center]`；新 Pool Artifact 无论是否有 Center 都写有序 `[repo, center]`。历史无
+`skills_manifest`、Legacy 无 shared、以及 Pool 无 Center/无 shared Artifact 保持可读；有
+Center 却无 exact Center delivery、Legacy 声明 Repo delivery 或其它组合均 fail closed。
+
+Legacy + Center 示例：
 
 ```json
 {
   "schema_version": 1,
+  "engine": "openclaw",
+  "active_layout": "legacy",
+  "layout_contract_version": null,
   "center_skills": [
     {
       "runtime_name": "pdf",
       "skill_uuid": "uuid",
       "sc_version_number": "1.0.0",
-      "mcp_dependencies": ["mcp.a"]
+      "mcp_dependencies": [{"code": "mcp.a"}]
+    }
+  ],
+  "shared_corpora": [
+    {
+      "corpus": "center",
+      "runtime_path": "/engine/workspace/skills-pool/skill-center",
+      "store_prefix": "aidesktop/aidesktop_<env>/bolt_shared/skills-center",
+      "layout_contract_version": "skills-pool-p3-v1",
+      "permission": "read_only",
+      "snapshot_policy": "exclude"
     }
   ]
 }
@@ -1070,8 +1115,18 @@ Repo/Center OSS 只读挂载到 physical runtime 的 `skills-pool/skills-repo` �
 按 `runtime_name + skill_uuid + sc_version_number` 稳定排序。Manifest 只承担 exact-version 审计、
 物理 Artifact 校验、Offline 血缘和问题定位，不在 restart 时重新解析 latest 或重建软链。旧 Artifact
 没有 `center_skills` 时按无 Center 的原合同读取。Validator 必须保证：不携带完整共享 Corpus；
-Center link 与 manifest 一一对应并指向 exact version；共享 Store 中 `SKILL.md` 可读；不存在
-未声明/版本漂移/越界 link。
+Center link 与 manifest 一一对应、使用 canonical absolute target 并指向 exact version；共享 Store
+exact Version 可读；不存在未声明/版本漂移/越界 link；Probe 返回的 active/local/repo/center roots
+为当前 Engine、同一 contract 下的 canonical 绝对路径。
+
+构建失败沿用现有 `FAILED + source_status=building` 与 Retry 状态机，并在内部 ext 记录稳定错误码：
+`SERVICE_ARTIFACT_LAYOUT_EVIDENCE_UNAVAILABLE`、
+`SERVICE_ARTIFACT_LAYOUT_EVIDENCE_INVALID`、
+`SERVICE_ARTIFACT_CENTER_STORE_NOT_READY`、
+`SERVICE_ARTIFACT_SNAPSHOT_INVALID`、
+`SERVICE_ARTIFACT_CAPABILITY_CHANGED`。公开 OpenAPI Service Publication facade 继续返回脱敏失败提示；
+存量 BFF 保留已有的详细 `error_message` 兼容合同，Probe 原始 evidence 与异常栈仍只进入内部日志。
+成功重试必须清理旧的 build error 字段。
 
 #### 14.3 Teclaw v4
 

--- a/src/backend/src/agentclaw/community/core/bot_management/services/teclaw_provision_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/services/teclaw_provision_service.py
@@ -154,8 +154,14 @@ class TeclawProvisionService:
         #    publish snapshot. (``owner_id`` is spliced in for the producer's
         #    ``_compose_request``, which reads the bot row's ``owner_id``.) Runtime
         #    edits later push updates via the teclaw device-sync variant.
+        from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+            ArtifactBuildRequest,
+        )
+
         deploy = self._producer_router.resolve(TECLAW_DEVICE_PROVIDER).produce_artifact(
-            {**bot, "owner_id": owner_id}, version=None
+            ArtifactBuildRequest.create(
+                bot={**bot, "owner_id": owner_id}, version=None
+            )
         )
         config_artifact = deploy.ext["config_artifact"]
 

--- a/src/backend/src/agentclaw/community/core/service_bot/README.md
+++ b/src/backend/src/agentclaw/community/core/service_bot/README.md
@@ -16,6 +16,11 @@ provides:
   - "BaasService"
   - "ServiceSkillsManifestBuilder"
   - "ResolvedSharedCorpusDelivery"
+  - "ArtifactBuildRequest"
+  - "ServiceArtifactLayoutObservation"
+  - "ServiceArtifactResolvedLayout"
+  - "ServiceArtifactBuildError"
+  - "ServiceArtifactBuildErrorCode"
   - "ServiceArtifactLineageReader"
   - "ServiceEditLockService"
   - "ServiceBot SQLAlchemy models"
@@ -23,6 +28,7 @@ consumes:
   - "BotManagement"
   - "DeviceService + repo"
   - "SkillsPool layout state"
+  - "RuntimeLayoutProbeServiceProtocol"
   - "SystemConfig"
   - "PassportPlugin"
 internal_dependencies:
@@ -71,8 +77,11 @@ internal_dependencies:
 ### Change impact
 
 Publication path is the user-visible go-live for bots — bugs here block customers from publishing.
-Service artifacts freeze the persisted Skills Pool layout state at build time;
-changes to the Skills Pool contract or repository therefore affect publication
+Service artifacts freeze the persisted Skills Pool policy state plus fresh
+Engine-observed filesystem evidence at build time. OCB remains the sole owner
+of Repo/Center mounts; ``shared_corpora`` is an artifact exclusion and audit
+contract, never a BaaS mount instruction. Changes to the Skills Pool probe,
+mapping contract or historical manifest reader therefore affect publication
 compatibility and must be reviewed together with this module.
 
 ## Publish operation ledger (#197)

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/arca_snapshot_producer.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/arca_snapshot_producer.py
@@ -10,12 +10,16 @@ a :class:`DeployArtifact`. The exact deployable pointers the build phase pins
 This is the ARCA branch of the provider-keyed producer selection wired in
 Task 12; external bots take :class:`TeclawComposeProducer` instead.
 """
+
 from __future__ import annotations
 
 import os
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+)
 from agentclaw.community.core.service_bot.services.deploy.producer import (
     DeployArtifact,
     DeployArtifactProducer,
@@ -27,11 +31,15 @@ from agentclaw.community.core.service_bot.services.deploy.service_skills_manifes
 )
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
-    from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
+    from agentclaw.community.core.service_bot.services.bot_build_service import (
+        BotBuildService,
+    )
 
 
 class ArcaSnapshotProducer(DeployArtifactProducer):
     """Wraps the existing ARCA build (rsync + mcporter snapshot), behavior-equivalent."""
+
+    requires_runtime_layout_observation = True
 
     def __init__(
         self,
@@ -44,7 +52,7 @@ class ArcaSnapshotProducer(DeployArtifactProducer):
         self._build_service = build_service
         self._skills_manifest_builder = skills_manifest_builder
 
-    def produce_artifact(self, bot: dict[str, Any], version: int) -> DeployArtifact:
+    def produce_artifact(self, request: ArtifactBuildRequest) -> DeployArtifact:
         """Delegate to ``build()`` and map its result onto :class:`DeployArtifact`.
 
         The build phase used to read ``success`` / ``migration_path`` /
@@ -53,13 +61,17 @@ class ArcaSnapshotProducer(DeployArtifactProducer):
         exactly that: same keys, same values, same failure message — only the
         return type changes.
         """
-        captured_layout = self._skills_manifest_builder.capture(bot=bot)
-        build_kwargs: dict[str, Any] = {"bot": bot, "version": version}
+        if request.version is None:
+            raise ValueError("ARCA snapshot build requires a publish version")
+        bot = dict(request.bot)
+        captured_layout = self._skills_manifest_builder.capture(
+            bot=bot,
+            layout_observation=request.layout_observation,
+        )
+        build_kwargs: dict[str, Any] = {"bot": bot, "version": request.version}
         if captured_layout is not None:
             build_kwargs["shared_corpora"] = captured_layout.shared_corpora
-            build_kwargs["active_runtime_path"] = (
-                captured_layout.active_runtime_path
-            )
+            build_kwargs["active_runtime_path"] = captured_layout.active_runtime_path
         result = self._build_service.build(**build_kwargs)
 
         success = bool(result.get("success"))
@@ -86,6 +98,7 @@ class ArcaSnapshotProducer(DeployArtifactProducer):
             # service version. It augments — never replaces — build_target_path.
             ext["skills_manifest"] = self._skills_manifest_builder.finalize(
                 captured=captured_layout,
+                bot=bot,
             )
 
         return DeployArtifact(
@@ -153,11 +166,7 @@ class ArcaSnapshotProducer(DeployArtifactProducer):
         expected = {
             (
                 str(active_path / item["runtime_name"]),
-                str(
-                    center_root
-                    / item["skill_uuid"]
-                    / item["sc_version_number"]
-                ),
+                str(center_root / item["skill_uuid"] / item["sc_version_number"]),
             )
             for item in captured.center_skills
         }

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/artifact_build_request.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/artifact_build_request.py
@@ -1,0 +1,264 @@
+"""Typed input and observed runtime layout for one artifact build.
+
+The runtime probe owns discovery of engine-specific filesystem paths.  Service
+artifact producers consume the normalized observation below instead of reading
+stale Skills-Pool state or interpreting the probe transport payload themselves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import PurePosixPath
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from agentclaw.community.core.skill_center.runtime_layout_probe_service_protocol import (
+    RuntimeLayoutProbeResult,
+    RuntimeLayoutProbeStatus,
+)
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    LAYOUT_CONTRACT_VERSION,
+)
+
+
+class ServiceArtifactBuildErrorCode(str, Enum):
+    """Stable internal classifications for Service Artifact build failures."""
+
+    LAYOUT_EVIDENCE_UNAVAILABLE = "SERVICE_ARTIFACT_LAYOUT_EVIDENCE_UNAVAILABLE"
+    LAYOUT_EVIDENCE_INVALID = "SERVICE_ARTIFACT_LAYOUT_EVIDENCE_INVALID"
+    CENTER_STORE_NOT_READY = "SERVICE_ARTIFACT_CENTER_STORE_NOT_READY"
+    SNAPSHOT_INVALID = "SERVICE_ARTIFACT_SNAPSHOT_INVALID"
+    CAPABILITY_CHANGED = "SERVICE_ARTIFACT_CAPABILITY_CHANGED"
+
+
+class ServiceArtifactBuildError(RuntimeError):
+    """Safe classified failure persisted by the publication build stage."""
+
+    def __init__(
+        self,
+        code: ServiceArtifactBuildErrorCode,
+        message: str,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceArtifactResolvedLayout:
+    """Canonical filesystem roots observed from the current Engine runtime."""
+
+    engine: str
+    layout_contract_version: str
+    active_root: str
+    local_root: str
+    repo_root: str
+    center_root: str
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceArtifactLayoutObservation:
+    """Normalized, build-local result of the current runtime layout probe."""
+
+    status: RuntimeLayoutProbeStatus
+    engine: str
+    layout_contract_version: str
+    resolved_layout: ServiceArtifactResolvedLayout | None
+    supported_mapping_contract_versions: frozenset[str]
+    center_mount_status: str | None
+    reason: str | None
+
+    @classmethod
+    def from_probe(
+        cls,
+        probe: RuntimeLayoutProbeResult,
+        *,
+        expected_engine: str,
+    ) -> ServiceArtifactLayoutObservation:
+        """Parse one probe without leaking its transport-shaped evidence onward.
+
+        Non-READY outcomes remain observations: a Legacy artifact with no Center
+        Skills may legally fall back to its historical static build plan.  A
+        malformed READY outcome is normalized to INVALID so the producer can
+        apply that same requirement matrix after it captures the active assets.
+        """
+
+        evidence = probe.evidence if isinstance(probe.evidence, dict) else {}
+        reason = evidence.get("reason")
+        normalized_reason = reason if isinstance(reason, str) and reason else None
+        if (
+            probe.status is not RuntimeLayoutProbeStatus.READY
+            or probe.engine != expected_engine
+            or probe.layout_contract_version != LAYOUT_CONTRACT_VERSION
+        ):
+            status = probe.status
+            if (
+                probe.status is RuntimeLayoutProbeStatus.READY
+                or probe.engine != expected_engine
+                or probe.layout_contract_version != LAYOUT_CONTRACT_VERSION
+            ):
+                status = RuntimeLayoutProbeStatus.INVALID
+                normalized_reason = "runtime_layout_probe_identity_mismatch"
+            return cls(
+                status=status,
+                engine=expected_engine,
+                layout_contract_version=LAYOUT_CONTRACT_VERSION,
+                resolved_layout=None,
+                supported_mapping_contract_versions=frozenset(),
+                center_mount_status=None,
+                reason=normalized_reason,
+            )
+
+        try:
+            resolved = cls._parse_resolved_layout(
+                evidence.get("resolved_layout"), expected_engine=expected_engine
+            )
+            supported = cls._parse_supported_mapping_contracts(evidence)
+            center_mount_status = cls._parse_center_mount_status(evidence)
+        except (TypeError, ValueError):
+            return cls(
+                status=RuntimeLayoutProbeStatus.INVALID,
+                engine=expected_engine,
+                layout_contract_version=LAYOUT_CONTRACT_VERSION,
+                resolved_layout=None,
+                supported_mapping_contract_versions=frozenset(),
+                center_mount_status=None,
+                reason="invalid_runtime_layout_probe_evidence",
+            )
+
+        return cls(
+            status=RuntimeLayoutProbeStatus.READY,
+            engine=expected_engine,
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            resolved_layout=resolved,
+            supported_mapping_contract_versions=supported,
+            center_mount_status=center_mount_status,
+            reason=None,
+        )
+
+    @staticmethod
+    def _parse_resolved_layout(
+        value: object,
+        *,
+        expected_engine: str,
+    ) -> ServiceArtifactResolvedLayout:
+        required = {
+            "engine",
+            "layout_contract_version",
+            "active_root",
+            "local_root",
+            "repo_root",
+            "pool_center",
+        }
+        if not isinstance(value, dict) or set(value) != required:
+            raise ValueError("invalid resolved layout")
+        if (
+            value.get("engine") != expected_engine
+            or value.get("layout_contract_version") != LAYOUT_CONTRACT_VERSION
+        ):
+            raise ValueError("resolved layout identity mismatch")
+
+        paths: dict[str, PurePosixPath] = {}
+        for field in ("active_root", "local_root", "repo_root", "pool_center"):
+            raw = value.get(field)
+            if not isinstance(raw, str) or not raw:
+                raise ValueError("missing resolved layout path")
+            path = PurePosixPath(raw)
+            if (
+                not path.is_absolute()
+                or path.as_posix() != raw
+                or raw == "/"
+                or raw.startswith("//")
+                or any(part in {"", ".", ".."} for part in path.parts)
+            ):
+                raise ValueError("non-canonical resolved layout path")
+            paths[field] = path
+
+        local = paths["local_root"]
+        repo = paths["repo_root"]
+        center = paths["pool_center"]
+        if (
+            local.parent != repo.parent
+            or repo.parent != center.parent
+            or local.name != "skills-local"
+            or repo.name != "skills-repo"
+            or center.name != "skill-center"
+        ):
+            raise ValueError("invalid shared Skills-Pool roots")
+        active = paths["active_root"]
+        for corpus in (local, repo, center):
+            try:
+                active.relative_to(corpus)
+            except ValueError:
+                continue
+            raise ValueError("active root cannot be inside a shared corpus")
+
+        return ServiceArtifactResolvedLayout(
+            engine=expected_engine,
+            layout_contract_version=LAYOUT_CONTRACT_VERSION,
+            active_root=active.as_posix(),
+            local_root=local.as_posix(),
+            repo_root=repo.as_posix(),
+            center_root=center.as_posix(),
+        )
+
+    @staticmethod
+    def _parse_supported_mapping_contracts(
+        evidence: dict[str, Any],
+    ) -> frozenset[str]:
+        result: set[str] = set()
+        legacy = evidence.get("mapping_contract_version")
+        if isinstance(legacy, str) and legacy:
+            result.add(legacy)
+        supported = evidence.get("supported_mapping_contract_versions")
+        if supported is not None:
+            if not isinstance(supported, list) or any(
+                not isinstance(item, str) or not item for item in supported
+            ):
+                raise ValueError("invalid mapping contracts")
+            result.update(supported)
+        return frozenset(result)
+
+    @staticmethod
+    def _parse_center_mount_status(evidence: dict[str, Any]) -> str | None:
+        center_mount = evidence.get("center_mount")
+        if center_mount is None:
+            return None
+        if not isinstance(center_mount, dict):
+            raise ValueError("invalid Center mount evidence")
+        status = center_mount.get("status")
+        if status not in {"READY", "NOT_READY", "UNAVAILABLE"}:
+            raise ValueError("invalid Center mount status")
+        return str(status)
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactBuildRequest:
+    """One immutable artifact-build command shared by all producer strategies."""
+
+    bot: Mapping[str, Any]
+    version: int | None
+    layout_observation: ServiceArtifactLayoutObservation | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        bot: Mapping[str, Any],
+        version: int | None,
+        layout_observation: ServiceArtifactLayoutObservation | None = None,
+    ) -> ArtifactBuildRequest:
+        return cls(
+            bot=MappingProxyType(dict(bot)),
+            version=version,
+            layout_observation=layout_observation,
+        )
+
+
+__all__ = [
+    "ArtifactBuildRequest",
+    "ServiceArtifactBuildError",
+    "ServiceArtifactBuildErrorCode",
+    "ServiceArtifactLayoutObservation",
+    "ServiceArtifactResolvedLayout",
+]

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/external_compose_producer.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/external_compose_producer.py
@@ -16,12 +16,16 @@ bytes are persisted separately), so there's nothing to materialize —
 already inside the artifact). Per Model 1 that pinned artifact is later **handed to
 baas and forwarded** to the external container (non-mount) — no ARCA mount chain.
 """
+
 from __future__ import annotations
 
 import dataclasses
 from typing import Any, Protocol
 
 from agentclaw.community.core.config_compose.models import ComposeRequest
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+)
 from agentclaw.community.core.service_bot.services.deploy.engine_ext_stage import (
     enrich_engine_ext,
 )
@@ -48,12 +52,12 @@ class ConfigComposerLike(Protocol):
 class ExternalComposeProducer(DeployArtifactProducer):
     """Compose-from-DB+NAS build producer (base for engine-specific subclasses)."""
 
+    requires_runtime_layout_observation = False
+
     def __init__(self, composer: ConfigComposerLike) -> None:
         self._composer = composer
 
-    def produce_artifact(
-        self, bot: dict[str, Any], version: int | None
-    ) -> DeployArtifact:
+    def produce_artifact(self, request: ArtifactBuildRequest) -> DeployArtifact:
         """Produce the deployable artifact: compose (+ inject ``engine_ext``) and pin
         the composed dict onto ``ext.config_artifact``.
 
@@ -63,10 +67,8 @@ class ExternalComposeProducer(DeployArtifactProducer):
         The verify/online publish stages — and eager teclaw provisioning — read
         ``ext.config_artifact`` and hand it to ``create_teclaw_bot`` (non-mount).
         """
-        artifact = self._compose_with_engine_ext(bot, version)
-        return DeployArtifact(
-            success=True, ext={"config_artifact": artifact.to_dict()}
-        )
+        artifact = self._compose_with_engine_ext(dict(request.bot), request.version)
+        return DeployArtifact(success=True, ext={"config_artifact": artifact.to_dict()})
 
     def _compose_with_engine_ext(
         self, bot: dict[str, Any], version: int | None

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/managed_composer.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/managed_composer.py
@@ -2,10 +2,10 @@
 
 The managed bot image lays four scripts under ``/home/admin/bin`` and expects
 them chained in order: bootstrap compensation, engine install, the start
-service, then the watchdog. Its NAS holds the system directory, the bot's data
-directory and the skills repo, and every bot gets a storage volume — the
-sessions directory, or the home directory for bots the ``nas_mount`` whitelist
-has moved.
+service, then the watchdog. Its NAS holds the system and bot-data directories;
+the image entrypoint is the sole owner of read-only Repo/Center corpus mounts.
+Every bot also gets a storage volume — the sessions directory, or the home
+directory for bots the ``nas_mount`` whitelist has moved.
 
 None of that is a platform invariant; all of it is this image's layout. The
 bodies below are the ones that lived on ``BaasService`` before the composer
@@ -42,9 +42,6 @@ from agentclaw.community.core.service_bot.services.deploy.deploy_models import (
     MountPointEntry,
     Storage,
     StorageType,
-)
-from agentclaw.community.core.service_bot.services.deploy.service_skills_manifest import (
-    frozen_shared_corpus_deliveries_from_ext,
 )
 from agentclaw.community.core.service_bot.types import PublishStage, is_editable_bot
 from agentclaw.community.core.workspace.constants import DEFAULT_ENGINE_TYPE
@@ -399,20 +396,6 @@ class ManagedDeployConfigComposer(DeployConfigComposer):
         """
         sp = self._storage_path
         bolt_data = sp.get_bolt_data_path(entity_type=entity_type, entity_id=entity_id, bot_id=bot_id)
-        skill_repo = sp.get_skills_repo_path()
-
-        # 引擎感知：通过 EngineSandboxProvider 动态解析 skills 挂载本地路径
-        # （base_path/{skill_target_relpath}/skills-repo），避免硬编码 openclaw
-        provider = self._resolve_sandbox_provider(engine=engine_type)
-        base_path = provider.get_base_path()
-        build_plan = provider.get_build_plan()
-        skills_local_dir = f"{base_path}/{build_plan.skill_target_relpath}/skills-repo"
-        shared_corpora = frozen_shared_corpus_deliveries_from_ext(
-            ext_info, {"active_engine": engine_type or DEFAULT_ENGINE_TYPE}
-        )
-        has_frozen_repo = any(
-            delivery.corpus == "repo" for delivery in shared_corpora
-        )
 
         # OSS 挂载点必须位于 /home/admin/nfs/ 下；引擎专用目录
         # （/home/admin/.{engine}、/home/admin/.config/{engine}）由
@@ -427,8 +410,9 @@ class ManagedDeployConfigComposer(DeployConfigComposer):
             ),
         ]
 
-        # skill repo独立挂载
-        # bolt 配置数据独立挂载
+        # Repo/Center are mounted by the managed image entrypoint. BaaS only
+        # receives platform storage and explicit user mounts, avoiding two
+        # independent writers for the same engine paths.
         if mount_home_dir_storage:
             mount_points.append(
                 MountPointEntry(
@@ -445,24 +429,6 @@ class ManagedDeployConfigComposer(DeployConfigComposer):
                     permission=MountPermission.READ_WRITE,
                 )
             )
-            if not has_frozen_repo:
-                mount_points.append(
-                    MountPointEntry(
-                        remote_dir=f"/{skill_repo}",
-                        local_dir=skills_local_dir,
-                        permission=MountPermission.READ_ONLY,
-                    )
-                )
-
-        for delivery in shared_corpora:
-            mount_points.append(
-                MountPointEntry(
-                    remote_dir=f"/{delivery.store_prefix}",
-                    local_dir=delivery.runtime_path,
-                    permission=MountPermission.READ_ONLY,
-                )
-            )
-
         # 用户自定义挂载路径
         if mount_path:
             mount_points.append(

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/producer.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/producer.py
@@ -12,11 +12,16 @@ The selector mirrors ``DeviceServiceRouter``: the DI composition root assembles
 the ``device_provider -> producer`` map; the router does pure dispatch with a
 default fallback and reads no environment (Rule 14: config-driven assembly).
 """
+
 from __future__ import annotations
 
 import abc
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
+
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+)
 
 
 @dataclass
@@ -38,12 +43,17 @@ class DeployArtifact:
 class DeployArtifactProducer(abc.ABC):
     """Strategy that produces (and pins) the deployable artifact at build."""
 
+    requires_runtime_layout_observation: ClassVar[bool] = False
+
     @abc.abstractmethod
-    def produce_artifact(
-        self, bot: dict[str, Any], version: int | None
-    ) -> DeployArtifact:
-        """Produce and pin the deployable artifact. ``version`` is the publish
-        snapshot version, or ``None`` for an unversioned (eager-provision) compose."""
+    def produce_artifact(self, request: ArtifactBuildRequest) -> DeployArtifact:
+        """Produce and pin the artifact described by ``request``.
+
+        ``request.version`` is the publish snapshot version, or ``None`` for an
+        unversioned (eager-provision) compose.  Filesystem snapshot producers
+        declare ``requires_runtime_layout_observation`` and validate the fresh
+        observation before consuming any engine-specific path.
+        """
         raise NotImplementedError
 
 

--- a/src/backend/src/agentclaw/community/core/service_bot/services/deploy/service_skills_manifest.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/deploy/service_skills_manifest.py
@@ -2,8 +2,8 @@
 
 This module deliberately owns only the service-publish contract. It never
 guesses an engine-specific filesystem path: exact shared-corpus delivery is
-strictly parsed from the versioned Engine Runtime probe evidence persisted with
-the editable draft's active layout, then frozen into the historical artifact.
+strictly parsed from the fresh Engine Runtime observation supplied by the build
+stage, then frozen into the historical artifact.
 """
 
 from __future__ import annotations
@@ -12,21 +12,32 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Any
 
-from agentclaw.community.core.repository.protocols.skills_pool import SkillsPoolLayoutRepositoryProtocol
-from agentclaw.community.core.skill_center.capability_state_contract import (
-    BotCapabilityStateReaderProtocol,
+from agentclaw.community.core.repository.protocols.skills_pool import (
+    SkillsPoolLayoutRepositoryProtocol,
+)
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ServiceArtifactBuildError,
+    ServiceArtifactBuildErrorCode,
+    ServiceArtifactLayoutObservation,
 )
 from agentclaw.community.core.skill_center.canonical_center_store import (
     CanonicalCenterVersionIdentity,
     CanonicalCenterVersionRef,
     CanonicalCenterVersionStore,
 )
+from agentclaw.community.core.skill_center.capability_state_contract import (
+    BotCapabilityStateReaderProtocol,
+)
 from agentclaw.community.core.skill_center.mcp_dependency_scope import (
     mcp_dependency_codes,
 )
+from agentclaw.community.core.skill_center.runtime_layout_probe_service_protocol import (
+    RuntimeLayoutProbeStatus,
+)
 from agentclaw.community.core.skill_center.runtime_resolver import RuntimeNamePolicy
-from agentclaw.community.core.workspace.skill_layout import (
-    runtime_layout_engine_for_bot,
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    MAPPING_CONTRACT_VERSION,
+    MAPPING_V3_CONTRACT_VERSION,
 )
 from agentclaw.community.core.skills_pool.types import (
     BotSkillLayoutScope,
@@ -41,7 +52,6 @@ class CapturedServiceSkillsLayout:
     """The draft layout decision captured before physical snapshotting starts."""
 
     engine: str
-    runtime_engine: str
     scope: BotSkillLayoutScope
     active_layout: SkillLayout
     phase: SkillLayoutPhase
@@ -52,53 +62,22 @@ class CapturedServiceSkillsLayout:
     shared_corpora: tuple[ResolvedSharedCorpusDelivery, ...]
 
 
-_SERVICE_MANIFEST_ENGINES = frozenset(
-    {"openclaw", "claude_code", "aicoding", "hermes"}
-)
+_SERVICE_MANIFEST_ENGINES = frozenset({"openclaw", "claude_code", "aicoding", "hermes"})
 SERVICE_SKILLS_POOL_CONTRACT_VERSION = "skills-pool-p3-v1"
 
 
-class ServiceSkillsManifestError(RuntimeError):
+class ServiceSkillsManifestError(ServiceArtifactBuildError):
     """The draft cannot be represented as a supported Skills manifest."""
 
-
-def _resolved_ready_layout(
-    *,
-    state,
-    bot: dict[str, Any],
-) -> dict[str, str]:
-    evidence = state.last_probe_evidence
-    resolved = evidence.get("resolved_layout") if isinstance(evidence, dict) else None
-    expected_engine = runtime_layout_engine_for_bot(bot)
-    required = {
-        "engine",
-        "layout_contract_version",
-        "active_root",
-        "local_root",
-        "repo_root",
-        "pool_center",
-    }
-    if (
-        state.last_probe_result != "READY"
-        or state.layout_contract_version != SERVICE_SKILLS_POOL_CONTRACT_VERSION
-        or not isinstance(resolved, dict)
-        or set(resolved) != required
-        or resolved.get("engine") != expected_engine
-        or resolved.get("layout_contract_version")
-        != SERVICE_SKILLS_POOL_CONTRACT_VERSION
-    ):
-        raise ServiceSkillsManifestError(
-            "service build requires matching READY Engine layout evidence"
-        )
-    normalized: dict[str, str] = {}
-    for field in required:
-        value = resolved.get(field)
-        if not isinstance(value, str) or not value:
-            raise ServiceSkillsManifestError(
-                "service build has invalid READY Engine layout evidence"
-            )
-        normalized[field] = value
-    return normalized
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: ServiceArtifactBuildErrorCode = (
+            ServiceArtifactBuildErrorCode.SNAPSHOT_INVALID
+        ),
+    ) -> None:
+        super().__init__(code, message)
 
 
 @dataclass(frozen=True, slots=True)
@@ -113,52 +92,54 @@ class ResolvedSharedCorpusDelivery:
     snapshot_policy: str = "exclude"
 
     @classmethod
-    def center_from_state(
+    def center_from_observation(
         cls,
         *,
-        state,
-        bot: dict[str, Any],
+        observation: ServiceArtifactLayoutObservation,
         store_prefix: str,
     ) -> ResolvedSharedCorpusDelivery:
-        return cls._from_state(
-            state=state,
-            bot=bot,
+        return cls._from_observation(
+            observation=observation,
             corpus="center",
-            evidence_field="pool_center",
+            runtime_path=(
+                observation.resolved_layout.center_root
+                if observation.resolved_layout is not None
+                else None
+            ),
             store_prefix=store_prefix,
         )
 
     @classmethod
-    def repo_from_state(
+    def repo_from_observation(
         cls,
         *,
-        state,
-        bot: dict[str, Any],
+        observation: ServiceArtifactLayoutObservation,
         store_prefix: str,
     ) -> ResolvedSharedCorpusDelivery:
-        return cls._from_state(
-            state=state,
-            bot=bot,
+        return cls._from_observation(
+            observation=observation,
             corpus="repo",
-            evidence_field="repo_root",
+            runtime_path=(
+                observation.resolved_layout.repo_root
+                if observation.resolved_layout is not None
+                else None
+            ),
             store_prefix=store_prefix,
         )
 
     @classmethod
-    def _from_state(
+    def _from_observation(
         cls,
         *,
-        state,
-        bot: dict[str, Any],
+        observation: ServiceArtifactLayoutObservation,
         corpus: str,
-        evidence_field: str,
+        runtime_path: str | None,
         store_prefix: str,
     ) -> ResolvedSharedCorpusDelivery:
-        resolved = _resolved_ready_layout(state=state, bot=bot)
-        runtime_path = resolved.get(evidence_field)
         if not isinstance(runtime_path, str):
             raise ServiceSkillsManifestError(
-                f"{corpus} Engine layout evidence is missing {evidence_field}"
+                f"{corpus} Engine layout evidence is missing its runtime path",
+                code=ServiceArtifactBuildErrorCode.LAYOUT_EVIDENCE_INVALID,
             )
         path = PurePosixPath(runtime_path)
         if (
@@ -167,7 +148,8 @@ class ResolvedSharedCorpusDelivery:
             or any(part in {"", ".", ".."} for part in path.parts)
         ):
             raise ServiceSkillsManifestError(
-                f"{corpus} Engine layout evidence has an invalid {evidence_field}"
+                f"{corpus} Engine layout evidence has an invalid runtime path",
+                code=ServiceArtifactBuildErrorCode.LAYOUT_EVIDENCE_INVALID,
             )
         prefix = PurePosixPath(store_prefix)
         if (
@@ -177,13 +159,14 @@ class ResolvedSharedCorpusDelivery:
             or any(part in {"", ".", ".."} for part in prefix.parts)
         ):
             raise ServiceSkillsManifestError(
-                f"invalid {corpus} Store prefix"
+                f"invalid {corpus} Store prefix",
+                code=ServiceArtifactBuildErrorCode.LAYOUT_EVIDENCE_INVALID,
             )
         return cls(
             corpus=corpus,
             runtime_path=runtime_path,
             store_prefix=store_prefix,
-            layout_contract_version=SERVICE_SKILLS_POOL_CONTRACT_VERSION,
+            layout_contract_version=observation.layout_contract_version,
         )
 
     def to_manifest(self) -> dict[str, str]:
@@ -218,6 +201,7 @@ class ServiceSkillsManifestBuilder:
         self,
         *,
         bot: dict[str, Any],
+        layout_observation: ServiceArtifactLayoutObservation | None,
     ) -> CapturedServiceSkillsLayout | None:
         engine = str(bot.get("active_engine") or "openclaw").strip().lower()
         scope = BotSkillLayoutScope(
@@ -254,71 +238,57 @@ class ServiceSkillsManifestBuilder:
         if is_pool and (
             not state.persisted
             or state.phase is not SkillLayoutPhase.POOL_ACTIVE
-            or not state.layout_contract_version
+            or state.layout_contract_version
+            != SERVICE_SKILLS_POOL_CONTRACT_VERSION
         ):
             raise ServiceSkillsManifestError(
                 "Pool service manifest requires a persisted POOL_ACTIVE draft"
             )
-        if engine == "hermes":
-            if not is_pool:
-                raise ServiceSkillsManifestError(
-                    "Hermes service build requires a READY Pool runtime"
-                )
-            _resolved_ready_layout(state=state, bot=bot)
-
-        try:
-            assets = self._capability_reader.active_skill_assets(
-                bot_id=str(bot.get("bot_id") or ""),
-                owner_id=str(bot.get("owner_id") or bot.get("entity_id") or ""),
-                bot=bot,
-            )
-            center_skills = tuple(
-                sorted(
-                    (
-                        self._center_skill(asset)
-                        for asset in assets
-                        if asset.git_path.startswith("center://")
-                    ),
-                    key=lambda item: (
-                        item["runtime_name"],
-                        item["skill_uuid"],
-                        item["sc_version_number"],
-                    ),
-                )
-            )
-        except Exception as exc:
-            raise ServiceSkillsManifestError(
-                "service build cannot freeze exact Center Skills"
-            ) from exc
+        center_skills = self._active_center_skills(bot)
 
         shared_corpora: tuple[ResolvedSharedCorpusDelivery, ...] = ()
         active_runtime_path: str | None = None
+        ready_observation: ServiceArtifactLayoutObservation | None = None
+        requires_observation = is_pool or bool(center_skills)
+        if requires_observation:
+            required_mapping = (
+                MAPPING_V3_CONTRACT_VERSION
+                if center_skills
+                else MAPPING_CONTRACT_VERSION
+            )
+            ready_observation = self._require_layout_observation(
+                layout_observation,
+                required_mapping_contract=required_mapping,
+            )
+            assert ready_observation.resolved_layout is not None
+            active_runtime_path = ready_observation.resolved_layout.active_root
+
         if is_pool:
-            active_runtime_path = _resolved_ready_layout(
-                state=state, bot=bot
-            )["active_root"]
+            assert ready_observation is not None
             shared_corpora = (
-                ResolvedSharedCorpusDelivery.repo_from_state(
-                    state=state,
-                    bot=bot,
+                ResolvedSharedCorpusDelivery.repo_from_observation(
+                    observation=ready_observation,
                     store_prefix=self._repo_store_prefix,
                 ),
-                ResolvedSharedCorpusDelivery.center_from_state(
-                    state=state,
-                    bot=bot,
+                ResolvedSharedCorpusDelivery.center_from_observation(
+                    observation=ready_observation,
                     store_prefix=self._center_store_prefix,
                 ),
             )
+        elif center_skills:
+            assert ready_observation is not None
+            shared_corpora = (
+                ResolvedSharedCorpusDelivery.center_from_observation(
+                    observation=ready_observation,
+                    store_prefix=self._center_store_prefix,
+                ),
+            )
+
         if center_skills:
-            if state.active_layout is not SkillLayout.POOL:
-                raise ServiceSkillsManifestError(
-                    "Center service build requires the Pool runtime layout"
-                )
             self._verify_exact_store(center_skills)
 
         return CapturedServiceSkillsLayout(
             engine=engine,
-            runtime_engine=runtime_layout_engine_for_bot(bot),
             scope=scope,
             active_layout=state.active_layout,
             phase=state.phase,
@@ -336,6 +306,7 @@ class ServiceSkillsManifestBuilder:
         self,
         *,
         captured: CapturedServiceSkillsLayout,
+        bot: dict[str, Any],
     ) -> dict[str, Any]:
         engine = captured.engine
         current = self._layout_repository.get(captured.scope)
@@ -343,29 +314,19 @@ class ServiceSkillsManifestBuilder:
             current.active_layout is not captured.active_layout
             or current.phase is not captured.phase
             or current.migration_generation != captured.migration_generation
-            or current.layout_contract_version
-            != captured.layout_contract_version
+            or current.layout_contract_version != captured.layout_contract_version
         ):
             raise ServiceSkillsManifestError(
                 "draft Skills layout changed during service build"
             )
-        if captured.shared_corpora:
-            current_deliveries = (
-                ResolvedSharedCorpusDelivery.repo_from_state(
-                    state=current,
-                    bot={"active_engine": captured.runtime_engine},
-                    store_prefix=self._repo_store_prefix,
-                ),
-                ResolvedSharedCorpusDelivery.center_from_state(
-                    state=current,
-                    bot={"active_engine": captured.runtime_engine},
-                    store_prefix=self._center_store_prefix,
-                ),
+
+        current_center_skills = self._active_center_skills(bot)
+        if current_center_skills != captured.center_skills:
+            raise ServiceSkillsManifestError(
+                "active Center Skills changed during service build",
+                code=ServiceArtifactBuildErrorCode.CAPABILITY_CHANGED,
             )
-            if current_deliveries != captured.shared_corpora:
-                raise ServiceSkillsManifestError(
-                    "Engine shared corpus delivery changed during service build"
-                )
+        if captured.center_skills:
             self._verify_exact_store(captured.center_skills)
 
         manifest = {
@@ -379,14 +340,80 @@ class ServiceSkillsManifestBuilder:
             ),
         }
         if captured.center_skills:
-            manifest["center_skills"] = [
-                dict(item) for item in captured.center_skills
-            ]
+            manifest["center_skills"] = [dict(item) for item in captured.center_skills]
         if captured.shared_corpora:
             manifest["shared_corpora"] = [
                 delivery.to_manifest() for delivery in captured.shared_corpora
             ]
         return manifest
+
+    @staticmethod
+    def _require_layout_observation(
+        observation: ServiceArtifactLayoutObservation | None,
+        *,
+        required_mapping_contract: str,
+    ) -> ServiceArtifactLayoutObservation:
+        if observation is None:
+            raise ServiceSkillsManifestError(
+                "service build runtime layout evidence is unavailable",
+                code=ServiceArtifactBuildErrorCode.LAYOUT_EVIDENCE_UNAVAILABLE,
+            )
+        if observation.status in {
+            RuntimeLayoutProbeStatus.NOT_CAPABLE,
+            RuntimeLayoutProbeStatus.TRANSIENT_ERROR,
+        }:
+            raise ServiceSkillsManifestError(
+                "service build runtime layout evidence is unavailable",
+                code=ServiceArtifactBuildErrorCode.LAYOUT_EVIDENCE_UNAVAILABLE,
+            )
+        if (
+            observation.status is not RuntimeLayoutProbeStatus.READY
+            or observation.resolved_layout is None
+        ):
+            raise ServiceSkillsManifestError(
+                "service build runtime layout evidence is invalid",
+                code=ServiceArtifactBuildErrorCode.LAYOUT_EVIDENCE_INVALID,
+            )
+        if (
+            required_mapping_contract
+            not in observation.supported_mapping_contract_versions
+        ):
+            raise ServiceSkillsManifestError(
+                "service build runtime mapping capability is unavailable",
+                code=ServiceArtifactBuildErrorCode.LAYOUT_EVIDENCE_UNAVAILABLE,
+            )
+        return observation
+
+    def _active_center_skills(
+        self,
+        bot: dict[str, Any],
+    ) -> tuple[dict[str, Any], ...]:
+        try:
+            assets = self._capability_reader.active_skill_assets(
+                bot_id=str(bot.get("bot_id") or ""),
+                owner_id=str(bot.get("owner_id") or bot.get("entity_id") or ""),
+                bot=bot,
+            )
+            return tuple(
+                sorted(
+                    (
+                        self._center_skill(asset)
+                        for asset in assets
+                        if asset.git_path.startswith("center://")
+                    ),
+                    key=lambda item: (
+                        item["runtime_name"],
+                        item["skill_uuid"],
+                        item["sc_version_number"],
+                    ),
+                )
+            )
+        except ServiceArtifactBuildError:
+            raise
+        except Exception as exc:
+            raise ServiceSkillsManifestError(
+                "service build cannot freeze exact Center Skills"
+            ) from exc
 
     @staticmethod
     def _center_skill(asset) -> dict[str, Any]:
@@ -420,13 +447,15 @@ class ServiceSkillsManifestBuilder:
                 )
                 if not ready:
                     raise ServiceSkillsManifestError(
-                        "Center service build requires every exact Store Version"
+                        "Center service build requires every exact Store Version",
+                        code=ServiceArtifactBuildErrorCode.CENTER_STORE_NOT_READY,
                     )
         except ServiceSkillsManifestError:
             raise
         except Exception as exc:
             raise ServiceSkillsManifestError(
-                "Center service build cannot verify every exact Store Version"
+                "Center service build cannot verify every exact Store Version",
+                code=ServiceArtifactBuildErrorCode.CENTER_STORE_NOT_READY,
             ) from exc
 
 
@@ -437,9 +466,7 @@ def validate_service_skills_manifest_for_release(
     """Fail closed when a live draft identity no longer matches its manifest."""
 
     if manifest.get("schema_version") != 1:
-        raise ServiceSkillsManifestError(
-            "unsupported service Skills manifest schema"
-        )
+        raise ServiceSkillsManifestError("unsupported service Skills manifest schema")
     manifest_engine = str(manifest.get("engine") or "").strip().lower()
     live_engine = str(bot.get("active_engine") or "openclaw").strip().lower()
     if manifest_engine != live_engine:
@@ -524,10 +551,22 @@ def validate_service_skills_manifest_for_release(
             raise ServiceSkillsManifestError(
                 "Pool shared corpora must contain ordered Repo and exact Center delivery"
             )
-    elif shared_corpora is not None:
-        raise ServiceSkillsManifestError(
-            "Legacy Skill manifest cannot carry shared corpora"
-        )
+    else:
+        if shared_corpora is None and not center_skills:
+            return
+        if not center_skills:
+            raise ServiceSkillsManifestError(
+                "Legacy Skill manifest cannot declare unused shared corpora"
+            )
+        if not isinstance(shared_corpora, list):
+            raise ServiceSkillsManifestError(
+                "Legacy Center Skill manifest requires frozen Center delivery"
+            )
+        deliveries = tuple(_parse_frozen_delivery(item) for item in shared_corpora)
+        if [delivery.corpus for delivery in deliveries] != ["center"]:
+            raise ServiceSkillsManifestError(
+                "Legacy Center Skill manifest requires exact Center delivery only"
+            )
 
 
 def _parse_frozen_delivery(value: object) -> ResolvedSharedCorpusDelivery:
@@ -543,9 +582,7 @@ def _parse_frozen_delivery(value: object) -> ResolvedSharedCorpusDelivery:
     try:
         delivery = ResolvedSharedCorpusDelivery(**value)
     except TypeError as exc:
-        raise ServiceSkillsManifestError(
-            "invalid shared corpus delivery"
-        ) from exc
+        raise ServiceSkillsManifestError("invalid shared corpus delivery") from exc
     if (
         delivery.corpus not in {"repo", "center"}
         or delivery.layout_contract_version != SERVICE_SKILLS_POOL_CONTRACT_VERSION

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/build_stage.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow/build_stage.py
@@ -11,13 +11,26 @@ provider resolution, producer routing) instead of reaching into
 ``PublishFlowService`` private members — it is a standalone component, not a
 friend of the facade.
 """
+
 from __future__ import annotations
 
 import asyncio
+from typing import TYPE_CHECKING
 
-from agentclaw.community.core.service_bot.repository.models import BotPublishRecord, PublishStatus
-from agentclaw.community.core.service_bot.schemas.publish_schemas import PublishFlowResult
+from agentclaw.community.core.service_bot.repository.models import (
+    BotPublishRecord,
+    PublishStatus,
+)
+from agentclaw.community.core.service_bot.schemas.publish_schemas import (
+    PublishFlowResult,
+)
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+    ServiceArtifactBuildError,
+    ServiceArtifactBuildErrorCode,
+    ServiceArtifactLayoutObservation,
+)
 from agentclaw.community.core.service_bot.services.deploy.producer import (
     DeployArtifactProducerRouter,
 )
@@ -36,12 +49,16 @@ from agentclaw.community.core.service_bot.services.service_artifact_refs import 
 from agentclaw.community.core.skill_center.bot_runtime_projector_protocol import (
     BotRuntimeProjectorProtocol,
 )
+from agentclaw.community.core.skill_center.runtime_layout_probe_service_protocol import (
+    RuntimeLayoutProbeServiceProtocol,
+)
 from agentclaw.community.core.skill_center.runtime_projection_contract import (
     ProjectionScope,
 )
+from agentclaw.community.core.workspace.skill_layout import (
+    runtime_layout_engine_for_bot,
+)
 from agentclaw.community.log import get_logger
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from agentclaw.community.core.bot_management.services.bot_service import BotService
@@ -61,6 +78,7 @@ class BuildStageRunner:
         producer_router: DeployArtifactProducerRouter,
         provider_behaviors: ProviderBehaviorRouter,
         runtime_projector: BotRuntimeProjectorProtocol,
+        runtime_layout_probe: RuntimeLayoutProbeServiceProtocol,
     ) -> None:
         self._ext_state = ext_state
         self._bot_service = bot_service
@@ -68,6 +86,7 @@ class BuildStageRunner:
         self._producer_router = producer_router
         self._provider_behaviors = provider_behaviors
         self._runtime_projector = runtime_projector
+        self._runtime_layout_probe = runtime_layout_probe
 
     async def build(
         self,
@@ -87,7 +106,10 @@ class BuildStageRunner:
             logger.info(
                 "[BuildStageRunner] Starting build: publish_id=%s, bot_id=%s, "
                 "operator=%s, owner_id=%s",
-                publish_id, bot_id, operator, owner_id,
+                publish_id,
+                bot_id,
+                operator,
+                owner_id,
             )
 
             bot = self._bot_service.get_bot(bot_id=bot_id, user_id=owner_id)
@@ -121,23 +143,75 @@ class BuildStageRunner:
             device_provider = self._baas_service.resolve_container_provider(bot)
             producer = self._producer_router.resolve(device_provider)
             behavior = self._provider_behaviors.resolve(device_provider)
-            artifact = await asyncio.to_thread(producer.produce_artifact, bot, version)
+            layout_observation = None
+            if producer.requires_runtime_layout_observation:
+                # TODO: let BotRuntimeProjector hand off its fresh observation
+                # once that Service API can do so without coupling projection
+                # results to filesystem Artifact producers. Until then, one
+                # read-only probe keeps the build contract explicit and current.
+                runtime_engine = runtime_layout_engine_for_bot(bot)
+                probe = await self._runtime_layout_probe.probe_bot(
+                    bot_id=str(bot["bot_id"]),
+                    user_id=str(bot["owner_id"]),
+                    engine=runtime_engine,
+                )
+                layout_observation = ServiceArtifactLayoutObservation.from_probe(
+                    probe,
+                    expected_engine=runtime_engine,
+                )
+                logger.info(
+                    "[BuildStageRunner] Runtime layout observed: bot_id=%s, "
+                    "engine=%s, status=%s, center_mount=%s, reason=%s",
+                    bot_id,
+                    runtime_engine,
+                    layout_observation.status.value,
+                    layout_observation.center_mount_status,
+                    layout_observation.reason,
+                )
+                if layout_observation.resolved_layout is not None:
+                    resolved = layout_observation.resolved_layout
+                    logger.debug(
+                        "[BuildStageRunner] Runtime layout paths: bot_id=%s, "
+                        "active_root=%s, local_root=%s, repo_root=%s, "
+                        "center_root=%s",
+                        bot_id,
+                        resolved.active_root,
+                        resolved.local_root,
+                        resolved.repo_root,
+                        resolved.center_root,
+                    )
+
+            request = ArtifactBuildRequest.create(
+                bot=bot,
+                version=version,
+                layout_observation=layout_observation,
+            )
+            artifact = await asyncio.to_thread(producer.produce_artifact, request)
 
             if not artifact.success:
-                raise PublishFlowServiceError(artifact.message or "Build failed")
+                raise ServiceArtifactBuildError(
+                    ServiceArtifactBuildErrorCode.SNAPSHOT_INVALID,
+                    artifact.message or "Service Artifact snapshot build failed",
+                )
 
             # Provider-specific post-build file staging (teclaw snapshots the
             # running source container's files into OSS and embeds the refs;
             # ARCA/baas write the live FS the build already sees → no-op).
             await behavior.stage_build_files(
-                artifact=artifact, bot=bot, bot_id=bot_id,
-                owner_id=owner_id, publish_id=publish_id,
+                artifact=artifact,
+                bot=bot,
+                bot_id=bot_id,
+                owner_id=owner_id,
+                publish_id=publish_id,
             )
 
             # Build succeeded: merge the artifact pointers into ext (ARCA =
             # migration_path/build_target_path; external = config_artifact/
             # content_hash/engine_ext).
             ext, expected_ext = self._ext_state.get_latest_ext_snapshot(publish_id)
+            ext.pop("error_code", None)
+            ext.pop("error_message", None)
+            ext.pop("source_status", None)
             ext.update(artifact.ext)
             center_skill_uuids = tuple(
                 sorted(
@@ -159,7 +233,8 @@ class BuildStageRunner:
 
             logger.info(
                 "[BuildStageRunner] Build completed: publish_id=%s, provider=%s",
-                publish_id, device_provider,
+                publish_id,
+                device_provider,
             )
 
             return PublishFlowResult(
@@ -170,11 +245,20 @@ class BuildStageRunner:
             )
 
         except Exception as e:
-            logger.error("[BuildStageRunner] Build failed: %s", e)
+            logger.exception("[BuildStageRunner] Build failed: %s", e)
 
             ext, expected_ext = self._ext_state.get_latest_ext_snapshot(publish_id)
             PublishExtState.clear_retry_flag(ext)
-            ext["error_message"] = str(e)
+            if isinstance(e, ServiceArtifactBuildError):
+                ext["error_code"] = e.code.value
+                error_message = str(e)
+            else:
+                ext.pop("error_code", None)
+                # Preserve the existing Legacy BFF diagnostic contract. The
+                # public OpenAPI facade independently sanitizes deployment
+                # failures before returning them to external callers.
+                error_message = str(e)
+            ext["error_message"] = error_message
             ext["source_status"] = PublishStatus.BUILDING.value
             self._ext_state.update_status(
                 publish_id=publish_id,
@@ -187,6 +271,6 @@ class BuildStageRunner:
             return PublishFlowResult(
                 publish_id=publish_id,
                 status=PublishStatus.FAILED,
-                message=f"Build failed: {str(e)}",
+                message=f"Build failed: {error_message}",
                 action="process",
             )

--- a/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
+++ b/src/backend/src/agentclaw/community/core/service_bot/services/publish_flow_service.py
@@ -29,6 +29,9 @@ from agentclaw.community.core.service_bot.services.baas_service import BaasServi
 from agentclaw.community.core.skill_center.bot_runtime_projector_protocol import (
     BotRuntimeProjectorProtocol,
 )
+from agentclaw.community.core.skill_center.runtime_layout_probe_service_protocol import (
+    RuntimeLayoutProbeServiceProtocol,
+)
 from agentclaw.community.core.service_bot.services.deploy.producer import (
     DeployArtifactProducerRouter,
 )
@@ -198,6 +201,7 @@ class PublishFlowService(
         task_queue_service: TaskQueueService,
         publish_operation_repo: PublishOperationRepository,
         runtime_projector: BotRuntimeProjectorProtocol,
+        runtime_layout_probe: RuntimeLayoutProbeServiceProtocol,
     ):
         """Initialize the flow processing service.
 
@@ -287,6 +291,7 @@ class PublishFlowService(
             producer_router=producer_router,
             provider_behaviors=self._provider_behaviors,
             runtime_projector=runtime_projector,
+            runtime_layout_probe=runtime_layout_probe,
         )
 
         # Durable task queue: backend-driven advances (build+verify release, online

--- a/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/service_bot_module.py
@@ -88,6 +88,9 @@ from agentclaw.community.api.bot_capability_state_reader import (
 from agentclaw.community.api.bot_runtime_projector import (
     BotRuntimeProjectorProtocol as ApiBotRuntimeProjectorProtocol,
 )
+from agentclaw.community.api.runtime_layout_probe_service import (
+    RuntimeLayoutProbeServiceProtocol,
+)
 from agentclaw.community.core.service_bot.services.baas_service import BaasService
 from agentclaw.community.core.service_bot.services.bot_build_service import BotBuildService
 from agentclaw.community.core.service_bot.services.bot_process import (
@@ -569,6 +572,7 @@ class ServiceBotModule(Module):
         task_queue_service: TaskQueueService,
         publish_operation_repo: PublishOperationRepository,
         runtime_projector: ApiBotRuntimeProjectorProtocol,
+        runtime_layout_probe: RuntimeLayoutProbeServiceProtocol,
     ) -> PublishFlowService:
         """Construct ``PublishFlowService``.
 
@@ -594,6 +598,7 @@ class ServiceBotModule(Module):
             task_queue_service=task_queue_service,
             publish_operation_repo=publish_operation_repo,
             runtime_projector=runtime_projector,
+            runtime_layout_probe=runtime_layout_probe,
         )
 
     @singleton

--- a/src/backend/tests/community/contracts/test_bot_config_artifact_schema.py
+++ b/src/backend/tests/community/contracts/test_bot_config_artifact_schema.py
@@ -38,6 +38,9 @@ from agentclaw.community.core.config_compose.services.mcporter_composer import (
 from agentclaw.community.core.service_bot.services.deploy.external_compose_producer import (
     ExternalComposeProducer,
 )
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+)
 from agentclaw.community.kernel.bot_config import SCHEMA_VERSION, BotConfigArtifact, StoreRef
 
 
@@ -285,7 +288,11 @@ def test_frozen_artifact_bytes_conform_to_schema() -> None:
     # Base ExternalComposeProducer injects engine_ext={} (the teclaw subclass would
     # source a real opaque payload via EngineExtClient — covered in its own suite).
     producer = ExternalComposeProducer(composer=_StubComposer(composed))
-    result = producer.produce_artifact({"bot_id": "bot7", "entity_id": "staff_u1"}, 7)
+    result = producer.produce_artifact(
+        ArtifactBuildRequest.create(
+            bot={"bot_id": "bot7", "entity_id": "staff_u1"}, version=7
+        )
+    )
 
     assert result.success is True
     pinned = result.ext["config_artifact"]
@@ -307,7 +314,11 @@ def test_frozen_artifact_with_opaque_engine_ext_still_conforms() -> None:
             return {"memory_ref": "oss://ws/MEMORY.md", "nested": {"x": [1, 2]}}
 
     producer = _ExtProducer(composer=_StubComposer(composed))
-    result = producer.produce_artifact({"bot_id": "bot7", "entity_id": "staff_u1"}, 1)
+    result = producer.produce_artifact(
+        ArtifactBuildRequest.create(
+            bot={"bot_id": "bot7", "entity_id": "staff_u1"}, version=1
+        )
+    )
 
     pinned = result.ext["config_artifact"]
     jsonschema.validate(instance=pinned, schema=_schema())

--- a/src/backend/tests/community/contracts/test_engine_ext_client.py
+++ b/src/backend/tests/community/contracts/test_engine_ext_client.py
@@ -32,6 +32,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+)
 from agentclaw.community.core.service_bot.services.deploy.teclaw_compose_producer import (
     TeclawComposeProducer,
 )
@@ -72,7 +75,11 @@ def test_consumer_surfaces_empty_engine_ext_from_local_noop() -> None:
     client = LocalEngineExtClient()
     producer = TeclawComposeProducer(_StubComposer(), client)
 
-    result = producer.produce_artifact({"bot_id": "b1", "entity_id": "u1"}, 3)
+    result = producer.produce_artifact(
+        ArtifactBuildRequest.create(
+            bot={"bot_id": "b1", "entity_id": "u1"}, version=3
+        )
+    )
 
     assert result.success is True
     # Engine payload empty (Noop); producer injects identity + draft stage (owner_id
@@ -108,7 +115,11 @@ def test_consumer_carries_mock_engine_ext_verbatim() -> None:
     client.set_response("fetch", opaque)
     producer = TeclawComposeProducer(_StubComposer(), client)
 
-    result = producer.produce_artifact({"bot_id": "b2", "entity_id": "u2"}, 5)
+    result = producer.produce_artifact(
+        ArtifactBuildRequest.create(
+            bot={"bot_id": "b2", "entity_id": "u2"}, version=5
+        )
+    )
 
     pinned = result.ext["config_artifact"]
     # Opaque payload carried byte-for-byte (verbatim, not merged/normalized), with

--- a/src/backend/tests/community/core/bot_management/services/test_teclaw_provision_service.py
+++ b/src/backend/tests/community/core/bot_management/services/test_teclaw_provision_service.py
@@ -110,8 +110,10 @@ def test_provision_produces_creates_approves_and_binds() -> None:
     #    owner_id spliced into the bot row for the producer's compose request.
     router.resolve.assert_called_once_with("teclaw")
     pa = router.resolve.return_value.produce_artifact.call_args
-    assert pa.args[0]["bot_id"] == "b1" and pa.args[0]["owner_id"] == "u1"
-    assert pa.kwargs["version"] is None
+    request = pa.args[0]
+    assert request.bot["bot_id"] == "b1" and request.bot["owner_id"] == "u1"
+    assert request.version is None
+    assert request.layout_observation is None
 
     # 2. created with the produced artifact + teclaw template; token 由创建发布单
     #    轮询任务在容器启动后写入 outbound rule，不混入 create payload。

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_arca_snapshot_producer.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_arca_snapshot_producer.py
@@ -9,6 +9,11 @@ import pytest
 from agentclaw.community.core.service_bot.services.deploy.arca_snapshot_producer import (
     ArcaSnapshotProducer,
 )
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+    ServiceArtifactLayoutObservation,
+    ServiceArtifactResolvedLayout,
+)
 from agentclaw.community.core.service_bot.services.deploy.service_skills_manifest import (
     ResolvedSharedCorpusDelivery,
     ServiceSkillsManifestBuilder,
@@ -24,6 +29,13 @@ from agentclaw.community.core.skills_pool.types import (
     SkillLayoutPhase,
 )
 from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+from agentclaw.community.core.skill_center.runtime_layout_probe_service_protocol import (
+    RuntimeLayoutProbeStatus,
+)
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    MAPPING_CONTRACT_VERSION,
+    MAPPING_V3_CONTRACT_VERSION,
+)
 
 
 _CENTER_STORE_PREFIX = "aidesktop/aidesktop_dev/bolt_shared/skills-center"
@@ -58,6 +70,46 @@ def _resolved_layout(engine: str, pool_center: str) -> dict[str, str]:
     }
 
 
+def _ready_observation(
+    engine: str,
+    pool_center: str | None = None,
+) -> ServiceArtifactLayoutObservation:
+    center = pool_center or {
+        "openclaw": "/home/admin/.openclaw/workspace/skills-pool/skill-center",
+        "claude_code": "/home/admin/.claude_code/workspace/skills-pool/skill-center",
+        "aicoding": "/home/admin/.aicoding/workspace/skills-pool/skill-center",
+        "hermes": "/home/admin/.hermes/workspace/skills-pool/skill-center",
+    }[engine]
+    resolved = _resolved_layout(engine, center)
+    return ServiceArtifactLayoutObservation(
+        status=RuntimeLayoutProbeStatus.READY,
+        engine=engine,
+        layout_contract_version="skills-pool-p3-v1",
+        resolved_layout=ServiceArtifactResolvedLayout(
+            engine=engine,
+            layout_contract_version="skills-pool-p3-v1",
+            active_root=resolved["active_root"],
+            local_root=resolved["local_root"],
+            repo_root=resolved["repo_root"],
+            center_root=resolved["pool_center"],
+        ),
+        supported_mapping_contract_versions=frozenset(
+            {MAPPING_CONTRACT_VERSION, MAPPING_V3_CONTRACT_VERSION}
+        ),
+        center_mount_status="READY",
+        reason=None,
+    )
+
+
+def _request(bot: dict[str, Any], version: int) -> ArtifactBuildRequest:
+    engine = str(bot.get("active_engine") or "openclaw")
+    return ArtifactBuildRequest.create(
+        bot=bot,
+        version=version,
+        layout_observation=_ready_observation(engine),
+    )
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     ("bot", "runtime_engine", "runtime_path"),
@@ -85,24 +137,8 @@ def _resolved_layout(engine: str, pool_center: str) -> dict[str, str]:
 def test_shared_center_delivery_uses_engine_runtime_evidence(
     bot, runtime_engine, runtime_path
 ) -> None:
-    scope = BotSkillLayoutScope(env="dev", entity_id="u1", bot_id="b1")
-    state = BotSkillLayoutState(
-        scope=scope,
-        active_layout=SkillLayout.POOL,
-        target_layout=None,
-        phase=SkillLayoutPhase.POOL_ACTIVE,
-        migration_generation="generation-1",
-        persisted=True,
-        layout_contract_version="skills-pool-p3-v1",
-        last_probe_result="READY",
-        last_probe_evidence={
-            "resolved_layout": _resolved_layout(runtime_engine, runtime_path)
-        },
-    )
-
-    delivery = ResolvedSharedCorpusDelivery.center_from_state(
-        state=state,
-        bot=bot,
+    delivery = ResolvedSharedCorpusDelivery.center_from_observation(
+        observation=_ready_observation(runtime_engine, runtime_path),
         store_prefix=_CENTER_STORE_PREFIX,
     )
 
@@ -112,23 +148,8 @@ def test_shared_center_delivery_uses_engine_runtime_evidence(
 @pytest.mark.unit
 def test_shared_repo_delivery_uses_engine_runtime_evidence() -> None:
     pool_center = "/home/admin/.openclaw/workspace/skills-pool/skill-center"
-    state = BotSkillLayoutState(
-        scope=BotSkillLayoutScope(env="dev", entity_id="u1", bot_id="b1"),
-        active_layout=SkillLayout.POOL,
-        target_layout=None,
-        phase=SkillLayoutPhase.POOL_ACTIVE,
-        migration_generation="generation-1",
-        persisted=True,
-        layout_contract_version="skills-pool-p3-v1",
-        last_probe_result="READY",
-        last_probe_evidence={
-            "resolved_layout": _resolved_layout("openclaw", pool_center)
-        },
-    )
-
-    delivery = ResolvedSharedCorpusDelivery.repo_from_state(
-        state=state,
-        bot={"active_engine": "openclaw"},
+    delivery = ResolvedSharedCorpusDelivery.repo_from_observation(
+        observation=_ready_observation("openclaw", pool_center),
         store_prefix=_REPO_STORE_PREFIX,
     )
 
@@ -138,43 +159,18 @@ def test_shared_repo_delivery_uses_engine_runtime_evidence() -> None:
 
 
 @pytest.mark.unit
-def test_shared_center_delivery_rejects_missing_or_mismatched_evidence() -> None:
-    scope = BotSkillLayoutScope(env="dev", entity_id="u1", bot_id="b1")
-    state = BotSkillLayoutState(
-        scope=scope,
-        active_layout=SkillLayout.POOL,
-        target_layout=None,
-        phase=SkillLayoutPhase.POOL_ACTIVE,
-        migration_generation="generation-1",
-        persisted=True,
-        layout_contract_version="skills-pool-p3-v1",
-        last_probe_result="READY",
-        last_probe_evidence={
-            "resolved_layout": {
-                "engine": "openclaw",
-                "layout_contract_version": "skills-pool-p3-v1",
-            }
-        },
-    )
-
-    with pytest.raises(ServiceSkillsManifestError, match="matching READY"):
-        ResolvedSharedCorpusDelivery.center_from_state(
-            state=state,
-            bot={"active_engine": "openclaw"},
-            store_prefix=_CENTER_STORE_PREFIX,
-        )
-    with pytest.raises(ServiceSkillsManifestError, match="matching READY"):
-        ResolvedSharedCorpusDelivery.center_from_state(
-            state=replace(
-                state,
-                last_probe_evidence={
-                    "resolved_layout": _resolved_layout(
-                        "hermes",
-                        "/home/admin/.hermes/workspace/skills-pool/skill-center",
-                    )
-                },
+def test_shared_center_delivery_rejects_missing_evidence() -> None:
+    with pytest.raises(ServiceSkillsManifestError, match="missing its runtime path"):
+        ResolvedSharedCorpusDelivery.center_from_observation(
+            observation=ServiceArtifactLayoutObservation(
+                status=RuntimeLayoutProbeStatus.INVALID,
+                engine="openclaw",
+                layout_contract_version="skills-pool-p3-v1",
+                resolved_layout=None,
+                supported_mapping_contract_versions=frozenset(),
+                center_mount_status=None,
+                reason="invalid",
             ),
-            bot={"active_engine": "openclaw"},
             store_prefix=_CENTER_STORE_PREFIX,
         )
 
@@ -208,7 +204,7 @@ class _NoSkillsManifestBuilder(ServiceSkillsManifestBuilder):
     def __init__(self) -> None:
         pass
 
-    def capture(self, *, bot: dict[str, Any]) -> None:
+    def capture(self, *, bot: dict[str, Any], layout_observation) -> None:
         return None
 
 
@@ -216,7 +212,9 @@ class _NoSkillsManifestBuilder(ServiceSkillsManifestBuilder):
 def test_passes_bot_and_version_through_to_build() -> None:
     stub = _RecordingBuild({"success": True})
     bot = {"bot_id": "b1", "entity_id": "u1"}
-    ArcaSnapshotProducer(stub, _NoSkillsManifestBuilder()).produce_artifact(bot, 7)
+    ArcaSnapshotProducer(stub, _NoSkillsManifestBuilder()).produce_artifact(
+        _request(bot, 7)
+    )
     assert stub.calls == [(bot, 7)]
 
 
@@ -234,7 +232,7 @@ def test_maps_success_and_both_paths_onto_ext() -> None:
     )
     artifact = ArcaSnapshotProducer(
         stub, _NoSkillsManifestBuilder()
-    ).produce_artifact({}, 3)
+    ).produce_artifact(_request({}, 3))
     assert artifact.success is True
     assert artifact.message == ""
     assert artifact.ext == {
@@ -248,7 +246,7 @@ def test_failed_build_propagates_success_false_and_message() -> None:
     stub = _RecordingBuild({"success": False})
     artifact = ArcaSnapshotProducer(
         stub, _NoSkillsManifestBuilder()
-    ).produce_artifact({}, 1)
+    ).produce_artifact(_request({}, 1))
     assert artifact.success is False
     assert artifact.message == "构建失败"
     assert artifact.ext == {}
@@ -261,7 +259,7 @@ def test_missing_paths_are_omitted_from_ext() -> None:
     stub = _RecordingBuild({"success": True, "migration_path": "/only/mig"})
     artifact = ArcaSnapshotProducer(
         stub, _NoSkillsManifestBuilder()
-    ).produce_artifact({}, 1)
+    ).produce_artifact(_request({}, 1))
     assert artifact.ext == {"migration_path": "/only/mig"}
 
 
@@ -313,13 +311,12 @@ def test_pool_build_freezes_the_draft_layout_into_one_versioned_artifact(
             _REPO_STORE_PREFIX,
         ),
     ).produce_artifact(
-        {
+        _request({
             "bot_id": "b1",
             "entity_id": "u1",
             "env": "dev",
             "active_engine": "openclaw",
-        },
-        7,
+        }, 7),
     )
 
     assert artifact.ext["skills_manifest"] == {
@@ -427,13 +424,12 @@ def test_pool_artifact_rejects_undeclared_center_link(tmp_path) -> None:
         match="Center links do not match the frozen exact manifest",
     ):
         producer.produce_artifact(
-            {
+            _request({
                 "bot_id": "b1",
                 "entity_id": "u1",
                 "env": "dev",
                 "active_engine": "openclaw",
-            },
-            7,
+            }, 7),
         )
 
 
@@ -499,13 +495,12 @@ def test_center_link_outside_active_root_cannot_satisfy_manifest(tmp_path) -> No
         match="Center links do not match the frozen exact manifest",
     ):
         producer.produce_artifact(
-            {
+            _request({
                 "bot_id": "b1",
                 "entity_id": "u1",
                 "env": "dev",
                 "active_engine": "openclaw",
-            },
-            7,
+            }, 7),
         )
 
 
@@ -588,14 +583,13 @@ def test_service_manifest_v1_adds_sorted_exact_center_skills(tmp_path) -> None:
     )
 
     artifact = producer.produce_artifact(
-        {
+        _request({
             "bot_id": "b1",
             "owner_id": "u1",
             "entity_id": "u1",
             "env": "dev",
             "active_engine": "openclaw",
-        },
-        7,
+        }, 7),
     )
 
     assert artifact.ext["skills_manifest"]["schema_version"] == 1
@@ -637,19 +631,18 @@ def test_service_manifest_v1_adds_sorted_exact_center_skills(tmp_path) -> None:
         "1.0.0",
         "2.0.0",
     ]
-    assert reader.calls == [
-        {
+    expected_reader_call = {
+        "bot_id": "b1",
+        "owner_id": "u1",
+        "bot": {
             "bot_id": "b1",
             "owner_id": "u1",
-            "bot": {
-                "bot_id": "b1",
-                "owner_id": "u1",
-                "entity_id": "u1",
-                "env": "dev",
-                "active_engine": "openclaw",
-            },
-        }
-    ]
+            "entity_id": "u1",
+            "env": "dev",
+            "active_engine": "openclaw",
+        },
+    }
+    assert reader.calls == [expected_reader_call, expected_reader_call]
 
 
 @pytest.mark.unit
@@ -696,7 +689,8 @@ def test_center_service_build_fails_when_exact_store_version_is_missing() -> Non
                 "entity_id": "u1",
                 "env": "dev",
                 "active_engine": "openclaw",
-            }
+            },
+            layout_observation=_ready_observation("openclaw"),
         )
 
 
@@ -758,13 +752,12 @@ def test_layout_is_captured_before_physical_build_starts(tmp_path) -> None:
         match="draft Skills layout changed during service build",
     ):
         producer.produce_artifact(
-            {
+            _request({
                 "bot_id": "b1",
                 "entity_id": "u1",
                 "env": "dev",
                 "active_engine": "openclaw",
-            },
-            8,
+            }, 8),
         )
 
 
@@ -812,13 +805,12 @@ def test_build_rejects_non_terminal_layout_before_physical_snapshot(
         match="terminal Skills layout state",
     ):
         producer.produce_artifact(
-            {
+            _request({
                 "bot_id": "b1",
                 "entity_id": "u1",
                 "env": "dev",
                 "active_engine": "openclaw",
-            },
-            8,
+            }, 8),
         )
 
     assert build.calls == []
@@ -893,13 +885,12 @@ def test_build_rejects_phase_or_generation_drift_after_physical_snapshot(
         match="draft Skills layout changed during service build",
     ):
         producer.produce_artifact(
-            {
+            _request({
                 "bot_id": "b1",
                 "entity_id": "u1",
                 "env": "dev",
                 "active_engine": "openclaw",
-            },
-            8,
+            }, 8),
         )
 
 
@@ -959,13 +950,12 @@ def test_legacy_build_rejects_contract_drift_after_physical_snapshot(
         match="draft Skills layout changed during service build",
     ):
         producer.produce_artifact(
-            {
+            _request({
                 "bot_id": "b1",
                 "entity_id": "u1",
                 "env": "dev",
                 "active_engine": "openclaw",
-            },
-            8,
+            }, 8),
         )
 
 
@@ -1046,13 +1036,12 @@ def test_legacy_draft_builds_a_legacy_artifact_without_pool_contract(
     )
 
     artifact = producer.produce_artifact(
-        {
+        _request({
             "bot_id": "legacy-bot",
             "entity_id": "u1",
             "env": "dev",
             "active_engine": "openclaw",
-        },
-        1,
+        }, 1),
     )
 
     frozen = artifact.ext["skills_manifest"]
@@ -1098,13 +1087,12 @@ def test_aicoding_service_engine_uses_the_shared_manifest_contract() -> None:
     )
 
     artifact = producer.produce_artifact(
-        {
+        _request({
             "bot_id": "b1",
             "entity_id": "u1",
             "env": "dev",
             "active_engine": "aicoding",
-        },
-        1,
+        }, 1),
     )
 
     assert artifact.ext["skills_manifest"]["engine"] == "aicoding"
@@ -1151,13 +1139,12 @@ def test_hermes_pool_service_manifest_uses_the_shared_contract() -> None:
     )
 
     artifact = producer.produce_artifact(
-        {
+        _request({
             "bot_id": "b1",
             "entity_id": "u1",
             "env": "dev",
             "active_engine": "hermes",
-        },
-        1,
+        }, 1),
     )
 
     assert artifact.ext["skills_manifest"] == {
@@ -1188,7 +1175,7 @@ def test_hermes_pool_service_manifest_uses_the_shared_contract() -> None:
 
 
 @pytest.mark.unit
-def test_hermes_legacy_publish_fails_without_ready_engine_evidence() -> None:
+def test_hermes_legacy_publish_without_center_uses_historical_build_plan() -> None:
     scope = BotSkillLayoutScope(env="dev", entity_id="u1", bot_id="b1")
     build = _RecordingBuild(
         {
@@ -1208,15 +1195,15 @@ def test_hermes_legacy_publish_fails_without_ready_engine_evidence() -> None:
         ),
     )
 
-    with pytest.raises(ServiceSkillsManifestError, match="READY Pool runtime"):
-        producer.produce_artifact(
-            {
+    artifact = producer.produce_artifact(
+        _request({
                 "bot_id": "b1",
                 "entity_id": "u1",
                 "env": "dev",
                 "active_engine": "hermes",
-            },
-            1,
-        )
+            }, 1),
+    )
 
-    assert build.calls == []
+    assert artifact.success is True
+    assert artifact.ext["skills_manifest"]["active_layout"] == "legacy"
+    assert build.calls

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_artifact_build_request.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_artifact_build_request.py
@@ -1,0 +1,129 @@
+"""Fresh runtime-layout observation normalization for Service Artifact builds."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+    ServiceArtifactLayoutObservation,
+)
+from agentclaw.community.core.skill_center.runtime_layout_probe_service_protocol import (
+    RuntimeLayoutProbeResult,
+    RuntimeLayoutProbeStatus,
+)
+
+
+def _probe(*, resolved_layout=None, **evidence) -> RuntimeLayoutProbeResult:
+    return RuntimeLayoutProbeResult(
+        status=RuntimeLayoutProbeStatus.READY,
+        engine="openclaw",
+        layout_contract_version="skills-pool-p3-v1",
+        preparation_id="preparation-1",
+        evidence={"resolved_layout": resolved_layout, **evidence},
+    )
+
+
+def _resolved_layout() -> dict[str, str]:
+    return {
+        "engine": "openclaw",
+        "layout_contract_version": "skills-pool-p3-v1",
+        "active_root": "/home/admin/.openclaw/workspace/skills",
+        "local_root": ("/home/admin/.openclaw/workspace/skills-pool/skills-local"),
+        "repo_root": "/home/admin/.openclaw/workspace/skills-pool/skills-repo",
+        "pool_center": ("/home/admin/.openclaw/workspace/skills-pool/skill-center"),
+    }
+
+
+@pytest.mark.unit
+def test_ready_probe_becomes_typed_observation_without_transport_extras() -> None:
+    observation = ServiceArtifactLayoutObservation.from_probe(
+        _probe(
+            resolved_layout=_resolved_layout(),
+            supported_mapping_contract_versions=[
+                "skills-pool-mapping-v2",
+                "skills-pool-mapping-v3",
+            ],
+            center_mount={
+                "status": "NOT_READY",
+                "reason": "mount_pending",
+                "restart_required": True,
+            },
+            checks={"sensitive_transport_detail": True},
+        ),
+        expected_engine="openclaw",
+    )
+
+    assert observation.status is RuntimeLayoutProbeStatus.READY
+    assert observation.resolved_layout is not None
+    assert observation.resolved_layout.center_root.endswith("/skill-center")
+    assert observation.center_mount_status == "NOT_READY"
+    assert observation.supported_mapping_contract_versions == frozenset(
+        {"skills-pool-mapping-v2", "skills-pool-mapping-v3"}
+    )
+    assert not hasattr(observation, "checks")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"repo_root": "relative/skills-repo"},
+        {"repo_root": "//home/admin/workspace/skills-pool/skills-repo"},
+        {"pool_center": "/home/admin/.openclaw/workspace/other"},
+        {
+            "active_root": (
+                "/home/admin/.openclaw/workspace/skills-pool/skill-center/active"
+            )
+        },
+    ],
+)
+def test_noncanonical_ready_paths_become_invalid(mutation) -> None:
+    resolved = {**_resolved_layout(), **mutation}
+
+    observation = ServiceArtifactLayoutObservation.from_probe(
+        _probe(
+            resolved_layout=resolved,
+            supported_mapping_contract_versions=["skills-pool-mapping-v3"],
+        ),
+        expected_engine="openclaw",
+    )
+
+    assert observation.status is RuntimeLayoutProbeStatus.INVALID
+    assert observation.resolved_layout is None
+    assert observation.reason == "invalid_runtime_layout_probe_evidence"
+
+
+@pytest.mark.unit
+def test_nonready_probe_preserves_safe_status_and_reason() -> None:
+    probe = RuntimeLayoutProbeResult(
+        status=RuntimeLayoutProbeStatus.TRANSIENT_ERROR,
+        engine="openclaw",
+        layout_contract_version="skills-pool-p3-v1",
+        preparation_id=None,
+        evidence={
+            "reason": "runtime_probe_failed",
+            "error": "private endpoint detail",
+        },
+    )
+
+    observation = ServiceArtifactLayoutObservation.from_probe(
+        probe, expected_engine="openclaw"
+    )
+
+    assert observation.status is RuntimeLayoutProbeStatus.TRANSIENT_ERROR
+    assert observation.reason == "runtime_probe_failed"
+    assert observation.resolved_layout is None
+    assert not hasattr(observation, "error")
+
+
+@pytest.mark.unit
+def test_build_request_copies_bot_mapping() -> None:
+    bot = {"bot_id": "b1"}
+    request = ArtifactBuildRequest.create(bot=bot, version=2)
+
+    bot["bot_id"] = "mutated"
+
+    assert request.bot["bot_id"] == "b1"
+    with pytest.raises(TypeError):
+        request.bot["bot_id"] = "forbidden"  # type: ignore[index]

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_external_compose_producer.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_external_compose_producer.py
@@ -11,6 +11,9 @@ from typing import Any
 import pytest
 
 from agentclaw.community.core.config_compose.models import ComposeRequest
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+)
 from agentclaw.community.core.service_bot.services.deploy.external_compose_producer import (
     ExternalComposeProducer,
 )
@@ -84,14 +87,16 @@ def test_compose_request_maps_bot_row_fields() -> None:
     producer = ExternalComposeProducer(composer=composer)
 
     producer.produce_artifact(
-        {
-            "bot_id": "bot7",
-            "entity_id": "staff_u1",
-            "entity_type": "staff",
-            "owner_id": "u1",
-            "active_engine": "teclaw",
-        },
-        9,
+        ArtifactBuildRequest.create(
+            bot={
+                "bot_id": "bot7",
+                "entity_id": "staff_u1",
+                "entity_type": "staff",
+                "owner_id": "u1",
+                "active_engine": "teclaw",
+            },
+            version=9,
+        )
     )
 
     req = composer.calls[0]
@@ -121,7 +126,10 @@ def test_produce_artifact_pins_refs_only_artifact() -> None:
     )
 
     result = producer.produce_artifact(
-        {"bot_id": "b", "entity_id": "u", "owner_id": "u1"}, 4
+        ArtifactBuildRequest.create(
+            bot={"bot_id": "b", "entity_id": "u", "owner_id": "u1"},
+            version=4,
+        )
     )
 
     assert result.success is True

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_notify_equivalence.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_notify_equivalence.py
@@ -20,10 +20,9 @@ elsewhere and intentionally not duplicated here:
 """
 from __future__ import annotations
 
-from typing import Any
-
-import pytest
-
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+)
 from agentclaw.community.core.service_bot.services.deploy.producer import (
     DeployArtifact,
     DeployArtifactProducer,
@@ -35,7 +34,7 @@ class _StubProducer(DeployArtifactProducer):
     def __init__(self, tag: str) -> None:
         self.tag = tag
 
-    def produce_artifact(self, bot: dict[str, Any], version: int) -> DeployArtifact:
+    def produce_artifact(self, request: ArtifactBuildRequest) -> DeployArtifact:
         return DeployArtifact(success=True, ext={"by": self.tag})
 
 

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_producer_router.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_producer_router.py
@@ -1,7 +1,6 @@
 """Unit tests for the DeployArtifactProducer selector (provider-keyed dispatch)."""
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -11,13 +10,16 @@ from agentclaw.community.core.service_bot.services.deploy.producer import (
     DeployArtifactProducer,
     DeployArtifactProducerRouter,
 )
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+)
 
 
 class _StubProducer(DeployArtifactProducer):
     def __init__(self, tag: str) -> None:
         self.tag = tag
 
-    def produce_artifact(self, bot: dict[str, Any], version: int) -> DeployArtifact:
+    def produce_artifact(self, request: ArtifactBuildRequest) -> DeployArtifact:
         return DeployArtifact(success=True, ext={"by": self.tag})
 
 
@@ -75,7 +77,9 @@ def test_arca_snapshot_producer_delegates_to_build() -> None:
     skills_builder.capture.return_value = None
     artifact = ArcaSnapshotProducer(
         _StubBuild(), skills_builder
-    ).produce_artifact({"bot_id": "b"}, 3)
+    ).produce_artifact(
+        ArtifactBuildRequest.create(bot={"bot_id": "b"}, version=3)
+    )
     assert artifact.success is True
     assert artifact.ext == {
         "migration_path": "/home/admin/nfs/bot-data/3/mig",

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_service_artifact_fresh_layout.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_service_artifact_fresh_layout.py
@@ -1,0 +1,287 @@
+"""Fresh layout evidence and Legacy/Pool Center manifest contracts."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ServiceArtifactBuildErrorCode,
+    ServiceArtifactLayoutObservation,
+    ServiceArtifactResolvedLayout,
+)
+from agentclaw.community.core.service_bot.services.deploy.service_skills_manifest import (
+    ServiceSkillsManifestBuilder,
+    ServiceSkillsManifestError,
+    validate_service_skills_manifest_for_release,
+)
+from agentclaw.community.core.skill_center.runtime_layout_probe_service_protocol import (
+    RuntimeLayoutProbeStatus,
+)
+from agentclaw.community.core.skill_center.services.runtime_layout_probe import (
+    MAPPING_CONTRACT_VERSION,
+    MAPPING_V3_CONTRACT_VERSION,
+)
+from agentclaw.community.core.skills_pool.models import RegisteredSkillAsset
+from agentclaw.community.core.skills_pool.types import (
+    BotSkillLayoutScope,
+    BotSkillLayoutState,
+    SkillLayout,
+    SkillLayoutPhase,
+)
+
+
+_CENTER_PREFIX = "aidesktop/aidesktop_dev/bolt_shared/skills-center"
+_REPO_PREFIX = "skills-repo/b1"
+_CENTER_ROOT = "/home/admin/.openclaw/workspace/skills-pool/skill-center"
+
+
+class _LayoutRepository:
+    def __init__(self, state: BotSkillLayoutState) -> None:
+        self.state = state
+
+    def get(self, scope: BotSkillLayoutScope) -> BotSkillLayoutState:
+        return self.state
+
+
+class _Reader:
+    def __init__(self, *snapshots) -> None:
+        self._snapshots = iter(snapshots or ((), ()))
+
+    def active_skill_assets(self, **_kwargs):
+        return tuple(next(self._snapshots))
+
+
+class _Store:
+    def __init__(self, ready: bool = True) -> None:
+        self.ready = ready
+
+    def verify_version(self, _ref) -> bool:
+        return self.ready
+
+
+def _legacy_state(bot_id: str = "b1") -> BotSkillLayoutState:
+    return BotSkillLayoutState.legacy_default(
+        BotSkillLayoutScope(env="dev", entity_id="u1", bot_id=bot_id)
+    )
+
+
+def _pool_state() -> BotSkillLayoutState:
+    return BotSkillLayoutState(
+        scope=BotSkillLayoutScope(env="dev", entity_id="u1", bot_id="b1"),
+        active_layout=SkillLayout.POOL,
+        target_layout=None,
+        phase=SkillLayoutPhase.POOL_ACTIVE,
+        migration_generation="generation-1",
+        persisted=True,
+        layout_contract_version="skills-pool-p3-v1",
+        # Deliberately unusable: Service Artifact must consume the fresh
+        # observation, not this persisted migration/recovery evidence.
+        last_probe_result="INVALID",
+        last_probe_evidence={"reason": "stale"},
+    )
+
+
+def _observation(
+    *,
+    status: RuntimeLayoutProbeStatus = RuntimeLayoutProbeStatus.READY,
+    mappings: frozenset[str] | None = None,
+    center_mount_status: str = "READY",
+) -> ServiceArtifactLayoutObservation:
+    resolved = None
+    if status is RuntimeLayoutProbeStatus.READY:
+        resolved = ServiceArtifactResolvedLayout(
+            engine="openclaw",
+            layout_contract_version="skills-pool-p3-v1",
+            active_root="/home/admin/.openclaw/workspace/skills",
+            local_root=(
+                "/home/admin/.openclaw/workspace/skills-pool/skills-local"
+            ),
+            repo_root="/home/admin/.openclaw/workspace/skills-pool/skills-repo",
+            center_root=_CENTER_ROOT,
+        )
+    return ServiceArtifactLayoutObservation(
+        status=status,
+        engine="openclaw",
+        layout_contract_version="skills-pool-p3-v1",
+        resolved_layout=resolved,
+        supported_mapping_contract_versions=(
+            mappings
+            if mappings is not None
+            else frozenset(
+                {MAPPING_CONTRACT_VERSION, MAPPING_V3_CONTRACT_VERSION}
+            )
+        ),
+        center_mount_status=center_mount_status,
+        reason=None if resolved is not None else "runtime_probe_failed",
+    )
+
+
+def _center_asset(
+    *,
+    name: str = "pdf",
+    skill_uuid: str = "00000000-0000-4000-8000-000000000001",
+    version: str = "1.0.0",
+) -> RegisteredSkillAsset:
+    return RegisteredSkillAsset(
+        skill_id=1,
+        name=name,
+        git_path=f"center://{name}",
+        skill_uuid=skill_uuid,
+        sc_version_number=version,
+    )
+
+
+def _builder(state, reader, store=None) -> ServiceSkillsManifestBuilder:
+    return ServiceSkillsManifestBuilder(
+        _LayoutRepository(state),
+        reader,
+        _CENTER_PREFIX,
+        store or _Store(),
+        _REPO_PREFIX,
+    )
+
+
+def _bot() -> dict[str, str]:
+    return {
+        "bot_id": "b1",
+        "owner_id": "u1",
+        "entity_id": "u1",
+        "env": "dev",
+        "active_engine": "openclaw",
+    }
+
+
+@pytest.mark.unit
+def test_legacy_center_uses_fresh_v3_evidence_and_center_delivery_only() -> None:
+    asset = _center_asset()
+    builder = _builder(_legacy_state(), _Reader((asset,), (asset,)))
+
+    captured = builder.capture(
+        bot=_bot(),
+        layout_observation=_observation(center_mount_status="NOT_READY"),
+    )
+    manifest = builder.finalize(captured=captured, bot=_bot())
+
+    assert captured.active_runtime_path.endswith("/workspace/skills")
+    assert [item.corpus for item in captured.shared_corpora] == ["center"]
+    assert manifest["active_layout"] == "legacy"
+    assert manifest["layout_contract_version"] is None
+    assert [item["corpus"] for item in manifest["shared_corpora"]] == ["center"]
+    assert manifest["center_skills"][0]["sc_version_number"] == "1.0.0"
+
+
+@pytest.mark.unit
+def test_pool_ignores_stale_persisted_probe_and_freezes_repo_then_center() -> None:
+    builder = _builder(_pool_state(), _Reader((), ()))
+
+    captured = builder.capture(bot=_bot(), layout_observation=_observation())
+    manifest = builder.finalize(captured=captured, bot=_bot())
+
+    assert [item.corpus for item in captured.shared_corpora] == ["repo", "center"]
+    assert [item["corpus"] for item in manifest["shared_corpora"]] == [
+        "repo",
+        "center",
+    ]
+
+
+@pytest.mark.unit
+def test_center_requires_mapping_v3() -> None:
+    asset = _center_asset()
+    builder = _builder(_legacy_state(), _Reader((asset,)))
+
+    with pytest.raises(ServiceSkillsManifestError) as raised:
+        builder.capture(
+            bot=_bot(),
+            layout_observation=_observation(
+                mappings=frozenset({MAPPING_CONTRACT_VERSION})
+            ),
+        )
+
+    assert raised.value.code is (
+        ServiceArtifactBuildErrorCode.LAYOUT_EVIDENCE_UNAVAILABLE
+    )
+
+
+@pytest.mark.unit
+def test_pool_requires_ready_observation_but_legacy_without_center_does_not() -> None:
+    unavailable = _observation(status=RuntimeLayoutProbeStatus.TRANSIENT_ERROR)
+
+    with pytest.raises(ServiceSkillsManifestError) as raised:
+        _builder(_pool_state(), _Reader(())).capture(
+            bot=_bot(), layout_observation=unavailable
+        )
+    assert raised.value.code is (
+        ServiceArtifactBuildErrorCode.LAYOUT_EVIDENCE_UNAVAILABLE
+    )
+
+    captured = _builder(_legacy_state(), _Reader(())).capture(
+        bot=_bot(), layout_observation=unavailable
+    )
+    assert captured.shared_corpora == ()
+    assert captured.active_runtime_path is None
+
+
+@pytest.mark.unit
+def test_center_capability_drift_fails_finalize() -> None:
+    first = _center_asset()
+    second = _center_asset(
+        name="writer",
+        skill_uuid="00000000-0000-4000-8000-000000000002",
+        version="2.0.0",
+    )
+    builder = _builder(_legacy_state(), _Reader((first,), (second,)))
+    captured = builder.capture(bot=_bot(), layout_observation=_observation())
+
+    with pytest.raises(ServiceSkillsManifestError) as raised:
+        builder.finalize(captured=captured, bot=_bot())
+
+    assert raised.value.code is ServiceArtifactBuildErrorCode.CAPABILITY_CHANGED
+
+
+@pytest.mark.unit
+def test_legacy_manifest_requires_center_delivery_iff_center_skills_exist() -> None:
+    valid = {
+        "schema_version": 1,
+        "engine": "openclaw",
+        "active_layout": "legacy",
+        "layout_contract_version": None,
+        "center_skills": [
+            {
+                "runtime_name": "pdf",
+                "skill_uuid": "00000000-0000-4000-8000-000000000001",
+                "sc_version_number": "1.0.0",
+                "mcp_dependencies": [],
+            }
+        ],
+        "shared_corpora": [
+            {
+                "corpus": "center",
+                "runtime_path": _CENTER_ROOT,
+                "store_prefix": _CENTER_PREFIX,
+                "layout_contract_version": "skills-pool-p3-v1",
+                "permission": "read_only",
+                "snapshot_policy": "exclude",
+            }
+        ],
+    }
+    validate_service_skills_manifest_for_release(valid, _bot())
+
+    for invalid in (
+        {**valid, "shared_corpora": None},
+        {**valid, "center_skills": None},
+        {
+            **valid,
+            "shared_corpora": [
+                {
+                    **valid["shared_corpora"][0],
+                    "corpus": "repo",
+                    "runtime_path": (
+                        "/home/admin/.openclaw/workspace/skills-pool/skills-repo"
+                    ),
+                    "store_prefix": _REPO_PREFIX,
+                }
+            ],
+        },
+    ):
+        with pytest.raises(ServiceSkillsManifestError):
+            validate_service_skills_manifest_for_release(invalid, _bot())

--- a/src/backend/tests/community/core/service_bot/services/deploy/test_teclaw_compose_producer.py
+++ b/src/backend/tests/community/core/service_bot/services/deploy/test_teclaw_compose_producer.py
@@ -5,6 +5,9 @@ from typing import Any
 
 import pytest
 
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+)
 from agentclaw.community.core.service_bot.services.deploy.teclaw_compose_producer import (
     TeclawComposeProducer,
 )
@@ -42,7 +45,15 @@ def test_engine_ext_fetched_via_plugin_and_frozen_verbatim() -> None:
     producer = TeclawComposeProducer(_StubComposer(_artifact()), client)
 
     result = producer.produce_artifact(
-        {"bot_id": "b", "entity_id": "u", "owner_id": "u1", "bot_name": "Support Bot"}, 3
+        ArtifactBuildRequest.create(
+            bot={
+                "bot_id": "b",
+                "entity_id": "u",
+                "owner_id": "u1",
+                "bot_name": "Support Bot",
+            },
+            version=3,
+        )
     )
 
     # plugin consulted with the bot dict
@@ -66,7 +77,9 @@ def test_empty_engine_ext_from_noop_client() -> None:
     producer = TeclawComposeProducer(
         _StubComposer(_artifact()), _MockEngineExtClient({})
     )
-    result = producer.produce_artifact({"bot_id": "b"}, 1)
+    result = producer.produce_artifact(
+        ArtifactBuildRequest.create(bot={"bot_id": "b"}, version=1)
+    )
     # Empty engine payload → only the backend identity/stage keys remain.
     assert result.ext["config_artifact"]["engine_ext"] == {
         "bot_id": "b",

--- a/src/backend/tests/community/core/service_bot/services/publish_flow/test_build_stage_layout_probe.py
+++ b/src/backend/tests/community/core/service_bot/services/publish_flow/test_build_stage_layout_probe.py
@@ -1,0 +1,208 @@
+"""BuildStage ownership of fresh filesystem layout observations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from agentclaw.community.core.service_bot.repository.models import (
+    BotPublishRecord,
+    PublishStatus,
+)
+from agentclaw.community.core.service_bot.services.deploy.artifact_build_request import (
+    ArtifactBuildRequest,
+    ServiceArtifactBuildError,
+    ServiceArtifactBuildErrorCode,
+)
+from agentclaw.community.core.service_bot.services.deploy.producer import (
+    DeployArtifact,
+    DeployArtifactProducer,
+)
+from agentclaw.community.core.service_bot.services.publish_flow.build_stage import (
+    BuildStageRunner,
+)
+from agentclaw.community.core.skill_center.runtime_layout_probe_service_protocol import (
+    RuntimeLayoutProbeResult,
+    RuntimeLayoutProbeStatus,
+)
+from agentclaw.community.core.skill_center.runtime_projection_contract import (
+    ProjectionScope,
+)
+
+
+class _Producer(DeployArtifactProducer):
+    def __init__(self, *, filesystem: bool) -> None:
+        self.requires_runtime_layout_observation = filesystem
+        self.requests: list[ArtifactBuildRequest] = []
+
+    def produce_artifact(self, request: ArtifactBuildRequest) -> DeployArtifact:
+        self.requests.append(request)
+        return DeployArtifact(success=True, ext={"migration_path": "/snapshot/1"})
+
+
+class _FailingProducer(DeployArtifactProducer):
+    def produce_artifact(self, request: ArtifactBuildRequest) -> DeployArtifact:
+        raise ServiceArtifactBuildError(
+            ServiceArtifactBuildErrorCode.LAYOUT_EVIDENCE_UNAVAILABLE,
+            "service build runtime layout evidence is unavailable",
+        )
+
+
+def _record() -> BotPublishRecord:
+    now = datetime.now()
+    return BotPublishRecord(
+        id=1,
+        source_bot_pk=11,
+        source_bot_id="b1",
+        publish_bot_id="published-b1",
+        name="demo",
+        owner_id="u1",
+        permission_owner="u1",
+        version=1,
+        env="dev",
+        status=PublishStatus.BUILDING.value,
+        ext={},
+        gmt_create=now,
+        gmt_modified=now,
+    )
+
+
+def _probe_result() -> RuntimeLayoutProbeResult:
+    return RuntimeLayoutProbeResult(
+        status=RuntimeLayoutProbeStatus.READY,
+        engine="openclaw",
+        layout_contract_version="skills-pool-p3-v1",
+        preparation_id="preparation-1",
+        evidence={
+            "resolved_layout": {
+                "engine": "openclaw",
+                "layout_contract_version": "skills-pool-p3-v1",
+                "active_root": "/home/admin/.openclaw/workspace/skills",
+                "local_root": (
+                    "/home/admin/.openclaw/workspace/skills-pool/skills-local"
+                ),
+                "repo_root": (
+                    "/home/admin/.openclaw/workspace/skills-pool/skills-repo"
+                ),
+                "pool_center": (
+                    "/home/admin/.openclaw/workspace/skills-pool/skill-center"
+                ),
+            },
+            "supported_mapping_contract_versions": [
+                "skills-pool-mapping-v2",
+                "skills-pool-mapping-v3",
+            ],
+            "center_mount": {
+                "status": "READY",
+                "reason": None,
+                "restart_required": False,
+            },
+        },
+    )
+
+
+def _runner(producer, *, ext=None):
+    ext_state = Mock()
+    ext_state.owner_id.return_value = "u1"
+    ext_state.get_latest_ext_snapshot.return_value = (
+        dict(ext or {}),
+        dict(ext or {}),
+    )
+    bot_service = Mock()
+    bot_service.get_bot.return_value = {
+        "bot_id": "b1",
+        "owner_id": "u1",
+        "entity_id": "u1",
+        "active_engine": "openclaw",
+        "env": "dev",
+    }
+    baas_service = Mock()
+    baas_service.resolve_container_provider.return_value = "baas"
+    producer_router = Mock()
+    producer_router.resolve.return_value = producer
+    behavior = Mock()
+    behavior.stage_build_files = AsyncMock()
+    behaviors = Mock()
+    behaviors.resolve.return_value = behavior
+    projector = Mock()
+    projector.project = AsyncMock()
+    probe = Mock()
+    probe.probe_bot = AsyncMock(return_value=_probe_result())
+    runner = BuildStageRunner(
+        ext_state=ext_state,
+        bot_service=bot_service,
+        baas_service=baas_service,
+        producer_router=producer_router,
+        provider_behaviors=behaviors,
+        runtime_projector=projector,
+        runtime_layout_probe=probe,
+    )
+    return runner, ext_state, projector, probe
+
+
+@pytest.mark.asyncio
+async def test_filesystem_producer_receives_one_fresh_observation() -> None:
+    producer = _Producer(filesystem=True)
+    runner, ext_state, projector, probe = _runner(producer)
+
+    result = await runner.build(_record(), "operator")
+
+    assert result.status == PublishStatus.BUILT
+    projector.project.assert_awaited_once_with(
+        bot_id="b1", owner_id="u1", scope=ProjectionScope.everything()
+    )
+    probe.probe_bot.assert_awaited_once_with(
+        bot_id="b1", user_id="u1", engine="openclaw"
+    )
+    observation = producer.requests[0].layout_observation
+    assert observation is not None
+    assert observation.status is RuntimeLayoutProbeStatus.READY
+    ext_state.commit_built_artifact.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_config_artifact_producer_does_not_probe_filesystem() -> None:
+    producer = _Producer(filesystem=False)
+    runner, _ext_state, _projector, probe = _runner(producer)
+
+    result = await runner.build(_record(), "operator")
+
+    assert result.status == PublishStatus.BUILT
+    probe.probe_bot.assert_not_awaited()
+    assert producer.requests[0].layout_observation is None
+
+
+@pytest.mark.asyncio
+async def test_classified_failure_is_persisted_for_internal_diagnosis() -> None:
+    runner, ext_state, _projector, _probe = _runner(_FailingProducer())
+
+    result = await runner.build(_record(), "operator")
+
+    assert result.status == PublishStatus.FAILED
+    failed_ext = ext_state.update_status.call_args.kwargs["ext"]
+    assert failed_ext["error_code"] == (
+        "SERVICE_ARTIFACT_LAYOUT_EVIDENCE_UNAVAILABLE"
+    )
+    assert failed_ext["source_status"] == PublishStatus.BUILDING.value
+
+
+@pytest.mark.asyncio
+async def test_successful_retry_clears_stale_build_error_fields() -> None:
+    producer = _Producer(filesystem=False)
+    runner, ext_state, _projector, _probe = _runner(
+        producer,
+        ext={
+            "error_code": "SERVICE_ARTIFACT_SNAPSHOT_INVALID",
+            "error_message": "old failure",
+            "source_status": PublishStatus.BUILDING.value,
+            "keep": "value",
+        },
+    )
+
+    result = await runner.build(_record(), "operator")
+
+    assert result.status == PublishStatus.BUILT
+    built_ext = ext_state.commit_built_artifact.call_args.kwargs["ext"]
+    assert built_ext == {"keep": "value", "migration_path": "/snapshot/1"}

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_deploy_config_golden.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_deploy_config_golden.py
@@ -153,11 +153,6 @@ class TestGoldenDeployConfig:
                     "local_dir": "/home/admin/nfs/bot-data",
                     "permission": "READ_WRITE",
                 },
-                {
-                    "remote_dir": "/skills-repo/b1",
-                    "local_dir": "/home/admin/.openclaw/workspace/skills/skills-repo",
-                    "permission": "READ_ONLY",
-                },
             ],
             "ttl_in_minutes": 10080,
             "outbound_operation_rule": {"header_operation_rules": []},

--- a/src/backend/tests/community/core/service_bot/services/test_baas_service_engine_aware_mounts.py
+++ b/src/backend/tests/community/core/service_bot/services/test_baas_service_engine_aware_mounts.py
@@ -98,18 +98,10 @@ def _sys_mount(entries):
     raise AssertionError(f"No sys mount in entries: {entries}")
 
 
-def _skills_repo_mount(entries):
-    """从 mount_points 中找到 skills-repo 那个条目。"""
-    for entry in entries:
-        if entry.remote_dir == "/skills-repo/b1":
-            return entry
-    raise AssertionError(f"No skills-repo mount in entries: {entries}")
-
-
 @pytest.mark.unit
 class TestSetupDirectoryEngineAware:
     def test_default_mount_points(self):
-        """验证默认返回 bolt_data、skills-repo 和 agentclaw-sys 三个挂载点。"""
+        """BaaS 只挂 platform storage；Repo/Center 由 OCB entrypoint 挂载。"""
         composer = _make_composer()
 
         entries = composer._setup_directory(
@@ -119,14 +111,13 @@ class TestSetupDirectoryEngineAware:
             engine_type="openclaw",
         )
 
-        assert len(entries) == 3
+        assert len(entries) == 2
         bolt_data = _bolt_data_mount(entries)
         assert bolt_data.permission == "READ_WRITE"
-        skills_repo = _skills_repo_mount(entries)
-        assert skills_repo.local_dir == "/home/admin/.openclaw/workspace/skills/skills-repo"
-        assert skills_repo.permission == "READ_ONLY"
         sys_mount = _sys_mount(entries)
         assert sys_mount.permission == "READ_ONLY"
+        assert all("skills-repo" not in entry.remote_dir for entry in entries)
+        assert all("skills-center" not in entry.remote_dir for entry in entries)
 
     def test_claude_code_engine_type_same_mounts(self):
         """claude_code 引擎类型的挂载点与 openclaw 相同。"""
@@ -139,12 +130,9 @@ class TestSetupDirectoryEngineAware:
             engine_type="claude_code",
         )
 
-        assert len(entries) == 3
+        assert len(entries) == 2
         bolt_data = _bolt_data_mount(entries)
         assert bolt_data.permission == "READ_WRITE"
-        skills_repo = _skills_repo_mount(entries)
-        assert skills_repo.local_dir == "/home/admin/.claude_code/workspace/skills/skills-repo"
-        assert skills_repo.permission == "READ_ONLY"
         sys_mount = _sys_mount(entries)
         assert sys_mount.permission == "READ_ONLY"
 
@@ -161,12 +149,10 @@ class TestSetupDirectoryEngineAware:
             engine_type="",
         )
 
-        assert len(entries) == 3
+        assert len(entries) == 2
         bolt_data = _bolt_data_mount(entries)
         assert bolt_data.permission == "READ_WRITE"
-        skills_repo = _skills_repo_mount(entries)
-        assert skills_repo.local_dir == "/home/admin/.openclaw/workspace/skills/skills-repo"
-        assert skills_repo.permission == "READ_ONLY"
+        assert all("skills-repo" not in entry.remote_dir for entry in entries)
 
     def test_custom_mount_path_is_appended(self):
         composer = _make_composer()
@@ -186,7 +172,7 @@ class TestSetupDirectoryEngineAware:
         assert custom is not None
         assert custom.permission == "READ_WRITE"
 
-    def test_hermes_engine_uses_its_own_build_provider(self):
+    def test_hermes_engine_does_not_add_shared_corpus_mounts(self):
         composer = _make_composer()
 
         entries = composer._setup_directory(
@@ -196,10 +182,11 @@ class TestSetupDirectoryEngineAware:
             engine_type="hermes",
         )
 
-        skills_repo = _skills_repo_mount(entries)
-        assert skills_repo.local_dir == "/home/admin/.hermes/skills/skills-repo"
+        assert len(entries) == 2
+        assert all("skills-repo" not in entry.remote_dir for entry in entries)
+        assert all("skills-center" not in entry.remote_dir for entry in entries)
 
-    def test_center_artifact_adds_frozen_read_only_mount(self):
+    def test_center_artifact_does_not_turn_manifest_into_mount_instructions(self):
         composer = _make_composer()
         manifest = {
             "schema_version": 1,
@@ -242,27 +229,9 @@ class TestSetupDirectoryEngineAware:
             ext_info={"skills_manifest": manifest},
         )
 
-        center = next(entry for entry in entries if "skills-center" in entry.remote_dir)
-        repo = next(
-            entry
-            for entry in entries
-            if entry.local_dir
-            == "/home/admin/.openclaw/workspace/skills-pool/skills-repo"
-        )
-        assert repo.remote_dir == "/skills-repo/b1"
-        assert repo.permission == "READ_ONLY"
-        assert all(
-            entry.local_dir
-            != "/home/admin/.openclaw/workspace/skills/skills-repo"
-            for entry in entries
-        )
-        assert center.remote_dir == (
-            "/aidesktop/aidesktop_dev/bolt_shared/skills-center"
-        )
-        assert center.local_dir == (
-            "/home/admin/.openclaw/workspace/skills-pool/skill-center"
-        )
-        assert center.permission == "READ_ONLY"
+        assert len(entries) == 2
+        assert all("skills-repo" not in entry.remote_dir for entry in entries)
+        assert all("skills-center" not in entry.remote_dir for entry in entries)
 
     def test_old_artifact_does_not_add_center_mount(self):
         composer = _make_composer()
@@ -281,9 +250,7 @@ class TestSetupDirectoryEngineAware:
         )
 
         assert all("skills-center" not in entry.remote_dir for entry in entries)
-        assert _skills_repo_mount(entries).local_dir == (
-            "/home/admin/.openclaw/workspace/skills/skills-repo"
-        )
+        assert all("skills-repo" not in entry.remote_dir for entry in entries)
 
 
 @pytest.mark.unit

--- a/src/backend/tests/community/core/service_bot/services/test_publish_crash_windows.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_crash_windows.py
@@ -28,6 +28,10 @@ from agentclaw.community.core.service_bot.repository.models import (  # noqa: F4
     PublishStatus,
 )
 from agentclaw.community.core.repository.implementations.publishing.publish_operation import OrmPublishOperationRepository as PublishOperationRepository
+from agentclaw.community.core.skill_center.runtime_layout_probe_service_protocol import (
+    RuntimeLayoutProbeResult,
+    RuntimeLayoutProbeStatus,
+)
 from agentclaw.community.core.service_bot.services.publish_flow_service import (
     PublishFlowService,
 )
@@ -148,6 +152,16 @@ def _flow(*, ledger, baas, build_service, publish_service=None):
     reader.overrides_for_stage.return_value = {}
     common_config_service = Mock()
     common_config_service.get_value.return_value = None
+    runtime_layout_probe = Mock()
+    runtime_layout_probe.probe_bot = AsyncMock(
+        side_effect=lambda *, engine, **_: RuntimeLayoutProbeResult(
+            status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+            engine=engine,
+            layout_contract_version="skills-pool-p3-v1",
+            preparation_id=None,
+            evidence={"reason": "test_runtime_without_probe"},
+        )
+    )
     svc = PublishFlowService(
         publish_service or Mock(),
         build_service,
@@ -163,6 +177,7 @@ def _flow(*, ledger, baas, build_service, publish_service=None):
         task_queue_service=Mock(),
         publish_operation_repo=ledger,
         runtime_projector=AsyncMock(),
+        runtime_layout_probe=runtime_layout_probe,
     )
     # ARCA delivery (no config_artifact) → compose_live no-ops to (delivery, None).
     svc._ext_state.owner_id = Mock(return_value="u1")

--- a/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
+++ b/src/backend/tests/community/core/service_bot/services/test_publish_flow_service.py
@@ -122,6 +122,23 @@ def _pf(*args, **kw):
     kw.setdefault("device_binding_repo", Mock())
     kw.setdefault("publish_operation_repo", _real_ledger())
     kw.setdefault("runtime_projector", AsyncMock())
+    if "runtime_layout_probe" not in kw:
+        from agentclaw.community.core.skill_center.runtime_layout_probe_service_protocol import (
+            RuntimeLayoutProbeResult,
+            RuntimeLayoutProbeStatus,
+        )
+
+        probe = Mock()
+        probe.probe_bot = AsyncMock(
+            side_effect=lambda *, engine, **_: RuntimeLayoutProbeResult(
+                status=RuntimeLayoutProbeStatus.NOT_CAPABLE,
+                engine=engine,
+                layout_contract_version="skills-pool-p3-v1",
+                preparation_id=None,
+                evidence={"reason": "test_runtime_without_probe"},
+            )
+        )
+        kw["runtime_layout_probe"] = probe
     # The operation runner queries baas_service.list_bot_publishes for adopt-by-
     # query; a bare Mock returns a non-iterable Mock. Default it to "no prior
     # workflows" so upgrade/existing-bot flow tests issue normally.
@@ -1025,10 +1042,10 @@ from agentclaw.community.core.service_bot.services.deploy.producer import (  # n
 class _StubProducer(DeployArtifactProducer):
     def __init__(self, ext: dict) -> None:
         self.ext = ext
-        self.calls: list[tuple[dict, int]] = []
+        self.calls = []
 
-    def produce_artifact(self, bot, version) -> DeployArtifact:
-        self.calls.append((bot, version))
+    def produce_artifact(self, request) -> DeployArtifact:
+        self.calls.append(request)
         return DeployArtifact(success=True, ext=self.ext)
 
 
@@ -1087,7 +1104,9 @@ async def test_build_phase_routes_arca_and_merges_mount_ext():
     await svc.execute_build_phase(record, "op")
 
     # openclaw → baas → ARCA producer; teclaw stub untouched.
-    assert arca.calls == [(bot, 3)]
+    assert len(arca.calls) == 1
+    assert dict(arca.calls[0].bot) == bot
+    assert arca.calls[0].version == 3
     assert teclaw.calls == []
     # ARCA ext carries the mount chain unchanged (the durable record).
     ext_written = svc._ext_state.update_status.call_args.kwargs["ext"]
@@ -1122,7 +1141,9 @@ async def test_build_phase_projects_everything_before_artifact_build():
         owner_id="owner-1",
         scope=ProjectionScope.everything(),
     )
-    assert arca.calls == [(bot, 3)]
+    assert len(arca.calls) == 1
+    assert dict(arca.calls[0].bot) == bot
+    assert arca.calls[0].version == 3
 
 
 @pytest.mark.asyncio
@@ -1153,8 +1174,8 @@ async def test_build_phase_continues_when_runtime_projection_is_unavailable():
     # blocked by transient current-runtime projection drift.
     assert result.status == PublishStatus.BUILT
     assert len(arca.calls) == 1
-    assert arca.calls[0][0]["bot_id"] == "b1"
-    assert arca.calls[0][1] == 3
+    assert arca.calls[0].bot["bot_id"] == "b1"
+    assert arca.calls[0].version == 3
 
 
 @pytest.mark.asyncio
@@ -1178,7 +1199,9 @@ async def test_build_phase_routes_external_and_merges_artifact_ext():
     await svc.execute_build_phase(record, "op")
 
     # baas reports a TECLAW container → teclaw producer.
-    assert teclaw.calls == [(bot, 2)]
+    assert len(teclaw.calls) == 1
+    assert dict(teclaw.calls[0].bot) == bot
+    assert teclaw.calls[0].version == 2
     assert arca.calls == []
     # external pins the refs-only artifact onto ext (no mount chain). The teclaw
     # file-promotion gather merges its (here empty) snapshot into the artifact,
@@ -1241,7 +1264,7 @@ async def test_build_commit_fences_exact_center_skills_before_built_status():
 @pytest.mark.asyncio
 async def test_build_phase_failed_artifact_returns_failed_result():
     class _Fail(DeployArtifactProducer):
-        def produce_artifact(self, bot, version):
+        def produce_artifact(self, request):
             return DeployArtifact(success=False, message="boom")
 
     router = DeployArtifactProducerRouter(


### PR DESCRIPTION
## Problem

File-based Service Bot publication could fail before creating the ARCA/BaaS sandbox when a Pool artifact declared Repo/Center corpora. Avernet interpreted `shared_corpora` as additional BaaS mount instructions while the OCB image entrypoint already owned those OSS mounts. Service Artifact construction also read persisted `last_probe_evidence`, rejected Legacy + Center outright, and therefore coupled Center delivery to Pool cutover state.

## Solution

- Add an immutable `ArtifactBuildRequest` and typed fresh runtime-layout observation.
- Let each artifact producer declare whether it needs filesystem observation; ARCA/BaaS probes once, while Teclaw remains on Config Artifact v4 without a filesystem probe.
- Build Legacy + Center artifacts with a Center-only shared-corpus declaration, while Pool artifacts freeze ordered Repo + Center declarations.
- Require Mapping v3 for exact Center refs, re-read Center capabilities before manifest finalization, validate canonical paths/exclusions/exact symlinks, and retain historical Artifact compatibility.
- Stop `ManagedDeployConfigComposer` from creating automatic Repo/Center BaaS mounts. OCB remains the sole physical mount owner; `shared_corpora` is now only Snapshot exclusion/audit metadata.
- Preserve the Legacy BFF detailed build-error contract while adding stable internal Service Artifact error codes; the public OpenAPI facade remains sanitized.

## Validation

- Service Bot/runtime/DI/architecture focused gate: `1244 passed`.
- Service Bot module and publish boundary gate: `1111 passed`.
- Focused implementation/compatibility set: `330 passed`.
- Ruff on every changed Python file: passed.
- Changed-file flake8/SAST block rules: passed.
- Standards/Spec dual-axis review: no remaining P0/P1/P2 findings.
- One Backend full-suite run: `16063 passed, 58 skipped, 1 failed`. The only failure found a Legacy BFF error-detail compatibility regression introduced during review; it was fixed. The exact endpoint regression then passed (`1 passed`) and the affected publish suite passed (`183 passed`). Per the repository rule, the full suite was not run a second time; GitHub required CI is the final full-suite proof.

## Compatibility and risk

- No DDL, OpenAPI route, Gateway artifact, frontend, or OCB change.
- `skills_manifest.schema_version` remains `1` with additive combinations.
- Historical artifacts without a manifest, Legacy artifacts without Center, and old Pool artifacts without shared corpora remain readable.
- Rollback is the single Avernet commit; no data correction is required.

## Spec

- Updates `src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md` section 14.2 with the frozen Probe, mount-ownership, manifest, failure, and compatibility contracts.
