### PR TITLE
feat(bcs): configure optional worker task message guidance

### DIFF
--- a/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/src/routes/providers.rs
@@ -575,6 +575,7 @@ fn coordination_from_wire(config: ProviderCoordinationConfigDto) -> ProviderCoor
             ProviderCoordinationModeDto::NativeTool => CoordinationMode::NativeTool,
             ProviderCoordinationModeDto::Disabled => CoordinationMode::Disabled,
         },
+        worker_send_task_message_enabled: config.worker_send_task_message_enabled,
         mcp_server: config.mcp_server,
         mcporter_command: config.mcporter_command,
         tool_name_mapping: config.tool_name_mapping,

--- a/src/bcs/crates/adapters/http/bcs-http/tests/bot_events_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/bot_events_contract.rs
@@ -2330,6 +2330,7 @@ async fn bot_coordination_accepts_mcporter_tool_result_for_matching_run() {
         "mcporter-manager",
         Some(ProviderCoordinationConfig {
             mode: CoordinationMode::McporterMcp,
+            worker_send_task_message_enabled: true,
             mcp_server: Some("bcs".to_string()),
             mcporter_command: Some("mcporter".to_string()),
             tool_name_mapping: Default::default(),
@@ -2405,6 +2406,7 @@ async fn bot_coordination_accepts_native_mcp_intent_for_matching_run() {
         "manager-v2",
         Some(ProviderCoordinationConfig {
             mode: CoordinationMode::NativeMcp,
+            worker_send_task_message_enabled: true,
             mcp_server: Some("bcs".to_string()),
             mcporter_command: None,
             tool_name_mapping: Default::default(),
@@ -2488,6 +2490,7 @@ async fn bot_coordination_accepts_mapped_native_mcp_tool_result() {
         "mapped-native-mcp-manager",
         Some(ProviderCoordinationConfig {
             mode: CoordinationMode::NativeMcp,
+            worker_send_task_message_enabled: true,
             mcp_server: Some("mcp.ant.agentclawscs.bcs".to_string()),
             mcporter_command: None,
             tool_name_mapping: [(
@@ -2571,6 +2574,7 @@ async fn bot_coordination_rejects_unmapped_native_mcp_tool_result() {
         "unmapped-native-mcp-manager",
         Some(ProviderCoordinationConfig {
             mode: CoordinationMode::NativeMcp,
+            worker_send_task_message_enabled: true,
             mcp_server: Some("mcp.ant.agentclawscs.bcs".to_string()),
             mcporter_command: None,
             tool_name_mapping: [(
@@ -2640,6 +2644,7 @@ async fn bot_coordination_rejects_native_mcp_tool_result_with_mismatched_canonic
         "mismatched-native-mcp-manager",
         Some(ProviderCoordinationConfig {
             mode: CoordinationMode::NativeMcp,
+            worker_send_task_message_enabled: true,
             mcp_server: Some("mcp.ant.agentclawscs.bcs".to_string()),
             mcporter_command: None,
             tool_name_mapping: [(
@@ -2708,6 +2713,7 @@ async fn bot_coordination_rejects_native_tool_with_mcp_server() {
         "native-tool-bot",
         Some(ProviderCoordinationConfig {
             mode: CoordinationMode::NativeTool,
+            worker_send_task_message_enabled: true,
             mcp_server: None,
             mcporter_command: None,
             tool_name_mapping: Default::default(),

--- a/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
+++ b/src/bcs/crates/adapters/http/bcs-http/tests/provider_routes_contract.rs
@@ -1470,6 +1470,9 @@ async fn register_provider_returns_coordination_metadata() {
     assert_eq!(body["coordination"]["mode"], "mcporter_mcp");
     assert_eq!(body["coordination"]["mcp_server"], "bcs");
     assert_eq!(body["coordination"]["mcporter_command"], "mcporter");
+    assert!(body["coordination"]
+        .get("worker_send_task_message_enabled")
+        .is_none());
 }
 
 #[tokio::test]
@@ -1494,6 +1497,7 @@ async fn register_provider_round_trips_native_mcp_tool_name_mapping() {
                         },
                         "coordination": {
                             "mode": "native_mcp",
+                            "worker_send_task_message_enabled": false,
                             "mcp_server": "mcp.ant.agentclawscs.bcs",
                             "tool_name_mapping": {
                                 (assign_tool): "bcs_assign_task",
@@ -1534,6 +1538,10 @@ async fn register_provider_round_trips_native_mcp_tool_name_mapping() {
     assert_eq!(
         body["coordination"]["tool_name_mapping"][send_message_tool],
         "bcs_send_task_message"
+    );
+    assert_eq!(
+        body["coordination"]["worker_send_task_message_enabled"],
+        false
     );
 }
 

--- a/src/bcs/crates/contracts/bcs-domain/src/provider.rs
+++ b/src/bcs/crates/contracts/bcs-domain/src/provider.rs
@@ -2,6 +2,14 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+fn default_worker_send_task_message_enabled() -> bool {
+    true
+}
+
+fn is_true(value: &bool) -> bool {
+    *value
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProviderAuthMode {
@@ -69,6 +77,13 @@ pub enum CoordinationMode {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProviderCoordinationConfig {
     pub mode: CoordinationMode,
+    /// Whether manager-worker worker contexts should explain the optional
+    /// `bcs_send_task_message` tool.
+    #[serde(
+        default = "default_worker_send_task_message_enabled",
+        skip_serializing_if = "is_true"
+    )]
+    pub worker_send_task_message_enabled: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp_server: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -98,6 +113,7 @@ impl ProviderCoordinationConfig {
     pub fn disabled() -> Self {
         Self {
             mode: CoordinationMode::Disabled,
+            worker_send_task_message_enabled: true,
             mcp_server: None,
             mcporter_command: None,
             tool_name_mapping: BTreeMap::new(),
@@ -108,6 +124,13 @@ impl ProviderCoordinationConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CoordinationSurface {
     pub mode: CoordinationMode,
+    /// Effective Provider setting for the optional worker send-message tool
+    /// guidance. Non-Provider surfaces use the backward-compatible default.
+    #[serde(
+        default = "default_worker_send_task_message_enabled",
+        skip_serializing_if = "is_true"
+    )]
+    pub worker_send_task_message_enabled: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp_server: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -121,6 +144,7 @@ impl CoordinationSurface {
     pub fn legacy_upstream() -> Self {
         Self {
             mode: CoordinationMode::LegacyUpstream,
+            worker_send_task_message_enabled: true,
             mcp_server: None,
             mcporter_command: None,
             tool_name_mapping: BTreeMap::new(),
@@ -130,6 +154,7 @@ impl CoordinationSurface {
     pub fn native_tool() -> Self {
         Self {
             mode: CoordinationMode::NativeTool,
+            worker_send_task_message_enabled: true,
             mcp_server: None,
             mcporter_command: None,
             tool_name_mapping: BTreeMap::new(),
@@ -141,6 +166,7 @@ impl From<ProviderCoordinationConfig> for CoordinationSurface {
     fn from(config: ProviderCoordinationConfig) -> Self {
         Self {
             mode: config.mode,
+            worker_send_task_message_enabled: config.worker_send_task_message_enabled,
             mcp_server: config.mcp_server,
             mcporter_command: config.mcporter_command,
             tool_name_mapping: config.tool_name_mapping,

--- a/src/bcs/crates/contracts/bcs-protocol/src/http/provider.rs
+++ b/src/bcs/crates/contracts/bcs-protocol/src/http/provider.rs
@@ -5,6 +5,14 @@ use serde_json::{Map, Value};
 
 use crate::{Attachment, Skill, deserialize_skills};
 
+fn default_worker_send_task_message_enabled() -> bool {
+    true
+}
+
+fn is_true(value: &bool) -> bool {
+    *value
+}
+
 pub const BCN_PROTOCOL_VERSION_HEADER: &str = "X-BCN-Protocol-Version";
 pub const BCN_TRANSPORT_HEADER: &str = "X-BCN-Transport";
 pub const BCN_MESSAGE_ID_HEADER: &str = "X-BCN-Message-Id";
@@ -56,6 +64,13 @@ impl Default for ProviderBotConnectionModeDto {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProviderCoordinationConfigDto {
     pub mode: ProviderCoordinationModeDto,
+    /// Whether manager-worker worker contexts should explain the optional
+    /// `bcs_send_task_message` tool. Omitted values default to `true`.
+    #[serde(
+        default = "default_worker_send_task_message_enabled",
+        skip_serializing_if = "is_true"
+    )]
+    pub worker_send_task_message_enabled: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mcp_server: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/bcs/crates/services/bcs-bot/tests/provider_core.rs
+++ b/src/bcs/crates/services/bcs-bot/tests/provider_core.rs
@@ -106,6 +106,7 @@ async fn register_provider_persists_mcporter_coordination_config() {
             None,
             Some(ProviderCoordinationConfig {
                 mode: CoordinationMode::McporterMcp,
+                worker_send_task_message_enabled: true,
                 mcp_server: Some("bcs".to_string()),
                 mcporter_command: Some("mcporter".to_string()),
                 tool_name_mapping: Default::default(),
@@ -119,6 +120,23 @@ async fn register_provider_persists_mcporter_coordination_config() {
     assert_eq!(config["coordination"]["mode"], "mcporter_mcp");
     assert_eq!(config["coordination"]["mcp_server"], "bcs");
     assert_eq!(config["coordination"]["mcporter_command"], "mcporter");
+    assert!(config["coordination"]
+        .get("worker_send_task_message_enabled")
+        .is_none());
+}
+
+#[test]
+fn provider_coordination_defaults_worker_send_task_message_to_enabled() {
+    let config: ProviderCoordinationConfig = serde_json::from_value(serde_json::json!({
+        "mode": "native_tool"
+    }))
+    .expect("coordination config should deserialize without the optional field");
+    assert!(config.worker_send_task_message_enabled);
+
+    let mut disabled = config;
+    disabled.worker_send_task_message_enabled = false;
+    let serialized = serde_json::to_value(disabled).expect("coordination config should serialize");
+    assert_eq!(serialized["worker_send_task_message_enabled"], false);
 }
 
 #[tokio::test]
@@ -137,6 +155,7 @@ async fn register_provider_persists_native_mcp_tool_name_mapping() {
             None,
             Some(ProviderCoordinationConfig {
                 mode: CoordinationMode::NativeMcp,
+                worker_send_task_message_enabled: true,
                 mcp_server: Some("mcp.ant.agentclawscs.bcs".to_string()),
                 mcporter_command: None,
                 tool_name_mapping: [
@@ -187,6 +206,7 @@ async fn register_provider_rejects_non_native_mcp_tool_name_mapping() {
             None,
             Some(ProviderCoordinationConfig {
                 mode: CoordinationMode::McporterMcp,
+                worker_send_task_message_enabled: true,
                 mcp_server: Some("bcs".to_string()),
                 mcporter_command: Some("mcporter".to_string()),
                 tool_name_mapping: [(
@@ -219,6 +239,7 @@ async fn register_provider_rejects_too_many_tool_name_mappings() {
             None,
             Some(ProviderCoordinationConfig {
                 mode: CoordinationMode::NativeMcp,
+                worker_send_task_message_enabled: true,
                 mcp_server: Some("bcs".to_string()),
                 mcporter_command: None,
                 tool_name_mapping,
@@ -243,6 +264,7 @@ async fn register_provider_rejects_invalid_provider_tool_name() {
             None,
             Some(ProviderCoordinationConfig {
                 mode: CoordinationMode::NativeMcp,
+                worker_send_task_message_enabled: true,
                 mcp_server: Some("bcs".to_string()),
                 mcporter_command: None,
                 tool_name_mapping: [(" provider-tool".to_string(), "bcs_assign_task".to_string())]
@@ -269,6 +291,7 @@ async fn register_provider_rejects_unsupported_canonical_tool_name() {
             None,
             Some(ProviderCoordinationConfig {
                 mode: CoordinationMode::NativeMcp,
+                worker_send_task_message_enabled: true,
                 mcp_server: Some("bcs".to_string()),
                 mcporter_command: None,
                 tool_name_mapping: [("provider-tool".to_string(), "unknown-tool".to_string())]
@@ -295,6 +318,7 @@ async fn register_provider_rejects_native_tool_with_mcp_fields() {
             None,
             Some(ProviderCoordinationConfig {
                 mode: CoordinationMode::NativeTool,
+                worker_send_task_message_enabled: true,
                 mcp_server: Some("bcs".to_string()),
                 mcporter_command: None,
                 tool_name_mapping: Default::default(),
@@ -314,6 +338,7 @@ async fn provider_bot_resolves_coordination_surface_from_provider_config() {
         ProviderAuthMode::StaticBearer,
         ProviderCoordinationConfig {
             mode: CoordinationMode::NativeMcp,
+            worker_send_task_message_enabled: false,
             mcp_server: Some("bcs".to_string()),
             mcporter_command: None,
             tool_name_mapping: [(
@@ -348,6 +373,7 @@ async fn provider_bot_resolves_coordination_surface_from_provider_config() {
         .expect("resolve coordination surface");
 
     assert_eq!(surface.mode, CoordinationMode::NativeMcp);
+    assert!(!surface.worker_send_task_message_enabled);
     assert_eq!(surface.mcp_server.as_deref(), Some("bcs"));
     assert_eq!(surface.mcporter_command, None);
     assert_eq!(
@@ -380,6 +406,7 @@ async fn websocket_plugin_bot_resolves_native_tool_surface() {
         .expect("resolve coordination surface");
 
     assert_eq!(surface.mode, CoordinationMode::NativeTool);
+    assert!(surface.worker_send_task_message_enabled);
     assert_eq!(surface.mcp_server, None);
     assert_eq!(surface.mcporter_command, None);
     assert!(surface.tool_name_mapping.is_empty());
@@ -455,6 +482,7 @@ async fn update_provider_normalizes_organization_management_and_preserves_other_
         ProviderAuthMode::StaticBearer,
         ProviderCoordinationConfig {
             mode: CoordinationMode::NativeMcp,
+            worker_send_task_message_enabled: true,
             mcp_server: Some("bcs".to_string()),
             mcporter_command: None,
             tool_name_mapping: Default::default(),

--- a/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
+++ b/src/bcs/crates/services/bcs-message-flow/tests/contract_bot_event.rs
@@ -2351,6 +2351,7 @@ async fn native_mcp_tool_result_coordination_echo_dispatches_from_exact_provider
             "bot-driver",
             CoordinationSurface {
                 mode: CoordinationMode::NativeMcp,
+                worker_send_task_message_enabled: true,
                 mcp_server: Some("bcs".to_string()),
                 mcporter_command: None,
                 tool_name_mapping: BTreeMap::from([(
@@ -2412,6 +2413,7 @@ async fn native_mcp_assign_task_echo_forwards_provider_participant_tags() {
             "bot-manager",
             CoordinationSurface {
                 mode: CoordinationMode::NativeMcp,
+                worker_send_task_message_enabled: true,
                 mcp_server: Some("bcs".to_string()),
                 mcporter_command: None,
                 tool_name_mapping: BTreeMap::from([(
@@ -2463,6 +2465,7 @@ async fn native_mcp_coordination_rejects_unmapped_or_mismatched_results_and_reso
             "bot-driver",
             CoordinationSurface {
                 mode: CoordinationMode::NativeMcp,
+                worker_send_task_message_enabled: true,
                 mcp_server: Some("bcs".to_string()),
                 mcporter_command: None,
                 tool_name_mapping: BTreeMap::from([(

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context.rs
@@ -366,11 +366,29 @@ fn manager_worker_coordination_instruction(
     status_line: &str,
 ) -> String {
     match surface.mode {
-        CoordinationMode::McporterMcp => mcporter_mcp_instruction(is_manager, surface, status_line),
-        CoordinationMode::NativeMcp => native_mcp_instruction(is_manager, surface, status_line),
-        CoordinationMode::NativeTool => native_tool_instruction(is_manager, status_line),
+        CoordinationMode::McporterMcp => mcporter_mcp_instruction(
+            is_manager,
+            surface,
+            status_line,
+            surface.worker_send_task_message_enabled,
+        ),
+        CoordinationMode::NativeMcp => native_mcp_instruction(
+            is_manager,
+            surface,
+            status_line,
+            surface.worker_send_task_message_enabled,
+        ),
+        CoordinationMode::NativeTool => native_tool_instruction(
+            is_manager,
+            status_line,
+            surface.worker_send_task_message_enabled,
+        ),
         CoordinationMode::Disabled | CoordinationMode::LegacyUpstream => {
-            legacy_manager_worker_instruction(delivery_type, status_line)
+            legacy_manager_worker_instruction(
+                delivery_type,
+                status_line,
+                surface.worker_send_task_message_enabled,
+            )
         }
     }
 }
@@ -379,6 +397,7 @@ fn mcporter_mcp_instruction(
     is_manager: bool,
     surface: &CoordinationSurface,
     status_line: &str,
+    worker_send_task_message_enabled: bool,
 ) -> String {
     let command = surface
         .mcporter_command
@@ -391,8 +410,15 @@ fn mcporter_mcp_instruction(
             status_line
         );
     }
+    let worker_task_instruction = if worker_send_task_message_enabled {
+        format!(
+            "收到主 Bot 派发的任务后，使用 `{command} call {server}.bcs_send_task_message message=\"<结果、进展、问题或阻塞>\"`。"
+        )
+    } else {
+        "收到主 Bot 派发的任务后直接处理。".to_string()
+    };
     format!(
-        "本群为任务群，你是子 Bot。你当前平台通过 mcporter 调用 BCS MCP 工具。收到主 Bot 派发的任务后，使用 `{command} call {server}.bcs_send_task_message message=\"<结果、进展、问题或阻塞>\"`。执行 `mcporter call` 后必须保留并回传完整原始输出；禁止使用 `tail`、`head`、`grep` 等管道或任何截断、筛选、摘要处理，否则 BCS 无法识别 MCP 调用结果。不要直接面向用户输出最终答案；最终汇总由 manager 完成，不要在普通回复中伪造工具结果。"
+        "本群为任务群，你是子 Bot。你当前平台通过 mcporter 调用 BCS MCP 工具。{worker_task_instruction}执行 `mcporter call` 后必须保留并回传完整原始输出；禁止使用 `tail`、`head`、`grep` 等管道或任何截断、筛选、摘要处理，否则 BCS 无法识别 MCP 调用结果。不要直接面向用户输出最终答案；最终汇总由 manager 完成，不要在普通回复中伪造工具结果。"
     )
 }
 
@@ -400,6 +426,7 @@ fn native_mcp_instruction(
     is_manager: bool,
     surface: &CoordinationSurface,
     status_line: &str,
+    worker_send_task_message_enabled: bool,
 ) -> String {
     let server = surface.mcp_server.as_deref().unwrap_or("bcs");
     if is_manager {
@@ -408,29 +435,55 @@ fn native_mcp_instruction(
             status_line
         );
     }
+    let worker_task_instruction = if worker_send_task_message_enabled {
+        format!(
+            "收到 manager 派发的任务后，直接调用 MCP server `{server}` 上的 `bcs_send_task_message` 回传结果、进展、问题或阻塞。"
+        )
+    } else {
+        "收到 manager 派发的任务后直接处理。".to_string()
+    };
     format!(
-        "本群为任务群，你是子 Bot。你当前平台原生提供 BCS MCP 工具。收到 manager 派发的任务后，直接调用 MCP server `{server}` 上的 `bcs_send_task_message` 回传结果、进展、问题或阻塞。不要使用 mcporter、exec、bash，不要直接面向用户输出最终答案。"
+        "本群为任务群，你是子 Bot。你当前平台原生提供 BCS MCP 工具。{worker_task_instruction}不要使用 mcporter、exec、bash，不要直接面向用户输出最终答案。"
     )
 }
 
-fn native_tool_instruction(is_manager: bool, status_line: &str) -> String {
+fn native_tool_instruction(
+    is_manager: bool,
+    status_line: &str,
+    worker_send_task_message_enabled: bool,
+) -> String {
     if is_manager {
         return format!(
             "本群为任务群，你是主 Bot。你当前平台原生提供 BCS 协同工具，这些工具是当前运行环境中的原生 tools，不是 MCP server 工具。需要派发子任务时，直接调用原生工具 `bcs_assign_task`；任务可以结束时，直接调用原生工具 `bcs_task_complete`。不要使用 mcporter、exec、bash，不要写 MCP server 名称，不要在普通回复中伪造工具结果。{}",
             status_line
         );
     }
-    "本群为任务群，你是子 Bot。你当前平台原生提供 BCS 协同工具，这些工具是当前运行环境中的原生 tools，不是 MCP server 工具。收到 manager 派发的任务后，直接调用原生工具 `bcs_send_task_message` 回传结果、进展、问题或阻塞。不要使用 mcporter、exec、bash，不要写 MCP server 名称，不要直接面向用户输出最终答案。".to_string()
+    let worker_task_instruction = if worker_send_task_message_enabled {
+        "收到 manager 派发的任务后，直接调用原生工具 `bcs_send_task_message` 回传结果、进展、问题或阻塞。"
+    } else {
+        "收到 manager 派发的任务后直接处理。"
+    };
+    format!(
+        "本群为任务群，你是子 Bot。你当前平台原生提供 BCS 协同工具，这些工具是当前运行环境中的原生 tools，不是 MCP server 工具。{worker_task_instruction}不要使用 mcporter、exec、bash，不要写 MCP server 名称，不要直接面向用户输出最终答案。"
+    )
 }
 
-fn legacy_manager_worker_instruction(delivery_type: DeliveryType, status_line: &str) -> String {
+fn legacy_manager_worker_instruction(
+    delivery_type: DeliveryType,
+    status_line: &str,
+    worker_send_task_message_enabled: bool,
+) -> String {
     match delivery_type {
         DeliveryType::Send => format!(
             "本群为任务群，你是主 Bot。派发子任务用 bcs_assign_task(target_bot, message)，可并行派发多个；收齐所有子 Bot 回复、综合完毕后用 bcs_task_complete(summary) 收尾。不要用引擎自带的发送工具向群里发消息。{}",
             status_line
         ),
         DeliveryType::Inject => {
-            "本群为任务群，你是子 Bot。收到主 Bot 派发的任务后直接处理并回复；需要阶段性同步进展 / 说明阻塞时，用 bcs_send_task_message(message) 发给主 Bot。不要用引擎自带的发送工具向群里发消息。".to_string()
+            if worker_send_task_message_enabled {
+                "本群为任务群，你是子 Bot。收到主 Bot 派发的任务后直接处理并回复；需要阶段性同步进展 / 说明阻塞时，用 bcs_send_task_message(message) 发给主 Bot。不要用引擎自带的发送工具向群里发消息。".to_string()
+            } else {
+                "本群为任务群，你是子 Bot。收到主 Bot 派发的任务后直接处理并回复。不要用引擎自带的发送工具向群里发消息。".to_string()
+            }
         }
     }
 }

--- a/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
+++ b/src/bcs/crates/services/bcs-system-message/src/producers/session_context_test.rs
@@ -349,6 +349,7 @@ async fn manager_worker_context_uses_recipient_coordination_surface() {
         manager_id,
         CoordinationSurface {
             mode: CoordinationMode::McporterMcp,
+            worker_send_task_message_enabled: true,
             mcp_server: Some("bcs".to_string()),
             mcporter_command: Some("mcporter".to_string()),
             tool_name_mapping: Default::default(),
@@ -358,6 +359,7 @@ async fn manager_worker_context_uses_recipient_coordination_surface() {
         mcporter_worker_id,
         CoordinationSurface {
             mode: CoordinationMode::McporterMcp,
+            worker_send_task_message_enabled: true,
             mcp_server: Some("bcs".to_string()),
             mcporter_command: Some("mcporter".to_string()),
             tool_name_mapping: Default::default(),
@@ -367,6 +369,7 @@ async fn manager_worker_context_uses_recipient_coordination_surface() {
         native_mcp_worker_id,
         CoordinationSurface {
             mode: CoordinationMode::NativeMcp,
+            worker_send_task_message_enabled: true,
             mcp_server: Some("bcs".to_string()),
             mcporter_command: None,
             tool_name_mapping: Default::default(),
@@ -412,6 +415,79 @@ async fn manager_worker_context_uses_recipient_coordination_surface() {
     for bot_id in [native_mcp_worker_id, native_tool_worker_id, legacy_worker_id] {
         assert!(!message_for(bot_id).contains("必须保留并回传完整原始输出"));
     }
+}
+
+#[tokio::test]
+async fn manager_worker_worker_context_omits_optional_send_message_tool_when_disabled() {
+    let manager_id = "provider-manager";
+    let worker_id = "provider-worker";
+
+    let mut manager = Participant::bot(manager_id, ParticipantRole::Manager);
+    manager.bot_name = Some("Provider Manager".to_string());
+    let mut worker = Participant::bot(worker_id, ParticipantRole::Worker);
+    worker.bot_name = Some("Provider Worker".to_string());
+
+    let mut group = Group::new(
+        "group-provider-surface",
+        manager_id,
+        vec![manager.clone(), worker.clone()],
+    );
+    group.group_strategy = GroupStrategy::ManagerWorker;
+    let participants = group.participants.clone();
+    let registry = NamedRegistry::new(&[
+        (manager_id, "Provider Manager", Some("manager")),
+        (worker_id, "Provider Worker", None),
+    ])
+    .with_surface(
+        manager_id,
+        CoordinationSurface {
+            mode: CoordinationMode::NativeMcp,
+            worker_send_task_message_enabled: true,
+            mcp_server: Some("bcs".to_string()),
+            mcporter_command: None,
+            tool_name_mapping: Default::default(),
+        },
+    )
+    .with_surface(
+        worker_id,
+        CoordinationSurface {
+            mode: CoordinationMode::NativeMcp,
+            worker_send_task_message_enabled: false,
+            mcp_server: Some("bcs".to_string()),
+            mcporter_command: None,
+            tool_name_mapping: Default::default(),
+        },
+    );
+    let event = SystemMessageEvent::SessionContext {
+        group_id: group.id.clone(),
+        session_id: "group-provider-surface:7c18e4be".to_string(),
+        reason: "协作任务".to_string(),
+        session_input: None,
+        task_ledger: None,
+        driver_delivery: None,
+    };
+
+    let (messages, _) = SessionContextMessageProducer
+        .produce(&event, &group, &registry, &participants)
+        .await;
+
+    let message_for = |bot_id: &str| {
+        messages
+            .iter()
+            .find(|message| message.recipients == vec![bot_id.to_string()])
+            .expect("recipient message")
+            .message
+            .as_str()
+    };
+    let manager_message = message_for(manager_id);
+    assert!(manager_message.contains("bcs_assign_task"));
+    assert!(manager_message.contains("bcs_task_complete"));
+    assert!(!manager_message.contains("bcs_send_task_message"));
+
+    let worker_message = message_for(worker_id);
+    assert!(worker_message.contains("本群为任务群，你是子 Bot。"));
+    assert!(worker_message.contains("收到 manager 派发的任务后直接处理。"));
+    assert!(!worker_message.contains("bcs_send_task_message"));
 }
 
 #[tokio::test]

--- a/src/bcs/docs/superpowers/specs/2026-06-30-bcs-platform-coordination-mode-design.md
+++ b/src/bcs/docs/superpowers/specs/2026-06-30-bcs-platform-coordination-mode-design.md
@@ -70,7 +70,8 @@ Provider 的 `config` 增加 `coordination` 节点：
   "coordination": {
     "mode": "mcporter_mcp",
     "mcp_server": "bcs",
-    "mcporter_command": "mcporter"
+    "mcporter_command": "mcporter",
+    "worker_send_task_message_enabled": true
   }
 }
 ```
@@ -83,6 +84,9 @@ Provider 的 `config` 增加 `coordination` 节点：
 - `tool_name_mapping`：Provider 原生 MCP tool result 中的精确工具名到 BCS canonical coordination tool
   的映射，只对 `native_mcp` 有意义。canonical tool 仅允许 `bcs_assign_task`、
   `bcs_send_task_message`、`bcs_task_complete`。
+- `worker_send_task_message_enabled`：是否在 manager-worker 群的 worker 上下文中说明可调用
+  `bcs_send_task_message`。缺省为 `true`，用于保持已有 Provider 的行为；设置为 `false` 时仅隐藏这段
+  worker 提示文案，不注销工具、不改变权限校验、不改变事件回传，也不改变 `task.message` 协议。
 
 校验规则：
 
@@ -96,6 +100,7 @@ Provider 的 `config` 增加 `coordination` 节点：
 缺省策略：
 
 - Provider 未配置 `coordination` 时，等同 `disabled`。
+- `worker_send_task_message_enabled` 未配置时按 `true` 处理；序列化 `true` 时可以省略该字段，`false` 时必须保留。
 - BCS 不从 ProviderBotBinding 或 Bot metadata 补任何 coordination override。
 
 ## 5. Plugin / WebSocket 派生规则
@@ -151,6 +156,10 @@ Worker：
 不要在普通回复中伪造工具结果。
 ```
 
+当 `worker_send_task_message_enabled = false` 时，worker 上下文不包含上述
+`bcs_send_task_message` 调用说明，改为提示“收到 manager 派发的任务后直接处理”，其余
+`mcporter call` 原始输出约束和 manager 汇总约束保持不变。
+
 ### 6.2 `native_mcp`
 
 Manager：
@@ -174,6 +183,9 @@ Worker：
 不要使用 mcporter、exec、bash。
 不要直接面向用户输出最终答案。
 ```
+
+当 `worker_send_task_message_enabled = false` 时，仅移除 worker 对
+`bcs_send_task_message` 的调用说明，保留 MCP 平台及其他安全约束文案。
 
 ### 6.3 `native_tool`
 
@@ -201,9 +213,14 @@ Worker：
 不要直接面向用户输出最终答案。
 ```
 
+当 `worker_send_task_message_enabled = false` 时，仅移除 worker 对原生
+`bcs_send_task_message` 的调用说明，保留原生 tool 平台及其他安全约束文案。
+
 ### 6.4 `legacy_upstream`
 
 保持现有上行兼容上下文，不注入 `mcporter`、MCP server 或 native tool 的新文案。
+若运行时 surface 显式携带 `worker_send_task_message_enabled = false`，同时移除旧兼容文案中
+worker 的 `bcs_send_task_message(message)` 阶段性同步说明；manager 文案不受影响。
 
 ## 7. Provider 协同回传
 
@@ -335,6 +352,7 @@ Provider coordination callback 拒绝时返回 `400 invalid_coordination_mode`�
 3. 上下文注入：
    - 同一主从群内，mcporter provider、native MCP provider、native tool plugin、legacy WS bot 收到不同文案。
    - Manager 和 worker 角色模板不同。
+   - `worker_send_task_message_enabled = false` 时仅 worker 隐藏 `bcs_send_task_message` 说明，manager 仍保留现有工具说明。
 4. Provider 回传：
    - `mcporter_mcp` 接受 `tool_result` 并执行现有 task flow。
    - `native_mcp` 接受 matching `coordination_intent`。


### PR DESCRIPTION
## Problem
在 BCS 的 manager-worker 群中，worker 上下文会默认包含 `bcs_send_task_message` 工具说明。但该工具并非所有下行 provider 都必须提供，当前提示会让 worker 误以为该工具始终可用。

## Solution
新增 Provider coordination 配置字段 `worker_send_task_message_enabled`：

- 缺省为 `true`，保持现有 Provider 行为兼容；
- 配置为 `false` 时，仅从 manager-worker 群的 worker 上下文中隐藏 `bcs_send_task_message` 说明；
- 不注销工具，不改变权限校验、事件回传或 `task.message` 协议；
- manager 上下文不受影响；
- `true` 序列化时省略字段，`false` 序列化时保留字段。

同时补充了 domain/protocol/API 传播、各 coordination mode 的条件渲染、HTTP round-trip 和回归测试，并更新了设计文档。

## Validation
- `cargo test -p bcs-system-message`：44 个单元测试、7 个 conformance 测试通过；
- `cargo test -p bcs-bot --test provider_core`：35 个测试通过；
- `cargo test -p bcs-http --test provider_routes_contract`：46 个测试通过；
- 上述测试使用阿里云 crates.io sparse 镜像完成依赖下载；
- `cargo metadata --offline --no-deps`：通过；
- `git diff --check`：通过。

默认 crates.io 源已重试，但 Cargo 仍卡在 `Updating crates.io index`，因此定向测试使用已验证可用的阿里云镜像完成。

## Compatibility and risk
新增配置字段默认启用，不影响已有 Provider 配置。关闭时只影响 worker 的上下文提示文案，不改变实际工具注册、权限和消息协议。当前变更不涉及数据库迁移或 canonical task 协议变更。

## Spec
`src/bcs/docs/superpowers/specs/2026-06-30-bcs-platform-coordination-mode-design.md`
