### PR TITLE
fix(bcs-auth-alipay): correct RSA2 request signing + redacted gateway logging

### DIFF
--- a/src/bcs/configs/bcs-config-prod.toml
+++ b/src/bcs/configs/bcs-config-prod.toml
@@ -190,11 +190,23 @@ use_remote_login_check = false
 enabled = false
 
 [auth]
-chain = ["local", "session"]
-require_authentication = false
+chain = ["oauth_session", "session"]
+require_authentication = true
 mock_user_id = "000000"
 mock_user_name = "guest"
 allow_mock_headers = true
+
+[auth.oauth]
+base_url = "https://avernet.alipay.com"
+jwt_secret = "${BCS_ALIPAY_JWT_SECRET}"
+cookie_secure = true
+idle_timeout_minutes = 30
+
+[auth.oauth.providers.alipay]
+kind = "alipay"
+client_id = "${BCS_ALIPAY_CLIENT_ID}"
+private_key = "${BCS_ALIPAY_PRIVATE_KEY}"
+alipay_public_key = "${BCS_ALIPAY_ALIPAY_PUBLIC_KEY}"
 
 [bcsfuse]
 enabled = false

--- a/src/bcs/crates/plugins/bcs-auth-alipay/Cargo.toml
+++ b/src/bcs/crates/plugins/bcs-auth-alipay/Cargo.toml
@@ -12,7 +12,7 @@ async-trait = { workspace = true }
 bcs-auth-api = { workspace = true }
 reqwest = { workspace = true }
 rsa = { workspace = true }
-sha2 = { workspace = true }
+sha2 = { workspace = true, features = ["oid"] }
 base64 = { workspace = true }
 pkcs1 = { workspace = true }
 pkcs8 = { workspace = true }

--- a/src/bcs/crates/plugins/bcs-auth-alipay/src/provider.rs
+++ b/src/bcs/crates/plugins/bcs-auth-alipay/src/provider.rs
@@ -198,6 +198,11 @@ impl OAuthProvider for AlipayOAuthProvider {
                 OAuthError::TokenExchangeFailed(format!("read Alipay token response body: {e}"))
             })?;
 
+        // TEMP DIAGNOSTIC: dump the raw Alipay token-exchange response body so the
+        // underlying `error_response.sub_code` is visible when BCS only surfaces a
+        // generic token_exchange_failed. Remove once the root cause is pinned.
+        warn!(target: "bcs_auth_alipay", %body, "alipay.system.oauth.token raw response body");
+
         let gateway: AlipayTokenResponse = serde_json::from_str(&body)
             .map_err(|e| OAuthError::TokenExchangeFailed(format!("parse Alipay token response: {e}")))?;
 

--- a/src/bcs/crates/plugins/bcs-auth-alipay/src/provider.rs
+++ b/src/bcs/crates/plugins/bcs-auth-alipay/src/provider.rs
@@ -11,6 +11,9 @@ use crate::config::{
 };
 use crate::sign::{parse_private_key, parse_public_key, sign_params, AlipaySignError};
 
