### PR TITLE
fix(skill-center): do not block offline on unreadable artifact

### DIFF
--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/frontend-api.md
@@ -453,8 +453,10 @@ Attempt。普通 FAILED 需要修改 Draft 后新建 Attempt。RESULT_UNKNOWN �
 GET .../offline-impact?page=1&page_size=20
 ```
 
-与 publication-impact 不同，下线是硬门禁。存在 Membership、Installation、Draft/Attempt、
-可重放 Service Artifact 或 UNKNOWN_ARTIFACT 时不能继续。
+与 publication-impact 不同，下线对已明确证明的引用是硬门禁：存在 Membership、Installation、
+Draft/Attempt 或可重放 Service Artifact 时不能继续。无法读取、解析或完整扫描 Artifact
+只作为诊断 warning 返回，不阻塞下线；因此历史 offloaded Artifact 的偶发不可读不会让所有
+Skill 永久无法下线。
 
 `data.items[].kind` 的稳定枚举及前端建议文案：
 
@@ -465,7 +467,7 @@ GET .../offline-impact?page=1&page_size=20
 | `MEMBERSHIP` | 普通或 Default SkillSet 仍引用该 Skill |
 | `INSTALLATION` | Bot Effective Installation 仍存在 |
 | `SERVICE_ARTIFACT` | 可重放的 Service Artifact 仍冻结该精确 Version |
-| `UNKNOWN_ARTIFACT` | Artifact 血缘无法完整证明，按安全策略阻断 |
+| `UNKNOWN_ARTIFACT` | Artifact 血缘无法完整证明；只在 `data.warnings` 返回，不阻断 |
 
 `blocked=false` 才启用：
 
@@ -481,6 +483,9 @@ Backend 会重新检查，所以仍可能返回 `SKILL_OFFLINE_BLOCKED`。成功
 - 不调用 SC 外部下线；
 - Owner/Manager 可继续编辑；
 - 发布 Vn+1 成功后恢复 PUBLISHED。
+
+`data.warnings` 是不计入 `total`、`counts` 或 `items` 的诊断信息；产品可以提示“部分历史
+Artifact 无法读取，未发现明确引用，已继续下线”，但不得把 warning 当成 blocker。
 
 409 `code=409313` 的 `data` 会带回最新 OfflineImpact/counts，前端直接用它刷新阻断弹窗；这是
 普通错误 `data=null` 的 route-specific 例外。

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/phase2-openapi-contract.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/phase2-openapi-contract.md
@@ -535,13 +535,15 @@ Query：`page=1&page_size=20`。响应：
 {
   "blocked": true,
   "total": 1,
-  "counts": {"MEMBERSHIP": 1, "INSTALLATION": 0, "SERVICE_ARTIFACT": 0},
-  "items": [{"kind": "MEMBERSHIP", "resource_id": "1115804", "display_name": "基础能力集"}]
+  "counts": {"MEMBERSHIP": 1},
+  "items": [{"kind": "MEMBERSHIP", "resource_id": "1115804", "display_name": "基础能力集"}],
+  "warnings": [{"kind": "UNKNOWN_ARTIFACT", "resource_id": "artifact-scan", "display_name": "Service Artifact lineage is unreadable"}]
 }
 ```
 
-Blocker kind：`DRAFT | PUBLICATION | MEMBERSHIP | INSTALLATION | SERVICE_ARTIFACT |
-UNKNOWN_ARTIFACT`。UNKNOWN 必须 fail closed。
+Blocker kind：`DRAFT | PUBLICATION | MEMBERSHIP | INSTALLATION | SERVICE_ARTIFACT`。
+`UNKNOWN_ARTIFACT` 是 `warnings[]` 中的诊断类别：Artifact 血缘不可读不能证明存在实际引用，
+不计入 `blocked`、`total`、`counts` 或 `items`，也不阻断 Offline。
 
 #### P2-OFF-002 执行 Offline
 

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/product-prd-conformance.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/product-prd-conformance.md
@@ -38,7 +38,7 @@
 | 查看发布影响 | Mock 在“确认升级”时展示 Bot，`CapabilityWorkshop.tsx:1046-1076` | 最终接口为 `publication-impact`，在真正发布前提示；upgrade 仅创建 Draft | **已由产品确认**：PD 后续把影响弹窗从 upgrade 移到 publish confirm |
 | 升级 Vn→Vn+1 | `CapabilityWorkshop.tsx:1046-1076` | 从 exact Published Vn 创建 Vn+1 EDITING Draft | 满足，除影响弹窗时机 |
 | 下线 | Mock 无引用时把 running 改回 draft，`CapabilityWorkshop.tsx:1078-1125` | TeamClaw-local Offline；保留 Published Vn 并创建 Vn+1 Draft，重新发布后上线 | 满足产品意图；前端需避免把历史 Vn 真正改成 Draft |
