### PR TITLE
feat(callback): include session_id in HTTP callback payload

### DIFF
--- a/src/baas/src/secbaas/community/core/service/callback/_http_callback.py
+++ b/src/baas/src/secbaas/community/core/service/callback/_http_callback.py
@@ -58,6 +58,7 @@ class HttpCallback:
             return
 
         metadata = record.metadata or {}
+        result_extra = record.result_extra or {}
         url: str | None = metadata.get("callback_url")
         if not url:
             logger.warning("[callback] no callback_url in metadata: run_id=%s", run_id)
@@ -69,7 +70,8 @@ class HttpCallback:
             status=record.status,
             result=record.result_content,
             error=record.error,
-            metadata=record.metadata,
+            metadata=metadata,
+            session_id=result_extra.get("session_id"),
         )
         result = await self._send(url, payload)
         if not result.success:

--- a/src/baas/src/secbaas/community/core/service/callback/_models.py
+++ b/src/baas/src/secbaas/community/core/service/callback/_models.py
@@ -22,6 +22,7 @@ class CallbackPayload:
     result: str | None = None
     error: str | None = None
     metadata: dict[str, Any] | None = None
+    session_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -31,6 +32,7 @@ class CallbackPayload:
             "result": self.result,
             "error": self.error,
             "metadata": self.metadata,
+            "session_id": self.session_id,
         }
 
 

--- a/src/baas/tests/unit/core/service/callback/test_http_callback.py
+++ b/src/baas/tests/unit/core/service/callback/test_http_callback.py
@@ -34,7 +34,7 @@ def _make_record(**overrides):
         "status": "COMPLETED",
         "result_content": "reply",
         "result_content_long": "reply content",
-        "result_extra": {"usage": {"prompt_tokens": 10}},
+        "result_extra": {"session_id": "sess-001", "usage": {"prompt_tokens": 10}},
         "error": None,
         "completed_at": datetime.now(),
     }
@@ -111,6 +111,49 @@ class TestHttpCallbackCall:
         assert payload.result == "reply"
         assert payload.error is None
         assert payload.metadata == {"callback_url": "http://example.com/cb"}
+        assert payload.session_id == "sess-001"
+
+    @pytest.mark.asyncio
+    async def test_session_id_from_result_extra(self):
+        record = _make_record(result_extra={"session_id": "sess-xyz", "other": 1})
+        repo = _make_repo(record=record)
+        cb = HttpCallback(repo)
+        mock_result = CallbackResult(success=True, status_code=200, message="")
+        with patch.object(
+            cb, "_send", new=AsyncMock(return_value=mock_result)
+        ) as mock_send:
+            await cb("run-001")
+
+        payload = mock_send.call_args[0][1]
+        assert payload.session_id == "sess-xyz"
+
+    @pytest.mark.asyncio
+    async def test_session_id_none_when_result_extra_missing_session_id(self):
+        record = _make_record(result_extra={"usage": {"prompt_tokens": 10}})
+        repo = _make_repo(record=record)
+        cb = HttpCallback(repo)
+        mock_result = CallbackResult(success=True, status_code=200, message="")
+        with patch.object(
+            cb, "_send", new=AsyncMock(return_value=mock_result)
+        ) as mock_send:
+            await cb("run-001")
+
+        payload = mock_send.call_args[0][1]
+        assert payload.session_id is None
+
+    @pytest.mark.asyncio
+    async def test_session_id_none_when_result_extra_is_none(self):
+        record = _make_record(result_extra=None)
+        repo = _make_repo(record=record)
+        cb = HttpCallback(repo)
+        mock_result = CallbackResult(success=True, status_code=200, message="")
+        with patch.object(
+            cb, "_send", new=AsyncMock(return_value=mock_result)
+        ) as mock_send:
+            await cb("run-001")
+
+        payload = mock_send.call_args[0][1]
+        assert payload.session_id is None
 
     @pytest.mark.asyncio
     async def test_send_failure_logs_error(self):
@@ -394,6 +437,7 @@ class TestHttpCallbackSendOnce:
             result="done",
             error=None,
             metadata={"key": "val"},
+            session_id="s-1",
         )
         with patch(
             "secbaas.community.core.service.callback._http_callback.httpx.AsyncClient"
@@ -414,6 +458,7 @@ class TestHttpCallbackSendOnce:
         assert body["result"] == "done"
         assert body["error"] is None
         assert body["metadata"] == {"key": "val"}
+        assert body["session_id"] == "s-1"
         assert post_kwargs["headers"]["Content-Type"] == "application/json"
 
     @pytest.mark.asyncio

--- a/src/baas/tests/unit/core/service/callback/test_models.py
+++ b/src/baas/tests/unit/core/service/callback/test_models.py
@@ -15,6 +15,7 @@ class TestCallbackPayload:
             result="done",
             error="err",
             metadata={"key": "val"},
+            session_id="sess-1",
         )
         d = payload.to_dict()
         assert d == {
@@ -24,6 +25,7 @@ class TestCallbackPayload:
             "result": "done",
             "error": "err",
             "metadata": {"key": "val"},
+            "session_id": "sess-1",
         }
 
     def test_to_dict_with_defaults(self):
@@ -35,6 +37,7 @@ class TestCallbackPayload:
         assert d["result"] is None
         assert d["error"] is None
         assert d["metadata"] is None
+        assert d["session_id"] is None
 
     def test_frozen(self):
         payload = CallbackPayload(run_id="r1", bot_id="b1", status="PENDING")


### PR DESCRIPTION
## Problem

The HTTP callback payload sent to `metadata.callback_url` after a bot run
only carried run-level fields (run_id, bot_id, status, result, error,
metadata). Receivers had no way to correlate a callback with the
conversation session that produced the run, even though the session id
is already persisted on the run record.

## Solution

Add an optional `session_id` field to `CallbackPayload`
(`_models.py:25`), serialized by `to_dict()` as `session_id`. In
`HttpCallback.__call__` (`_http_callback.py:74`) the field is populated
from `BotRunRecord.result_extra.session_id`, falling back to `None` when
`result_extra` is absent or has no `session_id` key — consistent with
the existing `or {}` handling for metadata.

Rejected alternative: stuffing `session_id` into `metadata` in the
payload. The run record keeps it under `result_extra`, so mirroring the
source field keeps the payload contract explicit and avoids colliding
with caller-provided metadata keys.

Unit tests now cover all three population paths (present, key missing,
`result_extra` is `None`) plus payload construction and JSON
serialization.

## Validation

- `uv run pytest tests/unit/core/service/callback/ -q` → 31 passed
- Not run: full pre-push CI gates (`OCB_PRE_PUSH_RUN_CI=1`), SAST/lint
  hook, and Singlebox E2E — change is local to the callback service and
  its unit tests; run the module gate before merging.

## Compatibility and risk

Additive wire-contract change: `session_id` is a new top-level key in
the POST body, `null` when unknown. JSON consumers that ignore unknown
fields are unaffected; strict schema validators on the receiving side
should be updated to allow the key. No schema, config, or migration
impact; rollback is a plain revert of the commit.