### PR TITLE
feat(w6): materialise manifest resources through the one write chain

### DIFF
--- a/docs/superpowers/plans/2026-09-02-bot-config-manifest-w6-resources.md
+++ b/docs/superpowers/plans/2026-09-02-bot-config-manifest-w6-resources.md
@@ -1,0 +1,1118 @@
+# W6 — manifest `resources`:文件与目录 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 `POST /openapi/v1/bots/{bot_id}/config-manifest/apply` 物化 `manifest.resources` 类目:文件条目写到 workspace 相对 path,目录条目按归档整体替换(path 树内含手工文件),两引擎系共用 `ResourceFileService` 一条链。
+
+**Architecture:** 一个 `ResourcesMaterialiser` 挂进既有 registry(callback 三段式 resolve→plan→write);fetch 走 W2/W11 的 `EntryFetcher` 漏斗(与 skills 同款 to_thread 调用);目录归档经 guarded unpacker(限额 keys 已注册)在**平台侧临时目录**解包后逐文件展开——"每次 apply 整体替换"与"读写不走 artifact"由构造保证。区域记账 v1 = 每条目自治(树替换语义),跨条目 `removals` 为空(与 W6 验收原文一致,验收只定义了树内所有权)。
+
+**Tech Stack:** Python 3.12 / pytest / 既有 materialiser 三段式协议(`apply/registry.py`)/ `ResourceFileService`(`core/services/resource_file_service.py`)。
+
+**分支:** `feat/bot-config-manifest-w6-arc`,基于 `origin/feat/bot-config-manifest-w5-dev`(W5 tip `28507ac43`;W5 PR #1795 合入后 rebase 上 dev)。**开工前必 `git fetch origin`,若 W5 分支前进了,先 `git rebase origin/feat/bot-config-manifest-w5-dev`。**
+
+**权威 spec:** `src/backend/docs/bot-config-manifest/work-items.zh-CN.md` 的 `#### W6` 小节(§5 工作项);`docs/superpowers/specs/2026-08-31-bot-config-manifest-design.md` §resources。
+
+**测试跑法(全部在 `/Users/rongzhi/PycharmProjects/Avernet/src/backend` 下):**
+- 单文件:`uv run pytest tests/community/core/bot_config_manifest -v`
+- 全量 gate:`cd ../../ && bash src/backend/scripts/ci_test.sh`(推 PR 前必跑)
+- 本分支 push 前 `AVERNET_PRE_PUSH_MERGE_TARGET=origin/feat/bot-config-manifest-w5-dev`
+
+**执行约定(用户已拍板):** 每 Task 实现+测试,全部完成后一次批量终审;W5 分支 rebase 冲突时优先保留 W5 侧的行号邻域。
+
+**已核实的关键事实(subagent 直接用,勿再考古):**
+
+- `Materialiser` 三段式协议在 `apply/registry.py:107-157`:`resolve(ctx, entries)->ResolveResult`、`plan(ctx, intents)->CategoryPlan`、`write(ctx, plan)->Sequence[EntryResult]`;`construct: ApplyConstruct` 是类属性。`ResolveResult`/`CategoryPlan`/`PlannedEntry`/`Intent` 同文件已定义。
+- `EntryFetcher.fetch(ctx, *, source_url, digest, auth, category, keep_last, entry_identity)` 是**同步方法**,在 materialiser 里用 `await asyncio.to_thread(...)` 包(照 `skills.py:228-238` 原样),抛 `EntryFetchError`(reason 字符串),返回 `FetchedEntry`(`entry_fetch.py:88`: `content: bytes, digest, from_store, content_type`)。
+- `unpack_archive(archive: bytes, kind, dest: Path, *, strip_components=0, member_limit=..., unpacked_size_limit=FETCH_ENTRY_LIMITS["resources_unpacked"]) -> UnpackedTree`(`fetch/unpack.py:186`),拒绝时抛 `UnpackError`,`kind` 是 `"zip"`/`"tar.gz"`。**它是目录式 API(写临时目录)**,成员限额/名称遍历防护/流式总大小全在 guard 里。
+- `ResourceFileService` 装配在 dispatcher 后面统一覆盖 arca/baas/teclaw(其 `_resolve_ctx` docstring 原话 "covering arca / baas / teclaw uniformly"),teclaw 的"逐文件转发"已经是这条链的传输实现——**不存在单独的 teclaw 臂要写**。
+- `ResourceFileService` 物化 API:
+  - `upload_file(*, entity_type="staff", entity_id, bot_id, engine_type, target_dir, filename, data: bytes, preserve_structure=False) -> dict`(:574)
+  - `delete(*, entity_type="staff", entity_id, bot_id, engine_type, path) -> bool`(:520;文件与目录都走它,rmtree 在内部分流)
+  - `exists(*, entity_id, bot_id, engine_type, path)`(返回 bool;签名同 upload 的公共前缀)
+- capabilities 的 `ManifestCategory.RESOURCES: None`(`capabilities.py:290`)——`None` 即 supported("Accepted with no materializer *yet* (W6)" 注释),挂上 materialiser 后 capabilities 无需任何改动;`APPLY_ORDER` 里 RESOURCES 已在位(ON_CONTAINER, position 2)。
+- `build_materialisers(*, ...)`:现挂 4 条(script/mcp/identity/skills),registry 结构测试钉"map 键与 APPLY_ORDER 对齐"且不点名类目。
+- ApplyContext 字段(`apply/context.py:47`):`bot_id/owner_id/actor_id/entity_id/env/tenant/engine_type/bot_type/bot/capabilities/apply_id`。
+- `ctx.entity_type` 不在 context 上(identity 用 `identity_coords_from_record(ctx.bot)` 懒加载拿 `entity_type/entity_id` 坐标;`resources` 同法:`resource_coords_from_record` 在 `core/services/resource_file_service.py:172`)。
+- 测试基建:`tests/community/core/bot_config_manifest/apply/_fakes.py` 已有 `make_context`/`FakeGuardedFetcher`/`FakeCredentials`/`FakeManifestContent`/`fetched_object`……新 fake 照 `FakeIdentityService` 的风格(记录调用、可预置)。
+- `EntryOutcome` 枚举在 `apply/outcomes.py`(`CREATED/UPDATED/UNCHANGED/FAILED/SKIPPED`);`EntryResult(construct, identity, outcome, detail=None)`——构造签名以 outcomes.py 现文为准(Task 1 开工时 `grep -n "class EntryResult" -A 12 outcomes.py` 确认 `detail` 关键字名,照抄现有构造)。
+
+---
+
+### Task 1: FakeResourceFileService(测试基建)
+
+**Files:**
+- Modify: `src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py`
+
+- [ ] **Step 1: 写验证 fake 行为的小测试(RED)**
+
+在 `tests/community/core/bot_config_manifest/apply/` 新建 `test_resources_materialiser.py` 该阶段只放 fake 的自测:
+
+```python
+"""Tests for the ``resources`` materialiser (W6).
+
+Pins, by the work item's acceptance criteria:
+- file entries materialise through ``ResourceFileService`` at a
+  workspace-relative ``path`` (physical placement stays the engine's call);
+- directory entries converge as the whole archive: the tree under ``path`` is
+  replaced in full, including hand-added files (ownership rule);
+- fetch failures abort the whole category before the first write (§3.2);
+- the platform unpacks to a temporary location — a bad archive or failed fetch
+  never reaches the bot;
+- convergence writes are file-grained (teclaw per-file forwarding is the same
+  transport), and the module never touches ``BotConfigArtifact``;
+- archive limits (member count / unpacked size) apply with W1's keys.
+"""
+from __future__ import annotations
+import asyncio
+
+from ._fakes import FakeResourceFileService, make_context
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_fake_resource_service_records_uploads_and_deletes():
+    svc = FakeResourceFileService(exists_paths={"data/old.bin"})
+    ctx = make_context(engine_type="claude_code")
+    svc.mark_write_count = 0
+    _run(
+        svc.upload_file(
+            entity_id=ctx.entity_id,
+            bot_id=ctx.bot_id,
+            engine_type=ctx.engine_type,
+            target_dir="data",
+            filename="a.bin",
+            data=b"hello",
+        )
+    )
+    _run(
+        svc.delete(
+            entity_id=ctx.entity_id,
+            bot_id=ctx.bot_id,
+            engine_type=ctx.engine_type,
+            path="data/old.bin",
+        )
+    )
+    assert svc.writes == {("data", "a.bin"): b"hello"}
+    assert svc.deleted == ["data/old.bin"]
+    assert svc.exists("data/old.bin") is False  # deleted paths report absent
+```
+
+- [ ] **Step 2: Run RED**
+
+Run: `uv run pytest tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py -q`
+Expected: FAIL —— `ImportError: cannot import name 'FakeResourceFileService'`。
+
+- [ ] **Step 3: 实现 fake(追加到 `_fakes.py` 尾部)**
+
+```python
+class FakeResourceFileService:
+    """ResourceFileService's materialisation calls, recorded.
+
+    ``ResourceFileService`` is v1's single write chain for manifest resources
+    (its dispatcher covers the arca / baas / teclaw transports), so the fake
+    only needs the two entry points the materialiser calls: ``upload_file``
+    and ``delete`` — plus ``exists`` for the plan stage's classification.
+    """
+
+    def __init__(self, exists_paths: set[str] | None = None) -> None:
+        self.writes: dict[tuple[str, str], bytes] = {}
+        self.deleted: list[str] = []
+        self._exists = set(exists_paths or ())
+
+    def record_present(self, *paths: str) -> None:
+        self._exists.update(paths)
+
+    async def upload_file(
+        self,
+        *,
+        entity_type: str = "staff",
+        entity_id: str,
+        bot_id: str,
+        engine_type: str,
+        target_dir: str,
+        filename: str,
+        data: bytes,
+        preserve_structure: bool = False,
+    ) -> dict:
+        self.writes[(target_dir, filename)] = data
+        self._exists.add(f"{target_dir}/{filename}".replace("//", "/"))
+        return {"path": f"{target_dir}/{filename}"}
+
+    async def delete(
+        self,
+        *,
+        entity_type: str = "staff",
+        entity_id: str,
+        bot_id: str,
+        engine_type: str,
+        path: str,
+    ) -> bool:
+        self.deleted.append(path)
+        self._exists.discard(path)
+        return True
+
+    async def exists(
+        self, *, entity_id: str, bot_id: str, engine_type: str, path: str
+    ) -> bool:
+        return path in self._exists
+```
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `uv run pytest tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py -q`
+Expected: PASS 1。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/community/core/bot_config_manifest/apply/_fakes.py \
+        tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+git commit -m "test(w6): fake ResourceFileService for the resources materialiser"
+```
+
+---
+
+### Task 2: 文件条目 resolve(URL + inline content)
+
+**Files:**
+- Create: `src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py`
+- Test: `tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py`
+
+- [ ] **Step 1: 写失败测试(追加)**
+
+```python
+from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
+    EntryFetchError,
+)
+from agentclaw.community.core.bot_config_manifest.apply.materialisers.resources import (
+    ResourcesMaterialiser,
+)
+
+from ._fakes import (
+    FakeCredentials,
+    FakeGuardedFetcher,
+    FakeManifestContent,
+    fetched_object,
+)
+
+
+def _materialiser(svc):
+    store = FakeManifestContent()
+    fetcher = FakeGuardedFetcher()
+    return ResourcesMaterialiser(svc, _rig_fetcher(),)
+
+
+def _rig_fetcher():
+    """EntryFetcher 的测试替身:不真拉网络。"""
+
+    class _Stub:
+        def fetch(self, ctx, *, source_url, digest, auth, category,
+                  keep_last, entry_identity):
+            if source_url.endswith("gone"):
+                raise EntryFetchError("source unreachable")
+            return fetched_object(b"bytes-of-" + source_url.encode())
+
+    return _Stub()
+
+
+def test_file_entry_from_url_resolves_to_intent_bytes():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _rig_fetcher())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(ctx, [{"path": "data/a.bin", "source": "https://x/a.bin"}]))
+    assert resolved.ok
+    assert [i.identity for i in resolved.intents] == ["data/a.bin"]
+    assert resolved.intents[0].value == _VALUE_BYTES(m, "https://x/a.bin")
+
+
+def _VALUE_BYTES(m, url):
+    return b"bytes-of-" + url.encode()
+
+
+def test_file_entry_inline_content_never_fetches():
+    svc = FakeResourceFileService()
+    stub = _rig_fetcher()
+    stub.seen = []
+    orig = stub.fetch
+    stub.fetch = lambda *a, **k: (stub.seen.append(k), orig(*a, **k))[1]
+    m = ResourcesMaterialiser(svc, stub)
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(ctx, [{"path": "notes/r.md", "content": "# rules"}])
+    )
+    assert resolved.ok
+    assert resolved.intents[0].value == b"# rules"
+    assert stub.seen == []
+
+
+def test_fetch_failure_aborts_whole_category():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _rig_fetcher())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(
+            ctx,
+            [
+                {"path": "data/a.bin", "source": "https://x/a.bin"},
+                {"path": "data/gone.bin", "source": "https://x/gone"},
+            ],
+        )
+    )
+    assert not resolved.ok
+    assert [f.identity for f in resolved.failures] == ["data/gone.bin"]
+
+
+def test_bad_path_entry_is_a_resolve_failure():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _rig_fetcher())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(ctx, [{"path": 123}]))
+    assert not resolved.ok
+```
+
+- [ ] **Step 2: Run RED**
+
+Run: `uv run pytest tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py -q`
+Expected: FAIL(`resources.py` 不存在,ImportError)。
+
+- [ ] **Step 3: 实现文件条目 resolve**
+
+`src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py`:
+
+```python
+"""``resources`` → ``ResourceFileService``: workspace files and directory trees.
+
+Three invariants, all from the W6 work item:
+
+- **One write chain for both engine families.** ``ResourceFileService``'s
+  dispatcher already fans out per transport (arac / baas: device sync; teclaw:
+  per-file forwarding), so the materialiser never branches on engine — the
+  acceptance criterion's "逐文件展开" is a property of this chain, not code
+  here. **This module must not import anything from
+  ``agentclaw.community.kernel.bot_config``** (the artifact contract stays
+  untouched: no directory-typed ``ResourceRef``, no T5 subtree optimisation).
+- **Ownership is per-entry.** A file entry owns its exact ``path``; a
+  directory entry owns the tree under ``path`` (its replacement removes files
+  the new archive no longer ships — including hand-added ones). Nothing
+  outside a declared ``path`` is ever touched. Cross-entry removals (a path
+  the previous document declared and this one no longer does) are **v1-empty
+  by the work item's own definition**: the acceptance criteria define
+  ownership only within each entry's tree, and the BaaS transport has no
+  "who wrote this file" ledger to answer the broader question — the W12
+  contract assigns that breadth to the engine-side applier.
+- **Replace, don't diff.** The directory criterion: re-applying an unchanged
+  archive must not skip writes based on the *source* looking unchanged — a
+  drifted tree would survive that. v1 takes the recommended option (1):
+  every apply rewrites every member. ``plan`` therefore classifies for the
+  report only (created / updated), never "unchanged", and the category is
+  never ``is_noop``.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Sequence
+import zipfile
+
+from agentclaw.community.core.bot_config_manifest.apply.context import ApplyContext
+from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
+    EntryFetchError,
+)
+from agentclaw.community.core.bot_config_manifest.apply.outcomes import (
+    EntryResult,
+)
+from agentclaw.community.core.bot_config_manifest.apply.registry import (
+    CategoryPlan,
+    Intent,
+    Materialiser,
+    PlannedEntry,
+    ResolveFailure,
+    ResolveResult,
+)
+from agentclaw.community.core.bot_config_manifest.capabilities import (
+    ManifestCategory,
+)
+
+_FETCH_CATEGORY = "resources"
+
+
+class ResourcesMaterialiser(Materialiser):
+    """Converges declared workspace resources toward the declaration."""
+
+    construct = ManifestCategory.RESOURCES
+
+    def __init__(self, resource_service: Any, fetcher: Any) -> None:
+        self._resources = resource_service
+        self._fetcher = fetcher
+
+    async def resolve(
+        self, ctx: ApplyContext, entries: Sequence[dict[str, Any]]
+    ) -> ResolveResult:
+        intents: list[Intent] = []
+        failures: list[ResolveFailure] = []
+        for index, entry in enumerate(
+            e if isinstance(e, dict) else {} for e in entries
+        ):
+            path = entry.get("path")
+            failed = self._entry_failure(entry, path, index)
+            if failed is not None:
+                failures.append(failed)
+                continue
+            if isinstance(path, str) and path.endswith("/"):
+                # Directory entries arrive with Task 3.
+                failures.append(
+                    ResolveFailure(
+                        str(path),
+                        "directory resource entries are not materialised yet",
+                    )
+                )
+                continue
+            inline = entry.get("content")
+            if isinstance(inline, str):
+                intents.append(Intent(identity=path, value=inline.encode("utf-8")))
+                continue
+            source_url = entry.get("source")
+            if not isinstance(source_url, str) or not source_url:
+                failures.append(
+                    ResolveFailure(
+                        str(path),
+                        "a resources entry must declare 'source' or 'content'",
+                    )
+                )
+                continue
+            try:
+                # Blocking network + disk I/O (W2's transport, W11's blob
+                # write) off the event loop — the identity and skills
+                # materialisers carry the same note.
+                fetched = await asyncio.to_thread(
+                    self._fetcher.fetch,
+                    ctx,
+                    source_url=source_url,
+                    digest=entry.get("digest"),
+                    auth=entry.get("auth"),
+                    category=_FETCH_CATEGORY,
+                    keep_last=(
+                        entry.get("on_fetch_failure", "keep_last") == "keep_last"
+                    ),
+                    entry_identity=path,
+                )
+            except EntryFetchError as exc:
+                failures.append(ResolveFailure(str(path), exc.reason))
+                continue
+            intents.append(Intent(identity=path, value=fetched.content))
+        self._check_nesting(entries, failures)
+        return ResolveResult(intents=tuple(intents), failures=tuple(failures))
+
+    def _entry_failure(
+        self, entry: dict[str, Any], path: Any, index: int
+    ) -> ResolveFailure | None:
+        if not isinstance(path, str) or not path:
+            return ResolveFailure(
+                f"[{index}]", "a resources entry must declare a 'path'"
+            )
+        if path.startswith("/") or ".." in path.split("/") or "\x00" in path:
+            return ResolveFailure(path, "path must be workspace-relative")
+        return None
+
+    def _check_nesting(
+        self,
+        entries: Sequence[dict[str, Any]],
+        failures: list[ResolveFailure],
+    ) -> None:
+        """The PUT-time nesting ban, re-asked here (W6 acceptance).
+
+        One declared path living under another declared directory path would
+        make the directory's whole-tree replace delete the sibling mid-apply.
+        Paths are already relative and normalised at schema time; here we
+        re-check, so a document that reached storage before this check existed
+        still cannot apply destructively.
+        """
+        paths = [
+            e.get("path")
+            for e in entries
+            if isinstance(e, dict) and isinstance(e.get("path"), str)
+        ]
+        directories = [p for p in paths if p.endswith("/")]
+        for candidate in paths:
+            for directory in directories:
+                if candidate != directory and candidate.startswith(directory):
+                    failures.append(
+                        ResolveFailure(
+                            candidate,
+                            f"path nests under another declared directory "
+                            f"{directory!r}",
+                        )
+                    )
+```
+
+注:`plan`/`write` 本 Task 先给最小占位实现(raise NotImplemented 会在协议测试冲突——*不*,Protocol 靠运行期 hasattr?**Protocol 是 abstractmethod 且 materialiser 继承 registry.Materialiser(ABC)**——三个方法必须都存在才能实例化。本 Task 就给出 stub 合法体:`async def plan(...)->CategoryPlan: return CategoryPlan()` 与 `async def write(...): return ()`(下两个 Task 覆盖)。
+
+```python
+    async def plan(
+        self, ctx: ApplyContext, intents: Sequence[Intent]
+    ) -> CategoryPlan:
+        return CategoryPlan()  # replaced in Task 4
+
+    async def write(
+        self, ctx: ApplyContext, plan: CategoryPlan
+    ) -> Sequence[EntryResult]:
+        return ()  # replaced in Task 5
+```
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `uv run pytest tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py -q`
+Expected: 文件条目 4 用例 PASS(加 Task 1 的 1=5 PASS)。失败的 `ResourceFileService` import 检查不存在(本模块常量占位——注意 `_import guard` 没写)。若 `%` 结构测试(`test_no_module_level_service_instances` 等)红,由 Task 6 统一处理。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py \
+        tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+git commit -m "feat(w6): resolve file resource entries through the entry fetcher"
+```
+
+---
+
+### Task 3: 目录条目 resolve(平台侧解包 + 成员展开)
+
+**Files:**
+- Modify: `src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py`
+- Test: `tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py`
+
+- [ ] **Step 1: 写失败测试(追加)**
+
+```python
+import tarfile, io, os
+
+
+def _tgz(member: dict[str, bytes]) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in member.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+class _TgzFetcher:
+    """Fetch a fixed archive for every URL."""
+
+    def __init__(self, archive: bytes) -> None:
+        self._archive = archive
+
+    def fetch(self, ctx, *, source_url, digest, auth, category,
+              keep_last, entry_identity):
+        return fetched_object(self._archive)
+
+
+def test_dir_entry_expands_members_under_path():
+    archive = _tgz({"top/a.txt": b"AAA", "top/sub/b.txt": b"BBB"})
+    drop = {"wrap/": {"unpack": "tar.gz", "strip_components": 1,
+                       "source": "https://x/tree.tgz"}}
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _TgzFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(
+        ctx,
+        [{"path": "wrap/", "unpack": "tar.gz", "strip_components": 1,
+          "source": "https://x/tree.tgz"}],
+    ))
+    assert resolved.ok, [f.reason for f in resolved.failures]
+    got = {i.identity: i.value for i in resolved.intents}
+    # "wrap/" 条目即目录 sentinel(value=None,树替换标记),先于成员
+    assert got == {
+        "wrap/": None,
+        "wrap/a.txt": b"AAA",
+        "wrap/sub/b.txt": b"BBB",
+    }
+
+
+def test_bad_archive_is_a_resolve_failure_and_Nothing_Was_fetched_to_bot():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(
+        svc,
+        _TgzFetcher(b"not-an-archive"),
+    )
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(
+        ctx,
+        [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/tree.tgz"}],
+    ))
+    assert not resolved.ok
+    assert resolved.failures[0].identity == "wrap/"
+    assert svc.writes == {} and svc.deleted == []
+
+
+def test_dir_unpack_missing_is_rejected_at_resolve():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _TgzFetcher(_tgz({"a.txt": b"x"})))
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(
+        ctx, [{"path": "wrap/", "source": "https://x/tree.tgz"}],
+    ))
+    assert not resolved.ok
+    assert "unpack" in resolved.failures[0].reason
+
+
+def test_nested_paths_abort_category():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _TgzFetcher(_tgz({"a.txt": b"x"})))
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(
+        ctx,
+        [
+            {"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t.tgz"},
+            {"path": "wrap/inner.txt", "source": "https://x/i.txt"},
+        ],
+    ))
+    assert not resolved.ok
+    assert any("nest" in f.reason for f in resolved.failures)
+```
+
+- [ ] **Step 2: Run RED**
+
+Expected: 目录 3+ 用例 FAIL(现在被"not materialised yet"拒绝);嵌套那条也红(`_check_nesting` 未接 path 前缀判定——若已绿,说明 Task 2 已含,跳过该断言口径调整)。
+
+Run: `uv run pytest tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py -q`
+
+- [ ] **Step 3: 实现目录解包**
+
+在 `resources.py` 顶部补 import:
+
+```python
+import tempfile
+from pathlib import Path
+
+from agentclaw.community.core.bot_config_manifest.fetch.unpack import (
+    UnpackError,
+    unpack_archive,
+)
+
+_LIMITS_UNPACKED = None  # placeholder-removed below
+```
+
+(删占位注:实际不需要额外常量——`unpack_archive` 的默认 `unpacked_size_limit` 已是 `FETCH_ENTRY_LIMITS["resources_unpacked"]`,成员限额默认 `ARCHIVE_MEMBER_LIMIT`,两条验收限额由此生效。)
+
+把 `resolve` 里目录分支的 `"directory resource entries are not materialised yet"` 拒绝**替换**为:
+
+```python
+            if isinstance(path, str) and path.endswith("/"):
+                unpack_kind = entry.get("unpack")
+                if unpack_kind not in ("zip", "tar.gz"):
+                    failures.append(
+                        ResolveFailure(
+                            path,
+                            "a directory entry fetched from a URL must declare "
+                            "'unpack: zip|tar.gz'",
+                        )
+                    )
+                    continue
+                source_url = entry.get("source")
+                if not isinstance(source_url, str) or not source_url:
+                    failures.append(
+                        ResolveFailure(
+                            path,
+                            "a directory entry must declare 'source'",
+                        )
+                    )
+                    continue
+                try:
+                    fetched = await asyncio.to_thread(
+                        self._fetcher.fetch,
+                        ctx,
+                        source_url=source_url,
+                        digest=entry.get("digest"),
+                        auth=entry.get("auth"),
+                        category=_FETCH_CATEGORY,
+                        keep_last=(
+                            entry.get("on_fetch_failure", "keep_last")
+                            == "keep_last"
+                        ),
+                        entry_identity=path,
+                    )
+                except EntryFetchError as exc:
+                    failures.append(ResolveFailure(path, exc.reason))
+                    continue
+                members = await asyncio.to_thread(
+                    self._unpack_members,
+                    fetched.content,
+                    unpack_kind,
+                    entry.get("strip_components", 0),
+                )
+                if isinstance(members, str):
+                    failures.append(ResolveFailure(path, members))
+                    continue
+                # The directory sentinel: identity=path, value=None. It rides
+                # first in the intent list so plan marks the tree for
+                # replacement and write deletes it before members upload.
+                intents.append(Intent(identity=path, value=None))
+                for rel, data in members:
+                    intents.append(Intent(identity=path + rel, value=data))
+                continue
+```
+
+并在类内加(非 async——由 to_thread 调用):
+
+```python
+    @staticmethod
+    def _unpack_members(
+        archive: bytes, kind: str, strip_components: int
+    ) -> list[tuple[str, bytes]] | str:
+        """The guarded unpack, platform-side, into a throwaway dir.
+
+        The bot is never a scratch space: ``unpack_archive`` writes only into
+        a fresh temporary directory, so a bad or oversized archive (W1's
+        member / unpacked-size limits live inside it) fails before anything
+        is delivered. Returned members are ``(relative path, bytes)`` with
+        ``strip_components`` already applied.
+        """
+        try:
+            with tempfile.TemporaryDirectory(prefix="manifest-resources-") as tmp:
+                tree = unpack_archive(
+                    archive,
+                    kind,
+                    Path(tmp) / "tree",
+                    strip_components=strip_components,
+                )
+                members: list[tuple[str, bytes]] = []
+                for name in tree.file_names():
+                    data = (Path(tmp) / "tree" / name).read_bytes()
+                    members.append((name, data))
+                return members
+        except UnpackError as exc:
+            return str(exc)
+```
+
+(`UnpackedTree` 的成员枚举 API 以现文件为准:开工先 `grep -n "class UnpackedTree" -A 18 fetch/unpack.py` 把 `file_names` 换成实际方法名——若有 `files()` 返回 `dict[str,bytes]` 直接用,整个函数体替换为遍历它。)
+
+嵌套判定(收尾顺带把 exact-prefix 语义钉住):`_check_nesting` 逻辑已在 Task 2 落地:`candidate.startswith(directory)` 且 `candidate != directory`——目录条目的 path 本身以 `/` 结尾,目录自身声明的 path 不应与其它目录再比。已覆盖。
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `uv run pytest tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py -q`
+Expected: 全部 PASS(目录展开/坏归档/缺 unpack/嵌套)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py \
+        tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+git commit -m "feat(w6): expand archived directory entries platform-side before delivery"
+```
+
+---
+
+### Task 4: plan(报告分类;never unchanged;removals 为空)
+
+**Files:**
+- Modify: `apply/materialisers/resources.py`
+- Test: `test_resources_materialiser.py`
+
+- [ ] **Step 1: 写失败测试(追加)**
+
+```python
+def _write_through(m, ctx, entries):
+    resolved = _run(m.resolve(ctx, entries))
+    assert resolved.ok, [f.reason for f in resolved.failures]
+    plan = _run(m.plan(ctx, resolved.intents))
+    results = _run(m.write(ctx, plan))
+    return plan, results
+
+
+def test_plan_classifies_exists_as_updated_and_new_as_created():
+    svc = FakeResourceFileService(exists_paths={"data/a.bin"})
+    m = ResourcesMaterialiser(svc, _rig_fetcher())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(ctx, [
+        {"path": "data/a.bin", "source": "https://x/a.bin"},
+        {"path": "data/new.bin", "source": "https://x/new.bin"},
+    ]))
+    plan = _run(m.plan(ctx, resolved.intents))
+    by_id = {p.intent.identity: p.outcome for p in plan.entries}
+    assert by_id == {"data/a.bin": "updated", "data/new.bin": "created"}
+    assert plan.removals == ()
+    assert not plan.is_noop  # v1 replaces on every apply, by design
+```
+
+- [ ] **Step 2: Run RED**
+
+Run: `uv run pytest tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py::test_plan_classifies_exists_as_updated_and_new_as_created -q`
+Expected: FAIL(plan 是 stub `CategoryPlan()`,entries 空)。
+
+- [ ] **Step 3: 实现 plan**
+
+替换 stub:
+
+```python
+    async def plan(
+        self, ctx: ApplyContext, intents: Sequence[Intent]
+    ) -> CategoryPlan:
+        """Classify for the report. Never ``unchanged`` — v1 replaces on
+        every apply (the work item's recommended option (1)), so classifying
+        anything as unchanged would be a claim the write stage does not
+        honour. ``exists`` is consulted only for the created/updated label.
+        """
+        planned: list[PlannedEntry] = []
+        entity = resource_coords(ctx)
+        for intent in intents:
+            if intent.value is None:
+                # Directory sentinel: ownership action (tree replacement),
+                # reported only through its member files' results.
+                planned.append(PlannedEntry(intent=intent, outcome="replaced"))
+                continue
+            present = await self._resources.exists(
+                entity_id=entity["entity_id"],
+                bot_id=ctx.bot_id,
+                engine_type=ctx.engine_type,
+                path=intent.identity,
+            )
+            planned.append(
+                PlannedEntry(
+                    intent=intent,
+                    outcome="updated" if present else "created",
+                )
+            )
+        return CategoryPlan(entries=tuple(planned), removals=())
+```
+
+并在模块尾部加坐标 helper:
+
+```python
+def resource_coords(ctx: ApplyContext) -> dict[str, str]:
+    """The addressing pair every resource write uses, the router's own way.
+
+    Mirrors the identity materialiser's ``_coords``: the coords function is
+    imported lazily because the service module pulls the device dispatcher
+    at import, and this package must not drag that graph into importers that
+    only walk manifest rules.
+    """
+    from agentclaw.community.core.services.resource_file_service import (
+        resource_coords_from_record,
+    )
+
+    entity_type, entity_id = resource_coords_from_record(ctx.bot)
+    return {"entity_type": entity_type, "entity_id": entity_id}
+```
+
+(`resource_coords_from_record` 的**返回形态**(tuple 还是 dict)以现文件为准:开工先 `grep -n "def resource_coords_from_record" -A 15 src/agentclaw/community/core/services/resource_file_service.py`,把 helper 调整为相应解包。`upload_file`/`delete` 调用同步带 `entity_type=entity[...]`。)
+
+- [ ] **Step 4: Run GREEN**
+
+Run: `uv run pytest tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py -q`
+Expected: 全 PASS(plan 用例 + 既有)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py \
+        tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+git commit -m "feat(w6): classify resource plans via exists, never unchanged"
+```
+
+---
+
+### Task 5: write(逐文件上传;树替换;半写窗口语义)
+
+**Files:**
+- Modify: `apply/materialisers/resources.py`
+- Test: `test_resources_materialiser.py`
+
+- [ ] **Step 1: 写失败测试(追加)**
+
+```python
+def test_write_uploads_every_file_through_the_service():
+    svc = FakeResourceFileService(exists_paths={"wrap/old.txt"})
+    archive = _tgz({"a.txt": b"AAA", "sub/b.txt": b"BBB"})
+    m = ResourcesMaterialiser(svc, _TgzFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+    plan, results = _write_through(m, ctx, [
+        {"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t.tgz"},
+    ])
+    assert svc.writes == {
+        ("wrap", "a.txt"): b"AAA",
+        ("wrap/sub", "b.txt"): b"BBB",
+    }
+    assert svc.deleted == ["wrap/"]  # tree replaced, hand-added old.txt gone
+    assert {r.identity for r in results} == {"wrap/a.txt", "wrap/sub/b.txt"}
+
+
+def test_write_is_player_setup_convergent():
+    """应用 N 次 = 应用 1 次:重复投递产出同一组 writes/deletes,无堆积。"""
+    archive = _tgz({"a.txt": b"AAA"})
+    for _ in range(2):
+        svc = FakeResourceFileService()
+        m = ResourcesMaterialiser(svc, _TgzFetcher(archive))
+        ctx = make_context(engine_type="claude_code")
+        _write_through(m, ctx, [
+            {"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t.tgz"},
+        ])
+        assert svc.writes == {("wrap", "a.txt"): b"AAA"}
+        assert svc.deleted == ["wrap/"]
+
+
+def test_write_failure_yields_failed_entry_per_member():
+    class _Buggy(FakeResourceFileService):
+        async def upload_file(self, **kw):
+            if kw["filename"] == "b.txt":
+                raise RuntimeError("transport down")
+            return await super().upload_file(**kw)
+
+    svc = _Buggy(exists_paths=set())
+    archive = _tgz({"a.txt": b"A", "b.txt": b"B"})
+    m = ResourcesMaterialiser(svc, _TgzFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(ctx, [
+        {"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t.tgz"},
+    ]))
+    plan = _run(m.plan(ctx, resolved.intents))
+    results = _run(m.write(ctx, plan))
+    outcomes = {(r.identity, r.outcome.value) for r in results}
+    assert ("wrap/b.txt", "failed") in outcomes
+    assert ("wrap/a.txt", "failed") not in outcomes
+```
+
+(write 的失败语义以 orchestrator 消费为准:看 `apply/orchestrator.py` 的 write 段与 `outcomes.py::EntryOutcome`,本测试按"materialiser 返回逐条 EntryResult,失败成员 outcome=FAILED,成功成员 CREATED/UPDATED"断言。)
+
+- [ ] **Step 2: Run RED**
+
+Run: `uv run pytest tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py -q`
+Expected: write 用例 FAIL(stub 返回 `()`)。
+
+- [ ] **Step 3: 实现 write**
+
+替换 stub:
+
+```python
+    async def write(
+        self, ctx: ApplyContext, plan: CategoryPlan
+    ) -> Sequence[EntryResult]:
+        """Execute: replace each declared directory tree, rewrite each file.
+
+        Half-written windows are v1's documented narrowing (the transport has
+        no rename): a mid-write stop leaves the tree in an unknown state and
+        the member's result row says ``failed`` — the report is the source of
+        truth, no rollback is attempted. The platform-side unpack already
+        kept a bad archive from reaching this far.
+        """
+        entity = resource_coords(ctx)
+        results: list[EntryResult] = []
+        # 1) directory sentinels first: one delete per declared tree. A tree's
+        # replace removes everything under ``path`` — including files the new
+        # archive no longer ships and hand-added ones (the ownership rule).
+        # Sentinels produce no EntryResult: an ownership action, not an entry.
+        for planned in plan.entries:
+            if planned.intent.value is not None:
+                continue
+            await self._resources.delete(
+                entity_type=entity["entity_type"],
+                entity_id=entity["entity_id"],
+                bot_id=ctx.bot_id,
+                engine_type=ctx.engine_type,
+                path=planned.intent.identity,
+            )
+        # 2) then each member file, in declaration order
+        for planned in plan.entries:
+            identity = planned.intent.identity
+            data = planned.intent.value
+            if data is None:
+                continue
+            target_dir, _, filename = identity.rpartition("/")
+            try:
+                await self._resources.upload_file(
+                    entity_type=entity["entity_type"],
+                    entity_id=entity["entity_id"],
+                    bot=ctx.bot_id,
+                    engine_type=ctx.engine_type,
+                    target_dir=target_dir,
+                    filename=filename,
+                    data=data,
+                )
+            except Exception as exc:  # noqa: BLE001 — surfaced per entry
+                results.append(
+                    EntryResult(
+                        self.construct,
+                        identity,
+                        EntryOutcome.FAILED,
+                        f"resource delivery failed: {exc}",
+                    )
+                )
+                continue
+            results.append(
+                EntryResult(
+                    self.construct, identity, EntryOutcome(planned.outcome)
+                )
+            )
+        return tuple(results)
+```
+
+(`EntryResult` 的第四个关键字参数名以 `outcomes.py` 现文为准——开工头一步 `grep -n "class EntryResult" -A 10 apply/outcomes.py`,skill/identity 材化器里现有构造怎么写就怎么写。上传调用里 `bot_id=ctx.bot_id 斟酌`——照 `upload_file` 签名精确为 `bot_id=ctx.bot_id`;上面代码里若与签名冲突以签名为准修正。)
+
+(树替换的所属关系由 sentinel 的顺序保证:Task 3 的 resolve 把 sentinel 放在该目录成员之前,write 按声明序执行,树删永远先于其成员上传。两个声明目录的嵌套已在 resolve 的 `_check_nesting` 拒绝。)
+
+- [ ] **Step 4: Run GREEN + 全文件回归**
+
+Run: `uv run pytest tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py -q`
+Expected: 全 PASS。
+
+Run: `uv run pytest tests/community/core/bot_config_manifest -q`
+Expected: 全 PASS(既有 identity/skills 等不受影响)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py \
+        tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+git commit -m "feat(w6): materialise resources through ResourceFileService with tree replacement"
+```
+
+---
+
+### Task 6: registry 挂载 + apply service 装配 + 结构钉子
+
+**Files:**
+- Modify: `apply/registry.py`(`build_materialisers`)
+- Modify: `services/config_manifest_apply_service.py`(`__init__` provider 槽 + `_orchestrator` 调用)
+- Modify: DI 装配所在模块(开工先 `rg -l "config_manifest_apply_service|ManifestApplyService" src/agentclaw/community/di` 定位,加 `resource_service_provider`)
+- Test: `tests/community/core/bot_config_manifest/apply/test_orchestrator_stays_generic.py` 与新结构断言
+
+- [ ] **Step 1: 写失败测试(结构钉子,追加到 test_resources_materialiser.py)**
+
+```python
+import ast
+from pathlib import Path
+import agentclaw.community.core.bot_config_manifest.apply.materialisers.resources as _res
+
+_SOURCE = Path(_res.__file__).read_text()
+
+
+def test_module_never_imports_the_artifact_contract():
+    tree = ast.parse(_SOURCE)
+    for node in ast.walk(tree):
+        names = []
+        if isinstance(node, ast.Import):
+            names += [a.name for a in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            names += [node.module or ""]
+        for name in names:
+            assert "kernel.bot_config" not in name, (
+                "W6 acceptance: BotConfigArtifact 不变 — the resources "
+                "materialiser must not reach the artifact contract"
+            )
+
+
+def test_build_materialisers_registers_five():
+    from agentclaw.community.core.bot_config_manifest.apply.registry import (
+        build_materialisers,
+    )
+
+    registry = build_materialisers(
+        script_service=object(),
+        activation_service=object(),
+        mcp_auth_service=object(),
+        identity_service=object(),
+        upload_service=object(),
+        capability_reader=object(),
+        package_validator=object(),
+        entry_fetcher=object(),
+        resource_service=object(),
+    )
+    from agentclaw.community.core.bot_config_manifest.capabilities import (
+        ManifestCategory,
+    )
+
+    assert ManifestCategory.RESOURCES in registry
+    assert len(registry) == 5
+```
+
+- [ ] **Step 2: Run RED**
+
+Expected: FAIL(`resource_service` 参数不存在;registry 无 resources)。
+
+Run: `uv run pytest tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py -q`
+
+- [ ] **Step 3: 实现挂载**
+
+`registry.py` `build_materialisers`:签名加 `resource_service: Any,`(排在 `entry_fetcher` 后);tuple 加 `ResourcesMaterialiser(resource_service, entry_fetcher),`;import 加同风格懒 import:
+
+```python
+    from agentclaw.community.core.bot_config_manifest.apply.materialisers.resources import (
+        ResourcesMaterialiser,
+    )
+```
+
+docstring 中 "W4 registered two; W5 registers four." 改为 "...W5 four, W6 five.";删去 "``resources`` arrives with W6" 半句(已到)。
+
+`config_manifest_apply_service.py`:
+- `__init__` 参数加 `resource_service_provider: Callable[[], Any],`(排在 `entry_fetcher_provider` 前),赋值 `self._resource_service_provider = resource_service_provider`;
+- `_orchestrator()` 的 `build_materialisers(...)` 调用加 `resource_service=self._resource_service_provider(),`。
+
+DI 模块:定位装配点(典型在 `di/modules/…manifest…` 或 infrastructure),为 `ManifestApplyService(...)` 构造加同形 provider(lambda: Injected(ResourceFileService)(...) 或按该文件里 identity/upload 的 provider 惰性写法照抄)。**先 grep 旁边的 `entry_fetcher_provider=` 现场行,加完全同型的一行。**
+
+- [ ] **Step 4: Run GREEN + 受影响面回归**
+
+Run: `uv run pytest tests/community/core/bot_config_manifest -q`
+Run: `uv run pytest tests/community/core/bot_config_manifest/apply/test_orchestrator_stays_generic.py -v`(钉子应仍绿——orchestrator 不点名类目)
+Run: `uv run pytest tests/community/endpoints/test_openapi_config_manifest_apply.py -q`(端到端 apply 路由族)
+Expected: 全 PASS。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A src/agentclaw/community tests/community
+git commit -m "feat(w6): register the resources materialiser in the apply engine"
+```
+
+---
+
+### Task 7: 端到端用例 + 文档 + 全量 gate(收尾)
+
+**Files:**
+- Test: `tests/community/adapters/http/openapi_v1/test_config_manifest_apply_bars.py`(或 `endpoints/test_openapi_config_manifest_apply.py`,以现有资源夹具所在文件为准)
+- Modify: `src/backend/docs/bot-config-manifest/README.zh-CN.md`(capabilities 表/模块 README 里 "resources accepted but inert" 措辞→已物化)
+- Verify: work-items 验收对照
+
+- [ ] **Step 1: 端到端(失败先写)**
+
+在 apply 路由测试中加一例(以现文件中现有 manifest+apply 用例为模板——同 fixture、同 passport/principal minting 形态):manifest 声明一个 URL 文件条目+一个目录条目(fake fetcher/transport 按现文件的 stub 方式),`POST …/config-manifest/apply` 后断言报告里 resources 逐条 CREATED/UPDATED 且服务写路径被调用。**以现有 e2e 用例 90% 改写,验收断两点:apply report 有 resources 条目结果;数据库/服务侧写入可查。**
+
+Run 先确认 RED(尚未有资源用例时,新用例直接写完整,RED 依赖 Task 6 已合入——此步预期 PASS;若已有 no-materialiser 的"inert"断言用例,反转它)。
+
+- [ ] **Step 2: 文档措辞更新**
+
+`README.zh-CN.md`/模块 README:`resources — accepted with no materialiser yet (W6)` 一类措辞改为已物化(保留 `engine_config` 的 inert 说明)。`work-items.zh-CN.md` 的 W6 小节头部加一行"已交付(PR 链接)"不带 issue 状态改动。
+
+- [ ] **Step 3: 全量回归 + 覆盖率 gate**
+
+```bash
+cd /Users/rongzhi/PycharmProjects/Avernet
+mv src/backend/src/agentclaw/community/core/bot_config_manifest_store_probe 2>/dev/null  # noop guard,见下
+bash src/backend/scripts/ci_test.sh --base origin/feat/bot-config-manifest-w5-dev
+```
+
+注意:若工作区存在**另一条工作线留下的 untracked 目录**(bot_config_* 残留)导致架构门误报,按记忆处理:跑 gate 前 `mv` 到 `/tmp`,跑完移回。
+
+Expected: `backend CI gate passed`,changed-line coverage ≥ 80%。
+
+- [ ] **Step 4: 批量终审(用户约定:一次审)**
+
+对 `git diff origin/feat/bot-config-manifest-w5-dev...HEAD` 派一次 code review(重点:验收六条逐条对照;嵌套禁令双查;半写窗口语义在文档;目录 sentinel 与 EntryResult 报告口径;artifact 零触碰;与 W5 冲突面(rebase 准备))。CRITICAL/HIGH 修复后重跑 Step 3。
+
+- [ ] **Step 5: push**
+
+```bash
+AVERNET_PRE_PUSH_MERGE_TARGET=origin/feat/bot-config-manifest-w5-dev \
+  git push -u origin feat/bot-config-manifest-w6-arc
+```
+
+W5 合入 dev 后:`git fetch origin && git rebase --onto origin/dev <旧W5tip> feat/bot-config-manifest-w6-arc`,再按用户当期指示提 PR(base:dev,基线是 W5 已合后的 dev)。
+
+---
+
+## Self-Review 记录
+
+- **验收覆盖:** ①文件条目经 ResourceFileService(Task 2/5)②目录整体替换+漂移由构造保证(每次 apply 重写,Task 3/5)③原子性收窄+`failed` 记录(Task 5 write;文档写进模块 docstring 与 guide)④嵌套禁令 PUT+apply 双查(Task 2 `_check_nesting`+schema 既有)⑤teclaw 逐文件=同一传输链,artifact 零触碰(Task 6 结构钉子)⑥限额=unpack_archive 内建(member/unpacked)✓ 全六条。
+- **类型一致性:** `ResourceFileService(fake) upload_file/delete/exists` 签名在 Task 1/4/5 一致;`EntryFetcher.fetch` 调用形态照 skills.py 逐字;`EntryResult`/`PlannedEntry`/`Intent` 名称与 registry.py 一致。**两处显式标注了"以现文件为准"的现场阅读指令**(`UnpackedTree` 成员枚举方法名、`resource_coords_from_record` 返回形态)——这两处是本计划写作时未逐一展开的唯二现场决策,均已给出核对命令与改写口径,不属于占位符。
+- **范围:** 不做跨条目 removal 记账(v1 空,与验收一致);不改 capabilities(RESOURCES:None 即 supported);不碰 BotConfigArtifact;engine_config/cli_tools 不在范围。

--- a/src/backend/docs/bot-config-manifest/work-items.zh-CN.md
+++ b/src/backend/docs/bot-config-manifest/work-items.zh-CN.md
@@ -1520,6 +1520,8 @@ manifest 概念。
 
 #### W6 — `resources`：文件与目录 · #1474
 
+**已交付**（分支 `feat/bot-config-manifest-w6-arc`，PR 待提）。
+
 **Owner.** `lucas-xzp` · 0.75 天 · 第 4 天 · 实现（§7）
 
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/README.md
@@ -20,7 +20,9 @@ that travel the manual-upload road (`SkillPackageValidator`, then
 minus the reserved names, written through the router's own
 `IdentityService` path. The one funnel they fetch through is
 `apply/entry_fetch.py`: substitute, consult the platform's copy, fetch under
-a named credential, file the receipt. `resources` remains for W6.
+a named credential, file the receipt. W6 adds `resources` — files and
+archived directory trees, written through `ResourceFileService`'s one
+dispatcher chain, directory entries replacing their declared tree in full.
 
 A credential never enters a document (W1 refuses it at the boundary); W2
 declares the injector protocol, and W3 binds it. W11 records a credential

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/README.md
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/README.md
@@ -516,6 +516,7 @@ consumes:
   - "MAX_SCRIPT_BYTES (core.bot_startup_script) — script.body IS the #926 startup script, so it takes that cap rather than a second one"
   - "TokenVault (core.bot_management) — enc:v1: AES-GCM reversible encryption for the credential secret; the master key comes from the SecretResolver, and the fail-closed profiles refuse writes without one"
   - "SourceCredentialRepositoryProtocol (core.repository) — persistence for the credential table"
+  - "ALLOWED_EXTENSIONS / MAX_FILE_SIZE (core.resources.services.file_service) — the workspace file surface's admission rules, re-asked in the `resources` materialiser's resolve so an undeliverable entry fails with the tree still standing (W6)"
 consumed_by:
   - "adapters/http/openapi_v1/bots — the public read/replace/clear/capabilities surface"
   - "the apply orchestration (`apply/`, W4 #1472 + W5 #1473) — di/modules/manifest_fetch_module.py constructor-injects the transport_allowlist and the content store root (read via the W2/W11 pure parsers over config_module's seam) and holds the one EntryFetcher over the fetcher, the store, and W3's credentials"
@@ -526,6 +527,7 @@ internal_dependencies:
   - agentclaw.community.core.bot_management.token_vault
   - agentclaw.community.core.mcp.mcp_auth_service_protocol  # the permission check DirectActivationService also consults
   - agentclaw.community.core.repository
+  - agentclaw.community.core.resources.services.file_service  # the workspace file surface's admission constants, re-asked at resolve (W6)
   - agentclaw.community.core.services.identity
   - agentclaw.community.core.skill_center.capability_state_contract  # the flush-then-read active-set the `skills` materialiser enumerates (W5)
   - agentclaw.community.core.skill_center.direct_activation_service_protocol  # the `mcp` materialiser's per-bot activation writes

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -43,6 +43,7 @@ from agentclaw.community.core.bot_config_manifest.apply.registry import (
     CategoryPlan,
     Intent,
     Materialiser,
+    PlannedEntry,
     ResolveFailure,
     ResolveResult,
 )
@@ -257,12 +258,56 @@ class ResourcesMaterialiser(Materialiser):
     async def plan(
         self, ctx: ApplyContext, intents: Sequence[Intent]
     ) -> CategoryPlan:
-        return CategoryPlan()  # replaced by the classification stage (W6)
+        """Classify for the report. Never ``unchanged`` — v1 replaces on
+        every apply (the work item's recommended option (1)), so classifying
+        anything as unchanged would be a claim the write stage does not
+        honour. ``exists`` is consulted only for the created/updated label,
+        and the directory sentinels classify within the same vocabulary:
+        the orchestrator's dry-run projection feeds every planned outcome
+        through :class:`EntryOutcome`, which a bespoke label would crash.
+        """
+        entity_type, entity_id = _coords(ctx)
+        planned: list[PlannedEntry] = []
+        for intent in intents:
+            present = await self._resources.exists(
+                entity_type=entity_type,
+                entity_id=entity_id,
+                bot_id=ctx.bot_id,
+                engine_type=ctx.engine_type,
+                path=intent.identity,
+            )
+            planned.append(
+                PlannedEntry(
+                    intent=intent,
+                    outcome="updated" if present else "created",
+                )
+            )
+        return CategoryPlan(entries=tuple(planned), removals=())
 
     async def write(
         self, ctx: ApplyContext, plan: CategoryPlan
     ) -> Sequence[EntryResult]:
         return ()  # replaced by the delivery stage (W6)
+
+
+def _coords(ctx: ApplyContext) -> tuple[str, str]:
+    """The entity pair every resource write uses, the router's own way.
+
+    The entity is the bot's owner — the address the resources router's
+    ``_resolve_params`` resolves and ``resource_coords_from_record`` derives
+    — so ``entity_id`` here is ``ctx.owner_id``, **not** ``ctx.entity_id``:
+    that field is the manifest's storage key, a different vocabulary that
+    happens to share the name. ``entity_type`` is ``"staff"``, the
+    personal-bot surface's fixed type.
+
+    The engine halves of the address come from ``ctx.engine_type``, resolved
+    once per apply rather than re-resolved here (the context's own rule: a
+    single resolution cannot disagree with itself midway through an apply).
+    ``resource_coords_from_record`` is therefore not called — it would
+    re-resolve the engine through a bot repository this materialiser does
+    not carry, for a value the pipeline already holds.
+    """
+    return "staff", ctx.owner_id
 
 
 __all__ = ["ResourcesMaterialiser"]

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -28,6 +28,8 @@ Three invariants, all from the W6 work item:
 from __future__ import annotations
 
 import asyncio
+import tempfile
+from pathlib import Path
 from typing import Any, Sequence
 
 from agentclaw.community.core.bot_config_manifest.apply.context import ApplyContext
@@ -46,6 +48,10 @@ from agentclaw.community.core.bot_config_manifest.apply.registry import (
 )
 from agentclaw.community.core.bot_config_manifest.capabilities import (
     ManifestCategory,
+)
+from agentclaw.community.core.bot_config_manifest.fetch.unpack import (
+    UnpackError,
+    unpack_archive,
 )
 
 _FETCH_CATEGORY = "resources"
@@ -81,13 +87,44 @@ class ResourcesMaterialiser(Materialiser):
                 failures.append(failed)
                 continue
             if isinstance(path, str) and path.endswith("/"):
-                # Directory entries arrive with Task 3.
-                failures.append(
-                    ResolveFailure(
-                        str(path),
-                        "directory resource entries are not materialised yet",
+                unpack_kind = entry.get("unpack")
+                if unpack_kind not in ("zip", "tar.gz"):
+                    failures.append(
+                        ResolveFailure(
+                            path,
+                            "a directory entry fetched from a URL must declare "
+                            "'unpack: zip|tar.gz'",
+                        )
                     )
+                    continue
+                source_url = entry.get("source")
+                if not isinstance(source_url, str) or not source_url:
+                    failures.append(
+                        ResolveFailure(
+                            path, "a directory entry must declare 'source'"
+                        )
+                    )
+                    continue
+                try:
+                    archive = await self._fetch_entry(ctx, source_url, entry, path)
+                except EntryFetchError as exc:
+                    failures.append(ResolveFailure(path, exc.reason))
+                    continue
+                members = await asyncio.to_thread(
+                    self._unpack_members,
+                    archive,
+                    unpack_kind,
+                    entry.get("strip_components", 0),
                 )
+                if isinstance(members, str):
+                    failures.append(ResolveFailure(path, members))
+                    continue
+                # The directory sentinel: identity=path, value=None. It rides
+                # first in the intent list so plan marks the tree for
+                # replacement and write deletes it before members upload.
+                intents.append(Intent(identity=path, value=None))
+                for rel, data in members:
+                    intents.append(Intent(identity=path + rel, value=data))
                 continue
             inline = entry.get("content")
             if isinstance(inline, str):
@@ -103,27 +140,71 @@ class ResourcesMaterialiser(Materialiser):
                 )
                 continue
             try:
-                # Blocking network + disk I/O (W2's sync transport, W11's blob
-                # write) off the event loop — see the identity materialiser's
-                # note; a dry run must not park the server on a hung source.
-                fetched = await asyncio.to_thread(
-                    self._fetcher.fetch,
-                    ctx,
-                    source_url=source_url,
-                    digest=entry.get("digest"),
-                    auth=entry.get("auth"),
-                    category=_FETCH_CATEGORY,
-                    keep_last=(
-                        entry.get("on_fetch_failure", "keep_last") == "keep_last"
-                    ),
-                    entry_identity=path,
-                )
+                value = await self._fetch_entry(ctx, source_url, entry, path)
             except EntryFetchError as exc:
                 failures.append(ResolveFailure(str(path), exc.reason))
                 continue
-            intents.append(Intent(identity=path, value=fetched.content))
+            intents.append(Intent(identity=path, value=value))
         self._check_nesting(entries, failures)
         return ResolveResult(intents=tuple(intents), failures=tuple(failures))
+
+    async def _fetch_entry(
+        self,
+        ctx: ApplyContext,
+        source_url: str,
+        entry: dict[str, Any],
+        path: str,
+    ) -> bytes:
+        """One entry's bytes (or archive) through the W2/W3/W11 funnel.
+
+        Raises :class:`EntryFetchError` — the caller translates it into this
+        category's ``ResolveFailure`` currency. Blocking network + disk I/O
+        (W2's sync transport, W11's blob write) off the event loop — see the
+        identity materialiser's note; a dry run must not park the server on
+        a hung source.
+        """
+        fetched = await asyncio.to_thread(
+            self._fetcher.fetch,
+            ctx,
+            source_url=source_url,
+            digest=entry.get("digest"),
+            auth=entry.get("auth"),
+            category=_FETCH_CATEGORY,
+            keep_last=(entry.get("on_fetch_failure", "keep_last") == "keep_last"),
+            entry_identity=path,
+        )
+        return fetched.content
+
+    @staticmethod
+    def _unpack_members(
+        archive: bytes, kind: str, strip_components: int
+    ) -> list[tuple[str, bytes]] | str:
+        """The guarded unpack, platform-side, into a throwaway directory.
+
+        The bot is never a scratch space: ``unpack_archive`` writes only into
+        a fresh temporary directory, so a bad or oversized archive (W1's
+        member / unpacked-size limits live inside it) fails before anything
+        is delivered. Returned members are ``(relative path, bytes)`` with
+        ``strip_components`` already applied — the bytes are read back
+        before the throwaway dir goes away; a refusal comes back as its
+        reason string rather than an exception, keeping every failure in
+        ``resolve``'s currency and the bot's tree untouched.
+        """
+        try:
+            with tempfile.TemporaryDirectory(prefix="manifest-resources-") as tmp:
+                tree = unpack_archive(
+                    archive,
+                    kind,
+                    Path(tmp) / "tree",
+                    strip_components=strip_components,
+                )
+                # ``UnpackedTree.members`` are the tree's files only —
+                # directories are structural — relative to ``root``.
+                return [
+                    (name, (tree.root / name).read_bytes()) for name in tree.members
+                ]
+        except UnpackError as exc:
+            return str(exc)
 
     def _entry_failure(
         self, entry: dict[str, Any], path: Any, index: int

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -24,6 +24,21 @@ Three invariants, all from the W6 work item:
   every apply rewrites every member. ``plan`` therefore classifies for the
   report only (created / updated), never "unchanged", and the category is
   never ``is_noop``.
+
+Two v1 narrows, stated here rather than discovered:
+
+- **The write chain's admission rules are re-asked in ``resolve``**
+  (extension allow-list, size cap — the same constants the service
+  enforces), so an undeliverable member fails its category with the tree
+  still standing rather than one delete ago. What is *not* re-asked is the
+  HTTP surface's read-only policy (dotfiles, reserved roots): a manifest
+  declaring ``.env`` is the owner's declaration, deliberately broader than
+  the console router's guard — that is the platform's contract with apply,
+  not an oversight.
+- **``plan`` probes ``exists`` per member** for the report's label alone.
+  A 5000-member tree therefore costs 5000 more device round trips than a
+  single probe would — accepted for v1's tree sizes, and the first place to
+  look if apply latency ever outruns the lock TTL on large archives.
 """
 from __future__ import annotations
 
@@ -61,9 +76,14 @@ from agentclaw.community.core.bot_config_manifest.fetch.unpack import (
 #: fetch funnel caps by these exact keys, so each form fetches under its own
 #: name. A shared "resources" would silently take the file width's fallback
 #: for archives, and the W11 linkage column would carry a category the
-#: vocabulary never defined.
-_FETCH_CATEGORY_FILE = "resources_file"
-_FETCH_CATEGORY_ARCHIVE = "resources_archive"
+#: vocabulary never defined. ``FetchCategory``'s members, not raw strings:
+#: a typo in a string would silently re-take the fallback cap.
+from agentclaw.community.core.bot_config_manifest.fetch.limits import (
+    FetchCategory,
+)
+
+_FETCH_CATEGORY_FILE = FetchCategory.RESOURCES_FILE.value
+_FETCH_CATEGORY_ARCHIVE = FetchCategory.RESOURCES_ARCHIVE.value
 
 
 class ResourcesMaterialiser(Materialiser):
@@ -106,6 +126,15 @@ class ResourcesMaterialiser(Materialiser):
                         )
                     )
                     continue
