### PR TITLE
fix(baas-paas): downgrade heartbeat orphan-delete failure log to warning

### DIFF
--- a/src/baas/src/secbaas/community/core/service/paas/_local_paas_service.py
+++ b/src/baas/src/secbaas/community/core/service/paas/_local_paas_service.py
@@ -2115,7 +2115,7 @@ class LocalPaasService(PaasService, LocalPaasServiceProtocol):
                 f"[HEARTBEAT_ORPHAN_DELETED] Successfully deleted orphan: {triple_id}"
             )
         except Exception as e:
-            logger.error(
+            logger.warning(
                 f"[HEARTBEAT_ORPHAN_DELETE_FAILED] Failed to delete orphan {triple_id}: "
                 f"{type(e).__name__}: {e}",
                 exc_info=True,

--- a/src/baas/tests/unit/core/service/paas/test_local_paas_service.py
+++ b/src/baas/tests/unit/core/service/paas/test_local_paas_service.py
@@ -10,6 +10,7 @@ All tests use mocked dependencies to isolate the service under test.
 """
 
 import asyncio
+import logging
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
@@ -5401,7 +5402,7 @@ class TestDestroyOrphanWithLogging:
 
     @pytest.mark.asyncio
     async def test_exception_during_destroy_is_logged(
-        self, local_paas_service, mock_repository
+        self, local_paas_service, mock_repository, caplog
     ):
         """Exception during orphan destruction is caught and logged (lines 1350-1356)."""
         # Setup: make destroy_device fail
@@ -5409,6 +5410,7 @@ class TestDestroyOrphanWithLogging:
 
         # Directly call _destroy_orphan_with_logging - it catches exceptions
         # destroy_device will raise DeviceCreationError because machine not found
+        caplog.set_level(logging.WARNING)
         result = await local_paas_service._destroy_orphan_with_logging(
             paas_device_id="container--machine-001--user-001",
             triple_id="container--machine-001--user-001",
@@ -5416,6 +5418,14 @@ class TestDestroyOrphanWithLogging:
 
         # Should not raise - exception is caught and logged
         assert result is None
+
+        failed_records = [
+            r
+            for r in caplog.records
+            if "[HEARTBEAT_ORPHAN_DELETE_FAILED]" in r.message
+        ]
+        assert len(failed_records) == 1
+        assert failed_records[0].levelno == logging.WARNING
 
 
 class TestHandleHeartbeatContainers:


### PR DESCRIPTION
 Problem

  BaaS receives MNG heartbeat messages carrying payload.bot_list from desktop bots. For each
  reported container, handle_heartbeat_containers checks whether a corresponding device record
  exists; if not, the container is treated as an orphan and a destroy command is fired to the
  desktop mng daemon.

  When the mng process is asleep or the destroy call fails, _destroy_orphan_with_logging logged
  the failure at ERROR level with [HEARTBEAT_ORPHAN_DELETE_FAILED], which lands in
  core-service-error.log and triggers operation alerts.

  This is not an error-level event:

  - Destroy failures leave no DB state behind (the orphan still has no device record).
  - Every subsequent heartbeat with a bot_list re-runs the orphan detection in full, so the
  next heartbeat retries the destroy — a natural retry-until-success loop.
  - If the mng process is permanently offline, BaaS receives no heartbeats at all, so no log
  spam occurs.

  The ERROR alerts are therefore noise.
  
  Solution

  Downgrade the failure log in the except branch of _destroy_orphan_with_logging from
  logger.error to logger.warning (message text and exc_info=True unchanged — the traceback is
  still recorded in the main log, just no longer in the error log).

  Pin the level with a test: added caplog to test_exception_during_destroy_is_logged and
  asserted that exactly one [HEARTBEAT_ORPHAN_DELETE_FAILED] record is emitted at
  logging.WARNING — guarding both directions (record existence and level regression).

  Rejected alternative: keeping ERROR and adding an alerting exemption. Fixing the level at the
  source is cleaner than carrying an exception rule in the ops stack.

  Validation

  - Targeted unit tests: PYTHONPATH=src uv run pytest
  tests/unit/core/service/paas/test_local_paas_service.py -k "DestroyOrphanWithLogging or
  HeartbeatContainers" -v → 9 passed, 232 deselected (Python 3.12.12, pytest 9.1.0).
  - Code review (standard depth, scoped to this diff): clean — 0 critical / 0 warning / 0 info.
  - Not run: full test suite / e2e — left to remote CI per development-phase discipline.
  - Diff surface: 2 files, 14 insertions / 2 deletions; product change is exactly one word
  (error → warning).

  Compatibility and risk (optional)

  - Log-level change only: no contract, schema, config, or migration impact.
  - Alerting based on the [HEARTBEAT_ORPHAN_DELETE_FAILED] marker in the error log will stop
  firing — that is the intent.
  - Rollback path: revert this single commit.