### PR TITLE
refactor(backend): route BBS execution through start_run

### DIFF
--- a/src/backend/src/agentclaw/community/core/task/domain/models.py
+++ b/src/backend/src/agentclaw/community/core/task/domain/models.py
@@ -229,8 +229,7 @@ class TaskExecutionGraph:
     extend_props: dict[str, Any] = field(default_factory=dict)
     execution_graph: dict[str, Any] | None = None  # 回调审计图快照(BCN/ClawMind DAG,按 session_id 反查挂图级;只读投影)
     task_id: str = ""   # 整图所属任务 ID(initialize 透传;query_task_dashboard 子树投影复制;
-                        # 供 bbs_runner.notify 经 _schedule_bbs_notify→run_bbs 取 task_id,
-                        # 因 run_bbs 链路只拿到 execution_graph、无法回溯 task_id)
+                        # 供执行 adapter、回调投影和 BBS 图查询使用)
     # 派生不持久: depth / child_tasks / parent_task(均从 relations 分解树派生)
 
     @property

--- a/src/backend/src/agentclaw/community/core/task/task_center/engine.py
+++ b/src/backend/src/agentclaw/community/core/task/task_center/engine.py
@@ -4,7 +4,7 @@
 ``_build_*`` 内部 new 引擎自带策略(TaskPlanner/TaskDispatcher/TaskRunner)+ 接线 TaskExecutor(三模态投递+poller)。
 引擎自身实现 ResultSink(poller 终态回投直接调 on_report)与 TaskContextBuilder(执行上下文派生),
 消除"先建 stub 再外部注入真实 body/接线点"的后填,无引擎子类化、无 reach-in setter。验收 100% 走 on_report
-回投(gap 计算即验收,无主动 verify dispatch);BBS 投递归 runner BBS 模态(无 BbsMarketPort,升 BBS 只翻图态 bbs_mode)。
+回投(gap 计算即验收,无主动 verify dispatch);BBS 与其它模态统一经 runner.start_run 投递。
 零 case 知识:engine 不含任何节点名字面量。测试可经 facade/engine 子类覆写 ``_build_*`` 注入 stub 策略/投递(测试 seam)。
 
 Step2 改造(状态机解耦 + PlanResult + 显式 target + harness 执行报错区分):
@@ -30,7 +30,7 @@ import os
 import random
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from agentclaw.community.core.bot_management.services.bcn_service import BcnService
@@ -185,7 +185,7 @@ class ExecutionEngine:
         if self._bot is None or self._bcs is None:
             logger.warning(
                 "[task][engine] execution_backend 不装配(bot=%s bcs=%s)→ form_coop_group/start_run/"
-                "trigger_workflow/run_bbs 全退 Avernet 桩(grp_<8hex>/stub_<8hex>/无 poller,任务卡 RUNNING 不收敛)。"
+                "trigger_workflow/BBS start_run 全退 Avernet 桩(grp_<8hex>/stub_<8hex>/无 poller,任务卡 RUNNING 不收敛)。"
                 "corp 排查: 确认 DEPLOY_PROFILE=corp + grep [task][corp-task] not configured 看哪个端口空。",
                 "None" if self._bot is None else type(self._bot).__name__,
                 "None" if self._bcs is None else type(self._bcs).__name__,
@@ -1099,8 +1099,8 @@ class ExecutionEngine:
                 task_id, node_id, node.status.value if node is not None else None,
             )
             return
-        # ① assignee 先置研发 bot(供 start_run 定位)+ 记录 bbs_owner; bbs 模式下 dispatch no-op
-        #    (FR-EXT-06: 框架不自动派发),状态机由自驱 auto-report 推进
+        # ① 图中保留 bbs 来源语义；实际交接给胜出的研发 bot 时，构造 single_bot
+        #    执行视图并走统一 start_run，避免把已 claim 的任务再次投回 BBS 广场。
         node.run_info.assignee = rnd_bot_id
         node.run_info.run_mode = "bbs"
         with self._lock_for(task_id):
@@ -1111,10 +1111,20 @@ class ExecutionEngine:
                     extend_props_patch={"bbs_owner": rnd_bot_id, "bbs_handed_to": rnd_bot_id},
                 )
             )
-        # ② start_run([node]) 走(bbs 模式 dispatch no-op 取派发态),不真发消息
+        delivery_node = replace(
+            node,
+            run_info=replace(
+                node.run_info,
+                run_mode="single_bot",
+                output=dict(node.run_info.output),
+                extend_props=dict(node.run_info.extend_props),
+                action_log=list(node.run_info.action_log),
+            ),
+        )
+        # ② start_run([delivery_node]) 真实投递给研发 bot。
         ok = False
         try:
