### PR TITLE
fix(backend): stop rejecting factory snapshots carrying form-field keys

### DIFF
--- a/docs/bot-create-api-guide.zh-CN.md
+++ b/docs/bot-create-api-guide.zh-CN.md
@@ -136,7 +136,7 @@ POST /openapi/v1/bots
 
   前端引导用户完成 `iframe_url` 授权，然后轮询 §1.2。
 
-**错误码**：400 不支持的引擎/集群错配（`code: 400000`）、403 无权限、404 空间不存在、409 名称重复或组合不支持（见 §1.3 ⑤）、422 请求体校验失败（server-managed 字段 / 混传 / 形态冒充，见 §1.3）。
+**错误码**：400 不支持的引擎/集群错配（`code: 400000`）、403 无权限、404 空间不存在、409 名称重复或组合不支持（见 §1.3 ⑤）、422 请求体校验失败（server-managed 字段 / 形态冒充,见 §1.3）。
 
 ### 1.2 授权轮询 `POST /openapi/v1/bots/{bot_id}/auth-status`
 
@@ -205,9 +205,9 @@ POST /openapi/v1/bots/20260813_a7k2m9p1/auth-status
 
 **④ 未知键**：原样存活、随快照落库（引擎自有扩展），但**平台不解读**——见 §3 命名提醒。工厂快照同理：未知键透传落库、平台不解读。
 
-**⑤ 混传拒绝 + 组合约束：**
+**⑤ 表单字段同名键 + 组合约束：**
 
-- **混传**：完整工厂快照（双键身份）+ 手填专用键（`devflow_workflow` / `code_repos` / `yuque_kb_repos`）→ 422 `template factory snapshot must not mix application-coding fields: [...]`。工厂路径不解读手填键，两种形态**二选一**。只带零散工厂键（缺 `template_uid`）混有手填键 → 走手填路径，工厂键按未知键存活。
+- **同名键不拒绝**：tc-list 快照会把 custom_field 表单值展开在 `template_config` 顶层——`yuque_kb_repos` / `devflow_workflow` / `code_repos` 等键与手填形态的外层契约键**同名**,但它们是快照的正常组成(空值/`null` 也照传),**不需要剔除**。形态由 `template_key`+`template_uid` 双键判定,不按键名区分。只带零散工厂键（缺 `template_uid`）的 config → 走手填路径,工厂键按未知键存活。
 - **组合约束（工厂与手填同受约束）**：`engine` 必须 `claude_code` + `bot_type=personal` + 个人空间 + 云端。违反 → 409（`BotCombinationUnsupportedError`，既语文案如 `application coding is cloud-only` / `application coding does not support engine: ...`）。
 
 **密钥落库口径**：顶层 `token` 出现即按既有策略加密落密文；`bot_template_config.ext_config.thetaKey` 后端无加密入口，密文由调用方产生、原样落库。查询面按 #1785 verbatim 决策随存随显（见 §1.4）。