-| 下线前引用阻断 | 同上，只展示 Bot refs | Offline impact 覆盖 Membership、Installation、Attempt、Artifact、UNKNOWN_ARTIFACT | Backend 更严格且满足安全需求；前端需支持非 Bot blocker 分类/counts |
+| 下线前引用阻断 | 同上，只展示 Bot refs | Offline impact 覆盖 Membership、Installation、Attempt、已证明的 Artifact；不可读 Artifact 以 UNKNOWN_ARTIFACT warning 返回 | 前端需支持非 Bot blocker 分类/counts 和不阻断的 warnings |
 | 删除未发布 Skill/放弃升级 Draft | Draft 卡片“删除”，`CapabilityWorkshop.tsx:762-770` | `DELETE .../draft` 返回 `deleted_scope=SKILL|DRAFT`，FROZEN 拒绝 | 满足 |
 | Team 编辑锁、抢占、关闭释放 | `CapabilityWorkshop.tsx:572-662,742-751,928-947` | 永久 Lease、fencing、acquire/release/takeover，无 TTL | 满足 |
 | 普通成员申请编辑权限 | `CapabilityWorkshop.tsx:554-569,746-760` | `editor-requests` + `SKILL_COLLABORATOR` Work Order | 满足 |
@@ -110,7 +110,7 @@ presentation metadata，不能映射到 `ac_skill.name` 或绕过 Version。
 
 ## 6. 明确不属于缺口的原型差异
 
-- 原型没有超时、并发、幂等、补偿、Task deadline、RESULT_UNKNOWN 和 UNKNOWN_ARTIFACT；这些是
+- 原型没有超时、并发、幂等、补偿、Task deadline、RESULT_UNKNOWN 和 UNKNOWN_ARTIFACT warning；这些是
   Backend 必须补齐的可靠性合同，不需要 Mock 先画出来。
 - 原型把状态压成 `draft/running/offline`；正式 Spec 使用 Asset、Draft、Attempt、Version、
   Offline 分离状态，前端必须映射，不能要求 Backend 把旧 Published Vn 变成 Draft。

--- a/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
+++ b/src/backend/specs/2026-08-20-skill-capability-upgrade/spec.md
@@ -884,7 +884,7 @@ GET impact 供产品预览，POST 必须在事务内锁定 Skill 并重新检查
 | 任意普通/Default Membership，含 inactive/excluded | 是 |
 | Bot Skill Installation | 是 |
 | 存活 Service Bot 仍可 restart/scale/rollback 的 exact Artifact ref | 是 |
-| 无法读取/解析/完整扫描的 Artifact | 是，返回 UNKNOWN_ARTIFACT |
+| 无法读取/解析/完整扫描的 Artifact | 否；作为 `UNKNOWN_ARTIFACT` diagnostic warning 返回，不计入 blocker |
 | Published Version、Canonical Store、Favorite、Grant、Space Binding | 否 |
 | Source Service Bot 已彻底删除，只剩审计 Artifact | 否 |
 

--- a/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/openapi_v1/spaces/schemas.py
@@ -567,7 +567,7 @@ class SpaceSkillDetail(SpaceSkillSummary):
 
 
 class SkillOfflineBlockerKind(_DocumentedEnum):
-    """Reason a Space Skill cannot safely enter recoverable Offline."""
+    """Category for an Offline blocker or a diagnostic warning."""
 
     DRAFT = "DRAFT"
     PUBLICATION = "PUBLICATION"
@@ -582,12 +582,15 @@ class SkillOfflineBlockerKind(_DocumentedEnum):
         "MEMBERSHIP": "An ordinary or Default SkillSet still contains the Skill.",
         "INSTALLATION": "A Bot still has an effective Skill Installation.",
         "SERVICE_ARTIFACT": "A live Service Bot can replay this exact Skill Version.",