+                strip = entry.get("strip_components", 0)
+                if not isinstance(strip, int) or isinstance(strip, bool) or strip < 0:
+                    failures.append(
+                        ResolveFailure(
+                            path,
+                            "'strip_components' must be a non-negative integer",
+                        )
+                    )
+                    continue
                 source_url = entry.get("source")
                 if not isinstance(source_url, str) or not source_url:
                     failures.append(
@@ -126,7 +155,7 @@ class ResourcesMaterialiser(Materialiser):
                     self._unpack_members,
                     archive,
                     unpack_kind,
-                    entry.get("strip_components", 0),
+                    strip,
                 )
                 if isinstance(members, str):
                     failures.append(ResolveFailure(path, members))
@@ -134,6 +163,22 @@ class ResourcesMaterialiser(Materialiser):
                 # The directory sentinel: identity=path, value=None. It rides
                 # first in the intent list so plan marks the tree for
                 # replacement and write deletes it before members upload.
+                # The gate on every member, before the sentinel that
+                # promises the tree: one undeliverable member must abort
+                # the category with the tree still standing, not delete it
+                # for a partial delivery that every re-apply would repeat.
+                bad = next(
+                    (
+                        (path + rel, refused)
+                        for rel, data in members
+                        if (refused := _delivery_refusal(path + rel, data))
+                        is not None
+                    ),
+                    None,
+                )
+                if bad is not None:
+                    failures.append(ResolveFailure(bad[0], bad[1]))
+                    continue
                 intents.append(
                     Intent(identity=path, value=None, note=fetched.fallback_reason)
                 )
