### PR TITLE
fix(backend): use BCSFuse worker lifecycle routes

### DIFF
--- a/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_public/services/bot_public_service.py
@@ -397,7 +397,7 @@ class BotPublicService(BotPublicServiceProtocol):
             return
 
         runtime_state = "online" if public == "1" else "offline"
-        url = f"{base_url}/api/v1/workers/{bot_id}/{runtime_state}"
+        url = f"{base_url}/v1/workers/{bot_id}/{runtime_state}"
         request = Request(url, data=b"", method="PUT")
         request.add_header("Content-Type", "application/json")
 

--- a/src/backend/tests/community/core/bot_public/test_bot_public_service.py
+++ b/src/backend/tests/community/core/bot_public/test_bot_public_service.py
@@ -763,7 +763,7 @@ class TestPublicBotBCSFuseSync:
 
         assert result["public"] == "1"
         request = mock_urlopen.call_args.args[0]
-        assert request.full_url == "http://bcsfuse.test/api/v1/workers/bot1/online"
+        assert request.full_url == "http://bcsfuse.test/v1/workers/bot1/online"
         assert request.get_method() == "PUT"
         mock_sync_rel.assert_called_once_with("bot1", "owner1", "OPEN", "1")
 
@@ -786,7 +786,7 @@ class TestPublicBotBCSFuseSync:
 
         assert result["public"] == "0"
         request = mock_urlopen.call_args.args[0]
-        assert request.full_url == "http://bcsfuse.test/api/v1/workers/bot1/offline"
+        assert request.full_url == "http://bcsfuse.test/v1/workers/bot1/offline"
         assert request.get_method() == "PUT"
         mock_sync_rel.assert_called_once_with("bot1", "owner1", "RESTRICTED", "0")
 
@@ -1021,7 +1021,7 @@ class TestHandlePublicApprovalCallback:
 
         assert result["success"] is True
         request = mock_urlopen.call_args.args[0]
-        assert request.full_url == "http://bcsfuse.test/api/v1/workers/bot1/online"
+        assert request.full_url == "http://bcsfuse.test/v1/workers/bot1/online"
 
     def test_agree_bcsfuse_failure_does_not_block_callback(self):
         bot_repo = MagicMock()


### PR DESCRIPTION
## Problem

Bot public and unpublish flows attempted to update BCSFuse runtime state through `/api/v1/workers/{bot_id}/online|offline`. The production OCB BCSFuse application mounts worker lifecycle endpoints under `/v1`, while `/api/v1` is used by recommendation and fusion endpoints.

As a result, lifecycle synchronization returned 404 and was ignored by the existing best-effort error handling, leaving the BCSFuse runtime state unchanged.

## Solution

- Change BCSFuse runtime-state synchronization to call `/v1/workers/{bot_id}/online` and `/v1/workers/{bot_id}/offline`.
- Update direct publish, unpublish, and approval-callback regression expectations to match the production OCB route contract.

## Validation

- `uv run pytest tests/community/core/bot_public/test_bot_public_service.py -q` — 138 passed.
- Python SAST checks passed for both changed files.
- Repository pre-push lint-only gate passed against `origin/dev`.
- `git diff --check` passed.

## Compatibility and risk

This change does not alter Backend or BCSFuse schemas. It aligns the Backend client with the existing production OCB BCSFuse worker lifecycle routes. Rollback is limited to reverting this commit.