### PR TITLE
feat(backend): expose legacy CLI call-type updates

### DIFF
--- a/src/backend/specs/cli-default-install-identity/005-frontend-interaction.md
+++ b/src/backend/specs/cli-default-install-identity/005-frontend-interaction.md
@@ -90,28 +90,34 @@ X-User-Id: {currentUserId}
 与资源请求同时读取 Caller Context：
 
 ```http
-GET /openapi/v1/bots/{botId}/caller-context?user_id={currentUserId}&owner_id={ownerId}
+GET /api/bots/{botId}/caller-context?ctoken={opaqueCtoken}&stage=draft&entity_id={entityId}
 ```
 
-使用既有 `/openapi/v1` 鉴权客户端。响应中 `mcp_call_types` 与 `cli_call_types` 是同一语义的稀疏 map：键为资源 code，缺少的 key 表示 `owner`。因此每一个已列出的 CLI 均按以下规则得到唯一身份状态：
+预发环境的完整 URL 形态如下，实际值均从当前老平台页面上下文取得：
+
+```text
+https://agentclaw-pre.alipay.com/api/bots/{botId}/caller-context?ctoken={opaqueCtoken}&stage=draft&entity_id={entityId}
+```
+
+使用老平台既有登录态和请求客户端。`ctoken` 是网关追加的兼容参数，前端不得持久化、打印或上报其值；用户身份仍以后端解析到的登录态为准。`entity_id` 从当前 Bot 页面上下文读取，不能由用户自由输入。
+
+该老平台接口直接返回 Caller Context 对象，不使用 OpenAPI envelope。响应中 `mcp_call_types` 与 `cli_call_types` 是同一语义的稀疏 map：键为资源 code，缺少的 key 表示 `owner`。因此每一个已列出的 CLI 均按以下规则得到唯一身份状态：
 
 ```ts
-const identityMode = callerContext.data.cli_call_types[cli.cli_code] ?? 'owner';
+const identityMode = callerContext.cli_call_types[cli.cli_code] ?? 'owner';
 ```
 
 示例：
 
 ```json
 {
-  "code": 200000,
-  "data": {
-    "capability": "caller_identity.v1",
-    "stage": "draft",
-    "bot_call_type": "owner",
-    "mcp_call_types": { "mcp.calendar": "caller" },
-    "cli_call_types": { "dataphin": "caller" },
-    "editable": true
-  }
+  "capability": "caller_identity.v1",
+  "stage": "draft",
+  "publish_id": null,
+  "bot_call_type": "owner",
+  "mcp_call_types": { "mcp.calendar": "caller" },
+  "cli_call_types": { "dataphin": "caller" },
+  "editable": true
 }
 ```
 
@@ -177,31 +183,29 @@ const identityMode = callerContext.data.cli_call_types[cli.cli_code] ?? 'owner';
 次按钮：取消
 ```
 
-### 4.3 写接口
+### 4.3 写接口（老平台兼容路由）
+
+老平台前端期望使用与 MCP caller 配置一致的兼容路径：
 
 ```http