@@ -148,7 +193,12 @@ class ResourcesMaterialiser(Materialiser):
                 continue
             inline = entry.get("content")
             if isinstance(inline, str):
-                intents.append(Intent(identity=path, value=inline.encode("utf-8")))
+                data = inline.encode("utf-8")
+                refused = _delivery_refusal(path, data)
+                if refused is not None:
+                    failures.append(ResolveFailure(path, refused))
+                    continue
+                intents.append(Intent(identity=path, value=data))
                 continue
             source_url = entry.get("source")
             if not isinstance(source_url, str) or not source_url:
@@ -165,6 +215,10 @@ class ResourcesMaterialiser(Materialiser):
                 )
             except EntryFetchError as exc:
                 failures.append(ResolveFailure(str(path), exc.reason))
+                continue
+            refused = _delivery_refusal(path, fetched.content)
+            if refused is not None:
+                failures.append(ResolveFailure(path, refused))
                 continue
             intents.append(
                 Intent(
@@ -331,22 +385,38 @@ class ResourcesMaterialiser(Materialiser):
         # tree's replace removes everything under ``path``, including files
         # the new archive no longer ships and hand-added ones (the
         # ownership rule). Sentinels produce no EntryResult: an ownership
-        # action, not an entry.
+        # action, not an entry — but a *failed* one fails its members, in
+        # the stage's composed words (never the exception's: a transport
+        # error can quote a header, a header can carry a token).
+        failed_trees: list[str] = []
         for planned in plan.entries:
             if planned.intent.value is not None:
                 continue
-            await self._resources.delete(
-                entity_type=entity_type,
-                entity_id=entity_id,
-                bot_id=ctx.bot_id,
-                engine_type=ctx.engine_type,
-                path=planned.intent.identity,
-            )
+            try:
+                await self._resources.delete(
+                    entity_type=entity_type,
+                    entity_id=entity_id,
+                    bot_id=ctx.bot_id,
+                    engine_type=ctx.engine_type,
+                    path=planned.intent.identity,
+                )
+            except Exception:  # noqa: BLE001 — surfaced per member, not as text
+                failed_trees.append(planned.intent.identity)
         # 2) then each member file, in declaration order
         for planned in plan.entries:
             identity = planned.intent.identity
             data = planned.intent.value
             if data is None:
+                continue
+            if any(identity.startswith(tree) for tree in failed_trees):
+                results.append(
+                    EntryResult(
+                        self.construct,
+                        identity,
+                        EntryOutcome.FAILED,
+                        "directory tree replacement failed",
+                    )
+                )
                 continue
             target_dir, _, filename = identity.rpartition("/")
             try:
@@ -381,6 +451,41 @@ class ResourcesMaterialiser(Materialiser):
                 )
             )
         return tuple(results)
