### PR TITLE
fix(skill-center): resolve space skill owner display names

### DIFF
--- a/src/backend/src/agentclaw/community/core/skill_center/README.md
+++ b/src/backend/src/agentclaw/community/core/skill_center/README.md
@@ -99,6 +99,7 @@ consumes:
   - "SecretResolver"
   - "SkillCenterClient"
   - "SkillCenterGateway"
+  - "StaffDeptPlugin"
   - "SpaceSkillSourcePlugin"
   - "SkillRepoSyncPlugin"
   - "WorkspacePathFactory"
@@ -174,6 +175,7 @@ internal_dependencies:
   - agentclaw.community.plugin_api.skill_repo_sync
   - agentclaw.community.plugin_api.skill_scanner
   - agentclaw.community.plugin_api.space_skill_source
+  - agentclaw.community.plugin_api.staff_dept
   - agentclaw.community.utils
   - agentclaw.community.utils.avernet_tenant
   - agentclaw.community.utils.env_utils

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_query_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_query_service.py
@@ -24,8 +24,17 @@ from agentclaw.community.core.spaces.services.space_access_service import (
 from agentclaw.community.core.skill_center.services.space_skill_grant_service import (
     space_skill_actor_permissions,
 )
+from agentclaw.community.log import get_logger
+from agentclaw.community.plugin_api.staff_dept import (
+    StaffDeptPlugin,
+    StaffProfileLookupError,
+)
 from agentclaw.community.utils.env_utils import get_current_env
 from agentclaw.community.utils.avernet_tenant import get_current_avernet_tenant
+from agentclaw.community.utils.work_no import normalize_work_no_for_lookup
+
+
+logger = get_logger()
 
 
 class SpaceSkillQueryService(SpaceSkillQueryServiceProtocol):
@@ -36,9 +45,11 @@ class SpaceSkillQueryService(SpaceSkillQueryServiceProtocol):
         self,
         access_service: SpaceAccessService,
         repository: SpaceSkillReadRepository,
+        staff_dept: StaffDeptPlugin,
     ) -> None:
         self._access_service = access_service
         self._repository = repository
+        self._staff_dept = staff_dept
 
     def list_space_skills(
         self,
@@ -64,12 +75,14 @@ class SpaceSkillQueryService(SpaceSkillQueryServiceProtocol):
             offset=(page - 1) * page_size,
             limit=page_size,
         )
+        owner_display_names = self._resolve_owner_display_names(records)
         return total, [
             self._to_summary(
                 record,
                 actor_id=actor_id,
                 space_type=space.space_type,
                 space_role=member.role,
+                owner_display_name=owner_display_names[record["owner_user_id"]],
             )
             for record in records
         ]
@@ -86,24 +99,29 @@ class SpaceSkillQueryService(SpaceSkillQueryServiceProtocol):
             actor_id=actor_id,
             env=get_current_env(),
         )
+        owner_display_name = self._resolve_owner_display_names([record])[
+            record["owner_user_id"]
+        ]
         summary = self._to_summary(
             record,
             actor_id=actor_id,
             space_type=space.space_type,
             space_role=member.role,
+            owner_display_name=owner_display_name,
         )
         summary["source"] = record["source_type"]
         summary["offline_at"] = record["offline_at"]
         summary["offline_by"] = record["offline_by"]
         return summary
 
-    @staticmethod
     def _to_summary(
+        self,
         record: SpaceSkillReadRecord,
         *,
         actor_id: str,
         space_type,
         space_role,
+        owner_display_name: str | None,
     ) -> SpaceSkillSummaryRecord:
         role = record["current_user_skill_role"]
         is_team = record["space_type"] == "TEAM"
@@ -207,7 +225,7 @@ class SpaceSkillQueryService(SpaceSkillQueryServiceProtocol):
             "space_type": record["space_type"],
             "owner": {
                 "user_id": record["owner_user_id"],
-                "display_name": record["owner_display_name"],
+                "display_name": owner_display_name,
             },
             "latest_published_version": latest,
             "draft": draft,
@@ -225,3 +243,34 @@ class SpaceSkillQueryService(SpaceSkillQueryServiceProtocol):
             "gmt_created": record["gmt_created"],
             "gmt_modified": record["gmt_modified"],
         }