-            results = await self._runner.start_run([node])
+            results = await self._runner.start_run([delivery_node])
             ok = bool(results[0]) if results else False
         except Exception as ex:  # noqa: BLE001
             logger.warning(
@@ -1734,7 +1744,7 @@ class ExecutionEngine:
         harness 重派不同:后者为临时性失败,重派有意义(见 _on_harness_collect)。
         乙' a+R1:节点已由 on_report 折叠直驱 RUNNING→HUNG(acceptance_result+gaps+hung_reason 一次写,
         无 FAILED 瞬态);此处仅升级传播(bbs_mode + loop_round++ + 冒泡到根——根/图 HUNG 才真 dispatch
-        run_bbs),不重复置节点态。"""
+        start_run),不重复置节点态。"""
         _n = next(
             (
                 x
@@ -2005,7 +2015,7 @@ class ExecutionEngine:
         """传播节点 HUNG 的影响,但不在节点级消耗根 BBS 轮次。
 
         ``_maybe_propagate_hung`` 负责判断阻塞是否已扩散到根;只有根节点确认进入
-        BBS 的分支才设置 ``bbs_mode``、递增 ``loop_round`` 并调度 ``run_bbs``。
+        BBS 的分支才设置 ``bbs_mode``、递增 ``loop_round`` 并经 ``start_run`` 调度。
         **不置节点态**——调用方须保证节点已 HUNG。乙' a+R1:验收 FAIL 节点已由
         on_report 折叠直驱 HUNG,故 _on_fail_collect 直接调用本方法;其余 HUNG
         (miss/harness/plan_round/gap_no_progress)经 _hung_and_escalate 写 HUNG 后复用本方法。
@@ -2059,6 +2069,14 @@ class ExecutionEngine:
         exc = getattr(bg, "exception", lambda: None)()
         if exc is not None:
             logger.error("[task][engine] background task 异常: %s", exc, exc_info=exc)
+            return
+        result = getattr(bg, "result", lambda: None)()
+        if isinstance(result, list) and any(item is not True for item in result):
+            logger.error(
+                "[task][engine] background start_run 投递失败 task=%s results=%s",
+                getattr(bg, "_bbs_task_id", ""),
+                result,
+            )
 
     def _ensure_bbs_loop(self) -> asyncio.AbstractEventLoop:
         """Return an engine-owned loop that outlives Harness' temporary loop.
@@ -2122,17 +2140,39 @@ class ExecutionEngine:
         )
 
     def _schedule_bbs_notify(self, task_id: str, execution_graph) -> None:
-        """可恢复拦截点(spec §5):fire-and-forget ``runner.run_bbs(execution_graph)``。
+        """可恢复拦截点(spec §5):fire-and-forget ``runner.start_run([bbs_node])``。
 
         命中根 BBS 可恢复态(bbs_mode + 未 claim)时调用——主动 bid→select→claim→
-        dispatch 给 claim-enabled bot。不持锁、不阻塞 ``on_*``/``_maybe_propagate_hung`` 汇报路径:``asyncio.create_task``
+        dispatch 给 claim-enabled bot。上层只使用统一 start_run seam，不感知 BBS 专用方法。
+        不持锁、不阻塞 ``on_*``/``_maybe_propagate_hung`` 汇报路径:``asyncio.create_task``
         调度后台协程,异常经 ``_on_bg_done`` 记 log。端口不全(无 runner/bot/bcs,如单测 stub)→ 静默跳过。"""
         logger.info("[task][bbs_mode], begin schedule bbs notify, task_id=%s", task_id)
         if not self._runner:
             logger.info("[task][bbs_mode], _runner is none, skip, task_id=%s", task_id)
             return
+        root = next(
+            (node for node in execution_graph.tasks if node.node_id == task_id),
+            None,
+        )
+        if root is None:
+            logger.error(
+                "[task][bbs_mode] root missing, skip start_run task_id=%s", task_id
+            )
+            return
+        # BBS 是本次执行请求的目标模态，不改写图中根节点原有 run_mode/assignee。
+        # 具体 BBS 语义由执行 adapter 隐藏，Runner 只接收普通 TaskNode。
+        bbs_node = replace(
+            root,
+            run_info=replace(
+                root.run_info,
+                run_mode="bbs",
+                output=dict(root.run_info.output),
+                extend_props=dict(root.run_info.extend_props),
+                action_log=list(root.run_info.action_log),
+            ),
+        )
         loop = self._ensure_bbs_loop()
-        coroutine = self._runner.run_bbs(execution_graph)
+        coroutine = self._runner.start_run([bbs_node])
         try:
             bg = asyncio.run_coroutine_threadsafe(coroutine, loop)
         except Exception:
@@ -2181,7 +2221,7 @@ class ExecutionEngine:
         **BBS 可恢复态(spec §10.5,调度优化)**:只要阻塞已经传播到根节点(任一 ``hung_reason``:
         ``miss_depth_exhausted``/``root_gap_no_decompose``/``gap_no_progress``/
         ``plan_round_exhausted``/``exec_stuck``/``child_hung`` 等),且根未被 claim,即进入根级 BBS
-        可恢复态(派发 ``run_bbs``);``loop_exhausted`` 由 ``_bump_loop_round`` 置根/图 HUNG,
+        可恢复态(经 ``start_run`` 派发 BBS);``loop_exhausted`` 由 ``_bump_loop_round`` 置根/图 HUNG,
         被上方 ``g.status==HUNG`` 短路拦截、不再调度,保留反失控兜底。在途 BBS(``bbs_owner``
         非空)亦跳过,不重复派发。``loop_round`` 只在根确认进入 BBS 时递增。
         """

--- a/src/backend/src/agentclaw/community/core/task/task_runner/integration/task_executor.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/integration/task_executor.py
@@ -1,7 +1,8 @@
-"""TaskExecutor:三模态派发(single_bot/coop_group/bbs)+ 旁路 poller 登记入口。
+"""TaskExecutor:三模态派发(single_bot/coop_group/bbs)+ poller 登记入口。
 
 dispatch(async):上游 start_run caller loop 上 gather+Semaphore await 端口 IO,拿到 run_id 即返回
-(不等待结果);bbs 仅记日志。form_coop_group(async):BCS 建群壳。poller 为独立 daemon sidecar(同 TaskHarness)。
+(不等待结果);BBS 也经统一 dispatch 入口启动。form_coop_group(async):BCS 建群壳。
+poller 为独立 daemon sidecar(同 TaskHarness)。
 """
 
 from __future__ import annotations
@@ -10,6 +11,7 @@ import asyncio
 import json
 import logging
 import time
+from dataclasses import replace
 from typing import Any
 
 from agentclaw.community.core.task.domain.identity import compose_bot_identity
@@ -81,7 +83,7 @@ class TaskExecutor:
         self._api_base_url = api_base_url
         self._bot_token_provider = bot_token_provider
         self._task_settings = task_settings
-        self._on_bbs_report = on_bbs_report  # 引擎 on_bbs_report 收口回调(供 run_bbs→notify 走引擎收敛)
+        self._on_bbs_report = on_bbs_report  # 引擎 on_bbs_report 收口回调(供 BBS dispatch→notify 走引擎收敛)
         self._group_meta: dict[
             str, dict[str, Any]
         ] = {}  # group_id -> {collab_mode, gf, definition_ref, session_id}
@@ -98,12 +100,12 @@ class TaskExecutor:
             mode = node.run_info.run_mode
             if mode == "bbs":
                 logger.info(
-                    "[task][task_executor] bbs node dispatched (no-op): task=%s node=%s assignee=%s",
+                    "[task][task_executor] >>> 投递 bbs task=%s node=%s assignee=%s",
                     node.task_id,
                     node.node_id,
                     node.run_info.assignee,
                 )
-                return True
+                return await self._dispatch_bbs(node, sem)
             if mode == "single_bot":
                 logger.info(
                     "[task][task-executor] >>> 投递 single_bot task=%s node=%s bot=%s → send_message",
@@ -127,6 +129,53 @@ class TaskExecutor:
             return False
 
         return list(await asyncio.gather(*[_one(n) for n in toDoTaskList]))
+
+    async def _dispatch_bbs(
+        self, node: TaskNode, sem: asyncio.Semaphore
+    ) -> bool:
+        """通过统一 dispatch seam 启动 BBS 接力。
+
+        Runner 只传入待执行节点；BBS adapter 在内部按 task_id 读取完整图，隐藏
+        roster、bid、claim 和 relay 等模态细节。返回值表示请求已被执行器接受，
+        最终任务结果仍经 ``on_bbs_report`` 回投编排核。
+        """
+        if self._graph is None:
+            logger.error(
+                "[task][bbs_mode] dispatch failed: graph missing task=%s node=%s",
+                node.task_id,
+                node.node_id,
+            )
+            return False
+        persisted_graph = self._graph.query_task_dashboard(node.task_id)
+        if not any(current.node_id == node.node_id for current in persisted_graph.tasks):
+            logger.error(
+                "[task][bbs_mode] dispatch failed: node missing task=%s node=%s",
+                node.task_id,
+                node.node_id,
+            )
+            return False
+        # start_run 的 TaskNode 是本次执行请求的权威输入。查询图只补齐 BBS 所需的
+        # 关系与其它节点快照，再以调用方传入节点覆盖同 id 的持久化快照。
+        execution_graph = replace(
+            persisted_graph,
+            tasks=[
+                node if current.node_id == node.node_id else current
+                for current in persisted_graph.tasks
+            ],
+        )
+        async with sem:
+            from agentclaw.community.core.task.task_runner.integration import bbs_runner
+
+            await bbs_runner.notify(
+                execution_graph=execution_graph,
+                bcn=self._bcn,
+                bot=self._bot,
+                graph=self._graph,
+                backend_url=self._api_base_url,
+                skill_name=bbs_runner._BBS_SKILL_NAME,
+                on_bbs_report=self._on_bbs_report,
+            )
+        return True
 
     def _single_bot_skill_report_enabled(self) -> bool:
         """single_bot 回收链路开关(默认 False=poller 拉消息回收)。
@@ -647,21 +696,6 @@ class TaskExecutor:
             detail = await self._bcs.get_group(group_id)
             sid = (detail or {}).get("latest_running_session_id")
         return sid
-
-    async def run_bbs(self, execution_graph) -> None:
-        """升 BBS 可恢复态后主动 bid→select→claim→dispatch(委托 bbs_runner)。
-        延迟导入 bbs_runner 避免顶层循环依赖;bbs_runner 自身 best-effort 不抛。"""
-        from agentclaw.community.core.task.task_runner.integration import bbs_runner
-
-        await bbs_runner.notify(
-            execution_graph=execution_graph,
-            bcn=self._bcn,
-            bot=self._bot,
-            graph=self._graph,
-            backend_url=self._api_base_url,
-            skill_name=bbs_runner._BBS_SKILL_NAME,
-            on_bbs_report=self._on_bbs_report,
-        )
 
     @staticmethod
     def _state_machine_bindings(gf: GroupFormation) -> dict[str, dict[str, Any]]:

--- a/src/backend/src/agentclaw/community/core/task/task_runner/runner.py
+++ b/src/backend/src/agentclaw/community/core/task/task_runner/runner.py
@@ -62,15 +62,16 @@ class TaskRunner:
         多节点经 ``asyncio.gather`` + ``_DELIVER_CONCURRENCY`` Semaphore 并发限流(对齐 backend lifecycle
         模式,防投递雪崩);否则 stub 记日志返 True。
         协程化:真实投递(单 bot workflow/BCS 协作群/BBS 广场)是网络 IO,并发 await 不阻塞编排核。"""
+        if self._execution_backend is not None:
+            # 真实后端一次接收完整批次，由其统一 semaphore 控制三种模态的并发。
+            return list(await self._execution_backend.dispatch(toDoTaskList))
+
         sem = asyncio.Semaphore(self._DELIVER_CONCURRENCY)
 
         async def _deliver_one(node: TaskNode) -> bool:
             mode = node.run_info.run_mode
             if mode not in ("single_bot", "coop_group", "bbs"):
                 return False
-            if self._execution_backend is not None:
-                # execution_backend.dispatch 自身按 run_mode 三模态分流(含 bbs no-op)
-                return await self._execution_backend.dispatch([node]) == [True]
             async with sem:
                 port = self._deliveries.get(mode)
                 if port is not None:
@@ -140,16 +141,6 @@ class TaskRunner:
         if self._execution_backend is not None:
             return await self._execution_backend.get_group_session(group_id)
         logger.debug("[task][runner] get_group_session 退桩→ None(group_id=%s 无 execution_backend)", group_id)
-        return None
-
-    async def run_bbs(self, execution_graph) -> None:
-        """升 BBS 可恢复态后主动通知 dream-mode bot 抢单(委托 execution_backend)。
-        注入 execution_backend 时委托其 run_bbs(→ TaskExecutor.run_bbs → bbs_runner.notify);
-        否则 stub 记日志(Avernet 无后端兜底,不抛)。"""
-        logger.info("[task][bbs_mode] run_bbs, begin, task=%s", execution_graph.task_id)
-        if self._execution_backend is not None:
-            return await self._execution_backend.run_bbs(execution_graph)
-        logger.info("[task][bbs_mode] run_bbs, finish, task=%s", execution_graph.task_id)
         return None
 
     def _build_context(self, task_id: str, node_id: str) -> dict[str, Any]:

--- a/src/backend/tests/community/core/task/e2e/test_e2e.py
+++ b/src/backend/tests/community/core/task/e2e/test_e2e.py
@@ -263,10 +263,6 @@ class _TestRunner:
         self._groups.append(gf)
         return gid
 
-    async def run_bbs(self, execution_graph) -> None:
-        # BBS relay is exercised explicitly through claim/attach/report in these tests.
-        return None
-
     def query_status(self, task_id): return self._graph.query_task_dashboard(task_id).status
     def query_detail(self, node): return node
     def query_result(self, node): return node

--- a/src/backend/tests/community/core/task/singlebox_e2e/bbs_bid/test_bbs_bid_two_dream_bots_e2e.py
+++ b/src/backend/tests/community/core/task/singlebox_e2e/bbs_bid/test_bbs_bid_two_dream_bots_e2e.py
@@ -10,7 +10,7 @@ gated by ``SINGLEBOX_TASK_E2E=1``。本地 ``./scripts/singlebox.sh start all`` 
 
 # 场景(动 LLM 自评 bid + 真执行;参考 test_writing_qc_state_machine_e2e.py 的 live 手法)
 
-任务 MISS→HUNG→升 BBS 后,引擎 ``_schedule_bbs_notify`` fire-and-forget ``run_bbs`` → ``bbs_runner.notify``:
+任务 MISS→HUNG→升 BBS 后,引擎 ``_schedule_bbs_notify`` fire-and-forget ``start_run`` → ``bbs_runner.notify``:
 
 1. **bid**:`list_bots_by_task_modes(dream=True)` 拉 dream-mode roster(本用例建**两个** dream bot 并开
    ``task_dream_mode``)→ 并发 ``send_and_wait_async`` 让每个 bot 自评 ``completion_rate``(真 LLM 出 JSON)。
@@ -38,7 +38,7 @@ staff_no,经 BCS ``authorize_bot_management`` 的 owner 匹配放行)PATCH
 
 # 已修的接缝
 
-``bbs_runner.notify``/``TaskRunner.run_bbs`` 取 ``execution_graph.task_id``,而 ``TaskExecutionGraph`` 原无该字段
+``bbs_runner.notify`` 经 BBS executor 取 ``execution_graph.task_id``,而 ``TaskExecutionGraph`` 原无该字段
 → live 触发即 ``AttributeError``(单测用 MagicMock.mask)。本仓已给 ``TaskExecutionGraph`` 加 ``task_id``
 (initialize / query_task_dashboard 子树投影透传),使真触发链可用。
 """

--- a/src/backend/tests/community/core/task/task_center/test_engine.py
+++ b/src/backend/tests/community/core/task/task_center/test_engine.py
@@ -114,16 +114,17 @@ class StubDispatcher:
 class StubRunner:
     def __init__(self):
         self.run_calls: list[list[TaskNode]] = []
-        self.bbs_calls: list = []   # engine 升 BBS 可恢复态时 run_bbs 调用的 task_id
+        self.bbs_calls: list = []   # engine 升 BBS 可恢复态时经 start_run 派发的 task_id
         self._groups = []
 
     async def start_run(self, toDoTaskList: list[TaskNode]) -> list[bool]:
         self.run_calls.append(list(toDoTaskList))
+        self.bbs_calls.extend(
+            node.task_id
+            for node in toDoTaskList
+            if node.run_info.run_mode == "bbs"
+        )
         return [True] * len(toDoTaskList)
-
-    async def run_bbs(self, execution_graph) -> None:
-        """记录 BBS 升级调度(根 HUNG 升 BBS 可恢复态时 fire-and-forget 调用;对齐真实 TaskExecutor.run_bbs)。"""
-        self.bbs_calls.append(getattr(execution_graph, "task_id", None))
 
     async def form_coop_group(self, gf):
         self._groups.append(gf)
@@ -609,7 +610,7 @@ class TestOnHarness:
         assert len(runner.run_calls) == 1
 
     def test_root_hung_schedules_bbs(self, svc):
-        """调度优化:任一根 HUNG(此处 exec_stuck 冒泡到根)即调度 run_bbs(MAX_LOOP 未达即升 BBS)。"""
+        """调度优化:任一根 HUNG(此处 exec_stuck 冒泡到根)即经 start_run 调度 BBS。"""
         g = svc.initialize_graph(_task_info("t_bbs", max_depth=1))
         g.extend_props["execution_config"]["MAX_LOOP"] = 10  # 确保不撞反失控兜底
         svc.add_task_nodes([_child("c1", "t_bbs")], parent_node_id="t_bbs")
@@ -629,7 +630,7 @@ class TestOnHarness:
         assert len(runner.bbs_calls) == 1  # 新行为:根 HUNG 即调度 bbs(恰好一次)
 
     def test_loop_exhausted_does_not_schedule_bbs(self, svc):
-        """反失控兜底:loop_round 达 MAX_LOOP→图 HUNG(loop_exhausted),不再调度 run_bbs。"""
+        """反失控兜底:loop_round 达 MAX_LOOP→图 HUNG(loop_exhausted),不再调度 BBS。"""
         g = svc.initialize_graph(_task_info("t_loop", max_depth=1))
         g.extend_props["execution_config"]["MAX_LOOP"] = 1
         g.loop_round = 1  # 先判后+1:预设 loop 已达 MAX_LOOP,首次 _bump_loop_round 先判即撞图 HUNG
@@ -722,7 +723,7 @@ class TestMaxPlanRound:
         def _pass(node):
             async def _go():
                 await eng.on_report(_patch("t1", node, acceptance_result=AcceptanceResult(verdict=AcceptanceVerdict.DONE)))
-                if eng._bg_tasks:  # 排空 fire-and-forget run_bbs,使 bbs_calls 落定
+                if eng._bg_tasks:  # 排空 fire-and-forget start_run,使 bbs_calls 落定
                     await _wait_bg_tasks(eng)
             _run(_go())
 
@@ -783,7 +784,7 @@ class TestMaxPlanRound:
         _pass("c7")
         assert graph.status == Status.HUNG
         assert graph.extend_props.get("hung_reason") == "loop_exhausted"
-        assert len(runner.bbs_calls) == 3  # loop 收尾硬停,不再调度 run_bbs
+        assert len(runner.bbs_calls) == 3  # loop 收尾硬停,不再调度 BBS
 
 # ===== 零 case 知识 =====
 class TestZeroCaseKnowledge:

--- a/src/backend/tests/community/core/task/task_center/test_engine_bbs_trigger.py
+++ b/src/backend/tests/community/core/task/task_center/test_engine_bbs_trigger.py
@@ -24,6 +24,7 @@ from agentclaw.community.core.task.domain.models import (
     PlanResult,
     RuntimeInfo,
     Status,
+    TaskExecutionGraph,
     TaskInfo,
     TaskNode,
     TaskNodePatch,
@@ -31,6 +32,8 @@ from agentclaw.community.core.task.domain.models import (
 )
 from agentclaw.community.core.task.task_center.engine import ExecutionEngine
 from agentclaw.community.core.task.task_context.task_graph_service import TaskGraphService
+from agentclaw.community.core.task.task_runner.integration.task_executor import TaskExecutor
+from agentclaw.community.core.task.task_runner.runner import TaskRunner
 
 
 # ===== domain helpers (mirrors test_engine.py minimal setup) =====
@@ -122,11 +125,16 @@ def test_engine_schedule_bbs_notify_submits_to_durable_loop():
     """BBS submission is independent of the caller's short-lived Harness loop."""
     engine = ExecutionEngine(graph=MagicMock(), api_base_url="http://x")
     engine._runner = MagicMock()
-    engine._runner.run_bbs = AsyncMock(return_value=None)
+    engine._runner.start_run = AsyncMock(return_value=[True])
     engine._bot = MagicMock()
     engine._bcs = MagicMock()
     fake_g = MagicMock()
     fake_g.task_id = "t1"
+    root = _child("t1", "t1")
+    root.run_info.run_mode = "single_bot"
+    root.run_info.assignee = "original-bot"
+    root.run_info.extend_props["business"] = {"version": 2}
+    fake_g.tasks = [root]
     durable_loop = MagicMock()
     durable_future = concurrent.futures.Future()
 
@@ -140,9 +148,43 @@ def test_engine_schedule_bbs_notify_submits_to_durable_loop():
         engine._schedule_bbs_notify("t1", fake_g)
         mock_submit.assert_called_once()
         assert len(engine._bg_tasks) == 1
+        submitted = engine._runner.start_run.call_args.args[0][0]
+        assert submitted is not root
+        assert submitted.run_info is not root.run_info
+        assert submitted.run_info.run_mode == "bbs"
+        assert submitted.run_info.assignee == "original-bot"
+        assert submitted.run_info.extend_props == {"business": {"version": 2}}
+        assert submitted.run_info.extend_props is not root.run_info.extend_props
+        assert root.run_info.run_mode == "single_bot"
         durable_future.set_result(None)
 
     assert engine._bg_tasks == set()
+
+
+def test_engine_schedule_bbs_notify_skips_when_root_missing(caplog):
+    engine = ExecutionEngine(graph=MagicMock(), api_base_url="http://x")
+    engine._runner = MagicMock()
+    fake_g = MagicMock()
+    fake_g.tasks = [_child("child", "t1")]
+
+    engine._schedule_bbs_notify("t1", fake_g)
+
+    engine._runner.start_run.assert_not_called()
+    assert "root missing" in caplog.text
+
+
+def test_engine_background_false_result_is_visible(caplog):
+    engine = ExecutionEngine(graph=MagicMock(), api_base_url="http://x")
+    future = concurrent.futures.Future()
+    future._bbs_task_id = "t1"
+    engine._bg_tasks.add(future)
+    future.set_result([False])
+
+    with caplog.at_level("ERROR"):
+        engine._on_bg_done(future)
+
+    assert future not in engine._bg_tasks
+    assert "background start_run 投递失败" in caplog.text
 
 
 def test_engine_bbs_survives_caller_loop_shutdown():
@@ -151,17 +193,20 @@ def test_engine_bbs_survives_caller_loop_shutdown():
     started = threading.Event()
     finished = threading.Event()
 
-    async def run_bbs(_execution_graph):
+    async def start_run(nodes):
+        assert len(nodes) == 1
+        assert nodes[0].run_info.run_mode == "bbs"
         started.set()
         await asyncio.sleep(0)
         finished.set()
 
     engine._runner = MagicMock()
-    engine._runner.run_bbs = run_bbs
+    engine._runner.start_run = start_run
     engine._bot = MagicMock()
     engine._bcs = MagicMock()
     fake_g = MagicMock()
     fake_g.task_id = "t-harness-loop"
+    fake_g.tasks = [_child("t-harness-loop", "t-harness-loop")]
 
     async def schedule_from_short_lived_loop():
         engine._schedule_bbs_notify(fake_g.task_id, fake_g)
@@ -170,6 +215,45 @@ def test_engine_bbs_survives_caller_loop_shutdown():
 
     assert started.wait(1.0)
     assert finished.wait(1.0)
+
+
+def test_engine_bbs_schedule_reaches_notify_through_start_run():
+    root = _child("t1", "t1")
+    fake_g = TaskExecutionGraph(
+        run_id=1,
+        loop_round=1,
+        status=Status.HUNG,
+        tasks=[root],
+        task_id="t1",
+    )
+    graph = MagicMock()
+    graph.query_task_dashboard.return_value = fake_g
+    executor = TaskExecutor(
+        bot=MagicMock(), bcs=MagicMock(), bcn=MagicMock(),
+        formatter=None, context=None, sink=None, poller=None,
+        graph=graph, api_base_url="http://x",
+    )
+    engine = ExecutionEngine(graph=graph, api_base_url="http://x")
+    engine._runner = TaskRunner(graph, execution_backend=executor)
+    durable_future = concurrent.futures.Future()
+    submitted = {}
+
+    def submit(coro, _loop):
+        submitted["coro"] = coro
+        return durable_future
+
+    with patch.object(engine, "_ensure_bbs_loop", return_value=MagicMock()), \
+         patch("asyncio.run_coroutine_threadsafe", side_effect=submit), \
+         patch(
+             "agentclaw.community.core.task.task_runner.integration.bbs_runner.notify",
+             new_callable=AsyncMock,
+         ) as notify:
+        engine._schedule_bbs_notify("t1", fake_g)
+        result = _run(submitted["coro"])
+        durable_future.set_result(result)
+
+    assert result == [True]
+    notify.assert_awaited_once()
 
 
 def test_engine_schedule_bbs_notify_skips_when_no_runner():

--- a/src/backend/tests/community/core/task/task_center/test_static_plan_engine.py
+++ b/src/backend/tests/community/core/task/task_center/test_static_plan_engine.py
@@ -2,7 +2,7 @@ import asyncio
 
 from agentclaw.community.core.task.domain.models import (
     Context, Goal, Metadata, RuntimeInfo, Status, TaskExecutionGraph, TaskInfo,
-    TaskNodePatch, TaskSpec, AcceptanceResult, AcceptanceVerdict,
+    TaskNode, TaskNodePatch, TaskSpec, AcceptanceResult, AcceptanceVerdict,
 )
 from agentclaw.community.core.task.task_center.engine import ExecutionEngine
 from agentclaw.community.core.task.task_dispatch.dispatcher import TaskDispatcher
@@ -49,10 +49,12 @@ def _run(coro):
 class _Runner:
     def __init__(self):
         self.started = []
+        self.started_nodes = []
         self.groups = []
 
     async def start_run(self, nodes):
         self.started.append([n.node_id for n in nodes])
+        self.started_nodes.append(list(nodes))
         return [True] * len(nodes)
 
     async def form_coop_group(self, group):
@@ -192,3 +194,45 @@ def test_static_plan_status_filter_ignores_empty_tokens():
     )
 
     assert parse_status_filter(", ,") is None
+
+
+def test_bbs_handoff_uses_single_bot_delivery_without_changing_bbs_origin():
+    graph_service = TaskGraphService()
+    task_info = _task_info()
+    task_info.execution_config["bbs_handoff_claim_delay"] = 0
+    graph_service.initialize_graph(task_info)
+    handoff = TaskNode(
+        node_id="handoff",
+        task_id="t1",
+        status=Status.PENDING,
+        task_spec=TaskSpec(
+            Metadata("t1", "handoff", "implement unavailable items"),
+            Context("", {"static_input": {"unhandled_tasks": [{"id": "u1"}]}}),
+            Goal("implement", []),
+        ),
+        run_info=RuntimeInfo(run_mode="bbs"),
+        node_run_graph=None,  # type: ignore[arg-type]
+    )
+    graph_service.add_task_nodes([handoff], parent_node_id="t1")
+    runner = _Runner()
+    engine = _engine(graph_service, runner)
+
+    async def claim():
+        await engine._bbs_handoff_claim("t1", "handoff", "rnd-bot", [{"id": "u1"}])
+        pending = list(engine._bg_tasks)
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    _run(claim())
+
+    delivered = runner.started_nodes[-1][0]
+    persisted = next(
+        node
+        for node in graph_service.query_task_dashboard("t1").tasks
+        if node.node_id == "handoff"
+    )
+    assert delivered.run_info.run_mode == "single_bot"
+    assert delivered.run_info.assignee == "rnd-bot"
+    assert persisted.run_info.run_mode == "bbs"
+    assert persisted.run_info.extend_props["bbs_status"] == "claimed_by_rnd"

--- a/src/backend/tests/community/core/task/task_center/test_task_service.py
+++ b/src/backend/tests/community/core/task/task_center/test_task_service.py
@@ -113,18 +113,19 @@ class _StubDispatchStrategy:
 class StubRunner:
     def __init__(self):
         self.run_calls: list[list[TaskNode]] = []
-        self.bbs_calls: list = []   # engine 升 BBS 可恢复态时 run_bbs 调用的 task_id
+        self.bbs_calls: list = []   # engine 升 BBS 可恢复态时经 start_run 派发的 task_id
 
     async def start_run(self, toDoTaskList: list[TaskNode]) -> list[bool]:
         self.run_calls.append(list(toDoTaskList))
+        self.bbs_calls.extend(
+            node.task_id
+            for node in toDoTaskList
+            if node.run_info.run_mode == "bbs"
+        )
         return [True] * len(toDoTaskList)
 
     async def form_coop_group(self, gf):
         return "grp_stub"
-
-    async def run_bbs(self, execution_graph) -> None:
-        """记录 BBS 升级调度(根 HUNG 升 BBS 可恢复态时 fire-and-forget 调用;对齐真实 TaskExecutor.run_bbs)。"""
-        self.bbs_calls.append(getattr(execution_graph, "task_id", None))
 
     def query_status(self, task_id): return Status.PENDING
     def query_detail(self, node): return node

--- a/src/backend/tests/community/core/task/task_runner/integration/test_bbs_executor.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_bbs_executor.py
@@ -1,6 +1,18 @@
 # tests/community/core/task/task_runner/integration/test_bbs_executor.py
 import asyncio
 from unittest.mock import MagicMock, patch, AsyncMock
+import pytest
+from agentclaw.community.core.task.domain.models import (
+    AcceptanceCriteria,
+    Context,
+    Goal,
+    Metadata,
+    RuntimeInfo,
+    Status,
+    TaskExecutionGraph,
+    TaskNode,
+    TaskSpec,
+)
 from agentclaw.community.core.task.task_runner.integration.task_executor import TaskExecutor
 
 
@@ -8,24 +20,89 @@ def _run(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
 
 
-def test_task_executor_run_bbs_delegates_to_bbs_runner():
-    """TaskExecutor.run_bbs delegates to bbs_runner.notify with correct args.
+def _node(objective: str) -> TaskNode:
+    return TaskNode(
+        node_id="t1",
+        task_id="t1",
+        status=Status.HUNG,
+        task_spec=TaskSpec(
+            Metadata("t1", "BBS", "execute updated task"),
+            Context("updated context"),
+            Goal(objective, [AcceptanceCriteria("a1", "done")]),
+        ),
+        run_info=RuntimeInfo(run_mode="bbs"),
+        node_run_graph=None,  # type: ignore[arg-type]
+    )
+
+
+def test_task_executor_dispatch_bbs_delegates_to_bbs_runner():
+    """TaskExecutor.dispatch delegates BBS nodes to bbs_runner.notify.
 
     BBS 候选 roster 经注入的 BcnService(复用统一 provider 身份)查询:notify 以
     ``bcn=``(BcnService)、``bot=`` 透传,不再传 ``bcs``。
     """
     on_bbs_report = AsyncMock()
+    graph = MagicMock()
+    persisted_root = _node("persisted objective")
+    execution_graph = TaskExecutionGraph(
+        run_id=1,
+        loop_round=1,
+        status=Status.HUNG,
+        tasks=[persisted_root],
+        task_id="t1",
+    )
+    graph.query_task_dashboard.return_value = execution_graph
     exe = TaskExecutor(bot=MagicMock(), bcs=MagicMock(), bcn=MagicMock(),
                        formatter=None, context=None, sink=None, poller=None,
-                       api_base_url="http://test:8888", on_bbs_report=on_bbs_report)
-    g = MagicMock()
-    g.task_id = "t1"
+                       graph=graph, api_base_url="http://test:8888",
+                       on_bbs_report=on_bbs_report)
+    node = _node("upper-layer updated objective")
     with patch("agentclaw.community.core.task.task_runner.integration.bbs_runner.notify", new_callable=AsyncMock) as mock_notify:
-        _run(exe.run_bbs(g))
+        assert _run(exe.dispatch([node])) == [True]
         mock_notify.assert_awaited_once()
         call_kwargs = mock_notify.call_args
         assert call_kwargs.kwargs["backend_url"] == "http://test:8888"
-        assert call_kwargs.kwargs["execution_graph"] is g
+        dispatched_graph = call_kwargs.kwargs["execution_graph"]
+        assert dispatched_graph is not execution_graph
+        assert dispatched_graph.tasks[0] is node
+        assert dispatched_graph.tasks[0].task_spec.goal.objective == "upper-layer updated objective"
+        assert execution_graph.tasks == [persisted_root]
         assert call_kwargs.kwargs["bcn"] is exe._bcn
         assert call_kwargs.kwargs["bot"] is exe._bot
         assert call_kwargs.kwargs["on_bbs_report"] is on_bbs_report  # 引擎收口回调透传 notify
+
+
+def test_task_executor_dispatch_bbs_propagates_graph_lookup_failure():
+    graph = MagicMock()
+    graph.query_task_dashboard.side_effect = RuntimeError("graph unavailable")
+    exe = TaskExecutor(
+        bot=MagicMock(), bcs=MagicMock(), bcn=MagicMock(),
+        formatter=None, context=None, sink=None, poller=None,
+        graph=graph, api_base_url="http://test:8888",
+    )
+
+    with pytest.raises(RuntimeError, match="graph unavailable"):
+        _run(exe.dispatch([_node("updated objective")]))
+
+
+def test_task_executor_dispatch_bbs_returns_false_when_node_missing():
+    graph = MagicMock()
+    graph.query_task_dashboard.return_value = TaskExecutionGraph(
+        run_id=1,
+        loop_round=1,
+        status=Status.HUNG,
+        tasks=[],
+        task_id="t1",
+    )
+    exe = TaskExecutor(
+        bot=MagicMock(), bcs=MagicMock(), bcn=MagicMock(),
+        formatter=None, context=None, sink=None, poller=None,
+        graph=graph, api_base_url="http://test:8888",
+    )
+
+    with patch(
+        "agentclaw.community.core.task.task_runner.integration.bbs_runner.notify",
+        new_callable=AsyncMock,
+    ) as notify:
+        assert _run(exe.dispatch([_node("updated objective")])) == [False]
+        notify.assert_not_awaited()

--- a/src/backend/tests/community/core/task/task_runner/integration/test_executor_e2e.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_executor_e2e.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import threading
 import time
+from unittest.mock import AsyncMock, patch
 
 from agentclaw.community.core.task.domain.models import (
     AcceptanceCriteria, Context, Goal, Metadata, RuntimeInfo, Status,
@@ -263,10 +264,9 @@ class TestCoopGroupStateMachineE2E:
         _stop_poller(eng)
 
 
-# ===== Test 4: bbs no-op(投递不翻态,不改节点状态)=====
-class TestBbsNoOpE2E:
-    def test_bbs_dispatch_noop(self):
-        # 单独构造一个 bbs 节点(RENNING + run_mode=bbs),投递应 no-op,status 不变
+# ===== Test 4: BBS 统一 dispatch(执行器接单,最终状态由 BBS 回投收敛)=====
+class TestBbsDispatchE2E:
+    def test_bbs_dispatch_invokes_bbs_adapter(self):
         svc = TaskGraphService()
         svc.initialize_graph(_task_info("t_bbs"))
         bcs = _DoubleBcsClient()
@@ -276,9 +276,15 @@ class TestBbsNoOpE2E:
                      task_spec=_task_info("t_bbs").task_spec,
                      run_info=RuntimeInfo(run_mode="bbs", assignee="bbs_bot"),
                      node_run_graph=None)  # type: ignore[arg-type]
-        ok = _run(exe._executor.dispatch([n]))  # type: ignore[attr-defined]
+        svc.add_task_nodes([n], parent_node_id="t_bbs")
+        with patch(
+            "agentclaw.community.core.task.task_runner.integration.bbs_runner.notify",
+            new_callable=AsyncMock,
+        ) as notify:
+            ok = _run(exe._executor.dispatch([n]))  # type: ignore[attr-defined]
         assert ok == [True]
-        assert n.status == Status.RUNNING  # bbs no-op 不翻态
+        notify.assert_awaited_once()
+        assert n.status == Status.RUNNING  # 最终状态仍由 BBS report 回投收敛
         _stop_poller(eng)
 
 

--- a/src/backend/tests/community/core/task/task_runner/integration/test_integration_e2e.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_integration_e2e.py
@@ -15,7 +15,7 @@ def _run(coro):
 
 def _wire():
     """真实 TaskService(真 ExecutionEngine/TaskRunner)+ build_integration(double) 注入点。
-    示范 _execution_backend 在真 TaskRunner 上生效(bbs 走 executor no-op,不改节点状态)。"""
+    示范 _execution_backend 在真 TaskRunner 上生效。"""
     g = TaskGraphService()
     svc = TaskService(g)
     exe = build_integration(double=True, sink=svc.callback, runner=None, poller_thread=False)
@@ -23,7 +23,7 @@ def _wire():
     return svc, exe
 
 
-def test_bbs_dispatch_noop_does_not_change_node_status(caplog):
+def test_bbs_dispatch_without_graph_fails_without_changing_node_status(caplog):
     exe = _wire()[1]
     n = TaskNode(node_id="b1", task_id="t1", status=Status.RUNNING,
                  task_spec=TaskSpec(Metadata("t1", "T", "do"), Context("bg"),
@@ -32,5 +32,6 @@ def test_bbs_dispatch_noop_does_not_change_node_status(caplog):
                  node_run_graph=None)  # type: ignore[arg-type]
     with caplog.at_level(logging.INFO):
         ok = _run(exe.dispatch([n]))
-    assert ok == [True]
-    assert n.status == Status.RUNNING  # bbs 仅记日志,不改节点状态、不登记 poller
+    assert ok == [False]
+    assert n.status == Status.RUNNING
+    assert "dispatch failed: graph missing" in caplog.text

--- a/src/backend/tests/community/core/task/task_runner/integration/test_runner_bbs.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_runner_bbs.py
@@ -8,18 +8,35 @@ def _run(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
 
 
-def test_task_runner_run_bbs_delegates_to_execution_backend():
+def _bbs_node():
+    node = MagicMock()
+    node.task_id = "t1"
+    node.node_id = "t1"
+    node.run_info.run_mode = "bbs"
+    node.run_info.assignee = None
+    return node
+
+
+def test_task_runner_start_run_delegates_bbs_to_execution_backend():
     backend = MagicMock()
-    backend.run_bbs = AsyncMock()
+    backend.dispatch = AsyncMock(return_value=[True])
     runner = TaskRunner(graph=None, execution_backend=backend)
-    g = MagicMock()
-    g.task_id = "t1"
-    _run(runner.run_bbs(g))
-    backend.run_bbs.assert_awaited_once_with(g)
+    node = _bbs_node()
+    assert _run(runner.start_run([node])) == [True]
+    backend.dispatch.assert_awaited_once_with([node])
 
 
-def test_task_runner_run_bbs_stub_when_no_backend():
+def test_task_runner_start_run_bbs_stub_when_no_backend():
     runner = TaskRunner(graph=None)  # no backend
-    g = MagicMock()
-    g.task_id = "t1"
-    _run(runner.run_bbs(g))  # no exception, no crash
+    assert _run(runner.start_run([_bbs_node()])) == [True]
+
+
+def test_task_runner_sends_real_backend_one_batch():
+    backend = MagicMock()
+    backend.dispatch = AsyncMock(return_value=[True, False])
+    runner = TaskRunner(graph=None, execution_backend=backend)
+    nodes = [_bbs_node(), _bbs_node()]
+    nodes[1].node_id = "t2"
+
+    assert _run(runner.start_run(nodes)) == [True, False]
+    backend.dispatch.assert_awaited_once_with(nodes)

--- a/src/backend/tests/community/core/task/task_runner/integration/test_task_executor_skeleton.py
+++ b/src/backend/tests/community/core/task/task_runner/integration/test_task_executor_skeleton.py
@@ -19,12 +19,12 @@ def _run(coro):
     return asyncio.new_event_loop().run_until_complete(coro)
 
 
-def test_bbs_dispatch_is_noop_and_returns_true(caplog):
+def test_bbs_dispatch_without_graph_returns_false(caplog):
     exe = TaskExecutor(bot=None, bcs=None, formatter=None, context=None, sink=None, poller=None)
     with caplog.at_level(logging.INFO):
         res = _run(exe.dispatch([_node(run_mode="bbs")]))
-    assert res == [True]
-    assert any("bbs" in r.getMessage().lower() for r in caplog.records)
+    assert res == [False]
+    assert "dispatch failed: graph missing" in caplog.text
 
 
 def test_unknown_mode_returns_false():
@@ -36,7 +36,7 @@ def test_unknown_mode_returns_false():
 def test_dispatch_returns_one_bool_per_node():
     exe = TaskExecutor(bot=None, bcs=None, formatter=None, context=None, sink=None, poller=None)
     res = _run(exe.dispatch([_node("a", run_mode="bbs"), _node("b", run_mode="bbs")]))
-    assert res == [True, True]
+    assert res == [False, False]
 
 
 def test_runner_falls_back_to_stub_without_backend():


### PR DESCRIPTION
建议 PR 标题：

`refactor(backend): route BBS execution through start_run`

## Problem

BBS execution had a dedicated `run_bbs` path alongside `TaskRunner.start_run`. This leaked execution-mode details into the runner API and bypassed the common task execution flow.

It also meant that upper-layer changes carried by `TaskNode` could be lost when BBS execution reloaded the persisted graph, while BBS handoff nodes could report successful dispatch without performing a real delivery.

## Solution

- Removed the dedicated `TaskRunner.run_bbs` and `TaskExecutor.run_bbs` methods.
- Routed BBS execution through the common `TaskRunner.start_run` and `TaskExecutor.dispatch` flow.
- Made the `TaskNode` passed to `start_run` authoritative for BBS execution while retaining graph relationships and related task context.
- Preserved the persisted root task by creating an isolated BBS execution view.
- Routed claimed BBS handoff tasks to the selected bot through `single_bot` delivery, avoiding recursive BBS dispatch.
- Passed real backend tasks as one batch so executor-level concurrency limits apply consistently.
- Added logging for background dispatch results that return failure.
- Updated existing tests that encoded the previous BBS no-op behavior.

## Validation

- Task domain test suite: `636 passed, 30 skipped`.
- Backend architecture test suite: `258 passed`.
- Focused BBS and task-runner tests: `20 passed`.
- Python compilation check passed.
- `git diff --check` passed.
- Pre-push Python SAST/lint gate passed.
- Verified that no calls or definitions remain for `TaskRunner.run_bbs` or `TaskExecutor.run_bbs`.

The 30 skipped tests require pre-production, Singlebox, or live Bot credentials and were not run in the local environment. The pre-push hook ran in lint-only mode, so its coverage and live E2E stages were not executed.

## Compatibility and risk

This change does not modify public HTTP APIs, persistence schemas, or configuration formats.

It removes internal `run_bbs` methods. Repository-wide searches found no remaining callers. The main behavioral change is that BBS nodes now perform real adapter dispatch instead of succeeding as a no-op.

Rollback is available by reverting commit `3cce40354`.

## Spec

Implements the task execution module requirement that BBS execution must use the unified `start_run` entry point, allowing upper-layer business changes to remain part of the task execution request.