### PR TITLE
feat(engine): add read-only OpenClaw active-session query API

### DIFF
--- a/src/engine/docs/heterogeneous-engine-architecture.md
+++ b/src/engine/docs/heterogeneous-engine-architecture.md
@@ -4408,6 +4408,27 @@ async def list_registered_engines():
             "engines": manager.get_registered_engines(),
         },
     }
+
+@router.get("/active-sessions")
+async def engine_active_sessions(
+    session_id: str | None = None,
+    agent_id: str | None = None,
+    timeout_seconds: float | None = None,
+):
+    """OpenClaw 只读活跃会话查询，供 BaaS 发布前判断是否存在仍在执行的 session/run。
+
+    返回双轴模型：``query_status`` ∈ {ok, unsupported, timeout, error}，
+    ``verdict`` ∈ {clear, active, unknown}（仅在 query_status=ok 时为 clear/active）。
+    OpenClaw 基于 engine 自有的进程内 active-run 记录实现；未实现该能力的
+    引擎返回 ``query_status=unsupported, verdict=unknown``。该端点只读、不阻塞
+    engine 主链路，查询失败统一降级为 unknown。
+    """
+    manager = EngineManager.get_instance()
+    return await manager.active_sessions_query(
+        session_id=session_id,
+        agent_id=agent_id,
+        timeout=timeout_seconds,
+    )
 ```
 
 ---

--- a/src/engine/src/engine/community/api/engine/router.py
+++ b/src/engine/src/engine/community/api/engine/router.py
@@ -18,7 +18,11 @@ import logging
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
-from engine.community.api.engine.schemas import EngineRestartRequest, EngineSwitchRequest
+from engine.community.api.engine.schemas import (
+    ActiveSessionQueryResponse,
+    EngineRestartRequest,
+    EngineSwitchRequest,
+)
 from engine.community.manager import EngineManager
 
 log = logging.getLogger("engine-web")
@@ -66,6 +70,33 @@ async def list_registered_engines() -> dict:
             "engines": manager.get_registered_engines(),
         },
     }
+
+
+@router.get("/active-sessions")
+async def engine_active_sessions(
+    session_id: str | None = None,
+    agent_id: str | None = None,
+    timeout_seconds: float | None = None,
+) -> ActiveSessionQueryResponse:
+    """Read-only Active Session query for the active engine (M4, doc §18.2).
+
+    Returns the dual-axis model (`query_status` / `verdict`):
+      - `query_status=ok`    → `verdict=clear` (no in-flight runs) or
+                                  `active` (>= 1 in-flight run)
+      - `query_status=unsupported|timeout|error` → `verdict=unknown`
+
+    OpenClaw backs this from its own process-local active-run registry; engines
+    without that surface return `unsupported` rather than failing. This endpoint
+    is read-only and never mutates engine or run state, and it must not block
+    the engine hot path — query failures degrade to `unknown`.
+    """
+    manager = EngineManager.get_instance()
+    result = await manager.active_sessions_query(
+        session_id=session_id,
+        agent_id=agent_id,
+        timeout=timeout_seconds,
+    )
+    return ActiveSessionQueryResponse(**result)
 
 
 @router.post("/switch")

--- a/src/engine/src/engine/community/api/engine/schemas.py
+++ b/src/engine/src/engine/community/api/engine/schemas.py
@@ -1,7 +1,10 @@
 """Engine management router HTTP schemas."""
 from __future__ import annotations
 
-from pydantic import BaseModel
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
 
 
 class EngineSwitchRequest(BaseModel):
@@ -13,4 +16,36 @@ class EngineRestartRequest(BaseModel):
     force: bool = False
 
 
-__all__ = ["EngineSwitchRequest", "EngineRestartRequest"]
+class ActiveSessionEntry(BaseModel):
+    """One active chat run surfaced by the Active Session query."""
+
+    session_id: str
+    run_id: str
+    state: Literal["running", "completed", "failed", "aborted"]
+    started_at: datetime
+    updated_at: datetime
+    agent_id: str | None = None
+
+
+class ActiveSessionQueryResponse(BaseModel):
+    """Response for ``GET /api/engine/active-sessions``.
+
+    ``query_status`` describes the query itself; ``verdict`` is the business
+    conclusion and is only ``clear``/``active`` when ``query_status=ok``.
+    """
+
+    query_status: Literal["ok", "unsupported", "timeout", "error"]
+    verdict: Literal["clear", "active", "unknown"]
+    engine: str
+    checked_at: datetime
+    count: int = 0
+    sessions: list[ActiveSessionEntry] = Field(default_factory=list)
+    reason: str | None = None
+
+
+__all__ = [
+    "EngineSwitchRequest",
+    "EngineRestartRequest",
+    "ActiveSessionEntry",
+    "ActiveSessionQueryResponse",
+]

--- a/src/engine/src/engine/community/core/adapters/openclaw/active_run_registry.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/active_run_registry.py
@@ -1,0 +1,321 @@
+"""OpenClaw active-run registry — process-local runtime state for the
+read-only Active Session query API (OpenClaw engine 侧).
+
+The OpenClaw gateway owns the authoritative run state upstream, but the engine
+itself historically had no readable per-session/per-run "is a run in flight"
+view: ``/api/sessions`` ``status=active`` only marks the session record's
+lifecycle, and ``/api/engine/status`` ``active_connections`` only counts
+WebSocket connections. Neither can prove there is (or isn't) a running chat
+``run``.
+
+Rather than fake a precise verdict from those proxies (or from the
+Claude-Code / AICoding registries, which belong to other engines), this module
+implements OpenClaw's *own* minimal runtime record: an in-process registry of
+chat runs observed through the single OpenClaw chat entry point
+(:class:`~engine.community.core.adapters.openclaw.chat.OpenClawChatAdapter`).
+The registry is updated as a side-channel of the chat stream (register on the
+first frame carrying a ``runId``; mark terminal on ``final`` / ``error`` /
+``aborted`` and in a ``finally`` safety net) and read by the read-only
+``GET /api/engine/active-sessions`` endpoint.
+
+Concurrency: all mutation/reads run inside the single asyncio event loop with
+no internal ``await`` points, so plain dict access is atomic without a lock.
+``query`` is async only so a caller-query timeout can be enforced via
+``asyncio.wait_for`` (maps to ``query_status=timeout`` / ``verdict=unknown``).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+log = logging.getLogger("openclaw-active-run-registry")
+
+# Run lifecycle states the registry records. Only ``running`` counts as
+# "active" for the verdict; the terminal states are retained so the lifecycle
+# tests can confirm a finished run no longer reports as active, then age off
+# via ``max_retained_terminal``.
+RunState = Literal["running", "completed", "failed", "aborted"]
+RUNNING_STATE: RunState = "running"
+_TERMINAL_STATES: frozenset[str] = frozenset({"completed", "failed", "aborted"})
+
+
+@dataclass
+class ActiveRun:
+    """One observed OpenClaw chat run.
+
+    ``session_key`` is the OpenClaw session identifier surfaced as
+    ``session_id`` in the public response (consistent with ``Session.id=key``
+    in the session ACL adapter).
+    """
+
+    run_id: str
+    session_key: str
+    agent_id: str | None
+    state: RunState
+    started_at: datetime
+    updated_at: datetime
+
+
+class ActiveSessionEntry(BaseModel):
+    """Public entry in an Active Session query response."""
+
+    session_id: str
+    run_id: str
+    state: RunState
+    started_at: datetime
+    updated_at: datetime
+    agent_id: str | None = None
+
+
+class ActiveSessionQueryResult(BaseModel):
+    """Public response for ``GET /api/engine/active-sessions``.
+
+    ``query_status`` describes the query itself; ``verdict`` is the business
+    conclusion and is only ``clear``/``active`` when ``query_status=ok``.
+    """
+
+    query_status: Literal["ok", "unsupported", "timeout", "error"]
+    verdict: Literal["clear", "active", "unknown"]
+    engine: str
+    checked_at: datetime
+    count: int
+    sessions: list[ActiveSessionEntry] = Field(default_factory=list)
+    reason: str | None = None
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _ok_result(
+    engine: str,
+    checked_at: datetime,
+    runs: list[ActiveRun],
+    *,
+    reason: str | None = None,
+) -> ActiveSessionQueryResult:
+    entries: list[ActiveSessionEntry] = []
+    if reason is None:
+        entries = [
+            ActiveSessionEntry(
+                session_id=r.session_key,
+                run_id=r.run_id,
+                state=r.state,
+                started_at=r.started_at,
+                updated_at=r.updated_at,
+                agent_id=r.agent_id,
+            )
+            for r in runs
+        ]
+    # When `reason` is set (e.g. incomplete), the raw runs cannot be reliably
+    # associated to sessions, so we do NOT surface them — only the verdict and
+    # reason communicate the degraded state.
+    verdict: Literal["clear", "active", "unknown"]
+    if reason is not None:
+        verdict = "unknown"
+    elif runs:
+        verdict = "active"
+    else:
+        verdict = "clear"
+    return ActiveSessionQueryResult(
+        query_status="ok",
+        verdict=verdict,
+        engine=engine,
+        checked_at=checked_at,
+        count=len(entries),
+        sessions=entries,
+        reason=reason,
+    )
+
+
+class ActiveRunRegistry:
+    """Process-local registry of OpenClaw chat runs.
+
+    Owned by :class:`~engine.community.engines.openclaw.engine.OpenClawEngine`
+    and injected into the chat adapter. Mutations happen inline on the chat
+    hot path with no ``await`` between read and write, so they are atomic
+    under the single-threaded asyncio loop.
+    """
+
+    def __init__(self, max_retained_terminal: int = 256) -> None:
+        self._runs: dict[str, ActiveRun] = {}
+        # Insertion order of terminal runs, for bounded retention so finished
+        # runs don't accumulate without limit.
+        self._terminal_order: list[str] = []
+        self._max_retained_terminal = max(0, max_retained_terminal)
+
+    # ── Mutation surface (called inline by the chat adapter) ──────────────
+
+    def register_run(
+        self,
+        run_id: str,
+        session_key: str,
+        *,
+        agent_id: str | None = None,
+        started_at: datetime | None = None,
+    ) -> None:
+        """Record (or refresh) a run as ``running``.
+
+        Idempotent for the same ``run_id``: a re-register of an already-running
+        run refreshes ``updated_at`` only. Re-registering a terminal run is a
+        no-op (a terminal run must not flip back to running) — this preserves
+        the "finished run is never active again" invariant.
+        """
+        if not run_id or not session_key:
+            return
+        now = started_at or _now()
+        existing = self._runs.get(run_id)
+        if existing is not None:
+            if existing.state != RUNNING_STATE:
+                return
+            existing.updated_at = now
+            existing.agent_id = agent_id or existing.agent_id
+            return
+        self._runs[run_id] = ActiveRun(
+            run_id=run_id,
+            session_key=session_key,
+            agent_id=agent_id,
+            state=RUNNING_STATE,
+            started_at=now,
+            updated_at=now,
+        )
+
+    def mark_terminal(
+        self,
+        run_id: str,
+        state: RunState,
+        *,
+        updated_at: datetime | None = None,
+    ) -> None:
+        """Mark a run terminal (``completed`` / ``failed`` / ``aborted``).
+
+        Silently ignores unknown run ids, non-terminal states, and runs that
+        are *already* terminal (the first terminal state wins, so the loop's
+        explicit terminal frame is not overwritten by the ``finally`` safety
+        net). This lets the chat adapter call this unconditionally from both
+        the streaming loop and its ``finally`` block.
+        """
+        if not run_id or state not in _TERMINAL_STATES:
+            return
+        run = self._runs.get(run_id)
+        if run is None or run.state in _TERMINAL_STATES:
+            return
+        now = updated_at or _now()
+        run.state = state
+        run.updated_at = now
+        self._terminal_order.append(run_id)
+        self._evict_terminal()
+
+    def _evict_terminal(self) -> None:
+        cap = self._max_retained_terminal
+        while len(self._terminal_order) > cap and self._terminal_order:
+            rid = self._terminal_order.pop(0)
+            run = self._runs.get(rid)
+            if run is not None and run.state in _TERMINAL_STATES:
+                del self._runs[rid]
+
+    # ── Read surface (called by the query path) ───────────────────────────
+
+    def snapshot(
+        self,
+        *,
+        session_id: str | None = None,
+        agent_id: str | None = None,
+    ) -> list[ActiveRun]:
+        """Return active (``running``) runs, optionally filtered.
+
+        Filtering is exact-match on ``session_id`` (OpenClaw session key) and
+        ``agent_id``. ``agent_id`` filtering never matches a run whose
+        ``agent_id`` is unset, so querying by agent on the OpenClaw path
+        (which does not populate ``agent_id``) yields an empty result — that
+        is the documented, safe semantics.
+        """
+        out: list[ActiveRun] = []
+        for run in self._runs.values():
+            if run.state != RUNNING_STATE:
+                continue
+            if session_id is not None and run.session_key != session_id:
+                continue
+            if agent_id is not None and run.agent_id != agent_id:
+                continue
+            out.append(run)
+        return out
+
+    async def query(
+        self,
+        *,
+        session_id: str | None = None,
+        agent_id: str | None = None,
+        timeout: float | None = None,
+        engine: str = "openclaw",
+    ) -> ActiveSessionQueryResult:
+        """Build the dual-axis query result.
+
+        ``timeout`` (seconds) bounds the snapshot; exceeding it returns
+        ``query_status=timeout``. Snapshot exceptions return ``error``. A
+        snapshot containing an entry that cannot be associated with a session
+        / run (both identifiers must be non-empty) returns ``unknown`` with
+        ``reason="incomplete"``. Otherwise ``clear`` (no active runs) or
+        ``active`` (>= 1 active run).
+        """
+        checked_at = _now()
+
+        async def _do_snapshot() -> list[ActiveRun]:
+            result = self.snapshot(session_id=session_id, agent_id=agent_id)
+            # ``snapshot`` is synchronous in production; tests (and any future
+            # async source) may return a coroutine, which we await here so the
+            # surrounding ``asyncio.wait_for`` can enforce a real timeout.
+            if asyncio.iscoroutine(result):
+                result = await result  # type: ignore[assignment]
+            return result  # type: ignore[return-value]
+
+        try:
+            if timeout is not None:
+                runs = await asyncio.wait_for(_do_snapshot(), timeout=timeout)
+            else:
+                runs = await _do_snapshot()
+        except asyncio.TimeoutError:
+            return ActiveSessionQueryResult(
+                query_status="timeout",
+                verdict="unknown",
+                engine=engine,
+                checked_at=checked_at,
+                count=0,
+                sessions=[],
+            )
+        except Exception as e:  # pragma: no cover - defensive
+            log.warning("active_sessions query failed: %s", e)
+            return ActiveSessionQueryResult(
+                query_status="error",
+                verdict="unknown",
+                engine=engine,
+                checked_at=checked_at,
+                count=0,
+                sessions=[],
+            )
+
+        if any(not r.run_id or not r.session_key for r in runs):
+            return _ok_result(engine, checked_at, runs, reason="incomplete")
+
+        return _ok_result(engine, checked_at, runs)
+
+    # ── Test/diagnostics helpers ──────────────────────────────────────────
+
+    def all_runs(self) -> list[ActiveRun]:
+        """Return every recorded run regardless of state (tests/diagnostics)."""
+        return list(self._runs.values())
+
+
+__all__ = [
+    "ActiveRun",
+    "ActiveRunRegistry",
+    "ActiveSessionEntry",
+    "ActiveSessionQueryResult",
+    "RunState",
+    "RUNNING_STATE",
+]

--- a/src/engine/src/engine/community/core/adapters/openclaw/active_run_registry.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/active_run_registry.py
@@ -185,6 +185,29 @@ class ActiveRunRegistry:
             updated_at=now,
         )
 
+    def rebind_run(self, old_run_id: str, new_run_id: str) -> bool:
+        """Replace a provisional run id with the gateway-assigned id.
+
+        The adapter registers the idempotency key before entering the stream so
+        silent runs are visible. If a gateway frame later carries a different
+        run id, merge the provisional record instead of exposing two active
+        entries for one execution.
+        """
+        if not old_run_id or not new_run_id or old_run_id == new_run_id:
+            return old_run_id == new_run_id
+        run = self._runs.pop(old_run_id, None)
+        if run is None:
+            return False
+        existing = self._runs.get(new_run_id)
+        if existing is not None:
+            # Keep the record already associated with the gateway id and avoid
+            # manufacturing a duplicate.
+            self._runs[old_run_id] = run
+            return False
+        run.run_id = new_run_id
+        self._runs[new_run_id] = run
+        return True
+
     def mark_terminal(
         self,
         run_id: str,

--- a/src/engine/src/engine/community/core/adapters/openclaw/chat.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/chat.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import uuid
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -148,6 +149,17 @@ class OpenClawChatAdapter(ChatService):
         seen_run_ids: set[str] = set()
         pending_terminal_state: str = "aborted"
 
+        # The gateway acknowledges chat.send with the run id before it may
+        # emit the first event. Use the idempotency key as the provisional run
+        # id (the gateway uses the same value as its expected_run_id), and
+        # register it before entering the port stream so a silent/stalled
+        # upstream run is still visible to active-session queries.
+        tracking_run_id = idempotency_key or uuid.uuid4().hex
+        idempotency_key = tracking_run_id
+        if registry is not None:
+            registry.register_run(tracking_run_id, session_key)
+            seen_run_ids.add(tracking_run_id)
+
         try:
             async for frame in self._port.chat_stream(
                 session_key=session_key,
@@ -207,8 +219,9 @@ class OpenClawChatAdapter(ChatService):
     ) -> None:
         """OpenClaw's own active-run side channel.
 
-        Registers a run on the first frame carrying a non-``inject-`` ``runId``
-        and marks it terminal on the matching ``final`` / ``error`` /
+        The adapter registers a provisional run before entering the port
+        stream; this method reconciles any non-``inject-`` run id observed in
+        frames and marks it terminal on the matching ``final`` / ``error`` /
         ``aborted`` frame. Records every distinct run id in ``seen_run_ids`` so
         the caller's ``finally`` can apply a residual terminal state to any
         still-running run (handles the multi-run-per-stream edge).

--- a/src/engine/src/engine/community/core/adapters/openclaw/chat.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/chat.py
@@ -239,7 +239,17 @@ class OpenClawChatAdapter(ChatService):
             return
 
         if run_id not in seen_run_ids:
-            registry.register_run(run_id, session_key)
+            # The first non-inject frame normally confirms the provisional
+            # idempotency key. If the gateway assigns a different id, merge
+            # the provisional record so one execution is not reported twice.
+            provisional_run_id = next(iter(seen_run_ids), None)
+            if (
+                provisional_run_id is not None
+                and registry.rebind_run(provisional_run_id, run_id)
+            ):
+                seen_run_ids.remove(provisional_run_id)
+            else:
+                registry.register_run(run_id, session_key)
             seen_run_ids.add(run_id)
 
         state = payload.get("state")

--- a/src/engine/src/engine/community/core/adapters/openclaw/chat.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/chat.py
@@ -18,6 +18,7 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
+from engine.community.core.adapters.openclaw.active_run_registry import ActiveRunRegistry
 from engine.community.core.adapters.openclaw.intent_eval_observer import IntentEvalObserver
 from engine.community.core.chat.models import ChatAbortRequest, ChatAbortResult, ChatRequest
 from engine.community.core.chat.protocol import ChatService
@@ -27,12 +28,27 @@ from engine.community.plugin_api.openclaw.chat import OpenClawChatPort
 
 log = logging.getLogger("openclaw-chat-adapter")
 
+# Gateway state → registry terminal state for the active-run side channel.
+# `inject-` run ids are out-of-band injected messages (see gateway_client /
+# port chat_stream) and are never tracked as active runs.
+_TERMINAL_STATE_MAP: dict[str, str] = {
+    "final": "completed",
+    "error": "failed",
+    "aborted": "aborted",
+}
+
 
 class OpenClawChatAdapter(ChatService):
     """`ChatService` over the OpenClaw native port."""
 
-    def __init__(self, port: OpenClawChatPort) -> None:
+    def __init__(
+        self,
+        port: OpenClawChatPort,
+        *,
+        active_run_registry: ActiveRunRegistry | None = None,
+    ) -> None:
         self._port = port
+        self._active_run_registry = active_run_registry
 
     async def inject(
         self,
@@ -118,6 +134,20 @@ class OpenClawChatAdapter(ChatService):
             token=token,
         )
 
+        registry = self._active_run_registry
+        # Residual state applied in `finally` for any run still marked running:
+        #   completed  — stream drained cleanly (observer.finalize ran)
+        #   failed     — transport/runtime exception (except arm)
+        #   aborted    — caller disconnect / cancellation (no except arm)
+        # The first explicit terminal frame already set the state, and
+        # mark_terminal is a no-op on already-terminal runs, so this only
+        # affects streams that ended without a terminal frame. We track every
+        # run id seen on this stream (not just the latest) so a stream that
+        # surfaces multiple distinct run ids does not strand earlier ones as a
+        # persistent false "active".
+        seen_run_ids: set[str] = set()
+        pending_terminal_state: str = "aborted"
+
         try:
             async for frame in self._port.chat_stream(
                 session_key=session_key,
@@ -128,14 +158,18 @@ class OpenClawChatAdapter(ChatService):
                 token=token,
             ):
                 observer.observe(frame)
+                self._track_active_run(
+                    registry, frame, session_key, seen_run_ids
+                )
                 yield frame
 
             # Normal-completion finalize. Sits inside the try block, after the
             # loop, matching legacy chat.py:199. NEVER called on exception paths.
             observer.finalize()
-
+            pending_terminal_state = "completed"
         except ConnectionError as e:
             log.error("[stream] connection error: %s", e)
+            pending_terminal_state = "failed"
             yield EventFrame(
                 event="error",
                 payload={
@@ -146,6 +180,7 @@ class OpenClawChatAdapter(ChatService):
             )
         except Exception as e:
             log.exception("[stream] error: %s: %s", type(e).__name__, e)
+            pending_terminal_state = "failed"
             yield EventFrame(
                 event="error",
                 payload={
@@ -154,6 +189,50 @@ class OpenClawChatAdapter(ChatService):
                     "errorMessage": str(e),
                 },
             )
+        finally:
+            # Safety net: move every run seen on this stream that is still
+            # running to the residual terminal state. mark_terminal is a no-op
+            # on already-terminal runs, so explicit terminal frames set during
+            # the loop are not overwritten.
+            if registry is not None:
+                for rid in seen_run_ids:
+                    registry.mark_terminal(rid, pending_terminal_state)  # type: ignore[arg-type]
+
+    def _track_active_run(
+        self,
+        registry: ActiveRunRegistry | None,
+        frame: EventFrame,
+        session_key: str,
+        seen_run_ids: set[str],
+    ) -> None:
+        """OpenClaw's own active-run side channel.
+
+        Registers a run on the first frame carrying a non-``inject-`` ``runId``
+        and marks it terminal on the matching ``final`` / ``error`` /
+        ``aborted`` frame. Records every distinct run id in ``seen_run_ids`` so
+        the caller's ``finally`` can apply a residual terminal state to any
+        still-running run (handles the multi-run-per-stream edge).
+        apply a residual terminal state in its ``finally``.
+
+        ``inject-`` run ids are out-of-band injected messages, not chat runs,
+        and are deliberately never tracked. No-op when the engine did not wire
+        a registry (e.g. isolated unit tests of the adapter).
+        """
+        if registry is None:
+            return
+        payload = frame.payload or {}
+        run_id = payload.get("runId")
+        if not isinstance(run_id, str) or not run_id or run_id.startswith("inject-"):
+            return
+
+        if run_id not in seen_run_ids:
+            registry.register_run(run_id, session_key)
+            seen_run_ids.add(run_id)
+
+        state = payload.get("state")
+        terminal = _TERMINAL_STATE_MAP.get(state) if isinstance(state, str) else None
+        if terminal is not None:
+            registry.mark_terminal(run_id, terminal)  # type: ignore[arg-type]
 
     async def abort(
         self,

--- a/src/engine/src/engine/community/core/adapters/openclaw/tests/test_active_run_registry.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/tests/test_active_run_registry.py
@@ -26,6 +26,16 @@ def _reg() -> ActiveRunRegistry:
     return ActiveRunRegistry()
 
 
+class TestRunIdentity:
+    def test_rebind_provisional_run_id(self):
+        reg = _reg()
+        reg.register_run("idempotency-key", "session:a:user:u")
+
+        assert reg.rebind_run("idempotency-key", "gateway-run") is True
+        assert [run.run_id for run in reg.all_runs()] == ["gateway-run"]
+        assert reg.snapshot()[0].run_id == "gateway-run"
+
+
 class TestQueryVerdict:
     async def test_empty_returns_ok_clear(self):
         reg = _reg()

--- a/src/engine/src/engine/community/core/adapters/openclaw/tests/test_active_run_registry.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/tests/test_active_run_registry.py
@@ -1,0 +1,193 @@
+"""Unit tests for OpenClaw's process-local ActiveRunRegistry — the dual-axis
+Active Session query model and lifecycle/隔离 semantics.
+
+Covers the behaviour-rule matrix:
+  - empty success → ok/clear
+  - active success → ok/active
+  - query timeout → timeout/unknown
+  - query exception → error/unknown
+  - incomplete result → ok/unknown
+  - terminal run no longer active (completed/failed/aborted)
+  - multi-session / multi-run isolation and session_id/agent_id filtering
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import pytest
+
+from engine.community.core.adapters.openclaw.active_run_registry import (
+    ActiveRunRegistry,
+)
+
+
+def _reg() -> ActiveRunRegistry:
+    return ActiveRunRegistry()
+
+
+class TestQueryVerdict:
+    async def test_empty_returns_ok_clear(self):
+        reg = _reg()
+        r = await reg.query(engine="openclaw")
+        assert r.query_status == "ok"
+        assert r.verdict == "clear"
+        assert r.count == 0
+        assert r.sessions == []
+        assert r.engine == "openclaw"
+
+    async def test_active_run_returns_ok_active(self):
+        reg = _reg()
+        reg.register_run("run-1", "session:a:user:u")
+        r = await reg.query(engine="openclaw")
+        assert r.query_status == "ok"
+        assert r.verdict == "active"
+        assert r.count == 1
+        entry = r.sessions[0]
+        assert entry.session_id == "session:a:user:u"
+        assert entry.run_id == "run-1"
+        assert entry.state == "running"
+        assert isinstance(entry.started_at, datetime)
+        assert isinstance(entry.updated_at, datetime)
+        assert entry.agent_id is None
+
+    async def test_timeout_returns_unknown(self):
+        reg = _reg()
+        reg.register_run("run-1", "session:a:user:u")
+
+        async def _hang(*a, **k):  # noqa: ANN002
+            await asyncio.sleep(30)
+            return []
+
+        reg.snapshot = _hang  # type: ignore[assignment]
+        r = await reg.query(engine="openclaw", timeout=0.01)
+        assert r.query_status == "timeout"
+        assert r.verdict == "unknown"
+        assert r.count == 0
+
+    async def test_error_returns_unknown(self):
+        reg = _reg()
+
+        def _boom(*a, **k):  # noqa: ANN002
+            raise RuntimeError("boom")
+
+        reg.snapshot = _boom  # type: ignore[assignment]
+        r = await reg.query(engine="openclaw")
+        assert r.query_status == "error"
+        assert r.verdict == "unknown"
+
+    async def test_incomplete_returns_unknown(self):
+        reg = _reg()
+        # Directly construct an incomplete record (missing session_key) to
+        # exercise the incomplete-guard path the spec calls out.
+        from engine.community.core.adapters.openclaw.active_run_registry import (
+            ActiveRun,
+            RUNNING_STATE,
+        )
+
+        now = datetime.now(UTC)
+        reg._runs["run-bad"] = ActiveRun(
+            run_id="run-bad",
+            session_key="",  # incomplete: cannot associate to a session
+            agent_id=None,
+            state=RUNNING_STATE,
+            started_at=now,
+            updated_at=now,
+        )
+        r = await reg.query(engine="openclaw")
+        assert r.query_status == "ok"
+        assert r.verdict == "unknown"
+        assert r.reason == "incomplete"
+        # Incomplete runs are NOT surfaced in the response body.
+        assert r.sessions == []
+        assert r.count == 0
+
+
+class TestLifecycle:
+    @pytest.mark.parametrize(
+        "terminal",
+        ["completed", "failed", "aborted"],
+    )
+    async def test_terminal_run_no_longer_active(self, terminal: str):
+        reg = _reg()
+        reg.register_run("run-1", "session:a:user:u")
+        assert (await reg.query()).verdict == "active"
+        reg.mark_terminal("run-1", terminal)  # type: ignore[arg-type]
+        assert (await reg.query()).verdict == "clear"
+        # The record is retained (not active) and reflects the terminal state.
+        assert reg.all_runs()[0].state == terminal
+
+    def test_mark_terminal_is_idempotent_first_state_wins(self):
+        reg = _reg()
+        reg.register_run("run-1", "session:a:user:u")
+        reg.mark_terminal("run-1", "failed")
+        reg.mark_terminal("run-1", "completed")  # must not overwrite a real terminal
+        assert reg.all_runs()[0].state == "failed"
+
+    def test_register_does_not_revive_terminal_run(self):
+        reg = _reg()
+        reg.register_run("run-1", "session:a:user:u")
+        reg.mark_terminal("run-1", "completed")
+        reg.register_run("run-1", "session:a:user:u")
+        assert reg.all_runs()[0].state == "completed"
+        assert reg.snapshot() == []
+
+    def test_register_ignores_empty_identifiers(self):
+        reg = _reg()
+        reg.register_run("", "session:a:user:u")
+        reg.register_run("run-x", "")
+        assert reg.all_runs() == []
+
+    def test_mark_terminal_ignores_unknown_run(self):
+        reg = _reg()
+        reg.mark_terminal("never-registered", "completed")
+        assert reg.all_runs() == []
+
+
+class TestIsolation:
+    def test_multiple_sessions_dont_cross(self):
+        reg = _reg()
+        reg.register_run("run-1", "session:a:user:u")
+        reg.register_run("run-2", "session:b:user:u")
+        all_active = reg.snapshot()
+        assert {r.run_id for r in all_active} == {"run-1", "run-2"}
+
+    def test_filter_by_session_id(self):
+        reg = _reg()
+        reg.register_run("run-1", "session:a:user:u")
+        reg.register_run("run-2", "session:b:user:u")
+        only_a = reg.snapshot(session_id="session:a:user:u")
+        assert [r.run_id for r in only_a] == ["run-1"]
+
+    def test_filter_by_agent_id_exact_match(self):
+        reg = _reg()
+        reg.register_run("run-1", "session:a:user:u", agent_id="agent-7")
+        reg.register_run("run-2", "session:b:user:u", agent_id="agent-9")
+        only_7 = reg.snapshot(agent_id="agent-7")
+        assert [r.run_id for r in only_7] == ["run-1"]
+        # Runs without an agent never match an agent filter.
+        reg.register_run("run-3", "session:c:user:u")
+        assert {r.run_id for r in reg.snapshot(agent_id="agent-7")} == {"run-1"}
+
+    async def test_query_with_session_filter_active_then_clear(self):
+        reg = _reg()
+        reg.register_run("run-1", "session:a:user:u")
+        reg.register_run("run-2", "session:b:user:u")
+        r = await reg.query(session_id="session:a:user:u")
+        assert r.verdict == "active"
+        assert r.count == 1
+        reg.mark_terminal("run-1", "completed")
+        r2 = await reg.query(session_id="session:a:user:u")
+        assert r2.verdict == "clear"
+        # Other session still active when queried unfiltered.
+        assert (await reg.query()).verdict == "active"
+
+
+class TestRetention:
+    def test_terminal_retention_is_bounded(self):
+        reg = ActiveRunRegistry(max_retained_terminal=2)
+        for i in range(5):
+            reg.register_run(f"run-{i}", "session:a:user:u")
+            reg.mark_terminal(f"run-{i}", "completed")
+        # Only the 2 most-recently terminal runs are retained.
+        assert {r.run_id for r in reg.all_runs()} == {"run-3", "run-4"}

--- a/src/engine/src/engine/community/core/adapters/openclaw/tests/test_active_sessions_integration.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/tests/test_active_sessions_integration.py
@@ -1,0 +1,197 @@
+"""Integration tests for the active-run side channel wired into
+`OpenClawChatAdapter.stream`.
+
+Feeds controlled frame sequences through the adapter and asserts OpenClaw's own
+`ActiveRunRegistry` reflects the lifecycle correctly:
+  - register on first non-`inject-` runId frame
+  - terminal on final/error/aborted
+  - finally safety net for transport errors / disconnect
+  - `inject-` frames are never tracked
+  - multi-run / multi-session isolation
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import engine.community.core.adapters.openclaw.chat as chat_mod
+from engine.community.core.adapters.openclaw.active_run_registry import ActiveRunRegistry
+from engine.community.core.adapters.openclaw.chat import OpenClawChatAdapter
+from engine.community.core.chat.models import ChatRequest
+from engine.community.core.engine.context import AuthContext
+from engine.community.kernel.frames import EventFrame
+
+
+# Reuse the fake-port + helpers pattern from test_chat.py but keep this file
+# self-contained so the active-session lifecycle is readable in isolation.
+class _FakePort:
+    def __init__(self, frames: list[EventFrame], raise_on_stream: Exception | None = None):
+        self._frames = frames
+        self._raise = raise_on_stream
+
+    async def chat_stream(self, session_key, message, timeout_ms=None, idempotency_key=None, attachments=None, token=None):
+        if self._raise is not None:
+            raise self._raise
+        for frame in self._frames:
+            yield frame
+
+
+class _FakeAuth:
+    token: str | None = None
+
+
+def _req(session_id: str = "session:a:user:u") -> ChatRequest:
+    return ChatRequest(userId="u", agentId="", query="hi", sessionId=session_id)
+
+
+def _frame(state: str, run_id: str, session_key: str = "session:a:user:u", event: str = "agent") -> EventFrame:
+    return EventFrame(event=event, payload={"state": state, "runId": run_id, "sessionKey": session_key})
+
+
+async def _drain(adapter: OpenClawChatAdapter, req: ChatRequest, auth: AuthContext | None = None) -> list[EventFrame]:
+    out: list[EventFrame] = []
+    async for f in adapter.stream(req, auth=auth):
+        out.append(f)
+    return out
+
+
+@pytest.fixture(autouse=True)
+def _no_intent_eval(monkeypatch):
+    """Disable IntentEvalObserver side effects (mirrors test_chat.py)."""
+    monkeypatch.setattr(chat_mod, "IntentEvalObserver", lambda *a, **k: _NoOpObserver())
+
+
+class _NoOpObserver:
+    def observe(self, frame: EventFrame) -> None:  # noqa: D401
+        return None
+
+    def finalize(self) -> None:
+        return None
+
+
+class TestRegisterAndTerminal:
+    async def test_running_then_final_marks_completed(self):
+        reg = ActiveRunRegistry()
+        port = _FakePort([_frame("delta", "run-1"), _frame("final", "run-1")])
+        adapter = OpenClawChatAdapter(port, active_run_registry=reg)  # type: ignore[arg-type]
+        await _drain(adapter, _req())
+        assert reg.snapshot() == []
+        assert reg.all_runs()[0].state == "completed"
+
+    async def test_error_frame_marks_failed(self):
+        reg = ActiveRunRegistry()
+        port = _FakePort([_frame("delta", "run-1"), _frame("error", "run-1")])
+        adapter = OpenClawChatAdapter(port, active_run_registry=reg)  # type: ignore[arg-type]
+        await _drain(adapter, _req())
+        assert reg.all_runs()[0].state == "failed"
+        assert reg.snapshot() == []
+
+    async def test_aborted_frame_marks_aborted(self):
+        reg = ActiveRunRegistry()
+        port = _FakePort([_frame("delta", "run-1"), _frame("aborted", "run-1")])
+        adapter = OpenClawChatAdapter(port, active_run_registry=reg)  # type: ignore[arg-type]
+        await _drain(adapter, _req())
+        assert reg.all_runs()[0].state == "aborted"
+
+    async def test_mid_stream_active_visible(self):
+        reg = ActiveRunRegistry()
+        port = _FakePort([_frame("delta", "run-1"), _frame("delta", "run-1"), _frame("final", "run-1")])
+        adapter = OpenClawChatAdapter(port, active_run_registry=reg)  # type: ignore[arg-type]
+        gen = adapter.stream(_req())
+        # Advance past the first frame but do NOT drain — the run should now be
+        # registered and visibly active mid-stream.
+        first = await gen.__anext__()
+        assert first.payload["runId"] == "run-1"
+        assert len(reg.snapshot()) == 1
+        assert reg.all_runs()[0].state == "running"
+        # Drain the rest; the final frame terminates the run.
+        async for _ in gen:
+            pass
+        assert reg.snapshot() == []
+        assert reg.all_runs()[0].state == "completed"
+
+
+class TestSafetyNet:
+    async def test_transport_exception_marks_failed(self):
+        reg = ActiveRunRegistry()
+        # First register the run via a delta frame, then the port raises on a
+        # second frame (simulating a mid-stream transport failure).
+        class _RaisePort:
+            async def chat_stream(self, *a, **k):
+                yield _frame("delta", "run-1")
+                raise ConnectionError("upstream gone")
+
+        adapter = OpenClawChatAdapter(_RaisePort(), active_run_registry=reg)  # type: ignore[arg-type]
+        frames = await _drain(adapter, _req())
+        assert any(f.payload.get("state") == "error" for f in frames)
+        assert reg.all_runs()[0].state == "failed"
+        assert reg.snapshot() == []
+
+    async def test_no_registry_is_no_op(self):
+        # Adapter constructed without a registry must behave as before.
+        port = _FakePort([_frame("delta", "run-1"), _frame("final", "run-1")])
+        adapter = OpenClawChatAdapter(port)  # type: ignore[arg-type]
+        frames = await _drain(adapter, _req())
+        assert len(frames) == 2
+
+    async def test_clean_completion_without_terminal_frame_marks_completed(self):
+        reg = ActiveRunRegistry()
+        # Stream drains with only a delta (no explicit final). The finally
+        # safety net must move it to `completed`, not leave it lingering.
+        port = _FakePort([_frame("delta", "run-1")])
+        adapter = OpenClawChatAdapter(port, active_run_registry=reg)  # type: ignore[arg-type]
+        await _drain(adapter, _req())
+        assert reg.all_runs()[0].state == "completed"
+        assert reg.snapshot() == []
+
+
+class TestInjectSkipped:
+    async def test_inject_run_ids_not_tracked(self):
+        reg = ActiveRunRegistry()
+        inject_frame = EventFrame(
+            event="chat", payload={"state": "final", "runId": "inject-xyz", "sessionKey": "session:a:user:u"}
+        )
+        port = _FakePort([inject_frame])
+        adapter = OpenClawChatAdapter(port, active_run_registry=reg)  # type: ignore[arg-type]
+        await _drain(adapter, _req())
+        assert reg.all_runs() == []
+
+
+class TestIsolation:
+    async def test_multi_run_per_stream_does_not_strand(self):
+        # A single stream surfaces two distinct run ids (e.g. a gateway
+        # re-issue mid-stream) and drains cleanly without an explicit terminal
+        # frame. The finally safety net must mark BOTH runs terminal so neither
+        # lingers as a false "active".
+        reg = ActiveRunRegistry()
+
+        class _TwoRunPort:
+            async def chat_stream(self, *a, **k):
+                yield _frame("delta", "run-1", "session:a:user:u")
+                yield _frame("delta", "run-2", "session:a:user:u")
+
+        adapter = OpenClawChatAdapter(_TwoRunPort(), active_run_registry=reg)  # type: ignore[arg-type]
+        await _drain(adapter, _req())
+        runs = {r.run_id: r for r in reg.all_runs()}
+        assert set(runs) == {"run-1", "run-2"}
+        # Neither remains running — both reached a terminal state via finally.
+        assert reg.snapshot() == []
+        assert all(r.state != "running" for r in runs.values())
+
+    async def test_concurrent_runs_do_not_cross(self):
+        reg = ActiveRunRegistry()
+        # Two streams with different run ids / sessions, each finishing.
+        port = _FakePort([_frame("delta", "run-1", "session:a:user:u"), _frame("final", "run-1", "session:a:user:u")])
+        adapter = OpenClawChatAdapter(port, active_run_registry=reg)  # type: ignore[arg-type]
+        await _drain(adapter, _req("session:a:user:u"))
+
+        port2 = _FakePort([_frame("delta", "run-2", "session:b:user:u"), _frame("final", "run-2", "session:b:user:u")])
+        adapter2 = OpenClawChatAdapter(port2, active_run_registry=reg)  # type: ignore[arg-type]
+        await _drain(adapter2, _req("session:b:user:u"))
+
+        runs = {r.run_id: r for r in reg.all_runs()}
+        assert set(runs) == {"run-1", "run-2"}
+        assert runs["run-1"].session_key == "session:a:user:u"
+        assert runs["run-2"].session_key == "session:b:user:u"
+        assert reg.snapshot() == []

--- a/src/engine/src/engine/community/core/adapters/openclaw/tests/test_active_sessions_integration.py
+++ b/src/engine/src/engine/community/core/adapters/openclaw/tests/test_active_sessions_integration.py
@@ -3,7 +3,8 @@
 
 Feeds controlled frame sequences through the adapter and asserts OpenClaw's own
 `ActiveRunRegistry` reflects the lifecycle correctly:
-  - register on first non-`inject-` runId frame
+  - register before the first upstream event and reconcile non-`inject-`
+    runId frames
   - terminal on final/error/aborted
   - finally safety net for transport errors / disconnect
   - `inject-` frames are never tracked
@@ -110,6 +111,43 @@ class TestRegisterAndTerminal:
             pass
         assert reg.snapshot() == []
         assert reg.all_runs()[0].state == "completed"
+
+
+class TestRunRegistrationBeforeFirstEvent:
+    async def test_run_is_active_before_upstream_emits_event(self):
+        """A successful chat start must be visible before the first event.
+
+        OpenClaw can acknowledge ``chat.send`` and then pause before emitting
+        its first event. The active-run query must not report clear during that
+        interval.
+        """
+        import asyncio
+
+        reg = ActiveRunRegistry()
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        class _AckedButSilentPort:
+            async def chat_stream(self, *args, **kwargs):
+                started.set()
+                await release.wait()
+                if False:
+                    yield _frame("delta", "never")
+
+        adapter = OpenClawChatAdapter(
+            _AckedButSilentPort(), active_run_registry=reg
+        )  # type: ignore[arg-type]
+        task = asyncio.create_task(_drain(adapter, _req()))
+        await started.wait()
+        await asyncio.sleep(0)
+
+        result = await reg.query()
+        assert result.verdict == "active"
+        assert result.count == 1
+
+        release.set()
+        await task
+        assert reg.snapshot() == []
 
 
 class TestSafetyNet:

--- a/src/engine/src/engine/community/core/engine/capability.py
+++ b/src/engine/src/engine/community/core/engine/capability.py
@@ -27,6 +27,10 @@ class Capability(Enum):
     SESSION_UPDATE = "session.update"
     SESSION_HISTORY = "session.history"
     SESSION_ARCHIVE = "session.archive"
+    # Read-only active-session / active-run query (OpenClaw engine first).
+    # Surfaces whether the engine currently has in-flight chat runs, with a
+    # clear/active/unknown verdict — see ``GET /api/engine/active-sessions``.
+    SESSION_ACTIVE_QUERY = "session.active_query"
 
     # ── Chat ──
     CHAT_STREAM = "chat.stream"

--- a/src/engine/src/engine/community/engines/openclaw/engine.py
+++ b/src/engine/src/engine/community/engines/openclaw/engine.py
@@ -21,6 +21,10 @@ import logging
 from typing import TYPE_CHECKING
 
 from engine.community.core.adapters.openclaw.approval import OpenClawApprovalAdapter
+from engine.community.core.adapters.openclaw.active_run_registry import (
+    ActiveRunRegistry,
+    ActiveSessionQueryResult,
+)
 from engine.community.core.adapters.openclaw.chat import OpenClawChatAdapter
 from engine.community.core.adapters.openclaw.cron import OpenClawCronAdapter
 from engine.community.core.adapters.openclaw.default_config import OpenClawDefaultConfigAdapter
@@ -69,6 +73,7 @@ class OpenClawEngine(BaseEngine):
             Capability.SESSION_DELETE,
             Capability.SESSION_UPDATE,
             Capability.SESSION_HISTORY,
+            Capability.SESSION_ACTIVE_QUERY,
             # Chat
             Capability.CHAT_STREAM,
             Capability.CHAT_COMPLETE,
@@ -154,12 +159,19 @@ class OpenClawEngine(BaseEngine):
         self._injected_client = client  # None in production; set only by tests
         self._injected_pool = pool  # None in production
 
+        # OpenClaw's own process-local active-run registry, fed as a side
+        # channel by the chat adapter and read by the read-only Active Session
+        # query API (`active_sessions` / `GET /api/engine/active-sessions`).
+        self._active_run_registry = ActiveRunRegistry()
+
         # The single production transport impl shared by every adapter.
         self._port = OpenClawPluginImpl(client=client, pool=pool)
 
         # ACL adapters implementing the core *Service protocols.
         self._session = OpenClawSessionAdapter(self._port)
-        self._chat = OpenClawChatAdapter(self._port)
+        self._chat = OpenClawChatAdapter(
+            self._port, active_run_registry=self._active_run_registry
+        )
         self._cron = OpenClawCronAdapter(self._port)
         self._relay = OpenClawRelayAdapter(self._port)
         self._approval = OpenClawApprovalAdapter(self._port)
@@ -182,6 +194,34 @@ class OpenClawEngine(BaseEngine):
         """Expose the pool so the (still-OpenClaw-specific) WS server can call
         `register` / `release` on handshake / disconnect."""
         return self._port.pool
+
+    @property
+    def active_run_registry(self) -> ActiveRunRegistry:
+        """OpenClaw's own process-local active-run registry (side channel of
+        the chat stream; read by `active_sessions`)."""
+        return self._active_run_registry
+
+    async def active_sessions(
+        self,
+        *,
+        session_id: str | None = None,
+        agent_id: str | None = None,
+        timeout: float | None = None,
+    ) -> ActiveSessionQueryResult:
+        """Read-only Active Session query over OpenClaw's own run registry.
+
+        Implements the dual-axis model (``query_status`` / ``verdict``) for
+        the Active Session query. ``session_id`` matches the OpenClaw session key;
+        ``agent_id`` is exact-match (the OpenClaw chat path does not populate
+        it, so filtering by agent yields ``clear`` — the documented safe
+        semantics). ``timeout`` is seconds; query_status=timeout → unknown.
+        """
+        return await self._active_run_registry.query(
+            session_id=session_id,
+            agent_id=agent_id,
+            timeout=timeout,
+            engine=self.name,
+        )
 
     async def initialize(self) -> None:
         """Best-effort eager connect of the shared gateway client + start the

--- a/src/engine/src/engine/community/engines/openclaw/tests/test_f2_baseline_parity.py
+++ b/src/engine/src/engine/community/engines/openclaw/tests/test_f2_baseline_parity.py
@@ -36,6 +36,7 @@ GOLDEN_SUPPORTED = frozenset({
     Capability.SESSION_DELETE,
     Capability.SESSION_UPDATE,
     Capability.SESSION_HISTORY,
+    Capability.SESSION_ACTIVE_QUERY,
     # Chat
     Capability.CHAT_STREAM,
     Capability.CHAT_COMPLETE,

--- a/src/engine/src/engine/community/manager.py
+++ b/src/engine/src/engine/community/manager.py
@@ -243,6 +243,59 @@ class EngineManager:
             )
         return out
 
+    async def active_sessions_query(
+        self,
+        *,
+        session_id: str | None = None,
+        agent_id: str | None = None,
+        timeout: float | None = None,
+    ) -> dict[str, Any]:
+        """Read-only Active Session query over the active engine.
+
+        Delegates to the active engine's ``active_sessions`` method when it
+        exposes one (OpenClaw does, via its own run registry). Engines without
+        that surface — or no active engine — get a uniform
+        ``query_status=unsupported, verdict=unknown`` result so callers always
+        receive the dual-axis model and never a hard 500 for the capability
+        gap.
+
+        ``timeout`` is seconds (query_status=timeout → unknown).
+        """
+        from datetime import UTC, datetime
+
+        engine = self._active_engine
+        active_sessions = getattr(engine, "active_sessions", None)
+        if engine is None or not callable(active_sessions):
+            return {
+                "query_status": "unsupported",
+                "verdict": "unknown",
+                "engine": self._engine,
+                "checked_at": datetime.now(UTC).isoformat(),
+                "count": 0,
+                "sessions": [],
+                "reason": "active engine does not support active_session query",
+            }
+        try:
+            result = await active_sessions(
+                session_id=session_id,
+                agent_id=agent_id,
+                timeout=timeout,
+            )
+        except Exception as e:
+            log.warning("active_sessions query raised: %s", e)
+            return {
+                "query_status": "error",
+                "verdict": "unknown",
+                "engine": self._engine,
+                "checked_at": datetime.now(UTC).isoformat(),
+                "count": 0,
+                "sessions": [],
+                "reason": str(e),
+            }
+        # ActiveSessionQueryResult is a pydantic model — return its dict form
+        # so the FastAPI route can return it directly.
+        return result.model_dump(mode="json") if hasattr(result, "model_dump") else dict(result)
+
     @property
     def session(self) -> SessionService:
         """Active engine's SessionService."""

--- a/src/engine/src/engine/community/tests/test_engine_active_sessions_router.py
+++ b/src/engine/src/engine/community/tests/test_engine_active_sessions_router.py
@@ -1,0 +1,185 @@
+"""HTTP tests for ``GET /api/engine/active-sessions``.
+
+Covers the dual-axis response model on the route:
+  - active engine exposing ``active_sessions`` → ok/clear | ok/active
+  - active engine WITHOUT the surface → unsupported/unknown
+  - query exception → error/unknown
+  - read-only + non-blocking: the route degrades to ``unknown`` rather than 500,
+    and existing ``/api/engine/status`` behaviour is unchanged.
+
+Mirrors the ``test_engine_router.py`` fixture strategy (construct an
+``EngineManager`` directly and poke it into the singleton).
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from engine.community.core.adapters.openclaw.active_run_registry import (
+    ActiveSessionQueryResult,
+)
+from engine.community.core.engine.base import BaseEngine
+from engine.community.core.engine.capability import Capability, EngineCapabilities
+from engine.community.core.engine.registry import EngineRegistry
+from engine.community.manager import EngineManager
+from engine.community.api.engine import router as engine_router
+
+
+# ── engine fixtures ────────────────────────────────────────────────────────────
+
+
+class _ActiveSessionsEngine(BaseEngine):
+    """Engine that exposes ``active_sessions`` (OpenClaw-like)."""
+
+    name = "with-active"
+    version = "1.0.0"
+
+    _CAPABILITIES = EngineCapabilities(
+        supported={Capability.SESSION_LIST, Capability.CHAT_STREAM, Capability.SESSION_ACTIVE_QUERY}
+    )
+
+    @property
+    def capabilities(self) -> EngineCapabilities:
+        return self._CAPABILITIES
+
+    def __init__(self, config: dict | None = None) -> None:
+        super().__init__(config)
+        self._session = MagicMock()
+        self._chat = MagicMock()
+        self.active_sessions = AsyncMock()
+
+
+class _PlainEngine(BaseEngine):
+    """Engine with no ``active_sessions`` surface (unsupported path)."""
+
+    name = "plain"
+    version = "0.1.0"
+
+    _CAPABILITIES = EngineCapabilities(
+        supported={Capability.SESSION_LIST, Capability.CHAT_STREAM}
+    )
+
+    @property
+    def capabilities(self) -> EngineCapabilities:
+        return self._CAPABILITIES
+
+    def __init__(self, config: dict | None = None) -> None:
+        super().__init__(config)
+        self._session = MagicMock()
+        self._chat = MagicMock()
+
+
+@pytest.fixture
+def registry() -> EngineRegistry:
+    r = EngineRegistry()
+    r.register(_ActiveSessionsEngine)
+    r.register(_PlainEngine)
+    return r
+
+
+@pytest.fixture
+def manager(registry: EngineRegistry):
+    EngineManager.reset_instance()
+    m = EngineManager("with-active", registry=registry)
+    m._active_engine = _ActiveSessionsEngine()
+    EngineManager._instance = m
+    yield m
+    EngineManager.reset_instance()
+
+
+@pytest.fixture
+def client(manager: EngineManager) -> TestClient:
+    app = FastAPI()
+    app.include_router(engine_router)
+    return TestClient(app)
+
+
+def _result(verdict: str, count: int = 0, engine: str = "with-active") -> ActiveSessionQueryResult:
+    from datetime import UTC, datetime
+
+    return ActiveSessionQueryResult(
+        query_status="ok",
+        verdict=verdict,  # type: ignore[arg-type]
+        engine=engine,
+        checked_at=datetime.now(UTC),
+        count=count,
+        sessions=[],
+    )
+
+
+# ── endpoint ──────────────────────────────────────────────────────────────────
+
+
+class TestActiveSessionsEndpoint:
+    def test_clear_when_no_active_runs(self, client: TestClient, manager: EngineManager):
+        manager._active_engine.active_sessions = AsyncMock(return_value=_result("clear"))
+        resp = client.get("/api/engine/active-sessions")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["query_status"] == "ok"
+        assert body["verdict"] == "clear"
+        assert body["engine"] == "with-active"
+        assert body["count"] == 0
+        assert body["sessions"] == []
+        assert "checked_at" in body
+
+    def test_active_when_runs_in_flight(self, client: TestClient, manager: EngineManager):
+        manager._active_engine.active_sessions = AsyncMock(
+            return_value=ActiveSessionQueryResult(
+                query_status="ok",
+                verdict="active",
+                engine="with-active",
+                checked_at="2026-09-01T12:00:00Z",
+                count=1,
+                sessions=[
+                    {
+                        "session_id": "session:a:user:u",
+                        "run_id": "run-1",
+                        "state": "running",
+                        "started_at": "2026-09-01T12:00:00Z",
+                        "updated_at": "2026-09-01T12:00:01Z",
+                        "agent_id": None,
+                    }
+                ],
+            )
+        )
+        resp = client.get("/api/engine/active-sessions")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["verdict"] == "active"
+        assert body["count"] == 1
+        assert body["sessions"][0]["run_id"] == "run-1"
+
+    def test_unsupported_when_engine_lacks_surface(self, client: TestClient, manager: EngineManager):
+        # Swap to an engine without active_sessions.
+        manager._active_engine = _PlainEngine()
+        resp = client.get("/api/engine/active-sessions")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["query_status"] == "unsupported"
+        assert body["verdict"] == "unknown"
+
+    def test_error_when_engine_raises(self, client: TestClient, manager: EngineManager):
+        manager._active_engine.active_sessions = AsyncMock(side_effect=RuntimeError("boom"))
+        resp = client.get("/api/engine/active-sessions")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["query_status"] == "error"
+        assert body["verdict"] == "unknown"
+
+    def test_forwards_query_params(self, client: TestClient, manager: EngineManager):
+        manager._active_engine.active_sessions = AsyncMock(return_value=_result("clear"))
+        client.get("/api/engine/active-sessions?session_id=session:a:user:u&agent_id=agent-7&timeout_seconds=0.5")
+        manager._active_engine.active_sessions.assert_awaited_once()
+        kwargs = manager._active_engine.active_sessions.await_args.kwargs
+        assert kwargs == {"session_id": "session:a:user:u", "agent_id": "agent-7", "timeout": 0.5}
+
+    def test_existing_status_endpoint_unchanged(self, client: TestClient, manager: EngineManager):
+        resp = client.get("/api/engine/status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["engine"] == "with-active"
+        assert "active_connections" in body


### PR DESCRIPTION
## What

Adds a read-only OpenClaw engine endpoint that reports whether any chat run is
currently in flight, so a pre-publish caller can distinguish a truly clear
runtime from an active one instead of inferring it from connection counts or
session-record lifecycle fields.

## Why

The engine had no readable per-session / per-run "is a run executing" view:
`/api/sessions` `status=active` only marks a session record's lifecycle, and
`/api/engine/status` `active_connections` only counts WebSocket connections.
Neither can prove there is (or is not) a running chat `run`, so a safe
publish-time "clear" decision could not be made reliably. Rather than fake a
precise verdict from those proxies, this adds OpenClaw's own minimal runtime
record that tracks chat runs observed through the engine's single chat entry
point.

## Changes

- New `GET /api/engine/active-sessions` read-only endpoint with a dual-axis
  response model:
  - `query_status` ∈ {`ok`, `unsupported`, `timeout`, `error`}
  - `verdict` ∈ {`clear`, `active`, `unknown`} — only `clear`/`active` when
    `query_status=ok`; every other query outcome returns `unknown`
  - optional `session_id`, `agent_id`, `timeout_seconds` query parameters
- New `Capability.SESSION_ACTIVE_QUERY`; OpenClaw declares it. Engines without
  the surface return `query_status=unsupported, verdict=unknown` (HTTP 200,
  not 500).
- New OpenClaw process-local `ActiveRunRegistry` that records chat runs as a
  side channel of `OpenClawChatAdapter.stream`:
  - registers a run on the first frame carrying a non-`inject-` `runId`
  - marks the run terminal on the `final` / `error` / `aborted` frame
  - a `finally` safety net moves any still-running run to a residual terminal
    state (completed / failed / aborted) so a stream that ends without an
    explicit terminal frame never lingers as a false active
- The chat event stream and the `IntentEvalObserver` finalize invariant are
  unchanged — the registry is tracked alongside, never inside, the streamed
  frames.

## Behavior matrix

| Scenario | Response |
|---|---|
| queried, no in-flight runs | `query_status=ok, verdict=clear` |
| queried, >= 1 in-flight run | `query_status=ok, verdict=active` |
| query timeout | `query_status=timeout, verdict=unknown` |
| query exception | `query_status=error, verdict=unknown` |
| engine lacks the capability | `query_status=unsupported, verdict=unknown` |
| incomplete result | `query_status=ok, verdict=unknown` (entries not surfaced) |

## Compatibility

- Pure addition: no existing route, response contract, or persistence shape is
  changed. `/api/engine/status`, `/api/sessions`, switch, restart and the chat
  WebSocket event stream behave exactly as before.
- The registry mutates inline on the asyncio hot path with no `await` between
  read and write, so it cannot block the chat stream.
- Risk is low (read-only endpoint + engine-internal registry).

## Tests

- `ActiveRunRegistry` unit tests: clear / active / timeout / error /
  incomplete, terminal lifecycle (completed/failed/aborted no longer active,
  idempotent terminal, no revive), multi-session / agent-id isolation, bounded
  terminal retention.
- `OpenClawChatAdapter` integration tests: register on first runId, terminal
  on final/error/aborted, transport-exception & clean-completion finally safety
  net, `inject-` frames skipped, multi-run-per-stream does not strand, mid-stream
  active visibility.
- Router tests: clear / active / unsupported / error via FastAPI TestClient,
  query-param forwarding, `/api/engine/status` unchanged.
- Existing OpenClaw engine + F2 baseline parity and ws_server dispatch suites
  remain green.

## Rollback

Revert the commit; the feature is additive and self-contained (no schema
migration, no persistent state).