@@ -305,7 +305,7 @@ Body 必带 `bot_id`，其余与创建一致回传。响应 `data.status ∈ {PE
 | token | `token` | 出现就必须非空 |
 
 **手填必须剔除/不要携带这些键（openapi 面 422）：**
-`template_uid`、`workspace_id`、`bot_id`、`workspace_status`、`workspace_state`、`start_status`、`engine_form`。如果第三方配置里带 `template_uid`，**由前端丢弃**（模板 uid 由平台侧解析/分配；这条只约束手填形态——工厂快照来源整段回传放行）。**也不要把手填键拼进完整工厂快照**（422 混传拒绝，见 §1.3 ⑤）。
+`template_uid`、`workspace_id`、`bot_id`、`workspace_status`、`workspace_state`、`start_status`、`engine_form`。如果第三方配置里带 `template_uid`，**由前端丢弃**（模板 uid 由平台侧解析/分配；这条只约束手填形态——工厂快照来源整段回传放行）。快照里带 `yuque_kb_repos`/`devflow_workflow` 等与手填键同名的表单字段是正常形态,直接透传。
 
 **注意事项：**
 
@@ -323,7 +323,6 @@ Body 必带 `bot_id`，其余与创建一致回传。响应 `data.status ∈ {PE
 | openapi 创建 400 `unsupported engine` | `engine` 传了 `aicoding` 或未部署的引擎 | 改传 `claude_code` 等真实引擎 |
 | openapi 创建 422 `applicationCoding template_config must not be empty` | `template_config` 缺失或空 dict | 工厂=快照整段回传；手填=散字段拼装，非空必填 |
 | openapi 创建 422 提到 `server-managed fields` | 手填 `template_config` 带了 `template_uid`/`engine_form` 等；或工厂快照带了 `workspace_id`/`engine_form` 等 | 手填：剔除这些键（§3 第三步）；工厂快照：四个工厂身份键（`template_key`/`template_uid`/`template_version`/`template_version_id`）放行，其余 server-managed 键剔除 |
-| openapi 创建 422 `template factory snapshot must not mix application-coding fields` | 完整工厂快照（`template_key`+`template_uid`）里混了 `devflow_workflow`/`code_repos`/`yuque_kb_repos` 手填键 | 工厂与手填二选一：快照整段回传，别拼手填键（§1.3 ⑤） |
 | openapi 创建 422 `engine_properties.template_type is required for template factory snapshots` | 工厂快照未传 `engine_properties.template_type`（或空串） | 照抄 tc-list item 的 `template_type`（§1.1 示例 C 字段表） |
 | openapi 创建 422 `engine_properties.template_type must be applicationCoding for non factory snapshots` | 手填形态传了 `applicationCoding` 以外的 `template_type` | 手填省略该键或写死 `applicationCoding`；要其它值走工厂快照 |
 | openapi 创建 422 `extra inputs not permitted` | 请求体多了未知字段（如 `engine_options`），或 `engine_properties` 下不是 `template_type`/`template_config`（旧键 `template` 已废） | 对照 §1.1 字段表与 §1.3 键域 |

--- a/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
+++ b/docs/superpowers/specs/2026-09-01-openapi-template-config-passthrough-design.md
@@ -80,7 +80,7 @@ Front-end 映射:`engine ← item.engine_type`,`bot_type ← item.bot_type`,`eng
 | 1 | `engine_properties` 出现 `template_type/template_config` 以外的键 | 422 `unsupported engine_properties fields: [...]`(沿用既有文案,键名集合更新) |
 | 2 | 工厂形态:`template_type` 缺失或空串 | 422 `engine_properties.template_type is required for template-config creates` |
 | 3 | 任何形态:`template_config` 缺失或空 | 422(沿用现有 `applicationCoding template_config must not be empty` 文案,新增错误才用新文案,减少测试 churn) |
-| 4 | 完整工厂快照(双键)与手填专用键(`devflow_workflow/code_repos/yuque_kb_repos` 等外层契约键)混传 | 422 工厂路径不解读手填键,明确拒绝;不完整快照(缺 `template_uid`)混有手填键则走手填路径,工厂键按未知键存活(现状) |
+| 4 | 【已删除(2026-09-02 实测修正)】真实 tc-list 快照把 custom_field 表单值展开在顶层,`yuque_kb_repos`/`devflow_workflow` 与手填键天然同名——混传拒绝会误伤所有带表单值的真实快照(pre 实测 architect 模板 422 复现)。形态歧义由工厂双键判定已足够,规则删除;不完整快照(缺 `template_uid`)仍走手填路径,工厂键按未知键存活 |
 | 5 | 任何形态的 `template_config` 顶层出现拒收 server-managed 字段:`bot_id/workspace_id/workspace_status/workspace_state/start_status/engine_form` | 422 `template_config contains server-managed fields: [...]`(实现事实修正:`TEMPLATE_SERVER_RESERVED_FIELDS` 本含 `template_uid`,工厂分支在 strategy 层对四个工厂身份键做豁免后复用同一拒绝逻辑,手填路径拒绝集合不变) |
 | 6 | 手填路径 `template_type` 传了且 ≠ `applicationCoding` | 422(防形态冒充;工厂值必须走工厂标记) |
 | 7 | 组合 gates 违反(cloud-only、engine 非 claude_code、bot_type 非 personal、非个人空间) | 409(沿用 `BotCombinationUnsupportedError` 既有文案与顺序) |

--- a/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
+++ b/src/backend/src/agentclaw/community/core/bot_management/engines/aicoding/strategy.py
@@ -54,11 +54,6 @@ TEMPLATE_CONFIG_CONSUMING_ENGINES = frozenset(
 #: implementation behind the hand-written application-coding shape and the
 #: template-factory snapshot passthrough shape.
 _ENGINE_PROPERTIES_KEYS = frozenset({"template_type", "template_config"})
-_HANDCRAFTED_MIX_REJECT_KEYS = (
-    "devflow_workflow",
-    "yuque_kb_repos",
-    "code_repos",
-)
 #: Template-factory identity keys allowed through the factory branch's PUBLIC
 #: server-managed-field check (design §5.5: the reserved list's concession for
 #: factory snapshots). A resolved snapshot legitimately carries its own
@@ -302,12 +297,13 @@ class AicodingProvisioningStrategy(EngineProvisioningStrategy):
                 "engine_properties.template_type is required for template "
                 "factory snapshots"
             )
-        mixed = [key for key in _HANDCRAFTED_MIX_REJECT_KEYS if key in template]
-        if mixed:
-            raise BotTemplateInvalidError(
-                "template factory snapshot must not mix application-coding "
-                f"fields: {sorted(mixed)}"
-            )
+        # NOTE: no mix-rejection between "factory keys" and "hand-written
+        # application-coding keys" on purpose. available-tc-list resolved
+        # snapshots spread their custom_field form values over the top level
+        # (``yuque_kb_repos``/``devflow_workflow``/``code_repos`` collide with
+        # the hand-written outer contract by name); the two shapes are
+        # disambiguated by the template_key+template_uid identity above, not
+        # by key names.
         if template_validation_mode is BotCreateTemplateValidationMode.PUBLIC:
             # Design §5.5: the factory branch reuses the shared
             # server-managed-field contract minus the factory identity keys.

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_bots_endpoints.py
@@ -873,23 +873,37 @@ def test_create_factory_snapshot_server_managed_field_is_422(client, svc):
     svc.create_bot.assert_not_called()
 
 
-def test_create_factory_snapshot_mix_is_422(client, svc):
-    response = client.post(
-        "/openapi/v1/bots",
-        json={
-            **_CREATE_BODY,
-            "engine": "claude_code",
-            "engine_properties": {
-                **_FACTORY_SNAPSHOT_BODY,
-                "template_config": {
-                    **_FACTORY_SNAPSHOT_BODY["template_config"],
-                    "devflow_workflow": "x",
+def test_create_factory_snapshot_with_form_fields_persists_verbatim(
+    client, svc, passport
+):
+    # tc-list 快照的 custom_field 表单值展开在顶层(与手填键同名):
+    # 工厂身份由 template_key+template_uid 判定,不按键名拒绝
+    passport.apply_first_agent_passport.return_value = {
+        "token": "tok",
+        "agent_code": "ac",
+    }
+    snapshot = {
+        **_FACTORY_SNAPSHOT_BODY["template_config"],
+        "architect_name": "大安全",
+        "yuque_kb_repos": [],
+        "devflow_workflow": None,
+    }
+    with patch.object(bots_router, "generate_bot_id", return_value="default"):
+        response = client.post(
+            "/openapi/v1/bots",
+            json={
+                **_CREATE_BODY,
+                "engine": "claude_code",
+                "engine_properties": {
+                    "template_type": "architect",
+                    "template_config": snapshot,
                 },
             },
-        },
-    )
-    assert response.status_code == 422, response.json()
-    svc.create_bot.assert_not_called()
+        )
+    assert response.status_code == 201, response.json()
+    kwargs = svc.create_bot.call_args.kwargs
+    assert kwargs["template_type"] == "architect"
+    assert kwargs["template_config"] == snapshot
 
 
 def test_create_handcrafted_with_foreign_template_type_is_422(client, svc):

--- a/src/backend/tests/community/core/bot_management/test_application_coding_create.py
+++ b/src/backend/tests/community/core/bot_management/test_application_coding_create.py
@@ -677,14 +677,27 @@ def test_factory_snapshot_rejects_blank_template_type() -> None:
         )
 
 
-def test_factory_snapshot_rejects_handcrafted_field_mix() -> None:
-    mixed = dict(_FACTORY_SNAPSHOT, devflow_workflow="app-flow")
-    with pytest.raises(BotTemplateInvalidError) as excinfo:
-        _strategy_prepare(
-            "claude_code",
-            {"template_type": "applicationCoding", "template_config": mixed},
-        )
-    assert "devflow_workflow" in str(excinfo.value)
+def test_factory_snapshot_carries_ac_form_field_keys_verbatim() -> None:
+    # available-tc-list 的 resolved 快照会把 custom_field 表单字段展开在
+    # template_config 顶层(含空值/None 也展开)。architect 模板的表单字段
+    # yuque_kb_repos / devflow_workflow 与手填 applicationCoding 的外层契约键
+    # 同名——它们是快照的正常组成,不是混传;工厂身份由 template_key+
+    # template_uid 双键判定,不存在歧义。
+    snapshot = dict(
+        _FACTORY_SNAPSHOT,
+        architect_name="大安全",
+        backend_repo=[],
+        frontend_repo=[],
+        lib_repo=[],
+        yuque_kb_repos=[],
+        devflow_workflow=None,
+    )
+    prepared = _strategy_prepare(
+        "claude_code",
+        {"template_type": "architect", "template_config": snapshot},
+    )
+    assert prepared.template_type == "architect"
+    assert prepared.template_config == snapshot
 
 
 def test_factory_snapshot_public_mode_rejects_server_managed_fields() -> None:


### PR DESCRIPTION
## Problem

Pre 环境联调:从 available-tc-list 选 architect 模板创建 bot(`POST /openapi/v1/bots`,`engine_properties.template_type="architect"`+完整快照)返回 422 `Invalid coding template`。

根因:#1797 落的工厂分支"混传拒绝"把 `devflow_workflow`/`yuque_kb_repos`/`code_repos` 键视作手填专用键——但 **available-tc-list 的 resolved 快照会把 custom_field 表单值展开在 `template_config` 顶层**(构架师模板的 `architect_name/backend_repo/.../yuque_kb_repos/devflow_workflow`,空值/`null` 也展开),每个带表单字段的真实快照都命中检查。

## Solution

- 删除 `strategy.py` 工厂分支的混传拒绝(`_HANDCRACTED_MIX_REJECT_KEYS` 常量一并移除):两种输入形态由 `template_key`+`template_uid` 双键判定已无歧义,表单同名键随快照 verbatim 透传。
- 回归测试按 pre 实际入参形状重放(空数组/`null` 表单值);guide §1.3/§3/§4 与 spec §5.4 同步更正(前端**不需要**剔除同名的表单键)。

## Validation

- 用户入参最小化重放:修复后 `template_type="architect"` 透传成功(config 与入参逐字一致)。
- `tests/community/core/bot_management` 1030 passed;`test_bots_endpoints.py` 143 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)