+
+
+def _delivery_refusal(identity: str, data: bytes) -> str | None:
+    """The write chain's own admission rules, asked before the first delete.
+
+    ``ResourceFileService.upload_file`` refuses extensions outside its
+    allow-list (no ``.sh``, no extensionless files) and content over its
+    size cap. A refusal that first lands on the write side would arrive
+    *after* the sentinel deleted the declared tree — a deterministically
+    half-written tree on every re-apply. So the materialiser re-asks the
+    same rules in ``resolve``, where failing costs nothing: the constants
+    are imported at call time so this module's importers still pull no
+    service graph, and the fake-driven tests cannot drift from the real
+    gate because both read the same constants.
+
+    Inline ``content`` is the other reason the gate lives here: it never
+    goes through the fetch funnel's caps, so this is the only line an
+    oversized inline entry meets.
+    """
+    from agentclaw.community.core.resources.services.file_service import (
+        ALLOWED_EXTENSIONS,
+        MAX_FILE_SIZE,
+    )
+
+    if Path(identity.rpartition("/")[2]).suffix.lower() not in ALLOWED_EXTENSIONS:
+        return (
+            "the workspace file surface does not allow this file type; "
+            f"allowed extensions: {', '.join(sorted(ALLOWED_EXTENSIONS))}"
+        )
+    if len(data) > MAX_FILE_SIZE:
+        return (
+            "content exceeds the workspace file surface's size cap "
+            f"({MAX_FILE_SIZE // (1024 * 1024)}MB)"
+        )
+    return None
 
 
 def _coords(ctx: ApplyContext) -> tuple[str, str]:

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -1,0 +1,187 @@
+"""``resources`` → ``ResourceFileService``: workspace files and directory trees.
+
+Three invariants, all from the W6 work item:
+
+- **One write chain for both engine families.** ``ResourceFileService``'s
+  dispatcher already fans out per transport (arca / baas: device sync; teclaw:
+  per-file forwarding), so the materialiser never branches on engine — the
+  acceptance criterion's "逐文件展开" is a property of this chain, not code
+  here. **This module must not import anything from
+  ``agentclaw.community.kernel.bot_config``** (the artifact contract stays
+  untouched: no directory-typed ``ResourceRef``, no T5 subtree optimisation).
+- **Ownership is per-entry.** A file entry owns its exact ``path``; a
+  directory entry owns the tree under ``path`` (its replacement removes files
+  the new archive no longer ships — including hand-added ones). Nothing
+  outside a declared ``path`` is ever touched. Cross-entry removals (a path
+  the previous document declared and this one no longer does) are **v1-empty
+  by the work item's own definition**: the acceptance criteria define
+  ownership only within each entry's tree, and the BaaS transport has no
+  "who wrote this file" ledger to answer the broader question — the W12
+  contract assigns that breadth to the engine-side applier.
+- **Replace, don't diff.** The directory criterion: re-applying an unchanged
+  archive must not skip writes based on the *source* looking unchanged — a
+  drifted tree would survive that. v1 takes the recommended option (1):
+  every apply rewrites every member. ``plan`` therefore classifies for the
+  report only (created / updated), never "unchanged", and the category is
+  never ``is_noop``.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Sequence
+
+from agentclaw.community.core.bot_config_manifest.apply.context import ApplyContext
+from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
+    EntryFetchError,
+)
+from agentclaw.community.core.bot_config_manifest.apply.outcomes import (
+    EntryResult,
+)
+from agentclaw.community.core.bot_config_manifest.apply.registry import (
+    CategoryPlan,
+    Intent,
+    Materialiser,
+    ResolveFailure,
+    ResolveResult,
+)
+from agentclaw.community.core.bot_config_manifest.capabilities import (
+    ManifestCategory,
+)
+
+_FETCH_CATEGORY = "resources"
+
+
+class ResourcesMaterialiser(Materialiser):
+    """Converges declared workspace resources toward the declaration."""
+
+    construct = ManifestCategory.RESOURCES
+
+    def __init__(self, resource_service: Any, fetcher: Any) -> None:
+        self._resources = resource_service
+        self._fetcher = fetcher
+
+    async def resolve(
+        self, ctx: ApplyContext, entries: Sequence[dict[str, Any]]
+    ) -> ResolveResult:
+        """Declared entries → intents: bytes per ``path``, both forms.
+
+        Everything that can fail **before touching the bot** fails here, the
+        registry's contract for the whole engine: path validation re-asked
+        (a document can predate the rule), inline ``content`` taken as the
+        bytes without a fetch, and ``source`` fetched through the W2/W3/W11
+        funnel — a failure aborts the whole category before the first write,
+        which under overwrite is the non-destructive answer.
+        """
+        intents: list[Intent] = []
+        failures: list[ResolveFailure] = []
+        for index, entry in enumerate(entries):
+            path = entry.get("path") if isinstance(entry, dict) else None
+            failed = self._entry_failure(entry, path, index)
+            if failed is not None:
+                failures.append(failed)
+                continue
+            if isinstance(path, str) and path.endswith("/"):
+                # Directory entries arrive with Task 3.
+                failures.append(
+                    ResolveFailure(
+                        str(path),
+                        "directory resource entries are not materialised yet",
+                    )
+                )
+                continue
+            inline = entry.get("content")
+            if isinstance(inline, str):
+                intents.append(Intent(identity=path, value=inline.encode("utf-8")))
+                continue
+            source_url = entry.get("source")
+            if not isinstance(source_url, str) or not source_url:
+                failures.append(
+                    ResolveFailure(
+                        str(path),
+                        "a resources entry must declare 'source' or 'content'",
+                    )
+                )
+                continue
+            try:
+                # Blocking network + disk I/O (W2's sync transport, W11's blob
+                # write) off the event loop — see the identity materialiser's
+                # note; a dry run must not park the server on a hung source.
+                fetched = await asyncio.to_thread(
+                    self._fetcher.fetch,
+                    ctx,
+                    source_url=source_url,
+                    digest=entry.get("digest"),
+                    auth=entry.get("auth"),
+                    category=_FETCH_CATEGORY,
+                    keep_last=(
+                        entry.get("on_fetch_failure", "keep_last") == "keep_last"
+                    ),
+                    entry_identity=path,
+                )
+            except EntryFetchError as exc:
+                failures.append(ResolveFailure(str(path), exc.reason))
+                continue
+            intents.append(Intent(identity=path, value=fetched.content))
+        self._check_nesting(entries, failures)
+        return ResolveResult(intents=tuple(intents), failures=tuple(failures))
+
+    def _entry_failure(
+        self, entry: dict[str, Any], path: Any, index: int
+    ) -> ResolveFailure | None:
+        """Path re-validation: the belt behind the PUT-time schema rules.
+
+        A stored document can predate a rule, or have skipped the validator
+        (a hand-built apply in W8's lifecycle points) — this is the half the
+        path-safety question needs answered at *apply* time, not only at
+        write time.
+        """
+        if not isinstance(path, str) or not path:
+            return ResolveFailure(
+                f"[{index}]", "a resources entry must declare a 'path'"
+            )
+        if path.startswith("/") or ".." in path.split("/") or "\x00" in path:
+            return ResolveFailure(path, "path must be workspace-relative")
+        return None
+
+    def _check_nesting(
+        self,
+        entries: Sequence[dict[str, Any]],
+        failures: list[ResolveFailure],
+    ) -> None:
+        """The PUT-time nesting ban, re-asked here (W6 acceptance).
+
+        One declared path living under another declared directory path would
+        make the directory's whole-tree replace delete the sibling mid-apply.
+        Paths are already relative and normalised at schema time; here we
+        re-check, so a document that reached storage before this check existed
+        still cannot apply destructively.
+        """
+        paths = [
+            e.get("path")
+            for e in entries
+            if isinstance(e, dict) and isinstance(e.get("path"), str)
+        ]
+        directories = [p for p in paths if p.endswith("/")]
+        for candidate in paths:
+            for directory in directories:
+                if candidate != directory and candidate.startswith(directory):
+                    failures.append(
+                        ResolveFailure(
+                            candidate,
+                            f"path nests under another declared directory "
+                            f"{directory!r}",
+                        )
+                    )
+
+    async def plan(
+        self, ctx: ApplyContext, intents: Sequence[Intent]
+    ) -> CategoryPlan:
+        return CategoryPlan()  # replaced by the classification stage (W6)
+
+    async def write(
+        self, ctx: ApplyContext, plan: CategoryPlan
+    ) -> Sequence[EntryResult]:
+        return ()  # replaced by the delivery stage (W6)
+
+
+__all__ = ["ResourcesMaterialiser"]

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -37,6 +37,7 @@ from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
     EntryFetchError,
 )
 from agentclaw.community.core.bot_config_manifest.apply.outcomes import (
+    EntryOutcome,
     EntryResult,
 )
 from agentclaw.community.core.bot_config_manifest.apply.registry import (
@@ -287,7 +288,67 @@ class ResourcesMaterialiser(Materialiser):
     async def write(
         self, ctx: ApplyContext, plan: CategoryPlan
     ) -> Sequence[EntryResult]:
-        return ()  # replaced by the delivery stage (W6)
+        """Execute: replace each declared tree, rewrite each file.
+
+        Half-written windows are v1's documented narrowing (the transport
+        has no rename): a mid-write stop leaves the tree in an unknown
+        state and the member's result row says ``failed`` — the report is
+        the source of truth, no rollback is attempted. The platform-side
+        unpack already kept a bad archive from reaching this far.
+        """
+        entity_type, entity_id = _coords(ctx)
+        results: list[EntryResult] = []
+        # 1) Directory sentinels first — one delete per declared tree. A
+        # tree's replace removes everything under ``path``, including files
+        # the new archive no longer ships and hand-added ones (the
+        # ownership rule). Sentinels produce no EntryResult: an ownership
+        # action, not an entry.
+        for planned in plan.entries:
+            if planned.intent.value is not None:
+                continue
+            await self._resources.delete(
+                entity_type=entity_type,
+                entity_id=entity_id,
+                bot_id=ctx.bot_id,
+                engine_type=ctx.engine_type,
+                path=planned.intent.identity,
+            )
+        # 2) then each member file, in declaration order
+        for planned in plan.entries:
+            identity = planned.intent.identity
+            data = planned.intent.value
+            if data is None:
+                continue
+            target_dir, _, filename = identity.rpartition("/")
+            try:
+                await self._resources.upload_file(
+                    entity_type=entity_type,
+                    entity_id=entity_id,
+                    bot_id=ctx.bot_id,
+                    engine_type=ctx.engine_type,
+                    target_dir=target_dir,
+                    filename=filename,
+                    data=data,
+                )
+            except Exception:  # noqa: BLE001 — surfaced per entry, not as text
+                # Deliberately composed, not interpolated: the report's
+                # reason may never carry raw exception text (a transport
+                # error can quote a header, a header can carry a token).
+                results.append(
+                    EntryResult(
+                        self.construct,
+                        identity,
+                        EntryOutcome.FAILED,
+                        "resource delivery failed",
+                    )
+                )
+                continue
+            results.append(
+                EntryResult(
+                    self.construct, identity, EntryOutcome(planned.outcome)
+                )
+            )
+        return tuple(results)
 
 
 def _coords(ctx: ApplyContext) -> tuple[str, str]:

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/materialisers/resources.py
@@ -56,7 +56,14 @@ from agentclaw.community.core.bot_config_manifest.fetch.unpack import (
     unpack_archive,
 )
 
-_FETCH_CATEGORY = "resources"
+#: Schema §5 states the two resource forms' fetch widths separately —
+#: ``resources_file`` (100MB) and ``resources_archive`` (200MB) — and the
+#: fetch funnel caps by these exact keys, so each form fetches under its own
+#: name. A shared "resources" would silently take the file width's fallback
+#: for archives, and the W11 linkage column would carry a category the
+#: vocabulary never defined.
+_FETCH_CATEGORY_FILE = "resources_file"
+_FETCH_CATEGORY_ARCHIVE = "resources_archive"
 
 
 class ResourcesMaterialiser(Materialiser):
@@ -108,7 +115,10 @@ class ResourcesMaterialiser(Materialiser):
                     )
                     continue
                 try:
-                    archive = await self._fetch_entry(ctx, source_url, entry, path)
+                    fetched = await self._fetch_entry(
+                        ctx, source_url, entry, path, _FETCH_CATEGORY_ARCHIVE
+                    )
+                    archive = fetched.content
                 except EntryFetchError as exc:
                     failures.append(ResolveFailure(path, exc.reason))
                     continue
@@ -124,9 +134,17 @@ class ResourcesMaterialiser(Materialiser):
                 # The directory sentinel: identity=path, value=None. It rides
                 # first in the intent list so plan marks the tree for
                 # replacement and write deletes it before members upload.
-                intents.append(Intent(identity=path, value=None))
+                intents.append(
+                    Intent(identity=path, value=None, note=fetched.fallback_reason)
+                )
                 for rel, data in members:
-                    intents.append(Intent(identity=path + rel, value=data))
+                    intents.append(
+                        Intent(
+                            identity=path + rel,
+                            value=data,
+                            note=fetched.fallback_reason,
+                        )
+                    )
                 continue
             inline = entry.get("content")
             if isinstance(inline, str):
@@ -142,11 +160,19 @@ class ResourcesMaterialiser(Materialiser):
                 )
                 continue
             try:
-                value = await self._fetch_entry(ctx, source_url, entry, path)
+                fetched = await self._fetch_entry(
+                    ctx, source_url, entry, path, _FETCH_CATEGORY_FILE
+                )
             except EntryFetchError as exc:
                 failures.append(ResolveFailure(str(path), exc.reason))
                 continue
-            intents.append(Intent(identity=path, value=value))
+            intents.append(
+                Intent(
+                    identity=path,
+                    value=fetched.content,
+                    note=fetched.fallback_reason,
+                )
+            )
         self._check_nesting(entries, failures)
         return ResolveResult(intents=tuple(intents), failures=tuple(failures))
 
@@ -156,26 +182,29 @@ class ResourcesMaterialiser(Materialiser):
         source_url: str,
         entry: dict[str, Any],
         path: str,
-    ) -> bytes:
+        category: str,
+    ):
         """One entry's bytes (or archive) through the W2/W3/W11 funnel.
 
         Raises :class:`EntryFetchError` — the caller translates it into this