-        "UNKNOWN_ARTIFACT": "Artifact lineage could not be proved complete and valid.",
+        "UNKNOWN_ARTIFACT": (
+            "Artifact lineage could not be proved complete and valid; "
+            "returned only as a non-blocking diagnostic warning."
+        ),
     }
 
 
 class SkillOfflineImpactItem(BaseModel):
-    """One live fact that prevents recoverable Offline."""
+    """One explicit blocker or diagnostic warning for recoverable Offline."""
 
     kind: SkillOfflineBlockerKind = Field(
         description="Category of the blocking reference or lifecycle fact."
@@ -597,15 +600,22 @@ class SkillOfflineImpactItem(BaseModel):
 
 
 class SkillOfflineImpact(BaseModel):
-    """Complete blocker counts plus one requested page of blocker details."""
+    """Complete explicit blockers plus diagnostic warnings for recoverable Offline."""
 
     blocked: bool = Field(description="Whether at least one blocker exists.")
-    total: int = Field(ge=0, description="Total blockers across all categories.")
+    total: int = Field(ge=0, description="Total explicit blockers across all categories.")
     counts: dict[str, int] = Field(
-        description="Non-zero blocker totals keyed by blocker category."
+        description="Non-zero explicit blocker totals keyed by blocker category."
     )
     items: list[SkillOfflineImpactItem] = Field(
         description="Requested page of blockers in deterministic order."
+    )
+    warnings: list[SkillOfflineImpactItem] = Field(
+        default_factory=list,
+        description=(
+            "Diagnostic findings that did not prove a live reference and therefore "
+            "do not block Offline."
+        ),
     )
 
 

--- a/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_offline_service.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/services/space_skill_offline_service.py
@@ -41,6 +41,7 @@ _BLOCKER_ORDER = {kind: index for index, kind in enumerate(OfflineBlockerKind)}
 class _OfflineEvaluation:
     identity: OfflineSkillIdentity
     blockers: tuple[OfflineImpactItem, ...]
+    warnings: tuple[OfflineImpactItem, ...] = ()
 
 
 class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
@@ -217,7 +218,8 @@ class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
             )
             for reference in lineage.references
         )
-        blockers.extend(
+        warnings = list(evaluation.warnings)
+        warnings.extend(
             OfflineImpactItem(
                 kind=OfflineBlockerKind.UNKNOWN_ARTIFACT,
                 resource_id=item.resource_id,
@@ -235,7 +237,21 @@ class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
                 ),
             )
         )
-        return _OfflineEvaluation(identity=evaluation.identity, blockers=ordered)
+        ordered_warnings = tuple(
+            sorted(
+                warnings,
+                key=lambda item: (
+                    _BLOCKER_ORDER[item.kind],
+                    item.resource_id,
+                    item.display_name,
+                ),
+            )
+        )
+        return _OfflineEvaluation(
+            identity=evaluation.identity,
+            blockers=ordered,
+            warnings=ordered_warnings,
+        )
 
     @staticmethod
     def _impact(
@@ -251,6 +267,7 @@ class SpaceSkillOfflineService(SpaceSkillOfflineServiceProtocol):
             total=len(blockers),
             counts={kind: count for kind, count in counts.items() if count},
             items=blockers[start : start + page_size],
+            warnings=inspection.warnings,
         )
 
     def _result(

--- a/src/backend/src/agentclaw/community/core/skill_center/space_skill_offline_service_protocol.py
+++ b/src/backend/src/agentclaw/community/core/skill_center/space_skill_offline_service_protocol.py
@@ -30,6 +30,7 @@ class OfflineImpact:
     total: int
     counts: dict[str, int]
     items: tuple[OfflineImpactItem, ...]
+    warnings: tuple[OfflineImpactItem, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/spaces/test_contract.py
@@ -1264,6 +1264,13 @@ def test_offline_impact_and_command_publish_stable_contracts(
                 display_name="基础能力集",
             ),
         ),
+        warnings=(
+            OfflineImpactItem(
+                kind=OfflineBlockerKind.UNKNOWN_ARTIFACT,
+                resource_id="artifact-scan",
+                display_name="Service Artifact lineage is unreadable",
+            ),
+        ),
     )
     skill_offline_service.impact.return_value = impact
     skill_offline_service.offline.return_value = SpaceSkillOfflineResult(
@@ -1294,6 +1301,13 @@ def test_offline_impact_and_command_publish_stable_contracts(
                 "display_name": "基础能力集",
             }
         ],