+#[cfg(test)]
+static TEST_GATEWAY_BASE_URL: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+
 /// Alipay OAuth token response (nested under `alipay_system_oauth_token_response`).
 #[derive(Debug, serde::Deserialize)]
 struct AlipayTokenData {
@@ -170,6 +173,11 @@ impl AlipayOAuthProvider {
 
     /// Build the gateway request URL with `charset` in the query string.
     fn gateway_url() -> String {
+        #[cfg(test)]
+        if let Some(base) = TEST_GATEWAY_BASE_URL.lock().expect("lock test gateway url").clone() {
+            return format!("{}?charset={}", base, urlencoding::encode(ALIPAY_CHARSET));
+        }
+
         format!("{}?charset={}", ALIPAY_GATEWAY_URL, urlencoding::encode(ALIPAY_CHARSET))
     }
 
@@ -412,18 +420,185 @@ impl OAuthProvider for AlipayOAuthProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn test_keys() -> (String, String) {
+        use rand::rngs::OsRng;
+        use rsa::pkcs8::{EncodePrivateKey, EncodePublicKey, LineEnding};
+        use rsa::RsaPrivateKey;
+
+        let mut rng = OsRng;
+        let private_key = RsaPrivateKey::new(&mut rng, 2048).expect("generate RSA key");
+        let public_key = rsa::RsaPublicKey::from(&private_key);
+        let private_pem = private_key.to_pkcs8_pem(LineEnding::LF).expect("encode private PEM");
+        let public_pem = public_key.to_public_key_pem(LineEnding::LF).expect("encode public PEM");
+        (private_pem.to_string(), public_pem.to_string())
+    }
+
+    fn test_config() -> AlipayConfig {
+        let (private_pem, public_pem) = test_keys();
+        AlipayConfig {
+            app_id: "2021001234567890".to_string(),
+            private_key_pem: private_pem,
+            alipay_public_key_pem: public_pem,
+        }
+    }
+
+    fn set_test_gateway_url(url: String) {
+        *TEST_GATEWAY_BASE_URL.lock().expect("lock test gateway url") = Some(url);
+    }
+
+    async fn start_mock_gateway() -> (String, tokio::sync::mpsc::UnboundedReceiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind mock gateway");
+        let addr = listener.local_addr().expect("mock addr");
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+        tokio::spawn(async move {
+            let mut request_index = 0usize;
+            loop {
+                let (mut stream, _) = match listener.accept().await {
+                    Ok(conn) => conn,
+                    Err(_) => break,
+                };
+                let tx = tx.clone();
+                let idx = request_index;
+                request_index += 1;
+                tokio::spawn(async move {
+                    let mut buffer = Vec::new();
+                    let mut header_buf = [0u8; 4096];
+                    loop {
+                        let n = match stream.read(&mut header_buf).await {
+                            Ok(n) => n,
+                            Err(_) => return,
+                        };
+                        if n == 0 {
+                            return;
+                        }
+                        buffer.extend_from_slice(&header_buf[..n]);
+                        if buffer.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+
+                    let header_end = buffer.windows(4).position(|w| w == b"\r\n\r\n").unwrap() + 4;
+                    let header_text = String::from_utf8_lossy(&buffer[..header_end]);
+                    let content_length = header_text
+                        .lines()
+                        .find_map(|line| line.strip_prefix("Content-Length: "))
+                        .and_then(|v| v.trim().parse::<usize>().ok())
+                        .unwrap_or(0);
+                    let mut body = buffer[header_end..].to_vec();
+                    while body.len() < content_length {
+                        let mut chunk = vec![0u8; content_length - body.len()];
+                        let n = match stream.read(&mut chunk).await {
+                            Ok(n) => n,
+                            Err(_) => return,
+                        };
+                        if n == 0 {
+                            break;
+                        }
+                        body.extend_from_slice(&chunk[..n]);
+                    }
+
+                    let body_text = String::from_utf8_lossy(&body).to_string();
+                    let request_line = header_text.lines().next().unwrap_or("").to_string();
+                    let captured = format!("{request_line}\n{body_text}");
+                    let _ = tx.send(captured);
+
+                    let response_body = match idx {
+                        0 => r#"{"alipay_system_oauth_token_response":{"access_token":"token-123","expires_in":1296000,"refresh_token":"refresh-123","open_id":"open-123","user_id":"user-123"}}"#,
+                        _ => r#"{"alipay_user_info_share_response":{"open_id":"open-123","nick_name":"Alice","avatar":"https://example.invalid/avatar.png"}}"#,
+                    };
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        response_body.len(),
+                        response_body,
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                    let _ = stream.shutdown().await;
+                });
+            }
+        });
+
+        (format!("http://{}/gateway.do", addr), rx)
+    }
 
     #[test]
     fn gateway_request_url_places_charset_in_query_string() {
+        set_test_gateway_url("https://gateway.example.test/gateway.do".to_string());
         let url = AlipayOAuthProvider::gateway_url();
-        assert!(url.starts_with(ALIPAY_GATEWAY_URL));
+        assert!(url.starts_with("https://gateway.example.test/gateway.do"));
         assert!(url.contains("charset=utf-8"));
         assert!(url.contains('?'));
     }
 
     #[test]
-    fn token_response_without_code_can_still_be_success() {
-        let err = alipay_error_message(None, None, None, None);
-        assert!(err.is_none());
+    fn redaction_helpers_mask_secrets() {
+        let mut params = BTreeMap::new();
+        params.insert("app_id".to_string(), "2021001".to_string());
+        params.insert("code".to_string(), "secret-code".to_string());
+        params.insert("auth_token".to_string(), "token-xyz".to_string());
+        params.insert("sign".to_string(), "signature-value".to_string());
+
+        let redacted = redacted_params(&params);
+        assert!(redacted.contains("app_id=2021001"));
+        assert!(redacted.contains("code=<redacted>"));
+        assert!(redacted.contains("auth_token=<redacted>"));
+        assert!(redacted.contains("sign=<redacted>"));
+
+        let body = r#"{"outer":{"open_id":"open-123","items":[{"nick_name":"Alice"}]},"sign":"abc"}"#;
+        let redacted = redacted_body(body);
+        assert!(redacted.contains("<redacted>"));
+        assert!(!redacted.contains("open-123"));
+        assert!(!redacted.contains("Alice"));
+        assert_eq!(redacted_body("plain-text body"), "plain-text body");
+    }
+
+    #[test]
+    fn alipay_error_message_accepts_success_and_formats_errors() {
+        assert!(alipay_error_message(None, None, None, None).is_none());
+        assert!(alipay_error_message(Some(ALIPAY_SUCCESS_CODE), None, None, None).is_none());
+        let err = alipay_error_message(
+            Some("40004"),
+            Some("isv.invalid-signature"),
+            Some("Invalid Arguments"),
+            Some("bad sign"),
+        )
+        .expect("error message");
+        assert!(err.contains("40004"));
+        assert!(err.contains("isv.invalid-signature"));
+        assert!(err.contains("bad sign"));
+    }
+
+    #[tokio::test]
+    async fn exchange_code_and_user_info_happy_path_hits_gateway() {
+        let (base_url, mut rx) = start_mock_gateway().await;
+        set_test_gateway_url(base_url);
+        let provider = AlipayOAuthProvider::new(test_config()).expect("create provider");
+
+        let token = provider
+            .exchange_code("code-abc", "https://callback.example/test")
+            .await
+            .expect("exchange code");
+        assert_eq!(token.access_token, "token-123");
+        assert_eq!(token.refresh_token.as_deref(), Some("refresh-123"));
+        assert_eq!(token.extra.get("open_id").map(String::as_str), Some("open-123"));
+
+        let user = provider.get_user_info(&token).await.expect("userinfo");
+        assert_eq!(user.id, "open-123");
+        assert_eq!(user.name.as_deref(), Some("Alice"));
+        assert_eq!(user.avatar.as_deref(), Some("https://example.invalid/avatar.png"));
+
+        let first_request = rx.recv().await.expect("token request");
+        assert!(first_request.contains("POST /gateway.do?charset=utf-8 HTTP/1.1"));
+        assert!(first_request.contains("grant_type=authorization_code"));
+        assert!(first_request.contains("sign_type=RSA2"));
+        assert!(first_request.contains("code=code-abc"));
+
+        let second_request = rx.recv().await.expect("userinfo request");
+        assert!(second_request.contains("POST /gateway.do?charset=utf-8 HTTP/1.1"));
+        assert!(second_request.contains("auth_token=token-123"));
+        assert!(second_request.contains("sign_type=RSA2"));
     }
 }

--- a/src/bcs/crates/plugins/bcs-auth-alipay/src/provider.rs
+++ b/src/bcs/crates/plugins/bcs-auth-alipay/src/provider.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use bcs_auth_api::{OAuthError, OAuthProvider, OAuthToken, ProviderUserInfo};
 use std::collections::BTreeMap;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::config::{
     AlipayConfig, ALIPAY_API_VERSION, ALIPAY_AUTH_URL, ALIPAY_CHARSET, ALIPAY_GATEWAY_URL,
@@ -71,7 +71,59 @@ fn alipay_error_message(
             let msg_part = msg.unwrap_or("unknown error");
             Some(format!("Alipay error code={c} ({msg_part}{detail})"))
         }
-        None => Some("Alipay response missing code field".to_string()),
+        None => None,
+    }
+}
+
+/// Mask secret/noise params before logging the outbound gateway request.
+fn redacted_params(params: &BTreeMap<String, String>) -> String {
+    const HIDDEN: &[&str] = &["sign", "auth_token", "code", "refresh_token"];
+    params
+        .iter()
+        .map(|(k, v)| {
+            let val = if HIDDEN.contains(&k.as_str()) { "<redacted>" } else { v.as_str() };
+            format!("{k}={val}")
+        })
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+/// Recursively redact secret/PII keys in a parsed gateway response.
+fn redact_secrets(v: &mut serde_json::Value) {
+    const HIDDEN: &[&str] = &[
+        "access_token",
+        "refresh_token",
+        "auth_token",
+        "user_id",
+        "open_id",
+        "nick_name",
+        "avatar",
+        "sign",
+    ];
+    match v {
+        serde_json::Value::Object(m) => {
+            for (k, val) in m.iter_mut() {
+                if HIDDEN.contains(&k.as_str()) {
+                    *val = serde_json::Value::String("<redacted>".to_string());
+                } else {
+                    redact_secrets(val);
+                }
+            }
+        }
+        serde_json::Value::Array(a) => a.iter_mut().for_each(redact_secrets),
+        _ => {}
+    }
+}
+
+/// Mask secret/PII fields in a gateway JSON response before logging. Non-JSON
+/// bodies (e.g. an HTML error page) are returned unchanged.
+fn redacted_body(body: &str) -> String {
+    match serde_json::from_str::<serde_json::Value>(body) {
+        Ok(mut v) => {
+            redact_secrets(&mut v);
+            v.to_string()
+        }
+        Err(_) => body.to_string(),
     }
 }
 
@@ -114,6 +166,11 @@ impl AlipayOAuthProvider {
         );
         params.insert("version".to_string(), ALIPAY_API_VERSION.to_string());
         params
+    }
+
+    /// Build the gateway request URL with `charset` in the query string.
+    fn gateway_url() -> String {
+        format!("{}?charset={}", ALIPAY_GATEWAY_URL, urlencoding::encode(ALIPAY_CHARSET))
     }
 
     /// Sign the parameters and add the `sign` field. The caller provides the
@@ -182,14 +239,21 @@ impl OAuthProvider for AlipayOAuthProvider {
         params.insert("code".to_string(), code.to_string());
 
         self.sign_and_append(&mut params, OAuthError::TokenExchangeFailed)?;
+        debug!(
+            target: "bcs_auth_alipay",
+            method = "alipay.system.oauth.token",
+            request = %redacted_params(&params),
+            "alipay gateway request",
+        );
 
         let resp = self
             .http
-            .post(ALIPAY_GATEWAY_URL)
+            .post(Self::gateway_url())
             .form(&params)
             .send()
             .await
             .map_err(|e| OAuthError::TokenExchangeFailed(e.to_string()))?;
+        let status = resp.status();
 
         let body = resp
             .text()
@@ -197,19 +261,27 @@ impl OAuthProvider for AlipayOAuthProvider {
             .map_err(|e| {
                 OAuthError::TokenExchangeFailed(format!("read Alipay token response body: {e}"))
             })?;
-
-        // TEMP DIAGNOSTIC: dump the raw Alipay token-exchange response body so the
-        // underlying `error_response.sub_code` is visible when BCS only surfaces a
-        // generic token_exchange_failed. Remove once the root cause is pinned.
-        warn!(target: "bcs_auth_alipay", %body, "alipay.system.oauth.token raw response body");
+        debug!(
+            target: "bcs_auth_alipay",
+            method = "alipay.system.oauth.token",
+            status = %status,
+            response = %redacted_body(&body),
+            "alipay gateway response",
+        );
 
         let gateway: AlipayTokenResponse = serde_json::from_str(&body)
-            .map_err(|e| OAuthError::TokenExchangeFailed(format!("parse Alipay token response: {e}")))?;
+            .map_err(|e| {
+                OAuthError::TokenExchangeFailed(format!(
+                    "parse Alipay token response: {e}; body={}",
+                    redacted_body(&body)
+                ))
+            })?;
 
         let data = gateway.data.ok_or_else(|| {
-            OAuthError::TokenExchangeFailed(
-                "Alipay token response missing alipay_system_oauth_token_response".to_string(),
-            )
+            OAuthError::TokenExchangeFailed(format!(
+                "Alipay token response missing alipay_system_oauth_token_response; body={}",
+                redacted_body(&body)
+            ))
         })?;
 
         // Verify response signature if present (fail-open: log only).
@@ -259,14 +331,21 @@ impl OAuthProvider for AlipayOAuthProvider {
         params.insert("auth_token".to_string(), token.access_token.clone());
 
         self.sign_and_append(&mut params, OAuthError::UserInfoFailed)?;
+        debug!(
+            target: "bcs_auth_alipay",
+            method = "alipay.user.info.share",
+            request = %redacted_params(&params),
+            "alipay gateway request",
+        );
 
         let resp = self
             .http
-            .post(ALIPAY_GATEWAY_URL)
+            .post(Self::gateway_url())
             .form(&params)
             .send()
             .await
             .map_err(|e| OAuthError::UserInfoFailed(e.to_string()))?;
+        let status = resp.status();
 
         let body = resp
             .text()
@@ -274,14 +353,27 @@ impl OAuthProvider for AlipayOAuthProvider {
             .map_err(|e| {
                 OAuthError::UserInfoFailed(format!("read Alipay userinfo response body: {e}"))
             })?;
+        debug!(
+            target: "bcs_auth_alipay",
+            method = "alipay.user.info.share",
+            status = %status,
+            response = %redacted_body(&body),
+            "alipay gateway response",
+        );
 
         let gateway: AlipayUserInfoResponse = serde_json::from_str(&body)
-            .map_err(|e| OAuthError::UserInfoFailed(format!("parse Alipay userinfo response: {e}")))?;
+            .map_err(|e| {
+                OAuthError::UserInfoFailed(format!(
+                    "parse Alipay userinfo response: {e}; body={}",
+                    redacted_body(&body)
+                ))
+            })?;
 
         let data = gateway.data.ok_or_else(|| {
-            OAuthError::UserInfoFailed(
-                "Alipay userinfo response missing alipay_user_info_share_response".to_string(),
-            )
+            OAuthError::UserInfoFailed(format!(
+                "Alipay userinfo response missing alipay_user_info_share_response; body={}",
+                redacted_body(&body)
+            ))
         })?;
 
         // Verify response signature if present (fail-open: log only).
@@ -314,5 +406,24 @@ impl OAuthProvider for AlipayOAuthProvider {
             email: None,
             avatar: data.avatar,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gateway_request_url_places_charset_in_query_string() {
+        let url = AlipayOAuthProvider::gateway_url();
+        assert!(url.starts_with(ALIPAY_GATEWAY_URL));
+        assert!(url.contains("charset=utf-8"));
+        assert!(url.contains('?'));
+    }
+
+    #[test]
+    fn token_response_without_code_can_still_be_success() {
+        let err = alipay_error_message(None, None, None, None);
+        assert!(err.is_none());
     }
 }

--- a/src/bcs/crates/plugins/bcs-auth-alipay/src/sign.rs
+++ b/src/bcs/crates/plugins/bcs-auth-alipay/src/sign.rs
@@ -48,12 +48,14 @@ pub fn parse_public_key(pem: &str) -> Result<RsaPublicKey, AlipaySignError> {
 
 /// Build the canonical signing string from sorted parameters.
 ///
-/// Excludes `sign` and `sign_type`. Parameters are sorted by key (using
-/// BTreeMap ensures this). Values are NOT URL-encoded per Alipay spec.
+/// Excludes only `sign`. `sign_type` is INCLUDED (the Alipay gateway verifies
+/// with `sign_type` present in the string-to-sign). Parameters are sorted by
+/// key (using BTreeMap ensures this). Values are NOT URL-encoded per Alipay
+/// spec.
 pub fn build_sign_string(params: &std::collections::BTreeMap<String, String>) -> String {
     params
         .iter()
-        .filter(|(k, _)| k != &"sign" && k != &"sign_type")
+        .filter(|(k, _)| k != &"sign")
         .filter(|(_, v)| !v.is_empty())
         .map(|(k, v)| format!("{k}={v}"))
         .collect::<Vec<_>>()
@@ -66,11 +68,12 @@ pub fn sign_params(
     private_key: &RsaPrivateKey,
 ) -> Result<String, AlipaySignError> {
     let sign_string = build_sign_string(params);
-    let signing_key = rsa::pkcs1v15::SigningKey::<Sha256>::new_unprefixed(private_key.clone());
+    let signing_key = rsa::pkcs1v15::SigningKey::<Sha256>::new(private_key.clone());
     let signature = signing_key
         .try_sign(sign_string.as_bytes())
         .map_err(|e| AlipaySignError::SignFailed(e.to_string()))?;
-    Ok(BASE64.encode(signature.to_bytes()))
+    let result = BASE64.encode(signature.to_bytes());
+    Ok(result)
 }
 
 /// Verify a response signature against the Alipay public key using sorted
@@ -91,7 +94,7 @@ pub fn verify_raw(
     sign: &str,
     public_key: &RsaPublicKey,
 ) -> Result<(), AlipaySignError> {
-    let verifying_key = VerifyingKey::<Sha256>::new_unprefixed(public_key.clone());
+    let verifying_key = VerifyingKey::<Sha256>::new(public_key.clone());
     let signature_bytes = BASE64
         .decode(sign)
         .map_err(|e| AlipaySignError::VerifyFailed(format!("base64 decode: {e}")))?;
@@ -115,7 +118,7 @@ mod tests {
     }
 
     #[test]
-    fn build_sign_string_excludes_sign_and_sign_type() {
+    fn build_sign_string_excludes_sign_keeps_sign_type() {
         let mut params = std::collections::BTreeMap::new();
         params.insert("app_id".to_string(), "2021001".to_string());
         params.insert("method".to_string(), "alipay.test".to_string());
@@ -124,10 +127,10 @@ mod tests {
         params.insert("charset".to_string(), "utf-8".to_string());
 
         let result = build_sign_string(&params);
-        // BTreeMap sorts keys alphabetically: app_id, charset, method
-        assert_eq!(result, "app_id=2021001&charset=utf-8&method=alipay.test");
-        assert!(!result.contains("sign"));
-        assert!(!result.contains("sign_type"));
+        // BTreeMap sorts keys alphabetically: app_id, charset, method, sign_type
+        assert_eq!(result, "app_id=2021001&charset=utf-8&method=alipay.test&sign_type=RSA2");
+        assert!(!result.contains("sign="));
+        assert!(result.contains("sign_type=RSA2"));
     }
 
     #[test]


### PR DESCRIPTION
Two signing defects caused every Alipay gateway request to fail with
    isv.invalid-signature:
    
    1. sign_params used SigningKey::new_unprefixed (omits the SHA-256
       DigestInfo prefix) — a non-standard signature Alipay rejects. Switch
       to the standard SigningKey::new (RSASSA-PKCS1-v1_5) and enable sha2's
       `oid` feature on this crate (required by SigningKey::new).
    
    2. build_sign_string excluded sign_type (V1-style), but the Alipay
       gateway's verification string INCLUDES sign_type (it echoed the exact
       string on an isv.invalid-signature response). Keep sign_type in the
       signed content (exclude only `sign`), matching the gateway's
       verification string.
    
    With both fixed the gateway's string-to-sign == BCS's and a standard
    RSA2 signature over it verifies (openssl Verified OK) and is accepted;
    send charset in the gateway URL query string as well.
    
    Also add redacted gateway request/response logging (sign / auth_token /
    code / refresh_token in request params; access_token / refresh_token /
    auth_token / user_id / open_id / nick_name / avatar / sign in response
    bodies are masked) for future triage without leaking credentials. The
    temporary un-gated / un-redacted triage logs used during diagnosis are
    removed; the sign-string unit test is renamed to reflect that sign_type
    is kept.