-        category's ``ResolveFailure`` currency. Blocking network + disk I/O
-        (W2's sync transport, W11's blob write) off the event loop — see the
-        identity materialiser's note; a dry run must not park the server on
-        a hung source.
+        category's ``ResolveFailure`` currency. Returns the whole
+        :class:`FetchedEntry` rather than just ``.content``: a keep_last
+        fallback's reason rides it (§9.6 — the report row must state the
+        fallback), and dropping it here would be the contract broken
+        quietly. Blocking network + disk I/O (W2's sync transport, W11's
+        blob write) off the event loop — see the identity materialiser's
+        note; a dry run must not park the server on a hung source.
         """
-        fetched = await asyncio.to_thread(
+        return await asyncio.to_thread(
             self._fetcher.fetch,
             ctx,
             source_url=source_url,
             digest=entry.get("digest"),
             auth=entry.get("auth"),
-            category=_FETCH_CATEGORY,
+            category=category,
             keep_last=(entry.get("on_fetch_failure", "keep_last") == "keep_last"),
             entry_identity=path,
         )
-        return fetched.content
 
     @staticmethod
     def _unpack_members(
@@ -345,7 +374,10 @@ class ResourcesMaterialiser(Materialiser):
                 continue
             results.append(
                 EntryResult(
-                    self.construct, identity, EntryOutcome(planned.outcome)
+                    self.construct,
+                    identity,
+                    EntryOutcome(planned.outcome),
+                    note=planned.intent.note,
                 )
             )
         return tuple(results)

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/registry.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/registry.py
@@ -173,6 +173,7 @@ def build_materialisers(
     capability_reader: Any,
     package_validator: Any,
     entry_fetcher: Any,
+    resource_service: Any,
 ) -> dict[ApplyConstruct, Materialiser]:
     """The registry, built from injected services.
 
@@ -182,7 +183,7 @@ def build_materialisers(
     exists for that class of thing) and pull the bot-configuration graph into
     anything that merely wants the ordering table.
 
-    **W4 registered two; W5 registers four.** The map is keyed by each
+    **W4 registered two, W5 four, W6 five.** The map is keyed by each
     materialiser's own ``construct`` rather than by a name written here — so
     a materialiser cannot be registered under the wrong key. The fetch-side
     dependencies (``package_validator``, ``entry_fetcher``) exist because the
@@ -198,6 +199,9 @@ def build_materialisers(
     )
     from agentclaw.community.core.bot_config_manifest.apply.materialisers.mcp import (
         McpMaterialiser,
+    )
+    from agentclaw.community.core.bot_config_manifest.apply.materialisers.resources import (
+        ResourcesMaterialiser,
     )
     from agentclaw.community.core.bot_config_manifest.apply.materialisers.script import (
         ScriptMaterialiser,
@@ -217,6 +221,7 @@ def build_materialisers(
             package_validator,
             entry_fetcher,
         ),
+        ResourcesMaterialiser(resource_service, entry_fetcher),
     )
     return {m.construct: m for m in materialisers}
 

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/resource_port.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/apply/resource_port.py
@@ -1,0 +1,66 @@
+"""The resources write path's narrow naming, for the apply wiring's providers.
+
+The same move ``identity_port.py`` records, for the same reason: the apply
+wiring's lazy providers are keyed by type, and the one type that would name
+``ResourceFileService`` is a module that reaches the device dispatcher graph
+at import time — importing it from the apply service (or eagerly from the DI
+module) would turn a lazy provider into an import cycle. So this module
+imports nothing, names the three methods the ``resources`` materialiser
+calls, and serves as the provider key.
+
+The bound object is the real ``ResourceFileService`` singleton — structural
+typing, no adapter, no second implementation. A signature drift on the real
+service surfaces as a ``TypeError`` in the materialiser's tests (whose fake
+mirrors these shapes) before it surfaces mid-apply.
+"""
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ManifestResourcePort(Protocol):
+    """The three methods the ``resources`` materialiser reaches, as a type key.
+
+    Signatures mirror the real service's keyword-only contract, so a drift
+    there is caught by the materialiser's fake-driven tests first.
+    """
+
+    @abstractmethod
+    async def upload_file(
+        self,
+        *,
+        entity_type: str = "staff",
+        entity_id: str,
+        bot_id: str,
+        engine_type: str,
+        target_dir: str,
+        filename: str,
+        data: bytes,
+        preserve_structure: bool = False,
+    ) -> dict[str, Any]: ...
+
+    @abstractmethod
+    async def delete(
+        self,
+        *,
+        entity_type: str = "staff",
+        entity_id: str,
+        bot_id: str,
+        engine_type: str,
+        path: str,
+    ) -> bool: ...
+
+    @abstractmethod
+    async def exists(
+        self,
+        *,
+        entity_id: str,
+        bot_id: str,
+        engine_type: str,
+        path: str,
+    ) -> bool: ...
+
+
+__all__ = ["ManifestResourcePort"]

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/capabilities.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/capabilities.py
@@ -284,9 +284,9 @@ def resolve_capabilities(
 
     blocked: dict[Construct, str | None] = {
         ManifestCategory.MCP: None,
-        # Accepted with no materializer *yet* (W6). An accepted document sits
-        # inert until then, which is what `GET …/capabilities` and the module
-        # README say out loud rather than leaving a caller to discover.
+        # Materialised since W6, through the one write chain
+        # (`ResourceFileService`'s dispatcher) with tree-replacement
+        # semantics for directory entries — see the resources materialiser.
         ManifestCategory.RESOURCES: None,
         ManifestCategory.SKILLS: None,
         ManifestCategory.ENGINE_CONFIG: _REASON_ENGINE_CONFIG,

--- a/src/backend/src/agentclaw/community/core/bot_config_manifest/services/config_manifest_apply_service.py
+++ b/src/backend/src/agentclaw/community/core/bot_config_manifest/services/config_manifest_apply_service.py
@@ -32,6 +32,9 @@ from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
 from agentclaw.community.core.bot_config_manifest.apply.identity_port import (
     ManifestIdentityPort,
 )
+from agentclaw.community.core.bot_config_manifest.apply.resource_port import (
+    ManifestResourcePort,
+)
 from agentclaw.community.core.bot_config_manifest.fetch.limits import (
     APPLY_BUDGET_S,
     APPLY_FETCH_TOTAL_LIMIT,
@@ -127,6 +130,7 @@ class BotConfigManifestApplyService(BotConfigManifestApplyServiceProtocol):
         capability_reader_provider: Callable[[], BotCapabilityStateReaderProtocol],
         package_validator_provider: Callable[[], SkillPackageValidator],
         entry_fetcher_provider: Callable[[], EntryFetcher],
+        resource_service_provider: Callable[[], ManifestResourcePort],
     ) -> None:
         self._manifests = manifest_service
         self._applies = apply_repository
@@ -150,6 +154,10 @@ class BotConfigManifestApplyService(BotConfigManifestApplyServiceProtocol):
         self._capability_reader_provider = capability_reader_provider
         self._package_validator_provider = package_validator_provider
         self._entry_fetcher_provider = entry_fetcher_provider
+        # The same laziness for W6's resources materialiser: the resource
+        # file service dispatches to devices, another arm of the same
+        # bot-configuration graph that made every provider above lazy.
+        self._resource_service_provider = resource_service_provider
 
     # ── starting ────────────────────────────────────────────────────────────
 
@@ -520,6 +528,7 @@ class BotConfigManifestApplyService(BotConfigManifestApplyServiceProtocol):
                 capability_reader=self._capability_reader_provider(),
                 package_validator=self._package_validator_provider(),
                 entry_fetcher=self._entry_fetcher_provider(),
+                resource_service=self._resource_service_provider(),
             )
         )
 

--- a/src/backend/src/agentclaw/community/di/modules/manifest_fetch_module.py
+++ b/src/backend/src/agentclaw/community/di/modules/manifest_fetch_module.py
@@ -2,7 +2,7 @@
 
 The apply wiring W11's repository binding comment reserved: the guarded
 fetcher (W2), the content store (W11), and the one entry-fetcher funnel over
-W2/W3/W11, plus the five lazy service factories the registry's two W5
+W2/W3/W11, plus the lazy service factories the registry's fetch-consuming
 materialisers take their collaborators through. One module because one
 feature wave owns them — the same reason the apply service and its
 repositories bind in ``bot_management_module``, where they landed with W4.
@@ -25,6 +25,9 @@ from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
 )
 from agentclaw.community.core.bot_config_manifest.apply.identity_port import (
     ManifestIdentityPort,
+)
+from agentclaw.community.core.bot_config_manifest.apply.resource_port import (
+    ManifestResourcePort,
 )
 from agentclaw.community.core.bot_config_manifest.content.service import (
     ManifestContentService,
@@ -218,3 +221,33 @@ class ManifestFetchModule(Module):
     ) -> Callable[[], EntryFetcher]:
         """The lazy lookup the apply service's registry wiring asks for."""
         return lambda: injector.get(EntryFetcher)
+
+    @singleton
+    @provider
+    @inject
+    def manifest_resource_service_factory(
+        self, injector: Injector
+    ) -> Callable[[], ManifestResourcePort]:
+        """The write chain the ``resources`` materialiser delivers through.
+
+        Lazy with a function-level import for the reason the identity
+        factory above records: the resource file service module reaches the
+        device dispatcher graph at import time, and this module's import
+        must not trigger that chain. Structural check at wiring time for
+        the same reason as there — the port has no implementation
+        relationship to the service, so nothing else would notice a rename
+        until mid-apply.
+        """
+        from agentclaw.community.core.services.resource_file_service import (
+            ResourceFileService,
+        )
+
+        def _resources() -> ManifestResourcePort:
+            service = injector.get(ResourceFileService)
+            if not isinstance(service, ManifestResourcePort):
+                raise TypeError(
+                    "ResourceFileService no longer satisfies ManifestResourcePort"
+                )
+            return service
+
+        return _resources

--- a/src/backend/tests/community/adapters/http/openapi_v1/test_config_manifest_apply_bars.py
+++ b/src/backend/tests/community/adapters/http/openapi_v1/test_config_manifest_apply_bars.py
@@ -133,6 +133,7 @@ def test_apply_declares_the_bar_w10_settled():
             capability_reader=object(),
             package_validator=object(),
             entry_fetcher=object(),
+            resource_service=object(),
         )
     ),
 )
@@ -189,6 +190,7 @@ def test_apply_admission_mode_is_no_wider_than_the_categories_it_writes():
         capability_reader=object(),
         package_validator=object(),
         entry_fetcher=object(),
+        resource_service=object(),
     ):
         for path in _CATEGORY_WRITE_PATHS[construct.value]:
             for (method, candidate), mode in ADMISSION.items():

--- a/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
@@ -658,3 +658,69 @@ def make_context(
             is_teclaw=lambda engine: engine == "teclaw",
         ),
     )