+        "warnings": [
+            {
+                "kind": "UNKNOWN_ARTIFACT",
+                "resource_id": "artifact-scan",
+                "display_name": "Service Artifact lineage is unreadable",
+            }
+        ],
     }
     assert executed.status_code == 200
     assert executed.json()["data"]["changed"] is True
@@ -1310,18 +1324,18 @@ def test_offline_impact_and_command_publish_stable_contracts(
     )
 
 
-def test_offline_blocked_returns_latest_impact_in_409_data(
+def test_offline_blocked_returns_latest_explicit_impact_in_409_data(
     client, skill_offline_service
 ):
     impact = OfflineImpact(
         blocked=True,
         total=1,
-        counts={"UNKNOWN_ARTIFACT": 1},
+        counts={"SERVICE_ARTIFACT": 1},
         items=(
             OfflineImpactItem(
-                kind=OfflineBlockerKind.UNKNOWN_ARTIFACT,
-                resource_id="artifact-scan",
-                display_name="scan incomplete",
+                kind=OfflineBlockerKind.SERVICE_ARTIFACT,
+                resource_id="123",
+                display_name="Service 123 V1 (Skill 1.0.0)",
             ),
         ),
     )
@@ -1331,7 +1345,7 @@ def test_offline_blocked_returns_latest_impact_in_409_data(
 
     assert response.status_code == 409
     assert response.json()["code"] == 409313
-    assert response.json()["data"]["counts"] == {"UNKNOWN_ARTIFACT": 1}
+    assert response.json()["data"]["counts"] == {"SERVICE_ARTIFACT": 1}
 
 
 def test_upgrade_maps_exact_source_failure_to_sc_unavailable(

--- a/src/backend/tests/community/core/skill_center/services/test_space_skill_offline_service.py
+++ b/src/backend/tests/community/core/skill_center/services/test_space_skill_offline_service.py
@@ -116,7 +116,7 @@ def _service(*, inspection, lineage_result=None):
     return service, access, repository, lineage, drafts, prepared
 
 
-def test_impact_counts_all_blocker_kinds_then_paginates_items():
+def test_impact_counts_explicit_blockers_then_returns_unknown_artifact_as_warning():
     inspection = _inspection(
         identity=_identity(draft=True),
         publication_attempts=(
@@ -155,12 +155,23 @@ def test_impact_counts_all_blocker_kinds_then_paginates_items():
     )
 
     assert impact.blocked is True
-    assert impact.total == 6
-    assert impact.counts == {kind.value: 1 for kind in OfflineBlockerKind}
+    assert impact.total == 5
+    assert impact.counts == {
+        kind.value: 1
+        for kind in OfflineBlockerKind
+        if kind is not OfflineBlockerKind.UNKNOWN_ARTIFACT
+    }
     assert [item.kind for item in impact.items] == [
         OfflineBlockerKind.MEMBERSHIP,
         OfflineBlockerKind.INSTALLATION,
     ]
+    assert impact.warnings == (
+        OfflineImpactItem(
+            kind=OfflineBlockerKind.UNKNOWN_ARTIFACT,
+            resource_id="6",
+            display_name="Unknown artifact",
+        ),
+    )
     access.require_space_member.assert_called_once_with(
         space_id=7, user_id="owner-1"
     )
@@ -202,6 +213,59 @@ def test_offline_idempotent_replay_does_not_prepare_another_revision():
     assert result.draft.revision_id == _EXISTING_REV
     drafts.prepare.assert_not_called()
     repository.commit.assert_not_called()
+
+
+def test_unknown_artifact_warning_does_not_block_offline():
+    service, _access, repository, _lineage, _drafts, _prepared = _service(
+        inspection=_inspection(),
+        lineage_result=ServiceArtifactLineage(
+            references=(),
+            unknown=(
+                UnknownServiceArtifact(
+                    resource_id="artifact-scan",
+                    display_name="Service Artifact lineage is unreadable",
+                ),
+            ),
+        ),
+    )
+
+    result = service.offline(space_id=7, skill_id=51, actor_id="owner-1")
+
+    assert result.changed is True
+    repository.commit.assert_called_once()
+
+
+def test_transaction_recheck_unknown_artifact_warning_does_not_roll_back_offline():
+    service, _access, repository, lineage, _drafts, _prepared = _service(
+        inspection=_inspection()
+    )
+    lineage.scan.side_effect = [
+        ServiceArtifactLineage((), ()),
+        ServiceArtifactLineage(
+            (),
+            (
+                UnknownServiceArtifact(
+                    resource_id="artifact-scan",
+                    display_name="Service Artifact lineage is unreadable",
+                ),
+            ),
+        ),
+    ]
+
+    def _commit(**kwargs):
+        kwargs["guard"](_inspection())
+        return OfflineCommit(
+            changed=True,
+            target_version=3,
+            status="EDITING",
+            locator=kwargs["new_locator"],
+        )
+
+    repository.commit.side_effect = _commit
+
+    result = service.offline(space_id=7, skill_id=51, actor_id="owner-1")
+
+    assert result.changed is True
 
 
 def test_concurrent_blocker_from_transaction_recheck_discards_prepared_revision():

--- a/src/gateway/configs/schemas/bots.openapi.json
+++ b/src/gateway/configs/schemas/bots.openapi.json
@@ -20064,7 +20064,7 @@
         "type": "object"
       },
       "SkillOfflineBlockerKind": {
-        "description": "Reason a Space Skill cannot safely enter recoverable Offline.",
+        "description": "Category for an Offline blocker or a diagnostic warning.",
         "enum": [
           "DRAFT",
           "PUBLICATION",
@@ -20081,7 +20081,7 @@
           "An ordinary or Default SkillSet still contains the Skill.",
           "A Bot still has an effective Skill Installation.",
           "A live Service Bot can replay this exact Skill Version.",
-          "Artifact lineage could not be proved complete and valid."
+          "Artifact lineage could not be proved complete and valid; returned only as a non-blocking diagnostic warning."
         ],
         "x-enum-varnames": [
           "DRAFT",
@@ -20101,7 +20101,7 @@
         ]
       },
       "SkillOfflineImpact": {
-        "description": "Complete blocker counts plus one requested page of blocker details.",
+        "description": "Complete explicit blockers plus diagnostic warnings for recoverable Offline.",
         "properties": {
           "blocked": {
             "description": "Whether at least one blocker exists.",
@@ -20112,7 +20112,7 @@
             "additionalProperties": {
               "type": "integer"
             },
-            "description": "Non-zero blocker totals keyed by blocker category.",
+            "description": "Non-zero explicit blocker totals keyed by blocker category.",
             "title": "Counts",
             "type": "object"
           },
@@ -20125,10 +20125,18 @@
             "type": "array"
           },
           "total": {
-            "description": "Total blockers across all categories.",
+            "description": "Total explicit blockers across all categories.",
             "minimum": 0.0,
             "title": "Total",
             "type": "integer"
+          },
+          "warnings": {
+            "description": "Diagnostic findings that did not prove a live reference and therefore do not block Offline.",
+            "items": {
+              "$ref": "#/components/schemas/SkillOfflineImpactItem"
+            },
+            "title": "Warnings",
+            "type": "array"
           }
         },
         "required": [
@@ -20141,7 +20149,7 @@
         "type": "object"
       },
       "SkillOfflineImpactItem": {
-        "description": "One live fact that prevents recoverable Offline.",
+        "description": "One explicit blocker or diagnostic warning for recoverable Offline.",
         "properties": {
           "display_name": {
             "description": "Human-readable blocker label.",


### PR DESCRIPTION
## 问题
离线影响面扫描读取历史 offloaded Service Artifact 失败时，原实现把 `UNKNOWN_ARTIFACT` 当作 hard blocker，导致没有已证明引用的 Skill 也无法下线。

## 修复
- 明确读取到的 Draft/Attempt/Membership/Installation/Service Artifact 继续阻断。
- `UNKNOWN_ARTIFACT` 改为 `OfflineImpact.warnings`，不计入 `blocked`、`total`、`counts`、`items`。
- 初次检查和事务内二次检查使用同一语义，避免提交阶段回滚。
- 更新 OpenAPI、前端合同与回归测试。

## 验证
- `uv run ruff check ...`
- `uv run pytest tests/community/core/skill_center/services/test_space_skill_offline_service.py tests/community/adapters/http/openapi_v1/spaces/test_contract.py -q`（66 passed）
- 生成并核对 Offline OpenAPI 组件与 Backend 输出一致。