-PATCH /openapi/v1/bots/{botId}/clis/{cliCode}/call-type?user_id={currentUserId}&owner_id={ownerId}
+PATCH /api/bots/{botId}/clis/{cliCode}/call-type?ctoken={opaqueCtoken}&entity_id={entityId}
 Content-Type: application/json
 
 {
-  "call_type": "caller"
+  "call_type": "caller",
+  "lock_epoch": 123
 }
 ```
 
-使用既有 `/openapi/v1` 鉴权客户端。不要向请求 body 添加 `actor_id`、`lock_epoch`、AgentPass token、IAM token 或 CLI 安装参数。
+使用老平台既有登录态和请求客户端。`ctoken`、`entity_id` 和可选 `lock_epoch` 的来源及安全约束与现有 MCP call-type 接口一致：当前 Bot 存在协作编辑锁时必须传入前端已持有的锁版本；没有锁时可省略。后端只从已认证登录态解析操作者；前端不得向请求 body 添加 `actor_id`、AgentPass token、IAM token 或 CLI 安装参数。
 
-成功响应采用 OpenAPI envelope：
+期望成功响应采用老平台直接对象结构：
 
 ```json
 {
-  "code": 200000,
-  "message": "OK",
-  "data": {
-    "cli_code": "dataphin",
-    "call_type": "caller",
-    "bot_call_type": "caller"
-  },
-  "request_id": "..."
+  "cli_code": "dataphin",
+  "call_type": "caller",
+  "bot_call_type": "caller"
 }
 ```
 
@@ -218,7 +222,7 @@ Content-Type: application/json
 | `422` | 请求 body 校验失败 | 记录前端诊断事件，不向用户暴露请求细节；恢复原选择。 |
 | `5xx` / 网络错误 | AgentPass 收敛失败或网络失败；后端会补偿本地 sparse 覆盖 | 提示“保存失败，请稍后重试”，刷新资源列表和 Caller Context 后允许用户手动重试。 |
 
-错误提示中可展示 `request_id` 供排查，但不能展示完整响应、HTTP 请求头、token 或用户身份凭据。
+错误响应若包含 `request_id`，可展示它供排查；不能展示完整响应、HTTP 请求头、`ctoken`、其他 token 或用户身份凭据。
 
 ## 5. 关键前端状态模型
 
@@ -246,7 +250,7 @@ type DefaultCliRow = {
 
 1. Default 能力集包含 CLI 时，正确展示 `cli_name`、`cli_desc`，并由 Caller Context 的 `cli_call_types` 显示身份；非 Default 能力集不显示 CLI 区块。
 2. `dataphin` 和 `deepinsight-cli` 在 AgentPass 已注册时可展示；页面不硬编码或客户端补造它们。
-3. Owner 在 Active 的 `openclaw` 或 `claude_code/generalCC` Bot 中可将 CLI 切为 caller，Bot aggregate 随之变为 caller；最后一个 caller 切回 owner 返回既有 `409 CALLER_TO_OWNER_UNSUPPORTED`，若仍有其它 caller 则允许切回 owner。每次成功后同时刷新资源列表和 Caller Context。
+3. 后端发布老平台 CLI PATCH 兼容路由后，Owner 在 Active 的 `openclaw` 或 `claude_code/generalCC` Bot 中可将 CLI 切为 caller，Bot aggregate 随之变为 caller；最后一个 caller 切回 owner 返回既有 `409 CALLER_TO_OWNER_UNSUPPORTED`，若仍有其它 caller 则允许切回 owner。每次成功后同时刷新资源列表和 Caller Context。
 4. `claude_code/normalCC`、其他引擎、非 service、非 Active 或非 Owner 状态下，UI 只读；即便前端预判遗漏，收到 `409/404` 也能安全回退。
 5. 他人持锁时收到 `423` 后不改本地身份、不自动重试。
 6. Caller Context 读取失败、`cli_call_types` 缺失或值未知时不允许切换；资源接口的 `identity_mode` 不影响选择器。
@@ -258,8 +262,9 @@ type DefaultCliRow = {
 | 目的 | 后端入口 |
 |---|---|
 | Default 能力集资源列表 | `adapters/http/skill_center/skillsets.py:list_skill_set_resources` |
-| MCP / CLI 统一 Caller 状态 | `adapters/http/openapi_v1/caller_identity/router.py:get_caller_context` |
-| CLI 身份切换 HTTP 入口 | `adapters/http/openapi_v1/caller_identity/router.py:update_cli_call_type` |
+| 老平台 MCP / CLI 统一 Caller 状态 | `adapters/http/caller_identity/router.py:get_caller_context`，对应 `GET /api/bots/{bot_id}/caller-context` |
+| 老平台 CLI 身份切换 HTTP 入口 | `adapters/http/caller_identity/router.py:update_cli_call_type`，对应 `PATCH /api/bots/{bot_id}/clis/{cli_code}/call-type` |
+| 现有 CLI 写实现（老平台前端不直连） | `adapters/http/openapi_v1/caller_identity/router.py:update_cli_call_type` |
 | 身份切换领域逻辑和补偿 | `core/caller_identity/service.py:CallerIdentityService.update_cli_call_type` |
 | Default CLI/历史 scope 收敛 | `core/mcp/services/cli_passport_scope.py:CliPassportScopeReconciler` |
 | UI 返回的 CLI 数据结构 | `adapters/http/skill_center/schemas.py:CLIInSetResponse` |

--- a/src/backend/specs/cli-default-install-identity/009-pr-report.md
+++ b/src/backend/specs/cli-default-install-identity/009-pr-report.md
@@ -1,6 +1,6 @@
 ---
 agent: tc-pr
-status: in_progress
+status: complete
 created: 2026-09-01T00:00:00+08:00
 ---
 
@@ -68,3 +68,12 @@ Validation after the fix will rerun the 16 failing gates first, then the affecte
 - Follow-up PR: [#1812](https://github.com/inclusionAI/Avernet/pull/1812), title `feat(backend): expose legacy CLI call-type updates`, head `rebase/legacy-cli-call-type-on-dev`, base `dev`.
 - PR description sections: Problem / Solution / Validation / Compatibility and risk / Spec. Human comments mode: `auto`.
 - Initial remote state: OPEN, review required, no comments or reviews; eight CI checks are queued or in progress and therefore remain `PENDING`.
+
+## Follow-up PR validation result
+
+- CI-validated head: `daf45f66e8eb24740ccbcbdce2e8cdd3d52cf0fe`.
+- All eight GitHub checks passed: Backend unit tests, BCS unit tests, Engine unit tests, BaaS unit tests, Gateway unit tests, Sandbox-proxy unit tests, Singlebox coverage, and BCS E2E.
+- Backend unit tests completed successfully in 17m36s; Singlebox coverage completed successfully in 13m32s.
+- PR #1812 is open, non-draft, and mergeable. GitHub still reports `REVIEW_REQUIRED` because no approval has been submitted.
+- There are no issue comments, inline review comments, or submitted reviews to address.
+- This report-only status update does not change the implementation. Its final PR head is revalidated by the same required GitHub checks after push.

--- a/src/backend/specs/cli-default-install-identity/009-pr-report.md
+++ b/src/backend/specs/cli-default-install-identity/009-pr-report.md
@@ -56,3 +56,12 @@ Validation after the fix will rerun the 16 failing gates first, then the affecte
 
 - GitHub Backend unit tests then found two remaining integration gaps: the generic endpoint runner seeded the CLI happy path without a phase-one engine, and the shared HTTP status-map module exceeded the 1000-line cap after the new CLI mappings.
 - The endpoint seed now explicitly uses `openclaw`; duplicate callback map rows were removed while adding the CLI mappings, returning the module to the cap. The exact generic endpoint case and the oversized-module gate pass locally, along with Ruff and whitespace checks.
+
+## Follow-up: legacy frontend CLI call-type route
+
+- PR #1796 is merged and cannot receive the follow-up change.
+- Source repository: GitHub `inclusionAI/Avernet`; base: `dev`.
+- Scope: expose `PATCH /api/bots/{bot_id}/clis/{cli_code}/call-type` through the authenticated legacy frontend surface, add exact `ctoken` boundary sanitization, response schema, endpoint coverage, and frontend contract documentation.
+- Security boundary: the actor is derived only from the authenticated request context; Bot ownership, CLI authorization, collaboration-lock fencing, persistence, and AgentPass reconciliation remain in the existing Caller Identity service.
+- Local validation: the new route and compatibility middleware passed 9 tests; the related Caller Identity suite passed 64 tests; endpoint coverage gate, Ruff, bytecode compilation, and `git diff --check` passed.
+- Follow-up PR: not created yet. A new topic branch will replay only this follow-up commit onto the latest GitHub `dev` so the already-merged #1796 commits are not duplicated.

--- a/src/backend/specs/cli-default-install-identity/009-pr-report.md
+++ b/src/backend/specs/cli-default-install-identity/009-pr-report.md
@@ -64,4 +64,7 @@ Validation after the fix will rerun the 16 failing gates first, then the affecte
 - Scope: expose `PATCH /api/bots/{bot_id}/clis/{cli_code}/call-type` through the authenticated legacy frontend surface, add exact `ctoken` boundary sanitization, response schema, endpoint coverage, and frontend contract documentation.
 - Security boundary: the actor is derived only from the authenticated request context; Bot ownership, CLI authorization, collaboration-lock fencing, persistence, and AgentPass reconciliation remain in the existing Caller Identity service.
 - Local validation: the new route and compatibility middleware passed 9 tests; the related Caller Identity suite passed 64 tests; endpoint coverage gate, Ruff, bytecode compilation, and `git diff --check` passed.
-- Follow-up PR: not created yet. A new topic branch will replay only this follow-up commit onto the latest GitHub `dev` so the already-merged #1796 commits are not duplicated.
+- Rebase result: branch `rebase/legacy-cli-call-type-on-dev` contains only follow-up commit `c5226bf9b` above GitHub `dev@cb842b314`; the already-merged #1796 commits are not duplicated.
+- Follow-up PR: [#1812](https://github.com/inclusionAI/Avernet/pull/1812), title `feat(backend): expose legacy CLI call-type updates`, head `rebase/legacy-cli-call-type-on-dev`, base `dev`.
+- PR description sections: Problem / Solution / Validation / Compatibility and risk / Spec. Human comments mode: `auto`.
+- Initial remote state: OPEN, review required, no comments or reviews; eight CI checks are queued or in progress and therefore remain `PENDING`.

--- a/src/backend/src/agentclaw/community/adapters/http/caller_identity/router.py
+++ b/src/backend/src/agentclaw/community/adapters/http/caller_identity/router.py
@@ -12,6 +12,7 @@ from agentclaw.community.adapters.http.auth.models import AuthenticatedUser
 from agentclaw.community.adapters.http.caller_identity.schemas import (
     CallerContextQuery,
     CallerContextResponse,
+    UpdateCliCallTypeResponse,
     UpdateMcpCallTypeQuery,
     UpdateMcpCallTypeRequest,
     UpdateMcpCallTypeResponse,
@@ -169,6 +170,80 @@ async def update_mcp_call_type(
         "server_code=%s call_type=%s bot_call_type=%s lock_epoch=%s entity_scoped=%s",
         bot_id,
         response.server_code,
+        response.call_type.value,
+        response.bot_call_type.value,
+        request.lock_epoch,
+        query.entity_id is not None,
+    )
+    return response
+
+
+@router.patch(
+    "/{bot_id}/clis/{cli_code}/call-type",
+    response_model=UpdateCliCallTypeResponse,
+)
+async def update_cli_call_type(
+    bot_id: str,
+    cli_code: str,
+    request: UpdateMcpCallTypeRequest,
+    query: Annotated[UpdateMcpCallTypeQuery, Query()],
+    user: AuthenticatedUser = Depends(get_current_user),
+    service: CallerIdentityServiceProtocol = Injected(CallerIdentityServiceProtocol),
+) -> UpdateCliCallTypeResponse:
+    """Update one authorized draft CLI using the authenticated Bot owner."""
+    logger.info(
+        "cli_call_type_http_update_started bot_id=%s stage=draft "
+        "cli_code=%s call_type=%s lock_epoch=%s entity_scoped=%s",
+        bot_id,
+        cli_code,
+        request.call_type.value,
+        request.lock_epoch,
+        query.entity_id is not None,
+    )
+    # COSEC: the authenticated request context is the only actor source; query
+    # and body values may locate a Bot or select a mode but cannot impersonate it.
+    try:
+        result = await service.update_cli_call_type(
+            bot_id=bot_id,
+            cli_code=cli_code,
+            call_type=request.call_type,
+            actor_id=user.staffId,
+            lock_epoch=request.lock_epoch,
+            entity_id=query.entity_id,
+        )
+    except DomainError:
+        logger.warning(
+            "cli_call_type_http_update_failed bot_id=%s stage=draft "
+            "cli_code=%s call_type=%s lock_epoch=%s entity_scoped=%s",
+            bot_id,
+            cli_code,
+            request.call_type.value,
+            request.lock_epoch,
+            query.entity_id is not None,
+        )
+        raise
+    except Exception:
+        logger.warning(
+            "cli_call_type_http_update_failed bot_id=%s stage=draft "
+            "cli_code=%s call_type=%s lock_epoch=%s entity_scoped=%s",
+            bot_id,
+            cli_code,
+            request.call_type.value,
+            request.lock_epoch,
+            query.entity_id is not None,
+        )
+        # COSEC: suppress untrusted dependency details from the HTTP response.
+        raise InternalError("CALLER_IDENTITY_INTERNAL_ERROR") from None
+    response = UpdateCliCallTypeResponse(
+        cli_code=result.cli_code,
+        call_type=result.call_type,
+        bot_call_type=result.bot_call_type,
+    )
+    logger.info(
+        "cli_call_type_http_update_succeeded bot_id=%s stage=draft "
+        "cli_code=%s call_type=%s bot_call_type=%s lock_epoch=%s entity_scoped=%s",
+        bot_id,
+        response.cli_code,
         response.call_type.value,
         response.bot_call_type.value,
         request.lock_epoch,

--- a/src/backend/src/agentclaw/community/adapters/http/caller_identity/schemas.py
+++ b/src/backend/src/agentclaw/community/adapters/http/caller_identity/schemas.py
@@ -80,9 +80,20 @@ class UpdateMcpCallTypeResponse(BaseModel):
     bot_call_type: McpCallType
 
 
+class UpdateCliCallTypeResponse(BaseModel):
+    """Low-sensitivity result of one draft CLI identity update."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    cli_code: str
+    call_type: McpCallType
+    bot_call_type: McpCallType
+
+
 __all__ = [
     "CallerContextQuery",
     "CallerContextResponse",
+    "UpdateCliCallTypeResponse",
     "UpdateMcpCallTypeQuery",
     "UpdateMcpCallTypeRequest",
     "UpdateMcpCallTypeResponse",

--- a/src/backend/src/agentclaw/community/adapters/http/middleware.py
+++ b/src/backend/src/agentclaw/community/adapters/http/middleware.py
@@ -43,6 +43,7 @@ logger = get_logger()
 _CTOKEN_COMPATIBILITY_PATHS = (
     re.compile(r"^/api/bots/[^/]+/caller-context$"),
     re.compile(r"^/api/bots/[^/]+/mcps/[^/]+/call-type$"),
+    re.compile(r"^/api/bots/[^/]+/clis/[^/]+/call-type$"),
     re.compile(r"^/api/v1/user-lists/(?:check|correct)$"),
 )
 

--- a/src/backend/tests/community/adapters/http/test_compatibility_ctoken_middleware.py
+++ b/src/backend/tests/community/adapters/http/test_compatibility_ctoken_middleware.py
@@ -19,6 +19,7 @@ from agentclaw.community.adapters.http.middleware import (
     [
         "/api/bots/a-bot/caller-context",
         "/api/bots/a-bot/mcps/a-server/call-type",
+        "/api/bots/a-bot/clis/a-cli/call-type",
         "/api/v1/user-lists/check",
         "/api/v1/user-lists/correct",
     ],

--- a/src/backend/tests/community/endpoints/test_caller_identity_router.py
+++ b/src/backend/tests/community/endpoints/test_caller_identity_router.py
@@ -148,8 +148,8 @@ def _seed_openapi_unlocked_mutable_caller_identity(world) -> None:
     _seed_unlocked_mutable_caller_identity(world)
 
 
-def _seed_openapi_unlocked_mutable_cli_caller_identity(world) -> None:
-    _seed_openapi_unlocked_mutable_caller_identity(world)
+def _seed_unlocked_mutable_cli_caller_identity(world) -> None:
+    _seed_unlocked_mutable_caller_identity(world)
     world.get(PassportPlugin).set_response("query_agent_passport", {
         "mcps": [],
         "clis": [{
@@ -159,6 +159,11 @@ def _seed_openapi_unlocked_mutable_cli_caller_identity(world) -> None:
             "identity_mode": "owner",
         }],
     })
+
+
+def _seed_openapi_unlocked_mutable_cli_caller_identity(world) -> None:
+    _enable_openapi_principal()
+    _seed_unlocked_mutable_cli_caller_identity(world)
 
 
 def _seed_openapi_owner(world) -> None:
@@ -389,6 +394,55 @@ def update_mcp_call_type_rejects_unknown_query_parameter():
 )
 def update_mcp_call_type_forbidden():
     """Only an owner of an existing service bot can change MCP call type."""
+
+
+@endpoint_test(
+    method="PATCH",
+    path="/api/bots/{bot_id}/clis/{cli_code}/call-type",
+    scenario="happy",
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID, "cli_code": _CLI_CODE},
+        query_params={
+            "ctoken": "opaque-gateway-compatibility-value",
+            "entity_id": _OWNER_ID,
+        },
+        headers={"x-user-id": _OWNER_ID},
+        json_body={"call_type": "caller"},
+    ),
+    seed=_seed_unlocked_mutable_cli_caller_identity,
+    expect=ExpectSuccess(
+        status=200,
+        json_contains={
+            "cli_code": _CLI_CODE,
+            "call_type": "caller",
+            "bot_call_type": "caller",
+        },
+    ),
+)
+def update_cli_call_type_happy():
+    """The legacy frontend updates an authorized CLI through its existing auth client."""
+
+
+@endpoint_test(
+    method="PATCH",
+    path="/api/bots/{bot_id}/clis/{cli_code}/call-type",
+    scenario="error",
+    input=CaseInput(
+        path_params={
+            "bot_id": "missing_caller_identity_bot",
+            "cli_code": _CLI_CODE,
+        },
+        headers={"x-user-id": _OWNER_ID},
+        json_body={"call_type": "caller"},
+    ),
+    seed=_seed_owner,
+    expect=ExpectError(
+        status=404,
+        json_contains={"detail": "BOT_NOT_FOUND"},
+    ),
+)
+def update_cli_call_type_not_found():
+    """The legacy CLI mutation does not expose an absent or inaccessible Bot."""
 
 
 @endpoint_test(


### PR DESCRIPTION
## Problem

The legacy AgentClaw frontend can read unified MCP and CLI caller identity from `/api/bots/{bot_id}/caller-context`, but it cannot update a CLI identity through the same authenticated compatibility surface. The only existing CLI mutation is under `/openapi/v1`, which the legacy frontend must not call directly.

## Solution

- Add `PATCH /api/bots/{bot_id}/clis/{cli_code}/call-type` with the same strict body and query contract as the legacy MCP mutation.
- Derive the actor only from the authenticated request context and delegate ownership, active CLI, collaboration-lock, persistence, and AgentPass reconciliation checks to the existing Caller Identity service.
- Strip the gateway-appended opaque `ctoken` at the ASGI boundary for the new exact route, and add declarative success/error coverage.
- Update the frontend integration contract with the legacy request and direct response shape.

## Validation

- `uv run pytest tests/community/core/caller_identity/test_service.py tests/community/adapters/http/openapi_v1/test_caller_identity_endpoints.py -q` — 57 passed.
- New legacy CLI route plus compatibility middleware tests — 9 passed.
- `uv run pytest tests/community/framework/test_coverage_gate.py::test_endpoint_coverage_against_baseline -q` — passed.
- Ruff checks for all changed Python files — passed.
- Bytecode compilation and `git diff --check` — passed.

## Compatibility and risk

The OpenAPI CLI route remains unchanged. The new route accepts the same optional `lock_epoch` fencing value as the existing legacy MCP route. Requests still require the authenticated Bot owner and an AgentPass-authorized CLI; no authentication token or actor identity is accepted from the request body.

## Spec

- `src/backend/specs/cli-default-install-identity/005-frontend-interaction.md`
- `src/backend/specs/cli-default-install-identity/009-pr-report.md`