+
+
+class FakeResourceFileService:
+    """Stands in for ``ResourceFileService``: uploads and deletes, recorded.
+
+    ``ResourceFileService`` is v1's single write chain for manifest resources
+    (its dispatcher covers the arca / baas / teclaw transports uniformly), so
+    the fake needs only the three entry points the materialiser calls:
+    ``upload_file``, ``delete`` — plus ``exists`` for the plan stage's
+    classification. Signatures mirror the real service's, so a drift shows up
+    as a TypeError in these tests before it shows up mid-apply in production.
+
+    ``delete`` removes from the presence set as well — the real service's
+    contract — because the plan stage classifies by ``exists`` and would
+    otherwise call a deleted path "unchanged".
+    """
+
+    def __init__(self, exists_paths: set[str] | None = None) -> None:
+        self.writes: dict[tuple[str, str], bytes] = {}
+        self.deleted: list[str] = []
+        self._exists = set(exists_paths or ())
+
+    def record_present(self, *paths: str) -> None:
+        self._exists.update(paths)
+
+    async def upload_file(
+        self,
+        *,
+        entity_type: str = "staff",
+        entity_id: str,
+        bot_id: str,
+        engine_type: str,
+        target_dir: str,
+        filename: str,
+        data: bytes,
+        preserve_structure: bool = False,
+    ) -> dict[str, Any]:
+        self.writes[(target_dir, filename)] = data
+        self._exists.add(f"{target_dir}/{filename}".replace("//", "/"))
+        return {"path": f"{target_dir}/{filename}"}
+
+    async def delete(
+        self,
+        *,
+        entity_type: str = "staff",
+        entity_id: str,
+        bot_id: str,
+        engine_type: str,
+        path: str,
+    ) -> bool:
+        self.deleted.append(path)
+        self._exists.discard(path)
+        return True
+
+    async def exists(
+        self,
+        *,
+        entity_type: str = "staff",
+        entity_id: str,
+        bot_id: str,
+        engine_type: str,
+        path: str,
+        publish_id: str | None = None,
+        device_uuid: str | None = None,
+    ) -> bool:
+        return path in self._exists

--- a/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
@@ -678,6 +678,10 @@ class FakeResourceFileService:
     def __init__(self, exists_paths: set[str] | None = None) -> None:
         self.writes: dict[tuple[str, str], bytes] = {}
         self.deleted: list[str] = []
+        # Full addressing of every call, so a test can pin *how* the write
+        # stage addressed the workspace — same rationale as exists_probes.
+        self.upload_calls: list[dict[str, Any]] = []
+        self.delete_calls: list[dict[str, Any]] = []
         self.exists_probes: list[dict[str, Any]] = []
         self._exists = set(exists_paths or ())
 
@@ -696,6 +700,16 @@ class FakeResourceFileService:
         data: bytes,
         preserve_structure: bool = False,
     ) -> dict[str, Any]:
+        self.upload_calls.append(
+            {
+                "entity_type": entity_type,
+                "entity_id": entity_id,
+                "bot_id": bot_id,
+                "engine_type": engine_type,
+                "target_dir": target_dir,
+                "filename": filename,
+            }
+        )
         self.writes[(target_dir, filename)] = data
         self._exists.add(f"{target_dir}/{filename}".replace("//", "/"))
         return {"path": f"{target_dir}/{filename}"}
@@ -709,6 +723,15 @@ class FakeResourceFileService:
         engine_type: str,
         path: str,
     ) -> bool:
+        self.delete_calls.append(
+            {
+                "entity_type": entity_type,
+                "entity_id": entity_id,
+                "bot_id": bot_id,
+                "engine_type": engine_type,
+                "path": path,
+            }
+        )
         self.deleted.append(path)
         self._exists.discard(path)
         return True

--- a/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/_fakes.py
@@ -678,6 +678,7 @@ class FakeResourceFileService:
     def __init__(self, exists_paths: set[str] | None = None) -> None:
         self.writes: dict[tuple[str, str], bytes] = {}
         self.deleted: list[str] = []
+        self.exists_probes: list[dict[str, Any]] = []
         self._exists = set(exists_paths or ())
 
     def record_present(self, *paths: str) -> None:
@@ -723,4 +724,16 @@ class FakeResourceFileService:
         publish_id: str | None = None,
         device_uuid: str | None = None,
     ) -> bool:
+        # Recorded so a test can pin *how* the plan stage addressed the
+        # workspace — the entity half must be the owner, the router's own
+        # address, not the manifest's storage key.
+        self.exists_probes.append(
+            {
+                "entity_type": entity_type,
+                "entity_id": entity_id,
+                "bot_id": bot_id,
+                "engine_type": engine_type,
+                "path": path,
+            }
+        )
         return path in self._exists

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_engine.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_engine.py
@@ -42,6 +42,7 @@ from ._fakes import (
     FakeIdentityService,
     FakeManifestContent,
     FakeMcpAuth,
+    FakeResourceFileService,
     FakeSkillUploadService,
     FakeStartupScriptService,
     fetched_object,
@@ -64,6 +65,7 @@ def _engine(scripts=None, activations=None, auth=None):
             capability_reader=FakeCapabilityReader(),
             package_validator=real_validator(),
             entry_fetcher=_dummy_entry_fetcher(),
+            resource_service=FakeResourceFileService(),
         )
     )
 
@@ -320,38 +322,40 @@ async def test_applying_one_category_leaves_the_others_alone():
 
 @pytest.mark.asyncio
 async def test_a_category_with_no_materialiser_fails_and_writes_nothing():
-    """W6's categories are an expected state, not a crash.
+    """Post-W6 categories are an expected state, not a crash.
 
     Every entry fails with a readable reason, the category is aborted so nothing
     is destroyed, and the categories that *do* have materialisers still apply.
 
-    Declared with ``resources``, the sparse construct of *this* wave: the
-    test was written against ``skills`` in W4's era and moved forward with
-    each wave that materialises its previous subject — W5 took skills.
+    Declared with ``cli_tools``, the sparse construct after W6: the test was
+    written against ``skills`` in W4's era and moved forward with each wave
+    that materialises its previous subject — W5 took skills, W6 resources.
+    W9 will move it forward again.
     """
     scripts = FakeStartupScriptService()
     report = await _apply(
         _engine(scripts),
         """schema_version: 1
 manifest:
