### PR TITLE
feat(bcs-http): dispatch bcs-fuse visibility sync on allowlisted provider bot registration

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
@@ -15,7 +15,7 @@ use bcs_service_api::application::v1::{
     PatchBotInternalAttributes, UserVisibility,
 };
 use bcs_service_api::{
-    BotUseCaseError, CoordinationMode, DeleteProviderBotCommand, ProviderAuthMode,
+    ActorKind, BotUseCaseError, CoordinationMode, DeleteProviderBotCommand, ProviderAuthMode,
     ProviderBotBinding, ProviderBotConnectionMode, ProviderBotRosterItem,
     ProviderBotTaskModesFilter, ProviderCoordinationConfig, ProviderOrganizationManagementConfig,
     ProviderRecord, RegisterProviderBotCommand, RegisterProviderCommand, ServiceError,
@@ -27,7 +27,7 @@ use serde_json::{Map, Value, json};
 use tracing::{info, warn};
 
 use crate::mapping::capabilities::{to_core_skill, to_wire_skill};
-use crate::state::HttpAppState;
+use crate::state::{HttpAppState, VisibilitySyncRequest};
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -217,6 +217,27 @@ pub async fn register_provider_bot(
         })
         .await
         .map_err(provider_error)?;
+
+    if allowed_switch_provider && outcome.created && outcome.actor_kind == ActorKind::Bot {
+        match outcome.capabilities.clone() {
+            Some(capabilities) => {
+                state.dispatch_visibility_sync(VisibilitySyncRequest {
+                    bot_uuid: outcome.bot_uuid.clone(),
+                    visibility: capabilities.visibility.clone(),
+                    capabilities,
+                    actor_kind: outcome.actor_kind,
+                });
+            }
+            None => {
+                warn!(
+                    provider_id = %outcome.provider_id,
+                    bot_uuid = %outcome.bot_uuid,
+                    "register_provider_bot: allowlisted provider but capabilities missing; \
+                     skipping bcs-fuse sync"
+                );
+            }
+        }
+    }
 
     Ok(Json(RegisterProviderBotResponse {
         bot_uuid: outcome.bot_uuid,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
@@ -14,7 +14,10 @@ use bcs_config::resolve_env_str;
 use bcs_http::{
     router::build_router,
     service_key::{ApiKeyEntry, ApiKeyRegistry},
-    state::{ChainUserIdentityPort, HttpAppState, HttpUserIdentity, UserIdentityPort},
+    state::{
+        ChainUserIdentityPort, HttpAppState, HttpUserIdentity, UserIdentityPort,
+        VisibilitySyncPort, VisibilitySyncRequest,
+    },
 };
 use bcs_service_api::application::v1::ApplicationError;
 use bcs_user_directory_api::{UserDirectoryPlugin, UserDirectoryProfile};
@@ -29,6 +32,7 @@ use bcs_service_api::{
 use bcs_services_container::Services;
 use serde_json::{Value, json};
 use tempfile::TempDir;
+use tokio::sync::Notify;
 use tower::ServiceExt;
 
 struct TestApp {
@@ -39,7 +43,41 @@ struct TestApp {
     relation: Arc<RecordingRelationCoreService>,
     control_plane: Arc<BotControlPlaneCore>,
     internal_bot_attributes: Arc<RecordingInternalBotAttributesService>,
+    visibility_sync: Option<Arc<RecordingVisibilitySyncPort>>,
     _temp_dir: TempDir,
+}
+
+#[derive(Default)]
+struct RecordingVisibilitySyncPort {
+    requests: tokio::sync::Mutex<Vec<VisibilitySyncRequest>>,
+    notify: Notify,
+}
+
+#[async_trait::async_trait]
+impl VisibilitySyncPort for RecordingVisibilitySyncPort {
+    async fn sync_visibility(&self, request: VisibilitySyncRequest) {
+        self.requests.lock().await.push(request);
+        self.notify.notify_waiters();
+    }
+}
+
+impl RecordingVisibilitySyncPort {
+    async fn wait_for(&self, count: usize) {
+        let mut retries = 0;
+        loop {
+            if self.requests.lock().await.len() >= count {
+                return;
+            }
+            retries += 1;
+            if retries > 200 {
+                panic!(
+                    "timed out waiting for {count} visibility sync requests, got {}",
+                    self.requests.lock().await.len()
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    }
 }
 
 #[derive(Default)]
@@ -91,7 +129,7 @@ fn test_app_with_user_identity_and_user_directory(
     user_identity: Arc<dyn UserIdentityPort>,
     user_directory: Option<Arc<dyn UserDirectoryPlugin>>,
 ) -> TestApp {
-    test_app_with_options(user_identity, user_directory, Vec::new(), Vec::new())
+    test_app_with_options(user_identity, user_directory, Vec::new(), Vec::new(), None)
 }
 
 fn test_app_with_allowed_switch_provider_ids(allowed_provider_ids: Vec<String>) -> TestApp {
@@ -101,6 +139,21 @@ fn test_app_with_allowed_switch_provider_ids(allowed_provider_ids: Vec<String>) 
         None,
         allowed_provider_ids,
         Vec::new(),
+        None,
+    )
+}
+
+fn test_app_with_allowed_switch_provider_ids_and_visibility_sync(
+    allowed_provider_ids: Vec<String>,
+    visibility_sync: Arc<RecordingVisibilitySyncPort>,
+) -> TestApp {
+    let chain = static_auth_chain("11111111", "Admin");
+    test_app_with_options(
+        Arc::new(ChainUserIdentityPort::new(chain)),
+        None,
+        allowed_provider_ids,
+        Vec::new(),
+        Some(visibility_sync),
     )
 }
 
@@ -109,6 +162,7 @@ fn test_app_with_options(
     user_directory: Option<Arc<dyn UserDirectoryPlugin>>,
     allowed_provider_ids: Vec<String>,
     service_keys: Vec<ApiKeyEntry>,
+    visibility_sync: Option<Arc<RecordingVisibilitySyncPort>>,
 ) -> TestApp {
     let temp_dir = tempfile::tempdir().expect("temp dir");
     let provider_store = Arc::new(MemoryProviderStore::new());
@@ -157,20 +211,24 @@ fn test_app_with_options(
         .provider_management(provider_management)
         .build_for_test();
 
+    let mut state_builder = HttpAppState::new(services)
+        .with_user_identity(user_identity)
+        .with_allowed_switch_provider_ids(allowed_provider_ids)
+        .with_internal_bot_attributes_service(internal_bot_attributes.clone())
+        .with_service_api_keys(Arc::new(ApiKeyRegistry::new(service_keys)));
+    if let Some(visibility_sync) = visibility_sync.clone() {
+        state_builder = state_builder.with_visibility_sync(visibility_sync);
+    }
+
     TestApp {
-        app: build_router(
-            HttpAppState::new(services)
-                .with_user_identity(user_identity)
-                .with_allowed_switch_provider_ids(allowed_provider_ids)
-                .with_internal_bot_attributes_service(internal_bot_attributes.clone())
-                .with_service_api_keys(Arc::new(ApiKeyRegistry::new(service_keys))),
-        ),
+        app: build_router(state_builder),
         provider_repo,
         provider_credentials,
         registry,
         relation,
         control_plane,
         internal_bot_attributes,
+        visibility_sync,
         _temp_dir: temp_dir,
     }
 }
@@ -3022,4 +3080,138 @@ async fn list_provider_bots_by_task_modes_rejects_invalid_toggle_and_accepts_fal
         task_mode_roster(&app, &provider_id, Some(admin_token), "?task_claim_mode=maybe").await;
     assert_eq!(status, StatusCode::BAD_REQUEST, "invalid toggle not rejected: {body}");
     assert_eq!(body["status"], 400);
+}
+
+async fn seed_allowed_provider(
+    provider_repo: &Arc<dyn ProviderRepoPort>,
+    provider_credentials: &Arc<dyn ProviderCredentialRepoPort>,
+    provider_id: &str,
+    admin_token: &str,
+) {
+    seed_provider_admin(provider_repo, provider_credentials, provider_id, admin_token, "11111111")
+        .await;
+}
+
+#[tokio::test]
+async fn register_provider_bot_dispatches_visibility_sync_for_allowlisted_provider() {
+    let provider_id = "prv_visibility_sync_allowed".to_string();
+    let admin_token = "admin-token";
+    let sync = Arc::new(RecordingVisibilitySyncPort::default());
+    let TestApp {
+        app,
+        provider_repo,
+        provider_credentials,
+        visibility_sync,
+        ..
+    } = test_app_with_allowed_switch_provider_ids_and_visibility_sync(
+        vec![provider_id.clone()],
+        sync.clone(),
+    );
+    seed_allowed_provider(&provider_repo, &provider_credentials, &provider_id, &admin_token).await;
+
+    let bot = register_provider_bot(&app, &provider_id, &admin_token, "teamclaw-bot:alice").await;
+    let bot_uuid = bot["bot_uuid"].as_str().unwrap().to_string();
+    let sync = visibility_sync.expect("visibility sync port wired");
+    sync.wait_for(1).await;
+    let requests = sync.requests.lock().await;
+    assert_eq!(requests.len(), 1, "expected exactly one visibility sync dispatch");
+    assert_eq!(requests[0].bot_uuid, bot_uuid);
+    assert_eq!(requests[0].actor_kind, ActorKind::Bot);
+    assert_eq!(requests[0].capabilities.visibility, "protected");
+    assert_eq!(requests[0].visibility, "protected");
+}
+
+#[tokio::test]
+async fn register_provider_bot_skips_visibility_sync_for_non_allowlisted_provider() {
+    let sync = Arc::new(RecordingVisibilitySyncPort::default());
+    let TestApp {
+        app,
+        visibility_sync,
+        ..
+    } = test_app_with_allowed_switch_provider_ids_and_visibility_sync(Vec::new(), sync);
+    let provider = register_provider(&app, json!({ "mode": "static_bearer" })).await;
+    let provider_id = provider["provider_id"].as_str().unwrap();
+    let admin_token = provider["provider_admin_token"].as_str().unwrap();
+
+    let _ = register_provider_bot(&app, provider_id, admin_token, "reviewer-v2").await;
+    // No notify is emitted for 0 requests, so poll briefly instead of wait_for.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let sync = visibility_sync.expect("visibility sync port wired");
+    let requests = sync.requests.lock().await;
+    assert!(
+        requests.is_empty(),
+        "non-allowlisted provider must not dispatch visibility sync, got {requests:?}"
+    );
+}
+
+#[tokio::test]
+async fn register_provider_bot_skips_visibility_sync_for_idempotent_gateway_replay() {
+    let provider_id = "prv_visibility_sync_replay".to_string();
+    let admin_token = "admin-token";
+    let sync = Arc::new(RecordingVisibilitySyncPort::default());
+    let TestApp {
+        app,
+        provider_repo,
+        provider_credentials,
+        visibility_sync,
+        ..
+    } = test_app_with_allowed_switch_provider_ids_and_visibility_sync(
+        vec![provider_id.clone()],
+        sync,
+    );
+    seed_allowed_provider(&provider_repo, &provider_credentials, &provider_id, &admin_token).await;
+
+    let first = register_provider_bot(&app, &provider_id, &admin_token, "teamclaw-bot:alice").await;
+    let first_bot_uuid = first["bot_uuid"].as_str().unwrap().to_string();
+    let sync = visibility_sync.expect("visibility sync port wired");
+    sync.wait_for(1).await;
+
+    // Idempotent replay with the same provider_bot_ref: Gateway short-circuits in
+    // core (`duplicate_registration=true`) and the message indicates the existing
+    // bot was returned.
+    let _ = register_provider_bot(&app, &provider_id, &admin_token, "teamclaw-bot:alice").await;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let requests = sync.requests.lock().await;
+    assert_eq!(
+        requests.len(),
+        1,
+        "idempotent replay must not dispatch a second visibility sync, got {requests:?}"
+    );
+    assert_eq!(requests[0].bot_uuid, first_bot_uuid);
+}
+
+#[tokio::test]
+async fn register_provider_bot_dispatches_visibility_sync_for_plugin_mode_allowlisted() {
+    let provider_id = "prv_visibility_sync_plugin".to_string();
+    let admin_token = "admin-token";
+    let sync = Arc::new(RecordingVisibilitySyncPort::default());
+    let TestApp {
+        app,
+        provider_repo,
+        provider_credentials,
+        visibility_sync,
+        ..
+    } = test_app_with_allowed_switch_provider_ids_and_visibility_sync(
+        vec![provider_id.clone()],
+        sync,
+    );
+    seed_allowed_provider(&provider_repo, &provider_credentials, &provider_id, &admin_token).await;
+
+    let bot_ref = "plugin-bot:alice";
+    let (status, body) =
+        register_provider_bot_mode(&app, &provider_id, &admin_token, bot_ref, "plugin").await;
+    assert_eq!(status, StatusCode::OK, "plugin mode rejected: {body}");
+    assert_eq!(body["bot_uuid"].as_str(), Some(bot_ref));
+
+    let sync = visibility_sync.expect("visibility sync port wired");
+    sync.wait_for(1).await;
+    let requests = sync.requests.lock().await;
+    assert_eq!(
+        requests.len(),
+        1,
+        "plugin mode over allowlisted provider should dispatch visibility sync once, got {requests:?}"
+    );
+    assert_eq!(requests[0].bot_uuid, bot_ref);
+    assert_eq!(requests[0].actor_kind, ActorKind::Bot);
 }

--- a/src/bcs/crates/service-api/bcs-service-api/src/application/provider.rs
+++ b/src/bcs/crates/service-api/bcs-service-api/src/application/provider.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
 use bcs_domain::{
-    ActorStatus, ProviderAuthMode, ProviderBotBinding, ProviderBotConnectionMode,
-    ProviderCoordinationConfig, ProviderOrganizationManagementConfig, ProviderRecord, Skill,
+    ActorKind, ActorStatus, BotCapabilities, ProviderAuthMode, ProviderBotBinding,
+    ProviderBotConnectionMode, ProviderCoordinationConfig, ProviderOrganizationManagementConfig,
+    ProviderRecord, Skill,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -97,6 +98,13 @@ pub struct RegisterProviderBotOutcome {
     pub provider_bot_ref: String,
     pub bot_runtime_token: Option<String>,
     pub message: Option<String>,
+    /// `true` 仅当本次实际写入了 bot/binding（非 Gateway 短路）。allowlisted
+    /// provider 据此决定是否 dispatch bcs-fuse 同步。
+    pub created: bool,
+    /// 新建成功时回填的 worker 级 capabilities；短路或读取失败时为 `None`。
+    pub capabilities: Option<BotCapabilities>,
+    /// Provider bot 恒为 `ActorKind::Bot`；与 onboard 路径一致的同步门控字段。
+    pub actor_kind: ActorKind,
 }
 
 #[derive(Debug, Clone)]

--- a/src/bcs/crates/services/bcs-bot/src/application/provider.rs
+++ b/src/bcs/crates/services/bcs-bot/src/application/provider.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bcs_service_api::{
-    BotControlPlaneCoreService, BotRegistryCoreService, BotTaskModesQuery,
+    ActorKind, BotControlPlaneCoreService, BotRegistryCoreService, BotTaskModesQuery,
     ChannelBindingCleanupPort, DeleteProviderBotCommand, DeleteProviderBotOutcome,
     NoopChannelBindingCleanupPort, ProviderBotBinding, ProviderBotCoreService,
     ProviderBotRosterItem, ProviderBotTaskModesFilter, ProviderCoreService,
@@ -283,6 +283,23 @@ impl ProviderManagementService for ProviderManagement {
         if !duplicate_registration {
             self.ensure_owner_binding(&binding.bot_uuid, &owner).await?;
         }
+        let created = !duplicate_registration;
+        let capabilities = if created {
+            match self.registry.get(&binding.bot_uuid).await {
+                Some(bot) => Some(bot.capabilities),
+                None => {
+                    tracing::warn!(
+                        bot_uuid = %binding.bot_uuid,
+                        provider_id = %binding.provider_id,
+                        "register_provider_bot: freshly created bot missing from registry; \
+                         capabilities unavailable for visibility sync"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
         Ok(RegisterProviderBotOutcome {
             bot_uuid: binding.bot_uuid,
             provider_id: binding.provider_id,
@@ -290,6 +307,9 @@ impl ProviderManagementService for ProviderManagement {
             bot_runtime_token,
             message: duplicate_registration
                 .then(|| "provider bot ref already registered; returning existing bot".to_string()),
+            created,
+            capabilities,
+            actor_kind: ActorKind::Bot,
         })
     }
 


### PR DESCRIPTION
## Summary

When a provider bot is registered through the `register_provider_bot` HTTP
route and the provider is allowlisted for switch-provider, the freshly created
bot must be visible to bcs-fuse without waiting for the next bot-list/refresh
cycle. This change wires a one-shot, fire-and-forget visibility sync dispatch
from the HTTP handler into bcs-fuse immediately after a successful creation.

`RegisterProviderBotOutcome` is extended with three application-internal fields
populated by the bcs-bot application layer:

- `created: bool` — `true` only when this call actually wrote the bot/binding
  (i.e. not a gateway short-circuit / idempotent replay);
- `capabilities: Option<BotCapabilities>` — the freshly read worker
  capabilities for a newly created bot, `None` on replay or transient miss;
- `actor_kind: ActorKind` — kept as `ActorKind::Bot` for the provider-bot path
  so the handler's sync gating stays explicit and consistent with other
  onboarding paths.

The HTTP handler dispatches a `VisibilitySyncRequest` only when
`allowed_switch_provider && outcome.created && outcome.actor_kind == ActorKind::Bot`
and `capabilities` is present. If `capabilities` is `None` (e.g. an eventual
registry miss right after creation), the handler logs a warning and skips the
sync, never blocking the registration response. Non-allowlisted providers and
idempotent gateway replays (`created=false`) are unchanged and never trigger
a sync.

## Why fire-and-forget is safe

- `bcs-fuse sync_worker` is idempotent per `worker_id`, so a duplicate
  fire-and-forget sync (e.g. the pre-existing duplicate-registration race
  window) is harmless.
- The rare `registry.get` miss right after creation degrades to a skipped sync
  for that single event; subsequent bot-list/refresh paths still discover the
  bot. The warn log keeps the miss observable.

## Changed files

- `src/bcs/crates/service-api/bcs-service-api/src/application/provider.rs` —
  extend `RegisterProviderBotOutcome` with `created`, `capabilities`,
  `actor_kind` (non-serialized, application-internal).
- `src/bcs/crates/services/bcs-bot/src/application/provider.rs` — populate the
  new fields in `ProviderManagement::register_provider_bot`; read capabilities
  from the registry only on the created branch with a warn-on-miss fallback.
- `src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs` — dispatch
  `VisibilitySyncRequest` for allowlisted + created + Bot actors; warn and skip
  when capabilities are missing.
- `src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs` —
  add `RecordingVisibilitySyncPort`, optional `with_visibility_sync` wiring on
  `HttpAppState`, and three contract tests.

## Tests

Local per-module test runs (using the local cargo build cache):

- `cargo check -p bcs-service-api -p bcs-bot -p bcs-http --tests`
- `cargo test -p bcs-http --test provider_routes_contract` — 50 passed
- `cargo test -p bcs-service-api` — 9 passed
- `cargo test -p bcs-bot` — 52 passed

New contract cases:

- `register_provider_bot_dispatches_visibility_sync_for_allowlisted_provider`
- `register_provider_bot_skips_visibility_sync_for_non_allowlisted_provider`
- `register_provider_bot_skips_visibility_sync_for_idempotent_gateway_replay`

No new failures introduced by this patch. One preexisting `dead_code` lint
warning in `bcs-http` test helpers (`bots_contract.rs`) is unrelated and not
affected by this diff.

Full per-module `src/backend/scripts/ci_test.sh --base <dev> --head HEAD` is
deferred to PR required checks per project convention.

## Security / privacy

- `capabilities` (including `agent_code`) is application-internal,
  `skip_serializing` on the wire, and is **not** serialized into the HTTP
  response; the response builder ignores it.
- The public diff privacy scan found no introduced or preexisting sensitive
  hits on the changed files.

## Risks

- The duplicate-registration TOCTOU between the duplicate check and the write
  is pre-existing; the new `created` flag inherits that window. At worst a
  duplicate fire-and-forget sync reaches an idempotent `sync_worker`. No data
  corruption, no behavioral regression.
- A rare post-creation `registry.get` miss means visibility sync is skipped
  for one registration event. Non-blocking by design; the warn makes it
  observable.

## Rollback

Revert this commit. The new `RegisterProviderBotOutcome` fields are
application-internal and not serialized, and the sync dispatch is additive, so
reverting does not change any public HTTP response shape. No data migration is
involved.