+
+    def _resolve_owner_display_names(
+        self, records: list[SpaceSkillReadRecord]
+    ) -> dict[str, str | None]:
+        """Resolve the current display name once per Owner in one read response.
+
+        ``ac_space_member.user_name`` is a historical snapshot and may be null.
+        The workshop contract needs the current staff-directory display name. A
+        profile outage must not make a read-only Skill listing unavailable, so
+        the persisted value remains a best-effort fallback.
+        """
+        persisted_names = {
+            record["owner_user_id"]: record["owner_display_name"] for record in records
+        }
+        resolved: dict[str, str | None] = {}
+        for owner_id, persisted_name in persisted_names.items():
+            try:
+                profile = self._staff_dept.get_profile_by_work_no(
+                    work_no=normalize_work_no_for_lookup(owner_id)
+                )
+            except StaffProfileLookupError:
+                logger.warning(
+                    "staff profile lookup failed; retaining stored Space Skill owner name",
+                    extra={"owner_id": owner_id},
+                    exc_info=True,
+                )
+                resolved[owner_id] = persisted_name
+                continue
+            display_name = (profile.nick_name or "").strip()
+            resolved[owner_id] = display_name[:128] or persisted_name
+        return resolved

--- a/src/backend/tests/community/core/skill_center/services/test_space_skill_query_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_space_skill_query_service.py
@@ -13,6 +13,10 @@ from agentclaw.community.core.spaces.errors import (
     SpaceAccessDeniedError,
     SpaceNotFoundError,
 )
+from agentclaw.community.plugin_api.staff_dept import (
+    StaffProfileInfo,
+    StaffProfileLookupError,
+)
 
 
 def _service():
@@ -23,7 +27,16 @@ def _service():
     )
     repository = MagicMock()
     repository.list_skills.return_value = (0, [])