-  resources:
-    - path: data/kb.xlsx
-      source: https://cdn.example.com/kb.xlsx
+  cli_tools:
+    - name: jq
+      source: https://cdn.example.com/jq
+      digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 script:
   body: "echo hi"
 """,
     )
 
-    assert _outcomes(report)["data/kb.xlsx"] is EntryOutcome.FAILED
+    assert _outcomes(report)["jq"] is EntryOutcome.FAILED
     assert _outcomes(report)["script"] is EntryOutcome.CREATED
     assert report.status is ApplyStatus.PARTIAL
 
-    resources = next(
-        c for c in report.categories if c.construct is ManifestCategory.RESOURCES
+    cli_tools = next(
+        c for c in report.categories if c.construct is ManifestCategory.CLI_TOOLS
     )
-    assert resources.aborted is True
-    assert resources.removals == ()
-    reason = resources.entries[0].reason or ""
+    assert cli_tools.aborted is True
+    assert cli_tools.removals == ()
+    reason = cli_tools.entries[0].reason or ""
     assert "materializer" in reason
 
 
@@ -792,6 +796,7 @@ async def test_a_fetching_document_applies_all_four_categories_in_order():
             entry_fetcher=EntryFetcher(
                 fetcher, FakeManifestContent(), FakeCredentials()
             ),
+            resource_service=FakeResourceFileService(),
         )
     )
 

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_service_lifecycle.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_apply_service_lifecycle.py
@@ -52,6 +52,7 @@ from ._fakes import (
     FakeIdentityService,
     FakeManifestContent,
     FakeMcpAuth,
+    FakeResourceFileService,
     FakeSkillUploadService,
     FakeStartupScriptService,
     real_validator,
@@ -152,6 +153,10 @@ def world():
         entry_fetcher_provider=lambda: EntryFetcher(
             FakeGuardedFetcher(), FakeManifestContent(), FakeCredentials()
         ),
+        # W6's materialiser: this suite's document declares no resources,
+        # so the write chain is never reached — but it must exist for the
+        # registry to register.
+        resource_service_provider=lambda: FakeResourceFileService(),
     )
     return service, applies, locks, scripts, BotConfigManifestRepository(db)
 

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_orchestrator_stays_generic.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_orchestrator_stays_generic.py
@@ -118,6 +118,7 @@ def test_every_registered_materialiser_has_a_place_in_the_order():
             capability_reader=object(),
             package_validator=object(),
             entry_fetcher=object(),
+            resource_service=object(),
         )
     )
     assert registered <= ordered

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -132,10 +132,10 @@ def test_file_entry_from_url_resolves_to_intent_bytes():
     m = ResourcesMaterialiser(svc, stub)
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
-        m.resolve(ctx, [{"path": "data/a.bin", "source": "https://x/a.bin"}])
+        m.resolve(ctx, [{"path": "data/a.md", "source": "https://x/a.bin"}])
     )
     assert resolved.ok
-    assert [i.identity for i in resolved.intents] == ["data/a.bin"]
+    assert [i.identity for i in resolved.intents] == ["data/a.md"]
     assert resolved.intents[0].value == b"bytes-of-https://x/a.bin"
     # The funnel saw the entry's own identity under the file form's own
     # category — the W11 apply/entry linkage — with keep_last as the
@@ -147,7 +147,7 @@ def test_file_entry_from_url_resolves_to_intent_bytes():
             "auth": None,
             "category": "resources_file",
             "keep_last": True,
-            "entry_identity": "data/a.bin",
+            "entry_identity": "data/a.md",
         }
     ]
 
@@ -172,13 +172,13 @@ def test_fetch_failure_aborts_whole_category():
         m.resolve(
             ctx,
             [
-                {"path": "data/a.bin", "source": "https://x/a.bin"},
-                {"path": "data/gone.bin", "source": "https://x/gone"},
+                {"path": "data/a.md", "source": "https://x/a.bin"},
+                {"path": "data/gone.md", "source": "https://x/gone"},
             ],
         )
     )
     assert not resolved.ok
-    assert [f.identity for f in resolved.failures] == ["data/gone.bin"]
+    assert [f.identity for f in resolved.failures] == ["data/gone.md"]
 
 
 def test_bad_path_entry_is_a_resolve_failure():
@@ -274,15 +274,15 @@ def test_nested_paths_abort_category():
 
 
 def test_plan_classifies_present_as_updated_and_new_as_created():
-    svc = FakeResourceFileService(exists_paths={"data/a.bin"})
+    svc = FakeResourceFileService(exists_paths={"data/a.md"})
     m = ResourcesMaterialiser(svc, _StubEntryFetcher())
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
         m.resolve(
             ctx,
             [
-                {"path": "data/a.bin", "source": "https://x/a.bin"},
-                {"path": "data/new.bin", "source": "https://x/new.bin"},
+                {"path": "data/a.md", "source": "https://x/a.bin"},
+                {"path": "data/new.md", "source": "https://x/new.bin"},
             ],
         )
     )
@@ -292,7 +292,7 @@ def test_plan_classifies_present_as_updated_and_new_as_created():
     # Never "unchanged": v1 replaces on every apply by design (the work
     # item's recommended option), and a plan that claimed otherwise would
     # be a promise the write stage does not honour.
-    assert by_id == {"data/a.bin": "updated", "data/new.bin": "created"}
+    assert by_id == {"data/a.md": "updated", "data/new.md": "created"}
     assert plan.removals == ()
     assert not plan.is_noop
 
@@ -315,7 +315,7 @@ def test_plan_addresses_the_bot_owner_not_the_manifest_storage_key():
         engine_type="claude_code",
     )
     resolved = _run(
-        m.resolve(ctx, [{"path": "data/a.bin", "source": "https://x/a.bin"}])
+        m.resolve(ctx, [{"path": "data/a.md", "source": "https://x/a.bin"}])
     )
     assert resolved.ok, [f.reason for f in resolved.failures]
     _run(m.plan(ctx, resolved.intents))
@@ -325,7 +325,7 @@ def test_plan_addresses_the_bot_owner_not_the_manifest_storage_key():
             "entity_id": "u_owner",
             "bot_id": "b_1",
             "engine_type": "claude_code",
-            "path": "data/a.bin",
+            "path": "data/a.md",
         }
     ]
 
@@ -443,10 +443,15 @@ def test_write_addresses_the_bot_owner():
 
 
 def test_write_is_player_setup_convergent():
-    """Applying N times equals applying once: same writes, same deletes, no growth."""
+    """Applying N times equals applying once: same writes, same deletes, no growth.
+
+    Both applies run against the SAME service state: the second pass is the
+    convergence claim (the tree from apply #1 is deleted and rewritten, no
+    duplicate rows, no stale entries), not a re-observation of apply #1.
+    """
     archive = _tgz({"a.txt": b"AAA"})
+    svc = FakeResourceFileService()
     for _ in range(2):
-        svc = FakeResourceFileService()
         m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
         ctx = make_context(engine_type="claude_code")
         _write_through(
@@ -454,8 +459,8 @@ def test_write_is_player_setup_convergent():
             ctx,
             [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t.tgz"}],
         )
-        assert svc.writes == {("wrap", "a.txt"): b"AAA"}
-        assert svc.deleted == ["wrap/"]
+    assert svc.writes == {("wrap", "a.txt"): b"AAA"}
+    assert svc.deleted == ["wrap/", "wrap/"]
 
 
 def test_write_failure_yields_failed_entry_per_member():
@@ -557,7 +562,7 @@ def test_each_form_fetches_under_its_own_category():
         m.resolve(
             ctx,
             [
-                {"path": "data/a.bin", "source": "https://x/a.bin"},
+                {"path": "data/a.md", "source": "https://x/a.bin"},
                 {
                     "path": "tools/",
                     "unpack": "tar.gz",
@@ -571,7 +576,7 @@ def test_each_form_fetches_under_its_own_category():
         "resources_file",
         "resources_archive",
     ]
-    assert [c["entry_identity"] for c in stub.calls] == ["data/a.bin", "tools/"]
+    assert [c["entry_identity"] for c in stub.calls] == ["data/a.md", "tools/"]
 
 
 def test_keep_last_fallback_surfaces_as_the_entries_note():
@@ -600,7 +605,7 @@ def test_keep_last_fallback_surfaces_as_the_entries_note():
     m = ResourcesMaterialiser(svc, _FallingBack())
     ctx = make_context(engine_type="claude_code")
     resolved = _run(
-        m.resolve(ctx, [{"path": "data/a.bin", "source": "https://x/a.bin"}])
+        m.resolve(ctx, [{"path": "data/a.md", "source": "https://x/a.bin"}])
     )
     assert resolved.ok, [f.reason for f in resolved.failures]
     assert (
@@ -628,6 +633,123 @@ def test_write_carries_the_note_onto_the_report_row():
     m = ResourcesMaterialiser(svc, _FallingBack())
     ctx = make_context(engine_type="claude_code")
     plan, results = _write_through(
-        m, ctx, [{"path": "data/a.bin", "source": "https://x/a.bin"}]
+        m, ctx, [{"path": "data/a.md", "source": "https://x/a.bin"}]
     )
     assert [r.note for r in results] == ["fell back (keep_last)"]
+
+
+# --- the write chain's admission rules, asked before the first delete (H1) ---
+
+
+def test_an_archive_member_the_chain_would_refuse_fails_at_resolve():
+    """``upload_file`` refuses extensions outside its allow-list (no ``.sh``,
+    no extensionless files). That refusal must land in ``resolve`` — before
+    the sentinel deletes the declared tree — or the category reaches write
+    with a member that deterministically fails *after* the destructive
+    delete, on every re-apply.
+    """
+    archive = _tgz({"a.md": b"ok", "run.sh": b"#!/bin/sh\n"})
+    svc = FakeResourceFileService(exists_paths={"tools/old.md"})
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(
+            ctx,
+            [{"path": "tools/", "unpack": "tar.gz", "source": "https://x/t.tgz"}],
+        )
+    )
+    # The whole category aborts (§3.2): one undeliverable member means the
+    # tree is NOT deleted for a partial delivery.
+    assert not resolved.ok
+    assert resolved.failures[0].identity == "tools/run.sh"
+    assert "file type" in resolved.failures[0].reason.lower()
+
+
+def test_an_extensionless_inline_file_fails_at_resolve():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(ctx, [{"path": "data/LICENSE", "content": "MIT"}]))
+    assert not resolved.ok
+    assert "file type" in resolved.failures[0].reason.lower()
+
+
+def test_inline_content_over_the_size_cap_fails_at_resolve(
+    monkeypatch,
+):
+    """Inline ``content`` never goes through the fetch funnel's caps, so the
+    delivery gate is the only line a 600MB inline entry meets — and it must
+    meet it in ``resolve``, not as a write-stage surprise."""
+    from agentclaw.community.core.resources.services import file_service as fs
+
+    monkeypatch.setattr(fs, "MAX_FILE_SIZE", 16)
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(ctx, [{"path": "data/big.md", "content": "x" * 32}])
+    )
+    assert not resolved.ok
+    assert "size cap" in resolved.failures[0].reason.lower()
+
+
+def test_strip_components_of_the_wrong_type_is_a_resolve_failure():
+    """A document from before the schema's type check: no raw ``TypeError``
+    may escape ``resolve`` — the orchestrator would abort the category with
+    the exception's text in it."""
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(_tgz({"a.md": b"x"})))
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(
+            ctx,
+            [
+                {
+                    "path": "tools/",
+                    "unpack": "tar.gz",
+                    "strip_components": "one",
+                    "source": "https://x/t.tgz",
+                }
+            ],
+        )
+    )
+    assert not resolved.ok
+    assert "strip_components" in resolved.failures[0].reason
+
+
+def test_a_failed_tree_replacement_fails_its_members_in_composed_words():
+    """M2: the sentinel delete is part of delivery — a raise there must not
+    escape as raw exception text (the orchestrator would abort the whole
+    category quoting it); the tree's members answer FAILED, in the stage's
+    own words, and other categories' entries in this one keep their shot.
+    """
+
+    class _BuggyTreeDelete(FakeResourceFileService):
+        async def delete(self, **kwargs):
+            if kwargs["path"] == "tools/":
+                raise RuntimeError("rmtree quoted a header with a token")
+            return await super().delete(**kwargs)
+
+    archive = _tgz({"a.md": b"A"})
+    svc = _BuggyTreeDelete(exists_paths=set())
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+    plan, results = _write_through(
+        m,
+        ctx,
+        [
+            {
+                "path": "tools/",
+                "unpack": "tar.gz",
+                "source": "https://x/t.tgz",
+            },
+            {"path": "notes/r.md", "content": "# rules"},
+        ],
+    )
+    by_id = {r.identity: r for r in results}
+    assert by_id["tools/a.md"].outcome.value == "failed"
+    assert by_id["tools/a.md"].reason == "directory tree replacement failed"
+    # the raw exception text never reached the report
+    assert all("token" not in (r.reason or "") for r in results)
+    # the sibling entry outside the failed tree was still delivered
+    assert by_id["notes/r.md"].outcome.value == "created"

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -1,0 +1,62 @@
+"""Tests for the ``resources`` materialiser (W6).
+
+Pins, by the work item's acceptance criteria:
+- file entries materialise through ``ResourceFileService`` at a
+  workspace-relative ``path`` (physical placement stays the engine's call);
+- directory entries converge as the whole archive: the tree under ``path`` is
+  replaced in full, including hand-added files (ownership rule);
+- fetch failures abort the whole category before the first write (§3.2);
+- the platform unpacks to a temporary location — a bad archive or failed fetch
+  never reaches the bot;
+- convergence writes are file-grained (teclaw per-file forwarding is the same
+  transport), and the module never touches ``BotConfigArtifact``;
+- archive limits (member count / unpacked size) apply with W1's keys.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from ._fakes import FakeResourceFileService, make_context
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_fake_resource_service_records_uploads_and_deletes():
+    svc = FakeResourceFileService(exists_paths={"data/old.bin"})
+    ctx = make_context(engine_type="claude_code")
+    _run(
+        svc.upload_file(
+            entity_id=ctx.entity_id,
+            bot_id=ctx.bot_id,
+            engine_type=ctx.engine_type,
+            target_dir="data",
+            filename="a.bin",
+            data=b"hello",
+        )
+    )
+    _run(
+        svc.delete(
+            entity_id=ctx.entity_id,
+            bot_id=ctx.bot_id,
+            engine_type=ctx.engine_type,
+            path="data/old.bin",
+        )
+    )
+    assert svc.writes == {("data", "a.bin"): b"hello"}
+    assert svc.deleted == ["data/old.bin"]
+    # Deleted paths report absent — the fake must contract this, because the
+    # plan stage's classification reads ``exists`` and would otherwise call
+    # a deleted file "unchanged".
+    assert (
+        _run(
+            svc.exists(
+                entity_id=ctx.entity_id,
+                bot_id=ctx.bot_id,
+                engine_type=ctx.engine_type,
+                path="data/old.bin",
+            )
+        )
+        is False
+    )

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -267,3 +267,106 @@ def test_nested_paths_abort_category():
     )
     assert not resolved.ok
     assert any("nest" in f.reason for f in resolved.failures)
+
+
+# --- plan: classification for the report (Task 4) ---
+
+
+def test_plan_classifies_present_as_updated_and_new_as_created():
+    svc = FakeResourceFileService(exists_paths={"data/a.bin"})
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(
+            ctx,
+            [
+                {"path": "data/a.bin", "source": "https://x/a.bin"},
+                {"path": "data/new.bin", "source": "https://x/new.bin"},
+            ],
+        )
+    )
+    assert resolved.ok, [f.reason for f in resolved.failures]
+    plan = _run(m.plan(ctx, resolved.intents))
+    by_id = {p.intent.identity: p.outcome for p in plan.entries}
+    # Never "unchanged": v1 replaces on every apply by design (the work
+    # item's recommended option), and a plan that claimed otherwise would
+    # be a promise the write stage does not honour.
+    assert by_id == {"data/a.bin": "updated", "data/new.bin": "created"}
+    assert plan.removals == ()
+    assert not plan.is_noop
+
+
+def test_plan_addresses_the_bot_owner_not_the_manifest_storage_key():
+    """``entity_id`` must be the owner (the router's address), not ``ctx.entity_id``.
+
+    The two vocabularies share a name: ``ApplyContext.entity_id`` is the
+    manifest's *storage key*, while ``ResourceFileService`` addresses a
+    workspace by its *owner* — the address the resources router's
+    ``_resolve_params`` resolves and ``resource_coords_from_record``
+    derives. A test that left them equal would never catch the swap.
+    """
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    ctx = make_context(
+        bot_id="b_1",
+        owner_id="u_owner",
+        entity_id="man-storage-key",
+        engine_type="claude_code",
+    )
+    resolved = _run(
+        m.resolve(ctx, [{"path": "data/a.bin", "source": "https://x/a.bin"}])
+    )
+    assert resolved.ok, [f.reason for f in resolved.failures]
+    _run(m.plan(ctx, resolved.intents))
+    assert svc.exists_probes == [
+        {
+            "entity_type": "staff",
+            "entity_id": "u_owner",
+            "bot_id": "b_1",
+            "engine_type": "claude_code",
+            "path": "data/a.bin",
+        }
+    ]
+
+
+def test_plan_classifies_the_directory_sentinel_within_the_report_vocabulary():
+    """The sentinel classifies like any entry — the vocabulary stays the enum's.
+
+    A bespoke outcome ("replaced") would crash the orchestrator's dry-run
+    projection, which feeds every planned outcome through
+    ``EntryOutcome(...)``; write recognises the sentinel by its ``value is
+    None``, not by the label.
+    """
+    archive = _tgz({"a.txt": b"AAA"})
+    svc = FakeResourceFileService(exists_paths={"established/"})
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(
+            ctx,
+            [
+                {
+                    "path": "established/",
+                    "unpack": "tar.gz",
+                    "source": "https://x/old.tgz",
+                },
+                {
+                    "path": "fresh/",
+                    "unpack": "tar.gz",
+                    "source": "https://x/new.tgz",
+                },
+            ],
+        )
+    )
+    assert resolved.ok, [f.reason for f in resolved.failures]
+    plan = _run(m.plan(ctx, resolved.intents))
+    by_id = {p.intent.identity: p.outcome for p in plan.entries}
+    # Presence is probed per identity: only the "established/" tree root was
+    # seeded present, so its member — a fresh upload under a replaced tree —
+    # classifies as created, exactly as a first apply of the member would.
+    assert by_id == {
+        "established/": "updated",
+        "established/a.txt": "created",
+        "fresh/": "created",
+        "fresh/a.txt": "created",
+    }

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -25,7 +25,7 @@ from agentclaw.community.core.bot_config_manifest.apply.materialisers.resources 
     ResourcesMaterialiser,
 )
 
-from ._fakes import FakeResourceFileService, make_context
+from ._fakes import FakeResourceFileService, build_skill_tgz, make_context
 
 
 def _run(coro):
@@ -33,17 +33,20 @@ def _run(coro):
 
 
 class _StubEntryFetcher:
-    """``EntryFetcher``'s test double: fixed bytes per URL, every call recorded.
+    """``EntryFetcher``'s test double, every call recorded.
 
-    URLs ending in ``gone`` stand in for unreachable sources. It answers in
-    the pipeline's own currency — a real :class:`FetchedEntry` — because the
-    materialiser consumes ``.content``; a stub answering in the transport's
+    URLs ending in ``gone`` stand in for unreachable sources. With
+    ``fixed_body``, every URL serves the same bytes (an archive); without it,
+    the URL's own ``bytes-of-<url>``. It answers in the pipeline's own
+    currency — a real :class:`FetchedEntry` — because the materialiser
+    consumes ``.content``; a stub answering in the transport's
     ``FetchedObject`` shape would pass collection and fail on the first real
     resolve.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, fixed_body: bytes | None = None) -> None:
         self.calls: list[dict[str, Any]] = []
+        self._fixed_body = fixed_body
 
     def fetch(
         self,
@@ -68,8 +71,17 @@ class _StubEntryFetcher:
         )
         if source_url.endswith("gone"):
             raise EntryFetchError("source unreachable")
-        body = b"bytes-of-" + source_url.encode()
+        body = (
+            self._fixed_body
+            if self._fixed_body is not None
+            else b"bytes-of-" + source_url.encode()
+        )
         return FetchedEntry(content=body, digest="sha256:stub", from_store=False)
+
+
+def _tgz(member: dict[str, bytes]) -> bytes:
+    """A real tar.gz carrying ``member`` — true bytes, not synthetic objects."""
+    return build_skill_tgz(list(member.items()))
 
 
 def test_fake_resource_service_records_uploads_and_deletes():
@@ -174,3 +186,84 @@ def test_bad_path_entry_is_a_resolve_failure():
     ctx = make_context(engine_type="claude_code")
     resolved = _run(m.resolve(ctx, [{"path": 123}]))
     assert not resolved.ok
+
+
+# --- directory entries: platform-side unpack (Task 3) ---
+
+
+def test_dir_entry_expands_members_under_path():
+    archive = _tgz({"top/a.txt": b"AAA", "top/sub/b.txt": b"BBB"})
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(
+            ctx,
+            [
+                {
+                    "path": "wrap/",
+                    "unpack": "tar.gz",
+                    "strip_components": 1,
+                    "source": "https://x/tree.tgz",
+                }
+            ],
+        )
+    )
+    assert resolved.ok, [f.reason for f in resolved.failures]
+    got = {i.identity: i.value for i in resolved.intents}
+    # The "wrap/" entry is the directory sentinel (value=None, the
+    # tree-replacement marker), riding first so write deletes the tree
+    # before any member uploads.
+    assert got == {
+        "wrap/": None,
+        "wrap/a.txt": b"AAA",
+        "wrap/sub/b.txt": b"BBB",
+    }
+    assert resolved.intents[0].identity == "wrap/"
+
+
+def test_bad_archive_is_a_resolve_failure_and_nothing_reaches_the_bot():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(b"not-an-archive"))
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(
+            ctx,
+            [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/tree.tgz"}],
+        )
+    )
+    assert not resolved.ok
+    assert resolved.failures[0].identity == "wrap/"
+    assert svc.writes == {} and svc.deleted == []
+
+
+def test_dir_unpack_missing_is_rejected_at_resolve():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(_tgz({"a.txt": b"x"})))
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(ctx, [{"path": "wrap/", "source": "https://x/tree.tgz"}])
+    )
+    assert not resolved.ok
+    assert "unpack" in resolved.failures[0].reason
+
+
+def test_nested_paths_abort_category():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(_tgz({"a.txt": b"x"})))
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(
+            ctx,
+            [
+                {
+                    "path": "wrap/",
+                    "unpack": "tar.gz",
+                    "source": "https://x/t.tgz",
+                },
+                {"path": "wrap/inner.txt", "source": "https://x/i.txt"},
+            ],
+        )
+    )
+    assert not resolved.ok
+    assert any("nest" in f.reason for f in resolved.failures)

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -370,3 +370,117 @@ def test_plan_classifies_the_directory_sentinel_within_the_report_vocabulary():
         "fresh/": "created",
         "fresh/a.txt": "created",
     }
+
+
+# --- write: delivery through the one write chain (Task 5) ---
+
+
+def _write_through(m, ctx, entries):
+    resolved = _run(m.resolve(ctx, entries))
+    assert resolved.ok, [f.reason for f in resolved.failures]
+    plan = _run(m.plan(ctx, resolved.intents))
+    return plan, _run(m.write(ctx, plan))
+
+
+def test_write_replaces_the_tree_then_uploads_every_member():
+    svc = FakeResourceFileService(exists_paths={"wrap/old.txt"})
+    archive = _tgz({"a.txt": b"AAA", "sub/b.txt": b"BBB"})
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+    plan, results = _write_through(
+        m,
+        ctx,
+        [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t.tgz"}],
+    )
+    # One delete per declared tree, first: the replace removes everything
+    # under "wrap/" — including files the new archive no longer ships and
+    # hand-added ones (the ownership rule).
+    assert svc.deleted == ["wrap/"]
+    assert svc.writes == {
+        ("wrap", "a.txt"): b"AAA",
+        ("wrap/sub", "b.txt"): b"BBB",
+    }
+    # The sentinel is an ownership action, not an entry: only its member
+    # files report.
+    assert [r.identity for r in results] == ["wrap/a.txt", "wrap/sub/b.txt"]
+    assert all(r.outcome.value == "created" for r in results)
+
+
+def test_write_addresses_the_bot_owner():
+    """The write chain gets the owner's address, the router's own way."""
+    svc = FakeResourceFileService()
+    archive = _tgz({"a.txt": b"AAA"})
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    ctx = make_context(
+        bot_id="b_1",
+        owner_id="u_owner",
+        entity_id="man-storage-key",
+        engine_type="claude_code",
+    )
+    _write_through(
+        m, ctx, [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t"}]
+    )
+    assert svc.delete_calls == [
+        {
+            "entity_type": "staff",
+            "entity_id": "u_owner",
+            "bot_id": "b_1",
+            "engine_type": "claude_code",
+            "path": "wrap/",
+        }
+    ]
+    assert svc.upload_calls == [
+        {
+            "entity_type": "staff",
+            "entity_id": "u_owner",
+            "bot_id": "b_1",
+            "engine_type": "claude_code",
+            "target_dir": "wrap",
+            "filename": "a.txt",
+        }
+    ]
+
+
+def test_write_is_player_setup_convergent():
+    """Applying N times equals applying once: same writes, same deletes, no growth."""
+    archive = _tgz({"a.txt": b"AAA"})
+    for _ in range(2):
+        svc = FakeResourceFileService()
+        m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+        ctx = make_context(engine_type="claude_code")
+        _write_through(
+            m,
+            ctx,
+            [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t.tgz"}],
+        )
+        assert svc.writes == {("wrap", "a.txt"): b"AAA"}
+        assert svc.deleted == ["wrap/"]
+
+
+def test_write_failure_yields_failed_entry_per_member():
+    class _Buggy(FakeResourceFileService):
+        async def upload_file(self, **kw):
+            if kw["filename"] == "b.txt":
+                raise RuntimeError("transport down")
+            return await super().upload_file(**kw)
+
+    svc = _Buggy(exists_paths=set())
+    archive = _tgz({"a.txt": b"A", "b.txt": "B".encode()})
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher(archive))
+    ctx = make_context(engine_type="claude_code")
+    plan, results = _write_through(
+        m,
+        ctx,
+        [{"path": "wrap/", "unpack": "tar.gz", "source": "https://x/t.tgz"}],
+    )
+    outcomes = {(r.identity, r.outcome.value) for r in results}
+    assert ("wrap/b.txt", "failed") in outcomes
+    assert ("wrap/a.txt", "failed") not in outcomes
+    # The report row states the failure in its own words, never raw
+    # exception text that might carry a credential.
+    assert all(
+        "transport down" not in (r.reason or "")
+        for r in results
+        if r.outcome.value == "failed"
+    )
+    assert svc.writes == {("wrap", "a.txt"): b"A"}

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -137,14 +137,15 @@ def test_file_entry_from_url_resolves_to_intent_bytes():
     assert resolved.ok
     assert [i.identity for i in resolved.intents] == ["data/a.bin"]
     assert resolved.intents[0].value == b"bytes-of-https://x/a.bin"
-    # The funnel saw the entry's own identity under the resources category —
-    # the W11 apply/entry linkage — with keep_last as the declared default.
+    # The funnel saw the entry's own identity under the file form's own
+    # category — the W11 apply/entry linkage — with keep_last as the
+    # declared default.
     assert stub.calls == [
         {
             "source_url": "https://x/a.bin",
             "digest": None,
             "auth": None,
-            "category": "resources",
+            "category": "resources_file",
             "keep_last": True,
             "entry_identity": "data/a.bin",
         }
@@ -534,3 +535,99 @@ def test_build_materialisers_registers_five():
     )
     assert ManifestCategory.RESOURCES in registry
     assert len(registry) == 5
+
+
+# --- fetch categories and the keep_last contract (review findings) ---
+
+
+def test_each_form_fetches_under_its_own_category():
+    """Files fetch as ``resources_file``, archives as ``resources_archive``.
+
+    Schema §5 states the two widths separately (100MB vs 200MB); a shared
+    "resources" would leave the fetch funnel's cap lookup to its fallback,
+    silently halving what the archive form allows — and the W11 linkage
+    column would carry a category the vocabulary never defined.
+    """
+    archive = _tgz({"a.txt": b"x"})
+    svc = FakeResourceFileService()
+    stub = _StubEntryFetcher(archive)
+    m = ResourcesMaterialiser(svc, stub)
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(
+            ctx,
+            [
+                {"path": "data/a.bin", "source": "https://x/a.bin"},
+                {
+                    "path": "tools/",
+                    "unpack": "tar.gz",
+                    "source": "https://x/t.tgz",
+                },
+            ],
+        )
+    )
+    assert resolved.ok, [f.reason for f in resolved.failures]
+    assert [c["category"] for c in stub.calls] == [
+        "resources_file",
+        "resources_archive",
+    ]
+    assert [c["entry_identity"] for c in stub.calls] == ["data/a.bin", "tools/"]
+
+
+def test_keep_last_fallback_surfaces_as_the_entries_note():
+    """§9.6: a keep_last row states the fallback.
+
+    The fetch pipeline hands the reason over as
+    ``FetchedEntry.fallback_reason``; the materialiser must carry it into the
+    intent's note — identity and skills already do, and a silent fallback is
+    the contract broken quietly.
+    """
+
+    class _FallingBack(_StubEntryFetcher):
+        def fetch(self, ctx, **kwargs):
+            entry = super().fetch(ctx, **kwargs)
+            return FetchedEntry(
+                content=entry.content,
+                digest=entry.digest,
+                from_store=True,
+                content_type=entry.content_type,
+                fallback_reason=(
+                    "delivered from the platform's stored copy (keep_last)"
+                ),
+            )
+
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _FallingBack())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(ctx, [{"path": "data/a.bin", "source": "https://x/a.bin"}])
+    )
+    assert resolved.ok, [f.reason for f in resolved.failures]
+    assert (
+        resolved.intents[0].note
+        == "delivered from the platform's stored copy (keep_last)"
+    )
+
+
+def test_write_carries_the_note_onto_the_report_row():
+    """The note reaches the report row — stating a keep_last fallback only in
+    the log is §9.6 broken quietly."""
+
+    class _FallingBack(_StubEntryFetcher):
+        def fetch(self, ctx, **kwargs):
+            entry = super().fetch(ctx, **kwargs)
+            return FetchedEntry(
+                content=entry.content,
+                digest=entry.digest,
+                from_store=True,
+                content_type=entry.content_type,
+                fallback_reason="fell back (keep_last)",
+            )
+
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _FallingBack())
+    ctx = make_context(engine_type="claude_code")
+    plan, results = _write_through(
+        m, ctx, [{"path": "data/a.bin", "source": "https://x/a.bin"}]
+    )
+    assert [r.note for r in results] == ["fell back (keep_last)"]

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -15,12 +15,61 @@ Pins, by the work item's acceptance criteria:
 from __future__ import annotations
 
 import asyncio
+from typing import Any
+
+from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
+    EntryFetchError,
+    FetchedEntry,
+)
+from agentclaw.community.core.bot_config_manifest.apply.materialisers.resources import (
+    ResourcesMaterialiser,
+)
 
 from ._fakes import FakeResourceFileService, make_context
 
 
 def _run(coro):
     return asyncio.run(coro)
+
+
+class _StubEntryFetcher:
+    """``EntryFetcher``'s test double: fixed bytes per URL, every call recorded.
+
+    URLs ending in ``gone`` stand in for unreachable sources. It answers in
+    the pipeline's own currency — a real :class:`FetchedEntry` — because the
+    materialiser consumes ``.content``; a stub answering in the transport's
+    ``FetchedObject`` shape would pass collection and fail on the first real
+    resolve.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def fetch(
+        self,
+        ctx: Any,
+        *,
+        source_url: str,
+        digest: str | None = None,
+        auth: str | None = None,
+        category: str = "resources_file",
+        keep_last: bool = False,
+        entry_identity: str | None = None,
+    ) -> FetchedEntry:
+        self.calls.append(
+            {
+                "source_url": source_url,
+                "digest": digest,
+                "auth": auth,
+                "category": category,
+                "keep_last": keep_last,
+                "entry_identity": entry_identity,
+            }
+        )
+        if source_url.endswith("gone"):
+            raise EntryFetchError("source unreachable")
+        body = b"bytes-of-" + source_url.encode()
+        return FetchedEntry(content=body, digest="sha256:stub", from_store=False)
 
 
 def test_fake_resource_service_records_uploads_and_deletes():
@@ -60,3 +109,68 @@ def test_fake_resource_service_records_uploads_and_deletes():
         )
         is False
     )
+
+
+# --- file entries: URL fetch and inline content (Task 2) ---
+
+
+def test_file_entry_from_url_resolves_to_intent_bytes():
+    svc = FakeResourceFileService()
+    stub = _StubEntryFetcher()
+    m = ResourcesMaterialiser(svc, stub)
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(ctx, [{"path": "data/a.bin", "source": "https://x/a.bin"}])
+    )
+    assert resolved.ok
+    assert [i.identity for i in resolved.intents] == ["data/a.bin"]
+    assert resolved.intents[0].value == b"bytes-of-https://x/a.bin"
+    # The funnel saw the entry's own identity under the resources category —
+    # the W11 apply/entry linkage — with keep_last as the declared default.
+    assert stub.calls == [
+        {
+            "source_url": "https://x/a.bin",
+            "digest": None,
+            "auth": None,
+            "category": "resources",
+            "keep_last": True,
+            "entry_identity": "data/a.bin",
+        }
+    ]
+
+
+def test_file_entry_inline_content_never_fetches():
+    svc = FakeResourceFileService()
+    stub = _StubEntryFetcher()
+    m = ResourcesMaterialiser(svc, stub)
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(ctx, [{"path": "notes/r.md", "content": "# rules"}]))
+    assert resolved.ok
+    assert [i.identity for i in resolved.intents] == ["notes/r.md"]
+    assert resolved.intents[0].value == b"# rules"
+    assert stub.calls == []  # inline content: no fetch, ever
+
+
+def test_fetch_failure_aborts_whole_category():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(
+        m.resolve(
+            ctx,
+            [
+                {"path": "data/a.bin", "source": "https://x/a.bin"},
+                {"path": "data/gone.bin", "source": "https://x/gone"},
+            ],
+        )
+    )
+    assert not resolved.ok
+    assert [f.identity for f in resolved.failures] == ["data/gone.bin"]
+
+
+def test_bad_path_entry_is_a_resolve_failure():
+    svc = FakeResourceFileService()
+    m = ResourcesMaterialiser(svc, _StubEntryFetcher())
+    ctx = make_context(engine_type="claude_code")
+    resolved = _run(m.resolve(ctx, [{"path": 123}]))
+    assert not resolved.ok

--- a/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
+++ b/src/backend/tests/community/core/bot_config_manifest/apply/test_resources_materialiser.py
@@ -484,3 +484,53 @@ def test_write_failure_yields_failed_entry_per_member():
         if r.outcome.value == "failed"
     )
     assert svc.writes == {("wrap", "a.txt"): b"A"}
+
+
+# --- registration: the fifth materialiser, and the artifact contract (Task 6) ---
+
+
+def test_module_never_imports_the_artifact_contract():
+    """W6 acceptance: ``BotConfigArtifact`` stays untouched.
+
+    The whole module is AST-walked (not just top-level imports) so a lazy
+    import inside a function cannot slip the contract in either.
+    """
+    import ast
+    from pathlib import Path
+
+    import agentclaw.community.core.bot_config_manifest.apply.materialisers.resources as _res
+
+    tree = ast.parse(Path(_res.__file__).read_text())
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names += [alias.name for alias in node.names]
+        elif isinstance(node, ast.ImportFrom):
+            names.append(node.module or "")
+    for name in names:
+        assert "kernel.bot_config" not in name, (
+            "the resources materialiser must not reach the artifact contract"
+        )
+
+
+def test_build_materialisers_registers_five():
+    from agentclaw.community.core.bot_config_manifest.apply.registry import (
+        build_materialisers,
+    )
+    from agentclaw.community.core.bot_config_manifest.capabilities import (
+        ManifestCategory,
+    )
+
+    registry = build_materialisers(
+        script_service=object(),
+        activation_service=object(),
+        mcp_auth_service=object(),
+        identity_service=object(),
+        upload_service=object(),
+        capability_reader=object(),
+        package_validator=object(),
+        entry_fetcher=object(),
+        resource_service=object(),
+    )
+    assert ManifestCategory.RESOURCES in registry
+    assert len(registry) == 5

--- a/src/backend/tests/community/endpoints/test_openapi_config_manifest_apply.py
+++ b/src/backend/tests/community/endpoints/test_openapi_config_manifest_apply.py
@@ -451,7 +451,7 @@ def _tool_archive() -> bytes:
     """A real tar.gz: the W6 unpack path must run against true bytes."""
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tf:
-        for name, data in {"top/a.sh": b"#!/bin/sh\n", "top/sub/b.sh": b"#!/bin/sh\n"}.items():
+        for name, data in {"top/a.py": b"x = 1\n", "top/sub/b.py": b"y = 2\n"}.items():
             info = tarfile.TarInfo(name)
             info.size = len(data)
             tf.addfile(info, io.BytesIO(data))
@@ -561,16 +561,16 @@ def _resources_reached_the_write_chain(_response, world) -> None:
         (e["category"], e["name"]): e["action"] for e in report["entries"]
     }
     assert by_entry[("resources", "notes/r.md")] == "created"
-    assert by_entry[("resources", "tools/a.sh")] == "created"
-    assert by_entry[("resources", "tools/sub/b.sh")] == "created"
+    assert by_entry[("resources", "tools/a.py")] == "created"
+    assert by_entry[("resources", "tools/sub/b.py")] == "created"
 
     uploads = _seed_bot_with_resource_manifest.uploads
     assert sorted(u["target_dir"] for u in uploads) == ["notes", "tools", "tools/sub"]
     writes = {(u["target_dir"], u["filename"]): u["data"] for u in uploads}
     assert writes == {
         ("notes", "r.md"): b"# rules\n",
-        ("tools", "a.sh"): b"#!/bin/sh\n",
-        ("tools/sub", "b.sh"): b"#!/bin/sh\n",
+        ("tools", "a.py"): b"x = 1\n",
+        ("tools/sub", "b.py"): b"y = 2\n",
     }
     # The declared directory tree is replaced in full, delete first — the
     # ownership rule, including files the new archive no longer ships.

--- a/src/backend/tests/community/endpoints/test_openapi_config_manifest_apply.py
+++ b/src/backend/tests/community/endpoints/test_openapi_config_manifest_apply.py
@@ -11,6 +11,9 @@ in ``tests/community/core/bot_config_manifest/apply/``. What these cover is the
 
 from __future__ import annotations
 
+import io
+import json
+import tarfile
 import threading
 import time
 
@@ -31,6 +34,7 @@ from tests.community.framework import (
     CaseInput,
     ExpectError,
     ExpectSuccess,
+    bind_overrides,
     endpoint_test,
 )
 
@@ -438,3 +442,153 @@ def apply_while_locked_is_a_409():
     through the assembled app rather than at the service, because the defect was
     entirely in the mapping: the service raised the right exception all along.
     """
+
+
+# ── the resources category, through the assembled app (W6) ─────────────────
+
+
+def _tool_archive() -> bytes:
+    """A real tar.gz: the W6 unpack path must run against true bytes."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in {"top/a.sh": b"#!/bin/sh\n", "top/sub/b.sh": b"#!/bin/sh\n"}.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+_RESOURCE_DOCUMENT = (
+    "schema_version: 1\n"
+    "manifest:\n"
+    "  resources:\n"
+    "    - path: notes/r.md\n"
+    "      content: |\n"
+    "        # rules\n"
+    "    - path: tools/\n"
+    "      unpack: tar.gz\n"
+    "      strip_components: 1\n"
+    "      source: https://mirror.example.test/tools.tgz\n"
+    "      digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+    "script:\n"
+    '  body: "echo hello"\n'
+)
+
+
+def _seed_bot_with_resource_manifest(world) -> None:
+    """A W6 document, applied against stubbed device I/O and fetch.
+
+    The write chain and the fetch funnel are bound over, the same seam
+    ``test_openapi_resources.py`` installs: through the assembled app is the
+    point, not through a real device or a real mirror.
+    """
+    init_principal_verifier_config(_Resolver(), "test-key", strict=False)
+    _insert_bot(world)
+    world.get(BotConfigManifestRepositoryProtocol).upsert(
+        env=get_current_env(),
+        entity_id=_OWNER,
+        bot_id=_BOT_ID,
+        document=_RESOURCE_DOCUMENT,
+        size_bytes=len(_RESOURCE_DOCUMENT.encode("utf-8")),
+        schema_version=1,
+        modifier=_OWNER,
+    )
+
+    from agentclaw.community.core.bot_config_manifest.apply.entry_fetch import (
+        EntryFetcher,
+        FetchedEntry,
+    )
+    from agentclaw.community.core.services.resource_file_service import (
+        ResourceFileService,
+    )
+
+    archive = _tool_archive()
+    uploads: list[dict] = []
+    deletes: list[str] = []
+
+    def fetch(_self, ctx, **kwargs):
+        return FetchedEntry(content=archive, digest="sha256:stub", from_store=False)
+
+    async def upload_file(_self, **kwargs):
+        uploads.append(
+            {
+                "target_dir": kwargs["target_dir"],
+                "filename": kwargs["filename"],
+                "data": kwargs["data"],
+            }
+        )
+        return {"path": f"{kwargs['target_dir']}/{kwargs['filename']}"}
+
+    async def delete(_self, **kwargs):
+        deletes.append(kwargs["path"])
+        return True
+
+    async def exists(_self, **_kwargs):
+        return False
+
+    bind_overrides(
+        world,
+        EntryFetcher,
+        {"fetch": fetch},
+    )
+    bind_overrides(
+        world,
+        ResourceFileService,
+        {"upload_file": upload_file, "delete": delete, "exists": exists},
+    )
+    # The stubs only record; the materialiser under test still decides what
+    # to call, so its decisions are visible on the recorders. Function
+    # attributes carry the recorders to the assertion — the framework builds
+    # a fresh injector per case, so there is no shared fixture to hang
+    # them on.
+    _seed_bot_with_resource_manifest.uploads = uploads
+    _seed_bot_with_resource_manifest.deletes = deletes
+
+
+def _resources_reached_the_write_chain(_response, world) -> None:
+    """The apply reported per-entry results, and the write chain saw them.
+
+    Joined-first via the same helper as the 202 case, so this asserts only
+    what the finished report says: the inline file and both archive members
+    created, and the declared tree replaced before its members uploaded.
+    """
+    record = world.get(BotConfigManifestApplyRepositoryProtocol).latest(
+        env=get_current_env(), entity_id=_OWNER, bot_id=_BOT_ID
+    )
+    assert record is not None and record.status == "SUCCEEDED", record
+    report = json.loads(record.report)
+    by_entry = {
+        (e["category"], e["name"]): e["action"] for e in report["entries"]
+    }
+    assert by_entry[("resources", "notes/r.md")] == "created"
+    assert by_entry[("resources", "tools/a.sh")] == "created"
+    assert by_entry[("resources", "tools/sub/b.sh")] == "created"
+
+    uploads = _seed_bot_with_resource_manifest.uploads
+    assert sorted(u["target_dir"] for u in uploads) == ["notes", "tools", "tools/sub"]
+    writes = {(u["target_dir"], u["filename"]): u["data"] for u in uploads}
+    assert writes == {
+        ("notes", "r.md"): b"# rules\n",
+        ("tools", "a.sh"): b"#!/bin/sh\n",
+        ("tools/sub", "b.sh"): b"#!/bin/sh\n",
+    }
+    # The declared directory tree is replaced in full, delete first — the
+    # ownership rule, including files the new archive no longer ships.
+    assert _seed_bot_with_resource_manifest.deletes == ["tools/"]
+
+
+@endpoint_test(
+    method="POST",
+    path="/openapi/v1/bots/{bot_id}/config-manifest/apply",
+    scenario="applies_the_resources_category",
+    input=CaseInput(
+        path_params={"bot_id": _BOT_ID}, query_params=_QUERY, headers=_HEADERS
+    ),
+    seed=_seed_bot_with_resource_manifest,
+    expect=ExpectSuccess(status=202, json_contains={"code": 200000}),
+    extra_assertions=(_await_the_background_apply, _resources_reached_the_write_chain),
+)
+def apply_materialises_resources():
+    """W6's category, end to end: an inline file entry and an archived
+    directory entry converge through the one write chain, each leaving its
+    per-entry row in the report."""


### PR DESCRIPTION
## Problem

`POST /openapi/v1/bots/{bot_id}/config-manifest/apply` accepted `manifest.resources` entries (W1's schema admits the vocabulary) but sat inert behind them — no materialiser was registered, so a declared document could never converge. Work item: `docs/bot-config-manifest/work-items.zh-CN.md` §W6 (#1474).

## Solution

One `ResourcesMaterialiser` in the apply registry's three-stage protocol (resolve → plan → write), mounted as the fifth materialiser:

- **File entries** — inline `content` taken as the bytes (no fetch, ever); `source` entries fetched through the W2/W3/W11 `EntryFetcher` funnel under schema §5's `resources_file` width (100MB), with keep_last fallback reasons surfaced on the report row (§9.6).
- **Directory entries** — the archive fetched under §5's `resources_archive` width (200MB) and unpacked **platform-side** through the guarded `unpack_archive` (member count / unpacked-size / traversal guards), then each member expanded as a file intent. The directory sentinel (identity=path, value=None) rides first so `write` deletes the declared tree before its members upload: whole-tree replacement, including hand-added files the new archive no longer ships — the ownership rule.
- **One write chain for both engine families** — every delivery is `ResourceFileService.upload_file`/`delete` (its dispatcher covers arca/baas/teclaw; teclaw's per-file forwarding is a property of that chain, not code here). The module never touches `BotConfigArtifact` (pinned by an AST-walk test).
- **Admission rules re-asked in `resolve`** — the write chain's extension allow-list and size cap (the same constants `upload_file` enforces) are checked before the first delete, so an undeliverable member aborts the category with the tree still standing instead of landing as a half-written tree on every re-apply. Inline `content` is also bounded here — it never goes through the fetch funnel's caps.
- **Entity addressing follows the router** — `("staff", ctx.owner_id)`, the address `resource_coords_from_record` derives; `ctx.entity_id` (the manifest storage key) is deliberately unused.
- **Wiring** — `ManifestResourcePort` (a Protocol type key, the identity-port move) + a lazy provider in `manifest_fetch_module`, so the DI graph stays cycle-free.
- `plan` classifies created/updated for the report only — never "unchanged" — because v1 replaces on every apply (the work item's recommended option); cross-entry removals stay v1-empty by the work item's own ownership definition (W12 owns the broader breadth).

Docs: capabilities comment, module README, and the work-items W6 section all move from "inert until W6" to delivered; two v1 narrows (dotfile policy breadth, per-member `exists` probe cost) are stated in the module docstring rather than left to be discovered.

## Validation

- `uv run pytest tests/community/core/bot_config_manifest` — 422 passed
- Full endpoint runner incl. a new W6 e2e case (inline file + archived directory through the assembled app, stubbed device/fetch seams) — all manifest route cases pass
- `bash src/backend/scripts/ci_test.sh --base origin/dev` — **gate passed**: 100% case pass rate, 88.39% line coverage, **93.57% changed-line coverage** (≥80% required)
- A full-branch review pass ran during development; its blocker (admission gates landing after the destructive tree delete) and four smaller findings are fixed in-tree with tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)