-    return SpaceSkillQueryService(access, repository), access, repository
+    staff_dept = MagicMock()
+    staff_dept.get_profile_by_work_no.return_value = StaffProfileInfo(
+        work_no="owner-1", nick_name=None
+    )
+    return (
+        SpaceSkillQueryService(access, repository, staff_dept),
+        access,
+        repository,
+        staff_dept,
+    )
 
 
 @pytest.mark.parametrize(
@@ -33,7 +46,7 @@ def _service():
 def test_list_space_skills_authorizes_normalizes_and_paginates(
     monkeypatch, keyword, expected
 ):
-    service, access, repository = _service()
+    service, access, repository, _ = _service()
     monkeypatch.setattr(
         "agentclaw.community.core.skill_center.services.space_skill_query_service.get_current_env",
         lambda: "test",
@@ -61,7 +74,7 @@ def test_list_space_skills_authorizes_normalizes_and_paginates(
 
 @pytest.mark.parametrize("error", [SpaceAccessDeniedError, SpaceNotFoundError])
 def test_list_space_skills_propagates_access_errors_without_querying_repository(error):
-    service, access, repository = _service()
+    service, access, repository, _ = _service()
     access.require_space_member.side_effect = error("denied")
 
     with pytest.raises(error):
@@ -69,7 +82,7 @@ def test_list_space_skills_propagates_access_errors_without_querying_repository(
             space_id=7,
             actor_id="outsider",
             keyword=None,
-                page=1,
+            page=1,
             page_size=20,
         )
 
@@ -91,7 +104,7 @@ def test_list_space_skills_derives_actor_permissions_and_lease_summary(
 ):
     from datetime import datetime
 
-    service, access, repository = _service()
+    service, access, repository, staff_dept = _service()
     access.require_space_member.return_value = (
         MagicMock(space_type=space_type),
         MagicMock(role="MEMBER"),
@@ -126,7 +139,9 @@ def test_list_space_skills_derives_actor_permissions_and_lease_summary(
                 "owner_user_id": "owner-1",
                 "owner_display_name": "Owner One",
                 "lease_holder_user_id": "manager-2" if space_type == "TEAM" else None,
-                "lease_holder_display_name": "Manager Two" if space_type == "TEAM" else None,
+                "lease_holder_display_name": "Manager Two"
+                if space_type == "TEAM"
+                else None,
                 "latest_version_id": None,
                 "latest_version_ordinal": None,
                 "latest_sc_version_number": None,
@@ -168,3 +183,111 @@ def test_list_space_skills_derives_actor_permissions_and_lease_summary(
         "holder_display_name": "Manager Two" if space_type == "TEAM" else None,
     }
     assert "fencing_token" not in records[0]["lease_summary"]
+    staff_dept.get_profile_by_work_no.assert_called_once_with(work_no="owner-1")
+
+
+def test_list_space_skills_uses_current_staff_profile_for_owner_display_name(
+    monkeypatch,
+):
+    from datetime import datetime
+
+    service, _, repository, staff_dept = _service()
+    staff_dept.get_profile_by_work_no.return_value = StaffProfileInfo(
+        work_no="165528", nick_name="  卷瓜  "
+    )
+    timestamp = datetime(2026, 9, 2, 9, 0)
+    repository.list_skills.return_value = (
+        1,
+        [
+            _record(
+                timestamp=timestamp,
+                owner_user_id="165528",
+                owner_display_name=None,
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "agentclaw.community.core.skill_center.services.space_skill_query_service.get_current_env",
+        lambda: "test",
+    )
+
+    _, records = service.list_space_skills(
+        space_id=7, actor_id="member-1", keyword=None, page=1, page_size=20
+    )
+
+    assert records[0]["owner"] == {"user_id": "165528", "display_name": "卷瓜"}
+    staff_dept.get_profile_by_work_no.assert_called_once_with(work_no="165528")
+
+
+def test_list_space_skills_preserves_owner_snapshot_when_profile_lookup_fails(
+    monkeypatch,
+):
+    from datetime import datetime
+
+    service, _, repository, staff_dept = _service()
+    timestamp = datetime(2026, 9, 2, 9, 0)
+    repository.list_skills.return_value = (
+        1,
+        [
+            _record(
+                timestamp=timestamp,
+                owner_user_id="165528",
+                owner_display_name="旧名称",
+            )
+        ],
+    )
+    staff_dept.get_profile_by_work_no.side_effect = StaffProfileLookupError(
+        "unavailable"
+    )
+    monkeypatch.setattr(
+        "agentclaw.community.core.skill_center.services.space_skill_query_service.get_current_env",
+        lambda: "test",
+    )
+
+    _, records = service.list_space_skills(
+        space_id=7, actor_id="member-1", keyword=None, page=1, page_size=20
+    )
+
+    assert records[0]["owner"] == {"user_id": "165528", "display_name": "旧名称"}
+
+
+def _record(*, timestamp, owner_user_id: str, owner_display_name: str | None):
+    return {
+        "id": 1,
+        "skill_uuid": "skill-1",
+        "name": "Example",
+        "description": None,
+        "status": "DEVELOPING",
+        "source_type": "FOLDER",
+        "draft_status": "EDITING",
+        "draft_target_version": 1,
+        "draft_description": "Draft example",
+        "draft_locator": (
+            "draft://11111111-1111-4111-8111-111111111111/"
+            "v1/22222222-2222-4222-8222-222222222222"
+        ),
+        "draft_source_kind": "FOLDER",
+        "source_repo_url": None,
+        "source_branch": None,
+        "source_subdir": None,
+        "source_commit_sha": None,
+        "offline_at": None,
+        "offline_by": None,
+        "space_type": "TEAM",
+        "current_user_skill_role": "OWNER",
+        "owner_user_id": owner_user_id,
+        "owner_display_name": owner_display_name,
+        "lease_holder_user_id": None,
+        "lease_holder_display_name": None,
+        "latest_version_id": None,
+        "latest_version_ordinal": None,
+        "latest_sc_version_number": None,
+        "latest_published_at": None,
+        "active_attempt_id": None,
+        "active_attempt_target_version": None,
+        "active_attempt_status": None,
+        "pending_request_id": None,
+        "pending_request_no": None,
+        "gmt_created": timestamp,
+        "gmt_modified": timestamp,
+    }


### PR DESCRIPTION
## Problem

Space Skill 列表和详情从 ac_space_member.user_name 读取 Owner 名称。这个历史快照可能为空，因此 OpenAPI owner.display_name 返回 null。

## Solution

- 在 SpaceSkillQueryService 中按 Owner 去重调用 StaffDeptPlugin.get_profile_by_work_no。
- 将 StaffProfileInfo.nick_name 作为 owner.display_name 返回。
- Staff 目录不可用时保留已有成员快照，避免只读列表因展示信息失败。

## Validation

- uv run ruff check src/agentclaw/community/core/skill_center/services/space_skill_query_service.py tests/community/core/skill_center/services/test_space_skill_query_service.py
- uv run pytest -q tests/community/core/skill_center/services/test_space_skill_query_service.py (12 passed)
- uv run pytest -q tests/community/adapters/http/openapi_v1/spaces/test_contract.py -k list_space_skills (6 passed)

## Compatibility and risk

OpenAPI wire schema and database schema unchanged. Profile lookup is best-effort and preserves the prior stored display name on Staff directory failure.